### PR TITLE
fix: Fix wrong param type in definitions for String.fromCharCodes

### DIFF
--- a/std/assembly/index.d.ts
+++ b/std/assembly/index.d.ts
@@ -1802,7 +1802,7 @@ declare class StaticArray<T> {
 /** Class representing a sequence of characters. */
 declare class String {
   static fromCharCode(ls: i32, hs?: i32): string;
-  static fromCharCodes(arr: u16[]): string;
+  static fromCharCodes(arr: i32[]): string;
   static fromCodePoint(code: i32): string;
   static fromCodePoints(arr: i32[]): string;
   static raw(parts: TemplateStringsArray, ...args: any[]): string;

--- a/std/portable/index.d.ts
+++ b/std/portable/index.d.ts
@@ -309,7 +309,7 @@ declare const JSMath: typeof Math;
 
 declare interface StringConstructor {
   /** Equivalent to calling `String.fromCharCode` with multiple arguments. */
-  fromCharCodes(arr: u16[]): string;
+  fromCharCodes(arr: i32[]): string;
   /** Equivalent to calling `String.fromCodePoint` with multiple arguments. */
   fromCodePoints(arr: i32[]): string;
 }


### PR DESCRIPTION
Fix #1609

- [x] I've read the contributing guidelines
- [x] I've added my name and email to the NOTICE file
