### PR TITLE
fix: infer return type in implicit return arrow function

### DIFF
--- a/src/resolver.ts
+++ b/src/resolver.ts
@@ -2627,7 +2627,7 @@ export class Resolver extends DiagnosticEmitter {
     ) {
       // (x) => ret, infer return type accordingt to `ret`
       const expr = (<ExpressionStatement>body).expression;
-      const type = this.resolveExpression(expr, ctxFlow, ctxType, ReportMode.SWALLOW);
+      const type = this.resolveExpression(expr, ctxFlow, ctxType, reportMode);
       if (type) {
         let signatureReference = assert(functionType.getSignature());
         signatureReference.returnType = type;

--- a/src/resolver.ts
+++ b/src/resolver.ts
@@ -79,7 +79,9 @@ import {
   isTypeOmitted,
   FunctionExpression,
   NewExpression,
-  ArrayLiteralExpression
+  ArrayLiteralExpression,
+  ArrowKind,
+  ExpressionStatement
 } from "./ast";
 
 import {
@@ -2613,7 +2615,25 @@ export class Resolver extends DiagnosticEmitter {
     /** How to proceed with eventual diagnostics. */
     reportMode: ReportMode = ReportMode.REPORT
   ): Type | null {
-    return this.resolveFunctionType(node.declaration.signature, ctxFlow.actualFunction, ctxFlow.contextualTypeArguments, reportMode);
+    const declaration = node.declaration;
+    const signature = declaration.signature;
+    const body = declaration.body;
+    let functionType = this.resolveFunctionType(signature, ctxFlow.actualFunction, ctxFlow.contextualTypeArguments, reportMode);
+    if (
+      functionType &&
+      declaration.arrowKind != ArrowKind.NONE &&
+      body && body.kind == NodeKind.EXPRESSION && 
+      isTypeOmitted(signature.returnType)
+    ) {
+      // (x) => ret, infer return type accordingt to `ret`
+      const expr = (<ExpressionStatement>body).expression;
+      const type = this.resolveExpression(expr, ctxFlow, ctxType, ReportMode.SWALLOW);
+      if (type) {
+        let signatureReference = assert(functionType.getSignature());
+        signatureReference.returnType = type;
+      }
+    }
+    return functionType;
   }
 
   // ==================================================== Elements =====================================================

--- a/tests/compiler/std/array.ts
+++ b/tests/compiler/std/array.ts
@@ -780,7 +780,7 @@ var i: i32;
 // Array#map ///////////////////////////////////////////////////////////////////////////////////////
 
 {
-  let newArr = arr.map<f32>((value: i32) => <f32>value);
+  let newArr = arr.map((value: i32, index: i32, arr: Array<i32>) => <f32>value);
   assert(newArr.length == 4);
   assert(newArr[0] == <f32>arr[0]);
 


### PR DESCRIPTION
It makes `resolveFunctionExpression` can return correct function type for expression like `(x: i32) => x`

- [x] I've read the contributing guidelines
- [x] I've added my name and email to the NOTICE file
