### PR TITLE
[cli] Prevent uses binaryFile in options

### DIFF
--- a/cli/index.js
+++ b/cli/index.js
@@ -855,6 +855,10 @@ export async function main(argv, options) {
 
   // Prepare output
   if (!opts.noEmit) {
+    if (opts.binaryFile) {
+      // We catched lagacy field for binary output (before 0.20)
+      return prepareResult(Error("`binaryFile` doesn't support. Please use `outFile` instead."));
+    }
     let bindings = opts.bindings || [];
     let hasStdout = false;
     let hasOutFile = opts.outFile != null;


### PR DESCRIPTION
It's pretty frequent mistake during migration from 0.19.x to 0.20.x.

- [x] I've read the contributing guidelines
- [x] I've added my name and email to the NOTICE file
