### PR TITLE
Optimize build flow, devide default build into release build and debu…

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,6 +64,7 @@
     "check:import": "tsc --noEmit --target ESNEXT --module es6 --experimentalDecorators tests/import/index",
     "lint": "eslint --max-warnings 0 --ext js . && eslint --max-warnings 0 --ext ts .",
     "build": "node scripts/build",
+    "build:debug": "node scripts/build --debug",
     "watch": "node scripts/build --watch",
     "test": "npm run test:parser && npm run test:compiler -- --parallel && npm run test:browser && npm run test:asconfig && npm run test:transform",
     "test:parser": "node --enable-source-maps tests/parser",

--- a/package.json
+++ b/package.json
@@ -65,6 +65,7 @@
     "lint": "eslint --max-warnings 0 --ext js . && eslint --max-warnings 0 --ext ts .",
     "build": "node scripts/build",
     "build:debug": "node scripts/build --debug",
+    "build:release": "node scripts/build --release",
     "watch": "node scripts/build --watch",
     "test": "npm run test:parser && npm run test:compiler -- --parallel && npm run test:browser && npm run test:asconfig && npm run test:transform",
     "test:parser": "node --enable-source-maps tests/parser",

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -10,6 +10,7 @@ import { stdoutColors } from "../util/terminal.js";
 const require = createRequire(import.meta.url);
 const dirname = path.dirname(fileURLToPath(import.meta.url));
 const watch = process.argv[2] === "--watch";
+const debug = process.argv[2] === "--debug";
 
 function prelude(name) {
   return [
@@ -206,9 +207,9 @@ const common = {
   ],
   legalComments: "none",
   bundle: true,
-  sourcemap: true,
+  sourcemap: debug,
   treeShaking: true,
-  minify: true,
+  minify: !debug,
   watch,
   incremental: watch
 };

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -11,6 +11,7 @@ const require = createRequire(import.meta.url);
 const dirname = path.dirname(fileURLToPath(import.meta.url));
 const watch = process.argv[2] === "--watch";
 const debug = process.argv[2] === "--debug";
+const release = process.argv[2] === "--release";
 
 function prelude(name) {
   return [
@@ -207,9 +208,10 @@ const common = {
   ],
   legalComments: "none",
   bundle: true,
-  sourcemap: debug,
+  sourcemap: true,
+  sourcesContent: debug || watch,
   treeShaking: true,
-  minify: !debug,
+  minify: release,
   watch,
   incremental: watch
 };

--- a/src/README.md
+++ b/src/README.md
@@ -27,9 +27,14 @@ To build the compiler, run:
 npm run build
 ```
 
-To build the debug version (with source map and un-minified js files), run:  
+To build the debug version, run:  
 ```sh
 npm run build:debug
+```
+
+To build the release version, run:  
+```sh
+npm run build:release
 ```
 
 The rebuild automatically when there are changes, do:

--- a/src/README.md
+++ b/src/README.md
@@ -27,6 +27,11 @@ To build the compiler, run:
 npm run build
 ```
 
+To build the debug version (with source map and un-minified js files), run:  
+```sh
+npm run build:debug
+```
+
 The rebuild automatically when there are changes, do:
 
 ```sh


### PR DESCRIPTION
`npm run build:debug` means debug version (un-minified js files, contains the source maps)
`npm run build` means release version (no source maps, minified js files)

Signed-off-by: Jesse <xiang19890319@gmail.com>


- [x] I've read the contributing guidelines
- [x] I've added my name and email to the NOTICE file
