### PR TITLE
[feat] Add isVector builtin

### DIFF
--- a/src/builtins.ts
+++ b/src/builtins.ts
@@ -127,10 +127,11 @@ export namespace BuiltinNames {
   export const trace = "~lib/builtins/trace";
   export const seed = "~lib/builtins/seed";
 
-  export const isInteger = "~lib/builtins/isInteger";
-  export const isFloat = "~lib/builtins/isFloat";
   export const isBoolean = "~lib/builtins/isBoolean";
+  export const isInteger = "~lib/builtins/isInteger";
   export const isSigned = "~lib/builtins/isSigned";
+  export const isFloat = "~lib/builtins/isFloat";
+  export const isVector = "~lib/builtins/isVector";
   export const isReference = "~lib/builtins/isReference";
   export const isString = "~lib/builtins/isString";
   export const isArray = "~lib/builtins/isArray";
@@ -758,6 +759,17 @@ export const function_builtins = new Map<string,(ctx: BuiltinContext) => Express
 
 // === Static type evaluation =================================================================
 
+// isBoolean<T!>() / isBoolean<T?>(value: T) -> bool
+function builtin_isBoolean(ctx: BuiltinContext): ExpressionRef {
+  var compiler = ctx.compiler;
+  var module = compiler.module;
+  var type = checkConstantType(ctx);
+  compiler.currentType = Type.bool;
+  if (!type) return module.unreachable();
+  return reifyConstantType(ctx, module.i32(type.isBooleanValue ? 1 : 0));
+}
+builtins.set(BuiltinNames.isBoolean, builtin_isBoolean);
+
 // isInteger<T!>() / isInteger<T?>(value: T) -> bool
 function builtin_isInteger(ctx: BuiltinContext): ExpressionRef {
   var compiler = ctx.compiler;
@@ -768,6 +780,17 @@ function builtin_isInteger(ctx: BuiltinContext): ExpressionRef {
   return reifyConstantType(ctx, module.i32(type.isIntegerValue ? 1 : 0));
 }
 builtins.set(BuiltinNames.isInteger, builtin_isInteger);
+
+// isSigned<T!>() / isSigned<T?>(value: T) -> bool
+function builtin_isSigned(ctx: BuiltinContext): ExpressionRef {
+  var compiler = ctx.compiler;
+  var module = compiler.module;
+  var type = checkConstantType(ctx);
+  compiler.currentType = Type.bool;
+  if (!type) return module.unreachable();
+  return reifyConstantType(ctx, module.i32(type.isSignedIntegerValue ? 1 : 0));
+}
+builtins.set(BuiltinNames.isSigned, builtin_isSigned);
 
 // isFloat<T!>() / isFloat<T?>(value: T) -> bool
 function builtin_isFloat(ctx: BuiltinContext): ExpressionRef {
@@ -780,27 +803,16 @@ function builtin_isFloat(ctx: BuiltinContext): ExpressionRef {
 }
 builtins.set(BuiltinNames.isFloat, builtin_isFloat);
 
-// isBoolean<T!>() / isBoolean<T?>(value: T) -> bool
-function builtin_isBoolean(ctx: BuiltinContext): ExpressionRef {
+// isVector<T!>() / isVector<T?>(value: T) -> bool
+function builtin_isVector(ctx: BuiltinContext): ExpressionRef {
   var compiler = ctx.compiler;
   var module = compiler.module;
   var type = checkConstantType(ctx);
   compiler.currentType = Type.bool;
   if (!type) return module.unreachable();
-  return reifyConstantType(ctx, module.i32(type.isBooleanValue ? 1 : 0));
+  return reifyConstantType(ctx, module.i32(type.isVectorValue ? 1 : 0));
 }
-builtins.set(BuiltinNames.isBoolean, builtin_isBoolean);
-
-// isSigned<T!>() / isSigned<T?>(value: T) -> bool
-function builtin_isSigned(ctx: BuiltinContext): ExpressionRef {
-  var compiler = ctx.compiler;
-  var module = compiler.module;
-  var type = checkConstantType(ctx);
-  compiler.currentType = Type.bool;
-  if (!type) return module.unreachable();
-  return reifyConstantType(ctx, module.i32(type.isSignedIntegerValue ? 1 : 0));
-}
-builtins.set(BuiltinNames.isSigned, builtin_isSigned);
+builtins.set(BuiltinNames.isVector, builtin_isVector);
 
 // isReference<T!>() / isReference<T?>(value: T) -> bool
 function builtin_isReference(ctx: BuiltinContext): ExpressionRef {

--- a/std/assembly/builtins.ts
+++ b/std/assembly/builtins.ts
@@ -2,7 +2,15 @@ type auto = i32;
 
 // @ts-ignore: decorator
 @builtin
+export declare function isBoolean<T>(value?: T): bool;
+
+// @ts-ignore: decorator
+@builtin
 export declare function isInteger<T>(value?: T): bool;
+
+// @ts-ignore: decorator
+@builtin
+export declare function isSigned<T>(value?: T): bool;
 
 // @ts-ignore: decorator
 @builtin
@@ -10,11 +18,7 @@ export declare function isFloat<T>(value?: T): bool;
 
 // @ts-ignore: decorator
 @builtin
-export declare function isBoolean<T>(value?: T): bool;
-
-// @ts-ignore: decorator
-@builtin
-export declare function isSigned<T>(value?: T): bool;
+export declare function isVector<T>(value?: T): bool;
 
 // @ts-ignore: decorator
 @builtin

--- a/std/assembly/index.d.ts
+++ b/std/assembly/index.d.ts
@@ -196,14 +196,16 @@ declare function instantiate<T>(...args: any[]): T;
 declare function isNaN<T extends f32 | f64>(value: T): bool;
 /** Tests if a 32-bit or 64-bit float is finite, that is not `NaN` or +/-`Infinity`. */
 declare function isFinite<T extends f32 | f64>(value: T): bool;
-/** Tests if the specified type *or* expression is of an integer type and not a reference. Compiles to a constant. */
-declare function isInteger<T>(value?: any): value is number;
-/** Tests if the specified type *or* expression is of a float type. Compiles to a constant. */
-declare function isFloat<T>(value?: any): value is number;
 /** Tests if the specified type *or* expression is of a boolean type. */
 declare function isBoolean<T>(value?: any): value is number;
+/** Tests if the specified type *or* expression is of an integer type and not a reference. Compiles to a constant. */
+declare function isInteger<T>(value?: any): value is number;
 /** Tests if the specified type *or* expression can represent negative numbers. Compiles to a constant. */
 declare function isSigned<T>(value?: any): value is number;
+/** Tests if the specified type *or* expression is of a float type. Compiles to a constant. */
+declare function isFloat<T>(value?: any): value is number;
+/** Tests if the specified type *or* expression is of a v128 type. Compiles to a constant. */
+declare function isVector<T>(value?: any): value is v128;
 /** Tests if the specified type *or* expression is of a reference type. Compiles to a constant. */
 declare function isReference<T>(value?: any): value is object | string;
 /** Tests if the specified type *or* expression can be used as a string. Compiles to a constant. */

--- a/tests/compiler/simd.debug.wat
+++ b/tests/compiler/simd.debug.wat
@@ -4657,6 +4657,16 @@
  (func $start:simd
   i32.const 1
   drop
+  i32.const 1
+  drop
+  i32.const 0
+  i32.eqz
+  drop
+  i32.const 1
+  drop
+  i32.const 0
+  i32.eqz
+  drop
   call $simd/test_v128
   call $simd/test_i8x16
   call $simd/test_i16x8

--- a/tests/compiler/simd.ts
+++ b/tests/compiler/simd.ts
@@ -760,6 +760,13 @@ export function test_vars_f64x2_full(a: f64, b: f64): v128 {
 }
 
 if (ASC_FEATURE_SIMD) {
+  // test builtins
+  assert(isVector<v128>());
+  assert(!isVector<i32>());
+
+  assert(isVector(i32x4.splat(0)));
+  assert(!isVector(0));
+
   test_v128();
   test_i8x16();
   test_i16x8();


### PR DESCRIPTION
```ts
/** Tests if the specified type *or* expression is of a v128 type. Compiles to a constant. */
declare function isVector<T>(value?: any): value is v128;
```
- [x] I've read the contributing guidelines
- [x] I've added my name and email to the NOTICE file
