### PR TITLE
BREAKING CHANGE: Remove externref in favour of anyref

### DIFF
--- a/src/builtins.ts
+++ b/src/builtins.ts
@@ -3334,7 +3334,6 @@ function builtin_assert(ctx: BuiltinContext): ExpressionRef {
       case TypeKind.F32: return module.if(module.binary(BinaryOp.EqF32, arg0, module.f32(0)), abort);
       case TypeKind.F64: return module.if(module.binary(BinaryOp.EqF64, arg0, module.f64(0)), abort);
       case TypeKind.FUNCREF:
-      case TypeKind.EXTERNREF:
       case TypeKind.ANYREF:
       case TypeKind.EQREF:
       case TypeKind.DATAREF:
@@ -3418,7 +3417,6 @@ function builtin_assert(ctx: BuiltinContext): ExpressionRef {
         return ret;
       }
       case TypeKind.FUNCREF:
-      case TypeKind.EXTERNREF:
       case TypeKind.ANYREF:
       case TypeKind.EQREF:
       case TypeKind.DATAREF:

--- a/src/common.ts
+++ b/src/common.ts
@@ -124,7 +124,6 @@ export namespace CommonNames {
   export const f64 = "f64";
   export const v128 = "v128";
   export const funcref = "funcref";
-  export const externref = "externref";
   export const anyref = "anyref";
   export const eqref = "eqref";
   export const i31ref = "i31ref";
@@ -201,7 +200,6 @@ export namespace CommonNames {
   export const F64 = "F64";
   export const V128 = "V128";
   export const Funcref = "Funcref";
-  export const Externref = "Externref";
   export const Anyref = "Anyref";
   export const Eqref = "Eqref";
   export const I31ref = "I31ref";

--- a/src/compiler.ts
+++ b/src/compiler.ts
@@ -4971,7 +4971,6 @@ export class Compiler extends DiagnosticEmitter {
         return module.ref_eq(leftExpr, rightExpr);
       }
       case TypeKind.FUNCREF:
-      case TypeKind.EXTERNREF:
       case TypeKind.ANYREF: {
         this.error(
           DiagnosticCode.Operation_0_cannot_be_applied_to_type_1,
@@ -5036,7 +5035,6 @@ export class Compiler extends DiagnosticEmitter {
         );
       }
       case TypeKind.FUNCREF:
-      case TypeKind.EXTERNREF:
       case TypeKind.ANYREF: {
         this.error(
           DiagnosticCode.Operation_0_cannot_be_applied_to_type_1,
@@ -9911,7 +9909,7 @@ export class Compiler extends DiagnosticEmitter {
                     typeString = "object";
                   }
                 } else {
-                  typeString = "externref"; // TODO?
+                  typeString = "anyref"; // TODO?
                 }
               }
             } else if (type == Type.bool) {
@@ -10021,11 +10019,11 @@ export class Compiler extends DiagnosticEmitter {
   /** Checks whether a particular type is supported. */
   checkTypeSupported(type: Type, reportNode: Node): bool {
     switch (type.kind) {
-      case TypeKind.V128: return this.checkFeatureEnabled(Feature.SIMD, reportNode);
+      case TypeKind.V128:
+        return this.checkFeatureEnabled(Feature.SIMD, reportNode);
       case TypeKind.FUNCREF:
-      case TypeKind.EXTERNREF:
-        return this.checkFeatureEnabled(Feature.REFERENCE_TYPES, reportNode);
       case TypeKind.ANYREF:
+        return this.checkFeatureEnabled(Feature.REFERENCE_TYPES, reportNode);
       case TypeKind.EQREF:
       case TypeKind.I31REF:
       case TypeKind.DATAREF: {
@@ -10134,7 +10132,6 @@ export class Compiler extends DiagnosticEmitter {
       case TypeKind.F64: return module.f64(0);
       case TypeKind.V128: return module.v128(v128_zero);
       case TypeKind.FUNCREF:
-      case TypeKind.EXTERNREF:
       case TypeKind.ANYREF:
       case TypeKind.EQREF:
       case TypeKind.DATAREF: return module.ref_null(type.toRef());
@@ -10248,7 +10245,6 @@ export class Compiler extends DiagnosticEmitter {
         return module.unary(UnaryOp.AnyTrueV128, expr);
       }
       case TypeKind.FUNCREF:
-      case TypeKind.EXTERNREF:
       case TypeKind.ANYREF:
       case TypeKind.EQREF:
       case TypeKind.DATAREF:

--- a/src/flow.ts
+++ b/src/flow.ts
@@ -333,7 +333,6 @@ export class Flow {
       case <u32>TypeRef.F64: { temps = parentFunction.tempF64s; break; }
       case <u32>TypeRef.V128: { temps = parentFunction.tempV128s; break; }
       case <u32>TypeRef.Funcref: { temps = parentFunction.tempFuncrefs; break; }
-      case <u32>TypeRef.Externref: { temps = parentFunction.tempExternrefs; break; }
       case <u32>TypeRef.Anyref: { temps = parentFunction.tempAnyrefs; break; }
       case <u32>TypeRef.Eqref: { temps = parentFunction.tempEqrefs; break; }
       case <u32>TypeRef.I31ref: { temps = parentFunction.tempI31refs; break; }
@@ -413,12 +412,6 @@ export class Flow {
         let tempFuncrefs = parentFunction.tempFuncrefs;
         if (tempFuncrefs) temps = tempFuncrefs;
         else parentFunction.tempFuncrefs = temps = [];
-        break;
-      }
-      case <u32>TypeRef.Externref: {
-        let tempExternrefs = parentFunction.tempExternrefs;
-        if (tempExternrefs) temps = tempExternrefs;
-        else parentFunction.tempExternrefs = temps = [];
         break;
       }
       case <u32>TypeRef.Anyref: {

--- a/src/module.ts
+++ b/src/module.ts
@@ -59,7 +59,6 @@ export namespace TypeRef {
   export const F64: TypeRef = 5 /* _BinaryenTypeFloat64 */;
   export const V128: TypeRef = 6 /* _BinaryenTypeVec128 */;
   export const Funcref: TypeRef = 7 /* _BinaryenTypeFuncref */;
-  export const Externref: TypeRef = 8 /* _BinaryenTypeExternref */;
   export const Anyref: TypeRef = 8 /* _BinaryenTypeAnyref */;
   export const Eqref: TypeRef = 9 /* _BinaryenTypeEqref */;
   export const I31ref: TypeRef = 10 /* _BinaryenTypeI31ref */;

--- a/src/program.ts
+++ b/src/program.ts
@@ -1007,7 +1007,6 @@ export class Program extends DiagnosticEmitter {
     // respectively stored or loaded.
     this.registerNativeType(CommonNames.v128, Type.v128);
     this.registerNativeType(CommonNames.funcref, Type.funcref);
-    this.registerNativeType(CommonNames.externref, Type.externref);
     this.registerNativeType(CommonNames.anyref, Type.anyref);
     this.registerNativeType(CommonNames.eqref, Type.eqref);
     this.registerNativeType(CommonNames.i31ref, Type.i31ref);
@@ -1275,9 +1274,8 @@ export class Program extends DiagnosticEmitter {
     if (options.hasFeature(Feature.SIMD)) this.registerWrapperClass(Type.v128, CommonNames.V128);
     if (options.hasFeature(Feature.REFERENCE_TYPES)) {
       this.registerWrapperClass(Type.funcref, CommonNames.Funcref);
-      this.registerWrapperClass(Type.externref, CommonNames.Externref);
+      this.registerWrapperClass(Type.anyref, CommonNames.Anyref);
       if (options.hasFeature(Feature.GC)) {
-        this.registerWrapperClass(Type.anyref, CommonNames.Anyref);
         this.registerWrapperClass(Type.eqref, CommonNames.Eqref);
         this.registerWrapperClass(Type.i31ref, CommonNames.I31ref);
         this.registerWrapperClass(Type.dataref, CommonNames.Dataref);
@@ -3727,7 +3725,6 @@ export class Function extends TypedElement {
   tempF64s: Local[] | null = null;
   tempV128s: Local[] | null = null;
   tempFuncrefs: Local[] | null = null;
-  tempExternrefs: Local[] | null = null;
   tempAnyrefs: Local[] | null = null;
   tempEqrefs: Local[] | null = null;
   tempI31refs: Local[] | null = null;

--- a/src/types.ts
+++ b/src/types.ts
@@ -61,8 +61,6 @@ export const enum TypeKind {
 
   /** Function reference. */
   FUNCREF,
-  /** External reference. */
-  EXTERNREF,
   /** Any reference. */
   ANYREF,
   /** Equatable reference. */
@@ -400,7 +398,7 @@ export class Type {
             if (targetFunction = target.getSignature()) {
               return currentFunction.isAssignableTo(targetFunction);
             }
-          } else if (this.isExternalReference && (this.kind == target.kind || (target.kind == TypeKind.ANYREF && this.kind != TypeKind.EXTERNREF))) {
+          } else if (this.isExternalReference && (this.kind == target.kind || target.kind == TypeKind.ANYREF)) {
             return true;
           }
         }
@@ -498,7 +496,6 @@ export class Type {
       case TypeKind.F64: return "f64";
       case TypeKind.V128: return "v128";
       case TypeKind.FUNCREF: return "funcref";
-      case TypeKind.EXTERNREF: return "externref";
       case TypeKind.ANYREF: return "anyref";
       case TypeKind.EQREF: return "eqref";
       case TypeKind.I31REF: return "i31ref";
@@ -530,7 +527,6 @@ export class Type {
       case TypeKind.V128: return TypeRef.V128;
       // TODO: nullable/non-nullable refs have different type refs
       case TypeKind.FUNCREF: return TypeRef.Funcref;
-      case TypeKind.EXTERNREF: return TypeRef.Externref;
       case TypeKind.ANYREF: return TypeRef.Anyref;
       case TypeKind.EQREF: return TypeRef.Eqref;
       case TypeKind.I31REF: return TypeRef.I31ref;
@@ -668,13 +664,6 @@ export class Type {
 
   /** Function reference. */
   static readonly funcref: Type = new Type(TypeKind.FUNCREF,
-    TypeFlags.EXTERNAL   |
-    TypeFlags.NULLABLE   |
-    TypeFlags.REFERENCE, 0
-  );
-
-  /** External reference. */
-  static readonly externref: Type = new Type(TypeKind.EXTERNREF,
     TypeFlags.EXTERNAL   |
     TypeFlags.NULLABLE   |
     TypeFlags.REFERENCE, 0

--- a/std/assembly/bindings/dom.ts
+++ b/std/assembly/bindings/dom.ts
@@ -1,5 +1,5 @@
 @external("env", "globalThis")
-export declare const globalThis: externref;
+export declare const globalThis: anyref;
 
 export declare namespace Math {
   @external("env", "Math.E")
@@ -92,27 +92,27 @@ export declare namespace Math {
 
 export declare namespace Reflect {
   @external("env", "Reflect.get")
-  export function get(target: externref, propertyKey: string): externref;
+  export function get(target: anyref, propertyKey: string): anyref;
   @external("env", "Reflect.getWithReceiver")
   @external.js("return Reflect.get(target, propertyKey, receiver);")
-  export function getWithReceiver(target: externref, propertyKey: string, receiver: externref): externref;
+  export function getWithReceiver(target: anyref, propertyKey: string, receiver: anyref): anyref;
   @external("env", "Reflect.has")
-  export function has(target: externref, propertyKey: string): bool;
+  export function has(target: anyref, propertyKey: string): bool;
   @external("env", "Reflect.set")
-  export function set(target: externref, propertyKey: string, value: externref): externref;
+  export function set(target: anyref, propertyKey: string, value: anyref): anyref;
   @external("env", "Reflect.setWithReceiver")
   @external.js("return Reflect.set(target, propertyKey, value, receiver);")
-  export function setWithReceiver(target: externref, propertyKey: string, value: externref , receiver: externref): externref;
+  export function setWithReceiver(target: anyref, propertyKey: string, value: anyref , receiver: anyref): anyref;
   @external("env", "Reflect.apply")
-  export function apply(target: externref, thisArgument: externref, argumentsList: externref): externref;
+  export function apply(target: anyref, thisArgument: anyref, argumentsList: anyref): anyref;
 }
 
 export declare namespace String {
   @external("env", "String.fromCodePoint")
-  export function fromCodePoint(codepoint: i32): externref;
+  export function fromCodePoint(codepoint: i32): anyref;
   @external("env", "String.fromCodePoints")
   @external.js("return String.fromCodePoint(...codepoints);")
-  export function fromCodePoints(codepoints: i32[]): externref;
+  export function fromCodePoints(codepoints: i32[]): anyref;
 }
 
 export declare namespace Date {
@@ -143,7 +143,7 @@ export declare namespace console {
 
 export declare namespace document {
   @external("env", "document.getElementById")
-  export function getElementById(id: string): externref;
+  export function getElementById(id: string): anyref;
 }
 
 export declare namespace performance {

--- a/std/assembly/index.d.ts
+++ b/std/assembly/index.d.ts
@@ -37,8 +37,6 @@ declare type f64 = number;
 declare type v128 = object;
 /** Function reference. */
 declare type funcref = object | null;
-/** External reference. */
-declare type externref = object | null;
 /** Any reference. */
 declare type anyref = object | null;
 /** Equatable reference. */

--- a/std/assembly/reference.ts
+++ b/std/assembly/reference.ts
@@ -7,10 +7,6 @@ export abstract class Funcref extends Ref {
 }
 
 @final @unmanaged
-export abstract class Externref extends Ref {
-}
-
-@final @unmanaged
 export abstract class Anyref extends Ref {
 }
 

--- a/tests/compiler/bindings/esm.debug.js
+++ b/tests/compiler/bindings/esm.debug.js
@@ -23,7 +23,7 @@ async function instantiate(module, imports = {}) {
         Math.log
       ),
       "globalThis.globalThis": (
-        // bindings/esm/immutableGlobalNested: externref
+        // bindings/esm/immutableGlobalNested: anyref
         globalThis.globalThis
       ),
       "Date.getTimezoneOffset"() {

--- a/tests/compiler/bindings/esm.release.js
+++ b/tests/compiler/bindings/esm.release.js
@@ -23,7 +23,7 @@ async function instantiate(module, imports = {}) {
         Math.log
       ),
       "globalThis.globalThis": (
-        // bindings/esm/immutableGlobalNested: externref
+        // bindings/esm/immutableGlobalNested: anyref
         globalThis.globalThis
       ),
       "Date.getTimezoneOffset"() {

--- a/tests/compiler/bindings/esm.ts
+++ b/tests/compiler/bindings/esm.ts
@@ -123,11 +123,11 @@ console.log("42 from console.log");
 Math.log(Math.E);
 
 // @ts-ignore
-@external("env", "globalThis") declare const immutableGlobal: externref;
+@external("env", "globalThis") declare const immutableGlobal: anyref;
 immutableGlobal;
 
 // @ts-ignore
-@external("env", "globalThis.globalThis") declare const immutableGlobalNested: externref;
+@external("env", "globalThis.globalThis") declare const immutableGlobalNested: anyref;
 immutableGlobalNested;
 
 // @ts-ignore

--- a/tests/compiler/bindings/raw.debug.js
+++ b/tests/compiler/bindings/raw.debug.js
@@ -23,7 +23,7 @@ export async function instantiate(module, imports = {}) {
         Math.log
       ),
       "globalThis.globalThis": (
-        // bindings/esm/immutableGlobalNested: externref
+        // bindings/esm/immutableGlobalNested: anyref
         globalThis.globalThis
       ),
       "Date.getTimezoneOffset"() {

--- a/tests/compiler/bindings/raw.release.js
+++ b/tests/compiler/bindings/raw.release.js
@@ -23,7 +23,7 @@ export async function instantiate(module, imports = {}) {
         Math.log
       ),
       "globalThis.globalThis": (
-        // bindings/esm/immutableGlobalNested: externref
+        // bindings/esm/immutableGlobalNested: anyref
         globalThis.globalThis
       ),
       "Date.getTimezoneOffset"() {


### PR DESCRIPTION
Continue of removing `externref` which superseded by `anyref`. See prev part: #2302
Also see spec changes: https://github.com/WebAssembly/gc/pull/271

`anyref` allowing in reference types proposal now

- [x] I've read the contributing guidelines
- [x] I've added my name and email to the NOTICE file
