### PR TITLE
compileStreaming node-fetch on file causes crash

### DIFF
--- a/src/bindings/js.ts
+++ b/src/bindings/js.ts
@@ -883,7 +883,10 @@ export class JSBuilder extends ExportsWalker {
       sb.push(`
 } = await (async url => instantiate(
   await (async () => {
-    try { return await globalThis.WebAssembly.compileStreaming(globalThis.fetch(url)); }
+    try { 
+      const source = await globalThis.fetch(url)
+      return await globalThis.WebAssembly.compileStreaming(source); 
+    }
     catch { return globalThis.WebAssembly.compile(await (await import("node:fs/promises")).readFile(url)); }
   })(), {
 `);

--- a/tests/compiler/bindings/esm.debug.js
+++ b/tests/compiler/bindings/esm.debug.js
@@ -412,7 +412,10 @@ export const {
   fn
 } = await (async url => instantiate(
   await (async () => {
-    try { return await globalThis.WebAssembly.compileStreaming(globalThis.fetch(url)); }
+    try { 
+      const source = await globalThis.fetch(url);
+      return await globalThis.WebAssembly.compileStreaming(source); 
+    }
     catch { return globalThis.WebAssembly.compile(await (await import("node:fs/promises")).readFile(url)); }
   })(), {
   }

--- a/tests/compiler/bindings/esm.release.js
+++ b/tests/compiler/bindings/esm.release.js
@@ -412,7 +412,10 @@ export const {
   fn
 } = await (async url => instantiate(
   await (async () => {
-    try { return await globalThis.WebAssembly.compileStreaming(globalThis.fetch(url)); }
+    try { 
+      const source = await globalThis.fetch(url);
+      return await globalThis.WebAssembly.compileStreaming(source); 
+    }
     catch { return globalThis.WebAssembly.compile(await (await import("node:fs/promises")).readFile(url)); }
   })(), {
   }

--- a/tests/compiler/bindings/noExportRuntime.debug.js
+++ b/tests/compiler/bindings/noExportRuntime.debug.js
@@ -147,7 +147,10 @@ export const {
   takesFunction
 } = await (async url => instantiate(
   await (async () => {
-    try { return await globalThis.WebAssembly.compileStreaming(globalThis.fetch(url)); }
+    try { 
+      const source = await globalThis.fetch(url);
+      return await globalThis.WebAssembly.compileStreaming(source); 
+    }
     catch { return globalThis.WebAssembly.compile(await (await import("node:fs/promises")).readFile(url)); }
   })(), {
   }

--- a/tests/compiler/bindings/noExportRuntime.release.js
+++ b/tests/compiler/bindings/noExportRuntime.release.js
@@ -147,7 +147,10 @@ export const {
   takesFunction
 } = await (async url => instantiate(
   await (async () => {
-    try { return await globalThis.WebAssembly.compileStreaming(globalThis.fetch(url)); }
+    try { 
+      const source = await globalThis.fetch(url);
+      return await globalThis.WebAssembly.compileStreaming(source); 
+    }
     catch { return globalThis.WebAssembly.compile(await (await import("node:fs/promises")).readFile(url)); }
   })(), {
   }


### PR DESCRIPTION
In a NextJS build, with a package that contains an assembly script generated library, node-fetch is crashing when encountering a URL of scheme file.

```
await (async () => {
    /*
     * imagine the url is of scheme file, it has a protocol of file:// and a hostname of ''
     * both of these conditions cause node-fetch to throw an error
     * 
     * eg: node-fetch code
     * if(!p.protocol||!p.hostname){ throw new TypeError("Only absolute URLs are supported")}if(!/^https?:$/.test(p.protocol)){throw new TypeError("Only HTTP(S) protocols are supported")}
     *
     * compileStreaming is called, it doesn't exist because this is Node, and the control flow enters the catch
     * meanwhile, globalThis.fetch(url) rejects due to node-fetch's code above, and goes unhandled, causing a crash
     */
    try { return await globalThis.WebAssembly.compileStreaming(globalThis.fetch(url)); }
    catch { return globalThis.WebAssembly.compile(await (await import("node:fs/promises")).readFile(url)); }
  })(), {
```

This PR first tries to resolve the promise (if that doesn't work it enters the catch), and then tries to compile it (if that doesn't work it enters the catch).

To be honest I'm not sure why this appears to work fine outside of NextJS. Any ideas?

<!--
 Thanks for submitting a pull request to AssemblyScript! Please take a moment to
 review the contributing guidelines linked below, and confirm with an [x] 🙂
-->

⯈
⯈
⯈

- [x] I've read the contributing guidelines
- [x] I've added my name and email to the NOTICE file
