### PR TITLE
fix: Use proper portable copysign polyfill

### DIFF
--- a/std/portable/index.js
+++ b/std/portable/index.js
@@ -140,7 +140,7 @@ if (typeof globalScope.ASC_TARGET === "undefined") {
     const INV_EPS64 = 4503599627370496.0;
     const y = Math.abs(value);
     return y < INV_EPS64
-      ? globalScope.copysign(y + INV_EPS64 - INV_EPS64, value)
+      ? Math.abs(y + INV_EPS64 - INV_EPS64) * Math.sign(value)
       : value;
   };
 
@@ -153,10 +153,15 @@ if (typeof globalScope.ASC_TARGET === "undefined") {
   globalScope["trunc"] = Math.trunc;
 
   globalScope["copysign"] = function copysign(x, y) {
-    F64[0] = y; y = U64[1] & 0x80000000;
-    F64[0] = x;
-    U64[1] = U64[1] & 0x7FFFFFFF | y;
-    return F64[0];
+    if (y) {
+      // fast path
+      return Math.abs(x) * Math.sign(y);
+    } else { // 0, -0, +NaN, -NaN
+      F64[0] = y; y = U64[1] & 0x80000000;
+      F64[0] = x;
+      U64[1] = U64[1] & 0x7FFFFFFF | y;
+      return F64[0];
+    }
   };
 
   globalScope["bswap"] = function bswap(value) {

--- a/std/portable/index.js
+++ b/std/portable/index.js
@@ -153,7 +153,10 @@ if (typeof globalScope.ASC_TARGET === "undefined") {
   globalScope["trunc"] = Math.trunc;
 
   globalScope["copysign"] = function copysign(x, y) {
-    return Math.abs(x) * Math.sign(y);
+    F64[0] = y; y = U64[1] & 0x80000000;
+    F64[0] = x;
+    U64[1] = U64[1] & 0x7FFFFFFF | y;
+    return F64[0];
   };
 
   globalScope["bswap"] = function bswap(value) {

--- a/std/portable/index.js
+++ b/std/portable/index.js
@@ -153,10 +153,9 @@ if (typeof globalScope.ASC_TARGET === "undefined") {
   globalScope["trunc"] = Math.trunc;
 
   globalScope["copysign"] = function copysign(x, y) {
-    return Math.abs(x) * (y
-      ? Math.sign(y)
-      : (F64[0] = y, U64[1] >>> 31 ? -1 : 1) // +0, -0, -NaN, +NaN
-    );
+    return y
+      ? Math.abs(x) * Math.sign(y)
+      : (F64[0] = y, U64[1] >>> 31 ? -1 : 1); // +0, -0, -NaN, +NaN
   };
 
   globalScope["bswap"] = function bswap(value) {

--- a/std/portable/index.js
+++ b/std/portable/index.js
@@ -153,15 +153,10 @@ if (typeof globalScope.ASC_TARGET === "undefined") {
   globalScope["trunc"] = Math.trunc;
 
   globalScope["copysign"] = function copysign(x, y) {
-    if (y) {
-      // fast path
-      return Math.abs(x) * Math.sign(y);
-    } else { // 0, -0, +NaN, -NaN
-      F64[0] = y; y = U64[1] & 0x80000000;
-      F64[0] = x;
-      U64[1] = U64[1] & 0x7FFFFFFF | y;
-      return F64[0];
-    }
+    return Math.abs(x) * (y
+      ? Math.sign(y)
+      : (F64[0] = y, U64[1] >>> 31 ? -1 : 1) // +0, -0, -NaN, +NaN
+    );
   };
 
   globalScope["bswap"] = function bswap(value) {

--- a/std/portable/index.js
+++ b/std/portable/index.js
@@ -140,7 +140,7 @@ if (typeof globalScope.ASC_TARGET === "undefined") {
     const INV_EPS64 = 4503599627370496.0;
     const y = Math.abs(value);
     return y < INV_EPS64
-      ? Math.abs(y + INV_EPS64 - INV_EPS64) * Math.sign(value)
+      ? globalScope.copysign(y + INV_EPS64 - INV_EPS64, value)
       : value;
   };
 

--- a/std/portable/index.js
+++ b/std/portable/index.js
@@ -140,7 +140,7 @@ if (typeof globalScope.ASC_TARGET === "undefined") {
     const INV_EPS64 = 4503599627370496.0;
     const y = Math.abs(value);
     return y < INV_EPS64
-      ? Math.abs(y + INV_EPS64 - INV_EPS64) * Math.sign(value)
+      ? (y + INV_EPS64 - INV_EPS64) * Math.sign(value)
       : value;
   };
 


### PR DESCRIPTION
Previous one  can't properly handle such edge cases:
```ts
copysign(1.0, +0.0)   ->  +0.0
copysign(1.0, -0.0)   ->  -0.0
copysign(1.0, +NaN)   ->  NaN
copysign(1.0, -NaN)   ->  NaN
```
Now, these cases don't change destination `x` argument. Only its sign:
```ts
copysign(1.0, +0.0)   ->  +1
copysign(1.0, -0.0)   ->  -1
copysign(1.0, +NaN)   ->  +1
copysign(1.0, -NaN)   ->  -1
```

- [x] I've read the contributing guidelines
- [x] I've added my name and email to the NOTICE file
