### PR TITLE
Add stringref expression ids

### DIFF
--- a/src/module.ts
+++ b/src/module.ts
@@ -185,7 +185,20 @@ export const enum ExpressionId {
   ArraySet = 66 /* _BinaryenArraySetId */,
   ArrayLen = 67 /* _BinaryenArrayLenId */,
   ArrayCopy = 68 /* _BinaryenArrayCopyId */,
-  RefAs = 69 /* _BinaryenRefAsId */
+  RefAs = 69 /* _BinaryenRefAsId */,
+  StringNew = 70 /* _BinaryenStringNewId */,
+  StringConst = 71 /* _BinaryenStringConstId */,
+  StringMeasure = 72 /* _BinaryenStringMeasureId */,
+  StringEncode = 73 /* _BinaryenStringEncodeId */,
+  StringConcat = 74 /* _BinaryenStringConcatId */,
+  StringEq = 75 /* _BinaryenStringEqId */,
+  StringAs = 76 /* _BinaryenStringAsId */,
+  StringWTF8Advance = 77 /* _BinaryenStringWTF8AdvanceId */,
+  StringWTF16Get = 78 /* _BinaryenStringWTF16GetId */,
+  StringIterNext = 79 /* _BinaryenStringIterNextId */,
+  StringIterMove = 80 /* _BinaryenStringIterMoveId */,
+  StringSliceWTF = 81 /* _BinaryenStringSliceWTFId */,
+  StringSliceIter = 82 /* _BinaryenStringSliceIterId */
 }
 
 /** Binaryen external kind constants. */


### PR DESCRIPTION
The `[Expression]Id` getters are [generated programmatically](https://github.com/WebAssembly/binaryen/blob/da24ef6ed7055f64299fce22a051ba0e85284c23/src/binaryen-c.h#L172-L175) by Binaryen nowadays, so already exist in the version of Binaryen we use - all that's left is to add them.

- [x] I've read the contributing guidelines
- [x] I've added my name and email to the NOTICE file
