### PR TITLE
fix: Add coercion for unsigned 64-bit types for bindings

### DIFF
--- a/src/bindings/js.ts
+++ b/src/bindings/js.ts
@@ -1007,16 +1007,12 @@ export class JSBuilder extends ExportsWalker {
       sb.push(")");
     } else {
       // Lift basic plain types
-      if (type.isUnsignedIntegerValue && type.size == 64) {
-        sb.push(`BigInt.asUintN(64, ${name})`);
+      if (type == Type.bool) {
+        sb.push(`${name} != 0`);
+      } else if (type.isUnsignedIntegerValue && type.size >= 32) {
+        sb.push(type.size == 64 ? `BigInt.asUintN(64, ${name})` : `${name} >>> 0`);
       } else {
-        if (type == Type.bool) {
-          sb.push(`${name} != 0`);
-        } else if (type.isUnsignedIntegerValue) {
-          sb.push(`${name} >>> 0`);
-        } else {
-          sb.push(name);
-        }
+        sb.push(name);
       }
     }
   }

--- a/tests/compiler/bindings/esm.debug.d.ts
+++ b/tests/compiler/bindings/esm.debug.d.ts
@@ -53,6 +53,16 @@ export declare function plainFunction(a: number, b: number): number;
  */
 export declare function plainFunction64(a: bigint, b: bigint): bigint;
 /**
+ * bindings/esm/plainFunctionGetUnsigned32
+ * @returns `u32`
+ */
+export declare function plainFunctionGetUnsigned32(): number;
+/**
+ * bindings/esm/plainFunctionGetUnsigned64
+ * @returns `u64`
+ */
+export declare function plainFunctionGetUnsigned64(): bigint;
+/**
  * bindings/esm/bufferFunction
  * @param a `~lib/arraybuffer/ArrayBuffer`
  * @param b `~lib/arraybuffer/ArrayBuffer`

--- a/tests/compiler/bindings/esm.debug.d.ts
+++ b/tests/compiler/bindings/esm.debug.d.ts
@@ -53,15 +53,15 @@ export declare function plainFunction(a: number, b: number): number;
  */
 export declare function plainFunction64(a: bigint, b: bigint): bigint;
 /**
- * bindings/esm/plainFunctionGetUnsigned32
+ * bindings/esm/getMaxUnsigned32
  * @returns `u32`
  */
-export declare function plainFunctionGetUnsigned32(): number;
+export declare function getMaxUnsigned32(): number;
 /**
- * bindings/esm/plainFunctionGetUnsigned64
+ * bindings/esm/getMaxUnsigned64
  * @returns `u64`
  */
-export declare function plainFunctionGetUnsigned64(): bigint;
+export declare function getMaxUnsigned64(): bigint;
 /**
  * bindings/esm/bufferFunction
  * @param a `~lib/arraybuffer/ArrayBuffer`

--- a/tests/compiler/bindings/esm.debug.js
+++ b/tests/compiler/bindings/esm.debug.js
@@ -86,13 +86,13 @@ async function instantiate(module, imports = {}) {
       b = b || 0n;
       return exports.plainFunction64(a, b);
     },
-    plainFunctionGetUnsigned32() {
-      // bindings/esm/plainFunctionGetUnsigned32() => u32
-      return exports.plainFunctionGetUnsigned32() >>> 0;
+    getMaxUnsigned32() {
+      // bindings/esm/getMaxUnsigned32() => u32
+      return exports.getMaxUnsigned32() >>> 0;
     },
-    plainFunctionGetUnsigned64() {
-      // bindings/esm/plainFunctionGetUnsigned64() => u64
-      return BigInt.asUintN(64, exports.plainFunctionGetUnsigned64());
+    getMaxUnsigned64() {
+      // bindings/esm/getMaxUnsigned64() => u64
+      return BigInt.asUintN(64, exports.getMaxUnsigned64());
     },
     bufferFunction(a, b) {
       // bindings/esm/bufferFunction(~lib/arraybuffer/ArrayBuffer, ~lib/arraybuffer/ArrayBuffer) => ~lib/arraybuffer/ArrayBuffer
@@ -368,8 +368,8 @@ export const {
   ConstEnum,
   plainFunction,
   plainFunction64,
-  plainFunctionGetUnsigned32,
-  plainFunctionGetUnsigned64,
+  getMaxUnsigned32,
+  getMaxUnsigned64,
   bufferFunction,
   stringFunction,
   stringFunctionOptional,

--- a/tests/compiler/bindings/esm.debug.js
+++ b/tests/compiler/bindings/esm.debug.js
@@ -86,6 +86,14 @@ async function instantiate(module, imports = {}) {
       b = b || 0n;
       return exports.plainFunction64(a, b);
     },
+    plainFunctionGetUnsigned32() {
+      // bindings/esm/plainFunctionGetUnsigned32() => u32
+      return exports.plainFunctionGetUnsigned32() >>> 0;
+    },
+    plainFunctionGetUnsigned64() {
+      // bindings/esm/plainFunctionGetUnsigned64() => u64
+      return BigInt.asUintN(64, exports.plainFunctionGetUnsigned64());
+    },
     bufferFunction(a, b) {
       // bindings/esm/bufferFunction(~lib/arraybuffer/ArrayBuffer, ~lib/arraybuffer/ArrayBuffer) => ~lib/arraybuffer/ArrayBuffer
       a = __retain(__lowerBuffer(a) || __notnull());
@@ -360,6 +368,8 @@ export const {
   ConstEnum,
   plainFunction,
   plainFunction64,
+  plainFunctionGetUnsigned32,
+  plainFunctionGetUnsigned64,
   bufferFunction,
   stringFunction,
   stringFunctionOptional,

--- a/tests/compiler/bindings/esm.debug.wat
+++ b/tests/compiler/bindings/esm.debug.wat
@@ -12,6 +12,7 @@
  (type $i32_i32_f64_f64_f64_f64_f64_=>_none (func (param i32 i32 f64 f64 f64 f64 f64)))
  (type $f64_=>_f64 (func (param f64) (result f64)))
  (type $i64_i64_=>_i64 (func (param i64 i64) (result i64)))
+ (type $none_=>_i64 (func (result i64)))
  (type $i32_i32_i64_=>_none (func (param i32 i32 i64)))
  (type $i32_i32_=>_f32 (func (param i32 i32) (result f32)))
  (type $i32_f32_=>_none (func (param i32 f32)))
@@ -91,6 +92,8 @@
  (export "ConstEnum.THREE" (global $bindings/esm/ConstEnum.THREE))
  (export "plainFunction" (func $bindings/esm/plainFunction))
  (export "plainFunction64" (func $bindings/esm/plainFunction64))
+ (export "plainFunctionGetUnsigned32" (func $bindings/esm/plainFunctionGetUnsigned32))
+ (export "plainFunctionGetUnsigned64" (func $bindings/esm/plainFunctionGetUnsigned64))
  (export "newInternref" (func $bindings/esm/newInternref))
  (export "__new" (func $~lib/rt/itcms/__new))
  (export "__pin" (func $~lib/rt/itcms/__pin))
@@ -117,6 +120,12 @@
   local.get $0
   local.get $1
   i64.add
+ )
+ (func $bindings/esm/plainFunctionGetUnsigned32 (result i32)
+  i32.const -2
+ )
+ (func $bindings/esm/plainFunctionGetUnsigned64 (result i64)
+  i64.const -2
  )
  (func $~lib/arraybuffer/ArrayBuffer#get:byteLength (param $0 i32) (result i32)
   local.get $0

--- a/tests/compiler/bindings/esm.debug.wat
+++ b/tests/compiler/bindings/esm.debug.wat
@@ -35,6 +35,8 @@
  (global $bindings/esm/ConstEnum.ONE i32 (i32.const 1))
  (global $bindings/esm/ConstEnum.TWO i32 (i32.const 2))
  (global $bindings/esm/ConstEnum.THREE i32 (i32.const 3))
+ (global $~lib/builtins/u32.MAX_VALUE i32 (i32.const -1))
+ (global $~lib/builtins/u64.MAX_VALUE i64 (i64.const -1))
  (global $~lib/shared/runtime/Runtime.Stub i32 (i32.const 0))
  (global $~lib/shared/runtime/Runtime.Minimal i32 (i32.const 1))
  (global $~lib/shared/runtime/Runtime.Incremental i32 (i32.const 2))
@@ -92,8 +94,8 @@
  (export "ConstEnum.THREE" (global $bindings/esm/ConstEnum.THREE))
  (export "plainFunction" (func $bindings/esm/plainFunction))
  (export "plainFunction64" (func $bindings/esm/plainFunction64))
- (export "plainFunctionGetUnsigned32" (func $bindings/esm/plainFunctionGetUnsigned32))
- (export "plainFunctionGetUnsigned64" (func $bindings/esm/plainFunctionGetUnsigned64))
+ (export "getMaxUnsigned32" (func $bindings/esm/getMaxUnsigned32))
+ (export "getMaxUnsigned64" (func $bindings/esm/getMaxUnsigned64))
  (export "newInternref" (func $bindings/esm/newInternref))
  (export "__new" (func $~lib/rt/itcms/__new))
  (export "__pin" (func $~lib/rt/itcms/__pin))
@@ -121,11 +123,11 @@
   local.get $1
   i64.add
  )
- (func $bindings/esm/plainFunctionGetUnsigned32 (result i32)
-  i32.const -2
+ (func $bindings/esm/getMaxUnsigned32 (result i32)
+  global.get $~lib/builtins/u32.MAX_VALUE
  )
- (func $bindings/esm/plainFunctionGetUnsigned64 (result i64)
-  i64.const -2
+ (func $bindings/esm/getMaxUnsigned64 (result i64)
+  global.get $~lib/builtins/u64.MAX_VALUE
  )
  (func $~lib/arraybuffer/ArrayBuffer#get:byteLength (param $0 i32) (result i32)
   local.get $0

--- a/tests/compiler/bindings/esm.js
+++ b/tests/compiler/bindings/esm.js
@@ -35,8 +35,8 @@ export async function postInstantiate(instance) {
   assert.strictEqual(exports.Enum.TWO, 2);
   assert.strictEqual(exports.Enum[2], "TWO");
 
-  assert.strictEqual(exports.plainFunctionGetUnsigned32(), 4294967294);
-  assert.strictEqual(exports.plainFunctionGetUnsigned64(), 18446744073709551614n);
+  assert.strictEqual(exports.getMaxUnsigned32(), 4294967295);
+  assert.strictEqual(exports.getMaxUnsigned64(), 18446744073709551615n);
 
   assert.strictEqual(exports.plainFunction(1, 2), 3);
 

--- a/tests/compiler/bindings/esm.js
+++ b/tests/compiler/bindings/esm.js
@@ -35,6 +35,9 @@ export async function postInstantiate(instance) {
   assert.strictEqual(exports.Enum.TWO, 2);
   assert.strictEqual(exports.Enum[2], "TWO");
 
+  assert.strictEqual(exports.plainFunctionGetUnsigned32(), 4294967294);
+  assert.strictEqual(exports.plainFunctionGetUnsigned64(), 18446744073709551614n);
+
   assert.strictEqual(exports.plainFunction(1, 2), 3);
 
   {

--- a/tests/compiler/bindings/esm.release.d.ts
+++ b/tests/compiler/bindings/esm.release.d.ts
@@ -53,6 +53,16 @@ export declare function plainFunction(a: number, b: number): number;
  */
 export declare function plainFunction64(a: bigint, b: bigint): bigint;
 /**
+ * bindings/esm/plainFunctionGetUnsigned32
+ * @returns `u32`
+ */
+export declare function plainFunctionGetUnsigned32(): number;
+/**
+ * bindings/esm/plainFunctionGetUnsigned64
+ * @returns `u64`
+ */
+export declare function plainFunctionGetUnsigned64(): bigint;
+/**
  * bindings/esm/bufferFunction
  * @param a `~lib/arraybuffer/ArrayBuffer`
  * @param b `~lib/arraybuffer/ArrayBuffer`

--- a/tests/compiler/bindings/esm.release.d.ts
+++ b/tests/compiler/bindings/esm.release.d.ts
@@ -53,15 +53,15 @@ export declare function plainFunction(a: number, b: number): number;
  */
 export declare function plainFunction64(a: bigint, b: bigint): bigint;
 /**
- * bindings/esm/plainFunctionGetUnsigned32
+ * bindings/esm/getMaxUnsigned32
  * @returns `u32`
  */
-export declare function plainFunctionGetUnsigned32(): number;
+export declare function getMaxUnsigned32(): number;
 /**
- * bindings/esm/plainFunctionGetUnsigned64
+ * bindings/esm/getMaxUnsigned64
  * @returns `u64`
  */
-export declare function plainFunctionGetUnsigned64(): bigint;
+export declare function getMaxUnsigned64(): bigint;
 /**
  * bindings/esm/bufferFunction
  * @param a `~lib/arraybuffer/ArrayBuffer`

--- a/tests/compiler/bindings/esm.release.js
+++ b/tests/compiler/bindings/esm.release.js
@@ -86,13 +86,13 @@ async function instantiate(module, imports = {}) {
       b = b || 0n;
       return exports.plainFunction64(a, b);
     },
-    plainFunctionGetUnsigned32() {
-      // bindings/esm/plainFunctionGetUnsigned32() => u32
-      return exports.plainFunctionGetUnsigned32() >>> 0;
+    getMaxUnsigned32() {
+      // bindings/esm/getMaxUnsigned32() => u32
+      return exports.getMaxUnsigned32() >>> 0;
     },
-    plainFunctionGetUnsigned64() {
-      // bindings/esm/plainFunctionGetUnsigned64() => u64
-      return BigInt.asUintN(64, exports.plainFunctionGetUnsigned64());
+    getMaxUnsigned64() {
+      // bindings/esm/getMaxUnsigned64() => u64
+      return BigInt.asUintN(64, exports.getMaxUnsigned64());
     },
     bufferFunction(a, b) {
       // bindings/esm/bufferFunction(~lib/arraybuffer/ArrayBuffer, ~lib/arraybuffer/ArrayBuffer) => ~lib/arraybuffer/ArrayBuffer
@@ -368,8 +368,8 @@ export const {
   ConstEnum,
   plainFunction,
   plainFunction64,
-  plainFunctionGetUnsigned32,
-  plainFunctionGetUnsigned64,
+  getMaxUnsigned32,
+  getMaxUnsigned64,
   bufferFunction,
   stringFunction,
   stringFunctionOptional,

--- a/tests/compiler/bindings/esm.release.js
+++ b/tests/compiler/bindings/esm.release.js
@@ -86,6 +86,14 @@ async function instantiate(module, imports = {}) {
       b = b || 0n;
       return exports.plainFunction64(a, b);
     },
+    plainFunctionGetUnsigned32() {
+      // bindings/esm/plainFunctionGetUnsigned32() => u32
+      return exports.plainFunctionGetUnsigned32() >>> 0;
+    },
+    plainFunctionGetUnsigned64() {
+      // bindings/esm/plainFunctionGetUnsigned64() => u64
+      return BigInt.asUintN(64, exports.plainFunctionGetUnsigned64());
+    },
     bufferFunction(a, b) {
       // bindings/esm/bufferFunction(~lib/arraybuffer/ArrayBuffer, ~lib/arraybuffer/ArrayBuffer) => ~lib/arraybuffer/ArrayBuffer
       a = __retain(__lowerBuffer(a) || __notnull());
@@ -360,6 +368,8 @@ export const {
   ConstEnum,
   plainFunction,
   plainFunction64,
+  plainFunctionGetUnsigned32,
+  plainFunctionGetUnsigned64,
   bufferFunction,
   stringFunction,
   stringFunctionOptional,

--- a/tests/compiler/bindings/esm.release.wat
+++ b/tests/compiler/bindings/esm.release.wat
@@ -92,8 +92,8 @@
  (export "ConstEnum.THREE" (global $bindings/esm/ConstEnum.THREE))
  (export "plainFunction" (func $bindings/esm/plainFunction))
  (export "plainFunction64" (func $bindings/esm/plainFunction64))
- (export "plainFunctionGetUnsigned32" (func $bindings/esm/plainFunctionGetUnsigned32))
- (export "plainFunctionGetUnsigned64" (func $bindings/esm/plainFunctionGetUnsigned64))
+ (export "getMaxUnsigned32" (func $bindings/esm/getMaxUnsigned32))
+ (export "getMaxUnsigned64" (func $bindings/esm/getMaxUnsigned64))
  (export "newInternref" (func $bindings/esm/newInternref))
  (export "__new" (func $~lib/rt/itcms/__new))
  (export "__pin" (func $~lib/rt/itcms/__pin))
@@ -121,11 +121,11 @@
   local.get $1
   i64.add
  )
- (func $bindings/esm/plainFunctionGetUnsigned32 (result i32)
-  i32.const -2
+ (func $bindings/esm/getMaxUnsigned32 (result i32)
+  i32.const -1
  )
- (func $bindings/esm/plainFunctionGetUnsigned64 (result i64)
-  i64.const -2
+ (func $bindings/esm/getMaxUnsigned64 (result i64)
+  i64.const -1
  )
  (func $~lib/rt/itcms/visitRoots
   (local $0 i32)

--- a/tests/compiler/bindings/esm.release.wat
+++ b/tests/compiler/bindings/esm.release.wat
@@ -1,13 +1,14 @@
 (module
  (type $i32_i32_=>_i32 (func (param i32 i32) (result i32)))
  (type $i32_=>_none (func (param i32)))
- (type $none_=>_none (func))
  (type $none_=>_i32 (func (result i32)))
+ (type $none_=>_none (func))
  (type $i32_i32_=>_none (func (param i32 i32)))
  (type $i32_i32_i32_=>_none (func (param i32 i32 i32)))
  (type $i32_i32_f64_f64_f64_f64_f64_=>_none (func (param i32 i32 f64 f64 f64 f64 f64)))
  (type $f64_=>_f64 (func (param f64) (result f64)))
  (type $i64_i64_=>_i64 (func (param i64 i64) (result i64)))
+ (type $none_=>_i64 (func (result i64)))
  (type $i32_i32_i32_i32_=>_none (func (param i32 i32 i32 i32)))
  (type $i32_i32_i64_=>_none (func (param i32 i32 i64)))
  (type $i32_=>_i32 (func (param i32) (result i32)))
@@ -91,6 +92,8 @@
  (export "ConstEnum.THREE" (global $bindings/esm/ConstEnum.THREE))
  (export "plainFunction" (func $bindings/esm/plainFunction))
  (export "plainFunction64" (func $bindings/esm/plainFunction64))
+ (export "plainFunctionGetUnsigned32" (func $bindings/esm/plainFunctionGetUnsigned32))
+ (export "plainFunctionGetUnsigned64" (func $bindings/esm/plainFunctionGetUnsigned64))
  (export "newInternref" (func $bindings/esm/newInternref))
  (export "__new" (func $~lib/rt/itcms/__new))
  (export "__pin" (func $~lib/rt/itcms/__pin))
@@ -117,6 +120,12 @@
   local.get $0
   local.get $1
   i64.add
+ )
+ (func $bindings/esm/plainFunctionGetUnsigned32 (result i32)
+  i32.const -2
+ )
+ (func $bindings/esm/plainFunctionGetUnsigned64 (result i64)
+  i64.const -2
  )
  (func $~lib/rt/itcms/visitRoots
   (local $0 i32)

--- a/tests/compiler/bindings/esm.ts
+++ b/tests/compiler/bindings/esm.ts
@@ -26,6 +26,14 @@ export function plainFunction64(a: i64, b: i64): i64 {
   return a + b;
 }
 
+export function plainFunctionGetUnsigned32(): u32 {
+  return -2; // 4294967294
+}
+
+export function plainFunctionGetUnsigned64(): u64 {
+  return -2; // 18446744073709551614n
+}
+
 export function bufferFunction(a: ArrayBuffer, b: ArrayBuffer): ArrayBuffer {
   var aByteLength = a.byteLength;
   var bByteLength = b.byteLength;

--- a/tests/compiler/bindings/esm.ts
+++ b/tests/compiler/bindings/esm.ts
@@ -26,12 +26,12 @@ export function plainFunction64(a: i64, b: i64): i64 {
   return a + b;
 }
 
-export function plainFunctionGetUnsigned32(): u32 {
-  return -2; // 4294967294
+export function getMaxUnsigned32(): u32 {
+  return u32.MAX_VALUE; // 4294967295
 }
 
-export function plainFunctionGetUnsigned64(): u64 {
-  return -2; // 18446744073709551614n
+export function getMaxUnsigned64(): u64 {
+  return u64.MAX_VALUE; // 18446744073709551615
 }
 
 export function bufferFunction(a: ArrayBuffer, b: ArrayBuffer): ArrayBuffer {

--- a/tests/compiler/bindings/raw.debug.d.ts
+++ b/tests/compiler/bindings/raw.debug.d.ts
@@ -54,6 +54,16 @@ declare namespace __AdaptedExports {
    */
   export function plainFunction64(a: bigint, b: bigint): bigint;
   /**
+   * bindings/esm/plainFunctionGetUnsigned32
+   * @returns `u32`
+   */
+  export function plainFunctionGetUnsigned32(): number;
+  /**
+   * bindings/esm/plainFunctionGetUnsigned64
+   * @returns `u64`
+   */
+  export function plainFunctionGetUnsigned64(): bigint;
+  /**
    * bindings/esm/bufferFunction
    * @param a `~lib/arraybuffer/ArrayBuffer`
    * @param b `~lib/arraybuffer/ArrayBuffer`

--- a/tests/compiler/bindings/raw.debug.d.ts
+++ b/tests/compiler/bindings/raw.debug.d.ts
@@ -54,15 +54,15 @@ declare namespace __AdaptedExports {
    */
   export function plainFunction64(a: bigint, b: bigint): bigint;
   /**
-   * bindings/esm/plainFunctionGetUnsigned32
+   * bindings/esm/getMaxUnsigned32
    * @returns `u32`
    */
-  export function plainFunctionGetUnsigned32(): number;
+  export function getMaxUnsigned32(): number;
   /**
-   * bindings/esm/plainFunctionGetUnsigned64
+   * bindings/esm/getMaxUnsigned64
    * @returns `u64`
    */
-  export function plainFunctionGetUnsigned64(): bigint;
+  export function getMaxUnsigned64(): bigint;
   /**
    * bindings/esm/bufferFunction
    * @param a `~lib/arraybuffer/ArrayBuffer`

--- a/tests/compiler/bindings/raw.debug.js
+++ b/tests/compiler/bindings/raw.debug.js
@@ -86,13 +86,13 @@ export async function instantiate(module, imports = {}) {
       b = b || 0n;
       return exports.plainFunction64(a, b);
     },
-    plainFunctionGetUnsigned32() {
-      // bindings/esm/plainFunctionGetUnsigned32() => u32
-      return exports.plainFunctionGetUnsigned32() >>> 0;
+    getMaxUnsigned32() {
+      // bindings/esm/getMaxUnsigned32() => u32
+      return exports.getMaxUnsigned32() >>> 0;
     },
-    plainFunctionGetUnsigned64() {
-      // bindings/esm/plainFunctionGetUnsigned64() => u64
-      return BigInt.asUintN(64, exports.plainFunctionGetUnsigned64());
+    getMaxUnsigned64() {
+      // bindings/esm/getMaxUnsigned64() => u64
+      return BigInt.asUintN(64, exports.getMaxUnsigned64());
     },
     bufferFunction(a, b) {
       // bindings/esm/bufferFunction(~lib/arraybuffer/ArrayBuffer, ~lib/arraybuffer/ArrayBuffer) => ~lib/arraybuffer/ArrayBuffer

--- a/tests/compiler/bindings/raw.debug.js
+++ b/tests/compiler/bindings/raw.debug.js
@@ -86,6 +86,14 @@ export async function instantiate(module, imports = {}) {
       b = b || 0n;
       return exports.plainFunction64(a, b);
     },
+    plainFunctionGetUnsigned32() {
+      // bindings/esm/plainFunctionGetUnsigned32() => u32
+      return exports.plainFunctionGetUnsigned32() >>> 0;
+    },
+    plainFunctionGetUnsigned64() {
+      // bindings/esm/plainFunctionGetUnsigned64() => u64
+      return BigInt.asUintN(64, exports.plainFunctionGetUnsigned64());
+    },
     bufferFunction(a, b) {
       // bindings/esm/bufferFunction(~lib/arraybuffer/ArrayBuffer, ~lib/arraybuffer/ArrayBuffer) => ~lib/arraybuffer/ArrayBuffer
       a = __retain(__lowerBuffer(a) || __notnull());

--- a/tests/compiler/bindings/raw.debug.wat
+++ b/tests/compiler/bindings/raw.debug.wat
@@ -35,6 +35,8 @@
  (global $bindings/esm/ConstEnum.ONE i32 (i32.const 1))
  (global $bindings/esm/ConstEnum.TWO i32 (i32.const 2))
  (global $bindings/esm/ConstEnum.THREE i32 (i32.const 3))
+ (global $~lib/builtins/u32.MAX_VALUE i32 (i32.const -1))
+ (global $~lib/builtins/u64.MAX_VALUE i64 (i64.const -1))
  (global $~lib/shared/runtime/Runtime.Stub i32 (i32.const 0))
  (global $~lib/shared/runtime/Runtime.Minimal i32 (i32.const 1))
  (global $~lib/shared/runtime/Runtime.Incremental i32 (i32.const 2))
@@ -92,8 +94,8 @@
  (export "ConstEnum.THREE" (global $bindings/esm/ConstEnum.THREE))
  (export "plainFunction" (func $bindings/esm/plainFunction))
  (export "plainFunction64" (func $bindings/esm/plainFunction64))
- (export "plainFunctionGetUnsigned32" (func $bindings/esm/plainFunctionGetUnsigned32))
- (export "plainFunctionGetUnsigned64" (func $bindings/esm/plainFunctionGetUnsigned64))
+ (export "getMaxUnsigned32" (func $bindings/esm/getMaxUnsigned32))
+ (export "getMaxUnsigned64" (func $bindings/esm/getMaxUnsigned64))
  (export "newInternref" (func $bindings/esm/newInternref))
  (export "__new" (func $~lib/rt/itcms/__new))
  (export "__pin" (func $~lib/rt/itcms/__pin))
@@ -124,11 +126,11 @@
   local.get $1
   i64.add
  )
- (func $bindings/esm/plainFunctionGetUnsigned32 (result i32)
-  i32.const -2
+ (func $bindings/esm/getMaxUnsigned32 (result i32)
+  global.get $~lib/builtins/u32.MAX_VALUE
  )
- (func $bindings/esm/plainFunctionGetUnsigned64 (result i64)
-  i64.const -2
+ (func $bindings/esm/getMaxUnsigned64 (result i64)
+  global.get $~lib/builtins/u64.MAX_VALUE
  )
  (func $~lib/arraybuffer/ArrayBuffer#get:byteLength (param $0 i32) (result i32)
   local.get $0

--- a/tests/compiler/bindings/raw.debug.wat
+++ b/tests/compiler/bindings/raw.debug.wat
@@ -12,6 +12,7 @@
  (type $i32_i32_f64_f64_f64_f64_f64_=>_none (func (param i32 i32 f64 f64 f64 f64 f64)))
  (type $f64_=>_f64 (func (param f64) (result f64)))
  (type $i64_i64_=>_i64 (func (param i64 i64) (result i64)))
+ (type $none_=>_i64 (func (result i64)))
  (type $i32_i32_i64_=>_none (func (param i32 i32 i64)))
  (type $i32_i32_=>_f32 (func (param i32 i32) (result f32)))
  (type $i32_f32_=>_none (func (param i32 f32)))
@@ -91,6 +92,8 @@
  (export "ConstEnum.THREE" (global $bindings/esm/ConstEnum.THREE))
  (export "plainFunction" (func $bindings/esm/plainFunction))
  (export "plainFunction64" (func $bindings/esm/plainFunction64))
+ (export "plainFunctionGetUnsigned32" (func $bindings/esm/plainFunctionGetUnsigned32))
+ (export "plainFunctionGetUnsigned64" (func $bindings/esm/plainFunctionGetUnsigned64))
  (export "newInternref" (func $bindings/esm/newInternref))
  (export "__new" (func $~lib/rt/itcms/__new))
  (export "__pin" (func $~lib/rt/itcms/__pin))
@@ -120,6 +123,12 @@
   local.get $0
   local.get $1
   i64.add
+ )
+ (func $bindings/esm/plainFunctionGetUnsigned32 (result i32)
+  i32.const -2
+ )
+ (func $bindings/esm/plainFunctionGetUnsigned64 (result i64)
+  i64.const -2
  )
  (func $~lib/arraybuffer/ArrayBuffer#get:byteLength (param $0 i32) (result i32)
   local.get $0

--- a/tests/compiler/bindings/raw.release.d.ts
+++ b/tests/compiler/bindings/raw.release.d.ts
@@ -54,6 +54,16 @@ declare namespace __AdaptedExports {
    */
   export function plainFunction64(a: bigint, b: bigint): bigint;
   /**
+   * bindings/esm/plainFunctionGetUnsigned32
+   * @returns `u32`
+   */
+  export function plainFunctionGetUnsigned32(): number;
+  /**
+   * bindings/esm/plainFunctionGetUnsigned64
+   * @returns `u64`
+   */
+  export function plainFunctionGetUnsigned64(): bigint;
+  /**
    * bindings/esm/bufferFunction
    * @param a `~lib/arraybuffer/ArrayBuffer`
    * @param b `~lib/arraybuffer/ArrayBuffer`

--- a/tests/compiler/bindings/raw.release.d.ts
+++ b/tests/compiler/bindings/raw.release.d.ts
@@ -54,15 +54,15 @@ declare namespace __AdaptedExports {
    */
   export function plainFunction64(a: bigint, b: bigint): bigint;
   /**
-   * bindings/esm/plainFunctionGetUnsigned32
+   * bindings/esm/getMaxUnsigned32
    * @returns `u32`
    */
-  export function plainFunctionGetUnsigned32(): number;
+  export function getMaxUnsigned32(): number;
   /**
-   * bindings/esm/plainFunctionGetUnsigned64
+   * bindings/esm/getMaxUnsigned64
    * @returns `u64`
    */
-  export function plainFunctionGetUnsigned64(): bigint;
+  export function getMaxUnsigned64(): bigint;
   /**
    * bindings/esm/bufferFunction
    * @param a `~lib/arraybuffer/ArrayBuffer`

--- a/tests/compiler/bindings/raw.release.js
+++ b/tests/compiler/bindings/raw.release.js
@@ -86,13 +86,13 @@ export async function instantiate(module, imports = {}) {
       b = b || 0n;
       return exports.plainFunction64(a, b);
     },
-    plainFunctionGetUnsigned32() {
-      // bindings/esm/plainFunctionGetUnsigned32() => u32
-      return exports.plainFunctionGetUnsigned32() >>> 0;
+    getMaxUnsigned32() {
+      // bindings/esm/getMaxUnsigned32() => u32
+      return exports.getMaxUnsigned32() >>> 0;
     },
-    plainFunctionGetUnsigned64() {
-      // bindings/esm/plainFunctionGetUnsigned64() => u64
-      return BigInt.asUintN(64, exports.plainFunctionGetUnsigned64());
+    getMaxUnsigned64() {
+      // bindings/esm/getMaxUnsigned64() => u64
+      return BigInt.asUintN(64, exports.getMaxUnsigned64());
     },
     bufferFunction(a, b) {
       // bindings/esm/bufferFunction(~lib/arraybuffer/ArrayBuffer, ~lib/arraybuffer/ArrayBuffer) => ~lib/arraybuffer/ArrayBuffer

--- a/tests/compiler/bindings/raw.release.js
+++ b/tests/compiler/bindings/raw.release.js
@@ -86,6 +86,14 @@ export async function instantiate(module, imports = {}) {
       b = b || 0n;
       return exports.plainFunction64(a, b);
     },
+    plainFunctionGetUnsigned32() {
+      // bindings/esm/plainFunctionGetUnsigned32() => u32
+      return exports.plainFunctionGetUnsigned32() >>> 0;
+    },
+    plainFunctionGetUnsigned64() {
+      // bindings/esm/plainFunctionGetUnsigned64() => u64
+      return BigInt.asUintN(64, exports.plainFunctionGetUnsigned64());
+    },
     bufferFunction(a, b) {
       // bindings/esm/bufferFunction(~lib/arraybuffer/ArrayBuffer, ~lib/arraybuffer/ArrayBuffer) => ~lib/arraybuffer/ArrayBuffer
       a = __retain(__lowerBuffer(a) || __notnull());

--- a/tests/compiler/bindings/raw.release.wat
+++ b/tests/compiler/bindings/raw.release.wat
@@ -92,8 +92,8 @@
  (export "ConstEnum.THREE" (global $bindings/esm/ConstEnum.THREE))
  (export "plainFunction" (func $bindings/esm/plainFunction))
  (export "plainFunction64" (func $bindings/esm/plainFunction64))
- (export "plainFunctionGetUnsigned32" (func $bindings/esm/plainFunctionGetUnsigned32))
- (export "plainFunctionGetUnsigned64" (func $bindings/esm/plainFunctionGetUnsigned64))
+ (export "getMaxUnsigned32" (func $bindings/esm/getMaxUnsigned32))
+ (export "getMaxUnsigned64" (func $bindings/esm/getMaxUnsigned64))
  (export "newInternref" (func $bindings/esm/newInternref))
  (export "__new" (func $~lib/rt/itcms/__new))
  (export "__pin" (func $~lib/rt/itcms/__pin))
@@ -121,11 +121,11 @@
   local.get $1
   i64.add
  )
- (func $bindings/esm/plainFunctionGetUnsigned32 (result i32)
-  i32.const -2
+ (func $bindings/esm/getMaxUnsigned32 (result i32)
+  i32.const -1
  )
- (func $bindings/esm/plainFunctionGetUnsigned64 (result i64)
-  i64.const -2
+ (func $bindings/esm/getMaxUnsigned64 (result i64)
+  i64.const -1
  )
  (func $~lib/rt/itcms/visitRoots
   (local $0 i32)

--- a/tests/compiler/bindings/raw.release.wat
+++ b/tests/compiler/bindings/raw.release.wat
@@ -1,13 +1,14 @@
 (module
  (type $i32_i32_=>_i32 (func (param i32 i32) (result i32)))
  (type $i32_=>_none (func (param i32)))
- (type $none_=>_none (func))
  (type $none_=>_i32 (func (result i32)))
+ (type $none_=>_none (func))
  (type $i32_i32_=>_none (func (param i32 i32)))
  (type $i32_i32_i32_=>_none (func (param i32 i32 i32)))
  (type $i32_i32_f64_f64_f64_f64_f64_=>_none (func (param i32 i32 f64 f64 f64 f64 f64)))
  (type $f64_=>_f64 (func (param f64) (result f64)))
  (type $i64_i64_=>_i64 (func (param i64 i64) (result i64)))
+ (type $none_=>_i64 (func (result i64)))
  (type $i32_i32_i32_i32_=>_none (func (param i32 i32 i32 i32)))
  (type $i32_i32_i64_=>_none (func (param i32 i32 i64)))
  (type $i32_=>_i32 (func (param i32) (result i32)))
@@ -91,6 +92,8 @@
  (export "ConstEnum.THREE" (global $bindings/esm/ConstEnum.THREE))
  (export "plainFunction" (func $bindings/esm/plainFunction))
  (export "plainFunction64" (func $bindings/esm/plainFunction64))
+ (export "plainFunctionGetUnsigned32" (func $bindings/esm/plainFunctionGetUnsigned32))
+ (export "plainFunctionGetUnsigned64" (func $bindings/esm/plainFunctionGetUnsigned64))
  (export "newInternref" (func $bindings/esm/newInternref))
  (export "__new" (func $~lib/rt/itcms/__new))
  (export "__pin" (func $~lib/rt/itcms/__pin))
@@ -117,6 +120,12 @@
   local.get $0
   local.get $1
   i64.add
+ )
+ (func $bindings/esm/plainFunctionGetUnsigned32 (result i32)
+  i32.const -2
+ )
+ (func $bindings/esm/plainFunctionGetUnsigned64 (result i64)
+  i64.const -2
  )
  (func $~lib/rt/itcms/visitRoots
   (local $0 i32)


### PR DESCRIPTION
Example:
```ts
export function test(): u64 {
  return 18446744073709551614; // i64.const -2
}
```
Before:
```ts
assert(exports.test() == 18446744073709551614n) // -> fail due to return -2n
```
Now with this PR:
```ts
assert(exports.test() == 18446744073709551614n) // pass!
```

- [x] I've read the contributing guidelines
- [x] I've added my name and email to the NOTICE file
