### PR TITLE
Basic support for inner type aliases

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -52,6 +52,7 @@ under the licensing terms detailed in LICENSE:
 * Ruixiang Chen <xiang19890319@gmail.com>
 * Daniel Salvadori <danaugrs@gmail.com>
 * Jairus Tanaka <jairus.v.tanaka@outlook.com>
+* CountBleck <Mr.YouKnowWhoIAm@protonmail.com>
 
 Portions of this software are derived from third-party works licensed under
 the following terms:

--- a/src/compiler.ts
+++ b/src/compiler.ts
@@ -145,6 +145,7 @@ import {
   SwitchStatement,
   ThrowStatement,
   TryStatement,
+  TypeDeclaration,
   VariableStatement,
   VoidStatement,
   WhileStatement,
@@ -2149,13 +2150,15 @@ export class Compiler extends DiagnosticEmitter {
         break;
       }
       case NodeKind.TYPEDECLARATION: {
-        // TODO: integrate inner type declaration into flow
-        this.error(
-          DiagnosticCode.Not_implemented_0,
-          statement.range,
-          "Inner type alias"
+        const declaration = <TypeDeclaration>statement;
+        const contextualTypeArguments = this.currentFlow.contextualTypeArguments!;
+        const type = this.resolver.resolveType(
+          declaration.type,
+          this.currentFlow.actualFunction,
+          cloneMap(contextualTypeArguments)
         );
-        stmt = module.unreachable();
+        contextualTypeArguments.set(declaration.name.text, type!);
+        stmt = module.nop();
         break;
       }
       case NodeKind.MODULE: {

--- a/src/flow.ts
+++ b/src/flow.ts
@@ -28,7 +28,8 @@ import {
   ElementKind,
   Field,
   Class,
-  TypedElement
+  TypedElement,
+  TypeDefinition
 } from "./program";
 
 import {
@@ -244,7 +245,9 @@ export class Flow {
   /** The label we break to when encountering a return statement, when inlining. */
   inlineReturnLabel: string | null = null;
   /** The current contextual type arguments */
-  contextualTypeArguments: Map<string,Type> | null = null;
+  contextualTypeArguments: Map<string,Type>;
+  /** The current contextual type definitions */
+  contextualTypeDefinitions: Map<string,TypeDefinition> | null = null;
 
   /** Tests if this is an inline flow. */
   get isInline(): bool {
@@ -298,6 +301,7 @@ export class Flow {
     branch.parent = this;
     branch.outer = this.outer;
     branch.contextualTypeArguments = cloneMap(this.contextualTypeArguments);
+    branch.contextualTypeDefinitions = cloneMap(this.contextualTypeDefinitions);
     if (resetBreakContext) {
       branch.flags = this.flags & ~(
         FlowFlags.BREAKS |

--- a/src/flow.ts
+++ b/src/flow.ts
@@ -209,6 +209,7 @@ export class Flow {
     var flow = new Flow(parentFunction);
     flow.inlineFunction = inlineFunction;
     flow.inlineReturnLabel = `${inlineFunction.internalName}|inlined.${(inlineFunction.nextInlineId++)}`;
+    flow.contextualTypeArguments = cloneMap(inlineFunction.contextualTypeArguments);
     if (inlineFunction.is(CommonFlags.CONSTRUCTOR)) {
       flow.initThisFieldFlags();
     }
@@ -219,7 +220,7 @@ export class Flow {
     /** Function this flow belongs to. */
     public parentFunction: Function
   ) {
-    /* nop */
+    this.contextualTypeArguments = cloneMap(this.parentFunction.contextualTypeArguments);
   }
 
   /** Parent flow. */
@@ -242,6 +243,8 @@ export class Flow {
   inlineFunction: Function | null = null;
   /** The label we break to when encountering a return statement, when inlining. */
   inlineReturnLabel: string | null = null;
+  /** The current contextual type arguments */
+  contextualTypeArguments: Map<string,Type> | null = null;
 
   /** Tests if this is an inline flow. */
   get isInline(): bool {
@@ -258,11 +261,6 @@ export class Flow {
   /** Gets the current return type. */
   get returnType(): Type {
     return this.actualFunction.signature.returnType;
-  }
-
-  /** Gets the current contextual type arguments. */
-  get contextualTypeArguments(): Map<string,Type> | null {
-    return this.actualFunction.contextualTypeArguments;
   }
 
   /** Tests if this flow has the specified flag or flags. */
@@ -299,6 +297,7 @@ export class Flow {
     var branch = new Flow(this.parentFunction);
     branch.parent = this;
     branch.outer = this.outer;
+    branch.contextualTypeArguments = cloneMap(this.contextualTypeArguments);
     if (resetBreakContext) {
       branch.flags = this.flags & ~(
         FlowFlags.BREAKS |

--- a/src/resolver.ts
+++ b/src/resolver.ts
@@ -720,7 +720,6 @@ export class Resolver extends DiagnosticEmitter {
     }
     var typeArguments = new Array<Type>(maxParameterCount);
     var oldCtxTypes = cloneMap(ctxTypes);
-    ctxTypes.clear();
     for (let i = 0; i < maxParameterCount; ++i) {
       let type = i < argumentCount
         ? this.resolveType( // reports

--- a/tests/compiler/typealias-error.json
+++ b/tests/compiler/typealias-error.json
@@ -1,0 +1,9 @@
+{
+  "asc_flags": [],
+  "stderr": [
+    "TS2304: Cannot find name 'T'.",
+    "let element: T = arr[0];",
+    "TS2304: Cannot find name 'element'.",
+    "return element;"
+  ]
+}

--- a/tests/compiler/typealias-error.ts
+++ b/tests/compiler/typealias-error.ts
@@ -1,0 +1,9 @@
+function foo<TArr extends ArrayLike<number>>(arr: TArr): valueof<TArr> {
+  {
+    type T = valueof<TArr>;
+  }
+  let element: T = arr[0];
+  return element;
+}
+
+foo([123]);

--- a/tests/compiler/typealias.debug.wat
+++ b/tests/compiler/typealias.debug.wat
@@ -8,8 +8,8 @@
  (elem $0 (i32.const 1))
  (export "alias" (func $typealias/alias))
  (export "memory" (memory $0))
- (func $typealias/alias (param $a f32) (result f64)
-  local.get $a
+ (func $typealias/alias (param $alias f32) (result f64)
+  local.get $alias
   f64.promote_f32
  )
 )

--- a/tests/compiler/typealias.debug.wat
+++ b/tests/compiler/typealias.debug.wat
@@ -1,5 +1,5 @@
 (module
- (type $i32_=>_i32 (func (param i32) (result i32)))
+ (type $f32_=>_f64 (func (param f32) (result f64)))
  (global $~lib/memory/__data_end i32 (i32.const 8))
  (global $~lib/memory/__stack_pointer (mut i32) (i32.const 16392))
  (global $~lib/memory/__heap_base i32 (i32.const 16392))
@@ -8,7 +8,8 @@
  (elem $0 (i32.const 1))
  (export "alias" (func $typealias/alias))
  (export "memory" (memory $0))
- (func $typealias/alias (param $a i32) (result i32)
+ (func $typealias/alias (param $a f32) (result f64)
   local.get $a
+  f64.promote_f32
  )
 )

--- a/tests/compiler/typealias.release.wat
+++ b/tests/compiler/typealias.release.wat
@@ -1,9 +1,10 @@
 (module
- (type $i32_=>_i32 (func (param i32) (result i32)))
+ (type $f32_=>_f64 (func (param f32) (result f64)))
  (memory $0 0)
  (export "alias" (func $typealias/alias))
  (export "memory" (memory $0))
- (func $typealias/alias (param $0 i32) (result i32)
+ (func $typealias/alias (param $0 f32) (result f64)
   local.get $0
+  f64.promote_f32
  )
 )

--- a/tests/compiler/typealias.ts
+++ b/tests/compiler/typealias.ts
@@ -1,8 +1,9 @@
-export type alias = i32;
+type A = f32;
 // TODO: Without 'export' this yields 'ERROR TS2395: Individual declarations in merged declaration...'
 // which differs from TypeScript, but we don't have individual element and type spaces per file and this
 // just merges.
 
-export function alias(a: alias): alias {
-  return a;
+export function alias(a: A): f64 {
+  type B = f64;
+  return a as B;
 }

--- a/tests/compiler/typealias.ts
+++ b/tests/compiler/typealias.ts
@@ -3,7 +3,31 @@ export type alias = f32;
 // which differs from TypeScript, but we don't have individual element and type spaces per file and this
 // just merges.
 
+@inline
+function complex<T>(): void {
+  type Dummy = Set<u8>;
+
+  type A = T;
+  type B = Array<T>;
+  type C = Dummy;
+
+  type D<X> = T;
+  type E<X> = Array<T>;
+  type F<X> = Dummy;
+  type G<X> = Map<X, T>;
+
+  const a: Dummy | null = null;
+  const b: A | null = null;
+  const c: B | null = null;
+  const d: C | null = null;
+  const e: D<i32> | null = null;
+  const f: E<i32> | null = null;
+  const g: F<i32> | null = null;
+  const h: G<i32> | null = null;
+}
+
 export function alias(alias: alias): f64 {
+  complex<Set<isize>>();
   type alias = f64;
   return alias as alias;
 }

--- a/tests/compiler/typealias.ts
+++ b/tests/compiler/typealias.ts
@@ -1,9 +1,9 @@
-type A = f32;
+export type alias = f32;
 // TODO: Without 'export' this yields 'ERROR TS2395: Individual declarations in merged declaration...'
 // which differs from TypeScript, but we don't have individual element and type spaces per file and this
 // just merges.
 
-export function alias(a: A): f64 {
-  type B = f64;
-  return a as B;
+export function alias(alias: alias): f64 {
+  type alias = f64;
+  return alias as alias;
 }


### PR DESCRIPTION
<!--
 Thanks for submitting a pull request to AssemblyScript! Please take a moment to
 review the contributing guidelines linked below, and confirm with an [x] 🙂
-->

This PR is an attempt at #2392. This is a basic implementation, with features missing like:
* Declaration hoisting: currently, inner type aliases can only be used after their declaration.
* ~~Parameter types: these are ignored by the implementation, leading them to be treated as if they were never defined.~~

However, these inner type declarations are block-scoped, thanks to a modification of `Flow`.

- [x] I've read the contributing guidelines
- [x] I've added my name and email to the NOTICE file
