### PR TITLE
Add workaround for Math.pow constant folding (only for JS builds)

### DIFF
--- a/tests/compiler/std/math.debug.wat
+++ b/tests/compiler/std/math.debug.wat
@@ -59299,6 +59299,76 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f64.const 10
+  f64.const 308
+  call $~lib/math/NativeMath.pow
+  f64.const 1.e+308
+  f64.eq
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 4136
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const 10
+  f64.const 208
+  call $~lib/math/NativeMath.pow
+  f64.const 1.e+208
+  f64.eq
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 4137
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const 10
+  f64.const -5
+  call $~lib/math/NativeMath.pow
+  f64.const 1e-05
+  f64.eq
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 4138
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const 10
+  f32.const 38
+  call $~lib/math/NativeMathf.pow
+  f32.const 9999999680285692465065626e13
+  f32.eq
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 4139
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const 10
+  f32.const -5
+  call $~lib/math/NativeMathf.pow
+  f32.const 9.999999747378752e-06
+  f32.eq
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 4140
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
  )
  (func $~start
   call $start:std/math

--- a/tests/compiler/std/math.ts
+++ b/tests/compiler/std/math.ts
@@ -4131,3 +4131,10 @@ assert(0 ** 0.5 == 0.0);
 assert(0 ** -1.0 == Infinity);
 assert(0.0 ** 0 == 1.0);
 assert(1.0 ** 1 == 1.0);
+
+// Special cases for test constant fold correctness
+assert(10.0 ** 308 == 1e308);
+assert(10.0 ** 208 == 1e208);
+assert(10.0 ** -5 == 1e-5);
+assert(f32(10) ** 38 == f32(1e38));
+assert(f32(10) ** -5 == f32(1e-5));


### PR DESCRIPTION
Many browsers have fast paths for `Math.pow` if exponents is integer-like. But it leads to imprecisions like `10 ** 208 != 1e208` or `10 ** -5 != 1e-5`. For avoid this in our constant folding special case I add some clever workaround. Also add tests.

For more info see this comment: https://bugzilla.mozilla.org/show_bug.cgi?id=1775254#c13


- [x] I've read the contributing guidelines
- [x] I've added my name and email to the NOTICE file
