### PR TITLE
fix: Fix `||` and `&&` will not inherit branch status

### DIFF
--- a/src/compiler.ts
+++ b/src/compiler.ts
@@ -4566,14 +4566,15 @@ export class Compiler extends DiagnosticEmitter {
               expr = module.if(leftExpr, rightExpr, module.i32(0));
             }
           }
+          flow.inheritBranch(rightFlow, condKind);
           this.currentFlow = flow;
-          this.currentFlow.inheritBranch(rightFlow, condKind);
           this.currentType = Type.bool;
 
         } else {
           rightExpr = this.compileExpression(right, leftType, inheritedConstraints | Constraints.CONV_IMPLICIT);
           rightType = this.currentType;
           rightFlow.freeScopedLocals();
+          flow.inheritBranch(rightFlow);
           this.currentFlow = flow;
 
           // simplify if copying left is trivial
@@ -4597,7 +4598,6 @@ export class Compiler extends DiagnosticEmitter {
             flow.freeTempLocal(tempLocal);
           }
           this.currentType = leftType;
-          this.currentFlow.inheritBranch(rightFlow);
         }
         break;
       }

--- a/src/compiler.ts
+++ b/src/compiler.ts
@@ -4597,6 +4597,7 @@ export class Compiler extends DiagnosticEmitter {
           }
           this.currentType = leftType;
         }
+        this.currentFlow.inheritBranch(rightFlow);
         break;
       }
       case Token.BAR_BAR: { // left || right -> ((t = left) ? t : right)
@@ -4661,6 +4662,7 @@ export class Compiler extends DiagnosticEmitter {
           }
           this.currentType = leftType;
         }
+        this.currentFlow.inheritBranch(rightFlow);
         break;
       }
       default: {

--- a/tests/compiler/nullable.json
+++ b/tests/compiler/nullable.json
@@ -3,6 +3,7 @@
   ],
   "stderr": [
     "TS2322: Type 'nullable/Example | null' is not assignable to type 'nullable/Example'.",
+    "TS2322: Type 'nullable/Example | null' is not assignable to type 'nullable/Example'.",
     "EOF"
   ]
 }

--- a/tests/compiler/nullable.ts
+++ b/tests/compiler/nullable.ts
@@ -4,4 +4,14 @@ function notNullable(a: Example): void {}
 
 notNullable(null);
 
+export function test(): void {
+  let value: Example | null = new Example();
+  if (value != null) {
+    // value = null;
+    true && (value = null);
+    // "TS2322: Type 'nullable/Example | null' is not assignable to type 'nullable/Example'.",
+    notNullable(value);
+  }
+}
+
 ERROR("EOF");

--- a/tests/compiler/nullable.ts
+++ b/tests/compiler/nullable.ts
@@ -4,7 +4,7 @@ function notNullable(a: Example): void {}
 
 notNullable(null);
 
-export function test(): void {
+function test(): void {
   let value: Example | null = new Example();
   if (value != null) {
     // value = null;
@@ -13,5 +13,7 @@ export function test(): void {
     notNullable(value);
   }
 }
+
+test();
 
 ERROR("EOF");


### PR DESCRIPTION
<!--
 Thanks for submitting a pull request to AssemblyScript! Please take a moment to
 review the contributing guidelines linked below, and confirm with an [x] 🙂
-->

⯈Fix #2359 


- [x] I've read the contributing guidelines
- [x] I've added my name and email to the NOTICE file
