### PR TITLE
BREAKING CHANGE: Unify Math & Mathf. Make every method in Math polymorphic

### DIFF
--- a/src/common.ts
+++ b/src/common.ts
@@ -218,7 +218,6 @@ export namespace CommonNames {
   export const Math = "Math";
   export const Mathf = "Mathf";
   export const NativeMath = "NativeMath";
-  export const NativeMathf = "NativeMathf";
   export const Int8Array = "Int8Array";
   export const Int16Array = "Int16Array";
   export const Int32Array = "Int32Array";
@@ -236,10 +235,12 @@ export namespace CommonNames {
   export const abort = "abort";
   export const trace = "trace";
   export const seed = "seed";
-  export const pow = "pow";
-  export const ipow32 = "ipow32";
-  export const ipow64 = "ipow64";
-  export const mod = "mod";
+  export const fpow32 = "~lib/util/math/pow32";
+  export const fpow64 = "~lib/util/math/pow64";
+  export const ipow32 = "~lib/util/math/ipow32";
+  export const ipow64 = "~lib/util/math/ipow64";
+  export const fmod32 = "~lib/util/math/mod32";
+  export const fmod64 = "~lib/util/math/mod64";
   export const alloc = "__alloc";
   export const realloc = "__realloc";
   export const free = "__free";

--- a/src/compiler.ts
+++ b/src/compiler.ts
@@ -5327,23 +5327,14 @@ export class Compiler extends DiagnosticEmitter {
         }
         let instance = this.f32PowInstance;
         if (!instance) {
-          let namespace = this.program.lookup(CommonNames.Mathf);
-          if (!namespace) {
+          let prototype = this.program.lookup(CommonNames.fpow32);
+          if (!prototype) {
             this.error(
               DiagnosticCode.Cannot_find_name_0,
-              reportNode.range, "Mathf"
+              reportNode.range, "pow32"
             );
             return module.unreachable();
           }
-          let namespaceMembers = namespace.members;
-          if (!namespaceMembers || !namespaceMembers.has(CommonNames.pow)) {
-            this.error(
-              DiagnosticCode.Cannot_find_name_0,
-              reportNode.range, "Mathf.pow"
-            );
-            return module.unreachable();
-          }
-          let prototype = assert(namespaceMembers.get(CommonNames.pow));
           assert(prototype.kind == ElementKind.FUNCTION_PROTOTYPE);
           this.f32PowInstance = instance = this.resolver.resolveFunction(<FunctionPrototype>prototype, null);
         }
@@ -5369,23 +5360,14 @@ export class Compiler extends DiagnosticEmitter {
         }
         let instance = this.f64PowInstance;
         if (!instance) {
-          let namespace = this.program.lookup(CommonNames.Math);
-          if (!namespace) {
+          let prototype = this.program.lookup(CommonNames.fpow64);
+          if (!prototype) {
             this.error(
               DiagnosticCode.Cannot_find_name_0,
-              reportNode.range, "Math"
+              reportNode.range, "pow64"
             );
             return module.unreachable();
           }
-          let namespaceMembers = namespace.members;
-          if (!namespaceMembers || !namespaceMembers.has(CommonNames.pow)) {
-            this.error(
-              DiagnosticCode.Cannot_find_name_0,
-              reportNode.range, "Math.pow"
-            );
-            return module.unreachable();
-          }
-          let prototype = assert(namespaceMembers.get(CommonNames.pow));
           assert(prototype.kind == ElementKind.FUNCTION_PROTOTYPE);
           this.f64PowInstance = instance = this.resolver.resolveFunction(<FunctionPrototype>prototype, null);
         }
@@ -5507,23 +5489,14 @@ export class Compiler extends DiagnosticEmitter {
       case TypeKind.F32: {
         let instance = this.f32ModInstance;
         if (!instance) {
-          let namespace = this.program.lookup(CommonNames.Mathf);
-          if (!namespace) {
+          let prototype = this.program.lookup(CommonNames.fmod32);
+          if (!prototype) {
             this.error(
               DiagnosticCode.Cannot_find_name_0,
-              reportNode.range, "Mathf"
+              reportNode.range, "mod32"
             );
             return module.unreachable();
           }
-          let namespaceMembers = namespace.members;
-          if (!namespaceMembers || !namespaceMembers.has(CommonNames.mod)) {
-            this.error(
-              DiagnosticCode.Cannot_find_name_0,
-              reportNode.range, "Mathf.mod"
-            );
-            return module.unreachable();
-          }
-          let prototype = assert(namespaceMembers.get(CommonNames.mod));
           assert(prototype.kind == ElementKind.FUNCTION_PROTOTYPE);
           this.f32ModInstance = instance = this.resolver.resolveFunction(<FunctionPrototype>prototype, null);
         }
@@ -5535,23 +5508,14 @@ export class Compiler extends DiagnosticEmitter {
       case TypeKind.F64: {
         let instance = this.f64ModInstance;
         if (!instance) {
-          let namespace = this.program.lookup(CommonNames.Math);
-          if (!namespace) {
+          let prototype = this.program.lookup(CommonNames.fmod64);
+          if (!prototype) {
             this.error(
               DiagnosticCode.Cannot_find_name_0,
-              reportNode.range, "Math"
+              reportNode.range, "mod64"
             );
             return module.unreachable();
           }
-          let namespaceMembers = namespace.members;
-          if (!namespaceMembers || !namespaceMembers.has(CommonNames.mod)) {
-            this.error(
-              DiagnosticCode.Cannot_find_name_0,
-              reportNode.range, "Math.mod"
-            );
-            return module.unreachable();
-          }
-          let prototype = assert(namespaceMembers.get(CommonNames.mod));
           assert(prototype.kind == ElementKind.FUNCTION_PROTOTYPE);
           this.f64ModInstance = instance = this.resolver.resolveFunction(<FunctionPrototype>prototype, null);
         }

--- a/src/program.ts
+++ b/src/program.ts
@@ -1401,9 +1401,6 @@ export class Program extends DiagnosticEmitter {
       if (!globalAliases.has(CommonNames.Math)) {
         globalAliases.set(CommonNames.Math, CommonNames.NativeMath);
       }
-      if (!globalAliases.has(CommonNames.Mathf)) {
-        globalAliases.set(CommonNames.Mathf, CommonNames.NativeMathf);
-      }
       // TODO: for (let [alias, name] of globalAliases) {
       for (let _keys = Map_keys(globalAliases), i = 0, k = _keys.length; i < k; ++i) {
         let alias = unchecked(_keys[i]);

--- a/std/assembly/index.d.ts
+++ b/std/assembly/index.d.ts
@@ -2025,127 +2025,119 @@ interface SymbolConstructor {
 declare const Symbol: SymbolConstructor;
 
 /** @internal */
-interface IMath<T> {
+interface IMath {
   /** The base of natural logarithms, e, approximately 2.718. */
-  readonly E: T;
+  readonly E: f64;
   /** The natural logarithm of 2, approximately 0.693. */
-  readonly LN2: T;
+  readonly LN2: f64;
   /** The natural logarithm of 10, approximately 2.302. */
-  readonly LN10: T;
+  readonly LN10: f64;
   /** The base 2 logarithm of e, approximately 1.442. */
-  readonly LOG2E: T;
+  readonly LOG2E: f64;
   /** The base 10 logarithm of e, approximately 0.434. */
-  readonly LOG10E: T;
+  readonly LOG10E: f64;
   /** The ratio of the circumference of a circle to its diameter, approximately 3.14159. */
-  readonly PI: T;
+  readonly PI: f64;
   /** The square root of 1/2, approximately 0.707. */
-  readonly SQRT1_2: T;
+  readonly SQRT1_2: f64;
   /** The square root of 2, approximately 1.414. */
-  readonly SQRT2: T;
+  readonly SQRT2: f64;
   /** Returns the absolute value of `x`. */
-  abs(x: T): T;
+  abs<T extends u8 | u16 | u32 | u64 | i8 | i16 | i32 | i64 | f32 | f64>(x: T): T;
   /** Returns the arccosine (in radians) of `x`. */
-  acos(x: T): T;
+  acos<T extends f32 | f64>(x: T): T;
   /** Returns the hyperbolic arc-cosine of `x`. */
-  acosh(x: T): T;
+  acosh<T extends f32 | f64>(x: T): T;
   /** Returns the arcsine (in radians) of `x`. */
-  asin(x: T): T;
+  asin<T extends f32 | f64>(x: T): T;
   /** Returns the hyperbolic arcsine of `x`. */
-  asinh(x: T): T;
+  asinh<T extends f32 | f64>(x: T): T;
   /** Returns the arctangent (in radians) of `x`. */
-  atan(x: T): T;
+  atan<T extends f32 | f64>(x: T): T;
   /** Returns the arctangent of the quotient of its arguments. */
-  atan2(y: T, x: T): T;
+  atan2<T extends f32 | f64>(y: T, x: T): T;
   /** Returns the hyperbolic arctangent of `x`. */
-  atanh(x: T): T;
+  atanh<T extends f32 | f64>(x: T): T;
   /** Returns the cube root of `x`. */
-  cbrt(x: T): T;
+  cbrt<T extends f32 | f64>(x: T): T;
   /** Returns the smallest integer greater than or equal to `x`. */
-  ceil(x: T): T;
+  ceil<T extends u8 | u16 | u32 | u64 | i8 | i16 | i32 | i64 | f32 | f64>(x: T): T;
   /** Returns the number of leading zero bits in the 32-bit binary representation of `x`. */
-  clz32(x: T): T;
+  clz32<T extends u8 | u16 | u32 | u64 | i8 | i16 | i32 | i64 | f32 | f64>(x: T): T;
   /** Returns the cosine (in radians) of `x`. */
-  cos(x: T): T;
+  cos<T extends f32 | f64>(x: T): T;
   /** Returns the hyperbolic cosine of `x`. */
-  cosh(x: T): T;
+  cosh<T extends f32 | f64>(x: T): T;
   /** Returns e to the power of `x`. */
-  exp(x: T): T;
+  exp<T extends f32 | f64>(x: T): T;
   /** Returns e to the power of `x`, minus 1. */
-  expm1(x: T): T;
+  expm1<T extends f32 | f64>(x: T): T;
   /** Returns the largest integer less than or equal to `x`. */
-  floor(x: T): T;
+  floor<T extends u8 | u16 | u32 | u64 | i8 | i16 | i32 | i64 | f32 | f64>(x: T): T;
   /** Returns the nearest 32-bit single precision float representation of `x`. */
-  fround(x: T): T;
+  fround<T extends f32 | f64>(x: T): T;
   /** Returns the square root of the sum of squares of its arguments. */
-  hypot(value1: T, value2: T): T; // TODO: rest
+  hypot<T extends f32 | f64>(a: T, b: T): T; // TODO: rest
   /** Returns the result of the C-like 32-bit multiplication of `a` and `b`. */
-  imul(a: T, b: T): T;
+  imul<T extends f32 | f64>(a: T, b: T): T;
   /** Returns the natural logarithm (base e) of `x`. */
-  log(x: T): T;
+  log<T extends f32 | f64>(x: T): T;
   /** Returns the base 10 logarithm of `x`. */
-  log10(x: T): T;
+  log10<T extends f32 | f64>(x: T): T;
   /** Returns the natural logarithm (base e) of 1 + `x`. */
-  log1p(x: T): T;
+  log1p<T extends f32 | f64>(x: T): T;
   /** Returns the base 2 logarithm of `x`. */
-  log2(x: T): T;
+  log2<T extends u8 | u16 | u32 | u64 | i8 | i16 | i32 | i64 | f32 | f64>(x: T): T;
   /** Returns the largest-valued number of its arguments. */
-  max(value1: T, value2: T): T; // TODO: rest
+  max<T extends u8 | u16 | u32 | u64 | i8 | i16 | i32 | i64 | f32 | f64>(a: T, b: T): T; // TODO: rest
   /** Returns the lowest-valued number of its arguments. */
-  min(value1: T, value2: T): T; // TODO: rest
+  min<T extends u8 | u16 | u32 | u64 | i8 | i16 | i32 | i64 | f32 | f64>(a: T, b: T): T; // TODO: rest
   /** Returns `base` to the power of `exponent`. */
-  pow(base: T, exponent: T): T;
+  pow<T extends u8 | u16 | u32 | u64 | i8 | i16 | i32 | i64 | f32 | f64>(base: T, exponent: T): T;
   /** Returns a pseudo-random number in the range from 0.0 inclusive up to but not including 1.0. */
-  random(): T;
+  random(): f64;
   /** Returns the value of `x` rounded to the nearest integer. */
-  round(x: T): T;
+  round<T extends u8 | u16 | u32 | u64 | i8 | i16 | i32 | i64 | f32 | f64>(x: T): T;
   /** Returns the sign of `x`, indicating whether the number is positive, negative or zero. */
-  sign(x: T): T;
+  sign<T extends u8 | u16 | u32 | u64 | i8 | i16 | i32 | i64 | f32 | f64>(x: T): T;
   /** Returns whether the sign bit of `x` is set. */
-  signbit(x: T): bool;
+  signbit<T extends u8 | u16 | u32 | u64 | i8 | i16 | i32 | i64 | f32 | f64>(x: T): bool;
   /** Returns the sine of `x`. */
-  sin(x: T): T;
+  sin<T extends f32 | f64>(x: T): T;
   /** Returns the hyperbolic sine of `x`. */
-  sinh(x: T): T;
+  sinh<T extends f32 | f64>(x: T): T;
   /** Returns the square root of `x`. */
-  sqrt(x: T): T;
+  sqrt<T extends f32 | f64>(x: T): T;
   /** Returns the tangent of `x`. */
-  tan(x: T): T;
+  tan<T extends f32 | f64>(x: T): T;
   /** Returns the hyperbolic tangent of `x`. */
-  tanh(x: T): T;
+  tanh<T extends f32 | f64>(x: T): T;
   /** Returns the integer part of `x` by removing any fractional digits. */
-  trunc(x: T): T;
+  trunc<T extends u8 | u16 | u32 | u64 | i8 | i16 | i32 | i64 | f32 | f64>(x: T): T;
 }
 
 /** @internal */
-interface INativeMath<T> extends IMath<T> {
-  /** Contains sin value produced after Math/Mathf.sincos */
-  sincos_sin: T;
-  /** Contains cos value produced after Math/Mathf.sincos */
-  sincos_cos: T;
+interface INativeMath extends IMath {
+  /** Contains sin value produced after Math.sincos */
+  sincos_sin: f64;
+  /** Contains cos value produced after Math.sincos */
+  sincos_cos: f64;
   /** Seeds the random number generator. */
   seedRandom(value: i64): void;
-  /** Multiplies a floating point `x` by 2 raised to power exp `n`. */
-  scalbn(x: T, n: i32): T;
   /** Returns the floating-point remainder of `x / y` (rounded towards zero). */
-  mod(x: T, y: T): T;
-  /** Returns the floating-point remainder of `x / y` (rounded to nearest). */
-  rem(x: T, y: T): T;
+  mod<T extends u8 | u16 | u32 | u64 | i8 | i16 | i32 | i64 | f32 | f64>(x: T, y: T): T;
   /** Returns sin and cos simultaneously for same angle. Results stored to `sincos_s32/64` and `sincos_c32/64` globals */
-  sincos(x: T): void;
+  sincos<T extends f32 | f64>(x: T): void;
   /** Returns 2 raised to the given power x. Equivalent to 2 ** x. */
-  exp2(x: T): T;
+  exp2<T extends f32 | f64>(x: T): T;
 }
 
 /** Double precision math imported from JavaScript. */
-declare const JSMath: IMath<f64>;
+declare const JSMath: IMath;
 /** Double precision math implemented natively. */
-declare const NativeMath: INativeMath<f64>;
-/** Single precision math implemented natively. */
-declare const NativeMathf: INativeMath<f32>;
+declare const NativeMath: INativeMath;
 /** Alias of {@link NativeMath} or {@link JSMath} respectively. Defaults to `NativeMath`. */
-declare const Math: IMath<f64>;
-/** Alias of {@link NativeMathf} or {@link JSMath} respectively. Defaults to `NativeMathf`. */
-declare const Mathf: IMath<f32>;
+declare const Math: IMath;
 
 /** Environmental abort function. */
 declare function abort(msg?: string | null, fileName?: string | null, lineNumber?: i32, columnNumber?: i32): never;

--- a/std/assembly/math.ts
+++ b/std/assembly/math.ts
@@ -2,8 +2,34 @@ import { Math as JSMath } from "./bindings/dom";
 export { JSMath };
 
 import {
-  pow_lut, exp_lut, exp2_lut, log_lut, log2_lut,
-  powf_lut, expf_lut, exp2f_lut, logf_lut, log2f_lut
+  dtoi32, murmurHash3,
+  ipow32, ipow64,
+  mod32, mod64,
+  acos32, acos64,
+  acosh32, acosh64,
+  asin32, asin64,
+  asinh32, asinh64,
+  atan32, atan64,
+  atanh32, atanh64,
+  atan2_32, atan2_64,
+  cbrt32, cbrt64,
+  cos32, cos64,
+  cosh32, cosh64,
+  exp32, exp64,
+  expm1_32, expm1_64,
+  log32, log64,
+  log1p32, log1p64,
+  log2_32, log2_64,
+  log10_32, log10_64,
+  hypot32, hypot64,
+  pow32, pow64,
+  sin32, sin64,
+  sinh32, sinh64,
+  tan32, tan64,
+  tanh32, tanh64,
+  sincos32, sincos64,
+  sincos_cos32, sincos_cos64,
+  exp2_32_lut, exp2_64_lut
 } from "./util/math";
 
 import {
@@ -27,390 +53,11 @@ import {
 //
 // Applies to all functions marked with a comment referring here.
 
-/** @internal */
 // @ts-ignore: decorator
-@lazy var rempio2_y0: f64, rempio2_y1: f64, res128_hi: u64;
-
-/** @internal */
-// @ts-ignore: decorator
-@lazy @inline const PIO2_TABLE = memory.data<u64>([
-  0x00000000A2F9836E, 0x4E441529FC2757D1, 0xF534DDC0DB629599, 0x3C439041FE5163AB,
-  0xDEBBC561B7246E3A, 0x424DD2E006492EEA, 0x09D1921CFE1DEB1C, 0xB129A73EE88235F5,
-  0x2EBB4484E99C7026, 0xB45F7E413991D639, 0x835339F49C845F8B, 0xBDF9283B1FF897FF,
-  0xDE05980FEF2F118B, 0x5A0A6D1F6D367ECF, 0x27CB09B74F463F66, 0x9E5FEA2D7527BAC7,
-  0xEBE5F17B3D0739F7, 0x8A5292EA6BFB5FB1, 0x1F8D5D0856033046, 0xFC7B6BABF0CFBC20,
-  0x9AF4361DA9E39161, 0x5EE61B086599855F, 0x14A068408DFFD880, 0x4D73273106061557
-]);
-
-/** @internal */
-function R(z: f64): f64 { // Rational approximation of (asin(x)-x)/x^3
-  const                   // see: musl/src/math/asin.c and SUN COPYRIGHT NOTICE above
-    pS0 = reinterpret<f64>(0x3FC5555555555555), //  1.66666666666666657415e-01
-    pS1 = reinterpret<f64>(0xBFD4D61203EB6F7D), // -3.25565818622400915405e-01
-    pS2 = reinterpret<f64>(0x3FC9C1550E884455), //  2.01212532134862925881e-01
-    pS3 = reinterpret<f64>(0xBFA48228B5688F3B), // -4.00555345006794114027e-02
-    pS4 = reinterpret<f64>(0x3F49EFE07501B288), //  7.91534994289814532176e-04
-    pS5 = reinterpret<f64>(0x3F023DE10DFDF709), //  3.47933107596021167570e-05
-    qS1 = reinterpret<f64>(0xC0033A271C8A2D4B), // -2.40339491173441421878e+00
-    qS2 = reinterpret<f64>(0x40002AE59C598AC8), //  2.02094576023350569471e+00
-    qS3 = reinterpret<f64>(0xBFE6066C1B8D0159), // -6.88283971605453293030e-01
-    qS4 = reinterpret<f64>(0x3FB3B8C5B12E9282); //  7.70381505559019352791e-02
-
-  var p = z * (pS0 + z * (pS1 + z * (pS2 + z * (pS3 + z * (pS4 + z * pS5)))));
-  var q = 1.0 + z * (qS1 + z * (qS2 + z * (qS3 + z * qS4)));
-  return p / q;
-}
-
-/** @internal */
-// @ts-ignore: decorator
-@inline
-function expo2(x: f64, sign: f64): f64 { // exp(x)/2 for x >= log(DBL_MAX)
-  const                       // see: musl/src/math/__expo2.c
-    k    = <u32>2043,
-    kln2 = reinterpret<f64>(0x40962066151ADD8B); // 0x1.62066151add8bp+10
-  var scale = reinterpret<f64>(<u64>((<u32>0x3FF + k / 2) << 20) << 32);
-  // in directed rounding correct sign before rounding or overflow is important
-  return NativeMath.exp(x - kln2) * (sign * scale) * scale;
-}
-
-/** @internal */
-/* Helper function to eventually get bits of π/2 * |x|
- *
- * y = π/4 * (frac << clz(frac) >> 11)
- * return clz(frac)
- *
- * Right shift 11 bits to make upper half fit in `double`
- */
-// @ts-ignore: decorator
-@inline
-function pio2_right(q0: u64, q1: u64): u64 { // see: jdh8/metallic/blob/master/src/math/double/rem_pio2.c
-  // Bits of π/4
-  const p0: u64 = 0xC4C6628B80DC1CD1;
-  const p1: u64 = 0xC90FDAA22168C234;
-
-  const Ox1p_64 = reinterpret<f64>(0x3BF0000000000000); // 0x1p-64
-  const Ox1p_75 = reinterpret<f64>(0x3B40000000000000); // 0x1p-75
-
-  var shift = clz(q1);
-
-  q1 = q1 << shift | q0 >> (64 - shift);
-  q0 <<= shift;
-
-  var lo = umuldi(p1, q1);
-  var hi = res128_hi;
-
-  var ahi = hi >> 11;
-  var alo = lo >> 11 | hi << 53;
-  var blo = <u64>(Ox1p_75 * <f64>p0 * <f64>q1 + Ox1p_75 * <f64>p1 * <f64>q0);
-
-  rempio2_y0 = <f64>(ahi + u64(lo < blo));
-  rempio2_y1 = Ox1p_64 * <f64>(alo + blo);
-
-  return shift;
-}
-
-/** @internal */
-// @ts-ignore: decorator
-@inline
-function umuldi(u: u64, v: u64): u64 {
-  var u1: u64 , v1: u64, w0: u64, w1: u64, t: u64;
-
-  u1 = u & 0xFFFFFFFF;
-  v1 = v & 0xFFFFFFFF;
-
-  u >>= 32;
-  v >>= 32;
-
-  t  = u1 * v1;
-  w0 = t & 0xFFFFFFFF;
-  t  = u * v1 + (t >> 32);
-  w1 = t >> 32;
-  t  = u1 * v + (t & 0xFFFFFFFF);
-
-  res128_hi = u * v + w1 + (t >> 32);
-  return (t << 32) + w0;
-}
-
-/** @internal */
-function pio2_large_quot(x: f64, u: i64): i32 { // see: jdh8/metallic/blob/master/src/math/double/rem_pio2.c
-  var magnitude = u & 0x7FFFFFFFFFFFFFFF;
-  var offset = (magnitude >> 52) - 1045;
-  var shift  = offset & 63;
-  var tblPtr = PIO2_TABLE + (<i32>(offset >> 6) << 3);
-  var s0: u64, s1: u64, s2: u64;
-
-  var b0 = load<u64>(tblPtr, 0 << 3);
-  var b1 = load<u64>(tblPtr, 1 << 3);
-  var b2 = load<u64>(tblPtr, 2 << 3);
-
-  // Get 192 bits of 0x1p-31 / π with `offset` bits skipped
-  if (shift) {
-    let rshift = 64 - shift;
-    let b3 = load<u64>(tblPtr, 3 << 3);
-    s0 = b1 >> rshift | b0 << shift;
-    s1 = b2 >> rshift | b1 << shift;
-    s2 = b3 >> rshift | b2 << shift;
-  } else {
-    s0 = b0;
-    s1 = b1;
-    s2 = b2;
-  }
-
-  var significand = (u & 0x000FFFFFFFFFFFFF) | 0x0010000000000000;
-
-  // First 128 bits of fractional part of x/(2π)
-  var blo = umuldi(s1, significand);
-  var bhi = res128_hi;
-
-  var ahi = s0 * significand;
-  var clo = (s2 >> 32) * (significand >> 32);
-  var plo = blo + clo;
-  var phi = ahi + bhi + u64(plo < clo);
-
-  // r: u128 = p << 2
-  var rlo = plo << 2;
-  var rhi = phi << 2 | plo >> 62;
-
-  // s: i128 = r >> 127
-  var slo = <i64>rhi >> 63;
-  var shi = slo >> 1;
-  var q   = (<i64>phi >> 62) - slo;
-
-  var shifter = 0x3CB0000000000000 - (pio2_right(rlo ^ slo, rhi ^ shi) << 52);
-  var signbit = (u ^ rhi) & 0x8000000000000000;
-  var coeff   = reinterpret<f64>(shifter | signbit);
-
-  rempio2_y0 *= coeff;
-  rempio2_y1 *= coeff;
-
-  return <i32>q;
-}
-
-/** @internal */
-// @ts-ignore: decorator
-@inline
-function rempio2(x: f64, u: u64, sign: i32): i32 {
-  const
-    pio2_1  = reinterpret<f64>(0x3FF921FB54400000), // 1.57079632673412561417e+00
-    pio2_1t = reinterpret<f64>(0x3DD0B4611A626331), // 6.07710050650619224932e-11
-    pio2_2  = reinterpret<f64>(0x3DD0B4611A600000), // 6.07710050630396597660e-11
-    pio2_2t = reinterpret<f64>(0x3BA3198A2E037073), // 2.02226624879595063154e-21
-    pio2_3  = reinterpret<f64>(0x3BA3198A2E000000), // 2.02226624871116645580e-21
-    pio2_3t = reinterpret<f64>(0x397B839A252049C1), // 8.47842766036889956997e-32
-    invpio2 = reinterpret<f64>(0x3FE45F306DC9C883); // 0.63661977236758134308
-
-  var ix = <u32>(u >> 32) & 0x7FFFFFFF;
-
-  if (ASC_SHRINK_LEVEL < 1) {
-    if (ix < 0x4002D97C) { // |x| < 3pi/4, special case with n=+-1
-      let q = 1, z: f64, y0: f64, y1: f64;
-      if (!sign) {
-        z = x - pio2_1;
-        if (ix != 0x3FF921FB) { // 33+53 bit pi is good enough
-          y0 = z - pio2_1t;
-          y1 = (z - y0) - pio2_1t;
-        } else { // near pi/2, use 33+33+53 bit pi
-          z -= pio2_2;
-          y0 = z - pio2_2t;
-          y1 = (z - y0) - pio2_2t;
-        }
-      } else { // negative x
-        z = x + pio2_1;
-        if (ix != 0x3FF921FB) { // 33+53 bit pi is good enough
-          y0 = z + pio2_1t;
-          y1 = (z - y0) + pio2_1t;
-        } else { // near pi/2, use 33+33+53 bit pi
-          z += pio2_2;
-          y0 = z + pio2_2t;
-          y1 = (z - y0) + pio2_2t;
-        }
-        q = -1;
-      }
-      rempio2_y0 = y0;
-      rempio2_y1 = y1;
-      return q;
-    }
-  }
-
-  if (ix < 0x413921FB) { // |x| ~< 2^20*pi/2 (1647099)
-    // Use precise Cody Waite scheme
-    let q  = nearest(x * invpio2);
-    let r  = x - q * pio2_1;
-    let w  = q * pio2_1t; // 1st round good to 85 bit
-    let j  = ix >> 20;
-    let y0 = r - w;
-    let hi = <u32>(reinterpret<u64>(y0) >> 32);
-    let i  = j - ((hi >> 20) & 0x7FF);
-
-    if (i > 16) { // 2nd iteration needed, good to 118
-      let t = r;
-      w  = q * pio2_2;
-      r  = t - w;
-      w  = q * pio2_2t - ((t - r) - w);
-      y0 = r - w;
-      hi = <u32>(reinterpret<u64>(y0) >> 32);
-      i = j - ((hi >> 20) & 0x7FF);
-      if (i > 49) { // 3rd iteration need, 151 bits acc
-        let t = r;
-        w  = q * pio2_3;
-        r  = t - w;
-        w  = q * pio2_3t - ((t - r) - w);
-        y0 = r - w;
-      }
-    }
-    let y1 = (r - y0) - w;
-    rempio2_y0 = y0;
-    rempio2_y1 = y1;
-    return <i32>q;
-  }
-  var q = pio2_large_quot(x, u);
-  return select(-q, q, sign);
-}
-
-/** @internal */
-// @ts-ignore: decorator
-@inline
-function sin_kern(x: f64, y: f64, iy: i32): f64 { // see: musl/tree/src/math/__sin.c
-  const
-    S1 = reinterpret<f64>(0xBFC5555555555549), // -1.66666666666666324348e-01
-    S2 = reinterpret<f64>(0x3F8111111110F8A6), //  8.33333333332248946124e-03
-    S3 = reinterpret<f64>(0xBF2A01A019C161D5), // -1.98412698298579493134e-04
-    S4 = reinterpret<f64>(0x3EC71DE357B1FE7D), //  2.75573137070700676789e-06
-    S5 = reinterpret<f64>(0xBE5AE5E68A2B9CEB), // -2.50507602534068634195e-08
-    S6 = reinterpret<f64>(0x3DE5D93A5ACFD57C); //  1.58969099521155010221e-10
-
-  var z = x * x;
-  var w = z * z;
-  var r = S2 + z * (S3 + z * S4) + z * w * (S5 + z * S6);
-  var v = z * x;
-  if (!iy) {
-    return x + v * (S1 + z * r);
-  } else {
-    return x - ((z * (0.5 * y - v * r) - y) - v * S1);
-  }
-}
-
-/** @internal */
-// @ts-ignore: decorator
-@inline
-function cos_kern(x: f64, y: f64): f64 { // see: musl/tree/src/math/__cos.c
-  const
-    C1 = reinterpret<f64>(0x3FA555555555554C), //  4.16666666666666019037e-02
-    C2 = reinterpret<f64>(0xBF56C16C16C15177), // -1.38888888888741095749e-03
-    C3 = reinterpret<f64>(0x3EFA01A019CB1590), //  2.48015872894767294178e-05
-    C4 = reinterpret<f64>(0xBE927E4F809C52AD), // -2.75573143513906633035e-07
-    C5 = reinterpret<f64>(0x3E21EE9EBDB4B1C4), //  2.08757232129817482790e-09
-    C6 = reinterpret<f64>(0xBDA8FAE9BE8838D4); // -1.13596475577881948265e-11
-
-  var z = x * x;
-  var w = z * z;
-  var r = z * (C1 + z * (C2 + z * C3)) + w * w * (C4 + z * (C5 + z * C6));
-  var hz = 0.5 * z;
-  w = 1.0 - hz;
-  return w + (((1.0 - w) - hz) + (z * r - x * y));
-}
-
-/** @internal */
-function tan_kern(x: f64, y: f64, iy: i32): f64 { // see: src/lib/msun/src/k_tan.c
-  const
-    T0  = reinterpret<f64>(0x3FD5555555555563), //  3.33333333333334091986e-01
-    T1  = reinterpret<f64>(0x3FC111111110FE7A), //  1.33333333333201242699e-01
-    T2  = reinterpret<f64>(0x3FABA1BA1BB341FE), //  5.39682539762260521377e-02
-    T3  = reinterpret<f64>(0x3F9664F48406D637), //  2.18694882948595424599e-02
-    T4  = reinterpret<f64>(0x3F8226E3E96E8493), //  8.86323982359930005737e-03
-    T5  = reinterpret<f64>(0x3F6D6D22C9560328), //  3.59207910759131235356e-03
-    T6  = reinterpret<f64>(0x3F57DBC8FEE08315), //  1.45620945432529025516e-03
-    T7  = reinterpret<f64>(0x3F4344D8F2F26501), //  5.88041240820264096874e-04
-    T8  = reinterpret<f64>(0x3F3026F71A8D1068), //  2.46463134818469906812e-04
-    T9  = reinterpret<f64>(0x3F147E88A03792A6), //  7.81794442939557092300e-05
-    T10 = reinterpret<f64>(0x3F12B80F32F0A7E9), //  7.14072491382608190305e-05
-    T11 = reinterpret<f64>(0xBEF375CBDB605373), // -1.85586374855275456654e-05
-    T12 = reinterpret<f64>(0x3EFB2A7074BF7AD4); //  2.59073051863633712884e-05
-
-  const
-    one    = reinterpret<f64>(0x3FF0000000000000), // 1.00000000000000000000e+00
-    pio4   = reinterpret<f64>(0x3FE921FB54442D18), // 7.85398163397448278999e-01
-    pio4lo = reinterpret<f64>(0x3C81A62633145C07); // 3.06161699786838301793e-17
-
-  var z: f64, r: f64, v: f64, w: f64, s: f64;
-  var hx = <i32>(reinterpret<u64>(x) >> 32); // high word of x
-  var ix = hx & 0x7FFFFFFF; // high word of |x|
-  var big = ix >= 0x3FE59428;
-  if (big) { // |x| >= 0.6744
-    if (hx < 0) { x = -x, y = -y; }
-    z = pio4 - x;
-    w = pio4lo - y;
-    x = z + w;
-    y = 0.0;
-  }
-  z = x * x;
-  w = z * z;
-  r = T1 + w * (T3 + w * (T5 + w * (T7 + w * (T9 + w * T11))));
-  v = z * (T2 + w * (T4 + w * (T6 + w * (T8 + w * (T10 + w * T12)))));
-  s = z * x;
-  r = y + z * (s * (r + v) + y);
-  r += T0 * s;
-  w = x + r;
-  if (big) {
-    v = iy;
-    return (1 - ((hx >> 30) & 2)) * (v - 2.0 * (x - (w * w / (w + v) - r)));
-  }
-  if (iy == 1) return w;
-  var a: f64, t: f64;
-  z = w;
-  z = reinterpret<f64>(reinterpret<u64>(z) & 0xFFFFFFFF00000000);
-  v = r - (z - x);  // z + v = r + x
-  t = a = -one / w; // a = -1.0 / w
-  t = reinterpret<f64>(reinterpret<u64>(t) & 0xFFFFFFFF00000000);
-  s = one + t * z;
-  return t + a * (s + t * v);
-}
-
-/** @internal */
-function dtoi32(x: f64): i32 {
-  if (ASC_SHRINK_LEVEL > 0) {
-    const inv32 = 1.0 / 4294967296;
-    return <i32><i64>(x - 4294967296 * floor(x * inv32));
-  } else {
-    let result = 0;
-    let u = reinterpret<u64>(x);
-    let e = (u >> 52) & 0x7FF;
-    if (e <= 1023 + 30) {
-      result = <i32>x;
-    } else if (e <= 1023 + 30 + 53) {
-      let v = (u & ((<u64>1 << 52) - 1)) | (<u64>1 << 52);
-      v = v << e - 1023 - 52 + 32;
-      result = <i32>(v >> 32);
-      result = select<i32>(-result, result, u >> 63);
-    }
-    return result;
-  }
-}
-
-// @ts-ignore: decorator
-@lazy var random_seeded = false;
-
-// @ts-ignore: decorator
-@lazy var random_state0_64: u64, random_state1_64: u64;
-
-// @ts-ignore: decorator
-@lazy var random_state0_32: u32, random_state1_32: u32;
-
-function murmurHash3(h: u64): u64 { // Force all bits of a hash block to avalanche
-  h ^= h >> 33;                     // see: https://github.com/aappleby/smhasher
-  h *= 0xFF51AFD7ED558CCD;
-  h ^= h >> 33;
-  h *= 0xC4CEB9FE1A85EC53;
-  h ^= h >> 33;
-  return h;
-}
-
-function splitMix32(h: u32): u32 {
-  h += 0x6D2B79F5;
-  h  = (h ^ (h >> 15)) * (h | 1);
-  h ^= h + (h ^ (h >> 7)) * (h | 61);
-  return h ^ (h >> 14);
-}
+@lazy var
+  random_seeded = false,
+  random_state0_64: u64,
+  random_state1_64: u64;
 
 export namespace NativeMath {
 
@@ -455,961 +102,364 @@ export namespace NativeMath {
   export var sincos_cos: f64 = 0;
 
   // @ts-ignore: decorator
-  @inline export function abs(x: f64): f64 {
-    return builtin_abs<f64>(x);
-  }
-
-  export function acos(x: f64): f64 { // see: musl/src/math/acos.c and SUN COPYRIGHT NOTICE above
-    const
-      pio2_hi   = reinterpret<f64>(0x3FF921FB54442D18), // 1.57079632679489655800e+00
-      pio2_lo   = reinterpret<f64>(0x3C91A62633145C07), // 6.12323399573676603587e-17
-      Ox1p_120f = reinterpret<f32>(0x03800000);
-
-    var hx = <u32>(reinterpret<u64>(x) >> 32);
-    var ix = hx & 0x7FFFFFFF;
-    if (ix >= 0x3FF00000) {
-      let lx = <u32>reinterpret<u64>(x);
-      if ((ix - 0x3FF00000 | lx) == 0) {
-        if (hx >> 31) return 2 * pio2_hi + Ox1p_120f;
-        return 0;
-      }
-      return 0 / (x - x);
-    }
-    if (ix < 0x3FE00000) {
-      if (ix <= 0x3C600000) return pio2_hi + Ox1p_120f;
-      return pio2_hi - (x - (pio2_lo - x * R(x * x)));
-    }
-    var s: f64, w: f64, z: f64;
-    if (hx >> 31) {
-      // z = (1.0 + x) * 0.5;
-      z = 0.5 + x * 0.5;
-      s = builtin_sqrt<f64>(z);
-      w = R(z) * s - pio2_lo;
-      return 2 * (pio2_hi - (s + w));
-    }
-    // z = (1.0 - x) * 0.5;
-    z = 0.5 - x * 0.5;
-    s = builtin_sqrt<f64>(z);
-    var df = reinterpret<f64>(reinterpret<u64>(s) & 0xFFFFFFFF00000000);
-    var c = (z - df * df) / (s + df);
-    w = R(z) * s + c;
-    return 2 * (df + w);
-  }
-
-  export function acosh(x: f64): f64 { // see: musl/src/math/acosh.c
-    const s = reinterpret<f64>(0x3FE62E42FEFA39EF);
-    var u = reinterpret<u64>(x);
-    // Prevent propagation for all input values less than 1.0.
-    // Note musl lib didn't fix this yet.
-    if (<i64>u < 0x3FF0000000000000) return (x - x) / 0.0;
-    var e = u >> 52 & 0x7FF;
-    if (e < 0x3FF + 1) return log1p(x - 1 + builtin_sqrt<f64>((x - 1) * (x - 1) + 2 * (x - 1)));
-    if (e < 0x3FF + 26) return log(2 * x - 1 / (x + builtin_sqrt<f64>(x * x - 1)));
-    return log(x) + s;
-  }
-
-  export function asin(x: f64): f64 { // see: musl/src/math/asin.c and SUN COPYRIGHT NOTICE above
-    const
-      pio2_hi   = reinterpret<f64>(0x3FF921FB54442D18), // 1.57079632679489655800e+00
-      pio2_lo   = reinterpret<f64>(0x3C91A62633145C07), // 6.12323399573676603587e-17
-      Ox1p_120f = reinterpret<f32>(0x03800000);
-
-    var hx = <u32>(reinterpret<u64>(x) >> 32);
-    var ix = hx & 0x7FFFFFFF;
-    if (ix >= 0x3FF00000) {
-      let lx = <u32>reinterpret<u64>(x);
-      if ((ix - 0x3FF00000 | lx) == 0) return x * pio2_hi + Ox1p_120f;
-      return 0 / (x - x);
-    }
-    if (ix < 0x3FE00000) {
-      if (ix < 0x3E500000 && ix >= 0x00100000) return x;
-      return x + x * R(x * x);
-    }
-    // var z = (1.0 - builtin_abs<f64>(x)) * 0.5;
-    var z = 0.5 - builtin_abs<f64>(x) * 0.5;
-    var s = builtin_sqrt<f64>(z);
-    var r = R(z);
-    if (ix >= 0x3FEF3333) x = pio2_hi - (2 * (s + s * r) - pio2_lo);
-    else {
-      let f = reinterpret<f64>(reinterpret<u64>(s) & 0xFFFFFFFF00000000);
-      let c = (z - f * f) / (s + f);
-      x = 0.5 * pio2_hi - (2 * s * r - (pio2_lo - 2 * c) - (0.5 * pio2_hi - 2 * f));
-    }
-    if (hx >> 31) return -x;
-    return x;
-  }
-
-  export function asinh(x: f64): f64 { // see: musl/src/math/asinh.c
-    const c = reinterpret<f64>(0x3FE62E42FEFA39EF); // 0.693147180559945309417232121458176568
-    var u = reinterpret<u64>(x);
-    var e = u >> 52 & 0x7FF;
-    var y = reinterpret<f64>(u & 0x7FFFFFFFFFFFFFFF);
-    if (e >= 0x3FF + 26) y = log(y) + c;
-    else if (e >= 0x3FF + 1)  y =   log(2 * y + 1 / (builtin_sqrt<f64>(y * y + 1) + y));
-    else if (e >= 0x3FF - 26) y = log1p(y + y * y / (builtin_sqrt<f64>(y * y + 1) + 1));
-    return builtin_copysign(y, x);
-  }
-
-  export function atan(x: f64): f64 { // see musl/src/math/atan.c and SUN COPYRIGHT NOTICE above
-    const
-      atanhi0   = reinterpret<f64>(0x3FDDAC670561BB4F), //  4.63647609000806093515e-01
-      atanhi1   = reinterpret<f64>(0x3FE921FB54442D18), //  7.85398163397448278999e-01
-      atanhi2   = reinterpret<f64>(0x3FEF730BD281F69B), //  9.82793723247329054082e-01
-      atanhi3   = reinterpret<f64>(0x3FF921FB54442D18), //  1.57079632679489655800e+00
-      atanlo0   = reinterpret<f64>(0x3C7A2B7F222F65E2), //  2.26987774529616870924e-17
-      atanlo1   = reinterpret<f64>(0x3C81A62633145C07), //  3.06161699786838301793e-17
-      atanlo2   = reinterpret<f64>(0x3C7007887AF0CBBD), //  1.39033110312309984516e-17
-      atanlo3   = reinterpret<f64>(0x3C91A62633145C07), //  6.12323399573676603587e-17
-      aT0       = reinterpret<f64>(0x3FD555555555550D), //  3.33333333333329318027e-01
-      aT1       = reinterpret<f64>(0xBFC999999998EBC4), // -1.99999999998764832476e-01
-      aT2       = reinterpret<f64>(0x3FC24924920083FF), //  1.42857142725034663711e-01
-      aT3       = reinterpret<f64>(0xBFBC71C6FE231671), // -1.11111104054623557880e-01,
-      aT4       = reinterpret<f64>(0x3FB745CDC54C206E), //  9.09088713343650656196e-02
-      aT5       = reinterpret<f64>(0xBFB3B0F2AF749A6D), // -7.69187620504482999495e-02
-      aT6       = reinterpret<f64>(0x3FB10D66A0D03D51), //  6.66107313738753120669e-02
-      aT7       = reinterpret<f64>(0xBFADDE2D52DEFD9A), // -5.83357013379057348645e-02
-      aT8       = reinterpret<f64>(0x3FA97B4B24760DEB), //  4.97687799461593236017e-02
-      aT9       = reinterpret<f64>(0xBFA2B4442C6A6C2F), // -3.65315727442169155270e-02
-      aT10      = reinterpret<f64>(0x3F90AD3AE322DA11), //  1.62858201153657823623e-02
-      Ox1p_120f = reinterpret<f32>(0x03800000);
-
-    var ix = <u32>(reinterpret<u64>(x) >> 32);
-    var sx = x;
-    ix &= 0x7FFFFFFF;
-    var z: f64;
-    if (ix >= 0x44100000) {
-      if (isNaN(x)) return x;
-      z = atanhi3 + Ox1p_120f;
-      return builtin_copysign<f64>(z, sx);
-    }
-    var id: i32;
-    if (ix < 0x3FDC0000) {
-      if (ix < 0x3E400000) return x;
-      id = -1;
-    } else {
-      x = builtin_abs<f64>(x);
-      if (ix < 0x3FF30000) {
-        if (ix < 0x3FE60000) {
-          id = 0;
-          x = (2.0 * x - 1.0) / (2.0 + x);
-        } else {
-          id = 1;
-          x = (x - 1.0) / (x + 1.0);
-        }
-      } else {
-        if (ix < 0x40038000) {
-          id = 2;
-          x = (x - 1.5) / (1.0 + 1.5 * x);
-        } else {
-          id = 3;
-          x = -1.0 / x;
-        }
-      }
-    }
-    z = x * x;
-    var w = z * z;
-    var s1 = z * (aT0 + w * (aT2 + w * (aT4 + w * (aT6 + w * (aT8 + w * aT10)))));
-    var s2 = w * (aT1 + w * (aT3 + w * (aT5 + w * (aT7 + w * aT9))));
-    var s3 = x * (s1 + s2);
-    if (id < 0) return x - s3;
-    switch (id) {
-      case 0: { z = atanhi0 - ((s3 - atanlo0) - x); break; }
-      case 1: { z = atanhi1 - ((s3 - atanlo1) - x); break; }
-      case 2: { z = atanhi2 - ((s3 - atanlo2) - x); break; }
-      case 3: { z = atanhi3 - ((s3 - atanlo3) - x); break; }
-      default: unreachable();
-    }
-    return builtin_copysign<f64>(z, sx);
-  }
-
-  export function atanh(x: f64): f64 { // see: musl/src/math/atanh.c
-    var u = reinterpret<u64>(x);
-    var e = u >> 52 & 0x7FF;
-    var y = builtin_abs(x);
-    if (e < 0x3FF - 1) {
-      if (e >= 0x3FF - 32) y = 0.5 * log1p(2 * y + 2 * y * y / (1 - y));
-    } else {
-      y = 0.5 * log1p(2 * (y / (1 - y)));
-    }
-    return builtin_copysign<f64>(y, x);
-  }
-
-  export function atan2(y: f64, x: f64): f64 { // see: musl/src/math/atan2.c and SUN COPYRIGHT NOTICE above
-    const pi_lo = reinterpret<f64>(0x3CA1A62633145C07); // 1.2246467991473531772E-16
-    if (isNaN(x) || isNaN(y)) return x + y;
-    var u = reinterpret<u64>(x);
-    var ix = <u32>(u >> 32);
-    var lx = <u32>u;
-    u = reinterpret<u64>(y);
-    var iy = <u32>(u >> 32);
-    var ly = <u32>u;
-    if ((ix - 0x3FF00000 | lx) == 0) return atan(y);
-    var m = ((iy >> 31) & 1) | ((ix >> 30) & 2);
-    ix = ix & 0x7FFFFFFF;
-    iy = iy & 0x7FFFFFFF;
-    if ((iy | ly) == 0) {
-      switch (m) {
-        case 0:
-        case 1: return  y;
-        case 2: return  PI;
-        case 3: return -PI;
-      }
-    }
-    if ((ix | lx) == 0) return m & 1 ? -PI / 2 : PI / 2;
-    if (ix == 0x7FF00000) {
-      if (iy == 0x7FF00000) {
-        let t = m & 2 ? 3 * PI / 4 : PI / 4;
-        return m & 1 ? -t : t;
-      } else {
-        let t = m & 2 ? PI : 0;
-        return m & 1 ? -t : t;
-      }
-    }
-    var z: f64;
-    if (ix + (64 << 20) < iy || iy == 0x7FF00000) return m & 1 ? -PI / 2 : PI / 2;
-    if ((m & 2) && iy + (64 << 20) < ix) z = 0;
-    else z = atan(builtin_abs<f64>(y / x));
-    switch (m) {
-      case 0: return  z;
-      case 1: return -z;
-      case 2: return PI - (z - pi_lo);
-      case 3: return (z - pi_lo) - PI;
-    }
-    unreachable();
-    return 0;
-  }
-
-  export function cbrt(x: f64): f64 { // see: musl/src/math/cbrt.c and SUN COPYRIGHT NOTICE above
-    const
-      B1     = <u32>715094163,
-      B2     = <u32>696219795,
-      P0     = reinterpret<f64>(0x3FFE03E60F61E692), //  1.87595182427177009643
-      P1     = reinterpret<f64>(0xBFFE28E092F02420), // -1.88497979543377169875
-      P2     = reinterpret<f64>(0x3FF9F1604A49D6C2), //  1.621429720105354466140
-      P3     = reinterpret<f64>(0xBFE844CBBEE751D9), // -0.758397934778766047437
-      P4     = reinterpret<f64>(0x3FC2B000D4E4EDD7), //  0.145996192886612446982
-      Ox1p54 = reinterpret<f64>(0x4350000000000000); //  0x1p54
-
-    var u = reinterpret<u64>(x);
-    var hx = <u32>(u >> 32) & 0x7FFFFFFF;
-    if (hx >= 0x7FF00000) return x + x;
-    if (hx < 0x00100000) {
-      u = reinterpret<u64>(x * Ox1p54);
-      hx = <u32>(u >> 32) & 0x7FFFFFFF;
-      if (hx == 0) return x;
-      hx = hx / 3 + B2;
-    } else {
-      hx = hx / 3 + B1;
-    }
-    u &= 1 << 63;
-    u |= <u64>hx << 32;
-    var t = reinterpret<f64>(u);
-    var r = (t * t) * (t / x);
-    t = t * ((P0 + r * (P1 + r * P2)) + ((r * r) * r) * (P3 + r * P4));
-    t = reinterpret<f64>((reinterpret<u64>(t) + 0x80000000) & 0xFFFFFFFFC0000000);
-    var s = t * t;
-    r = x / s;
-    r = (r - t) / (2 * t + r);
-    t = t + t * r;
-    return t;
+  @inline
+  export function abs<T extends number = f64>(x: T): T {
+    return builtin_abs<T>(x);
   }
 
   // @ts-ignore: decorator
   @inline
-  export function ceil(x: f64): f64 {
-    return builtin_ceil<f64>(x);
-  }
-
-  export function clz32(x: f64): f64 {
-    if (!isFinite(x)) return 32;
-    /*
-     * Wasm (MVP) and JS have different approaches for double->int conversions.
-     *
-     * For emulate JS conversion behavior and avoid trapping from wasm we should modulate by MAX_INT
-     * our float-point arguments before actual convertion to integers.
-     */
-    return builtin_clz(dtoi32(x));
-  }
-
-  export function cos(x: f64): f64 { // see: musl/src/math/cos.c
-    var u  = reinterpret<u64>(x);
-    var ix = <u32>(u >> 32);
-    var sign = ix >> 31;
-
-    ix &= 0x7FFFFFFF;
-
-    // |x| ~< pi/4
-    if (ix <= 0x3FE921FB) {
-      if (ix < 0x3E46A09E) {  // |x| < 2**-27 * sqrt(2)
-        return 1.0;
+  export function acos<T extends number = f64>(x: T): T {
+    if (isFloat<T>()) {
+      if (sizeof<T>() == 4) {
+        return <T>acos32(x);
       }
-      return cos_kern(x, 0);
-    }
-
-    // sin(Inf or NaN) is NaN
-    if (ix >= 0x7FF00000) return x - x;
-
-    // argument reduction needed
-    var n  = rempio2(x, u, sign);
-    var y0 = rempio2_y0;
-    var y1 = rempio2_y1;
-
-    x = n & 1 ? sin_kern(y0, y1, 1) : cos_kern(y0, y1);
-    return (n + 1) & 2 ? -x : x;
-  }
-
-  export function cosh(x: f64): f64 { // see: musl/src/math/cosh.c
-    var u = reinterpret<u64>(x);
-    u &= 0x7FFFFFFFFFFFFFFF;
-    x = reinterpret<f64>(u);
-    var w = <u32>(u >> 32);
-    var t: f64;
-    if (w < 0x3FE62E42) {
-      if (w < 0x3FF00000 - (26 << 20)) return 1;
-      t = expm1(x);
-      // return 1 + t * t / (2 * (1 + t));
-      return 1 + t * t / (2 + 2 * t);
-    }
-    if (w < 0x40862E42) {
-      t = exp(x);
-      return 0.5 * (t + 1 / t);
-    }
-    t = expo2(x, 1);
-    return t;
-  }
-
-  export function exp(x: f64): f64 { // see: musl/src/math/exp.c and SUN COPYRIGHT NOTICE above
-    if (ASC_SHRINK_LEVEL < 1) {
-      return exp_lut(x);
-    } else {
-      const
-        ln2hi     = reinterpret<f64>(0x3FE62E42FEE00000), //  6.93147180369123816490e-01
-        ln2lo     = reinterpret<f64>(0x3DEA39EF35793C76), //  1.90821492927058770002e-10
-        invln2    = reinterpret<f64>(0x3FF71547652B82FE), //  1.44269504088896338700e+00
-        P1        = reinterpret<f64>(0x3FC555555555553E), //  1.66666666666666019037e-01
-        P2        = reinterpret<f64>(0xBF66C16C16BEBD93), // -2.77777777770155933842e-03
-        P3        = reinterpret<f64>(0x3F11566AAF25DE2C), //  6.61375632143793436117e-05
-        P4        = reinterpret<f64>(0xBEBBBD41C5D26BF1), // -1.65339022054652515390e-06
-        P5        = reinterpret<f64>(0x3E66376972BEA4D0), //  4.13813679705723846039e-08
-        overflow  = reinterpret<f64>(0x40862E42FEFA39EF), //  709.782712893383973096
-        underflow = reinterpret<f64>(0xC0874910D52D3051), // -745.13321910194110842
-        Ox1p1023  = reinterpret<f64>(0x7FE0000000000000); //  0x1p1023
-
-      let hx = <u32>(reinterpret<u64>(x) >> 32);
-      let sign_ = <i32>(hx >> 31);
-      hx &= 0x7FFFFFFF;
-      if (hx >= 0x4086232B) {
-        if (isNaN(x)) return x;
-        if (x > overflow)  return x * Ox1p1023;
-        if (x < underflow) return 0;
+      if (sizeof<T>() == 8) {
+        return <T>acos64(x);
       }
-      let hi: f64, lo: f64 = 0;
-      let k = 0;
-      if (hx > 0x3FD62E42) {
-        if (hx >= 0x3FF0A2B2) {
-          k = <i32>(invln2 * x + builtin_copysign<f64>(0.5, x));
-        } else {
-          k = 1 - (sign_ << 1);
-        }
-        hi = x - k * ln2hi;
-        lo = k * ln2lo;
-        x = hi - lo;
-      } else if (hx > 0x3E300000) {
-        hi = x;
-      } else return 1.0 + x;
-      let xs = x * x;
-      // var c = x - xp2 * (P1 + xp2 * (P2 + xp2 * (P3 + xp2 * (P4 + xp2 * P5))));
-      let xq = xs * xs;
-      let c = x - (xs * P1 + xq * ((P2 + xs * P3) + xq * (P4 + xs * P5)));
-      let y = 1.0 + (x * c / (2 - c) - lo + hi);
-      return k == 0 ? y : scalbn(y, k);
     }
-  }
-
-  export function exp2(x: f64): f64 {
-    return exp2_lut(x);
-  }
-
-  export function expm1(x: f64): f64 { // see: musl/src/math/expm1.c and SUN COPYRIGHT NOTICE above
-    const
-      o_threshold = reinterpret<f64>(0x40862E42FEFA39EF), //  7.09782712893383973096e+02
-      ln2_hi      = reinterpret<f64>(0x3FE62E42FEE00000), //  6.93147180369123816490e-01
-      ln2_lo      = reinterpret<f64>(0x3DEA39EF35793C76), //  1.90821492927058770002e-10
-      invln2      = reinterpret<f64>(0x3FF71547652B82FE), //  1.44269504088896338700e+00
-      Q1          = reinterpret<f64>(0xBFA11111111110F4), // -3.33333333333331316428e-02
-      Q2          = reinterpret<f64>(0x3F5A01A019FE5585), //  1.58730158725481460165e-03
-      Q3          = reinterpret<f64>(0xBF14CE199EAADBB7), // -7.93650757867487942473e-05
-      Q4          = reinterpret<f64>(0x3ED0CFCA86E65239), //  4.00821782732936239552e-06
-      Q5          = reinterpret<f64>(0xBE8AFDB76E09C32D), // -2.01099218183624371326e-07
-      Ox1p1023    = reinterpret<f64>(0x7FE0000000000000); //  0x1p1023
-
-    var u = reinterpret<u64>(x);
-    var hx = <u32>(u >> 32 & 0x7FFFFFFF);
-    var k = 0, sign_ = <i32>(u >> 63);
-    if (hx >= 0x4043687A) {
-      if (isNaN(x)) return x;
-      if (sign_) return -1;
-      if (x > o_threshold) return x * Ox1p1023;
-    }
-    var c = 0.0, t: f64;
-    if (hx > 0x3FD62E42) {
-      k = select<i32>(
-        1 - (sign_ << 1),
-        <i32>(invln2 * x + builtin_copysign<f64>(0.5, x)),
-        hx < 0x3FF0A2B2
-      );
-      t = <f64>k;
-      let hi = x - t * ln2_hi;
-      let lo = t * ln2_lo;
-      x = hi - lo;
-      c = (hi - x) - lo;
-    } else if (hx < 0x3C900000) return x;
-    var hfx = 0.5 * x;
-    var hxs = x * hfx;
-    // var r1 = 1.0 + hxs * (Q1 + hxs * (Q2 + hxs * (Q3 + hxs * (Q4 + hxs * Q5))));
-    var hxq = hxs * hxs;
-    var r1 = (1.0 + hxs * Q1) + hxq * ((Q2 + hxs * Q3) + hxq * (Q4 + hxs * Q5));
-    t = 3.0 - r1 * hfx;
-    var e = hxs * ((r1 - t) / (6.0 - x * t));
-    if (k == 0) return x - (x * e - hxs);
-    e = x * (e - c) - c;
-    e -= hxs;
-    if (k == -1) return 0.5 * (x - e) - 0.5;
-    if (k == 1) {
-      if (x < -0.25) return -2.0 * (e - (x + 0.5));
-      return 1.0 + 2.0 * (x - e);
-    }
-    u = (0x3FF + k) << 52;
-    var twopk = reinterpret<f64>(u);
-    var y: f64;
-    if (k < 0 || k > 56) {
-      y = x - e + 1.0;
-      if (k == 1024) y = y * 2.0 * Ox1p1023;
-      else y = y * twopk;
-      return y - 1.0;
-    }
-    u = (0x3FF - k) << 52;
-    y = reinterpret<f64>(u);
-    if (k < 20) y = (1 - y) - e;
-    else y = 1 - (e + y);
-    return (x + y) * twopk;
+    return ERROR("Math.acos accept only f32 or f64 types");
   }
 
   // @ts-ignore: decorator
   @inline
-  export function floor(x: f64): f64 {
-    return builtin_floor<f64>(x);
+  export function acosh<T extends number = f64>(x: T): T {
+    if (isFloat<T>()) {
+      if (sizeof<T>() == 4) {
+        return <T>acosh32(x);
+      }
+      if (sizeof<T>() == 8) {
+        return <T>acosh64(x);
+      }
+    }
+    return ERROR("Math.acosh accept only f32 or f64 types");
   }
 
   // @ts-ignore: decorator
   @inline
-  export function fround(x: f64): f64 {
-    return <f32>x;
-  }
-
-  export function hypot(x: f64, y: f64): f64 { // see: musl/src/math/hypot.c
-    const
-      SPLIT    = reinterpret<f64>(0x41A0000000000000) + 1, // 0x1p27 + 1
-      Ox1p700  = reinterpret<f64>(0x6BB0000000000000),
-      Ox1p_700 = reinterpret<f64>(0x1430000000000000);
-
-    var ux = reinterpret<u64>(x);
-    var uy = reinterpret<u64>(y);
-    ux &= 0x7FFFFFFFFFFFFFFF;
-    uy &= 0x7FFFFFFFFFFFFFFF;
-    if (ux < uy) {
-      let ut = ux;
-      ux = uy;
-      uy = ut;
-    }
-    var ex = <i32>(ux >> 52);
-    var ey = <i32>(uy >> 52);
-    y = reinterpret<f64>(uy);
-    if (ey == 0x7FF) return y;
-    x = reinterpret<f64>(ux);
-    if (ex == 0x7FF || uy == 0) return x;
-    if (ex - ey > 64) return x + y;
-    var z = 1.0;
-    if (ex > 0x3FF + 510) {
-      z  = Ox1p700;
-      x *= Ox1p_700;
-      y *= Ox1p_700;
-    } else if (ey < 0x3FF - 450) {
-      z  = Ox1p_700;
-      x *= Ox1p700;
-      y *= Ox1p700;
-    }
-    var c = x * SPLIT;
-    var h = x - c + c;
-    var l = x - h;
-    var hx = x * x;
-    var lx = h * h - hx + (2 * h + l) * l;
-    c = y * SPLIT;
-    h = y - c + c;
-    l = y - h;
-    var hy = y * y;
-    var ly = h * h - hy + (2 * h + l) * l;
-    return z * builtin_sqrt(ly + lx + hy + hx);
-  }
-
-  export function imul(x: f64, y: f64): f64 {
-    /*
-     * Wasm (MVP) and JS have different approaches for double->int conversions.
-     *
-     * For emulate JS conversion behavior and avoid trapping from wasm we should modulate by MAX_INT
-     * our float-point arguments before actual convertion to integers.
-     */
-    if (!isFinite(x + y)) return 0;
-    return dtoi32(x) * dtoi32(y);
-  }
-
-  export function log(x: f64): f64 { // see: musl/src/math/log.c and SUN COPYRIGHT NOTICE above
-    if (ASC_SHRINK_LEVEL < 1) {
-      return log_lut(x);
-    } else {
-      const
-        ln2_hi = reinterpret<f64>(0x3FE62E42FEE00000), // 6.93147180369123816490e-01
-        ln2_lo = reinterpret<f64>(0x3DEA39EF35793C76), // 1.90821492927058770002e-10
-        Lg1    = reinterpret<f64>(0x3FE5555555555593), // 6.666666666666735130e-01
-        Lg2    = reinterpret<f64>(0x3FD999999997FA04), // 3.999999999940941908e-01
-        Lg3    = reinterpret<f64>(0x3FD2492494229359), // 2.857142874366239149e-01
-        Lg4    = reinterpret<f64>(0x3FCC71C51D8E78AF), // 2.222219843214978396e-01
-        Lg5    = reinterpret<f64>(0x3FC7466496CB03DE), // 1.818357216161805012e-01
-        Lg6    = reinterpret<f64>(0x3FC39A09D078C69F), // 1.531383769920937332e-01
-        Lg7    = reinterpret<f64>(0x3FC2F112DF3E5244), // 1.479819860511658591e-01
-        Ox1p54 = reinterpret<f64>(0x4350000000000000); // 0x1p54
-
-      let u = reinterpret<u64>(x);
-      let hx = <u32>(u >> 32);
-      let k = 0;
-      if (hx < 0x00100000 || <bool>(hx >> 31)) {
-        if (u << 1 == 0) return -1 / (x * x);
-        if (hx >> 31)    return (x - x) / 0.0;
-        k -= 54;
-        x *= Ox1p54;
-        u = reinterpret<u64>(x);
-        hx = <u32>(u >> 32);
-      } else if (hx >= 0x7FF00000) {
-        return x;
-      } else if (hx == 0x3FF00000 && u << 32 == 0) {
-        return 0;
+  export function asin<T extends number = f64>(x: T): T {
+    if (isFloat<T>()) {
+      if (sizeof<T>() == 4) {
+        return <T>asin32(x);
       }
-      hx += 0x3FF00000 - 0x3FE6A09E;
-      k += (<i32>hx >> 20) - 0x3FF;
-      hx = (hx & 0x000FFFFF) + 0x3FE6A09E;
-      u = <u64>hx << 32 | (u & 0xFFFFFFFF);
-      x = reinterpret<f64>(u);
-      let f = x - 1.0;
-      let hfsq = 0.5 * f * f;
-      let s = f / (2.0 + f);
-      let z = s * s;
-      let w = z * z;
-      let t1 = w * (Lg2 + w * (Lg4 + w * Lg6));
-      let t2 = z * (Lg1 + w * (Lg3 + w * (Lg5 + w * Lg7)));
-      let r = t2 + t1;
-      let dk = <f64>k;
-      return s * (hfsq + r) + dk * ln2_lo - hfsq + f + dk * ln2_hi;
+      if (sizeof<T>() == 8) {
+        return <T>asin64(x);
+      }
     }
+    return ERROR("Math.asin accept only f32 or f64 types");
   }
 
-  export function log10(x: f64): f64 { // see: musl/src/math/log10.c and SUN COPYRIGHT NOTICE above
-    const
-      ivln10hi  = reinterpret<f64>(0x3FDBCB7B15200000), // 4.34294481878168880939e-01
-      ivln10lo  = reinterpret<f64>(0x3DBB9438CA9AADD5), // 2.50829467116452752298e-11
-      log10_2hi = reinterpret<f64>(0x3FD34413509F6000), // 3.01029995663611771306e-01
-      log10_2lo = reinterpret<f64>(0x3D59FEF311F12B36), // 3.69423907715893078616e-13
-      Lg1       = reinterpret<f64>(0x3FE5555555555593), // 6.666666666666735130e-01
-      Lg2       = reinterpret<f64>(0x3FD999999997FA04), // 3.999999999940941908e-01
-      Lg3       = reinterpret<f64>(0x3FD2492494229359), // 2.857142874366239149e-01
-      Lg4       = reinterpret<f64>(0x3FCC71C51D8E78AF), // 2.222219843214978396e-01
-      Lg5       = reinterpret<f64>(0x3FC7466496CB03DE), // 1.818357216161805012e-01
-      Lg6       = reinterpret<f64>(0x3FC39A09D078C69F), // 1.531383769920937332e-01
-      Lg7       = reinterpret<f64>(0x3FC2F112DF3E5244), // 1.479819860511658591e-01
-      Ox1p54    = reinterpret<f64>(0x4350000000000000); // 0x1p54
+  // @ts-ignore: decorator
+  @inline
+  export function asinh<T extends number = f64>(x: T): T {
+    if (isFloat<T>()) {
+      if (sizeof<T>() == 4) {
+        return <T>asinh32(x);
+      }
+      if (sizeof<T>() == 8) {
+        return <T>asinh64(x);
+      }
+    }
+    return ERROR("Math.asinh accept only f32 or f64 types");
+  }
 
-    var u = reinterpret<u64>(x);
-    var hx = <u32>(u >> 32);
-    var k = 0;
-    if (hx < 0x00100000 || <bool>(hx >> 31)) {
-      if (u << 1 == 0) return -1 / (x * x);
-      if (hx >> 31) return (x - x) / 0.0;
-      k -= 54;
-      x *= Ox1p54;
-      u = reinterpret<u64>(x);
-      hx = <u32>(u >> 32);
-    } else if (hx >= 0x7FF00000) {
+  // @ts-ignore: decorator
+  @inline
+  export function atan<T extends number = f64>(x: T): T {
+    if (isFloat<T>()) {
+      if (sizeof<T>() == 4) {
+        return <T>atan32(x);
+      }
+      if (sizeof<T>() == 8) {
+        return <T>atan64(x);
+      }
+    }
+    return ERROR("Math.atan accept only f32 or f64 types");
+  }
+
+  // @ts-ignore: decorator
+  @inline
+  export function atanh<T extends number = f64>(x: T): T {
+    if (isFloat<T>()) {
+      if (sizeof<T>() == 4) {
+        return <T>atanh32(x);
+      }
+      if (sizeof<T>() == 8) {
+        return <T>atanh64(x);
+      }
+    }
+    return ERROR("Math.atanh accept only f32 or f64 types");
+  }
+
+  // @ts-ignore: decorator
+  @inline
+  export function atan2<T extends number = f64>(x: T, y: T): T {
+    if (isFloat<T>()) {
+      if (sizeof<T>() == 4) {
+        return <T>atan2_32(x, y);
+      }
+      if (sizeof<T>() == 8) {
+        return <T>atan2_64(x, y);
+      }
+    }
+    return ERROR("Math.atan2 accept only f32 or f64 types");
+  }
+
+  // @ts-ignore: decorator
+  @inline
+  export function cbrt<T extends number = f64>(x: T): T {
+    if (isFloat<T>()) {
+      if (sizeof<T>() == 4) {
+        return <T>cbrt32(x);
+      }
+      if (sizeof<T>() == 8) {
+        return <T>cbrt64(x);
+      }
+    }
+    return ERROR("Math.cbrt accept only f32 or f64 types");
+  }
+
+  // @ts-ignore: decorator
+  @inline
+  export function ceil<T extends number = f64>(x: T): T {
+    if (isInteger<T>()) {
       return x;
-    } else if (hx == 0x3FF00000 && u << 32 == 0) {
-      return 0;
-    }
-    hx += 0x3FF00000 - 0x3FE6A09E;
-    k += <i32>(hx >> 20) - 0x3FF;
-    hx = (hx & 0x000FFFFF) + 0x3FE6A09E;
-    u = <u64>hx << 32 | (u & 0xFFFFFFFF);
-    x = reinterpret<f64>(u);
-    var f = x - 1.0;
-    var hfsq = 0.5 * f * f;
-    var s = f / (2.0 + f);
-    var z = s * s;
-    var w = z * z;
-    var t1 = w * (Lg2 + w * (Lg4 + w * Lg6));
-    var t2 = z * (Lg1 + w * (Lg3 + w * (Lg5 + w * Lg7)));
-    var r = t2 + t1;
-    var hi = f - hfsq;
-    u = reinterpret<u64>(hi);
-    u &= 0xFFFFFFFF00000000;
-    hi = reinterpret<f64>(u);
-    var lo = f - hi - hfsq + s * (hfsq + r);
-    var val_hi = hi * ivln10hi;
-    var dk = <f64>k;
-    var y = dk * log10_2hi;
-    var val_lo = dk * log10_2lo + (lo + hi) * ivln10lo + lo * ivln10hi;
-    w = y + val_hi;
-    val_lo += (y - w) + val_hi;
-    return val_lo + w;
-  }
-
-  export function log1p(x: f64): f64 { // see: musl/src/math/log1p.c and SUN COPYRIGHT NOTICE above
-    const
-      ln2_hi = reinterpret<f64>(0x3FE62E42FEE00000), // 6.93147180369123816490e-01
-      ln2_lo = reinterpret<f64>(0x3DEA39EF35793C76), // 1.90821492927058770002e-10
-      Lg1    = reinterpret<f64>(0x3FE5555555555593), // 6.666666666666735130e-01
-      Lg2    = reinterpret<f64>(0x3FD999999997FA04), // 3.999999999940941908e-01
-      Lg3    = reinterpret<f64>(0x3FD2492494229359), // 2.857142874366239149e-01
-      Lg4    = reinterpret<f64>(0x3FCC71C51D8E78AF), // 2.222219843214978396e-01
-      Lg5    = reinterpret<f64>(0x3FC7466496CB03DE), // 1.818357216161805012e-01
-      Lg6    = reinterpret<f64>(0x3FC39A09D078C69F), // 1.531383769920937332e-01
-      Lg7    = reinterpret<f64>(0x3FC2F112DF3E5244); // 1.479819860511658591e-01
-
-    var u = reinterpret<u64>(x);
-    var hx = <u32>(u >> 32);
-    var k = 1;
-    var c = 0.0, f = 0.0;
-    if (hx < 0x3FDA827A || <bool>(hx >> 31)) {
-      if (hx >= 0xBFF00000) {
-        if (x == -1) return x / 0.0;
-        return (x - x) / 0.0;
-      }
-      if (hx << 1 < 0x3CA00000 << 1) return x;
-      if (hx <= 0xBFD2BEC4) {
-        k = 0;
-        c = 0;
-        f = x;
-      }
-    } else if (hx >= 0x7FF00000) return x;
-    if (k) {
-      u = reinterpret<u64>(1 + x);
-      let hu = <u32>(u >> 32);
-      hu += 0x3FF00000 - 0x3FE6A09E;
-      k = <i32>(hu >> 20) - 0x3FF;
-      if (k < 54) {
-        let uf = reinterpret<f64>(u);
-        c = k >= 2 ? 1 - (uf - x) : x - (uf - 1);
-        c /= uf;
-      } else c = 0;
-      hu = (hu & 0x000FFFFF) + 0x3FE6A09E;
-      u = <u64>hu << 32 | (u & 0xFFFFFFFF);
-      f = reinterpret<f64>(u) - 1;
-    }
-    var hfsq = 0.5 * f * f;
-    var s = f / (2.0 + f);
-    var z = s * s;
-    var w = z * z;
-    var t1 = w * (Lg2 + w * (Lg4 + w * Lg6));
-    var t2 = z * (Lg1 + w * (Lg3 + w * (Lg5 + w * Lg7)));
-    var r = t2 + t1;
-    var dk = <f64>k;
-    return s * (hfsq + r) + (dk * ln2_lo + c) - hfsq + f + dk * ln2_hi;
-  }
-
-  export function log2(x: f64): f64 { // see: musl/src/math/log2.c and SUN COPYRIGHT NOTICE above
-    if (ASC_SHRINK_LEVEL < 1) {
-      return log2_lut(x);
+    } else if (isFloat<T>()) {
+      return builtin_ceil<T>(x);
     } else {
-      const
-        ivln2hi = reinterpret<f64>(0x3FF7154765200000), // 1.44269504072144627571e+00
-        ivln2lo = reinterpret<f64>(0x3DE705FC2EEFA200), // 1.67517131648865118353e-10
-        Lg1     = reinterpret<f64>(0x3FE5555555555593), // 6.666666666666735130e-01
-        Lg2     = reinterpret<f64>(0x3FD999999997FA04), // 3.999999999940941908e-01
-        Lg3     = reinterpret<f64>(0x3FD2492494229359), // 2.857142874366239149e-01
-        Lg4     = reinterpret<f64>(0x3FCC71C51D8E78AF), // 2.222219843214978396e-01
-        Lg5     = reinterpret<f64>(0x3FC7466496CB03DE), // 1.818357216161805012e-01
-        Lg6     = reinterpret<f64>(0x3FC39A09D078C69F), // 1.531383769920937332e-01
-        Lg7     = reinterpret<f64>(0x3FC2F112DF3E5244), // 1.479819860511658591e-01
-        Ox1p54  = reinterpret<f64>(0x4350000000000000); // 1p54
+      return ERROR("Math.ceil accept only numeric types");
+    }
+  }
 
-      let u = reinterpret<u64>(x);
-      let hx = <u32>(u >> 32);
-      let k = 0;
-      if (hx < 0x00100000 || <bool>(hx >> 31)) {
-        if (u << 1 == 0) return -1 / (x * x);
-        if (hx >> 31) return (x - x) / 0.0;
-        k -= 54;
-        x *= Ox1p54;
-        u = reinterpret<u64>(x);
-        hx = <u32>(u >> 32);
-      } else if (hx >= 0x7FF00000) {
-        return x;
-      } else if (hx == 0x3FF00000 && u << 32 == 0) {
-        return 0;
-      }
-      hx += 0x3FF00000 - 0x3FE6A09E;
-      k += <i32>(hx >> 20) - 0x3FF;
-      hx = (hx & 0x000FFFFF) + 0x3FE6A09E;
-      u = <u64>hx << 32 | (u & 0xFFFFFFFF);
-      x = reinterpret<f64>(u);
-      let f = x - 1.0;
-      let hfsq = 0.5 * f * f;
-      let s = f / (2.0 + f);
-      let z = s * s;
-      let w = z * z;
-      let t1 = w * (Lg2 + w * (Lg4 + w * Lg6));
-      let t2 = z * (Lg1 + w * (Lg3 + w * (Lg5 + w * Lg7)));
-      let r = t2 + t1;
-      let hi = f - hfsq;
-      u = reinterpret<u64>(hi);
-      u &= 0xFFFFFFFF00000000;
-      hi = reinterpret<f64>(u);
-      let lo = f - hi - hfsq + s * (hfsq + r);
-      let val_hi = hi * ivln2hi;
-      let val_lo = (lo + hi) * ivln2lo + lo * ivln2hi;
-      let y = <f64>k;
-      w = y + val_hi;
-      val_lo += (y - w) + val_hi;
-      val_hi = w;
-      return val_lo + val_hi;
+  export function clz32<T extends number = f64>(x: T): i32 {
+    if (isInteger<T>()) {
+      return builtin_clz(i32(x));
+    } else if (isFloat<T>()) {
+      if (!isFinite<T>(x)) return 32;
+      /*
+      * Wasm (MVP) and JS have different approaches for double->int conversions.
+      *
+      * For emulate JS conversion behavior and avoid trapping from wasm we should modulate by MAX_INT
+      * our float-point arguments before actual convertion to integers.
+      */
+      return builtin_clz<i32>(dtoi32(f64(x)));
+    } else {
+      return ERROR("Math.clz32 accept only numeric types");
     }
   }
 
   // @ts-ignore: decorator
   @inline
-  export function max(value1: f64, value2: f64): f64 {
-    return builtin_max<f64>(value1, value2);
+  export function cos<T extends number = f64>(x: T): T {
+    if (isFloat<T>()) {
+      if (sizeof<T>() == 4) {
+        return <T>cos32(x);
+      }
+      if (sizeof<T>() == 8) {
+        return <T>cos64(x);
+      }
+    }
+    return ERROR("Math.cos accept only f32 or f64 types");
   }
 
   // @ts-ignore: decorator
   @inline
-  export function min(value1: f64, value2: f64): f64 {
-    return builtin_min<f64>(value1, value2);
+  export function cosh<T extends number = f64>(x: T): T {
+    if (isFloat<T>()) {
+      if (sizeof<T>() == 4) {
+        return <T>cosh32(x);
+      }
+      if (sizeof<T>() == 8) {
+        return <T>cosh64(x);
+      }
+    }
+    return ERROR("Math.cosh accept only f32 or f64 types");
   }
 
-  export function pow(x: f64, y: f64): f64 { // see: musl/src/math/pow.c and SUN COPYRIGHT NOTICE above
-    // TODO: remove this fast pathes after introduced own mid-end IR with "stdlib call simplify" transforms
-    if (builtin_abs<f64>(y) <= 2) {
-      if (y == 2.0) return x * x;
-      if (y == 0.5) {
-        return select<f64>(
-          builtin_abs<f64>(builtin_sqrt<f64>(x)),
-          Infinity,
-          x != -Infinity
-        );
+  // @ts-ignore: decorator
+  @inline
+  export function exp<T extends number = f64>(x: T): T {
+    if (isFloat<T>()) {
+      if (sizeof<T>() == 4) {
+        return <T>exp32(x);
       }
-      if (y == -1.0) return 1 / x;
-      if (y == 1.0) return x;
-      if (y == 0.0) return 1.0;
+      if (sizeof<T>() == 8) {
+        return <T>exp64(x);
+      }
     }
-    if (ASC_SHRINK_LEVEL < 1) {
-      return pow_lut(x, y);
-    } else {
-      const
-        dp_h1   = reinterpret<f64>(0x3FE2B80340000000), //  5.84962487220764160156e-01
-        dp_l1   = reinterpret<f64>(0x3E4CFDEB43CFD006), //  1.35003920212974897128e-08
-        two53   = reinterpret<f64>(0x4340000000000000), //  9007199254740992.0
-        huge    = reinterpret<f64>(0x7E37E43C8800759C), //  1e+300
-        tiny    = reinterpret<f64>(0x01A56E1FC2F8F359), //  1e-300
-        L1      = reinterpret<f64>(0x3FE3333333333303), //  5.99999999999994648725e-01
-        L2      = reinterpret<f64>(0x3FDB6DB6DB6FABFF), //  4.28571428578550184252e-01
-        L3      = reinterpret<f64>(0x3FD55555518F264D), //  3.33333329818377432918e-01
-        L4      = reinterpret<f64>(0x3FD17460A91D4101), //  2.72728123808534006489e-01
-        L5      = reinterpret<f64>(0x3FCD864A93C9DB65), //  2.30660745775561754067e-01
-        L6      = reinterpret<f64>(0x3FCA7E284A454EEF), //  2.06975017800338417784e-01
-        P1      = reinterpret<f64>(0x3FC555555555553E), //  1.66666666666666019037e-01
-        P2      = reinterpret<f64>(0xBF66C16C16BEBD93), // -2.77777777770155933842e-03
-        P3      = reinterpret<f64>(0x3F11566AAF25DE2C), //  6.61375632143793436117e-05
-        P4      = reinterpret<f64>(0xBEBBBD41C5D26BF1), // -1.65339022054652515390e-06
-        P5      = reinterpret<f64>(0x3E66376972BEA4D0), //  4.13813679705723846039e-08
-        lg2     = reinterpret<f64>(0x3FE62E42FEFA39EF), //  6.93147180559945286227e-01
-        lg2_h   = reinterpret<f64>(0x3FE62E4300000000), //  6.93147182464599609375e-01
-        lg2_l   = reinterpret<f64>(0xBE205C610CA86C39), // -1.90465429995776804525e-09
-        ovt     = reinterpret<f64>(0x3C971547652B82FE), //  8.0085662595372944372e-017
-        cp      = reinterpret<f64>(0x3FEEC709DC3A03FD), //  9.61796693925975554329e-01
-        cp_h    = reinterpret<f64>(0x3FEEC709E0000000), //  9.61796700954437255859e-01
-        cp_l    = reinterpret<f64>(0xBE3E2FE0145B01F5), // -7.02846165095275826516e-09
-        ivln2   = reinterpret<f64>(0x3FF71547652B82FE), //  1.44269504088896338700e+00
-        ivln2_h = reinterpret<f64>(0x3FF7154760000000), //  1.44269502162933349609e+00
-        ivln2_l = reinterpret<f64>(0x3E54AE0BF85DDF44), //  1.92596299112661746887e-08
-        inv3    = reinterpret<f64>(0x3FD5555555555555); //  0.3333333333333333333333
+    return ERROR("Math.exp accept only f32 or f64 types");
+  }
 
-      let u_ = reinterpret<u64>(x);
-      let hx = <i32>(u_ >> 32);
-      let lx = <u32>u_;
-      u_ = reinterpret<u64>(y);
-      let hy = <i32>(u_ >> 32);
-      let ly = <u32>u_;
-      let ix = hx & 0x7FFFFFFF;
-      let iy = hy & 0x7FFFFFFF;
-      if ((iy | ly) == 0) return 1.0; // x**0 = 1, even if x is NaN
-      // if (hx == 0x3FF00000 && lx == 0) return 1.0; // C: 1**y = 1, even if y is NaN, JS: NaN
-      if ( // NaN if either arg is NaN
-        ix > 0x7FF00000 || (ix == 0x7FF00000 && lx != 0) ||
-        iy > 0x7FF00000 || (iy == 0x7FF00000 && ly != 0)
-      ) return x + y;
-      let yisint = 0, k: i32;
-      if (hx < 0) {
-        if (iy >= 0x43400000) yisint = 2;
-        else if (iy >= 0x3FF00000) {
-          k = (iy >> 20) - 0x3FF;
-          let offset = select<u32>(52, 20, k > 20) - k;
-          let Ly = select<u32>(ly, iy, k > 20);
-          let jj = Ly >> offset;
-          if ((jj << offset) == Ly) yisint = 2 - (jj & 1);
-        }
+  // @ts-ignore: decorator
+  @inline
+  export function exp2<T extends number = f64>(x: T): T {
+    if (isFloat<T>()) {
+      if (sizeof<T>() == 4) {
+        return <T>exp2_32_lut(x);
       }
-      if (ly == 0) {
-        if (iy == 0x7FF00000) { // y is +-inf
-          if (((ix - 0x3FF00000) | lx) == 0) return NaN; // C: (-1)**+-inf is 1, JS: NaN
-          else if (ix >= 0x3FF00000) return hy >= 0 ? y : 0.0; // (|x|>1)**+-inf = inf,0
-          else return hy >= 0 ? 0.0 : -y; // (|x|<1)**+-inf = 0,inf
-        }
-        if (iy == 0x3FF00000) {
-          if (hy >= 0) return x;
-          return 1 / x;
-        }
-        if (hy == 0x40000000) return x * x;
-        if (hy == 0x3FE00000) {
-          if (hx >= 0) return builtin_sqrt(x);
-        }
+      if (sizeof<T>() == 8) {
+        return <T>exp2_64_lut(x);
       }
-      let ax = builtin_abs<f64>(x), z: f64;
-      if (lx == 0) {
-        if (ix == 0 || ix == 0x7FF00000 || ix == 0x3FF00000) {
-          z = ax;
-          if (hy < 0) z = 1.0 / z;
-          if (hx < 0) {
-            if (((ix - 0x3FF00000) | yisint) == 0) {
-              let d = z - z;
-              z = d / d;
-            } else if (yisint == 1) z = -z;
-          }
-          return z;
-        }
-      }
-      let s = 1.0;
-      if (hx < 0) {
-        if (yisint == 0) {
-          let d = x - x;
-          return d / d;
-        }
-        if (yisint == 1) s = -1.0;
-      }
-      let t1: f64, t2: f64, p_h: f64, p_l: f64, r: f64, t: f64, u: f64, v: f64, w: f64;
-      let j: i32, n: i32;
-      if (iy > 0x41E00000) {
-        if (iy > 0x43F00000) {
-          if (ix <= 0x3FEFFFFF) return hy < 0 ? huge * huge : tiny * tiny;
-          if (ix >= 0x3FF00000) return hy > 0 ? huge * huge : tiny * tiny;
-        }
-        if (ix < 0x3FEFFFFF) return hy < 0 ? s * huge * huge : s * tiny * tiny;
-        if (ix > 0x3FF00000) return hy > 0 ? s * huge * huge : s * tiny * tiny;
-        t = ax - 1.0;
-        w = (t * t) * (0.5 - t * (inv3 - t * 0.25));
-        u = ivln2_h * t;
-        v = t * ivln2_l - w * ivln2;
-        t1 = u + v;
-        t1 = reinterpret<f64>(reinterpret<u64>(t1) & 0xFFFFFFFF00000000);
-        t2 = v - (t1 - u);
-      } else {
-        let ss: f64, s2: f64, s_h: f64, s_l: f64, t_h: f64, t_l: f64;
-        n = 0;
-        if (ix < 0x00100000) {
-          ax *= two53;
-          n -= 53;
-          ix = <u32>(reinterpret<u64>(ax) >> 32);
-        }
-        n += (ix >> 20) - 0x3FF;
-        j = ix & 0x000FFFFF;
-        ix = j | 0x3FF00000;
-        if (j <= 0x3988E) k = 0;
-        else if (j < 0xBB67A) k = 1;
-        else {
-          k = 0;
-          n += 1;
-          ix -= 0x00100000;
-        }
-        ax = reinterpret<f64>(reinterpret<u64>(ax) & 0xFFFFFFFF | (<u64>ix << 32));
-        let bp = select<f64>(1.5, 1.0, k); // k ? 1.5 : 1.0
-        u = ax - bp;
-        v = 1.0 / (ax + bp);
-        ss = u * v;
-        s_h = ss;
-        s_h = reinterpret<f64>(reinterpret<u64>(s_h) & 0xFFFFFFFF00000000);
-        t_h = reinterpret<f64>(<u64>(((ix >> 1) | 0x20000000) + 0x00080000 + (k << 18)) << 32);
-        t_l = ax - (t_h - bp);
-        s_l = v * ((u - s_h * t_h) - s_h * t_l);
-        s2 = ss * ss;
-        r = s2 * s2 * (L1 + s2 * (L2 + s2 * (L3 + s2 * (L4 + s2 * (L5 + s2 * L6)))));
-        r += s_l * (s_h + ss);
-        s2 = s_h * s_h;
-        t_h = 3.0 + s2 + r;
-        t_h = reinterpret<f64>(reinterpret<u64>(t_h) & 0xFFFFFFFF00000000);
-        t_l = r - ((t_h - 3.0) - s2);
-        u = s_h * t_h;
-        v = s_l * t_h + t_l * ss;
-        p_h = u + v;
-        p_h = reinterpret<f64>(reinterpret<u64>(p_h) & 0xFFFFFFFF00000000);
-        p_l = v - (p_h - u);
-        let z_h = cp_h * p_h;
-        let dp_l = select<f64>(dp_l1, 0.0, k);
-        let z_l = cp_l * p_h + p_l * cp + dp_l;
-        t = <f64>n;
-        let dp_h = select<f64>(dp_h1, 0.0, k);
-        t1 = ((z_h + z_l) + dp_h) + t;
-        t1 = reinterpret<f64>(reinterpret<u64>(t1) & 0xFFFFFFFF00000000);
-        t2 = z_l - (((t1 - t) - dp_h) - z_h);
-      }
-      let y1 = y;
-      y1 = reinterpret<f64>(reinterpret<u64>(y1) & 0xFFFFFFFF00000000);
-      p_l = (y - y1) * t1 + y * t2;
-      p_h = y1 * t1;
-      z = p_l + p_h;
-      u_ = reinterpret<u64>(z);
-      j = <u32>(u_ >> 32);
-      let i = <i32>u_;
-      if (j >= 0x40900000) {
-        if (((j - 0x40900000) | i) != 0) return s * huge * huge;
-        if (p_l + ovt > z - p_h) return s * huge * huge;
-      } else if ((j & 0x7FFFFFFF) >= 0x4090CC00) {
-        if (((j - 0xC090CC00) | i) != 0) return s * tiny * tiny;
-        if (p_l <= z - p_h) return s * tiny * tiny;
-      }
-      i = j & 0x7FFFFFFF;
-      k = (i >> 20) - 0x3FF;
-      n = 0;
-      if (i > 0x3FE00000) {
-        n = j + (0x00100000 >> (k + 1));
-        k = ((n & 0x7FFFFFFF) >> 20) - 0x3FF;
-        t = 0.0;
-        t = reinterpret<f64>(<u64>(n & ~(0x000FFFFF >> k)) << 32);
-        n = ((n & 0x000FFFFF) | 0x00100000) >> (20 - k);
-        if (j < 0) n = -n;
-        p_h -= t;
-      }
-      t = p_l + p_h;
-      t = reinterpret<f64>(reinterpret<u64>(t) & 0xFFFFFFFF00000000);
-      u = t * lg2_h;
-      v = (p_l - (t - p_h)) * lg2 + t * lg2_l;
-      z = u + v;
-      w = v - (z - u);
-      t = z * z;
-      t1 = z - t * (P1 + t * (P2 + t * (P3 + t * (P4 + t * P5))));
-      r = (z * t1) / (t1 - 2.0) - (w + z * w);
-      z = 1.0 - (r - z);
-      j = <u32>(reinterpret<u64>(z) >> 32);
-      j += n << 20;
-      if ((j >> 20) <= 0) z = scalbn(z, n);
-      else z = reinterpret<f64>(reinterpret<u64>(z) & 0xFFFFFFFF | (<u64>j << 32));
-      return s * z;
     }
+    return ERROR("Math.exp2 accept only numeric types");
+  }
+
+  // @ts-ignore: decorator
+  @inline
+  export function expm1<T extends number = f64>(x: T): T {
+    if (isFloat<T>()) {
+      if (sizeof<T>() == 4) {
+        return <T>expm1_32(x);
+      }
+      if (sizeof<T>() == 8) {
+        return <T>expm1_64(x);
+      }
+    }
+    return ERROR("Math.expm1 accept only numeric types");
+  }
+
+  // @ts-ignore: decorator
+  @inline
+  export function floor<T extends number = f64>(x: T): T {
+    if (isInteger<T>()) {
+      return x;
+    } else if (isFloat<T>()) {
+      return builtin_floor<T>(x);
+    } else {
+      return ERROR("Math.floor accept only numeric types");
+    }
+  }
+
+  // @ts-ignore: decorator
+  @inline
+  export function fround<T extends number = f64>(x: T): f32 {
+    if (isFloat<T>()) {
+      return <f32>x;
+    } else {
+      return ERROR("Math.fround accept only f32 or f64 types");
+    }
+  }
+
+  // @ts-ignore: decorator
+  @inline
+  export function hypot<T extends number = f64>(x: T, y: T): T {
+    if (isFloat<T>()) {
+      if (sizeof<T>() == 4) {
+        return <T>hypot32(x, y);
+      }
+      if (sizeof<T>() == 8) {
+        return <T>hypot64(x, y);
+      }
+    }
+    return ERROR("Math.hypot accept only f32 or f64 types");
+  }
+
+  export function imul<T extends number = f64>(x: T, y: T): T {
+    if (isInteger<T>()) {
+      return <T>(<i32>x * <i32>y);
+    } else if (isFloat<T>()) {
+      /*
+      * Wasm (MVP) and JS have different approaches for double->int conversions.
+      *
+      * For emulate JS conversion behavior and avoid trapping from wasm we should modulate by MAX_INT
+      * our float-point arguments before actual convertion to integers.
+      */
+      if (!isFinite(x + y)) return <T>0;
+      return <T>(dtoi32(x) * dtoi32(y));
+    } else {
+      return ERROR("Math.imul accept only numeric types");
+    }
+  }
+
+  // @ts-ignore: decorator
+  @inline
+  export function log<T extends number = f64>(x: T): T {
+    if (isFloat<T>()) {
+      if (sizeof<T>() == 4) {
+        return <T>log32(x);
+      }
+      if (sizeof<T>() == 8) {
+        return <T>log64(x);
+      }
+    }
+    return ERROR("Math.log accept only f32 or f64 types");
+  }
+
+  // @ts-ignore: decorator
+  @inline
+  export function log10<T extends number = f64>(x: T): T {
+    if (isFloat<T>()) {
+      if (sizeof<T>() == 4) {
+        return <T>log10_32(x);
+      }
+      if (sizeof<T>() == 8) {
+        return <T>log10_64(x);
+      }
+    }
+    return ERROR("Math.log10 accept only f32 or f64 types");
+  }
+
+  // @ts-ignore: decorator
+  @inline
+  export function log1p<T extends number = f64>(x: T): T {
+    if (isFloat<T>()) {
+      if (sizeof<T>() == 4) {
+        return <T>log1p32(x);
+      }
+      if (sizeof<T>() == 8) {
+        return <T>log1p64(x);
+      }
+    }
+    return ERROR("Math.log1p accept only f32 or f64 types");
+  }
+
+  // @ts-ignore: decorator
+  @inline
+  export function log2<T extends number = f64>(x: T): T {
+    if (isFloat<T>()) {
+      if (sizeof<T>() == 4) {
+        return <T>log2_32(x);
+      }
+      if (sizeof<T>() == 8) {
+        return <T>log2_64(x);
+      }
+    } else if (isInteger<T>()) {
+      return <T>(sizeof<native<T>>() * 8 - 1 - clz<T>(x));
+    }
+    return ERROR("Math.log2 accept only numeric types");
+  }
+
+  // @ts-ignore: decorator
+  @inline
+  export function max<T extends number = f64>(a: T, b: T): T {
+    return builtin_max<T>(a, b);
+  }
+
+  // @ts-ignore: decorator
+  @inline
+  export function min<T extends number = f64>(a: T, b: T): T {
+    return builtin_min<T>(a, b);
+  }
+
+  // @ts-ignore: decorator
+  @inline
+  export function pow<T extends number = f64>(x: T, y: T): T {
+    if (isFloat<T>()) {
+      if (sizeof<T>() == 4) {
+        return <T>pow32(x, y);
+      }
+      if (sizeof<T>() == 8) {
+        return <T>pow64(x, y);
+      }
+    } else if (isInteger<T>()) {
+      if (sizeof<T>() <= 4) {
+        return <T>ipow32(x, y);
+      }
+      if (sizeof<T>() == 8) {
+        return <T>ipow64(x, y);
+      }
+    }
+    return ERROR("Math.pow accept only numeric types");
   }
 
   export function seedRandom(value: i64): void {
@@ -1419,8 +469,6 @@ export namespace NativeMath {
     if (value == 0) value = 0x9e3779b97f4a7c15;
     random_state0_64 = murmurHash3(value);
     random_state1_64 = murmurHash3(~random_state0_64);
-    random_state0_32 = splitMix32(<u32>value);
-    random_state1_32 = splitMix32(random_state0_32);
     random_seeded = true;
   }
 
@@ -1440,1846 +488,166 @@ export namespace NativeMath {
 
   // @ts-ignore: decorator
   @inline
-  export function round(x: f64): f64 {
-    let roundUp = builtin_ceil<f64>(x);
-    return select<f64>(roundUp, roundUp - 1.0, roundUp - 0.5 <= x);
-  }
-
-  // @ts-ignore: decorator
-  @inline
-  export function sign(x: f64): f64 {
-    if (ASC_SHRINK_LEVEL > 0) {
-      return builtin_abs(x) > 0 ? builtin_copysign<f64>(1, x) : x;
-    } else {
-      return x > 0 ? 1 : x < 0 ? -1 : x;
-    }
-  }
-
-  // @ts-ignore: decorator
-  @inline
-  export function signbit(x: f64): bool {
-    return <bool>(reinterpret<u64>(x) >>> 63);
-  }
-
-  export function sin(x: f64): f64 { // see: musl/src/math/sin.c
-    var u  = reinterpret<u64>(x);
-    var ix = <u32>(u >> 32);
-    var sign = ix >> 31;
-
-    ix &= 0x7FFFFFFF;
-
-    // |x| ~< pi/4
-    if (ix <= 0x3FE921FB) {
-      if (ix < 0x3E500000) { // |x| < 2**-26
-        return x;
-      }
-      return sin_kern(x, 0.0, 0);
-    }
-
-    // sin(Inf or NaN) is NaN
-    if (ix >= 0x7FF00000) return x - x;
-
-    // argument reduction needed
-    var n  = rempio2(x, u, sign);
-    var y0 = rempio2_y0;
-    var y1 = rempio2_y1;
-
-    x = n & 1 ? cos_kern(y0, y1) : sin_kern(y0, y1, 1);
-    return n & 2 ? -x : x;
-  }
-
-  export function sinh(x: f64): f64 { // see: musl/src/math/sinh.c
-    var u = reinterpret<u64>(x) & 0x7FFFFFFFFFFFFFFF;
-    var a = reinterpret<f64>(u);
-    var w = <u32>(u >> 32);
-    var h = builtin_copysign(0.5, x);
-    if (w < 0x40862E42) {
-      let t = expm1(a);
-      if (w < 0x3FF00000) {
-        if (w < 0x3FF00000 - (26 << 20)) return x;
-        return h * (2 * t - t * t / (t + 1));
-      }
-      return h * (t + t / (t + 1));
-    }
-    return expo2(a, 2 * h);
-  }
-
-  // @ts-ignore: decorator
-  @inline
-  export function sqrt(x: f64): f64 {
-    return builtin_sqrt<f64>(x);
-  }
-
-  export function tan(x: f64): f64 { // see: musl/src/math/tan.c
-    var u = reinterpret<u64>(x);
-    var ix = <i32>(u >> 32);
-    var sign = ix >>> 31;
-
-    ix &= 0x7FFFFFFF;
-
-    // |x| ~< pi/4
-    if (ix <= 0x3FE921FB) {
-      if (ix < 0x3E400000) { // |x| < 2**-27
-        return x;
-      }
-      return tan_kern(x, 0.0, 1);
-    }
-
-    // tan(Inf or NaN) is NaN
-    if (ix >= 0x7FF00000) return x - x;
-
-    var n = rempio2(x, u, sign);
-    return tan_kern(rempio2_y0, rempio2_y1, 1 - ((n & 1) << 1));
-  }
-
-  export function tanh(x: f64): f64 { // see: musl/src/math/tanh.c
-    var u = reinterpret<u64>(x);
-    u &= 0x7FFFFFFFFFFFFFFF;
-    var y = reinterpret<f64>(u);
-    var w = <u32>(u >> 32);
-    var t: f64;
-    if (w > 0x3FE193EA) {
-      if (w > 0x40340000) {
-        t = 1 - 0 / y;
-      } else {
-        t = expm1(2 * y);
-        t = 1 - 2 / (t + 2);
-      }
-    } else if (w > 0x3FD058AE) {
-      t = expm1(2 * y);
-      t = t / (t + 2);
-    } else if (w >= 0x00100000) {
-      t = expm1(-2 * y);
-      t = -t / (t + 2);
-    } else t = y;
-    return builtin_copysign<f64>(t, x);
-  }
-
-  // @ts-ignore: decorator
-  @inline
-  export function trunc(x: f64): f64 {
-    return builtin_trunc<f64>(x);
-  }
-
-  export function scalbn(x: f64, n: i32): f64 { // see: https://git.musl-libc.org/cgit/musl/tree/src/math/scalbn.c
-    const
-      Ox1p53    = reinterpret<f64>(0x4340000000000000),
-      Ox1p1023  = reinterpret<f64>(0x7FE0000000000000),
-      Ox1p_1022 = reinterpret<f64>(0x0010000000000000);
-
-    var y = x;
-    if (n > 1023) {
-      y *= Ox1p1023;
-      n -= 1023;
-      if (n > 1023) {
-        y *= Ox1p1023;
-        n = builtin_min<i32>(n - 1023, 1023);
-      }
-    } else if (n < -1022) {
-      // make sure final n < -53 to avoid double
-      // rounding in the subnormal range
-      y *= Ox1p_1022 * Ox1p53;
-      n += 1022 - 53;
-      if (n < -1022) {
-        y *= Ox1p_1022 * Ox1p53;
-        n = builtin_max<i32>(n + 1022 - 53, -1022);
-      }
-    }
-    return y * reinterpret<f64>(<u64>(0x3FF + n) << 52);
-  }
-
-  export function mod(x: f64, y: f64): f64 { // see: musl/src/math/fmod.c
-    if (builtin_abs<f64>(y) == 1.0) {
-      // x % 1, x % -1  ==>  sign(x) * abs(x - 1.0 * trunc(x / 1.0))
-      // TODO: move this rule to compiler's optimization pass.
-      // It could be apply for any x % C_pot, where "C_pot" is pow of two const.
-      return builtin_copysign<f64>(x - builtin_trunc<f64>(x), x);
-    }
-    var ux = reinterpret<u64>(x);
-    var uy = reinterpret<u64>(y);
-    var ex = <i64>(ux >> 52 & 0x7FF);
-    var ey = <i64>(uy >> 52 & 0x7FF);
-    var sx = ux >> 63;
-    var uy1 = uy << 1;
-    if (uy1 == 0 || ex == 0x7FF || isNaN<f64>(y)) {
-      let m = x * y;
-      return m / m;
-    }
-    var ux1 = ux << 1;
-    if (ux1 <= uy1) {
-      return x * f64(ux1 != uy1);
-    }
-    if (!ex) {
-      ex -= builtin_clz<i64>(ux << 12);
-      ux <<= 1 - ex;
-    } else {
-      ux &= <u64>-1 >> 12;
-      ux |= 1 << 52;
-    }
-    if (!ey) {
-      ey -= builtin_clz<i64>(uy << 12);
-      uy <<= 1 - ey;
-    } else {
-      uy &= <u64>-1 >> 12;
-      uy |= 1 << 52;
-    }
-    while (ex > ey) {
-      if (ux >= uy) {
-        if (ux == uy) return 0 * x;
-        ux -= uy;
-      }
-      ux <<= 1;
-      --ex;
-    }
-    if (ux >= uy) {
-      if (ux == uy) return 0 * x;
-      ux -= uy;
-    }
-    // for (; !(ux >> 52); ux <<= 1) --ex;
-    var shift = builtin_clz<i64>(ux << 11);
-    ex -= shift;
-    ux <<= shift;
-    if (ex > 0) {
-      ux -= 1 << 52;
-      ux |= ex << 52;
-    } else {
-      ux >>= -ex + 1;
-    }
-    return reinterpret<f64>(ux | (sx << 63));
-  }
-
-  export function rem(x: f64, y: f64): f64 { // see: musl/src/math/remquo.c
-    var ux = reinterpret<u64>(x);
-    var uy = reinterpret<u64>(y);
-    var ex = <i64>(ux >> 52 & 0x7FF);
-    var ey = <i64>(uy >> 52 & 0x7FF);
-    var sx = <i32>(ux >> 63);
-    if (uy << 1 == 0 || ex == 0x7FF || isNaN(y)) {
-      let m = x * y;
-      return m / m;
-    }
-    if (ux << 1 == 0) return x;
-    var uxi = ux;
-    if (!ex) {
-      ex -= builtin_clz<i64>(uxi << 12);
-      uxi <<= 1 - ex;
-    } else {
-      uxi &= <u64>-1 >> 12;
-      uxi |= 1 << 52;
-    }
-    if (!ey) {
-      ey -= builtin_clz<i64>(uy << 12);
-      uy <<= 1 - ey;
-    } else {
-      uy &= <u64>-1 >> 12;
-      uy |= 1 << 52;
-    }
-    var q: u32 = 0;
-    do {
-      if (ex < ey) {
-        if (ex + 1 == ey) break; // goto end
-        return x;
-      }
-      while (ex > ey) {
-        if (uxi >= uy) {
-          uxi -= uy;
-          ++q;
-        }
-        uxi <<= 1;
-        q <<= 1;
-        --ex;
-      }
-      if (uxi >= uy) {
-        uxi -= uy;
-        ++q;
-      }
-      if (uxi == 0) ex = -60;
-      else {
-        let shift = builtin_clz<i64>(uxi << 11);
-        ex -= shift;
-        uxi <<= shift;
-      }
-      break;
-    } while (false);
-    // end:
-    if (ex > 0) {
-      uxi -= 1 << 52;
-      uxi |= ex << 52;
-    } else {
-      uxi >>= -ex + 1;
-    }
-    x = reinterpret<f64>(uxi);
-    y = builtin_abs<f64>(y);
-    var x2 = x + x;
-    if (ex == ey || (ex + 1 == ey && (x2 > y || (x2 == y && <bool>(q & 1))))) {
-      x -= y;
-      // ++q;
-    }
-    return sx ? -x : x;
-  }
-
-  export function sincos(x: f64): void { // see: musl/tree/src/math/sincos.c
-    var u = reinterpret<u64>(x);
-    var ix = <u32>(u >> 32);
-    var sign = ix >> 31;
-    ix &= 0x7FFFFFFF;
-
-    if (ix <= 0x3FE921FB) {  // |x| ~<= π/4
-      if (ix < 0x3E46A09E) { // if |x| < 2**-27 * sqrt(2)
-        sincos_sin = x;
-        sincos_cos = 1;
-        return;
-      }
-      sincos_sin = sin_kern(x, 0, 0);
-      sincos_cos = cos_kern(x, 0);
-      return;
-    }
-    // sin(Inf or NaN) is NaN
-    if (ix >= 0x7F800000) {
-      let xx = x - x;
-      sincos_sin = xx;
-      sincos_cos = xx;
-      return;
-    }
-    // general argument reduction needed
-    var n = rempio2(x, u, sign);
-    var y0 = rempio2_y0;
-    var y1 = rempio2_y1;
-    var s = sin_kern(y0, y1, 1);
-    var c = cos_kern(y0, y1);
-    var sin = s, cos = c;
-    if (n & 1) {
-      sin =  c;
-      cos = -s;
-    }
-    if (n & 2) {
-      sin = -sin;
-      cos = -cos;
-    }
-    sincos_sin = sin;
-    sincos_cos = cos;
-  }
-}
-
-// @ts-ignore: decorator
-@lazy var rempio2f_y: f64;
-
-// @ts-ignore: decorator
-@lazy @inline const PIO2F_TABLE = memory.data<u64>([
-  0xA2F9836E4E441529,
-  0xFC2757D1F534DDC0,
-  0xDB6295993C439041,
-  0xFE5163ABDEBBC561
-]);
-
-function Rf(z: f32): f32 { // Rational approximation of (asin(x)-x)/x^3
-  const                    // see: musl/src/math/asinf.c and SUN COPYRIGHT NOTICE above
-    pS0 = reinterpret<f32>(0x3E2AAA75), //  1.6666586697e-01f
-    pS1 = reinterpret<f32>(0xBD2F13BA), // -4.2743422091e-02f
-    pS2 = reinterpret<f32>(0xBC0DD36B), // -8.6563630030e-03f
-    qS1 = reinterpret<f32>(0xBF34E5AE); // -7.0662963390e-01f
-
-  var p = z * (pS0 + z * (pS1 + z * pS2));
-  var q: f32 = 1 + z * qS1;
-  return p / q;
-}
-
-// @ts-ignore: decorator
-@inline
-function expo2f(x: f32, sign: f32): f32 { // exp(x)/2 for x >= log(DBL_MAX)
-  const                                // see: musl/src/math/__expo2f.c
-    k    = <u32>235,
-    kln2 = reinterpret<f32>(0x4322E3BC); // 0x1.45c778p+7f
-  var scale = reinterpret<f32>(<u32>(0x7F + (k >> 1)) << 23);
-  // in directed rounding correct sign before rounding or overflow is important
-  return NativeMathf.exp(x - kln2) * (sign * scale) * scale;
-}
-
-// @ts-ignore: decorator
-@inline
-function pio2f_large_quot(x: f32, u: i32): i32 { // see: jdh8/metallic/blob/master/src/math/float/rem_pio2f.c
-  const coeff = reinterpret<f64>(0x3BF921FB54442D18); // π * 0x1p-65 = 8.51530395021638647334e-20
-
-  var offset = (u >> 23) - 152;
-  var shift  = <u64>(offset & 63);
-  var tblPtr = PIO2F_TABLE + (offset >> 6 << 3);
-
-  var b0 = load<u64>(tblPtr, 0 << 3);
-  var b1 = load<u64>(tblPtr, 1 << 3);
-  var lo: u64;
-
-  if (shift > 32) {
-    let b2 = load<u64>(tblPtr, 2 << 3);
-    lo  = b2 >> (96 - shift);
-    lo |= b1 << (shift - 32);
-  } else {
-    lo = b1 >> (32 - shift);
-  }
-
-  var hi = (b1 >> (64 - shift)) | (b0 << shift);
-  var mantissa: u64 = (u & 0x007FFFFF) | 0x00800000;
-  var product = mantissa * hi + (mantissa * lo >> 32);
-  var r: i64 = product << 2;
-  var q = <i32>((product >> 62) + (r >>> 63));
-  rempio2f_y = copysign<f64>(coeff, x) * <f64>r;
-  return q;
-}
-
-// @ts-ignore: decorator
-@inline
-function rempio2f(x: f32, u: u32, sign: i32): i32 { // see: jdh8/metallic/blob/master/src/math/float/rem_pio2f.c
-  const
-    pi2hi = reinterpret<f64>(0x3FF921FB50000000), // 1.57079631090164184570
-    pi2lo = reinterpret<f64>(0x3E5110B4611A6263), // 1.58932547735281966916e-8
-    _2_pi = reinterpret<f64>(0x3FE45F306DC9C883); // 0.63661977236758134308
-
-  if (u < 0x4DC90FDB) { // π * 0x1p28
-    let q = nearest(x * _2_pi);
-    rempio2f_y = x - q * pi2hi - q * pi2lo;
-    return <i32>q;
-  }
-
-  var q = pio2f_large_quot(x, u);
-  return select(-q, q, sign);
-}
-
-// |sin(x)/x - s(x)| < 2**-37.5 (~[-4.89e-12, 4.824e-12]).
-// @ts-ignore: decorator
-@inline
-function sin_kernf(x: f64): f32 { // see: musl/tree/src/math/__sindf.c
-  const
-    S1 = reinterpret<f64>(0xBFC5555554CBAC77), // -0x15555554cbac77.0p-55
-    S2 = reinterpret<f64>(0x3F811110896EFBB2), //  0x111110896efbb2.0p-59
-    S3 = reinterpret<f64>(0xBF2A00F9E2CAE774), // -0x1a00f9e2cae774.0p-65
-    S4 = reinterpret<f64>(0x3EC6CD878C3B46A7); //  0x16cd878c3b46a7.0p-71
-
-  var z = x * x;
-  var w = z * z;
-  var r = S3 + z * S4;
-  var s = z * x;
-  return <f32>((x + s * (S1 + z * S2)) + s * w * r);
-}
-
-// |cos(x) - c(x)| < 2**-34.1 (~[-5.37e-11, 5.295e-11]).
-// @ts-ignore: decorator
-@inline
-function cos_kernf(x: f64): f32 { // see: musl/tree/src/math/__cosdf.c
-  const
-    C0 = reinterpret<f64>(0xBFDFFFFFFD0C5E81), // -0x1ffffffd0c5e81.0p-54
-    C1 = reinterpret<f64>(0x3FA55553E1053A42), //  0x155553e1053a42.0p-57
-    C2 = reinterpret<f64>(0xBF56C087E80F1E27), // -0x16c087e80f1e27.0p-62
-    C3 = reinterpret<f64>(0x3EF99342E0EE5069); //  0x199342e0ee5069.0p-68
-
-  var z = x * x;
-  var w = z * z;
-  var r = C2 + z * C3;
-  return <f32>(((1 + z * C0) + w * C1) + (w * z) * r);
-}
-
-// |tan(x)/x - t(x)| < 2**-25.5 (~[-2e-08, 2e-08]).
-// @ts-ignore: decorator
-@inline
-function tan_kernf(x: f64, odd: i32): f32 { // see: musl/tree/src/math/__tandf.c
-  const
-    T0 = reinterpret<f64>(0x3FD5554D3418C99F), // 0x15554d3418c99f.0p-54
-    T1 = reinterpret<f64>(0x3FC112FD38999F72), // 0x1112fd38999f72.0p-55
-    T2 = reinterpret<f64>(0x3FAB54C91D865AFE), // 0x1b54c91d865afe.0p-57
-    T3 = reinterpret<f64>(0x3F991DF3908C33CE), // 0x191df3908c33ce.0p-58
-    T4 = reinterpret<f64>(0x3F685DADFCECF44E), // 0x185dadfcecf44e.0p-61
-    T5 = reinterpret<f64>(0x3F8362B9BF971BCD); // 0x1362b9bf971bcd.0p-59
-
-  var z = x * x;
-  var r = T4 + z * T5;
-  var t = T2 + z * T3;
-  var w = z * z;
-  var s = z * x;
-  var u = T0 + z * T1;
-
-  r = (x + s * u) + (s * w) * (t + w * r);
-  return <f32>(odd ? -1 / r : r);
-}
-
-// See: jdh8/metallic/src/math/float/log2f.c and jdh8/metallic/src/math/float/kernel/atanh.h
-// @ts-ignore: decorator
-@inline
-function log2f(x: f64): f64 {
-  const
-    log2e = reinterpret<f64>(0x3FF71547652B82FE), // 1.44269504088896340736
-    c0 = reinterpret<f64>(0x3FD555554FD9CAEF),    // 0.33333332822728226129
-    c1 = reinterpret<f64>(0x3FC999A7A8AF4132),    // 0.20000167595436263505
-    c2 = reinterpret<f64>(0x3FC2438D79437030),    // 0.14268654271188685375
-    c3 = reinterpret<f64>(0x3FBE2F663B001C97);    // 0.11791075649681414150
-
-  var i = reinterpret<i64>(x);
-  var exponent = (i - 0x3FE6A09E667F3BCD) >> 52;
-  x = reinterpret<f64>(i - (exponent << 52));
-  x = (x - 1) / (x + 1);
-  var xx = x * x;
-  var y = x + x * xx * (c0 + c1 * xx + (c2 + c3 * xx) * (xx * xx));
-  return (2 * log2e) * y + <f64>exponent;
-}
-
-// See: jdh8/metallic/src/math/float/exp2f.h and jdh8/metallic/blob/master/src/math/float/kernel/exp2f.h
-// @ts-ignore: decorator
-@inline
-function exp2f(x: f64): f64 {
-  const
-    c0 = reinterpret<f64>(0x3FE62E4302FCC24A), // 6.931471880289532425e-1
-    c1 = reinterpret<f64>(0x3FCEBFBE07D97B91), // 2.402265108421173406e-1
-    c2 = reinterpret<f64>(0x3FAC6AF6CCFC1A65), // 5.550357105498874537e-2
-    c3 = reinterpret<f64>(0x3F83B29E3CE9AEF6), // 9.618030771171497658e-3
-    c4 = reinterpret<f64>(0x3F55F0896145A89F), // 1.339086685300950937e-3
-    c5 = reinterpret<f64>(0x3F2446C81E384864); // 1.546973499989028719e-4
-
-  if (x < -1022) return 0;
-  if (x >= 1024) return Infinity;
-
-  var n = nearest(x);
-  x -= n;
-  var xx = x * x;
-  var y = 1 + x * (c0 + c1 * x + (c2 + c3 * x) * xx + (c4 + c5 * x) * (xx * xx));
-  return reinterpret<f64>(reinterpret<i64>(y) + (<i64>n << 52));
-}
-
-export namespace NativeMathf {
-
-  // @ts-ignore: decorator
-  @lazy
-  export const E       = <f32>NativeMath.E;
-
-  // @ts-ignore: decorator
-  @lazy
-  export const LN2     = <f32>NativeMath.LN2;
-
-  // @ts-ignore: decorator
-  @lazy
-  export const LN10    = <f32>NativeMath.LN10;
-
-  // @ts-ignore: decorator
-  @lazy
-  export const LOG2E   = <f32>NativeMath.LOG2E;
-
-  // @ts-ignore: decorator
-  @lazy
-  export const LOG10E  = <f32>NativeMath.LOG10E;
-
-  // @ts-ignore: decorator
-  @lazy
-  export const PI      = <f32>NativeMath.PI;
-
-  // @ts-ignore: decorator
-  @lazy
-  export const SQRT1_2 = <f32>NativeMath.SQRT1_2;
-
-  // @ts-ignore: decorator
-  @lazy
-  export const SQRT2   = <f32>NativeMath.SQRT2;
-
-  // @ts-ignore: decorator
-  @lazy
-  export var sincos_sin: f32 = 0;
-
-  // @ts-ignore: decorator
-  @lazy
-  export var sincos_cos: f32 = 0;
-
-  // @ts-ignore: decorator
-  @inline
-  export function abs(x: f32): f32 {
-    return builtin_abs<f32>(x);
-  }
-
-  export function acos(x: f32): f32 { // see: musl/src/math/acosf.c and SUN COPYRIGHT NOTICE above
-    const
-      pio2_hi   = reinterpret<f32>(0x3FC90FDA), // 1.5707962513e+00f
-      pio2_lo   = reinterpret<f32>(0x33A22168), // 7.5497894159e-08f
-      Ox1p_120f = reinterpret<f32>(0x03800000); // 0x1p-120f
-
-    var hx = reinterpret<u32>(x);
-    var ix = hx & 0x7FFFFFFF;
-    if (ix >= 0x3F800000) {
-      if (ix == 0x3F800000) {
-        if (hx >> 31) return 2 * pio2_hi + Ox1p_120f;
-        return 0;
-      }
-      return 0 / (x - x);
-    }
-    if (ix < 0x3F000000) {
-      if (ix <= 0x32800000) return pio2_hi + Ox1p_120f;
-      return pio2_hi - (x - (pio2_lo - x * Rf(x * x)));
-    }
-    var z: f32, w: f32, s: f32;
-    if (hx >> 31) {
-      // z = (1 + x) * 0.5;
-      z = 0.5 + x * 0.5;
-      s = builtin_sqrt<f32>(z);
-      w = Rf(z) * s - pio2_lo;
-      return 2 * (pio2_hi - (s + w));
-    }
-    // z = (1 - x) * 0.5;
-    z = 0.5 - x * 0.5;
-    s = builtin_sqrt<f32>(z);
-    hx = reinterpret<u32>(s);
-    var df = reinterpret<f32>(hx & 0xFFFFF000);
-    var c = (z - df * df) / (s + df);
-    w = Rf(z) * s + c;
-    return 2 * (df + w);
-  }
-
-  export function acosh(x: f32): f32 { // see: musl/src/math/acoshf.c
-    const s = reinterpret<f32>(0x3F317218); // 0.693147180559945309417232121458176568f
-    var u = reinterpret<u32>(x);
-    var a = u & 0x7FFFFFFF;
-    if (a < 0x3F800000 + (1 << 23)) { // |x| < 2, invalid if x < 1
-      let xm1 = x - 1;
-      return log1p(xm1 + builtin_sqrt(xm1 * (xm1 + 2)));
-    }
-    if (u < 0x3F800000 + (12 << 23)) { // 2 <= x < 0x1p12
-      return log(2 * x - 1 / (x + builtin_sqrt<f32>(x * x - 1)));
-    }
-    // x >= 0x1p12 or x <= -2 or NaN
-    return log(x) + s;
-  }
-
-  export function asin(x: f32): f32 { // see: musl/src/math/asinf.c and SUN COPYRIGHT NOTICE above
-    const
-      pio2      = reinterpret<f32>(0x3FC90FDB), // 1.570796326794896558e+00f
-      Ox1p_120f = reinterpret<f32>(0x03800000); // 0x1p-120f
-
-    var sx = x;
-    var hx = reinterpret<u32>(x) & 0x7FFFFFFF;
-    if (hx >= 0x3F800000) {
-      if (hx == 0x3F800000) return x * pio2 + Ox1p_120f;
-      return 0 / (x - x);
-    }
-    if (hx < 0x3F000000) {
-      if (hx < 0x39800000 && hx >= 0x00800000) return x;
-      return x + x * Rf(x * x);
-    }
-    // var z: f32 = (1 - builtin_abs<f32>(x)) * 0.5;
-    var z: f32 = 0.5 - builtin_abs<f32>(x) * 0.5;
-    var s = builtin_sqrt<f64>(z); // sic
-    x = <f32>(pio2 - 2 * (s + s * Rf(z)));
-    return builtin_copysign(x, sx);
-  }
-
-  export function asinh(x: f32): f32 { // see: musl/src/math/asinhf.c
-    const c = reinterpret<f32>(0x3F317218); // 0.693147180559945309417232121458176568f
-    var u = reinterpret<u32>(x) & 0x7FFFFFFF;
-    var y = reinterpret<f32>(u);
-    if (u >= 0x3F800000 + (12 << 23)) y = log(y) + c;
-    else if (u >= 0x3F800000 + (1 << 23))  y =   log(2 * y + 1 / (builtin_sqrt<f32>(y * y + 1) + y));
-    else if (u >= 0x3F800000 - (12 << 23)) y = log1p(y + y * y / (builtin_sqrt<f32>(y * y + 1) + 1));
-    return builtin_copysign(y, x);
-  }
-
-  export function atan(x: f32): f32 { // see: musl/src/math/atanf.c and SUN COPYRIGHT NOTICE above
-    const
-      atanhi0   = reinterpret<f32>(0x3EED6338), //  4.6364760399e-01f
-      atanhi1   = reinterpret<f32>(0x3F490FDA), //  7.8539812565e-01f
-      atanhi2   = reinterpret<f32>(0x3F7B985E), //  9.8279368877e-01f
-      atanhi3   = reinterpret<f32>(0x3FC90FDA), //  1.5707962513e+00f
-      atanlo0   = reinterpret<f32>(0x31AC3769), //  5.0121582440e-09f
-      atanlo1   = reinterpret<f32>(0x33222168), //  3.7748947079e-08f
-      atanlo2   = reinterpret<f32>(0x33140FB4), //  3.4473217170e-08f
-      atanlo3   = reinterpret<f32>(0x33A22168), //  7.5497894159e-08f
-      aT0       = reinterpret<f32>(0x3EAAAAA9), //  3.3333328366e-01f
-      aT1       = reinterpret<f32>(0xBE4CCA98), // -1.9999158382e-01f
-      aT2       = reinterpret<f32>(0x3E11F50D), //  1.4253635705e-01f
-      aT3       = reinterpret<f32>(0xBDDA1247), // -1.0648017377e-01f
-      aT4       = reinterpret<f32>(0x3D7CAC25), //  6.1687607318e-02f
-      Ox1p_120f = reinterpret<f32>(0x03800000); //  0x1p-120f
-
-    var ix = reinterpret<u32>(x);
-    var sx = x;
-    ix &= 0x7FFFFFFF;
-    var z: f32;
-    if (ix >= 0x4C800000) {
-      if (isNaN(x)) return x;
-      z = atanhi3 + Ox1p_120f;
-      return builtin_copysign(z, sx);
-    }
-    var id: i32;
-    if (ix < 0x3EE00000) {
-      if (ix < 0x39800000) return x;
-      id = -1;
-    } else {
-      x = builtin_abs<f32>(x);
-      if (ix < 0x3F980000) {
-        if (ix < 0x3F300000) {
-          id = 0;
-          x = (2.0 * x - 1.0) / (2.0 + x);
-        } else {
-          id = 1;
-          x = (x - 1.0) / (x + 1.0);
-        }
-      } else {
-        if (ix < 0x401C0000) {
-          id = 2;
-          x = (x - 1.5) / (1.0 + 1.5 * x);
-        } else {
-          id = 3;
-          x = -1.0 / x;
-        }
-      }
-    }
-    z = x * x;
-    var w = z * z;
-    var s1 = z * (aT0 + w * (aT2 + w * aT4));
-    var s2 = w * (aT1 + w * aT3);
-    var s3 = x * (s1 + s2);
-    if (id < 0) return x - s3;
-    switch (id) {
-      case 0: { z = atanhi0 - ((s3 - atanlo0) - x); break; }
-      case 1: { z = atanhi1 - ((s3 - atanlo1) - x); break; }
-      case 2: { z = atanhi2 - ((s3 - atanlo2) - x); break; }
-      case 3: { z = atanhi3 - ((s3 - atanlo3) - x); break; }
-      default: unreachable();
-    }
-    return builtin_copysign(z, sx);
-  }
-
-  export function atanh(x: f32): f32 { // see: musl/src/math/atanhf.c
-    var u = reinterpret<u32>(x);
-    var y = builtin_abs(x);
-    if (u < 0x3F800000 - (1 << 23)) {
-      if (u >= 0x3F800000 - (32 << 23)) y = 0.5 * log1p(2 * y * (1.0 + y / (1 - y)));
-    } else y = 0.5 * log1p(2 * (y / (1 - y)));
-    return builtin_copysign(y, x);
-  }
-
-  export function atan2(y: f32, x: f32): f32 { // see: musl/src/math/atan2f.c and SUN COPYRIGHT NOTICE above
-    const
-      pi    = reinterpret<f32>(0x40490FDB), //  3.1415927410e+00f
-      pi_lo = reinterpret<f32>(0xB3BBBD2E); // -8.7422776573e-08f
-
-    if (isNaN(x) || isNaN(y)) return x + y;
-    var ix = reinterpret<u32>(x);
-    var iy = reinterpret<u32>(y);
-    if (ix == 0x3F800000) return atan(y);
-    var m = <u32>(((iy >> 31) & 1) | ((ix >> 30) & 2));
-    ix &= 0x7FFFFFFF;
-    iy &= 0x7FFFFFFF;
-    if (iy == 0) {
-      switch (m) {
-        case 0:
-        case 1: return  y;
-        case 2: return  pi;
-        case 3: return -pi;
-      }
-    }
-    if (ix == 0) return m & 1 ? -pi / 2 : pi / 2;
-    if (ix == 0x7F800000) {
-      if (iy == 0x7F800000) {
-        let t: f32 = m & 2 ? 3 * pi / 4 : pi / 4;
-        return m & 1 ? -t : t;
-      } else {
-        let t: f32 = m & 2 ? pi : 0.0;
-        return m & 1 ? -t : t;
-      }
-    }
-    if (ix + (26 << 23) < iy || iy == 0x7F800000) return m & 1 ? -pi / 2 : pi / 2;
-    var z: f32;
-    if ((m & 2) && iy + (26 << 23) < ix) z = 0.0;
-    else z = atan(builtin_abs<f32>(y / x));
-    switch (m) {
-      case 0: return  z;
-      case 1: return -z;
-      case 2: return pi - (z - pi_lo);
-      case 3: return (z - pi_lo) - pi;
-    }
-    unreachable();
-    return 0;
-  }
-
-  export function cbrt(x: f32): f32 { // see: musl/src/math/cbrtf.c and SUN COPYRIGHT NOTICE above
-    const
-      B1      = <u32>709958130,
-      B2      = <u32>642849266,
-      Ox1p24f = reinterpret<f32>(0x4B800000);
-
-    var u = reinterpret<u32>(x);
-    var hx = u & 0x7FFFFFFF;
-    if (hx >= 0x7F800000) return x + x;
-    if (hx < 0x00800000) {
-      if (hx == 0) return x;
-      u = reinterpret<u32>(x * Ox1p24f);
-      hx = u & 0x7FFFFFFF;
-      hx = hx / 3 + B2;
-    } else {
-      hx = hx / 3 + B1;
-    }
-    u &= 0x80000000;
-    u |= hx;
-    var t = <f64>reinterpret<f32>(u);
-    var r = t * t * t;
-    t = t * (<f64>x + x + r) / (x + r + r);
-    r = t * t * t;
-    t = t * (<f64>x + x + r) / (x + r + r);
-    return <f32>t;
-  }
-
-  // @ts-ignore: decorator
-  @inline
-  export function ceil(x: f32): f32 {
-    return builtin_ceil<f32>(x);
-  }
-
-  export function clz32(x: f32): f32 {
-    if (!isFinite(x)) return 32;
-    return <f32>builtin_clz(dtoi32(x));
-  }
-
-  export function cos(x: f32): f32 { // see: musl/src/math/cosf.c
-    const
-      c1pio2 = reinterpret<f64>(0x3FF921FB54442D18), // M_PI_2 * 1
-      c2pio2 = reinterpret<f64>(0x400921FB54442D18), // M_PI_2 * 2
-      c3pio2 = reinterpret<f64>(0x4012D97C7F3321D2), // M_PI_2 * 3
-      c4pio2 = reinterpret<f64>(0x401921FB54442D18); // M_PI_2 * 4
-
-    var ix = reinterpret<u32>(x);
-    var sign = ix >> 31;
-    ix &= 0x7FFFFFFF;
-
-    if (ix <= 0x3F490FDA) {  // |x| ~<= π/4
-      if (ix < 0x39800000) { // |x| < 2**-12
-        // raise inexact if x != 0
-        return 1;
-      }
-      return cos_kernf(x);
-    }
-
-    if (ASC_SHRINK_LEVEL < 1) {
-      if (ix <= 0x407B53D1) {  // |x| ~<= 5π/4
-        if (ix > 0x4016CBE3) { // |x|  ~> 3π/4
-          return -cos_kernf(sign ? x + c2pio2 : x - c2pio2);
-        } else {
-          return sign ? sin_kernf(x + c1pio2) : sin_kernf(c1pio2 - x);
-        }
-      }
-      if (ix <= 0x40E231D5) {  // |x| ~<= 9π/4
-        if (ix > 0x40AFEDDF) { // |x|  ~> 7π/4
-          return cos_kernf(sign ? x + c4pio2 : x - c4pio2);
-        } else {
-          return sign ? sin_kernf(-x - c3pio2) : sin_kernf(x - c3pio2);
-        }
-      }
-    }
-
-    // cos(Inf or NaN) is NaN
-    if (ix >= 0x7F800000) return x - x;
-
-    // general argument reduction needed
-    var n = rempio2f(x, ix, sign);
-    var y = rempio2f_y;
-
-    var t = n & 1 ? sin_kernf(y) : cos_kernf(y);
-    return (n + 1) & 2 ? -t : t;
-  }
-
-  export function cosh(x: f32): f32 { // see: musl/src/math/coshf.c
-    var u = reinterpret<u32>(x);
-    u &= 0x7FFFFFFF;
-    x = reinterpret<f32>(u);
-    if (u < 0x3F317217) {
-      if (u < 0x3F800000 - (12 << 23)) return 1;
-      let t = expm1(x);
-      // return 1 + t * t / (2 * (1 + t));
-      return 1 + t * t / (2 + 2 * t);
-    }
-    if (u < 0x42B17217) {
-      let t = exp(x);
-      // return 0.5 * (t + 1 / t);
-      return 0.5 * t + 0.5 / t;
-    }
-    return expo2f(x, 1);
-  }
-
-  // @ts-ignore: decorator
-  @inline
-  export function floor(x: f32): f32 {
-    return builtin_floor<f32>(x);
-  }
-
-  export function exp(x: f32): f32 { // see: musl/src/math/expf.c and SUN COPYRIGHT NOTICE above
-    if (ASC_SHRINK_LEVEL < 1) {
-      return expf_lut(x);
-    } else {
-      const
-        ln2hi    = reinterpret<f32>(0x3F317200), //  6.9314575195e-1f
-        ln2lo    = reinterpret<f32>(0x35BFBE8E), //  1.4286067653e-6f
-        invln2   = reinterpret<f32>(0x3FB8AA3B), //  1.4426950216e+0f
-        P1       = reinterpret<f32>(0x3E2AAA8F), //  1.6666625440e-1f
-        P2       = reinterpret<f32>(0xBB355215), // -2.7667332906e-3f
-        Ox1p127f = reinterpret<f32>(0x7F000000); //  0x1p+127f
-
-      let hx = reinterpret<u32>(x);
-      let sign_ = <i32>(hx >> 31);
-      hx &= 0x7FFFFFFF;
-      if (hx >= 0x42AEAC50) {
-        if (hx > 0x7F800000) return x; // NaN
-        if (hx >= 0x42B17218) {
-          if (!sign_) return x * Ox1p127f;
-          else if (hx >= 0x42CFF1B5) return 0;
-        }
-      }
-      let hi: f32, lo: f32;
-      let k: i32;
-      if (hx > 0x3EB17218) {
-        if (hx > 0x3F851592) {
-          k = <i32>(invln2 * x + builtin_copysign<f32>(0.5, x));
-        } else {
-          k = 1 - (sign_ << 1);
-        }
-        hi = x - <f32>k * ln2hi;
-        lo = <f32>k * ln2lo;
-        x = hi - lo;
-      } else if (hx > 0x39000000) {
-        k = 0;
-        hi = x;
-        lo = 0;
-      } else {
-        return 1 + x;
-      }
-      let xx = x * x;
-      let c = x - xx * (P1 + xx * P2);
-      let y: f32 = 1 + (x * c / (2 - c) - lo + hi);
-      return k == 0 ? y : scalbn(y, k);
-    }
-  }
-
-  export function exp2(x: f32): f32 {
-    return exp2f_lut(x);
-  }
-
-  export function expm1(x: f32): f32 { // see: musl/src/math/expm1f.c and SUN COPYRIGHT NOTICE above
-    const
-      ln2_hi   = reinterpret<f32>(0x3F317180), //  6.9313812256e-01f
-      ln2_lo   = reinterpret<f32>(0x3717F7D1), //  9.0580006145e-06f
-      invln2   = reinterpret<f32>(0x3FB8AA3B), //  1.4426950216e+00f
-      Q1       = reinterpret<f32>(0xBD088868), // -3.3333212137e-02f
-      Q2       = reinterpret<f32>(0x3ACF3010), //  1.5807170421e-03f
-      Ox1p127f = reinterpret<f32>(0x7F000000); //  0x1p+127f
-
-    var u = reinterpret<u32>(x);
-    var hx = u & 0x7FFFFFFF;
-    var sign_ = <i32>(u >> 31);
-    if (hx >= 0x4195B844) {
-      if (hx > 0x7F800000) return x;
-      if (sign_) return -1;
-      if (hx > 0x42B17217) { // x > log(FLT_MAX)
-        x *= Ox1p127f;
-        return x;
-      }
-    }
-    var c: f32 = 0.0, t: f32, k: i32;
-    if (hx > 0x3EB17218) {
-      k = select<i32>(
-        1 - (sign_ << 1),
-        <i32>(invln2 * x + builtin_copysign<f32>(0.5, x)),
-        hx < 0x3F851592
-      );
-      t = <f32>k;
-      let hi = x - t * ln2_hi;
-      let lo = t * ln2_lo;
-      x = hi - lo;
-      c = (hi - x) - lo;
-    } else if (hx < 0x33000000) {
+  export function round<T extends number = f64>(x: T): T {
+    if (isInteger<T>()) {
       return x;
-    } else k = 0;
-    var hfx: f32 = 0.5 * x;
-    var hxs: f32 = x * hfx;
-    var r1: f32 = 1.0 + hxs * (Q1 + hxs * Q2);
-    t  = 3.0 - r1 * hfx;
-    var e = hxs * ((r1 - t) / (6.0 - x * t));
-    if (k == 0) return x - (x * e - hxs);
-    e  = x * (e - c) - c;
-    e -= hxs;
-    if (k == -1) return 0.5 * (x - e) - 0.5;
-    if (k == 1) {
-      if (x < -0.25) return -2.0 * (e - (x + 0.5));
-      return 1.0 + 2.0 * (x - e);
-    }
-    u = (0x7F + k) << 23;
-    var twopk = reinterpret<f32>(u);
-    var y: f32;
-    if (k < 0 || k > 56) {
-      y = x - e + 1.0;
-      if (k == 128) y = y * 2.0 * Ox1p127f;
-      else y = y * twopk;
-      return y - 1.0;
-    }
-    u = (0x7F - k) << 23;
-    y = reinterpret<f32>(u);
-    if (k < 20) y = (1 - y) - e;
-    else y = 1 - (e + y);
-    return (x + y) * twopk;
-  }
-
-  // @ts-ignore: decorator
-  @inline
-  export function fround(x: f32): f32 {
-    return x;
-  }
-
-  export function hypot(x: f32, y: f32): f32 { // see: musl/src/math/hypotf.c
-    const
-      Ox1p90f  = reinterpret<f32>(0x6C800000),
-      Ox1p_90f = reinterpret<f32>(0x12800000);
-
-    var ux = reinterpret<u32>(x);
-    var uy = reinterpret<u32>(y);
-    ux &= 0x7FFFFFFF;
-    uy &= 0x7FFFFFFF;
-    if (ux < uy) {
-      let ut = ux;
-      ux = uy;
-      uy = ut;
-    }
-    x = reinterpret<f32>(ux);
-    y = reinterpret<f32>(uy);
-    if (uy == 0xFF << 23) return y;
-    if (ux >= 0xFF << 23 || uy == 0 || ux - uy >= 25 << 23) return x + y;
-    var z: f32 = 1;
-    if (ux >= (0x7F + 60) << 23) {
-      z  = Ox1p90f;
-      x *= Ox1p_90f;
-      y *= Ox1p_90f;
-    } else if (uy < (0x7F - 60) << 23) {
-      z  = Ox1p_90f;
-      x *= Ox1p90f;
-      y *= Ox1p90f;
-    }
-    return z * builtin_sqrt<f32>(<f32>(<f64>x * x + <f64>y * y));
-  }
-
-  // @ts-ignore: decorator
-  @inline
-  export function imul(x: f32, y: f32): f32 {
-    /*
-     * Wasm (MVP) and JS have different approaches for double->int conversions.
-     *
-     * For emulate JS conversion behavior and avoid trapping from wasm we should modulate by MAX_INT
-     * our float-point arguments before actual convertion to integers.
-     */
-    if (!isFinite(x + y)) return 0;
-    return <f32>(dtoi32(x) * dtoi32(y));
-  }
-
-  export function log(x: f32): f32 { // see: musl/src/math/logf.c and SUN COPYRIGHT NOTICE above
-    if (ASC_SHRINK_LEVEL < 1) {
-      return logf_lut(x);
+    } else if (isFloat<T>()) {
+      let roundUp = builtin_ceil<T>(x);
+      return select<T>(roundUp, <T>(roundUp - 1.0), roundUp - 0.5 <= x);
     } else {
-      const
-        ln2_hi  = reinterpret<f32>(0x3F317180), // 6.9313812256e-01f
-        ln2_lo  = reinterpret<f32>(0x3717F7D1), // 9.0580006145e-06f
-        Lg1     = reinterpret<f32>(0x3F2AAAAA), // 0xaaaaaa.0p-24f
-        Lg2     = reinterpret<f32>(0x3ECCCE13), // 0xccce13.0p-25f
-        Lg3     = reinterpret<f32>(0x3E91E9EE), // 0x91e9ee.0p-25f
-        Lg4     = reinterpret<f32>(0x3E789E26), // 0xf89e26.0p-26f
-        Ox1p25f = reinterpret<f32>(0x4C000000);
-
-      let u = reinterpret<u32>(x);
-      let k = 0;
-      if (u < 0x00800000 || <bool>(u >> 31)) {
-        if (u << 1 == 0) return -1 / (x * x);
-        if (u >> 31) return (x - x) / 0;
-        k -= 25;
-        x *= Ox1p25f;
-        u = reinterpret<u32>(x);
-      } else if (u >= 0x7F800000) {
-        return x;
-      } else if (u == 0x3F800000) {
-        return 0;
-      }
-      u += 0x3F800000 - 0x3F3504F3;
-      k += <u32>(<i32>u >> 23) - 0x7F;
-      u = (u & 0x007FFFFF) + 0x3F3504F3;
-      x = reinterpret<f32>(u);
-      let f = x - 1.0;
-      let s = f / (2.0 + f);
-      let z = s * s;
-      let w = z * z;
-      let t1 = w * (Lg2 + w * Lg4);
-      let t2 = z * (Lg1 + w * Lg3);
-      let r = t2 + t1;
-      let hfsq = <f32>0.5 * f * f;
-      let dk = <f32>k;
-      return s * (hfsq + r) + dk * ln2_lo - hfsq + f + dk * ln2_hi;
-    }
-  }
-
-  export function log10(x: f32): f32 { // see: musl/src/math/log10f.c and SUN COPYRIGHT NOTICE above
-    const
-      ivln10hi  = reinterpret<f32>(0x3EDE6000), //  4.3432617188e-01f
-      ivln10lo  = reinterpret<f32>(0xB804EAD9), // -3.1689971365e-05f
-      log10_2hi = reinterpret<f32>(0x3E9A2080), //  3.0102920532e-01f
-      log10_2lo = reinterpret<f32>(0x355427DB), //  7.9034151668e-07f
-      Lg1       = reinterpret<f32>(0x3F2AAAAA), //  0xaaaaaa.0p-24f, 0.66666662693f
-      Lg2       = reinterpret<f32>(0x3ECCCE13), //  0xccce13.0p-25f, 0.40000972152f
-      Lg3       = reinterpret<f32>(0x3E91E9EE), //  0x91e9ee.0p-25f, 0.28498786688f
-      Lg4       = reinterpret<f32>(0x3E789E26), //  0xf89e26.0p-26f, 0.24279078841f
-      Ox1p25f   = reinterpret<f32>(0x4C000000); //  0x1p25f
-
-    var ix = reinterpret<u32>(x);
-    var k = 0;
-    if (ix < 0x00800000 || <bool>(ix >> 31)) {
-      if (ix << 1 == 0) return -1 / (x * x);
-      if (ix >> 31) return (x - x) / 0.0;
-      k -= 25;
-      x *= Ox1p25f;
-      ix = reinterpret<u32>(x);
-    } else if (ix >= 0x7F800000) {
-      return x;
-    } else if (ix == 0x3F800000) {
-      return 0;
-    }
-    ix += 0x3F800000 - 0x3F3504F3;
-    k += <i32>(ix >> 23) - 0x7F;
-    ix = (ix & 0x007FFFFF) + 0x3F3504F3;
-    x = reinterpret<f32>(ix);
-    var f = x - 1.0;
-    var s = f / (2.0 + f);
-    var z = s * s;
-    var w = z * z;
-    var t1 = w * (Lg2 + w * Lg4);
-    var t2 = z * (Lg1 + w * Lg3);
-    var r = t2 + t1;
-    var hfsq: f32 = 0.5 * f * f;
-    var hi = f - hfsq;
-    ix = reinterpret<u32>(hi);
-    ix &= 0xFFFFF000;
-    hi = reinterpret<f32>(ix);
-    var lo = f - hi - hfsq + s * (hfsq + r);
-    var dk = <f32>k;
-    return dk * log10_2lo + (lo + hi) * ivln10lo + lo * ivln10hi + hi * ivln10hi + dk * log10_2hi;
-  }
-
-  export function log1p(x: f32): f32 { // see: musl/src/math/log1pf.c and SUN COPYRIGHT NOTICE above
-    const
-      ln2_hi = reinterpret<f32>(0x3F317180), // 6.9313812256e-01
-      ln2_lo = reinterpret<f32>(0x3717F7D1), // 9.0580006145e-06
-      Lg1    = reinterpret<f32>(0x3F2AAAAA), // 0xaaaaaa.0p-24f, 0.66666662693f
-      Lg2    = reinterpret<f32>(0x3ECCCE13), // 0xccce13.0p-25f, 0.40000972152f
-      Lg3    = reinterpret<f32>(0x3E91E9EE), // 0x91e9ee.0p-25f, 0.28498786688f
-      Lg4    = reinterpret<f32>(0x3E789E26); // 0xf89e26.0p-26f, 0.24279078841f
-
-    var ix = reinterpret<u32>(x);
-    var c: f32 = 0, f: f32 = 0;
-    var k: i32 = 1;
-    if (ix < 0x3ED413D0 || <bool>(ix >> 31)) {
-      if (ix >= 0xBF800000) {
-        if (x == -1) return x / 0.0;
-        return (x - x) / 0.0;
-      }
-      if (ix << 1 < 0x33800000 << 1) return x;
-      if (ix <= 0xBE95F619) {
-        k = 0;
-        c = 0;
-        f = x;
-      }
-    } else if (ix >= 0x7F800000) return x;
-    if (k) {
-      let uf: f32 = 1 + x;
-      let iu = reinterpret<u32>(uf);
-      iu += 0x3F800000 - 0x3F3504F3;
-      k = <i32>(iu >> 23) - 0x7F;
-      if (k < 25) {
-        c = k >= 2 ? 1 - (uf - x) : x - (uf - 1);
-        c /= uf;
-      } else c = 0;
-      iu = (iu & 0x007FFFFF) + 0x3F3504F3;
-      f = reinterpret<f32>(iu) - 1;
-    }
-    var s = f / (2.0 + f);
-    var z = s * s;
-    var w = z * z;
-    var t1 = w * (Lg2 + w * Lg4);
-    var t2 = z * (Lg1 + w * Lg3);
-    var r = t2 + t1;
-    var hfsq: f32 = 0.5 * f * f;
-    var dk = <f32>k;
-    return s * (hfsq + r) + (dk * ln2_lo + c) - hfsq + f + dk * ln2_hi;
-  }
-
-  export function log2(x: f32): f32 { // see: musl/src/math/log2f.c and SUN COPYRIGHT NOTICE above
-    if (ASC_SHRINK_LEVEL < 1) {
-      return log2f_lut(x);
-    } else {
-      const
-        ivln2hi = reinterpret<f32>(0x3FB8B000), //  1.4428710938e+00f
-        ivln2lo = reinterpret<f32>(0xB9389AD4), // -1.7605285393e-04
-        Lg1     = reinterpret<f32>(0x3F2AAAAA), //  0xaaaaaa.0p-24f, 0.66666662693f
-        Lg2     = reinterpret<f32>(0x3ECCCE13), //  0xccce13.0p-25f, 0.40000972152f
-        Lg3     = reinterpret<f32>(0x3E91E9EE), //  0x91e9ee.0p-25f, 0.28498786688f
-        Lg4     = reinterpret<f32>(0x3E789E26), //  0xf89e26.0p-26f, 0.24279078841f
-        Ox1p25f = reinterpret<f32>(0x4C000000); //  0x1p25f
-
-      let ix = reinterpret<u32>(x);
-      let k: i32 = 0;
-      if (ix < 0x00800000 || <bool>(ix >> 31)) {
-        if (ix << 1 == 0) return -1 / (x * x);
-        if (ix >> 31) return (x - x) / 0.0;
-        k -= 25;
-        x *= Ox1p25f;
-        ix = reinterpret<u32>(x);
-      } else if (ix >= 0x7F800000) {
-        return x;
-      } else if (ix == 0x3F800000) {
-        return 0;
-      }
-      ix += 0x3F800000 - 0x3F3504F3;
-      k += <i32>(ix >> 23) - 0x7F;
-      ix = (ix & 0x007FFFFF) + 0x3F3504F3;
-      x = reinterpret<f32>(ix);
-      let f = x - 1.0;
-      let s = f / (2.0 + f);
-      let z = s * s;
-      let w = z * z;
-      let t1 = w * (Lg2 + w * Lg4);
-      let t2 = z * (Lg1 + w * Lg3);
-      let r = t2 + t1;
-      let hfsq: f32 = 0.5 * f * f;
-      let hi = f - hfsq;
-      let u = reinterpret<u32>(hi);
-      u &= 0xFFFFF000;
-      hi = reinterpret<f32>(u);
-      let lo: f32 = f - hi - hfsq + s * (hfsq + r);
-      let dk = <f32>k;
-      return (lo + hi) * ivln2lo + lo * ivln2hi + hi * ivln2hi + dk;
+      return ERROR("Math.round accept only numeric types");
     }
   }
 
   // @ts-ignore: decorator
   @inline
-  export function max(value1: f32, value2: f32): f32 {
-    return builtin_max<f32>(value1, value2);
-  }
-
-  // @ts-ignore: decorator
-  @inline
-  export function min(value1: f32, value2: f32): f32 {
-    return builtin_min<f32>(value1, value2);
-  }
-
-  export function pow(x: f32, y: f32): f32 {
-    // TODO: remove this fast pathes after introduced own mid-end IR with "stdlib call simplify" transforms
-    if (builtin_abs<f32>(y) <= 2) {
-      if (y == 2.0) return x * x;
-      if (y == 0.5) {
-        return select<f32>(
-          builtin_abs<f32>(builtin_sqrt<f32>(x)),
-          Infinity,
-          x != -Infinity
-        );
-      }
-      if (y == -1.0) return 1 / x;
-      if (y == 1.0) return x;
-      if (y == 0.0) return 1.0;
-    }
-    if (ASC_SHRINK_LEVEL < 1) {
-      // see: musl/src/math/powf.c
-      return powf_lut(x, y);
-    } else {
-      // based on:  jdh8/metallic/src/math/float/powf.c
-      if (y == 0) return 1;
-      // @ts-ignore: cast
-      if (isNaN(x) | isNaN(y)) {
-        return NaN;
-      }
-      let sign: u32 = 0;
-      let uy = reinterpret<u32>(y);
-      let ux = reinterpret<u32>(x);
-      let sx = ux >> 31;
-      ux &= 0x7FFFFFFF;
-      if (sx && nearest(y) == y) {
-        x = -x;
-        sx = 0;
-        sign = u32(nearest(y * 0.5) != y * 0.5) << 31;
-      }
-      let m: u32;
-      if (ux == 0x3F800000) { // x == 1
-        m = sx | u32((uy & 0x7FFFFFFF) == 0x7F800000) ? 0x7FC00000 : 0x3F800000;
-      } else if (ux == 0) {
-        m = uy >> 31 ? 0x7F800000 : 0;
-      } else if (ux == 0x7F800000) {
-        m = uy >> 31 ? 0 : 0x7F800000;
-      } else if (sx) {
-        m = 0x7FC00000;
+  export function sign<T extends number = f64>(x: T): T {
+    if (isInteger<T>()) {
+      if (isSigned<T>()) {
+        return <T>(x ? (x >> sizeof<T>() * 8 - 1) | 1 : 0);
       } else {
-        m = reinterpret<u32>(<f32>exp2f(<f64>y * log2f(x)));
+        return <T>(x ? 1 : 0);
       }
-      return reinterpret<f32>(m | sign);
+    } else if (isFloat<T>()) {
+      if (ASC_SHRINK_LEVEL > 0) {
+        return builtin_abs<T>(x) > 0 ? builtin_copysign<T>(<T>1, x) : x;
+      } else {
+        return <T>(x > 0 ? 1 : x < 0 ? -1 : x);
+      }
+    } else {
+      return ERROR("Math.sign accept only numeric types");
     }
   }
 
   // @ts-ignore: decorator
   @inline
-  export function seedRandom(value: i64): void {
-    NativeMath.seedRandom(value);
-  }
-
-  // Using xoroshiro64starstar from http://xoshiro.di.unimi.it/xoroshiro64starstar.c
-  export function random(): f32 {
-    if (!random_seeded) seedRandom(reinterpret<i64>(seed()));
-
-    var s0 = random_state0_32;
-    var s1 = random_state1_32;
-    var r  = rotl<u32>(s0 * 0x9E3779BB, 5) * 5;
-
-    s1 ^= s0;
-    random_state0_32 = rotl<u32>(s0, 26) ^ s1 ^ (s1 << 9);
-    random_state1_32 = rotl<u32>(s1, 13);
-
-    return reinterpret<f32>((r >> 9) | (127 << 23)) - 1.0;
-  }
-
-  // @ts-ignore: decorator
-  @inline
-  export function round(x: f32): f32 {
-    let roundUp = builtin_ceil<f32>(x);
-    return select<f32>(roundUp, roundUp - 1.0, roundUp - 0.5 <= x);
+  export function signbit<T extends number = f64>(x: T): bool {
+    if (isInteger<T>()) {
+      if (isSigned<T>()) {
+        return <bool>(x >>> sizeof<T>() * 8 - 1);
+      } else {
+        return false;
+      }
+    } else if (isFloat<T>()) {
+      if (sizeof<T>() == 4) {
+        return <bool>(reinterpret<u32>(x) >>> 31);
+      }
+      if (sizeof<T>() == 8) {
+        return <bool>(reinterpret<u64>(x) >>> 63);
+      }
+    }
+    return ERROR("Math.signbit accept only numeric types");
   }
 
   // @ts-ignore: decorator
   @inline
-  export function sign(x: f32): f32 {
-    if (ASC_SHRINK_LEVEL > 0) {
-      return builtin_abs(x) > 0 ? builtin_copysign<f32>(1, x) : x;
+  export function sin<T extends number = f64>(x: T): T {
+    if (isFloat<T>()) {
+      if (sizeof<T>() == 4) {
+        return <T>sin32(x);
+      }
+      if (sizeof<T>() == 8) {
+        return <T>sin64(x);
+      }
+    }
+    return ERROR("Math.sin accept only f32 or f64 types");
+  }
+
+  // @ts-ignore: decorator
+  @inline
+  export function sinh<T extends number = f64>(x: T): T {
+    if (isFloat<T>()) {
+      if (sizeof<T>() == 4) {
+        return <T>sinh32(x);
+      }
+      if (sizeof<T>() == 8) {
+        return <T>sinh64(x);
+      }
+    }
+    return ERROR("Math.sinh accept only f32 or f64 types");
+  }
+
+  // @ts-ignore: decorator
+  @inline
+  export function sqrt<T extends number = f64>(x: T): T {
+    if (isFloat<T>()) {
+      return builtin_sqrt<T>(x);
     } else {
-      return x > 0 ? 1 : x < 0 ? -1 : x;
+      return ERROR("Math.sqrt accept only f32 or f64 types");
     }
   }
 
   // @ts-ignore: decorator
   @inline
-  export function signbit(x: f32): bool {
-    return <bool>(reinterpret<u32>(x) >>> 31);
-  }
-
-  export function sin(x: f32): f32 { // see: musl/src/math/sinf.c
-    const
-      s1pio2 = reinterpret<f64>(0x3FF921FB54442D18), // M_PI_2 * 1
-      s2pio2 = reinterpret<f64>(0x400921FB54442D18), // M_PI_2 * 2
-      s3pio2 = reinterpret<f64>(0x4012D97C7F3321D2), // M_PI_2 * 3
-      s4pio2 = reinterpret<f64>(0x401921FB54442D18); // M_PI_2 * 4
-
-    var ix = reinterpret<u32>(x);
-    var sign = ix >> 31;
-    ix &= 0x7FFFFFFF;
-
-    if (ix <= 0x3F490FDA) {  // |x| ~<= π/4
-      if (ix < 0x39800000) { // |x| < 2**-12
-        return x;
+  export function tan<T extends number = f64>(x: T): T {
+    if (isFloat<T>()) {
+      if (sizeof<T>() == 4) {
+        return <T>tan32(x);
       }
-      return sin_kernf(x);
-    }
-
-    if (ASC_SHRINK_LEVEL < 1) {
-      if (ix <= 0x407B53D1) {   // |x| ~<= 5π/4
-        if (ix <= 0x4016CBE3) { // |x| ~<= 3π/4
-          return sign ? -cos_kernf(x + s1pio2) : cos_kernf(x - s1pio2);
-        }
-        return sin_kernf(-(sign ? x + s2pio2 : x - s2pio2));
-      }
-
-      if (ix <= 0x40E231D5) {   // |x| ~<= 9π/4
-        if (ix <= 0x40AFEDDF) { // |x| ~<= 7π/4
-          return sign ? cos_kernf(x + s3pio2) : -cos_kernf(x - s3pio2);
-        }
-        return sin_kernf(sign ? x + s4pio2 : x - s4pio2);
+      if (sizeof<T>() == 8) {
+        return <T>tan64(x);
       }
     }
-
-    // sin(Inf or NaN) is NaN
-    if (ix >= 0x7F800000) return x - x;
-
-    var n = rempio2f(x, ix, sign);
-    var y = rempio2f_y;
-
-    var t = n & 1 ? cos_kernf(y) : sin_kernf(y);
-    return n & 2 ? -t : t;
-  }
-
-  export function sinh(x: f32): f32 { // see: musl/src/math/sinhf.c
-    var u = reinterpret<u32>(x) & 0x7FFFFFFF;
-    var a = reinterpret<f32>(u);
-    var h = builtin_copysign<f32>(0.5, x);
-    if (u < 0x42B17217) {
-      let t = expm1(a);
-      if (u < 0x3F800000) {
-        if (u < 0x3F800000 - (12 << 23)) return x;
-        return h * (2 * t - t * t / (t + 1));
-      }
-      return h * (t + t / (t + 1));
-    }
-    return expo2f(a, 2 * h);
+    return ERROR("Math.tan accept only f32 or f64 types");
   }
 
   // @ts-ignore: decorator
   @inline
-  export function sqrt(x: f32): f32 {
-    return builtin_sqrt<f32>(x);
-  }
-
-  export function tan(x: f32): f32 { // see: musl/src/math/tanf.c
-    const
-      t1pio2 = reinterpret<f64>(0x3FF921FB54442D18), // 1 * M_PI_2
-      t2pio2 = reinterpret<f64>(0x400921FB54442D18), // 2 * M_PI_2
-      t3pio2 = reinterpret<f64>(0x4012D97C7F3321D2), // 3 * M_PI_2
-      t4pio2 = reinterpret<f64>(0x401921FB54442D18); // 4 * M_PI_2
-
-    var ix = reinterpret<u32>(x);
-    var sign = ix >> 31;
-    ix &= 0x7FFFFFFF;
-
-    if (ix <= 0x3F490FDA) {  // |x| ~<= π/4
-      if (ix < 0x39800000) { // |x| < 2**-12
-        return x;
+  export function tanh<T extends number = f64>(x: T): T {
+    if (isFloat<T>()) {
+      if (sizeof<T>() == 4) {
+        return <T>tanh32(x);
       }
-      return tan_kernf(x, 0);
-    }
-
-    if (ASC_SHRINK_LEVEL < 1) {
-      if (ix <= 0x407B53D1) {   // |x| ~<= 5π/4
-        if (ix <= 0x4016CBE3) { // |x| ~<= 3π/4
-          return tan_kernf((sign ? x + t1pio2 : x - t1pio2), 1);
-        } else {
-          return tan_kernf((sign ? x + t2pio2 : x - t2pio2), 0);
-        }
-      }
-      if (ix <= 0x40E231D5) {   // |x| ~<= 9π/4
-        if (ix <= 0x40AFEDDF) { // |x| ~<= 7π/4
-          return tan_kernf((sign ? x + t3pio2 : x - t3pio2), 1);
-        } else {
-          return tan_kernf((sign ? x + t4pio2 : x - t4pio2), 0);
-        }
+      if (sizeof<T>() == 8) {
+        return <T>tanh64(x);
       }
     }
-
-    // tan(Inf or NaN) is NaN
-    if (ix >= 0x7F800000) return x - x;
-
-    // argument reduction
-    var n = rempio2f(x, ix, sign);
-    var y = rempio2f_y;
-    return tan_kernf(y, n & 1);
-  }
-
-  export function tanh(x: f32): f32 { // see: musl/src/math/tanhf.c
-    var u = reinterpret<u32>(x);
-    u &= 0x7FFFFFFF;
-    var y = reinterpret<f32>(u);
-    var t: f32;
-    if (u > 0x3F0C9F54) {
-      if (u > 0x41200000) t = 1 + 0 / y;
-      else {
-        t = expm1(2 * y);
-        t = 1 - 2 / (t + 2);
-      }
-    } else if (u > 0x3E82C578) {
-      t = expm1(2 * y);
-      t = t / (t + 2);
-    } else if (u >= 0x00800000) {
-      t = expm1(-2 * y);
-      t = -t / (t + 2);
-    } else t = y;
-    return builtin_copysign<f32>(t, x);
+    return ERROR("Math.tanh accept only f32 or f64 types");
   }
 
   // @ts-ignore: decorator
   @inline
-  export function trunc(x: f32): f32 {
-    return builtin_trunc<f32>(x);
+  export function trunc<T extends number = f64>(x: T): T {
+    if (isInteger<T>()) {
+      return x;
+    } else if (isFloat<T>()) {
+      return builtin_trunc<T>(x);
+    } else {
+      return ERROR("Math.trunc accept only numeric types");
+    }
   }
 
-  export function scalbn(x: f32, n: i32): f32 { // see: https://git.musl-libc.org/cgit/musl/tree/src/math/scalbnf.c
-    const
-      Ox1p24f   = reinterpret<f32>(0x4B800000),
-      Ox1p127f  = reinterpret<f32>(0x7F000000),
-      Ox1p_126f = reinterpret<f32>(0x00800000);
-
-    var y = x;
-    if (n > 127) {
-      y *= Ox1p127f;
-      n -= 127;
-      if (n > 127) {
-        y *= Ox1p127f;
-        n = builtin_min<i32>(n - 127, 127);
+  // @ts-ignore: decorator
+  @inline
+  export function mod<T extends number = f64>(x: T, y: T): T {
+    if (isInteger<T>()) {
+      return <T>(x % y);
+    } else if (isFloat<T>()) {
+      if (sizeof<T>() == 4) {
+        return <T>mod32(x, y);
       }
-    } else if (n < -126) {
-      y *= Ox1p_126f * Ox1p24f;
-      n += 126 - 24;
-      if (n < -126) {
-        y *= Ox1p_126f * Ox1p24f;
-        n = builtin_max<i32>(n + 126 - 24, -126);
+      if (sizeof<T>() == 8) {
+        return <T>mod64(x, y);
       }
     }
-    return y * reinterpret<f32>(<u32>(0x7F + n) << 23);
+    return ERROR("Math.mod accept only numeric types");
   }
 
-  export function mod(x: f32, y: f32): f32 { // see: musl/src/math/fmodf.c
-    if (builtin_abs<f32>(y) == 1.0) {
-      // x % 1, x % -1  ==>  sign(x) * abs(x - 1.0 * trunc(x / 1.0))
-      // TODO: move this rule to compiler's optimization pass.
-      // It could be apply for any x % C_pot, where "C_pot" is pow of two const.
-      return builtin_copysign<f32>(x - builtin_trunc<f32>(x), x);
-    }
-    var ux = reinterpret<u32>(x);
-    var uy = reinterpret<u32>(y);
-    var ex = <i32>(ux >> 23 & 0xFF);
-    var ey = <i32>(uy >> 23 & 0xFF);
-    var sm = ux & 0x80000000;
-    var uy1 = uy << 1;
-    if (uy1 == 0 || ex == 0xFF || isNaN<f32>(y)) {
-      let m = x * y;
-      return m / m;
-    }
-    var ux1 = ux << 1;
-    if (ux1 <= uy1) {
-      return x * f32(ux1 != uy1);
-    }
-    if (!ex) {
-      ex -= builtin_clz<u32>(ux << 9);
-      ux <<= 1 - ex;
+  // @ts-ignore: decorator
+  @inline
+  export function sincos<T extends number = f64>(x: T): void {
+    if (isFloat<T>()) {
+      if (sizeof<T>() == 4) {
+        sincos_sin = <f64>sincos32(x);
+        sincos_cos = <f64>sincos_cos32;
+      } else if (sizeof<T>() == 8) {
+        sincos_sin = sincos64(x);
+        sincos_cos = sincos_cos64;
+      } else {
+        ERROR("Math.sincos accept only f32 or f64 types");
+      }
     } else {
-      ux &= <u32>-1 >> 9;
-      ux |= 1 << 23;
+      ERROR("Math.sincos accept only f32 or f64 types");
     }
-    if (!ey) {
-      ey -= builtin_clz<u32>(uy << 9);
-      uy <<= 1 - ey;
-    } else {
-      uy &= <u32>-1 >> 9;
-      uy |= 1 << 23;
-    }
-    while (ex > ey) {
-      if (ux >= uy) {
-        if (ux == uy) return 0 * x;
-        ux -= uy;
-      }
-      ux <<= 1;
-      --ex;
-    }
-    if (ux >= uy) {
-      if (ux == uy) return 0 * x;
-      ux -= uy;
-    }
-    // for (; !(ux >> 23); ux <<= 1) --ex;
-    var shift = <i32>builtin_clz<u32>(ux << 8);
-    ex -= shift;
-    ux <<= shift;
-    if (ex > 0) {
-      ux -= 1 << 23;
-      ux |= <u32>ex << 23;
-    } else {
-      ux >>= -ex + 1;
-    }
-    return reinterpret<f32>(ux | sm);
-  }
-
-  export function rem(x: f32, y: f32): f32 { // see: musl/src/math/remquof.c
-    var ux = reinterpret<u32>(x);
-    var uy = reinterpret<u32>(y);
-    var ex = <i32>(ux >> 23 & 0xFF);
-    var ey = <i32>(uy >> 23 & 0xFF);
-    var sx = <i32>(ux >> 31);
-    var uxi = ux;
-    if (uy << 1 == 0 || ex == 0xFF || isNaN(y)) return (x * y) / (x * y);
-    if (ux << 1 == 0) return x;
-    if (!ex) {
-      ex -= builtin_clz<u32>(uxi << 9);
-      uxi <<= 1 - ex;
-    } else {
-      uxi &= <u32>-1 >> 9;
-      uxi |= 1 << 23;
-    }
-    if (!ey) {
-      ey -= builtin_clz<u32>(uy << 9);
-      uy <<= 1 - ey;
-    } else {
-      uy &= <u32>-1 >> 9;
-      uy |= 1 << 23;
-    }
-    var q = 0;
-    do {
-      if (ex < ey) {
-        if (ex + 1 == ey) break; // goto end
-        return x;
-      }
-      while (ex > ey) {
-        if (uxi >= uy) {
-          uxi -= uy;
-          ++q;
-        }
-        uxi <<= 1;
-        q <<= 1;
-        --ex;
-      }
-      if (uxi >= uy) {
-        uxi -= uy;
-        ++q;
-      }
-      if (uxi == 0) ex = -30;
-      else {
-        let shift = builtin_clz<i32>(uxi << 8);
-        ex -= shift;
-        uxi <<= shift;
-      }
-      break;
-    } while (false);
-    // end:
-    if (ex > 0) {
-      uxi -= 1 << 23;
-      uxi |= <u32>ex << 23;
-    } else {
-      uxi >>= -ex + 1;
-    }
-    x = reinterpret<f32>(uxi);
-    y = builtin_abs<f32>(y);
-    var x2 = x + x;
-    if (ex == ey || (ex + 1 == ey && (<f32>x2 > y || (<f32>x2 == y && <bool>(q & 1))))) {
-      x -= y;
-      // q++;
-    }
-    return sx ? -x : x;
-  }
-
-  export function sincos(x: f32): void { // see: musl/tree/src/math/sincosf.c
-    const
-      s1pio2 = reinterpret<f64>(0x3FF921FB54442D18), // 1 * M_PI_2
-      s2pio2 = reinterpret<f64>(0x400921FB54442D18), // 2 * M_PI_2
-      s3pio2 = reinterpret<f64>(0x4012D97C7F3321D2), // 3 * M_PI_2
-      s4pio2 = reinterpret<f64>(0x401921FB54442D18); // 4 * M_PI_2
-
-    var ix = reinterpret<u32>(x);
-    var sign = ix >> 31;
-    ix &= 0x7FFFFFFF;
-
-    if (ix <= 0x3F490FDA) {  // |x| ~<= π/4
-      if (ix < 0x39800000) { // |x| < 2**-12
-        sincos_sin = x;
-        sincos_cos = 1;
-        return;
-      }
-      sincos_sin = sin_kernf(x);
-      sincos_cos = cos_kernf(x);
-      return;
-    }
-    if (ASC_SHRINK_LEVEL < 1) {
-      if (ix <= 0x407B53D1) {   // |x| ~<= 5π/4
-        if (ix <= 0x4016CBE3) { // |x| ~<= 3π/4
-          if (sign) {
-            sincos_sin = -cos_kernf(x + s1pio2);
-            sincos_cos =  sin_kernf(x + s1pio2);
-          } else {
-            sincos_sin = cos_kernf(s1pio2 - x);
-            sincos_cos = sin_kernf(s1pio2 - x);
-          }
-          return;
-        }
-        // -sin(x + c) is not correct if x+c could be 0: -0 vs +0
-        sincos_sin = -sin_kernf(sign ? x + s2pio2 : x - s2pio2);
-        sincos_cos = -cos_kernf(sign ? x + s2pio2 : x - s2pio2);
-        return;
-      }
-      if (ix <= 0x40E231D5) {   // |x| ~<= 9π/4
-        if (ix <= 0x40AFEDDF) { // |x| ~<= 7π/4
-          if (sign) {
-            sincos_sin =  cos_kernf(x + s3pio2);
-            sincos_cos = -sin_kernf(x + s3pio2);
-          } else {
-            sincos_sin = -cos_kernf(x - s3pio2);
-            sincos_cos =  sin_kernf(x - s3pio2);
-          }
-          return;
-        }
-        sincos_sin = sin_kernf(sign ? x + s4pio2 : x - s4pio2);
-        sincos_cos = cos_kernf(sign ? x + s4pio2 : x - s4pio2);
-        return;
-      }
-    }
-    // sin(Inf or NaN) is NaN
-    if (ix >= 0x7F800000) {
-      let xx = x - x;
-      sincos_sin = xx;
-      sincos_cos = xx;
-      return;
-    }
-    // general argument reduction needed
-    var n = rempio2f(x, ix, sign);
-    var y = rempio2f_y;
-    var s = sin_kernf(y);
-    var c = cos_kernf(y);
-    var sin = s, cos = c;
-    if (n & 1) {
-      sin =  c;
-      cos = -s;
-    }
-    if (n & 2) {
-      sin = -sin;
-      cos = -cos;
-    }
-    sincos_sin = sin;
-    sincos_cos = cos;
   }
 }
-
-export function ipow32(x: i32, e: i32): i32 {
-  var out = 1;
-  if (ASC_SHRINK_LEVEL < 1) {
-    if (x == 2) {
-      return select<i32>(1 << e, 0, <u32>e < 32);
-    }
-    if (e <= 0) {
-      if (x == -1) return select<i32>(-1, 1, e & 1);
-      return i32(e == 0) | i32(x == 1);
-    }
-    else if (e == 1) return x;
-    else if (e == 2) return x * x;
-    else if (e < 32) {
-      let log = 32 - clz(e);
-      // 32 = 2 ^ 5, so need only five cases.
-      // But some extra cases needs for properly overflowing
-      switch (log) {
-        case 5: {
-          if (e & 1) out *= x;
-          e >>>= 1;
-          x *= x;
-        }
-        case 4: {
-          if (e & 1) out *= x;
-          e >>>= 1;
-          x *= x;
-        }
-        case 3: {
-          if (e & 1) out *= x;
-          e >>>= 1;
-          x *= x;
-        }
-        case 2: {
-          if (e & 1) out *= x;
-          e >>>= 1;
-          x *= x;
-        }
-        case 1: {
-          if (e & 1) out *= x;
-        }
-      }
-      return out;
-    }
-  }
-  while (e) {
-    if (e & 1) out *= x;
-    e >>>= 1;
-    x *= x;
-  }
-  return out;
-}
-
-export function ipow64(x: i64, e: i64): i64 {
-  var out: i64 = 1;
-  if (ASC_SHRINK_LEVEL < 1) {
-    if (x == 2) {
-      return select<i64>(1 << e, 0, <u64>e < 64);
-    }
-    if (e <= 0) {
-      if (x == -1) return select<i64>(-1, 1, e & 1);
-      return i64(e == 0) | i64(x == 1);
-    }
-    else if (e == 1) return x;
-    else if (e == 2) return x * x;
-    else if (e < 64) {
-      let log = 64 - <i32>clz(e);
-      // 64 = 2 ^ 6, so need only six cases.
-      // But some extra cases needs for properly overflowing
-      switch (log) {
-        case 6: {
-          if (e & 1) out *= x;
-          e >>>= 1;
-          x *= x;
-        }
-        case 5: {
-          if (e & 1) out *= x;
-          e >>>= 1;
-          x *= x;
-        }
-        case 4: {
-          if (e & 1) out *= x;
-          e >>>= 1;
-          x *= x;
-        }
-        case 3: {
-          if (e & 1) out *= x;
-          e >>>= 1;
-          x *= x;
-        }
-        case 2: {
-          if (e & 1) out *= x;
-          e >>>= 1;
-          x *= x;
-        }
-        case 1: {
-          if (e & 1) out *= x;
-        }
-      }
-      return out;
-    }
-  }
-  while (e) {
-    if (e & 1) out *= x;
-    e >>>= 1;
-    x *= x;
-  }
-  return out;
-}
-
-/*
-TODO:
-In compile time if only exponent is constant we could replace ipow32/ipow64 by shortest addition chains
-which usually faster than exponentiation by squaring
-
-for ipow32 and e < 32:
-
-let b: i32, c: i32, d: i32, h: i32, k: i32, g: i32;
-switch (e) {
-  case  1: return x;
-  case  2: return x * x;
-  case  3: return x * x * x;
-  case  4: return (b = x * x) * b;
-  case  5: return (b = x * x) * b * x;
-  case  6: return (b = x * x) * b * b;
-  case  7: return (b = x * x) * b * b * x;
-  case  8: return (d = (b = x * x) * b) * d;
-  case  9: return (c = x * x * x) * c * c;
-  case 10: return (d = (b = x * x) * b) * d * b;
-  case 11: return (d = (b = x * x) * b) * d * b * x;
-  case 12: return (d = (b = x * x) * b) * d * d;
-  case 13: return (d = (b = x * x) * b) * d * d * x;
-  case 14: return (d = (b = x * x) * b) * d * d * b;
-  case 15: return (k = (b = x * x) * b * x) * k * k;
-  case 16: return (h = (d = (b = x * x) * b) * d) * h;
-  case 17: return (h = (d = (b = x * x) * b) * d) * h * x;
-  case 18: return (h = (d = (b = x * x) * b) * d * x) * h;
-  case 19: return (h = (d = (b = x * x) * b) * d * x) * h * x;
-  case 20: return (h = (k = (b = x * x) * b * x) * k) * h;
-  case 21: return (h = (k = (b = x * x) * b * x) * k) * h * x;
-  case 22: return (g = (h = (k = (b = x * x) * b * x) * k) * x) * g;
-  case 23: return (h = (d = (c = (b = x * x) * x) * b) * d) * h * c;
-  case 24: return (h = (d = (c = x * x * x) * c) * d) * h;
-  case 25: return (h = (d = (c = x * x * x) * c) * d) * h * x;
-  case 26: return (g = (h = (d = (c = x * x * x) * c) * d) * x) * g;
-  case 27: return (h = (d = (c = x * x * x) * c) * d) * h * c;
-  case 28: return (h = (d = (c = x * x * x) * c * x) * d) * h;
-  case 29: return (h = (d = (c = x * x * x) * c * x) * d) * h * x;
-  case 30: return (h = (d = (c = x * x * x) * c) * d * c) * h;
-  case 31: return (h = (d = (c = x * x * x) * c) * d * c) * h * x;
-}
-
-for ipow64: TODO
-switch (e) {
-  case 32:
-  ...
-  case 63:
-}
-*/

--- a/std/assembly/util/math.ts
+++ b/std/assembly/util/math.ts
@@ -1,12 +1,33 @@
-//
+// Lookup data for pio2f_large_quot
+
+// @ts-ignore: decorator
+@lazy @inline
+const PIO2_TABLE32 = memory.data<u64>([
+  0xA2F9836E4E441529,
+  0xFC2757D1F534DDC0,
+  0xDB6295993C439041,
+  0xFE5163ABDEBBC561
+]);
+
+// Lookup data for pio2_large_quot
+
+/** @internal */
+// @ts-ignore: decorator
+@lazy @inline
+const PIO2_TABLE64 = memory.data<u64>([
+  0x00000000A2F9836E, 0x4E441529FC2757D1, 0xF534DDC0DB629599, 0x3C439041FE5163AB,
+  0xDEBBC561B7246E3A, 0x424DD2E006492EEA, 0x09D1921CFE1DEB1C, 0xB129A73EE88235F5,
+  0x2EBB4484E99C7026, 0xB45F7E413991D639, 0x835339F49C845F8B, 0xBDF9283B1FF897FF,
+  0xDE05980FEF2F118B, 0x5A0A6D1F6D367ECF, 0x27CB09B74F463F66, 0x9E5FEA2D7527BAC7,
+  0xEBE5F17B3D0739F7, 0x8A5292EA6BFB5FB1, 0x1F8D5D0856033046, 0xFC7B6BABF0CFBC20,
+  0x9AF4361DA9E39161, 0x5EE61B086599855F, 0x14A068408DFFD880, 0x4D73273106061557
+]);
+
 // Lookup data for exp2f
-//
 
 // @ts-ignore: decorator
-@inline const EXP2F_TABLE_BITS = 5;
-
-// @ts-ignore: decorator
-@lazy @inline const EXP2F_DATA_TAB = memory.data<u64>([
+@lazy @inline
+const EXP2_TABLE32 = memory.data<u64>([
   // exp2f_data_tab[i] = uint(2^(i/N)) - (i << 52-BITS)
   // used for computing 2^(k/N) for an int |k| < 150 N as
   // double(tab[k%N] + (k << 52-BITS))
@@ -20,445 +41,69 @@
   0x3FEF5818DCFBA487, 0x3FEF7C97337B9B5F, 0x3FEFA4AFA2A490DA, 0x3FEFD0765B6E4540
 ]);
 
-// ULP error: 0.502 (nearest rounding.)
-// Relative error: 1.69 * 2^-34 in [-1/64, 1/64] (before rounding.)
-// Wrong count: 168353 (all nearest rounding wrong results with fma.)
 // @ts-ignore: decorator
 @inline
-export function exp2f_lut(x: f32): f32 {
-  const
-    N      = 1 << EXP2F_TABLE_BITS,
-    N_MASK = N - 1,
-    shift  = reinterpret<f64>(0x4338000000000000) / N, // 0x1.8p+52
-    Ox127f = reinterpret<f32>(0x7F000000);
+const EXP2_TABLE32_BITS = 5;
 
-  const
-    C0 = reinterpret<f64>(0x3FAC6AF84B912394), // 0x1.c6af84b912394p-5
-    C1 = reinterpret<f64>(0x3FCEBFCE50FAC4F3), // 0x1.ebfce50fac4f3p-3
-    C2 = reinterpret<f64>(0x3FE62E42FF0C52D6); // 0x1.62e42ff0c52d6p-1
-
-  var xd = <f64>x;
-  var ix = reinterpret<u32>(x);
-  var ux = ix >> 20 & 0x7FF;
-  if (ux >= 0x430) {
-    // |x| >= 128 or x is nan.
-    if (ix == 0xFF800000) return 0; // x == -Inf    -> 0
-    if (ux >= 0x7F8) return x + x;  // x == Inf/NaN -> Inf/NaN
-    if (x > 0) return x * Ox127f;   // x >     0    -> HugeVal (Owerflow)
-    if (x <= -150) return 0;        // x <= -150    -> 0 (Underflow)
-  }
-
-  // x = k/N + r with r in [-1/(2N), 1/(2N)] and int k.
-  var kd = xd + shift;
-  var ki = reinterpret<u64>(kd);
-  var r  = xd - (kd - shift);
-  var t: u64, y: f64, s: f64;
-
-  // exp2(x) = 2^(k/N) * 2^r ~= s * (C0*r^3 + C1*r^2 + C2*r + 1)
-  t  = load<u64>(EXP2F_DATA_TAB + ((<usize>ki & N_MASK) << alignof<u64>()));
-  t += ki << (52 - EXP2F_TABLE_BITS);
-  s  = reinterpret<f64>(t);
-  y  = C2 * r + 1;
-  y += (C0 * r + C1) * (r  * r);
-  y *= s;
-
-  return <f32>y;
-}
-
-// ULP error: 0.502 (nearest rounding.)
-// Relative error: 1.69 * 2^-34 in [-ln2/64, ln2/64] (before rounding.)
-// Wrong count: 170635 (all nearest rounding wrong results with fma.)
-// @ts-ignore: decorator
-@inline
-export function expf_lut(x: f32): f32 {
-  const
-    N        = 1 << EXP2F_TABLE_BITS,
-    N_MASK   = N - 1,
-    shift    = reinterpret<f64>(0x4338000000000000),        // 0x1.8p+52
-    InvLn2N  = reinterpret<f64>(0x3FF71547652B82FE) * N,    // 0x1.71547652b82fep+0
-    Ox1p127f = reinterpret<f32>(0x7F000000);
-
-  const
-    C0 = reinterpret<f64>(0x3FAC6AF84B912394) / N / N / N, // 0x1.c6af84b912394p-5
-    C1 = reinterpret<f64>(0x3FCEBFCE50FAC4F3) / N / N,     // 0x1.ebfce50fac4f3p-3
-    C2 = reinterpret<f64>(0x3FE62E42FF0C52D6) / N;         // 0x1.62e42ff0c52d6p-1
-
-  var xd = <f64>x;
-  var ix = reinterpret<u32>(x);
-  var ux = ix >> 20 & 0x7FF;
-  if (ux >= 0x42B) {
-    // |x| >= 88 or x is nan.
-    if (ix == 0xFF800000) return 0;                            // x == -Inf    -> 0
-    if (ux >= 0x7F8) return x + x;                             // x == Inf/NaN -> Inf/NaN
-    if (x > reinterpret<f32>(0x42B17217)) return x * Ox1p127f; // x > log(0x1p128)  ~=  88.72 -> HugeVal (Owerflow)
-    if (x < reinterpret<f32>(0xC2CFF1B4)) return 0;            // x < log(0x1p-150) ~= -103.97 -> 0 (Underflow)
-  }
-
-  // x*N/Ln2 = k + r with r in [-1/2, 1/2] and int k.
-  var z = InvLn2N * xd;
-
-  // Round and convert z to int, the result is in [-150*N, 128*N] and
-  // ideally ties-to-even rule is used, otherwise the magnitude of r
-  // can be bigger which gives larger approximation error.
-  var kd = <f64>(z + shift);
-  var ki = reinterpret<u64>(kd);
-  var r  = z - (kd - shift);
-  var s: f64, y: f64, t: u64;
-
-  // exp(x) = 2^(k/N) * 2^(r/N) ~= s * (C0*r^3 + C1*r^2 + C2*r + 1)
-  t  = load<u64>(EXP2F_DATA_TAB + ((<usize>ki & N_MASK) << alignof<u64>()));
-  t += ki << (52 - EXP2F_TABLE_BITS);
-  s  = reinterpret<f64>(t);
-  z  = C0 * r + C1;
-  y  = C2 * r + 1;
-  y += z * (r * r);
-  y *= s;
-
-  return <f32>y;
-}
-
-//
 // Lookup data for log2f
-//
 
 // @ts-ignore: decorator
-@inline const LOG2F_TABLE_BITS = 4;
-
-// @ts-ignore: decorator
-@lazy @inline const LOG2F_DATA_TAB = memory.data<f64>([
-  reinterpret<f64>(0x3FF661EC79F8F3BE), reinterpret<f64>(0xBFDEFEC65B963019), // 0x1.661ec79f8f3bep+0, -0x1.efec65b963019p-2,
-  reinterpret<f64>(0x3FF571ED4AAF883D), reinterpret<f64>(0xBFDB0B6832D4FCA4), // 0x1.571ed4aaf883dp+0, -0x1.b0b6832d4fca4p-2,
-  reinterpret<f64>(0x3FF49539F0F010B0), reinterpret<f64>(0xBFD7418B0A1FB77B), // 0x1.49539f0f010bp+0 , -0x1.7418b0a1fb77bp-2,
-  reinterpret<f64>(0x3FF3C995B0B80385), reinterpret<f64>(0xBFD39DE91A6DCF7B), // 0x1.3c995b0b80385p+0, -0x1.39de91a6dcf7bp-2,
-  reinterpret<f64>(0x3FF30D190C8864A5), reinterpret<f64>(0xBFD01D9BF3F2B631), // 0x1.30d190c8864a5p+0, -0x1.01d9bf3f2b631p-2,
-  reinterpret<f64>(0x3FF25E227B0B8EA0), reinterpret<f64>(0xBFC97C1D1B3B7AF0), // 0x1.25e227b0b8eap+0 , -0x1.97c1d1b3b7afp-3 ,
-  reinterpret<f64>(0x3FF1BB4A4A1A343F), reinterpret<f64>(0xBFC2F9E393AF3C9F), // 0x1.1bb4a4a1a343fp+0, -0x1.2f9e393af3c9fp-3,
-  reinterpret<f64>(0x3FF12358F08AE5BA), reinterpret<f64>(0xBFB960CBBF788D5C), // 0x1.12358f08ae5bap+0, -0x1.960cbbf788d5cp-4,
-  reinterpret<f64>(0x3FF0953F419900A7), reinterpret<f64>(0xBFAA6F9DB6475FCE), // 0x1.0953f419900a7p+0, -0x1.a6f9db6475fcep-5,
-  reinterpret<f64>(0x3FF0000000000000), 0,                                    // 0x1p+0,                0x0,
-  reinterpret<f64>(0x3FEE608CFD9A47AC), reinterpret<f64>(0x3FB338CA9F24F53D), // 0x1.e608cfd9a47acp-1,  0x1.338ca9f24f53dp-4,
-  reinterpret<f64>(0x3FECA4B31F026AA0), reinterpret<f64>(0x3FC476A9543891BA), // 0x1.ca4b31f026aap-1 ,  0x1.476a9543891bap-3,
-  reinterpret<f64>(0x3FEB2036576AFCE6), reinterpret<f64>(0x3FCE840B4AC4E4D2), // 0x1.b2036576afce6p-1,  0x1.e840b4ac4e4d2p-3,
-  reinterpret<f64>(0x3FE9C2D163A1AA2D), reinterpret<f64>(0x3FD40645F0C6651C), // 0x1.9c2d163a1aa2dp-1,  0x1.40645f0c6651cp-2,
-  reinterpret<f64>(0x3FE886E6037841ED), reinterpret<f64>(0x3FD88E9C2C1B9FF8), // 0x1.886e6037841edp-1,  0x1.88e9c2c1b9ff8p-2,
-  reinterpret<f64>(0x3FE767DCF5534862), reinterpret<f64>(0x3FDCE0A44EB17BCC)  // 0x1.767dcf5534862p-1,  0x1.ce0a44eb17bccp-2
+@lazy @inline
+const LOG2_TABLE32 = memory.data<u64>([
+  0x3FF661EC79F8F3BE, 0xBFDEFEC65B963019, // 0x1.661ec79f8f3bep+0, -0x1.efec65b963019p-2,
+  0x3FF571ED4AAF883D, 0xBFDB0B6832D4FCA4, // 0x1.571ed4aaf883dp+0, -0x1.b0b6832d4fca4p-2,
+  0x3FF49539F0F010B0, 0xBFD7418B0A1FB77B, // 0x1.49539f0f010bp+0 , -0x1.7418b0a1fb77bp-2,
+  0x3FF3C995B0B80385, 0xBFD39DE91A6DCF7B, // 0x1.3c995b0b80385p+0, -0x1.39de91a6dcf7bp-2,
+  0x3FF30D190C8864A5, 0xBFD01D9BF3F2B631, // 0x1.30d190c8864a5p+0, -0x1.01d9bf3f2b631p-2,
+  0x3FF25E227B0B8EA0, 0xBFC97C1D1B3B7AF0, // 0x1.25e227b0b8eap+0 , -0x1.97c1d1b3b7afp-3 ,
+  0x3FF1BB4A4A1A343F, 0xBFC2F9E393AF3C9F, // 0x1.1bb4a4a1a343fp+0, -0x1.2f9e393af3c9fp-3,
+  0x3FF12358F08AE5BA, 0xBFB960CBBF788D5C, // 0x1.12358f08ae5bap+0, -0x1.960cbbf788d5cp-4,
+  0x3FF0953F419900A7, 0xBFAA6F9DB6475FCE, // 0x1.0953f419900a7p+0, -0x1.a6f9db6475fcep-5,
+  0x3FF0000000000000, 0,                  // 0x1p+0,                0x0,
+  0x3FEE608CFD9A47AC, 0x3FB338CA9F24F53D, // 0x1.e608cfd9a47acp-1,  0x1.338ca9f24f53dp-4,
+  0x3FECA4B31F026AA0, 0x3FC476A9543891BA, // 0x1.ca4b31f026aap-1 ,  0x1.476a9543891bap-3,
+  0x3FEB2036576AFCE6, 0x3FCE840B4AC4E4D2, // 0x1.b2036576afce6p-1,  0x1.e840b4ac4e4d2p-3,
+  0x3FE9C2D163A1AA2D, 0x3FD40645F0C6651C, // 0x1.9c2d163a1aa2dp-1,  0x1.40645f0c6651cp-2,
+  0x3FE886E6037841ED, 0x3FD88E9C2C1B9FF8, // 0x1.886e6037841edp-1,  0x1.88e9c2c1b9ff8p-2,
+  0x3FE767DCF5534862, 0x3FDCE0A44EB17BCC  // 0x1.767dcf5534862p-1,  0x1.ce0a44eb17bccp-2
 ]);
 
-// ULP error: 0.752 (nearest rounding.)
-// Relative error: 1.9 * 2^-26 (before rounding.)
 // @ts-ignore: decorator
 @inline
-export function log2f_lut(x: f32): f32 {
-  const
-    N_MASK  = (1 << LOG2F_TABLE_BITS) - 1,
-    Ox1p23f = reinterpret<f32>(0x4B000000); // 0x1p23f
+const LOG2_TABLE32_BITS = 4;
 
-  const
-    A0 = reinterpret<f64>(0xBFD712B6F70A7E4D), // -0x1.712b6f70a7e4dp-2
-    A1 = reinterpret<f64>(0x3FDECABF496832E0), //  0x1.ecabf496832ep-2
-    A2 = reinterpret<f64>(0xBFE715479FFAE3DE), // -0x1.715479ffae3dep-1
-    A3 = reinterpret<f64>(0x3FF715475F35C8B8); //  0x1.715475f35c8b8p0
-
-  var ux = reinterpret<u32>(x);
-  // Fix sign of zero with downward rounding when x==1.
-  // if (WANT_ROUNDING && predict_false(ix == 0x3f800000)) return 0;
-  if (ux - 0x00800000 >= 0x7F800000 - 0x00800000) {
-    // x < 0x1p-126 or inf or nan.
-    if (ux * 2 == 0) return -Infinity;
-    if (ux == 0x7F800000) return x; // log2(inf) == inf.
-    if ((ux >> 31) || ux * 2 >= 0xFF000000) return (x - x) / (x - x);
-    // x is subnormal, normalize it.
-    ux = reinterpret<u32>(x * Ox1p23f);
-    ux -= 23 << 23;
-  }
-  // x = 2^k z; where z is in range [OFF,2*OFF] and exact.
-  // The range is split into N subintervals.
-  // The ith subinterval contains z and c is near its center.
-  var tmp  = ux - 0x3F330000;
-  var i    = (tmp >> (23 - LOG2F_TABLE_BITS)) & N_MASK;
-  var top  = tmp & 0xFF800000;
-  var iz   = ux - top;
-  var k    = <i32>tmp >> 23;
-
-  var invc = load<f64>(LOG2F_DATA_TAB + (i << (1 + alignof<f64>())), 0 << alignof<f64>());
-  var logc = load<f64>(LOG2F_DATA_TAB + (i << (1 + alignof<f64>())), 1 << alignof<f64>());
-  var z    = <f64>reinterpret<f32>(iz);
-
-  // log2(x) = log1p(z/c-1)/ln2 + log2(c) + k
-  var r  = z * invc - 1;
-  var y0 = logc + <f64>k;
-
-  // Pipelined polynomial evaluation to approximate log1p(r)/ln2.
-  var y  = A1 * r + A2;
-  var p  = A3 * r + y0;
-  var r2 = r * r;
-  y += A0 * r2;
-  y  = y * r2 + p;
-
-  return <f32>y;
-}
-
-//
 // Lookup data for logf. See: https://git.musl-libc.org/cgit/musl/tree/src/math/logf.c
-//
 
 // @ts-ignore: decorator
-@inline const LOGF_TABLE_BITS = 4;
-
-// @ts-ignore: decorator
-@lazy @inline const LOGF_DATA_TAB = memory.data<f64>([
-  reinterpret<f64>(0x3FF661EC79F8F3BE), reinterpret<f64>(0xBFD57BF7808CAADE), // 0x1.661ec79f8f3bep+0, -0x1.57bf7808caadep-2,
-  reinterpret<f64>(0x3FF571ED4AAF883D), reinterpret<f64>(0xBFD2BEF0A7C06DDB), // 0x1.571ed4aaf883dp+0, -0x1.2bef0a7c06ddbp-2,
-  reinterpret<f64>(0x3FF49539F0F010B0), reinterpret<f64>(0xBFD01EAE7F513A67), // 0x1.49539f0f010bp+0 , -0x1.01eae7f513a67p-2,
-  reinterpret<f64>(0x3FF3C995B0B80385), reinterpret<f64>(0xBFCB31D8A68224E9), // 0x1.3c995b0b80385p+0, -0x1.b31d8a68224e9p-3,
-  reinterpret<f64>(0x3FF30D190C8864A5), reinterpret<f64>(0xBFC6574F0AC07758), // 0x1.30d190c8864a5p+0, -0x1.6574f0ac07758p-3,
-  reinterpret<f64>(0x3FF25E227B0B8EA0), reinterpret<f64>(0xBFC1AA2BC79C8100), // 0x1.25e227b0b8eap+0 , -0x1.1aa2bc79c81p-3  ,
-  reinterpret<f64>(0x3FF1BB4A4A1A343F), reinterpret<f64>(0xBFBA4E76CE8C0E5E), // 0x1.1bb4a4a1a343fp+0, -0x1.a4e76ce8c0e5ep-4,
-  reinterpret<f64>(0x3FF12358F08AE5BA), reinterpret<f64>(0xBFB1973C5A611CCC), // 0x1.12358f08ae5bap+0, -0x1.1973c5a611cccp-4,
-  reinterpret<f64>(0x3FF0953F419900A7), reinterpret<f64>(0xBFA252F438E10C1E), // 0x1.0953f419900a7p+0, -0x1.252f438e10c1ep-5,
-  reinterpret<f64>(0x3FF0000000000000), 0,                                    // 0x1p+0,                0,
-  reinterpret<f64>(0x3FEE608CFD9A47AC), reinterpret<f64>(0x3FAAA5AA5DF25984), // 0x1.e608cfd9a47acp-1,  0x1.aa5aa5df25984p-5,
-  reinterpret<f64>(0x3FECA4B31F026AA0), reinterpret<f64>(0x3FBC5E53AA362EB4), // 0x1.ca4b31f026aap-1 ,  0x1.c5e53aa362eb4p-4,
-  reinterpret<f64>(0x3FEB2036576AFCE6), reinterpret<f64>(0x3FC526E57720DB08), // 0x1.b2036576afce6p-1,  0x1.526e57720db08p-3,
-  reinterpret<f64>(0x3FE9C2D163A1AA2D), reinterpret<f64>(0x3FCBC2860D224770), // 0x1.9c2d163a1aa2dp-1,  0x1.bc2860d22477p-3 ,
-  reinterpret<f64>(0x3FE886E6037841ED), reinterpret<f64>(0x3FD1058BC8A07EE1), // 0x1.886e6037841edp-1,  0x1.1058bc8a07ee1p-2,
-  reinterpret<f64>(0x3FE767DCF5534862), reinterpret<f64>(0x3FD4043057B6EE09)  // 0x1.767dcf5534862p-1,  0x1.4043057b6ee09p-2
+@lazy @inline
+const LOG_TABLE32 = memory.data<u64>([
+  0x3FF661EC79F8F3BE, 0xBFD57BF7808CAADE, // 0x1.661ec79f8f3bep+0, -0x1.57bf7808caadep-2,
+  0x3FF571ED4AAF883D, 0xBFD2BEF0A7C06DDB, // 0x1.571ed4aaf883dp+0, -0x1.2bef0a7c06ddbp-2,
+  0x3FF49539F0F010B0, 0xBFD01EAE7F513A67, // 0x1.49539f0f010bp+0 , -0x1.01eae7f513a67p-2,
+  0x3FF3C995B0B80385, 0xBFCB31D8A68224E9, // 0x1.3c995b0b80385p+0, -0x1.b31d8a68224e9p-3,
+  0x3FF30D190C8864A5, 0xBFC6574F0AC07758, // 0x1.30d190c8864a5p+0, -0x1.6574f0ac07758p-3,
+  0x3FF25E227B0B8EA0, 0xBFC1AA2BC79C8100, // 0x1.25e227b0b8eap+0 , -0x1.1aa2bc79c81p-3  ,
+  0x3FF1BB4A4A1A343F, 0xBFBA4E76CE8C0E5E, // 0x1.1bb4a4a1a343fp+0, -0x1.a4e76ce8c0e5ep-4,
+  0x3FF12358F08AE5BA, 0xBFB1973C5A611CCC, // 0x1.12358f08ae5bap+0, -0x1.1973c5a611cccp-4,
+  0x3FF0953F419900A7, 0xBFA252F438E10C1E, // 0x1.0953f419900a7p+0, -0x1.252f438e10c1ep-5,
+  0x3FF0000000000000, 0,                  // 0x1p+0,                0,
+  0x3FEE608CFD9A47AC, 0x3FAAA5AA5DF25984, // 0x1.e608cfd9a47acp-1,  0x1.aa5aa5df25984p-5,
+  0x3FECA4B31F026AA0, 0x3FBC5E53AA362EB4, // 0x1.ca4b31f026aap-1 ,  0x1.c5e53aa362eb4p-4,
+  0x3FEB2036576AFCE6, 0x3FC526E57720DB08, // 0x1.b2036576afce6p-1,  0x1.526e57720db08p-3,
+  0x3FE9C2D163A1AA2D, 0x3FCBC2860D224770, // 0x1.9c2d163a1aa2dp-1,  0x1.bc2860d22477p-3 ,
+  0x3FE886E6037841ED, 0x3FD1058BC8A07EE1, // 0x1.886e6037841edp-1,  0x1.1058bc8a07ee1p-2,
+  0x3FE767DCF5534862, 0x3FD4043057B6EE09  // 0x1.767dcf5534862p-1,  0x1.4043057b6ee09p-2
 ]);
 
-// ULP error: 0.818 (nearest rounding.)
-// Relative error: 1.957 * 2^-26 (before rounding.)
 // @ts-ignore: decorator
 @inline
-export function logf_lut(x: f32): f32 {
-  const
-    N_MASK  = (1 << LOGF_TABLE_BITS) - 1,
-    Ox1p23f = reinterpret<f32>(0x4B000000); // 0x1p23f
+const LOG_TABLE32_BITS = 4;
 
-  const
-    Ln2 = reinterpret<f64>(0x3FE62E42FEFA39EF), // 0x1.62e42fefa39efp-1;
-    A0  = reinterpret<f64>(0xBFD00EA348B88334), // -0x1.00ea348b88334p-2
-    A1  = reinterpret<f64>(0x3FD5575B0BE00B6A), //  0x1.5575b0be00b6ap-2
-    A2  = reinterpret<f64>(0xBFDFFFFEF20A4123); // -0x1.ffffef20a4123p-2
-
-  var ux = reinterpret<u32>(x);
-  // Fix sign of zero with downward rounding when x==1.
-  // if (WANT_ROUNDING && ux == 0x3f800000) return 0;
-  if (ux - 0x00800000 >= 0x7F800000 - 0x00800000) {
-    // x < 0x1p-126 or inf or nan.
-    if ((ux << 1) == 0) return -Infinity;
-    if (ux == 0x7F800000) return x; // log(inf) == inf.
-    if ((ux >> 31) || (ux << 1) >= 0xFF000000) return (x - x) / (x - x);
-    // x is subnormal, normalize it.
-    ux = reinterpret<u32>(x * Ox1p23f);
-    ux -= 23 << 23;
-  }
-  // x = 2^k z; where z is in range [OFF,2*OFF] and exact.
-  // The range is split into N subintervals.
-  // The ith subinterval contains z and c is near its center.
-  var tmp = ux - 0x3F330000;
-  var i   = (tmp >> (23 - LOGF_TABLE_BITS)) & N_MASK;
-  var k   = <i32>tmp >> 23;
-  var iz  = ux - (tmp & 0x1FF << 23);
-
-  var invc = load<f64>(LOGF_DATA_TAB + (i << (1 + alignof<f64>())), 0 << alignof<f64>());
-  var logc = load<f64>(LOGF_DATA_TAB + (i << (1 + alignof<f64>())), 1 << alignof<f64>());
-
-  var z = <f64>reinterpret<f32>(iz);
-
-  // log(x) = log1p(z/c-1) + log(c) + k*Ln2
-  var r = z * invc - 1;
-  var y0 = logc + <f64>k * Ln2;
-
-  // Pipelined polynomial evaluation to approximate log1p(r).
-  var r2 = r * r;
-  var y  = A1 * r + A2;
-  y += A0 * r2;
-  y = y * r2 + (y0 + r);
-
-  return <f32>y;
-}
-
-//
-// Lookup data for powf. See: https://git.musl-libc.org/cgit/musl/tree/src/math/powf.c
-//
-
-// @ts-ignore: decorator
-@inline
-function zeroinfnanf(ux: u32): bool {
-  return (ux << 1) - 1 >= (<u32>0x7f800000 << 1) - 1;
-}
-
-// Returns 0 if not int, 1 if odd int, 2 if even int. The argument is
-// the bit representation of a non-zero finite floating-point value.
-// @ts-ignore: decorator
-@inline
-function checkintf(iy: u32): i32 {
-  var e = iy >> 23 & 0xFF;
-  if (e < 0x7F     ) return 0;
-  if (e > 0x7F + 23) return 2;
-  e = 1 << (0x7F + 23 - e);
-  if (iy & (e - 1)) return 0;
-  if (iy &  e     ) return 1;
-  return 2;
-}
-
-// Subnormal input is normalized so ix has negative biased exponent.
-// Output is multiplied by N (POWF_SCALE) if TOINT_INTRINICS is set.
-// @ts-ignore: decorator
-@inline
-function log2f_inline(ux: u32): f64 {
-  const N_MASK = (1 << LOG2F_TABLE_BITS) - 1;
-
-  const
-    A0 = reinterpret<f64>(0x3FD27616C9496E0B), //  0x1.27616c9496e0bp-2
-    A1 = reinterpret<f64>(0xBFD71969A075C67A), // -0x1.71969a075c67ap-2
-    A2 = reinterpret<f64>(0x3FDEC70A6CA7BADD), //  0x1.ec70a6ca7baddp-2
-    A3 = reinterpret<f64>(0xBFE7154748BEF6C8), // -0x1.7154748bef6c8p-1
-    A4 = reinterpret<f64>(0x3FF71547652AB82B); //  0x1.71547652ab82bp+0
-
-  // x = 2^k z; where z is in range [OFF,2*OFF] and exact.
-  // The range is split into N subintervals.
-  // The ith subinterval contains z and c is near its center.
-  var tmp  = ux - 0x3F330000;
-  var i    = <usize>((tmp >> (23 - LOG2F_TABLE_BITS)) & N_MASK);
-  var top  = tmp & 0xFF800000;
-  var uz   = ux - top;
-  var k    = <i32>(<i32>top >> 23);
-
-  var invc = load<f64>(LOG2F_DATA_TAB + (i << (1 + alignof<f64>())), 0 << alignof<f64>());
-  var logc = load<f64>(LOG2F_DATA_TAB + (i << (1 + alignof<f64>())), 1 << alignof<f64>());
-  var z    = <f64>reinterpret<f32>(uz);
-
-  // log2(x) = log1p(z/c-1)/ln2 + log2(c) + k
-  var r  = z * invc - 1;
-  var y0 = logc + <f64>k;
-
-  // Pipelined polynomial evaluation to approximate log1p(r)/ln2.
-  var y = A0 * r + A1;
-  var p = A2 * r + A3;
-  var q = A4 * r + y0;
-
-  r *= r;
-  q += p * r;
-  y  = y * (r * r) + q;
-
-  return y;
-}
-
-// The output of log2 and thus the input of exp2 is either scaled by N
-// (in case of fast toint intrinsics) or not.  The unscaled xd must be
-// in [-1021,1023], sign_bias sets the sign of the result.
-// @ts-ignore: decorator
-@inline
-function exp2f_inline(xd: f64, signBias: u32): f32 {
-  const
-    N      = 1 << EXP2F_TABLE_BITS,
-    N_MASK = N - 1,
-    shift  = reinterpret<f64>(0x4338000000000000) / N; // 0x1.8p+52
-
-  const
-    C0 = reinterpret<f64>(0x3FAC6AF84B912394), // 0x1.c6af84b912394p-5
-    C1 = reinterpret<f64>(0x3FCEBFCE50FAC4F3), // 0x1.ebfce50fac4f3p-3
-    C2 = reinterpret<f64>(0x3FE62E42FF0C52D6); // 0x1.62e42ff0c52d6p-1
-
-  // x = k/N + r with r in [-1/(2N), 1/(2N)]
-  var kd = <f64>(xd + shift);
-  var ki = reinterpret<u64>(kd);
-  var r  = xd - (kd - shift);
-  var t: u64, z: f64, y: f64, s: f64;
-
-  // exp2(x) = 2^(k/N) * 2^r ~= s * (C0*r^3 + C1*r^2 + C2*r + 1)
-  t  = load<u64>(EXP2F_DATA_TAB + ((<usize>ki & N_MASK) << alignof<u64>()));
-  t += (ki + signBias) << (52 - EXP2F_TABLE_BITS);
-  s  = reinterpret<f64>(t);
-  z  = C0 * r + C1;
-  y  = C2 * r + 1;
-  y += z * (r * r);
-  y *= s;
-  return <f32>y;
-}
-
-// @ts-ignore: decorator
-@inline
-function xflowf(sign: u32, y: f32): f32 {
-  return select<f32>(-y, y, sign) * y;
-}
-
-// @ts-ignore: decorator
-@inline
-function oflowf(sign: u32): f32 {
-  return xflowf(sign, reinterpret<f32>(0x70000000)); // 0x1p97f
-}
-
-// @ts-ignore: decorator
-@inline
-function uflowf(sign: u32): f32 {
-  return xflowf(sign, reinterpret<f32>(0x10000000)); // 0x1p-95f
-}
-
-// @ts-ignore: decorator
-@inline
-export function powf_lut(x: f32, y: f32): f32 {
-  const
-    Ox1p23f     = reinterpret<f32>(0x4B000000), // 0x1p23f
-    UPPER_LIMIT = reinterpret<f64>(0x405FFFFFFFD1D571), // 0x1.fffffffd1d571p+6
-    LOWER_LIMIT = -150.0,
-    SIGN_BIAS   = 1 << (EXP2F_TABLE_BITS + 11);
-
-  var signBias: u32 = 0;
-  var ix = reinterpret<u32>(x);
-  var iy = reinterpret<u32>(y);
-  var ny = 0;
-
-  if (i32(ix - 0x00800000 >= 0x7f800000 - 0x00800000) | (ny = i32(zeroinfnanf(iy)))) {
-    // Either (x < 0x1p-126 or inf or nan) or (y is 0 or inf or nan).
-    if (ny) {
-      if ((iy << 1) == 0) return 1.0;
-      if (ix == 0x3F800000) return NaN; // original: 1.0
-      if ((ix << 1) > (<u32>0x7F800000 << 1) || (iy << 1) > (<u32>0x7F800000 << 1)) return x + y;
-      if ((ix << 1) == (0x3F800000 << 1)) return NaN; // original: 1.0
-      if (((ix << 1) < (0x3F800000 << 1)) == !(iy >> 31)) return 0; // |x| < 1 && y==inf or |x| > 1 && y==-inf.
-      return y * y;
-    }
-    if (zeroinfnanf(ix)) {
-      let x2 = x * x;
-      if ((ix >> 31) && checkintf(iy) == 1) x2 = -x2;
-      return iy >> 31 ? 1 / x2 : x2;
-    }
-    // x and y are non-zero finite.
-    if (ix >> 31) {
-      // Finite x < 0.
-      let yint = checkintf(iy);
-      if (yint == 0) return (x - x) / (x - x);
-      if (yint == 1) signBias = SIGN_BIAS;
-      ix &= 0x7FFFFFFF;
-    }
-    if (ix < 0x00800000) {
-      // Normalize subnormal x so exponent becomes negative.
-      ix = reinterpret<u32>(x * Ox1p23f);
-      ix &= 0x7FFFFFFF;
-      ix -= 23 << 23;
-    }
-  }
-  var logx = log2f_inline(ix);
-  var ylogx = y * logx; // cannot overflow, y is single prec.
-  if ((reinterpret<u64>(ylogx) >> 47 & 0xFFFF) >= 0x80BF) { // reinterpret<u64>(126.0) >> 47
-    // |y * log(x)| >= 126
-    if (ylogx  > UPPER_LIMIT) return oflowf(signBias); // overflow
-    if (ylogx <= LOWER_LIMIT) return uflowf(signBias); // underflow
-  }
-  return exp2f_inline(ylogx, signBias);
-}
-
-//
 // Lookup data for exp. See: https://git.musl-libc.org/cgit/musl/tree/src/math/exp.c
-//
 
 // @ts-ignore: decorator
-@inline const EXP_TABLE_BITS = 7;
-
-// @ts-ignore: decorator
-@lazy @inline const EXP_DATA_TAB = memory.data<u64>([
+@lazy @inline
+const EXP_TABLE64 = memory.data<u64>([
   0x0000000000000000, 0x3FF0000000000000,
   0x3C9B3B4F1A88BF6E, 0x3FEFF63DA9FB3335,
   0xBC7160139CD8DC5D, 0x3FEFEC9A3E778061,
@@ -589,6 +234,2354 @@ export function powf_lut(x: f32, y: f32): f32 {
   0x3C5305C14160CC89, 0x3FEFF3C22B8F71F1
 ]);
 
+// @ts-ignore: decorator
+@inline
+const EXP_TABLE64_BITS = 7;
+
+// Lookup data for log2. See: https://git.musl-libc.org/cgit/musl/tree/src/math/log2.c
+
+/* Algorithm:
+
+  x = 2^k z
+  log2(x) = k + log2(c) + log2(z/c)
+  log2(z/c) = poly(z/c - 1)
+
+where z is in [1.6p-1; 1.6p0] which is split into N subintervals and z falls
+into the ith one, then table entries are computed as
+
+  tab[i].invc = 1/c
+  tab[i].logc = (double)log2(c)
+  tab2[i].chi = (double)c
+  tab2[i].clo = (double)(c - (double)c)
+
+where c is near the center of the subinterval and is chosen by trying +-2^29
+floating point invc candidates around 1/center and selecting one for which
+
+  1) the rounding error in 0x1.8p10 + logc is 0,
+  2) the rounding error in z - chi - clo is < 0x1p-64 and
+  3) the rounding error in (double)log2(c) is minimized (< 0x1p-68).
+
+Note: 1) ensures that k + logc can be computed without rounding error, 2)
+ensures that z/c - 1 can be computed as (z - chi - clo)*invc with close to a
+single rounding error when there is no fast fma for z*invc - 1, 3) ensures
+that logc + poly(z/c - 1) has small error, however near x == 1 when
+|log2(x)| < 0x1p-4, this is not enough so that is special cased. */
+
+// @ts-ignore: decorator
+@lazy @inline
+const LOG2_TABLE1_64 = memory.data<u64>([
+  //     invc       ,        logc
+  0x3FF724286BB1ACF8, 0xBFE1095FEECDB000,
+  0x3FF6E1F766D2CCA1, 0xBFE08494BD76D000,
+  0x3FF6A13D0E30D48A, 0xBFE00143AEE8F800,
+  0x3FF661EC32D06C85, 0xBFDEFEC5360B4000,
+  0x3FF623FA951198F8, 0xBFDDFDD91AB7E000,
+  0x3FF5E75BA4CF026C, 0xBFDCFFAE0CC79000,
+  0x3FF5AC055A214FB8, 0xBFDC043811FDA000,
+  0x3FF571ED0F166E1E, 0xBFDB0B67323AE000,
+  0x3FF53909590BF835, 0xBFDA152F5A2DB000,
+  0x3FF5014FED61ADDD, 0xBFD9217F5AF86000,
+  0x3FF4CAB88E487BD0, 0xBFD8304DB0719000,
+  0x3FF49539B4334FEE, 0xBFD74189F9A9E000,
+  0x3FF460CBDFAFD569, 0xBFD6552BB5199000,
+  0x3FF42D664EE4B953, 0xBFD56B23A29B1000,
+  0x3FF3FB01111DD8A6, 0xBFD483650F5FA000,
+  0x3FF3C995B70C5836, 0xBFD39DE937F6A000,
+  0x3FF3991C4AB6FD4A, 0xBFD2BAA1538D6000,
+  0x3FF3698E0CE099B5, 0xBFD1D98340CA4000,
+  0x3FF33AE48213E7B2, 0xBFD0FA853A40E000,
+  0x3FF30D191985BDB1, 0xBFD01D9C32E73000,
+  0x3FF2E025CAB271D7, 0xBFCE857DA2FA6000,
+  0x3FF2B404CF13CD82, 0xBFCCD3C8633D8000,
+  0x3FF288B02C7CCB50, 0xBFCB26034C14A000,
+  0x3FF25E2263944DE5, 0xBFC97C1C2F4FE000,
+  0x3FF234563D8615B1, 0xBFC7D6023F800000,
+  0x3FF20B46E33EAF38, 0xBFC633A71A05E000,
+  0x3FF1E2EEFDCDA3DD, 0xBFC494F5E9570000,
+  0x3FF1BB4A580B3930, 0xBFC2F9E424E0A000,
+  0x3FF19453847F2200, 0xBFC162595AFDC000,
+  0x3FF16E06C0D5D73C, 0xBFBF9C9A75BD8000,
+  0x3FF1485F47B7E4C2, 0xBFBC7B575BF9C000,
+  0x3FF12358AD0085D1, 0xBFB960C60FF48000,
+  0x3FF0FEF00F532227, 0xBFB64CE247B60000,
+  0x3FF0DB2077D03A8F, 0xBFB33F78B2014000,
+  0x3FF0B7E6D65980D9, 0xBFB0387D1A42C000,
+  0x3FF0953EFE7B408D, 0xBFAA6F9208B50000,
+  0x3FF07325CAC53B83, 0xBFA47A954F770000,
+  0x3FF05197E40D1B5C, 0xBF9D23A8C50C0000,
+  0x3FF03091C1208EA2, 0xBF916A2629780000,
+  0x3FF0101025B37E21, 0xBF7720F8D8E80000,
+  0x3FEFC07EF9CAA76B, 0x3F86FE53B1500000,
+  0x3FEF4465D3F6F184, 0x3FA11CCCE10F8000,
+  0x3FEECC079F84107F, 0x3FAC4DFC8C8B8000,
+  0x3FEE573A99975AE8, 0x3FB3AA321E574000,
+  0x3FEDE5D6F0BD3DE6, 0x3FB918A0D08B8000,
+  0x3FED77B681FF38B3, 0x3FBE72E9DA044000,
+  0x3FED0CB5724DE943, 0x3FC1DCD2507F6000,
+  0x3FECA4B2DC0E7563, 0x3FC476AB03DEA000,
+  0x3FEC3F8EE8D6CB51, 0x3FC7074377E22000,
+  0x3FEBDD2B4F020C4C, 0x3FC98EDE8BA94000,
+  0x3FEB7D6C006015CA, 0x3FCC0DB86AD2E000,
+  0x3FEB20366E2E338F, 0x3FCE840AAFCEE000,
+  0x3FEAC57026295039, 0x3FD0790AB4678000,
+  0x3FEA6D01BC2731DD, 0x3FD1AC056801C000,
+  0x3FEA16D3BC3FF18B, 0x3FD2DB11D4FEE000,
+  0x3FE9C2D14967FEAD, 0x3FD406464EC58000,
+  0x3FE970E4F47C9902, 0x3FD52DBE093AF000,
+  0x3FE920FB3982BCF2, 0x3FD651902050D000,
+  0x3FE8D30187F759F1, 0x3FD771D2CDEAF000,
+  0x3FE886E5EBB9F66D, 0x3FD88E9C857D9000,
+  0x3FE83C97B658B994, 0x3FD9A80155E16000,
+  0x3FE7F405FFC61022, 0x3FDABE186ED3D000,
+  0x3FE7AD22181415CA, 0x3FDBD0F2AEA0E000,
+  0x3FE767DCF99EFF8C, 0x3FDCE0A43DBF4000
+]);
+
+// @ts-ignore: decorator
+@lazy @inline
+const LOG2_TABLE2_64 = memory.data<u64>([
+  //      chi       ,         clo
+  0x3FE6200012B90A8E, 0x3C8904AB0644B605,
+  0x3FE66000045734A6, 0x3C61FF9BEA62F7A9,
+  0x3FE69FFFC325F2C5, 0x3C827ECFCB3C90BA,
+  0x3FE6E00038B95A04, 0x3C88FF8856739326,
+  0x3FE71FFFE09994E3, 0x3C8AFD40275F82B1,
+  0x3FE7600015590E10, 0xBC72FD75B4238341,
+  0x3FE7A00012655BD5, 0x3C7808E67C242B76,
+  0x3FE7E0003259E9A6, 0xBC6208E426F622B7,
+  0x3FE81FFFEDB4B2D2, 0xBC8402461EA5C92F,
+  0x3FE860002DFAFCC3, 0x3C6DF7F4A2F29A1F,
+  0x3FE89FFFF78C6B50, 0xBC8E0453094995FD,
+  0x3FE8E00039671566, 0xBC8A04F3BEC77B45,
+  0x3FE91FFFE2BF1745, 0xBC77FA34400E203C,
+  0x3FE95FFFCC5C9FD1, 0xBC76FF8005A0695D,
+  0x3FE9A0003BBA4767, 0x3C70F8C4C4EC7E03,
+  0x3FE9DFFFE7B92DA5, 0x3C8E7FD9478C4602,
+  0x3FEA1FFFD72EFDAF, 0xBC6A0C554DCDAE7E,
+  0x3FEA5FFFDE04FF95, 0x3C867DA98CE9B26B,
+  0x3FEA9FFFCA5E8D2B, 0xBC8284C9B54C13DE,
+  0x3FEADFFFDDAD03EA, 0x3C5812C8EA602E3C,
+  0x3FEB1FFFF10D3D4D, 0xBC8EFADDAD27789C,
+  0x3FEB5FFFCE21165A, 0x3C53CB1719C61237,
+  0x3FEB9FFFD950E674, 0x3C73F7D94194CE00,
+  0x3FEBE000139CA8AF, 0x3C750AC4215D9BC0,
+  0x3FEC20005B46DF99, 0x3C6BEEA653E9C1C9,
+  0x3FEC600040B9F7AE, 0xBC7C079F274A70D6,
+  0x3FECA0006255FD8A, 0xBC7A0B4076E84C1F,
+  0x3FECDFFFD94C095D, 0x3C88F933F99AB5D7,
+  0x3FED1FFFF975D6CF, 0xBC582C08665FE1BE,
+  0x3FED5FFFA2561C93, 0xBC7B04289BD295F3,
+  0x3FED9FFF9D228B0C, 0x3C870251340FA236,
+  0x3FEDE00065BC7E16, 0xBC75011E16A4D80C,
+  0x3FEE200002F64791, 0x3C89802F09EF62E0,
+  0x3FEE600057D7A6D8, 0xBC7E0B75580CF7FA,
+  0x3FEEA00027EDC00C, 0xBC8C848309459811,
+  0x3FEEE0006CF5CB7C, 0xBC8F8027951576F4,
+  0x3FEF2000782B7DCC, 0xBC8F81D97274538F,
+  0x3FEF6000260C450A, 0xBC4071002727FFDC,
+  0x3FEF9FFFE88CD533, 0xBC581BDCE1FDA8B0,
+  0x3FEFDFFFD50F8689, 0x3C87F91ACB918E6E,
+  0x3FF0200004292367, 0x3C9B7FF365324681,
+  0x3FF05FFFE3E3D668, 0x3C86FA08DDAE957B,
+  0x3FF0A0000A85A757, 0xBC57E2DE80D3FB91,
+  0x3FF0E0001A5F3FCC, 0xBC91823305C5F014,
+  0x3FF11FFFF8AFBAF5, 0xBC8BFABB6680BAC2,
+  0x3FF15FFFE54D91AD, 0xBC9D7F121737E7EF,
+  0x3FF1A00011AC36E1, 0x3C9C000A0516F5FF,
+  0x3FF1E00019C84248, 0xBC9082FBE4DA5DA0,
+  0x3FF220000FFE5E6E, 0xBC88FDD04C9CFB43,
+  0x3FF26000269FD891, 0x3C8CFE2A7994D182,
+  0x3FF2A00029A6E6DA, 0xBC700273715E8BC5,
+  0x3FF2DFFFE0293E39, 0x3C9B7C39DAB2A6F9,
+  0x3FF31FFFF7DCF082, 0x3C7DF1336EDC5254,
+  0x3FF35FFFF05A8B60, 0xBC9E03564CCD31EB,
+  0x3FF3A0002E0EAECC, 0x3C75F0E74BD3A477,
+  0x3FF3E000043BB236, 0x3C9C7DCB149D8833,
+  0x3FF4200002D187FF, 0x3C7E08AFCF2D3D28,
+  0x3FF460000D387CB1, 0x3C820837856599A6,
+  0x3FF4A00004569F89, 0xBC89FA5C904FBCD2,
+  0x3FF4E000043543F3, 0xBC781125ED175329,
+  0x3FF51FFFCC027F0F, 0x3C9883D8847754DC,
+  0x3FF55FFFFD87B36F, 0xBC8709E731D02807,
+  0x3FF59FFFF21DF7BA, 0x3C87F79F68727B02,
+  0x3FF5DFFFEBFC3481, 0xBC9180902E30E93E
+]);
+
+// @ts-ignore: decorator
+@inline
+const LOG2_TABLE64_BITS = 6;
+
+// Lookup data for log. See: https://git.musl-libc.org/cgit/musl/tree/src/math/log.c
+
+/* Algorithm:
+
+  x = 2^k z
+  log(x) = k ln2 + log(c) + log(z/c)
+  log(z/c) = poly(z/c - 1)
+
+where z is in [1.6p-1; 1.6p0] which is split into N subintervals and z falls
+into the ith one, then table entries are computed as
+
+  tab[i].invc = 1/c
+  tab[i].logc = (double)log(c)
+  tab2[i].chi = (double)c
+  tab2[i].clo = (double)(c - (double)c)
+
+where c is near the center of the subinterval and is chosen by trying +-2^29
+floating point invc candidates around 1/center and selecting one for which
+
+  1) the rounding error in 0x1.8p9 + logc is 0,
+  2) the rounding error in z - chi - clo is < 0x1p-66 and
+  3) the rounding error in (double)log(c) is minimized (< 0x1p-66).
+
+Note: 1) ensures that k*ln2hi + logc can be computed without rounding error,
+2) ensures that z/c - 1 can be computed as (z - chi - clo)*invc with close to
+a single rounding error when there is no fast fma for z*invc - 1, 3) ensures
+that logc + poly(z/c - 1) has small error, however near x == 1 when
+|log(x)| < 0x1p-4, this is not enough so that is special cased.*/
+
+// @ts-ignore: decorator
+@lazy @inline
+const LOG_TABLE1_64 = memory.data<u64>([
+  //      invc      ,        logc
+  0x3FF734F0C3E0DE9F, 0xBFD7CC7F79E69000,
+  0x3FF713786A2CE91F, 0xBFD76FEEC20D0000,
+  0x3FF6F26008FAB5A0, 0xBFD713E31351E000,
+  0x3FF6D1A61F138C7D, 0xBFD6B85B38287800,
+  0x3FF6B1490BC5B4D1, 0xBFD65D5590807800,
+  0x3FF69147332F0CBA, 0xBFD602D076180000,
+  0x3FF6719F18224223, 0xBFD5A8CA86909000,
+  0x3FF6524F99A51ED9, 0xBFD54F4356035000,
+  0x3FF63356AA8F24C4, 0xBFD4F637C36B4000,
+  0x3FF614B36B9DDC14, 0xBFD49DA7FDA85000,
+  0x3FF5F66452C65C4C, 0xBFD445923989A800,
+  0x3FF5D867B5912C4F, 0xBFD3EDF439B0B800,
+  0x3FF5BABCCB5B90DE, 0xBFD396CE448F7000,
+  0x3FF59D61F2D91A78, 0xBFD3401E17BDA000,
+  0x3FF5805612465687, 0xBFD2E9E2EF468000,
+  0x3FF56397CEE76BD3, 0xBFD2941B3830E000,
+  0x3FF54725E2A77F93, 0xBFD23EC58CDA8800,
+  0x3FF52AFF42064583, 0xBFD1E9E129279000,
+  0x3FF50F22DBB2BDDF, 0xBFD1956D2B48F800,
+  0x3FF4F38F4734DED7, 0xBFD141679AB9F800,
+  0x3FF4D843CFDE2840, 0xBFD0EDD094EF9800,
+  0x3FF4BD3EC078A3C8, 0xBFD09AA518DB1000,
+  0x3FF4A27FC3E0258A, 0xBFD047E65263B800,
+  0x3FF4880524D48434, 0xBFCFEB224586F000,
+  0x3FF46DCE1B192D0B, 0xBFCF474A7517B000,
+  0x3FF453D9D3391854, 0xBFCEA4443D103000,
+  0x3FF43A2744B4845A, 0xBFCE020D44E9B000,
+  0x3FF420B54115F8FB, 0xBFCD60A22977F000,
+  0x3FF40782DA3EF4B1, 0xBFCCC00104959000,
+  0x3FF3EE8F5D57FE8F, 0xBFCC202956891000,
+  0x3FF3D5D9A00B4CE9, 0xBFCB81178D811000,
+  0x3FF3BD60C010C12B, 0xBFCAE2C9CCD3D000,
+  0x3FF3A5242B75DAB8, 0xBFCA45402E129000,
+  0x3FF38D22CD9FD002, 0xBFC9A877681DF000,
+  0x3FF3755BC5847A1C, 0xBFC90C6D69483000,
+  0x3FF35DCE49AD36E2, 0xBFC87120A645C000,
+  0x3FF34679984DD440, 0xBFC7D68FB4143000,
+  0x3FF32F5CCEFFCB24, 0xBFC73CB83C627000,
+  0x3FF3187775A10D49, 0xBFC6A39A9B376000,
+  0x3FF301C8373E3990, 0xBFC60B3154B7A000,
+  0x3FF2EB4EBB95F841, 0xBFC5737D76243000,
+  0x3FF2D50A0219A9D1, 0xBFC4DC7B8FC23000,
+  0x3FF2BEF9A8B7FD2A, 0xBFC4462C51D20000,
+  0x3FF2A91C7A0C1BAB, 0xBFC3B08ABC830000,
+  0x3FF293726014B530, 0xBFC31B996B490000,
+  0x3FF27DFA5757A1F5, 0xBFC2875490A44000,
+  0x3FF268B39B1D3BBF, 0xBFC1F3B9F879A000,
+  0x3FF2539D838FF5BD, 0xBFC160C8252CA000,
+  0x3FF23EB7AAC9083B, 0xBFC0CE7F57F72000,
+  0x3FF22A012BA940B6, 0xBFC03CDC49FEA000,
+  0x3FF2157996CC4132, 0xBFBF57BDBC4B8000,
+  0x3FF201201DD2FC9B, 0xBFBE370896404000,
+  0x3FF1ECF4494D480B, 0xBFBD17983EF94000,
+  0x3FF1D8F5528F6569, 0xBFBBF9674ED8A000,
+  0x3FF1C52311577E7C, 0xBFBADC79202F6000,
+  0x3FF1B17C74CB26E9, 0xBFB9C0C3E7288000,
+  0x3FF19E010C2C1AB6, 0xBFB8A646B372C000,
+  0x3FF18AB07BB670BD, 0xBFB78D01B3AC0000,
+  0x3FF1778A25EFBCB6, 0xBFB674F145380000,
+  0x3FF1648D354C31DA, 0xBFB55E0E6D878000,
+  0x3FF151B990275FDD, 0xBFB4485CDEA1E000,
+  0x3FF13F0EA432D24C, 0xBFB333D94D6AA000,
+  0x3FF12C8B7210F9DA, 0xBFB22079F8C56000,
+  0x3FF11A3028ECB531, 0xBFB10E4698622000,
+  0x3FF107FBDA8434AF, 0xBFAFFA6C6AD20000,
+  0x3FF0F5EE0F4E6BB3, 0xBFADDA8D4A774000,
+  0x3FF0E4065D2A9FCE, 0xBFABBCECE4850000,
+  0x3FF0D244632CA521, 0xBFA9A1894012C000,
+  0x3FF0C0A77CE2981A, 0xBFA788583302C000,
+  0x3FF0AF2F83C636D1, 0xBFA5715E67D68000,
+  0x3FF09DDB98A01339, 0xBFA35C8A49658000,
+  0x3FF08CABAF52E7DF, 0xBFA149E364154000,
+  0x3FF07B9F2F4E28FB, 0xBF9E72C082EB8000,
+  0x3FF06AB58C358F19, 0xBF9A55F152528000,
+  0x3FF059EEA5ECF92C, 0xBF963D62CF818000,
+  0x3FF04949CDD12C90, 0xBF9228FB8CAA0000,
+  0x3FF038C6C6F0ADA9, 0xBF8C317B20F90000,
+  0x3FF02865137932A9, 0xBF8419355DAA0000,
+  0x3FF0182427EA7348, 0xBF781203C2EC0000,
+  0x3FF008040614B195, 0xBF60040979240000,
+  0x3FEFE01FF726FA1A, 0x3F6FEFF384900000,
+  0x3FEFA11CC261EA74, 0x3F87DC41353D0000,
+  0x3FEF6310B081992E, 0x3F93CEA3C4C28000,
+  0x3FEF25F63CEEADCD, 0x3F9B9FC114890000,
+  0x3FEEE9C8039113E7, 0x3FA1B0D8CE110000,
+  0x3FEEAE8078CBB1AB, 0x3FA58A5BD001C000,
+  0x3FEE741AA29D0C9B, 0x3FA95C8340D88000,
+  0x3FEE3A91830A99B5, 0x3FAD276AEF578000,
+  0x3FEE01E009609A56, 0x3FB07598E598C000,
+  0x3FEDCA01E577BB98, 0x3FB253F5E30D2000,
+  0x3FED92F20B7C9103, 0x3FB42EDD8B380000,
+  0x3FED5CAC66FB5CCE, 0x3FB606598757C000,
+  0x3FED272CAA5EDE9D, 0x3FB7DA76356A0000,
+  0x3FECF26E3E6B2CCD, 0x3FB9AB434E1C6000,
+  0x3FECBE6DA2A77902, 0x3FBB78C7BB0D6000,
+  0x3FEC8B266D37086D, 0x3FBD431332E72000,
+  0x3FEC5894BD5D5804, 0x3FBF0A3171DE6000,
+  0x3FEC26B533BB9F8C, 0x3FC067152B914000,
+  0x3FEBF583EEECE73F, 0x3FC147858292B000,
+  0x3FEBC4FD75DB96C1, 0x3FC2266ECDCA3000,
+  0x3FEB951E0C864A28, 0x3FC303D7A6C55000,
+  0x3FEB65E2C5EF3E2C, 0x3FC3DFC33C331000,
+  0x3FEB374867C9888B, 0x3FC4BA366B7A8000,
+  0x3FEB094B211D304A, 0x3FC5933928D1F000,
+  0x3FEADBE885F2EF7E, 0x3FC66ACD2418F000,
+  0x3FEAAF1D31603DA2, 0x3FC740F8EC669000,
+  0x3FEA82E63FD358A7, 0x3FC815C0F51AF000,
+  0x3FEA5740EF09738B, 0x3FC8E92954F68000,
+  0x3FEA2C2A90AB4B27, 0x3FC9BB3602F84000,
+  0x3FEA01A01393F2D1, 0x3FCA8BED1C2C0000,
+  0x3FE9D79F24DB3C1B, 0x3FCB5B515C01D000,
+  0x3FE9AE2505C7B190, 0x3FCC2967CCBCC000,
+  0x3FE9852EF297CE2F, 0x3FCCF635D5486000,
+  0x3FE95CBAEEA44B75, 0x3FCDC1BD3446C000,
+  0x3FE934C69DE74838, 0x3FCE8C01B8CFE000,
+  0x3FE90D4F2F6752E6, 0x3FCF5509C0179000,
+  0x3FE8E6528EFFD79D, 0x3FD00E6C121FB800,
+  0x3FE8BFCE9FCC007C, 0x3FD071B80E93D000,
+  0x3FE899C0DABEC30E, 0x3FD0D46B9E867000,
+  0x3FE87427AA2317FB, 0x3FD13687334BD000,
+  0x3FE84F00ACB39A08, 0x3FD1980D67234800,
+  0x3FE82A49E8653E55, 0x3FD1F8FFE0CC8000,
+  0x3FE8060195F40260, 0x3FD2595FD7636800,
+  0x3FE7E22563E0A329, 0x3FD2B9300914A800,
+  0x3FE7BEB377DCB5AD, 0x3FD3187210436000,
+  0x3FE79BAA679725C2, 0x3FD377266DEC1800,
+  0x3FE77907F2170657, 0x3FD3D54FFBAF3000,
+  0x3FE756CADBD6130C, 0x3FD432EEE32FE000
+]);
+
+// @ts-ignore: decorator
+@lazy @inline
+const LOG_TABLE2_64 = memory.data<u64>([
+  //      chi       ,         clo
+  0x3FE61000014FB66B, 0x3C7E026C91425B3C,
+  0x3FE63000034DB495, 0x3C8DBFEA48005D41,
+  0x3FE650000D94D478, 0x3C8E7FA786D6A5B7,
+  0x3FE67000074E6FAD, 0x3C61FCEA6B54254C,
+  0x3FE68FFFFEDF0FAE, 0xBC7C7E274C590EFD,
+  0x3FE6B0000763C5BC, 0xBC8AC16848DCDA01,
+  0x3FE6D0001E5CC1F6, 0x3C833F1C9D499311,
+  0x3FE6EFFFEB05F63E, 0xBC7E80041AE22D53,
+  0x3FE710000E869780, 0x3C7BFF6671097952,
+  0x3FE72FFFFC67E912, 0x3C8C00E226BD8724,
+  0x3FE74FFFDF81116A, 0xBC6E02916EF101D2,
+  0x3FE770000F679C90, 0xBC67FC71CD549C74,
+  0x3FE78FFFFA7EC835, 0x3C81BEC19EF50483,
+  0x3FE7AFFFFE20C2E6, 0xBC707E1729CC6465,
+  0x3FE7CFFFED3FC900, 0xBC808072087B8B1C,
+  0x3FE7EFFFE9261A76, 0x3C8DC0286D9DF9AE,
+  0x3FE81000049CA3E8, 0x3C897FD251E54C33,
+  0x3FE8300017932C8F, 0xBC8AFEE9B630F381,
+  0x3FE850000633739C, 0x3C89BFBF6B6535BC,
+  0x3FE87000204289C6, 0xBC8BBF65F3117B75,
+  0x3FE88FFFEBF57904, 0xBC89006EA23DCB57,
+  0x3FE8B00022BC04DF, 0xBC7D00DF38E04B0A,
+  0x3FE8CFFFE50C1B8A, 0xBC88007146FF9F05,
+  0x3FE8EFFFFC918E43, 0x3C83817BD07A7038,
+  0x3FE910001EFA5FC7, 0x3C893E9176DFB403,
+  0x3FE9300013467BB9, 0x3C7F804E4B980276,
+  0x3FE94FFFE6EE076F, 0xBC8F7EF0D9FF622E,
+  0x3FE96FFFDE3C12D1, 0xBC7082AA962638BA,
+  0x3FE98FFFF4458A0D, 0xBC87801B9164A8EF,
+  0x3FE9AFFFDD982E3E, 0xBC8740E08A5A9337,
+  0x3FE9CFFFED49FB66, 0x3C3FCE08C19BE000,
+  0x3FE9F00020F19C51, 0xBC8A3FAA27885B0A,
+  0x3FEA10001145B006, 0x3C74FF489958DA56,
+  0x3FEA300007BBF6FA, 0x3C8CBEAB8A2B6D18,
+  0x3FEA500010971D79, 0x3C88FECADD787930,
+  0x3FEA70001DF52E48, 0xBC8F41763DD8ABDB,
+  0x3FEA90001C593352, 0xBC8EBF0284C27612,
+  0x3FEAB0002A4F3E4B, 0xBC69FD043CFF3F5F,
+  0x3FEACFFFD7AE1ED1, 0xBC823EE7129070B4,
+  0x3FEAEFFFEE510478, 0x3C6A063EE00EDEA3,
+  0x3FEB0FFFDB650D5B, 0x3C5A06C8381F0AB9,
+  0x3FEB2FFFFEAACA57, 0xBC79011E74233C1D,
+  0x3FEB4FFFD995BADC, 0xBC79FF1068862A9F,
+  0x3FEB7000249E659C, 0x3C8AFF45D0864F3E,
+  0x3FEB8FFFF9871640, 0x3C7CFE7796C2C3F9,
+  0x3FEBAFFFD204CB4F, 0xBC63FF27EEF22BC4,
+  0x3FEBCFFFD2415C45, 0xBC6CFFB7EE3BEA21,
+  0x3FEBEFFFF86309DF, 0xBC814103972E0B5C,
+  0x3FEC0FFFE1B57653, 0x3C8BC16494B76A19,
+  0x3FEC2FFFF1FA57E3, 0xBC64FEEF8D30C6ED,
+  0x3FEC4FFFDCBFE424, 0xBC843F68BCEC4775,
+  0x3FEC6FFFED54B9F7, 0x3C847EA3F053E0EC,
+  0x3FEC8FFFEB998FD5, 0x3C7383068DF992F1,
+  0x3FECB0002125219A, 0xBC68FD8E64180E04,
+  0x3FECCFFFDD94469C, 0x3C8E7EBE1CC7EA72,
+  0x3FECEFFFEAFDC476, 0x3C8EBE39AD9F88FE,
+  0x3FED1000169AF82B, 0x3C757D91A8B95A71,
+  0x3FED30000D0FF71D, 0x3C89C1906970C7DA,
+  0x3FED4FFFEA790FC4, 0xBC580E37C558FE0C,
+  0x3FED70002EDC87E5, 0xBC7F80D64DC10F44,
+  0x3FED900021DC82AA, 0xBC747C8F94FD5C5C,
+  0x3FEDAFFFD86B0283, 0x3C8C7F1DC521617E,
+  0x3FEDD000296C4739, 0x3C88019EB2FFB153,
+  0x3FEDEFFFE54490F5, 0x3C6E00D2C652CC89,
+  0x3FEE0FFFCDABF694, 0xBC7F8340202D69D2,
+  0x3FEE2FFFDB52C8DD, 0x3C7B00C1CA1B0864,
+  0x3FEE4FFFF24216EF, 0x3C72FFA8B094AB51,
+  0x3FEE6FFFE88A5E11, 0xBC57F673B1EFBE59,
+  0x3FEE9000119EFF0D, 0xBC84808D5E0BC801,
+  0x3FEEAFFFDFA51744, 0x3C780006D54320B5,
+  0x3FEED0001A127FA1, 0xBC5002F860565C92,
+  0x3FEEF00007BABCC4, 0xBC8540445D35E611,
+  0x3FEF0FFFF57A8D02, 0xBC4FFB3139EF9105,
+  0x3FEF30001EE58AC7, 0x3C8A81ACF2731155,
+  0x3FEF4FFFF5823494, 0x3C8A3F41D4D7C743,
+  0x3FEF6FFFFCA94C6B, 0xBC6202F41C987875,
+  0x3FEF8FFFE1F9C441, 0x3C777DD1F477E74B,
+  0x3FEFAFFFD2E0E37E, 0xBC6F01199A7CA331,
+  0x3FEFD0001C77E49E, 0x3C7181EE4BCEACB1,
+  0x3FEFEFFFF7E0C331, 0xBC6E05370170875A,
+  0x3FF00FFFF465606E, 0xBC8A7EAD491C0ADA,
+  0x3FF02FFFF3867A58, 0xBC977F69C3FCB2E0,
+  0x3FF04FFFFDFC0D17, 0x3C97BFFE34CB945B,
+  0x3FF0700003CD4D82, 0x3C820083C0E456CB,
+  0x3FF08FFFF9F2CBE8, 0xBC6DFFDFBE37751A,
+  0x3FF0B000010CDA65, 0xBC913F7FAEE626EB,
+  0x3FF0D00001A4D338, 0x3C807DFA79489FF7,
+  0x3FF0EFFFFADAFDFD, 0xBC77040570D66BC0,
+  0x3FF110000BBAFD96, 0x3C8E80D4846D0B62,
+  0x3FF12FFFFAE5F45D, 0x3C9DBFFA64FD36EF,
+  0x3FF150000DD59AD9, 0x3C9A0077701250AE,
+  0x3FF170000F21559A, 0x3C8DFDF9E2E3DEEE,
+  0x3FF18FFFFC275426, 0x3C910030DC3B7273,
+  0x3FF1B000123D3C59, 0x3C997F7980030188,
+  0x3FF1CFFFF8299EB7, 0xBC65F932AB9F8C67,
+  0x3FF1EFFFF48AD400, 0x3C937FBF9DA75BEB,
+  0x3FF210000C8B86A4, 0x3C9F806B91FD5B22,
+  0x3FF2300003854303, 0x3C93FFC2EB9FBF33,
+  0x3FF24FFFFFBCF684, 0x3C7601E77E2E2E72,
+  0x3FF26FFFF52921D9, 0x3C7FFCBB767F0C61,
+  0x3FF2900014933A3C, 0xBC7202CA3C02412B,
+  0x3FF2B00014556313, 0xBC92808233F21F02,
+  0x3FF2CFFFEBFE523B, 0xBC88FF7E384FDCF2,
+  0x3FF2F0000BB8AD96, 0xBC85FF51503041C5,
+  0x3FF30FFFFB7AE2AF, 0xBC810071885E289D,
+  0x3FF32FFFFEAC5F7F, 0xBC91FF5D3FB7B715,
+  0x3FF350000CA66756, 0x3C957F82228B82BD,
+  0x3FF3700011FBF721, 0x3C8000BAC40DD5CC,
+  0x3FF38FFFF9592FB9, 0xBC943F9D2DB2A751,
+  0x3FF3B00004DDD242, 0x3C857F6B707638E1,
+  0x3FF3CFFFF5B2C957, 0x3C7A023A10BF1231,
+  0x3FF3EFFFEAB0B418, 0x3C987F6D66B152B0,
+  0x3FF410001532AFF4, 0x3C67F8375F198524,
+  0x3FF4300017478B29, 0x3C8301E672DC5143,
+  0x3FF44FFFE795B463, 0x3C89FF69B8B2895A,
+  0x3FF46FFFE80475E0, 0xBC95C0B19BC2F254,
+  0x3FF48FFFEF6FC1E7, 0x3C9B4009F23A2A72,
+  0x3FF4AFFFE5BEA704, 0xBC94FFB7BF0D7D45,
+  0x3FF4D000171027DE, 0xBC99C06471DC6A3D,
+  0x3FF4F0000FF03EE2, 0x3C977F890B85531C,
+  0x3FF5100012DC4BD1, 0x3C6004657166A436,
+  0x3FF530001605277A, 0xBC96BFCECE233209,
+  0x3FF54FFFECDB704C, 0xBC8902720505A1D7,
+  0x3FF56FFFEF5F54A9, 0x3C9BBFE60EC96412,
+  0x3FF5900017E61012, 0x3C887EC581AFEF90,
+  0x3FF5B00003C93E92, 0xBC9F41080ABF0CC0,
+  0x3FF5D0001D4919BC, 0xBC98812AFB254729,
+  0x3FF5EFFFE7B87A89, 0xBC947EB780ED6904
+]);
+
+// @ts-ignore: decorator
+@inline
+const LOG_TABLE64_BITS = 7;
+
+// Lookup data for pow. See: https://git.musl-libc.org/cgit/musl/tree/src/math/pow.c
+
+/* Algorithm:
+
+  x = 2^k z
+  log(x) = k ln2 + log(c) + log(z/c)
+  log(z/c) = poly(z/c - 1)
+
+where z is in [0x1.69555p-1; 0x1.69555p0] which is split into N subintervals
+and z falls into the ith one, then table entries are computed as
+
+  tab[i].invc = 1/c
+  tab[i].logc = round(0x1p43*log(c))/0x1p43
+  tab[i].logctail = (double)(log(c) - logc)
+
+where c is chosen near the center of the subinterval such that 1/c has only a
+few precision bits so z/c - 1 is exactly representible as double:
+
+  1/c = center < 1 ? round(N/center)/N : round(2*N/center)/N/2
+
+Note: |z/c - 1| < 1/N for the chosen c, |log(c) - logc - logctail| < 0x1p-97,
+the last few bits of logc are rounded away so k*ln2hi + logc has no rounding
+error and the interval for z is selected such that near x == 1, where log(x)
+is tiny, large cancellation error is avoided in logc + poly(z/c - 1). */
+
+// @ts-ignore: decorator
+@lazy @inline
+const POW_LOG_TABLE64 = memory.data<u64>([
+  //      invc      ,pad,       logc       ,       logctail
+  0x3FF6A00000000000, 0, 0xBFD62C82F2B9C800, 0x3CFAB42428375680,
+  0x3FF6800000000000, 0, 0xBFD5D1BDBF580800, 0xBD1CA508D8E0F720,
+  0x3FF6600000000000, 0, 0xBFD5767717455800, 0xBD2362A4D5B6506D,
+  0x3FF6400000000000, 0, 0xBFD51AAD872DF800, 0xBCE684E49EB067D5,
+  0x3FF6200000000000, 0, 0xBFD4BE5F95777800, 0xBD041B6993293EE0,
+  0x3FF6000000000000, 0, 0xBFD4618BC21C6000, 0x3D13D82F484C84CC,
+  0x3FF5E00000000000, 0, 0xBFD404308686A800, 0x3CDC42F3ED820B3A,
+  0x3FF5C00000000000, 0, 0xBFD3A64C55694800, 0x3D20B1C686519460,
+  0x3FF5A00000000000, 0, 0xBFD347DD9A988000, 0x3D25594DD4C58092,
+  0x3FF5800000000000, 0, 0xBFD2E8E2BAE12000, 0x3D267B1E99B72BD8,
+  0x3FF5600000000000, 0, 0xBFD2895A13DE8800, 0x3D15CA14B6CFB03F,
+  0x3FF5600000000000, 0, 0xBFD2895A13DE8800, 0x3D15CA14B6CFB03F,
+  0x3FF5400000000000, 0, 0xBFD22941FBCF7800, 0xBD165A242853DA76,
+  0x3FF5200000000000, 0, 0xBFD1C898C1699800, 0xBD1FAFBC68E75404,
+  0x3FF5000000000000, 0, 0xBFD1675CABABA800, 0x3D1F1FC63382A8F0,
+  0x3FF4E00000000000, 0, 0xBFD1058BF9AE4800, 0xBD26A8C4FD055A66,
+  0x3FF4C00000000000, 0, 0xBFD0A324E2739000, 0xBD0C6BEE7EF4030E,
+  0x3FF4A00000000000, 0, 0xBFD0402594B4D000, 0xBCF036B89EF42D7F,
+  0x3FF4A00000000000, 0, 0xBFD0402594B4D000, 0xBCF036B89EF42D7F,
+  0x3FF4800000000000, 0, 0xBFCFB9186D5E4000, 0x3D0D572AAB993C87,
+  0x3FF4600000000000, 0, 0xBFCEF0ADCBDC6000, 0x3D2B26B79C86AF24,
+  0x3FF4400000000000, 0, 0xBFCE27076E2AF000, 0xBD172F4F543FFF10,
+  0x3FF4200000000000, 0, 0xBFCD5C216B4FC000, 0x3D21BA91BBCA681B,
+  0x3FF4000000000000, 0, 0xBFCC8FF7C79AA000, 0x3D27794F689F8434,
+  0x3FF4000000000000, 0, 0xBFCC8FF7C79AA000, 0x3D27794F689F8434,
+  0x3FF3E00000000000, 0, 0xBFCBC286742D9000, 0x3D194EB0318BB78F,
+  0x3FF3C00000000000, 0, 0xBFCAF3C94E80C000, 0x3CBA4E633FCD9066,
+  0x3FF3A00000000000, 0, 0xBFCA23BC1FE2B000, 0xBD258C64DC46C1EA,
+  0x3FF3A00000000000, 0, 0xBFCA23BC1FE2B000, 0xBD258C64DC46C1EA,
+  0x3FF3800000000000, 0, 0xBFC9525A9CF45000, 0xBD2AD1D904C1D4E3,
+  0x3FF3600000000000, 0, 0xBFC87FA06520D000, 0x3D2BBDBF7FDBFA09,
+  0x3FF3400000000000, 0, 0xBFC7AB890210E000, 0x3D2BDB9072534A58,
+  0x3FF3400000000000, 0, 0xBFC7AB890210E000, 0x3D2BDB9072534A58,
+  0x3FF3200000000000, 0, 0xBFC6D60FE719D000, 0xBD10E46AA3B2E266,
+  0x3FF3000000000000, 0, 0xBFC5FF3070A79000, 0xBD1E9E439F105039,
+  0x3FF3000000000000, 0, 0xBFC5FF3070A79000, 0xBD1E9E439F105039,
+  0x3FF2E00000000000, 0, 0xBFC526E5E3A1B000, 0xBD20DE8B90075B8F,
+  0x3FF2C00000000000, 0, 0xBFC44D2B6CCB8000, 0x3D170CC16135783C,
+  0x3FF2C00000000000, 0, 0xBFC44D2B6CCB8000, 0x3D170CC16135783C,
+  0x3FF2A00000000000, 0, 0xBFC371FC201E9000, 0x3CF178864D27543A,
+  0x3FF2800000000000, 0, 0xBFC29552F81FF000, 0xBD248D301771C408,
+  0x3FF2600000000000, 0, 0xBFC1B72AD52F6000, 0xBD2E80A41811A396,
+  0x3FF2600000000000, 0, 0xBFC1B72AD52F6000, 0xBD2E80A41811A396,
+  0x3FF2400000000000, 0, 0xBFC0D77E7CD09000, 0x3D0A699688E85BF4,
+  0x3FF2400000000000, 0, 0xBFC0D77E7CD09000, 0x3D0A699688E85BF4,
+  0x3FF2200000000000, 0, 0xBFBFEC9131DBE000, 0xBD2575545CA333F2,
+  0x3FF2000000000000, 0, 0xBFBE27076E2B0000, 0x3D2A342C2AF0003C,
+  0x3FF2000000000000, 0, 0xBFBE27076E2B0000, 0x3D2A342C2AF0003C,
+  0x3FF1E00000000000, 0, 0xBFBC5E548F5BC000, 0xBD1D0C57585FBE06,
+  0x3FF1C00000000000, 0, 0xBFBA926D3A4AE000, 0x3D253935E85BAAC8,
+  0x3FF1C00000000000, 0, 0xBFBA926D3A4AE000, 0x3D253935E85BAAC8,
+  0x3FF1A00000000000, 0, 0xBFB8C345D631A000, 0x3D137C294D2F5668,
+  0x3FF1A00000000000, 0, 0xBFB8C345D631A000, 0x3D137C294D2F5668,
+  0x3FF1800000000000, 0, 0xBFB6F0D28AE56000, 0xBD269737C93373DA,
+  0x3FF1600000000000, 0, 0xBFB51B073F062000, 0x3D1F025B61C65E57,
+  0x3FF1600000000000, 0, 0xBFB51B073F062000, 0x3D1F025B61C65E57,
+  0x3FF1400000000000, 0, 0xBFB341D7961BE000, 0x3D2C5EDACCF913DF,
+  0x3FF1400000000000, 0, 0xBFB341D7961BE000, 0x3D2C5EDACCF913DF,
+  0x3FF1200000000000, 0, 0xBFB16536EEA38000, 0x3D147C5E768FA309,
+  0x3FF1000000000000, 0, 0xBFAF0A30C0118000, 0x3D2D599E83368E91,
+  0x3FF1000000000000, 0, 0xBFAF0A30C0118000, 0x3D2D599E83368E91,
+  0x3FF0E00000000000, 0, 0xBFAB42DD71198000, 0x3D1C827AE5D6704C,
+  0x3FF0E00000000000, 0, 0xBFAB42DD71198000, 0x3D1C827AE5D6704C,
+  0x3FF0C00000000000, 0, 0xBFA77458F632C000, 0xBD2CFC4634F2A1EE,
+  0x3FF0C00000000000, 0, 0xBFA77458F632C000, 0xBD2CFC4634F2A1EE,
+  0x3FF0A00000000000, 0, 0xBFA39E87B9FEC000, 0x3CF502B7F526FEAA,
+  0x3FF0A00000000000, 0, 0xBFA39E87B9FEC000, 0x3CF502B7F526FEAA,
+  0x3FF0800000000000, 0, 0xBF9F829B0E780000, 0xBD2980267C7E09E4,
+  0x3FF0800000000000, 0, 0xBF9F829B0E780000, 0xBD2980267C7E09E4,
+  0x3FF0600000000000, 0, 0xBF97B91B07D58000, 0xBD288D5493FAA639,
+  0x3FF0400000000000, 0, 0xBF8FC0A8B0FC0000, 0xBCDF1E7CF6D3A69C,
+  0x3FF0400000000000, 0, 0xBF8FC0A8B0FC0000, 0xBCDF1E7CF6D3A69C,
+  0x3FF0200000000000, 0, 0xBF7FE02A6B100000, 0xBD19E23F0DDA40E4,
+  0x3FF0200000000000, 0, 0xBF7FE02A6B100000, 0xBD19E23F0DDA40E4,
+  0x3FF0000000000000, 0, 0,                  0,
+  0x3FF0000000000000, 0, 0,                  0,
+  0x3FEFC00000000000, 0, 0x3F80101575890000, 0xBD10C76B999D2BE8,
+  0x3FEF800000000000, 0, 0x3F90205658938000, 0xBD23DC5B06E2F7D2,
+  0x3FEF400000000000, 0, 0x3F98492528C90000, 0xBD2AA0BA325A0C34,
+  0x3FEF000000000000, 0, 0x3FA0415D89E74000, 0x3D0111C05CF1D753,
+  0x3FEEC00000000000, 0, 0x3FA466AED42E0000, 0xBD2C167375BDFD28,
+  0x3FEE800000000000, 0, 0x3FA894AA149FC000, 0xBD197995D05A267D,
+  0x3FEE400000000000, 0, 0x3FACCB73CDDDC000, 0xBD1A68F247D82807,
+  0x3FEE200000000000, 0, 0x3FAEEA31C006C000, 0xBD0E113E4FC93B7B,
+  0x3FEDE00000000000, 0, 0x3FB1973BD1466000, 0xBD25325D560D9E9B,
+  0x3FEDA00000000000, 0, 0x3FB3BDF5A7D1E000, 0x3D2CC85EA5DB4ED7,
+  0x3FED600000000000, 0, 0x3FB5E95A4D97A000, 0xBD2C69063C5D1D1E,
+  0x3FED400000000000, 0, 0x3FB700D30AEAC000, 0x3CEC1E8DA99DED32,
+  0x3FED000000000000, 0, 0x3FB9335E5D594000, 0x3D23115C3ABD47DA,
+  0x3FECC00000000000, 0, 0x3FBB6AC88DAD6000, 0xBD1390802BF768E5,
+  0x3FECA00000000000, 0, 0x3FBC885801BC4000, 0x3D2646D1C65AACD3,
+  0x3FEC600000000000, 0, 0x3FBEC739830A2000, 0xBD2DC068AFE645E0,
+  0x3FEC400000000000, 0, 0x3FBFE89139DBE000, 0xBD2534D64FA10AFD,
+  0x3FEC000000000000, 0, 0x3FC1178E8227E000, 0x3D21EF78CE2D07F2,
+  0x3FEBE00000000000, 0, 0x3FC1AA2B7E23F000, 0x3D2CA78E44389934,
+  0x3FEBA00000000000, 0, 0x3FC2D1610C868000, 0x3D039D6CCB81B4A1,
+  0x3FEB800000000000, 0, 0x3FC365FCB0159000, 0x3CC62FA8234B7289,
+  0x3FEB400000000000, 0, 0x3FC4913D8333B000, 0x3D25837954FDB678,
+  0x3FEB200000000000, 0, 0x3FC527E5E4A1B000, 0x3D2633E8E5697DC7,
+  0x3FEAE00000000000, 0, 0x3FC6574EBE8C1000, 0x3D19CF8B2C3C2E78,
+  0x3FEAC00000000000, 0, 0x3FC6F0128B757000, 0xBD25118DE59C21E1,
+  0x3FEAA00000000000, 0, 0x3FC7898D85445000, 0xBD1C661070914305,
+  0x3FEA600000000000, 0, 0x3FC8BEAFEB390000, 0xBD073D54AAE92CD1,
+  0x3FEA400000000000, 0, 0x3FC95A5ADCF70000, 0x3D07F22858A0FF6F,
+  0x3FEA000000000000, 0, 0x3FCA93ED3C8AE000, 0xBD28724350562169,
+  0x3FE9E00000000000, 0, 0x3FCB31D8575BD000, 0xBD0C358D4EACE1AA,
+  0x3FE9C00000000000, 0, 0x3FCBD087383BE000, 0xBD2D4BC4595412B6,
+  0x3FE9A00000000000, 0, 0x3FCC6FFBC6F01000, 0xBCF1EC72C5962BD2,
+  0x3FE9600000000000, 0, 0x3FCDB13DB0D49000, 0xBD2AFF2AF715B035,
+  0x3FE9400000000000, 0, 0x3FCE530EFFE71000, 0x3CC212276041F430,
+  0x3FE9200000000000, 0, 0x3FCEF5ADE4DD0000, 0xBCCA211565BB8E11,
+  0x3FE9000000000000, 0, 0x3FCF991C6CB3B000, 0x3D1BCBECCA0CDF30,
+  0x3FE8C00000000000, 0, 0x3FD07138604D5800, 0x3CF89CDB16ED4E91,
+  0x3FE8A00000000000, 0, 0x3FD0C42D67616000, 0x3D27188B163CEAE9,
+  0x3FE8800000000000, 0, 0x3FD1178E8227E800, 0xBD2C210E63A5F01C,
+  0x3FE8600000000000, 0, 0x3FD16B5CCBACF800, 0x3D2B9ACDF7A51681,
+  0x3FE8400000000000, 0, 0x3FD1BF99635A6800, 0x3D2CA6ED5147BDB7,
+  0x3FE8200000000000, 0, 0x3FD214456D0EB800, 0x3D0A87DEBA46BAEA,
+  0x3FE7E00000000000, 0, 0x3FD2BEF07CDC9000, 0x3D2A9CFA4A5004F4,
+  0x3FE7C00000000000, 0, 0x3FD314F1E1D36000, 0xBD28E27AD3213CB8,
+  0x3FE7A00000000000, 0, 0x3FD36B6776BE1000, 0x3D116ECDB0F177C8,
+  0x3FE7800000000000, 0, 0x3FD3C25277333000, 0x3D183B54B606BD5C,
+  0x3FE7600000000000, 0, 0x3FD419B423D5E800, 0x3D08E436EC90E09D,
+  0x3FE7400000000000, 0, 0x3FD4718DC271C800, 0xBD2F27CE0967D675,
+  0x3FE7200000000000, 0, 0x3FD4C9E09E173000, 0xBD2E20891B0AD8A4,
+  0x3FE7000000000000, 0, 0x3FD522AE0738A000, 0x3D2EBE708164C759,
+  0x3FE6E00000000000, 0, 0x3FD57BF753C8D000, 0x3D1FADEDEE5D40EF,
+  0x3FE6C00000000000, 0, 0x3FD5D5BDDF596000, 0xBD0A0B2A08A465DC
+]);
+
+// @ts-ignore: decorator
+@inline
+const POW_LOG_TABLE64_BITS = 7;
+
+
+/** @internal */
+// @ts-ignore: decorator
+@lazy var
+  rempio2_32_y: f64,
+  rempio2_y0: f64,
+  rempio2_y1: f64,
+  res128_hi:  u64;
+
+/** @internal */
+// @ts-ignore: decorator
+@lazy export var
+  sincos_cos32: f32,
+  sincos_cos64: f64;
+
+
+/** @internal */
+export function murmurHash3(h: u64): u64 { // Force all bits of a hash block to avalanche
+  h ^= h >> 33;                     // see: https://github.com/aappleby/smhasher
+  h *= 0xFF51AFD7ED558CCD;
+  h ^= h >> 33;
+  h *= 0xC4CEB9FE1A85EC53;
+  h ^= h >> 33;
+  return h;
+}
+
+/** @internal */
+function R32(z: f32): f32 { // Rational approximation of (asin(x)-x)/x^3
+  const                    // see: musl/src/math/asinf.c and SUN COPYRIGHT NOTICE above
+    pS0 = reinterpret<f32>(0x3E2AAA75), //  1.6666586697e-01f
+    pS1 = reinterpret<f32>(0xBD2F13BA), // -4.2743422091e-02f
+    pS2 = reinterpret<f32>(0xBC0DD36B), // -8.6563630030e-03f
+    qS1 = reinterpret<f32>(0xBF34E5AE); // -7.0662963390e-01f
+
+  var p = z * (pS0 + z * (pS1 + z * pS2));
+  var q: f32 = 1 + z * qS1;
+  return p / q;
+}
+
+/** @internal */
+function R64(z: f64): f64 { // Rational approximation of (asin(x)-x)/x^3
+  const                   // see: musl/src/math/asin.c and SUN COPYRIGHT NOTICE above
+    pS0 = reinterpret<f64>(0x3FC5555555555555), //  1.66666666666666657415e-01
+    pS1 = reinterpret<f64>(0xBFD4D61203EB6F7D), // -3.25565818622400915405e-01
+    pS2 = reinterpret<f64>(0x3FC9C1550E884455), //  2.01212532134862925881e-01
+    pS3 = reinterpret<f64>(0xBFA48228B5688F3B), // -4.00555345006794114027e-02
+    pS4 = reinterpret<f64>(0x3F49EFE07501B288), //  7.91534994289814532176e-04
+    pS5 = reinterpret<f64>(0x3F023DE10DFDF709), //  3.47933107596021167570e-05
+    qS1 = reinterpret<f64>(0xC0033A271C8A2D4B), // -2.40339491173441421878e+00
+    qS2 = reinterpret<f64>(0x40002AE59C598AC8), //  2.02094576023350569471e+00
+    qS3 = reinterpret<f64>(0xBFE6066C1B8D0159), // -6.88283971605453293030e-01
+    qS4 = reinterpret<f64>(0x3FB3B8C5B12E9282); //  7.70381505559019352791e-02
+
+  var p = z * (pS0 + z * (pS1 + z * (pS2 + z * (pS3 + z * (pS4 + z * pS5)))));
+  var q = 1.0 + z * (qS1 + z * (qS2 + z * (qS3 + z * qS4)));
+  return p / q;
+}
+
+// @ts-ignore: decorator
+@inline
+function expo2_32(x: f32, sign: f32): f32 { // exp(x)/2 for x >= log(DBL_MAX)
+  const                                // see: musl/src/math/__expo2f.c
+    k    = <u32>235,
+    kln2 = reinterpret<f32>(0x4322E3BC); // 0x1.45c778p+7f
+  var scale = reinterpret<f32>(<u32>(0x7F + (k >> 1)) << 23);
+  // in directed rounding correct sign before rounding or overflow is important
+  return exp32(x - kln2) * (sign * scale) * scale;
+}
+
+/** @internal */
+// @ts-ignore: decorator
+@inline
+function expo2_64(x: f64, sign: f64): f64 { // exp(x)/2 for x >= log(DBL_MAX)
+  const                       // see: musl/src/math/__expo2.c
+    k    = <u32>2043,
+    kln2 = reinterpret<f64>(0x40962066151ADD8B); // 0x1.62066151add8bp+10
+  var scale = reinterpret<f64>(<u64>((<u32>0x3FF + k / 2) << 20) << 32);
+  // in directed rounding correct sign before rounding or overflow is important
+  return exp64(x - kln2) * (sign * scale) * scale;
+}
+
+/** @internal */
+// helper for pow32
+// See: jdh8/metallic/src/math/float/log2f.c and jdh8/metallic/src/math/float/kernel/atanh.h
+// @ts-ignore: decorator
+@inline
+function log2up32(x: f64): f64 {
+  const
+    log2e = reinterpret<f64>(0x3FF71547652B82FE), // 1.44269504088896340736
+    c0 = reinterpret<f64>(0x3FD555554FD9CAEF),    // 0.33333332822728226129
+    c1 = reinterpret<f64>(0x3FC999A7A8AF4132),    // 0.20000167595436263505
+    c2 = reinterpret<f64>(0x3FC2438D79437030),    // 0.14268654271188685375
+    c3 = reinterpret<f64>(0x3FBE2F663B001C97);    // 0.11791075649681414150
+
+  var i = reinterpret<i64>(x);
+  var exponent = (i - 0x3FE6A09E667F3BCD) >> 52;
+  x = reinterpret<f64>(i - (exponent << 52));
+  x = (x - 1) / (x + 1);
+  var xx = x * x;
+  var y = x + x * xx * (c0 + c1 * xx + (c2 + c3 * xx) * (xx * xx));
+  return (2 * log2e) * y + <f64>exponent;
+}
+
+/** @internal */
+// helper for pow32
+// See: jdh8/metallic/src/math/float/exp2f.h and jdh8/metallic/blob/master/src/math/float/kernel/exp2f.h
+// @ts-ignore: decorator
+@inline
+function exp2up32(x: f64): f64 {
+  const
+    c0 = reinterpret<f64>(0x3FE62E4302FCC24A), // 6.931471880289532425e-1
+    c1 = reinterpret<f64>(0x3FCEBFBE07D97B91), // 2.402265108421173406e-1
+    c2 = reinterpret<f64>(0x3FAC6AF6CCFC1A65), // 5.550357105498874537e-2
+    c3 = reinterpret<f64>(0x3F83B29E3CE9AEF6), // 9.618030771171497658e-3
+    c4 = reinterpret<f64>(0x3F55F0896145A89F), // 1.339086685300950937e-3
+    c5 = reinterpret<f64>(0x3F2446C81E384864); // 1.546973499989028719e-4
+
+  if (x < -1022) return 0;
+  if (x >= 1024) return Infinity;
+
+  var n = nearest(x);
+  x -= n;
+  var xx = x * x;
+  var y = 1 + x * (c0 + c1 * x + (c2 + c3 * x) * xx + (c4 + c5 * x) * (xx * xx));
+  return reinterpret<f64>(reinterpret<i64>(y) + (<i64>n << 52));
+}
+
+/** @internal */
+/* Helper function to eventually get bits of π/2 * |x|
+ *
+ * y = π/4 * (frac << clz(frac) >> 11)
+ * return clz(frac)
+ *
+ * Right shift 11 bits to make upper half fit in `double`
+ */
+// @ts-ignore: decorator
+@inline
+function pio2_right(q0: u64, q1: u64): u64 { // see: jdh8/metallic/blob/master/src/math/double/rem_pio2.c
+  // Bits of π/4
+  const p0: u64 = 0xC4C6628B80DC1CD1;
+  const p1: u64 = 0xC90FDAA22168C234;
+
+  const Ox1p_64 = reinterpret<f64>(0x3BF0000000000000); // 0x1p-64
+  const Ox1p_75 = reinterpret<f64>(0x3B40000000000000); // 0x1p-75
+
+  var shift = clz(q1);
+
+  q1 = q1 << shift | q0 >> (64 - shift);
+  q0 <<= shift;
+
+  var lo = umuldi(p1, q1);
+  var hi = res128_hi;
+
+  var ahi = hi >> 11;
+  var alo = lo >> 11 | hi << 53;
+  var blo = <u64>(Ox1p_75 * <f64>p0 * <f64>q1 + Ox1p_75 * <f64>p1 * <f64>q0);
+
+  rempio2_y0 = <f64>(ahi + u64(lo < blo));
+  rempio2_y1 = Ox1p_64 * <f64>(alo + blo);
+
+  return shift;
+}
+
+/** @internal */
+// @ts-ignore: decorator
+@inline
+function umuldi(u: u64, v: u64): u64 {
+  var u1: u64 , v1: u64, w0: u64, w1: u64, t: u64;
+
+  u1 = u & 0xFFFFFFFF;
+  v1 = v & 0xFFFFFFFF;
+
+  u >>= 32;
+  v >>= 32;
+
+  t  = u1 * v1;
+  w0 = t & 0xFFFFFFFF;
+  t  = u * v1 + (t >> 32);
+  w1 = t >> 32;
+  t  = u1 * v + (t & 0xFFFFFFFF);
+
+  res128_hi = u * v + w1 + (t >> 32);
+  return (t << 32) + w0;
+}
+
+/** @internal */
+// @ts-ignore: decorator
+@inline
+function pio2_32_large_quot(x: f32, u: i32): i32 { // see: jdh8/metallic/blob/master/src/math/float/rem_pio2f.c
+  const coeff = reinterpret<f64>(0x3BF921FB54442D18); // π * 0x1p-65 = 8.51530395021638647334e-20
+
+  var offset = (u >> 23) - 152;
+  var shift  = <u64>(offset & 63);
+  var tblPtr = PIO2_TABLE32 + (offset >> 6 << 3);
+
+  var b0 = load<u64>(tblPtr, 0 << 3);
+  var b1 = load<u64>(tblPtr, 1 << 3);
+  var lo: u64;
+
+  if (shift > 32) {
+    let b2 = load<u64>(tblPtr, 2 << 3);
+    lo  = b2 >> (96 - shift);
+    lo |= b1 << (shift - 32);
+  } else {
+    lo = b1 >> (32 - shift);
+  }
+
+  var hi = (b1 >> (64 - shift)) | (b0 << shift);
+  var mantissa: u64 = (u & 0x007FFFFF) | 0x00800000;
+  var product = mantissa * hi + (mantissa * lo >> 32);
+  var r: i64 = product << 2;
+  var q = <i32>((product >> 62) + (r >>> 63));
+  rempio2_32_y = copysign<f64>(coeff, x) * <f64>r;
+  return q;
+}
+
+/** @internal */
+function pio2_64_large_quot(x: f64, u: i64): i32 { // see: jdh8/metallic/blob/master/src/math/double/rem_pio2.c
+  var magnitude = u & 0x7FFFFFFFFFFFFFFF;
+  var offset = (magnitude >> 52) - 1045;
+  var shift  = offset & 63;
+  var tblPtr = PIO2_TABLE64 + (<i32>(offset >> 6) << 3);
+  var s0: u64, s1: u64, s2: u64;
+
+  var b0 = load<u64>(tblPtr, 0 << 3);
+  var b1 = load<u64>(tblPtr, 1 << 3);
+  var b2 = load<u64>(tblPtr, 2 << 3);
+
+  // Get 192 bits of 0x1p-31 / π with `offset` bits skipped
+  if (shift) {
+    let rshift = 64 - shift;
+    let b3 = load<u64>(tblPtr, 3 << 3);
+    s0 = b1 >> rshift | b0 << shift;
+    s1 = b2 >> rshift | b1 << shift;
+    s2 = b3 >> rshift | b2 << shift;
+  } else {
+    s0 = b0;
+    s1 = b1;
+    s2 = b2;
+  }
+
+  var significand = (u & 0x000FFFFFFFFFFFFF) | 0x0010000000000000;
+
+  // First 128 bits of fractional part of x/(2π)
+  var blo = umuldi(s1, significand);
+  var bhi = res128_hi;
+
+  var ahi = s0 * significand;
+  var clo = (s2 >> 32) * (significand >> 32);
+  var plo = blo + clo;
+  var phi = ahi + bhi + u64(plo < clo);
+
+  // r: u128 = p << 2
+  var rlo = plo << 2;
+  var rhi = phi << 2 | plo >> 62;
+
+  // s: i128 = r >> 127
+  var slo = <i64>rhi >> 63;
+  var shi = slo >> 1;
+  var q   = (<i64>phi >> 62) - slo;
+
+  var shifter = 0x3CB0000000000000 - (pio2_right(rlo ^ slo, rhi ^ shi) << 52);
+  var signbit = (u ^ rhi) & 0x8000000000000000;
+  var coeff   = reinterpret<f64>(shifter | signbit);
+
+  rempio2_y0 *= coeff;
+  rempio2_y1 *= coeff;
+
+  return <i32>q;
+}
+
+/** @internal */
+// @ts-ignore: decorator
+@inline
+function rempio2_32(x: f32, u: u32, sign: i32): i32 { // see: jdh8/metallic/blob/master/src/math/float/rem_pio2f.c
+  const
+    pi2hi = reinterpret<f64>(0x3FF921FB50000000), // 1.57079631090164184570
+    pi2lo = reinterpret<f64>(0x3E5110B4611A6263), // 1.58932547735281966916e-8
+    _2_pi = reinterpret<f64>(0x3FE45F306DC9C883); // 0.63661977236758134308
+
+  if (u < 0x4DC90FDB) { // π * 0x1p28
+    let q = nearest<f64>(x * _2_pi);
+    rempio2_32_y = x - q * pi2hi - q * pi2lo;
+    return <i32>q;
+  }
+
+  var q = pio2_32_large_quot(x, u);
+  return select<i32>(-q, q, sign);
+}
+
+/** @internal */
+// @ts-ignore: decorator
+@inline
+function rempio2_64(x: f64, u: u64, sign: i32): i32 {
+  const
+    pio2_1  = reinterpret<f64>(0x3FF921FB54400000), // 1.57079632673412561417e+00
+    pio2_1t = reinterpret<f64>(0x3DD0B4611A626331), // 6.07710050650619224932e-11
+    pio2_2  = reinterpret<f64>(0x3DD0B4611A600000), // 6.07710050630396597660e-11
+    pio2_2t = reinterpret<f64>(0x3BA3198A2E037073), // 2.02226624879595063154e-21
+    pio2_3  = reinterpret<f64>(0x3BA3198A2E000000), // 2.02226624871116645580e-21
+    pio2_3t = reinterpret<f64>(0x397B839A252049C1), // 8.47842766036889956997e-32
+    invpio2 = reinterpret<f64>(0x3FE45F306DC9C883); // 0.63661977236758134308
+
+  var ix = <u32>(u >> 32) & 0x7FFFFFFF;
+
+  if (ASC_SHRINK_LEVEL < 1) {
+    if (ix < 0x4002D97C) { // |x| < 3pi/4, special case with n=+-1
+      let q = 1, z: f64, y0: f64, y1: f64;
+      if (!sign) {
+        z = x - pio2_1;
+        if (ix != 0x3FF921FB) { // 33+53 bit pi is good enough
+          y0 = z - pio2_1t;
+          y1 = (z - y0) - pio2_1t;
+        } else { // near pi/2, use 33+33+53 bit pi
+          z -= pio2_2;
+          y0 = z - pio2_2t;
+          y1 = (z - y0) - pio2_2t;
+        }
+      } else { // negative x
+        z = x + pio2_1;
+        if (ix != 0x3FF921FB) { // 33+53 bit pi is good enough
+          y0 = z + pio2_1t;
+          y1 = (z - y0) + pio2_1t;
+        } else { // near pi/2, use 33+33+53 bit pi
+          z += pio2_2;
+          y0 = z + pio2_2t;
+          y1 = (z - y0) + pio2_2t;
+        }
+        q = -1;
+      }
+      rempio2_y0 = y0;
+      rempio2_y1 = y1;
+      return q;
+    }
+  }
+
+  if (ix < 0x413921FB) { // |x| ~< 2^20*pi/2 (1647099)
+    // Use precise Cody Waite scheme
+    let q  = nearest<f64>(x * invpio2);
+    let r  = x - q * pio2_1;
+    let w  = q * pio2_1t; // 1st round good to 85 bit
+    let j  = ix >> 20;
+    let y0 = r - w;
+    let hi = <u32>(reinterpret<u64>(y0) >> 32);
+    let i  = j - ((hi >> 20) & 0x7FF);
+
+    if (i > 16) { // 2nd iteration needed, good to 118
+      let t = r;
+      w  = q * pio2_2;
+      r  = t - w;
+      w  = q * pio2_2t - ((t - r) - w);
+      y0 = r - w;
+      hi = <u32>(reinterpret<u64>(y0) >> 32);
+      i = j - ((hi >> 20) & 0x7FF);
+      if (i > 49) { // 3rd iteration need, 151 bits acc
+        let t = r;
+        w  = q * pio2_3;
+        r  = t - w;
+        w  = q * pio2_3t - ((t - r) - w);
+        y0 = r - w;
+      }
+    }
+    let y1 = (r - y0) - w;
+    rempio2_y0 = y0;
+    rempio2_y1 = y1;
+    return <i32>q;
+  }
+  var q = pio2_64_large_quot(x, u);
+  return select<i32>(-q, q, sign);
+}
+
+/** @internal */
+// |sin(x)/x - s(x)| < 2**-37.5 (~[-4.89e-12, 4.824e-12]).
+// @ts-ignore: decorator
+@inline
+function sin32_kern(x: f64): f32 { // see: musl/tree/src/math/__sindf.c
+  const
+    S1 = reinterpret<f64>(0xBFC5555554CBAC77), // -0x15555554cbac77.0p-55
+    S2 = reinterpret<f64>(0x3F811110896EFBB2), //  0x111110896efbb2.0p-59
+    S3 = reinterpret<f64>(0xBF2A00F9E2CAE774), // -0x1a00f9e2cae774.0p-65
+    S4 = reinterpret<f64>(0x3EC6CD878C3B46A7); //  0x16cd878c3b46a7.0p-71
+
+  var z = x * x;
+  var w = z * z;
+  var r = S3 + z * S4;
+  var s = z * x;
+  return <f32>((x + s * (S1 + z * S2)) + s * w * r);
+}
+
+/** @internal */
+// @ts-ignore: decorator
+@inline
+function sin64_kern(x: f64, y: f64, iy: i32): f64 { // see: musl/tree/src/math/__sin.c
+  const
+    S1 = reinterpret<f64>(0xBFC5555555555549), // -1.66666666666666324348e-01
+    S2 = reinterpret<f64>(0x3F8111111110F8A6), //  8.33333333332248946124e-03
+    S3 = reinterpret<f64>(0xBF2A01A019C161D5), // -1.98412698298579493134e-04
+    S4 = reinterpret<f64>(0x3EC71DE357B1FE7D), //  2.75573137070700676789e-06
+    S5 = reinterpret<f64>(0xBE5AE5E68A2B9CEB), // -2.50507602534068634195e-08
+    S6 = reinterpret<f64>(0x3DE5D93A5ACFD57C); //  1.58969099521155010221e-10
+
+  var z = x * x;
+  var w = z * z;
+  var r = S2 + z * (S3 + z * S4) + z * w * (S5 + z * S6);
+  var v = z * x;
+  if (!iy) {
+    return x + v * (S1 + z * r);
+  } else {
+    return x - ((z * (0.5 * y - v * r) - y) - v * S1);
+  }
+}
+
+/** @internal */
+// |cos(x) - c(x)| < 2**-34.1 (~[-5.37e-11, 5.295e-11]).
+// @ts-ignore: decorator
+@inline
+function cos32_kern(x: f64): f32 { // see: musl/tree/src/math/__cosdf.c
+  const
+    C0 = reinterpret<f64>(0xBFDFFFFFFD0C5E81), // -0x1ffffffd0c5e81.0p-54
+    C1 = reinterpret<f64>(0x3FA55553E1053A42), //  0x155553e1053a42.0p-57
+    C2 = reinterpret<f64>(0xBF56C087E80F1E27), // -0x16c087e80f1e27.0p-62
+    C3 = reinterpret<f64>(0x3EF99342E0EE5069); //  0x199342e0ee5069.0p-68
+
+  var z = x * x;
+  var w = z * z;
+  var r = C2 + z * C3;
+  return <f32>(((1 + z * C0) + w * C1) + (w * z) * r);
+}
+
+/** @internal */
+// @ts-ignore: decorator
+@inline
+function cos64_kern(x: f64, y: f64): f64 { // see: musl/tree/src/math/__cos.c
+  const
+    C1 = reinterpret<f64>(0x3FA555555555554C), //  4.16666666666666019037e-02
+    C2 = reinterpret<f64>(0xBF56C16C16C15177), // -1.38888888888741095749e-03
+    C3 = reinterpret<f64>(0x3EFA01A019CB1590), //  2.48015872894767294178e-05
+    C4 = reinterpret<f64>(0xBE927E4F809C52AD), // -2.75573143513906633035e-07
+    C5 = reinterpret<f64>(0x3E21EE9EBDB4B1C4), //  2.08757232129817482790e-09
+    C6 = reinterpret<f64>(0xBDA8FAE9BE8838D4); // -1.13596475577881948265e-11
+
+  var z = x * x;
+  var w = z * z;
+  var r = z * (C1 + z * (C2 + z * C3)) + w * w * (C4 + z * (C5 + z * C6));
+  var hz = 0.5 * z;
+  w = 1.0 - hz;
+  return w + (((1.0 - w) - hz) + (z * r - x * y));
+}
+
+/** @internal */
+// |tan(x)/x - t(x)| < 2**-25.5 (~[-2e-08, 2e-08]).
+// @ts-ignore: decorator
+@inline
+function tan32_kern(x: f64, odd: i32): f32 { // see: musl/tree/src/math/__tandf.c
+  const
+    T0 = reinterpret<f64>(0x3FD5554D3418C99F), // 0x15554d3418c99f.0p-54
+    T1 = reinterpret<f64>(0x3FC112FD38999F72), // 0x1112fd38999f72.0p-55
+    T2 = reinterpret<f64>(0x3FAB54C91D865AFE), // 0x1b54c91d865afe.0p-57
+    T3 = reinterpret<f64>(0x3F991DF3908C33CE), // 0x191df3908c33ce.0p-58
+    T4 = reinterpret<f64>(0x3F685DADFCECF44E), // 0x185dadfcecf44e.0p-61
+    T5 = reinterpret<f64>(0x3F8362B9BF971BCD); // 0x1362b9bf971bcd.0p-59
+
+  var z = x * x;
+  var r = T4 + z * T5;
+  var t = T2 + z * T3;
+  var w = z * z;
+  var s = z * x;
+  var u = T0 + z * T1;
+
+  r = (x + s * u) + (s * w) * (t + w * r);
+  return <f32>(odd ? -1 / r : r);
+}
+
+/** @internal */
+function tan64_kern(x: f64, y: f64, iy: i32): f64 { // see: src/lib/msun/src/k_tan.c
+  const
+    T0  = reinterpret<f64>(0x3FD5555555555563), //  3.33333333333334091986e-01
+    T1  = reinterpret<f64>(0x3FC111111110FE7A), //  1.33333333333201242699e-01
+    T2  = reinterpret<f64>(0x3FABA1BA1BB341FE), //  5.39682539762260521377e-02
+    T3  = reinterpret<f64>(0x3F9664F48406D637), //  2.18694882948595424599e-02
+    T4  = reinterpret<f64>(0x3F8226E3E96E8493), //  8.86323982359930005737e-03
+    T5  = reinterpret<f64>(0x3F6D6D22C9560328), //  3.59207910759131235356e-03
+    T6  = reinterpret<f64>(0x3F57DBC8FEE08315), //  1.45620945432529025516e-03
+    T7  = reinterpret<f64>(0x3F4344D8F2F26501), //  5.88041240820264096874e-04
+    T8  = reinterpret<f64>(0x3F3026F71A8D1068), //  2.46463134818469906812e-04
+    T9  = reinterpret<f64>(0x3F147E88A03792A6), //  7.81794442939557092300e-05
+    T10 = reinterpret<f64>(0x3F12B80F32F0A7E9), //  7.14072491382608190305e-05
+    T11 = reinterpret<f64>(0xBEF375CBDB605373), // -1.85586374855275456654e-05
+    T12 = reinterpret<f64>(0x3EFB2A7074BF7AD4); //  2.59073051863633712884e-05
+
+  const
+    one    = reinterpret<f64>(0x3FF0000000000000), // 1.00000000000000000000e+00
+    pio4   = reinterpret<f64>(0x3FE921FB54442D18), // 7.85398163397448278999e-01
+    pio4lo = reinterpret<f64>(0x3C81A62633145C07); // 3.06161699786838301793e-17
+
+  var z: f64, r: f64, v: f64, w: f64, s: f64;
+  var hx = <i32>(reinterpret<u64>(x) >> 32); // high word of x
+  var ix = hx & 0x7FFFFFFF; // high word of |x|
+  var big = ix >= 0x3FE59428;
+  if (big) { // |x| >= 0.6744
+    if (hx < 0) { x = -x, y = -y; }
+    z = pio4 - x;
+    w = pio4lo - y;
+    x = z + w;
+    y = 0.0;
+  }
+  z = x * x;
+  w = z * z;
+  r = T1 + w * (T3 + w * (T5 + w * (T7 + w * (T9 + w * T11))));
+  v = z * (T2 + w * (T4 + w * (T6 + w * (T8 + w * (T10 + w * T12)))));
+  s = z * x;
+  r = y + z * (s * (r + v) + y);
+  r += T0 * s;
+  w = x + r;
+  if (big) {
+    v = iy;
+    return (1 - ((hx >> 30) & 2)) * (v - 2.0 * (x - (w * w / (w + v) - r)));
+  }
+  if (iy == 1) return w;
+  var a: f64, t: f64;
+  z = w;
+  z = reinterpret<f64>(reinterpret<u64>(z) & 0xFFFFFFFF00000000);
+  v = r - (z - x);  // z + v = r + x
+  t = a = -one / w; // a = -1.0 / w
+  t = reinterpret<f64>(reinterpret<u64>(t) & 0xFFFFFFFF00000000);
+  s = one + t * z;
+  return t + a * (s + t * v);
+}
+
+/** @internal */
+export function dtoi32(x: f64): i32 {
+  if (ASC_SHRINK_LEVEL > 0) {
+    const inv32 = 1.0 / 4294967296;
+    return <i32><i64>(x - 4294967296 * floor(x * inv32));
+  } else {
+    let result = 0;
+    let u = reinterpret<u64>(x);
+    let e = (u >> 52) & 0x7FF;
+    if (e <= 1023 + 30) {
+      result = <i32>x;
+    } else if (e <= 1023 + 30 + 53) {
+      let v = (u & ((<u64>1 << 52) - 1)) | (<u64>1 << 52);
+      v = v << e - 1023 - 52 + 32;
+      result = <i32>(v >> 32);
+      result = select<i32>(-result, result, u >> 63);
+    }
+    return result;
+  }
+}
+
+export function ipow32(x: i32, e: i32): i32 {
+  var out = 1;
+  if (ASC_SHRINK_LEVEL < 1) {
+    if (x == 2) {
+      return select<i32>(1 << e, 0, <u32>e < 32);
+    }
+    if (e <= 0) {
+      if (x == -1) return select<i32>(-1, 1, e & 1);
+      return i32(e == 0) | i32(x == 1);
+    }
+    else if (e == 1) return x;
+    else if (e == 2) return x * x;
+    else if (e < 32) {
+      let log = 32 - clz<i32>(e);
+      // 32 = 2 ^ 5, so need only five cases.
+      // But some extra cases needs for properly overflowing
+      switch (log) {
+        case 5: {
+          if (e & 1) out *= x;
+          e >>>= 1;
+          x *= x;
+        }
+        case 4: {
+          if (e & 1) out *= x;
+          e >>>= 1;
+          x *= x;
+        }
+        case 3: {
+          if (e & 1) out *= x;
+          e >>>= 1;
+          x *= x;
+        }
+        case 2: {
+          if (e & 1) out *= x;
+          e >>>= 1;
+          x *= x;
+        }
+        case 1: {
+          if (e & 1) out *= x;
+        }
+      }
+      return out;
+    }
+  }
+  while (e) {
+    if (e & 1) out *= x;
+    e >>>= 1;
+    x *= x;
+  }
+  return out;
+}
+
+export function ipow64(x: i64, e: i64): i64 {
+  var out: i64 = 1;
+  if (ASC_SHRINK_LEVEL < 1) {
+    if (x == 2) {
+      return select<i64>(1 << e, 0, <u64>e < 64);
+    }
+    if (e <= 0) {
+      if (x == -1) return select<i64>(-1, 1, e & 1);
+      return i64(e == 0) | i64(x == 1);
+    }
+    else if (e == 1) return x;
+    else if (e == 2) return x * x;
+    else if (e < 64) {
+      let log = 64 - <i32>clz<i64>(e);
+      // 64 = 2 ^ 6, so need only six cases.
+      // But some extra cases needs for properly overflowing
+      switch (log) {
+        case 6: {
+          if (e & 1) out *= x;
+          e >>>= 1;
+          x *= x;
+        }
+        case 5: {
+          if (e & 1) out *= x;
+          e >>>= 1;
+          x *= x;
+        }
+        case 4: {
+          if (e & 1) out *= x;
+          e >>>= 1;
+          x *= x;
+        }
+        case 3: {
+          if (e & 1) out *= x;
+          e >>>= 1;
+          x *= x;
+        }
+        case 2: {
+          if (e & 1) out *= x;
+          e >>>= 1;
+          x *= x;
+        }
+        case 1: {
+          if (e & 1) out *= x;
+        }
+      }
+      return out;
+    }
+  }
+  while (e) {
+    if (e & 1) out *= x;
+    e >>>= 1;
+    x *= x;
+  }
+  return out;
+}
+
+export function acos32(x: f32): f32 { // see: musl/src/math/acosf.c and SUN COPYRIGHT NOTICE above
+  const
+    pio2_hi   = reinterpret<f32>(0x3FC90FDA), // 1.5707962513e+00f
+    pio2_lo   = reinterpret<f32>(0x33A22168), // 7.5497894159e-08f
+    Ox1p_120f = reinterpret<f32>(0x03800000); // 0x1p-120f
+
+  var hx = reinterpret<u32>(x);
+  var ix = hx & 0x7FFFFFFF;
+  if (ix >= 0x3F800000) {
+    if (ix == 0x3F800000) {
+      if (hx >> 31) return 2 * pio2_hi + Ox1p_120f;
+      return 0;
+    }
+    return 0 / (x - x);
+  }
+  if (ix < 0x3F000000) {
+    if (ix <= 0x32800000) return pio2_hi + Ox1p_120f;
+    return pio2_hi - (x - (pio2_lo - x * R32(x * x)));
+  }
+  var z: f32, w: f32, s: f32;
+  if (hx >> 31) {
+    // z = (1 + x) * 0.5;
+    z = 0.5 + x * 0.5;
+    s = sqrt<f32>(z);
+    w = R32(z) * s - pio2_lo;
+    return 2 * (pio2_hi - (s + w));
+  }
+  // z = (1 - x) * 0.5;
+  z = 0.5 - x * 0.5;
+  s = sqrt<f32>(z);
+  hx = reinterpret<u32>(s);
+  var df = reinterpret<f32>(hx & 0xFFFFF000);
+  var c = (z - df * df) / (s + df);
+  w = R32(z) * s + c;
+  return 2 * (df + w);
+}
+
+export function acos64(x: f64): f64 { // see: musl/src/math/acos.c and SUN COPYRIGHT NOTICE above
+  const
+    pio2_hi   = reinterpret<f64>(0x3FF921FB54442D18), // 1.57079632679489655800e+00
+    pio2_lo   = reinterpret<f64>(0x3C91A62633145C07), // 6.12323399573676603587e-17
+    Ox1p_120f = reinterpret<f32>(0x03800000);
+
+  var hx = <u32>(reinterpret<u64>(x) >> 32);
+  var ix = hx & 0x7FFFFFFF;
+  if (ix >= 0x3FF00000) {
+    let lx = <u32>reinterpret<u64>(x);
+    if ((ix - 0x3FF00000 | lx) == 0) {
+      if (hx >> 31) return 2 * pio2_hi + Ox1p_120f;
+      return 0;
+    }
+    return 0 / (x - x);
+  }
+  if (ix < 0x3FE00000) {
+    if (ix <= 0x3C600000) return pio2_hi + Ox1p_120f;
+    return pio2_hi - (x - (pio2_lo - x * R64(x * x)));
+  }
+  var s: f64, w: f64, z: f64;
+  if (hx >> 31) {
+    // z = (1.0 + x) * 0.5;
+    z = 0.5 + x * 0.5;
+    s = sqrt<f64>(z);
+    w = R64(z) * s - pio2_lo;
+    return 2 * (pio2_hi - (s + w));
+  }
+  // z = (1.0 - x) * 0.5;
+  z = 0.5 - x * 0.5;
+  s = sqrt<f64>(z);
+  var df = reinterpret<f64>(reinterpret<u64>(s) & 0xFFFFFFFF00000000);
+  var c = (z - df * df) / (s + df);
+  w = R64(z) * s + c;
+  return 2 * (df + w);
+}
+
+export function acosh32(x: f32): f32 { // see: musl/src/math/acoshf.c
+  const s = reinterpret<f32>(0x3F317218); // 0.693147180559945309417232121458176568f
+  var u = reinterpret<u32>(x);
+  var a = u & 0x7FFFFFFF;
+  if (a < 0x3F800000 + (1 << 23)) { // |x| < 2, invalid if x < 1
+    let xm1 = x - 1;
+    return log1p32(xm1 + sqrt<f32>(xm1 * (xm1 + 2)));
+  }
+  if (u < 0x3F800000 + (12 << 23)) { // 2 <= x < 0x1p12
+    return log32(2 * x - 1 / (x + sqrt<f32>(x * x - 1)));
+  }
+  // x >= 0x1p12 or x <= -2 or NaN
+  return log32(x) + s;
+}
+
+export function acosh64(x: f64): f64 { // see: musl/src/math/acosh.c
+  const s = reinterpret<f64>(0x3FE62E42FEFA39EF);
+  var u = reinterpret<u64>(x);
+  // Prevent propagation for all input values less than 1.0.
+  // Note musl lib didn't fix this yet.
+  if (<i64>u < 0x3FF0000000000000) return (x - x) / 0.0;
+  var e = u >> 52 & 0x7FF;
+  if (e < 0x3FF + 1) return log1p64(x - 1 + sqrt<f64>((x - 1) * (x - 1) + 2 * (x - 1)));
+  if (e < 0x3FF + 26) return log64(2 * x - 1 / (x + sqrt<f64>(x * x - 1)));
+  return log64(x) + s;
+}
+
+export function asin32(x: f32): f32 { // see: musl/src/math/asinf.c and SUN COPYRIGHT NOTICE above
+  const
+    pio2      = reinterpret<f32>(0x3FC90FDB), // 1.570796326794896558e+00f
+    Ox1p_120f = reinterpret<f32>(0x03800000); // 0x1p-120f
+
+  var sx = x;
+  var hx = reinterpret<u32>(x) & 0x7FFFFFFF;
+  if (hx >= 0x3F800000) {
+    if (hx == 0x3F800000) return x * pio2 + Ox1p_120f;
+    return 0 / (x - x);
+  }
+  if (hx < 0x3F000000) {
+    if (hx < 0x39800000 && hx >= 0x00800000) return x;
+    return x + x * R32(x * x);
+  }
+  // var z: f32 = (1 - builtin_abs<f32>(x)) * 0.5;
+  var z: f32 = 0.5 - abs<f32>(x) * 0.5;
+  var s = sqrt<f64>(z); // sic
+  x = <f32>(pio2 - 2 * (s + s * R32(z)));
+  return copysign<f32>(x, sx);
+}
+
+export function asin64(x: f64): f64 { // see: musl/src/math/asin.c and SUN COPYRIGHT NOTICE above
+  const
+    pio2_hi   = reinterpret<f64>(0x3FF921FB54442D18), // 1.57079632679489655800e+00
+    pio2_lo   = reinterpret<f64>(0x3C91A62633145C07), // 6.12323399573676603587e-17
+    Ox1p_120f = reinterpret<f32>(0x03800000);
+
+  var hx = <u32>(reinterpret<u64>(x) >> 32);
+  var ix = hx & 0x7FFFFFFF;
+  if (ix >= 0x3FF00000) {
+    let lx = <u32>reinterpret<u64>(x);
+    if ((ix - 0x3FF00000 | lx) == 0) return x * pio2_hi + Ox1p_120f;
+    return 0 / (x - x);
+  }
+  if (ix < 0x3FE00000) {
+    if (ix < 0x3E500000 && ix >= 0x00100000) return x;
+    return x + x * R64(x * x);
+  }
+  // var z = (1.0 - builtin_abs<f64>(x)) * 0.5;
+  var z = 0.5 - abs<f64>(x) * 0.5;
+  var s = sqrt<f64>(z);
+  var r = R64(z);
+  if (ix >= 0x3FEF3333) x = pio2_hi - (2 * (s + s * r) - pio2_lo);
+  else {
+    let f = reinterpret<f64>(reinterpret<u64>(s) & 0xFFFFFFFF00000000);
+    let c = (z - f * f) / (s + f);
+    x = 0.5 * pio2_hi - (2 * s * r - (pio2_lo - 2 * c) - (0.5 * pio2_hi - 2 * f));
+  }
+  if (hx >> 31) return -x;
+  return x;
+}
+
+export function asinh32(x: f32): f32 { // see: musl/src/math/asinhf.c
+  const c = reinterpret<f32>(0x3F317218); // 0.693147180559945309417232121458176568f
+  var u = reinterpret<u32>(x) & 0x7FFFFFFF;
+  var y = reinterpret<f32>(u);
+  if (u >= 0x3F800000 + (12 << 23)) y = log32(y) + c;
+  else if (u >= 0x3F800000 + (1 << 23))  y =   log32(2 * y + 1 / (sqrt<f32>(y * y + 1) + y));
+  else if (u >= 0x3F800000 - (12 << 23)) y = log1p32(y + y * y / (sqrt<f32>(y * y + 1) + 1));
+  return copysign<f32>(y, x);
+}
+
+export function asinh64(x: f64): f64 { // see: musl/src/math/asinh.c
+  const c = reinterpret<f64>(0x3FE62E42FEFA39EF); // 0.693147180559945309417232121458176568
+  var u = reinterpret<u64>(x);
+  var e = u >> 52 & 0x7FF;
+  var y = reinterpret<f64>(u & 0x7FFFFFFFFFFFFFFF);
+  if (e >= 0x3FF + 26) y = log64(y) + c;
+  else if (e >= 0x3FF + 1)  y =   log64(2 * y + 1 / (sqrt<f64>(y * y + 1) + y));
+  else if (e >= 0x3FF - 26) y = log1p64(y + y * y / (sqrt<f64>(y * y + 1) + 1));
+  return copysign<f64>(y, x);
+}
+
+export function atan32(x: f32): f32 { // see: musl/src/math/atanf.c and SUN COPYRIGHT NOTICE above
+  const
+    atanhi0   = reinterpret<f32>(0x3EED6338), //  4.6364760399e-01f
+    atanhi1   = reinterpret<f32>(0x3F490FDA), //  7.8539812565e-01f
+    atanhi2   = reinterpret<f32>(0x3F7B985E), //  9.8279368877e-01f
+    atanhi3   = reinterpret<f32>(0x3FC90FDA), //  1.5707962513e+00f
+    atanlo0   = reinterpret<f32>(0x31AC3769), //  5.0121582440e-09f
+    atanlo1   = reinterpret<f32>(0x33222168), //  3.7748947079e-08f
+    atanlo2   = reinterpret<f32>(0x33140FB4), //  3.4473217170e-08f
+    atanlo3   = reinterpret<f32>(0x33A22168), //  7.5497894159e-08f
+    aT0       = reinterpret<f32>(0x3EAAAAA9), //  3.3333328366e-01f
+    aT1       = reinterpret<f32>(0xBE4CCA98), // -1.9999158382e-01f
+    aT2       = reinterpret<f32>(0x3E11F50D), //  1.4253635705e-01f
+    aT3       = reinterpret<f32>(0xBDDA1247), // -1.0648017377e-01f
+    aT4       = reinterpret<f32>(0x3D7CAC25), //  6.1687607318e-02f
+    Ox1p_120f = reinterpret<f32>(0x03800000); //  0x1p-120f
+
+  var ix = reinterpret<u32>(x);
+  var sx = x;
+  ix &= 0x7FFFFFFF;
+  var z: f32;
+  if (ix >= 0x4C800000) {
+    if (isNaN(x)) return x;
+    z = atanhi3 + Ox1p_120f;
+    return copysign<f32>(z, sx);
+  }
+  var id: i32;
+  if (ix < 0x3EE00000) {
+    if (ix < 0x39800000) return x;
+    id = -1;
+  } else {
+    x = abs<f32>(x);
+    if (ix < 0x3F980000) {
+      if (ix < 0x3F300000) {
+        id = 0;
+        x = (2.0 * x - 1.0) / (2.0 + x);
+      } else {
+        id = 1;
+        x = (x - 1.0) / (x + 1.0);
+      }
+    } else {
+      if (ix < 0x401C0000) {
+        id = 2;
+        x = (x - 1.5) / (1.0 + 1.5 * x);
+      } else {
+        id = 3;
+        x = -1.0 / x;
+      }
+    }
+  }
+  z = x * x;
+  var w = z * z;
+  var s1 = z * (aT0 + w * (aT2 + w * aT4));
+  var s2 = w * (aT1 + w * aT3);
+  var s3 = x * (s1 + s2);
+  if (id < 0) return x - s3;
+  switch (id) {
+    case 0: { z = atanhi0 - ((s3 - atanlo0) - x); break; }
+    case 1: { z = atanhi1 - ((s3 - atanlo1) - x); break; }
+    case 2: { z = atanhi2 - ((s3 - atanlo2) - x); break; }
+    case 3: { z = atanhi3 - ((s3 - atanlo3) - x); break; }
+    default: unreachable();
+  }
+  return copysign<f32>(z, sx);
+}
+
+export function atan64(x: f64): f64 { // see musl/src/math/atan.c and SUN COPYRIGHT NOTICE above
+  const
+    atanhi0   = reinterpret<f64>(0x3FDDAC670561BB4F), //  4.63647609000806093515e-01
+    atanhi1   = reinterpret<f64>(0x3FE921FB54442D18), //  7.85398163397448278999e-01
+    atanhi2   = reinterpret<f64>(0x3FEF730BD281F69B), //  9.82793723247329054082e-01
+    atanhi3   = reinterpret<f64>(0x3FF921FB54442D18), //  1.57079632679489655800e+00
+    atanlo0   = reinterpret<f64>(0x3C7A2B7F222F65E2), //  2.26987774529616870924e-17
+    atanlo1   = reinterpret<f64>(0x3C81A62633145C07), //  3.06161699786838301793e-17
+    atanlo2   = reinterpret<f64>(0x3C7007887AF0CBBD), //  1.39033110312309984516e-17
+    atanlo3   = reinterpret<f64>(0x3C91A62633145C07), //  6.12323399573676603587e-17
+    aT0       = reinterpret<f64>(0x3FD555555555550D), //  3.33333333333329318027e-01
+    aT1       = reinterpret<f64>(0xBFC999999998EBC4), // -1.99999999998764832476e-01
+    aT2       = reinterpret<f64>(0x3FC24924920083FF), //  1.42857142725034663711e-01
+    aT3       = reinterpret<f64>(0xBFBC71C6FE231671), // -1.11111104054623557880e-01,
+    aT4       = reinterpret<f64>(0x3FB745CDC54C206E), //  9.09088713343650656196e-02
+    aT5       = reinterpret<f64>(0xBFB3B0F2AF749A6D), // -7.69187620504482999495e-02
+    aT6       = reinterpret<f64>(0x3FB10D66A0D03D51), //  6.66107313738753120669e-02
+    aT7       = reinterpret<f64>(0xBFADDE2D52DEFD9A), // -5.83357013379057348645e-02
+    aT8       = reinterpret<f64>(0x3FA97B4B24760DEB), //  4.97687799461593236017e-02
+    aT9       = reinterpret<f64>(0xBFA2B4442C6A6C2F), // -3.65315727442169155270e-02
+    aT10      = reinterpret<f64>(0x3F90AD3AE322DA11), //  1.62858201153657823623e-02
+    Ox1p_120f = reinterpret<f32>(0x03800000);
+
+  var ix = <u32>(reinterpret<u64>(x) >> 32);
+  var sx = x;
+  ix &= 0x7FFFFFFF;
+  var z: f64;
+  if (ix >= 0x44100000) {
+    if (isNaN(x)) return x;
+    z = atanhi3 + Ox1p_120f;
+    return copysign<f64>(z, sx);
+  }
+  var id: i32;
+  if (ix < 0x3FDC0000) {
+    if (ix < 0x3E400000) return x;
+    id = -1;
+  } else {
+    x = abs<f64>(x);
+    if (ix < 0x3FF30000) {
+      if (ix < 0x3FE60000) {
+        id = 0;
+        x = (2.0 * x - 1.0) / (2.0 + x);
+      } else {
+        id = 1;
+        x = (x - 1.0) / (x + 1.0);
+      }
+    } else {
+      if (ix < 0x40038000) {
+        id = 2;
+        x = (x - 1.5) / (1.0 + 1.5 * x);
+      } else {
+        id = 3;
+        x = -1.0 / x;
+      }
+    }
+  }
+  z = x * x;
+  var w = z * z;
+  var s1 = z * (aT0 + w * (aT2 + w * (aT4 + w * (aT6 + w * (aT8 + w * aT10)))));
+  var s2 = w * (aT1 + w * (aT3 + w * (aT5 + w * (aT7 + w * aT9))));
+  var s3 = x * (s1 + s2);
+  if (id < 0) return x - s3;
+  switch (id) {
+    case 0: { z = atanhi0 - ((s3 - atanlo0) - x); break; }
+    case 1: { z = atanhi1 - ((s3 - atanlo1) - x); break; }
+    case 2: { z = atanhi2 - ((s3 - atanlo2) - x); break; }
+    case 3: { z = atanhi3 - ((s3 - atanlo3) - x); break; }
+    default: unreachable();
+  }
+  return copysign<f64>(z, sx);
+}
+
+export function atanh32(x: f32): f32 { // see: musl/src/math/atanhf.c
+  var u = reinterpret<u32>(x);
+  var y = abs<f32>(x);
+  if (u < 0x3F800000 - (1 << 23)) {
+    if (u >= 0x3F800000 - (32 << 23)) y = 0.5 * log1p32(2 * y * (1.0 + y / (1 - y)));
+  } else y = 0.5 * log1p32(2 * (y / (1 - y)));
+  return copysign<f32>(y, x);
+}
+
+export function atanh64(x: f64): f64 { // see: musl/src/math/atanh.c
+  var u = reinterpret<u64>(x);
+  var e = u >> 52 & 0x7FF;
+  var y = abs<f64>(x);
+  if (e < 0x3FF - 1) {
+    if (e >= 0x3FF - 32) y = 0.5 * log1p64(2 * y + 2 * y * y / (1 - y));
+  } else {
+    y = 0.5 * log1p64(2 * (y / (1 - y)));
+  }
+  return copysign<f64>(y, x);
+}
+
+export function atan2_32(y: f32, x: f32): f32 { // see: musl/src/math/atan2f.c and SUN COPYRIGHT NOTICE above
+  const
+    pi    = reinterpret<f32>(0x40490FDB), //  3.1415927410e+00f
+    pi_lo = reinterpret<f32>(0xB3BBBD2E); // -8.7422776573e-08f
+
+  if (isNaN(x) || isNaN(y)) return x + y;
+  var ix = reinterpret<u32>(x);
+  var iy = reinterpret<u32>(y);
+  if (ix == 0x3F800000) return atan32(y);
+  var m = <u32>(((iy >> 31) & 1) | ((ix >> 30) & 2));
+  ix &= 0x7FFFFFFF;
+  iy &= 0x7FFFFFFF;
+  if (iy == 0) {
+    switch (m) {
+      case 0:
+      case 1: return  y;
+      case 2: return  pi;
+      case 3: return -pi;
+    }
+  }
+  if (ix == 0) return m & 1 ? -pi / 2 : pi / 2;
+  if (ix == 0x7F800000) {
+    if (iy == 0x7F800000) {
+      let t: f32 = m & 2 ? 3 * pi / 4 : pi / 4;
+      return m & 1 ? -t : t;
+    } else {
+      let t: f32 = m & 2 ? pi : 0.0;
+      return m & 1 ? -t : t;
+    }
+  }
+  if (ix + (26 << 23) < iy || iy == 0x7F800000) return m & 1 ? -pi / 2 : pi / 2;
+  var z: f32;
+  if ((m & 2) && iy + (26 << 23) < ix) z = 0.0;
+  else z = atan32(abs<f32>(y / x));
+  switch (m) {
+    case 0: return  z;
+    case 1: return -z;
+    case 2: return pi - (z - pi_lo);
+    case 3: return (z - pi_lo) - pi;
+  }
+  return unreachable();
+}
+
+export function atan2_64(y: f64, x: f64): f64 { // see: musl/src/math/atan2.c and SUN COPYRIGHT NOTICE above
+  const
+    pi    = reinterpret<f64>(0x400921FB54442D18), // 3.14159265358979323846
+    pi_lo = reinterpret<f64>(0x3CA1A62633145C07); // 1.2246467991473531772E-16
+
+  if (isNaN(x) || isNaN(y)) return x + y;
+  var u = reinterpret<u64>(x);
+  var ix = <u32>(u >> 32);
+  var lx = <u32>u;
+  u = reinterpret<u64>(y);
+  var iy = <u32>(u >> 32);
+  var ly = <u32>u;
+  if ((ix - 0x3FF00000 | lx) == 0) return atan64(y);
+  var m = ((iy >> 31) & 1) | ((ix >> 30) & 2);
+  ix = ix & 0x7FFFFFFF;
+  iy = iy & 0x7FFFFFFF;
+  if ((iy | ly) == 0) {
+    switch (m) {
+      case 0:
+      case 1: return  y;
+      case 2: return  pi;
+      case 3: return -pi;
+    }
+  }
+  if ((ix | lx) == 0) return m & 1 ? -pi / 2 : pi / 2;
+  if (ix == 0x7FF00000) {
+    if (iy == 0x7FF00000) {
+      let t = m & 2 ? 3 * pi / 4 : pi / 4;
+      return m & 1 ? -t : t;
+    } else {
+      let t = m & 2 ? pi : 0;
+      return m & 1 ? -t : t;
+    }
+  }
+  var z: f64;
+  if (ix + (64 << 20) < iy || iy == 0x7FF00000) return m & 1 ? -pi / 2 : pi / 2;
+  if ((m & 2) && iy + (64 << 20) < ix) z = 0;
+  else z = atan64(abs<f64>(y / x));
+  switch (m) {
+    case 0: return  z;
+    case 1: return -z;
+    case 2: return pi - (z - pi_lo);
+    case 3: return (z - pi_lo) - pi;
+  }
+  return unreachable();
+}
+
+export function cbrt32(x: f32): f32 { // see: musl/src/math/cbrtf.c and SUN COPYRIGHT NOTICE above
+  const
+    B1      = <u32>709958130,
+    B2      = <u32>642849266,
+    Ox1p24f = reinterpret<f32>(0x4B800000);
+
+  var u = reinterpret<u32>(x);
+  var hx = u & 0x7FFFFFFF;
+  if (hx >= 0x7F800000) return x + x;
+  if (hx < 0x00800000) {
+    if (hx == 0) return x;
+    u = reinterpret<u32>(x * Ox1p24f);
+    hx = u & 0x7FFFFFFF;
+    hx = hx / 3 + B2;
+  } else {
+    hx = hx / 3 + B1;
+  }
+  u &= 0x80000000;
+  u |= hx;
+  var t = <f64>reinterpret<f32>(u);
+  var r = t * t * t;
+  t = t * (<f64>x + x + r) / (x + r + r);
+  r = t * t * t;
+  t = t * (<f64>x + x + r) / (x + r + r);
+  return <f32>t;
+}
+
+export function cbrt64(x: f64): f64 { // see: musl/src/math/cbrt.c and SUN COPYRIGHT NOTICE above
+  const
+    B1     = <u32>715094163,
+    B2     = <u32>696219795,
+    P0     = reinterpret<f64>(0x3FFE03E60F61E692), //  1.87595182427177009643
+    P1     = reinterpret<f64>(0xBFFE28E092F02420), // -1.88497979543377169875
+    P2     = reinterpret<f64>(0x3FF9F1604A49D6C2), //  1.621429720105354466140
+    P3     = reinterpret<f64>(0xBFE844CBBEE751D9), // -0.758397934778766047437
+    P4     = reinterpret<f64>(0x3FC2B000D4E4EDD7), //  0.145996192886612446982
+    Ox1p54 = reinterpret<f64>(0x4350000000000000); //  0x1p54
+
+  var u = reinterpret<u64>(x);
+  var hx = <u32>(u >> 32) & 0x7FFFFFFF;
+  if (hx >= 0x7FF00000) return x + x;
+  if (hx < 0x00100000) {
+    u = reinterpret<u64>(x * Ox1p54);
+    hx = <u32>(u >> 32) & 0x7FFFFFFF;
+    if (hx == 0) return x;
+    hx = hx / 3 + B2;
+  } else {
+    hx = hx / 3 + B1;
+  }
+  u &= 1 << 63;
+  u |= <u64>hx << 32;
+  var t = reinterpret<f64>(u);
+  var r = (t * t) * (t / x);
+  t = t * ((P0 + r * (P1 + r * P2)) + ((r * r) * r) * (P3 + r * P4));
+  t = reinterpret<f64>((reinterpret<u64>(t) + 0x80000000) & 0xFFFFFFFFC0000000);
+  var s = t * t;
+  r = x / s;
+  r = (r - t) / (2 * t + r);
+  t = t + t * r;
+  return t;
+}
+
+export function cos32(x: f32): f32 { // see: musl/src/math/cosf.c
+  const
+    c1pio2 = reinterpret<f64>(0x3FF921FB54442D18), // M_PI_2 * 1
+    c2pio2 = reinterpret<f64>(0x400921FB54442D18), // M_PI_2 * 2
+    c3pio2 = reinterpret<f64>(0x4012D97C7F3321D2), // M_PI_2 * 3
+    c4pio2 = reinterpret<f64>(0x401921FB54442D18); // M_PI_2 * 4
+
+  var ix = reinterpret<u32>(x);
+  var sign = ix >> 31;
+  ix &= 0x7FFFFFFF;
+
+  if (ix <= 0x3F490FDA) {  // |x| ~<= π/4
+    if (ix < 0x39800000) { // |x| < 2**-12
+      // raise inexact if x != 0
+      return 1;
+    }
+    return cos32_kern(x);
+  }
+
+  if (ASC_SHRINK_LEVEL < 1) {
+    if (ix <= 0x407B53D1) {  // |x| ~<= 5π/4
+      if (ix > 0x4016CBE3) { // |x|  ~> 3π/4
+        return -cos32_kern(sign ? x + c2pio2 : x - c2pio2);
+      } else {
+        return sign ? sin32_kern(x + c1pio2) : sin32_kern(c1pio2 - x);
+      }
+    }
+    if (ix <= 0x40E231D5) {  // |x| ~<= 9π/4
+      if (ix > 0x40AFEDDF) { // |x|  ~> 7π/4
+        return cos32_kern(sign ? x + c4pio2 : x - c4pio2);
+      } else {
+        return sign ? sin32_kern(-x - c3pio2) : sin32_kern(x - c3pio2);
+      }
+    }
+  }
+
+  // cos(Inf or NaN) is NaN
+  if (ix >= 0x7F800000) return x - x;
+
+  // general argument reduction needed
+  var n = rempio2_32(x, ix, sign);
+  var y = rempio2_32_y;
+
+  var t = n & 1 ? sin32_kern(y) : cos32_kern(y);
+  return (n + 1) & 2 ? -t : t;
+}
+
+export function cos64(x: f64): f64 { // see: musl/src/math/cos.c
+  var u  = reinterpret<u64>(x);
+  var ix = <u32>(u >> 32);
+  var sign = ix >> 31;
+
+  ix &= 0x7FFFFFFF;
+
+  // |x| ~< pi/4
+  if (ix <= 0x3FE921FB) {
+    if (ix < 0x3E46A09E) {  // |x| < 2**-27 * sqrt(2)
+      return 1.0;
+    }
+    return cos64_kern(x, 0);
+  }
+
+  // sin(Inf or NaN) is NaN
+  if (ix >= 0x7FF00000) return x - x;
+
+  // argument reduction needed
+  var n  = rempio2_64(x, u, sign);
+  var y0 = rempio2_y0;
+  var y1 = rempio2_y1;
+
+  x = n & 1 ? sin64_kern(y0, y1, 1) : cos64_kern(y0, y1);
+  return (n + 1) & 2 ? -x : x;
+}
+
+export function cosh32(x: f32): f32 { // see: musl/src/math/coshf.c
+  var u = reinterpret<u32>(x);
+  u &= 0x7FFFFFFF;
+  x = reinterpret<f32>(u);
+  if (u < 0x3F317217) {
+    if (u < 0x3F800000 - (12 << 23)) return 1;
+    let t = expm1_32(x);
+    // return 1 + t * t / (2 * (1 + t));
+    return 1 + t * t / (2 + 2 * t);
+  }
+  if (u < 0x42B17217) {
+    let t = exp32(x);
+    // return 0.5 * (t + 1 / t);
+    return 0.5 * t + 0.5 / t;
+  }
+  return expo2_32(x, 1);
+}
+
+export function cosh64(x: f64): f64 { // see: musl/src/math/cosh.c
+  var u = reinterpret<u64>(x);
+  u &= 0x7FFFFFFFFFFFFFFF;
+  x = reinterpret<f64>(u);
+  var w = <u32>(u >> 32);
+  var t: f64;
+  if (w < 0x3FE62E42) {
+    if (w < 0x3FF00000 - (26 << 20)) return 1;
+    t = expm1_64(x);
+    // return 1 + t * t / (2 * (1 + t));
+    return 1 + t * t / (2 + 2 * t);
+  }
+  if (w < 0x40862E42) {
+    t = exp64(x);
+    return 0.5 * (t + 1 / t);
+  }
+  t = expo2_64(x, 1);
+  return t;
+}
+
+export function hypot32(x: f32, y: f32): f32 { // see: musl/src/math/hypotf.c
+  const
+    Ox1p90f  = reinterpret<f32>(0x6C800000),
+    Ox1p_90f = reinterpret<f32>(0x12800000);
+
+  var ux = reinterpret<u32>(x);
+  var uy = reinterpret<u32>(y);
+  ux &= 0x7FFFFFFF;
+  uy &= 0x7FFFFFFF;
+  if (ux < uy) {
+    let ut = ux;
+    ux = uy;
+    uy = ut;
+  }
+  x = reinterpret<f32>(ux);
+  y = reinterpret<f32>(uy);
+  if (uy == 0xFF << 23) return y;
+  if (ux >= 0xFF << 23 || uy == 0 || ux - uy >= 25 << 23) return x + y;
+  var z: f32 = 1;
+  if (ux >= (0x7F + 60) << 23) {
+    z  = Ox1p90f;
+    x *= Ox1p_90f;
+    y *= Ox1p_90f;
+  } else if (uy < (0x7F - 60) << 23) {
+    z  = Ox1p_90f;
+    x *= Ox1p90f;
+    y *= Ox1p90f;
+  }
+  return z * sqrt<f32>(<f32>(<f64>x * x + <f64>y * y));
+}
+
+export function hypot64(x: f64, y: f64): f64 { // see: musl/src/math/hypot.c
+  const
+    SPLIT    = reinterpret<f64>(0x41A0000000000000) + 1, // 0x1p27 + 1
+    Ox1p700  = reinterpret<f64>(0x6BB0000000000000),
+    Ox1p_700 = reinterpret<f64>(0x1430000000000000);
+
+  var ux = reinterpret<u64>(x);
+  var uy = reinterpret<u64>(y);
+  ux &= 0x7FFFFFFFFFFFFFFF;
+  uy &= 0x7FFFFFFFFFFFFFFF;
+  if (ux < uy) {
+    let ut = ux;
+    ux = uy;
+    uy = ut;
+  }
+  var ex = <i32>(ux >> 52);
+  var ey = <i32>(uy >> 52);
+  y = reinterpret<f64>(uy);
+  if (ey == 0x7FF) return y;
+  x = reinterpret<f64>(ux);
+  if (ex == 0x7FF || uy == 0) return x;
+  if (ex - ey > 64) return x + y;
+  var z = 1.0;
+  if (ex > 0x3FF + 510) {
+    z  = Ox1p700;
+    x *= Ox1p_700;
+    y *= Ox1p_700;
+  } else if (ey < 0x3FF - 450) {
+    z  = Ox1p_700;
+    x *= Ox1p700;
+    y *= Ox1p700;
+  }
+  var c = x * SPLIT;
+  var h = x - c + c;
+  var l = x - h;
+  var hx = x * x;
+  var lx = h * h - hx + (2 * h + l) * l;
+  c = y * SPLIT;
+  h = y - c + c;
+  l = y - h;
+  var hy = y * y;
+  var ly = h * h - hy + (2 * h + l) * l;
+  return z * sqrt<f64>(ly + lx + hy + hx);
+}
+
+// ULP error: 0.502 (nearest rounding.)
+// Relative error: 1.69 * 2^-34 in [-1/64, 1/64] (before rounding.)
+// Wrong count: 168353 (all nearest rounding wrong results with fma.)
+export function exp2_32_lut(x: f32): f32 {
+  const
+    N      = 1 << EXP2_TABLE32_BITS,
+    N_MASK = N - 1,
+    shift  = reinterpret<f64>(0x4338000000000000) / N, // 0x1.8p+52
+    Ox127f = reinterpret<f32>(0x7F000000);
+
+  const
+    C0 = reinterpret<f64>(0x3FAC6AF84B912394), // 0x1.c6af84b912394p-5
+    C1 = reinterpret<f64>(0x3FCEBFCE50FAC4F3), // 0x1.ebfce50fac4f3p-3
+    C2 = reinterpret<f64>(0x3FE62E42FF0C52D6); // 0x1.62e42ff0c52d6p-1
+
+  var xd = <f64>x;
+  var ix = reinterpret<u32>(x);
+  var ux = ix >> 20 & 0x7FF;
+  if (ux >= 0x430) {
+    // |x| >= 128 or x is nan.
+    if (ix == 0xFF800000) return 0; // x == -Inf    -> 0
+    if (ux >= 0x7F8) return x + x;  // x == Inf/NaN -> Inf/NaN
+    if (x > 0) return x * Ox127f;   // x >     0    -> HugeVal (Owerflow)
+    if (x <= -150) return 0;        // x <= -150    -> 0 (Underflow)
+  }
+
+  // x = k/N + r with r in [-1/(2N), 1/(2N)] and int k.
+  var kd = xd + shift;
+  var ki = reinterpret<u64>(kd);
+  var r  = xd - (kd - shift);
+  var t: u64, y: f64, s: f64;
+
+  // exp2(x) = 2^(k/N) * 2^r ~= s * (C0*r^3 + C1*r^2 + C2*r + 1)
+  t  = load<u64>(EXP2_TABLE32 + ((<usize>ki & N_MASK) << alignof<u64>()));
+  t += ki << (52 - EXP2_TABLE32_BITS);
+  s  = reinterpret<f64>(t);
+  y  = C2 * r + 1;
+  y += (C0 * r + C1) * (r  * r);
+  y *= s;
+
+  return <f32>y;
+}
+
+// ULP error: 0.502 (nearest rounding.)
+// Relative error: 1.69 * 2^-34 in [-ln2/64, ln2/64] (before rounding.)
+// Wrong count: 170635 (all nearest rounding wrong results with fma.)
+// @ts-ignore: decorator
+@inline
+export function exp32_lut(x: f32): f32 {
+  const
+    N        = 1 << EXP2_TABLE32_BITS,
+    N_MASK   = N - 1,
+    shift    = reinterpret<f64>(0x4338000000000000),        // 0x1.8p+52
+    InvLn2N  = reinterpret<f64>(0x3FF71547652B82FE) * N,    // 0x1.71547652b82fep+0
+    Ox1p127f = reinterpret<f32>(0x7F000000);
+
+  const
+    C0 = reinterpret<f64>(0x3FAC6AF84B912394) / N / N / N, // 0x1.c6af84b912394p-5
+    C1 = reinterpret<f64>(0x3FCEBFCE50FAC4F3) / N / N,     // 0x1.ebfce50fac4f3p-3
+    C2 = reinterpret<f64>(0x3FE62E42FF0C52D6) / N;         // 0x1.62e42ff0c52d6p-1
+
+  var xd = <f64>x;
+  var ix = reinterpret<u32>(x);
+  var ux = ix >> 20 & 0x7FF;
+  if (ux >= 0x42B) {
+    // |x| >= 88 or x is nan.
+    if (ix == 0xFF800000) return 0;                            // x == -Inf    -> 0
+    if (ux >= 0x7F8) return x + x;                             // x == Inf/NaN -> Inf/NaN
+    if (x > reinterpret<f32>(0x42B17217)) return x * Ox1p127f; // x > log(0x1p128)  ~=  88.72 -> HugeVal (Owerflow)
+    if (x < reinterpret<f32>(0xC2CFF1B4)) return 0;            // x < log(0x1p-150) ~= -103.97 -> 0 (Underflow)
+  }
+
+  // x*N/Ln2 = k + r with r in [-1/2, 1/2] and int k.
+  var z = InvLn2N * xd;
+
+  // Round and convert z to int, the result is in [-150*N, 128*N] and
+  // ideally ties-to-even rule is used, otherwise the magnitude of r
+  // can be bigger which gives larger approximation error.
+  var kd = <f64>(z + shift);
+  var ki = reinterpret<u64>(kd);
+  var r  = z - (kd - shift);
+  var s: f64, y: f64, t: u64;
+
+  // exp(x) = 2^(k/N) * 2^(r/N) ~= s * (C0*r^3 + C1*r^2 + C2*r + 1)
+  t  = load<u64>(EXP2_TABLE32 + ((<usize>ki & N_MASK) << alignof<u64>()));
+  t += ki << (52 - EXP2_TABLE32_BITS);
+  s  = reinterpret<f64>(t);
+  z  = C0 * r + C1;
+  y  = C2 * r + 1;
+  y += z * (r * r);
+  y *= s;
+
+  return <f32>y;
+}
+
+// ULP error: 0.752 (nearest rounding.)
+// Relative error: 1.9 * 2^-26 (before rounding.)
+// @ts-ignore: decorator
+@inline
+export function log2_32_lut(x: f32): f32 {
+  const
+    N_MASK  = (1 << LOG2_TABLE32_BITS) - 1,
+    Ox1p23f = reinterpret<f32>(0x4B000000); // 0x1p23f
+
+  const
+    A0 = reinterpret<f64>(0xBFD712B6F70A7E4D), // -0x1.712b6f70a7e4dp-2
+    A1 = reinterpret<f64>(0x3FDECABF496832E0), //  0x1.ecabf496832ep-2
+    A2 = reinterpret<f64>(0xBFE715479FFAE3DE), // -0x1.715479ffae3dep-1
+    A3 = reinterpret<f64>(0x3FF715475F35C8B8); //  0x1.715475f35c8b8p0
+
+  var ux = reinterpret<u32>(x);
+  // Fix sign of zero with downward rounding when x==1.
+  // if (WANT_ROUNDING && predict_false(ix == 0x3f800000)) return 0;
+  if (ux - 0x00800000 >= 0x7F800000 - 0x00800000) {
+    // x < 0x1p-126 or inf or nan.
+    if (ux * 2 == 0) return -Infinity;
+    if (ux == 0x7F800000) return x; // log2(inf) == inf.
+    if ((ux >> 31) || ux * 2 >= 0xFF000000) return (x - x) / (x - x);
+    // x is subnormal, normalize it.
+    ux = reinterpret<u32>(x * Ox1p23f);
+    ux -= 23 << 23;
+  }
+  // x = 2^k z; where z is in range [OFF,2*OFF] and exact.
+  // The range is split into N subintervals.
+  // The ith subinterval contains z and c is near its center.
+  var tmp  = ux - 0x3F330000;
+  var i    = (tmp >> (23 - LOG2_TABLE32_BITS)) & N_MASK;
+  var top  = tmp & 0xFF800000;
+  var iz   = ux - top;
+  var k    = <i32>tmp >> 23;
+
+  var invc = load<f64>(LOG2_TABLE32 + (i << (1 + alignof<f64>())), 0 << alignof<f64>());
+  var logc = load<f64>(LOG2_TABLE32 + (i << (1 + alignof<f64>())), 1 << alignof<f64>());
+  var z    = <f64>reinterpret<f32>(iz);
+
+  // log2(x) = log1p(z/c-1)/ln2 + log2(c) + k
+  var r  = z * invc - 1;
+  var y0 = logc + <f64>k;
+
+  // Pipelined polynomial evaluation to approximate log1p(r)/ln2.
+  var y  = A1 * r + A2;
+  var p  = A3 * r + y0;
+  var r2 = r * r;
+  y += A0 * r2;
+  y  = y * r2 + p;
+
+  return <f32>y;
+}
+
+// ULP error: 0.818 (nearest rounding.)
+// Relative error: 1.957 * 2^-26 (before rounding.)
+// @ts-ignore: decorator
+@inline
+export function logf_lut(x: f32): f32 {
+  const
+    N_MASK  = (1 << LOG_TABLE32_BITS) - 1,
+    Ox1p23f = reinterpret<f32>(0x4B000000); // 0x1p23f
+
+  const
+    Ln2 = reinterpret<f64>(0x3FE62E42FEFA39EF), // 0x1.62e42fefa39efp-1;
+    A0  = reinterpret<f64>(0xBFD00EA348B88334), // -0x1.00ea348b88334p-2
+    A1  = reinterpret<f64>(0x3FD5575B0BE00B6A), //  0x1.5575b0be00b6ap-2
+    A2  = reinterpret<f64>(0xBFDFFFFEF20A4123); // -0x1.ffffef20a4123p-2
+
+  var ux = reinterpret<u32>(x);
+  // Fix sign of zero with downward rounding when x==1.
+  // if (WANT_ROUNDING && ux == 0x3f800000) return 0;
+  if (ux - 0x00800000 >= 0x7F800000 - 0x00800000) {
+    // x < 0x1p-126 or inf or nan.
+    if ((ux << 1) == 0) return -Infinity;
+    if (ux == 0x7F800000) return x; // log(inf) == inf.
+    if ((ux >> 31) || (ux << 1) >= 0xFF000000) return (x - x) / (x - x);
+    // x is subnormal, normalize it.
+    ux = reinterpret<u32>(x * Ox1p23f);
+    ux -= 23 << 23;
+  }
+  // x = 2^k z; where z is in range [OFF,2*OFF] and exact.
+  // The range is split into N subintervals.
+  // The ith subinterval contains z and c is near its center.
+  var tmp = ux - 0x3F330000;
+  var i   = (tmp >> (23 - LOG_TABLE32_BITS)) & N_MASK;
+  var k   = <i32>tmp >> 23;
+  var iz  = ux - (tmp & 0x1FF << 23);
+
+  var invc = load<f64>(LOG_TABLE32 + (i << (1 + alignof<f64>())), 0 << alignof<f64>());
+  var logc = load<f64>(LOG_TABLE32 + (i << (1 + alignof<f64>())), 1 << alignof<f64>());
+
+  var z = <f64>reinterpret<f32>(iz);
+
+  // log(x) = log1p(z/c-1) + log(c) + k*Ln2
+  var r = z * invc - 1;
+  var y0 = logc + <f64>k * Ln2;
+
+  // Pipelined polynomial evaluation to approximate log1p(r).
+  var r2 = r * r;
+  var y  = A1 * r + A2;
+  y += A0 * r2;
+  y = y * r2 + (y0 + r);
+
+  return <f32>y;
+}
+
+//
+// Lookup data for powf. See: https://git.musl-libc.org/cgit/musl/tree/src/math/powf.c
+//
+
+// @ts-ignore: decorator
+@inline
+function zeroinfnan32(ux: u32): bool {
+  return (ux << 1) - 1 >= (<u32>0x7f800000 << 1) - 1;
+}
+
+// Returns 0 if not int, 1 if odd int, 2 if even int. The argument is
+// the bit representation of a non-zero finite floating-point value.
+// @ts-ignore: decorator
+@inline
+function checkint32(iy: u32): i32 {
+  var e = iy >> 23 & 0xFF;
+  if (e < 0x7F     ) return 0;
+  if (e > 0x7F + 23) return 2;
+  e = 1 << (0x7F + 23 - e);
+  if (iy & (e - 1)) return 0;
+  if (iy &  e     ) return 1;
+  return 2;
+}
+
+// Subnormal input is normalized so ix has negative biased exponent.
+// Output is multiplied by N (POWF_SCALE) if TOINT_INTRINICS is set.
+// @ts-ignore: decorator
+@inline
+function log2_32_inline(ux: u32): f64 {
+  const N_MASK = (1 << LOG2_TABLE32_BITS) - 1;
+
+  const
+    A0 = reinterpret<f64>(0x3FD27616C9496E0B), //  0x1.27616c9496e0bp-2
+    A1 = reinterpret<f64>(0xBFD71969A075C67A), // -0x1.71969a075c67ap-2
+    A2 = reinterpret<f64>(0x3FDEC70A6CA7BADD), //  0x1.ec70a6ca7baddp-2
+    A3 = reinterpret<f64>(0xBFE7154748BEF6C8), // -0x1.7154748bef6c8p-1
+    A4 = reinterpret<f64>(0x3FF71547652AB82B); //  0x1.71547652ab82bp+0
+
+  // x = 2^k z; where z is in range [OFF,2*OFF] and exact.
+  // The range is split into N subintervals.
+  // The ith subinterval contains z and c is near its center.
+  var tmp  = ux - 0x3F330000;
+  var i    = <usize>((tmp >> (23 - LOG2_TABLE32_BITS)) & N_MASK);
+  var top  = tmp & 0xFF800000;
+  var uz   = ux - top;
+  var k    = <i32>(<i32>top >> 23);
+
+  var invc = load<f64>(LOG2_TABLE32 + (i << (1 + alignof<f64>())), 0 << alignof<f64>());
+  var logc = load<f64>(LOG2_TABLE32 + (i << (1 + alignof<f64>())), 1 << alignof<f64>());
+  var z    = <f64>reinterpret<f32>(uz);
+
+  // log2(x) = log1p(z/c-1)/ln2 + log2(c) + k
+  var r  = z * invc - 1;
+  var y0 = logc + <f64>k;
+
+  // Pipelined polynomial evaluation to approximate log1p(r)/ln2.
+  var y = A0 * r + A1;
+  var p = A2 * r + A3;
+  var q = A4 * r + y0;
+
+  r *= r;
+  q += p * r;
+  y  = y * (r * r) + q;
+
+  return y;
+}
+
+// The output of log2 and thus the input of exp2 is either scaled by N
+// (in case of fast toint intrinsics) or not.  The unscaled xd must be
+// in [-1021,1023], sign_bias sets the sign of the result.
+// @ts-ignore: decorator
+@inline
+function exp2_32_inline(xd: f64, signBias: u32): f32 {
+  const
+    N      = 1 << EXP2_TABLE32_BITS,
+    N_MASK = N - 1,
+    shift  = reinterpret<f64>(0x4338000000000000) / N; // 0x1.8p+52
+
+  const
+    C0 = reinterpret<f64>(0x3FAC6AF84B912394), // 0x1.c6af84b912394p-5
+    C1 = reinterpret<f64>(0x3FCEBFCE50FAC4F3), // 0x1.ebfce50fac4f3p-3
+    C2 = reinterpret<f64>(0x3FE62E42FF0C52D6); // 0x1.62e42ff0c52d6p-1
+
+  // x = k/N + r with r in [-1/(2N), 1/(2N)]
+  var kd = <f64>(xd + shift);
+  var ki = reinterpret<u64>(kd);
+  var r  = xd - (kd - shift);
+  var t: u64, z: f64, y: f64, s: f64;
+
+  // exp2(x) = 2^(k/N) * 2^r ~= s * (C0*r^3 + C1*r^2 + C2*r + 1)
+  t  = load<u64>(EXP2_TABLE32 + ((<usize>ki & N_MASK) << alignof<u64>()));
+  t += (ki + signBias) << (52 - EXP2_TABLE32_BITS);
+  s  = reinterpret<f64>(t);
+  z  = C0 * r + C1;
+  y  = C2 * r + 1;
+  y += z * (r * r);
+  y *= s;
+  return <f32>y;
+}
+
+// @ts-ignore: decorator
+@inline
+function xflow32(sign: u32, y: f32): f32 {
+  return select<f32>(-y, y, sign) * y;
+}
+
+// @ts-ignore: decorator
+@inline
+function oflow32(sign: u32): f32 {
+  return xflow32(sign, reinterpret<f32>(0x70000000)); // 0x1p97f
+}
+
+// @ts-ignore: decorator
+@inline
+function uflow32(sign: u32): f32 {
+  return xflow32(sign, reinterpret<f32>(0x10000000)); // 0x1p-95f
+}
+
+// @ts-ignore: decorator
+@inline
+function pow32_lut(x: f32, y: f32): f32 {
+  const
+    Ox1p23f     = reinterpret<f32>(0x4B000000), // 0x1p23f
+    UPPER_LIMIT = reinterpret<f64>(0x405FFFFFFFD1D571), // 0x1.fffffffd1d571p+6
+    LOWER_LIMIT = -150.0,
+    SIGN_BIAS   = 1 << (EXP2_TABLE32_BITS + 11);
+
+  var signBias: u32 = 0;
+  var ix = reinterpret<u32>(x);
+  var iy = reinterpret<u32>(y);
+  var ny = 0;
+
+  if (i32(ix - 0x00800000 >= 0x7f800000 - 0x00800000) | (ny = i32(zeroinfnan32(iy)))) {
+    // Either (x < 0x1p-126 or inf or nan) or (y is 0 or inf or nan).
+    if (ny) {
+      if ((iy << 1) == 0) return 1.0;
+      if (ix == 0x3F800000) return NaN; // original: 1.0
+      if ((ix << 1) > (<u32>0x7F800000 << 1) || (iy << 1) > (<u32>0x7F800000 << 1)) return x + y;
+      if ((ix << 1) == (0x3F800000 << 1)) return NaN; // original: 1.0
+      if (((ix << 1) < (0x3F800000 << 1)) == !(iy >> 31)) return 0; // |x| < 1 && y==inf or |x| > 1 && y==-inf.
+      return y * y;
+    }
+    if (zeroinfnan32(ix)) {
+      let x2 = x * x;
+      if ((ix >> 31) && checkint32(iy) == 1) x2 = -x2;
+      return iy >> 31 ? 1 / x2 : x2;
+    }
+    // x and y are non-zero finite.
+    if (ix >> 31) {
+      // Finite x < 0.
+      let yint = checkint32(iy);
+      if (yint == 0) return (x - x) / (x - x);
+      if (yint == 1) signBias = SIGN_BIAS;
+      ix &= 0x7FFFFFFF;
+    }
+    if (ix < 0x00800000) {
+      // Normalize subnormal x so exponent becomes negative.
+      ix = reinterpret<u32>(x * Ox1p23f);
+      ix &= 0x7FFFFFFF;
+      ix -= 23 << 23;
+    }
+  }
+  var logx = log2_32_inline(ix);
+  var ylogx = y * logx; // cannot overflow, y is single prec.
+  if ((reinterpret<u64>(ylogx) >> 47 & 0xFFFF) >= 0x80BF) { // reinterpret<u64>(126.0) >> 47
+    // |y * log(x)| >= 126
+    if (ylogx  > UPPER_LIMIT) return oflow32(signBias); // overflow
+    if (ylogx <= LOWER_LIMIT) return uflow32(signBias); // underflow
+  }
+  return exp2_32_inline(ylogx, signBias);
+}
+
 // Handle cases that may overflow or underflow when computing the result that
 // is scale*(1+TMP) without intermediate rounding. The bit representation of
 // scale is in SBITS, however it has a computed exponent that may have
@@ -615,12 +2608,12 @@ function specialcase(tmp: f64, sbits: u64, ki: u64): f64 {
   // Note: sbits is signed scale.
   scale = reinterpret<f64>(sbits);
   var y = scale + scale * tmp;
-  if (abs(y) < 1.0) {
+  if (abs<f64>(y) < 1.0) {
     // Round y to the right precision before scaling it into the subnormal
     // range to avoid double rounding that can cause 0.5+E/2 ulp error where
     // E is the worst-case ulp error outside the subnormal range.  So this
     // is only useful if the goal is better than 1 ulp worst-case error.
-    let one = copysign(1.0, y);
+    let one = copysign<f64>(1.0, y);
     let lo = scale - y + scale * tmp;
     let hi = one + y;
     lo = one - hi + y + lo;
@@ -635,7 +2628,7 @@ function specialcase(tmp: f64, sbits: u64, ki: u64): f64 {
 @inline
 export function exp_lut(x: f64): f64 {
   const
-    N      = 1 << EXP_TABLE_BITS,
+    N      = 1 << EXP_TABLE64_BITS,
     N_MASK = N - 1;
 
   const
@@ -683,11 +2676,11 @@ export function exp_lut(x: f64): f64 {
   var r = x + kd * NegLn2hiN + kd * NegLn2loN;
   // 2^(k/N) ~= scale * (1 + tail).
   var idx = <usize>((ki & N_MASK) << 1);
-  var top = ki << (52 - EXP_TABLE_BITS);
+  var top = ki << (52 - EXP_TABLE64_BITS);
 
-  var tail = reinterpret<f64>(load<u64>(EXP_DATA_TAB + (idx << alignof<u64>()))); // T[idx]
+  var tail = reinterpret<f64>(load<u64>(EXP_TABLE64 + (idx << alignof<u64>()))); // T[idx]
   // This is only a valid scale when -1023*N < k < 1024*N
-  var sbits = load<u64>(EXP_DATA_TAB + (idx << alignof<u64>()), 1 << alignof<u64>()) + top; // T[idx + 1]
+  var sbits = load<u64>(EXP_TABLE64 + (idx << alignof<u64>()), 1 << alignof<u64>()) + top; // T[idx + 1]
   // exp(x) = 2^(k/N) * exp(r) ~= scale + scale * (tail + exp(r) - 1).
   // Evaluation is optimized assuming superscalar pipelined execution.
   var r2 = r * r;
@@ -741,11 +2734,9 @@ function specialcase2(tmp: f64, sbits: u64, ki: u64): f64 {
   return y * Ox1p_1022;
 }
 
-// @ts-ignore: decorator
-@inline
-export function exp2_lut(x: f64): f64 {
+export function exp2_64_lut(x: f64): f64 {
   const
-    N      = 1 << EXP_TABLE_BITS,
+    N      = 1 << EXP_TABLE64_BITS,
     N_MASK = N - 1,
     shift  = reinterpret<f64>(0x4338000000000000) / N; // 0x1.8p52
 
@@ -777,11 +2768,11 @@ export function exp2_lut(x: f64): f64 {
   var r = x - kd;
   // 2^(k/N) ~= scale * (1 + tail)
   var idx = <usize>((ki & N_MASK) << 1);
-  var top = ki << (52 - EXP_TABLE_BITS);
+  var top = ki << (52 - EXP_TABLE64_BITS);
 
-  var tail = reinterpret<f64>(load<u64>(EXP_DATA_TAB + (idx << alignof<u64>()), 0 << alignof<u64>())); // T[idx])
+  var tail = reinterpret<f64>(load<u64>(EXP_TABLE64 + (idx << alignof<u64>()), 0 << alignof<u64>())); // T[idx])
   // This is only a valid scale when -1023*N < k < 1024*N
-  var sbits = load<u64>(EXP_DATA_TAB + (idx << alignof<u64>()), 1 << alignof<u64>()) + top; // T[idx + 1]
+  var sbits = load<u64>(EXP_TABLE64 + (idx << alignof<u64>()), 1 << alignof<u64>()) + top; // T[idx + 1]
   // exp2(x) = 2^(k/N) * 2^r ~= scale + scale * (tail + 2^r - 1).
   // Evaluation is optimized assuming superscalar pipelined execution
   var r2 = r * r;
@@ -795,182 +2786,10 @@ export function exp2_lut(x: f64): f64 {
   return scale * tmp + scale;
 }
 
-//
-// Lookup data for log2. See: https://git.musl-libc.org/cgit/musl/tree/src/math/log2.c
-//
-
-// @ts-ignore: decorator
-@inline const LOG2_TABLE_BITS = 6;
-
-/* Algorithm:
-
-  x = 2^k z
-  log2(x) = k + log2(c) + log2(z/c)
-  log2(z/c) = poly(z/c - 1)
-
-where z is in [1.6p-1; 1.6p0] which is split into N subintervals and z falls
-into the ith one, then table entries are computed as
-
-  tab[i].invc = 1/c
-  tab[i].logc = (double)log2(c)
-  tab2[i].chi = (double)c
-  tab2[i].clo = (double)(c - (double)c)
-
-where c is near the center of the subinterval and is chosen by trying +-2^29
-floating point invc candidates around 1/center and selecting one for which
-
-  1) the rounding error in 0x1.8p10 + logc is 0,
-  2) the rounding error in z - chi - clo is < 0x1p-64 and
-  3) the rounding error in (double)log2(c) is minimized (< 0x1p-68).
-
-Note: 1) ensures that k + logc can be computed without rounding error, 2)
-ensures that z/c - 1 can be computed as (z - chi - clo)*invc with close to a
-single rounding error when there is no fast fma for z*invc - 1, 3) ensures
-that logc + poly(z/c - 1) has small error, however near x == 1 when
-|log2(x)| < 0x1p-4, this is not enough so that is special cased. */
-
-// @ts-ignore: decorator
-@lazy @inline const LOG2_DATA_TAB1 = memory.data<f64>([
-  //            invc                  ,                logc
-  reinterpret<f64>(0x3FF724286BB1ACF8), reinterpret<f64>(0xBFE1095FEECDB000),
-  reinterpret<f64>(0x3FF6E1F766D2CCA1), reinterpret<f64>(0xBFE08494BD76D000),
-  reinterpret<f64>(0x3FF6A13D0E30D48A), reinterpret<f64>(0xBFE00143AEE8F800),
-  reinterpret<f64>(0x3FF661EC32D06C85), reinterpret<f64>(0xBFDEFEC5360B4000),
-  reinterpret<f64>(0x3FF623FA951198F8), reinterpret<f64>(0xBFDDFDD91AB7E000),
-  reinterpret<f64>(0x3FF5E75BA4CF026C), reinterpret<f64>(0xBFDCFFAE0CC79000),
-  reinterpret<f64>(0x3FF5AC055A214FB8), reinterpret<f64>(0xBFDC043811FDA000),
-  reinterpret<f64>(0x3FF571ED0F166E1E), reinterpret<f64>(0xBFDB0B67323AE000),
-  reinterpret<f64>(0x3FF53909590BF835), reinterpret<f64>(0xBFDA152F5A2DB000),
-  reinterpret<f64>(0x3FF5014FED61ADDD), reinterpret<f64>(0xBFD9217F5AF86000),
-  reinterpret<f64>(0x3FF4CAB88E487BD0), reinterpret<f64>(0xBFD8304DB0719000),
-  reinterpret<f64>(0x3FF49539B4334FEE), reinterpret<f64>(0xBFD74189F9A9E000),
-  reinterpret<f64>(0x3FF460CBDFAFD569), reinterpret<f64>(0xBFD6552BB5199000),
-  reinterpret<f64>(0x3FF42D664EE4B953), reinterpret<f64>(0xBFD56B23A29B1000),
-  reinterpret<f64>(0x3FF3FB01111DD8A6), reinterpret<f64>(0xBFD483650F5FA000),
-  reinterpret<f64>(0x3FF3C995B70C5836), reinterpret<f64>(0xBFD39DE937F6A000),
-  reinterpret<f64>(0x3FF3991C4AB6FD4A), reinterpret<f64>(0xBFD2BAA1538D6000),
-  reinterpret<f64>(0x3FF3698E0CE099B5), reinterpret<f64>(0xBFD1D98340CA4000),
-  reinterpret<f64>(0x3FF33AE48213E7B2), reinterpret<f64>(0xBFD0FA853A40E000),
-  reinterpret<f64>(0x3FF30D191985BDB1), reinterpret<f64>(0xBFD01D9C32E73000),
-  reinterpret<f64>(0x3FF2E025CAB271D7), reinterpret<f64>(0xBFCE857DA2FA6000),
-  reinterpret<f64>(0x3FF2B404CF13CD82), reinterpret<f64>(0xBFCCD3C8633D8000),
-  reinterpret<f64>(0x3FF288B02C7CCB50), reinterpret<f64>(0xBFCB26034C14A000),
-  reinterpret<f64>(0x3FF25E2263944DE5), reinterpret<f64>(0xBFC97C1C2F4FE000),
-  reinterpret<f64>(0x3FF234563D8615B1), reinterpret<f64>(0xBFC7D6023F800000),
-  reinterpret<f64>(0x3FF20B46E33EAF38), reinterpret<f64>(0xBFC633A71A05E000),
-  reinterpret<f64>(0x3FF1E2EEFDCDA3DD), reinterpret<f64>(0xBFC494F5E9570000),
-  reinterpret<f64>(0x3FF1BB4A580B3930), reinterpret<f64>(0xBFC2F9E424E0A000),
-  reinterpret<f64>(0x3FF19453847F2200), reinterpret<f64>(0xBFC162595AFDC000),
-  reinterpret<f64>(0x3FF16E06C0D5D73C), reinterpret<f64>(0xBFBF9C9A75BD8000),
-  reinterpret<f64>(0x3FF1485F47B7E4C2), reinterpret<f64>(0xBFBC7B575BF9C000),
-  reinterpret<f64>(0x3FF12358AD0085D1), reinterpret<f64>(0xBFB960C60FF48000),
-  reinterpret<f64>(0x3FF0FEF00F532227), reinterpret<f64>(0xBFB64CE247B60000),
-  reinterpret<f64>(0x3FF0DB2077D03A8F), reinterpret<f64>(0xBFB33F78B2014000),
-  reinterpret<f64>(0x3FF0B7E6D65980D9), reinterpret<f64>(0xBFB0387D1A42C000),
-  reinterpret<f64>(0x3FF0953EFE7B408D), reinterpret<f64>(0xBFAA6F9208B50000),
-  reinterpret<f64>(0x3FF07325CAC53B83), reinterpret<f64>(0xBFA47A954F770000),
-  reinterpret<f64>(0x3FF05197E40D1B5C), reinterpret<f64>(0xBF9D23A8C50C0000),
-  reinterpret<f64>(0x3FF03091C1208EA2), reinterpret<f64>(0xBF916A2629780000),
-  reinterpret<f64>(0x3FF0101025B37E21), reinterpret<f64>(0xBF7720F8D8E80000),
-  reinterpret<f64>(0x3FEFC07EF9CAA76B), reinterpret<f64>(0x3F86FE53B1500000),
-  reinterpret<f64>(0x3FEF4465D3F6F184), reinterpret<f64>(0x3FA11CCCE10F8000),
-  reinterpret<f64>(0x3FEECC079F84107F), reinterpret<f64>(0x3FAC4DFC8C8B8000),
-  reinterpret<f64>(0x3FEE573A99975AE8), reinterpret<f64>(0x3FB3AA321E574000),
-  reinterpret<f64>(0x3FEDE5D6F0BD3DE6), reinterpret<f64>(0x3FB918A0D08B8000),
-  reinterpret<f64>(0x3FED77B681FF38B3), reinterpret<f64>(0x3FBE72E9DA044000),
-  reinterpret<f64>(0x3FED0CB5724DE943), reinterpret<f64>(0x3FC1DCD2507F6000),
-  reinterpret<f64>(0x3FECA4B2DC0E7563), reinterpret<f64>(0x3FC476AB03DEA000),
-  reinterpret<f64>(0x3FEC3F8EE8D6CB51), reinterpret<f64>(0x3FC7074377E22000),
-  reinterpret<f64>(0x3FEBDD2B4F020C4C), reinterpret<f64>(0x3FC98EDE8BA94000),
-  reinterpret<f64>(0x3FEB7D6C006015CA), reinterpret<f64>(0x3FCC0DB86AD2E000),
-  reinterpret<f64>(0x3FEB20366E2E338F), reinterpret<f64>(0x3FCE840AAFCEE000),
-  reinterpret<f64>(0x3FEAC57026295039), reinterpret<f64>(0x3FD0790AB4678000),
-  reinterpret<f64>(0x3FEA6D01BC2731DD), reinterpret<f64>(0x3FD1AC056801C000),
-  reinterpret<f64>(0x3FEA16D3BC3FF18B), reinterpret<f64>(0x3FD2DB11D4FEE000),
-  reinterpret<f64>(0x3FE9C2D14967FEAD), reinterpret<f64>(0x3FD406464EC58000),
-  reinterpret<f64>(0x3FE970E4F47C9902), reinterpret<f64>(0x3FD52DBE093AF000),
-  reinterpret<f64>(0x3FE920FB3982BCF2), reinterpret<f64>(0x3FD651902050D000),
-  reinterpret<f64>(0x3FE8D30187F759F1), reinterpret<f64>(0x3FD771D2CDEAF000),
-  reinterpret<f64>(0x3FE886E5EBB9F66D), reinterpret<f64>(0x3FD88E9C857D9000),
-  reinterpret<f64>(0x3FE83C97B658B994), reinterpret<f64>(0x3FD9A80155E16000),
-  reinterpret<f64>(0x3FE7F405FFC61022), reinterpret<f64>(0x3FDABE186ED3D000),
-  reinterpret<f64>(0x3FE7AD22181415CA), reinterpret<f64>(0x3FDBD0F2AEA0E000),
-  reinterpret<f64>(0x3FE767DCF99EFF8C), reinterpret<f64>(0x3FDCE0A43DBF4000)
-]);
-
-// @ts-ignore: decorator
-@lazy @inline const LOG2_DATA_TAB2 = memory.data<f64>([
-  //              chi                 ,                 clo
-  reinterpret<f64>(0x3FE6200012B90A8E), reinterpret<f64>(0x3C8904AB0644B605),
-  reinterpret<f64>(0x3FE66000045734A6), reinterpret<f64>(0x3C61FF9BEA62F7A9),
-  reinterpret<f64>(0x3FE69FFFC325F2C5), reinterpret<f64>(0x3C827ECFCB3C90BA),
-  reinterpret<f64>(0x3FE6E00038B95A04), reinterpret<f64>(0x3C88FF8856739326),
-  reinterpret<f64>(0x3FE71FFFE09994E3), reinterpret<f64>(0x3C8AFD40275F82B1),
-  reinterpret<f64>(0x3FE7600015590E10), reinterpret<f64>(0xBC72FD75B4238341),
-  reinterpret<f64>(0x3FE7A00012655BD5), reinterpret<f64>(0x3C7808E67C242B76),
-  reinterpret<f64>(0x3FE7E0003259E9A6), reinterpret<f64>(0xBC6208E426F622B7),
-  reinterpret<f64>(0x3FE81FFFEDB4B2D2), reinterpret<f64>(0xBC8402461EA5C92F),
-  reinterpret<f64>(0x3FE860002DFAFCC3), reinterpret<f64>(0x3C6DF7F4A2F29A1F),
-  reinterpret<f64>(0x3FE89FFFF78C6B50), reinterpret<f64>(0xBC8E0453094995FD),
-  reinterpret<f64>(0x3FE8E00039671566), reinterpret<f64>(0xBC8A04F3BEC77B45),
-  reinterpret<f64>(0x3FE91FFFE2BF1745), reinterpret<f64>(0xBC77FA34400E203C),
-  reinterpret<f64>(0x3FE95FFFCC5C9FD1), reinterpret<f64>(0xBC76FF8005A0695D),
-  reinterpret<f64>(0x3FE9A0003BBA4767), reinterpret<f64>(0x3C70F8C4C4EC7E03),
-  reinterpret<f64>(0x3FE9DFFFE7B92DA5), reinterpret<f64>(0x3C8E7FD9478C4602),
-  reinterpret<f64>(0x3FEA1FFFD72EFDAF), reinterpret<f64>(0xBC6A0C554DCDAE7E),
-  reinterpret<f64>(0x3FEA5FFFDE04FF95), reinterpret<f64>(0x3C867DA98CE9B26B),
-  reinterpret<f64>(0x3FEA9FFFCA5E8D2B), reinterpret<f64>(0xBC8284C9B54C13DE),
-  reinterpret<f64>(0x3FEADFFFDDAD03EA), reinterpret<f64>(0x3C5812C8EA602E3C),
-  reinterpret<f64>(0x3FEB1FFFF10D3D4D), reinterpret<f64>(0xBC8EFADDAD27789C),
-  reinterpret<f64>(0x3FEB5FFFCE21165A), reinterpret<f64>(0x3C53CB1719C61237),
-  reinterpret<f64>(0x3FEB9FFFD950E674), reinterpret<f64>(0x3C73F7D94194CE00),
-  reinterpret<f64>(0x3FEBE000139CA8AF), reinterpret<f64>(0x3C750AC4215D9BC0),
-  reinterpret<f64>(0x3FEC20005B46DF99), reinterpret<f64>(0x3C6BEEA653E9C1C9),
-  reinterpret<f64>(0x3FEC600040B9F7AE), reinterpret<f64>(0xBC7C079F274A70D6),
-  reinterpret<f64>(0x3FECA0006255FD8A), reinterpret<f64>(0xBC7A0B4076E84C1F),
-  reinterpret<f64>(0x3FECDFFFD94C095D), reinterpret<f64>(0x3C88F933F99AB5D7),
-  reinterpret<f64>(0x3FED1FFFF975D6CF), reinterpret<f64>(0xBC582C08665FE1BE),
-  reinterpret<f64>(0x3FED5FFFA2561C93), reinterpret<f64>(0xBC7B04289BD295F3),
-  reinterpret<f64>(0x3FED9FFF9D228B0C), reinterpret<f64>(0x3C870251340FA236),
-  reinterpret<f64>(0x3FEDE00065BC7E16), reinterpret<f64>(0xBC75011E16A4D80C),
-  reinterpret<f64>(0x3FEE200002F64791), reinterpret<f64>(0x3C89802F09EF62E0),
-  reinterpret<f64>(0x3FEE600057D7A6D8), reinterpret<f64>(0xBC7E0B75580CF7FA),
-  reinterpret<f64>(0x3FEEA00027EDC00C), reinterpret<f64>(0xBC8C848309459811),
-  reinterpret<f64>(0x3FEEE0006CF5CB7C), reinterpret<f64>(0xBC8F8027951576F4),
-  reinterpret<f64>(0x3FEF2000782B7DCC), reinterpret<f64>(0xBC8F81D97274538F),
-  reinterpret<f64>(0x3FEF6000260C450A), reinterpret<f64>(0xBC4071002727FFDC),
-  reinterpret<f64>(0x3FEF9FFFE88CD533), reinterpret<f64>(0xBC581BDCE1FDA8B0),
-  reinterpret<f64>(0x3FEFDFFFD50F8689), reinterpret<f64>(0x3C87F91ACB918E6E),
-  reinterpret<f64>(0x3FF0200004292367), reinterpret<f64>(0x3C9B7FF365324681),
-  reinterpret<f64>(0x3FF05FFFE3E3D668), reinterpret<f64>(0x3C86FA08DDAE957B),
-  reinterpret<f64>(0x3FF0A0000A85A757), reinterpret<f64>(0xBC57E2DE80D3FB91),
-  reinterpret<f64>(0x3FF0E0001A5F3FCC), reinterpret<f64>(0xBC91823305C5F014),
-  reinterpret<f64>(0x3FF11FFFF8AFBAF5), reinterpret<f64>(0xBC8BFABB6680BAC2),
-  reinterpret<f64>(0x3FF15FFFE54D91AD), reinterpret<f64>(0xBC9D7F121737E7EF),
-  reinterpret<f64>(0x3FF1A00011AC36E1), reinterpret<f64>(0x3C9C000A0516F5FF),
-  reinterpret<f64>(0x3FF1E00019C84248), reinterpret<f64>(0xBC9082FBE4DA5DA0),
-  reinterpret<f64>(0x3FF220000FFE5E6E), reinterpret<f64>(0xBC88FDD04C9CFB43),
-  reinterpret<f64>(0x3FF26000269FD891), reinterpret<f64>(0x3C8CFE2A7994D182),
-  reinterpret<f64>(0x3FF2A00029A6E6DA), reinterpret<f64>(0xBC700273715E8BC5),
-  reinterpret<f64>(0x3FF2DFFFE0293E39), reinterpret<f64>(0x3C9B7C39DAB2A6F9),
-  reinterpret<f64>(0x3FF31FFFF7DCF082), reinterpret<f64>(0x3C7DF1336EDC5254),
-  reinterpret<f64>(0x3FF35FFFF05A8B60), reinterpret<f64>(0xBC9E03564CCD31EB),
-  reinterpret<f64>(0x3FF3A0002E0EAECC), reinterpret<f64>(0x3C75F0E74BD3A477),
-  reinterpret<f64>(0x3FF3E000043BB236), reinterpret<f64>(0x3C9C7DCB149D8833),
-  reinterpret<f64>(0x3FF4200002D187FF), reinterpret<f64>(0x3C7E08AFCF2D3D28),
-  reinterpret<f64>(0x3FF460000D387CB1), reinterpret<f64>(0x3C820837856599A6),
-  reinterpret<f64>(0x3FF4A00004569F89), reinterpret<f64>(0xBC89FA5C904FBCD2),
-  reinterpret<f64>(0x3FF4E000043543F3), reinterpret<f64>(0xBC781125ED175329),
-  reinterpret<f64>(0x3FF51FFFCC027F0F), reinterpret<f64>(0x3C9883D8847754DC),
-  reinterpret<f64>(0x3FF55FFFFD87B36F), reinterpret<f64>(0xBC8709E731D02807),
-  reinterpret<f64>(0x3FF59FFFF21DF7BA), reinterpret<f64>(0x3C87F79F68727B02),
-  reinterpret<f64>(0x3FF5DFFFEBFC3481), reinterpret<f64>(0xBC9180902E30E93E)
-]);
-
 // @ts-ignore: decorator
 @inline
-export function log2_lut(x: f64): f64 {
-  const N_MASK = (1 << LOG2_TABLE_BITS) - 1;
+export function log2_64_lut(x: f64): f64 {
+  const N_MASK = (1 << LOG2_TABLE64_BITS) - 1;
 
   const
     LO: u64 = 0x3FEEA4AF00000000, // reinterpret<u64>(1.0 - 0x1.5b51p-5)
@@ -1038,12 +2857,12 @@ export function log2_lut(x: f64): f64 {
   // The range is split into N subintervals.
   // The ith subinterval contains z and c is near its center.
   var tmp  = ix - 0x3FE6000000000000;
-  var i    = <usize>((tmp >> (52 - LOG2_TABLE_BITS)) & N_MASK);
+  var i    = <usize>((tmp >> (52 - LOG2_TABLE64_BITS)) & N_MASK);
   var k    = <i64>tmp >> 52;
   var iz   = ix - (tmp & 0xFFF0000000000000);
 
-  var invc = load<f64>(LOG2_DATA_TAB1  + (i << (1 + alignof<f64>())), 0 << alignof<f64>()); // T[i].invc;
-  var logc = load<f64>(LOG2_DATA_TAB1  + (i << (1 + alignof<f64>())), 1 << alignof<f64>()); // T[i].logc;
+  var invc = load<f64>(LOG2_TABLE1_64  + (i << (1 + alignof<f64>())), 0 << alignof<f64>()); // T[i].invc;
+  var logc = load<f64>(LOG2_TABLE1_64  + (i << (1 + alignof<f64>())), 1 << alignof<f64>()); // T[i].logc;
   var z    = reinterpret<f64>(iz);
   var kd   = <f64>k;
 
@@ -1056,8 +2875,8 @@ export function log2_lut(x: f64): f64 {
   // 	t2 = r * InvLn2lo + __builtin_fma(r, InvLn2hi, -t1);
   // #else
   // rounding error: 0x1p-55/N + 0x1p-65.
-  var chi = load<f64>(LOG2_DATA_TAB2 + (i << (1 + alignof<f64>())), 0 << alignof<f64>()); // T[i].chi;
-  var clo = load<f64>(LOG2_DATA_TAB2 + (i << (1 + alignof<f64>())), 1 << alignof<f64>()); // T[i].clo;
+  var chi = load<f64>(LOG2_TABLE2_64 + (i << (1 + alignof<f64>())), 0 << alignof<f64>()); // T[i].chi;
+  var clo = load<f64>(LOG2_TABLE2_64 + (i << (1 + alignof<f64>())), 1 << alignof<f64>()); // T[i].clo;
 
   var r   = (z - chi - clo) * invc;
   var rhi = reinterpret<f64>(reinterpret<u64>(r) & 0xFFFFFFFF00000000);
@@ -1080,310 +2899,10 @@ export function log2_lut(x: f64): f64 {
   return lo + r2 * p + hi;
 }
 
-//
-// Lookup data for log. See: https://git.musl-libc.org/cgit/musl/tree/src/math/log.c
-//
-
-// @ts-ignore: decorator
-@inline const LOG_TABLE_BITS = 7;
-
-/* Algorithm:
-
-  x = 2^k z
-  log(x) = k ln2 + log(c) + log(z/c)
-  log(z/c) = poly(z/c - 1)
-
-where z is in [1.6p-1; 1.6p0] which is split into N subintervals and z falls
-into the ith one, then table entries are computed as
-
-  tab[i].invc = 1/c
-  tab[i].logc = (double)log(c)
-  tab2[i].chi = (double)c
-  tab2[i].clo = (double)(c - (double)c)
-
-where c is near the center of the subinterval and is chosen by trying +-2^29
-floating point invc candidates around 1/center and selecting one for which
-
-  1) the rounding error in 0x1.8p9 + logc is 0,
-  2) the rounding error in z - chi - clo is < 0x1p-66 and
-  3) the rounding error in (double)log(c) is minimized (< 0x1p-66).
-
-Note: 1) ensures that k*ln2hi + logc can be computed without rounding error,
-2) ensures that z/c - 1 can be computed as (z - chi - clo)*invc with close to
-a single rounding error when there is no fast fma for z*invc - 1, 3) ensures
-that logc + poly(z/c - 1) has small error, however near x == 1 when
-|log(x)| < 0x1p-4, this is not enough so that is special cased.*/
-
-// @ts-ignore: decorator
-@lazy @inline const LOG_DATA_TAB1 = memory.data<f64>([
-  //              invc                ,                 logc
-  reinterpret<f64>(0x3FF734F0C3E0DE9F), reinterpret<f64>(0xBFD7CC7F79E69000),
-  reinterpret<f64>(0x3FF713786A2CE91F), reinterpret<f64>(0xBFD76FEEC20D0000),
-  reinterpret<f64>(0x3FF6F26008FAB5A0), reinterpret<f64>(0xBFD713E31351E000),
-  reinterpret<f64>(0x3FF6D1A61F138C7D), reinterpret<f64>(0xBFD6B85B38287800),
-  reinterpret<f64>(0x3FF6B1490BC5B4D1), reinterpret<f64>(0xBFD65D5590807800),
-  reinterpret<f64>(0x3FF69147332F0CBA), reinterpret<f64>(0xBFD602D076180000),
-  reinterpret<f64>(0x3FF6719F18224223), reinterpret<f64>(0xBFD5A8CA86909000),
-  reinterpret<f64>(0x3FF6524F99A51ED9), reinterpret<f64>(0xBFD54F4356035000),
-  reinterpret<f64>(0x3FF63356AA8F24C4), reinterpret<f64>(0xBFD4F637C36B4000),
-  reinterpret<f64>(0x3FF614B36B9DDC14), reinterpret<f64>(0xBFD49DA7FDA85000),
-  reinterpret<f64>(0x3FF5F66452C65C4C), reinterpret<f64>(0xBFD445923989A800),
-  reinterpret<f64>(0x3FF5D867B5912C4F), reinterpret<f64>(0xBFD3EDF439B0B800),
-  reinterpret<f64>(0x3FF5BABCCB5B90DE), reinterpret<f64>(0xBFD396CE448F7000),
-  reinterpret<f64>(0x3FF59D61F2D91A78), reinterpret<f64>(0xBFD3401E17BDA000),
-  reinterpret<f64>(0x3FF5805612465687), reinterpret<f64>(0xBFD2E9E2EF468000),
-  reinterpret<f64>(0x3FF56397CEE76BD3), reinterpret<f64>(0xBFD2941B3830E000),
-  reinterpret<f64>(0x3FF54725E2A77F93), reinterpret<f64>(0xBFD23EC58CDA8800),
-  reinterpret<f64>(0x3FF52AFF42064583), reinterpret<f64>(0xBFD1E9E129279000),
-  reinterpret<f64>(0x3FF50F22DBB2BDDF), reinterpret<f64>(0xBFD1956D2B48F800),
-  reinterpret<f64>(0x3FF4F38F4734DED7), reinterpret<f64>(0xBFD141679AB9F800),
-  reinterpret<f64>(0x3FF4D843CFDE2840), reinterpret<f64>(0xBFD0EDD094EF9800),
-  reinterpret<f64>(0x3FF4BD3EC078A3C8), reinterpret<f64>(0xBFD09AA518DB1000),
-  reinterpret<f64>(0x3FF4A27FC3E0258A), reinterpret<f64>(0xBFD047E65263B800),
-  reinterpret<f64>(0x3FF4880524D48434), reinterpret<f64>(0xBFCFEB224586F000),
-  reinterpret<f64>(0x3FF46DCE1B192D0B), reinterpret<f64>(0xBFCF474A7517B000),
-  reinterpret<f64>(0x3FF453D9D3391854), reinterpret<f64>(0xBFCEA4443D103000),
-  reinterpret<f64>(0x3FF43A2744B4845A), reinterpret<f64>(0xBFCE020D44E9B000),
-  reinterpret<f64>(0x3FF420B54115F8FB), reinterpret<f64>(0xBFCD60A22977F000),
-  reinterpret<f64>(0x3FF40782DA3EF4B1), reinterpret<f64>(0xBFCCC00104959000),
-  reinterpret<f64>(0x3FF3EE8F5D57FE8F), reinterpret<f64>(0xBFCC202956891000),
-  reinterpret<f64>(0x3FF3D5D9A00B4CE9), reinterpret<f64>(0xBFCB81178D811000),
-  reinterpret<f64>(0x3FF3BD60C010C12B), reinterpret<f64>(0xBFCAE2C9CCD3D000),
-  reinterpret<f64>(0x3FF3A5242B75DAB8), reinterpret<f64>(0xBFCA45402E129000),
-  reinterpret<f64>(0x3FF38D22CD9FD002), reinterpret<f64>(0xBFC9A877681DF000),
-  reinterpret<f64>(0x3FF3755BC5847A1C), reinterpret<f64>(0xBFC90C6D69483000),
-  reinterpret<f64>(0x3FF35DCE49AD36E2), reinterpret<f64>(0xBFC87120A645C000),
-  reinterpret<f64>(0x3FF34679984DD440), reinterpret<f64>(0xBFC7D68FB4143000),
-  reinterpret<f64>(0x3FF32F5CCEFFCB24), reinterpret<f64>(0xBFC73CB83C627000),
-  reinterpret<f64>(0x3FF3187775A10D49), reinterpret<f64>(0xBFC6A39A9B376000),
-  reinterpret<f64>(0x3FF301C8373E3990), reinterpret<f64>(0xBFC60B3154B7A000),
-  reinterpret<f64>(0x3FF2EB4EBB95F841), reinterpret<f64>(0xBFC5737D76243000),
-  reinterpret<f64>(0x3FF2D50A0219A9D1), reinterpret<f64>(0xBFC4DC7B8FC23000),
-  reinterpret<f64>(0x3FF2BEF9A8B7FD2A), reinterpret<f64>(0xBFC4462C51D20000),
-  reinterpret<f64>(0x3FF2A91C7A0C1BAB), reinterpret<f64>(0xBFC3B08ABC830000),
-  reinterpret<f64>(0x3FF293726014B530), reinterpret<f64>(0xBFC31B996B490000),
-  reinterpret<f64>(0x3FF27DFA5757A1F5), reinterpret<f64>(0xBFC2875490A44000),
-  reinterpret<f64>(0x3FF268B39B1D3BBF), reinterpret<f64>(0xBFC1F3B9F879A000),
-  reinterpret<f64>(0x3FF2539D838FF5BD), reinterpret<f64>(0xBFC160C8252CA000),
-  reinterpret<f64>(0x3FF23EB7AAC9083B), reinterpret<f64>(0xBFC0CE7F57F72000),
-  reinterpret<f64>(0x3FF22A012BA940B6), reinterpret<f64>(0xBFC03CDC49FEA000),
-  reinterpret<f64>(0x3FF2157996CC4132), reinterpret<f64>(0xBFBF57BDBC4B8000),
-  reinterpret<f64>(0x3FF201201DD2FC9B), reinterpret<f64>(0xBFBE370896404000),
-  reinterpret<f64>(0x3FF1ECF4494D480B), reinterpret<f64>(0xBFBD17983EF94000),
-  reinterpret<f64>(0x3FF1D8F5528F6569), reinterpret<f64>(0xBFBBF9674ED8A000),
-  reinterpret<f64>(0x3FF1C52311577E7C), reinterpret<f64>(0xBFBADC79202F6000),
-  reinterpret<f64>(0x3FF1B17C74CB26E9), reinterpret<f64>(0xBFB9C0C3E7288000),
-  reinterpret<f64>(0x3FF19E010C2C1AB6), reinterpret<f64>(0xBFB8A646B372C000),
-  reinterpret<f64>(0x3FF18AB07BB670BD), reinterpret<f64>(0xBFB78D01B3AC0000),
-  reinterpret<f64>(0x3FF1778A25EFBCB6), reinterpret<f64>(0xBFB674F145380000),
-  reinterpret<f64>(0x3FF1648D354C31DA), reinterpret<f64>(0xBFB55E0E6D878000),
-  reinterpret<f64>(0x3FF151B990275FDD), reinterpret<f64>(0xBFB4485CDEA1E000),
-  reinterpret<f64>(0x3FF13F0EA432D24C), reinterpret<f64>(0xBFB333D94D6AA000),
-  reinterpret<f64>(0x3FF12C8B7210F9DA), reinterpret<f64>(0xBFB22079F8C56000),
-  reinterpret<f64>(0x3FF11A3028ECB531), reinterpret<f64>(0xBFB10E4698622000),
-  reinterpret<f64>(0x3FF107FBDA8434AF), reinterpret<f64>(0xBFAFFA6C6AD20000),
-  reinterpret<f64>(0x3FF0F5EE0F4E6BB3), reinterpret<f64>(0xBFADDA8D4A774000),
-  reinterpret<f64>(0x3FF0E4065D2A9FCE), reinterpret<f64>(0xBFABBCECE4850000),
-  reinterpret<f64>(0x3FF0D244632CA521), reinterpret<f64>(0xBFA9A1894012C000),
-  reinterpret<f64>(0x3FF0C0A77CE2981A), reinterpret<f64>(0xBFA788583302C000),
-  reinterpret<f64>(0x3FF0AF2F83C636D1), reinterpret<f64>(0xBFA5715E67D68000),
-  reinterpret<f64>(0x3FF09DDB98A01339), reinterpret<f64>(0xBFA35C8A49658000),
-  reinterpret<f64>(0x3FF08CABAF52E7DF), reinterpret<f64>(0xBFA149E364154000),
-  reinterpret<f64>(0x3FF07B9F2F4E28FB), reinterpret<f64>(0xBF9E72C082EB8000),
-  reinterpret<f64>(0x3FF06AB58C358F19), reinterpret<f64>(0xBF9A55F152528000),
-  reinterpret<f64>(0x3FF059EEA5ECF92C), reinterpret<f64>(0xBF963D62CF818000),
-  reinterpret<f64>(0x3FF04949CDD12C90), reinterpret<f64>(0xBF9228FB8CAA0000),
-  reinterpret<f64>(0x3FF038C6C6F0ADA9), reinterpret<f64>(0xBF8C317B20F90000),
-  reinterpret<f64>(0x3FF02865137932A9), reinterpret<f64>(0xBF8419355DAA0000),
-  reinterpret<f64>(0x3FF0182427EA7348), reinterpret<f64>(0xBF781203C2EC0000),
-  reinterpret<f64>(0x3FF008040614B195), reinterpret<f64>(0xBF60040979240000),
-  reinterpret<f64>(0x3FEFE01FF726FA1A), reinterpret<f64>(0x3F6FEFF384900000),
-  reinterpret<f64>(0x3FEFA11CC261EA74), reinterpret<f64>(0x3F87DC41353D0000),
-  reinterpret<f64>(0x3FEF6310B081992E), reinterpret<f64>(0x3F93CEA3C4C28000),
-  reinterpret<f64>(0x3FEF25F63CEEADCD), reinterpret<f64>(0x3F9B9FC114890000),
-  reinterpret<f64>(0x3FEEE9C8039113E7), reinterpret<f64>(0x3FA1B0D8CE110000),
-  reinterpret<f64>(0x3FEEAE8078CBB1AB), reinterpret<f64>(0x3FA58A5BD001C000),
-  reinterpret<f64>(0x3FEE741AA29D0C9B), reinterpret<f64>(0x3FA95C8340D88000),
-  reinterpret<f64>(0x3FEE3A91830A99B5), reinterpret<f64>(0x3FAD276AEF578000),
-  reinterpret<f64>(0x3FEE01E009609A56), reinterpret<f64>(0x3FB07598E598C000),
-  reinterpret<f64>(0x3FEDCA01E577BB98), reinterpret<f64>(0x3FB253F5E30D2000),
-  reinterpret<f64>(0x3FED92F20B7C9103), reinterpret<f64>(0x3FB42EDD8B380000),
-  reinterpret<f64>(0x3FED5CAC66FB5CCE), reinterpret<f64>(0x3FB606598757C000),
-  reinterpret<f64>(0x3FED272CAA5EDE9D), reinterpret<f64>(0x3FB7DA76356A0000),
-  reinterpret<f64>(0x3FECF26E3E6B2CCD), reinterpret<f64>(0x3FB9AB434E1C6000),
-  reinterpret<f64>(0x3FECBE6DA2A77902), reinterpret<f64>(0x3FBB78C7BB0D6000),
-  reinterpret<f64>(0x3FEC8B266D37086D), reinterpret<f64>(0x3FBD431332E72000),
-  reinterpret<f64>(0x3FEC5894BD5D5804), reinterpret<f64>(0x3FBF0A3171DE6000),
-  reinterpret<f64>(0x3FEC26B533BB9F8C), reinterpret<f64>(0x3FC067152B914000),
-  reinterpret<f64>(0x3FEBF583EEECE73F), reinterpret<f64>(0x3FC147858292B000),
-  reinterpret<f64>(0x3FEBC4FD75DB96C1), reinterpret<f64>(0x3FC2266ECDCA3000),
-  reinterpret<f64>(0x3FEB951E0C864A28), reinterpret<f64>(0x3FC303D7A6C55000),
-  reinterpret<f64>(0x3FEB65E2C5EF3E2C), reinterpret<f64>(0x3FC3DFC33C331000),
-  reinterpret<f64>(0x3FEB374867C9888B), reinterpret<f64>(0x3FC4BA366B7A8000),
-  reinterpret<f64>(0x3FEB094B211D304A), reinterpret<f64>(0x3FC5933928D1F000),
-  reinterpret<f64>(0x3FEADBE885F2EF7E), reinterpret<f64>(0x3FC66ACD2418F000),
-  reinterpret<f64>(0x3FEAAF1D31603DA2), reinterpret<f64>(0x3FC740F8EC669000),
-  reinterpret<f64>(0x3FEA82E63FD358A7), reinterpret<f64>(0x3FC815C0F51AF000),
-  reinterpret<f64>(0x3FEA5740EF09738B), reinterpret<f64>(0x3FC8E92954F68000),
-  reinterpret<f64>(0x3FEA2C2A90AB4B27), reinterpret<f64>(0x3FC9BB3602F84000),
-  reinterpret<f64>(0x3FEA01A01393F2D1), reinterpret<f64>(0x3FCA8BED1C2C0000),
-  reinterpret<f64>(0x3FE9D79F24DB3C1B), reinterpret<f64>(0x3FCB5B515C01D000),
-  reinterpret<f64>(0x3FE9AE2505C7B190), reinterpret<f64>(0x3FCC2967CCBCC000),
-  reinterpret<f64>(0x3FE9852EF297CE2F), reinterpret<f64>(0x3FCCF635D5486000),
-  reinterpret<f64>(0x3FE95CBAEEA44B75), reinterpret<f64>(0x3FCDC1BD3446C000),
-  reinterpret<f64>(0x3FE934C69DE74838), reinterpret<f64>(0x3FCE8C01B8CFE000),
-  reinterpret<f64>(0x3FE90D4F2F6752E6), reinterpret<f64>(0x3FCF5509C0179000),
-  reinterpret<f64>(0x3FE8E6528EFFD79D), reinterpret<f64>(0x3FD00E6C121FB800),
-  reinterpret<f64>(0x3FE8BFCE9FCC007C), reinterpret<f64>(0x3FD071B80E93D000),
-  reinterpret<f64>(0x3FE899C0DABEC30E), reinterpret<f64>(0x3FD0D46B9E867000),
-  reinterpret<f64>(0x3FE87427AA2317FB), reinterpret<f64>(0x3FD13687334BD000),
-  reinterpret<f64>(0x3FE84F00ACB39A08), reinterpret<f64>(0x3FD1980D67234800),
-  reinterpret<f64>(0x3FE82A49E8653E55), reinterpret<f64>(0x3FD1F8FFE0CC8000),
-  reinterpret<f64>(0x3FE8060195F40260), reinterpret<f64>(0x3FD2595FD7636800),
-  reinterpret<f64>(0x3FE7E22563E0A329), reinterpret<f64>(0x3FD2B9300914A800),
-  reinterpret<f64>(0x3FE7BEB377DCB5AD), reinterpret<f64>(0x3FD3187210436000),
-  reinterpret<f64>(0x3FE79BAA679725C2), reinterpret<f64>(0x3FD377266DEC1800),
-  reinterpret<f64>(0x3FE77907F2170657), reinterpret<f64>(0x3FD3D54FFBAF3000),
-  reinterpret<f64>(0x3FE756CADBD6130C), reinterpret<f64>(0x3FD432EEE32FE000)
-]);
-
-// @ts-ignore: decorator
-@lazy @inline const LOG_DATA_TAB2 = memory.data<f64>([
-  //               chi                ,                  clo
-  reinterpret<f64>(0x3FE61000014FB66B), reinterpret<f64>(0x3C7E026C91425B3C),
-  reinterpret<f64>(0x3FE63000034DB495), reinterpret<f64>(0x3C8DBFEA48005D41),
-  reinterpret<f64>(0x3FE650000D94D478), reinterpret<f64>(0x3C8E7FA786D6A5B7),
-  reinterpret<f64>(0x3FE67000074E6FAD), reinterpret<f64>(0x3C61FCEA6B54254C),
-  reinterpret<f64>(0x3FE68FFFFEDF0FAE), reinterpret<f64>(0xBC7C7E274C590EFD),
-  reinterpret<f64>(0x3FE6B0000763C5BC), reinterpret<f64>(0xBC8AC16848DCDA01),
-  reinterpret<f64>(0x3FE6D0001E5CC1F6), reinterpret<f64>(0x3C833F1C9D499311),
-  reinterpret<f64>(0x3FE6EFFFEB05F63E), reinterpret<f64>(0xBC7E80041AE22D53),
-  reinterpret<f64>(0x3FE710000E869780), reinterpret<f64>(0x3C7BFF6671097952),
-  reinterpret<f64>(0x3FE72FFFFC67E912), reinterpret<f64>(0x3C8C00E226BD8724),
-  reinterpret<f64>(0x3FE74FFFDF81116A), reinterpret<f64>(0xBC6E02916EF101D2),
-  reinterpret<f64>(0x3FE770000F679C90), reinterpret<f64>(0xBC67FC71CD549C74),
-  reinterpret<f64>(0x3FE78FFFFA7EC835), reinterpret<f64>(0x3C81BEC19EF50483),
-  reinterpret<f64>(0x3FE7AFFFFE20C2E6), reinterpret<f64>(0xBC707E1729CC6465),
-  reinterpret<f64>(0x3FE7CFFFED3FC900), reinterpret<f64>(0xBC808072087B8B1C),
-  reinterpret<f64>(0x3FE7EFFFE9261A76), reinterpret<f64>(0x3C8DC0286D9DF9AE),
-  reinterpret<f64>(0x3FE81000049CA3E8), reinterpret<f64>(0x3C897FD251E54C33),
-  reinterpret<f64>(0x3FE8300017932C8F), reinterpret<f64>(0xBC8AFEE9B630F381),
-  reinterpret<f64>(0x3FE850000633739C), reinterpret<f64>(0x3C89BFBF6B6535BC),
-  reinterpret<f64>(0x3FE87000204289C6), reinterpret<f64>(0xBC8BBF65F3117B75),
-  reinterpret<f64>(0x3FE88FFFEBF57904), reinterpret<f64>(0xBC89006EA23DCB57),
-  reinterpret<f64>(0x3FE8B00022BC04DF), reinterpret<f64>(0xBC7D00DF38E04B0A),
-  reinterpret<f64>(0x3FE8CFFFE50C1B8A), reinterpret<f64>(0xBC88007146FF9F05),
-  reinterpret<f64>(0x3FE8EFFFFC918E43), reinterpret<f64>(0x3C83817BD07A7038),
-  reinterpret<f64>(0x3FE910001EFA5FC7), reinterpret<f64>(0x3C893E9176DFB403),
-  reinterpret<f64>(0x3FE9300013467BB9), reinterpret<f64>(0x3C7F804E4B980276),
-  reinterpret<f64>(0x3FE94FFFE6EE076F), reinterpret<f64>(0xBC8F7EF0D9FF622E),
-  reinterpret<f64>(0x3FE96FFFDE3C12D1), reinterpret<f64>(0xBC7082AA962638BA),
-  reinterpret<f64>(0x3FE98FFFF4458A0D), reinterpret<f64>(0xBC87801B9164A8EF),
-  reinterpret<f64>(0x3FE9AFFFDD982E3E), reinterpret<f64>(0xBC8740E08A5A9337),
-  reinterpret<f64>(0x3FE9CFFFED49FB66), reinterpret<f64>(0x3C3FCE08C19BE000),
-  reinterpret<f64>(0x3FE9F00020F19C51), reinterpret<f64>(0xBC8A3FAA27885B0A),
-  reinterpret<f64>(0x3FEA10001145B006), reinterpret<f64>(0x3C74FF489958DA56),
-  reinterpret<f64>(0x3FEA300007BBF6FA), reinterpret<f64>(0x3C8CBEAB8A2B6D18),
-  reinterpret<f64>(0x3FEA500010971D79), reinterpret<f64>(0x3C88FECADD787930),
-  reinterpret<f64>(0x3FEA70001DF52E48), reinterpret<f64>(0xBC8F41763DD8ABDB),
-  reinterpret<f64>(0x3FEA90001C593352), reinterpret<f64>(0xBC8EBF0284C27612),
-  reinterpret<f64>(0x3FEAB0002A4F3E4B), reinterpret<f64>(0xBC69FD043CFF3F5F),
-  reinterpret<f64>(0x3FEACFFFD7AE1ED1), reinterpret<f64>(0xBC823EE7129070B4),
-  reinterpret<f64>(0x3FEAEFFFEE510478), reinterpret<f64>(0x3C6A063EE00EDEA3),
-  reinterpret<f64>(0x3FEB0FFFDB650D5B), reinterpret<f64>(0x3C5A06C8381F0AB9),
-  reinterpret<f64>(0x3FEB2FFFFEAACA57), reinterpret<f64>(0xBC79011E74233C1D),
-  reinterpret<f64>(0x3FEB4FFFD995BADC), reinterpret<f64>(0xBC79FF1068862A9F),
-  reinterpret<f64>(0x3FEB7000249E659C), reinterpret<f64>(0x3C8AFF45D0864F3E),
-  reinterpret<f64>(0x3FEB8FFFF9871640), reinterpret<f64>(0x3C7CFE7796C2C3F9),
-  reinterpret<f64>(0x3FEBAFFFD204CB4F), reinterpret<f64>(0xBC63FF27EEF22BC4),
-  reinterpret<f64>(0x3FEBCFFFD2415C45), reinterpret<f64>(0xBC6CFFB7EE3BEA21),
-  reinterpret<f64>(0x3FEBEFFFF86309DF), reinterpret<f64>(0xBC814103972E0B5C),
-  reinterpret<f64>(0x3FEC0FFFE1B57653), reinterpret<f64>(0x3C8BC16494B76A19),
-  reinterpret<f64>(0x3FEC2FFFF1FA57E3), reinterpret<f64>(0xBC64FEEF8D30C6ED),
-  reinterpret<f64>(0x3FEC4FFFDCBFE424), reinterpret<f64>(0xBC843F68BCEC4775),
-  reinterpret<f64>(0x3FEC6FFFED54B9F7), reinterpret<f64>(0x3C847EA3F053E0EC),
-  reinterpret<f64>(0x3FEC8FFFEB998FD5), reinterpret<f64>(0x3C7383068DF992F1),
-  reinterpret<f64>(0x3FECB0002125219A), reinterpret<f64>(0xBC68FD8E64180E04),
-  reinterpret<f64>(0x3FECCFFFDD94469C), reinterpret<f64>(0x3C8E7EBE1CC7EA72),
-  reinterpret<f64>(0x3FECEFFFEAFDC476), reinterpret<f64>(0x3C8EBE39AD9F88FE),
-  reinterpret<f64>(0x3FED1000169AF82B), reinterpret<f64>(0x3C757D91A8B95A71),
-  reinterpret<f64>(0x3FED30000D0FF71D), reinterpret<f64>(0x3C89C1906970C7DA),
-  reinterpret<f64>(0x3FED4FFFEA790FC4), reinterpret<f64>(0xBC580E37C558FE0C),
-  reinterpret<f64>(0x3FED70002EDC87E5), reinterpret<f64>(0xBC7F80D64DC10F44),
-  reinterpret<f64>(0x3FED900021DC82AA), reinterpret<f64>(0xBC747C8F94FD5C5C),
-  reinterpret<f64>(0x3FEDAFFFD86B0283), reinterpret<f64>(0x3C8C7F1DC521617E),
-  reinterpret<f64>(0x3FEDD000296C4739), reinterpret<f64>(0x3C88019EB2FFB153),
-  reinterpret<f64>(0x3FEDEFFFE54490F5), reinterpret<f64>(0x3C6E00D2C652CC89),
-  reinterpret<f64>(0x3FEE0FFFCDABF694), reinterpret<f64>(0xBC7F8340202D69D2),
-  reinterpret<f64>(0x3FEE2FFFDB52C8DD), reinterpret<f64>(0x3C7B00C1CA1B0864),
-  reinterpret<f64>(0x3FEE4FFFF24216EF), reinterpret<f64>(0x3C72FFA8B094AB51),
-  reinterpret<f64>(0x3FEE6FFFE88A5E11), reinterpret<f64>(0xBC57F673B1EFBE59),
-  reinterpret<f64>(0x3FEE9000119EFF0D), reinterpret<f64>(0xBC84808D5E0BC801),
-  reinterpret<f64>(0x3FEEAFFFDFA51744), reinterpret<f64>(0x3C780006D54320B5),
-  reinterpret<f64>(0x3FEED0001A127FA1), reinterpret<f64>(0xBC5002F860565C92),
-  reinterpret<f64>(0x3FEEF00007BABCC4), reinterpret<f64>(0xBC8540445D35E611),
-  reinterpret<f64>(0x3FEF0FFFF57A8D02), reinterpret<f64>(0xBC4FFB3139EF9105),
-  reinterpret<f64>(0x3FEF30001EE58AC7), reinterpret<f64>(0x3C8A81ACF2731155),
-  reinterpret<f64>(0x3FEF4FFFF5823494), reinterpret<f64>(0x3C8A3F41D4D7C743),
-  reinterpret<f64>(0x3FEF6FFFFCA94C6B), reinterpret<f64>(0xBC6202F41C987875),
-  reinterpret<f64>(0x3FEF8FFFE1F9C441), reinterpret<f64>(0x3C777DD1F477E74B),
-  reinterpret<f64>(0x3FEFAFFFD2E0E37E), reinterpret<f64>(0xBC6F01199A7CA331),
-  reinterpret<f64>(0x3FEFD0001C77E49E), reinterpret<f64>(0x3C7181EE4BCEACB1),
-  reinterpret<f64>(0x3FEFEFFFF7E0C331), reinterpret<f64>(0xBC6E05370170875A),
-  reinterpret<f64>(0x3FF00FFFF465606E), reinterpret<f64>(0xBC8A7EAD491C0ADA),
-  reinterpret<f64>(0x3FF02FFFF3867A58), reinterpret<f64>(0xBC977F69C3FCB2E0),
-  reinterpret<f64>(0x3FF04FFFFDFC0D17), reinterpret<f64>(0x3C97BFFE34CB945B),
-  reinterpret<f64>(0x3FF0700003CD4D82), reinterpret<f64>(0x3C820083C0E456CB),
-  reinterpret<f64>(0x3FF08FFFF9F2CBE8), reinterpret<f64>(0xBC6DFFDFBE37751A),
-  reinterpret<f64>(0x3FF0B000010CDA65), reinterpret<f64>(0xBC913F7FAEE626EB),
-  reinterpret<f64>(0x3FF0D00001A4D338), reinterpret<f64>(0x3C807DFA79489FF7),
-  reinterpret<f64>(0x3FF0EFFFFADAFDFD), reinterpret<f64>(0xBC77040570D66BC0),
-  reinterpret<f64>(0x3FF110000BBAFD96), reinterpret<f64>(0x3C8E80D4846D0B62),
-  reinterpret<f64>(0x3FF12FFFFAE5F45D), reinterpret<f64>(0x3C9DBFFA64FD36EF),
-  reinterpret<f64>(0x3FF150000DD59AD9), reinterpret<f64>(0x3C9A0077701250AE),
-  reinterpret<f64>(0x3FF170000F21559A), reinterpret<f64>(0x3C8DFDF9E2E3DEEE),
-  reinterpret<f64>(0x3FF18FFFFC275426), reinterpret<f64>(0x3C910030DC3B7273),
-  reinterpret<f64>(0x3FF1B000123D3C59), reinterpret<f64>(0x3C997F7980030188),
-  reinterpret<f64>(0x3FF1CFFFF8299EB7), reinterpret<f64>(0xBC65F932AB9F8C67),
-  reinterpret<f64>(0x3FF1EFFFF48AD400), reinterpret<f64>(0x3C937FBF9DA75BEB),
-  reinterpret<f64>(0x3FF210000C8B86A4), reinterpret<f64>(0x3C9F806B91FD5B22),
-  reinterpret<f64>(0x3FF2300003854303), reinterpret<f64>(0x3C93FFC2EB9FBF33),
-  reinterpret<f64>(0x3FF24FFFFFBCF684), reinterpret<f64>(0x3C7601E77E2E2E72),
-  reinterpret<f64>(0x3FF26FFFF52921D9), reinterpret<f64>(0x3C7FFCBB767F0C61),
-  reinterpret<f64>(0x3FF2900014933A3C), reinterpret<f64>(0xBC7202CA3C02412B),
-  reinterpret<f64>(0x3FF2B00014556313), reinterpret<f64>(0xBC92808233F21F02),
-  reinterpret<f64>(0x3FF2CFFFEBFE523B), reinterpret<f64>(0xBC88FF7E384FDCF2),
-  reinterpret<f64>(0x3FF2F0000BB8AD96), reinterpret<f64>(0xBC85FF51503041C5),
-  reinterpret<f64>(0x3FF30FFFFB7AE2AF), reinterpret<f64>(0xBC810071885E289D),
-  reinterpret<f64>(0x3FF32FFFFEAC5F7F), reinterpret<f64>(0xBC91FF5D3FB7B715),
-  reinterpret<f64>(0x3FF350000CA66756), reinterpret<f64>(0x3C957F82228B82BD),
-  reinterpret<f64>(0x3FF3700011FBF721), reinterpret<f64>(0x3C8000BAC40DD5CC),
-  reinterpret<f64>(0x3FF38FFFF9592FB9), reinterpret<f64>(0xBC943F9D2DB2A751),
-  reinterpret<f64>(0x3FF3B00004DDD242), reinterpret<f64>(0x3C857F6B707638E1),
-  reinterpret<f64>(0x3FF3CFFFF5B2C957), reinterpret<f64>(0x3C7A023A10BF1231),
-  reinterpret<f64>(0x3FF3EFFFEAB0B418), reinterpret<f64>(0x3C987F6D66B152B0),
-  reinterpret<f64>(0x3FF410001532AFF4), reinterpret<f64>(0x3C67F8375F198524),
-  reinterpret<f64>(0x3FF4300017478B29), reinterpret<f64>(0x3C8301E672DC5143),
-  reinterpret<f64>(0x3FF44FFFE795B463), reinterpret<f64>(0x3C89FF69B8B2895A),
-  reinterpret<f64>(0x3FF46FFFE80475E0), reinterpret<f64>(0xBC95C0B19BC2F254),
-  reinterpret<f64>(0x3FF48FFFEF6FC1E7), reinterpret<f64>(0x3C9B4009F23A2A72),
-  reinterpret<f64>(0x3FF4AFFFE5BEA704), reinterpret<f64>(0xBC94FFB7BF0D7D45),
-  reinterpret<f64>(0x3FF4D000171027DE), reinterpret<f64>(0xBC99C06471DC6A3D),
-  reinterpret<f64>(0x3FF4F0000FF03EE2), reinterpret<f64>(0x3C977F890B85531C),
-  reinterpret<f64>(0x3FF5100012DC4BD1), reinterpret<f64>(0x3C6004657166A436),
-  reinterpret<f64>(0x3FF530001605277A), reinterpret<f64>(0xBC96BFCECE233209),
-  reinterpret<f64>(0x3FF54FFFECDB704C), reinterpret<f64>(0xBC8902720505A1D7),
-  reinterpret<f64>(0x3FF56FFFEF5F54A9), reinterpret<f64>(0x3C9BBFE60EC96412),
-  reinterpret<f64>(0x3FF5900017E61012), reinterpret<f64>(0x3C887EC581AFEF90),
-  reinterpret<f64>(0x3FF5B00003C93E92), reinterpret<f64>(0xBC9F41080ABF0CC0),
-  reinterpret<f64>(0x3FF5D0001D4919BC), reinterpret<f64>(0xBC98812AFB254729),
-  reinterpret<f64>(0x3FF5EFFFE7B87A89), reinterpret<f64>(0xBC947EB780ED6904)
-]);
-
 // @ts-ignore: decorator
 @inline
-export function log_lut(x: f64): f64 {
-  const N_MASK = (1 << LOG_TABLE_BITS) - 1;
+export function log64_lut(x: f64): f64 {
+  const N_MASK = (1 << LOG_TABLE64_BITS) - 1;
 
   const
     B0  = reinterpret<f64>(0xBFE0000000000000), // -0x1p-1
@@ -1449,12 +2968,12 @@ export function log_lut(x: f64): f64 {
   // The range is split into N subintervals.
   // The ith subinterval contains z and c is near its center.
   var tmp  = ix - 0x3FE6000000000000;
-  var i    = <usize>((tmp >> (52 - LOG_TABLE_BITS)) & N_MASK);
+  var i    = <usize>((tmp >> (52 - LOG_TABLE64_BITS)) & N_MASK);
   var k    = <i64>tmp >> 52;
   var iz   = ix - (tmp & (u64(0xFFF) << 52));
 
-  var invc = load<f64>(LOG_DATA_TAB1 + (i << (1 + alignof<f64>())), 0 << alignof<f64>()); // T[i].invc;
-  var logc = load<f64>(LOG_DATA_TAB1 + (i << (1 + alignof<f64>())), 1 << alignof<f64>()); // T[i].logc;
+  var invc = load<f64>(LOG_TABLE1_64 + (i << (1 + alignof<f64>())), 0 << alignof<f64>()); // T[i].invc;
+  var logc = load<f64>(LOG_TABLE1_64 + (i << (1 + alignof<f64>())), 1 << alignof<f64>()); // T[i].logc;
   var z    = reinterpret<f64>(iz);
 
   // log(x) = log1p(z/c-1) + log(c) + k*Ln2.
@@ -1464,8 +2983,8 @@ export function log_lut(x: f64): f64 {
   // 	r = __builtin_fma(z, invc, -1.0);
   // #else
   // rounding error: 0x1p-55/N + 0x1p-66
-  const chi = load<f64>(LOG_DATA_TAB2 + (i << (1 + alignof<f64>())), 0 << alignof<f64>()); // T2[i].chi
-  const clo = load<f64>(LOG_DATA_TAB2 + (i << (1 + alignof<f64>())), 1 << alignof<f64>()); // T2[i].clo
+  const chi = load<f64>(LOG_TABLE2_64 + (i << (1 + alignof<f64>())), 0 << alignof<f64>()); // T2[i].chi
+  const clo = load<f64>(LOG_TABLE2_64 + (i << (1 + alignof<f64>())), 1 << alignof<f64>()); // T2[i].clo
   var r = (z - chi - clo) * invc;
   // #endif
   var kd = <f64>k;
@@ -1484,174 +3003,11 @@ export function log_lut(x: f64): f64 {
   return lo + r2 * A0 + r * r2 * (A1 + r * A2 + r2 * (A3 + r * A4)) + hi;
 }
 
-//
-// Lookup data for pow. See: https://git.musl-libc.org/cgit/musl/tree/src/math/pow.c
-//
-
-// @ts-ignore: decorator
-@inline const POW_LOG_TABLE_BITS = 7;
-
-/* Algorithm:
-
-  x = 2^k z
-  log(x) = k ln2 + log(c) + log(z/c)
-  log(z/c) = poly(z/c - 1)
-
-where z is in [0x1.69555p-1; 0x1.69555p0] which is split into N subintervals
-and z falls into the ith one, then table entries are computed as
-
-  tab[i].invc = 1/c
-  tab[i].logc = round(0x1p43*log(c))/0x1p43
-  tab[i].logctail = (double)(log(c) - logc)
-
-where c is chosen near the center of the subinterval such that 1/c has only a
-few precision bits so z/c - 1 is exactly representible as double:
-
-  1/c = center < 1 ? round(N/center)/N : round(2*N/center)/N/2
-
-Note: |z/c - 1| < 1/N for the chosen c, |log(c) - logc - logctail| < 0x1p-97,
-the last few bits of logc are rounded away so k*ln2hi + logc has no rounding
-error and the interval for z is selected such that near x == 1, where log(x)
-is tiny, large cancellation error is avoided in logc + poly(z/c - 1). */
-
-// @ts-ignore: decorator
-@lazy @inline const POW_LOG_DATA_TAB = memory.data<f64>([
-  //             invc                 ,pad,               logc                 ,               logctail
-  reinterpret<f64>(0x3FF6A00000000000), 0, reinterpret<f64>(0xBFD62C82F2B9C800), reinterpret<f64>(0x3CFAB42428375680),
-  reinterpret<f64>(0x3FF6800000000000), 0, reinterpret<f64>(0xBFD5D1BDBF580800), reinterpret<f64>(0xBD1CA508D8E0F720),
-  reinterpret<f64>(0x3FF6600000000000), 0, reinterpret<f64>(0xBFD5767717455800), reinterpret<f64>(0xBD2362A4D5B6506D),
-  reinterpret<f64>(0x3FF6400000000000), 0, reinterpret<f64>(0xBFD51AAD872DF800), reinterpret<f64>(0xBCE684E49EB067D5),
-  reinterpret<f64>(0x3FF6200000000000), 0, reinterpret<f64>(0xBFD4BE5F95777800), reinterpret<f64>(0xBD041B6993293EE0),
-  reinterpret<f64>(0x3FF6000000000000), 0, reinterpret<f64>(0xBFD4618BC21C6000), reinterpret<f64>(0x3D13D82F484C84CC),
-  reinterpret<f64>(0x3FF5E00000000000), 0, reinterpret<f64>(0xBFD404308686A800), reinterpret<f64>(0x3CDC42F3ED820B3A),
-  reinterpret<f64>(0x3FF5C00000000000), 0, reinterpret<f64>(0xBFD3A64C55694800), reinterpret<f64>(0x3D20B1C686519460),
-  reinterpret<f64>(0x3FF5A00000000000), 0, reinterpret<f64>(0xBFD347DD9A988000), reinterpret<f64>(0x3D25594DD4C58092),
-  reinterpret<f64>(0x3FF5800000000000), 0, reinterpret<f64>(0xBFD2E8E2BAE12000), reinterpret<f64>(0x3D267B1E99B72BD8),
-  reinterpret<f64>(0x3FF5600000000000), 0, reinterpret<f64>(0xBFD2895A13DE8800), reinterpret<f64>(0x3D15CA14B6CFB03F),
-  reinterpret<f64>(0x3FF5600000000000), 0, reinterpret<f64>(0xBFD2895A13DE8800), reinterpret<f64>(0x3D15CA14B6CFB03F),
-  reinterpret<f64>(0x3FF5400000000000), 0, reinterpret<f64>(0xBFD22941FBCF7800), reinterpret<f64>(0xBD165A242853DA76),
-  reinterpret<f64>(0x3FF5200000000000), 0, reinterpret<f64>(0xBFD1C898C1699800), reinterpret<f64>(0xBD1FAFBC68E75404),
-  reinterpret<f64>(0x3FF5000000000000), 0, reinterpret<f64>(0xBFD1675CABABA800), reinterpret<f64>(0x3D1F1FC63382A8F0),
-  reinterpret<f64>(0x3FF4E00000000000), 0, reinterpret<f64>(0xBFD1058BF9AE4800), reinterpret<f64>(0xBD26A8C4FD055A66),
-  reinterpret<f64>(0x3FF4C00000000000), 0, reinterpret<f64>(0xBFD0A324E2739000), reinterpret<f64>(0xBD0C6BEE7EF4030E),
-  reinterpret<f64>(0x3FF4A00000000000), 0, reinterpret<f64>(0xBFD0402594B4D000), reinterpret<f64>(0xBCF036B89EF42D7F),
-  reinterpret<f64>(0x3FF4A00000000000), 0, reinterpret<f64>(0xBFD0402594B4D000), reinterpret<f64>(0xBCF036B89EF42D7F),
-  reinterpret<f64>(0x3FF4800000000000), 0, reinterpret<f64>(0xBFCFB9186D5E4000), reinterpret<f64>(0x3D0D572AAB993C87),
-  reinterpret<f64>(0x3FF4600000000000), 0, reinterpret<f64>(0xBFCEF0ADCBDC6000), reinterpret<f64>(0x3D2B26B79C86AF24),
-  reinterpret<f64>(0x3FF4400000000000), 0, reinterpret<f64>(0xBFCE27076E2AF000), reinterpret<f64>(0xBD172F4F543FFF10),
-  reinterpret<f64>(0x3FF4200000000000), 0, reinterpret<f64>(0xBFCD5C216B4FC000), reinterpret<f64>(0x3D21BA91BBCA681B),
-  reinterpret<f64>(0x3FF4000000000000), 0, reinterpret<f64>(0xBFCC8FF7C79AA000), reinterpret<f64>(0x3D27794F689F8434),
-  reinterpret<f64>(0x3FF4000000000000), 0, reinterpret<f64>(0xBFCC8FF7C79AA000), reinterpret<f64>(0x3D27794F689F8434),
-  reinterpret<f64>(0x3FF3E00000000000), 0, reinterpret<f64>(0xBFCBC286742D9000), reinterpret<f64>(0x3D194EB0318BB78F),
-  reinterpret<f64>(0x3FF3C00000000000), 0, reinterpret<f64>(0xBFCAF3C94E80C000), reinterpret<f64>(0x3CBA4E633FCD9066),
-  reinterpret<f64>(0x3FF3A00000000000), 0, reinterpret<f64>(0xBFCA23BC1FE2B000), reinterpret<f64>(0xBD258C64DC46C1EA),
-  reinterpret<f64>(0x3FF3A00000000000), 0, reinterpret<f64>(0xBFCA23BC1FE2B000), reinterpret<f64>(0xBD258C64DC46C1EA),
-  reinterpret<f64>(0x3FF3800000000000), 0, reinterpret<f64>(0xBFC9525A9CF45000), reinterpret<f64>(0xBD2AD1D904C1D4E3),
-  reinterpret<f64>(0x3FF3600000000000), 0, reinterpret<f64>(0xBFC87FA06520D000), reinterpret<f64>(0x3D2BBDBF7FDBFA09),
-  reinterpret<f64>(0x3FF3400000000000), 0, reinterpret<f64>(0xBFC7AB890210E000), reinterpret<f64>(0x3D2BDB9072534A58),
-  reinterpret<f64>(0x3FF3400000000000), 0, reinterpret<f64>(0xBFC7AB890210E000), reinterpret<f64>(0x3D2BDB9072534A58),
-  reinterpret<f64>(0x3FF3200000000000), 0, reinterpret<f64>(0xBFC6D60FE719D000), reinterpret<f64>(0xBD10E46AA3B2E266),
-  reinterpret<f64>(0x3FF3000000000000), 0, reinterpret<f64>(0xBFC5FF3070A79000), reinterpret<f64>(0xBD1E9E439F105039),
-  reinterpret<f64>(0x3FF3000000000000), 0, reinterpret<f64>(0xBFC5FF3070A79000), reinterpret<f64>(0xBD1E9E439F105039),
-  reinterpret<f64>(0x3FF2E00000000000), 0, reinterpret<f64>(0xBFC526E5E3A1B000), reinterpret<f64>(0xBD20DE8B90075B8F),
-  reinterpret<f64>(0x3FF2C00000000000), 0, reinterpret<f64>(0xBFC44D2B6CCB8000), reinterpret<f64>(0x3D170CC16135783C),
-  reinterpret<f64>(0x3FF2C00000000000), 0, reinterpret<f64>(0xBFC44D2B6CCB8000), reinterpret<f64>(0x3D170CC16135783C),
-  reinterpret<f64>(0x3FF2A00000000000), 0, reinterpret<f64>(0xBFC371FC201E9000), reinterpret<f64>(0x3CF178864D27543A),
-  reinterpret<f64>(0x3FF2800000000000), 0, reinterpret<f64>(0xBFC29552F81FF000), reinterpret<f64>(0xBD248D301771C408),
-  reinterpret<f64>(0x3FF2600000000000), 0, reinterpret<f64>(0xBFC1B72AD52F6000), reinterpret<f64>(0xBD2E80A41811A396),
-  reinterpret<f64>(0x3FF2600000000000), 0, reinterpret<f64>(0xBFC1B72AD52F6000), reinterpret<f64>(0xBD2E80A41811A396),
-  reinterpret<f64>(0x3FF2400000000000), 0, reinterpret<f64>(0xBFC0D77E7CD09000), reinterpret<f64>(0x3D0A699688E85BF4),
-  reinterpret<f64>(0x3FF2400000000000), 0, reinterpret<f64>(0xBFC0D77E7CD09000), reinterpret<f64>(0x3D0A699688E85BF4),
-  reinterpret<f64>(0x3FF2200000000000), 0, reinterpret<f64>(0xBFBFEC9131DBE000), reinterpret<f64>(0xBD2575545CA333F2),
-  reinterpret<f64>(0x3FF2000000000000), 0, reinterpret<f64>(0xBFBE27076E2B0000), reinterpret<f64>(0x3D2A342C2AF0003C),
-  reinterpret<f64>(0x3FF2000000000000), 0, reinterpret<f64>(0xBFBE27076E2B0000), reinterpret<f64>(0x3D2A342C2AF0003C),
-  reinterpret<f64>(0x3FF1E00000000000), 0, reinterpret<f64>(0xBFBC5E548F5BC000), reinterpret<f64>(0xBD1D0C57585FBE06),
-  reinterpret<f64>(0x3FF1C00000000000), 0, reinterpret<f64>(0xBFBA926D3A4AE000), reinterpret<f64>(0x3D253935E85BAAC8),
-  reinterpret<f64>(0x3FF1C00000000000), 0, reinterpret<f64>(0xBFBA926D3A4AE000), reinterpret<f64>(0x3D253935E85BAAC8),
-  reinterpret<f64>(0x3FF1A00000000000), 0, reinterpret<f64>(0xBFB8C345D631A000), reinterpret<f64>(0x3D137C294D2F5668),
-  reinterpret<f64>(0x3FF1A00000000000), 0, reinterpret<f64>(0xBFB8C345D631A000), reinterpret<f64>(0x3D137C294D2F5668),
-  reinterpret<f64>(0x3FF1800000000000), 0, reinterpret<f64>(0xBFB6F0D28AE56000), reinterpret<f64>(0xBD269737C93373DA),
-  reinterpret<f64>(0x3FF1600000000000), 0, reinterpret<f64>(0xBFB51B073F062000), reinterpret<f64>(0x3D1F025B61C65E57),
-  reinterpret<f64>(0x3FF1600000000000), 0, reinterpret<f64>(0xBFB51B073F062000), reinterpret<f64>(0x3D1F025B61C65E57),
-  reinterpret<f64>(0x3FF1400000000000), 0, reinterpret<f64>(0xBFB341D7961BE000), reinterpret<f64>(0x3D2C5EDACCF913DF),
-  reinterpret<f64>(0x3FF1400000000000), 0, reinterpret<f64>(0xBFB341D7961BE000), reinterpret<f64>(0x3D2C5EDACCF913DF),
-  reinterpret<f64>(0x3FF1200000000000), 0, reinterpret<f64>(0xBFB16536EEA38000), reinterpret<f64>(0x3D147C5E768FA309),
-  reinterpret<f64>(0x3FF1000000000000), 0, reinterpret<f64>(0xBFAF0A30C0118000), reinterpret<f64>(0x3D2D599E83368E91),
-  reinterpret<f64>(0x3FF1000000000000), 0, reinterpret<f64>(0xBFAF0A30C0118000), reinterpret<f64>(0x3D2D599E83368E91),
-  reinterpret<f64>(0x3FF0E00000000000), 0, reinterpret<f64>(0xBFAB42DD71198000), reinterpret<f64>(0x3D1C827AE5D6704C),
-  reinterpret<f64>(0x3FF0E00000000000), 0, reinterpret<f64>(0xBFAB42DD71198000), reinterpret<f64>(0x3D1C827AE5D6704C),
-  reinterpret<f64>(0x3FF0C00000000000), 0, reinterpret<f64>(0xBFA77458F632C000), reinterpret<f64>(0xBD2CFC4634F2A1EE),
-  reinterpret<f64>(0x3FF0C00000000000), 0, reinterpret<f64>(0xBFA77458F632C000), reinterpret<f64>(0xBD2CFC4634F2A1EE),
-  reinterpret<f64>(0x3FF0A00000000000), 0, reinterpret<f64>(0xBFA39E87B9FEC000), reinterpret<f64>(0x3CF502B7F526FEAA),
-  reinterpret<f64>(0x3FF0A00000000000), 0, reinterpret<f64>(0xBFA39E87B9FEC000), reinterpret<f64>(0x3CF502B7F526FEAA),
-  reinterpret<f64>(0x3FF0800000000000), 0, reinterpret<f64>(0xBF9F829B0E780000), reinterpret<f64>(0xBD2980267C7E09E4),
-  reinterpret<f64>(0x3FF0800000000000), 0, reinterpret<f64>(0xBF9F829B0E780000), reinterpret<f64>(0xBD2980267C7E09E4),
-  reinterpret<f64>(0x3FF0600000000000), 0, reinterpret<f64>(0xBF97B91B07D58000), reinterpret<f64>(0xBD288D5493FAA639),
-  reinterpret<f64>(0x3FF0400000000000), 0, reinterpret<f64>(0xBF8FC0A8B0FC0000), reinterpret<f64>(0xBCDF1E7CF6D3A69C),
-  reinterpret<f64>(0x3FF0400000000000), 0, reinterpret<f64>(0xBF8FC0A8B0FC0000), reinterpret<f64>(0xBCDF1E7CF6D3A69C),
-  reinterpret<f64>(0x3FF0200000000000), 0, reinterpret<f64>(0xBF7FE02A6B100000), reinterpret<f64>(0xBD19E23F0DDA40E4),
-  reinterpret<f64>(0x3FF0200000000000), 0, reinterpret<f64>(0xBF7FE02A6B100000), reinterpret<f64>(0xBD19E23F0DDA40E4),
-  reinterpret<f64>(0x3FF0000000000000), 0, 0, 0,
-  reinterpret<f64>(0x3FF0000000000000), 0, 0, 0,
-  reinterpret<f64>(0x3FEFC00000000000), 0, reinterpret<f64>(0x3F80101575890000), reinterpret<f64>(0xBD10C76B999D2BE8),
-  reinterpret<f64>(0x3FEF800000000000), 0, reinterpret<f64>(0x3F90205658938000), reinterpret<f64>(0xBD23DC5B06E2F7D2),
-  reinterpret<f64>(0x3FEF400000000000), 0, reinterpret<f64>(0x3F98492528C90000), reinterpret<f64>(0xBD2AA0BA325A0C34),
-  reinterpret<f64>(0x3FEF000000000000), 0, reinterpret<f64>(0x3FA0415D89E74000), reinterpret<f64>(0x3D0111C05CF1D753),
-  reinterpret<f64>(0x3FEEC00000000000), 0, reinterpret<f64>(0x3FA466AED42E0000), reinterpret<f64>(0xBD2C167375BDFD28),
-  reinterpret<f64>(0x3FEE800000000000), 0, reinterpret<f64>(0x3FA894AA149FC000), reinterpret<f64>(0xBD197995D05A267D),
-  reinterpret<f64>(0x3FEE400000000000), 0, reinterpret<f64>(0x3FACCB73CDDDC000), reinterpret<f64>(0xBD1A68F247D82807),
-  reinterpret<f64>(0x3FEE200000000000), 0, reinterpret<f64>(0x3FAEEA31C006C000), reinterpret<f64>(0xBD0E113E4FC93B7B),
-  reinterpret<f64>(0x3FEDE00000000000), 0, reinterpret<f64>(0x3FB1973BD1466000), reinterpret<f64>(0xBD25325D560D9E9B),
-  reinterpret<f64>(0x3FEDA00000000000), 0, reinterpret<f64>(0x3FB3BDF5A7D1E000), reinterpret<f64>(0x3D2CC85EA5DB4ED7),
-  reinterpret<f64>(0x3FED600000000000), 0, reinterpret<f64>(0x3FB5E95A4D97A000), reinterpret<f64>(0xBD2C69063C5D1D1E),
-  reinterpret<f64>(0x3FED400000000000), 0, reinterpret<f64>(0x3FB700D30AEAC000), reinterpret<f64>(0x3CEC1E8DA99DED32),
-  reinterpret<f64>(0x3FED000000000000), 0, reinterpret<f64>(0x3FB9335E5D594000), reinterpret<f64>(0x3D23115C3ABD47DA),
-  reinterpret<f64>(0x3FECC00000000000), 0, reinterpret<f64>(0x3FBB6AC88DAD6000), reinterpret<f64>(0xBD1390802BF768E5),
-  reinterpret<f64>(0x3FECA00000000000), 0, reinterpret<f64>(0x3FBC885801BC4000), reinterpret<f64>(0x3D2646D1C65AACD3),
-  reinterpret<f64>(0x3FEC600000000000), 0, reinterpret<f64>(0x3FBEC739830A2000), reinterpret<f64>(0xBD2DC068AFE645E0),
-  reinterpret<f64>(0x3FEC400000000000), 0, reinterpret<f64>(0x3FBFE89139DBE000), reinterpret<f64>(0xBD2534D64FA10AFD),
-  reinterpret<f64>(0x3FEC000000000000), 0, reinterpret<f64>(0x3FC1178E8227E000), reinterpret<f64>(0x3D21EF78CE2D07F2),
-  reinterpret<f64>(0x3FEBE00000000000), 0, reinterpret<f64>(0x3FC1AA2B7E23F000), reinterpret<f64>(0x3D2CA78E44389934),
-  reinterpret<f64>(0x3FEBA00000000000), 0, reinterpret<f64>(0x3FC2D1610C868000), reinterpret<f64>(0x3D039D6CCB81B4A1),
-  reinterpret<f64>(0x3FEB800000000000), 0, reinterpret<f64>(0x3FC365FCB0159000), reinterpret<f64>(0x3CC62FA8234B7289),
-  reinterpret<f64>(0x3FEB400000000000), 0, reinterpret<f64>(0x3FC4913D8333B000), reinterpret<f64>(0x3D25837954FDB678),
-  reinterpret<f64>(0x3FEB200000000000), 0, reinterpret<f64>(0x3FC527E5E4A1B000), reinterpret<f64>(0x3D2633E8E5697DC7),
-  reinterpret<f64>(0x3FEAE00000000000), 0, reinterpret<f64>(0x3FC6574EBE8C1000), reinterpret<f64>(0x3D19CF8B2C3C2E78),
-  reinterpret<f64>(0x3FEAC00000000000), 0, reinterpret<f64>(0x3FC6F0128B757000), reinterpret<f64>(0xBD25118DE59C21E1),
-  reinterpret<f64>(0x3FEAA00000000000), 0, reinterpret<f64>(0x3FC7898D85445000), reinterpret<f64>(0xBD1C661070914305),
-  reinterpret<f64>(0x3FEA600000000000), 0, reinterpret<f64>(0x3FC8BEAFEB390000), reinterpret<f64>(0xBD073D54AAE92CD1),
-  reinterpret<f64>(0x3FEA400000000000), 0, reinterpret<f64>(0x3FC95A5ADCF70000), reinterpret<f64>(0x3D07F22858A0FF6F),
-  reinterpret<f64>(0x3FEA000000000000), 0, reinterpret<f64>(0x3FCA93ED3C8AE000), reinterpret<f64>(0xBD28724350562169),
-  reinterpret<f64>(0x3FE9E00000000000), 0, reinterpret<f64>(0x3FCB31D8575BD000), reinterpret<f64>(0xBD0C358D4EACE1AA),
-  reinterpret<f64>(0x3FE9C00000000000), 0, reinterpret<f64>(0x3FCBD087383BE000), reinterpret<f64>(0xBD2D4BC4595412B6),
-  reinterpret<f64>(0x3FE9A00000000000), 0, reinterpret<f64>(0x3FCC6FFBC6F01000), reinterpret<f64>(0xBCF1EC72C5962BD2),
-  reinterpret<f64>(0x3FE9600000000000), 0, reinterpret<f64>(0x3FCDB13DB0D49000), reinterpret<f64>(0xBD2AFF2AF715B035),
-  reinterpret<f64>(0x3FE9400000000000), 0, reinterpret<f64>(0x3FCE530EFFE71000), reinterpret<f64>(0x3CC212276041F430),
-  reinterpret<f64>(0x3FE9200000000000), 0, reinterpret<f64>(0x3FCEF5ADE4DD0000), reinterpret<f64>(0xBCCA211565BB8E11),
-  reinterpret<f64>(0x3FE9000000000000), 0, reinterpret<f64>(0x3FCF991C6CB3B000), reinterpret<f64>(0x3D1BCBECCA0CDF30),
-  reinterpret<f64>(0x3FE8C00000000000), 0, reinterpret<f64>(0x3FD07138604D5800), reinterpret<f64>(0x3CF89CDB16ED4E91),
-  reinterpret<f64>(0x3FE8A00000000000), 0, reinterpret<f64>(0x3FD0C42D67616000), reinterpret<f64>(0x3D27188B163CEAE9),
-  reinterpret<f64>(0x3FE8800000000000), 0, reinterpret<f64>(0x3FD1178E8227E800), reinterpret<f64>(0xBD2C210E63A5F01C),
-  reinterpret<f64>(0x3FE8600000000000), 0, reinterpret<f64>(0x3FD16B5CCBACF800), reinterpret<f64>(0x3D2B9ACDF7A51681),
-  reinterpret<f64>(0x3FE8400000000000), 0, reinterpret<f64>(0x3FD1BF99635A6800), reinterpret<f64>(0x3D2CA6ED5147BDB7),
-  reinterpret<f64>(0x3FE8200000000000), 0, reinterpret<f64>(0x3FD214456D0EB800), reinterpret<f64>(0x3D0A87DEBA46BAEA),
-  reinterpret<f64>(0x3FE7E00000000000), 0, reinterpret<f64>(0x3FD2BEF07CDC9000), reinterpret<f64>(0x3D2A9CFA4A5004F4),
-  reinterpret<f64>(0x3FE7C00000000000), 0, reinterpret<f64>(0x3FD314F1E1D36000), reinterpret<f64>(0xBD28E27AD3213CB8),
-  reinterpret<f64>(0x3FE7A00000000000), 0, reinterpret<f64>(0x3FD36B6776BE1000), reinterpret<f64>(0x3D116ECDB0F177C8),
-  reinterpret<f64>(0x3FE7800000000000), 0, reinterpret<f64>(0x3FD3C25277333000), reinterpret<f64>(0x3D183B54B606BD5C),
-  reinterpret<f64>(0x3FE7600000000000), 0, reinterpret<f64>(0x3FD419B423D5E800), reinterpret<f64>(0x3D08E436EC90E09D),
-  reinterpret<f64>(0x3FE7400000000000), 0, reinterpret<f64>(0x3FD4718DC271C800), reinterpret<f64>(0xBD2F27CE0967D675),
-  reinterpret<f64>(0x3FE7200000000000), 0, reinterpret<f64>(0x3FD4C9E09E173000), reinterpret<f64>(0xBD2E20891B0AD8A4),
-  reinterpret<f64>(0x3FE7000000000000), 0, reinterpret<f64>(0x3FD522AE0738A000), reinterpret<f64>(0x3D2EBE708164C759),
-  reinterpret<f64>(0x3FE6E00000000000), 0, reinterpret<f64>(0x3FD57BF753C8D000), reinterpret<f64>(0x3D1FADEDEE5D40EF),
-  reinterpret<f64>(0x3FE6C00000000000), 0, reinterpret<f64>(0x3FD5D5BDDF596000), reinterpret<f64>(0xBD0A0B2A08A465DC)
-]);
-
 // Returns 0 if not int, 1 if odd int, 2 if even int. The argument is
 // the bit representation of a non-zero finite floating-point value.
 // @ts-ignore: decorator
 @inline
-function checkint(iy: u64): i32 {
+function checkint64(iy: u64): i32 {
   var e = iy >> 52 & 0x7FF;
   if (e < 0x3FF     ) return 0;
   if (e > 0x3FF + 52) return 2;
@@ -1663,20 +3019,20 @@ function checkint(iy: u64): i32 {
 
 // @ts-ignore: decorator
 @inline
-function xflow(sign: u32, y: f64): f64 {
+function xflow64(sign: u32, y: f64): f64 {
   return select(-y, y, sign) * y;
 }
 
 // @ts-ignore: decorator
 @inline
-function uflow(sign: u32): f64 {
-  return xflow(sign, reinterpret<f64>(0x1000000000000000)); // 0x1p-767
+function uflow64(sign: u32): f64 {
+  return xflow64(sign, reinterpret<f64>(0x1000000000000000)); // 0x1p-767
 }
 
 // @ts-ignore: decorator
 @inline
-function oflow(sign: u32): f64 {
-  return xflow(sign, reinterpret<f64>(0x7000000000000000)); // 0x1p769
+function oflow64(sign: u32): f64 {
+  return xflow64(sign, reinterpret<f64>(0x7000000000000000)); // 0x1p769
 }
 
 // Returns 1 if input is the bit representation of 0, infinity or nan.
@@ -1694,8 +3050,8 @@ function zeroinfnan(u: u64): bool {
 // normalized in the subnormal range using the sign bit for the exponent.
 // @ts-ignore: decorator
 @inline
-function log_inline(ix: u64): f64 {
-  const N = 1 << POW_LOG_TABLE_BITS;
+function log64_inline(ix: u64): f64 {
+  const N = 1 << POW_LOG_TABLE64_BITS;
   const N_MASK = N - 1;
 
   const
@@ -1715,16 +3071,16 @@ function log_inline(ix: u64): f64 {
   // The range is split into N subintervals.
   // The ith subinterval contains z and c is near its center.
   var tmp = ix - 0x3fE6955500000000;
-  var i   = <usize>((tmp >> (52 - POW_LOG_TABLE_BITS)) & N_MASK);
+  var i   = <usize>((tmp >> (52 - POW_LOG_TABLE64_BITS)) & N_MASK);
   var k   = <i64>tmp >> 52;
   var iz  = ix - (tmp & u64(0xFFF) << 52);
   var z   = reinterpret<f64>(iz);
   var kd  = <f64>k;
 
   // log(x) = k*Ln2 + log(c) + log1p(z/c-1).
-  var invc     = load<f64>(POW_LOG_DATA_TAB + (i << (2 + alignof<f64>())), 0 << alignof<f64>()); // tab[i].invc
-  var logc     = load<f64>(POW_LOG_DATA_TAB + (i << (2 + alignof<f64>())), 2 << alignof<f64>()); // tab[i].logc
-  var logctail = load<f64>(POW_LOG_DATA_TAB + (i << (2 + alignof<f64>())), 3 << alignof<f64>()); // tab[i].logctail
+  var invc     = load<f64>(POW_LOG_TABLE64 + (i << (2 + alignof<f64>())), 0 << alignof<f64>()); // tab[i].invc
+  var logc     = load<f64>(POW_LOG_TABLE64 + (i << (2 + alignof<f64>())), 2 << alignof<f64>()); // tab[i].logc
+  var logctail = load<f64>(POW_LOG_TABLE64 + (i << (2 + alignof<f64>())), 3 << alignof<f64>()); // tab[i].logctail
 
   // Note: 1/c is j/N or j/N/2 where j is an integer in [N,2N) and
   // |z/c - 1| < 1/N, so r = z/c - 1 is exactly representible.
@@ -1762,14 +3118,14 @@ function log_inline(ix: u64): f64 {
 }
 
 // @ts-ignore: decorator
-@inline const SIGN_BIAS = 0x800 << EXP_TABLE_BITS;
+@inline const SIGN_BIAS = 0x800 << EXP_TABLE64_BITS;
 
 // Computes sign*exp(x+xtail) where |xtail| < 2^-8/N and |xtail| <= |x|.
 // The sign_bias argument is SIGN_BIAS or 0 and sets the sign to -1 or 1.
 // @ts-ignore: decorator
 @inline
-function exp_inline(x: f64, xtail: f64, sign_bias: u32): f64 {
-  const N      = 1 << EXP_TABLE_BITS;
+function exp64_inline(x: f64, xtail: f64, sign_bias: u32): f64 {
+  const N      = 1 << EXP_TABLE64_BITS;
   const N_MASK = N - 1;
 
   const
@@ -1796,11 +3152,11 @@ function exp_inline(x: f64, xtail: f64, sign_bias: u32): f64 {
     if (abstop - 0x3C9 >= 0x80000000) {
       // Avoid spurious underflow for tiny x.
       // Note: 0 is common input.
-      return select(-1.0, 1.0, sign_bias);
+      return select<f64>(-1.0, 1.0, sign_bias);
     }
     if (abstop >= 0x409) { // top12(1024.0)
       // Note: inf and nan are already handled.
-      return ux >> 63 ? uflow(sign_bias) : oflow(sign_bias);
+      return ux >> 63 ? uflow64(sign_bias) : oflow64(sign_bias);
     }
     // Large x is special cased below.
     abstop = 0;
@@ -1829,11 +3185,11 @@ function exp_inline(x: f64, xtail: f64, sign_bias: u32): f64 {
   r += xtail;
   // 2^(k/N) ~= scale * (1 + tail)
   idx = <usize>((ki & N_MASK) << 1);
-  top = (ki + sign_bias) << (52 - EXP_TABLE_BITS);
+  top = (ki + sign_bias) << (52 - EXP_TABLE64_BITS);
 
-  tail = reinterpret<f64>(load<u64>(EXP_DATA_TAB + (idx << alignof<u64>())));
+  tail = reinterpret<f64>(load<u64>(EXP_TABLE64 + (idx << alignof<u64>())));
   // This is only a valid scale when -1023*N < k < 1024*N
-  sbits = load<u64>(EXP_DATA_TAB + (idx << alignof<u64>()), 1 << alignof<u64>()) + top;
+  sbits = load<u64>(EXP_TABLE64 + (idx << alignof<u64>()), 1 << alignof<u64>()) + top;
   // exp(x) = 2^(k/N) * exp(r) ~= scale + scale * (tail + exp(r) - 1).
   // Evaluation is optimized assuming superscalar pipelined execution.
   r2 = r * r;
@@ -1849,7 +3205,7 @@ function exp_inline(x: f64, xtail: f64, sign_bias: u32): f64 {
 
 // @ts-ignore: decorator
 @inline
-export function pow_lut(x: f64, y: f64): f64 {
+function pow64_lut(x: f64, y: f64): f64 {
   const Ox1p52 = reinterpret<f64>(0x4330000000000000); // 0x1p52
 
   var sign_bias: u32 = 0;
@@ -1873,13 +3229,13 @@ export function pow_lut(x: f64, y: f64): f64 {
     }
     if (zeroinfnan(ix)) {
       let x2 = x * x;
-      if (i32(ix >> 63) && checkint(iy) == 1) x2 = -x2;
+      if (i32(ix >> 63) && checkint64(iy) == 1) x2 = -x2;
       return iy >> 63 ? 1 / x2 : x2;
     }
     // Here x and y are non-zero finite
     if (ix >> 63) {
       // Finite x < 0
-      let yint = checkint(iy);
+      let yint = checkint64(iy);
       if (yint == 0) return (x - x) / (x - x);
       if (yint == 1) sign_bias = SIGN_BIAS;
       ix   &= 0x7FFFFFFFFFFFFFFF;
@@ -1899,7 +3255,7 @@ export function pow_lut(x: f64, y: f64): f64 {
     }
   }
 
-  var hi = log_inline(ix);
+  var hi = log64_inline(ix);
   var lo = log_tail;
   var ehi: f64, elo: f64;
   // #if __FP_FAST_FMA
@@ -1913,5 +3269,1396 @@ export function pow_lut(x: f64, y: f64): f64 {
   ehi = yhi * lhi;
   elo = ylo * lhi + y * llo; // |elo| < |ehi| * 2^-25.
   // #endif
-  return exp_inline(ehi, elo, sign_bias);
+  return exp64_inline(ehi, elo, sign_bias);
+}
+
+export function pow32(x: f32, y: f32): f32 {
+  // TODO: remove this fast pathes after introduced own mid-end IR with "stdlib call simplify" transforms
+  if (abs<f32>(y) <= 2) {
+    if (y == 2.0) return x * x;
+    if (y == 0.5) {
+      return select<f32>(
+        abs<f32>(sqrt<f32>(x)),
+        Infinity,
+        x != -Infinity
+      );
+    }
+    if (y == -1.0) return 1 / x;
+    if (y == 1.0) return x;
+    if (y == 0.0) return 1.0;
+  }
+  if (ASC_SHRINK_LEVEL < 1) {
+    // see: musl/src/math/powf.c
+    return pow32_lut(x, y);
+  } else {
+    // based on:  jdh8/metallic/src/math/float/powf.c
+    if (y == 0) return 1;
+    // @ts-ignore: cast
+    if (isNaN(x) | isNaN(y)) {
+      return NaN;
+    }
+    let sign: u32 = 0;
+    let uy = reinterpret<u32>(y);
+    let ux = reinterpret<u32>(x);
+    let sx = ux >> 31;
+    ux &= 0x7FFFFFFF;
+    if (sx && nearest<f32>(y) == y) {
+      x = -x;
+      sx = 0;
+      sign = u32(nearest<f32>(y * 0.5) != y * 0.5) << 31;
+    }
+    let m: u32;
+    if (ux == 0x3F800000) { // x == 1
+      m = sx | u32((uy & 0x7FFFFFFF) == 0x7F800000) ? 0x7FC00000 : 0x3F800000;
+    } else if (ux == 0) {
+      m = uy >> 31 ? 0x7F800000 : 0;
+    } else if (ux == 0x7F800000) {
+      m = uy >> 31 ? 0 : 0x7F800000;
+    } else if (sx) {
+      m = 0x7FC00000;
+    } else {
+      m = reinterpret<u32>(<f32>exp2up32(<f64>y * log2up32(x)));
+    }
+    return reinterpret<f32>(m | sign);
+  }
+}
+
+export function pow64(x: f64, y: f64): f64 { // see: musl/src/math/pow.c and SUN COPYRIGHT NOTICE above
+  // TODO: remove this fast pathes after introduced own mid-end IR with "stdlib call simplify" transforms
+  if (abs<f64>(y) <= 2) {
+    if (y == 2.0) return x * x;
+    if (y == 0.5) {
+      return select<f64>(
+        abs<f64>(sqrt<f64>(x)),
+        Infinity,
+        x != -Infinity
+      );
+    }
+    if (y == -1.0) return 1 / x;
+    if (y == 1.0) return x;
+    if (y == 0.0) return 1.0;
+  }
+  if (ASC_SHRINK_LEVEL < 1) {
+    return pow64_lut(x, y);
+  } else {
+    const
+      dp_h1   = reinterpret<f64>(0x3FE2B80340000000), //  5.84962487220764160156e-01
+      dp_l1   = reinterpret<f64>(0x3E4CFDEB43CFD006), //  1.35003920212974897128e-08
+      two53   = reinterpret<f64>(0x4340000000000000), //  9007199254740992.0
+      huge    = reinterpret<f64>(0x7E37E43C8800759C), //  1e+300
+      tiny    = reinterpret<f64>(0x01A56E1FC2F8F359), //  1e-300
+      L1      = reinterpret<f64>(0x3FE3333333333303), //  5.99999999999994648725e-01
+      L2      = reinterpret<f64>(0x3FDB6DB6DB6FABFF), //  4.28571428578550184252e-01
+      L3      = reinterpret<f64>(0x3FD55555518F264D), //  3.33333329818377432918e-01
+      L4      = reinterpret<f64>(0x3FD17460A91D4101), //  2.72728123808534006489e-01
+      L5      = reinterpret<f64>(0x3FCD864A93C9DB65), //  2.30660745775561754067e-01
+      L6      = reinterpret<f64>(0x3FCA7E284A454EEF), //  2.06975017800338417784e-01
+      P1      = reinterpret<f64>(0x3FC555555555553E), //  1.66666666666666019037e-01
+      P2      = reinterpret<f64>(0xBF66C16C16BEBD93), // -2.77777777770155933842e-03
+      P3      = reinterpret<f64>(0x3F11566AAF25DE2C), //  6.61375632143793436117e-05
+      P4      = reinterpret<f64>(0xBEBBBD41C5D26BF1), // -1.65339022054652515390e-06
+      P5      = reinterpret<f64>(0x3E66376972BEA4D0), //  4.13813679705723846039e-08
+      lg2     = reinterpret<f64>(0x3FE62E42FEFA39EF), //  6.93147180559945286227e-01
+      lg2_h   = reinterpret<f64>(0x3FE62E4300000000), //  6.93147182464599609375e-01
+      lg2_l   = reinterpret<f64>(0xBE205C610CA86C39), // -1.90465429995776804525e-09
+      ovt     = reinterpret<f64>(0x3C971547652B82FE), //  8.0085662595372944372e-017
+      cp      = reinterpret<f64>(0x3FEEC709DC3A03FD), //  9.61796693925975554329e-01
+      cp_h    = reinterpret<f64>(0x3FEEC709E0000000), //  9.61796700954437255859e-01
+      cp_l    = reinterpret<f64>(0xBE3E2FE0145B01F5), // -7.02846165095275826516e-09
+      ivln2   = reinterpret<f64>(0x3FF71547652B82FE), //  1.44269504088896338700e+00
+      ivln2_h = reinterpret<f64>(0x3FF7154760000000), //  1.44269502162933349609e+00
+      ivln2_l = reinterpret<f64>(0x3E54AE0BF85DDF44), //  1.92596299112661746887e-08
+      inv3    = reinterpret<f64>(0x3FD5555555555555); //  0.3333333333333333333333
+
+    let u_ = reinterpret<u64>(x);
+    let hx = <i32>(u_ >> 32);
+    let lx = <u32>u_;
+    u_ = reinterpret<u64>(y);
+    let hy = <i32>(u_ >> 32);
+    let ly = <u32>u_;
+    let ix = hx & 0x7FFFFFFF;
+    let iy = hy & 0x7FFFFFFF;
+    if ((iy | ly) == 0) return 1.0; // x**0 = 1, even if x is NaN
+    // if (hx == 0x3FF00000 && lx == 0) return 1.0; // C: 1**y = 1, even if y is NaN, JS: NaN
+    if ( // NaN if either arg is NaN
+      ix > 0x7FF00000 || (ix == 0x7FF00000 && lx != 0) ||
+      iy > 0x7FF00000 || (iy == 0x7FF00000 && ly != 0)
+    ) return x + y;
+    let yisint = 0, k: i32;
+    if (hx < 0) {
+      if (iy >= 0x43400000) yisint = 2;
+      else if (iy >= 0x3FF00000) {
+        k = (iy >> 20) - 0x3FF;
+        let offset = select<u32>(52, 20, k > 20) - k;
+        let Ly = select<u32>(ly, iy, k > 20);
+        let jj = Ly >> offset;
+        if ((jj << offset) == Ly) yisint = 2 - (jj & 1);
+      }
+    }
+    if (ly == 0) {
+      if (iy == 0x7FF00000) { // y is +-inf
+        if (((ix - 0x3FF00000) | lx) == 0) return NaN; // C: (-1)**+-inf is 1, JS: NaN
+        else if (ix >= 0x3FF00000) return hy >= 0 ? y : 0.0; // (|x|>1)**+-inf = inf,0
+        else return hy >= 0 ? 0.0 : -y; // (|x|<1)**+-inf = 0,inf
+      }
+      if (iy == 0x3FF00000) {
+        if (hy >= 0) return x;
+        return 1 / x;
+      }
+      if (hy == 0x40000000) return x * x;
+      if (hy == 0x3FE00000) {
+        if (hx >= 0) return sqrt<f64>(x);
+      }
+    }
+    let ax = abs<f64>(x), z: f64;
+    if (lx == 0) {
+      if (ix == 0 || ix == 0x7FF00000 || ix == 0x3FF00000) {
+        z = ax;
+        if (hy < 0) z = 1.0 / z;
+        if (hx < 0) {
+          if (((ix - 0x3FF00000) | yisint) == 0) {
+            let d = z - z;
+            z = d / d;
+          } else if (yisint == 1) z = -z;
+        }
+        return z;
+      }
+    }
+    let s = 1.0;
+    if (hx < 0) {
+      if (yisint == 0) {
+        let d = x - x;
+        return d / d;
+      }
+      if (yisint == 1) s = -1.0;
+    }
+    let t1: f64, t2: f64, p_h: f64, p_l: f64, r: f64, t: f64, u: f64, v: f64, w: f64;
+    let j: i32, n: i32;
+    if (iy > 0x41E00000) {
+      if (iy > 0x43F00000) {
+        if (ix <= 0x3FEFFFFF) return hy < 0 ? huge * huge : tiny * tiny;
+        if (ix >= 0x3FF00000) return hy > 0 ? huge * huge : tiny * tiny;
+      }
+      if (ix < 0x3FEFFFFF) return hy < 0 ? s * huge * huge : s * tiny * tiny;
+      if (ix > 0x3FF00000) return hy > 0 ? s * huge * huge : s * tiny * tiny;
+      t = ax - 1.0;
+      w = (t * t) * (0.5 - t * (inv3 - t * 0.25));
+      u = ivln2_h * t;
+      v = t * ivln2_l - w * ivln2;
+      t1 = u + v;
+      t1 = reinterpret<f64>(reinterpret<u64>(t1) & 0xFFFFFFFF00000000);
+      t2 = v - (t1 - u);
+    } else {
+      let ss: f64, s2: f64, s_h: f64, s_l: f64, t_h: f64, t_l: f64;
+      n = 0;
+      if (ix < 0x00100000) {
+        ax *= two53;
+        n -= 53;
+        ix = <u32>(reinterpret<u64>(ax) >> 32);
+      }
+      n += (ix >> 20) - 0x3FF;
+      j = ix & 0x000FFFFF;
+      ix = j | 0x3FF00000;
+      if (j <= 0x3988E) k = 0;
+      else if (j < 0xBB67A) k = 1;
+      else {
+        k = 0;
+        n += 1;
+        ix -= 0x00100000;
+      }
+      ax = reinterpret<f64>(reinterpret<u64>(ax) & 0xFFFFFFFF | (<u64>ix << 32));
+      let bp = select<f64>(1.5, 1.0, k); // k ? 1.5 : 1.0
+      u = ax - bp;
+      v = 1.0 / (ax + bp);
+      ss = u * v;
+      s_h = ss;
+      s_h = reinterpret<f64>(reinterpret<u64>(s_h) & 0xFFFFFFFF00000000);
+      t_h = reinterpret<f64>(<u64>(((ix >> 1) | 0x20000000) + 0x00080000 + (k << 18)) << 32);
+      t_l = ax - (t_h - bp);
+      s_l = v * ((u - s_h * t_h) - s_h * t_l);
+      s2 = ss * ss;
+      r = s2 * s2 * (L1 + s2 * (L2 + s2 * (L3 + s2 * (L4 + s2 * (L5 + s2 * L6)))));
+      r += s_l * (s_h + ss);
+      s2 = s_h * s_h;
+      t_h = 3.0 + s2 + r;
+      t_h = reinterpret<f64>(reinterpret<u64>(t_h) & 0xFFFFFFFF00000000);
+      t_l = r - ((t_h - 3.0) - s2);
+      u = s_h * t_h;
+      v = s_l * t_h + t_l * ss;
+      p_h = u + v;
+      p_h = reinterpret<f64>(reinterpret<u64>(p_h) & 0xFFFFFFFF00000000);
+      p_l = v - (p_h - u);
+      let z_h = cp_h * p_h;
+      let dp_l = select<f64>(dp_l1, 0.0, k);
+      let z_l = cp_l * p_h + p_l * cp + dp_l;
+      t = <f64>n;
+      let dp_h = select<f64>(dp_h1, 0.0, k);
+      t1 = ((z_h + z_l) + dp_h) + t;
+      t1 = reinterpret<f64>(reinterpret<u64>(t1) & 0xFFFFFFFF00000000);
+      t2 = z_l - (((t1 - t) - dp_h) - z_h);
+    }
+    let y1 = y;
+    y1 = reinterpret<f64>(reinterpret<u64>(y1) & 0xFFFFFFFF00000000);
+    p_l = (y - y1) * t1 + y * t2;
+    p_h = y1 * t1;
+    z = p_l + p_h;
+    u_ = reinterpret<u64>(z);
+    j = <u32>(u_ >> 32);
+    let i = <i32>u_;
+    if (j >= 0x40900000) {
+      if (((j - 0x40900000) | i) != 0) return s * huge * huge;
+      if (p_l + ovt > z - p_h) return s * huge * huge;
+    } else if ((j & 0x7FFFFFFF) >= 0x4090CC00) {
+      if (((j - 0xC090CC00) | i) != 0) return s * tiny * tiny;
+      if (p_l <= z - p_h) return s * tiny * tiny;
+    }
+    i = j & 0x7FFFFFFF;
+    k = (i >> 20) - 0x3FF;
+    n = 0;
+    if (i > 0x3FE00000) {
+      n = j + (0x00100000 >> (k + 1));
+      k = ((n & 0x7FFFFFFF) >> 20) - 0x3FF;
+      t = 0.0;
+      t = reinterpret<f64>(<u64>(n & ~(0x000FFFFF >> k)) << 32);
+      n = ((n & 0x000FFFFF) | 0x00100000) >> (20 - k);
+      if (j < 0) n = -n;
+      p_h -= t;
+    }
+    t = p_l + p_h;
+    t = reinterpret<f64>(reinterpret<u64>(t) & 0xFFFFFFFF00000000);
+    u = t * lg2_h;
+    v = (p_l - (t - p_h)) * lg2 + t * lg2_l;
+    z = u + v;
+    w = v - (z - u);
+    t = z * z;
+    t1 = z - t * (P1 + t * (P2 + t * (P3 + t * (P4 + t * P5))));
+    r = (z * t1) / (t1 - 2.0) - (w + z * w);
+    z = 1.0 - (r - z);
+    j = <u32>(reinterpret<u64>(z) >> 32);
+    j += n << 20;
+    if ((j >> 20) <= 0) z = scalbn64(z, n);
+    else z = reinterpret<f64>(reinterpret<u64>(z) & 0xFFFFFFFF | (<u64>j << 32));
+    return s * z;
+  }
+}
+
+export function sin32(x: f32): f32 { // see: musl/src/math/sinf.c
+  const
+    s1pio2 = reinterpret<f64>(0x3FF921FB54442D18), // M_PI_2 * 1
+    s2pio2 = reinterpret<f64>(0x400921FB54442D18), // M_PI_2 * 2
+    s3pio2 = reinterpret<f64>(0x4012D97C7F3321D2), // M_PI_2 * 3
+    s4pio2 = reinterpret<f64>(0x401921FB54442D18); // M_PI_2 * 4
+
+  var ix = reinterpret<u32>(x);
+  var sign = ix >> 31;
+  ix &= 0x7FFFFFFF;
+
+  if (ix <= 0x3F490FDA) {  // |x| ~<= π/4
+    if (ix < 0x39800000) { // |x| < 2**-12
+      return x;
+    }
+    return sin32_kern(x);
+  }
+
+  if (ASC_SHRINK_LEVEL < 1) {
+    if (ix <= 0x407B53D1) {   // |x| ~<= 5π/4
+      if (ix <= 0x4016CBE3) { // |x| ~<= 3π/4
+        return sign ? -cos32_kern(x + s1pio2) : cos32_kern(x - s1pio2);
+      }
+      return sin32_kern(-(sign ? x + s2pio2 : x - s2pio2));
+    }
+
+    if (ix <= 0x40E231D5) {   // |x| ~<= 9π/4
+      if (ix <= 0x40AFEDDF) { // |x| ~<= 7π/4
+        return sign ? cos32_kern(x + s3pio2) : -cos32_kern(x - s3pio2);
+      }
+      return sin32_kern(sign ? x + s4pio2 : x - s4pio2);
+    }
+  }
+
+  // sin(Inf or NaN) is NaN
+  if (ix >= 0x7F800000) return x - x;
+
+  var n = rempio2_32(x, ix, sign);
+  var y = rempio2_32_y;
+
+  var t = n & 1 ? cos32_kern(y) : sin32_kern(y);
+  return n & 2 ? -t : t;
+}
+
+export function sin64(x: f64): f64 { // see: musl/src/math/sin.c
+  var u  = reinterpret<u64>(x);
+  var ix = <u32>(u >> 32);
+  var sign = ix >> 31;
+
+  ix &= 0x7FFFFFFF;
+
+  // |x| ~< pi/4
+  if (ix <= 0x3FE921FB) {
+    if (ix < 0x3E500000) { // |x| < 2**-26
+      return x;
+    }
+    return sin64_kern(x, 0.0, 0);
+  }
+
+  // sin(Inf or NaN) is NaN
+  if (ix >= 0x7FF00000) return x - x;
+
+  // argument reduction needed
+  var n  = rempio2_64(x, u, sign);
+  var y0 = rempio2_y0;
+  var y1 = rempio2_y1;
+
+  x = n & 1 ? cos64_kern(y0, y1) : sin64_kern(y0, y1, 1);
+  return n & 2 ? -x : x;
+}
+
+export function sinh32(x: f32): f32 { // see: musl/src/math/sinhf.c
+  var u = reinterpret<u32>(x) & 0x7FFFFFFF;
+  var a = reinterpret<f32>(u);
+  var h = copysign<f32>(0.5, x);
+  if (u < 0x42B17217) {
+    let t = expm1_32(a);
+    if (u < 0x3F800000) {
+      if (u < 0x3F800000 - (12 << 23)) return x;
+      return h * (2 * t - t * t / (t + 1));
+    }
+    return h * (t + t / (t + 1));
+  }
+  return expo2_32(a, 2 * h);
+}
+
+export function sinh64(x: f64): f64 { // see: musl/src/math/sinh.c
+  var u = reinterpret<u64>(x) & 0x7FFFFFFFFFFFFFFF;
+  var a = reinterpret<f64>(u);
+  var w = <u32>(u >> 32);
+  var h = copysign<f64>(0.5, x);
+  if (w < 0x40862E42) {
+    let t = expm1_64(a);
+    if (w < 0x3FF00000) {
+      if (w < 0x3FF00000 - (26 << 20)) return x;
+      return h * (2 * t - t * t / (t + 1));
+    }
+    return h * (t + t / (t + 1));
+  }
+  return expo2_64(a, 2 * h);
+}
+
+export function tan32(x: f32): f32 { // see: musl/src/math/tanf.c
+  const
+    t1pio2 = reinterpret<f64>(0x3FF921FB54442D18), // 1 * M_PI_2
+    t2pio2 = reinterpret<f64>(0x400921FB54442D18), // 2 * M_PI_2
+    t3pio2 = reinterpret<f64>(0x4012D97C7F3321D2), // 3 * M_PI_2
+    t4pio2 = reinterpret<f64>(0x401921FB54442D18); // 4 * M_PI_2
+
+  var ix = reinterpret<u32>(x);
+  var sign = ix >> 31;
+  ix &= 0x7FFFFFFF;
+
+  if (ix <= 0x3F490FDA) {  // |x| ~<= π/4
+    if (ix < 0x39800000) { // |x| < 2**-12
+      return x;
+    }
+    return tan32_kern(x, 0);
+  }
+
+  if (ASC_SHRINK_LEVEL < 1) {
+    if (ix <= 0x407B53D1) {   // |x| ~<= 5π/4
+      if (ix <= 0x4016CBE3) { // |x| ~<= 3π/4
+        return tan32_kern((sign ? x + t1pio2 : x - t1pio2), 1);
+      } else {
+        return tan32_kern((sign ? x + t2pio2 : x - t2pio2), 0);
+      }
+    }
+    if (ix <= 0x40E231D5) {   // |x| ~<= 9π/4
+      if (ix <= 0x40AFEDDF) { // |x| ~<= 7π/4
+        return tan32_kern((sign ? x + t3pio2 : x - t3pio2), 1);
+      } else {
+        return tan32_kern((sign ? x + t4pio2 : x - t4pio2), 0);
+      }
+    }
+  }
+
+  // tan(Inf or NaN) is NaN
+  if (ix >= 0x7F800000) return x - x;
+
+  // argument reduction
+  var n = rempio2_32(x, ix, sign);
+  var y = rempio2_32_y;
+  return tan32_kern(y, n & 1);
+}
+
+export function tan64(x: f64): f64 { // see: musl/src/math/tan.c
+  var u = reinterpret<u64>(x);
+  var ix = <i32>(u >> 32);
+  var sign = ix >>> 31;
+
+  ix &= 0x7FFFFFFF;
+
+  // |x| ~< pi/4
+  if (ix <= 0x3FE921FB) {
+    if (ix < 0x3E400000) { // |x| < 2**-27
+      return x;
+    }
+    return tan64_kern(x, 0.0, 1);
+  }
+
+  // tan(Inf or NaN) is NaN
+  if (ix >= 0x7FF00000) return x - x;
+
+  var n = rempio2_64(x, u, sign);
+  return tan64_kern(rempio2_y0, rempio2_y1, 1 - ((n & 1) << 1));
+}
+
+export function tanh32(x: f32): f32 { // see: musl/src/math/tanhf.c
+  var u = reinterpret<u32>(x);
+  u &= 0x7FFFFFFF;
+  var y = reinterpret<f32>(u);
+  var t: f32;
+  if (u > 0x3F0C9F54) {
+    if (u > 0x41200000) t = 1 + 0 / y;
+    else {
+      t = expm1_32(2 * y);
+      t = 1 - 2 / (t + 2);
+    }
+  } else if (u > 0x3E82C578) {
+    t = expm1_32(2 * y);
+    t = t / (t + 2);
+  } else if (u >= 0x00800000) {
+    t = expm1_32(-2 * y);
+    t = -t / (t + 2);
+  } else t = y;
+  return copysign<f32>(t, x);
+}
+
+export function tanh64(x: f64): f64 { // see: musl/src/math/tanh.c
+  var u = reinterpret<u64>(x);
+  u &= 0x7FFFFFFFFFFFFFFF;
+  var y = reinterpret<f64>(u);
+  var w = <u32>(u >> 32);
+  var t: f64;
+  if (w > 0x3FE193EA) {
+    if (w > 0x40340000) {
+      t = 1 - 0 / y;
+    } else {
+      t = expm1_64(2 * y);
+      t = 1 - 2 / (t + 2);
+    }
+  } else if (w > 0x3FD058AE) {
+    t = expm1_64(2 * y);
+    t = t / (t + 2);
+  } else if (w >= 0x00100000) {
+    t = expm1_64(-2 * y);
+    t = -t / (t + 2);
+  } else t = y;
+  return copysign<f64>(t, x);
+}
+
+export function sincos32(x: f32): f32 { // see: musl/tree/src/math/sincosf.c
+  const
+    s1pio2 = reinterpret<f64>(0x3FF921FB54442D18), // 1 * M_PI_2
+    s2pio2 = reinterpret<f64>(0x400921FB54442D18), // 2 * M_PI_2
+    s3pio2 = reinterpret<f64>(0x4012D97C7F3321D2), // 3 * M_PI_2
+    s4pio2 = reinterpret<f64>(0x401921FB54442D18); // 4 * M_PI_2
+
+  var ix = reinterpret<u32>(x);
+  var sign = ix >> 31;
+  ix &= 0x7FFFFFFF;
+
+  if (ix <= 0x3F490FDA) {  // |x| ~<= π/4
+    if (ix < 0x39800000) { // |x| < 2**-12
+      sincos_cos32 = 1;
+      return x;
+    }
+    sincos_cos32 = cos32_kern(x);
+    return sin32_kern(x);
+  }
+  if (ASC_SHRINK_LEVEL < 1) {
+    if (ix <= 0x407B53D1) {   // |x| ~<= 5π/4
+      if (ix <= 0x4016CBE3) { // |x| ~<= 3π/4
+        if (sign) {
+          sincos_cos32 = sin32_kern(x + s1pio2);
+          return -cos32_kern(x + s1pio2)
+        } else {
+          sincos_cos32 = sin32_kern(s1pio2 - x);
+          return cos32_kern(s1pio2 - x);
+        }
+      }
+      // -sin(x + c) is not correct if x+c could be 0: -0 vs +0
+      sincos_cos32 = -cos32_kern(sign ? x + s2pio2 : x - s2pio2);
+      return -sin32_kern(sign ? x + s2pio2 : x - s2pio2)
+    }
+    if (ix <= 0x40E231D5) {   // |x| ~<= 9π/4
+      if (ix <= 0x40AFEDDF) { // |x| ~<= 7π/4
+        if (sign) {
+          sincos_cos32 = -sin32_kern(x + s3pio2);
+          return cos32_kern(x + s3pio2);
+        } else {
+          sincos_cos32 = sin32_kern(x - s3pio2);
+          return -cos32_kern(x - s3pio2);
+        }
+      }
+      sincos_cos32 = cos32_kern(sign ? x + s4pio2 : x - s4pio2);
+      return sin32_kern(sign ? x + s4pio2 : x - s4pio2);
+    }
+  }
+  // sin(Inf or NaN) is NaN
+  if (ix >= 0x7F800000) {
+    let xx = x - x;
+    sincos_cos32 = xx;
+    return xx;
+  }
+  // general argument reduction needed
+  var n = rempio2_32(x, ix, sign);
+  var y = rempio2_32_y;
+  var s = sin32_kern(y);
+  var c = cos32_kern(y);
+  var sin = s, cos = c;
+  if (n & 1) {
+    sin =  c;
+    cos = -s;
+  }
+  if (n & 2) {
+    sin = -sin;
+    cos = -cos;
+  }
+  sincos_cos32 = cos;
+  return sin;
+}
+
+export function sincos64(x: f64): f64 { // see: musl/tree/src/math/sincos.c
+  var u = reinterpret<u64>(x);
+  var ix = <u32>(u >> 32);
+  var sign = ix >> 31;
+  ix &= 0x7FFFFFFF;
+
+  if (ix <= 0x3FE921FB) {  // |x| ~<= π/4
+    if (ix < 0x3E46A09E) { // if |x| < 2**-27 * sqrt(2)
+      sincos_cos64 = 1;
+      return x; // sin
+    }
+    sincos_cos64 = cos64_kern(x, 0);
+    return sin64_kern(x, 0, 0);
+  }
+  // sin(Inf or NaN) is NaN
+  if (ix >= 0x7F800000) {
+    let xx = x - x;
+    sincos_cos64 = xx;
+    return xx;
+  }
+  // general argument reduction needed
+  var n = rempio2_64(x, u, sign);
+  var y0 = rempio2_y0;
+  var y1 = rempio2_y1;
+  var s = sin64_kern(y0, y1, 1);
+  var c = cos64_kern(y0, y1);
+  var sin = s, cos = c;
+  if (n & 1) {
+    sin =  c;
+    cos = -s;
+  }
+  if (n & 2) {
+    sin = -sin;
+    cos = -cos;
+  }
+  sincos_cos64 = cos;
+  return sin;
+}
+
+export function scalbn32(x: f32, n: i32): f32 { // see: https://git.musl-libc.org/cgit/musl/tree/src/math/scalbnf.c
+  const
+    Ox1p24f   = reinterpret<f32>(0x4B800000),
+    Ox1p127f  = reinterpret<f32>(0x7F000000),
+    Ox1p_126f = reinterpret<f32>(0x00800000);
+
+  var y = x;
+  if (n > 127) {
+    y *= Ox1p127f;
+    n -= 127;
+    if (n > 127) {
+      y *= Ox1p127f;
+      n = min<i32>(n - 127, 127);
+    }
+  } else if (n < -126) {
+    y *= Ox1p_126f * Ox1p24f;
+    n += 126 - 24;
+    if (n < -126) {
+      y *= Ox1p_126f * Ox1p24f;
+      n = max<i32>(n + 126 - 24, -126);
+    }
+  }
+  return y * reinterpret<f32>(<u32>(0x7F + n) << 23);
+}
+
+export function scalbn64(x: f64, n: i32): f64 { // see: https://git.musl-libc.org/cgit/musl/tree/src/math/scalbn.c
+  const
+    Ox1p53    = reinterpret<f64>(0x4340000000000000),
+    Ox1p1023  = reinterpret<f64>(0x7FE0000000000000),
+    Ox1p_1022 = reinterpret<f64>(0x0010000000000000);
+
+  var y = x;
+  if (n > 1023) {
+    y *= Ox1p1023;
+    n -= 1023;
+    if (n > 1023) {
+      y *= Ox1p1023;
+      n = min<i32>(n - 1023, 1023);
+    }
+  } else if (n < -1022) {
+    // make sure final n < -53 to avoid double
+    // rounding in the subnormal range
+    y *= Ox1p_1022 * Ox1p53;
+    n += 1022 - 53;
+    if (n < -1022) {
+      y *= Ox1p_1022 * Ox1p53;
+      n = max<i32>(n + 1022 - 53, -1022);
+    }
+  }
+  return y * reinterpret<f64>(<u64>(0x3FF + n) << 52);
+}
+
+export function exp32(x: f32): f32 { // see: musl/src/math/expf.c and SUN COPYRIGHT NOTICE above
+  if (ASC_SHRINK_LEVEL < 1) {
+    return exp32_lut(x);
+  } else {
+    const
+      ln2hi    = reinterpret<f32>(0x3F317200), //  6.9314575195e-1f
+      ln2lo    = reinterpret<f32>(0x35BFBE8E), //  1.4286067653e-6f
+      invln2   = reinterpret<f32>(0x3FB8AA3B), //  1.4426950216e+0f
+      P1       = reinterpret<f32>(0x3E2AAA8F), //  1.6666625440e-1f
+      P2       = reinterpret<f32>(0xBB355215), // -2.7667332906e-3f
+      Ox1p127f = reinterpret<f32>(0x7F000000); //  0x1p+127f
+
+    let hx = reinterpret<u32>(x);
+    let sign_ = <i32>(hx >> 31);
+    hx &= 0x7FFFFFFF;
+    if (hx >= 0x42AEAC50) {
+      if (hx > 0x7F800000) return x; // NaN
+      if (hx >= 0x42B17218) {
+        if (!sign_) return x * Ox1p127f;
+        else if (hx >= 0x42CFF1B5) return 0;
+      }
+    }
+    let hi: f32, lo: f32;
+    let k: i32;
+    if (hx > 0x3EB17218) {
+      if (hx > 0x3F851592) {
+        k = <i32>(invln2 * x + copysign<f32>(0.5, x));
+      } else {
+        k = 1 - (sign_ << 1);
+      }
+      hi = x - <f32>k * ln2hi;
+      lo = <f32>k * ln2lo;
+      x = hi - lo;
+    } else if (hx > 0x39000000) {
+      k = 0;
+      hi = x;
+      lo = 0;
+    } else {
+      return 1 + x;
+    }
+    let xx = x * x;
+    let c = x - xx * (P1 + xx * P2);
+    let y: f32 = 1 + (x * c / (2 - c) - lo + hi);
+    return k == 0 ? y : scalbn32(y, k);
+  }
+}
+
+export function exp64(x: f64): f64 { // see: musl/src/math/exp.c and SUN COPYRIGHT NOTICE above
+  if (ASC_SHRINK_LEVEL < 1) {
+    return exp_lut(x);
+  } else {
+    const
+      ln2hi     = reinterpret<f64>(0x3FE62E42FEE00000), //  6.93147180369123816490e-01
+      ln2lo     = reinterpret<f64>(0x3DEA39EF35793C76), //  1.90821492927058770002e-10
+      invln2    = reinterpret<f64>(0x3FF71547652B82FE), //  1.44269504088896338700e+00
+      P1        = reinterpret<f64>(0x3FC555555555553E), //  1.66666666666666019037e-01
+      P2        = reinterpret<f64>(0xBF66C16C16BEBD93), // -2.77777777770155933842e-03
+      P3        = reinterpret<f64>(0x3F11566AAF25DE2C), //  6.61375632143793436117e-05
+      P4        = reinterpret<f64>(0xBEBBBD41C5D26BF1), // -1.65339022054652515390e-06
+      P5        = reinterpret<f64>(0x3E66376972BEA4D0), //  4.13813679705723846039e-08
+      overflow  = reinterpret<f64>(0x40862E42FEFA39EF), //  709.782712893383973096
+      underflow = reinterpret<f64>(0xC0874910D52D3051), // -745.13321910194110842
+      Ox1p1023  = reinterpret<f64>(0x7FE0000000000000); //  0x1p1023
+
+    let hx = <u32>(reinterpret<u64>(x) >> 32);
+    let sign_ = <i32>(hx >> 31);
+    hx &= 0x7FFFFFFF;
+    if (hx >= 0x4086232B) {
+      if (isNaN(x)) return x;
+      if (x > overflow)  return x * Ox1p1023;
+      if (x < underflow) return 0;
+    }
+    let hi: f64, lo: f64 = 0;
+    let k = 0;
+    if (hx > 0x3FD62E42) {
+      if (hx >= 0x3FF0A2B2) {
+        k = <i32>(invln2 * x + copysign<f64>(0.5, x));
+      } else {
+        k = 1 - (sign_ << 1);
+      }
+      hi = x - k * ln2hi;
+      lo = k * ln2lo;
+      x = hi - lo;
+    } else if (hx > 0x3E300000) {
+      hi = x;
+    } else return 1.0 + x;
+    let xs = x * x;
+    // var c = x - xp2 * (P1 + xp2 * (P2 + xp2 * (P3 + xp2 * (P4 + xp2 * P5))));
+    let xq = xs * xs;
+    let c = x - (xs * P1 + xq * ((P2 + xs * P3) + xq * (P4 + xs * P5)));
+    let y = 1.0 + (x * c / (2 - c) - lo + hi);
+    return k == 0 ? y : scalbn64(y, k);
+  }
+}
+
+export function expm1_32(x: f32): f32 { // see: musl/src/math/expm1f.c and SUN COPYRIGHT NOTICE above
+  const
+    ln2_hi   = reinterpret<f32>(0x3F317180), //  6.9313812256e-01f
+    ln2_lo   = reinterpret<f32>(0x3717F7D1), //  9.0580006145e-06f
+    invln2   = reinterpret<f32>(0x3FB8AA3B), //  1.4426950216e+00f
+    Q1       = reinterpret<f32>(0xBD088868), // -3.3333212137e-02f
+    Q2       = reinterpret<f32>(0x3ACF3010), //  1.5807170421e-03f
+    Ox1p127f = reinterpret<f32>(0x7F000000); //  0x1p+127f
+
+  var u = reinterpret<u32>(x);
+  var hx = u & 0x7FFFFFFF;
+  var sign_ = <i32>(u >> 31);
+  if (hx >= 0x4195B844) {
+    if (hx > 0x7F800000) return x;
+    if (sign_) return -1;
+    if (hx > 0x42B17217) { // x > log(FLT_MAX)
+      x *= Ox1p127f;
+      return x;
+    }
+  }
+  var c: f32 = 0.0, t: f32, k: i32;
+  if (hx > 0x3EB17218) {
+    k = select<i32>(
+      1 - (sign_ << 1),
+      <i32>(invln2 * x + copysign<f32>(0.5, x)),
+      hx < 0x3F851592
+    );
+    t = <f32>k;
+    let hi = x - t * ln2_hi;
+    let lo = t * ln2_lo;
+    x = hi - lo;
+    c = (hi - x) - lo;
+  } else if (hx < 0x33000000) {
+    return x;
+  } else k = 0;
+  var hfx: f32 = 0.5 * x;
+  var hxs: f32 = x * hfx;
+  var r1: f32 = 1.0 + hxs * (Q1 + hxs * Q2);
+  t  = 3.0 - r1 * hfx;
+  var e = hxs * ((r1 - t) / (6.0 - x * t));
+  if (k == 0) return x - (x * e - hxs);
+  e  = x * (e - c) - c;
+  e -= hxs;
+  if (k == -1) return 0.5 * (x - e) - 0.5;
+  if (k == 1) {
+    if (x < -0.25) return -2.0 * (e - (x + 0.5));
+    return 1.0 + 2.0 * (x - e);
+  }
+  u = (0x7F + k) << 23;
+  var twopk = reinterpret<f32>(u);
+  var y: f32;
+  if (k < 0 || k > 56) {
+    y = x - e + 1.0;
+    if (k == 128) y = y * 2.0 * Ox1p127f;
+    else y = y * twopk;
+    return y - 1.0;
+  }
+  u = (0x7F - k) << 23;
+  y = reinterpret<f32>(u);
+  if (k < 20) y = (1 - y) - e;
+  else y = 1 - (e + y);
+  return (x + y) * twopk;
+}
+
+export function expm1_64(x: f64): f64 { // see: musl/src/math/expm1.c and SUN COPYRIGHT NOTICE above
+  const
+    o_threshold = reinterpret<f64>(0x40862E42FEFA39EF), //  7.09782712893383973096e+02
+    ln2_hi      = reinterpret<f64>(0x3FE62E42FEE00000), //  6.93147180369123816490e-01
+    ln2_lo      = reinterpret<f64>(0x3DEA39EF35793C76), //  1.90821492927058770002e-10
+    invln2      = reinterpret<f64>(0x3FF71547652B82FE), //  1.44269504088896338700e+00
+    Q1          = reinterpret<f64>(0xBFA11111111110F4), // -3.33333333333331316428e-02
+    Q2          = reinterpret<f64>(0x3F5A01A019FE5585), //  1.58730158725481460165e-03
+    Q3          = reinterpret<f64>(0xBF14CE199EAADBB7), // -7.93650757867487942473e-05
+    Q4          = reinterpret<f64>(0x3ED0CFCA86E65239), //  4.00821782732936239552e-06
+    Q5          = reinterpret<f64>(0xBE8AFDB76E09C32D), // -2.01099218183624371326e-07
+    Ox1p1023    = reinterpret<f64>(0x7FE0000000000000); //  0x1p1023
+
+  var u = reinterpret<u64>(x);
+  var hx = <u32>(u >> 32 & 0x7FFFFFFF);
+  var k = 0, sign_ = <i32>(u >> 63);
+  if (hx >= 0x4043687A) {
+    if (isNaN(x)) return x;
+    if (sign_) return -1;
+    if (x > o_threshold) return x * Ox1p1023;
+  }
+  var c = 0.0, t: f64;
+  if (hx > 0x3FD62E42) {
+    k = select<i32>(
+      1 - (sign_ << 1),
+      <i32>(invln2 * x + copysign<f64>(0.5, x)),
+      hx < 0x3FF0A2B2
+    );
+    t = <f64>k;
+    let hi = x - t * ln2_hi;
+    let lo = t * ln2_lo;
+    x = hi - lo;
+    c = (hi - x) - lo;
+  } else if (hx < 0x3C900000) return x;
+  var hfx = 0.5 * x;
+  var hxs = x * hfx;
+  // var r1 = 1.0 + hxs * (Q1 + hxs * (Q2 + hxs * (Q3 + hxs * (Q4 + hxs * Q5))));
+  var hxq = hxs * hxs;
+  var r1 = (1.0 + hxs * Q1) + hxq * ((Q2 + hxs * Q3) + hxq * (Q4 + hxs * Q5));
+  t = 3.0 - r1 * hfx;
+  var e = hxs * ((r1 - t) / (6.0 - x * t));
+  if (k == 0) return x - (x * e - hxs);
+  e = x * (e - c) - c;
+  e -= hxs;
+  if (k == -1) return 0.5 * (x - e) - 0.5;
+  if (k == 1) {
+    if (x < -0.25) return -2.0 * (e - (x + 0.5));
+    return 1.0 + 2.0 * (x - e);
+  }
+  u = (0x3FF + k) << 52;
+  var twopk = reinterpret<f64>(u);
+  var y: f64;
+  if (k < 0 || k > 56) {
+    y = x - e + 1.0;
+    if (k == 1024) y = y * 2.0 * Ox1p1023;
+    else y = y * twopk;
+    return y - 1.0;
+  }
+  u = (0x3FF - k) << 52;
+  y = reinterpret<f64>(u);
+  if (k < 20) y = (1 - y) - e;
+  else y = 1 - (e + y);
+  return (x + y) * twopk;
+}
+
+export function log32(x: f32): f32 { // see: musl/src/math/logf.c and SUN COPYRIGHT NOTICE above
+  if (ASC_SHRINK_LEVEL < 1) {
+    return logf_lut(x);
+  } else {
+    const
+      ln2_hi  = reinterpret<f32>(0x3F317180), // 6.9313812256e-01f
+      ln2_lo  = reinterpret<f32>(0x3717F7D1), // 9.0580006145e-06f
+      Lg1     = reinterpret<f32>(0x3F2AAAAA), // 0xaaaaaa.0p-24f
+      Lg2     = reinterpret<f32>(0x3ECCCE13), // 0xccce13.0p-25f
+      Lg3     = reinterpret<f32>(0x3E91E9EE), // 0x91e9ee.0p-25f
+      Lg4     = reinterpret<f32>(0x3E789E26), // 0xf89e26.0p-26f
+      Ox1p25f = reinterpret<f32>(0x4C000000);
+
+    let u = reinterpret<u32>(x);
+    let k = 0;
+    if (u < 0x00800000 || <bool>(u >> 31)) {
+      if (u << 1 == 0) return -1 / (x * x);
+      if (u >> 31) return (x - x) / 0;
+      k -= 25;
+      x *= Ox1p25f;
+      u = reinterpret<u32>(x);
+    } else if (u >= 0x7F800000) {
+      return x;
+    } else if (u == 0x3F800000) {
+      return 0;
+    }
+    u += 0x3F800000 - 0x3F3504F3;
+    k += <u32>(<i32>u >> 23) - 0x7F;
+    u = (u & 0x007FFFFF) + 0x3F3504F3;
+    x = reinterpret<f32>(u);
+    let f = x - 1.0;
+    let s = f / (2.0 + f);
+    let z = s * s;
+    let w = z * z;
+    let t1 = w * (Lg2 + w * Lg4);
+    let t2 = z * (Lg1 + w * Lg3);
+    let r = t2 + t1;
+    let hfsq = <f32>0.5 * f * f;
+    let dk = <f32>k;
+    return s * (hfsq + r) + dk * ln2_lo - hfsq + f + dk * ln2_hi;
+  }
+}
+
+export function log64(x: f64): f64 { // see: musl/src/math/log.c and SUN COPYRIGHT NOTICE above
+  if (ASC_SHRINK_LEVEL < 1) {
+    return log64_lut(x);
+  } else {
+    const
+      ln2_hi = reinterpret<f64>(0x3FE62E42FEE00000), // 6.93147180369123816490e-01
+      ln2_lo = reinterpret<f64>(0x3DEA39EF35793C76), // 1.90821492927058770002e-10
+      Lg1    = reinterpret<f64>(0x3FE5555555555593), // 6.666666666666735130e-01
+      Lg2    = reinterpret<f64>(0x3FD999999997FA04), // 3.999999999940941908e-01
+      Lg3    = reinterpret<f64>(0x3FD2492494229359), // 2.857142874366239149e-01
+      Lg4    = reinterpret<f64>(0x3FCC71C51D8E78AF), // 2.222219843214978396e-01
+      Lg5    = reinterpret<f64>(0x3FC7466496CB03DE), // 1.818357216161805012e-01
+      Lg6    = reinterpret<f64>(0x3FC39A09D078C69F), // 1.531383769920937332e-01
+      Lg7    = reinterpret<f64>(0x3FC2F112DF3E5244), // 1.479819860511658591e-01
+      Ox1p54 = reinterpret<f64>(0x4350000000000000); // 0x1p54
+
+    let u = reinterpret<u64>(x);
+    let hx = <u32>(u >> 32);
+    let k = 0;
+    if (hx < 0x00100000 || <bool>(hx >> 31)) {
+      if (u << 1 == 0) return -1 / (x * x);
+      if (hx >> 31)    return (x - x) / 0.0;
+      k -= 54;
+      x *= Ox1p54;
+      u = reinterpret<u64>(x);
+      hx = <u32>(u >> 32);
+    } else if (hx >= 0x7FF00000) {
+      return x;
+    } else if (hx == 0x3FF00000 && u << 32 == 0) {
+      return 0;
+    }
+    hx += 0x3FF00000 - 0x3FE6A09E;
+    k += (<i32>hx >> 20) - 0x3FF;
+    hx = (hx & 0x000FFFFF) + 0x3FE6A09E;
+    u = <u64>hx << 32 | (u & 0xFFFFFFFF);
+    x = reinterpret<f64>(u);
+    let f = x - 1.0;
+    let hfsq = 0.5 * f * f;
+    let s = f / (2.0 + f);
+    let z = s * s;
+    let w = z * z;
+    let t1 = w * (Lg2 + w * (Lg4 + w * Lg6));
+    let t2 = z * (Lg1 + w * (Lg3 + w * (Lg5 + w * Lg7)));
+    let r = t2 + t1;
+    let dk = <f64>k;
+    return s * (hfsq + r) + dk * ln2_lo - hfsq + f + dk * ln2_hi;
+  }
+}
+
+export function log10_32(x: f32): f32 { // see: musl/src/math/log10f.c and SUN COPYRIGHT NOTICE above
+  const
+    ivln10hi  = reinterpret<f32>(0x3EDE6000), //  4.3432617188e-01f
+    ivln10lo  = reinterpret<f32>(0xB804EAD9), // -3.1689971365e-05f
+    log10_2hi = reinterpret<f32>(0x3E9A2080), //  3.0102920532e-01f
+    log10_2lo = reinterpret<f32>(0x355427DB), //  7.9034151668e-07f
+    Lg1       = reinterpret<f32>(0x3F2AAAAA), //  0xaaaaaa.0p-24f, 0.66666662693f
+    Lg2       = reinterpret<f32>(0x3ECCCE13), //  0xccce13.0p-25f, 0.40000972152f
+    Lg3       = reinterpret<f32>(0x3E91E9EE), //  0x91e9ee.0p-25f, 0.28498786688f
+    Lg4       = reinterpret<f32>(0x3E789E26), //  0xf89e26.0p-26f, 0.24279078841f
+    Ox1p25f   = reinterpret<f32>(0x4C000000); //  0x1p25f
+
+  var ix = reinterpret<u32>(x);
+  var k = 0;
+  if (ix < 0x00800000 || <bool>(ix >> 31)) {
+    if (ix << 1 == 0) return -1 / (x * x);
+    if (ix >> 31) return (x - x) / 0.0;
+    k -= 25;
+    x *= Ox1p25f;
+    ix = reinterpret<u32>(x);
+  } else if (ix >= 0x7F800000) {
+    return x;
+  } else if (ix == 0x3F800000) {
+    return 0;
+  }
+  ix += 0x3F800000 - 0x3F3504F3;
+  k += <i32>(ix >> 23) - 0x7F;
+  ix = (ix & 0x007FFFFF) + 0x3F3504F3;
+  x = reinterpret<f32>(ix);
+  var f = x - 1.0;
+  var s = f / (2.0 + f);
+  var z = s * s;
+  var w = z * z;
+  var t1 = w * (Lg2 + w * Lg4);
+  var t2 = z * (Lg1 + w * Lg3);
+  var r = t2 + t1;
+  var hfsq: f32 = 0.5 * f * f;
+  var hi = f - hfsq;
+  ix = reinterpret<u32>(hi);
+  ix &= 0xFFFFF000;
+  hi = reinterpret<f32>(ix);
+  var lo = f - hi - hfsq + s * (hfsq + r);
+  var dk = <f32>k;
+  return dk * log10_2lo + (lo + hi) * ivln10lo + lo * ivln10hi + hi * ivln10hi + dk * log10_2hi;
+}
+
+export function log10_64(x: f64): f64 { // see: musl/src/math/log10.c and SUN COPYRIGHT NOTICE above
+  const
+    ivln10hi  = reinterpret<f64>(0x3FDBCB7B15200000), // 4.34294481878168880939e-01
+    ivln10lo  = reinterpret<f64>(0x3DBB9438CA9AADD5), // 2.50829467116452752298e-11
+    log10_2hi = reinterpret<f64>(0x3FD34413509F6000), // 3.01029995663611771306e-01
+    log10_2lo = reinterpret<f64>(0x3D59FEF311F12B36), // 3.69423907715893078616e-13
+    Lg1       = reinterpret<f64>(0x3FE5555555555593), // 6.666666666666735130e-01
+    Lg2       = reinterpret<f64>(0x3FD999999997FA04), // 3.999999999940941908e-01
+    Lg3       = reinterpret<f64>(0x3FD2492494229359), // 2.857142874366239149e-01
+    Lg4       = reinterpret<f64>(0x3FCC71C51D8E78AF), // 2.222219843214978396e-01
+    Lg5       = reinterpret<f64>(0x3FC7466496CB03DE), // 1.818357216161805012e-01
+    Lg6       = reinterpret<f64>(0x3FC39A09D078C69F), // 1.531383769920937332e-01
+    Lg7       = reinterpret<f64>(0x3FC2F112DF3E5244), // 1.479819860511658591e-01
+    Ox1p54    = reinterpret<f64>(0x4350000000000000); // 0x1p54
+
+  var u = reinterpret<u64>(x);
+  var hx = <u32>(u >> 32);
+  var k = 0;
+  if (hx < 0x00100000 || <bool>(hx >> 31)) {
+    if (u << 1 == 0) return -1 / (x * x);
+    if (hx >> 31) return (x - x) / 0.0;
+    k -= 54;
+    x *= Ox1p54;
+    u = reinterpret<u64>(x);
+    hx = <u32>(u >> 32);
+  } else if (hx >= 0x7FF00000) {
+    return x;
+  } else if (hx == 0x3FF00000 && u << 32 == 0) {
+    return 0;
+  }
+  hx += 0x3FF00000 - 0x3FE6A09E;
+  k += <i32>(hx >> 20) - 0x3FF;
+  hx = (hx & 0x000FFFFF) + 0x3FE6A09E;
+  u = <u64>hx << 32 | (u & 0xFFFFFFFF);
+  x = reinterpret<f64>(u);
+  var f = x - 1.0;
+  var hfsq = 0.5 * f * f;
+  var s = f / (2.0 + f);
+  var z = s * s;
+  var w = z * z;
+  var t1 = w * (Lg2 + w * (Lg4 + w * Lg6));
+  var t2 = z * (Lg1 + w * (Lg3 + w * (Lg5 + w * Lg7)));
+  var r = t2 + t1;
+  var hi = f - hfsq;
+  u = reinterpret<u64>(hi);
+  u &= 0xFFFFFFFF00000000;
+  hi = reinterpret<f64>(u);
+  var lo = f - hi - hfsq + s * (hfsq + r);
+  var val_hi = hi * ivln10hi;
+  var dk = <f64>k;
+  var y = dk * log10_2hi;
+  var val_lo = dk * log10_2lo + (lo + hi) * ivln10lo + lo * ivln10hi;
+  w = y + val_hi;
+  val_lo += (y - w) + val_hi;
+  return val_lo + w;
+}
+
+export function log1p32(x: f32): f32 { // see: musl/src/math/log1pf.c and SUN COPYRIGHT NOTICE above
+  const
+    ln2_hi = reinterpret<f32>(0x3F317180), // 6.9313812256e-01
+    ln2_lo = reinterpret<f32>(0x3717F7D1), // 9.0580006145e-06
+    Lg1    = reinterpret<f32>(0x3F2AAAAA), // 0xaaaaaa.0p-24f, 0.66666662693f
+    Lg2    = reinterpret<f32>(0x3ECCCE13), // 0xccce13.0p-25f, 0.40000972152f
+    Lg3    = reinterpret<f32>(0x3E91E9EE), // 0x91e9ee.0p-25f, 0.28498786688f
+    Lg4    = reinterpret<f32>(0x3E789E26); // 0xf89e26.0p-26f, 0.24279078841f
+
+  var ix = reinterpret<u32>(x);
+  var c: f32 = 0, f: f32 = 0;
+  var k: i32 = 1;
+  if (ix < 0x3ED413D0 || <bool>(ix >> 31)) {
+    if (ix >= 0xBF800000) {
+      if (x == -1) return x / 0.0;
+      return (x - x) / 0.0;
+    }
+    if (ix << 1 < 0x33800000 << 1) return x;
+    if (ix <= 0xBE95F619) {
+      k = 0;
+      c = 0;
+      f = x;
+    }
+  } else if (ix >= 0x7F800000) return x;
+  if (k) {
+    let uf: f32 = 1 + x;
+    let iu = reinterpret<u32>(uf);
+    iu += 0x3F800000 - 0x3F3504F3;
+    k = <i32>(iu >> 23) - 0x7F;
+    if (k < 25) {
+      c = k >= 2 ? 1 - (uf - x) : x - (uf - 1);
+      c /= uf;
+    } else c = 0;
+    iu = (iu & 0x007FFFFF) + 0x3F3504F3;
+    f = reinterpret<f32>(iu) - 1;
+  }
+  var s = f / (2.0 + f);
+  var z = s * s;
+  var w = z * z;
+  var t1 = w * (Lg2 + w * Lg4);
+  var t2 = z * (Lg1 + w * Lg3);
+  var r = t2 + t1;
+  var hfsq: f32 = 0.5 * f * f;
+  var dk = <f32>k;
+  return s * (hfsq + r) + (dk * ln2_lo + c) - hfsq + f + dk * ln2_hi;
+}
+
+export function log1p64(x: f64): f64 { // see: musl/src/math/log1p.c and SUN COPYRIGHT NOTICE above
+  const
+    ln2_hi = reinterpret<f64>(0x3FE62E42FEE00000), // 6.93147180369123816490e-01
+    ln2_lo = reinterpret<f64>(0x3DEA39EF35793C76), // 1.90821492927058770002e-10
+    Lg1    = reinterpret<f64>(0x3FE5555555555593), // 6.666666666666735130e-01
+    Lg2    = reinterpret<f64>(0x3FD999999997FA04), // 3.999999999940941908e-01
+    Lg3    = reinterpret<f64>(0x3FD2492494229359), // 2.857142874366239149e-01
+    Lg4    = reinterpret<f64>(0x3FCC71C51D8E78AF), // 2.222219843214978396e-01
+    Lg5    = reinterpret<f64>(0x3FC7466496CB03DE), // 1.818357216161805012e-01
+    Lg6    = reinterpret<f64>(0x3FC39A09D078C69F), // 1.531383769920937332e-01
+    Lg7    = reinterpret<f64>(0x3FC2F112DF3E5244); // 1.479819860511658591e-01
+
+  var u = reinterpret<u64>(x);
+  var hx = <u32>(u >> 32);
+  var k = 1;
+  var c = 0.0, f = 0.0;
+  if (hx < 0x3FDA827A || <bool>(hx >> 31)) {
+    if (hx >= 0xBFF00000) {
+      if (x == -1) return x / 0.0;
+      return (x - x) / 0.0;
+    }
+    if (hx << 1 < 0x3CA00000 << 1) return x;
+    if (hx <= 0xBFD2BEC4) {
+      k = 0;
+      c = 0;
+      f = x;
+    }
+  } else if (hx >= 0x7FF00000) return x;
+  if (k) {
+    u = reinterpret<u64>(1 + x);
+    let hu = <u32>(u >> 32);
+    hu += 0x3FF00000 - 0x3FE6A09E;
+    k = <i32>(hu >> 20) - 0x3FF;
+    if (k < 54) {
+      let uf = reinterpret<f64>(u);
+      c = k >= 2 ? 1 - (uf - x) : x - (uf - 1);
+      c /= uf;
+    } else c = 0;
+    hu = (hu & 0x000FFFFF) + 0x3FE6A09E;
+    u = <u64>hu << 32 | (u & 0xFFFFFFFF);
+    f = reinterpret<f64>(u) - 1;
+  }
+  var hfsq = 0.5 * f * f;
+  var s = f / (2.0 + f);
+  var z = s * s;
+  var w = z * z;
+  var t1 = w * (Lg2 + w * (Lg4 + w * Lg6));
+  var t2 = z * (Lg1 + w * (Lg3 + w * (Lg5 + w * Lg7)));
+  var r = t2 + t1;
+  var dk = <f64>k;
+  return s * (hfsq + r) + (dk * ln2_lo + c) - hfsq + f + dk * ln2_hi;
+}
+
+export function log2_32(x: f32): f32 { // see: musl/src/math/log2f.c and SUN COPYRIGHT NOTICE above
+  if (ASC_SHRINK_LEVEL < 1) {
+    return log2_32_lut(x);
+  } else {
+    const
+      ivln2hi = reinterpret<f32>(0x3FB8B000), //  1.4428710938e+00f
+      ivln2lo = reinterpret<f32>(0xB9389AD4), // -1.7605285393e-04
+      Lg1     = reinterpret<f32>(0x3F2AAAAA), //  0xaaaaaa.0p-24f, 0.66666662693f
+      Lg2     = reinterpret<f32>(0x3ECCCE13), //  0xccce13.0p-25f, 0.40000972152f
+      Lg3     = reinterpret<f32>(0x3E91E9EE), //  0x91e9ee.0p-25f, 0.28498786688f
+      Lg4     = reinterpret<f32>(0x3E789E26), //  0xf89e26.0p-26f, 0.24279078841f
+      Ox1p25f = reinterpret<f32>(0x4C000000); //  0x1p25f
+
+    let ix = reinterpret<u32>(x);
+    let k: i32 = 0;
+    if (ix < 0x00800000 || <bool>(ix >> 31)) {
+      if (ix << 1 == 0) return -1 / (x * x);
+      if (ix >> 31) return (x - x) / 0.0;
+      k -= 25;
+      x *= Ox1p25f;
+      ix = reinterpret<u32>(x);
+    } else if (ix >= 0x7F800000) {
+      return x;
+    } else if (ix == 0x3F800000) {
+      return 0;
+    }
+    ix += 0x3F800000 - 0x3F3504F3;
+    k += <i32>(ix >> 23) - 0x7F;
+    ix = (ix & 0x007FFFFF) + 0x3F3504F3;
+    x = reinterpret<f32>(ix);
+    let f = x - 1.0;
+    let s = f / (2.0 + f);
+    let z = s * s;
+    let w = z * z;
+    let t1 = w * (Lg2 + w * Lg4);
+    let t2 = z * (Lg1 + w * Lg3);
+    let r = t2 + t1;
+    let hfsq: f32 = 0.5 * f * f;
+    let hi = f - hfsq;
+    let u = reinterpret<u32>(hi);
+    u &= 0xFFFFF000;
+    hi = reinterpret<f32>(u);
+    let lo: f32 = f - hi - hfsq + s * (hfsq + r);
+    let dk = <f32>k;
+    return (lo + hi) * ivln2lo + lo * ivln2hi + hi * ivln2hi + dk;
+  }
+}
+
+export function log2_64(x: f64): f64 { // see: musl/src/math/log2.c and SUN COPYRIGHT NOTICE above
+  if (ASC_SHRINK_LEVEL < 1) {
+    return log2_64_lut(x);
+  } else {
+    const
+      ivln2hi = reinterpret<f64>(0x3FF7154765200000), // 1.44269504072144627571e+00
+      ivln2lo = reinterpret<f64>(0x3DE705FC2EEFA200), // 1.67517131648865118353e-10
+      Lg1     = reinterpret<f64>(0x3FE5555555555593), // 6.666666666666735130e-01
+      Lg2     = reinterpret<f64>(0x3FD999999997FA04), // 3.999999999940941908e-01
+      Lg3     = reinterpret<f64>(0x3FD2492494229359), // 2.857142874366239149e-01
+      Lg4     = reinterpret<f64>(0x3FCC71C51D8E78AF), // 2.222219843214978396e-01
+      Lg5     = reinterpret<f64>(0x3FC7466496CB03DE), // 1.818357216161805012e-01
+      Lg6     = reinterpret<f64>(0x3FC39A09D078C69F), // 1.531383769920937332e-01
+      Lg7     = reinterpret<f64>(0x3FC2F112DF3E5244), // 1.479819860511658591e-01
+      Ox1p54  = reinterpret<f64>(0x4350000000000000); // 1p54
+
+    let u = reinterpret<u64>(x);
+    let hx = <u32>(u >> 32);
+    let k = 0;
+    if (hx < 0x00100000 || <bool>(hx >> 31)) {
+      if (u << 1 == 0) return -1 / (x * x);
+      if (hx >> 31) return (x - x) / 0.0;
+      k -= 54;
+      x *= Ox1p54;
+      u = reinterpret<u64>(x);
+      hx = <u32>(u >> 32);
+    } else if (hx >= 0x7FF00000) {
+      return x;
+    } else if (hx == 0x3FF00000 && u << 32 == 0) {
+      return 0;
+    }
+    hx += 0x3FF00000 - 0x3FE6A09E;
+    k += <i32>(hx >> 20) - 0x3FF;
+    hx = (hx & 0x000FFFFF) + 0x3FE6A09E;
+    u = <u64>hx << 32 | (u & 0xFFFFFFFF);
+    x = reinterpret<f64>(u);
+    let f = x - 1.0;
+    let hfsq = 0.5 * f * f;
+    let s = f / (2.0 + f);
+    let z = s * s;
+    let w = z * z;
+    let t1 = w * (Lg2 + w * (Lg4 + w * Lg6));
+    let t2 = z * (Lg1 + w * (Lg3 + w * (Lg5 + w * Lg7)));
+    let r = t2 + t1;
+    let hi = f - hfsq;
+    u = reinterpret<u64>(hi);
+    u &= 0xFFFFFFFF00000000;
+    hi = reinterpret<f64>(u);
+    let lo = f - hi - hfsq + s * (hfsq + r);
+    let val_hi = hi * ivln2hi;
+    let val_lo = (lo + hi) * ivln2lo + lo * ivln2hi;
+    let y = <f64>k;
+    w = y + val_hi;
+    val_lo += (y - w) + val_hi;
+    val_hi = w;
+    return val_lo + val_hi;
+  }
+}
+
+export function mod32(x: f32, y: f32): f32 { // see: musl/src/math/fmodf.c
+  if (abs<f32>(y) == 1.0) {
+    // x % 1, x % -1  ==>  sign(x) * abs(x - 1.0 * trunc(x / 1.0))
+    // TODO: move this rule to compiler's optimization pass.
+    // It could be apply for any x % C_pot, where "C_pot" is pow of two const.
+    return copysign<f32>(x - trunc<f32>(x), x);
+  }
+  var ux = reinterpret<u32>(x);
+  var uy = reinterpret<u32>(y);
+  var ex = <i32>(ux >> 23 & 0xFF);
+  var ey = <i32>(uy >> 23 & 0xFF);
+  var sm = ux & 0x80000000;
+  var uy1 = uy << 1;
+  if (uy1 == 0 || ex == 0xFF || isNaN<f32>(y)) {
+    let m = x * y;
+    return m / m;
+  }
+  var ux1 = ux << 1;
+  if (ux1 <= uy1) {
+    return x * f32(ux1 != uy1);
+  }
+  if (!ex) {
+    ex -= clz<u32>(ux << 9);
+    ux <<= 1 - ex;
+  } else {
+    ux &= <u32>-1 >> 9;
+    ux |= 1 << 23;
+  }
+  if (!ey) {
+    ey -= clz<u32>(uy << 9);
+    uy <<= 1 - ey;
+  } else {
+    uy &= <u32>-1 >> 9;
+    uy |= 1 << 23;
+  }
+  while (ex > ey) {
+    if (ux >= uy) {
+      if (ux == uy) return 0 * x;
+      ux -= uy;
+    }
+    ux <<= 1;
+    --ex;
+  }
+  if (ux >= uy) {
+    if (ux == uy) return 0 * x;
+    ux -= uy;
+  }
+  // for (; !(ux >> 23); ux <<= 1) --ex;
+  var shift = <i32>clz<u32>(ux << 8);
+  ex -= shift;
+  ux <<= shift;
+  if (ex > 0) {
+    ux -= 1 << 23;
+    ux |= <u32>ex << 23;
+  } else {
+    ux >>= -ex + 1;
+  }
+  return reinterpret<f32>(ux | sm);
+}
+
+export function mod64(x: f64, y: f64): f64 { // see: musl/src/math/fmod.c
+  if (abs<f64>(y) == 1.0) {
+    // x % 1, x % -1  ==>  sign(x) * abs(x - 1.0 * trunc(x / 1.0))
+    // TODO: move this rule to compiler's optimization pass.
+    // It could be apply for any x % C_pot, where "C_pot" is pow of two const.
+    return copysign<f64>(x - trunc<f64>(x), x);
+  }
+  var ux = reinterpret<u64>(x);
+  var uy = reinterpret<u64>(y);
+  var ex = <i64>(ux >> 52 & 0x7FF);
+  var ey = <i64>(uy >> 52 & 0x7FF);
+  var sx = ux >> 63;
+  var uy1 = uy << 1;
+  if (uy1 == 0 || ex == 0x7FF || isNaN<f64>(y)) {
+    let m = x * y;
+    return m / m;
+  }
+  var ux1 = ux << 1;
+  if (ux1 <= uy1) {
+    return x * f64(ux1 != uy1);
+  }
+  if (!ex) {
+    ex -= clz<i64>(ux << 12);
+    ux <<= 1 - ex;
+  } else {
+    ux &= <u64>-1 >> 12;
+    ux |= 1 << 52;
+  }
+  if (!ey) {
+    ey -= clz<i64>(uy << 12);
+    uy <<= 1 - ey;
+  } else {
+    uy &= <u64>-1 >> 12;
+    uy |= 1 << 52;
+  }
+  while (ex > ey) {
+    if (ux >= uy) {
+      if (ux == uy) return 0 * x;
+      ux -= uy;
+    }
+    ux <<= 1;
+    --ex;
+  }
+  if (ux >= uy) {
+    if (ux == uy) return 0 * x;
+    ux -= uy;
+  }
+  // for (; !(ux >> 52); ux <<= 1) --ex;
+  var shift = clz<i64>(ux << 11);
+  ex -= shift;
+  ux <<= shift;
+  if (ex > 0) {
+    ux -= 1 << 52;
+    ux |= ex << 52;
+  } else {
+    ux >>= -ex + 1;
+  }
+  return reinterpret<f64>(ux | (sx << 63));
 }

--- a/std/assembly/util/string.ts
+++ b/std/assembly/util/string.ts
@@ -1,5 +1,5 @@
 import { itoa32, utoa32, itoa64, utoa64, dtoa, itoa_buffered, dtoa_buffered, MAX_DOUBLE_LENGTH } from "./number";
-import { ipow32 } from "../math";
+import { scalbn64, ipow32 } from "../util/math";
 
 // All tables are stored as two staged lookup tables (static tries)
 // because the full range of Unicode symbols can't be efficiently
@@ -1092,7 +1092,7 @@ function scaledown(significand: u64, exp: i32): f64 {
   significand = (q << s) + <u64>(reinterpret<f64>(reinterpret<u64>(<f64>r) + (s << 52)) / <f64>b);
   shift -= s;
 
-  return NativeMath.scalbn(<f64>significand, <i32>shift);
+  return scalbn64(<f64>significand, <i32>shift);
 }
 
 // Adopted from metallic lib:
@@ -1111,7 +1111,7 @@ function scaleup(significand: u64, exp: i32): f64 {
   }
   significand = fixmul(significand, <u32>ipow32(5, exp));
   shift = __fixmulShift;
-  return NativeMath.scalbn(<f64>significand, <i32>shift);
+  return scalbn64(<f64>significand, <i32>shift);
 }
 
 // Adopted from metallic lib:

--- a/std/portable/index.d.ts
+++ b/std/portable/index.d.ts
@@ -304,7 +304,6 @@ declare function bswap16<T = i16 | u16 | i32 | u32>(value: T): T;
 
 // Standard library
 
-declare const Mathf: typeof Math;
 declare const JSMath: typeof Math;
 
 declare interface StringConstructor {

--- a/tests/compiler/binary.debug.wat
+++ b/tests/compiler/binary.debug.wat
@@ -22,7 +22,7 @@
  (elem $0 (i32.const 1))
  (export "memory" (memory $0))
  (start $~start)
- (func $~lib/math/ipow32 (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/util/math/ipow32 (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -241,7 +241,7 @@
   end
   local.get $2
  )
- (func $~lib/math/NativeMath.pow (param $0 f64) (param $1 f64) (result f64)
+ (func $~lib/util/math/pow64 (param $0 f64) (param $1 f64) (result f64)
   (local $2 f64)
   (local $3 f64)
   (local $4 i32)
@@ -342,7 +342,7 @@
   i32.const 1
   i32.lt_s
   drop
-  block $~lib/util/math/pow_lut|inlined.0 (result f64)
+  block $~lib/util/math/pow64_lut|inlined.0 (result f64)
    local.get $0
    local.set $3
    local.get $1
@@ -403,14 +403,14 @@
      i64.eq
      if
       f64.const 1
-      br $~lib/util/math/pow_lut|inlined.0
+      br $~lib/util/math/pow64_lut|inlined.0
      end
      local.get $5
      i64.const 4607182418800017408
      i64.eq
      if
       f64.const nan:0x8000000000000
-      br $~lib/util/math/pow_lut|inlined.0
+      br $~lib/util/math/pow64_lut|inlined.0
      end
      local.get $5
      i64.const 1
@@ -430,7 +430,7 @@
       local.get $3
       local.get $2
       f64.add
-      br $~lib/util/math/pow_lut|inlined.0
+      br $~lib/util/math/pow64_lut|inlined.0
      end
      local.get $5
      i64.const 1
@@ -439,7 +439,7 @@
      i64.eq
      if
       f64.const nan:0x8000000000000
-      br $~lib/util/math/pow_lut|inlined.0
+      br $~lib/util/math/pow64_lut|inlined.0
      end
      local.get $5
      i64.const 1
@@ -455,12 +455,12 @@
      i32.eq
      if
       f64.const 0
-      br $~lib/util/math/pow_lut|inlined.0
+      br $~lib/util/math/pow64_lut|inlined.0
      end
      local.get $2
      local.get $2
      f64.mul
-     br $~lib/util/math/pow_lut|inlined.0
+     br $~lib/util/math/pow64_lut|inlined.0
     end
     local.get $5
     local.set $9
@@ -483,7 +483,7 @@
      i64.shr_u
      i32.wrap_i64
      if (result i32)
-      block $~lib/util/math/checkint|inlined.0 (result i32)
+      block $~lib/util/math/checkint64|inlined.0 (result i32)
        local.get $6
        local.set $9
        local.get $9
@@ -497,7 +497,7 @@
        i64.lt_u
        if
         i32.const 0
-        br $~lib/util/math/checkint|inlined.0
+        br $~lib/util/math/checkint64|inlined.0
        end
        local.get $11
        i64.const 1023
@@ -506,7 +506,7 @@
        i64.gt_u
        if
         i32.const 2
-        br $~lib/util/math/checkint|inlined.0
+        br $~lib/util/math/checkint64|inlined.0
        end
        i64.const 1
        i64.const 1023
@@ -525,7 +525,7 @@
        i64.ne
        if
         i32.const 0
-        br $~lib/util/math/checkint|inlined.0
+        br $~lib/util/math/checkint64|inlined.0
        end
        local.get $9
        local.get $11
@@ -534,7 +534,7 @@
        i64.ne
        if
         i32.const 1
-        br $~lib/util/math/checkint|inlined.0
+        br $~lib/util/math/checkint64|inlined.0
        end
        i32.const 2
       end
@@ -560,7 +560,7 @@
      else
       local.get $10
      end
-     br $~lib/util/math/pow_lut|inlined.0
+     br $~lib/util/math/pow64_lut|inlined.0
     end
     local.get $5
     i64.const 63
@@ -568,7 +568,7 @@
     i64.const 0
     i64.ne
     if
-     block $~lib/util/math/checkint|inlined.1 (result i32)
+     block $~lib/util/math/checkint64|inlined.1 (result i32)
       local.get $6
       local.set $9
       local.get $9
@@ -582,7 +582,7 @@
       i64.lt_u
       if
        i32.const 0
-       br $~lib/util/math/checkint|inlined.1
+       br $~lib/util/math/checkint64|inlined.1
       end
       local.get $11
       i64.const 1023
@@ -591,7 +591,7 @@
       i64.gt_u
       if
        i32.const 2
-       br $~lib/util/math/checkint|inlined.1
+       br $~lib/util/math/checkint64|inlined.1
       end
       i64.const 1
       i64.const 1023
@@ -610,7 +610,7 @@
       i64.ne
       if
        i32.const 0
-       br $~lib/util/math/checkint|inlined.1
+       br $~lib/util/math/checkint64|inlined.1
       end
       local.get $9
       local.get $11
@@ -619,7 +619,7 @@
       i64.ne
       if
        i32.const 1
-       br $~lib/util/math/checkint|inlined.1
+       br $~lib/util/math/checkint64|inlined.1
       end
       i32.const 2
      end
@@ -635,7 +635,7 @@
       local.get $3
       f64.sub
       f64.div
-      br $~lib/util/math/pow_lut|inlined.0
+      br $~lib/util/math/pow64_lut|inlined.0
      end
      local.get $12
      i32.const 1
@@ -668,7 +668,7 @@
      i64.eq
      if
       f64.const 1
-      br $~lib/util/math/pow_lut|inlined.0
+      br $~lib/util/math/pow64_lut|inlined.0
      end
      local.get $8
      i64.const 2047
@@ -677,7 +677,7 @@
      i64.lt_u
      if
       f64.const 1
-      br $~lib/util/math/pow_lut|inlined.0
+      br $~lib/util/math/pow64_lut|inlined.0
      end
      local.get $5
      i64.const 4607182418800017408
@@ -691,7 +691,7 @@
      else
       f64.const 0
      end
-     br $~lib/util/math/pow_lut|inlined.0
+     br $~lib/util/math/pow64_lut|inlined.0
     end
     local.get $7
     i64.const 0
@@ -940,7 +940,7 @@
    f64.mul
    f64.add
    local.set $35
-   block $~lib/util/math/exp_inline|inlined.0 (result f64)
+   block $~lib/util/math/exp64_inline|inlined.0 (result f64)
     local.get $36
     local.set $15
     local.get $35
@@ -973,7 +973,7 @@
       f64.const 1
       local.get $12
       select
-      br $~lib/util/math/exp_inline|inlined.0
+      br $~lib/util/math/exp64_inline|inlined.0
      end
      local.get $39
      i32.const 1033
@@ -1015,7 +1015,7 @@
        local.get $17
        f64.mul
       end
-      br $~lib/util/math/exp_inline|inlined.0
+      br $~lib/util/math/exp64_inline|inlined.0
      end
      i32.const 0
      local.set $39
@@ -1211,7 +1211,7 @@
       f64.const 2.2250738585072014e-308
       f64.mul
      end
-     br $~lib/util/math/exp_inline|inlined.0
+     br $~lib/util/math/exp64_inline|inlined.0
     end
     local.get $11
     f64.reinterpret_i64
@@ -1225,7 +1225,7 @@
   end
   return
  )
- (func $~lib/math/NativeMathf.mod (param $0 f32) (param $1 f32) (result f32)
+ (func $~lib/util/math/mod32 (param $0 f32) (param $1 f32) (result f32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -1476,7 +1476,7 @@
   i32.or
   f32.reinterpret_i32
  )
- (func $~lib/math/NativeMathf.pow (param $0 f32) (param $1 f32) (result f32)
+ (func $~lib/util/math/pow32 (param $0 f32) (param $1 f32) (result f32)
   (local $2 f32)
   (local $3 f32)
   (local $4 i32)
@@ -1557,7 +1557,7 @@
   i32.const 1
   i32.lt_s
   drop
-  block $~lib/util/math/powf_lut|inlined.0 (result f32)
+  block $~lib/util/math/pow32_lut|inlined.0 (result f32)
    local.get $0
    local.set $3
    local.get $1
@@ -1606,14 +1606,14 @@
      i32.eq
      if
       f32.const 1
-      br $~lib/util/math/powf_lut|inlined.0
+      br $~lib/util/math/pow32_lut|inlined.0
      end
      local.get $5
      i32.const 1065353216
      i32.eq
      if
       f32.const nan:0x400000
-      br $~lib/util/math/powf_lut|inlined.0
+      br $~lib/util/math/pow32_lut|inlined.0
      end
      local.get $5
      i32.const 1
@@ -1637,7 +1637,7 @@
       local.get $3
       local.get $2
       f32.add
-      br $~lib/util/math/powf_lut|inlined.0
+      br $~lib/util/math/pow32_lut|inlined.0
      end
      local.get $5
      i32.const 1
@@ -1648,7 +1648,7 @@
      i32.eq
      if
       f32.const nan:0x400000
-      br $~lib/util/math/powf_lut|inlined.0
+      br $~lib/util/math/pow32_lut|inlined.0
      end
      local.get $5
      i32.const 1
@@ -1664,12 +1664,12 @@
      i32.eq
      if
       f32.const 0
-      br $~lib/util/math/powf_lut|inlined.0
+      br $~lib/util/math/pow32_lut|inlined.0
      end
      local.get $2
      local.get $2
      f32.mul
-     br $~lib/util/math/powf_lut|inlined.0
+     br $~lib/util/math/pow32_lut|inlined.0
     end
     local.get $5
     local.set $8
@@ -1693,7 +1693,7 @@
      i32.const 31
      i32.shr_u
      if (result i32)
-      block $~lib/util/math/checkintf|inlined.0 (result i32)
+      block $~lib/util/math/checkint32|inlined.0 (result i32)
        local.get $6
        local.set $8
        local.get $8
@@ -1707,7 +1707,7 @@
        i32.lt_u
        if
         i32.const 0
-        br $~lib/util/math/checkintf|inlined.0
+        br $~lib/util/math/checkint32|inlined.0
        end
        local.get $10
        i32.const 127
@@ -1716,7 +1716,7 @@
        i32.gt_u
        if
         i32.const 2
-        br $~lib/util/math/checkintf|inlined.0
+        br $~lib/util/math/checkint32|inlined.0
        end
        i32.const 1
        i32.const 127
@@ -1733,14 +1733,14 @@
        i32.and
        if
         i32.const 0
-        br $~lib/util/math/checkintf|inlined.0
+        br $~lib/util/math/checkint32|inlined.0
        end
        local.get $8
        local.get $10
        i32.and
        if
         i32.const 1
-        br $~lib/util/math/checkintf|inlined.0
+        br $~lib/util/math/checkint32|inlined.0
        end
        i32.const 2
       end
@@ -1764,13 +1764,13 @@
      else
       local.get $9
      end
-     br $~lib/util/math/powf_lut|inlined.0
+     br $~lib/util/math/pow32_lut|inlined.0
     end
     local.get $5
     i32.const 31
     i32.shr_u
     if
-     block $~lib/util/math/checkintf|inlined.1 (result i32)
+     block $~lib/util/math/checkint32|inlined.1 (result i32)
       local.get $6
       local.set $8
       local.get $8
@@ -1784,7 +1784,7 @@
       i32.lt_u
       if
        i32.const 0
-       br $~lib/util/math/checkintf|inlined.1
+       br $~lib/util/math/checkint32|inlined.1
       end
       local.get $10
       i32.const 127
@@ -1793,7 +1793,7 @@
       i32.gt_u
       if
        i32.const 2
-       br $~lib/util/math/checkintf|inlined.1
+       br $~lib/util/math/checkint32|inlined.1
       end
       i32.const 1
       i32.const 127
@@ -1810,14 +1810,14 @@
       i32.and
       if
        i32.const 0
-       br $~lib/util/math/checkintf|inlined.1
+       br $~lib/util/math/checkint32|inlined.1
       end
       local.get $8
       local.get $10
       i32.and
       if
        i32.const 1
-       br $~lib/util/math/checkintf|inlined.1
+       br $~lib/util/math/checkint32|inlined.1
       end
       i32.const 2
      end
@@ -1833,7 +1833,7 @@
       local.get $3
       f32.sub
       f32.div
-      br $~lib/util/math/powf_lut|inlined.0
+      br $~lib/util/math/pow32_lut|inlined.0
      end
      local.get $10
      i32.const 1
@@ -1997,7 +1997,7 @@
      select
      local.get $9
      f32.mul
-     br $~lib/util/math/powf_lut|inlined.0
+     br $~lib/util/math/pow32_lut|inlined.0
     end
     local.get $21
     f64.const -150
@@ -2017,7 +2017,7 @@
      select
      local.get $9
      f32.mul
-     br $~lib/util/math/powf_lut|inlined.0
+     br $~lib/util/math/pow32_lut|inlined.0
     end
    end
    local.get $21
@@ -2091,7 +2091,7 @@
   end
   return
  )
- (func $~lib/math/NativeMath.mod (param $0 f64) (param $1 f64) (result f64)
+ (func $~lib/util/math/mod64 (param $0 f64) (param $1 f64) (result f64)
   (local $2 i64)
   (local $3 i64)
   (local $4 i64)
@@ -2395,7 +2395,7 @@
   drop
   global.get $binary/i
   i32.const 1
-  call $~lib/math/ipow32
+  call $~lib/util/math/ipow32
   drop
   global.get $binary/i
   i32.const 1
@@ -2467,7 +2467,7 @@
   global.set $binary/i
   global.get $binary/i
   i32.const 1
-  call $~lib/math/ipow32
+  call $~lib/util/math/ipow32
   global.set $binary/i
   global.get $binary/i
   i32.const 1
@@ -2580,7 +2580,7 @@
   global.get $binary/I
   f64.convert_i64_s
   f64.const 1
-  call $~lib/math/NativeMath.pow
+  call $~lib/util/math/pow64
   drop
   global.get $binary/I
   i64.const 1
@@ -2653,7 +2653,7 @@
   global.get $binary/I
   f64.convert_i64_s
   f64.const 1
-  call $~lib/math/NativeMath.pow
+  call $~lib/util/math/pow64
   i64.trunc_sat_f64_s
   global.set $binary/I
   global.get $binary/I
@@ -2762,11 +2762,11 @@
   drop
   global.get $binary/f
   f32.const 1
-  call $~lib/math/NativeMathf.mod
+  call $~lib/util/math/mod32
   drop
   global.get $binary/f
   f32.const 1
-  call $~lib/math/NativeMathf.pow
+  call $~lib/util/math/pow32
   drop
   global.get $binary/f
   f32.const 1
@@ -2810,11 +2810,11 @@
   global.set $binary/f
   global.get $binary/f
   f32.const 1
-  call $~lib/math/NativeMathf.mod
+  call $~lib/util/math/mod32
   global.set $binary/f
   global.get $binary/f
   f32.const 1
-  call $~lib/math/NativeMathf.pow
+  call $~lib/util/math/pow32
   global.set $binary/f
   global.get $binary/f
   f32.const 1
@@ -2830,11 +2830,11 @@
   global.set $binary/f
   global.get $binary/f
   f32.const 1
-  call $~lib/math/NativeMathf.mod
+  call $~lib/util/math/mod32
   global.set $binary/f
   global.get $binary/f
   f32.const 1
-  call $~lib/math/NativeMathf.pow
+  call $~lib/util/math/pow32
   global.set $binary/f
   global.get $binary/F
   f64.const 1
@@ -2878,11 +2878,11 @@
   drop
   global.get $binary/F
   f64.const 1
-  call $~lib/math/NativeMath.mod
+  call $~lib/util/math/mod64
   drop
   global.get $binary/F
   f64.const 1
-  call $~lib/math/NativeMath.pow
+  call $~lib/util/math/pow64
   drop
   global.get $binary/F
   f64.const 1
@@ -2926,11 +2926,11 @@
   global.set $binary/F
   global.get $binary/F
   f64.const 1
-  call $~lib/math/NativeMath.mod
+  call $~lib/util/math/mod64
   global.set $binary/F
   global.get $binary/F
   f64.const 1
-  call $~lib/math/NativeMath.pow
+  call $~lib/util/math/pow64
   global.set $binary/F
   global.get $binary/F
   f64.const 1
@@ -2946,11 +2946,11 @@
   global.set $binary/F
   global.get $binary/F
   f64.const 1
-  call $~lib/math/NativeMath.mod
+  call $~lib/util/math/mod64
   global.set $binary/F
   global.get $binary/F
   f64.const 1
-  call $~lib/math/NativeMath.pow
+  call $~lib/util/math/pow64
   global.set $binary/F
  )
  (func $~start

--- a/tests/compiler/issues/2322/index.release.wat
+++ b/tests/compiler/issues/2322/index.release.wat
@@ -175,37 +175,37 @@
    local.get $4
    i32.store offset=4
   end
-  local.get $2
+  local.get $1
+  local.get $0
   local.get $3
   i32.const 4
   i32.shl
+  local.get $2
   i32.add
   i32.const 2
   i32.shl
-  local.get $0
   i32.add
   i32.load offset=96
-  local.get $1
   i32.eq
   if
-   local.get $2
+   local.get $0
    local.get $3
    i32.const 4
    i32.shl
+   local.get $2
    i32.add
    i32.const 2
    i32.shl
-   local.get $0
    i32.add
    local.get $5
    i32.store offset=96
    local.get $5
    i32.eqz
    if
+    local.get $0
     local.get $3
     i32.const 2
     i32.shl
-    local.get $0
     i32.add
     local.tee $1
     i32.load offset=4
@@ -356,12 +356,12 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $2
+  local.get $4
   local.get $1
   i32.const 4
   i32.add
+  local.get $2
   i32.add
-  local.get $4
   i32.ne
   if
    i32.const 0
@@ -422,14 +422,14 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $2
+  local.get $0
   local.get $5
   i32.const 4
   i32.shl
+  local.get $2
   i32.add
   i32.const 2
   i32.shl
-  local.get $0
   i32.add
   i32.load offset=96
   local.set $3
@@ -445,14 +445,14 @@
    local.get $1
    i32.store offset=4
   end
-  local.get $2
+  local.get $0
   local.get $5
   i32.const 4
   i32.shl
+  local.get $2
   i32.add
   i32.const 2
   i32.shl
-  local.get $0
   i32.add
   local.get $1
   i32.store offset=96
@@ -464,10 +464,10 @@
   i32.shl
   i32.or
   i32.store
+  local.get $0
   local.get $5
   i32.const 2
   i32.shl
-  local.get $0
   i32.add
   local.tee $0
   local.get $0
@@ -504,11 +504,11 @@
   i32.load offset=1568
   local.tee $4
   if
-   local.get $1
    local.get $4
    i32.const 4
    i32.add
-   i32.lt_u
+   local.get $1
+   i32.gt_u
    if
     i32.const 0
     i32.const 1392
@@ -517,10 +517,10 @@
     call $~lib/builtins/abort
     unreachable
    end
-   local.get $4
    local.get $1
    i32.const 16
    i32.sub
+   local.get $4
    i32.eq
    if
     local.get $4
@@ -532,11 +532,11 @@
     local.set $1
    end
   else
-   local.get $1
    local.get $0
    i32.const 1572
    i32.add
-   i32.lt_u
+   local.get $1
+   i32.gt_u
    if
     i32.const 0
     i32.const 1392
@@ -575,10 +575,10 @@
   local.get $1
   i32.const 0
   i32.store offset=8
-  local.get $2
   local.get $1
   i32.const 4
   i32.add
+  local.get $2
   i32.add
   local.tee $2
   i32.const 2
@@ -635,10 +635,10 @@
      i32.const 16
      i32.lt_u
      if
-      local.get $1
       local.get $0
       i32.const 4
       i32.shl
+      local.get $1
       i32.add
       i32.const 2
       i32.shl
@@ -699,25 +699,25 @@
     i32.and
     local.set $0
     loop $while-continue|1
-     global.get $~lib/rt/itcms/toSpace
      local.get $0
+     global.get $~lib/rt/itcms/toSpace
      i32.ne
      if
       local.get $0
       global.set $~lib/rt/itcms/iter
+      local.get $1
       local.get $0
       i32.load offset=4
       i32.const 3
       i32.and
-      local.get $1
       i32.ne
       if
        local.get $0
-       local.get $1
        local.get $0
        i32.load offset=4
        i32.const -4
        i32.and
+       local.get $1
        i32.or
        i32.store offset=4
        i32.const 0
@@ -774,23 +774,23 @@
      i32.and
      local.set $0
      loop $while-continue|2
-      global.get $~lib/rt/itcms/toSpace
       local.get $0
+      global.get $~lib/rt/itcms/toSpace
       i32.ne
       if
+       local.get $1
        local.get $0
        i32.load offset=4
        i32.const 3
        i32.and
-       local.get $1
        i32.ne
        if
         local.get $0
-        local.get $1
         local.get $0
         i32.load offset=4
         i32.const -4
         i32.and
+        local.get $1
         i32.or
         i32.store offset=4
         local.get $0
@@ -943,11 +943,11 @@
   i32.and
   local.tee $1
   if (result i32)
+   local.get $0
    local.get $1
    i32.ctz
    i32.const 2
    i32.shl
-   local.get $0
    i32.add
    i32.load offset=96
   else
@@ -957,12 +957,12 @@
    i32.and
    local.tee $1
    if (result i32)
+    local.get $0
     local.get $1
     i32.ctz
     local.tee $2
     i32.const 2
     i32.shl
-    local.get $0
     i32.add
     i32.load offset=4
     local.tee $1
@@ -975,6 +975,7 @@
      call $~lib/builtins/abort
      unreachable
     end
+    local.get $0
     local.get $1
     i32.ctz
     local.get $2
@@ -983,7 +984,6 @@
     i32.add
     i32.const 2
     i32.shl
-    local.get $0
     i32.add
     i32.load offset=96
    else
@@ -1277,19 +1277,19 @@
    i32.load offset=8
    local.set $3
    local.get $0
-   local.get $2
    global.get $~lib/rt/itcms/white
+   local.get $2
    i32.or
    i32.store offset=4
    local.get $0
    local.get $3
    i32.store offset=8
    local.get $3
+   local.get $0
    local.get $3
    i32.load offset=4
    i32.const 3
    i32.and
-   local.get $0
    i32.or
    i32.store offset=4
    local.get $2
@@ -1350,8 +1350,8 @@
   i32.and
   i32.eq
   if
-   global.get $~lib/rt/itcms/iter
    local.get $1
+   global.get $~lib/rt/itcms/iter
    i32.eq
    if
     local.get $1
@@ -1411,11 +1411,11 @@
     local.get $2
     i32.store offset=8
     local.get $2
+    local.get $0
     local.get $2
     i32.load offset=4
     i32.const 3
     i32.and
-    local.get $0
     i32.or
     i32.store offset=4
    end
@@ -1429,10 +1429,10 @@
    if (result i32)
     i32.const 1
    else
+    local.get $0
     i32.const 1440
     i32.load
-    local.get $0
-    i32.lt_u
+    i32.gt_u
     if
      i32.const 1248
      i32.const 1312
@@ -1469,11 +1469,11 @@
    local.get $0
    i32.store offset=8
    local.get $0
+   local.get $1
    local.get $0
    i32.load offset=4
    i32.const 3
    i32.and
-   local.get $1
    i32.or
    i32.store offset=4
    local.get $2

--- a/tests/compiler/resolve-binary.debug.wat
+++ b/tests/compiler/resolve-binary.debug.wat
@@ -2753,7 +2753,7 @@
   local.get $1
   call $~lib/util/number/itoa32
  )
- (func $~lib/math/NativeMath.pow (param $0 f64) (param $1 f64) (result f64)
+ (func $~lib/util/math/pow64 (param $0 f64) (param $1 f64) (result f64)
   (local $2 f64)
   (local $3 f64)
   (local $4 i32)
@@ -2854,7 +2854,7 @@
   i32.const 1
   i32.lt_s
   drop
-  block $~lib/util/math/pow_lut|inlined.0 (result f64)
+  block $~lib/util/math/pow64_lut|inlined.0 (result f64)
    local.get $0
    local.set $3
    local.get $1
@@ -2915,14 +2915,14 @@
      i64.eq
      if
       f64.const 1
-      br $~lib/util/math/pow_lut|inlined.0
+      br $~lib/util/math/pow64_lut|inlined.0
      end
      local.get $5
      i64.const 4607182418800017408
      i64.eq
      if
       f64.const nan:0x8000000000000
-      br $~lib/util/math/pow_lut|inlined.0
+      br $~lib/util/math/pow64_lut|inlined.0
      end
      local.get $5
      i64.const 1
@@ -2942,7 +2942,7 @@
       local.get $3
       local.get $2
       f64.add
-      br $~lib/util/math/pow_lut|inlined.0
+      br $~lib/util/math/pow64_lut|inlined.0
      end
      local.get $5
      i64.const 1
@@ -2951,7 +2951,7 @@
      i64.eq
      if
       f64.const nan:0x8000000000000
-      br $~lib/util/math/pow_lut|inlined.0
+      br $~lib/util/math/pow64_lut|inlined.0
      end
      local.get $5
      i64.const 1
@@ -2967,12 +2967,12 @@
      i32.eq
      if
       f64.const 0
-      br $~lib/util/math/pow_lut|inlined.0
+      br $~lib/util/math/pow64_lut|inlined.0
      end
      local.get $2
      local.get $2
      f64.mul
-     br $~lib/util/math/pow_lut|inlined.0
+     br $~lib/util/math/pow64_lut|inlined.0
     end
     local.get $5
     local.set $9
@@ -2995,7 +2995,7 @@
      i64.shr_u
      i32.wrap_i64
      if (result i32)
-      block $~lib/util/math/checkint|inlined.0 (result i32)
+      block $~lib/util/math/checkint64|inlined.0 (result i32)
        local.get $6
        local.set $9
        local.get $9
@@ -3009,7 +3009,7 @@
        i64.lt_u
        if
         i32.const 0
-        br $~lib/util/math/checkint|inlined.0
+        br $~lib/util/math/checkint64|inlined.0
        end
        local.get $11
        i64.const 1023
@@ -3018,7 +3018,7 @@
        i64.gt_u
        if
         i32.const 2
-        br $~lib/util/math/checkint|inlined.0
+        br $~lib/util/math/checkint64|inlined.0
        end
        i64.const 1
        i64.const 1023
@@ -3037,7 +3037,7 @@
        i64.ne
        if
         i32.const 0
-        br $~lib/util/math/checkint|inlined.0
+        br $~lib/util/math/checkint64|inlined.0
        end
        local.get $9
        local.get $11
@@ -3046,7 +3046,7 @@
        i64.ne
        if
         i32.const 1
-        br $~lib/util/math/checkint|inlined.0
+        br $~lib/util/math/checkint64|inlined.0
        end
        i32.const 2
       end
@@ -3072,7 +3072,7 @@
      else
       local.get $10
      end
-     br $~lib/util/math/pow_lut|inlined.0
+     br $~lib/util/math/pow64_lut|inlined.0
     end
     local.get $5
     i64.const 63
@@ -3080,7 +3080,7 @@
     i64.const 0
     i64.ne
     if
-     block $~lib/util/math/checkint|inlined.1 (result i32)
+     block $~lib/util/math/checkint64|inlined.1 (result i32)
       local.get $6
       local.set $9
       local.get $9
@@ -3094,7 +3094,7 @@
       i64.lt_u
       if
        i32.const 0
-       br $~lib/util/math/checkint|inlined.1
+       br $~lib/util/math/checkint64|inlined.1
       end
       local.get $11
       i64.const 1023
@@ -3103,7 +3103,7 @@
       i64.gt_u
       if
        i32.const 2
-       br $~lib/util/math/checkint|inlined.1
+       br $~lib/util/math/checkint64|inlined.1
       end
       i64.const 1
       i64.const 1023
@@ -3122,7 +3122,7 @@
       i64.ne
       if
        i32.const 0
-       br $~lib/util/math/checkint|inlined.1
+       br $~lib/util/math/checkint64|inlined.1
       end
       local.get $9
       local.get $11
@@ -3131,7 +3131,7 @@
       i64.ne
       if
        i32.const 1
-       br $~lib/util/math/checkint|inlined.1
+       br $~lib/util/math/checkint64|inlined.1
       end
       i32.const 2
      end
@@ -3147,7 +3147,7 @@
       local.get $3
       f64.sub
       f64.div
-      br $~lib/util/math/pow_lut|inlined.0
+      br $~lib/util/math/pow64_lut|inlined.0
      end
      local.get $12
      i32.const 1
@@ -3180,7 +3180,7 @@
      i64.eq
      if
       f64.const 1
-      br $~lib/util/math/pow_lut|inlined.0
+      br $~lib/util/math/pow64_lut|inlined.0
      end
      local.get $8
      i64.const 2047
@@ -3189,7 +3189,7 @@
      i64.lt_u
      if
       f64.const 1
-      br $~lib/util/math/pow_lut|inlined.0
+      br $~lib/util/math/pow64_lut|inlined.0
      end
      local.get $5
      i64.const 4607182418800017408
@@ -3203,7 +3203,7 @@
      else
       f64.const 0
      end
-     br $~lib/util/math/pow_lut|inlined.0
+     br $~lib/util/math/pow64_lut|inlined.0
     end
     local.get $7
     i64.const 0
@@ -3452,7 +3452,7 @@
    f64.mul
    f64.add
    local.set $35
-   block $~lib/util/math/exp_inline|inlined.0 (result f64)
+   block $~lib/util/math/exp64_inline|inlined.0 (result f64)
     local.get $36
     local.set $15
     local.get $35
@@ -3485,7 +3485,7 @@
       f64.const 1
       local.get $12
       select
-      br $~lib/util/math/exp_inline|inlined.0
+      br $~lib/util/math/exp64_inline|inlined.0
      end
      local.get $39
      i32.const 1033
@@ -3527,7 +3527,7 @@
        local.get $17
        f64.mul
       end
-      br $~lib/util/math/exp_inline|inlined.0
+      br $~lib/util/math/exp64_inline|inlined.0
      end
      i32.const 0
      local.set $39
@@ -3723,7 +3723,7 @@
       f64.const 2.2250738585072014e-308
       f64.mul
      end
-     br $~lib/util/math/exp_inline|inlined.0
+     br $~lib/util/math/exp64_inline|inlined.0
     end
     local.get $11
     f64.reinterpret_i64
@@ -4992,7 +4992,7 @@
   local.get $0
   call $~lib/util/number/dtoa
  )
- (func $~lib/math/ipow32 (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/util/math/ipow32 (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -5667,7 +5667,7 @@
   global.set $resolve-binary/f
   global.get $resolve-binary/f
   f64.const 2
-  call $~lib/math/NativeMath.pow
+  call $~lib/util/math/pow64
   global.set $resolve-binary/f
   global.get $resolve-binary/f
   i32.const 0
@@ -6051,7 +6051,7 @@
   end
   i32.const 2
   i32.const 2
-  call $~lib/math/ipow32
+  call $~lib/util/math/ipow32
   i32.const 10
   call $~lib/number/I32#toString
   local.set $0
@@ -6077,7 +6077,7 @@
   end
   f64.const 2
   f64.const 2
-  call $~lib/math/NativeMath.pow
+  call $~lib/util/math/pow64
   i32.const 0
   call $~lib/number/F64#toString
   local.set $0
@@ -6103,7 +6103,7 @@
   end
   f64.const 2
   f64.const 2
-  call $~lib/math/NativeMath.pow
+  call $~lib/util/math/pow64
   i32.const 0
   call $~lib/number/F64#toString
   local.set $0

--- a/tests/compiler/return-unreachable.release.wat
+++ b/tests/compiler/return-unreachable.release.wat
@@ -90,8 +90,8 @@
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
-  global.get $~lib/rt/itcms/iter
   local.get $0
+  global.get $~lib/rt/itcms/iter
   i32.eq
   if
    local.get $0
@@ -151,11 +151,11 @@
    local.get $2
    i32.store offset=8
    local.get $2
+   local.get $1
    local.get $2
    i32.load offset=4
    i32.const 3
    i32.and
-   local.get $1
    i32.or
    i32.store offset=4
   end
@@ -169,10 +169,10 @@
   if (result i32)
    i32.const 1
   else
+   local.get $1
    i32.const 1536
    i32.load
-   local.get $1
-   i32.lt_u
+   i32.gt_u
    if
     i32.const 1344
     i32.const 1408
@@ -195,23 +195,23 @@
   i32.load offset=8
   local.set $1
   local.get $0
-  local.get $2
   global.get $~lib/rt/itcms/white
   i32.eqz
   i32.const 2
   local.get $3
   select
+  local.get $2
   i32.or
   i32.store offset=4
   local.get $0
   local.get $1
   i32.store offset=8
   local.get $1
+  local.get $0
   local.get $1
   i32.load offset=4
   i32.const 3
   i32.and
-  local.get $0
   i32.or
   i32.store offset=4
   local.get $2
@@ -314,37 +314,37 @@
    local.get $4
    i32.store offset=4
   end
-  local.get $2
+  local.get $1
+  local.get $0
   local.get $3
   i32.const 4
   i32.shl
+  local.get $2
   i32.add
   i32.const 2
   i32.shl
-  local.get $0
   i32.add
   i32.load offset=96
-  local.get $1
   i32.eq
   if
-   local.get $2
+   local.get $0
    local.get $3
    i32.const 4
    i32.shl
+   local.get $2
    i32.add
    i32.const 2
    i32.shl
-   local.get $0
    i32.add
    local.get $5
    i32.store offset=96
    local.get $5
    i32.eqz
    if
+    local.get $0
     local.get $3
     i32.const 2
     i32.shl
-    local.get $0
     i32.add
     local.tee $1
     i32.load offset=4
@@ -495,12 +495,12 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $2
+  local.get $4
   local.get $1
   i32.const 4
   i32.add
+  local.get $2
   i32.add
-  local.get $4
   i32.ne
   if
    i32.const 0
@@ -561,14 +561,14 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $2
+  local.get $0
   local.get $5
   i32.const 4
   i32.shl
+  local.get $2
   i32.add
   i32.const 2
   i32.shl
-  local.get $0
   i32.add
   i32.load offset=96
   local.set $3
@@ -584,14 +584,14 @@
    local.get $1
    i32.store offset=4
   end
-  local.get $2
+  local.get $0
   local.get $5
   i32.const 4
   i32.shl
+  local.get $2
   i32.add
   i32.const 2
   i32.shl
-  local.get $0
   i32.add
   local.get $1
   i32.store offset=96
@@ -603,10 +603,10 @@
   i32.shl
   i32.or
   i32.store
+  local.get $0
   local.get $5
   i32.const 2
   i32.shl
-  local.get $0
   i32.add
   local.tee $0
   local.get $0
@@ -643,11 +643,11 @@
   i32.load offset=1568
   local.tee $4
   if
-   local.get $1
    local.get $4
    i32.const 4
    i32.add
-   i32.lt_u
+   local.get $1
+   i32.gt_u
    if
     i32.const 0
     i32.const 1488
@@ -656,10 +656,10 @@
     call $~lib/builtins/abort
     unreachable
    end
-   local.get $4
    local.get $1
    i32.const 16
    i32.sub
+   local.get $4
    i32.eq
    if
     local.get $4
@@ -671,11 +671,11 @@
     local.set $1
    end
   else
-   local.get $1
    local.get $0
    i32.const 1572
    i32.add
-   i32.lt_u
+   local.get $1
+   i32.gt_u
    if
     i32.const 0
     i32.const 1488
@@ -714,10 +714,10 @@
   local.get $1
   i32.const 0
   i32.store offset=8
-  local.get $2
   local.get $1
   i32.const 4
   i32.add
+  local.get $2
   i32.add
   local.tee $2
   i32.const 2
@@ -774,10 +774,10 @@
      i32.const 16
      i32.lt_u
      if
-      local.get $1
       local.get $0
       i32.const 4
       i32.shl
+      local.get $1
       i32.add
       i32.const 2
       i32.shl
@@ -838,25 +838,25 @@
     i32.and
     local.set $0
     loop $while-continue|1
-     global.get $~lib/rt/itcms/toSpace
      local.get $0
+     global.get $~lib/rt/itcms/toSpace
      i32.ne
      if
       local.get $0
       global.set $~lib/rt/itcms/iter
+      local.get $1
       local.get $0
       i32.load offset=4
       i32.const 3
       i32.and
-      local.get $1
       i32.ne
       if
        local.get $0
-       local.get $1
        local.get $0
        i32.load offset=4
        i32.const -4
        i32.and
+       local.get $1
        i32.or
        i32.store offset=4
        i32.const 0
@@ -913,23 +913,23 @@
      i32.and
      local.set $0
      loop $while-continue|2
-      global.get $~lib/rt/itcms/toSpace
       local.get $0
+      global.get $~lib/rt/itcms/toSpace
       i32.ne
       if
+       local.get $1
        local.get $0
        i32.load offset=4
        i32.const 3
        i32.and
-       local.get $1
        i32.ne
        if
         local.get $0
-        local.get $1
         local.get $0
         i32.load offset=4
         i32.const -4
         i32.and
+        local.get $1
         i32.or
         i32.store offset=4
         local.get $0
@@ -1085,13 +1085,13 @@
    i32.shr_u
   else
    i32.const 31
+   local.get $1
    i32.const 1
    i32.const 27
    local.get $1
    i32.clz
    i32.sub
    i32.shl
-   local.get $1
    i32.add
    i32.const 1
    i32.sub
@@ -1131,10 +1131,10 @@
    call $~lib/builtins/abort
    unreachable
   end
+  local.get $0
   local.get $2
   i32.const 2
   i32.shl
-  local.get $0
   i32.add
   i32.load offset=4
   i32.const -1
@@ -1143,6 +1143,7 @@
   i32.and
   local.tee $1
   if (result i32)
+   local.get $0
    local.get $1
    i32.ctz
    local.get $2
@@ -1151,7 +1152,6 @@
    i32.add
    i32.const 2
    i32.shl
-   local.get $0
    i32.add
    i32.load offset=96
   else
@@ -1165,12 +1165,12 @@
    i32.and
    local.tee $1
    if (result i32)
+    local.get $0
     local.get $1
     i32.ctz
     local.tee $1
     i32.const 2
     i32.shl
-    local.get $0
     i32.add
     i32.load offset=4
     local.tee $2
@@ -1183,6 +1183,7 @@
      call $~lib/builtins/abort
      unreachable
     end
+    local.get $0
     local.get $2
     i32.ctz
     local.get $1
@@ -1191,7 +1192,6 @@
     i32.add
     i32.const 2
     i32.shl
-    local.get $0
     i32.add
     i32.load offset=96
    else
@@ -1312,6 +1312,7 @@
    i32.sub
    i32.ne
    i32.shl
+   local.get $5
    i32.const 1
    i32.const 27
    local.get $5
@@ -1320,7 +1321,6 @@
    i32.shl
    i32.const 1
    i32.sub
-   local.get $5
    i32.add
    local.get $5
    local.get $5
@@ -1373,12 +1373,12 @@
     unreachable
    end
   end
+  local.get $5
   local.get $2
   i32.load
   i32.const -4
   i32.and
-  local.get $5
-  i32.lt_u
+  i32.gt_u
   if
    i32.const 0
    i32.const 1488
@@ -1416,16 +1416,16 @@
   i32.ge_u
   if
    local.get $2
+   local.get $5
    local.get $3
    i32.const 2
    i32.and
-   local.get $5
    i32.or
    i32.store
-   local.get $5
    local.get $2
    i32.const 4
    i32.add
+   local.get $5
    i32.add
    local.tee $3
    local.get $6
@@ -1469,19 +1469,19 @@
   i32.load offset=8
   local.set $3
   local.get $2
-  global.get $~lib/rt/itcms/white
   local.get $1
+  global.get $~lib/rt/itcms/white
   i32.or
   i32.store offset=4
   local.get $2
   local.get $3
   i32.store offset=8
   local.get $3
+  local.get $2
   local.get $3
   i32.load offset=4
   i32.const 3
   i32.and
-  local.get $2
   i32.or
   i32.store offset=4
   local.get $1

--- a/tests/compiler/std/array.debug.wat
+++ b/tests/compiler/std/array.debug.wat
@@ -56,8 +56,6 @@
  (global $~argumentsLength (mut i32) (i32.const 0))
  (global $~lib/math/random_state0_64 (mut i64) (i64.const 0))
  (global $~lib/math/random_state1_64 (mut i64) (i64.const 0))
- (global $~lib/math/random_state0_32 (mut i32) (i32.const 0))
- (global $~lib/math/random_state1_32 (mut i32) (i32.const 0))
  (global $~lib/math/random_seeded (mut i32) (i32.const 0))
  (global $std/array/charset i32 (i32.const 7136))
  (global $std/array/inputStabArr (mut i32) (i32.const 0))
@@ -3181,7 +3179,6 @@
   (local $3 i32)
   (local $4 i32)
   (local $5 f32)
-  (local $6 f64)
   local.get $2
   i32.eqz
   if
@@ -3235,30 +3232,46 @@
      if
       br $for-continue|0
      end
-     local.get $0
-     local.get $3
-     call $~lib/array/Array<f32>#__get
-     f64.promote_f32
-     local.set $6
-     local.get $6
-     i64.reinterpret_f64
-     i64.const 63
-     i64.shr_u
-     i64.const 0
-     i64.ne
+     block $~lib/math/NativeMath.signbit<f32>|inlined.0 (result i32)
+      local.get $0
+      local.get $3
+      call $~lib/array/Array<f32>#__get
+      local.set $5
+      i32.const 0
+      drop
+      i32.const 1
+      drop
+      i32.const 4
+      i32.const 4
+      i32.eq
+      drop
+      local.get $5
+      i32.reinterpret_f32
+      i32.const 31
+      i32.shr_u
+      br $~lib/math/NativeMath.signbit<f32>|inlined.0
+     end
      i32.const 0
      i32.ne
-     local.get $1
-     local.get $3
-     call $~lib/array/Array<f32>#__get
-     f64.promote_f32
-     local.set $6
-     local.get $6
-     i64.reinterpret_f64
-     i64.const 63
-     i64.shr_u
-     i64.const 0
-     i64.ne
+     block $~lib/math/NativeMath.signbit<f32>|inlined.1 (result i32)
+      local.get $1
+      local.get $3
+      call $~lib/array/Array<f32>#__get
+      local.set $5
+      i32.const 0
+      drop
+      i32.const 1
+      drop
+      i32.const 4
+      i32.const 4
+      i32.eq
+      drop
+      local.get $5
+      i32.reinterpret_f32
+      i32.const 31
+      i32.shr_u
+      br $~lib/math/NativeMath.signbit<f32>|inlined.1
+     end
      i32.const 0
      i32.ne
      i32.ne
@@ -5715,7 +5728,7 @@
   local.get $1
   i32.add
  )
- (func $~lib/math/murmurHash3 (param $0 i64) (result i64)
+ (func $~lib/util/math/murmurHash3 (param $0 i64) (result i64)
   local.get $0
   local.get $0
   i64.const 33
@@ -5744,41 +5757,6 @@
   local.set $0
   local.get $0
  )
- (func $~lib/math/splitMix32 (param $0 i32) (result i32)
-  local.get $0
-  i32.const 1831565813
-  i32.add
-  local.set $0
-  local.get $0
-  local.get $0
-  i32.const 15
-  i32.shr_u
-  i32.xor
-  local.get $0
-  i32.const 1
-  i32.or
-  i32.mul
-  local.set $0
-  local.get $0
-  local.get $0
-  local.get $0
-  local.get $0
-  i32.const 7
-  i32.shr_u
-  i32.xor
-  local.get $0
-  i32.const 61
-  i32.or
-  i32.mul
-  i32.add
-  i32.xor
-  local.set $0
-  local.get $0
-  local.get $0
-  i32.const 14
-  i32.shr_u
-  i32.xor
- )
  (func $~lib/math/NativeMath.seedRandom (param $0 i64)
   local.get $0
   i64.const 0
@@ -5788,20 +5766,13 @@
    local.set $0
   end
   local.get $0
-  call $~lib/math/murmurHash3
+  call $~lib/util/math/murmurHash3
   global.set $~lib/math/random_state0_64
   global.get $~lib/math/random_state0_64
   i64.const -1
   i64.xor
-  call $~lib/math/murmurHash3
+  call $~lib/util/math/murmurHash3
   global.set $~lib/math/random_state1_64
-  local.get $0
-  i32.wrap_i64
-  call $~lib/math/splitMix32
-  global.set $~lib/math/random_state0_32
-  global.get $~lib/math/random_state0_32
-  call $~lib/math/splitMix32
-  global.set $~lib/math/random_state1_32
   i32.const 1
   global.set $~lib/math/random_seeded
  )
@@ -7858,28 +7829,58 @@
      if
       br $for-continue|0
      end
-     local.get $0
-     local.get $3
-     call $~lib/array/Array<f64>#__get
-     local.set $5
-     local.get $5
-     i64.reinterpret_f64
-     i64.const 63
-     i64.shr_u
-     i64.const 0
-     i64.ne
+     block $~lib/math/NativeMath.signbit<f64>|inlined.0 (result i32)
+      local.get $0
+      local.get $3
+      call $~lib/array/Array<f64>#__get
+      local.set $5
+      i32.const 0
+      drop
+      i32.const 1
+      drop
+      i32.const 8
+      i32.const 4
+      i32.eq
+      drop
+      i32.const 8
+      i32.const 8
+      i32.eq
+      drop
+      local.get $5
+      i64.reinterpret_f64
+      i64.const 63
+      i64.shr_u
+      i64.const 0
+      i64.ne
+      br $~lib/math/NativeMath.signbit<f64>|inlined.0
+     end
      i32.const 0
      i32.ne
-     local.get $1
-     local.get $3
-     call $~lib/array/Array<f64>#__get
-     local.set $5
-     local.get $5
-     i64.reinterpret_f64
-     i64.const 63
-     i64.shr_u
-     i64.const 0
-     i64.ne
+     block $~lib/math/NativeMath.signbit<f64>|inlined.1 (result i32)
+      local.get $1
+      local.get $3
+      call $~lib/array/Array<f64>#__get
+      local.set $5
+      i32.const 0
+      drop
+      i32.const 1
+      drop
+      i32.const 8
+      i32.const 4
+      i32.eq
+      drop
+      i32.const 8
+      i32.const 8
+      i32.eq
+      drop
+      local.get $5
+      i64.reinterpret_f64
+      i64.const 63
+      i64.shr_u
+      i64.const 0
+      i64.ne
+      br $~lib/math/NativeMath.signbit<f64>|inlined.1
+     end
      i32.const 0
      i32.ne
      i32.ne
@@ -20707,19 +20708,26 @@
     local.get $5
     i32.store offset=4
     local.get $5
-    call $~lib/math/NativeMath.random
-    global.get $std/array/charset
-    local.set $5
-    global.get $~lib/memory/__stack_pointer
-    local.get $5
-    i32.store offset=8
-    local.get $5
-    call $~lib/string/String#get:length
-    f64.convert_i32_s
-    f64.mul
-    local.set $4
-    local.get $4
-    f64.floor
+    block $~lib/math/NativeMath.floor<f64>|inlined.0 (result f64)
+     call $~lib/math/NativeMath.random
+     global.get $std/array/charset
+     local.set $5
+     global.get $~lib/memory/__stack_pointer
+     local.get $5
+     i32.store offset=8
+     local.get $5
+     call $~lib/string/String#get:length
+     f64.convert_i32_s
+     f64.mul
+     local.set $4
+     i32.const 0
+     drop
+     i32.const 1
+     drop
+     local.get $4
+     f64.floor
+     br $~lib/math/NativeMath.floor<f64>|inlined.0
+    end
     i32.trunc_sat_f64_s
     call $~lib/string/String#charAt
     local.set $5

--- a/tests/compiler/std/array.release.wat
+++ b/tests/compiler/std/array.release.wat
@@ -2539,19 +2539,15 @@
      local.get $0
      local.get $2
      call $~lib/array/Array<f32>#__get
-     f64.promote_f32
-     i64.reinterpret_f64
-     i64.const 63
-     i64.shr_u
-     i32.wrap_i64
+     i32.reinterpret_f32
+     i32.const 31
+     i32.shr_u
      local.get $1
      local.get $2
      call $~lib/array/Array<f32>#__get
-     f64.promote_f32
-     i64.reinterpret_f64
-     i64.const 63
-     i64.shr_u
-     i32.wrap_i64
+     i32.reinterpret_f32
+     i32.const 31
+     i32.shr_u
      i32.ne
      if
       i32.const 0
@@ -6930,54 +6926,55 @@
   global.get $~lib/math/random_seeded
   i32.eqz
   if
-   i64.const -7046029254386353131
    call $~lib/builtins/seed
    i64.reinterpret_f64
    local.tee $0
-   local.get $0
    i64.eqz
-   select
-   local.tee $0
+   if
+    i64.const -7046029254386353131
+    local.set $0
+   end
    local.get $0
    i64.const 33
    i64.shr_u
+   local.get $0
    i64.xor
    i64.const -49064778989728563
    i64.mul
    local.tee $0
-   local.get $0
    i64.const 33
    i64.shr_u
+   local.get $0
    i64.xor
    i64.const -4265267296055464877
    i64.mul
    local.tee $0
-   local.get $0
    i64.const 33
    i64.shr_u
+   local.get $0
    i64.xor
    global.set $~lib/math/random_state0_64
    global.get $~lib/math/random_state0_64
    i64.const -1
    i64.xor
    local.tee $0
-   local.get $0
    i64.const 33
    i64.shr_u
+   local.get $0
    i64.xor
    i64.const -49064778989728563
    i64.mul
    local.tee $0
-   local.get $0
    i64.const 33
    i64.shr_u
+   local.get $0
    i64.xor
    i64.const -4265267296055464877
    i64.mul
    local.tee $0
-   local.get $0
    i64.const 33
    i64.shr_u
+   local.get $0
    i64.xor
    global.set $~lib/math/random_state1_64
    i32.const 1
@@ -6994,9 +6991,9 @@
   i64.shl
   i64.xor
   local.tee $1
-  local.get $1
   i64.const 17
   i64.shr_u
+  local.get $1
   i64.xor
   local.get $0
   i64.xor
@@ -13090,8 +13087,8 @@
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
-  (local $4 i32)
-  (local $5 i64)
+  (local $4 i64)
+  (local $5 i32)
   (local $6 f64)
   (local $7 f32)
   (local $8 i32)
@@ -22743,54 +22740,55 @@
    local.get $0
    i32.const 3
    call $~lib/array/Array<i32>#push
-   i64.const -7046029254386353131
    call $~lib/bindings/dom/Math.random
    i64.reinterpret_f64
-   local.tee $5
-   local.get $5
+   local.tee $4
    i64.eqz
-   select
-   local.tee $5
-   local.get $5
+   if
+    i64.const -7046029254386353131
+    local.set $4
+   end
+   local.get $4
    i64.const 33
    i64.shr_u
+   local.get $4
    i64.xor
    i64.const -49064778989728563
    i64.mul
-   local.tee $5
-   local.get $5
+   local.tee $4
    i64.const 33
    i64.shr_u
+   local.get $4
    i64.xor
    i64.const -4265267296055464877
    i64.mul
-   local.tee $5
-   local.get $5
+   local.tee $4
    i64.const 33
    i64.shr_u
+   local.get $4
    i64.xor
    global.set $~lib/math/random_state0_64
    global.get $~lib/math/random_state0_64
    i64.const -1
    i64.xor
-   local.tee $5
-   local.get $5
+   local.tee $4
    i64.const 33
    i64.shr_u
+   local.get $4
    i64.xor
    i64.const -49064778989728563
    i64.mul
-   local.tee $5
-   local.get $5
+   local.tee $4
    i64.const 33
    i64.shr_u
+   local.get $4
    i64.xor
    i64.const -4265267296055464877
    i64.mul
-   local.tee $5
-   local.get $5
+   local.tee $4
    i64.const 33
    i64.shr_u
+   local.get $4
    i64.xor
    global.set $~lib/math/random_state1_64
    i32.const 1
@@ -23827,13 +23825,13 @@
    local.set $1
    loop $for-loop|02
     local.get $1
-    local.get $4
+    local.get $5
     i32.gt_s
     if
      block $for-break0
       global.get $~lib/memory/__stack_pointer
       local.get $9
-      local.get $4
+      local.get $5
       call $~lib/array/Array<std/array/Ref>#__get
       local.tee $3
       i32.store offset=16
@@ -23843,7 +23841,7 @@
       i32.store
       global.get $~lib/memory/__stack_pointer
       local.get $8
-      local.get $4
+      local.get $5
       call $~lib/array/Array<std/array/Ref>#__get
       local.tee $8
       i32.store offset=20
@@ -23866,10 +23864,10 @@
        local.set $0
        br $for-break0
       end
-      local.get $4
+      local.get $5
       i32.const 1
       i32.add
-      local.set $4
+      local.set $5
       br $for-loop|02
      end
     end
@@ -23969,20 +23967,20 @@
    i32.const 32
    i32.const 0
    call $~lib/rt/itcms/__new
-   local.tee $4
+   local.tee $5
    i32.store offset=4
    local.get $3
-   local.get $4
+   local.get $5
    i32.store
-   local.get $4
+   local.get $5
    if
     local.get $3
-    local.get $4
+    local.get $5
     i32.const 0
     call $byn-split-outlined-A$~lib/rt/itcms/__link
    end
    local.get $3
-   local.get $4
+   local.get $5
    i32.store offset=4
    local.get $3
    i32.const 32
@@ -24007,9 +24005,9 @@
      global.get $~lib/memory/__stack_pointer
      i32.const 1
      call $~lib/array/Array<i32>#constructor
-     local.tee $4
+     local.tee $5
      i32.store offset=4
-     local.get $4
+     local.get $5
      i32.const 0
      i32.const 1
      local.get $0
@@ -24017,7 +24015,7 @@
      call $~lib/array/Array<i32>#__set
      local.get $3
      local.get $0
-     local.get $4
+     local.get $5
      call $~lib/array/Array<~lib/array/Array<i32>>#__set
      local.get $0
      i32.const 1
@@ -24062,25 +24060,25 @@
    i32.lt_s
    br_if $folding-inner1
    global.get $~lib/memory/__stack_pointer
-   local.tee $4
+   local.tee $5
    i64.const 0
    i64.store
-   local.get $4
+   local.get $5
    i32.const 16
    i32.const 29
    call $~lib/rt/itcms/__new
-   local.tee $4
+   local.tee $5
    i32.store
-   local.get $4
+   local.get $5
    i32.const 0
    i32.store
-   local.get $4
+   local.get $5
    i32.const 0
    i32.store offset=4
-   local.get $4
+   local.get $5
    i32.const 0
    i32.store offset=8
-   local.get $4
+   local.get $5
    i32.const 0
    i32.store offset=12
    global.get $~lib/memory/__stack_pointer
@@ -24089,23 +24087,23 @@
    call $~lib/rt/itcms/__new
    local.tee $8
    i32.store offset=4
-   local.get $4
+   local.get $5
    local.get $8
    i32.store
    local.get $8
    if
-    local.get $4
+    local.get $5
     local.get $8
     i32.const 0
     call $byn-split-outlined-A$~lib/rt/itcms/__link
    end
-   local.get $4
+   local.get $5
    local.get $8
    i32.store offset=4
-   local.get $4
+   local.get $5
    i32.const 2048
    i32.store offset=8
-   local.get $4
+   local.get $5
    i32.const 512
    i32.store offset=12
    global.get $~lib/memory/__stack_pointer
@@ -24113,7 +24111,7 @@
    i32.add
    global.set $~lib/memory/__stack_pointer
    local.get $1
-   local.get $4
+   local.get $5
    i32.store
    loop $for-loop|03
     local.get $3
@@ -24150,7 +24148,7 @@
      global.get $~lib/memory/__stack_pointer
      local.get $1
      i32.store offset=4
-     local.get $4
+     local.get $5
      local.get $3
      local.get $1
      call $~lib/array/Array<~lib/array/Array<i32>>#__set
@@ -24165,12 +24163,12 @@
    i32.const 8
    i32.add
    global.set $~lib/memory/__stack_pointer
-   local.get $4
+   local.get $5
    i32.store offset=156
    global.get $~lib/memory/__stack_pointer
    i32.const 9536
    i32.store offset=8
-   local.get $4
+   local.get $5
    i32.const 9536
    call $std/array/assertSorted<~lib/array/Array<i32>>
    global.get $~lib/memory/__stack_pointer
@@ -24187,7 +24185,7 @@
    i32.const 31
    i32.const 9776
    call $~lib/rt/__newArray
-   local.tee $4
+   local.tee $5
    i32.store offset=152
    i32.const 1
    global.set $~argumentsLength
@@ -24340,7 +24338,7 @@
     local.get $0
     i32.load offset=12
     local.tee $1
-    local.get $4
+    local.get $5
     i32.load offset=12
     i32.ne
     if
@@ -24352,7 +24350,7 @@
      br $__inlined_func$std/array/isArraysEqual<~lib/string/String|null>
     end
     local.get $0
-    local.get $4
+    local.get $5
     i32.eq
     if
      global.get $~lib/memory/__stack_pointer
@@ -24376,7 +24374,7 @@
       global.get $~lib/memory/__stack_pointer
       local.get $8
       i32.store
-      local.get $4
+      local.get $5
       local.get $3
       call $~lib/array/Array<std/array/Ref|null>#__get
       local.set $9
@@ -24492,7 +24490,7 @@
     local.get $0
     i32.const 1
     i32.sub
-    local.tee $4
+    local.tee $5
     i32.const 0
     i32.lt_s
     if
@@ -24504,7 +24502,7 @@
      local.set $0
      br $__inlined_func$~lib/util/string/joinBooleanArray
     end
-    local.get $4
+    local.get $5
     i32.eqz
     if
      i32.const 9920
@@ -24527,7 +24525,7 @@
     local.tee $8
     i32.const 5
     i32.add
-    local.get $4
+    local.get $5
     i32.mul
     i32.const 5
     i32.add
@@ -24542,7 +24540,7 @@
     local.set $0
     loop $for-loop|155
      local.get $2
-     local.get $4
+     local.get $5
      i32.lt_s
      if
       local.get $2
@@ -24596,7 +24594,7 @@
      end
     end
     local.get $3
-    local.get $4
+    local.get $5
     i32.add
     i32.load8_u
     local.tee $2
@@ -25168,7 +25166,7 @@
     local.get $0
     i32.const 1
     i32.sub
-    local.tee $4
+    local.tee $5
     i32.const 0
     i32.lt_s
     if
@@ -25180,7 +25178,7 @@
      local.set $0
      br $__inlined_func$~lib/util/string/joinIntegerArray<u16>
     end
-    local.get $4
+    local.get $5
     i32.eqz
     if
      local.get $3
@@ -25201,7 +25199,7 @@
     local.tee $8
     i32.const 10
     i32.add
-    local.get $4
+    local.get $5
     i32.mul
     i32.const 10
     i32.add
@@ -25216,7 +25214,7 @@
     local.set $0
     loop $for-loop|056
      local.get $2
-     local.get $4
+     local.get $5
      i32.lt_s
      if
       local.get $1
@@ -25264,7 +25262,7 @@
     i32.shl
     i32.add
     local.get $3
-    local.get $4
+    local.get $5
     i32.const 1
     i32.shl
     i32.add
@@ -25363,7 +25361,7 @@
     local.get $0
     i32.const 1
     i32.sub
-    local.tee $4
+    local.tee $5
     i32.const 0
     i32.lt_s
     if
@@ -25375,7 +25373,7 @@
      local.set $0
      br $__inlined_func$~lib/util/string/joinIntegerArray<i16>
     end
-    local.get $4
+    local.get $5
     i32.eqz
     if
      local.get $3
@@ -25396,7 +25394,7 @@
     local.tee $8
     i32.const 11
     i32.add
-    local.get $4
+    local.get $5
     i32.mul
     i32.const 11
     i32.add
@@ -25411,7 +25409,7 @@
     local.set $0
     loop $for-loop|057
      local.get $2
-     local.get $4
+     local.get $5
      i32.lt_s
      if
       local.get $1
@@ -25459,7 +25457,7 @@
     i32.shl
     i32.add
     local.get $3
-    local.get $4
+    local.get $5
     i32.const 1
     i32.shl
     i32.add
@@ -25816,7 +25814,7 @@
     i32.load
     i32.const 1
     i32.shr_u
-    local.set $4
+    local.set $5
     loop $for-loop|058
      local.get $1
      local.get $2
@@ -25846,7 +25844,7 @@
        local.tee $0
        i32.store offset=4
       end
-      local.get $4
+      local.get $5
       if
        global.get $~lib/memory/__stack_pointer
        local.get $0
@@ -26030,7 +26028,7 @@
     i32.load
     i32.const 1
     i32.shr_u
-    local.set $4
+    local.set $5
     loop $for-loop|059
      local.get $1
      local.get $2
@@ -26060,7 +26058,7 @@
        local.tee $0
        i32.store offset=4
       end
-      local.get $4
+      local.get $5
       if
        global.get $~lib/memory/__stack_pointer
        local.get $0
@@ -26252,7 +26250,7 @@
     i32.load
     i32.const 1
     i32.shr_u
-    local.set $4
+    local.set $5
     loop $for-loop|060
      local.get $1
      local.get $2
@@ -26282,7 +26280,7 @@
        local.tee $0
        i32.store offset=4
       end
-      local.get $4
+      local.get $5
       if
        global.get $~lib/memory/__stack_pointer
        local.get $0
@@ -26814,9 +26812,9 @@
    i32.const 26
    i32.const 0
    call $~lib/rt/__newArray
-   local.tee $4
+   local.tee $5
    i32.store
-   local.get $4
+   local.get $5
    i32.load offset=4
    local.set $8
    i32.const 0
@@ -26863,7 +26861,7 @@
      i32.store
      local.get $9
      if
-      local.get $4
+      local.get $5
       local.get $9
       i32.const 1
       call $byn-split-outlined-A$~lib/rt/itcms/__link
@@ -26880,9 +26878,9 @@
    i32.add
    global.set $~lib/memory/__stack_pointer
    global.get $~lib/memory/__stack_pointer
-   local.get $4
+   local.get $5
    i32.store
-   local.get $4
+   local.get $5
    call $~lib/array/Array<~lib/array/Array<i32>>#flat
    local.tee $0
    i32.store offset=144

--- a/tests/compiler/std/math.debug.wat
+++ b/tests/compiler/std/math.debug.wat
@@ -7,24 +7,21 @@
  (type $f64_f64_f64_f64_i32_=>_i32 (func (param f64 f64 f64 f64 i32) (result i32)))
  (type $f32_f32_f32_f32_i32_=>_i32 (func (param f32 f32 f32 f32 i32) (result i32)))
  (type $f32_f32_=>_f32 (func (param f32 f32) (result f32)))
- (type $none_=>_f64 (func (result f64)))
  (type $f64_=>_i32 (func (param f64) (result i32)))
+ (type $none_=>_f64 (func (result f64)))
  (type $none_=>_none (func))
  (type $f64_i32_=>_f64 (func (param f64 i32) (result f64)))
  (type $f64_f64_f64_=>_f64 (func (param f64 f64 f64) (result f64)))
  (type $i32_i32_i32_i32_=>_none (func (param i32 i32 i32 i32)))
- (type $f32_=>_i32 (func (param f32) (result i32)))
- (type $f32_i32_=>_f32 (func (param f32 i32) (result f32)))
- (type $f32_f32_f32_=>_f32 (func (param f32 f32 f32) (result f32)))
  (type $f64_i32_f64_f64_i32_=>_i32 (func (param f64 i32 f64 f64 i32) (result i32)))
+ (type $f32_i32_=>_f32 (func (param f32 i32) (result f32)))
+ (type $f32_=>_i32 (func (param f32) (result i32)))
+ (type $f32_f32_f32_=>_f32 (func (param f32 f32 f32) (result f32)))
  (type $f32_i32_f32_f32_i32_=>_i32 (func (param f32 i32 f32 f32 i32) (result i32)))
  (type $f64_i64_=>_i32 (func (param f64 i64) (result i32)))
  (type $i64_=>_i64 (func (param i64) (result i64)))
- (type $i32_=>_i32 (func (param i32) (result i32)))
  (type $i64_=>_none (func (param i64)))
- (type $none_=>_f32 (func (result f32)))
  (type $f64_f64_i32_=>_f64 (func (param f64 f64 i32) (result f64)))
- (type $f64_=>_none (func (param f64)))
  (type $i64_i64_i64_i64_i64_i32_=>_i32 (func (param i64 i64 i64 i64 i64 i32) (result i32)))
  (type $i64_i64_=>_i64 (func (param i64 i64) (result i64)))
  (type $i32_i32_=>_i32 (func (param i32 i32) (result i32)))
@@ -77,33 +74,25 @@
  (global $std/math/kPI f64 (f64.const 3.141592653589793))
  (global $std/math/kTwo120 f64 (f64.const 1329227995784915872903807e12))
  (global $~lib/math/NativeMath.E f64 (f64.const 2.718281828459045))
- (global $~lib/math/NativeMathf.E f32 (f32.const 2.7182817459106445))
  (global $~lib/math/NativeMath.LN2 f64 (f64.const 0.6931471805599453))
  (global $~lib/math/NativeMath.LN10 f64 (f64.const 2.302585092994046))
  (global $~lib/math/NativeMath.LOG2E f64 (f64.const 1.4426950408889634))
  (global $~lib/math/NativeMath.PI f64 (f64.const 3.141592653589793))
  (global $~lib/math/NativeMath.SQRT1_2 f64 (f64.const 0.7071067811865476))
  (global $~lib/math/NativeMath.SQRT2 f64 (f64.const 1.4142135623730951))
- (global $~lib/math/NativeMathf.LN2 f32 (f32.const 0.6931471824645996))
- (global $~lib/math/NativeMathf.LN10 f32 (f32.const 2.3025851249694824))
- (global $~lib/math/NativeMathf.LOG2E f32 (f32.const 1.4426950216293335))
- (global $~lib/math/NativeMathf.PI f32 (f32.const 3.1415927410125732))
- (global $~lib/math/NativeMathf.SQRT1_2 f32 (f32.const 0.7071067690849304))
- (global $~lib/math/NativeMathf.SQRT2 f32 (f32.const 1.4142135381698608))
  (global $~lib/native/ASC_SHRINK_LEVEL i32 (i32.const 0))
- (global $~lib/math/rempio2_y0 (mut f64) (f64.const 0))
- (global $~lib/math/rempio2_y1 (mut f64) (f64.const 0))
- (global $~lib/math/res128_hi (mut i64) (i64.const 0))
- (global $~lib/math/rempio2f_y (mut f64) (f64.const 0))
+ (global $~lib/util/math/rempio2_y0 (mut f64) (f64.const 0))
+ (global $~lib/util/math/rempio2_y1 (mut f64) (f64.const 0))
+ (global $~lib/util/math/res128_hi (mut i64) (i64.const 0))
+ (global $~lib/util/math/rempio2_32_y (mut f64) (f64.const 0))
  (global $~lib/builtins/f32.MAX_VALUE f32 (f32.const 3402823466385288598117041e14))
  (global $~lib/builtins/f64.MIN_VALUE f64 (f64.const 5e-324))
  (global $~lib/util/math/log_tail (mut f64) (f64.const 0))
  (global $~lib/math/random_state0_64 (mut i64) (i64.const 0))
  (global $~lib/math/random_state1_64 (mut i64) (i64.const 0))
- (global $~lib/math/random_state0_32 (mut i32) (i32.const 0))
- (global $~lib/math/random_state1_32 (mut i32) (i32.const 0))
  (global $~lib/math/random_seeded (mut i32) (i32.const 0))
  (global $~lib/math/NativeMath.sincos_sin (mut f64) (f64.const 0))
+ (global $~lib/util/math/sincos_cos64 (mut f64) (f64.const 0))
  (global $~lib/math/NativeMath.sincos_cos (mut f64) (f64.const 0))
  (global $~lib/builtins/f64.MAX_VALUE f64 (f64.const 1797693134862315708145274e284))
  (global $~lib/builtins/f64.MAX_SAFE_INTEGER f64 (f64.const 9007199254740991))
@@ -155,7 +144,7 @@
   i32.const 52
   i32.sub
  )
- (func $~lib/math/NativeMath.scalbn (param $0 f64) (param $1 i32) (result f64)
+ (func $~lib/util/math/scalbn64 (param $0 f64) (param $1 i32) (result f64)
   (local $2 f64)
   (local $3 i32)
   (local $4 i32)
@@ -266,24 +255,54 @@
   local.get $1
   f64.eq
   if
-   local.get $0
-   local.set $3
-   local.get $3
-   i64.reinterpret_f64
-   i64.const 63
-   i64.shr_u
-   i64.const 0
-   i64.ne
+   block $~lib/math/NativeMath.signbit<f64>|inlined.0 (result i32)
+    local.get $0
+    local.set $3
+    i32.const 0
+    drop
+    i32.const 1
+    drop
+    i32.const 8
+    i32.const 4
+    i32.eq
+    drop
+    i32.const 8
+    i32.const 8
+    i32.eq
+    drop
+    local.get $3
+    i64.reinterpret_f64
+    i64.const 63
+    i64.shr_u
+    i64.const 0
+    i64.ne
+    br $~lib/math/NativeMath.signbit<f64>|inlined.0
+   end
    i32.const 0
    i32.ne
-   local.get $1
-   local.set $3
-   local.get $3
-   i64.reinterpret_f64
-   i64.const 63
-   i64.shr_u
-   i64.const 0
-   i64.ne
+   block $~lib/math/NativeMath.signbit<f64>|inlined.1 (result i32)
+    local.get $1
+    local.set $3
+    i32.const 0
+    drop
+    i32.const 1
+    drop
+    i32.const 8
+    i32.const 4
+    i32.eq
+    drop
+    i32.const 8
+    i32.const 8
+    i32.eq
+    drop
+    local.get $3
+    i64.reinterpret_f64
+    i64.const 63
+    i64.shr_u
+    i64.const 0
+    i64.ne
+    br $~lib/math/NativeMath.signbit<f64>|inlined.1
+   end
    i32.const 0
    i32.ne
    i32.eq
@@ -317,7 +336,7 @@
   local.get $1
   call $std/math/eulp
   i32.sub
-  call $~lib/math/NativeMath.scalbn
+  call $~lib/util/math/scalbn64
   local.get $2
   f64.add
  )
@@ -358,33 +377,16 @@
   end
   i32.const 1
  )
- (func $std/math/eulpf (param $0 f32) (result i32)
-  (local $1 i32)
-  (local $2 i32)
+ (func $std/math/test_scalbn (param $0 f64) (param $1 i32) (param $2 f64) (param $3 f64) (param $4 i32) (result i32)
   local.get $0
-  i32.reinterpret_f32
-  local.set $1
   local.get $1
-  i32.const 23
-  i32.shr_u
-  i32.const 255
-  i32.and
-  local.set $2
+  call $~lib/util/math/scalbn64
   local.get $2
-  i32.eqz
-  if
-   local.get $2
-   i32.const 1
-   i32.add
-   local.set $2
-  end
-  local.get $2
-  i32.const 127
-  i32.sub
-  i32.const 23
-  i32.sub
+  local.get $3
+  local.get $4
+  call $std/math/check<f64>
  )
- (func $~lib/math/NativeMathf.scalbn (param $0 f32) (param $1 i32) (result f32)
+ (func $~lib/util/math/scalbn32 (param $0 f32) (param $1 i32) (result f32)
   (local $2 f32)
   (local $3 i32)
   (local $4 i32)
@@ -474,6 +476,32 @@
   f32.reinterpret_i32
   f32.mul
  )
+ (func $std/math/eulpf (param $0 f32) (result i32)
+  (local $1 i32)
+  (local $2 i32)
+  local.get $0
+  i32.reinterpret_f32
+  local.set $1
+  local.get $1
+  i32.const 23
+  i32.shr_u
+  i32.const 255
+  i32.and
+  local.set $2
+  local.get $2
+  i32.eqz
+  if
+   local.get $2
+   i32.const 1
+   i32.add
+   local.set $2
+  end
+  local.get $2
+  i32.const 127
+  i32.sub
+  i32.const 23
+  i32.sub
+ )
  (func $std/math/ulperrf (param $0 f32) (param $1 f32) (param $2 f32) (result f32)
   (local $3 f32)
   local.get $0
@@ -494,20 +522,42 @@
   local.get $1
   f32.eq
   if
-   local.get $0
-   local.set $3
-   local.get $3
-   i32.reinterpret_f32
-   i32.const 31
-   i32.shr_u
+   block $~lib/math/NativeMath.signbit<f32>|inlined.0 (result i32)
+    local.get $0
+    local.set $3
+    i32.const 0
+    drop
+    i32.const 1
+    drop
+    i32.const 4
+    i32.const 4
+    i32.eq
+    drop
+    local.get $3
+    i32.reinterpret_f32
+    i32.const 31
+    i32.shr_u
+    br $~lib/math/NativeMath.signbit<f32>|inlined.0
+   end
    i32.const 0
    i32.ne
-   local.get $1
-   local.set $3
-   local.get $3
-   i32.reinterpret_f32
-   i32.const 31
-   i32.shr_u
+   block $~lib/math/NativeMath.signbit<f32>|inlined.1 (result i32)
+    local.get $1
+    local.set $3
+    i32.const 0
+    drop
+    i32.const 1
+    drop
+    i32.const 4
+    i32.const 4
+    i32.eq
+    drop
+    local.get $3
+    i32.reinterpret_f32
+    i32.const 31
+    i32.shr_u
+    br $~lib/math/NativeMath.signbit<f32>|inlined.1
+   end
    i32.const 0
    i32.ne
    i32.eq
@@ -541,7 +591,7 @@
   local.get $1
   call $std/math/eulpf
   i32.sub
-  call $~lib/math/NativeMathf.scalbn
+  call $~lib/util/math/scalbn32
   local.get $2
   f32.add
  )
@@ -586,19 +636,10 @@
   end
   i32.const 1
  )
- (func $std/math/test_scalbn (param $0 f64) (param $1 i32) (param $2 f64) (param $3 f64) (param $4 i32) (result i32)
-  local.get $0
-  local.get $1
-  call $~lib/math/NativeMath.scalbn
-  local.get $2
-  local.get $3
-  local.get $4
-  call $std/math/check<f64>
- )
  (func $std/math/test_scalbnf (param $0 f32) (param $1 i32) (param $2 f32) (param $3 f32) (param $4 i32) (result i32)
   local.get $0
   local.get $1
-  call $~lib/math/NativeMathf.scalbn
+  call $~lib/util/math/scalbn32
   local.get $2
   local.get $3
   local.get $4
@@ -636,7 +677,7 @@
   local.get $3
   call $std/math/check<f32>
  )
- (func $~lib/math/R (param $0 f64) (result f64)
+ (func $~lib/util/math/R64 (param $0 f64) (result f64)
   (local $1 f64)
   (local $2 f64)
   local.get $0
@@ -685,7 +726,7 @@
   local.get $2
   f64.div
  )
- (func $~lib/math/NativeMath.acos (param $0 f64) (result f64)
+ (func $~lib/util/math/acos64 (param $0 f64) (result f64)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -763,7 +804,7 @@
    local.get $0
    local.get $0
    f64.mul
-   call $~lib/math/R
+   call $~lib/util/math/R64
    f64.mul
    f64.sub
    f64.sub
@@ -784,7 +825,7 @@
    f64.sqrt
    local.set $4
    local.get $6
-   call $~lib/math/R
+   call $~lib/util/math/R64
    local.get $4
    f64.mul
    f64.const 6.123233995736766e-17
@@ -825,7 +866,7 @@
   f64.div
   local.set $8
   local.get $6
-  call $~lib/math/R
+  call $~lib/util/math/R64
   local.get $4
   f64.mul
   local.get $8
@@ -838,8 +879,24 @@
   f64.mul
  )
  (func $std/math/test_acos (param $0 f64) (param $1 f64) (param $2 f64) (param $3 i32) (result i32)
-  local.get $0
-  call $~lib/math/NativeMath.acos
+  (local $4 f64)
+  block $~lib/math/NativeMath.acos<f64>|inlined.0 (result f64)
+   local.get $0
+   local.set $4
+   i32.const 1
+   drop
+   i32.const 8
+   i32.const 4
+   i32.eq
+   drop
+   i32.const 8
+   i32.const 8
+   i32.eq
+   drop
+   local.get $4
+   call $~lib/util/math/acos64
+   br $~lib/math/NativeMath.acos<f64>|inlined.0
+  end
   local.get $1
   local.get $2
   local.get $3
@@ -855,7 +912,7 @@
    i32.const 0
   end
  )
- (func $~lib/math/Rf (param $0 f32) (result f32)
+ (func $~lib/util/math/R32 (param $0 f32) (result f32)
   (local $1 f32)
   (local $2 f32)
   local.get $0
@@ -880,7 +937,7 @@
   local.get $2
   f32.div
  )
- (func $~lib/math/NativeMathf.acos (param $0 f32) (result f32)
+ (func $~lib/util/math/acos32 (param $0 f32) (result f32)
   (local $1 i32)
   (local $2 i32)
   (local $3 f32)
@@ -944,7 +1001,7 @@
    local.get $0
    local.get $0
    f32.mul
-   call $~lib/math/Rf
+   call $~lib/util/math/R32
    f32.mul
    f32.sub
    f32.sub
@@ -965,7 +1022,7 @@
    f32.sqrt
    local.set $5
    local.get $3
-   call $~lib/math/Rf
+   call $~lib/util/math/R32
    local.get $5
    f32.mul
    f32.const 7.549789415861596e-08
@@ -1008,7 +1065,7 @@
   f32.div
   local.set $7
   local.get $3
-  call $~lib/math/Rf
+  call $~lib/util/math/R32
   local.get $5
   f32.mul
   local.get $7
@@ -1021,14 +1078,26 @@
   f32.mul
  )
  (func $std/math/test_acosf (param $0 f32) (param $1 f32) (param $2 f32) (param $3 i32) (result i32)
-  local.get $0
-  call $~lib/math/NativeMathf.acos
+  (local $4 f32)
+  block $~lib/math/NativeMath.acos<f32>|inlined.0 (result f32)
+   local.get $0
+   local.set $4
+   i32.const 1
+   drop
+   i32.const 4
+   i32.const 4
+   i32.eq
+   drop
+   local.get $4
+   call $~lib/util/math/acos32
+   br $~lib/math/NativeMath.acos<f32>|inlined.0
+  end
   local.get $1
   local.get $2
   local.get $3
   call $std/math/check<f32>
  )
- (func $~lib/math/NativeMath.log1p (param $0 f64) (result f64)
+ (func $~lib/util/math/log1p64 (param $0 f64) (result f64)
   (local $1 i64)
   (local $2 i32)
   (local $3 i32)
@@ -1272,7 +1341,7 @@
   f64.mul
   f64.add
  )
- (func $~lib/math/NativeMath.log (param $0 f64) (result f64)
+ (func $~lib/util/math/log64 (param $0 f64) (result f64)
   (local $1 f64)
   (local $2 i64)
   (local $3 f64)
@@ -1295,7 +1364,7 @@
   i32.const 1
   i32.lt_s
   drop
-  block $~lib/util/math/log_lut|inlined.0 (result f64)
+  block $~lib/util/math/log64_lut|inlined.0 (result f64)
    local.get $0
    local.set $1
    local.get $1
@@ -1406,7 +1475,7 @@
     f64.add
     local.get $10
     f64.add
-    br $~lib/util/math/log_lut|inlined.0
+    br $~lib/util/math/log64_lut|inlined.0
    end
    local.get $2
    i64.const 48
@@ -1432,7 +1501,7 @@
      local.get $1
      f64.mul
      f64.div
-     br $~lib/util/math/log_lut|inlined.0
+     br $~lib/util/math/log64_lut|inlined.0
     end
     local.get $2
     f64.const inf
@@ -1440,7 +1509,7 @@
     i64.eq
     if
      local.get $1
-     br $~lib/util/math/log_lut|inlined.0
+     br $~lib/util/math/log64_lut|inlined.0
     end
     local.get $12
     i32.const 32768
@@ -1462,7 +1531,7 @@
      local.get $1
      f64.sub
      f64.div
-     br $~lib/util/math/log_lut|inlined.0
+     br $~lib/util/math/log64_lut|inlined.0
     end
     local.get $1
     f64.const 4503599627370496
@@ -1605,7 +1674,7 @@
   end
   return
  )
- (func $~lib/math/NativeMath.acosh (param $0 f64) (result f64)
+ (func $~lib/util/math/acosh64 (param $0 f64) (result f64)
   (local $1 i64)
   (local $2 i64)
   local.get $0
@@ -1652,7 +1721,7 @@
    f64.add
    f64.sqrt
    f64.add
-   call $~lib/math/NativeMath.log1p
+   call $~lib/util/math/log1p64
    return
   end
   local.get $2
@@ -1675,17 +1744,33 @@
    f64.add
    f64.div
    f64.sub
-   call $~lib/math/NativeMath.log
+   call $~lib/util/math/log64
    return
   end
   local.get $0
-  call $~lib/math/NativeMath.log
+  call $~lib/util/math/log64
   f64.const 0.6931471805599453
   f64.add
  )
  (func $std/math/test_acosh (param $0 f64) (param $1 f64) (param $2 f64) (param $3 i32) (result i32)
-  local.get $0
-  call $~lib/math/NativeMath.acosh
+  (local $4 f64)
+  block $~lib/math/NativeMath.acosh<f64>|inlined.0 (result f64)
+   local.get $0
+   local.set $4
+   i32.const 1
+   drop
+   i32.const 8
+   i32.const 4
+   i32.eq
+   drop
+   i32.const 8
+   i32.const 8
+   i32.eq
+   drop
+   local.get $4
+   call $~lib/util/math/acosh64
+   br $~lib/math/NativeMath.acosh<f64>|inlined.0
+  end
   local.get $1
   local.get $2
   local.get $3
@@ -1701,7 +1786,7 @@
    i32.const 0
   end
  )
- (func $~lib/math/NativeMathf.log1p (param $0 f32) (result f32)
+ (func $~lib/util/math/log1p32 (param $0 f32) (result f32)
   (local $1 i32)
   (local $2 f32)
   (local $3 f32)
@@ -1912,7 +1997,7 @@
   f32.mul
   f32.add
  )
- (func $~lib/math/NativeMathf.log (param $0 f32) (result f32)
+ (func $~lib/util/math/log32 (param $0 f32) (result f32)
   (local $1 f32)
   (local $2 i32)
   (local $3 i32)
@@ -2083,7 +2168,7 @@
   end
   return
  )
- (func $~lib/math/NativeMathf.acosh (param $0 f32) (result f32)
+ (func $~lib/util/math/acosh32 (param $0 f32) (result f32)
   (local $1 i32)
   (local $2 i32)
   (local $3 f32)
@@ -2114,7 +2199,7 @@
    f32.mul
    f32.sqrt
    f32.add
-   call $~lib/math/NativeMathf.log1p
+   call $~lib/util/math/log1p32
    return
   end
   local.get $1
@@ -2139,23 +2224,35 @@
    f32.add
    f32.div
    f32.sub
-   call $~lib/math/NativeMathf.log
+   call $~lib/util/math/log32
    return
   end
   local.get $0
-  call $~lib/math/NativeMathf.log
+  call $~lib/util/math/log32
   f32.const 0.6931471824645996
   f32.add
  )
  (func $std/math/test_acoshf (param $0 f32) (param $1 f32) (param $2 f32) (param $3 i32) (result i32)
-  local.get $0
-  call $~lib/math/NativeMathf.acosh
+  (local $4 f32)
+  block $~lib/math/NativeMath.acosh<f32>|inlined.0 (result f32)
+   local.get $0
+   local.set $4
+   i32.const 1
+   drop
+   i32.const 4
+   i32.const 4
+   i32.eq
+   drop
+   local.get $4
+   call $~lib/util/math/acosh32
+   br $~lib/math/NativeMath.acosh<f32>|inlined.0
+  end
   local.get $1
   local.get $2
   local.get $3
   call $std/math/check<f32>
  )
- (func $~lib/math/NativeMath.asin (param $0 f64) (result f64)
+ (func $~lib/util/math/asin64 (param $0 f64) (result f64)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -2228,7 +2325,7 @@
    local.get $0
    local.get $0
    f64.mul
-   call $~lib/math/R
+   call $~lib/util/math/R64
    f64.mul
    f64.add
    return
@@ -2244,7 +2341,7 @@
   f64.sqrt
   local.set $5
   local.get $4
-  call $~lib/math/R
+  call $~lib/util/math/R64
   local.set $6
   local.get $2
   i32.const 1072640819
@@ -2315,8 +2412,24 @@
   local.get $0
  )
  (func $std/math/test_asin (param $0 f64) (param $1 f64) (param $2 f64) (param $3 i32) (result i32)
-  local.get $0
-  call $~lib/math/NativeMath.asin
+  (local $4 f64)
+  block $~lib/math/NativeMath.asin<f64>|inlined.0 (result f64)
+   local.get $0
+   local.set $4
+   i32.const 1
+   drop
+   i32.const 8
+   i32.const 4
+   i32.eq
+   drop
+   i32.const 8
+   i32.const 8
+   i32.eq
+   drop
+   local.get $4
+   call $~lib/util/math/asin64
+   br $~lib/math/NativeMath.asin<f64>|inlined.0
+  end
   local.get $1
   local.get $2
   local.get $3
@@ -2332,7 +2445,7 @@
    i32.const 0
   end
  )
- (func $~lib/math/NativeMathf.asin (param $0 f32) (result f32)
+ (func $~lib/util/math/asin32 (param $0 f32) (result f32)
   (local $1 f32)
   (local $2 i32)
   (local $3 f32)
@@ -2389,7 +2502,7 @@
    local.get $0
    local.get $0
    f32.mul
-   call $~lib/math/Rf
+   call $~lib/util/math/R32
    f32.mul
    f32.add
    return
@@ -2412,7 +2525,7 @@
   local.get $4
   local.get $4
   local.get $3
-  call $~lib/math/Rf
+  call $~lib/util/math/R32
   f64.promote_f32
   f64.mul
   f64.add
@@ -2425,14 +2538,26 @@
   f32.copysign
  )
  (func $std/math/test_asinf (param $0 f32) (param $1 f32) (param $2 f32) (param $3 i32) (result i32)
-  local.get $0
-  call $~lib/math/NativeMathf.asin
+  (local $4 f32)
+  block $~lib/math/NativeMath.asin<f32>|inlined.0 (result f32)
+   local.get $0
+   local.set $4
+   i32.const 1
+   drop
+   i32.const 4
+   i32.const 4
+   i32.eq
+   drop
+   local.get $4
+   call $~lib/util/math/asin32
+   br $~lib/math/NativeMath.asin<f32>|inlined.0
+  end
   local.get $1
   local.get $2
   local.get $3
   call $std/math/check<f32>
  )
- (func $~lib/math/NativeMath.asinh (param $0 f64) (result f64)
+ (func $~lib/util/math/asinh64 (param $0 f64) (result f64)
   (local $1 i64)
   (local $2 i64)
   (local $3 f64)
@@ -2457,7 +2582,7 @@
   i64.ge_u
   if
    local.get $3
-   call $~lib/math/NativeMath.log
+   call $~lib/util/math/log64
    f64.const 0.6931471805599453
    f64.add
    local.set $3
@@ -2482,7 +2607,7 @@
     f64.add
     f64.div
     f64.add
-    call $~lib/math/NativeMath.log
+    call $~lib/util/math/log64
     local.set $3
    else
     local.get $2
@@ -2505,7 +2630,7 @@
      f64.add
      f64.div
      f64.add
-     call $~lib/math/NativeMath.log1p
+     call $~lib/util/math/log1p64
      local.set $3
     end
    end
@@ -2515,8 +2640,24 @@
   f64.copysign
  )
  (func $std/math/test_asinh (param $0 f64) (param $1 f64) (param $2 f64) (param $3 i32) (result i32)
-  local.get $0
-  call $~lib/math/NativeMath.asinh
+  (local $4 f64)
+  block $~lib/math/NativeMath.asinh<f64>|inlined.0 (result f64)
+   local.get $0
+   local.set $4
+   i32.const 1
+   drop
+   i32.const 8
+   i32.const 4
+   i32.eq
+   drop
+   i32.const 8
+   i32.const 8
+   i32.eq
+   drop
+   local.get $4
+   call $~lib/util/math/asinh64
+   br $~lib/math/NativeMath.asinh<f64>|inlined.0
+  end
   local.get $1
   local.get $2
   local.get $3
@@ -2532,7 +2673,7 @@
    i32.const 0
   end
  )
- (func $~lib/math/NativeMathf.asinh (param $0 f32) (result f32)
+ (func $~lib/util/math/asinh32 (param $0 f32) (result f32)
   (local $1 i32)
   (local $2 f32)
   local.get $0
@@ -2552,7 +2693,7 @@
   i32.ge_u
   if
    local.get $2
-   call $~lib/math/NativeMathf.log
+   call $~lib/util/math/log32
    f32.const 0.6931471824645996
    f32.add
    local.set $2
@@ -2579,7 +2720,7 @@
     f32.add
     f32.div
     f32.add
-    call $~lib/math/NativeMathf.log
+    call $~lib/util/math/log32
     local.set $2
    else
     local.get $1
@@ -2604,7 +2745,7 @@
      f32.add
      f32.div
      f32.add
-     call $~lib/math/NativeMathf.log1p
+     call $~lib/util/math/log1p32
      local.set $2
     end
    end
@@ -2614,14 +2755,26 @@
   f32.copysign
  )
  (func $std/math/test_asinhf (param $0 f32) (param $1 f32) (param $2 f32) (param $3 i32) (result i32)
-  local.get $0
-  call $~lib/math/NativeMathf.asinh
+  (local $4 f32)
+  block $~lib/math/NativeMath.asinh<f32>|inlined.0 (result f32)
+   local.get $0
+   local.set $4
+   i32.const 1
+   drop
+   i32.const 4
+   i32.const 4
+   i32.eq
+   drop
+   local.get $4
+   call $~lib/util/math/asinh32
+   br $~lib/math/NativeMath.asinh<f32>|inlined.0
+  end
   local.get $1
   local.get $2
   local.get $3
   call $std/math/check<f32>
  )
- (func $~lib/math/NativeMath.atan (param $0 f64) (result f64)
+ (func $~lib/util/math/atan64 (param $0 f64) (result f64)
   (local $1 i32)
   (local $2 f64)
   (local $3 f64)
@@ -2880,8 +3033,24 @@
   f64.copysign
  )
  (func $std/math/test_atan (param $0 f64) (param $1 f64) (param $2 f64) (param $3 i32) (result i32)
-  local.get $0
-  call $~lib/math/NativeMath.atan
+  (local $4 f64)
+  block $~lib/math/NativeMath.atan<f64>|inlined.0 (result f64)
+   local.get $0
+   local.set $4
+   i32.const 1
+   drop
+   i32.const 8
+   i32.const 4
+   i32.eq
+   drop
+   i32.const 8
+   i32.const 8
+   i32.eq
+   drop
+   local.get $4
+   call $~lib/util/math/atan64
+   br $~lib/math/NativeMath.atan<f64>|inlined.0
+  end
   local.get $1
   local.get $2
   local.get $3
@@ -2897,7 +3066,7 @@
    i32.const 0
   end
  )
- (func $~lib/math/NativeMathf.atan (param $0 f32) (result f32)
+ (func $~lib/util/math/atan32 (param $0 f32) (result f32)
   (local $1 i32)
   (local $2 f32)
   (local $3 f32)
@@ -3128,14 +3297,26 @@
   f32.copysign
  )
  (func $std/math/test_atanf (param $0 f32) (param $1 f32) (param $2 f32) (param $3 i32) (result i32)
-  local.get $0
-  call $~lib/math/NativeMathf.atan
+  (local $4 f32)
+  block $~lib/math/NativeMath.atan<f32>|inlined.0 (result f32)
+   local.get $0
+   local.set $4
+   i32.const 1
+   drop
+   i32.const 4
+   i32.const 4
+   i32.eq
+   drop
+   local.get $4
+   call $~lib/util/math/atan32
+   br $~lib/math/NativeMath.atan<f32>|inlined.0
+  end
   local.get $1
   local.get $2
   local.get $3
   call $std/math/check<f32>
  )
- (func $~lib/math/NativeMath.atanh (param $0 f64) (result f64)
+ (func $~lib/util/math/atanh64 (param $0 f64) (result f64)
   (local $1 i64)
   (local $2 i64)
   (local $3 f64)
@@ -3177,7 +3358,7 @@
     f64.sub
     f64.div
     f64.add
-    call $~lib/math/NativeMath.log1p
+    call $~lib/util/math/log1p64
     f64.mul
     local.set $3
    end
@@ -3190,7 +3371,7 @@
    f64.sub
    f64.div
    f64.mul
-   call $~lib/math/NativeMath.log1p
+   call $~lib/util/math/log1p64
    f64.mul
    local.set $3
   end
@@ -3199,8 +3380,24 @@
   f64.copysign
  )
  (func $std/math/test_atanh (param $0 f64) (param $1 f64) (param $2 f64) (param $3 i32) (result i32)
-  local.get $0
-  call $~lib/math/NativeMath.atanh
+  (local $4 f64)
+  block $~lib/math/NativeMath.atanh<f64>|inlined.0 (result f64)
+   local.get $0
+   local.set $4
+   i32.const 1
+   drop
+   i32.const 8
+   i32.const 4
+   i32.eq
+   drop
+   i32.const 8
+   i32.const 8
+   i32.eq
+   drop
+   local.get $4
+   call $~lib/util/math/atanh64
+   br $~lib/math/NativeMath.atanh<f64>|inlined.0
+  end
   local.get $1
   local.get $2
   local.get $3
@@ -3216,7 +3413,7 @@
    i32.const 0
   end
  )
- (func $~lib/math/NativeMathf.atanh (param $0 f32) (result f32)
+ (func $~lib/util/math/atanh32 (param $0 f32) (result f32)
   (local $1 i32)
   (local $2 f32)
   local.get $0
@@ -3253,7 +3450,7 @@
     f32.div
     f32.add
     f32.mul
-    call $~lib/math/NativeMathf.log1p
+    call $~lib/util/math/log1p32
     f32.mul
     local.set $2
    end
@@ -3266,7 +3463,7 @@
    f32.sub
    f32.div
    f32.mul
-   call $~lib/math/NativeMathf.log1p
+   call $~lib/util/math/log1p32
    f32.mul
    local.set $2
   end
@@ -3275,14 +3472,26 @@
   f32.copysign
  )
  (func $std/math/test_atanhf (param $0 f32) (param $1 f32) (param $2 f32) (param $3 i32) (result i32)
-  local.get $0
-  call $~lib/math/NativeMathf.atanh
+  (local $4 f32)
+  block $~lib/math/NativeMath.atanh<f32>|inlined.0 (result f32)
+   local.get $0
+   local.set $4
+   i32.const 1
+   drop
+   i32.const 4
+   i32.const 4
+   i32.eq
+   drop
+   local.get $4
+   call $~lib/util/math/atanh32
+   br $~lib/math/NativeMath.atanh<f32>|inlined.0
+  end
   local.get $1
   local.get $2
   local.get $3
   call $std/math/check<f32>
  )
- (func $~lib/math/NativeMath.atan2 (param $0 f64) (param $1 f64) (result f64)
+ (func $~lib/util/math/atan2_64 (param $0 f64) (param $1 f64) (result f64)
   (local $2 i64)
   (local $3 i32)
   (local $4 i32)
@@ -3339,7 +3548,7 @@
   i32.eq
   if
    local.get $0
-   call $~lib/math/NativeMath.atan
+   call $~lib/util/math/atan64
    return
   end
   local.get $5
@@ -3397,10 +3606,10 @@
       local.get $0
       return
      end
-     global.get $~lib/math/NativeMath.PI
+     f64.const 3.141592653589793
      return
     end
-    global.get $~lib/math/NativeMath.PI
+    f64.const 3.141592653589793
     f64.neg
     return
    end
@@ -3415,12 +3624,12 @@
    i32.const 1
    i32.and
    if (result f64)
-    global.get $~lib/math/NativeMath.PI
+    f64.const 3.141592653589793
     f64.neg
     f64.const 2
     f64.div
    else
-    global.get $~lib/math/NativeMath.PI
+    f64.const 3.141592653589793
     f64.const 2
     f64.div
    end
@@ -3440,12 +3649,12 @@
     if (result f64)
      i32.const 3
      f64.convert_i32_s
-     global.get $~lib/math/NativeMath.PI
+     f64.const 3.141592653589793
      f64.mul
      f64.const 4
      f64.div
     else
-     global.get $~lib/math/NativeMath.PI
+     f64.const 3.141592653589793
      f64.const 4
      f64.div
     end
@@ -3465,7 +3674,7 @@
     i32.const 2
     i32.and
     if (result f64)
-     global.get $~lib/math/NativeMath.PI
+     f64.const 3.141592653589793
     else
      f64.const 0
     end
@@ -3502,12 +3711,12 @@
    i32.const 1
    i32.and
    if (result f64)
-    global.get $~lib/math/NativeMath.PI
+    f64.const 3.141592653589793
     f64.neg
     f64.const 2
     f64.div
    else
-    global.get $~lib/math/NativeMath.PI
+    f64.const 3.141592653589793
     f64.const 2
     f64.div
    end
@@ -3535,7 +3744,7 @@
    local.get $1
    f64.div
    f64.abs
-   call $~lib/math/NativeMath.atan
+   call $~lib/util/math/atan64
    local.set $10
   end
   block $break|1
@@ -3570,7 +3779,7 @@
      f64.neg
      return
     end
-    global.get $~lib/math/NativeMath.PI
+    f64.const 3.141592653589793
     local.get $10
     f64.const 1.2246467991473532e-16
     f64.sub
@@ -3580,16 +3789,35 @@
    local.get $10
    f64.const 1.2246467991473532e-16
    f64.sub
-   global.get $~lib/math/NativeMath.PI
+   f64.const 3.141592653589793
    f64.sub
    return
   end
   unreachable
  )
  (func $std/math/test_atan2 (param $0 f64) (param $1 f64) (param $2 f64) (param $3 f64) (param $4 i32) (result i32)
-  local.get $0
-  local.get $1
-  call $~lib/math/NativeMath.atan2
+  (local $5 f64)
+  (local $6 f64)
+  block $~lib/math/NativeMath.atan2<f64>|inlined.0 (result f64)
+   local.get $0
+   local.set $6
+   local.get $1
+   local.set $5
+   i32.const 1
+   drop
+   i32.const 8
+   i32.const 4
+   i32.eq
+   drop
+   i32.const 8
+   i32.const 8
+   i32.eq
+   drop
+   local.get $6
+   local.get $5
+   call $~lib/util/math/atan2_64
+   br $~lib/math/NativeMath.atan2<f64>|inlined.0
+  end
   local.get $2
   local.get $3
   local.get $4
@@ -3606,7 +3834,7 @@
    i32.const 0
   end
  )
- (func $~lib/math/NativeMathf.atan2 (param $0 f32) (param $1 f32) (result f32)
+ (func $~lib/util/math/atan2_32 (param $0 f32) (param $1 f32) (result f32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -3640,7 +3868,7 @@
   i32.eq
   if
    local.get $0
-   call $~lib/math/NativeMathf.atan
+   call $~lib/util/math/atan32
    return
   end
   local.get $3
@@ -3831,7 +4059,7 @@
    local.get $1
    f32.div
    f32.abs
-   call $~lib/math/NativeMathf.atan
+   call $~lib/util/math/atan32
    local.set $7
   end
   block $break|1
@@ -3883,15 +4111,30 @@
   unreachable
  )
  (func $std/math/test_atan2f (param $0 f32) (param $1 f32) (param $2 f32) (param $3 f32) (param $4 i32) (result i32)
-  local.get $0
-  local.get $1
-  call $~lib/math/NativeMathf.atan2
+  (local $5 f32)
+  (local $6 f32)
+  block $~lib/math/NativeMath.atan2<f32>|inlined.0 (result f32)
+   local.get $0
+   local.set $6
+   local.get $1
+   local.set $5
+   i32.const 1
+   drop
+   i32.const 4
+   i32.const 4
+   i32.eq
+   drop
+   local.get $6
+   local.get $5
+   call $~lib/util/math/atan2_32
+   br $~lib/math/NativeMath.atan2<f32>|inlined.0
+  end
   local.get $2
   local.get $3
   local.get $4
   call $std/math/check<f32>
  )
- (func $~lib/math/NativeMath.cbrt (param $0 f64) (result f64)
+ (func $~lib/util/math/cbrt64 (param $0 f64) (result f64)
   (local $1 i64)
   (local $2 i32)
   (local $3 f64)
@@ -4036,8 +4279,24 @@
   local.get $3
  )
  (func $std/math/test_cbrt (param $0 f64) (param $1 f64) (param $2 f64) (param $3 i32) (result i32)
-  local.get $0
-  call $~lib/math/NativeMath.cbrt
+  (local $4 f64)
+  block $~lib/math/NativeMath.cbrt<f64>|inlined.0 (result f64)
+   local.get $0
+   local.set $4
+   i32.const 1
+   drop
+   i32.const 8
+   i32.const 4
+   i32.eq
+   drop
+   i32.const 8
+   i32.const 8
+   i32.eq
+   drop
+   local.get $4
+   call $~lib/util/math/cbrt64
+   br $~lib/math/NativeMath.cbrt<f64>|inlined.0
+  end
   local.get $1
   local.get $2
   local.get $3
@@ -4053,7 +4312,7 @@
    i32.const 0
   end
  )
- (func $~lib/math/NativeMathf.cbrt (param $0 f32) (result f32)
+ (func $~lib/util/math/cbrt32 (param $0 f32) (result f32)
   (local $1 i32)
   (local $2 i32)
   (local $3 f64)
@@ -4170,8 +4429,20 @@
   f32.demote_f64
  )
  (func $std/math/test_cbrtf (param $0 f32) (param $1 f32) (param $2 f32) (param $3 i32) (result i32)
-  local.get $0
-  call $~lib/math/NativeMathf.cbrt
+  (local $4 f32)
+  block $~lib/math/NativeMath.cbrt<f32>|inlined.0 (result f32)
+   local.get $0
+   local.set $4
+   i32.const 1
+   drop
+   i32.const 4
+   i32.const 4
+   i32.eq
+   drop
+   local.get $4
+   call $~lib/util/math/cbrt32
+   br $~lib/math/NativeMath.cbrt<f32>|inlined.0
+  end
   local.get $1
   local.get $2
   local.get $3
@@ -4179,10 +4450,17 @@
  )
  (func $std/math/test_ceil (param $0 f64) (param $1 f64) (param $2 f64) (param $3 i32) (result i32)
   (local $4 f64)
-  local.get $0
-  local.set $4
-  local.get $4
-  f64.ceil
+  block $~lib/math/NativeMath.ceil<f64>|inlined.0 (result f64)
+   local.get $0
+   local.set $4
+   i32.const 0
+   drop
+   i32.const 1
+   drop
+   local.get $4
+   f64.ceil
+   br $~lib/math/NativeMath.ceil<f64>|inlined.0
+  end
   local.get $1
   local.get $2
   local.get $3
@@ -4200,16 +4478,23 @@
  )
  (func $std/math/test_ceilf (param $0 f32) (param $1 f32) (param $2 f32) (param $3 i32) (result i32)
   (local $4 f32)
-  local.get $0
-  local.set $4
-  local.get $4
-  f32.ceil
+  block $~lib/math/NativeMath.ceil<f32>|inlined.0 (result f32)
+   local.get $0
+   local.set $4
+   i32.const 0
+   drop
+   i32.const 1
+   drop
+   local.get $4
+   f32.ceil
+   br $~lib/math/NativeMath.ceil<f32>|inlined.0
+  end
   local.get $1
   local.get $2
   local.get $3
   call $std/math/check<f32>
  )
- (func $~lib/math/pio2_large_quot (param $0 f64) (param $1 i64) (result i32)
+ (func $~lib/util/math/pio2_64_large_quot (param $0 f64) (param $1 i64) (result i32)
   (local $2 i64)
   (local $3 i64)
   (local $4 i64)
@@ -4384,14 +4669,14 @@
   i64.const 32
   i64.shr_u
   i64.add
-  global.set $~lib/math/res128_hi
+  global.set $~lib/util/math/res128_hi
   local.get $19
   i64.const 32
   i64.shl
   local.get $17
   i64.add
   local.set $20
-  global.get $~lib/math/res128_hi
+  global.get $~lib/util/math/res128_hi
   local.set $21
   local.get $6
   local.get $14
@@ -4527,14 +4812,14 @@
   i64.const 32
   i64.shr_u
   i64.add
-  global.set $~lib/math/res128_hi
+  global.set $~lib/util/math/res128_hi
   local.get $33
   i64.const 32
   i64.shl
   local.get $31
   i64.add
   local.set $33
-  global.get $~lib/math/res128_hi
+  global.get $~lib/util/math/res128_hi
   local.set $32
   local.get $32
   i64.const 11
@@ -4572,14 +4857,14 @@
   i64.extend_i32_u
   i64.add
   f64.convert_i64_u
-  global.set $~lib/math/rempio2_y0
+  global.set $~lib/util/math/rempio2_y0
   f64.const 5.421010862427522e-20
   local.get $17
   local.get $18
   i64.add
   f64.convert_i64_u
   f64.mul
-  global.set $~lib/math/rempio2_y1
+  global.set $~lib/util/math/rempio2_y1
   local.get $19
   i64.const 52
   i64.shl
@@ -4596,18 +4881,18 @@
   i64.or
   f64.reinterpret_i64
   local.set $36
-  global.get $~lib/math/rempio2_y0
+  global.get $~lib/util/math/rempio2_y0
   local.get $36
   f64.mul
-  global.set $~lib/math/rempio2_y0
-  global.get $~lib/math/rempio2_y1
+  global.set $~lib/util/math/rempio2_y0
+  global.get $~lib/util/math/rempio2_y1
   local.get $36
   f64.mul
-  global.set $~lib/math/rempio2_y1
+  global.set $~lib/util/math/rempio2_y1
   local.get $30
   i32.wrap_i64
  )
- (func $~lib/math/NativeMath.cos (param $0 f64) (result f64)
+ (func $~lib/util/math/cos64 (param $0 f64) (result f64)
   (local $1 i64)
   (local $2 i32)
   (local $3 i32)
@@ -4726,7 +5011,7 @@
    f64.sub
    return
   end
-  block $~lib/math/rempio2|inlined.0 (result i32)
+  block $~lib/util/math/rempio2_64|inlined.0 (result i32)
    local.get $0
    local.set $4
    local.get $1
@@ -4826,11 +5111,11 @@
      local.set $13
     end
     local.get $8
-    global.set $~lib/math/rempio2_y0
+    global.set $~lib/util/math/rempio2_y0
     local.get $7
-    global.set $~lib/math/rempio2_y1
+    global.set $~lib/util/math/rempio2_y1
     local.get $13
-    br $~lib/math/rempio2|inlined.0
+    br $~lib/util/math/rempio2_64|inlined.0
    end
    local.get $12
    i32.const 1094263291
@@ -4952,16 +5237,16 @@
     f64.sub
     local.set $5
     local.get $6
-    global.set $~lib/math/rempio2_y0
+    global.set $~lib/util/math/rempio2_y0
     local.get $5
-    global.set $~lib/math/rempio2_y1
+    global.set $~lib/util/math/rempio2_y1
     local.get $7
     i32.trunc_sat_f64_s
-    br $~lib/math/rempio2|inlined.0
+    br $~lib/util/math/rempio2_64|inlined.0
    end
    local.get $4
    local.get $11
-   call $~lib/math/pio2_large_quot
+   call $~lib/util/math/pio2_64_large_quot
    local.set $15
    i32.const 0
    local.get $15
@@ -4971,15 +5256,15 @@
    select
   end
   local.set $17
-  global.get $~lib/math/rempio2_y0
+  global.get $~lib/util/math/rempio2_y0
   local.set $18
-  global.get $~lib/math/rempio2_y1
+  global.get $~lib/util/math/rempio2_y1
   local.set $19
   local.get $17
   i32.const 1
   i32.and
   if (result f64)
-   block $~lib/math/sin_kern|inlined.0 (result f64)
+   block $~lib/util/math/sin64_kern|inlined.0 (result f64)
     local.get $18
     local.set $7
     local.get $19
@@ -5030,7 +5315,7 @@
      f64.add
      f64.mul
      f64.add
-     br $~lib/math/sin_kern|inlined.0
+     br $~lib/util/math/sin64_kern|inlined.0
     else
      local.get $7
      local.get $4
@@ -5049,7 +5334,7 @@
      f64.mul
      f64.sub
      f64.sub
-     br $~lib/math/sin_kern|inlined.0
+     br $~lib/util/math/sin64_kern|inlined.0
     end
     unreachable
    end
@@ -5130,8 +5415,24 @@
   end
  )
  (func $std/math/test_cos (param $0 f64) (param $1 f64) (param $2 f64) (param $3 i32) (result i32)
-  local.get $0
-  call $~lib/math/NativeMath.cos
+  (local $4 f64)
+  block $~lib/math/NativeMath.cos<f64>|inlined.0 (result f64)
+   local.get $0
+   local.set $4
+   i32.const 1
+   drop
+   i32.const 8
+   i32.const 4
+   i32.eq
+   drop
+   i32.const 8
+   i32.const 8
+   i32.eq
+   drop
+   local.get $4
+   call $~lib/util/math/cos64
+   br $~lib/math/NativeMath.cos<f64>|inlined.0
+  end
   local.get $1
   local.get $2
   local.get $3
@@ -5147,7 +5448,7 @@
    i32.const 0
   end
  )
- (func $~lib/math/NativeMathf.cos (param $0 f32) (result f32)
+ (func $~lib/util/math/cos32 (param $0 f32) (result f32)
   (local $1 i32)
   (local $2 i32)
   (local $3 f64)
@@ -5527,7 +5828,7 @@
    f32.sub
    return
   end
-  block $~lib/math/rempio2f|inlined.0 (result i32)
+  block $~lib/util/math/rempio2_32|inlined.0 (result i32)
    local.get $0
    local.set $10
    local.get $1
@@ -5554,10 +5855,10 @@
     f64.const 1.5893254773528196e-08
     f64.mul
     f64.sub
-    global.set $~lib/math/rempio2f_y
+    global.set $~lib/util/math/rempio2_32_y
     local.get $6
     i32.trunc_sat_f64_s
-    br $~lib/math/rempio2f|inlined.0
+    br $~lib/util/math/rempio2_32|inlined.0
    end
    local.get $10
    local.set $12
@@ -5664,7 +5965,7 @@
    local.get $22
    f64.convert_i64_s
    f64.mul
-   global.set $~lib/math/rempio2f_y
+   global.set $~lib/util/math/rempio2_32_y
    local.get $23
    local.set $23
    i32.const 0
@@ -5675,7 +5976,7 @@
    select
   end
   local.set $24
-  global.get $~lib/math/rempio2f_y
+  global.get $~lib/util/math/rempio2_32_y
   local.set $25
   local.get $24
   i32.const 1
@@ -5766,14 +6067,26 @@
   end
  )
  (func $std/math/test_cosf (param $0 f32) (param $1 f32) (param $2 f32) (param $3 i32) (result i32)
-  local.get $0
-  call $~lib/math/NativeMathf.cos
+  (local $4 f32)
+  block $~lib/math/NativeMath.cos<f32>|inlined.0 (result f32)
+   local.get $0
+   local.set $4
+   i32.const 1
+   drop
+   i32.const 4
+   i32.const 4
+   i32.eq
+   drop
+   local.get $4
+   call $~lib/util/math/cos32
+   br $~lib/math/NativeMath.cos<f32>|inlined.0
+  end
   local.get $1
   local.get $2
   local.get $3
   call $std/math/check<f32>
  )
- (func $~lib/math/NativeMath.expm1 (param $0 f64) (result f64)
+ (func $~lib/util/math/expm1_64 (param $0 f64) (result f64)
   (local $1 i64)
   (local $2 i32)
   (local $3 i32)
@@ -6086,7 +6399,7 @@
   local.get $14
   f64.mul
  )
- (func $~lib/math/NativeMath.exp (param $0 f64) (result f64)
+ (func $~lib/util/math/exp64 (param $0 f64) (result f64)
   (local $1 f64)
   (local $2 i64)
   (local $3 i32)
@@ -6370,7 +6683,7 @@
   end
   return
  )
- (func $~lib/math/NativeMath.cosh (param $0 f64) (result f64)
+ (func $~lib/util/math/cosh64 (param $0 f64) (result f64)
   (local $1 i64)
   (local $2 i32)
   (local $3 f64)
@@ -6408,7 +6721,7 @@
     return
    end
    local.get $0
-   call $~lib/math/NativeMath.expm1
+   call $~lib/util/math/expm1_64
    local.set $3
    f64.const 1
    local.get $3
@@ -6428,7 +6741,7 @@
   i32.lt_u
   if
    local.get $0
-   call $~lib/math/NativeMath.exp
+   call $~lib/util/math/exp64
    local.set $3
    f64.const 0.5
    local.get $3
@@ -6458,7 +6771,7 @@
   local.get $5
   f64.const 1416.0996898839683
   f64.sub
-  call $~lib/math/NativeMath.exp
+  call $~lib/util/math/exp64
   local.get $4
   local.get $6
   f64.mul
@@ -6469,8 +6782,24 @@
   local.get $3
  )
  (func $std/math/test_cosh (param $0 f64) (param $1 f64) (param $2 f64) (param $3 i32) (result i32)
-  local.get $0
-  call $~lib/math/NativeMath.cosh
+  (local $4 f64)
+  block $~lib/math/NativeMath.cosh<f64>|inlined.0 (result f64)
+   local.get $0
+   local.set $4
+   i32.const 1
+   drop
+   i32.const 8
+   i32.const 4
+   i32.eq
+   drop
+   i32.const 8
+   i32.const 8
+   i32.eq
+   drop
+   local.get $4
+   call $~lib/util/math/cosh64
+   br $~lib/math/NativeMath.cosh<f64>|inlined.0
+  end
   local.get $1
   local.get $2
   local.get $3
@@ -6486,7 +6815,7 @@
    i32.const 0
   end
  )
- (func $~lib/math/NativeMathf.expm1 (param $0 f32) (result f32)
+ (func $~lib/util/math/expm1_32 (param $0 f32) (result f32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -6779,7 +7108,7 @@
   local.get $13
   f32.mul
  )
- (func $~lib/math/NativeMathf.exp (param $0 f32) (result f32)
+ (func $~lib/util/math/exp32 (param $0 f32) (result f32)
   (local $1 f32)
   (local $2 f64)
   (local $3 i32)
@@ -6795,7 +7124,7 @@
   i32.const 1
   i32.lt_s
   drop
-  block $~lib/util/math/expf_lut|inlined.0 (result f32)
+  block $~lib/util/math/exp32_lut|inlined.0 (result f32)
    local.get $0
    local.set $1
    local.get $1
@@ -6819,7 +7148,7 @@
     i32.eq
     if
      f32.const 0
-     br $~lib/util/math/expf_lut|inlined.0
+     br $~lib/util/math/exp32_lut|inlined.0
     end
     local.get $4
     i32.const 2040
@@ -6828,7 +7157,7 @@
      local.get $1
      local.get $1
      f32.add
-     br $~lib/util/math/expf_lut|inlined.0
+     br $~lib/util/math/exp32_lut|inlined.0
     end
     local.get $1
     i32.const 1118925335
@@ -6838,7 +7167,7 @@
      local.get $1
      f32.const 1701411834604692317316873e14
      f32.mul
-     br $~lib/util/math/expf_lut|inlined.0
+     br $~lib/util/math/exp32_lut|inlined.0
     end
     local.get $1
     i32.const -1026559564
@@ -6846,7 +7175,7 @@
     f32.lt
     if
      f32.const 0
-     br $~lib/util/math/expf_lut|inlined.0
+     br $~lib/util/math/exp32_lut|inlined.0
     end
    end
    f64.const 46.16624130844683
@@ -6917,7 +7246,7 @@
   end
   return
  )
- (func $~lib/math/NativeMathf.cosh (param $0 f32) (result f32)
+ (func $~lib/util/math/cosh32 (param $0 f32) (result f32)
   (local $1 i32)
   (local $2 f32)
   (local $3 f32)
@@ -6948,7 +7277,7 @@
     return
    end
    local.get $0
-   call $~lib/math/NativeMathf.expm1
+   call $~lib/util/math/expm1_32
    local.set $2
    f32.const 1
    local.get $2
@@ -6968,7 +7297,7 @@
   i32.lt_u
   if
    local.get $0
-   call $~lib/math/NativeMathf.exp
+   call $~lib/util/math/exp32
    local.set $2
    f32.const 0.5
    local.get $2
@@ -6995,7 +7324,7 @@
   local.get $3
   f32.const 162.88958740234375
   f32.sub
-  call $~lib/math/NativeMathf.exp
+  call $~lib/util/math/exp32
   local.get $2
   local.get $4
   f32.mul
@@ -7004,16 +7333,44 @@
   f32.mul
  )
  (func $std/math/test_coshf (param $0 f32) (param $1 f32) (param $2 f32) (param $3 i32) (result i32)
-  local.get $0
-  call $~lib/math/NativeMathf.cosh
+  (local $4 f32)
+  block $~lib/math/NativeMath.cosh<f32>|inlined.0 (result f32)
+   local.get $0
+   local.set $4
+   i32.const 1
+   drop
+   i32.const 4
+   i32.const 4
+   i32.eq
+   drop
+   local.get $4
+   call $~lib/util/math/cosh32
+   br $~lib/math/NativeMath.cosh<f32>|inlined.0
+  end
   local.get $1
   local.get $2
   local.get $3
   call $std/math/check<f32>
  )
  (func $std/math/test_exp (param $0 f64) (param $1 f64) (param $2 f64) (param $3 i32) (result i32)
-  local.get $0
-  call $~lib/math/NativeMath.exp
+  (local $4 f64)
+  block $~lib/math/NativeMath.exp<f64>|inlined.0 (result f64)
+   local.get $0
+   local.set $4
+   i32.const 1
+   drop
+   i32.const 8
+   i32.const 4
+   i32.eq
+   drop
+   i32.const 8
+   i32.const 8
+   i32.eq
+   drop
+   local.get $4
+   call $~lib/util/math/exp64
+   br $~lib/math/NativeMath.exp<f64>|inlined.0
+  end
   local.get $1
   local.get $2
   local.get $3
@@ -7030,16 +7387,44 @@
   end
  )
  (func $std/math/test_expf (param $0 f32) (param $1 f32) (param $2 f32) (param $3 i32) (result i32)
-  local.get $0
-  call $~lib/math/NativeMathf.exp
+  (local $4 f32)
+  block $~lib/math/NativeMath.exp<f32>|inlined.0 (result f32)
+   local.get $0
+   local.set $4
+   i32.const 1
+   drop
+   i32.const 4
+   i32.const 4
+   i32.eq
+   drop
+   local.get $4
+   call $~lib/util/math/exp32
+   br $~lib/math/NativeMath.exp<f32>|inlined.0
+  end
   local.get $1
   local.get $2
   local.get $3
   call $std/math/check<f32>
  )
  (func $std/math/test_expm1 (param $0 f64) (param $1 f64) (param $2 f64) (param $3 i32) (result i32)
-  local.get $0
-  call $~lib/math/NativeMath.expm1
+  (local $4 f64)
+  block $~lib/math/NativeMath.expm1<f64>|inlined.0 (result f64)
+   local.get $0
+   local.set $4
+   i32.const 1
+   drop
+   i32.const 8
+   i32.const 4
+   i32.eq
+   drop
+   i32.const 8
+   i32.const 8
+   i32.eq
+   drop
+   local.get $4
+   call $~lib/util/math/expm1_64
+   br $~lib/math/NativeMath.expm1<f64>|inlined.0
+  end
   local.get $1
   local.get $2
   local.get $3
@@ -7056,285 +7441,309 @@
   end
  )
  (func $std/math/test_expm1f (param $0 f32) (param $1 f32) (param $2 f32) (param $3 i32) (result i32)
-  local.get $0
-  call $~lib/math/NativeMathf.expm1
+  (local $4 f32)
+  block $~lib/math/NativeMath.expm1<f32>|inlined.0 (result f32)
+   local.get $0
+   local.set $4
+   i32.const 1
+   drop
+   i32.const 4
+   i32.const 4
+   i32.eq
+   drop
+   local.get $4
+   call $~lib/util/math/expm1_32
+   br $~lib/math/NativeMath.expm1<f32>|inlined.0
+  end
   local.get $1
   local.get $2
   local.get $3
   call $std/math/check<f32>
  )
- (func $~lib/math/NativeMath.exp2 (param $0 f64) (result f64)
-  (local $1 f64)
-  (local $2 i64)
-  (local $3 i32)
-  (local $4 f64)
-  (local $5 i64)
-  (local $6 f64)
-  (local $7 i32)
-  (local $8 i64)
-  (local $9 f64)
-  (local $10 i64)
+ (func $~lib/util/math/exp2_64_lut (param $0 f64) (result f64)
+  (local $1 i64)
+  (local $2 i32)
+  (local $3 f64)
+  (local $4 i64)
+  (local $5 f64)
+  (local $6 i32)
+  (local $7 i64)
+  (local $8 f64)
+  (local $9 i64)
+  (local $10 f64)
   (local $11 f64)
-  (local $12 f64)
+  (local $12 i64)
   (local $13 i64)
-  (local $14 i64)
+  (local $14 f64)
   (local $15 f64)
   (local $16 f64)
   (local $17 f64)
   (local $18 f64)
   (local $19 f64)
-  block $~lib/util/math/exp2_lut|inlined.0 (result f64)
-   local.get $0
-   local.set $1
-   local.get $1
-   i64.reinterpret_f64
-   local.set $2
+  local.get $0
+  i64.reinterpret_f64
+  local.set $1
+  local.get $1
+  i64.const 52
+  i64.shr_u
+  i64.const 2047
+  i64.and
+  i32.wrap_i64
+  local.set $2
+  local.get $2
+  i32.const 969
+  i32.sub
+  i32.const 63
+  i32.ge_u
+  if
    local.get $2
-   i64.const 52
-   i64.shr_u
-   i64.const 2047
-   i64.and
-   i32.wrap_i64
-   local.set $3
-   local.get $3
    i32.const 969
    i32.sub
-   i32.const 63
+   i32.const -2147483648
    i32.ge_u
    if
-    local.get $3
-    i32.const 969
-    i32.sub
-    i32.const -2147483648
+    f64.const 1
+    return
+   end
+   local.get $2
+   i32.const 1033
+   i32.ge_u
+   if
+    local.get $1
+    i64.const -4503599627370496
+    i64.eq
+    if
+     f64.const 0
+     return
+    end
+    local.get $2
+    i32.const 2047
     i32.ge_u
     if
      f64.const 1
-     br $~lib/util/math/exp2_lut|inlined.0
+     local.get $0
+     f64.add
+     return
     end
-    local.get $3
-    i32.const 1033
-    i32.ge_u
+    local.get $1
+    i64.const 63
+    i64.shr_u
+    i64.const 0
+    i64.ne
+    i32.eqz
     if
-     local.get $2
-     i64.const -4503599627370496
-     i64.eq
+     f64.const inf
+     return
+    else
+     local.get $1
+     i64.const -4570929321408987136
+     i64.ge_u
      if
       f64.const 0
-      br $~lib/util/math/exp2_lut|inlined.0
+      return
      end
-     local.get $3
-     i32.const 2047
-     i32.ge_u
-     if
-      f64.const 1
-      local.get $1
-      f64.add
-      br $~lib/util/math/exp2_lut|inlined.0
-     end
-     local.get $2
-     i64.const 63
-     i64.shr_u
-     i64.const 0
-     i64.ne
-     i32.eqz
-     if
-      f64.const inf
-      br $~lib/util/math/exp2_lut|inlined.0
-     else
-      local.get $2
-      i64.const -4570929321408987136
-      i64.ge_u
-      if
-       f64.const 0
-       br $~lib/util/math/exp2_lut|inlined.0
-      end
-     end
-    end
-    local.get $2
-    i64.const 1
-    i64.shl
-    i64.const -9143996093422370816
-    i64.gt_u
-    if
-     i32.const 0
-     local.set $3
     end
    end
    local.get $1
-   f64.const 52776558133248
-   f64.add
-   local.set $4
-   local.get $4
-   i64.reinterpret_f64
-   local.set $5
-   local.get $4
-   f64.const 52776558133248
-   f64.sub
-   local.set $4
-   local.get $1
-   local.get $4
-   f64.sub
-   local.set $6
-   local.get $5
-   i32.const 127
-   i64.extend_i32_s
-   i64.and
    i64.const 1
    i64.shl
-   i32.wrap_i64
-   local.set $7
-   local.get $5
-   i64.const 52
-   i32.const 7
-   i64.extend_i32_s
-   i64.sub
-   i64.shl
-   local.set $8
-   i32.const 4640
-   local.get $7
-   i32.const 3
-   i32.shl
-   i32.add
-   i64.load
-   f64.reinterpret_i64
-   local.set $9
-   i32.const 4640
-   local.get $7
-   i32.const 3
-   i32.shl
-   i32.add
-   i64.load offset=8
-   local.get $8
-   i64.add
-   local.set $10
-   local.get $6
-   local.get $6
-   f64.mul
-   local.set $11
-   local.get $9
-   local.get $6
-   f64.const 0.6931471805599453
-   f64.mul
-   f64.add
-   local.get $11
-   f64.const 0.24022650695909065
-   local.get $6
-   f64.const 0.0555041086686087
-   f64.mul
-   f64.add
-   f64.mul
-   f64.add
-   local.get $11
-   local.get $11
-   f64.mul
-   f64.const 0.009618131975721055
-   local.get $6
-   f64.const 1.3332074570119598e-03
-   f64.mul
-   f64.add
-   f64.mul
-   f64.add
-   local.set $12
-   local.get $3
-   i32.const 0
-   i32.eq
+   i64.const -9143996093422370816
+   i64.gt_u
    if
-    block $~lib/util/math/specialcase2|inlined.0 (result f64)
-     local.get $12
-     local.set $15
-     local.get $10
-     local.set $14
-     local.get $5
-     local.set $13
+    i32.const 0
+    local.set $2
+   end
+  end
+  local.get $0
+  f64.const 52776558133248
+  f64.add
+  local.set $3
+  local.get $3
+  i64.reinterpret_f64
+  local.set $4
+  local.get $3
+  f64.const 52776558133248
+  f64.sub
+  local.set $3
+  local.get $0
+  local.get $3
+  f64.sub
+  local.set $5
+  local.get $4
+  i32.const 127
+  i64.extend_i32_s
+  i64.and
+  i64.const 1
+  i64.shl
+  i32.wrap_i64
+  local.set $6
+  local.get $4
+  i64.const 52
+  i32.const 7
+  i64.extend_i32_s
+  i64.sub
+  i64.shl
+  local.set $7
+  i32.const 4640
+  local.get $6
+  i32.const 3
+  i32.shl
+  i32.add
+  i64.load
+  f64.reinterpret_i64
+  local.set $8
+  i32.const 4640
+  local.get $6
+  i32.const 3
+  i32.shl
+  i32.add
+  i64.load offset=8
+  local.get $7
+  i64.add
+  local.set $9
+  local.get $5
+  local.get $5
+  f64.mul
+  local.set $10
+  local.get $8
+  local.get $5
+  f64.const 0.6931471805599453
+  f64.mul
+  f64.add
+  local.get $10
+  f64.const 0.24022650695909065
+  local.get $5
+  f64.const 0.0555041086686087
+  f64.mul
+  f64.add
+  f64.mul
+  f64.add
+  local.get $10
+  local.get $10
+  f64.mul
+  f64.const 0.009618131975721055
+  local.get $5
+  f64.const 1.3332074570119598e-03
+  f64.mul
+  f64.add
+  f64.mul
+  f64.add
+  local.set $11
+  local.get $2
+  i32.const 0
+  i32.eq
+  if
+   block $~lib/util/math/specialcase2|inlined.0 (result f64)
+    local.get $11
+    local.set $14
+    local.get $9
+    local.set $13
+    local.get $4
+    local.set $12
+    local.get $12
+    i64.const 2147483648
+    i64.and
+    i64.const 0
+    i64.eq
+    if
      local.get $13
-     i64.const 2147483648
-     i64.and
-     i64.const 0
-     i64.eq
-     if
-      local.get $14
-      i64.const 1
-      i64.const 52
-      i64.shl
-      i64.sub
-      local.set $14
-      local.get $14
-      f64.reinterpret_i64
-      local.set $16
-      f64.const 2
-      local.get $16
-      local.get $15
-      f64.mul
-      local.get $16
-      f64.add
-      f64.mul
-      br $~lib/util/math/specialcase2|inlined.0
-     end
-     local.get $14
-     i64.const 1022
+     i64.const 1
      i64.const 52
      i64.shl
-     i64.add
-     local.set $14
-     local.get $14
+     i64.sub
+     local.set $13
+     local.get $13
      f64.reinterpret_i64
-     local.set $16
-     local.get $16
+     local.set $15
+     f64.const 2
      local.get $15
+     local.get $14
      f64.mul
+     local.get $15
+     f64.add
+     f64.mul
+     br $~lib/util/math/specialcase2|inlined.0
+    end
+    local.get $13
+    i64.const 1022
+    i64.const 52
+    i64.shl
+    i64.add
+    local.set $13
+    local.get $13
+    f64.reinterpret_i64
+    local.set $15
+    local.get $15
+    local.get $14
+    f64.mul
+    local.get $15
+    f64.add
+    local.set $16
+    local.get $16
+    f64.const 1
+    f64.lt
+    if
+     local.get $15
+     local.get $16
+     f64.sub
+     local.get $15
+     local.get $14
+     f64.mul
+     f64.add
+     local.set $18
+     f64.const 1
      local.get $16
      f64.add
      local.set $17
-     local.get $17
      f64.const 1
-     f64.lt
-     if
-      local.get $16
-      local.get $17
-      f64.sub
-      local.get $16
-      local.get $15
-      f64.mul
-      f64.add
-      local.set $19
-      f64.const 1
-      local.get $17
-      f64.add
-      local.set $18
-      f64.const 1
-      local.get $18
-      f64.sub
-      local.get $17
-      f64.add
-      local.get $19
-      f64.add
-      local.set $19
-      local.get $18
-      local.get $19
-      f64.add
-      f64.const 1
-      f64.sub
-      local.set $17
-     end
      local.get $17
-     f64.const 2.2250738585072014e-308
-     f64.mul
+     f64.sub
+     local.get $16
+     f64.add
+     local.get $18
+     f64.add
+     local.set $18
+     local.get $17
+     local.get $18
+     f64.add
+     f64.const 1
+     f64.sub
+     local.set $16
     end
-    br $~lib/util/math/exp2_lut|inlined.0
+    local.get $16
+    f64.const 2.2250738585072014e-308
+    f64.mul
    end
-   local.get $10
-   f64.reinterpret_i64
-   local.set $17
-   local.get $17
-   local.get $12
-   f64.mul
-   local.get $17
-   f64.add
+   return
   end
+  local.get $9
+  f64.reinterpret_i64
+  local.set $19
+  local.get $19
+  local.get $11
+  f64.mul
+  local.get $19
+  f64.add
  )
  (func $std/math/test_exp2 (param $0 f64) (param $1 f64) (param $2 f64) (param $3 i32) (result i32)
-  local.get $0
-  call $~lib/math/NativeMath.exp2
+  (local $4 f64)
+  block $~lib/math/NativeMath.exp2<f64>|inlined.0 (result f64)
+   local.get $0
+   local.set $4
+   i32.const 1
+   drop
+   i32.const 8
+   i32.const 4
+   i32.eq
+   drop
+   i32.const 8
+   i32.const 8
+   i32.eq
+   drop
+   local.get $4
+   call $~lib/util/math/exp2_64_lut
+   br $~lib/math/NativeMath.exp2<f64>|inlined.0
+  end
   local.get $1
   local.get $2
   local.get $3
@@ -7351,133 +7760,140 @@
    i32.const 0
   end
  )
- (func $~lib/math/NativeMathf.exp2 (param $0 f32) (result f32)
-  (local $1 f32)
-  (local $2 f64)
+ (func $~lib/util/math/exp2_32_lut (param $0 f32) (result f32)
+  (local $1 f64)
+  (local $2 i32)
   (local $3 i32)
-  (local $4 i32)
-  (local $5 f64)
-  (local $6 i64)
-  (local $7 f64)
-  (local $8 i64)
+  (local $4 f64)
+  (local $5 i64)
+  (local $6 f64)
+  (local $7 i64)
+  (local $8 f64)
   (local $9 f64)
-  (local $10 f64)
-  block $~lib/util/math/exp2f_lut|inlined.0 (result f32)
-   local.get $0
-   local.set $1
-   local.get $1
-   f64.promote_f32
-   local.set $2
-   local.get $1
-   i32.reinterpret_f32
-   local.set $3
+  local.get $0
+  f64.promote_f32
+  local.set $1
+  local.get $0
+  i32.reinterpret_f32
+  local.set $2
+  local.get $2
+  i32.const 20
+  i32.shr_u
+  i32.const 2047
+  i32.and
+  local.set $3
+  local.get $3
+  i32.const 1072
+  i32.ge_u
+  if
+   local.get $2
+   i32.const -8388608
+   i32.eq
+   if
+    f32.const 0
+    return
+   end
    local.get $3
-   i32.const 20
-   i32.shr_u
-   i32.const 2047
-   i32.and
-   local.set $4
-   local.get $4
-   i32.const 1072
+   i32.const 2040
    i32.ge_u
    if
-    local.get $3
-    i32.const -8388608
-    i32.eq
-    if
-     f32.const 0
-     br $~lib/util/math/exp2f_lut|inlined.0
-    end
-    local.get $4
-    i32.const 2040
-    i32.ge_u
-    if
-     local.get $1
-     local.get $1
-     f32.add
-     br $~lib/util/math/exp2f_lut|inlined.0
-    end
-    local.get $1
-    f32.const 0
-    f32.gt
-    if
-     local.get $1
-     f32.const 1701411834604692317316873e14
-     f32.mul
-     br $~lib/util/math/exp2f_lut|inlined.0
-    end
-    local.get $1
-    f32.const -150
-    f32.le
-    if
-     f32.const 0
-     br $~lib/util/math/exp2f_lut|inlined.0
-    end
+    local.get $0
+    local.get $0
+    f32.add
+    return
    end
-   local.get $2
-   f64.const 211106232532992
-   f64.add
-   local.set $5
-   local.get $5
-   i64.reinterpret_f64
-   local.set $6
-   local.get $2
-   local.get $5
-   f64.const 211106232532992
-   f64.sub
-   f64.sub
-   local.set $7
-   i32.const 6688
-   local.get $6
-   i32.wrap_i64
-   i32.const 31
-   i32.and
-   i32.const 3
-   i32.shl
-   i32.add
-   i64.load
-   local.set $8
-   local.get $8
-   local.get $6
-   i64.const 52
-   i32.const 5
-   i64.extend_i32_s
-   i64.sub
-   i64.shl
-   i64.add
-   local.set $8
-   local.get $8
-   f64.reinterpret_i64
-   local.set $10
-   f64.const 0.6931471806916203
-   local.get $7
-   f64.mul
-   f64.const 1
-   f64.add
-   local.set $9
-   local.get $9
-   f64.const 0.05550361559341535
-   local.get $7
-   f64.mul
-   f64.const 0.2402284522445722
-   f64.add
-   local.get $7
-   local.get $7
-   f64.mul
-   f64.mul
-   f64.add
-   local.set $9
-   local.get $9
-   local.get $10
-   f64.mul
-   local.set $9
-   local.get $9
-   f32.demote_f64
+   local.get $0
+   f32.const 0
+   f32.gt
+   if
+    local.get $0
+    f32.const 1701411834604692317316873e14
+    f32.mul
+    return
+   end
+   local.get $0
+   f32.const -150
+   f32.le
+   if
+    f32.const 0
+    return
+   end
   end
+  local.get $1
+  f64.const 211106232532992
+  f64.add
+  local.set $4
+  local.get $4
+  i64.reinterpret_f64
+  local.set $5
+  local.get $1
+  local.get $4
+  f64.const 211106232532992
+  f64.sub
+  f64.sub
+  local.set $6
+  i32.const 6688
+  local.get $5
+  i32.wrap_i64
+  i32.const 31
+  i32.and
+  i32.const 3
+  i32.shl
+  i32.add
+  i64.load
+  local.set $7
+  local.get $7
+  local.get $5
+  i64.const 52
+  i32.const 5
+  i64.extend_i32_s
+  i64.sub
+  i64.shl
+  i64.add
+  local.set $7
+  local.get $7
+  f64.reinterpret_i64
+  local.set $9
+  f64.const 0.6931471806916203
+  local.get $6
+  f64.mul
+  f64.const 1
+  f64.add
+  local.set $8
+  local.get $8
+  f64.const 0.05550361559341535
+  local.get $6
+  f64.mul
+  f64.const 0.2402284522445722
+  f64.add
+  local.get $6
+  local.get $6
+  f64.mul
+  f64.mul
+  f64.add
+  local.set $8
+  local.get $8
+  local.get $9
+  f64.mul
+  local.set $8
+  local.get $8
+  f32.demote_f64
  )
  (func $std/math/test_exp2f (param $0 f32) (param $1 f32) (param $2 f32) (param $3 i32) (result i32)
-  local.get $0
-  call $~lib/math/NativeMathf.exp2
+  (local $4 f32)
+  block $~lib/math/NativeMath.exp2<f32>|inlined.0 (result f32)
+   local.get $0
+   local.set $4
+   i32.const 1
+   drop
+   i32.const 4
+   i32.const 4
+   i32.eq
+   drop
+   local.get $4
+   call $~lib/util/math/exp2_32_lut
+   br $~lib/math/NativeMath.exp2<f32>|inlined.0
+  end
   local.get $1
   local.get $2
   local.get $3
@@ -7485,10 +7901,17 @@
  )
  (func $std/math/test_floor (param $0 f64) (param $1 f64) (param $2 f64) (param $3 i32) (result i32)
   (local $4 f64)
-  local.get $0
-  local.set $4
-  local.get $4
-  f64.floor
+  block $~lib/math/NativeMath.floor<f64>|inlined.0 (result f64)
+   local.get $0
+   local.set $4
+   i32.const 0
+   drop
+   i32.const 1
+   drop
+   local.get $4
+   f64.floor
+   br $~lib/math/NativeMath.floor<f64>|inlined.0
+  end
   local.get $1
   local.get $2
   local.get $3
@@ -7506,16 +7929,23 @@
  )
  (func $std/math/test_floorf (param $0 f32) (param $1 f32) (param $2 f32) (param $3 i32) (result i32)
   (local $4 f32)
-  local.get $0
-  local.set $4
-  local.get $4
-  f32.floor
+  block $~lib/math/NativeMath.floor<f32>|inlined.0 (result f32)
+   local.get $0
+   local.set $4
+   i32.const 0
+   drop
+   i32.const 1
+   drop
+   local.get $4
+   f32.floor
+   br $~lib/math/NativeMath.floor<f32>|inlined.0
+  end
   local.get $1
   local.get $2
   local.get $3
   call $std/math/check<f32>
  )
- (func $~lib/math/NativeMath.hypot (param $0 f64) (param $1 f64) (result f64)
+ (func $~lib/util/math/hypot64 (param $0 f64) (param $1 f64) (result f64)
   (local $2 i64)
   (local $3 i64)
   (local $4 i64)
@@ -7715,15 +8145,34 @@
   f64.mul
  )
  (func $std/math/test_hypot (param $0 f64) (param $1 f64) (param $2 f64) (param $3 f64) (param $4 i32) (result i32)
-  local.get $0
-  local.get $1
-  call $~lib/math/NativeMath.hypot
+  (local $5 f64)
+  (local $6 f64)
+  block $~lib/math/NativeMath.hypot<f64>|inlined.0 (result f64)
+   local.get $0
+   local.set $6
+   local.get $1
+   local.set $5
+   i32.const 1
+   drop
+   i32.const 8
+   i32.const 4
+   i32.eq
+   drop
+   i32.const 8
+   i32.const 8
+   i32.eq
+   drop
+   local.get $6
+   local.get $5
+   call $~lib/util/math/hypot64
+   br $~lib/math/NativeMath.hypot<f64>|inlined.0
+  end
   local.get $2
   local.get $3
   local.get $4
   call $std/math/check<f64>
  )
- (func $~lib/math/NativeMathf.hypot (param $0 f32) (param $1 f32) (result f32)
+ (func $~lib/util/math/hypot32 (param $0 f32) (param $1 f32) (result f32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -7855,17 +8304,48 @@
   f32.mul
  )
  (func $std/math/test_hypotf (param $0 f32) (param $1 f32) (param $2 f32) (param $3 f32) (param $4 i32) (result i32)
-  local.get $0
-  local.get $1
-  call $~lib/math/NativeMathf.hypot
+  (local $5 f32)
+  (local $6 f32)
+  block $~lib/math/NativeMath.hypot<f32>|inlined.0 (result f32)
+   local.get $0
+   local.set $6
+   local.get $1
+   local.set $5
+   i32.const 1
+   drop
+   i32.const 4
+   i32.const 4
+   i32.eq
+   drop
+   local.get $6
+   local.get $5
+   call $~lib/util/math/hypot32
+   br $~lib/math/NativeMath.hypot<f32>|inlined.0
+  end
   local.get $2
   local.get $3
   local.get $4
   call $std/math/check<f32>
  )
  (func $std/math/test_log (param $0 f64) (param $1 f64) (param $2 f64) (param $3 i32) (result i32)
-  local.get $0
-  call $~lib/math/NativeMath.log
+  (local $4 f64)
+  block $~lib/math/NativeMath.log<f64>|inlined.0 (result f64)
+   local.get $0
+   local.set $4
+   i32.const 1
+   drop
+   i32.const 8
+   i32.const 4
+   i32.eq
+   drop
+   i32.const 8
+   i32.const 8
+   i32.eq
+   drop
+   local.get $4
+   call $~lib/util/math/log64
+   br $~lib/math/NativeMath.log<f64>|inlined.0
+  end
   local.get $1
   local.get $2
   local.get $3
@@ -7882,14 +8362,26 @@
   end
  )
  (func $std/math/test_logf (param $0 f32) (param $1 f32) (param $2 f32) (param $3 i32) (result i32)
-  local.get $0
-  call $~lib/math/NativeMathf.log
+  (local $4 f32)
+  block $~lib/math/NativeMath.log<f32>|inlined.0 (result f32)
+   local.get $0
+   local.set $4
+   i32.const 1
+   drop
+   i32.const 4
+   i32.const 4
+   i32.eq
+   drop
+   local.get $4
+   call $~lib/util/math/log32
+   br $~lib/math/NativeMath.log<f32>|inlined.0
+  end
   local.get $1
   local.get $2
   local.get $3
   call $std/math/check<f32>
  )
- (func $~lib/math/NativeMath.log10 (param $0 f64) (result f64)
+ (func $~lib/util/math/log10_64 (param $0 f64) (result f64)
   (local $1 i64)
   (local $2 i32)
   (local $3 i32)
@@ -8150,8 +8642,24 @@
   f64.add
  )
  (func $std/math/test_log10 (param $0 f64) (param $1 f64) (param $2 f64) (param $3 i32) (result i32)
-  local.get $0
-  call $~lib/math/NativeMath.log10
+  (local $4 f64)
+  block $~lib/math/NativeMath.log10<f64>|inlined.0 (result f64)
+   local.get $0
+   local.set $4
+   i32.const 1
+   drop
+   i32.const 8
+   i32.const 4
+   i32.eq
+   drop
+   i32.const 8
+   i32.const 8
+   i32.eq
+   drop
+   local.get $4
+   call $~lib/util/math/log10_64
+   br $~lib/math/NativeMath.log10<f64>|inlined.0
+  end
   local.get $1
   local.get $2
   local.get $3
@@ -8167,7 +8675,7 @@
    i32.const 0
   end
  )
- (func $~lib/math/NativeMathf.log10 (param $0 f32) (result f32)
+ (func $~lib/util/math/log10_32 (param $0 f32) (result f32)
   (local $1 i32)
   (local $2 i32)
   (local $3 f32)
@@ -8368,16 +8876,44 @@
   f32.add
  )
  (func $std/math/test_log10f (param $0 f32) (param $1 f32) (param $2 f32) (param $3 i32) (result i32)
-  local.get $0
-  call $~lib/math/NativeMathf.log10
+  (local $4 f32)
+  block $~lib/math/NativeMath.log10<f32>|inlined.0 (result f32)
+   local.get $0
+   local.set $4
+   i32.const 1
+   drop
+   i32.const 4
+   i32.const 4
+   i32.eq
+   drop
+   local.get $4
+   call $~lib/util/math/log10_32
+   br $~lib/math/NativeMath.log10<f32>|inlined.0
+  end
   local.get $1
   local.get $2
   local.get $3
   call $std/math/check<f32>
  )
  (func $std/math/test_log1p (param $0 f64) (param $1 f64) (param $2 f64) (param $3 i32) (result i32)
-  local.get $0
-  call $~lib/math/NativeMath.log1p
+  (local $4 f64)
+  block $~lib/math/NativeMath.log1p<f64>|inlined.0 (result f64)
+   local.get $0
+   local.set $4
+   i32.const 1
+   drop
+   i32.const 8
+   i32.const 4
+   i32.eq
+   drop
+   i32.const 8
+   i32.const 8
+   i32.eq
+   drop
+   local.get $4
+   call $~lib/util/math/log1p64
+   br $~lib/math/NativeMath.log1p<f64>|inlined.0
+  end
   local.get $1
   local.get $2
   local.get $3
@@ -8394,14 +8930,26 @@
   end
  )
  (func $std/math/test_log1pf (param $0 f32) (param $1 f32) (param $2 f32) (param $3 i32) (result i32)
-  local.get $0
-  call $~lib/math/NativeMathf.log1p
+  (local $4 f32)
+  block $~lib/math/NativeMath.log1p<f32>|inlined.0 (result f32)
+   local.get $0
+   local.set $4
+   i32.const 1
+   drop
+   i32.const 4
+   i32.const 4
+   i32.eq
+   drop
+   local.get $4
+   call $~lib/util/math/log1p32
+   br $~lib/math/NativeMath.log1p<f32>|inlined.0
+  end
   local.get $1
   local.get $2
   local.get $3
   call $std/math/check<f32>
  )
- (func $~lib/math/NativeMath.log2 (param $0 f64) (result f64)
+ (func $~lib/util/math/log2_64 (param $0 f64) (result f64)
   (local $1 f64)
   (local $2 i64)
   (local $3 f64)
@@ -8429,7 +8977,7 @@
   i32.const 1
   i32.lt_s
   drop
-  block $~lib/util/math/log2_lut|inlined.0 (result f64)
+  block $~lib/util/math/log2_64_lut|inlined.0 (result f64)
    local.get $0
    local.set $1
    local.get $1
@@ -8534,7 +9082,7 @@
     local.get $11
     local.get $7
     f64.add
-    br $~lib/util/math/log2_lut|inlined.0
+    br $~lib/util/math/log2_64_lut|inlined.0
    end
    local.get $2
    i64.const 48
@@ -8560,14 +9108,14 @@
      local.get $1
      f64.mul
      f64.div
-     br $~lib/util/math/log2_lut|inlined.0
+     br $~lib/util/math/log2_64_lut|inlined.0
     end
     local.get $2
     i64.const 9218868437227405312
     i64.eq
     if
      local.get $1
-     br $~lib/util/math/log2_lut|inlined.0
+     br $~lib/util/math/log2_64_lut|inlined.0
     end
     local.get $12
     i32.const 32768
@@ -8589,7 +9137,7 @@
      local.get $1
      f64.sub
      f64.div
-     br $~lib/util/math/log2_lut|inlined.0
+     br $~lib/util/math/log2_64_lut|inlined.0
     end
     local.get $1
     f64.const 4503599627370496
@@ -8755,8 +9303,24 @@
   return
  )
  (func $std/math/test_log2 (param $0 f64) (param $1 f64) (param $2 f64) (param $3 i32) (result i32)
-  local.get $0
-  call $~lib/math/NativeMath.log2
+  (local $4 f64)
+  block $~lib/math/NativeMath.log2<f64>|inlined.0 (result f64)
+   local.get $0
+   local.set $4
+   i32.const 1
+   drop
+   i32.const 8
+   i32.const 4
+   i32.eq
+   drop
+   i32.const 8
+   i32.const 8
+   i32.eq
+   drop
+   local.get $4
+   call $~lib/util/math/log2_64
+   br $~lib/math/NativeMath.log2<f64>|inlined.0
+  end
   local.get $1
   local.get $2
   local.get $3
@@ -8772,7 +9336,7 @@
    i32.const 0
   end
  )
- (func $~lib/math/NativeMathf.log2 (param $0 f32) (result f32)
+ (func $~lib/util/math/log2_32 (param $0 f32) (result f32)
   (local $1 f32)
   (local $2 i32)
   (local $3 i32)
@@ -8792,7 +9356,7 @@
   i32.const 1
   i32.lt_s
   drop
-  block $~lib/util/math/log2f_lut|inlined.0 (result f32)
+  block $~lib/util/math/log2_32_lut|inlined.0 (result f32)
    local.get $0
    local.set $1
    local.get $1
@@ -8814,14 +9378,14 @@
     if
      f32.const inf
      f32.neg
-     br $~lib/util/math/log2f_lut|inlined.0
+     br $~lib/util/math/log2_32_lut|inlined.0
     end
     local.get $2
     i32.const 2139095040
     i32.eq
     if
      local.get $1
-     br $~lib/util/math/log2f_lut|inlined.0
+     br $~lib/util/math/log2_32_lut|inlined.0
     end
     local.get $2
     i32.const 31
@@ -8843,7 +9407,7 @@
      local.get $1
      f32.sub
      f32.div
-     br $~lib/util/math/log2f_lut|inlined.0
+     br $~lib/util/math/log2_32_lut|inlined.0
     end
     local.get $1
     f32.const 8388608
@@ -8948,8 +9512,20 @@
   return
  )
  (func $std/math/test_log2f (param $0 f32) (param $1 f32) (param $2 f32) (param $3 i32) (result i32)
-  local.get $0
-  call $~lib/math/NativeMathf.log2
+  (local $4 f32)
+  block $~lib/math/NativeMath.log2<f32>|inlined.0 (result f32)
+   local.get $0
+   local.set $4
+   i32.const 1
+   drop
+   i32.const 4
+   i32.const 4
+   i32.eq
+   drop
+   local.get $4
+   call $~lib/util/math/log2_32
+   br $~lib/math/NativeMath.log2<f32>|inlined.0
+  end
   local.get $1
   local.get $2
   local.get $3
@@ -9037,7 +9613,7 @@
   local.get $4
   call $std/math/check<f32>
  )
- (func $~lib/math/NativeMath.mod (param $0 f64) (param $1 f64) (result f64)
+ (func $~lib/util/math/mod64 (param $0 f64) (param $1 f64) (result f64)
   (local $2 i64)
   (local $3 i64)
   (local $4 i64)
@@ -9295,9 +9871,30 @@
   f64.reinterpret_i64
  )
  (func $std/math/test_mod (param $0 f64) (param $1 f64) (param $2 f64) (param $3 f64) (param $4 i32) (result i32)
-  local.get $0
-  local.get $1
-  call $~lib/math/NativeMath.mod
+  (local $5 f64)
+  (local $6 f64)
+  block $~lib/math/NativeMath.mod<f64>|inlined.0 (result f64)
+   local.get $0
+   local.set $6
+   local.get $1
+   local.set $5
+   i32.const 0
+   drop
+   i32.const 1
+   drop
+   i32.const 8
+   i32.const 4
+   i32.eq
+   drop
+   i32.const 8
+   i32.const 8
+   i32.eq
+   drop
+   local.get $6
+   local.get $5
+   call $~lib/util/math/mod64
+   br $~lib/math/NativeMath.mod<f64>|inlined.0
+  end
   local.get $2
   local.get $3
   local.get $4
@@ -9314,7 +9911,7 @@
    i32.const 0
   end
  )
- (func $~lib/math/NativeMathf.mod (param $0 f32) (param $1 f32) (result f32)
+ (func $~lib/util/math/mod32 (param $0 f32) (param $1 f32) (result f32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -9566,15 +10163,32 @@
   f32.reinterpret_i32
  )
  (func $std/math/test_modf (param $0 f32) (param $1 f32) (param $2 f32) (param $3 f32) (param $4 i32) (result i32)
-  local.get $0
-  local.get $1
-  call $~lib/math/NativeMathf.mod
+  (local $5 f32)
+  (local $6 f32)
+  block $~lib/math/NativeMath.mod<f32>|inlined.0 (result f32)
+   local.get $0
+   local.set $6
+   local.get $1
+   local.set $5
+   i32.const 0
+   drop
+   i32.const 1
+   drop
+   i32.const 4
+   i32.const 4
+   i32.eq
+   drop
+   local.get $6
+   local.get $5
+   call $~lib/util/math/mod32
+   br $~lib/math/NativeMath.mod<f32>|inlined.0
+  end
   local.get $2
   local.get $3
   local.get $4
   call $std/math/check<f32>
  )
- (func $~lib/math/NativeMath.pow (param $0 f64) (param $1 f64) (result f64)
+ (func $~lib/util/math/pow64 (param $0 f64) (param $1 f64) (result f64)
   (local $2 f64)
   (local $3 f64)
   (local $4 i32)
@@ -9675,7 +10289,7 @@
   i32.const 1
   i32.lt_s
   drop
-  block $~lib/util/math/pow_lut|inlined.0 (result f64)
+  block $~lib/util/math/pow64_lut|inlined.0 (result f64)
    local.get $0
    local.set $3
    local.get $1
@@ -9736,14 +10350,14 @@
      i64.eq
      if
       f64.const 1
-      br $~lib/util/math/pow_lut|inlined.0
+      br $~lib/util/math/pow64_lut|inlined.0
      end
      local.get $5
      i64.const 4607182418800017408
      i64.eq
      if
       f64.const nan:0x8000000000000
-      br $~lib/util/math/pow_lut|inlined.0
+      br $~lib/util/math/pow64_lut|inlined.0
      end
      local.get $5
      i64.const 1
@@ -9763,7 +10377,7 @@
       local.get $3
       local.get $2
       f64.add
-      br $~lib/util/math/pow_lut|inlined.0
+      br $~lib/util/math/pow64_lut|inlined.0
      end
      local.get $5
      i64.const 1
@@ -9772,7 +10386,7 @@
      i64.eq
      if
       f64.const nan:0x8000000000000
-      br $~lib/util/math/pow_lut|inlined.0
+      br $~lib/util/math/pow64_lut|inlined.0
      end
      local.get $5
      i64.const 1
@@ -9788,12 +10402,12 @@
      i32.eq
      if
       f64.const 0
-      br $~lib/util/math/pow_lut|inlined.0
+      br $~lib/util/math/pow64_lut|inlined.0
      end
      local.get $2
      local.get $2
      f64.mul
-     br $~lib/util/math/pow_lut|inlined.0
+     br $~lib/util/math/pow64_lut|inlined.0
     end
     local.get $5
     local.set $9
@@ -9816,7 +10430,7 @@
      i64.shr_u
      i32.wrap_i64
      if (result i32)
-      block $~lib/util/math/checkint|inlined.0 (result i32)
+      block $~lib/util/math/checkint64|inlined.0 (result i32)
        local.get $6
        local.set $9
        local.get $9
@@ -9830,7 +10444,7 @@
        i64.lt_u
        if
         i32.const 0
-        br $~lib/util/math/checkint|inlined.0
+        br $~lib/util/math/checkint64|inlined.0
        end
        local.get $11
        i64.const 1023
@@ -9839,7 +10453,7 @@
        i64.gt_u
        if
         i32.const 2
-        br $~lib/util/math/checkint|inlined.0
+        br $~lib/util/math/checkint64|inlined.0
        end
        i64.const 1
        i64.const 1023
@@ -9858,7 +10472,7 @@
        i64.ne
        if
         i32.const 0
-        br $~lib/util/math/checkint|inlined.0
+        br $~lib/util/math/checkint64|inlined.0
        end
        local.get $9
        local.get $11
@@ -9867,7 +10481,7 @@
        i64.ne
        if
         i32.const 1
-        br $~lib/util/math/checkint|inlined.0
+        br $~lib/util/math/checkint64|inlined.0
        end
        i32.const 2
       end
@@ -9893,7 +10507,7 @@
      else
       local.get $10
      end
-     br $~lib/util/math/pow_lut|inlined.0
+     br $~lib/util/math/pow64_lut|inlined.0
     end
     local.get $5
     i64.const 63
@@ -9901,7 +10515,7 @@
     i64.const 0
     i64.ne
     if
-     block $~lib/util/math/checkint|inlined.1 (result i32)
+     block $~lib/util/math/checkint64|inlined.1 (result i32)
       local.get $6
       local.set $9
       local.get $9
@@ -9915,7 +10529,7 @@
       i64.lt_u
       if
        i32.const 0
-       br $~lib/util/math/checkint|inlined.1
+       br $~lib/util/math/checkint64|inlined.1
       end
       local.get $11
       i64.const 1023
@@ -9924,7 +10538,7 @@
       i64.gt_u
       if
        i32.const 2
-       br $~lib/util/math/checkint|inlined.1
+       br $~lib/util/math/checkint64|inlined.1
       end
       i64.const 1
       i64.const 1023
@@ -9943,7 +10557,7 @@
       i64.ne
       if
        i32.const 0
-       br $~lib/util/math/checkint|inlined.1
+       br $~lib/util/math/checkint64|inlined.1
       end
       local.get $9
       local.get $11
@@ -9952,7 +10566,7 @@
       i64.ne
       if
        i32.const 1
-       br $~lib/util/math/checkint|inlined.1
+       br $~lib/util/math/checkint64|inlined.1
       end
       i32.const 2
      end
@@ -9968,7 +10582,7 @@
       local.get $3
       f64.sub
       f64.div
-      br $~lib/util/math/pow_lut|inlined.0
+      br $~lib/util/math/pow64_lut|inlined.0
      end
      local.get $12
      i32.const 1
@@ -10001,7 +10615,7 @@
      i64.eq
      if
       f64.const 1
-      br $~lib/util/math/pow_lut|inlined.0
+      br $~lib/util/math/pow64_lut|inlined.0
      end
      local.get $8
      i64.const 2047
@@ -10010,7 +10624,7 @@
      i64.lt_u
      if
       f64.const 1
-      br $~lib/util/math/pow_lut|inlined.0
+      br $~lib/util/math/pow64_lut|inlined.0
      end
      local.get $5
      i64.const 4607182418800017408
@@ -10024,7 +10638,7 @@
      else
       f64.const 0
      end
-     br $~lib/util/math/pow_lut|inlined.0
+     br $~lib/util/math/pow64_lut|inlined.0
     end
     local.get $7
     i64.const 0
@@ -10273,7 +10887,7 @@
    f64.mul
    f64.add
    local.set $35
-   block $~lib/util/math/exp_inline|inlined.0 (result f64)
+   block $~lib/util/math/exp64_inline|inlined.0 (result f64)
     local.get $36
     local.set $15
     local.get $35
@@ -10306,7 +10920,7 @@
       f64.const 1
       local.get $12
       select
-      br $~lib/util/math/exp_inline|inlined.0
+      br $~lib/util/math/exp64_inline|inlined.0
      end
      local.get $39
      i32.const 1033
@@ -10348,7 +10962,7 @@
        local.get $17
        f64.mul
       end
-      br $~lib/util/math/exp_inline|inlined.0
+      br $~lib/util/math/exp64_inline|inlined.0
      end
      i32.const 0
      local.set $39
@@ -10544,7 +11158,7 @@
       f64.const 2.2250738585072014e-308
       f64.mul
      end
-     br $~lib/util/math/exp_inline|inlined.0
+     br $~lib/util/math/exp64_inline|inlined.0
     end
     local.get $11
     f64.reinterpret_i64
@@ -10559,9 +11173,28 @@
   return
  )
  (func $std/math/test_pow (param $0 f64) (param $1 f64) (param $2 f64) (param $3 f64) (param $4 i32) (result i32)
-  local.get $0
-  local.get $1
-  call $~lib/math/NativeMath.pow
+  (local $5 f64)
+  (local $6 f64)
+  block $~lib/math/NativeMath.pow<f64>|inlined.0 (result f64)
+   local.get $0
+   local.set $6
+   local.get $1
+   local.set $5
+   i32.const 1
+   drop
+   i32.const 8
+   i32.const 4
+   i32.eq
+   drop
+   i32.const 8
+   i32.const 8
+   i32.eq
+   drop
+   local.get $6
+   local.get $5
+   call $~lib/util/math/pow64
+   br $~lib/math/NativeMath.pow<f64>|inlined.0
+  end
   local.get $2
   local.get $3
   local.get $4
@@ -10578,7 +11211,7 @@
    i32.const 0
   end
  )
- (func $~lib/math/NativeMathf.pow (param $0 f32) (param $1 f32) (result f32)
+ (func $~lib/util/math/pow32 (param $0 f32) (param $1 f32) (result f32)
   (local $2 f32)
   (local $3 f32)
   (local $4 i32)
@@ -10659,7 +11292,7 @@
   i32.const 1
   i32.lt_s
   drop
-  block $~lib/util/math/powf_lut|inlined.0 (result f32)
+  block $~lib/util/math/pow32_lut|inlined.0 (result f32)
    local.get $0
    local.set $3
    local.get $1
@@ -10708,14 +11341,14 @@
      i32.eq
      if
       f32.const 1
-      br $~lib/util/math/powf_lut|inlined.0
+      br $~lib/util/math/pow32_lut|inlined.0
      end
      local.get $5
      i32.const 1065353216
      i32.eq
      if
       f32.const nan:0x400000
-      br $~lib/util/math/powf_lut|inlined.0
+      br $~lib/util/math/pow32_lut|inlined.0
      end
      local.get $5
      i32.const 1
@@ -10739,7 +11372,7 @@
       local.get $3
       local.get $2
       f32.add
-      br $~lib/util/math/powf_lut|inlined.0
+      br $~lib/util/math/pow32_lut|inlined.0
      end
      local.get $5
      i32.const 1
@@ -10750,7 +11383,7 @@
      i32.eq
      if
       f32.const nan:0x400000
-      br $~lib/util/math/powf_lut|inlined.0
+      br $~lib/util/math/pow32_lut|inlined.0
      end
      local.get $5
      i32.const 1
@@ -10766,12 +11399,12 @@
      i32.eq
      if
       f32.const 0
-      br $~lib/util/math/powf_lut|inlined.0
+      br $~lib/util/math/pow32_lut|inlined.0
      end
      local.get $2
      local.get $2
      f32.mul
-     br $~lib/util/math/powf_lut|inlined.0
+     br $~lib/util/math/pow32_lut|inlined.0
     end
     local.get $5
     local.set $8
@@ -10795,7 +11428,7 @@
      i32.const 31
      i32.shr_u
      if (result i32)
-      block $~lib/util/math/checkintf|inlined.0 (result i32)
+      block $~lib/util/math/checkint32|inlined.0 (result i32)
        local.get $6
        local.set $8
        local.get $8
@@ -10809,7 +11442,7 @@
        i32.lt_u
        if
         i32.const 0
-        br $~lib/util/math/checkintf|inlined.0
+        br $~lib/util/math/checkint32|inlined.0
        end
        local.get $10
        i32.const 127
@@ -10818,7 +11451,7 @@
        i32.gt_u
        if
         i32.const 2
-        br $~lib/util/math/checkintf|inlined.0
+        br $~lib/util/math/checkint32|inlined.0
        end
        i32.const 1
        i32.const 127
@@ -10835,14 +11468,14 @@
        i32.and
        if
         i32.const 0
-        br $~lib/util/math/checkintf|inlined.0
+        br $~lib/util/math/checkint32|inlined.0
        end
        local.get $8
        local.get $10
        i32.and
        if
         i32.const 1
-        br $~lib/util/math/checkintf|inlined.0
+        br $~lib/util/math/checkint32|inlined.0
        end
        i32.const 2
       end
@@ -10866,13 +11499,13 @@
      else
       local.get $9
      end
-     br $~lib/util/math/powf_lut|inlined.0
+     br $~lib/util/math/pow32_lut|inlined.0
     end
     local.get $5
     i32.const 31
     i32.shr_u
     if
-     block $~lib/util/math/checkintf|inlined.1 (result i32)
+     block $~lib/util/math/checkint32|inlined.1 (result i32)
       local.get $6
       local.set $8
       local.get $8
@@ -10886,7 +11519,7 @@
       i32.lt_u
       if
        i32.const 0
-       br $~lib/util/math/checkintf|inlined.1
+       br $~lib/util/math/checkint32|inlined.1
       end
       local.get $10
       i32.const 127
@@ -10895,7 +11528,7 @@
       i32.gt_u
       if
        i32.const 2
-       br $~lib/util/math/checkintf|inlined.1
+       br $~lib/util/math/checkint32|inlined.1
       end
       i32.const 1
       i32.const 127
@@ -10912,14 +11545,14 @@
       i32.and
       if
        i32.const 0
-       br $~lib/util/math/checkintf|inlined.1
+       br $~lib/util/math/checkint32|inlined.1
       end
       local.get $8
       local.get $10
       i32.and
       if
        i32.const 1
-       br $~lib/util/math/checkintf|inlined.1
+       br $~lib/util/math/checkint32|inlined.1
       end
       i32.const 2
      end
@@ -10935,7 +11568,7 @@
       local.get $3
       f32.sub
       f32.div
-      br $~lib/util/math/powf_lut|inlined.0
+      br $~lib/util/math/pow32_lut|inlined.0
      end
      local.get $10
      i32.const 1
@@ -11099,7 +11732,7 @@
      select
      local.get $9
      f32.mul
-     br $~lib/util/math/powf_lut|inlined.0
+     br $~lib/util/math/pow32_lut|inlined.0
     end
     local.get $21
     f64.const -150
@@ -11119,7 +11752,7 @@
      select
      local.get $9
      f32.mul
-     br $~lib/util/math/powf_lut|inlined.0
+     br $~lib/util/math/pow32_lut|inlined.0
     end
    end
    local.get $21
@@ -11194,15 +11827,30 @@
   return
  )
  (func $std/math/test_powf (param $0 f32) (param $1 f32) (param $2 f32) (param $3 f32) (param $4 i32) (result i32)
-  local.get $0
-  local.get $1
-  call $~lib/math/NativeMathf.pow
+  (local $5 f32)
+  (local $6 f32)
+  block $~lib/math/NativeMath.pow<f32>|inlined.0 (result f32)
+   local.get $0
+   local.set $6
+   local.get $1
+   local.set $5
+   i32.const 1
+   drop
+   i32.const 4
+   i32.const 4
+   i32.eq
+   drop
+   local.get $6
+   local.get $5
+   call $~lib/util/math/pow32
+   br $~lib/math/NativeMath.pow<f32>|inlined.0
+  end
   local.get $2
   local.get $3
   local.get $4
   call $std/math/check<f32>
  )
- (func $~lib/math/murmurHash3 (param $0 i64) (result i64)
+ (func $~lib/util/math/murmurHash3 (param $0 i64) (result i64)
   local.get $0
   local.get $0
   i64.const 33
@@ -11231,41 +11879,6 @@
   local.set $0
   local.get $0
  )
- (func $~lib/math/splitMix32 (param $0 i32) (result i32)
-  local.get $0
-  i32.const 1831565813
-  i32.add
-  local.set $0
-  local.get $0
-  local.get $0
-  i32.const 15
-  i32.shr_u
-  i32.xor
-  local.get $0
-  i32.const 1
-  i32.or
-  i32.mul
-  local.set $0
-  local.get $0
-  local.get $0
-  local.get $0
-  local.get $0
-  i32.const 7
-  i32.shr_u
-  i32.xor
-  local.get $0
-  i32.const 61
-  i32.or
-  i32.mul
-  i32.add
-  i32.xor
-  local.set $0
-  local.get $0
-  local.get $0
-  i32.const 14
-  i32.shr_u
-  i32.xor
- )
  (func $~lib/math/NativeMath.seedRandom (param $0 i64)
   local.get $0
   i64.const 0
@@ -11275,20 +11888,13 @@
    local.set $0
   end
   local.get $0
-  call $~lib/math/murmurHash3
+  call $~lib/util/math/murmurHash3
   global.set $~lib/math/random_state0_64
   global.get $~lib/math/random_state0_64
   i64.const -1
   i64.xor
-  call $~lib/math/murmurHash3
+  call $~lib/util/math/murmurHash3
   global.set $~lib/math/random_state1_64
-  local.get $0
-  i32.wrap_i64
-  call $~lib/math/splitMix32
-  global.set $~lib/math/random_state0_32
-  global.get $~lib/math/random_state0_32
-  call $~lib/math/splitMix32
-  global.set $~lib/math/random_state1_32
   i32.const 1
   global.set $~lib/math/random_seeded
  )
@@ -11344,79 +11950,31 @@
   f64.const 1
   f64.sub
  )
- (func $~lib/math/NativeMathf.random (result f32)
-  (local $0 i64)
-  (local $1 i32)
-  (local $2 i32)
-  (local $3 i32)
-  global.get $~lib/math/random_seeded
-  i32.eqz
-  if
-   call $~lib/builtins/seed
-   i64.reinterpret_f64
-   local.set $0
-   local.get $0
-   call $~lib/math/NativeMath.seedRandom
-  end
-  global.get $~lib/math/random_state0_32
-  local.set $1
-  global.get $~lib/math/random_state1_32
-  local.set $2
-  local.get $1
-  i32.const -1640531525
-  i32.mul
-  i32.const 5
-  i32.rotl
-  i32.const 5
-  i32.mul
-  local.set $3
-  local.get $2
-  local.get $1
-  i32.xor
-  local.set $2
-  local.get $1
-  i32.const 26
-  i32.rotl
-  local.get $2
-  i32.xor
-  local.get $2
-  i32.const 9
-  i32.shl
-  i32.xor
-  global.set $~lib/math/random_state0_32
-  local.get $2
-  i32.const 13
-  i32.rotl
-  global.set $~lib/math/random_state1_32
-  local.get $3
-  i32.const 9
-  i32.shr_u
-  i32.const 127
-  i32.const 23
-  i32.shl
-  i32.or
-  f32.reinterpret_i32
-  f32.const 1
-  f32.sub
- )
  (func $std/math/test_round (param $0 f64) (param $1 f64) (param $2 f64) (param $3 i32) (result i32)
   (local $4 f64)
   (local $5 f64)
-  local.get $0
-  local.set $4
-  local.get $4
-  f64.ceil
-  local.set $5
-  local.get $5
-  local.get $5
-  f64.const 1
-  f64.sub
-  local.get $5
-  f64.const 0.5
-  f64.sub
-  local.get $4
-  f64.le
-  select
+  block $~lib/math/NativeMath.round<f64>|inlined.0 (result f64)
+   local.get $0
+   local.set $4
+   i32.const 0
+   drop
+   i32.const 1
+   drop
+   local.get $4
+   f64.ceil
+   local.set $5
+   local.get $5
+   local.get $5
+   f64.const 1
+   f64.sub
+   local.get $5
+   f64.const 0.5
+   f64.sub
+   local.get $4
+   f64.le
+   select
+   br $~lib/math/NativeMath.round<f64>|inlined.0
+  end
   local.get $1
   local.get $2
   local.get $3
@@ -11425,21 +11983,28 @@
  (func $std/math/test_roundf (param $0 f32) (param $1 f32) (param $2 f32) (param $3 i32) (result i32)
   (local $4 f32)
   (local $5 f32)
-  local.get $0
-  local.set $4
-  local.get $4
-  f32.ceil
-  local.set $5
-  local.get $5
-  local.get $5
-  f32.const 1
-  f32.sub
-  local.get $5
-  f32.const 0.5
-  f32.sub
-  local.get $4
-  f32.le
-  select
+  block $~lib/math/NativeMath.round<f32>|inlined.0 (result f32)
+   local.get $0
+   local.set $4
+   i32.const 0
+   drop
+   i32.const 1
+   drop
+   local.get $4
+   f32.ceil
+   local.set $5
+   local.get $5
+   local.get $5
+   f32.const 1
+   f32.sub
+   local.get $5
+   f32.const 0.5
+   f32.sub
+   local.get $4
+   f32.le
+   select
+   br $~lib/math/NativeMath.round<f32>|inlined.0
+  end
   local.get $1
   local.get $2
   local.get $3
@@ -11447,9 +12012,13 @@
  )
  (func $std/math/test_sign (param $0 f64) (param $1 f64) (param $2 f64) (param $3 i32) (result i32)
   (local $4 f64)
-  block $~lib/math/NativeMath.sign|inlined.0 (result f64)
+  block $~lib/math/NativeMath.sign<f64>|inlined.0 (result f64)
    local.get $0
    local.set $4
+   i32.const 0
+   drop
+   i32.const 1
+   drop
    i32.const 0
    i32.const 0
    i32.gt_s
@@ -11469,7 +12038,7 @@
      local.get $4
     end
    end
-   br $~lib/math/NativeMath.sign|inlined.0
+   br $~lib/math/NativeMath.sign<f64>|inlined.0
   end
   local.get $1
   local.get $2
@@ -11488,9 +12057,13 @@
  )
  (func $std/math/test_signf (param $0 f32) (param $1 f32) (param $2 f32) (param $3 i32) (result i32)
   (local $4 f32)
-  block $~lib/math/NativeMathf.sign|inlined.0 (result f32)
+  block $~lib/math/NativeMath.sign<f32>|inlined.0 (result f32)
    local.get $0
    local.set $4
+   i32.const 0
+   drop
+   i32.const 1
+   drop
    i32.const 0
    i32.const 0
    i32.gt_s
@@ -11510,653 +12083,14 @@
      local.get $4
     end
    end
-   br $~lib/math/NativeMathf.sign|inlined.0
+   br $~lib/math/NativeMath.sign<f32>|inlined.0
   end
   local.get $1
   local.get $2
   local.get $3
   call $std/math/check<f32>
  )
- (func $~lib/math/NativeMath.rem (param $0 f64) (param $1 f64) (result f64)
-  (local $2 i64)
-  (local $3 i64)
-  (local $4 i64)
-  (local $5 i64)
-  (local $6 i32)
-  (local $7 f64)
-  (local $8 i64)
-  (local $9 i32)
-  (local $10 i32)
-  (local $11 i64)
-  (local $12 f64)
-  local.get $0
-  i64.reinterpret_f64
-  local.set $2
-  local.get $1
-  i64.reinterpret_f64
-  local.set $3
-  local.get $2
-  i64.const 52
-  i64.shr_u
-  i64.const 2047
-  i64.and
-  local.set $4
-  local.get $3
-  i64.const 52
-  i64.shr_u
-  i64.const 2047
-  i64.and
-  local.set $5
-  local.get $2
-  i64.const 63
-  i64.shr_u
-  i32.wrap_i64
-  local.set $6
-  local.get $3
-  i64.const 1
-  i64.shl
-  i64.const 0
-  i64.eq
-  if (result i32)
-   i32.const 1
-  else
-   local.get $4
-   i64.const 2047
-   i64.eq
-  end
-  if (result i32)
-   i32.const 1
-  else
-   local.get $1
-   local.get $1
-   f64.ne
-  end
-  if
-   local.get $0
-   local.get $1
-   f64.mul
-   local.set $7
-   local.get $7
-   local.get $7
-   f64.div
-   return
-  end
-  local.get $2
-  i64.const 1
-  i64.shl
-  i64.const 0
-  i64.eq
-  if
-   local.get $0
-   return
-  end
-  local.get $2
-  local.set $8
-  local.get $4
-  i64.const 0
-  i64.ne
-  i32.eqz
-  if
-   local.get $4
-   local.get $8
-   i64.const 12
-   i64.shl
-   i64.clz
-   i64.sub
-   local.set $4
-   local.get $8
-   i64.const 1
-   local.get $4
-   i64.sub
-   i64.shl
-   local.set $8
-  else
-   local.get $8
-   i64.const -1
-   i64.const 12
-   i64.shr_u
-   i64.and
-   local.set $8
-   local.get $8
-   i64.const 1
-   i64.const 52
-   i64.shl
-   i64.or
-   local.set $8
-  end
-  local.get $5
-  i64.const 0
-  i64.ne
-  i32.eqz
-  if
-   local.get $5
-   local.get $3
-   i64.const 12
-   i64.shl
-   i64.clz
-   i64.sub
-   local.set $5
-   local.get $3
-   i64.const 1
-   local.get $5
-   i64.sub
-   i64.shl
-   local.set $3
-  else
-   local.get $3
-   i64.const -1
-   i64.const 12
-   i64.shr_u
-   i64.and
-   local.set $3
-   local.get $3
-   i64.const 1
-   i64.const 52
-   i64.shl
-   i64.or
-   local.set $3
-  end
-  i32.const 0
-  local.set $9
-  block $do-break|0
-   loop $do-loop|0
-    local.get $4
-    local.get $5
-    i64.lt_s
-    if
-     local.get $4
-     i64.const 1
-     i64.add
-     local.get $5
-     i64.eq
-     if
-      br $do-break|0
-     end
-     local.get $0
-     return
-    end
-    loop $while-continue|1
-     local.get $4
-     local.get $5
-     i64.gt_s
-     local.set $10
-     local.get $10
-     if
-      local.get $8
-      local.get $3
-      i64.ge_u
-      if
-       local.get $8
-       local.get $3
-       i64.sub
-       local.set $8
-       local.get $9
-       i32.const 1
-       i32.add
-       local.set $9
-      end
-      local.get $8
-      i64.const 1
-      i64.shl
-      local.set $8
-      local.get $9
-      i32.const 1
-      i32.shl
-      local.set $9
-      local.get $4
-      i64.const 1
-      i64.sub
-      local.set $4
-      br $while-continue|1
-     end
-    end
-    local.get $8
-    local.get $3
-    i64.ge_u
-    if
-     local.get $8
-     local.get $3
-     i64.sub
-     local.set $8
-     local.get $9
-     i32.const 1
-     i32.add
-     local.set $9
-    end
-    local.get $8
-    i64.const 0
-    i64.eq
-    if
-     i64.const -60
-     local.set $4
-    else
-     local.get $8
-     i64.const 11
-     i64.shl
-     i64.clz
-     local.set $11
-     local.get $4
-     local.get $11
-     i64.sub
-     local.set $4
-     local.get $8
-     local.get $11
-     i64.shl
-     local.set $8
-    end
-    br $do-break|0
-   end
-   unreachable
-  end
-  local.get $4
-  i64.const 0
-  i64.gt_s
-  if
-   local.get $8
-   i64.const 1
-   i64.const 52
-   i64.shl
-   i64.sub
-   local.set $8
-   local.get $8
-   local.get $4
-   i64.const 52
-   i64.shl
-   i64.or
-   local.set $8
-  else
-   local.get $8
-   i64.const 0
-   local.get $4
-   i64.sub
-   i64.const 1
-   i64.add
-   i64.shr_u
-   local.set $8
-  end
-  local.get $8
-  f64.reinterpret_i64
-  local.set $0
-  local.get $1
-  f64.abs
-  local.set $1
-  local.get $0
-  local.get $0
-  f64.add
-  local.set $12
-  local.get $4
-  local.get $5
-  i64.eq
-  if (result i32)
-   i32.const 1
-  else
-   local.get $4
-   i64.const 1
-   i64.add
-   local.get $5
-   i64.eq
-   if (result i32)
-    local.get $12
-    local.get $1
-    f64.gt
-    if (result i32)
-     i32.const 1
-    else
-     local.get $12
-     local.get $1
-     f64.eq
-     if (result i32)
-      local.get $9
-      i32.const 1
-      i32.and
-     else
-      i32.const 0
-     end
-    end
-   else
-    i32.const 0
-   end
-  end
-  if
-   local.get $0
-   local.get $1
-   f64.sub
-   local.set $0
-  end
-  local.get $6
-  if (result f64)
-   local.get $0
-   f64.neg
-  else
-   local.get $0
-  end
- )
- (func $std/math/test_rem (param $0 f64) (param $1 f64) (param $2 f64) (param $3 f64) (param $4 i32) (result i32)
-  local.get $0
-  local.get $1
-  call $~lib/math/NativeMath.rem
-  local.get $2
-  local.get $3
-  local.get $4
-  call $std/math/check<f64>
- )
- (func $~lib/math/NativeMathf.rem (param $0 f32) (param $1 f32) (result f32)
-  (local $2 i32)
-  (local $3 i32)
-  (local $4 i32)
-  (local $5 i32)
-  (local $6 i32)
-  (local $7 i32)
-  (local $8 i32)
-  (local $9 i32)
-  (local $10 f32)
-  local.get $0
-  i32.reinterpret_f32
-  local.set $2
-  local.get $1
-  i32.reinterpret_f32
-  local.set $3
-  local.get $2
-  i32.const 23
-  i32.shr_u
-  i32.const 255
-  i32.and
-  local.set $4
-  local.get $3
-  i32.const 23
-  i32.shr_u
-  i32.const 255
-  i32.and
-  local.set $5
-  local.get $2
-  i32.const 31
-  i32.shr_u
-  local.set $6
-  local.get $2
-  local.set $7
-  local.get $3
-  i32.const 1
-  i32.shl
-  i32.const 0
-  i32.eq
-  if (result i32)
-   i32.const 1
-  else
-   local.get $4
-   i32.const 255
-   i32.eq
-  end
-  if (result i32)
-   i32.const 1
-  else
-   local.get $1
-   local.get $1
-   f32.ne
-  end
-  if
-   local.get $0
-   local.get $1
-   f32.mul
-   local.get $0
-   local.get $1
-   f32.mul
-   f32.div
-   return
-  end
-  local.get $2
-  i32.const 1
-  i32.shl
-  i32.const 0
-  i32.eq
-  if
-   local.get $0
-   return
-  end
-  local.get $4
-  i32.eqz
-  if
-   local.get $4
-   local.get $7
-   i32.const 9
-   i32.shl
-   i32.clz
-   i32.sub
-   local.set $4
-   local.get $7
-   i32.const 1
-   local.get $4
-   i32.sub
-   i32.shl
-   local.set $7
-  else
-   local.get $7
-   i32.const -1
-   i32.const 9
-   i32.shr_u
-   i32.and
-   local.set $7
-   local.get $7
-   i32.const 1
-   i32.const 23
-   i32.shl
-   i32.or
-   local.set $7
-  end
-  local.get $5
-  i32.eqz
-  if
-   local.get $5
-   local.get $3
-   i32.const 9
-   i32.shl
-   i32.clz
-   i32.sub
-   local.set $5
-   local.get $3
-   i32.const 1
-   local.get $5
-   i32.sub
-   i32.shl
-   local.set $3
-  else
-   local.get $3
-   i32.const -1
-   i32.const 9
-   i32.shr_u
-   i32.and
-   local.set $3
-   local.get $3
-   i32.const 1
-   i32.const 23
-   i32.shl
-   i32.or
-   local.set $3
-  end
-  i32.const 0
-  local.set $8
-  block $do-break|0
-   loop $do-loop|0
-    local.get $4
-    local.get $5
-    i32.lt_s
-    if
-     local.get $4
-     i32.const 1
-     i32.add
-     local.get $5
-     i32.eq
-     if
-      br $do-break|0
-     end
-     local.get $0
-     return
-    end
-    loop $while-continue|1
-     local.get $4
-     local.get $5
-     i32.gt_s
-     local.set $9
-     local.get $9
-     if
-      local.get $7
-      local.get $3
-      i32.ge_u
-      if
-       local.get $7
-       local.get $3
-       i32.sub
-       local.set $7
-       local.get $8
-       i32.const 1
-       i32.add
-       local.set $8
-      end
-      local.get $7
-      i32.const 1
-      i32.shl
-      local.set $7
-      local.get $8
-      i32.const 1
-      i32.shl
-      local.set $8
-      local.get $4
-      i32.const 1
-      i32.sub
-      local.set $4
-      br $while-continue|1
-     end
-    end
-    local.get $7
-    local.get $3
-    i32.ge_u
-    if
-     local.get $7
-     local.get $3
-     i32.sub
-     local.set $7
-     local.get $8
-     i32.const 1
-     i32.add
-     local.set $8
-    end
-    local.get $7
-    i32.const 0
-    i32.eq
-    if
-     i32.const -30
-     local.set $4
-    else
-     local.get $7
-     i32.const 8
-     i32.shl
-     i32.clz
-     local.set $9
-     local.get $4
-     local.get $9
-     i32.sub
-     local.set $4
-     local.get $7
-     local.get $9
-     i32.shl
-     local.set $7
-    end
-    br $do-break|0
-   end
-   unreachable
-  end
-  local.get $4
-  i32.const 0
-  i32.gt_s
-  if
-   local.get $7
-   i32.const 1
-   i32.const 23
-   i32.shl
-   i32.sub
-   local.set $7
-   local.get $7
-   local.get $4
-   i32.const 23
-   i32.shl
-   i32.or
-   local.set $7
-  else
-   local.get $7
-   i32.const 0
-   local.get $4
-   i32.sub
-   i32.const 1
-   i32.add
-   i32.shr_u
-   local.set $7
-  end
-  local.get $7
-  f32.reinterpret_i32
-  local.set $0
-  local.get $1
-  f32.abs
-  local.set $1
-  local.get $0
-  local.get $0
-  f32.add
-  local.set $10
-  local.get $4
-  local.get $5
-  i32.eq
-  if (result i32)
-   i32.const 1
-  else
-   local.get $4
-   i32.const 1
-   i32.add
-   local.get $5
-   i32.eq
-   if (result i32)
-    local.get $10
-    local.get $1
-    f32.gt
-    if (result i32)
-     i32.const 1
-    else
-     local.get $10
-     local.get $1
-     f32.eq
-     if (result i32)
-      local.get $8
-      i32.const 1
-      i32.and
-     else
-      i32.const 0
-     end
-    end
-   else
-    i32.const 0
-   end
-  end
-  if
-   local.get $0
-   local.get $1
-   f32.sub
-   local.set $0
-  end
-  local.get $6
-  if (result f32)
-   local.get $0
-   f32.neg
-  else
-   local.get $0
-  end
- )
- (func $std/math/test_remf (param $0 f32) (param $1 f32) (param $2 f32) (param $3 f32) (param $4 i32) (result i32)
-  local.get $0
-  local.get $1
-  call $~lib/math/NativeMathf.rem
-  local.get $2
-  local.get $3
-  local.get $4
-  call $std/math/check<f32>
- )
- (func $~lib/math/NativeMath.sin (param $0 f64) (result f64)
+ (func $~lib/util/math/sin64 (param $0 f64) (result f64)
   (local $1 i64)
   (local $2 i32)
   (local $3 i32)
@@ -12203,7 +12137,7 @@
     local.get $0
     return
    end
-   block $~lib/math/sin_kern|inlined.1 (result f64)
+   block $~lib/util/math/sin64_kern|inlined.1 (result f64)
     local.get $0
     local.set $6
     f64.const 0
@@ -12254,7 +12188,7 @@
      f64.add
      f64.mul
      f64.add
-     br $~lib/math/sin_kern|inlined.1
+     br $~lib/util/math/sin64_kern|inlined.1
     else
      local.get $6
      local.get $7
@@ -12273,7 +12207,7 @@
      f64.mul
      f64.sub
      f64.sub
-     br $~lib/math/sin_kern|inlined.1
+     br $~lib/util/math/sin64_kern|inlined.1
     end
     unreachable
    end
@@ -12288,7 +12222,7 @@
    f64.sub
    return
   end
-  block $~lib/math/rempio2|inlined.1 (result i32)
+  block $~lib/util/math/rempio2_64|inlined.1 (result i32)
    local.get $0
    local.set $5
    local.get $1
@@ -12388,11 +12322,11 @@
      local.set $13
     end
     local.get $9
-    global.set $~lib/math/rempio2_y0
+    global.set $~lib/util/math/rempio2_y0
     local.get $8
-    global.set $~lib/math/rempio2_y1
+    global.set $~lib/util/math/rempio2_y1
     local.get $13
-    br $~lib/math/rempio2|inlined.1
+    br $~lib/util/math/rempio2_64|inlined.1
    end
    local.get $12
    i32.const 1094263291
@@ -12514,16 +12448,16 @@
     f64.sub
     local.set $6
     local.get $7
-    global.set $~lib/math/rempio2_y0
+    global.set $~lib/util/math/rempio2_y0
     local.get $6
-    global.set $~lib/math/rempio2_y1
+    global.set $~lib/util/math/rempio2_y1
     local.get $8
     i32.trunc_sat_f64_s
-    br $~lib/math/rempio2|inlined.1
+    br $~lib/util/math/rempio2_64|inlined.1
    end
    local.get $5
    local.get $11
-   call $~lib/math/pio2_large_quot
+   call $~lib/util/math/pio2_64_large_quot
    local.set $15
    i32.const 0
    local.get $15
@@ -12533,9 +12467,9 @@
    select
   end
   local.set $17
-  global.get $~lib/math/rempio2_y0
+  global.get $~lib/util/math/rempio2_y0
   local.set $18
-  global.get $~lib/math/rempio2_y1
+  global.get $~lib/util/math/rempio2_y1
   local.set $19
   local.get $17
   i32.const 1
@@ -12603,7 +12537,7 @@
    f64.add
    f64.add
   else
-   block $~lib/math/sin_kern|inlined.2 (result f64)
+   block $~lib/util/math/sin64_kern|inlined.2 (result f64)
     local.get $18
     local.set $16
     local.get $19
@@ -12654,7 +12588,7 @@
      f64.add
      f64.mul
      f64.add
-     br $~lib/math/sin_kern|inlined.2
+     br $~lib/util/math/sin64_kern|inlined.2
     else
      local.get $16
      local.get $10
@@ -12673,7 +12607,7 @@
      f64.mul
      f64.sub
      f64.sub
-     br $~lib/math/sin_kern|inlined.2
+     br $~lib/util/math/sin64_kern|inlined.2
     end
     unreachable
    end
@@ -12690,8 +12624,24 @@
   end
  )
  (func $std/math/test_sin (param $0 f64) (param $1 f64) (param $2 f64) (param $3 i32) (result i32)
-  local.get $0
-  call $~lib/math/NativeMath.sin
+  (local $4 f64)
+  block $~lib/math/NativeMath.sin<f64>|inlined.0 (result f64)
+   local.get $0
+   local.set $4
+   i32.const 1
+   drop
+   i32.const 8
+   i32.const 4
+   i32.eq
+   drop
+   i32.const 8
+   i32.const 8
+   i32.eq
+   drop
+   local.get $4
+   call $~lib/util/math/sin64
+   br $~lib/math/NativeMath.sin<f64>|inlined.0
+  end
   local.get $1
   local.get $2
   local.get $3
@@ -12707,7 +12657,7 @@
    i32.const 0
   end
  )
- (func $~lib/math/NativeMathf.sin (param $0 f32) (result f32)
+ (func $~lib/util/math/sin32 (param $0 f32) (result f32)
   (local $1 i32)
   (local $2 i32)
   (local $3 f64)
@@ -13081,7 +13031,7 @@
    f32.sub
    return
   end
-  block $~lib/math/rempio2f|inlined.1 (result i32)
+  block $~lib/util/math/rempio2_32|inlined.1 (result i32)
    local.get $0
    local.set $10
    local.get $1
@@ -13108,10 +13058,10 @@
     f64.const 1.5893254773528196e-08
     f64.mul
     f64.sub
-    global.set $~lib/math/rempio2f_y
+    global.set $~lib/util/math/rempio2_32_y
     local.get $7
     i32.trunc_sat_f64_s
-    br $~lib/math/rempio2f|inlined.1
+    br $~lib/util/math/rempio2_32|inlined.1
    end
    local.get $10
    local.set $12
@@ -13218,7 +13168,7 @@
    local.get $22
    f64.convert_i64_s
    f64.mul
-   global.set $~lib/math/rempio2f_y
+   global.set $~lib/util/math/rempio2_32_y
    local.get $23
    local.set $23
    i32.const 0
@@ -13229,7 +13179,7 @@
    select
   end
   local.set $24
-  global.get $~lib/math/rempio2f_y
+  global.get $~lib/util/math/rempio2_32_y
   local.set $25
   local.get $24
   i32.const 1
@@ -13318,14 +13268,26 @@
   end
  )
  (func $std/math/test_sinf (param $0 f32) (param $1 f32) (param $2 f32) (param $3 i32) (result i32)
-  local.get $0
-  call $~lib/math/NativeMathf.sin
+  (local $4 f32)
+  block $~lib/math/NativeMath.sin<f32>|inlined.0 (result f32)
+   local.get $0
+   local.set $4
+   i32.const 1
+   drop
+   i32.const 4
+   i32.const 4
+   i32.eq
+   drop
+   local.get $4
+   call $~lib/util/math/sin32
+   br $~lib/math/NativeMath.sin<f32>|inlined.0
+  end
   local.get $1
   local.get $2
   local.get $3
   call $std/math/check<f32>
  )
- (func $~lib/math/NativeMath.sinh (param $0 f64) (result f64)
+ (func $~lib/util/math/sinh64 (param $0 f64) (result f64)
   (local $1 i64)
   (local $2 f64)
   (local $3 i32)
@@ -13355,7 +13317,7 @@
   i32.lt_u
   if
    local.get $2
-   call $~lib/math/NativeMath.expm1
+   call $~lib/util/math/expm1_64
    local.set $5
    local.get $3
    i32.const 1072693248
@@ -13419,7 +13381,7 @@
   local.get $6
   f64.const 1416.0996898839683
   f64.sub
-  call $~lib/math/NativeMath.exp
+  call $~lib/util/math/exp64
   local.get $5
   local.get $7
   f64.mul
@@ -13428,8 +13390,24 @@
   f64.mul
  )
  (func $std/math/test_sinh (param $0 f64) (param $1 f64) (param $2 f64) (param $3 i32) (result i32)
-  local.get $0
-  call $~lib/math/NativeMath.sinh
+  (local $4 f64)
+  block $~lib/math/NativeMath.sinh<f64>|inlined.0 (result f64)
+   local.get $0
+   local.set $4
+   i32.const 1
+   drop
+   i32.const 8
+   i32.const 4
+   i32.eq
+   drop
+   i32.const 8
+   i32.const 8
+   i32.eq
+   drop
+   local.get $4
+   call $~lib/util/math/sinh64
+   br $~lib/math/NativeMath.sinh<f64>|inlined.0
+  end
   local.get $1
   local.get $2
   local.get $3
@@ -13445,7 +13423,7 @@
    i32.const 0
   end
  )
- (func $~lib/math/NativeMathf.sinh (param $0 f32) (result f32)
+ (func $~lib/util/math/sinh32 (param $0 f32) (result f32)
   (local $1 i32)
   (local $2 f32)
   (local $3 f32)
@@ -13469,7 +13447,7 @@
   i32.lt_u
   if
    local.get $2
-   call $~lib/math/NativeMathf.expm1
+   call $~lib/util/math/expm1_32
    local.set $4
    local.get $1
    i32.const 1065353216
@@ -13530,7 +13508,7 @@
   local.get $5
   f32.const 162.88958740234375
   f32.sub
-  call $~lib/math/NativeMathf.exp
+  call $~lib/util/math/exp32
   local.get $4
   local.get $6
   f32.mul
@@ -13539,8 +13517,20 @@
   f32.mul
  )
  (func $std/math/test_sinhf (param $0 f32) (param $1 f32) (param $2 f32) (param $3 i32) (result i32)
-  local.get $0
-  call $~lib/math/NativeMathf.sinh
+  (local $4 f32)
+  block $~lib/math/NativeMath.sinh<f32>|inlined.0 (result f32)
+   local.get $0
+   local.set $4
+   i32.const 1
+   drop
+   i32.const 4
+   i32.const 4
+   i32.eq
+   drop
+   local.get $4
+   call $~lib/util/math/sinh32
+   br $~lib/math/NativeMath.sinh<f32>|inlined.0
+  end
   local.get $1
   local.get $2
   local.get $3
@@ -13548,10 +13538,15 @@
  )
  (func $std/math/test_sqrt (param $0 f64) (param $1 f64) (param $2 f64) (param $3 i32) (result i32)
   (local $4 f64)
-  local.get $0
-  local.set $4
-  local.get $4
-  f64.sqrt
+  block $~lib/math/NativeMath.sqrt<f64>|inlined.0 (result f64)
+   local.get $0
+   local.set $4
+   i32.const 1
+   drop
+   local.get $4
+   f64.sqrt
+   br $~lib/math/NativeMath.sqrt<f64>|inlined.0
+  end
   local.get $1
   local.get $2
   local.get $3
@@ -13569,16 +13564,21 @@
  )
  (func $std/math/test_sqrtf (param $0 f32) (param $1 f32) (param $2 f32) (param $3 i32) (result i32)
   (local $4 f32)
-  local.get $0
-  local.set $4
-  local.get $4
-  f32.sqrt
+  block $~lib/math/NativeMath.sqrt<f32>|inlined.0 (result f32)
+   local.get $0
+   local.set $4
+   i32.const 1
+   drop
+   local.get $4
+   f32.sqrt
+   br $~lib/math/NativeMath.sqrt<f32>|inlined.0
+  end
   local.get $1
   local.get $2
   local.get $3
   call $std/math/check<f32>
  )
- (func $~lib/math/tan_kern (param $0 f64) (param $1 f64) (param $2 i32) (result f64)
+ (func $~lib/util/math/tan64_kern (param $0 f64) (param $1 f64) (param $2 i32) (result f64)
   (local $3 f64)
   (local $4 f64)
   (local $5 f64)
@@ -13791,7 +13791,7 @@
   f64.mul
   f64.add
  )
- (func $~lib/math/NativeMath.tan (param $0 f64) (result f64)
+ (func $~lib/util/math/tan64 (param $0 f64) (result f64)
   (local $1 i64)
   (local $2 i32)
   (local $3 i32)
@@ -13839,7 +13839,7 @@
    local.get $0
    f64.const 0
    i32.const 1
-   call $~lib/math/tan_kern
+   call $~lib/util/math/tan64_kern
    return
   end
   local.get $2
@@ -13851,7 +13851,7 @@
    f64.sub
    return
   end
-  block $~lib/math/rempio2|inlined.2 (result i32)
+  block $~lib/util/math/rempio2_64|inlined.2 (result i32)
    local.get $0
    local.set $6
    local.get $1
@@ -13951,11 +13951,11 @@
      local.set $8
     end
     local.get $10
-    global.set $~lib/math/rempio2_y0
+    global.set $~lib/util/math/rempio2_y0
     local.get $11
-    global.set $~lib/math/rempio2_y1
+    global.set $~lib/util/math/rempio2_y1
     local.get $8
-    br $~lib/math/rempio2|inlined.2
+    br $~lib/util/math/rempio2_64|inlined.2
    end
    local.get $7
    i32.const 1094263291
@@ -14077,16 +14077,16 @@
     f64.sub
     local.set $15
     local.get $12
-    global.set $~lib/math/rempio2_y0
+    global.set $~lib/util/math/rempio2_y0
     local.get $15
-    global.set $~lib/math/rempio2_y1
+    global.set $~lib/util/math/rempio2_y1
     local.get $11
     i32.trunc_sat_f64_s
-    br $~lib/math/rempio2|inlined.2
+    br $~lib/util/math/rempio2_64|inlined.2
    end
    local.get $6
    local.get $5
-   call $~lib/math/pio2_large_quot
+   call $~lib/util/math/pio2_64_large_quot
    local.set $14
    i32.const 0
    local.get $14
@@ -14096,8 +14096,8 @@
    select
   end
   local.set $17
-  global.get $~lib/math/rempio2_y0
-  global.get $~lib/math/rempio2_y1
+  global.get $~lib/util/math/rempio2_y0
+  global.get $~lib/util/math/rempio2_y1
   i32.const 1
   local.get $17
   i32.const 1
@@ -14105,11 +14105,27 @@
   i32.const 1
   i32.shl
   i32.sub
-  call $~lib/math/tan_kern
+  call $~lib/util/math/tan64_kern
  )
  (func $std/math/test_tan (param $0 f64) (param $1 f64) (param $2 f64) (param $3 i32) (result i32)
-  local.get $0
-  call $~lib/math/NativeMath.tan
+  (local $4 f64)
+  block $~lib/math/NativeMath.tan<f64>|inlined.0 (result f64)
+   local.get $0
+   local.set $4
+   i32.const 1
+   drop
+   i32.const 8
+   i32.const 4
+   i32.eq
+   drop
+   i32.const 8
+   i32.const 8
+   i32.eq
+   drop
+   local.get $4
+   call $~lib/util/math/tan64
+   br $~lib/math/NativeMath.tan<f64>|inlined.0
+  end
   local.get $1
   local.get $2
   local.get $3
@@ -14125,7 +14141,7 @@
    i32.const 0
   end
  )
- (func $~lib/math/NativeMathf.tan (param $0 f32) (result f32)
+ (func $~lib/util/math/tan32 (param $0 f32) (result f32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -14563,7 +14579,7 @@
    f32.sub
    return
   end
-  block $~lib/math/rempio2f|inlined.2 (result i32)
+  block $~lib/util/math/rempio2_32|inlined.2 (result i32)
    local.get $0
    local.set $12
    local.get $1
@@ -14590,10 +14606,10 @@
     f64.const 1.5893254773528196e-08
     f64.mul
     f64.sub
-    global.set $~lib/math/rempio2f_y
+    global.set $~lib/util/math/rempio2_32_y
     local.get $10
     i32.trunc_sat_f64_s
-    br $~lib/math/rempio2f|inlined.2
+    br $~lib/util/math/rempio2_32|inlined.2
    end
    local.get $12
    local.set $14
@@ -14700,7 +14716,7 @@
    local.get $24
    f64.convert_i64_s
    f64.mul
-   global.set $~lib/math/rempio2f_y
+   global.set $~lib/util/math/rempio2_32_y
    local.get $25
    local.set $25
    i32.const 0
@@ -14711,7 +14727,7 @@
    select
   end
   local.set $26
-  global.get $~lib/math/rempio2f_y
+  global.get $~lib/util/math/rempio2_32_y
   local.set $27
   local.get $27
   local.set $4
@@ -14777,14 +14793,26 @@
   f32.demote_f64
  )
  (func $std/math/test_tanf (param $0 f32) (param $1 f32) (param $2 f32) (param $3 i32) (result i32)
-  local.get $0
-  call $~lib/math/NativeMathf.tan
+  (local $4 f32)
+  block $~lib/math/NativeMath.tan<f32>|inlined.0 (result f32)
+   local.get $0
+   local.set $4
+   i32.const 1
+   drop
+   i32.const 4
+   i32.const 4
+   i32.eq
+   drop
+   local.get $4
+   call $~lib/util/math/tan32
+   br $~lib/math/NativeMath.tan<f32>|inlined.0
+  end
   local.get $1
   local.get $2
   local.get $3
   call $std/math/check<f32>
  )
- (func $~lib/math/NativeMath.tanh (param $0 f64) (result f64)
+ (func $~lib/util/math/tanh64 (param $0 f64) (result f64)
   (local $1 i64)
   (local $2 f64)
   (local $3 i32)
@@ -14822,7 +14850,7 @@
     f64.const 2
     local.get $2
     f64.mul
-    call $~lib/math/NativeMath.expm1
+    call $~lib/util/math/expm1_64
     local.set $4
     f64.const 1
     f64.const 2
@@ -14841,7 +14869,7 @@
     f64.const 2
     local.get $2
     f64.mul
-    call $~lib/math/NativeMath.expm1
+    call $~lib/util/math/expm1_64
     local.set $4
     local.get $4
     local.get $4
@@ -14857,7 +14885,7 @@
      f64.const -2
      local.get $2
      f64.mul
-     call $~lib/math/NativeMath.expm1
+     call $~lib/util/math/expm1_64
      local.set $4
      local.get $4
      f64.neg
@@ -14877,8 +14905,24 @@
   f64.copysign
  )
  (func $std/math/test_tanh (param $0 f64) (param $1 f64) (param $2 f64) (param $3 i32) (result i32)
-  local.get $0
-  call $~lib/math/NativeMath.tanh
+  (local $4 f64)
+  block $~lib/math/NativeMath.tanh<f64>|inlined.0 (result f64)
+   local.get $0
+   local.set $4
+   i32.const 1
+   drop
+   i32.const 8
+   i32.const 4
+   i32.eq
+   drop
+   i32.const 8
+   i32.const 8
+   i32.eq
+   drop
+   local.get $4
+   call $~lib/util/math/tanh64
+   br $~lib/math/NativeMath.tanh<f64>|inlined.0
+  end
   local.get $1
   local.get $2
   local.get $3
@@ -14894,7 +14938,7 @@
    i32.const 0
   end
  )
- (func $~lib/math/NativeMathf.tanh (param $0 f32) (result f32)
+ (func $~lib/util/math/tanh32 (param $0 f32) (result f32)
   (local $1 i32)
   (local $2 f32)
   (local $3 f32)
@@ -14926,7 +14970,7 @@
     f32.const 2
     local.get $2
     f32.mul
-    call $~lib/math/NativeMathf.expm1
+    call $~lib/util/math/expm1_32
     local.set $3
     f32.const 1
     f32.const 2
@@ -14945,7 +14989,7 @@
     f32.const 2
     local.get $2
     f32.mul
-    call $~lib/math/NativeMathf.expm1
+    call $~lib/util/math/expm1_32
     local.set $3
     local.get $3
     local.get $3
@@ -14961,7 +15005,7 @@
      f32.const -2
      local.get $2
      f32.mul
-     call $~lib/math/NativeMathf.expm1
+     call $~lib/util/math/expm1_32
      local.set $3
      local.get $3
      f32.neg
@@ -14981,8 +15025,20 @@
   f32.copysign
  )
  (func $std/math/test_tanhf (param $0 f32) (param $1 f32) (param $2 f32) (param $3 i32) (result i32)
-  local.get $0
-  call $~lib/math/NativeMathf.tanh
+  (local $4 f32)
+  block $~lib/math/NativeMath.tanh<f32>|inlined.0 (result f32)
+   local.get $0
+   local.set $4
+   i32.const 1
+   drop
+   i32.const 4
+   i32.const 4
+   i32.eq
+   drop
+   local.get $4
+   call $~lib/util/math/tanh32
+   br $~lib/math/NativeMath.tanh<f32>|inlined.0
+  end
   local.get $1
   local.get $2
   local.get $3
@@ -14990,10 +15046,17 @@
  )
  (func $std/math/test_trunc (param $0 f64) (param $1 f64) (param $2 f64) (param $3 i32) (result i32)
   (local $4 f64)
-  local.get $0
-  local.set $4
-  local.get $4
-  f64.trunc
+  block $~lib/math/NativeMath.trunc<f64>|inlined.0 (result f64)
+   local.get $0
+   local.set $4
+   i32.const 0
+   drop
+   i32.const 1
+   drop
+   local.get $4
+   f64.trunc
+   br $~lib/math/NativeMath.trunc<f64>|inlined.0
+  end
   local.get $1
   local.get $2
   local.get $3
@@ -15011,26 +15074,33 @@
  )
  (func $std/math/test_truncf (param $0 f32) (param $1 f32) (param $2 f32) (param $3 i32) (result i32)
   (local $4 f32)
-  local.get $0
-  local.set $4
-  local.get $4
-  f32.trunc
+  block $~lib/math/NativeMath.trunc<f32>|inlined.0 (result f32)
+   local.get $0
+   local.set $4
+   i32.const 0
+   drop
+   i32.const 1
+   drop
+   local.get $4
+   f32.trunc
+   br $~lib/math/NativeMath.trunc<f32>|inlined.0
+  end
   local.get $1
   local.get $2
   local.get $3
   call $std/math/check<f32>
  )
- (func $~lib/math/NativeMath.sincos (param $0 f64)
+ (func $~lib/util/math/sincos64 (param $0 f64) (result f64)
   (local $1 i64)
   (local $2 i32)
   (local $3 i32)
-  (local $4 i32)
+  (local $4 f64)
   (local $5 f64)
   (local $6 f64)
   (local $7 f64)
   (local $8 f64)
   (local $9 f64)
-  (local $10 f64)
+  (local $10 i32)
   (local $11 i64)
   (local $12 i32)
   (local $13 i32)
@@ -15068,117 +15138,41 @@
    i32.const 1044816030
    i32.lt_u
    if
-    local.get $0
-    global.set $~lib/math/NativeMath.sincos_sin
     f64.const 1
-    global.set $~lib/math/NativeMath.sincos_cos
+    global.set $~lib/util/math/sincos_cos64
+    local.get $0
     return
    end
-   block $~lib/math/sin_kern|inlined.3 (result f64)
-    local.get $0
-    local.set $6
-    f64.const 0
-    local.set $5
-    i32.const 0
-    local.set $4
-    local.get $6
-    local.get $6
-    f64.mul
-    local.set $7
-    local.get $7
-    local.get $7
-    f64.mul
-    local.set $8
-    f64.const 0.00833333333332249
-    local.get $7
-    f64.const -1.984126982985795e-04
-    local.get $7
-    f64.const 2.7557313707070068e-06
-    f64.mul
-    f64.add
-    f64.mul
-    f64.add
-    local.get $7
-    local.get $8
-    f64.mul
-    f64.const -2.5050760253406863e-08
-    local.get $7
-    f64.const 1.58969099521155e-10
-    f64.mul
-    f64.add
-    f64.mul
-    f64.add
-    local.set $9
-    local.get $7
-    local.get $6
-    f64.mul
-    local.set $10
-    local.get $4
-    i32.eqz
-    if
-     local.get $6
-     local.get $10
-     f64.const -0.16666666666666632
-     local.get $7
-     local.get $9
-     f64.mul
-     f64.add
-     f64.mul
-     f64.add
-     br $~lib/math/sin_kern|inlined.3
-    else
-     local.get $6
-     local.get $7
-     f64.const 0.5
-     local.get $5
-     f64.mul
-     local.get $10
-     local.get $9
-     f64.mul
-     f64.sub
-     f64.mul
-     local.get $5
-     f64.sub
-     local.get $10
-     f64.const -0.16666666666666632
-     f64.mul
-     f64.sub
-     f64.sub
-     br $~lib/math/sin_kern|inlined.3
-    end
-    unreachable
-   end
-   global.set $~lib/math/NativeMath.sincos_sin
    local.get $0
-   local.set $6
-   f64.const 0
    local.set $5
+   f64.const 0
+   local.set $4
+   local.get $5
+   local.get $5
+   f64.mul
+   local.set $6
    local.get $6
    local.get $6
    f64.mul
-   local.set $10
-   local.get $10
-   local.get $10
-   f64.mul
-   local.set $9
-   local.get $10
+   local.set $7
+   local.get $6
    f64.const 0.0416666666666666
-   local.get $10
+   local.get $6
    f64.const -0.001388888888887411
-   local.get $10
+   local.get $6
    f64.const 2.480158728947673e-05
    f64.mul
    f64.add
    f64.mul
    f64.add
    f64.mul
-   local.get $9
-   local.get $9
+   local.get $7
+   local.get $7
    f64.mul
    f64.const -2.7557314351390663e-07
-   local.get $10
+   local.get $6
    f64.const 2.087572321298175e-09
-   local.get $10
+   local.get $6
    f64.const -1.1359647557788195e-11
    f64.mul
    f64.add
@@ -15188,29 +15182,103 @@
    f64.add
    local.set $8
    f64.const 0.5
-   local.get $10
+   local.get $6
    f64.mul
-   local.set $7
-   f64.const 1
-   local.get $7
-   f64.sub
    local.set $9
-   local.get $9
    f64.const 1
    local.get $9
    f64.sub
+   local.set $7
+   local.get $7
+   f64.const 1
    local.get $7
    f64.sub
-   local.get $10
+   local.get $9
+   f64.sub
+   local.get $6
    local.get $8
    f64.mul
-   local.get $6
    local.get $5
+   local.get $4
    f64.mul
    f64.sub
    f64.add
    f64.add
-   global.set $~lib/math/NativeMath.sincos_cos
+   global.set $~lib/util/math/sincos_cos64
+   block $~lib/util/math/sin64_kern|inlined.3 (result f64)
+    local.get $0
+    local.set $5
+    f64.const 0
+    local.set $4
+    i32.const 0
+    local.set $10
+    local.get $5
+    local.get $5
+    f64.mul
+    local.set $9
+    local.get $9
+    local.get $9
+    f64.mul
+    local.set $8
+    f64.const 0.00833333333332249
+    local.get $9
+    f64.const -1.984126982985795e-04
+    local.get $9
+    f64.const 2.7557313707070068e-06
+    f64.mul
+    f64.add
+    f64.mul
+    f64.add
+    local.get $9
+    local.get $8
+    f64.mul
+    f64.const -2.5050760253406863e-08
+    local.get $9
+    f64.const 1.58969099521155e-10
+    f64.mul
+    f64.add
+    f64.mul
+    f64.add
+    local.set $7
+    local.get $9
+    local.get $5
+    f64.mul
+    local.set $6
+    local.get $10
+    i32.eqz
+    if
+     local.get $5
+     local.get $6
+     f64.const -0.16666666666666632
+     local.get $9
+     local.get $7
+     f64.mul
+     f64.add
+     f64.mul
+     f64.add
+     br $~lib/util/math/sin64_kern|inlined.3
+    else
+     local.get $5
+     local.get $9
+     f64.const 0.5
+     local.get $4
+     f64.mul
+     local.get $6
+     local.get $7
+     f64.mul
+     f64.sub
+     f64.mul
+     local.get $4
+     f64.sub
+     local.get $6
+     f64.const -0.16666666666666632
+     f64.mul
+     f64.sub
+     f64.sub
+     br $~lib/util/math/sin64_kern|inlined.3
+    end
+    unreachable
+   end
    return
   end
   local.get $2
@@ -15220,20 +15288,19 @@
    local.get $0
    local.get $0
    f64.sub
-   local.set $7
-   local.get $7
-   global.set $~lib/math/NativeMath.sincos_sin
-   local.get $7
-   global.set $~lib/math/NativeMath.sincos_cos
+   local.set $6
+   local.get $6
+   global.set $~lib/util/math/sincos_cos64
+   local.get $6
    return
   end
-  block $~lib/math/rempio2|inlined.3 (result i32)
+  block $~lib/util/math/rempio2_64|inlined.3 (result i32)
    local.get $0
-   local.set $5
+   local.set $4
    local.get $1
    local.set $11
    local.get $3
-   local.set $4
+   local.set $10
    local.get $11
    i64.const 32
    i64.shr_u
@@ -15251,116 +15318,116 @@
    if
     i32.const 1
     local.set $13
-    local.get $4
+    local.get $10
     i32.eqz
     if
-     local.get $5
+     local.get $4
      f64.const 1.5707963267341256
      f64.sub
-     local.set $7
+     local.set $6
      local.get $12
      i32.const 1073291771
      i32.ne
      if
-      local.get $7
+      local.get $6
       f64.const 6.077100506506192e-11
-      f64.sub
-      local.set $8
-      local.get $7
-      local.get $8
-      f64.sub
-      f64.const 6.077100506506192e-11
-      f64.sub
-      local.set $9
-     else
-      local.get $7
-      f64.const 6.077100506303966e-11
       f64.sub
       local.set $7
+      local.get $6
       local.get $7
+      f64.sub
+      f64.const 6.077100506506192e-11
+      f64.sub
+      local.set $8
+     else
+      local.get $6
+      f64.const 6.077100506303966e-11
+      f64.sub
+      local.set $6
+      local.get $6
+      f64.const 2.0222662487959506e-21
+      f64.sub
+      local.set $7
+      local.get $6
+      local.get $7
+      f64.sub
       f64.const 2.0222662487959506e-21
       f64.sub
       local.set $8
-      local.get $7
-      local.get $8
-      f64.sub
-      f64.const 2.0222662487959506e-21
-      f64.sub
-      local.set $9
      end
     else
-     local.get $5
+     local.get $4
      f64.const 1.5707963267341256
      f64.add
-     local.set $7
+     local.set $6
      local.get $12
      i32.const 1073291771
      i32.ne
      if
-      local.get $7
+      local.get $6
       f64.const 6.077100506506192e-11
-      f64.add
-      local.set $8
-      local.get $7
-      local.get $8
-      f64.sub
-      f64.const 6.077100506506192e-11
-      f64.add
-      local.set $9
-     else
-      local.get $7
-      f64.const 6.077100506303966e-11
       f64.add
       local.set $7
+      local.get $6
       local.get $7
-      f64.const 2.0222662487959506e-21
+      f64.sub
+      f64.const 6.077100506506192e-11
       f64.add
       local.set $8
+     else
+      local.get $6
+      f64.const 6.077100506303966e-11
+      f64.add
+      local.set $6
+      local.get $6
+      f64.const 2.0222662487959506e-21
+      f64.add
+      local.set $7
+      local.get $6
       local.get $7
-      local.get $8
       f64.sub
       f64.const 2.0222662487959506e-21
       f64.add
-      local.set $9
+      local.set $8
      end
      i32.const -1
      local.set $13
     end
+    local.get $7
+    global.set $~lib/util/math/rempio2_y0
     local.get $8
-    global.set $~lib/math/rempio2_y0
-    local.get $9
-    global.set $~lib/math/rempio2_y1
+    global.set $~lib/util/math/rempio2_y1
     local.get $13
-    br $~lib/math/rempio2|inlined.3
+    br $~lib/util/math/rempio2_64|inlined.3
    end
    local.get $12
    i32.const 1094263291
    i32.lt_u
    if
-    local.get $5
+    local.get $4
     f64.const 0.6366197723675814
     f64.mul
     f64.nearest
-    local.set $9
-    local.get $5
-    local.get $9
+    local.set $8
+    local.get $4
+    local.get $8
     f64.const 1.5707963267341256
     f64.mul
     f64.sub
-    local.set $8
-    local.get $9
+    local.set $7
+    local.get $8
     f64.const 6.077100506506192e-11
     f64.mul
-    local.set $7
+    local.set $6
     local.get $12
     i32.const 20
     i32.shr_u
     local.set $13
-    local.get $8
     local.get $7
+    local.get $6
     f64.sub
-    local.set $10
-    local.get $10
+    local.set $9
+    local.get $9
     i64.reinterpret_f64
     i64.const 32
     i64.shr_u
@@ -15378,31 +15445,31 @@
     i32.const 16
     i32.gt_u
     if
+     local.get $7
+     local.set $5
      local.get $8
-     local.set $6
-     local.get $9
      f64.const 6.077100506303966e-11
      f64.mul
-     local.set $7
+     local.set $6
+     local.get $5
      local.get $6
-     local.get $7
      f64.sub
-     local.set $8
-     local.get $9
+     local.set $7
+     local.get $8
      f64.const 2.0222662487959506e-21
      f64.mul
+     local.get $5
+     local.get $7
+     f64.sub
      local.get $6
-     local.get $8
      f64.sub
+     f64.sub
+     local.set $6
      local.get $7
+     local.get $6
      f64.sub
-     f64.sub
-     local.set $7
-     local.get $8
-     local.get $7
-     f64.sub
-     local.set $10
-     local.get $10
+     local.set $9
+     local.get $9
      i64.reinterpret_f64
      i64.const 32
      i64.shr_u
@@ -15420,133 +15487,133 @@
      i32.const 49
      i32.gt_u
      if
-      local.get $8
+      local.get $7
       local.set $16
-      local.get $9
+      local.get $8
       f64.const 2.0222662487111665e-21
       f64.mul
-      local.set $7
+      local.set $6
       local.get $16
-      local.get $7
+      local.get $6
       f64.sub
-      local.set $8
-      local.get $9
+      local.set $7
+      local.get $8
       f64.const 8.4784276603689e-32
       f64.mul
       local.get $16
-      local.get $8
-      f64.sub
       local.get $7
       f64.sub
+      local.get $6
       f64.sub
-      local.set $7
-      local.get $8
+      f64.sub
+      local.set $6
       local.get $7
+      local.get $6
       f64.sub
-      local.set $10
+      local.set $9
      end
     end
-    local.get $8
-    local.get $10
-    f64.sub
     local.get $7
-    f64.sub
-    local.set $6
-    local.get $10
-    global.set $~lib/math/rempio2_y0
-    local.get $6
-    global.set $~lib/math/rempio2_y1
     local.get $9
+    f64.sub
+    local.get $6
+    f64.sub
+    local.set $5
+    local.get $9
+    global.set $~lib/util/math/rempio2_y0
+    local.get $5
+    global.set $~lib/util/math/rempio2_y1
+    local.get $8
     i32.trunc_sat_f64_s
-    br $~lib/math/rempio2|inlined.3
+    br $~lib/util/math/rempio2_64|inlined.3
    end
-   local.get $5
+   local.get $4
    local.get $11
-   call $~lib/math/pio2_large_quot
+   call $~lib/util/math/pio2_64_large_quot
    local.set $15
    i32.const 0
    local.get $15
    i32.sub
    local.get $15
-   local.get $4
+   local.get $10
    select
   end
   local.set $17
-  global.get $~lib/math/rempio2_y0
+  global.get $~lib/util/math/rempio2_y0
   local.set $18
-  global.get $~lib/math/rempio2_y1
+  global.get $~lib/util/math/rempio2_y1
   local.set $19
-  block $~lib/math/sin_kern|inlined.4 (result f64)
+  block $~lib/util/math/sin64_kern|inlined.4 (result f64)
    local.get $18
-   local.set $9
+   local.set $8
    local.get $19
    local.set $16
    i32.const 1
    local.set $13
-   local.get $9
-   local.get $9
+   local.get $8
+   local.get $8
+   f64.mul
+   local.set $4
+   local.get $4
+   local.get $4
    f64.mul
    local.set $5
-   local.get $5
-   local.get $5
-   f64.mul
-   local.set $6
    f64.const 0.00833333333332249
-   local.get $5
+   local.get $4
    f64.const -1.984126982985795e-04
-   local.get $5
+   local.get $4
    f64.const 2.7557313707070068e-06
    f64.mul
    f64.add
    f64.mul
    f64.add
+   local.get $4
    local.get $5
-   local.get $6
    f64.mul
    f64.const -2.5050760253406863e-08
-   local.get $5
+   local.get $4
    f64.const 1.58969099521155e-10
    f64.mul
    f64.add
    f64.mul
    f64.add
-   local.set $10
-   local.get $5
-   local.get $9
+   local.set $9
+   local.get $4
+   local.get $8
    f64.mul
-   local.set $7
+   local.set $6
    local.get $13
    i32.eqz
    if
-    local.get $9
-    local.get $7
+    local.get $8
+    local.get $6
     f64.const -0.16666666666666632
-    local.get $5
-    local.get $10
-    f64.mul
-    f64.add
-    f64.mul
-    f64.add
-    br $~lib/math/sin_kern|inlined.4
-   else
+    local.get $4
     local.get $9
-    local.get $5
+    f64.mul
+    f64.add
+    f64.mul
+    f64.add
+    br $~lib/util/math/sin64_kern|inlined.4
+   else
+    local.get $8
+    local.get $4
     f64.const 0.5
     local.get $16
     f64.mul
-    local.get $7
-    local.get $10
+    local.get $6
+    local.get $9
     f64.mul
     f64.sub
     f64.mul
     local.get $16
     f64.sub
-    local.get $7
+    local.get $6
     f64.const -0.16666666666666632
     f64.mul
     f64.sub
     f64.sub
-    br $~lib/math/sin_kern|inlined.4
+    br $~lib/util/math/sin64_kern|inlined.4
    end
    unreachable
   end
@@ -15554,33 +15621,33 @@
   local.get $18
   local.set $16
   local.get $19
-  local.set $8
-  local.get $16
-  local.get $16
-  f64.mul
   local.set $7
-  local.get $7
-  local.get $7
+  local.get $16
+  local.get $16
   f64.mul
-  local.set $10
-  local.get $7
+  local.set $6
+  local.get $6
+  local.get $6
+  f64.mul
+  local.set $9
+  local.get $6
   f64.const 0.0416666666666666
-  local.get $7
+  local.get $6
   f64.const -0.001388888888887411
-  local.get $7
+  local.get $6
   f64.const 2.480158728947673e-05
   f64.mul
   f64.add
   f64.mul
   f64.add
   f64.mul
-  local.get $10
-  local.get $10
+  local.get $9
+  local.get $9
   f64.mul
   f64.const -2.7557314351390663e-07
-  local.get $7
+  local.get $6
   f64.const 2.087572321298175e-09
-  local.get $7
+  local.get $6
   f64.const -1.1359647557788195e-11
   f64.mul
   f64.add
@@ -15588,26 +15655,26 @@
   f64.add
   f64.mul
   f64.add
-  local.set $6
-  f64.const 0.5
-  local.get $7
-  f64.mul
   local.set $5
-  f64.const 1
-  local.get $5
-  f64.sub
-  local.set $10
-  local.get $10
-  f64.const 1
-  local.get $10
-  f64.sub
-  local.get $5
-  f64.sub
-  local.get $7
+  f64.const 0.5
   local.get $6
   f64.mul
+  local.set $4
+  f64.const 1
+  local.get $4
+  f64.sub
+  local.set $9
+  local.get $9
+  f64.const 1
+  local.get $9
+  f64.sub
+  local.get $4
+  f64.sub
+  local.get $6
+  local.get $5
+  f64.mul
   local.get $16
-  local.get $8
+  local.get $7
   f64.mul
   f64.sub
   f64.add
@@ -15638,10 +15705,9 @@
    f64.neg
    local.set $23
   end
-  local.get $22
-  global.set $~lib/math/NativeMath.sincos_sin
   local.get $23
-  global.set $~lib/math/NativeMath.sincos_cos
+  global.set $~lib/util/math/sincos_cos64
+  local.get $22
  )
  (func $std/math/test_sincos (param $0 i64) (param $1 i64) (param $2 i64) (param $3 i64) (param $4 i64) (param $5 i32) (result i32)
   (local $6 f64)
@@ -15649,6 +15715,7 @@
   (local $8 f64)
   (local $9 f64)
   (local $10 f64)
+  (local $11 f64)
   local.get $0
   f64.reinterpret_i64
   local.set $6
@@ -15665,7 +15732,22 @@
   f64.reinterpret_i64
   local.set $10
   local.get $6
-  call $~lib/math/NativeMath.sincos
+  local.set $11
+  i32.const 1
+  drop
+  i32.const 8
+  i32.const 4
+  i32.eq
+  drop
+  i32.const 8
+  i32.const 8
+  i32.eq
+  drop
+  local.get $11
+  call $~lib/util/math/sincos64
+  global.set $~lib/math/NativeMath.sincos_sin
+  global.get $~lib/util/math/sincos_cos64
+  global.set $~lib/math/NativeMath.sincos_cos
   global.get $~lib/math/NativeMath.sincos_sin
   local.get $7
   local.get $9
@@ -15681,7 +15763,7 @@
    i32.const 0
   end
  )
- (func $~lib/math/dtoi32 (param $0 f64) (result i32)
+ (func $~lib/util/math/dtoi32 (param $0 f64) (result i32)
   (local $1 i32)
   (local $2 i64)
   (local $3 i64)
@@ -15762,8 +15844,12 @@
   local.get $1
   return
  )
- (func $~lib/math/NativeMath.imul (param $0 f64) (param $1 f64) (result f64)
+ (func $~lib/math/NativeMath.imul<f64> (param $0 f64) (param $1 f64) (result f64)
   (local $2 f64)
+  i32.const 0
+  drop
+  i32.const 1
+  drop
   local.get $0
   local.get $1
   f64.add
@@ -15778,13 +15864,18 @@
    return
   end
   local.get $0
-  call $~lib/math/dtoi32
+  call $~lib/util/math/dtoi32
   local.get $1
-  call $~lib/math/dtoi32
+  call $~lib/util/math/dtoi32
   i32.mul
   f64.convert_i32_s
+  return
  )
- (func $~lib/math/NativeMath.clz32 (param $0 f64) (result f64)
+ (func $~lib/math/NativeMath.clz32<f64> (param $0 f64) (result i32)
+  i32.const 0
+  drop
+  i32.const 1
+  drop
   local.get $0
   local.get $0
   f64.sub
@@ -15792,15 +15883,15 @@
   f64.eq
   i32.eqz
   if
-   f64.const 32
+   i32.const 32
    return
   end
   local.get $0
-  call $~lib/math/dtoi32
+  call $~lib/util/math/dtoi32
   i32.clz
-  f64.convert_i32_s
+  return
  )
- (func $~lib/math/ipow64 (param $0 i64) (param $1 i64) (result i64)
+ (func $~lib/util/math/ipow64 (param $0 i64) (param $1 i64) (result i64)
   (local $2 i64)
   (local $3 i32)
   (local $4 i32)
@@ -16063,7 +16154,7 @@
   end
   local.get $2
  )
- (func $~lib/math/ipow32 (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/util/math/ipow32 (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -16284,18 +16375,13 @@
  )
  (func $start:std/math
   (local $0 f64)
-  (local $1 i32)
+  (local $1 f64)
   (local $2 i32)
-  (local $3 i64)
+  (local $3 i32)
   (local $4 f32)
-  (local $5 f64)
   global.get $~lib/math/NativeMath.E
   global.get $~lib/math/NativeMath.E
   f64.eq
-  drop
-  global.get $~lib/math/NativeMathf.E
-  global.get $~lib/math/NativeMathf.E
-  f32.eq
   drop
   global.get $~lib/math/NativeMath.E
   global.get $~lib/bindings/dom/Math.E
@@ -16306,7 +16392,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 111
+   i32.const 116
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -16320,7 +16406,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 112
+   i32.const 117
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -16334,7 +16420,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 113
+   i32.const 118
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -16348,7 +16434,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 114
+   i32.const 119
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -16362,7 +16448,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 115
+   i32.const 120
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -16376,7 +16462,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 116
+   i32.const 121
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -16390,112 +16476,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 117
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  global.get $~lib/math/NativeMathf.E
-  global.get $~lib/bindings/dom/Math.E
-  f32.demote_f64
-  f32.const 0
-  i32.const 0
-  call $std/math/check<f32>
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 119
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  global.get $~lib/math/NativeMathf.LN2
-  global.get $~lib/bindings/dom/Math.LN2
-  f32.demote_f64
-  f32.const 0
-  i32.const 0
-  call $std/math/check<f32>
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 120
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  global.get $~lib/math/NativeMathf.LN10
-  global.get $~lib/bindings/dom/Math.LN10
-  f32.demote_f64
-  f32.const 0
-  i32.const 0
-  call $std/math/check<f32>
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 121
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  global.get $~lib/math/NativeMathf.LOG2E
-  global.get $~lib/bindings/dom/Math.LOG2E
-  f32.demote_f64
-  f32.const 0
-  i32.const 0
-  call $std/math/check<f32>
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
    i32.const 122
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  global.get $~lib/math/NativeMathf.PI
-  global.get $~lib/bindings/dom/Math.PI
-  f32.demote_f64
-  f32.const 0
-  i32.const 0
-  call $std/math/check<f32>
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 123
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  global.get $~lib/math/NativeMathf.SQRT1_2
-  global.get $~lib/bindings/dom/Math.SQRT1_2
-  f32.demote_f64
-  f32.const 0
-  i32.const 0
-  call $std/math/check<f32>
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 124
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  global.get $~lib/math/NativeMathf.SQRT2
-  global.get $~lib/bindings/dom/Math.SQRT2
-  f32.demote_f64
-  f32.const 0
-  i32.const 0
-  call $std/math/check<f32>
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 125
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -16510,7 +16491,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 136
+   i32.const 133
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -16525,7 +16506,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 137
+   i32.const 134
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -16540,7 +16521,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 138
+   i32.const 135
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -16555,7 +16536,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 139
+   i32.const 136
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -16570,7 +16551,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 140
+   i32.const 137
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -16585,7 +16566,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 141
+   i32.const 138
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -16600,7 +16581,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 142
+   i32.const 139
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -16615,7 +16596,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 143
+   i32.const 140
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -16630,7 +16611,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 144
+   i32.const 141
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -16645,7 +16626,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 145
+   i32.const 142
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -16660,7 +16641,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 148
+   i32.const 145
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -16675,7 +16656,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 149
+   i32.const 146
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -16690,7 +16671,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 150
+   i32.const 147
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -16698,6 +16679,53 @@
   f64.const nan:0x8000000000000
   i32.const 0
   f64.const nan:0x8000000000000
+  f64.const 0
+  i32.const 0
+  call $std/math/test_scalbn
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 148
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const inf
+  i32.const 0
+  f64.const inf
+  f64.const 0
+  i32.const 0
+  call $std/math/test_scalbn
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 149
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const inf
+  f64.neg
+  i32.const 0
+  f64.const inf
+  f64.neg
+  f64.const 0
+  i32.const 0
+  call $std/math/test_scalbn
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 150
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const 1
+  i32.const 0
+  f64.const 1
   f64.const 0
   i32.const 0
   call $std/math/test_scalbn
@@ -16706,53 +16734,6 @@
    i32.const 0
    i32.const 32
    i32.const 151
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const inf
-  i32.const 0
-  f64.const inf
-  f64.const 0
-  i32.const 0
-  call $std/math/test_scalbn
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 152
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const inf
-  f64.neg
-  i32.const 0
-  f64.const inf
-  f64.neg
-  f64.const 0
-  i32.const 0
-  call $std/math/test_scalbn
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 153
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const 1
-  i32.const 0
-  f64.const 1
-  f64.const 0
-  i32.const 0
-  call $std/math/test_scalbn
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 154
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -16767,7 +16748,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 155
+   i32.const 152
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -16782,7 +16763,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 156
+   i32.const 153
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -16799,7 +16780,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 157
+   i32.const 154
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -16814,7 +16795,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 158
+   i32.const 155
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -16829,7 +16810,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 159
+   i32.const 156
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -16844,7 +16825,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 160
+   i32.const 157
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -16861,7 +16842,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 161
+   i32.const 158
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -16876,7 +16857,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 162
+   i32.const 159
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -16891,7 +16872,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 163
+   i32.const 160
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -16908,7 +16889,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 164
+   i32.const 161
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -16925,7 +16906,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 165
+   i32.const 162
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -16942,7 +16923,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 166
+   i32.const 163
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -16957,7 +16938,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 175
+   i32.const 172
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -16972,7 +16953,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 176
+   i32.const 173
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -16987,7 +16968,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 177
+   i32.const 174
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -17002,7 +16983,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 178
+   i32.const 175
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -17017,7 +16998,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 179
+   i32.const 176
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -17032,7 +17013,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 180
+   i32.const 177
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -17047,7 +17028,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 181
+   i32.const 178
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -17062,7 +17043,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 182
+   i32.const 179
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -17077,7 +17058,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 183
+   i32.const 180
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -17092,7 +17073,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 184
+   i32.const 181
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -17107,7 +17088,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 187
+   i32.const 184
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -17122,7 +17103,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 188
+   i32.const 185
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -17137,7 +17118,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 189
+   i32.const 186
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -17145,6 +17126,53 @@
   f32.const nan:0x400000
   i32.const 0
   f32.const nan:0x400000
+  f32.const 0
+  i32.const 0
+  call $std/math/test_scalbnf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 187
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const inf
+  i32.const 0
+  f32.const inf
+  f32.const 0
+  i32.const 0
+  call $std/math/test_scalbnf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 188
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const inf
+  f32.neg
+  i32.const 0
+  f32.const inf
+  f32.neg
+  f32.const 0
+  i32.const 0
+  call $std/math/test_scalbnf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 189
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const 1
+  i32.const 0
+  f32.const 1
   f32.const 0
   i32.const 0
   call $std/math/test_scalbnf
@@ -17153,53 +17181,6 @@
    i32.const 0
    i32.const 32
    i32.const 190
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const inf
-  i32.const 0
-  f32.const inf
-  f32.const 0
-  i32.const 0
-  call $std/math/test_scalbnf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 191
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const inf
-  f32.neg
-  i32.const 0
-  f32.const inf
-  f32.neg
-  f32.const 0
-  i32.const 0
-  call $std/math/test_scalbnf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 192
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const 1
-  i32.const 0
-  f32.const 1
-  f32.const 0
-  i32.const 0
-  call $std/math/test_scalbnf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 193
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -17214,7 +17195,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 194
+   i32.const 191
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -17229,7 +17210,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 195
+   i32.const 192
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -17246,7 +17227,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 196
+   i32.const 193
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -17261,7 +17242,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 197
+   i32.const 194
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -17276,7 +17257,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 198
+   i32.const 195
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -17291,7 +17272,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 199
+   i32.const 196
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -17308,7 +17289,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 200
+   i32.const 197
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -17323,7 +17304,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 201
+   i32.const 198
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -17338,7 +17319,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 202
+   i32.const 199
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -17355,7 +17336,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 203
+   i32.const 200
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -17372,7 +17353,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 204
+   i32.const 201
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -17389,7 +17370,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 205
+   i32.const 202
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -17403,7 +17384,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 217
+   i32.const 214
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -17417,7 +17398,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 218
+   i32.const 215
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -17431,7 +17412,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 219
+   i32.const 216
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -17445,7 +17426,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 220
+   i32.const 217
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -17459,7 +17440,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 221
+   i32.const 218
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -17473,7 +17454,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 222
+   i32.const 219
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -17487,7 +17468,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 223
+   i32.const 220
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -17501,7 +17482,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 224
+   i32.const 221
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -17515,7 +17496,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 225
+   i32.const 222
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -17529,7 +17510,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 226
+   i32.const 223
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -17543,7 +17524,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 229
+   i32.const 226
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -17557,7 +17538,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 230
+   i32.const 227
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -17571,7 +17552,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 231
+   i32.const 228
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -17585,7 +17566,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 232
+   i32.const 229
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -17599,7 +17580,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 233
+   i32.const 230
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -17614,7 +17595,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 234
+   i32.const 231
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -17628,7 +17609,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 235
+   i32.const 232
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -17642,7 +17623,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 244
+   i32.const 241
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -17656,7 +17637,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 245
+   i32.const 242
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -17670,7 +17651,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 246
+   i32.const 243
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -17684,7 +17665,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 247
+   i32.const 244
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -17698,7 +17679,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 248
+   i32.const 245
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -17712,7 +17693,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 249
+   i32.const 246
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -17726,7 +17707,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 250
+   i32.const 247
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -17740,7 +17721,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 251
+   i32.const 248
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -17754,7 +17735,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 252
+   i32.const 249
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -17768,7 +17749,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 253
+   i32.const 250
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -17782,7 +17763,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 256
+   i32.const 253
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -17796,7 +17777,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 257
+   i32.const 254
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -17810,7 +17791,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 258
+   i32.const 255
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -17824,7 +17805,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 259
+   i32.const 256
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -17838,7 +17819,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 260
+   i32.const 257
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -17853,7 +17834,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 261
+   i32.const 258
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -17867,12 +17848,54 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 262
+   i32.const 259
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f64.const -8.06684839057968
+  f64.const nan:0x8000000000000
+  f64.const 0
+  global.get $std/math/INVALID
+  call $std/math/test_acos
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 271
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const 4.345239849338305
+  f64.const nan:0x8000000000000
+  f64.const 0
+  global.get $std/math/INVALID
+  call $std/math/test_acos
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 272
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const -8.38143342755525
+  f64.const nan:0x8000000000000
+  f64.const 0
+  global.get $std/math/INVALID
+  call $std/math/test_acos
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 273
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const -6.531673581913484
   f64.const nan:0x8000000000000
   f64.const 0
   global.get $std/math/INVALID
@@ -17886,7 +17909,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 4.345239849338305
+  f64.const 9.267056966972586
   f64.const nan:0x8000000000000
   f64.const 0
   global.get $std/math/INVALID
@@ -17900,48 +17923,6 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -8.38143342755525
-  f64.const nan:0x8000000000000
-  f64.const 0
-  global.get $std/math/INVALID
-  call $std/math/test_acos
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 276
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const -6.531673581913484
-  f64.const nan:0x8000000000000
-  f64.const 0
-  global.get $std/math/INVALID
-  call $std/math/test_acos
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 277
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const 9.267056966972586
-  f64.const nan:0x8000000000000
-  f64.const 0
-  global.get $std/math/INVALID
-  call $std/math/test_acos
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 278
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
   f64.const 0.6619858980995045
   f64.const 0.8473310828433507
   f64.const -0.41553276777267456
@@ -17951,7 +17932,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 279
+   i32.const 276
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -17965,7 +17946,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 280
+   i32.const 277
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -17979,7 +17960,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 281
+   i32.const 278
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -17993,7 +17974,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 282
+   i32.const 279
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -18007,7 +17988,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 283
+   i32.const 280
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -18021,7 +18002,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 286
+   i32.const 283
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -18035,7 +18016,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 287
+   i32.const 284
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -18049,12 +18030,55 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 288
+   i32.const 285
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f64.const 1.0000000000000002
+  f64.const nan:0x8000000000000
+  f64.const 0
+  global.get $std/math/INVALID
+  call $std/math/test_acos
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 286
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const -1.0000000000000002
+  f64.const nan:0x8000000000000
+  f64.const 0
+  global.get $std/math/INVALID
+  call $std/math/test_acos
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 287
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const inf
+  f64.const nan:0x8000000000000
+  f64.const 0
+  global.get $std/math/INVALID
+  call $std/math/test_acos
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 288
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const inf
+  f64.neg
   f64.const nan:0x8000000000000
   f64.const 0
   global.get $std/math/INVALID
@@ -18068,49 +18092,6 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -1.0000000000000002
-  f64.const nan:0x8000000000000
-  f64.const 0
-  global.get $std/math/INVALID
-  call $std/math/test_acos
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 290
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const inf
-  f64.const nan:0x8000000000000
-  f64.const 0
-  global.get $std/math/INVALID
-  call $std/math/test_acos
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 291
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const inf
-  f64.neg
-  f64.const nan:0x8000000000000
-  f64.const 0
-  global.get $std/math/INVALID
-  call $std/math/test_acos
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 292
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
   f64.const nan:0x8000000000000
   f64.const nan:0x8000000000000
   f64.const 0
@@ -18120,7 +18101,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 293
+   i32.const 290
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -18134,7 +18115,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 294
+   i32.const 291
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -18148,12 +18129,54 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 295
+   i32.const 292
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f32.const -8.066848754882812
+  f32.const nan:0x400000
+  f32.const 0
+  global.get $std/math/INVALID
+  call $std/math/test_acosf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 301
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const 4.345239639282227
+  f32.const nan:0x400000
+  f32.const 0
+  global.get $std/math/INVALID
+  call $std/math/test_acosf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 302
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const -8.381433486938477
+  f32.const nan:0x400000
+  f32.const 0
+  global.get $std/math/INVALID
+  call $std/math/test_acosf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 303
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const -6.531673431396484
   f32.const nan:0x400000
   f32.const 0
   global.get $std/math/INVALID
@@ -18167,7 +18190,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 4.345239639282227
+  f32.const 9.267057418823242
   f32.const nan:0x400000
   f32.const 0
   global.get $std/math/INVALID
@@ -18181,48 +18204,6 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -8.381433486938477
-  f32.const nan:0x400000
-  f32.const 0
-  global.get $std/math/INVALID
-  call $std/math/test_acosf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 306
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const -6.531673431396484
-  f32.const nan:0x400000
-  f32.const 0
-  global.get $std/math/INVALID
-  call $std/math/test_acosf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 307
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const 9.267057418823242
-  f32.const nan:0x400000
-  f32.const 0
-  global.get $std/math/INVALID
-  call $std/math/test_acosf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 308
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
   f32.const 0.6619858741760254
   f32.const 0.8473311066627502
   f32.const -0.13588131964206696
@@ -18232,7 +18213,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 309
+   i32.const 306
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -18246,7 +18227,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 310
+   i32.const 307
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -18260,7 +18241,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 311
+   i32.const 308
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -18274,7 +18255,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 312
+   i32.const 309
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -18288,7 +18269,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 313
+   i32.const 310
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -18302,7 +18283,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 316
+   i32.const 313
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -18316,7 +18297,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 317
+   i32.const 314
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -18330,12 +18311,55 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 318
+   i32.const 315
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f32.const 1.0000001192092896
+  f32.const nan:0x400000
+  f32.const 0
+  global.get $std/math/INVALID
+  call $std/math/test_acosf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 316
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const -1.0000001192092896
+  f32.const nan:0x400000
+  f32.const 0
+  global.get $std/math/INVALID
+  call $std/math/test_acosf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 317
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const inf
+  f32.const nan:0x400000
+  f32.const 0
+  global.get $std/math/INVALID
+  call $std/math/test_acosf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 318
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const inf
+  f32.neg
   f32.const nan:0x400000
   f32.const 0
   global.get $std/math/INVALID
@@ -18349,49 +18373,6 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -1.0000001192092896
-  f32.const nan:0x400000
-  f32.const 0
-  global.get $std/math/INVALID
-  call $std/math/test_acosf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 320
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const inf
-  f32.const nan:0x400000
-  f32.const 0
-  global.get $std/math/INVALID
-  call $std/math/test_acosf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 321
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const inf
-  f32.neg
-  f32.const nan:0x400000
-  f32.const 0
-  global.get $std/math/INVALID
-  call $std/math/test_acosf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 322
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
   f32.const nan:0x400000
   f32.const nan:0x400000
   f32.const 0
@@ -18401,7 +18382,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 323
+   i32.const 320
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -18415,7 +18396,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 324
+   i32.const 321
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -18429,7 +18410,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 325
+   i32.const 322
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -18443,7 +18424,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 326
+   i32.const 323
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -18457,7 +18438,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 338
+   i32.const 335
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -18471,7 +18452,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 339
+   i32.const 336
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -18485,7 +18466,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 340
+   i32.const 337
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -18499,7 +18480,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 341
+   i32.const 338
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -18513,12 +18494,54 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 342
+   i32.const 339
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f64.const 0.6619858980995045
+  f64.const nan:0x8000000000000
+  f64.const 0
+  global.get $std/math/INVALID
+  call $std/math/test_acosh
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 340
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const -0.4066039223853553
+  f64.const nan:0x8000000000000
+  f64.const 0
+  global.get $std/math/INVALID
+  call $std/math/test_acosh
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 341
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const 0.5617597462207241
+  f64.const nan:0x8000000000000
+  f64.const 0
+  global.get $std/math/INVALID
+  call $std/math/test_acosh
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 342
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const 0.7741522965913037
   f64.const nan:0x8000000000000
   f64.const 0
   global.get $std/math/INVALID
@@ -18532,7 +18555,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -0.4066039223853553
+  f64.const -0.6787637026394024
   f64.const nan:0x8000000000000
   f64.const 0
   global.get $std/math/INVALID
@@ -18546,38 +18569,10 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 0.5617597462207241
+  f64.const nan:0x8000000000000
   f64.const nan:0x8000000000000
   f64.const 0
-  global.get $std/math/INVALID
-  call $std/math/test_acosh
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 345
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const 0.7741522965913037
-  f64.const nan:0x8000000000000
-  f64.const 0
-  global.get $std/math/INVALID
-  call $std/math/test_acosh
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 346
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const -0.6787637026394024
-  f64.const nan:0x8000000000000
-  f64.const 0
-  global.get $std/math/INVALID
+  i32.const 0
   call $std/math/test_acosh
   i32.eqz
   if
@@ -18588,20 +18583,6 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const nan:0x8000000000000
-  f64.const nan:0x8000000000000
-  f64.const 0
-  i32.const 0
-  call $std/math/test_acosh
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 350
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
   f64.const inf
   f64.const inf
   f64.const 0
@@ -18611,7 +18592,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 351
+   i32.const 348
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -18625,7 +18606,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 352
+   i32.const 349
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -18639,7 +18620,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 353
+   i32.const 350
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -18653,7 +18634,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 354
+   i32.const 351
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -18667,7 +18648,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 355
+   i32.const 352
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -18681,7 +18662,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 356
+   i32.const 353
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -18696,7 +18677,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 357
+   i32.const 354
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -18710,7 +18691,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 373
+   i32.const 370
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -18724,7 +18705,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 375
+   i32.const 372
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -18738,7 +18719,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 376
+   i32.const 373
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -18752,7 +18733,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 385
+   i32.const 382
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -18766,7 +18747,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 386
+   i32.const 383
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -18780,7 +18761,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 387
+   i32.const 384
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -18794,7 +18775,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 388
+   i32.const 385
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -18808,12 +18789,54 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 389
+   i32.const 386
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f32.const 0.6619858741760254
+  f32.const nan:0x400000
+  f32.const 0
+  global.get $std/math/INVALID
+  call $std/math/test_acoshf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 387
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const -0.40660393238067627
+  f32.const nan:0x400000
+  f32.const 0
+  global.get $std/math/INVALID
+  call $std/math/test_acoshf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 388
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const 0.5617597699165344
+  f32.const nan:0x400000
+  f32.const 0
+  global.get $std/math/INVALID
+  call $std/math/test_acoshf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 389
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const 0.7741522789001465
   f32.const nan:0x400000
   f32.const 0
   global.get $std/math/INVALID
@@ -18827,7 +18850,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -0.40660393238067627
+  f32.const -0.6787636876106262
   f32.const nan:0x400000
   f32.const 0
   global.get $std/math/INVALID
@@ -18841,38 +18864,10 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 0.5617597699165344
+  f32.const nan:0x400000
   f32.const nan:0x400000
   f32.const 0
-  global.get $std/math/INVALID
-  call $std/math/test_acoshf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 392
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const 0.7741522789001465
-  f32.const nan:0x400000
-  f32.const 0
-  global.get $std/math/INVALID
-  call $std/math/test_acoshf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 393
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const -0.6787636876106262
-  f32.const nan:0x400000
-  f32.const 0
-  global.get $std/math/INVALID
+  i32.const 0
   call $std/math/test_acoshf
   i32.eqz
   if
@@ -18883,20 +18878,6 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const nan:0x400000
-  f32.const nan:0x400000
-  f32.const 0
-  i32.const 0
-  call $std/math/test_acoshf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 397
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
   f32.const inf
   f32.const inf
   f32.const 0
@@ -18906,7 +18887,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 398
+   i32.const 395
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -18920,7 +18901,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 399
+   i32.const 396
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -18934,7 +18915,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 400
+   i32.const 397
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -18948,7 +18929,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 401
+   i32.const 398
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -18962,7 +18943,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 402
+   i32.const 399
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -18977,7 +18958,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 403
+   i32.const 400
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -18991,12 +18972,54 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 404
+   i32.const 401
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f64.const -8.06684839057968
+  f64.const nan:0x8000000000000
+  f64.const 0
+  global.get $std/math/INVALID
+  call $std/math/test_asin
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 413
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const 4.345239849338305
+  f64.const nan:0x8000000000000
+  f64.const 0
+  global.get $std/math/INVALID
+  call $std/math/test_asin
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 414
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const -8.38143342755525
+  f64.const nan:0x8000000000000
+  f64.const 0
+  global.get $std/math/INVALID
+  call $std/math/test_asin
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 415
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const -6.531673581913484
   f64.const nan:0x8000000000000
   f64.const 0
   global.get $std/math/INVALID
@@ -19010,7 +19033,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 4.345239849338305
+  f64.const 9.267056966972586
   f64.const nan:0x8000000000000
   f64.const 0
   global.get $std/math/INVALID
@@ -19024,48 +19047,6 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -8.38143342755525
-  f64.const nan:0x8000000000000
-  f64.const 0
-  global.get $std/math/INVALID
-  call $std/math/test_asin
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 418
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const -6.531673581913484
-  f64.const nan:0x8000000000000
-  f64.const 0
-  global.get $std/math/INVALID
-  call $std/math/test_asin
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 419
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const 9.267056966972586
-  f64.const nan:0x8000000000000
-  f64.const 0
-  global.get $std/math/INVALID
-  call $std/math/test_asin
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 420
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
   f64.const 0.6619858980995045
   f64.const 0.7234652439515459
   f64.const -0.13599912822246552
@@ -19075,7 +19056,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 421
+   i32.const 418
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -19089,7 +19070,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 422
+   i32.const 419
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -19103,7 +19084,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 423
+   i32.const 420
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -19117,7 +19098,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 424
+   i32.const 421
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -19131,7 +19112,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 425
+   i32.const 422
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -19145,7 +19126,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 428
+   i32.const 425
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -19159,7 +19140,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 429
+   i32.const 426
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -19173,7 +19154,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 430
+   i32.const 427
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -19187,7 +19168,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 431
+   i32.const 428
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -19201,7 +19182,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 432
+   i32.const 429
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -19215,7 +19196,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 433
+   i32.const 430
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -19229,7 +19210,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 434
+   i32.const 431
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -19244,7 +19225,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 435
+   i32.const 432
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -19258,7 +19239,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 436
+   i32.const 433
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -19272,12 +19253,54 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 437
+   i32.const 434
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f32.const -8.066848754882812
+  f32.const nan:0x400000
+  f32.const 0
+  global.get $std/math/INVALID
+  call $std/math/test_asinf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 443
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const 4.345239639282227
+  f32.const nan:0x400000
+  f32.const 0
+  global.get $std/math/INVALID
+  call $std/math/test_asinf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 444
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const -8.381433486938477
+  f32.const nan:0x400000
+  f32.const 0
+  global.get $std/math/INVALID
+  call $std/math/test_asinf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 445
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const -6.531673431396484
   f32.const nan:0x400000
   f32.const 0
   global.get $std/math/INVALID
@@ -19291,7 +19314,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 4.345239639282227
+  f32.const 9.267057418823242
   f32.const nan:0x400000
   f32.const 0
   global.get $std/math/INVALID
@@ -19305,48 +19328,6 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -8.381433486938477
-  f32.const nan:0x400000
-  f32.const 0
-  global.get $std/math/INVALID
-  call $std/math/test_asinf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 448
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const -6.531673431396484
-  f32.const nan:0x400000
-  f32.const 0
-  global.get $std/math/INVALID
-  call $std/math/test_asinf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 449
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const 9.267057418823242
-  f32.const nan:0x400000
-  f32.const 0
-  global.get $std/math/INVALID
-  call $std/math/test_asinf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 450
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
   f32.const 0.6619858741760254
   f32.const 0.7234652042388916
   f32.const -0.1307632476091385
@@ -19356,7 +19337,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 451
+   i32.const 448
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -19370,7 +19351,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 452
+   i32.const 449
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -19384,7 +19365,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 453
+   i32.const 450
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -19398,7 +19379,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 454
+   i32.const 451
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -19412,7 +19393,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 455
+   i32.const 452
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -19426,7 +19407,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 458
+   i32.const 455
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -19440,7 +19421,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 459
+   i32.const 456
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -19454,7 +19435,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 460
+   i32.const 457
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -19468,7 +19449,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 461
+   i32.const 458
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -19482,7 +19463,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 462
+   i32.const 459
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -19496,7 +19477,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 463
+   i32.const 460
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -19510,7 +19491,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 464
+   i32.const 461
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -19525,7 +19506,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 465
+   i32.const 462
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -19539,7 +19520,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 466
+   i32.const 463
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -19553,7 +19534,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 467
+   i32.const 464
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -19567,7 +19548,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 479
+   i32.const 476
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -19581,7 +19562,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 480
+   i32.const 477
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -19595,7 +19576,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 481
+   i32.const 478
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -19609,7 +19590,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 482
+   i32.const 479
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -19623,7 +19604,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 483
+   i32.const 480
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -19637,7 +19618,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 484
+   i32.const 481
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -19651,7 +19632,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 485
+   i32.const 482
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -19665,7 +19646,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 486
+   i32.const 483
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -19679,7 +19660,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 487
+   i32.const 484
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -19693,13 +19674,57 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 488
+   i32.const 485
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f64.const nan:0x8000000000000
   f64.const nan:0x8000000000000
+  f64.const 0
+  i32.const 0
+  call $std/math/test_asinh
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 488
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const inf
+  f64.const inf
+  f64.const 0
+  i32.const 0
+  call $std/math/test_asinh
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 489
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const inf
+  f64.neg
+  f64.const inf
+  f64.neg
+  f64.const 0
+  i32.const 0
+  call $std/math/test_asinh
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 490
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const 0
+  f64.const 0
   f64.const 0
   i32.const 0
   call $std/math/test_asinh
@@ -19712,8 +19737,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const inf
-  f64.const inf
+  f64.const -0
+  f64.const -0
   f64.const 0
   i32.const 0
   call $std/math/test_asinh
@@ -19722,50 +19747,6 @@
    i32.const 0
    i32.const 32
    i32.const 492
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const inf
-  f64.neg
-  f64.const inf
-  f64.neg
-  f64.const 0
-  i32.const 0
-  call $std/math/test_asinh
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 493
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const 0
-  f64.const 0
-  f64.const 0
-  i32.const 0
-  call $std/math/test_asinh
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 494
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const -0
-  f64.const -0
-  f64.const 0
-  i32.const 0
-  call $std/math/test_asinh
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 495
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -19779,7 +19760,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 524
+   i32.const 521
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -19793,7 +19774,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 525
+   i32.const 522
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -19807,7 +19788,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 526
+   i32.const 523
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -19821,7 +19802,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 527
+   i32.const 524
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -19835,7 +19816,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 528
+   i32.const 525
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -19849,7 +19830,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 529
+   i32.const 526
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -19863,7 +19844,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 530
+   i32.const 527
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -19877,7 +19858,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 531
+   i32.const 528
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -19891,7 +19872,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 532
+   i32.const 529
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -19905,13 +19886,57 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 533
+   i32.const 530
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f32.const nan:0x400000
   f32.const nan:0x400000
+  f32.const 0
+  i32.const 0
+  call $std/math/test_asinhf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 533
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const inf
+  f32.const inf
+  f32.const 0
+  i32.const 0
+  call $std/math/test_asinhf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 534
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const inf
+  f32.neg
+  f32.const inf
+  f32.neg
+  f32.const 0
+  i32.const 0
+  call $std/math/test_asinhf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 535
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const 0
+  f32.const 0
   f32.const 0
   i32.const 0
   call $std/math/test_asinhf
@@ -19924,8 +19949,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const inf
-  f32.const inf
+  f32.const -0
+  f32.const -0
   f32.const 0
   i32.const 0
   call $std/math/test_asinhf
@@ -19934,50 +19959,6 @@
    i32.const 0
    i32.const 32
    i32.const 537
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const inf
-  f32.neg
-  f32.const inf
-  f32.neg
-  f32.const 0
-  i32.const 0
-  call $std/math/test_asinhf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 538
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const 0
-  f32.const 0
-  f32.const 0
-  i32.const 0
-  call $std/math/test_asinhf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 539
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const -0
-  f32.const -0
-  f32.const 0
-  i32.const 0
-  call $std/math/test_asinhf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 540
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -19991,7 +19972,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 552
+   i32.const 549
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -20005,7 +19986,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 553
+   i32.const 550
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -20019,7 +20000,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 554
+   i32.const 551
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -20033,7 +20014,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 555
+   i32.const 552
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -20047,7 +20028,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 556
+   i32.const 553
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -20061,7 +20042,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 557
+   i32.const 554
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -20075,7 +20056,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 558
+   i32.const 555
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -20089,7 +20070,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 559
+   i32.const 556
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -20103,7 +20084,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 560
+   i32.const 557
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -20117,25 +20098,25 @@
   if
    i32.const 0
    i32.const 32
+   i32.const 558
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const 0
+  f64.const 0
+  f64.const 0
+  i32.const 0
+  call $std/math/test_atan
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
    i32.const 561
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 0
-  f64.const 0
-  f64.const 0
-  i32.const 0
-  call $std/math/test_atan
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 564
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
   f64.const -0
   f64.const -0
   f64.const 0
@@ -20145,7 +20126,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 565
+   i32.const 562
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -20159,7 +20140,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 566
+   i32.const 563
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -20173,7 +20154,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 567
+   i32.const 564
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -20187,7 +20168,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 568
+   i32.const 565
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -20202,7 +20183,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 569
+   i32.const 566
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -20216,7 +20197,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 570
+   i32.const 567
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -20230,7 +20211,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 571
+   i32.const 568
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -20244,7 +20225,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 580
+   i32.const 577
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -20258,7 +20239,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 581
+   i32.const 578
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -20272,7 +20253,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 582
+   i32.const 579
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -20286,7 +20267,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 583
+   i32.const 580
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -20300,7 +20281,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 584
+   i32.const 581
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -20314,7 +20295,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 585
+   i32.const 582
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -20328,7 +20309,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 586
+   i32.const 583
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -20342,7 +20323,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 587
+   i32.const 584
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -20356,7 +20337,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 588
+   i32.const 585
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -20370,25 +20351,25 @@
   if
    i32.const 0
    i32.const 32
+   i32.const 586
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const 0
+  f32.const 0
+  f32.const 0
+  i32.const 0
+  call $std/math/test_atanf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
    i32.const 589
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 0
-  f32.const 0
-  f32.const 0
-  i32.const 0
-  call $std/math/test_atanf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 592
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
   f32.const -0
   f32.const -0
   f32.const 0
@@ -20398,7 +20379,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 593
+   i32.const 590
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -20412,7 +20393,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 594
+   i32.const 591
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -20426,7 +20407,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 595
+   i32.const 592
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -20440,7 +20421,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 596
+   i32.const 593
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -20455,7 +20436,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 597
+   i32.const 594
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -20469,7 +20450,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 598
+   i32.const 595
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -20483,7 +20464,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 610
+   i32.const 607
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -20497,7 +20478,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 611
+   i32.const 608
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -20511,7 +20492,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 612
+   i32.const 609
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -20525,7 +20506,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 613
+   i32.const 610
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -20539,7 +20520,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 614
+   i32.const 611
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -20553,7 +20534,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 615
+   i32.const 612
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -20567,7 +20548,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 616
+   i32.const 613
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -20581,7 +20562,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 617
+   i32.const 614
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -20595,7 +20576,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 618
+   i32.const 615
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -20609,7 +20590,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 619
+   i32.const 616
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -20623,7 +20604,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 622
+   i32.const 619
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -20637,7 +20618,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 623
+   i32.const 620
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -20652,7 +20633,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 624
+   i32.const 621
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -20666,7 +20647,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 625
+   i32.const 622
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -20680,7 +20661,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 626
+   i32.const 623
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -20694,7 +20675,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 627
+   i32.const 624
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -20709,7 +20690,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 628
+   i32.const 625
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -20723,7 +20704,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 629
+   i32.const 626
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -20737,7 +20718,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 630
+   i32.const 627
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -20746,58 +20727,58 @@
   f64.const 1.3552527156068805e-20
   f64.const 0
   global.get $std/math/INEXACT
+  call $std/math/test_atanh
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 628
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const 9.332636185032189e-302
+  f64.const 9.332636185032189e-302
+  f64.const 0
+  global.get $std/math/INEXACT
+  call $std/math/test_atanh
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 629
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const 5.562684646268003e-309
+  f64.const 5.562684646268003e-309
+  f64.const 0
+  global.get $std/math/INEXACT
+  global.get $std/math/UNDERFLOW
+  i32.or
+  call $std/math/test_atanh
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 630
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const -5.562684646268003e-309
+  f64.const -5.562684646268003e-309
+  f64.const 0
+  global.get $std/math/INEXACT
+  global.get $std/math/UNDERFLOW
+  i32.or
   call $std/math/test_atanh
   i32.eqz
   if
    i32.const 0
    i32.const 32
    i32.const 631
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const 9.332636185032189e-302
-  f64.const 9.332636185032189e-302
-  f64.const 0
-  global.get $std/math/INEXACT
-  call $std/math/test_atanh
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 632
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const 5.562684646268003e-309
-  f64.const 5.562684646268003e-309
-  f64.const 0
-  global.get $std/math/INEXACT
-  global.get $std/math/UNDERFLOW
-  i32.or
-  call $std/math/test_atanh
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 633
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const -5.562684646268003e-309
-  f64.const -5.562684646268003e-309
-  f64.const 0
-  global.get $std/math/INEXACT
-  global.get $std/math/UNDERFLOW
-  i32.or
-  call $std/math/test_atanh
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 634
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -20811,7 +20792,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 635
+   i32.const 632
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -20825,7 +20806,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 644
+   i32.const 641
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -20839,7 +20820,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 645
+   i32.const 642
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -20853,7 +20834,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 646
+   i32.const 643
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -20867,7 +20848,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 647
+   i32.const 644
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -20881,7 +20862,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 648
+   i32.const 645
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -20895,7 +20876,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 649
+   i32.const 646
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -20909,7 +20890,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 650
+   i32.const 647
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -20923,7 +20904,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 651
+   i32.const 648
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -20937,7 +20918,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 652
+   i32.const 649
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -20951,7 +20932,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 653
+   i32.const 650
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -20965,7 +20946,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 656
+   i32.const 653
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -20979,7 +20960,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 657
+   i32.const 654
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -20994,7 +20975,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 658
+   i32.const 655
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -21008,7 +20989,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 659
+   i32.const 656
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -21022,7 +21003,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 660
+   i32.const 657
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -21036,7 +21017,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 661
+   i32.const 658
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -21051,7 +21032,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 662
+   i32.const 659
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -21065,7 +21046,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 663
+   i32.const 660
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -21079,7 +21060,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 664
+   i32.const 661
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -21088,58 +21069,58 @@
   f32.const 1.3552527156068805e-20
   f32.const 0
   global.get $std/math/INEXACT
+  call $std/math/test_atanhf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 662
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const 7.888609052210118e-31
+  f32.const 7.888609052210118e-31
+  f32.const 0
+  global.get $std/math/INEXACT
+  call $std/math/test_atanhf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 663
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const 2.938735877055719e-39
+  f32.const 2.938735877055719e-39
+  f32.const 0
+  global.get $std/math/INEXACT
+  global.get $std/math/UNDERFLOW
+  i32.or
+  call $std/math/test_atanhf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 664
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const -2.938735877055719e-39
+  f32.const -2.938735877055719e-39
+  f32.const 0
+  global.get $std/math/INEXACT
+  global.get $std/math/UNDERFLOW
+  i32.or
   call $std/math/test_atanhf
   i32.eqz
   if
    i32.const 0
    i32.const 32
    i32.const 665
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const 7.888609052210118e-31
-  f32.const 7.888609052210118e-31
-  f32.const 0
-  global.get $std/math/INEXACT
-  call $std/math/test_atanhf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 666
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const 2.938735877055719e-39
-  f32.const 2.938735877055719e-39
-  f32.const 0
-  global.get $std/math/INEXACT
-  global.get $std/math/UNDERFLOW
-  i32.or
-  call $std/math/test_atanhf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 667
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const -2.938735877055719e-39
-  f32.const -2.938735877055719e-39
-  f32.const 0
-  global.get $std/math/INEXACT
-  global.get $std/math/UNDERFLOW
-  i32.or
-  call $std/math/test_atanhf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 668
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -21153,7 +21134,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 669
+   i32.const 666
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -21168,7 +21149,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 681
+   i32.const 678
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -21183,7 +21164,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 682
+   i32.const 679
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -21198,7 +21179,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 683
+   i32.const 680
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -21213,7 +21194,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 684
+   i32.const 681
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -21228,7 +21209,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 685
+   i32.const 682
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -21243,7 +21224,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 686
+   i32.const 683
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -21258,7 +21239,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 687
+   i32.const 684
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -21273,7 +21254,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 688
+   i32.const 685
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -21288,7 +21269,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 689
+   i32.const 686
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -21303,7 +21284,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 690
+   i32.const 687
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -21318,7 +21299,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 693
+   i32.const 690
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -21333,7 +21314,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 694
+   i32.const 691
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -21348,7 +21329,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 695
+   i32.const 692
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -21364,7 +21345,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 696
+   i32.const 693
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -21379,7 +21360,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 697
+   i32.const 694
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -21394,7 +21375,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 698
+   i32.const 695
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -21409,7 +21390,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 699
+   i32.const 696
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -21424,7 +21405,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 700
+   i32.const 697
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -21439,7 +21420,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 701
+   i32.const 698
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -21448,6 +21429,51 @@
   f64.const inf
   f64.neg
   f64.const -3.141592653589793
+  f64.const 0.27576595544815063
+  global.get $std/math/INEXACT
+  call $std/math/test_atan2
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 699
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const -0
+  f64.const 1
+  f64.const -0
+  f64.const 0
+  i32.const 0
+  call $std/math/test_atan2
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 700
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const -0
+  f64.const inf
+  f64.const -0
+  f64.const 0
+  i32.const 0
+  call $std/math/test_atan2
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 701
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const -1
+  f64.const 0
+  f64.const -1.5707963267948966
   f64.const 0.27576595544815063
   global.get $std/math/INEXACT
   call $std/math/test_atan2
@@ -21460,11 +21486,11 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f64.const -1
   f64.const -0
-  f64.const 1
-  f64.const -0
-  f64.const 0
-  i32.const 0
+  f64.const -1.5707963267948966
+  f64.const 0.27576595544815063
+  global.get $std/math/INEXACT
   call $std/math/test_atan2
   i32.eqz
   if
@@ -21475,11 +21501,11 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -0
-  f64.const inf
-  f64.const -0
+  f64.const 1
   f64.const 0
-  i32.const 0
+  f64.const 1.5707963267948966
+  f64.const -0.27576595544815063
+  global.get $std/math/INEXACT
   call $std/math/test_atan2
   i32.eqz
   if
@@ -21490,10 +21516,10 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -1
-  f64.const 0
-  f64.const -1.5707963267948966
-  f64.const 0.27576595544815063
+  f64.const 1
+  f64.const -0
+  f64.const 1.5707963267948966
+  f64.const -0.27576595544815063
   global.get $std/math/INEXACT
   call $std/math/test_atan2
   i32.eqz
@@ -21506,10 +21532,10 @@
    unreachable
   end
   f64.const -1
+  f64.const inf
   f64.const -0
-  f64.const -1.5707963267948966
-  f64.const 0.27576595544815063
-  global.get $std/math/INEXACT
+  f64.const 0
+  i32.const 0
   call $std/math/test_atan2
   i32.eqz
   if
@@ -21521,61 +21547,16 @@
    unreachable
   end
   f64.const 1
+  f64.const inf
   f64.const 0
-  f64.const 1.5707963267948966
-  f64.const -0.27576595544815063
-  global.get $std/math/INEXACT
+  f64.const 0
+  i32.const 0
   call $std/math/test_atan2
   i32.eqz
   if
    i32.const 0
    i32.const 32
    i32.const 707
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const 1
-  f64.const -0
-  f64.const 1.5707963267948966
-  f64.const -0.27576595544815063
-  global.get $std/math/INEXACT
-  call $std/math/test_atan2
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 708
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const -1
-  f64.const inf
-  f64.const -0
-  f64.const 0
-  i32.const 0
-  call $std/math/test_atan2
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 709
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const 1
-  f64.const inf
-  f64.const 0
-  f64.const 0
-  i32.const 0
-  call $std/math/test_atan2
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 710
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -21591,7 +21572,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 711
+   i32.const 708
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -21607,7 +21588,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 712
+   i32.const 709
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -21622,7 +21603,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 713
+   i32.const 710
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -21638,7 +21619,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 714
+   i32.const 711
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -21653,7 +21634,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 715
+   i32.const 712
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -21669,7 +21650,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 716
+   i32.const 713
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -21685,7 +21666,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 717
+   i32.const 714
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -21702,7 +21683,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 718
+   i32.const 715
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -21719,7 +21700,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 719
+   i32.const 716
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -21736,7 +21717,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 720
+   i32.const 717
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -21753,7 +21734,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 721
+   i32.const 718
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -21768,7 +21749,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 722
+   i32.const 719
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -21783,7 +21764,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 731
+   i32.const 728
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -21798,7 +21779,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 732
+   i32.const 729
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -21813,7 +21794,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 733
+   i32.const 730
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -21828,7 +21809,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 734
+   i32.const 731
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -21843,7 +21824,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 735
+   i32.const 732
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -21858,7 +21839,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 736
+   i32.const 733
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -21873,7 +21854,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 737
+   i32.const 734
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -21888,7 +21869,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 738
+   i32.const 735
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -21903,7 +21884,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 739
+   i32.const 736
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -21918,7 +21899,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 740
+   i32.const 737
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -21933,7 +21914,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 743
+   i32.const 740
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -21948,7 +21929,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 744
+   i32.const 741
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -21963,7 +21944,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 745
+   i32.const 742
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -21979,7 +21960,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 746
+   i32.const 743
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -21994,7 +21975,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 747
+   i32.const 744
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -22009,7 +21990,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 748
+   i32.const 745
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -22024,7 +22005,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 749
+   i32.const 746
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -22039,7 +22020,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 750
+   i32.const 747
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -22054,7 +22035,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 751
+   i32.const 748
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -22063,6 +22044,51 @@
   f32.const inf
   f32.neg
   f32.const -3.1415927410125732
+  f32.const -0.3666777014732361
+  global.get $std/math/INEXACT
+  call $std/math/test_atan2f
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 749
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const -0
+  f32.const 1
+  f32.const -0
+  f32.const 0
+  i32.const 0
+  call $std/math/test_atan2f
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 750
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const -0
+  f32.const inf
+  f32.const -0
+  f32.const 0
+  i32.const 0
+  call $std/math/test_atan2f
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 751
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const -1
+  f32.const 0
+  f32.const -1.5707963705062866
   f32.const -0.3666777014732361
   global.get $std/math/INEXACT
   call $std/math/test_atan2f
@@ -22075,11 +22101,11 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f32.const -1
   f32.const -0
-  f32.const 1
-  f32.const -0
-  f32.const 0
-  i32.const 0
+  f32.const -1.5707963705062866
+  f32.const -0.3666777014732361
+  global.get $std/math/INEXACT
   call $std/math/test_atan2f
   i32.eqz
   if
@@ -22090,11 +22116,11 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -0
-  f32.const inf
-  f32.const -0
+  f32.const 1
   f32.const 0
-  i32.const 0
+  f32.const 1.5707963705062866
+  f32.const 0.3666777014732361
+  global.get $std/math/INEXACT
   call $std/math/test_atan2f
   i32.eqz
   if
@@ -22105,10 +22131,10 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -1
-  f32.const 0
-  f32.const -1.5707963705062866
-  f32.const -0.3666777014732361
+  f32.const 1
+  f32.const -0
+  f32.const 1.5707963705062866
+  f32.const 0.3666777014732361
   global.get $std/math/INEXACT
   call $std/math/test_atan2f
   i32.eqz
@@ -22121,10 +22147,10 @@
    unreachable
   end
   f32.const -1
+  f32.const inf
   f32.const -0
-  f32.const -1.5707963705062866
-  f32.const -0.3666777014732361
-  global.get $std/math/INEXACT
+  f32.const 0
+  i32.const 0
   call $std/math/test_atan2f
   i32.eqz
   if
@@ -22136,61 +22162,16 @@
    unreachable
   end
   f32.const 1
+  f32.const inf
   f32.const 0
-  f32.const 1.5707963705062866
-  f32.const 0.3666777014732361
-  global.get $std/math/INEXACT
+  f32.const 0
+  i32.const 0
   call $std/math/test_atan2f
   i32.eqz
   if
    i32.const 0
    i32.const 32
    i32.const 757
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const 1
-  f32.const -0
-  f32.const 1.5707963705062866
-  f32.const 0.3666777014732361
-  global.get $std/math/INEXACT
-  call $std/math/test_atan2f
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 758
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const -1
-  f32.const inf
-  f32.const -0
-  f32.const 0
-  i32.const 0
-  call $std/math/test_atan2f
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 759
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const 1
-  f32.const inf
-  f32.const 0
-  f32.const 0
-  i32.const 0
-  call $std/math/test_atan2f
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 760
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -22206,7 +22187,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 761
+   i32.const 758
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -22222,7 +22203,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 762
+   i32.const 759
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -22237,7 +22218,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 763
+   i32.const 760
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -22253,7 +22234,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 764
+   i32.const 761
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -22268,7 +22249,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 765
+   i32.const 762
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -22284,7 +22265,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 766
+   i32.const 763
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -22300,7 +22281,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 767
+   i32.const 764
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -22317,7 +22298,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 768
+   i32.const 765
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -22334,7 +22315,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 769
+   i32.const 766
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -22351,7 +22332,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 770
+   i32.const 767
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -22365,7 +22346,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 782
+   i32.const 779
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -22379,7 +22360,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 783
+   i32.const 780
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -22393,7 +22374,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 784
+   i32.const 781
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -22407,7 +22388,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 785
+   i32.const 782
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -22421,7 +22402,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 786
+   i32.const 783
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -22435,7 +22416,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 787
+   i32.const 784
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -22449,7 +22430,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 788
+   i32.const 785
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -22463,7 +22444,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 789
+   i32.const 786
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -22477,7 +22458,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 790
+   i32.const 787
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -22491,13 +22472,57 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 791
+   i32.const 788
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f64.const nan:0x8000000000000
   f64.const nan:0x8000000000000
+  f64.const 0
+  i32.const 0
+  call $std/math/test_cbrt
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 791
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const inf
+  f64.const inf
+  f64.const 0
+  i32.const 0
+  call $std/math/test_cbrt
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 792
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const inf
+  f64.neg
+  f64.const inf
+  f64.neg
+  f64.const 0
+  i32.const 0
+  call $std/math/test_cbrt
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 793
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const 0
+  f64.const 0
   f64.const 0
   i32.const 0
   call $std/math/test_cbrt
@@ -22510,8 +22535,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const inf
-  f64.const inf
+  f64.const -0
+  f64.const -0
   f64.const 0
   i32.const 0
   call $std/math/test_cbrt
@@ -22520,50 +22545,6 @@
    i32.const 0
    i32.const 32
    i32.const 795
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const inf
-  f64.neg
-  f64.const inf
-  f64.neg
-  f64.const 0
-  i32.const 0
-  call $std/math/test_cbrt
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 796
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const 0
-  f64.const 0
-  f64.const 0
-  i32.const 0
-  call $std/math/test_cbrt
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 797
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const -0
-  f64.const -0
-  f64.const 0
-  i32.const 0
-  call $std/math/test_cbrt
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 798
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -22577,7 +22558,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 799
+   i32.const 796
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -22591,7 +22572,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 800
+   i32.const 797
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -22605,7 +22586,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 801
+   i32.const 798
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -22619,7 +22600,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 802
+   i32.const 799
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -22633,7 +22614,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 803
+   i32.const 800
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -22647,7 +22628,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 812
+   i32.const 809
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -22661,7 +22642,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 813
+   i32.const 810
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -22675,7 +22656,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 814
+   i32.const 811
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -22689,7 +22670,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 815
+   i32.const 812
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -22703,7 +22684,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 816
+   i32.const 813
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -22717,7 +22698,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 817
+   i32.const 814
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -22731,7 +22712,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 818
+   i32.const 815
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -22745,7 +22726,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 819
+   i32.const 816
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -22759,7 +22740,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 820
+   i32.const 817
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -22773,13 +22754,57 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 821
+   i32.const 818
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f32.const nan:0x400000
   f32.const nan:0x400000
+  f32.const 0
+  i32.const 0
+  call $std/math/test_cbrtf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 821
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const inf
+  f32.const inf
+  f32.const 0
+  i32.const 0
+  call $std/math/test_cbrtf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 822
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const inf
+  f32.neg
+  f32.const inf
+  f32.neg
+  f32.const 0
+  i32.const 0
+  call $std/math/test_cbrtf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 823
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const 0
+  f32.const 0
   f32.const 0
   i32.const 0
   call $std/math/test_cbrtf
@@ -22792,8 +22817,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const inf
-  f32.const inf
+  f32.const -0
+  f32.const -0
   f32.const 0
   i32.const 0
   call $std/math/test_cbrtf
@@ -22802,50 +22827,6 @@
    i32.const 0
    i32.const 32
    i32.const 825
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const inf
-  f32.neg
-  f32.const inf
-  f32.neg
-  f32.const 0
-  i32.const 0
-  call $std/math/test_cbrtf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 826
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const 0
-  f32.const 0
-  f32.const 0
-  i32.const 0
-  call $std/math/test_cbrtf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 827
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const -0
-  f32.const -0
-  f32.const 0
-  i32.const 0
-  call $std/math/test_cbrtf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 828
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -22859,7 +22840,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 829
+   i32.const 826
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -22873,7 +22854,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 830
+   i32.const 827
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -22887,7 +22868,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 831
+   i32.const 828
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -22901,7 +22882,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 832
+   i32.const 829
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -22915,7 +22896,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 833
+   i32.const 830
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -22929,7 +22910,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 845
+   i32.const 842
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -22943,7 +22924,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 846
+   i32.const 843
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -22957,7 +22938,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 847
+   i32.const 844
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -22971,7 +22952,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 848
+   i32.const 845
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -22985,12 +22966,54 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 849
+   i32.const 846
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f64.const 0.6619858980995045
+  f64.const 1
+  f64.const 0
+  global.get $std/math/INEXACT
+  call $std/math/test_ceil
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 847
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const -0.4066039223853553
+  f64.const -0
+  f64.const 0
+  global.get $std/math/INEXACT
+  call $std/math/test_ceil
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 848
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const 0.5617597462207241
+  f64.const 1
+  f64.const 0
+  global.get $std/math/INEXACT
+  call $std/math/test_ceil
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 849
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const 0.7741522965913037
   f64.const 1
   f64.const 0
   global.get $std/math/INEXACT
@@ -23004,7 +23027,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -0.4066039223853553
+  f64.const -0.6787637026394024
   f64.const -0
   f64.const 0
   global.get $std/math/INEXACT
@@ -23018,38 +23041,10 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 0.5617597462207241
-  f64.const 1
+  f64.const nan:0x8000000000000
+  f64.const nan:0x8000000000000
   f64.const 0
-  global.get $std/math/INEXACT
-  call $std/math/test_ceil
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 852
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const 0.7741522965913037
-  f64.const 1
-  f64.const 0
-  global.get $std/math/INEXACT
-  call $std/math/test_ceil
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 853
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const -0.6787637026394024
-  f64.const -0
-  f64.const 0
-  global.get $std/math/INEXACT
+  i32.const 0
   call $std/math/test_ceil
   i32.eqz
   if
@@ -23060,8 +23055,38 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const nan:0x8000000000000
-  f64.const nan:0x8000000000000
+  f64.const inf
+  f64.const inf
+  f64.const 0
+  i32.const 0
+  call $std/math/test_ceil
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 855
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const inf
+  f64.neg
+  f64.const inf
+  f64.neg
+  f64.const 0
+  i32.const 0
+  call $std/math/test_ceil
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 856
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const 0
+  f64.const 0
   f64.const 0
   i32.const 0
   call $std/math/test_ceil
@@ -23074,8 +23099,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const inf
-  f64.const inf
+  f64.const -0
+  f64.const -0
   f64.const 0
   i32.const 0
   call $std/math/test_ceil
@@ -23088,10 +23113,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const inf
-  f64.neg
-  f64.const inf
-  f64.neg
+  f64.const 1
+  f64.const 1
   f64.const 0
   i32.const 0
   call $std/math/test_ceil
@@ -23104,8 +23127,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 0
-  f64.const 0
+  f64.const -1
+  f64.const -1
   f64.const 0
   i32.const 0
   call $std/math/test_ceil
@@ -23118,10 +23141,10 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -0
-  f64.const -0
+  f64.const 0.5
+  f64.const 1
   f64.const 0
-  i32.const 0
+  global.get $std/math/INEXACT
   call $std/math/test_ceil
   i32.eqz
   if
@@ -23132,10 +23155,10 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 1
-  f64.const 1
+  f64.const -0.5
+  f64.const -0
   f64.const 0
-  i32.const 0
+  global.get $std/math/INEXACT
   call $std/math/test_ceil
   i32.eqz
   if
@@ -23146,10 +23169,10 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -1
-  f64.const -1
+  f64.const 1.0000152587890625
+  f64.const 2
   f64.const 0
-  i32.const 0
+  global.get $std/math/INEXACT
   call $std/math/test_ceil
   i32.eqz
   if
@@ -23160,8 +23183,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 0.5
-  f64.const 1
+  f64.const -1.0000152587890625
+  f64.const -1
   f64.const 0
   global.get $std/math/INEXACT
   call $std/math/test_ceil
@@ -23174,8 +23197,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -0.5
-  f64.const -0
+  f64.const 0.9999923706054688
+  f64.const 1
   f64.const 0
   global.get $std/math/INEXACT
   call $std/math/test_ceil
@@ -23188,8 +23211,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 1.0000152587890625
-  f64.const 2
+  f64.const -0.9999923706054688
+  f64.const -0
   f64.const 0
   global.get $std/math/INEXACT
   call $std/math/test_ceil
@@ -23202,8 +23225,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -1.0000152587890625
-  f64.const -1
+  f64.const 7.888609052210118e-31
+  f64.const 1
   f64.const 0
   global.get $std/math/INEXACT
   call $std/math/test_ceil
@@ -23216,8 +23239,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 0.9999923706054688
-  f64.const 1
+  f64.const -7.888609052210118e-31
+  f64.const -0
   f64.const 0
   global.get $std/math/INEXACT
   call $std/math/test_ceil
@@ -23230,10 +23253,10 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -0.9999923706054688
-  f64.const -0
+  f64.const nan:0x8000000000000
+  f64.const nan:0x8000000000000
   f64.const 0
-  global.get $std/math/INEXACT
+  i32.const 0
   call $std/math/test_ceil
   i32.eqz
   if
@@ -23244,10 +23267,10 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 7.888609052210118e-31
-  f64.const 1
+  f64.const inf
+  f64.const inf
   f64.const 0
-  global.get $std/math/INEXACT
+  i32.const 0
   call $std/math/test_ceil
   i32.eqz
   if
@@ -23258,10 +23281,12 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -7.888609052210118e-31
-  f64.const -0
+  f64.const inf
+  f64.neg
+  f64.const inf
+  f64.neg
   f64.const 0
-  global.get $std/math/INEXACT
+  i32.const 0
   call $std/math/test_ceil
   i32.eqz
   if
@@ -23272,8 +23297,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const nan:0x8000000000000
-  f64.const nan:0x8000000000000
+  f64.const 0
+  f64.const 0
   f64.const 0
   i32.const 0
   call $std/math/test_ceil
@@ -23286,8 +23311,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const inf
-  f64.const inf
+  f64.const -0
+  f64.const -0
   f64.const 0
   i32.const 0
   call $std/math/test_ceil
@@ -23300,10 +23325,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const inf
-  f64.neg
-  f64.const inf
-  f64.neg
+  f64.const 1
+  f64.const 1
   f64.const 0
   i32.const 0
   call $std/math/test_ceil
@@ -23316,8 +23339,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 0
-  f64.const 0
+  f64.const -1
+  f64.const -1
   f64.const 0
   i32.const 0
   call $std/math/test_ceil
@@ -23330,10 +23353,10 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -0
-  f64.const -0
+  f64.const 0.5
+  f64.const 1
   f64.const 0
-  i32.const 0
+  global.get $std/math/INEXACT
   call $std/math/test_ceil
   i32.eqz
   if
@@ -23344,10 +23367,10 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 1
-  f64.const 1
+  f64.const -0.5
+  f64.const -0
   f64.const 0
-  i32.const 0
+  global.get $std/math/INEXACT
   call $std/math/test_ceil
   i32.eqz
   if
@@ -23358,10 +23381,10 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -1
-  f64.const -1
+  f64.const 1.0000152587890625
+  f64.const 2
   f64.const 0
-  i32.const 0
+  global.get $std/math/INEXACT
   call $std/math/test_ceil
   i32.eqz
   if
@@ -23372,8 +23395,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 0.5
-  f64.const 1
+  f64.const -1.0000152587890625
+  f64.const -1
   f64.const 0
   global.get $std/math/INEXACT
   call $std/math/test_ceil
@@ -23386,48 +23409,6 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -0.5
-  f64.const -0
-  f64.const 0
-  global.get $std/math/INEXACT
-  call $std/math/test_ceil
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 880
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const 1.0000152587890625
-  f64.const 2
-  f64.const 0
-  global.get $std/math/INEXACT
-  call $std/math/test_ceil
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 881
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const -1.0000152587890625
-  f64.const -1
-  f64.const 0
-  global.get $std/math/INEXACT
-  call $std/math/test_ceil
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 882
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
   f64.const 0.9999923706054688
   f64.const 1
   f64.const 0
@@ -23437,7 +23418,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 883
+   i32.const 880
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -23451,7 +23432,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 884
+   i32.const 881
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -23465,7 +23446,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 885
+   i32.const 882
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -23479,13 +23460,57 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 886
+   i32.const 883
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f64.const nan:0x8000000000000
   f64.const nan:0x8000000000000
+  f64.const 0
+  i32.const 0
+  call $std/math/test_ceil
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 884
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const inf
+  f64.const inf
+  f64.const 0
+  i32.const 0
+  call $std/math/test_ceil
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 885
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const inf
+  f64.neg
+  f64.const inf
+  f64.neg
+  f64.const 0
+  i32.const 0
+  call $std/math/test_ceil
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 886
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const 0
+  f64.const 0
   f64.const 0
   i32.const 0
   call $std/math/test_ceil
@@ -23498,8 +23523,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const inf
-  f64.const inf
+  f64.const -0
+  f64.const -0
   f64.const 0
   i32.const 0
   call $std/math/test_ceil
@@ -23512,10 +23537,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const inf
-  f64.neg
-  f64.const inf
-  f64.neg
+  f64.const 1
+  f64.const 1
   f64.const 0
   i32.const 0
   call $std/math/test_ceil
@@ -23528,8 +23551,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 0
-  f64.const 0
+  f64.const -1
+  f64.const -1
   f64.const 0
   i32.const 0
   call $std/math/test_ceil
@@ -23538,48 +23561,6 @@
    i32.const 0
    i32.const 32
    i32.const 890
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const -0
-  f64.const -0
-  f64.const 0
-  i32.const 0
-  call $std/math/test_ceil
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 891
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const 1
-  f64.const 1
-  f64.const 0
-  i32.const 0
-  call $std/math/test_ceil
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 892
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const -1
-  f64.const -1
-  f64.const 0
-  i32.const 0
-  call $std/math/test_ceil
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 893
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -23593,7 +23574,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 894
+   i32.const 891
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -23607,7 +23588,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 895
+   i32.const 892
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -23621,7 +23602,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 896
+   i32.const 893
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -23635,7 +23616,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 897
+   i32.const 894
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -23649,7 +23630,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 898
+   i32.const 895
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -23663,7 +23644,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 899
+   i32.const 896
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -23677,7 +23658,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 900
+   i32.const 897
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -23691,7 +23672,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 901
+   i32.const 898
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -23705,7 +23686,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 910
+   i32.const 907
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -23719,7 +23700,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 911
+   i32.const 908
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -23733,7 +23714,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 912
+   i32.const 909
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -23747,7 +23728,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 913
+   i32.const 910
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -23761,12 +23742,54 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 914
+   i32.const 911
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f32.const 0.6619858741760254
+  f32.const 1
+  f32.const 0
+  global.get $std/math/INEXACT
+  call $std/math/test_ceilf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 912
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const -0.40660393238067627
+  f32.const -0
+  f32.const 0
+  global.get $std/math/INEXACT
+  call $std/math/test_ceilf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 913
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const 0.5617597699165344
+  f32.const 1
+  f32.const 0
+  global.get $std/math/INEXACT
+  call $std/math/test_ceilf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 914
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const 0.7741522789001465
   f32.const 1
   f32.const 0
   global.get $std/math/INEXACT
@@ -23780,7 +23803,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -0.40660393238067627
+  f32.const -0.6787636876106262
   f32.const -0
   f32.const 0
   global.get $std/math/INEXACT
@@ -23794,38 +23817,10 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 0.5617597699165344
-  f32.const 1
+  f32.const nan:0x400000
+  f32.const nan:0x400000
   f32.const 0
-  global.get $std/math/INEXACT
-  call $std/math/test_ceilf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 917
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const 0.7741522789001465
-  f32.const 1
-  f32.const 0
-  global.get $std/math/INEXACT
-  call $std/math/test_ceilf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 918
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const -0.6787636876106262
-  f32.const -0
-  f32.const 0
-  global.get $std/math/INEXACT
+  i32.const 0
   call $std/math/test_ceilf
   i32.eqz
   if
@@ -23836,8 +23831,38 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const nan:0x400000
-  f32.const nan:0x400000
+  f32.const inf
+  f32.const inf
+  f32.const 0
+  i32.const 0
+  call $std/math/test_ceilf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 920
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const inf
+  f32.neg
+  f32.const inf
+  f32.neg
+  f32.const 0
+  i32.const 0
+  call $std/math/test_ceilf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 921
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const 0
+  f32.const 0
   f32.const 0
   i32.const 0
   call $std/math/test_ceilf
@@ -23850,8 +23875,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const inf
-  f32.const inf
+  f32.const -0
+  f32.const -0
   f32.const 0
   i32.const 0
   call $std/math/test_ceilf
@@ -23864,10 +23889,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const inf
-  f32.neg
-  f32.const inf
-  f32.neg
+  f32.const 1
+  f32.const 1
   f32.const 0
   i32.const 0
   call $std/math/test_ceilf
@@ -23880,8 +23903,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 0
-  f32.const 0
+  f32.const -1
+  f32.const -1
   f32.const 0
   i32.const 0
   call $std/math/test_ceilf
@@ -23894,10 +23917,10 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -0
-  f32.const -0
+  f32.const 0.5
+  f32.const 1
   f32.const 0
-  i32.const 0
+  global.get $std/math/INEXACT
   call $std/math/test_ceilf
   i32.eqz
   if
@@ -23908,10 +23931,10 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 1
-  f32.const 1
+  f32.const -0.5
+  f32.const -0
   f32.const 0
-  i32.const 0
+  global.get $std/math/INEXACT
   call $std/math/test_ceilf
   i32.eqz
   if
@@ -23922,10 +23945,10 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -1
-  f32.const -1
+  f32.const 1.0000152587890625
+  f32.const 2
   f32.const 0
-  i32.const 0
+  global.get $std/math/INEXACT
   call $std/math/test_ceilf
   i32.eqz
   if
@@ -23936,8 +23959,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 0.5
-  f32.const 1
+  f32.const -1.0000152587890625
+  f32.const -1
   f32.const 0
   global.get $std/math/INEXACT
   call $std/math/test_ceilf
@@ -23950,8 +23973,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -0.5
-  f32.const -0
+  f32.const 0.9999923706054688
+  f32.const 1
   f32.const 0
   global.get $std/math/INEXACT
   call $std/math/test_ceilf
@@ -23964,8 +23987,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 1.0000152587890625
-  f32.const 2
+  f32.const -0.9999923706054688
+  f32.const -0
   f32.const 0
   global.get $std/math/INEXACT
   call $std/math/test_ceilf
@@ -23978,8 +24001,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -1.0000152587890625
-  f32.const -1
+  f32.const 7.888609052210118e-31
+  f32.const 1
   f32.const 0
   global.get $std/math/INEXACT
   call $std/math/test_ceilf
@@ -23992,8 +24015,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 0.9999923706054688
-  f32.const 1
+  f32.const -7.888609052210118e-31
+  f32.const -0
   f32.const 0
   global.get $std/math/INEXACT
   call $std/math/test_ceilf
@@ -24006,10 +24029,10 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -0.9999923706054688
-  f32.const -0
+  f32.const nan:0x400000
+  f32.const nan:0x400000
   f32.const 0
-  global.get $std/math/INEXACT
+  i32.const 0
   call $std/math/test_ceilf
   i32.eqz
   if
@@ -24020,10 +24043,10 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 7.888609052210118e-31
-  f32.const 1
+  f32.const inf
+  f32.const inf
   f32.const 0
-  global.get $std/math/INEXACT
+  i32.const 0
   call $std/math/test_ceilf
   i32.eqz
   if
@@ -24034,10 +24057,12 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -7.888609052210118e-31
-  f32.const -0
+  f32.const inf
+  f32.neg
+  f32.const inf
+  f32.neg
   f32.const 0
-  global.get $std/math/INEXACT
+  i32.const 0
   call $std/math/test_ceilf
   i32.eqz
   if
@@ -24048,8 +24073,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const nan:0x400000
-  f32.const nan:0x400000
+  f32.const 0
+  f32.const 0
   f32.const 0
   i32.const 0
   call $std/math/test_ceilf
@@ -24062,8 +24087,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const inf
-  f32.const inf
+  f32.const -0
+  f32.const -0
   f32.const 0
   i32.const 0
   call $std/math/test_ceilf
@@ -24076,10 +24101,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const inf
-  f32.neg
-  f32.const inf
-  f32.neg
+  f32.const 1
+  f32.const 1
   f32.const 0
   i32.const 0
   call $std/math/test_ceilf
@@ -24092,8 +24115,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 0
-  f32.const 0
+  f32.const -1
+  f32.const -1
   f32.const 0
   i32.const 0
   call $std/math/test_ceilf
@@ -24106,10 +24129,10 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -0
-  f32.const -0
+  f32.const 0.5
+  f32.const 1
   f32.const 0
-  i32.const 0
+  global.get $std/math/INEXACT
   call $std/math/test_ceilf
   i32.eqz
   if
@@ -24120,10 +24143,10 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 1
-  f32.const 1
+  f32.const -0.5
+  f32.const -0
   f32.const 0
-  i32.const 0
+  global.get $std/math/INEXACT
   call $std/math/test_ceilf
   i32.eqz
   if
@@ -24134,10 +24157,10 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -1
-  f32.const -1
+  f32.const 1.0000152587890625
+  f32.const 2
   f32.const 0
-  i32.const 0
+  global.get $std/math/INEXACT
   call $std/math/test_ceilf
   i32.eqz
   if
@@ -24148,8 +24171,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 0.5
-  f32.const 1
+  f32.const -1.0000152587890625
+  f32.const -1
   f32.const 0
   global.get $std/math/INEXACT
   call $std/math/test_ceilf
@@ -24162,48 +24185,6 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -0.5
-  f32.const -0
-  f32.const 0
-  global.get $std/math/INEXACT
-  call $std/math/test_ceilf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 945
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const 1.0000152587890625
-  f32.const 2
-  f32.const 0
-  global.get $std/math/INEXACT
-  call $std/math/test_ceilf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 946
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const -1.0000152587890625
-  f32.const -1
-  f32.const 0
-  global.get $std/math/INEXACT
-  call $std/math/test_ceilf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 947
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
   f32.const 0.9999923706054688
   f32.const 1
   f32.const 0
@@ -24213,7 +24194,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 948
+   i32.const 945
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -24227,7 +24208,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 949
+   i32.const 946
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -24241,7 +24222,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 950
+   i32.const 947
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -24255,13 +24236,57 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 951
+   i32.const 948
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f32.const nan:0x400000
   f32.const nan:0x400000
+  f32.const 0
+  i32.const 0
+  call $std/math/test_ceilf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 949
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const inf
+  f32.const inf
+  f32.const 0
+  i32.const 0
+  call $std/math/test_ceilf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 950
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const inf
+  f32.neg
+  f32.const inf
+  f32.neg
+  f32.const 0
+  i32.const 0
+  call $std/math/test_ceilf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 951
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const 0
+  f32.const 0
   f32.const 0
   i32.const 0
   call $std/math/test_ceilf
@@ -24274,8 +24299,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const inf
-  f32.const inf
+  f32.const -0
+  f32.const -0
   f32.const 0
   i32.const 0
   call $std/math/test_ceilf
@@ -24288,10 +24313,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const inf
-  f32.neg
-  f32.const inf
-  f32.neg
+  f32.const 1
+  f32.const 1
   f32.const 0
   i32.const 0
   call $std/math/test_ceilf
@@ -24304,8 +24327,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 0
-  f32.const 0
+  f32.const -1
+  f32.const -1
   f32.const 0
   i32.const 0
   call $std/math/test_ceilf
@@ -24314,48 +24337,6 @@
    i32.const 0
    i32.const 32
    i32.const 955
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const -0
-  f32.const -0
-  f32.const 0
-  i32.const 0
-  call $std/math/test_ceilf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 956
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const 1
-  f32.const 1
-  f32.const 0
-  i32.const 0
-  call $std/math/test_ceilf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 957
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const -1
-  f32.const -1
-  f32.const 0
-  i32.const 0
-  call $std/math/test_ceilf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 958
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -24369,7 +24350,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 959
+   i32.const 956
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -24383,7 +24364,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 960
+   i32.const 957
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -24397,7 +24378,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 961
+   i32.const 958
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -24411,7 +24392,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 962
+   i32.const 959
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -24425,7 +24406,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 963
+   i32.const 960
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -24439,7 +24420,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 964
+   i32.const 961
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -24453,7 +24434,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 965
+   i32.const 962
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -24467,7 +24448,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 966
+   i32.const 963
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -24481,7 +24462,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 977
+   i32.const 974
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -24495,7 +24476,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 978
+   i32.const 975
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -24509,7 +24490,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 979
+   i32.const 976
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -24523,7 +24504,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 980
+   i32.const 977
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -24537,7 +24518,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 981
+   i32.const 978
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -24551,7 +24532,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 982
+   i32.const 979
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -24565,7 +24546,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 983
+   i32.const 980
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -24579,7 +24560,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 984
+   i32.const 981
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -24593,7 +24574,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 985
+   i32.const 982
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -24607,7 +24588,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 986
+   i32.const 983
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -24621,7 +24602,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 989
+   i32.const 986
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -24635,7 +24616,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 990
+   i32.const 987
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -24649,7 +24630,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 991
+   i32.const 988
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -24664,7 +24645,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 992
+   i32.const 989
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -24678,7 +24659,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 993
+   i32.const 990
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -24692,7 +24673,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 994
+   i32.const 991
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -24706,7 +24687,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 995
+   i32.const 992
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -24720,7 +24701,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 996
+   i32.const 993
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -24734,7 +24715,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 997
+   i32.const 994
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -24748,7 +24729,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 998
+   i32.const 995
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -24762,7 +24743,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 999
+   i32.const 996
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -24776,7 +24757,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1000
+   i32.const 997
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -24790,7 +24771,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1001
+   i32.const 998
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -24804,7 +24785,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1002
+   i32.const 999
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -24818,7 +24799,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1003
+   i32.const 1000
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -24832,7 +24813,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1004
+   i32.const 1001
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -24846,7 +24827,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1005
+   i32.const 1002
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -24860,7 +24841,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1006
+   i32.const 1003
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -24874,7 +24855,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1007
+   i32.const 1004
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -24888,7 +24869,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1008
+   i32.const 1005
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -24902,7 +24883,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1009
+   i32.const 1006
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -24916,7 +24897,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1010
+   i32.const 1007
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -24930,7 +24911,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1011
+   i32.const 1008
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -24944,7 +24925,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1012
+   i32.const 1009
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -24958,7 +24939,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1013
+   i32.const 1010
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -24972,7 +24953,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1014
+   i32.const 1011
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -24986,7 +24967,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1015
+   i32.const 1012
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -25000,7 +24981,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1016
+   i32.const 1013
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -25014,7 +24995,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1017
+   i32.const 1014
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -25028,7 +25009,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1018
+   i32.const 1015
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -25042,7 +25023,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1019
+   i32.const 1016
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -25056,7 +25037,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1020
+   i32.const 1017
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -25070,7 +25051,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1021
+   i32.const 1018
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -25084,7 +25065,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1022
+   i32.const 1019
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -25098,7 +25079,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1023
+   i32.const 1020
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -25112,7 +25093,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1024
+   i32.const 1021
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -25126,7 +25107,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1025
+   i32.const 1022
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -25140,7 +25121,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1026
+   i32.const 1023
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -25154,7 +25135,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1027
+   i32.const 1024
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -25168,7 +25149,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1028
+   i32.const 1025
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -25182,7 +25163,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1029
+   i32.const 1026
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -25196,7 +25177,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1030
+   i32.const 1027
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -25210,7 +25191,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1031
+   i32.const 1028
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -25224,7 +25205,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1032
+   i32.const 1029
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -25238,7 +25219,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1033
+   i32.const 1030
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -25252,7 +25233,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1034
+   i32.const 1031
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -25266,7 +25247,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1035
+   i32.const 1032
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -25280,7 +25261,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1036
+   i32.const 1033
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -25294,7 +25275,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1037
+   i32.const 1034
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -25308,7 +25289,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1038
+   i32.const 1035
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -25322,7 +25303,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1039
+   i32.const 1036
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -25336,7 +25317,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1040
+   i32.const 1037
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -25350,7 +25331,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1041
+   i32.const 1038
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -25364,7 +25345,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1042
+   i32.const 1039
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -25378,7 +25359,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1043
+   i32.const 1040
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -25392,7 +25373,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1044
+   i32.const 1041
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -25406,7 +25387,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1045
+   i32.const 1042
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -25420,7 +25401,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1046
+   i32.const 1043
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -25434,7 +25415,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1047
+   i32.const 1044
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -25448,7 +25429,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1048
+   i32.const 1045
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -25462,7 +25443,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1049
+   i32.const 1046
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -25476,7 +25457,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1050
+   i32.const 1047
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -25490,7 +25471,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1051
+   i32.const 1048
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -25504,7 +25485,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1052
+   i32.const 1049
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -25518,7 +25499,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1053
+   i32.const 1050
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -25532,7 +25513,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1054
+   i32.const 1051
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -25546,7 +25527,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1055
+   i32.const 1052
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -25560,7 +25541,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1056
+   i32.const 1053
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -25574,7 +25555,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1057
+   i32.const 1054
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -25588,7 +25569,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1058
+   i32.const 1055
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -25602,7 +25583,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1059
+   i32.const 1056
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -25616,7 +25597,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1060
+   i32.const 1057
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -25630,7 +25611,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1061
+   i32.const 1058
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -25644,7 +25625,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1062
+   i32.const 1059
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -25658,7 +25639,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1063
+   i32.const 1060
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -25672,7 +25653,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1064
+   i32.const 1061
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -25686,7 +25667,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1065
+   i32.const 1062
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -25700,7 +25681,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1066
+   i32.const 1063
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -25714,7 +25695,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1069
+   i32.const 1066
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -25728,7 +25709,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1070
+   i32.const 1067
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -25742,7 +25723,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1071
+   i32.const 1068
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -25756,7 +25737,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1072
+   i32.const 1069
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -25770,7 +25751,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1073
+   i32.const 1070
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -25784,7 +25765,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1074
+   i32.const 1071
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -25798,7 +25779,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1075
+   i32.const 1072
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -25812,7 +25793,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1076
+   i32.const 1073
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -25826,7 +25807,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1077
+   i32.const 1074
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -25840,7 +25821,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1078
+   i32.const 1075
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -25854,7 +25835,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1079
+   i32.const 1076
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -25868,7 +25849,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1080
+   i32.const 1077
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -25882,7 +25863,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1081
+   i32.const 1078
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -25896,7 +25877,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1082
+   i32.const 1079
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -25910,7 +25891,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1083
+   i32.const 1080
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -25924,7 +25905,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1084
+   i32.const 1081
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -25938,7 +25919,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1085
+   i32.const 1082
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -25952,7 +25933,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1086
+   i32.const 1083
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -25966,7 +25947,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1087
+   i32.const 1084
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -25980,7 +25961,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1088
+   i32.const 1085
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -25994,7 +25975,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1089
+   i32.const 1086
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -26008,7 +25989,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1090
+   i32.const 1087
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -26022,7 +26003,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1091
+   i32.const 1088
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -26036,7 +26017,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1092
+   i32.const 1089
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -26050,7 +26031,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1093
+   i32.const 1090
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -26064,7 +26045,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1094
+   i32.const 1091
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -26078,7 +26059,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1095
+   i32.const 1092
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -26092,7 +26073,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1096
+   i32.const 1093
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -26106,7 +26087,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1097
+   i32.const 1094
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -26120,7 +26101,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1098
+   i32.const 1095
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -26134,7 +26115,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1099
+   i32.const 1096
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -26148,7 +26129,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1100
+   i32.const 1097
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -26162,7 +26143,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1101
+   i32.const 1098
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -26176,7 +26157,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1102
+   i32.const 1099
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -26190,7 +26171,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1103
+   i32.const 1100
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -26204,7 +26185,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1104
+   i32.const 1101
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -26218,7 +26199,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1105
+   i32.const 1102
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -26232,85 +26213,188 @@
   if
    i32.const 0
    i32.const 32
+   i32.const 1103
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  block $~lib/math/NativeMath.cos<f64>|inlined.1 (result f64)
+   global.get $std/math/kPI
+   f64.const 2
+   f64.div
+   local.set $0
+   i32.const 1
+   drop
+   i32.const 8
+   i32.const 4
+   i32.eq
+   drop
+   i32.const 8
+   i32.const 8
+   i32.eq
+   drop
+   local.get $0
+   call $~lib/util/math/cos64
+   br $~lib/math/NativeMath.cos<f64>|inlined.1
+  end
+  global.get $std/math/kPI
+  f64.const 2
+  f64.div
+  call $~lib/bindings/dom/Math.cos
+  f64.eq
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 1105
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  block $~lib/math/NativeMath.cos<f64>|inlined.2 (result f64)
+   f64.const 2
+   global.get $std/math/kPI
+   f64.mul
+   f64.const 2
+   f64.div
+   local.set $0
+   i32.const 1
+   drop
+   i32.const 8
+   i32.const 4
+   i32.eq
+   drop
+   i32.const 8
+   i32.const 8
+   i32.eq
+   drop
+   local.get $0
+   call $~lib/util/math/cos64
+   br $~lib/math/NativeMath.cos<f64>|inlined.2
+  end
+  f64.const 2
+  global.get $std/math/kPI
+  f64.mul
+  f64.const 2
+  f64.div
+  call $~lib/bindings/dom/Math.cos
+  f64.eq
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
    i32.const 1106
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
-  global.get $std/math/kPI
-  f64.const 2
-  f64.div
-  call $~lib/math/NativeMath.cos
-  global.get $std/math/kPI
-  f64.const 2
-  f64.div
-  call $~lib/bindings/dom/Math.cos
-  f64.eq
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 1108
+  block $~lib/math/NativeMath.cos<f64>|inlined.3 (result f64)
+   f64.const 1.e+90
+   global.get $std/math/kPI
+   f64.mul
+   local.set $0
    i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const 2
-  global.get $std/math/kPI
-  f64.mul
-  f64.const 2
-  f64.div
-  call $~lib/math/NativeMath.cos
-  f64.const 2
-  global.get $std/math/kPI
-  f64.mul
-  f64.const 2
-  f64.div
-  call $~lib/bindings/dom/Math.cos
-  f64.eq
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 1109
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
+   drop
+   i32.const 8
+   i32.const 4
+   i32.eq
+   drop
+   i32.const 8
+   i32.const 8
+   i32.eq
+   drop
+   local.get $0
+   call $~lib/util/math/cos64
+   br $~lib/math/NativeMath.cos<f64>|inlined.3
   end
   f64.const 1.e+90
   global.get $std/math/kPI
   f64.mul
-  call $~lib/math/NativeMath.cos
-  f64.const 1.e+90
-  global.get $std/math/kPI
-  f64.mul
   call $~lib/bindings/dom/Math.cos
   f64.eq
   i32.eqz
   if
    i32.const 0
    i32.const 32
-   i32.const 1110
+   i32.const 1107
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 2.3283064365386963e-10
-  call $~lib/math/NativeMath.cos
+  block $~lib/math/NativeMath.cos<f64>|inlined.4 (result f64)
+   f64.const 2.3283064365386963e-10
+   local.set $0
+   i32.const 1
+   drop
+   i32.const 8
+   i32.const 4
+   i32.eq
+   drop
+   i32.const 8
+   i32.const 8
+   i32.eq
+   drop
+   local.get $0
+   call $~lib/util/math/cos64
+   br $~lib/math/NativeMath.cos<f64>|inlined.4
+  end
   f64.const 1
   f64.eq
   i32.eqz
   if
    i32.const 0
    i32.const 32
-   i32.const 1114
+   i32.const 1111
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -2.3283064365386963e-10
-  call $~lib/math/NativeMath.cos
+  block $~lib/math/NativeMath.cos<f64>|inlined.5 (result f64)
+   f64.const -2.3283064365386963e-10
+   local.set $0
+   i32.const 1
+   drop
+   i32.const 8
+   i32.const 4
+   i32.eq
+   drop
+   i32.const 8
+   i32.const 8
+   i32.eq
+   drop
+   local.get $0
+   call $~lib/util/math/cos64
+   br $~lib/math/NativeMath.cos<f64>|inlined.5
+  end
   f64.const 1
+  f64.eq
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 1112
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  block $~lib/math/NativeMath.cos<f64>|inlined.6 (result f64)
+   f64.const 0.15707963267948966
+   local.set $0
+   i32.const 1
+   drop
+   i32.const 8
+   i32.const 4
+   i32.eq
+   drop
+   i32.const 8
+   i32.const 8
+   i32.eq
+   drop
+   local.get $0
+   call $~lib/util/math/cos64
+   br $~lib/math/NativeMath.cos<f64>|inlined.6
+  end
+  f64.const 0.9876883405951378
   f64.eq
   i32.eqz
   if
@@ -26321,9 +26405,52 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 0.15707963267948966
-  call $~lib/math/NativeMath.cos
-  f64.const 0.9876883405951378
+  block $~lib/math/NativeMath.cos<f64>|inlined.7 (result f64)
+   f64.const 0.7812504768371582
+   local.set $0
+   i32.const 1
+   drop
+   i32.const 8
+   i32.const 4
+   i32.eq
+   drop
+   i32.const 8
+   i32.const 8
+   i32.eq
+   drop
+   local.get $0
+   call $~lib/util/math/cos64
+   br $~lib/math/NativeMath.cos<f64>|inlined.7
+  end
+  f64.const 0.7100335477927638
+  f64.eq
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 1117
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  block $~lib/math/NativeMath.cos<f64>|inlined.8 (result f64)
+   f64.const 0.78125
+   local.set $0
+   i32.const 1
+   drop
+   i32.const 8
+   i32.const 4
+   i32.eq
+   drop
+   i32.const 8
+   i32.const 8
+   i32.eq
+   drop
+   local.get $0
+   call $~lib/util/math/cos64
+   br $~lib/math/NativeMath.cos<f64>|inlined.8
+  end
+  f64.const 0.7100338835660797
   f64.eq
   i32.eqz
   if
@@ -26334,22 +26461,24 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 0.7812504768371582
-  call $~lib/math/NativeMath.cos
-  f64.const 0.7100335477927638
-  f64.eq
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 1120
+  block $~lib/math/NativeMath.cos<f64>|inlined.9 (result f64)
+   f64.const 0.39269908169872414
+   local.set $0
    i32.const 1
-   call $~lib/builtins/abort
-   unreachable
+   drop
+   i32.const 8
+   i32.const 4
+   i32.eq
+   drop
+   i32.const 8
+   i32.const 8
+   i32.eq
+   drop
+   local.get $0
+   call $~lib/util/math/cos64
+   br $~lib/math/NativeMath.cos<f64>|inlined.9
   end
-  f64.const 0.78125
-  call $~lib/math/NativeMath.cos
-  f64.const 0.7100338835660797
+  f64.const 0.9238795325112867
   f64.eq
   i32.eqz
   if
@@ -26360,22 +26489,52 @@
    call $~lib/builtins/abort
    unreachable
   end
+  block $~lib/math/NativeMath.cos<f64>|inlined.10 (result f64)
+   f64.const -0.39269908169872414
+   local.set $0
+   i32.const 1
+   drop
+   i32.const 8
+   i32.const 4
+   i32.eq
+   drop
+   i32.const 8
+   i32.const 8
+   i32.eq
+   drop
+   local.get $0
+   call $~lib/util/math/cos64
+   br $~lib/math/NativeMath.cos<f64>|inlined.10
+  end
   f64.const 0.9238795325112867
-  f64.const 0.39269908169872414
-  call $~lib/math/NativeMath.cos
   f64.eq
   i32.eqz
   if
    i32.const 0
    i32.const 32
-   i32.const 1124
+   i32.const 1123
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 0.9238795325112867
-  f64.const -0.39269908169872414
-  call $~lib/math/NativeMath.cos
+  block $~lib/math/NativeMath.cos<f64>|inlined.11 (result f64)
+   f64.const 3.725290298461914e-09
+   local.set $0
+   i32.const 1
+   drop
+   i32.const 8
+   i32.const 4
+   i32.eq
+   drop
+   i32.const 8
+   i32.const 8
+   i32.eq
+   drop
+   local.get $0
+   call $~lib/util/math/cos64
+   br $~lib/math/NativeMath.cos<f64>|inlined.11
+  end
+  f64.const 1
   f64.eq
   i32.eqz
   if
@@ -26386,9 +26545,52 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 3.725290298461914e-09
-  call $~lib/math/NativeMath.cos
-  f64.const 1
+  block $~lib/math/NativeMath.cos<f64>|inlined.12 (result f64)
+   f64.const 0.25
+   local.set $0
+   i32.const 1
+   drop
+   i32.const 8
+   i32.const 4
+   i32.eq
+   drop
+   i32.const 8
+   i32.const 8
+   i32.eq
+   drop
+   local.get $0
+   call $~lib/util/math/cos64
+   br $~lib/math/NativeMath.cos<f64>|inlined.12
+  end
+  f64.const 0.9689124217106447
+  f64.eq
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 1128
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  block $~lib/math/NativeMath.cos<f64>|inlined.13 (result f64)
+   f64.const 0.5
+   local.set $0
+   i32.const 1
+   drop
+   i32.const 8
+   i32.const 4
+   i32.eq
+   drop
+   i32.const 8
+   i32.const 8
+   i32.eq
+   drop
+   local.get $0
+   call $~lib/util/math/cos64
+   br $~lib/math/NativeMath.cos<f64>|inlined.13
+  end
+  f64.const 0.8775825618903728
   f64.eq
   i32.eqz
   if
@@ -26399,22 +26601,52 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 0.9689124217106447
-  f64.const 0.25
-  call $~lib/math/NativeMath.cos
+  block $~lib/math/NativeMath.cos<f64>|inlined.14 (result f64)
+   f64.const 0.785
+   local.set $0
+   i32.const 1
+   drop
+   i32.const 8
+   i32.const 4
+   i32.eq
+   drop
+   i32.const 8
+   i32.const 8
+   i32.eq
+   drop
+   local.get $0
+   call $~lib/util/math/cos64
+   br $~lib/math/NativeMath.cos<f64>|inlined.14
+  end
+  f64.const 0.7073882691671998
   f64.eq
   i32.eqz
   if
    i32.const 0
    i32.const 32
-   i32.const 1131
+   i32.const 1130
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 0.8775825618903728
-  f64.const 0.5
-  call $~lib/math/NativeMath.cos
+  block $~lib/math/NativeMath.cos<f64>|inlined.15 (result f64)
+   f64.const 1.5707963267948966
+   local.set $0
+   i32.const 1
+   drop
+   i32.const 8
+   i32.const 4
+   i32.eq
+   drop
+   i32.const 8
+   i32.const 8
+   i32.eq
+   drop
+   local.get $0
+   call $~lib/util/math/cos64
+   br $~lib/math/NativeMath.cos<f64>|inlined.15
+  end
+  f64.const 6.123233995736766e-17
   f64.eq
   i32.eqz
   if
@@ -26425,22 +26657,60 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 0.7073882691671998
-  f64.const 0.785
-  call $~lib/math/NativeMath.cos
+  block $~lib/math/NativeMath.cos<f64>|inlined.16 (result f64)
+   f64.const 7
+   f64.const 4
+   f64.div
+   global.get $std/math/kPI
+   f64.mul
+   local.set $0
+   i32.const 1
+   drop
+   i32.const 8
+   i32.const 4
+   i32.eq
+   drop
+   i32.const 8
+   i32.const 8
+   i32.eq
+   drop
+   local.get $0
+   call $~lib/util/math/cos64
+   br $~lib/math/NativeMath.cos<f64>|inlined.16
+  end
+  f64.const 0.7071067811865474
   f64.eq
   i32.eqz
   if
    i32.const 0
    i32.const 32
-   i32.const 1133
+   i32.const 1134
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 6.123233995736766e-17
-  f64.const 1.5707963267948966
-  call $~lib/math/NativeMath.cos
+  block $~lib/math/NativeMath.cos<f64>|inlined.17 (result f64)
+   f64.const 9
+   f64.const 4
+   f64.div
+   global.get $std/math/kPI
+   f64.mul
+   local.set $0
+   i32.const 1
+   drop
+   i32.const 8
+   i32.const 4
+   i32.eq
+   drop
+   i32.const 8
+   i32.const 8
+   i32.eq
+   drop
+   local.get $0
+   call $~lib/util/math/cos64
+   br $~lib/math/NativeMath.cos<f64>|inlined.17
+  end
+  f64.const 0.7071067811865477
   f64.eq
   i32.eqz
   if
@@ -26451,13 +26721,60 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 0.7071067811865474
-  f64.const 7
-  f64.const 4
-  f64.div
-  global.get $std/math/kPI
-  f64.mul
-  call $~lib/math/NativeMath.cos
+  block $~lib/math/NativeMath.cos<f64>|inlined.18 (result f64)
+   f64.const 11
+   f64.const 4
+   f64.div
+   global.get $std/math/kPI
+   f64.mul
+   local.set $0
+   i32.const 1
+   drop
+   i32.const 8
+   i32.const 4
+   i32.eq
+   drop
+   i32.const 8
+   i32.const 8
+   i32.eq
+   drop
+   local.get $0
+   call $~lib/util/math/cos64
+   br $~lib/math/NativeMath.cos<f64>|inlined.18
+  end
+  f64.const -0.7071067811865467
+  f64.eq
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 1136
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  block $~lib/math/NativeMath.cos<f64>|inlined.19 (result f64)
+   f64.const 13
+   f64.const 4
+   f64.div
+   global.get $std/math/kPI
+   f64.mul
+   local.set $0
+   i32.const 1
+   drop
+   i32.const 8
+   i32.const 4
+   i32.eq
+   drop
+   i32.const 8
+   i32.const 8
+   i32.eq
+   drop
+   local.get $0
+   call $~lib/util/math/cos64
+   br $~lib/math/NativeMath.cos<f64>|inlined.19
+  end
+  f64.const -0.7071067811865471
   f64.eq
   i32.eqz
   if
@@ -26468,13 +26785,24 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 0.7071067811865477
-  f64.const 9
-  f64.const 4
-  f64.div
-  global.get $std/math/kPI
-  f64.mul
-  call $~lib/math/NativeMath.cos
+  block $~lib/math/NativeMath.cos<f64>|inlined.20 (result f64)
+   f64.const 1e6
+   local.set $0
+   i32.const 1
+   drop
+   i32.const 8
+   i32.const 4
+   i32.eq
+   drop
+   i32.const 8
+   i32.const 8
+   i32.eq
+   drop
+   local.get $0
+   call $~lib/util/math/cos64
+   br $~lib/math/NativeMath.cos<f64>|inlined.20
+  end
+  f64.const 0.9367521275331447
   f64.eq
   i32.eqz
   if
@@ -26485,66 +26813,34 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -0.7071067811865467
-  f64.const 11
-  f64.const 4
-  f64.div
-  global.get $std/math/kPI
-  f64.mul
-  call $~lib/math/NativeMath.cos
+  block $~lib/math/NativeMath.cos<f64>|inlined.21 (result f64)
+   f64.const 1048575
+   f64.const 2
+   f64.div
+   global.get $std/math/kPI
+   f64.mul
+   local.set $0
+   i32.const 1
+   drop
+   i32.const 8
+   i32.const 4
+   i32.eq
+   drop
+   i32.const 8
+   i32.const 8
+   i32.eq
+   drop
+   local.get $0
+   call $~lib/util/math/cos64
+   br $~lib/math/NativeMath.cos<f64>|inlined.21
+  end
+  f64.const -3.435757038074824e-12
   f64.eq
   i32.eqz
   if
    i32.const 0
    i32.const 32
    i32.const 1139
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const -0.7071067811865471
-  f64.const 13
-  f64.const 4
-  f64.div
-  global.get $std/math/kPI
-  f64.mul
-  call $~lib/math/NativeMath.cos
-  f64.eq
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 1140
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const 0.9367521275331447
-  f64.const 1e6
-  call $~lib/math/NativeMath.cos
-  f64.eq
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 1141
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const -3.435757038074824e-12
-  f64.const 1048575
-  f64.const 2
-  f64.div
-  global.get $std/math/kPI
-  f64.mul
-  call $~lib/math/NativeMath.cos
-  f64.eq
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 1142
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -26558,7 +26854,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1151
+   i32.const 1148
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -26572,7 +26868,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1152
+   i32.const 1149
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -26586,7 +26882,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1153
+   i32.const 1150
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -26600,7 +26896,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1154
+   i32.const 1151
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -26614,7 +26910,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1155
+   i32.const 1152
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -26628,7 +26924,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1156
+   i32.const 1153
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -26642,7 +26938,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1157
+   i32.const 1154
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -26656,7 +26952,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1158
+   i32.const 1155
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -26670,7 +26966,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1159
+   i32.const 1156
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -26684,7 +26980,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1160
+   i32.const 1157
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -26698,7 +26994,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1163
+   i32.const 1160
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -26712,7 +27008,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1164
+   i32.const 1161
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -26726,7 +27022,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1165
+   i32.const 1162
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -26741,7 +27037,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1166
+   i32.const 1163
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -26755,7 +27051,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1167
+   i32.const 1164
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -26769,7 +27065,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1170
+   i32.const 1167
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -26783,7 +27079,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1171
+   i32.const 1168
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -26797,7 +27093,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1172
+   i32.const 1169
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -26811,7 +27107,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1173
+   i32.const 1170
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -26825,7 +27121,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1174
+   i32.const 1171
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -26839,7 +27135,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1175
+   i32.const 1172
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -26853,7 +27149,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1176
+   i32.const 1173
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -26867,7 +27163,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1177
+   i32.const 1174
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -26881,7 +27177,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1178
+   i32.const 1175
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -26895,7 +27191,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1179
+   i32.const 1176
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -26909,7 +27205,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1180
+   i32.const 1177
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -26923,7 +27219,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1181
+   i32.const 1178
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -26937,7 +27233,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1182
+   i32.const 1179
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -26951,7 +27247,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1183
+   i32.const 1180
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -26965,7 +27261,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1184
+   i32.const 1181
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -26979,7 +27275,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1185
+   i32.const 1182
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -26993,7 +27289,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1186
+   i32.const 1183
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -27007,7 +27303,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1187
+   i32.const 1184
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -27021,7 +27317,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1188
+   i32.const 1185
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -27035,7 +27331,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1189
+   i32.const 1186
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -27049,7 +27345,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1190
+   i32.const 1187
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -27063,7 +27359,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1191
+   i32.const 1188
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -27077,7 +27373,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1192
+   i32.const 1189
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -27091,7 +27387,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1193
+   i32.const 1190
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -27105,7 +27401,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1194
+   i32.const 1191
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -27119,7 +27415,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1195
+   i32.const 1192
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -27133,7 +27429,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1196
+   i32.const 1193
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -27147,7 +27443,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1197
+   i32.const 1194
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -27161,7 +27457,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1198
+   i32.const 1195
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -27175,7 +27471,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1199
+   i32.const 1196
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -27189,7 +27485,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1200
+   i32.const 1197
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -27203,7 +27499,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1201
+   i32.const 1198
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -27217,7 +27513,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1202
+   i32.const 1199
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -27231,7 +27527,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1203
+   i32.const 1200
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -27245,7 +27541,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1204
+   i32.const 1201
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -27259,7 +27555,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1205
+   i32.const 1202
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -27273,7 +27569,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1206
+   i32.const 1203
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -27287,7 +27583,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1207
+   i32.const 1204
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -27301,7 +27597,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1210
+   i32.const 1207
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -27315,7 +27611,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1211
+   i32.const 1208
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -27329,7 +27625,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1212
+   i32.const 1209
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -27343,7 +27639,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1213
+   i32.const 1210
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -27357,7 +27653,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1214
+   i32.const 1211
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -27371,7 +27667,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1215
+   i32.const 1212
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -27385,7 +27681,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1216
+   i32.const 1213
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -27399,7 +27695,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1217
+   i32.const 1214
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -27413,7 +27709,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1218
+   i32.const 1215
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -27427,7 +27723,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1219
+   i32.const 1216
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -27441,7 +27737,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1220
+   i32.const 1217
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -27455,7 +27751,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1221
+   i32.const 1218
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -27469,7 +27765,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1222
+   i32.const 1219
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -27484,7 +27780,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1223
+   i32.const 1220
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -27498,7 +27794,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1234
+   i32.const 1231
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -27512,7 +27808,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1235
+   i32.const 1232
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -27526,7 +27822,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1236
+   i32.const 1233
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -27540,7 +27836,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1237
+   i32.const 1234
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -27554,7 +27850,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1238
+   i32.const 1235
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -27568,7 +27864,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1239
+   i32.const 1236
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -27582,7 +27878,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1240
+   i32.const 1237
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -27596,7 +27892,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1241
+   i32.const 1238
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -27610,7 +27906,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1242
+   i32.const 1239
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -27624,7 +27920,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1243
+   i32.const 1240
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -27638,7 +27934,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1246
+   i32.const 1243
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -27652,7 +27948,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1247
+   i32.const 1244
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -27666,7 +27962,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1248
+   i32.const 1245
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -27681,7 +27977,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1249
+   i32.const 1246
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -27695,7 +27991,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1250
+   i32.const 1247
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -27709,7 +28005,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1259
+   i32.const 1256
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -27723,7 +28019,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1260
+   i32.const 1257
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -27737,7 +28033,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1261
+   i32.const 1258
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -27751,7 +28047,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1262
+   i32.const 1259
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -27765,7 +28061,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1263
+   i32.const 1260
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -27779,7 +28075,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1264
+   i32.const 1261
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -27793,7 +28089,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1265
+   i32.const 1262
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -27807,7 +28103,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1266
+   i32.const 1263
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -27821,7 +28117,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1267
+   i32.const 1264
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -27835,7 +28131,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1268
+   i32.const 1265
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -27849,7 +28145,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1271
+   i32.const 1268
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -27863,7 +28159,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1272
+   i32.const 1269
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -27877,7 +28173,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1273
+   i32.const 1270
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -27892,7 +28188,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1274
+   i32.const 1271
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -27906,7 +28202,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1275
+   i32.const 1272
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -27920,7 +28216,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1287
+   i32.const 1284
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -27934,7 +28230,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1288
+   i32.const 1285
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -27948,7 +28244,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1289
+   i32.const 1286
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -27962,7 +28258,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1290
+   i32.const 1287
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -27976,7 +28272,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1291
+   i32.const 1288
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -27990,7 +28286,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1292
+   i32.const 1289
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -28004,7 +28300,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1293
+   i32.const 1290
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -28018,7 +28314,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1294
+   i32.const 1291
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -28032,7 +28328,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1295
+   i32.const 1292
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -28046,7 +28342,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1296
+   i32.const 1293
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -28060,7 +28356,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1299
+   i32.const 1296
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -28074,7 +28370,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1300
+   i32.const 1297
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -28088,7 +28384,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1301
+   i32.const 1298
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -28102,7 +28398,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1302
+   i32.const 1299
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -28116,7 +28412,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1303
+   i32.const 1300
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -28131,7 +28427,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1304
+   i32.const 1301
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -28145,7 +28441,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1305
+   i32.const 1302
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -28159,7 +28455,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1306
+   i32.const 1303
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -28173,7 +28469,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1307
+   i32.const 1304
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -28187,7 +28483,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1308
+   i32.const 1305
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -28201,7 +28497,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1309
+   i32.const 1306
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -28215,7 +28511,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1312
+   i32.const 1309
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -28230,7 +28526,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1313
+   i32.const 1310
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -28247,7 +28543,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1315
+   i32.const 1312
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -28264,7 +28560,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1322
+   i32.const 1319
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -28282,7 +28578,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1323
+   i32.const 1320
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -28300,7 +28596,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1330
+   i32.const 1327
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -28317,7 +28613,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1337
+   i32.const 1334
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -28336,7 +28632,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1344
+   i32.const 1341
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -28353,7 +28649,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1351
+   i32.const 1348
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -28370,7 +28666,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1358
+   i32.const 1355
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -28387,7 +28683,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1365
+   i32.const 1362
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -28404,7 +28700,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1371
+   i32.const 1368
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -28421,7 +28717,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1377
+   i32.const 1374
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -28438,7 +28734,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1383
+   i32.const 1380
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -28455,7 +28751,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1390
+   i32.const 1387
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -28472,7 +28768,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1397
+   i32.const 1394
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -28489,7 +28785,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1404
+   i32.const 1401
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -28506,7 +28802,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1411
+   i32.const 1408
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -28523,7 +28819,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1418
+   i32.const 1415
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -28540,7 +28836,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1425
+   i32.const 1422
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -28557,7 +28853,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1432
+   i32.const 1429
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -28574,7 +28870,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1439
+   i32.const 1436
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -28588,7 +28884,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1453
+   i32.const 1450
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -28602,7 +28898,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1454
+   i32.const 1451
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -28616,7 +28912,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1455
+   i32.const 1452
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -28630,7 +28926,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1456
+   i32.const 1453
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -28644,7 +28940,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1457
+   i32.const 1454
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -28658,7 +28954,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1458
+   i32.const 1455
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -28672,7 +28968,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1459
+   i32.const 1456
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -28686,7 +28982,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1460
+   i32.const 1457
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -28700,7 +28996,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1461
+   i32.const 1458
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -28714,7 +29010,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1462
+   i32.const 1459
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -28728,7 +29024,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1465
+   i32.const 1462
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -28742,7 +29038,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1466
+   i32.const 1463
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -28756,7 +29052,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1467
+   i32.const 1464
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -28770,7 +29066,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1468
+   i32.const 1465
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -28784,7 +29080,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1469
+   i32.const 1466
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -28799,7 +29095,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1470
+   i32.const 1467
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -28813,7 +29109,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1471
+   i32.const 1468
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -28827,7 +29123,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1472
+   i32.const 1469
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -28843,7 +29139,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1473
+   i32.const 1470
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -28859,7 +29155,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1474
+   i32.const 1471
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -28875,7 +29171,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1475
+   i32.const 1472
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -28889,7 +29185,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1476
+   i32.const 1473
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -28903,7 +29199,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1477
+   i32.const 1474
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -28917,7 +29213,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1478
+   i32.const 1475
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -28931,7 +29227,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1490
+   i32.const 1487
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -28945,7 +29241,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1491
+   i32.const 1488
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -28959,7 +29255,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1492
+   i32.const 1489
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -28973,7 +29269,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1493
+   i32.const 1490
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -28987,7 +29283,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1494
+   i32.const 1491
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -29001,7 +29297,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1495
+   i32.const 1492
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -29015,7 +29311,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1496
+   i32.const 1493
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -29029,7 +29325,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1497
+   i32.const 1494
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -29043,7 +29339,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1498
+   i32.const 1495
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -29057,25 +29353,25 @@
   if
    i32.const 0
    i32.const 32
+   i32.const 1496
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const 0
+  f64.const 0
+  f64.const 0
+  i32.const 0
+  call $std/math/test_expm1
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
    i32.const 1499
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 0
-  f64.const 0
-  f64.const 0
-  i32.const 0
-  call $std/math/test_expm1
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 1502
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
   f64.const -0
   f64.const -0
   f64.const 0
@@ -29085,7 +29381,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1503
+   i32.const 1500
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -29099,7 +29395,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1504
+   i32.const 1501
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -29113,7 +29409,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1505
+   i32.const 1502
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -29127,7 +29423,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1506
+   i32.const 1503
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -29142,7 +29438,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1507
+   i32.const 1504
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -29156,7 +29452,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1508
+   i32.const 1505
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -29172,7 +29468,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1509
+   i32.const 1506
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -29188,7 +29484,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1510
+   i32.const 1507
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -29202,7 +29498,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1519
+   i32.const 1516
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -29216,7 +29512,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1520
+   i32.const 1517
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -29230,7 +29526,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1521
+   i32.const 1518
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -29244,7 +29540,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1522
+   i32.const 1519
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -29258,7 +29554,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1523
+   i32.const 1520
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -29272,7 +29568,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1524
+   i32.const 1521
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -29286,7 +29582,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1525
+   i32.const 1522
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -29300,7 +29596,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1526
+   i32.const 1523
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -29314,7 +29610,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1527
+   i32.const 1524
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -29328,25 +29624,25 @@
   if
    i32.const 0
    i32.const 32
+   i32.const 1525
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const 0
+  f32.const 0
+  f32.const 0
+  i32.const 0
+  call $std/math/test_expm1f
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
    i32.const 1528
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 0
-  f32.const 0
-  f32.const 0
-  i32.const 0
-  call $std/math/test_expm1f
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 1531
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
   f32.const -0
   f32.const -0
   f32.const 0
@@ -29356,7 +29652,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1532
+   i32.const 1529
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -29370,7 +29666,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1533
+   i32.const 1530
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -29384,7 +29680,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1534
+   i32.const 1531
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -29398,7 +29694,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1535
+   i32.const 1532
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -29413,7 +29709,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1536
+   i32.const 1533
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -29427,7 +29723,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1537
+   i32.const 1534
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -29444,7 +29740,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1549
+   i32.const 1546
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -29461,7 +29757,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1550
+   i32.const 1547
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -29478,7 +29774,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1551
+   i32.const 1548
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -29495,7 +29791,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1552
+   i32.const 1549
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -29512,7 +29808,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1553
+   i32.const 1550
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -29529,7 +29825,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1554
+   i32.const 1551
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -29546,7 +29842,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1555
+   i32.const 1552
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -29563,7 +29859,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1556
+   i32.const 1553
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -29580,7 +29876,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1557
+   i32.const 1554
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -29592,6 +29888,21 @@
   i64.const -4624080701338157056
   f64.reinterpret_i64
   global.get $std/math/INEXACT
+  call $std/math/test_exp2
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 1555
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const 0
+  i64.const 4607182418800017408
+  f64.reinterpret_i64
+  f64.const 0
+  i32.const 0
   call $std/math/test_exp2
   i32.eqz
   if
@@ -29612,22 +29923,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1561
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const 0
-  i64.const 4607182418800017408
-  f64.reinterpret_i64
-  f64.const 0
-  i32.const 0
-  call $std/math/test_exp2
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 1562
+   i32.const 1559
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -29642,7 +29938,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1563
+   i32.const 1560
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -29657,7 +29953,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1564
+   i32.const 1561
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -29671,7 +29967,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1565
+   i32.const 1562
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -29686,7 +29982,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1566
+   i32.const 1563
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -29700,7 +29996,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1567
+   i32.const 1564
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -29717,7 +30013,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1568
+   i32.const 1565
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -29734,7 +30030,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1569
+   i32.const 1566
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -29750,7 +30046,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1570
+   i32.const 1567
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -29769,7 +30065,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1571
+   i32.const 1568
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -29785,7 +30081,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1572
+   i32.const 1569
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -29802,7 +30098,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1573
+   i32.const 1570
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -29819,7 +30115,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1574
+   i32.const 1571
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -29836,7 +30132,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1575
+   i32.const 1572
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -29853,7 +30149,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1576
+   i32.const 1573
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -29872,7 +30168,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1577
+   i32.const 1574
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -29888,7 +30184,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1578
+   i32.const 1575
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -29907,7 +30203,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1579
+   i32.const 1576
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -29923,7 +30219,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1580
+   i32.const 1577
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -29939,7 +30235,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1581
+   i32.const 1578
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -29955,7 +30251,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1582
+   i32.const 1579
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -29974,7 +30270,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1583
+   i32.const 1580
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -29992,7 +30288,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1584
+   i32.const 1581
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -30009,7 +30305,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1585
+   i32.const 1582
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -30029,7 +30325,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1596
+   i32.const 1593
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -30049,7 +30345,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1597
+   i32.const 1594
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -30069,7 +30365,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1598
+   i32.const 1595
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -30089,7 +30385,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1599
+   i32.const 1596
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -30109,7 +30405,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1600
+   i32.const 1597
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -30129,7 +30425,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1601
+   i32.const 1598
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -30149,7 +30445,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1602
+   i32.const 1599
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -30169,7 +30465,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1603
+   i32.const 1600
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -30189,7 +30485,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1604
+   i32.const 1601
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -30209,7 +30505,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1605
+   i32.const 1602
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -30223,7 +30519,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1617
+   i32.const 1614
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -30237,7 +30533,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1618
+   i32.const 1615
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -30251,7 +30547,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1619
+   i32.const 1616
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -30265,7 +30561,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1620
+   i32.const 1617
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -30279,7 +30575,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1621
+   i32.const 1618
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -30293,7 +30589,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1622
+   i32.const 1619
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -30307,7 +30603,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1623
+   i32.const 1620
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -30321,7 +30617,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1624
+   i32.const 1621
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -30335,7 +30631,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1625
+   i32.const 1622
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -30349,13 +30645,57 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1626
+   i32.const 1623
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f64.const nan:0x8000000000000
   f64.const nan:0x8000000000000
+  f64.const 0
+  i32.const 0
+  call $std/math/test_floor
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 1626
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const inf
+  f64.const inf
+  f64.const 0
+  i32.const 0
+  call $std/math/test_floor
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 1627
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const inf
+  f64.neg
+  f64.const inf
+  f64.neg
+  f64.const 0
+  i32.const 0
+  call $std/math/test_floor
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 1628
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const 0
+  f64.const 0
   f64.const 0
   i32.const 0
   call $std/math/test_floor
@@ -30368,8 +30708,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const inf
-  f64.const inf
+  f64.const -0
+  f64.const -0
   f64.const 0
   i32.const 0
   call $std/math/test_floor
@@ -30382,10 +30722,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const inf
-  f64.neg
-  f64.const inf
-  f64.neg
+  f64.const 1
+  f64.const 1
   f64.const 0
   i32.const 0
   call $std/math/test_floor
@@ -30398,8 +30736,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 0
-  f64.const 0
+  f64.const -1
+  f64.const -1
   f64.const 0
   i32.const 0
   call $std/math/test_floor
@@ -30408,48 +30746,6 @@
    i32.const 0
    i32.const 32
    i32.const 1632
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const -0
-  f64.const -0
-  f64.const 0
-  i32.const 0
-  call $std/math/test_floor
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 1633
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const 1
-  f64.const 1
-  f64.const 0
-  i32.const 0
-  call $std/math/test_floor
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 1634
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const -1
-  f64.const -1
-  f64.const 0
-  i32.const 0
-  call $std/math/test_floor
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 1635
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -30463,7 +30759,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1636
+   i32.const 1633
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -30477,7 +30773,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1637
+   i32.const 1634
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -30491,7 +30787,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1638
+   i32.const 1635
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -30505,7 +30801,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1639
+   i32.const 1636
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -30519,7 +30815,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1640
+   i32.const 1637
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -30533,7 +30829,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1641
+   i32.const 1638
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -30547,7 +30843,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1642
+   i32.const 1639
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -30561,7 +30857,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1643
+   i32.const 1640
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -30575,7 +30871,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1652
+   i32.const 1649
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -30589,7 +30885,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1653
+   i32.const 1650
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -30603,7 +30899,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1654
+   i32.const 1651
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -30617,7 +30913,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1655
+   i32.const 1652
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -30631,7 +30927,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1656
+   i32.const 1653
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -30645,7 +30941,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1657
+   i32.const 1654
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -30659,7 +30955,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1658
+   i32.const 1655
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -30673,7 +30969,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1659
+   i32.const 1656
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -30687,7 +30983,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1660
+   i32.const 1657
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -30701,13 +30997,57 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1661
+   i32.const 1658
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f32.const nan:0x400000
   f32.const nan:0x400000
+  f32.const 0
+  i32.const 0
+  call $std/math/test_floorf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 1661
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const inf
+  f32.const inf
+  f32.const 0
+  i32.const 0
+  call $std/math/test_floorf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 1662
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const inf
+  f32.neg
+  f32.const inf
+  f32.neg
+  f32.const 0
+  i32.const 0
+  call $std/math/test_floorf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 1663
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const 0
+  f32.const 0
   f32.const 0
   i32.const 0
   call $std/math/test_floorf
@@ -30720,8 +31060,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const inf
-  f32.const inf
+  f32.const -0
+  f32.const -0
   f32.const 0
   i32.const 0
   call $std/math/test_floorf
@@ -30734,10 +31074,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const inf
-  f32.neg
-  f32.const inf
-  f32.neg
+  f32.const 1
+  f32.const 1
   f32.const 0
   i32.const 0
   call $std/math/test_floorf
@@ -30750,8 +31088,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 0
-  f32.const 0
+  f32.const -1
+  f32.const -1
   f32.const 0
   i32.const 0
   call $std/math/test_floorf
@@ -30760,48 +31098,6 @@
    i32.const 0
    i32.const 32
    i32.const 1667
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const -0
-  f32.const -0
-  f32.const 0
-  i32.const 0
-  call $std/math/test_floorf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 1668
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const 1
-  f32.const 1
-  f32.const 0
-  i32.const 0
-  call $std/math/test_floorf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 1669
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const -1
-  f32.const -1
-  f32.const 0
-  i32.const 0
-  call $std/math/test_floorf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 1670
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -30815,7 +31111,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1671
+   i32.const 1668
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -30829,7 +31125,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1672
+   i32.const 1669
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -30843,7 +31139,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1673
+   i32.const 1670
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -30857,7 +31153,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1674
+   i32.const 1671
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -30871,7 +31167,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1675
+   i32.const 1672
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -30885,7 +31181,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1676
+   i32.const 1673
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -30899,7 +31195,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1677
+   i32.const 1674
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -30913,7 +31209,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1678
+   i32.const 1675
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -30928,7 +31224,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1692
+   i32.const 1689
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -30943,7 +31239,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1693
+   i32.const 1690
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -30958,7 +31254,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1694
+   i32.const 1691
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -30973,7 +31269,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1695
+   i32.const 1692
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -30988,7 +31284,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1696
+   i32.const 1693
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -31003,7 +31299,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1697
+   i32.const 1694
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -31018,7 +31314,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1698
+   i32.const 1695
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -31033,7 +31329,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1699
+   i32.const 1696
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -31048,7 +31344,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1700
+   i32.const 1697
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -31063,13 +31359,58 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1701
+   i32.const 1698
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f64.const 3
   f64.const 4
+  f64.const 5
+  f64.const 0
+  i32.const 0
+  call $std/math/test_hypot
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 1701
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const -3
+  f64.const 4
+  f64.const 5
+  f64.const 0
+  i32.const 0
+  call $std/math/test_hypot
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 1702
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const 4
+  f64.const 3
+  f64.const 5
+  f64.const 0
+  i32.const 0
+  call $std/math/test_hypot
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 1703
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const 4
+  f64.const -3
   f64.const 5
   f64.const 0
   i32.const 0
@@ -31084,7 +31425,7 @@
    unreachable
   end
   f64.const -3
-  f64.const 4
+  f64.const -4
   f64.const 5
   f64.const 0
   i32.const 0
@@ -31098,9 +31439,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 4
-  f64.const 3
-  f64.const 5
+  f64.const 1797693134862315708145274e284
+  f64.const 0
+  f64.const 1797693134862315708145274e284
   f64.const 0
   i32.const 0
   call $std/math/test_hypot
@@ -31113,9 +31454,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 4
-  f64.const -3
-  f64.const 5
+  f64.const 1797693134862315708145274e284
+  f64.const -0
+  f64.const 1797693134862315708145274e284
   f64.const 0
   i32.const 0
   call $std/math/test_hypot
@@ -31128,9 +31469,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -3
-  f64.const -4
-  f64.const 5
+  f64.const 5e-324
+  f64.const 0
+  f64.const 5e-324
   f64.const 0
   i32.const 0
   call $std/math/test_hypot
@@ -31143,9 +31484,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 1797693134862315708145274e284
-  f64.const 0
-  f64.const 1797693134862315708145274e284
+  f64.const 5e-324
+  f64.const -0
+  f64.const 5e-324
   f64.const 0
   i32.const 0
   call $std/math/test_hypot
@@ -31158,9 +31499,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 1797693134862315708145274e284
-  f64.const -0
-  f64.const 1797693134862315708145274e284
+  f64.const inf
+  f64.const 1
+  f64.const inf
   f64.const 0
   i32.const 0
   call $std/math/test_hypot
@@ -31173,9 +31514,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 5e-324
-  f64.const 0
-  f64.const 5e-324
+  f64.const 1
+  f64.const inf
+  f64.const inf
   f64.const 0
   i32.const 0
   call $std/math/test_hypot
@@ -31188,9 +31529,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 5e-324
-  f64.const -0
-  f64.const 5e-324
+  f64.const inf
+  f64.const nan:0x8000000000000
+  f64.const inf
   f64.const 0
   i32.const 0
   call $std/math/test_hypot
@@ -31203,8 +31544,8 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f64.const nan:0x8000000000000
   f64.const inf
-  f64.const 1
   f64.const inf
   f64.const 0
   i32.const 0
@@ -31218,8 +31559,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 1
   f64.const inf
+  f64.neg
+  f64.const 1
   f64.const inf
   f64.const 0
   i32.const 0
@@ -31233,8 +31575,9 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f64.const 1
   f64.const inf
-  f64.const nan:0x8000000000000
+  f64.neg
   f64.const inf
   f64.const 0
   i32.const 0
@@ -31248,8 +31591,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const nan:0x8000000000000
   f64.const inf
+  f64.neg
+  f64.const nan:0x8000000000000
   f64.const inf
   f64.const 0
   i32.const 0
@@ -31263,9 +31607,9 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f64.const nan:0x8000000000000
   f64.const inf
   f64.neg
-  f64.const 1
   f64.const inf
   f64.const 0
   i32.const 0
@@ -31279,10 +31623,9 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f64.const nan:0x8000000000000
   f64.const 1
-  f64.const inf
-  f64.neg
-  f64.const inf
+  f64.const nan:0x8000000000000
   f64.const 0
   i32.const 0
   call $std/math/test_hypot
@@ -31295,10 +31638,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const inf
-  f64.neg
+  f64.const 1
   f64.const nan:0x8000000000000
-  f64.const inf
+  f64.const nan:0x8000000000000
   f64.const 0
   i32.const 0
   call $std/math/test_hypot
@@ -31312,9 +31654,8 @@
    unreachable
   end
   f64.const nan:0x8000000000000
-  f64.const inf
-  f64.neg
-  f64.const inf
+  f64.const 0
+  f64.const nan:0x8000000000000
   f64.const 0
   i32.const 0
   call $std/math/test_hypot
@@ -31327,8 +31668,8 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f64.const 0
   f64.const nan:0x8000000000000
-  f64.const 1
   f64.const nan:0x8000000000000
   f64.const 0
   i32.const 0
@@ -31338,51 +31679,6 @@
    i32.const 0
    i32.const 32
    i32.const 1721
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const 1
-  f64.const nan:0x8000000000000
-  f64.const nan:0x8000000000000
-  f64.const 0
-  i32.const 0
-  call $std/math/test_hypot
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 1722
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const nan:0x8000000000000
-  f64.const 0
-  f64.const nan:0x8000000000000
-  f64.const 0
-  i32.const 0
-  call $std/math/test_hypot
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 1723
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const 0
-  f64.const nan:0x8000000000000
-  f64.const nan:0x8000000000000
-  f64.const 0
-  i32.const 0
-  call $std/math/test_hypot
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 1724
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -31397,7 +31693,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1733
+   i32.const 1730
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -31412,7 +31708,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1734
+   i32.const 1731
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -31427,7 +31723,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1735
+   i32.const 1732
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -31442,7 +31738,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1736
+   i32.const 1733
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -31457,7 +31753,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1737
+   i32.const 1734
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -31472,7 +31768,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1738
+   i32.const 1735
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -31487,7 +31783,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1739
+   i32.const 1736
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -31502,7 +31798,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1740
+   i32.const 1737
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -31517,7 +31813,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1741
+   i32.const 1738
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -31532,13 +31828,58 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1742
+   i32.const 1739
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f32.const 3
   f32.const 4
+  f32.const 5
+  f32.const 0
+  i32.const 0
+  call $std/math/test_hypotf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 1742
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const -3
+  f32.const 4
+  f32.const 5
+  f32.const 0
+  i32.const 0
+  call $std/math/test_hypotf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 1743
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const 4
+  f32.const 3
+  f32.const 5
+  f32.const 0
+  i32.const 0
+  call $std/math/test_hypotf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 1744
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const 4
+  f32.const -3
   f32.const 5
   f32.const 0
   i32.const 0
@@ -31553,7 +31894,7 @@
    unreachable
   end
   f32.const -3
-  f32.const 4
+  f32.const -4
   f32.const 5
   f32.const 0
   i32.const 0
@@ -31567,9 +31908,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 4
-  f32.const 3
-  f32.const 5
+  f32.const 3402823466385288598117041e14
+  f32.const 0
+  f32.const 3402823466385288598117041e14
   f32.const 0
   i32.const 0
   call $std/math/test_hypotf
@@ -31582,9 +31923,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 4
-  f32.const -3
-  f32.const 5
+  f32.const 3402823466385288598117041e14
+  f32.const -0
+  f32.const 3402823466385288598117041e14
   f32.const 0
   i32.const 0
   call $std/math/test_hypotf
@@ -31597,9 +31938,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -3
-  f32.const -4
-  f32.const 5
+  f32.const 1.401298464324817e-45
+  f32.const 0
+  f32.const 1.401298464324817e-45
   f32.const 0
   i32.const 0
   call $std/math/test_hypotf
@@ -31612,9 +31953,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 3402823466385288598117041e14
-  f32.const 0
-  f32.const 3402823466385288598117041e14
+  f32.const 1.401298464324817e-45
+  f32.const -0
+  f32.const 1.401298464324817e-45
   f32.const 0
   i32.const 0
   call $std/math/test_hypotf
@@ -31627,9 +31968,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 3402823466385288598117041e14
-  f32.const -0
-  f32.const 3402823466385288598117041e14
+  f32.const inf
+  f32.const 1
+  f32.const inf
   f32.const 0
   i32.const 0
   call $std/math/test_hypotf
@@ -31642,9 +31983,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 1.401298464324817e-45
-  f32.const 0
-  f32.const 1.401298464324817e-45
+  f32.const 1
+  f32.const inf
+  f32.const inf
   f32.const 0
   i32.const 0
   call $std/math/test_hypotf
@@ -31657,9 +31998,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 1.401298464324817e-45
-  f32.const -0
-  f32.const 1.401298464324817e-45
+  f32.const inf
+  f32.const nan:0x400000
+  f32.const inf
   f32.const 0
   i32.const 0
   call $std/math/test_hypotf
@@ -31672,8 +32013,8 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f32.const nan:0x400000
   f32.const inf
-  f32.const 1
   f32.const inf
   f32.const 0
   i32.const 0
@@ -31687,8 +32028,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 1
   f32.const inf
+  f32.neg
+  f32.const 1
   f32.const inf
   f32.const 0
   i32.const 0
@@ -31702,8 +32044,9 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f32.const 1
   f32.const inf
-  f32.const nan:0x400000
+  f32.neg
   f32.const inf
   f32.const 0
   i32.const 0
@@ -31717,8 +32060,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const nan:0x400000
   f32.const inf
+  f32.neg
+  f32.const nan:0x400000
   f32.const inf
   f32.const 0
   i32.const 0
@@ -31732,9 +32076,9 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f32.const nan:0x400000
   f32.const inf
   f32.neg
-  f32.const 1
   f32.const inf
   f32.const 0
   i32.const 0
@@ -31748,10 +32092,9 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f32.const nan:0x400000
   f32.const 1
-  f32.const inf
-  f32.neg
-  f32.const inf
+  f32.const nan:0x400000
   f32.const 0
   i32.const 0
   call $std/math/test_hypotf
@@ -31764,10 +32107,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const inf
-  f32.neg
+  f32.const 1
   f32.const nan:0x400000
-  f32.const inf
+  f32.const nan:0x400000
   f32.const 0
   i32.const 0
   call $std/math/test_hypotf
@@ -31776,52 +32118,6 @@
    i32.const 0
    i32.const 32
    i32.const 1760
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const nan:0x400000
-  f32.const inf
-  f32.neg
-  f32.const inf
-  f32.const 0
-  i32.const 0
-  call $std/math/test_hypotf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 1761
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const nan:0x400000
-  f32.const 1
-  f32.const nan:0x400000
-  f32.const 0
-  i32.const 0
-  call $std/math/test_hypotf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 1762
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const 1
-  f32.const nan:0x400000
-  f32.const nan:0x400000
-  f32.const 0
-  i32.const 0
-  call $std/math/test_hypotf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 1763
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -31835,7 +32131,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1775
+   i32.const 1772
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -31849,7 +32145,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1776
+   i32.const 1773
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -31863,7 +32159,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1777
+   i32.const 1774
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -31877,7 +32173,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1778
+   i32.const 1775
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -31891,7 +32187,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1779
+   i32.const 1776
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -31905,7 +32201,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1780
+   i32.const 1777
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -31919,7 +32215,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1781
+   i32.const 1778
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -31933,7 +32229,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1782
+   i32.const 1779
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -31947,7 +32243,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1783
+   i32.const 1780
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -31961,7 +32257,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1784
+   i32.const 1781
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -31976,7 +32272,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1787
+   i32.const 1784
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -31991,7 +32287,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1788
+   i32.const 1785
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -32005,7 +32301,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1789
+   i32.const 1786
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -32019,7 +32315,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1790
+   i32.const 1787
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -32033,7 +32329,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1791
+   i32.const 1788
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -32047,7 +32343,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1792
+   i32.const 1789
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -32062,7 +32358,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1793
+   i32.const 1790
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -32076,7 +32372,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1794
+   i32.const 1791
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -32086,6 +32382,49 @@
   f32.neg
   f32.const 0
   global.get $std/math/DIVBYZERO
+  call $std/math/test_logf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 1800
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const -0
+  f32.const inf
+  f32.neg
+  f32.const 0
+  global.get $std/math/DIVBYZERO
+  call $std/math/test_logf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 1801
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const -7.888609052210118e-31
+  f32.const nan:0x400000
+  f32.const 0
+  global.get $std/math/INVALID
+  call $std/math/test_logf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 1802
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const 1
+  f32.const 0
+  f32.const 0
+  i32.const 0
   call $std/math/test_logf
   i32.eqz
   if
@@ -32096,11 +32435,10 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -0
-  f32.const inf
-  f32.neg
+  f32.const -1
+  f32.const nan:0x400000
   f32.const 0
-  global.get $std/math/DIVBYZERO
+  global.get $std/math/INVALID
   call $std/math/test_logf
   i32.eqz
   if
@@ -32111,58 +32449,16 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -7.888609052210118e-31
-  f32.const nan:0x400000
+  f32.const inf
+  f32.const inf
   f32.const 0
-  global.get $std/math/INVALID
+  i32.const 0
   call $std/math/test_logf
   i32.eqz
   if
    i32.const 0
    i32.const 32
    i32.const 1805
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const 1
-  f32.const 0
-  f32.const 0
-  i32.const 0
-  call $std/math/test_logf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 1806
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const -1
-  f32.const nan:0x400000
-  f32.const 0
-  global.get $std/math/INVALID
-  call $std/math/test_logf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 1807
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const inf
-  f32.const inf
-  f32.const 0
-  i32.const 0
-  call $std/math/test_logf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 1808
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -32177,7 +32473,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1809
+   i32.const 1806
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -32191,7 +32487,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1810
+   i32.const 1807
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -32206,7 +32502,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1813
+   i32.const 1810
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -32221,7 +32517,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1814
+   i32.const 1811
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -32235,7 +32531,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1815
+   i32.const 1812
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -32249,7 +32545,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1816
+   i32.const 1813
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -32263,7 +32559,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1817
+   i32.const 1814
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -32277,7 +32573,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1818
+   i32.const 1815
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -32292,7 +32588,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1819
+   i32.const 1816
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -32306,7 +32602,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1820
+   i32.const 1817
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -32320,7 +32616,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1832
+   i32.const 1829
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -32334,7 +32630,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1833
+   i32.const 1830
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -32348,7 +32644,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1834
+   i32.const 1831
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -32362,7 +32658,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1835
+   i32.const 1832
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -32376,7 +32672,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1836
+   i32.const 1833
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -32390,7 +32686,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1837
+   i32.const 1834
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -32404,7 +32700,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1838
+   i32.const 1835
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -32418,7 +32714,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1839
+   i32.const 1836
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -32432,7 +32728,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1840
+   i32.const 1837
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -32446,7 +32742,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1841
+   i32.const 1838
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -32461,7 +32757,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1844
+   i32.const 1841
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -32476,7 +32772,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1845
+   i32.const 1842
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -32490,7 +32786,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1846
+   i32.const 1843
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -32504,7 +32800,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1847
+   i32.const 1844
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -32518,7 +32814,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1848
+   i32.const 1845
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -32532,7 +32828,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1849
+   i32.const 1846
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -32547,7 +32843,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1850
+   i32.const 1847
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -32561,7 +32857,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1851
+   i32.const 1848
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -32575,7 +32871,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1860
+   i32.const 1857
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -32589,7 +32885,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1861
+   i32.const 1858
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -32603,7 +32899,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1862
+   i32.const 1859
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -32617,7 +32913,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1863
+   i32.const 1860
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -32631,7 +32927,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1864
+   i32.const 1861
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -32645,7 +32941,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1865
+   i32.const 1862
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -32659,7 +32955,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1866
+   i32.const 1863
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -32673,7 +32969,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1867
+   i32.const 1864
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -32687,7 +32983,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1868
+   i32.const 1865
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -32701,7 +32997,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1869
+   i32.const 1866
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -32716,7 +33012,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1872
+   i32.const 1869
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -32731,7 +33027,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1873
+   i32.const 1870
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -32745,7 +33041,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1874
+   i32.const 1871
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -32759,7 +33055,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1875
+   i32.const 1872
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -32773,7 +33069,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1876
+   i32.const 1873
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -32787,7 +33083,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1877
+   i32.const 1874
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -32802,7 +33098,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1878
+   i32.const 1875
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -32816,7 +33112,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1879
+   i32.const 1876
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -32830,7 +33126,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1891
+   i32.const 1888
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -32844,7 +33140,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1892
+   i32.const 1889
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -32858,7 +33154,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1893
+   i32.const 1890
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -32872,7 +33168,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1894
+   i32.const 1891
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -32886,7 +33182,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1895
+   i32.const 1892
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -32900,7 +33196,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1896
+   i32.const 1893
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -32914,7 +33210,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1897
+   i32.const 1894
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -32928,7 +33224,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1898
+   i32.const 1895
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -32942,7 +33238,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1899
+   i32.const 1896
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -32956,25 +33252,25 @@
   if
    i32.const 0
    i32.const 32
+   i32.const 1897
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const 0
+  f64.const 0
+  f64.const 0
+  i32.const 0
+  call $std/math/test_log1p
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
    i32.const 1900
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 0
-  f64.const 0
-  f64.const 0
-  i32.const 0
-  call $std/math/test_log1p
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 1903
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
   f64.const -0
   f64.const -0
   f64.const 0
@@ -32984,7 +33280,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1904
+   i32.const 1901
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -32998,7 +33294,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1905
+   i32.const 1902
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -33012,7 +33308,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1906
+   i32.const 1903
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -33027,7 +33323,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1907
+   i32.const 1904
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -33041,7 +33337,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1908
+   i32.const 1905
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -33056,7 +33352,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1909
+   i32.const 1906
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -33070,7 +33366,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1910
+   i32.const 1907
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -33084,7 +33380,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1919
+   i32.const 1916
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -33098,7 +33394,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1920
+   i32.const 1917
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -33112,7 +33408,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1921
+   i32.const 1918
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -33126,7 +33422,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1922
+   i32.const 1919
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -33140,7 +33436,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1923
+   i32.const 1920
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -33154,7 +33450,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1924
+   i32.const 1921
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -33168,7 +33464,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1925
+   i32.const 1922
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -33182,7 +33478,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1926
+   i32.const 1923
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -33196,7 +33492,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1927
+   i32.const 1924
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -33210,25 +33506,25 @@
   if
    i32.const 0
    i32.const 32
+   i32.const 1925
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const 0
+  f32.const 0
+  f32.const 0
+  i32.const 0
+  call $std/math/test_log1pf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
    i32.const 1928
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 0
-  f32.const 0
-  f32.const 0
-  i32.const 0
-  call $std/math/test_log1pf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 1931
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
   f32.const -0
   f32.const -0
   f32.const 0
@@ -33238,7 +33534,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1932
+   i32.const 1929
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -33252,7 +33548,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1933
+   i32.const 1930
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -33266,7 +33562,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1934
+   i32.const 1931
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -33281,7 +33577,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1935
+   i32.const 1932
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -33295,7 +33591,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1936
+   i32.const 1933
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -33310,7 +33606,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1937
+   i32.const 1934
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -33324,7 +33620,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1938
+   i32.const 1935
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -33340,7 +33636,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1939
+   i32.const 1936
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -33354,7 +33650,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1951
+   i32.const 1948
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -33368,7 +33664,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1952
+   i32.const 1949
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -33382,7 +33678,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1953
+   i32.const 1950
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -33396,7 +33692,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1954
+   i32.const 1951
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -33410,7 +33706,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1955
+   i32.const 1952
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -33424,7 +33720,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1956
+   i32.const 1953
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -33438,7 +33734,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1957
+   i32.const 1954
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -33452,7 +33748,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1958
+   i32.const 1955
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -33466,7 +33762,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1959
+   i32.const 1956
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -33480,7 +33776,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1960
+   i32.const 1957
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -33495,7 +33791,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1963
+   i32.const 1960
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -33510,7 +33806,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1964
+   i32.const 1961
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -33524,7 +33820,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1965
+   i32.const 1962
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -33538,7 +33834,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1966
+   i32.const 1963
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -33552,7 +33848,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1967
+   i32.const 1964
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -33566,7 +33862,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1968
+   i32.const 1965
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -33581,7 +33877,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1969
+   i32.const 1966
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -33595,7 +33891,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1970
+   i32.const 1967
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -33609,7 +33905,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1979
+   i32.const 1976
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -33623,7 +33919,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1980
+   i32.const 1977
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -33637,7 +33933,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1981
+   i32.const 1978
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -33651,7 +33947,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1982
+   i32.const 1979
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -33665,7 +33961,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1983
+   i32.const 1980
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -33679,7 +33975,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1984
+   i32.const 1981
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -33693,7 +33989,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1985
+   i32.const 1982
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -33707,7 +34003,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1986
+   i32.const 1983
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -33721,7 +34017,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1987
+   i32.const 1984
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -33735,7 +34031,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1988
+   i32.const 1985
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -33750,7 +34046,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1991
+   i32.const 1988
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -33765,7 +34061,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1992
+   i32.const 1989
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -33779,7 +34075,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1993
+   i32.const 1990
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -33793,7 +34089,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1994
+   i32.const 1991
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -33807,7 +34103,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1995
+   i32.const 1992
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -33821,7 +34117,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1996
+   i32.const 1993
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -33836,7 +34132,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1997
+   i32.const 1994
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -33850,7 +34146,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1998
+   i32.const 1995
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -33865,7 +34161,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2010
+   i32.const 2007
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -33880,7 +34176,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2011
+   i32.const 2008
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -33895,7 +34191,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2012
+   i32.const 2009
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -33910,7 +34206,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2013
+   i32.const 2010
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -33925,7 +34221,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2014
+   i32.const 2011
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -33940,7 +34236,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2015
+   i32.const 2012
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -33955,7 +34251,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2016
+   i32.const 2013
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -33970,7 +34266,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2017
+   i32.const 2014
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -33985,7 +34281,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2018
+   i32.const 2015
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -34000,12 +34296,57 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2019
+   i32.const 2016
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f64.const 0
+  f64.const 1
+  f64.const 1
+  f64.const 0
+  i32.const 0
+  call $std/math/test_max
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 2019
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const -0
+  f64.const 1
+  f64.const 1
+  f64.const 0
+  i32.const 0
+  call $std/math/test_max
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 2020
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const 0.5
+  f64.const 1
+  f64.const 1
+  f64.const 0
+  i32.const 0
+  call $std/math/test_max
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 2021
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const -0.5
   f64.const 1
   f64.const 1
   f64.const 0
@@ -34020,7 +34361,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -0
+  f64.const 1
   f64.const 1
   f64.const 1
   f64.const 0
@@ -34035,7 +34376,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 0.5
+  f64.const -1
   f64.const 1
   f64.const 1
   f64.const 0
@@ -34050,9 +34391,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -0.5
+  f64.const inf
   f64.const 1
-  f64.const 1
+  f64.const inf
   f64.const 0
   i32.const 0
   call $std/math/test_max
@@ -34065,7 +34406,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 1
+  f64.const inf
+  f64.neg
   f64.const 1
   f64.const 1
   f64.const 0
@@ -34080,9 +34422,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -1
+  f64.const nan:0x8000000000000
   f64.const 1
-  f64.const 1
+  f64.const nan:0x8000000000000
   f64.const 0
   i32.const 0
   call $std/math/test_max
@@ -34095,9 +34437,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const inf
-  f64.const 1
-  f64.const inf
+  f64.const 0
+  f64.const -1
+  f64.const 0
   f64.const 0
   i32.const 0
   call $std/math/test_max
@@ -34110,10 +34452,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const inf
-  f64.neg
-  f64.const 1
-  f64.const 1
+  f64.const -0
+  f64.const -1
+  f64.const -0
   f64.const 0
   i32.const 0
   call $std/math/test_max
@@ -34126,9 +34467,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const nan:0x8000000000000
-  f64.const 1
-  f64.const nan:0x8000000000000
+  f64.const 0.5
+  f64.const -1
+  f64.const 0.5
   f64.const 0
   i32.const 0
   call $std/math/test_max
@@ -34141,9 +34482,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 0
+  f64.const -0.5
   f64.const -1
-  f64.const 0
+  f64.const -0.5
   f64.const 0
   i32.const 0
   call $std/math/test_max
@@ -34156,9 +34497,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -0
+  f64.const 1
   f64.const -1
-  f64.const -0
+  f64.const 1
   f64.const 0
   i32.const 0
   call $std/math/test_max
@@ -34171,9 +34512,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 0.5
   f64.const -1
-  f64.const 0.5
+  f64.const -1
+  f64.const -1
   f64.const 0
   i32.const 0
   call $std/math/test_max
@@ -34186,9 +34527,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -0.5
+  f64.const inf
   f64.const -1
-  f64.const -0.5
+  f64.const inf
   f64.const 0
   i32.const 0
   call $std/math/test_max
@@ -34197,51 +34538,6 @@
    i32.const 0
    i32.const 32
    i32.const 2034
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const 1
-  f64.const -1
-  f64.const 1
-  f64.const 0
-  i32.const 0
-  call $std/math/test_max
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 2035
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const -1
-  f64.const -1
-  f64.const -1
-  f64.const 0
-  i32.const 0
-  call $std/math/test_max
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 2036
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const inf
-  f64.const -1
-  f64.const inf
-  f64.const 0
-  i32.const 0
-  call $std/math/test_max
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 2037
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -34257,7 +34553,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2038
+   i32.const 2035
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -34265,6 +34561,51 @@
   f64.const nan:0x8000000000000
   f64.const -1
   f64.const nan:0x8000000000000
+  f64.const 0
+  i32.const 0
+  call $std/math/test_max
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 2036
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const 0
+  f64.const 0
+  f64.const 0
+  f64.const 0
+  i32.const 0
+  call $std/math/test_max
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 2037
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const 0
+  f64.const -0
+  f64.const 0
+  f64.const 0
+  i32.const 0
+  call $std/math/test_max
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 2038
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const 0
+  f64.const inf
+  f64.const inf
   f64.const 0
   i32.const 0
   call $std/math/test_max
@@ -34278,7 +34619,8 @@
    unreachable
   end
   f64.const 0
-  f64.const 0
+  f64.const inf
+  f64.neg
   f64.const 0
   f64.const 0
   i32.const 0
@@ -34293,8 +34635,8 @@
    unreachable
   end
   f64.const 0
-  f64.const -0
-  f64.const 0
+  f64.const nan:0x8000000000000
+  f64.const nan:0x8000000000000
   f64.const 0
   i32.const 0
   call $std/math/test_max
@@ -34307,9 +34649,9 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f64.const -0
   f64.const 0
-  f64.const inf
-  f64.const inf
+  f64.const 0
   f64.const 0
   i32.const 0
   call $std/math/test_max
@@ -34322,10 +34664,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 0
-  f64.const inf
-  f64.neg
-  f64.const 0
+  f64.const -0
+  f64.const -0
+  f64.const -0
   f64.const 0
   i32.const 0
   call $std/math/test_max
@@ -34338,9 +34679,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 0
-  f64.const nan:0x8000000000000
-  f64.const nan:0x8000000000000
+  f64.const -0
+  f64.const inf
+  f64.const inf
   f64.const 0
   i32.const 0
   call $std/math/test_max
@@ -34354,8 +34695,9 @@
    unreachable
   end
   f64.const -0
-  f64.const 0
-  f64.const 0
+  f64.const inf
+  f64.neg
+  f64.const -0
   f64.const 0
   i32.const 0
   call $std/math/test_max
@@ -34369,8 +34711,8 @@
    unreachable
   end
   f64.const -0
-  f64.const -0
-  f64.const -0
+  f64.const nan:0x8000000000000
+  f64.const nan:0x8000000000000
   f64.const 0
   i32.const 0
   call $std/math/test_max
@@ -34383,9 +34725,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -0
-  f64.const inf
-  f64.const inf
+  f64.const 1
+  f64.const 0
+  f64.const 1
   f64.const 0
   i32.const 0
   call $std/math/test_max
@@ -34394,52 +34736,6 @@
    i32.const 0
    i32.const 32
    i32.const 2047
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const -0
-  f64.const inf
-  f64.neg
-  f64.const -0
-  f64.const 0
-  i32.const 0
-  call $std/math/test_max
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 2048
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const -0
-  f64.const nan:0x8000000000000
-  f64.const nan:0x8000000000000
-  f64.const 0
-  i32.const 0
-  call $std/math/test_max
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 2049
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const 1
-  f64.const 0
-  f64.const 1
-  f64.const 0
-  i32.const 0
-  call $std/math/test_max
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 2050
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -34454,7 +34750,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2051
+   i32.const 2048
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -34462,6 +34758,52 @@
   f64.const inf
   f64.const 0
   f64.const inf
+  f64.const 0
+  i32.const 0
+  call $std/math/test_max
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 2049
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const inf
+  f64.neg
+  f64.const 0
+  f64.const 0
+  f64.const 0
+  i32.const 0
+  call $std/math/test_max
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 2050
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const nan:0x8000000000000
+  f64.const 0
+  f64.const nan:0x8000000000000
+  f64.const 0
+  i32.const 0
+  call $std/math/test_max
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 2051
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const -1
+  f64.const -0
+  f64.const -0
   f64.const 0
   i32.const 0
   call $std/math/test_max
@@ -34475,9 +34817,8 @@
    unreachable
   end
   f64.const inf
-  f64.neg
-  f64.const 0
-  f64.const 0
+  f64.const -0
+  f64.const inf
   f64.const 0
   i32.const 0
   call $std/math/test_max
@@ -34490,9 +34831,10 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const nan:0x8000000000000
-  f64.const 0
-  f64.const nan:0x8000000000000
+  f64.const inf
+  f64.neg
+  f64.const -0
+  f64.const -0
   f64.const 0
   i32.const 0
   call $std/math/test_max
@@ -34505,9 +34847,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -1
+  f64.const nan:0x8000000000000
   f64.const -0
-  f64.const -0
+  f64.const nan:0x8000000000000
   f64.const 0
   i32.const 0
   call $std/math/test_max
@@ -34521,7 +34863,7 @@
    unreachable
   end
   f64.const inf
-  f64.const -0
+  f64.const 2
   f64.const inf
   f64.const 0
   i32.const 0
@@ -34536,9 +34878,8 @@
    unreachable
   end
   f64.const inf
-  f64.neg
-  f64.const -0
-  f64.const -0
+  f64.const -0.5
+  f64.const inf
   f64.const 0
   i32.const 0
   call $std/math/test_max
@@ -34551,8 +34892,8 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f64.const inf
   f64.const nan:0x8000000000000
-  f64.const -0
   f64.const nan:0x8000000000000
   f64.const 0
   i32.const 0
@@ -34567,8 +34908,9 @@
    unreachable
   end
   f64.const inf
+  f64.neg
   f64.const 2
-  f64.const inf
+  f64.const 2
   f64.const 0
   i32.const 0
   call $std/math/test_max
@@ -34582,8 +34924,9 @@
    unreachable
   end
   f64.const inf
+  f64.neg
   f64.const -0.5
-  f64.const inf
+  f64.const -0.5
   f64.const 0
   i32.const 0
   call $std/math/test_max
@@ -34597,6 +34940,7 @@
    unreachable
   end
   f64.const inf
+  f64.neg
   f64.const nan:0x8000000000000
   f64.const nan:0x8000000000000
   f64.const 0
@@ -34611,10 +34955,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const inf
-  f64.neg
-  f64.const 2
-  f64.const 2
+  f64.const nan:0x8000000000000
+  f64.const nan:0x8000000000000
+  f64.const nan:0x8000000000000
   f64.const 0
   i32.const 0
   call $std/math/test_max
@@ -34627,10 +34970,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const inf
-  f64.neg
-  f64.const -0.5
-  f64.const -0.5
+  f64.const 1
+  f64.const nan:0x8000000000000
+  f64.const nan:0x8000000000000
   f64.const 0
   i32.const 0
   call $std/math/test_max
@@ -34643,8 +34985,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const inf
-  f64.neg
+  f64.const -1
   f64.const nan:0x8000000000000
   f64.const nan:0x8000000000000
   f64.const 0
@@ -34659,9 +35000,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const nan:0x8000000000000
-  f64.const nan:0x8000000000000
-  f64.const nan:0x8000000000000
+  f64.const 1
+  f64.const inf
+  f64.const inf
   f64.const 0
   i32.const 0
   call $std/math/test_max
@@ -34674,9 +35015,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 1
-  f64.const nan:0x8000000000000
-  f64.const nan:0x8000000000000
+  f64.const -1
+  f64.const inf
+  f64.const inf
   f64.const 0
   i32.const 0
   call $std/math/test_max
@@ -34689,9 +35030,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -1
-  f64.const nan:0x8000000000000
-  f64.const nan:0x8000000000000
+  f64.const inf
+  f64.const inf
+  f64.const inf
   f64.const 0
   i32.const 0
   call $std/math/test_max
@@ -34704,7 +35045,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 1
+  f64.const inf
+  f64.neg
   f64.const inf
   f64.const inf
   f64.const 0
@@ -34719,9 +35061,10 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -1
+  f64.const 1
   f64.const inf
-  f64.const inf
+  f64.neg
+  f64.const 1
   f64.const 0
   i32.const 0
   call $std/math/test_max
@@ -34734,9 +35077,10 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f64.const -1
   f64.const inf
-  f64.const inf
-  f64.const inf
+  f64.neg
+  f64.const -1
   f64.const 0
   i32.const 0
   call $std/math/test_max
@@ -34750,8 +35094,8 @@
    unreachable
   end
   f64.const inf
-  f64.neg
   f64.const inf
+  f64.neg
   f64.const inf
   f64.const 0
   i32.const 0
@@ -34765,10 +35109,12 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 1
   f64.const inf
   f64.neg
-  f64.const 1
+  f64.const inf
+  f64.neg
+  f64.const inf
+  f64.neg
   f64.const 0
   i32.const 0
   call $std/math/test_max
@@ -34781,10 +35127,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -1
-  f64.const inf
-  f64.neg
-  f64.const -1
+  f64.const 1.75
+  f64.const 0.5
+  f64.const 1.75
   f64.const 0
   i32.const 0
   call $std/math/test_max
@@ -34797,10 +35142,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const inf
-  f64.const inf
-  f64.neg
-  f64.const inf
+  f64.const -1.75
+  f64.const 0.5
+  f64.const 0.5
   f64.const 0
   i32.const 0
   call $std/math/test_max
@@ -34813,12 +35157,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const inf
-  f64.neg
-  f64.const inf
-  f64.neg
-  f64.const inf
-  f64.neg
+  f64.const 1.75
+  f64.const -0.5
+  f64.const 1.75
   f64.const 0
   i32.const 0
   call $std/math/test_max
@@ -34831,9 +35172,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 1.75
-  f64.const 0.5
-  f64.const 1.75
+  f64.const -1.75
+  f64.const -0.5
+  f64.const -0.5
   f64.const 0
   i32.const 0
   call $std/math/test_max
@@ -34842,51 +35183,6 @@
    i32.const 0
    i32.const 32
    i32.const 2076
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const -1.75
-  f64.const 0.5
-  f64.const 0.5
-  f64.const 0
-  i32.const 0
-  call $std/math/test_max
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 2077
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const 1.75
-  f64.const -0.5
-  f64.const 1.75
-  f64.const 0
-  i32.const 0
-  call $std/math/test_max
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 2078
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const -1.75
-  f64.const -0.5
-  f64.const -0.5
-  f64.const 0
-  i32.const 0
-  call $std/math/test_max
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 2079
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -34901,7 +35197,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2088
+   i32.const 2085
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -34916,7 +35212,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2089
+   i32.const 2086
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -34931,7 +35227,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2090
+   i32.const 2087
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -34946,7 +35242,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2091
+   i32.const 2088
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -34961,7 +35257,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2092
+   i32.const 2089
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -34976,7 +35272,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2093
+   i32.const 2090
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -34991,7 +35287,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2094
+   i32.const 2091
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -35006,7 +35302,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2095
+   i32.const 2092
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -35021,7 +35317,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2096
+   i32.const 2093
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -35036,12 +35332,57 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2097
+   i32.const 2094
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f32.const 0
+  f32.const 1
+  f32.const 1
+  f32.const 0
+  i32.const 0
+  call $std/math/test_maxf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 2097
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const -0
+  f32.const 1
+  f32.const 1
+  f32.const 0
+  i32.const 0
+  call $std/math/test_maxf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 2098
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const 0.5
+  f32.const 1
+  f32.const 1
+  f32.const 0
+  i32.const 0
+  call $std/math/test_maxf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 2099
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const -0.5
   f32.const 1
   f32.const 1
   f32.const 0
@@ -35056,7 +35397,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -0
+  f32.const 1
   f32.const 1
   f32.const 1
   f32.const 0
@@ -35071,7 +35412,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 0.5
+  f32.const -1
   f32.const 1
   f32.const 1
   f32.const 0
@@ -35086,9 +35427,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -0.5
+  f32.const inf
   f32.const 1
-  f32.const 1
+  f32.const inf
   f32.const 0
   i32.const 0
   call $std/math/test_maxf
@@ -35101,7 +35442,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 1
+  f32.const inf
+  f32.neg
   f32.const 1
   f32.const 1
   f32.const 0
@@ -35116,9 +35458,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -1
+  f32.const nan:0x400000
   f32.const 1
-  f32.const 1
+  f32.const nan:0x400000
   f32.const 0
   i32.const 0
   call $std/math/test_maxf
@@ -35131,9 +35473,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const inf
-  f32.const 1
-  f32.const inf
+  f32.const 0
+  f32.const -1
+  f32.const 0
   f32.const 0
   i32.const 0
   call $std/math/test_maxf
@@ -35146,10 +35488,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const inf
-  f32.neg
-  f32.const 1
-  f32.const 1
+  f32.const -0
+  f32.const -1
+  f32.const -0
   f32.const 0
   i32.const 0
   call $std/math/test_maxf
@@ -35162,9 +35503,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const nan:0x400000
-  f32.const 1
-  f32.const nan:0x400000
+  f32.const 0.5
+  f32.const -1
+  f32.const 0.5
   f32.const 0
   i32.const 0
   call $std/math/test_maxf
@@ -35177,9 +35518,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 0
+  f32.const -0.5
   f32.const -1
-  f32.const 0
+  f32.const -0.5
   f32.const 0
   i32.const 0
   call $std/math/test_maxf
@@ -35192,9 +35533,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -0
+  f32.const 1
   f32.const -1
-  f32.const -0
+  f32.const 1
   f32.const 0
   i32.const 0
   call $std/math/test_maxf
@@ -35207,9 +35548,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 0.5
   f32.const -1
-  f32.const 0.5
+  f32.const -1
+  f32.const -1
   f32.const 0
   i32.const 0
   call $std/math/test_maxf
@@ -35222,9 +35563,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -0.5
+  f32.const inf
   f32.const -1
-  f32.const -0.5
+  f32.const inf
   f32.const 0
   i32.const 0
   call $std/math/test_maxf
@@ -35233,51 +35574,6 @@
    i32.const 0
    i32.const 32
    i32.const 2112
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const 1
-  f32.const -1
-  f32.const 1
-  f32.const 0
-  i32.const 0
-  call $std/math/test_maxf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 2113
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const -1
-  f32.const -1
-  f32.const -1
-  f32.const 0
-  i32.const 0
-  call $std/math/test_maxf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 2114
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const inf
-  f32.const -1
-  f32.const inf
-  f32.const 0
-  i32.const 0
-  call $std/math/test_maxf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 2115
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -35293,7 +35589,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2116
+   i32.const 2113
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -35301,6 +35597,51 @@
   f32.const nan:0x400000
   f32.const -1
   f32.const nan:0x400000
+  f32.const 0
+  i32.const 0
+  call $std/math/test_maxf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 2114
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const 0
+  f32.const 0
+  f32.const 0
+  f32.const 0
+  i32.const 0
+  call $std/math/test_maxf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 2115
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const 0
+  f32.const -0
+  f32.const 0
+  f32.const 0
+  i32.const 0
+  call $std/math/test_maxf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 2116
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const 0
+  f32.const inf
+  f32.const inf
   f32.const 0
   i32.const 0
   call $std/math/test_maxf
@@ -35314,7 +35655,8 @@
    unreachable
   end
   f32.const 0
-  f32.const 0
+  f32.const inf
+  f32.neg
   f32.const 0
   f32.const 0
   i32.const 0
@@ -35329,8 +35671,8 @@
    unreachable
   end
   f32.const 0
-  f32.const -0
-  f32.const 0
+  f32.const nan:0x400000
+  f32.const nan:0x400000
   f32.const 0
   i32.const 0
   call $std/math/test_maxf
@@ -35343,9 +35685,9 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f32.const -0
   f32.const 0
-  f32.const inf
-  f32.const inf
+  f32.const 0
   f32.const 0
   i32.const 0
   call $std/math/test_maxf
@@ -35358,10 +35700,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 0
-  f32.const inf
-  f32.neg
-  f32.const 0
+  f32.const -0
+  f32.const -0
+  f32.const -0
   f32.const 0
   i32.const 0
   call $std/math/test_maxf
@@ -35374,9 +35715,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 0
-  f32.const nan:0x400000
-  f32.const nan:0x400000
+  f32.const -0
+  f32.const inf
+  f32.const inf
   f32.const 0
   i32.const 0
   call $std/math/test_maxf
@@ -35390,8 +35731,9 @@
    unreachable
   end
   f32.const -0
-  f32.const 0
-  f32.const 0
+  f32.const inf
+  f32.neg
+  f32.const -0
   f32.const 0
   i32.const 0
   call $std/math/test_maxf
@@ -35405,8 +35747,8 @@
    unreachable
   end
   f32.const -0
-  f32.const -0
-  f32.const -0
+  f32.const nan:0x400000
+  f32.const nan:0x400000
   f32.const 0
   i32.const 0
   call $std/math/test_maxf
@@ -35419,9 +35761,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -0
-  f32.const inf
-  f32.const inf
+  f32.const 1
+  f32.const 0
+  f32.const 1
   f32.const 0
   i32.const 0
   call $std/math/test_maxf
@@ -35430,52 +35772,6 @@
    i32.const 0
    i32.const 32
    i32.const 2125
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const -0
-  f32.const inf
-  f32.neg
-  f32.const -0
-  f32.const 0
-  i32.const 0
-  call $std/math/test_maxf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 2126
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const -0
-  f32.const nan:0x400000
-  f32.const nan:0x400000
-  f32.const 0
-  i32.const 0
-  call $std/math/test_maxf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 2127
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const 1
-  f32.const 0
-  f32.const 1
-  f32.const 0
-  i32.const 0
-  call $std/math/test_maxf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 2128
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -35490,7 +35786,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2129
+   i32.const 2126
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -35498,6 +35794,52 @@
   f32.const inf
   f32.const 0
   f32.const inf
+  f32.const 0
+  i32.const 0
+  call $std/math/test_maxf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 2127
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const inf
+  f32.neg
+  f32.const 0
+  f32.const 0
+  f32.const 0
+  i32.const 0
+  call $std/math/test_maxf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 2128
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const nan:0x400000
+  f32.const 0
+  f32.const nan:0x400000
+  f32.const 0
+  i32.const 0
+  call $std/math/test_maxf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 2129
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const -1
+  f32.const -0
+  f32.const -0
   f32.const 0
   i32.const 0
   call $std/math/test_maxf
@@ -35511,9 +35853,8 @@
    unreachable
   end
   f32.const inf
-  f32.neg
-  f32.const 0
-  f32.const 0
+  f32.const -0
+  f32.const inf
   f32.const 0
   i32.const 0
   call $std/math/test_maxf
@@ -35526,9 +35867,10 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const nan:0x400000
-  f32.const 0
-  f32.const nan:0x400000
+  f32.const inf
+  f32.neg
+  f32.const -0
+  f32.const -0
   f32.const 0
   i32.const 0
   call $std/math/test_maxf
@@ -35541,9 +35883,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -1
+  f32.const nan:0x400000
   f32.const -0
-  f32.const -0
+  f32.const nan:0x400000
   f32.const 0
   i32.const 0
   call $std/math/test_maxf
@@ -35557,7 +35899,7 @@
    unreachable
   end
   f32.const inf
-  f32.const -0
+  f32.const 2
   f32.const inf
   f32.const 0
   i32.const 0
@@ -35572,9 +35914,8 @@
    unreachable
   end
   f32.const inf
-  f32.neg
-  f32.const -0
-  f32.const -0
+  f32.const -0.5
+  f32.const inf
   f32.const 0
   i32.const 0
   call $std/math/test_maxf
@@ -35587,8 +35928,8 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f32.const inf
   f32.const nan:0x400000
-  f32.const -0
   f32.const nan:0x400000
   f32.const 0
   i32.const 0
@@ -35603,8 +35944,9 @@
    unreachable
   end
   f32.const inf
+  f32.neg
   f32.const 2
-  f32.const inf
+  f32.const 2
   f32.const 0
   i32.const 0
   call $std/math/test_maxf
@@ -35618,8 +35960,9 @@
    unreachable
   end
   f32.const inf
+  f32.neg
   f32.const -0.5
-  f32.const inf
+  f32.const -0.5
   f32.const 0
   i32.const 0
   call $std/math/test_maxf
@@ -35633,6 +35976,7 @@
    unreachable
   end
   f32.const inf
+  f32.neg
   f32.const nan:0x400000
   f32.const nan:0x400000
   f32.const 0
@@ -35647,10 +35991,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const inf
-  f32.neg
-  f32.const 2
-  f32.const 2
+  f32.const nan:0x400000
+  f32.const nan:0x400000
+  f32.const nan:0x400000
   f32.const 0
   i32.const 0
   call $std/math/test_maxf
@@ -35663,10 +36006,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const inf
-  f32.neg
-  f32.const -0.5
-  f32.const -0.5
+  f32.const 1
+  f32.const nan:0x400000
+  f32.const nan:0x400000
   f32.const 0
   i32.const 0
   call $std/math/test_maxf
@@ -35679,8 +36021,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const inf
-  f32.neg
+  f32.const -1
   f32.const nan:0x400000
   f32.const nan:0x400000
   f32.const 0
@@ -35695,9 +36036,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const nan:0x400000
-  f32.const nan:0x400000
-  f32.const nan:0x400000
+  f32.const 1
+  f32.const inf
+  f32.const inf
   f32.const 0
   i32.const 0
   call $std/math/test_maxf
@@ -35710,9 +36051,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 1
-  f32.const nan:0x400000
-  f32.const nan:0x400000
+  f32.const -1
+  f32.const inf
+  f32.const inf
   f32.const 0
   i32.const 0
   call $std/math/test_maxf
@@ -35725,9 +36066,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -1
-  f32.const nan:0x400000
-  f32.const nan:0x400000
+  f32.const inf
+  f32.const inf
+  f32.const inf
   f32.const 0
   i32.const 0
   call $std/math/test_maxf
@@ -35740,7 +36081,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 1
+  f32.const inf
+  f32.neg
   f32.const inf
   f32.const inf
   f32.const 0
@@ -35755,9 +36097,10 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -1
+  f32.const 1
   f32.const inf
-  f32.const inf
+  f32.neg
+  f32.const 1
   f32.const 0
   i32.const 0
   call $std/math/test_maxf
@@ -35770,9 +36113,10 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f32.const -1
   f32.const inf
-  f32.const inf
-  f32.const inf
+  f32.neg
+  f32.const -1
   f32.const 0
   i32.const 0
   call $std/math/test_maxf
@@ -35786,8 +36130,8 @@
    unreachable
   end
   f32.const inf
-  f32.neg
   f32.const inf
+  f32.neg
   f32.const inf
   f32.const 0
   i32.const 0
@@ -35801,10 +36145,12 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 1
   f32.const inf
   f32.neg
-  f32.const 1
+  f32.const inf
+  f32.neg
+  f32.const inf
+  f32.neg
   f32.const 0
   i32.const 0
   call $std/math/test_maxf
@@ -35817,10 +36163,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -1
-  f32.const inf
-  f32.neg
-  f32.const -1
+  f32.const 1.75
+  f32.const 0.5
+  f32.const 1.75
   f32.const 0
   i32.const 0
   call $std/math/test_maxf
@@ -35833,10 +36178,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const inf
-  f32.const inf
-  f32.neg
-  f32.const inf
+  f32.const -1.75
+  f32.const 0.5
+  f32.const 0.5
   f32.const 0
   i32.const 0
   call $std/math/test_maxf
@@ -35849,12 +36193,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const inf
-  f32.neg
-  f32.const inf
-  f32.neg
-  f32.const inf
-  f32.neg
+  f32.const 1.75
+  f32.const -0.5
+  f32.const 1.75
   f32.const 0
   i32.const 0
   call $std/math/test_maxf
@@ -35867,9 +36208,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 1.75
-  f32.const 0.5
-  f32.const 1.75
+  f32.const -1.75
+  f32.const -0.5
+  f32.const -0.5
   f32.const 0
   i32.const 0
   call $std/math/test_maxf
@@ -35878,51 +36219,6 @@
    i32.const 0
    i32.const 32
    i32.const 2154
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const -1.75
-  f32.const 0.5
-  f32.const 0.5
-  f32.const 0
-  i32.const 0
-  call $std/math/test_maxf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 2155
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const 1.75
-  f32.const -0.5
-  f32.const 1.75
-  f32.const 0
-  i32.const 0
-  call $std/math/test_maxf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 2156
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const -1.75
-  f32.const -0.5
-  f32.const -0.5
-  f32.const 0
-  i32.const 0
-  call $std/math/test_maxf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 2157
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -35937,7 +36233,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2169
+   i32.const 2166
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -35952,7 +36248,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2170
+   i32.const 2167
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -35967,7 +36263,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2171
+   i32.const 2168
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -35982,7 +36278,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2172
+   i32.const 2169
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -35997,7 +36293,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2173
+   i32.const 2170
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -36012,7 +36308,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2174
+   i32.const 2171
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -36027,7 +36323,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2175
+   i32.const 2172
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -36042,7 +36338,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2176
+   i32.const 2173
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -36057,7 +36353,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2177
+   i32.const 2174
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -36072,7 +36368,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2178
+   i32.const 2175
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -36080,6 +36376,51 @@
   f64.const 0
   f64.const 1
   f64.const 0
+  f64.const 0
+  i32.const 0
+  call $std/math/test_min
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 2178
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const -0
+  f64.const 1
+  f64.const -0
+  f64.const 0
+  i32.const 0
+  call $std/math/test_min
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 2179
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const 0.5
+  f64.const 1
+  f64.const 0.5
+  f64.const 0
+  i32.const 0
+  call $std/math/test_min
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 2180
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const -0.5
+  f64.const 1
+  f64.const -0.5
   f64.const 0
   i32.const 0
   call $std/math/test_min
@@ -36092,9 +36433,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -0
   f64.const 1
-  f64.const -0
+  f64.const 1
+  f64.const 1
   f64.const 0
   i32.const 0
   call $std/math/test_min
@@ -36107,9 +36448,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 0.5
+  f64.const -1
   f64.const 1
-  f64.const 0.5
+  f64.const -1
   f64.const 0
   i32.const 0
   call $std/math/test_min
@@ -36122,9 +36463,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -0.5
+  f64.const inf
   f64.const 1
-  f64.const -0.5
+  f64.const 1
   f64.const 0
   i32.const 0
   call $std/math/test_min
@@ -36137,9 +36478,11 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f64.const inf
+  f64.neg
   f64.const 1
-  f64.const 1
-  f64.const 1
+  f64.const inf
+  f64.neg
   f64.const 0
   i32.const 0
   call $std/math/test_min
@@ -36152,9 +36495,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -1
+  f64.const nan:0x8000000000000
   f64.const 1
-  f64.const -1
+  f64.const nan:0x8000000000000
   f64.const 0
   i32.const 0
   call $std/math/test_min
@@ -36167,9 +36510,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const inf
-  f64.const 1
-  f64.const 1
+  f64.const 0
+  f64.const -1
+  f64.const -1
   f64.const 0
   i32.const 0
   call $std/math/test_min
@@ -36182,11 +36525,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const inf
-  f64.neg
-  f64.const 1
-  f64.const inf
-  f64.neg
+  f64.const -0
+  f64.const -1
+  f64.const -1
   f64.const 0
   i32.const 0
   call $std/math/test_min
@@ -36199,9 +36540,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const nan:0x8000000000000
-  f64.const 1
-  f64.const nan:0x8000000000000
+  f64.const 0.5
+  f64.const -1
+  f64.const -1
   f64.const 0
   i32.const 0
   call $std/math/test_min
@@ -36214,7 +36555,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 0
+  f64.const -0.5
   f64.const -1
   f64.const -1
   f64.const 0
@@ -36229,7 +36570,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -0
+  f64.const 1
   f64.const -1
   f64.const -1
   f64.const 0
@@ -36244,7 +36585,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 0.5
+  f64.const -1
   f64.const -1
   f64.const -1
   f64.const 0
@@ -36259,7 +36600,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -0.5
+  f64.const inf
   f64.const -1
   f64.const -1
   f64.const 0
@@ -36274,9 +36615,11 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 1
+  f64.const inf
+  f64.neg
   f64.const -1
-  f64.const -1
+  f64.const inf
+  f64.neg
   f64.const 0
   i32.const 0
   call $std/math/test_min
@@ -36289,9 +36632,9 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f64.const nan:0x8000000000000
   f64.const -1
-  f64.const -1
-  f64.const -1
+  f64.const nan:0x8000000000000
   f64.const 0
   i32.const 0
   call $std/math/test_min
@@ -36304,9 +36647,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const inf
-  f64.const -1
-  f64.const -1
+  f64.const 0
+  f64.const 0
+  f64.const 0
   f64.const 0
   i32.const 0
   call $std/math/test_min
@@ -36319,11 +36662,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const inf
-  f64.neg
-  f64.const -1
-  f64.const inf
-  f64.neg
+  f64.const 0
+  f64.const -0
+  f64.const -0
   f64.const 0
   i32.const 0
   call $std/math/test_min
@@ -36336,9 +36677,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const nan:0x8000000000000
-  f64.const -1
-  f64.const nan:0x8000000000000
+  f64.const 0
+  f64.const inf
+  f64.const 0
   f64.const 0
   i32.const 0
   call $std/math/test_min
@@ -36352,8 +36693,10 @@
    unreachable
   end
   f64.const 0
-  f64.const 0
-  f64.const 0
+  f64.const inf
+  f64.neg
+  f64.const inf
+  f64.neg
   f64.const 0
   i32.const 0
   call $std/math/test_min
@@ -36367,8 +36710,8 @@
    unreachable
   end
   f64.const 0
-  f64.const -0
-  f64.const -0
+  f64.const nan:0x8000000000000
+  f64.const nan:0x8000000000000
   f64.const 0
   i32.const 0
   call $std/math/test_min
@@ -36381,9 +36724,9 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f64.const -0
   f64.const 0
-  f64.const inf
-  f64.const 0
+  f64.const -0
   f64.const 0
   i32.const 0
   call $std/math/test_min
@@ -36396,11 +36739,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 0
-  f64.const inf
-  f64.neg
-  f64.const inf
-  f64.neg
+  f64.const -0
+  f64.const -0
+  f64.const -0
   f64.const 0
   i32.const 0
   call $std/math/test_min
@@ -36413,9 +36754,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 0
-  f64.const nan:0x8000000000000
-  f64.const nan:0x8000000000000
+  f64.const -0
+  f64.const inf
+  f64.const -0
   f64.const 0
   i32.const 0
   call $std/math/test_min
@@ -36429,8 +36770,10 @@
    unreachable
   end
   f64.const -0
-  f64.const 0
-  f64.const -0
+  f64.const inf
+  f64.neg
+  f64.const inf
+  f64.neg
   f64.const 0
   i32.const 0
   call $std/math/test_min
@@ -36444,8 +36787,8 @@
    unreachable
   end
   f64.const -0
-  f64.const -0
-  f64.const -0
+  f64.const nan:0x8000000000000
+  f64.const nan:0x8000000000000
   f64.const 0
   i32.const 0
   call $std/math/test_min
@@ -36454,53 +36797,6 @@
    i32.const 0
    i32.const 32
    i32.const 2205
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const -0
-  f64.const inf
-  f64.const -0
-  f64.const 0
-  i32.const 0
-  call $std/math/test_min
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 2206
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const -0
-  f64.const inf
-  f64.neg
-  f64.const inf
-  f64.neg
-  f64.const 0
-  i32.const 0
-  call $std/math/test_min
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 2207
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const -0
-  f64.const nan:0x8000000000000
-  f64.const nan:0x8000000000000
-  f64.const 0
-  i32.const 0
-  call $std/math/test_min
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 2208
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -36515,7 +36811,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2209
+   i32.const 2206
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -36530,7 +36826,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2210
+   i32.const 2207
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -36538,6 +36834,53 @@
   f64.const inf
   f64.const 0
   f64.const 0
+  f64.const 0
+  i32.const 0
+  call $std/math/test_min
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 2208
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const inf
+  f64.neg
+  f64.const 0
+  f64.const inf
+  f64.neg
+  f64.const 0
+  i32.const 0
+  call $std/math/test_min
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 2209
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const nan:0x8000000000000
+  f64.const 0
+  f64.const nan:0x8000000000000
+  f64.const 0
+  i32.const 0
+  call $std/math/test_min
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 2210
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const -1
+  f64.const -0
+  f64.const -1
   f64.const 0
   i32.const 0
   call $std/math/test_min
@@ -36551,10 +36894,8 @@
    unreachable
   end
   f64.const inf
-  f64.neg
-  f64.const 0
-  f64.const inf
-  f64.neg
+  f64.const -0
+  f64.const -0
   f64.const 0
   i32.const 0
   call $std/math/test_min
@@ -36567,9 +36908,11 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const nan:0x8000000000000
-  f64.const 0
-  f64.const nan:0x8000000000000
+  f64.const inf
+  f64.neg
+  f64.const -0
+  f64.const inf
+  f64.neg
   f64.const 0
   i32.const 0
   call $std/math/test_min
@@ -36582,9 +36925,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -1
+  f64.const nan:0x8000000000000
   f64.const -0
-  f64.const -1
+  f64.const nan:0x8000000000000
   f64.const 0
   i32.const 0
   call $std/math/test_min
@@ -36598,8 +36941,8 @@
    unreachable
   end
   f64.const inf
-  f64.const -0
-  f64.const -0
+  f64.const 2
+  f64.const 2
   f64.const 0
   i32.const 0
   call $std/math/test_min
@@ -36613,10 +36956,8 @@
    unreachable
   end
   f64.const inf
-  f64.neg
-  f64.const -0
-  f64.const inf
-  f64.neg
+  f64.const -0.5
+  f64.const -0.5
   f64.const 0
   i32.const 0
   call $std/math/test_min
@@ -36629,8 +36970,8 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f64.const inf
   f64.const nan:0x8000000000000
-  f64.const -0
   f64.const nan:0x8000000000000
   f64.const 0
   i32.const 0
@@ -36645,8 +36986,10 @@
    unreachable
   end
   f64.const inf
+  f64.neg
   f64.const 2
-  f64.const 2
+  f64.const inf
+  f64.neg
   f64.const 0
   i32.const 0
   call $std/math/test_min
@@ -36660,8 +37003,10 @@
    unreachable
   end
   f64.const inf
+  f64.neg
   f64.const -0.5
-  f64.const -0.5
+  f64.const inf
+  f64.neg
   f64.const 0
   i32.const 0
   call $std/math/test_min
@@ -36675,6 +37020,7 @@
    unreachable
   end
   f64.const inf
+  f64.neg
   f64.const nan:0x8000000000000
   f64.const nan:0x8000000000000
   f64.const 0
@@ -36689,11 +37035,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const inf
-  f64.neg
-  f64.const 2
-  f64.const inf
-  f64.neg
+  f64.const nan:0x8000000000000
+  f64.const nan:0x8000000000000
+  f64.const nan:0x8000000000000
   f64.const 0
   i32.const 0
   call $std/math/test_min
@@ -36706,11 +37050,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const inf
-  f64.neg
-  f64.const -0.5
-  f64.const inf
-  f64.neg
+  f64.const 1
+  f64.const nan:0x8000000000000
+  f64.const nan:0x8000000000000
   f64.const 0
   i32.const 0
   call $std/math/test_min
@@ -36723,8 +37065,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const inf
-  f64.neg
+  f64.const -1
   f64.const nan:0x8000000000000
   f64.const nan:0x8000000000000
   f64.const 0
@@ -36739,9 +37080,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const nan:0x8000000000000
-  f64.const nan:0x8000000000000
-  f64.const nan:0x8000000000000
+  f64.const 1
+  f64.const inf
+  f64.const 1
   f64.const 0
   i32.const 0
   call $std/math/test_min
@@ -36754,9 +37095,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 1
-  f64.const nan:0x8000000000000
-  f64.const nan:0x8000000000000
+  f64.const -1
+  f64.const inf
+  f64.const -1
   f64.const 0
   i32.const 0
   call $std/math/test_min
@@ -36769,9 +37110,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -1
-  f64.const nan:0x8000000000000
-  f64.const nan:0x8000000000000
+  f64.const inf
+  f64.const inf
+  f64.const inf
   f64.const 0
   i32.const 0
   call $std/math/test_min
@@ -36784,9 +37125,11 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 1
   f64.const inf
-  f64.const 1
+  f64.neg
+  f64.const inf
+  f64.const inf
+  f64.neg
   f64.const 0
   i32.const 0
   call $std/math/test_min
@@ -36799,9 +37142,11 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -1
+  f64.const 1
   f64.const inf
-  f64.const -1
+  f64.neg
+  f64.const inf
+  f64.neg
   f64.const 0
   i32.const 0
   call $std/math/test_min
@@ -36814,9 +37159,11 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f64.const -1
   f64.const inf
+  f64.neg
   f64.const inf
-  f64.const inf
+  f64.neg
   f64.const 0
   i32.const 0
   call $std/math/test_min
@@ -36830,8 +37177,8 @@
    unreachable
   end
   f64.const inf
-  f64.neg
   f64.const inf
+  f64.neg
   f64.const inf
   f64.neg
   f64.const 0
@@ -36846,7 +37193,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 1
+  f64.const inf
+  f64.neg
   f64.const inf
   f64.neg
   f64.const inf
@@ -36863,11 +37211,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -1
-  f64.const inf
-  f64.neg
-  f64.const inf
-  f64.neg
+  f64.const 1.75
+  f64.const 0.5
+  f64.const 0.5
   f64.const 0
   i32.const 0
   call $std/math/test_min
@@ -36880,11 +37226,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const inf
-  f64.const inf
-  f64.neg
-  f64.const inf
-  f64.neg
+  f64.const -1.75
+  f64.const 0.5
+  f64.const -1.75
   f64.const 0
   i32.const 0
   call $std/math/test_min
@@ -36897,12 +37241,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const inf
-  f64.neg
-  f64.const inf
-  f64.neg
-  f64.const inf
-  f64.neg
+  f64.const 1.75
+  f64.const -0.5
+  f64.const -0.5
   f64.const 0
   i32.const 0
   call $std/math/test_min
@@ -36915,9 +37256,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 1.75
-  f64.const 0.5
-  f64.const 0.5
+  f64.const -1.75
+  f64.const -0.5
+  f64.const -1.75
   f64.const 0
   i32.const 0
   call $std/math/test_min
@@ -36926,51 +37267,6 @@
    i32.const 0
    i32.const 32
    i32.const 2235
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const -1.75
-  f64.const 0.5
-  f64.const -1.75
-  f64.const 0
-  i32.const 0
-  call $std/math/test_min
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 2236
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const 1.75
-  f64.const -0.5
-  f64.const -0.5
-  f64.const 0
-  i32.const 0
-  call $std/math/test_min
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 2237
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const -1.75
-  f64.const -0.5
-  f64.const -1.75
-  f64.const 0
-  i32.const 0
-  call $std/math/test_min
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 2238
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -36985,7 +37281,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2247
+   i32.const 2244
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -37000,7 +37296,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2248
+   i32.const 2245
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -37015,7 +37311,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2249
+   i32.const 2246
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -37030,7 +37326,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2250
+   i32.const 2247
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -37045,7 +37341,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2251
+   i32.const 2248
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -37060,7 +37356,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2252
+   i32.const 2249
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -37075,7 +37371,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2253
+   i32.const 2250
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -37090,7 +37386,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2254
+   i32.const 2251
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -37105,7 +37401,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2255
+   i32.const 2252
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -37120,7 +37416,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2256
+   i32.const 2253
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -37128,6 +37424,51 @@
   f32.const 0
   f32.const 1
   f32.const 0
+  f32.const 0
+  i32.const 0
+  call $std/math/test_minf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 2256
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const -0
+  f32.const 1
+  f32.const -0
+  f32.const 0
+  i32.const 0
+  call $std/math/test_minf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 2257
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const 0.5
+  f32.const 1
+  f32.const 0.5
+  f32.const 0
+  i32.const 0
+  call $std/math/test_minf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 2258
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const -0.5
+  f32.const 1
+  f32.const -0.5
   f32.const 0
   i32.const 0
   call $std/math/test_minf
@@ -37140,9 +37481,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -0
   f32.const 1
-  f32.const -0
+  f32.const 1
+  f32.const 1
   f32.const 0
   i32.const 0
   call $std/math/test_minf
@@ -37155,9 +37496,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 0.5
+  f32.const -1
   f32.const 1
-  f32.const 0.5
+  f32.const -1
   f32.const 0
   i32.const 0
   call $std/math/test_minf
@@ -37170,9 +37511,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -0.5
+  f32.const inf
   f32.const 1
-  f32.const -0.5
+  f32.const 1
   f32.const 0
   i32.const 0
   call $std/math/test_minf
@@ -37185,9 +37526,11 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f32.const inf
+  f32.neg
   f32.const 1
-  f32.const 1
-  f32.const 1
+  f32.const inf
+  f32.neg
   f32.const 0
   i32.const 0
   call $std/math/test_minf
@@ -37200,9 +37543,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -1
+  f32.const nan:0x400000
   f32.const 1
-  f32.const -1
+  f32.const nan:0x400000
   f32.const 0
   i32.const 0
   call $std/math/test_minf
@@ -37215,9 +37558,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const inf
-  f32.const 1
-  f32.const 1
+  f32.const 0
+  f32.const -1
+  f32.const -1
   f32.const 0
   i32.const 0
   call $std/math/test_minf
@@ -37230,11 +37573,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const inf
-  f32.neg
-  f32.const 1
-  f32.const inf
-  f32.neg
+  f32.const -0
+  f32.const -1
+  f32.const -1
   f32.const 0
   i32.const 0
   call $std/math/test_minf
@@ -37247,9 +37588,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const nan:0x400000
-  f32.const 1
-  f32.const nan:0x400000
+  f32.const 0.5
+  f32.const -1
+  f32.const -1
   f32.const 0
   i32.const 0
   call $std/math/test_minf
@@ -37262,7 +37603,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 0
+  f32.const -0.5
   f32.const -1
   f32.const -1
   f32.const 0
@@ -37277,7 +37618,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -0
+  f32.const 1
   f32.const -1
   f32.const -1
   f32.const 0
@@ -37292,7 +37633,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 0.5
+  f32.const -1
   f32.const -1
   f32.const -1
   f32.const 0
@@ -37307,7 +37648,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -0.5
+  f32.const inf
   f32.const -1
   f32.const -1
   f32.const 0
@@ -37322,9 +37663,11 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 1
+  f32.const inf
+  f32.neg
   f32.const -1
-  f32.const -1
+  f32.const inf
+  f32.neg
   f32.const 0
   i32.const 0
   call $std/math/test_minf
@@ -37337,9 +37680,9 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f32.const nan:0x400000
   f32.const -1
-  f32.const -1
-  f32.const -1
+  f32.const nan:0x400000
   f32.const 0
   i32.const 0
   call $std/math/test_minf
@@ -37352,9 +37695,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const inf
-  f32.const -1
-  f32.const -1
+  f32.const 0
+  f32.const 0
+  f32.const 0
   f32.const 0
   i32.const 0
   call $std/math/test_minf
@@ -37367,11 +37710,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const inf
-  f32.neg
-  f32.const -1
-  f32.const inf
-  f32.neg
+  f32.const 0
+  f32.const -0
+  f32.const -0
   f32.const 0
   i32.const 0
   call $std/math/test_minf
@@ -37384,9 +37725,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const nan:0x400000
-  f32.const -1
-  f32.const nan:0x400000
+  f32.const 0
+  f32.const inf
+  f32.const 0
   f32.const 0
   i32.const 0
   call $std/math/test_minf
@@ -37400,8 +37741,10 @@
    unreachable
   end
   f32.const 0
-  f32.const 0
-  f32.const 0
+  f32.const inf
+  f32.neg
+  f32.const inf
+  f32.neg
   f32.const 0
   i32.const 0
   call $std/math/test_minf
@@ -37415,8 +37758,8 @@
    unreachable
   end
   f32.const 0
-  f32.const -0
-  f32.const -0
+  f32.const nan:0x400000
+  f32.const nan:0x400000
   f32.const 0
   i32.const 0
   call $std/math/test_minf
@@ -37429,9 +37772,9 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f32.const -0
   f32.const 0
-  f32.const inf
-  f32.const 0
+  f32.const -0
   f32.const 0
   i32.const 0
   call $std/math/test_minf
@@ -37444,11 +37787,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 0
-  f32.const inf
-  f32.neg
-  f32.const inf
-  f32.neg
+  f32.const -0
+  f32.const -0
+  f32.const -0
   f32.const 0
   i32.const 0
   call $std/math/test_minf
@@ -37461,9 +37802,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 0
-  f32.const nan:0x400000
-  f32.const nan:0x400000
+  f32.const -0
+  f32.const inf
+  f32.const -0
   f32.const 0
   i32.const 0
   call $std/math/test_minf
@@ -37477,8 +37818,10 @@
    unreachable
   end
   f32.const -0
-  f32.const 0
-  f32.const -0
+  f32.const inf
+  f32.neg
+  f32.const inf
+  f32.neg
   f32.const 0
   i32.const 0
   call $std/math/test_minf
@@ -37492,8 +37835,8 @@
    unreachable
   end
   f32.const -0
-  f32.const -0
-  f32.const -0
+  f32.const nan:0x400000
+  f32.const nan:0x400000
   f32.const 0
   i32.const 0
   call $std/math/test_minf
@@ -37502,53 +37845,6 @@
    i32.const 0
    i32.const 32
    i32.const 2283
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const -0
-  f32.const inf
-  f32.const -0
-  f32.const 0
-  i32.const 0
-  call $std/math/test_minf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 2284
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const -0
-  f32.const inf
-  f32.neg
-  f32.const inf
-  f32.neg
-  f32.const 0
-  i32.const 0
-  call $std/math/test_minf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 2285
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const -0
-  f32.const nan:0x400000
-  f32.const nan:0x400000
-  f32.const 0
-  i32.const 0
-  call $std/math/test_minf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 2286
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -37563,7 +37859,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2287
+   i32.const 2284
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -37578,7 +37874,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2288
+   i32.const 2285
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -37586,6 +37882,53 @@
   f32.const inf
   f32.const 0
   f32.const 0
+  f32.const 0
+  i32.const 0
+  call $std/math/test_minf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 2286
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const inf
+  f32.neg
+  f32.const 0
+  f32.const inf
+  f32.neg
+  f32.const 0
+  i32.const 0
+  call $std/math/test_minf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 2287
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const nan:0x400000
+  f32.const 0
+  f32.const nan:0x400000
+  f32.const 0
+  i32.const 0
+  call $std/math/test_minf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 2288
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const -1
+  f32.const -0
+  f32.const -1
   f32.const 0
   i32.const 0
   call $std/math/test_minf
@@ -37599,10 +37942,8 @@
    unreachable
   end
   f32.const inf
-  f32.neg
-  f32.const 0
-  f32.const inf
-  f32.neg
+  f32.const -0
+  f32.const -0
   f32.const 0
   i32.const 0
   call $std/math/test_minf
@@ -37615,9 +37956,11 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const nan:0x400000
-  f32.const 0
-  f32.const nan:0x400000
+  f32.const inf
+  f32.neg
+  f32.const -0
+  f32.const inf
+  f32.neg
   f32.const 0
   i32.const 0
   call $std/math/test_minf
@@ -37630,9 +37973,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -1
+  f32.const nan:0x400000
   f32.const -0
-  f32.const -1
+  f32.const nan:0x400000
   f32.const 0
   i32.const 0
   call $std/math/test_minf
@@ -37646,8 +37989,8 @@
    unreachable
   end
   f32.const inf
-  f32.const -0
-  f32.const -0
+  f32.const 2
+  f32.const 2
   f32.const 0
   i32.const 0
   call $std/math/test_minf
@@ -37661,10 +38004,8 @@
    unreachable
   end
   f32.const inf
-  f32.neg
-  f32.const -0
-  f32.const inf
-  f32.neg
+  f32.const -0.5
+  f32.const -0.5
   f32.const 0
   i32.const 0
   call $std/math/test_minf
@@ -37677,8 +38018,8 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f32.const inf
   f32.const nan:0x400000
-  f32.const -0
   f32.const nan:0x400000
   f32.const 0
   i32.const 0
@@ -37693,8 +38034,10 @@
    unreachable
   end
   f32.const inf
+  f32.neg
   f32.const 2
-  f32.const 2
+  f32.const inf
+  f32.neg
   f32.const 0
   i32.const 0
   call $std/math/test_minf
@@ -37708,8 +38051,10 @@
    unreachable
   end
   f32.const inf
+  f32.neg
   f32.const -0.5
-  f32.const -0.5
+  f32.const inf
+  f32.neg
   f32.const 0
   i32.const 0
   call $std/math/test_minf
@@ -37723,6 +38068,7 @@
    unreachable
   end
   f32.const inf
+  f32.neg
   f32.const nan:0x400000
   f32.const nan:0x400000
   f32.const 0
@@ -37737,11 +38083,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const inf
-  f32.neg
-  f32.const 2
-  f32.const inf
-  f32.neg
+  f32.const nan:0x400000
+  f32.const nan:0x400000
+  f32.const nan:0x400000
   f32.const 0
   i32.const 0
   call $std/math/test_minf
@@ -37754,11 +38098,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const inf
-  f32.neg
-  f32.const -0.5
-  f32.const inf
-  f32.neg
+  f32.const 1
+  f32.const nan:0x400000
+  f32.const nan:0x400000
   f32.const 0
   i32.const 0
   call $std/math/test_minf
@@ -37771,8 +38113,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const inf
-  f32.neg
+  f32.const -1
   f32.const nan:0x400000
   f32.const nan:0x400000
   f32.const 0
@@ -37787,9 +38128,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const nan:0x400000
-  f32.const nan:0x400000
-  f32.const nan:0x400000
+  f32.const 1
+  f32.const inf
+  f32.const 1
   f32.const 0
   i32.const 0
   call $std/math/test_minf
@@ -37802,9 +38143,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 1
-  f32.const nan:0x400000
-  f32.const nan:0x400000
+  f32.const -1
+  f32.const inf
+  f32.const -1
   f32.const 0
   i32.const 0
   call $std/math/test_minf
@@ -37817,9 +38158,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -1
-  f32.const nan:0x400000
-  f32.const nan:0x400000
+  f32.const inf
+  f32.const inf
+  f32.const inf
   f32.const 0
   i32.const 0
   call $std/math/test_minf
@@ -37832,9 +38173,11 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 1
   f32.const inf
-  f32.const 1
+  f32.neg
+  f32.const inf
+  f32.const inf
+  f32.neg
   f32.const 0
   i32.const 0
   call $std/math/test_minf
@@ -37847,9 +38190,11 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -1
+  f32.const 1
   f32.const inf
-  f32.const -1
+  f32.neg
+  f32.const inf
+  f32.neg
   f32.const 0
   i32.const 0
   call $std/math/test_minf
@@ -37862,9 +38207,11 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f32.const -1
   f32.const inf
+  f32.neg
   f32.const inf
-  f32.const inf
+  f32.neg
   f32.const 0
   i32.const 0
   call $std/math/test_minf
@@ -37878,8 +38225,8 @@
    unreachable
   end
   f32.const inf
-  f32.neg
   f32.const inf
+  f32.neg
   f32.const inf
   f32.neg
   f32.const 0
@@ -37894,7 +38241,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 1
+  f32.const inf
+  f32.neg
   f32.const inf
   f32.neg
   f32.const inf
@@ -37911,11 +38259,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -1
-  f32.const inf
-  f32.neg
-  f32.const inf
-  f32.neg
+  f32.const 1.75
+  f32.const 0.5
+  f32.const 0.5
   f32.const 0
   i32.const 0
   call $std/math/test_minf
@@ -37928,11 +38274,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const inf
-  f32.const inf
-  f32.neg
-  f32.const inf
-  f32.neg
+  f32.const -1.75
+  f32.const 0.5
+  f32.const -1.75
   f32.const 0
   i32.const 0
   call $std/math/test_minf
@@ -37945,12 +38289,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const inf
-  f32.neg
-  f32.const inf
-  f32.neg
-  f32.const inf
-  f32.neg
+  f32.const 1.75
+  f32.const -0.5
+  f32.const -0.5
   f32.const 0
   i32.const 0
   call $std/math/test_minf
@@ -37963,9 +38304,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 1.75
-  f32.const 0.5
-  f32.const 0.5
+  f32.const -1.75
+  f32.const -0.5
+  f32.const -1.75
   f32.const 0
   i32.const 0
   call $std/math/test_minf
@@ -37974,51 +38315,6 @@
    i32.const 0
    i32.const 32
    i32.const 2313
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const -1.75
-  f32.const 0.5
-  f32.const -1.75
-  f32.const 0
-  i32.const 0
-  call $std/math/test_minf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 2314
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const 1.75
-  f32.const -0.5
-  f32.const -0.5
-  f32.const 0
-  i32.const 0
-  call $std/math/test_minf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 2315
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const -1.75
-  f32.const -0.5
-  f32.const -1.75
-  f32.const 0
-  i32.const 0
-  call $std/math/test_minf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 2316
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -38033,7 +38329,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2330
+   i32.const 2327
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -38048,7 +38344,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2331
+   i32.const 2328
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -38063,7 +38359,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2332
+   i32.const 2329
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -38078,7 +38374,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2333
+   i32.const 2330
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -38093,7 +38389,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2334
+   i32.const 2331
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -38108,7 +38404,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2335
+   i32.const 2332
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -38123,7 +38419,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2336
+   i32.const 2333
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -38138,7 +38434,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2337
+   i32.const 2334
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -38153,7 +38449,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2338
+   i32.const 2335
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -38168,7 +38464,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2339
+   i32.const 2336
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -38176,6 +38472,51 @@
   f64.const 0
   f64.const 1
   f64.const 0
+  f64.const 0
+  i32.const 0
+  call $std/math/test_mod
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 2339
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const -0
+  f64.const 1
+  f64.const -0
+  f64.const 0
+  i32.const 0
+  call $std/math/test_mod
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 2340
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const 0.5
+  f64.const 1
+  f64.const 0.5
+  f64.const 0
+  i32.const 0
+  call $std/math/test_mod
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 2341
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const -0.5
+  f64.const 1
+  f64.const -0.5
   f64.const 0
   i32.const 0
   call $std/math/test_mod
@@ -38188,9 +38529,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -0
   f64.const 1
-  f64.const -0
+  f64.const 1
+  f64.const 0
   f64.const 0
   i32.const 0
   call $std/math/test_mod
@@ -38199,51 +38540,6 @@
    i32.const 0
    i32.const 32
    i32.const 2343
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const 0.5
-  f64.const 1
-  f64.const 0.5
-  f64.const 0
-  i32.const 0
-  call $std/math/test_mod
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 2344
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const -0.5
-  f64.const 1
-  f64.const -0.5
-  f64.const 0
-  i32.const 0
-  call $std/math/test_mod
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 2345
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const 1
-  f64.const 1
-  f64.const 0
-  f64.const 0
-  i32.const 0
-  call $std/math/test_mod
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 2346
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -38258,7 +38554,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2347
+   i32.const 2344
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -38273,7 +38569,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2348
+   i32.const 2345
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -38288,7 +38584,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2349
+   i32.const 2346
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -38303,7 +38599,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2350
+   i32.const 2347
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -38318,7 +38614,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2351
+   i32.const 2348
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -38333,7 +38629,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2352
+   i32.const 2349
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -38349,7 +38645,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2353
+   i32.const 2350
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -38357,6 +38653,51 @@
   f64.const nan:0x8000000000000
   f64.const 1
   f64.const nan:0x8000000000000
+  f64.const 0
+  i32.const 0
+  call $std/math/test_mod
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 2351
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const 0
+  f64.const -1
+  f64.const 0
+  f64.const 0
+  i32.const 0
+  call $std/math/test_mod
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 2352
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const -0
+  f64.const -1
+  f64.const -0
+  f64.const 0
+  i32.const 0
+  call $std/math/test_mod
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 2353
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const 0.5
+  f64.const -1
+  f64.const 0.5
   f64.const 0
   i32.const 0
   call $std/math/test_mod
@@ -38369,9 +38710,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 0
+  f64.const -0.5
   f64.const -1
-  f64.const 0
+  f64.const -0.5
   f64.const 0
   i32.const 0
   call $std/math/test_mod
@@ -38380,51 +38721,6 @@
    i32.const 0
    i32.const 32
    i32.const 2355
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const -0
-  f64.const -1
-  f64.const -0
-  f64.const 0
-  i32.const 0
-  call $std/math/test_mod
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 2356
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const 0.5
-  f64.const -1
-  f64.const 0.5
-  f64.const 0
-  i32.const 0
-  call $std/math/test_mod
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 2357
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const -0.5
-  f64.const -1
-  f64.const -0.5
-  f64.const 0
-  i32.const 0
-  call $std/math/test_mod
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 2358
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -38439,7 +38735,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2359
+   i32.const 2356
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -38454,7 +38750,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2360
+   i32.const 2357
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -38469,7 +38765,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2361
+   i32.const 2358
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -38484,7 +38780,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2362
+   i32.const 2359
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -38499,7 +38795,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2363
+   i32.const 2360
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -38514,13 +38810,59 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2364
+   i32.const 2361
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f64.const inf
   f64.const -1
+  f64.const nan:0x8000000000000
+  f64.const 0
+  global.get $std/math/INVALID
+  call $std/math/test_mod
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 2362
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const inf
+  f64.neg
+  f64.const -1
+  f64.const nan:0x8000000000000
+  f64.const 0
+  global.get $std/math/INVALID
+  call $std/math/test_mod
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 2363
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const nan:0x8000000000000
+  f64.const -1
+  f64.const nan:0x8000000000000
+  f64.const 0
+  i32.const 0
+  call $std/math/test_mod
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 2364
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const 0
+  f64.const 0
   f64.const nan:0x8000000000000
   f64.const 0
   global.get $std/math/INVALID
@@ -38534,9 +38876,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const inf
-  f64.neg
-  f64.const -1
+  f64.const 0
+  f64.const -0
   f64.const nan:0x8000000000000
   f64.const 0
   global.get $std/math/INVALID
@@ -38550,9 +38891,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const nan:0x8000000000000
-  f64.const -1
-  f64.const nan:0x8000000000000
+  f64.const 0
+  f64.const inf
+  f64.const 0
   f64.const 0
   i32.const 0
   call $std/math/test_mod
@@ -38566,10 +38907,11 @@
    unreachable
   end
   f64.const 0
+  f64.const inf
+  f64.neg
   f64.const 0
-  f64.const nan:0x8000000000000
   f64.const 0
-  global.get $std/math/INVALID
+  i32.const 0
   call $std/math/test_mod
   i32.eqz
   if
@@ -38581,10 +38923,10 @@
    unreachable
   end
   f64.const 0
-  f64.const -0
+  f64.const nan:0x8000000000000
   f64.const nan:0x8000000000000
   f64.const 0
-  global.get $std/math/INVALID
+  i32.const 0
   call $std/math/test_mod
   i32.eqz
   if
@@ -38595,11 +38937,11 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f64.const -0
   f64.const 0
-  f64.const inf
+  f64.const nan:0x8000000000000
   f64.const 0
-  f64.const 0
-  i32.const 0
+  global.get $std/math/INVALID
   call $std/math/test_mod
   i32.eqz
   if
@@ -38610,12 +38952,11 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f64.const -0
+  f64.const -0
+  f64.const nan:0x8000000000000
   f64.const 0
-  f64.const inf
-  f64.neg
-  f64.const 0
-  f64.const 0
-  i32.const 0
+  global.get $std/math/INVALID
   call $std/math/test_mod
   i32.eqz
   if
@@ -38626,9 +38967,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 0
-  f64.const nan:0x8000000000000
-  f64.const nan:0x8000000000000
+  f64.const -0
+  f64.const inf
+  f64.const -0
   f64.const 0
   i32.const 0
   call $std/math/test_mod
@@ -38642,10 +38983,11 @@
    unreachable
   end
   f64.const -0
+  f64.const inf
+  f64.neg
+  f64.const -0
   f64.const 0
-  f64.const nan:0x8000000000000
-  f64.const 0
-  global.get $std/math/INVALID
+  i32.const 0
   call $std/math/test_mod
   i32.eqz
   if
@@ -38657,10 +38999,10 @@
    unreachable
   end
   f64.const -0
-  f64.const -0
+  f64.const nan:0x8000000000000
   f64.const nan:0x8000000000000
   f64.const 0
-  global.get $std/math/INVALID
+  i32.const 0
   call $std/math/test_mod
   i32.eqz
   if
@@ -38671,11 +39013,11 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -0
-  f64.const inf
-  f64.const -0
+  f64.const 1
   f64.const 0
-  i32.const 0
+  f64.const nan:0x8000000000000
+  f64.const 0
+  global.get $std/math/INVALID
   call $std/math/test_mod
   i32.eqz
   if
@@ -38686,12 +39028,11 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -0
-  f64.const inf
-  f64.neg
-  f64.const -0
+  f64.const -1
   f64.const 0
-  i32.const 0
+  f64.const nan:0x8000000000000
+  f64.const 0
+  global.get $std/math/INVALID
   call $std/math/test_mod
   i32.eqz
   if
@@ -38702,11 +39043,11 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -0
-  f64.const nan:0x8000000000000
+  f64.const inf
+  f64.const 0
   f64.const nan:0x8000000000000
   f64.const 0
-  i32.const 0
+  global.get $std/math/INVALID
   call $std/math/test_mod
   i32.eqz
   if
@@ -38717,7 +39058,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 1
+  f64.const inf
+  f64.neg
   f64.const 0
   f64.const nan:0x8000000000000
   f64.const 0
@@ -38732,11 +39074,11 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -1
+  f64.const nan:0x8000000000000
   f64.const 0
   f64.const nan:0x8000000000000
   f64.const 0
-  global.get $std/math/INVALID
+  i32.const 0
   call $std/math/test_mod
   i32.eqz
   if
@@ -38747,8 +39089,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const inf
-  f64.const 0
+  f64.const -1
+  f64.const -0
   f64.const nan:0x8000000000000
   f64.const 0
   global.get $std/math/INVALID
@@ -38763,8 +39105,7 @@
    unreachable
   end
   f64.const inf
-  f64.neg
-  f64.const 0
+  f64.const -0
   f64.const nan:0x8000000000000
   f64.const 0
   global.get $std/math/INVALID
@@ -38778,11 +39119,12 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f64.const inf
+  f64.neg
+  f64.const -0
   f64.const nan:0x8000000000000
   f64.const 0
-  f64.const nan:0x8000000000000
-  f64.const 0
-  i32.const 0
+  global.get $std/math/INVALID
   call $std/math/test_mod
   i32.eqz
   if
@@ -38793,11 +39135,11 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -1
+  f64.const nan:0x8000000000000
   f64.const -0
   f64.const nan:0x8000000000000
   f64.const 0
-  global.get $std/math/INVALID
+  i32.const 0
   call $std/math/test_mod
   i32.eqz
   if
@@ -38809,7 +39151,7 @@
    unreachable
   end
   f64.const inf
-  f64.const -0
+  f64.const 2
   f64.const nan:0x8000000000000
   f64.const 0
   global.get $std/math/INVALID
@@ -38824,8 +39166,7 @@
    unreachable
   end
   f64.const inf
-  f64.neg
-  f64.const -0
+  f64.const -0.5
   f64.const nan:0x8000000000000
   f64.const 0
   global.get $std/math/INVALID
@@ -38839,8 +39180,8 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f64.const inf
   f64.const nan:0x8000000000000
-  f64.const -0
   f64.const nan:0x8000000000000
   f64.const 0
   i32.const 0
@@ -38855,6 +39196,7 @@
    unreachable
   end
   f64.const inf
+  f64.neg
   f64.const 2
   f64.const nan:0x8000000000000
   f64.const 0
@@ -38870,6 +39212,7 @@
    unreachable
   end
   f64.const inf
+  f64.neg
   f64.const -0.5
   f64.const nan:0x8000000000000
   f64.const 0
@@ -38885,6 +39228,7 @@
    unreachable
   end
   f64.const inf
+  f64.neg
   f64.const nan:0x8000000000000
   f64.const nan:0x8000000000000
   f64.const 0
@@ -38899,12 +39243,11 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const inf
-  f64.neg
-  f64.const 2
+  f64.const nan:0x8000000000000
+  f64.const nan:0x8000000000000
   f64.const nan:0x8000000000000
   f64.const 0
-  global.get $std/math/INVALID
+  i32.const 0
   call $std/math/test_mod
   i32.eqz
   if
@@ -38915,12 +39258,11 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const inf
-  f64.neg
-  f64.const -0.5
+  f64.const 1
+  f64.const nan:0x8000000000000
   f64.const nan:0x8000000000000
   f64.const 0
-  global.get $std/math/INVALID
+  i32.const 0
   call $std/math/test_mod
   i32.eqz
   if
@@ -38931,8 +39273,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const inf
-  f64.neg
+  f64.const -1
   f64.const nan:0x8000000000000
   f64.const nan:0x8000000000000
   f64.const 0
@@ -38947,9 +39288,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const nan:0x8000000000000
-  f64.const nan:0x8000000000000
-  f64.const nan:0x8000000000000
+  f64.const 1
+  f64.const inf
+  f64.const 1
   f64.const 0
   i32.const 0
   call $std/math/test_mod
@@ -38962,9 +39303,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 1
-  f64.const nan:0x8000000000000
-  f64.const nan:0x8000000000000
+  f64.const -1
+  f64.const inf
+  f64.const -1
   f64.const 0
   i32.const 0
   call $std/math/test_mod
@@ -38973,51 +39314,6 @@
    i32.const 0
    i32.const 32
    i32.const 2394
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const -1
-  f64.const nan:0x8000000000000
-  f64.const nan:0x8000000000000
-  f64.const 0
-  i32.const 0
-  call $std/math/test_mod
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 2395
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const 1
-  f64.const inf
-  f64.const 1
-  f64.const 0
-  i32.const 0
-  call $std/math/test_mod
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 2396
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const -1
-  f64.const inf
-  f64.const -1
-  f64.const 0
-  i32.const 0
-  call $std/math/test_mod
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 2397
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -39032,7 +39328,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2398
+   i32.const 2395
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -39040,6 +39336,54 @@
   f64.const inf
   f64.neg
   f64.const inf
+  f64.const nan:0x8000000000000
+  f64.const 0
+  global.get $std/math/INVALID
+  call $std/math/test_mod
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 2396
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const 1
+  f64.const inf
+  f64.neg
+  f64.const 1
+  f64.const 0
+  i32.const 0
+  call $std/math/test_mod
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 2397
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const -1
+  f64.const inf
+  f64.neg
+  f64.const -1
+  f64.const 0
+  i32.const 0
+  call $std/math/test_mod
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 2398
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const inf
+  f64.const inf
+  f64.neg
   f64.const nan:0x8000000000000
   f64.const 0
   global.get $std/math/INVALID
@@ -39053,12 +39397,13 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 1
   f64.const inf
   f64.neg
-  f64.const 1
+  f64.const inf
+  f64.neg
+  f64.const nan:0x8000000000000
   f64.const 0
-  i32.const 0
+  global.get $std/math/INVALID
   call $std/math/test_mod
   i32.eqz
   if
@@ -39069,10 +39414,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -1
-  f64.const inf
-  f64.neg
-  f64.const -1
+  f64.const 1.75
+  f64.const 0.5
+  f64.const 0.25
   f64.const 0
   i32.const 0
   call $std/math/test_mod
@@ -39085,12 +39429,11 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const inf
-  f64.const inf
-  f64.neg
-  f64.const nan:0x8000000000000
+  f64.const -1.75
+  f64.const 0.5
+  f64.const -0.25
   f64.const 0
-  global.get $std/math/INVALID
+  i32.const 0
   call $std/math/test_mod
   i32.eqz
   if
@@ -39101,13 +39444,11 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const inf
-  f64.neg
-  f64.const inf
-  f64.neg
-  f64.const nan:0x8000000000000
+  f64.const 1.75
+  f64.const -0.5
+  f64.const 0.25
   f64.const 0
-  global.get $std/math/INVALID
+  i32.const 0
   call $std/math/test_mod
   i32.eqz
   if
@@ -39118,9 +39459,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 1.75
-  f64.const 0.5
-  f64.const 0.25
+  f64.const -1.75
+  f64.const -0.5
+  f64.const -0.25
   f64.const 0
   i32.const 0
   call $std/math/test_mod
@@ -39133,39 +39474,11 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -1.75
-  f64.const 0.5
-  f64.const -0.25
+  i64.const 4503599627370496
+  f64.reinterpret_i64
+  i64.const 4503599627370496
+  f64.reinterpret_i64
   f64.const 0
-  i32.const 0
-  call $std/math/test_mod
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 2405
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const 1.75
-  f64.const -0.5
-  f64.const 0.25
-  f64.const 0
-  i32.const 0
-  call $std/math/test_mod
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 2406
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const -1.75
-  f64.const -0.5
-  f64.const -0.25
   f64.const 0
   i32.const 0
   call $std/math/test_mod
@@ -39180,9 +39493,43 @@
   end
   i64.const 4503599627370496
   f64.reinterpret_i64
-  i64.const 4503599627370496
+  i64.const -9218868437227405312
   f64.reinterpret_i64
   f64.const 0
+  f64.const 0
+  i32.const 0
+  call $std/math/test_mod
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 2408
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  i64.const -9218868437227405312
+  f64.reinterpret_i64
+  i64.const 4503599627370496
+  f64.reinterpret_i64
+  f64.const -0
+  f64.const 0
+  i32.const 0
+  call $std/math/test_mod
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 2409
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  i64.const -9218868437227405312
+  f64.reinterpret_i64
+  i64.const -9218868437227405312
+  f64.reinterpret_i64
+  f64.const -0
   f64.const 0
   i32.const 0
   call $std/math/test_mod
@@ -39195,9 +39542,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  i64.const 4503599627370496
+  i64.const 9218868437227405311
   f64.reinterpret_i64
-  i64.const -9218868437227405312
+  i64.const 9218868437227405311
   f64.reinterpret_i64
   f64.const 0
   f64.const 0
@@ -39212,11 +39559,11 @@
    call $~lib/builtins/abort
    unreachable
   end
-  i64.const -9218868437227405312
+  i64.const 9218868437227405311
   f64.reinterpret_i64
-  i64.const 4503599627370496
+  i64.const -4503599627370497
   f64.reinterpret_i64
-  f64.const -0
+  f64.const 0
   f64.const 0
   i32.const 0
   call $std/math/test_mod
@@ -39229,9 +39576,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  i64.const -9218868437227405312
+  i64.const -4503599627370497
   f64.reinterpret_i64
-  i64.const -9218868437227405312
+  i64.const 9218868437227405311
   f64.reinterpret_i64
   f64.const -0
   f64.const 0
@@ -39246,11 +39593,11 @@
    call $~lib/builtins/abort
    unreachable
   end
-  i64.const 9218868437227405311
+  i64.const -4503599627370497
   f64.reinterpret_i64
-  i64.const 9218868437227405311
+  i64.const -4503599627370497
   f64.reinterpret_i64
-  f64.const 0
+  f64.const -0
   f64.const 0
   i32.const 0
   call $std/math/test_mod
@@ -39263,45 +39610,11 @@
    call $~lib/builtins/abort
    unreachable
   end
-  i64.const 9218868437227405311
+  i64.const 0
   f64.reinterpret_i64
-  i64.const -4503599627370497
+  i64.const 4503599627370496
   f64.reinterpret_i64
   f64.const 0
-  f64.const 0
-  i32.const 0
-  call $std/math/test_mod
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 2415
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  i64.const -4503599627370497
-  f64.reinterpret_i64
-  i64.const 9218868437227405311
-  f64.reinterpret_i64
-  f64.const -0
-  f64.const 0
-  i32.const 0
-  call $std/math/test_mod
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 2416
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  i64.const -4503599627370497
-  f64.reinterpret_i64
-  i64.const -4503599627370497
-  f64.reinterpret_i64
-  f64.const -0
   f64.const 0
   i32.const 0
   call $std/math/test_mod
@@ -39316,7 +39629,41 @@
   end
   i64.const 0
   f64.reinterpret_i64
-  i64.const 4503599627370496
+  i64.const 9218868437227405311
+  f64.reinterpret_i64
+  f64.const 0
+  f64.const 0
+  i32.const 0
+  call $std/math/test_mod
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 2418
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  i64.const 0
+  f64.reinterpret_i64
+  i64.const -9218868437227405312
+  f64.reinterpret_i64
+  f64.const 0
+  f64.const 0
+  i32.const 0
+  call $std/math/test_mod
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 2419
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  i64.const 0
+  f64.reinterpret_i64
+  i64.const -4503599627370497
   f64.reinterpret_i64
   f64.const 0
   f64.const 0
@@ -39331,11 +39678,11 @@
    call $~lib/builtins/abort
    unreachable
   end
-  i64.const 0
+  i64.const -9223372036854775808
   f64.reinterpret_i64
-  i64.const 9218868437227405311
+  i64.const 4503599627370496
   f64.reinterpret_i64
-  f64.const 0
+  f64.const -0
   f64.const 0
   i32.const 0
   call $std/math/test_mod
@@ -39348,11 +39695,11 @@
    call $~lib/builtins/abort
    unreachable
   end
-  i64.const 0
+  i64.const -9223372036854775808
   f64.reinterpret_i64
-  i64.const -9218868437227405312
+  i64.const 9218868437227405311
   f64.reinterpret_i64
-  f64.const 0
+  f64.const -0
   f64.const 0
   i32.const 0
   call $std/math/test_mod
@@ -39365,11 +39712,11 @@
    call $~lib/builtins/abort
    unreachable
   end
-  i64.const 0
+  i64.const -9223372036854775808
   f64.reinterpret_i64
-  i64.const -4503599627370497
+  i64.const -9218868437227405312
   f64.reinterpret_i64
-  f64.const 0
+  f64.const -0
   f64.const 0
   i32.const 0
   call $std/math/test_mod
@@ -39384,7 +39731,7 @@
   end
   i64.const -9223372036854775808
   f64.reinterpret_i64
-  i64.const 4503599627370496
+  i64.const -4503599627370497
   f64.reinterpret_i64
   f64.const -0
   f64.const 0
@@ -39399,45 +39746,12 @@
    call $~lib/builtins/abort
    unreachable
   end
-  i64.const -9223372036854775808
-  f64.reinterpret_i64
   i64.const 9218868437227405311
   f64.reinterpret_i64
-  f64.const -0
-  f64.const 0
-  i32.const 0
-  call $std/math/test_mod
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 2425
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  i64.const -9223372036854775808
+  i64.const 9218868437227405310
   f64.reinterpret_i64
-  i64.const -9218868437227405312
+  i64.const 8980177656976769024
   f64.reinterpret_i64
-  f64.const -0
-  f64.const 0
-  i32.const 0
-  call $std/math/test_mod
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 2426
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  i64.const -9223372036854775808
-  f64.reinterpret_i64
-  i64.const -4503599627370497
-  f64.reinterpret_i64
-  f64.const -0
   f64.const 0
   i32.const 0
   call $std/math/test_mod
@@ -39450,11 +39764,29 @@
    call $~lib/builtins/abort
    unreachable
   end
-  i64.const 9218868437227405311
+  i64.const -4503599627370497
   f64.reinterpret_i64
   i64.const 9218868437227405310
   f64.reinterpret_i64
-  i64.const 8980177656976769024
+  i64.const -243194379878006784
+  f64.reinterpret_i64
+  f64.const 0
+  i32.const 0
+  call $std/math/test_mod
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 2428
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  i64.const 9218868437227405311
+  f64.reinterpret_i64
+  i64.const -9007199254740992
+  f64.reinterpret_i64
+  i64.const 9214364837600034814
   f64.reinterpret_i64
   f64.const 0
   i32.const 0
@@ -39470,42 +39802,6 @@
   end
   i64.const -4503599627370497
   f64.reinterpret_i64
-  i64.const 9218868437227405310
-  f64.reinterpret_i64
-  i64.const -243194379878006784
-  f64.reinterpret_i64
-  f64.const 0
-  i32.const 0
-  call $std/math/test_mod
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 2431
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  i64.const 9218868437227405311
-  f64.reinterpret_i64
-  i64.const -9007199254740992
-  f64.reinterpret_i64
-  i64.const 9214364837600034814
-  f64.reinterpret_i64
-  f64.const 0
-  i32.const 0
-  call $std/math/test_mod
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 2433
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  i64.const -4503599627370497
-  f64.reinterpret_i64
   i64.const -9007199254740992
   f64.reinterpret_i64
   i64.const -9007199254740994
@@ -39517,7 +39813,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2434
+   i32.const 2431
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -39535,7 +39831,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2436
+   i32.const 2433
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -39553,7 +39849,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2437
+   i32.const 2434
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -39571,7 +39867,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2439
+   i32.const 2436
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -39589,7 +39885,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2440
+   i32.const 2437
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -39599,6 +39895,42 @@
   i64.const 9218868437227405311
   f64.reinterpret_i64
   i64.const 9214364837600034816
+  f64.reinterpret_i64
+  f64.const 0
+  i32.const 0
+  call $std/math/test_mod
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 2439
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  i64.const -9007199254740992
+  f64.reinterpret_i64
+  i64.const 9218868437227405311
+  f64.reinterpret_i64
+  i64.const -9007199254740992
+  f64.reinterpret_i64
+  f64.const 0
+  i32.const 0
+  call $std/math/test_mod
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 2440
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  i64.const 9214364837600034815
+  f64.reinterpret_i64
+  i64.const -4503599627370497
+  f64.reinterpret_i64
+  i64.const 9214364837600034815
   f64.reinterpret_i64
   f64.const 0
   i32.const 0
@@ -39612,11 +39944,11 @@
    call $~lib/builtins/abort
    unreachable
   end
-  i64.const -9007199254740992
+  i64.const -9007199254740993
   f64.reinterpret_i64
-  i64.const 9218868437227405311
+  i64.const -4503599627370497
   f64.reinterpret_i64
-  i64.const -9007199254740992
+  i64.const -9007199254740993
   f64.reinterpret_i64
   f64.const 0
   i32.const 0
@@ -39630,11 +39962,11 @@
    call $~lib/builtins/abort
    unreachable
   end
-  i64.const 9214364837600034815
+  i64.const 9214364837600034814
   f64.reinterpret_i64
-  i64.const -4503599627370497
+  i64.const 9218868437227405311
   f64.reinterpret_i64
-  i64.const 9214364837600034815
+  i64.const 9214364837600034814
   f64.reinterpret_i64
   f64.const 0
   i32.const 0
@@ -39648,11 +39980,11 @@
    call $~lib/builtins/abort
    unreachable
   end
-  i64.const -9007199254740993
+  i64.const -9007199254740994
   f64.reinterpret_i64
-  i64.const -4503599627370497
+  i64.const 9218868437227405311
   f64.reinterpret_i64
-  i64.const -9007199254740993
+  i64.const -9007199254740994
   f64.reinterpret_i64
   f64.const 0
   i32.const 0
@@ -39666,11 +39998,11 @@
    call $~lib/builtins/abort
    unreachable
   end
-  i64.const 9214364837600034814
+  i64.const 9218868437227405310
   f64.reinterpret_i64
-  i64.const 9218868437227405311
+  i64.const -4503599627370497
   f64.reinterpret_i64
-  i64.const 9214364837600034814
+  i64.const 9218868437227405310
   f64.reinterpret_i64
   f64.const 0
   i32.const 0
@@ -39684,11 +40016,11 @@
    call $~lib/builtins/abort
    unreachable
   end
-  i64.const -9007199254740994
+  i64.const -4503599627370498
   f64.reinterpret_i64
-  i64.const 9218868437227405311
+  i64.const -4503599627370497
   f64.reinterpret_i64
-  i64.const -9007199254740994
+  i64.const -4503599627370498
   f64.reinterpret_i64
   f64.const 0
   i32.const 0
@@ -39698,42 +40030,6 @@
    i32.const 0
    i32.const 32
    i32.const 2449
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  i64.const 9218868437227405310
-  f64.reinterpret_i64
-  i64.const -4503599627370497
-  f64.reinterpret_i64
-  i64.const 9218868437227405310
-  f64.reinterpret_i64
-  f64.const 0
-  i32.const 0
-  call $std/math/test_mod
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 2451
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  i64.const -4503599627370498
-  f64.reinterpret_i64
-  i64.const -4503599627370497
-  f64.reinterpret_i64
-  i64.const -4503599627370498
-  f64.reinterpret_i64
-  f64.const 0
-  i32.const 0
-  call $std/math/test_mod
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 2452
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -39751,7 +40047,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2454
+   i32.const 2451
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -39769,7 +40065,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2455
+   i32.const 2452
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -39785,7 +40081,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2457
+   i32.const 2454
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -39801,7 +40097,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2458
+   i32.const 2455
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -39817,7 +40113,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2459
+   i32.const 2456
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -39833,7 +40129,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2460
+   i32.const 2457
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -39849,7 +40145,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2461
+   i32.const 2458
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -39865,7 +40161,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2462
+   i32.const 2459
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -39881,7 +40177,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2463
+   i32.const 2460
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -39897,7 +40193,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2464
+   i32.const 2461
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -39915,7 +40211,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2466
+   i32.const 2463
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -39933,7 +40229,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2467
+   i32.const 2464
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -39951,7 +40247,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2468
+   i32.const 2465
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -39969,7 +40265,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2469
+   i32.const 2466
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -39987,7 +40283,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2470
+   i32.const 2467
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -40005,7 +40301,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2471
+   i32.const 2468
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -40023,7 +40319,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2472
+   i32.const 2469
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -40041,7 +40337,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2473
+   i32.const 2470
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -40059,7 +40355,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2474
+   i32.const 2471
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -40077,7 +40373,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2475
+   i32.const 2472
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -40095,7 +40391,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2476
+   i32.const 2473
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -40105,6 +40401,60 @@
   i64.const 3
   f64.reinterpret_i64
   i64.const 0
+  f64.reinterpret_i64
+  f64.const 0
+  i32.const 0
+  call $std/math/test_mod
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 2474
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  i64.const 4503599627370498
+  f64.reinterpret_i64
+  i64.const -9223372036854775805
+  f64.reinterpret_i64
+  i64.const 0
+  f64.reinterpret_i64
+  f64.const 0
+  i32.const 0
+  call $std/math/test_mod
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 2475
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  i64.const 4503599627370499
+  f64.reinterpret_i64
+  i64.const 3
+  f64.reinterpret_i64
+  i64.const 1
+  f64.reinterpret_i64
+  f64.const 0
+  i32.const 0
+  call $std/math/test_mod
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 2476
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  i64.const 4503599627370499
+  f64.reinterpret_i64
+  i64.const 4503599627370501
+  f64.reinterpret_i64
+  i64.const 4503599627370499
   f64.reinterpret_i64
   f64.const 0
   i32.const 0
@@ -40118,11 +40468,11 @@
    call $~lib/builtins/abort
    unreachable
   end
-  i64.const 4503599627370498
+  i64.const 4503599627370499
   f64.reinterpret_i64
   i64.const -9223372036854775805
   f64.reinterpret_i64
-  i64.const 0
+  i64.const 1
   f64.reinterpret_i64
   f64.const 0
   i32.const 0
@@ -40136,11 +40486,11 @@
    call $~lib/builtins/abort
    unreachable
   end
-  i64.const 4503599627370499
+  i64.const 4503599627370500
   f64.reinterpret_i64
-  i64.const 3
+  i64.const 4503599627370501
   f64.reinterpret_i64
-  i64.const 1
+  i64.const 4503599627370500
   f64.reinterpret_i64
   f64.const 0
   i32.const 0
@@ -40150,60 +40500,6 @@
    i32.const 0
    i32.const 32
    i32.const 2479
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  i64.const 4503599627370499
-  f64.reinterpret_i64
-  i64.const 4503599627370501
-  f64.reinterpret_i64
-  i64.const 4503599627370499
-  f64.reinterpret_i64
-  f64.const 0
-  i32.const 0
-  call $std/math/test_mod
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 2480
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  i64.const 4503599627370499
-  f64.reinterpret_i64
-  i64.const -9223372036854775805
-  f64.reinterpret_i64
-  i64.const 1
-  f64.reinterpret_i64
-  f64.const 0
-  i32.const 0
-  call $std/math/test_mod
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 2481
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  i64.const 4503599627370500
-  f64.reinterpret_i64
-  i64.const 4503599627370501
-  f64.reinterpret_i64
-  i64.const 4503599627370500
-  f64.reinterpret_i64
-  f64.const 0
-  i32.const 0
-  call $std/math/test_mod
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 2482
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -40221,7 +40517,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2483
+   i32.const 2480
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -40239,7 +40535,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2484
+   i32.const 2481
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -40257,7 +40553,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2485
+   i32.const 2482
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -40272,7 +40568,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2494
+   i32.const 2491
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -40287,7 +40583,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2495
+   i32.const 2492
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -40302,7 +40598,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2496
+   i32.const 2493
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -40317,7 +40613,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2497
+   i32.const 2494
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -40332,7 +40628,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2498
+   i32.const 2495
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -40347,7 +40643,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2499
+   i32.const 2496
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -40362,7 +40658,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2500
+   i32.const 2497
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -40377,7 +40673,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2501
+   i32.const 2498
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -40392,7 +40688,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2502
+   i32.const 2499
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -40407,7 +40703,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2503
+   i32.const 2500
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -40415,6 +40711,51 @@
   f32.const 0
   f32.const 1
   f32.const 0
+  f32.const 0
+  i32.const 0
+  call $std/math/test_modf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 2503
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const -0
+  f32.const 1
+  f32.const -0
+  f32.const 0
+  i32.const 0
+  call $std/math/test_modf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 2504
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const 0.5
+  f32.const 1
+  f32.const 0.5
+  f32.const 0
+  i32.const 0
+  call $std/math/test_modf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 2505
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const -0.5
+  f32.const 1
+  f32.const -0.5
   f32.const 0
   i32.const 0
   call $std/math/test_modf
@@ -40427,9 +40768,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -0
   f32.const 1
-  f32.const -0
+  f32.const 1
+  f32.const 0
   f32.const 0
   i32.const 0
   call $std/math/test_modf
@@ -40438,51 +40779,6 @@
    i32.const 0
    i32.const 32
    i32.const 2507
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const 0.5
-  f32.const 1
-  f32.const 0.5
-  f32.const 0
-  i32.const 0
-  call $std/math/test_modf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 2508
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const -0.5
-  f32.const 1
-  f32.const -0.5
-  f32.const 0
-  i32.const 0
-  call $std/math/test_modf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 2509
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const 1
-  f32.const 1
-  f32.const 0
-  f32.const 0
-  i32.const 0
-  call $std/math/test_modf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 2510
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -40497,7 +40793,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2511
+   i32.const 2508
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -40512,7 +40808,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2512
+   i32.const 2509
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -40527,7 +40823,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2513
+   i32.const 2510
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -40542,7 +40838,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2514
+   i32.const 2511
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -40557,7 +40853,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2515
+   i32.const 2512
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -40572,7 +40868,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2516
+   i32.const 2513
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -40588,7 +40884,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2517
+   i32.const 2514
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -40596,6 +40892,51 @@
   f32.const nan:0x400000
   f32.const 1
   f32.const nan:0x400000
+  f32.const 0
+  i32.const 0
+  call $std/math/test_modf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 2515
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const 0
+  f32.const -1
+  f32.const 0
+  f32.const 0
+  i32.const 0
+  call $std/math/test_modf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 2516
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const -0
+  f32.const -1
+  f32.const -0
+  f32.const 0
+  i32.const 0
+  call $std/math/test_modf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 2517
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const 0.5
+  f32.const -1
+  f32.const 0.5
   f32.const 0
   i32.const 0
   call $std/math/test_modf
@@ -40608,9 +40949,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 0
+  f32.const -0.5
   f32.const -1
-  f32.const 0
+  f32.const -0.5
   f32.const 0
   i32.const 0
   call $std/math/test_modf
@@ -40619,51 +40960,6 @@
    i32.const 0
    i32.const 32
    i32.const 2519
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const -0
-  f32.const -1
-  f32.const -0
-  f32.const 0
-  i32.const 0
-  call $std/math/test_modf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 2520
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const 0.5
-  f32.const -1
-  f32.const 0.5
-  f32.const 0
-  i32.const 0
-  call $std/math/test_modf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 2521
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const -0.5
-  f32.const -1
-  f32.const -0.5
-  f32.const 0
-  i32.const 0
-  call $std/math/test_modf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 2522
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -40678,7 +40974,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2523
+   i32.const 2520
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -40693,7 +40989,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2524
+   i32.const 2521
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -40708,7 +41004,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2525
+   i32.const 2522
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -40723,7 +41019,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2526
+   i32.const 2523
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -40738,7 +41034,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2527
+   i32.const 2524
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -40753,13 +41049,59 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2528
+   i32.const 2525
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f32.const inf
   f32.const -1
+  f32.const nan:0x400000
+  f32.const 0
+  global.get $std/math/INVALID
+  call $std/math/test_modf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 2526
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const inf
+  f32.neg
+  f32.const -1
+  f32.const nan:0x400000
+  f32.const 0
+  global.get $std/math/INVALID
+  call $std/math/test_modf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 2527
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const nan:0x400000
+  f32.const -1
+  f32.const nan:0x400000
+  f32.const 0
+  i32.const 0
+  call $std/math/test_modf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 2528
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const 0
+  f32.const 0
   f32.const nan:0x400000
   f32.const 0
   global.get $std/math/INVALID
@@ -40773,9 +41115,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const inf
-  f32.neg
-  f32.const -1
+  f32.const 0
+  f32.const -0
   f32.const nan:0x400000
   f32.const 0
   global.get $std/math/INVALID
@@ -40789,9 +41130,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const nan:0x400000
-  f32.const -1
-  f32.const nan:0x400000
+  f32.const 0
+  f32.const inf
+  f32.const 0
   f32.const 0
   i32.const 0
   call $std/math/test_modf
@@ -40805,10 +41146,11 @@
    unreachable
   end
   f32.const 0
+  f32.const inf
+  f32.neg
   f32.const 0
-  f32.const nan:0x400000
   f32.const 0
-  global.get $std/math/INVALID
+  i32.const 0
   call $std/math/test_modf
   i32.eqz
   if
@@ -40820,10 +41162,10 @@
    unreachable
   end
   f32.const 0
-  f32.const -0
+  f32.const nan:0x400000
   f32.const nan:0x400000
   f32.const 0
-  global.get $std/math/INVALID
+  i32.const 0
   call $std/math/test_modf
   i32.eqz
   if
@@ -40834,11 +41176,11 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f32.const -0
   f32.const 0
-  f32.const inf
+  f32.const nan:0x400000
   f32.const 0
-  f32.const 0
-  i32.const 0
+  global.get $std/math/INVALID
   call $std/math/test_modf
   i32.eqz
   if
@@ -40849,12 +41191,11 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f32.const -0
+  f32.const -0
+  f32.const nan:0x400000
   f32.const 0
-  f32.const inf
-  f32.neg
-  f32.const 0
-  f32.const 0
-  i32.const 0
+  global.get $std/math/INVALID
   call $std/math/test_modf
   i32.eqz
   if
@@ -40865,9 +41206,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 0
-  f32.const nan:0x400000
-  f32.const nan:0x400000
+  f32.const -0
+  f32.const inf
+  f32.const -0
   f32.const 0
   i32.const 0
   call $std/math/test_modf
@@ -40881,10 +41222,11 @@
    unreachable
   end
   f32.const -0
+  f32.const inf
+  f32.neg
+  f32.const -0
   f32.const 0
-  f32.const nan:0x400000
-  f32.const 0
-  global.get $std/math/INVALID
+  i32.const 0
   call $std/math/test_modf
   i32.eqz
   if
@@ -40896,10 +41238,10 @@
    unreachable
   end
   f32.const -0
-  f32.const -0
+  f32.const nan:0x400000
   f32.const nan:0x400000
   f32.const 0
-  global.get $std/math/INVALID
+  i32.const 0
   call $std/math/test_modf
   i32.eqz
   if
@@ -40910,11 +41252,11 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -0
-  f32.const inf
-  f32.const -0
+  f32.const 1
   f32.const 0
-  i32.const 0
+  f32.const nan:0x400000
+  f32.const 0
+  global.get $std/math/INVALID
   call $std/math/test_modf
   i32.eqz
   if
@@ -40925,12 +41267,11 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -0
-  f32.const inf
-  f32.neg
-  f32.const -0
+  f32.const -1
   f32.const 0
-  i32.const 0
+  f32.const nan:0x400000
+  f32.const 0
+  global.get $std/math/INVALID
   call $std/math/test_modf
   i32.eqz
   if
@@ -40941,11 +41282,11 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -0
-  f32.const nan:0x400000
+  f32.const inf
+  f32.const 0
   f32.const nan:0x400000
   f32.const 0
-  i32.const 0
+  global.get $std/math/INVALID
   call $std/math/test_modf
   i32.eqz
   if
@@ -40956,7 +41297,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 1
+  f32.const inf
+  f32.neg
   f32.const 0
   f32.const nan:0x400000
   f32.const 0
@@ -40971,11 +41313,11 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -1
+  f32.const nan:0x400000
   f32.const 0
   f32.const nan:0x400000
   f32.const 0
-  global.get $std/math/INVALID
+  i32.const 0
   call $std/math/test_modf
   i32.eqz
   if
@@ -40986,8 +41328,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const inf
-  f32.const 0
+  f32.const -1
+  f32.const -0
   f32.const nan:0x400000
   f32.const 0
   global.get $std/math/INVALID
@@ -41002,8 +41344,7 @@
    unreachable
   end
   f32.const inf
-  f32.neg
-  f32.const 0
+  f32.const -0
   f32.const nan:0x400000
   f32.const 0
   global.get $std/math/INVALID
@@ -41017,11 +41358,12 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f32.const inf
+  f32.neg
+  f32.const -0
   f32.const nan:0x400000
   f32.const 0
-  f32.const nan:0x400000
-  f32.const 0
-  i32.const 0
+  global.get $std/math/INVALID
   call $std/math/test_modf
   i32.eqz
   if
@@ -41032,11 +41374,11 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -1
+  f32.const nan:0x400000
   f32.const -0
   f32.const nan:0x400000
   f32.const 0
-  global.get $std/math/INVALID
+  i32.const 0
   call $std/math/test_modf
   i32.eqz
   if
@@ -41048,7 +41390,7 @@
    unreachable
   end
   f32.const inf
-  f32.const -0
+  f32.const 2
   f32.const nan:0x400000
   f32.const 0
   global.get $std/math/INVALID
@@ -41063,8 +41405,7 @@
    unreachable
   end
   f32.const inf
-  f32.neg
-  f32.const -0
+  f32.const -0.5
   f32.const nan:0x400000
   f32.const 0
   global.get $std/math/INVALID
@@ -41078,8 +41419,8 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f32.const inf
   f32.const nan:0x400000
-  f32.const -0
   f32.const nan:0x400000
   f32.const 0
   i32.const 0
@@ -41094,6 +41435,7 @@
    unreachable
   end
   f32.const inf
+  f32.neg
   f32.const 2
   f32.const nan:0x400000
   f32.const 0
@@ -41109,6 +41451,7 @@
    unreachable
   end
   f32.const inf
+  f32.neg
   f32.const -0.5
   f32.const nan:0x400000
   f32.const 0
@@ -41124,6 +41467,7 @@
    unreachable
   end
   f32.const inf
+  f32.neg
   f32.const nan:0x400000
   f32.const nan:0x400000
   f32.const 0
@@ -41138,12 +41482,11 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const inf
-  f32.neg
-  f32.const 2
+  f32.const nan:0x400000
+  f32.const nan:0x400000
   f32.const nan:0x400000
   f32.const 0
-  global.get $std/math/INVALID
+  i32.const 0
   call $std/math/test_modf
   i32.eqz
   if
@@ -41154,12 +41497,11 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const inf
-  f32.neg
-  f32.const -0.5
+  f32.const 1
+  f32.const nan:0x400000
   f32.const nan:0x400000
   f32.const 0
-  global.get $std/math/INVALID
+  i32.const 0
   call $std/math/test_modf
   i32.eqz
   if
@@ -41170,8 +41512,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const inf
-  f32.neg
+  f32.const -1
   f32.const nan:0x400000
   f32.const nan:0x400000
   f32.const 0
@@ -41186,9 +41527,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const nan:0x400000
-  f32.const nan:0x400000
-  f32.const nan:0x400000
+  f32.const 1
+  f32.const inf
+  f32.const 1
   f32.const 0
   i32.const 0
   call $std/math/test_modf
@@ -41201,9 +41542,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 1
-  f32.const nan:0x400000
-  f32.const nan:0x400000
+  f32.const -1
+  f32.const inf
+  f32.const -1
   f32.const 0
   i32.const 0
   call $std/math/test_modf
@@ -41212,51 +41553,6 @@
    i32.const 0
    i32.const 32
    i32.const 2558
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const -1
-  f32.const nan:0x400000
-  f32.const nan:0x400000
-  f32.const 0
-  i32.const 0
-  call $std/math/test_modf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 2559
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const 1
-  f32.const inf
-  f32.const 1
-  f32.const 0
-  i32.const 0
-  call $std/math/test_modf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 2560
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const -1
-  f32.const inf
-  f32.const -1
-  f32.const 0
-  i32.const 0
-  call $std/math/test_modf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 2561
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -41271,7 +41567,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2562
+   i32.const 2559
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -41279,6 +41575,54 @@
   f32.const inf
   f32.neg
   f32.const inf
+  f32.const nan:0x400000
+  f32.const 0
+  global.get $std/math/INVALID
+  call $std/math/test_modf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 2560
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const 1
+  f32.const inf
+  f32.neg
+  f32.const 1
+  f32.const 0
+  i32.const 0
+  call $std/math/test_modf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 2561
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const -1
+  f32.const inf
+  f32.neg
+  f32.const -1
+  f32.const 0
+  i32.const 0
+  call $std/math/test_modf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 2562
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const inf
+  f32.const inf
+  f32.neg
   f32.const nan:0x400000
   f32.const 0
   global.get $std/math/INVALID
@@ -41292,12 +41636,13 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 1
   f32.const inf
   f32.neg
-  f32.const 1
+  f32.const inf
+  f32.neg
+  f32.const nan:0x400000
   f32.const 0
-  i32.const 0
+  global.get $std/math/INVALID
   call $std/math/test_modf
   i32.eqz
   if
@@ -41308,10 +41653,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -1
-  f32.const inf
-  f32.neg
-  f32.const -1
+  f32.const 1.75
+  f32.const 0.5
+  f32.const 0.25
   f32.const 0
   i32.const 0
   call $std/math/test_modf
@@ -41324,12 +41668,11 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const inf
-  f32.const inf
-  f32.neg
-  f32.const nan:0x400000
+  f32.const -1.75
+  f32.const 0.5
+  f32.const -0.25
   f32.const 0
-  global.get $std/math/INVALID
+  i32.const 0
   call $std/math/test_modf
   i32.eqz
   if
@@ -41340,13 +41683,11 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const inf
-  f32.neg
-  f32.const inf
-  f32.neg
-  f32.const nan:0x400000
+  f32.const 1.75
+  f32.const -0.5
+  f32.const 0.25
   f32.const 0
-  global.get $std/math/INVALID
+  i32.const 0
   call $std/math/test_modf
   i32.eqz
   if
@@ -41357,9 +41698,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 1.75
-  f32.const 0.5
-  f32.const 0.25
+  f32.const -1.75
+  f32.const -0.5
+  f32.const -0.25
   f32.const 0
   i32.const 0
   call $std/math/test_modf
@@ -41368,51 +41709,6 @@
    i32.const 0
    i32.const 32
    i32.const 2568
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const -1.75
-  f32.const 0.5
-  f32.const -0.25
-  f32.const 0
-  i32.const 0
-  call $std/math/test_modf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 2569
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const 1.75
-  f32.const -0.5
-  f32.const 0.25
-  f32.const 0
-  i32.const 0
-  call $std/math/test_modf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 2570
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const -1.75
-  f32.const -0.5
-  f32.const -0.25
-  f32.const 0
-  i32.const 0
-  call $std/math/test_modf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 2571
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -41427,7 +41723,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2583
+   i32.const 2580
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -41442,7 +41738,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2584
+   i32.const 2581
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -41457,7 +41753,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2585
+   i32.const 2582
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -41472,7 +41768,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2586
+   i32.const 2583
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -41487,7 +41783,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2587
+   i32.const 2584
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -41502,7 +41798,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2588
+   i32.const 2585
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -41517,7 +41813,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2589
+   i32.const 2586
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -41532,7 +41828,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2590
+   i32.const 2587
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -41547,7 +41843,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2591
+   i32.const 2588
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -41562,7 +41858,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2592
+   i32.const 2589
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -41577,13 +41873,58 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2595
+   i32.const 2592
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f64.const 0
   f64.const inf
+  f64.const 0
+  f64.const 0
+  i32.const 0
+  call $std/math/test_pow
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 2593
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const 0
+  f64.const 3
+  f64.const 0
+  f64.const 0
+  i32.const 0
+  call $std/math/test_pow
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 2594
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const 0
+  f64.const 2
+  f64.const 0
+  f64.const 0
+  i32.const 0
+  call $std/math/test_pow
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 2595
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const 0
+  f64.const 1
   f64.const 0
   f64.const 0
   i32.const 0
@@ -41598,7 +41939,7 @@
    unreachable
   end
   f64.const 0
-  f64.const 3
+  f64.const 0.5
   f64.const 0
   f64.const 0
   i32.const 0
@@ -41613,8 +41954,8 @@
    unreachable
   end
   f64.const 0
-  f64.const 2
   f64.const 0
+  f64.const 1
   f64.const 0
   i32.const 0
   call $std/math/test_pow
@@ -41623,51 +41964,6 @@
    i32.const 0
    i32.const 32
    i32.const 2598
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const 0
-  f64.const 1
-  f64.const 0
-  f64.const 0
-  i32.const 0
-  call $std/math/test_pow
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 2599
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const 0
-  f64.const 0.5
-  f64.const 0
-  f64.const 0
-  i32.const 0
-  call $std/math/test_pow
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 2600
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const 0
-  f64.const 0
-  f64.const 1
-  f64.const 0
-  i32.const 0
-  call $std/math/test_pow
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 2601
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -41682,13 +41978,58 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2602
+   i32.const 2599
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f64.const 0
   f64.const -0.5
+  f64.const inf
+  f64.const 0
+  global.get $std/math/DIVBYZERO
+  call $std/math/test_pow
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 2600
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const 0
+  f64.const -1
+  f64.const inf
+  f64.const 0
+  global.get $std/math/DIVBYZERO
+  call $std/math/test_pow
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 2601
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const 0
+  f64.const -2
+  f64.const inf
+  f64.const 0
+  global.get $std/math/DIVBYZERO
+  call $std/math/test_pow
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 2602
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const 0
+  f64.const -3
   f64.const inf
   f64.const 0
   global.get $std/math/DIVBYZERO
@@ -41703,7 +42044,7 @@
    unreachable
   end
   f64.const 0
-  f64.const -1
+  f64.const -4
   f64.const inf
   f64.const 0
   global.get $std/math/DIVBYZERO
@@ -41718,51 +42059,6 @@
    unreachable
   end
   f64.const 0
-  f64.const -2
-  f64.const inf
-  f64.const 0
-  global.get $std/math/DIVBYZERO
-  call $std/math/test_pow
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 2605
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const 0
-  f64.const -3
-  f64.const inf
-  f64.const 0
-  global.get $std/math/DIVBYZERO
-  call $std/math/test_pow
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 2606
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const 0
-  f64.const -4
-  f64.const inf
-  f64.const 0
-  global.get $std/math/DIVBYZERO
-  call $std/math/test_pow
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 2607
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const 0
   f64.const inf
   f64.neg
   f64.const inf
@@ -41773,7 +42069,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2608
+   i32.const 2605
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -41788,7 +42084,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2609
+   i32.const 2606
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -41803,7 +42099,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2610
+   i32.const 2607
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -41818,7 +42114,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2611
+   i32.const 2608
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -41833,7 +42129,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2612
+   i32.const 2609
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -41848,7 +42144,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2613
+   i32.const 2610
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -41863,7 +42159,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2614
+   i32.const 2611
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -41878,7 +42174,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2615
+   i32.const 2612
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -41893,7 +42189,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2616
+   i32.const 2613
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -41908,7 +42204,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2617
+   i32.const 2614
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -41924,7 +42220,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2618
+   i32.const 2615
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -41939,7 +42235,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2619
+   i32.const 2616
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -41955,7 +42251,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2620
+   i32.const 2617
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -41970,7 +42266,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2621
+   i32.const 2618
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -41986,12 +42282,58 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2622
+   i32.const 2619
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f64.const nan:0x8000000000000
+  f64.const 0
+  f64.const 1
+  f64.const 0
+  i32.const 0
+  call $std/math/test_pow
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 2620
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const inf
+  f64.const 0
+  f64.const 1
+  f64.const 0
+  i32.const 0
+  call $std/math/test_pow
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 2621
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const inf
+  f64.neg
+  f64.const 0
+  f64.const 1
+  f64.const 0
+  i32.const 0
+  call $std/math/test_pow
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 2622
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const 1
   f64.const 0
   f64.const 1
   f64.const 0
@@ -42006,7 +42348,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const inf
+  f64.const -1
   f64.const 0
   f64.const 1
   f64.const 0
@@ -42021,8 +42363,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const inf
-  f64.neg
+  f64.const -0.5
   f64.const 0
   f64.const 1
   f64.const 0
@@ -42037,8 +42378,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 1
-  f64.const 0
+  f64.const nan:0x8000000000000
+  f64.const -0
   f64.const 1
   f64.const 0
   i32.const 0
@@ -42052,8 +42393,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -1
-  f64.const 0
+  f64.const inf
+  f64.const -0
   f64.const 1
   f64.const 0
   i32.const 0
@@ -42067,8 +42408,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -0.5
-  f64.const 0
+  f64.const inf
+  f64.neg
+  f64.const -0
   f64.const 1
   f64.const 0
   i32.const 0
@@ -42082,7 +42424,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const nan:0x8000000000000
+  f64.const 1
   f64.const -0
   f64.const 1
   f64.const 0
@@ -42097,7 +42439,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const inf
+  f64.const -1
   f64.const -0
   f64.const 1
   f64.const 0
@@ -42112,8 +42454,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const inf
-  f64.neg
+  f64.const -0.5
   f64.const -0
   f64.const 1
   f64.const 0
@@ -42128,9 +42469,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 1
-  f64.const -0
-  f64.const 1
+  f64.const -1
+  f64.const nan:0x8000000000000
+  f64.const nan:0x8000000000000
   f64.const 0
   i32.const 0
   call $std/math/test_pow
@@ -42139,51 +42480,6 @@
    i32.const 0
    i32.const 32
    i32.const 2632
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const -1
-  f64.const -0
-  f64.const 1
-  f64.const 0
-  i32.const 0
-  call $std/math/test_pow
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 2633
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const -0.5
-  f64.const -0
-  f64.const 1
-  f64.const 0
-  i32.const 0
-  call $std/math/test_pow
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 2634
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const -1
-  f64.const nan:0x8000000000000
-  f64.const nan:0x8000000000000
-  f64.const 0
-  i32.const 0
-  call $std/math/test_pow
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 2635
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -42198,7 +42494,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2636
+   i32.const 2633
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -42214,7 +42510,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2637
+   i32.const 2634
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -42229,7 +42525,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2638
+   i32.const 2635
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -42244,7 +42540,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2639
+   i32.const 2636
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -42259,7 +42555,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2640
+   i32.const 2637
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -42274,7 +42570,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2641
+   i32.const 2638
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -42289,7 +42585,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2642
+   i32.const 2639
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -42304,7 +42600,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2643
+   i32.const 2640
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -42319,7 +42615,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2644
+   i32.const 2641
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -42335,7 +42631,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2645
+   i32.const 2642
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -42350,7 +42646,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2646
+   i32.const 2643
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -42365,7 +42661,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2647
+   i32.const 2644
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -42380,7 +42676,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2648
+   i32.const 2645
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -42395,7 +42691,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2649
+   i32.const 2646
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -42410,7 +42706,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2650
+   i32.const 2647
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -42425,7 +42721,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2651
+   i32.const 2648
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -42440,7 +42736,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2652
+   i32.const 2649
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -42455,7 +42751,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2653
+   i32.const 2650
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -42470,12 +42766,58 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2654
+   i32.const 2651
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f64.const -0.5
+  f64.const inf
+  f64.neg
+  f64.const inf
+  f64.const 0
+  i32.const 0
+  call $std/math/test_pow
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 2652
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const -0.5
+  f64.const nan:0x8000000000000
+  f64.const nan:0x8000000000000
+  f64.const 0
+  i32.const 0
+  call $std/math/test_pow
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 2653
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const 0.5
+  f64.const inf
+  f64.const 0
+  f64.const 0
+  i32.const 0
+  call $std/math/test_pow
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 2654
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const 0.5
   f64.const inf
   f64.neg
   f64.const inf
@@ -42491,7 +42833,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -0.5
+  f64.const 0.5
   f64.const nan:0x8000000000000
   f64.const nan:0x8000000000000
   f64.const 0
@@ -42506,9 +42848,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 0.5
+  f64.const 1.5
   f64.const inf
-  f64.const 0
+  f64.const inf
   f64.const 0
   i32.const 0
   call $std/math/test_pow
@@ -42521,10 +42863,10 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 0.5
+  f64.const 1.5
   f64.const inf
   f64.neg
-  f64.const inf
+  f64.const 0
   f64.const 0
   i32.const 0
   call $std/math/test_pow
@@ -42537,7 +42879,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 0.5
+  f64.const 1.5
   f64.const nan:0x8000000000000
   f64.const nan:0x8000000000000
   f64.const 0
@@ -42552,9 +42894,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 1.5
   f64.const inf
-  f64.const inf
+  f64.const nan:0x8000000000000
+  f64.const nan:0x8000000000000
   f64.const 0
   i32.const 0
   call $std/math/test_pow
@@ -42567,10 +42909,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 1.5
   f64.const inf
-  f64.neg
-  f64.const 0
+  f64.const inf
+  f64.const inf
   f64.const 0
   i32.const 0
   call $std/math/test_pow
@@ -42583,51 +42924,6 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 1.5
-  f64.const nan:0x8000000000000
-  f64.const nan:0x8000000000000
-  f64.const 0
-  i32.const 0
-  call $std/math/test_pow
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 2662
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const inf
-  f64.const nan:0x8000000000000
-  f64.const nan:0x8000000000000
-  f64.const 0
-  i32.const 0
-  call $std/math/test_pow
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 2663
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const inf
-  f64.const inf
-  f64.const inf
-  f64.const 0
-  i32.const 0
-  call $std/math/test_pow
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 2664
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
   f64.const inf
   f64.const inf
   f64.neg
@@ -42639,7 +42935,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2665
+   i32.const 2662
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -42654,7 +42950,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2666
+   i32.const 2663
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -42669,7 +42965,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2667
+   i32.const 2664
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -42684,7 +42980,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2668
+   i32.const 2665
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -42699,7 +42995,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2669
+   i32.const 2666
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -42714,7 +43010,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2670
+   i32.const 2667
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -42729,13 +43025,62 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2671
+   i32.const 2668
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f64.const inf
   f64.const -2
+  f64.const 0
+  f64.const 0
+  i32.const 0
+  call $std/math/test_pow
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 2669
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const inf
+  f64.neg
+  f64.const nan:0x8000000000000
+  f64.const nan:0x8000000000000
+  f64.const 0
+  i32.const 0
+  call $std/math/test_pow
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 2670
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const inf
+  f64.neg
+  f64.const inf
+  f64.const inf
+  f64.const 0
+  i32.const 0
+  call $std/math/test_pow
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 2671
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const inf
+  f64.neg
+  f64.const inf
+  f64.neg
   f64.const 0
   f64.const 0
   i32.const 0
@@ -42751,8 +43096,9 @@
   end
   f64.const inf
   f64.neg
-  f64.const nan:0x8000000000000
-  f64.const nan:0x8000000000000
+  f64.const 3
+  f64.const inf
+  f64.neg
   f64.const 0
   i32.const 0
   call $std/math/test_pow
@@ -42767,7 +43113,7 @@
   end
   f64.const inf
   f64.neg
-  f64.const inf
+  f64.const 2
   f64.const inf
   f64.const 0
   i32.const 0
@@ -42783,9 +43129,9 @@
   end
   f64.const inf
   f64.neg
+  f64.const 1
   f64.const inf
   f64.neg
-  f64.const 0
   f64.const 0
   i32.const 0
   call $std/math/test_pow
@@ -42800,9 +43146,8 @@
   end
   f64.const inf
   f64.neg
-  f64.const 3
+  f64.const 0.5
   f64.const inf
-  f64.neg
   f64.const 0
   i32.const 0
   call $std/math/test_pow
@@ -42817,8 +43162,8 @@
   end
   f64.const inf
   f64.neg
-  f64.const 2
-  f64.const inf
+  f64.const -0.5
+  f64.const 0
   f64.const 0
   i32.const 0
   call $std/math/test_pow
@@ -42833,9 +43178,8 @@
   end
   f64.const inf
   f64.neg
-  f64.const 1
-  f64.const inf
-  f64.neg
+  f64.const -1
+  f64.const -0
   f64.const 0
   i32.const 0
   call $std/math/test_pow
@@ -42850,8 +43194,8 @@
   end
   f64.const inf
   f64.neg
-  f64.const 0.5
-  f64.const inf
+  f64.const -2
+  f64.const 0
   f64.const 0
   i32.const 0
   call $std/math/test_pow
@@ -42864,10 +43208,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const inf
-  f64.neg
-  f64.const -0.5
-  f64.const 0
+  f64.const nan:0x8000000000000
+  f64.const 1
+  f64.const nan:0x8000000000000
   f64.const 0
   i32.const 0
   call $std/math/test_pow
@@ -42880,10 +43223,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const inf
-  f64.neg
+  f64.const nan:0x8000000000000
   f64.const -1
-  f64.const -0
+  f64.const nan:0x8000000000000
   f64.const 0
   i32.const 0
   call $std/math/test_pow
@@ -42896,10 +43238,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const inf
-  f64.neg
   f64.const -2
-  f64.const 0
+  f64.const 1
+  f64.const -2
   f64.const 0
   i32.const 0
   call $std/math/test_pow
@@ -42908,51 +43249,6 @@
    i32.const 0
    i32.const 32
    i32.const 2682
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const nan:0x8000000000000
-  f64.const 1
-  f64.const nan:0x8000000000000
-  f64.const 0
-  i32.const 0
-  call $std/math/test_pow
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 2683
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const nan:0x8000000000000
-  f64.const -1
-  f64.const nan:0x8000000000000
-  f64.const 0
-  i32.const 0
-  call $std/math/test_pow
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 2684
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const -2
-  f64.const 1
-  f64.const -2
-  f64.const 0
-  i32.const 0
-  call $std/math/test_pow
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 2685
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -42967,14 +43263,124 @@
   if
    i32.const 0
    i32.const 32
+   i32.const 2683
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  block $~lib/math/NativeMath.pow<f64>|inlined.1 (result f64)
+   f64.const 0
+   local.set $1
+   f64.const 0
+   local.set $0
+   i32.const 1
+   drop
+   i32.const 8
+   i32.const 4
+   i32.eq
+   drop
+   i32.const 8
+   i32.const 8
+   i32.eq
+   drop
+   local.get $1
+   local.get $0
+   call $~lib/util/math/pow64
+   br $~lib/math/NativeMath.pow<f64>|inlined.1
+  end
+  f64.const 1
+  f64.eq
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
    i32.const 2686
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 0
-  f64.const 0
-  call $~lib/math/NativeMath.pow
+  block $~lib/math/NativeMath.pow<f64>|inlined.2 (result f64)
+   f64.const -0
+   local.set $1
+   f64.const 0
+   local.set $0
+   i32.const 1
+   drop
+   i32.const 8
+   i32.const 4
+   i32.eq
+   drop
+   i32.const 8
+   i32.const 8
+   i32.eq
+   drop
+   local.get $1
+   local.get $0
+   call $~lib/util/math/pow64
+   br $~lib/math/NativeMath.pow<f64>|inlined.2
+  end
+  f64.const 1
+  f64.eq
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 2687
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  block $~lib/math/NativeMath.pow<f64>|inlined.3 (result f64)
+   f64.const -0
+   local.set $1
+   f64.const -0
+   local.set $0
+   i32.const 1
+   drop
+   i32.const 8
+   i32.const 4
+   i32.eq
+   drop
+   i32.const 8
+   i32.const 8
+   i32.eq
+   drop
+   local.get $1
+   local.get $0
+   call $~lib/util/math/pow64
+   br $~lib/math/NativeMath.pow<f64>|inlined.3
+  end
+  f64.const 1
+  f64.eq
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 2688
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  block $~lib/math/NativeMath.pow<f64>|inlined.4 (result f64)
+   f64.const 0
+   local.set $1
+   f64.const -0
+   local.set $0
+   i32.const 1
+   drop
+   i32.const 8
+   i32.const 4
+   i32.eq
+   drop
+   i32.const 8
+   i32.const 8
+   i32.eq
+   drop
+   local.get $1
+   local.get $0
+   call $~lib/util/math/pow64
+   br $~lib/math/NativeMath.pow<f64>|inlined.4
+  end
   f64.const 1
   f64.eq
   i32.eqz
@@ -42986,9 +43392,26 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -0
-  f64.const 0
-  call $~lib/math/NativeMath.pow
+  block $~lib/math/NativeMath.pow<f64>|inlined.5 (result f64)
+   f64.const -1
+   local.set $1
+   f64.const 0
+   local.set $0
+   i32.const 1
+   drop
+   i32.const 8
+   i32.const 4
+   i32.eq
+   drop
+   i32.const 8
+   i32.const 8
+   i32.eq
+   drop
+   local.get $1
+   local.get $0
+   call $~lib/util/math/pow64
+   br $~lib/math/NativeMath.pow<f64>|inlined.5
+  end
   f64.const 1
   f64.eq
   i32.eqz
@@ -43000,9 +43423,26 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -0
-  f64.const -0
-  call $~lib/math/NativeMath.pow
+  block $~lib/math/NativeMath.pow<f64>|inlined.6 (result f64)
+   f64.const inf
+   local.set $1
+   f64.const 0
+   local.set $0
+   i32.const 1
+   drop
+   i32.const 8
+   i32.const 4
+   i32.eq
+   drop
+   i32.const 8
+   i32.const 8
+   i32.eq
+   drop
+   local.get $1
+   local.get $0
+   call $~lib/util/math/pow64
+   br $~lib/math/NativeMath.pow<f64>|inlined.6
+  end
   f64.const 1
   f64.eq
   i32.eqz
@@ -43014,9 +43454,27 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 0
-  f64.const -0
-  call $~lib/math/NativeMath.pow
+  block $~lib/math/NativeMath.pow<f64>|inlined.7 (result f64)
+   f64.const inf
+   f64.neg
+   local.set $1
+   f64.const 0
+   local.set $0
+   i32.const 1
+   drop
+   i32.const 8
+   i32.const 4
+   i32.eq
+   drop
+   i32.const 8
+   i32.const 8
+   i32.eq
+   drop
+   local.get $1
+   local.get $0
+   call $~lib/util/math/pow64
+   br $~lib/math/NativeMath.pow<f64>|inlined.7
+  end
   f64.const 1
   f64.eq
   i32.eqz
@@ -43028,9 +43486,26 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -1
-  f64.const 0
-  call $~lib/math/NativeMath.pow
+  block $~lib/math/NativeMath.pow<f64>|inlined.8 (result f64)
+   f64.const nan:0x8000000000000
+   local.set $1
+   f64.const 0
+   local.set $0
+   i32.const 1
+   drop
+   i32.const 8
+   i32.const 4
+   i32.eq
+   drop
+   i32.const 8
+   i32.const 8
+   i32.eq
+   drop
+   local.get $1
+   local.get $0
+   call $~lib/util/math/pow64
+   br $~lib/math/NativeMath.pow<f64>|inlined.8
+  end
   f64.const 1
   f64.eq
   i32.eqz
@@ -43042,25 +43517,27 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const inf
-  f64.const 0
-  call $~lib/math/NativeMath.pow
-  f64.const 1
-  f64.eq
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 2694
+  block $~lib/math/NativeMath.pow<f64>|inlined.9 (result f64)
+   f64.const 0
+   local.set $1
+   f64.const 1
+   local.set $0
    i32.const 1
-   call $~lib/builtins/abort
-   unreachable
+   drop
+   i32.const 8
+   i32.const 4
+   i32.eq
+   drop
+   i32.const 8
+   i32.const 8
+   i32.eq
+   drop
+   local.get $1
+   local.get $0
+   call $~lib/util/math/pow64
+   br $~lib/math/NativeMath.pow<f64>|inlined.9
   end
-  f64.const inf
-  f64.neg
   f64.const 0
-  call $~lib/math/NativeMath.pow
-  f64.const 1
   f64.eq
   i32.eqz
   if
@@ -43071,10 +43548,27 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const nan:0x8000000000000
-  f64.const 0
-  call $~lib/math/NativeMath.pow
-  f64.const 1
+  block $~lib/math/NativeMath.pow<f64>|inlined.10 (result f64)
+   f64.const -0
+   local.set $1
+   f64.const 1
+   local.set $0
+   i32.const 1
+   drop
+   i32.const 8
+   i32.const 4
+   i32.eq
+   drop
+   i32.const 8
+   i32.const 8
+   i32.eq
+   drop
+   local.get $1
+   local.get $0
+   call $~lib/util/math/pow64
+   br $~lib/math/NativeMath.pow<f64>|inlined.10
+  end
+  f64.const -0
   f64.eq
   i32.eqz
   if
@@ -43085,10 +43579,58 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 0
-  f64.const 1
-  call $~lib/math/NativeMath.pow
-  f64.const 0
+  block $~lib/math/NativeMath.pow<f64>|inlined.11 (result f64)
+   f64.const -1
+   local.set $1
+   f64.const 1
+   local.set $0
+   i32.const 1
+   drop
+   i32.const 8
+   i32.const 4
+   i32.eq
+   drop
+   i32.const 8
+   i32.const 8
+   i32.eq
+   drop
+   local.get $1
+   local.get $0
+   call $~lib/util/math/pow64
+   br $~lib/math/NativeMath.pow<f64>|inlined.11
+  end
+  f64.const -1
+  f64.eq
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 2697
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  block $~lib/math/NativeMath.pow<f64>|inlined.12 (result f64)
+   f64.const inf
+   local.set $1
+   f64.const 1
+   local.set $0
+   i32.const 1
+   drop
+   i32.const 8
+   i32.const 4
+   i32.eq
+   drop
+   i32.const 8
+   i32.const 8
+   i32.eq
+   drop
+   local.get $1
+   local.get $0
+   call $~lib/util/math/pow64
+   br $~lib/math/NativeMath.pow<f64>|inlined.12
+  end
+  f64.const inf
   f64.eq
   i32.eqz
   if
@@ -43099,10 +43641,29 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -0
-  f64.const 1
-  call $~lib/math/NativeMath.pow
-  f64.const -0
+  block $~lib/math/NativeMath.pow<f64>|inlined.13 (result f64)
+   f64.const inf
+   f64.neg
+   local.set $1
+   f64.const 1
+   local.set $0
+   i32.const 1
+   drop
+   i32.const 8
+   i32.const 4
+   i32.eq
+   drop
+   i32.const 8
+   i32.const 8
+   i32.eq
+   drop
+   local.get $1
+   local.get $0
+   call $~lib/util/math/pow64
+   br $~lib/math/NativeMath.pow<f64>|inlined.13
+  end
+  f64.const inf
+  f64.neg
   f64.eq
   i32.eqz
   if
@@ -43113,11 +43674,29 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -1
-  f64.const 1
-  call $~lib/math/NativeMath.pow
-  f64.const -1
-  f64.eq
+  block $~lib/math/NativeMath.pow<f64>|inlined.14 (result f64)
+   f64.const nan:0x8000000000000
+   local.set $1
+   f64.const 1
+   local.set $0
+   i32.const 1
+   drop
+   i32.const 8
+   i32.const 4
+   i32.eq
+   drop
+   i32.const 8
+   i32.const 8
+   i32.eq
+   drop
+   local.get $1
+   local.get $0
+   call $~lib/util/math/pow64
+   br $~lib/math/NativeMath.pow<f64>|inlined.14
+  end
+  local.tee $1
+  local.get $1
+  f64.ne
   i32.eqz
   if
    i32.const 0
@@ -43127,26 +43706,27 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const inf
-  f64.const 1
-  call $~lib/math/NativeMath.pow
-  f64.const inf
-  f64.eq
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 2701
+  block $~lib/math/NativeMath.pow<f64>|inlined.15 (result f64)
+   f64.const 0
+   local.set $1
+   f64.const -1
+   local.set $0
    i32.const 1
-   call $~lib/builtins/abort
-   unreachable
+   drop
+   i32.const 8
+   i32.const 4
+   i32.eq
+   drop
+   i32.const 8
+   i32.const 8
+   i32.eq
+   drop
+   local.get $1
+   local.get $0
+   call $~lib/util/math/pow64
+   br $~lib/math/NativeMath.pow<f64>|inlined.15
   end
   f64.const inf
-  f64.neg
-  f64.const 1
-  call $~lib/math/NativeMath.pow
-  f64.const inf
-  f64.neg
   f64.eq
   i32.eqz
   if
@@ -43157,12 +43737,29 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const nan:0x8000000000000
-  f64.const 1
-  call $~lib/math/NativeMath.pow
-  local.tee $0
-  local.get $0
-  f64.ne
+  block $~lib/math/NativeMath.pow<f64>|inlined.16 (result f64)
+   f64.const -0
+   local.set $1
+   f64.const -1
+   local.set $0
+   i32.const 1
+   drop
+   i32.const 8
+   i32.const 4
+   i32.eq
+   drop
+   i32.const 8
+   i32.const 8
+   i32.eq
+   drop
+   local.get $1
+   local.get $0
+   call $~lib/util/math/pow64
+   br $~lib/math/NativeMath.pow<f64>|inlined.16
+  end
+  f64.const inf
+  f64.neg
+  f64.eq
   i32.eqz
   if
    i32.const 0
@@ -43172,10 +43769,58 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 0
+  block $~lib/math/NativeMath.pow<f64>|inlined.17 (result f64)
+   f64.const -1
+   local.set $1
+   f64.const -1
+   local.set $0
+   i32.const 1
+   drop
+   i32.const 8
+   i32.const 4
+   i32.eq
+   drop
+   i32.const 8
+   i32.const 8
+   i32.eq
+   drop
+   local.get $1
+   local.get $0
+   call $~lib/util/math/pow64
+   br $~lib/math/NativeMath.pow<f64>|inlined.17
+  end
   f64.const -1
-  call $~lib/math/NativeMath.pow
-  f64.const inf
+  f64.eq
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 2704
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  block $~lib/math/NativeMath.pow<f64>|inlined.18 (result f64)
+   f64.const 0.5
+   local.set $1
+   f64.const -1
+   local.set $0
+   i32.const 1
+   drop
+   i32.const 8
+   i32.const 4
+   i32.eq
+   drop
+   i32.const 8
+   i32.const 8
+   i32.eq
+   drop
+   local.get $1
+   local.get $0
+   call $~lib/util/math/pow64
+   br $~lib/math/NativeMath.pow<f64>|inlined.18
+  end
+  f64.const 2
   f64.eq
   i32.eqz
   if
@@ -43186,11 +43831,27 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -0
-  f64.const -1
-  call $~lib/math/NativeMath.pow
-  f64.const inf
-  f64.neg
+  block $~lib/math/NativeMath.pow<f64>|inlined.19 (result f64)
+   f64.const 1
+   local.set $1
+   f64.const -1
+   local.set $0
+   i32.const 1
+   drop
+   i32.const 8
+   i32.const 4
+   i32.eq
+   drop
+   i32.const 8
+   i32.const 8
+   i32.eq
+   drop
+   local.get $1
+   local.get $0
+   call $~lib/util/math/pow64
+   br $~lib/math/NativeMath.pow<f64>|inlined.19
+  end
+  f64.const 1
   f64.eq
   i32.eqz
   if
@@ -43201,10 +43862,27 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -1
-  f64.const -1
-  call $~lib/math/NativeMath.pow
-  f64.const -1
+  block $~lib/math/NativeMath.pow<f64>|inlined.20 (result f64)
+   f64.const inf
+   local.set $1
+   f64.const -1
+   local.set $0
+   i32.const 1
+   drop
+   i32.const 8
+   i32.const 4
+   i32.eq
+   drop
+   i32.const 8
+   i32.const 8
+   i32.eq
+   drop
+   local.get $1
+   local.get $0
+   call $~lib/util/math/pow64
+   br $~lib/math/NativeMath.pow<f64>|inlined.20
+  end
+  f64.const 0
   f64.eq
   i32.eqz
   if
@@ -43215,10 +43893,28 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 0.5
-  f64.const -1
-  call $~lib/math/NativeMath.pow
-  f64.const 2
+  block $~lib/math/NativeMath.pow<f64>|inlined.21 (result f64)
+   f64.const inf
+   f64.neg
+   local.set $1
+   f64.const -1
+   local.set $0
+   i32.const 1
+   drop
+   i32.const 8
+   i32.const 4
+   i32.eq
+   drop
+   i32.const 8
+   i32.const 8
+   i32.eq
+   drop
+   local.get $1
+   local.get $0
+   call $~lib/util/math/pow64
+   br $~lib/math/NativeMath.pow<f64>|inlined.21
+  end
+  f64.const -0
   f64.eq
   i32.eqz
   if
@@ -43229,11 +43925,29 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 1
-  f64.const -1
-  call $~lib/math/NativeMath.pow
-  f64.const 1
-  f64.eq
+  block $~lib/math/NativeMath.pow<f64>|inlined.22 (result f64)
+   f64.const nan:0x8000000000000
+   local.set $1
+   f64.const -1
+   local.set $0
+   i32.const 1
+   drop
+   i32.const 8
+   i32.const 4
+   i32.eq
+   drop
+   i32.const 8
+   i32.const 8
+   i32.eq
+   drop
+   local.get $1
+   local.get $0
+   call $~lib/util/math/pow64
+   br $~lib/math/NativeMath.pow<f64>|inlined.22
+  end
+  local.tee $1
+  local.get $1
+  f64.ne
   i32.eqz
   if
    i32.const 0
@@ -43243,25 +43957,27 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const inf
-  f64.const -1
-  call $~lib/math/NativeMath.pow
-  f64.const 0
-  f64.eq
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 2710
+  block $~lib/math/NativeMath.pow<f64>|inlined.23 (result f64)
+   f64.const 0
+   local.set $1
+   f64.const 2
+   local.set $0
    i32.const 1
-   call $~lib/builtins/abort
-   unreachable
+   drop
+   i32.const 8
+   i32.const 4
+   i32.eq
+   drop
+   i32.const 8
+   i32.const 8
+   i32.eq
+   drop
+   local.get $1
+   local.get $0
+   call $~lib/util/math/pow64
+   br $~lib/math/NativeMath.pow<f64>|inlined.23
   end
-  f64.const inf
-  f64.neg
-  f64.const -1
-  call $~lib/math/NativeMath.pow
-  f64.const -0
+  f64.const 0
   f64.eq
   i32.eqz
   if
@@ -43272,12 +43988,28 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const nan:0x8000000000000
-  f64.const -1
-  call $~lib/math/NativeMath.pow
-  local.tee $0
-  local.get $0
-  f64.ne
+  block $~lib/math/NativeMath.pow<f64>|inlined.24 (result f64)
+   f64.const -0
+   local.set $1
+   f64.const 2
+   local.set $0
+   i32.const 1
+   drop
+   i32.const 8
+   i32.const 4
+   i32.eq
+   drop
+   i32.const 8
+   i32.const 8
+   i32.eq
+   drop
+   local.get $1
+   local.get $0
+   call $~lib/util/math/pow64
+   br $~lib/math/NativeMath.pow<f64>|inlined.24
+  end
+  f64.const 0
+  f64.eq
   i32.eqz
   if
    i32.const 0
@@ -43287,10 +44019,58 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 0
-  f64.const 2
-  call $~lib/math/NativeMath.pow
-  f64.const 0
+  block $~lib/math/NativeMath.pow<f64>|inlined.25 (result f64)
+   f64.const -1
+   local.set $1
+   f64.const 2
+   local.set $0
+   i32.const 1
+   drop
+   i32.const 8
+   i32.const 4
+   i32.eq
+   drop
+   i32.const 8
+   i32.const 8
+   i32.eq
+   drop
+   local.get $1
+   local.get $0
+   call $~lib/util/math/pow64
+   br $~lib/math/NativeMath.pow<f64>|inlined.25
+  end
+  f64.const 1
+  f64.eq
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 2713
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  block $~lib/math/NativeMath.pow<f64>|inlined.26 (result f64)
+   f64.const 0.5
+   local.set $1
+   f64.const 2
+   local.set $0
+   i32.const 1
+   drop
+   i32.const 8
+   i32.const 4
+   i32.eq
+   drop
+   i32.const 8
+   i32.const 8
+   i32.eq
+   drop
+   local.get $1
+   local.get $0
+   call $~lib/util/math/pow64
+   br $~lib/math/NativeMath.pow<f64>|inlined.26
+  end
+  f64.const 0.25
   f64.eq
   i32.eqz
   if
@@ -43301,10 +44081,27 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -0
-  f64.const 2
-  call $~lib/math/NativeMath.pow
-  f64.const 0
+  block $~lib/math/NativeMath.pow<f64>|inlined.27 (result f64)
+   f64.const 1
+   local.set $1
+   f64.const 2
+   local.set $0
+   i32.const 1
+   drop
+   i32.const 8
+   i32.const 4
+   i32.eq
+   drop
+   i32.const 8
+   i32.const 8
+   i32.eq
+   drop
+   local.get $1
+   local.get $0
+   call $~lib/util/math/pow64
+   br $~lib/math/NativeMath.pow<f64>|inlined.27
+  end
+  f64.const 1
   f64.eq
   i32.eqz
   if
@@ -43315,10 +44112,27 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -1
-  f64.const 2
-  call $~lib/math/NativeMath.pow
-  f64.const 1
+  block $~lib/math/NativeMath.pow<f64>|inlined.28 (result f64)
+   f64.const inf
+   local.set $1
+   f64.const 2
+   local.set $0
+   i32.const 1
+   drop
+   i32.const 8
+   i32.const 4
+   i32.eq
+   drop
+   i32.const 8
+   i32.const 8
+   i32.eq
+   drop
+   local.get $1
+   local.get $0
+   call $~lib/util/math/pow64
+   br $~lib/math/NativeMath.pow<f64>|inlined.28
+  end
+  f64.const inf
   f64.eq
   i32.eqz
   if
@@ -43329,10 +44143,28 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 0.5
-  f64.const 2
-  call $~lib/math/NativeMath.pow
-  f64.const 0.25
+  block $~lib/math/NativeMath.pow<f64>|inlined.29 (result f64)
+   f64.const inf
+   f64.neg
+   local.set $1
+   f64.const 2
+   local.set $0
+   i32.const 1
+   drop
+   i32.const 8
+   i32.const 4
+   i32.eq
+   drop
+   i32.const 8
+   i32.const 8
+   i32.eq
+   drop
+   local.get $1
+   local.get $0
+   call $~lib/util/math/pow64
+   br $~lib/math/NativeMath.pow<f64>|inlined.29
+  end
+  f64.const inf
   f64.eq
   i32.eqz
   if
@@ -43343,11 +44175,29 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 1
-  f64.const 2
-  call $~lib/math/NativeMath.pow
-  f64.const 1
-  f64.eq
+  block $~lib/math/NativeMath.pow<f64>|inlined.30 (result f64)
+   f64.const nan:0x8000000000000
+   local.set $1
+   f64.const 2
+   local.set $0
+   i32.const 1
+   drop
+   i32.const 8
+   i32.const 4
+   i32.eq
+   drop
+   i32.const 8
+   i32.const 8
+   i32.eq
+   drop
+   local.get $1
+   local.get $0
+   call $~lib/util/math/pow64
+   br $~lib/math/NativeMath.pow<f64>|inlined.30
+  end
+  local.tee $1
+  local.get $1
+  f64.ne
   i32.eqz
   if
    i32.const 0
@@ -43357,25 +44207,27 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const inf
-  f64.const 2
-  call $~lib/math/NativeMath.pow
-  f64.const inf
-  f64.eq
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 2719
+  block $~lib/math/NativeMath.pow<f64>|inlined.31 (result f64)
+   f64.const 0
+   local.set $1
+   f64.const 0.5
+   local.set $0
    i32.const 1
-   call $~lib/builtins/abort
-   unreachable
+   drop
+   i32.const 8
+   i32.const 4
+   i32.eq
+   drop
+   i32.const 8
+   i32.const 8
+   i32.eq
+   drop
+   local.get $1
+   local.get $0
+   call $~lib/util/math/pow64
+   br $~lib/math/NativeMath.pow<f64>|inlined.31
   end
-  f64.const inf
-  f64.neg
-  f64.const 2
-  call $~lib/math/NativeMath.pow
-  f64.const inf
+  f64.const 0
   f64.eq
   i32.eqz
   if
@@ -43386,12 +44238,28 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const nan:0x8000000000000
-  f64.const 2
-  call $~lib/math/NativeMath.pow
-  local.tee $0
-  local.get $0
-  f64.ne
+  block $~lib/math/NativeMath.pow<f64>|inlined.32 (result f64)
+   f64.const -0
+   local.set $1
+   f64.const 0.5
+   local.set $0
+   i32.const 1
+   drop
+   i32.const 8
+   i32.const 4
+   i32.eq
+   drop
+   i32.const 8
+   i32.const 8
+   i32.eq
+   drop
+   local.get $1
+   local.get $0
+   call $~lib/util/math/pow64
+   br $~lib/math/NativeMath.pow<f64>|inlined.32
+  end
+  f64.const 0
+  f64.eq
   i32.eqz
   if
    i32.const 0
@@ -43401,10 +44269,59 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 0
-  f64.const 0.5
-  call $~lib/math/NativeMath.pow
-  f64.const 0
+  block $~lib/math/NativeMath.pow<f64>|inlined.33 (result f64)
+   f64.const -1
+   local.set $1
+   f64.const 0.5
+   local.set $0
+   i32.const 1
+   drop
+   i32.const 8
+   i32.const 4
+   i32.eq
+   drop
+   i32.const 8
+   i32.const 8
+   i32.eq
+   drop
+   local.get $1
+   local.get $0
+   call $~lib/util/math/pow64
+   br $~lib/math/NativeMath.pow<f64>|inlined.33
+  end
+  local.tee $1
+  local.get $1
+  f64.ne
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 2722
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  block $~lib/math/NativeMath.pow<f64>|inlined.34 (result f64)
+   f64.const 4
+   local.set $1
+   f64.const 0.5
+   local.set $0
+   i32.const 1
+   drop
+   i32.const 8
+   i32.const 4
+   i32.eq
+   drop
+   i32.const 8
+   i32.const 8
+   i32.eq
+   drop
+   local.get $1
+   local.get $0
+   call $~lib/util/math/pow64
+   br $~lib/math/NativeMath.pow<f64>|inlined.34
+  end
+  f64.const 2
   f64.eq
   i32.eqz
   if
@@ -43415,10 +44332,27 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -0
-  f64.const 0.5
-  call $~lib/math/NativeMath.pow
-  f64.const 0
+  block $~lib/math/NativeMath.pow<f64>|inlined.35 (result f64)
+   f64.const 1
+   local.set $1
+   f64.const 0.5
+   local.set $0
+   i32.const 1
+   drop
+   i32.const 8
+   i32.const 4
+   i32.eq
+   drop
+   i32.const 8
+   i32.const 8
+   i32.eq
+   drop
+   local.get $1
+   local.get $0
+   call $~lib/util/math/pow64
+   br $~lib/math/NativeMath.pow<f64>|inlined.35
+  end
+  f64.const 1
   f64.eq
   i32.eqz
   if
@@ -43429,12 +44363,28 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -1
-  f64.const 0.5
-  call $~lib/math/NativeMath.pow
-  local.tee $0
-  local.get $0
-  f64.ne
+  block $~lib/math/NativeMath.pow<f64>|inlined.36 (result f64)
+   f64.const inf
+   local.set $1
+   f64.const 0.5
+   local.set $0
+   i32.const 1
+   drop
+   i32.const 8
+   i32.const 4
+   i32.eq
+   drop
+   i32.const 8
+   i32.const 8
+   i32.eq
+   drop
+   local.get $1
+   local.get $0
+   call $~lib/util/math/pow64
+   br $~lib/math/NativeMath.pow<f64>|inlined.36
+  end
+  f64.const inf
+  f64.eq
   i32.eqz
   if
    i32.const 0
@@ -43444,10 +44394,28 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 4
-  f64.const 0.5
-  call $~lib/math/NativeMath.pow
-  f64.const 2
+  block $~lib/math/NativeMath.pow<f64>|inlined.37 (result f64)
+   f64.const inf
+   f64.neg
+   local.set $1
+   f64.const 0.5
+   local.set $0
+   i32.const 1
+   drop
+   i32.const 8
+   i32.const 4
+   i32.eq
+   drop
+   i32.const 8
+   i32.const 8
+   i32.eq
+   drop
+   local.get $1
+   local.get $0
+   call $~lib/util/math/pow64
+   br $~lib/math/NativeMath.pow<f64>|inlined.37
+  end
+  f64.const inf
   f64.eq
   i32.eqz
   if
@@ -43458,60 +44426,34 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 1
-  f64.const 0.5
-  call $~lib/math/NativeMath.pow
-  f64.const 1
-  f64.eq
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 2727
+  block $~lib/math/NativeMath.pow<f64>|inlined.38 (result f64)
+   f64.const nan:0x8000000000000
+   local.set $1
+   f64.const 0.5
+   local.set $0
    i32.const 1
-   call $~lib/builtins/abort
-   unreachable
+   drop
+   i32.const 8
+   i32.const 4
+   i32.eq
+   drop
+   i32.const 8
+   i32.const 8
+   i32.eq
+   drop
+   local.get $1
+   local.get $0
+   call $~lib/util/math/pow64
+   br $~lib/math/NativeMath.pow<f64>|inlined.38
   end
-  f64.const inf
-  f64.const 0.5
-  call $~lib/math/NativeMath.pow
-  f64.const inf
-  f64.eq
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 2728
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const inf
-  f64.neg
-  f64.const 0.5
-  call $~lib/math/NativeMath.pow
-  f64.const inf
-  f64.eq
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 2729
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const nan:0x8000000000000
-  f64.const 0.5
-  call $~lib/math/NativeMath.pow
-  local.tee $0
-  local.get $0
+  local.tee $1
+  local.get $1
   f64.ne
   i32.eqz
   if
    i32.const 0
    i32.const 32
-   i32.const 2730
+   i32.const 2727
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -43526,7 +44468,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2739
+   i32.const 2736
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -43541,7 +44483,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2740
+   i32.const 2737
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -43556,7 +44498,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2741
+   i32.const 2738
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -43571,7 +44513,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2742
+   i32.const 2739
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -43586,7 +44528,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2743
+   i32.const 2740
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -43601,7 +44543,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2744
+   i32.const 2741
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -43616,7 +44558,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2745
+   i32.const 2742
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -43631,7 +44573,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2746
+   i32.const 2743
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -43646,7 +44588,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2747
+   i32.const 2744
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -43661,7 +44603,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2748
+   i32.const 2745
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -43676,13 +44618,58 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2751
+   i32.const 2748
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f32.const 0
   f32.const inf
+  f32.const 0
+  f32.const 0
+  i32.const 0
+  call $std/math/test_powf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 2749
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const 0
+  f32.const 3
+  f32.const 0
+  f32.const 0
+  i32.const 0
+  call $std/math/test_powf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 2750
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const 0
+  f32.const 2
+  f32.const 0
+  f32.const 0
+  i32.const 0
+  call $std/math/test_powf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 2751
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const 0
+  f32.const 1
   f32.const 0
   f32.const 0
   i32.const 0
@@ -43697,7 +44684,7 @@
    unreachable
   end
   f32.const 0
-  f32.const 3
+  f32.const 0.5
   f32.const 0
   f32.const 0
   i32.const 0
@@ -43712,8 +44699,8 @@
    unreachable
   end
   f32.const 0
-  f32.const 2
   f32.const 0
+  f32.const 1
   f32.const 0
   i32.const 0
   call $std/math/test_powf
@@ -43722,51 +44709,6 @@
    i32.const 0
    i32.const 32
    i32.const 2754
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const 0
-  f32.const 1
-  f32.const 0
-  f32.const 0
-  i32.const 0
-  call $std/math/test_powf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 2755
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const 0
-  f32.const 0.5
-  f32.const 0
-  f32.const 0
-  i32.const 0
-  call $std/math/test_powf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 2756
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const 0
-  f32.const 0
-  f32.const 1
-  f32.const 0
-  i32.const 0
-  call $std/math/test_powf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 2757
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -43781,13 +44723,58 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2758
+   i32.const 2755
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f32.const 0
   f32.const -0.5
+  f32.const inf
+  f32.const 0
+  global.get $std/math/DIVBYZERO
+  call $std/math/test_powf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 2756
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const 0
+  f32.const -1
+  f32.const inf
+  f32.const 0
+  global.get $std/math/DIVBYZERO
+  call $std/math/test_powf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 2757
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const 0
+  f32.const -2
+  f32.const inf
+  f32.const 0
+  global.get $std/math/DIVBYZERO
+  call $std/math/test_powf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 2758
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const 0
+  f32.const -3
   f32.const inf
   f32.const 0
   global.get $std/math/DIVBYZERO
@@ -43802,7 +44789,7 @@
    unreachable
   end
   f32.const 0
-  f32.const -1
+  f32.const -4
   f32.const inf
   f32.const 0
   global.get $std/math/DIVBYZERO
@@ -43817,51 +44804,6 @@
    unreachable
   end
   f32.const 0
-  f32.const -2
-  f32.const inf
-  f32.const 0
-  global.get $std/math/DIVBYZERO
-  call $std/math/test_powf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 2761
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const 0
-  f32.const -3
-  f32.const inf
-  f32.const 0
-  global.get $std/math/DIVBYZERO
-  call $std/math/test_powf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 2762
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const 0
-  f32.const -4
-  f32.const inf
-  f32.const 0
-  global.get $std/math/DIVBYZERO
-  call $std/math/test_powf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 2763
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const 0
   f32.const inf
   f32.neg
   f32.const inf
@@ -43872,7 +44814,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2764
+   i32.const 2761
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -43887,7 +44829,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2765
+   i32.const 2762
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -43902,7 +44844,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2766
+   i32.const 2763
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -43917,7 +44859,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2767
+   i32.const 2764
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -43932,7 +44874,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2768
+   i32.const 2765
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -43947,7 +44889,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2769
+   i32.const 2766
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -43962,7 +44904,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2770
+   i32.const 2767
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -43977,7 +44919,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2771
+   i32.const 2768
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -43992,7 +44934,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2772
+   i32.const 2769
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -44007,7 +44949,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2773
+   i32.const 2770
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -44023,7 +44965,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2774
+   i32.const 2771
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -44038,7 +44980,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2775
+   i32.const 2772
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -44054,7 +44996,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2776
+   i32.const 2773
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -44069,7 +45011,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2777
+   i32.const 2774
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -44085,12 +45027,58 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2778
+   i32.const 2775
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f32.const nan:0x400000
+  f32.const 0
+  f32.const 1
+  f32.const 0
+  i32.const 0
+  call $std/math/test_powf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 2776
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const inf
+  f32.const 0
+  f32.const 1
+  f32.const 0
+  i32.const 0
+  call $std/math/test_powf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 2777
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const inf
+  f32.neg
+  f32.const 0
+  f32.const 1
+  f32.const 0
+  i32.const 0
+  call $std/math/test_powf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 2778
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const 1
   f32.const 0
   f32.const 1
   f32.const 0
@@ -44105,7 +45093,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const inf
+  f32.const -1
   f32.const 0
   f32.const 1
   f32.const 0
@@ -44120,8 +45108,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const inf
-  f32.neg
+  f32.const -0.5
   f32.const 0
   f32.const 1
   f32.const 0
@@ -44136,8 +45123,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 1
-  f32.const 0
+  f32.const nan:0x400000
+  f32.const -0
   f32.const 1
   f32.const 0
   i32.const 0
@@ -44151,8 +45138,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -1
-  f32.const 0
+  f32.const inf
+  f32.const -0
   f32.const 1
   f32.const 0
   i32.const 0
@@ -44166,8 +45153,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -0.5
-  f32.const 0
+  f32.const inf
+  f32.neg
+  f32.const -0
   f32.const 1
   f32.const 0
   i32.const 0
@@ -44181,7 +45169,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const nan:0x400000
+  f32.const 1
   f32.const -0
   f32.const 1
   f32.const 0
@@ -44196,7 +45184,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const inf
+  f32.const -1
   f32.const -0
   f32.const 1
   f32.const 0
@@ -44211,8 +45199,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const inf
-  f32.neg
+  f32.const -0.5
   f32.const -0
   f32.const 1
   f32.const 0
@@ -44227,9 +45214,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 1
-  f32.const -0
-  f32.const 1
+  f32.const -1
+  f32.const nan:0x400000
+  f32.const nan:0x400000
   f32.const 0
   i32.const 0
   call $std/math/test_powf
@@ -44238,51 +45225,6 @@
    i32.const 0
    i32.const 32
    i32.const 2788
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const -1
-  f32.const -0
-  f32.const 1
-  f32.const 0
-  i32.const 0
-  call $std/math/test_powf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 2789
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const -0.5
-  f32.const -0
-  f32.const 1
-  f32.const 0
-  i32.const 0
-  call $std/math/test_powf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 2790
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const -1
-  f32.const nan:0x400000
-  f32.const nan:0x400000
-  f32.const 0
-  i32.const 0
-  call $std/math/test_powf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 2791
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -44297,7 +45239,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2792
+   i32.const 2789
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -44313,7 +45255,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2793
+   i32.const 2790
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -44328,7 +45270,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2794
+   i32.const 2791
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -44343,7 +45285,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2795
+   i32.const 2792
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -44358,7 +45300,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2796
+   i32.const 2793
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -44373,7 +45315,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2797
+   i32.const 2794
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -44388,7 +45330,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2798
+   i32.const 2795
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -44403,7 +45345,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2799
+   i32.const 2796
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -44418,7 +45360,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2800
+   i32.const 2797
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -44434,7 +45376,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2801
+   i32.const 2798
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -44449,7 +45391,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2802
+   i32.const 2799
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -44464,7 +45406,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2803
+   i32.const 2800
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -44479,7 +45421,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2804
+   i32.const 2801
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -44494,7 +45436,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2805
+   i32.const 2802
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -44509,7 +45451,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2806
+   i32.const 2803
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -44524,7 +45466,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2807
+   i32.const 2804
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -44539,7 +45481,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2808
+   i32.const 2805
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -44554,7 +45496,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2809
+   i32.const 2806
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -44569,12 +45511,58 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2810
+   i32.const 2807
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f32.const -0.5
+  f32.const inf
+  f32.neg
+  f32.const inf
+  f32.const 0
+  i32.const 0
+  call $std/math/test_powf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 2808
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const -0.5
+  f32.const nan:0x400000
+  f32.const nan:0x400000
+  f32.const 0
+  i32.const 0
+  call $std/math/test_powf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 2809
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const 0.5
+  f32.const inf
+  f32.const 0
+  f32.const 0
+  i32.const 0
+  call $std/math/test_powf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 2810
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const 0.5
   f32.const inf
   f32.neg
   f32.const inf
@@ -44590,7 +45578,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -0.5
+  f32.const 0.5
   f32.const nan:0x400000
   f32.const nan:0x400000
   f32.const 0
@@ -44605,9 +45593,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 0.5
+  f32.const 1.5
   f32.const inf
-  f32.const 0
+  f32.const inf
   f32.const 0
   i32.const 0
   call $std/math/test_powf
@@ -44620,10 +45608,10 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 0.5
+  f32.const 1.5
   f32.const inf
   f32.neg
-  f32.const inf
+  f32.const 0
   f32.const 0
   i32.const 0
   call $std/math/test_powf
@@ -44636,7 +45624,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 0.5
+  f32.const 1.5
   f32.const nan:0x400000
   f32.const nan:0x400000
   f32.const 0
@@ -44651,9 +45639,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 1.5
   f32.const inf
-  f32.const inf
+  f32.const nan:0x400000
+  f32.const nan:0x400000
   f32.const 0
   i32.const 0
   call $std/math/test_powf
@@ -44666,10 +45654,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 1.5
   f32.const inf
-  f32.neg
-  f32.const 0
+  f32.const inf
+  f32.const inf
   f32.const 0
   i32.const 0
   call $std/math/test_powf
@@ -44682,51 +45669,6 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 1.5
-  f32.const nan:0x400000
-  f32.const nan:0x400000
-  f32.const 0
-  i32.const 0
-  call $std/math/test_powf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 2818
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const inf
-  f32.const nan:0x400000
-  f32.const nan:0x400000
-  f32.const 0
-  i32.const 0
-  call $std/math/test_powf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 2819
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const inf
-  f32.const inf
-  f32.const inf
-  f32.const 0
-  i32.const 0
-  call $std/math/test_powf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 2820
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
   f32.const inf
   f32.const inf
   f32.neg
@@ -44738,7 +45680,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2821
+   i32.const 2818
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -44753,7 +45695,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2822
+   i32.const 2819
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -44768,7 +45710,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2823
+   i32.const 2820
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -44783,7 +45725,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2824
+   i32.const 2821
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -44798,7 +45740,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2825
+   i32.const 2822
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -44813,7 +45755,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2826
+   i32.const 2823
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -44828,13 +45770,62 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2827
+   i32.const 2824
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f32.const inf
   f32.const -2
+  f32.const 0
+  f32.const 0
+  i32.const 0
+  call $std/math/test_powf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 2825
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const inf
+  f32.neg
+  f32.const nan:0x400000
+  f32.const nan:0x400000
+  f32.const 0
+  i32.const 0
+  call $std/math/test_powf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 2826
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const inf
+  f32.neg
+  f32.const inf
+  f32.const inf
+  f32.const 0
+  i32.const 0
+  call $std/math/test_powf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 2827
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const inf
+  f32.neg
+  f32.const inf
+  f32.neg
   f32.const 0
   f32.const 0
   i32.const 0
@@ -44850,8 +45841,9 @@
   end
   f32.const inf
   f32.neg
-  f32.const nan:0x400000
-  f32.const nan:0x400000
+  f32.const 3
+  f32.const inf
+  f32.neg
   f32.const 0
   i32.const 0
   call $std/math/test_powf
@@ -44866,7 +45858,7 @@
   end
   f32.const inf
   f32.neg
-  f32.const inf
+  f32.const 2
   f32.const inf
   f32.const 0
   i32.const 0
@@ -44882,56 +45874,6 @@
   end
   f32.const inf
   f32.neg
-  f32.const inf
-  f32.neg
-  f32.const 0
-  f32.const 0
-  i32.const 0
-  call $std/math/test_powf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 2831
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const inf
-  f32.neg
-  f32.const 3
-  f32.const inf
-  f32.neg
-  f32.const 0
-  i32.const 0
-  call $std/math/test_powf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 2832
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const inf
-  f32.neg
-  f32.const 2
-  f32.const inf
-  f32.const 0
-  i32.const 0
-  call $std/math/test_powf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 2833
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const inf
-  f32.neg
   f32.const 1
   f32.const inf
   f32.neg
@@ -44942,7 +45884,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2834
+   i32.const 2831
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -44958,7 +45900,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2835
+   i32.const 2832
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -44967,6 +45909,53 @@
   f32.neg
   f32.const -0.5
   f32.const 0
+  f32.const 0
+  i32.const 0
+  call $std/math/test_powf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 2833
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const inf
+  f32.neg
+  f32.const -1
+  f32.const -0
+  f32.const 0
+  i32.const 0
+  call $std/math/test_powf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 2834
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const inf
+  f32.neg
+  f32.const -2
+  f32.const 0
+  f32.const 0
+  i32.const 0
+  call $std/math/test_powf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 2835
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const nan:0x400000
+  f32.const 1
+  f32.const nan:0x400000
   f32.const 0
   i32.const 0
   call $std/math/test_powf
@@ -44979,10 +45968,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const inf
-  f32.neg
+  f32.const nan:0x400000
   f32.const -1
-  f32.const -0
+  f32.const nan:0x400000
   f32.const 0
   i32.const 0
   call $std/math/test_powf
@@ -44995,10 +45983,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const inf
-  f32.neg
   f32.const -2
-  f32.const 0
+  f32.const 1
+  f32.const -2
   f32.const 0
   i32.const 0
   call $std/math/test_powf
@@ -45007,51 +45994,6 @@
    i32.const 0
    i32.const 32
    i32.const 2838
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const nan:0x400000
-  f32.const 1
-  f32.const nan:0x400000
-  f32.const 0
-  i32.const 0
-  call $std/math/test_powf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 2839
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const nan:0x400000
-  f32.const -1
-  f32.const nan:0x400000
-  f32.const 0
-  i32.const 0
-  call $std/math/test_powf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 2840
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const -2
-  f32.const 1
-  f32.const -2
-  f32.const 0
-  i32.const 0
-  call $std/math/test_powf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 2841
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -45066,7 +46008,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2842
+   i32.const 2839
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -45074,6 +46016,55 @@
   f32.const 0
   f32.const 1
   f32.const 0
+  f32.const 0
+  i32.const 0
+  call $std/math/test_powf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 2842
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const -0
+  f32.const 1
+  f32.const -0
+  f32.const 0
+  i32.const 0
+  call $std/math/test_powf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 2843
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  i32.const 8388608
+  f32.reinterpret_i32
+  f32.const 1
+  i32.const 8388608
+  f32.reinterpret_i32
+  f32.const 0
+  i32.const 0
+  call $std/math/test_powf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 2844
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  i32.const -2139095040
+  f32.reinterpret_i32
+  f32.const 1
+  i32.const -2139095040
+  f32.reinterpret_i32
   f32.const 0
   i32.const 0
   call $std/math/test_powf
@@ -45086,9 +46077,11 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -0
+  i32.const 2139095039
+  f32.reinterpret_i32
   f32.const 1
-  f32.const -0
+  i32.const 2139095039
+  f32.reinterpret_i32
   f32.const 0
   i32.const 0
   call $std/math/test_powf
@@ -45101,10 +46094,10 @@
    call $~lib/builtins/abort
    unreachable
   end
-  i32.const 8388608
+  i32.const -8388609
   f32.reinterpret_i32
   f32.const 1
-  i32.const 8388608
+  i32.const -8388609
   f32.reinterpret_i32
   f32.const 0
   i32.const 0
@@ -45118,28 +46111,10 @@
    call $~lib/builtins/abort
    unreachable
   end
-  i32.const -2139095040
-  f32.reinterpret_i32
-  f32.const 1
-  i32.const -2139095040
+  f32.const 0
+  i32.const 2139095039
   f32.reinterpret_i32
   f32.const 0
-  i32.const 0
-  call $std/math/test_powf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 2848
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  i32.const 2139095039
-  f32.reinterpret_i32
-  f32.const 1
-  i32.const 2139095039
-  f32.reinterpret_i32
   f32.const 0
   i32.const 0
   call $std/math/test_powf
@@ -45148,39 +46123,6 @@
    i32.const 0
    i32.const 32
    i32.const 2849
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  i32.const -8388609
-  f32.reinterpret_i32
-  f32.const 1
-  i32.const -8388609
-  f32.reinterpret_i32
-  f32.const 0
-  i32.const 0
-  call $std/math/test_powf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 2850
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const 0
-  i32.const 2139095039
-  f32.reinterpret_i32
-  f32.const 0
-  f32.const 0
-  i32.const 0
-  call $std/math/test_powf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 2852
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -45196,7 +46138,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2853
+   i32.const 2850
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -45212,7 +46154,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2854
+   i32.const 2851
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -45228,7 +46170,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2855
+   i32.const 2852
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -45243,7 +46185,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2856
+   i32.const 2853
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -45259,7 +46201,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2857
+   i32.const 2854
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -45278,7 +46220,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2859
+   i32.const 2856
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -45296,7 +46238,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2861
+   i32.const 2858
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -45314,7 +46256,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2862
+   i32.const 2859
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -45332,7 +46274,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2863
+   i32.const 2860
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -45350,7 +46292,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2864
+   i32.const 2861
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -45369,7 +46311,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2866
+   i32.const 2863
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -45388,7 +46330,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2867
+   i32.const 2864
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -45407,7 +46349,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2868
+   i32.const 2865
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -45426,7 +46368,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2869
+   i32.const 2866
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -45445,7 +46387,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2870
+   i32.const 2867
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -45464,7 +46406,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2871
+   i32.const 2868
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -45483,7 +46425,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2872
+   i32.const 2869
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -45502,7 +46444,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2873
+   i32.const 2870
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -45521,7 +46463,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2874
+   i32.const 2871
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -45540,37 +46482,37 @@
   if
    i32.const 0
    i32.const 32
+   i32.const 2872
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const nan:0x400000
+  f32.const 0
+  f32.const 1
+  f32.const 0
+  i32.const 0
+  call $std/math/test_powf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 2874
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const nan:0x400000
+  f32.const 0
+  f32.const 1
+  f32.const 0
+  i32.const 0
+  call $std/math/test_powf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
    i32.const 2875
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const nan:0x400000
-  f32.const 0
-  f32.const 1
-  f32.const 0
-  i32.const 0
-  call $std/math/test_powf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 2877
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const nan:0x400000
-  f32.const 0
-  f32.const 1
-  f32.const 0
-  i32.const 0
-  call $std/math/test_powf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 2878
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -45585,7 +46527,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2879
+   i32.const 2876
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -45601,7 +46543,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2880
+   i32.const 2877
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -45617,7 +46559,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2881
+   i32.const 2878
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -45633,7 +46575,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2882
+   i32.const 2879
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -45641,6 +46583,53 @@
   f32.const nan:0x400000
   f32.const 1
   f32.const nan:0x400000
+  f32.const 0
+  i32.const 0
+  call $std/math/test_powf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 2881
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const nan:0x400000
+  f32.const 1
+  f32.const nan:0x400000
+  f32.const 0
+  i32.const 0
+  call $std/math/test_powf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 2882
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const inf
+  f32.const 1
+  f32.const inf
+  f32.const 0
+  i32.const 0
+  call $std/math/test_powf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 2883
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const inf
+  f32.neg
+  f32.const 1
+  f32.const inf
+  f32.neg
   f32.const 0
   i32.const 0
   call $std/math/test_powf
@@ -45654,23 +46643,8 @@
    unreachable
   end
   f32.const nan:0x400000
-  f32.const 1
   f32.const nan:0x400000
-  f32.const 0
-  i32.const 0
-  call $std/math/test_powf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 2885
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const inf
-  f32.const 1
-  f32.const inf
+  f32.const nan:0x400000
   f32.const 0
   i32.const 0
   call $std/math/test_powf
@@ -45684,10 +46658,8 @@
    unreachable
   end
   f32.const inf
-  f32.neg
-  f32.const 1
-  f32.const inf
-  f32.neg
+  f32.const nan:0x400000
+  f32.const nan:0x400000
   f32.const 0
   i32.const 0
   call $std/math/test_powf
@@ -45700,7 +46672,23 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f32.const inf
+  f32.neg
   f32.const nan:0x400000
+  f32.const nan:0x400000
+  f32.const 0
+  i32.const 0
+  call $std/math/test_powf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 2888
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const 1
   f32.const nan:0x400000
   f32.const nan:0x400000
   f32.const 0
@@ -45715,7 +46703,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const inf
+  f32.const -1
   f32.const nan:0x400000
   f32.const nan:0x400000
   f32.const 0
@@ -45730,8 +46718,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const inf
-  f32.neg
+  f32.const -0
   f32.const nan:0x400000
   f32.const nan:0x400000
   f32.const 0
@@ -45746,7 +46733,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 1
+  f32.const 0
   f32.const nan:0x400000
   f32.const nan:0x400000
   f32.const 0
@@ -45757,51 +46744,6 @@
    i32.const 0
    i32.const 32
    i32.const 2892
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const -1
-  f32.const nan:0x400000
-  f32.const nan:0x400000
-  f32.const 0
-  i32.const 0
-  call $std/math/test_powf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 2893
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const -0
-  f32.const nan:0x400000
-  f32.const nan:0x400000
-  f32.const 0
-  i32.const 0
-  call $std/math/test_powf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 2894
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const 0
-  f32.const nan:0x400000
-  f32.const nan:0x400000
-  f32.const 0
-  i32.const 0
-  call $std/math/test_powf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 2895
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -45817,7 +46759,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2897
+   i32.const 2894
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -45832,7 +46774,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2898
+   i32.const 2895
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -45848,7 +46790,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2899
+   i32.const 2896
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -45864,13 +46806,63 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2900
+   i32.const 2897
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   i32.const 1065353217
   f32.reinterpret_i32
+  f32.const inf
+  f32.neg
+  f32.const 0
+  f32.const 0
+  i32.const 0
+  call $std/math/test_powf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 2899
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const inf
+  f32.const inf
+  f32.neg
+  f32.const 0
+  f32.const 0
+  i32.const 0
+  call $std/math/test_powf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 2900
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  i32.const -1082130431
+  f32.reinterpret_i32
+  f32.const inf
+  f32.neg
+  f32.const 0
+  f32.const 0
+  i32.const 0
+  call $std/math/test_powf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 2901
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const inf
+  f32.neg
   f32.const inf
   f32.neg
   f32.const 0
@@ -45886,56 +46878,6 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const inf
-  f32.const inf
-  f32.neg
-  f32.const 0
-  f32.const 0
-  i32.const 0
-  call $std/math/test_powf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 2903
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  i32.const -1082130431
-  f32.reinterpret_i32
-  f32.const inf
-  f32.neg
-  f32.const 0
-  f32.const 0
-  i32.const 0
-  call $std/math/test_powf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 2904
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const inf
-  f32.neg
-  f32.const inf
-  f32.neg
-  f32.const 0
-  f32.const 0
-  i32.const 0
-  call $std/math/test_powf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 2905
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
   i32.const 1065353215
   f32.reinterpret_i32
   f32.const inf
@@ -45947,7 +46889,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2907
+   i32.const 2904
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -45963,7 +46905,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2908
+   i32.const 2905
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -45978,7 +46920,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2909
+   i32.const 2906
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -45994,7 +46936,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2910
+   i32.const 2907
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -46010,7 +46952,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2911
+   i32.const 2908
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -46025,7 +46967,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2912
+   i32.const 2909
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -46041,7 +46983,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2914
+   i32.const 2911
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -46057,7 +46999,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2915
+   i32.const 2912
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -46073,12 +47015,59 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2917
+   i32.const 2914
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f32.const 0
+  i32.const -2147483647
+  f32.reinterpret_i32
+  f32.const inf
+  f32.const 0
+  global.get $std/math/DIVBYZERO
+  call $std/math/test_powf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 2915
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const -0
+  i32.const -8388609
+  f32.reinterpret_i32
+  f32.const inf
+  f32.const 0
+  global.get $std/math/DIVBYZERO
+  call $std/math/test_powf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 2916
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const -0
+  f32.const -2
+  f32.const inf
+  f32.const 0
+  global.get $std/math/DIVBYZERO
+  call $std/math/test_powf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 2917
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const -0
   i32.const -2147483647
   f32.reinterpret_i32
   f32.const inf
@@ -46095,53 +47084,6 @@
    unreachable
   end
   f32.const -0
-  i32.const -8388609
-  f32.reinterpret_i32
-  f32.const inf
-  f32.const 0
-  global.get $std/math/DIVBYZERO
-  call $std/math/test_powf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 2919
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const -0
-  f32.const -2
-  f32.const inf
-  f32.const 0
-  global.get $std/math/DIVBYZERO
-  call $std/math/test_powf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 2920
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const -0
-  i32.const -2147483647
-  f32.reinterpret_i32
-  f32.const inf
-  f32.const 0
-  global.get $std/math/DIVBYZERO
-  call $std/math/test_powf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 2921
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const -0
   f32.const -1
   f32.const inf
   f32.neg
@@ -46152,7 +47094,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2922
+   i32.const 2919
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -46169,7 +47111,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2923
+   i32.const 2920
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -46185,7 +47127,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2925
+   i32.const 2922
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -46201,7 +47143,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2926
+   i32.const 2923
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -46218,7 +47160,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2928
+   i32.const 2925
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -46235,7 +47177,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2929
+   i32.const 2926
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -46252,7 +47194,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2930
+   i32.const 2927
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -46269,7 +47211,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2931
+   i32.const 2928
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -46287,7 +47229,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2932
+   i32.const 2929
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -46304,7 +47246,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2933
+   i32.const 2930
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -46321,7 +47263,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2934
+   i32.const 2931
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -46338,7 +47280,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2935
+   i32.const 2932
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -46355,7 +47297,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2937
+   i32.const 2934
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -46371,7 +47313,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2938
+   i32.const 2935
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -46388,7 +47330,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2939
+   i32.const 2936
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -46408,7 +47350,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2941
+   i32.const 2938
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -46424,7 +47366,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2942
+   i32.const 2939
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -46441,7 +47383,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2944
+   i32.const 2941
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -46458,7 +47400,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2945
+   i32.const 2942
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -46475,7 +47417,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2946
+   i32.const 2943
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -46492,7 +47434,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2947
+   i32.const 2944
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -46509,7 +47451,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2948
+   i32.const 2945
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -46526,7 +47468,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2949
+   i32.const 2946
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -46543,7 +47485,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2950
+   i32.const 2947
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -46560,7 +47502,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2951
+   i32.const 2948
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -46577,7 +47519,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2952
+   i32.const 2949
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -46594,7 +47536,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2953
+   i32.const 2950
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -46611,7 +47553,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2954
+   i32.const 2951
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -46628,7 +47570,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2955
+   i32.const 2952
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -46645,7 +47587,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2956
+   i32.const 2953
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -46662,7 +47604,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2957
+   i32.const 2954
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -46679,7 +47621,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2958
+   i32.const 2955
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -46696,7 +47638,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2959
+   i32.const 2956
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -46713,7 +47655,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2960
+   i32.const 2957
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -46730,7 +47672,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2961
+   i32.const 2958
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -46745,7 +47687,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2962
+   i32.const 2959
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -46760,7 +47702,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2963
+   i32.const 2960
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -46777,7 +47719,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2965
+   i32.const 2962
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -46794,7 +47736,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2966
+   i32.const 2963
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -46810,7 +47752,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2967
+   i32.const 2964
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -46827,7 +47769,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2968
+   i32.const 2965
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -46844,7 +47786,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2969
+   i32.const 2966
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -46861,7 +47803,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2970
+   i32.const 2967
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -46878,7 +47820,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2971
+   i32.const 2968
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -46894,7 +47836,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2973
+   i32.const 2970
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -46911,7 +47853,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2974
+   i32.const 2971
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -46930,7 +47872,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2976
+   i32.const 2973
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -46949,7 +47891,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2977
+   i32.const 2974
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -46968,7 +47910,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2978
+   i32.const 2975
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -46986,7 +47928,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2979
+   i32.const 2976
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -47005,7 +47947,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2980
+   i32.const 2977
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -47024,7 +47966,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2981
+   i32.const 2978
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -47043,7 +47985,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2982
+   i32.const 2979
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -47062,7 +48004,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2983
+   i32.const 2980
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -47080,7 +48022,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2984
+   i32.const 2981
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -47100,7 +48042,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2985
+   i32.const 2982
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -47119,7 +48061,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2986
+   i32.const 2983
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -47138,7 +48080,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2988
+   i32.const 2985
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -47156,7 +48098,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2989
+   i32.const 2986
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -47176,7 +48118,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2990
+   i32.const 2987
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -47195,7 +48137,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2991
+   i32.const 2988
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -47204,22 +48146,22 @@
   i64.reinterpret_f64
   call $~lib/math/NativeMath.seedRandom
   i32.const 0
-  local.set $1
+  local.set $2
   loop $for-loop|0
-   local.get $1
+   local.get $2
    f64.convert_i32_s
    f64.const 1e6
    f64.lt
-   local.set $2
-   local.get $2
+   local.set $3
+   local.get $3
    if
     call $~lib/math/NativeMath.random
-    local.set $0
-    local.get $0
+    local.set $1
+    local.get $1
     f64.const 0
     f64.ge
     if (result i32)
-     local.get $0
+     local.get $1
      f64.const 1
      f64.lt
     else
@@ -47229,59 +48171,16 @@
     if
      i32.const 0
      i32.const 32
-     i32.const 3000
+     i32.const 2997
      i32.const 3
      call $~lib/builtins/abort
      unreachable
     end
-    local.get $1
+    local.get $2
     i32.const 1
     i32.add
-    local.set $1
+    local.set $2
     br $for-loop|0
-   end
-  end
-  call $~lib/bindings/dom/Math.random
-  i64.reinterpret_f64
-  local.set $3
-  local.get $3
-  call $~lib/math/NativeMath.seedRandom
-  i32.const 0
-  local.set $1
-  loop $for-loop|1
-   local.get $1
-   f64.convert_i32_s
-   f64.const 1e6
-   f64.lt
-   local.set $2
-   local.get $2
-   if
-    call $~lib/math/NativeMathf.random
-    local.set $4
-    local.get $4
-    f32.const 0
-    f32.ge
-    if (result i32)
-     local.get $4
-     f32.const 1
-     f32.lt
-    else
-     i32.const 0
-    end
-    i32.eqz
-    if
-     i32.const 0
-     i32.const 32
-     i32.const 3008
-     i32.const 3
-     call $~lib/builtins/abort
-     unreachable
-    end
-    local.get $1
-    i32.const 1
-    i32.add
-    local.set $1
-    br $for-loop|1
    end
   end
   f64.const -8.06684839057968
@@ -47293,7 +48192,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3022
+   i32.const 3011
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -47307,7 +48206,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3023
+   i32.const 3012
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -47321,7 +48220,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3024
+   i32.const 3013
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -47335,7 +48234,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3025
+   i32.const 3014
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -47349,7 +48248,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3026
+   i32.const 3015
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -47363,7 +48262,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3027
+   i32.const 3016
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -47377,7 +48276,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3028
+   i32.const 3017
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -47391,12 +48290,140 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3029
+   i32.const 3018
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f64.const 0.7741522965913037
+  f64.const 1
+  f64.const 0
+  global.get $std/math/INEXACT
+  call $std/math/test_round
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 3019
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const -0.6787637026394024
+  f64.const -1
+  f64.const 0
+  global.get $std/math/INEXACT
+  call $std/math/test_round
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 3020
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const nan:0x8000000000000
+  f64.const nan:0x8000000000000
+  f64.const 0
+  i32.const 0
+  call $std/math/test_round
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 3023
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const inf
+  f64.const inf
+  f64.const 0
+  i32.const 0
+  call $std/math/test_round
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 3024
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const inf
+  f64.neg
+  f64.const inf
+  f64.neg
+  f64.const 0
+  i32.const 0
+  call $std/math/test_round
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 3025
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const 0
+  f64.const 0
+  f64.const 0
+  i32.const 0
+  call $std/math/test_round
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 3026
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const -0
+  f64.const -0
+  f64.const 0
+  i32.const 0
+  call $std/math/test_round
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 3027
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const 1
+  f64.const 1
+  f64.const 0
+  i32.const 0
+  call $std/math/test_round
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 3028
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const -1
+  f64.const -1
+  f64.const 0
+  i32.const 0
+  call $std/math/test_round
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 3029
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const 0.5
   f64.const 1
   f64.const 0
   global.get $std/math/INEXACT
@@ -47410,134 +48437,6 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -0.6787637026394024
-  f64.const -1
-  f64.const 0
-  global.get $std/math/INEXACT
-  call $std/math/test_round
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3031
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const nan:0x8000000000000
-  f64.const nan:0x8000000000000
-  f64.const 0
-  i32.const 0
-  call $std/math/test_round
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3034
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const inf
-  f64.const inf
-  f64.const 0
-  i32.const 0
-  call $std/math/test_round
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3035
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const inf
-  f64.neg
-  f64.const inf
-  f64.neg
-  f64.const 0
-  i32.const 0
-  call $std/math/test_round
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3036
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const 0
-  f64.const 0
-  f64.const 0
-  i32.const 0
-  call $std/math/test_round
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3037
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const -0
-  f64.const -0
-  f64.const 0
-  i32.const 0
-  call $std/math/test_round
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3038
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const 1
-  f64.const 1
-  f64.const 0
-  i32.const 0
-  call $std/math/test_round
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3039
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const -1
-  f64.const -1
-  f64.const 0
-  i32.const 0
-  call $std/math/test_round
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3040
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const 0.5
-  f64.const 1
-  f64.const 0
-  global.get $std/math/INEXACT
-  call $std/math/test_round
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3041
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
   f64.const -0.5
   f64.const -0
   f64.const 0
@@ -47547,7 +48446,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3042
+   i32.const 3031
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -47561,7 +48460,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3043
+   i32.const 3032
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -47575,7 +48474,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3044
+   i32.const 3033
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -47589,7 +48488,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3045
+   i32.const 3034
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -47603,7 +48502,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3046
+   i32.const 3035
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -47617,7 +48516,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3047
+   i32.const 3036
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -47631,7 +48530,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3048
+   i32.const 3037
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -47645,7 +48544,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3049
+   i32.const 3038
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -47659,98 +48558,133 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3050
+   i32.const 3039
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
+  block $~lib/math/NativeMath.round<f64>|inlined.1 (result f64)
+   f64.const 9007199254740990
+   local.set $0
+   i32.const 0
+   drop
+   i32.const 1
+   drop
+   local.get $0
+   f64.ceil
+   local.set $1
+   local.get $1
+   local.get $1
+   f64.const 1
+   f64.sub
+   local.get $1
+   f64.const 0.5
+   f64.sub
+   local.get $0
+   f64.le
+   select
+   br $~lib/math/NativeMath.round<f64>|inlined.1
+  end
   f64.const 9007199254740990
-  local.set $0
-  local.get $0
-  f64.ceil
-  local.set $5
-  local.get $5
-  local.get $5
-  f64.const 1
-  f64.sub
-  local.get $5
-  f64.const 0.5
-  f64.sub
-  local.get $0
-  f64.le
-  select
-  f64.const 9007199254740990
   f64.eq
   drop
-  f64.const -9007199254740990
-  local.set $0
-  local.get $0
-  f64.ceil
-  local.set $5
-  local.get $5
-  local.get $5
-  f64.const 1
-  f64.sub
-  local.get $5
-  f64.const 0.5
-  f64.sub
-  local.get $0
-  f64.le
-  select
+  block $~lib/math/NativeMath.round<f64>|inlined.2 (result f64)
+   f64.const -9007199254740990
+   local.set $1
+   i32.const 0
+   drop
+   i32.const 1
+   drop
+   local.get $1
+   f64.ceil
+   local.set $0
+   local.get $0
+   local.get $0
+   f64.const 1
+   f64.sub
+   local.get $0
+   f64.const 0.5
+   f64.sub
+   local.get $1
+   f64.le
+   select
+   br $~lib/math/NativeMath.round<f64>|inlined.2
+  end
   f64.const -9007199254740990
   f64.eq
   drop
-  f64.const 9007199254740991
-  local.set $0
-  local.get $0
-  f64.ceil
-  local.set $5
-  local.get $5
-  local.get $5
-  f64.const 1
-  f64.sub
-  local.get $5
-  f64.const 0.5
-  f64.sub
-  local.get $0
-  f64.le
-  select
+  block $~lib/math/NativeMath.round<f64>|inlined.3 (result f64)
+   f64.const 9007199254740991
+   local.set $0
+   i32.const 0
+   drop
+   i32.const 1
+   drop
+   local.get $0
+   f64.ceil
+   local.set $1
+   local.get $1
+   local.get $1
+   f64.const 1
+   f64.sub
+   local.get $1
+   f64.const 0.5
+   f64.sub
+   local.get $0
+   f64.le
+   select
+   br $~lib/math/NativeMath.round<f64>|inlined.3
+  end
   f64.const 9007199254740991
   f64.eq
   drop
-  f64.const -9007199254740991
-  local.set $0
-  local.get $0
-  f64.ceil
-  local.set $5
-  local.get $5
-  local.get $5
-  f64.const 1
-  f64.sub
-  local.get $5
-  f64.const 0.5
-  f64.sub
-  local.get $0
-  f64.le
-  select
+  block $~lib/math/NativeMath.round<f64>|inlined.4 (result f64)
+   f64.const -9007199254740991
+   local.set $1
+   i32.const 0
+   drop
+   i32.const 1
+   drop
+   local.get $1
+   f64.ceil
+   local.set $0
+   local.get $0
+   local.get $0
+   f64.const 1
+   f64.sub
+   local.get $0
+   f64.const 0.5
+   f64.sub
+   local.get $1
+   f64.le
+   select
+   br $~lib/math/NativeMath.round<f64>|inlined.4
+  end
   f64.const -9007199254740991
   f64.eq
   drop
-  f64.const -1797693134862315708145274e284
-  local.set $0
-  local.get $0
-  f64.ceil
-  local.set $5
-  local.get $5
-  local.get $5
-  f64.const 1
-  f64.sub
-  local.get $5
-  f64.const 0.5
-  f64.sub
-  local.get $0
-  f64.le
-  select
+  block $~lib/math/NativeMath.round<f64>|inlined.5 (result f64)
+   f64.const -1797693134862315708145274e284
+   local.set $0
+   i32.const 0
+   drop
+   i32.const 1
+   drop
+   local.get $0
+   f64.ceil
+   local.set $1
+   local.get $1
+   local.get $1
+   f64.const 1
+   f64.sub
+   local.get $1
+   f64.const 0.5
+   f64.sub
+   local.get $0
+   f64.le
+   select
+   br $~lib/math/NativeMath.round<f64>|inlined.5
+  end
   f64.const -1797693134862315708145274e284
   f64.eq
   drop
@@ -47763,7 +48697,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3065
+   i32.const 3054
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -47777,7 +48711,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3066
+   i32.const 3055
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -47791,7 +48725,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3067
+   i32.const 3056
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -47805,7 +48739,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3068
+   i32.const 3057
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -47819,7 +48753,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3069
+   i32.const 3058
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -47833,7 +48767,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3070
+   i32.const 3059
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -47847,7 +48781,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3071
+   i32.const 3060
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -47861,12 +48795,140 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3072
+   i32.const 3061
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f32.const 0.7741522789001465
+  f32.const 1
+  f32.const 0
+  global.get $std/math/INEXACT
+  call $std/math/test_roundf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 3062
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const -0.6787636876106262
+  f32.const -1
+  f32.const 0
+  global.get $std/math/INEXACT
+  call $std/math/test_roundf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 3063
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const nan:0x400000
+  f32.const nan:0x400000
+  f32.const 0
+  i32.const 0
+  call $std/math/test_roundf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 3066
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const inf
+  f32.const inf
+  f32.const 0
+  i32.const 0
+  call $std/math/test_roundf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 3067
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const inf
+  f32.neg
+  f32.const inf
+  f32.neg
+  f32.const 0
+  i32.const 0
+  call $std/math/test_roundf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 3068
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const 0
+  f32.const 0
+  f32.const 0
+  i32.const 0
+  call $std/math/test_roundf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 3069
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const -0
+  f32.const -0
+  f32.const 0
+  i32.const 0
+  call $std/math/test_roundf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 3070
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const 1
+  f32.const 1
+  f32.const 0
+  i32.const 0
+  call $std/math/test_roundf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 3071
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const -1
+  f32.const -1
+  f32.const 0
+  i32.const 0
+  call $std/math/test_roundf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 3072
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const 0.5
   f32.const 1
   f32.const 0
   global.get $std/math/INEXACT
@@ -47880,134 +48942,6 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -0.6787636876106262
-  f32.const -1
-  f32.const 0
-  global.get $std/math/INEXACT
-  call $std/math/test_roundf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3074
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const nan:0x400000
-  f32.const nan:0x400000
-  f32.const 0
-  i32.const 0
-  call $std/math/test_roundf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3077
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const inf
-  f32.const inf
-  f32.const 0
-  i32.const 0
-  call $std/math/test_roundf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3078
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const inf
-  f32.neg
-  f32.const inf
-  f32.neg
-  f32.const 0
-  i32.const 0
-  call $std/math/test_roundf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3079
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const 0
-  f32.const 0
-  f32.const 0
-  i32.const 0
-  call $std/math/test_roundf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3080
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const -0
-  f32.const -0
-  f32.const 0
-  i32.const 0
-  call $std/math/test_roundf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3081
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const 1
-  f32.const 1
-  f32.const 0
-  i32.const 0
-  call $std/math/test_roundf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3082
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const -1
-  f32.const -1
-  f32.const 0
-  i32.const 0
-  call $std/math/test_roundf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3083
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const 0.5
-  f32.const 1
-  f32.const 0
-  global.get $std/math/INEXACT
-  call $std/math/test_roundf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3084
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
   f32.const -0.5
   f32.const -0
   f32.const 0
@@ -48017,7 +48951,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3085
+   i32.const 3074
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -48031,7 +48965,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3086
+   i32.const 3075
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -48045,7 +48979,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3087
+   i32.const 3076
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -48059,7 +48993,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3088
+   i32.const 3077
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -48073,7 +49007,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3089
+   i32.const 3078
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -48087,7 +49021,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3090
+   i32.const 3079
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -48101,7 +49035,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3091
+   i32.const 3080
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -48115,7 +49049,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3092
+   i32.const 3081
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -48129,25 +49063,25 @@
   if
    i32.const 0
    i32.const 32
+   i32.const 3082
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const 0
+  f64.const 0
+  f64.const 0
+  i32.const 0
+  call $std/math/test_sign
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
    i32.const 3093
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 0
-  f64.const 0
-  f64.const 0
-  i32.const 0
-  call $std/math/test_sign
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3104
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
   f64.const -0
   f64.const -0
   f64.const 0
@@ -48157,7 +49091,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3105
+   i32.const 3094
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -48171,7 +49105,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3106
+   i32.const 3095
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -48185,7 +49119,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3107
+   i32.const 3096
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -48199,7 +49133,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3108
+   i32.const 3097
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -48209,6 +49143,63 @@
   f64.const 0
   i32.const 0
   call $std/math/test_sign
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 3098
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const inf
+  f64.const 1
+  f64.const 0
+  i32.const 0
+  call $std/math/test_sign
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 3099
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const inf
+  f64.neg
+  f64.const -1
+  f64.const 0
+  i32.const 0
+  call $std/math/test_sign
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 3100
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const nan:0x8000000000000
+  f64.const nan:0x8000000000000
+  f64.const 0
+  i32.const 0
+  call $std/math/test_sign
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 3101
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const 0
+  f32.const 0
+  f32.const 0
+  i32.const 0
+  call $std/math/test_signf
   i32.eqz
   if
    i32.const 0
@@ -48218,11 +49209,11 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const inf
-  f64.const 1
-  f64.const 0
+  f32.const -0
+  f32.const -0
+  f32.const 0
   i32.const 0
-  call $std/math/test_sign
+  call $std/math/test_signf
   i32.eqz
   if
    i32.const 0
@@ -48232,12 +49223,11 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const inf
-  f64.neg
-  f64.const -1
-  f64.const 0
+  f32.const 1
+  f32.const 1
+  f32.const 0
   i32.const 0
-  call $std/math/test_sign
+  call $std/math/test_signf
   i32.eqz
   if
    i32.const 0
@@ -48247,11 +49237,11 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const nan:0x8000000000000
-  f64.const nan:0x8000000000000
-  f64.const 0
+  f32.const 2
+  f32.const 1
+  f32.const 0
   i32.const 0
-  call $std/math/test_sign
+  call $std/math/test_signf
   i32.eqz
   if
    i32.const 0
@@ -48261,62 +49251,6 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 0
-  f32.const 0
-  f32.const 0
-  i32.const 0
-  call $std/math/test_signf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3120
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const -0
-  f32.const -0
-  f32.const 0
-  i32.const 0
-  call $std/math/test_signf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3121
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const 1
-  f32.const 1
-  f32.const 0
-  i32.const 0
-  call $std/math/test_signf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3122
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const 2
-  f32.const 1
-  f32.const 0
-  i32.const 0
-  call $std/math/test_signf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3123
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
   f32.const -1
   f32.const -1
   f32.const 0
@@ -48326,7 +49260,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3124
+   i32.const 3113
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -48340,7 +49274,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3125
+   i32.const 3114
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -48354,7 +49288,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3126
+   i32.const 3115
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -48369,7 +49303,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3127
+   i32.const 3116
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -48383,2547 +49317,415 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3128
+   i32.const 3117
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 0
-  local.set $0
-  local.get $0
-  i64.reinterpret_f64
-  i64.const 63
-  i64.shr_u
-  i64.const 0
-  i64.ne
+  block $~lib/math/NativeMath.signbit<f64>|inlined.2 (result i32)
+   f64.const 0
+   local.set $1
+   i32.const 0
+   drop
+   i32.const 1
+   drop
+   i32.const 8
+   i32.const 4
+   i32.eq
+   drop
+   i32.const 8
+   i32.const 8
+   i32.eq
+   drop
+   local.get $1
+   i64.reinterpret_f64
+   i64.const 63
+   i64.shr_u
+   i64.const 0
+   i64.ne
+   br $~lib/math/NativeMath.signbit<f64>|inlined.2
+  end
   i32.const 0
   i32.ne
   i32.const 0
   i32.eq
   drop
-  f64.const -0
-  local.set $5
-  local.get $5
-  i64.reinterpret_f64
-  i64.const 63
-  i64.shr_u
-  i64.const 0
-  i64.ne
-  i32.const 0
-  i32.ne
-  i32.const 1
-  i32.eq
-  drop
-  f64.const 1
-  local.set $0
-  local.get $0
-  i64.reinterpret_f64
-  i64.const 63
-  i64.shr_u
-  i64.const 0
-  i64.ne
-  i32.const 0
-  i32.ne
-  i32.const 0
-  i32.eq
-  drop
-  f64.const -1
-  local.set $5
-  local.get $5
-  i64.reinterpret_f64
-  i64.const 63
-  i64.shr_u
-  i64.const 0
-  i64.ne
-  i32.const 0
-  i32.ne
-  i32.const 1
-  i32.eq
-  drop
-  f64.const nan:0x8000000000000
-  local.set $0
-  local.get $0
-  i64.reinterpret_f64
-  i64.const 63
-  i64.shr_u
-  i64.const 0
-  i64.ne
-  i32.const 0
-  i32.ne
-  i32.const 0
-  i32.eq
-  drop
-  f64.const nan:0x8000000000000
-  f64.neg
-  local.set $5
-  local.get $5
-  i64.reinterpret_f64
-  i64.const 63
-  i64.shr_u
-  i64.const 0
-  i64.ne
+  block $~lib/math/NativeMath.signbit<f64>|inlined.3 (result i32)
+   f64.const -0
+   local.set $0
+   i32.const 0
+   drop
+   i32.const 1
+   drop
+   i32.const 8
+   i32.const 4
+   i32.eq
+   drop
+   i32.const 8
+   i32.const 8
+   i32.eq
+   drop
+   local.get $0
+   i64.reinterpret_f64
+   i64.const 63
+   i64.shr_u
+   i64.const 0
+   i64.ne
+   br $~lib/math/NativeMath.signbit<f64>|inlined.3
+  end
   i32.const 0
   i32.ne
   i32.const 1
   i32.eq
   drop
-  f64.const inf
-  local.set $0
-  local.get $0
-  i64.reinterpret_f64
-  i64.const 63
-  i64.shr_u
-  i64.const 0
-  i64.ne
+  block $~lib/math/NativeMath.signbit<f64>|inlined.4 (result i32)
+   f64.const 1
+   local.set $1
+   i32.const 0
+   drop
+   i32.const 1
+   drop
+   i32.const 8
+   i32.const 4
+   i32.eq
+   drop
+   i32.const 8
+   i32.const 8
+   i32.eq
+   drop
+   local.get $1
+   i64.reinterpret_f64
+   i64.const 63
+   i64.shr_u
+   i64.const 0
+   i64.ne
+   br $~lib/math/NativeMath.signbit<f64>|inlined.4
+  end
   i32.const 0
   i32.ne
   i32.const 0
   i32.eq
   drop
-  f64.const inf
-  f64.neg
-  local.set $5
-  local.get $5
-  i64.reinterpret_f64
-  i64.const 63
-  i64.shr_u
-  i64.const 0
-  i64.ne
-  i32.const 0
-  i32.ne
-  i32.const 1
-  i32.eq
-  drop
-  f32.const 0
-  local.set $4
-  local.get $4
-  i32.reinterpret_f32
-  i32.const 31
-  i32.shr_u
-  i32.const 0
-  i32.ne
-  i32.const 0
-  i32.eq
-  drop
-  f32.const -0
-  local.set $4
-  local.get $4
-  i32.reinterpret_f32
-  i32.const 31
-  i32.shr_u
-  i32.const 0
-  i32.ne
-  i32.const 1
-  i32.eq
-  drop
-  f32.const 1
-  local.set $4
-  local.get $4
-  i32.reinterpret_f32
-  i32.const 31
-  i32.shr_u
-  i32.const 0
-  i32.ne
-  i32.const 0
-  i32.eq
-  drop
-  f32.const -1
-  local.set $4
-  local.get $4
-  i32.reinterpret_f32
-  i32.const 31
-  i32.shr_u
+  block $~lib/math/NativeMath.signbit<f64>|inlined.5 (result i32)
+   f64.const -1
+   local.set $0
+   i32.const 0
+   drop
+   i32.const 1
+   drop
+   i32.const 8
+   i32.const 4
+   i32.eq
+   drop
+   i32.const 8
+   i32.const 8
+   i32.eq
+   drop
+   local.get $0
+   i64.reinterpret_f64
+   i64.const 63
+   i64.shr_u
+   i64.const 0
+   i64.ne
+   br $~lib/math/NativeMath.signbit<f64>|inlined.5
+  end
   i32.const 0
   i32.ne
   i32.const 1
   i32.eq
   drop
-  f32.const nan:0x400000
-  local.set $4
-  local.get $4
-  i32.reinterpret_f32
-  i32.const 31
-  i32.shr_u
+  block $~lib/math/NativeMath.signbit<f64>|inlined.6 (result i32)
+   f64.const nan:0x8000000000000
+   local.set $1
+   i32.const 0
+   drop
+   i32.const 1
+   drop
+   i32.const 8
+   i32.const 4
+   i32.eq
+   drop
+   i32.const 8
+   i32.const 8
+   i32.eq
+   drop
+   local.get $1
+   i64.reinterpret_f64
+   i64.const 63
+   i64.shr_u
+   i64.const 0
+   i64.ne
+   br $~lib/math/NativeMath.signbit<f64>|inlined.6
+  end
   i32.const 0
   i32.ne
   i32.const 0
   i32.eq
   drop
-  f32.const nan:0x400000
-  f32.neg
-  local.set $4
-  local.get $4
-  i32.reinterpret_f32
-  i32.const 31
-  i32.shr_u
+  block $~lib/math/NativeMath.signbit<f64>|inlined.7 (result i32)
+   f64.const nan:0x8000000000000
+   f64.neg
+   local.set $0
+   i32.const 0
+   drop
+   i32.const 1
+   drop
+   i32.const 8
+   i32.const 4
+   i32.eq
+   drop
+   i32.const 8
+   i32.const 8
+   i32.eq
+   drop
+   local.get $0
+   i64.reinterpret_f64
+   i64.const 63
+   i64.shr_u
+   i64.const 0
+   i64.ne
+   br $~lib/math/NativeMath.signbit<f64>|inlined.7
+  end
   i32.const 0
   i32.ne
   i32.const 1
   i32.eq
   drop
-  f32.const inf
-  local.set $4
-  local.get $4
-  i32.reinterpret_f32
-  i32.const 31
-  i32.shr_u
+  block $~lib/math/NativeMath.signbit<f64>|inlined.8 (result i32)
+   f64.const inf
+   local.set $1
+   i32.const 0
+   drop
+   i32.const 1
+   drop
+   i32.const 8
+   i32.const 4
+   i32.eq
+   drop
+   i32.const 8
+   i32.const 8
+   i32.eq
+   drop
+   local.get $1
+   i64.reinterpret_f64
+   i64.const 63
+   i64.shr_u
+   i64.const 0
+   i64.ne
+   br $~lib/math/NativeMath.signbit<f64>|inlined.8
+  end
   i32.const 0
   i32.ne
   i32.const 0
   i32.eq
   drop
-  f32.const inf
-  f32.neg
-  local.set $4
-  local.get $4
-  i32.reinterpret_f32
-  i32.const 31
-  i32.shr_u
+  block $~lib/math/NativeMath.signbit<f64>|inlined.9 (result i32)
+   f64.const inf
+   f64.neg
+   local.set $0
+   i32.const 0
+   drop
+   i32.const 1
+   drop
+   i32.const 8
+   i32.const 4
+   i32.eq
+   drop
+   i32.const 8
+   i32.const 8
+   i32.eq
+   drop
+   local.get $0
+   i64.reinterpret_f64
+   i64.const 63
+   i64.shr_u
+   i64.const 0
+   i64.ne
+   br $~lib/math/NativeMath.signbit<f64>|inlined.9
+  end
   i32.const 0
   i32.ne
   i32.const 1
   i32.eq
   drop
-  f64.const -8.06684839057968
-  f64.const 4.535662560676869
-  f64.const 1.0044767307740567
-  f64.const 0
-  i32.const 0
-  call $std/math/test_rem
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3165
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const 4.345239849338305
-  f64.const -8.88799136300345
-  f64.const 4.345239849338305
-  f64.const 0
-  i32.const 0
-  call $std/math/test_rem
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3166
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const -8.38143342755525
-  f64.const -2.763607337379588
-  f64.const -0.09061141541648476
-  f64.const 0
-  i32.const 0
-  call $std/math/test_rem
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3167
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const -6.531673581913484
-  f64.const 4.567535276842744
-  f64.const -1.9641383050707404
-  f64.const 0
-  i32.const 0
-  call $std/math/test_rem
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3168
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const 9.267056966972586
-  f64.const 4.811392084359796
-  f64.const -0.35572720174700656
-  f64.const 0
-  i32.const 0
-  call $std/math/test_rem
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3169
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const -6.450045556060236
-  f64.const 0.6620717923376739
-  f64.const 0.17067236731650248
-  f64.const 0
-  i32.const 0
-  call $std/math/test_rem
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3170
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const 7.858890253041697
-  f64.const 0.05215452675006225
-  f64.const -0.016443286217702822
-  f64.const 0
-  i32.const 0
-  call $std/math/test_rem
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3171
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const -0.792054511984896
-  f64.const 7.67640268511754
-  f64.const -0.792054511984896
-  f64.const 0
-  i32.const 0
-  call $std/math/test_rem
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3172
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const 0.615702673197924
-  f64.const 2.0119025790324803
-  f64.const 0.615702673197924
-  f64.const 0
-  i32.const 0
-  call $std/math/test_rem
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3173
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const -0.5587586823609152
-  f64.const 0.03223983060263804
-  f64.const -0.0106815621160685
-  f64.const 0
-  i32.const 0
-  call $std/math/test_rem
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3174
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const 0
-  f64.const 1
-  f64.const 0
-  f64.const 0
-  i32.const 0
-  call $std/math/test_rem
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3177
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const -0
-  f64.const 1
-  f64.const -0
-  f64.const 0
-  i32.const 0
-  call $std/math/test_rem
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3178
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const 0.5
-  f64.const 1
-  f64.const 0.5
-  f64.const 0
-  i32.const 0
-  call $std/math/test_rem
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3179
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const -0.5
-  f64.const 1
-  f64.const -0.5
-  f64.const 0
-  i32.const 0
-  call $std/math/test_rem
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3180
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const 1
-  f64.const 1
-  f64.const 0
-  f64.const 0
-  i32.const 0
-  call $std/math/test_rem
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3181
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const -1
-  f64.const 1
-  f64.const -0
-  f64.const 0
-  i32.const 0
-  call $std/math/test_rem
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3182
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const 1.5
-  f64.const 1
-  f64.const -0.5
-  f64.const 0
-  i32.const 0
-  call $std/math/test_rem
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3183
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const -1.5
-  f64.const 1
-  f64.const 0.5
-  f64.const 0
-  i32.const 0
-  call $std/math/test_rem
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3184
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const 2
-  f64.const 1
-  f64.const 0
-  f64.const 0
-  i32.const 0
-  call $std/math/test_rem
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3185
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const -2
-  f64.const 1
-  f64.const -0
-  f64.const 0
-  i32.const 0
-  call $std/math/test_rem
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3186
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const inf
-  f64.const 1
-  f64.const nan:0x8000000000000
-  f64.const 0
-  global.get $std/math/INVALID
-  call $std/math/test_rem
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3187
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const inf
-  f64.neg
-  f64.const 1
-  f64.const nan:0x8000000000000
-  f64.const 0
-  global.get $std/math/INVALID
-  call $std/math/test_rem
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3188
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const nan:0x8000000000000
-  f64.const 1
-  f64.const nan:0x8000000000000
-  f64.const 0
-  i32.const 0
-  call $std/math/test_rem
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3189
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const 0
-  f64.const -1
-  f64.const 0
-  f64.const 0
-  i32.const 0
-  call $std/math/test_rem
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3190
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const -0
-  f64.const -1
-  f64.const -0
-  f64.const 0
-  i32.const 0
-  call $std/math/test_rem
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3191
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const 0.5
-  f64.const -1
-  f64.const 0.5
-  f64.const 0
-  i32.const 0
-  call $std/math/test_rem
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3192
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const -0.5
-  f64.const -1
-  f64.const -0.5
-  f64.const 0
-  i32.const 0
-  call $std/math/test_rem
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3193
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const 1
-  f64.const -1
-  f64.const 0
-  f64.const 0
-  i32.const 0
-  call $std/math/test_rem
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3194
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const -1
-  f64.const -1
-  f64.const -0
-  f64.const 0
-  i32.const 0
-  call $std/math/test_rem
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3195
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const 1.5
-  f64.const -1
-  f64.const -0.5
-  f64.const 0
-  i32.const 0
-  call $std/math/test_rem
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3196
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const -1.5
-  f64.const -1
-  f64.const 0.5
-  f64.const 0
-  i32.const 0
-  call $std/math/test_rem
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3197
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const 2
-  f64.const -1
-  f64.const 0
-  f64.const 0
-  i32.const 0
-  call $std/math/test_rem
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3198
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const -2
-  f64.const -1
-  f64.const -0
-  f64.const 0
-  i32.const 0
-  call $std/math/test_rem
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3199
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const inf
-  f64.const -1
-  f64.const nan:0x8000000000000
-  f64.const 0
-  global.get $std/math/INVALID
-  call $std/math/test_rem
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3200
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const inf
-  f64.neg
-  f64.const -1
-  f64.const nan:0x8000000000000
-  f64.const 0
-  global.get $std/math/INVALID
-  call $std/math/test_rem
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3201
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const nan:0x8000000000000
-  f64.const -1
-  f64.const nan:0x8000000000000
-  f64.const 0
-  i32.const 0
-  call $std/math/test_rem
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3202
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const 0
-  f64.const 0
-  f64.const nan:0x8000000000000
-  f64.const 0
-  global.get $std/math/INVALID
-  call $std/math/test_rem
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3203
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const 0
-  f64.const -0
-  f64.const nan:0x8000000000000
-  f64.const 0
-  global.get $std/math/INVALID
-  call $std/math/test_rem
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3204
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const 0
-  f64.const inf
-  f64.const 0
-  f64.const 0
-  i32.const 0
-  call $std/math/test_rem
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3205
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const 0
-  f64.const inf
-  f64.neg
-  f64.const 0
-  f64.const 0
-  i32.const 0
-  call $std/math/test_rem
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3206
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const 0
-  f64.const nan:0x8000000000000
-  f64.const nan:0x8000000000000
-  f64.const 0
-  i32.const 0
-  call $std/math/test_rem
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3207
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const -0
-  f64.const 0
-  f64.const nan:0x8000000000000
-  f64.const 0
-  global.get $std/math/INVALID
-  call $std/math/test_rem
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3208
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const -0
-  f64.const -0
-  f64.const nan:0x8000000000000
-  f64.const 0
-  global.get $std/math/INVALID
-  call $std/math/test_rem
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3209
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const -0
-  f64.const inf
-  f64.const -0
-  f64.const 0
-  i32.const 0
-  call $std/math/test_rem
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3210
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const -0
-  f64.const inf
-  f64.neg
-  f64.const -0
-  f64.const 0
-  i32.const 0
-  call $std/math/test_rem
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3211
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const -0
-  f64.const nan:0x8000000000000
-  f64.const nan:0x8000000000000
-  f64.const 0
-  i32.const 0
-  call $std/math/test_rem
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3212
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const 1
-  f64.const 0
-  f64.const nan:0x8000000000000
-  f64.const 0
-  global.get $std/math/INVALID
-  call $std/math/test_rem
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3213
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const -1
-  f64.const 0
-  f64.const nan:0x8000000000000
-  f64.const 0
-  global.get $std/math/INVALID
-  call $std/math/test_rem
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3214
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const inf
-  f64.const 0
-  f64.const nan:0x8000000000000
-  f64.const 0
-  global.get $std/math/INVALID
-  call $std/math/test_rem
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3215
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const inf
-  f64.neg
-  f64.const 0
-  f64.const nan:0x8000000000000
-  f64.const 0
-  global.get $std/math/INVALID
-  call $std/math/test_rem
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3216
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const nan:0x8000000000000
-  f64.const 0
-  f64.const nan:0x8000000000000
-  f64.const 0
-  i32.const 0
-  call $std/math/test_rem
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3217
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const -1
-  f64.const -0
-  f64.const nan:0x8000000000000
-  f64.const 0
-  global.get $std/math/INVALID
-  call $std/math/test_rem
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3218
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const inf
-  f64.const -0
-  f64.const nan:0x8000000000000
-  f64.const 0
-  global.get $std/math/INVALID
-  call $std/math/test_rem
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3219
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const inf
-  f64.neg
-  f64.const -0
-  f64.const nan:0x8000000000000
-  f64.const 0
-  global.get $std/math/INVALID
-  call $std/math/test_rem
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3220
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const nan:0x8000000000000
-  f64.const -0
-  f64.const nan:0x8000000000000
-  f64.const 0
-  i32.const 0
-  call $std/math/test_rem
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3221
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const inf
-  f64.const 2
-  f64.const nan:0x8000000000000
-  f64.const 0
-  global.get $std/math/INVALID
-  call $std/math/test_rem
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3222
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const inf
-  f64.const -0.5
-  f64.const nan:0x8000000000000
-  f64.const 0
-  global.get $std/math/INVALID
-  call $std/math/test_rem
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3223
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const inf
-  f64.const nan:0x8000000000000
-  f64.const nan:0x8000000000000
-  f64.const 0
-  i32.const 0
-  call $std/math/test_rem
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3224
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const inf
-  f64.neg
-  f64.const 2
-  f64.const nan:0x8000000000000
-  f64.const 0
-  global.get $std/math/INVALID
-  call $std/math/test_rem
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3225
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const inf
-  f64.neg
-  f64.const -0.5
-  f64.const nan:0x8000000000000
-  f64.const 0
-  global.get $std/math/INVALID
-  call $std/math/test_rem
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3226
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const inf
-  f64.neg
-  f64.const nan:0x8000000000000
-  f64.const nan:0x8000000000000
-  f64.const 0
-  i32.const 0
-  call $std/math/test_rem
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3227
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const nan:0x8000000000000
-  f64.const nan:0x8000000000000
-  f64.const nan:0x8000000000000
-  f64.const 0
-  i32.const 0
-  call $std/math/test_rem
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3228
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const 1
-  f64.const nan:0x8000000000000
-  f64.const nan:0x8000000000000
-  f64.const 0
-  i32.const 0
-  call $std/math/test_rem
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3229
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const -1
-  f64.const nan:0x8000000000000
-  f64.const nan:0x8000000000000
-  f64.const 0
-  i32.const 0
-  call $std/math/test_rem
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3230
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const 1
-  f64.const inf
-  f64.const 1
-  f64.const 0
-  i32.const 0
-  call $std/math/test_rem
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3231
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const -1
-  f64.const inf
-  f64.const -1
-  f64.const 0
-  i32.const 0
-  call $std/math/test_rem
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3232
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const inf
-  f64.const inf
-  f64.const nan:0x8000000000000
-  f64.const 0
-  global.get $std/math/INVALID
-  call $std/math/test_rem
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3233
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const inf
-  f64.neg
-  f64.const inf
-  f64.const nan:0x8000000000000
-  f64.const 0
-  global.get $std/math/INVALID
-  call $std/math/test_rem
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3234
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const 1
-  f64.const inf
-  f64.neg
-  f64.const 1
-  f64.const 0
-  i32.const 0
-  call $std/math/test_rem
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3235
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const -1
-  f64.const inf
-  f64.neg
-  f64.const -1
-  f64.const 0
-  i32.const 0
-  call $std/math/test_rem
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3236
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const inf
-  f64.const inf
-  f64.neg
-  f64.const nan:0x8000000000000
-  f64.const 0
-  global.get $std/math/INVALID
-  call $std/math/test_rem
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3237
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const inf
-  f64.neg
-  f64.const inf
-  f64.neg
-  f64.const nan:0x8000000000000
-  f64.const 0
-  global.get $std/math/INVALID
-  call $std/math/test_rem
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3238
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const 1.75
-  f64.const 0.5
-  f64.const -0.25
-  f64.const 0
-  i32.const 0
-  call $std/math/test_rem
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3239
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const -1.75
-  f64.const 0.5
-  f64.const 0.25
-  f64.const 0
-  i32.const 0
-  call $std/math/test_rem
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3240
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const 1.75
-  f64.const -0.5
-  f64.const -0.25
-  f64.const 0
-  i32.const 0
-  call $std/math/test_rem
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3241
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const -1.75
-  f64.const -0.5
-  f64.const 0.25
-  f64.const 0
-  i32.const 0
-  call $std/math/test_rem
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3242
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const 8e-323
-  f64.const inf
-  f64.const 8e-323
-  f64.const 0
-  i32.const 0
-  call $std/math/test_rem
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3243
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const -8.066848754882812
-  f32.const 4.535662651062012
-  f32.const 1.004476547241211
-  f32.const 0
-  i32.const 0
-  call $std/math/test_remf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3252
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const 4.345239639282227
-  f32.const -8.887990951538086
-  f32.const 4.345239639282227
-  f32.const 0
-  i32.const 0
-  call $std/math/test_remf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3253
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const -8.381433486938477
-  f32.const -2.7636072635650635
-  f32.const -0.09061169624328613
-  f32.const 0
-  i32.const 0
-  call $std/math/test_remf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3254
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const -6.531673431396484
-  f32.const 4.567535400390625
-  f32.const -1.9641380310058594
-  f32.const 0
-  i32.const 0
-  call $std/math/test_remf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3255
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const 9.267057418823242
-  f32.const 4.811392307281494
-  f32.const -0.3557271957397461
-  f32.const 0
-  i32.const 0
-  call $std/math/test_remf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3256
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const -6.450045585632324
-  f32.const 0.6620717644691467
-  f32.const 0.17067205905914307
-  f32.const 0
-  i32.const 0
-  call $std/math/test_remf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3257
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const 7.858890056610107
-  f32.const 0.052154526114463806
-  f32.const -0.016443386673927307
-  f32.const 0
-  i32.const 0
-  call $std/math/test_remf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3258
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const -0.7920545339584351
-  f32.const 7.676402568817139
-  f32.const -0.7920545339584351
-  f32.const 0
-  i32.const 0
-  call $std/math/test_remf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3259
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const 0.6157026886940002
-  f32.const 2.0119025707244873
-  f32.const 0.6157026886940002
-  f32.const 0
-  i32.const 0
-  call $std/math/test_remf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3260
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const -0.5587586760520935
-  f32.const 0.03223983198404312
-  f32.const -0.010681532323360443
-  f32.const 0
-  i32.const 0
-  call $std/math/test_remf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3261
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const 0
-  f32.const 1
-  f32.const 0
-  f32.const 0
-  i32.const 0
-  call $std/math/test_remf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3264
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const -0
-  f32.const 1
-  f32.const -0
-  f32.const 0
-  i32.const 0
-  call $std/math/test_remf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3265
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const 0.5
-  f32.const 1
-  f32.const 0.5
-  f32.const 0
-  i32.const 0
-  call $std/math/test_remf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3266
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const -0.5
-  f32.const 1
-  f32.const -0.5
-  f32.const 0
-  i32.const 0
-  call $std/math/test_remf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3267
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const 1
-  f32.const 1
-  f32.const 0
-  f32.const 0
-  i32.const 0
-  call $std/math/test_remf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3268
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const -1
-  f32.const 1
-  f32.const -0
-  f32.const 0
-  i32.const 0
-  call $std/math/test_remf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3269
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const 1.5
-  f32.const 1
-  f32.const -0.5
-  f32.const 0
-  i32.const 0
-  call $std/math/test_remf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3270
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const -1.5
-  f32.const 1
-  f32.const 0.5
-  f32.const 0
-  i32.const 0
-  call $std/math/test_remf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3271
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const 2
-  f32.const 1
-  f32.const 0
-  f32.const 0
-  i32.const 0
-  call $std/math/test_remf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3272
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const -2
-  f32.const 1
-  f32.const -0
-  f32.const 0
-  i32.const 0
-  call $std/math/test_remf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3273
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const inf
-  f32.const 1
-  f32.const nan:0x400000
-  f32.const 0
-  global.get $std/math/INVALID
-  call $std/math/test_remf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3274
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const inf
-  f32.neg
-  f32.const 1
-  f32.const nan:0x400000
-  f32.const 0
-  global.get $std/math/INVALID
-  call $std/math/test_remf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3275
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const nan:0x400000
-  f32.const 1
-  f32.const nan:0x400000
-  f32.const 0
-  i32.const 0
-  call $std/math/test_remf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3276
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const 0
-  f32.const -1
-  f32.const 0
-  f32.const 0
-  i32.const 0
-  call $std/math/test_remf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3277
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const -0
-  f32.const -1
-  f32.const -0
-  f32.const 0
-  i32.const 0
-  call $std/math/test_remf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3278
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const 0.5
-  f32.const -1
-  f32.const 0.5
-  f32.const 0
-  i32.const 0
-  call $std/math/test_remf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3279
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const -0.5
-  f32.const -1
-  f32.const -0.5
-  f32.const 0
-  i32.const 0
-  call $std/math/test_remf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3280
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const 1
-  f32.const -1
-  f32.const 0
-  f32.const 0
-  i32.const 0
-  call $std/math/test_remf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3281
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const -1
-  f32.const -1
-  f32.const -0
-  f32.const 0
-  i32.const 0
-  call $std/math/test_remf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3282
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const 1.5
-  f32.const -1
-  f32.const -0.5
-  f32.const 0
-  i32.const 0
-  call $std/math/test_remf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3283
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const -1.5
-  f32.const -1
-  f32.const 0.5
-  f32.const 0
-  i32.const 0
-  call $std/math/test_remf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3284
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const 2
-  f32.const -1
-  f32.const 0
-  f32.const 0
-  i32.const 0
-  call $std/math/test_remf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3285
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const -2
-  f32.const -1
-  f32.const -0
-  f32.const 0
-  i32.const 0
-  call $std/math/test_remf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3286
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const inf
-  f32.const -1
-  f32.const nan:0x400000
-  f32.const 0
-  global.get $std/math/INVALID
-  call $std/math/test_remf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3287
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const inf
-  f32.neg
-  f32.const -1
-  f32.const nan:0x400000
-  f32.const 0
-  global.get $std/math/INVALID
-  call $std/math/test_remf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3288
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const nan:0x400000
-  f32.const -1
-  f32.const nan:0x400000
-  f32.const 0
-  i32.const 0
-  call $std/math/test_remf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3289
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const 0
-  f32.const 0
-  f32.const nan:0x400000
-  f32.const 0
-  global.get $std/math/INVALID
-  call $std/math/test_remf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3290
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const 0
-  f32.const -0
-  f32.const nan:0x400000
-  f32.const 0
-  global.get $std/math/INVALID
-  call $std/math/test_remf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3291
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const 0
-  f32.const inf
-  f32.const 0
-  f32.const 0
-  i32.const 0
-  call $std/math/test_remf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3292
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const 0
-  f32.const inf
-  f32.neg
-  f32.const 0
-  f32.const 0
-  i32.const 0
-  call $std/math/test_remf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3293
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const 0
-  f32.const nan:0x400000
-  f32.const nan:0x400000
-  f32.const 0
-  i32.const 0
-  call $std/math/test_remf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3294
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const -0
-  f32.const 0
-  f32.const nan:0x400000
-  f32.const 0
-  global.get $std/math/INVALID
-  call $std/math/test_remf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3295
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const -0
-  f32.const -0
-  f32.const nan:0x400000
-  f32.const 0
-  global.get $std/math/INVALID
-  call $std/math/test_remf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3296
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const -0
-  f32.const inf
-  f32.const -0
-  f32.const 0
-  i32.const 0
-  call $std/math/test_remf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3297
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const -0
-  f32.const inf
-  f32.neg
-  f32.const -0
-  f32.const 0
-  i32.const 0
-  call $std/math/test_remf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3298
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const -0
-  f32.const nan:0x400000
-  f32.const nan:0x400000
-  f32.const 0
-  i32.const 0
-  call $std/math/test_remf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3299
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const 1
-  f32.const 0
-  f32.const nan:0x400000
-  f32.const 0
-  global.get $std/math/INVALID
-  call $std/math/test_remf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3300
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const -1
-  f32.const 0
-  f32.const nan:0x400000
-  f32.const 0
-  global.get $std/math/INVALID
-  call $std/math/test_remf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3301
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const inf
-  f32.const 0
-  f32.const nan:0x400000
-  f32.const 0
-  global.get $std/math/INVALID
-  call $std/math/test_remf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3302
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const inf
-  f32.neg
-  f32.const 0
-  f32.const nan:0x400000
-  f32.const 0
-  global.get $std/math/INVALID
-  call $std/math/test_remf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3303
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const nan:0x400000
-  f32.const 0
-  f32.const nan:0x400000
-  f32.const 0
-  i32.const 0
-  call $std/math/test_remf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3304
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const -1
-  f32.const -0
-  f32.const nan:0x400000
-  f32.const 0
-  global.get $std/math/INVALID
-  call $std/math/test_remf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3305
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const inf
-  f32.const -0
-  f32.const nan:0x400000
-  f32.const 0
-  global.get $std/math/INVALID
-  call $std/math/test_remf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3306
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const inf
-  f32.neg
-  f32.const -0
-  f32.const nan:0x400000
-  f32.const 0
-  global.get $std/math/INVALID
-  call $std/math/test_remf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3307
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const nan:0x400000
-  f32.const -0
-  f32.const nan:0x400000
-  f32.const 0
-  i32.const 0
-  call $std/math/test_remf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3308
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const inf
-  f32.const 2
-  f32.const nan:0x400000
-  f32.const 0
-  global.get $std/math/INVALID
-  call $std/math/test_remf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3309
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const inf
-  f32.const -0.5
-  f32.const nan:0x400000
-  f32.const 0
-  global.get $std/math/INVALID
-  call $std/math/test_remf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3310
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const inf
-  f32.const nan:0x400000
-  f32.const nan:0x400000
-  f32.const 0
-  i32.const 0
-  call $std/math/test_remf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3311
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const inf
-  f32.neg
-  f32.const 2
-  f32.const nan:0x400000
-  f32.const 0
-  global.get $std/math/INVALID
-  call $std/math/test_remf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3312
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const inf
-  f32.neg
-  f32.const -0.5
-  f32.const nan:0x400000
-  f32.const 0
-  global.get $std/math/INVALID
-  call $std/math/test_remf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3313
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const inf
-  f32.neg
-  f32.const nan:0x400000
-  f32.const nan:0x400000
-  f32.const 0
-  i32.const 0
-  call $std/math/test_remf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3314
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const nan:0x400000
-  f32.const nan:0x400000
-  f32.const nan:0x400000
-  f32.const 0
-  i32.const 0
-  call $std/math/test_remf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3315
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const 1
-  f32.const nan:0x400000
-  f32.const nan:0x400000
-  f32.const 0
-  i32.const 0
-  call $std/math/test_remf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3316
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const -1
-  f32.const nan:0x400000
-  f32.const nan:0x400000
-  f32.const 0
-  i32.const 0
-  call $std/math/test_remf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3317
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const 1
-  f32.const inf
-  f32.const 1
-  f32.const 0
-  i32.const 0
-  call $std/math/test_remf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3318
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const -1
-  f32.const inf
-  f32.const -1
-  f32.const 0
-  i32.const 0
-  call $std/math/test_remf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3319
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const inf
-  f32.const inf
-  f32.const nan:0x400000
-  f32.const 0
-  global.get $std/math/INVALID
-  call $std/math/test_remf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3320
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const inf
-  f32.neg
-  f32.const inf
-  f32.const nan:0x400000
-  f32.const 0
-  global.get $std/math/INVALID
-  call $std/math/test_remf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3321
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const 1
-  f32.const inf
-  f32.neg
-  f32.const 1
-  f32.const 0
-  i32.const 0
-  call $std/math/test_remf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3322
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const -1
-  f32.const inf
-  f32.neg
-  f32.const -1
-  f32.const 0
-  i32.const 0
-  call $std/math/test_remf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3323
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const inf
-  f32.const inf
-  f32.neg
-  f32.const nan:0x400000
-  f32.const 0
-  global.get $std/math/INVALID
-  call $std/math/test_remf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3324
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const inf
-  f32.neg
-  f32.const inf
-  f32.neg
-  f32.const nan:0x400000
-  f32.const 0
-  global.get $std/math/INVALID
-  call $std/math/test_remf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3325
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const 1.75
-  f32.const 0.5
-  f32.const -0.25
-  f32.const 0
-  i32.const 0
-  call $std/math/test_remf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3326
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const -1.75
-  f32.const 0.5
-  f32.const 0.25
-  f32.const 0
-  i32.const 0
-  call $std/math/test_remf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3327
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const 1.75
-  f32.const -0.5
-  f32.const -0.25
-  f32.const 0
-  i32.const 0
-  call $std/math/test_remf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3328
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const -1.75
-  f32.const -0.5
-  f32.const 0.25
-  f32.const 0
-  i32.const 0
-  call $std/math/test_remf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3329
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const 5.877471754111438e-39
-  f32.const inf
-  f32.const 5.877471754111438e-39
-  f32.const 0
-  i32.const 0
-  call $std/math/test_remf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3330
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
+  block $~lib/math/NativeMath.signbit<f32>|inlined.2 (result i32)
+   f32.const 0
+   local.set $4
+   i32.const 0
+   drop
+   i32.const 1
+   drop
+   i32.const 4
+   i32.const 4
+   i32.eq
+   drop
+   local.get $4
+   i32.reinterpret_f32
+   i32.const 31
+   i32.shr_u
+   br $~lib/math/NativeMath.signbit<f32>|inlined.2
+  end
+  i32.const 0
+  i32.ne
+  i32.const 0
+  i32.eq
+  drop
+  block $~lib/math/NativeMath.signbit<f32>|inlined.3 (result i32)
+   f32.const -0
+   local.set $4
+   i32.const 0
+   drop
+   i32.const 1
+   drop
+   i32.const 4
+   i32.const 4
+   i32.eq
+   drop
+   local.get $4
+   i32.reinterpret_f32
+   i32.const 31
+   i32.shr_u
+   br $~lib/math/NativeMath.signbit<f32>|inlined.3
+  end
+  i32.const 0
+  i32.ne
+  i32.const 1
+  i32.eq
+  drop
+  block $~lib/math/NativeMath.signbit<f32>|inlined.4 (result i32)
+   f32.const 1
+   local.set $4
+   i32.const 0
+   drop
+   i32.const 1
+   drop
+   i32.const 4
+   i32.const 4
+   i32.eq
+   drop
+   local.get $4
+   i32.reinterpret_f32
+   i32.const 31
+   i32.shr_u
+   br $~lib/math/NativeMath.signbit<f32>|inlined.4
+  end
+  i32.const 0
+  i32.ne
+  i32.const 0
+  i32.eq
+  drop
+  block $~lib/math/NativeMath.signbit<f32>|inlined.5 (result i32)
+   f32.const -1
+   local.set $4
+   i32.const 0
+   drop
+   i32.const 1
+   drop
+   i32.const 4
+   i32.const 4
+   i32.eq
+   drop
+   local.get $4
+   i32.reinterpret_f32
+   i32.const 31
+   i32.shr_u
+   br $~lib/math/NativeMath.signbit<f32>|inlined.5
+  end
+  i32.const 0
+  i32.ne
+  i32.const 1
+  i32.eq
+  drop
+  block $~lib/math/NativeMath.signbit<f32>|inlined.6 (result i32)
+   f32.const nan:0x400000
+   local.set $4
+   i32.const 0
+   drop
+   i32.const 1
+   drop
+   i32.const 4
+   i32.const 4
+   i32.eq
+   drop
+   local.get $4
+   i32.reinterpret_f32
+   i32.const 31
+   i32.shr_u
+   br $~lib/math/NativeMath.signbit<f32>|inlined.6
+  end
+  i32.const 0
+  i32.ne
+  i32.const 0
+  i32.eq
+  drop
+  block $~lib/math/NativeMath.signbit<f32>|inlined.7 (result i32)
+   f32.const nan:0x400000
+   f32.neg
+   local.set $4
+   i32.const 0
+   drop
+   i32.const 1
+   drop
+   i32.const 4
+   i32.const 4
+   i32.eq
+   drop
+   local.get $4
+   i32.reinterpret_f32
+   i32.const 31
+   i32.shr_u
+   br $~lib/math/NativeMath.signbit<f32>|inlined.7
+  end
+  i32.const 0
+  i32.ne
+  i32.const 1
+  i32.eq
+  drop
+  block $~lib/math/NativeMath.signbit<f32>|inlined.8 (result i32)
+   f32.const inf
+   local.set $4
+   i32.const 0
+   drop
+   i32.const 1
+   drop
+   i32.const 4
+   i32.const 4
+   i32.eq
+   drop
+   local.get $4
+   i32.reinterpret_f32
+   i32.const 31
+   i32.shr_u
+   br $~lib/math/NativeMath.signbit<f32>|inlined.8
+  end
+  i32.const 0
+  i32.ne
+  i32.const 0
+  i32.eq
+  drop
+  block $~lib/math/NativeMath.signbit<f32>|inlined.9 (result i32)
+   f32.const inf
+   f32.neg
+   local.set $4
+   i32.const 0
+   drop
+   i32.const 1
+   drop
+   i32.const 4
+   i32.const 4
+   i32.eq
+   drop
+   local.get $4
+   i32.reinterpret_f32
+   i32.const 31
+   i32.shr_u
+   br $~lib/math/NativeMath.signbit<f32>|inlined.9
+  end
+  i32.const 0
+  i32.ne
+  i32.const 1
+  i32.eq
+  drop
   f64.const -8.06684839057968
   f64.const -0.9774292928781227
   f64.const -0.14564912021160126
@@ -50933,7 +49735,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3342
+   i32.const 3155
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -50947,7 +49749,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3343
+   i32.const 3156
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -50961,7 +49763,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3344
+   i32.const 3157
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -50975,7 +49777,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3345
+   i32.const 3158
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -50989,7 +49791,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3346
+   i32.const 3159
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -51003,7 +49805,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3347
+   i32.const 3160
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -51017,7 +49819,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3348
+   i32.const 3161
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -51031,7 +49833,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3349
+   i32.const 3162
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -51045,7 +49847,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3350
+   i32.const 3163
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -51059,7 +49861,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3351
+   i32.const 3164
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -51073,7 +49875,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3354
+   i32.const 3167
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -51087,7 +49889,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3355
+   i32.const 3168
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -51101,7 +49903,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3356
+   i32.const 3169
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -51115,7 +49917,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3357
+   i32.const 3170
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -51131,7 +49933,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3358
+   i32.const 3171
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -51147,7 +49949,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3359
+   i32.const 3172
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -51161,7 +49963,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3360
+   i32.const 3173
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -51175,7 +49977,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3361
+   i32.const 3174
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -51189,7 +49991,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3362
+   i32.const 3175
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -51203,7 +50005,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3363
+   i32.const 3176
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -51217,7 +50019,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3364
+   i32.const 3177
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -51231,7 +50033,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3365
+   i32.const 3178
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -51245,7 +50047,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3366
+   i32.const 3179
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -51259,7 +50061,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3367
+   i32.const 3180
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -51273,7 +50075,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3368
+   i32.const 3181
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -51287,7 +50089,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3369
+   i32.const 3182
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -51301,7 +50103,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3370
+   i32.const 3183
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -51315,7 +50117,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3371
+   i32.const 3184
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -51329,7 +50131,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3372
+   i32.const 3185
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -51343,7 +50145,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3373
+   i32.const 3186
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -51357,7 +50159,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3374
+   i32.const 3187
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -51371,7 +50173,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3375
+   i32.const 3188
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -51385,7 +50187,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3376
+   i32.const 3189
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -51399,7 +50201,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3377
+   i32.const 3190
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -51413,7 +50215,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3378
+   i32.const 3191
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -51429,7 +50231,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3379
+   i32.const 3192
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -51445,7 +50247,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3380
+   i32.const 3193
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -51461,7 +50263,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3381
+   i32.const 3194
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -51477,7 +50279,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3382
+   i32.const 3195
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -51493,7 +50295,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3383
+   i32.const 3196
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -51509,7 +50311,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3384
+   i32.const 3197
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -51525,7 +50327,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3385
+   i32.const 3198
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -51541,7 +50343,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3386
+   i32.const 3199
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -51557,7 +50359,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3387
+   i32.const 3200
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -51573,7 +50375,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3388
+   i32.const 3201
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -51589,7 +50391,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3389
+   i32.const 3202
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -51605,7 +50407,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3390
+   i32.const 3203
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -51619,7 +50421,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3393
+   i32.const 3206
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -51633,7 +50435,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3394
+   i32.const 3207
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -51647,7 +50449,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3395
+   i32.const 3208
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -51662,7 +50464,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3396
+   i32.const 3209
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -51676,296 +50478,585 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3397
+   i32.const 3210
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
-  global.get $std/math/kPI
-  f64.const 2
-  f64.div
-  call $~lib/math/NativeMath.sin
-  global.get $std/math/kPI
-  f64.const 2
-  f64.div
-  call $~lib/bindings/dom/Math.sin
-  f64.eq
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3400
+  block $~lib/math/NativeMath.sin<f64>|inlined.1 (result f64)
+   f64.const 1
+   global.get $std/math/kPI
+   f64.mul
+   f64.const 2
+   f64.div
+   local.set $1
    i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const 2
-  global.get $std/math/kPI
-  f64.mul
-  f64.const 2
-  f64.div
-  call $~lib/math/NativeMath.sin
-  f64.const 2
-  global.get $std/math/kPI
-  f64.mul
-  f64.const 2
-  f64.div
-  call $~lib/bindings/dom/Math.sin
-  f64.eq
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3401
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const 2.3283064365386963e-10
-  f64.const 2.3283064365386963e-10
-  call $~lib/math/NativeMath.sin
-  f64.eq
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3404
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const -2.3283064365386963e-10
-  f64.const -2.3283064365386963e-10
-  call $~lib/math/NativeMath.sin
-  f64.eq
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3405
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const 0.3826834323650898
-  f64.const 0.39269908169872414
-  call $~lib/math/NativeMath.sin
-  f64.eq
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3407
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const -0.3826834323650898
-  f64.const -0.39269908169872414
-  call $~lib/math/NativeMath.sin
-  f64.eq
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3408
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const 0.479425538604203
-  f64.const 0.5
-  call $~lib/math/NativeMath.sin
-  f64.eq
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3411
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const -0.479425538604203
-  f64.const -0.5
-  call $~lib/math/NativeMath.sin
-  f64.eq
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3412
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
+   drop
+   i32.const 8
+   i32.const 4
+   i32.eq
+   drop
+   i32.const 8
+   i32.const 8
+   i32.eq
+   drop
+   local.get $1
+   call $~lib/util/math/sin64
+   br $~lib/math/NativeMath.sin<f64>|inlined.1
   end
   f64.const 1
   global.get $std/math/kPI
+  f64.mul
   f64.const 2
   f64.div
-  call $~lib/math/NativeMath.sin
+  call $~lib/bindings/dom/Math.sin
   f64.eq
   i32.eqz
   if
    i32.const 0
    i32.const 32
-   i32.const 3413
+   i32.const 3213
    i32.const 1
    call $~lib/builtins/abort
    unreachable
+  end
+  block $~lib/math/NativeMath.sin<f64>|inlined.2 (result f64)
+   f64.const 2
+   global.get $std/math/kPI
+   f64.mul
+   f64.const 2
+   f64.div
+   local.set $0
+   i32.const 1
+   drop
+   i32.const 8
+   i32.const 4
+   i32.eq
+   drop
+   i32.const 8
+   i32.const 8
+   i32.eq
+   drop
+   local.get $0
+   call $~lib/util/math/sin64
+   br $~lib/math/NativeMath.sin<f64>|inlined.2
+  end
+  f64.const 2
+  global.get $std/math/kPI
+  f64.mul
+  f64.const 2
+  f64.div
+  call $~lib/bindings/dom/Math.sin
+  f64.eq
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 3214
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  block $~lib/math/NativeMath.sin<f64>|inlined.3 (result f64)
+   f64.const 2.3283064365386963e-10
+   local.set $1
+   i32.const 1
+   drop
+   i32.const 8
+   i32.const 4
+   i32.eq
+   drop
+   i32.const 8
+   i32.const 8
+   i32.eq
+   drop
+   local.get $1
+   call $~lib/util/math/sin64
+   br $~lib/math/NativeMath.sin<f64>|inlined.3
+  end
+  f64.const 2.3283064365386963e-10
+  f64.eq
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 3217
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  block $~lib/math/NativeMath.sin<f64>|inlined.4 (result f64)
+   f64.const -2.3283064365386963e-10
+   local.set $0
+   i32.const 1
+   drop
+   i32.const 8
+   i32.const 4
+   i32.eq
+   drop
+   i32.const 8
+   i32.const 8
+   i32.eq
+   drop
+   local.get $0
+   call $~lib/util/math/sin64
+   br $~lib/math/NativeMath.sin<f64>|inlined.4
+  end
+  f64.const -2.3283064365386963e-10
+  f64.eq
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 3218
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  block $~lib/math/NativeMath.sin<f64>|inlined.5 (result f64)
+   f64.const 0.39269908169872414
+   local.set $1
+   i32.const 1
+   drop
+   i32.const 8
+   i32.const 4
+   i32.eq
+   drop
+   i32.const 8
+   i32.const 8
+   i32.eq
+   drop
+   local.get $1
+   call $~lib/util/math/sin64
+   br $~lib/math/NativeMath.sin<f64>|inlined.5
+  end
+  f64.const 0.3826834323650898
+  f64.eq
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 3220
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  block $~lib/math/NativeMath.sin<f64>|inlined.6 (result f64)
+   f64.const -0.39269908169872414
+   local.set $0
+   i32.const 1
+   drop
+   i32.const 8
+   i32.const 4
+   i32.eq
+   drop
+   i32.const 8
+   i32.const 8
+   i32.eq
+   drop
+   local.get $0
+   call $~lib/util/math/sin64
+   br $~lib/math/NativeMath.sin<f64>|inlined.6
+  end
+  f64.const -0.3826834323650898
+  f64.eq
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 3221
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  block $~lib/math/NativeMath.sin<f64>|inlined.7 (result f64)
+   f64.const 0.5
+   local.set $1
+   i32.const 1
+   drop
+   i32.const 8
+   i32.const 4
+   i32.eq
+   drop
+   i32.const 8
+   i32.const 8
+   i32.eq
+   drop
+   local.get $1
+   call $~lib/util/math/sin64
+   br $~lib/math/NativeMath.sin<f64>|inlined.7
+  end
+  f64.const 0.479425538604203
+  f64.eq
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 3224
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  block $~lib/math/NativeMath.sin<f64>|inlined.8 (result f64)
+   f64.const -0.5
+   local.set $0
+   i32.const 1
+   drop
+   i32.const 8
+   i32.const 4
+   i32.eq
+   drop
+   i32.const 8
+   i32.const 8
+   i32.eq
+   drop
+   local.get $0
+   call $~lib/util/math/sin64
+   br $~lib/math/NativeMath.sin<f64>|inlined.8
+  end
+  f64.const -0.479425538604203
+  f64.eq
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 3225
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  block $~lib/math/NativeMath.sin<f64>|inlined.9 (result f64)
+   global.get $std/math/kPI
+   f64.const 2
+   f64.div
+   local.set $1
+   i32.const 1
+   drop
+   i32.const 8
+   i32.const 4
+   i32.eq
+   drop
+   i32.const 8
+   i32.const 8
+   i32.eq
+   drop
+   local.get $1
+   call $~lib/util/math/sin64
+   br $~lib/math/NativeMath.sin<f64>|inlined.9
+  end
+  f64.const 1
+  f64.eq
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 3226
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  block $~lib/math/NativeMath.sin<f64>|inlined.10 (result f64)
+   global.get $std/math/kPI
+   f64.neg
+   f64.const 2
+   f64.div
+   local.set $0
+   i32.const 1
+   drop
+   i32.const 8
+   i32.const 4
+   i32.eq
+   drop
+   i32.const 8
+   i32.const 8
+   i32.eq
+   drop
+   local.get $0
+   call $~lib/util/math/sin64
+   br $~lib/math/NativeMath.sin<f64>|inlined.10
   end
   f64.const -1
-  global.get $std/math/kPI
-  f64.neg
-  f64.const 2
-  f64.div
-  call $~lib/math/NativeMath.sin
   f64.eq
   i32.eqz
   if
    i32.const 0
    i32.const 32
-   i32.const 3414
+   i32.const 3227
    i32.const 1
    call $~lib/builtins/abort
    unreachable
+  end
+  block $~lib/math/NativeMath.sin<f64>|inlined.11 (result f64)
+   global.get $std/math/kPI
+   local.set $1
+   i32.const 1
+   drop
+   i32.const 8
+   i32.const 4
+   i32.eq
+   drop
+   i32.const 8
+   i32.const 8
+   i32.eq
+   drop
+   local.get $1
+   call $~lib/util/math/sin64
+   br $~lib/math/NativeMath.sin<f64>|inlined.11
   end
   f64.const 1.2246467991473532e-16
-  global.get $std/math/kPI
-  call $~lib/math/NativeMath.sin
   f64.eq
   i32.eqz
   if
    i32.const 0
    i32.const 32
-   i32.const 3416
+   i32.const 3229
    i32.const 1
    call $~lib/builtins/abort
    unreachable
+  end
+  block $~lib/math/NativeMath.sin<f64>|inlined.12 (result f64)
+   f64.const 2200
+   global.get $std/math/kPI
+   f64.mul
+   local.set $0
+   i32.const 1
+   drop
+   i32.const 8
+   i32.const 4
+   i32.eq
+   drop
+   i32.const 8
+   i32.const 8
+   i32.eq
+   drop
+   local.get $0
+   call $~lib/util/math/sin64
+   br $~lib/math/NativeMath.sin<f64>|inlined.12
   end
   f64.const -7.047032979958965e-14
-  f64.const 2200
-  global.get $std/math/kPI
-  f64.mul
-  call $~lib/math/NativeMath.sin
   f64.eq
   i32.eqz
   if
    i32.const 0
    i32.const 32
-   i32.const 3417
+   i32.const 3230
    i32.const 1
    call $~lib/builtins/abort
    unreachable
+  end
+  block $~lib/math/NativeMath.sin<f64>|inlined.13 (result f64)
+   f64.const 7
+   f64.const 4
+   f64.div
+   global.get $std/math/kPI
+   f64.mul
+   local.set $1
+   i32.const 1
+   drop
+   i32.const 8
+   i32.const 4
+   i32.eq
+   drop
+   i32.const 8
+   i32.const 8
+   i32.eq
+   drop
+   local.get $1
+   call $~lib/util/math/sin64
+   br $~lib/math/NativeMath.sin<f64>|inlined.13
   end
   f64.const -0.7071067811865477
-  f64.const 7
-  f64.const 4
-  f64.div
-  global.get $std/math/kPI
-  f64.mul
-  call $~lib/math/NativeMath.sin
   f64.eq
   i32.eqz
   if
    i32.const 0
    i32.const 32
-   i32.const 3419
+   i32.const 3232
    i32.const 1
    call $~lib/builtins/abort
    unreachable
+  end
+  block $~lib/math/NativeMath.sin<f64>|inlined.14 (result f64)
+   f64.const 9
+   f64.const 4
+   f64.div
+   global.get $std/math/kPI
+   f64.mul
+   local.set $0
+   i32.const 1
+   drop
+   i32.const 8
+   i32.const 4
+   i32.eq
+   drop
+   i32.const 8
+   i32.const 8
+   i32.eq
+   drop
+   local.get $0
+   call $~lib/util/math/sin64
+   br $~lib/math/NativeMath.sin<f64>|inlined.14
   end
   f64.const 0.7071067811865474
-  f64.const 9
-  f64.const 4
-  f64.div
-  global.get $std/math/kPI
-  f64.mul
-  call $~lib/math/NativeMath.sin
   f64.eq
   i32.eqz
   if
    i32.const 0
    i32.const 32
-   i32.const 3420
+   i32.const 3233
    i32.const 1
    call $~lib/builtins/abort
    unreachable
+  end
+  block $~lib/math/NativeMath.sin<f64>|inlined.15 (result f64)
+   f64.const 11
+   f64.const 4
+   f64.div
+   global.get $std/math/kPI
+   f64.mul
+   local.set $1
+   i32.const 1
+   drop
+   i32.const 8
+   i32.const 4
+   i32.eq
+   drop
+   i32.const 8
+   i32.const 8
+   i32.eq
+   drop
+   local.get $1
+   call $~lib/util/math/sin64
+   br $~lib/math/NativeMath.sin<f64>|inlined.15
   end
   f64.const 0.7071067811865483
-  f64.const 11
-  f64.const 4
-  f64.div
-  global.get $std/math/kPI
-  f64.mul
-  call $~lib/math/NativeMath.sin
   f64.eq
   i32.eqz
   if
    i32.const 0
    i32.const 32
-   i32.const 3421
+   i32.const 3234
    i32.const 1
    call $~lib/builtins/abort
    unreachable
+  end
+  block $~lib/math/NativeMath.sin<f64>|inlined.16 (result f64)
+   f64.const 13
+   f64.const 4
+   f64.div
+   global.get $std/math/kPI
+   f64.mul
+   local.set $0
+   i32.const 1
+   drop
+   i32.const 8
+   i32.const 4
+   i32.eq
+   drop
+   i32.const 8
+   i32.const 8
+   i32.eq
+   drop
+   local.get $0
+   call $~lib/util/math/sin64
+   br $~lib/math/NativeMath.sin<f64>|inlined.16
   end
   f64.const -0.7071067811865479
-  f64.const 13
-  f64.const 4
-  f64.div
-  global.get $std/math/kPI
-  f64.mul
-  call $~lib/math/NativeMath.sin
   f64.eq
   i32.eqz
   if
    i32.const 0
    i32.const 32
-   i32.const 3422
+   i32.const 3235
    i32.const 1
    call $~lib/builtins/abort
    unreachable
+  end
+  block $~lib/math/NativeMath.sin<f64>|inlined.17 (result f64)
+   f64.const 1048576
+   f64.const 4
+   f64.div
+   global.get $std/math/kPI
+   f64.mul
+   local.set $1
+   i32.const 1
+   drop
+   i32.const 8
+   i32.const 4
+   i32.eq
+   drop
+   i32.const 8
+   i32.const 8
+   i32.eq
+   drop
+   local.get $1
+   call $~lib/util/math/sin64
+   br $~lib/math/NativeMath.sin<f64>|inlined.17
   end
   f64.const -3.2103381051568376e-11
-  f64.const 1048576
-  f64.const 4
-  f64.div
-  global.get $std/math/kPI
-  f64.mul
-  call $~lib/math/NativeMath.sin
   f64.eq
   i32.eqz
   if
    i32.const 0
    i32.const 32
-   i32.const 3423
+   i32.const 3236
    i32.const 1
    call $~lib/builtins/abort
    unreachable
+  end
+  block $~lib/math/NativeMath.sin<f64>|inlined.18 (result f64)
+   global.get $std/math/kTwo120
+   local.set $0
+   i32.const 1
+   drop
+   i32.const 8
+   i32.const 4
+   i32.eq
+   drop
+   i32.const 8
+   i32.const 8
+   i32.eq
+   drop
+   local.get $0
+   call $~lib/util/math/sin64
+   br $~lib/math/NativeMath.sin<f64>|inlined.18
   end
   f64.const 0.377820109360752
-  global.get $std/math/kTwo120
-  call $~lib/math/NativeMath.sin
   f64.eq
   i32.eqz
   if
    i32.const 0
    i32.const 32
-   i32.const 3426
+   i32.const 3239
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
+  block $~lib/math/NativeMath.sin<f64>|inlined.19 (result f64)
+   global.get $std/math/kTwo120
+   f64.neg
+   local.set $1
+   i32.const 1
+   drop
+   i32.const 8
+   i32.const 4
+   i32.eq
+   drop
+   i32.const 8
+   i32.const 8
+   i32.eq
+   drop
+   local.get $1
+   call $~lib/util/math/sin64
+   br $~lib/math/NativeMath.sin<f64>|inlined.19
+  end
   f64.const -0.377820109360752
-  global.get $std/math/kTwo120
-  f64.neg
-  call $~lib/math/NativeMath.sin
   f64.eq
   i32.eqz
   if
    i32.const 0
    i32.const 32
-   i32.const 3427
+   i32.const 3240
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -51979,7 +51070,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3436
+   i32.const 3249
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -51993,7 +51084,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3437
+   i32.const 3250
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -52007,7 +51098,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3438
+   i32.const 3251
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -52021,7 +51112,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3439
+   i32.const 3252
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -52035,7 +51126,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3440
+   i32.const 3253
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -52049,7 +51140,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3441
+   i32.const 3254
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -52063,7 +51154,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3442
+   i32.const 3255
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -52077,7 +51168,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3443
+   i32.const 3256
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -52091,7 +51182,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3444
+   i32.const 3257
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -52105,7 +51196,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3445
+   i32.const 3258
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -52119,7 +51210,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3448
+   i32.const 3261
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -52133,7 +51224,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3449
+   i32.const 3262
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -52147,7 +51238,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3450
+   i32.const 3263
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -52162,7 +51253,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3451
+   i32.const 3264
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -52176,7 +51267,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3452
+   i32.const 3265
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -52190,7 +51281,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3455
+   i32.const 3268
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -52204,7 +51295,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3456
+   i32.const 3269
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -52218,7 +51309,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3457
+   i32.const 3270
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -52232,7 +51323,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3458
+   i32.const 3271
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -52248,7 +51339,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3459
+   i32.const 3272
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -52264,7 +51355,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3460
+   i32.const 3273
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -52278,7 +51369,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3461
+   i32.const 3274
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -52292,7 +51383,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3462
+   i32.const 3275
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -52306,7 +51397,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3463
+   i32.const 3276
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -52320,7 +51411,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3464
+   i32.const 3277
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -52334,7 +51425,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3465
+   i32.const 3278
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -52348,7 +51439,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3466
+   i32.const 3279
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -52362,7 +51453,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3467
+   i32.const 3280
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -52376,7 +51467,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3468
+   i32.const 3281
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -52390,7 +51481,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3469
+   i32.const 3282
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -52404,7 +51495,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3470
+   i32.const 3283
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -52418,7 +51509,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3471
+   i32.const 3284
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -52432,7 +51523,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3472
+   i32.const 3285
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -52446,7 +51537,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3473
+   i32.const 3286
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -52460,7 +51551,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3474
+   i32.const 3287
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -52474,7 +51565,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3475
+   i32.const 3288
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -52488,7 +51579,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3476
+   i32.const 3289
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -52502,7 +51593,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3477
+   i32.const 3290
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -52516,7 +51607,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3478
+   i32.const 3291
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -52530,7 +51621,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3479
+   i32.const 3292
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -52544,7 +51635,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3480
+   i32.const 3293
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -52560,7 +51651,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3481
+   i32.const 3294
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -52576,7 +51667,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3482
+   i32.const 3295
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -52592,7 +51683,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3483
+   i32.const 3296
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -52608,7 +51699,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3484
+   i32.const 3297
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -52624,7 +51715,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3485
+   i32.const 3298
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -52640,7 +51731,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3486
+   i32.const 3299
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -52656,7 +51747,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3487
+   i32.const 3300
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -52672,7 +51763,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3488
+   i32.const 3301
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -52688,7 +51779,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3489
+   i32.const 3302
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -52704,7 +51795,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3490
+   i32.const 3303
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -52720,7 +51811,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3491
+   i32.const 3304
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -52736,7 +51827,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3492
+   i32.const 3305
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -52750,7 +51841,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3495
+   i32.const 3308
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -52764,7 +51855,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3496
+   i32.const 3309
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -52778,7 +51869,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3497
+   i32.const 3310
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -52792,7 +51883,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3498
+   i32.const 3311
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -52806,7 +51897,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3499
+   i32.const 3312
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -52820,7 +51911,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3500
+   i32.const 3313
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -52834,7 +51925,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3501
+   i32.const 3314
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -52848,7 +51939,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3502
+   i32.const 3315
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -52862,7 +51953,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3503
+   i32.const 3316
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -52876,7 +51967,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3504
+   i32.const 3317
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -52890,7 +51981,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3505
+   i32.const 3318
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -52904,7 +51995,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3506
+   i32.const 3319
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -52918,7 +52009,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3507
+   i32.const 3320
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -52933,7 +52024,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3508
+   i32.const 3321
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -52947,7 +52038,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3520
+   i32.const 3333
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -52961,7 +52052,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3521
+   i32.const 3334
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -52975,7 +52066,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3522
+   i32.const 3335
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -52989,7 +52080,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3523
+   i32.const 3336
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -53003,7 +52094,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3524
+   i32.const 3337
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -53017,7 +52108,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3525
+   i32.const 3338
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -53031,7 +52122,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3526
+   i32.const 3339
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -53045,7 +52136,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3527
+   i32.const 3340
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -53059,7 +52150,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3528
+   i32.const 3341
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -53073,7 +52164,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3529
+   i32.const 3342
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -53087,7 +52178,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3532
+   i32.const 3345
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -53101,7 +52192,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3533
+   i32.const 3346
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -53115,7 +52206,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3534
+   i32.const 3347
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -53131,7 +52222,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3535
+   i32.const 3348
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -53145,7 +52236,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3536
+   i32.const 3349
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -53159,7 +52250,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3545
+   i32.const 3358
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -53173,7 +52264,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3546
+   i32.const 3359
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -53187,7 +52278,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3547
+   i32.const 3360
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -53201,7 +52292,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3548
+   i32.const 3361
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -53215,7 +52306,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3549
+   i32.const 3362
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -53229,7 +52320,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3550
+   i32.const 3363
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -53243,7 +52334,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3551
+   i32.const 3364
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -53257,7 +52348,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3552
+   i32.const 3365
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -53271,7 +52362,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3553
+   i32.const 3366
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -53285,7 +52376,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3554
+   i32.const 3367
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -53299,7 +52390,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3557
+   i32.const 3370
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -53313,7 +52404,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3558
+   i32.const 3371
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -53327,7 +52418,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3559
+   i32.const 3372
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -53343,7 +52434,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3560
+   i32.const 3373
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -53357,7 +52448,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3561
+   i32.const 3374
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -53371,7 +52462,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3573
+   i32.const 3386
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -53385,7 +52476,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3574
+   i32.const 3387
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -53399,7 +52490,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3575
+   i32.const 3388
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -53413,7 +52504,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3576
+   i32.const 3389
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -53427,7 +52518,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3577
+   i32.const 3390
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -53441,7 +52532,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3578
+   i32.const 3391
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -53455,7 +52546,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3579
+   i32.const 3392
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -53469,7 +52560,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3580
+   i32.const 3393
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -53483,7 +52574,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3581
+   i32.const 3394
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -53497,7 +52588,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3582
+   i32.const 3395
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -53511,7 +52602,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3585
+   i32.const 3398
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -53525,7 +52616,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3586
+   i32.const 3399
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -53540,7 +52631,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3587
+   i32.const 3400
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -53554,7 +52645,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3588
+   i32.const 3401
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -53568,7 +52659,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3589
+   i32.const 3402
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -53582,7 +52673,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3590
+   i32.const 3403
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -53596,7 +52687,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3591
+   i32.const 3404
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -53610,7 +52701,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3592
+   i32.const 3405
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -53624,7 +52715,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3593
+   i32.const 3406
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -53638,7 +52729,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3594
+   i32.const 3407
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -53652,7 +52743,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3595
+   i32.const 3408
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -53666,7 +52757,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3596
+   i32.const 3409
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -53680,7 +52771,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3597
+   i32.const 3410
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -53694,7 +52785,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3598
+   i32.const 3411
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -53708,7 +52799,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3599
+   i32.const 3412
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -53722,7 +52813,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3600
+   i32.const 3413
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -53736,7 +52827,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3601
+   i32.const 3414
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -53750,7 +52841,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3602
+   i32.const 3415
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -53764,7 +52855,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3603
+   i32.const 3416
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -53778,7 +52869,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3604
+   i32.const 3417
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -53792,7 +52883,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3605
+   i32.const 3418
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -53806,7 +52897,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3606
+   i32.const 3419
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -53820,7 +52911,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3607
+   i32.const 3420
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -53834,7 +52925,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3608
+   i32.const 3421
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -53848,7 +52939,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3609
+   i32.const 3422
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -53862,7 +52953,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3610
+   i32.const 3423
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -53876,7 +52967,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3611
+   i32.const 3424
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -53890,7 +52981,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3612
+   i32.const 3425
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -53904,7 +52995,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3613
+   i32.const 3426
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -53918,7 +53009,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3614
+   i32.const 3427
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -53932,7 +53023,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3615
+   i32.const 3428
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -53946,7 +53037,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3616
+   i32.const 3429
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -53960,7 +53051,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3617
+   i32.const 3430
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -53974,7 +53065,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3618
+   i32.const 3431
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -53988,7 +53079,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3619
+   i32.const 3432
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -54002,7 +53093,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3620
+   i32.const 3433
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -54016,7 +53107,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3621
+   i32.const 3434
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -54030,7 +53121,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3622
+   i32.const 3435
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -54044,7 +53135,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3623
+   i32.const 3436
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -54058,7 +53149,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3624
+   i32.const 3437
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -54072,7 +53163,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3625
+   i32.const 3438
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -54086,7 +53177,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3626
+   i32.const 3439
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -54100,7 +53191,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3627
+   i32.const 3440
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -54114,7 +53205,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3628
+   i32.const 3441
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -54128,7 +53219,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3629
+   i32.const 3442
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -54142,7 +53233,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3630
+   i32.const 3443
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -54156,7 +53247,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3631
+   i32.const 3444
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -54170,7 +53261,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3632
+   i32.const 3445
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -54184,7 +53275,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3633
+   i32.const 3446
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -54198,7 +53289,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3634
+   i32.const 3447
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -54212,7 +53303,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3635
+   i32.const 3448
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -54226,7 +53317,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3636
+   i32.const 3449
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -54240,7 +53331,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3637
+   i32.const 3450
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -54254,7 +53345,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3638
+   i32.const 3451
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -54268,7 +53359,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3639
+   i32.const 3452
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -54282,7 +53373,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3640
+   i32.const 3453
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -54296,7 +53387,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3641
+   i32.const 3454
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -54310,7 +53401,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3642
+   i32.const 3455
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -54324,7 +53415,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3643
+   i32.const 3456
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -54338,7 +53429,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3644
+   i32.const 3457
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -54352,7 +53443,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3645
+   i32.const 3458
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -54366,7 +53457,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3646
+   i32.const 3459
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -54380,7 +53471,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3647
+   i32.const 3460
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -54394,7 +53485,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3648
+   i32.const 3461
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -54408,7 +53499,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3649
+   i32.const 3462
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -54422,7 +53513,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3650
+   i32.const 3463
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -54436,7 +53527,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3651
+   i32.const 3464
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -54450,7 +53541,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3652
+   i32.const 3465
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -54464,7 +53555,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3653
+   i32.const 3466
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -54478,7 +53569,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3654
+   i32.const 3467
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -54492,7 +53583,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3655
+   i32.const 3468
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -54506,7 +53597,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3656
+   i32.const 3469
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -54520,7 +53611,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3657
+   i32.const 3470
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -54534,7 +53625,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3658
+   i32.const 3471
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -54548,7 +53639,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3667
+   i32.const 3480
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -54562,7 +53653,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3668
+   i32.const 3481
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -54576,7 +53667,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3669
+   i32.const 3482
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -54590,7 +53681,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3670
+   i32.const 3483
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -54604,7 +53695,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3671
+   i32.const 3484
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -54618,7 +53709,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3672
+   i32.const 3485
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -54632,7 +53723,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3673
+   i32.const 3486
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -54646,7 +53737,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3674
+   i32.const 3487
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -54660,7 +53751,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3675
+   i32.const 3488
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -54674,7 +53765,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3676
+   i32.const 3489
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -54688,7 +53779,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3679
+   i32.const 3492
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -54702,7 +53793,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3680
+   i32.const 3493
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -54717,7 +53808,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3681
+   i32.const 3494
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -54731,7 +53822,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3682
+   i32.const 3495
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -54745,7 +53836,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3683
+   i32.const 3496
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -54759,7 +53850,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3684
+   i32.const 3497
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -54773,7 +53864,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3685
+   i32.const 3498
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -54787,7 +53878,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3686
+   i32.const 3499
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -54801,7 +53892,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3687
+   i32.const 3500
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -54815,7 +53906,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3688
+   i32.const 3501
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -54829,7 +53920,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3689
+   i32.const 3502
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -54843,7 +53934,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3690
+   i32.const 3503
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -54857,7 +53948,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3691
+   i32.const 3504
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -54871,7 +53962,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3692
+   i32.const 3505
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -54885,7 +53976,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3693
+   i32.const 3506
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -54899,7 +53990,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3694
+   i32.const 3507
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -54913,7 +54004,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3695
+   i32.const 3508
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -54927,7 +54018,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3696
+   i32.const 3509
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -54941,7 +54032,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3697
+   i32.const 3510
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -54955,7 +54046,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3698
+   i32.const 3511
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -54969,7 +54060,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3699
+   i32.const 3512
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -54983,7 +54074,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3700
+   i32.const 3513
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -54997,7 +54088,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3712
+   i32.const 3525
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -55011,7 +54102,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3713
+   i32.const 3526
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -55025,7 +54116,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3714
+   i32.const 3527
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -55039,7 +54130,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3715
+   i32.const 3528
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -55053,7 +54144,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3716
+   i32.const 3529
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -55067,7 +54158,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3717
+   i32.const 3530
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -55081,7 +54172,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3718
+   i32.const 3531
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -55095,7 +54186,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3719
+   i32.const 3532
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -55109,7 +54200,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3720
+   i32.const 3533
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -55123,7 +54214,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3721
+   i32.const 3534
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -55137,7 +54228,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3724
+   i32.const 3537
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -55151,7 +54242,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3725
+   i32.const 3538
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -55165,7 +54256,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3726
+   i32.const 3539
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -55179,7 +54270,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3727
+   i32.const 3540
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -55195,7 +54286,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3728
+   i32.const 3541
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -55211,7 +54302,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3729
+   i32.const 3542
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -55225,7 +54316,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3730
+   i32.const 3543
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -55239,7 +54330,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3731
+   i32.const 3544
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -55253,7 +54344,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3732
+   i32.const 3545
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -55267,7 +54358,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3733
+   i32.const 3546
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -55281,7 +54372,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3734
+   i32.const 3547
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -55295,7 +54386,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3735
+   i32.const 3548
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -55309,7 +54400,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3736
+   i32.const 3549
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -55323,7 +54414,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3737
+   i32.const 3550
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -55337,7 +54428,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3738
+   i32.const 3551
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -55351,7 +54442,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3739
+   i32.const 3552
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -55365,7 +54456,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3740
+   i32.const 3553
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -55379,7 +54470,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3741
+   i32.const 3554
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -55393,7 +54484,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3742
+   i32.const 3555
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -55407,7 +54498,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3743
+   i32.const 3556
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -55421,7 +54512,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3744
+   i32.const 3557
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -55435,7 +54526,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3745
+   i32.const 3558
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -55449,7 +54540,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3746
+   i32.const 3559
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -55463,7 +54554,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3747
+   i32.const 3560
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -55477,7 +54568,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3748
+   i32.const 3561
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -55491,7 +54582,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3749
+   i32.const 3562
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -55507,7 +54598,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3750
+   i32.const 3563
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -55523,7 +54614,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3751
+   i32.const 3564
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -55539,7 +54630,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3752
+   i32.const 3565
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -55555,7 +54646,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3753
+   i32.const 3566
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -55571,7 +54662,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3754
+   i32.const 3567
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -55587,7 +54678,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3755
+   i32.const 3568
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -55603,7 +54694,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3756
+   i32.const 3569
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -55619,7 +54710,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3757
+   i32.const 3570
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -55635,7 +54726,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3758
+   i32.const 3571
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -55651,7 +54742,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3759
+   i32.const 3572
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -55667,7 +54758,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3760
+   i32.const 3573
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -55683,13 +54774,28 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3761
+   i32.const 3574
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 2.3283064365386963e-10
-  call $~lib/math/NativeMath.tan
+  block $~lib/math/NativeMath.tan<f64>|inlined.1 (result f64)
+   f64.const 2.3283064365386963e-10
+   local.set $0
+   i32.const 1
+   drop
+   i32.const 8
+   i32.const 4
+   i32.eq
+   drop
+   i32.const 8
+   i32.const 8
+   i32.eq
+   drop
+   local.get $0
+   call $~lib/util/math/tan64
+   br $~lib/math/NativeMath.tan<f64>|inlined.1
+  end
   f64.const 2.3283064365386963e-10
   call $~lib/bindings/dom/Math.tan
   f64.eq
@@ -55697,13 +54803,28 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3764
+   i32.const 3577
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -2.3283064365386963e-10
-  call $~lib/math/NativeMath.tan
+  block $~lib/math/NativeMath.tan<f64>|inlined.2 (result f64)
+   f64.const -2.3283064365386963e-10
+   local.set $1
+   i32.const 1
+   drop
+   i32.const 8
+   i32.const 4
+   i32.eq
+   drop
+   i32.const 8
+   i32.const 8
+   i32.eq
+   drop
+   local.get $1
+   call $~lib/util/math/tan64
+   br $~lib/math/NativeMath.tan<f64>|inlined.2
+  end
   f64.const -2.3283064365386963e-10
   call $~lib/bindings/dom/Math.tan
   f64.eq
@@ -55711,63 +54832,123 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3765
+   i32.const 3578
    i32.const 1
    call $~lib/builtins/abort
    unreachable
+  end
+  block $~lib/math/NativeMath.tan<f64>|inlined.3 (result f64)
+   f64.const 11
+   f64.const 16
+   f64.div
+   local.set $0
+   i32.const 1
+   drop
+   i32.const 8
+   i32.const 4
+   i32.eq
+   drop
+   i32.const 8
+   i32.const 8
+   i32.eq
+   drop
+   local.get $0
+   call $~lib/util/math/tan64
+   br $~lib/math/NativeMath.tan<f64>|inlined.3
   end
   f64.const 11
   f64.const 16
   f64.div
-  call $~lib/math/NativeMath.tan
-  f64.const 11
-  f64.const 16
-  f64.div
   call $~lib/bindings/dom/Math.tan
   f64.eq
   i32.eqz
   if
    i32.const 0
    i32.const 32
-   i32.const 3766
+   i32.const 3579
    i32.const 1
    call $~lib/builtins/abort
    unreachable
+  end
+  block $~lib/math/NativeMath.tan<f64>|inlined.4 (result f64)
+   f64.const -11
+   f64.const 16
+   f64.div
+   local.set $1
+   i32.const 1
+   drop
+   i32.const 8
+   i32.const 4
+   i32.eq
+   drop
+   i32.const 8
+   i32.const 8
+   i32.eq
+   drop
+   local.get $1
+   call $~lib/util/math/tan64
+   br $~lib/math/NativeMath.tan<f64>|inlined.4
   end
   f64.const -11
   f64.const 16
   f64.div
-  call $~lib/math/NativeMath.tan
-  f64.const -11
-  f64.const 16
-  f64.div
   call $~lib/bindings/dom/Math.tan
   f64.eq
   i32.eqz
   if
    i32.const 0
    i32.const 32
-   i32.const 3767
+   i32.const 3580
    i32.const 1
    call $~lib/builtins/abort
    unreachable
+  end
+  block $~lib/math/NativeMath.tan<f64>|inlined.5 (result f64)
+   f64.const 0.39269908169872414
+   local.set $0
+   i32.const 1
+   drop
+   i32.const 8
+   i32.const 4
+   i32.eq
+   drop
+   i32.const 8
+   i32.const 8
+   i32.eq
+   drop
+   local.get $0
+   call $~lib/util/math/tan64
+   br $~lib/math/NativeMath.tan<f64>|inlined.5
   end
   f64.const 0.39269908169872414
-  call $~lib/math/NativeMath.tan
-  f64.const 0.39269908169872414
   call $~lib/bindings/dom/Math.tan
   f64.eq
   i32.eqz
   if
    i32.const 0
    i32.const 32
-   i32.const 3768
+   i32.const 3581
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 0.6743358
-  call $~lib/math/NativeMath.tan
+  block $~lib/math/NativeMath.tan<f64>|inlined.6 (result f64)
+   f64.const 0.6743358
+   local.set $1
+   i32.const 1
+   drop
+   i32.const 8
+   i32.const 4
+   i32.eq
+   drop
+   i32.const 8
+   i32.const 8
+   i32.eq
+   drop
+   local.get $1
+   call $~lib/util/math/tan64
+   br $~lib/math/NativeMath.tan<f64>|inlined.6
+  end
   f64.const 0.6743358
   call $~lib/bindings/dom/Math.tan
   f64.eq
@@ -55775,13 +54956,28 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3769
+   i32.const 3582
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 3.725290298461914e-09
-  call $~lib/math/NativeMath.tan
+  block $~lib/math/NativeMath.tan<f64>|inlined.7 (result f64)
+   f64.const 3.725290298461914e-09
+   local.set $0
+   i32.const 1
+   drop
+   i32.const 8
+   i32.const 4
+   i32.eq
+   drop
+   i32.const 8
+   i32.const 8
+   i32.eq
+   drop
+   local.get $0
+   call $~lib/util/math/tan64
+   br $~lib/math/NativeMath.tan<f64>|inlined.7
+  end
   f64.const 3.725290298461914e-09
   call $~lib/bindings/dom/Math.tan
   f64.eq
@@ -55789,31 +54985,61 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3770
+   i32.const 3583
    i32.const 1
    call $~lib/builtins/abort
    unreachable
+  end
+  block $~lib/math/NativeMath.tan<f64>|inlined.8 (result f64)
+   global.get $std/math/kPI
+   f64.const 2
+   f64.div
+   local.set $1
+   i32.const 1
+   drop
+   i32.const 8
+   i32.const 4
+   i32.eq
+   drop
+   i32.const 8
+   i32.const 8
+   i32.eq
+   drop
+   local.get $1
+   call $~lib/util/math/tan64
+   br $~lib/math/NativeMath.tan<f64>|inlined.8
   end
   global.get $std/math/kPI
   f64.const 2
   f64.div
-  call $~lib/math/NativeMath.tan
-  global.get $std/math/kPI
-  f64.const 2
-  f64.div
   call $~lib/bindings/dom/Math.tan
   f64.eq
   i32.eqz
   if
    i32.const 0
    i32.const 32
-   i32.const 3771
+   i32.const 3584
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 0.5
-  call $~lib/math/NativeMath.tan
+  block $~lib/math/NativeMath.tan<f64>|inlined.9 (result f64)
+   f64.const 0.5
+   local.set $0
+   i32.const 1
+   drop
+   i32.const 8
+   i32.const 4
+   i32.eq
+   drop
+   i32.const 8
+   i32.const 8
+   i32.eq
+   drop
+   local.get $0
+   call $~lib/util/math/tan64
+   br $~lib/math/NativeMath.tan<f64>|inlined.9
+  end
   f64.const 0.5
   call $~lib/bindings/dom/Math.tan
   f64.eq
@@ -55821,13 +55047,28 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3773
+   i32.const 3586
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 1.107148717794091
-  call $~lib/math/NativeMath.tan
+  block $~lib/math/NativeMath.tan<f64>|inlined.10 (result f64)
+   f64.const 1.107148717794091
+   local.set $1
+   i32.const 1
+   drop
+   i32.const 8
+   i32.const 4
+   i32.eq
+   drop
+   i32.const 8
+   i32.const 8
+   i32.eq
+   drop
+   local.get $1
+   call $~lib/util/math/tan64
+   br $~lib/math/NativeMath.tan<f64>|inlined.10
+  end
   f64.const 1.107148717794091
   call $~lib/bindings/dom/Math.tan
   f64.eq
@@ -55835,101 +55076,176 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3774
+   i32.const 3587
    i32.const 1
    call $~lib/builtins/abort
    unreachable
+  end
+  block $~lib/math/NativeMath.tan<f64>|inlined.11 (result f64)
+   f64.const 7
+   f64.const 4
+   f64.div
+   global.get $std/math/kPI
+   f64.mul
+   local.set $0
+   i32.const 1
+   drop
+   i32.const 8
+   i32.const 4
+   i32.eq
+   drop
+   i32.const 8
+   i32.const 8
+   i32.eq
+   drop
+   local.get $0
+   call $~lib/util/math/tan64
+   br $~lib/math/NativeMath.tan<f64>|inlined.11
   end
   f64.const 7
   f64.const 4
   f64.div
   global.get $std/math/kPI
   f64.mul
-  call $~lib/math/NativeMath.tan
-  f64.const 7
-  f64.const 4
-  f64.div
-  global.get $std/math/kPI
-  f64.mul
   call $~lib/bindings/dom/Math.tan
   f64.eq
   i32.eqz
   if
    i32.const 0
    i32.const 32
-   i32.const 3775
+   i32.const 3588
    i32.const 1
    call $~lib/builtins/abort
    unreachable
+  end
+  block $~lib/math/NativeMath.tan<f64>|inlined.12 (result f64)
+   f64.const 9
+   f64.const 4
+   f64.div
+   global.get $std/math/kPI
+   f64.mul
+   local.set $1
+   i32.const 1
+   drop
+   i32.const 8
+   i32.const 4
+   i32.eq
+   drop
+   i32.const 8
+   i32.const 8
+   i32.eq
+   drop
+   local.get $1
+   call $~lib/util/math/tan64
+   br $~lib/math/NativeMath.tan<f64>|inlined.12
   end
   f64.const 9
   f64.const 4
   f64.div
   global.get $std/math/kPI
   f64.mul
-  call $~lib/math/NativeMath.tan
-  f64.const 9
-  f64.const 4
-  f64.div
-  global.get $std/math/kPI
-  f64.mul
   call $~lib/bindings/dom/Math.tan
   f64.eq
   i32.eqz
   if
    i32.const 0
    i32.const 32
-   i32.const 3776
+   i32.const 3589
    i32.const 1
    call $~lib/builtins/abort
    unreachable
+  end
+  block $~lib/math/NativeMath.tan<f64>|inlined.13 (result f64)
+   f64.const 1048576
+   f64.const 2
+   f64.div
+   global.get $std/math/kPI
+   f64.mul
+   local.set $0
+   i32.const 1
+   drop
+   i32.const 8
+   i32.const 4
+   i32.eq
+   drop
+   i32.const 8
+   i32.const 8
+   i32.eq
+   drop
+   local.get $0
+   call $~lib/util/math/tan64
+   br $~lib/math/NativeMath.tan<f64>|inlined.13
   end
   f64.const 1048576
   f64.const 2
   f64.div
   global.get $std/math/kPI
   f64.mul
-  call $~lib/math/NativeMath.tan
-  f64.const 1048576
-  f64.const 2
-  f64.div
-  global.get $std/math/kPI
-  f64.mul
   call $~lib/bindings/dom/Math.tan
   f64.eq
   i32.eqz
   if
    i32.const 0
    i32.const 32
-   i32.const 3777
+   i32.const 3590
    i32.const 1
    call $~lib/builtins/abort
    unreachable
+  end
+  block $~lib/math/NativeMath.tan<f64>|inlined.14 (result f64)
+   f64.const 1048575
+   f64.const 2
+   f64.div
+   global.get $std/math/kPI
+   f64.mul
+   local.set $1
+   i32.const 1
+   drop
+   i32.const 8
+   i32.const 4
+   i32.eq
+   drop
+   i32.const 8
+   i32.const 8
+   i32.eq
+   drop
+   local.get $1
+   call $~lib/util/math/tan64
+   br $~lib/math/NativeMath.tan<f64>|inlined.14
   end
   f64.const 1048575
   f64.const 2
   f64.div
   global.get $std/math/kPI
   f64.mul
-  call $~lib/math/NativeMath.tan
-  f64.const 1048575
-  f64.const 2
-  f64.div
-  global.get $std/math/kPI
-  f64.mul
   call $~lib/bindings/dom/Math.tan
   f64.eq
   i32.eqz
   if
    i32.const 0
    i32.const 32
-   i32.const 3778
+   i32.const 3591
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
-  global.get $std/math/kTwo120
-  call $~lib/math/NativeMath.tan
+  block $~lib/math/NativeMath.tan<f64>|inlined.15 (result f64)
+   global.get $std/math/kTwo120
+   local.set $0
+   i32.const 1
+   drop
+   i32.const 8
+   i32.const 4
+   i32.eq
+   drop
+   i32.const 8
+   i32.const 8
+   i32.eq
+   drop
+   local.get $0
+   call $~lib/util/math/tan64
+   br $~lib/math/NativeMath.tan<f64>|inlined.15
+  end
   global.get $std/math/kTwo120
   call $~lib/bindings/dom/Math.tan
   f64.eq
@@ -55937,14 +55253,29 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3779
+   i32.const 3592
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
-  global.get $std/math/kTwo120
-  f64.neg
-  call $~lib/math/NativeMath.tan
+  block $~lib/math/NativeMath.tan<f64>|inlined.16 (result f64)
+   global.get $std/math/kTwo120
+   f64.neg
+   local.set $1
+   i32.const 1
+   drop
+   i32.const 8
+   i32.const 4
+   i32.eq
+   drop
+   i32.const 8
+   i32.const 8
+   i32.eq
+   drop
+   local.get $1
+   call $~lib/util/math/tan64
+   br $~lib/math/NativeMath.tan<f64>|inlined.16
+  end
   global.get $std/math/kTwo120
   f64.neg
   call $~lib/bindings/dom/Math.tan
@@ -55953,7 +55284,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3780
+   i32.const 3593
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -55967,7 +55298,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3783
+   i32.const 3596
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -55981,7 +55312,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3784
+   i32.const 3597
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -55995,7 +55326,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3785
+   i32.const 3598
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -56010,7 +55341,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3786
+   i32.const 3599
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -56024,7 +55355,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3787
+   i32.const 3600
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -56038,7 +55369,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3796
+   i32.const 3609
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -56052,7 +55383,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3797
+   i32.const 3610
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -56066,7 +55397,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3798
+   i32.const 3611
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -56080,7 +55411,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3799
+   i32.const 3612
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -56094,7 +55425,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3800
+   i32.const 3613
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -56108,7 +55439,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3801
+   i32.const 3614
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -56122,7 +55453,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3802
+   i32.const 3615
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -56136,7 +55467,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3803
+   i32.const 3616
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -56150,7 +55481,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3804
+   i32.const 3617
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -56164,7 +55495,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3805
+   i32.const 3618
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -56178,7 +55509,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3808
+   i32.const 3621
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -56192,7 +55523,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3809
+   i32.const 3622
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -56206,7 +55537,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3810
+   i32.const 3623
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -56221,7 +55552,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3811
+   i32.const 3624
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -56235,7 +55566,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3812
+   i32.const 3625
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -56249,7 +55580,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3815
+   i32.const 3628
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -56263,7 +55594,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3816
+   i32.const 3629
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -56277,7 +55608,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3817
+   i32.const 3630
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -56291,7 +55622,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3818
+   i32.const 3631
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -56307,7 +55638,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3819
+   i32.const 3632
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -56323,7 +55654,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3820
+   i32.const 3633
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -56337,7 +55668,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3821
+   i32.const 3634
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -56351,7 +55682,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3822
+   i32.const 3635
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -56365,7 +55696,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3823
+   i32.const 3636
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -56379,7 +55710,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3824
+   i32.const 3637
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -56393,7 +55724,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3825
+   i32.const 3638
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -56407,7 +55738,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3826
+   i32.const 3639
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -56421,7 +55752,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3827
+   i32.const 3640
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -56435,7 +55766,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3828
+   i32.const 3641
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -56449,7 +55780,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3829
+   i32.const 3642
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -56463,7 +55794,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3830
+   i32.const 3643
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -56477,7 +55808,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3831
+   i32.const 3644
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -56491,7 +55822,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3832
+   i32.const 3645
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -56505,7 +55836,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3833
+   i32.const 3646
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -56519,7 +55850,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3834
+   i32.const 3647
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -56533,7 +55864,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3835
+   i32.const 3648
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -56547,7 +55878,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3836
+   i32.const 3649
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -56561,7 +55892,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3837
+   i32.const 3650
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -56575,7 +55906,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3838
+   i32.const 3651
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -56591,7 +55922,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3839
+   i32.const 3652
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -56607,7 +55938,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3840
+   i32.const 3653
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -56623,7 +55954,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3841
+   i32.const 3654
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -56639,7 +55970,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3842
+   i32.const 3655
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -56655,7 +55986,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3843
+   i32.const 3656
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -56671,7 +56002,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3844
+   i32.const 3657
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -56687,7 +56018,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3845
+   i32.const 3658
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -56703,7 +56034,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3846
+   i32.const 3659
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -56719,7 +56050,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3847
+   i32.const 3660
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -56735,7 +56066,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3848
+   i32.const 3661
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -56751,7 +56082,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3849
+   i32.const 3662
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -56767,7 +56098,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3850
+   i32.const 3663
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -56781,7 +56112,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3862
+   i32.const 3675
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -56795,7 +56126,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3863
+   i32.const 3676
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -56809,7 +56140,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3864
+   i32.const 3677
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -56823,7 +56154,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3865
+   i32.const 3678
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -56837,7 +56168,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3866
+   i32.const 3679
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -56851,7 +56182,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3867
+   i32.const 3680
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -56865,7 +56196,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3868
+   i32.const 3681
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -56879,7 +56210,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3869
+   i32.const 3682
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -56893,7 +56224,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3870
+   i32.const 3683
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -56907,7 +56238,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3871
+   i32.const 3684
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -56921,7 +56252,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3874
+   i32.const 3687
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -56935,7 +56266,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3875
+   i32.const 3688
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -56949,7 +56280,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3876
+   i32.const 3689
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -56964,7 +56295,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3877
+   i32.const 3690
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -56978,7 +56309,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3878
+   i32.const 3691
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -56992,7 +56323,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3887
+   i32.const 3700
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -57006,7 +56337,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3888
+   i32.const 3701
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -57020,7 +56351,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3889
+   i32.const 3702
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -57034,7 +56365,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3890
+   i32.const 3703
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -57048,7 +56379,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3891
+   i32.const 3704
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -57062,7 +56393,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3892
+   i32.const 3705
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -57076,7 +56407,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3893
+   i32.const 3706
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -57090,7 +56421,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3894
+   i32.const 3707
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -57104,7 +56435,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3895
+   i32.const 3708
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -57118,7 +56449,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3896
+   i32.const 3709
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -57132,7 +56463,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3899
+   i32.const 3712
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -57146,7 +56477,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3900
+   i32.const 3713
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -57160,7 +56491,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3901
+   i32.const 3714
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -57175,7 +56506,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3902
+   i32.const 3715
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -57189,7 +56520,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3903
+   i32.const 3716
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -57203,7 +56534,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3915
+   i32.const 3728
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -57217,7 +56548,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3916
+   i32.const 3729
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -57231,7 +56562,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3917
+   i32.const 3730
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -57245,7 +56576,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3918
+   i32.const 3731
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -57259,7 +56590,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3919
+   i32.const 3732
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -57273,7 +56604,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3920
+   i32.const 3733
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -57287,7 +56618,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3921
+   i32.const 3734
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -57301,7 +56632,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3922
+   i32.const 3735
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -57315,7 +56646,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3923
+   i32.const 3736
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -57329,7 +56660,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3924
+   i32.const 3737
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -57343,7 +56674,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3927
+   i32.const 3740
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -57357,7 +56688,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3928
+   i32.const 3741
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -57373,7 +56704,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3929
+   i32.const 3742
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -57387,7 +56718,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3930
+   i32.const 3743
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -57401,7 +56732,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3931
+   i32.const 3744
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -57415,7 +56746,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3932
+   i32.const 3745
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -57429,7 +56760,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3933
+   i32.const 3746
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -57443,7 +56774,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3934
+   i32.const 3747
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -57457,7 +56788,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3935
+   i32.const 3748
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -57471,7 +56802,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3936
+   i32.const 3749
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -57485,7 +56816,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3937
+   i32.const 3750
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -57499,7 +56830,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3938
+   i32.const 3751
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -57513,7 +56844,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3939
+   i32.const 3752
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -57527,7 +56858,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3940
+   i32.const 3753
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -57541,7 +56872,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3941
+   i32.const 3754
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -57555,7 +56886,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3950
+   i32.const 3763
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -57569,7 +56900,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3951
+   i32.const 3764
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -57583,7 +56914,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3952
+   i32.const 3765
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -57597,7 +56928,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3953
+   i32.const 3766
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -57611,7 +56942,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3954
+   i32.const 3767
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -57625,7 +56956,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3955
+   i32.const 3768
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -57639,7 +56970,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3956
+   i32.const 3769
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -57653,7 +56984,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3957
+   i32.const 3770
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -57667,7 +56998,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3958
+   i32.const 3771
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -57681,7 +57012,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3959
+   i32.const 3772
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -57695,7 +57026,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3962
+   i32.const 3775
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -57709,7 +57040,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3963
+   i32.const 3776
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -57725,7 +57056,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3964
+   i32.const 3777
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -57739,7 +57070,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3965
+   i32.const 3778
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -57753,7 +57084,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3966
+   i32.const 3779
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -57767,7 +57098,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3967
+   i32.const 3780
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -57781,7 +57112,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3968
+   i32.const 3781
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -57795,7 +57126,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3969
+   i32.const 3782
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -57809,7 +57140,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3970
+   i32.const 3783
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -57823,7 +57154,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3971
+   i32.const 3784
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -57837,7 +57168,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3972
+   i32.const 3785
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -57851,7 +57182,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3973
+   i32.const 3786
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -57865,7 +57196,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3974
+   i32.const 3787
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -57879,7 +57210,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3975
+   i32.const 3788
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -57893,7 +57224,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3976
+   i32.const 3789
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -57980,784 +57311,784 @@
   drop
   f64.const 2
   f64.const 4
-  call $~lib/math/NativeMath.imul
+  call $~lib/math/NativeMath.imul<f64>
   f64.const 8
   f64.eq
   i32.eqz
   if
    i32.const 0
    i32.const 32
-   i32.const 4017
+   i32.const 3830
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f64.const -1
   f64.const 8
-  call $~lib/math/NativeMath.imul
+  call $~lib/math/NativeMath.imul<f64>
   f64.const -8
   f64.eq
   i32.eqz
   if
    i32.const 0
    i32.const 32
-   i32.const 4018
+   i32.const 3831
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f64.const -2
   f64.const -2
-  call $~lib/math/NativeMath.imul
+  call $~lib/math/NativeMath.imul<f64>
   f64.const 4
   f64.eq
   i32.eqz
   if
    i32.const 0
    i32.const 32
-   i32.const 4019
+   i32.const 3832
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f64.const 4294967295
   f64.const 5
-  call $~lib/math/NativeMath.imul
+  call $~lib/math/NativeMath.imul<f64>
   f64.const -5
   f64.eq
   i32.eqz
   if
    i32.const 0
    i32.const 32
-   i32.const 4020
+   i32.const 3833
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f64.const 4294967294
   f64.const 5
-  call $~lib/math/NativeMath.imul
+  call $~lib/math/NativeMath.imul<f64>
   f64.const -10
   f64.eq
   i32.eqz
   if
    i32.const 0
    i32.const 32
-   i32.const 4021
+   i32.const 3834
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f64.const 1.e+60
   f64.const 1.e+60
-  call $~lib/math/NativeMath.imul
+  call $~lib/math/NativeMath.imul<f64>
   f64.const 0
   f64.eq
   i32.eqz
   if
    i32.const 0
    i32.const 32
-   i32.const 4022
+   i32.const 3835
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f64.const 1.e+60
   f64.const -1.e+60
-  call $~lib/math/NativeMath.imul
+  call $~lib/math/NativeMath.imul<f64>
   f64.const 0
   f64.eq
   i32.eqz
   if
    i32.const 0
    i32.const 32
-   i32.const 4023
+   i32.const 3836
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f64.const -1.e+60
   f64.const -1.e+60
-  call $~lib/math/NativeMath.imul
+  call $~lib/math/NativeMath.imul<f64>
   f64.const 0
   f64.eq
   i32.eqz
   if
    i32.const 0
    i32.const 32
-   i32.const 4024
+   i32.const 3837
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f64.const 1.e+24
   f64.const 100
-  call $~lib/math/NativeMath.imul
+  call $~lib/math/NativeMath.imul<f64>
   f64.const -2147483648
   f64.eq
   i32.eqz
   if
    i32.const 0
    i32.const 32
-   i32.const 4025
+   i32.const 3838
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f64.const nan:0x8000000000000
   f64.const 1
-  call $~lib/math/NativeMath.imul
+  call $~lib/math/NativeMath.imul<f64>
   f64.const 0
   f64.eq
   i32.eqz
   if
    i32.const 0
    i32.const 32
-   i32.const 4026
+   i32.const 3839
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f64.const 1
   f64.const inf
-  call $~lib/math/NativeMath.imul
+  call $~lib/math/NativeMath.imul<f64>
   f64.const 0
   f64.eq
   i32.eqz
   if
    i32.const 0
    i32.const 32
-   i32.const 4027
+   i32.const 3840
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   global.get $~lib/builtins/f64.MAX_VALUE
   global.get $~lib/builtins/f64.MAX_VALUE
-  call $~lib/math/NativeMath.imul
+  call $~lib/math/NativeMath.imul<f64>
   f64.const 0
   f64.eq
   i32.eqz
   if
    i32.const 0
    i32.const 32
-   i32.const 4028
+   i32.const 3841
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f64.const 0
-  call $~lib/math/NativeMath.clz32
-  f64.const 32
-  f64.eq
+  call $~lib/math/NativeMath.clz32<f64>
+  i32.const 32
+  i32.eq
   i32.eqz
   if
    i32.const 0
    i32.const 32
-   i32.const 4032
+   i32.const 3845
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f64.const 1
-  call $~lib/math/NativeMath.clz32
-  f64.const 31
-  f64.eq
+  call $~lib/math/NativeMath.clz32<f64>
+  i32.const 31
+  i32.eq
   i32.eqz
   if
    i32.const 0
    i32.const 32
-   i32.const 4033
+   i32.const 3846
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f64.const -1
-  call $~lib/math/NativeMath.clz32
-  f64.const 0
-  f64.eq
+  call $~lib/math/NativeMath.clz32<f64>
+  i32.const 0
+  i32.eq
   i32.eqz
   if
    i32.const 0
    i32.const 32
-   i32.const 4034
+   i32.const 3847
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f64.const -128
-  call $~lib/math/NativeMath.clz32
-  f64.const 0
-  f64.eq
+  call $~lib/math/NativeMath.clz32<f64>
+  i32.const 0
+  i32.eq
   i32.eqz
   if
    i32.const 0
    i32.const 32
-   i32.const 4035
+   i32.const 3848
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f64.const 4294967295
-  call $~lib/math/NativeMath.clz32
-  f64.const 0
-  f64.eq
+  call $~lib/math/NativeMath.clz32<f64>
+  i32.const 0
+  i32.eq
   i32.eqz
   if
    i32.const 0
    i32.const 32
-   i32.const 4036
+   i32.const 3849
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f64.const 4294967295.5
-  call $~lib/math/NativeMath.clz32
-  f64.const 0
-  f64.eq
+  call $~lib/math/NativeMath.clz32<f64>
+  i32.const 0
+  i32.eq
   i32.eqz
   if
    i32.const 0
    i32.const 32
-   i32.const 4037
+   i32.const 3850
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f64.const 4294967296
-  call $~lib/math/NativeMath.clz32
-  f64.const 32
-  f64.eq
+  call $~lib/math/NativeMath.clz32<f64>
+  i32.const 32
+  i32.eq
   i32.eqz
   if
    i32.const 0
    i32.const 32
-   i32.const 4038
+   i32.const 3851
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f64.const 4294967297
-  call $~lib/math/NativeMath.clz32
-  f64.const 31
-  f64.eq
+  call $~lib/math/NativeMath.clz32<f64>
+  i32.const 31
+  i32.eq
   i32.eqz
   if
    i32.const 0
    i32.const 32
-   i32.const 4039
+   i32.const 3852
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f64.const nan:0x8000000000000
-  call $~lib/math/NativeMath.clz32
-  f64.const 32
-  f64.eq
+  call $~lib/math/NativeMath.clz32<f64>
+  i32.const 32
+  i32.eq
   i32.eqz
   if
    i32.const 0
    i32.const 32
-   i32.const 4040
+   i32.const 3853
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f64.const inf
-  call $~lib/math/NativeMath.clz32
-  f64.const 32
-  f64.eq
+  call $~lib/math/NativeMath.clz32<f64>
+  i32.const 32
+  i32.eq
   i32.eqz
   if
    i32.const 0
    i32.const 32
-   i32.const 4041
+   i32.const 3854
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   global.get $~lib/builtins/f64.MAX_SAFE_INTEGER
-  call $~lib/math/NativeMath.clz32
-  f64.const 0
-  f64.eq
+  call $~lib/math/NativeMath.clz32<f64>
+  i32.const 0
+  i32.eq
   i32.eqz
   if
    i32.const 0
    i32.const 32
-   i32.const 4042
+   i32.const 3855
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   global.get $~lib/builtins/f64.MAX_SAFE_INTEGER
   f64.neg
-  call $~lib/math/NativeMath.clz32
-  f64.const 31
-  f64.eq
+  call $~lib/math/NativeMath.clz32<f64>
+  i32.const 31
+  i32.eq
   i32.eqz
   if
    i32.const 0
    i32.const 32
-   i32.const 4043
+   i32.const 3856
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   global.get $~lib/builtins/f64.MAX_VALUE
-  call $~lib/math/NativeMath.clz32
-  f64.const 32
-  f64.eq
+  call $~lib/math/NativeMath.clz32<f64>
+  i32.const 32
+  i32.eq
   i32.eqz
   if
    i32.const 0
    i32.const 32
-   i32.const 4044
+   i32.const 3857
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   global.get $~lib/builtins/f64.MIN_VALUE
-  call $~lib/math/NativeMath.clz32
-  f64.const 32
-  f64.eq
+  call $~lib/math/NativeMath.clz32<f64>
+  i32.const 32
+  i32.eq
   i32.eqz
   if
    i32.const 0
    i32.const 32
-   i32.const 4045
+   i32.const 3858
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   global.get $~lib/builtins/f64.MAX_VALUE
   f64.neg
-  call $~lib/math/NativeMath.clz32
-  f64.const 32
-  f64.eq
+  call $~lib/math/NativeMath.clz32<f64>
+  i32.const 32
+  i32.eq
   i32.eqz
   if
    i32.const 0
    i32.const 32
-   i32.const 4046
+   i32.const 3859
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   global.get $~lib/builtins/f64.EPSILON
-  call $~lib/math/NativeMath.clz32
-  f64.const 32
-  f64.eq
+  call $~lib/math/NativeMath.clz32<f64>
+  i32.const 32
+  i32.eq
   i32.eqz
   if
    i32.const 0
    i32.const 32
-   i32.const 4047
+   i32.const 3860
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   i64.const 0
   i64.const 0
-  call $~lib/math/ipow64
+  call $~lib/util/math/ipow64
   i64.const 1
   i64.eq
   i32.eqz
   if
    i32.const 0
    i32.const 32
-   i32.const 4051
+   i32.const 3864
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   i64.const 0
   i64.const 1
-  call $~lib/math/ipow64
+  call $~lib/util/math/ipow64
   i64.const 0
   i64.eq
   i32.eqz
   if
    i32.const 0
    i32.const 32
-   i32.const 4052
+   i32.const 3865
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   i64.const 0
   i64.const 2
-  call $~lib/math/ipow64
+  call $~lib/util/math/ipow64
   i64.const 0
   i64.eq
   i32.eqz
   if
    i32.const 0
    i32.const 32
-   i32.const 4053
+   i32.const 3866
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   i64.const 0
   i64.const 3
-  call $~lib/math/ipow64
+  call $~lib/util/math/ipow64
   i64.const 0
   i64.eq
   i32.eqz
   if
    i32.const 0
    i32.const 32
-   i32.const 4054
+   i32.const 3867
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   i64.const 1
   i64.const 0
-  call $~lib/math/ipow64
+  call $~lib/util/math/ipow64
   i64.const 1
   i64.eq
   i32.eqz
   if
    i32.const 0
    i32.const 32
-   i32.const 4056
+   i32.const 3869
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   i64.const 1
   i64.const 1
-  call $~lib/math/ipow64
+  call $~lib/util/math/ipow64
   i64.const 1
   i64.eq
   i32.eqz
   if
    i32.const 0
    i32.const 32
-   i32.const 4057
+   i32.const 3870
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   i64.const 1
   i64.const 2
-  call $~lib/math/ipow64
+  call $~lib/util/math/ipow64
   i64.const 1
   i64.eq
   i32.eqz
   if
    i32.const 0
    i32.const 32
-   i32.const 4058
+   i32.const 3871
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   i64.const 1
   i64.const 3
-  call $~lib/math/ipow64
+  call $~lib/util/math/ipow64
   i64.const 1
   i64.eq
   i32.eqz
   if
    i32.const 0
    i32.const 32
-   i32.const 4059
+   i32.const 3872
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   i64.const 2
   i64.const 0
-  call $~lib/math/ipow64
+  call $~lib/util/math/ipow64
   i64.const 1
   i64.eq
   i32.eqz
   if
    i32.const 0
    i32.const 32
-   i32.const 4061
+   i32.const 3874
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   i64.const 2
   i64.const 1
-  call $~lib/math/ipow64
+  call $~lib/util/math/ipow64
   i64.const 2
   i64.eq
   i32.eqz
   if
    i32.const 0
    i32.const 32
-   i32.const 4062
+   i32.const 3875
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   i64.const 2
   i64.const 2
-  call $~lib/math/ipow64
+  call $~lib/util/math/ipow64
   i64.const 4
   i64.eq
   i32.eqz
   if
    i32.const 0
    i32.const 32
-   i32.const 4063
+   i32.const 3876
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   i64.const 2
   i64.const 3
-  call $~lib/math/ipow64
+  call $~lib/util/math/ipow64
   i64.const 8
   i64.eq
   i32.eqz
   if
    i32.const 0
    i32.const 32
-   i32.const 4064
+   i32.const 3877
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   i64.const -1
   i64.const 0
-  call $~lib/math/ipow64
+  call $~lib/util/math/ipow64
   i64.const 1
   i64.eq
   i32.eqz
   if
    i32.const 0
    i32.const 32
-   i32.const 4066
+   i32.const 3879
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   i64.const -1
   i64.const 1
-  call $~lib/math/ipow64
+  call $~lib/util/math/ipow64
   i64.const -1
   i64.eq
   i32.eqz
   if
    i32.const 0
    i32.const 32
-   i32.const 4067
+   i32.const 3880
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   i64.const -1
   i64.const 2
-  call $~lib/math/ipow64
+  call $~lib/util/math/ipow64
   i64.const 1
   i64.eq
   i32.eqz
   if
    i32.const 0
    i32.const 32
-   i32.const 4068
+   i32.const 3881
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   i64.const -1
   i64.const 3
-  call $~lib/math/ipow64
+  call $~lib/util/math/ipow64
   i64.const -1
   i64.eq
   i32.eqz
   if
    i32.const 0
    i32.const 32
-   i32.const 4069
+   i32.const 3882
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   i64.const -2
   i64.const 0
-  call $~lib/math/ipow64
+  call $~lib/util/math/ipow64
   i64.const 1
   i64.eq
   i32.eqz
   if
    i32.const 0
    i32.const 32
-   i32.const 4071
+   i32.const 3884
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   i64.const -2
   i64.const 1
-  call $~lib/math/ipow64
+  call $~lib/util/math/ipow64
   i64.const -2
   i64.eq
   i32.eqz
   if
    i32.const 0
    i32.const 32
-   i32.const 4072
+   i32.const 3885
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   i64.const -2
   i64.const 2
-  call $~lib/math/ipow64
+  call $~lib/util/math/ipow64
   i64.const 4
   i64.eq
   i32.eqz
   if
    i32.const 0
    i32.const 32
-   i32.const 4073
+   i32.const 3886
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   i64.const -2
   i64.const 3
-  call $~lib/math/ipow64
+  call $~lib/util/math/ipow64
   i64.const -8
   i64.eq
   i32.eqz
   if
    i32.const 0
    i32.const 32
-   i32.const 4074
+   i32.const 3887
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   i64.const 2
   i64.const 63
-  call $~lib/math/ipow64
+  call $~lib/util/math/ipow64
   i64.const -9223372036854775808
   i64.eq
   i32.eqz
   if
    i32.const 0
    i32.const 32
-   i32.const 4076
+   i32.const 3889
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   i64.const 3
   i64.const 40
-  call $~lib/math/ipow64
+  call $~lib/util/math/ipow64
   i64.const -6289078614652622815
   i64.eq
   i32.eqz
   if
    i32.const 0
    i32.const 32
-   i32.const 4077
+   i32.const 3890
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   i64.const 2
   i64.const 64
-  call $~lib/math/ipow64
+  call $~lib/util/math/ipow64
   i64.const 0
   i64.eq
   i32.eqz
   if
    i32.const 0
    i32.const 32
-   i32.const 4078
+   i32.const 3891
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   i64.const 3
   i64.const 41
-  call $~lib/math/ipow64
+  call $~lib/util/math/ipow64
   i64.const -420491770248316829
   i64.eq
   i32.eqz
   if
    i32.const 0
    i32.const 32
-   i32.const 4079
+   i32.const 3892
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   i64.const 3
   i64.const 128
-  call $~lib/math/ipow64
+  call $~lib/util/math/ipow64
   i64.const -9204772141784466943
   i64.eq
   i32.eqz
   if
    i32.const 0
    i32.const 32
-   i32.const 4080
+   i32.const 3893
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   i64.const 1
   i64.const -1
-  call $~lib/math/ipow64
+  call $~lib/util/math/ipow64
   i64.const 1
   i64.eq
   i32.eqz
   if
    i32.const 0
    i32.const 32
-   i32.const 4082
+   i32.const 3895
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   i64.const 2
   i64.const -1
-  call $~lib/math/ipow64
+  call $~lib/util/math/ipow64
   i64.const 0
   i64.eq
   i32.eqz
   if
    i32.const 0
    i32.const 32
-   i32.const 4083
+   i32.const 3896
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   i64.const 2
   i64.const 64
-  call $~lib/math/ipow64
+  call $~lib/util/math/ipow64
   i64.const 0
   i64.eq
   i32.eqz
   if
    i32.const 0
    i32.const 32
-   i32.const 4084
+   i32.const 3897
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   i64.const 2
   i64.const 128
-  call $~lib/math/ipow64
+  call $~lib/util/math/ipow64
   i64.const 0
   i64.eq
   i32.eqz
   if
    i32.const 0
    i32.const 32
-   i32.const 4085
+   i32.const 3898
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -58782,112 +58113,112 @@
   drop
   i32.const 1
   i32.const 3
-  call $~lib/math/ipow32
+  call $~lib/util/math/ipow32
   i32.const 1
   i32.eq
   i32.eqz
   if
    i32.const 0
    i32.const 32
-   i32.const 4091
+   i32.const 3904
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   i32.const -2
   i32.const 3
-  call $~lib/math/ipow32
+  call $~lib/util/math/ipow32
   i32.const -8
   i32.eq
   i32.eqz
   if
    i32.const 0
    i32.const 32
-   i32.const 4092
+   i32.const 3905
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   i32.const -1
   i32.const 0
-  call $~lib/math/ipow32
+  call $~lib/util/math/ipow32
   i32.const 1
   i32.eq
   i32.eqz
   if
    i32.const 0
    i32.const 32
-   i32.const 4093
+   i32.const 3906
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   i32.const -1
   i32.const -1
-  call $~lib/math/ipow32
+  call $~lib/util/math/ipow32
   i32.const -1
   i32.eq
   i32.eqz
   if
    i32.const 0
    i32.const 32
-   i32.const 4094
+   i32.const 3907
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   i32.const -1
   i32.const -2
-  call $~lib/math/ipow32
+  call $~lib/util/math/ipow32
   i32.const 1
   i32.eq
   i32.eqz
   if
    i32.const 0
    i32.const 32
-   i32.const 4095
+   i32.const 3908
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   i32.const -1
   i32.const -3
-  call $~lib/math/ipow32
+  call $~lib/util/math/ipow32
   i32.const -1
   i32.eq
   i32.eqz
   if
    i32.const 0
    i32.const 32
-   i32.const 4096
+   i32.const 3909
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   i32.const 0
   i32.const -2
-  call $~lib/math/ipow32
+  call $~lib/util/math/ipow32
   i32.const 0
   i32.eq
   i32.eqz
   if
    i32.const 0
    i32.const 32
-   i32.const 4098
+   i32.const 3911
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   i32.const 0
   i32.const -1
-  call $~lib/math/ipow32
+  call $~lib/util/math/ipow32
   i32.const 0
   i32.eq
   i32.eqz
   if
    i32.const 0
    i32.const 32
-   i32.const 4099
+   i32.const 3912
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -58912,42 +58243,42 @@
   drop
   i32.const 0
   i32.const 2
-  call $~lib/math/ipow32
+  call $~lib/util/math/ipow32
   i32.const 0
   i32.eq
   i32.eqz
   if
    i32.const 0
    i32.const 32
-   i32.const 4102
+   i32.const 3915
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   i32.const 1
   i32.const -2
-  call $~lib/math/ipow32
+  call $~lib/util/math/ipow32
   i32.const 1
   i32.eq
   i32.eqz
   if
    i32.const 0
    i32.const 32
-   i32.const 4104
+   i32.const 3917
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   i32.const 1
   i32.const -1
-  call $~lib/math/ipow32
+  call $~lib/util/math/ipow32
   i32.const 1
   i32.eq
   i32.eqz
   if
    i32.const 0
    i32.const 32
-   i32.const 4105
+   i32.const 3918
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -58972,21 +58303,21 @@
   drop
   i32.const 1
   i32.const 2
-  call $~lib/math/ipow32
+  call $~lib/util/math/ipow32
   i32.const 1
   i32.eq
   i32.eqz
   if
    i32.const 0
    i32.const 32
-   i32.const 4108
+   i32.const 3921
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   i32.const 1
   i32.const 3
-  call $~lib/math/ipow32
+  call $~lib/util/math/ipow32
   i32.extend8_s
   i32.const 1
   i32.eq
@@ -58994,14 +58325,14 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 4110
+   i32.const 3923
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   i32.const -2
   i32.const 3
-  call $~lib/math/ipow32
+  call $~lib/util/math/ipow32
   i32.extend8_s
   i32.const -8
   i32.eq
@@ -59009,14 +58340,14 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 4111
+   i32.const 3924
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   i32.const 4
   i32.const 7
-  call $~lib/math/ipow32
+  call $~lib/util/math/ipow32
   i32.const 65535
   i32.and
   i32.const 16384
@@ -59025,14 +58356,14 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 4112
+   i32.const 3925
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   i32.const 4
   i32.const 8
-  call $~lib/math/ipow32
+  call $~lib/util/math/ipow32
   i32.const 65535
   i32.and
   i32.const 0
@@ -59041,14 +58372,14 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 4113
+   i32.const 3926
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   i32.const 5
   i32.const 10
-  call $~lib/math/ipow32
+  call $~lib/util/math/ipow32
   i32.const 65535
   i32.and
   i32.const 761
@@ -59057,163 +58388,163 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 4114
+   i32.const 3927
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   i64.const 0
   i64.const 0
-  call $~lib/math/ipow64
+  call $~lib/util/math/ipow64
   i64.const 1
   i64.eq
   i32.eqz
   if
    i32.const 0
    i32.const 32
-   i32.const 4116
+   i32.const 3929
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   i64.const 0
   i64.const 1
-  call $~lib/math/ipow64
+  call $~lib/util/math/ipow64
   i64.const 0
   i64.eq
   i32.eqz
   if
    i32.const 0
    i32.const 32
-   i32.const 4117
+   i32.const 3930
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   i64.const 1
   i64.const 3
-  call $~lib/math/ipow64
+  call $~lib/util/math/ipow64
   i64.const 1
   i64.eq
   i32.eqz
   if
    i32.const 0
    i32.const 32
-   i32.const 4118
+   i32.const 3931
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   i64.const 2
   i64.const 3
-  call $~lib/math/ipow64
+  call $~lib/util/math/ipow64
   i64.const 8
   i64.eq
   i32.eqz
   if
    i32.const 0
    i32.const 32
-   i32.const 4119
+   i32.const 3932
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   i64.const 4294967295
   i64.const 3
-  call $~lib/math/ipow64
+  call $~lib/util/math/ipow64
   i64.const 12884901887
   i64.eq
   i32.eqz
   if
    i32.const 0
    i32.const 32
-   i32.const 4120
+   i32.const 3933
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   i64.const 65535
   i64.const 3
-  call $~lib/math/ipow64
+  call $~lib/util/math/ipow64
   i64.const 281462092005375
   i64.eq
   i32.eqz
   if
    i32.const 0
    i32.const 32
-   i32.const 4121
+   i32.const 3934
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   i64.const 65535
   i64.const 8
-  call $~lib/math/ipow64
+  call $~lib/util/math/ipow64
   i64.const -15762478437236735
   i64.eq
   i32.eqz
   if
    i32.const 0
    i32.const 32
-   i32.const 4122
+   i32.const 3935
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   i64.const 61731
   i64.const 4
-  call $~lib/math/ipow64
+  call $~lib/util/math/ipow64
   i64.const -3925184889716469295
   i64.eq
   i32.eqz
   if
    i32.const 0
    i32.const 32
-   i32.const 4123
+   i32.const 3936
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   i64.const 61731
   i64.const 4
-  call $~lib/math/ipow64
+  call $~lib/util/math/ipow64
   i64.const -3925184889716469295
   i64.eq
   i32.eqz
   if
    i32.const 0
    i32.const 32
-   i32.const 4124
+   i32.const 3937
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   i64.const 57055
   i64.const 3
-  call $~lib/math/ipow64
+  call $~lib/util/math/ipow64
   i64.const 339590
   i64.const 3
-  call $~lib/math/ipow64
+  call $~lib/util/math/ipow64
   i64.add
   i64.const 340126
   i64.const 3
-  call $~lib/math/ipow64
+  call $~lib/util/math/ipow64
   i64.ne
   i32.eqz
   if
    i32.const 0
    i32.const 32
-   i32.const 4126
+   i32.const 3939
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   i64.const 57055
   i64.const 3
-  call $~lib/math/ipow64
+  call $~lib/util/math/ipow64
   i64.const 339590
   i64.const 3
-  call $~lib/math/ipow64
+  call $~lib/util/math/ipow64
   i64.add
   i64.const 39347712995520375
   i64.eq
@@ -59221,7 +58552,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 4127
+   i32.const 3940
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -59229,14 +58560,14 @@
   i32.const 1
   f64.convert_i32_u
   f64.const 0.5
-  call $~lib/math/NativeMath.pow
+  call $~lib/util/math/pow64
   f64.const 1
   f64.eq
   i32.eqz
   if
    i32.const 0
    i32.const 32
-   i32.const 4129
+   i32.const 3942
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -59244,14 +58575,14 @@
   i32.const 0
   f64.convert_i32_u
   f64.const 0.5
-  call $~lib/math/NativeMath.pow
+  call $~lib/util/math/pow64
   f64.const 0
   f64.eq
   i32.eqz
   if
    i32.const 0
    i32.const 32
-   i32.const 4130
+   i32.const 3943
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -59259,42 +58590,42 @@
   i32.const 0
   f64.convert_i32_u
   f64.const -1
-  call $~lib/math/NativeMath.pow
+  call $~lib/util/math/pow64
   f64.const inf
   f64.eq
   i32.eqz
   if
    i32.const 0
    i32.const 32
-   i32.const 4131
+   i32.const 3944
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f64.const 0
   f64.const 0
-  call $~lib/math/NativeMath.pow
+  call $~lib/util/math/pow64
   f64.const 1
   f64.eq
   i32.eqz
   if
    i32.const 0
    i32.const 32
-   i32.const 4132
+   i32.const 3945
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f64.const 1
   f64.const 1
-  call $~lib/math/NativeMath.pow
+  call $~lib/util/math/pow64
   f64.const 1
   f64.eq
   i32.eqz
   if
    i32.const 0
    i32.const 32
-   i32.const 4133
+   i32.const 3946
    i32.const 1
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/std/math.release.wat
+++ b/tests/compiler/std/math.release.wat
@@ -4,8 +4,9 @@
  (type $f32_f32_f32_=>_i32 (func (param f32 f32 f32) (result i32)))
  (type $f32_=>_f32 (func (param f32) (result f32)))
  (type $f64_f64_=>_f64 (func (param f64 f64) (result f64)))
- (type $f32_f32_=>_f32 (func (param f32 f32) (result f32)))
  (type $f64_f64_f64_f64_=>_i32 (func (param f64 f64 f64 f64) (result i32)))
+ (type $f32_f32_f32_f32_=>_i32 (func (param f32 f32 f32 f32) (result i32)))
+ (type $f32_f32_=>_f32 (func (param f32 f32) (result f32)))
  (type $none_=>_f64 (func (result f64)))
  (type $f64_f64_=>_i32 (func (param f64 f64) (result i32)))
  (type $f32_f32_=>_i32 (func (param f32 f32) (result i32)))
@@ -13,10 +14,7 @@
  (type $f64_i32_=>_f64 (func (param f64 i32) (result f64)))
  (type $i32_i32_i32_i32_=>_none (func (param i32 i32 i32 i32)))
  (type $i64_=>_i32 (func (param i64) (result i32)))
- (type $f32_f32_f32_f32_=>_i32 (func (param f32 f32 f32 f32) (result i32)))
- (type $i64_=>_none (func (param i64)))
  (type $f64_f64_i32_=>_f64 (func (param f64 f64 i32) (result f64)))
- (type $f64_=>_none (func (param f64)))
  (type $i64_i64_i64_i64_i64_=>_none (func (param i64 i64 i64 i64 i64)))
  (type $i64_i64_=>_i64 (func (param i64 i64) (result i64)))
  (import "env" "Math.E" (global $~lib/bindings/dom/Math.E f64))
@@ -59,17 +57,16 @@
  (import "env" "Math.tan" (func $~lib/bindings/dom/Math.tan (param f64) (result f64)))
  (import "env" "Math.tanh" (func $~lib/bindings/dom/Math.tanh (param f64) (result f64)))
  (import "env" "Math.trunc" (func $~lib/bindings/dom/Math.trunc (param f64) (result f64)))
- (global $~lib/math/rempio2_y0 (mut f64) (f64.const 0))
- (global $~lib/math/rempio2_y1 (mut f64) (f64.const 0))
- (global $~lib/math/res128_hi (mut i64) (i64.const 0))
- (global $~lib/math/rempio2f_y (mut f64) (f64.const 0))
+ (global $~lib/util/math/rempio2_y0 (mut f64) (f64.const 0))
+ (global $~lib/util/math/rempio2_y1 (mut f64) (f64.const 0))
+ (global $~lib/util/math/res128_hi (mut i64) (i64.const 0))
+ (global $~lib/util/math/rempio2_32_y (mut f64) (f64.const 0))
  (global $~lib/util/math/log_tail (mut f64) (f64.const 0))
  (global $~lib/math/random_state0_64 (mut i64) (i64.const 0))
  (global $~lib/math/random_state1_64 (mut i64) (i64.const 0))
- (global $~lib/math/random_state0_32 (mut i32) (i32.const 0))
- (global $~lib/math/random_state1_32 (mut i32) (i32.const 0))
  (global $~lib/math/random_seeded (mut i32) (i32.const 0))
  (global $~lib/math/NativeMath.sincos_sin (mut f64) (f64.const 0))
+ (global $~lib/util/math/sincos_cos64 (mut f64) (f64.const 0))
  (global $~lib/math/NativeMath.sincos_cos (mut f64) (f64.const 0))
  (memory $0 1)
  (data (i32.const 1036) ",")
@@ -215,7 +212,7 @@
  (data (i32.const 14353) "`Y\df\bd\d5\d5?\dce\a4\08*\0b\n\bd")
  (export "memory" (memory $0))
  (start $~start)
- (func $~lib/math/NativeMath.scalbn (param $0 f64) (param $1 i32) (result f64)
+ (func $~lib/util/math/scalbn64 (param $0 f64) (param $1 i32) (result f64)
   local.get $1
   i32.const 1023
   i32.gt_s
@@ -377,7 +374,7 @@
     i32.add
    end
    i32.sub
-   call $~lib/math/NativeMath.scalbn
+   call $~lib/util/math/scalbn64
    local.get $2
    f64.add
   end
@@ -559,7 +556,7 @@
   end
   i32.const 1
  )
- (func $~lib/math/NativeMath.acos (param $0 f64) (result f64)
+ (func $~lib/util/math/acos64 (param $0 f64) (result f64)
   (local $1 i32)
   (local $2 i32)
   (local $3 f64)
@@ -801,98 +798,137 @@
   f64.const 2
   f64.mul
  )
- (func $~lib/math/NativeMathf.acos (param $0 f32) (result f32)
-  (local $1 i32)
-  (local $2 i32)
-  (local $3 f32)
-  (local $4 f32)
-  local.get $0
-  i32.reinterpret_f32
-  local.tee $2
-  i32.const 2147483647
-  i32.and
-  local.tee $1
-  i32.const 1065353216
-  i32.ge_u
-  if
-   local.get $1
+ (func $std/math/test_acosf (param $0 f32) (param $1 f32) (param $2 f32) (result i32)
+  (local $3 i32)
+  (local $4 i32)
+  (local $5 f32)
+  (local $6 f32)
+  block $__inlined_func$~lib/util/math/acos32 (result f32)
+   local.get $0
+   i32.reinterpret_f32
+   local.tee $4
+   i32.const 2147483647
+   i32.and
+   local.tee $3
    i32.const 1065353216
-   i32.eq
+   i32.ge_u
    if
-    local.get $2
-    i32.const 31
-    i32.shr_u
+    local.get $3
+    i32.const 1065353216
+    i32.eq
     if
      f32.const 3.141592502593994
-     return
+     local.get $4
+     i32.const 31
+     i32.shr_u
+     br_if $__inlined_func$~lib/util/math/acos32
+     drop
+     f32.const 0
+     br $__inlined_func$~lib/util/math/acos32
     end
     f32.const 0
-    return
+    local.get $0
+    local.get $0
+    f32.sub
+    f32.div
+    br $__inlined_func$~lib/util/math/acos32
    end
-   f32.const 0
-   local.get $0
-   local.get $0
-   f32.sub
-   f32.div
-   return
-  end
-  local.get $1
-  i32.const 1056964608
-  i32.lt_u
-  if
-   local.get $1
-   i32.const 847249408
-   i32.le_u
+   local.get $3
+   i32.const 1056964608
+   i32.lt_u
    if
     f32.const 1.570796251296997
-    return
+    local.get $3
+    i32.const 847249408
+    i32.le_u
+    br_if $__inlined_func$~lib/util/math/acos32
+    drop
+    f32.const 1.570796251296997
+    local.get $0
+    f32.const 7.549789415861596e-08
+    local.get $0
+    local.get $0
+    local.get $0
+    f32.mul
+    local.tee $0
+    local.get $0
+    local.get $0
+    f32.const -0.008656363002955914
+    f32.mul
+    f32.const -0.04274342209100723
+    f32.add
+    f32.mul
+    f32.const 0.16666586697101593
+    f32.add
+    f32.mul
+    local.get $0
+    f32.const -0.7066296339035034
+    f32.mul
+    f32.const 1
+    f32.add
+    f32.div
+    f32.mul
+    f32.sub
+    f32.sub
+    f32.sub
+    br $__inlined_func$~lib/util/math/acos32
    end
-   f32.const 1.570796251296997
-   local.get $0
-   f32.const 7.549789415861596e-08
-   local.get $0
-   local.get $0
-   local.get $0
-   f32.mul
-   local.tee $0
-   local.get $0
-   local.get $0
-   f32.const -0.008656363002955914
-   f32.mul
-   f32.const -0.04274342209100723
-   f32.add
-   f32.mul
-   f32.const 0.16666586697101593
-   f32.add
-   f32.mul
-   local.get $0
-   f32.const -0.7066296339035034
-   f32.mul
-   f32.const 1
-   f32.add
-   f32.div
-   f32.mul
-   f32.sub
-   f32.sub
-   f32.sub
-   return
-  end
-  local.get $2
-  i32.const 31
-  i32.shr_u
-  if
-   f32.const 1.570796251296997
+   local.get $4
+   i32.const 31
+   i32.shr_u
+   if
+    f32.const 1.570796251296997
+    local.get $0
+    f32.const 0.5
+    f32.mul
+    f32.const 0.5
+    f32.add
+    local.tee $0
+    f32.sqrt
+    local.tee $5
+    local.get $0
+    local.get $0
+    local.get $0
+    f32.const -0.008656363002955914
+    f32.mul
+    f32.const -0.04274342209100723
+    f32.add
+    f32.mul
+    f32.const 0.16666586697101593
+    f32.add
+    f32.mul
+    local.get $0
+    f32.const -0.7066296339035034
+    f32.mul
+    f32.const 1
+    f32.add
+    f32.div
+    local.get $5
+    f32.mul
+    f32.const 7.549789415861596e-08
+    f32.sub
+    f32.add
+    f32.sub
+    f32.const 2
+    f32.mul
+    br $__inlined_func$~lib/util/math/acos32
+   end
+   f32.const 0.5
    local.get $0
    f32.const 0.5
    f32.mul
-   f32.const 0.5
-   f32.add
-   local.tee $0
+   f32.sub
+   local.tee $5
    f32.sqrt
-   local.tee $3
-   local.get $0
-   local.get $0
-   local.get $0
+   local.tee $6
+   i32.reinterpret_f32
+   i32.const -4096
+   i32.and
+   f32.reinterpret_i32
+   local.tee $0
+   local.get $5
+   local.get $5
+   local.get $5
    f32.const -0.008656363002955914
    f32.mul
    f32.const -0.04274342209100723
@@ -901,69 +937,33 @@
    f32.const 0.16666586697101593
    f32.add
    f32.mul
-   local.get $0
+   local.get $5
    f32.const -0.7066296339035034
    f32.mul
    f32.const 1
    f32.add
    f32.div
-   local.get $3
+   local.get $6
    f32.mul
-   f32.const 7.549789415861596e-08
+   local.get $5
+   local.get $0
+   local.get $0
+   f32.mul
    f32.sub
+   local.get $6
+   local.get $0
    f32.add
-   f32.sub
+   f32.div
+   f32.add
+   f32.add
    f32.const 2
    f32.mul
-   return
   end
-  f32.const 0.5
-  local.get $0
-  f32.const 0.5
-  f32.mul
-  f32.sub
-  local.tee $3
-  f32.sqrt
-  local.tee $4
-  i32.reinterpret_f32
-  i32.const -4096
-  i32.and
-  f32.reinterpret_i32
-  local.tee $0
-  local.get $3
-  local.get $3
-  local.get $3
-  f32.const -0.008656363002955914
-  f32.mul
-  f32.const -0.04274342209100723
-  f32.add
-  f32.mul
-  f32.const 0.16666586697101593
-  f32.add
-  f32.mul
-  local.get $3
-  f32.const -0.7066296339035034
-  f32.mul
-  f32.const 1
-  f32.add
-  f32.div
-  local.get $4
-  f32.mul
-  local.get $3
-  local.get $0
-  local.get $0
-  f32.mul
-  f32.sub
-  local.get $4
-  local.get $0
-  f32.add
-  f32.div
-  f32.add
-  f32.add
-  f32.const 2
-  f32.mul
+  local.get $1
+  local.get $2
+  call $std/math/check<f32>
  )
- (func $~lib/math/NativeMath.log1p (param $0 f64) (result f64)
+ (func $~lib/util/math/log1p64 (param $0 f64) (result f64)
   (local $1 f64)
   (local $2 i32)
   (local $3 i64)
@@ -1160,7 +1160,7 @@
   f64.mul
   f64.add
  )
- (func $~lib/math/NativeMath.log (param $0 f64) (result f64)
+ (func $~lib/util/math/log64 (param $0 f64) (result f64)
   (local $1 i64)
   (local $2 i32)
   (local $3 i64)
@@ -1168,7 +1168,7 @@
   (local $5 f64)
   (local $6 f64)
   (local $7 i32)
-  block $~lib/util/math/log_lut|inlined.0 (result f64)
+  block $~lib/util/math/log64_lut|inlined.0 (result f64)
    local.get $0
    i64.reinterpret_f64
    local.tee $1
@@ -1259,7 +1259,7 @@
     f64.add
     local.get $6
     f64.add
-    br $~lib/util/math/log_lut|inlined.0
+    br $~lib/util/math/log64_lut|inlined.0
    end
    local.get $1
    i64.const 48
@@ -1280,13 +1280,13 @@
     i64.const 1
     i64.shl
     i64.eqz
-    br_if $~lib/util/math/log_lut|inlined.0
+    br_if $~lib/util/math/log64_lut|inlined.0
     drop
     local.get $0
     local.get $1
     i64.const 9218868437227405312
     i64.eq
-    br_if $~lib/util/math/log_lut|inlined.0
+    br_if $~lib/util/math/log64_lut|inlined.0
     drop
     i32.const 1
     local.get $2
@@ -1305,7 +1305,7 @@
      local.tee $0
      local.get $0
      f64.div
-     br $~lib/util/math/log_lut|inlined.0
+     br $~lib/util/math/log64_lut|inlined.0
     end
     local.get $0
     f64.const 4503599627370496
@@ -1403,7 +1403,7 @@
  (func $std/math/test_acosh (param $0 f64) (param $1 f64) (param $2 f64) (result i32)
   (local $3 f64)
   (local $4 i64)
-  block $__inlined_func$~lib/math/NativeMath.acosh (result f64)
+  block $__inlined_func$~lib/util/math/acosh64 (result f64)
    local.get $0
    local.get $0
    f64.sub
@@ -1414,7 +1414,7 @@
    local.tee $4
    i64.const 4607182418800017408
    i64.lt_s
-   br_if $__inlined_func$~lib/math/NativeMath.acosh
+   br_if $__inlined_func$~lib/util/math/acosh64
    drop
    local.get $4
    i64.const 52
@@ -1438,8 +1438,8 @@
     f64.add
     f64.sqrt
     f64.add
-    call $~lib/math/NativeMath.log1p
-    br $__inlined_func$~lib/math/NativeMath.acosh
+    call $~lib/util/math/log1p64
+    br $__inlined_func$~lib/util/math/acosh64
    end
    local.get $4
    i64.const 1049
@@ -1459,11 +1459,11 @@
     f64.add
     f64.div
     f64.sub
-    call $~lib/math/NativeMath.log
-    br $__inlined_func$~lib/math/NativeMath.acosh
+    call $~lib/util/math/log64
+    br $__inlined_func$~lib/util/math/acosh64
    end
    local.get $0
-   call $~lib/math/NativeMath.log
+   call $~lib/util/math/log64
    f64.const 0.6931471805599453
    f64.add
   end
@@ -1480,7 +1480,7 @@
    i32.const 0
   end
  )
- (func $~lib/math/NativeMathf.log1p (param $0 f32) (result f32)
+ (func $~lib/util/math/log1p32 (param $0 f32) (result f32)
   (local $1 f32)
   (local $2 i32)
   (local $3 f32)
@@ -1649,7 +1649,7 @@
   f32.mul
   f32.add
  )
- (func $~lib/math/NativeMathf.log (param $0 f32) (result f32)
+ (func $~lib/util/math/log32 (param $0 f32) (result f32)
   (local $1 i32)
   (local $2 f64)
   (local $3 i32)
@@ -1760,7 +1760,7 @@
  )
  (func $std/math/test_acoshf (param $0 f32) (param $1 f32) (param $2 f32) (result i32)
   (local $3 i32)
-  block $__inlined_func$~lib/math/NativeMathf.acosh (result f32)
+  block $__inlined_func$~lib/util/math/acosh32 (result f32)
    local.get $0
    i32.reinterpret_f32
    local.tee $3
@@ -1780,8 +1780,8 @@
     f32.mul
     f32.sqrt
     f32.add
-    call $~lib/math/NativeMathf.log1p
-    br $__inlined_func$~lib/math/NativeMathf.acosh
+    call $~lib/util/math/log1p32
+    br $__inlined_func$~lib/util/math/acosh32
    end
    local.get $3
    i32.const 1166016512
@@ -1801,11 +1801,11 @@
     f32.add
     f32.div
     f32.sub
-    call $~lib/math/NativeMathf.log
-    br $__inlined_func$~lib/math/NativeMathf.acosh
+    call $~lib/util/math/log32
+    br $__inlined_func$~lib/util/math/acosh32
    end
    local.get $0
-   call $~lib/math/NativeMathf.log
+   call $~lib/util/math/log32
    f32.const 0.6931471824645996
    f32.add
   end
@@ -1813,7 +1813,7 @@
   local.get $2
   call $std/math/check<f32>
  )
- (func $~lib/math/NativeMath.asin (param $0 f64) (result f64)
+ (func $~lib/util/math/asin64 (param $0 f64) (result f64)
   (local $1 i32)
   (local $2 i32)
   (local $3 f64)
@@ -2029,59 +2029,91 @@
   end
   local.get $0
  )
- (func $~lib/math/NativeMathf.asin (param $0 f32) (result f32)
-  (local $1 i32)
-  (local $2 f64)
-  (local $3 f32)
-  local.get $0
-  i32.reinterpret_f32
-  i32.const 2147483647
-  i32.and
-  local.tee $1
-  i32.const 1065353216
-  i32.ge_u
-  if
-   local.get $1
+ (func $std/math/test_asinf (param $0 f32) (param $1 f32) (param $2 f32) (result i32)
+  (local $3 i32)
+  (local $4 f64)
+  (local $5 f32)
+  block $__inlined_func$~lib/util/math/asin32 (result f32)
+   local.get $0
+   i32.reinterpret_f32
+   i32.const 2147483647
+   i32.and
+   local.tee $3
    i32.const 1065353216
-   i32.eq
+   i32.ge_u
    if
     local.get $0
     f32.const 1.5707963705062866
     f32.mul
     f32.const 7.52316384526264e-37
     f32.add
-    return
+    local.get $3
+    i32.const 1065353216
+    i32.eq
+    br_if $__inlined_func$~lib/util/math/asin32
+    drop
+    f32.const 0
+    local.get $0
+    local.get $0
+    f32.sub
+    f32.div
+    br $__inlined_func$~lib/util/math/asin32
    end
-   f32.const 0
-   local.get $0
-   local.get $0
-   f32.sub
-   f32.div
-   return
-  end
-  local.get $1
-  i32.const 1056964608
-  i32.lt_u
-  if
-   local.get $1
-   i32.const 964689920
+   local.get $3
+   i32.const 1056964608
    i32.lt_u
-   local.get $1
-   i32.const 8388608
-   i32.ge_u
-   i32.and
    if
     local.get $0
-    return
+    local.get $3
+    i32.const 964689920
+    i32.lt_u
+    local.get $3
+    i32.const 8388608
+    i32.ge_u
+    i32.and
+    br_if $__inlined_func$~lib/util/math/asin32
+    drop
+    local.get $0
+    local.get $0
+    local.get $0
+    local.get $0
+    f32.mul
+    local.tee $0
+    local.get $0
+    local.get $0
+    f32.const -0.008656363002955914
+    f32.mul
+    f32.const -0.04274342209100723
+    f32.add
+    f32.mul
+    f32.const 0.16666586697101593
+    f32.add
+    f32.mul
+    local.get $0
+    f32.const -0.7066296339035034
+    f32.mul
+    f32.const 1
+    f32.add
+    f32.div
+    f32.mul
+    f32.add
+    br $__inlined_func$~lib/util/math/asin32
    end
+   f64.const 1.5707963705062866
+   f32.const 0.5
    local.get $0
-   local.get $0
-   local.get $0
-   local.get $0
+   f32.abs
+   f32.const 0.5
    f32.mul
-   local.tee $0
-   local.get $0
-   local.get $0
+   f32.sub
+   local.tee $5
+   f64.promote_f32
+   f64.sqrt
+   local.tee $4
+   local.get $4
+   local.get $5
+   local.get $5
+   local.get $5
    f32.const -0.008656363002955914
    f32.mul
    f32.const -0.04274342209100723
@@ -2090,54 +2122,25 @@
    f32.const 0.16666586697101593
    f32.add
    f32.mul
-   local.get $0
+   local.get $5
    f32.const -0.7066296339035034
    f32.mul
    f32.const 1
    f32.add
    f32.div
-   f32.mul
-   f32.add
-   return
+   f64.promote_f32
+   f64.mul
+   f64.add
+   f64.const 2
+   f64.mul
+   f64.sub
+   f32.demote_f64
+   local.get $0
+   f32.copysign
   end
-  f64.const 1.5707963705062866
-  f32.const 0.5
-  local.get $0
-  f32.abs
-  f32.const 0.5
-  f32.mul
-  f32.sub
-  local.tee $3
-  f64.promote_f32
-  f64.sqrt
-  local.tee $2
+  local.get $1
   local.get $2
-  local.get $3
-  local.get $3
-  local.get $3
-  f32.const -0.008656363002955914
-  f32.mul
-  f32.const -0.04274342209100723
-  f32.add
-  f32.mul
-  f32.const 0.16666586697101593
-  f32.add
-  f32.mul
-  local.get $3
-  f32.const -0.7066296339035034
-  f32.mul
-  f32.const 1
-  f32.add
-  f32.div
-  f64.promote_f32
-  f64.mul
-  f64.add
-  f64.const 2
-  f64.mul
-  f64.sub
-  f32.demote_f64
-  local.get $0
-  f32.copysign
+  call $std/math/check<f32>
  )
  (func $std/math/test_asinh (param $0 f64) (param $1 f64) (param $2 f64) (result i32)
   (local $3 i64)
@@ -2161,7 +2164,7 @@
   i64.ge_u
   if (result f64)
    local.get $5
-   call $~lib/math/NativeMath.log
+   call $~lib/util/math/log64
    f64.const 0.6931471805599453
    f64.add
   else
@@ -2183,7 +2186,7 @@
     f64.add
     f64.div
     f64.add
-    call $~lib/math/NativeMath.log
+    call $~lib/util/math/log64
    else
     local.get $3
     i64.const 997
@@ -2202,7 +2205,7 @@
      f64.add
      f64.div
      f64.add
-     call $~lib/math/NativeMath.log1p
+     call $~lib/util/math/log1p64
     else
      local.get $5
     end
@@ -2238,7 +2241,7 @@
   i32.ge_u
   if (result f32)
    local.get $4
-   call $~lib/math/NativeMathf.log
+   call $~lib/util/math/log32
    f32.const 0.6931471824645996
    f32.add
   else
@@ -2260,7 +2263,7 @@
     f32.add
     f32.div
     f32.add
-    call $~lib/math/NativeMathf.log
+    call $~lib/util/math/log32
    else
     local.get $3
     i32.const 964689920
@@ -2279,7 +2282,7 @@
      f32.add
      f32.div
      f32.add
-     call $~lib/math/NativeMathf.log1p
+     call $~lib/util/math/log1p32
     else
      local.get $4
     end
@@ -2291,7 +2294,7 @@
   local.get $2
   call $std/math/check<f32>
  )
- (func $~lib/math/NativeMath.atan (param $0 f64) (result f64)
+ (func $~lib/util/math/atan64 (param $0 f64) (result f64)
   (local $1 f64)
   (local $2 i32)
   (local $3 i32)
@@ -2510,7 +2513,7 @@
   local.get $1
   f64.copysign
  )
- (func $~lib/math/NativeMathf.atan (param $0 f32) (result f32)
+ (func $~lib/util/math/atan32 (param $0 f32) (result f32)
   (local $1 f32)
   (local $2 i32)
   (local $3 i32)
@@ -2735,7 +2738,7 @@
     f64.sub
     f64.div
     f64.add
-    call $~lib/math/NativeMath.log1p
+    call $~lib/util/math/log1p64
     f64.const 0.5
     f64.mul
    else
@@ -2749,7 +2752,7 @@
    f64.div
    f64.const 2
    f64.mul
-   call $~lib/math/NativeMath.log1p
+   call $~lib/util/math/log1p64
    f64.const 0.5
    f64.mul
   end
@@ -2795,7 +2798,7 @@
     f32.const 1
     f32.add
     f32.mul
-    call $~lib/math/NativeMathf.log1p
+    call $~lib/util/math/log1p32
     f32.const 0.5
     f32.mul
    else
@@ -2809,7 +2812,7 @@
    f32.div
    f32.const 2
    f32.mul
-   call $~lib/math/NativeMathf.log1p
+   call $~lib/util/math/log1p32
    f32.const 0.5
    f32.mul
   end
@@ -2827,7 +2830,7 @@
   (local $8 i32)
   (local $9 i32)
   (local $10 f64)
-  block $__inlined_func$~lib/math/NativeMath.atan2 (result f64)
+  block $__inlined_func$~lib/util/math/atan2_64 (result f64)
    local.get $1
    local.get $0
    f64.add
@@ -2838,7 +2841,7 @@
    local.get $1
    f64.ne
    i32.or
-   br_if $__inlined_func$~lib/math/NativeMath.atan2
+   br_if $__inlined_func$~lib/util/math/atan2_64
    drop
    local.get $0
    i64.reinterpret_f64
@@ -2864,8 +2867,8 @@
    i32.eqz
    if
     local.get $0
-    call $~lib/math/NativeMath.atan
-    br $__inlined_func$~lib/math/NativeMath.atan2
+    call $~lib/util/math/atan64
+    br $__inlined_func$~lib/util/math/atan2_64
    end
    local.get $8
    i32.const 30
@@ -2889,18 +2892,18 @@
     block $break|0
      block $case3|0
       block $case2|0
-       block $case0|0
+       block $case1|0
         local.get $4
-        br_table $case0|0 $case0|0 $case2|0 $case3|0 $break|0
+        br_table $case1|0 $case1|0 $case2|0 $case3|0 $break|0
        end
        local.get $0
-       br $__inlined_func$~lib/math/NativeMath.atan2
+       br $__inlined_func$~lib/util/math/atan2_64
       end
       f64.const 3.141592653589793
-      br $__inlined_func$~lib/math/NativeMath.atan2
+      br $__inlined_func$~lib/util/math/atan2_64
      end
      f64.const -3.141592653589793
-     br $__inlined_func$~lib/math/NativeMath.atan2
+     br $__inlined_func$~lib/util/math/atan2_64
     end
    end
    block $folding-inner0
@@ -2926,13 +2929,6 @@
       i32.const 2
       i32.and
       select
-      local.tee $10
-      f64.neg
-      local.get $10
-      local.get $4
-      i32.const 1
-      i32.and
-      select
      else
       f64.const 3.141592653589793
       f64.const 0
@@ -2940,15 +2936,15 @@
       i32.const 2
       i32.and
       select
-      local.tee $10
-      f64.neg
-      local.get $10
-      local.get $4
-      i32.const 1
-      i32.and
-      select
      end
-     br $__inlined_func$~lib/math/NativeMath.atan2
+     local.tee $10
+     f64.neg
+     local.get $10
+     local.get $4
+     i32.const 1
+     i32.and
+     select
+     br $__inlined_func$~lib/util/math/atan2_64
     end
     local.get $9
     i32.const 2146435072
@@ -2977,7 +2973,7 @@
      local.get $1
      f64.div
      f64.abs
-     call $~lib/math/NativeMath.atan
+     call $~lib/util/math/atan64
     end
     local.set $10
     block $break|1
@@ -2989,25 +2985,25 @@
          br_table $case0|1 $case1|1 $case2|1 $case3|1 $break|1
         end
         local.get $10
-        br $__inlined_func$~lib/math/NativeMath.atan2
+        br $__inlined_func$~lib/util/math/atan2_64
        end
        local.get $10
        f64.neg
-       br $__inlined_func$~lib/math/NativeMath.atan2
+       br $__inlined_func$~lib/util/math/atan2_64
       end
       f64.const 3.141592653589793
       local.get $10
       f64.const 1.2246467991473532e-16
       f64.sub
       f64.sub
-      br $__inlined_func$~lib/math/NativeMath.atan2
+      br $__inlined_func$~lib/util/math/atan2_64
      end
      local.get $10
      f64.const 1.2246467991473532e-16
      f64.sub
      f64.const 3.141592653589793
      f64.sub
-     br $__inlined_func$~lib/math/NativeMath.atan2
+     br $__inlined_func$~lib/util/math/atan2_64
     end
     unreachable
    end
@@ -3032,180 +3028,184 @@
    i32.const 0
   end
  )
- (func $~lib/math/NativeMathf.atan2 (param $0 f32) (param $1 f32) (result f32)
-  (local $2 i32)
-  (local $3 i32)
+ (func $std/math/test_atan2f (param $0 f32) (param $1 f32) (param $2 f32) (param $3 f32) (result i32)
   (local $4 i32)
-  local.get $0
-  local.get $0
-  f32.ne
-  local.get $1
-  local.get $1
-  f32.ne
-  i32.or
-  if
+  (local $5 i32)
+  (local $6 i32)
+  block $__inlined_func$~lib/util/math/atan2_32 (result f32)
    local.get $1
    local.get $0
    f32.add
-   return
-  end
-  local.get $1
-  i32.reinterpret_f32
-  local.tee $3
-  i32.const 1065353216
-  i32.eq
-  if
    local.get $0
-   call $~lib/math/NativeMathf.atan
-   return
-  end
-  local.get $3
-  i32.const 30
-  i32.shr_u
-  i32.const 2
-  i32.and
-  local.get $0
-  i32.reinterpret_f32
-  local.tee $4
-  i32.const 31
-  i32.shr_u
-  i32.or
-  local.set $2
-  local.get $4
-  i32.const 2147483647
-  i32.and
-  local.tee $4
-  i32.eqz
-  if
-   block $break|0
-    block $case3|0
-     block $case2|0
-      block $case1|0
-       local.get $2
-       br_table $case1|0 $case1|0 $case2|0 $case3|0 $break|0
-      end
-      local.get $0
-      return
-     end
-     f32.const 3.1415927410125732
-     return
-    end
-    f32.const -3.1415927410125732
-    return
-   end
-  end
-  block $folding-inner0
-   local.get $3
-   i32.const 2147483647
-   i32.and
-   local.tee $3
-   i32.eqz
-   br_if $folding-inner0
-   local.get $3
-   i32.const 2139095040
+   local.get $0
+   f32.ne
+   local.get $1
+   local.get $1
+   f32.ne
+   i32.or
+   br_if $__inlined_func$~lib/util/math/atan2_32
+   drop
+   local.get $1
+   i32.reinterpret_f32
+   local.tee $5
+   i32.const 1065353216
    i32.eq
    if
-    local.get $4
-    i32.const 2139095040
-    i32.eq
-    if (result f32)
-     f32.const 2.356194496154785
-     f32.const 0.7853981852531433
-     local.get $2
-     i32.const 2
-     i32.and
-     select
-    else
-     f32.const 3.1415927410125732
-     f32.const 0
-     local.get $2
-     i32.const 2
-     i32.and
-     select
-    end
-    local.tee $0
-    f32.neg
     local.get $0
-    local.get $2
-    i32.const 1
-    i32.and
-    select
-    return
+    call $~lib/util/math/atan32
+    br $__inlined_func$~lib/util/math/atan2_32
    end
-   local.get $4
-   i32.const 2139095040
-   i32.eq
-   local.get $3
-   i32.const 218103808
-   i32.add
-   local.get $4
-   i32.lt_u
-   i32.or
-   br_if $folding-inner0
-   local.get $4
-   i32.const 218103808
-   i32.add
-   local.get $3
-   i32.lt_u
-   i32.const 0
-   local.get $2
+   local.get $5
+   i32.const 30
+   i32.shr_u
    i32.const 2
    i32.and
-   select
-   if (result f32)
-    f32.const 0
-   else
-    local.get $0
-    local.get $1
-    f32.div
-    f32.abs
-    call $~lib/math/NativeMathf.atan
-   end
-   local.set $0
-   block $break|1
-    block $case3|1
-     block $case2|1
-      block $case1|1
-       block $case0|1
-        local.get $2
-        br_table $case0|1 $case1|1 $case2|1 $case3|1 $break|1
+   local.get $0
+   i32.reinterpret_f32
+   local.tee $6
+   i32.const 31
+   i32.shr_u
+   i32.or
+   local.set $4
+   local.get $6
+   i32.const 2147483647
+   i32.and
+   local.tee $6
+   i32.eqz
+   if
+    block $break|0
+     block $case3|0
+      block $case2|0
+       block $case1|0
+        local.get $4
+        br_table $case1|0 $case1|0 $case2|0 $case3|0 $break|0
        end
        local.get $0
-       return
+       br $__inlined_func$~lib/util/math/atan2_32
       end
-      local.get $0
-      f32.neg
-      return
+      f32.const 3.1415927410125732
+      br $__inlined_func$~lib/util/math/atan2_32
      end
-     f32.const 3.1415927410125732
+     f32.const -3.1415927410125732
+     br $__inlined_func$~lib/util/math/atan2_32
+    end
+   end
+   block $folding-inner0
+    local.get $5
+    i32.const 2147483647
+    i32.and
+    local.tee $5
+    i32.eqz
+    br_if $folding-inner0
+    local.get $5
+    i32.const 2139095040
+    i32.eq
+    if
+     local.get $6
+     i32.const 2139095040
+     i32.eq
+     if (result f32)
+      f32.const 2.356194496154785
+      f32.const 0.7853981852531433
+      local.get $4
+      i32.const 2
+      i32.and
+      select
+     else
+      f32.const 3.1415927410125732
+      f32.const 0
+      local.get $4
+      i32.const 2
+      i32.and
+      select
+     end
+     local.tee $0
+     f32.neg
+     local.get $0
+     local.get $4
+     i32.const 1
+     i32.and
+     select
+     br $__inlined_func$~lib/util/math/atan2_32
+    end
+    local.get $6
+    i32.const 2139095040
+    i32.eq
+    local.get $5
+    i32.const 218103808
+    i32.add
+    local.get $6
+    i32.lt_u
+    i32.or
+    br_if $folding-inner0
+    local.get $6
+    i32.const 218103808
+    i32.add
+    local.get $5
+    i32.lt_u
+    i32.const 0
+    local.get $4
+    i32.const 2
+    i32.and
+    select
+    if (result f32)
+     f32.const 0
+    else
+     local.get $0
+     local.get $1
+     f32.div
+     f32.abs
+     call $~lib/util/math/atan32
+    end
+    local.set $0
+    block $break|1
+     block $case3|1
+      block $case2|1
+       block $case1|1
+        block $case0|1
+         local.get $4
+         br_table $case0|1 $case1|1 $case2|1 $case3|1 $break|1
+        end
+        local.get $0
+        br $__inlined_func$~lib/util/math/atan2_32
+       end
+       local.get $0
+       f32.neg
+       br $__inlined_func$~lib/util/math/atan2_32
+      end
+      f32.const 3.1415927410125732
+      local.get $0
+      f32.const -8.742277657347586e-08
+      f32.sub
+      f32.sub
+      br $__inlined_func$~lib/util/math/atan2_32
+     end
      local.get $0
      f32.const -8.742277657347586e-08
      f32.sub
+     f32.const 3.1415927410125732
      f32.sub
-     return
+     br $__inlined_func$~lib/util/math/atan2_32
     end
-    local.get $0
-    f32.const -8.742277657347586e-08
-    f32.sub
-    f32.const 3.1415927410125732
-    f32.sub
-    return
+    unreachable
    end
-   unreachable
+   f32.const -1.5707963705062866
+   f32.const 1.5707963705062866
+   local.get $4
+   i32.const 1
+   i32.and
+   select
   end
-  f32.const -1.5707963705062866
-  f32.const 1.5707963705062866
   local.get $2
-  i32.const 1
-  i32.and
-  select
+  local.get $3
+  call $std/math/check<f32>
  )
  (func $std/math/test_cbrt (param $0 f64) (param $1 f64) (param $2 f64) (result i32)
   (local $3 i32)
   (local $4 i64)
   (local $5 f64)
   (local $6 f64)
-  block $__inlined_func$~lib/math/NativeMath.cbrt (result f64)
+  block $__inlined_func$~lib/util/math/cbrt64 (result f64)
    local.get $0
    local.get $0
    f64.add
@@ -3220,7 +3220,7 @@
    local.tee $3
    i32.const 2146435072
    i32.ge_u
-   br_if $__inlined_func$~lib/math/NativeMath.cbrt
+   br_if $__inlined_func$~lib/util/math/cbrt64
    drop
    local.get $3
    i32.const 1048576
@@ -3239,7 +3239,7 @@
     i32.and
     local.tee $3
     i32.eqz
-    br_if $__inlined_func$~lib/math/NativeMath.cbrt
+    br_if $__inlined_func$~lib/util/math/cbrt64
     drop
     local.get $3
     i32.const 3
@@ -3340,7 +3340,7 @@
   (local $6 f64)
   (local $7 f64)
   (local $8 f64)
-  block $__inlined_func$~lib/math/NativeMathf.cbrt (result f32)
+  block $__inlined_func$~lib/util/math/cbrt32 (result f32)
    local.get $0
    local.get $0
    f32.add
@@ -3352,7 +3352,7 @@
    local.tee $4
    i32.const 2139095040
    i32.ge_u
-   br_if $__inlined_func$~lib/math/NativeMathf.cbrt
+   br_if $__inlined_func$~lib/util/math/cbrt32
    drop
    local.get $4
    i32.const 8388608
@@ -3361,7 +3361,7 @@
     local.get $0
     local.get $4
     i32.eqz
-    br_if $__inlined_func$~lib/math/NativeMathf.cbrt
+    br_if $__inlined_func$~lib/util/math/cbrt32
     drop
     local.get $0
     f32.const 16777216
@@ -3432,7 +3432,7 @@
   local.get $2
   call $std/math/check<f32>
  )
- (func $~lib/math/pio2_large_quot (param $0 i64) (result i32)
+ (func $~lib/util/math/pio2_64_large_quot (param $0 i64) (result i32)
   (local $1 i64)
   (local $2 i64)
   (local $3 i64)
@@ -3553,7 +3553,7 @@
   i64.const 32
   i64.shr_u
   i64.add
-  global.set $~lib/math/res128_hi
+  global.set $~lib/util/math/res128_hi
   local.get $10
   local.get $1
   i64.const 32
@@ -3572,7 +3572,7 @@
   local.get $1
   i64.lt_u
   i64.extend_i32_u
-  global.get $~lib/math/res128_hi
+  global.get $~lib/util/math/res128_hi
   local.get $3
   local.get $6
   i64.mul
@@ -3646,7 +3646,7 @@
   i64.const 32
   i64.shr_u
   i64.add
-  global.set $~lib/math/res128_hi
+  global.set $~lib/util/math/res128_hi
   local.get $11
   i64.const 4294967295
   i64.and
@@ -3670,13 +3670,13 @@
   local.tee $2
   i64.lt_u
   i64.extend_i32_u
-  global.get $~lib/math/res128_hi
+  global.get $~lib/util/math/res128_hi
   local.tee $9
   i64.const 11
   i64.shr_u
   i64.add
   f64.convert_i64_u
-  global.set $~lib/math/rempio2_y0
+  global.set $~lib/util/math/rempio2_y0
   local.get $9
   i64.const 53
   i64.shl
@@ -3689,8 +3689,8 @@
   f64.convert_i64_u
   f64.const 5.421010862427522e-20
   f64.mul
-  global.set $~lib/math/rempio2_y1
-  global.get $~lib/math/rempio2_y0
+  global.set $~lib/util/math/rempio2_y1
+  global.get $~lib/util/math/rempio2_y0
   i64.const 4372995238176751616
   local.get $8
   i64.const 52
@@ -3705,11 +3705,11 @@
   f64.reinterpret_i64
   local.tee $5
   f64.mul
-  global.set $~lib/math/rempio2_y0
-  global.get $~lib/math/rempio2_y1
+  global.set $~lib/util/math/rempio2_y0
+  global.get $~lib/util/math/rempio2_y1
   local.get $5
   f64.mul
-  global.set $~lib/math/rempio2_y1
+  global.set $~lib/util/math/rempio2_y1
   local.get $3
   i64.const 62
   i64.shr_s
@@ -3717,7 +3717,7 @@
   i64.sub
   i32.wrap_i64
  )
- (func $~lib/math/NativeMath.cos (param $0 f64) (result f64)
+ (func $~lib/util/math/cos64 (param $0 f64) (result f64)
   (local $1 f64)
   (local $2 f64)
   (local $3 i32)
@@ -3814,7 +3814,7 @@
    f64.sub
    return
   end
-  block $~lib/math/rempio2|inlined.0 (result i32)
+  block $~lib/util/math/rempio2_64|inlined.0 (result i32)
    local.get $5
    i64.const 32
    i64.shr_u
@@ -3894,10 +3894,10 @@
      end
     end
     local.get $0
-    global.set $~lib/math/rempio2_y0
-    global.set $~lib/math/rempio2_y1
+    global.set $~lib/util/math/rempio2_y0
+    global.set $~lib/util/math/rempio2_y1
     local.get $3
-    br $~lib/math/rempio2|inlined.0
+    br $~lib/util/math/rempio2_64|inlined.0
    end
    local.get $4
    i32.const 1094263291
@@ -3991,20 +3991,20 @@
      end
     end
     local.get $1
-    global.set $~lib/math/rempio2_y0
+    global.set $~lib/util/math/rempio2_y0
     local.get $0
     local.get $1
     f64.sub
     local.get $2
     f64.sub
-    global.set $~lib/math/rempio2_y1
+    global.set $~lib/util/math/rempio2_y1
     local.get $7
     i32.trunc_sat_f64_s
-    br $~lib/math/rempio2|inlined.0
+    br $~lib/util/math/rempio2_64|inlined.0
    end
    i32.const 0
    local.get $5
-   call $~lib/math/pio2_large_quot
+   call $~lib/util/math/pio2_64_large_quot
    local.tee $3
    i32.sub
    local.get $3
@@ -4012,9 +4012,9 @@
    select
   end
   local.set $3
-  global.get $~lib/math/rempio2_y0
+  global.get $~lib/util/math/rempio2_y0
   local.set $1
-  global.get $~lib/math/rempio2_y1
+  global.get $~lib/util/math/rempio2_y1
   local.set $2
   local.get $3
   i32.const 1
@@ -4128,7 +4128,7 @@
   i32.and
   select
  )
- (func $~lib/math/NativeMathf.cos (param $0 f32) (result f32)
+ (func $~lib/util/math/cos32 (param $0 f32) (result f32)
   (local $1 f64)
   (local $2 f64)
   (local $3 i32)
@@ -4357,7 +4357,7 @@
     f32.sub
     return
    end
-   block $~lib/math/rempio2f|inlined.0 (result i32)
+   block $~lib/util/math/rempio2_32|inlined.0 (result i32)
     local.get $3
     i32.const 1305022427
     i32.lt_u
@@ -4378,10 +4378,10 @@
      f64.const 1.5893254773528196e-08
      f64.mul
      f64.sub
-     global.set $~lib/math/rempio2f_y
+     global.set $~lib/util/math/rempio2_32_y
      local.get $2
      i32.trunc_sat_f64_s
-     br $~lib/math/rempio2f|inlined.0
+     br $~lib/util/math/rempio2_32|inlined.0
     end
     local.get $3
     i32.const 23
@@ -4459,7 +4459,7 @@
     local.tee $8
     f64.convert_i64_s
     f64.mul
-    global.set $~lib/math/rempio2f_y
+    global.set $~lib/util/math/rempio2_32_y
     i32.const 0
     local.get $4
     i64.const 62
@@ -4476,7 +4476,7 @@
     select
    end
    local.set $3
-   global.get $~lib/math/rempio2f_y
+   global.get $~lib/util/math/rempio2_32_y
    local.set $1
    local.get $3
    i32.const 1
@@ -4571,7 +4571,7 @@
   f64.add
   f32.demote_f64
  )
- (func $~lib/math/NativeMath.expm1 (param $0 f64) (result f64)
+ (func $~lib/util/math/expm1_64 (param $0 f64) (result f64)
   (local $1 i32)
   (local $2 f64)
   (local $3 i32)
@@ -4842,7 +4842,7 @@
   local.get $6
   f64.mul
  )
- (func $~lib/math/NativeMath.exp (param $0 f64) (result f64)
+ (func $~lib/util/math/exp64 (param $0 f64) (result f64)
   (local $1 i32)
   (local $2 i64)
   (local $3 i32)
@@ -5059,7 +5059,7 @@
   (local $3 i32)
   (local $4 i64)
   (local $5 f64)
-  block $__inlined_func$~lib/math/NativeMath.cosh (result f64)
+  block $__inlined_func$~lib/util/math/cosh64 (result f64)
    local.get $0
    i64.reinterpret_f64
    i64.const 9223372036854775807
@@ -5079,10 +5079,10 @@
     local.get $3
     i32.const 1045430272
     i32.lt_u
-    br_if $__inlined_func$~lib/math/NativeMath.cosh
+    br_if $__inlined_func$~lib/util/math/cosh64
     drop
     local.get $5
-    call $~lib/math/NativeMath.expm1
+    call $~lib/util/math/expm1_64
     local.tee $5
     local.get $5
     f64.mul
@@ -5094,14 +5094,14 @@
     f64.div
     f64.const 1
     f64.add
-    br $__inlined_func$~lib/math/NativeMath.cosh
+    br $__inlined_func$~lib/util/math/cosh64
    end
    local.get $3
    i32.const 1082535490
    i32.lt_u
    if
     local.get $5
-    call $~lib/math/NativeMath.exp
+    call $~lib/util/math/exp64
     local.tee $5
     f64.const 1
     local.get $5
@@ -5109,12 +5109,12 @@
     f64.add
     f64.const 0.5
     f64.mul
-    br $__inlined_func$~lib/math/NativeMath.cosh
+    br $__inlined_func$~lib/util/math/cosh64
    end
    local.get $5
    f64.const 1416.0996898839683
    f64.sub
-   call $~lib/math/NativeMath.exp
+   call $~lib/util/math/exp64
    f64.const 2247116418577894884661631e283
    f64.mul
    f64.const 2247116418577894884661631e283
@@ -5133,7 +5133,7 @@
    i32.const 0
   end
  )
- (func $~lib/math/NativeMathf.expm1 (param $0 f32) (result f32)
+ (func $~lib/util/math/expm1_32 (param $0 f32) (result f32)
   (local $1 i32)
   (local $2 f32)
   (local $3 i32)
@@ -5381,13 +5381,13 @@
   local.get $4
   f32.mul
  )
- (func $~lib/math/NativeMathf.exp (param $0 f32) (result f32)
+ (func $~lib/util/math/exp32 (param $0 f32) (result f32)
   (local $1 f64)
   (local $2 i64)
   (local $3 i32)
   (local $4 i32)
   (local $5 f64)
-  block $~lib/util/math/expf_lut|inlined.0 (result f32)
+  block $~lib/util/math/exp32_lut|inlined.0 (result f32)
    local.get $0
    i32.reinterpret_f32
    local.tee $3
@@ -5403,7 +5403,7 @@
     local.get $3
     i32.const -8388608
     i32.eq
-    br_if $~lib/util/math/expf_lut|inlined.0
+    br_if $~lib/util/math/exp32_lut|inlined.0
     drop
     local.get $0
     local.get $0
@@ -5411,7 +5411,7 @@
     local.get $4
     i32.const 2040
     i32.ge_u
-    br_if $~lib/util/math/expf_lut|inlined.0
+    br_if $~lib/util/math/exp32_lut|inlined.0
     drop
     local.get $0
     f32.const 1701411834604692317316873e14
@@ -5419,13 +5419,13 @@
     local.get $0
     f32.const 88.72283172607422
     f32.gt
-    br_if $~lib/util/math/expf_lut|inlined.0
+    br_if $~lib/util/math/exp32_lut|inlined.0
     drop
     f32.const 0
     local.get $0
     f32.const -103.97207641601562
     f32.lt
-    br_if $~lib/util/math/expf_lut|inlined.0
+    br_if $~lib/util/math/exp32_lut|inlined.0
     drop
    end
    local.get $0
@@ -5478,7 +5478,7 @@
  )
  (func $std/math/test_coshf (param $0 f32) (param $1 f32) (param $2 f32) (result i32)
   (local $3 i32)
-  block $__inlined_func$~lib/math/NativeMathf.cosh (result f32)
+  block $__inlined_func$~lib/util/math/cosh32 (result f32)
    local.get $0
    i32.reinterpret_f32
    i32.const 2147483647
@@ -5494,10 +5494,10 @@
     local.get $3
     i32.const 964689920
     i32.lt_u
-    br_if $__inlined_func$~lib/math/NativeMathf.cosh
+    br_if $__inlined_func$~lib/util/math/cosh32
     drop
     local.get $0
-    call $~lib/math/NativeMathf.expm1
+    call $~lib/util/math/expm1_32
     local.tee $0
     local.get $0
     f32.mul
@@ -5509,14 +5509,14 @@
     f32.div
     f32.const 1
     f32.add
-    br $__inlined_func$~lib/math/NativeMathf.cosh
+    br $__inlined_func$~lib/util/math/cosh32
    end
    local.get $3
    i32.const 1118925335
    i32.lt_u
    if
     local.get $0
-    call $~lib/math/NativeMathf.exp
+    call $~lib/util/math/exp32
     local.tee $0
     f32.const 0.5
     f32.mul
@@ -5524,12 +5524,12 @@
     local.get $0
     f32.div
     f32.add
-    br $__inlined_func$~lib/math/NativeMathf.cosh
+    br $__inlined_func$~lib/util/math/cosh32
    end
    local.get $0
    f32.const 162.88958740234375
    f32.sub
-   call $~lib/math/NativeMathf.exp
+   call $~lib/util/math/exp32
    f32.const 1661534994731144841129758e11
    f32.mul
    f32.const 1661534994731144841129758e11
@@ -5548,7 +5548,7 @@
   (local $8 i64)
   (local $9 f64)
   (local $10 f64)
-  block $~lib/util/math/exp2_lut|inlined.0 (result f64)
+  block $__inlined_func$~lib/util/math/exp2_64_lut (result f64)
    local.get $0
    i64.reinterpret_f64
    local.tee $4
@@ -5569,7 +5569,7 @@
     i32.sub
     i32.const -2147483648
     i32.ge_u
-    br_if $~lib/util/math/exp2_lut|inlined.0
+    br_if $__inlined_func$~lib/util/math/exp2_64_lut
     drop
     local.get $3
     i32.const 1033
@@ -5579,7 +5579,7 @@
      local.get $4
      i64.const -4503599627370496
      i64.eq
-     br_if $~lib/util/math/exp2_lut|inlined.0
+     br_if $__inlined_func$~lib/util/math/exp2_64_lut
      drop
      local.get $0
      f64.const 1
@@ -5587,20 +5587,20 @@
      local.get $3
      i32.const 2047
      i32.ge_u
-     br_if $~lib/util/math/exp2_lut|inlined.0
+     br_if $__inlined_func$~lib/util/math/exp2_64_lut
      drop
      f64.const inf
      local.get $4
      i64.const 63
      i64.shr_u
      i64.eqz
-     br_if $~lib/util/math/exp2_lut|inlined.0
+     br_if $__inlined_func$~lib/util/math/exp2_64_lut
      drop
      f64.const 0
      local.get $4
      i64.const -4570929321408987136
      i64.ge_u
-     br_if $~lib/util/math/exp2_lut|inlined.0
+     br_if $__inlined_func$~lib/util/math/exp2_64_lut
      drop
     end
     i32.const 0
@@ -5730,7 +5730,7 @@
      f64.const 2.2250738585072014e-308
      f64.mul
     end
-    br $~lib/util/math/exp2_lut|inlined.0
+    br $__inlined_func$~lib/util/math/exp2_64_lut
    end
    local.get $4
    f64.reinterpret_i64
@@ -5760,7 +5760,7 @@
   (local $5 i32)
   (local $6 i32)
   (local $7 f64)
-  block $~lib/util/math/exp2f_lut|inlined.0 (result f32)
+  block $__inlined_func$~lib/util/math/exp2_32_lut (result f32)
    local.get $0
    i32.reinterpret_f32
    local.tee $5
@@ -5776,7 +5776,7 @@
     local.get $5
     i32.const -8388608
     i32.eq
-    br_if $~lib/util/math/exp2f_lut|inlined.0
+    br_if $__inlined_func$~lib/util/math/exp2_32_lut
     drop
     local.get $0
     local.get $0
@@ -5784,7 +5784,7 @@
     local.get $6
     i32.const 2040
     i32.ge_u
-    br_if $~lib/util/math/exp2f_lut|inlined.0
+    br_if $__inlined_func$~lib/util/math/exp2_32_lut
     drop
     local.get $0
     f32.const 1701411834604692317316873e14
@@ -5792,13 +5792,13 @@
     local.get $0
     f32.const 0
     f32.gt
-    br_if $~lib/util/math/exp2f_lut|inlined.0
+    br_if $__inlined_func$~lib/util/math/exp2_32_lut
     drop
     f32.const 0
     local.get $0
     f32.const -150
     f32.le
-    br_if $~lib/util/math/exp2f_lut|inlined.0
+    br_if $__inlined_func$~lib/util/math/exp2_32_lut
     drop
    end
    local.get $0
@@ -5882,7 +5882,7 @@
   f64.reinterpret_i64
   local.tee $9
   local.set $0
-  block $__inlined_func$~lib/math/NativeMath.hypot
+  block $__inlined_func$~lib/util/math/hypot64
    local.get $5
    i64.const 52
    i64.shr_u
@@ -5890,7 +5890,7 @@
    local.tee $7
    i32.const 2047
    i32.eq
-   br_if $__inlined_func$~lib/math/NativeMath.hypot
+   br_if $__inlined_func$~lib/util/math/hypot64
    local.get $4
    f64.reinterpret_i64
    local.tee $1
@@ -5905,7 +5905,7 @@
    i32.const 2047
    i32.eq
    i32.or
-   br_if $__inlined_func$~lib/math/NativeMath.hypot
+   br_if $__inlined_func$~lib/util/math/hypot64
    local.get $1
    local.get $9
    f64.add
@@ -5915,7 +5915,7 @@
    i32.sub
    i32.const 64
    i32.gt_s
-   br_if $__inlined_func$~lib/math/NativeMath.hypot
+   br_if $__inlined_func$~lib/util/math/hypot64
    f64.const 1
    local.set $0
    local.get $8
@@ -6026,7 +6026,7 @@
   (local $5 i32)
   (local $6 i32)
   (local $7 f64)
-  block $__inlined_func$~lib/math/NativeMathf.hypot (result f32)
+  block $__inlined_func$~lib/util/math/hypot32 (result f32)
    local.get $1
    i32.reinterpret_f32
    i32.const 2147483647
@@ -6053,7 +6053,7 @@
    local.get $5
    i32.const 2139095040
    i32.eq
-   br_if $__inlined_func$~lib/math/NativeMathf.hypot
+   br_if $__inlined_func$~lib/util/math/hypot32
    drop
    local.get $0
    local.get $1
@@ -6070,7 +6070,7 @@
    i32.const 209715200
    i32.ge_u
    i32.or
-   br_if $__inlined_func$~lib/math/NativeMathf.hypot
+   br_if $__inlined_func$~lib/util/math/hypot32
    drop
    local.get $4
    i32.const 1568669696
@@ -6132,7 +6132,7 @@
   (local $9 f64)
   (local $10 f64)
   (local $11 f64)
-  block $__inlined_func$~lib/math/NativeMath.log10 (result f64)
+  block $__inlined_func$~lib/util/math/log10_64 (result f64)
    local.get $0
    i64.reinterpret_f64
    local.tee $4
@@ -6156,7 +6156,7 @@
     i64.const 1
     i64.shl
     i64.eqz
-    br_if $__inlined_func$~lib/math/NativeMath.log10
+    br_if $__inlined_func$~lib/util/math/log10_64
     drop
     local.get $0
     local.get $0
@@ -6166,7 +6166,7 @@
     local.get $3
     i32.const 31
     i32.shr_u
-    br_if $__inlined_func$~lib/math/NativeMath.log10
+    br_if $__inlined_func$~lib/util/math/log10_64
     drop
     i32.const -54
     local.set $5
@@ -6185,7 +6185,7 @@
     i32.ge_u
     if
      local.get $0
-     br $__inlined_func$~lib/math/NativeMath.log10
+     br $__inlined_func$~lib/util/math/log10_64
     else
      f64.const 0
      local.get $4
@@ -6196,7 +6196,7 @@
      i32.const 1072693248
      i32.eq
      i32.and
-     br_if $__inlined_func$~lib/math/NativeMath.log10
+     br_if $__inlined_func$~lib/util/math/log10_64
      drop
     end
    end
@@ -6342,7 +6342,7 @@
   (local $7 f32)
   (local $8 f32)
   (local $9 f32)
-  block $__inlined_func$~lib/math/NativeMathf.log10 (result f32)
+  block $__inlined_func$~lib/util/math/log10_32 (result f32)
    local.get $0
    i32.reinterpret_f32
    local.tee $3
@@ -6362,7 +6362,7 @@
     i32.const 1
     i32.shl
     i32.eqz
-    br_if $__inlined_func$~lib/math/NativeMathf.log10
+    br_if $__inlined_func$~lib/util/math/log10_32
     drop
     local.get $0
     local.get $0
@@ -6372,7 +6372,7 @@
     local.get $3
     i32.const 31
     i32.shr_u
-    br_if $__inlined_func$~lib/math/NativeMathf.log10
+    br_if $__inlined_func$~lib/util/math/log10_32
     drop
     i32.const -25
     local.set $5
@@ -6387,13 +6387,13 @@
     i32.ge_u
     if
      local.get $0
-     br $__inlined_func$~lib/math/NativeMathf.log10
+     br $__inlined_func$~lib/util/math/log10_32
     else
      f32.const 0
      local.get $3
      i32.const 1065353216
      i32.eq
-     br_if $__inlined_func$~lib/math/NativeMathf.log10
+     br_if $__inlined_func$~lib/util/math/log10_32
      drop
     end
    end
@@ -6491,7 +6491,7 @@
   local.get $2
   call $std/math/check<f32>
  )
- (func $~lib/math/NativeMath.log2 (param $0 f64) (result f64)
+ (func $~lib/util/math/log2_64 (param $0 f64) (result f64)
   (local $1 i64)
   (local $2 i32)
   (local $3 i64)
@@ -6502,7 +6502,7 @@
   (local $8 f64)
   (local $9 f64)
   (local $10 i32)
-  block $~lib/util/math/log2_lut|inlined.0 (result f64)
+  block $~lib/util/math/log2_64_lut|inlined.0 (result f64)
    local.get $0
    i64.reinterpret_f64
    local.tee $1
@@ -6589,7 +6589,7 @@
     f64.mul
     f64.add
     f64.add
-    br $~lib/util/math/log2_lut|inlined.0
+    br $~lib/util/math/log2_64_lut|inlined.0
    end
    local.get $1
    i64.const 48
@@ -6610,13 +6610,13 @@
     i64.const 1
     i64.shl
     i64.eqz
-    br_if $~lib/util/math/log2_lut|inlined.0
+    br_if $~lib/util/math/log2_64_lut|inlined.0
     drop
     local.get $0
     local.get $1
     i64.const 9218868437227405312
     i64.eq
-    br_if $~lib/util/math/log2_lut|inlined.0
+    br_if $~lib/util/math/log2_64_lut|inlined.0
     drop
     i32.const 1
     local.get $2
@@ -6635,7 +6635,7 @@
      local.tee $0
      local.get $0
      f64.div
-     br $~lib/util/math/log2_lut|inlined.0
+     br $~lib/util/math/log2_64_lut|inlined.0
     end
     local.get $0
     f64.const 4503599627370496
@@ -6751,7 +6751,7 @@
   (local $5 i32)
   (local $6 i32)
   (local $7 f64)
-  block $~lib/util/math/log2f_lut|inlined.0 (result f32)
+  block $~lib/util/math/log2_32_lut|inlined.0 (result f32)
    local.get $0
    i32.reinterpret_f32
    local.tee $3
@@ -6765,13 +6765,13 @@
     i32.const 1
     i32.shl
     i32.eqz
-    br_if $~lib/util/math/log2f_lut|inlined.0
+    br_if $~lib/util/math/log2_32_lut|inlined.0
     drop
     local.get $0
     local.get $3
     i32.const 2139095040
     i32.eq
-    br_if $~lib/util/math/log2f_lut|inlined.0
+    br_if $~lib/util/math/log2_32_lut|inlined.0
     drop
     local.get $3
     i32.const 31
@@ -6789,7 +6789,7 @@
      local.tee $0
      local.get $0
      f32.div
-     br $~lib/util/math/log2f_lut|inlined.0
+     br $~lib/util/math/log2_32_lut|inlined.0
     end
     local.get $0
     f32.const 8388608
@@ -6901,7 +6901,7 @@
   (local $7 f64)
   (local $8 i64)
   (local $9 i64)
-  block $__inlined_func$~lib/math/NativeMath.mod (result f64)
+  block $__inlined_func$~lib/util/math/mod64 (result f64)
    local.get $0
    local.get $0
    f64.trunc
@@ -6912,7 +6912,7 @@
    f64.abs
    f64.const 1
    f64.eq
-   br_if $__inlined_func$~lib/math/NativeMath.mod
+   br_if $__inlined_func$~lib/util/math/mod64
    drop
    local.get $1
    i64.reinterpret_f64
@@ -6949,7 +6949,7 @@
     local.tee $7
     local.get $7
     f64.div
-    br $__inlined_func$~lib/math/NativeMath.mod
+    br $__inlined_func$~lib/util/math/mod64
    end
    local.get $6
    i64.const 1
@@ -6964,7 +6964,7 @@
     i64.ne
     f64.convert_i32_u
     f64.mul
-    br $__inlined_func$~lib/math/NativeMath.mod
+    br $__inlined_func$~lib/util/math/mod64
    end
    local.get $9
    i64.eqz
@@ -7025,7 +7025,7 @@
       local.get $3
       local.get $4
       i64.eq
-      br_if $__inlined_func$~lib/math/NativeMath.mod
+      br_if $__inlined_func$~lib/util/math/mod64
       drop
       local.get $3
       local.get $4
@@ -7053,7 +7053,7 @@
     local.get $3
     local.get $4
     i64.eq
-    br_if $__inlined_func$~lib/math/NativeMath.mod
+    br_if $__inlined_func$~lib/util/math/mod64
     drop
     local.get $3
     local.get $4
@@ -7109,7 +7109,7 @@
    i32.const 0
   end
  )
- (func $~lib/math/NativeMathf.mod (param $0 f32) (param $1 f32) (result f32)
+ (func $~lib/util/math/mod32 (param $0 f32) (param $1 f32) (result f32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -7310,7 +7310,7 @@
   i32.or
   f32.reinterpret_i32
  )
- (func $~lib/math/NativeMath.pow (param $0 f64) (param $1 f64) (result f64)
+ (func $~lib/util/math/pow64 (param $0 f64) (param $1 f64) (result f64)
   (local $2 i64)
   (local $3 i32)
   (local $4 i64)
@@ -7380,7 +7380,7 @@
     return
    end
   end
-  block $~lib/util/math/pow_lut|inlined.0 (result f64)
+  block $~lib/util/math/pow64_lut|inlined.0 (result f64)
    local.get $1
    i64.reinterpret_f64
    local.tee $12
@@ -7418,13 +7418,13 @@
      i64.const 1
      i64.shl
      i64.eqz
-     br_if $~lib/util/math/pow_lut|inlined.0
+     br_if $~lib/util/math/pow64_lut|inlined.0
      drop
      f64.const nan:0x8000000000000
      local.get $2
      i64.const 4607182418800017408
      i64.eq
-     br_if $~lib/util/math/pow_lut|inlined.0
+     br_if $~lib/util/math/pow64_lut|inlined.0
      drop
      local.get $0
      local.get $1
@@ -7440,7 +7440,7 @@
      i64.const -9007199254740992
      i64.gt_u
      i32.or
-     br_if $~lib/util/math/pow_lut|inlined.0
+     br_if $~lib/util/math/pow64_lut|inlined.0
      drop
      f64.const nan:0x8000000000000
      local.get $2
@@ -7448,7 +7448,7 @@
      i64.shl
      i64.const 9214364837600034816
      i64.eq
-     br_if $~lib/util/math/pow_lut|inlined.0
+     br_if $~lib/util/math/pow64_lut|inlined.0
      drop
      f64.const 0
      local.get $12
@@ -7461,12 +7461,12 @@
      i64.const 9214364837600034816
      i64.lt_u
      i32.eq
-     br_if $~lib/util/math/pow_lut|inlined.0
+     br_if $~lib/util/math/pow64_lut|inlined.0
      drop
      local.get $1
      local.get $1
      f64.mul
-     br $~lib/util/math/pow_lut|inlined.0
+     br $~lib/util/math/pow64_lut|inlined.0
     end
     local.get $2
     i64.const 1
@@ -7488,7 +7488,7 @@
      i64.shr_u
      i32.wrap_i64
      if (result i32)
-      block $~lib/util/math/checkint|inlined.0 (result i32)
+      block $~lib/util/math/checkint64|inlined.0 (result i32)
        i32.const 0
        local.get $12
        i64.const 52
@@ -7498,13 +7498,13 @@
        local.tee $2
        i64.const 1023
        i64.lt_u
-       br_if $~lib/util/math/checkint|inlined.0
+       br_if $~lib/util/math/checkint64|inlined.0
        drop
        i32.const 2
        local.get $2
        i64.const 1075
        i64.gt_u
-       br_if $~lib/util/math/checkint|inlined.0
+       br_if $~lib/util/math/checkint64|inlined.0
        drop
        i32.const 0
        local.get $12
@@ -7519,7 +7519,7 @@
        i64.and
        i64.const 0
        i64.ne
-       br_if $~lib/util/math/checkint|inlined.0
+       br_if $~lib/util/math/checkint64|inlined.0
        drop
        i32.const 1
        local.get $2
@@ -7527,7 +7527,7 @@
        i64.and
        i64.const 0
        i64.ne
-       br_if $~lib/util/math/checkint|inlined.0
+       br_if $~lib/util/math/checkint64|inlined.0
        drop
        i32.const 2
       end
@@ -7545,14 +7545,14 @@
      i64.shr_u
      i32.wrap_i64
      select
-     br $~lib/util/math/pow_lut|inlined.0
+     br $~lib/util/math/pow64_lut|inlined.0
     end
     local.get $2
     i64.const 63
     i64.shr_u
     i32.wrap_i64
     if
-     block $~lib/util/math/checkint|inlined.1 (result i32)
+     block $~lib/util/math/checkint64|inlined.1 (result i32)
       i32.const 0
       local.get $12
       i64.const 52
@@ -7562,13 +7562,13 @@
       local.tee $13
       i64.const 1023
       i64.lt_u
-      br_if $~lib/util/math/checkint|inlined.1
+      br_if $~lib/util/math/checkint64|inlined.1
       drop
       i32.const 2
       local.get $13
       i64.const 1075
       i64.gt_u
-      br_if $~lib/util/math/checkint|inlined.1
+      br_if $~lib/util/math/checkint64|inlined.1
       drop
       i32.const 0
       local.get $12
@@ -7583,7 +7583,7 @@
       i64.and
       i64.const 0
       i64.ne
-      br_if $~lib/util/math/checkint|inlined.1
+      br_if $~lib/util/math/checkint64|inlined.1
       drop
       i32.const 1
       local.get $12
@@ -7591,7 +7591,7 @@
       i64.and
       i64.const 0
       i64.ne
-      br_if $~lib/util/math/checkint|inlined.1
+      br_if $~lib/util/math/checkint64|inlined.1
       drop
       i32.const 2
      end
@@ -7604,7 +7604,7 @@
       local.tee $0
       local.get $0
       f64.div
-      br $~lib/util/math/pow_lut|inlined.0
+      br $~lib/util/math/pow64_lut|inlined.0
      end
      local.get $4
      i64.const 2047
@@ -7634,7 +7634,7 @@
      local.get $2
      i64.const 4607182418800017408
      i64.eq
-     br_if $~lib/util/math/pow_lut|inlined.0
+     br_if $~lib/util/math/pow64_lut|inlined.0
      drop
      f64.const 1
      local.get $6
@@ -7642,7 +7642,7 @@
      i64.and
      i64.const 958
      i64.lt_u
-     br_if $~lib/util/math/pow_lut|inlined.0
+     br_if $~lib/util/math/pow64_lut|inlined.0
      drop
      f64.const inf
      f64.const 0
@@ -7654,7 +7654,7 @@
      i64.gt_u
      i32.eq
      select
-     br $~lib/util/math/pow_lut|inlined.0
+     br $~lib/util/math/pow64_lut|inlined.0
     end
     local.get $0
     f64.const 4503599627370496
@@ -7800,7 +7800,7 @@
    local.get $0
    f64.add
    global.set $~lib/util/math/log_tail
-   block $~lib/util/math/exp_inline|inlined.0 (result f64)
+   block $~lib/util/math/exp64_inline|inlined.0 (result f64)
     local.get $12
     i64.const -134217728
     i64.and
@@ -7836,7 +7836,7 @@
      i32.sub
      i32.const -2147483648
      i32.ge_u
-     br_if $~lib/util/math/exp_inline|inlined.0
+     br_if $~lib/util/math/exp64_inline|inlined.0
      drop
      local.get $2
      i64.const 63
@@ -7860,7 +7860,7 @@
      local.get $3
      i32.const 1033
      i32.ge_u
-     br_if $~lib/util/math/exp_inline|inlined.0
+     br_if $~lib/util/math/exp64_inline|inlined.0
      drop
      i32.const 0
      local.set $3
@@ -8022,7 +8022,7 @@
       f64.const 2.2250738585072014e-308
       f64.mul
      end
-     br $~lib/util/math/exp_inline|inlined.0
+     br $~lib/util/math/exp64_inline|inlined.0
     end
     local.get $4
     f64.reinterpret_i64
@@ -8037,7 +8037,7 @@
  (func $std/math/test_pow (param $0 f64) (param $1 f64) (param $2 f64) (param $3 f64) (result i32)
   local.get $0
   local.get $1
-  call $~lib/math/NativeMath.pow
+  call $~lib/util/math/pow64
   local.get $2
   local.get $3
   call $std/math/check<f64>
@@ -8052,7 +8052,7 @@
    i32.const 0
   end
  )
- (func $~lib/math/NativeMathf.pow (param $0 f32) (param $1 f32) (result f32)
+ (func $~lib/util/math/pow32 (param $0 f32) (param $1 f32) (result f32)
   (local $2 i32)
   (local $3 f64)
   (local $4 i32)
@@ -8112,7 +8112,7 @@
     return
    end
   end
-  block $~lib/util/math/powf_lut|inlined.0 (result f32)
+  block $~lib/util/math/pow32_lut|inlined.0 (result f32)
    local.get $1
    i32.reinterpret_f32
    local.tee $7
@@ -8139,13 +8139,13 @@
      i32.const 1
      i32.shl
      i32.eqz
-     br_if $~lib/util/math/powf_lut|inlined.0
+     br_if $~lib/util/math/pow32_lut|inlined.0
      drop
      f32.const nan:0x400000
      local.get $2
      i32.const 1065353216
      i32.eq
-     br_if $~lib/util/math/powf_lut|inlined.0
+     br_if $~lib/util/math/pow32_lut|inlined.0
      drop
      local.get $0
      local.get $1
@@ -8161,7 +8161,7 @@
      i32.const -16777216
      i32.gt_u
      i32.or
-     br_if $~lib/util/math/powf_lut|inlined.0
+     br_if $~lib/util/math/pow32_lut|inlined.0
      drop
      f32.const nan:0x400000
      local.get $2
@@ -8169,7 +8169,7 @@
      i32.shl
      i32.const 2130706432
      i32.eq
-     br_if $~lib/util/math/powf_lut|inlined.0
+     br_if $~lib/util/math/pow32_lut|inlined.0
      drop
      f32.const 0
      local.get $7
@@ -8182,12 +8182,12 @@
      i32.const 2130706432
      i32.lt_u
      i32.eq
-     br_if $~lib/util/math/powf_lut|inlined.0
+     br_if $~lib/util/math/pow32_lut|inlined.0
      drop
      local.get $1
      local.get $1
      f32.mul
-     br $~lib/util/math/powf_lut|inlined.0
+     br $~lib/util/math/pow32_lut|inlined.0
     end
     local.get $2
     i32.const 1
@@ -8208,7 +8208,7 @@
      i32.const 31
      i32.shr_u
      if (result i32)
-      block $~lib/util/math/checkintf|inlined.0 (result i32)
+      block $~lib/util/math/checkint32|inlined.0 (result i32)
        i32.const 0
        local.get $7
        i32.const 23
@@ -8218,13 +8218,13 @@
        local.tee $2
        i32.const 127
        i32.lt_u
-       br_if $~lib/util/math/checkintf|inlined.0
+       br_if $~lib/util/math/checkint32|inlined.0
        drop
        i32.const 2
        local.get $2
        i32.const 150
        i32.gt_u
-       br_if $~lib/util/math/checkintf|inlined.0
+       br_if $~lib/util/math/checkint32|inlined.0
        drop
        i32.const 0
        local.get $7
@@ -8237,13 +8237,13 @@
        i32.const 1
        i32.sub
        i32.and
-       br_if $~lib/util/math/checkintf|inlined.0
+       br_if $~lib/util/math/checkint32|inlined.0
        drop
        i32.const 1
        local.get $2
        local.get $7
        i32.and
-       br_if $~lib/util/math/checkintf|inlined.0
+       br_if $~lib/util/math/checkint32|inlined.0
        drop
        i32.const 2
       end
@@ -8260,13 +8260,13 @@
      i32.const 31
      i32.shr_u
      select
-     br $~lib/util/math/powf_lut|inlined.0
+     br $~lib/util/math/pow32_lut|inlined.0
     end
     local.get $2
     i32.const 31
     i32.shr_u
     if
-     block $~lib/util/math/checkintf|inlined.1 (result i32)
+     block $~lib/util/math/checkint32|inlined.1 (result i32)
       i32.const 0
       local.get $7
       i32.const 23
@@ -8276,13 +8276,13 @@
       local.tee $4
       i32.const 127
       i32.lt_u
-      br_if $~lib/util/math/checkintf|inlined.1
+      br_if $~lib/util/math/checkint32|inlined.1
       drop
       i32.const 2
       local.get $4
       i32.const 150
       i32.gt_u
-      br_if $~lib/util/math/checkintf|inlined.1
+      br_if $~lib/util/math/checkint32|inlined.1
       drop
       i32.const 0
       local.get $7
@@ -8295,13 +8295,13 @@
       i32.const 1
       i32.sub
       i32.and
-      br_if $~lib/util/math/checkintf|inlined.1
+      br_if $~lib/util/math/checkint32|inlined.1
       drop
       i32.const 1
       local.get $4
       local.get $7
       i32.and
-      br_if $~lib/util/math/checkintf|inlined.1
+      br_if $~lib/util/math/checkint32|inlined.1
       drop
       i32.const 2
      end
@@ -8314,7 +8314,7 @@
       local.tee $0
       local.get $0
       f32.div
-      br $~lib/util/math/powf_lut|inlined.0
+      br $~lib/util/math/pow32_lut|inlined.0
      end
      i32.const 65536
      i32.const 0
@@ -8422,7 +8422,7 @@
     local.get $3
     f64.const 127.99999995700433
     f64.gt
-    br_if $~lib/util/math/powf_lut|inlined.0
+    br_if $~lib/util/math/pow32_lut|inlined.0
     drop
     f32.const -2.524354896707238e-29
     f32.const 2.524354896707238e-29
@@ -8433,7 +8433,7 @@
     local.get $3
     f64.const -150
     f64.le
-    br_if $~lib/util/math/powf_lut|inlined.0
+    br_if $~lib/util/math/pow32_lut|inlined.0
     drop
    end
    local.get $3
@@ -8482,123 +8482,6 @@
    f64.mul
    f32.demote_f64
   end
- )
- (func $~lib/math/NativeMath.seedRandom (param $0 i64)
-  (local $1 i32)
-  (local $2 i64)
-  i64.const -7046029254386353131
-  local.get $0
-  local.get $0
-  i64.eqz
-  select
-  local.tee $0
-  i64.const 33
-  i64.shr_u
-  local.get $0
-  i64.xor
-  i64.const -49064778989728563
-  i64.mul
-  local.tee $2
-  i64.const 33
-  i64.shr_u
-  local.get $2
-  i64.xor
-  i64.const -4265267296055464877
-  i64.mul
-  local.tee $2
-  i64.const 33
-  i64.shr_u
-  local.get $2
-  i64.xor
-  global.set $~lib/math/random_state0_64
-  global.get $~lib/math/random_state0_64
-  i64.const -1
-  i64.xor
-  local.tee $2
-  i64.const 33
-  i64.shr_u
-  local.get $2
-  i64.xor
-  i64.const -49064778989728563
-  i64.mul
-  local.tee $2
-  i64.const 33
-  i64.shr_u
-  local.get $2
-  i64.xor
-  i64.const -4265267296055464877
-  i64.mul
-  local.tee $2
-  i64.const 33
-  i64.shr_u
-  local.get $2
-  i64.xor
-  global.set $~lib/math/random_state1_64
-  local.get $0
-  i32.wrap_i64
-  i32.const 1831565813
-  i32.add
-  local.tee $1
-  i32.const 1
-  i32.or
-  local.get $1
-  local.get $1
-  i32.const 15
-  i32.shr_u
-  i32.xor
-  i32.mul
-  local.tee $1
-  i32.const 61
-  i32.or
-  local.get $1
-  local.get $1
-  i32.const 7
-  i32.shr_u
-  i32.xor
-  i32.mul
-  local.get $1
-  i32.add
-  local.get $1
-  i32.xor
-  local.tee $1
-  i32.const 14
-  i32.shr_u
-  local.get $1
-  i32.xor
-  global.set $~lib/math/random_state0_32
-  global.get $~lib/math/random_state0_32
-  i32.const 1831565813
-  i32.add
-  local.tee $1
-  i32.const 1
-  i32.or
-  local.get $1
-  local.get $1
-  i32.const 15
-  i32.shr_u
-  i32.xor
-  i32.mul
-  local.tee $1
-  i32.const 61
-  i32.or
-  local.get $1
-  local.get $1
-  i32.const 7
-  i32.shr_u
-  i32.xor
-  i32.mul
-  local.get $1
-  i32.add
-  local.get $1
-  i32.xor
-  local.tee $1
-  i32.const 14
-  i32.shr_u
-  local.get $1
-  i32.xor
-  global.set $~lib/math/random_state1_32
-  i32.const 1
-  global.set $~lib/math/random_seeded
  )
  (func $std/math/test_round (param $0 f64) (param $1 f64) (result i32)
   (local $2 f64)
@@ -8677,482 +8560,7 @@
   f32.const 0
   call $std/math/check<f32>
  )
- (func $~lib/math/NativeMath.rem (param $0 f64) (param $1 f64) (result f64)
-  (local $2 i64)
-  (local $3 i64)
-  (local $4 i64)
-  (local $5 i32)
-  (local $6 i32)
-  (local $7 i64)
-  (local $8 f64)
-  local.get $1
-  i64.reinterpret_f64
-  local.tee $7
-  i64.const 52
-  i64.shr_u
-  i64.const 2047
-  i64.and
-  local.set $4
-  local.get $7
-  i64.const 1
-  i64.shl
-  i64.eqz
-  local.get $0
-  i64.reinterpret_f64
-  local.tee $2
-  i64.const 52
-  i64.shr_u
-  i64.const 2047
-  i64.and
-  local.tee $3
-  i64.const 2047
-  i64.eq
-  i32.or
-  local.get $1
-  local.get $1
-  f64.ne
-  i32.or
-  if
-   local.get $0
-   local.get $1
-   f64.mul
-   local.tee $0
-   local.get $0
-   f64.div
-   return
-  end
-  local.get $2
-  i64.const 1
-  i64.shl
-  i64.eqz
-  if
-   local.get $0
-   return
-  end
-  local.get $2
-  i64.const 63
-  i64.shr_u
-  i32.wrap_i64
-  local.set $6
-  local.get $3
-  i64.eqz
-  if (result i64)
-   local.get $2
-   i64.const 1
-   local.get $3
-   local.get $2
-   i64.const 12
-   i64.shl
-   i64.clz
-   i64.sub
-   local.tee $3
-   i64.sub
-   i64.shl
-  else
-   local.get $2
-   i64.const 4503599627370495
-   i64.and
-   i64.const 4503599627370496
-   i64.or
-  end
-  local.set $2
-  local.get $4
-  i64.eqz
-  if (result i64)
-   local.get $7
-   i64.const 1
-   local.get $4
-   local.get $7
-   i64.const 12
-   i64.shl
-   i64.clz
-   i64.sub
-   local.tee $4
-   i64.sub
-   i64.shl
-  else
-   local.get $7
-   i64.const 4503599627370495
-   i64.and
-   i64.const 4503599627370496
-   i64.or
-  end
-  local.set $7
-  block $do-break|0
-   local.get $3
-   local.get $4
-   i64.lt_s
-   if
-    local.get $3
-    i64.const 1
-    i64.add
-    local.get $4
-    i64.eq
-    br_if $do-break|0
-    local.get $0
-    return
-   end
-   loop $while-continue|1
-    local.get $3
-    local.get $4
-    i64.gt_s
-    if
-     local.get $2
-     local.get $7
-     i64.ge_u
-     if (result i64)
-      local.get $5
-      i32.const 1
-      i32.add
-      local.set $5
-      local.get $2
-      local.get $7
-      i64.sub
-     else
-      local.get $2
-     end
-     i64.const 1
-     i64.shl
-     local.set $2
-     local.get $5
-     i32.const 1
-     i32.shl
-     local.set $5
-     local.get $3
-     i64.const 1
-     i64.sub
-     local.set $3
-     br $while-continue|1
-    end
-   end
-   local.get $2
-   local.get $7
-   i64.ge_u
-   if
-    local.get $5
-    i32.const 1
-    i32.add
-    local.set $5
-    local.get $2
-    local.get $7
-    i64.sub
-    local.set $2
-   end
-   local.get $2
-   i64.eqz
-   if
-    i64.const -60
-    local.set $3
-   else
-    local.get $3
-    local.get $2
-    i64.const 11
-    i64.shl
-    i64.clz
-    local.tee $7
-    i64.sub
-    local.set $3
-    local.get $2
-    local.get $7
-    i64.shl
-    local.set $2
-   end
-  end
-  local.get $2
-  i64.const 4503599627370496
-  i64.sub
-  local.get $3
-  i64.const 52
-  i64.shl
-  i64.or
-  local.get $2
-  i64.const 1
-  local.get $3
-  i64.sub
-  i64.shr_u
-  local.get $3
-  i64.const 0
-  i64.gt_s
-  select
-  f64.reinterpret_i64
-  local.tee $0
-  local.get $0
-  f64.add
-  local.set $8
-  local.get $0
-  local.get $1
-  f64.abs
-  local.tee $1
-  f64.sub
-  local.get $0
-  local.get $3
-  local.get $4
-  i64.eq
-  if (result i32)
-   i32.const 1
-  else
-   local.get $5
-   i32.const 1
-   i32.and
-   local.get $1
-   local.get $8
-   f64.eq
-   i32.and
-   local.get $1
-   local.get $8
-   f64.lt
-   i32.or
-   local.get $3
-   i64.const 1
-   i64.add
-   local.get $4
-   i64.eq
-   i32.and
-  end
-  select
-  local.tee $0
-  f64.neg
-  local.get $0
-  local.get $6
-  select
- )
- (func $~lib/math/NativeMathf.rem (param $0 f32) (param $1 f32) (result f32)
-  (local $2 i32)
-  (local $3 i32)
-  (local $4 i32)
-  (local $5 i32)
-  (local $6 i32)
-  (local $7 i32)
-  (local $8 f32)
-  local.get $1
-  i32.reinterpret_f32
-  local.tee $7
-  i32.const 23
-  i32.shr_u
-  i32.const 255
-  i32.and
-  local.set $4
-  i32.const 1
-  local.get $1
-  local.get $1
-  f32.ne
-  local.get $0
-  i32.reinterpret_f32
-  local.tee $2
-  i32.const 23
-  i32.shr_u
-  i32.const 255
-  i32.and
-  local.tee $3
-  i32.const 255
-  i32.eq
-  i32.const 1
-  local.get $7
-  i32.const 1
-  i32.shl
-  select
-  select
-  if
-   local.get $0
-   local.get $1
-   f32.mul
-   local.tee $0
-   local.get $0
-   f32.div
-   return
-  end
-  local.get $2
-  i32.const 1
-  i32.shl
-  i32.eqz
-  if
-   local.get $0
-   return
-  end
-  local.get $2
-  i32.const 31
-  i32.shr_u
-  local.set $6
-  local.get $3
-  if (result i32)
-   local.get $2
-   i32.const 8388607
-   i32.and
-   i32.const 8388608
-   i32.or
-  else
-   local.get $2
-   i32.const 1
-   local.get $3
-   local.get $2
-   i32.const 9
-   i32.shl
-   i32.clz
-   i32.sub
-   local.tee $3
-   i32.sub
-   i32.shl
-  end
-  local.set $2
-  local.get $4
-  if (result i32)
-   local.get $7
-   i32.const 8388607
-   i32.and
-   i32.const 8388608
-   i32.or
-  else
-   local.get $7
-   i32.const 1
-   local.get $4
-   local.get $7
-   i32.const 9
-   i32.shl
-   i32.clz
-   i32.sub
-   local.tee $4
-   i32.sub
-   i32.shl
-  end
-  local.set $7
-  block $do-break|0
-   local.get $3
-   local.get $4
-   i32.lt_s
-   if
-    local.get $3
-    i32.const 1
-    i32.add
-    local.get $4
-    i32.eq
-    br_if $do-break|0
-    local.get $0
-    return
-   end
-   loop $while-continue|1
-    local.get $3
-    local.get $4
-    i32.gt_s
-    if
-     local.get $2
-     local.get $7
-     i32.ge_u
-     if (result i32)
-      local.get $5
-      i32.const 1
-      i32.add
-      local.set $5
-      local.get $2
-      local.get $7
-      i32.sub
-     else
-      local.get $2
-     end
-     i32.const 1
-     i32.shl
-     local.set $2
-     local.get $5
-     i32.const 1
-     i32.shl
-     local.set $5
-     local.get $3
-     i32.const 1
-     i32.sub
-     local.set $3
-     br $while-continue|1
-    end
-   end
-   local.get $2
-   local.get $7
-   i32.ge_u
-   if
-    local.get $5
-    i32.const 1
-    i32.add
-    local.set $5
-    local.get $2
-    local.get $7
-    i32.sub
-    local.set $2
-   end
-   local.get $2
-   if
-    local.get $3
-    local.get $2
-    i32.const 8
-    i32.shl
-    i32.clz
-    local.tee $7
-    i32.sub
-    local.set $3
-    local.get $2
-    local.get $7
-    i32.shl
-    local.set $2
-   else
-    i32.const -30
-    local.set $3
-   end
-  end
-  local.get $2
-  i32.const 8388608
-  i32.sub
-  local.get $3
-  i32.const 23
-  i32.shl
-  i32.or
-  local.get $2
-  i32.const 1
-  local.get $3
-  i32.sub
-  i32.shr_u
-  local.get $3
-  i32.const 0
-  i32.gt_s
-  select
-  f32.reinterpret_i32
-  local.tee $0
-  local.get $0
-  f32.add
-  local.set $8
-  local.get $0
-  local.get $1
-  f32.abs
-  local.tee $1
-  f32.sub
-  local.get $0
-  local.get $3
-  local.get $4
-  i32.eq
-  if (result i32)
-   i32.const 1
-  else
-   local.get $5
-   i32.const 1
-   i32.and
-   local.get $1
-   local.get $8
-   f32.eq
-   i32.and
-   local.get $1
-   local.get $8
-   f32.lt
-   i32.or
-   local.get $3
-   i32.const 1
-   i32.add
-   local.get $4
-   i32.eq
-   i32.and
-  end
-  select
-  local.tee $0
-  f32.neg
-  local.get $0
-  local.get $6
-  select
- )
- (func $~lib/math/NativeMath.sin (param $0 f64) (result f64)
+ (func $~lib/util/math/sin64 (param $0 f64) (result f64)
   (local $1 f64)
   (local $2 f64)
   (local $3 i32)
@@ -9231,7 +8639,7 @@
    f64.sub
    return
   end
-  block $~lib/math/rempio2|inlined.1 (result i32)
+  block $~lib/util/math/rempio2_64|inlined.1 (result i32)
    local.get $5
    i64.const 32
    i64.shr_u
@@ -9311,10 +8719,10 @@
      end
     end
     local.get $0
-    global.set $~lib/math/rempio2_y0
-    global.set $~lib/math/rempio2_y1
+    global.set $~lib/util/math/rempio2_y0
+    global.set $~lib/util/math/rempio2_y1
     local.get $3
-    br $~lib/math/rempio2|inlined.1
+    br $~lib/util/math/rempio2_64|inlined.1
    end
    local.get $4
    i32.const 1094263291
@@ -9408,20 +8816,20 @@
      end
     end
     local.get $1
-    global.set $~lib/math/rempio2_y0
+    global.set $~lib/util/math/rempio2_y0
     local.get $0
     local.get $1
     f64.sub
     local.get $2
     f64.sub
-    global.set $~lib/math/rempio2_y1
+    global.set $~lib/util/math/rempio2_y1
     local.get $7
     i32.trunc_sat_f64_s
-    br $~lib/math/rempio2|inlined.1
+    br $~lib/util/math/rempio2_64|inlined.1
    end
    i32.const 0
    local.get $5
-   call $~lib/math/pio2_large_quot
+   call $~lib/util/math/pio2_64_large_quot
    local.tee $3
    i32.sub
    local.get $3
@@ -9429,9 +8837,9 @@
    select
   end
   local.set $3
-  global.get $~lib/math/rempio2_y0
+  global.get $~lib/util/math/rempio2_y0
   local.set $2
-  global.get $~lib/math/rempio2_y1
+  global.get $~lib/util/math/rempio2_y1
   local.set $7
   local.get $3
   i32.const 1
@@ -9543,7 +8951,7 @@
   i32.and
   select
  )
- (func $~lib/math/NativeMathf.sin (param $0 f32) (result f32)
+ (func $~lib/util/math/sin32 (param $0 f32) (result f32)
   (local $1 f64)
   (local $2 f64)
   (local $3 i32)
@@ -9787,7 +9195,7 @@
     f32.sub
     return
    end
-   block $~lib/math/rempio2f|inlined.1 (result i32)
+   block $~lib/util/math/rempio2_32|inlined.1 (result i32)
     local.get $3
     i32.const 1305022427
     i32.lt_u
@@ -9808,10 +9216,10 @@
      f64.const 1.5893254773528196e-08
      f64.mul
      f64.sub
-     global.set $~lib/math/rempio2f_y
+     global.set $~lib/util/math/rempio2_32_y
      local.get $2
      i32.trunc_sat_f64_s
-     br $~lib/math/rempio2f|inlined.1
+     br $~lib/util/math/rempio2_32|inlined.1
     end
     local.get $3
     i32.const 23
@@ -9889,7 +9297,7 @@
     local.tee $8
     f64.convert_i64_s
     f64.mul
-    global.set $~lib/math/rempio2f_y
+    global.set $~lib/util/math/rempio2_32_y
     i32.const 0
     local.get $5
     i64.const 62
@@ -9906,7 +9314,7 @@
     select
    end
    local.set $3
-   global.get $~lib/math/rempio2f_y
+   global.get $~lib/util/math/rempio2_32_y
    local.set $1
    local.get $3
    i32.const 1
@@ -10006,7 +9414,7 @@
   (local $4 i32)
   (local $5 i64)
   (local $6 f64)
-  block $__inlined_func$~lib/math/NativeMath.sinh (result f64)
+  block $__inlined_func$~lib/util/math/sinh64 (result f64)
    local.get $0
    i64.reinterpret_f64
    i64.const 9223372036854775807
@@ -10027,7 +9435,7 @@
    i32.lt_u
    if
     local.get $6
-    call $~lib/math/NativeMath.expm1
+    call $~lib/util/math/expm1_64
     local.set $6
     local.get $4
     i32.const 1072693248
@@ -10037,7 +9445,7 @@
      local.get $4
      i32.const 1045430272
      i32.lt_u
-     br_if $__inlined_func$~lib/math/NativeMath.sinh
+     br_if $__inlined_func$~lib/util/math/sinh64
      drop
      local.get $3
      local.get $6
@@ -10052,7 +9460,7 @@
      f64.div
      f64.sub
      f64.mul
-     br $__inlined_func$~lib/math/NativeMath.sinh
+     br $__inlined_func$~lib/util/math/sinh64
     end
     local.get $3
     local.get $6
@@ -10063,12 +9471,12 @@
     f64.div
     f64.add
     f64.mul
-    br $__inlined_func$~lib/math/NativeMath.sinh
+    br $__inlined_func$~lib/util/math/sinh64
    end
    local.get $6
    f64.const 1416.0996898839683
    f64.sub
-   call $~lib/math/NativeMath.exp
+   call $~lib/util/math/exp64
    local.get $3
    local.get $3
    f64.add
@@ -10106,13 +9514,13 @@
   local.get $0
   f32.copysign
   local.set $3
-  block $__inlined_func$~lib/math/NativeMathf.sinh
+  block $__inlined_func$~lib/util/math/sinh32
    local.get $4
    i32.const 1118925335
    i32.lt_u
    if
     local.get $5
-    call $~lib/math/NativeMathf.expm1
+    call $~lib/util/math/expm1_32
     local.set $5
     local.get $4
     i32.const 1065353216
@@ -10121,7 +9529,7 @@
      local.get $4
      i32.const 964689920
      i32.lt_u
-     br_if $__inlined_func$~lib/math/NativeMathf.sinh
+     br_if $__inlined_func$~lib/util/math/sinh32
      local.get $3
      local.get $5
      local.get $5
@@ -10136,7 +9544,7 @@
      f32.sub
      f32.mul
      local.set $0
-     br $__inlined_func$~lib/math/NativeMathf.sinh
+     br $__inlined_func$~lib/util/math/sinh32
     end
     local.get $3
     local.get $5
@@ -10148,12 +9556,12 @@
     f32.add
     f32.mul
     local.set $0
-    br $__inlined_func$~lib/math/NativeMathf.sinh
+    br $__inlined_func$~lib/util/math/sinh32
    end
    local.get $5
    f32.const 162.88958740234375
    f32.sub
-   call $~lib/math/NativeMathf.exp
+   call $~lib/util/math/exp32
    local.get $3
    local.get $3
    f32.add
@@ -10169,7 +9577,7 @@
   local.get $2
   call $std/math/check<f32>
  )
- (func $~lib/math/tan_kern (param $0 f64) (param $1 f64) (param $2 i32) (result f64)
+ (func $~lib/util/math/tan64_kern (param $0 f64) (param $1 f64) (param $2 i32) (result f64)
   (local $3 i32)
   (local $4 i32)
   (local $5 f64)
@@ -10348,7 +9756,7 @@
   f64.mul
   f64.add
  )
- (func $~lib/math/NativeMath.tan (param $0 f64) (result f64)
+ (func $~lib/util/math/tan64 (param $0 f64) (result f64)
   (local $1 f64)
   (local $2 i32)
   (local $3 i64)
@@ -10383,7 +9791,7 @@
    local.get $0
    f64.const 0
    i32.const 1
-   call $~lib/math/tan_kern
+   call $~lib/util/math/tan64_kern
    return
   end
   local.get $2
@@ -10395,7 +9803,7 @@
    f64.sub
    return
   end
-  block $~lib/math/rempio2|inlined.2
+  block $~lib/util/math/rempio2_64|inlined.2
    local.get $3
    i64.const 32
    i64.shr_u
@@ -10475,9 +9883,9 @@
      end
     end
     local.get $0
-    global.set $~lib/math/rempio2_y0
-    global.set $~lib/math/rempio2_y1
-    br $~lib/math/rempio2|inlined.2
+    global.set $~lib/util/math/rempio2_y0
+    global.set $~lib/util/math/rempio2_y1
+    br $~lib/util/math/rempio2_64|inlined.2
    end
    local.get $7
    i32.const 1094263291
@@ -10571,21 +9979,21 @@
      end
     end
     local.get $1
-    global.set $~lib/math/rempio2_y0
+    global.set $~lib/util/math/rempio2_y0
     local.get $0
     local.get $1
     f64.sub
     local.get $5
     f64.sub
-    global.set $~lib/math/rempio2_y1
+    global.set $~lib/util/math/rempio2_y1
     local.get $4
     i32.trunc_sat_f64_s
     local.set $2
-    br $~lib/math/rempio2|inlined.2
+    br $~lib/util/math/rempio2_64|inlined.2
    end
    i32.const 0
    local.get $3
-   call $~lib/math/pio2_large_quot
+   call $~lib/util/math/pio2_64_large_quot
    local.tee $2
    i32.sub
    local.get $2
@@ -10593,8 +10001,8 @@
    select
    local.set $2
   end
-  global.get $~lib/math/rempio2_y0
-  global.get $~lib/math/rempio2_y1
+  global.get $~lib/util/math/rempio2_y0
+  global.get $~lib/util/math/rempio2_y1
   i32.const 1
   local.get $2
   i32.const 1
@@ -10602,9 +10010,9 @@
   i32.const 1
   i32.shl
   i32.sub
-  call $~lib/math/tan_kern
+  call $~lib/util/math/tan64_kern
  )
- (func $~lib/math/NativeMathf.tan (param $0 f32) (result f32)
+ (func $~lib/util/math/tan32 (param $0 f32) (result f32)
   (local $1 f64)
   (local $2 f64)
   (local $3 f64)
@@ -10752,7 +10160,7 @@
      f32.sub
      return
     end
-    block $~lib/math/rempio2f|inlined.2 (result i32)
+    block $~lib/util/math/rempio2_32|inlined.2 (result i32)
      local.get $4
      i32.const 1305022427
      i32.lt_u
@@ -10773,10 +10181,10 @@
       f64.const 1.5893254773528196e-08
       f64.mul
       f64.sub
-      global.set $~lib/math/rempio2f_y
+      global.set $~lib/util/math/rempio2_32_y
       local.get $2
       i32.trunc_sat_f64_s
-      br $~lib/math/rempio2f|inlined.2
+      br $~lib/util/math/rempio2_32|inlined.2
      end
      local.get $4
      i32.const 23
@@ -10854,7 +10262,7 @@
      local.tee $8
      f64.convert_i64_s
      f64.mul
-     global.set $~lib/math/rempio2f_y
+     global.set $~lib/util/math/rempio2_32_y
      i32.const 0
      local.get $5
      i64.const 62
@@ -10871,7 +10279,7 @@
      select
     end
     local.set $4
-    global.get $~lib/math/rempio2f_y
+    global.get $~lib/util/math/rempio2_32_y
     local.tee $1
     local.get $1
     f64.mul
@@ -11021,7 +10429,7 @@
     local.get $5
     local.get $5
     f64.add
-    call $~lib/math/NativeMath.expm1
+    call $~lib/util/math/expm1_64
     f64.const 2
     f64.add
     f64.div
@@ -11035,7 +10443,7 @@
     local.get $5
     local.get $5
     f64.add
-    call $~lib/math/NativeMath.expm1
+    call $~lib/util/math/expm1_64
     local.tee $5
     local.get $5
     f64.const 2
@@ -11049,7 +10457,7 @@
      local.get $5
      f64.const -2
      f64.mul
-     call $~lib/math/NativeMath.expm1
+     call $~lib/util/math/expm1_64
      local.tee $5
      f64.neg
      local.get $5
@@ -11105,7 +10513,7 @@
     local.get $4
     local.get $4
     f32.add
-    call $~lib/math/NativeMathf.expm1
+    call $~lib/util/math/expm1_32
     f32.const 2
     f32.add
     f32.div
@@ -11119,7 +10527,7 @@
     local.get $4
     local.get $4
     f32.add
-    call $~lib/math/NativeMathf.expm1
+    call $~lib/util/math/expm1_32
     local.tee $4
     local.get $4
     f32.const 2
@@ -11133,7 +10541,7 @@
      local.get $4
      f32.const -2
      f32.mul
-     call $~lib/math/NativeMathf.expm1
+     call $~lib/util/math/expm1_32
      local.tee $4
      f32.neg
      local.get $4
@@ -11151,7 +10559,7 @@
   local.get $2
   call $std/math/check<f32>
  )
- (func $~lib/math/NativeMath.sincos (param $0 f64)
+ (func $~lib/util/math/sincos64 (param $0 f64) (result f64)
   (local $1 f64)
   (local $2 f64)
   (local $3 i32)
@@ -11183,48 +10591,18 @@
    i32.const 1044816030
    i32.lt_u
    if
-    local.get $0
-    global.set $~lib/math/NativeMath.sincos_sin
     f64.const 1
-    global.set $~lib/math/NativeMath.sincos_cos
+    global.set $~lib/util/math/sincos_cos64
+    local.get $0
     return
    end
    local.get $0
    local.get $0
-   local.get $0
    f64.mul
    local.tee $1
-   local.get $0
-   f64.mul
-   local.get $1
-   local.get $1
-   local.get $1
-   f64.const 2.7557313707070068e-06
-   f64.mul
-   f64.const -1.984126982985795e-04
-   f64.add
-   f64.mul
-   f64.const 0.00833333333332249
-   f64.add
-   local.get $1
-   local.get $1
    local.get $1
    f64.mul
-   local.tee $2
-   f64.mul
-   local.get $1
-   f64.const 1.58969099521155e-10
-   f64.mul
-   f64.const -2.5050760253406863e-08
-   f64.add
-   f64.mul
-   f64.add
-   f64.mul
-   f64.const -0.16666666666666632
-   f64.add
-   f64.mul
-   f64.add
-   global.set $~lib/math/NativeMath.sincos_sin
+   local.set $2
    f64.const 1
    local.get $1
    f64.const 0.5
@@ -11270,7 +10648,38 @@
    f64.sub
    f64.add
    f64.add
-   global.set $~lib/math/NativeMath.sincos_cos
+   global.set $~lib/util/math/sincos_cos64
+   local.get $0
+   local.get $1
+   local.get $0
+   f64.mul
+   local.get $1
+   local.get $1
+   local.get $1
+   f64.const 2.7557313707070068e-06
+   f64.mul
+   f64.const -1.984126982985795e-04
+   f64.add
+   f64.mul
+   f64.const 0.00833333333332249
+   f64.add
+   local.get $1
+   local.get $1
+   local.get $1
+   f64.mul
+   f64.mul
+   local.get $1
+   f64.const 1.58969099521155e-10
+   f64.mul
+   f64.const -2.5050760253406863e-08
+   f64.add
+   f64.mul
+   f64.add
+   f64.mul
+   f64.const -0.16666666666666632
+   f64.add
+   f64.mul
+   f64.add
    return
   end
   local.get $3
@@ -11281,12 +10690,11 @@
    local.get $0
    f64.sub
    local.tee $0
-   global.set $~lib/math/NativeMath.sincos_sin
+   global.set $~lib/util/math/sincos_cos64
    local.get $0
-   global.set $~lib/math/NativeMath.sincos_cos
    return
   end
-  block $~lib/math/rempio2|inlined.3 (result i32)
+  block $~lib/util/math/rempio2_64|inlined.3 (result i32)
    local.get $5
    i64.const 32
    i64.shr_u
@@ -11366,10 +10774,10 @@
      end
     end
     local.get $0
-    global.set $~lib/math/rempio2_y0
-    global.set $~lib/math/rempio2_y1
+    global.set $~lib/util/math/rempio2_y0
+    global.set $~lib/util/math/rempio2_y1
     local.get $3
-    br $~lib/math/rempio2|inlined.3
+    br $~lib/util/math/rempio2_64|inlined.3
    end
    local.get $4
    i32.const 1094263291
@@ -11463,20 +10871,20 @@
      end
     end
     local.get $2
-    global.set $~lib/math/rempio2_y0
+    global.set $~lib/util/math/rempio2_y0
     local.get $0
     local.get $2
     f64.sub
     local.get $1
     f64.sub
-    global.set $~lib/math/rempio2_y1
+    global.set $~lib/util/math/rempio2_y1
     local.get $7
     i32.trunc_sat_f64_s
-    br $~lib/math/rempio2|inlined.3
+    br $~lib/util/math/rempio2_64|inlined.3
    end
    i32.const 0
    local.get $5
-   call $~lib/math/pio2_large_quot
+   call $~lib/util/math/pio2_64_large_quot
    local.tee $3
    i32.sub
    local.get $3
@@ -11484,7 +10892,7 @@
    select
   end
   local.set $3
-  global.get $~lib/math/rempio2_y0
+  global.get $~lib/util/math/rempio2_y0
   local.tee $7
   local.get $7
   f64.mul
@@ -11495,7 +10903,7 @@
   local.set $1
   local.get $7
   local.get $0
-  global.get $~lib/math/rempio2_y1
+  global.get $~lib/util/math/rempio2_y1
   local.tee $9
   f64.const 0.5
   f64.mul
@@ -11595,18 +11003,17 @@
   local.get $3
   i32.const 2
   i32.and
-  if (result f64)
+  if
    local.get $1
    f64.neg
    local.set $1
    local.get $0
    f64.neg
-  else
-   local.get $0
+   local.set $0
   end
-  global.set $~lib/math/NativeMath.sincos_sin
   local.get $1
-  global.set $~lib/math/NativeMath.sincos_cos
+  global.set $~lib/util/math/sincos_cos64
+  local.get $0
  )
  (func $std/math/test_sincos (param $0 i64) (param $1 i64) (param $2 i64) (param $3 i64) (param $4 i64)
   (local $5 f64)
@@ -11619,7 +11026,10 @@
   local.set $6
   local.get $0
   f64.reinterpret_i64
-  call $~lib/math/NativeMath.sincos
+  call $~lib/util/math/sincos64
+  global.set $~lib/math/NativeMath.sincos_sin
+  global.get $~lib/util/math/sincos_cos64
+  global.set $~lib/math/NativeMath.sincos_cos
   global.get $~lib/math/NativeMath.sincos_sin
   local.get $1
   f64.reinterpret_i64
@@ -11634,7 +11044,7 @@
    drop
   end
  )
- (func $~lib/math/NativeMath.imul (param $0 f64) (param $1 f64) (result f64)
+ (func $~lib/math/NativeMath.imul<f64> (param $0 f64) (param $1 f64) (result f64)
   (local $2 i32)
   (local $3 i64)
   (local $4 f64)
@@ -11740,7 +11150,7 @@
   i32.mul
   f64.convert_i32_s
  )
- (func $~lib/math/ipow64 (param $0 i64) (param $1 i64) (result i64)
+ (func $~lib/util/math/ipow64 (param $0 i64) (param $1 i64) (result i64)
   (local $2 i64)
   i64.const 1
   local.set $2
@@ -11958,13 +11368,10 @@
   local.get $2
  )
  (func $start:std/math
-  (local $0 f64)
-  (local $1 i32)
-  (local $2 i64)
-  (local $3 i32)
-  (local $4 i32)
-  (local $5 f32)
-  (local $6 i64)
+  (local $0 i64)
+  (local $1 f64)
+  (local $2 i32)
+  (local $3 i64)
   f64.const 2.718281828459045
   global.get $~lib/bindings/dom/Math.E
   f64.const 0
@@ -11973,7 +11380,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 111
+   i32.const 116
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -11986,7 +11393,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 112
+   i32.const 117
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -11999,7 +11406,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 113
+   i32.const 118
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -12012,7 +11419,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 114
+   i32.const 119
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -12025,7 +11432,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 115
+   i32.const 120
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -12038,7 +11445,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 116
+   i32.const 121
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -12051,113 +11458,60 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 117
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const 2.7182817459106445
-  global.get $~lib/bindings/dom/Math.E
-  f32.demote_f64
-  f32.const 0
-  call $std/math/check<f32>
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 119
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const 0.6931471824645996
-  global.get $~lib/bindings/dom/Math.LN2
-  f32.demote_f64
-  f32.const 0
-  call $std/math/check<f32>
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 120
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const 2.3025851249694824
-  global.get $~lib/bindings/dom/Math.LN10
-  f32.demote_f64
-  f32.const 0
-  call $std/math/check<f32>
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 121
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const 1.4426950216293335
-  global.get $~lib/bindings/dom/Math.LOG2E
-  f32.demote_f64
-  f32.const 0
-  call $std/math/check<f32>
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
    i32.const 122
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const 3.1415927410125732
-  global.get $~lib/bindings/dom/Math.PI
-  f32.demote_f64
-  f32.const 0
-  call $std/math/check<f32>
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 123
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const 0.7071067690849304
-  global.get $~lib/bindings/dom/Math.SQRT1_2
-  f32.demote_f64
-  f32.const 0
-  call $std/math/check<f32>
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 124
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const 1.4142135381698608
-  global.get $~lib/bindings/dom/Math.SQRT2
-  f32.demote_f64
-  f32.const 0
-  call $std/math/check<f32>
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 125
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f64.const -8.06684839057968
   i32.const -2
-  call $~lib/math/NativeMath.scalbn
+  call $~lib/util/math/scalbn64
   f64.const -2.01671209764492
+  f64.const 0
+  call $std/math/check<f64>
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 133
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const 4.345239849338305
+  i32.const -1
+  call $~lib/util/math/scalbn64
+  f64.const 2.1726199246691524
+  f64.const 0
+  call $std/math/check<f64>
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 134
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const -8.38143342755525
+  i32.const 0
+  call $~lib/util/math/scalbn64
+  f64.const -8.38143342755525
+  f64.const 0
+  call $std/math/check<f64>
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 135
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const -6.531673581913484
+  i32.const 1
+  call $~lib/util/math/scalbn64
+  f64.const -13.063347163826968
   f64.const 0
   call $std/math/check<f64>
   i32.eqz
@@ -12169,10 +11523,10 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 4.345239849338305
-  i32.const -1
-  call $~lib/math/NativeMath.scalbn
-  f64.const 2.1726199246691524
+  f64.const 9.267056966972586
+  i32.const 2
+  call $~lib/util/math/scalbn64
+  f64.const 37.06822786789034
   f64.const 0
   call $std/math/check<f64>
   i32.eqz
@@ -12184,10 +11538,10 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -8.38143342755525
-  i32.const 0
-  call $~lib/math/NativeMath.scalbn
-  f64.const -8.38143342755525
+  f64.const 0.6619858980995045
+  i32.const 3
+  call $~lib/util/math/scalbn64
+  f64.const 5.295887184796036
   f64.const 0
   call $std/math/check<f64>
   i32.eqz
@@ -12199,10 +11553,10 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -6.531673581913484
-  i32.const 1
-  call $~lib/math/NativeMath.scalbn
-  f64.const -13.063347163826968
+  f64.const -0.4066039223853553
+  i32.const 4
+  call $~lib/util/math/scalbn64
+  f64.const -6.505662758165685
   f64.const 0
   call $std/math/check<f64>
   i32.eqz
@@ -12214,10 +11568,10 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 9.267056966972586
-  i32.const 2
-  call $~lib/math/NativeMath.scalbn
-  f64.const 37.06822786789034
+  f64.const 0.5617597462207241
+  i32.const 5
+  call $~lib/util/math/scalbn64
+  f64.const 17.97631187906317
   f64.const 0
   call $std/math/check<f64>
   i32.eqz
@@ -12229,10 +11583,10 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 0.6619858980995045
-  i32.const 3
-  call $~lib/math/NativeMath.scalbn
-  f64.const 5.295887184796036
+  f64.const 0.7741522965913037
+  i32.const 6
+  call $~lib/util/math/scalbn64
+  f64.const 49.545746981843436
   f64.const 0
   call $std/math/check<f64>
   i32.eqz
@@ -12244,10 +11598,10 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -0.4066039223853553
-  i32.const 4
-  call $~lib/math/NativeMath.scalbn
-  f64.const -6.505662758165685
+  f64.const -0.6787637026394024
+  i32.const 7
+  call $~lib/util/math/scalbn64
+  f64.const -86.88175393784351
   f64.const 0
   call $std/math/check<f64>
   i32.eqz
@@ -12259,40 +11613,10 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 0.5617597462207241
-  i32.const 5
-  call $~lib/math/NativeMath.scalbn
-  f64.const 17.97631187906317
   f64.const 0
-  call $std/math/check<f64>
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 143
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const 0.7741522965913037
-  i32.const 6
-  call $~lib/math/NativeMath.scalbn
-  f64.const 49.545746981843436
+  i32.const 2147483647
+  call $~lib/util/math/scalbn64
   f64.const 0
-  call $std/math/check<f64>
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 144
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const -0.6787637026394024
-  i32.const 7
-  call $~lib/math/NativeMath.scalbn
-  f64.const -86.88175393784351
   f64.const 0
   call $std/math/check<f64>
   i32.eqz
@@ -12305,9 +11629,39 @@
    unreachable
   end
   f64.const 0
-  i32.const 2147483647
-  call $~lib/math/NativeMath.scalbn
+  i32.const -2147483647
+  call $~lib/util/math/scalbn64
   f64.const 0
+  f64.const 0
+  call $std/math/check<f64>
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 146
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const -0
+  i32.const 2147483647
+  call $~lib/util/math/scalbn64
+  f64.const -0
+  f64.const 0
+  call $std/math/check<f64>
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 147
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const nan:0x8000000000000
+  i32.const 0
+  call $~lib/util/math/scalbn64
+  f64.const nan:0x8000000000000
   f64.const 0
   call $std/math/check<f64>
   i32.eqz
@@ -12319,10 +11673,10 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 0
-  i32.const -2147483647
-  call $~lib/math/NativeMath.scalbn
-  f64.const 0
+  f64.const inf
+  i32.const 0
+  call $~lib/util/math/scalbn64
+  f64.const inf
   f64.const 0
   call $std/math/check<f64>
   i32.eqz
@@ -12334,10 +11688,10 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -0
-  i32.const 2147483647
-  call $~lib/math/NativeMath.scalbn
-  f64.const -0
+  f64.const -inf
+  i32.const 0
+  call $~lib/util/math/scalbn64
+  f64.const -inf
   f64.const 0
   call $std/math/check<f64>
   i32.eqz
@@ -12349,10 +11703,10 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const nan:0x8000000000000
+  f64.const 1
   i32.const 0
-  call $~lib/math/NativeMath.scalbn
-  f64.const nan:0x8000000000000
+  call $~lib/util/math/scalbn64
+  f64.const 1
   f64.const 0
   call $std/math/check<f64>
   i32.eqz
@@ -12364,10 +11718,10 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const inf
-  i32.const 0
-  call $~lib/math/NativeMath.scalbn
-  f64.const inf
+  f64.const 1
+  i32.const 1
+  call $~lib/util/math/scalbn64
+  f64.const 2
   f64.const 0
   call $std/math/check<f64>
   i32.eqz
@@ -12379,10 +11733,10 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -inf
-  i32.const 0
-  call $~lib/math/NativeMath.scalbn
-  f64.const -inf
+  f64.const 1
+  i32.const -1
+  call $~lib/util/math/scalbn64
+  f64.const 0.5
   f64.const 0
   call $std/math/check<f64>
   i32.eqz
@@ -12395,9 +11749,9 @@
    unreachable
   end
   f64.const 1
-  i32.const 0
-  call $~lib/math/NativeMath.scalbn
-  f64.const 1
+  i32.const 2147483647
+  call $~lib/util/math/scalbn64
+  f64.const inf
   f64.const 0
   call $std/math/check<f64>
   i32.eqz
@@ -12409,10 +11763,10 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 1
+  f64.const nan:0x8000000000000
   i32.const 1
-  call $~lib/math/NativeMath.scalbn
-  f64.const 2
+  call $~lib/util/math/scalbn64
+  f64.const nan:0x8000000000000
   f64.const 0
   call $std/math/check<f64>
   i32.eqz
@@ -12424,10 +11778,10 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 1
-  i32.const -1
-  call $~lib/math/NativeMath.scalbn
-  f64.const 0.5
+  f64.const inf
+  i32.const 2147483647
+  call $~lib/util/math/scalbn64
+  f64.const inf
   f64.const 0
   call $std/math/check<f64>
   i32.eqz
@@ -12439,9 +11793,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 1
-  i32.const 2147483647
-  call $~lib/math/NativeMath.scalbn
+  f64.const inf
+  i32.const -2147483647
+  call $~lib/util/math/scalbn64
   f64.const inf
   f64.const 0
   call $std/math/check<f64>
@@ -12454,10 +11808,10 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const nan:0x8000000000000
-  i32.const 1
-  call $~lib/math/NativeMath.scalbn
-  f64.const nan:0x8000000000000
+  f64.const -inf
+  i32.const 2147483647
+  call $~lib/util/math/scalbn64
+  f64.const -inf
   f64.const 0
   call $std/math/check<f64>
   i32.eqz
@@ -12469,10 +11823,10 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const inf
-  i32.const 2147483647
-  call $~lib/math/NativeMath.scalbn
-  f64.const inf
+  f64.const 8988465674311579538646525e283
+  i32.const -2097
+  call $~lib/util/math/scalbn64
+  f64.const 5e-324
   f64.const 0
   call $std/math/check<f64>
   i32.eqz
@@ -12484,10 +11838,10 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const inf
-  i32.const -2147483647
-  call $~lib/math/NativeMath.scalbn
-  f64.const inf
+  f64.const 5e-324
+  i32.const 2097
+  call $~lib/util/math/scalbn64
+  f64.const 8988465674311579538646525e283
   f64.const 0
   call $std/math/check<f64>
   i32.eqz
@@ -12499,10 +11853,10 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -inf
-  i32.const 2147483647
-  call $~lib/math/NativeMath.scalbn
-  f64.const -inf
+  f64.const 1.000244140625
+  i32.const -1074
+  call $~lib/util/math/scalbn64
+  f64.const 5e-324
   f64.const 0
   call $std/math/check<f64>
   i32.eqz
@@ -12514,9 +11868,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 8988465674311579538646525e283
-  i32.const -2097
-  call $~lib/math/NativeMath.scalbn
+  f64.const 0.7499999999999999
+  i32.const -1073
+  call $~lib/util/math/scalbn64
   f64.const 5e-324
   f64.const 0
   call $std/math/check<f64>
@@ -12529,10 +11883,10 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 5e-324
-  i32.const 2097
-  call $~lib/math/NativeMath.scalbn
-  f64.const 8988465674311579538646525e283
+  f64.const 0.5000000000000012
+  i32.const -1024
+  call $~lib/util/math/scalbn64
+  f64.const 2.781342323134007e-309
   f64.const 0
   call $std/math/check<f64>
   i32.eqz
@@ -12544,53 +11898,47 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 1.000244140625
-  i32.const -1074
-  call $~lib/math/NativeMath.scalbn
-  f64.const 5e-324
-  f64.const 0
-  call $std/math/check<f64>
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 164
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const 0.7499999999999999
-  i32.const -1073
-  call $~lib/math/NativeMath.scalbn
-  f64.const 5e-324
-  f64.const 0
-  call $std/math/check<f64>
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 165
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const 0.5000000000000012
-  i32.const -1024
-  call $~lib/math/NativeMath.scalbn
-  f64.const 2.781342323134007e-309
-  f64.const 0
-  call $std/math/check<f64>
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 166
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
   f32.const -2.016712188720703
   f32.const -2.016712188720703
+  f32.const 0
+  call $std/math/check<f32>
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 172
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const 2.1726198196411133
+  f32.const 2.1726198196411133
+  f32.const 0
+  call $std/math/check<f32>
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 173
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const -8.381433486938477
+  f32.const -8.381433486938477
+  f32.const 0
+  call $std/math/check<f32>
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 174
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const -13.063346862792969
+  f32.const -13.063346862792969
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -12602,8 +11950,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 2.1726198196411133
-  f32.const 2.1726198196411133
+  f32.const 37.06822967529297
+  f32.const 37.06822967529297
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -12615,8 +11963,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -8.381433486938477
-  f32.const -8.381433486938477
+  f32.const 5.295886993408203
+  f32.const 5.295886993408203
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -12628,8 +11976,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -13.063346862792969
-  f32.const -13.063346862792969
+  f32.const -6.50566291809082
+  f32.const -6.50566291809082
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -12641,8 +11989,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 37.06822967529297
-  f32.const 37.06822967529297
+  f32.const 17.9763126373291
+  f32.const 17.9763126373291
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -12654,8 +12002,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 5.295886993408203
-  f32.const 5.295886993408203
+  f32.const 49.545745849609375
+  f32.const 49.545745849609375
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -12667,8 +12015,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -6.50566291809082
-  f32.const -6.50566291809082
+  f32.const -86.88175201416016
+  f32.const -86.88175201416016
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -12680,34 +12028,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 17.9763126373291
-  f32.const 17.9763126373291
   f32.const 0
-  call $std/math/check<f32>
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 182
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const 49.545745849609375
-  f32.const 49.545745849609375
   f32.const 0
-  call $std/math/check<f32>
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 183
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const -86.88175201416016
-  f32.const -86.88175201416016
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -12727,13 +12049,39 @@
   if
    i32.const 0
    i32.const 1056
+   i32.const 185
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const -0
+  f32.const -0
+  f32.const 0
+  call $std/math/check<f32>
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 186
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const nan:0x400000
+  f32.const nan:0x400000
+  f32.const 0
+  call $std/math/check<f32>
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1056
    i32.const 187
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 0
-  f32.const 0
+  f32.const inf
+  f32.const inf
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -12745,8 +12093,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -0
-  f32.const -0
+  f32.const -inf
+  f32.const -inf
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -12758,8 +12106,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const nan:0x400000
-  f32.const nan:0x400000
+  f32.const 1
+  f32.const 1
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -12771,8 +12119,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const inf
-  f32.const inf
+  f32.const 2
+  f32.const 2
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -12784,8 +12132,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -inf
-  f32.const -inf
+  f32.const 0.5
+  f32.const 0.5
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -12797,8 +12145,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 1
-  f32.const 1
+  f32.const inf
+  f32.const inf
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -12810,8 +12158,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 2
-  f32.const 2
+  f32.const nan:0x400000
+  f32.const nan:0x400000
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -12823,8 +12171,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 0.5
-  f32.const 0.5
+  f32.const inf
+  f32.const inf
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -12849,8 +12197,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const nan:0x400000
-  f32.const nan:0x400000
+  f32.const -inf
+  f32.const -inf
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -12862,8 +12210,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const inf
-  f32.const inf
+  f32.const 1.401298464324817e-45
+  f32.const 1.401298464324817e-45
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -12875,8 +12223,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const inf
-  f32.const inf
+  f32.const 1701411834604692317316873e14
+  f32.const 1701411834604692317316873e14
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -12888,8 +12236,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -inf
-  f32.const -inf
+  f32.const 1.401298464324817e-45
+  f32.const 1.401298464324817e-45
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -12914,8 +12262,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 1701411834604692317316873e14
-  f32.const 1701411834604692317316873e14
+  f32.const 1.4693693398263237e-39
+  f32.const 1.4693693398263237e-39
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -12923,45 +12271,6 @@
    i32.const 0
    i32.const 1056
    i32.const 202
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const 1.401298464324817e-45
-  f32.const 1.401298464324817e-45
-  f32.const 0
-  call $std/math/check<f32>
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 203
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const 1.401298464324817e-45
-  f32.const 1.401298464324817e-45
-  f32.const 0
-  call $std/math/check<f32>
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 204
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const 1.4693693398263237e-39
-  f32.const 1.4693693398263237e-39
-  f32.const 0
-  call $std/math/check<f32>
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 205
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -12983,7 +12292,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 217
+   i32.const 214
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -13005,7 +12314,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 218
+   i32.const 215
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -13027,7 +12336,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 219
+   i32.const 216
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -13049,7 +12358,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 220
+   i32.const 217
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -13071,7 +12380,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 221
+   i32.const 218
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -13093,7 +12402,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 222
+   i32.const 219
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -13115,7 +12424,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 223
+   i32.const 220
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -13137,7 +12446,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 224
+   i32.const 221
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -13159,7 +12468,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 225
+   i32.const 222
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -13181,7 +12490,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 226
+   i32.const 223
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -13203,7 +12512,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 229
+   i32.const 226
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -13225,7 +12534,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 230
+   i32.const 227
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -13247,7 +12556,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 231
+   i32.const 228
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -13269,7 +12578,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 232
+   i32.const 229
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -13291,7 +12600,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 233
+   i32.const 230
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -13313,7 +12622,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 234
+   i32.const 231
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -13335,13 +12644,52 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 235
+   i32.const 232
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f32.const 8.066848754882812
   f32.const 8.066848754882812
+  f32.const 0
+  call $std/math/check<f32>
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 241
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const 4.345239639282227
+  f32.const 4.345239639282227
+  f32.const 0
+  call $std/math/check<f32>
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 242
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const 8.381433486938477
+  f32.const 8.381433486938477
+  f32.const 0
+  call $std/math/check<f32>
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 243
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const 6.531673431396484
+  f32.const 6.531673431396484
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -13353,8 +12701,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 4.345239639282227
-  f32.const 4.345239639282227
+  f32.const 9.267057418823242
+  f32.const 9.267057418823242
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -13366,8 +12714,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 8.381433486938477
-  f32.const 8.381433486938477
+  f32.const 0.6619858741760254
+  f32.const 0.6619858741760254
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -13379,8 +12727,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 6.531673431396484
-  f32.const 6.531673431396484
+  f32.const 0.40660393238067627
+  f32.const 0.40660393238067627
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -13392,8 +12740,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 9.267057418823242
-  f32.const 9.267057418823242
+  f32.const 0.5617597699165344
+  f32.const 0.5617597699165344
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -13405,8 +12753,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 0.6619858741760254
-  f32.const 0.6619858741760254
+  f32.const 0.7741522789001465
+  f32.const 0.7741522789001465
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -13418,8 +12766,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 0.40660393238067627
-  f32.const 0.40660393238067627
+  f32.const 0.6787636876106262
+  f32.const 0.6787636876106262
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -13431,34 +12779,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 0.5617597699165344
-  f32.const 0.5617597699165344
   f32.const 0
-  call $std/math/check<f32>
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 251
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const 0.7741522789001465
-  f32.const 0.7741522789001465
   f32.const 0
-  call $std/math/check<f32>
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 252
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const 0.6787636876106262
-  f32.const 0.6787636876106262
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -13478,13 +12800,39 @@
   if
    i32.const 0
    i32.const 1056
+   i32.const 254
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const 1
+  f32.const 1
+  f32.const 0
+  call $std/math/check<f32>
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 255
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const 1
+  f32.const 1
+  f32.const 0
+  call $std/math/check<f32>
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1056
    i32.const 256
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 0
-  f32.const 0
+  f32.const inf
+  f32.const inf
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -13496,8 +12844,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 1
-  f32.const 1
+  f32.const inf
+  f32.const inf
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -13509,8 +12857,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 1
-  f32.const 1
+  f32.const nan:0x400000
+  f32.const nan:0x400000
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -13522,52 +12870,82 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const inf
-  f32.const inf
-  f32.const 0
-  call $std/math/check<f32>
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 260
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const inf
-  f32.const inf
-  f32.const 0
-  call $std/math/check<f32>
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 261
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const nan:0x400000
-  f32.const nan:0x400000
-  f32.const 0
-  call $std/math/check<f32>
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 262
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
   f64.const -8.06684839057968
-  call $~lib/math/NativeMath.acos
+  call $~lib/util/math/acos64
   f64.const nan:0x8000000000000
   f64.const 0
   call $std/math/check<f64>
   if (result i32)
    f64.const -8.06684839057968
+   call $~lib/bindings/dom/Math.acos
+   f64.const nan:0x8000000000000
+   f64.const 0
+   call $std/math/check<f64>
+  else
+   i32.const 0
+  end
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 271
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const 4.345239849338305
+  call $~lib/util/math/acos64
+  f64.const nan:0x8000000000000
+  f64.const 0
+  call $std/math/check<f64>
+  if (result i32)
+   f64.const 4.345239849338305
+   call $~lib/bindings/dom/Math.acos
+   f64.const nan:0x8000000000000
+   f64.const 0
+   call $std/math/check<f64>
+  else
+   i32.const 0
+  end
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 272
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const -8.38143342755525
+  call $~lib/util/math/acos64
+  f64.const nan:0x8000000000000
+  f64.const 0
+  call $std/math/check<f64>
+  if (result i32)
+   f64.const -8.38143342755525
+   call $~lib/bindings/dom/Math.acos
+   f64.const nan:0x8000000000000
+   f64.const 0
+   call $std/math/check<f64>
+  else
+   i32.const 0
+  end
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 273
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const -6.531673581913484
+  call $~lib/util/math/acos64
+  f64.const nan:0x8000000000000
+  f64.const 0
+  call $std/math/check<f64>
+  if (result i32)
+   f64.const -6.531673581913484
    call $~lib/bindings/dom/Math.acos
    f64.const nan:0x8000000000000
    f64.const 0
@@ -13584,13 +12962,13 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 4.345239849338305
-  call $~lib/math/NativeMath.acos
+  f64.const 9.267056966972586
+  call $~lib/util/math/acos64
   f64.const nan:0x8000000000000
   f64.const 0
   call $std/math/check<f64>
   if (result i32)
-   f64.const 4.345239849338305
+   f64.const 9.267056966972586
    call $~lib/bindings/dom/Math.acos
    f64.const nan:0x8000000000000
    f64.const 0
@@ -13607,77 +12985,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -8.38143342755525
-  call $~lib/math/NativeMath.acos
-  f64.const nan:0x8000000000000
-  f64.const 0
-  call $std/math/check<f64>
-  if (result i32)
-   f64.const -8.38143342755525
-   call $~lib/bindings/dom/Math.acos
-   f64.const nan:0x8000000000000
-   f64.const 0
-   call $std/math/check<f64>
-  else
-   i32.const 0
-  end
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 276
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const -6.531673581913484
-  call $~lib/math/NativeMath.acos
-  f64.const nan:0x8000000000000
-  f64.const 0
-  call $std/math/check<f64>
-  if (result i32)
-   f64.const -6.531673581913484
-   call $~lib/bindings/dom/Math.acos
-   f64.const nan:0x8000000000000
-   f64.const 0
-   call $std/math/check<f64>
-  else
-   i32.const 0
-  end
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 277
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const 9.267056966972586
-  call $~lib/math/NativeMath.acos
-  f64.const nan:0x8000000000000
-  f64.const 0
-  call $std/math/check<f64>
-  if (result i32)
-   f64.const 9.267056966972586
-   call $~lib/bindings/dom/Math.acos
-   f64.const nan:0x8000000000000
-   f64.const 0
-   call $std/math/check<f64>
-  else
-   i32.const 0
-  end
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 278
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
   f64.const 0.6619858980995045
-  call $~lib/math/NativeMath.acos
+  call $~lib/util/math/acos64
   f64.const 0.8473310828433507
   f64.const -0.41553276777267456
   call $std/math/check<f64>
@@ -13694,13 +13003,13 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 279
+   i32.const 276
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f64.const -0.4066039223853553
-  call $~lib/math/NativeMath.acos
+  call $~lib/util/math/acos64
   f64.const 1.989530071088669
   f64.const 0.4973946213722229
   call $std/math/check<f64>
@@ -13717,13 +13026,13 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 280
+   i32.const 277
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f64.const 0.5617597462207241
-  call $~lib/math/NativeMath.acos
+  call $~lib/util/math/acos64
   f64.const 0.9742849645674904
   f64.const -0.4428897500038147
   call $std/math/check<f64>
@@ -13740,13 +13049,13 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 281
+   i32.const 278
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f64.const 0.7741522965913037
-  call $~lib/math/NativeMath.acos
+  call $~lib/util/math/acos64
   f64.const 0.6854215158636222
   f64.const -0.12589527666568756
   call $std/math/check<f64>
@@ -13763,13 +13072,13 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 282
+   i32.const 279
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f64.const -0.6787637026394024
-  call $~lib/math/NativeMath.acos
+  call $~lib/util/math/acos64
   f64.const 2.316874138205964
   f64.const -0.17284949123859406
   call $std/math/check<f64>
@@ -13786,13 +13095,13 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 283
+   i32.const 280
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f64.const 0
-  call $~lib/math/NativeMath.acos
+  call $~lib/util/math/acos64
   f64.const 1.5707963267948966
   f64.const -0.27576595544815063
   call $std/math/check<f64>
@@ -13809,13 +13118,13 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 286
+   i32.const 283
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f64.const -1
-  call $~lib/math/NativeMath.acos
+  call $~lib/util/math/acos64
   f64.const 3.141592653589793
   f64.const -0.27576595544815063
   call $std/math/check<f64>
@@ -13832,13 +13141,13 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 287
+   i32.const 284
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f64.const 1
-  call $~lib/math/NativeMath.acos
+  call $~lib/util/math/acos64
   f64.const 0
   f64.const 0
   call $std/math/check<f64>
@@ -13855,18 +13164,87 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 288
+   i32.const 285
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f64.const 1.0000000000000002
-  call $~lib/math/NativeMath.acos
+  call $~lib/util/math/acos64
   f64.const nan:0x8000000000000
   f64.const 0
   call $std/math/check<f64>
   if (result i32)
    f64.const 1.0000000000000002
+   call $~lib/bindings/dom/Math.acos
+   f64.const nan:0x8000000000000
+   f64.const 0
+   call $std/math/check<f64>
+  else
+   i32.const 0
+  end
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 286
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const -1.0000000000000002
+  call $~lib/util/math/acos64
+  f64.const nan:0x8000000000000
+  f64.const 0
+  call $std/math/check<f64>
+  if (result i32)
+   f64.const -1.0000000000000002
+   call $~lib/bindings/dom/Math.acos
+   f64.const nan:0x8000000000000
+   f64.const 0
+   call $std/math/check<f64>
+  else
+   i32.const 0
+  end
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 287
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const inf
+  call $~lib/util/math/acos64
+  f64.const nan:0x8000000000000
+  f64.const 0
+  call $std/math/check<f64>
+  if (result i32)
+   f64.const inf
+   call $~lib/bindings/dom/Math.acos
+   f64.const nan:0x8000000000000
+   f64.const 0
+   call $std/math/check<f64>
+  else
+   i32.const 0
+  end
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 288
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const -inf
+  call $~lib/util/math/acos64
+  f64.const nan:0x8000000000000
+  f64.const 0
+  call $std/math/check<f64>
+  if (result i32)
+   f64.const -inf
    call $~lib/bindings/dom/Math.acos
    f64.const nan:0x8000000000000
    f64.const 0
@@ -13883,13 +13261,13 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -1.0000000000000002
-  call $~lib/math/NativeMath.acos
+  f64.const nan:0x8000000000000
+  call $~lib/util/math/acos64
   f64.const nan:0x8000000000000
   f64.const 0
   call $std/math/check<f64>
   if (result i32)
-   f64.const -1.0000000000000002
+   f64.const nan:0x8000000000000
    call $~lib/bindings/dom/Math.acos
    f64.const nan:0x8000000000000
    f64.const 0
@@ -13906,77 +13284,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const inf
-  call $~lib/math/NativeMath.acos
-  f64.const nan:0x8000000000000
-  f64.const 0
-  call $std/math/check<f64>
-  if (result i32)
-   f64.const inf
-   call $~lib/bindings/dom/Math.acos
-   f64.const nan:0x8000000000000
-   f64.const 0
-   call $std/math/check<f64>
-  else
-   i32.const 0
-  end
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 291
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const -inf
-  call $~lib/math/NativeMath.acos
-  f64.const nan:0x8000000000000
-  f64.const 0
-  call $std/math/check<f64>
-  if (result i32)
-   f64.const -inf
-   call $~lib/bindings/dom/Math.acos
-   f64.const nan:0x8000000000000
-   f64.const 0
-   call $std/math/check<f64>
-  else
-   i32.const 0
-  end
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 292
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const nan:0x8000000000000
-  call $~lib/math/NativeMath.acos
-  f64.const nan:0x8000000000000
-  f64.const 0
-  call $std/math/check<f64>
-  if (result i32)
-   f64.const nan:0x8000000000000
-   call $~lib/bindings/dom/Math.acos
-   f64.const nan:0x8000000000000
-   f64.const 0
-   call $std/math/check<f64>
-  else
-   i32.const 0
-  end
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 293
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
   f64.const -0.5309227209592985
-  call $~lib/math/NativeMath.acos
+  call $~lib/util/math/acos64
   f64.const 2.1304853799705463
   f64.const 0.1391008496284485
   call $std/math/check<f64>
@@ -13993,13 +13302,13 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 294
+   i32.const 291
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f64.const 0.4939556746399746
-  call $~lib/math/NativeMath.acos
+  call $~lib/util/math/acos64
   f64.const 1.0541629875851946
   f64.const 0.22054767608642578
   call $std/math/check<f64>
@@ -14016,16 +13325,54 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 295
+   i32.const 292
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f32.const -8.066848754882812
-  call $~lib/math/NativeMathf.acos
   f32.const nan:0x400000
   f32.const 0
-  call $std/math/check<f32>
+  call $std/math/test_acosf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 301
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const 4.345239639282227
+  f32.const nan:0x400000
+  f32.const 0
+  call $std/math/test_acosf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 302
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const -8.381433486938477
+  f32.const nan:0x400000
+  f32.const 0
+  call $std/math/test_acosf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 303
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const -6.531673431396484
+  f32.const nan:0x400000
+  f32.const 0
+  call $std/math/test_acosf
   i32.eqz
   if
    i32.const 0
@@ -14035,11 +13382,10 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 4.345239639282227
-  call $~lib/math/NativeMathf.acos
+  f32.const 9.267057418823242
   f32.const nan:0x400000
   f32.const 0
-  call $std/math/check<f32>
+  call $std/math/test_acosf
   i32.eqz
   if
    i32.const 0
@@ -14049,11 +13395,10 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -8.381433486938477
-  call $~lib/math/NativeMathf.acos
-  f32.const nan:0x400000
-  f32.const 0
-  call $std/math/check<f32>
+  f32.const 0.6619858741760254
+  f32.const 0.8473311066627502
+  f32.const -0.13588131964206696
+  call $std/math/test_acosf
   i32.eqz
   if
    i32.const 0
@@ -14063,11 +13408,10 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -6.531673431396484
-  call $~lib/math/NativeMathf.acos
-  f32.const nan:0x400000
-  f32.const 0
-  call $std/math/check<f32>
+  f32.const -0.40660393238067627
+  f32.const 1.989530086517334
+  f32.const 0.03764917701482773
+  call $std/math/test_acosf
   i32.eqz
   if
    i32.const 0
@@ -14077,11 +13421,10 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 9.267057418823242
-  call $~lib/math/NativeMathf.acos
-  f32.const nan:0x400000
-  f32.const 0
-  call $std/math/check<f32>
+  f32.const 0.5617597699165344
+  f32.const 0.9742849469184875
+  f32.const 0.18443739414215088
+  call $std/math/test_acosf
   i32.eqz
   if
    i32.const 0
@@ -14091,11 +13434,10 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 0.6619858741760254
-  call $~lib/math/NativeMathf.acos
-  f32.const 0.8473311066627502
-  f32.const -0.13588131964206696
-  call $std/math/check<f32>
+  f32.const 0.7741522789001465
+  f32.const 0.6854215264320374
+  f32.const -0.29158344864845276
+  call $std/math/test_acosf
   i32.eqz
   if
    i32.const 0
@@ -14105,11 +13447,10 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -0.40660393238067627
-  call $~lib/math/NativeMathf.acos
-  f32.const 1.989530086517334
-  f32.const 0.03764917701482773
-  call $std/math/check<f32>
+  f32.const -0.6787636876106262
+  f32.const 2.3168740272521973
+  f32.const -0.3795364499092102
+  call $std/math/test_acosf
   i32.eqz
   if
    i32.const 0
@@ -14119,39 +13460,10 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 0.5617597699165344
-  call $~lib/math/NativeMathf.acos
-  f32.const 0.9742849469184875
-  f32.const 0.18443739414215088
-  call $std/math/check<f32>
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 311
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const 0.7741522789001465
-  call $~lib/math/NativeMathf.acos
-  f32.const 0.6854215264320374
-  f32.const -0.29158344864845276
-  call $std/math/check<f32>
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 312
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const -0.6787636876106262
-  call $~lib/math/NativeMathf.acos
-  f32.const 2.3168740272521973
-  f32.const -0.3795364499092102
-  call $std/math/check<f32>
+  f32.const 0
+  f32.const 1.5707963705062866
+  f32.const 0.3666777014732361
+  call $std/math/test_acosf
   i32.eqz
   if
    i32.const 0
@@ -14161,11 +13473,36 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 0
-  call $~lib/math/NativeMathf.acos
-  f32.const 1.5707963705062866
+  f32.const -1
+  f32.const 3.1415927410125732
   f32.const 0.3666777014732361
-  call $std/math/check<f32>
+  call $std/math/test_acosf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 314
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const 1
+  f32.const 0
+  f32.const 0
+  call $std/math/test_acosf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 315
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const 1.0000001192092896
+  f32.const nan:0x400000
+  f32.const 0
+  call $std/math/test_acosf
   i32.eqz
   if
    i32.const 0
@@ -14175,11 +13512,10 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -1
-  call $~lib/math/NativeMathf.acos
-  f32.const 3.1415927410125732
-  f32.const 0.3666777014732361
-  call $std/math/check<f32>
+  f32.const -1.0000001192092896
+  f32.const nan:0x400000
+  f32.const 0
+  call $std/math/test_acosf
   i32.eqz
   if
    i32.const 0
@@ -14189,11 +13525,10 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 1
-  call $~lib/math/NativeMathf.acos
+  f32.const inf
+  f32.const nan:0x400000
   f32.const 0
-  f32.const 0
-  call $std/math/check<f32>
+  call $std/math/test_acosf
   i32.eqz
   if
    i32.const 0
@@ -14203,11 +13538,10 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 1.0000001192092896
-  call $~lib/math/NativeMathf.acos
+  f32.const -inf
   f32.const nan:0x400000
   f32.const 0
-  call $std/math/check<f32>
+  call $std/math/test_acosf
   i32.eqz
   if
    i32.const 0
@@ -14217,11 +13551,10 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -1.0000001192092896
-  call $~lib/math/NativeMathf.acos
+  f32.const nan:0x400000
   f32.const nan:0x400000
   f32.const 0
-  call $std/math/check<f32>
+  call $std/math/test_acosf
   i32.eqz
   if
    i32.const 0
@@ -14231,11 +13564,10 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const inf
-  call $~lib/math/NativeMathf.acos
-  f32.const nan:0x400000
-  f32.const 0
-  call $std/math/check<f32>
+  f32.const 0.49965065717697144
+  f32.const 1.0476008653640747
+  f32.const -0.21161814033985138
+  call $std/math/test_acosf
   i32.eqz
   if
    i32.const 0
@@ -14245,11 +13577,10 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -inf
-  call $~lib/math/NativeMathf.acos
-  f32.const nan:0x400000
-  f32.const 0
-  call $std/math/check<f32>
+  f32.const -0.5051405429840088
+  f32.const 2.1003410816192627
+  f32.const -0.20852705836296082
+  call $std/math/test_acosf
   i32.eqz
   if
    i32.const 0
@@ -14259,58 +13590,15 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const nan:0x400000
-  call $~lib/math/NativeMathf.acos
-  f32.const nan:0x400000
-  f32.const 0
-  call $std/math/check<f32>
+  f32.const -0.5189794898033142
+  f32.const 2.116452932357788
+  f32.const -0.14600826799869537
+  call $std/math/test_acosf
   i32.eqz
   if
    i32.const 0
    i32.const 1056
    i32.const 323
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const 0.49965065717697144
-  call $~lib/math/NativeMathf.acos
-  f32.const 1.0476008653640747
-  f32.const -0.21161814033985138
-  call $std/math/check<f32>
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 324
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const -0.5051405429840088
-  call $~lib/math/NativeMathf.acos
-  f32.const 2.1003410816192627
-  f32.const -0.20852705836296082
-  call $std/math/check<f32>
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 325
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const -0.5189794898033142
-  call $~lib/math/NativeMathf.acos
-  f32.const 2.116452932357788
-  f32.const -0.14600826799869537
-  call $std/math/check<f32>
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 326
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -14323,7 +13611,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 338
+   i32.const 335
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -14336,7 +13624,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 339
+   i32.const 336
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -14349,7 +13637,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 340
+   i32.const 337
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -14362,7 +13650,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 341
+   i32.const 338
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -14375,7 +13663,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 342
+   i32.const 339
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -14388,7 +13676,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 343
+   i32.const 340
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -14401,7 +13689,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 344
+   i32.const 341
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -14414,7 +13702,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 345
+   i32.const 342
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -14427,7 +13715,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 346
+   i32.const 343
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -14440,24 +13728,24 @@
   if
    i32.const 0
    i32.const 1056
+   i32.const 344
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const nan:0x8000000000000
+  f64.const nan:0x8000000000000
+  f64.const 0
+  call $std/math/test_acosh
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1056
    i32.const 347
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const nan:0x8000000000000
-  f64.const nan:0x8000000000000
-  f64.const 0
-  call $std/math/test_acosh
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 350
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
   f64.const inf
   f64.const inf
   f64.const 0
@@ -14466,7 +13754,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 351
+   i32.const 348
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -14479,7 +13767,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 352
+   i32.const 349
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -14492,7 +13780,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 353
+   i32.const 350
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -14505,7 +13793,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 354
+   i32.const 351
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -14518,7 +13806,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 355
+   i32.const 352
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -14531,7 +13819,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 356
+   i32.const 353
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -14544,7 +13832,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 357
+   i32.const 354
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -14557,7 +13845,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 373
+   i32.const 370
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -14570,7 +13858,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 375
+   i32.const 372
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -14583,7 +13871,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 376
+   i32.const 373
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -14596,7 +13884,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 385
+   i32.const 382
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -14609,7 +13897,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 386
+   i32.const 383
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -14622,7 +13910,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 387
+   i32.const 384
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -14635,7 +13923,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 388
+   i32.const 385
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -14648,7 +13936,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 389
+   i32.const 386
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -14661,7 +13949,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 390
+   i32.const 387
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -14674,7 +13962,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 391
+   i32.const 388
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -14687,7 +13975,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 392
+   i32.const 389
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -14700,7 +13988,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 393
+   i32.const 390
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -14713,24 +14001,24 @@
   if
    i32.const 0
    i32.const 1056
+   i32.const 391
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const nan:0x400000
+  f32.const nan:0x400000
+  f32.const 0
+  call $std/math/test_acoshf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1056
    i32.const 394
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const nan:0x400000
-  f32.const nan:0x400000
-  f32.const 0
-  call $std/math/test_acoshf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 397
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
   f32.const inf
   f32.const inf
   f32.const 0
@@ -14739,7 +14027,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 398
+   i32.const 395
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -14752,7 +14040,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 399
+   i32.const 396
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -14765,7 +14053,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 400
+   i32.const 397
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -14778,7 +14066,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 401
+   i32.const 398
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -14791,7 +14079,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 402
+   i32.const 399
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -14804,7 +14092,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 403
+   i32.const 400
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -14817,18 +14105,87 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 404
+   i32.const 401
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f64.const -8.06684839057968
-  call $~lib/math/NativeMath.asin
+  call $~lib/util/math/asin64
   f64.const nan:0x8000000000000
   f64.const 0
   call $std/math/check<f64>
   if (result i32)
    f64.const -8.06684839057968
+   call $~lib/bindings/dom/Math.asin
+   f64.const nan:0x8000000000000
+   f64.const 0
+   call $std/math/check<f64>
+  else
+   i32.const 0
+  end
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 413
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const 4.345239849338305
+  call $~lib/util/math/asin64
+  f64.const nan:0x8000000000000
+  f64.const 0
+  call $std/math/check<f64>
+  if (result i32)
+   f64.const 4.345239849338305
+   call $~lib/bindings/dom/Math.asin
+   f64.const nan:0x8000000000000
+   f64.const 0
+   call $std/math/check<f64>
+  else
+   i32.const 0
+  end
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 414
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const -8.38143342755525
+  call $~lib/util/math/asin64
+  f64.const nan:0x8000000000000
+  f64.const 0
+  call $std/math/check<f64>
+  if (result i32)
+   f64.const -8.38143342755525
+   call $~lib/bindings/dom/Math.asin
+   f64.const nan:0x8000000000000
+   f64.const 0
+   call $std/math/check<f64>
+  else
+   i32.const 0
+  end
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 415
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const -6.531673581913484
+  call $~lib/util/math/asin64
+  f64.const nan:0x8000000000000
+  f64.const 0
+  call $std/math/check<f64>
+  if (result i32)
+   f64.const -6.531673581913484
    call $~lib/bindings/dom/Math.asin
    f64.const nan:0x8000000000000
    f64.const 0
@@ -14845,13 +14202,13 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 4.345239849338305
-  call $~lib/math/NativeMath.asin
+  f64.const 9.267056966972586
+  call $~lib/util/math/asin64
   f64.const nan:0x8000000000000
   f64.const 0
   call $std/math/check<f64>
   if (result i32)
-   f64.const 4.345239849338305
+   f64.const 9.267056966972586
    call $~lib/bindings/dom/Math.asin
    f64.const nan:0x8000000000000
    f64.const 0
@@ -14868,77 +14225,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -8.38143342755525
-  call $~lib/math/NativeMath.asin
-  f64.const nan:0x8000000000000
-  f64.const 0
-  call $std/math/check<f64>
-  if (result i32)
-   f64.const -8.38143342755525
-   call $~lib/bindings/dom/Math.asin
-   f64.const nan:0x8000000000000
-   f64.const 0
-   call $std/math/check<f64>
-  else
-   i32.const 0
-  end
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 418
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const -6.531673581913484
-  call $~lib/math/NativeMath.asin
-  f64.const nan:0x8000000000000
-  f64.const 0
-  call $std/math/check<f64>
-  if (result i32)
-   f64.const -6.531673581913484
-   call $~lib/bindings/dom/Math.asin
-   f64.const nan:0x8000000000000
-   f64.const 0
-   call $std/math/check<f64>
-  else
-   i32.const 0
-  end
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 419
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const 9.267056966972586
-  call $~lib/math/NativeMath.asin
-  f64.const nan:0x8000000000000
-  f64.const 0
-  call $std/math/check<f64>
-  if (result i32)
-   f64.const 9.267056966972586
-   call $~lib/bindings/dom/Math.asin
-   f64.const nan:0x8000000000000
-   f64.const 0
-   call $std/math/check<f64>
-  else
-   i32.const 0
-  end
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 420
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
   f64.const 0.6619858980995045
-  call $~lib/math/NativeMath.asin
+  call $~lib/util/math/asin64
   f64.const 0.7234652439515459
   f64.const -0.13599912822246552
   call $std/math/check<f64>
@@ -14955,13 +14243,13 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 421
+   i32.const 418
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f64.const -0.4066039223853553
-  call $~lib/math/NativeMath.asin
+  call $~lib/util/math/asin64
   f64.const -0.41873374429377225
   f64.const -0.09264230728149414
   call $std/math/check<f64>
@@ -14978,13 +14266,13 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 422
+   i32.const 419
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f64.const 0.5617597462207241
-  call $~lib/math/NativeMath.asin
+  call $~lib/util/math/asin64
   f64.const 0.5965113622274062
   f64.const -0.10864213854074478
   call $std/math/check<f64>
@@ -15001,13 +14289,13 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 423
+   i32.const 420
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f64.const 0.7741522965913037
-  call $~lib/math/NativeMath.asin
+  call $~lib/util/math/asin64
   f64.const 0.8853748109312743
   f64.const -0.4256366193294525
   call $std/math/check<f64>
@@ -15024,13 +14312,13 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 424
+   i32.const 421
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f64.const -0.6787637026394024
-  call $~lib/math/NativeMath.asin
+  call $~lib/util/math/asin64
   f64.const -0.7460778114110673
   f64.const 0.13986606895923615
   call $std/math/check<f64>
@@ -15047,13 +14335,13 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 425
+   i32.const 422
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f64.const 1
-  call $~lib/math/NativeMath.asin
+  call $~lib/util/math/asin64
   f64.const 1.5707963267948966
   f64.const -0.27576595544815063
   call $std/math/check<f64>
@@ -15070,13 +14358,13 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 428
+   i32.const 425
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f64.const -1
-  call $~lib/math/NativeMath.asin
+  call $~lib/util/math/asin64
   f64.const -1.5707963267948966
   f64.const 0.27576595544815063
   call $std/math/check<f64>
@@ -15093,13 +14381,13 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 429
+   i32.const 426
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f64.const 0
-  call $~lib/math/NativeMath.asin
+  call $~lib/util/math/asin64
   f64.const 0
   f64.const 0
   call $std/math/check<f64>
@@ -15116,13 +14404,13 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 430
+   i32.const 427
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f64.const -0
-  call $~lib/math/NativeMath.asin
+  call $~lib/util/math/asin64
   f64.const -0
   f64.const 0
   call $std/math/check<f64>
@@ -15139,13 +14427,13 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 431
+   i32.const 428
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f64.const 1.0000000000000002
-  call $~lib/math/NativeMath.asin
+  call $~lib/util/math/asin64
   f64.const nan:0x8000000000000
   f64.const 0
   call $std/math/check<f64>
@@ -15162,13 +14450,13 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 432
+   i32.const 429
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f64.const -1.0000000000000002
-  call $~lib/math/NativeMath.asin
+  call $~lib/util/math/asin64
   f64.const nan:0x8000000000000
   f64.const 0
   call $std/math/check<f64>
@@ -15185,13 +14473,13 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 433
+   i32.const 430
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f64.const inf
-  call $~lib/math/NativeMath.asin
+  call $~lib/util/math/asin64
   f64.const nan:0x8000000000000
   f64.const 0
   call $std/math/check<f64>
@@ -15208,13 +14496,13 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 434
+   i32.const 431
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f64.const -inf
-  call $~lib/math/NativeMath.asin
+  call $~lib/util/math/asin64
   f64.const nan:0x8000000000000
   f64.const 0
   call $std/math/check<f64>
@@ -15231,13 +14519,13 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 435
+   i32.const 432
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f64.const nan:0x8000000000000
-  call $~lib/math/NativeMath.asin
+  call $~lib/util/math/asin64
   f64.const nan:0x8000000000000
   f64.const 0
   call $std/math/check<f64>
@@ -15254,13 +14542,13 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 436
+   i32.const 433
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f64.const 0.5073043929119148
-  call $~lib/math/NativeMath.asin
+  call $~lib/util/math/asin64
   f64.const 0.5320538997772349
   f64.const -0.16157317161560059
   call $std/math/check<f64>
@@ -15277,16 +14565,54 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 437
+   i32.const 434
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f32.const -8.066848754882812
-  call $~lib/math/NativeMathf.asin
   f32.const nan:0x400000
   f32.const 0
-  call $std/math/check<f32>
+  call $std/math/test_asinf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 443
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const 4.345239639282227
+  f32.const nan:0x400000
+  f32.const 0
+  call $std/math/test_asinf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 444
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const -8.381433486938477
+  f32.const nan:0x400000
+  f32.const 0
+  call $std/math/test_asinf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 445
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const -6.531673431396484
+  f32.const nan:0x400000
+  f32.const 0
+  call $std/math/test_asinf
   i32.eqz
   if
    i32.const 0
@@ -15296,11 +14622,10 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 4.345239639282227
-  call $~lib/math/NativeMathf.asin
+  f32.const 9.267057418823242
   f32.const nan:0x400000
   f32.const 0
-  call $std/math/check<f32>
+  call $std/math/test_asinf
   i32.eqz
   if
    i32.const 0
@@ -15310,11 +14635,10 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -8.381433486938477
-  call $~lib/math/NativeMathf.asin
-  f32.const nan:0x400000
-  f32.const 0
-  call $std/math/check<f32>
+  f32.const 0.6619858741760254
+  f32.const 0.7234652042388916
+  f32.const -0.1307632476091385
+  call $std/math/test_asinf
   i32.eqz
   if
    i32.const 0
@@ -15324,11 +14648,10 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -6.531673431396484
-  call $~lib/math/NativeMathf.asin
-  f32.const nan:0x400000
-  f32.const 0
-  call $std/math/check<f32>
+  f32.const -0.40660393238067627
+  f32.const -0.41873374581336975
+  f32.const 0.3161141574382782
+  call $std/math/test_asinf
   i32.eqz
   if
    i32.const 0
@@ -15338,11 +14661,10 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 9.267057418823242
-  call $~lib/math/NativeMathf.asin
-  f32.const nan:0x400000
-  f32.const 0
-  call $std/math/check<f32>
+  f32.const 0.5617597699165344
+  f32.const 0.5965113639831543
+  f32.const -0.4510819613933563
+  call $std/math/test_asinf
   i32.eqz
   if
    i32.const 0
@@ -15352,11 +14674,10 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 0.6619858741760254
-  call $~lib/math/NativeMathf.asin
-  f32.const 0.7234652042388916
-  f32.const -0.1307632476091385
-  call $std/math/check<f32>
+  f32.const 0.7741522789001465
+  f32.const 0.8853747844696045
+  f32.const 0.02493886835873127
+  call $std/math/test_asinf
   i32.eqz
   if
    i32.const 0
@@ -15366,11 +14687,10 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -0.40660393238067627
-  call $~lib/math/NativeMathf.asin
-  f32.const -0.41873374581336975
-  f32.const 0.3161141574382782
-  call $std/math/check<f32>
+  f32.const -0.6787636876106262
+  f32.const -0.7460777759552002
+  f32.const 0.2515012323856354
+  call $std/math/test_asinf
   i32.eqz
   if
    i32.const 0
@@ -15380,39 +14700,10 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 0.5617597699165344
-  call $~lib/math/NativeMathf.asin
-  f32.const 0.5965113639831543
-  f32.const -0.4510819613933563
-  call $std/math/check<f32>
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 453
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const 0.7741522789001465
-  call $~lib/math/NativeMathf.asin
-  f32.const 0.8853747844696045
-  f32.const 0.02493886835873127
-  call $std/math/check<f32>
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 454
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const -0.6787636876106262
-  call $~lib/math/NativeMathf.asin
-  f32.const -0.7460777759552002
-  f32.const 0.2515012323856354
-  call $std/math/check<f32>
+  f32.const 1
+  f32.const 1.5707963705062866
+  f32.const 0.3666777014732361
+  call $std/math/test_asinf
   i32.eqz
   if
    i32.const 0
@@ -15422,11 +14713,36 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 1
-  call $~lib/math/NativeMathf.asin
-  f32.const 1.5707963705062866
-  f32.const 0.3666777014732361
-  call $std/math/check<f32>
+  f32.const -1
+  f32.const -1.5707963705062866
+  f32.const -0.3666777014732361
+  call $std/math/test_asinf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 456
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const 0
+  f32.const 0
+  f32.const 0
+  call $std/math/test_asinf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 457
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const -0
+  f32.const -0
+  f32.const 0
+  call $std/math/test_asinf
   i32.eqz
   if
    i32.const 0
@@ -15436,11 +14752,10 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -1
-  call $~lib/math/NativeMathf.asin
-  f32.const -1.5707963705062866
-  f32.const -0.3666777014732361
-  call $std/math/check<f32>
+  f32.const 1.0000001192092896
+  f32.const nan:0x400000
+  f32.const 0
+  call $std/math/test_asinf
   i32.eqz
   if
    i32.const 0
@@ -15450,11 +14765,10 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f32.const -1.0000001192092896
+  f32.const nan:0x400000
   f32.const 0
-  call $~lib/math/NativeMathf.asin
-  f32.const 0
-  f32.const 0
-  call $std/math/check<f32>
+  call $std/math/test_asinf
   i32.eqz
   if
    i32.const 0
@@ -15464,11 +14778,10 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -0
-  call $~lib/math/NativeMathf.asin
-  f32.const -0
+  f32.const inf
+  f32.const nan:0x400000
   f32.const 0
-  call $std/math/check<f32>
+  call $std/math/test_asinf
   i32.eqz
   if
    i32.const 0
@@ -15478,11 +14791,10 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 1.0000001192092896
-  call $~lib/math/NativeMathf.asin
+  f32.const -inf
   f32.const nan:0x400000
   f32.const 0
-  call $std/math/check<f32>
+  call $std/math/test_asinf
   i32.eqz
   if
    i32.const 0
@@ -15492,11 +14804,10 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -1.0000001192092896
-  call $~lib/math/NativeMathf.asin
+  f32.const nan:0x400000
   f32.const nan:0x400000
   f32.const 0
-  call $std/math/check<f32>
+  call $std/math/test_asinf
   i32.eqz
   if
    i32.const 0
@@ -15506,58 +14817,15 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const inf
-  call $~lib/math/NativeMathf.asin
-  f32.const nan:0x400000
-  f32.const 0
-  call $std/math/check<f32>
+  f32.const 0.5004770159721375
+  f32.const 0.5241496562957764
+  f32.const -0.29427099227905273
+  call $std/math/test_asinf
   i32.eqz
   if
    i32.const 0
    i32.const 1056
    i32.const 464
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const -inf
-  call $~lib/math/NativeMathf.asin
-  f32.const nan:0x400000
-  f32.const 0
-  call $std/math/check<f32>
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 465
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const nan:0x400000
-  call $~lib/math/NativeMathf.asin
-  f32.const nan:0x400000
-  f32.const 0
-  call $std/math/check<f32>
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 466
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const 0.5004770159721375
-  call $~lib/math/NativeMathf.asin
-  f32.const 0.5241496562957764
-  f32.const -0.29427099227905273
-  call $std/math/check<f32>
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 467
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -15570,7 +14838,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 479
+   i32.const 476
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -15583,7 +14851,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 480
+   i32.const 477
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -15596,7 +14864,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 481
+   i32.const 478
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -15609,7 +14877,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 482
+   i32.const 479
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -15622,7 +14890,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 483
+   i32.const 480
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -15635,7 +14903,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 484
+   i32.const 481
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -15648,7 +14916,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 485
+   i32.const 482
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -15661,7 +14929,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 486
+   i32.const 483
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -15674,7 +14942,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 487
+   i32.const 484
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -15687,13 +14955,52 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 488
+   i32.const 485
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f64.const nan:0x8000000000000
   f64.const nan:0x8000000000000
+  f64.const 0
+  call $std/math/test_asinh
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 488
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const inf
+  f64.const inf
+  f64.const 0
+  call $std/math/test_asinh
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 489
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const -inf
+  f64.const -inf
+  f64.const 0
+  call $std/math/test_asinh
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 490
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const 0
+  f64.const 0
   f64.const 0
   call $std/math/test_asinh
   i32.eqz
@@ -15705,8 +15012,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const inf
-  f64.const inf
+  f64.const -0
+  f64.const -0
   f64.const 0
   call $std/math/test_asinh
   i32.eqz
@@ -15714,45 +15021,6 @@
    i32.const 0
    i32.const 1056
    i32.const 492
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const -inf
-  f64.const -inf
-  f64.const 0
-  call $std/math/test_asinh
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 493
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const 0
-  f64.const 0
-  f64.const 0
-  call $std/math/test_asinh
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 494
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const -0
-  f64.const -0
-  f64.const 0
-  call $std/math/test_asinh
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 495
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -15765,7 +15033,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 524
+   i32.const 521
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -15778,7 +15046,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 525
+   i32.const 522
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -15791,7 +15059,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 526
+   i32.const 523
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -15804,7 +15072,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 527
+   i32.const 524
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -15817,7 +15085,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 528
+   i32.const 525
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -15830,7 +15098,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 529
+   i32.const 526
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -15843,7 +15111,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 530
+   i32.const 527
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -15856,7 +15124,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 531
+   i32.const 528
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -15869,7 +15137,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 532
+   i32.const 529
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -15882,13 +15150,52 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 533
+   i32.const 530
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f32.const nan:0x400000
   f32.const nan:0x400000
+  f32.const 0
+  call $std/math/test_asinhf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 533
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const inf
+  f32.const inf
+  f32.const 0
+  call $std/math/test_asinhf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 534
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const -inf
+  f32.const -inf
+  f32.const 0
+  call $std/math/test_asinhf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 535
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const 0
+  f32.const 0
   f32.const 0
   call $std/math/test_asinhf
   i32.eqz
@@ -15900,8 +15207,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const inf
-  f32.const inf
+  f32.const -0
+  f32.const -0
   f32.const 0
   call $std/math/test_asinhf
   i32.eqz
@@ -15913,47 +15220,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -inf
-  f32.const -inf
-  f32.const 0
-  call $std/math/test_asinhf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 538
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const 0
-  f32.const 0
-  f32.const 0
-  call $std/math/test_asinhf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 539
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const -0
-  f32.const -0
-  f32.const 0
-  call $std/math/test_asinhf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 540
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
   f64.const -8.06684839057968
-  call $~lib/math/NativeMath.atan
+  call $~lib/util/math/atan64
   f64.const -1.4474613762633468
   f64.const 0.14857111871242523
   call $std/math/check<f64>
@@ -15970,13 +15238,13 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 552
+   i32.const 549
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f64.const 4.345239849338305
-  call $~lib/math/NativeMath.atan
+  call $~lib/util/math/atan64
   f64.const 1.344597927114538
   f64.const -0.08170335739850998
   call $std/math/check<f64>
@@ -15993,13 +15261,13 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 553
+   i32.const 550
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f64.const -8.38143342755525
-  call $~lib/math/NativeMath.atan
+  call $~lib/util/math/atan64
   f64.const -1.4520463463295539
   f64.const -0.07505480200052261
   call $std/math/check<f64>
@@ -16016,13 +15284,13 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 554
+   i32.const 551
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f64.const -6.531673581913484
-  call $~lib/math/NativeMath.atan
+  call $~lib/util/math/atan64
   f64.const -1.4188758658752532
   f64.const -0.057633496820926666
   call $std/math/check<f64>
@@ -16039,13 +15307,13 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 555
+   i32.const 552
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f64.const 9.267056966972586
-  call $~lib/math/NativeMath.atan
+  call $~lib/util/math/atan64
   f64.const 1.463303145448706
   f64.const 0.1606956422328949
   call $std/math/check<f64>
@@ -16062,13 +15330,13 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 556
+   i32.const 553
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f64.const 0.6619858980995045
-  call $~lib/math/NativeMath.atan
+  call $~lib/util/math/atan64
   f64.const 0.5847550670238325
   f64.const 0.4582556486129761
   call $std/math/check<f64>
@@ -16085,13 +15353,13 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 557
+   i32.const 554
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f64.const -0.4066039223853553
-  call $~lib/math/NativeMath.atan
+  call $~lib/util/math/atan64
   f64.const -0.3861864177552131
   f64.const -0.2574281692504883
   call $std/math/check<f64>
@@ -16108,13 +15376,13 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 558
+   i32.const 555
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f64.const 0.5617597462207241
-  call $~lib/math/NativeMath.atan
+  call $~lib/util/math/atan64
   f64.const 0.5118269531628881
   f64.const -0.11444277316331863
   call $std/math/check<f64>
@@ -16131,13 +15399,13 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 559
+   i32.const 556
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f64.const 0.7741522965913037
-  call $~lib/math/NativeMath.atan
+  call $~lib/util/math/atan64
   f64.const 0.6587802431653822
   f64.const -0.11286488175392151
   call $std/math/check<f64>
@@ -16154,13 +15422,13 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 560
+   i32.const 557
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f64.const -0.6787637026394024
-  call $~lib/math/NativeMath.atan
+  call $~lib/util/math/atan64
   f64.const -0.5963307826973472
   f64.const -0.2182842344045639
   call $std/math/check<f64>
@@ -16177,36 +15445,36 @@
   if
    i32.const 0
    i32.const 1056
+   i32.const 558
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const 0
+  call $~lib/util/math/atan64
+  f64.const 0
+  f64.const 0
+  call $std/math/check<f64>
+  if (result i32)
+   f64.const 0
+   call $~lib/bindings/dom/Math.atan
+   f64.const 0
+   f64.const 0
+   call $std/math/check<f64>
+  else
+   i32.const 0
+  end
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1056
    i32.const 561
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 0
-  call $~lib/math/NativeMath.atan
-  f64.const 0
-  f64.const 0
-  call $std/math/check<f64>
-  if (result i32)
-   f64.const 0
-   call $~lib/bindings/dom/Math.atan
-   f64.const 0
-   f64.const 0
-   call $std/math/check<f64>
-  else
-   i32.const 0
-  end
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 564
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
   f64.const -0
-  call $~lib/math/NativeMath.atan
+  call $~lib/util/math/atan64
   f64.const -0
   f64.const 0
   call $std/math/check<f64>
@@ -16223,13 +15491,13 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 565
+   i32.const 562
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f64.const 1
-  call $~lib/math/NativeMath.atan
+  call $~lib/util/math/atan64
   f64.const 0.7853981633974483
   f64.const -0.27576595544815063
   call $std/math/check<f64>
@@ -16246,13 +15514,13 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 566
+   i32.const 563
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f64.const -1
-  call $~lib/math/NativeMath.atan
+  call $~lib/util/math/atan64
   f64.const -0.7853981633974483
   f64.const 0.27576595544815063
   call $std/math/check<f64>
@@ -16269,13 +15537,13 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 567
+   i32.const 564
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f64.const inf
-  call $~lib/math/NativeMath.atan
+  call $~lib/util/math/atan64
   f64.const 1.5707963267948966
   f64.const -0.27576595544815063
   call $std/math/check<f64>
@@ -16292,13 +15560,13 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 568
+   i32.const 565
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f64.const -inf
-  call $~lib/math/NativeMath.atan
+  call $~lib/util/math/atan64
   f64.const -1.5707963267948966
   f64.const 0.27576595544815063
   call $std/math/check<f64>
@@ -16315,13 +15583,13 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 569
+   i32.const 566
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f64.const nan:0x8000000000000
-  call $~lib/math/NativeMath.atan
+  call $~lib/util/math/atan64
   f64.const nan:0x8000000000000
   f64.const 0
   call $std/math/check<f64>
@@ -16338,13 +15606,13 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 570
+   i32.const 567
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f64.const 0.6929821535674624
-  call $~lib/math/NativeMath.atan
+  call $~lib/util/math/atan64
   f64.const 0.6060004555152562
   f64.const -0.17075790464878082
   call $std/math/check<f64>
@@ -16361,15 +15629,57 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 571
+   i32.const 568
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f32.const -8.066848754882812
-  call $~lib/math/NativeMathf.atan
+  call $~lib/util/math/atan32
   f32.const -1.4474613666534424
   f32.const 0.12686480581760406
+  call $std/math/check<f32>
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 577
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const 4.345239639282227
+  call $~lib/util/math/atan32
+  f32.const 1.3445979356765747
+  f32.const 0.16045434772968292
+  call $std/math/check<f32>
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 578
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const -8.381433486938477
+  call $~lib/util/math/atan32
+  f32.const -1.4520463943481445
+  f32.const -0.39581751823425293
+  call $std/math/check<f32>
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 579
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const -6.531673431396484
+  call $~lib/util/math/atan32
+  f32.const -1.418875813484192
+  f32.const 0.410570353269577
   call $std/math/check<f32>
   i32.eqz
   if
@@ -16380,10 +15690,10 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 4.345239639282227
-  call $~lib/math/NativeMathf.atan
-  f32.const 1.3445979356765747
-  f32.const 0.16045434772968292
+  f32.const 9.267057418823242
+  call $~lib/util/math/atan32
+  f32.const 1.4633032083511353
+  f32.const 0.48403501510620117
   call $std/math/check<f32>
   i32.eqz
   if
@@ -16394,10 +15704,10 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -8.381433486938477
-  call $~lib/math/NativeMathf.atan
-  f32.const -1.4520463943481445
-  f32.const -0.39581751823425293
+  f32.const 0.6619858741760254
+  call $~lib/util/math/atan32
+  f32.const 0.5847550630569458
+  f32.const 0.2125193476676941
   call $std/math/check<f32>
   i32.eqz
   if
@@ -16408,10 +15718,10 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -6.531673431396484
-  call $~lib/math/NativeMathf.atan
-  f32.const -1.418875813484192
-  f32.const 0.410570353269577
+  f32.const -0.40660393238067627
+  call $~lib/util/math/atan32
+  f32.const -0.386186420917511
+  f32.const 0.18169628083705902
   call $std/math/check<f32>
   i32.eqz
   if
@@ -16422,10 +15732,10 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 9.267057418823242
-  call $~lib/math/NativeMathf.atan
-  f32.const 1.4633032083511353
-  f32.const 0.48403501510620117
+  f32.const 0.5617597699165344
+  call $~lib/util/math/atan32
+  f32.const 0.5118269920349121
+  f32.const 0.3499770760536194
   call $std/math/check<f32>
   i32.eqz
   if
@@ -16436,10 +15746,10 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 0.6619858741760254
-  call $~lib/math/NativeMathf.atan
-  f32.const 0.5847550630569458
-  f32.const 0.2125193476676941
+  f32.const 0.7741522789001465
+  call $~lib/util/math/atan32
+  f32.const 0.6587802171707153
+  f32.const -0.2505330741405487
   call $std/math/check<f32>
   i32.eqz
   if
@@ -16450,10 +15760,10 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -0.40660393238067627
-  call $~lib/math/NativeMathf.atan
-  f32.const -0.386186420917511
-  f32.const 0.18169628083705902
+  f32.const -0.6787636876106262
+  call $~lib/util/math/atan32
+  f32.const -0.5963307619094849
+  f32.const 0.17614826560020447
   call $std/math/check<f32>
   i32.eqz
   if
@@ -16464,38 +15774,10 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 0.5617597699165344
-  call $~lib/math/NativeMathf.atan
-  f32.const 0.5118269920349121
-  f32.const 0.3499770760536194
-  call $std/math/check<f32>
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 587
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const 0.7741522789001465
-  call $~lib/math/NativeMathf.atan
-  f32.const 0.6587802171707153
-  f32.const -0.2505330741405487
-  call $std/math/check<f32>
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 588
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const -0.6787636876106262
-  call $~lib/math/NativeMathf.atan
-  f32.const -0.5963307619094849
-  f32.const 0.17614826560020447
+  f32.const 0
+  call $~lib/util/math/atan32
+  f32.const 0
+  f32.const 0
   call $std/math/check<f32>
   i32.eqz
   if
@@ -16506,10 +15788,38 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f32.const -0
+  call $~lib/util/math/atan32
+  f32.const -0
   f32.const 0
-  call $~lib/math/NativeMathf.atan
-  f32.const 0
-  f32.const 0
+  call $std/math/check<f32>
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 590
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const 1
+  call $~lib/util/math/atan32
+  f32.const 0.7853981852531433
+  f32.const 0.3666777014732361
+  call $std/math/check<f32>
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 591
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const -1
+  call $~lib/util/math/atan32
+  f32.const -0.7853981852531433
+  f32.const -0.3666777014732361
   call $std/math/check<f32>
   i32.eqz
   if
@@ -16520,10 +15830,10 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -0
-  call $~lib/math/NativeMathf.atan
-  f32.const -0
-  f32.const 0
+  f32.const inf
+  call $~lib/util/math/atan32
+  f32.const 1.5707963705062866
+  f32.const 0.3666777014732361
   call $std/math/check<f32>
   i32.eqz
   if
@@ -16534,10 +15844,10 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 1
-  call $~lib/math/NativeMathf.atan
-  f32.const 0.7853981852531433
-  f32.const 0.3666777014732361
+  f32.const -inf
+  call $~lib/util/math/atan32
+  f32.const -1.5707963705062866
+  f32.const -0.3666777014732361
   call $std/math/check<f32>
   i32.eqz
   if
@@ -16548,50 +15858,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -1
-  call $~lib/math/NativeMathf.atan
-  f32.const -0.7853981852531433
-  f32.const -0.3666777014732361
-  call $std/math/check<f32>
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 595
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const inf
-  call $~lib/math/NativeMathf.atan
-  f32.const 1.5707963705062866
-  f32.const 0.3666777014732361
-  call $std/math/check<f32>
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 596
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const -inf
-  call $~lib/math/NativeMathf.atan
-  f32.const -1.5707963705062866
-  f32.const -0.3666777014732361
-  call $std/math/check<f32>
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 597
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
   f32.const nan:0x400000
-  call $~lib/math/NativeMathf.atan
+  call $~lib/util/math/atan32
   f32.const nan:0x400000
   f32.const 0
   call $std/math/check<f32>
@@ -16599,7 +15867,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 598
+   i32.const 595
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -16612,7 +15880,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 610
+   i32.const 607
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -16625,7 +15893,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 611
+   i32.const 608
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -16638,7 +15906,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 612
+   i32.const 609
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -16651,7 +15919,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 613
+   i32.const 610
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -16664,7 +15932,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 614
+   i32.const 611
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -16677,7 +15945,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 615
+   i32.const 612
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -16690,7 +15958,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 616
+   i32.const 613
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -16703,7 +15971,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 617
+   i32.const 614
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -16716,7 +15984,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 618
+   i32.const 615
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -16729,7 +15997,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 619
+   i32.const 616
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -16742,7 +16010,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 622
+   i32.const 619
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -16755,7 +16023,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 623
+   i32.const 620
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -16768,7 +16036,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 624
+   i32.const 621
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -16781,7 +16049,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 625
+   i32.const 622
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -16794,7 +16062,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 626
+   i32.const 623
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -16807,7 +16075,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 627
+   i32.const 624
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -16820,7 +16088,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 628
+   i32.const 625
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -16833,7 +16101,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 629
+   i32.const 626
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -16846,13 +16114,52 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 630
+   i32.const 627
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f64.const 1.3552527156068805e-20
   f64.const 1.3552527156068805e-20
+  f64.const 0
+  call $std/math/test_atanh
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 628
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const 9.332636185032189e-302
+  f64.const 9.332636185032189e-302
+  f64.const 0
+  call $std/math/test_atanh
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 629
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const 5.562684646268003e-309
+  f64.const 5.562684646268003e-309
+  f64.const 0
+  call $std/math/test_atanh
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 630
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const -5.562684646268003e-309
+  f64.const -5.562684646268003e-309
   f64.const 0
   call $std/math/test_atanh
   i32.eqz
@@ -16860,45 +16167,6 @@
    i32.const 0
    i32.const 1056
    i32.const 631
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const 9.332636185032189e-302
-  f64.const 9.332636185032189e-302
-  f64.const 0
-  call $std/math/test_atanh
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 632
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const 5.562684646268003e-309
-  f64.const 5.562684646268003e-309
-  f64.const 0
-  call $std/math/test_atanh
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 633
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const -5.562684646268003e-309
-  f64.const -5.562684646268003e-309
-  f64.const 0
-  call $std/math/test_atanh
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 634
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -16911,7 +16179,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 635
+   i32.const 632
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -16924,7 +16192,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 644
+   i32.const 641
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -16937,7 +16205,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 645
+   i32.const 642
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -16950,7 +16218,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 646
+   i32.const 643
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -16963,7 +16231,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 647
+   i32.const 644
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -16976,7 +16244,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 648
+   i32.const 645
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -16989,7 +16257,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 649
+   i32.const 646
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -17002,7 +16270,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 650
+   i32.const 647
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -17015,7 +16283,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 651
+   i32.const 648
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -17028,7 +16296,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 652
+   i32.const 649
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -17041,7 +16309,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 653
+   i32.const 650
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -17054,7 +16322,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 656
+   i32.const 653
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -17067,7 +16335,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 657
+   i32.const 654
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -17080,7 +16348,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 658
+   i32.const 655
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -17093,7 +16361,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 659
+   i32.const 656
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -17106,7 +16374,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 660
+   i32.const 657
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -17119,7 +16387,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 661
+   i32.const 658
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -17132,7 +16400,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 662
+   i32.const 659
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -17145,7 +16413,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 663
+   i32.const 660
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -17158,13 +16426,52 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 664
+   i32.const 661
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f32.const 1.3552527156068805e-20
   f32.const 1.3552527156068805e-20
+  f32.const 0
+  call $std/math/test_atanhf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 662
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const 7.888609052210118e-31
+  f32.const 7.888609052210118e-31
+  f32.const 0
+  call $std/math/test_atanhf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 663
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const 2.938735877055719e-39
+  f32.const 2.938735877055719e-39
+  f32.const 0
+  call $std/math/test_atanhf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 664
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const -2.938735877055719e-39
+  f32.const -2.938735877055719e-39
   f32.const 0
   call $std/math/test_atanhf
   i32.eqz
@@ -17172,45 +16479,6 @@
    i32.const 0
    i32.const 1056
    i32.const 665
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const 7.888609052210118e-31
-  f32.const 7.888609052210118e-31
-  f32.const 0
-  call $std/math/test_atanhf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 666
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const 2.938735877055719e-39
-  f32.const 2.938735877055719e-39
-  f32.const 0
-  call $std/math/test_atanhf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 667
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const -2.938735877055719e-39
-  f32.const -2.938735877055719e-39
-  f32.const 0
-  call $std/math/test_atanhf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 668
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -17223,7 +16491,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 669
+   i32.const 666
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -17237,7 +16505,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 681
+   i32.const 678
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -17251,7 +16519,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 682
+   i32.const 679
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -17265,7 +16533,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 683
+   i32.const 680
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -17279,7 +16547,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 684
+   i32.const 681
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -17293,7 +16561,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 685
+   i32.const 682
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -17307,7 +16575,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 686
+   i32.const 683
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -17321,7 +16589,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 687
+   i32.const 684
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -17335,7 +16603,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 688
+   i32.const 685
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -17349,7 +16617,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 689
+   i32.const 686
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -17363,7 +16631,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 690
+   i32.const 687
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -17372,6 +16640,48 @@
   f64.const 0
   f64.const 0
   f64.const 0
+  call $std/math/test_atan2
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 690
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const 0
+  f64.const -0
+  f64.const 3.141592653589793
+  f64.const -0.27576595544815063
+  call $std/math/test_atan2
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 691
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const 0
+  f64.const -1
+  f64.const 3.141592653589793
+  f64.const -0.27576595544815063
+  call $std/math/test_atan2
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 692
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const 0
+  f64.const -inf
+  f64.const 3.141592653589793
+  f64.const -0.27576595544815063
   call $std/math/test_atan2
   i32.eqz
   if
@@ -17383,9 +16693,9 @@
    unreachable
   end
   f64.const 0
-  f64.const -0
-  f64.const 3.141592653589793
-  f64.const -0.27576595544815063
+  f64.const 1
+  f64.const 0
+  f64.const 0
   call $std/math/test_atan2
   i32.eqz
   if
@@ -17397,9 +16707,9 @@
    unreachable
   end
   f64.const 0
-  f64.const -1
-  f64.const 3.141592653589793
-  f64.const -0.27576595544815063
+  f64.const inf
+  f64.const 0
+  f64.const 0
   call $std/math/test_atan2
   i32.eqz
   if
@@ -17410,10 +16720,10 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f64.const -0
   f64.const 0
-  f64.const -inf
-  f64.const 3.141592653589793
-  f64.const -0.27576595544815063
+  f64.const -0
+  f64.const 0
   call $std/math/test_atan2
   i32.eqz
   if
@@ -17424,10 +16734,10 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 0
-  f64.const 1
-  f64.const 0
-  f64.const 0
+  f64.const -0
+  f64.const -0
+  f64.const -3.141592653589793
+  f64.const 0.27576595544815063
   call $std/math/test_atan2
   i32.eqz
   if
@@ -17438,10 +16748,10 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 0
-  f64.const inf
-  f64.const 0
-  f64.const 0
+  f64.const -0
+  f64.const -1
+  f64.const -3.141592653589793
+  f64.const 0.27576595544815063
   call $std/math/test_atan2
   i32.eqz
   if
@@ -17453,9 +16763,9 @@
    unreachable
   end
   f64.const -0
-  f64.const 0
-  f64.const -0
-  f64.const 0
+  f64.const -inf
+  f64.const -3.141592653589793
+  f64.const 0.27576595544815063
   call $std/math/test_atan2
   i32.eqz
   if
@@ -17467,9 +16777,9 @@
    unreachable
   end
   f64.const -0
+  f64.const 1
   f64.const -0
-  f64.const -3.141592653589793
-  f64.const 0.27576595544815063
+  f64.const 0
   call $std/math/test_atan2
   i32.eqz
   if
@@ -17481,9 +16791,9 @@
    unreachable
   end
   f64.const -0
-  f64.const -1
-  f64.const -3.141592653589793
-  f64.const 0.27576595544815063
+  f64.const inf
+  f64.const -0
+  f64.const 0
   call $std/math/test_atan2
   i32.eqz
   if
@@ -17494,9 +16804,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -0
-  f64.const -inf
-  f64.const -3.141592653589793
+  f64.const -1
+  f64.const 0
+  f64.const -1.5707963267948966
   f64.const 0.27576595544815063
   call $std/math/test_atan2
   i32.eqz
@@ -17508,10 +16818,10 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f64.const -1
   f64.const -0
-  f64.const 1
-  f64.const -0
-  f64.const 0
+  f64.const -1.5707963267948966
+  f64.const 0.27576595544815063
   call $std/math/test_atan2
   i32.eqz
   if
@@ -17522,10 +16832,10 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -0
-  f64.const inf
-  f64.const -0
+  f64.const 1
   f64.const 0
+  f64.const 1.5707963267948966
+  f64.const -0.27576595544815063
   call $std/math/test_atan2
   i32.eqz
   if
@@ -17536,10 +16846,10 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -1
-  f64.const 0
-  f64.const -1.5707963267948966
-  f64.const 0.27576595544815063
+  f64.const 1
+  f64.const -0
+  f64.const 1.5707963267948966
+  f64.const -0.27576595544815063
   call $std/math/test_atan2
   i32.eqz
   if
@@ -17551,9 +16861,9 @@
    unreachable
   end
   f64.const -1
+  f64.const inf
   f64.const -0
-  f64.const -1.5707963267948966
-  f64.const 0.27576595544815063
+  f64.const 0
   call $std/math/test_atan2
   i32.eqz
   if
@@ -17565,57 +16875,15 @@
    unreachable
   end
   f64.const 1
+  f64.const inf
   f64.const 0
-  f64.const 1.5707963267948966
-  f64.const -0.27576595544815063
+  f64.const 0
   call $std/math/test_atan2
   i32.eqz
   if
    i32.const 0
    i32.const 1056
    i32.const 707
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const 1
-  f64.const -0
-  f64.const 1.5707963267948966
-  f64.const -0.27576595544815063
-  call $std/math/test_atan2
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 708
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const -1
-  f64.const inf
-  f64.const -0
-  f64.const 0
-  call $std/math/test_atan2
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 709
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const 1
-  f64.const inf
-  f64.const 0
-  f64.const 0
-  call $std/math/test_atan2
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 710
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -17629,7 +16897,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 711
+   i32.const 708
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -17643,7 +16911,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 712
+   i32.const 709
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -17657,7 +16925,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 713
+   i32.const 710
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -17671,7 +16939,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 714
+   i32.const 711
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -17685,7 +16953,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 715
+   i32.const 712
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -17699,7 +16967,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 716
+   i32.const 713
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -17713,7 +16981,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 717
+   i32.const 714
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -17727,7 +16995,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 718
+   i32.const 715
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -17741,7 +17009,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 719
+   i32.const 716
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -17755,7 +17023,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 720
+   i32.const 717
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -17769,7 +17037,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 721
+   i32.const 718
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -17783,17 +17051,58 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 722
+   i32.const 719
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f32.const -8.066848754882812
   f32.const 4.535662651062012
-  call $~lib/math/NativeMathf.atan2
   f32.const -1.0585895776748657
   f32.const -0.22352588176727295
-  call $std/math/check<f32>
+  call $std/math/test_atan2f
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 728
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const 4.345239639282227
+  f32.const -8.887990951538086
+  f32.const 2.686873435974121
+  f32.const 0.09464472532272339
+  call $std/math/test_atan2f
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 729
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const -8.381433486938477
+  f32.const -2.7636072635650635
+  f32.const -1.8893001079559326
+  f32.const -0.21941901743412018
+  call $std/math/test_atan2f
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 730
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const -6.531673431396484
+  f32.const 4.567535400390625
+  f32.const -0.9605468511581421
+  f32.const 0.46015575528144836
+  call $std/math/test_atan2f
   i32.eqz
   if
    i32.const 0
@@ -17803,12 +17112,11 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 4.345239639282227
-  f32.const -8.887990951538086
-  call $~lib/math/NativeMathf.atan2
-  f32.const 2.686873435974121
-  f32.const 0.09464472532272339
-  call $std/math/check<f32>
+  f32.const 9.267057418823242
+  f32.const 4.811392307281494
+  f32.const 1.0919123888015747
+  f32.const -0.05708503723144531
+  call $std/math/test_atan2f
   i32.eqz
   if
    i32.const 0
@@ -17818,12 +17126,11 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -8.381433486938477
-  f32.const -2.7636072635650635
-  call $~lib/math/NativeMathf.atan2
-  f32.const -1.8893001079559326
-  f32.const -0.21941901743412018
-  call $std/math/check<f32>
+  f32.const -6.450045585632324
+  f32.const 0.6620717644691467
+  f32.const -1.4685084819793701
+  f32.const 0.19611206650733948
+  call $std/math/test_atan2f
   i32.eqz
   if
    i32.const 0
@@ -17833,12 +17140,11 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -6.531673431396484
-  f32.const 4.567535400390625
-  call $~lib/math/NativeMathf.atan2
-  f32.const -0.9605468511581421
-  f32.const 0.46015575528144836
-  call $std/math/check<f32>
+  f32.const 7.858890056610107
+  f32.const 0.052154526114463806
+  f32.const 1.5641601085662842
+  f32.const 0.48143187165260315
+  call $std/math/test_atan2f
   i32.eqz
   if
    i32.const 0
@@ -17848,12 +17154,11 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 9.267057418823242
-  f32.const 4.811392307281494
-  call $~lib/math/NativeMathf.atan2
-  f32.const 1.0919123888015747
-  f32.const -0.05708503723144531
-  call $std/math/check<f32>
+  f32.const -0.7920545339584351
+  f32.const 7.676402568817139
+  f32.const -0.10281659662723541
+  f32.const -0.4216274917125702
+  call $std/math/test_atan2f
   i32.eqz
   if
    i32.const 0
@@ -17863,12 +17168,11 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -6.450045585632324
-  f32.const 0.6620717644691467
-  call $~lib/math/NativeMathf.atan2
-  f32.const -1.4685084819793701
-  f32.const 0.19611206650733948
-  call $std/math/check<f32>
+  f32.const 0.6157026886940002
+  f32.const 2.0119025707244873
+  f32.const 0.29697975516319275
+  f32.const 0.2322007566690445
+  call $std/math/test_atan2f
   i32.eqz
   if
    i32.const 0
@@ -17878,12 +17182,11 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 7.858890056610107
-  f32.const 0.052154526114463806
-  call $~lib/math/NativeMathf.atan2
-  f32.const 1.5641601085662842
-  f32.const 0.48143187165260315
-  call $std/math/check<f32>
+  f32.const -0.5587586760520935
+  f32.const 0.03223983198404312
+  f32.const -1.5131611824035645
+  f32.const 0.16620726883411407
+  call $std/math/test_atan2f
   i32.eqz
   if
    i32.const 0
@@ -17893,42 +17196,11 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -0.7920545339584351
-  f32.const 7.676402568817139
-  call $~lib/math/NativeMathf.atan2
-  f32.const -0.10281659662723541
-  f32.const -0.4216274917125702
-  call $std/math/check<f32>
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 738
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const 0.6157026886940002
-  f32.const 2.0119025707244873
-  call $~lib/math/NativeMathf.atan2
-  f32.const 0.29697975516319275
-  f32.const 0.2322007566690445
-  call $std/math/check<f32>
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 739
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const -0.5587586760520935
-  f32.const 0.03223983198404312
-  call $~lib/math/NativeMathf.atan2
-  f32.const -1.5131611824035645
-  f32.const 0.16620726883411407
-  call $std/math/check<f32>
+  f32.const 0
+  f32.const 0
+  f32.const 0
+  f32.const 0
+  call $std/math/test_atan2f
   i32.eqz
   if
    i32.const 0
@@ -17939,11 +17211,38 @@
    unreachable
   end
   f32.const 0
+  f32.const -0
+  f32.const 3.1415927410125732
+  f32.const 0.3666777014732361
+  call $std/math/test_atan2f
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 741
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
   f32.const 0
-  call $~lib/math/NativeMathf.atan2
+  f32.const -1
+  f32.const 3.1415927410125732
+  f32.const 0.3666777014732361
+  call $std/math/test_atan2f
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 742
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
   f32.const 0
-  f32.const 0
-  call $std/math/check<f32>
+  f32.const -inf
+  f32.const 3.1415927410125732
+  f32.const 0.3666777014732361
+  call $std/math/test_atan2f
   i32.eqz
   if
    i32.const 0
@@ -17954,11 +17253,10 @@
    unreachable
   end
   f32.const 0
-  f32.const -0
-  call $~lib/math/NativeMathf.atan2
-  f32.const 3.1415927410125732
-  f32.const 0.3666777014732361
-  call $std/math/check<f32>
+  f32.const 1
+  f32.const 0
+  f32.const 0
+  call $std/math/test_atan2f
   i32.eqz
   if
    i32.const 0
@@ -17969,11 +17267,10 @@
    unreachable
   end
   f32.const 0
-  f32.const -1
-  call $~lib/math/NativeMathf.atan2
-  f32.const 3.1415927410125732
-  f32.const 0.3666777014732361
-  call $std/math/check<f32>
+  f32.const inf
+  f32.const 0
+  f32.const 0
+  call $std/math/test_atan2f
   i32.eqz
   if
    i32.const 0
@@ -17983,12 +17280,11 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f32.const -0
   f32.const 0
-  f32.const -inf
-  call $~lib/math/NativeMathf.atan2
-  f32.const 3.1415927410125732
-  f32.const 0.3666777014732361
-  call $std/math/check<f32>
+  f32.const -0
+  f32.const 0
+  call $std/math/test_atan2f
   i32.eqz
   if
    i32.const 0
@@ -17998,12 +17294,11 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 0
-  f32.const 1
-  call $~lib/math/NativeMathf.atan2
-  f32.const 0
-  f32.const 0
-  call $std/math/check<f32>
+  f32.const -0
+  f32.const -0
+  f32.const -3.1415927410125732
+  f32.const -0.3666777014732361
+  call $std/math/test_atan2f
   i32.eqz
   if
    i32.const 0
@@ -18013,12 +17308,11 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 0
-  f32.const inf
-  call $~lib/math/NativeMathf.atan2
-  f32.const 0
-  f32.const 0
-  call $std/math/check<f32>
+  f32.const -0
+  f32.const -1
+  f32.const -3.1415927410125732
+  f32.const -0.3666777014732361
+  call $std/math/test_atan2f
   i32.eqz
   if
    i32.const 0
@@ -18029,11 +17323,10 @@
    unreachable
   end
   f32.const -0
-  f32.const 0
-  call $~lib/math/NativeMathf.atan2
-  f32.const -0
-  f32.const 0
-  call $std/math/check<f32>
+  f32.const -inf
+  f32.const -3.1415927410125732
+  f32.const -0.3666777014732361
+  call $std/math/test_atan2f
   i32.eqz
   if
    i32.const 0
@@ -18044,11 +17337,10 @@
    unreachable
   end
   f32.const -0
+  f32.const 1
   f32.const -0
-  call $~lib/math/NativeMathf.atan2
-  f32.const -3.1415927410125732
-  f32.const -0.3666777014732361
-  call $std/math/check<f32>
+  f32.const 0
+  call $std/math/test_atan2f
   i32.eqz
   if
    i32.const 0
@@ -18059,11 +17351,10 @@
    unreachable
   end
   f32.const -0
-  f32.const -1
-  call $~lib/math/NativeMathf.atan2
-  f32.const -3.1415927410125732
-  f32.const -0.3666777014732361
-  call $std/math/check<f32>
+  f32.const inf
+  f32.const -0
+  f32.const 0
+  call $std/math/test_atan2f
   i32.eqz
   if
    i32.const 0
@@ -18073,12 +17364,11 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -0
-  f32.const -inf
-  call $~lib/math/NativeMathf.atan2
-  f32.const -3.1415927410125732
+  f32.const -1
+  f32.const 0
+  f32.const -1.5707963705062866
   f32.const -0.3666777014732361
-  call $std/math/check<f32>
+  call $std/math/test_atan2f
   i32.eqz
   if
    i32.const 0
@@ -18088,12 +17378,11 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f32.const -1
   f32.const -0
-  f32.const 1
-  call $~lib/math/NativeMathf.atan2
-  f32.const -0
-  f32.const 0
-  call $std/math/check<f32>
+  f32.const -1.5707963705062866
+  f32.const -0.3666777014732361
+  call $std/math/test_atan2f
   i32.eqz
   if
    i32.const 0
@@ -18103,12 +17392,11 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -0
-  f32.const inf
-  call $~lib/math/NativeMathf.atan2
-  f32.const -0
+  f32.const 1
   f32.const 0
-  call $std/math/check<f32>
+  f32.const 1.5707963705062866
+  f32.const 0.3666777014732361
+  call $std/math/test_atan2f
   i32.eqz
   if
    i32.const 0
@@ -18118,12 +17406,11 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -1
-  f32.const 0
-  call $~lib/math/NativeMathf.atan2
-  f32.const -1.5707963705062866
-  f32.const -0.3666777014732361
-  call $std/math/check<f32>
+  f32.const 1
+  f32.const -0
+  f32.const 1.5707963705062866
+  f32.const 0.3666777014732361
+  call $std/math/test_atan2f
   i32.eqz
   if
    i32.const 0
@@ -18134,11 +17421,10 @@
    unreachable
   end
   f32.const -1
+  f32.const inf
   f32.const -0
-  call $~lib/math/NativeMathf.atan2
-  f32.const -1.5707963705062866
-  f32.const -0.3666777014732361
-  call $std/math/check<f32>
+  f32.const 0
+  call $std/math/test_atan2f
   i32.eqz
   if
    i32.const 0
@@ -18149,11 +17435,10 @@
    unreachable
   end
   f32.const 1
+  f32.const inf
   f32.const 0
-  call $~lib/math/NativeMathf.atan2
-  f32.const 1.5707963705062866
-  f32.const 0.3666777014732361
-  call $std/math/check<f32>
+  f32.const 0
+  call $std/math/test_atan2f
   i32.eqz
   if
    i32.const 0
@@ -18163,12 +17448,11 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 1
-  f32.const -0
-  call $~lib/math/NativeMathf.atan2
-  f32.const 1.5707963705062866
-  f32.const 0.3666777014732361
-  call $std/math/check<f32>
+  f32.const -1
+  f32.const -inf
+  f32.const -3.1415927410125732
+  f32.const -0.3666777014732361
+  call $std/math/test_atan2f
   i32.eqz
   if
    i32.const 0
@@ -18178,12 +17462,11 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -1
-  f32.const inf
-  call $~lib/math/NativeMathf.atan2
-  f32.const -0
-  f32.const 0
-  call $std/math/check<f32>
+  f32.const 1
+  f32.const -inf
+  f32.const 3.1415927410125732
+  f32.const 0.3666777014732361
+  call $std/math/test_atan2f
   i32.eqz
   if
    i32.const 0
@@ -18193,12 +17476,11 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 1
   f32.const inf
-  call $~lib/math/NativeMathf.atan2
   f32.const 0
-  f32.const 0
-  call $std/math/check<f32>
+  f32.const 1.5707963705062866
+  f32.const 0.3666777014732361
+  call $std/math/test_atan2f
   i32.eqz
   if
    i32.const 0
@@ -18208,12 +17490,11 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -1
   f32.const -inf
-  call $~lib/math/NativeMathf.atan2
-  f32.const -3.1415927410125732
+  f32.const 0
+  f32.const -1.5707963705062866
   f32.const -0.3666777014732361
-  call $std/math/check<f32>
+  call $std/math/test_atan2f
   i32.eqz
   if
    i32.const 0
@@ -18223,12 +17504,11 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 1
-  f32.const -inf
-  call $~lib/math/NativeMathf.atan2
-  f32.const 3.1415927410125732
+  f32.const inf
+  f32.const inf
+  f32.const 0.7853981852531433
   f32.const 0.3666777014732361
-  call $std/math/check<f32>
+  call $std/math/test_atan2f
   i32.eqz
   if
    i32.const 0
@@ -18239,11 +17519,10 @@
    unreachable
   end
   f32.const inf
-  f32.const 0
-  call $~lib/math/NativeMathf.atan2
-  f32.const 1.5707963705062866
-  f32.const 0.3666777014732361
-  call $std/math/check<f32>
+  f32.const -inf
+  f32.const 2.356194496154785
+  f32.const 0.02500828728079796
+  call $std/math/test_atan2f
   i32.eqz
   if
    i32.const 0
@@ -18254,11 +17533,10 @@
    unreachable
   end
   f32.const -inf
-  f32.const 0
-  call $~lib/math/NativeMathf.atan2
-  f32.const -1.5707963705062866
+  f32.const inf
+  f32.const -0.7853981852531433
   f32.const -0.3666777014732361
-  call $std/math/check<f32>
+  call $std/math/test_atan2f
   i32.eqz
   if
    i32.const 0
@@ -18268,12 +17546,11 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const inf
-  f32.const inf
-  call $~lib/math/NativeMathf.atan2
-  f32.const 0.7853981852531433
-  f32.const 0.3666777014732361
-  call $std/math/check<f32>
+  f32.const -inf
+  f32.const -inf
+  f32.const -2.356194496154785
+  f32.const -0.02500828728079796
+  call $std/math/test_atan2f
   i32.eqz
   if
    i32.const 0
@@ -18283,12 +17560,11 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const inf
-  f32.const -inf
-  call $~lib/math/NativeMathf.atan2
-  f32.const 2.356194496154785
-  f32.const 0.02500828728079796
-  call $std/math/check<f32>
+  f32.const 5.877471754111438e-39
+  f32.const 1
+  f32.const 5.877471754111438e-39
+  f32.const 0
+  call $std/math/test_atan2f
   i32.eqz
   if
    i32.const 0
@@ -18298,62 +17574,16 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -inf
-  f32.const inf
-  call $~lib/math/NativeMathf.atan2
-  f32.const -0.7853981852531433
-  f32.const -0.3666777014732361
-  call $std/math/check<f32>
+  f32.const 1
+  f32.const 1701411834604692317316873e14
+  f32.const 5.877471754111438e-39
+  f32.const 0
+  call $std/math/test_atan2f
   i32.eqz
   if
    i32.const 0
    i32.const 1056
    i32.const 767
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const -inf
-  f32.const -inf
-  call $~lib/math/NativeMathf.atan2
-  f32.const -2.356194496154785
-  f32.const -0.02500828728079796
-  call $std/math/check<f32>
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 768
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const 5.877471754111438e-39
-  f32.const 1
-  call $~lib/math/NativeMathf.atan2
-  f32.const 5.877471754111438e-39
-  f32.const 0
-  call $std/math/check<f32>
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 769
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const 1
-  f32.const 1701411834604692317316873e14
-  call $~lib/math/NativeMathf.atan2
-  f32.const 5.877471754111438e-39
-  f32.const 0
-  call $std/math/check<f32>
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 770
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -18366,7 +17596,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 782
+   i32.const 779
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -18379,7 +17609,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 783
+   i32.const 780
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -18392,7 +17622,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 784
+   i32.const 781
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -18405,7 +17635,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 785
+   i32.const 782
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -18418,7 +17648,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 786
+   i32.const 783
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -18431,7 +17661,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 787
+   i32.const 784
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -18444,7 +17674,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 788
+   i32.const 785
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -18457,7 +17687,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 789
+   i32.const 786
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -18470,7 +17700,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 790
+   i32.const 787
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -18483,13 +17713,52 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 791
+   i32.const 788
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f64.const nan:0x8000000000000
   f64.const nan:0x8000000000000
+  f64.const 0
+  call $std/math/test_cbrt
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 791
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const inf
+  f64.const inf
+  f64.const 0
+  call $std/math/test_cbrt
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 792
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const -inf
+  f64.const -inf
+  f64.const 0
+  call $std/math/test_cbrt
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 793
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const 0
+  f64.const 0
   f64.const 0
   call $std/math/test_cbrt
   i32.eqz
@@ -18501,8 +17770,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const inf
-  f64.const inf
+  f64.const -0
+  f64.const -0
   f64.const 0
   call $std/math/test_cbrt
   i32.eqz
@@ -18510,45 +17779,6 @@
    i32.const 0
    i32.const 1056
    i32.const 795
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const -inf
-  f64.const -inf
-  f64.const 0
-  call $std/math/test_cbrt
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 796
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const 0
-  f64.const 0
-  f64.const 0
-  call $std/math/test_cbrt
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 797
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const -0
-  f64.const -0
-  f64.const 0
-  call $std/math/test_cbrt
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 798
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -18561,7 +17791,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 799
+   i32.const 796
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -18574,7 +17804,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 800
+   i32.const 797
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -18587,7 +17817,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 801
+   i32.const 798
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -18600,7 +17830,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 802
+   i32.const 799
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -18613,7 +17843,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 803
+   i32.const 800
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -18626,7 +17856,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 812
+   i32.const 809
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -18639,7 +17869,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 813
+   i32.const 810
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -18652,7 +17882,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 814
+   i32.const 811
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -18665,7 +17895,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 815
+   i32.const 812
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -18678,7 +17908,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 816
+   i32.const 813
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -18691,7 +17921,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 817
+   i32.const 814
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -18704,7 +17934,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 818
+   i32.const 815
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -18717,7 +17947,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 819
+   i32.const 816
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -18730,7 +17960,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 820
+   i32.const 817
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -18743,13 +17973,52 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 821
+   i32.const 818
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f32.const nan:0x400000
   f32.const nan:0x400000
+  f32.const 0
+  call $std/math/test_cbrtf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 821
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const inf
+  f32.const inf
+  f32.const 0
+  call $std/math/test_cbrtf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 822
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const -inf
+  f32.const -inf
+  f32.const 0
+  call $std/math/test_cbrtf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 823
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const 0
+  f32.const 0
   f32.const 0
   call $std/math/test_cbrtf
   i32.eqz
@@ -18761,8 +18030,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const inf
-  f32.const inf
+  f32.const -0
+  f32.const -0
   f32.const 0
   call $std/math/test_cbrtf
   i32.eqz
@@ -18770,45 +18039,6 @@
    i32.const 0
    i32.const 1056
    i32.const 825
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const -inf
-  f32.const -inf
-  f32.const 0
-  call $std/math/test_cbrtf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 826
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const 0
-  f32.const 0
-  f32.const 0
-  call $std/math/test_cbrtf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 827
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const -0
-  f32.const -0
-  f32.const 0
-  call $std/math/test_cbrtf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 828
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -18821,7 +18051,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 829
+   i32.const 826
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -18834,7 +18064,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 830
+   i32.const 827
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -18847,7 +18077,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 831
+   i32.const 828
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -18860,7 +18090,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 832
+   i32.const 829
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -18873,7 +18103,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 833
+   i32.const 830
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -18895,7 +18125,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 845
+   i32.const 842
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -18917,7 +18147,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 846
+   i32.const 843
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -18939,7 +18169,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 847
+   i32.const 844
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -18961,7 +18191,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 848
+   i32.const 845
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -18983,7 +18213,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 849
+   i32.const 846
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -19005,7 +18235,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 850
+   i32.const 847
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -19027,7 +18257,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 851
+   i32.const 848
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -19049,7 +18279,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 852
+   i32.const 849
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -19071,7 +18301,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 853
+   i32.const 850
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -19093,7 +18323,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 854
+   i32.const 851
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -19106,6 +18336,72 @@
    f64.const nan:0x8000000000000
    call $~lib/bindings/dom/Math.ceil
    f64.const nan:0x8000000000000
+   f64.const 0
+   call $std/math/check<f64>
+  else
+   i32.const 0
+  end
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 854
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const inf
+  f64.const inf
+  f64.const 0
+  call $std/math/check<f64>
+  if (result i32)
+   f64.const inf
+   call $~lib/bindings/dom/Math.ceil
+   f64.const inf
+   f64.const 0
+   call $std/math/check<f64>
+  else
+   i32.const 0
+  end
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 855
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const -inf
+  f64.const -inf
+  f64.const 0
+  call $std/math/check<f64>
+  if (result i32)
+   f64.const -inf
+   call $~lib/bindings/dom/Math.ceil
+   f64.const -inf
+   f64.const 0
+   call $std/math/check<f64>
+  else
+   i32.const 0
+  end
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 856
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const 0
+  f64.const 0
+  f64.const 0
+  call $std/math/check<f64>
+  if (result i32)
+   f64.const 0
+   call $~lib/bindings/dom/Math.ceil
+   f64.const 0
    f64.const 0
    call $std/math/check<f64>
   else
@@ -19120,14 +18416,14 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const inf
-  f64.const inf
+  f64.const -0
+  f64.const -0
   f64.const 0
   call $std/math/check<f64>
   if (result i32)
-   f64.const inf
+   f64.const -0
    call $~lib/bindings/dom/Math.ceil
-   f64.const inf
+   f64.const -0
    f64.const 0
    call $std/math/check<f64>
   else
@@ -19142,14 +18438,14 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -inf
-  f64.const -inf
+  f64.const 1
+  f64.const 1
   f64.const 0
   call $std/math/check<f64>
   if (result i32)
-   f64.const -inf
+   f64.const 1
    call $~lib/bindings/dom/Math.ceil
-   f64.const -inf
+   f64.const 1
    f64.const 0
    call $std/math/check<f64>
   else
@@ -19164,14 +18460,14 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 0
-  f64.const 0
+  f64.const -1
+  f64.const -1
   f64.const 0
   call $std/math/check<f64>
   if (result i32)
-   f64.const 0
+   f64.const -1
    call $~lib/bindings/dom/Math.ceil
-   f64.const 0
+   f64.const -1
    f64.const 0
    call $std/math/check<f64>
   else
@@ -19186,14 +18482,14 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -0
-  f64.const -0
+  f64.const 1
+  f64.const 1
   f64.const 0
   call $std/math/check<f64>
   if (result i32)
-   f64.const -0
+   f64.const 0.5
    call $~lib/bindings/dom/Math.ceil
-   f64.const -0
+   f64.const 1
    f64.const 0
    call $std/math/check<f64>
   else
@@ -19208,14 +18504,14 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 1
-  f64.const 1
+  f64.const -0
+  f64.const -0
   f64.const 0
   call $std/math/check<f64>
   if (result i32)
-   f64.const 1
+   f64.const -0.5
    call $~lib/bindings/dom/Math.ceil
-   f64.const 1
+   f64.const -0
    f64.const 0
    call $std/math/check<f64>
   else
@@ -19230,14 +18526,14 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -1
-  f64.const -1
+  f64.const 2
+  f64.const 2
   f64.const 0
   call $std/math/check<f64>
   if (result i32)
-   f64.const -1
+   f64.const 1.0000152587890625
    call $~lib/bindings/dom/Math.ceil
-   f64.const -1
+   f64.const 2
    f64.const 0
    call $std/math/check<f64>
   else
@@ -19252,14 +18548,14 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 1
-  f64.const 1
+  f64.const -1
+  f64.const -1
   f64.const 0
   call $std/math/check<f64>
   if (result i32)
-   f64.const 0.5
+   f64.const -1.0000152587890625
    call $~lib/bindings/dom/Math.ceil
-   f64.const 1
+   f64.const -1
    f64.const 0
    call $std/math/check<f64>
   else
@@ -19274,14 +18570,14 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -0
-  f64.const -0
+  f64.const 1
+  f64.const 1
   f64.const 0
   call $std/math/check<f64>
   if (result i32)
-   f64.const -0.5
+   f64.const 0.9999923706054688
    call $~lib/bindings/dom/Math.ceil
-   f64.const -0
+   f64.const 1
    f64.const 0
    call $std/math/check<f64>
   else
@@ -19296,14 +18592,14 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 2
-  f64.const 2
+  f64.const -0
+  f64.const -0
   f64.const 0
   call $std/math/check<f64>
   if (result i32)
-   f64.const 1.0000152587890625
+   f64.const -0.9999923706054688
    call $~lib/bindings/dom/Math.ceil
-   f64.const 2
+   f64.const -0
    f64.const 0
    call $std/math/check<f64>
   else
@@ -19318,14 +18614,14 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -1
-  f64.const -1
+  f64.const 1
+  f64.const 1
   f64.const 0
   call $std/math/check<f64>
   if (result i32)
-   f64.const -1.0000152587890625
+   f64.const 7.888609052210118e-31
    call $~lib/bindings/dom/Math.ceil
-   f64.const -1
+   f64.const 1
    f64.const 0
    call $std/math/check<f64>
   else
@@ -19340,14 +18636,14 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 1
-  f64.const 1
+  f64.const -0
+  f64.const -0
   f64.const 0
   call $std/math/check<f64>
   if (result i32)
-   f64.const 0.9999923706054688
+   f64.const -7.888609052210118e-31
    call $~lib/bindings/dom/Math.ceil
-   f64.const 1
+   f64.const -0
    f64.const 0
    call $std/math/check<f64>
   else
@@ -19362,14 +18658,14 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -0
-  f64.const -0
+  f64.const nan:0x8000000000000
+  f64.const nan:0x8000000000000
   f64.const 0
   call $std/math/check<f64>
   if (result i32)
-   f64.const -0.9999923706054688
+   f64.const nan:0x8000000000000
    call $~lib/bindings/dom/Math.ceil
-   f64.const -0
+   f64.const nan:0x8000000000000
    f64.const 0
    call $std/math/check<f64>
   else
@@ -19384,14 +18680,14 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 1
-  f64.const 1
+  f64.const inf
+  f64.const inf
   f64.const 0
   call $std/math/check<f64>
   if (result i32)
-   f64.const 7.888609052210118e-31
+   f64.const inf
    call $~lib/bindings/dom/Math.ceil
-   f64.const 1
+   f64.const inf
    f64.const 0
    call $std/math/check<f64>
   else
@@ -19406,14 +18702,14 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -0
-  f64.const -0
+  f64.const -inf
+  f64.const -inf
   f64.const 0
   call $std/math/check<f64>
   if (result i32)
-   f64.const -7.888609052210118e-31
+   f64.const -inf
    call $~lib/bindings/dom/Math.ceil
-   f64.const -0
+   f64.const -inf
    f64.const 0
    call $std/math/check<f64>
   else
@@ -19428,14 +18724,14 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const nan:0x8000000000000
-  f64.const nan:0x8000000000000
+  f64.const 0
+  f64.const 0
   f64.const 0
   call $std/math/check<f64>
   if (result i32)
-   f64.const nan:0x8000000000000
+   f64.const 0
    call $~lib/bindings/dom/Math.ceil
-   f64.const nan:0x8000000000000
+   f64.const 0
    f64.const 0
    call $std/math/check<f64>
   else
@@ -19450,14 +18746,14 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const inf
-  f64.const inf
+  f64.const -0
+  f64.const -0
   f64.const 0
   call $std/math/check<f64>
   if (result i32)
-   f64.const inf
+   f64.const -0
    call $~lib/bindings/dom/Math.ceil
-   f64.const inf
+   f64.const -0
    f64.const 0
    call $std/math/check<f64>
   else
@@ -19472,14 +18768,14 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -inf
-  f64.const -inf
+  f64.const 1
+  f64.const 1
   f64.const 0
   call $std/math/check<f64>
   if (result i32)
-   f64.const -inf
+   f64.const 1
    call $~lib/bindings/dom/Math.ceil
-   f64.const -inf
+   f64.const 1
    f64.const 0
    call $std/math/check<f64>
   else
@@ -19494,14 +18790,14 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 0
-  f64.const 0
+  f64.const -1
+  f64.const -1
   f64.const 0
   call $std/math/check<f64>
   if (result i32)
-   f64.const 0
+   f64.const -1
    call $~lib/bindings/dom/Math.ceil
-   f64.const 0
+   f64.const -1
    f64.const 0
    call $std/math/check<f64>
   else
@@ -19516,14 +18812,14 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -0
-  f64.const -0
+  f64.const 1
+  f64.const 1
   f64.const 0
   call $std/math/check<f64>
   if (result i32)
-   f64.const -0
+   f64.const 0.5
    call $~lib/bindings/dom/Math.ceil
-   f64.const -0
+   f64.const 1
    f64.const 0
    call $std/math/check<f64>
   else
@@ -19538,14 +18834,14 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 1
-  f64.const 1
+  f64.const -0
+  f64.const -0
   f64.const 0
   call $std/math/check<f64>
   if (result i32)
-   f64.const 1
+   f64.const -0.5
    call $~lib/bindings/dom/Math.ceil
-   f64.const 1
+   f64.const -0
    f64.const 0
    call $std/math/check<f64>
   else
@@ -19560,14 +18856,14 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -1
-  f64.const -1
+  f64.const 2
+  f64.const 2
   f64.const 0
   call $std/math/check<f64>
   if (result i32)
-   f64.const -1
+   f64.const 1.0000152587890625
    call $~lib/bindings/dom/Math.ceil
-   f64.const -1
+   f64.const 2
    f64.const 0
    call $std/math/check<f64>
   else
@@ -19582,14 +18878,14 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 1
-  f64.const 1
+  f64.const -1
+  f64.const -1
   f64.const 0
   call $std/math/check<f64>
   if (result i32)
-   f64.const 0.5
+   f64.const -1.0000152587890625
    call $~lib/bindings/dom/Math.ceil
-   f64.const 1
+   f64.const -1
    f64.const 0
    call $std/math/check<f64>
   else
@@ -19604,72 +18900,6 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -0
-  f64.const -0
-  f64.const 0
-  call $std/math/check<f64>
-  if (result i32)
-   f64.const -0.5
-   call $~lib/bindings/dom/Math.ceil
-   f64.const -0
-   f64.const 0
-   call $std/math/check<f64>
-  else
-   i32.const 0
-  end
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 880
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const 2
-  f64.const 2
-  f64.const 0
-  call $std/math/check<f64>
-  if (result i32)
-   f64.const 1.0000152587890625
-   call $~lib/bindings/dom/Math.ceil
-   f64.const 2
-   f64.const 0
-   call $std/math/check<f64>
-  else
-   i32.const 0
-  end
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 881
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const -1
-  f64.const -1
-  f64.const 0
-  call $std/math/check<f64>
-  if (result i32)
-   f64.const -1.0000152587890625
-   call $~lib/bindings/dom/Math.ceil
-   f64.const -1
-   f64.const 0
-   call $std/math/check<f64>
-  else
-   i32.const 0
-  end
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 882
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
   f64.const 1
   f64.const 1
   f64.const 0
@@ -19687,7 +18917,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 883
+   i32.const 880
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -19709,7 +18939,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 884
+   i32.const 881
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -19731,7 +18961,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 885
+   i32.const 882
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -19753,7 +18983,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 886
+   i32.const 883
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -19766,6 +18996,72 @@
    f64.const nan:0x8000000000000
    call $~lib/bindings/dom/Math.ceil
    f64.const nan:0x8000000000000
+   f64.const 0
+   call $std/math/check<f64>
+  else
+   i32.const 0
+  end
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 884
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const inf
+  f64.const inf
+  f64.const 0
+  call $std/math/check<f64>
+  if (result i32)
+   f64.const inf
+   call $~lib/bindings/dom/Math.ceil
+   f64.const inf
+   f64.const 0
+   call $std/math/check<f64>
+  else
+   i32.const 0
+  end
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 885
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const -inf
+  f64.const -inf
+  f64.const 0
+  call $std/math/check<f64>
+  if (result i32)
+   f64.const -inf
+   call $~lib/bindings/dom/Math.ceil
+   f64.const -inf
+   f64.const 0
+   call $std/math/check<f64>
+  else
+   i32.const 0
+  end
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 886
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const 0
+  f64.const 0
+  f64.const 0
+  call $std/math/check<f64>
+  if (result i32)
+   f64.const 0
+   call $~lib/bindings/dom/Math.ceil
+   f64.const 0
    f64.const 0
    call $std/math/check<f64>
   else
@@ -19780,14 +19076,14 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const inf
-  f64.const inf
+  f64.const -0
+  f64.const -0
   f64.const 0
   call $std/math/check<f64>
   if (result i32)
-   f64.const inf
+   f64.const -0
    call $~lib/bindings/dom/Math.ceil
-   f64.const inf
+   f64.const -0
    f64.const 0
    call $std/math/check<f64>
   else
@@ -19802,14 +19098,14 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -inf
-  f64.const -inf
+  f64.const 1
+  f64.const 1
   f64.const 0
   call $std/math/check<f64>
   if (result i32)
-   f64.const -inf
+   f64.const 1
    call $~lib/bindings/dom/Math.ceil
-   f64.const -inf
+   f64.const 1
    f64.const 0
    call $std/math/check<f64>
   else
@@ -19824,14 +19120,14 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 0
-  f64.const 0
+  f64.const -1
+  f64.const -1
   f64.const 0
   call $std/math/check<f64>
   if (result i32)
-   f64.const 0
+   f64.const -1
    call $~lib/bindings/dom/Math.ceil
-   f64.const 0
+   f64.const -1
    f64.const 0
    call $std/math/check<f64>
   else
@@ -19842,72 +19138,6 @@
    i32.const 0
    i32.const 1056
    i32.const 890
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const -0
-  f64.const -0
-  f64.const 0
-  call $std/math/check<f64>
-  if (result i32)
-   f64.const -0
-   call $~lib/bindings/dom/Math.ceil
-   f64.const -0
-   f64.const 0
-   call $std/math/check<f64>
-  else
-   i32.const 0
-  end
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 891
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const 1
-  f64.const 1
-  f64.const 0
-  call $std/math/check<f64>
-  if (result i32)
-   f64.const 1
-   call $~lib/bindings/dom/Math.ceil
-   f64.const 1
-   f64.const 0
-   call $std/math/check<f64>
-  else
-   i32.const 0
-  end
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 892
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const -1
-  f64.const -1
-  f64.const 0
-  call $std/math/check<f64>
-  if (result i32)
-   f64.const -1
-   call $~lib/bindings/dom/Math.ceil
-   f64.const -1
-   f64.const 0
-   call $std/math/check<f64>
-  else
-   i32.const 0
-  end
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 893
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -19929,7 +19159,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 894
+   i32.const 891
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -19951,7 +19181,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 895
+   i32.const 892
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -19973,7 +19203,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 896
+   i32.const 893
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -19995,7 +19225,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 897
+   i32.const 894
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -20017,7 +19247,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 898
+   i32.const 895
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -20039,7 +19269,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 899
+   i32.const 896
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -20061,7 +19291,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 900
+   i32.const 897
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -20083,13 +19313,52 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 901
+   i32.const 898
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f32.const -8
   f32.const -8
+  f32.const 0
+  call $std/math/check<f32>
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 907
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const 5
+  f32.const 5
+  f32.const 0
+  call $std/math/check<f32>
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 908
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const -8
+  f32.const -8
+  f32.const 0
+  call $std/math/check<f32>
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 909
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const -6
+  f32.const -6
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -20101,8 +19370,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 5
-  f32.const 5
+  f32.const 10
+  f32.const 10
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -20114,8 +19383,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -8
-  f32.const -8
+  f32.const 1
+  f32.const 1
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -20127,8 +19396,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -6
-  f32.const -6
+  f32.const -0
+  f32.const -0
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -20140,8 +19409,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 10
-  f32.const 10
+  f32.const 1
+  f32.const 1
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -20179,34 +19448,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 1
-  f32.const 1
-  f32.const 0
-  call $std/math/check<f32>
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 917
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const 1
-  f32.const 1
-  f32.const 0
-  call $std/math/check<f32>
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 918
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const -0
-  f32.const -0
+  f32.const nan:0x400000
+  f32.const nan:0x400000
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -20218,8 +19461,34 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const nan:0x400000
-  f32.const nan:0x400000
+  f32.const inf
+  f32.const inf
+  f32.const 0
+  call $std/math/check<f32>
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 920
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const -inf
+  f32.const -inf
+  f32.const 0
+  call $std/math/check<f32>
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 921
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const 0
+  f32.const 0
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -20231,8 +19500,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const inf
-  f32.const inf
+  f32.const -0
+  f32.const -0
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -20244,8 +19513,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -inf
-  f32.const -inf
+  f32.const 1
+  f32.const 1
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -20257,8 +19526,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 0
-  f32.const 0
+  f32.const -1
+  f32.const -1
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -20270,8 +19539,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -0
-  f32.const -0
+  f32.const 1
+  f32.const 1
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -20283,8 +19552,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 1
-  f32.const 1
+  f32.const -0
+  f32.const -0
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -20296,8 +19565,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -1
-  f32.const -1
+  f32.const 2
+  f32.const 2
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -20309,8 +19578,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 1
-  f32.const 1
+  f32.const -1
+  f32.const -1
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -20322,8 +19591,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -0
-  f32.const -0
+  f32.const 1
+  f32.const 1
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -20335,8 +19604,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 2
-  f32.const 2
+  f32.const -0
+  f32.const -0
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -20348,8 +19617,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -1
-  f32.const -1
+  f32.const 1
+  f32.const 1
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -20361,8 +19630,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 1
-  f32.const 1
+  f32.const -0
+  f32.const -0
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -20374,8 +19643,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -0
-  f32.const -0
+  f32.const nan:0x400000
+  f32.const nan:0x400000
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -20387,8 +19656,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 1
-  f32.const 1
+  f32.const inf
+  f32.const inf
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -20400,8 +19669,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -0
-  f32.const -0
+  f32.const -inf
+  f32.const -inf
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -20413,8 +19682,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const nan:0x400000
-  f32.const nan:0x400000
+  f32.const 0
+  f32.const 0
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -20426,8 +19695,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const inf
-  f32.const inf
+  f32.const -0
+  f32.const -0
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -20439,8 +19708,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -inf
-  f32.const -inf
+  f32.const 1
+  f32.const 1
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -20452,8 +19721,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 0
-  f32.const 0
+  f32.const -1
+  f32.const -1
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -20465,8 +19734,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -0
-  f32.const -0
+  f32.const 1
+  f32.const 1
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -20478,8 +19747,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 1
-  f32.const 1
+  f32.const -0
+  f32.const -0
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -20491,8 +19760,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -1
-  f32.const -1
+  f32.const 2
+  f32.const 2
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -20504,8 +19773,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 1
-  f32.const 1
+  f32.const -1
+  f32.const -1
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -20517,8 +19786,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -0
-  f32.const -0
+  f32.const 1
+  f32.const 1
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -20530,8 +19799,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 2
-  f32.const 2
+  f32.const -0
+  f32.const -0
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -20543,8 +19812,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -1
-  f32.const -1
+  f32.const 1
+  f32.const 1
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -20556,8 +19825,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 1
-  f32.const 1
+  f32.const -0
+  f32.const -0
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -20569,8 +19838,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -0
-  f32.const -0
+  f32.const nan:0x400000
+  f32.const nan:0x400000
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -20582,8 +19851,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 1
-  f32.const 1
+  f32.const inf
+  f32.const inf
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -20595,8 +19864,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -0
-  f32.const -0
+  f32.const -inf
+  f32.const -inf
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -20608,8 +19877,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const nan:0x400000
-  f32.const nan:0x400000
+  f32.const 0
+  f32.const 0
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -20621,8 +19890,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const inf
-  f32.const inf
+  f32.const -0
+  f32.const -0
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -20634,8 +19903,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -inf
-  f32.const -inf
+  f32.const 1
+  f32.const 1
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -20647,8 +19916,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 0
-  f32.const 0
+  f32.const -1
+  f32.const -1
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -20660,8 +19929,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -0
-  f32.const -0
+  f32.const 1
+  f32.const 1
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -20673,8 +19942,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 1
-  f32.const 1
+  f32.const -0
+  f32.const -0
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -20686,8 +19955,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -1
-  f32.const -1
+  f32.const 2
+  f32.const 2
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -20699,8 +19968,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 1
-  f32.const 1
+  f32.const -1
+  f32.const -1
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -20712,8 +19981,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -0
-  f32.const -0
+  f32.const 1
+  f32.const 1
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -20725,8 +19994,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 2
-  f32.const 2
+  f32.const -0
+  f32.const -0
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -20738,8 +20007,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -1
-  f32.const -1
+  f32.const 1
+  f32.const 1
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -20751,8 +20020,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 1
-  f32.const 1
+  f32.const -0
+  f32.const -0
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -20764,47 +20033,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -0
-  f32.const -0
-  f32.const 0
-  call $std/math/check<f32>
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 964
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const 1
-  f32.const 1
-  f32.const 0
-  call $std/math/check<f32>
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 965
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const -0
-  f32.const -0
-  f32.const 0
-  call $std/math/check<f32>
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 966
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
   f64.const -8.06684839057968
-  call $~lib/math/NativeMath.cos
+  call $~lib/util/math/cos64
   f64.const -0.21126281599887137
   f64.const -0.10962469130754471
   call $std/math/check<f64>
@@ -20821,13 +20051,13 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 977
+   i32.const 974
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f64.const 4.345239849338305
-  call $~lib/math/NativeMath.cos
+  call $~lib/util/math/cos64
   f64.const -0.35895602297578955
   f64.const -0.10759828239679337
   call $std/math/check<f64>
@@ -20844,13 +20074,13 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 978
+   i32.const 975
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f64.const -8.38143342755525
-  call $~lib/math/NativeMath.cos
+  call $~lib/util/math/cos64
   f64.const -0.503333091765516
   f64.const -0.021430473774671555
   call $std/math/check<f64>
@@ -20867,13 +20097,13 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 979
+   i32.const 976
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f64.const -6.531673581913484
-  call $~lib/math/NativeMath.cos
+  call $~lib/util/math/cos64
   f64.const 0.9692853212503283
   f64.const -0.4787876307964325
   call $std/math/check<f64>
@@ -20890,13 +20120,13 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 980
+   i32.const 977
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f64.const 9.267056966972586
-  call $~lib/math/NativeMath.cos
+  call $~lib/util/math/cos64
   f64.const -0.9875878064788627
   f64.const 0.4880668818950653
   call $std/math/check<f64>
@@ -20913,13 +20143,13 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 981
+   i32.const 978
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f64.const 0.6619858980995045
-  call $~lib/math/NativeMath.cos
+  call $~lib/util/math/cos64
   f64.const 0.7887730869248576
   f64.const 0.12708666920661926
   call $std/math/check<f64>
@@ -20936,13 +20166,13 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 982
+   i32.const 979
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f64.const -0.4066039223853553
-  call $~lib/math/NativeMath.cos
+  call $~lib/util/math/cos64
   f64.const 0.9184692397007294
   f64.const -0.26120713353157043
   call $std/math/check<f64>
@@ -20959,13 +20189,13 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 983
+   i32.const 980
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f64.const 0.5617597462207241
-  call $~lib/math/NativeMath.cos
+  call $~lib/util/math/cos64
   f64.const 0.8463190467415896
   f64.const -0.302586168050766
   call $std/math/check<f64>
@@ -20982,13 +20212,13 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 984
+   i32.const 981
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f64.const 0.7741522965913037
-  call $~lib/math/NativeMath.cos
+  call $~lib/util/math/cos64
   f64.const 0.7150139289952383
   f64.const -0.08537746220827103
   call $std/math/check<f64>
@@ -21005,13 +20235,13 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 985
+   i32.const 982
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f64.const -0.6787637026394024
-  call $~lib/math/NativeMath.cos
+  call $~lib/util/math/cos64
   f64.const 0.7783494994757447
   f64.const 0.30890750885009766
   call $std/math/check<f64>
@@ -21028,13 +20258,13 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 986
+   i32.const 983
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f64.const 0
-  call $~lib/math/NativeMath.cos
+  call $~lib/util/math/cos64
   f64.const 1
   f64.const 0
   call $std/math/check<f64>
@@ -21051,13 +20281,13 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 989
+   i32.const 986
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f64.const -0
-  call $~lib/math/NativeMath.cos
+  call $~lib/util/math/cos64
   f64.const 1
   f64.const 0
   call $std/math/check<f64>
@@ -21074,13 +20304,13 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 990
+   i32.const 987
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f64.const inf
-  call $~lib/math/NativeMath.cos
+  call $~lib/util/math/cos64
   f64.const nan:0x8000000000000
   f64.const 0
   call $std/math/check<f64>
@@ -21097,13 +20327,13 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 991
+   i32.const 988
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f64.const -inf
-  call $~lib/math/NativeMath.cos
+  call $~lib/util/math/cos64
   f64.const nan:0x8000000000000
   f64.const 0
   call $std/math/check<f64>
@@ -21120,13 +20350,13 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 992
+   i32.const 989
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f64.const nan:0x8000000000000
-  call $~lib/math/NativeMath.cos
+  call $~lib/util/math/cos64
   f64.const nan:0x8000000000000
   f64.const 0
   call $std/math/check<f64>
@@ -21143,13 +20373,13 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 993
+   i32.const 990
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f64.const 1
-  call $~lib/math/NativeMath.cos
+  call $~lib/util/math/cos64
   f64.const 0.5403023058681398
   f64.const 0.4288286566734314
   call $std/math/check<f64>
@@ -21166,13 +20396,13 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 994
+   i32.const 991
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f64.const 2
-  call $~lib/math/NativeMath.cos
+  call $~lib/util/math/cos64
   f64.const -0.4161468365471424
   f64.const -0.35859397053718567
   call $std/math/check<f64>
@@ -21189,13 +20419,13 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 995
+   i32.const 992
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f64.const 3
-  call $~lib/math/NativeMath.cos
+  call $~lib/util/math/cos64
   f64.const -0.9899924966004454
   f64.const 0.3788451552391052
   call $std/math/check<f64>
@@ -21212,13 +20442,13 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 996
+   i32.const 993
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f64.const 4
-  call $~lib/math/NativeMath.cos
+  call $~lib/util/math/cos64
   f64.const -0.6536436208636119
   f64.const -0.23280560970306396
   call $std/math/check<f64>
@@ -21235,13 +20465,13 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 997
+   i32.const 994
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f64.const 5
-  call $~lib/math/NativeMath.cos
+  call $~lib/util/math/cos64
   f64.const 0.28366218546322625
   f64.const -0.3277357816696167
   call $std/math/check<f64>
@@ -21258,13 +20488,13 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 998
+   i32.const 995
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f64.const 0.1
-  call $~lib/math/NativeMath.cos
+  call $~lib/util/math/cos64
   f64.const 0.9950041652780258
   f64.const 0.49558526277542114
   call $std/math/check<f64>
@@ -21281,13 +20511,13 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 999
+   i32.const 996
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f64.const 0.2
-  call $~lib/math/NativeMath.cos
+  call $~lib/util/math/cos64
   f64.const 0.9800665778412416
   f64.const -0.02407640963792801
   call $std/math/check<f64>
@@ -21304,13 +20534,13 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1000
+   i32.const 997
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f64.const 0.3
-  call $~lib/math/NativeMath.cos
+  call $~lib/util/math/cos64
   f64.const 0.955336489125606
   f64.const -0.37772229313850403
   call $std/math/check<f64>
@@ -21327,13 +20557,13 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1001
+   i32.const 998
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f64.const 0.4
-  call $~lib/math/NativeMath.cos
+  call $~lib/util/math/cos64
   f64.const 0.9210609940028851
   f64.const 0.25818485021591187
   call $std/math/check<f64>
@@ -21350,13 +20580,13 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1002
+   i32.const 999
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f64.const 0.5
-  call $~lib/math/NativeMath.cos
+  call $~lib/util/math/cos64
   f64.const 0.8775825618903728
   f64.const 0.3839152157306671
   call $std/math/check<f64>
@@ -21373,13 +20603,13 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1003
+   i32.const 1000
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f64.const 2.3641409746639015e-308
-  call $~lib/math/NativeMath.cos
+  call $~lib/util/math/cos64
   f64.const 1
   f64.const 0
   call $std/math/check<f64>
@@ -21396,13 +20626,13 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1004
+   i32.const 1001
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f64.const 1.1820704873319507e-308
-  call $~lib/math/NativeMath.cos
+  call $~lib/util/math/cos64
   f64.const 1
   f64.const 0
   call $std/math/check<f64>
@@ -21419,13 +20649,13 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1005
+   i32.const 1002
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f64.const 5e-324
-  call $~lib/math/NativeMath.cos
+  call $~lib/util/math/cos64
   f64.const 1
   f64.const 0
   call $std/math/check<f64>
@@ -21442,13 +20672,13 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1006
+   i32.const 1003
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f64.const -5e-324
-  call $~lib/math/NativeMath.cos
+  call $~lib/util/math/cos64
   f64.const 1
   f64.const 0
   call $std/math/check<f64>
@@ -21465,13 +20695,13 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1007
+   i32.const 1004
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f64.const -3.14
-  call $~lib/math/NativeMath.cos
+  call $~lib/util/math/cos64
   f64.const -0.9999987317275395
   f64.const 0.3855516016483307
   call $std/math/check<f64>
@@ -21488,13 +20718,13 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1008
+   i32.const 1005
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f64.const 8988465674311579538646525e283
-  call $~lib/math/NativeMath.cos
+  call $~lib/util/math/cos64
   f64.const -0.826369834614148
   f64.const -0.3695965111255646
   call $std/math/check<f64>
@@ -21511,13 +20741,13 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1009
+   i32.const 1006
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f64.const 1797693134862315708145274e284
-  call $~lib/math/NativeMath.cos
+  call $~lib/util/math/cos64
   f64.const -0.9999876894265599
   f64.const 0.23448343575000763
   call $std/math/check<f64>
@@ -21534,13 +20764,13 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1010
+   i32.const 1007
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f64.const -8988465674311579538646525e283
-  call $~lib/math/NativeMath.cos
+  call $~lib/util/math/cos64
   f64.const -0.826369834614148
   f64.const -0.3695965111255646
   call $std/math/check<f64>
@@ -21557,13 +20787,13 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1011
+   i32.const 1008
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f64.const 3.14
-  call $~lib/math/NativeMath.cos
+  call $~lib/util/math/cos64
   f64.const -0.9999987317275395
   f64.const 0.3855516016483307
   call $std/math/check<f64>
@@ -21580,13 +20810,13 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1012
+   i32.const 1009
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f64.const 3.1415
-  call $~lib/math/NativeMath.cos
+  call $~lib/util/math/cos64
   f64.const -0.9999999957076562
   f64.const -0.30608975887298584
   call $std/math/check<f64>
@@ -21603,13 +20833,13 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1013
+   i32.const 1010
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f64.const 3.141592
-  call $~lib/math/NativeMath.cos
+  call $~lib/util/math/cos64
   f64.const -0.9999999999997864
   f64.const 0.15403328835964203
   call $std/math/check<f64>
@@ -21626,13 +20856,13 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1014
+   i32.const 1011
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f64.const 3.14159265
-  call $~lib/math/NativeMath.cos
+  call $~lib/util/math/cos64
   f64.const -1
   f64.const -0.02901807427406311
   call $std/math/check<f64>
@@ -21649,13 +20879,13 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1015
+   i32.const 1012
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f64.const 3.1415926535
-  call $~lib/math/NativeMath.cos
+  call $~lib/util/math/cos64
   f64.const -1
   f64.const -1.8155848010792397e-05
   call $std/math/check<f64>
@@ -21672,13 +20902,13 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1016
+   i32.const 1013
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f64.const 3.141592653589
-  call $~lib/math/NativeMath.cos
+  call $~lib/util/math/cos64
   f64.const -1
   f64.const -1.4169914130945926e-09
   call $std/math/check<f64>
@@ -21695,13 +20925,13 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1017
+   i32.const 1014
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f64.const 3.14159265358979
-  call $~lib/math/NativeMath.cos
+  call $~lib/util/math/cos64
   f64.const -1
   f64.const -2.350864897985184e-14
   call $std/math/check<f64>
@@ -21718,13 +20948,13 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1018
+   i32.const 1015
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f64.const 3.141592653589793
-  call $~lib/math/NativeMath.cos
+  call $~lib/util/math/cos64
   f64.const -1
   f64.const -3.377158741883318e-17
   call $std/math/check<f64>
@@ -21741,13 +20971,13 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1019
+   i32.const 1016
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f64.const 1.57
-  call $~lib/math/NativeMath.cos
+  call $~lib/util/math/cos64
   f64.const 7.963267107332633e-04
   f64.const 0.2968159317970276
   call $std/math/check<f64>
@@ -21764,13 +20994,13 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1020
+   i32.const 1017
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f64.const 1.570796
-  call $~lib/math/NativeMath.cos
+  call $~lib/util/math/cos64
   f64.const 3.2679489653813835e-07
   f64.const -0.32570895552635193
   call $std/math/check<f64>
@@ -21787,13 +21017,13 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1021
+   i32.const 1018
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f64.const 1.5707963267
-  call $~lib/math/NativeMath.cos
+  call $~lib/util/math/cos64
   f64.const 9.489659630678013e-11
   f64.const -0.27245646715164185
   call $std/math/check<f64>
@@ -21810,13 +21040,13 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1022
+   i32.const 1019
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f64.const 1.57079632679489
-  call $~lib/math/NativeMath.cos
+  call $~lib/util/math/cos64
   f64.const 6.722570487708307e-15
   f64.const -0.10747683793306351
   call $std/math/check<f64>
@@ -21833,13 +21063,13 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1023
+   i32.const 1020
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f64.const 1.5707963267948966
-  call $~lib/math/NativeMath.cos
+  call $~lib/util/math/cos64
   f64.const 6.123233995736766e-17
   f64.const 0.12148229777812958
   call $std/math/check<f64>
@@ -21856,13 +21086,13 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1024
+   i32.const 1021
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f64.const 0.6700635199486106
-  call $~lib/math/NativeMath.cos
+  call $~lib/util/math/cos64
   f64.const 0.7837822193016158
   f64.const -0.07278502732515335
   call $std/math/check<f64>
@@ -21879,13 +21109,13 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1025
+   i32.const 1022
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f64.const 0.5343890189437553
-  call $~lib/math/NativeMath.cos
+  call $~lib/util/math/cos64
   f64.const 0.8605799719039517
   f64.const -0.48434028029441833
   call $std/math/check<f64>
@@ -21902,13 +21132,13 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1026
+   i32.const 1023
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f64.const 0.43999702754890085
-  call $~lib/math/NativeMath.cos
+  call $~lib/util/math/cos64
   f64.const 0.9047529293001976
   f64.const 0.029777472838759422
   call $std/math/check<f64>
@@ -21925,13 +21155,13 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1027
+   i32.const 1024
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f64.const 0.9902840844687313
-  call $~lib/math/NativeMath.cos
+  call $~lib/util/math/cos64
   f64.const 0.5484523364480768
   f64.const 0.19765280187129974
   call $std/math/check<f64>
@@ -21948,13 +21178,13 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1028
+   i32.const 1025
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f64.const 0.45381447534338915
-  call $~lib/math/NativeMath.cos
+  call $~lib/util/math/cos64
   f64.const 0.8987813902263783
   f64.const -0.017724866047501564
   call $std/math/check<f64>
@@ -21971,13 +21201,13 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1029
+   i32.const 1026
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f64.const 0.4609888813583589
-  call $~lib/math/NativeMath.cos
+  call $~lib/util/math/cos64
   f64.const 0.8956130474713057
   f64.const 0.36449819803237915
   call $std/math/check<f64>
@@ -21994,13 +21224,13 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1030
+   i32.const 1027
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f64.const 0.9285434097956422
-  call $~lib/math/NativeMath.cos
+  call $~lib/util/math/cos64
   f64.const 0.5990009794292984
   f64.const -0.2899416387081146
   call $std/math/check<f64>
@@ -22017,13 +21247,13 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1031
+   i32.const 1028
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f64.const 0.9109092124488352
-  call $~lib/math/NativeMath.cos
+  call $~lib/util/math/cos64
   f64.const 0.6130276692774378
   f64.const -0.49353134632110596
   call $std/math/check<f64>
@@ -22040,13 +21270,13 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1032
+   i32.const 1029
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f64.const 0.8328600650359556
-  call $~lib/math/NativeMath.cos
+  call $~lib/util/math/cos64
   f64.const 0.6727624710046357
   f64.const -0.36606088280677795
   call $std/math/check<f64>
@@ -22063,13 +21293,13 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1033
+   i32.const 1030
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f64.const 0.9536201252203433
-  call $~lib/math/NativeMath.cos
+  call $~lib/util/math/cos64
   f64.const 0.5787346183487084
   f64.const -0.17089833319187164
   call $std/math/check<f64>
@@ -22086,13 +21316,13 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1034
+   i32.const 1031
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f64.const 0.8726590065457699
-  call $~lib/math/NativeMath.cos
+  call $~lib/util/math/cos64
   f64.const 0.6427919144259047
   f64.const -0.2744986116886139
   call $std/math/check<f64>
@@ -22109,13 +21339,13 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1035
+   i32.const 1032
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f64.const 0.18100447535968447
-  call $~lib/math/NativeMath.cos
+  call $~lib/util/math/cos64
   f64.const 0.9836633656884893
   f64.const 3.0195272993296385e-03
   call $std/math/check<f64>
@@ -22132,13 +21362,13 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1036
+   i32.const 1033
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f64.const 2.356194490349839
-  call $~lib/math/NativeMath.cos
+  call $~lib/util/math/cos64
   f64.const -0.7071067812979126
   f64.const -0.48278746008872986
   call $std/math/check<f64>
@@ -22155,13 +21385,13 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1037
+   i32.const 1034
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f64.const 2.356194490372272
-  call $~lib/math/NativeMath.cos
+  call $~lib/util/math/cos64
   f64.const -0.7071067813137752
   f64.const -0.4866050183773041
   call $std/math/check<f64>
@@ -22178,13 +21408,13 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1038
+   i32.const 1035
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f64.const 2.3561944902251115
-  call $~lib/math/NativeMath.cos
+  call $~lib/util/math/cos64
   f64.const -0.707106781209717
   f64.const -0.3533952236175537
   call $std/math/check<f64>
@@ -22201,13 +21431,13 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1039
+   i32.const 1036
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f64.const 2.3561944903149996
-  call $~lib/math/NativeMath.cos
+  call $~lib/util/math/cos64
   f64.const -0.7071067812732775
   f64.const -0.41911986470222473
   call $std/math/check<f64>
@@ -22224,13 +21454,13 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1040
+   i32.const 1037
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f64.const 2.3561944903603527
-  call $~lib/math/NativeMath.cos
+  call $~lib/util/math/cos64
   f64.const -0.707106781305347
   f64.const -0.4706200063228607
   call $std/math/check<f64>
@@ -22247,13 +21477,13 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1041
+   i32.const 1038
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f64.const 2.3561944903826197
-  call $~lib/math/NativeMath.cos
+  call $~lib/util/math/cos64
   f64.const -0.7071067813210922
   f64.const -0.30618351697921753
   call $std/math/check<f64>
@@ -22270,13 +21500,13 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1042
+   i32.const 1039
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f64.const 2.356194490371803
-  call $~lib/math/NativeMath.cos
+  call $~lib/util/math/cos64
   f64.const -0.7071067813134436
   f64.const -0.30564820766448975
   call $std/math/check<f64>
@@ -22293,13 +21523,13 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1043
+   i32.const 1040
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f64.const 2.356194490399931
-  call $~lib/math/NativeMath.cos
+  call $~lib/util/math/cos64
   f64.const -0.7071067813333329
   f64.const -0.38845571875572205
   call $std/math/check<f64>
@@ -22316,13 +21546,13 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1044
+   i32.const 1041
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f64.const 2.356194490260191
-  call $~lib/math/NativeMath.cos
+  call $~lib/util/math/cos64
   f64.const -0.707106781234522
   f64.const -0.23796851933002472
   call $std/math/check<f64>
@@ -22339,13 +21569,13 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1045
+   i32.const 1042
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f64.const 2.3561944904043153
-  call $~lib/math/NativeMath.cos
+  call $~lib/util/math/cos64
   f64.const -0.7071067813364332
   f64.const -0.3274589478969574
   call $std/math/check<f64>
@@ -22362,13 +21592,13 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1046
+   i32.const 1043
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f64.const 2.0943951024759446
-  call $~lib/math/NativeMath.cos
+  call $~lib/util/math/cos64
   f64.const -0.5000000000716629
   f64.const -0.41711342334747314
   call $std/math/check<f64>
@@ -22385,13 +21615,13 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1047
+   i32.const 1044
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f64.const 2.09439510243324
-  call $~lib/math/NativeMath.cos
+  call $~lib/util/math/cos64
   f64.const -0.5000000000346797
   f64.const -0.3566164970397949
   call $std/math/check<f64>
@@ -22408,13 +21638,13 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1048
+   i32.const 1045
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f64.const 2.0943951025133885
-  call $~lib/math/NativeMath.cos
+  call $~lib/util/math/cos64
   f64.const -0.5000000001040902
   f64.const -0.2253485918045044
   call $std/math/check<f64>
@@ -22431,13 +21661,13 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1049
+   i32.const 1046
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f64.const 2.0943951025466707
-  call $~lib/math/NativeMath.cos
+  call $~lib/util/math/cos64
   f64.const -0.5000000001329135
   f64.const -0.12982259690761566
   call $std/math/check<f64>
@@ -22454,13 +21684,13 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1050
+   i32.const 1047
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f64.const 2.094395102413896
-  call $~lib/math/NativeMath.cos
+  call $~lib/util/math/cos64
   f64.const -0.5000000000179272
   f64.const -0.15886764228343964
   call $std/math/check<f64>
@@ -22477,13 +21707,13 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1051
+   i32.const 1048
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f64.const 2.0943951024223404
-  call $~lib/math/NativeMath.cos
+  call $~lib/util/math/cos64
   f64.const -0.5000000000252403
   f64.const -0.266656756401062
   call $std/math/check<f64>
@@ -22500,13 +21730,13 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1052
+   i32.const 1049
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f64.const 2.0943951024960477
-  call $~lib/math/NativeMath.cos
+  call $~lib/util/math/cos64
   f64.const -0.5000000000890726
   f64.const -0.4652077853679657
   call $std/math/check<f64>
@@ -22523,13 +21753,13 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1053
+   i32.const 1050
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f64.const 2.0943951025173315
-  call $~lib/math/NativeMath.cos
+  call $~lib/util/math/cos64
   f64.const -0.500000000107505
   f64.const -0.46710994839668274
   call $std/math/check<f64>
@@ -22546,13 +21776,13 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1054
+   i32.const 1051
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f64.const 2.094395102405924
-  call $~lib/math/NativeMath.cos
+  call $~lib/util/math/cos64
   f64.const -0.5000000000110234
   f64.const -0.2469603717327118
   call $std/math/check<f64>
@@ -22569,13 +21799,13 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1055
+   i32.const 1052
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f64.const 2.094395102428558
-  call $~lib/math/NativeMath.cos
+  call $~lib/util/math/cos64
   f64.const -0.500000000030625
   f64.const -0.3799441158771515
   call $std/math/check<f64>
@@ -22592,13 +21822,13 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1056
+   i32.const 1053
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f64.const 8.513210770864056
-  call $~lib/math/NativeMath.cos
+  call $~lib/util/math/cos64
   f64.const -0.6125076939987759
   f64.const 0.4989966154098511
   call $std/math/check<f64>
@@ -22615,13 +21845,13 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1057
+   i32.const 1054
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f64.const 6.802886129801017
-  call $~lib/math/NativeMath.cos
+  call $~lib/util/math/cos64
   f64.const 0.8679677961345452
   f64.const 0.4972165524959564
   call $std/math/check<f64>
@@ -22638,13 +21868,13 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1058
+   i32.const 1055
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f64.const 9.171925393086408
-  call $~lib/math/NativeMath.cos
+  call $~lib/util/math/cos64
   f64.const -0.9682027440424544
   f64.const -0.49827584624290466
   call $std/math/check<f64>
@@ -22661,13 +21891,13 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1059
+   i32.const 1056
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f64.const 8.854690112888573
-  call $~lib/math/NativeMath.cos
+  call $~lib/util/math/cos64
   f64.const -0.8418535663818527
   f64.const 0.4974979758262634
   call $std/math/check<f64>
@@ -22684,13 +21914,13 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1060
+   i32.const 1057
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f64.const 9.213510813859608
-  call $~lib/math/NativeMath.cos
+  call $~lib/util/math/cos64
   f64.const -0.9777659802838506
   f64.const -0.4995604455471039
   call $std/math/check<f64>
@@ -22707,13 +21937,13 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1061
+   i32.const 1058
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f64.const 7.782449081542151
-  call $~lib/math/NativeMath.cos
+  call $~lib/util/math/cos64
   f64.const 0.07147156381293339
   f64.const 0.49858126044273376
   call $std/math/check<f64>
@@ -22730,13 +21960,13 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1062
+   i32.const 1059
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f64.const 7.500261332273616
-  call $~lib/math/NativeMath.cos
+  call $~lib/util/math/cos64
   f64.const 0.34639017633458113
   f64.const -0.4996210038661957
   call $std/math/check<f64>
@@ -22753,13 +21983,13 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1063
+   i32.const 1060
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f64.const 9.121739418731588
-  call $~lib/math/NativeMath.cos
+  call $~lib/util/math/cos64
   f64.const -0.9544341297541811
   f64.const 0.4982815086841583
   call $std/math/check<f64>
@@ -22776,13 +22006,13 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1064
+   i32.const 1061
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f64.const 6.784954020476316
-  call $~lib/math/NativeMath.cos
+  call $~lib/util/math/cos64
   f64.const 0.8767332233166646
   f64.const -0.4988083839416504
   call $std/math/check<f64>
@@ -22799,13 +22029,13 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1065
+   i32.const 1062
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f64.const 8.770846542666664
-  call $~lib/math/NativeMath.cos
+  call $~lib/util/math/cos64
   f64.const -0.7936984117400705
   f64.const 0.4999682903289795
   call $std/math/check<f64>
@@ -22822,13 +22052,13 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1066
+   i32.const 1063
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f64.const 9.313225746154785e-10
-  call $~lib/math/NativeMath.cos
+  call $~lib/util/math/cos64
   f64.const 1
   f64.const 0.001953125
   call $std/math/check<f64>
@@ -22845,13 +22075,13 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1069
+   i32.const 1066
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f64.const -9.313225746154785e-10
-  call $~lib/math/NativeMath.cos
+  call $~lib/util/math/cos64
   f64.const 1
   f64.const 0.001953125
   call $std/math/check<f64>
@@ -22868,13 +22098,13 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1070
+   i32.const 1067
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f64.const 2.2250738585072014e-308
-  call $~lib/math/NativeMath.cos
+  call $~lib/util/math/cos64
   f64.const 1
   f64.const 0
   call $std/math/check<f64>
@@ -22891,13 +22121,13 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1071
+   i32.const 1068
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f64.const -2.2250738585072014e-308
-  call $~lib/math/NativeMath.cos
+  call $~lib/util/math/cos64
   f64.const 1
   f64.const 0
   call $std/math/check<f64>
@@ -22914,18 +22144,87 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1072
+   i32.const 1069
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f64.const 5e-324
-  call $~lib/math/NativeMath.cos
+  call $~lib/util/math/cos64
   f64.const 1
   f64.const 0
   call $std/math/check<f64>
   if (result i32)
    f64.const 5e-324
+   call $~lib/bindings/dom/Math.cos
+   f64.const 1
+   f64.const 0
+   call $std/math/check<f64>
+  else
+   i32.const 0
+  end
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 1070
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const -5e-324
+  call $~lib/util/math/cos64
+  f64.const 1
+  f64.const 0
+  call $std/math/check<f64>
+  if (result i32)
+   f64.const -5e-324
+   call $~lib/bindings/dom/Math.cos
+   f64.const 1
+   f64.const 0
+   call $std/math/check<f64>
+  else
+   i32.const 0
+  end
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 1071
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const 0
+  call $~lib/util/math/cos64
+  f64.const 1
+  f64.const 0
+  call $std/math/check<f64>
+  if (result i32)
+   f64.const 0
+   call $~lib/bindings/dom/Math.cos
+   f64.const 1
+   f64.const 0
+   call $std/math/check<f64>
+  else
+   i32.const 0
+  end
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 1072
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const -0
+  call $~lib/util/math/cos64
+  f64.const 1
+  f64.const 0
+  call $std/math/check<f64>
+  if (result i32)
+   f64.const -0
    call $~lib/bindings/dom/Math.cos
    f64.const 1
    f64.const 0
@@ -22942,77 +22241,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -5e-324
-  call $~lib/math/NativeMath.cos
-  f64.const 1
-  f64.const 0
-  call $std/math/check<f64>
-  if (result i32)
-   f64.const -5e-324
-   call $~lib/bindings/dom/Math.cos
-   f64.const 1
-   f64.const 0
-   call $std/math/check<f64>
-  else
-   i32.const 0
-  end
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 1074
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const 0
-  call $~lib/math/NativeMath.cos
-  f64.const 1
-  f64.const 0
-  call $std/math/check<f64>
-  if (result i32)
-   f64.const 0
-   call $~lib/bindings/dom/Math.cos
-   f64.const 1
-   f64.const 0
-   call $std/math/check<f64>
-  else
-   i32.const 0
-  end
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 1075
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const -0
-  call $~lib/math/NativeMath.cos
-  f64.const 1
-  f64.const 0
-  call $std/math/check<f64>
-  if (result i32)
-   f64.const -0
-   call $~lib/bindings/dom/Math.cos
-   f64.const 1
-   f64.const 0
-   call $std/math/check<f64>
-  else
-   i32.const 0
-  end
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 1076
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
   f64.const 1e-323
-  call $~lib/math/NativeMath.cos
+  call $~lib/util/math/cos64
   f64.const 1
   f64.const 0
   call $std/math/check<f64>
@@ -23029,13 +22259,13 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1077
+   i32.const 1074
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f64.const 4.4e-323
-  call $~lib/math/NativeMath.cos
+  call $~lib/util/math/cos64
   f64.const 1
   f64.const 0
   call $std/math/check<f64>
@@ -23052,13 +22282,13 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1078
+   i32.const 1075
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f64.const 5.562684646268003e-309
-  call $~lib/math/NativeMath.cos
+  call $~lib/util/math/cos64
   f64.const 1
   f64.const 0
   call $std/math/check<f64>
@@ -23075,13 +22305,13 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1079
+   i32.const 1076
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f64.const 1.1125369292536007e-308
-  call $~lib/math/NativeMath.cos
+  call $~lib/util/math/cos64
   f64.const 1
   f64.const 0
   call $std/math/check<f64>
@@ -23098,13 +22328,13 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1080
+   i32.const 1077
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f64.const 2.2250738585072004e-308
-  call $~lib/math/NativeMath.cos
+  call $~lib/util/math/cos64
   f64.const 1
   f64.const 0
   call $std/math/check<f64>
@@ -23121,13 +22351,13 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1081
+   i32.const 1078
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f64.const 2.225073858507201e-308
-  call $~lib/math/NativeMath.cos
+  call $~lib/util/math/cos64
   f64.const 1
   f64.const 0
   call $std/math/check<f64>
@@ -23144,13 +22374,13 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1082
+   i32.const 1079
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f64.const 2.225073858507202e-308
-  call $~lib/math/NativeMath.cos
+  call $~lib/util/math/cos64
   f64.const 1
   f64.const 0
   call $std/math/check<f64>
@@ -23167,13 +22397,13 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1083
+   i32.const 1080
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f64.const 2.2250738585072024e-308
-  call $~lib/math/NativeMath.cos
+  call $~lib/util/math/cos64
   f64.const 1
   f64.const 0
   call $std/math/check<f64>
@@ -23190,13 +22420,13 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1084
+   i32.const 1081
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f64.const 4.4501477170144003e-308
-  call $~lib/math/NativeMath.cos
+  call $~lib/util/math/cos64
   f64.const 1
   f64.const 0
   call $std/math/check<f64>
@@ -23213,13 +22443,13 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1085
+   i32.const 1082
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f64.const 4.450147717014403e-308
-  call $~lib/math/NativeMath.cos
+  call $~lib/util/math/cos64
   f64.const 1
   f64.const 0
   call $std/math/check<f64>
@@ -23236,13 +22466,13 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1086
+   i32.const 1083
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f64.const 4.450147717014406e-308
-  call $~lib/math/NativeMath.cos
+  call $~lib/util/math/cos64
   f64.const 1
   f64.const 0
   call $std/math/check<f64>
@@ -23259,13 +22489,13 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1087
+   i32.const 1084
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f64.const 8.900295434028806e-308
-  call $~lib/math/NativeMath.cos
+  call $~lib/util/math/cos64
   f64.const 1
   f64.const 0
   call $std/math/check<f64>
@@ -23282,13 +22512,13 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1088
+   i32.const 1085
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f64.const 7.450580596923828e-09
-  call $~lib/math/NativeMath.cos
+  call $~lib/util/math/cos64
   f64.const 1
   f64.const 0.125
   call $std/math/check<f64>
@@ -23305,13 +22535,13 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1089
+   i32.const 1086
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f64.const 1.4901161193847656e-08
-  call $~lib/math/NativeMath.cos
+  call $~lib/util/math/cos64
   f64.const 0.9999999999999999
   f64.const -1.850372590034581e-17
   call $std/math/check<f64>
@@ -23328,13 +22558,13 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1090
+   i32.const 1087
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f64.const 4.470348358154297e-08
-  call $~lib/math/NativeMath.cos
+  call $~lib/util/math/cos64
   f64.const 0.999999999999999
   f64.const -1.4988010832439613e-15
   call $std/math/check<f64>
@@ -23351,13 +22581,13 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1091
+   i32.const 1088
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f64.const -1e-323
-  call $~lib/math/NativeMath.cos
+  call $~lib/util/math/cos64
   f64.const 1
   f64.const 0
   call $std/math/check<f64>
@@ -23374,13 +22604,13 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1092
+   i32.const 1089
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f64.const -4.4e-323
-  call $~lib/math/NativeMath.cos
+  call $~lib/util/math/cos64
   f64.const 1
   f64.const 0
   call $std/math/check<f64>
@@ -23397,13 +22627,13 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1093
+   i32.const 1090
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f64.const -5.562684646268003e-309
-  call $~lib/math/NativeMath.cos
+  call $~lib/util/math/cos64
   f64.const 1
   f64.const 0
   call $std/math/check<f64>
@@ -23420,13 +22650,13 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1094
+   i32.const 1091
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f64.const -1.1125369292536007e-308
-  call $~lib/math/NativeMath.cos
+  call $~lib/util/math/cos64
   f64.const 1
   f64.const 0
   call $std/math/check<f64>
@@ -23443,13 +22673,13 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1095
+   i32.const 1092
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f64.const -2.2250738585072004e-308
-  call $~lib/math/NativeMath.cos
+  call $~lib/util/math/cos64
   f64.const 1
   f64.const 0
   call $std/math/check<f64>
@@ -23466,13 +22696,13 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1096
+   i32.const 1093
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f64.const -2.225073858507201e-308
-  call $~lib/math/NativeMath.cos
+  call $~lib/util/math/cos64
   f64.const 1
   f64.const 0
   call $std/math/check<f64>
@@ -23489,13 +22719,13 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1097
+   i32.const 1094
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f64.const -2.225073858507202e-308
-  call $~lib/math/NativeMath.cos
+  call $~lib/util/math/cos64
   f64.const 1
   f64.const 0
   call $std/math/check<f64>
@@ -23512,13 +22742,13 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1098
+   i32.const 1095
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f64.const -2.2250738585072024e-308
-  call $~lib/math/NativeMath.cos
+  call $~lib/util/math/cos64
   f64.const 1
   f64.const 0
   call $std/math/check<f64>
@@ -23535,13 +22765,13 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1099
+   i32.const 1096
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f64.const -4.4501477170144003e-308
-  call $~lib/math/NativeMath.cos
+  call $~lib/util/math/cos64
   f64.const 1
   f64.const 0
   call $std/math/check<f64>
@@ -23558,13 +22788,13 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1100
+   i32.const 1097
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f64.const -4.450147717014403e-308
-  call $~lib/math/NativeMath.cos
+  call $~lib/util/math/cos64
   f64.const 1
   f64.const 0
   call $std/math/check<f64>
@@ -23581,13 +22811,13 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1101
+   i32.const 1098
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f64.const -4.450147717014406e-308
-  call $~lib/math/NativeMath.cos
+  call $~lib/util/math/cos64
   f64.const 1
   f64.const 0
   call $std/math/check<f64>
@@ -23604,13 +22834,13 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1102
+   i32.const 1099
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f64.const -8.900295434028806e-308
-  call $~lib/math/NativeMath.cos
+  call $~lib/util/math/cos64
   f64.const 1
   f64.const 0
   call $std/math/check<f64>
@@ -23627,13 +22857,13 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1103
+   i32.const 1100
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f64.const -7.450580596923828e-09
-  call $~lib/math/NativeMath.cos
+  call $~lib/util/math/cos64
   f64.const 1
   f64.const 0.125
   call $std/math/check<f64>
@@ -23650,13 +22880,13 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1104
+   i32.const 1101
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f64.const -1.4901161193847656e-08
-  call $~lib/math/NativeMath.cos
+  call $~lib/util/math/cos64
   f64.const 0.9999999999999999
   f64.const -1.850372590034581e-17
   call $std/math/check<f64>
@@ -23673,13 +22903,13 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1105
+   i32.const 1102
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f64.const -4.470348358154297e-08
-  call $~lib/math/NativeMath.cos
+  call $~lib/util/math/cos64
   f64.const 0.999999999999999
   f64.const -1.4988010832439613e-15
   call $std/math/check<f64>
@@ -23696,65 +22926,77 @@
   if
    i32.const 0
    i32.const 1056
+   i32.const 1103
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const 1.5707963267948966
+  call $~lib/util/math/cos64
+  f64.const 1.5707963267948966
+  call $~lib/bindings/dom/Math.cos
+  f64.ne
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 1105
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const 3.141592653589793
+  call $~lib/util/math/cos64
+  f64.const 3.141592653589793
+  call $~lib/bindings/dom/Math.cos
+  f64.ne
+  if
+   i32.const 0
+   i32.const 1056
    i32.const 1106
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 1.5707963267948966
-  call $~lib/math/NativeMath.cos
-  f64.const 1.5707963267948966
-  call $~lib/bindings/dom/Math.cos
-  f64.ne
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 1108
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const 3.141592653589793
-  call $~lib/math/NativeMath.cos
-  f64.const 3.141592653589793
-  call $~lib/bindings/dom/Math.cos
-  f64.ne
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 1109
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
   f64.const 3141592653589793231804887e66
-  call $~lib/math/NativeMath.cos
+  call $~lib/util/math/cos64
   f64.const 3141592653589793231804887e66
   call $~lib/bindings/dom/Math.cos
   f64.ne
   if
    i32.const 0
    i32.const 1056
-   i32.const 1110
+   i32.const 1107
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f64.const 2.3283064365386963e-10
-  call $~lib/math/NativeMath.cos
+  call $~lib/util/math/cos64
   f64.const 1
   f64.ne
   if
    i32.const 0
    i32.const 1056
-   i32.const 1114
+   i32.const 1111
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f64.const -2.3283064365386963e-10
-  call $~lib/math/NativeMath.cos
+  call $~lib/util/math/cos64
   f64.const 1
+  f64.ne
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 1112
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const 0.15707963267948966
+  call $~lib/util/math/cos64
+  f64.const 0.9876883405951378
   f64.ne
   if
    i32.const 0
@@ -23764,9 +23006,21 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 0.15707963267948966
-  call $~lib/math/NativeMath.cos
-  f64.const 0.9876883405951378
+  f64.const 0.7812504768371582
+  call $~lib/util/math/cos64
+  f64.const 0.7100335477927638
+  f64.ne
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 1117
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const 0.78125
+  call $~lib/util/math/cos64
+  f64.const 0.7100338835660797
   f64.ne
   if
    i32.const 0
@@ -23776,21 +23030,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 0.7812504768371582
-  call $~lib/math/NativeMath.cos
-  f64.const 0.7100335477927638
-  f64.ne
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 1120
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const 0.78125
-  call $~lib/math/NativeMath.cos
-  f64.const 0.7100338835660797
+  f64.const 0.39269908169872414
+  call $~lib/util/math/cos64
+  f64.const 0.9238795325112867
   f64.ne
   if
    i32.const 0
@@ -23800,21 +23042,21 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 0.39269908169872414
-  call $~lib/math/NativeMath.cos
+  f64.const -0.39269908169872414
+  call $~lib/util/math/cos64
   f64.const 0.9238795325112867
   f64.ne
   if
    i32.const 0
    i32.const 1056
-   i32.const 1124
+   i32.const 1123
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -0.39269908169872414
-  call $~lib/math/NativeMath.cos
-  f64.const 0.9238795325112867
+  f64.const 3.725290298461914e-09
+  call $~lib/util/math/cos64
+  f64.const 1
   f64.ne
   if
    i32.const 0
@@ -23824,9 +23066,21 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 3.725290298461914e-09
-  call $~lib/math/NativeMath.cos
-  f64.const 1
+  f64.const 0.25
+  call $~lib/util/math/cos64
+  f64.const 0.9689124217106447
+  f64.ne
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 1128
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const 0.5
+  call $~lib/util/math/cos64
+  f64.const 0.8775825618903728
   f64.ne
   if
    i32.const 0
@@ -23836,21 +23090,21 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 0.25
-  call $~lib/math/NativeMath.cos
-  f64.const 0.9689124217106447
+  f64.const 0.785
+  call $~lib/util/math/cos64
+  f64.const 0.7073882691671998
   f64.ne
   if
    i32.const 0
    i32.const 1056
-   i32.const 1131
+   i32.const 1130
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 0.5
-  call $~lib/math/NativeMath.cos
-  f64.const 0.8775825618903728
+  f64.const 1.5707963267948966
+  call $~lib/util/math/cos64
+  f64.const 6.123233995736766e-17
   f64.ne
   if
    i32.const 0
@@ -23860,21 +23114,21 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 0.785
-  call $~lib/math/NativeMath.cos
-  f64.const 0.7073882691671998
+  f64.const 5.497787143782138
+  call $~lib/util/math/cos64
+  f64.const 0.7071067811865474
   f64.ne
   if
    i32.const 0
    i32.const 1056
-   i32.const 1133
+   i32.const 1134
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 1.5707963267948966
-  call $~lib/math/NativeMath.cos
-  f64.const 6.123233995736766e-17
+  f64.const 7.0685834705770345
+  call $~lib/util/math/cos64
+  f64.const 0.7071067811865477
   f64.ne
   if
    i32.const 0
@@ -23884,9 +23138,21 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 5.497787143782138
-  call $~lib/math/NativeMath.cos
-  f64.const 0.7071067811865474
+  f64.const 8.63937979737193
+  call $~lib/util/math/cos64
+  f64.const -0.7071067811865467
+  f64.ne
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 1136
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const 10.210176124166829
+  call $~lib/util/math/cos64
+  f64.const -0.7071067811865471
   f64.ne
   if
    i32.const 0
@@ -23896,9 +23162,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 7.0685834705770345
-  call $~lib/math/NativeMath.cos
-  f64.const 0.7071067811865477
+  f64.const 1e6
+  call $~lib/util/math/cos64
+  f64.const 0.9367521275331447
   f64.ne
   if
    i32.const 0
@@ -23908,9 +23174,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 8.63937979737193
-  call $~lib/math/NativeMath.cos
-  f64.const -0.7071067811865467
+  f64.const 1647097.7583689587
+  call $~lib/util/math/cos64
+  f64.const -3.435757038074824e-12
   f64.ne
   if
    i32.const 0
@@ -23920,46 +23186,52 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 10.210176124166829
-  call $~lib/math/NativeMath.cos
-  f64.const -0.7071067811865471
-  f64.ne
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 1140
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const 1e6
-  call $~lib/math/NativeMath.cos
-  f64.const 0.9367521275331447
-  f64.ne
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 1141
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const 1647097.7583689587
-  call $~lib/math/NativeMath.cos
-  f64.const -3.435757038074824e-12
-  f64.ne
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 1142
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
   f32.const -8.066848754882812
-  call $~lib/math/NativeMathf.cos
+  call $~lib/util/math/cos32
   f32.const -0.21126316487789154
   f32.const 0.48328569531440735
+  call $std/math/check<f32>
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 1148
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const 4.345239639282227
+  call $~lib/util/math/cos32
+  f32.const -0.3589562177658081
+  f32.const 0.042505208402872086
+  call $std/math/check<f32>
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 1149
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const -8.381433486938477
+  call $~lib/util/math/cos32
+  f32.const -0.5033331513404846
+  f32.const -0.1386195719242096
+  call $std/math/check<f32>
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 1150
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const -6.531673431396484
+  call $~lib/util/math/cos32
+  f32.const 0.9692853689193726
+  f32.const 0.1786951720714569
   call $std/math/check<f32>
   i32.eqz
   if
@@ -23970,10 +23242,10 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 4.345239639282227
-  call $~lib/math/NativeMathf.cos
-  f32.const -0.3589562177658081
-  f32.const 0.042505208402872086
+  f32.const 9.267057418823242
+  call $~lib/util/math/cos32
+  f32.const -0.9875878691673279
+  f32.const 0.1389600932598114
   call $std/math/check<f32>
   i32.eqz
   if
@@ -23984,10 +23256,10 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -8.381433486938477
-  call $~lib/math/NativeMathf.cos
-  f32.const -0.5033331513404846
-  f32.const -0.1386195719242096
+  f32.const 0.6619858741760254
+  call $~lib/util/math/cos32
+  f32.const 0.7887731194496155
+  f32.const 0.2989593744277954
   call $std/math/check<f32>
   i32.eqz
   if
@@ -23998,10 +23270,10 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -6.531673431396484
-  call $~lib/math/NativeMathf.cos
-  f32.const 0.9692853689193726
-  f32.const 0.1786951720714569
+  f32.const -0.40660393238067627
+  call $~lib/util/math/cos32
+  f32.const 0.918469250202179
+  f32.const 0.24250665307044983
   call $std/math/check<f32>
   i32.eqz
   if
@@ -24012,10 +23284,10 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 9.267057418823242
-  call $~lib/math/NativeMathf.cos
-  f32.const -0.9875878691673279
-  f32.const 0.1389600932598114
+  f32.const 0.5617597699165344
+  call $~lib/util/math/cos32
+  f32.const 0.8463190197944641
+  f32.const -0.24033240973949432
   call $std/math/check<f32>
   i32.eqz
   if
@@ -24026,10 +23298,10 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 0.6619858741760254
-  call $~lib/math/NativeMathf.cos
-  f32.const 0.7887731194496155
-  f32.const 0.2989593744277954
+  f32.const 0.7741522789001465
+  call $~lib/util/math/cos32
+  f32.const 0.7150139212608337
+  f32.const -0.3372635245323181
   call $std/math/check<f32>
   i32.eqz
   if
@@ -24040,10 +23312,10 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -0.40660393238067627
-  call $~lib/math/NativeMathf.cos
-  f32.const 0.918469250202179
-  f32.const 0.24250665307044983
+  f32.const -0.6787636876106262
+  call $~lib/util/math/cos32
+  f32.const 0.7783495187759399
+  f32.const 0.16550153493881226
   call $std/math/check<f32>
   i32.eqz
   if
@@ -24054,38 +23326,10 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 0.5617597699165344
-  call $~lib/math/NativeMathf.cos
-  f32.const 0.8463190197944641
-  f32.const -0.24033240973949432
-  call $std/math/check<f32>
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 1158
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const 0.7741522789001465
-  call $~lib/math/NativeMathf.cos
-  f32.const 0.7150139212608337
-  f32.const -0.3372635245323181
-  call $std/math/check<f32>
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 1159
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const -0.6787636876106262
-  call $~lib/math/NativeMathf.cos
-  f32.const 0.7783495187759399
-  f32.const 0.16550153493881226
+  f32.const 0
+  call $~lib/util/math/cos32
+  f32.const 1
+  f32.const 0
   call $std/math/check<f32>
   i32.eqz
   if
@@ -24096,9 +23340,37 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 0
-  call $~lib/math/NativeMathf.cos
+  f32.const -0
+  call $~lib/util/math/cos32
   f32.const 1
+  f32.const 0
+  call $std/math/check<f32>
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 1161
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const inf
+  call $~lib/util/math/cos32
+  f32.const nan:0x400000
+  f32.const 0
+  call $std/math/check<f32>
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 1162
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const -inf
+  call $~lib/util/math/cos32
+  f32.const nan:0x400000
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -24110,9 +23382,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -0
-  call $~lib/math/NativeMathf.cos
-  f32.const 1
+  f32.const nan:0x400000
+  call $~lib/util/math/cos32
+  f32.const nan:0x400000
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -24124,38 +23396,10 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const inf
-  call $~lib/math/NativeMathf.cos
-  f32.const nan:0x400000
-  f32.const 0
-  call $std/math/check<f32>
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 1165
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const -inf
-  call $~lib/math/NativeMathf.cos
-  f32.const nan:0x400000
-  f32.const 0
-  call $std/math/check<f32>
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 1166
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const nan:0x400000
-  call $~lib/math/NativeMathf.cos
-  f32.const nan:0x400000
-  f32.const 0
+  f32.const 1.862645149230957e-09
+  call $~lib/util/math/cos32
+  f32.const 1
+  f32.const 1.4551915228366852e-11
   call $std/math/check<f32>
   i32.eqz
   if
@@ -24166,10 +23410,38 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 1.862645149230957e-09
-  call $~lib/math/NativeMathf.cos
+  f32.const -1.862645149230957e-09
+  call $~lib/util/math/cos32
   f32.const 1
   f32.const 1.4551915228366852e-11
+  call $std/math/check<f32>
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 1168
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const 1.1754943508222875e-38
+  call $~lib/util/math/cos32
+  f32.const 1
+  f32.const 0
+  call $std/math/check<f32>
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 1169
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const -1.1754943508222875e-38
+  call $~lib/util/math/cos32
+  f32.const 1
+  f32.const 0
   call $std/math/check<f32>
   i32.eqz
   if
@@ -24180,10 +23452,10 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -1.862645149230957e-09
-  call $~lib/math/NativeMathf.cos
+  f32.const 1.401298464324817e-45
+  call $~lib/util/math/cos32
   f32.const 1
-  f32.const 1.4551915228366852e-11
+  f32.const 0
   call $std/math/check<f32>
   i32.eqz
   if
@@ -24194,8 +23466,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 1.1754943508222875e-38
-  call $~lib/math/NativeMathf.cos
+  f32.const -1.401298464324817e-45
+  call $~lib/util/math/cos32
   f32.const 1
   f32.const 0
   call $std/math/check<f32>
@@ -24208,8 +23480,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -1.1754943508222875e-38
-  call $~lib/math/NativeMathf.cos
+  f32.const 2.802596928649634e-45
+  call $~lib/util/math/cos32
   f32.const 1
   f32.const 0
   call $std/math/check<f32>
@@ -24222,8 +23494,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 1.401298464324817e-45
-  call $~lib/math/NativeMathf.cos
+  f32.const 1.2611686178923354e-44
+  call $~lib/util/math/cos32
   f32.const 1
   f32.const 0
   call $std/math/check<f32>
@@ -24236,8 +23508,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -1.401298464324817e-45
-  call $~lib/math/NativeMathf.cos
+  f32.const 2.938735877055719e-39
+  call $~lib/util/math/cos32
   f32.const 1
   f32.const 0
   call $std/math/check<f32>
@@ -24250,8 +23522,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 2.802596928649634e-45
-  call $~lib/math/NativeMathf.cos
+  f32.const 5.877471754111438e-39
+  call $~lib/util/math/cos32
   f32.const 1
   f32.const 0
   call $std/math/check<f32>
@@ -24264,8 +23536,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 1.2611686178923354e-44
-  call $~lib/math/NativeMathf.cos
+  f32.const 1.1754940705625946e-38
+  call $~lib/util/math/cos32
   f32.const 1
   f32.const 0
   call $std/math/check<f32>
@@ -24278,8 +23550,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 2.938735877055719e-39
-  call $~lib/math/NativeMathf.cos
+  f32.const 1.1754942106924411e-38
+  call $~lib/util/math/cos32
   f32.const 1
   f32.const 0
   call $std/math/check<f32>
@@ -24292,8 +23564,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 5.877471754111438e-39
-  call $~lib/math/NativeMathf.cos
+  f32.const 1.175494490952134e-38
+  call $~lib/util/math/cos32
   f32.const 1
   f32.const 0
   call $std/math/check<f32>
@@ -24306,8 +23578,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 1.1754940705625946e-38
-  call $~lib/math/NativeMathf.cos
+  f32.const 1.1754946310819804e-38
+  call $~lib/util/math/cos32
   f32.const 1
   f32.const 0
   call $std/math/check<f32>
@@ -24320,8 +23592,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 1.1754942106924411e-38
-  call $~lib/math/NativeMathf.cos
+  f32.const 2.3509880009953429e-38
+  call $~lib/util/math/cos32
   f32.const 1
   f32.const 0
   call $std/math/check<f32>
@@ -24334,8 +23606,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 1.175494490952134e-38
-  call $~lib/math/NativeMathf.cos
+  f32.const 2.350988701644575e-38
+  call $~lib/util/math/cos32
   f32.const 1
   f32.const 0
   call $std/math/check<f32>
@@ -24348,8 +23620,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 1.1754946310819804e-38
-  call $~lib/math/NativeMathf.cos
+  f32.const 2.3509895424236536e-38
+  call $~lib/util/math/cos32
   f32.const 1
   f32.const 0
   call $std/math/check<f32>
@@ -24362,8 +23634,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 2.3509880009953429e-38
-  call $~lib/math/NativeMathf.cos
+  f32.const 4.70197740328915e-38
+  call $~lib/util/math/cos32
   f32.const 1
   f32.const 0
   call $std/math/check<f32>
@@ -24376,10 +23648,10 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 2.350988701644575e-38
-  call $~lib/math/NativeMathf.cos
+  f32.const 7.450580596923828e-09
+  call $~lib/util/math/cos32
   f32.const 1
-  f32.const 0
+  f32.const 2.3283064365386963e-10
   call $std/math/check<f32>
   i32.eqz
   if
@@ -24390,10 +23662,10 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 2.3509895424236536e-38
-  call $~lib/math/NativeMathf.cos
+  f32.const 0.000244140625
+  call $~lib/util/math/cos32
   f32.const 1
-  f32.const 0
+  f32.const 0.25
   call $std/math/check<f32>
   i32.eqz
   if
@@ -24404,10 +23676,10 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 4.70197740328915e-38
-  call $~lib/math/NativeMathf.cos
-  f32.const 1
-  f32.const 0
+  f32.const 0.00048828125
+  call $~lib/util/math/cos32
+  f32.const 0.9999998807907104
+  f32.const -3.973643103449831e-08
   call $std/math/check<f32>
   i32.eqz
   if
@@ -24418,10 +23690,10 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 7.450580596923828e-09
-  call $~lib/math/NativeMathf.cos
-  f32.const 1
-  f32.const 2.3283064365386963e-10
+  f32.const 0.0009765625
+  call $~lib/util/math/cos32
+  f32.const 0.9999995231628418
+  f32.const -6.357828397085541e-07
   call $std/math/check<f32>
   i32.eqz
   if
@@ -24432,10 +23704,10 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 0.000244140625
-  call $~lib/math/NativeMathf.cos
+  f32.const -2.802596928649634e-45
+  call $~lib/util/math/cos32
   f32.const 1
-  f32.const 0.25
+  f32.const 0
   call $std/math/check<f32>
   i32.eqz
   if
@@ -24446,10 +23718,10 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 0.00048828125
-  call $~lib/math/NativeMathf.cos
-  f32.const 0.9999998807907104
-  f32.const -3.973643103449831e-08
+  f32.const -1.2611686178923354e-44
+  call $~lib/util/math/cos32
+  f32.const 1
+  f32.const 0
   call $std/math/check<f32>
   i32.eqz
   if
@@ -24460,10 +23732,10 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 0.0009765625
-  call $~lib/math/NativeMathf.cos
-  f32.const 0.9999995231628418
-  f32.const -6.357828397085541e-07
+  f32.const -2.938735877055719e-39
+  call $~lib/util/math/cos32
+  f32.const 1
+  f32.const 0
   call $std/math/check<f32>
   i32.eqz
   if
@@ -24474,8 +23746,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -2.802596928649634e-45
-  call $~lib/math/NativeMathf.cos
+  f32.const -5.877471754111438e-39
+  call $~lib/util/math/cos32
   f32.const 1
   f32.const 0
   call $std/math/check<f32>
@@ -24488,8 +23760,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -1.2611686178923354e-44
-  call $~lib/math/NativeMathf.cos
+  f32.const -1.1754940705625946e-38
+  call $~lib/util/math/cos32
   f32.const 1
   f32.const 0
   call $std/math/check<f32>
@@ -24502,8 +23774,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -2.938735877055719e-39
-  call $~lib/math/NativeMathf.cos
+  f32.const -1.1754942106924411e-38
+  call $~lib/util/math/cos32
   f32.const 1
   f32.const 0
   call $std/math/check<f32>
@@ -24516,8 +23788,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -5.877471754111438e-39
-  call $~lib/math/NativeMathf.cos
+  f32.const -1.175494490952134e-38
+  call $~lib/util/math/cos32
   f32.const 1
   f32.const 0
   call $std/math/check<f32>
@@ -24530,8 +23802,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -1.1754940705625946e-38
-  call $~lib/math/NativeMathf.cos
+  f32.const -1.1754946310819804e-38
+  call $~lib/util/math/cos32
   f32.const 1
   f32.const 0
   call $std/math/check<f32>
@@ -24544,8 +23816,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -1.1754942106924411e-38
-  call $~lib/math/NativeMathf.cos
+  f32.const -2.3509880009953429e-38
+  call $~lib/util/math/cos32
   f32.const 1
   f32.const 0
   call $std/math/check<f32>
@@ -24558,8 +23830,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -1.175494490952134e-38
-  call $~lib/math/NativeMathf.cos
+  f32.const -2.350988701644575e-38
+  call $~lib/util/math/cos32
   f32.const 1
   f32.const 0
   call $std/math/check<f32>
@@ -24572,8 +23844,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -1.1754946310819804e-38
-  call $~lib/math/NativeMathf.cos
+  f32.const -2.3509895424236536e-38
+  call $~lib/util/math/cos32
   f32.const 1
   f32.const 0
   call $std/math/check<f32>
@@ -24586,8 +23858,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -2.3509880009953429e-38
-  call $~lib/math/NativeMathf.cos
+  f32.const -4.70197740328915e-38
+  call $~lib/util/math/cos32
   f32.const 1
   f32.const 0
   call $std/math/check<f32>
@@ -24600,10 +23872,10 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -2.350988701644575e-38
-  call $~lib/math/NativeMathf.cos
+  f32.const -7.450580596923828e-09
+  call $~lib/util/math/cos32
   f32.const 1
-  f32.const 0
+  f32.const 2.3283064365386963e-10
   call $std/math/check<f32>
   i32.eqz
   if
@@ -24614,10 +23886,10 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -2.3509895424236536e-38
-  call $~lib/math/NativeMathf.cos
+  f32.const -0.000244140625
+  call $~lib/util/math/cos32
   f32.const 1
-  f32.const 0
+  f32.const 0.25
   call $std/math/check<f32>
   i32.eqz
   if
@@ -24628,10 +23900,10 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -4.70197740328915e-38
-  call $~lib/math/NativeMathf.cos
-  f32.const 1
-  f32.const 0
+  f32.const -0.00048828125
+  call $~lib/util/math/cos32
+  f32.const 0.9999998807907104
+  f32.const -3.973643103449831e-08
   call $std/math/check<f32>
   i32.eqz
   if
@@ -24642,10 +23914,10 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -7.450580596923828e-09
-  call $~lib/math/NativeMathf.cos
-  f32.const 1
-  f32.const 2.3283064365386963e-10
+  f32.const -0.0009765625
+  call $~lib/util/math/cos32
+  f32.const 0.9999995231628418
+  f32.const -6.357828397085541e-07
   call $std/math/check<f32>
   i32.eqz
   if
@@ -24656,38 +23928,10 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -0.000244140625
-  call $~lib/math/NativeMathf.cos
-  f32.const 1
-  f32.const 0.25
-  call $std/math/check<f32>
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 1205
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const -0.00048828125
-  call $~lib/math/NativeMathf.cos
-  f32.const 0.9999998807907104
-  f32.const -3.973643103449831e-08
-  call $std/math/check<f32>
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 1206
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const -0.0009765625
-  call $~lib/math/NativeMathf.cos
-  f32.const 0.9999995231628418
-  f32.const -6.357828397085541e-07
+  f32.const 255.99993896484375
+  call $~lib/util/math/cos32
+  f32.const -0.03985174745321274
+  f32.const 0
   call $std/math/check<f32>
   i32.eqz
   if
@@ -24698,9 +23942,37 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 255.99993896484375
-  call $~lib/math/NativeMathf.cos
-  f32.const -0.03985174745321274
+  f32.const 5033165
+  call $~lib/util/math/cos32
+  f32.const 0.8471871614456177
+  f32.const 0
+  call $std/math/check<f32>
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 1208
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const 421657440
+  call $~lib/util/math/cos32
+  f32.const 0.6728929281234741
+  f32.const 0
+  call $std/math/check<f32>
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 1209
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const 2147483392
+  call $~lib/util/math/cos32
+  f32.const 0.9610780477523804
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -24712,9 +23984,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 5033165
-  call $~lib/math/NativeMathf.cos
-  f32.const 0.8471871614456177
+  f32.const 68719476736
+  call $~lib/util/math/cos32
+  f32.const 0.1694190502166748
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -24726,9 +23998,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 421657440
-  call $~lib/math/NativeMathf.cos
-  f32.const 0.6728929281234741
+  f32.const 549755813888
+  call $~lib/util/math/cos32
+  f32.const 0.20735950767993927
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -24740,9 +24012,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 2147483392
-  call $~lib/math/NativeMathf.cos
-  f32.const 0.9610780477523804
+  f32.const 3402823466385288598117041e14
+  call $~lib/util/math/cos32
+  f32.const 0.8530210256576538
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -24754,9 +24026,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 68719476736
-  call $~lib/math/NativeMathf.cos
-  f32.const 0.1694190502166748
+  f32.const -255.99993896484375
+  call $~lib/util/math/cos32
+  f32.const -0.03985174745321274
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -24768,9 +24040,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 549755813888
-  call $~lib/math/NativeMathf.cos
-  f32.const 0.20735950767993927
+  f32.const -5033165
+  call $~lib/util/math/cos32
+  f32.const 0.8471871614456177
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -24782,9 +24054,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 3402823466385288598117041e14
-  call $~lib/math/NativeMathf.cos
-  f32.const 0.8530210256576538
+  f32.const -421657440
+  call $~lib/util/math/cos32
+  f32.const 0.6728929281234741
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -24796,9 +24068,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -255.99993896484375
-  call $~lib/math/NativeMathf.cos
-  f32.const -0.03985174745321274
+  f32.const -2147483392
+  call $~lib/util/math/cos32
+  f32.const 0.9610780477523804
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -24810,9 +24082,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -5033165
-  call $~lib/math/NativeMathf.cos
-  f32.const 0.8471871614456177
+  f32.const -68719476736
+  call $~lib/util/math/cos32
+  f32.const 0.1694190502166748
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -24824,9 +24096,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -421657440
-  call $~lib/math/NativeMathf.cos
-  f32.const 0.6728929281234741
+  f32.const -549755813888
+  call $~lib/util/math/cos32
+  f32.const 0.20735950767993927
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -24838,50 +24110,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -2147483392
-  call $~lib/math/NativeMathf.cos
-  f32.const 0.9610780477523804
-  f32.const 0
-  call $std/math/check<f32>
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 1220
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const -68719476736
-  call $~lib/math/NativeMathf.cos
-  f32.const 0.1694190502166748
-  f32.const 0
-  call $std/math/check<f32>
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 1221
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const -549755813888
-  call $~lib/math/NativeMathf.cos
-  f32.const 0.20735950767993927
-  f32.const 0
-  call $std/math/check<f32>
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 1222
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
   f32.const -3402823466385288598117041e14
-  call $~lib/math/NativeMathf.cos
+  call $~lib/util/math/cos32
   f32.const 0.8530210256576538
   f32.const 0
   call $std/math/check<f32>
@@ -24889,7 +24119,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1223
+   i32.const 1220
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -24902,7 +24132,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1234
+   i32.const 1231
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -24915,7 +24145,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1235
+   i32.const 1232
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -24928,7 +24158,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1236
+   i32.const 1233
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -24941,7 +24171,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1237
+   i32.const 1234
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -24954,7 +24184,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1238
+   i32.const 1235
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -24967,7 +24197,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1239
+   i32.const 1236
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -24980,7 +24210,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1240
+   i32.const 1237
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -24993,7 +24223,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1241
+   i32.const 1238
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -25006,7 +24236,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1242
+   i32.const 1239
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -25019,7 +24249,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1243
+   i32.const 1240
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -25032,7 +24262,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1246
+   i32.const 1243
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -25045,7 +24275,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1247
+   i32.const 1244
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -25058,7 +24288,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1248
+   i32.const 1245
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -25071,7 +24301,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1249
+   i32.const 1246
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -25084,7 +24314,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1250
+   i32.const 1247
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -25097,7 +24327,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1259
+   i32.const 1256
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -25110,7 +24340,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1260
+   i32.const 1257
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -25123,7 +24353,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1261
+   i32.const 1258
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -25136,7 +24366,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1262
+   i32.const 1259
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -25149,7 +24379,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1263
+   i32.const 1260
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -25162,7 +24392,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1264
+   i32.const 1261
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -25175,7 +24405,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1265
+   i32.const 1262
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -25188,7 +24418,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1266
+   i32.const 1263
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -25201,7 +24431,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1267
+   i32.const 1264
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -25214,7 +24444,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1268
+   i32.const 1265
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -25227,7 +24457,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1271
+   i32.const 1268
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -25240,7 +24470,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1272
+   i32.const 1269
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -25253,7 +24483,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1273
+   i32.const 1270
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -25266,7 +24496,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1274
+   i32.const 1271
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -25279,13 +24509,13 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1275
+   i32.const 1272
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f64.const -8.06684839057968
-  call $~lib/math/NativeMath.exp
+  call $~lib/util/math/exp64
   f64.const 3.137706068161745e-04
   f64.const -0.2599197328090668
   call $std/math/check<f64>
@@ -25302,13 +24532,13 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1287
+   i32.const 1284
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f64.const 4.345239849338305
-  call $~lib/math/NativeMath.exp
+  call $~lib/util/math/exp64
   f64.const 77.11053017112141
   f64.const -0.02792675793170929
   call $std/math/check<f64>
@@ -25325,13 +24555,13 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1288
+   i32.const 1285
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f64.const -8.38143342755525
-  call $~lib/math/NativeMath.exp
+  call $~lib/util/math/exp64
   f64.const 2.290813384916323e-04
   f64.const -0.24974334239959717
   call $std/math/check<f64>
@@ -25348,13 +24578,13 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1289
+   i32.const 1286
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f64.const -6.531673581913484
-  call $~lib/math/NativeMath.exp
+  call $~lib/util/math/exp64
   f64.const 1.4565661260931588e-03
   f64.const -0.4816822409629822
   call $std/math/check<f64>
@@ -25371,13 +24601,13 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1290
+   i32.const 1287
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f64.const 9.267056966972586
-  call $~lib/math/NativeMath.exp
+  call $~lib/util/math/exp64
   f64.const 10583.558245524993
   f64.const 0.17696762084960938
   call $std/math/check<f64>
@@ -25394,13 +24624,13 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1291
+   i32.const 1288
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f64.const 0.6619858980995045
-  call $~lib/math/NativeMath.exp
+  call $~lib/util/math/exp64
   f64.const 1.9386384525571998
   f64.const -0.4964246451854706
   call $std/math/check<f64>
@@ -25417,13 +24647,13 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1292
+   i32.const 1289
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f64.const -0.4066039223853553
-  call $~lib/math/NativeMath.exp
+  call $~lib/util/math/exp64
   f64.const 0.6659078892838025
   f64.const -0.10608318448066711
   call $std/math/check<f64>
@@ -25440,13 +24670,13 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1293
+   i32.const 1290
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f64.const 0.5617597462207241
-  call $~lib/math/NativeMath.exp
+  call $~lib/util/math/exp64
   f64.const 1.7537559518626311
   f64.const -0.39162111282348633
   call $std/math/check<f64>
@@ -25463,13 +24693,13 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1294
+   i32.const 1291
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f64.const 0.7741522965913037
-  call $~lib/math/NativeMath.exp
+  call $~lib/util/math/exp64
   f64.const 2.1687528885129246
   f64.const -0.2996125817298889
   call $std/math/check<f64>
@@ -25486,13 +24716,13 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1295
+   i32.const 1292
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f64.const -0.6787637026394024
-  call $~lib/math/NativeMath.exp
+  call $~lib/util/math/exp64
   f64.const 0.5072437089402843
   f64.const 0.47261738777160645
   call $std/math/check<f64>
@@ -25509,13 +24739,13 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1296
+   i32.const 1293
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f64.const 0
-  call $~lib/math/NativeMath.exp
+  call $~lib/util/math/exp64
   f64.const 1
   f64.const 0
   call $std/math/check<f64>
@@ -25532,13 +24762,13 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1299
+   i32.const 1296
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f64.const -0
-  call $~lib/math/NativeMath.exp
+  call $~lib/util/math/exp64
   f64.const 1
   f64.const 0
   call $std/math/check<f64>
@@ -25555,13 +24785,13 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1300
+   i32.const 1297
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f64.const 1
-  call $~lib/math/NativeMath.exp
+  call $~lib/util/math/exp64
   f64.const 2.718281828459045
   f64.const -0.3255307376384735
   call $std/math/check<f64>
@@ -25578,13 +24808,13 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1301
+   i32.const 1298
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f64.const -1
-  call $~lib/math/NativeMath.exp
+  call $~lib/util/math/exp64
   f64.const 0.36787944117144233
   f64.const 0.22389651834964752
   call $std/math/check<f64>
@@ -25601,13 +24831,13 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1302
+   i32.const 1299
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f64.const inf
-  call $~lib/math/NativeMath.exp
+  call $~lib/util/math/exp64
   f64.const inf
   f64.const 0
   call $std/math/check<f64>
@@ -25624,13 +24854,13 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1303
+   i32.const 1300
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f64.const -inf
-  call $~lib/math/NativeMath.exp
+  call $~lib/util/math/exp64
   f64.const 0
   f64.const 0
   call $std/math/check<f64>
@@ -25647,13 +24877,13 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1304
+   i32.const 1301
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f64.const nan:0x8000000000000
-  call $~lib/math/NativeMath.exp
+  call $~lib/util/math/exp64
   f64.const nan:0x8000000000000
   f64.const 0
   call $std/math/check<f64>
@@ -25670,13 +24900,13 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1305
+   i32.const 1302
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f64.const 1.0397214889526365
-  call $~lib/math/NativeMath.exp
+  call $~lib/util/math/exp64
   f64.const 2.828429155876411
   f64.const 0.18803080916404724
   call $std/math/check<f64>
@@ -25693,13 +24923,13 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1306
+   i32.const 1303
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f64.const -1.0397214889526365
-  call $~lib/math/NativeMath.exp
+  call $~lib/util/math/exp64
   f64.const 0.35355313670217847
   f64.const 0.2527272403240204
   call $std/math/check<f64>
@@ -25716,13 +24946,13 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1307
+   i32.const 1304
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f64.const 1.0397210121154785
-  call $~lib/math/NativeMath.exp
+  call $~lib/util/math/exp64
   f64.const 2.8284278071766122
   f64.const -0.4184139370918274
   call $std/math/check<f64>
@@ -25739,13 +24969,13 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1308
+   i32.const 1305
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f64.const 1.0397214889526367
-  call $~lib/math/NativeMath.exp
+  call $~lib/util/math/exp64
   f64.const 2.8284291558764116
   f64.const -0.22618377208709717
   call $std/math/check<f64>
@@ -25762,13 +24992,13 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1309
+   i32.const 1306
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f64.const 5e-324
-  call $~lib/math/NativeMath.exp
+  call $~lib/util/math/exp64
   f64.const 1
   f64.const 0
   call $std/math/check<f64>
@@ -25785,13 +25015,13 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1312
+   i32.const 1309
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f64.const -5e-324
-  call $~lib/math/NativeMath.exp
+  call $~lib/util/math/exp64
   f64.const 1
   f64.const 0
   call $std/math/check<f64>
@@ -25808,13 +25038,13 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1313
+   i32.const 1310
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f64.const 709.782712893384
-  call $~lib/math/NativeMath.exp
+  call $~lib/util/math/exp64
   f64.const 1797693134862273196746681e284
   f64.const -0.10568465292453766
   call $std/math/check<f64>
@@ -25831,13 +25061,13 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1315
+   i32.const 1312
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f64.const 709.7827128933841
-  call $~lib/math/NativeMath.exp
+  call $~lib/util/math/exp64
   f64.const inf
   f64.const 0
   call $std/math/check<f64>
@@ -25854,13 +25084,13 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1322
+   i32.const 1319
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f64.const -745.1332191019411
-  call $~lib/math/NativeMath.exp
+  call $~lib/util/math/exp64
   f64.const 5e-324
   f64.const 0.5
   call $std/math/check<f64>
@@ -25877,13 +25107,13 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1323
+   i32.const 1320
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f64.const -745.1332191019412
-  call $~lib/math/NativeMath.exp
+  call $~lib/util/math/exp64
   f64.const 0
   f64.const -0.5
   call $std/math/check<f64>
@@ -25900,13 +25130,13 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1330
+   i32.const 1327
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f64.const -708.3964185322641
-  call $~lib/math/NativeMath.exp
+  call $~lib/util/math/exp64
   f64.const 2.2250738585072626e-308
   f64.const 0.26172348856925964
   call $std/math/check<f64>
@@ -25923,13 +25153,13 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1337
+   i32.const 1334
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f64.const -708.3964185322642
-  call $~lib/math/NativeMath.exp
+  call $~lib/util/math/exp64
   f64.const 2.2250738585070097e-308
   f64.const 2.2250738585070097e-308
   call $std/math/check<f64>
@@ -25946,13 +25176,13 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1344
+   i32.const 1341
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f64.const 0.5006933289508785
-  call $~lib/math/NativeMath.exp
+  call $~lib/util/math/exp64
   f64.const 1.6498647732549399
   f64.const 0.5
   call $std/math/check<f64>
@@ -25969,13 +25199,13 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1351
+   i32.const 1348
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f64.const 0.628493326460252
-  call $~lib/math/NativeMath.exp
+  call $~lib/util/math/exp64
   f64.const 1.8747837631658781
   f64.const 0.5
   call $std/math/check<f64>
@@ -25992,13 +25222,13 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1358
+   i32.const 1355
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f64.const 0.837522455340574
-  call $~lib/math/NativeMath.exp
+  call $~lib/util/math/exp64
   f64.const 2.3106351774748006
   f64.const -0.5
   call $std/math/check<f64>
@@ -26015,13 +25245,13 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1365
+   i32.const 1362
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f64.const 0.8504909932810999
-  call $~lib/math/NativeMath.exp
+  call $~lib/util/math/exp64
   f64.const 2.3407958848710777
   f64.const 0.5
   call $std/math/check<f64>
@@ -26038,13 +25268,13 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1371
+   i32.const 1368
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f64.const 1.6270060846924657
-  call $~lib/math/NativeMath.exp
+  call $~lib/util/math/exp64
   f64.const 5.088617001442459
   f64.const 0.5
   call $std/math/check<f64>
@@ -26061,13 +25291,13 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1377
+   i32.const 1374
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f64.const 1.6744336219614115
-  call $~lib/math/NativeMath.exp
+  call $~lib/util/math/exp64
   f64.const 5.335772228886831
   f64.const 0.5
   call $std/math/check<f64>
@@ -26084,13 +25314,13 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1383
+   i32.const 1380
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f64.const 6.657914718791208
-  call $~lib/math/NativeMath.exp
+  call $~lib/util/math/exp64
   f64.const 778.924964819056
   f64.const 0.5
   call $std/math/check<f64>
@@ -26107,13 +25337,13 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1390
+   i32.const 1387
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f64.const 11.022872793631722
-  call $~lib/math/NativeMath.exp
+  call $~lib/util/math/exp64
   f64.const 61259.41271820104
   f64.const 0.5
   call $std/math/check<f64>
@@ -26130,13 +25360,13 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1397
+   i32.const 1394
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f64.const 11.411195701885317
-  call $~lib/math/NativeMath.exp
+  call $~lib/util/math/exp64
   f64.const 90327.36165653409
   f64.const 0.5
   call $std/math/check<f64>
@@ -26153,13 +25383,13 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1404
+   i32.const 1401
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f64.const 11.794490387560606
-  call $~lib/math/NativeMath.exp
+  call $~lib/util/math/exp64
   f64.const 132520.20290772576
   f64.const 0.5
   call $std/math/check<f64>
@@ -26176,13 +25406,13 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1411
+   i32.const 1408
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f64.const 412.83872756953286
-  call $~lib/math/NativeMath.exp
+  call $~lib/util/math/exp64
   f64.const 1965989977109266413433084e155
   f64.const 0.5
   call $std/math/check<f64>
@@ -26199,13 +25429,13 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1418
+   i32.const 1415
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f64.const 510.87569028483415
-  call $~lib/math/NativeMath.exp
+  call $~lib/util/math/exp64
   f64.const 7421526272656495968225491e197
   f64.const -0.5
   call $std/math/check<f64>
@@ -26222,13 +25452,13 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1425
+   i32.const 1422
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f64.const -2.6589841439772853e-14
-  call $~lib/math/NativeMath.exp
+  call $~lib/util/math/exp64
   f64.const 0.9999999999999735
   f64.const 0.5
   call $std/math/check<f64>
@@ -26245,13 +25475,13 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1432
+   i32.const 1429
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f64.const -2.7144952952085447e-14
-  call $~lib/math/NativeMath.exp
+  call $~lib/util/math/exp64
   f64.const 0.9999999999999728
   f64.const -0.5
   call $std/math/check<f64>
@@ -26268,15 +25498,57 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1439
+   i32.const 1436
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f32.const -8.066848754882812
-  call $~lib/math/NativeMathf.exp
+  call $~lib/util/math/exp32
   f32.const 3.1377049162983894e-04
   f32.const -0.030193336308002472
+  call $std/math/check<f32>
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 1450
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const 4.345239639282227
+  call $~lib/util/math/exp32
+  f32.const 77.11051177978516
+  f32.const -0.2875460684299469
+  call $std/math/check<f32>
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 1451
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const -8.381433486938477
+  call $~lib/util/math/exp32
+  f32.const 2.2908132814336568e-04
+  f32.const 0.2237040400505066
+  call $std/math/check<f32>
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 1452
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const -6.531673431396484
+  call $~lib/util/math/exp32
+  f32.const 1.4565663877874613e-03
+  f32.const 0.36469703912734985
   call $std/math/check<f32>
   i32.eqz
   if
@@ -26287,10 +25559,10 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 4.345239639282227
-  call $~lib/math/NativeMathf.exp
-  f32.const 77.11051177978516
-  f32.const -0.2875460684299469
+  f32.const 9.267057418823242
+  call $~lib/util/math/exp32
+  f32.const 10583.5634765625
+  f32.const 0.45962104201316833
   call $std/math/check<f32>
   i32.eqz
   if
@@ -26301,10 +25573,10 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -8.381433486938477
-  call $~lib/math/NativeMathf.exp
-  f32.const 2.2908132814336568e-04
-  f32.const 0.2237040400505066
+  f32.const 0.6619858741760254
+  call $~lib/util/math/exp32
+  f32.const 1.93863844871521
+  f32.const 0.3568260967731476
   call $std/math/check<f32>
   i32.eqz
   if
@@ -26315,10 +25587,10 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -6.531673431396484
-  call $~lib/math/NativeMathf.exp
-  f32.const 1.4565663877874613e-03
-  f32.const 0.36469703912734985
+  f32.const -0.40660393238067627
+  call $~lib/util/math/exp32
+  f32.const 0.6659078598022461
+  f32.const -0.38294991850852966
   call $std/math/check<f32>
   i32.eqz
   if
@@ -26329,10 +25601,10 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 9.267057418823242
-  call $~lib/math/NativeMathf.exp
-  f32.const 10583.5634765625
-  f32.const 0.45962104201316833
+  f32.const 0.5617597699165344
+  call $~lib/util/math/exp32
+  f32.const 1.753756046295166
+  f32.const 0.44355490803718567
   call $std/math/check<f32>
   i32.eqz
   if
@@ -26343,10 +25615,10 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 0.6619858741760254
-  call $~lib/math/NativeMathf.exp
-  f32.const 1.93863844871521
-  f32.const 0.3568260967731476
+  f32.const 0.7741522789001465
+  call $~lib/util/math/exp32
+  f32.const 2.168752908706665
+  f32.const 0.24562469124794006
   call $std/math/check<f32>
   i32.eqz
   if
@@ -26357,10 +25629,10 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -0.40660393238067627
-  call $~lib/math/NativeMathf.exp
-  f32.const 0.6659078598022461
-  f32.const -0.38294991850852966
+  f32.const -0.6787636876106262
+  call $~lib/util/math/exp32
+  f32.const 0.5072436928749084
+  f32.const -0.3974292278289795
   call $std/math/check<f32>
   i32.eqz
   if
@@ -26371,38 +25643,10 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 0.5617597699165344
-  call $~lib/math/NativeMathf.exp
-  f32.const 1.753756046295166
-  f32.const 0.44355490803718567
-  call $std/math/check<f32>
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 1460
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const 0.7741522789001465
-  call $~lib/math/NativeMathf.exp
-  f32.const 2.168752908706665
-  f32.const 0.24562469124794006
-  call $std/math/check<f32>
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 1461
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const -0.6787636876106262
-  call $~lib/math/NativeMathf.exp
-  f32.const 0.5072436928749084
-  f32.const -0.3974292278289795
+  f32.const 0
+  call $~lib/util/math/exp32
+  f32.const 1
+  f32.const 0
   call $std/math/check<f32>
   i32.eqz
   if
@@ -26413,10 +25657,38 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 0
-  call $~lib/math/NativeMathf.exp
+  f32.const -0
+  call $~lib/util/math/exp32
   f32.const 1
   f32.const 0
+  call $std/math/check<f32>
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 1463
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const 1
+  call $~lib/util/math/exp32
+  f32.const 2.7182817459106445
+  f32.const -0.3462330996990204
+  call $std/math/check<f32>
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 1464
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const -1
+  call $~lib/util/math/exp32
+  f32.const 0.3678794503211975
+  f32.const 0.3070148527622223
   call $std/math/check<f32>
   i32.eqz
   if
@@ -26427,9 +25699,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -0
-  call $~lib/math/NativeMathf.exp
-  f32.const 1
+  f32.const inf
+  call $~lib/util/math/exp32
+  f32.const inf
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -26441,10 +25713,10 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 1
-  call $~lib/math/NativeMathf.exp
-  f32.const 2.7182817459106445
-  f32.const -0.3462330996990204
+  f32.const -inf
+  call $~lib/util/math/exp32
+  f32.const 0
+  f32.const 0
   call $std/math/check<f32>
   i32.eqz
   if
@@ -26455,10 +25727,10 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -1
-  call $~lib/math/NativeMathf.exp
-  f32.const 0.3678794503211975
-  f32.const 0.3070148527622223
+  f32.const nan:0x400000
+  call $~lib/util/math/exp32
+  f32.const nan:0x400000
+  f32.const 0
   call $std/math/check<f32>
   i32.eqz
   if
@@ -26469,10 +25741,10 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const inf
-  call $~lib/math/NativeMathf.exp
-  f32.const inf
-  f32.const 0
+  f32.const 88.72283172607422
+  call $~lib/util/math/exp32
+  f32.const 340279851902147610656242e15
+  f32.const -0.09067153930664062
   call $std/math/check<f32>
   i32.eqz
   if
@@ -26483,9 +25755,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -inf
-  call $~lib/math/NativeMathf.exp
-  f32.const 0
+  f32.const 88.72283935546875
+  call $~lib/util/math/exp32
+  f32.const inf
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -26497,10 +25769,10 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const nan:0x400000
-  call $~lib/math/NativeMathf.exp
-  f32.const nan:0x400000
-  f32.const 0
+  f32.const -103.97207641601562
+  call $~lib/util/math/exp32
+  f32.const 1.401298464324817e-45
+  f32.const 0.49999967217445374
   call $std/math/check<f32>
   i32.eqz
   if
@@ -26511,10 +25783,10 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 88.72283172607422
-  call $~lib/math/NativeMathf.exp
-  f32.const 340279851902147610656242e15
-  f32.const -0.09067153930664062
+  f32.const -103.97208404541016
+  call $~lib/util/math/exp32
+  f32.const 0
+  f32.const -0.49999651312828064
   call $std/math/check<f32>
   i32.eqz
   if
@@ -26525,10 +25797,10 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 88.72283935546875
-  call $~lib/math/NativeMathf.exp
-  f32.const inf
-  f32.const 0
+  f32.const 0.3465735614299774
+  call $~lib/util/math/exp32
+  f32.const 1.4142135381698608
+  f32.const 0.13922421634197235
   call $std/math/check<f32>
   i32.eqz
   if
@@ -26539,10 +25811,10 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -103.97207641601562
-  call $~lib/math/NativeMathf.exp
-  f32.const 1.401298464324817e-45
-  f32.const 0.49999967217445374
+  f32.const 0.3465735912322998
+  call $~lib/util/math/exp32
+  f32.const 1.4142135381698608
+  f32.const -0.21432916820049286
   call $std/math/check<f32>
   i32.eqz
   if
@@ -26553,10 +25825,10 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -103.97208404541016
-  call $~lib/math/NativeMathf.exp
-  f32.const 0
-  f32.const -0.49999651312828064
+  f32.const 0.3465736210346222
+  call $~lib/util/math/exp32
+  f32.const 1.4142136573791504
+  f32.const 0.43211743235588074
   call $std/math/check<f32>
   i32.eqz
   if
@@ -26567,50 +25839,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 0.3465735614299774
-  call $~lib/math/NativeMathf.exp
-  f32.const 1.4142135381698608
-  f32.const 0.13922421634197235
-  call $std/math/check<f32>
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 1476
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const 0.3465735912322998
-  call $~lib/math/NativeMathf.exp
-  f32.const 1.4142135381698608
-  f32.const -0.21432916820049286
-  call $std/math/check<f32>
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 1477
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const 0.3465736210346222
-  call $~lib/math/NativeMathf.exp
-  f32.const 1.4142136573791504
-  f32.const 0.43211743235588074
-  call $std/math/check<f32>
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 1478
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
   f64.const -8.06684839057968
-  call $~lib/math/NativeMath.expm1
+  call $~lib/util/math/expm1_64
   f64.const -0.9996862293931839
   f64.const -0.2760058343410492
   call $std/math/check<f64>
@@ -26627,13 +25857,13 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1490
+   i32.const 1487
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f64.const 4.345239849338305
-  call $~lib/math/NativeMath.expm1
+  call $~lib/util/math/expm1_64
   f64.const 76.11053017112141
   f64.const -0.02792675793170929
   call $std/math/check<f64>
@@ -26650,13 +25880,13 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1491
+   i32.const 1488
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f64.const -8.38143342755525
-  call $~lib/math/NativeMath.expm1
+  call $~lib/util/math/expm1_64
   f64.const -0.9997709186615084
   f64.const 0.10052496194839478
   call $std/math/check<f64>
@@ -26673,13 +25903,13 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1492
+   i32.const 1489
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f64.const -6.531673581913484
-  call $~lib/math/NativeMath.expm1
+  call $~lib/util/math/expm1_64
   f64.const -0.9985434338739069
   f64.const -0.27437829971313477
   call $std/math/check<f64>
@@ -26696,13 +25926,13 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1493
+   i32.const 1490
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f64.const 9.267056966972586
-  call $~lib/math/NativeMath.expm1
+  call $~lib/util/math/expm1_64
   f64.const 10582.558245524993
   f64.const 0.17696762084960938
   call $std/math/check<f64>
@@ -26719,13 +25949,13 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1494
+   i32.const 1491
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f64.const 0.6619858980995045
-  call $~lib/math/NativeMath.expm1
+  call $~lib/util/math/expm1_64
   f64.const 0.9386384525571999
   f64.const 0.007150684483349323
   call $std/math/check<f64>
@@ -26742,13 +25972,13 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1495
+   i32.const 1492
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f64.const -0.4066039223853553
-  call $~lib/math/NativeMath.expm1
+  call $~lib/util/math/expm1_64
   f64.const -0.3340921107161975
   f64.const -0.21216636896133423
   call $std/math/check<f64>
@@ -26765,13 +25995,13 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1496
+   i32.const 1493
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f64.const 0.5617597462207241
-  call $~lib/math/NativeMath.expm1
+  call $~lib/util/math/expm1_64
   f64.const 0.7537559518626312
   f64.const 0.21675777435302734
   call $std/math/check<f64>
@@ -26788,13 +26018,13 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1497
+   i32.const 1494
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f64.const 0.7741522965913037
-  call $~lib/math/NativeMath.expm1
+  call $~lib/util/math/expm1_64
   f64.const 1.1687528885129248
   f64.const 0.4007748067378998
   call $std/math/check<f64>
@@ -26811,13 +26041,13 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1498
+   i32.const 1495
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f64.const -0.6787637026394024
-  call $~lib/math/NativeMath.expm1
+  call $~lib/util/math/expm1_64
   f64.const -0.4927562910597158
   f64.const -0.05476519837975502
   call $std/math/check<f64>
@@ -26834,36 +26064,36 @@
   if
    i32.const 0
    i32.const 1056
+   i32.const 1496
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const 0
+  call $~lib/util/math/expm1_64
+  f64.const 0
+  f64.const 0
+  call $std/math/check<f64>
+  if (result i32)
+   f64.const 0
+   call $~lib/bindings/dom/Math.expm1
+   f64.const 0
+   f64.const 0
+   call $std/math/check<f64>
+  else
+   i32.const 0
+  end
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1056
    i32.const 1499
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 0
-  call $~lib/math/NativeMath.expm1
-  f64.const 0
-  f64.const 0
-  call $std/math/check<f64>
-  if (result i32)
-   f64.const 0
-   call $~lib/bindings/dom/Math.expm1
-   f64.const 0
-   f64.const 0
-   call $std/math/check<f64>
-  else
-   i32.const 0
-  end
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 1502
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
   f64.const -0
-  call $~lib/math/NativeMath.expm1
+  call $~lib/util/math/expm1_64
   f64.const -0
   f64.const 0
   call $std/math/check<f64>
@@ -26880,13 +26110,13 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1503
+   i32.const 1500
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f64.const 1
-  call $~lib/math/NativeMath.expm1
+  call $~lib/util/math/expm1_64
   f64.const 1.7182818284590453
   f64.const 0.348938524723053
   call $std/math/check<f64>
@@ -26903,13 +26133,13 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1504
+   i32.const 1501
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f64.const -1
-  call $~lib/math/NativeMath.expm1
+  call $~lib/util/math/expm1_64
   f64.const -0.6321205588285577
   f64.const 0.11194825917482376
   call $std/math/check<f64>
@@ -26926,13 +26156,13 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1505
+   i32.const 1502
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f64.const inf
-  call $~lib/math/NativeMath.expm1
+  call $~lib/util/math/expm1_64
   f64.const inf
   f64.const 0
   call $std/math/check<f64>
@@ -26949,13 +26179,13 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1506
+   i32.const 1503
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f64.const -inf
-  call $~lib/math/NativeMath.expm1
+  call $~lib/util/math/expm1_64
   f64.const -1
   f64.const 0
   call $std/math/check<f64>
@@ -26972,84 +26202,126 @@
   if
    i32.const 0
    i32.const 1056
+   i32.const 1504
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const nan:0x8000000000000
+  call $~lib/util/math/expm1_64
+  f64.const nan:0x8000000000000
+  f64.const 0
+  call $std/math/check<f64>
+  if (result i32)
+   f64.const nan:0x8000000000000
+   call $~lib/bindings/dom/Math.expm1
+   f64.const nan:0x8000000000000
+   f64.const 0
+   call $std/math/check<f64>
+  else
+   i32.const 0
+  end
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 1505
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const 2.225073858507201e-308
+  call $~lib/util/math/expm1_64
+  f64.const 2.225073858507201e-308
+  f64.const 0
+  call $std/math/check<f64>
+  if (result i32)
+   f64.const 2.225073858507201e-308
+   call $~lib/bindings/dom/Math.expm1
+   f64.const 2.225073858507201e-308
+   f64.const 0
+   call $std/math/check<f64>
+  else
+   i32.const 0
+  end
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 1506
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const -2.225073858507201e-308
+  call $~lib/util/math/expm1_64
+  f64.const -2.225073858507201e-308
+  f64.const 0
+  call $std/math/check<f64>
+  if (result i32)
+   f64.const -2.225073858507201e-308
+   call $~lib/bindings/dom/Math.expm1
+   f64.const -2.225073858507201e-308
+   f64.const 0
+   call $std/math/check<f64>
+  else
+   i32.const 0
+  end
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1056
    i32.const 1507
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const nan:0x8000000000000
-  call $~lib/math/NativeMath.expm1
-  f64.const nan:0x8000000000000
-  f64.const 0
-  call $std/math/check<f64>
-  if (result i32)
-   f64.const nan:0x8000000000000
-   call $~lib/bindings/dom/Math.expm1
-   f64.const nan:0x8000000000000
-   f64.const 0
-   call $std/math/check<f64>
-  else
-   i32.const 0
-  end
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 1508
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const 2.225073858507201e-308
-  call $~lib/math/NativeMath.expm1
-  f64.const 2.225073858507201e-308
-  f64.const 0
-  call $std/math/check<f64>
-  if (result i32)
-   f64.const 2.225073858507201e-308
-   call $~lib/bindings/dom/Math.expm1
-   f64.const 2.225073858507201e-308
-   f64.const 0
-   call $std/math/check<f64>
-  else
-   i32.const 0
-  end
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 1509
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const -2.225073858507201e-308
-  call $~lib/math/NativeMath.expm1
-  f64.const -2.225073858507201e-308
-  f64.const 0
-  call $std/math/check<f64>
-  if (result i32)
-   f64.const -2.225073858507201e-308
-   call $~lib/bindings/dom/Math.expm1
-   f64.const -2.225073858507201e-308
-   f64.const 0
-   call $std/math/check<f64>
-  else
-   i32.const 0
-  end
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 1510
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
   f32.const -8.066848754882812
-  call $~lib/math/NativeMathf.expm1
+  call $~lib/util/math/expm1_32
   f32.const -0.9996862411499023
   f32.const -0.19532723724842072
+  call $std/math/check<f32>
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 1516
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const 4.345239639282227
+  call $~lib/util/math/expm1_32
+  f32.const 76.11051177978516
+  f32.const -0.2875460684299469
+  call $std/math/check<f32>
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 1517
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const -8.381433486938477
+  call $~lib/util/math/expm1_32
+  f32.const -0.9997709393501282
+  f32.const -0.34686920046806335
+  call $std/math/check<f32>
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 1518
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const -6.531673431396484
+  call $~lib/util/math/expm1_32
+  f32.const -0.9985434412956238
+  f32.const -0.1281939446926117
   call $std/math/check<f32>
   i32.eqz
   if
@@ -27060,10 +26332,10 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 4.345239639282227
-  call $~lib/math/NativeMathf.expm1
-  f32.const 76.11051177978516
-  f32.const -0.2875460684299469
+  f32.const 9.267057418823242
+  call $~lib/util/math/expm1_32
+  f32.const 10582.5634765625
+  f32.const 0.45962104201316833
   call $std/math/check<f32>
   i32.eqz
   if
@@ -27074,10 +26346,10 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -8.381433486938477
-  call $~lib/math/NativeMathf.expm1
-  f32.const -0.9997709393501282
-  f32.const -0.34686920046806335
+  f32.const 0.6619858741760254
+  call $~lib/util/math/expm1_32
+  f32.const 0.9386383891105652
+  f32.const -0.28634780645370483
   call $std/math/check<f32>
   i32.eqz
   if
@@ -27088,10 +26360,10 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -6.531673431396484
-  call $~lib/math/NativeMathf.expm1
-  f32.const -0.9985434412956238
-  f32.const -0.1281939446926117
+  f32.const -0.40660393238067627
+  call $~lib/util/math/expm1_32
+  f32.const -0.3340921103954315
+  f32.const 0.23410017788410187
   call $std/math/check<f32>
   i32.eqz
   if
@@ -27102,10 +26374,10 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 9.267057418823242
-  call $~lib/math/NativeMathf.expm1
-  f32.const 10582.5634765625
-  f32.const 0.45962104201316833
+  f32.const 0.5617597699165344
+  call $~lib/util/math/expm1_32
+  f32.const 0.7537559866905212
+  f32.const -0.11289017647504807
   call $std/math/check<f32>
   i32.eqz
   if
@@ -27116,10 +26388,10 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 0.6619858741760254
-  call $~lib/math/NativeMathf.expm1
-  f32.const 0.9386383891105652
-  f32.const -0.28634780645370483
+  f32.const 0.7741522789001465
+  call $~lib/util/math/expm1_32
+  f32.const 1.168752908706665
+  f32.const 0.4912493824958801
   call $std/math/check<f32>
   i32.eqz
   if
@@ -27130,10 +26402,10 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -0.40660393238067627
-  call $~lib/math/NativeMathf.expm1
-  f32.const -0.3340921103954315
-  f32.const 0.23410017788410187
+  f32.const -0.6787636876106262
+  call $~lib/util/math/expm1_32
+  f32.const -0.49275627732276917
+  f32.const 0.20514154434204102
   call $std/math/check<f32>
   i32.eqz
   if
@@ -27144,38 +26416,10 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 0.5617597699165344
-  call $~lib/math/NativeMathf.expm1
-  f32.const 0.7537559866905212
-  f32.const -0.11289017647504807
-  call $std/math/check<f32>
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 1526
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const 0.7741522789001465
-  call $~lib/math/NativeMathf.expm1
-  f32.const 1.168752908706665
-  f32.const 0.4912493824958801
-  call $std/math/check<f32>
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 1527
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const -0.6787636876106262
-  call $~lib/math/NativeMathf.expm1
-  f32.const -0.49275627732276917
-  f32.const 0.20514154434204102
+  f32.const 0
+  call $~lib/util/math/expm1_32
+  f32.const 0
+  f32.const 0
   call $std/math/check<f32>
   i32.eqz
   if
@@ -27186,10 +26430,38 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f32.const -0
+  call $~lib/util/math/expm1_32
+  f32.const -0
   f32.const 0
-  call $~lib/math/NativeMathf.expm1
-  f32.const 0
-  f32.const 0
+  call $std/math/check<f32>
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 1529
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const 1
+  call $~lib/util/math/expm1_32
+  f32.const 1.718281865119934
+  f32.const 0.3075338304042816
+  call $std/math/check<f32>
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 1530
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const -1
+  call $~lib/util/math/expm1_32
+  f32.const -0.6321205496788025
+  f32.const 0.15350742638111115
   call $std/math/check<f32>
   i32.eqz
   if
@@ -27200,9 +26472,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -0
-  call $~lib/math/NativeMathf.expm1
-  f32.const -0
+  f32.const inf
+  call $~lib/util/math/expm1_32
+  f32.const inf
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -27214,10 +26486,10 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 1
-  call $~lib/math/NativeMathf.expm1
-  f32.const 1.718281865119934
-  f32.const 0.3075338304042816
+  f32.const -inf
+  call $~lib/util/math/expm1_32
+  f32.const -1
+  f32.const 0
   call $std/math/check<f32>
   i32.eqz
   if
@@ -27228,58 +26500,16 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -1
-  call $~lib/math/NativeMathf.expm1
-  f32.const -0.6321205496788025
-  f32.const 0.15350742638111115
+  f32.const nan:0x400000
+  call $~lib/util/math/expm1_32
+  f32.const nan:0x400000
+  f32.const 0
   call $std/math/check<f32>
   i32.eqz
   if
    i32.const 0
    i32.const 1056
    i32.const 1534
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const inf
-  call $~lib/math/NativeMathf.expm1
-  f32.const inf
-  f32.const 0
-  call $std/math/check<f32>
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 1535
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const -inf
-  call $~lib/math/NativeMathf.expm1
-  f32.const -1
-  f32.const 0
-  call $std/math/check<f32>
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 1536
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const nan:0x400000
-  call $~lib/math/NativeMathf.expm1
-  f32.const nan:0x400000
-  f32.const 0
-  call $std/math/check<f32>
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 1537
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -27292,7 +26522,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1549
+   i32.const 1546
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -27305,7 +26535,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1550
+   i32.const 1547
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -27318,7 +26548,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1551
+   i32.const 1548
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -27331,7 +26561,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1552
+   i32.const 1549
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -27344,7 +26574,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1553
+   i32.const 1550
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -27357,7 +26587,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1554
+   i32.const 1551
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -27370,7 +26600,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1555
+   i32.const 1552
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -27383,7 +26613,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1556
+   i32.const 1553
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -27396,7 +26626,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1557
+   i32.const 1554
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -27404,6 +26634,19 @@
   f64.const -0.6787637026394024
   f64.const 0.6247003734030933
   f64.const -0.31195688247680664
+  call $std/math/test_exp2
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 1555
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const 0
+  f64.const 1
+  f64.const 0
   call $std/math/test_exp2
   i32.eqz
   if
@@ -27422,20 +26665,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1561
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const 0
-  f64.const 1
-  f64.const 0
-  call $std/math/test_exp2
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 1562
+   i32.const 1559
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -27448,7 +26678,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1563
+   i32.const 1560
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -27461,7 +26691,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1564
+   i32.const 1561
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -27474,7 +26704,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1565
+   i32.const 1562
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -27487,7 +26717,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1566
+   i32.const 1563
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -27500,7 +26730,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1567
+   i32.const 1564
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -27513,7 +26743,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1568
+   i32.const 1565
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -27526,7 +26756,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1569
+   i32.const 1566
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -27539,7 +26769,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1570
+   i32.const 1567
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -27552,7 +26782,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1571
+   i32.const 1568
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -27565,7 +26795,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1572
+   i32.const 1569
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -27578,7 +26808,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1573
+   i32.const 1570
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -27591,7 +26821,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1574
+   i32.const 1571
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -27604,7 +26834,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1575
+   i32.const 1572
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -27617,7 +26847,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1576
+   i32.const 1573
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -27630,7 +26860,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1577
+   i32.const 1574
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -27643,7 +26873,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1578
+   i32.const 1575
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -27656,7 +26886,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1579
+   i32.const 1576
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -27669,7 +26899,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1580
+   i32.const 1577
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -27682,7 +26912,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1581
+   i32.const 1578
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -27695,7 +26925,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1582
+   i32.const 1579
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -27708,7 +26938,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1583
+   i32.const 1580
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -27721,7 +26951,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1584
+   i32.const 1581
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -27734,7 +26964,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1585
+   i32.const 1582
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -27747,7 +26977,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1596
+   i32.const 1593
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -27760,7 +26990,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1597
+   i32.const 1594
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -27773,7 +27003,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1598
+   i32.const 1595
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -27786,7 +27016,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1599
+   i32.const 1596
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -27799,7 +27029,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1600
+   i32.const 1597
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -27812,7 +27042,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1601
+   i32.const 1598
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -27825,7 +27055,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1602
+   i32.const 1599
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -27838,7 +27068,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1603
+   i32.const 1600
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -27851,7 +27081,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1604
+   i32.const 1601
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -27864,7 +27094,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1605
+   i32.const 1602
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -27886,7 +27116,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1617
+   i32.const 1614
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -27908,7 +27138,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1618
+   i32.const 1615
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -27930,7 +27160,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1619
+   i32.const 1616
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -27952,7 +27182,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1620
+   i32.const 1617
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -27974,7 +27204,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1621
+   i32.const 1618
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -27996,7 +27226,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1622
+   i32.const 1619
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -28018,7 +27248,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1623
+   i32.const 1620
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -28040,7 +27270,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1624
+   i32.const 1621
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -28062,7 +27292,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1625
+   i32.const 1622
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -28084,7 +27314,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1626
+   i32.const 1623
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -28097,6 +27327,72 @@
    f64.const nan:0x8000000000000
    call $~lib/bindings/dom/Math.floor
    f64.const nan:0x8000000000000
+   f64.const 0
+   call $std/math/check<f64>
+  else
+   i32.const 0
+  end
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 1626
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const inf
+  f64.const inf
+  f64.const 0
+  call $std/math/check<f64>
+  if (result i32)
+   f64.const inf
+   call $~lib/bindings/dom/Math.floor
+   f64.const inf
+   f64.const 0
+   call $std/math/check<f64>
+  else
+   i32.const 0
+  end
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 1627
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const -inf
+  f64.const -inf
+  f64.const 0
+  call $std/math/check<f64>
+  if (result i32)
+   f64.const -inf
+   call $~lib/bindings/dom/Math.floor
+   f64.const -inf
+   f64.const 0
+   call $std/math/check<f64>
+  else
+   i32.const 0
+  end
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 1628
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const 0
+  f64.const 0
+  f64.const 0
+  call $std/math/check<f64>
+  if (result i32)
+   f64.const 0
+   call $~lib/bindings/dom/Math.floor
+   f64.const 0
    f64.const 0
    call $std/math/check<f64>
   else
@@ -28111,14 +27407,14 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const inf
-  f64.const inf
+  f64.const -0
+  f64.const -0
   f64.const 0
   call $std/math/check<f64>
   if (result i32)
-   f64.const inf
+   f64.const -0
    call $~lib/bindings/dom/Math.floor
-   f64.const inf
+   f64.const -0
    f64.const 0
    call $std/math/check<f64>
   else
@@ -28133,14 +27429,14 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -inf
-  f64.const -inf
+  f64.const 1
+  f64.const 1
   f64.const 0
   call $std/math/check<f64>
   if (result i32)
-   f64.const -inf
+   f64.const 1
    call $~lib/bindings/dom/Math.floor
-   f64.const -inf
+   f64.const 1
    f64.const 0
    call $std/math/check<f64>
   else
@@ -28155,14 +27451,14 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 0
-  f64.const 0
+  f64.const -1
+  f64.const -1
   f64.const 0
   call $std/math/check<f64>
   if (result i32)
-   f64.const 0
+   f64.const -1
    call $~lib/bindings/dom/Math.floor
-   f64.const 0
+   f64.const -1
    f64.const 0
    call $std/math/check<f64>
   else
@@ -28173,72 +27469,6 @@
    i32.const 0
    i32.const 1056
    i32.const 1632
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const -0
-  f64.const -0
-  f64.const 0
-  call $std/math/check<f64>
-  if (result i32)
-   f64.const -0
-   call $~lib/bindings/dom/Math.floor
-   f64.const -0
-   f64.const 0
-   call $std/math/check<f64>
-  else
-   i32.const 0
-  end
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 1633
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const 1
-  f64.const 1
-  f64.const 0
-  call $std/math/check<f64>
-  if (result i32)
-   f64.const 1
-   call $~lib/bindings/dom/Math.floor
-   f64.const 1
-   f64.const 0
-   call $std/math/check<f64>
-  else
-   i32.const 0
-  end
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 1634
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const -1
-  f64.const -1
-  f64.const 0
-  call $std/math/check<f64>
-  if (result i32)
-   f64.const -1
-   call $~lib/bindings/dom/Math.floor
-   f64.const -1
-   f64.const 0
-   call $std/math/check<f64>
-  else
-   i32.const 0
-  end
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 1635
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -28260,7 +27490,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1636
+   i32.const 1633
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -28282,7 +27512,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1637
+   i32.const 1634
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -28304,7 +27534,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1638
+   i32.const 1635
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -28326,7 +27556,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1639
+   i32.const 1636
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -28348,7 +27578,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1640
+   i32.const 1637
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -28370,7 +27600,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1641
+   i32.const 1638
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -28392,7 +27622,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1642
+   i32.const 1639
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -28414,13 +27644,52 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1643
+   i32.const 1640
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f32.const -9
   f32.const -9
+  f32.const 0
+  call $std/math/check<f32>
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 1649
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const 4
+  f32.const 4
+  f32.const 0
+  call $std/math/check<f32>
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 1650
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const -9
+  f32.const -9
+  f32.const 0
+  call $std/math/check<f32>
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 1651
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const -7
+  f32.const -7
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -28432,8 +27701,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 4
-  f32.const 4
+  f32.const 9
+  f32.const 9
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -28445,8 +27714,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -9
-  f32.const -9
+  f32.const 0
+  f32.const 0
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -28458,8 +27727,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -7
-  f32.const -7
+  f32.const -1
+  f32.const -1
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -28471,8 +27740,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 9
-  f32.const 9
+  f32.const 0
+  f32.const 0
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -28510,34 +27779,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 0
-  f32.const 0
-  f32.const 0
-  call $std/math/check<f32>
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 1659
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const 0
-  f32.const 0
-  f32.const 0
-  call $std/math/check<f32>
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 1660
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const -1
-  f32.const -1
+  f32.const nan:0x400000
+  f32.const nan:0x400000
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -28549,8 +27792,34 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const nan:0x400000
-  f32.const nan:0x400000
+  f32.const inf
+  f32.const inf
+  f32.const 0
+  call $std/math/check<f32>
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 1662
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const -inf
+  f32.const -inf
+  f32.const 0
+  call $std/math/check<f32>
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 1663
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const 0
+  f32.const 0
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -28562,8 +27831,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const inf
-  f32.const inf
+  f32.const -0
+  f32.const -0
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -28575,8 +27844,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -inf
-  f32.const -inf
+  f32.const 1
+  f32.const 1
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -28588,8 +27857,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 0
-  f32.const 0
+  f32.const -1
+  f32.const -1
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -28601,8 +27870,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -0
-  f32.const -0
+  f32.const 0
+  f32.const 0
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -28614,8 +27883,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 1
-  f32.const 1
+  f32.const -1
+  f32.const -1
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -28627,8 +27896,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -1
-  f32.const -1
+  f32.const 1
+  f32.const 1
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -28640,8 +27909,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 0
-  f32.const 0
+  f32.const -2
+  f32.const -2
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -28653,8 +27922,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -1
-  f32.const -1
+  f32.const 0
+  f32.const 0
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -28666,8 +27935,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 1
-  f32.const 1
+  f32.const -1
+  f32.const -1
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -28679,8 +27948,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -2
-  f32.const -2
+  f32.const 0
+  f32.const 0
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -28692,8 +27961,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 0
-  f32.const 0
+  f32.const -1
+  f32.const -1
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -28701,45 +27970,6 @@
    i32.const 0
    i32.const 1056
    i32.const 1675
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const -1
-  f32.const -1
-  f32.const 0
-  call $std/math/check<f32>
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 1676
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const 0
-  f32.const 0
-  f32.const 0
-  call $std/math/check<f32>
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 1677
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const -1
-  f32.const -1
-  f32.const 0
-  call $std/math/check<f32>
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 1678
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -28753,7 +27983,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1692
+   i32.const 1689
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -28767,7 +27997,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1693
+   i32.const 1690
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -28781,7 +28011,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1694
+   i32.const 1691
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -28795,7 +28025,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1695
+   i32.const 1692
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -28809,7 +28039,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1696
+   i32.const 1693
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -28823,7 +28053,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1697
+   i32.const 1694
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -28837,7 +28067,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1698
+   i32.const 1695
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -28851,7 +28081,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1699
+   i32.const 1696
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -28865,7 +28095,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1700
+   i32.const 1697
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -28879,13 +28109,55 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1701
+   i32.const 1698
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f64.const 3
   f64.const 4
+  f64.const 5
+  f64.const 0
+  call $std/math/test_hypot
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 1701
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const -3
+  f64.const 4
+  f64.const 5
+  f64.const 0
+  call $std/math/test_hypot
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 1702
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const 4
+  f64.const 3
+  f64.const 5
+  f64.const 0
+  call $std/math/test_hypot
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 1703
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const 4
+  f64.const -3
   f64.const 5
   f64.const 0
   call $std/math/test_hypot
@@ -28899,7 +28171,7 @@
    unreachable
   end
   f64.const -3
-  f64.const 4
+  f64.const -4
   f64.const 5
   f64.const 0
   call $std/math/test_hypot
@@ -28912,9 +28184,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 4
-  f64.const 3
-  f64.const 5
+  f64.const 1797693134862315708145274e284
+  f64.const 0
+  f64.const 1797693134862315708145274e284
   f64.const 0
   call $std/math/test_hypot
   i32.eqz
@@ -28926,9 +28198,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 4
-  f64.const -3
-  f64.const 5
+  f64.const 1797693134862315708145274e284
+  f64.const -0
+  f64.const 1797693134862315708145274e284
   f64.const 0
   call $std/math/test_hypot
   i32.eqz
@@ -28940,9 +28212,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -3
-  f64.const -4
-  f64.const 5
+  f64.const 5e-324
+  f64.const 0
+  f64.const 5e-324
   f64.const 0
   call $std/math/test_hypot
   i32.eqz
@@ -28954,9 +28226,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 1797693134862315708145274e284
-  f64.const 0
-  f64.const 1797693134862315708145274e284
+  f64.const 5e-324
+  f64.const -0
+  f64.const 5e-324
   f64.const 0
   call $std/math/test_hypot
   i32.eqz
@@ -28968,9 +28240,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 1797693134862315708145274e284
-  f64.const -0
-  f64.const 1797693134862315708145274e284
+  f64.const inf
+  f64.const 1
+  f64.const inf
   f64.const 0
   call $std/math/test_hypot
   i32.eqz
@@ -28982,9 +28254,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 5e-324
-  f64.const 0
-  f64.const 5e-324
+  f64.const 1
+  f64.const inf
+  f64.const inf
   f64.const 0
   call $std/math/test_hypot
   i32.eqz
@@ -28996,9 +28268,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 5e-324
-  f64.const -0
-  f64.const 5e-324
+  f64.const inf
+  f64.const nan:0x8000000000000
+  f64.const inf
   f64.const 0
   call $std/math/test_hypot
   i32.eqz
@@ -29010,8 +28282,8 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f64.const nan:0x8000000000000
   f64.const inf
-  f64.const 1
   f64.const inf
   f64.const 0
   call $std/math/test_hypot
@@ -29024,8 +28296,8 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f64.const -inf
   f64.const 1
-  f64.const inf
   f64.const inf
   f64.const 0
   call $std/math/test_hypot
@@ -29038,8 +28310,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const inf
-  f64.const nan:0x8000000000000
+  f64.const 1
+  f64.const -inf
   f64.const inf
   f64.const 0
   call $std/math/test_hypot
@@ -29052,8 +28324,8 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f64.const -inf
   f64.const nan:0x8000000000000
-  f64.const inf
   f64.const inf
   f64.const 0
   call $std/math/test_hypot
@@ -29066,8 +28338,8 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f64.const nan:0x8000000000000
   f64.const -inf
-  f64.const 1
   f64.const inf
   f64.const 0
   call $std/math/test_hypot
@@ -29080,9 +28352,9 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f64.const nan:0x8000000000000
   f64.const 1
-  f64.const -inf
-  f64.const inf
+  f64.const nan:0x8000000000000
   f64.const 0
   call $std/math/test_hypot
   i32.eqz
@@ -29094,9 +28366,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -inf
+  f64.const 1
   f64.const nan:0x8000000000000
-  f64.const inf
+  f64.const nan:0x8000000000000
   f64.const 0
   call $std/math/test_hypot
   i32.eqz
@@ -29109,8 +28381,8 @@
    unreachable
   end
   f64.const nan:0x8000000000000
-  f64.const -inf
-  f64.const inf
+  f64.const 0
+  f64.const nan:0x8000000000000
   f64.const 0
   call $std/math/test_hypot
   i32.eqz
@@ -29122,8 +28394,8 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f64.const 0
   f64.const nan:0x8000000000000
-  f64.const 1
   f64.const nan:0x8000000000000
   f64.const 0
   call $std/math/test_hypot
@@ -29132,48 +28404,6 @@
    i32.const 0
    i32.const 1056
    i32.const 1721
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const 1
-  f64.const nan:0x8000000000000
-  f64.const nan:0x8000000000000
-  f64.const 0
-  call $std/math/test_hypot
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 1722
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const nan:0x8000000000000
-  f64.const 0
-  f64.const nan:0x8000000000000
-  f64.const 0
-  call $std/math/test_hypot
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 1723
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const 0
-  f64.const nan:0x8000000000000
-  f64.const nan:0x8000000000000
-  f64.const 0
-  call $std/math/test_hypot
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 1724
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -29187,7 +28417,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1733
+   i32.const 1730
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -29201,7 +28431,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1734
+   i32.const 1731
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -29215,7 +28445,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1735
+   i32.const 1732
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -29229,7 +28459,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1736
+   i32.const 1733
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -29243,7 +28473,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1737
+   i32.const 1734
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -29257,7 +28487,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1738
+   i32.const 1735
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -29271,7 +28501,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1739
+   i32.const 1736
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -29285,7 +28515,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1740
+   i32.const 1737
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -29299,7 +28529,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1741
+   i32.const 1738
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -29313,13 +28543,55 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1742
+   i32.const 1739
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f32.const 3
   f32.const 4
+  f32.const 5
+  f32.const 0
+  call $std/math/test_hypotf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 1742
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const -3
+  f32.const 4
+  f32.const 5
+  f32.const 0
+  call $std/math/test_hypotf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 1743
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const 4
+  f32.const 3
+  f32.const 5
+  f32.const 0
+  call $std/math/test_hypotf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 1744
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const 4
+  f32.const -3
   f32.const 5
   f32.const 0
   call $std/math/test_hypotf
@@ -29333,7 +28605,7 @@
    unreachable
   end
   f32.const -3
-  f32.const 4
+  f32.const -4
   f32.const 5
   f32.const 0
   call $std/math/test_hypotf
@@ -29346,9 +28618,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 4
-  f32.const 3
-  f32.const 5
+  f32.const 3402823466385288598117041e14
+  f32.const 0
+  f32.const 3402823466385288598117041e14
   f32.const 0
   call $std/math/test_hypotf
   i32.eqz
@@ -29360,9 +28632,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 4
-  f32.const -3
-  f32.const 5
+  f32.const 3402823466385288598117041e14
+  f32.const -0
+  f32.const 3402823466385288598117041e14
   f32.const 0
   call $std/math/test_hypotf
   i32.eqz
@@ -29374,9 +28646,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -3
-  f32.const -4
-  f32.const 5
+  f32.const 1.401298464324817e-45
+  f32.const 0
+  f32.const 1.401298464324817e-45
   f32.const 0
   call $std/math/test_hypotf
   i32.eqz
@@ -29388,9 +28660,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 3402823466385288598117041e14
-  f32.const 0
-  f32.const 3402823466385288598117041e14
+  f32.const 1.401298464324817e-45
+  f32.const -0
+  f32.const 1.401298464324817e-45
   f32.const 0
   call $std/math/test_hypotf
   i32.eqz
@@ -29402,9 +28674,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 3402823466385288598117041e14
-  f32.const -0
-  f32.const 3402823466385288598117041e14
+  f32.const inf
+  f32.const 1
+  f32.const inf
   f32.const 0
   call $std/math/test_hypotf
   i32.eqz
@@ -29416,9 +28688,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 1.401298464324817e-45
-  f32.const 0
-  f32.const 1.401298464324817e-45
+  f32.const 1
+  f32.const inf
+  f32.const inf
   f32.const 0
   call $std/math/test_hypotf
   i32.eqz
@@ -29430,9 +28702,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 1.401298464324817e-45
-  f32.const -0
-  f32.const 1.401298464324817e-45
+  f32.const inf
+  f32.const nan:0x400000
+  f32.const inf
   f32.const 0
   call $std/math/test_hypotf
   i32.eqz
@@ -29444,8 +28716,8 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f32.const nan:0x400000
   f32.const inf
-  f32.const 1
   f32.const inf
   f32.const 0
   call $std/math/test_hypotf
@@ -29458,8 +28730,8 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f32.const -inf
   f32.const 1
-  f32.const inf
   f32.const inf
   f32.const 0
   call $std/math/test_hypotf
@@ -29472,8 +28744,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const inf
-  f32.const nan:0x400000
+  f32.const 1
+  f32.const -inf
   f32.const inf
   f32.const 0
   call $std/math/test_hypotf
@@ -29486,8 +28758,8 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f32.const -inf
   f32.const nan:0x400000
-  f32.const inf
   f32.const inf
   f32.const 0
   call $std/math/test_hypotf
@@ -29500,8 +28772,8 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f32.const nan:0x400000
   f32.const -inf
-  f32.const 1
   f32.const inf
   f32.const 0
   call $std/math/test_hypotf
@@ -29514,9 +28786,9 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f32.const nan:0x400000
   f32.const 1
-  f32.const -inf
-  f32.const inf
+  f32.const nan:0x400000
   f32.const 0
   call $std/math/test_hypotf
   i32.eqz
@@ -29528,9 +28800,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -inf
+  f32.const 1
   f32.const nan:0x400000
-  f32.const inf
+  f32.const nan:0x400000
   f32.const 0
   call $std/math/test_hypotf
   i32.eqz
@@ -29542,50 +28814,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const nan:0x400000
-  f32.const -inf
-  f32.const inf
-  f32.const 0
-  call $std/math/test_hypotf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 1761
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const nan:0x400000
-  f32.const 1
-  f32.const nan:0x400000
-  f32.const 0
-  call $std/math/test_hypotf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 1762
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const 1
-  f32.const nan:0x400000
-  f32.const nan:0x400000
-  f32.const 0
-  call $std/math/test_hypotf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 1763
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
   f64.const -8.06684839057968
-  call $~lib/math/NativeMath.log
+  call $~lib/util/math/log64
   f64.const nan:0x8000000000000
   f64.const 0
   call $std/math/check<f64>
@@ -29602,13 +28832,13 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1775
+   i32.const 1772
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f64.const 4.345239849338305
-  call $~lib/math/NativeMath.log
+  call $~lib/util/math/log64
   f64.const 1.4690809584224322
   f64.const -0.3412533402442932
   call $std/math/check<f64>
@@ -29625,13 +28855,13 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1776
+   i32.const 1773
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f64.const -8.38143342755525
-  call $~lib/math/NativeMath.log
+  call $~lib/util/math/log64
   f64.const nan:0x8000000000000
   f64.const 0
   call $std/math/check<f64>
@@ -29648,13 +28878,13 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1777
+   i32.const 1774
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f64.const -6.531673581913484
-  call $~lib/math/NativeMath.log
+  call $~lib/util/math/log64
   f64.const nan:0x8000000000000
   f64.const 0
   call $std/math/check<f64>
@@ -29671,13 +28901,13 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1778
+   i32.const 1775
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f64.const 9.267056966972586
-  call $~lib/math/NativeMath.log
+  call $~lib/util/math/log64
   f64.const 2.2264658498795615
   f64.const 0.3638114035129547
   call $std/math/check<f64>
@@ -29694,13 +28924,13 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1779
+   i32.const 1776
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f64.const 0.6619858980995045
-  call $~lib/math/NativeMath.log
+  call $~lib/util/math/log64
   f64.const -0.4125110252365137
   f64.const -0.29108747839927673
   call $std/math/check<f64>
@@ -29717,13 +28947,13 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1780
+   i32.const 1777
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f64.const -0.4066039223853553
-  call $~lib/math/NativeMath.log
+  call $~lib/util/math/log64
   f64.const nan:0x8000000000000
   f64.const 0
   call $std/math/check<f64>
@@ -29740,13 +28970,13 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1781
+   i32.const 1778
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f64.const 0.5617597462207241
-  call $~lib/math/NativeMath.log
+  call $~lib/util/math/log64
   f64.const -0.5766810183195862
   f64.const -0.10983199626207352
   call $std/math/check<f64>
@@ -29763,13 +28993,13 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1782
+   i32.const 1779
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f64.const 0.7741522965913037
-  call $~lib/math/NativeMath.log
+  call $~lib/util/math/log64
   f64.const -0.2559866591263865
   f64.const -0.057990044355392456
   call $std/math/check<f64>
@@ -29786,13 +29016,13 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1783
+   i32.const 1780
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f64.const -0.6787637026394024
-  call $~lib/math/NativeMath.log
+  call $~lib/util/math/log64
   f64.const nan:0x8000000000000
   f64.const 0
   call $std/math/check<f64>
@@ -29809,13 +29039,13 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1784
+   i32.const 1781
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f64.const 0
-  call $~lib/math/NativeMath.log
+  call $~lib/util/math/log64
   f64.const -inf
   f64.const 0
   call $std/math/check<f64>
@@ -29832,13 +29062,13 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1787
+   i32.const 1784
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f64.const -0
-  call $~lib/math/NativeMath.log
+  call $~lib/util/math/log64
   f64.const -inf
   f64.const 0
   call $std/math/check<f64>
@@ -29855,13 +29085,13 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1788
+   i32.const 1785
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f64.const -7.888609052210118e-31
-  call $~lib/math/NativeMath.log
+  call $~lib/util/math/log64
   f64.const nan:0x8000000000000
   f64.const 0
   call $std/math/check<f64>
@@ -29878,13 +29108,13 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1789
+   i32.const 1786
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f64.const 1
-  call $~lib/math/NativeMath.log
+  call $~lib/util/math/log64
   f64.const 0
   f64.const 0
   call $std/math/check<f64>
@@ -29901,18 +29131,87 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1790
+   i32.const 1787
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f64.const -1
-  call $~lib/math/NativeMath.log
+  call $~lib/util/math/log64
   f64.const nan:0x8000000000000
   f64.const 0
   call $std/math/check<f64>
   if (result i32)
    f64.const -1
+   call $~lib/bindings/dom/Math.log
+   f64.const nan:0x8000000000000
+   f64.const 0
+   call $std/math/check<f64>
+  else
+   i32.const 0
+  end
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 1788
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const inf
+  call $~lib/util/math/log64
+  f64.const inf
+  f64.const 0
+  call $std/math/check<f64>
+  if (result i32)
+   f64.const inf
+   call $~lib/bindings/dom/Math.log
+   f64.const inf
+   f64.const 0
+   call $std/math/check<f64>
+  else
+   i32.const 0
+  end
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 1789
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const -inf
+  call $~lib/util/math/log64
+  f64.const nan:0x8000000000000
+  f64.const 0
+  call $std/math/check<f64>
+  if (result i32)
+   f64.const -inf
+   call $~lib/bindings/dom/Math.log
+   f64.const nan:0x8000000000000
+   f64.const 0
+   call $std/math/check<f64>
+  else
+   i32.const 0
+  end
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 1790
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const nan:0x8000000000000
+  call $~lib/util/math/log64
+  f64.const nan:0x8000000000000
+  f64.const 0
+  call $std/math/check<f64>
+  if (result i32)
+   f64.const nan:0x8000000000000
    call $~lib/bindings/dom/Math.log
    f64.const nan:0x8000000000000
    f64.const 0
@@ -29929,78 +29228,51 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const inf
-  call $~lib/math/NativeMath.log
-  f64.const inf
-  f64.const 0
-  call $std/math/check<f64>
-  if (result i32)
-   f64.const inf
-   call $~lib/bindings/dom/Math.log
-   f64.const inf
-   f64.const 0
-   call $std/math/check<f64>
-  else
-   i32.const 0
-  end
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 1792
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const -inf
-  call $~lib/math/NativeMath.log
-  f64.const nan:0x8000000000000
-  f64.const 0
-  call $std/math/check<f64>
-  if (result i32)
-   f64.const -inf
-   call $~lib/bindings/dom/Math.log
-   f64.const nan:0x8000000000000
-   f64.const 0
-   call $std/math/check<f64>
-  else
-   i32.const 0
-  end
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 1793
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const nan:0x8000000000000
-  call $~lib/math/NativeMath.log
-  f64.const nan:0x8000000000000
-  f64.const 0
-  call $std/math/check<f64>
-  if (result i32)
-   f64.const nan:0x8000000000000
-   call $~lib/bindings/dom/Math.log
-   f64.const nan:0x8000000000000
-   f64.const 0
-   call $std/math/check<f64>
-  else
-   i32.const 0
-  end
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 1794
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
   f32.const 0
-  call $~lib/math/NativeMathf.log
+  call $~lib/util/math/log32
   f32.const -inf
+  f32.const 0
+  call $std/math/check<f32>
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 1800
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const -0
+  call $~lib/util/math/log32
+  f32.const -inf
+  f32.const 0
+  call $std/math/check<f32>
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 1801
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const -7.888609052210118e-31
+  call $~lib/util/math/log32
+  f32.const nan:0x400000
+  f32.const 0
+  call $std/math/check<f32>
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 1802
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const 1
+  call $~lib/util/math/log32
+  f32.const 0
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -30012,9 +29284,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -0
-  call $~lib/math/NativeMathf.log
-  f32.const -inf
+  f32.const -1
+  call $~lib/util/math/log32
+  f32.const nan:0x400000
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -30026,9 +29298,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -7.888609052210118e-31
-  call $~lib/math/NativeMathf.log
-  f32.const nan:0x400000
+  f32.const inf
+  call $~lib/util/math/log32
+  f32.const inf
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -30040,9 +29312,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 1
-  call $~lib/math/NativeMathf.log
-  f32.const 0
+  f32.const -inf
+  call $~lib/util/math/log32
+  f32.const nan:0x400000
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -30054,8 +29326,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -1
-  call $~lib/math/NativeMathf.log
+  f32.const nan:0x400000
+  call $~lib/util/math/log32
   f32.const nan:0x400000
   f32.const 0
   call $std/math/check<f32>
@@ -30068,37 +29340,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const inf
-  call $~lib/math/NativeMathf.log
-  f32.const inf
   f32.const 0
-  call $std/math/check<f32>
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 1808
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
+  call $~lib/util/math/log32
   f32.const -inf
-  call $~lib/math/NativeMathf.log
-  f32.const nan:0x400000
-  f32.const 0
-  call $std/math/check<f32>
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 1809
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const nan:0x400000
-  call $~lib/math/NativeMathf.log
-  f32.const nan:0x400000
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -30110,9 +29354,37 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 0
-  call $~lib/math/NativeMathf.log
+  f32.const -0
+  call $~lib/util/math/log32
   f32.const -inf
+  f32.const 0
+  call $std/math/check<f32>
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 1811
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const -7.888609052210118e-31
+  call $~lib/util/math/log32
+  f32.const nan:0x400000
+  f32.const 0
+  call $std/math/check<f32>
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 1812
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const 1
+  call $~lib/util/math/log32
+  f32.const 0
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -30124,9 +29396,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -0
-  call $~lib/math/NativeMathf.log
-  f32.const -inf
+  f32.const -1
+  call $~lib/util/math/log32
+  f32.const nan:0x400000
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -30138,9 +29410,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -7.888609052210118e-31
-  call $~lib/math/NativeMathf.log
-  f32.const nan:0x400000
+  f32.const inf
+  call $~lib/util/math/log32
+  f32.const inf
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -30152,9 +29424,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 1
-  call $~lib/math/NativeMathf.log
-  f32.const 0
+  f32.const -inf
+  call $~lib/util/math/log32
+  f32.const nan:0x400000
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -30166,8 +29438,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -1
-  call $~lib/math/NativeMathf.log
+  f32.const nan:0x400000
+  call $~lib/util/math/log32
   f32.const nan:0x400000
   f32.const 0
   call $std/math/check<f32>
@@ -30180,48 +29452,6 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const inf
-  call $~lib/math/NativeMathf.log
-  f32.const inf
-  f32.const 0
-  call $std/math/check<f32>
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 1818
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const -inf
-  call $~lib/math/NativeMathf.log
-  f32.const nan:0x400000
-  f32.const 0
-  call $std/math/check<f32>
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 1819
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const nan:0x400000
-  call $~lib/math/NativeMathf.log
-  f32.const nan:0x400000
-  f32.const 0
-  call $std/math/check<f32>
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 1820
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
   f64.const -8.06684839057968
   f64.const nan:0x8000000000000
   f64.const 0
@@ -30230,7 +29460,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1832
+   i32.const 1829
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -30243,7 +29473,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1833
+   i32.const 1830
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -30256,7 +29486,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1834
+   i32.const 1831
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -30269,7 +29499,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1835
+   i32.const 1832
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -30282,7 +29512,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1836
+   i32.const 1833
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -30295,7 +29525,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1837
+   i32.const 1834
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -30308,7 +29538,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1838
+   i32.const 1835
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -30321,7 +29551,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1839
+   i32.const 1836
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -30334,7 +29564,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1840
+   i32.const 1837
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -30347,7 +29577,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1841
+   i32.const 1838
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -30360,7 +29590,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1844
+   i32.const 1841
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -30373,7 +29603,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1845
+   i32.const 1842
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -30386,7 +29616,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1846
+   i32.const 1843
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -30399,7 +29629,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1847
+   i32.const 1844
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -30412,7 +29642,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1848
+   i32.const 1845
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -30425,7 +29655,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1849
+   i32.const 1846
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -30438,7 +29668,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1850
+   i32.const 1847
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -30451,7 +29681,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1851
+   i32.const 1848
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -30464,7 +29694,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1860
+   i32.const 1857
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -30477,7 +29707,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1861
+   i32.const 1858
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -30490,7 +29720,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1862
+   i32.const 1859
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -30503,7 +29733,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1863
+   i32.const 1860
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -30516,7 +29746,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1864
+   i32.const 1861
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -30529,7 +29759,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1865
+   i32.const 1862
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -30542,7 +29772,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1866
+   i32.const 1863
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -30555,7 +29785,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1867
+   i32.const 1864
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -30568,7 +29798,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1868
+   i32.const 1865
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -30581,7 +29811,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1869
+   i32.const 1866
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -30594,7 +29824,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1872
+   i32.const 1869
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -30607,7 +29837,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1873
+   i32.const 1870
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -30620,7 +29850,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1874
+   i32.const 1871
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -30633,7 +29863,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1875
+   i32.const 1872
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -30646,7 +29876,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1876
+   i32.const 1873
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -30659,7 +29889,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1877
+   i32.const 1874
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -30672,7 +29902,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1878
+   i32.const 1875
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -30685,13 +29915,13 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1879
+   i32.const 1876
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f64.const -8.06684839057968
-  call $~lib/math/NativeMath.log1p
+  call $~lib/util/math/log1p64
   f64.const nan:0x8000000000000
   f64.const 0
   call $std/math/check<f64>
@@ -30708,13 +29938,13 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1891
+   i32.const 1888
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f64.const 4.345239849338305
-  call $~lib/math/NativeMath.log1p
+  call $~lib/util/math/log1p64
   f64.const 1.6762064170601734
   f64.const 0.46188199520111084
   call $std/math/check<f64>
@@ -30731,13 +29961,13 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1892
+   i32.const 1889
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f64.const -8.38143342755525
-  call $~lib/math/NativeMath.log1p
+  call $~lib/util/math/log1p64
   f64.const nan:0x8000000000000
   f64.const 0
   call $std/math/check<f64>
@@ -30754,13 +29984,13 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1893
+   i32.const 1890
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f64.const -6.531673581913484
-  call $~lib/math/NativeMath.log1p
+  call $~lib/util/math/log1p64
   f64.const nan:0x8000000000000
   f64.const 0
   call $std/math/check<f64>
@@ -30777,13 +30007,13 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1894
+   i32.const 1891
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f64.const 9.267056966972586
-  call $~lib/math/NativeMath.log1p
+  call $~lib/util/math/log1p64
   f64.const 2.3289404168523826
   f64.const -0.411114901304245
   call $std/math/check<f64>
@@ -30800,13 +30030,13 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1895
+   i32.const 1892
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f64.const 0.6619858980995045
-  call $~lib/math/NativeMath.log1p
+  call $~lib/util/math/log1p64
   f64.const 0.5080132114992477
   f64.const -0.29306045174598694
   call $std/math/check<f64>
@@ -30823,13 +30053,13 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1896
+   i32.const 1893
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f64.const -0.4066039223853553
-  call $~lib/math/NativeMath.log1p
+  call $~lib/util/math/log1p64
   f64.const -0.5218931811663979
   f64.const -0.25825726985931396
   call $std/math/check<f64>
@@ -30846,13 +30076,13 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1897
+   i32.const 1894
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f64.const 0.5617597462207241
-  call $~lib/math/NativeMath.log1p
+  call $~lib/util/math/log1p64
   f64.const 0.4458132279488102
   f64.const -0.13274887204170227
   call $std/math/check<f64>
@@ -30869,13 +30099,13 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1898
+   i32.const 1895
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f64.const 0.7741522965913037
-  call $~lib/math/NativeMath.log1p
+  call $~lib/util/math/log1p64
   f64.const 0.5733227294648414
   f64.const 0.02716583013534546
   call $std/math/check<f64>
@@ -30892,13 +30122,13 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1899
+   i32.const 1896
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f64.const -0.6787637026394024
-  call $~lib/math/NativeMath.log1p
+  call $~lib/util/math/log1p64
   f64.const -1.1355782978128564
   f64.const 0.2713092863559723
   call $std/math/check<f64>
@@ -30915,36 +30145,36 @@
   if
    i32.const 0
    i32.const 1056
+   i32.const 1897
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const 0
+  call $~lib/util/math/log1p64
+  f64.const 0
+  f64.const 0
+  call $std/math/check<f64>
+  if (result i32)
+   f64.const 0
+   call $~lib/bindings/dom/Math.log1p
+   f64.const 0
+   f64.const 0
+   call $std/math/check<f64>
+  else
+   i32.const 0
+  end
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1056
    i32.const 1900
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 0
-  call $~lib/math/NativeMath.log1p
-  f64.const 0
-  f64.const 0
-  call $std/math/check<f64>
-  if (result i32)
-   f64.const 0
-   call $~lib/bindings/dom/Math.log1p
-   f64.const 0
-   f64.const 0
-   call $std/math/check<f64>
-  else
-   i32.const 0
-  end
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 1903
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
   f64.const -0
-  call $~lib/math/NativeMath.log1p
+  call $~lib/util/math/log1p64
   f64.const -0
   f64.const 0
   call $std/math/check<f64>
@@ -30961,13 +30191,13 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1904
+   i32.const 1901
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f64.const -7.888609052210118e-31
-  call $~lib/math/NativeMath.log1p
+  call $~lib/util/math/log1p64
   f64.const -7.888609052210118e-31
   f64.const 1.7763568394002505e-15
   call $std/math/check<f64>
@@ -30984,13 +30214,13 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1905
+   i32.const 1902
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f64.const 1
-  call $~lib/math/NativeMath.log1p
+  call $~lib/util/math/log1p64
   f64.const 0.6931471805599453
   f64.const -0.2088811695575714
   call $std/math/check<f64>
@@ -31007,13 +30237,13 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1906
+   i32.const 1903
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f64.const -1
-  call $~lib/math/NativeMath.log1p
+  call $~lib/util/math/log1p64
   f64.const -inf
   f64.const 0
   call $std/math/check<f64>
@@ -31030,13 +30260,13 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1907
+   i32.const 1904
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f64.const inf
-  call $~lib/math/NativeMath.log1p
+  call $~lib/util/math/log1p64
   f64.const inf
   f64.const 0
   call $std/math/check<f64>
@@ -31053,13 +30283,13 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1908
+   i32.const 1905
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f64.const -inf
-  call $~lib/math/NativeMath.log1p
+  call $~lib/util/math/log1p64
   f64.const nan:0x8000000000000
   f64.const 0
   call $std/math/check<f64>
@@ -31076,13 +30306,13 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1909
+   i32.const 1906
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f64.const nan:0x8000000000000
-  call $~lib/math/NativeMath.log1p
+  call $~lib/util/math/log1p64
   f64.const nan:0x8000000000000
   f64.const 0
   call $std/math/check<f64>
@@ -31099,13 +30329,55 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1910
+   i32.const 1907
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f32.const -8.066848754882812
-  call $~lib/math/NativeMathf.log1p
+  call $~lib/util/math/log1p32
+  f32.const nan:0x400000
+  f32.const 0
+  call $std/math/check<f32>
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 1916
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const 4.345239639282227
+  call $~lib/util/math/log1p32
+  f32.const 1.676206350326538
+  f32.const -0.23014859855175018
+  call $std/math/check<f32>
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 1917
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const -8.381433486938477
+  call $~lib/util/math/log1p32
+  f32.const nan:0x400000
+  f32.const 0
+  call $std/math/check<f32>
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 1918
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const -6.531673431396484
+  call $~lib/util/math/log1p32
   f32.const nan:0x400000
   f32.const 0
   call $std/math/check<f32>
@@ -31118,10 +30390,10 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 4.345239639282227
-  call $~lib/math/NativeMathf.log1p
-  f32.const 1.676206350326538
-  f32.const -0.23014859855175018
+  f32.const 9.267057418823242
+  call $~lib/util/math/log1p32
+  f32.const 2.3289403915405273
+  f32.const -0.29075589776039124
   call $std/math/check<f32>
   i32.eqz
   if
@@ -31132,10 +30404,10 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -8.381433486938477
-  call $~lib/math/NativeMathf.log1p
-  f32.const nan:0x400000
-  f32.const 0
+  f32.const 0.6619858741760254
+  call $~lib/util/math/log1p32
+  f32.const 0.5080131888389587
+  f32.const -0.1386766880750656
   call $std/math/check<f32>
   i32.eqz
   if
@@ -31146,10 +30418,10 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -6.531673431396484
-  call $~lib/math/NativeMathf.log1p
-  f32.const nan:0x400000
-  f32.const 0
+  f32.const -0.40660393238067627
+  call $~lib/util/math/log1p32
+  f32.const -0.5218932032585144
+  f32.const -0.08804433047771454
   call $std/math/check<f32>
   i32.eqz
   if
@@ -31160,10 +30432,10 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 9.267057418823242
-  call $~lib/math/NativeMathf.log1p
-  f32.const 2.3289403915405273
-  f32.const -0.29075589776039124
+  f32.const 0.5617597699165344
+  call $~lib/util/math/log1p32
+  f32.const 0.44581323862075806
+  f32.const -0.15101368725299835
   call $std/math/check<f32>
   i32.eqz
   if
@@ -31174,10 +30446,10 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 0.6619858741760254
-  call $~lib/math/NativeMathf.log1p
-  f32.const 0.5080131888389587
-  f32.const -0.1386766880750656
+  f32.const 0.7741522789001465
+  call $~lib/util/math/log1p32
+  f32.const 0.5733227133750916
+  f32.const -0.10264533013105392
   call $std/math/check<f32>
   i32.eqz
   if
@@ -31188,10 +30460,10 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -0.40660393238067627
-  call $~lib/math/NativeMathf.log1p
-  f32.const -0.5218932032585144
-  f32.const -0.08804433047771454
+  f32.const -0.6787636876106262
+  call $~lib/util/math/log1p32
+  f32.const -1.1355782747268677
+  f32.const -0.19879481196403503
   call $std/math/check<f32>
   i32.eqz
   if
@@ -31202,38 +30474,10 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 0.5617597699165344
-  call $~lib/math/NativeMathf.log1p
-  f32.const 0.44581323862075806
-  f32.const -0.15101368725299835
-  call $std/math/check<f32>
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 1926
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const 0.7741522789001465
-  call $~lib/math/NativeMathf.log1p
-  f32.const 0.5733227133750916
-  f32.const -0.10264533013105392
-  call $std/math/check<f32>
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 1927
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const -0.6787636876106262
-  call $~lib/math/NativeMathf.log1p
-  f32.const -1.1355782747268677
-  f32.const -0.19879481196403503
+  f32.const 0
+  call $~lib/util/math/log1p32
+  f32.const 0
+  f32.const 0
   call $std/math/check<f32>
   i32.eqz
   if
@@ -31244,10 +30488,38 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f32.const -0
+  call $~lib/util/math/log1p32
+  f32.const -0
   f32.const 0
-  call $~lib/math/NativeMathf.log1p
-  f32.const 0
-  f32.const 0
+  call $std/math/check<f32>
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 1929
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const -7.888609052210118e-31
+  call $~lib/util/math/log1p32
+  f32.const -7.888609052210118e-31
+  f32.const 3.308722450212111e-24
+  call $std/math/check<f32>
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 1930
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const 1
+  call $~lib/util/math/log1p32
+  f32.const 0.6931471824645996
+  f32.const 0.031954795122146606
   call $std/math/check<f32>
   i32.eqz
   if
@@ -31258,9 +30530,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -0
-  call $~lib/math/NativeMathf.log1p
-  f32.const -0
+  f32.const -1
+  call $~lib/util/math/log1p32
+  f32.const -inf
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -31272,10 +30544,10 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -7.888609052210118e-31
-  call $~lib/math/NativeMathf.log1p
-  f32.const -7.888609052210118e-31
-  f32.const 3.308722450212111e-24
+  f32.const inf
+  call $~lib/util/math/log1p32
+  f32.const inf
+  f32.const 0
   call $std/math/check<f32>
   i32.eqz
   if
@@ -31286,10 +30558,10 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 1
-  call $~lib/math/NativeMathf.log1p
-  f32.const 0.6931471824645996
-  f32.const 0.031954795122146606
+  f32.const -inf
+  call $~lib/util/math/log1p32
+  f32.const nan:0x400000
+  f32.const 0
   call $std/math/check<f32>
   i32.eqz
   if
@@ -31300,9 +30572,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -1
-  call $~lib/math/NativeMathf.log1p
-  f32.const -inf
+  f32.const nan:0x400000
+  call $~lib/util/math/log1p32
+  f32.const nan:0x400000
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -31314,10 +30586,10 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const inf
-  call $~lib/math/NativeMathf.log1p
-  f32.const inf
-  f32.const 0
+  f32.const -1.1754942106924411e-38
+  call $~lib/util/math/log1p32
+  f32.const -1.1754942106924411e-38
+  f32.const 4.930380657631324e-32
   call $std/math/check<f32>
   i32.eqz
   if
@@ -31328,50 +30600,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -inf
-  call $~lib/math/NativeMathf.log1p
-  f32.const nan:0x400000
-  f32.const 0
-  call $std/math/check<f32>
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 1937
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const nan:0x400000
-  call $~lib/math/NativeMathf.log1p
-  f32.const nan:0x400000
-  f32.const 0
-  call $std/math/check<f32>
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 1938
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const -1.1754942106924411e-38
-  call $~lib/math/NativeMathf.log1p
-  f32.const -1.1754942106924411e-38
-  f32.const 4.930380657631324e-32
-  call $std/math/check<f32>
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 1939
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
   f64.const -8.06684839057968
-  call $~lib/math/NativeMath.log2
+  call $~lib/util/math/log2_64
   f64.const nan:0x8000000000000
   f64.const 0
   call $std/math/check<f64>
@@ -31388,13 +30618,13 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1951
+   i32.const 1948
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f64.const 4.345239849338305
-  call $~lib/math/NativeMath.log2
+  call $~lib/util/math/log2_64
   f64.const 2.1194358133804485
   f64.const -0.10164877772331238
   call $std/math/check<f64>
@@ -31411,13 +30641,13 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1952
+   i32.const 1949
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f64.const -8.38143342755525
-  call $~lib/math/NativeMath.log2
+  call $~lib/util/math/log2_64
   f64.const nan:0x8000000000000
   f64.const 0
   call $std/math/check<f64>
@@ -31434,13 +30664,13 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1953
+   i32.const 1950
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f64.const -6.531673581913484
-  call $~lib/math/NativeMath.log2
+  call $~lib/util/math/log2_64
   f64.const nan:0x8000000000000
   f64.const 0
   call $std/math/check<f64>
@@ -31457,13 +30687,13 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1954
+   i32.const 1951
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f64.const 9.267056966972586
-  call $~lib/math/NativeMath.log2
+  call $~lib/util/math/log2_64
   f64.const 3.2121112403298744
   f64.const -0.15739446878433228
   call $std/math/check<f64>
@@ -31480,13 +30710,13 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1955
+   i32.const 1952
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f64.const 0.6619858980995045
-  call $~lib/math/NativeMath.log2
+  call $~lib/util/math/log2_64
   f64.const -0.5951276104207402
   f64.const 0.3321485221385956
   call $std/math/check<f64>
@@ -31503,13 +30733,13 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1956
+   i32.const 1953
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f64.const -0.4066039223853553
-  call $~lib/math/NativeMath.log2
+  call $~lib/util/math/log2_64
   f64.const nan:0x8000000000000
   f64.const 0
   call $std/math/check<f64>
@@ -31526,13 +30756,13 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1957
+   i32.const 1954
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f64.const 0.5617597462207241
-  call $~lib/math/NativeMath.log2
+  call $~lib/util/math/log2_64
   f64.const -0.8319748453044644
   f64.const 0.057555437088012695
   call $std/math/check<f64>
@@ -31549,13 +30779,13 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1958
+   i32.const 1955
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f64.const 0.7741522965913037
-  call $~lib/math/NativeMath.log2
+  call $~lib/util/math/log2_64
   f64.const -0.36931068365537134
   f64.const -0.19838279485702515
   call $std/math/check<f64>
@@ -31572,13 +30802,13 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1959
+   i32.const 1956
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f64.const -0.6787637026394024
-  call $~lib/math/NativeMath.log2
+  call $~lib/util/math/log2_64
   f64.const nan:0x8000000000000
   f64.const 0
   call $std/math/check<f64>
@@ -31595,13 +30825,13 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1960
+   i32.const 1957
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f64.const 0
-  call $~lib/math/NativeMath.log2
+  call $~lib/util/math/log2_64
   f64.const -inf
   f64.const 0
   call $std/math/check<f64>
@@ -31618,13 +30848,13 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1963
+   i32.const 1960
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f64.const -0
-  call $~lib/math/NativeMath.log2
+  call $~lib/util/math/log2_64
   f64.const -inf
   f64.const 0
   call $std/math/check<f64>
@@ -31641,13 +30871,13 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1964
+   i32.const 1961
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f64.const -7.888609052210118e-31
-  call $~lib/math/NativeMath.log2
+  call $~lib/util/math/log2_64
   f64.const nan:0x8000000000000
   f64.const 0
   call $std/math/check<f64>
@@ -31664,13 +30894,13 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1965
+   i32.const 1962
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f64.const 1
-  call $~lib/math/NativeMath.log2
+  call $~lib/util/math/log2_64
   f64.const 0
   f64.const 0
   call $std/math/check<f64>
@@ -31687,13 +30917,13 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1966
+   i32.const 1963
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f64.const -1
-  call $~lib/math/NativeMath.log2
+  call $~lib/util/math/log2_64
   f64.const nan:0x8000000000000
   f64.const 0
   call $std/math/check<f64>
@@ -31710,13 +30940,13 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1967
+   i32.const 1964
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f64.const inf
-  call $~lib/math/NativeMath.log2
+  call $~lib/util/math/log2_64
   f64.const inf
   f64.const 0
   call $std/math/check<f64>
@@ -31733,13 +30963,13 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1968
+   i32.const 1965
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f64.const -inf
-  call $~lib/math/NativeMath.log2
+  call $~lib/util/math/log2_64
   f64.const nan:0x8000000000000
   f64.const 0
   call $std/math/check<f64>
@@ -31756,13 +30986,13 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1969
+   i32.const 1966
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f64.const nan:0x8000000000000
-  call $~lib/math/NativeMath.log2
+  call $~lib/util/math/log2_64
   f64.const nan:0x8000000000000
   f64.const 0
   call $std/math/check<f64>
@@ -31779,7 +31009,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1970
+   i32.const 1967
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -31792,7 +31022,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1979
+   i32.const 1976
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -31805,7 +31035,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1980
+   i32.const 1977
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -31818,7 +31048,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1981
+   i32.const 1978
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -31831,7 +31061,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1982
+   i32.const 1979
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -31844,7 +31074,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1983
+   i32.const 1980
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -31857,7 +31087,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1984
+   i32.const 1981
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -31870,7 +31100,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1985
+   i32.const 1982
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -31883,7 +31113,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1986
+   i32.const 1983
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -31896,7 +31126,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1987
+   i32.const 1984
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -31909,7 +31139,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1988
+   i32.const 1985
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -31922,7 +31152,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1991
+   i32.const 1988
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -31935,7 +31165,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1992
+   i32.const 1989
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -31948,7 +31178,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1993
+   i32.const 1990
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -31961,7 +31191,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1994
+   i32.const 1991
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -31974,7 +31204,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1995
+   i32.const 1992
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -31987,7 +31217,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1996
+   i32.const 1993
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -32000,7 +31230,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1997
+   i32.const 1994
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -32013,7 +31243,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1998
+   i32.const 1995
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -32026,7 +31256,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 2010
+   i32.const 2007
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -32039,7 +31269,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 2011
+   i32.const 2008
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -32052,7 +31282,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 2012
+   i32.const 2009
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -32065,7 +31295,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 2013
+   i32.const 2010
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -32078,7 +31308,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 2014
+   i32.const 2011
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -32091,7 +31321,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 2015
+   i32.const 2012
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -32104,7 +31334,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 2016
+   i32.const 2013
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -32117,7 +31347,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 2017
+   i32.const 2014
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -32130,7 +31360,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 2018
+   i32.const 2015
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -32143,12 +31373,51 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 2019
+   i32.const 2016
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f64.const 0
+  f64.const 1
+  f64.const 1
+  call $std/math/test_max
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 2019
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const -0
+  f64.const 1
+  f64.const 1
+  call $std/math/test_max
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 2020
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const 0.5
+  f64.const 1
+  f64.const 1
+  call $std/math/test_max
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 2021
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const -0.5
   f64.const 1
   f64.const 1
   call $std/math/test_max
@@ -32161,7 +31430,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -0
+  f64.const 1
   f64.const 1
   f64.const 1
   call $std/math/test_max
@@ -32174,7 +31443,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 0.5
+  f64.const -1
   f64.const 1
   f64.const 1
   call $std/math/test_max
@@ -32187,9 +31456,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -0.5
+  f64.const inf
   f64.const 1
-  f64.const 1
+  f64.const inf
   call $std/math/test_max
   i32.eqz
   if
@@ -32200,7 +31469,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 1
+  f64.const -inf
   f64.const 1
   f64.const 1
   call $std/math/test_max
@@ -32213,9 +31482,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -1
+  f64.const nan:0x8000000000000
   f64.const 1
-  f64.const 1
+  f64.const nan:0x8000000000000
   call $std/math/test_max
   i32.eqz
   if
@@ -32226,9 +31495,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const inf
-  f64.const 1
-  f64.const inf
+  f64.const 0
+  f64.const -1
+  f64.const 0
   call $std/math/test_max
   i32.eqz
   if
@@ -32239,9 +31508,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -inf
-  f64.const 1
-  f64.const 1
+  f64.const -0
+  f64.const -1
+  f64.const -0
   call $std/math/test_max
   i32.eqz
   if
@@ -32252,9 +31521,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const nan:0x8000000000000
-  f64.const 1
-  f64.const nan:0x8000000000000
+  f64.const 0.5
+  f64.const -1
+  f64.const 0.5
   call $std/math/test_max
   i32.eqz
   if
@@ -32265,9 +31534,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 0
+  f64.const -0.5
   f64.const -1
-  f64.const 0
+  f64.const -0.5
   call $std/math/test_max
   i32.eqz
   if
@@ -32278,9 +31547,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -0
+  f64.const 1
   f64.const -1
-  f64.const -0
+  f64.const 1
   call $std/math/test_max
   i32.eqz
   if
@@ -32291,9 +31560,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 0.5
   f64.const -1
-  f64.const 0.5
+  f64.const -1
+  f64.const -1
   call $std/math/test_max
   i32.eqz
   if
@@ -32304,54 +31573,15 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -0.5
+  f64.const inf
   f64.const -1
-  f64.const -0.5
+  f64.const inf
   call $std/math/test_max
   i32.eqz
   if
    i32.const 0
    i32.const 1056
    i32.const 2034
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const 1
-  f64.const -1
-  f64.const 1
-  call $std/math/test_max
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 2035
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const -1
-  f64.const -1
-  f64.const -1
-  call $std/math/test_max
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 2036
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const inf
-  f64.const -1
-  f64.const inf
-  call $std/math/test_max
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 2037
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -32364,7 +31594,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 2038
+   i32.const 2035
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -32372,6 +31602,45 @@
   f64.const nan:0x8000000000000
   f64.const -1
   f64.const nan:0x8000000000000
+  call $std/math/test_max
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 2036
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const 0
+  f64.const 0
+  f64.const 0
+  call $std/math/test_max
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 2037
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const 0
+  f64.const -0
+  f64.const 0
+  call $std/math/test_max
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 2038
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const 0
+  f64.const inf
+  f64.const inf
   call $std/math/test_max
   i32.eqz
   if
@@ -32383,7 +31652,7 @@
    unreachable
   end
   f64.const 0
-  f64.const 0
+  f64.const -inf
   f64.const 0
   call $std/math/test_max
   i32.eqz
@@ -32396,8 +31665,8 @@
    unreachable
   end
   f64.const 0
-  f64.const -0
-  f64.const 0
+  f64.const nan:0x8000000000000
+  f64.const nan:0x8000000000000
   call $std/math/test_max
   i32.eqz
   if
@@ -32408,9 +31677,9 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f64.const -0
   f64.const 0
-  f64.const inf
-  f64.const inf
+  f64.const 0
   call $std/math/test_max
   i32.eqz
   if
@@ -32421,9 +31690,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 0
-  f64.const -inf
-  f64.const 0
+  f64.const -0
+  f64.const -0
+  f64.const -0
   call $std/math/test_max
   i32.eqz
   if
@@ -32434,9 +31703,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 0
-  f64.const nan:0x8000000000000
-  f64.const nan:0x8000000000000
+  f64.const -0
+  f64.const inf
+  f64.const inf
   call $std/math/test_max
   i32.eqz
   if
@@ -32448,8 +31717,8 @@
    unreachable
   end
   f64.const -0
-  f64.const 0
-  f64.const 0
+  f64.const -inf
+  f64.const -0
   call $std/math/test_max
   i32.eqz
   if
@@ -32461,8 +31730,8 @@
    unreachable
   end
   f64.const -0
-  f64.const -0
-  f64.const -0
+  f64.const nan:0x8000000000000
+  f64.const nan:0x8000000000000
   call $std/math/test_max
   i32.eqz
   if
@@ -32473,9 +31742,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -0
-  f64.const inf
-  f64.const inf
+  f64.const 1
+  f64.const 0
+  f64.const 1
   call $std/math/test_max
   i32.eqz
   if
@@ -32486,9 +31755,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -0
-  f64.const -inf
-  f64.const -0
+  f64.const -1
+  f64.const 0
+  f64.const 0
   call $std/math/test_max
   i32.eqz
   if
@@ -32499,9 +31768,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -0
-  f64.const nan:0x8000000000000
-  f64.const nan:0x8000000000000
+  f64.const inf
+  f64.const 0
+  f64.const inf
   call $std/math/test_max
   i32.eqz
   if
@@ -32512,9 +31781,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 1
+  f64.const -inf
   f64.const 0
-  f64.const 1
+  f64.const 0
   call $std/math/test_max
   i32.eqz
   if
@@ -32525,9 +31794,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -1
+  f64.const nan:0x8000000000000
   f64.const 0
-  f64.const 0
+  f64.const nan:0x8000000000000
   call $std/math/test_max
   i32.eqz
   if
@@ -32538,9 +31807,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const inf
-  f64.const 0
-  f64.const inf
+  f64.const -1
+  f64.const -0
+  f64.const -0
   call $std/math/test_max
   i32.eqz
   if
@@ -32551,9 +31820,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -inf
-  f64.const 0
-  f64.const 0
+  f64.const inf
+  f64.const -0
+  f64.const inf
   call $std/math/test_max
   i32.eqz
   if
@@ -32564,9 +31833,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const nan:0x8000000000000
-  f64.const 0
-  f64.const nan:0x8000000000000
+  f64.const -inf
+  f64.const -0
+  f64.const -0
   call $std/math/test_max
   i32.eqz
   if
@@ -32577,54 +31846,15 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -1
+  f64.const nan:0x8000000000000
   f64.const -0
-  f64.const -0
+  f64.const nan:0x8000000000000
   call $std/math/test_max
   i32.eqz
   if
    i32.const 0
    i32.const 1056
    i32.const 2055
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const inf
-  f64.const -0
-  f64.const inf
-  call $std/math/test_max
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 2056
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const -inf
-  f64.const -0
-  f64.const -0
-  call $std/math/test_max
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 2057
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const nan:0x8000000000000
-  f64.const -0
-  f64.const nan:0x8000000000000
-  call $std/math/test_max
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 2058
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -32637,7 +31867,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 2059
+   i32.const 2056
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -32650,12 +31880,51 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 2060
+   i32.const 2057
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f64.const inf
+  f64.const nan:0x8000000000000
+  f64.const nan:0x8000000000000
+  call $std/math/test_max
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 2058
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const -inf
+  f64.const 2
+  f64.const 2
+  call $std/math/test_max
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 2059
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const -inf
+  f64.const -0.5
+  f64.const -0.5
+  call $std/math/test_max
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 2060
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const -inf
   f64.const nan:0x8000000000000
   f64.const nan:0x8000000000000
   call $std/math/test_max
@@ -32668,9 +31937,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -inf
-  f64.const 2
-  f64.const 2
+  f64.const nan:0x8000000000000
+  f64.const nan:0x8000000000000
+  f64.const nan:0x8000000000000
   call $std/math/test_max
   i32.eqz
   if
@@ -32681,9 +31950,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -inf
-  f64.const -0.5
-  f64.const -0.5
+  f64.const 1
+  f64.const nan:0x8000000000000
+  f64.const nan:0x8000000000000
   call $std/math/test_max
   i32.eqz
   if
@@ -32694,7 +31963,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -inf
+  f64.const -1
   f64.const nan:0x8000000000000
   f64.const nan:0x8000000000000
   call $std/math/test_max
@@ -32707,9 +31976,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const nan:0x8000000000000
-  f64.const nan:0x8000000000000
-  f64.const nan:0x8000000000000
+  f64.const 1
+  f64.const inf
+  f64.const inf
   call $std/math/test_max
   i32.eqz
   if
@@ -32720,9 +31989,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 1
-  f64.const nan:0x8000000000000
-  f64.const nan:0x8000000000000
+  f64.const -1
+  f64.const inf
+  f64.const inf
   call $std/math/test_max
   i32.eqz
   if
@@ -32733,9 +32002,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -1
-  f64.const nan:0x8000000000000
-  f64.const nan:0x8000000000000
+  f64.const inf
+  f64.const inf
+  f64.const inf
   call $std/math/test_max
   i32.eqz
   if
@@ -32746,7 +32015,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 1
+  f64.const -inf
   f64.const inf
   f64.const inf
   call $std/math/test_max
@@ -32759,9 +32028,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -1
-  f64.const inf
-  f64.const inf
+  f64.const 1
+  f64.const -inf
+  f64.const 1
   call $std/math/test_max
   i32.eqz
   if
@@ -32772,9 +32041,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const inf
-  f64.const inf
-  f64.const inf
+  f64.const -1
+  f64.const -inf
+  f64.const -1
   call $std/math/test_max
   i32.eqz
   if
@@ -32785,8 +32054,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -inf
   f64.const inf
+  f64.const -inf
   f64.const inf
   call $std/math/test_max
   i32.eqz
@@ -32798,9 +32067,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 1
   f64.const -inf
-  f64.const 1
+  f64.const -inf
+  f64.const -inf
   call $std/math/test_max
   i32.eqz
   if
@@ -32811,9 +32080,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -1
-  f64.const -inf
-  f64.const -1
+  f64.const 1.75
+  f64.const 0.5
+  f64.const 1.75
   call $std/math/test_max
   i32.eqz
   if
@@ -32824,9 +32093,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const inf
-  f64.const -inf
-  f64.const inf
+  f64.const -1.75
+  f64.const 0.5
+  f64.const 0.5
   call $std/math/test_max
   i32.eqz
   if
@@ -32837,9 +32106,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -inf
-  f64.const -inf
-  f64.const -inf
+  f64.const 1.75
+  f64.const -0.5
+  f64.const 1.75
   call $std/math/test_max
   i32.eqz
   if
@@ -32850,9 +32119,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 1.75
-  f64.const 0.5
-  f64.const 1.75
+  f64.const -1.75
+  f64.const -0.5
+  f64.const -0.5
   call $std/math/test_max
   i32.eqz
   if
@@ -32863,47 +32132,47 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -1.75
-  f64.const 0.5
-  f64.const 0.5
-  call $std/math/test_max
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 2077
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const 1.75
-  f64.const -0.5
-  f64.const 1.75
-  call $std/math/test_max
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 2078
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const -1.75
-  f64.const -0.5
-  f64.const -0.5
-  call $std/math/test_max
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 2079
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
   f32.const 4.535662651062012
   f32.const 4.535662651062012
+  f32.const 0
+  call $std/math/check<f32>
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 2085
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const 4.345239639282227
+  f32.const 4.345239639282227
+  f32.const 0
+  call $std/math/check<f32>
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 2086
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const -2.7636072635650635
+  f32.const -2.7636072635650635
+  f32.const 0
+  call $std/math/check<f32>
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 2087
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const 4.567535400390625
+  f32.const 4.567535400390625
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -32915,8 +32184,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 4.345239639282227
-  f32.const 4.345239639282227
+  f32.const 9.267057418823242
+  f32.const 9.267057418823242
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -32928,8 +32197,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -2.7636072635650635
-  f32.const -2.7636072635650635
+  f32.const 0.6620717644691467
+  f32.const 0.6620717644691467
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -32941,8 +32210,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 4.567535400390625
-  f32.const 4.567535400390625
+  f32.const 7.858890056610107
+  f32.const 7.858890056610107
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -32954,8 +32223,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 9.267057418823242
-  f32.const 9.267057418823242
+  f32.const 7.676402568817139
+  f32.const 7.676402568817139
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -32967,8 +32236,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 0.6620717644691467
-  f32.const 0.6620717644691467
+  f32.const 2.0119025707244873
+  f32.const 2.0119025707244873
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -32980,8 +32249,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 7.858890056610107
-  f32.const 7.858890056610107
+  f32.const 0.03223983198404312
+  f32.const 0.03223983198404312
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -32993,34 +32262,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 7.676402568817139
-  f32.const 7.676402568817139
-  f32.const 0
-  call $std/math/check<f32>
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 2095
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const 2.0119025707244873
-  f32.const 2.0119025707244873
-  f32.const 0
-  call $std/math/check<f32>
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 2096
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const 0.03223983198404312
-  f32.const 0.03223983198404312
+  f32.const 1
+  f32.const 1
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -33028,6 +32271,32 @@
    i32.const 0
    i32.const 1056
    i32.const 2097
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const 1
+  f32.const 1
+  f32.const 0
+  call $std/math/check<f32>
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 2098
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const 1
+  f32.const 1
+  f32.const 0
+  call $std/math/check<f32>
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 2099
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -33071,8 +32340,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 1
-  f32.const 1
+  f32.const inf
+  f32.const inf
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -33097,8 +32366,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 1
-  f32.const 1
+  f32.const nan:0x400000
+  f32.const nan:0x400000
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -33110,8 +32379,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const inf
-  f32.const inf
+  f32.const 0
+  f32.const 0
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -33123,8 +32392,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 1
-  f32.const 1
+  f32.const -0
+  f32.const -0
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -33136,8 +32405,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const nan:0x400000
-  f32.const nan:0x400000
+  f32.const 0.5
+  f32.const 0.5
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -33149,8 +32418,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 0
-  f32.const 0
+  f32.const -0.5
+  f32.const -0.5
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -33162,8 +32431,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -0
-  f32.const -0
+  f32.const 1
+  f32.const 1
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -33175,8 +32444,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 0.5
-  f32.const 0.5
+  f32.const -1
+  f32.const -1
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -33188,8 +32457,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -0.5
-  f32.const -0.5
+  f32.const inf
+  f32.const inf
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -33201,8 +32470,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 1
-  f32.const 1
+  f32.const -1
+  f32.const -1
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -33214,8 +32483,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -1
-  f32.const -1
+  f32.const nan:0x400000
+  f32.const nan:0x400000
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -33227,8 +32496,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const inf
-  f32.const inf
+  f32.const 0
+  f32.const 0
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -33240,8 +32509,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -1
-  f32.const -1
+  f32.const 0
+  f32.const 0
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -33253,8 +32522,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const nan:0x400000
-  f32.const nan:0x400000
+  f32.const inf
+  f32.const inf
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -33279,8 +32548,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 0
-  f32.const 0
+  f32.const nan:0x400000
+  f32.const nan:0x400000
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -33292,8 +32561,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const inf
-  f32.const inf
+  f32.const 0
+  f32.const 0
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -33305,8 +32574,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 0
-  f32.const 0
+  f32.const -0
+  f32.const -0
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -33318,8 +32587,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const nan:0x400000
-  f32.const nan:0x400000
+  f32.const inf
+  f32.const inf
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -33331,8 +32600,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 0
-  f32.const 0
+  f32.const -0
+  f32.const -0
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -33344,8 +32613,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -0
-  f32.const -0
+  f32.const nan:0x400000
+  f32.const nan:0x400000
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -33357,8 +32626,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const inf
-  f32.const inf
+  f32.const 1
+  f32.const 1
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -33370,8 +32639,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -0
-  f32.const -0
+  f32.const 0
+  f32.const 0
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -33383,8 +32652,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const nan:0x400000
-  f32.const nan:0x400000
+  f32.const inf
+  f32.const inf
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -33396,8 +32665,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 1
-  f32.const 1
+  f32.const 0
+  f32.const 0
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -33409,8 +32678,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 0
-  f32.const 0
+  f32.const nan:0x400000
+  f32.const nan:0x400000
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -33422,8 +32691,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const inf
-  f32.const inf
+  f32.const -0
+  f32.const -0
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -33435,8 +32704,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 0
-  f32.const 0
+  f32.const inf
+  f32.const inf
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -33448,8 +32717,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const nan:0x400000
-  f32.const nan:0x400000
+  f32.const -0
+  f32.const -0
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -33461,8 +32730,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -0
-  f32.const -0
+  f32.const nan:0x400000
+  f32.const nan:0x400000
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -33487,8 +32756,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -0
-  f32.const -0
+  f32.const inf
+  f32.const inf
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -33513,8 +32782,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const inf
-  f32.const inf
+  f32.const 2
+  f32.const 2
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -33526,8 +32795,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const inf
-  f32.const inf
+  f32.const -0.5
+  f32.const -0.5
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -33552,8 +32821,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 2
-  f32.const 2
+  f32.const nan:0x400000
+  f32.const nan:0x400000
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -33565,8 +32834,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -0.5
-  f32.const -0.5
+  f32.const nan:0x400000
+  f32.const nan:0x400000
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -33591,8 +32860,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const nan:0x400000
-  f32.const nan:0x400000
+  f32.const inf
+  f32.const inf
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -33604,8 +32873,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const nan:0x400000
-  f32.const nan:0x400000
+  f32.const inf
+  f32.const inf
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -33617,8 +32886,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const nan:0x400000
-  f32.const nan:0x400000
+  f32.const inf
+  f32.const inf
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -33643,8 +32912,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const inf
-  f32.const inf
+  f32.const 1
+  f32.const 1
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -33656,8 +32925,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const inf
-  f32.const inf
+  f32.const -1
+  f32.const -1
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -33682,8 +32951,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 1
-  f32.const 1
+  f32.const -inf
+  f32.const -inf
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -33695,8 +32964,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -1
-  f32.const -1
+  f32.const 1.75
+  f32.const 1.75
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -33708,8 +32977,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const inf
-  f32.const inf
+  f32.const 0.5
+  f32.const 0.5
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -33721,8 +32990,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -inf
-  f32.const -inf
+  f32.const 1.75
+  f32.const 1.75
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -33734,8 +33003,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 1.75
-  f32.const 1.75
+  f32.const -0.5
+  f32.const -0.5
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -33743,45 +33012,6 @@
    i32.const 0
    i32.const 1056
    i32.const 2154
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const 0.5
-  f32.const 0.5
-  f32.const 0
-  call $std/math/check<f32>
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 2155
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const 1.75
-  f32.const 1.75
-  f32.const 0
-  call $std/math/check<f32>
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 2156
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const -0.5
-  f32.const -0.5
-  f32.const 0
-  call $std/math/check<f32>
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 2157
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -33794,7 +33024,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 2169
+   i32.const 2166
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -33807,7 +33037,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 2170
+   i32.const 2167
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -33820,7 +33050,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 2171
+   i32.const 2168
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -33833,7 +33063,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 2172
+   i32.const 2169
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -33846,7 +33076,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 2173
+   i32.const 2170
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -33859,7 +33089,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 2174
+   i32.const 2171
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -33872,7 +33102,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 2175
+   i32.const 2172
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -33885,7 +33115,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 2176
+   i32.const 2173
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -33898,7 +33128,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 2177
+   i32.const 2174
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -33911,7 +33141,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 2178
+   i32.const 2175
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -33919,6 +33149,45 @@
   f64.const 0
   f64.const 1
   f64.const 0
+  call $std/math/test_min
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 2178
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const -0
+  f64.const 1
+  f64.const -0
+  call $std/math/test_min
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 2179
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const 0.5
+  f64.const 1
+  f64.const 0.5
+  call $std/math/test_min
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 2180
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const -0.5
+  f64.const 1
+  f64.const -0.5
   call $std/math/test_min
   i32.eqz
   if
@@ -33929,9 +33198,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -0
   f64.const 1
-  f64.const -0
+  f64.const 1
+  f64.const 1
   call $std/math/test_min
   i32.eqz
   if
@@ -33942,54 +33211,15 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 0.5
+  f64.const -1
   f64.const 1
-  f64.const 0.5
+  f64.const -1
   call $std/math/test_min
   i32.eqz
   if
    i32.const 0
    i32.const 1056
    i32.const 2183
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const -0.5
-  f64.const 1
-  f64.const -0.5
-  call $std/math/test_min
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 2184
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const 1
-  f64.const 1
-  f64.const 1
-  call $std/math/test_min
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 2185
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const -1
-  f64.const 1
-  f64.const -1
-  call $std/math/test_min
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 2186
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -34002,7 +33232,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 2187
+   i32.const 2184
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -34010,6 +33240,45 @@
   f64.const -inf
   f64.const 1
   f64.const -inf
+  call $std/math/test_min
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 2185
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const nan:0x8000000000000
+  f64.const 1
+  f64.const nan:0x8000000000000
+  call $std/math/test_min
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 2186
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const 0
+  f64.const -1
+  f64.const -1
+  call $std/math/test_min
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 2187
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const -0
+  f64.const -1
+  f64.const -1
   call $std/math/test_min
   i32.eqz
   if
@@ -34020,9 +33289,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const nan:0x8000000000000
-  f64.const 1
-  f64.const nan:0x8000000000000
+  f64.const 0.5
+  f64.const -1
+  f64.const -1
   call $std/math/test_min
   i32.eqz
   if
@@ -34033,7 +33302,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 0
+  f64.const -0.5
   f64.const -1
   f64.const -1
   call $std/math/test_min
@@ -34046,7 +33315,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -0
+  f64.const 1
   f64.const -1
   f64.const -1
   call $std/math/test_min
@@ -34059,7 +33328,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 0.5
+  f64.const -1
   f64.const -1
   f64.const -1
   call $std/math/test_min
@@ -34072,7 +33341,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -0.5
+  f64.const inf
   f64.const -1
   f64.const -1
   call $std/math/test_min
@@ -34085,9 +33354,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 1
+  f64.const -inf
   f64.const -1
-  f64.const -1
+  f64.const -inf
   call $std/math/test_min
   i32.eqz
   if
@@ -34098,9 +33367,9 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f64.const nan:0x8000000000000
   f64.const -1
-  f64.const -1
-  f64.const -1
+  f64.const nan:0x8000000000000
   call $std/math/test_min
   i32.eqz
   if
@@ -34111,9 +33380,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const inf
-  f64.const -1
-  f64.const -1
+  f64.const 0
+  f64.const 0
+  f64.const 0
   call $std/math/test_min
   i32.eqz
   if
@@ -34124,9 +33393,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -inf
-  f64.const -1
-  f64.const -inf
+  f64.const 0
+  f64.const -0
+  f64.const -0
   call $std/math/test_min
   i32.eqz
   if
@@ -34137,9 +33406,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const nan:0x8000000000000
-  f64.const -1
-  f64.const nan:0x8000000000000
+  f64.const 0
+  f64.const inf
+  f64.const 0
   call $std/math/test_min
   i32.eqz
   if
@@ -34151,8 +33420,8 @@
    unreachable
   end
   f64.const 0
-  f64.const 0
-  f64.const 0
+  f64.const -inf
+  f64.const -inf
   call $std/math/test_min
   i32.eqz
   if
@@ -34164,8 +33433,8 @@
    unreachable
   end
   f64.const 0
-  f64.const -0
-  f64.const -0
+  f64.const nan:0x8000000000000
+  f64.const nan:0x8000000000000
   call $std/math/test_min
   i32.eqz
   if
@@ -34176,9 +33445,9 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f64.const -0
   f64.const 0
-  f64.const inf
-  f64.const 0
+  f64.const -0
   call $std/math/test_min
   i32.eqz
   if
@@ -34189,9 +33458,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 0
-  f64.const -inf
-  f64.const -inf
+  f64.const -0
+  f64.const -0
+  f64.const -0
   call $std/math/test_min
   i32.eqz
   if
@@ -34202,9 +33471,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 0
-  f64.const nan:0x8000000000000
-  f64.const nan:0x8000000000000
+  f64.const -0
+  f64.const inf
+  f64.const -0
   call $std/math/test_min
   i32.eqz
   if
@@ -34216,8 +33485,8 @@
    unreachable
   end
   f64.const -0
-  f64.const 0
-  f64.const -0
+  f64.const -inf
+  f64.const -inf
   call $std/math/test_min
   i32.eqz
   if
@@ -34229,53 +33498,14 @@
    unreachable
   end
   f64.const -0
-  f64.const -0
-  f64.const -0
+  f64.const nan:0x8000000000000
+  f64.const nan:0x8000000000000
   call $std/math/test_min
   i32.eqz
   if
    i32.const 0
    i32.const 1056
    i32.const 2205
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const -0
-  f64.const inf
-  f64.const -0
-  call $std/math/test_min
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 2206
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const -0
-  f64.const -inf
-  f64.const -inf
-  call $std/math/test_min
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 2207
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const -0
-  f64.const nan:0x8000000000000
-  f64.const nan:0x8000000000000
-  call $std/math/test_min
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 2208
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -34288,7 +33518,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 2209
+   i32.const 2206
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -34301,7 +33531,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 2210
+   i32.const 2207
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -34314,7 +33544,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 2211
+   i32.const 2208
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -34322,6 +33552,45 @@
   f64.const -inf
   f64.const 0
   f64.const -inf
+  call $std/math/test_min
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 2209
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const nan:0x8000000000000
+  f64.const 0
+  f64.const nan:0x8000000000000
+  call $std/math/test_min
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 2210
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const -1
+  f64.const -0
+  f64.const -1
+  call $std/math/test_min
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 2211
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const inf
+  f64.const -0
+  f64.const -0
   call $std/math/test_min
   i32.eqz
   if
@@ -34332,9 +33601,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const nan:0x8000000000000
-  f64.const 0
-  f64.const nan:0x8000000000000
+  f64.const -inf
+  f64.const -0
+  f64.const -inf
   call $std/math/test_min
   i32.eqz
   if
@@ -34345,9 +33614,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -1
+  f64.const nan:0x8000000000000
   f64.const -0
-  f64.const -1
+  f64.const nan:0x8000000000000
   call $std/math/test_min
   i32.eqz
   if
@@ -34359,8 +33628,8 @@
    unreachable
   end
   f64.const inf
-  f64.const -0
-  f64.const -0
+  f64.const 2
+  f64.const 2
   call $std/math/test_min
   i32.eqz
   if
@@ -34371,9 +33640,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -inf
-  f64.const -0
-  f64.const -inf
+  f64.const inf
+  f64.const -0.5
+  f64.const -0.5
   call $std/math/test_min
   i32.eqz
   if
@@ -34384,8 +33653,8 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f64.const inf
   f64.const nan:0x8000000000000
-  f64.const -0
   f64.const nan:0x8000000000000
   call $std/math/test_min
   i32.eqz
@@ -34397,9 +33666,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const inf
+  f64.const -inf
   f64.const 2
-  f64.const 2
+  f64.const -inf
   call $std/math/test_min
   i32.eqz
   if
@@ -34410,9 +33679,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const inf
+  f64.const -inf
   f64.const -0.5
-  f64.const -0.5
+  f64.const -inf
   call $std/math/test_min
   i32.eqz
   if
@@ -34423,7 +33692,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const inf
+  f64.const -inf
   f64.const nan:0x8000000000000
   f64.const nan:0x8000000000000
   call $std/math/test_min
@@ -34436,9 +33705,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -inf
-  f64.const 2
-  f64.const -inf
+  f64.const nan:0x8000000000000
+  f64.const nan:0x8000000000000
+  f64.const nan:0x8000000000000
   call $std/math/test_min
   i32.eqz
   if
@@ -34449,9 +33718,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -inf
-  f64.const -0.5
-  f64.const -inf
+  f64.const 1
+  f64.const nan:0x8000000000000
+  f64.const nan:0x8000000000000
   call $std/math/test_min
   i32.eqz
   if
@@ -34462,7 +33731,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -inf
+  f64.const -1
   f64.const nan:0x8000000000000
   f64.const nan:0x8000000000000
   call $std/math/test_min
@@ -34475,9 +33744,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const nan:0x8000000000000
-  f64.const nan:0x8000000000000
-  f64.const nan:0x8000000000000
+  f64.const 1
+  f64.const inf
+  f64.const 1
   call $std/math/test_min
   i32.eqz
   if
@@ -34488,9 +33757,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 1
-  f64.const nan:0x8000000000000
-  f64.const nan:0x8000000000000
+  f64.const -1
+  f64.const inf
+  f64.const -1
   call $std/math/test_min
   i32.eqz
   if
@@ -34501,9 +33770,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -1
-  f64.const nan:0x8000000000000
-  f64.const nan:0x8000000000000
+  f64.const inf
+  f64.const inf
+  f64.const inf
   call $std/math/test_min
   i32.eqz
   if
@@ -34514,9 +33783,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 1
+  f64.const -inf
   f64.const inf
-  f64.const 1
+  f64.const -inf
   call $std/math/test_min
   i32.eqz
   if
@@ -34527,9 +33796,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -1
-  f64.const inf
-  f64.const -1
+  f64.const 1
+  f64.const -inf
+  f64.const -inf
   call $std/math/test_min
   i32.eqz
   if
@@ -34540,9 +33809,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const inf
-  f64.const inf
-  f64.const inf
+  f64.const -1
+  f64.const -inf
+  f64.const -inf
   call $std/math/test_min
   i32.eqz
   if
@@ -34553,8 +33822,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -inf
   f64.const inf
+  f64.const -inf
   f64.const -inf
   call $std/math/test_min
   i32.eqz
@@ -34566,7 +33835,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 1
+  f64.const -inf
   f64.const -inf
   f64.const -inf
   call $std/math/test_min
@@ -34579,9 +33848,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -1
-  f64.const -inf
-  f64.const -inf
+  f64.const 1.75
+  f64.const 0.5
+  f64.const 0.5
   call $std/math/test_min
   i32.eqz
   if
@@ -34592,9 +33861,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const inf
-  f64.const -inf
-  f64.const -inf
+  f64.const -1.75
+  f64.const 0.5
+  f64.const -1.75
   call $std/math/test_min
   i32.eqz
   if
@@ -34605,9 +33874,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -inf
-  f64.const -inf
-  f64.const -inf
+  f64.const 1.75
+  f64.const -0.5
+  f64.const -0.5
   call $std/math/test_min
   i32.eqz
   if
@@ -34618,9 +33887,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 1.75
-  f64.const 0.5
-  f64.const 0.5
+  f64.const -1.75
+  f64.const -0.5
+  f64.const -1.75
   call $std/math/test_min
   i32.eqz
   if
@@ -34631,47 +33900,47 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -1.75
-  f64.const 0.5
-  f64.const -1.75
-  call $std/math/test_min
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 2236
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const 1.75
-  f64.const -0.5
-  f64.const -0.5
-  call $std/math/test_min
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 2237
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const -1.75
-  f64.const -0.5
-  f64.const -1.75
-  call $std/math/test_min
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 2238
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
   f32.const -8.066848754882812
   f32.const -8.066848754882812
+  f32.const 0
+  call $std/math/check<f32>
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 2244
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const -8.887990951538086
+  f32.const -8.887990951538086
+  f32.const 0
+  call $std/math/check<f32>
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 2245
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const -8.381433486938477
+  f32.const -8.381433486938477
+  f32.const 0
+  call $std/math/check<f32>
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 2246
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const -6.531673431396484
+  f32.const -6.531673431396484
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -34683,8 +33952,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -8.887990951538086
-  f32.const -8.887990951538086
+  f32.const 4.811392307281494
+  f32.const 4.811392307281494
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -34696,8 +33965,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -8.381433486938477
-  f32.const -8.381433486938477
+  f32.const -6.450045585632324
+  f32.const -6.450045585632324
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -34709,8 +33978,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -6.531673431396484
-  f32.const -6.531673431396484
+  f32.const 0.052154526114463806
+  f32.const 0.052154526114463806
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -34722,8 +33991,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 4.811392307281494
-  f32.const 4.811392307281494
+  f32.const -0.7920545339584351
+  f32.const -0.7920545339584351
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -34735,8 +34004,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -6.450045585632324
-  f32.const -6.450045585632324
+  f32.const 0.6157026886940002
+  f32.const 0.6157026886940002
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -34748,8 +34017,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 0.052154526114463806
-  f32.const 0.052154526114463806
+  f32.const -0.5587586760520935
+  f32.const -0.5587586760520935
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -34761,34 +34030,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -0.7920545339584351
-  f32.const -0.7920545339584351
   f32.const 0
-  call $std/math/check<f32>
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 2254
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const 0.6157026886940002
-  f32.const 0.6157026886940002
   f32.const 0
-  call $std/math/check<f32>
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 2255
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const -0.5587586760520935
-  f32.const -0.5587586760520935
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -34800,8 +34043,34 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f32.const -0
+  f32.const -0
   f32.const 0
+  call $std/math/check<f32>
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 2257
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const 0.5
+  f32.const 0.5
   f32.const 0
+  call $std/math/check<f32>
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 2258
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const -0.5
+  f32.const -0.5
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -34813,8 +34082,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -0
-  f32.const -0
+  f32.const 1
+  f32.const 1
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -34826,8 +34095,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 0.5
-  f32.const 0.5
+  f32.const -1
+  f32.const -1
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -34839,8 +34108,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -0.5
-  f32.const -0.5
+  f32.const 1
+  f32.const 1
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -34852,8 +34121,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 1
-  f32.const 1
+  f32.const -inf
+  f32.const -inf
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -34865,8 +34134,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -1
-  f32.const -1
+  f32.const nan:0x400000
+  f32.const nan:0x400000
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -34878,8 +34147,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 1
-  f32.const 1
+  f32.const -1
+  f32.const -1
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -34891,8 +34160,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -inf
-  f32.const -inf
+  f32.const -1
+  f32.const -1
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -34904,8 +34173,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const nan:0x400000
-  f32.const nan:0x400000
+  f32.const -1
+  f32.const -1
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -34969,8 +34238,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -1
-  f32.const -1
+  f32.const -inf
+  f32.const -inf
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -34982,8 +34251,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -1
-  f32.const -1
+  f32.const nan:0x400000
+  f32.const nan:0x400000
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -34995,8 +34264,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -1
-  f32.const -1
+  f32.const 0
+  f32.const 0
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -35008,8 +34277,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -inf
-  f32.const -inf
+  f32.const -0
+  f32.const -0
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -35021,8 +34290,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const nan:0x400000
-  f32.const nan:0x400000
+  f32.const 0
+  f32.const 0
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -35034,8 +34303,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 0
-  f32.const 0
+  f32.const -inf
+  f32.const -inf
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -35047,8 +34316,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -0
-  f32.const -0
+  f32.const nan:0x400000
+  f32.const nan:0x400000
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -35060,8 +34329,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 0
-  f32.const 0
+  f32.const -0
+  f32.const -0
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -35073,8 +34342,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -inf
-  f32.const -inf
+  f32.const -0
+  f32.const -0
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -35086,8 +34355,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const nan:0x400000
-  f32.const nan:0x400000
+  f32.const -0
+  f32.const -0
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -35099,8 +34368,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -0
-  f32.const -0
+  f32.const -inf
+  f32.const -inf
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -35112,8 +34381,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -0
-  f32.const -0
+  f32.const nan:0x400000
+  f32.const nan:0x400000
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -35125,8 +34394,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -0
-  f32.const -0
+  f32.const 0
+  f32.const 0
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -35138,8 +34407,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -inf
-  f32.const -inf
+  f32.const -1
+  f32.const -1
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -35151,8 +34420,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const nan:0x400000
-  f32.const nan:0x400000
+  f32.const 0
+  f32.const 0
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -35164,8 +34433,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 0
-  f32.const 0
+  f32.const -inf
+  f32.const -inf
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -35177,8 +34446,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -1
-  f32.const -1
+  f32.const nan:0x400000
+  f32.const nan:0x400000
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -35190,8 +34459,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 0
-  f32.const 0
+  f32.const -1
+  f32.const -1
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -35203,8 +34472,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -inf
-  f32.const -inf
+  f32.const -0
+  f32.const -0
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -35216,8 +34485,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const nan:0x400000
-  f32.const nan:0x400000
+  f32.const -inf
+  f32.const -inf
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -35229,8 +34498,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -1
-  f32.const -1
+  f32.const nan:0x400000
+  f32.const nan:0x400000
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -35242,8 +34511,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -0
-  f32.const -0
+  f32.const 2
+  f32.const 2
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -35255,8 +34524,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -inf
-  f32.const -inf
+  f32.const -0.5
+  f32.const -0.5
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -35281,8 +34550,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 2
-  f32.const 2
+  f32.const -inf
+  f32.const -inf
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -35294,8 +34563,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -0.5
-  f32.const -0.5
+  f32.const -inf
+  f32.const -inf
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -35320,8 +34589,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -inf
-  f32.const -inf
+  f32.const nan:0x400000
+  f32.const nan:0x400000
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -35333,8 +34602,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -inf
-  f32.const -inf
+  f32.const nan:0x400000
+  f32.const nan:0x400000
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -35359,8 +34628,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const nan:0x400000
-  f32.const nan:0x400000
+  f32.const 1
+  f32.const 1
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -35372,8 +34641,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const nan:0x400000
-  f32.const nan:0x400000
+  f32.const -1
+  f32.const -1
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -35385,8 +34654,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const nan:0x400000
-  f32.const nan:0x400000
+  f32.const inf
+  f32.const inf
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -35398,8 +34667,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 1
-  f32.const 1
+  f32.const -inf
+  f32.const -inf
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -35411,8 +34680,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -1
-  f32.const -1
+  f32.const -inf
+  f32.const -inf
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -35424,8 +34693,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const inf
-  f32.const inf
+  f32.const -inf
+  f32.const -inf
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -35463,8 +34732,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -inf
-  f32.const -inf
+  f32.const 0.5
+  f32.const 0.5
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -35476,8 +34745,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -inf
-  f32.const -inf
+  f32.const -1.75
+  f32.const -1.75
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -35489,8 +34758,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -inf
-  f32.const -inf
+  f32.const -0.5
+  f32.const -0.5
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -35502,8 +34771,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 0.5
-  f32.const 0.5
+  f32.const -1.75
+  f32.const -1.75
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -35511,45 +34780,6 @@
    i32.const 0
    i32.const 1056
    i32.const 2313
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const -1.75
-  f32.const -1.75
-  f32.const 0
-  call $std/math/check<f32>
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 2314
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const -0.5
-  f32.const -0.5
-  f32.const 0
-  call $std/math/check<f32>
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 2315
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const -1.75
-  f32.const -1.75
-  f32.const 0
-  call $std/math/check<f32>
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 2316
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -35562,7 +34792,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 2330
+   i32.const 2327
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -35575,7 +34805,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 2331
+   i32.const 2328
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -35588,7 +34818,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 2332
+   i32.const 2329
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -35601,7 +34831,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 2333
+   i32.const 2330
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -35614,7 +34844,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 2334
+   i32.const 2331
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -35627,7 +34857,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 2335
+   i32.const 2332
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -35640,7 +34870,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 2336
+   i32.const 2333
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -35653,7 +34883,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 2337
+   i32.const 2334
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -35666,7 +34896,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 2338
+   i32.const 2335
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -35679,7 +34909,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 2339
+   i32.const 2336
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -35687,6 +34917,45 @@
   f64.const 0
   f64.const 1
   f64.const 0
+  call $std/math/test_mod
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 2339
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const -0
+  f64.const 1
+  f64.const -0
+  call $std/math/test_mod
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 2340
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const 0.5
+  f64.const 1
+  f64.const 0.5
+  call $std/math/test_mod
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 2341
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const -0.5
+  f64.const 1
+  f64.const -0.5
   call $std/math/test_mod
   i32.eqz
   if
@@ -35697,45 +34966,6 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -0
-  f64.const 1
-  f64.const -0
-  call $std/math/test_mod
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 2343
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const 0.5
-  f64.const 1
-  f64.const 0.5
-  call $std/math/test_mod
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 2344
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const -0.5
-  f64.const 1
-  f64.const -0.5
-  call $std/math/test_mod
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 2345
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
   f64.const 1
   f64.const 1
   f64.const 0
@@ -35744,7 +34974,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 2346
+   i32.const 2343
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -35757,7 +34987,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 2347
+   i32.const 2344
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -35770,7 +35000,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 2348
+   i32.const 2345
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -35783,7 +35013,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 2349
+   i32.const 2346
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -35796,7 +35026,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 2350
+   i32.const 2347
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -35809,7 +35039,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 2351
+   i32.const 2348
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -35822,7 +35052,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 2352
+   i32.const 2349
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -35835,7 +35065,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 2353
+   i32.const 2350
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -35843,6 +35073,45 @@
   f64.const nan:0x8000000000000
   f64.const 1
   f64.const nan:0x8000000000000
+  call $std/math/test_mod
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 2351
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const 0
+  f64.const -1
+  f64.const 0
+  call $std/math/test_mod
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 2352
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const -0
+  f64.const -1
+  f64.const -0
+  call $std/math/test_mod
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 2353
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const 0.5
+  f64.const -1
+  f64.const 0.5
   call $std/math/test_mod
   i32.eqz
   if
@@ -35853,54 +35122,15 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 0
+  f64.const -0.5
   f64.const -1
-  f64.const 0
+  f64.const -0.5
   call $std/math/test_mod
   i32.eqz
   if
    i32.const 0
    i32.const 1056
    i32.const 2355
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const -0
-  f64.const -1
-  f64.const -0
-  call $std/math/test_mod
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 2356
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const 0.5
-  f64.const -1
-  f64.const 0.5
-  call $std/math/test_mod
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 2357
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const -0.5
-  f64.const -1
-  f64.const -0.5
-  call $std/math/test_mod
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 2358
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -35913,7 +35143,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 2359
+   i32.const 2356
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -35926,7 +35156,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 2360
+   i32.const 2357
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -35939,7 +35169,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 2361
+   i32.const 2358
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -35952,7 +35182,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 2362
+   i32.const 2359
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -35965,7 +35195,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 2363
+   i32.const 2360
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -35978,13 +35208,52 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 2364
+   i32.const 2361
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f64.const inf
   f64.const -1
+  f64.const nan:0x8000000000000
+  call $std/math/test_mod
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 2362
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const -inf
+  f64.const -1
+  f64.const nan:0x8000000000000
+  call $std/math/test_mod
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 2363
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const nan:0x8000000000000
+  f64.const -1
+  f64.const nan:0x8000000000000
+  call $std/math/test_mod
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 2364
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const 0
+  f64.const 0
   f64.const nan:0x8000000000000
   call $std/math/test_mod
   i32.eqz
@@ -35996,8 +35265,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -inf
-  f64.const -1
+  f64.const 0
+  f64.const -0
   f64.const nan:0x8000000000000
   call $std/math/test_mod
   i32.eqz
@@ -36009,9 +35278,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const nan:0x8000000000000
-  f64.const -1
-  f64.const nan:0x8000000000000
+  f64.const 0
+  f64.const inf
+  f64.const 0
   call $std/math/test_mod
   i32.eqz
   if
@@ -36023,8 +35292,8 @@
    unreachable
   end
   f64.const 0
+  f64.const -inf
   f64.const 0
-  f64.const nan:0x8000000000000
   call $std/math/test_mod
   i32.eqz
   if
@@ -36036,7 +35305,7 @@
    unreachable
   end
   f64.const 0
-  f64.const -0
+  f64.const nan:0x8000000000000
   f64.const nan:0x8000000000000
   call $std/math/test_mod
   i32.eqz
@@ -36048,9 +35317,9 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f64.const -0
   f64.const 0
-  f64.const inf
-  f64.const 0
+  f64.const nan:0x8000000000000
   call $std/math/test_mod
   i32.eqz
   if
@@ -36061,9 +35330,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 0
-  f64.const -inf
-  f64.const 0
+  f64.const -0
+  f64.const -0
+  f64.const nan:0x8000000000000
   call $std/math/test_mod
   i32.eqz
   if
@@ -36074,9 +35343,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 0
-  f64.const nan:0x8000000000000
-  f64.const nan:0x8000000000000
+  f64.const -0
+  f64.const inf
+  f64.const -0
   call $std/math/test_mod
   i32.eqz
   if
@@ -36088,8 +35357,8 @@
    unreachable
   end
   f64.const -0
-  f64.const 0
-  f64.const nan:0x8000000000000
+  f64.const -inf
+  f64.const -0
   call $std/math/test_mod
   i32.eqz
   if
@@ -36101,7 +35370,7 @@
    unreachable
   end
   f64.const -0
-  f64.const -0
+  f64.const nan:0x8000000000000
   f64.const nan:0x8000000000000
   call $std/math/test_mod
   i32.eqz
@@ -36113,9 +35382,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -0
-  f64.const inf
-  f64.const -0
+  f64.const 1
+  f64.const 0
+  f64.const nan:0x8000000000000
   call $std/math/test_mod
   i32.eqz
   if
@@ -36126,9 +35395,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -0
-  f64.const -inf
-  f64.const -0
+  f64.const -1
+  f64.const 0
+  f64.const nan:0x8000000000000
   call $std/math/test_mod
   i32.eqz
   if
@@ -36139,8 +35408,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -0
-  f64.const nan:0x8000000000000
+  f64.const inf
+  f64.const 0
   f64.const nan:0x8000000000000
   call $std/math/test_mod
   i32.eqz
@@ -36152,7 +35421,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 1
+  f64.const -inf
   f64.const 0
   f64.const nan:0x8000000000000
   call $std/math/test_mod
@@ -36165,7 +35434,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -1
+  f64.const nan:0x8000000000000
   f64.const 0
   f64.const nan:0x8000000000000
   call $std/math/test_mod
@@ -36178,8 +35447,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const inf
-  f64.const 0
+  f64.const -1
+  f64.const -0
   f64.const nan:0x8000000000000
   call $std/math/test_mod
   i32.eqz
@@ -36191,8 +35460,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -inf
-  f64.const 0
+  f64.const inf
+  f64.const -0
   f64.const nan:0x8000000000000
   call $std/math/test_mod
   i32.eqz
@@ -36204,8 +35473,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const nan:0x8000000000000
-  f64.const 0
+  f64.const -inf
+  f64.const -0
   f64.const nan:0x8000000000000
   call $std/math/test_mod
   i32.eqz
@@ -36217,7 +35486,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -1
+  f64.const nan:0x8000000000000
   f64.const -0
   f64.const nan:0x8000000000000
   call $std/math/test_mod
@@ -36231,7 +35500,7 @@
    unreachable
   end
   f64.const inf
-  f64.const -0
+  f64.const 2
   f64.const nan:0x8000000000000
   call $std/math/test_mod
   i32.eqz
@@ -36243,8 +35512,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -inf
-  f64.const -0
+  f64.const inf
+  f64.const -0.5
   f64.const nan:0x8000000000000
   call $std/math/test_mod
   i32.eqz
@@ -36256,8 +35525,8 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f64.const inf
   f64.const nan:0x8000000000000
-  f64.const -0
   f64.const nan:0x8000000000000
   call $std/math/test_mod
   i32.eqz
@@ -36269,7 +35538,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const inf
+  f64.const -inf
   f64.const 2
   f64.const nan:0x8000000000000
   call $std/math/test_mod
@@ -36282,7 +35551,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const inf
+  f64.const -inf
   f64.const -0.5
   f64.const nan:0x8000000000000
   call $std/math/test_mod
@@ -36295,7 +35564,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const inf
+  f64.const -inf
   f64.const nan:0x8000000000000
   f64.const nan:0x8000000000000
   call $std/math/test_mod
@@ -36308,8 +35577,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -inf
-  f64.const 2
+  f64.const nan:0x8000000000000
+  f64.const nan:0x8000000000000
   f64.const nan:0x8000000000000
   call $std/math/test_mod
   i32.eqz
@@ -36321,8 +35590,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -inf
-  f64.const -0.5
+  f64.const 1
+  f64.const nan:0x8000000000000
   f64.const nan:0x8000000000000
   call $std/math/test_mod
   i32.eqz
@@ -36334,7 +35603,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -inf
+  f64.const -1
   f64.const nan:0x8000000000000
   f64.const nan:0x8000000000000
   call $std/math/test_mod
@@ -36347,9 +35616,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const nan:0x8000000000000
-  f64.const nan:0x8000000000000
-  f64.const nan:0x8000000000000
+  f64.const 1
+  f64.const inf
+  f64.const 1
   call $std/math/test_mod
   i32.eqz
   if
@@ -36360,9 +35629,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 1
-  f64.const nan:0x8000000000000
-  f64.const nan:0x8000000000000
+  f64.const -1
+  f64.const inf
+  f64.const -1
   call $std/math/test_mod
   i32.eqz
   if
@@ -36373,8 +35642,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -1
-  f64.const nan:0x8000000000000
+  f64.const inf
+  f64.const inf
   f64.const nan:0x8000000000000
   call $std/math/test_mod
   i32.eqz
@@ -36386,9 +35655,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 1
+  f64.const -inf
   f64.const inf
-  f64.const 1
+  f64.const nan:0x8000000000000
   call $std/math/test_mod
   i32.eqz
   if
@@ -36399,9 +35668,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -1
-  f64.const inf
-  f64.const -1
+  f64.const 1
+  f64.const -inf
+  f64.const 1
   call $std/math/test_mod
   i32.eqz
   if
@@ -36412,9 +35681,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const inf
-  f64.const inf
-  f64.const nan:0x8000000000000
+  f64.const -1
+  f64.const -inf
+  f64.const -1
   call $std/math/test_mod
   i32.eqz
   if
@@ -36425,8 +35694,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -inf
   f64.const inf
+  f64.const -inf
   f64.const nan:0x8000000000000
   call $std/math/test_mod
   i32.eqz
@@ -36438,9 +35707,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 1
   f64.const -inf
-  f64.const 1
+  f64.const -inf
+  f64.const nan:0x8000000000000
   call $std/math/test_mod
   i32.eqz
   if
@@ -36451,9 +35720,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -1
-  f64.const -inf
-  f64.const -1
+  f64.const 1.75
+  f64.const 0.5
+  f64.const 0.25
   call $std/math/test_mod
   i32.eqz
   if
@@ -36464,9 +35733,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const inf
-  f64.const -inf
-  f64.const nan:0x8000000000000
+  f64.const -1.75
+  f64.const 0.5
+  f64.const -0.25
   call $std/math/test_mod
   i32.eqz
   if
@@ -36477,9 +35746,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -inf
-  f64.const -inf
-  f64.const nan:0x8000000000000
+  f64.const 1.75
+  f64.const -0.5
+  f64.const 0.25
   call $std/math/test_mod
   i32.eqz
   if
@@ -36490,9 +35759,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 1.75
-  f64.const 0.5
-  f64.const 0.25
+  f64.const -1.75
+  f64.const -0.5
+  f64.const -0.25
   call $std/math/test_mod
   i32.eqz
   if
@@ -36503,35 +35772,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -1.75
-  f64.const 0.5
-  f64.const -0.25
-  call $std/math/test_mod
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 2405
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const 1.75
-  f64.const -0.5
-  f64.const 0.25
-  call $std/math/test_mod
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 2406
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const -1.75
-  f64.const -0.5
-  f64.const -0.25
+  f64.const 2.2250738585072014e-308
+  f64.const 2.2250738585072014e-308
+  f64.const 0
   call $std/math/test_mod
   i32.eqz
   if
@@ -36543,8 +35786,34 @@
    unreachable
   end
   f64.const 2.2250738585072014e-308
-  f64.const 2.2250738585072014e-308
+  f64.const -2.2250738585072014e-308
   f64.const 0
+  call $std/math/test_mod
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 2408
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const -2.2250738585072014e-308
+  f64.const 2.2250738585072014e-308
+  f64.const -0
+  call $std/math/test_mod
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 2409
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const -2.2250738585072014e-308
+  f64.const -2.2250738585072014e-308
+  f64.const -0
   call $std/math/test_mod
   i32.eqz
   if
@@ -36555,8 +35824,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 2.2250738585072014e-308
-  f64.const -2.2250738585072014e-308
+  f64.const 1797693134862315708145274e284
+  f64.const 1797693134862315708145274e284
   f64.const 0
   call $std/math/test_mod
   i32.eqz
@@ -36568,9 +35837,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -2.2250738585072014e-308
-  f64.const 2.2250738585072014e-308
-  f64.const -0
+  f64.const 1797693134862315708145274e284
+  f64.const -1797693134862315708145274e284
+  f64.const 0
   call $std/math/test_mod
   i32.eqz
   if
@@ -36581,8 +35850,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -2.2250738585072014e-308
-  f64.const -2.2250738585072014e-308
+  f64.const -1797693134862315708145274e284
+  f64.const 1797693134862315708145274e284
   f64.const -0
   call $std/math/test_mod
   i32.eqz
@@ -36594,9 +35863,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 1797693134862315708145274e284
-  f64.const 1797693134862315708145274e284
-  f64.const 0
+  f64.const -1797693134862315708145274e284
+  f64.const -1797693134862315708145274e284
+  f64.const -0
   call $std/math/test_mod
   i32.eqz
   if
@@ -36607,35 +35876,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 1797693134862315708145274e284
-  f64.const -1797693134862315708145274e284
   f64.const 0
-  call $std/math/test_mod
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 2415
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const -1797693134862315708145274e284
-  f64.const 1797693134862315708145274e284
-  f64.const -0
-  call $std/math/test_mod
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 2416
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const -1797693134862315708145274e284
-  f64.const -1797693134862315708145274e284
-  f64.const -0
+  f64.const 2.2250738585072014e-308
+  f64.const 0
   call $std/math/test_mod
   i32.eqz
   if
@@ -36647,7 +35890,33 @@
    unreachable
   end
   f64.const 0
-  f64.const 2.2250738585072014e-308
+  f64.const 1797693134862315708145274e284
+  f64.const 0
+  call $std/math/test_mod
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 2418
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const 0
+  f64.const -2.2250738585072014e-308
+  f64.const 0
+  call $std/math/test_mod
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 2419
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const 0
+  f64.const -1797693134862315708145274e284
   f64.const 0
   call $std/math/test_mod
   i32.eqz
@@ -36659,9 +35928,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 0
-  f64.const 1797693134862315708145274e284
-  f64.const 0
+  f64.const -0
+  f64.const 2.2250738585072014e-308
+  f64.const -0
   call $std/math/test_mod
   i32.eqz
   if
@@ -36672,9 +35941,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 0
-  f64.const -2.2250738585072014e-308
-  f64.const 0
+  f64.const -0
+  f64.const 1797693134862315708145274e284
+  f64.const -0
   call $std/math/test_mod
   i32.eqz
   if
@@ -36685,9 +35954,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 0
-  f64.const -1797693134862315708145274e284
-  f64.const 0
+  f64.const -0
+  f64.const -2.2250738585072014e-308
+  f64.const -0
   call $std/math/test_mod
   i32.eqz
   if
@@ -36699,45 +35968,6 @@
    unreachable
   end
   f64.const -0
-  f64.const 2.2250738585072014e-308
-  f64.const -0
-  call $std/math/test_mod
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 2424
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const -0
-  f64.const 1797693134862315708145274e284
-  f64.const -0
-  call $std/math/test_mod
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 2425
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const -0
-  f64.const -2.2250738585072014e-308
-  f64.const -0
-  call $std/math/test_mod
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 2426
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const -0
   f64.const -1797693134862315708145274e284
   f64.const -0
   call $std/math/test_mod
@@ -36745,7 +35975,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 2427
+   i32.const 2424
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -36758,7 +35988,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 2430
+   i32.const 2427
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -36771,7 +36001,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 2431
+   i32.const 2428
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -36784,7 +36014,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 2433
+   i32.const 2430
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -36797,7 +36027,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 2434
+   i32.const 2431
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -36810,7 +36040,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 2436
+   i32.const 2433
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -36823,7 +36053,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 2437
+   i32.const 2434
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -36836,7 +36066,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 2439
+   i32.const 2436
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -36849,7 +36079,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 2440
+   i32.const 2437
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -36857,6 +36087,32 @@
   f64.const 8988465674311579538646525e283
   f64.const 1797693134862315708145274e284
   f64.const 8988465674311579538646525e283
+  call $std/math/test_mod
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 2439
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const -8988465674311579538646525e283
+  f64.const 1797693134862315708145274e284
+  f64.const -8988465674311579538646525e283
+  call $std/math/test_mod
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 2440
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const 8988465674311578540726371e283
+  f64.const -1797693134862315708145274e284
+  f64.const 8988465674311578540726371e283
   call $std/math/test_mod
   i32.eqz
   if
@@ -36867,9 +36123,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -8988465674311579538646525e283
-  f64.const 1797693134862315708145274e284
-  f64.const -8988465674311579538646525e283
+  f64.const -8988465674311578540726371e283
+  f64.const -1797693134862315708145274e284
+  f64.const -8988465674311578540726371e283
   call $std/math/test_mod
   i32.eqz
   if
@@ -36880,9 +36136,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 8988465674311578540726371e283
-  f64.const -1797693134862315708145274e284
-  f64.const 8988465674311578540726371e283
+  f64.const 8988465674311577542806216e283
+  f64.const 1797693134862315708145274e284
+  f64.const 8988465674311577542806216e283
   call $std/math/test_mod
   i32.eqz
   if
@@ -36893,9 +36149,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -8988465674311578540726371e283
-  f64.const -1797693134862315708145274e284
-  f64.const -8988465674311578540726371e283
+  f64.const -8988465674311577542806216e283
+  f64.const 1797693134862315708145274e284
+  f64.const -8988465674311577542806216e283
   call $std/math/test_mod
   i32.eqz
   if
@@ -36906,9 +36162,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 8988465674311577542806216e283
-  f64.const 1797693134862315708145274e284
-  f64.const 8988465674311577542806216e283
+  f64.const 1797693134862315508561243e284
+  f64.const -1797693134862315708145274e284
+  f64.const 1797693134862315508561243e284
   call $std/math/test_mod
   i32.eqz
   if
@@ -36919,41 +36175,15 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -8988465674311577542806216e283
-  f64.const 1797693134862315708145274e284
-  f64.const -8988465674311577542806216e283
+  f64.const -1797693134862315508561243e284
+  f64.const -1797693134862315708145274e284
+  f64.const -1797693134862315508561243e284
   call $std/math/test_mod
   i32.eqz
   if
    i32.const 0
    i32.const 1056
    i32.const 2449
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const 1797693134862315508561243e284
-  f64.const -1797693134862315708145274e284
-  f64.const 1797693134862315508561243e284
-  call $std/math/test_mod
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 2451
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const -1797693134862315508561243e284
-  f64.const -1797693134862315708145274e284
-  f64.const -1797693134862315508561243e284
-  call $std/math/test_mod
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 2452
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -36966,7 +36196,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 2454
+   i32.const 2451
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -36979,7 +36209,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 2455
+   i32.const 2452
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -36992,7 +36222,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 2457
+   i32.const 2454
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -37005,7 +36235,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 2458
+   i32.const 2455
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -37018,7 +36248,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 2459
+   i32.const 2456
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -37031,7 +36261,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 2460
+   i32.const 2457
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -37044,7 +36274,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 2461
+   i32.const 2458
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -37057,7 +36287,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 2462
+   i32.const 2459
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -37070,7 +36300,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 2463
+   i32.const 2460
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -37083,7 +36313,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 2464
+   i32.const 2461
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -37096,7 +36326,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 2466
+   i32.const 2463
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -37109,7 +36339,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 2467
+   i32.const 2464
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -37122,7 +36352,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 2468
+   i32.const 2465
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -37135,7 +36365,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 2469
+   i32.const 2466
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -37148,7 +36378,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 2470
+   i32.const 2467
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -37161,7 +36391,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 2471
+   i32.const 2468
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -37174,7 +36404,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 2472
+   i32.const 2469
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -37187,7 +36417,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 2473
+   i32.const 2470
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -37200,7 +36430,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 2474
+   i32.const 2471
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -37213,7 +36443,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 2475
+   i32.const 2472
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -37226,7 +36456,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 2476
+   i32.const 2473
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -37234,6 +36464,45 @@
   f64.const 2.2250738585072024e-308
   f64.const 1.5e-323
   f64.const 0
+  call $std/math/test_mod
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 2474
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const 2.2250738585072024e-308
+  f64.const -1.5e-323
+  f64.const 0
+  call $std/math/test_mod
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 2475
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const 2.225073858507203e-308
+  f64.const 1.5e-323
+  f64.const 5e-324
+  call $std/math/test_mod
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 2476
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const 2.225073858507203e-308
+  f64.const 2.225073858507204e-308
+  f64.const 2.225073858507203e-308
   call $std/math/test_mod
   i32.eqz
   if
@@ -37244,9 +36513,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 2.2250738585072024e-308
+  f64.const 2.225073858507203e-308
   f64.const -1.5e-323
-  f64.const 0
+  f64.const 5e-324
   call $std/math/test_mod
   i32.eqz
   if
@@ -37257,54 +36526,15 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 2.225073858507203e-308
-  f64.const 1.5e-323
-  f64.const 5e-324
+  f64.const 2.2250738585072034e-308
+  f64.const 2.225073858507204e-308
+  f64.const 2.2250738585072034e-308
   call $std/math/test_mod
   i32.eqz
   if
    i32.const 0
    i32.const 1056
    i32.const 2479
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const 2.225073858507203e-308
-  f64.const 2.225073858507204e-308
-  f64.const 2.225073858507203e-308
-  call $std/math/test_mod
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 2480
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const 2.225073858507203e-308
-  f64.const -1.5e-323
-  f64.const 5e-324
-  call $std/math/test_mod
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 2481
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const 2.2250738585072034e-308
-  f64.const 2.225073858507204e-308
-  f64.const 2.2250738585072034e-308
-  call $std/math/test_mod
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 2482
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -37317,7 +36547,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 2483
+   i32.const 2480
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -37330,7 +36560,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 2484
+   i32.const 2481
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -37343,15 +36573,60 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 2485
+   i32.const 2482
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f32.const -8.066848754882812
   f32.const 4.535662651062012
-  call $~lib/math/NativeMathf.mod
+  call $~lib/util/math/mod32
   f32.const -3.531186103820801
+  f32.const 0
+  call $std/math/check<f32>
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 2491
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const 4.345239639282227
+  f32.const -8.887990951538086
+  call $~lib/util/math/mod32
+  f32.const 4.345239639282227
+  f32.const 0
+  call $std/math/check<f32>
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 2492
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const -8.381433486938477
+  f32.const -2.7636072635650635
+  call $~lib/util/math/mod32
+  f32.const -0.09061169624328613
+  f32.const 0
+  call $std/math/check<f32>
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 2493
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const -6.531673431396484
+  f32.const 4.567535400390625
+  call $~lib/util/math/mod32
+  f32.const -1.9641380310058594
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -37363,10 +36638,10 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 4.345239639282227
-  f32.const -8.887990951538086
-  call $~lib/math/NativeMathf.mod
-  f32.const 4.345239639282227
+  f32.const 9.267057418823242
+  f32.const 4.811392307281494
+  call $~lib/util/math/mod32
+  f32.const 4.455665111541748
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -37378,10 +36653,10 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -8.381433486938477
-  f32.const -2.7636072635650635
-  call $~lib/math/NativeMathf.mod
-  f32.const -0.09061169624328613
+  f32.const -6.450045585632324
+  f32.const 0.6620717644691467
+  call $~lib/util/math/mod32
+  f32.const -0.49139970541000366
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -37393,10 +36668,10 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -6.531673431396484
-  f32.const 4.567535400390625
-  call $~lib/math/NativeMathf.mod
-  f32.const -1.9641380310058594
+  f32.const 7.858890056610107
+  f32.const 0.052154526114463806
+  call $~lib/util/math/mod32
+  f32.const 0.0357111394405365
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -37408,10 +36683,10 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 9.267057418823242
-  f32.const 4.811392307281494
-  call $~lib/math/NativeMathf.mod
-  f32.const 4.455665111541748
+  f32.const -0.7920545339584351
+  f32.const 7.676402568817139
+  call $~lib/util/math/mod32
+  f32.const -0.7920545339584351
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -37423,10 +36698,10 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -6.450045585632324
-  f32.const 0.6620717644691467
-  call $~lib/math/NativeMathf.mod
-  f32.const -0.49139970541000366
+  f32.const 0.6157026886940002
+  f32.const 2.0119025707244873
+  call $~lib/util/math/mod32
+  f32.const 0.6157026886940002
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -37438,10 +36713,10 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 7.858890056610107
-  f32.const 0.052154526114463806
-  call $~lib/math/NativeMathf.mod
-  f32.const 0.0357111394405365
+  f32.const -0.5587586760520935
+  f32.const 0.03223983198404312
+  call $~lib/util/math/mod32
+  f32.const -0.010681532323360443
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -37453,40 +36728,10 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -0.7920545339584351
-  f32.const 7.676402568817139
-  call $~lib/math/NativeMathf.mod
-  f32.const -0.7920545339584351
   f32.const 0
-  call $std/math/check<f32>
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 2501
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const 0.6157026886940002
-  f32.const 2.0119025707244873
-  call $~lib/math/NativeMathf.mod
-  f32.const 0.6157026886940002
+  f32.const 1
+  call $~lib/util/math/mod32
   f32.const 0
-  call $std/math/check<f32>
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 2502
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const -0.5587586760520935
-  f32.const 0.03223983198404312
-  call $~lib/math/NativeMathf.mod
-  f32.const -0.010681532323360443
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -37498,10 +36743,40 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 0
+  f32.const -0
   f32.const 1
-  call $~lib/math/NativeMathf.mod
+  call $~lib/util/math/mod32
+  f32.const -0
   f32.const 0
+  call $std/math/check<f32>
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 2504
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const 0.5
+  f32.const 1
+  call $~lib/util/math/mod32
+  f32.const 0.5
+  f32.const 0
+  call $std/math/check<f32>
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 2505
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const -0.5
+  f32.const 1
+  call $~lib/util/math/mod32
+  f32.const -0.5
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -37513,10 +36788,10 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -0
   f32.const 1
-  call $~lib/math/NativeMathf.mod
-  f32.const -0
+  f32.const 1
+  call $~lib/util/math/mod32
+  f32.const 0
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -37528,10 +36803,10 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 0.5
+  f32.const -1
   f32.const 1
-  call $~lib/math/NativeMathf.mod
-  f32.const 0.5
+  call $~lib/util/math/mod32
+  f32.const -0
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -37543,10 +36818,10 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -0.5
+  f32.const 1.5
   f32.const 1
-  call $~lib/math/NativeMathf.mod
-  f32.const -0.5
+  call $~lib/util/math/mod32
+  f32.const 0.5
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -37558,10 +36833,10 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f32.const -1.5
   f32.const 1
-  f32.const 1
-  call $~lib/math/NativeMathf.mod
-  f32.const 0
+  call $~lib/util/math/mod32
+  f32.const -0.5
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -37573,10 +36848,10 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -1
+  f32.const 2
   f32.const 1
-  call $~lib/math/NativeMathf.mod
-  f32.const -0
+  call $~lib/util/math/mod32
+  f32.const 0
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -37588,10 +36863,10 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 1.5
+  f32.const -2
   f32.const 1
-  call $~lib/math/NativeMathf.mod
-  f32.const 0.5
+  call $~lib/util/math/mod32
+  f32.const -0
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -37603,10 +36878,10 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -1.5
+  f32.const inf
   f32.const 1
-  call $~lib/math/NativeMathf.mod
-  f32.const -0.5
+  call $~lib/util/math/mod32
+  f32.const nan:0x400000
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -37618,10 +36893,10 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 2
+  f32.const -inf
   f32.const 1
-  call $~lib/math/NativeMathf.mod
-  f32.const 0
+  call $~lib/util/math/mod32
+  f32.const nan:0x400000
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -37633,10 +36908,10 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -2
+  f32.const nan:0x400000
   f32.const 1
-  call $~lib/math/NativeMathf.mod
-  f32.const -0
+  call $~lib/util/math/mod32
+  f32.const nan:0x400000
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -37648,10 +36923,10 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const inf
-  f32.const 1
-  call $~lib/math/NativeMathf.mod
-  f32.const nan:0x400000
+  f32.const 0
+  f32.const -1
+  call $~lib/util/math/mod32
+  f32.const 0
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -37663,10 +36938,10 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -inf
-  f32.const 1
-  call $~lib/math/NativeMathf.mod
-  f32.const nan:0x400000
+  f32.const -0
+  f32.const -1
+  call $~lib/util/math/mod32
+  f32.const -0
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -37678,10 +36953,10 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const nan:0x400000
-  f32.const 1
-  call $~lib/math/NativeMathf.mod
-  f32.const nan:0x400000
+  f32.const 0.5
+  f32.const -1
+  call $~lib/util/math/mod32
+  f32.const 0.5
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -37693,10 +36968,10 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 0
+  f32.const -0.5
   f32.const -1
-  call $~lib/math/NativeMathf.mod
-  f32.const 0
+  call $~lib/util/math/mod32
+  f32.const -0.5
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -37708,10 +36983,10 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -0
+  f32.const 1
   f32.const -1
-  call $~lib/math/NativeMathf.mod
-  f32.const -0
+  call $~lib/util/math/mod32
+  f32.const 0
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -37723,10 +36998,10 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 0.5
   f32.const -1
-  call $~lib/math/NativeMathf.mod
-  f32.const 0.5
+  f32.const -1
+  call $~lib/util/math/mod32
+  f32.const -0
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -37738,10 +37013,10 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -0.5
+  f32.const 1.5
   f32.const -1
-  call $~lib/math/NativeMathf.mod
-  f32.const -0.5
+  call $~lib/util/math/mod32
+  f32.const 0.5
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -37753,10 +37028,10 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 1
+  f32.const -1.5
   f32.const -1
-  call $~lib/math/NativeMathf.mod
-  f32.const 0
+  call $~lib/util/math/mod32
+  f32.const -0.5
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -37768,10 +37043,10 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f32.const 2
   f32.const -1
-  f32.const -1
-  call $~lib/math/NativeMathf.mod
-  f32.const -0
+  call $~lib/util/math/mod32
+  f32.const 0
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -37783,10 +37058,10 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 1.5
+  f32.const -2
   f32.const -1
-  call $~lib/math/NativeMathf.mod
-  f32.const 0.5
+  call $~lib/util/math/mod32
+  f32.const -0
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -37798,10 +37073,10 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -1.5
+  f32.const inf
   f32.const -1
-  call $~lib/math/NativeMathf.mod
-  f32.const -0.5
+  call $~lib/util/math/mod32
+  f32.const nan:0x400000
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -37813,10 +37088,10 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 2
+  f32.const -inf
   f32.const -1
-  call $~lib/math/NativeMathf.mod
-  f32.const 0
+  call $~lib/util/math/mod32
+  f32.const nan:0x400000
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -37828,10 +37103,10 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -2
+  f32.const nan:0x400000
   f32.const -1
-  call $~lib/math/NativeMathf.mod
-  f32.const -0
+  call $~lib/util/math/mod32
+  f32.const nan:0x400000
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -37843,9 +37118,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const inf
-  f32.const -1
-  call $~lib/math/NativeMathf.mod
+  f32.const 0
+  f32.const 0
+  call $~lib/util/math/mod32
   f32.const nan:0x400000
   f32.const 0
   call $std/math/check<f32>
@@ -37858,9 +37133,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -inf
-  f32.const -1
-  call $~lib/math/NativeMathf.mod
+  f32.const 0
+  f32.const -0
+  call $~lib/util/math/mod32
   f32.const nan:0x400000
   f32.const 0
   call $std/math/check<f32>
@@ -37873,10 +37148,10 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const nan:0x400000
-  f32.const -1
-  call $~lib/math/NativeMathf.mod
-  f32.const nan:0x400000
+  f32.const 0
+  f32.const inf
+  call $~lib/util/math/mod32
+  f32.const 0
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -37889,9 +37164,9 @@
    unreachable
   end
   f32.const 0
+  f32.const -inf
+  call $~lib/util/math/mod32
   f32.const 0
-  call $~lib/math/NativeMathf.mod
-  f32.const nan:0x400000
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -37904,8 +37179,8 @@
    unreachable
   end
   f32.const 0
-  f32.const -0
-  call $~lib/math/NativeMathf.mod
+  f32.const nan:0x400000
+  call $~lib/util/math/mod32
   f32.const nan:0x400000
   f32.const 0
   call $std/math/check<f32>
@@ -37918,10 +37193,10 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f32.const -0
   f32.const 0
-  f32.const inf
-  call $~lib/math/NativeMathf.mod
-  f32.const 0
+  call $~lib/util/math/mod32
+  f32.const nan:0x400000
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -37933,10 +37208,10 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 0
-  f32.const -inf
-  call $~lib/math/NativeMathf.mod
-  f32.const 0
+  f32.const -0
+  f32.const -0
+  call $~lib/util/math/mod32
+  f32.const nan:0x400000
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -37948,10 +37223,10 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 0
-  f32.const nan:0x400000
-  call $~lib/math/NativeMathf.mod
-  f32.const nan:0x400000
+  f32.const -0
+  f32.const inf
+  call $~lib/util/math/mod32
+  f32.const -0
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -37964,9 +37239,9 @@
    unreachable
   end
   f32.const -0
-  f32.const 0
-  call $~lib/math/NativeMathf.mod
-  f32.const nan:0x400000
+  f32.const -inf
+  call $~lib/util/math/mod32
+  f32.const -0
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -37979,8 +37254,8 @@
    unreachable
   end
   f32.const -0
-  f32.const -0
-  call $~lib/math/NativeMathf.mod
+  f32.const nan:0x400000
+  call $~lib/util/math/mod32
   f32.const nan:0x400000
   f32.const 0
   call $std/math/check<f32>
@@ -37993,10 +37268,10 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -0
-  f32.const inf
-  call $~lib/math/NativeMathf.mod
-  f32.const -0
+  f32.const 1
+  f32.const 0
+  call $~lib/util/math/mod32
+  f32.const nan:0x400000
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -38008,10 +37283,10 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -0
-  f32.const -inf
-  call $~lib/math/NativeMathf.mod
-  f32.const -0
+  f32.const -1
+  f32.const 0
+  call $~lib/util/math/mod32
+  f32.const nan:0x400000
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -38023,9 +37298,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -0
-  f32.const nan:0x400000
-  call $~lib/math/NativeMathf.mod
+  f32.const inf
+  f32.const 0
+  call $~lib/util/math/mod32
   f32.const nan:0x400000
   f32.const 0
   call $std/math/check<f32>
@@ -38038,9 +37313,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 1
+  f32.const -inf
   f32.const 0
-  call $~lib/math/NativeMathf.mod
+  call $~lib/util/math/mod32
   f32.const nan:0x400000
   f32.const 0
   call $std/math/check<f32>
@@ -38053,9 +37328,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -1
+  f32.const nan:0x400000
   f32.const 0
-  call $~lib/math/NativeMathf.mod
+  call $~lib/util/math/mod32
   f32.const nan:0x400000
   f32.const 0
   call $std/math/check<f32>
@@ -38068,9 +37343,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const inf
-  f32.const 0
-  call $~lib/math/NativeMathf.mod
+  f32.const -1
+  f32.const -0
+  call $~lib/util/math/mod32
   f32.const nan:0x400000
   f32.const 0
   call $std/math/check<f32>
@@ -38083,9 +37358,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -inf
-  f32.const 0
-  call $~lib/math/NativeMathf.mod
+  f32.const inf
+  f32.const -0
+  call $~lib/util/math/mod32
   f32.const nan:0x400000
   f32.const 0
   call $std/math/check<f32>
@@ -38098,9 +37373,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const nan:0x400000
-  f32.const 0
-  call $~lib/math/NativeMathf.mod
+  f32.const -inf
+  f32.const -0
+  call $~lib/util/math/mod32
   f32.const nan:0x400000
   f32.const 0
   call $std/math/check<f32>
@@ -38113,9 +37388,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -1
+  f32.const nan:0x400000
   f32.const -0
-  call $~lib/math/NativeMathf.mod
+  call $~lib/util/math/mod32
   f32.const nan:0x400000
   f32.const 0
   call $std/math/check<f32>
@@ -38129,8 +37404,8 @@
    unreachable
   end
   f32.const inf
-  f32.const -0
-  call $~lib/math/NativeMathf.mod
+  f32.const 2
+  call $~lib/util/math/mod32
   f32.const nan:0x400000
   f32.const 0
   call $std/math/check<f32>
@@ -38143,9 +37418,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -inf
-  f32.const -0
-  call $~lib/math/NativeMathf.mod
+  f32.const inf
+  f32.const -0.5
+  call $~lib/util/math/mod32
   f32.const nan:0x400000
   f32.const 0
   call $std/math/check<f32>
@@ -38158,9 +37433,9 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f32.const inf
   f32.const nan:0x400000
-  f32.const -0
-  call $~lib/math/NativeMathf.mod
+  call $~lib/util/math/mod32
   f32.const nan:0x400000
   f32.const 0
   call $std/math/check<f32>
@@ -38173,9 +37448,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const inf
+  f32.const -inf
   f32.const 2
-  call $~lib/math/NativeMathf.mod
+  call $~lib/util/math/mod32
   f32.const nan:0x400000
   f32.const 0
   call $std/math/check<f32>
@@ -38188,9 +37463,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const inf
+  f32.const -inf
   f32.const -0.5
-  call $~lib/math/NativeMathf.mod
+  call $~lib/util/math/mod32
   f32.const nan:0x400000
   f32.const 0
   call $std/math/check<f32>
@@ -38203,9 +37478,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const inf
+  f32.const -inf
   f32.const nan:0x400000
-  call $~lib/math/NativeMathf.mod
+  call $~lib/util/math/mod32
   f32.const nan:0x400000
   f32.const 0
   call $std/math/check<f32>
@@ -38218,9 +37493,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -inf
-  f32.const 2
-  call $~lib/math/NativeMathf.mod
+  f32.const nan:0x400000
+  f32.const nan:0x400000
+  call $~lib/util/math/mod32
   f32.const nan:0x400000
   f32.const 0
   call $std/math/check<f32>
@@ -38233,9 +37508,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -inf
-  f32.const -0.5
-  call $~lib/math/NativeMathf.mod
+  f32.const 1
+  f32.const nan:0x400000
+  call $~lib/util/math/mod32
   f32.const nan:0x400000
   f32.const 0
   call $std/math/check<f32>
@@ -38248,9 +37523,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -inf
+  f32.const -1
   f32.const nan:0x400000
-  call $~lib/math/NativeMathf.mod
+  call $~lib/util/math/mod32
   f32.const nan:0x400000
   f32.const 0
   call $std/math/check<f32>
@@ -38263,10 +37538,10 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const nan:0x400000
-  f32.const nan:0x400000
-  call $~lib/math/NativeMathf.mod
-  f32.const nan:0x400000
+  f32.const 1
+  f32.const inf
+  call $~lib/util/math/mod32
+  f32.const 1
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -38278,10 +37553,10 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 1
-  f32.const nan:0x400000
-  call $~lib/math/NativeMathf.mod
-  f32.const nan:0x400000
+  f32.const -1
+  f32.const inf
+  call $~lib/util/math/mod32
+  f32.const -1
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -38293,9 +37568,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -1
-  f32.const nan:0x400000
-  call $~lib/math/NativeMathf.mod
+  f32.const inf
+  f32.const inf
+  call $~lib/util/math/mod32
   f32.const nan:0x400000
   f32.const 0
   call $std/math/check<f32>
@@ -38308,10 +37583,10 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 1
+  f32.const -inf
   f32.const inf
-  call $~lib/math/NativeMathf.mod
-  f32.const 1
+  call $~lib/util/math/mod32
+  f32.const nan:0x400000
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -38323,10 +37598,10 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -1
-  f32.const inf
-  call $~lib/math/NativeMathf.mod
-  f32.const -1
+  f32.const 1
+  f32.const -inf
+  call $~lib/util/math/mod32
+  f32.const 1
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -38338,10 +37613,10 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const inf
-  f32.const inf
-  call $~lib/math/NativeMathf.mod
-  f32.const nan:0x400000
+  f32.const -1
+  f32.const -inf
+  call $~lib/util/math/mod32
+  f32.const -1
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -38353,9 +37628,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -inf
   f32.const inf
-  call $~lib/math/NativeMathf.mod
+  f32.const -inf
+  call $~lib/util/math/mod32
   f32.const nan:0x400000
   f32.const 0
   call $std/math/check<f32>
@@ -38368,10 +37643,10 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 1
   f32.const -inf
-  call $~lib/math/NativeMathf.mod
-  f32.const 1
+  f32.const -inf
+  call $~lib/util/math/mod32
+  f32.const nan:0x400000
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -38383,10 +37658,10 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -1
-  f32.const -inf
-  call $~lib/math/NativeMathf.mod
-  f32.const -1
+  f32.const 1.75
+  f32.const 0.5
+  call $~lib/util/math/mod32
+  f32.const 0.25
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -38398,10 +37673,10 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const inf
-  f32.const -inf
-  call $~lib/math/NativeMathf.mod
-  f32.const nan:0x400000
+  f32.const -1.75
+  f32.const 0.5
+  call $~lib/util/math/mod32
+  f32.const -0.25
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -38413,10 +37688,10 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -inf
-  f32.const -inf
-  call $~lib/math/NativeMathf.mod
-  f32.const nan:0x400000
+  f32.const 1.75
+  f32.const -0.5
+  call $~lib/util/math/mod32
+  f32.const 0.25
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -38428,10 +37703,10 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 1.75
-  f32.const 0.5
-  call $~lib/math/NativeMathf.mod
-  f32.const 0.25
+  f32.const -1.75
+  f32.const -0.5
+  call $~lib/util/math/mod32
+  f32.const -0.25
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -38439,51 +37714,6 @@
    i32.const 0
    i32.const 1056
    i32.const 2568
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const -1.75
-  f32.const 0.5
-  call $~lib/math/NativeMathf.mod
-  f32.const -0.25
-  f32.const 0
-  call $std/math/check<f32>
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 2569
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const 1.75
-  f32.const -0.5
-  call $~lib/math/NativeMathf.mod
-  f32.const 0.25
-  f32.const 0
-  call $std/math/check<f32>
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 2570
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const -1.75
-  f32.const -0.5
-  call $~lib/math/NativeMathf.mod
-  f32.const -0.25
-  f32.const 0
-  call $std/math/check<f32>
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 2571
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -38497,7 +37727,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 2583
+   i32.const 2580
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -38511,7 +37741,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 2584
+   i32.const 2581
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -38525,7 +37755,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 2585
+   i32.const 2582
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -38539,7 +37769,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 2586
+   i32.const 2583
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -38553,7 +37783,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 2587
+   i32.const 2584
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -38567,7 +37797,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 2588
+   i32.const 2585
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -38581,7 +37811,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 2589
+   i32.const 2586
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -38595,7 +37825,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 2590
+   i32.const 2587
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -38609,13 +37839,27 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 2591
+   i32.const 2588
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f64.const -0.5587586823609152
   f64.const 0.03223983060263804
+  f64.const nan:0x8000000000000
+  f64.const 0
+  call $std/math/test_pow
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 2589
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const 0
+  f64.const nan:0x8000000000000
   f64.const nan:0x8000000000000
   f64.const 0
   call $std/math/test_pow
@@ -38629,8 +37873,36 @@
    unreachable
   end
   f64.const 0
-  f64.const nan:0x8000000000000
-  f64.const nan:0x8000000000000
+  f64.const inf
+  f64.const 0
+  f64.const 0
+  call $std/math/test_pow
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 2593
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const 0
+  f64.const 3
+  f64.const 0
+  f64.const 0
+  call $std/math/test_pow
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 2594
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const 0
+  f64.const 2
+  f64.const 0
   f64.const 0
   call $std/math/test_pow
   i32.eqz
@@ -38643,7 +37915,7 @@
    unreachable
   end
   f64.const 0
-  f64.const inf
+  f64.const 1
   f64.const 0
   f64.const 0
   call $std/math/test_pow
@@ -38657,7 +37929,7 @@
    unreachable
   end
   f64.const 0
-  f64.const 3
+  f64.const 0.5
   f64.const 0
   f64.const 0
   call $std/math/test_pow
@@ -38671,8 +37943,8 @@
    unreachable
   end
   f64.const 0
-  f64.const 2
   f64.const 0
+  f64.const 1
   f64.const 0
   call $std/math/test_pow
   i32.eqz
@@ -38680,48 +37952,6 @@
    i32.const 0
    i32.const 1056
    i32.const 2598
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const 0
-  f64.const 1
-  f64.const 0
-  f64.const 0
-  call $std/math/test_pow
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 2599
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const 0
-  f64.const 0.5
-  f64.const 0
-  f64.const 0
-  call $std/math/test_pow
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 2600
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const 0
-  f64.const 0
-  f64.const 1
-  f64.const 0
-  call $std/math/test_pow
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 2601
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -38735,13 +37965,55 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 2602
+   i32.const 2599
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f64.const 0
   f64.const -0.5
+  f64.const inf
+  f64.const 0
+  call $std/math/test_pow
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 2600
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const 0
+  f64.const -1
+  f64.const inf
+  f64.const 0
+  call $std/math/test_pow
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 2601
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const 0
+  f64.const -2
+  f64.const inf
+  f64.const 0
+  call $std/math/test_pow
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 2602
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const 0
+  f64.const -3
   f64.const inf
   f64.const 0
   call $std/math/test_pow
@@ -38755,7 +38027,7 @@
    unreachable
   end
   f64.const 0
-  f64.const -1
+  f64.const -4
   f64.const inf
   f64.const 0
   call $std/math/test_pow
@@ -38769,7 +38041,7 @@
    unreachable
   end
   f64.const 0
-  f64.const -2
+  f64.const -inf
   f64.const inf
   f64.const 0
   call $std/math/test_pow
@@ -38782,9 +38054,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 0
-  f64.const -3
-  f64.const inf
+  f64.const -0
+  f64.const nan:0x8000000000000
+  f64.const nan:0x8000000000000
   f64.const 0
   call $std/math/test_pow
   i32.eqz
@@ -38796,9 +38068,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 0
-  f64.const -4
+  f64.const -0
   f64.const inf
+  f64.const 0
   f64.const 0
   call $std/math/test_pow
   i32.eqz
@@ -38806,48 +38078,6 @@
    i32.const 0
    i32.const 1056
    i32.const 2607
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const 0
-  f64.const -inf
-  f64.const inf
-  f64.const 0
-  call $std/math/test_pow
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 2608
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const -0
-  f64.const nan:0x8000000000000
-  f64.const nan:0x8000000000000
-  f64.const 0
-  call $std/math/test_pow
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 2609
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const -0
-  f64.const inf
-  f64.const 0
-  f64.const 0
-  call $std/math/test_pow
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 2610
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -38861,7 +38091,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 2611
+   i32.const 2608
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -38875,7 +38105,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 2612
+   i32.const 2609
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -38889,7 +38119,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 2613
+   i32.const 2610
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -38903,7 +38133,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 2614
+   i32.const 2611
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -38917,7 +38147,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 2615
+   i32.const 2612
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -38931,7 +38161,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 2616
+   i32.const 2613
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -38945,7 +38175,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 2617
+   i32.const 2614
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -38959,7 +38189,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 2618
+   i32.const 2615
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -38973,7 +38203,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 2619
+   i32.const 2616
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -38987,7 +38217,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 2620
+   i32.const 2617
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -39001,7 +38231,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 2621
+   i32.const 2618
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -39015,12 +38245,54 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 2622
+   i32.const 2619
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f64.const nan:0x8000000000000
+  f64.const 0
+  f64.const 1
+  f64.const 0
+  call $std/math/test_pow
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 2620
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const inf
+  f64.const 0
+  f64.const 1
+  f64.const 0
+  call $std/math/test_pow
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 2621
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const -inf
+  f64.const 0
+  f64.const 1
+  f64.const 0
+  call $std/math/test_pow
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 2622
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const 1
   f64.const 0
   f64.const 1
   f64.const 0
@@ -39034,7 +38306,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const inf
+  f64.const -1
   f64.const 0
   f64.const 1
   f64.const 0
@@ -39048,7 +38320,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -inf
+  f64.const -0.5
   f64.const 0
   f64.const 1
   f64.const 0
@@ -39062,8 +38334,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 1
-  f64.const 0
+  f64.const nan:0x8000000000000
+  f64.const -0
   f64.const 1
   f64.const 0
   call $std/math/test_pow
@@ -39076,8 +38348,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -1
-  f64.const 0
+  f64.const inf
+  f64.const -0
   f64.const 1
   f64.const 0
   call $std/math/test_pow
@@ -39090,8 +38362,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -0.5
-  f64.const 0
+  f64.const -inf
+  f64.const -0
   f64.const 1
   f64.const 0
   call $std/math/test_pow
@@ -39104,7 +38376,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const nan:0x8000000000000
+  f64.const 1
   f64.const -0
   f64.const 1
   f64.const 0
@@ -39118,7 +38390,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const inf
+  f64.const -1
   f64.const -0
   f64.const 1
   f64.const 0
@@ -39132,7 +38404,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -inf
+  f64.const -0.5
   f64.const -0
   f64.const 1
   f64.const 0
@@ -39146,9 +38418,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 1
-  f64.const -0
-  f64.const 1
+  f64.const -1
+  f64.const nan:0x8000000000000
+  f64.const nan:0x8000000000000
   f64.const 0
   call $std/math/test_pow
   i32.eqz
@@ -39156,48 +38428,6 @@
    i32.const 0
    i32.const 1056
    i32.const 2632
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const -1
-  f64.const -0
-  f64.const 1
-  f64.const 0
-  call $std/math/test_pow
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 2633
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const -0.5
-  f64.const -0
-  f64.const 1
-  f64.const 0
-  call $std/math/test_pow
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 2634
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const -1
-  f64.const nan:0x8000000000000
-  f64.const nan:0x8000000000000
-  f64.const 0
-  call $std/math/test_pow
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 2635
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -39211,7 +38441,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 2636
+   i32.const 2633
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -39225,7 +38455,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 2637
+   i32.const 2634
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -39239,7 +38469,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 2638
+   i32.const 2635
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -39253,7 +38483,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 2639
+   i32.const 2636
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -39267,7 +38497,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 2640
+   i32.const 2637
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -39281,13 +38511,55 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 2641
+   i32.const 2638
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f64.const -1
   f64.const 0.5
+  f64.const nan:0x8000000000000
+  f64.const 0
+  call $std/math/test_pow
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 2639
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const 1
+  f64.const nan:0x8000000000000
+  f64.const nan:0x8000000000000
+  f64.const 0
+  call $std/math/test_pow
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 2640
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const 1
+  f64.const inf
+  f64.const nan:0x8000000000000
+  f64.const 0
+  call $std/math/test_pow
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 2641
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const 1
+  f64.const -inf
   f64.const nan:0x8000000000000
   f64.const 0
   call $std/math/test_pow
@@ -39301,48 +38573,6 @@
    unreachable
   end
   f64.const 1
-  f64.const nan:0x8000000000000
-  f64.const nan:0x8000000000000
-  f64.const 0
-  call $std/math/test_pow
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 2643
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const 1
-  f64.const inf
-  f64.const nan:0x8000000000000
-  f64.const 0
-  call $std/math/test_pow
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 2644
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const 1
-  f64.const -inf
-  f64.const nan:0x8000000000000
-  f64.const 0
-  call $std/math/test_pow
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 2645
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const 1
   f64.const 3
   f64.const 1
   f64.const 0
@@ -39351,7 +38581,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 2646
+   i32.const 2643
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -39365,7 +38595,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 2647
+   i32.const 2644
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -39379,7 +38609,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 2648
+   i32.const 2645
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -39393,7 +38623,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 2649
+   i32.const 2646
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -39407,7 +38637,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 2650
+   i32.const 2647
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -39421,7 +38651,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 2651
+   i32.const 2648
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -39435,7 +38665,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 2652
+   i32.const 2649
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -39449,12 +38679,54 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 2653
+   i32.const 2650
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f64.const -0.5
+  f64.const inf
+  f64.const 0
+  f64.const 0
+  call $std/math/test_pow
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 2651
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const -0.5
+  f64.const -inf
+  f64.const inf
+  f64.const 0
+  call $std/math/test_pow
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 2652
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const -0.5
+  f64.const nan:0x8000000000000
+  f64.const nan:0x8000000000000
+  f64.const 0
+  call $std/math/test_pow
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 2653
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const 0.5
   f64.const inf
   f64.const 0
   f64.const 0
@@ -39468,7 +38740,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -0.5
+  f64.const 0.5
   f64.const -inf
   f64.const inf
   f64.const 0
@@ -39482,7 +38754,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -0.5
+  f64.const 0.5
   f64.const nan:0x8000000000000
   f64.const nan:0x8000000000000
   f64.const 0
@@ -39496,9 +38768,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 0.5
+  f64.const 1.5
   f64.const inf
-  f64.const 0
+  f64.const inf
   f64.const 0
   call $std/math/test_pow
   i32.eqz
@@ -39510,9 +38782,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 0.5
+  f64.const 1.5
   f64.const -inf
-  f64.const inf
+  f64.const 0
   f64.const 0
   call $std/math/test_pow
   i32.eqz
@@ -39524,7 +38796,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 0.5
+  f64.const 1.5
   f64.const nan:0x8000000000000
   f64.const nan:0x8000000000000
   f64.const 0
@@ -39538,9 +38810,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 1.5
   f64.const inf
-  f64.const inf
+  f64.const nan:0x8000000000000
+  f64.const nan:0x8000000000000
   f64.const 0
   call $std/math/test_pow
   i32.eqz
@@ -39552,9 +38824,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 1.5
-  f64.const -inf
-  f64.const 0
+  f64.const inf
+  f64.const inf
+  f64.const inf
   f64.const 0
   call $std/math/test_pow
   i32.eqz
@@ -39566,9 +38838,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 1.5
-  f64.const nan:0x8000000000000
-  f64.const nan:0x8000000000000
+  f64.const inf
+  f64.const -inf
+  f64.const 0
   f64.const 0
   call $std/math/test_pow
   i32.eqz
@@ -39581,8 +38853,8 @@
    unreachable
   end
   f64.const inf
-  f64.const nan:0x8000000000000
-  f64.const nan:0x8000000000000
+  f64.const 3
+  f64.const inf
   f64.const 0
   call $std/math/test_pow
   i32.eqz
@@ -39595,7 +38867,7 @@
    unreachable
   end
   f64.const inf
-  f64.const inf
+  f64.const 2
   f64.const inf
   f64.const 0
   call $std/math/test_pow
@@ -39609,8 +38881,8 @@
    unreachable
   end
   f64.const inf
-  f64.const -inf
-  f64.const 0
+  f64.const 1
+  f64.const inf
   f64.const 0
   call $std/math/test_pow
   i32.eqz
@@ -39623,7 +38895,7 @@
    unreachable
   end
   f64.const inf
-  f64.const 3
+  f64.const 0.5
   f64.const inf
   f64.const 0
   call $std/math/test_pow
@@ -39637,48 +38909,6 @@
    unreachable
   end
   f64.const inf
-  f64.const 2
-  f64.const inf
-  f64.const 0
-  call $std/math/test_pow
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 2667
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const inf
-  f64.const 1
-  f64.const inf
-  f64.const 0
-  call $std/math/test_pow
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 2668
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const inf
-  f64.const 0.5
-  f64.const inf
-  f64.const 0
-  call $std/math/test_pow
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 2669
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const inf
   f64.const -0.5
   f64.const 0
   f64.const 0
@@ -39687,7 +38917,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 2670
+   i32.const 2667
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -39701,13 +38931,55 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 2671
+   i32.const 2668
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f64.const inf
   f64.const -2
+  f64.const 0
+  f64.const 0
+  call $std/math/test_pow
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 2669
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const -inf
+  f64.const nan:0x8000000000000
+  f64.const nan:0x8000000000000
+  f64.const 0
+  call $std/math/test_pow
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 2670
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const -inf
+  f64.const inf
+  f64.const inf
+  f64.const 0
+  call $std/math/test_pow
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 2671
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const -inf
+  f64.const -inf
   f64.const 0
   f64.const 0
   call $std/math/test_pow
@@ -39721,8 +38993,8 @@
    unreachable
   end
   f64.const -inf
-  f64.const nan:0x8000000000000
-  f64.const nan:0x8000000000000
+  f64.const 3
+  f64.const -inf
   f64.const 0
   call $std/math/test_pow
   i32.eqz
@@ -39735,7 +39007,7 @@
    unreachable
   end
   f64.const -inf
-  f64.const inf
+  f64.const 2
   f64.const inf
   f64.const 0
   call $std/math/test_pow
@@ -39749,8 +39021,8 @@
    unreachable
   end
   f64.const -inf
+  f64.const 1
   f64.const -inf
-  f64.const 0
   f64.const 0
   call $std/math/test_pow
   i32.eqz
@@ -39763,8 +39035,8 @@
    unreachable
   end
   f64.const -inf
-  f64.const 3
-  f64.const -inf
+  f64.const 0.5
+  f64.const inf
   f64.const 0
   call $std/math/test_pow
   i32.eqz
@@ -39777,8 +39049,8 @@
    unreachable
   end
   f64.const -inf
-  f64.const 2
-  f64.const inf
+  f64.const -0.5
+  f64.const 0
   f64.const 0
   call $std/math/test_pow
   i32.eqz
@@ -39791,8 +39063,8 @@
    unreachable
   end
   f64.const -inf
-  f64.const 1
-  f64.const -inf
+  f64.const -1
+  f64.const -0
   f64.const 0
   call $std/math/test_pow
   i32.eqz
@@ -39805,8 +39077,8 @@
    unreachable
   end
   f64.const -inf
-  f64.const 0.5
-  f64.const inf
+  f64.const -2
+  f64.const 0
   f64.const 0
   call $std/math/test_pow
   i32.eqz
@@ -39818,9 +39090,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -inf
-  f64.const -0.5
-  f64.const 0
+  f64.const nan:0x8000000000000
+  f64.const 1
+  f64.const nan:0x8000000000000
   f64.const 0
   call $std/math/test_pow
   i32.eqz
@@ -39832,9 +39104,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -inf
+  f64.const nan:0x8000000000000
   f64.const -1
-  f64.const -0
+  f64.const nan:0x8000000000000
   f64.const 0
   call $std/math/test_pow
   i32.eqz
@@ -39846,9 +39118,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -inf
   f64.const -2
-  f64.const 0
+  f64.const 1
+  f64.const -2
   f64.const 0
   call $std/math/test_pow
   i32.eqz
@@ -39856,48 +39128,6 @@
    i32.const 0
    i32.const 1056
    i32.const 2682
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const nan:0x8000000000000
-  f64.const 1
-  f64.const nan:0x8000000000000
-  f64.const 0
-  call $std/math/test_pow
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 2683
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const nan:0x8000000000000
-  f64.const -1
-  f64.const nan:0x8000000000000
-  f64.const 0
-  call $std/math/test_pow
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 2684
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const -2
-  f64.const 1
-  f64.const -2
-  f64.const 0
-  call $std/math/test_pow
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 2685
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -39911,14 +39141,53 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 2686
+   i32.const 2683
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f64.const 0
   f64.const 0
-  call $~lib/math/NativeMath.pow
+  call $~lib/util/math/pow64
+  f64.const 1
+  f64.ne
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 2686
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const -0
+  f64.const 0
+  call $~lib/util/math/pow64
+  f64.const 1
+  f64.ne
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 2687
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const -0
+  f64.const -0
+  call $~lib/util/math/pow64
+  f64.const 1
+  f64.ne
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 2688
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const 0
+  f64.const -0
+  call $~lib/util/math/pow64
   f64.const 1
   f64.ne
   if
@@ -39929,9 +39198,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -0
+  f64.const -1
   f64.const 0
-  call $~lib/math/NativeMath.pow
+  call $~lib/util/math/pow64
   f64.const 1
   f64.ne
   if
@@ -39942,9 +39211,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -0
-  f64.const -0
-  call $~lib/math/NativeMath.pow
+  f64.const inf
+  f64.const 0
+  call $~lib/util/math/pow64
   f64.const 1
   f64.ne
   if
@@ -39955,9 +39224,9 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f64.const -inf
   f64.const 0
-  f64.const -0
-  call $~lib/math/NativeMath.pow
+  call $~lib/util/math/pow64
   f64.const 1
   f64.ne
   if
@@ -39968,9 +39237,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -1
+  f64.const nan:0x8000000000000
   f64.const 0
-  call $~lib/math/NativeMath.pow
+  call $~lib/util/math/pow64
   f64.const 1
   f64.ne
   if
@@ -39981,23 +39250,10 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const inf
   f64.const 0
-  call $~lib/math/NativeMath.pow
   f64.const 1
-  f64.ne
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 2694
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const -inf
+  call $~lib/util/math/pow64
   f64.const 0
-  call $~lib/math/NativeMath.pow
-  f64.const 1
   f64.ne
   if
    i32.const 0
@@ -40007,10 +39263,10 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const nan:0x8000000000000
-  f64.const 0
-  call $~lib/math/NativeMath.pow
+  f64.const -0
   f64.const 1
+  call $~lib/util/math/pow64
+  f64.const -0
   f64.ne
   if
    i32.const 0
@@ -40020,10 +39276,23 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 0
+  f64.const -1
   f64.const 1
-  call $~lib/math/NativeMath.pow
-  f64.const 0
+  call $~lib/util/math/pow64
+  f64.const -1
+  f64.ne
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 2697
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const inf
+  f64.const 1
+  call $~lib/util/math/pow64
+  f64.const inf
   f64.ne
   if
    i32.const 0
@@ -40033,10 +39302,10 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -0
+  f64.const -inf
   f64.const 1
-  call $~lib/math/NativeMath.pow
-  f64.const -0
+  call $~lib/util/math/pow64
+  f64.const -inf
   f64.ne
   if
    i32.const 0
@@ -40046,11 +39315,12 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -1
+  f64.const nan:0x8000000000000
   f64.const 1
-  call $~lib/math/NativeMath.pow
-  f64.const -1
-  f64.ne
+  call $~lib/util/math/pow64
+  local.tee $1
+  local.get $1
+  f64.eq
   if
    i32.const 0
    i32.const 1056
@@ -40059,23 +39329,10 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f64.const 0
+  f64.const -1
+  call $~lib/util/math/pow64
   f64.const inf
-  f64.const 1
-  call $~lib/math/NativeMath.pow
-  f64.const inf
-  f64.ne
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 2701
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const -inf
-  f64.const 1
-  call $~lib/math/NativeMath.pow
-  f64.const -inf
   f64.ne
   if
    i32.const 0
@@ -40085,12 +39342,11 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const nan:0x8000000000000
-  f64.const 1
-  call $~lib/math/NativeMath.pow
-  local.tee $0
-  local.get $0
-  f64.eq
+  f64.const -0
+  f64.const -1
+  call $~lib/util/math/pow64
+  f64.const -inf
+  f64.ne
   if
    i32.const 0
    i32.const 1056
@@ -40099,10 +39355,23 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 0
   f64.const -1
-  call $~lib/math/NativeMath.pow
-  f64.const inf
+  f64.const -1
+  call $~lib/util/math/pow64
+  f64.const -1
+  f64.ne
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 2704
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const 0.5
+  f64.const -1
+  call $~lib/util/math/pow64
+  f64.const 2
   f64.ne
   if
    i32.const 0
@@ -40112,10 +39381,10 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -0
+  f64.const 1
   f64.const -1
-  call $~lib/math/NativeMath.pow
-  f64.const -inf
+  call $~lib/util/math/pow64
+  f64.const 1
   f64.ne
   if
    i32.const 0
@@ -40125,10 +39394,10 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f64.const inf
   f64.const -1
-  f64.const -1
-  call $~lib/math/NativeMath.pow
-  f64.const -1
+  call $~lib/util/math/pow64
+  f64.const 0
   f64.ne
   if
    i32.const 0
@@ -40138,10 +39407,10 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 0.5
+  f64.const -inf
   f64.const -1
-  call $~lib/math/NativeMath.pow
-  f64.const 2
+  call $~lib/util/math/pow64
+  f64.const -0
   f64.ne
   if
    i32.const 0
@@ -40151,11 +39420,12 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 1
+  f64.const nan:0x8000000000000
   f64.const -1
-  call $~lib/math/NativeMath.pow
-  f64.const 1
-  f64.ne
+  call $~lib/util/math/pow64
+  local.tee $1
+  local.get $1
+  f64.eq
   if
    i32.const 0
    i32.const 1056
@@ -40164,23 +39434,10 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const inf
-  f64.const -1
-  call $~lib/math/NativeMath.pow
   f64.const 0
-  f64.ne
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 2710
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const -inf
-  f64.const -1
-  call $~lib/math/NativeMath.pow
-  f64.const -0
+  f64.const 2
+  call $~lib/util/math/pow64
+  f64.const 0
   f64.ne
   if
    i32.const 0
@@ -40190,12 +39447,11 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const nan:0x8000000000000
-  f64.const -1
-  call $~lib/math/NativeMath.pow
-  local.tee $0
-  local.get $0
-  f64.eq
+  f64.const -0
+  f64.const 2
+  call $~lib/util/math/pow64
+  f64.const 0
+  f64.ne
   if
    i32.const 0
    i32.const 1056
@@ -40204,10 +39460,23 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 0
+  f64.const -1
   f64.const 2
-  call $~lib/math/NativeMath.pow
-  f64.const 0
+  call $~lib/util/math/pow64
+  f64.const 1
+  f64.ne
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 2713
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const 0.5
+  f64.const 2
+  call $~lib/util/math/pow64
+  f64.const 0.25
   f64.ne
   if
    i32.const 0
@@ -40217,10 +39486,10 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -0
+  f64.const 1
   f64.const 2
-  call $~lib/math/NativeMath.pow
-  f64.const 0
+  call $~lib/util/math/pow64
+  f64.const 1
   f64.ne
   if
    i32.const 0
@@ -40230,10 +39499,10 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -1
+  f64.const inf
   f64.const 2
-  call $~lib/math/NativeMath.pow
-  f64.const 1
+  call $~lib/util/math/pow64
+  f64.const inf
   f64.ne
   if
    i32.const 0
@@ -40243,10 +39512,10 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 0.5
+  f64.const -inf
   f64.const 2
-  call $~lib/math/NativeMath.pow
-  f64.const 0.25
+  call $~lib/util/math/pow64
+  f64.const inf
   f64.ne
   if
    i32.const 0
@@ -40256,11 +39525,12 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 1
+  f64.const nan:0x8000000000000
   f64.const 2
-  call $~lib/math/NativeMath.pow
-  f64.const 1
-  f64.ne
+  call $~lib/util/math/pow64
+  local.tee $1
+  local.get $1
+  f64.eq
   if
    i32.const 0
    i32.const 1056
@@ -40269,23 +39539,10 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const inf
-  f64.const 2
-  call $~lib/math/NativeMath.pow
-  f64.const inf
-  f64.ne
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 2719
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const -inf
-  f64.const 2
-  call $~lib/math/NativeMath.pow
-  f64.const inf
+  f64.const 0
+  f64.const 0.5
+  call $~lib/util/math/pow64
+  f64.const 0
   f64.ne
   if
    i32.const 0
@@ -40295,12 +39552,11 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const nan:0x8000000000000
-  f64.const 2
-  call $~lib/math/NativeMath.pow
-  local.tee $0
-  local.get $0
-  f64.eq
+  f64.const -0
+  f64.const 0.5
+  call $~lib/util/math/pow64
+  f64.const 0
+  f64.ne
   if
    i32.const 0
    i32.const 1056
@@ -40309,10 +39565,24 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 0
+  f64.const -1
   f64.const 0.5
-  call $~lib/math/NativeMath.pow
-  f64.const 0
+  call $~lib/util/math/pow64
+  local.tee $1
+  local.get $1
+  f64.eq
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 2722
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const 4
+  f64.const 0.5
+  call $~lib/util/math/pow64
+  f64.const 2
   f64.ne
   if
    i32.const 0
@@ -40322,10 +39592,10 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -0
+  f64.const 1
   f64.const 0.5
-  call $~lib/math/NativeMath.pow
-  f64.const 0
+  call $~lib/util/math/pow64
+  f64.const 1
   f64.ne
   if
    i32.const 0
@@ -40335,12 +39605,11 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -1
+  f64.const inf
   f64.const 0.5
-  call $~lib/math/NativeMath.pow
-  local.tee $0
-  local.get $0
-  f64.eq
+  call $~lib/util/math/pow64
+  f64.const inf
+  f64.ne
   if
    i32.const 0
    i32.const 1056
@@ -40349,10 +39618,10 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 4
+  f64.const -inf
   f64.const 0.5
-  call $~lib/math/NativeMath.pow
-  f64.const 2
+  call $~lib/util/math/pow64
+  f64.const inf
   f64.ne
   if
    i32.const 0
@@ -40362,11 +39631,12 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 1
+  f64.const nan:0x8000000000000
   f64.const 0.5
-  call $~lib/math/NativeMath.pow
-  f64.const 1
-  f64.ne
+  call $~lib/util/math/pow64
+  local.tee $1
+  local.get $1
+  f64.eq
   if
    i32.const 0
    i32.const 1056
@@ -40375,49 +39645,54 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const inf
-  f64.const 0.5
-  call $~lib/math/NativeMath.pow
-  f64.const inf
-  f64.ne
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 2728
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const -inf
-  f64.const 0.5
-  call $~lib/math/NativeMath.pow
-  f64.const inf
-  f64.ne
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 2729
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const nan:0x8000000000000
-  f64.const 0.5
-  call $~lib/math/NativeMath.pow
-  local.tee $0
-  local.get $0
-  f64.eq
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 2730
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
   f32.const -8.066848754882812
   f32.const 4.535662651062012
-  call $~lib/math/NativeMathf.pow
+  call $~lib/util/math/pow32
+  f32.const nan:0x400000
+  f32.const 0
+  call $std/math/check<f32>
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 2736
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const 4.345239639282227
+  f32.const -8.887990951538086
+  call $~lib/util/math/pow32
+  f32.const 2.134714122803416e-06
+  f32.const 0.1436440795660019
+  call $std/math/check<f32>
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 2737
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const -8.381433486938477
+  f32.const -2.7636072635650635
+  call $~lib/util/math/pow32
+  f32.const nan:0x400000
+  f32.const 0
+  call $std/math/check<f32>
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 2738
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const -6.531673431396484
+  f32.const 4.567535400390625
+  call $~lib/util/math/pow32
   f32.const nan:0x400000
   f32.const 0
   call $std/math/check<f32>
@@ -40430,11 +39705,11 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 4.345239639282227
-  f32.const -8.887990951538086
-  call $~lib/math/NativeMathf.pow
-  f32.const 2.134714122803416e-06
-  f32.const 0.1436440795660019
+  f32.const 9.267057418823242
+  f32.const 4.811392307281494
+  call $~lib/util/math/pow32
+  f32.const 44909.33203125
+  f32.const -0.05356409028172493
   call $std/math/check<f32>
   i32.eqz
   if
@@ -40445,9 +39720,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -8.381433486938477
-  f32.const -2.7636072635650635
-  call $~lib/math/NativeMathf.pow
+  f32.const -6.450045585632324
+  f32.const 0.6620717644691467
+  call $~lib/util/math/pow32
   f32.const nan:0x400000
   f32.const 0
   call $std/math/check<f32>
@@ -40460,11 +39735,11 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -6.531673431396484
-  f32.const 4.567535400390625
-  call $~lib/math/NativeMathf.pow
-  f32.const nan:0x400000
-  f32.const 0
+  f32.const 7.858890056610107
+  f32.const 0.052154526114463806
+  call $~lib/util/math/pow32
+  f32.const 1.1135177612304688
+  f32.const 0.19122089445590973
   call $std/math/check<f32>
   i32.eqz
   if
@@ -40475,11 +39750,11 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 9.267057418823242
-  f32.const 4.811392307281494
-  call $~lib/math/NativeMathf.pow
-  f32.const 44909.33203125
-  f32.const -0.05356409028172493
+  f32.const -0.7920545339584351
+  f32.const 7.676402568817139
+  call $~lib/util/math/pow32
+  f32.const nan:0x400000
+  f32.const 0
   call $std/math/check<f32>
   i32.eqz
   if
@@ -40490,11 +39765,11 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -6.450045585632324
-  f32.const 0.6620717644691467
-  call $~lib/math/NativeMathf.pow
-  f32.const nan:0x400000
-  f32.const 0
+  f32.const 0.6157026886940002
+  f32.const 2.0119025707244873
+  call $~lib/util/math/pow32
+  f32.const 0.3769077658653259
+  f32.const 0.337149053812027
   call $std/math/check<f32>
   i32.eqz
   if
@@ -40505,11 +39780,11 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 7.858890056610107
-  f32.const 0.052154526114463806
-  call $~lib/math/NativeMathf.pow
-  f32.const 1.1135177612304688
-  f32.const 0.19122089445590973
+  f32.const -0.5587586760520935
+  f32.const 0.03223983198404312
+  call $~lib/util/math/pow32
+  f32.const nan:0x400000
+  f32.const 0
   call $std/math/check<f32>
   i32.eqz
   if
@@ -40520,39 +39795,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -0.7920545339584351
-  f32.const 7.676402568817139
-  call $~lib/math/NativeMathf.pow
-  f32.const nan:0x400000
   f32.const 0
-  call $std/math/check<f32>
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 2746
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const 0.6157026886940002
-  f32.const 2.0119025707244873
-  call $~lib/math/NativeMathf.pow
-  f32.const 0.3769077658653259
-  f32.const 0.337149053812027
-  call $std/math/check<f32>
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 2747
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const -0.5587586760520935
-  f32.const 0.03223983198404312
-  call $~lib/math/NativeMathf.pow
+  f32.const nan:0x400000
+  call $~lib/util/math/pow32
   f32.const nan:0x400000
   f32.const 0
   call $std/math/check<f32>
@@ -40566,9 +39811,39 @@
    unreachable
   end
   f32.const 0
-  f32.const nan:0x400000
-  call $~lib/math/NativeMathf.pow
-  f32.const nan:0x400000
+  f32.const inf
+  call $~lib/util/math/pow32
+  f32.const 0
+  f32.const 0
+  call $std/math/check<f32>
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 2749
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const 0
+  f32.const 3
+  call $~lib/util/math/pow32
+  f32.const 0
+  f32.const 0
+  call $std/math/check<f32>
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 2750
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const 0
+  f32.const 2
+  call $~lib/util/math/pow32
+  f32.const 0
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -40581,8 +39856,8 @@
    unreachable
   end
   f32.const 0
-  f32.const inf
-  call $~lib/math/NativeMathf.pow
+  f32.const 1
+  call $~lib/util/math/pow32
   f32.const 0
   f32.const 0
   call $std/math/check<f32>
@@ -40596,8 +39871,8 @@
    unreachable
   end
   f32.const 0
-  f32.const 3
-  call $~lib/math/NativeMathf.pow
+  f32.const 0.5
+  call $~lib/util/math/pow32
   f32.const 0
   f32.const 0
   call $std/math/check<f32>
@@ -40611,9 +39886,9 @@
    unreachable
   end
   f32.const 0
-  f32.const 2
-  call $~lib/math/NativeMathf.pow
   f32.const 0
+  call $~lib/util/math/pow32
+  f32.const 1
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -40626,9 +39901,9 @@
    unreachable
   end
   f32.const 0
+  f32.const -0
+  call $~lib/util/math/pow32
   f32.const 1
-  call $~lib/math/NativeMathf.pow
-  f32.const 0
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -40641,9 +39916,9 @@
    unreachable
   end
   f32.const 0
-  f32.const 0.5
-  call $~lib/math/NativeMathf.pow
-  f32.const 0
+  f32.const -0.5
+  call $~lib/util/math/pow32
+  f32.const inf
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -40656,9 +39931,9 @@
    unreachable
   end
   f32.const 0
-  f32.const 0
-  call $~lib/math/NativeMathf.pow
-  f32.const 1
+  f32.const -1
+  call $~lib/util/math/pow32
+  f32.const inf
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -40671,9 +39946,9 @@
    unreachable
   end
   f32.const 0
-  f32.const -0
-  call $~lib/math/NativeMathf.pow
-  f32.const 1
+  f32.const -2
+  call $~lib/util/math/pow32
+  f32.const inf
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -40686,8 +39961,8 @@
    unreachable
   end
   f32.const 0
-  f32.const -0.5
-  call $~lib/math/NativeMathf.pow
+  f32.const -3
+  call $~lib/util/math/pow32
   f32.const inf
   f32.const 0
   call $std/math/check<f32>
@@ -40701,8 +39976,8 @@
    unreachable
   end
   f32.const 0
-  f32.const -1
-  call $~lib/math/NativeMathf.pow
+  f32.const -4
+  call $~lib/util/math/pow32
   f32.const inf
   f32.const 0
   call $std/math/check<f32>
@@ -40716,8 +39991,8 @@
    unreachable
   end
   f32.const 0
-  f32.const -2
-  call $~lib/math/NativeMathf.pow
+  f32.const -inf
+  call $~lib/util/math/pow32
   f32.const inf
   f32.const 0
   call $std/math/check<f32>
@@ -40730,10 +40005,10 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 0
-  f32.const -3
-  call $~lib/math/NativeMathf.pow
-  f32.const inf
+  f32.const -0
+  f32.const nan:0x400000
+  call $~lib/util/math/pow32
+  f32.const nan:0x400000
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -40745,10 +40020,10 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 0
-  f32.const -4
-  call $~lib/math/NativeMathf.pow
+  f32.const -0
   f32.const inf
+  call $~lib/util/math/pow32
+  f32.const 0
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -40760,10 +40035,10 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 0
-  f32.const -inf
-  call $~lib/math/NativeMathf.pow
-  f32.const inf
+  f32.const -0
+  f32.const 3
+  call $~lib/util/math/pow32
+  f32.const -0
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -40776,9 +40051,9 @@
    unreachable
   end
   f32.const -0
-  f32.const nan:0x400000
-  call $~lib/math/NativeMathf.pow
-  f32.const nan:0x400000
+  f32.const 2
+  call $~lib/util/math/pow32
+  f32.const 0
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -40791,9 +40066,9 @@
    unreachable
   end
   f32.const -0
-  f32.const inf
-  call $~lib/math/NativeMathf.pow
-  f32.const 0
+  f32.const 1
+  call $~lib/util/math/pow32
+  f32.const -0
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -40806,9 +40081,9 @@
    unreachable
   end
   f32.const -0
-  f32.const 3
-  call $~lib/math/NativeMathf.pow
-  f32.const -0
+  f32.const 0.5
+  call $~lib/util/math/pow32
+  f32.const 0
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -40821,9 +40096,9 @@
    unreachable
   end
   f32.const -0
-  f32.const 2
-  call $~lib/math/NativeMathf.pow
   f32.const 0
+  call $~lib/util/math/pow32
+  f32.const 1
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -40836,9 +40111,9 @@
    unreachable
   end
   f32.const -0
-  f32.const 1
-  call $~lib/math/NativeMathf.pow
   f32.const -0
+  call $~lib/util/math/pow32
+  f32.const 1
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -40851,9 +40126,9 @@
    unreachable
   end
   f32.const -0
-  f32.const 0.5
-  call $~lib/math/NativeMathf.pow
-  f32.const 0
+  f32.const -0.5
+  call $~lib/util/math/pow32
+  f32.const inf
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -40866,9 +40141,9 @@
    unreachable
   end
   f32.const -0
-  f32.const 0
-  call $~lib/math/NativeMathf.pow
-  f32.const 1
+  f32.const -1
+  call $~lib/util/math/pow32
+  f32.const -inf
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -40881,9 +40156,9 @@
    unreachable
   end
   f32.const -0
-  f32.const -0
-  call $~lib/math/NativeMathf.pow
-  f32.const 1
+  f32.const -2
+  call $~lib/util/math/pow32
+  f32.const inf
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -40896,9 +40171,9 @@
    unreachable
   end
   f32.const -0
-  f32.const -0.5
-  call $~lib/math/NativeMathf.pow
-  f32.const inf
+  f32.const -3
+  call $~lib/util/math/pow32
+  f32.const -inf
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -40911,9 +40186,9 @@
    unreachable
   end
   f32.const -0
-  f32.const -1
-  call $~lib/math/NativeMathf.pow
-  f32.const -inf
+  f32.const -4
+  call $~lib/util/math/pow32
+  f32.const inf
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -40926,8 +40201,8 @@
    unreachable
   end
   f32.const -0
-  f32.const -2
-  call $~lib/math/NativeMathf.pow
+  f32.const -inf
+  call $~lib/util/math/pow32
   f32.const inf
   f32.const 0
   call $std/math/check<f32>
@@ -40940,10 +40215,10 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -0
-  f32.const -3
-  call $~lib/math/NativeMathf.pow
-  f32.const -inf
+  f32.const nan:0x400000
+  f32.const 0
+  call $~lib/util/math/pow32
+  f32.const 1
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -40955,10 +40230,10 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -0
-  f32.const -4
-  call $~lib/math/NativeMathf.pow
   f32.const inf
+  f32.const 0
+  call $~lib/util/math/pow32
+  f32.const 1
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -40970,10 +40245,10 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -0
   f32.const -inf
-  call $~lib/math/NativeMathf.pow
-  f32.const inf
+  f32.const 0
+  call $~lib/util/math/pow32
+  f32.const 1
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -40985,9 +40260,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const nan:0x400000
+  f32.const 1
   f32.const 0
-  call $~lib/math/NativeMathf.pow
+  call $~lib/util/math/pow32
   f32.const 1
   f32.const 0
   call $std/math/check<f32>
@@ -41000,9 +40275,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const inf
+  f32.const -1
   f32.const 0
-  call $~lib/math/NativeMathf.pow
+  call $~lib/util/math/pow32
   f32.const 1
   f32.const 0
   call $std/math/check<f32>
@@ -41015,9 +40290,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -inf
+  f32.const -0.5
   f32.const 0
-  call $~lib/math/NativeMathf.pow
+  call $~lib/util/math/pow32
   f32.const 1
   f32.const 0
   call $std/math/check<f32>
@@ -41030,9 +40305,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 1
-  f32.const 0
-  call $~lib/math/NativeMathf.pow
+  f32.const nan:0x400000
+  f32.const -0
+  call $~lib/util/math/pow32
   f32.const 1
   f32.const 0
   call $std/math/check<f32>
@@ -41045,9 +40320,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -1
-  f32.const 0
-  call $~lib/math/NativeMathf.pow
+  f32.const inf
+  f32.const -0
+  call $~lib/util/math/pow32
   f32.const 1
   f32.const 0
   call $std/math/check<f32>
@@ -41060,9 +40335,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -0.5
-  f32.const 0
-  call $~lib/math/NativeMathf.pow
+  f32.const -inf
+  f32.const -0
+  call $~lib/util/math/pow32
   f32.const 1
   f32.const 0
   call $std/math/check<f32>
@@ -41075,9 +40350,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const nan:0x400000
+  f32.const 1
   f32.const -0
-  call $~lib/math/NativeMathf.pow
+  call $~lib/util/math/pow32
   f32.const 1
   f32.const 0
   call $std/math/check<f32>
@@ -41090,9 +40365,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const inf
+  f32.const -1
   f32.const -0
-  call $~lib/math/NativeMathf.pow
+  call $~lib/util/math/pow32
   f32.const 1
   f32.const 0
   call $std/math/check<f32>
@@ -41105,9 +40380,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -inf
+  f32.const -0.5
   f32.const -0
-  call $~lib/math/NativeMathf.pow
+  call $~lib/util/math/pow32
   f32.const 1
   f32.const 0
   call $std/math/check<f32>
@@ -41120,10 +40395,10 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 1
-  f32.const -0
-  call $~lib/math/NativeMathf.pow
-  f32.const 1
+  f32.const -1
+  f32.const nan:0x400000
+  call $~lib/util/math/pow32
+  f32.const nan:0x400000
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -41136,9 +40411,9 @@
    unreachable
   end
   f32.const -1
-  f32.const -0
-  call $~lib/math/NativeMathf.pow
-  f32.const 1
+  f32.const inf
+  call $~lib/util/math/pow32
+  f32.const nan:0x400000
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -41150,10 +40425,10 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -0.5
-  f32.const -0
-  call $~lib/math/NativeMathf.pow
-  f32.const 1
+  f32.const -1
+  f32.const -inf
+  call $~lib/util/math/pow32
+  f32.const nan:0x400000
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -41166,9 +40441,9 @@
    unreachable
   end
   f32.const -1
-  f32.const nan:0x400000
-  call $~lib/math/NativeMathf.pow
-  f32.const nan:0x400000
+  f32.const 2
+  call $~lib/util/math/pow32
+  f32.const 1
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -41181,9 +40456,9 @@
    unreachable
   end
   f32.const -1
-  f32.const inf
-  call $~lib/math/NativeMathf.pow
-  f32.const nan:0x400000
+  f32.const -1
+  call $~lib/util/math/pow32
+  f32.const -1
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -41196,9 +40471,9 @@
    unreachable
   end
   f32.const -1
-  f32.const -inf
-  call $~lib/math/NativeMathf.pow
-  f32.const nan:0x400000
+  f32.const -2
+  call $~lib/util/math/pow32
+  f32.const 1
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -41211,9 +40486,9 @@
    unreachable
   end
   f32.const -1
-  f32.const 2
-  call $~lib/math/NativeMathf.pow
-  f32.const 1
+  f32.const -3
+  call $~lib/util/math/pow32
+  f32.const -1
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -41226,9 +40501,9 @@
    unreachable
   end
   f32.const -1
-  f32.const -1
-  call $~lib/math/NativeMathf.pow
-  f32.const -1
+  f32.const 0.5
+  call $~lib/util/math/pow32
+  f32.const nan:0x400000
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -41240,10 +40515,10 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -1
-  f32.const -2
-  call $~lib/math/NativeMathf.pow
   f32.const 1
+  f32.const nan:0x400000
+  call $~lib/util/math/pow32
+  f32.const nan:0x400000
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -41255,10 +40530,10 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -1
-  f32.const -3
-  call $~lib/math/NativeMathf.pow
-  f32.const -1
+  f32.const 1
+  f32.const inf
+  call $~lib/util/math/pow32
+  f32.const nan:0x400000
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -41270,9 +40545,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -1
-  f32.const 0.5
-  call $~lib/math/NativeMathf.pow
+  f32.const 1
+  f32.const -inf
+  call $~lib/util/math/pow32
   f32.const nan:0x400000
   f32.const 0
   call $std/math/check<f32>
@@ -41286,9 +40561,9 @@
    unreachable
   end
   f32.const 1
-  f32.const nan:0x400000
-  call $~lib/math/NativeMathf.pow
-  f32.const nan:0x400000
+  f32.const 3
+  call $~lib/util/math/pow32
+  f32.const 1
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -41301,9 +40576,9 @@
    unreachable
   end
   f32.const 1
-  f32.const inf
-  call $~lib/math/NativeMathf.pow
-  f32.const nan:0x400000
+  f32.const 0.5
+  call $~lib/util/math/pow32
+  f32.const 1
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -41316,9 +40591,9 @@
    unreachable
   end
   f32.const 1
-  f32.const -inf
-  call $~lib/math/NativeMathf.pow
-  f32.const nan:0x400000
+  f32.const -0.5
+  call $~lib/util/math/pow32
+  f32.const 1
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -41331,8 +40606,8 @@
    unreachable
   end
   f32.const 1
-  f32.const 3
-  call $~lib/math/NativeMathf.pow
+  f32.const -3
+  call $~lib/util/math/pow32
   f32.const 1
   f32.const 0
   call $std/math/check<f32>
@@ -41345,10 +40620,10 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 1
+  f32.const -0.5
   f32.const 0.5
-  call $~lib/math/NativeMathf.pow
-  f32.const 1
+  call $~lib/util/math/pow32
+  f32.const nan:0x400000
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -41360,10 +40635,10 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 1
   f32.const -0.5
-  call $~lib/math/NativeMathf.pow
-  f32.const 1
+  f32.const 1.5
+  call $~lib/util/math/pow32
+  f32.const nan:0x400000
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -41375,10 +40650,10 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 1
-  f32.const -3
-  call $~lib/math/NativeMathf.pow
-  f32.const 1
+  f32.const -0.5
+  f32.const 2
+  call $~lib/util/math/pow32
+  f32.const 0.25
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -41391,9 +40666,9 @@
    unreachable
   end
   f32.const -0.5
-  f32.const 0.5
-  call $~lib/math/NativeMathf.pow
-  f32.const nan:0x400000
+  f32.const 3
+  call $~lib/util/math/pow32
+  f32.const -0.125
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -41406,9 +40681,9 @@
    unreachable
   end
   f32.const -0.5
-  f32.const 1.5
-  call $~lib/math/NativeMathf.pow
-  f32.const nan:0x400000
+  f32.const inf
+  call $~lib/util/math/pow32
+  f32.const 0
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -41421,9 +40696,9 @@
    unreachable
   end
   f32.const -0.5
-  f32.const 2
-  call $~lib/math/NativeMathf.pow
-  f32.const 0.25
+  f32.const -inf
+  call $~lib/util/math/pow32
+  f32.const inf
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -41436,9 +40711,9 @@
    unreachable
   end
   f32.const -0.5
-  f32.const 3
-  call $~lib/math/NativeMathf.pow
-  f32.const -0.125
+  f32.const nan:0x400000
+  call $~lib/util/math/pow32
+  f32.const nan:0x400000
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -41450,9 +40725,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -0.5
+  f32.const 0.5
   f32.const inf
-  call $~lib/math/NativeMathf.pow
+  call $~lib/util/math/pow32
   f32.const 0
   f32.const 0
   call $std/math/check<f32>
@@ -41465,9 +40740,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -0.5
+  f32.const 0.5
   f32.const -inf
-  call $~lib/math/NativeMathf.pow
+  call $~lib/util/math/pow32
   f32.const inf
   f32.const 0
   call $std/math/check<f32>
@@ -41480,9 +40755,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -0.5
+  f32.const 0.5
   f32.const nan:0x400000
-  call $~lib/math/NativeMathf.pow
+  call $~lib/util/math/pow32
   f32.const nan:0x400000
   f32.const 0
   call $std/math/check<f32>
@@ -41495,10 +40770,10 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 0.5
+  f32.const 1.5
   f32.const inf
-  call $~lib/math/NativeMathf.pow
-  f32.const 0
+  call $~lib/util/math/pow32
+  f32.const inf
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -41510,10 +40785,10 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 0.5
+  f32.const 1.5
   f32.const -inf
-  call $~lib/math/NativeMathf.pow
-  f32.const inf
+  call $~lib/util/math/pow32
+  f32.const 0
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -41525,9 +40800,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 0.5
+  f32.const 1.5
   f32.const nan:0x400000
-  call $~lib/math/NativeMathf.pow
+  call $~lib/util/math/pow32
   f32.const nan:0x400000
   f32.const 0
   call $std/math/check<f32>
@@ -41540,10 +40815,10 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 1.5
   f32.const inf
-  call $~lib/math/NativeMathf.pow
-  f32.const inf
+  f32.const nan:0x400000
+  call $~lib/util/math/pow32
+  f32.const nan:0x400000
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -41555,10 +40830,10 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 1.5
-  f32.const -inf
-  call $~lib/math/NativeMathf.pow
-  f32.const 0
+  f32.const inf
+  f32.const inf
+  call $~lib/util/math/pow32
+  f32.const inf
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -41570,10 +40845,10 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 1.5
-  f32.const nan:0x400000
-  call $~lib/math/NativeMathf.pow
-  f32.const nan:0x400000
+  f32.const inf
+  f32.const -inf
+  call $~lib/util/math/pow32
+  f32.const 0
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -41586,9 +40861,9 @@
    unreachable
   end
   f32.const inf
-  f32.const nan:0x400000
-  call $~lib/math/NativeMathf.pow
-  f32.const nan:0x400000
+  f32.const 3
+  call $~lib/util/math/pow32
+  f32.const inf
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -41601,8 +40876,8 @@
    unreachable
   end
   f32.const inf
-  f32.const inf
-  call $~lib/math/NativeMathf.pow
+  f32.const 2
+  call $~lib/util/math/pow32
   f32.const inf
   f32.const 0
   call $std/math/check<f32>
@@ -41616,9 +40891,9 @@
    unreachable
   end
   f32.const inf
-  f32.const -inf
-  call $~lib/math/NativeMathf.pow
-  f32.const 0
+  f32.const 1
+  call $~lib/util/math/pow32
+  f32.const inf
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -41631,8 +40906,8 @@
    unreachable
   end
   f32.const inf
-  f32.const 3
-  call $~lib/math/NativeMathf.pow
+  f32.const 0.5
+  call $~lib/util/math/pow32
   f32.const inf
   f32.const 0
   call $std/math/check<f32>
@@ -41646,9 +40921,9 @@
    unreachable
   end
   f32.const inf
-  f32.const 2
-  call $~lib/math/NativeMathf.pow
-  f32.const inf
+  f32.const -0.5
+  call $~lib/util/math/pow32
+  f32.const 0
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -41661,9 +40936,9 @@
    unreachable
   end
   f32.const inf
-  f32.const 1
-  call $~lib/math/NativeMathf.pow
-  f32.const inf
+  f32.const -1
+  call $~lib/util/math/pow32
+  f32.const 0
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -41676,9 +40951,9 @@
    unreachable
   end
   f32.const inf
-  f32.const 0.5
-  call $~lib/math/NativeMathf.pow
-  f32.const inf
+  f32.const -2
+  call $~lib/util/math/pow32
+  f32.const 0
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -41690,10 +40965,10 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const inf
-  f32.const -0.5
-  call $~lib/math/NativeMathf.pow
-  f32.const 0
+  f32.const -inf
+  f32.const nan:0x400000
+  call $~lib/util/math/pow32
+  f32.const nan:0x400000
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -41705,10 +40980,10 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f32.const -inf
   f32.const inf
-  f32.const -1
-  call $~lib/math/NativeMathf.pow
-  f32.const 0
+  call $~lib/util/math/pow32
+  f32.const inf
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -41720,9 +40995,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const inf
-  f32.const -2
-  call $~lib/math/NativeMathf.pow
+  f32.const -inf
+  f32.const -inf
+  call $~lib/util/math/pow32
   f32.const 0
   f32.const 0
   call $std/math/check<f32>
@@ -41736,9 +41011,9 @@
    unreachable
   end
   f32.const -inf
-  f32.const nan:0x400000
-  call $~lib/math/NativeMathf.pow
-  f32.const nan:0x400000
+  f32.const 3
+  call $~lib/util/math/pow32
+  f32.const -inf
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -41751,8 +41026,8 @@
    unreachable
   end
   f32.const -inf
-  f32.const inf
-  call $~lib/math/NativeMathf.pow
+  f32.const 2
+  call $~lib/util/math/pow32
   f32.const inf
   f32.const 0
   call $std/math/check<f32>
@@ -41766,9 +41041,9 @@
    unreachable
   end
   f32.const -inf
+  f32.const 1
+  call $~lib/util/math/pow32
   f32.const -inf
-  call $~lib/math/NativeMathf.pow
-  f32.const 0
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -41781,9 +41056,9 @@
    unreachable
   end
   f32.const -inf
-  f32.const 3
-  call $~lib/math/NativeMathf.pow
-  f32.const -inf
+  f32.const 0.5
+  call $~lib/util/math/pow32
+  f32.const inf
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -41796,9 +41071,9 @@
    unreachable
   end
   f32.const -inf
-  f32.const 2
-  call $~lib/math/NativeMathf.pow
-  f32.const inf
+  f32.const -0.5
+  call $~lib/util/math/pow32
+  f32.const 0
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -41811,9 +41086,9 @@
    unreachable
   end
   f32.const -inf
-  f32.const 1
-  call $~lib/math/NativeMathf.pow
-  f32.const -inf
+  f32.const -1
+  call $~lib/util/math/pow32
+  f32.const -0
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -41826,9 +41101,9 @@
    unreachable
   end
   f32.const -inf
-  f32.const 0.5
-  call $~lib/math/NativeMathf.pow
-  f32.const inf
+  f32.const -2
+  call $~lib/util/math/pow32
+  f32.const 0
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -41840,10 +41115,10 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -inf
-  f32.const -0.5
-  call $~lib/math/NativeMathf.pow
-  f32.const 0
+  f32.const nan:0x400000
+  f32.const 1
+  call $~lib/util/math/pow32
+  f32.const nan:0x400000
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -41855,10 +41130,10 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -inf
+  f32.const nan:0x400000
   f32.const -1
-  call $~lib/math/NativeMathf.pow
-  f32.const -0
+  call $~lib/util/math/pow32
+  f32.const nan:0x400000
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -41870,10 +41145,10 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -inf
   f32.const -2
-  call $~lib/math/NativeMathf.pow
-  f32.const 0
+  f32.const 1
+  call $~lib/util/math/pow32
+  f32.const -2
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -41885,10 +41160,10 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const nan:0x400000
-  f32.const 1
-  call $~lib/math/NativeMathf.pow
-  f32.const nan:0x400000
+  f32.const -2
+  f32.const -1
+  call $~lib/util/math/pow32
+  f32.const -0.5
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -41900,40 +41175,10 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const nan:0x400000
-  f32.const -1
-  call $~lib/math/NativeMathf.pow
-  f32.const nan:0x400000
   f32.const 0
-  call $std/math/check<f32>
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 2840
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const -2
   f32.const 1
-  call $~lib/math/NativeMathf.pow
-  f32.const -2
+  call $~lib/util/math/pow32
   f32.const 0
-  call $std/math/check<f32>
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 2841
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const -2
-  f32.const -1
-  call $~lib/math/NativeMathf.pow
-  f32.const -0.5
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -41945,10 +41190,40 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 0
+  f32.const -0
   f32.const 1
-  call $~lib/math/NativeMathf.pow
+  call $~lib/util/math/pow32
+  f32.const -0
   f32.const 0
+  call $std/math/check<f32>
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 2843
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const 1.1754943508222875e-38
+  f32.const 1
+  call $~lib/util/math/pow32
+  f32.const 1.1754943508222875e-38
+  f32.const 0
+  call $std/math/check<f32>
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 2844
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const -1.1754943508222875e-38
+  f32.const 1
+  call $~lib/util/math/pow32
+  f32.const -1.1754943508222875e-38
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -41960,10 +41235,10 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -0
+  f32.const 3402823466385288598117041e14
   f32.const 1
-  call $~lib/math/NativeMathf.pow
-  f32.const -0
+  call $~lib/util/math/pow32
+  f32.const 3402823466385288598117041e14
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -41975,10 +41250,10 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 1.1754943508222875e-38
+  f32.const -3402823466385288598117041e14
   f32.const 1
-  call $~lib/math/NativeMathf.pow
-  f32.const 1.1754943508222875e-38
+  call $~lib/util/math/pow32
+  f32.const -3402823466385288598117041e14
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -41990,25 +41265,10 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -1.1754943508222875e-38
-  f32.const 1
-  call $~lib/math/NativeMathf.pow
-  f32.const -1.1754943508222875e-38
   f32.const 0
-  call $std/math/check<f32>
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 2848
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
   f32.const 3402823466385288598117041e14
-  f32.const 1
-  call $~lib/math/NativeMathf.pow
-  f32.const 3402823466385288598117041e14
+  call $~lib/util/math/pow32
+  f32.const 0
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -42020,10 +41280,10 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -3402823466385288598117041e14
-  f32.const 1
-  call $~lib/math/NativeMathf.pow
-  f32.const -3402823466385288598117041e14
+  f32.const 0
+  f32.const 1.1754943508222875e-38
+  call $~lib/util/math/pow32
+  f32.const 0
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -42035,10 +41295,25 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 0
+  f32.const -0
   f32.const 3402823466385288598117041e14
-  call $~lib/math/NativeMathf.pow
+  call $~lib/util/math/pow32
   f32.const 0
+  f32.const 0
+  call $std/math/check<f32>
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 2851
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const -0
+  f32.const 17
+  call $~lib/util/math/pow32
+  f32.const -0
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -42050,9 +41325,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 0
-  f32.const 1.1754943508222875e-38
-  call $~lib/math/NativeMathf.pow
+  f32.const -0
+  f32.const 2
+  call $~lib/util/math/pow32
   f32.const 0
   f32.const 0
   call $std/math/check<f32>
@@ -42066,8 +41341,8 @@
    unreachable
   end
   f32.const -0
-  f32.const 3402823466385288598117041e14
-  call $~lib/math/NativeMathf.pow
+  f32.const 1.1754943508222875e-38
+  call $~lib/util/math/pow32
   f32.const 0
   f32.const 0
   call $std/math/check<f32>
@@ -42080,26 +41355,11 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -0
-  f32.const 17
-  call $~lib/math/NativeMathf.pow
-  f32.const -0
-  f32.const 0
-  call $std/math/check<f32>
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 2855
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const -0
-  f32.const 2
-  call $~lib/math/NativeMathf.pow
-  f32.const 0
-  f32.const 0
+  f32.const -1.100000023841858
+  f32.const 101
+  call $~lib/util/math/pow32
+  f32.const -15158.70703125
+  f32.const -0.2798735499382019
   call $std/math/check<f32>
   i32.eqz
   if
@@ -42110,26 +41370,26 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -0
-  f32.const 1.1754943508222875e-38
-  call $~lib/math/NativeMathf.pow
-  f32.const 0
+  f32.const 19
+  f32.const 5
+  call $~lib/util/math/pow32
+  f32.const 2476099
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
   if
    i32.const 0
    i32.const 1056
-   i32.const 2857
+   i32.const 2858
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -1.100000023841858
-  f32.const 101
-  call $~lib/math/NativeMathf.pow
-  f32.const -15158.70703125
-  f32.const -0.2798735499382019
+  f32.const -19
+  f32.const 5
+  call $~lib/util/math/pow32
+  f32.const -2476099
+  f32.const 0
   call $std/math/check<f32>
   i32.eqz
   if
@@ -42140,10 +41400,25 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 19
-  f32.const 5
-  call $~lib/math/NativeMathf.pow
-  f32.const 2476099
+  f32.const -193
+  f32.const 3
+  call $~lib/util/math/pow32
+  f32.const -7189057
+  f32.const 0
+  call $std/math/check<f32>
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 2860
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const -1201
+  f32.const 2
+  call $~lib/util/math/pow32
+  f32.const 1442401
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -42155,26 +41430,11 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -19
-  f32.const 5
-  call $~lib/math/NativeMathf.pow
-  f32.const -2476099
-  f32.const 0
-  call $std/math/check<f32>
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 2862
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const -193
-  f32.const 3
-  call $~lib/math/NativeMathf.pow
-  f32.const -7189057
-  f32.const 0
+  f32.const 7.312918663024902
+  f32.const 17.122268676757812
+  call $~lib/util/math/pow32
+  f32.const 624013315407872
+  f32.const -0.14995409548282623
   call $std/math/check<f32>
   i32.eqz
   if
@@ -42185,11 +41445,11 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -1201
-  f32.const 2
-  call $~lib/math/NativeMathf.pow
-  f32.const 1442401
-  f32.const 0
+  f32.const 18.804489135742188
+  f32.const 3.3214492797851562
+  call $~lib/util/math/pow32
+  f32.const 17076.3515625
+  f32.const 0.3042995035648346
   call $std/math/check<f32>
   i32.eqz
   if
@@ -42200,11 +41460,26 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 7.312918663024902
-  f32.const 17.122268676757812
-  call $~lib/math/NativeMathf.pow
-  f32.const 624013315407872
-  f32.const -0.14995409548282623
+  f32.const 7.290969371795654
+  f32.const 9.60707950592041
+  call $~lib/util/math/pow32
+  f32.const 194467360
+  f32.const -0.10728006064891815
+  call $std/math/check<f32>
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 2865
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const 15.783316612243652
+  f32.const 18.55087661743164
+  call $~lib/util/math/pow32
+  f32.const 16889945384019652771840
+  f32.const 0.09180249273777008
   call $std/math/check<f32>
   i32.eqz
   if
@@ -42215,11 +41490,11 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 18.804489135742188
-  f32.const 3.3214492797851562
-  call $~lib/math/NativeMathf.pow
-  f32.const 17076.3515625
-  f32.const 0.3042995035648346
+  f32.const 8.319306373596191
+  f32.const 0.4197559952735901
+  call $~lib/util/math/pow32
+  f32.const 2.43339204788208
+  f32.const 0.009661106392741203
   call $std/math/check<f32>
   i32.eqz
   if
@@ -42230,11 +41505,11 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 7.290969371795654
-  f32.const 9.60707950592041
-  call $~lib/math/NativeMathf.pow
-  f32.const 194467360
-  f32.const -0.10728006064891815
+  f32.const 5.831245422363281
+  f32.const 10.462174415588379
+  call $~lib/util/math/pow32
+  f32.const 102690080
+  f32.const -1.4237762661650777e-03
   call $std/math/check<f32>
   i32.eqz
   if
@@ -42245,11 +41520,11 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 15.783316612243652
-  f32.const 18.55087661743164
-  call $~lib/math/NativeMathf.pow
-  f32.const 16889945384019652771840
-  f32.const 0.09180249273777008
+  f32.const 2.415773391723633
+  f32.const 17.12181282043457
+  call $~lib/util/math/pow32
+  f32.const 3619232.25
+  f32.const 0.2961936891078949
   call $std/math/check<f32>
   i32.eqz
   if
@@ -42260,11 +41535,11 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 8.319306373596191
-  f32.const 0.4197559952735901
-  call $~lib/math/NativeMathf.pow
-  f32.const 2.43339204788208
-  f32.const 0.009661106392741203
+  f32.const 0.03832307085394859
+  f32.const 0.011254354380071163
+  call $~lib/util/math/pow32
+  f32.const 0.9639571905136108
+  f32.const -0.4840981066226959
   call $std/math/check<f32>
   i32.eqz
   if
@@ -42275,11 +41550,11 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 5.831245422363281
-  f32.const 10.462174415588379
-  call $~lib/math/NativeMathf.pow
-  f32.const 102690080
-  f32.const -1.4237762661650777e-03
+  f32.const 5.4462971687316895
+  f32.const 15.814705848693848
+  call $~lib/util/math/pow32
+  f32.const 437749907456
+  f32.const -0.40305933356285095
   call $std/math/check<f32>
   i32.eqz
   if
@@ -42290,11 +41565,11 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 2.415773391723633
-  f32.const 17.12181282043457
-  call $~lib/math/NativeMathf.pow
-  f32.const 3619232.25
-  f32.const 0.2961936891078949
+  f32.const 12.87027645111084
+  f32.const 14.93734359741211
+  call $~lib/util/math/pow32
+  f32.const 37522809982812160
+  f32.const 0.10445278882980347
   call $std/math/check<f32>
   i32.eqz
   if
@@ -42305,26 +41580,11 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 0.03832307085394859
-  f32.const 0.011254354380071163
-  call $~lib/math/NativeMathf.pow
-  f32.const 0.9639571905136108
-  f32.const -0.4840981066226959
-  call $std/math/check<f32>
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 2873
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const 5.4462971687316895
-  f32.const 15.814705848693848
-  call $~lib/math/NativeMathf.pow
-  f32.const 437749907456
-  f32.const -0.40305933356285095
+  f32.const nan:0x400000
+  f32.const 0
+  call $~lib/util/math/pow32
+  f32.const 1
+  f32.const 0
   call $std/math/check<f32>
   i32.eqz
   if
@@ -42335,11 +41595,11 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 12.87027645111084
-  f32.const 14.93734359741211
-  call $~lib/math/NativeMathf.pow
-  f32.const 37522809982812160
-  f32.const 0.10445278882980347
+  f32.const nan:0x400000
+  f32.const 0
+  call $~lib/util/math/pow32
+  f32.const 1
+  f32.const 0
   call $std/math/check<f32>
   i32.eqz
   if
@@ -42350,9 +41610,24 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const nan:0x400000
+  f32.const inf
   f32.const 0
-  call $~lib/math/NativeMathf.pow
+  call $~lib/util/math/pow32
+  f32.const 1
+  f32.const 0
+  call $std/math/check<f32>
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 2876
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const -inf
+  f32.const 0
+  call $~lib/util/math/pow32
   f32.const 1
   f32.const 0
   call $std/math/check<f32>
@@ -42365,9 +41640,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const nan:0x400000
+  f32.const 1.401298464324817e-45
   f32.const 0
-  call $~lib/math/NativeMathf.pow
+  call $~lib/util/math/pow32
   f32.const 1
   f32.const 0
   call $std/math/check<f32>
@@ -42380,9 +41655,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const inf
+  f32.const -1.401298464324817e-45
   f32.const 0
-  call $~lib/math/NativeMathf.pow
+  call $~lib/util/math/pow32
   f32.const 1
   f32.const 0
   call $std/math/check<f32>
@@ -42395,25 +41670,10 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -inf
-  f32.const 0
-  call $~lib/math/NativeMathf.pow
+  f32.const nan:0x400000
   f32.const 1
-  f32.const 0
-  call $std/math/check<f32>
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 2880
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const 1.401298464324817e-45
-  f32.const 0
-  call $~lib/math/NativeMathf.pow
-  f32.const 1
+  call $~lib/util/math/pow32
+  f32.const nan:0x400000
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -42425,10 +41685,10 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -1.401298464324817e-45
-  f32.const 0
-  call $~lib/math/NativeMathf.pow
+  f32.const nan:0x400000
   f32.const 1
+  call $~lib/util/math/pow32
+  f32.const nan:0x400000
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -42440,10 +41700,25 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const nan:0x400000
+  f32.const inf
   f32.const 1
-  call $~lib/math/NativeMathf.pow
-  f32.const nan:0x400000
+  call $~lib/util/math/pow32
+  f32.const inf
+  f32.const 0
+  call $std/math/check<f32>
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 2883
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const -inf
+  f32.const 1
+  call $~lib/util/math/pow32
+  f32.const -inf
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -42456,24 +41731,9 @@
    unreachable
   end
   f32.const nan:0x400000
-  f32.const 1
-  call $~lib/math/NativeMathf.pow
   f32.const nan:0x400000
-  f32.const 0
-  call $std/math/check<f32>
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 2885
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const inf
-  f32.const 1
-  call $~lib/math/NativeMathf.pow
-  f32.const inf
+  call $~lib/util/math/pow32
+  f32.const nan:0x400000
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -42485,10 +41745,10 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -inf
-  f32.const 1
-  call $~lib/math/NativeMathf.pow
-  f32.const -inf
+  f32.const inf
+  f32.const nan:0x400000
+  call $~lib/util/math/pow32
+  f32.const nan:0x400000
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -42500,9 +41760,24 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f32.const -inf
   f32.const nan:0x400000
+  call $~lib/util/math/pow32
   f32.const nan:0x400000
-  call $~lib/math/NativeMathf.pow
+  f32.const 0
+  call $std/math/check<f32>
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 2888
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const 1
+  f32.const nan:0x400000
+  call $~lib/util/math/pow32
   f32.const nan:0x400000
   f32.const 0
   call $std/math/check<f32>
@@ -42515,9 +41790,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const inf
+  f32.const -1
   f32.const nan:0x400000
-  call $~lib/math/NativeMathf.pow
+  call $~lib/util/math/pow32
   f32.const nan:0x400000
   f32.const 0
   call $std/math/check<f32>
@@ -42530,9 +41805,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -inf
+  f32.const -0
   f32.const nan:0x400000
-  call $~lib/math/NativeMathf.pow
+  call $~lib/util/math/pow32
   f32.const nan:0x400000
   f32.const 0
   call $std/math/check<f32>
@@ -42545,9 +41820,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 1
+  f32.const 0
   f32.const nan:0x400000
-  call $~lib/math/NativeMathf.pow
+  call $~lib/util/math/pow32
   f32.const nan:0x400000
   f32.const 0
   call $std/math/check<f32>
@@ -42560,25 +41835,10 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -1
-  f32.const nan:0x400000
-  call $~lib/math/NativeMathf.pow
-  f32.const nan:0x400000
-  f32.const 0
-  call $std/math/check<f32>
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 2893
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const -0
-  f32.const nan:0x400000
-  call $~lib/math/NativeMathf.pow
-  f32.const nan:0x400000
+  f32.const 1.0000001192092896
+  f32.const inf
+  call $~lib/util/math/pow32
+  f32.const inf
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -42590,10 +41850,10 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 0
-  f32.const nan:0x400000
-  call $~lib/math/NativeMathf.pow
-  f32.const nan:0x400000
+  f32.const inf
+  f32.const inf
+  call $~lib/util/math/pow32
+  f32.const inf
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -42605,9 +41865,24 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 1.0000001192092896
+  f32.const -1.0000001192092896
   f32.const inf
-  call $~lib/math/NativeMathf.pow
+  call $~lib/util/math/pow32
+  f32.const inf
+  f32.const 0
+  call $std/math/check<f32>
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 2896
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const -inf
+  f32.const inf
+  call $~lib/util/math/pow32
   f32.const inf
   f32.const 0
   call $std/math/check<f32>
@@ -42620,25 +41895,10 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const inf
-  f32.const inf
-  call $~lib/math/NativeMathf.pow
-  f32.const inf
+  f32.const 1.0000001192092896
+  f32.const -inf
+  call $~lib/util/math/pow32
   f32.const 0
-  call $std/math/check<f32>
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 2898
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const -1.0000001192092896
-  f32.const inf
-  call $~lib/math/NativeMathf.pow
-  f32.const inf
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -42650,10 +41910,10 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f32.const inf
   f32.const -inf
-  f32.const inf
-  call $~lib/math/NativeMathf.pow
-  f32.const inf
+  call $~lib/util/math/pow32
+  f32.const 0
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -42665,9 +41925,24 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 1.0000001192092896
+  f32.const -1.0000001192092896
   f32.const -inf
-  call $~lib/math/NativeMathf.pow
+  call $~lib/util/math/pow32
+  f32.const 0
+  f32.const 0
+  call $std/math/check<f32>
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 2901
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const -inf
+  f32.const -inf
+  call $~lib/util/math/pow32
   f32.const 0
   f32.const 0
   call $std/math/check<f32>
@@ -42680,24 +41955,9 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f32.const 0.9999999403953552
   f32.const inf
-  f32.const -inf
-  call $~lib/math/NativeMathf.pow
-  f32.const 0
-  f32.const 0
-  call $std/math/check<f32>
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 2903
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const -1.0000001192092896
-  f32.const -inf
-  call $~lib/math/NativeMathf.pow
+  call $~lib/util/math/pow32
   f32.const 0
   f32.const 0
   call $std/math/check<f32>
@@ -42710,9 +41970,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -inf
-  f32.const -inf
-  call $~lib/math/NativeMathf.pow
+  f32.const 1.401298464324817e-45
+  f32.const inf
+  call $~lib/util/math/pow32
   f32.const 0
   f32.const 0
   call $std/math/check<f32>
@@ -42725,9 +41985,24 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 0.9999999403953552
+  f32.const 0
   f32.const inf
-  call $~lib/math/NativeMathf.pow
+  call $~lib/util/math/pow32
+  f32.const 0
+  f32.const 0
+  call $std/math/check<f32>
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 2906
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const -0.9999999403953552
+  f32.const inf
+  call $~lib/util/math/pow32
   f32.const 0
   f32.const 0
   call $std/math/check<f32>
@@ -42740,9 +42015,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 1.401298464324817e-45
+  f32.const -1.401298464324817e-45
   f32.const inf
-  call $~lib/math/NativeMathf.pow
+  call $~lib/util/math/pow32
   f32.const 0
   f32.const 0
   call $std/math/check<f32>
@@ -42755,9 +42030,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 0
+  f32.const -0
   f32.const inf
-  call $~lib/math/NativeMathf.pow
+  call $~lib/util/math/pow32
   f32.const 0
   f32.const 0
   call $std/math/check<f32>
@@ -42770,24 +42045,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -0.9999999403953552
-  f32.const inf
-  call $~lib/math/NativeMathf.pow
   f32.const 0
-  f32.const 0
-  call $std/math/check<f32>
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 2910
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const -1.401298464324817e-45
-  f32.const inf
-  call $~lib/math/NativeMathf.pow
+  f32.const 1.401298464324817e-45
+  call $~lib/util/math/pow32
   f32.const 0
   f32.const 0
   call $std/math/check<f32>
@@ -42801,8 +42061,8 @@
    unreachable
   end
   f32.const -0
-  f32.const inf
-  call $~lib/math/NativeMathf.pow
+  f32.const 1.401298464324817e-45
+  call $~lib/util/math/pow32
   f32.const 0
   f32.const 0
   call $std/math/check<f32>
@@ -42816,9 +42076,9 @@
    unreachable
   end
   f32.const 0
-  f32.const 1.401298464324817e-45
-  call $~lib/math/NativeMathf.pow
-  f32.const 0
+  f32.const -3402823466385288598117041e14
+  call $~lib/util/math/pow32
+  f32.const inf
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -42830,10 +42090,10 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -0
-  f32.const 1.401298464324817e-45
-  call $~lib/math/NativeMathf.pow
   f32.const 0
+  f32.const -1.401298464324817e-45
+  call $~lib/util/math/pow32
+  f32.const inf
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -42845,9 +42105,24 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 0
+  f32.const -0
   f32.const -3402823466385288598117041e14
-  call $~lib/math/NativeMathf.pow
+  call $~lib/util/math/pow32
+  f32.const inf
+  f32.const 0
+  call $std/math/check<f32>
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 2916
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const -0
+  f32.const -2
+  call $~lib/util/math/pow32
   f32.const inf
   f32.const 0
   call $std/math/check<f32>
@@ -42860,9 +42135,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 0
+  f32.const -0
   f32.const -1.401298464324817e-45
-  call $~lib/math/NativeMathf.pow
+  call $~lib/util/math/pow32
   f32.const inf
   f32.const 0
   call $std/math/check<f32>
@@ -42876,9 +42151,9 @@
    unreachable
   end
   f32.const -0
-  f32.const -3402823466385288598117041e14
-  call $~lib/math/NativeMathf.pow
-  f32.const inf
+  f32.const -1
+  call $~lib/util/math/pow32
+  f32.const -inf
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -42891,9 +42166,9 @@
    unreachable
   end
   f32.const -0
-  f32.const -2
-  call $~lib/math/NativeMathf.pow
-  f32.const inf
+  f32.const -17
+  call $~lib/util/math/pow32
+  f32.const -inf
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -42905,25 +42180,10 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -0
-  f32.const -1.401298464324817e-45
-  call $~lib/math/NativeMathf.pow
   f32.const inf
-  f32.const 0
-  call $std/math/check<f32>
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 2921
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const -0
-  f32.const -1
-  call $~lib/math/NativeMathf.pow
-  f32.const -inf
+  f32.const 1.401298464324817e-45
+  call $~lib/util/math/pow32
+  f32.const inf
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -42935,10 +42195,10 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -0
-  f32.const -17
-  call $~lib/math/NativeMathf.pow
-  f32.const -inf
+  f32.const inf
+  f32.const -1.401298464324817e-45
+  call $~lib/util/math/pow32
+  f32.const 0
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -42950,9 +42210,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const inf
-  f32.const 1.401298464324817e-45
-  call $~lib/math/NativeMathf.pow
+  f32.const -inf
+  f32.const 3402823466385288598117041e14
+  call $~lib/util/math/pow32
   f32.const inf
   f32.const 0
   call $std/math/check<f32>
@@ -42965,10 +42225,10 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f32.const -inf
+  f32.const 1.401298464324817e-45
+  call $~lib/util/math/pow32
   f32.const inf
-  f32.const -1.401298464324817e-45
-  call $~lib/math/NativeMathf.pow
-  f32.const 0
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -42981,9 +42241,24 @@
    unreachable
   end
   f32.const -inf
-  f32.const 3402823466385288598117041e14
-  call $~lib/math/NativeMathf.pow
-  f32.const inf
+  f32.const -3402823466385288598117041e14
+  call $~lib/util/math/pow32
+  f32.const 0
+  f32.const 0
+  call $std/math/check<f32>
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 2927
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const -inf
+  f32.const -1.401298464324817e-45
+  call $~lib/util/math/pow32
+  f32.const 0
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -42996,9 +42271,9 @@
    unreachable
   end
   f32.const -inf
-  f32.const 1.401298464324817e-45
-  call $~lib/math/NativeMathf.pow
-  f32.const inf
+  f32.const 5
+  call $~lib/util/math/pow32
+  f32.const -inf
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -43011,9 +42286,9 @@
    unreachable
   end
   f32.const -inf
-  f32.const -3402823466385288598117041e14
-  call $~lib/math/NativeMathf.pow
-  f32.const 0
+  f32.const -5
+  call $~lib/util/math/pow32
+  f32.const -0
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -43026,9 +42301,9 @@
    unreachable
   end
   f32.const -inf
-  f32.const -1.401298464324817e-45
-  call $~lib/math/NativeMathf.pow
-  f32.const 0
+  f32.const 6
+  call $~lib/util/math/pow32
+  f32.const inf
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -43041,9 +42316,9 @@
    unreachable
   end
   f32.const -inf
-  f32.const 5
-  call $~lib/math/NativeMathf.pow
-  f32.const -inf
+  f32.const -6
+  call $~lib/util/math/pow32
+  f32.const 0
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -43056,23 +42331,8 @@
    unreachable
   end
   f32.const -inf
-  f32.const -5
-  call $~lib/math/NativeMathf.pow
-  f32.const -0
-  f32.const 0
-  call $std/math/check<f32>
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 2933
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const -inf
-  f32.const 6
-  call $~lib/math/NativeMathf.pow
+  f32.const 2.000000238418579
+  call $~lib/util/math/pow32
   f32.const inf
   f32.const 0
   call $std/math/check<f32>
@@ -43085,10 +42345,10 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -inf
-  f32.const -6
-  call $~lib/math/NativeMathf.pow
-  f32.const 0
+  f32.const -1
+  f32.const 1.0000001192092896
+  call $~lib/util/math/pow32
+  f32.const nan:0x400000
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -43100,25 +42360,25 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -inf
-  f32.const 2.000000238418579
-  call $~lib/math/NativeMathf.pow
-  f32.const inf
+  f32.const -1.401298464324817e-45
+  f32.const -1.9999998807907104
+  call $~lib/util/math/pow32
+  f32.const nan:0x400000
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
   if
    i32.const 0
    i32.const 1056
-   i32.const 2937
+   i32.const 2936
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -1
-  f32.const 1.0000001192092896
-  call $~lib/math/NativeMathf.pow
-  f32.const nan:0x400000
+  f32.const -10
+  f32.const 309
+  call $~lib/util/math/pow32
+  f32.const -inf
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -43130,10 +42390,10 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -1.401298464324817e-45
-  f32.const -1.9999998807907104
-  call $~lib/math/NativeMathf.pow
-  f32.const nan:0x400000
+  f32.const -inf
+  f32.const 0.5
+  call $~lib/util/math/pow32
+  f32.const inf
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -43145,10 +42405,10 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -10
-  f32.const 309
-  call $~lib/math/NativeMathf.pow
-  f32.const -inf
+  f32.const 2.802596928649634e-45
+  f32.const 0.5
+  call $~lib/util/math/pow32
+  f32.const 5.293955920339377e-23
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -43160,10 +42420,10 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -inf
+  f32.const 1.1210387714598537e-44
   f32.const 0.5
-  call $~lib/math/NativeMathf.pow
-  f32.const inf
+  call $~lib/util/math/pow32
+  f32.const 1.0587911840678754e-22
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -43175,10 +42435,25 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 2.802596928649634e-45
+  f32.const 2.938735877055719e-39
   f32.const 0.5
-  call $~lib/math/NativeMathf.pow
-  f32.const 5.293955920339377e-23
+  call $~lib/util/math/pow32
+  f32.const 5.421010862427522e-20
+  f32.const 0
+  call $std/math/check<f32>
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 2943
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const 5.877471754111438e-39
+  f32.const -1
+  call $~lib/util/math/pow32
+  f32.const 1701411834604692317316873e14
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -43190,10 +42465,10 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 1.1210387714598537e-44
+  f32.const 1.1754943508222875e-38
   f32.const 0.5
-  call $~lib/math/NativeMathf.pow
-  f32.const 1.0587911840678754e-22
+  call $~lib/util/math/pow32
+  f32.const 1.0842021724855044e-19
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -43205,10 +42480,10 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 2.938735877055719e-39
-  f32.const 0.5
-  call $~lib/math/NativeMathf.pow
-  f32.const 5.421010862427522e-20
+  f32.const 1.1754943508222875e-38
+  f32.const -1
+  call $~lib/util/math/pow32
+  f32.const 8507059173023461586584365e13
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -43220,10 +42495,10 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 5.877471754111438e-39
+  f32.const 2.350988701644575e-38
   f32.const -1
-  call $~lib/math/NativeMathf.pow
-  f32.const 1701411834604692317316873e14
+  call $~lib/util/math/pow32
+  f32.const 4253529586511730793292182e13
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -43235,10 +42510,10 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 1.1754943508222875e-38
+  f32.const 4.70197740328915e-38
   f32.const 0.5
-  call $~lib/math/NativeMathf.pow
-  f32.const 1.0842021724855044e-19
+  call $~lib/util/math/pow32
+  f32.const 2.168404344971009e-19
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -43250,10 +42525,10 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 1.1754943508222875e-38
+  f32.const 4.70197740328915e-38
   f32.const -1
-  call $~lib/math/NativeMathf.pow
-  f32.const 8507059173023461586584365e13
+  call $~lib/util/math/pow32
+  f32.const 2126764793255865396646091e13
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -43265,10 +42540,10 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 2.350988701644575e-38
-  f32.const -1
-  call $~lib/math/NativeMathf.pow
-  f32.const 4253529586511730793292182e13
+  f32.const 5.293955920339377e-23
+  f32.const 2
+  call $~lib/util/math/pow32
+  f32.const 2.802596928649634e-45
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -43280,10 +42555,10 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 4.70197740328915e-38
-  f32.const 0.5
-  call $~lib/math/NativeMathf.pow
   f32.const 2.168404344971009e-19
+  f32.const 0.5
+  call $~lib/util/math/pow32
+  f32.const 4.656612873077393e-10
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -43295,10 +42570,10 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 4.70197740328915e-38
-  f32.const -1
-  call $~lib/math/NativeMathf.pow
-  f32.const 2126764793255865396646091e13
+  f32.const 2.3283064365386963e-10
+  f32.const 2
+  call $~lib/util/math/pow32
+  f32.const 5.421010862427522e-20
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -43310,10 +42585,10 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 5.293955920339377e-23
+  f32.const 4.656612873077393e-10
   f32.const 2
-  call $~lib/math/NativeMathf.pow
-  f32.const 2.802596928649634e-45
+  call $~lib/util/math/pow32
+  f32.const 2.168404344971009e-19
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -43325,10 +42600,10 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 2.168404344971009e-19
-  f32.const 0.5
-  call $~lib/math/NativeMathf.pow
-  f32.const 4.656612873077393e-10
+  f32.const 1.1920928955078125e-07
+  f32.const -1
+  call $~lib/util/math/pow32
+  f32.const 8388608
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -43340,10 +42615,10 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 2.3283064365386963e-10
-  f32.const 2
-  call $~lib/math/NativeMathf.pow
-  f32.const 5.421010862427522e-20
+  f32.const 0.000034332275390625
+  f32.const 0.5
+  call $~lib/util/math/pow32
+  f32.const 0.005859375
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -43355,10 +42630,10 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 4.656612873077393e-10
-  f32.const 2
-  call $~lib/math/NativeMathf.pow
-  f32.const 2.168404344971009e-19
+  f32.const 0.00006103515625
+  f32.const 0.5
+  call $~lib/util/math/pow32
+  f32.const 0.0078125
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -43370,10 +42645,10 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 1.1920928955078125e-07
-  f32.const -1
-  call $~lib/math/NativeMathf.pow
-  f32.const 8388608
+  f32.const 0.00390625
+  f32.const 0.5
+  call $~lib/util/math/pow32
+  f32.const 0.0625
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -43385,10 +42660,10 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 0.000034332275390625
+  f32.const 0.03515625
   f32.const 0.5
-  call $~lib/math/NativeMathf.pow
-  f32.const 0.005859375
+  call $~lib/util/math/pow32
+  f32.const 0.1875
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -43400,10 +42675,10 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 0.00006103515625
+  f32.const 0.0625
   f32.const 0.5
-  call $~lib/math/NativeMathf.pow
-  f32.const 0.0078125
+  call $~lib/util/math/pow32
+  f32.const 0.25
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -43415,9 +42690,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 0.00390625
-  f32.const 0.5
-  call $~lib/math/NativeMathf.pow
+  f32.const 0.25
+  f32.const 2
+  call $~lib/util/math/pow32
   f32.const 0.0625
   f32.const 0
   call $std/math/check<f32>
@@ -43430,25 +42705,10 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 0.03515625
+  f32.const 2126764793255865396646091e13
   f32.const 0.5
-  call $~lib/math/NativeMathf.pow
-  f32.const 0.1875
-  f32.const 0
-  call $std/math/check<f32>
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 2961
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const 0.0625
-  f32.const 0.5
-  call $~lib/math/NativeMathf.pow
-  f32.const 0.25
+  call $~lib/util/math/pow32
+  f32.const 4611686018427387904
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -43460,10 +42720,10 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 0.25
-  f32.const 2
-  call $~lib/math/NativeMathf.pow
-  f32.const 0.0625
+  f32.const 2126764793255865396646091e13
+  f32.const -1
+  call $~lib/util/math/pow32
+  f32.const 4.70197740328915e-38
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -43475,10 +42735,25 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 2126764793255865396646091e13
-  f32.const 0.5
-  call $~lib/math/NativeMathf.pow
-  f32.const 4611686018427387904
+  f32.const 4253529586511730793292182e13
+  f32.const inf
+  call $~lib/util/math/pow32
+  f32.const inf
+  f32.const 0
+  call $std/math/check<f32>
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 2964
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const 4253529586511730793292182e13
+  f32.const -1
+  call $~lib/util/math/pow32
+  f32.const 2.350988701644575e-38
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -43490,10 +42765,10 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 2126764793255865396646091e13
-  f32.const -1
-  call $~lib/math/NativeMathf.pow
-  f32.const 4.70197740328915e-38
+  f32.const 4253529586511730793292182e13
+  f32.const -inf
+  call $~lib/util/math/pow32
+  f32.const 0
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -43505,10 +42780,10 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 4253529586511730793292182e13
-  f32.const inf
-  call $~lib/math/NativeMathf.pow
-  f32.const inf
+  f32.const 8507059173023461586584365e13
+  f32.const 0.5
+  call $~lib/util/math/pow32
+  f32.const 9223372036854775808
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -43520,10 +42795,10 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 4253529586511730793292182e13
+  f32.const 8507059173023461586584365e13
   f32.const -1
-  call $~lib/math/NativeMathf.pow
-  f32.const 2.350988701644575e-38
+  call $~lib/util/math/pow32
+  f32.const 1.1754943508222875e-38
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -43535,25 +42810,10 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 4253529586511730793292182e13
-  f32.const -inf
-  call $~lib/math/NativeMathf.pow
-  f32.const 0
-  f32.const 0
-  call $std/math/check<f32>
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 2969
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const 8507059173023461586584365e13
-  f32.const 0.5
-  call $~lib/math/NativeMathf.pow
-  f32.const 9223372036854775808
+  f32.const 3402823466385288598117041e14
+  f32.const inf
+  call $~lib/util/math/pow32
+  f32.const inf
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -43565,10 +42825,10 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 8507059173023461586584365e13
-  f32.const -1
-  call $~lib/math/NativeMathf.pow
-  f32.const 1.1754943508222875e-38
+  f32.const 3402823466385288598117041e14
+  f32.const -inf
+  call $~lib/util/math/pow32
+  f32.const 0
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -43580,11 +42840,11 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 3402823466385288598117041e14
-  f32.const inf
-  call $~lib/math/NativeMathf.pow
-  f32.const inf
+  f32.const 1701411834604692317316873e14
+  f32.const -2
+  call $~lib/util/math/pow32
   f32.const 0
+  f32.const -2.465190328815662e-32
   call $std/math/check<f32>
   i32.eqz
   if
@@ -43595,11 +42855,11 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 3402823466385288598117041e14
-  f32.const -inf
-  call $~lib/math/NativeMathf.pow
+  f32.const 1701411834604692317316873e14
+  f32.const -3
+  call $~lib/util/math/pow32
   f32.const 0
-  f32.const 0
+  f32.const -0
   call $std/math/check<f32>
   i32.eqz
   if
@@ -43611,10 +42871,25 @@
    unreachable
   end
   f32.const 1701411834604692317316873e14
-  f32.const -2
-  call $~lib/math/NativeMathf.pow
+  f32.const -255
+  call $~lib/util/math/pow32
   f32.const 0
-  f32.const -2.465190328815662e-32
+  f32.const -0
+  call $std/math/check<f32>
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 2975
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const 1701411834604692317316873e14
+  f32.const -256
+  call $~lib/util/math/pow32
+  f32.const 0
+  f32.const -0
   call $std/math/check<f32>
   i32.eqz
   if
@@ -43626,8 +42901,8 @@
    unreachable
   end
   f32.const 1701411834604692317316873e14
-  f32.const -3
-  call $~lib/math/NativeMathf.pow
+  f32.const -257
+  call $~lib/util/math/pow32
   f32.const 0
   f32.const -0
   call $std/math/check<f32>
@@ -43641,8 +42916,8 @@
    unreachable
   end
   f32.const 1701411834604692317316873e14
-  f32.const -255
-  call $~lib/math/NativeMathf.pow
+  f32.const -260
+  call $~lib/util/math/pow32
   f32.const 0
   f32.const -0
   call $std/math/check<f32>
@@ -43656,8 +42931,8 @@
    unreachable
   end
   f32.const 1701411834604692317316873e14
-  f32.const -256
-  call $~lib/math/NativeMathf.pow
+  f32.const -261
+  call $~lib/util/math/pow32
   f32.const 0
   f32.const -0
   call $std/math/check<f32>
@@ -43671,8 +42946,8 @@
    unreachable
   end
   f32.const 1701411834604692317316873e14
-  f32.const -257
-  call $~lib/math/NativeMathf.pow
+  f32.const -32767
+  call $~lib/util/math/pow32
   f32.const 0
   f32.const -0
   call $std/math/check<f32>
@@ -43686,8 +42961,8 @@
    unreachable
   end
   f32.const 1701411834604692317316873e14
-  f32.const -260
-  call $~lib/math/NativeMathf.pow
+  f32.const -32768
+  call $~lib/util/math/pow32
   f32.const 0
   f32.const -0
   call $std/math/check<f32>
@@ -43700,11 +42975,11 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 1701411834604692317316873e14
-  f32.const -261
-  call $~lib/math/NativeMathf.pow
-  f32.const 0
-  f32.const -0
+  f32.const 3402822046616616342500112e14
+  f32.const -1
+  call $~lib/util/math/pow32
+  f32.const 2.938737278354183e-39
+  f32.const -4.768373855768004e-07
   call $std/math/check<f32>
   i32.eqz
   if
@@ -43715,11 +42990,11 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 1701411834604692317316873e14
-  f32.const -32767
-  call $~lib/math/NativeMathf.pow
+  f32.const 3402822046616616342500112e14
+  f32.const -2
+  call $~lib/util/math/pow32
   f32.const 0
-  f32.const -0
+  f32.const -6.162981699510909e-33
   call $std/math/check<f32>
   i32.eqz
   if
@@ -43730,26 +43005,11 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 1701411834604692317316873e14
-  f32.const -32768
-  call $~lib/math/NativeMathf.pow
-  f32.const 0
+  f32.const -1701411834604692317316873e14
+  f32.const -32767
+  call $~lib/util/math/pow32
   f32.const -0
-  call $std/math/check<f32>
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 2984
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const 3402822046616616342500112e14
-  f32.const -1
-  call $~lib/math/NativeMathf.pow
-  f32.const 2.938737278354183e-39
-  f32.const -4.768373855768004e-07
+  f32.const 0
   call $std/math/check<f32>
   i32.eqz
   if
@@ -43760,11 +43020,11 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 3402822046616616342500112e14
-  f32.const -2
-  call $~lib/math/NativeMathf.pow
+  f32.const -1701411834604692317316873e14
+  f32.const -32768
+  call $~lib/util/math/pow32
   f32.const 0
-  f32.const -6.162981699510909e-33
+  f32.const -0
   call $std/math/check<f32>
   i32.eqz
   if
@@ -43775,11 +43035,26 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -1701411834604692317316873e14
-  f32.const -32767
-  call $~lib/math/NativeMathf.pow
-  f32.const -0
+  f32.const -3402822046616616342500112e14
+  f32.const -1
+  call $~lib/util/math/pow32
+  f32.const -2.938737278354183e-39
+  f32.const 4.768373855768004e-07
+  call $std/math/check<f32>
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 2987
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const -3402822046616616342500112e14
+  f32.const -2
+  call $~lib/util/math/pow32
   f32.const 0
+  f32.const -6.162981699510909e-33
   call $std/math/check<f32>
   i32.eqz
   if
@@ -43790,56 +43065,61 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -1701411834604692317316873e14
-  f32.const -32768
-  call $~lib/math/NativeMathf.pow
-  f32.const 0
-  f32.const -0
-  call $std/math/check<f32>
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 2989
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const -3402822046616616342500112e14
-  f32.const -1
-  call $~lib/math/NativeMathf.pow
-  f32.const -2.938737278354183e-39
-  f32.const 4.768373855768004e-07
-  call $std/math/check<f32>
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 2990
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const -3402822046616616342500112e14
-  f32.const -2
-  call $~lib/math/NativeMathf.pow
-  f32.const 0
-  f32.const -6.162981699510909e-33
-  call $std/math/check<f32>
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 2991
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
   call $~lib/bindings/dom/Math.random
   i64.reinterpret_f64
-  call $~lib/math/NativeMath.seedRandom
+  local.tee $0
+  i64.eqz
+  if
+   i64.const -7046029254386353131
+   local.set $0
+  end
+  local.get $0
+  i64.const 33
+  i64.shr_u
+  local.get $0
+  i64.xor
+  i64.const -49064778989728563
+  i64.mul
+  local.tee $0
+  local.get $0
+  i64.const 33
+  i64.shr_u
+  i64.xor
+  i64.const -4265267296055464877
+  i64.mul
+  local.tee $0
+  local.get $0
+  i64.const 33
+  i64.shr_u
+  i64.xor
+  global.set $~lib/math/random_state0_64
+  global.get $~lib/math/random_state0_64
+  i64.const -1
+  i64.xor
+  local.tee $0
+  local.get $0
+  i64.const 33
+  i64.shr_u
+  i64.xor
+  i64.const -49064778989728563
+  i64.mul
+  local.tee $0
+  local.get $0
+  i64.const 33
+  i64.shr_u
+  i64.xor
+  i64.const -4265267296055464877
+  i64.mul
+  local.tee $0
+  local.get $0
+  i64.const 33
+  i64.shr_u
+  i64.xor
+  global.set $~lib/math/random_state1_64
+  i32.const 1
+  global.set $~lib/math/random_seeded
   loop $for-loop|0
-   local.get $1
+   local.get $2
    f64.convert_i32_s
    f64.const 1e6
    f64.lt
@@ -43849,31 +43129,81 @@
     if
      call $~lib/builtins/seed
      i64.reinterpret_f64
-     call $~lib/math/NativeMath.seedRandom
+     local.tee $0
+     i64.eqz
+     if
+      i64.const -7046029254386353131
+      local.set $0
+     end
+     local.get $0
+     i64.const 33
+     i64.shr_u
+     local.get $0
+     i64.xor
+     i64.const -49064778989728563
+     i64.mul
+     local.tee $0
+     local.get $0
+     i64.const 33
+     i64.shr_u
+     i64.xor
+     i64.const -4265267296055464877
+     i64.mul
+     local.tee $0
+     local.get $0
+     i64.const 33
+     i64.shr_u
+     i64.xor
+     global.set $~lib/math/random_state0_64
+     global.get $~lib/math/random_state0_64
+     i64.const -1
+     i64.xor
+     local.tee $0
+     local.get $0
+     i64.const 33
+     i64.shr_u
+     i64.xor
+     i64.const -49064778989728563
+     i64.mul
+     local.tee $0
+     local.get $0
+     i64.const 33
+     i64.shr_u
+     i64.xor
+     i64.const -4265267296055464877
+     i64.mul
+     local.tee $0
+     local.get $0
+     i64.const 33
+     i64.shr_u
+     i64.xor
+     global.set $~lib/math/random_state1_64
+     i32.const 1
+     global.set $~lib/math/random_seeded
     end
     global.get $~lib/math/random_state0_64
-    local.set $6
+    local.set $3
     global.get $~lib/math/random_state1_64
-    local.tee $2
+    local.tee $0
     global.set $~lib/math/random_state0_64
-    local.get $2
-    local.get $6
-    local.get $6
+    local.get $0
+    local.get $3
+    local.get $3
     i64.const 23
     i64.shl
     i64.xor
-    local.tee $6
+    local.tee $3
     i64.const 17
     i64.shr_u
-    local.get $6
+    local.get $3
     i64.xor
     i64.xor
-    local.get $2
+    local.get $0
     i64.const 26
     i64.shr_u
     i64.xor
     global.set $~lib/math/random_state1_64
-    local.get $2
+    local.get $0
     i64.const 12
     i64.shr_u
     i64.const 4607182418800017408
@@ -43881,10 +43211,10 @@
     f64.reinterpret_i64
     f64.const 1
     f64.sub
-    local.tee $0
+    local.tee $1
     f64.const 1
     f64.lt
-    local.get $0
+    local.get $1
     f64.const 0
     f64.ge
     i32.and
@@ -43892,89 +43222,16 @@
     if
      i32.const 0
      i32.const 1056
-     i32.const 3000
+     i32.const 2997
      i32.const 3
      call $~lib/builtins/abort
      unreachable
     end
-    local.get $1
+    local.get $2
     i32.const 1
     i32.add
-    local.set $1
+    local.set $2
     br $for-loop|0
-   end
-  end
-  call $~lib/bindings/dom/Math.random
-  i64.reinterpret_f64
-  call $~lib/math/NativeMath.seedRandom
-  i32.const 0
-  local.set $1
-  loop $for-loop|1
-   local.get $1
-   f64.convert_i32_s
-   f64.const 1e6
-   f64.lt
-   if
-    global.get $~lib/math/random_seeded
-    i32.eqz
-    if
-     call $~lib/builtins/seed
-     i64.reinterpret_f64
-     call $~lib/math/NativeMath.seedRandom
-    end
-    global.get $~lib/math/random_state0_32
-    local.tee $4
-    global.get $~lib/math/random_state1_32
-    i32.xor
-    local.tee $3
-    local.get $4
-    i32.const 26
-    i32.rotl
-    i32.xor
-    local.get $3
-    i32.const 9
-    i32.shl
-    i32.xor
-    global.set $~lib/math/random_state0_32
-    local.get $3
-    i32.const 13
-    i32.rotl
-    global.set $~lib/math/random_state1_32
-    local.get $4
-    i32.const -1640531525
-    i32.mul
-    i32.const 5
-    i32.rotl
-    i32.const 5
-    i32.mul
-    i32.const 9
-    i32.shr_u
-    i32.const 1065353216
-    i32.or
-    f32.reinterpret_i32
-    f32.const 1
-    f32.sub
-    local.tee $5
-    f32.const 1
-    f32.lt
-    local.get $5
-    f32.const 0
-    f32.ge
-    i32.and
-    i32.eqz
-    if
-     i32.const 0
-     i32.const 1056
-     i32.const 3008
-     i32.const 3
-     call $~lib/builtins/abort
-     unreachable
-    end
-    local.get $1
-    i32.const 1
-    i32.add
-    local.set $1
-    br $for-loop|1
    end
   end
   f64.const -8.06684839057968
@@ -43984,7 +43241,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3022
+   i32.const 3011
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -43996,7 +43253,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3023
+   i32.const 3012
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -44008,7 +43265,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3024
+   i32.const 3013
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -44020,7 +43277,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3025
+   i32.const 3014
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -44032,7 +43289,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3026
+   i32.const 3015
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -44044,7 +43301,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3027
+   i32.const 3016
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -44056,7 +43313,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3028
+   i32.const 3017
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -44068,7 +43325,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3029
+   i32.const 3018
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -44080,7 +43337,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3030
+   i32.const 3019
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -44092,7 +43349,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3031
+   i32.const 3020
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -44104,7 +43361,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3034
+   i32.const 3023
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -44116,7 +43373,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3035
+   i32.const 3024
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -44128,7 +43385,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3036
+   i32.const 3025
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -44140,7 +43397,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3037
+   i32.const 3026
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -44152,7 +43409,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3038
+   i32.const 3027
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -44164,7 +43421,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3039
+   i32.const 3028
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -44176,7 +43433,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3040
+   i32.const 3029
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -44188,7 +43445,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3041
+   i32.const 3030
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -44200,7 +43457,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3042
+   i32.const 3031
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -44212,7 +43469,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3043
+   i32.const 3032
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -44224,7 +43481,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3044
+   i32.const 3033
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -44236,7 +43493,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3045
+   i32.const 3034
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -44248,7 +43505,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3046
+   i32.const 3035
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -44260,7 +43517,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3047
+   i32.const 3036
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -44272,7 +43529,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3048
+   i32.const 3037
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -44284,7 +43541,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3049
+   i32.const 3038
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -44296,7 +43553,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3050
+   i32.const 3039
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -44308,7 +43565,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3065
+   i32.const 3054
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -44320,7 +43577,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3066
+   i32.const 3055
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -44332,7 +43589,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3067
+   i32.const 3056
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -44344,7 +43601,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3068
+   i32.const 3057
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -44356,7 +43613,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3069
+   i32.const 3058
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -44368,7 +43625,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3070
+   i32.const 3059
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -44380,7 +43637,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3071
+   i32.const 3060
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -44392,7 +43649,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3072
+   i32.const 3061
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -44404,7 +43661,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3073
+   i32.const 3062
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -44416,7 +43673,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3074
+   i32.const 3063
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -44428,7 +43685,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3077
+   i32.const 3066
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -44440,7 +43697,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3078
+   i32.const 3067
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -44452,7 +43709,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3079
+   i32.const 3068
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -44464,7 +43721,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3080
+   i32.const 3069
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -44476,7 +43733,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3081
+   i32.const 3070
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -44488,7 +43745,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3082
+   i32.const 3071
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -44500,7 +43757,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3083
+   i32.const 3072
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -44512,7 +43769,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3084
+   i32.const 3073
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -44524,7 +43781,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3085
+   i32.const 3074
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -44536,7 +43793,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3086
+   i32.const 3075
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -44548,7 +43805,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3087
+   i32.const 3076
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -44560,7 +43817,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3088
+   i32.const 3077
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -44572,7 +43829,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3089
+   i32.const 3078
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -44584,7 +43841,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3090
+   i32.const 3079
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -44596,7 +43853,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3091
+   i32.const 3080
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -44608,7 +43865,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3092
+   i32.const 3081
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -44620,23 +43877,23 @@
   if
    i32.const 0
    i32.const 1056
+   i32.const 3082
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const 0
+  f64.const 0
+  call $std/math/test_sign
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1056
    i32.const 3093
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 0
-  f64.const 0
-  call $std/math/test_sign
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 3104
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
   f64.const -0
   f64.const -0
   call $std/math/test_sign
@@ -44644,7 +43901,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3105
+   i32.const 3094
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -44656,7 +43913,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3106
+   i32.const 3095
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -44668,7 +43925,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3107
+   i32.const 3096
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -44680,7 +43937,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3108
+   i32.const 3097
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -44688,6 +43945,54 @@
   f64.const -2
   f64.const -1
   call $std/math/test_sign
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 3098
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const inf
+  f64.const 1
+  call $std/math/test_sign
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 3099
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const -inf
+  f64.const -1
+  call $std/math/test_sign
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 3100
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const nan:0x8000000000000
+  f64.const nan:0x8000000000000
+  call $std/math/test_sign
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 3101
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const 0
+  f32.const 0
+  call $std/math/test_signf
   i32.eqz
   if
    i32.const 0
@@ -44697,9 +44002,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const inf
-  f64.const 1
-  call $std/math/test_sign
+  f32.const -0
+  f32.const -0
+  call $std/math/test_signf
   i32.eqz
   if
    i32.const 0
@@ -44709,9 +44014,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -inf
-  f64.const -1
-  call $std/math/test_sign
+  f32.const 1
+  f32.const 1
+  call $std/math/test_signf
   i32.eqz
   if
    i32.const 0
@@ -44721,9 +44026,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const nan:0x8000000000000
-  f64.const nan:0x8000000000000
-  call $std/math/test_sign
+  f32.const 2
+  f32.const 1
+  call $std/math/test_signf
   i32.eqz
   if
    i32.const 0
@@ -44733,54 +44038,6 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 0
-  f32.const 0
-  call $std/math/test_signf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 3120
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const -0
-  f32.const -0
-  call $std/math/test_signf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 3121
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const 1
-  f32.const 1
-  call $std/math/test_signf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 3122
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const 2
-  f32.const 1
-  call $std/math/test_signf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 3123
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
   f32.const -1
   f32.const -1
   call $std/math/test_signf
@@ -44788,7 +44045,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3124
+   i32.const 3113
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -44800,7 +44057,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3125
+   i32.const 3114
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -44812,7 +44069,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3126
+   i32.const 3115
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -44824,7 +44081,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3127
+   i32.const 3116
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -44836,2323 +44093,13 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3128
+   i32.const 3117
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f64.const -8.06684839057968
-  f64.const 4.535662560676869
-  call $~lib/math/NativeMath.rem
-  f64.const 1.0044767307740567
-  f64.const 0
-  call $std/math/check<f64>
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 3165
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const 4.345239849338305
-  f64.const -8.88799136300345
-  call $~lib/math/NativeMath.rem
-  f64.const 4.345239849338305
-  f64.const 0
-  call $std/math/check<f64>
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 3166
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const -8.38143342755525
-  f64.const -2.763607337379588
-  call $~lib/math/NativeMath.rem
-  f64.const -0.09061141541648476
-  f64.const 0
-  call $std/math/check<f64>
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 3167
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const -6.531673581913484
-  f64.const 4.567535276842744
-  call $~lib/math/NativeMath.rem
-  f64.const -1.9641383050707404
-  f64.const 0
-  call $std/math/check<f64>
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 3168
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const 9.267056966972586
-  f64.const 4.811392084359796
-  call $~lib/math/NativeMath.rem
-  f64.const -0.35572720174700656
-  f64.const 0
-  call $std/math/check<f64>
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 3169
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const -6.450045556060236
-  f64.const 0.6620717923376739
-  call $~lib/math/NativeMath.rem
-  f64.const 0.17067236731650248
-  f64.const 0
-  call $std/math/check<f64>
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 3170
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const 7.858890253041697
-  f64.const 0.05215452675006225
-  call $~lib/math/NativeMath.rem
-  f64.const -0.016443286217702822
-  f64.const 0
-  call $std/math/check<f64>
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 3171
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const -0.792054511984896
-  f64.const 7.67640268511754
-  call $~lib/math/NativeMath.rem
-  f64.const -0.792054511984896
-  f64.const 0
-  call $std/math/check<f64>
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 3172
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const 0.615702673197924
-  f64.const 2.0119025790324803
-  call $~lib/math/NativeMath.rem
-  f64.const 0.615702673197924
-  f64.const 0
-  call $std/math/check<f64>
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 3173
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const -0.5587586823609152
-  f64.const 0.03223983060263804
-  call $~lib/math/NativeMath.rem
-  f64.const -0.0106815621160685
-  f64.const 0
-  call $std/math/check<f64>
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 3174
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const 0
-  f64.const 1
-  call $~lib/math/NativeMath.rem
-  f64.const 0
-  f64.const 0
-  call $std/math/check<f64>
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 3177
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const -0
-  f64.const 1
-  call $~lib/math/NativeMath.rem
-  f64.const -0
-  f64.const 0
-  call $std/math/check<f64>
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 3178
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const 0.5
-  f64.const 1
-  call $~lib/math/NativeMath.rem
-  f64.const 0.5
-  f64.const 0
-  call $std/math/check<f64>
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 3179
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const -0.5
-  f64.const 1
-  call $~lib/math/NativeMath.rem
-  f64.const -0.5
-  f64.const 0
-  call $std/math/check<f64>
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 3180
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const 1
-  f64.const 1
-  call $~lib/math/NativeMath.rem
-  f64.const 0
-  f64.const 0
-  call $std/math/check<f64>
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 3181
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const -1
-  f64.const 1
-  call $~lib/math/NativeMath.rem
-  f64.const -0
-  f64.const 0
-  call $std/math/check<f64>
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 3182
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const 1.5
-  f64.const 1
-  call $~lib/math/NativeMath.rem
-  f64.const -0.5
-  f64.const 0
-  call $std/math/check<f64>
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 3183
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const -1.5
-  f64.const 1
-  call $~lib/math/NativeMath.rem
-  f64.const 0.5
-  f64.const 0
-  call $std/math/check<f64>
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 3184
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const 2
-  f64.const 1
-  call $~lib/math/NativeMath.rem
-  f64.const 0
-  f64.const 0
-  call $std/math/check<f64>
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 3185
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const -2
-  f64.const 1
-  call $~lib/math/NativeMath.rem
-  f64.const -0
-  f64.const 0
-  call $std/math/check<f64>
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 3186
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const inf
-  f64.const 1
-  call $~lib/math/NativeMath.rem
-  f64.const nan:0x8000000000000
-  f64.const 0
-  call $std/math/check<f64>
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 3187
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const -inf
-  f64.const 1
-  call $~lib/math/NativeMath.rem
-  f64.const nan:0x8000000000000
-  f64.const 0
-  call $std/math/check<f64>
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 3188
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const nan:0x8000000000000
-  f64.const 1
-  call $~lib/math/NativeMath.rem
-  f64.const nan:0x8000000000000
-  f64.const 0
-  call $std/math/check<f64>
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 3189
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const 0
-  f64.const -1
-  call $~lib/math/NativeMath.rem
-  f64.const 0
-  f64.const 0
-  call $std/math/check<f64>
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 3190
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const -0
-  f64.const -1
-  call $~lib/math/NativeMath.rem
-  f64.const -0
-  f64.const 0
-  call $std/math/check<f64>
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 3191
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const 0.5
-  f64.const -1
-  call $~lib/math/NativeMath.rem
-  f64.const 0.5
-  f64.const 0
-  call $std/math/check<f64>
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 3192
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const -0.5
-  f64.const -1
-  call $~lib/math/NativeMath.rem
-  f64.const -0.5
-  f64.const 0
-  call $std/math/check<f64>
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 3193
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const 1
-  f64.const -1
-  call $~lib/math/NativeMath.rem
-  f64.const 0
-  f64.const 0
-  call $std/math/check<f64>
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 3194
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const -1
-  f64.const -1
-  call $~lib/math/NativeMath.rem
-  f64.const -0
-  f64.const 0
-  call $std/math/check<f64>
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 3195
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const 1.5
-  f64.const -1
-  call $~lib/math/NativeMath.rem
-  f64.const -0.5
-  f64.const 0
-  call $std/math/check<f64>
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 3196
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const -1.5
-  f64.const -1
-  call $~lib/math/NativeMath.rem
-  f64.const 0.5
-  f64.const 0
-  call $std/math/check<f64>
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 3197
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const 2
-  f64.const -1
-  call $~lib/math/NativeMath.rem
-  f64.const 0
-  f64.const 0
-  call $std/math/check<f64>
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 3198
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const -2
-  f64.const -1
-  call $~lib/math/NativeMath.rem
-  f64.const -0
-  f64.const 0
-  call $std/math/check<f64>
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 3199
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const inf
-  f64.const -1
-  call $~lib/math/NativeMath.rem
-  f64.const nan:0x8000000000000
-  f64.const 0
-  call $std/math/check<f64>
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 3200
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const -inf
-  f64.const -1
-  call $~lib/math/NativeMath.rem
-  f64.const nan:0x8000000000000
-  f64.const 0
-  call $std/math/check<f64>
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 3201
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const nan:0x8000000000000
-  f64.const -1
-  call $~lib/math/NativeMath.rem
-  f64.const nan:0x8000000000000
-  f64.const 0
-  call $std/math/check<f64>
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 3202
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const 0
-  f64.const 0
-  call $~lib/math/NativeMath.rem
-  f64.const nan:0x8000000000000
-  f64.const 0
-  call $std/math/check<f64>
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 3203
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const 0
-  f64.const -0
-  call $~lib/math/NativeMath.rem
-  f64.const nan:0x8000000000000
-  f64.const 0
-  call $std/math/check<f64>
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 3204
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const 0
-  f64.const inf
-  call $~lib/math/NativeMath.rem
-  f64.const 0
-  f64.const 0
-  call $std/math/check<f64>
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 3205
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const 0
-  f64.const -inf
-  call $~lib/math/NativeMath.rem
-  f64.const 0
-  f64.const 0
-  call $std/math/check<f64>
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 3206
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const 0
-  f64.const nan:0x8000000000000
-  call $~lib/math/NativeMath.rem
-  f64.const nan:0x8000000000000
-  f64.const 0
-  call $std/math/check<f64>
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 3207
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const -0
-  f64.const 0
-  call $~lib/math/NativeMath.rem
-  f64.const nan:0x8000000000000
-  f64.const 0
-  call $std/math/check<f64>
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 3208
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const -0
-  f64.const -0
-  call $~lib/math/NativeMath.rem
-  f64.const nan:0x8000000000000
-  f64.const 0
-  call $std/math/check<f64>
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 3209
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const -0
-  f64.const inf
-  call $~lib/math/NativeMath.rem
-  f64.const -0
-  f64.const 0
-  call $std/math/check<f64>
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 3210
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const -0
-  f64.const -inf
-  call $~lib/math/NativeMath.rem
-  f64.const -0
-  f64.const 0
-  call $std/math/check<f64>
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 3211
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const -0
-  f64.const nan:0x8000000000000
-  call $~lib/math/NativeMath.rem
-  f64.const nan:0x8000000000000
-  f64.const 0
-  call $std/math/check<f64>
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 3212
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const 1
-  f64.const 0
-  call $~lib/math/NativeMath.rem
-  f64.const nan:0x8000000000000
-  f64.const 0
-  call $std/math/check<f64>
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 3213
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const -1
-  f64.const 0
-  call $~lib/math/NativeMath.rem
-  f64.const nan:0x8000000000000
-  f64.const 0
-  call $std/math/check<f64>
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 3214
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const inf
-  f64.const 0
-  call $~lib/math/NativeMath.rem
-  f64.const nan:0x8000000000000
-  f64.const 0
-  call $std/math/check<f64>
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 3215
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const -inf
-  f64.const 0
-  call $~lib/math/NativeMath.rem
-  f64.const nan:0x8000000000000
-  f64.const 0
-  call $std/math/check<f64>
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 3216
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const nan:0x8000000000000
-  f64.const 0
-  call $~lib/math/NativeMath.rem
-  f64.const nan:0x8000000000000
-  f64.const 0
-  call $std/math/check<f64>
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 3217
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const -1
-  f64.const -0
-  call $~lib/math/NativeMath.rem
-  f64.const nan:0x8000000000000
-  f64.const 0
-  call $std/math/check<f64>
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 3218
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const inf
-  f64.const -0
-  call $~lib/math/NativeMath.rem
-  f64.const nan:0x8000000000000
-  f64.const 0
-  call $std/math/check<f64>
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 3219
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const -inf
-  f64.const -0
-  call $~lib/math/NativeMath.rem
-  f64.const nan:0x8000000000000
-  f64.const 0
-  call $std/math/check<f64>
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 3220
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const nan:0x8000000000000
-  f64.const -0
-  call $~lib/math/NativeMath.rem
-  f64.const nan:0x8000000000000
-  f64.const 0
-  call $std/math/check<f64>
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 3221
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const inf
-  f64.const 2
-  call $~lib/math/NativeMath.rem
-  f64.const nan:0x8000000000000
-  f64.const 0
-  call $std/math/check<f64>
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 3222
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const inf
-  f64.const -0.5
-  call $~lib/math/NativeMath.rem
-  f64.const nan:0x8000000000000
-  f64.const 0
-  call $std/math/check<f64>
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 3223
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const inf
-  f64.const nan:0x8000000000000
-  call $~lib/math/NativeMath.rem
-  f64.const nan:0x8000000000000
-  f64.const 0
-  call $std/math/check<f64>
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 3224
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const -inf
-  f64.const 2
-  call $~lib/math/NativeMath.rem
-  f64.const nan:0x8000000000000
-  f64.const 0
-  call $std/math/check<f64>
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 3225
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const -inf
-  f64.const -0.5
-  call $~lib/math/NativeMath.rem
-  f64.const nan:0x8000000000000
-  f64.const 0
-  call $std/math/check<f64>
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 3226
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const -inf
-  f64.const nan:0x8000000000000
-  call $~lib/math/NativeMath.rem
-  f64.const nan:0x8000000000000
-  f64.const 0
-  call $std/math/check<f64>
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 3227
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const nan:0x8000000000000
-  f64.const nan:0x8000000000000
-  call $~lib/math/NativeMath.rem
-  f64.const nan:0x8000000000000
-  f64.const 0
-  call $std/math/check<f64>
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 3228
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const 1
-  f64.const nan:0x8000000000000
-  call $~lib/math/NativeMath.rem
-  f64.const nan:0x8000000000000
-  f64.const 0
-  call $std/math/check<f64>
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 3229
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const -1
-  f64.const nan:0x8000000000000
-  call $~lib/math/NativeMath.rem
-  f64.const nan:0x8000000000000
-  f64.const 0
-  call $std/math/check<f64>
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 3230
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const 1
-  f64.const inf
-  call $~lib/math/NativeMath.rem
-  f64.const 1
-  f64.const 0
-  call $std/math/check<f64>
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 3231
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const -1
-  f64.const inf
-  call $~lib/math/NativeMath.rem
-  f64.const -1
-  f64.const 0
-  call $std/math/check<f64>
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 3232
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const inf
-  f64.const inf
-  call $~lib/math/NativeMath.rem
-  f64.const nan:0x8000000000000
-  f64.const 0
-  call $std/math/check<f64>
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 3233
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const -inf
-  f64.const inf
-  call $~lib/math/NativeMath.rem
-  f64.const nan:0x8000000000000
-  f64.const 0
-  call $std/math/check<f64>
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 3234
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const 1
-  f64.const -inf
-  call $~lib/math/NativeMath.rem
-  f64.const 1
-  f64.const 0
-  call $std/math/check<f64>
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 3235
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const -1
-  f64.const -inf
-  call $~lib/math/NativeMath.rem
-  f64.const -1
-  f64.const 0
-  call $std/math/check<f64>
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 3236
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const inf
-  f64.const -inf
-  call $~lib/math/NativeMath.rem
-  f64.const nan:0x8000000000000
-  f64.const 0
-  call $std/math/check<f64>
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 3237
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const -inf
-  f64.const -inf
-  call $~lib/math/NativeMath.rem
-  f64.const nan:0x8000000000000
-  f64.const 0
-  call $std/math/check<f64>
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 3238
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const 1.75
-  f64.const 0.5
-  call $~lib/math/NativeMath.rem
-  f64.const -0.25
-  f64.const 0
-  call $std/math/check<f64>
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 3239
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const -1.75
-  f64.const 0.5
-  call $~lib/math/NativeMath.rem
-  f64.const 0.25
-  f64.const 0
-  call $std/math/check<f64>
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 3240
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const 1.75
-  f64.const -0.5
-  call $~lib/math/NativeMath.rem
-  f64.const -0.25
-  f64.const 0
-  call $std/math/check<f64>
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 3241
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const -1.75
-  f64.const -0.5
-  call $~lib/math/NativeMath.rem
-  f64.const 0.25
-  f64.const 0
-  call $std/math/check<f64>
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 3242
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const 8e-323
-  f64.const inf
-  call $~lib/math/NativeMath.rem
-  f64.const 8e-323
-  f64.const 0
-  call $std/math/check<f64>
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 3243
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const -8.066848754882812
-  f32.const 4.535662651062012
-  call $~lib/math/NativeMathf.rem
-  f32.const 1.004476547241211
-  f32.const 0
-  call $std/math/check<f32>
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 3252
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const 4.345239639282227
-  f32.const -8.887990951538086
-  call $~lib/math/NativeMathf.rem
-  f32.const 4.345239639282227
-  f32.const 0
-  call $std/math/check<f32>
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 3253
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const -8.381433486938477
-  f32.const -2.7636072635650635
-  call $~lib/math/NativeMathf.rem
-  f32.const -0.09061169624328613
-  f32.const 0
-  call $std/math/check<f32>
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 3254
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const -6.531673431396484
-  f32.const 4.567535400390625
-  call $~lib/math/NativeMathf.rem
-  f32.const -1.9641380310058594
-  f32.const 0
-  call $std/math/check<f32>
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 3255
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const 9.267057418823242
-  f32.const 4.811392307281494
-  call $~lib/math/NativeMathf.rem
-  f32.const -0.3557271957397461
-  f32.const 0
-  call $std/math/check<f32>
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 3256
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const -6.450045585632324
-  f32.const 0.6620717644691467
-  call $~lib/math/NativeMathf.rem
-  f32.const 0.17067205905914307
-  f32.const 0
-  call $std/math/check<f32>
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 3257
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const 7.858890056610107
-  f32.const 0.052154526114463806
-  call $~lib/math/NativeMathf.rem
-  f32.const -0.016443386673927307
-  f32.const 0
-  call $std/math/check<f32>
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 3258
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const -0.7920545339584351
-  f32.const 7.676402568817139
-  call $~lib/math/NativeMathf.rem
-  f32.const -0.7920545339584351
-  f32.const 0
-  call $std/math/check<f32>
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 3259
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const 0.6157026886940002
-  f32.const 2.0119025707244873
-  call $~lib/math/NativeMathf.rem
-  f32.const 0.6157026886940002
-  f32.const 0
-  call $std/math/check<f32>
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 3260
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const -0.5587586760520935
-  f32.const 0.03223983198404312
-  call $~lib/math/NativeMathf.rem
-  f32.const -0.010681532323360443
-  f32.const 0
-  call $std/math/check<f32>
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 3261
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const 0
-  f32.const 1
-  call $~lib/math/NativeMathf.rem
-  f32.const 0
-  f32.const 0
-  call $std/math/check<f32>
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 3264
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const -0
-  f32.const 1
-  call $~lib/math/NativeMathf.rem
-  f32.const -0
-  f32.const 0
-  call $std/math/check<f32>
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 3265
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const 0.5
-  f32.const 1
-  call $~lib/math/NativeMathf.rem
-  f32.const 0.5
-  f32.const 0
-  call $std/math/check<f32>
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 3266
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const -0.5
-  f32.const 1
-  call $~lib/math/NativeMathf.rem
-  f32.const -0.5
-  f32.const 0
-  call $std/math/check<f32>
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 3267
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const 1
-  f32.const 1
-  call $~lib/math/NativeMathf.rem
-  f32.const 0
-  f32.const 0
-  call $std/math/check<f32>
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 3268
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const -1
-  f32.const 1
-  call $~lib/math/NativeMathf.rem
-  f32.const -0
-  f32.const 0
-  call $std/math/check<f32>
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 3269
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const 1.5
-  f32.const 1
-  call $~lib/math/NativeMathf.rem
-  f32.const -0.5
-  f32.const 0
-  call $std/math/check<f32>
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 3270
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const -1.5
-  f32.const 1
-  call $~lib/math/NativeMathf.rem
-  f32.const 0.5
-  f32.const 0
-  call $std/math/check<f32>
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 3271
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const 2
-  f32.const 1
-  call $~lib/math/NativeMathf.rem
-  f32.const 0
-  f32.const 0
-  call $std/math/check<f32>
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 3272
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const -2
-  f32.const 1
-  call $~lib/math/NativeMathf.rem
-  f32.const -0
-  f32.const 0
-  call $std/math/check<f32>
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 3273
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const inf
-  f32.const 1
-  call $~lib/math/NativeMathf.rem
-  f32.const nan:0x400000
-  f32.const 0
-  call $std/math/check<f32>
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 3274
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const -inf
-  f32.const 1
-  call $~lib/math/NativeMathf.rem
-  f32.const nan:0x400000
-  f32.const 0
-  call $std/math/check<f32>
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 3275
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const nan:0x400000
-  f32.const 1
-  call $~lib/math/NativeMathf.rem
-  f32.const nan:0x400000
-  f32.const 0
-  call $std/math/check<f32>
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 3276
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const 0
-  f32.const -1
-  call $~lib/math/NativeMathf.rem
-  f32.const 0
-  f32.const 0
-  call $std/math/check<f32>
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 3277
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const -0
-  f32.const -1
-  call $~lib/math/NativeMathf.rem
-  f32.const -0
-  f32.const 0
-  call $std/math/check<f32>
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 3278
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const 0.5
-  f32.const -1
-  call $~lib/math/NativeMathf.rem
-  f32.const 0.5
-  f32.const 0
-  call $std/math/check<f32>
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 3279
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const -0.5
-  f32.const -1
-  call $~lib/math/NativeMathf.rem
-  f32.const -0.5
-  f32.const 0
-  call $std/math/check<f32>
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 3280
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const 1
-  f32.const -1
-  call $~lib/math/NativeMathf.rem
-  f32.const 0
-  f32.const 0
-  call $std/math/check<f32>
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 3281
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const -1
-  f32.const -1
-  call $~lib/math/NativeMathf.rem
-  f32.const -0
-  f32.const 0
-  call $std/math/check<f32>
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 3282
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const 1.5
-  f32.const -1
-  call $~lib/math/NativeMathf.rem
-  f32.const -0.5
-  f32.const 0
-  call $std/math/check<f32>
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 3283
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const -1.5
-  f32.const -1
-  call $~lib/math/NativeMathf.rem
-  f32.const 0.5
-  f32.const 0
-  call $std/math/check<f32>
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 3284
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const 2
-  f32.const -1
-  call $~lib/math/NativeMathf.rem
-  f32.const 0
-  f32.const 0
-  call $std/math/check<f32>
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 3285
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const -2
-  f32.const -1
-  call $~lib/math/NativeMathf.rem
-  f32.const -0
-  f32.const 0
-  call $std/math/check<f32>
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 3286
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const inf
-  f32.const -1
-  call $~lib/math/NativeMathf.rem
-  f32.const nan:0x400000
-  f32.const 0
-  call $std/math/check<f32>
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 3287
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const -inf
-  f32.const -1
-  call $~lib/math/NativeMathf.rem
-  f32.const nan:0x400000
-  f32.const 0
-  call $std/math/check<f32>
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 3288
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const nan:0x400000
-  f32.const -1
-  call $~lib/math/NativeMathf.rem
-  f32.const nan:0x400000
-  f32.const 0
-  call $std/math/check<f32>
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 3289
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const 0
-  f32.const 0
-  call $~lib/math/NativeMathf.rem
-  f32.const nan:0x400000
-  f32.const 0
-  call $std/math/check<f32>
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 3290
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const 0
-  f32.const -0
-  call $~lib/math/NativeMathf.rem
-  f32.const nan:0x400000
-  f32.const 0
-  call $std/math/check<f32>
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 3291
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const 0
-  f32.const inf
-  call $~lib/math/NativeMathf.rem
-  f32.const 0
-  f32.const 0
-  call $std/math/check<f32>
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 3292
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const 0
-  f32.const -inf
-  call $~lib/math/NativeMathf.rem
-  f32.const 0
-  f32.const 0
-  call $std/math/check<f32>
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 3293
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const 0
-  f32.const nan:0x400000
-  call $~lib/math/NativeMathf.rem
-  f32.const nan:0x400000
-  f32.const 0
-  call $std/math/check<f32>
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 3294
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const -0
-  f32.const 0
-  call $~lib/math/NativeMathf.rem
-  f32.const nan:0x400000
-  f32.const 0
-  call $std/math/check<f32>
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 3295
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const -0
-  f32.const -0
-  call $~lib/math/NativeMathf.rem
-  f32.const nan:0x400000
-  f32.const 0
-  call $std/math/check<f32>
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 3296
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const -0
-  f32.const inf
-  call $~lib/math/NativeMathf.rem
-  f32.const -0
-  f32.const 0
-  call $std/math/check<f32>
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 3297
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const -0
-  f32.const -inf
-  call $~lib/math/NativeMathf.rem
-  f32.const -0
-  f32.const 0
-  call $std/math/check<f32>
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 3298
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const -0
-  f32.const nan:0x400000
-  call $~lib/math/NativeMathf.rem
-  f32.const nan:0x400000
-  f32.const 0
-  call $std/math/check<f32>
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 3299
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const 1
-  f32.const 0
-  call $~lib/math/NativeMathf.rem
-  f32.const nan:0x400000
-  f32.const 0
-  call $std/math/check<f32>
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 3300
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const -1
-  f32.const 0
-  call $~lib/math/NativeMathf.rem
-  f32.const nan:0x400000
-  f32.const 0
-  call $std/math/check<f32>
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 3301
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const inf
-  f32.const 0
-  call $~lib/math/NativeMathf.rem
-  f32.const nan:0x400000
-  f32.const 0
-  call $std/math/check<f32>
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 3302
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const -inf
-  f32.const 0
-  call $~lib/math/NativeMathf.rem
-  f32.const nan:0x400000
-  f32.const 0
-  call $std/math/check<f32>
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 3303
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const nan:0x400000
-  f32.const 0
-  call $~lib/math/NativeMathf.rem
-  f32.const nan:0x400000
-  f32.const 0
-  call $std/math/check<f32>
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 3304
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const -1
-  f32.const -0
-  call $~lib/math/NativeMathf.rem
-  f32.const nan:0x400000
-  f32.const 0
-  call $std/math/check<f32>
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 3305
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const inf
-  f32.const -0
-  call $~lib/math/NativeMathf.rem
-  f32.const nan:0x400000
-  f32.const 0
-  call $std/math/check<f32>
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 3306
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const -inf
-  f32.const -0
-  call $~lib/math/NativeMathf.rem
-  f32.const nan:0x400000
-  f32.const 0
-  call $std/math/check<f32>
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 3307
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const nan:0x400000
-  f32.const -0
-  call $~lib/math/NativeMathf.rem
-  f32.const nan:0x400000
-  f32.const 0
-  call $std/math/check<f32>
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 3308
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const inf
-  f32.const 2
-  call $~lib/math/NativeMathf.rem
-  f32.const nan:0x400000
-  f32.const 0
-  call $std/math/check<f32>
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 3309
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const inf
-  f32.const -0.5
-  call $~lib/math/NativeMathf.rem
-  f32.const nan:0x400000
-  f32.const 0
-  call $std/math/check<f32>
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 3310
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const inf
-  f32.const nan:0x400000
-  call $~lib/math/NativeMathf.rem
-  f32.const nan:0x400000
-  f32.const 0
-  call $std/math/check<f32>
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 3311
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const -inf
-  f32.const 2
-  call $~lib/math/NativeMathf.rem
-  f32.const nan:0x400000
-  f32.const 0
-  call $std/math/check<f32>
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 3312
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const -inf
-  f32.const -0.5
-  call $~lib/math/NativeMathf.rem
-  f32.const nan:0x400000
-  f32.const 0
-  call $std/math/check<f32>
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 3313
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const -inf
-  f32.const nan:0x400000
-  call $~lib/math/NativeMathf.rem
-  f32.const nan:0x400000
-  f32.const 0
-  call $std/math/check<f32>
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 3314
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const nan:0x400000
-  f32.const nan:0x400000
-  call $~lib/math/NativeMathf.rem
-  f32.const nan:0x400000
-  f32.const 0
-  call $std/math/check<f32>
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 3315
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const 1
-  f32.const nan:0x400000
-  call $~lib/math/NativeMathf.rem
-  f32.const nan:0x400000
-  f32.const 0
-  call $std/math/check<f32>
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 3316
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const -1
-  f32.const nan:0x400000
-  call $~lib/math/NativeMathf.rem
-  f32.const nan:0x400000
-  f32.const 0
-  call $std/math/check<f32>
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 3317
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const 1
-  f32.const inf
-  call $~lib/math/NativeMathf.rem
-  f32.const 1
-  f32.const 0
-  call $std/math/check<f32>
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 3318
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const -1
-  f32.const inf
-  call $~lib/math/NativeMathf.rem
-  f32.const -1
-  f32.const 0
-  call $std/math/check<f32>
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 3319
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const inf
-  f32.const inf
-  call $~lib/math/NativeMathf.rem
-  f32.const nan:0x400000
-  f32.const 0
-  call $std/math/check<f32>
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 3320
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const -inf
-  f32.const inf
-  call $~lib/math/NativeMathf.rem
-  f32.const nan:0x400000
-  f32.const 0
-  call $std/math/check<f32>
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 3321
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const 1
-  f32.const -inf
-  call $~lib/math/NativeMathf.rem
-  f32.const 1
-  f32.const 0
-  call $std/math/check<f32>
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 3322
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const -1
-  f32.const -inf
-  call $~lib/math/NativeMathf.rem
-  f32.const -1
-  f32.const 0
-  call $std/math/check<f32>
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 3323
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const inf
-  f32.const -inf
-  call $~lib/math/NativeMathf.rem
-  f32.const nan:0x400000
-  f32.const 0
-  call $std/math/check<f32>
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 3324
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const -inf
-  f32.const -inf
-  call $~lib/math/NativeMathf.rem
-  f32.const nan:0x400000
-  f32.const 0
-  call $std/math/check<f32>
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 3325
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const 1.75
-  f32.const 0.5
-  call $~lib/math/NativeMathf.rem
-  f32.const -0.25
-  f32.const 0
-  call $std/math/check<f32>
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 3326
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const -1.75
-  f32.const 0.5
-  call $~lib/math/NativeMathf.rem
-  f32.const 0.25
-  f32.const 0
-  call $std/math/check<f32>
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 3327
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const 1.75
-  f32.const -0.5
-  call $~lib/math/NativeMathf.rem
-  f32.const -0.25
-  f32.const 0
-  call $std/math/check<f32>
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 3328
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const -1.75
-  f32.const -0.5
-  call $~lib/math/NativeMathf.rem
-  f32.const 0.25
-  f32.const 0
-  call $std/math/check<f32>
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 3329
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const 5.877471754111438e-39
-  f32.const inf
-  call $~lib/math/NativeMathf.rem
-  f32.const 5.877471754111438e-39
-  f32.const 0
-  call $std/math/check<f32>
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 3330
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const -8.06684839057968
-  call $~lib/math/NativeMath.sin
+  call $~lib/util/math/sin64
   f64.const -0.9774292928781227
   f64.const -0.14564912021160126
   call $std/math/check<f64>
@@ -47169,13 +44116,13 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3342
+   i32.const 3155
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f64.const 4.345239849338305
-  call $~lib/math/NativeMath.sin
+  call $~lib/util/math/sin64
   f64.const -0.9333544736965718
   f64.const -0.08813747018575668
   call $std/math/check<f64>
@@ -47192,13 +44139,13 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3343
+   i32.const 3156
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f64.const -8.38143342755525
-  call $~lib/math/NativeMath.sin
+  call $~lib/util/math/sin64
   f64.const -0.8640924711706304
   f64.const -0.11743883043527603
   call $std/math/check<f64>
@@ -47215,13 +44162,13 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3344
+   i32.const 3157
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f64.const -6.531673581913484
-  call $~lib/math/NativeMath.sin
+  call $~lib/util/math/sin64
   f64.const -0.24593894772615374
   f64.const -0.12697851657867432
   call $std/math/check<f64>
@@ -47238,13 +44185,13 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3345
+   i32.const 3158
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f64.const 9.267056966972586
-  call $~lib/math/NativeMath.sin
+  call $~lib/util/math/sin64
   f64.const 0.15706789772028007
   f64.const -0.029550159350037575
   call $std/math/check<f64>
@@ -47261,13 +44208,13 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3346
+   i32.const 3159
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f64.const 0.6619858980995045
-  call $~lib/math/NativeMath.sin
+  call $~lib/util/math/sin64
   f64.const 0.6146844860113447
   f64.const -0.09976737946271896
   call $std/math/check<f64>
@@ -47284,13 +44231,13 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3347
+   i32.const 3160
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f64.const -0.4066039223853553
-  call $~lib/math/NativeMath.sin
+  call $~lib/util/math/sin64
   f64.const -0.39549242182823696
   f64.const -0.3668774962425232
   call $std/math/check<f64>
@@ -47307,13 +44254,13 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3348
+   i32.const 3161
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f64.const 0.5617597462207241
-  call $~lib/math/NativeMath.sin
+  call $~lib/util/math/sin64
   f64.const 0.5326763286672376
   f64.const -0.3550407588481903
   call $std/math/check<f64>
@@ -47330,13 +44277,13 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3349
+   i32.const 3162
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f64.const 0.7741522965913037
-  call $~lib/math/NativeMath.sin
+  call $~lib/util/math/sin64
   f64.const 0.6991102068649779
   f64.const -0.427672415971756
   call $std/math/check<f64>
@@ -47353,13 +44300,13 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3350
+   i32.const 3163
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f64.const -0.6787637026394024
-  call $~lib/math/NativeMath.sin
+  call $~lib/util/math/sin64
   f64.const -0.6278312326301215
   f64.const -0.3828115463256836
   call $std/math/check<f64>
@@ -47376,13 +44323,13 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3351
+   i32.const 3164
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f64.const 9.313225746154785e-10
-  call $~lib/math/NativeMath.sin
+  call $~lib/util/math/sin64
   f64.const 9.313225746154785e-10
   f64.const 6.510416860692203e-04
   call $std/math/check<f64>
@@ -47399,13 +44346,13 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3354
+   i32.const 3167
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f64.const -9.313225746154785e-10
-  call $~lib/math/NativeMath.sin
+  call $~lib/util/math/sin64
   f64.const -9.313225746154785e-10
   f64.const -6.510416860692203e-04
   call $std/math/check<f64>
@@ -47422,13 +44369,13 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3355
+   i32.const 3168
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f64.const 2.2250738585072014e-308
-  call $~lib/math/NativeMath.sin
+  call $~lib/util/math/sin64
   f64.const 2.2250738585072014e-308
   f64.const 0
   call $std/math/check<f64>
@@ -47445,13 +44392,13 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3356
+   i32.const 3169
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f64.const -2.2250738585072014e-308
-  call $~lib/math/NativeMath.sin
+  call $~lib/util/math/sin64
   f64.const -2.2250738585072014e-308
   f64.const 0
   call $std/math/check<f64>
@@ -47468,13 +44415,13 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3357
+   i32.const 3170
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f64.const 5e-324
-  call $~lib/math/NativeMath.sin
+  call $~lib/util/math/sin64
   f64.const 5e-324
   f64.const 0
   call $std/math/check<f64>
@@ -47491,13 +44438,13 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3358
+   i32.const 3171
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f64.const -5e-324
-  call $~lib/math/NativeMath.sin
+  call $~lib/util/math/sin64
   f64.const -5e-324
   f64.const 0
   call $std/math/check<f64>
@@ -47514,13 +44461,13 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3359
+   i32.const 3172
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f64.const 0
-  call $~lib/math/NativeMath.sin
+  call $~lib/util/math/sin64
   f64.const 0
   f64.const 0
   call $std/math/check<f64>
@@ -47537,13 +44484,13 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3360
+   i32.const 3173
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f64.const -0
-  call $~lib/math/NativeMath.sin
+  call $~lib/util/math/sin64
   f64.const -0
   f64.const 0
   call $std/math/check<f64>
@@ -47560,13 +44507,13 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3361
+   i32.const 3174
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f64.const 2.225073858507202e-308
-  call $~lib/math/NativeMath.sin
+  call $~lib/util/math/sin64
   f64.const 2.225073858507202e-308
   f64.const 0
   call $std/math/check<f64>
@@ -47583,13 +44530,13 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3362
+   i32.const 3175
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f64.const 2.2250738585072024e-308
-  call $~lib/math/NativeMath.sin
+  call $~lib/util/math/sin64
   f64.const 2.2250738585072024e-308
   f64.const 0
   call $std/math/check<f64>
@@ -47606,13 +44553,13 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3363
+   i32.const 3176
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f64.const 4.4501477170144003e-308
-  call $~lib/math/NativeMath.sin
+  call $~lib/util/math/sin64
   f64.const 4.4501477170144003e-308
   f64.const 0
   call $std/math/check<f64>
@@ -47629,13 +44576,13 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3364
+   i32.const 3177
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f64.const 4.450147717014403e-308
-  call $~lib/math/NativeMath.sin
+  call $~lib/util/math/sin64
   f64.const 4.450147717014403e-308
   f64.const 0
   call $std/math/check<f64>
@@ -47652,13 +44599,13 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3365
+   i32.const 3178
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f64.const 4.450147717014406e-308
-  call $~lib/math/NativeMath.sin
+  call $~lib/util/math/sin64
   f64.const 4.450147717014406e-308
   f64.const 0
   call $std/math/check<f64>
@@ -47675,13 +44622,13 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3366
+   i32.const 3179
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f64.const 8.900295434028806e-308
-  call $~lib/math/NativeMath.sin
+  call $~lib/util/math/sin64
   f64.const 8.900295434028806e-308
   f64.const 0
   call $std/math/check<f64>
@@ -47698,13 +44645,13 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3367
+   i32.const 3180
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f64.const 1.1175870895385742e-08
-  call $~lib/math/NativeMath.sin
+  call $~lib/util/math/sin64
   f64.const 1.1175870895385742e-08
   f64.const 0.140625
   call $std/math/check<f64>
@@ -47721,13 +44668,13 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3368
+   i32.const 3181
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f64.const 1.4901161193847656e-08
-  call $~lib/math/NativeMath.sin
+  call $~lib/util/math/sin64
   f64.const 1.4901161193847656e-08
   f64.const 0.1666666716337204
   call $std/math/check<f64>
@@ -47744,13 +44691,13 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3369
+   i32.const 3182
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f64.const -2.225073858507202e-308
-  call $~lib/math/NativeMath.sin
+  call $~lib/util/math/sin64
   f64.const -2.225073858507202e-308
   f64.const 0
   call $std/math/check<f64>
@@ -47767,13 +44714,13 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3370
+   i32.const 3183
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f64.const -2.2250738585072024e-308
-  call $~lib/math/NativeMath.sin
+  call $~lib/util/math/sin64
   f64.const -2.2250738585072024e-308
   f64.const 0
   call $std/math/check<f64>
@@ -47790,13 +44737,13 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3371
+   i32.const 3184
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f64.const -4.4501477170144003e-308
-  call $~lib/math/NativeMath.sin
+  call $~lib/util/math/sin64
   f64.const -4.4501477170144003e-308
   f64.const 0
   call $std/math/check<f64>
@@ -47813,13 +44760,13 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3372
+   i32.const 3185
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f64.const -4.450147717014403e-308
-  call $~lib/math/NativeMath.sin
+  call $~lib/util/math/sin64
   f64.const -4.450147717014403e-308
   f64.const 0
   call $std/math/check<f64>
@@ -47836,13 +44783,13 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3373
+   i32.const 3186
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f64.const -4.450147717014406e-308
-  call $~lib/math/NativeMath.sin
+  call $~lib/util/math/sin64
   f64.const -4.450147717014406e-308
   f64.const 0
   call $std/math/check<f64>
@@ -47859,13 +44806,13 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3374
+   i32.const 3187
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f64.const -8.900295434028806e-308
-  call $~lib/math/NativeMath.sin
+  call $~lib/util/math/sin64
   f64.const -8.900295434028806e-308
   f64.const 0
   call $std/math/check<f64>
@@ -47882,13 +44829,13 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3375
+   i32.const 3188
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f64.const -1.1175870895385742e-08
-  call $~lib/math/NativeMath.sin
+  call $~lib/util/math/sin64
   f64.const -1.1175870895385742e-08
   f64.const -0.140625
   call $std/math/check<f64>
@@ -47905,36 +44852,13 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3376
+   i32.const 3189
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f64.const -1.4901161193847656e-08
-  call $~lib/math/NativeMath.sin
-  f64.const -1.4901161193847656e-08
-  f64.const -0.1666666716337204
-  call $std/math/check<f64>
-  if (result i32)
-   f64.const -1.4901161193847656e-08
-   call $~lib/bindings/dom/Math.sin
-   f64.const -1.4901161193847656e-08
-   f64.const -0.1666666716337204
-   call $std/math/check<f64>
-  else
-   i32.const 0
-  end
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 3377
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const -1.4901161193847656e-08
-  call $~lib/math/NativeMath.sin
+  call $~lib/util/math/sin64
   f64.const -1.4901161193847656e-08
   f64.const -0.1666666716337204
   call $std/math/check<f64>
@@ -47951,13 +44875,36 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3378
+   i32.const 3190
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const -1.4901161193847656e-08
+  call $~lib/util/math/sin64
+  f64.const -1.4901161193847656e-08
+  f64.const -0.1666666716337204
+  call $std/math/check<f64>
+  if (result i32)
+   f64.const -1.4901161193847656e-08
+   call $~lib/bindings/dom/Math.sin
+   f64.const -1.4901161193847656e-08
+   f64.const -0.1666666716337204
+   call $std/math/check<f64>
+  else
+   i32.const 0
+  end
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 3191
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f64.const 1e-323
-  call $~lib/math/NativeMath.sin
+  call $~lib/util/math/sin64
   f64.const 1e-323
   f64.const 0
   call $std/math/check<f64>
@@ -47974,13 +44921,13 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3379
+   i32.const 3192
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f64.const 4.4e-323
-  call $~lib/math/NativeMath.sin
+  call $~lib/util/math/sin64
   f64.const 4.4e-323
   f64.const 0
   call $std/math/check<f64>
@@ -47997,13 +44944,13 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3380
+   i32.const 3193
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f64.const 5.562684646268003e-309
-  call $~lib/math/NativeMath.sin
+  call $~lib/util/math/sin64
   f64.const 5.562684646268003e-309
   f64.const 0
   call $std/math/check<f64>
@@ -48020,13 +44967,13 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3381
+   i32.const 3194
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f64.const 1.1125369292536007e-308
-  call $~lib/math/NativeMath.sin
+  call $~lib/util/math/sin64
   f64.const 1.1125369292536007e-308
   f64.const 0
   call $std/math/check<f64>
@@ -48043,13 +44990,13 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3382
+   i32.const 3195
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f64.const 2.2250738585072004e-308
-  call $~lib/math/NativeMath.sin
+  call $~lib/util/math/sin64
   f64.const 2.2250738585072004e-308
   f64.const 0
   call $std/math/check<f64>
@@ -48066,13 +45013,13 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3383
+   i32.const 3196
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f64.const 2.225073858507201e-308
-  call $~lib/math/NativeMath.sin
+  call $~lib/util/math/sin64
   f64.const 2.225073858507201e-308
   f64.const 0
   call $std/math/check<f64>
@@ -48089,13 +45036,13 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3384
+   i32.const 3197
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f64.const -1e-323
-  call $~lib/math/NativeMath.sin
+  call $~lib/util/math/sin64
   f64.const -1e-323
   f64.const 0
   call $std/math/check<f64>
@@ -48112,13 +45059,13 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3385
+   i32.const 3198
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f64.const -4.4e-323
-  call $~lib/math/NativeMath.sin
+  call $~lib/util/math/sin64
   f64.const -4.4e-323
   f64.const 0
   call $std/math/check<f64>
@@ -48135,13 +45082,13 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3386
+   i32.const 3199
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f64.const -5.562684646268003e-309
-  call $~lib/math/NativeMath.sin
+  call $~lib/util/math/sin64
   f64.const -5.562684646268003e-309
   f64.const 0
   call $std/math/check<f64>
@@ -48158,13 +45105,13 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3387
+   i32.const 3200
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f64.const -1.1125369292536007e-308
-  call $~lib/math/NativeMath.sin
+  call $~lib/util/math/sin64
   f64.const -1.1125369292536007e-308
   f64.const 0
   call $std/math/check<f64>
@@ -48181,13 +45128,13 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3388
+   i32.const 3201
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f64.const -2.2250738585072004e-308
-  call $~lib/math/NativeMath.sin
+  call $~lib/util/math/sin64
   f64.const -2.2250738585072004e-308
   f64.const 0
   call $std/math/check<f64>
@@ -48204,13 +45151,13 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3389
+   i32.const 3202
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f64.const -2.225073858507201e-308
-  call $~lib/math/NativeMath.sin
+  call $~lib/util/math/sin64
   f64.const -2.225073858507201e-308
   f64.const 0
   call $std/math/check<f64>
@@ -48227,13 +45174,13 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3390
+   i32.const 3203
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f64.const 0
-  call $~lib/math/NativeMath.sin
+  call $~lib/util/math/sin64
   f64.const 0
   f64.const 0
   call $std/math/check<f64>
@@ -48250,13 +45197,13 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3393
+   i32.const 3206
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f64.const -0
-  call $~lib/math/NativeMath.sin
+  call $~lib/util/math/sin64
   f64.const -0
   f64.const 0
   call $std/math/check<f64>
@@ -48273,13 +45220,13 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3394
+   i32.const 3207
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f64.const inf
-  call $~lib/math/NativeMath.sin
+  call $~lib/util/math/sin64
   f64.const nan:0x8000000000000
   f64.const 0
   call $std/math/check<f64>
@@ -48296,13 +45243,13 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3395
+   i32.const 3208
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f64.const -inf
-  call $~lib/math/NativeMath.sin
+  call $~lib/util/math/sin64
   f64.const nan:0x8000000000000
   f64.const 0
   call $std/math/check<f64>
@@ -48319,13 +45266,13 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3396
+   i32.const 3209
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f64.const nan:0x8000000000000
-  call $~lib/math/NativeMath.sin
+  call $~lib/util/math/sin64
   f64.const nan:0x8000000000000
   f64.const 0
   call $std/math/check<f64>
@@ -48342,243 +45289,243 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3397
+   i32.const 3210
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f64.const 1.5707963267948966
-  call $~lib/math/NativeMath.sin
+  call $~lib/util/math/sin64
   f64.const 1.5707963267948966
   call $~lib/bindings/dom/Math.sin
   f64.ne
   if
    i32.const 0
    i32.const 1056
-   i32.const 3400
+   i32.const 3213
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f64.const 3.141592653589793
-  call $~lib/math/NativeMath.sin
+  call $~lib/util/math/sin64
   f64.const 3.141592653589793
   call $~lib/bindings/dom/Math.sin
   f64.ne
   if
    i32.const 0
    i32.const 1056
-   i32.const 3401
+   i32.const 3214
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f64.const 2.3283064365386963e-10
-  call $~lib/math/NativeMath.sin
+  call $~lib/util/math/sin64
   f64.const 2.3283064365386963e-10
   f64.ne
   if
    i32.const 0
    i32.const 1056
-   i32.const 3404
+   i32.const 3217
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f64.const -2.3283064365386963e-10
-  call $~lib/math/NativeMath.sin
+  call $~lib/util/math/sin64
   f64.const -2.3283064365386963e-10
   f64.ne
   if
    i32.const 0
    i32.const 1056
-   i32.const 3405
+   i32.const 3218
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f64.const 0.39269908169872414
-  call $~lib/math/NativeMath.sin
+  call $~lib/util/math/sin64
   f64.const 0.3826834323650898
   f64.ne
   if
    i32.const 0
    i32.const 1056
-   i32.const 3407
+   i32.const 3220
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f64.const -0.39269908169872414
-  call $~lib/math/NativeMath.sin
+  call $~lib/util/math/sin64
   f64.const -0.3826834323650898
   f64.ne
   if
    i32.const 0
    i32.const 1056
-   i32.const 3408
+   i32.const 3221
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f64.const 0.5
-  call $~lib/math/NativeMath.sin
+  call $~lib/util/math/sin64
   f64.const 0.479425538604203
   f64.ne
   if
    i32.const 0
    i32.const 1056
-   i32.const 3411
+   i32.const 3224
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f64.const -0.5
-  call $~lib/math/NativeMath.sin
+  call $~lib/util/math/sin64
   f64.const -0.479425538604203
   f64.ne
   if
    i32.const 0
    i32.const 1056
-   i32.const 3412
+   i32.const 3225
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f64.const 1.5707963267948966
-  call $~lib/math/NativeMath.sin
+  call $~lib/util/math/sin64
   f64.const 1
   f64.ne
   if
    i32.const 0
    i32.const 1056
-   i32.const 3413
+   i32.const 3226
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f64.const -1.5707963267948966
-  call $~lib/math/NativeMath.sin
+  call $~lib/util/math/sin64
   f64.const -1
   f64.ne
   if
    i32.const 0
    i32.const 1056
-   i32.const 3414
+   i32.const 3227
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f64.const 3.141592653589793
-  call $~lib/math/NativeMath.sin
+  call $~lib/util/math/sin64
   f64.const 1.2246467991473532e-16
   f64.ne
   if
    i32.const 0
    i32.const 1056
-   i32.const 3416
+   i32.const 3229
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f64.const 6911.503837897545
-  call $~lib/math/NativeMath.sin
+  call $~lib/util/math/sin64
   f64.const -7.047032979958965e-14
   f64.ne
   if
    i32.const 0
    i32.const 1056
-   i32.const 3417
+   i32.const 3230
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f64.const 5.497787143782138
-  call $~lib/math/NativeMath.sin
+  call $~lib/util/math/sin64
   f64.const -0.7071067811865477
   f64.ne
   if
    i32.const 0
    i32.const 1056
-   i32.const 3419
+   i32.const 3232
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f64.const 7.0685834705770345
-  call $~lib/math/NativeMath.sin
+  call $~lib/util/math/sin64
   f64.const 0.7071067811865474
   f64.ne
   if
    i32.const 0
    i32.const 1056
-   i32.const 3420
+   i32.const 3233
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f64.const 8.63937979737193
-  call $~lib/math/NativeMath.sin
+  call $~lib/util/math/sin64
   f64.const 0.7071067811865483
   f64.ne
   if
    i32.const 0
    i32.const 1056
-   i32.const 3421
+   i32.const 3234
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f64.const 10.210176124166829
-  call $~lib/math/NativeMath.sin
+  call $~lib/util/math/sin64
   f64.const -0.7071067811865479
   f64.ne
   if
    i32.const 0
    i32.const 1056
-   i32.const 3422
+   i32.const 3235
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f64.const 823549.6645826427
-  call $~lib/math/NativeMath.sin
+  call $~lib/util/math/sin64
   f64.const -3.2103381051568376e-11
   f64.ne
   if
    i32.const 0
    i32.const 1056
-   i32.const 3423
+   i32.const 3236
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f64.const 1329227995784915872903807e12
-  call $~lib/math/NativeMath.sin
+  call $~lib/util/math/sin64
   f64.const 0.377820109360752
   f64.ne
   if
    i32.const 0
    i32.const 1056
-   i32.const 3426
+   i32.const 3239
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f64.const -1329227995784915872903807e12
-  call $~lib/math/NativeMath.sin
+  call $~lib/util/math/sin64
   f64.const -0.377820109360752
   f64.ne
   if
    i32.const 0
    i32.const 1056
-   i32.const 3427
+   i32.const 3240
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f32.const -8.066848754882812
-  call $~lib/math/NativeMathf.sin
+  call $~lib/util/math/sin32
   f32.const -0.977429211139679
   f32.const 0.0801057294011116
   call $std/math/check<f32>
@@ -48586,13 +45533,13 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3436
+   i32.const 3249
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f32.const 4.345239639282227
-  call $~lib/math/NativeMathf.sin
+  call $~lib/util/math/sin32
   f32.const -0.933354377746582
   f32.const 0.34475627541542053
   call $std/math/check<f32>
@@ -48600,13 +45547,13 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3437
+   i32.const 3250
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f32.const -8.381433486938477
-  call $~lib/math/NativeMathf.sin
+  call $~lib/util/math/sin32
   f32.const -0.8640924692153931
   f32.const -0.468659907579422
   call $std/math/check<f32>
@@ -48614,13 +45561,13 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3438
+   i32.const 3251
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f32.const -6.531673431396484
-  call $~lib/math/NativeMathf.sin
+  call $~lib/util/math/sin32
   f32.const -0.24593880772590637
   f32.const -0.3955177664756775
   call $std/math/check<f32>
@@ -48628,13 +45575,13 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3439
+   i32.const 3252
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f32.const 9.267057418823242
-  call $~lib/math/NativeMathf.sin
+  call $~lib/util/math/sin32
   f32.const 0.1570674479007721
   f32.const -0.24006809294223785
   call $std/math/check<f32>
@@ -48642,13 +45589,13 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3440
+   i32.const 3253
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f32.const 0.6619858741760254
-  call $~lib/math/NativeMathf.sin
+  call $~lib/util/math/sin32
   f32.const 0.6146844625473022
   f32.const -0.07707194238901138
   call $std/math/check<f32>
@@ -48656,13 +45603,13 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3441
+   i32.const 3254
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f32.const -0.40660393238067627
-  call $~lib/math/NativeMathf.sin
+  call $~lib/util/math/sin32
   f32.const -0.39549243450164795
   f32.const -0.11720617115497589
   call $std/math/check<f32>
@@ -48670,13 +45617,13 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3442
+   i32.const 3255
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f32.const 0.5617597699165344
-  call $~lib/math/NativeMathf.sin
+  call $~lib/util/math/sin32
   f32.const 0.5326763391494751
   f32.const -0.16059114038944244
   call $std/math/check<f32>
@@ -48684,13 +45631,13 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3443
+   i32.const 3256
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f32.const 0.7741522789001465
-  call $~lib/math/NativeMathf.sin
+  call $~lib/util/math/sin32
   f32.const 0.699110209941864
   f32.const 0.26384368538856506
   call $std/math/check<f32>
@@ -48698,13 +45645,13 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3444
+   i32.const 3257
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f32.const -0.6787636876106262
-  call $~lib/math/NativeMathf.sin
+  call $~lib/util/math/sin32
   f32.const -0.627831220626831
   f32.const 0.005127954296767712
   call $std/math/check<f32>
@@ -48712,13 +45659,13 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3445
+   i32.const 3258
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f32.const 0
-  call $~lib/math/NativeMathf.sin
+  call $~lib/util/math/sin32
   f32.const 0
   f32.const 0
   call $std/math/check<f32>
@@ -48726,13 +45673,13 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3448
+   i32.const 3261
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f32.const -0
-  call $~lib/math/NativeMathf.sin
+  call $~lib/util/math/sin32
   f32.const -0
   f32.const 0
   call $std/math/check<f32>
@@ -48740,13 +45687,13 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3449
+   i32.const 3262
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f32.const inf
-  call $~lib/math/NativeMathf.sin
+  call $~lib/util/math/sin32
   f32.const nan:0x400000
   f32.const 0
   call $std/math/check<f32>
@@ -48754,13 +45701,13 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3450
+   i32.const 3263
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f32.const -inf
-  call $~lib/math/NativeMathf.sin
+  call $~lib/util/math/sin32
   f32.const nan:0x400000
   f32.const 0
   call $std/math/check<f32>
@@ -48768,13 +45715,13 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3451
+   i32.const 3264
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f32.const nan:0x400000
-  call $~lib/math/NativeMathf.sin
+  call $~lib/util/math/sin32
   f32.const nan:0x400000
   f32.const 0
   call $std/math/check<f32>
@@ -48782,13 +45729,13 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3452
+   i32.const 3265
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f32.const 1.862645149230957e-09
-  call $~lib/math/NativeMathf.sin
+  call $~lib/util/math/sin32
   f32.const 1.862645149230957e-09
   f32.const 4.850638554015907e-12
   call $std/math/check<f32>
@@ -48796,13 +45743,13 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3455
+   i32.const 3268
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f32.const -1.862645149230957e-09
-  call $~lib/math/NativeMathf.sin
+  call $~lib/util/math/sin32
   f32.const -1.862645149230957e-09
   f32.const -4.850638554015907e-12
   call $std/math/check<f32>
@@ -48810,13 +45757,13 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3456
+   i32.const 3269
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f32.const 1.1754943508222875e-38
-  call $~lib/math/NativeMathf.sin
+  call $~lib/util/math/sin32
   f32.const 1.1754943508222875e-38
   f32.const 0
   call $std/math/check<f32>
@@ -48824,13 +45771,13 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3457
+   i32.const 3270
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f32.const -1.1754943508222875e-38
-  call $~lib/math/NativeMathf.sin
+  call $~lib/util/math/sin32
   f32.const -1.1754943508222875e-38
   f32.const 0
   call $std/math/check<f32>
@@ -48838,13 +45785,13 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3458
+   i32.const 3271
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f32.const 1.401298464324817e-45
-  call $~lib/math/NativeMathf.sin
+  call $~lib/util/math/sin32
   f32.const 1.401298464324817e-45
   f32.const 0
   call $std/math/check<f32>
@@ -48852,13 +45799,13 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3459
+   i32.const 3272
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f32.const -1.401298464324817e-45
-  call $~lib/math/NativeMathf.sin
+  call $~lib/util/math/sin32
   f32.const -1.401298464324817e-45
   f32.const 0
   call $std/math/check<f32>
@@ -48866,13 +45813,13 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3460
+   i32.const 3273
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f32.const 1.175494490952134e-38
-  call $~lib/math/NativeMathf.sin
+  call $~lib/util/math/sin32
   f32.const 1.175494490952134e-38
   f32.const 0
   call $std/math/check<f32>
@@ -48880,13 +45827,13 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3461
+   i32.const 3274
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f32.const 1.1754946310819804e-38
-  call $~lib/math/NativeMathf.sin
+  call $~lib/util/math/sin32
   f32.const 1.1754946310819804e-38
   f32.const 0
   call $std/math/check<f32>
@@ -48894,13 +45841,13 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3462
+   i32.const 3275
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f32.const 2.3509880009953429e-38
-  call $~lib/math/NativeMathf.sin
+  call $~lib/util/math/sin32
   f32.const 2.3509880009953429e-38
   f32.const 0
   call $std/math/check<f32>
@@ -48908,13 +45855,13 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3463
+   i32.const 3276
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f32.const 2.350988701644575e-38
-  call $~lib/math/NativeMathf.sin
+  call $~lib/util/math/sin32
   f32.const 2.350988701644575e-38
   f32.const 0
   call $std/math/check<f32>
@@ -48922,13 +45869,13 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3464
+   i32.const 3277
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f32.const 2.3509895424236536e-38
-  call $~lib/math/NativeMathf.sin
+  call $~lib/util/math/sin32
   f32.const 2.3509895424236536e-38
   f32.const 0
   call $std/math/check<f32>
@@ -48936,13 +45883,13 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3465
+   i32.const 3278
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f32.const 4.70197740328915e-38
-  call $~lib/math/NativeMathf.sin
+  call $~lib/util/math/sin32
   f32.const 4.70197740328915e-38
   f32.const 0
   call $std/math/check<f32>
@@ -48950,13 +45897,13 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3466
+   i32.const 3279
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f32.const 1.1175870895385742e-08
-  call $~lib/math/NativeMathf.sin
+  call $~lib/util/math/sin32
   f32.const 1.1175870895385742e-08
   f32.const 2.6193447411060333e-10
   call $std/math/check<f32>
@@ -48964,13 +45911,13 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3467
+   i32.const 3280
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f32.const 1.4901161193847656e-08
-  call $~lib/math/NativeMathf.sin
+  call $~lib/util/math/sin32
   f32.const 1.4901161193847656e-08
   f32.const 3.1044086745701804e-10
   call $std/math/check<f32>
@@ -48978,13 +45925,13 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3468
+   i32.const 3281
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f32.const 0.000244140625
-  call $~lib/math/NativeMathf.sin
+  call $~lib/util/math/sin32
   f32.const 0.000244140625
   f32.const 0.0833333358168602
   call $std/math/check<f32>
@@ -48992,13 +45939,13 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3469
+   i32.const 3282
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f32.const 0.0003662109375
-  call $~lib/math/NativeMathf.sin
+  call $~lib/util/math/sin32
   f32.const 0.0003662109375
   f32.const 0.28125
   call $std/math/check<f32>
@@ -49006,13 +45953,13 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3470
+   i32.const 3283
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f32.const -1.175494490952134e-38
-  call $~lib/math/NativeMathf.sin
+  call $~lib/util/math/sin32
   f32.const -1.175494490952134e-38
   f32.const 0
   call $std/math/check<f32>
@@ -49020,13 +45967,13 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3471
+   i32.const 3284
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f32.const -1.1754946310819804e-38
-  call $~lib/math/NativeMathf.sin
+  call $~lib/util/math/sin32
   f32.const -1.1754946310819804e-38
   f32.const 0
   call $std/math/check<f32>
@@ -49034,13 +45981,13 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3472
+   i32.const 3285
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f32.const -2.3509880009953429e-38
-  call $~lib/math/NativeMathf.sin
+  call $~lib/util/math/sin32
   f32.const -2.3509880009953429e-38
   f32.const 0
   call $std/math/check<f32>
@@ -49048,13 +45995,13 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3473
+   i32.const 3286
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f32.const -2.350988701644575e-38
-  call $~lib/math/NativeMathf.sin
+  call $~lib/util/math/sin32
   f32.const -2.350988701644575e-38
   f32.const 0
   call $std/math/check<f32>
@@ -49062,13 +46009,13 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3474
+   i32.const 3287
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f32.const -2.3509895424236536e-38
-  call $~lib/math/NativeMathf.sin
+  call $~lib/util/math/sin32
   f32.const -2.3509895424236536e-38
   f32.const 0
   call $std/math/check<f32>
@@ -49076,13 +46023,13 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3475
+   i32.const 3288
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f32.const -4.70197740328915e-38
-  call $~lib/math/NativeMathf.sin
+  call $~lib/util/math/sin32
   f32.const -4.70197740328915e-38
   f32.const 0
   call $std/math/check<f32>
@@ -49090,13 +46037,13 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3476
+   i32.const 3289
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f32.const -1.1175870895385742e-08
-  call $~lib/math/NativeMathf.sin
+  call $~lib/util/math/sin32
   f32.const -1.1175870895385742e-08
   f32.const -2.6193447411060333e-10
   call $std/math/check<f32>
@@ -49104,13 +46051,13 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3477
+   i32.const 3290
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f32.const -1.4901161193847656e-08
-  call $~lib/math/NativeMathf.sin
+  call $~lib/util/math/sin32
   f32.const -1.4901161193847656e-08
   f32.const -3.1044086745701804e-10
   call $std/math/check<f32>
@@ -49118,13 +46065,13 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3478
+   i32.const 3291
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f32.const -0.000244140625
-  call $~lib/math/NativeMathf.sin
+  call $~lib/util/math/sin32
   f32.const -0.000244140625
   f32.const -0.0833333358168602
   call $std/math/check<f32>
@@ -49132,13 +46079,13 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3479
+   i32.const 3292
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f32.const -0.0003662109375
-  call $~lib/math/NativeMathf.sin
+  call $~lib/util/math/sin32
   f32.const -0.0003662109375
   f32.const -0.28125
   call $std/math/check<f32>
@@ -49146,13 +46093,13 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3480
+   i32.const 3293
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f32.const 2.802596928649634e-45
-  call $~lib/math/NativeMathf.sin
+  call $~lib/util/math/sin32
   f32.const 2.802596928649634e-45
   f32.const 0
   call $std/math/check<f32>
@@ -49160,13 +46107,13 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3481
+   i32.const 3294
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f32.const 1.2611686178923354e-44
-  call $~lib/math/NativeMathf.sin
+  call $~lib/util/math/sin32
   f32.const 1.2611686178923354e-44
   f32.const 0
   call $std/math/check<f32>
@@ -49174,13 +46121,13 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3482
+   i32.const 3295
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f32.const 2.938735877055719e-39
-  call $~lib/math/NativeMathf.sin
+  call $~lib/util/math/sin32
   f32.const 2.938735877055719e-39
   f32.const 0
   call $std/math/check<f32>
@@ -49188,13 +46135,13 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3483
+   i32.const 3296
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f32.const 5.877471754111438e-39
-  call $~lib/math/NativeMathf.sin
+  call $~lib/util/math/sin32
   f32.const 5.877471754111438e-39
   f32.const 0
   call $std/math/check<f32>
@@ -49202,13 +46149,13 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3484
+   i32.const 3297
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f32.const 1.1754940705625946e-38
-  call $~lib/math/NativeMathf.sin
+  call $~lib/util/math/sin32
   f32.const 1.1754940705625946e-38
   f32.const 0
   call $std/math/check<f32>
@@ -49216,13 +46163,13 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3485
+   i32.const 3298
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f32.const 1.1754942106924411e-38
-  call $~lib/math/NativeMathf.sin
+  call $~lib/util/math/sin32
   f32.const 1.1754942106924411e-38
   f32.const 0
   call $std/math/check<f32>
@@ -49230,13 +46177,13 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3486
+   i32.const 3299
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f32.const -2.802596928649634e-45
-  call $~lib/math/NativeMathf.sin
+  call $~lib/util/math/sin32
   f32.const -2.802596928649634e-45
   f32.const 0
   call $std/math/check<f32>
@@ -49244,13 +46191,13 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3487
+   i32.const 3300
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f32.const -1.2611686178923354e-44
-  call $~lib/math/NativeMathf.sin
+  call $~lib/util/math/sin32
   f32.const -1.2611686178923354e-44
   f32.const 0
   call $std/math/check<f32>
@@ -49258,13 +46205,13 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3488
+   i32.const 3301
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f32.const -2.938735877055719e-39
-  call $~lib/math/NativeMathf.sin
+  call $~lib/util/math/sin32
   f32.const -2.938735877055719e-39
   f32.const 0
   call $std/math/check<f32>
@@ -49272,13 +46219,13 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3489
+   i32.const 3302
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f32.const -5.877471754111438e-39
-  call $~lib/math/NativeMathf.sin
+  call $~lib/util/math/sin32
   f32.const -5.877471754111438e-39
   f32.const 0
   call $std/math/check<f32>
@@ -49286,13 +46233,13 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3490
+   i32.const 3303
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f32.const -1.1754940705625946e-38
-  call $~lib/math/NativeMathf.sin
+  call $~lib/util/math/sin32
   f32.const -1.1754940705625946e-38
   f32.const 0
   call $std/math/check<f32>
@@ -49300,13 +46247,13 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3491
+   i32.const 3304
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f32.const -1.1754942106924411e-38
-  call $~lib/math/NativeMathf.sin
+  call $~lib/util/math/sin32
   f32.const -1.1754942106924411e-38
   f32.const 0
   call $std/math/check<f32>
@@ -49314,13 +46261,13 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3492
+   i32.const 3305
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f32.const 255.99993896484375
-  call $~lib/math/NativeMathf.sin
+  call $~lib/util/math/sin32
   f32.const -0.9992055892944336
   f32.const 0
   call $std/math/check<f32>
@@ -49328,13 +46275,13 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3495
+   i32.const 3308
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f32.const 5033165
-  call $~lib/math/NativeMathf.sin
+  call $~lib/util/math/sin32
   f32.const 0.5312945246696472
   f32.const 0
   call $std/math/check<f32>
@@ -49342,13 +46289,13 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3496
+   i32.const 3309
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f32.const 421657440
-  call $~lib/math/NativeMathf.sin
+  call $~lib/util/math/sin32
   f32.const -0.7397398948669434
   f32.const 0
   call $std/math/check<f32>
@@ -49356,13 +46303,13 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3497
+   i32.const 3310
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f32.const 2147483392
-  call $~lib/math/NativeMathf.sin
+  call $~lib/util/math/sin32
   f32.const 0.2762770354747772
   f32.const 0
   call $std/math/check<f32>
@@ -49370,13 +46317,13 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3498
+   i32.const 3311
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f32.const 68719476736
-  call $~lib/math/NativeMathf.sin
+  call $~lib/util/math/sin32
   f32.const 0.9855440855026245
   f32.const 0
   call $std/math/check<f32>
@@ -49384,13 +46331,13 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3499
+   i32.const 3312
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f32.const 549755813888
-  call $~lib/math/NativeMathf.sin
+  call $~lib/util/math/sin32
   f32.const -0.9782648086547852
   f32.const 0
   call $std/math/check<f32>
@@ -49398,13 +46345,13 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3500
+   i32.const 3313
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f32.const 3402823466385288598117041e14
-  call $~lib/math/NativeMathf.sin
+  call $~lib/util/math/sin32
   f32.const -0.5218765139579773
   f32.const 0
   call $std/math/check<f32>
@@ -49412,13 +46359,13 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3501
+   i32.const 3314
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f32.const -255.99993896484375
-  call $~lib/math/NativeMathf.sin
+  call $~lib/util/math/sin32
   f32.const 0.9992055892944336
   f32.const 0
   call $std/math/check<f32>
@@ -49426,13 +46373,13 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3502
+   i32.const 3315
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f32.const -5033165
-  call $~lib/math/NativeMathf.sin
+  call $~lib/util/math/sin32
   f32.const -0.5312945246696472
   f32.const 0
   call $std/math/check<f32>
@@ -49440,13 +46387,13 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3503
+   i32.const 3316
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f32.const -421657440
-  call $~lib/math/NativeMathf.sin
+  call $~lib/util/math/sin32
   f32.const 0.7397398948669434
   f32.const 0
   call $std/math/check<f32>
@@ -49454,13 +46401,13 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3504
+   i32.const 3317
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f32.const -2147483392
-  call $~lib/math/NativeMathf.sin
+  call $~lib/util/math/sin32
   f32.const -0.2762770354747772
   f32.const 0
   call $std/math/check<f32>
@@ -49468,13 +46415,13 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3505
+   i32.const 3318
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f32.const -68719476736
-  call $~lib/math/NativeMathf.sin
+  call $~lib/util/math/sin32
   f32.const -0.9855440855026245
   f32.const 0
   call $std/math/check<f32>
@@ -49482,13 +46429,13 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3506
+   i32.const 3319
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f32.const -549755813888
-  call $~lib/math/NativeMathf.sin
+  call $~lib/util/math/sin32
   f32.const 0.9782648086547852
   f32.const 0
   call $std/math/check<f32>
@@ -49496,13 +46443,13 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3507
+   i32.const 3320
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f32.const -3402823466385288598117041e14
-  call $~lib/math/NativeMathf.sin
+  call $~lib/util/math/sin32
   f32.const 0.5218765139579773
   f32.const 0
   call $std/math/check<f32>
@@ -49510,7 +46457,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3508
+   i32.const 3321
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -49523,7 +46470,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3520
+   i32.const 3333
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -49536,7 +46483,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3521
+   i32.const 3334
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -49549,7 +46496,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3522
+   i32.const 3335
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -49562,7 +46509,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3523
+   i32.const 3336
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -49575,7 +46522,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3524
+   i32.const 3337
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -49588,7 +46535,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3525
+   i32.const 3338
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -49601,7 +46548,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3526
+   i32.const 3339
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -49614,7 +46561,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3527
+   i32.const 3340
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -49627,7 +46574,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3528
+   i32.const 3341
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -49640,7 +46587,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3529
+   i32.const 3342
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -49653,7 +46600,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3532
+   i32.const 3345
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -49666,7 +46613,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3533
+   i32.const 3346
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -49679,7 +46626,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3534
+   i32.const 3347
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -49692,7 +46639,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3535
+   i32.const 3348
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -49705,7 +46652,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3536
+   i32.const 3349
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -49718,7 +46665,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3545
+   i32.const 3358
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -49731,7 +46678,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3546
+   i32.const 3359
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -49744,7 +46691,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3547
+   i32.const 3360
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -49757,7 +46704,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3548
+   i32.const 3361
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -49770,7 +46717,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3549
+   i32.const 3362
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -49783,7 +46730,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3550
+   i32.const 3363
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -49796,7 +46743,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3551
+   i32.const 3364
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -49809,7 +46756,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3552
+   i32.const 3365
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -49822,7 +46769,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3553
+   i32.const 3366
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -49835,7 +46782,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3554
+   i32.const 3367
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -49848,7 +46795,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3557
+   i32.const 3370
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -49861,7 +46808,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3558
+   i32.const 3371
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -49874,7 +46821,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3559
+   i32.const 3372
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -49887,7 +46834,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3560
+   i32.const 3373
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -49900,7 +46847,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3561
+   i32.const 3374
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -49922,7 +46869,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3573
+   i32.const 3386
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -49944,7 +46891,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3574
+   i32.const 3387
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -49966,7 +46913,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3575
+   i32.const 3388
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -49988,7 +46935,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3576
+   i32.const 3389
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -50010,7 +46957,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3577
+   i32.const 3390
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -50032,7 +46979,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3578
+   i32.const 3391
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -50054,7 +47001,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3579
+   i32.const 3392
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -50076,7 +47023,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3580
+   i32.const 3393
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -50098,7 +47045,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3581
+   i32.const 3394
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -50120,7 +47067,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3582
+   i32.const 3395
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -50142,7 +47089,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3585
+   i32.const 3398
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -50164,7 +47111,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3586
+   i32.const 3399
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -50186,7 +47133,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3587
+   i32.const 3400
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -50208,7 +47155,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3588
+   i32.const 3401
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -50230,7 +47177,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3589
+   i32.const 3402
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -50252,7 +47199,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3590
+   i32.const 3403
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -50274,7 +47221,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3591
+   i32.const 3404
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -50296,7 +47243,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3592
+   i32.const 3405
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -50318,7 +47265,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3593
+   i32.const 3406
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -50340,7 +47287,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3594
+   i32.const 3407
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -50362,7 +47309,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3595
+   i32.const 3408
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -50384,7 +47331,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3596
+   i32.const 3409
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -50406,7 +47353,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3597
+   i32.const 3410
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -50428,7 +47375,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3598
+   i32.const 3411
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -50450,7 +47397,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3599
+   i32.const 3412
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -50472,7 +47419,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3600
+   i32.const 3413
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -50494,7 +47441,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3601
+   i32.const 3414
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -50516,7 +47463,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3602
+   i32.const 3415
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -50538,7 +47485,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3603
+   i32.const 3416
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -50560,7 +47507,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3604
+   i32.const 3417
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -50582,7 +47529,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3605
+   i32.const 3418
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -50604,7 +47551,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3606
+   i32.const 3419
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -50626,7 +47573,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3607
+   i32.const 3420
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -50648,7 +47595,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3608
+   i32.const 3421
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -50670,7 +47617,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3609
+   i32.const 3422
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -50692,7 +47639,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3610
+   i32.const 3423
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -50714,7 +47661,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3611
+   i32.const 3424
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -50736,7 +47683,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3612
+   i32.const 3425
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -50758,7 +47705,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3613
+   i32.const 3426
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -50780,7 +47727,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3614
+   i32.const 3427
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -50802,7 +47749,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3615
+   i32.const 3428
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -50824,7 +47771,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3616
+   i32.const 3429
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -50846,7 +47793,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3617
+   i32.const 3430
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -50868,7 +47815,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3618
+   i32.const 3431
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -50890,7 +47837,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3619
+   i32.const 3432
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -50912,7 +47859,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3620
+   i32.const 3433
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -50934,7 +47881,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3621
+   i32.const 3434
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -50956,7 +47903,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3622
+   i32.const 3435
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -50978,7 +47925,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3623
+   i32.const 3436
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -51000,7 +47947,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3624
+   i32.const 3437
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -51022,7 +47969,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3625
+   i32.const 3438
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -51044,7 +47991,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3626
+   i32.const 3439
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -51066,7 +48013,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3627
+   i32.const 3440
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -51088,7 +48035,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3628
+   i32.const 3441
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -51110,7 +48057,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3629
+   i32.const 3442
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -51132,7 +48079,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3630
+   i32.const 3443
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -51154,7 +48101,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3631
+   i32.const 3444
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -51176,7 +48123,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3632
+   i32.const 3445
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -51198,7 +48145,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3633
+   i32.const 3446
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -51220,7 +48167,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3634
+   i32.const 3447
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -51242,7 +48189,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3635
+   i32.const 3448
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -51264,7 +48211,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3636
+   i32.const 3449
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -51286,7 +48233,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3637
+   i32.const 3450
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -51308,7 +48255,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3638
+   i32.const 3451
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -51330,7 +48277,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3639
+   i32.const 3452
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -51352,7 +48299,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3640
+   i32.const 3453
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -51374,7 +48321,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3641
+   i32.const 3454
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -51396,7 +48343,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3642
+   i32.const 3455
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -51418,7 +48365,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3643
+   i32.const 3456
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -51440,7 +48387,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3644
+   i32.const 3457
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -51462,7 +48409,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3645
+   i32.const 3458
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -51484,7 +48431,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3646
+   i32.const 3459
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -51506,7 +48453,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3647
+   i32.const 3460
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -51528,7 +48475,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3648
+   i32.const 3461
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -51550,7 +48497,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3649
+   i32.const 3462
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -51572,7 +48519,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3650
+   i32.const 3463
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -51594,7 +48541,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3651
+   i32.const 3464
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -51616,7 +48563,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3652
+   i32.const 3465
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -51638,7 +48585,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3653
+   i32.const 3466
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -51660,7 +48607,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3654
+   i32.const 3467
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -51682,7 +48629,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3655
+   i32.const 3468
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -51704,7 +48651,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3656
+   i32.const 3469
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -51726,7 +48673,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3657
+   i32.const 3470
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -51748,7 +48695,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3658
+   i32.const 3471
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -51761,7 +48708,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3667
+   i32.const 3480
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -51774,7 +48721,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3668
+   i32.const 3481
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -51787,7 +48734,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3669
+   i32.const 3482
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -51800,7 +48747,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3670
+   i32.const 3483
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -51813,7 +48760,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3671
+   i32.const 3484
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -51826,7 +48773,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3672
+   i32.const 3485
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -51839,7 +48786,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3673
+   i32.const 3486
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -51852,7 +48799,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3674
+   i32.const 3487
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -51865,7 +48812,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3675
+   i32.const 3488
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -51878,7 +48825,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3676
+   i32.const 3489
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -51891,7 +48838,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3679
+   i32.const 3492
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -51904,7 +48851,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3680
+   i32.const 3493
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -51917,7 +48864,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3681
+   i32.const 3494
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -51930,7 +48877,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3682
+   i32.const 3495
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -51943,7 +48890,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3683
+   i32.const 3496
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -51956,7 +48903,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3684
+   i32.const 3497
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -51969,7 +48916,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3685
+   i32.const 3498
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -51982,7 +48929,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3686
+   i32.const 3499
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -51995,7 +48942,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3687
+   i32.const 3500
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -52008,7 +48955,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3688
+   i32.const 3501
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -52021,7 +48968,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3689
+   i32.const 3502
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -52034,7 +48981,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3690
+   i32.const 3503
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -52047,7 +48994,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3691
+   i32.const 3504
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -52060,7 +49007,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3692
+   i32.const 3505
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -52073,7 +49020,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3693
+   i32.const 3506
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -52086,7 +49033,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3694
+   i32.const 3507
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -52099,7 +49046,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3695
+   i32.const 3508
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -52112,7 +49059,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3696
+   i32.const 3509
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -52125,7 +49072,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3697
+   i32.const 3510
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -52138,7 +49085,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3698
+   i32.const 3511
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -52151,7 +49098,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3699
+   i32.const 3512
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -52164,13 +49111,13 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3700
+   i32.const 3513
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f64.const -8.06684839057968
-  call $~lib/math/NativeMath.tan
+  call $~lib/util/math/tan64
   f64.const 4.626603542401633
   f64.const -0.2727603316307068
   call $std/math/check<f64>
@@ -52187,13 +49134,13 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3712
+   i32.const 3525
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f64.const 4.345239849338305
-  call $~lib/math/NativeMath.tan
+  call $~lib/util/math/tan64
   f64.const 2.600191705822202
   f64.const 0.2651003301143646
   call $std/math/check<f64>
@@ -52210,13 +49157,13 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3713
+   i32.const 3526
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f64.const -8.38143342755525
-  call $~lib/math/NativeMath.tan
+  call $~lib/util/math/tan64
   f64.const 1.7167408328741052
   f64.const -0.24687519669532776
   call $std/math/check<f64>
@@ -52233,13 +49180,13 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3714
+   i32.const 3527
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f64.const -6.531673581913484
-  call $~lib/math/NativeMath.tan
+  call $~lib/util/math/tan64
   f64.const -0.2537322523453725
   f64.const -0.4679703712463379
   call $std/math/check<f64>
@@ -52256,13 +49203,13 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3715
+   i32.const 3528
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f64.const 9.267056966972586
-  call $~lib/math/NativeMath.tan
+  call $~lib/util/math/tan64
   f64.const -0.15904195727191958
   f64.const -0.06704077869653702
   call $std/math/check<f64>
@@ -52279,13 +49226,13 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3716
+   i32.const 3529
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f64.const 0.6619858980995045
-  call $~lib/math/NativeMath.tan
+  call $~lib/util/math/tan64
   f64.const 0.7792919106910434
   f64.const -0.038056135177612305
   call $std/math/check<f64>
@@ -52302,13 +49249,13 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3717
+   i32.const 3530
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f64.const -0.4066039223853553
-  call $~lib/math/NativeMath.tan
+  call $~lib/util/math/tan64
   f64.const -0.43059952879543656
   f64.const -0.09242714196443558
   call $std/math/check<f64>
@@ -52325,13 +49272,13 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3718
+   i32.const 3531
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f64.const 0.5617597462207241
-  call $~lib/math/NativeMath.tan
+  call $~lib/util/math/tan64
   f64.const 0.62940368731874
   f64.const -0.321913480758667
   call $std/math/check<f64>
@@ -52348,13 +49295,13 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3719
+   i32.const 3532
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f64.const 0.7741522965913037
-  call $~lib/math/NativeMath.tan
+  call $~lib/util/math/tan64
   f64.const 0.9777574652949645
   f64.const -0.1966651827096939
   call $std/math/check<f64>
@@ -52371,13 +49318,13 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3720
+   i32.const 3533
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f64.const -0.6787637026394024
-  call $~lib/math/NativeMath.tan
+  call $~lib/util/math/tan64
   f64.const -0.8066186630209123
   f64.const -0.067665696144104
   call $std/math/check<f64>
@@ -52394,13 +49341,13 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3721
+   i32.const 3534
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f64.const 9.313225746154785e-10
-  call $~lib/math/NativeMath.tan
+  call $~lib/util/math/tan64
   f64.const 9.313225746154785e-10
   f64.const -1.3020833721384406e-03
   call $std/math/check<f64>
@@ -52417,13 +49364,13 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3724
+   i32.const 3537
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f64.const -9.313225746154785e-10
-  call $~lib/math/NativeMath.tan
+  call $~lib/util/math/tan64
   f64.const -9.313225746154785e-10
   f64.const 1.3020833721384406e-03
   call $std/math/check<f64>
@@ -52440,13 +49387,13 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3725
+   i32.const 3538
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f64.const 2.2250738585072014e-308
-  call $~lib/math/NativeMath.tan
+  call $~lib/util/math/tan64
   f64.const 2.2250738585072014e-308
   f64.const 0
   call $std/math/check<f64>
@@ -52463,13 +49410,13 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3726
+   i32.const 3539
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f64.const -2.2250738585072014e-308
-  call $~lib/math/NativeMath.tan
+  call $~lib/util/math/tan64
   f64.const -2.2250738585072014e-308
   f64.const 0
   call $std/math/check<f64>
@@ -52486,13 +49433,13 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3727
+   i32.const 3540
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f64.const 5e-324
-  call $~lib/math/NativeMath.tan
+  call $~lib/util/math/tan64
   f64.const 5e-324
   f64.const 0
   call $std/math/check<f64>
@@ -52509,13 +49456,13 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3728
+   i32.const 3541
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f64.const -5e-324
-  call $~lib/math/NativeMath.tan
+  call $~lib/util/math/tan64
   f64.const -5e-324
   f64.const 0
   call $std/math/check<f64>
@@ -52532,13 +49479,13 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3729
+   i32.const 3542
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f64.const 0
-  call $~lib/math/NativeMath.tan
+  call $~lib/util/math/tan64
   f64.const 0
   f64.const 0
   call $std/math/check<f64>
@@ -52555,13 +49502,13 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3730
+   i32.const 3543
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f64.const -0
-  call $~lib/math/NativeMath.tan
+  call $~lib/util/math/tan64
   f64.const -0
   f64.const 0
   call $std/math/check<f64>
@@ -52578,13 +49525,13 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3731
+   i32.const 3544
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f64.const 0.7853981633974483
-  call $~lib/math/NativeMath.tan
+  call $~lib/util/math/tan64
   f64.const 0.9999999999999999
   f64.const -0.4484681189060211
   call $std/math/check<f64>
@@ -52601,13 +49548,13 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3732
+   i32.const 3545
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f64.const -0.7853981633974483
-  call $~lib/math/NativeMath.tan
+  call $~lib/util/math/tan64
   f64.const -0.9999999999999999
   f64.const 0.4484681189060211
   call $std/math/check<f64>
@@ -52624,13 +49571,13 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3733
+   i32.const 3546
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f64.const 2.225073858507202e-308
-  call $~lib/math/NativeMath.tan
+  call $~lib/util/math/tan64
   f64.const 2.225073858507202e-308
   f64.const 0
   call $std/math/check<f64>
@@ -52647,13 +49594,13 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3734
+   i32.const 3547
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f64.const 2.2250738585072024e-308
-  call $~lib/math/NativeMath.tan
+  call $~lib/util/math/tan64
   f64.const 2.2250738585072024e-308
   f64.const 0
   call $std/math/check<f64>
@@ -52670,13 +49617,13 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3735
+   i32.const 3548
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f64.const 4.4501477170144003e-308
-  call $~lib/math/NativeMath.tan
+  call $~lib/util/math/tan64
   f64.const 4.4501477170144003e-308
   f64.const 0
   call $std/math/check<f64>
@@ -52693,13 +49640,13 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3736
+   i32.const 3549
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f64.const 4.450147717014403e-308
-  call $~lib/math/NativeMath.tan
+  call $~lib/util/math/tan64
   f64.const 4.450147717014403e-308
   f64.const 0
   call $std/math/check<f64>
@@ -52716,13 +49663,13 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3737
+   i32.const 3550
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f64.const 4.450147717014406e-308
-  call $~lib/math/NativeMath.tan
+  call $~lib/util/math/tan64
   f64.const 4.450147717014406e-308
   f64.const 0
   call $std/math/check<f64>
@@ -52739,13 +49686,13 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3738
+   i32.const 3551
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f64.const 8.900295434028806e-308
-  call $~lib/math/NativeMath.tan
+  call $~lib/util/math/tan64
   f64.const 8.900295434028806e-308
   f64.const 0
   call $std/math/check<f64>
@@ -52762,13 +49709,13 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3739
+   i32.const 3552
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f64.const 1.1175870895385742e-08
-  call $~lib/math/NativeMath.tan
+  call $~lib/util/math/tan64
   f64.const 1.1175870895385742e-08
   f64.const -0.28125
   call $std/math/check<f64>
@@ -52785,13 +49732,13 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3740
+   i32.const 3553
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f64.const 1.4901161193847656e-08
-  call $~lib/math/NativeMath.tan
+  call $~lib/util/math/tan64
   f64.const 1.4901161193847656e-08
   f64.const -0.3333333432674408
   call $std/math/check<f64>
@@ -52808,13 +49755,13 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3741
+   i32.const 3554
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f64.const -2.225073858507202e-308
-  call $~lib/math/NativeMath.tan
+  call $~lib/util/math/tan64
   f64.const -2.225073858507202e-308
   f64.const 0
   call $std/math/check<f64>
@@ -52831,13 +49778,13 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3742
+   i32.const 3555
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f64.const -2.2250738585072024e-308
-  call $~lib/math/NativeMath.tan
+  call $~lib/util/math/tan64
   f64.const -2.2250738585072024e-308
   f64.const 0
   call $std/math/check<f64>
@@ -52854,13 +49801,13 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3743
+   i32.const 3556
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f64.const -4.4501477170144003e-308
-  call $~lib/math/NativeMath.tan
+  call $~lib/util/math/tan64
   f64.const -4.4501477170144003e-308
   f64.const 0
   call $std/math/check<f64>
@@ -52877,13 +49824,13 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3744
+   i32.const 3557
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f64.const -4.450147717014403e-308
-  call $~lib/math/NativeMath.tan
+  call $~lib/util/math/tan64
   f64.const -4.450147717014403e-308
   f64.const 0
   call $std/math/check<f64>
@@ -52900,13 +49847,13 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3745
+   i32.const 3558
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f64.const -4.450147717014406e-308
-  call $~lib/math/NativeMath.tan
+  call $~lib/util/math/tan64
   f64.const -4.450147717014406e-308
   f64.const 0
   call $std/math/check<f64>
@@ -52923,13 +49870,13 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3746
+   i32.const 3559
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f64.const -8.900295434028806e-308
-  call $~lib/math/NativeMath.tan
+  call $~lib/util/math/tan64
   f64.const -8.900295434028806e-308
   f64.const 0
   call $std/math/check<f64>
@@ -52946,13 +49893,13 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3747
+   i32.const 3560
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f64.const -1.1175870895385742e-08
-  call $~lib/math/NativeMath.tan
+  call $~lib/util/math/tan64
   f64.const -1.1175870895385742e-08
   f64.const 0.28125
   call $std/math/check<f64>
@@ -52969,13 +49916,13 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3748
+   i32.const 3561
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f64.const -1.4901161193847656e-08
-  call $~lib/math/NativeMath.tan
+  call $~lib/util/math/tan64
   f64.const -1.4901161193847656e-08
   f64.const 0.3333333432674408
   call $std/math/check<f64>
@@ -52992,13 +49939,13 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3749
+   i32.const 3562
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f64.const 1e-323
-  call $~lib/math/NativeMath.tan
+  call $~lib/util/math/tan64
   f64.const 1e-323
   f64.const 0
   call $std/math/check<f64>
@@ -53015,13 +49962,13 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3750
+   i32.const 3563
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f64.const 4.4e-323
-  call $~lib/math/NativeMath.tan
+  call $~lib/util/math/tan64
   f64.const 4.4e-323
   f64.const 0
   call $std/math/check<f64>
@@ -53038,13 +49985,13 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3751
+   i32.const 3564
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f64.const 5.562684646268003e-309
-  call $~lib/math/NativeMath.tan
+  call $~lib/util/math/tan64
   f64.const 5.562684646268003e-309
   f64.const 0
   call $std/math/check<f64>
@@ -53061,13 +50008,13 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3752
+   i32.const 3565
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f64.const 1.1125369292536007e-308
-  call $~lib/math/NativeMath.tan
+  call $~lib/util/math/tan64
   f64.const 1.1125369292536007e-308
   f64.const 0
   call $std/math/check<f64>
@@ -53084,13 +50031,13 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3753
+   i32.const 3566
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f64.const 2.2250738585072004e-308
-  call $~lib/math/NativeMath.tan
+  call $~lib/util/math/tan64
   f64.const 2.2250738585072004e-308
   f64.const 0
   call $std/math/check<f64>
@@ -53107,13 +50054,13 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3754
+   i32.const 3567
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f64.const 2.225073858507201e-308
-  call $~lib/math/NativeMath.tan
+  call $~lib/util/math/tan64
   f64.const 2.225073858507201e-308
   f64.const 0
   call $std/math/check<f64>
@@ -53130,13 +50077,13 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3755
+   i32.const 3568
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f64.const -1e-323
-  call $~lib/math/NativeMath.tan
+  call $~lib/util/math/tan64
   f64.const -1e-323
   f64.const 0
   call $std/math/check<f64>
@@ -53153,13 +50100,13 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3756
+   i32.const 3569
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f64.const -4.4e-323
-  call $~lib/math/NativeMath.tan
+  call $~lib/util/math/tan64
   f64.const -4.4e-323
   f64.const 0
   call $std/math/check<f64>
@@ -53176,13 +50123,13 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3757
+   i32.const 3570
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f64.const -5.562684646268003e-309
-  call $~lib/math/NativeMath.tan
+  call $~lib/util/math/tan64
   f64.const -5.562684646268003e-309
   f64.const 0
   call $std/math/check<f64>
@@ -53199,13 +50146,13 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3758
+   i32.const 3571
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f64.const -1.1125369292536007e-308
-  call $~lib/math/NativeMath.tan
+  call $~lib/util/math/tan64
   f64.const -1.1125369292536007e-308
   f64.const 0
   call $std/math/check<f64>
@@ -53222,13 +50169,13 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3759
+   i32.const 3572
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f64.const -2.2250738585072004e-308
-  call $~lib/math/NativeMath.tan
+  call $~lib/util/math/tan64
   f64.const -2.2250738585072004e-308
   f64.const 0
   call $std/math/check<f64>
@@ -53245,13 +50192,13 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3760
+   i32.const 3573
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f64.const -2.225073858507201e-308
-  call $~lib/math/NativeMath.tan
+  call $~lib/util/math/tan64
   f64.const -2.225073858507201e-308
   f64.const 0
   call $std/math/check<f64>
@@ -53268,221 +50215,221 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3761
+   i32.const 3574
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f64.const 2.3283064365386963e-10
-  call $~lib/math/NativeMath.tan
+  call $~lib/util/math/tan64
   f64.const 2.3283064365386963e-10
   call $~lib/bindings/dom/Math.tan
   f64.ne
   if
    i32.const 0
    i32.const 1056
-   i32.const 3764
+   i32.const 3577
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f64.const -2.3283064365386963e-10
-  call $~lib/math/NativeMath.tan
+  call $~lib/util/math/tan64
   f64.const -2.3283064365386963e-10
   call $~lib/bindings/dom/Math.tan
   f64.ne
   if
    i32.const 0
    i32.const 1056
-   i32.const 3765
+   i32.const 3578
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f64.const 0.6875
-  call $~lib/math/NativeMath.tan
+  call $~lib/util/math/tan64
   f64.const 0.6875
   call $~lib/bindings/dom/Math.tan
   f64.ne
   if
    i32.const 0
    i32.const 1056
-   i32.const 3766
+   i32.const 3579
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f64.const -0.6875
-  call $~lib/math/NativeMath.tan
+  call $~lib/util/math/tan64
   f64.const -0.6875
   call $~lib/bindings/dom/Math.tan
   f64.ne
   if
    i32.const 0
    i32.const 1056
-   i32.const 3767
+   i32.const 3580
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f64.const 0.39269908169872414
-  call $~lib/math/NativeMath.tan
+  call $~lib/util/math/tan64
   f64.const 0.39269908169872414
   call $~lib/bindings/dom/Math.tan
   f64.ne
   if
    i32.const 0
    i32.const 1056
-   i32.const 3768
+   i32.const 3581
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f64.const 0.6743358
-  call $~lib/math/NativeMath.tan
+  call $~lib/util/math/tan64
   f64.const 0.6743358
   call $~lib/bindings/dom/Math.tan
   f64.ne
   if
    i32.const 0
    i32.const 1056
-   i32.const 3769
+   i32.const 3582
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f64.const 3.725290298461914e-09
-  call $~lib/math/NativeMath.tan
+  call $~lib/util/math/tan64
   f64.const 3.725290298461914e-09
   call $~lib/bindings/dom/Math.tan
   f64.ne
   if
    i32.const 0
    i32.const 1056
-   i32.const 3770
+   i32.const 3583
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f64.const 1.5707963267948966
-  call $~lib/math/NativeMath.tan
+  call $~lib/util/math/tan64
   f64.const 1.5707963267948966
   call $~lib/bindings/dom/Math.tan
   f64.ne
   if
    i32.const 0
    i32.const 1056
-   i32.const 3771
+   i32.const 3584
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f64.const 0.5
-  call $~lib/math/NativeMath.tan
+  call $~lib/util/math/tan64
   f64.const 0.5
   call $~lib/bindings/dom/Math.tan
   f64.ne
   if
    i32.const 0
    i32.const 1056
-   i32.const 3773
+   i32.const 3586
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f64.const 1.107148717794091
-  call $~lib/math/NativeMath.tan
+  call $~lib/util/math/tan64
   f64.const 1.107148717794091
   call $~lib/bindings/dom/Math.tan
   f64.ne
   if
    i32.const 0
    i32.const 1056
-   i32.const 3774
+   i32.const 3587
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f64.const 5.497787143782138
-  call $~lib/math/NativeMath.tan
+  call $~lib/util/math/tan64
   f64.const 5.497787143782138
   call $~lib/bindings/dom/Math.tan
   f64.ne
   if
    i32.const 0
    i32.const 1056
-   i32.const 3775
+   i32.const 3588
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f64.const 7.0685834705770345
-  call $~lib/math/NativeMath.tan
+  call $~lib/util/math/tan64
   f64.const 7.0685834705770345
   call $~lib/bindings/dom/Math.tan
   f64.ne
   if
    i32.const 0
    i32.const 1056
-   i32.const 3776
+   i32.const 3589
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f64.const 1647099.3291652855
-  call $~lib/math/NativeMath.tan
+  call $~lib/util/math/tan64
   f64.const 1647099.3291652855
   call $~lib/bindings/dom/Math.tan
   f64.ne
   if
    i32.const 0
    i32.const 1056
-   i32.const 3777
+   i32.const 3590
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f64.const 1647097.7583689587
-  call $~lib/math/NativeMath.tan
+  call $~lib/util/math/tan64
   f64.const 1647097.7583689587
   call $~lib/bindings/dom/Math.tan
   f64.ne
   if
    i32.const 0
    i32.const 1056
-   i32.const 3778
+   i32.const 3591
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f64.const 1329227995784915872903807e12
-  call $~lib/math/NativeMath.tan
+  call $~lib/util/math/tan64
   f64.const 1329227995784915872903807e12
   call $~lib/bindings/dom/Math.tan
   f64.ne
   if
    i32.const 0
    i32.const 1056
-   i32.const 3779
+   i32.const 3592
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f64.const -1329227995784915872903807e12
-  call $~lib/math/NativeMath.tan
+  call $~lib/util/math/tan64
   f64.const -1329227995784915872903807e12
   call $~lib/bindings/dom/Math.tan
   f64.ne
   if
    i32.const 0
    i32.const 1056
-   i32.const 3780
+   i32.const 3593
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f64.const 0
-  call $~lib/math/NativeMath.tan
+  call $~lib/util/math/tan64
   f64.const 0
   f64.const 0
   call $std/math/check<f64>
@@ -53499,13 +50446,13 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3783
+   i32.const 3596
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f64.const -0
-  call $~lib/math/NativeMath.tan
+  call $~lib/util/math/tan64
   f64.const -0
   f64.const 0
   call $std/math/check<f64>
@@ -53522,13 +50469,13 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3784
+   i32.const 3597
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f64.const inf
-  call $~lib/math/NativeMath.tan
+  call $~lib/util/math/tan64
   f64.const nan:0x8000000000000
   f64.const 0
   call $std/math/check<f64>
@@ -53545,13 +50492,13 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3785
+   i32.const 3598
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f64.const -inf
-  call $~lib/math/NativeMath.tan
+  call $~lib/util/math/tan64
   f64.const nan:0x8000000000000
   f64.const 0
   call $std/math/check<f64>
@@ -53568,13 +50515,13 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3786
+   i32.const 3599
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f64.const nan:0x8000000000000
-  call $~lib/math/NativeMath.tan
+  call $~lib/util/math/tan64
   f64.const nan:0x8000000000000
   f64.const 0
   call $std/math/check<f64>
@@ -53591,13 +50538,13 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3787
+   i32.const 3600
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f32.const -8.066848754882812
-  call $~lib/math/NativeMathf.tan
+  call $~lib/util/math/tan32
   f32.const 4.626595497131348
   f32.const 0.2455666959285736
   call $std/math/check<f32>
@@ -53605,13 +50552,13 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3796
+   i32.const 3609
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f32.const 4.345239639282227
-  call $~lib/math/NativeMathf.tan
+  call $~lib/util/math/tan32
   f32.const 2.6001901626586914
   f32.const 0.3652407228946686
   call $std/math/check<f32>
@@ -53619,13 +50566,13 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3797
+   i32.const 3610
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f32.const -8.381433486938477
-  call $~lib/math/NativeMathf.tan
+  call $~lib/util/math/tan32
   f32.const 1.716740608215332
   f32.const 0.08169349282979965
   call $std/math/check<f32>
@@ -53633,13 +50580,13 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3798
+   i32.const 3611
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f32.const -6.531673431396484
-  call $~lib/math/NativeMathf.tan
+  call $~lib/util/math/tan32
   f32.const -0.2537320852279663
   f32.const 0.23186513781547546
   call $std/math/check<f32>
@@ -53647,13 +50594,13 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3799
+   i32.const 3612
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f32.const 9.267057418823242
-  call $~lib/math/NativeMathf.tan
+  call $~lib/util/math/tan32
   f32.const -0.15904149413108826
   f32.const -0.009332014247775078
   call $std/math/check<f32>
@@ -53661,13 +50608,13 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3800
+   i32.const 3613
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f32.const 0.6619858741760254
-  call $~lib/math/NativeMathf.tan
+  call $~lib/util/math/tan32
   f32.const 0.7792918682098389
   f32.const -0.06759700924158096
   call $std/math/check<f32>
@@ -53675,13 +50622,13 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3801
+   i32.const 3614
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f32.const -0.40660393238067627
-  call $~lib/math/NativeMathf.tan
+  call $~lib/util/math/tan32
   f32.const -0.43059954047203064
   f32.const 0.005771996453404427
   call $std/math/check<f32>
@@ -53689,13 +50636,13 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3802
+   i32.const 3615
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f32.const 0.5617597699165344
-  call $~lib/math/NativeMathf.tan
+  call $~lib/util/math/tan32
   f32.const 0.6294037103652954
   f32.const -0.16838163137435913
   call $std/math/check<f32>
@@ -53703,13 +50650,13 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3803
+   i32.const 3616
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f32.const 0.7741522789001465
-  call $~lib/math/NativeMathf.tan
+  call $~lib/util/math/tan32
   f32.const 0.977757453918457
   f32.const 0.38969388604164124
   call $std/math/check<f32>
@@ -53717,13 +50664,13 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3804
+   i32.const 3617
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f32.const -0.6787636876106262
-  call $~lib/math/NativeMathf.tan
+  call $~lib/util/math/tan32
   f32.const -0.8066186308860779
   f32.const 0.12294059991836548
   call $std/math/check<f32>
@@ -53731,13 +50678,13 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3805
+   i32.const 3618
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f32.const 0
-  call $~lib/math/NativeMathf.tan
+  call $~lib/util/math/tan32
   f32.const 0
   f32.const 0
   call $std/math/check<f32>
@@ -53745,13 +50692,13 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3808
+   i32.const 3621
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f32.const -0
-  call $~lib/math/NativeMathf.tan
+  call $~lib/util/math/tan32
   f32.const -0
   f32.const 0
   call $std/math/check<f32>
@@ -53759,13 +50706,13 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3809
+   i32.const 3622
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f32.const inf
-  call $~lib/math/NativeMathf.tan
+  call $~lib/util/math/tan32
   f32.const nan:0x400000
   f32.const 0
   call $std/math/check<f32>
@@ -53773,13 +50720,13 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3810
+   i32.const 3623
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f32.const -inf
-  call $~lib/math/NativeMathf.tan
+  call $~lib/util/math/tan32
   f32.const nan:0x400000
   f32.const 0
   call $std/math/check<f32>
@@ -53787,13 +50734,13 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3811
+   i32.const 3624
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f32.const nan:0x400000
-  call $~lib/math/NativeMathf.tan
+  call $~lib/util/math/tan32
   f32.const nan:0x400000
   f32.const 0
   call $std/math/check<f32>
@@ -53801,13 +50748,13 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3812
+   i32.const 3625
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f32.const 1.862645149230957e-09
-  call $~lib/math/NativeMathf.tan
+  call $~lib/util/math/tan32
   f32.const 1.862645149230957e-09
   f32.const -9.701277108031814e-12
   call $std/math/check<f32>
@@ -53815,13 +50762,13 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3815
+   i32.const 3628
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f32.const -1.862645149230957e-09
-  call $~lib/math/NativeMathf.tan
+  call $~lib/util/math/tan32
   f32.const -1.862645149230957e-09
   f32.const 9.701277108031814e-12
   call $std/math/check<f32>
@@ -53829,13 +50776,13 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3816
+   i32.const 3629
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f32.const 1.1754943508222875e-38
-  call $~lib/math/NativeMathf.tan
+  call $~lib/util/math/tan32
   f32.const 1.1754943508222875e-38
   f32.const 0
   call $std/math/check<f32>
@@ -53843,13 +50790,13 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3817
+   i32.const 3630
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f32.const -1.1754943508222875e-38
-  call $~lib/math/NativeMathf.tan
+  call $~lib/util/math/tan32
   f32.const -1.1754943508222875e-38
   f32.const 0
   call $std/math/check<f32>
@@ -53857,13 +50804,13 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3818
+   i32.const 3631
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f32.const 1.401298464324817e-45
-  call $~lib/math/NativeMathf.tan
+  call $~lib/util/math/tan32
   f32.const 1.401298464324817e-45
   f32.const 0
   call $std/math/check<f32>
@@ -53871,13 +50818,13 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3819
+   i32.const 3632
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f32.const -1.401298464324817e-45
-  call $~lib/math/NativeMathf.tan
+  call $~lib/util/math/tan32
   f32.const -1.401298464324817e-45
   f32.const 0
   call $std/math/check<f32>
@@ -53885,13 +50832,13 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3820
+   i32.const 3633
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f32.const 1.175494490952134e-38
-  call $~lib/math/NativeMathf.tan
+  call $~lib/util/math/tan32
   f32.const 1.175494490952134e-38
   f32.const 0
   call $std/math/check<f32>
@@ -53899,13 +50846,13 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3821
+   i32.const 3634
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f32.const 1.1754946310819804e-38
-  call $~lib/math/NativeMathf.tan
+  call $~lib/util/math/tan32
   f32.const 1.1754946310819804e-38
   f32.const 0
   call $std/math/check<f32>
@@ -53913,13 +50860,13 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3822
+   i32.const 3635
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f32.const 2.3509880009953429e-38
-  call $~lib/math/NativeMathf.tan
+  call $~lib/util/math/tan32
   f32.const 2.3509880009953429e-38
   f32.const 0
   call $std/math/check<f32>
@@ -53927,13 +50874,13 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3823
+   i32.const 3636
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f32.const 2.350988701644575e-38
-  call $~lib/math/NativeMathf.tan
+  call $~lib/util/math/tan32
   f32.const 2.350988701644575e-38
   f32.const 0
   call $std/math/check<f32>
@@ -53941,13 +50888,13 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3824
+   i32.const 3637
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f32.const 2.3509895424236536e-38
-  call $~lib/math/NativeMathf.tan
+  call $~lib/util/math/tan32
   f32.const 2.3509895424236536e-38
   f32.const 0
   call $std/math/check<f32>
@@ -53955,13 +50902,13 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3825
+   i32.const 3638
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f32.const 4.70197740328915e-38
-  call $~lib/math/NativeMathf.tan
+  call $~lib/util/math/tan32
   f32.const 4.70197740328915e-38
   f32.const 0
   call $std/math/check<f32>
@@ -53969,13 +50916,13 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3826
+   i32.const 3639
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f32.const 1.1175870895385742e-08
-  call $~lib/math/NativeMathf.tan
+  call $~lib/util/math/tan32
   f32.const 1.1175870895385742e-08
   f32.const -5.238689482212067e-10
   call $std/math/check<f32>
@@ -53983,13 +50930,13 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3827
+   i32.const 3640
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f32.const 1.4901161193847656e-08
-  call $~lib/math/NativeMathf.tan
+  call $~lib/util/math/tan32
   f32.const 1.4901161193847656e-08
   f32.const -6.208817349140361e-10
   call $std/math/check<f32>
@@ -53997,13 +50944,13 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3828
+   i32.const 3641
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f32.const 0.000244140625
-  call $~lib/math/NativeMathf.tan
+  call $~lib/util/math/tan32
   f32.const 0.000244140625
   f32.const -0.1666666716337204
   call $std/math/check<f32>
@@ -54011,13 +50958,13 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3829
+   i32.const 3642
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f32.const -1.175494490952134e-38
-  call $~lib/math/NativeMathf.tan
+  call $~lib/util/math/tan32
   f32.const -1.175494490952134e-38
   f32.const 0
   call $std/math/check<f32>
@@ -54025,13 +50972,13 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3830
+   i32.const 3643
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f32.const -1.1754946310819804e-38
-  call $~lib/math/NativeMathf.tan
+  call $~lib/util/math/tan32
   f32.const -1.1754946310819804e-38
   f32.const 0
   call $std/math/check<f32>
@@ -54039,13 +50986,13 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3831
+   i32.const 3644
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f32.const -2.3509880009953429e-38
-  call $~lib/math/NativeMathf.tan
+  call $~lib/util/math/tan32
   f32.const -2.3509880009953429e-38
   f32.const 0
   call $std/math/check<f32>
@@ -54053,13 +51000,13 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3832
+   i32.const 3645
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f32.const 2.350988701644575e-38
-  call $~lib/math/NativeMathf.tan
+  call $~lib/util/math/tan32
   f32.const 2.350988701644575e-38
   f32.const 0
   call $std/math/check<f32>
@@ -54067,13 +51014,13 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3833
+   i32.const 3646
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f32.const -2.3509895424236536e-38
-  call $~lib/math/NativeMathf.tan
+  call $~lib/util/math/tan32
   f32.const -2.3509895424236536e-38
   f32.const 0
   call $std/math/check<f32>
@@ -54081,13 +51028,13 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3834
+   i32.const 3647
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f32.const -4.70197740328915e-38
-  call $~lib/math/NativeMathf.tan
+  call $~lib/util/math/tan32
   f32.const -4.70197740328915e-38
   f32.const 0
   call $std/math/check<f32>
@@ -54095,13 +51042,13 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3835
+   i32.const 3648
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f32.const -1.1175870895385742e-08
-  call $~lib/math/NativeMathf.tan
+  call $~lib/util/math/tan32
   f32.const -1.1175870895385742e-08
   f32.const 5.238689482212067e-10
   call $std/math/check<f32>
@@ -54109,13 +51056,13 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3836
+   i32.const 3649
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f32.const -1.4901161193847656e-08
-  call $~lib/math/NativeMathf.tan
+  call $~lib/util/math/tan32
   f32.const -1.4901161193847656e-08
   f32.const 6.208817349140361e-10
   call $std/math/check<f32>
@@ -54123,13 +51070,13 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3837
+   i32.const 3650
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f32.const -0.000244140625
-  call $~lib/math/NativeMathf.tan
+  call $~lib/util/math/tan32
   f32.const -0.000244140625
   f32.const 0.1666666716337204
   call $std/math/check<f32>
@@ -54137,13 +51084,13 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3838
+   i32.const 3651
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f32.const 2.802596928649634e-45
-  call $~lib/math/NativeMathf.tan
+  call $~lib/util/math/tan32
   f32.const 2.802596928649634e-45
   f32.const 0
   call $std/math/check<f32>
@@ -54151,13 +51098,13 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3839
+   i32.const 3652
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f32.const 1.2611686178923354e-44
-  call $~lib/math/NativeMathf.tan
+  call $~lib/util/math/tan32
   f32.const 1.2611686178923354e-44
   f32.const 0
   call $std/math/check<f32>
@@ -54165,13 +51112,13 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3840
+   i32.const 3653
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f32.const 2.938735877055719e-39
-  call $~lib/math/NativeMathf.tan
+  call $~lib/util/math/tan32
   f32.const 2.938735877055719e-39
   f32.const 0
   call $std/math/check<f32>
@@ -54179,13 +51126,13 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3841
+   i32.const 3654
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f32.const 5.877471754111438e-39
-  call $~lib/math/NativeMathf.tan
+  call $~lib/util/math/tan32
   f32.const 5.877471754111438e-39
   f32.const 0
   call $std/math/check<f32>
@@ -54193,13 +51140,13 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3842
+   i32.const 3655
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f32.const 1.1754940705625946e-38
-  call $~lib/math/NativeMathf.tan
+  call $~lib/util/math/tan32
   f32.const 1.1754940705625946e-38
   f32.const 0
   call $std/math/check<f32>
@@ -54207,13 +51154,13 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3843
+   i32.const 3656
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f32.const 1.1754942106924411e-38
-  call $~lib/math/NativeMathf.tan
+  call $~lib/util/math/tan32
   f32.const 1.1754942106924411e-38
   f32.const 0
   call $std/math/check<f32>
@@ -54221,13 +51168,13 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3844
+   i32.const 3657
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f32.const -2.802596928649634e-45
-  call $~lib/math/NativeMathf.tan
+  call $~lib/util/math/tan32
   f32.const -2.802596928649634e-45
   f32.const 0
   call $std/math/check<f32>
@@ -54235,13 +51182,13 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3845
+   i32.const 3658
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f32.const -1.2611686178923354e-44
-  call $~lib/math/NativeMathf.tan
+  call $~lib/util/math/tan32
   f32.const -1.2611686178923354e-44
   f32.const 0
   call $std/math/check<f32>
@@ -54249,13 +51196,13 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3846
+   i32.const 3659
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f32.const -2.938735877055719e-39
-  call $~lib/math/NativeMathf.tan
+  call $~lib/util/math/tan32
   f32.const -2.938735877055719e-39
   f32.const 0
   call $std/math/check<f32>
@@ -54263,13 +51210,13 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3847
+   i32.const 3660
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f32.const -5.877471754111438e-39
-  call $~lib/math/NativeMathf.tan
+  call $~lib/util/math/tan32
   f32.const -5.877471754111438e-39
   f32.const 0
   call $std/math/check<f32>
@@ -54277,13 +51224,13 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3848
+   i32.const 3661
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f32.const -1.1754940705625946e-38
-  call $~lib/math/NativeMathf.tan
+  call $~lib/util/math/tan32
   f32.const -1.1754940705625946e-38
   f32.const 0
   call $std/math/check<f32>
@@ -54291,13 +51238,13 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3849
+   i32.const 3662
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f32.const -1.1754942106924411e-38
-  call $~lib/math/NativeMathf.tan
+  call $~lib/util/math/tan32
   f32.const -1.1754942106924411e-38
   f32.const 0
   call $std/math/check<f32>
@@ -54305,7 +51252,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3850
+   i32.const 3663
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -54318,7 +51265,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3862
+   i32.const 3675
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -54331,7 +51278,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3863
+   i32.const 3676
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -54344,7 +51291,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3864
+   i32.const 3677
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -54357,7 +51304,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3865
+   i32.const 3678
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -54370,7 +51317,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3866
+   i32.const 3679
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -54383,7 +51330,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3867
+   i32.const 3680
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -54396,7 +51343,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3868
+   i32.const 3681
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -54409,7 +51356,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3869
+   i32.const 3682
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -54422,7 +51369,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3870
+   i32.const 3683
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -54435,7 +51382,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3871
+   i32.const 3684
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -54448,7 +51395,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3874
+   i32.const 3687
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -54461,7 +51408,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3875
+   i32.const 3688
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -54474,7 +51421,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3876
+   i32.const 3689
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -54487,7 +51434,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3877
+   i32.const 3690
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -54500,7 +51447,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3878
+   i32.const 3691
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -54513,7 +51460,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3887
+   i32.const 3700
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -54526,7 +51473,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3888
+   i32.const 3701
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -54539,7 +51486,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3889
+   i32.const 3702
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -54552,7 +51499,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3890
+   i32.const 3703
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -54565,7 +51512,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3891
+   i32.const 3704
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -54578,7 +51525,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3892
+   i32.const 3705
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -54591,7 +51538,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3893
+   i32.const 3706
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -54604,7 +51551,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3894
+   i32.const 3707
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -54617,7 +51564,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3895
+   i32.const 3708
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -54630,7 +51577,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3896
+   i32.const 3709
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -54643,7 +51590,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3899
+   i32.const 3712
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -54656,7 +51603,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3900
+   i32.const 3713
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -54669,7 +51616,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3901
+   i32.const 3714
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -54682,7 +51629,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3902
+   i32.const 3715
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -54695,7 +51642,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3903
+   i32.const 3716
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -54717,7 +51664,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3915
+   i32.const 3728
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -54739,7 +51686,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3916
+   i32.const 3729
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -54761,7 +51708,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3917
+   i32.const 3730
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -54783,7 +51730,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3918
+   i32.const 3731
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -54805,7 +51752,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3919
+   i32.const 3732
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -54827,7 +51774,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3920
+   i32.const 3733
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -54849,7 +51796,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3921
+   i32.const 3734
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -54871,7 +51818,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3922
+   i32.const 3735
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -54893,7 +51840,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3923
+   i32.const 3736
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -54915,7 +51862,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3924
+   i32.const 3737
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -54937,7 +51884,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3927
+   i32.const 3740
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -54959,7 +51906,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3928
+   i32.const 3741
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -54981,7 +51928,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3929
+   i32.const 3742
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -55003,7 +51950,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3930
+   i32.const 3743
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -55025,7 +51972,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3931
+   i32.const 3744
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -55047,7 +51994,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3932
+   i32.const 3745
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -55069,7 +52016,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3933
+   i32.const 3746
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -55091,7 +52038,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3934
+   i32.const 3747
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -55113,7 +52060,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3935
+   i32.const 3748
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -55135,7 +52082,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3936
+   i32.const 3749
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -55157,7 +52104,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3937
+   i32.const 3750
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -55179,7 +52126,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3938
+   i32.const 3751
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -55201,7 +52148,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3939
+   i32.const 3752
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -55223,7 +52170,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3940
+   i32.const 3753
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -55245,7 +52192,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3941
+   i32.const 3754
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -55258,7 +52205,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3950
+   i32.const 3763
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -55271,7 +52218,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3951
+   i32.const 3764
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -55284,7 +52231,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3952
+   i32.const 3765
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -55297,7 +52244,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3953
+   i32.const 3766
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -55310,7 +52257,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3954
+   i32.const 3767
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -55323,46 +52270,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3955
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const -0
-  f32.const -0
-  f32.const 0
-  call $std/math/check<f32>
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 3956
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const 0
-  f32.const 0
-  f32.const 0
-  call $std/math/check<f32>
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 3957
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const 0
-  f32.const 0
-  f32.const 0
-  call $std/math/check<f32>
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 3958
+   i32.const 3768
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -55375,7 +52283,46 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3959
+   i32.const 3769
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const 0
+  f32.const 0
+  f32.const 0
+  call $std/math/check<f32>
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 3770
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const 0
+  f32.const 0
+  f32.const 0
+  call $std/math/check<f32>
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 3771
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const -0
+  f32.const -0
+  f32.const 0
+  call $std/math/check<f32>
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 3772
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -55388,7 +52335,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3962
+   i32.const 3775
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -55401,7 +52348,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3963
+   i32.const 3776
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -55414,7 +52361,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3964
+   i32.const 3777
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -55427,7 +52374,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3965
+   i32.const 3778
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -55440,7 +52387,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3966
+   i32.const 3779
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -55453,7 +52400,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3967
+   i32.const 3780
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -55466,7 +52413,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3968
+   i32.const 3781
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -55479,7 +52426,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3969
+   i32.const 3782
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -55492,7 +52439,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3970
+   i32.const 3783
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -55505,7 +52452,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3971
+   i32.const 3784
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -55518,7 +52465,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3972
+   i32.const 3785
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -55531,7 +52478,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3973
+   i32.const 3786
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -55544,7 +52491,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3974
+   i32.const 3787
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -55557,7 +52504,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3975
+   i32.const 3788
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -55570,7 +52517,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3976
+   i32.const 3789
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -55637,572 +52584,572 @@
   call $std/math/test_sincos
   f64.const 2
   f64.const 4
-  call $~lib/math/NativeMath.imul
+  call $~lib/math/NativeMath.imul<f64>
   f64.const 8
   f64.ne
   if
    i32.const 0
    i32.const 1056
-   i32.const 4017
+   i32.const 3830
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f64.const -1
   f64.const 8
-  call $~lib/math/NativeMath.imul
+  call $~lib/math/NativeMath.imul<f64>
   f64.const -8
   f64.ne
   if
    i32.const 0
    i32.const 1056
-   i32.const 4018
+   i32.const 3831
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f64.const -2
   f64.const -2
-  call $~lib/math/NativeMath.imul
+  call $~lib/math/NativeMath.imul<f64>
   f64.const 4
   f64.ne
   if
    i32.const 0
    i32.const 1056
-   i32.const 4019
+   i32.const 3832
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f64.const 4294967295
   f64.const 5
-  call $~lib/math/NativeMath.imul
+  call $~lib/math/NativeMath.imul<f64>
   f64.const -5
   f64.ne
   if
    i32.const 0
    i32.const 1056
-   i32.const 4020
+   i32.const 3833
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f64.const 4294967294
   f64.const 5
-  call $~lib/math/NativeMath.imul
+  call $~lib/math/NativeMath.imul<f64>
   f64.const -10
   f64.ne
   if
    i32.const 0
    i32.const 1056
-   i32.const 4021
+   i32.const 3834
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f64.const 1.e+60
   f64.const 1.e+60
-  call $~lib/math/NativeMath.imul
+  call $~lib/math/NativeMath.imul<f64>
   f64.const 0
   f64.ne
   if
    i32.const 0
    i32.const 1056
-   i32.const 4022
+   i32.const 3835
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f64.const 1.e+60
   f64.const -1.e+60
-  call $~lib/math/NativeMath.imul
+  call $~lib/math/NativeMath.imul<f64>
   f64.const 0
   f64.ne
   if
    i32.const 0
    i32.const 1056
-   i32.const 4023
+   i32.const 3836
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f64.const -1.e+60
   f64.const -1.e+60
-  call $~lib/math/NativeMath.imul
+  call $~lib/math/NativeMath.imul<f64>
   f64.const 0
   f64.ne
   if
    i32.const 0
    i32.const 1056
-   i32.const 4024
+   i32.const 3837
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f64.const 1.e+24
   f64.const 100
-  call $~lib/math/NativeMath.imul
+  call $~lib/math/NativeMath.imul<f64>
   f64.const -2147483648
   f64.ne
   if
    i32.const 0
    i32.const 1056
-   i32.const 4025
+   i32.const 3838
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f64.const nan:0x8000000000000
   f64.const 1
-  call $~lib/math/NativeMath.imul
+  call $~lib/math/NativeMath.imul<f64>
   f64.const 0
   f64.ne
   if
    i32.const 0
    i32.const 1056
-   i32.const 4026
+   i32.const 3839
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f64.const 1
   f64.const inf
-  call $~lib/math/NativeMath.imul
+  call $~lib/math/NativeMath.imul<f64>
   f64.const 0
   f64.ne
   if
    i32.const 0
    i32.const 1056
-   i32.const 4027
+   i32.const 3840
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f64.const 1797693134862315708145274e284
   f64.const 1797693134862315708145274e284
-  call $~lib/math/NativeMath.imul
+  call $~lib/math/NativeMath.imul<f64>
   f64.const 0
   f64.ne
   if
    i32.const 0
    i32.const 1056
-   i32.const 4028
+   i32.const 3841
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   i64.const 0
   i64.const 0
-  call $~lib/math/ipow64
+  call $~lib/util/math/ipow64
   i64.const 1
   i64.ne
   if
    i32.const 0
    i32.const 1056
-   i32.const 4051
+   i32.const 3864
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   i64.const 0
   i64.const 1
-  call $~lib/math/ipow64
+  call $~lib/util/math/ipow64
   i64.eqz
   i32.eqz
   if
    i32.const 0
    i32.const 1056
-   i32.const 4052
+   i32.const 3865
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   i64.const 0
   i64.const 2
-  call $~lib/math/ipow64
+  call $~lib/util/math/ipow64
   i64.eqz
   i32.eqz
   if
    i32.const 0
    i32.const 1056
-   i32.const 4053
+   i32.const 3866
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   i64.const 0
   i64.const 3
-  call $~lib/math/ipow64
+  call $~lib/util/math/ipow64
   i64.eqz
   i32.eqz
   if
    i32.const 0
    i32.const 1056
-   i32.const 4054
+   i32.const 3867
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   i64.const 1
   i64.const 0
-  call $~lib/math/ipow64
+  call $~lib/util/math/ipow64
   i64.const 1
   i64.ne
   if
    i32.const 0
    i32.const 1056
-   i32.const 4056
+   i32.const 3869
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   i64.const 1
   i64.const 1
-  call $~lib/math/ipow64
+  call $~lib/util/math/ipow64
   i64.const 1
   i64.ne
   if
    i32.const 0
    i32.const 1056
-   i32.const 4057
+   i32.const 3870
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   i64.const 1
   i64.const 2
-  call $~lib/math/ipow64
+  call $~lib/util/math/ipow64
   i64.const 1
   i64.ne
   if
    i32.const 0
    i32.const 1056
-   i32.const 4058
+   i32.const 3871
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   i64.const 1
   i64.const 3
-  call $~lib/math/ipow64
+  call $~lib/util/math/ipow64
   i64.const 1
   i64.ne
   if
    i32.const 0
    i32.const 1056
-   i32.const 4059
+   i32.const 3872
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   i64.const 2
   i64.const 0
-  call $~lib/math/ipow64
+  call $~lib/util/math/ipow64
   i64.const 1
   i64.ne
   if
    i32.const 0
    i32.const 1056
-   i32.const 4061
+   i32.const 3874
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   i64.const 2
   i64.const 1
-  call $~lib/math/ipow64
+  call $~lib/util/math/ipow64
   i64.const 2
   i64.ne
   if
    i32.const 0
    i32.const 1056
-   i32.const 4062
+   i32.const 3875
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   i64.const 2
   i64.const 2
-  call $~lib/math/ipow64
+  call $~lib/util/math/ipow64
   i64.const 4
   i64.ne
   if
    i32.const 0
    i32.const 1056
-   i32.const 4063
+   i32.const 3876
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   i64.const 2
   i64.const 3
-  call $~lib/math/ipow64
+  call $~lib/util/math/ipow64
   i64.const 8
   i64.ne
   if
    i32.const 0
    i32.const 1056
-   i32.const 4064
+   i32.const 3877
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   i64.const -1
   i64.const 0
-  call $~lib/math/ipow64
+  call $~lib/util/math/ipow64
   i64.const 1
   i64.ne
   if
    i32.const 0
    i32.const 1056
-   i32.const 4066
+   i32.const 3879
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   i64.const -1
   i64.const 1
-  call $~lib/math/ipow64
+  call $~lib/util/math/ipow64
   i64.const -1
   i64.ne
   if
    i32.const 0
    i32.const 1056
-   i32.const 4067
+   i32.const 3880
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   i64.const -1
   i64.const 2
-  call $~lib/math/ipow64
+  call $~lib/util/math/ipow64
   i64.const 1
   i64.ne
   if
    i32.const 0
    i32.const 1056
-   i32.const 4068
+   i32.const 3881
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   i64.const -1
   i64.const 3
-  call $~lib/math/ipow64
+  call $~lib/util/math/ipow64
   i64.const -1
   i64.ne
   if
    i32.const 0
    i32.const 1056
-   i32.const 4069
+   i32.const 3882
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   i64.const -2
   i64.const 0
-  call $~lib/math/ipow64
+  call $~lib/util/math/ipow64
   i64.const 1
   i64.ne
   if
    i32.const 0
    i32.const 1056
-   i32.const 4071
+   i32.const 3884
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   i64.const -2
   i64.const 1
-  call $~lib/math/ipow64
+  call $~lib/util/math/ipow64
   i64.const -2
   i64.ne
   if
    i32.const 0
    i32.const 1056
-   i32.const 4072
+   i32.const 3885
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   i64.const -2
   i64.const 2
-  call $~lib/math/ipow64
+  call $~lib/util/math/ipow64
   i64.const 4
   i64.ne
   if
    i32.const 0
    i32.const 1056
-   i32.const 4073
+   i32.const 3886
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   i64.const -2
   i64.const 3
-  call $~lib/math/ipow64
+  call $~lib/util/math/ipow64
   i64.const -8
   i64.ne
   if
    i32.const 0
    i32.const 1056
-   i32.const 4074
+   i32.const 3887
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   i64.const 2
   i64.const 63
-  call $~lib/math/ipow64
+  call $~lib/util/math/ipow64
   i64.const -9223372036854775808
   i64.ne
   if
    i32.const 0
    i32.const 1056
-   i32.const 4076
+   i32.const 3889
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   i64.const 3
   i64.const 40
-  call $~lib/math/ipow64
+  call $~lib/util/math/ipow64
   i64.const -6289078614652622815
   i64.ne
   if
    i32.const 0
    i32.const 1056
-   i32.const 4077
+   i32.const 3890
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   i64.const 2
   i64.const 64
-  call $~lib/math/ipow64
+  call $~lib/util/math/ipow64
   i64.eqz
   i32.eqz
   if
    i32.const 0
    i32.const 1056
-   i32.const 4078
+   i32.const 3891
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   i64.const 3
   i64.const 41
-  call $~lib/math/ipow64
+  call $~lib/util/math/ipow64
   i64.const -420491770248316829
   i64.ne
   if
    i32.const 0
    i32.const 1056
-   i32.const 4079
+   i32.const 3892
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   i64.const 3
   i64.const 128
-  call $~lib/math/ipow64
+  call $~lib/util/math/ipow64
   i64.const -9204772141784466943
   i64.ne
   if
    i32.const 0
    i32.const 1056
-   i32.const 4080
+   i32.const 3893
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   i64.const 1
   i64.const -1
-  call $~lib/math/ipow64
+  call $~lib/util/math/ipow64
   i64.const 1
   i64.ne
   if
    i32.const 0
    i32.const 1056
-   i32.const 4082
+   i32.const 3895
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   i64.const 2
   i64.const -1
-  call $~lib/math/ipow64
+  call $~lib/util/math/ipow64
   i64.eqz
   i32.eqz
   if
    i32.const 0
    i32.const 1056
-   i32.const 4083
+   i32.const 3896
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   i64.const 2
   i64.const 64
-  call $~lib/math/ipow64
+  call $~lib/util/math/ipow64
   i64.eqz
   i32.eqz
   if
    i32.const 0
    i32.const 1056
-   i32.const 4084
+   i32.const 3897
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   i64.const 2
   i64.const 128
-  call $~lib/math/ipow64
+  call $~lib/util/math/ipow64
   i64.eqz
   i32.eqz
   if
    i32.const 0
    i32.const 1056
-   i32.const 4085
+   i32.const 3898
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f64.const 1
   f64.const 0.5
-  call $~lib/math/NativeMath.pow
+  call $~lib/util/math/pow64
   f64.const 1
   f64.ne
   if
    i32.const 0
    i32.const 1056
-   i32.const 4129
+   i32.const 3942
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f64.const 0
   f64.const 0.5
-  call $~lib/math/NativeMath.pow
+  call $~lib/util/math/pow64
   f64.const 0
   f64.ne
   if
    i32.const 0
    i32.const 1056
-   i32.const 4130
+   i32.const 3943
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f64.const 0
   f64.const -1
-  call $~lib/math/NativeMath.pow
+  call $~lib/util/math/pow64
   f64.const inf
   f64.ne
   if
    i32.const 0
    i32.const 1056
-   i32.const 4131
+   i32.const 3944
    i32.const 1
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/std/math.ts
+++ b/tests/compiler/std/math.ts
@@ -30,6 +30,12 @@
   and src/math/crlibm/* for details
 */
 
+import {
+  scalbn32,
+  scalbn64,
+  ipow64
+} from "util/math";
+
 const js = true; // also test, and thus compare to, JS math?
 
 // these flags are unused, but kept in case these might just so happen to become useful
@@ -60,7 +66,7 @@ function ulperr(got: f64, want: f64, dwant: f64): f64 {
     got = copysign<f64>(Ox1p1023, got);
     want *= 0.5;
   }
-  return NativeMath.scalbn(got - want, -eulp(want)) + dwant;
+  return scalbn64(got - want, -eulp(want)) + dwant;
 }
 
 function eulpf(x: f32): i32 {
@@ -74,22 +80,22 @@ function ulperrf(got: f32, want: f32, dwant: f32): f32 {
   const Ox1p127f = reinterpret<f32>(0x7F000000);
   if (isNaN(got) && isNaN(want)) return 0;
   if (got == want) {
-    if (NativeMathf.signbit(got) == NativeMathf.signbit(want)) return dwant;
+    if (NativeMath.signbit(got) == NativeMath.signbit(want)) return dwant;
     return Infinity;
   }
   if (!isFinite(got)) {
     got = copysign<f32>(Ox1p127f, got);
     want *= 0.5;
   }
-  return NativeMathf.scalbn(got - want, -eulpf(want)) + dwant;
+  return scalbn32(got - want, -eulpf(want)) + dwant;
 }
 
-function check<T>(actual: T, expected: T, dy: T, flags: i32): bool {
+function check<T extends number>(actual: T, expected: T, dy: T, flags: i32): bool {
   if (actual == expected) return true;
   if (isNaN(expected)) return isNaN(actual);
   var d: T;
-  if (sizeof<T>() == 8) d = ulperr(actual, expected, dy);
-  else if (sizeof<T>() == 4) d = ulperrf(actual, expected, dy);
+  if (sizeof<T>() == 8) d = <T>ulperr(actual, expected, dy);
+  else if (sizeof<T>() == 4) d = <T>ulperrf(actual, expected, dy);
   else return false;
   if (abs<T>(d) >= 1.5) {
     return false;
@@ -102,7 +108,6 @@ function check<T>(actual: T, expected: T, dy: T, flags: i32): bool {
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 
 assert(Math.E == NativeMath.E);
-assert(Mathf.E == NativeMathf.E);
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 // Constants
@@ -116,20 +121,12 @@ assert(check<f64>(NativeMath.PI, JSMath.PI, 0.0, 0));
 assert(check<f64>(NativeMath.SQRT1_2, JSMath.SQRT1_2, 0.0, 0));
 assert(check<f64>(NativeMath.SQRT2, JSMath.SQRT2, 0.0, 0));
 
-assert(check<f32>(NativeMathf.E, <f32>JSMath.E, 0.0, 0));
-assert(check<f32>(NativeMathf.LN2, <f32>JSMath.LN2, 0.0, 0));
-assert(check<f32>(NativeMathf.LN10, <f32>JSMath.LN10, 0.0, 0));
-assert(check<f32>(NativeMathf.LOG2E, <f32>JSMath.LOG2E, 0.0, 0));
-assert(check<f32>(NativeMathf.PI, <f32>JSMath.PI, 0.0, 0));
-assert(check<f32>(NativeMathf.SQRT1_2, <f32>JSMath.SQRT1_2, 0.0, 0));
-assert(check<f32>(NativeMathf.SQRT2, <f32>JSMath.SQRT2, 0.0, 0));
-
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 // Internal scalbn
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 
 function test_scalbn(value: f64, n: i32, expected: f64, error: f64, flags: i32): bool {
-  return check<f64>(NativeMath.scalbn(value, n), expected, error, flags);
+  return check<f64>(scalbn64(value, n), expected, error, flags);
 }
 
 // sanity
@@ -168,7 +165,7 @@ assert(test_scalbn(0.500000000000001221, -1024, 2.78134232313400667e-309, 0.0, I
 // Internal scalbnf ////////////////////////////////////////////////////////////////////////////////
 
 function test_scalbnf(value: f32, n: i32, expected: f32, error: f32, flags: i32): bool {
-  return check<f32>(NativeMathf.scalbn(value, n), expected, error, flags);
+  return check<f32>(scalbn32(value, n), expected, error, flags);
 }
 
 // sanity
@@ -237,7 +234,7 @@ assert(test_abs(NaN, NaN, 0.0, 0));
 // Mathf.abs ///////////////////////////////////////////////////////////////////////////////////////
 
 function test_absf(value: f32, expected: f32, error: f32, flags: i32): bool {
-  return check<f32>(NativeMathf.abs(value), expected, error, flags);
+  return check<f32>(NativeMath.abs<f32>(value), expected, error, flags);
 }
 
 // sanity
@@ -297,7 +294,7 @@ assert(test_acos(0.493955674639974585, 1.05416298758519456, 0.220547676086425781
 // Mathf.acos //////////////////////////////////////////////////////////////////////////////////////
 
 function test_acosf(value: f32, expected: f32, error: f32, flags: i32): bool {
-  return check<f32>(NativeMathf.acos(value), expected, error, flags);
+  return check<f32>(NativeMath.acos<f32>(value), expected, error, flags);
 }
 
 // sanity
@@ -378,7 +375,7 @@ assert(test_acosh(1.11694291598755213, 0.47902433134075284, -0.32167410850524902
 // Mathf.acosh /////////////////////////////////////////////////////////////////////////////////////
 
 function test_acoshf(value: f32, expected: f32, error: f32, flags: i32): bool {
-  return check<f32>(NativeMathf.acosh(value), expected, error, flags);
+  return check<f32>(NativeMath.acosh<f32>(value), expected, error, flags);
 }
 
 // sanity
@@ -439,7 +436,7 @@ assert(test_asin(0.507304392911914759, 0.53205389977723494, -0.16157317161560058
 // Mathf.asin //////////////////////////////////////////////////////////////////////////////////////
 
 function test_asinf(value: f32, expected: f32, error: f32, flags: i32): bool {
-  return check<f32>(NativeMathf.asin(value), expected, error, flags);
+  return check<f32>(NativeMath.asin<f32>(value), expected, error, flags);
 }
 
 // sanity
@@ -517,7 +514,7 @@ assert(test_asinh(-0.0, -0.0, 0.0, 0));
 // Mathf.asinh /////////////////////////////////////////////////////////////////////////////////////
 
 function test_asinhf(value: f32, expected: f32, error: f32, flags: i32): bool {
-  return check<f32>(NativeMathf.asinh(value), expected, error, flags);
+  return check<f32>(NativeMath.asinh<f32>(value), expected, error, flags);
 }
 
 // sanity
@@ -573,7 +570,7 @@ assert(test_atan(0.6929821535674624, 0.606000455515256164, -0.170757904648780823
 // Mathf.atan //////////////////////////////////////////////////////////////////////////////////////
 
 function test_atanf(value: f32, expected: f32, error: f32, flags: i32): bool {
-  return check<f32>(NativeMathf.atan(value), expected, error, flags);
+  return check<f32>(NativeMath.atan<f32>(value), expected, error, flags);
 }
 
 // sanity
@@ -637,7 +634,7 @@ assert(test_atanh(8.98846567431157954e+307, NaN, 0.0, INVALID));
 // Mathf.atanh /////////////////////////////////////////////////////////////////////////////////////
 
 function test_atanhf(value: f32, expected: f32, error: f32, flags: i32): bool {
-  return check<f32>(NativeMathf.atanh(value), expected, error, flags);
+  return check<f32>(NativeMath.atanh<f32>(value), expected, error, flags);
 }
 
 // sanity
@@ -724,7 +721,7 @@ assert(test_atan2(1.5, -8.98846567431157954e+307, 3.14159265358979312, 0.0, INEX
 // Mathf.atan2 /////////////////////////////////////////////////////////////////////////////////////
 
 function test_atan2f(value1: f32, value2: f32, expected: f32, error: f32, flags: i32): bool {
-  return check<f32>(NativeMathf.atan2(value1, value2), expected, error, flags);
+  return check<f32>(NativeMath.atan2<f32>(value1, value2), expected, error, flags);
 }
 
 // sanity
@@ -805,7 +802,7 @@ assert(test_cbrt(8.0, 2.0, 0.0, 0));
 // Mathf.cbrt //////////////////////////////////////////////////////////////////////////////////////
 
 function test_cbrtf(value: f32, expected: f32, error: f32, flags: i32): bool {
-  return check<f32>(NativeMathf.cbrt(value), expected, error, flags);
+  return check<f32>(NativeMath.cbrt<f32>(value), expected, error, flags);
 }
 
 // sanity
@@ -903,7 +900,7 @@ assert(test_ceil(-7.88860905221011805e-31, -0.0, 0.0, INEXACT));
 // Mathf.ceil //////////////////////////////////////////////////////////////////////////////////////
 
 function test_ceilf(value: f32, expected: f32, error: f32, flags: i32): bool {
-  return check<f32>(NativeMathf.ceil(value), expected, error, flags);
+  return check<f32>(NativeMath.ceil<f32>(value), expected, error, flags);
 }
 
 // sanity
@@ -1111,40 +1108,40 @@ assert(NativeMath.cos(1e90 * kPI) == JSMath.cos(1e90 * kPI));
 
 // v8 ieee754-unittest.cc
 // cos(x) = 1 for |x| < 2^-27
-assert(NativeMath.cos(2.3283064365386963e-10) == 1.0);
-assert(NativeMath.cos(-2.3283064365386963e-10) == 1.0);
+assert(NativeMath.cos<f64>(+2.3283064365386963e-10) == 1.0);
+assert(NativeMath.cos<f64>(-2.3283064365386963e-10) == 1.0);
 // Test KERNELCOS for |x| < 0.3.
 // cos(pi/20) = sqrt(sqrt(2)*sqrt(sqrt(5)+5)+4)/2^(3/2)
-assert(NativeMath.cos(0.15707963267948966) == 0.9876883405951378);
+assert(NativeMath.cos<f64>(0.15707963267948966) == 0.9876883405951378);
 // Test KERNELCOS for x ~= 0.78125
-assert(NativeMath.cos(0.7812504768371582) == 0.7100335477927638);
-assert(NativeMath.cos(0.78125) == 0.7100338835660797);
+assert(NativeMath.cos<f64>(0.7812504768371582) == 0.7100335477927638);
+assert(NativeMath.cos<f64>(0.78125) == 0.7100338835660797);
 // Test KERNELCOS for |x| > 0.3.
 // cos(pi/8) = sqrt(sqrt(2)+1)/2^(3/4)
-assert(0.9238795325112867 == NativeMath.cos(0.39269908169872414));
+assert(NativeMath.cos<f64>(0.39269908169872414) == 0.9238795325112867);
 // Test KERNELTAN for |x| < 0.67434.
-assert(0.9238795325112867 == NativeMath.cos(-0.39269908169872414));
+assert(NativeMath.cos<f64>(-0.39269908169872414) == 0.9238795325112867);
 
 // Tests for cos.
-assert(NativeMath.cos(3.725290298461914e-9) == 1.0);
+assert(NativeMath.cos<f64>(3.725290298461914e-9) == 1.0);
 // Cover different code paths in KERNELCOS.
-assert(0.9689124217106447 == NativeMath.cos(0.25));
-assert(0.8775825618903728 == NativeMath.cos(0.5));
-assert(0.7073882691671998 == NativeMath.cos(0.785));
+assert(NativeMath.cos<f64>(0.25) == 0.9689124217106447);
+assert(NativeMath.cos<f64>(0.5) == 0.8775825618903728);
+assert(NativeMath.cos<f64>(0.785) == 0.7073882691671998);
 // Test that cos(Math.PI/2) != 0 since Math.PI is not exact.
-assert(6.123233995736766e-17 == NativeMath.cos(1.5707963267948966));
+assert(NativeMath.cos<f64>(1.5707963267948966) == 6.123233995736766e-17);
 // Test cos for various phases.
-assert(0.7071067811865474 == NativeMath.cos(7.0 / 4 * kPI));
-assert(0.7071067811865477 == NativeMath.cos(9.0 / 4 * kPI));
-assert(-0.7071067811865467 == NativeMath.cos(11.0 / 4 * kPI));
-assert(-0.7071067811865471 == NativeMath.cos(13.0 / 4 * kPI));
-assert(0.9367521275331447 == NativeMath.cos(1000000.0));
-assert(-3.435757038074824e-12 == NativeMath.cos(1048575.0 / 2 * kPI));
+assert(NativeMath.cos(7.0 / 4 * kPI) == 0.7071067811865474);
+assert(NativeMath.cos(9.0 / 4 * kPI) == 0.7071067811865477);
+assert(NativeMath.cos(11.0 / 4 * kPI) == -0.7071067811865467);
+assert(NativeMath.cos(13.0 / 4 * kPI) == -0.7071067811865471);
+assert(NativeMath.cos<f64>(1000000.0) == 0.9367521275331447);
+assert(NativeMath.cos(1048575.0 / 2 * kPI) == -3.435757038074824e-12);
 
 // Mathf.cos ///////////////////////////////////////////////////////////////////////////////////////
 
 function test_cosf(value: f32, expected: f32, error: f32, flags: i32): bool {
-  return  check<f32>(NativeMathf.cos(value), expected, error, flags);
+  return  check<f32>(NativeMath.cos<f32>(value), expected, error, flags);
 }
 
 // sanity
@@ -1252,7 +1249,7 @@ assert(test_cosh(NaN, NaN, 0.0, 0));
 // Mathf.cosh //////////////////////////////////////////////////////////////////////////////////////
 
 function test_coshf(value: f32, expected: f32, error: f32, flags: i32): bool {
-  return check<f32>(NativeMathf.cosh(value), expected, error, flags);
+  return check<f32>(NativeMath.cosh<f32>(value), expected, error, flags);
 }
 
 // sanity
@@ -1446,7 +1443,7 @@ assert(test_exp(
 // Mathf.exp ///////////////////////////////////////////////////////////////////////////////////////
 
 function test_expf(value: f32, expected: f32, error: f32, flags: i32): bool {
-  return check<f32>(NativeMathf.exp(value), expected, error, flags);
+  return check<f32>(NativeMath.exp<f32>(value), expected, error, flags);
 }
 
 // sanity
@@ -1512,7 +1509,7 @@ assert(test_expm1(-2.22507385850720089e-308,-2.22507385850720089e-308, 0.0, INEX
 // Mathf.expm1 /////////////////////////////////////////////////////////////////////////////////////
 
 function test_expm1f(value: f32, expected: f32, error: f32, flags: i32): bool {
-  return check<f32>(NativeMathf.expm1(value), expected, error, flags);
+  return check<f32>(NativeMath.expm1<f32>(value), expected, error, flags);
 }
 
 // sanity
@@ -1589,7 +1586,7 @@ assert(test_exp2(reinterpret<f64>(0xC0A0000000000000),                          
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 
 function test_exp2f(value: f32, expected: f32, error: f32, flags: i32): bool {
-  return check<f32>(NativeMathf.exp2(value), expected, error, flags);
+  return check<f32>(NativeMath.exp2<f32>(value), expected, error, flags);
 }
 
 // sanity
@@ -1645,7 +1642,7 @@ assert(test_floor(-7.88860905221011805e-31, -1.0, 0.0, INEXACT));
 // Mathf.floor /////////////////////////////////////////////////////////////////////////////////////
 
 function test_floorf(value: f32, expected: f32, error: f32, flags: i32): bool {
-  return check<f32>(NativeMathf.floor(value), expected, error, flags);
+  return check<f32>(NativeMath.floor<f32>(value), expected, error, flags);
 }
 
 // sanity
@@ -1726,7 +1723,7 @@ assert(test_hypot(0.0, NaN, NaN, 0.0, 0));
 // Mathf.hypot /////////////////////////////////////////////////////////////////////////////////////
 
 function test_hypotf(value1: f32, value2: f32, expected: f32, error: f32, flags: i32): bool {
-  return check<f32>(NativeMathf.hypot(value1, value2), expected, error, flags);
+  return check<f32>(NativeMath.hypot<f32>(value1, value2), expected, error, flags);
 }
 
 // sanity
@@ -1796,7 +1793,7 @@ assert(test_log(NaN, NaN, 0.0, 0));
 // Mathf.log ///////////////////////////////////////////////////////////////////////////////////////
 
 function test_logf(value: f32, expected: f32, error: f32, flags: i32): bool {
-  return check<f32>(NativeMathf.log(value), expected, error, flags);
+  return check<f32>(NativeMath.log<f32>(value), expected, error, flags);
 }
 
 // sanity
@@ -1853,7 +1850,7 @@ assert(test_log10(NaN, NaN, 0.0, 0));
 // Mathf.log10 /////////////////////////////////////////////////////////////////////////////////////
 
 function test_log10f(value: f32, expected: f32, error: f32, flags: i32): bool {
-  return check<f32>(NativeMathf.log10(value), expected, error, flags);
+  return check<f32>(NativeMath.log10<f32>(value), expected, error, flags);
 }
 
 // sanity
@@ -1912,7 +1909,7 @@ assert(test_log1p(NaN, NaN, 0.0, 0));
 // Mathf.log1p /////////////////////////////////////////////////////////////////////////////////////
 
 function test_log1pf(value: f32, expected: f32, error: f32, flags: i32): bool {
-  return check<f32>(NativeMathf.log1p(value), expected, error, flags);
+  return check<f32>(NativeMath.log1p<f32>(value), expected, error, flags);
 }
 
 // sanity
@@ -1972,7 +1969,7 @@ assert(test_log2(NaN, NaN, 0.0, 0));
 // Mathf.log2 //////////////////////////////////////////////////////////////////////////////////////
 
 function test_log2f(value: f32, expected: f32, error: f32, flags: i32): bool {
-  return check<f32>(NativeMathf.log2(value), expected, error, flags);
+  return check<f32>(NativeMath.log2<f32>(value), expected, error, flags);
 }
 
 // sanity
@@ -2081,7 +2078,7 @@ assert(test_max(-1.75, -0.5, -0.5, 0.0, 0));
 // Mathf.max ///////////////////////////////////////////////////////////////////////////////////////
 
 function test_maxf(left: f32, right: f32, expected: f32, error: f32, flags: i32): bool {
-  return check<f32>(NativeMathf.max(left, right), expected, error, flags);
+  return check<f32>(NativeMath.max<f32>(left, right), expected, error, flags);
 }
 
 // sanity
@@ -2240,7 +2237,7 @@ assert(test_min(-1.75, -0.5, -1.75, 0.0, 0));
 // Mathf.min ///////////////////////////////////////////////////////////////////////////////////////
 
 function test_minf(left: f32, right: f32, expected: f32, error: f32, flags: i32): bool {
-  return check<f32>(NativeMathf.min(left, right), expected, error, flags);
+  return check<f32>(NativeMath.min<f32>(left, right), expected, error, flags);
 }
 
 // sanity
@@ -2487,7 +2484,7 @@ assert(test_mod(reinterpret<f64>(0x009FFFFFFFFFFFFF), reinterpret<f64>(0x0090000
 // Mathf.mod ///////////////////////////////////////////////////////////////////////////////////////
 
 function test_modf(left: f32, right: f32, expected: f32, error: f32, flags: i32): bool {
-  return check<f32>(NativeMathf.mod(left, right), expected, error, flags);
+  return check<f32>(NativeMath.mod<f32>(left, right), expected, error, flags);
 }
 
 // sanity
@@ -2686,53 +2683,53 @@ assert(test_pow(-2.0, 1.0, -2.0, 0.0, 0));
 assert(test_pow(-2.0, -1.0, -0.5, 0.0, 0));
 
 // Fast paths
-assert(NativeMath.pow(+0.0,+0.0) == 1.0);
-assert(NativeMath.pow(-0.0,+0.0) == 1.0);
-assert(NativeMath.pow(-0.0,-0.0) == 1.0);
-assert(NativeMath.pow(+0.0,-0.0) == 1.0);
-assert(NativeMath.pow(-1.0, 0.0) == 1.0);
-assert(NativeMath.pow(+Infinity, 0.0) == 1.0);
-assert(NativeMath.pow(-Infinity, 0.0) == 1.0);
-assert(NativeMath.pow(NaN, 0.0) == 1.0);
+assert(NativeMath.pow<f64>(+0.0,+0.0) == 1.0);
+assert(NativeMath.pow<f64>(-0.0,+0.0) == 1.0);
+assert(NativeMath.pow<f64>(-0.0,-0.0) == 1.0);
+assert(NativeMath.pow<f64>(+0.0,-0.0) == 1.0);
+assert(NativeMath.pow<f64>(-1.0, 0.0) == 1.0);
+assert(NativeMath.pow<f64>(+Infinity, 0.0) == 1.0);
+assert(NativeMath.pow<f64>(-Infinity, 0.0) == 1.0);
+assert(NativeMath.pow<f64>(NaN, 0.0) == 1.0);
 
-assert(NativeMath.pow(+0.0,+1.0) == +0.0);
-assert(NativeMath.pow(-0.0,+1.0) == -0.0);
-assert(NativeMath.pow(-1.0, 1.0) == -1.0);
-assert(NativeMath.pow(+Infinity, 1.0) == +Infinity);
-assert(NativeMath.pow(-Infinity, 1.0) == -Infinity);
-assert(isNaN(NativeMath.pow(NaN, 1.0)));
+assert(NativeMath.pow<f64>(+0.0,+1.0) == +0.0);
+assert(NativeMath.pow<f64>(-0.0,+1.0) == -0.0);
+assert(NativeMath.pow<f64>(-1.0, 1.0) == -1.0);
+assert(NativeMath.pow<f64>(+Infinity, 1.0) == +Infinity);
+assert(NativeMath.pow<f64>(-Infinity, 1.0) == -Infinity);
+assert(isNaN(NativeMath.pow<f64>(NaN, 1.0)));
 
-assert(NativeMath.pow(+0.0,-1.0) == +Infinity);
-assert(NativeMath.pow(-0.0,-1.0) == -Infinity);
-assert(NativeMath.pow(-1.0,-1.0) == -1.0);
-assert(NativeMath.pow( 0.5,-1.0) == +2.0);
-assert(NativeMath.pow( 1.0,-1.0) == +1.0);
-assert(NativeMath.pow(+Infinity,-1.0) == +0.0);
-assert(NativeMath.pow(-Infinity,-1.0) == -0.0);
+assert(NativeMath.pow<f64>(+0.0,-1.0) == +Infinity);
+assert(NativeMath.pow<f64>(-0.0,-1.0) == -Infinity);
+assert(NativeMath.pow<f64>(-1.0,-1.0) == -1.0);
+assert(NativeMath.pow<f64>( 0.5,-1.0) == +2.0);
+assert(NativeMath.pow<f64>( 1.0,-1.0) == +1.0);
+assert(NativeMath.pow<f64>(+Infinity,-1.0) == +0.0);
+assert(NativeMath.pow<f64>(-Infinity,-1.0) == -0.0);
 assert(isNaN(NativeMath.pow(NaN,-1.0)));
 
-assert(NativeMath.pow(+0.0, 2.0) == +0.0);
-assert(NativeMath.pow(-0.0, 2.0) == +0.0);
-assert(NativeMath.pow(-1.0, 2.0) == +1.0);
-assert(NativeMath.pow( 0.5, 2.0) == +0.25);
-assert(NativeMath.pow( 1.0, 2.0) == +1.0);
-assert(NativeMath.pow(+Infinity, 2.0) == +Infinity);
-assert(NativeMath.pow(-Infinity, 2.0) == +Infinity);
-assert(isNaN(NativeMath.pow(NaN, 2.0)));
+assert(NativeMath.pow<f64>(+0.0, 2.0) == +0.0);
+assert(NativeMath.pow<f64>(-0.0, 2.0) == +0.0);
+assert(NativeMath.pow<f64>(-1.0, 2.0) == +1.0);
+assert(NativeMath.pow<f64>( 0.5, 2.0) == +0.25);
+assert(NativeMath.pow<f64>( 1.0, 2.0) == +1.0);
+assert(NativeMath.pow<f64>(+Infinity, 2.0) == +Infinity);
+assert(NativeMath.pow<f64>(-Infinity, 2.0) == +Infinity);
+assert(isNaN(NativeMath.pow<f64>(NaN, 2.0)));
 
-assert(NativeMath.pow(+0.0, 0.5) == +0.0);
-assert(NativeMath.pow(-0.0, 0.5) == +0.0);
-assert(isNaN(NativeMath.pow(-1.0, 0.5)));
-assert(NativeMath.pow( 4.0, 0.5) == +2.0);
-assert(NativeMath.pow( 1.0, 0.5) == +1.0);
-assert(NativeMath.pow(+Infinity, 0.5) == +Infinity);
-assert(NativeMath.pow(-Infinity, 0.5) == +Infinity);
-assert(isNaN(NativeMath.pow(NaN, 0.5)));
+assert(NativeMath.pow<f64>(+0.0, 0.5) == +0.0);
+assert(NativeMath.pow<f64>(-0.0, 0.5) == +0.0);
+assert(isNaN(NativeMath.pow<f64>(-1.0, 0.5)));
+assert(NativeMath.pow<f64>( 4.0, 0.5) == +2.0);
+assert(NativeMath.pow<f64>( 1.0, 0.5) == +1.0);
+assert(NativeMath.pow<f64>(+Infinity, 0.5) == +Infinity);
+assert(NativeMath.pow<f64>(-Infinity, 0.5) == +Infinity);
+assert(isNaN(NativeMath.pow<f64>(NaN, 0.5)));
 
 // Mathf.pow ///////////////////////////////////////////////////////////////////////////////////////
 
 function test_powf(left: f32, right: f32, expected: f32, error: f32, flags: i32): bool {
-  return check<f32>(NativeMathf.pow(left, right), expected, error, flags);
+  return check<f32>(NativeMath.pow<f32>(left, right), expected, error, flags);
 }
 
 // sanity
@@ -3000,14 +2997,6 @@ for (let i = 0; i < 1e6; ++i) {
   assert(r >= 0.0 && r < 1.0);
 }
 
-// Mathf.random ////////////////////////////////////////////////////////////////////////////////////
-
-NativeMathf.seedRandom(reinterpret<u64>(JSMath.random()));
-for (let i = 0; i < 1e6; ++i) {
-  let r = NativeMathf.random();
-  assert(r >= 0.0 && r < 1.0);
-}
-
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 // Math.round
 ////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -3058,7 +3047,7 @@ assert(NativeMath.round(-1.7976931348623157e+308) == -1.7976931348623157e+308);
 // Mathf.round /////////////////////////////////////////////////////////////////////////////////////
 
 function test_roundf(value: f32, expected: f32, error: f32, flags: i32): bool {
-  return  check<f32>(NativeMathf.round(value), expected, error, flags);
+  return  check<f32>(NativeMath.round<f32>(value), expected, error, flags);
 }
 
 // sanity
@@ -3114,7 +3103,7 @@ assert(test_sign(NaN, NaN, 0.0, 0));
 // Mathf.sign //////////////////////////////////////////////////////////////////////////////////////
 
 function test_signf(value: f32, expected: f32, error: f32, flags: i32): bool {
-  return  check<f32>(NativeMathf.sign(value), expected, error, flags);
+  return  check<f32>(NativeMath.sign<f32>(value), expected, error, flags);
 }
 
 assert(test_signf(0.0, 0.0, 0.0, 0));
@@ -3144,190 +3133,14 @@ assert(NativeMath.signbit(-Infinity) == true);
 // Mathf.signbit
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 
-assert(NativeMathf.signbit(0.0)  == false);
-assert(NativeMathf.signbit(-0.0) == true);
-assert(NativeMathf.signbit(1.0)  == false);
-assert(NativeMathf.signbit(-1.0) == true);
-assert(NativeMathf.signbit(+NaN) == false);
-assert(NativeMathf.signbit(-NaN) == true);
-assert(NativeMathf.signbit(+Infinity) == false);
-assert(NativeMathf.signbit(-Infinity) == true);
-
-////////////////////////////////////////////////////////////////////////////////////////////////////
-// Math.rem
-////////////////////////////////////////////////////////////////////////////////////////////////////
-
-function test_rem(left: f64, right: f64, expected: f64, error: f64, flags: i32): bool {
-  return check<f64>(NativeMath.rem(left, right), expected, error, flags);
-}
-
-// sanity
-assert(test_rem(-8.06684839057968084, 4.53566256067686879, 1.00447673077405675, 0.0, 0));
-assert(test_rem(4.34523984933830487, -8.88799136300345083, 4.34523984933830487, 0.0, 0));
-assert(test_rem(-8.38143342755524934, -2.76360733737958819, -0.0906114154164847641, 0.0, 0));
-assert(test_rem(-6.53167358191348413, 4.56753527684274374, -1.96413830507074039, 0.0, 0));
-assert(test_rem(9.26705696697258574, 4.81139208435979615, -0.355727201747006561, 0.0, 0));
-assert(test_rem(-6.45004555606023633, 0.662071792337673881, 0.170672367316502482, 0.0, 0));
-assert(test_rem(7.85889025304169664, 0.0521545267500622481, -0.0164432862177028224, 0.0, 0));
-assert(test_rem(-0.792054511984895959, 7.67640268511753998, -0.792054511984895959, 0.0, 0));
-assert(test_rem(0.615702673197924044, 2.01190257903248026, 0.615702673197924044, 0.0, 0));
-assert(test_rem(-0.558758682360915193, 0.0322398306026380407, -0.0106815621160685006, 0.0, 0));
-
-// special
-assert(test_rem(0.0, 1.0, 0.0, 0.0, 0));
-assert(test_rem(-0.0, 1.0, -0.0, 0.0, 0));
-assert(test_rem(0.5, 1.0, 0.5, 0.0, 0));
-assert(test_rem(-0.5, 1.0, -0.5, 0.0, 0));
-assert(test_rem(1.0, 1.0, 0.0, 0.0, 0));
-assert(test_rem(-1.0, 1.0, -0.0, 0.0, 0));
-assert(test_rem(1.5, 1.0, -0.5, 0.0, 0));
-assert(test_rem(-1.5, 1.0, 0.5, 0.0, 0));
-assert(test_rem(2.0, 1.0, 0.0, 0.0, 0));
-assert(test_rem(-2.0, 1.0, -0.0, 0.0, 0));
-assert(test_rem(Infinity, 1.0, NaN, 0.0, INVALID));
-assert(test_rem(-Infinity, 1.0, NaN, 0.0, INVALID));
-assert(test_rem(NaN, 1.0, NaN, 0.0, 0));
-assert(test_rem(0.0, -1.0, 0.0, 0.0, 0));
-assert(test_rem(-0.0, -1.0, -0.0, 0.0, 0));
-assert(test_rem(0.5, -1.0, 0.5, 0.0, 0));
-assert(test_rem(-0.5, -1.0, -0.5, 0.0, 0));
-assert(test_rem(1.0, -1.0, 0.0, 0.0, 0));
-assert(test_rem(-1.0, -1.0, -0.0, 0.0, 0));
-assert(test_rem(1.5, -1.0, -0.5, 0.0, 0));
-assert(test_rem(-1.5, -1.0, 0.5, 0.0, 0));
-assert(test_rem(2.0, -1.0, 0.0, 0.0, 0));
-assert(test_rem(-2.0, -1.0, -0.0, 0.0, 0));
-assert(test_rem(Infinity, -1.0, NaN, 0.0, INVALID));
-assert(test_rem(-Infinity, -1.0, NaN, 0.0, INVALID));
-assert(test_rem(NaN, -1.0, NaN, 0.0, 0));
-assert(test_rem(0.0, 0.0, NaN, 0.0, INVALID));
-assert(test_rem(0.0, -0.0, NaN, 0.0, INVALID));
-assert(test_rem(0.0, Infinity, 0.0, 0.0, 0));
-assert(test_rem(0.0, -Infinity, 0.0, 0.0, 0));
-assert(test_rem(0.0, NaN, NaN, 0.0, 0));
-assert(test_rem(-0.0, 0.0, NaN, 0.0, INVALID));
-assert(test_rem(-0.0, -0.0, NaN, 0.0, INVALID));
-assert(test_rem(-0.0, Infinity, -0.0, 0.0, 0));
-assert(test_rem(-0.0, -Infinity, -0.0, 0.0, 0));
-assert(test_rem(-0.0, NaN, NaN, 0.0, 0));
-assert(test_rem(1.0, 0.0, NaN, 0.0, INVALID));
-assert(test_rem(-1.0, 0.0, NaN, 0.0, INVALID));
-assert(test_rem(Infinity, 0.0, NaN, 0.0, INVALID));
-assert(test_rem(-Infinity, 0.0, NaN, 0.0, INVALID));
-assert(test_rem(NaN, 0.0, NaN, 0.0, 0));
-assert(test_rem(-1.0, -0.0, NaN, 0.0, INVALID));
-assert(test_rem(Infinity, -0.0, NaN, 0.0, INVALID));
-assert(test_rem(-Infinity, -0.0, NaN, 0.0, INVALID));
-assert(test_rem(NaN, -0.0, NaN, 0.0, 0));
-assert(test_rem(Infinity, 2.0, NaN, 0.0, INVALID));
-assert(test_rem(Infinity, -0.5, NaN, 0.0, INVALID));
-assert(test_rem(Infinity, NaN, NaN, 0.0, 0));
-assert(test_rem(-Infinity, 2.0, NaN, 0.0, INVALID));
-assert(test_rem(-Infinity, -0.5, NaN, 0.0, INVALID));
-assert(test_rem(-Infinity, NaN, NaN, 0.0, 0));
-assert(test_rem(NaN, NaN, NaN, 0.0, 0));
-assert(test_rem(1.0, NaN, NaN, 0.0, 0));
-assert(test_rem(-1.0, NaN, NaN, 0.0, 0));
-assert(test_rem(1.0, Infinity, 1.0, 0.0, 0));
-assert(test_rem(-1.0, Infinity, -1.0, 0.0, 0));
-assert(test_rem(Infinity, Infinity, NaN, 0.0, INVALID));
-assert(test_rem(-Infinity, Infinity, NaN, 0.0, INVALID));
-assert(test_rem(1.0, -Infinity, 1.0, 0.0, 0));
-assert(test_rem(-1.0, -Infinity, -1.0, 0.0, 0));
-assert(test_rem(Infinity, -Infinity, NaN, 0.0, INVALID));
-assert(test_rem(-Infinity, -Infinity, NaN, 0.0, INVALID));
-assert(test_rem(1.75, 0.5, -0.25, 0.0, 0));
-assert(test_rem(-1.75, 0.5, 0.25, 0.0, 0));
-assert(test_rem(1.75, -0.5, -0.25, 0.0, 0));
-assert(test_rem(-1.75, -0.5, 0.25, 0.0, 0));
-assert(test_rem(7.90505033345994471e-323, Infinity, 7.90505033345994471e-323, 0.0, 0));
-
-// Mathf.rem ///////////////////////////////////////////////////////////////////////////////////////
-
-function test_remf(left: f32, right: f32, expected: f32, error: f32, flags: i32): bool {
-  return check<f32>(NativeMathf.rem(left, right), expected, error, flags);
-}
-
-// sanity
-assert(test_remf(-8.066848755, 4.535662651, 1.004476547, 0.0, 0));
-assert(test_remf(4.345239639, -8.887990952, 4.345239639, 0.0, 0));
-assert(test_remf(-8.381433487, -2.763607264, -0.09061169624, 0.0, 0));
-assert(test_remf(-6.531673431, 4.5675354, -1.964138031, 0.0, 0));
-assert(test_remf(9.267057419, 4.811392307, -0.3557271957, 0.0, 0));
-assert(test_remf(-6.450045586, 0.6620717645, 0.1706720591, 0.0, 0));
-assert(test_remf(7.858890057, 0.05215452611, -0.01644338667, 0.0, 0));
-assert(test_remf(-0.792054534, 7.676402569, -0.792054534, 0.0, 0));
-assert(test_remf(0.6157026887, 2.011902571, 0.6157026887, 0.0, 0));
-assert(test_remf(-0.5587586761, 0.03223983198, -0.01068153232, 0.0, 0));
-
-// special
-assert(test_remf(0.0, 1.0, 0.0, 0.0, 0));
-assert(test_remf(-0.0, 1.0, -0.0, 0.0, 0));
-assert(test_remf(0.5, 1.0, 0.5, 0.0, 0));
-assert(test_remf(-0.5, 1.0, -0.5, 0.0, 0));
-assert(test_remf(1.0, 1.0, 0.0, 0.0, 0));
-assert(test_remf(-1.0, 1.0, -0.0, 0.0, 0));
-assert(test_remf(1.5, 1.0, -0.5, 0.0, 0));
-assert(test_remf(-1.5, 1.0, 0.5, 0.0, 0));
-assert(test_remf(2.0, 1.0, 0.0, 0.0, 0));
-assert(test_remf(-2.0, 1.0, -0.0, 0.0, 0));
-assert(test_remf(Infinity, 1.0, NaN, 0.0, INVALID));
-assert(test_remf(-Infinity, 1.0, NaN, 0.0, INVALID));
-assert(test_remf(NaN, 1.0, NaN, 0.0, 0));
-assert(test_remf(0.0, -1.0, 0.0, 0.0, 0));
-assert(test_remf(-0.0, -1.0, -0.0, 0.0, 0));
-assert(test_remf(0.5, -1.0, 0.5, 0.0, 0));
-assert(test_remf(-0.5, -1.0, -0.5, 0.0, 0));
-assert(test_remf(1.0, -1.0, 0.0, 0.0, 0));
-assert(test_remf(-1.0, -1.0, -0.0, 0.0, 0));
-assert(test_remf(1.5, -1.0, -0.5, 0.0, 0));
-assert(test_remf(-1.5, -1.0, 0.5, 0.0, 0));
-assert(test_remf(2.0, -1.0, 0.0, 0.0, 0));
-assert(test_remf(-2.0, -1.0, -0.0, 0.0, 0));
-assert(test_remf(Infinity, -1.0, NaN, 0.0, INVALID));
-assert(test_remf(-Infinity, -1.0, NaN, 0.0, INVALID));
-assert(test_remf(NaN, -1.0, NaN, 0.0, 0));
-assert(test_remf(0.0, 0.0, NaN, 0.0, INVALID));
-assert(test_remf(0.0, -0.0, NaN, 0.0, INVALID));
-assert(test_remf(0.0, Infinity, 0.0, 0.0, 0));
-assert(test_remf(0.0, -Infinity, 0.0, 0.0, 0));
-assert(test_remf(0.0, NaN, NaN, 0.0, 0));
-assert(test_remf(-0.0, 0.0, NaN, 0.0, INVALID));
-assert(test_remf(-0.0, -0.0, NaN, 0.0, INVALID));
-assert(test_remf(-0.0, Infinity, -0.0, 0.0, 0));
-assert(test_remf(-0.0, -Infinity, -0.0, 0.0, 0));
-assert(test_remf(-0.0, NaN, NaN, 0.0, 0));
-assert(test_remf(1.0, 0.0, NaN, 0.0, INVALID));
-assert(test_remf(-1.0, 0.0, NaN, 0.0, INVALID));
-assert(test_remf(Infinity, 0.0, NaN, 0.0, INVALID));
-assert(test_remf(-Infinity, 0.0, NaN, 0.0, INVALID));
-assert(test_remf(NaN, 0.0, NaN, 0.0, 0));
-assert(test_remf(-1.0, -0.0, NaN, 0.0, INVALID));
-assert(test_remf(Infinity, -0.0, NaN, 0.0, INVALID));
-assert(test_remf(-Infinity, -0.0, NaN, 0.0, INVALID));
-assert(test_remf(NaN, -0.0, NaN, 0.0, 0));
-assert(test_remf(Infinity, 2.0, NaN, 0.0, INVALID));
-assert(test_remf(Infinity, -0.5, NaN, 0.0, INVALID));
-assert(test_remf(Infinity, NaN, NaN, 0.0, 0));
-assert(test_remf(-Infinity, 2.0, NaN, 0.0, INVALID));
-assert(test_remf(-Infinity, -0.5, NaN, 0.0, INVALID));
-assert(test_remf(-Infinity, NaN, NaN, 0.0, 0));
-assert(test_remf(NaN, NaN, NaN, 0.0, 0));
-assert(test_remf(1.0, NaN, NaN, 0.0, 0));
-assert(test_remf(-1.0, NaN, NaN, 0.0, 0));
-assert(test_remf(1.0, Infinity, 1.0, 0.0, 0));
-assert(test_remf(-1.0, Infinity, -1.0, 0.0, 0));
-assert(test_remf(Infinity, Infinity, NaN, 0.0, INVALID));
-assert(test_remf(-Infinity, Infinity, NaN, 0.0, INVALID));
-assert(test_remf(1.0, -Infinity, 1.0, 0.0, 0));
-assert(test_remf(-1.0, -Infinity, -1.0, 0.0, 0));
-assert(test_remf(Infinity, -Infinity, NaN, 0.0, INVALID));
-assert(test_remf(-Infinity, -Infinity, NaN, 0.0, INVALID));
-assert(test_remf(1.75, 0.5, -0.25, 0.0, 0));
-assert(test_remf(-1.75, 0.5, 0.25, 0.0, 0));
-assert(test_remf(1.75, -0.5, -0.25, 0.0, 0));
-assert(test_remf(-1.75, -0.5, 0.25, 0.0, 0));
-assert(test_remf(5.877471754e-39, Infinity, 5.877471754e-39, 0.0, 0));
+assert(NativeMath.signbit<f32>(0.0)  == false);
+assert(NativeMath.signbit<f32>(-0.0) == true);
+assert(NativeMath.signbit<f32>(1.0)  == false);
+assert(NativeMath.signbit<f32>(-1.0) == true);
+assert(NativeMath.signbit<f32>(+NaN) == false);
+assert(NativeMath.signbit<f32>(-NaN) == true);
+assert(NativeMath.signbit<f32>(+Infinity) == false);
+assert(NativeMath.signbit<f32>(-Infinity) == true);
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 // Math.sin
@@ -3397,39 +3210,39 @@ assert(test_sin(-Infinity,  NaN, 0.0, INVALID));
 assert(test_sin(      NaN,  NaN, 0.0, 0));
 
 // from v8
-assert(NativeMath.sin(kPI / 2) == JSMath.sin(kPI / 2));
+assert(NativeMath.sin(1 * kPI / 2) == JSMath.sin(1 * kPI / 2));
 assert(NativeMath.sin(2 * kPI / 2) == JSMath.sin(2 * kPI / 2));
 
 // sin(x) = x for x < 2^-27
-assert(+2.3283064365386963e-10 == NativeMath.sin(+2.3283064365386963e-10));
-assert(-2.3283064365386963e-10 == NativeMath.sin(-2.3283064365386963e-10));
+assert(NativeMath.sin(+2.3283064365386963e-10) == +2.3283064365386963e-10);
+assert(NativeMath.sin(-2.3283064365386963e-10) == -2.3283064365386963e-10);
 // sin(pi/8) = sqrt(sqrt(2)-1)/2^(3/4)
-assert(+0.3826834323650898 == NativeMath.sin(+0.39269908169872414));
-assert(-0.3826834323650898 == NativeMath.sin(-0.39269908169872414));
+assert(NativeMath.sin<f64>(+0.39269908169872414) == +0.3826834323650898);
+assert(NativeMath.sin<f64>(-0.39269908169872414) == -0.3826834323650898);
 
 // Tests for sin.
-assert(+0.479425538604203 == NativeMath.sin(+0.5));
-assert(-0.479425538604203 == NativeMath.sin(-0.5));
-assert(+1.0 == NativeMath.sin(+kPI / 2.0));
-assert(-1.0 == NativeMath.sin(-kPI / 2.0));
+assert(NativeMath.sin<f64>(+0.5)  == +0.479425538604203);
+assert(NativeMath.sin<f64>(-0.5)  == -0.479425538604203);
+assert(NativeMath.sin(+kPI / 2.0) == +1.0);
+assert(NativeMath.sin(-kPI / 2.0) == -1.0);
 // Test that sin(Math.PI) != 0 since Math.PI is not exact.
-assert(1.2246467991473532e-16 == NativeMath.sin(kPI));
-assert(-7.047032979958965e-14 == NativeMath.sin(2200.0 * kPI));
+assert(NativeMath.sin(kPI) == 1.2246467991473532e-16);
+assert(NativeMath.sin(2200.0 * kPI) == -7.0470329799589650e-14);
 // Test sin for various phases.
-assert(-0.7071067811865477 == NativeMath.sin(7.0 / 4.0 * kPI));
-assert(+0.7071067811865474 == NativeMath.sin(9.0 / 4.0 * kPI));
-assert(+0.7071067811865483 == NativeMath.sin(11.0 / 4.0 * kPI));
-assert(-0.7071067811865479 == NativeMath.sin(13.0 / 4.0 * kPI));
-assert(-3.2103381051568376e-11 == NativeMath.sin(1048576.0 / 4 * kPI));
+assert(NativeMath.sin(7.0  / 4.0 * kPI) == -0.7071067811865477);
+assert(NativeMath.sin(9.0  / 4.0 * kPI) == +0.7071067811865474);
+assert(NativeMath.sin(11.0 / 4.0 * kPI) == +0.7071067811865483);
+assert(NativeMath.sin(13.0 / 4.0 * kPI) == -0.7071067811865479);
+assert(NativeMath.sin(1048576.0 / 4 * kPI) == -3.2103381051568376e-11);
 
 // Test Hayne-Panek reduction.
-assert( 0.377820109360752e0 == NativeMath.sin(+kTwo120));
-assert(-0.377820109360752e0 == NativeMath.sin(-kTwo120));
+assert(NativeMath.sin(+kTwo120) == +0.377820109360752e0);
+assert(NativeMath.sin(-kTwo120) == -0.377820109360752e0);
 
 // Mathf.sin ///////////////////////////////////////////////////////////////////////////////////////
 
 function test_sinf(value: f32, expected: f32, error: f32, flags: i32): bool {
-  return check<f32>(NativeMathf.sin(value), expected, error, flags);
+  return check<f32>(NativeMath.sin<f32>(value), expected, error, flags);
 }
 
 // sanity
@@ -3538,7 +3351,7 @@ assert(test_sinh(NaN, NaN, 0.0, 0));
 // Mathf.sinh //////////////////////////////////////////////////////////////////////////////////////
 
 function test_sinhf(value: f32, expected: f32, error: f32, flags: i32): bool {
-  return check<f32>(NativeMathf.sinh(value), expected, error, flags);
+  return check<f32>(NativeMath.sinh<f32>(value), expected, error, flags);
 }
 
 // sanity
@@ -3660,7 +3473,7 @@ assert(test_sqrt(4.57432207785627658e-306, 2.13876648511619359e-153, 0.499859392
 // Mathf.sqrt //////////////////////////////////////////////////////////////////////////////////////
 
 function test_sqrtf(value: f32, expected: f32, error: f32, flags: i32): bool {
-  return check<f32>(NativeMathf.sqrt(value), expected, error, flags);
+  return check<f32>(NativeMath.sqrt<f32>(value), expected, error, flags);
 }
 
 // sanity
@@ -3789,7 +3602,7 @@ assert(test_tan(NaN, NaN, 0.0, 0));
 // Mathf.tan ///////////////////////////////////////////////////////////////////////////////////////
 
 function test_tanf(value: f32, expected: f32, error: f32, flags: i32): bool {
-  return check<f32>(NativeMathf.tan(value), expected, error, flags);
+  return check<f32>(NativeMath.tan<f32>(value), expected, error, flags);
 }
 
 // sanity
@@ -3880,7 +3693,7 @@ assert(test_tanh(NaN, NaN, 0.0, 0));
 // Mathf.tanh //////////////////////////////////////////////////////////////////////////////////////
 
 function test_tanhf(value: f32, expected: f32, error: f32, flags: i32): bool {
-  return check<f32>(NativeMathf.tanh(value), expected, error, flags);
+  return check<f32>(NativeMath.tanh<f32>(value), expected, error, flags);
 }
 
 // sanity
@@ -3943,7 +3756,7 @@ assert(test_trunc(-7.88860905221011805e-31, -0.0, 0.0, INEXACT));
 // Mathf.trunc /////////////////////////////////////////////////////////////////////////////////////
 
 function test_truncf(value: f32, expected: f32, error: f32, flags: i32): bool {
-  return check<f32>(NativeMathf.trunc(value), expected, error, flags);
+  return check<f32>(NativeMath.trunc<f32>(value), expected, error, flags);
 }
 
 // sanity
@@ -4014,37 +3827,37 @@ test_sincos(0xBFE5B86EA8118A0E, 0xBFE417318671B83D, 0xBFD87FFC00000000, 0x3FE8E8
 
 // Math.imul //////////////////////////////////////////////////////////////////////////////////
 
-assert(NativeMath.imul(2, 4) == 8);
-assert(NativeMath.imul(-1, 8) == -8);
-assert(NativeMath.imul(-2, -2) == 4);
-assert(NativeMath.imul(0xffffffff, 5) == -5);
-assert(NativeMath.imul(0xfffffffe, 5) == -10);
-assert(NativeMath.imul(1e+60, 1e+60) == 0);
-assert(NativeMath.imul(1e+60,-1e+60) == 0);
-assert(NativeMath.imul(-1e+60,-1e+60) == 0);
-assert(NativeMath.imul(1e+24, 1e2) == -2147483648);
-assert(NativeMath.imul(NaN, 1) == 0);
-assert(NativeMath.imul(1, Infinity) == 0);
-assert(NativeMath.imul(f64.MAX_VALUE, f64.MAX_VALUE) == 0);
+assert(NativeMath.imul<f64>(+2, +4) == +8);
+assert(NativeMath.imul<f64>(-1, +8) == -8);
+assert(NativeMath.imul<f64>(-2, -2) == +4);
+assert(NativeMath.imul<f64>(0xffffffff, 5) == -5);
+assert(NativeMath.imul<f64>(0xfffffffe, 5) == -10);
+assert(NativeMath.imul<f64>(+1e+60,+1e+60) == 0);
+assert(NativeMath.imul<f64>(+1e+60,-1e+60) == 0);
+assert(NativeMath.imul<f64>(-1e+60,-1e+60) == 0);
+assert(NativeMath.imul<f64>(1e+24, 1e2) == -2147483648);
+assert(NativeMath.imul<f64>(NaN, 1.0) == 0);
+assert(NativeMath.imul<f64>(1.0, Infinity) == 0);
+assert(NativeMath.imul<f64>(f64.MAX_VALUE, f64.MAX_VALUE) == 0);
 
 // Math.clz32 /////////////////////////////////////////////////////////////////////////////////
 
-assert(NativeMath.clz32(0) == 32);
-assert(NativeMath.clz32(1) == 31);
-assert(NativeMath.clz32(-1) == 0);
-assert(NativeMath.clz32(-128) == 0);
-assert(NativeMath.clz32(4294967295.) == 0);
-assert(NativeMath.clz32(4294967295.5) == 0);
-assert(NativeMath.clz32(4294967296) == 32);
-assert(NativeMath.clz32(4294967297) == 31);
-assert(NativeMath.clz32(NaN) == 32);
-assert(NativeMath.clz32(Infinity) == 32);
-assert(NativeMath.clz32(f64.MAX_SAFE_INTEGER) == 0);
-assert(NativeMath.clz32(-f64.MAX_SAFE_INTEGER) == 31);
-assert(NativeMath.clz32(f64.MAX_VALUE) == 32);
-assert(NativeMath.clz32(f64.MIN_VALUE) == 32);
-assert(NativeMath.clz32(-f64.MAX_VALUE) == 32);
-assert(NativeMath.clz32(f64.EPSILON) == 32);
+assert(NativeMath.clz32<f64>(+0.0) == 32);
+assert(NativeMath.clz32<f64>(+1.0) == 31);
+assert(NativeMath.clz32<f64>(-1.0) == 0);
+assert(NativeMath.clz32<f64>(-128.0) == 0);
+assert(NativeMath.clz32<f64>(4294967295.0) == 0);
+assert(NativeMath.clz32<f64>(4294967295.5) == 0);
+assert(NativeMath.clz32<f64>(4294967296.0) == 32);
+assert(NativeMath.clz32<f64>(4294967297.0) == 31);
+assert(NativeMath.clz32<f64>(NaN) == 32);
+assert(NativeMath.clz32<f64>(Infinity) == 32);
+assert(NativeMath.clz32<f64>(+f64.MAX_SAFE_INTEGER) == 0);
+assert(NativeMath.clz32<f64>(-f64.MAX_SAFE_INTEGER) == 31);
+assert(NativeMath.clz32<f64>(+f64.MAX_VALUE) == 32);
+assert(NativeMath.clz32<f64>(+f64.MIN_VALUE) == 32);
+assert(NativeMath.clz32<f64>(-f64.MAX_VALUE) == 32);
+assert(NativeMath.clz32<f64>(+f64.EPSILON)   == 32);
 
 // ipow64 /////////////////////////////////////////////////////////////////////////////////////
 

--- a/tests/compiler/std/mod.debug.wat
+++ b/tests/compiler/std/mod.debug.wat
@@ -20,7 +20,7 @@
  (export "mod" (func $std/mod/mod))
  (export "memory" (memory $0))
  (start $~start)
- (func $~lib/math/NativeMath.mod (param $0 f64) (param $1 f64) (result f64)
+ (func $~lib/util/math/mod64 (param $0 f64) (param $1 f64) (result f64)
   (local $2 i64)
   (local $3 i64)
   (local $4 i64)
@@ -308,7 +308,7 @@
  (func $std/mod/test_fmod (param $0 f64) (param $1 f64) (param $2 f64) (result i32)
   local.get $0
   local.get $1
-  call $~lib/math/NativeMath.mod
+  call $~lib/util/math/mod64
   local.get $2
   call $std/mod/check<f64>
   if (result i32)
@@ -321,7 +321,7 @@
    i32.const 0
   end
  )
- (func $~lib/math/NativeMathf.mod (param $0 f32) (param $1 f32) (result f32)
+ (func $~lib/util/math/mod32 (param $0 f32) (param $1 f32) (result f32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -603,7 +603,7 @@
  (func $std/mod/test_fmodf (param $0 f32) (param $1 f32) (param $2 f32) (result i32)
   local.get $0
   local.get $1
-  call $~lib/math/NativeMathf.mod
+  call $~lib/util/math/mod32
   local.get $2
   call $std/mod/check<f32>
  )

--- a/tests/compiler/std/mod.release.wat
+++ b/tests/compiler/std/mod.release.wat
@@ -21,7 +21,7 @@
   (local $8 i64)
   (local $9 i64)
   block $__inlined_func$std/mod/check<f64> (result i32)
-   block $__inlined_func$~lib/math/NativeMath.mod (result f64)
+   block $__inlined_func$~lib/util/math/mod64 (result f64)
     local.get $0
     local.get $0
     f64.trunc
@@ -32,7 +32,7 @@
     f64.abs
     f64.const 1
     f64.eq
-    br_if $__inlined_func$~lib/math/NativeMath.mod
+    br_if $__inlined_func$~lib/util/math/mod64
     drop
     local.get $1
     i64.reinterpret_f64
@@ -69,7 +69,7 @@
      local.tee $4
      local.get $4
      f64.div
-     br $__inlined_func$~lib/math/NativeMath.mod
+     br $__inlined_func$~lib/util/math/mod64
     end
     local.get $7
     i64.const 1
@@ -84,7 +84,7 @@
      i64.ne
      f64.convert_i32_u
      f64.mul
-     br $__inlined_func$~lib/math/NativeMath.mod
+     br $__inlined_func$~lib/util/math/mod64
     end
     local.get $9
     i64.eqz
@@ -145,7 +145,7 @@
        local.get $3
        local.get $5
        i64.eq
-       br_if $__inlined_func$~lib/math/NativeMath.mod
+       br_if $__inlined_func$~lib/util/math/mod64
        drop
        local.get $3
        local.get $5
@@ -173,7 +173,7 @@
      local.get $3
      local.get $5
      i64.eq
-     br_if $__inlined_func$~lib/math/NativeMath.mod
+     br_if $__inlined_func$~lib/util/math/mod64
      drop
      local.get $3
      local.get $5
@@ -280,7 +280,7 @@
   (local $7 i32)
   (local $8 i32)
   block $__inlined_func$std/mod/check<f32> (result i32)
-   block $__inlined_func$~lib/math/NativeMathf.mod (result f32)
+   block $__inlined_func$~lib/util/math/mod32 (result f32)
     local.get $0
     local.get $0
     f32.trunc
@@ -291,7 +291,7 @@
     f32.abs
     f32.const 1
     f32.eq
-    br_if $__inlined_func$~lib/math/NativeMathf.mod
+    br_if $__inlined_func$~lib/util/math/mod32
     drop
     local.get $1
     i32.reinterpret_f32
@@ -329,7 +329,7 @@
      local.tee $0
      local.get $0
      f32.div
-     br $__inlined_func$~lib/math/NativeMathf.mod
+     br $__inlined_func$~lib/util/math/mod32
     end
     local.get $6
     i32.const 1
@@ -344,7 +344,7 @@
      i32.ne
      f32.convert_i32_u
      f32.mul
-     br $__inlined_func$~lib/math/NativeMathf.mod
+     br $__inlined_func$~lib/util/math/mod32
     end
     local.get $8
     if (result i32)
@@ -403,7 +403,7 @@
        local.get $3
        local.get $4
        i32.eq
-       br_if $__inlined_func$~lib/math/NativeMathf.mod
+       br_if $__inlined_func$~lib/util/math/mod32
        drop
        local.get $3
        local.get $4
@@ -431,7 +431,7 @@
      local.get $3
      local.get $4
      i32.eq
-     br_if $__inlined_func$~lib/math/NativeMathf.mod
+     br_if $__inlined_func$~lib/util/math/mod32
      drop
      local.get $3
      local.get $4

--- a/tests/compiler/std/operator-overloading.debug.wat
+++ b/tests/compiler/std/operator-overloading.debug.wat
@@ -2262,7 +2262,7 @@
   i32.rem_s
   call $std/operator-overloading/Tester#constructor
  )
- (func $~lib/math/ipow32 (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/util/math/ipow32 (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -2487,12 +2487,12 @@
   i32.load
   local.get $1
   i32.load
-  call $~lib/math/ipow32
+  call $~lib/util/math/ipow32
   local.get $0
   i32.load offset=4
   local.get $1
   i32.load offset=4
-  call $~lib/math/ipow32
+  call $~lib/util/math/ipow32
   call $std/operator-overloading/Tester#constructor
  )
  (func $std/operator-overloading/Tester.and (param $0 i32) (param $1 i32) (result i32)

--- a/tests/compiler/std/operator-overloading.release.wat
+++ b/tests/compiler/std/operator-overloading.release.wat
@@ -1288,7 +1288,7 @@
   i64.store align=1
   local.get $0
  )
- (func $~lib/math/ipow32 (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/util/math/ipow32 (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   i32.const 1
   local.set $2
@@ -2194,12 +2194,12 @@
   i32.load
   local.get $0
   i32.load
-  call $~lib/math/ipow32
+  call $~lib/util/math/ipow32
   local.get $1
   i32.load offset=4
   local.get $0
   i32.load offset=4
-  call $~lib/math/ipow32
+  call $~lib/util/math/ipow32
   call $std/operator-overloading/Tester#constructor
   global.set $std/operator-overloading/p
   global.get $std/operator-overloading/p

--- a/tests/compiler/std/string.debug.wat
+++ b/tests/compiler/std/string.debug.wat
@@ -4368,7 +4368,7 @@
   local.get $1
   call $~lib/util/string/strtol<i64>
  )
- (func $~lib/math/ipow32 (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/util/math/ipow32 (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -4587,7 +4587,7 @@
   end
   local.get $2
  )
- (func $~lib/math/NativeMath.scalbn (param $0 f64) (param $1 i32) (result f64)
+ (func $~lib/util/math/scalbn64 (param $0 f64) (param $1 i32) (result f64)
   (local $2 f64)
   (local $3 i32)
   (local $4 i32)
@@ -5393,7 +5393,7 @@
      i32.const 0
      local.get $12
      i32.sub
-     call $~lib/math/ipow32
+     call $~lib/util/math/ipow32
      i64.extend_i32_s
      local.set $23
      local.get $19
@@ -5432,7 +5432,7 @@
      f64.convert_i64_u
      local.get $20
      i32.wrap_i64
-     call $~lib/math/NativeMath.scalbn
+     call $~lib/util/math/scalbn64
      br $~lib/util/string/scientific|inlined.0
     else
      local.get $17
@@ -5530,7 +5530,7 @@
      local.set $20
      i32.const 5
      local.get $13
-     call $~lib/math/ipow32
+     call $~lib/util/math/ipow32
      local.set $15
      local.get $20
      i64.const 4294967295
@@ -5593,7 +5593,7 @@
      f64.convert_i64_u
      local.get $24
      i32.wrap_i64
-     call $~lib/math/NativeMath.scalbn
+     call $~lib/util/math/scalbn64
      br $~lib/util/string/scientific|inlined.0
     end
     unreachable
@@ -11089,21 +11089,36 @@
    call $~lib/builtins/abort
    unreachable
   end
-  i32.const 2704
-  local.set $4
-  global.get $~lib/memory/__stack_pointer
-  local.get $4
-  i32.store
-  local.get $4
-  i32.const 0
-  call $~lib/string/parseInt
-  local.set $2
-  local.get $2
-  i64.reinterpret_f64
-  i64.const 63
-  i64.shr_u
-  i64.const 0
-  i64.ne
+  block $~lib/math/NativeMath.signbit<f64>|inlined.0 (result i32)
+   i32.const 2704
+   local.set $4
+   global.get $~lib/memory/__stack_pointer
+   local.get $4
+   i32.store
+   local.get $4
+   i32.const 0
+   call $~lib/string/parseInt
+   local.set $2
+   i32.const 0
+   drop
+   i32.const 1
+   drop
+   i32.const 8
+   i32.const 4
+   i32.eq
+   drop
+   i32.const 8
+   i32.const 8
+   i32.eq
+   drop
+   local.get $2
+   i64.reinterpret_f64
+   i64.const 63
+   i64.shr_u
+   i64.const 0
+   i64.ne
+   br $~lib/math/NativeMath.signbit<f64>|inlined.0
+  end
   i32.const 0
   i32.ne
   i32.eqz

--- a/tests/compiler/std/string.release.wat
+++ b/tests/compiler/std/string.release.wat
@@ -3695,7 +3695,7 @@
   local.get $5
   i64.mul
  )
- (func $~lib/math/ipow32 (param $0 i32) (result i32)
+ (func $~lib/util/math/ipow32 (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   i32.const 5
@@ -3849,7 +3849,7 @@
   end
   local.get $2
  )
- (func $~lib/math/NativeMath.scalbn (param $0 f64) (param $1 i32) (result f64)
+ (func $~lib/util/math/scalbn64 (param $0 f64) (param $1 i32) (result f64)
   local.get $1
   i32.const 1023
   i32.gt_s
@@ -4566,7 +4566,7 @@
       i32.const 0
       local.get $1
       i32.sub
-      call $~lib/math/ipow32
+      call $~lib/util/math/ipow32
       i64.extend_i32_s
       local.tee $13
       i64.div_u
@@ -4596,7 +4596,7 @@
       local.get $12
       i64.sub
       i32.wrap_i64
-      call $~lib/math/NativeMath.scalbn
+      call $~lib/util/math/scalbn64
      else
       local.get $6
       local.get $6
@@ -4668,7 +4668,7 @@
        end
       end
       local.get $3
-      call $~lib/math/ipow32
+      call $~lib/util/math/ipow32
       i64.extend_i32_u
       local.tee $8
       local.get $6
@@ -4718,7 +4718,7 @@
       f64.convert_i64_u
       global.get $~lib/util/string/__fixmulShift
       i32.wrap_i64
-      call $~lib/math/NativeMath.scalbn
+      call $~lib/util/math/scalbn64
      end
     end
     local.set $9

--- a/tests/compiler/std/typedarray.debug.wat
+++ b/tests/compiler/std/typedarray.debug.wat
@@ -10626,7 +10626,7 @@
   i64.const 2
   i64.eq
  )
- (func $~lib/math/NativeMathf.mod (param $0 f32) (param $1 f32) (result f32)
+ (func $~lib/util/math/mod32 (param $0 f32) (param $1 f32) (result f32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -10880,7 +10880,7 @@
  (func $std/typedarray/testArrayEvery<~lib/typedarray/Float32Array,f32>~anonymous|0 (param $0 f32) (param $1 i32) (param $2 i32) (result i32)
   local.get $0
   f32.const 2
-  call $~lib/math/NativeMathf.mod
+  call $~lib/util/math/mod32
   f32.const 0
   f32.eq
  )
@@ -10946,7 +10946,7 @@
   f32.const 2
   f32.eq
  )
- (func $~lib/math/NativeMath.mod (param $0 f64) (param $1 f64) (result f64)
+ (func $~lib/util/math/mod64 (param $0 f64) (param $1 f64) (result f64)
   (local $2 i64)
   (local $3 i64)
   (local $4 i64)
@@ -11206,7 +11206,7 @@
  (func $std/typedarray/testArrayEvery<~lib/typedarray/Float64Array,f64>~anonymous|0 (param $0 f64) (param $1 i32) (param $2 i32) (result i32)
   local.get $0
   f64.const 2
-  call $~lib/math/NativeMath.mod
+  call $~lib/util/math/mod64
   f64.const 0
   f64.eq
  )

--- a/tests/compiler/std/typedarray.release.wat
+++ b/tests/compiler/std/typedarray.release.wat
@@ -4976,7 +4976,7 @@
  (func $std/typedarray/testArrayEvery<~lib/typedarray/Float32Array,f32>~anonymous|0 (param $0 f32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
-  block $__inlined_func$~lib/math/NativeMathf.mod (result f32)
+  block $__inlined_func$~lib/util/math/mod32 (result f32)
    local.get $0
    i32.reinterpret_f32
    local.tee $3
@@ -4994,7 +4994,7 @@
     local.tee $0
     local.get $0
     f32.div
-    br $__inlined_func$~lib/math/NativeMathf.mod
+    br $__inlined_func$~lib/util/math/mod32
    end
    local.get $3
    i32.const 1
@@ -5009,7 +5009,7 @@
     i32.ne
     f32.convert_i32_u
     f32.mul
-    br $__inlined_func$~lib/math/NativeMathf.mod
+    br $__inlined_func$~lib/util/math/mod32
    end
    local.get $2
    if (result i32)
@@ -5047,7 +5047,7 @@
       local.get $1
       i32.const 8388608
       i32.eq
-      br_if $__inlined_func$~lib/math/NativeMathf.mod
+      br_if $__inlined_func$~lib/util/math/mod32
       drop
       local.get $1
       i32.const 8388608
@@ -5075,7 +5075,7 @@
     local.get $1
     i32.const 8388608
     i32.eq
-    br_if $__inlined_func$~lib/math/NativeMathf.mod
+    br_if $__inlined_func$~lib/util/math/mod32
     drop
     local.get $1
     i32.const 8388608
@@ -5123,7 +5123,7 @@
   (local $4 i64)
   (local $5 i64)
   (local $6 i64)
-  block $__inlined_func$~lib/math/NativeMath.mod (result f64)
+  block $__inlined_func$~lib/util/math/mod64 (result f64)
    local.get $0
    i64.reinterpret_f64
    local.tee $5
@@ -5141,7 +5141,7 @@
     local.tee $0
     local.get $0
     f64.div
-    br $__inlined_func$~lib/math/NativeMath.mod
+    br $__inlined_func$~lib/util/math/mod64
    end
    local.get $5
    i64.const 1
@@ -5156,7 +5156,7 @@
     i64.ne
     f64.convert_i32_u
     f64.mul
-    br $__inlined_func$~lib/math/NativeMath.mod
+    br $__inlined_func$~lib/util/math/mod64
    end
    local.get $4
    i64.eqz
@@ -5195,7 +5195,7 @@
       local.get $3
       i64.const 4503599627370496
       i64.eq
-      br_if $__inlined_func$~lib/math/NativeMath.mod
+      br_if $__inlined_func$~lib/util/math/mod64
       drop
       local.get $3
       i64.const 4503599627370496
@@ -5223,7 +5223,7 @@
     local.get $3
     i64.const 4503599627370496
     i64.eq
-    br_if $__inlined_func$~lib/math/NativeMath.mod
+    br_if $__inlined_func$~lib/util/math/mod64
     drop
     local.get $3
     i64.const 4503599627370496

--- a/tests/compiler/wasi/seed.debug.wat
+++ b/tests/compiler/wasi/seed.debug.wat
@@ -2,7 +2,6 @@
  (type $none_=>_f64 (func (result f64)))
  (type $i32_i32_=>_i32 (func (param i32 i32) (result i32)))
  (type $i64_=>_i64 (func (param i64) (result i64)))
- (type $i32_=>_i32 (func (param i32) (result i32)))
  (type $i64_=>_none (func (param i64)))
  (type $none_=>_none (func))
  (import "wasi_snapshot_preview1" "random_get" (func $~lib/bindings/wasi_snapshot_preview1/random_get (param i32 i32) (result i32)))
@@ -10,8 +9,6 @@
  (global $~lib/bindings/wasi/tempbuf i32 (i32.const 16))
  (global $~lib/math/random_state0_64 (mut i64) (i64.const 0))
  (global $~lib/math/random_state1_64 (mut i64) (i64.const 0))
- (global $~lib/math/random_state0_32 (mut i32) (i32.const 0))
- (global $~lib/math/random_state1_32 (mut i32) (i32.const 0))
  (global $~lib/memory/__data_end i32 (i32.const 32))
  (global $~lib/memory/__stack_pointer (mut i32) (i32.const 16416))
  (global $~lib/memory/__heap_base i32 (i32.const 16416))
@@ -41,7 +38,7 @@
   local.get $0
   f64.reinterpret_i64
  )
- (func $~lib/math/murmurHash3 (param $0 i64) (result i64)
+ (func $~lib/util/math/murmurHash3 (param $0 i64) (result i64)
   local.get $0
   local.get $0
   i64.const 33
@@ -70,41 +67,6 @@
   local.set $0
   local.get $0
  )
- (func $~lib/math/splitMix32 (param $0 i32) (result i32)
-  local.get $0
-  i32.const 1831565813
-  i32.add
-  local.set $0
-  local.get $0
-  local.get $0
-  i32.const 15
-  i32.shr_u
-  i32.xor
-  local.get $0
-  i32.const 1
-  i32.or
-  i32.mul
-  local.set $0
-  local.get $0
-  local.get $0
-  local.get $0
-  local.get $0
-  i32.const 7
-  i32.shr_u
-  i32.xor
-  local.get $0
-  i32.const 61
-  i32.or
-  i32.mul
-  i32.add
-  i32.xor
-  local.set $0
-  local.get $0
-  local.get $0
-  i32.const 14
-  i32.shr_u
-  i32.xor
- )
  (func $~lib/math/NativeMath.seedRandom (param $0 i64)
   local.get $0
   i64.const 0
@@ -114,20 +76,13 @@
    local.set $0
   end
   local.get $0
-  call $~lib/math/murmurHash3
+  call $~lib/util/math/murmurHash3
   global.set $~lib/math/random_state0_64
   global.get $~lib/math/random_state0_64
   i64.const -1
   i64.xor
-  call $~lib/math/murmurHash3
+  call $~lib/util/math/murmurHash3
   global.set $~lib/math/random_state1_64
-  local.get $0
-  i32.wrap_i64
-  call $~lib/math/splitMix32
-  global.set $~lib/math/random_state0_32
-  global.get $~lib/math/random_state0_32
-  call $~lib/math/splitMix32
-  global.set $~lib/math/random_state1_32
   i32.const 1
   global.set $~lib/math/random_seeded
  )

--- a/tests/compiler/wasi/seed.release.wat
+++ b/tests/compiler/wasi/seed.release.wat
@@ -40,39 +40,39 @@
    i64.const -49064778989728563
    i64.mul
    local.tee $0
+   local.get $0
    i64.const 33
    i64.shr_u
-   local.get $0
    i64.xor
    i64.const -4265267296055464877
    i64.mul
    local.tee $0
+   local.get $0
    i64.const 33
    i64.shr_u
-   local.get $0
    i64.xor
    global.set $~lib/math/random_state0_64
    global.get $~lib/math/random_state0_64
    i64.const -1
    i64.xor
    local.tee $0
+   local.get $0
    i64.const 33
    i64.shr_u
-   local.get $0
    i64.xor
    i64.const -49064778989728563
    i64.mul
    local.tee $0
+   local.get $0
    i64.const 33
    i64.shr_u
-   local.get $0
    i64.xor
    i64.const -4265267296055464877
    i64.mul
    local.tee $0
+   local.get $0
    i64.const 33
    i64.shr_u
-   local.get $0
    i64.xor
    global.set $~lib/math/random_state1_64
    i32.const 1
@@ -90,9 +90,9 @@
   i64.shl
   i64.xor
   local.tee $1
+  local.get $1
   i64.const 17
   i64.shr_u
-  local.get $1
   i64.xor
   i64.xor
   local.get $0


### PR DESCRIPTION
In this PR we're doing several breaking changes:


  + move all detailed implementations to `std/util/math`
  + make all Math's methods polymorphic
  + remove non-standard `Math#scalebn`
  + remove non-standard `Math#rem`
  + remove `NativeMathf` completely
  + for now, we have only single `Math.random` (for `f64` type)


Caveats:

  1. I have observed quite often the script that users from JS for example:
  
  ```ts
  function foo(x: i32, y: i32): i32 {
     let res = Math.floor(x / y) as i32;
     return res;
  }
  ```
  Before this PR this will create unnecessary cast to f64, `Math.floor` and downcast to `i32`. With this PR this code now equivalent to `x / y` without all this unnecessary work due to `Math.floor`, `Math.trunc` and etc accept integers and pass through it "as is". 
  
  2. Now following code will generate a compilation error:
  ```ts
  const cos3 = Math.cos(3);
  // -> ERROR: Math.cos accept only f32 or f64 types
  // Solution: it may be fixed as Math.cos(3.0)
  
  const x: i32 = 123;
  const sqr = Math.sqrt(x);
  // -> ERROR: Math.sqrt accept only f32 or f64 types
  // Solution: Math.sqrt(x as f64)
  ```
  
 This is the most painful caveat, which can lead to many breaking changes in some code.
 Perhaps we could add new generic builtin helper which forces parameter type to float. Something like:
 ```ts
 type Real<T> = T extends f32 | f64 ? infer T : f64
 
 function sqrt<T extends i32 | i64 | f32 | f64>(x: T): Real<T> {
    if (isInteger<T>()) {
      return Real<T>builtin_sqrt<f64>(x as f64);
    }
    if (isFloat<T>) {
      return Real<T>builtin_sqrt<T>(x);
    }
 }
 
 // now we can use integer inputs which will forced to f64 for outputs but safely preserve f32
 const sqrt3 = sqrt(3);
 ```
 Thoughts?

- [x] I've read the contributing guidelines
- [x] I've added my name and email to the NOTICE file
