### PR TITLE
feat: add `--disableWarning` option to disable compilation warning

### DIFF
--- a/cli/index.js
+++ b/cli/index.js
@@ -1125,12 +1125,12 @@ export function checkDiagnostics(program, stderr, disableWarning, reportDiagnost
     if (!diagnostic) break;
     if (stderr) {
       const isDisabledWarning = (diagnostic) => {
-        if (disableWarning == null) return true;
-        if (!disableWarning.length) return false;
+        if (disableWarning == null) return false;
+        if (!disableWarning.length) return true;
         const code = assemblyscript.getDiagnosticCode(diagnostic);
-        return !disableWarning.includes(code);
+        return disableWarning.includes(code);
       };
-      if (assemblyscript.isError(diagnostic) || isDisabledWarning(diagnostic)) {
+      if (assemblyscript.isError(diagnostic) || !isDisabledWarning(diagnostic)) {
         stderr.write(assemblyscript.formatDiagnostic(diagnostic, useColors, true) + EOL + EOL);
       }
     }

--- a/cli/index.js
+++ b/cli/index.js
@@ -1124,13 +1124,13 @@ export function checkDiagnostics(program, stderr, disableWarning, reportDiagnost
     let diagnostic = assemblyscript.nextDiagnostic(program);
     if (!diagnostic) break;
     if (stderr) {
-      const checkWarningPrint = (diagnostic) => {
+      const isDisabledWarning = (diagnostic) => {
         if (disableWarning == null) return true;
         if (!disableWarning.length) return false;
         const code = assemblyscript.getDiagnosticCode(diagnostic);
         return !disableWarning.includes(code);
       };
-      if (assemblyscript.isError(diagnostic) || checkWarningPrint(diagnostic)) {
+      if (assemblyscript.isError(diagnostic) || isDisabledWarning(diagnostic)) {
         stderr.write(assemblyscript.formatDiagnostic(diagnostic, useColors, true) + EOL + EOL);
       }
     }

--- a/cli/index.js
+++ b/cli/index.js
@@ -1125,11 +1125,10 @@ export function checkDiagnostics(program, stderr, disableWarning, reportDiagnost
     if (!diagnostic) break;
     if (stderr) {
       const checkWarningPrint = (diagnostic) => {
+        if (disableWarning == null) return true;
+        if (!disableWarning.length) return false;
         const code = assemblyscript.getDiagnosticCode(diagnostic);
-        if (disableWarning === undefined) return true;
-        if (disableWarning.length === 0) return false;
-        if (disableWarning.includes(code)) return false;
-        return true;
+        return !disableWarning.includes(code);
       };
       if (assemblyscript.isError(diagnostic) || checkWarningPrint(diagnostic)) {
         stderr.write(assemblyscript.formatDiagnostic(diagnostic, useColors, true) + EOL + EOL);

--- a/cli/options.json
+++ b/cli/options.json
@@ -315,8 +315,8 @@
   },
   "disableWarning": {
     "description": [
-      "Disables specified warning output", 
-      "not define specified warning number will disable all kinds of warning"
+      "Disables warnings matching the given diagnostic code.", 
+      "If no diagnostic code is given, all warnings are disabled."
     ],
     "type": "I"
   },

--- a/cli/options.json
+++ b/cli/options.json
@@ -282,7 +282,7 @@
   },
   "runPasses": {
     "category": "Binaryen",
-    "description":  [
+    "description": [
       "Specifies additional Binaryen passes to run after other",
       "optimizations, if any. See: Binaryen/src/passes/pass.cpp"
     ],
@@ -312,6 +312,13 @@
     ],
     "type": "b",
     "default": false
+  },
+  "disableWarning": {
+    "description": [
+      "Disables specified warning output", 
+      "not define specified warning number will disable all kinds of warning"
+    ],
+    "type": "I"
   },
   "noEmit": {
     "description": "Performs compilation as usual but does not emit code.",


### PR DESCRIPTION
<!--
 Thanks for submitting a pull request to AssemblyScript! Please take a moment to
 review the contributing guidelines linked below, and confirm with an [x] 🙂
-->

⯈fix #2277
⯈add `--disableWarning` option to disable compilation warning
eg:
    `--disableWarning 201` can disable warning 201
    `--disableWarning` can disable all warnings

- [x] I've read the contributing guidelines
- [x] I've added my name and email to the NOTICE file
