### PR TITLE
Introduce more faster and memory optimal BitSet as replacment of Set<i32>

### DIFF
--- a/src/compiler.ts
+++ b/src/compiler.ts
@@ -188,6 +188,7 @@ import {
 } from "./types";
 
 import {
+  BitSet,
   writeI8,
   writeI16,
   writeI32,
@@ -6748,7 +6749,7 @@ export class Compiler extends DiagnosticEmitter {
     var previousFlow = this.currentFlow;
     var flow = Flow.createInline(previousFlow.parentFunction, instance);
     var body = [];
-    var usedLocals = new Set<i32>();
+    var usedLocals = new BitSet();
 
     // Prepare compiled arguments right to left, keeping track of used locals.
     for (let i = numArguments - 1; i >= 0; --i) {

--- a/src/flow.ts
+++ b/src/flow.ts
@@ -84,6 +84,7 @@ import {
 } from "./ast";
 
 import {
+  BitSet,
   uniqueMap
 } from "./util";
 
@@ -323,7 +324,7 @@ export class Flow {
   }
 
   /** Gets a free temporary local of the specified type. */
-  getTempLocal(type: Type, except: Set<i32> | null = null): Local {
+  getTempLocal(type: Type, except: BitSet | null = null): Local {
     var parentFunction = this.parentFunction;
     var temps: Local[] | null;
     switch (<u32>type.toRef()) {
@@ -458,7 +459,7 @@ export class Flow {
   }
 
   /** Adds a new scoped local of the specified name. */
-  addScopedLocal(name: string, type: Type, except: Set<i32> | null = null): Local {
+  addScopedLocal(name: string, type: Type, except: BitSet | null = null): Local {
     var scopedLocal = this.getTempLocal(type, except);
     scopedLocal.setTemporaryName(name);
     var scopedLocals = this.scopedLocals;

--- a/src/passes/findusedlocals.ts
+++ b/src/passes/findusedlocals.ts
@@ -4,6 +4,10 @@
  */
 
 import {
+  BitSet
+} from "../util";
+
+import {
   Visitor
 } from "./pass";
 
@@ -17,13 +21,13 @@ import {
 } from "../glue/binaryen";
 
 class FindUsedLocalsVisitor extends Visitor {
-  used: Set<i32>;
+  used: BitSet;
 
-  constructor(used: Set<i32> = new Set()) {
+  constructor(used: BitSet = new BitSet()) {
     super();
     this.used = used;
   }
-  
+
   /** @override */
   visitLocalGet(localGet: ExpressionRef): void {
     this.used.add(<i32>_BinaryenLocalGetGetIndex(localGet));
@@ -40,8 +44,8 @@ var singleton: FindUsedLocalsVisitor | null = null;
 /** Finds the indexes of all locals used in the specified expression. */
 export function findUsedLocals(
   expr: ExpressionRef,
-  used: Set<i32> = new Set()
-): Set<i32> {
+  used: BitSet = new BitSet()
+): BitSet {
   var visitor = singleton;
   if (!visitor) singleton = visitor = new FindUsedLocalsVisitor(used);
   else visitor.used = used;

--- a/src/util/collections.ts
+++ b/src/util/collections.ts
@@ -25,6 +25,10 @@ export function uniqueMap<K,V>(original: Map<K,V> | null = null, overrides: Map<
   return cloned;
 }
 
+/** BitSet represent growable sequence of N bits. It's faster alternative of Set<i32> when elements
+ * are not too much sparsed. Also it's more memory and cache efficient than Array<bool>.
+ * The best way to use it for short bit sequences (less than 32*(2**16)).
+ */
 export class BitSet {
   words!: Uint32Array;
 

--- a/src/util/collections.ts
+++ b/src/util/collections.ts
@@ -58,7 +58,10 @@ export class BitSet {
   }
 
   has(index: i32): bool {
-    return (this.words[index >>> 5] & (1 << index)) !== 0;
+    var idx = index >>> 5;
+    var words = this.words;
+    if (idx >= words.length) return false;
+    return (unchecked(words[index >>> 5]) & (1 << index)) !== 0;
   }
 
   clear(): void {

--- a/src/util/collections.ts
+++ b/src/util/collections.ts
@@ -36,7 +36,8 @@ export class BitSet {
     var count = 0;
     var words = this.words;
     for (let i = 0, len = words.length; i < len; i++) {
-      count += popcnt(unchecked(words[i]));
+      let word = unchecked(words[i]);
+      if (word) count += popcnt(word);
     }
     return count;
   }

--- a/src/util/collections.ts
+++ b/src/util/collections.ts
@@ -45,7 +45,7 @@ export class BitSet {
   add(index: i32): this {
     var idx = index >>> 5;
     var words = this.words;
-    if (idx > words.length) { // resize
+    if (idx >= words.length) { // resize
       this.words = new Uint32Array(idx + 16);
       this.words.set(words);
       words = this.words;

--- a/src/util/collections.ts
+++ b/src/util/collections.ts
@@ -43,10 +43,13 @@ export class BitSet {
 
   add(index: i32): this {
     var idx = index >>> 5;
-    if (idx > this.words.length) {
-      this.resize(index);
+    var words = this.words;
+    if (idx > words.length) { // resize
+      this.words = new Uint32Array(idx + 8);
+      this.words.set(words);
+      words = this.words;
     }
-    unchecked(this.words[idx] |= 1 << index);
+    unchecked(words[idx] |= 1 << index);
     return this;
   }
 
@@ -66,12 +69,6 @@ export class BitSet {
 
   clear(): void {
     this.words = new Uint32Array(8);
-  }
-
-  private resize(index: i32): void {
-    var newWords = new Uint32Array((index + 64) >>> 5);
-    newWords.set(this.words);
-    this.words = newWords;
   }
 
   toArray(): i32[] {

--- a/src/util/collections.ts
+++ b/src/util/collections.ts
@@ -24,3 +24,67 @@ export function uniqueMap<K,V>(original: Map<K,V> | null = null, overrides: Map<
   }
   return cloned;
 }
+
+export class BitSet {
+  words!: Uint32Array;
+
+  constructor() {
+    this.clear();
+  }
+
+  get size(): i32 {
+    var count = 0;
+    var words = this.words;
+    for (let i = 0, len = words.length; i < len; i++) {
+      count += popcnt(unchecked(words[i]));
+    }
+    return count;
+  }
+
+  add(index: i32): this {
+    var idx = index >>> 5;
+    if (idx > this.words.length) {
+      this.resize(index);
+    }
+    unchecked(this.words[idx] |= 1 << index);
+    return this;
+  }
+
+  delete(index: i32): void {
+    var idx = index >>> 5;
+    var words = this.words;
+    if (idx >= words.length) return;
+    unchecked(words[idx] &= ~(1 << index));
+  }
+
+  has(index: i32): bool {
+    return (this.words[index >>> 5] & (1 << index)) !== 0;
+  }
+
+  clear(): void {
+    this.words = new Uint32Array(8);
+  }
+
+  private resize(index: i32): void {
+    var newWords = new Uint32Array((index + 64) >>> 5);
+    newWords.set(this.words);
+    this.words = newWords;
+  }
+
+  toArray(): i32[] {
+    var res = new Array<i32>(this.size);
+    for (let i = 0, p = 0, len = this.words.length; i < len; ++i) {
+      let word = unchecked(this.words[i]);
+      while (word) {
+        let mask = word & -word;
+        res[p++] = (i << 5) + popcnt(mask - 1);
+        word ^= mask;
+      }
+    }
+    return res;
+  }
+
+  toString(): string {
+    return `BitSet { ${this.toArray()} }`;
+  }
+}

--- a/src/util/collections.ts
+++ b/src/util/collections.ts
@@ -45,7 +45,7 @@ export class BitSet {
     var idx = index >>> 5;
     var words = this.words;
     if (idx > words.length) { // resize
-      this.words = new Uint32Array(idx + 8);
+      this.words = new Uint32Array(idx + 16);
       this.words.set(words);
       words = this.words;
     }
@@ -68,7 +68,7 @@ export class BitSet {
   }
 
   clear(): void {
-    this.words = new Uint32Array(8);
+    this.words = new Uint32Array(16);
   }
 
   toArray(): i32[] {
@@ -77,7 +77,7 @@ export class BitSet {
       let word = unchecked(this.words[i]);
       while (word) {
         let mask = word & -word;
-        res[p++] = (i << 5) + popcnt(mask - 1);
+        unchecked(res[p++] = (i << 5) + popcnt(mask - 1));
         word ^= mask;
       }
     }


### PR DESCRIPTION
Benchmark results for 1M items (JS):
```
BitSet add: 7.995ms
BitSet has: 4.894ms

Set<i32> add: 15.898ms
Set<i32> has: 15.414ms
```

Benchmark results for 100M items (Wasm):
```
BitSet add: 39.5000
BitSet has: 29.3000

Set<i32> add: 194.6000
Set<i32> has: 207.3000
```

- [x] I've read the contributing guidelines
- [x] I've added my name and email to the NOTICE file
