### PR TITLE
fix: add class expressions to resolver

### DIFF
--- a/src/resolver.ts
+++ b/src/resolver.ts
@@ -1029,6 +1029,9 @@ export class Resolver extends DiagnosticEmitter {
           ctxFlow, ctxType, reportMode
         );
       }
+      case NodeKind.CLASS: {
+        return Type.void;
+      }
       case NodeKind.COMMA: {
         return this.resolveCommaExpression(
           <CommaExpression>node,

--- a/src/resolver.ts
+++ b/src/resolver.ts
@@ -1030,7 +1030,14 @@ export class Resolver extends DiagnosticEmitter {
         );
       }
       case NodeKind.CLASS: {
-        return Type.void;
+        if (reportMode == ReportMode.REPORT) {
+          this.error(
+            DiagnosticCode.Not_implemented_0,
+            node.range,
+            "Block-scoped class declarations or expressions"
+          );
+        }
+        return null;
       }
       case NodeKind.COMMA: {
         return this.resolveCommaExpression(

--- a/tests/compiler/issues/2356.json
+++ b/tests/compiler/issues/2356.json
@@ -1,0 +1,9 @@
+{
+  "asc_flags": [
+  ],
+  "stderr": [
+    "TS2329: Index signature is missing in type 'void'.",
+    "class Foo {}[0];",
+    "EOF"
+  ]
+}

--- a/tests/compiler/issues/2356.json
+++ b/tests/compiler/issues/2356.json
@@ -2,7 +2,7 @@
   "asc_flags": [
   ],
   "stderr": [
-    "TS2329: Index signature is missing in type 'void'.",
+    "AS100: Not implemented: Block-scoped class declarations or expressions",
     "class Foo {}[0];",
     "EOF"
   ]

--- a/tests/compiler/issues/2356.ts
+++ b/tests/compiler/issues/2356.ts
@@ -1,0 +1,5 @@
+export function foo(): void {
+  class Foo {}[0];
+  ERROR("EOF");
+}
+


### PR DESCRIPTION
<!--
 Thanks for submitting a pull request to AssemblyScript! Please take a moment to
 review the contributing guidelines linked below, and confirm with an [x] 🙂
-->

While testing array destructuring, I found that indexing a class crashed the compiler.

```ts
class Foo {}[0];
```

classes in JS return undefined, so I thought a void type would be fitting for class expressions.

- [x] I've read the contributing guidelines
- [x] I've added my name and email to the NOTICE file
