### PR TITLE
Refactor branch / select sign checks from rshift to cmp with zero

### DIFF
--- a/std/assembly/util/math.ts
+++ b/std/assembly/util/math.ts
@@ -426,7 +426,7 @@ export function powf_lut(x: f32, y: f32): f32 {
       return iy >> 31 ? 1 / x2 : x2;
     }
     // x and y are non-zero finite.
-    if (ix >> 31) {
+    if (<i32>ix < 0) {
       // Finite x < 0.
       let yint = checkintf(iy);
       if (yint == 0) return (x - x) / (x - x);
@@ -763,7 +763,7 @@ export function exp2_lut(x: f64): f64 {
     if (abstop >= 0x409) {
       if (ux == 0xFFF0000000000000) return 0;
       if (abstop >= 0x7FF) return 1.0 + x;
-      if (!(ux >> 63)) return Infinity;
+      if (<i64>ux >= 0) return Infinity;
       else if (ux >= 0xC090CC0000000000) return 0;
     }
     if ((ux << 1) > 0x811A000000000000) abstop = 0; // Large x is special cased below.
@@ -1877,7 +1877,7 @@ export function pow_lut(x: f64, y: f64): f64 {
       return iy >> 63 ? 1 / x2 : x2;
     }
     // Here x and y are non-zero finite
-    if (ix >> 63) {
+    if (<i64>ix < 0) {
       // Finite x < 0
       let yint = checkint(iy);
       if (yint == 0) return (x - x) / (x - x);

--- a/std/assembly/util/math.ts
+++ b/std/assembly/util/math.ts
@@ -320,10 +320,10 @@ function log2f_inline(ux: u32): f64 {
   // The range is split into N subintervals.
   // The ith subinterval contains z and c is near its center.
   var tmp  = ux - 0x3F330000;
-  var i    = <usize>((tmp >> (23 - LOG2F_TABLE_BITS)) & N_MASK);
+  var i    = usize((tmp >> (23 - LOG2F_TABLE_BITS)) & N_MASK);
   var top  = tmp & 0xFF800000;
   var uz   = ux - top;
-  var k    = <i32>(<i32>top >> 23);
+  var k    = <i32>top >> 23;
 
   var invc = load<f64>(LOG2F_DATA_TAB + (i << (1 + alignof<f64>())), 0 << alignof<f64>());
   var logc = load<f64>(LOG2F_DATA_TAB + (i << (1 + alignof<f64>())), 1 << alignof<f64>());
@@ -423,7 +423,7 @@ export function powf_lut(x: f32, y: f32): f32 {
     if (zeroinfnanf(ix)) {
       let x2 = x * x;
       if ((ix >> 31) && checkintf(iy) == 1) x2 = -x2;
-      return iy >> 31 ? 1 / x2 : x2;
+      return <i32>iy < 0 ? 1 / x2 : x2;
     }
     // x and y are non-zero finite.
     if (<i32>ix < 0) {
@@ -651,13 +651,16 @@ export function exp_lut(x: f64): f64 {
     C5 = reinterpret<f64>(0x3F81111167A4D017); // __exp_data.poly[3] (0x1.1111167a4d017p-7)
 
   var ux = reinterpret<u64>(x);
-  var abstop = <u32>(ux >> 52 & 0x7FF);
+  var abstop = u32(ux >> 52) & 0x7FF;
   if (abstop - 0x3C9 >= 0x03F) {
     if (abstop - 0x3C9 >= 0x80000000) return 1;
     if (abstop >= 0x409) {
       if (ux == 0xFFF0000000000000) return 0;
-      if (abstop >= 0x7FF) return 1.0 + x;
-      return select<f64>(0, Infinity, ux >> 63);
+      if (abstop >= 0x7FF) {
+        return 1.0 + x;
+      } else {
+        return select<f64>(0, Infinity, <i64>ux < 0);
+      }
     }
     // Large x is special cased below.
     abstop = 0;
@@ -682,7 +685,7 @@ export function exp_lut(x: f64): f64 {
   // #endif
   var r = x + kd * NegLn2hiN + kd * NegLn2loN;
   // 2^(k/N) ~= scale * (1 + tail).
-  var idx = <usize>((ki & N_MASK) << 1);
+  var idx = usize((ki & N_MASK) << 1);
   var top = ki << (52 - EXP_TABLE_BITS);
 
   var tail = reinterpret<f64>(load<u64>(EXP_DATA_TAB + (idx << alignof<u64>()))); // T[idx]
@@ -757,7 +760,7 @@ export function exp2_lut(x: f64): f64 {
     C5 = reinterpret<f64>(0x3F55D7E09B4E3A84); // 0x1.5d7e09b4e3a84p-10
 
   var ux = reinterpret<u64>(x);
-  var abstop = <u32>(ux >> 52 & 0x7ff);
+  var abstop = u32(ux >> 52) & 0x7ff;
   if (abstop - 0x3C9 >= 0x03F) {
     if (abstop - 0x3C9 >= 0x80000000) return 1.0;
     if (abstop >= 0x409) {
@@ -776,7 +779,7 @@ export function exp2_lut(x: f64): f64 {
   kd -= shift; // k/N for int k
   var r = x - kd;
   // 2^(k/N) ~= scale * (1 + tail)
-  var idx = <usize>((ki & N_MASK) << 1);
+  var idx = usize((ki & N_MASK) << 1);
   var top = ki << (52 - EXP_TABLE_BITS);
 
   var tail = reinterpret<f64>(load<u64>(EXP_DATA_TAB + (idx << alignof<u64>()), 0 << alignof<u64>())); // T[idx])
@@ -1023,7 +1026,7 @@ export function log2_lut(x: f64): f64 {
           r4 * (B6 + r * B7 + r2 * (B8 + r * B9)));
     return y + lo;
   }
-  var top = <u32>(ix >> 48);
+  var top = u32(ix >> 48);
   if (top - 0x0010 >= 0x7ff0 - 0x0010) {
     // x < 0x1p-1022 or inf or nan.
     if ((ix << 1) == 0) return -1.0 / (x * x);
@@ -1715,7 +1718,7 @@ function log_inline(ix: u64): f64 {
   // The range is split into N subintervals.
   // The ith subinterval contains z and c is near its center.
   var tmp = ix - 0x3fE6955500000000;
-  var i   = <usize>((tmp >> (52 - POW_LOG_TABLE_BITS)) & N_MASK);
+  var i   = usize((tmp >> (52 - POW_LOG_TABLE_BITS)) & N_MASK);
   var k   = <i64>tmp >> 52;
   var iz  = ix - (tmp & u64(0xFFF) << 52);
   var z   = reinterpret<f64>(iz);
@@ -1791,7 +1794,7 @@ function exp_inline(x: f64, xtail: f64, sign_bias: u32): f64 {
   var kd: f64, z: f64, r: f64, r2: f64, scale: f64, tail: f64, tmp: f64;
 
   var ux = reinterpret<u64>(x);
-  abstop = <u32>(ux >> 52) & 0x7FF;
+  abstop = u32(ux >> 52) & 0x7FF;
   if (abstop - 0x3C9 >= 0x03F) {
     if (abstop - 0x3C9 >= 0x80000000) {
       // Avoid spurious underflow for tiny x.
@@ -1800,7 +1803,9 @@ function exp_inline(x: f64, xtail: f64, sign_bias: u32): f64 {
     }
     if (abstop >= 0x409) { // top12(1024.0)
       // Note: inf and nan are already handled.
-      return ux >> 63 ? uflow(sign_bias) : oflow(sign_bias);
+      return <i64>ux < 0
+        ? uflow(sign_bias)
+        : oflow(sign_bias);
     }
     // Large x is special cased below.
     abstop = 0;
@@ -1828,7 +1833,7 @@ function exp_inline(x: f64, xtail: f64, sign_bias: u32): f64 {
   // The code assumes 2^-200 < |xtail| < 2^-8/N
   r += xtail;
   // 2^(k/N) ~= scale * (1 + tail)
-  idx = <usize>((ki & N_MASK) << 1);
+  idx = usize((ki & N_MASK) << 1);
   top = (ki + sign_bias) << (52 - EXP_TABLE_BITS);
 
   tail = reinterpret<f64>(load<u64>(EXP_DATA_TAB + (idx << alignof<u64>())));
@@ -1874,7 +1879,7 @@ export function pow_lut(x: f64, y: f64): f64 {
     if (zeroinfnan(ix)) {
       let x2 = x * x;
       if (i32(ix >> 63) && checkint(iy) == 1) x2 = -x2;
-      return iy >> 63 ? 1 / x2 : x2;
+      return <i64>iy < 0 ? 1 / x2 : x2;
     }
     // Here x and y are non-zero finite
     if (<i64>ix < 0) {

--- a/tests/compiler/binary.debug.wat
+++ b/tests/compiler/binary.debug.wat
@@ -549,10 +549,8 @@
       local.set $10
      end
      local.get $6
-     i64.const 63
-     i64.shr_u
      i64.const 0
-     i64.ne
+     i64.lt_s
      if (result f64)
       f64.const 1
       local.get $10
@@ -978,10 +976,8 @@
      i32.ge_u
      if
       local.get $9
-      i64.const 63
-      i64.shr_u
       i64.const 0
-      i64.ne
+      i64.lt_s
       if (result f64)
        local.get $12
        local.set $41
@@ -1753,8 +1749,8 @@
       local.set $9
      end
      local.get $6
-     i32.const 31
-     i32.shr_u
+     i32.const 0
+     i32.lt_s
      if (result f32)
       f32.const 1
       local.get $9

--- a/tests/compiler/binary.debug.wat
+++ b/tests/compiler/binary.debug.wat
@@ -563,10 +563,8 @@
      br $~lib/util/math/pow_lut|inlined.0
     end
     local.get $5
-    i64.const 63
-    i64.shr_u
     i64.const 0
-    i64.ne
+    i64.lt_s
     if
      block $~lib/util/math/checkint|inlined.1 (result i32)
       local.get $6
@@ -1767,8 +1765,8 @@
      br $~lib/util/math/powf_lut|inlined.0
     end
     local.get $5
-    i32.const 31
-    i32.shr_u
+    i32.const 0
+    i32.lt_s
     if
      block $~lib/util/math/checkintf|inlined.1 (result i32)
       local.get $6

--- a/tests/compiler/resolve-binary.debug.wat
+++ b/tests/compiler/resolve-binary.debug.wat
@@ -3061,10 +3061,8 @@
       local.set $10
      end
      local.get $6
-     i64.const 63
-     i64.shr_u
      i64.const 0
-     i64.ne
+     i64.lt_s
      if (result f64)
       f64.const 1
       local.get $10
@@ -3490,10 +3488,8 @@
      i32.ge_u
      if
       local.get $9
-      i64.const 63
-      i64.shr_u
       i64.const 0
-      i64.ne
+      i64.lt_s
       if (result f64)
        local.get $12
        local.set $41

--- a/tests/compiler/resolve-binary.debug.wat
+++ b/tests/compiler/resolve-binary.debug.wat
@@ -3075,10 +3075,8 @@
      br $~lib/util/math/pow_lut|inlined.0
     end
     local.get $5
-    i64.const 63
-    i64.shr_u
     i64.const 0
-    i64.ne
+    i64.lt_s
     if
      block $~lib/util/math/checkint|inlined.1 (result i32)
       local.get $6

--- a/tests/compiler/std/math.debug.wat
+++ b/tests/compiler/std/math.debug.wat
@@ -910,8 +910,8 @@
     f32.add
     f32.const 0
     local.get $1
-    i32.const 31
-    i32.shr_u
+    i32.const 0
+    i32.lt_s
     select
     return
    end
@@ -5791,16 +5791,16 @@
   local.get $1
   i64.const 32
   i64.shr_u
-  i64.const 2147483647
-  i64.and
   i32.wrap_i64
+  i32.const 2147483647
+  i32.and
   local.set $2
-  i32.const 0
-  local.set $3
   local.get $1
   i64.const 63
   i64.shr_u
   i32.wrap_i64
+  local.set $3
+  i32.const 0
   local.set $4
   local.get $2
   i32.const 1078159482
@@ -5813,7 +5813,7 @@
     local.get $0
     return
    end
-   local.get $4
+   local.get $3
    if
     f64.const -1
     return
@@ -5835,7 +5835,7 @@
   i32.gt_u
   if
    i32.const 1
-   local.get $4
+   local.get $3
    i32.const 1
    i32.shl
    i32.sub
@@ -5851,8 +5851,8 @@
    i32.const 1072734898
    i32.lt_u
    select
-   local.set $3
-   local.get $3
+   local.set $4
+   local.get $4
    f64.convert_i32_s
    local.set $6
    local.get $0
@@ -5936,7 +5936,7 @@
   f64.div
   f64.mul
   local.set $13
-  local.get $3
+  local.get $4
   i32.const 0
   i32.eq
   if
@@ -5961,7 +5961,7 @@
   local.get $10
   f64.sub
   local.set $13
-  local.get $3
+  local.get $4
   i32.const -1
   i32.eq
   if
@@ -5974,7 +5974,7 @@
    f64.sub
    return
   end
-  local.get $3
+  local.get $4
   i32.const 1
   i32.eq
   if
@@ -6001,7 +6001,7 @@
    return
   end
   i64.const 1023
-  local.get $3
+  local.get $4
   i64.extend_i32_s
   i64.add
   i64.const 52
@@ -6010,13 +6010,13 @@
   local.get $1
   f64.reinterpret_i64
   local.set $14
-  local.get $3
+  local.get $4
   i32.const 0
   i32.lt_s
   if (result i32)
    i32.const 1
   else
-   local.get $3
+   local.get $4
    i32.const 56
    i32.gt_s
   end
@@ -6027,7 +6027,7 @@
    f64.const 1
    f64.add
    local.set $15
-   local.get $3
+   local.get $4
    i32.const 1024
    i32.eq
    if
@@ -6049,7 +6049,7 @@
    return
   end
   i64.const 1023
-  local.get $3
+  local.get $4
   i64.extend_i32_s
   i64.sub
   i64.const 52
@@ -6058,7 +6058,7 @@
   local.get $1
   f64.reinterpret_i64
   local.set $15
-  local.get $3
+  local.get $4
   i32.const 20
   i32.lt_s
   if
@@ -11515,13 +11515,12 @@
   (local $3 i64)
   (local $4 i64)
   (local $5 i64)
-  (local $6 i32)
-  (local $7 f64)
-  (local $8 i64)
+  (local $6 f64)
+  (local $7 i64)
+  (local $8 i32)
   (local $9 i32)
-  (local $10 i32)
-  (local $11 i64)
-  (local $12 f64)
+  (local $10 i64)
+  (local $11 f64)
   local.get $0
   i64.reinterpret_f64
   local.set $2
@@ -11540,11 +11539,6 @@
   i64.const 2047
   i64.and
   local.set $5
-  local.get $2
-  i64.const 63
-  i64.shr_u
-  i32.wrap_i64
-  local.set $6
   local.get $3
   i64.const 1
   i64.shl
@@ -11568,9 +11562,9 @@
    local.get $0
    local.get $1
    f64.mul
-   local.set $7
-   local.get $7
-   local.get $7
+   local.set $6
+   local.get $6
+   local.get $6
    f64.div
    return
   end
@@ -11584,38 +11578,38 @@
    return
   end
   local.get $2
-  local.set $8
+  local.set $7
   local.get $4
   i64.const 0
   i64.ne
   i32.eqz
   if
    local.get $4
-   local.get $8
+   local.get $7
    i64.const 12
    i64.shl
    i64.clz
    i64.sub
    local.set $4
-   local.get $8
+   local.get $7
    i64.const 1
    local.get $4
    i64.sub
    i64.shl
-   local.set $8
+   local.set $7
   else
-   local.get $8
+   local.get $7
    i64.const -1
    i64.const 12
    i64.shr_u
    i64.and
-   local.set $8
-   local.get $8
+   local.set $7
+   local.get $7
    i64.const 1
    i64.const 52
    i64.shl
    i64.or
-   local.set $8
+   local.set $7
   end
   local.get $5
   i64.const 0
@@ -11650,7 +11644,7 @@
    local.set $3
   end
   i32.const 0
-  local.set $9
+  local.set $8
   block $do-break|0
    loop $do-loop|0
     local.get $4
@@ -11672,30 +11666,30 @@
      local.get $4
      local.get $5
      i64.gt_s
-     local.set $10
-     local.get $10
+     local.set $9
+     local.get $9
      if
-      local.get $8
+      local.get $7
       local.get $3
       i64.ge_u
       if
-       local.get $8
+       local.get $7
        local.get $3
        i64.sub
-       local.set $8
-       local.get $9
+       local.set $7
+       local.get $8
        i32.const 1
        i32.add
-       local.set $9
+       local.set $8
       end
-      local.get $8
+      local.get $7
       i64.const 1
       i64.shl
-      local.set $8
-      local.get $9
+      local.set $7
+      local.get $8
       i32.const 1
       i32.shl
-      local.set $9
+      local.set $8
       local.get $4
       i64.const 1
       i64.sub
@@ -11703,39 +11697,39 @@
       br $while-continue|1
      end
     end
-    local.get $8
+    local.get $7
     local.get $3
     i64.ge_u
     if
-     local.get $8
+     local.get $7
      local.get $3
      i64.sub
-     local.set $8
-     local.get $9
+     local.set $7
+     local.get $8
      i32.const 1
      i32.add
-     local.set $9
+     local.set $8
     end
-    local.get $8
+    local.get $7
     i64.const 0
     i64.eq
     if
      i64.const -60
      local.set $4
     else
-     local.get $8
+     local.get $7
      i64.const 11
      i64.shl
      i64.clz
-     local.set $11
+     local.set $10
      local.get $4
-     local.get $11
+     local.get $10
      i64.sub
      local.set $4
-     local.get $8
-     local.get $11
+     local.get $7
+     local.get $10
      i64.shl
-     local.set $8
+     local.set $7
     end
     br $do-break|0
    end
@@ -11745,29 +11739,29 @@
   i64.const 0
   i64.gt_s
   if
-   local.get $8
+   local.get $7
    i64.const 1
    i64.const 52
    i64.shl
    i64.sub
-   local.set $8
-   local.get $8
+   local.set $7
+   local.get $7
    local.get $4
    i64.const 52
    i64.shl
    i64.or
-   local.set $8
+   local.set $7
   else
-   local.get $8
+   local.get $7
    i64.const 0
    local.get $4
    i64.sub
    i64.const 1
    i64.add
    i64.shr_u
-   local.set $8
+   local.set $7
   end
-  local.get $8
+  local.get $7
   f64.reinterpret_i64
   local.set $0
   local.get $1
@@ -11776,7 +11770,7 @@
   local.get $0
   local.get $0
   f64.add
-  local.set $12
+  local.set $11
   local.get $4
   local.get $5
   i64.eq
@@ -11789,17 +11783,17 @@
    local.get $5
    i64.eq
    if (result i32)
-    local.get $12
+    local.get $11
     local.get $1
     f64.gt
     if (result i32)
      i32.const 1
     else
-     local.get $12
+     local.get $11
      local.get $1
      f64.eq
      if (result i32)
-      local.get $9
+      local.get $8
       i32.const 1
       i32.and
      else
@@ -11816,7 +11810,9 @@
    f64.sub
    local.set $0
   end
-  local.get $6
+  local.get $2
+  i64.const 0
+  i64.lt_s
   if (result f64)
    local.get $0
    f64.neg
@@ -11841,8 +11837,7 @@
   (local $6 i32)
   (local $7 i32)
   (local $8 i32)
-  (local $9 i32)
-  (local $10 f32)
+  (local $9 f32)
   local.get $0
   i32.reinterpret_f32
   local.set $2
@@ -11862,11 +11857,7 @@
   i32.and
   local.set $5
   local.get $2
-  i32.const 31
-  i32.shr_u
   local.set $6
-  local.get $2
-  local.set $7
   local.get $3
   i32.const 1
   i32.shl
@@ -11909,31 +11900,31 @@
   i32.eqz
   if
    local.get $4
-   local.get $7
+   local.get $6
    i32.const 9
    i32.shl
    i32.clz
    i32.sub
    local.set $4
-   local.get $7
+   local.get $6
    i32.const 1
    local.get $4
    i32.sub
    i32.shl
-   local.set $7
+   local.set $6
   else
-   local.get $7
+   local.get $6
    i32.const -1
    i32.const 9
    i32.shr_u
    i32.and
-   local.set $7
-   local.get $7
+   local.set $6
+   local.get $6
    i32.const 1
    i32.const 23
    i32.shl
    i32.or
-   local.set $7
+   local.set $6
   end
   local.get $5
   i32.eqz
@@ -11966,7 +11957,7 @@
    local.set $3
   end
   i32.const 0
-  local.set $8
+  local.set $7
   block $do-break|0
    loop $do-loop|0
     local.get $4
@@ -11988,30 +11979,30 @@
      local.get $4
      local.get $5
      i32.gt_s
-     local.set $9
-     local.get $9
+     local.set $8
+     local.get $8
      if
-      local.get $7
+      local.get $6
       local.get $3
       i32.ge_u
       if
-       local.get $7
+       local.get $6
        local.get $3
        i32.sub
-       local.set $7
-       local.get $8
+       local.set $6
+       local.get $7
        i32.const 1
        i32.add
-       local.set $8
+       local.set $7
       end
+      local.get $6
+      i32.const 1
+      i32.shl
+      local.set $6
       local.get $7
       i32.const 1
       i32.shl
       local.set $7
-      local.get $8
-      i32.const 1
-      i32.shl
-      local.set $8
       local.get $4
       i32.const 1
       i32.sub
@@ -12019,39 +12010,39 @@
       br $while-continue|1
      end
     end
-    local.get $7
+    local.get $6
     local.get $3
     i32.ge_u
     if
-     local.get $7
+     local.get $6
      local.get $3
      i32.sub
-     local.set $7
-     local.get $8
+     local.set $6
+     local.get $7
      i32.const 1
      i32.add
-     local.set $8
+     local.set $7
     end
-    local.get $7
+    local.get $6
     i32.const 0
     i32.eq
     if
      i32.const -30
      local.set $4
     else
-     local.get $7
+     local.get $6
      i32.const 8
      i32.shl
      i32.clz
-     local.set $9
+     local.set $8
      local.get $4
-     local.get $9
+     local.get $8
      i32.sub
      local.set $4
-     local.get $7
-     local.get $9
+     local.get $6
+     local.get $8
      i32.shl
-     local.set $7
+     local.set $6
     end
     br $do-break|0
    end
@@ -12061,29 +12052,29 @@
   i32.const 0
   i32.gt_s
   if
-   local.get $7
+   local.get $6
    i32.const 1
    i32.const 23
    i32.shl
    i32.sub
-   local.set $7
-   local.get $7
+   local.set $6
+   local.get $6
    local.get $4
    i32.const 23
    i32.shl
    i32.or
-   local.set $7
+   local.set $6
   else
-   local.get $7
+   local.get $6
    i32.const 0
    local.get $4
    i32.sub
    i32.const 1
    i32.add
    i32.shr_u
-   local.set $7
+   local.set $6
   end
-  local.get $7
+  local.get $6
   f32.reinterpret_i32
   local.set $0
   local.get $1
@@ -12092,7 +12083,7 @@
   local.get $0
   local.get $0
   f32.add
-  local.set $10
+  local.set $9
   local.get $4
   local.get $5
   i32.eq
@@ -12105,17 +12096,17 @@
    local.get $5
    i32.eq
    if (result i32)
-    local.get $10
+    local.get $9
     local.get $1
     f32.gt
     if (result i32)
      i32.const 1
     else
-     local.get $10
+     local.get $9
      local.get $1
      f32.eq
      if (result i32)
-      local.get $8
+      local.get $7
       i32.const 1
       i32.and
      else
@@ -12132,7 +12123,9 @@
    f32.sub
    local.set $0
   end
-  local.get $6
+  local.get $2
+  i32.const 0
+  i32.lt_s
   if (result f32)
    local.get $0
    f32.neg
@@ -15744,10 +15737,8 @@
     i32.sub
     local.get $1
     local.get $2
-    i64.const 63
-    i64.shr_u
     i64.const 0
-    i64.ne
+    i64.lt_s
     select
     local.set $1
    end

--- a/tests/compiler/std/math.debug.wat
+++ b/tests/compiler/std/math.debug.wat
@@ -721,8 +721,8 @@
    i32.eq
    if
     local.get $1
-    i32.const 31
-    i32.shr_u
+    i32.const 0
+    i32.lt_s
     if
      f64.const 2
      f64.const 1.5707963267948966
@@ -771,8 +771,8 @@
    return
   end
   local.get $1
-  i32.const 31
-  i32.shr_u
+  i32.const 0
+  i32.lt_s
   if
    f64.const 0.5
    local.get $0
@@ -903,18 +903,16 @@
    i32.const 1065353216
    i32.eq
    if
+    f32.const 2
+    f32.const 1.570796251296997
+    f32.mul
+    f32.const 7.52316384526264e-37
+    f32.add
+    f32.const 0
     local.get $1
     i32.const 31
     i32.shr_u
-    if
-     f32.const 2
-     f32.const 1.570796251296997
-     f32.mul
-     f32.const 7.52316384526264e-37
-     f32.add
-     return
-    end
-    f32.const 0
+    select
     return
    end
    f32.const 0
@@ -952,8 +950,8 @@
    return
   end
   local.get $1
-  i32.const 31
-  i32.shr_u
+  i32.const 0
+  i32.lt_s
   if
    f32.const 0.5
    local.get $0
@@ -2304,15 +2302,13 @@
    f64.sub
    local.set $0
   end
-  local.get $1
-  i32.const 31
-  i32.shr_u
-  if
-   local.get $0
-   f64.neg
-   return
-  end
   local.get $0
+  f64.neg
+  local.get $0
+  local.get $1
+  i32.const 0
+  i32.lt_s
+  select
  )
  (func $std/math/test_asin (param $0 f64) (param $1 f64) (param $2 f64) (param $3 i32) (result i32)
   local.get $0
@@ -7132,11 +7128,8 @@
       br $~lib/util/math/exp2_lut|inlined.0
      end
      local.get $2
-     i64.const 63
-     i64.shr_u
      i64.const 0
-     i64.ne
-     i32.eqz
+     i64.ge_s
      if
       f64.const inf
       br $~lib/util/math/exp2_lut|inlined.0
@@ -7893,7 +7886,7 @@
   (local $1 i64)
   (local $2 i32)
   (local $3 i32)
-  (local $4 f64)
+  (local $4 i32)
   (local $5 f64)
   (local $6 f64)
   (local $7 f64)
@@ -7907,6 +7900,7 @@
   (local $15 f64)
   (local $16 f64)
   (local $17 f64)
+  (local $18 f64)
   local.get $0
   i64.reinterpret_f64
   local.set $1
@@ -7918,14 +7912,16 @@
   i32.const 0
   local.set $3
   local.get $2
-  i32.const 1048576
-  i32.lt_u
+  i32.const 31
+  i32.shr_u
+  local.set $4
+  local.get $4
   if (result i32)
    i32.const 1
   else
    local.get $2
-   i32.const 31
-   i32.shr_u
+   i32.const 1048576
+   i32.lt_u
   end
   if
    local.get $1
@@ -7941,9 +7937,7 @@
     f64.div
     return
    end
-   local.get $2
-   i32.const 31
-   i32.shr_u
+   local.get $4
    if
     local.get $0
     local.get $0
@@ -8029,46 +8023,46 @@
   local.get $0
   f64.const 1
   f64.sub
-  local.set $4
-  f64.const 0.5
-  local.get $4
-  f64.mul
-  local.get $4
-  f64.mul
   local.set $5
-  local.get $4
+  f64.const 0.5
+  local.get $5
+  f64.mul
+  local.get $5
+  f64.mul
+  local.set $6
+  local.get $5
   f64.const 2
-  local.get $4
+  local.get $5
   f64.add
   f64.div
-  local.set $6
-  local.get $6
-  local.get $6
-  f64.mul
   local.set $7
   local.get $7
   local.get $7
   f64.mul
   local.set $8
   local.get $8
+  local.get $8
+  f64.mul
+  local.set $9
+  local.get $9
   f64.const 0.3999999999940942
-  local.get $8
+  local.get $9
   f64.const 0.22222198432149784
-  local.get $8
+  local.get $9
   f64.const 0.15313837699209373
   f64.mul
   f64.add
   f64.mul
   f64.add
   f64.mul
-  local.set $9
-  local.get $7
+  local.set $10
+  local.get $8
   f64.const 0.6666666666666735
-  local.get $8
+  local.get $9
   f64.const 0.2857142874366239
-  local.get $8
+  local.get $9
   f64.const 0.1818357216161805
-  local.get $8
+  local.get $9
   f64.const 0.14798198605116586
   f64.mul
   f64.add
@@ -8077,16 +8071,16 @@
   f64.mul
   f64.add
   f64.mul
-  local.set $10
-  local.get $10
-  local.get $9
-  f64.add
   local.set $11
-  local.get $4
-  local.get $5
-  f64.sub
+  local.get $11
+  local.get $10
+  f64.add
   local.set $12
-  local.get $12
+  local.get $5
+  local.get $6
+  f64.sub
+  local.set $13
+  local.get $13
   i64.reinterpret_f64
   local.set $1
   local.get $1
@@ -8095,58 +8089,58 @@
   local.set $1
   local.get $1
   f64.reinterpret_i64
-  local.set $12
-  local.get $4
-  local.get $12
-  f64.sub
+  local.set $13
   local.get $5
+  local.get $13
   f64.sub
   local.get $6
-  local.get $5
-  local.get $11
+  f64.sub
+  local.get $7
+  local.get $6
+  local.get $12
   f64.add
   f64.mul
   f64.add
-  local.set $13
-  local.get $12
+  local.set $14
+  local.get $13
   f64.const 0.4342944818781689
   f64.mul
-  local.set $14
+  local.set $15
   local.get $3
   f64.convert_i32_s
-  local.set $15
-  local.get $15
+  local.set $16
+  local.get $16
   f64.const 0.30102999566361177
   f64.mul
-  local.set $16
-  local.get $15
+  local.set $17
+  local.get $16
   f64.const 3.694239077158931e-13
   f64.mul
+  local.get $14
   local.get $13
-  local.get $12
   f64.add
   f64.const 2.5082946711645275e-11
   f64.mul
   f64.add
-  local.get $13
+  local.get $14
   f64.const 0.4342944818781689
   f64.mul
   f64.add
-  local.set $17
-  local.get $16
-  local.get $14
-  f64.add
-  local.set $8
+  local.set $18
   local.get $17
-  local.get $16
-  local.get $8
+  local.get $15
+  f64.add
+  local.set $9
+  local.get $18
+  local.get $17
+  local.get $9
   f64.sub
-  local.get $14
+  local.get $15
   f64.add
   f64.add
-  local.set $17
-  local.get $17
-  local.get $8
+  local.set $18
+  local.get $18
+  local.get $9
   f64.add
  )
  (func $std/math/test_log10 (param $0 f64) (param $1 f64) (param $2 f64) (param $3 i32) (result i32)
@@ -8170,7 +8164,7 @@
  (func $~lib/math/NativeMathf.log10 (param $0 f32) (result f32)
   (local $1 i32)
   (local $2 i32)
-  (local $3 f32)
+  (local $3 i32)
   (local $4 f32)
   (local $5 f32)
   (local $6 f32)
@@ -8181,20 +8175,23 @@
   (local $11 f32)
   (local $12 f32)
   (local $13 f32)
+  (local $14 f32)
   local.get $0
   i32.reinterpret_f32
   local.set $1
   i32.const 0
   local.set $2
   local.get $1
-  i32.const 8388608
-  i32.lt_u
+  i32.const 31
+  i32.shr_u
+  local.set $3
+  local.get $3
   if (result i32)
    i32.const 1
   else
    local.get $1
-   i32.const 31
-   i32.shr_u
+   i32.const 8388608
+   i32.lt_u
   end
   if
    local.get $1
@@ -8210,9 +8207,7 @@
     f32.div
     return
    end
-   local.get $1
-   i32.const 31
-   i32.shr_u
+   local.get $3
    if
     local.get $0
     local.get $0
@@ -8275,52 +8270,52 @@
   local.get $0
   f32.const 1
   f32.sub
-  local.set $3
-  local.get $3
-  f32.const 2
-  local.get $3
-  f32.add
-  f32.div
   local.set $4
   local.get $4
+  f32.const 2
   local.get $4
-  f32.mul
+  f32.add
+  f32.div
   local.set $5
   local.get $5
   local.get $5
   f32.mul
   local.set $6
   local.get $6
-  f32.const 0.40000972151756287
   local.get $6
+  f32.mul
+  local.set $7
+  local.get $7
+  f32.const 0.40000972151756287
+  local.get $7
   f32.const 0.24279078841209412
   f32.mul
   f32.add
   f32.mul
-  local.set $7
-  local.get $5
-  f32.const 0.6666666269302368
+  local.set $8
   local.get $6
+  f32.const 0.6666666269302368
+  local.get $7
   f32.const 0.2849878668785095
   f32.mul
   f32.add
   f32.mul
-  local.set $8
-  local.get $8
-  local.get $7
-  f32.add
   local.set $9
-  f32.const 0.5
-  local.get $3
-  f32.mul
-  local.get $3
-  f32.mul
+  local.get $9
+  local.get $8
+  f32.add
   local.set $10
-  local.get $3
-  local.get $10
-  f32.sub
+  f32.const 0.5
+  local.get $4
+  f32.mul
+  local.get $4
+  f32.mul
   local.set $11
+  local.get $4
   local.get $11
+  f32.sub
+  local.set $12
+  local.get $12
   i32.reinterpret_f32
   local.set $1
   local.get $1
@@ -8329,40 +8324,40 @@
   local.set $1
   local.get $1
   f32.reinterpret_i32
-  local.set $11
-  local.get $3
+  local.set $12
+  local.get $4
+  local.get $12
+  f32.sub
   local.get $11
   f32.sub
+  local.get $5
+  local.get $11
   local.get $10
-  f32.sub
-  local.get $4
-  local.get $10
-  local.get $9
   f32.add
   f32.mul
   f32.add
-  local.set $12
+  local.set $13
   local.get $2
   f32.convert_i32_s
-  local.set $13
-  local.get $13
+  local.set $14
+  local.get $14
   f32.const 7.903415166765626e-07
   f32.mul
+  local.get $13
   local.get $12
-  local.get $11
   f32.add
   f32.const -3.168997136526741e-05
   f32.mul
   f32.add
+  local.get $13
+  f32.const 0.434326171875
+  f32.mul
+  f32.add
   local.get $12
   f32.const 0.434326171875
   f32.mul
   f32.add
-  local.get $11
-  f32.const 0.434326171875
-  f32.mul
-  f32.add
-  local.get $13
+  local.get $14
   f32.const 0.3010292053222656
   f32.mul
   f32.add
@@ -9896,10 +9891,8 @@
      br $~lib/util/math/pow_lut|inlined.0
     end
     local.get $5
-    i64.const 63
-    i64.shr_u
     i64.const 0
-    i64.ne
+    i64.lt_s
     if
      block $~lib/util/math/checkint|inlined.1 (result i32)
       local.get $6
@@ -10869,8 +10862,8 @@
      br $~lib/util/math/powf_lut|inlined.0
     end
     local.get $5
-    i32.const 31
-    i32.shr_u
+    i32.const 0
+    i32.lt_s
     if
      block $~lib/util/math/checkintf|inlined.1 (result i32)
       local.get $6
@@ -13827,11 +13820,11 @@
   local.set $2
   local.get $2
   i32.const 1072243195
-  i32.le_s
+  i32.le_u
   if
    local.get $2
    i32.const 1044381696
-   i32.lt_s
+   i32.lt_u
    if
     local.get $0
     return
@@ -13844,7 +13837,7 @@
   end
   local.get $2
   i32.const 2146435072
-  i32.ge_s
+  i32.ge_u
   if
    local.get $0
    local.get $0

--- a/tests/compiler/std/math.debug.wat
+++ b/tests/compiler/std/math.debug.wat
@@ -6117,9 +6117,9 @@
    local.get $2
    i64.const 52
    i64.shr_u
-   i64.const 2047
-   i64.and
    i32.wrap_i64
+   i32.const 2047
+   i32.and
    local.set $3
    local.get $3
    i32.const 969
@@ -6155,16 +6155,16 @@
       local.get $1
       f64.add
       br $~lib/util/math/exp_lut|inlined.0
+     else
+      f64.const 0
+      f64.const inf
+      local.get $2
+      i64.const 0
+      i64.lt_s
+      select
+      br $~lib/util/math/exp_lut|inlined.0
      end
-     f64.const 0
-     f64.const inf
-     local.get $2
-     i64.const 63
-     i64.shr_u
-     i64.const 0
-     i64.ne
-     select
-     br $~lib/util/math/exp_lut|inlined.0
+     unreachable
     end
     i32.const 0
     local.set $3
@@ -7088,9 +7088,9 @@
    local.get $2
    i64.const 52
    i64.shr_u
-   i64.const 2047
-   i64.and
    i32.wrap_i64
+   i32.const 2047
+   i32.and
    local.set $3
    local.get $3
    i32.const 969
@@ -9877,10 +9877,8 @@
       local.set $10
      end
      local.get $6
-     i64.const 63
-     i64.shr_u
      i64.const 0
-     i64.ne
+     i64.lt_s
      if (result f64)
       f64.const 1
       local.get $10
@@ -10306,10 +10304,8 @@
      i32.ge_u
      if
       local.get $9
-      i64.const 63
-      i64.shr_u
       i64.const 0
-      i64.ne
+      i64.lt_s
       if (result f64)
        local.get $12
        local.set $41
@@ -10850,8 +10846,8 @@
       local.set $9
      end
      local.get $6
-     i32.const 31
-     i32.shr_u
+     i32.const 0
+     i32.lt_s
      if (result f32)
       f32.const 1
       local.get $9

--- a/tests/compiler/std/math.release.wat
+++ b/tests/compiler/std/math.release.wat
@@ -822,8 +822,8 @@
     f32.const 3.141592502593994
     f32.const 0
     local.get $2
-    i32.const 31
-    i32.shr_u
+    i32.const 0
+    i32.lt_s
     select
     return
    end
@@ -4580,9 +4580,9 @@
   local.tee $5
   i64.const 32
   i64.shr_u
-  i64.const 2147483647
-  i64.and
   i32.wrap_i64
+  i32.const 2147483647
+  i32.and
   local.set $3
   local.get $5
   i64.const 63
@@ -8675,7 +8675,7 @@
   (local $3 i64)
   (local $4 i64)
   (local $5 i32)
-  (local $6 i32)
+  (local $6 i64)
   (local $7 i64)
   (local $8 f64)
   local.get $1
@@ -8692,7 +8692,7 @@
   i64.eqz
   local.get $0
   i64.reinterpret_f64
-  local.tee $2
+  local.tee $6
   i64.const 52
   i64.shr_u
   i64.const 2047
@@ -8714,7 +8714,7 @@
    f64.div
    return
   end
-  local.get $2
+  local.get $6
   i64.const 1
   i64.shl
   i64.eqz
@@ -8722,18 +8722,13 @@
    local.get $0
    return
   end
-  local.get $2
-  i64.const 63
-  i64.shr_u
-  i32.wrap_i64
-  local.set $6
   local.get $3
   i64.eqz
   if (result i64)
-   local.get $2
+   local.get $6
    i64.const 1
    local.get $3
-   local.get $2
+   local.get $6
    i64.const 12
    i64.shl
    i64.clz
@@ -8742,7 +8737,7 @@
    i64.sub
    i64.shl
   else
-   local.get $2
+   local.get $6
    i64.const 4503599627370495
    i64.and
    i64.const 4503599627370496
@@ -8907,6 +8902,8 @@
   f64.neg
   local.get $0
   local.get $6
+  i64.const 0
+  i64.lt_s
   select
  )
  (func $~lib/math/NativeMathf.rem (param $0 f32) (param $1 f32) (result f32)
@@ -8931,7 +8928,7 @@
   f32.ne
   local.get $0
   i32.reinterpret_f32
-  local.tee $2
+  local.tee $6
   i32.const 23
   i32.shr_u
   i32.const 255
@@ -8954,7 +8951,7 @@
    f32.div
    return
   end
-  local.get $2
+  local.get $6
   i32.const 1
   i32.shl
   i32.eqz
@@ -8962,22 +8959,18 @@
    local.get $0
    return
   end
-  local.get $2
-  i32.const 31
-  i32.shr_u
-  local.set $6
   local.get $3
   if (result i32)
-   local.get $2
+   local.get $6
    i32.const 8388607
    i32.and
    i32.const 8388608
    i32.or
   else
-   local.get $2
+   local.get $6
    i32.const 1
    local.get $3
-   local.get $2
+   local.get $6
    i32.const 9
    i32.shl
    i32.clz
@@ -9143,6 +9136,8 @@
   f32.neg
   local.get $0
   local.get $6
+  i32.const 0
+  i32.lt_s
   select
  )
  (func $~lib/math/NativeMath.sin (param $0 f64) (result f64)
@@ -11679,9 +11674,8 @@
     i32.sub
     local.get $2
     local.get $3
-    i64.const 63
-    i64.shr_u
-    i32.wrap_i64
+    i64.const 0
+    i64.lt_s
     select
    else
     i32.const 0
@@ -11722,9 +11716,8 @@
     i32.sub
     local.get $2
     local.get $3
-    i64.const 63
-    i64.shr_u
-    i32.wrap_i64
+    i64.const 0
+    i64.lt_s
     select
    else
     i32.const 0

--- a/tests/compiler/std/math.release.wat
+++ b/tests/compiler/std/math.release.wat
@@ -4852,9 +4852,9 @@
    local.tee $2
    i64.const 52
    i64.shr_u
-   i64.const 2047
-   i64.and
    i32.wrap_i64
+   i32.const 2047
+   i32.and
    local.tee $1
    i32.const 969
    i32.sub
@@ -4890,9 +4890,8 @@
      f64.const 0
      f64.const inf
      local.get $2
-     i64.const 63
-     i64.shr_u
-     i32.wrap_i64
+     i64.const 0
+     i64.lt_s
      select
      br $~lib/util/math/exp_lut|inlined.0
     end
@@ -5549,9 +5548,9 @@
    local.tee $4
    i64.const 52
    i64.shr_u
-   i64.const 2047
-   i64.and
    i32.wrap_i64
+   i32.const 2047
+   i32.and
    local.tee $3
    i32.const 969
    i32.sub
@@ -7535,9 +7534,8 @@
      f64.div
      local.get $0
      local.get $12
-     i64.const 63
-     i64.shr_u
-     i32.wrap_i64
+     i64.const 0
+     i64.lt_s
      select
      br $~lib/util/math/pow_lut|inlined.0
     end
@@ -7832,9 +7830,8 @@
      br_if $~lib/util/math/exp_inline|inlined.0
      drop
      local.get $2
-     i64.const 63
-     i64.shr_u
-     i32.wrap_i64
+     i64.const 0
+     i64.lt_s
      if (result f64)
       f64.const -1.2882297539194267e-231
       f64.const 1.2882297539194267e-231
@@ -8250,8 +8247,8 @@
      f32.div
      local.get $0
      local.get $7
-     i32.const 31
-     i32.shr_u
+     i32.const 0
+     i32.lt_s
      select
      br $~lib/util/math/powf_lut|inlined.0
     end

--- a/tests/compiler/std/math.release.wat
+++ b/tests/compiler/std/math.release.wat
@@ -586,8 +586,8 @@
    i32.eqz
    if
     local.get $2
-    i32.const 31
-    i32.shr_u
+    i32.const 0
+    i32.lt_s
     if
      f64.const 3.141592653589793
      return
@@ -668,8 +668,8 @@
    return
   end
   local.get $2
-  i32.const 31
-  i32.shr_u
+  i32.const 0
+  i32.lt_s
   if
    f64.const 1.5707963267948966
    local.get $0
@@ -819,14 +819,12 @@
    i32.const 1065353216
    i32.eq
    if
+    f32.const 3.141592502593994
+    f32.const 0
     local.get $2
     i32.const 31
     i32.shr_u
-    if
-     f32.const 3.141592502593994
-     return
-    end
-    f32.const 0
+    select
     return
    end
    f32.const 0
@@ -878,8 +876,8 @@
    return
   end
   local.get $2
-  i32.const 31
-  i32.shr_u
+  i32.const 0
+  i32.lt_s
   if
    f32.const 1.570796251296997
    local.get $0
@@ -2018,16 +2016,13 @@
    f64.sub
    f64.sub
   end
-  local.set $0
-  local.get $2
-  i32.const 31
-  i32.shr_u
-  if
-   local.get $0
-   f64.neg
-   return
-  end
+  local.tee $0
+  f64.neg
   local.get $0
+  local.get $2
+  i32.const 0
+  i32.lt_s
+  select
  )
  (func $~lib/math/NativeMathf.asin (param $0 f32) (result f32)
   (local $1 i32)
@@ -5591,9 +5586,8 @@
      drop
      f64.const inf
      local.get $4
-     i64.const 63
-     i64.shr_u
-     i64.eqz
+     i64.const 0
+     i64.ge_s
      br_if $~lib/util/math/exp2_lut|inlined.0
      drop
      f64.const 0
@@ -6126,12 +6120,13 @@
   (local $3 i32)
   (local $4 i64)
   (local $5 i32)
-  (local $6 f64)
+  (local $6 i32)
   (local $7 f64)
   (local $8 f64)
   (local $9 f64)
   (local $10 f64)
   (local $11 f64)
+  (local $12 f64)
   block $__inlined_func$~lib/math/NativeMath.log10 (result f64)
    local.get $0
    i64.reinterpret_f64
@@ -6142,6 +6137,7 @@
    local.tee $3
    i32.const 31
    i32.shr_u
+   local.tee $6
    local.get $3
    i32.const 1048576
    i32.lt_u
@@ -6163,9 +6159,7 @@
     f64.sub
     f64.const 0
     f64.div
-    local.get $3
-    i32.const 31
-    i32.shr_u
+    local.get $6
     br_if $__inlined_func$~lib/math/NativeMath.log10
     drop
     i32.const -54
@@ -6218,42 +6212,42 @@
    f64.reinterpret_i64
    f64.const 1
    f64.sub
-   local.tee $6
+   local.tee $7
    f64.const 0.5
    f64.mul
-   local.get $6
+   local.get $7
    f64.mul
-   local.set $7
-   local.get $6
-   local.get $6
+   local.set $8
+   local.get $7
+   local.get $7
    f64.const 2
    f64.add
    f64.div
-   local.tee $8
-   local.get $8
-   f64.mul
    local.tee $9
    local.get $9
    f64.mul
-   local.set $10
-   local.get $6
-   local.get $6
+   local.tee $10
+   local.get $10
+   f64.mul
+   local.set $11
    local.get $7
+   local.get $7
+   local.get $8
    f64.sub
    i64.reinterpret_f64
    i64.const -4294967296
    i64.and
    f64.reinterpret_i64
-   local.tee $11
-   f64.sub
-   local.get $7
+   local.tee $12
    f64.sub
    local.get $8
-   local.get $7
+   f64.sub
    local.get $9
+   local.get $8
    local.get $10
-   local.get $10
-   local.get $10
+   local.get $11
+   local.get $11
+   local.get $11
    f64.const 0.14798198605116586
    f64.mul
    f64.const 0.1818357216161805
@@ -6265,9 +6259,9 @@
    f64.const 0.6666666666666735
    f64.add
    f64.mul
-   local.get $10
-   local.get $10
-   local.get $10
+   local.get $11
+   local.get $11
+   local.get $11
    f64.const 0.15313837699209373
    f64.mul
    f64.const 0.22222198432149784
@@ -6280,7 +6274,7 @@
    f64.add
    f64.mul
    f64.add
-   local.set $7
+   local.set $8
    local.get $5
    local.get $3
    i32.const 20
@@ -6289,36 +6283,36 @@
    i32.sub
    i32.add
    f64.convert_i32_s
-   local.tee $8
+   local.tee $9
    f64.const 0.30102999566361177
    f64.mul
-   local.tee $9
-   local.get $11
+   local.tee $10
+   local.get $12
    f64.const 0.4342944818781689
    f64.mul
-   local.tee $10
+   local.tee $11
    f64.add
-   local.set $6
-   local.get $8
+   local.set $7
+   local.get $9
    f64.const 3.694239077158931e-13
    f64.mul
-   local.get $7
-   local.get $11
+   local.get $8
+   local.get $12
    f64.add
    f64.const 2.5082946711645275e-11
    f64.mul
    f64.add
-   local.get $7
+   local.get $8
    f64.const 0.4342944818781689
    f64.mul
    f64.add
-   local.get $9
-   local.get $6
-   f64.sub
    local.get $10
+   local.get $7
+   f64.sub
+   local.get $11
    f64.add
    f64.add
-   local.get $6
+   local.get $7
    f64.add
   end
   local.get $1
@@ -6338,16 +6332,18 @@
   (local $3 i32)
   (local $4 f32)
   (local $5 i32)
-  (local $6 f32)
+  (local $6 i32)
   (local $7 f32)
   (local $8 f32)
   (local $9 f32)
+  (local $10 f32)
   block $__inlined_func$~lib/math/NativeMathf.log10 (result f32)
    local.get $0
    i32.reinterpret_f32
    local.tee $3
    i32.const 31
    i32.shr_u
+   local.tee $5
    local.get $3
    i32.const 8388608
    i32.lt_u
@@ -6369,13 +6365,11 @@
     f32.sub
     f32.const 0
     f32.div
-    local.get $3
-    i32.const 31
-    i32.shr_u
+    local.get $5
     br_if $__inlined_func$~lib/math/NativeMathf.log10
     drop
     i32.const -25
-    local.set $5
+    local.set $6
     local.get $0
     f32.const 33554432
     f32.mul
@@ -6408,8 +6402,8 @@
    f32.reinterpret_i32
    f32.const 1
    f32.sub
-   local.tee $7
-   local.get $7
+   local.tee $8
+   local.get $8
    f32.const 2
    f32.add
    f32.div
@@ -6419,8 +6413,8 @@
    local.tee $4
    local.get $4
    f32.mul
-   local.set $8
-   local.get $5
+   local.set $9
+   local.get $6
    local.get $3
    i32.const 23
    i32.shr_u
@@ -6428,37 +6422,37 @@
    i32.sub
    i32.add
    f32.convert_i32_s
-   local.tee $6
+   local.tee $7
    f32.const 7.903415166765626e-07
    f32.mul
-   local.get $7
-   local.get $7
-   local.get $7
+   local.get $8
+   local.get $8
+   local.get $8
    f32.const 0.5
    f32.mul
-   local.get $7
+   local.get $8
    f32.mul
-   local.tee $7
+   local.tee $8
    f32.sub
    i32.reinterpret_f32
    i32.const -4096
    i32.and
    f32.reinterpret_i32
-   local.tee $9
+   local.tee $10
    f32.sub
-   local.get $7
+   local.get $8
    f32.sub
    local.get $0
-   local.get $7
-   local.get $4
    local.get $8
+   local.get $4
+   local.get $9
    f32.const 0.2849878668785095
    f32.mul
    f32.const 0.6666666269302368
    f32.add
    f32.mul
-   local.get $8
-   local.get $8
+   local.get $9
+   local.get $9
    f32.const 0.24279078841209412
    f32.mul
    f32.const 0.40000972151756287
@@ -6469,7 +6463,7 @@
    f32.mul
    f32.add
    local.tee $0
-   local.get $9
+   local.get $10
    f32.add
    f32.const -3.168997136526741e-05
    f32.mul
@@ -6478,11 +6472,11 @@
    f32.const 0.434326171875
    f32.mul
    f32.add
-   local.get $9
+   local.get $10
    f32.const 0.434326171875
    f32.mul
    f32.add
-   local.get $6
+   local.get $7
    f32.const 0.3010292053222656
    f32.mul
    f32.add
@@ -7548,9 +7542,8 @@
      br $~lib/util/math/pow_lut|inlined.0
     end
     local.get $2
-    i64.const 63
-    i64.shr_u
-    i32.wrap_i64
+    i64.const 0
+    i64.lt_s
     if
      block $~lib/util/math/checkint|inlined.1 (result i32)
       i32.const 0
@@ -8263,8 +8256,8 @@
      br $~lib/util/math/powf_lut|inlined.0
     end
     local.get $2
-    i32.const 31
-    i32.shr_u
+    i32.const 0
+    i32.lt_s
     if
      block $~lib/util/math/checkintf|inlined.1 (result i32)
       i32.const 0


### PR DESCRIPTION
Motivation:

Right shifts makes sense mostly for single expressions or complex conditions. While single `if (x < 0)` or `select(..., x < 0)` usually fused to single instruction `js` / `jns` / `cmovs` / `cmovns` on wasm engines

- [x] I've read the contributing guidelines
- [x] I've added my name and email to the NOTICE file
