### PR TITLE
fix: Add missing type for i64_signbit input argument

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -51,6 +51,7 @@ under the licensing terms detailed in LICENSE:
 * Adrien Zinger <zinger.ad@gmail.com>
 * Ruixiang Chen <xiang19890319@gmail.com>
 * Daniel Salvadori <danaugrs@gmail.com>
+* Jairus Tanaka <jairus.v.tanaka@outlook.com>
 
 Portions of this software are derived from third-party works licensed under
 the following terms:

--- a/src/glue/js/i64.d.ts
+++ b/src/glue/js/i64.d.ts
@@ -48,7 +48,7 @@ declare function i64_lt(left: i64, right: i64): boolean;
 declare function i64_lt_u(left: i64, right: i64): boolean;
 
 declare function i64_align(value: i64, alignment: i32): i64;
-declare function i64_signbit(value): boolean;
+declare function i64_signbit(value: i64): boolean;
 
 declare function i64_is_i8(value: i64): boolean;
 declare function i64_is_i16(value: i64): boolean;


### PR DESCRIPTION

- I've read the contributing guidelines
- I've added my name and email to the NOTICE file

Fixed a type def for i64_signbit in https://github.com/AssemblyScript/assemblyscript/blob/3a5b51d184bf4dfc3c1a5e1d57481a1b0ce1a71d/src/glue/js/i64.d.ts#L51
