### PR TITLE
fix: 'asc' will not exit with exit code 1 after compile failing(#2311)

### DIFF
--- a/bin/asc.js
+++ b/bin/asc.js
@@ -19,15 +19,17 @@ if ((!hasSourceMaps || ~posCustomArgs) && !isDeno) {
     nodeArgs.push(...args.slice(posCustomArgs + 1));
     args.length = posCustomArgs;
   }
-  (await import("child_process")).spawnSync(
+  const { status, signal } = (await import("child_process")).spawnSync(
     nodePath,
     [...nodeArgs, thisPath, ...args],
     { stdio: "inherit" }
   );
+  if (status || signal) process.exitCode = 1;
 } else {
-  const { error } = (await import("../dist/asc.js")).main(process.argv.slice(2), {
+  const apiResult = (await import("../dist/asc.js")).main(process.argv.slice(2), {
     stdout: process.stdout,
     stderr: process.stderr
   });
+  const { error }  = await apiResult;
   if (error) process.exitCode = 1;
 }


### PR DESCRIPTION
<!--
 Thanks for submitting a pull request to AssemblyScript! Please take a moment to
 review the contributing guidelines linked below, and confirm with an [x] 🙂
-->

Fix #2311
⯈receive error correctly from `main`
⯈pass the exit code from `spawnSync`

- [x] I've read the contributing guidelines
- [x] I've added my name and email to the NOTICE file
