### PR TITLE
fix: fix shadowstack pass discard debuginfo

### DIFF
--- a/src/compiler.ts
+++ b/src/compiler.ts
@@ -54,8 +54,7 @@ import {
   ExpressionRunnerFlags,
   isConstZero,
   isConstNegZero,
-  isConstExpressionNaN,
-  getFunctionName,
+  isConstExpressionNaN
 } from "./module";
 
 import {
@@ -707,18 +706,6 @@ export class Compiler extends DiagnosticEmitter {
     // Run custom passes
     if (hasShadowStack) {
       this.shadowStack.walkModule();
-      const modifiedFunction = this.shadowStack.modifiedFunction;
-      for (let i = 0, k = modifiedFunction.length; i < k; i++) {
-        const modifiedFunctionRef = modifiedFunction[i];
-        const modifiedFunctionName = getFunctionName(modifiedFunctionRef);
-        if (!modifiedFunctionName) continue;
-        if (!this.program.instancesByName.has(modifiedFunctionName)) continue;
-        const element = this.program.instancesByName.get(modifiedFunctionName);
-        if (element && element.kind == ElementKind.FUNCTION) {
-          const func = <Function>element;
-          func.addDebugInfo(module, modifiedFunctionRef);
-        }
-      }
     }
     if (program.lookup("ASC_RTRACE") != null) {
       new RtraceMemory(this).walkModule();

--- a/src/passes/shadowstack.ts
+++ b/src/passes/shadowstack.ts
@@ -147,7 +147,6 @@ import {
 import {
   BuiltinNames
 } from "../builtins";
-import { Function } from "../program";
 
 type LocalIndex = Index;
 type SlotIndex = Index;
@@ -480,7 +479,7 @@ export class ShadowStackPass extends Pass {
     let cArr = allocPtrArray(vars);
     let newFuncRef = _BinaryenAddFunction(moduleRef, name, params, results, cArr, vars.length, body);
     if (this.options.sourceMap || this.options.debugInfo) {
-      let func = Function.searchFunctionByRef(this.compiler, newFuncRef);
+      let func = this.compiler.program.searchFunctionByRef(newFuncRef);
       if (func) func.addDebugInfo(this.module, newFuncRef);
     }
     _free(cArr);

--- a/src/passes/shadowstack.ts
+++ b/src/passes/shadowstack.ts
@@ -132,7 +132,7 @@ import {
   ExternalKind,
   ExportRef,
   expandType,
-  isConstZero
+  isConstZero,
 } from "../module";
 
 import {
@@ -147,6 +147,7 @@ import {
 import {
   BuiltinNames
 } from "../builtins";
+import { Function } from "../program";
 
 type LocalIndex = Index;
 type SlotIndex = Index;
@@ -187,8 +188,6 @@ export class ShadowStackPass extends Pass {
   exportMap: Map<string,i32[]> = new Map();
   /** Compiler reference. */
   compiler: Compiler;
-  /** Re-add function due to local count change */
-  modifiedFunction: Array<FunctionRef> = [];
 
   constructor(compiler: Compiler) {
     super(compiler.module);
@@ -480,7 +479,8 @@ export class ShadowStackPass extends Pass {
     _BinaryenRemoveFunction(moduleRef, name);
     let cArr = allocPtrArray(vars);
     let newFuncRef = _BinaryenAddFunction(moduleRef, name, params, results, cArr, vars.length, body);
-    this.modifiedFunction.push(newFuncRef);
+    let func = Function.searchFunctionByRef(this.compiler, newFuncRef);
+    if (func) func.addDebugInfo(this.module, newFuncRef);
     _free(cArr);
   }
 

--- a/src/passes/shadowstack.ts
+++ b/src/passes/shadowstack.ts
@@ -187,6 +187,8 @@ export class ShadowStackPass extends Pass {
   exportMap: Map<string,i32[]> = new Map();
   /** Compiler reference. */
   compiler: Compiler;
+  /** Re-add function due to local count change */
+  modifiedFunction: Array<FunctionRef> = [];
 
   constructor(compiler: Compiler) {
     super(compiler.module);
@@ -477,7 +479,8 @@ export class ShadowStackPass extends Pass {
     let moduleRef = this.module.ref;
     _BinaryenRemoveFunction(moduleRef, name);
     let cArr = allocPtrArray(vars);
-    _BinaryenAddFunction(moduleRef, name, params, results, cArr, vars.length, body);
+    let newFuncRef = _BinaryenAddFunction(moduleRef, name, params, results, cArr, vars.length, body);
+    this.modifiedFunction.push(newFuncRef);
     _free(cArr);
   }
 

--- a/src/passes/shadowstack.ts
+++ b/src/passes/shadowstack.ts
@@ -479,8 +479,10 @@ export class ShadowStackPass extends Pass {
     _BinaryenRemoveFunction(moduleRef, name);
     let cArr = allocPtrArray(vars);
     let newFuncRef = _BinaryenAddFunction(moduleRef, name, params, results, cArr, vars.length, body);
-    let func = Function.searchFunctionByRef(this.compiler, newFuncRef);
-    if (func) func.addDebugInfo(this.module, newFuncRef);
+    if (this.options.sourceMap || this.options.debugInfo) {
+      let func = Function.searchFunctionByRef(this.compiler, newFuncRef);
+      if (func) func.addDebugInfo(this.module, newFuncRef);
+    }
     _free(cArr);
   }
 

--- a/src/program.ts
+++ b/src/program.ts
@@ -53,6 +53,7 @@ import {
 } from "./common";
 
 import {
+  Compiler,
   Options
 } from "./compiler";
 
@@ -117,7 +118,8 @@ import {
 import {
   Module,
   FunctionRef,
-  MemorySegment
+  MemorySegment,
+  getFunctionName
 } from "./module";
 
 import {
@@ -3793,6 +3795,20 @@ export class Function extends TypedElement {
         module.setLocalName(ref, i, localName);
       }
     }
+  }
+
+  static searchFunctionByRef(compiler: Compiler, ref: FunctionRef): Function | null {
+    const modifiedFunctionName = getFunctionName(ref);
+    if (modifiedFunctionName) {
+      const instancesByName = compiler.program.instancesByName;
+      if (instancesByName.has(modifiedFunctionName)) {
+        const element = assert(instancesByName.get(modifiedFunctionName));
+        if (element.kind == ElementKind.FUNCTION) {
+          return <Function>element;
+        }
+      }
+    }
+    return null;
   }
 }
 

--- a/src/program.ts
+++ b/src/program.ts
@@ -3759,6 +3759,10 @@ export class Function extends TypedElement {
     this.breakStack = breakStack = null;
     this.breakLabel = null;
     this.tempI32s = this.tempI64s = this.tempF32s = this.tempF64s = null;
+    this.addDebugInfo(module, ref);
+  }
+
+  addDebugInfo(module: Module, ref: FunctionRef): void {
     if (this.program.options.sourceMap) {
       let debugLocations = this.debugLocations;
       for (let i = 0, k = debugLocations.length; i < k; ++i) {

--- a/src/program.ts
+++ b/src/program.ts
@@ -53,7 +53,6 @@ import {
 } from "./common";
 
 import {
-  Compiler,
   Options
 } from "./compiler";
 
@@ -812,6 +811,20 @@ export class Program extends DiagnosticEmitter {
     // BLOCK | OBJECT+align | data...
     // └     = TOTAL      ┘ ^ 16b alignment
     return this.blockOverhead + this.objectOverhead;
+  }
+
+  searchFunctionByRef(ref: FunctionRef): Function | null {
+    const modifiedFunctionName = getFunctionName(ref);
+    if (modifiedFunctionName) {
+      const instancesByName = this.instancesByName;
+      if (instancesByName.has(modifiedFunctionName)) {
+        const element = assert(instancesByName.get(modifiedFunctionName));
+        if (element.kind == ElementKind.FUNCTION) {
+          return <Function>element;
+        }
+      }
+    }
+    return null;
   }
 
   /** Computes the next properly aligned offset of a memory manager block, given the current bump offset. */
@@ -3795,20 +3808,6 @@ export class Function extends TypedElement {
         module.setLocalName(ref, i, localName);
       }
     }
-  }
-
-  static searchFunctionByRef(compiler: Compiler, ref: FunctionRef): Function | null {
-    const modifiedFunctionName = getFunctionName(ref);
-    if (modifiedFunctionName) {
-      const instancesByName = compiler.program.instancesByName;
-      if (instancesByName.has(modifiedFunctionName)) {
-        const element = assert(instancesByName.get(modifiedFunctionName));
-        if (element.kind == ElementKind.FUNCTION) {
-          return <Function>element;
-        }
-      }
-    }
-    return null;
   }
 }
 

--- a/tests/compiler/assert-nonnull.debug.wat
+++ b/tests/compiler/assert-nonnull.debug.wat
@@ -92,8 +92,8 @@
    unreachable
   end
  )
- (func $assert-nonnull/testArr (param $0 i32) (result i32)
-  (local $1 i32)
+ (func $assert-nonnull/testArr (param $foo i32) (result i32)
+  (local $var$1 i32)
   (local $2 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -103,10 +103,10 @@
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   i32.store $0
-  local.get $0
-  local.tee $1
+  local.get $foo
+  local.tee $var$1
   if (result i32)
-   local.get $1
+   local.get $var$1
   else
    i32.const 32
    i32.const 96
@@ -129,8 +129,8 @@
   global.set $~lib/memory/__stack_pointer
   local.get $2
  )
- (func $assert-nonnull/testAll (param $0 i32) (result i32)
-  (local $1 i32)
+ (func $assert-nonnull/testAll (param $foo i32) (result i32)
+  (local $var$1 i32)
   (local $2 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 8
@@ -142,10 +142,10 @@
   i64.store $0
   global.get $~lib/memory/__stack_pointer
   global.get $~lib/memory/__stack_pointer
-  local.get $0
-  local.tee $1
+  local.get $foo
+  local.tee $var$1
   if (result i32)
-   local.get $1
+   local.get $var$1
   else
    i32.const 32
    i32.const 96
@@ -161,11 +161,11 @@
   local.get $2
   i32.const 0
   call $~lib/array/Array<assert-nonnull/Foo|null>#__get
-  local.tee $1
+  local.tee $var$1
   i32.store $0 offset=4
-  local.get $1
+  local.get $var$1
   if (result i32)
-   local.get $1
+   local.get $var$1
   else
    i32.const 32
    i32.const 96
@@ -175,11 +175,11 @@
    unreachable
   end
   i32.load $0
-  local.tee $1
+  local.tee $var$1
   i32.store $0 offset=4
-  local.get $1
+  local.get $var$1
   if (result i32)
-   local.get $1
+   local.get $var$1
   else
    i32.const 32
    i32.const 96
@@ -195,8 +195,8 @@
   global.set $~lib/memory/__stack_pointer
   local.get $2
  )
- (func $assert-nonnull/testAll2 (param $0 i32) (result i32)
-  (local $1 i32)
+ (func $assert-nonnull/testAll2 (param $foo i32) (result i32)
+  (local $var$1 i32)
   (local $2 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 8
@@ -208,10 +208,10 @@
   i64.store $0
   global.get $~lib/memory/__stack_pointer
   global.get $~lib/memory/__stack_pointer
-  local.get $0
-  local.tee $1
+  local.get $foo
+  local.tee $var$1
   if (result i32)
-   local.get $1
+   local.get $var$1
   else
    i32.const 32
    i32.const 96
@@ -227,11 +227,11 @@
   local.get $2
   i32.const 0
   call $~lib/array/Array<assert-nonnull/Foo|null>#__get
-  local.tee $1
+  local.tee $var$1
   i32.store $0 offset=4
-  local.get $1
+  local.get $var$1
   if (result i32)
-   local.get $1
+   local.get $var$1
   else
    i32.const 32
    i32.const 96
@@ -241,11 +241,11 @@
    unreachable
   end
   i32.load $0
-  local.tee $1
+  local.tee $var$1
   i32.store $0 offset=4
-  local.get $1
+  local.get $var$1
   if (result i32)
-   local.get $1
+   local.get $var$1
   else
    i32.const 32
    i32.const 96
@@ -261,8 +261,8 @@
   global.set $~lib/memory/__stack_pointer
   local.get $2
  )
- (func $assert-nonnull/testProp (param $0 i32) (result i32)
-  (local $1 i32)
+ (func $assert-nonnull/testProp (param $foo i32) (result i32)
+  (local $var$1 i32)
   (local $2 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -273,13 +273,13 @@
   i32.const 0
   i32.store $0
   global.get $~lib/memory/__stack_pointer
-  local.get $0
+  local.get $foo
   i32.load $0
-  local.tee $1
+  local.tee $var$1
   i32.store $0
-  local.get $1
+  local.get $var$1
   if (result i32)
-   local.get $1
+   local.get $var$1
   else
    i32.const 32
    i32.const 96
@@ -295,8 +295,8 @@
   global.set $~lib/memory/__stack_pointer
   local.get $2
  )
- (func $~lib/array/Array<assert-nonnull/Foo>#__get (param $0 i32) (param $1 i32) (result i32)
-  (local $2 i32)
+ (func $~lib/array/Array<assert-nonnull/Foo>#__get (param $this i32) (param $index i32) (result i32)
+  (local $value i32)
   (local $3 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -306,8 +306,8 @@
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   i32.store $0
-  local.get $1
-  local.get $0
+  local.get $index
+  local.get $this
   i32.load $0 offset=12
   i32.ge_u
   if
@@ -319,21 +319,21 @@
    unreachable
   end
   global.get $~lib/memory/__stack_pointer
-  local.get $0
+  local.get $this
   i32.load $0 offset=4
-  local.get $1
+  local.get $index
   i32.const 2
   i32.shl
   i32.add
   i32.load $0
-  local.tee $2
+  local.tee $value
   i32.store $0
   i32.const 1
   drop
   i32.const 0
   i32.eqz
   drop
-  local.get $2
+  local.get $value
   i32.eqz
   if
    i32.const 272
@@ -343,7 +343,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $2
+  local.get $value
   local.set $3
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -351,8 +351,8 @@
   global.set $~lib/memory/__stack_pointer
   local.get $3
  )
- (func $~lib/array/Array<assert-nonnull/Foo|null>#__get (param $0 i32) (param $1 i32) (result i32)
-  (local $2 i32)
+ (func $~lib/array/Array<assert-nonnull/Foo|null>#__get (param $this i32) (param $index i32) (result i32)
+  (local $value i32)
   (local $3 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -362,8 +362,8 @@
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   i32.store $0
-  local.get $1
-  local.get $0
+  local.get $index
+  local.get $this
   i32.load $0 offset=12
   i32.ge_u
   if
@@ -375,21 +375,21 @@
    unreachable
   end
   global.get $~lib/memory/__stack_pointer
-  local.get $0
+  local.get $this
   i32.load $0 offset=4
-  local.get $1
+  local.get $index
   i32.const 2
   i32.shl
   i32.add
   i32.load $0
-  local.tee $2
+  local.tee $value
   i32.store $0
   i32.const 1
   drop
   i32.const 1
   i32.eqz
   drop
-  local.get $2
+  local.get $value
   local.set $3
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -397,8 +397,8 @@
   global.set $~lib/memory/__stack_pointer
   local.get $3
  )
- (func $assert-nonnull/testElem (param $0 i32) (result i32)
-  (local $1 i32)
+ (func $assert-nonnull/testElem (param $foo i32) (result i32)
+  (local $var$1 i32)
   (local $2 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -409,14 +409,14 @@
   i32.const 0
   i32.store $0
   global.get $~lib/memory/__stack_pointer
-  local.get $0
+  local.get $foo
   i32.const 0
   call $~lib/array/Array<assert-nonnull/Foo|null>#__get
-  local.tee $1
+  local.tee $var$1
   i32.store $0
-  local.get $1
+  local.get $var$1
   if (result i32)
-   local.get $1
+   local.get $var$1
   else
    i32.const 32
    i32.const 96
@@ -432,9 +432,9 @@
   global.set $~lib/memory/__stack_pointer
   local.get $2
  )
- (func $assert-nonnull/testFn2 (param $0 i32) (result i32)
-  (local $1 i32)
-  (local $2 i32)
+ (func $assert-nonnull/testFn2 (param $fn i32) (result i32)
+  (local $var$1 i32)
+  (local $fn2 i32)
   (local $3 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -445,10 +445,10 @@
   i32.const 0
   i32.store $0
   global.get $~lib/memory/__stack_pointer
-  local.get $0
-  local.tee $1
+  local.get $fn
+  local.tee $var$1
   if (result i32)
-   local.get $1
+   local.get $var$1
   else
    i32.const 32
    i32.const 96
@@ -457,11 +457,11 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.tee $2
+  local.tee $fn2
   i32.store $0
   i32.const 0
   global.set $~argumentsLength
-  local.get $2
+  local.get $fn2
   i32.load $0
   call_indirect $0 (type $none_=>_i32)
   local.set $3
@@ -471,8 +471,8 @@
   global.set $~lib/memory/__stack_pointer
   local.get $3
  )
- (func $assert-nonnull/testRet (param $0 i32) (result i32)
-  (local $1 i32)
+ (func $assert-nonnull/testRet (param $fn i32) (result i32)
+  (local $var$1 i32)
   (local $2 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -485,14 +485,14 @@
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   global.set $~argumentsLength
-  local.get $0
+  local.get $fn
   i32.load $0
   call_indirect $0 (type $none_=>_i32)
-  local.tee $1
+  local.tee $var$1
   i32.store $0
-  local.get $1
+  local.get $var$1
   if (result i32)
-   local.get $1
+   local.get $var$1
   else
    i32.const 32
    i32.const 96
@@ -508,8 +508,8 @@
   global.set $~lib/memory/__stack_pointer
   local.get $2
  )
- (func $assert-nonnull/testObjRet (param $0 i32) (result i32)
-  (local $1 i32)
+ (func $assert-nonnull/testObjRet (param $foo i32) (result i32)
+  (local $var$1 i32)
   (local $2 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -522,15 +522,15 @@
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   global.set $~argumentsLength
-  local.get $0
+  local.get $foo
   i32.load $0 offset=4
   i32.load $0
   call_indirect $0 (type $none_=>_i32)
-  local.tee $1
+  local.tee $var$1
   i32.store $0
-  local.get $1
+  local.get $var$1
   if (result i32)
-   local.get $1
+   local.get $var$1
   else
    i32.const 32
    i32.const 96

--- a/tests/compiler/bindings/esm.debug.wat
+++ b/tests/compiler/bindings/esm.debug.wat
@@ -3266,8 +3266,8 @@
   i32.add
   global.set $~lib/memory/__stack_pointer
  )
- (func $~lib/arraybuffer/ArrayBuffer#constructor (param $0 i32) (param $1 i32) (result i32)
-  (local $2 i32)
+ (func $~lib/arraybuffer/ArrayBuffer#constructor (param $this i32) (param $length i32) (result i32)
+  (local $buffer i32)
   (local $3 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -3277,7 +3277,7 @@
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   i32.store $0
-  local.get $1
+  local.get $length
   i32.const 1073741820
   i32.gt_u
   if
@@ -3289,16 +3289,16 @@
    unreachable
   end
   global.get $~lib/memory/__stack_pointer
-  local.get $1
+  local.get $length
   i32.const 0
   call $~lib/rt/itcms/__new
-  local.tee $2
+  local.tee $buffer
   i32.store $0
   i32.const 2
   global.get $~lib/shared/runtime/Runtime.Incremental
   i32.ne
   drop
-  local.get $2
+  local.get $buffer
   local.set $3
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -3306,10 +3306,10 @@
   global.set $~lib/memory/__stack_pointer
   local.get $3
  )
- (func $bindings/esm/bufferFunction (param $0 i32) (param $1 i32) (result i32)
-  (local $2 i32)
-  (local $3 i32)
-  (local $4 i32)
+ (func $bindings/esm/bufferFunction (param $a i32) (param $b i32) (result i32)
+  (local $aByteLength i32)
+  (local $bByteLength i32)
+  (local $out i32)
   (local $5 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -3319,31 +3319,31 @@
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   i32.store $0
-  local.get $0
+  local.get $a
   call $~lib/arraybuffer/ArrayBuffer#get:byteLength
-  local.set $2
-  local.get $1
+  local.set $aByteLength
+  local.get $b
   call $~lib/arraybuffer/ArrayBuffer#get:byteLength
-  local.set $3
+  local.set $bByteLength
   global.get $~lib/memory/__stack_pointer
   i32.const 0
-  local.get $2
-  local.get $3
+  local.get $aByteLength
+  local.get $bByteLength
   i32.add
   call $~lib/arraybuffer/ArrayBuffer#constructor
-  local.tee $4
+  local.tee $out
   i32.store $0
-  local.get $4
-  local.get $0
-  local.get $2
+  local.get $out
+  local.get $a
+  local.get $aByteLength
   memory.copy $0 $0
-  local.get $4
-  local.get $2
+  local.get $out
+  local.get $aByteLength
   i32.add
-  local.get $1
-  local.get $3
+  local.get $b
+  local.get $bByteLength
   memory.copy $0 $0
-  local.get $4
+  local.get $out
   local.set $5
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -3351,11 +3351,11 @@
   global.set $~lib/memory/__stack_pointer
   local.get $5
  )
- (func $~lib/string/String#concat (param $0 i32) (param $1 i32) (result i32)
-  (local $2 i32)
-  (local $3 i32)
-  (local $4 i32)
-  (local $5 i32)
+ (func $~lib/string/String#concat (param $this i32) (param $other i32) (result i32)
+  (local $thisSize i32)
+  (local $otherSize i32)
+  (local $outSize i32)
+  (local $out i32)
   (local $6 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -3365,21 +3365,21 @@
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   i32.store $0
-  local.get $0
+  local.get $this
   call $~lib/string/String#get:length
   i32.const 1
   i32.shl
-  local.set $2
-  local.get $1
+  local.set $thisSize
+  local.get $other
   call $~lib/string/String#get:length
   i32.const 1
   i32.shl
-  local.set $3
-  local.get $2
-  local.get $3
+  local.set $otherSize
+  local.get $thisSize
+  local.get $otherSize
   i32.add
-  local.set $4
-  local.get $4
+  local.set $outSize
+  local.get $outSize
   i32.const 0
   i32.eq
   if
@@ -3393,22 +3393,22 @@
    return
   end
   global.get $~lib/memory/__stack_pointer
-  local.get $4
+  local.get $outSize
   i32.const 1
   call $~lib/rt/itcms/__new
-  local.tee $5
+  local.tee $out
   i32.store $0
-  local.get $5
-  local.get $0
-  local.get $2
+  local.get $out
+  local.get $this
+  local.get $thisSize
   memory.copy $0 $0
-  local.get $5
-  local.get $2
+  local.get $out
+  local.get $thisSize
   i32.add
-  local.get $1
-  local.get $3
+  local.get $other
+  local.get $otherSize
   memory.copy $0 $0
-  local.get $5
+  local.get $out
   local.set $6
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -3416,7 +3416,7 @@
   global.set $~lib/memory/__stack_pointer
   local.get $6
  )
- (func $bindings/esm/stringFunctionOptional@varargs (param $0 i32) (param $1 i32) (result i32)
+ (func $bindings/esm/stringFunctionOptional@varargs (param $a i32) (param $b i32) (result i32)
   (local $2 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -3438,11 +3438,11 @@
    end
    global.get $~lib/memory/__stack_pointer
    i32.const 64
-   local.tee $1
+   local.tee $b
    i32.store $0
   end
-  local.get $0
-  local.get $1
+  local.get $a
+  local.get $b
   call $bindings/esm/stringFunctionOptional
   local.set $2
   global.get $~lib/memory/__stack_pointer
@@ -3451,8 +3451,8 @@
   global.set $~lib/memory/__stack_pointer
   local.get $2
  )
- (func $~lib/arraybuffer/ArrayBufferView#constructor (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
-  (local $3 i32)
+ (func $~lib/arraybuffer/ArrayBufferView#constructor (param $this i32) (param $length i32) (param $alignLog2 i32) (result i32)
+  (local $buffer i32)
   (local $4 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 8
@@ -3462,28 +3462,28 @@
   global.get $~lib/memory/__stack_pointer
   i64.const 0
   i64.store $0
-  local.get $0
+  local.get $this
   i32.eqz
   if
    global.get $~lib/memory/__stack_pointer
    i32.const 12
    i32.const 2
    call $~lib/rt/itcms/__new
-   local.tee $0
+   local.tee $this
    i32.store $0
   end
-  local.get $0
+  local.get $this
   i32.const 0
   call $~lib/arraybuffer/ArrayBufferView#set:buffer
-  local.get $0
+  local.get $this
   i32.const 0
   call $~lib/arraybuffer/ArrayBufferView#set:dataStart
-  local.get $0
+  local.get $this
   i32.const 0
   call $~lib/arraybuffer/ArrayBufferView#set:byteLength
-  local.get $1
+  local.get $length
   i32.const 1073741820
-  local.get $2
+  local.get $alignLog2
   i32.shr_u
   i32.gt_u
   if
@@ -3495,28 +3495,28 @@
    unreachable
   end
   global.get $~lib/memory/__stack_pointer
-  local.get $1
-  local.get $2
+  local.get $length
+  local.get $alignLog2
   i32.shl
-  local.tee $1
+  local.tee $length
   i32.const 0
   call $~lib/rt/itcms/__new
-  local.tee $3
+  local.tee $buffer
   i32.store $0 offset=4
   i32.const 2
   global.get $~lib/shared/runtime/Runtime.Incremental
   i32.ne
   drop
-  local.get $0
-  local.get $3
+  local.get $this
+  local.get $buffer
   call $~lib/arraybuffer/ArrayBufferView#set:buffer
-  local.get $0
-  local.get $3
+  local.get $this
+  local.get $buffer
   call $~lib/arraybuffer/ArrayBufferView#set:dataStart
-  local.get $0
-  local.get $1
+  local.get $this
+  local.get $length
   call $~lib/arraybuffer/ArrayBufferView#set:byteLength
-  local.get $0
+  local.get $this
   local.set $4
   global.get $~lib/memory/__stack_pointer
   i32.const 8
@@ -3524,7 +3524,7 @@
   global.set $~lib/memory/__stack_pointer
   local.get $4
  )
- (func $~lib/typedarray/Uint64Array#constructor (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/typedarray/Uint64Array#constructor (param $this i32) (param $length i32) (result i32)
   (local $2 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -3534,24 +3534,24 @@
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   i32.store $0
-  local.get $0
+  local.get $this
   i32.eqz
   if
    global.get $~lib/memory/__stack_pointer
    i32.const 12
    i32.const 6
    call $~lib/rt/itcms/__new
-   local.tee $0
+   local.tee $this
    i32.store $0
   end
   global.get $~lib/memory/__stack_pointer
-  local.get $0
-  local.get $1
+  local.get $this
+  local.get $length
   i32.const 3
   call $~lib/arraybuffer/ArrayBufferView#constructor
-  local.tee $0
+  local.tee $this
   i32.store $0
-  local.get $0
+  local.get $this
   local.set $2
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -3559,10 +3559,10 @@
   global.set $~lib/memory/__stack_pointer
   local.get $2
  )
- (func $bindings/esm/typedarrayFunction (param $0 i32) (param $1 i32) (result i32)
-  (local $2 i32)
-  (local $3 i32)
-  (local $4 i32)
+ (func $bindings/esm/typedarrayFunction (param $a i32) (param $b i32) (result i32)
+  (local $out i32)
+  (local $var$3 i32)
+  (local $var$4 i32)
   (local $5 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -3574,66 +3574,66 @@
   i32.store $0
   global.get $~lib/memory/__stack_pointer
   i32.const 0
-  local.get $0
+  local.get $a
   call $~lib/typedarray/Int16Array#get:length
-  local.get $1
+  local.get $b
   call $~lib/typedarray/Float32Array#get:length
   i32.add
   call $~lib/typedarray/Uint64Array#constructor
-  local.tee $2
+  local.tee $out
   i32.store $0
   i32.const 0
-  local.set $3
+  local.set $var$3
   loop $for-loop|0
-   local.get $3
-   local.get $0
+   local.get $var$3
+   local.get $a
    call $~lib/typedarray/Int16Array#get:length
    i32.lt_s
-   local.set $4
-   local.get $4
+   local.set $var$4
+   local.get $var$4
    if
-    local.get $2
-    local.get $3
-    local.get $0
-    local.get $3
+    local.get $out
+    local.get $var$3
+    local.get $a
+    local.get $var$3
     call $~lib/typedarray/Int16Array#__get
     i64.extend_i32_s
     call $~lib/typedarray/Uint64Array#__set
-    local.get $3
+    local.get $var$3
     i32.const 1
     i32.add
-    local.set $3
+    local.set $var$3
     br $for-loop|0
    end
   end
   i32.const 0
-  local.set $3
+  local.set $var$3
   loop $for-loop|1
-   local.get $3
-   local.get $1
+   local.get $var$3
+   local.get $b
    call $~lib/typedarray/Float32Array#get:length
    i32.lt_s
-   local.set $4
-   local.get $4
+   local.set $var$4
+   local.get $var$4
    if
-    local.get $2
-    local.get $0
+    local.get $out
+    local.get $a
     call $~lib/typedarray/Int16Array#get:length
-    local.get $3
+    local.get $var$3
     i32.add
-    local.get $1
-    local.get $3
+    local.get $b
+    local.get $var$3
     call $~lib/typedarray/Float32Array#__get
     i64.trunc_sat_f32_u
     call $~lib/typedarray/Uint64Array#__set
-    local.get $3
+    local.get $var$3
     i32.const 1
     i32.add
-    local.set $3
+    local.set $var$3
     br $for-loop|1
    end
   end
-  local.get $2
+  local.get $out
   local.set $5
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -3641,9 +3641,9 @@
   global.set $~lib/memory/__stack_pointer
   local.get $5
  )
- (func $~lib/staticarray/StaticArray<i32>#constructor (param $0 i32) (param $1 i32) (result i32)
-  (local $2 i32)
-  (local $3 i32)
+ (func $~lib/staticarray/StaticArray<i32>#constructor (param $this i32) (param $length i32) (result i32)
+  (local $outSize i32)
+  (local $out i32)
   (local $4 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -3653,7 +3653,7 @@
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   i32.store $0
-  local.get $1
+  local.get $length
   i32.const 1073741820
   i32.const 2
   i32.shr_u
@@ -3666,21 +3666,21 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $1
+  local.get $length
   i32.const 2
   i32.shl
-  local.set $2
+  local.set $outSize
   global.get $~lib/memory/__stack_pointer
-  local.get $2
+  local.get $outSize
   i32.const 7
   call $~lib/rt/itcms/__new
-  local.tee $3
+  local.tee $out
   i32.store $0
   i32.const 2
   global.get $~lib/shared/runtime/Runtime.Incremental
   i32.ne
   drop
-  local.get $3
+  local.get $out
   local.set $4
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -3688,10 +3688,10 @@
   global.set $~lib/memory/__stack_pointer
   local.get $4
  )
- (func $bindings/esm/staticarrayFunction (param $0 i32) (param $1 i32) (result i32)
-  (local $2 i32)
-  (local $3 i32)
-  (local $4 i32)
+ (func $bindings/esm/staticarrayFunction (param $a i32) (param $b i32) (result i32)
+  (local $c i32)
+  (local $var$3 i32)
+  (local $var$4 i32)
   (local $5 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -3703,64 +3703,64 @@
   i32.store $0
   global.get $~lib/memory/__stack_pointer
   i32.const 0
-  local.get $0
+  local.get $a
   call $~lib/staticarray/StaticArray<i32>#get:length
-  local.get $1
+  local.get $b
   call $~lib/staticarray/StaticArray<i32>#get:length
   i32.add
   call $~lib/staticarray/StaticArray<i32>#constructor
-  local.tee $2
+  local.tee $c
   i32.store $0
   i32.const 0
-  local.set $3
+  local.set $var$3
   loop $for-loop|0
-   local.get $3
-   local.get $0
+   local.get $var$3
+   local.get $a
    call $~lib/staticarray/StaticArray<i32>#get:length
    i32.lt_s
-   local.set $4
-   local.get $4
+   local.set $var$4
+   local.get $var$4
    if
-    local.get $2
-    local.get $3
-    local.get $0
-    local.get $3
+    local.get $c
+    local.get $var$3
+    local.get $a
+    local.get $var$3
     call $~lib/staticarray/StaticArray<i32>#__get
     call $~lib/staticarray/StaticArray<i32>#__set
-    local.get $3
+    local.get $var$3
     i32.const 1
     i32.add
-    local.set $3
+    local.set $var$3
     br $for-loop|0
    end
   end
   i32.const 0
-  local.set $3
+  local.set $var$3
   loop $for-loop|1
-   local.get $3
-   local.get $1
+   local.get $var$3
+   local.get $b
    call $~lib/staticarray/StaticArray<i32>#get:length
    i32.lt_s
-   local.set $4
-   local.get $4
+   local.set $var$4
+   local.get $var$4
    if
-    local.get $2
-    local.get $0
+    local.get $c
+    local.get $a
     call $~lib/staticarray/StaticArray<i32>#get:length
-    local.get $3
+    local.get $var$3
     i32.add
-    local.get $1
-    local.get $3
+    local.get $b
+    local.get $var$3
     call $~lib/staticarray/StaticArray<i32>#__get
     call $~lib/staticarray/StaticArray<i32>#__set
-    local.get $3
+    local.get $var$3
     i32.const 1
     i32.add
-    local.set $3
+    local.set $var$3
     br $for-loop|1
    end
   end
-  local.get $2
+  local.get $c
   local.set $5
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -3768,11 +3768,11 @@
   global.set $~lib/memory/__stack_pointer
   local.get $5
  )
- (func $~lib/array/Array<i32>#constructor (param $0 i32) (param $1 i32) (result i32)
-  (local $2 i32)
-  (local $3 i32)
-  (local $4 i32)
-  (local $5 i32)
+ (func $~lib/array/Array<i32>#constructor (param $this i32) (param $length i32) (result i32)
+  (local $var$2 i32)
+  (local $var$3 i32)
+  (local $bufferSize i32)
+  (local $buffer i32)
   (local $6 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 8
@@ -3782,29 +3782,29 @@
   global.get $~lib/memory/__stack_pointer
   i64.const 0
   i64.store $0
-  local.get $0
+  local.get $this
   i32.eqz
   if
    global.get $~lib/memory/__stack_pointer
    i32.const 16
    i32.const 10
    call $~lib/rt/itcms/__new
-   local.tee $0
+   local.tee $this
    i32.store $0
   end
-  local.get $0
+  local.get $this
   i32.const 0
   call $~lib/array/Array<i32>#set:buffer
-  local.get $0
+  local.get $this
   i32.const 0
   call $~lib/array/Array<i32>#set:dataStart
-  local.get $0
+  local.get $this
   i32.const 0
   call $~lib/array/Array<i32>#set:byteLength
-  local.get $0
+  local.get $this
   i32.const 0
   call $~lib/array/Array<i32>#set:length_
-  local.get $1
+  local.get $length
   i32.const 1073741820
   i32.const 2
   i32.shr_u
@@ -3817,40 +3817,40 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $1
-  local.tee $2
+  local.get $length
+  local.tee $var$2
   i32.const 8
-  local.tee $3
-  local.get $2
-  local.get $3
+  local.tee $var$3
+  local.get $var$2
+  local.get $var$3
   i32.gt_u
   select
   i32.const 2
   i32.shl
-  local.set $4
+  local.set $bufferSize
   global.get $~lib/memory/__stack_pointer
-  local.get $4
+  local.get $bufferSize
   i32.const 0
   call $~lib/rt/itcms/__new
-  local.tee $5
+  local.tee $buffer
   i32.store $0 offset=4
   i32.const 2
   global.get $~lib/shared/runtime/Runtime.Incremental
   i32.ne
   drop
-  local.get $0
-  local.get $5
+  local.get $this
+  local.get $buffer
   call $~lib/array/Array<i32>#set:buffer
-  local.get $0
-  local.get $5
+  local.get $this
+  local.get $buffer
   call $~lib/array/Array<i32>#set:dataStart
-  local.get $0
-  local.get $4
+  local.get $this
+  local.get $bufferSize
   call $~lib/array/Array<i32>#set:byteLength
-  local.get $0
-  local.get $1
+  local.get $this
+  local.get $length
   call $~lib/array/Array<i32>#set:length_
-  local.get $0
+  local.get $this
   local.set $6
   global.get $~lib/memory/__stack_pointer
   i32.const 8
@@ -3858,10 +3858,10 @@
   global.set $~lib/memory/__stack_pointer
   local.get $6
  )
- (func $bindings/esm/arrayFunction (param $0 i32) (param $1 i32) (result i32)
-  (local $2 i32)
-  (local $3 i32)
-  (local $4 i32)
+ (func $bindings/esm/arrayFunction (param $a i32) (param $b i32) (result i32)
+  (local $c i32)
+  (local $var$3 i32)
+  (local $var$4 i32)
   (local $5 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -3873,64 +3873,64 @@
   i32.store $0
   global.get $~lib/memory/__stack_pointer
   i32.const 0
-  local.get $0
+  local.get $a
   call $~lib/array/Array<i32>#get:length
-  local.get $1
+  local.get $b
   call $~lib/array/Array<i32>#get:length
   i32.add
   call $~lib/array/Array<i32>#constructor
-  local.tee $2
+  local.tee $c
   i32.store $0
   i32.const 0
-  local.set $3
+  local.set $var$3
   loop $for-loop|0
-   local.get $3
-   local.get $0
+   local.get $var$3
+   local.get $a
    call $~lib/array/Array<i32>#get:length
    i32.lt_s
-   local.set $4
-   local.get $4
+   local.set $var$4
+   local.get $var$4
    if
-    local.get $2
-    local.get $3
-    local.get $0
-    local.get $3
+    local.get $c
+    local.get $var$3
+    local.get $a
+    local.get $var$3
     call $~lib/array/Array<i32>#__get
     call $~lib/array/Array<i32>#__set
-    local.get $3
+    local.get $var$3
     i32.const 1
     i32.add
-    local.set $3
+    local.set $var$3
     br $for-loop|0
    end
   end
   i32.const 0
-  local.set $3
+  local.set $var$3
   loop $for-loop|1
-   local.get $3
-   local.get $1
+   local.get $var$3
+   local.get $b
    call $~lib/array/Array<i32>#get:length
    i32.lt_s
-   local.set $4
-   local.get $4
+   local.set $var$4
+   local.get $var$4
    if
-    local.get $2
-    local.get $0
+    local.get $c
+    local.get $a
     call $~lib/array/Array<i32>#get:length
-    local.get $3
+    local.get $var$3
     i32.add
-    local.get $1
-    local.get $3
+    local.get $b
+    local.get $var$3
     call $~lib/array/Array<i32>#__get
     call $~lib/array/Array<i32>#__set
-    local.get $3
+    local.get $var$3
     i32.const 1
     i32.add
-    local.set $3
+    local.set $var$3
     br $for-loop|1
    end
   end
-  local.get $2
+  local.get $c
   local.set $5
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -3938,7 +3938,7 @@
   global.set $~lib/memory/__stack_pointer
   local.get $5
  )
- (func $bindings/esm/PlainObject#constructor (param $0 i32) (result i32)
+ (func $bindings/esm/PlainObject#constructor (param $this i32) (result i32)
   (local $1 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -3948,65 +3948,65 @@
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   i32.store $0
-  local.get $0
+  local.get $this
   i32.eqz
   if
    global.get $~lib/memory/__stack_pointer
    i32.const 68
    i32.const 11
    call $~lib/rt/itcms/__new
-   local.tee $0
+   local.tee $this
    i32.store $0
   end
-  local.get $0
+  local.get $this
   i32.const 0
   call $bindings/esm/PlainObject#set:a
-  local.get $0
+  local.get $this
   i32.const 0
   call $bindings/esm/PlainObject#set:b
-  local.get $0
+  local.get $this
   i32.const 0
   call $bindings/esm/PlainObject#set:c
-  local.get $0
+  local.get $this
   i64.const 0
   call $bindings/esm/PlainObject#set:d
-  local.get $0
+  local.get $this
   i32.const 0
   call $bindings/esm/PlainObject#set:e
-  local.get $0
+  local.get $this
   i32.const 0
   call $bindings/esm/PlainObject#set:f
-  local.get $0
+  local.get $this
   i32.const 0
   call $bindings/esm/PlainObject#set:g
-  local.get $0
+  local.get $this
   i64.const 0
   call $bindings/esm/PlainObject#set:h
-  local.get $0
+  local.get $this
   i32.const 0
   call $bindings/esm/PlainObject#set:i
-  local.get $0
+  local.get $this
   i32.const 0
   call $bindings/esm/PlainObject#set:j
-  local.get $0
+  local.get $this
   i32.const 0
   call $bindings/esm/PlainObject#set:k
-  local.get $0
+  local.get $this
   f32.const 0
   call $bindings/esm/PlainObject#set:l
-  local.get $0
+  local.get $this
   f64.const 0
   call $bindings/esm/PlainObject#set:m
-  local.get $0
+  local.get $this
   i32.const 0
   call $bindings/esm/PlainObject#set:n
-  local.get $0
+  local.get $this
   i32.const 0
   call $bindings/esm/PlainObject#set:o
-  local.get $0
+  local.get $this
   i32.const 0
   call $bindings/esm/PlainObject#set:p
-  local.get $0
+  local.get $this
   local.set $1
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -4014,8 +4014,8 @@
   global.set $~lib/memory/__stack_pointer
   local.get $1
  )
- (func $bindings/esm/objectFunction (param $0 i32) (param $1 i32) (result i32)
-  (local $2 i32)
+ (func $bindings/esm/objectFunction (param $a i32) (param $b i32) (result i32)
+  (local $var$2 i32)
   (local $3 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -4028,23 +4028,23 @@
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   call $bindings/esm/PlainObject#constructor
-  local.tee $2
+  local.tee $var$2
   i32.store $0
-  local.get $2
-  local.get $0
+  local.get $var$2
+  local.get $a
   i32.load8_s $0
-  local.get $1
+  local.get $b
   i32.load8_s $0
   i32.add
   call $bindings/esm/PlainObject#set:a
-  local.get $2
-  local.get $0
+  local.get $var$2
+  local.get $a
   i32.load16_s $0 offset=2
-  local.get $1
+  local.get $b
   i32.load16_s $0 offset=2
   i32.add
   call $bindings/esm/PlainObject#set:b
-  local.get $2
+  local.get $var$2
   local.set $3
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -4052,7 +4052,7 @@
   global.set $~lib/memory/__stack_pointer
   local.get $3
  )
- (func $bindings/esm/NonPlainObject#constructor (param $0 i32) (result i32)
+ (func $bindings/esm/NonPlainObject#constructor (param $this i32) (result i32)
   (local $1 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -4062,17 +4062,17 @@
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   i32.store $0
-  local.get $0
+  local.get $this
   i32.eqz
   if
    global.get $~lib/memory/__stack_pointer
    i32.const 0
    i32.const 14
    call $~lib/rt/itcms/__new
-   local.tee $0
+   local.tee $this
    i32.store $0
   end
-  local.get $0
+  local.get $this
   local.set $1
   global.get $~lib/memory/__stack_pointer
   i32.const 4

--- a/tests/compiler/bindings/noExportRuntime.debug.wat
+++ b/tests/compiler/bindings/noExportRuntime.debug.wat
@@ -2473,8 +2473,8 @@
    unreachable
   end
  )
- (func $~lib/arraybuffer/ArrayBuffer#constructor (param $0 i32) (param $1 i32) (result i32)
-  (local $2 i32)
+ (func $~lib/arraybuffer/ArrayBuffer#constructor (param $this i32) (param $length i32) (result i32)
+  (local $buffer i32)
   (local $3 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -2484,7 +2484,7 @@
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   i32.store $0
-  local.get $1
+  local.get $length
   i32.const 1073741820
   i32.gt_u
   if
@@ -2496,16 +2496,16 @@
    unreachable
   end
   global.get $~lib/memory/__stack_pointer
-  local.get $1
+  local.get $length
   i32.const 0
   call $~lib/rt/itcms/__new
-  local.tee $2
+  local.tee $buffer
   i32.store $0
   i32.const 2
   global.get $~lib/shared/runtime/Runtime.Incremental
   i32.ne
   drop
-  local.get $2
+  local.get $buffer
   local.set $3
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -2513,8 +2513,8 @@
   global.set $~lib/memory/__stack_pointer
   local.get $3
  )
- (func $~lib/arraybuffer/ArrayBufferView#constructor (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
-  (local $3 i32)
+ (func $~lib/arraybuffer/ArrayBufferView#constructor (param $this i32) (param $length i32) (param $alignLog2 i32) (result i32)
+  (local $buffer i32)
   (local $4 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 8
@@ -2524,28 +2524,28 @@
   global.get $~lib/memory/__stack_pointer
   i64.const 0
   i64.store $0
-  local.get $0
+  local.get $this
   i32.eqz
   if
    global.get $~lib/memory/__stack_pointer
    i32.const 12
    i32.const 2
    call $~lib/rt/itcms/__new
-   local.tee $0
+   local.tee $this
    i32.store $0
   end
-  local.get $0
+  local.get $this
   i32.const 0
   call $~lib/arraybuffer/ArrayBufferView#set:buffer
-  local.get $0
+  local.get $this
   i32.const 0
   call $~lib/arraybuffer/ArrayBufferView#set:dataStart
-  local.get $0
+  local.get $this
   i32.const 0
   call $~lib/arraybuffer/ArrayBufferView#set:byteLength
-  local.get $1
+  local.get $length
   i32.const 1073741820
-  local.get $2
+  local.get $alignLog2
   i32.shr_u
   i32.gt_u
   if
@@ -2557,28 +2557,28 @@
    unreachable
   end
   global.get $~lib/memory/__stack_pointer
-  local.get $1
-  local.get $2
+  local.get $length
+  local.get $alignLog2
   i32.shl
-  local.tee $1
+  local.tee $length
   i32.const 0
   call $~lib/rt/itcms/__new
-  local.tee $3
+  local.tee $buffer
   i32.store $0 offset=4
   i32.const 2
   global.get $~lib/shared/runtime/Runtime.Incremental
   i32.ne
   drop
-  local.get $0
-  local.get $3
+  local.get $this
+  local.get $buffer
   call $~lib/arraybuffer/ArrayBufferView#set:buffer
-  local.get $0
-  local.get $3
+  local.get $this
+  local.get $buffer
   call $~lib/arraybuffer/ArrayBufferView#set:dataStart
-  local.get $0
-  local.get $1
+  local.get $this
+  local.get $length
   call $~lib/arraybuffer/ArrayBufferView#set:byteLength
-  local.get $0
+  local.get $this
   local.set $4
   global.get $~lib/memory/__stack_pointer
   i32.const 8
@@ -2586,7 +2586,7 @@
   global.set $~lib/memory/__stack_pointer
   local.get $4
  )
- (func $~lib/typedarray/Int32Array#constructor (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/typedarray/Int32Array#constructor (param $this i32) (param $length i32) (result i32)
   (local $2 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -2596,24 +2596,24 @@
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   i32.store $0
-  local.get $0
+  local.get $this
   i32.eqz
   if
    global.get $~lib/memory/__stack_pointer
    i32.const 12
    i32.const 3
    call $~lib/rt/itcms/__new
-   local.tee $0
+   local.tee $this
    i32.store $0
   end
   global.get $~lib/memory/__stack_pointer
-  local.get $0
-  local.get $1
+  local.get $this
+  local.get $length
   i32.const 2
   call $~lib/arraybuffer/ArrayBufferView#constructor
-  local.tee $0
+  local.tee $this
   i32.store $0
-  local.get $0
+  local.get $this
   local.set $2
   global.get $~lib/memory/__stack_pointer
   i32.const 4

--- a/tests/compiler/bindings/raw.debug.wat
+++ b/tests/compiler/bindings/raw.debug.wat
@@ -3269,8 +3269,8 @@
   i32.add
   global.set $~lib/memory/__stack_pointer
  )
- (func $~lib/arraybuffer/ArrayBuffer#constructor (param $0 i32) (param $1 i32) (result i32)
-  (local $2 i32)
+ (func $~lib/arraybuffer/ArrayBuffer#constructor (param $this i32) (param $length i32) (result i32)
+  (local $buffer i32)
   (local $3 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -3280,7 +3280,7 @@
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   i32.store $0
-  local.get $1
+  local.get $length
   i32.const 1073741820
   i32.gt_u
   if
@@ -3292,16 +3292,16 @@
    unreachable
   end
   global.get $~lib/memory/__stack_pointer
-  local.get $1
+  local.get $length
   i32.const 0
   call $~lib/rt/itcms/__new
-  local.tee $2
+  local.tee $buffer
   i32.store $0
   i32.const 2
   global.get $~lib/shared/runtime/Runtime.Incremental
   i32.ne
   drop
-  local.get $2
+  local.get $buffer
   local.set $3
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -3309,10 +3309,10 @@
   global.set $~lib/memory/__stack_pointer
   local.get $3
  )
- (func $bindings/esm/bufferFunction (param $0 i32) (param $1 i32) (result i32)
-  (local $2 i32)
-  (local $3 i32)
-  (local $4 i32)
+ (func $bindings/esm/bufferFunction (param $a i32) (param $b i32) (result i32)
+  (local $aByteLength i32)
+  (local $bByteLength i32)
+  (local $out i32)
   (local $5 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -3322,31 +3322,31 @@
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   i32.store $0
-  local.get $0
+  local.get $a
   call $~lib/arraybuffer/ArrayBuffer#get:byteLength
-  local.set $2
-  local.get $1
+  local.set $aByteLength
+  local.get $b
   call $~lib/arraybuffer/ArrayBuffer#get:byteLength
-  local.set $3
+  local.set $bByteLength
   global.get $~lib/memory/__stack_pointer
   i32.const 0
-  local.get $2
-  local.get $3
+  local.get $aByteLength
+  local.get $bByteLength
   i32.add
   call $~lib/arraybuffer/ArrayBuffer#constructor
-  local.tee $4
+  local.tee $out
   i32.store $0
-  local.get $4
-  local.get $0
-  local.get $2
+  local.get $out
+  local.get $a
+  local.get $aByteLength
   memory.copy $0 $0
-  local.get $4
-  local.get $2
+  local.get $out
+  local.get $aByteLength
   i32.add
-  local.get $1
-  local.get $3
+  local.get $b
+  local.get $bByteLength
   memory.copy $0 $0
-  local.get $4
+  local.get $out
   local.set $5
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -3354,11 +3354,11 @@
   global.set $~lib/memory/__stack_pointer
   local.get $5
  )
- (func $~lib/string/String#concat (param $0 i32) (param $1 i32) (result i32)
-  (local $2 i32)
-  (local $3 i32)
-  (local $4 i32)
-  (local $5 i32)
+ (func $~lib/string/String#concat (param $this i32) (param $other i32) (result i32)
+  (local $thisSize i32)
+  (local $otherSize i32)
+  (local $outSize i32)
+  (local $out i32)
   (local $6 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -3368,21 +3368,21 @@
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   i32.store $0
-  local.get $0
+  local.get $this
   call $~lib/string/String#get:length
   i32.const 1
   i32.shl
-  local.set $2
-  local.get $1
+  local.set $thisSize
+  local.get $other
   call $~lib/string/String#get:length
   i32.const 1
   i32.shl
-  local.set $3
-  local.get $2
-  local.get $3
+  local.set $otherSize
+  local.get $thisSize
+  local.get $otherSize
   i32.add
-  local.set $4
-  local.get $4
+  local.set $outSize
+  local.get $outSize
   i32.const 0
   i32.eq
   if
@@ -3396,22 +3396,22 @@
    return
   end
   global.get $~lib/memory/__stack_pointer
-  local.get $4
+  local.get $outSize
   i32.const 1
   call $~lib/rt/itcms/__new
-  local.tee $5
+  local.tee $out
   i32.store $0
-  local.get $5
-  local.get $0
-  local.get $2
+  local.get $out
+  local.get $this
+  local.get $thisSize
   memory.copy $0 $0
-  local.get $5
-  local.get $2
+  local.get $out
+  local.get $thisSize
   i32.add
-  local.get $1
-  local.get $3
+  local.get $other
+  local.get $otherSize
   memory.copy $0 $0
-  local.get $5
+  local.get $out
   local.set $6
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -3419,7 +3419,7 @@
   global.set $~lib/memory/__stack_pointer
   local.get $6
  )
- (func $bindings/esm/stringFunctionOptional@varargs (param $0 i32) (param $1 i32) (result i32)
+ (func $bindings/esm/stringFunctionOptional@varargs (param $a i32) (param $b i32) (result i32)
   (local $2 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -3441,11 +3441,11 @@
    end
    global.get $~lib/memory/__stack_pointer
    i32.const 64
-   local.tee $1
+   local.tee $b
    i32.store $0
   end
-  local.get $0
-  local.get $1
+  local.get $a
+  local.get $b
   call $bindings/esm/stringFunctionOptional
   local.set $2
   global.get $~lib/memory/__stack_pointer
@@ -3454,8 +3454,8 @@
   global.set $~lib/memory/__stack_pointer
   local.get $2
  )
- (func $~lib/arraybuffer/ArrayBufferView#constructor (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
-  (local $3 i32)
+ (func $~lib/arraybuffer/ArrayBufferView#constructor (param $this i32) (param $length i32) (param $alignLog2 i32) (result i32)
+  (local $buffer i32)
   (local $4 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 8
@@ -3465,28 +3465,28 @@
   global.get $~lib/memory/__stack_pointer
   i64.const 0
   i64.store $0
-  local.get $0
+  local.get $this
   i32.eqz
   if
    global.get $~lib/memory/__stack_pointer
    i32.const 12
    i32.const 2
    call $~lib/rt/itcms/__new
-   local.tee $0
+   local.tee $this
    i32.store $0
   end
-  local.get $0
+  local.get $this
   i32.const 0
   call $~lib/arraybuffer/ArrayBufferView#set:buffer
-  local.get $0
+  local.get $this
   i32.const 0
   call $~lib/arraybuffer/ArrayBufferView#set:dataStart
-  local.get $0
+  local.get $this
   i32.const 0
   call $~lib/arraybuffer/ArrayBufferView#set:byteLength
-  local.get $1
+  local.get $length
   i32.const 1073741820
-  local.get $2
+  local.get $alignLog2
   i32.shr_u
   i32.gt_u
   if
@@ -3498,28 +3498,28 @@
    unreachable
   end
   global.get $~lib/memory/__stack_pointer
-  local.get $1
-  local.get $2
+  local.get $length
+  local.get $alignLog2
   i32.shl
-  local.tee $1
+  local.tee $length
   i32.const 0
   call $~lib/rt/itcms/__new
-  local.tee $3
+  local.tee $buffer
   i32.store $0 offset=4
   i32.const 2
   global.get $~lib/shared/runtime/Runtime.Incremental
   i32.ne
   drop
-  local.get $0
-  local.get $3
+  local.get $this
+  local.get $buffer
   call $~lib/arraybuffer/ArrayBufferView#set:buffer
-  local.get $0
-  local.get $3
+  local.get $this
+  local.get $buffer
   call $~lib/arraybuffer/ArrayBufferView#set:dataStart
-  local.get $0
-  local.get $1
+  local.get $this
+  local.get $length
   call $~lib/arraybuffer/ArrayBufferView#set:byteLength
-  local.get $0
+  local.get $this
   local.set $4
   global.get $~lib/memory/__stack_pointer
   i32.const 8
@@ -3527,7 +3527,7 @@
   global.set $~lib/memory/__stack_pointer
   local.get $4
  )
- (func $~lib/typedarray/Uint64Array#constructor (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/typedarray/Uint64Array#constructor (param $this i32) (param $length i32) (result i32)
   (local $2 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -3537,24 +3537,24 @@
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   i32.store $0
-  local.get $0
+  local.get $this
   i32.eqz
   if
    global.get $~lib/memory/__stack_pointer
    i32.const 12
    i32.const 6
    call $~lib/rt/itcms/__new
-   local.tee $0
+   local.tee $this
    i32.store $0
   end
   global.get $~lib/memory/__stack_pointer
-  local.get $0
-  local.get $1
+  local.get $this
+  local.get $length
   i32.const 3
   call $~lib/arraybuffer/ArrayBufferView#constructor
-  local.tee $0
+  local.tee $this
   i32.store $0
-  local.get $0
+  local.get $this
   local.set $2
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -3562,10 +3562,10 @@
   global.set $~lib/memory/__stack_pointer
   local.get $2
  )
- (func $bindings/esm/typedarrayFunction (param $0 i32) (param $1 i32) (result i32)
-  (local $2 i32)
-  (local $3 i32)
-  (local $4 i32)
+ (func $bindings/esm/typedarrayFunction (param $a i32) (param $b i32) (result i32)
+  (local $out i32)
+  (local $var$3 i32)
+  (local $var$4 i32)
   (local $5 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -3577,66 +3577,66 @@
   i32.store $0
   global.get $~lib/memory/__stack_pointer
   i32.const 0
-  local.get $0
+  local.get $a
   call $~lib/typedarray/Int16Array#get:length
-  local.get $1
+  local.get $b
   call $~lib/typedarray/Float32Array#get:length
   i32.add
   call $~lib/typedarray/Uint64Array#constructor
-  local.tee $2
+  local.tee $out
   i32.store $0
   i32.const 0
-  local.set $3
+  local.set $var$3
   loop $for-loop|0
-   local.get $3
-   local.get $0
+   local.get $var$3
+   local.get $a
    call $~lib/typedarray/Int16Array#get:length
    i32.lt_s
-   local.set $4
-   local.get $4
+   local.set $var$4
+   local.get $var$4
    if
-    local.get $2
-    local.get $3
-    local.get $0
-    local.get $3
+    local.get $out
+    local.get $var$3
+    local.get $a
+    local.get $var$3
     call $~lib/typedarray/Int16Array#__get
     i64.extend_i32_s
     call $~lib/typedarray/Uint64Array#__set
-    local.get $3
+    local.get $var$3
     i32.const 1
     i32.add
-    local.set $3
+    local.set $var$3
     br $for-loop|0
    end
   end
   i32.const 0
-  local.set $3
+  local.set $var$3
   loop $for-loop|1
-   local.get $3
-   local.get $1
+   local.get $var$3
+   local.get $b
    call $~lib/typedarray/Float32Array#get:length
    i32.lt_s
-   local.set $4
-   local.get $4
+   local.set $var$4
+   local.get $var$4
    if
-    local.get $2
-    local.get $0
+    local.get $out
+    local.get $a
     call $~lib/typedarray/Int16Array#get:length
-    local.get $3
+    local.get $var$3
     i32.add
-    local.get $1
-    local.get $3
+    local.get $b
+    local.get $var$3
     call $~lib/typedarray/Float32Array#__get
     i64.trunc_sat_f32_u
     call $~lib/typedarray/Uint64Array#__set
-    local.get $3
+    local.get $var$3
     i32.const 1
     i32.add
-    local.set $3
+    local.set $var$3
     br $for-loop|1
    end
   end
-  local.get $2
+  local.get $out
   local.set $5
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -3644,9 +3644,9 @@
   global.set $~lib/memory/__stack_pointer
   local.get $5
  )
- (func $~lib/staticarray/StaticArray<i32>#constructor (param $0 i32) (param $1 i32) (result i32)
-  (local $2 i32)
-  (local $3 i32)
+ (func $~lib/staticarray/StaticArray<i32>#constructor (param $this i32) (param $length i32) (result i32)
+  (local $outSize i32)
+  (local $out i32)
   (local $4 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -3656,7 +3656,7 @@
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   i32.store $0
-  local.get $1
+  local.get $length
   i32.const 1073741820
   i32.const 2
   i32.shr_u
@@ -3669,21 +3669,21 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $1
+  local.get $length
   i32.const 2
   i32.shl
-  local.set $2
+  local.set $outSize
   global.get $~lib/memory/__stack_pointer
-  local.get $2
+  local.get $outSize
   i32.const 7
   call $~lib/rt/itcms/__new
-  local.tee $3
+  local.tee $out
   i32.store $0
   i32.const 2
   global.get $~lib/shared/runtime/Runtime.Incremental
   i32.ne
   drop
-  local.get $3
+  local.get $out
   local.set $4
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -3691,10 +3691,10 @@
   global.set $~lib/memory/__stack_pointer
   local.get $4
  )
- (func $bindings/esm/staticarrayFunction (param $0 i32) (param $1 i32) (result i32)
-  (local $2 i32)
-  (local $3 i32)
-  (local $4 i32)
+ (func $bindings/esm/staticarrayFunction (param $a i32) (param $b i32) (result i32)
+  (local $c i32)
+  (local $var$3 i32)
+  (local $var$4 i32)
   (local $5 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -3706,64 +3706,64 @@
   i32.store $0
   global.get $~lib/memory/__stack_pointer
   i32.const 0
-  local.get $0
+  local.get $a
   call $~lib/staticarray/StaticArray<i32>#get:length
-  local.get $1
+  local.get $b
   call $~lib/staticarray/StaticArray<i32>#get:length
   i32.add
   call $~lib/staticarray/StaticArray<i32>#constructor
-  local.tee $2
+  local.tee $c
   i32.store $0
   i32.const 0
-  local.set $3
+  local.set $var$3
   loop $for-loop|0
-   local.get $3
-   local.get $0
+   local.get $var$3
+   local.get $a
    call $~lib/staticarray/StaticArray<i32>#get:length
    i32.lt_s
-   local.set $4
-   local.get $4
+   local.set $var$4
+   local.get $var$4
    if
-    local.get $2
-    local.get $3
-    local.get $0
-    local.get $3
+    local.get $c
+    local.get $var$3
+    local.get $a
+    local.get $var$3
     call $~lib/staticarray/StaticArray<i32>#__get
     call $~lib/staticarray/StaticArray<i32>#__set
-    local.get $3
+    local.get $var$3
     i32.const 1
     i32.add
-    local.set $3
+    local.set $var$3
     br $for-loop|0
    end
   end
   i32.const 0
-  local.set $3
+  local.set $var$3
   loop $for-loop|1
-   local.get $3
-   local.get $1
+   local.get $var$3
+   local.get $b
    call $~lib/staticarray/StaticArray<i32>#get:length
    i32.lt_s
-   local.set $4
-   local.get $4
+   local.set $var$4
+   local.get $var$4
    if
-    local.get $2
-    local.get $0
+    local.get $c
+    local.get $a
     call $~lib/staticarray/StaticArray<i32>#get:length
-    local.get $3
+    local.get $var$3
     i32.add
-    local.get $1
-    local.get $3
+    local.get $b
+    local.get $var$3
     call $~lib/staticarray/StaticArray<i32>#__get
     call $~lib/staticarray/StaticArray<i32>#__set
-    local.get $3
+    local.get $var$3
     i32.const 1
     i32.add
-    local.set $3
+    local.set $var$3
     br $for-loop|1
    end
   end
-  local.get $2
+  local.get $c
   local.set $5
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -3771,11 +3771,11 @@
   global.set $~lib/memory/__stack_pointer
   local.get $5
  )
- (func $~lib/array/Array<i32>#constructor (param $0 i32) (param $1 i32) (result i32)
-  (local $2 i32)
-  (local $3 i32)
-  (local $4 i32)
-  (local $5 i32)
+ (func $~lib/array/Array<i32>#constructor (param $this i32) (param $length i32) (result i32)
+  (local $var$2 i32)
+  (local $var$3 i32)
+  (local $bufferSize i32)
+  (local $buffer i32)
   (local $6 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 8
@@ -3785,29 +3785,29 @@
   global.get $~lib/memory/__stack_pointer
   i64.const 0
   i64.store $0
-  local.get $0
+  local.get $this
   i32.eqz
   if
    global.get $~lib/memory/__stack_pointer
    i32.const 16
    i32.const 10
    call $~lib/rt/itcms/__new
-   local.tee $0
+   local.tee $this
    i32.store $0
   end
-  local.get $0
+  local.get $this
   i32.const 0
   call $~lib/array/Array<i32>#set:buffer
-  local.get $0
+  local.get $this
   i32.const 0
   call $~lib/array/Array<i32>#set:dataStart
-  local.get $0
+  local.get $this
   i32.const 0
   call $~lib/array/Array<i32>#set:byteLength
-  local.get $0
+  local.get $this
   i32.const 0
   call $~lib/array/Array<i32>#set:length_
-  local.get $1
+  local.get $length
   i32.const 1073741820
   i32.const 2
   i32.shr_u
@@ -3820,40 +3820,40 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $1
-  local.tee $2
+  local.get $length
+  local.tee $var$2
   i32.const 8
-  local.tee $3
-  local.get $2
-  local.get $3
+  local.tee $var$3
+  local.get $var$2
+  local.get $var$3
   i32.gt_u
   select
   i32.const 2
   i32.shl
-  local.set $4
+  local.set $bufferSize
   global.get $~lib/memory/__stack_pointer
-  local.get $4
+  local.get $bufferSize
   i32.const 0
   call $~lib/rt/itcms/__new
-  local.tee $5
+  local.tee $buffer
   i32.store $0 offset=4
   i32.const 2
   global.get $~lib/shared/runtime/Runtime.Incremental
   i32.ne
   drop
-  local.get $0
-  local.get $5
+  local.get $this
+  local.get $buffer
   call $~lib/array/Array<i32>#set:buffer
-  local.get $0
-  local.get $5
+  local.get $this
+  local.get $buffer
   call $~lib/array/Array<i32>#set:dataStart
-  local.get $0
-  local.get $4
+  local.get $this
+  local.get $bufferSize
   call $~lib/array/Array<i32>#set:byteLength
-  local.get $0
-  local.get $1
+  local.get $this
+  local.get $length
   call $~lib/array/Array<i32>#set:length_
-  local.get $0
+  local.get $this
   local.set $6
   global.get $~lib/memory/__stack_pointer
   i32.const 8
@@ -3861,10 +3861,10 @@
   global.set $~lib/memory/__stack_pointer
   local.get $6
  )
- (func $bindings/esm/arrayFunction (param $0 i32) (param $1 i32) (result i32)
-  (local $2 i32)
-  (local $3 i32)
-  (local $4 i32)
+ (func $bindings/esm/arrayFunction (param $a i32) (param $b i32) (result i32)
+  (local $c i32)
+  (local $var$3 i32)
+  (local $var$4 i32)
   (local $5 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -3876,64 +3876,64 @@
   i32.store $0
   global.get $~lib/memory/__stack_pointer
   i32.const 0
-  local.get $0
+  local.get $a
   call $~lib/array/Array<i32>#get:length
-  local.get $1
+  local.get $b
   call $~lib/array/Array<i32>#get:length
   i32.add
   call $~lib/array/Array<i32>#constructor
-  local.tee $2
+  local.tee $c
   i32.store $0
   i32.const 0
-  local.set $3
+  local.set $var$3
   loop $for-loop|0
-   local.get $3
-   local.get $0
+   local.get $var$3
+   local.get $a
    call $~lib/array/Array<i32>#get:length
    i32.lt_s
-   local.set $4
-   local.get $4
+   local.set $var$4
+   local.get $var$4
    if
-    local.get $2
-    local.get $3
-    local.get $0
-    local.get $3
+    local.get $c
+    local.get $var$3
+    local.get $a
+    local.get $var$3
     call $~lib/array/Array<i32>#__get
     call $~lib/array/Array<i32>#__set
-    local.get $3
+    local.get $var$3
     i32.const 1
     i32.add
-    local.set $3
+    local.set $var$3
     br $for-loop|0
    end
   end
   i32.const 0
-  local.set $3
+  local.set $var$3
   loop $for-loop|1
-   local.get $3
-   local.get $1
+   local.get $var$3
+   local.get $b
    call $~lib/array/Array<i32>#get:length
    i32.lt_s
-   local.set $4
-   local.get $4
+   local.set $var$4
+   local.get $var$4
    if
-    local.get $2
-    local.get $0
+    local.get $c
+    local.get $a
     call $~lib/array/Array<i32>#get:length
-    local.get $3
+    local.get $var$3
     i32.add
-    local.get $1
-    local.get $3
+    local.get $b
+    local.get $var$3
     call $~lib/array/Array<i32>#__get
     call $~lib/array/Array<i32>#__set
-    local.get $3
+    local.get $var$3
     i32.const 1
     i32.add
-    local.set $3
+    local.set $var$3
     br $for-loop|1
    end
   end
-  local.get $2
+  local.get $c
   local.set $5
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -3941,7 +3941,7 @@
   global.set $~lib/memory/__stack_pointer
   local.get $5
  )
- (func $bindings/esm/PlainObject#constructor (param $0 i32) (result i32)
+ (func $bindings/esm/PlainObject#constructor (param $this i32) (result i32)
   (local $1 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -3951,65 +3951,65 @@
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   i32.store $0
-  local.get $0
+  local.get $this
   i32.eqz
   if
    global.get $~lib/memory/__stack_pointer
    i32.const 68
    i32.const 11
    call $~lib/rt/itcms/__new
-   local.tee $0
+   local.tee $this
    i32.store $0
   end
-  local.get $0
+  local.get $this
   i32.const 0
   call $bindings/esm/PlainObject#set:a
-  local.get $0
+  local.get $this
   i32.const 0
   call $bindings/esm/PlainObject#set:b
-  local.get $0
+  local.get $this
   i32.const 0
   call $bindings/esm/PlainObject#set:c
-  local.get $0
+  local.get $this
   i64.const 0
   call $bindings/esm/PlainObject#set:d
-  local.get $0
+  local.get $this
   i32.const 0
   call $bindings/esm/PlainObject#set:e
-  local.get $0
+  local.get $this
   i32.const 0
   call $bindings/esm/PlainObject#set:f
-  local.get $0
+  local.get $this
   i32.const 0
   call $bindings/esm/PlainObject#set:g
-  local.get $0
+  local.get $this
   i64.const 0
   call $bindings/esm/PlainObject#set:h
-  local.get $0
+  local.get $this
   i32.const 0
   call $bindings/esm/PlainObject#set:i
-  local.get $0
+  local.get $this
   i32.const 0
   call $bindings/esm/PlainObject#set:j
-  local.get $0
+  local.get $this
   i32.const 0
   call $bindings/esm/PlainObject#set:k
-  local.get $0
+  local.get $this
   f32.const 0
   call $bindings/esm/PlainObject#set:l
-  local.get $0
+  local.get $this
   f64.const 0
   call $bindings/esm/PlainObject#set:m
-  local.get $0
+  local.get $this
   i32.const 0
   call $bindings/esm/PlainObject#set:n
-  local.get $0
+  local.get $this
   i32.const 0
   call $bindings/esm/PlainObject#set:o
-  local.get $0
+  local.get $this
   i32.const 0
   call $bindings/esm/PlainObject#set:p
-  local.get $0
+  local.get $this
   local.set $1
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -4017,8 +4017,8 @@
   global.set $~lib/memory/__stack_pointer
   local.get $1
  )
- (func $bindings/esm/objectFunction (param $0 i32) (param $1 i32) (result i32)
-  (local $2 i32)
+ (func $bindings/esm/objectFunction (param $a i32) (param $b i32) (result i32)
+  (local $var$2 i32)
   (local $3 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -4031,23 +4031,23 @@
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   call $bindings/esm/PlainObject#constructor
-  local.tee $2
+  local.tee $var$2
   i32.store $0
-  local.get $2
-  local.get $0
+  local.get $var$2
+  local.get $a
   i32.load8_s $0
-  local.get $1
+  local.get $b
   i32.load8_s $0
   i32.add
   call $bindings/esm/PlainObject#set:a
-  local.get $2
-  local.get $0
+  local.get $var$2
+  local.get $a
   i32.load16_s $0 offset=2
-  local.get $1
+  local.get $b
   i32.load16_s $0 offset=2
   i32.add
   call $bindings/esm/PlainObject#set:b
-  local.get $2
+  local.get $var$2
   local.set $3
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -4055,7 +4055,7 @@
   global.set $~lib/memory/__stack_pointer
   local.get $3
  )
- (func $bindings/esm/NonPlainObject#constructor (param $0 i32) (result i32)
+ (func $bindings/esm/NonPlainObject#constructor (param $this i32) (result i32)
   (local $1 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -4065,17 +4065,17 @@
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   i32.store $0
-  local.get $0
+  local.get $this
   i32.eqz
   if
    global.get $~lib/memory/__stack_pointer
    i32.const 0
    i32.const 14
    call $~lib/rt/itcms/__new
-   local.tee $0
+   local.tee $this
    i32.store $0
   end
-  local.get $0
+  local.get $this
   local.set $1
   global.get $~lib/memory/__stack_pointer
   i32.const 4

--- a/tests/compiler/call-super.debug.wat
+++ b/tests/compiler/call-super.debug.wat
@@ -2506,7 +2506,7 @@
    unreachable
   end
  )
- (func $call-super/A#constructor (param $0 i32) (result i32)
+ (func $call-super/A#constructor (param $this i32) (result i32)
   (local $1 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -2516,20 +2516,20 @@
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   i32.store $0
-  local.get $0
+  local.get $this
   i32.eqz
   if
    global.get $~lib/memory/__stack_pointer
    i32.const 4
    i32.const 4
    call $~lib/rt/itcms/__new
-   local.tee $0
+   local.tee $this
    i32.store $0
   end
-  local.get $0
+  local.get $this
   i32.const 1
   call $call-super/A#set:a
-  local.get $0
+  local.get $this
   i32.load $0
   i32.const 1
   i32.eq
@@ -2542,7 +2542,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $0
+  local.get $this
   local.set $1
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -2550,7 +2550,7 @@
   global.set $~lib/memory/__stack_pointer
   local.get $1
  )
- (func $call-super/B#constructor (param $0 i32) (result i32)
+ (func $call-super/B#constructor (param $this i32) (result i32)
   (local $1 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -2560,25 +2560,25 @@
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   i32.store $0
-  local.get $0
+  local.get $this
   i32.eqz
   if
    global.get $~lib/memory/__stack_pointer
    i32.const 8
    i32.const 3
    call $~lib/rt/itcms/__new
-   local.tee $0
+   local.tee $this
    i32.store $0
   end
-  local.get $0
+  local.get $this
   i32.const 2
   call $call-super/B#set:b
   global.get $~lib/memory/__stack_pointer
-  local.get $0
+  local.get $this
   call $call-super/A#constructor
-  local.tee $0
+  local.tee $this
   i32.store $0
-  local.get $0
+  local.get $this
   i32.load $0
   i32.const 1
   i32.eq
@@ -2591,7 +2591,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $0
+  local.get $this
   i32.load $0 offset=4
   i32.const 2
   i32.eq
@@ -2604,7 +2604,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $0
+  local.get $this
   local.set $1
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -2612,7 +2612,7 @@
   global.set $~lib/memory/__stack_pointer
   local.get $1
  )
- (func $call-super/C#constructor (param $0 i32) (result i32)
+ (func $call-super/C#constructor (param $this i32) (result i32)
   (local $1 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -2622,20 +2622,20 @@
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   i32.store $0
-  local.get $0
+  local.get $this
   i32.eqz
   if
    global.get $~lib/memory/__stack_pointer
    i32.const 4
    i32.const 6
    call $~lib/rt/itcms/__new
-   local.tee $0
+   local.tee $this
    i32.store $0
   end
-  local.get $0
+  local.get $this
   i32.const 1
   call $call-super/C#set:a
-  local.get $0
+  local.get $this
   local.set $1
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -2643,7 +2643,7 @@
   global.set $~lib/memory/__stack_pointer
   local.get $1
  )
- (func $call-super/D#constructor (param $0 i32) (result i32)
+ (func $call-super/D#constructor (param $this i32) (result i32)
   (local $1 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -2653,25 +2653,25 @@
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   i32.store $0
-  local.get $0
+  local.get $this
   i32.eqz
   if
    global.get $~lib/memory/__stack_pointer
    i32.const 8
    i32.const 5
    call $~lib/rt/itcms/__new
-   local.tee $0
+   local.tee $this
    i32.store $0
   end
-  local.get $0
+  local.get $this
   i32.const 2
   call $call-super/D#set:b
   global.get $~lib/memory/__stack_pointer
-  local.get $0
+  local.get $this
   call $call-super/C#constructor
-  local.tee $0
+  local.tee $this
   i32.store $0
-  local.get $0
+  local.get $this
   i32.load $0
   i32.const 1
   i32.eq
@@ -2684,7 +2684,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $0
+  local.get $this
   i32.load $0 offset=4
   i32.const 2
   i32.eq
@@ -2697,7 +2697,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $0
+  local.get $this
   local.set $1
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -2705,7 +2705,7 @@
   global.set $~lib/memory/__stack_pointer
   local.get $1
  )
- (func $call-super/E#constructor (param $0 i32) (result i32)
+ (func $call-super/E#constructor (param $this i32) (result i32)
   (local $1 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -2715,20 +2715,20 @@
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   i32.store $0
-  local.get $0
+  local.get $this
   i32.eqz
   if
    global.get $~lib/memory/__stack_pointer
    i32.const 4
    i32.const 8
    call $~lib/rt/itcms/__new
-   local.tee $0
+   local.tee $this
    i32.store $0
   end
-  local.get $0
+  local.get $this
   i32.const 1
   call $call-super/E#set:a
-  local.get $0
+  local.get $this
   i32.load $0
   i32.const 1
   i32.eq
@@ -2741,7 +2741,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $0
+  local.get $this
   local.set $1
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -2749,7 +2749,7 @@
   global.set $~lib/memory/__stack_pointer
   local.get $1
  )
- (func $call-super/F#constructor (param $0 i32) (result i32)
+ (func $call-super/F#constructor (param $this i32) (result i32)
   (local $1 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -2759,25 +2759,25 @@
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   i32.store $0
-  local.get $0
+  local.get $this
   i32.eqz
   if
    global.get $~lib/memory/__stack_pointer
    i32.const 8
    i32.const 7
    call $~lib/rt/itcms/__new
-   local.tee $0
+   local.tee $this
    i32.store $0
   end
   global.get $~lib/memory/__stack_pointer
-  local.get $0
+  local.get $this
   call $call-super/E#constructor
-  local.tee $0
+  local.tee $this
   i32.store $0
-  local.get $0
+  local.get $this
   i32.const 2
   call $call-super/F#set:b
-  local.get $0
+  local.get $this
   local.set $1
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -2785,7 +2785,7 @@
   global.set $~lib/memory/__stack_pointer
   local.get $1
  )
- (func $call-super/G#constructor (param $0 i32) (result i32)
+ (func $call-super/G#constructor (param $this i32) (result i32)
   (local $1 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -2795,20 +2795,20 @@
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   i32.store $0
-  local.get $0
+  local.get $this
   i32.eqz
   if
    global.get $~lib/memory/__stack_pointer
    i32.const 4
    i32.const 10
    call $~lib/rt/itcms/__new
-   local.tee $0
+   local.tee $this
    i32.store $0
   end
-  local.get $0
+  local.get $this
   i32.const 1
   call $call-super/G#set:a
-  local.get $0
+  local.get $this
   local.set $1
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -2816,7 +2816,7 @@
   global.set $~lib/memory/__stack_pointer
   local.get $1
  )
- (func $call-super/H#constructor (param $0 i32) (result i32)
+ (func $call-super/H#constructor (param $this i32) (result i32)
   (local $1 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -2826,25 +2826,25 @@
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   i32.store $0
-  local.get $0
+  local.get $this
   i32.eqz
   if
    global.get $~lib/memory/__stack_pointer
    i32.const 8
    i32.const 9
    call $~lib/rt/itcms/__new
-   local.tee $0
+   local.tee $this
    i32.store $0
   end
   global.get $~lib/memory/__stack_pointer
-  local.get $0
+  local.get $this
   call $call-super/G#constructor
-  local.tee $0
+  local.tee $this
   i32.store $0
-  local.get $0
+  local.get $this
   i32.const 2
   call $call-super/H#set:b
-  local.get $0
+  local.get $this
   local.set $1
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -2852,7 +2852,7 @@
   global.set $~lib/memory/__stack_pointer
   local.get $1
  )
- (func $call-super/I#constructor (param $0 i32) (result i32)
+ (func $call-super/I#constructor (param $this i32) (result i32)
   (local $1 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -2862,20 +2862,20 @@
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   i32.store $0
-  local.get $0
+  local.get $this
   i32.eqz
   if
    global.get $~lib/memory/__stack_pointer
    i32.const 4
    i32.const 12
    call $~lib/rt/itcms/__new
-   local.tee $0
+   local.tee $this
    i32.store $0
   end
-  local.get $0
+  local.get $this
   i32.const 1
   call $call-super/I#set:a
-  local.get $0
+  local.get $this
   local.set $1
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -2883,7 +2883,7 @@
   global.set $~lib/memory/__stack_pointer
   local.get $1
  )
- (func $call-super/J#constructor (param $0 i32) (result i32)
+ (func $call-super/J#constructor (param $this i32) (result i32)
   (local $1 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -2893,25 +2893,25 @@
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   i32.store $0
-  local.get $0
+  local.get $this
   i32.eqz
   if
    global.get $~lib/memory/__stack_pointer
    i32.const 8
    i32.const 11
    call $~lib/rt/itcms/__new
-   local.tee $0
+   local.tee $this
    i32.store $0
   end
   global.get $~lib/memory/__stack_pointer
-  local.get $0
+  local.get $this
   call $call-super/I#constructor
-  local.tee $0
+  local.tee $this
   i32.store $0
-  local.get $0
+  local.get $this
   i32.const 2
   call $call-super/J#set:b
-  local.get $0
+  local.get $this
   local.set $1
   global.get $~lib/memory/__stack_pointer
   i32.const 4

--- a/tests/compiler/class-implements.debug.wat
+++ b/tests/compiler/class-implements.debug.wat
@@ -2280,7 +2280,7 @@
   i32.add
   global.set $~lib/memory/__stack_pointer
  )
- (func $class-implements/A#constructor (param $0 i32) (result i32)
+ (func $class-implements/A#constructor (param $this i32) (result i32)
   (local $1 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -2290,17 +2290,17 @@
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   i32.store $0
-  local.get $0
+  local.get $this
   i32.eqz
   if
    global.get $~lib/memory/__stack_pointer
    i32.const 0
    i32.const 3
    call $~lib/rt/itcms/__new
-   local.tee $0
+   local.tee $this
    i32.store $0
   end
-  local.get $0
+  local.get $this
   local.set $1
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -2308,7 +2308,7 @@
   global.set $~lib/memory/__stack_pointer
   local.get $1
  )
- (func $class-implements/B#constructor (param $0 i32) (result i32)
+ (func $class-implements/B#constructor (param $this i32) (result i32)
   (local $1 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -2318,17 +2318,17 @@
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   i32.store $0
-  local.get $0
+  local.get $this
   i32.eqz
   if
    global.get $~lib/memory/__stack_pointer
    i32.const 0
    i32.const 6
    call $~lib/rt/itcms/__new
-   local.tee $0
+   local.tee $this
    i32.store $0
   end
-  local.get $0
+  local.get $this
   local.set $1
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -2336,7 +2336,7 @@
   global.set $~lib/memory/__stack_pointer
   local.get $1
  )
- (func $class-implements/C#constructor (param $0 i32) (result i32)
+ (func $class-implements/C#constructor (param $this i32) (result i32)
   (local $1 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -2346,22 +2346,22 @@
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   i32.store $0
-  local.get $0
+  local.get $this
   i32.eqz
   if
    global.get $~lib/memory/__stack_pointer
    i32.const 0
    i32.const 5
    call $~lib/rt/itcms/__new
-   local.tee $0
+   local.tee $this
    i32.store $0
   end
   global.get $~lib/memory/__stack_pointer
-  local.get $0
+  local.get $this
   call $class-implements/B#constructor
-  local.tee $0
+  local.tee $this
   i32.store $0
-  local.get $0
+  local.get $this
   local.set $1
   global.get $~lib/memory/__stack_pointer
   i32.const 4

--- a/tests/compiler/class-overloading-cast.debug.wat
+++ b/tests/compiler/class-overloading-cast.debug.wat
@@ -2682,7 +2682,7 @@
   i32.add
   global.set $~lib/memory/__stack_pointer
  )
- (func $class-overloading-cast/A<i32>#constructor (param $0 i32) (result i32)
+ (func $class-overloading-cast/A<i32>#constructor (param $this i32) (result i32)
   (local $1 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -2692,17 +2692,17 @@
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   i32.store $0
-  local.get $0
+  local.get $this
   i32.eqz
   if
    global.get $~lib/memory/__stack_pointer
    i32.const 0
    i32.const 4
    call $~lib/rt/itcms/__new
-   local.tee $0
+   local.tee $this
    i32.store $0
   end
-  local.get $0
+  local.get $this
   local.set $1
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -2710,7 +2710,7 @@
   global.set $~lib/memory/__stack_pointer
   local.get $1
  )
- (func $class-overloading-cast/B<i32,f64>#constructor (param $0 i32) (result i32)
+ (func $class-overloading-cast/B<i32,f64>#constructor (param $this i32) (result i32)
   (local $1 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -2720,22 +2720,22 @@
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   i32.store $0
-  local.get $0
+  local.get $this
   i32.eqz
   if
    global.get $~lib/memory/__stack_pointer
    i32.const 0
    i32.const 3
    call $~lib/rt/itcms/__new
-   local.tee $0
+   local.tee $this
    i32.store $0
   end
   global.get $~lib/memory/__stack_pointer
-  local.get $0
+  local.get $this
   call $class-overloading-cast/A<i32>#constructor
-  local.tee $0
+  local.tee $this
   i32.store $0
-  local.get $0
+  local.get $this
   local.set $1
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -2743,7 +2743,7 @@
   global.set $~lib/memory/__stack_pointer
   local.get $1
  )
- (func $class-overloading-cast/B<i32,~lib/string/String>#constructor (param $0 i32) (result i32)
+ (func $class-overloading-cast/B<i32,~lib/string/String>#constructor (param $this i32) (result i32)
   (local $1 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -2753,22 +2753,22 @@
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   i32.store $0
-  local.get $0
+  local.get $this
   i32.eqz
   if
    global.get $~lib/memory/__stack_pointer
    i32.const 0
    i32.const 5
    call $~lib/rt/itcms/__new
-   local.tee $0
+   local.tee $this
    i32.store $0
   end
   global.get $~lib/memory/__stack_pointer
-  local.get $0
+  local.get $this
   call $class-overloading-cast/A<i32>#constructor
-  local.tee $0
+  local.tee $this
   i32.store $0
-  local.get $0
+  local.get $this
   local.set $1
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -2776,7 +2776,7 @@
   global.set $~lib/memory/__stack_pointer
   local.get $1
  )
- (func $class-overloading-cast/A<f64>#constructor (param $0 i32) (result i32)
+ (func $class-overloading-cast/A<f64>#constructor (param $this i32) (result i32)
   (local $1 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -2786,17 +2786,17 @@
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   i32.store $0
-  local.get $0
+  local.get $this
   i32.eqz
   if
    global.get $~lib/memory/__stack_pointer
    i32.const 0
    i32.const 7
    call $~lib/rt/itcms/__new
-   local.tee $0
+   local.tee $this
    i32.store $0
   end
-  local.get $0
+  local.get $this
   local.set $1
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -2804,7 +2804,7 @@
   global.set $~lib/memory/__stack_pointer
   local.get $1
  )
- (func $class-overloading-cast/B<f64,~lib/string/String>#constructor (param $0 i32) (result i32)
+ (func $class-overloading-cast/B<f64,~lib/string/String>#constructor (param $this i32) (result i32)
   (local $1 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -2814,22 +2814,22 @@
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   i32.store $0
-  local.get $0
+  local.get $this
   i32.eqz
   if
    global.get $~lib/memory/__stack_pointer
    i32.const 0
    i32.const 6
    call $~lib/rt/itcms/__new
-   local.tee $0
+   local.tee $this
    i32.store $0
   end
   global.get $~lib/memory/__stack_pointer
-  local.get $0
+  local.get $this
   call $class-overloading-cast/A<f64>#constructor
-  local.tee $0
+  local.tee $this
   i32.store $0
-  local.get $0
+  local.get $this
   local.set $1
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -2837,7 +2837,7 @@
   global.set $~lib/memory/__stack_pointer
   local.get $1
  )
- (func $class-overloading-cast/A<~lib/string/String>#constructor (param $0 i32) (result i32)
+ (func $class-overloading-cast/A<~lib/string/String>#constructor (param $this i32) (result i32)
   (local $1 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -2847,17 +2847,17 @@
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   i32.store $0
-  local.get $0
+  local.get $this
   i32.eqz
   if
    global.get $~lib/memory/__stack_pointer
    i32.const 0
    i32.const 9
    call $~lib/rt/itcms/__new
-   local.tee $0
+   local.tee $this
    i32.store $0
   end
-  local.get $0
+  local.get $this
   local.set $1
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -2865,7 +2865,7 @@
   global.set $~lib/memory/__stack_pointer
   local.get $1
  )
- (func $class-overloading-cast/C#constructor (param $0 i32) (result i32)
+ (func $class-overloading-cast/C#constructor (param $this i32) (result i32)
   (local $1 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -2875,22 +2875,22 @@
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   i32.store $0
-  local.get $0
+  local.get $this
   i32.eqz
   if
    global.get $~lib/memory/__stack_pointer
    i32.const 0
    i32.const 8
    call $~lib/rt/itcms/__new
-   local.tee $0
+   local.tee $this
    i32.store $0
   end
   global.get $~lib/memory/__stack_pointer
-  local.get $0
+  local.get $this
   call $class-overloading-cast/A<~lib/string/String>#constructor
-  local.tee $0
+  local.tee $this
   i32.store $0
-  local.get $0
+  local.get $this
   local.set $1
   global.get $~lib/memory/__stack_pointer
   i32.const 4

--- a/tests/compiler/class-overloading.debug.wat
+++ b/tests/compiler/class-overloading.debug.wat
@@ -2810,7 +2810,7 @@
    unreachable
   end
  )
- (func $class-overloading/C#a<i32> (param $0 i32) (param $1 i32)
+ (func $class-overloading/C#a<i32> (param $this i32) (param $a i32)
   (local $2 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 8
@@ -2820,8 +2820,8 @@
   global.get $~lib/memory/__stack_pointer
   i64.const 0
   i64.store $0
-  local.get $0
-  local.get $1
+  local.get $this
+  local.get $a
   call $class-overloading/B#a<i32>
   global.get $class-overloading/which
   local.set $2
@@ -3620,7 +3620,7 @@
   i32.add
   global.set $~lib/memory/__stack_pointer
  )
- (func $class-overloading/B2#foo (param $0 i32) (result i32)
+ (func $class-overloading/B2#foo (param $this i32) (result i32)
   (local $1 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -3645,7 +3645,7 @@
   global.set $~lib/memory/__stack_pointer
   local.get $1
  )
- (func $class-overloading/A#constructor (param $0 i32) (result i32)
+ (func $class-overloading/A#constructor (param $this i32) (result i32)
   (local $1 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -3655,17 +3655,17 @@
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   i32.store $0
-  local.get $0
+  local.get $this
   i32.eqz
   if
    global.get $~lib/memory/__stack_pointer
    i32.const 0
    i32.const 3
    call $~lib/rt/itcms/__new
-   local.tee $0
+   local.tee $this
    i32.store $0
   end
-  local.get $0
+  local.get $this
   local.set $1
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -3673,7 +3673,7 @@
   global.set $~lib/memory/__stack_pointer
   local.get $1
  )
- (func $class-overloading/B#constructor (param $0 i32) (result i32)
+ (func $class-overloading/B#constructor (param $this i32) (result i32)
   (local $1 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -3683,22 +3683,22 @@
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   i32.store $0
-  local.get $0
+  local.get $this
   i32.eqz
   if
    global.get $~lib/memory/__stack_pointer
    i32.const 0
    i32.const 4
    call $~lib/rt/itcms/__new
-   local.tee $0
+   local.tee $this
    i32.store $0
   end
   global.get $~lib/memory/__stack_pointer
-  local.get $0
+  local.get $this
   call $class-overloading/A#constructor
-  local.tee $0
+  local.tee $this
   i32.store $0
-  local.get $0
+  local.get $this
   local.set $1
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -3706,7 +3706,7 @@
   global.set $~lib/memory/__stack_pointer
   local.get $1
  )
- (func $class-overloading/C#constructor (param $0 i32) (result i32)
+ (func $class-overloading/C#constructor (param $this i32) (result i32)
   (local $1 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -3716,22 +3716,22 @@
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   i32.store $0
-  local.get $0
+  local.get $this
   i32.eqz
   if
    global.get $~lib/memory/__stack_pointer
    i32.const 0
    i32.const 5
    call $~lib/rt/itcms/__new
-   local.tee $0
+   local.tee $this
    i32.store $0
   end
   global.get $~lib/memory/__stack_pointer
-  local.get $0
+  local.get $this
   call $class-overloading/B#constructor
-  local.tee $0
+  local.tee $this
   i32.store $0
-  local.get $0
+  local.get $this
   local.set $1
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -3739,7 +3739,7 @@
   global.set $~lib/memory/__stack_pointer
   local.get $1
  )
- (func $class-overloading/D#constructor (param $0 i32) (result i32)
+ (func $class-overloading/D#constructor (param $this i32) (result i32)
   (local $1 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -3749,22 +3749,22 @@
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   i32.store $0
-  local.get $0
+  local.get $this
   i32.eqz
   if
    global.get $~lib/memory/__stack_pointer
    i32.const 0
    i32.const 6
    call $~lib/rt/itcms/__new
-   local.tee $0
+   local.tee $this
    i32.store $0
   end
   global.get $~lib/memory/__stack_pointer
-  local.get $0
+  local.get $this
   call $class-overloading/B#constructor
-  local.tee $0
+  local.tee $this
   i32.store $0
-  local.get $0
+  local.get $this
   local.set $1
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -3772,7 +3772,7 @@
   global.set $~lib/memory/__stack_pointer
   local.get $1
  )
- (func $class-overloading/E#constructor (param $0 i32) (result i32)
+ (func $class-overloading/E#constructor (param $this i32) (result i32)
   (local $1 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -3782,22 +3782,22 @@
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   i32.store $0
-  local.get $0
+  local.get $this
   i32.eqz
   if
    global.get $~lib/memory/__stack_pointer
    i32.const 0
    i32.const 7
    call $~lib/rt/itcms/__new
-   local.tee $0
+   local.tee $this
    i32.store $0
   end
   global.get $~lib/memory/__stack_pointer
-  local.get $0
+  local.get $this
   call $class-overloading/D#constructor
-  local.tee $0
+  local.tee $this
   i32.store $0
-  local.get $0
+  local.get $this
   local.set $1
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -3805,7 +3805,7 @@
   global.set $~lib/memory/__stack_pointer
   local.get $1
  )
- (func $class-overloading/F#constructor (param $0 i32) (result i32)
+ (func $class-overloading/F#constructor (param $this i32) (result i32)
   (local $1 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -3815,22 +3815,22 @@
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   i32.store $0
-  local.get $0
+  local.get $this
   i32.eqz
   if
    global.get $~lib/memory/__stack_pointer
    i32.const 0
    i32.const 8
    call $~lib/rt/itcms/__new
-   local.tee $0
+   local.tee $this
    i32.store $0
   end
   global.get $~lib/memory/__stack_pointer
-  local.get $0
+  local.get $this
   call $class-overloading/E#constructor
-  local.tee $0
+  local.tee $this
   i32.store $0
-  local.get $0
+  local.get $this
   local.set $1
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -3838,7 +3838,7 @@
   global.set $~lib/memory/__stack_pointer
   local.get $1
  )
- (func $class-overloading/CA#constructor (param $0 i32) (result i32)
+ (func $class-overloading/CA#constructor (param $this i32) (result i32)
   (local $1 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -3848,17 +3848,17 @@
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   i32.store $0
-  local.get $0
+  local.get $this
   i32.eqz
   if
    global.get $~lib/memory/__stack_pointer
    i32.const 0
    i32.const 10
    call $~lib/rt/itcms/__new
-   local.tee $0
+   local.tee $this
    i32.store $0
   end
-  local.get $0
+  local.get $this
   local.set $1
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -3866,7 +3866,7 @@
   global.set $~lib/memory/__stack_pointer
   local.get $1
  )
- (func $class-overloading/CC#constructor (param $0 i32) (result i32)
+ (func $class-overloading/CC#constructor (param $this i32) (result i32)
   (local $1 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -3876,17 +3876,17 @@
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   i32.store $0
-  local.get $0
+  local.get $this
   i32.eqz
   if
    global.get $~lib/memory/__stack_pointer
    i32.const 0
    i32.const 12
    call $~lib/rt/itcms/__new
-   local.tee $0
+   local.tee $this
    i32.store $0
   end
-  local.get $0
+  local.get $this
   local.set $1
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -3894,7 +3894,7 @@
   global.set $~lib/memory/__stack_pointer
   local.get $1
  )
- (func $class-overloading/A2#constructor (param $0 i32) (result i32)
+ (func $class-overloading/A2#constructor (param $this i32) (result i32)
   (local $1 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -3904,17 +3904,17 @@
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   i32.store $0
-  local.get $0
+  local.get $this
   i32.eqz
   if
    global.get $~lib/memory/__stack_pointer
    i32.const 0
    i32.const 13
    call $~lib/rt/itcms/__new
-   local.tee $0
+   local.tee $this
    i32.store $0
   end
-  local.get $0
+  local.get $this
   local.set $1
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -3922,7 +3922,7 @@
   global.set $~lib/memory/__stack_pointer
   local.get $1
  )
- (func $class-overloading/B2#constructor (param $0 i32) (result i32)
+ (func $class-overloading/B2#constructor (param $this i32) (result i32)
   (local $1 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -3932,22 +3932,22 @@
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   i32.store $0
-  local.get $0
+  local.get $this
   i32.eqz
   if
    global.get $~lib/memory/__stack_pointer
    i32.const 0
    i32.const 14
    call $~lib/rt/itcms/__new
-   local.tee $0
+   local.tee $this
    i32.store $0
   end
   global.get $~lib/memory/__stack_pointer
-  local.get $0
+  local.get $this
   call $class-overloading/A2#constructor
-  local.tee $0
+  local.tee $this
   i32.store $0
-  local.get $0
+  local.get $this
   local.set $1
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -3955,7 +3955,7 @@
   global.set $~lib/memory/__stack_pointer
   local.get $1
  )
- (func $class-overloading/A1#constructor (param $0 i32) (result i32)
+ (func $class-overloading/A1#constructor (param $this i32) (result i32)
   (local $1 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -3965,17 +3965,17 @@
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   i32.store $0
-  local.get $0
+  local.get $this
   i32.eqz
   if
    global.get $~lib/memory/__stack_pointer
    i32.const 0
    i32.const 16
    call $~lib/rt/itcms/__new
-   local.tee $0
+   local.tee $this
    i32.store $0
   end
-  local.get $0
+  local.get $this
   local.set $1
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -3983,7 +3983,7 @@
   global.set $~lib/memory/__stack_pointer
   local.get $1
  )
- (func $class-overloading/B1#constructor (param $0 i32) (result i32)
+ (func $class-overloading/B1#constructor (param $this i32) (result i32)
   (local $1 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -3993,22 +3993,22 @@
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   i32.store $0
-  local.get $0
+  local.get $this
   i32.eqz
   if
    global.get $~lib/memory/__stack_pointer
    i32.const 0
    i32.const 15
    call $~lib/rt/itcms/__new
-   local.tee $0
+   local.tee $this
    i32.store $0
   end
   global.get $~lib/memory/__stack_pointer
-  local.get $0
+  local.get $this
   call $class-overloading/A1#constructor
-  local.tee $0
+  local.tee $this
   i32.store $0
-  local.get $0
+  local.get $this
   local.set $1
   global.get $~lib/memory/__stack_pointer
   i32.const 4

--- a/tests/compiler/class.debug.wat
+++ b/tests/compiler/class.debug.wat
@@ -2450,11 +2450,11 @@
    unreachable
   end
  )
- (func $~lib/array/Array<i32>#constructor (param $0 i32) (param $1 i32) (result i32)
-  (local $2 i32)
-  (local $3 i32)
-  (local $4 i32)
-  (local $5 i32)
+ (func $~lib/array/Array<i32>#constructor (param $this i32) (param $length i32) (result i32)
+  (local $var$2 i32)
+  (local $var$3 i32)
+  (local $bufferSize i32)
+  (local $buffer i32)
   (local $6 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 8
@@ -2464,29 +2464,29 @@
   global.get $~lib/memory/__stack_pointer
   i64.const 0
   i64.store $0
-  local.get $0
+  local.get $this
   i32.eqz
   if
    global.get $~lib/memory/__stack_pointer
    i32.const 16
    i32.const 5
    call $~lib/rt/itcms/__new
-   local.tee $0
+   local.tee $this
    i32.store $0
   end
-  local.get $0
+  local.get $this
   i32.const 0
   call $~lib/array/Array<i32>#set:buffer
-  local.get $0
+  local.get $this
   i32.const 0
   call $~lib/array/Array<i32>#set:dataStart
-  local.get $0
+  local.get $this
   i32.const 0
   call $~lib/array/Array<i32>#set:byteLength
-  local.get $0
+  local.get $this
   i32.const 0
   call $~lib/array/Array<i32>#set:length_
-  local.get $1
+  local.get $length
   i32.const 1073741820
   i32.const 2
   i32.shr_u
@@ -2499,40 +2499,40 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $1
-  local.tee $2
+  local.get $length
+  local.tee $var$2
   i32.const 8
-  local.tee $3
-  local.get $2
-  local.get $3
+  local.tee $var$3
+  local.get $var$2
+  local.get $var$3
   i32.gt_u
   select
   i32.const 2
   i32.shl
-  local.set $4
+  local.set $bufferSize
   global.get $~lib/memory/__stack_pointer
-  local.get $4
+  local.get $bufferSize
   i32.const 0
   call $~lib/rt/itcms/__new
-  local.tee $5
+  local.tee $buffer
   i32.store $0 offset=4
   i32.const 2
   global.get $~lib/shared/runtime/Runtime.Incremental
   i32.ne
   drop
-  local.get $0
-  local.get $5
+  local.get $this
+  local.get $buffer
   call $~lib/array/Array<i32>#set:buffer
-  local.get $0
-  local.get $5
+  local.get $this
+  local.get $buffer
   call $~lib/array/Array<i32>#set:dataStart
-  local.get $0
-  local.get $4
+  local.get $this
+  local.get $bufferSize
   call $~lib/array/Array<i32>#set:byteLength
-  local.get $0
-  local.get $1
+  local.get $this
+  local.get $length
   call $~lib/array/Array<i32>#set:length_
-  local.get $0
+  local.get $this
   local.set $6
   global.get $~lib/memory/__stack_pointer
   i32.const 8
@@ -2540,7 +2540,7 @@
   global.set $~lib/memory/__stack_pointer
   local.get $6
  )
- (func $class/GenericInitializer<i32>#constructor (param $0 i32) (result i32)
+ (func $class/GenericInitializer<i32>#constructor (param $this i32) (result i32)
   (local $1 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -2550,22 +2550,22 @@
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   i32.store $0
-  local.get $0
+  local.get $this
   i32.eqz
   if
    global.get $~lib/memory/__stack_pointer
    i32.const 4
    i32.const 4
    call $~lib/rt/itcms/__new
-   local.tee $0
+   local.tee $this
    i32.store $0
   end
-  local.get $0
+  local.get $this
   i32.const 0
   i32.const 0
   call $~lib/array/Array<i32>#constructor
   call $class/GenericInitializer<i32>#set:foo
-  local.get $0
+  local.get $this
   local.set $1
   global.get $~lib/memory/__stack_pointer
   i32.const 4

--- a/tests/compiler/constructor.debug.wat
+++ b/tests/compiler/constructor.debug.wat
@@ -2430,7 +2430,7 @@
    unreachable
   end
  )
- (func $constructor/EmptyCtor#constructor (param $0 i32) (result i32)
+ (func $constructor/EmptyCtor#constructor (param $this i32) (result i32)
   (local $1 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -2440,17 +2440,17 @@
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   i32.store $0
-  local.get $0
+  local.get $this
   i32.eqz
   if
    global.get $~lib/memory/__stack_pointer
    i32.const 0
    i32.const 3
    call $~lib/rt/itcms/__new
-   local.tee $0
+   local.tee $this
    i32.store $0
   end
-  local.get $0
+  local.get $this
   local.set $1
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -2458,7 +2458,7 @@
   global.set $~lib/memory/__stack_pointer
   local.get $1
  )
- (func $constructor/EmptyCtorWithFieldInit#constructor (param $0 i32) (result i32)
+ (func $constructor/EmptyCtorWithFieldInit#constructor (param $this i32) (result i32)
   (local $1 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -2468,20 +2468,20 @@
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   i32.store $0
-  local.get $0
+  local.get $this
   i32.eqz
   if
    global.get $~lib/memory/__stack_pointer
    i32.const 4
    i32.const 4
    call $~lib/rt/itcms/__new
-   local.tee $0
+   local.tee $this
    i32.store $0
   end
-  local.get $0
+  local.get $this
   i32.const 1
   call $constructor/EmptyCtorWithFieldInit#set:a
-  local.get $0
+  local.get $this
   local.set $1
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -2489,7 +2489,7 @@
   global.set $~lib/memory/__stack_pointer
   local.get $1
  )
- (func $constructor/EmptyCtorWithFieldNoInit#constructor (param $0 i32) (result i32)
+ (func $constructor/EmptyCtorWithFieldNoInit#constructor (param $this i32) (result i32)
   (local $1 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -2499,20 +2499,20 @@
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   i32.store $0
-  local.get $0
+  local.get $this
   i32.eqz
   if
    global.get $~lib/memory/__stack_pointer
    i32.const 4
    i32.const 5
    call $~lib/rt/itcms/__new
-   local.tee $0
+   local.tee $this
    i32.store $0
   end
-  local.get $0
+  local.get $this
   i32.const 0
   call $constructor/EmptyCtorWithFieldNoInit#set:a
-  local.get $0
+  local.get $this
   local.set $1
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -2520,7 +2520,7 @@
   global.set $~lib/memory/__stack_pointer
   local.get $1
  )
- (func $constructor/EmptyCtorWithFieldAccess#constructor (param $0 i32) (result i32)
+ (func $constructor/EmptyCtorWithFieldAccess#constructor (param $this i32) (result i32)
   (local $1 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -2530,23 +2530,23 @@
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   i32.store $0
-  local.get $0
+  local.get $this
   i32.eqz
   if
    global.get $~lib/memory/__stack_pointer
    i32.const 4
    i32.const 6
    call $~lib/rt/itcms/__new
-   local.tee $0
+   local.tee $this
    i32.store $0
   end
-  local.get $0
+  local.get $this
   i32.const 0
   call $constructor/EmptyCtorWithFieldAccess#set:a
-  local.get $0
+  local.get $this
   i32.const 1
   call $constructor/EmptyCtorWithFieldAccess#set:a
-  local.get $0
+  local.get $this
   local.set $1
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -2554,7 +2554,7 @@
   global.set $~lib/memory/__stack_pointer
   local.get $1
  )
- (func $constructor/None#constructor (param $0 i32) (result i32)
+ (func $constructor/None#constructor (param $this i32) (result i32)
   (local $1 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -2564,17 +2564,17 @@
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   i32.store $0
-  local.get $0
+  local.get $this
   i32.eqz
   if
    global.get $~lib/memory/__stack_pointer
    i32.const 0
    i32.const 7
    call $~lib/rt/itcms/__new
-   local.tee $0
+   local.tee $this
    i32.store $0
   end
-  local.get $0
+  local.get $this
   local.set $1
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -2582,7 +2582,7 @@
   global.set $~lib/memory/__stack_pointer
   local.get $1
  )
- (func $constructor/JustFieldInit#constructor (param $0 i32) (result i32)
+ (func $constructor/JustFieldInit#constructor (param $this i32) (result i32)
   (local $1 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -2592,20 +2592,20 @@
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   i32.store $0
-  local.get $0
+  local.get $this
   i32.eqz
   if
    global.get $~lib/memory/__stack_pointer
    i32.const 4
    i32.const 8
    call $~lib/rt/itcms/__new
-   local.tee $0
+   local.tee $this
    i32.store $0
   end
-  local.get $0
+  local.get $this
   i32.const 1
   call $constructor/JustFieldInit#set:a
-  local.get $0
+  local.get $this
   local.set $1
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -2613,7 +2613,7 @@
   global.set $~lib/memory/__stack_pointer
   local.get $1
  )
- (func $constructor/JustFieldNoInit#constructor (param $0 i32) (result i32)
+ (func $constructor/JustFieldNoInit#constructor (param $this i32) (result i32)
   (local $1 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -2623,20 +2623,20 @@
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   i32.store $0
-  local.get $0
+  local.get $this
   i32.eqz
   if
    global.get $~lib/memory/__stack_pointer
    i32.const 4
    i32.const 9
    call $~lib/rt/itcms/__new
-   local.tee $0
+   local.tee $this
    i32.store $0
   end
-  local.get $0
+  local.get $this
   i32.const 0
   call $constructor/JustFieldNoInit#set:a
-  local.get $0
+  local.get $this
   local.set $1
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -2644,7 +2644,7 @@
   global.set $~lib/memory/__stack_pointer
   local.get $1
  )
- (func $constructor/CtorConditionallyReturns#constructor (param $0 i32) (result i32)
+ (func $constructor/CtorConditionallyReturns#constructor (param $this i32) (result i32)
   (local $1 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -2654,14 +2654,14 @@
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   i32.store $0
-  local.get $0
+  local.get $this
   i32.eqz
   if
    global.get $~lib/memory/__stack_pointer
    i32.const 0
    i32.const 11
    call $~lib/rt/itcms/__new
-   local.tee $0
+   local.tee $this
    i32.store $0
   end
   global.get $constructor/b
@@ -2675,7 +2675,7 @@
    local.get $1
    return
   end
-  local.get $0
+  local.get $this
   local.set $1
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -2683,7 +2683,7 @@
   global.set $~lib/memory/__stack_pointer
   local.get $1
  )
- (func $constructor/CtorConditionallyReturnsThis#constructor (param $0 i32) (result i32)
+ (func $constructor/CtorConditionallyReturnsThis#constructor (param $this i32) (result i32)
   (local $1 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -2693,19 +2693,19 @@
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   i32.store $0
-  local.get $0
+  local.get $this
   i32.eqz
   if
    global.get $~lib/memory/__stack_pointer
    i32.const 0
    i32.const 12
    call $~lib/rt/itcms/__new
-   local.tee $0
+   local.tee $this
    i32.store $0
   end
   global.get $constructor/b
   if
-   local.get $0
+   local.get $this
    local.set $1
    global.get $~lib/memory/__stack_pointer
    i32.const 4
@@ -2714,7 +2714,7 @@
    local.get $1
    return
   end
-  local.get $0
+  local.get $this
   local.set $1
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -2722,7 +2722,7 @@
   global.set $~lib/memory/__stack_pointer
   local.get $1
  )
- (func $constructor/CtorFieldInitOrder#constructor (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $constructor/CtorFieldInitOrder#constructor (param $this i32) (param $a i32) (param $b i32) (result i32)
   (local $3 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -2732,30 +2732,30 @@
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   i32.store $0
-  local.get $0
+  local.get $this
   i32.eqz
   if
    global.get $~lib/memory/__stack_pointer
    i32.const 12
    i32.const 13
    call $~lib/rt/itcms/__new
-   local.tee $0
+   local.tee $this
    i32.store $0
   end
-  local.get $0
-  local.get $1
+  local.get $this
+  local.get $a
   call $constructor/CtorFieldInitOrder#set:a
-  local.get $0
-  local.get $2
+  local.get $this
+  local.get $b
   call $constructor/CtorFieldInitOrder#set:b
-  local.get $0
-  local.get $0
+  local.get $this
+  local.get $this
   i32.load $0 offset=4
-  local.get $0
+  local.get $this
   i32.load $0 offset=8
   i32.add
   call $constructor/CtorFieldInitOrder#set:c
-  local.get $1
+  local.get $a
   i32.const 1
   i32.eq
   i32.eqz
@@ -2767,7 +2767,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $0
+  local.get $this
   i32.load $0 offset=4
   i32.const 1
   i32.eq
@@ -2780,7 +2780,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $2
+  local.get $b
   i32.const 2
   i32.eq
   i32.eqz
@@ -2792,7 +2792,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $0
+  local.get $this
   i32.load $0 offset=8
   i32.const 2
   i32.eq
@@ -2805,7 +2805,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $0
+  local.get $this
   i32.load $0
   i32.const 3
   i32.eq
@@ -2818,7 +2818,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $0
+  local.get $this
   local.set $3
   global.get $~lib/memory/__stack_pointer
   i32.const 4

--- a/tests/compiler/do.debug.wat
+++ b/tests/compiler/do.debug.wat
@@ -2947,7 +2947,7 @@
    unreachable
   end
  )
- (func $do/Ref#constructor (param $0 i32) (result i32)
+ (func $do/Ref#constructor (param $this i32) (result i32)
   (local $1 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -2957,17 +2957,17 @@
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   i32.store $0
-  local.get $0
+  local.get $this
   i32.eqz
   if
    global.get $~lib/memory/__stack_pointer
    i32.const 0
    i32.const 3
    call $~lib/rt/itcms/__new
-   local.tee $0
+   local.tee $this
    i32.store $0
   end
-  local.get $0
+  local.get $this
   local.set $1
   global.get $~lib/memory/__stack_pointer
   i32.const 4

--- a/tests/compiler/duplicate-fields.debug.wat
+++ b/tests/compiler/duplicate-fields.debug.wat
@@ -2473,7 +2473,7 @@
   i32.add
   global.set $~lib/memory/__stack_pointer
  )
- (func $duplicate-fields/A#constructor (param $0 i32) (param $1 i32) (result i32)
+ (func $duplicate-fields/A#constructor (param $this i32) (param $bar i32) (result i32)
   (local $2 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -2483,23 +2483,23 @@
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   i32.store $0
-  local.get $0
+  local.get $this
   i32.eqz
   if
    global.get $~lib/memory/__stack_pointer
    i32.const 4
    i32.const 3
    call $~lib/rt/itcms/__new
-   local.tee $0
+   local.tee $this
    i32.store $0
   end
-  local.get $0
+  local.get $this
   i32.const 0
   call $duplicate-fields/A#set:bar
-  local.get $0
-  local.get $1
+  local.get $this
+  local.get $bar
   call $duplicate-fields/A#set:bar
-  local.get $0
+  local.get $this
   local.set $2
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -2507,7 +2507,7 @@
   global.set $~lib/memory/__stack_pointer
   local.get $2
  )
- (func $duplicate-fields/B#constructor (param $0 i32) (param $1 i32) (result i32)
+ (func $duplicate-fields/B#constructor (param $this i32) (param $bar i32) (result i32)
   (local $2 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -2517,29 +2517,29 @@
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   i32.store $0
-  local.get $0
+  local.get $this
   i32.eqz
   if
    global.get $~lib/memory/__stack_pointer
    i32.const 4
    i32.const 4
    call $~lib/rt/itcms/__new
-   local.tee $0
+   local.tee $this
    i32.store $0
   end
-  local.get $0
+  local.get $this
   i32.const 0
   call $duplicate-fields/B#set:bar
   global.get $~lib/memory/__stack_pointer
-  local.get $0
-  local.get $1
+  local.get $this
+  local.get $bar
   call $duplicate-fields/A#constructor
-  local.tee $0
+  local.tee $this
   i32.store $0
-  local.get $0
-  local.get $1
+  local.get $this
+  local.get $bar
   call $duplicate-fields/B#set:bar
-  local.get $0
+  local.get $this
   local.set $2
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -2547,7 +2547,7 @@
   global.set $~lib/memory/__stack_pointer
   local.get $2
  )
- (func $duplicate-fields/A2#constructor (param $0 i32) (param $1 i32) (result i32)
+ (func $duplicate-fields/A2#constructor (param $this i32) (param $bar i32) (result i32)
   (local $2 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -2557,23 +2557,23 @@
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   i32.store $0
-  local.get $0
+  local.get $this
   i32.eqz
   if
    global.get $~lib/memory/__stack_pointer
    i32.const 4
    i32.const 5
    call $~lib/rt/itcms/__new
-   local.tee $0
+   local.tee $this
    i32.store $0
   end
-  local.get $0
+  local.get $this
   i32.const 0
   call $duplicate-fields/A2#set:bar
-  local.get $0
-  local.get $1
+  local.get $this
+  local.get $bar
   call $duplicate-fields/A2#set:bar
-  local.get $0
+  local.get $this
   local.set $2
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -2581,7 +2581,7 @@
   global.set $~lib/memory/__stack_pointer
   local.get $2
  )
- (func $duplicate-fields/B2#constructor (param $0 i32) (param $1 i32) (result i32)
+ (func $duplicate-fields/B2#constructor (param $this i32) (param $bar i32) (result i32)
   (local $2 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -2591,29 +2591,29 @@
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   i32.store $0
-  local.get $0
+  local.get $this
   i32.eqz
   if
    global.get $~lib/memory/__stack_pointer
    i32.const 4
    i32.const 7
    call $~lib/rt/itcms/__new
-   local.tee $0
+   local.tee $this
    i32.store $0
   end
-  local.get $0
+  local.get $this
   i32.const 0
   call $duplicate-fields/B2#set:bar
   global.get $~lib/memory/__stack_pointer
-  local.get $0
-  local.get $1
+  local.get $this
+  local.get $bar
   call $duplicate-fields/A2#constructor
-  local.tee $0
+  local.tee $this
   i32.store $0
-  local.get $0
-  local.get $1
+  local.get $this
+  local.get $bar
   call $duplicate-fields/B2#set:bar
-  local.get $0
+  local.get $this
   local.set $2
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -2621,7 +2621,7 @@
   global.set $~lib/memory/__stack_pointer
   local.get $2
  )
- (func $duplicate-fields/Foo#constructor (param $0 i32) (param $1 i32) (result i32)
+ (func $duplicate-fields/Foo#constructor (param $this i32) (param $foo i32) (result i32)
   (local $2 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -2631,23 +2631,23 @@
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   i32.store $0
-  local.get $0
+  local.get $this
   i32.eqz
   if
    global.get $~lib/memory/__stack_pointer
    i32.const 4
    i32.const 6
    call $~lib/rt/itcms/__new
-   local.tee $0
+   local.tee $this
    i32.store $0
   end
-  local.get $0
+  local.get $this
   i32.const 0
   call $duplicate-fields/Foo#set:foo
-  local.get $0
-  local.get $1
+  local.get $this
+  local.get $foo
   call $duplicate-fields/Foo#set:foo
-  local.get $0
+  local.get $this
   local.set $2
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -2655,7 +2655,7 @@
   global.set $~lib/memory/__stack_pointer
   local.get $2
  )
- (func $duplicate-fields/Bar#constructor (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $duplicate-fields/Bar#constructor (param $this i32) (param $foo i32) (param $bar i32) (result i32)
   (local $3 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -2665,29 +2665,29 @@
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   i32.store $0
-  local.get $0
+  local.get $this
   i32.eqz
   if
    global.get $~lib/memory/__stack_pointer
    i32.const 8
    i32.const 8
    call $~lib/rt/itcms/__new
-   local.tee $0
+   local.tee $this
    i32.store $0
   end
-  local.get $0
+  local.get $this
   i32.const 0
   call $duplicate-fields/Bar#set:bar
   global.get $~lib/memory/__stack_pointer
-  local.get $0
-  local.get $1
+  local.get $this
+  local.get $foo
   call $duplicate-fields/Foo#constructor
-  local.tee $0
+  local.tee $this
   i32.store $0
-  local.get $0
-  local.get $2
+  local.get $this
+  local.get $bar
   call $duplicate-fields/Bar#set:bar
-  local.get $0
+  local.get $this
   local.set $3
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -2695,7 +2695,7 @@
   global.set $~lib/memory/__stack_pointer
   local.get $3
  )
- (func $duplicate-fields/A3#constructor (param $0 i32) (result i32)
+ (func $duplicate-fields/A3#constructor (param $this i32) (result i32)
   (local $1 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -2705,26 +2705,26 @@
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   i32.store $0
-  local.get $0
+  local.get $this
   i32.eqz
   if
    global.get $~lib/memory/__stack_pointer
    i32.const 12
    i32.const 10
    call $~lib/rt/itcms/__new
-   local.tee $0
+   local.tee $this
    i32.store $0
   end
-  local.get $0
+  local.get $this
   i32.const 0
   call $duplicate-fields/A3#set:protProt
-  local.get $0
+  local.get $this
   i32.const 0
   call $duplicate-fields/A3#set:protPub
-  local.get $0
+  local.get $this
   i32.const 0
   call $duplicate-fields/A3#set:pubPub
-  local.get $0
+  local.get $this
   local.set $1
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -2732,7 +2732,7 @@
   global.set $~lib/memory/__stack_pointer
   local.get $1
  )
- (func $duplicate-fields/B3#constructor (param $0 i32) (result i32)
+ (func $duplicate-fields/B3#constructor (param $this i32) (result i32)
   (local $1 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -2742,31 +2742,31 @@
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   i32.store $0
-  local.get $0
+  local.get $this
   i32.eqz
   if
    global.get $~lib/memory/__stack_pointer
    i32.const 12
    i32.const 9
    call $~lib/rt/itcms/__new
-   local.tee $0
+   local.tee $this
    i32.store $0
   end
   global.get $~lib/memory/__stack_pointer
-  local.get $0
+  local.get $this
   call $duplicate-fields/A3#constructor
-  local.tee $0
+  local.tee $this
   i32.store $0
-  local.get $0
+  local.get $this
   i32.const 0
   call $duplicate-fields/B3#set:protProt
-  local.get $0
+  local.get $this
   i32.const 0
   call $duplicate-fields/B3#set:protPub
-  local.get $0
+  local.get $this
   i32.const 0
   call $duplicate-fields/B3#set:pubPub
-  local.get $0
+  local.get $this
   local.set $1
   global.get $~lib/memory/__stack_pointer
   i32.const 4

--- a/tests/compiler/exportstar-rereexport.debug.wat
+++ b/tests/compiler/exportstar-rereexport.debug.wat
@@ -2448,7 +2448,7 @@
   i32.add
   global.set $~lib/memory/__stack_pointer
  )
- (func $exports/Car#constructor (param $0 i32) (param $1 i32) (result i32)
+ (func $exports/Car#constructor (param $this i32) (param $doors i32) (result i32)
   (local $2 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -2458,23 +2458,23 @@
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   i32.store $0
-  local.get $0
+  local.get $this
   i32.eqz
   if
    global.get $~lib/memory/__stack_pointer
    i32.const 4
    i32.const 3
    call $~lib/rt/itcms/__new
-   local.tee $0
+   local.tee $this
    i32.store $0
   end
-  local.get $0
-  local.get $1
+  local.get $this
+  local.get $doors
   call $exports/Car#set:doors
-  local.get $0
-  local.get $1
+  local.get $this
+  local.get $doors
   call $exports/Car#set:doors
-  local.get $0
+  local.get $this
   local.set $2
   global.get $~lib/memory/__stack_pointer
   i32.const 4

--- a/tests/compiler/extends-baseaggregate.debug.wat
+++ b/tests/compiler/extends-baseaggregate.debug.wat
@@ -2683,7 +2683,7 @@
   i32.add
   global.set $~lib/memory/__stack_pointer
  )
- (func $extends-baseaggregate/A1#constructor (param $0 i32) (result i32)
+ (func $extends-baseaggregate/A1#constructor (param $this i32) (result i32)
   (local $1 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -2693,26 +2693,26 @@
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   i32.store $0
-  local.get $0
+  local.get $this
   i32.eqz
   if
    global.get $~lib/memory/__stack_pointer
    i32.const 20
    i32.const 4
    call $~lib/rt/itcms/__new
-   local.tee $0
+   local.tee $this
    i32.store $0
   end
-  local.get $0
+  local.get $this
   f64.const 0
   call $extends-baseaggregate/A1#set:padding0
-  local.get $0
+  local.get $this
   f64.const 0
   call $extends-baseaggregate/A1#set:padding1
-  local.get $0
+  local.get $this
   i32.const 0
   call $extends-baseaggregate/A1#set:c1
-  local.get $0
+  local.get $this
   local.set $1
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -2720,7 +2720,7 @@
   global.set $~lib/memory/__stack_pointer
   local.get $1
  )
- (func $extends-baseaggregate/A2#constructor (param $0 i32) (result i32)
+ (func $extends-baseaggregate/A2#constructor (param $this i32) (result i32)
   (local $1 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -2730,22 +2730,22 @@
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   i32.store $0
-  local.get $0
+  local.get $this
   i32.eqz
   if
    global.get $~lib/memory/__stack_pointer
    i32.const 20
    i32.const 6
    call $~lib/rt/itcms/__new
-   local.tee $0
+   local.tee $this
    i32.store $0
   end
   global.get $~lib/memory/__stack_pointer
-  local.get $0
+  local.get $this
   call $extends-baseaggregate/A1#constructor
-  local.tee $0
+  local.tee $this
   i32.store $0
-  local.get $0
+  local.get $this
   local.set $1
   global.get $~lib/memory/__stack_pointer
   i32.const 4

--- a/tests/compiler/extends-recursive.debug.wat
+++ b/tests/compiler/extends-recursive.debug.wat
@@ -2298,7 +2298,7 @@
    unreachable
   end
  )
- (func $extends-recursive/Parent#constructor (param $0 i32) (result i32)
+ (func $extends-recursive/Parent#constructor (param $this i32) (result i32)
   (local $1 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -2308,20 +2308,20 @@
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   i32.store $0
-  local.get $0
+  local.get $this
   i32.eqz
   if
    global.get $~lib/memory/__stack_pointer
    i32.const 4
    i32.const 4
    call $~lib/rt/itcms/__new
-   local.tee $0
+   local.tee $this
    i32.store $0
   end
-  local.get $0
+  local.get $this
   i32.const 0
   call $extends-recursive/Parent#set:child
-  local.get $0
+  local.get $this
   local.set $1
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -2329,7 +2329,7 @@
   global.set $~lib/memory/__stack_pointer
   local.get $1
  )
- (func $extends-recursive/Child#constructor (param $0 i32) (result i32)
+ (func $extends-recursive/Child#constructor (param $this i32) (result i32)
   (local $1 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -2339,22 +2339,22 @@
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   i32.store $0
-  local.get $0
+  local.get $this
   i32.eqz
   if
    global.get $~lib/memory/__stack_pointer
    i32.const 4
    i32.const 3
    call $~lib/rt/itcms/__new
-   local.tee $0
+   local.tee $this
    i32.store $0
   end
   global.get $~lib/memory/__stack_pointer
-  local.get $0
+  local.get $this
   call $extends-recursive/Parent#constructor
-  local.tee $0
+  local.tee $this
   i32.store $0
-  local.get $0
+  local.get $this
   local.set $1
   global.get $~lib/memory/__stack_pointer
   i32.const 4

--- a/tests/compiler/field-initialization.debug.wat
+++ b/tests/compiler/field-initialization.debug.wat
@@ -3637,7 +3637,7 @@
   i32.add
   global.set $~lib/memory/__stack_pointer
  )
- (func $field-initialization/Value_Init#constructor (param $0 i32) (result i32)
+ (func $field-initialization/Value_Init#constructor (param $this i32) (result i32)
   (local $1 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -3647,20 +3647,20 @@
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   i32.store $0
-  local.get $0
+  local.get $this
   i32.eqz
   if
    global.get $~lib/memory/__stack_pointer
    i32.const 4
    i32.const 3
    call $~lib/rt/itcms/__new
-   local.tee $0
+   local.tee $this
    i32.store $0
   end
-  local.get $0
+  local.get $this
   i32.const 1
   call $field-initialization/Value_Init#set:a
-  local.get $0
+  local.get $this
   local.set $1
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -3668,7 +3668,7 @@
   global.set $~lib/memory/__stack_pointer
   local.get $1
  )
- (func $field-initialization/Value#constructor (param $0 i32) (result i32)
+ (func $field-initialization/Value#constructor (param $this i32) (result i32)
   (local $1 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -3678,20 +3678,20 @@
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   i32.store $0
-  local.get $0
+  local.get $this
   i32.eqz
   if
    global.get $~lib/memory/__stack_pointer
    i32.const 4
    i32.const 4
    call $~lib/rt/itcms/__new
-   local.tee $0
+   local.tee $this
    i32.store $0
   end
-  local.get $0
+  local.get $this
   i32.const 0
   call $field-initialization/Value#set:a
-  local.get $0
+  local.get $this
   local.set $1
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -3699,8 +3699,8 @@
   global.set $~lib/memory/__stack_pointer
   local.get $1
  )
- (func $~lib/arraybuffer/ArrayBuffer#constructor (param $0 i32) (param $1 i32) (result i32)
-  (local $2 i32)
+ (func $~lib/arraybuffer/ArrayBuffer#constructor (param $this i32) (param $length i32) (result i32)
+  (local $buffer i32)
   (local $3 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -3710,7 +3710,7 @@
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   i32.store $0
-  local.get $1
+  local.get $length
   i32.const 1073741820
   i32.gt_u
   if
@@ -3722,16 +3722,16 @@
    unreachable
   end
   global.get $~lib/memory/__stack_pointer
-  local.get $1
+  local.get $length
   i32.const 0
   call $~lib/rt/itcms/__new
-  local.tee $2
+  local.tee $buffer
   i32.store $0
   i32.const 2
   global.get $~lib/shared/runtime/Runtime.Incremental
   i32.ne
   drop
-  local.get $2
+  local.get $buffer
   local.set $3
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -3739,7 +3739,7 @@
   global.set $~lib/memory/__stack_pointer
   local.get $3
  )
- (func $field-initialization/Ref_Init#constructor (param $0 i32) (result i32)
+ (func $field-initialization/Ref_Init#constructor (param $this i32) (result i32)
   (local $1 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -3749,22 +3749,22 @@
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   i32.store $0
-  local.get $0
+  local.get $this
   i32.eqz
   if
    global.get $~lib/memory/__stack_pointer
    i32.const 4
    i32.const 5
    call $~lib/rt/itcms/__new
-   local.tee $0
+   local.tee $this
    i32.store $0
   end
-  local.get $0
+  local.get $this
   i32.const 0
   i32.const 0
   call $~lib/arraybuffer/ArrayBuffer#constructor
   call $field-initialization/Ref_Init#set:a
-  local.get $0
+  local.get $this
   local.set $1
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -3772,7 +3772,7 @@
   global.set $~lib/memory/__stack_pointer
   local.get $1
  )
- (func $field-initialization/Nullable_Init#constructor (param $0 i32) (result i32)
+ (func $field-initialization/Nullable_Init#constructor (param $this i32) (result i32)
   (local $1 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -3782,22 +3782,22 @@
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   i32.store $0
-  local.get $0
+  local.get $this
   i32.eqz
   if
    global.get $~lib/memory/__stack_pointer
    i32.const 4
    i32.const 6
    call $~lib/rt/itcms/__new
-   local.tee $0
+   local.tee $this
    i32.store $0
   end
-  local.get $0
+  local.get $this
   i32.const 0
   i32.const 0
   call $~lib/arraybuffer/ArrayBuffer#constructor
   call $field-initialization/Nullable_Init#set:a
-  local.get $0
+  local.get $this
   local.set $1
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -3805,7 +3805,7 @@
   global.set $~lib/memory/__stack_pointer
   local.get $1
  )
- (func $field-initialization/Nullable#constructor (param $0 i32) (result i32)
+ (func $field-initialization/Nullable#constructor (param $this i32) (result i32)
   (local $1 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -3815,20 +3815,20 @@
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   i32.store $0
-  local.get $0
+  local.get $this
   i32.eqz
   if
    global.get $~lib/memory/__stack_pointer
    i32.const 4
    i32.const 7
    call $~lib/rt/itcms/__new
-   local.tee $0
+   local.tee $this
    i32.store $0
   end
-  local.get $0
+  local.get $this
   i32.const 0
   call $field-initialization/Nullable#set:a
-  local.get $0
+  local.get $this
   local.set $1
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -3836,7 +3836,7 @@
   global.set $~lib/memory/__stack_pointer
   local.get $1
  )
- (func $field-initialization/Value_Ctor#constructor (param $0 i32) (result i32)
+ (func $field-initialization/Value_Ctor#constructor (param $this i32) (result i32)
   (local $1 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -3846,20 +3846,20 @@
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   i32.store $0
-  local.get $0
+  local.get $this
   i32.eqz
   if
    global.get $~lib/memory/__stack_pointer
    i32.const 4
    i32.const 8
    call $~lib/rt/itcms/__new
-   local.tee $0
+   local.tee $this
    i32.store $0
   end
-  local.get $0
+  local.get $this
   i32.const 0
   call $field-initialization/Value_Ctor#set:a
-  local.get $0
+  local.get $this
   local.set $1
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -3867,7 +3867,7 @@
   global.set $~lib/memory/__stack_pointer
   local.get $1
  )
- (func $field-initialization/Value_Init_Ctor#constructor (param $0 i32) (result i32)
+ (func $field-initialization/Value_Init_Ctor#constructor (param $this i32) (result i32)
   (local $1 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -3877,20 +3877,20 @@
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   i32.store $0
-  local.get $0
+  local.get $this
   i32.eqz
   if
    global.get $~lib/memory/__stack_pointer
    i32.const 4
    i32.const 9
    call $~lib/rt/itcms/__new
-   local.tee $0
+   local.tee $this
    i32.store $0
   end
-  local.get $0
+  local.get $this
   i32.const 1
   call $field-initialization/Value_Init_Ctor#set:a
-  local.get $0
+  local.get $this
   local.set $1
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -3898,7 +3898,7 @@
   global.set $~lib/memory/__stack_pointer
   local.get $1
  )
- (func $field-initialization/Value_Ctor_Init#constructor (param $0 i32) (result i32)
+ (func $field-initialization/Value_Ctor_Init#constructor (param $this i32) (result i32)
   (local $1 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -3908,23 +3908,23 @@
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   i32.store $0
-  local.get $0
+  local.get $this
   i32.eqz
   if
    global.get $~lib/memory/__stack_pointer
    i32.const 4
    i32.const 10
    call $~lib/rt/itcms/__new
-   local.tee $0
+   local.tee $this
    i32.store $0
   end
-  local.get $0
+  local.get $this
   i32.const 0
   call $field-initialization/Value_Ctor_Init#set:a
-  local.get $0
+  local.get $this
   i32.const 1
   call $field-initialization/Value_Ctor_Init#set:a
-  local.get $0
+  local.get $this
   local.set $1
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -3932,7 +3932,7 @@
   global.set $~lib/memory/__stack_pointer
   local.get $1
  )
- (func $field-initialization/Ref_Init_Ctor#constructor (param $0 i32) (result i32)
+ (func $field-initialization/Ref_Init_Ctor#constructor (param $this i32) (result i32)
   (local $1 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -3942,22 +3942,22 @@
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   i32.store $0
-  local.get $0
+  local.get $this
   i32.eqz
   if
    global.get $~lib/memory/__stack_pointer
    i32.const 4
    i32.const 11
    call $~lib/rt/itcms/__new
-   local.tee $0
+   local.tee $this
    i32.store $0
   end
-  local.get $0
+  local.get $this
   i32.const 0
   i32.const 0
   call $~lib/arraybuffer/ArrayBuffer#constructor
   call $field-initialization/Ref_Init_Ctor#set:a
-  local.get $0
+  local.get $this
   local.set $1
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -3965,7 +3965,7 @@
   global.set $~lib/memory/__stack_pointer
   local.get $1
  )
- (func $field-initialization/Ref_Ctor_Init#constructor (param $0 i32) (result i32)
+ (func $field-initialization/Ref_Ctor_Init#constructor (param $this i32) (result i32)
   (local $1 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -3975,25 +3975,25 @@
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   i32.store $0
-  local.get $0
+  local.get $this
   i32.eqz
   if
    global.get $~lib/memory/__stack_pointer
    i32.const 4
    i32.const 12
    call $~lib/rt/itcms/__new
-   local.tee $0
+   local.tee $this
    i32.store $0
   end
-  local.get $0
+  local.get $this
   i32.const 0
   call $field-initialization/Ref_Ctor_Init#set:a
-  local.get $0
+  local.get $this
   i32.const 0
   i32.const 0
   call $~lib/arraybuffer/ArrayBuffer#constructor
   call $field-initialization/Ref_Ctor_Init#set:a
-  local.get $0
+  local.get $this
   local.set $1
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -4001,7 +4001,7 @@
   global.set $~lib/memory/__stack_pointer
   local.get $1
  )
- (func $field-initialization/Ref_Ctor_Param#constructor (param $0 i32) (param $1 i32) (result i32)
+ (func $field-initialization/Ref_Ctor_Param#constructor (param $this i32) (param $a i32) (result i32)
   (local $2 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -4011,20 +4011,20 @@
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   i32.store $0
-  local.get $0
+  local.get $this
   i32.eqz
   if
    global.get $~lib/memory/__stack_pointer
    i32.const 4
    i32.const 13
    call $~lib/rt/itcms/__new
-   local.tee $0
+   local.tee $this
    i32.store $0
   end
-  local.get $0
-  local.get $1
+  local.get $this
+  local.get $a
   call $field-initialization/Ref_Ctor_Param#set:a
-  local.get $0
+  local.get $this
   local.set $2
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -4032,7 +4032,7 @@
   global.set $~lib/memory/__stack_pointer
   local.get $2
  )
- (func $field-initialization/Nullable_Ctor#constructor (param $0 i32) (result i32)
+ (func $field-initialization/Nullable_Ctor#constructor (param $this i32) (result i32)
   (local $1 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -4042,20 +4042,20 @@
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   i32.store $0
-  local.get $0
+  local.get $this
   i32.eqz
   if
    global.get $~lib/memory/__stack_pointer
    i32.const 4
    i32.const 14
    call $~lib/rt/itcms/__new
-   local.tee $0
+   local.tee $this
    i32.store $0
   end
-  local.get $0
+  local.get $this
   i32.const 0
   call $field-initialization/Nullable_Ctor#set:a
-  local.get $0
+  local.get $this
   local.set $1
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -4063,7 +4063,7 @@
   global.set $~lib/memory/__stack_pointer
   local.get $1
  )
- (func $field-initialization/Nullable_Init_Ctor#constructor (param $0 i32) (result i32)
+ (func $field-initialization/Nullable_Init_Ctor#constructor (param $this i32) (result i32)
   (local $1 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -4073,22 +4073,22 @@
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   i32.store $0
-  local.get $0
+  local.get $this
   i32.eqz
   if
    global.get $~lib/memory/__stack_pointer
    i32.const 4
    i32.const 15
    call $~lib/rt/itcms/__new
-   local.tee $0
+   local.tee $this
    i32.store $0
   end
-  local.get $0
+  local.get $this
   i32.const 0
   i32.const 0
   call $~lib/arraybuffer/ArrayBuffer#constructor
   call $field-initialization/Nullable_Init_Ctor#set:a
-  local.get $0
+  local.get $this
   local.set $1
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -4096,7 +4096,7 @@
   global.set $~lib/memory/__stack_pointer
   local.get $1
  )
- (func $field-initialization/Nullable_Ctor_Init#constructor (param $0 i32) (result i32)
+ (func $field-initialization/Nullable_Ctor_Init#constructor (param $this i32) (result i32)
   (local $1 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -4106,25 +4106,25 @@
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   i32.store $0
-  local.get $0
+  local.get $this
   i32.eqz
   if
    global.get $~lib/memory/__stack_pointer
    i32.const 4
    i32.const 16
    call $~lib/rt/itcms/__new
-   local.tee $0
+   local.tee $this
    i32.store $0
   end
-  local.get $0
+  local.get $this
   i32.const 0
   call $field-initialization/Nullable_Ctor_Init#set:a
-  local.get $0
+  local.get $this
   i32.const 0
   i32.const 0
   call $~lib/arraybuffer/ArrayBuffer#constructor
   call $field-initialization/Nullable_Ctor_Init#set:a
-  local.get $0
+  local.get $this
   local.set $1
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -4132,7 +4132,7 @@
   global.set $~lib/memory/__stack_pointer
   local.get $1
  )
- (func $field-initialization/Inherit_Base#constructor (param $0 i32) (result i32)
+ (func $field-initialization/Inherit_Base#constructor (param $this i32) (result i32)
   (local $1 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -4142,22 +4142,22 @@
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   i32.store $0
-  local.get $0
+  local.get $this
   i32.eqz
   if
    global.get $~lib/memory/__stack_pointer
    i32.const 4
    i32.const 18
    call $~lib/rt/itcms/__new
-   local.tee $0
+   local.tee $this
    i32.store $0
   end
-  local.get $0
+  local.get $this
   i32.const 0
   i32.const 0
   call $~lib/arraybuffer/ArrayBuffer#constructor
   call $field-initialization/Inherit_Base#set:a
-  local.get $0
+  local.get $this
   local.set $1
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -4165,7 +4165,7 @@
   global.set $~lib/memory/__stack_pointer
   local.get $1
  )
- (func $field-initialization/Inherit#constructor (param $0 i32) (result i32)
+ (func $field-initialization/Inherit#constructor (param $this i32) (result i32)
   (local $1 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -4175,22 +4175,22 @@
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   i32.store $0
-  local.get $0
+  local.get $this
   i32.eqz
   if
    global.get $~lib/memory/__stack_pointer
    i32.const 4
    i32.const 17
    call $~lib/rt/itcms/__new
-   local.tee $0
+   local.tee $this
    i32.store $0
   end
   global.get $~lib/memory/__stack_pointer
-  local.get $0
+  local.get $this
   call $field-initialization/Inherit_Base#constructor
-  local.tee $0
+  local.tee $this
   i32.store $0
-  local.get $0
+  local.get $this
   local.set $1
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -4198,7 +4198,7 @@
   global.set $~lib/memory/__stack_pointer
   local.get $1
  )
- (func $field-initialization/Inherit_Ctor#constructor (param $0 i32) (result i32)
+ (func $field-initialization/Inherit_Ctor#constructor (param $this i32) (result i32)
   (local $1 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -4208,22 +4208,22 @@
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   i32.store $0
-  local.get $0
+  local.get $this
   i32.eqz
   if
    global.get $~lib/memory/__stack_pointer
    i32.const 4
    i32.const 19
    call $~lib/rt/itcms/__new
-   local.tee $0
+   local.tee $this
    i32.store $0
   end
   global.get $~lib/memory/__stack_pointer
-  local.get $0
+  local.get $this
   call $field-initialization/Inherit_Base#constructor
-  local.tee $0
+  local.tee $this
   i32.store $0
-  local.get $0
+  local.get $this
   local.set $1
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -4231,7 +4231,7 @@
   global.set $~lib/memory/__stack_pointer
   local.get $1
  )
- (func $field-initialization/SomeObject#constructor (param $0 i32) (result i32)
+ (func $field-initialization/SomeObject#constructor (param $this i32) (result i32)
   (local $1 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -4241,23 +4241,23 @@
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   i32.store $0
-  local.get $0
+  local.get $this
   i32.eqz
   if
    global.get $~lib/memory/__stack_pointer
    i32.const 8
    i32.const 20
    call $~lib/rt/itcms/__new
-   local.tee $0
+   local.tee $this
    i32.store $0
   end
-  local.get $0
+  local.get $this
   i32.const 0
   call $field-initialization/SomeObject#set:a
-  local.get $0
+  local.get $this
   i32.const 0
   call $field-initialization/SomeObject#set:b
-  local.get $0
+  local.get $this
   local.set $1
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -4265,7 +4265,7 @@
   global.set $~lib/memory/__stack_pointer
   local.get $1
  )
- (func $field-initialization/SomeOtherObject#constructor (param $0 i32) (result i32)
+ (func $field-initialization/SomeOtherObject#constructor (param $this i32) (result i32)
   (local $1 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -4275,25 +4275,25 @@
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   i32.store $0
-  local.get $0
+  local.get $this
   i32.eqz
   if
    global.get $~lib/memory/__stack_pointer
    i32.const 12
    i32.const 21
    call $~lib/rt/itcms/__new
-   local.tee $0
+   local.tee $this
    i32.store $0
   end
   global.get $~lib/memory/__stack_pointer
-  local.get $0
+  local.get $this
   call $field-initialization/SomeObject#constructor
-  local.tee $0
+  local.tee $this
   i32.store $0
-  local.get $0
+  local.get $this
   i32.const 0
   call $field-initialization/SomeOtherObject#set:c
-  local.get $0
+  local.get $this
   local.set $1
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -4301,7 +4301,7 @@
   global.set $~lib/memory/__stack_pointer
   local.get $1
  )
- (func $field-initialization/Flow_Balanced#constructor (param $0 i32) (param $1 i32) (result i32)
+ (func $field-initialization/Flow_Balanced#constructor (param $this i32) (param $cond i32) (result i32)
   (local $2 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -4311,34 +4311,34 @@
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   i32.store $0
-  local.get $0
+  local.get $this
   i32.eqz
   if
    global.get $~lib/memory/__stack_pointer
    i32.const 4
    i32.const 22
    call $~lib/rt/itcms/__new
-   local.tee $0
+   local.tee $this
    i32.store $0
   end
-  local.get $0
+  local.get $this
   i32.const 0
   call $field-initialization/Flow_Balanced#set:a
-  local.get $1
+  local.get $cond
   if
-   local.get $0
+   local.get $this
    i32.const 0
    i32.const 0
    call $~lib/arraybuffer/ArrayBuffer#constructor
    call $field-initialization/Flow_Balanced#set:a
   else
-   local.get $0
+   local.get $this
    i32.const 0
    i32.const 0
    call $~lib/arraybuffer/ArrayBuffer#constructor
    call $field-initialization/Flow_Balanced#set:a
   end
-  local.get $0
+  local.get $this
   local.set $2
   global.get $~lib/memory/__stack_pointer
   i32.const 4

--- a/tests/compiler/field.debug.wat
+++ b/tests/compiler/field.debug.wat
@@ -2454,10 +2454,10 @@
    unreachable
   end
  )
- (func $~lib/rt/__newArray (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
-  (local $4 i32)
-  (local $5 i32)
-  (local $6 i32)
+ (func $~lib/rt/__newArray (param $length i32) (param $alignLog2 i32) (param $id i32) (param $data i32) (result i32)
+  (local $bufferSize i32)
+  (local $buffer i32)
+  (local $array i32)
   (local $7 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -2467,38 +2467,38 @@
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   i32.store $0
-  local.get $0
-  local.get $1
+  local.get $length
+  local.get $alignLog2
   i32.shl
-  local.set $4
+  local.set $bufferSize
   global.get $~lib/memory/__stack_pointer
-  local.get $4
+  local.get $bufferSize
   i32.const 0
-  local.get $3
+  local.get $data
   call $~lib/rt/__newBuffer
-  local.tee $5
+  local.tee $buffer
   i32.store $0
   i32.const 16
-  local.get $2
+  local.get $id
   call $~lib/rt/itcms/__new
-  local.set $6
-  local.get $6
-  local.get $5
+  local.set $array
+  local.get $array
+  local.get $buffer
   i32.store $0
-  local.get $6
-  local.get $5
+  local.get $array
+  local.get $buffer
   i32.const 0
   call $~lib/rt/itcms/__link
-  local.get $6
-  local.get $5
+  local.get $array
+  local.get $buffer
   i32.store $0 offset=4
-  local.get $6
-  local.get $4
+  local.get $array
+  local.get $bufferSize
   i32.store $0 offset=8
-  local.get $6
-  local.get $0
+  local.get $array
+  local.get $length
   i32.store $0 offset=12
-  local.get $6
+  local.get $array
   local.set $7
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -2506,9 +2506,9 @@
   global.set $~lib/memory/__stack_pointer
   local.get $7
  )
- (func $field/NoStaticConflict#constructor (param $0 i32) (result i32)
-  (local $1 i32)
-  (local $2 i32)
+ (func $field/NoStaticConflict#constructor (param $this i32) (result i32)
+  (local $var$1 i32)
+  (local $var$2 i32)
   (local $3 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -2518,24 +2518,24 @@
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   i32.store $0
-  local.get $0
+  local.get $this
   i32.eqz
   if
    global.get $~lib/memory/__stack_pointer
    i32.const 4
    i32.const 3
    call $~lib/rt/itcms/__new
-   local.tee $0
+   local.tee $this
    i32.store $0
   end
-  local.get $0
+  local.get $this
   i32.const 0
   i32.const 2
   i32.const 4
   i32.const 432
   call $~lib/rt/__newArray
   call $field/NoStaticConflict#set:a
-  local.get $0
+  local.get $this
   local.set $3
   global.get $~lib/memory/__stack_pointer
   i32.const 4

--- a/tests/compiler/for.debug.wat
+++ b/tests/compiler/for.debug.wat
@@ -2996,7 +2996,7 @@
    unreachable
   end
  )
- (func $for/Ref#constructor (param $0 i32) (result i32)
+ (func $for/Ref#constructor (param $this i32) (result i32)
   (local $1 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -3006,17 +3006,17 @@
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   i32.store $0
-  local.get $0
+  local.get $this
   i32.eqz
   if
    global.get $~lib/memory/__stack_pointer
    i32.const 0
    i32.const 3
    call $~lib/rt/itcms/__new
-   local.tee $0
+   local.tee $this
    i32.store $0
   end
-  local.get $0
+  local.get $this
   local.set $1
   global.get $~lib/memory/__stack_pointer
   i32.const 4

--- a/tests/compiler/function-call.debug.wat
+++ b/tests/compiler/function-call.debug.wat
@@ -2462,7 +2462,7 @@
   i32.add
   global.set $~lib/memory/__stack_pointer
  )
- (func $function-call/Foo#constructor (param $0 i32) (result i32)
+ (func $function-call/Foo#constructor (param $this i32) (result i32)
   (local $1 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -2472,17 +2472,17 @@
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   i32.store $0
-  local.get $0
+  local.get $this
   i32.eqz
   if
    global.get $~lib/memory/__stack_pointer
    i32.const 0
    i32.const 6
    call $~lib/rt/itcms/__new
-   local.tee $0
+   local.tee $this
    i32.store $0
   end
-  local.get $0
+  local.get $this
   local.set $1
   global.get $~lib/memory/__stack_pointer
   i32.const 4

--- a/tests/compiler/function-expression.debug.wat
+++ b/tests/compiler/function-expression.debug.wat
@@ -2603,8 +2603,8 @@
   end
  )
  (func $function-expression/testField
-  (local $0 i32)
-  (local $1 i32)
+  (local $fieldInst i32)
+  (local $var$1 i32)
   (local $2 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 12
@@ -2626,21 +2626,21 @@
   i32.store $0
   local.get $2
   call $function-expression/FieldClass#constructor
-  local.tee $0
+  local.tee $fieldInst
   i32.store $0 offset=4
   i32.const 1
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   global.set $~argumentsLength
-  local.get $0
+  local.get $fieldInst
   i32.load $0
   i32.load $0
   call_indirect $0 (type $none_=>_i32)
-  local.tee $1
+  local.tee $var$1
   i32.store $0 offset=8
   i32.const 1
   global.set $~argumentsLength
-  local.get $1
+  local.get $var$1
   i32.load $0
   call_indirect $0 (type $i32_=>_i32)
   i32.const 25
@@ -2872,7 +2872,7 @@
   global.set $~lib/memory/__stack_pointer
  )
  (func $function-expression/testGlobal~anonymous|0 (result i32)
-  (local $0 i32)
+  (local $var$0 i32)
   (local $1 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -2884,9 +2884,9 @@
   i32.store $0
   global.get $~lib/memory/__stack_pointer
   i32.const 448
-  local.tee $0
+  local.tee $var$0
   i32.store $0
-  local.get $0
+  local.get $var$0
   local.set $1
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -2895,7 +2895,7 @@
   local.get $1
  )
  (func $function-expression/testLocal~anonymous|0 (result i32)
-  (local $0 i32)
+  (local $var$0 i32)
   (local $1 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -2907,9 +2907,9 @@
   i32.store $0
   global.get $~lib/memory/__stack_pointer
   i32.const 512
-  local.tee $0
+  local.tee $var$0
   i32.store $0
-  local.get $0
+  local.get $var$0
   local.set $1
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -2917,7 +2917,7 @@
   global.set $~lib/memory/__stack_pointer
   local.get $1
  )
- (func $function-expression/FieldClass#constructor (param $0 i32) (param $1 i32) (result i32)
+ (func $function-expression/FieldClass#constructor (param $this i32) (param $fieldFunc i32) (result i32)
   (local $2 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -2927,20 +2927,20 @@
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   i32.store $0
-  local.get $0
+  local.get $this
   i32.eqz
   if
    global.get $~lib/memory/__stack_pointer
    i32.const 4
    i32.const 8
    call $~lib/rt/itcms/__new
-   local.tee $0
+   local.tee $this
    i32.store $0
   end
-  local.get $0
-  local.get $1
+  local.get $this
+  local.get $fieldFunc
   call $function-expression/FieldClass#set:fieldFunc
-  local.get $0
+  local.get $this
   local.set $2
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -2949,7 +2949,7 @@
   local.get $2
  )
  (func $function-expression/testField~anonymous|0 (result i32)
-  (local $0 i32)
+  (local $var$0 i32)
   (local $1 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -2961,9 +2961,9 @@
   i32.store $0
   global.get $~lib/memory/__stack_pointer
   i32.const 976
-  local.tee $0
+  local.tee $var$0
   i32.store $0
-  local.get $0
+  local.get $var$0
   local.set $1
   global.get $~lib/memory/__stack_pointer
   i32.const 4

--- a/tests/compiler/function-types.debug.wat
+++ b/tests/compiler/function-types.debug.wat
@@ -259,7 +259,7 @@
   i32.add
   global.set $~lib/memory/__stack_pointer
  )
- (func $function-types/makeAndAdd<i32>@varargs (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $function-types/makeAndAdd<i32>@varargs (param $a i32) (param $b i32) (param $adder i32) (result i32)
   (local $3 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -281,12 +281,12 @@
    end
    global.get $~lib/memory/__stack_pointer
    call $function-types/makeAdder<i32>
-   local.tee $2
+   local.tee $adder
    i32.store $0
   end
-  local.get $0
-  local.get $1
-  local.get $2
+  local.get $a
+  local.get $b
+  local.get $adder
   call $function-types/makeAndAdd<i32>
   local.set $3
   global.get $~lib/memory/__stack_pointer

--- a/tests/compiler/getter-call.debug.wat
+++ b/tests/compiler/getter-call.debug.wat
@@ -2216,7 +2216,7 @@
    unreachable
   end
  )
- (func $getter-call/C#constructor (param $0 i32) (result i32)
+ (func $getter-call/C#constructor (param $this i32) (result i32)
   (local $1 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -2226,17 +2226,17 @@
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   i32.store $0
-  local.get $0
+  local.get $this
   i32.eqz
   if
    global.get $~lib/memory/__stack_pointer
    i32.const 0
    i32.const 3
    call $~lib/rt/itcms/__new
-   local.tee $0
+   local.tee $this
    i32.store $0
   end
-  local.get $0
+  local.get $this
   local.set $1
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -2245,7 +2245,7 @@
   local.get $1
  )
  (func $getter-call/test (result i32)
-  (local $0 i32)
+  (local $var$0 i32)
   (local $1 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -2258,11 +2258,11 @@
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   call $getter-call/C#constructor
-  local.tee $0
+  local.tee $var$0
   i32.store $0
   i32.const 0
   global.set $~argumentsLength
-  local.get $0
+  local.get $var$0
   call $getter-call/C#get:x
   i32.load $0
   call_indirect $0 (type $none_=>_i32)

--- a/tests/compiler/infer-array.debug.wat
+++ b/tests/compiler/infer-array.debug.wat
@@ -3262,10 +3262,10 @@
    unreachable
   end
  )
- (func $~lib/rt/__newArray (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
-  (local $4 i32)
-  (local $5 i32)
-  (local $6 i32)
+ (func $~lib/rt/__newArray (param $length i32) (param $alignLog2 i32) (param $id i32) (param $data i32) (result i32)
+  (local $bufferSize i32)
+  (local $buffer i32)
+  (local $array i32)
   (local $7 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -3275,38 +3275,38 @@
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   i32.store $0
-  local.get $0
-  local.get $1
+  local.get $length
+  local.get $alignLog2
   i32.shl
-  local.set $4
+  local.set $bufferSize
   global.get $~lib/memory/__stack_pointer
-  local.get $4
+  local.get $bufferSize
   i32.const 0
-  local.get $3
+  local.get $data
   call $~lib/rt/__newBuffer
-  local.tee $5
+  local.tee $buffer
   i32.store $0
   i32.const 16
-  local.get $2
+  local.get $id
   call $~lib/rt/itcms/__new
-  local.set $6
-  local.get $6
-  local.get $5
+  local.set $array
+  local.get $array
+  local.get $buffer
   i32.store $0
-  local.get $6
-  local.get $5
+  local.get $array
+  local.get $buffer
   i32.const 0
   call $~lib/rt/itcms/__link
-  local.get $6
-  local.get $5
+  local.get $array
+  local.get $buffer
   i32.store $0 offset=4
-  local.get $6
-  local.get $4
+  local.get $array
+  local.get $bufferSize
   i32.store $0 offset=8
-  local.get $6
-  local.get $0
+  local.get $array
+  local.get $length
   i32.store $0 offset=12
-  local.get $6
+  local.get $array
   local.set $7
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -3314,7 +3314,7 @@
   global.set $~lib/memory/__stack_pointer
   local.get $7
  )
- (func $infer-array/Ref#constructor (param $0 i32) (result i32)
+ (func $infer-array/Ref#constructor (param $this i32) (result i32)
   (local $1 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -3324,17 +3324,17 @@
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   i32.store $0
-  local.get $0
+  local.get $this
   i32.eqz
   if
    global.get $~lib/memory/__stack_pointer
    i32.const 0
    i32.const 7
    call $~lib/rt/itcms/__new
-   local.tee $0
+   local.tee $this
    i32.store $0
   end
-  local.get $0
+  local.get $this
   local.set $1
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -3342,8 +3342,8 @@
   global.set $~lib/memory/__stack_pointer
   local.get $1
  )
- (func $~lib/array/Array<infer-array/Ref|null>#__get (param $0 i32) (param $1 i32) (result i32)
-  (local $2 i32)
+ (func $~lib/array/Array<infer-array/Ref|null>#__get (param $this i32) (param $index i32) (result i32)
+  (local $value i32)
   (local $3 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -3353,8 +3353,8 @@
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   i32.store $0
-  local.get $1
-  local.get $0
+  local.get $index
+  local.get $this
   i32.load $0 offset=12
   i32.ge_u
   if
@@ -3366,21 +3366,21 @@
    unreachable
   end
   global.get $~lib/memory/__stack_pointer
-  local.get $0
+  local.get $this
   i32.load $0 offset=4
-  local.get $1
+  local.get $index
   i32.const 2
   i32.shl
   i32.add
   i32.load $0
-  local.tee $2
+  local.tee $value
   i32.store $0
   i32.const 1
   drop
   i32.const 1
   i32.eqz
   drop
-  local.get $2
+  local.get $value
   local.set $3
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -3388,8 +3388,8 @@
   global.set $~lib/memory/__stack_pointer
   local.get $3
  )
- (func $~lib/array/Array<~lib/string/String|null>#__get (param $0 i32) (param $1 i32) (result i32)
-  (local $2 i32)
+ (func $~lib/array/Array<~lib/string/String|null>#__get (param $this i32) (param $index i32) (result i32)
+  (local $value i32)
   (local $3 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -3399,8 +3399,8 @@
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   i32.store $0
-  local.get $1
-  local.get $0
+  local.get $index
+  local.get $this
   i32.load $0 offset=12
   i32.ge_u
   if
@@ -3412,21 +3412,21 @@
    unreachable
   end
   global.get $~lib/memory/__stack_pointer
-  local.get $0
+  local.get $this
   i32.load $0 offset=4
-  local.get $1
+  local.get $index
   i32.const 2
   i32.shl
   i32.add
   i32.load $0
-  local.tee $2
+  local.tee $value
   i32.store $0
   i32.const 1
   drop
   i32.const 1
   i32.eqz
   drop
-  local.get $2
+  local.get $value
   local.set $3
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -3434,8 +3434,8 @@
   global.set $~lib/memory/__stack_pointer
   local.get $3
  )
- (func $~lib/array/Array<~lib/array/Array<i32>>#__get (param $0 i32) (param $1 i32) (result i32)
-  (local $2 i32)
+ (func $~lib/array/Array<~lib/array/Array<i32>>#__get (param $this i32) (param $index i32) (result i32)
+  (local $value i32)
   (local $3 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -3445,8 +3445,8 @@
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   i32.store $0
-  local.get $1
-  local.get $0
+  local.get $index
+  local.get $this
   i32.load $0 offset=12
   i32.ge_u
   if
@@ -3458,21 +3458,21 @@
    unreachable
   end
   global.get $~lib/memory/__stack_pointer
-  local.get $0
+  local.get $this
   i32.load $0 offset=4
-  local.get $1
+  local.get $index
   i32.const 2
   i32.shl
   i32.add
   i32.load $0
-  local.tee $2
+  local.tee $value
   i32.store $0
   i32.const 1
   drop
   i32.const 0
   i32.eqz
   drop
-  local.get $2
+  local.get $value
   i32.eqz
   if
    i32.const 976
@@ -3482,7 +3482,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $2
+  local.get $value
   local.set $3
   global.get $~lib/memory/__stack_pointer
   i32.const 4

--- a/tests/compiler/infer-generic.debug.wat
+++ b/tests/compiler/infer-generic.debug.wat
@@ -2518,7 +2518,7 @@
   i32.add
   global.set $~lib/memory/__stack_pointer
  )
- (func $infer-generic/Ref#constructor (param $0 i32) (result i32)
+ (func $infer-generic/Ref#constructor (param $this i32) (result i32)
   (local $1 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -2528,20 +2528,20 @@
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   i32.store $0
-  local.get $0
+  local.get $this
   i32.eqz
   if
    global.get $~lib/memory/__stack_pointer
    i32.const 4
    i32.const 5
    call $~lib/rt/itcms/__new
-   local.tee $0
+   local.tee $this
    i32.store $0
   end
-  local.get $0
+  local.get $this
   i32.const 0
   call $infer-generic/Ref#set:x
-  local.get $0
+  local.get $this
   local.set $1
   global.get $~lib/memory/__stack_pointer
   i32.const 4

--- a/tests/compiler/instanceof-class.debug.wat
+++ b/tests/compiler/instanceof-class.debug.wat
@@ -2309,7 +2309,7 @@
    unreachable
   end
  )
- (func $instanceof-class/Parent<i32>#constructor (param $0 i32) (result i32)
+ (func $instanceof-class/Parent<i32>#constructor (param $this i32) (result i32)
   (local $1 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -2319,17 +2319,17 @@
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   i32.store $0
-  local.get $0
+  local.get $this
   i32.eqz
   if
    global.get $~lib/memory/__stack_pointer
    i32.const 0
    i32.const 4
    call $~lib/rt/itcms/__new
-   local.tee $0
+   local.tee $this
    i32.store $0
   end
-  local.get $0
+  local.get $this
   local.set $1
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -2337,7 +2337,7 @@
   global.set $~lib/memory/__stack_pointer
   local.get $1
  )
- (func $instanceof-class/Child<i32>#constructor (param $0 i32) (result i32)
+ (func $instanceof-class/Child<i32>#constructor (param $this i32) (result i32)
   (local $1 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -2347,22 +2347,22 @@
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   i32.store $0
-  local.get $0
+  local.get $this
   i32.eqz
   if
    global.get $~lib/memory/__stack_pointer
    i32.const 0
    i32.const 3
    call $~lib/rt/itcms/__new
-   local.tee $0
+   local.tee $this
    i32.store $0
   end
   global.get $~lib/memory/__stack_pointer
-  local.get $0
+  local.get $this
   call $instanceof-class/Parent<i32>#constructor
-  local.tee $0
+  local.tee $this
   i32.store $0
-  local.get $0
+  local.get $this
   local.set $1
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -2370,7 +2370,7 @@
   global.set $~lib/memory/__stack_pointer
   local.get $1
  )
- (func $instanceof-class/Parent<f32>#constructor (param $0 i32) (result i32)
+ (func $instanceof-class/Parent<f32>#constructor (param $this i32) (result i32)
   (local $1 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -2380,17 +2380,17 @@
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   i32.store $0
-  local.get $0
+  local.get $this
   i32.eqz
   if
    global.get $~lib/memory/__stack_pointer
    i32.const 0
    i32.const 5
    call $~lib/rt/itcms/__new
-   local.tee $0
+   local.tee $this
    i32.store $0
   end
-  local.get $0
+  local.get $this
   local.set $1
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -2398,7 +2398,7 @@
   global.set $~lib/memory/__stack_pointer
   local.get $1
  )
- (func $instanceof-class/Child<f32>#constructor (param $0 i32) (result i32)
+ (func $instanceof-class/Child<f32>#constructor (param $this i32) (result i32)
   (local $1 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -2408,22 +2408,22 @@
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   i32.store $0
-  local.get $0
+  local.get $this
   i32.eqz
   if
    global.get $~lib/memory/__stack_pointer
    i32.const 0
    i32.const 6
    call $~lib/rt/itcms/__new
-   local.tee $0
+   local.tee $this
    i32.store $0
   end
   global.get $~lib/memory/__stack_pointer
-  local.get $0
+  local.get $this
   call $instanceof-class/Parent<f32>#constructor
-  local.tee $0
+  local.tee $this
   i32.store $0
-  local.get $0
+  local.get $this
   local.set $1
   global.get $~lib/memory/__stack_pointer
   i32.const 4

--- a/tests/compiler/issues/1095.debug.wat
+++ b/tests/compiler/issues/1095.debug.wat
@@ -2341,7 +2341,7 @@
   i32.add
   global.set $~lib/memory/__stack_pointer
  )
- (func $issues/1095/Foo#constructor (param $0 i32) (result i32)
+ (func $issues/1095/Foo#constructor (param $this i32) (result i32)
   (local $1 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -2351,20 +2351,20 @@
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   i32.store $0
-  local.get $0
+  local.get $this
   i32.eqz
   if
    global.get $~lib/memory/__stack_pointer
    i32.const 4
    i32.const 3
    call $~lib/rt/itcms/__new
-   local.tee $0
+   local.tee $this
    i32.store $0
   end
-  local.get $0
+  local.get $this
   i32.const 432
   call $issues/1095/Foo#set:bar
-  local.get $0
+  local.get $this
   local.set $1
   global.get $~lib/memory/__stack_pointer
   i32.const 4

--- a/tests/compiler/issues/1225.debug.wat
+++ b/tests/compiler/issues/1225.debug.wat
@@ -2309,7 +2309,7 @@
    unreachable
   end
  )
- (func $issues/1225/X#constructor (param $0 i32) (param $1 i32) (result i32)
+ (func $issues/1225/X#constructor (param $this i32) (param $x i32) (result i32)
   (local $2 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -2319,33 +2319,33 @@
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   i32.store $0
-  local.get $0
+  local.get $this
   i32.eqz
   if
    global.get $~lib/memory/__stack_pointer
    i32.const 12
    i32.const 3
    call $~lib/rt/itcms/__new
-   local.tee $0
+   local.tee $this
    i32.store $0
   end
-  local.get $0
-  local.get $1
+  local.get $this
+  local.get $x
   call $issues/1225/X#set:x
-  local.get $0
+  local.get $this
   i32.const 0
   call $issues/1225/X#set:normal
-  local.get $0
+  local.get $this
   i32.const 0
   call $issues/1225/X#set:viaThis
-  local.get $0
-  local.get $0
+  local.get $this
+  local.get $this
   i32.load $0 offset=8
   call $issues/1225/X#set:viaThis
-  local.get $0
-  local.get $1
+  local.get $this
+  local.get $x
   call $issues/1225/X#set:normal
-  local.get $0
+  local.get $this
   local.set $2
   global.get $~lib/memory/__stack_pointer
   i32.const 4

--- a/tests/compiler/issues/1699.debug.wat
+++ b/tests/compiler/issues/1699.debug.wat
@@ -2550,10 +2550,10 @@
   end
  )
  (func $issues/1699/test
-  (local $0 i32)
-  (local $1 i32)
-  (local $2 i32)
-  (local $3 i32)
+  (local $testinstances i32)
+  (local $var$1 i32)
+  (local $var$2 i32)
+  (local $var$3 i32)
   (local $4 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 16
@@ -2570,14 +2570,14 @@
   i32.const 0
   i32.const 3
   call $~lib/array/Array<issues/1699/MultiAssignmentTest>#constructor
-  local.tee $0
+  local.tee $testinstances
   i32.store $0
-  local.get $0
+  local.get $testinstances
   i32.const 0
-  local.get $0
-  local.tee $1
+  local.get $testinstances
+  local.tee $var$1
   i32.const 1
-  local.tee $2
+  local.tee $var$2
   i32.const 0
   call $issues/1699/MultiAssignmentTest#constructor
   local.set $4
@@ -2586,8 +2586,8 @@
   i32.store $0 offset=8
   local.get $4
   call $~lib/array/Array<issues/1699/MultiAssignmentTest>#__set
-  local.get $1
-  local.get $2
+  local.get $var$1
+  local.get $var$2
   call $~lib/array/Array<issues/1699/MultiAssignmentTest>#__get
   local.set $4
   global.get $~lib/memory/__stack_pointer
@@ -2596,40 +2596,40 @@
   local.get $4
   call $~lib/array/Array<issues/1699/MultiAssignmentTest>#__set
   i32.const 0
-  local.set $1
+  local.set $var$1
   loop $for-loop|0
-   local.get $1
-   local.get $0
+   local.get $var$1
+   local.get $testinstances
    call $~lib/array/Array<issues/1699/MultiAssignmentTest>#get:length
    i32.lt_s
-   local.set $2
-   local.get $2
+   local.set $var$2
+   local.get $var$2
    if
     global.get $~lib/memory/__stack_pointer
     i32.const 0
     call $issues/1699/MultiAssignmentTest#constructor
-    local.tee $3
+    local.tee $var$3
     i32.store $0 offset=12
-    local.get $1
+    local.get $var$1
     i32.const 1
     i32.gt_s
     if
-     local.get $0
-     local.get $1
-     local.get $3
+     local.get $testinstances
+     local.get $var$1
+     local.get $var$3
      call $~lib/array/Array<issues/1699/MultiAssignmentTest>#__set
     end
-    local.get $1
+    local.get $var$1
     i32.const 1
     i32.add
-    local.set $1
+    local.set $var$1
     br $for-loop|0
    end
   end
-  local.get $0
+  local.get $testinstances
   i32.const 0
   call $~lib/array/Array<issues/1699/MultiAssignmentTest>#__get
-  local.get $0
+  local.get $testinstances
   i32.const 1
   call $~lib/array/Array<issues/1699/MultiAssignmentTest>#__get
   i32.eq
@@ -2642,10 +2642,10 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $0
+  local.get $testinstances
   i32.const 2
   call $~lib/array/Array<issues/1699/MultiAssignmentTest>#__get
-  local.get $0
+  local.get $testinstances
   i32.const 1
   call $~lib/array/Array<issues/1699/MultiAssignmentTest>#__get
   i32.ne
@@ -2663,11 +2663,11 @@
   i32.add
   global.set $~lib/memory/__stack_pointer
  )
- (func $~lib/array/Array<issues/1699/MultiAssignmentTest>#constructor (param $0 i32) (param $1 i32) (result i32)
-  (local $2 i32)
-  (local $3 i32)
-  (local $4 i32)
-  (local $5 i32)
+ (func $~lib/array/Array<issues/1699/MultiAssignmentTest>#constructor (param $this i32) (param $length i32) (result i32)
+  (local $var$2 i32)
+  (local $var$3 i32)
+  (local $bufferSize i32)
+  (local $buffer i32)
   (local $6 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 8
@@ -2677,29 +2677,29 @@
   global.get $~lib/memory/__stack_pointer
   i64.const 0
   i64.store $0
-  local.get $0
+  local.get $this
   i32.eqz
   if
    global.get $~lib/memory/__stack_pointer
    i32.const 16
    i32.const 4
    call $~lib/rt/itcms/__new
-   local.tee $0
+   local.tee $this
    i32.store $0
   end
-  local.get $0
+  local.get $this
   i32.const 0
   call $~lib/array/Array<issues/1699/MultiAssignmentTest>#set:buffer
-  local.get $0
+  local.get $this
   i32.const 0
   call $~lib/array/Array<issues/1699/MultiAssignmentTest>#set:dataStart
-  local.get $0
+  local.get $this
   i32.const 0
   call $~lib/array/Array<issues/1699/MultiAssignmentTest>#set:byteLength
-  local.get $0
+  local.get $this
   i32.const 0
   call $~lib/array/Array<issues/1699/MultiAssignmentTest>#set:length_
-  local.get $1
+  local.get $length
   i32.const 1073741820
   i32.const 2
   i32.shr_u
@@ -2712,40 +2712,40 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $1
-  local.tee $2
+  local.get $length
+  local.tee $var$2
   i32.const 8
-  local.tee $3
-  local.get $2
-  local.get $3
+  local.tee $var$3
+  local.get $var$2
+  local.get $var$3
   i32.gt_u
   select
   i32.const 2
   i32.shl
-  local.set $4
+  local.set $bufferSize
   global.get $~lib/memory/__stack_pointer
-  local.get $4
+  local.get $bufferSize
   i32.const 0
   call $~lib/rt/itcms/__new
-  local.tee $5
+  local.tee $buffer
   i32.store $0 offset=4
   i32.const 2
   global.get $~lib/shared/runtime/Runtime.Incremental
   i32.ne
   drop
-  local.get $0
-  local.get $5
+  local.get $this
+  local.get $buffer
   call $~lib/array/Array<issues/1699/MultiAssignmentTest>#set:buffer
-  local.get $0
-  local.get $5
+  local.get $this
+  local.get $buffer
   call $~lib/array/Array<issues/1699/MultiAssignmentTest>#set:dataStart
-  local.get $0
-  local.get $4
+  local.get $this
+  local.get $bufferSize
   call $~lib/array/Array<issues/1699/MultiAssignmentTest>#set:byteLength
-  local.get $0
-  local.get $1
+  local.get $this
+  local.get $length
   call $~lib/array/Array<issues/1699/MultiAssignmentTest>#set:length_
-  local.get $0
+  local.get $this
   local.set $6
   global.get $~lib/memory/__stack_pointer
   i32.const 8
@@ -2753,7 +2753,7 @@
   global.set $~lib/memory/__stack_pointer
   local.get $6
  )
- (func $issues/1699/MultiAssignmentTest#constructor (param $0 i32) (result i32)
+ (func $issues/1699/MultiAssignmentTest#constructor (param $this i32) (result i32)
   (local $1 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -2763,20 +2763,20 @@
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   i32.store $0
-  local.get $0
+  local.get $this
   i32.eqz
   if
    global.get $~lib/memory/__stack_pointer
    i32.const 4
    i32.const 3
    call $~lib/rt/itcms/__new
-   local.tee $0
+   local.tee $this
    i32.store $0
   end
-  local.get $0
+  local.get $this
   i32.const 2
   call $issues/1699/MultiAssignmentTest#set:test
-  local.get $0
+  local.get $this
   local.set $1
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -2784,8 +2784,8 @@
   global.set $~lib/memory/__stack_pointer
   local.get $1
  )
- (func $~lib/array/Array<issues/1699/MultiAssignmentTest>#__get (param $0 i32) (param $1 i32) (result i32)
-  (local $2 i32)
+ (func $~lib/array/Array<issues/1699/MultiAssignmentTest>#__get (param $this i32) (param $index i32) (result i32)
+  (local $value i32)
   (local $3 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -2795,8 +2795,8 @@
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   i32.store $0
-  local.get $1
-  local.get $0
+  local.get $index
+  local.get $this
   i32.load $0 offset=12
   i32.ge_u
   if
@@ -2808,21 +2808,21 @@
    unreachable
   end
   global.get $~lib/memory/__stack_pointer
-  local.get $0
+  local.get $this
   i32.load $0 offset=4
-  local.get $1
+  local.get $index
   i32.const 2
   i32.shl
   i32.add
   i32.load $0
-  local.tee $2
+  local.tee $value
   i32.store $0
   i32.const 1
   drop
   i32.const 0
   i32.eqz
   drop
-  local.get $2
+  local.get $value
   i32.eqz
   if
    i32.const 528
@@ -2832,7 +2832,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $2
+  local.get $value
   local.set $3
   global.get $~lib/memory/__stack_pointer
   i32.const 4

--- a/tests/compiler/issues/2166.debug.wat
+++ b/tests/compiler/issues/2166.debug.wat
@@ -2339,7 +2339,7 @@
    unreachable
   end
  )
- (func $issues/2166/Test2166Ref1<~lib/string/String>#fn<i32> (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $issues/2166/Test2166Ref1<~lib/string/String>#fn<i32> (param $this i32) (param $a1 i32) (param $a2 i32)
   (local $3 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 8
@@ -2399,7 +2399,7 @@
   global.set $~lib/memory/__stack_pointer
  )
  (func $issues/2166/testfunc2166<i64>
-  (local $0 i32)
+  (local $a i32)
   (local $1 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 8
@@ -2412,9 +2412,9 @@
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   call $issues/2166/Test2166Ref1<~lib/string/String>#constructor
-  local.tee $0
+  local.tee $a
   i32.store $0
-  local.get $0
+  local.get $a
   i32.const 432
   local.set $1
   global.get $~lib/memory/__stack_pointer
@@ -2428,7 +2428,7 @@
   i32.add
   global.set $~lib/memory/__stack_pointer
  )
- (func $issues/2166/Test2166Ref2<i32>#constructor (param $0 i32) (result i32)
+ (func $issues/2166/Test2166Ref2<i32>#constructor (param $this i32) (result i32)
   (local $1 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 12
@@ -2441,14 +2441,14 @@
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   i32.store $0 offset=8
-  local.get $0
+  local.get $this
   i32.eqz
   if
    global.get $~lib/memory/__stack_pointer
    i32.const 0
    i32.const 4
    call $~lib/rt/itcms/__new
-   local.tee $0
+   local.tee $this
    i32.store $0
   end
   i32.const 544
@@ -2473,7 +2473,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $0
+  local.get $this
   local.set $1
   global.get $~lib/memory/__stack_pointer
   i32.const 12
@@ -2481,7 +2481,7 @@
   global.set $~lib/memory/__stack_pointer
   local.get $1
  )
- (func $issues/2166/Test2166Ref2<i32>#bar<~lib/string/String> (param $0 i32) (param $1 i32)
+ (func $issues/2166/Test2166Ref2<i32>#bar<~lib/string/String> (param $this i32) (param $i i32)
   (local $2 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 8
@@ -2565,7 +2565,7 @@
   i32.add
   global.set $~lib/memory/__stack_pointer
  )
- (func $issues/2166/Test2166Ref1<~lib/string/String>#constructor (param $0 i32) (result i32)
+ (func $issues/2166/Test2166Ref1<~lib/string/String>#constructor (param $this i32) (result i32)
   (local $1 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -2575,17 +2575,17 @@
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   i32.store $0
-  local.get $0
+  local.get $this
   i32.eqz
   if
    global.get $~lib/memory/__stack_pointer
    i32.const 0
    i32.const 3
    call $~lib/rt/itcms/__new
-   local.tee $0
+   local.tee $this
    i32.store $0
   end
-  local.get $0
+  local.get $this
   local.set $1
   global.get $~lib/memory/__stack_pointer
   i32.const 4

--- a/tests/compiler/issues/2322/index.debug.wat
+++ b/tests/compiler/issues/2322/index.debug.wat
@@ -2222,7 +2222,7 @@
   i32.add
   global.set $~lib/memory/__stack_pointer
  )
- (func $issues/2322/lib/Wrapper<i32>#constructor (param $0 i32) (result i32)
+ (func $issues/2322/lib/Wrapper<i32>#constructor (param $this i32) (result i32)
   (local $1 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -2232,20 +2232,20 @@
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   i32.store $0
-  local.get $0
+  local.get $this
   i32.eqz
   if
    global.get $~lib/memory/__stack_pointer
    i32.const 4
    i32.const 3
    call $~lib/rt/itcms/__new
-   local.tee $0
+   local.tee $this
    i32.store $0
   end
-  local.get $0
+  local.get $this
   i32.const 0
   call $issues/2322/lib/Wrapper<i32>#set:v
-  local.get $0
+  local.get $this
   local.set $1
   global.get $~lib/memory/__stack_pointer
   i32.const 4

--- a/tests/compiler/logical.debug.wat
+++ b/tests/compiler/logical.debug.wat
@@ -2818,7 +2818,7 @@
   i32.add
   global.set $~lib/memory/__stack_pointer
  )
- (func $logical/Obj#constructor (param $0 i32) (result i32)
+ (func $logical/Obj#constructor (param $this i32) (result i32)
   (local $1 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -2828,17 +2828,17 @@
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   i32.store $0
-  local.get $0
+  local.get $this
   i32.eqz
   if
    global.get $~lib/memory/__stack_pointer
    i32.const 0
    i32.const 3
    call $~lib/rt/itcms/__new
-   local.tee $0
+   local.tee $this
    i32.store $0
   end
-  local.get $0
+  local.get $this
   local.set $1
   global.get $~lib/memory/__stack_pointer
   i32.const 4

--- a/tests/compiler/managed-cast.debug.wat
+++ b/tests/compiler/managed-cast.debug.wat
@@ -2379,8 +2379,8 @@
    unreachable
   end
  )
- (func $managed-cast/testUpcastFromNullable (param $0 i32)
-  (local $1 i32)
+ (func $managed-cast/testUpcastFromNullable (param $cat i32)
+  (local $var$1 i32)
   (local $2 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -2390,10 +2390,10 @@
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   i32.store $0
-  local.get $0
-  local.tee $1
+  local.get $cat
+  local.tee $var$1
   if (result i32)
-   local.get $1
+   local.get $var$1
   else
    i32.const 432
    i32.const 496
@@ -2413,8 +2413,8 @@
   i32.add
   global.set $~lib/memory/__stack_pointer
  )
- (func $managed-cast/testDowncast (param $0 i32)
-  (local $1 i32)
+ (func $managed-cast/testDowncast (param $animal i32)
+  (local $var$1 i32)
   (local $2 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -2424,12 +2424,12 @@
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   i32.store $0
-  local.get $0
-  local.tee $1
+  local.get $animal
+  local.tee $var$1
   i32.const 3
   call $~lib/rt/__instanceof
   if (result i32)
-   local.get $1
+   local.get $var$1
   else
    i32.const 560
    i32.const 496
@@ -2449,8 +2449,8 @@
   i32.add
   global.set $~lib/memory/__stack_pointer
  )
- (func $managed-cast/testDowncastFromNullable (param $0 i32)
-  (local $1 i32)
+ (func $managed-cast/testDowncastFromNullable (param $animal i32)
+  (local $var$1 i32)
   (local $2 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 8
@@ -2461,10 +2461,10 @@
   i64.const 0
   i64.store $0
   global.get $~lib/memory/__stack_pointer
-  local.get $0
-  local.tee $1
+  local.get $animal
+  local.tee $var$1
   if (result i32)
-   local.get $1
+   local.get $var$1
   else
    i32.const 432
    i32.const 496
@@ -2473,13 +2473,13 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.tee $1
+  local.tee $var$1
   i32.store $0 offset=4
-  local.get $1
+  local.get $var$1
   i32.const 3
   call $~lib/rt/__instanceof
   if (result i32)
-   local.get $1
+   local.get $var$1
   else
    i32.const 560
    i32.const 496
@@ -2598,7 +2598,7 @@
   i32.add
   global.set $~lib/memory/__stack_pointer
  )
- (func $managed-cast/Animal#constructor (param $0 i32) (result i32)
+ (func $managed-cast/Animal#constructor (param $this i32) (result i32)
   (local $1 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -2608,17 +2608,17 @@
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   i32.store $0
-  local.get $0
+  local.get $this
   i32.eqz
   if
    global.get $~lib/memory/__stack_pointer
    i32.const 0
    i32.const 4
    call $~lib/rt/itcms/__new
-   local.tee $0
+   local.tee $this
    i32.store $0
   end
-  local.get $0
+  local.get $this
   local.set $1
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -2626,7 +2626,7 @@
   global.set $~lib/memory/__stack_pointer
   local.get $1
  )
- (func $managed-cast/Cat#constructor (param $0 i32) (result i32)
+ (func $managed-cast/Cat#constructor (param $this i32) (result i32)
   (local $1 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -2636,22 +2636,22 @@
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   i32.store $0
-  local.get $0
+  local.get $this
   i32.eqz
   if
    global.get $~lib/memory/__stack_pointer
    i32.const 0
    i32.const 3
    call $~lib/rt/itcms/__new
-   local.tee $0
+   local.tee $this
    i32.store $0
   end
   global.get $~lib/memory/__stack_pointer
-  local.get $0
+  local.get $this
   call $managed-cast/Animal#constructor
-  local.tee $0
+  local.tee $this
   i32.store $0
-  local.get $0
+  local.get $this
   local.set $1
   global.get $~lib/memory/__stack_pointer
   i32.const 4

--- a/tests/compiler/new.debug.wat
+++ b/tests/compiler/new.debug.wat
@@ -2326,7 +2326,7 @@
   i32.add
   global.set $~lib/memory/__stack_pointer
  )
- (func $new/Ref#constructor (param $0 i32) (result i32)
+ (func $new/Ref#constructor (param $this i32) (result i32)
   (local $1 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -2336,17 +2336,17 @@
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   i32.store $0
-  local.get $0
+  local.get $this
   i32.eqz
   if
    global.get $~lib/memory/__stack_pointer
    i32.const 0
    i32.const 3
    call $~lib/rt/itcms/__new
-   local.tee $0
+   local.tee $this
    i32.store $0
   end
-  local.get $0
+  local.get $this
   local.set $1
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -2354,7 +2354,7 @@
   global.set $~lib/memory/__stack_pointer
   local.get $1
  )
- (func $new/Gen<i32>#constructor (param $0 i32) (result i32)
+ (func $new/Gen<i32>#constructor (param $this i32) (result i32)
   (local $1 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -2364,17 +2364,17 @@
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   i32.store $0
-  local.get $0
+  local.get $this
   i32.eqz
   if
    global.get $~lib/memory/__stack_pointer
    i32.const 0
    i32.const 4
    call $~lib/rt/itcms/__new
-   local.tee $0
+   local.tee $this
    i32.store $0
   end
-  local.get $0
+  local.get $this
   local.set $1
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -2382,7 +2382,7 @@
   global.set $~lib/memory/__stack_pointer
   local.get $1
  )
- (func $new/ns.Ref#constructor (param $0 i32) (result i32)
+ (func $new/ns.Ref#constructor (param $this i32) (result i32)
   (local $1 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -2392,17 +2392,17 @@
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   i32.store $0
-  local.get $0
+  local.get $this
   i32.eqz
   if
    global.get $~lib/memory/__stack_pointer
    i32.const 0
    i32.const 5
    call $~lib/rt/itcms/__new
-   local.tee $0
+   local.tee $this
    i32.store $0
   end
-  local.get $0
+  local.get $this
   local.set $1
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -2410,7 +2410,7 @@
   global.set $~lib/memory/__stack_pointer
   local.get $1
  )
- (func $new/GenExt#constructor (param $0 i32) (result i32)
+ (func $new/GenExt#constructor (param $this i32) (result i32)
   (local $1 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -2420,22 +2420,22 @@
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   i32.store $0
-  local.get $0
+  local.get $this
   i32.eqz
   if
    global.get $~lib/memory/__stack_pointer
    i32.const 0
    i32.const 6
    call $~lib/rt/itcms/__new
-   local.tee $0
+   local.tee $this
    i32.store $0
   end
   global.get $~lib/memory/__stack_pointer
-  local.get $0
+  local.get $this
   call $new/Gen<i32>#constructor
-  local.tee $0
+  local.tee $this
   i32.store $0
-  local.get $0
+  local.get $this
   local.set $1
   global.get $~lib/memory/__stack_pointer
   i32.const 4

--- a/tests/compiler/object-literal.debug.wat
+++ b/tests/compiler/object-literal.debug.wat
@@ -2964,7 +2964,7 @@
    unreachable
   end
  )
- (func $object-literal/testManaged (param $0 i32)
+ (func $object-literal/testManaged (param $managed i32)
   (local $1 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 8
@@ -2974,7 +2974,7 @@
   global.get $~lib/memory/__stack_pointer
   i64.const 0
   i64.store $0
-  local.get $0
+  local.get $managed
   i32.load $0
   i32.const 123
   i32.eq
@@ -2987,7 +2987,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $0
+  local.get $managed
   i32.load $0 offset=4
   local.set $1
   global.get $~lib/memory/__stack_pointer
@@ -3015,7 +3015,7 @@
   i32.add
   global.set $~lib/memory/__stack_pointer
  )
- (func $object-literal/testUnmanaged (param $0 i32)
+ (func $object-literal/testUnmanaged (param $unmanaged i32)
   (local $1 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 8
@@ -3025,7 +3025,7 @@
   global.get $~lib/memory/__stack_pointer
   i64.const 0
   i64.store $0
-  local.get $0
+  local.get $unmanaged
   i32.load $0
   i32.const 123
   i32.eq
@@ -3038,7 +3038,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $0
+  local.get $unmanaged
   i32.load $0 offset=4
   local.set $1
   global.get $~lib/memory/__stack_pointer
@@ -3061,14 +3061,14 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $0
+  local.get $unmanaged
   call $~lib/rt/tlsf/__free
   global.get $~lib/memory/__stack_pointer
   i32.const 8
   i32.add
   global.set $~lib/memory/__stack_pointer
  )
- (func $object-literal/testMixedOmitted (param $0 i32)
+ (func $object-literal/testMixedOmitted (param $omitted i32)
   (local $1 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 8
@@ -3078,7 +3078,7 @@
   global.get $~lib/memory/__stack_pointer
   i64.const 0
   i64.store $0
-  local.get $0
+  local.get $omitted
   i32.load $0
   i32.const 0
   i32.eq
@@ -3091,7 +3091,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $0
+  local.get $omitted
   i32.load $0 offset=4
   local.set $1
   global.get $~lib/memory/__stack_pointer
@@ -3114,7 +3114,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $0
+  local.get $omitted
   f64.load $0 offset=8
   f64.const 0
   f64.eq
@@ -3132,7 +3132,7 @@
   i32.add
   global.set $~lib/memory/__stack_pointer
  )
- (func $object-literal/testOmittedFoo (param $0 i32)
+ (func $object-literal/testOmittedFoo (param $foo i32)
   (local $1 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 8
@@ -3142,7 +3142,7 @@
   global.get $~lib/memory/__stack_pointer
   i64.const 0
   i64.store $0
-  local.get $0
+  local.get $foo
   i32.load $0
   local.set $1
   global.get $~lib/memory/__stack_pointer
@@ -3165,7 +3165,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $0
+  local.get $foo
   i32.load $0 offset=4
   local.set $1
   global.get $~lib/memory/__stack_pointer
@@ -3188,7 +3188,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $0
+  local.get $foo
   i32.load $0 offset=8
   local.set $1
   global.get $~lib/memory/__stack_pointer
@@ -3206,7 +3206,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $0
+  local.get $foo
   i32.load $0 offset=12
   local.set $1
   global.get $~lib/memory/__stack_pointer
@@ -3224,7 +3224,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $0
+  local.get $foo
   i32.load $0 offset=16
   local.set $1
   global.get $~lib/memory/__stack_pointer
@@ -3242,7 +3242,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $0
+  local.get $foo
   i32.load $0 offset=20
   local.set $1
   global.get $~lib/memory/__stack_pointer
@@ -3260,7 +3260,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $0
+  local.get $foo
   i32.load $0 offset=24
   local.set $1
   global.get $~lib/memory/__stack_pointer
@@ -3278,7 +3278,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $0
+  local.get $foo
   i32.load $0 offset=28
   local.set $1
   global.get $~lib/memory/__stack_pointer
@@ -3296,7 +3296,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $0
+  local.get $foo
   i32.load $0 offset=32
   i32.const 0
   i32.eq
@@ -3309,7 +3309,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $0
+  local.get $foo
   i32.load $0 offset=36
   i32.const -1
   i32.eq
@@ -3512,7 +3512,7 @@
   i32.add
   global.set $~lib/memory/__stack_pointer
  )
- (func $object-literal/Managed#constructor (param $0 i32) (result i32)
+ (func $object-literal/Managed#constructor (param $this i32) (result i32)
   (local $1 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -3522,23 +3522,23 @@
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   i32.store $0
-  local.get $0
+  local.get $this
   i32.eqz
   if
    global.get $~lib/memory/__stack_pointer
    i32.const 8
    i32.const 3
    call $~lib/rt/itcms/__new
-   local.tee $0
+   local.tee $this
    i32.store $0
   end
-  local.get $0
+  local.get $this
   i32.const 0
   call $object-literal/Managed#set:bar
-  local.get $0
+  local.get $this
   i32.const 0
   call $object-literal/Managed#set:baz
-  local.get $0
+  local.get $this
   local.set $1
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -3546,16 +3546,16 @@
   global.set $~lib/memory/__stack_pointer
   local.get $1
  )
- (func $~lib/string/String#substring (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
-  (local $3 i32)
-  (local $4 i32)
-  (local $5 i32)
-  (local $6 i32)
-  (local $7 i32)
-  (local $8 i32)
-  (local $9 i32)
-  (local $10 i32)
-  (local $11 i32)
+ (func $~lib/string/String#substring (param $this i32) (param $start i32) (param $end i32) (result i32)
+  (local $len i32)
+  (local $var$4 i32)
+  (local $var$5 i32)
+  (local $finalStart i32)
+  (local $finalEnd i32)
+  (local $fromPos i32)
+  (local $toPos i32)
+  (local $size i32)
+  (local $out i32)
   (local $12 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -3565,68 +3565,68 @@
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   i32.store $0
-  local.get $0
+  local.get $this
   call $~lib/string/String#get:length
-  local.set $3
-  local.get $1
-  local.tee $4
+  local.set $len
+  local.get $start
+  local.tee $var$4
   i32.const 0
-  local.tee $5
-  local.get $4
-  local.get $5
+  local.tee $var$5
+  local.get $var$4
+  local.get $var$5
   i32.gt_s
   select
-  local.tee $5
-  local.get $3
-  local.tee $4
-  local.get $5
-  local.get $4
+  local.tee $var$5
+  local.get $len
+  local.tee $var$4
+  local.get $var$5
+  local.get $var$4
   i32.lt_s
   select
-  local.set $6
-  local.get $2
-  local.tee $4
+  local.set $finalStart
+  local.get $end
+  local.tee $var$4
   i32.const 0
-  local.tee $5
-  local.get $4
-  local.get $5
+  local.tee $var$5
+  local.get $var$4
+  local.get $var$5
   i32.gt_s
   select
-  local.tee $5
-  local.get $3
-  local.tee $4
-  local.get $5
-  local.get $4
+  local.tee $var$5
+  local.get $len
+  local.tee $var$4
+  local.get $var$5
+  local.get $var$4
   i32.lt_s
   select
-  local.set $7
-  local.get $6
-  local.tee $4
-  local.get $7
-  local.tee $5
-  local.get $4
-  local.get $5
+  local.set $finalEnd
+  local.get $finalStart
+  local.tee $var$4
+  local.get $finalEnd
+  local.tee $var$5
+  local.get $var$4
+  local.get $var$5
   i32.lt_s
   select
   i32.const 1
   i32.shl
-  local.set $8
-  local.get $6
-  local.tee $5
-  local.get $7
-  local.tee $4
-  local.get $5
-  local.get $4
+  local.set $fromPos
+  local.get $finalStart
+  local.tee $var$5
+  local.get $finalEnd
+  local.tee $var$4
+  local.get $var$5
+  local.get $var$4
   i32.gt_s
   select
   i32.const 1
   i32.shl
-  local.set $9
-  local.get $9
-  local.get $8
+  local.set $toPos
+  local.get $toPos
+  local.get $fromPos
   i32.sub
-  local.set $10
-  local.get $10
+  local.set $size
+  local.get $size
   i32.eqz
   if
    i32.const 544
@@ -3638,11 +3638,11 @@
    local.get $12
    return
   end
-  local.get $8
+  local.get $fromPos
   i32.eqz
   if (result i32)
-   local.get $9
-   local.get $3
+   local.get $toPos
+   local.get $len
    i32.const 1
    i32.shl
    i32.eq
@@ -3650,7 +3650,7 @@
    i32.const 0
   end
   if
-   local.get $0
+   local.get $this
    local.set $12
    global.get $~lib/memory/__stack_pointer
    i32.const 4
@@ -3660,18 +3660,18 @@
    return
   end
   global.get $~lib/memory/__stack_pointer
-  local.get $10
+  local.get $size
   i32.const 1
   call $~lib/rt/itcms/__new
-  local.tee $11
+  local.tee $out
   i32.store $0
-  local.get $11
-  local.get $0
-  local.get $8
+  local.get $out
+  local.get $this
+  local.get $fromPos
   i32.add
-  local.get $10
+  local.get $size
   memory.copy $0 $0
-  local.get $11
+  local.get $out
   local.set $12
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -3679,7 +3679,7 @@
   global.set $~lib/memory/__stack_pointer
   local.get $12
  )
- (func $object-literal/OmittedTypes#constructor (param $0 i32) (result i32)
+ (func $object-literal/OmittedTypes#constructor (param $this i32) (result i32)
   (local $1 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -3689,59 +3689,59 @@
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   i32.store $0
-  local.get $0
+  local.get $this
   i32.eqz
   if
    global.get $~lib/memory/__stack_pointer
    i32.const 65
    i32.const 4
    call $~lib/rt/itcms/__new
-   local.tee $0
+   local.tee $this
    i32.store $0
   end
-  local.get $0
+  local.get $this
   i32.const 0
   call $object-literal/OmittedTypes#set:int32
-  local.get $0
+  local.get $this
   i32.const 0
   call $object-literal/OmittedTypes#set:uint32
-  local.get $0
+  local.get $this
   i64.const 0
   call $object-literal/OmittedTypes#set:int64
-  local.get $0
+  local.get $this
   i64.const 0
   call $object-literal/OmittedTypes#set:uint64
-  local.get $0
+  local.get $this
   f32.const 0
   call $object-literal/OmittedTypes#set:float32
-  local.get $0
+  local.get $this
   f64.const 0
   call $object-literal/OmittedTypes#set:float64
-  local.get $0
+  local.get $this
   i32.const 0
   call $object-literal/OmittedTypes#set:int8
-  local.get $0
+  local.get $this
   i32.const 0
   call $object-literal/OmittedTypes#set:uint8
-  local.get $0
+  local.get $this
   i32.const 0
   call $object-literal/OmittedTypes#set:int16
-  local.get $0
+  local.get $this
   i32.const 0
   call $object-literal/OmittedTypes#set:uint16
-  local.get $0
+  local.get $this
   i32.const 0
   call $object-literal/OmittedTypes#set:intsize
-  local.get $0
+  local.get $this
   i32.const 0
   call $object-literal/OmittedTypes#set:uintsize
-  local.get $0
+  local.get $this
   f64.const 0
   call $object-literal/OmittedTypes#set:alias
-  local.get $0
+  local.get $this
   i32.const 0
   call $object-literal/OmittedTypes#set:isTrue
-  local.get $0
+  local.get $this
   local.set $1
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -3749,7 +3749,7 @@
   global.set $~lib/memory/__stack_pointer
   local.get $1
  )
- (func $object-literal/MixedOmitted#constructor (param $0 i32) (result i32)
+ (func $object-literal/MixedOmitted#constructor (param $this i32) (result i32)
   (local $1 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -3759,26 +3759,26 @@
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   i32.store $0
-  local.get $0
+  local.get $this
   i32.eqz
   if
    global.get $~lib/memory/__stack_pointer
    i32.const 16
    i32.const 5
    call $~lib/rt/itcms/__new
-   local.tee $0
+   local.tee $this
    i32.store $0
   end
-  local.get $0
+  local.get $this
   i32.const 0
   call $object-literal/MixedOmitted#set:simpleType
-  local.get $0
+  local.get $this
   i32.const 0
   call $object-literal/MixedOmitted#set:complexType
-  local.get $0
+  local.get $this
   f64.const 0
   call $object-literal/MixedOmitted#set:anotherSimpleType
-  local.get $0
+  local.get $this
   local.set $1
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -3786,7 +3786,7 @@
   global.set $~lib/memory/__stack_pointer
   local.get $1
  )
- (func $object-literal/OmittedFoo#constructor (param $0 i32) (result i32)
+ (func $object-literal/OmittedFoo#constructor (param $this i32) (result i32)
   (local $1 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -3796,47 +3796,47 @@
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   i32.store $0
-  local.get $0
+  local.get $this
   i32.eqz
   if
    global.get $~lib/memory/__stack_pointer
    i32.const 40
    i32.const 6
    call $~lib/rt/itcms/__new
-   local.tee $0
+   local.tee $this
    i32.store $0
   end
-  local.get $0
+  local.get $this
   i32.const 640
   call $object-literal/OmittedFoo#set:bar
-  local.get $0
+  local.get $this
   i32.const 672
   call $object-literal/OmittedFoo#set:baz
-  local.get $0
+  local.get $this
   i32.const 0
   call $object-literal/OmittedFoo#set:quux
-  local.get $0
+  local.get $this
   i32.const 0
   call $object-literal/OmittedFoo#set:quuz
-  local.get $0
+  local.get $this
   i32.const 0
   call $object-literal/OmittedFoo#set:corge
-  local.get $0
+  local.get $this
   i32.const 0
   call $object-literal/OmittedFoo#set:grault
-  local.get $0
+  local.get $this
   i32.const 0
   call $object-literal/OmittedFoo#set:garply
-  local.get $0
+  local.get $this
   i32.const 0
   call $object-literal/OmittedFoo#set:waldo
-  local.get $0
+  local.get $this
   i32.const 0
   call $object-literal/OmittedFoo#set:fred
-  local.get $0
+  local.get $this
   i32.const -1
   call $object-literal/OmittedFoo#set:qux
-  local.get $0
+  local.get $this
   local.set $1
   global.get $~lib/memory/__stack_pointer
   i32.const 4

--- a/tests/compiler/optional-typeparameters.debug.wat
+++ b/tests/compiler/optional-typeparameters.debug.wat
@@ -2388,7 +2388,7 @@
   i32.add
   global.set $~lib/memory/__stack_pointer
  )
- (func $optional-typeparameters/TestConcrete<i32,i32>#constructor (param $0 i32) (result i32)
+ (func $optional-typeparameters/TestConcrete<i32,i32>#constructor (param $this i32) (result i32)
   (local $1 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -2398,17 +2398,17 @@
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   i32.store $0
-  local.get $0
+  local.get $this
   i32.eqz
   if
    global.get $~lib/memory/__stack_pointer
    i32.const 0
    i32.const 3
    call $~lib/rt/itcms/__new
-   local.tee $0
+   local.tee $this
    i32.store $0
   end
-  local.get $0
+  local.get $this
   local.set $1
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -2416,7 +2416,7 @@
   global.set $~lib/memory/__stack_pointer
   local.get $1
  )
- (func $optional-typeparameters/TestDerived<f64,f64>#constructor (param $0 i32) (result i32)
+ (func $optional-typeparameters/TestDerived<f64,f64>#constructor (param $this i32) (result i32)
   (local $1 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -2426,17 +2426,17 @@
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   i32.store $0
-  local.get $0
+  local.get $this
   i32.eqz
   if
    global.get $~lib/memory/__stack_pointer
    i32.const 0
    i32.const 4
    call $~lib/rt/itcms/__new
-   local.tee $0
+   local.tee $this
    i32.store $0
   end
-  local.get $0
+  local.get $this
   local.set $1
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -2444,7 +2444,7 @@
   global.set $~lib/memory/__stack_pointer
   local.get $1
  )
- (func $optional-typeparameters/TestMethodDerived<~lib/string/String>#constructor (param $0 i32) (result i32)
+ (func $optional-typeparameters/TestMethodDerived<~lib/string/String>#constructor (param $this i32) (result i32)
   (local $1 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -2454,17 +2454,17 @@
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   i32.store $0
-  local.get $0
+  local.get $this
   i32.eqz
   if
    global.get $~lib/memory/__stack_pointer
    i32.const 0
    i32.const 5
    call $~lib/rt/itcms/__new
-   local.tee $0
+   local.tee $this
    i32.store $0
   end
-  local.get $0
+  local.get $this
   local.set $1
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -2472,7 +2472,7 @@
   global.set $~lib/memory/__stack_pointer
   local.get $1
  )
- (func $optional-typeparameters/TestMethodDerived2<f64>#constructor (param $0 i32) (result i32)
+ (func $optional-typeparameters/TestMethodDerived2<f64>#constructor (param $this i32) (result i32)
   (local $1 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -2482,17 +2482,17 @@
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   i32.store $0
-  local.get $0
+  local.get $this
   i32.eqz
   if
    global.get $~lib/memory/__stack_pointer
    i32.const 0
    i32.const 7
    call $~lib/rt/itcms/__new
-   local.tee $0
+   local.tee $this
    i32.store $0
   end
-  local.get $0
+  local.get $this
   local.set $1
   global.get $~lib/memory/__stack_pointer
   i32.const 4

--- a/tests/compiler/reexport.debug.wat
+++ b/tests/compiler/reexport.debug.wat
@@ -2327,7 +2327,7 @@
   i32.add
   global.set $~lib/memory/__stack_pointer
  )
- (func $exports/Car#constructor (param $0 i32) (param $1 i32) (result i32)
+ (func $exports/Car#constructor (param $this i32) (param $doors i32) (result i32)
   (local $2 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -2337,23 +2337,23 @@
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   i32.store $0
-  local.get $0
+  local.get $this
   i32.eqz
   if
    global.get $~lib/memory/__stack_pointer
    i32.const 4
    i32.const 3
    call $~lib/rt/itcms/__new
-   local.tee $0
+   local.tee $this
    i32.store $0
   end
-  local.get $0
-  local.get $1
+  local.get $this
+  local.get $doors
   call $exports/Car#set:doors
-  local.get $0
-  local.get $1
+  local.get $this
+  local.get $doors
   call $exports/Car#set:doors
-  local.get $0
+  local.get $this
   local.set $2
   global.get $~lib/memory/__stack_pointer
   i32.const 4

--- a/tests/compiler/rereexport.debug.wat
+++ b/tests/compiler/rereexport.debug.wat
@@ -2445,7 +2445,7 @@
   i32.add
   global.set $~lib/memory/__stack_pointer
  )
- (func $exports/Car#constructor (param $0 i32) (param $1 i32) (result i32)
+ (func $exports/Car#constructor (param $this i32) (param $doors i32) (result i32)
   (local $2 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -2455,23 +2455,23 @@
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   i32.store $0
-  local.get $0
+  local.get $this
   i32.eqz
   if
    global.get $~lib/memory/__stack_pointer
    i32.const 4
    i32.const 3
    call $~lib/rt/itcms/__new
-   local.tee $0
+   local.tee $this
    i32.store $0
   end
-  local.get $0
-  local.get $1
+  local.get $this
+  local.get $doors
   call $exports/Car#set:doors
-  local.get $0
-  local.get $1
+  local.get $this
+  local.get $doors
   call $exports/Car#set:doors
-  local.get $0
+  local.get $this
   local.set $2
   global.get $~lib/memory/__stack_pointer
   i32.const 4

--- a/tests/compiler/resolve-access.debug.wat
+++ b/tests/compiler/resolve-access.debug.wat
@@ -2977,10 +2977,10 @@
    unreachable
   end
  )
- (func $~lib/rt/__newArray (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
-  (local $4 i32)
-  (local $5 i32)
-  (local $6 i32)
+ (func $~lib/rt/__newArray (param $length i32) (param $alignLog2 i32) (param $id i32) (param $data i32) (result i32)
+  (local $bufferSize i32)
+  (local $buffer i32)
+  (local $array i32)
   (local $7 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -2990,38 +2990,38 @@
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   i32.store $0
-  local.get $0
-  local.get $1
+  local.get $length
+  local.get $alignLog2
   i32.shl
-  local.set $4
+  local.set $bufferSize
   global.get $~lib/memory/__stack_pointer
-  local.get $4
+  local.get $bufferSize
   i32.const 0
-  local.get $3
+  local.get $data
   call $~lib/rt/__newBuffer
-  local.tee $5
+  local.tee $buffer
   i32.store $0
   i32.const 16
-  local.get $2
+  local.get $id
   call $~lib/rt/itcms/__new
-  local.set $6
-  local.get $6
-  local.get $5
+  local.set $array
+  local.get $array
+  local.get $buffer
   i32.store $0
-  local.get $6
-  local.get $5
+  local.get $array
+  local.get $buffer
   i32.const 0
   call $~lib/rt/itcms/__link
-  local.get $6
-  local.get $5
+  local.get $array
+  local.get $buffer
   i32.store $0 offset=4
-  local.get $6
-  local.get $4
+  local.get $array
+  local.get $bufferSize
   i32.store $0 offset=8
-  local.get $6
-  local.get $0
+  local.get $array
+  local.get $length
   i32.store $0 offset=12
-  local.get $6
+  local.get $array
   local.set $7
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -3029,14 +3029,14 @@
   global.set $~lib/memory/__stack_pointer
   local.get $7
  )
- (func $~lib/util/number/utoa64 (param $0 i64) (param $1 i32) (result i32)
-  (local $2 i32)
-  (local $3 i32)
-  (local $4 i32)
-  (local $5 i32)
-  (local $6 i32)
-  (local $7 i32)
-  (local $8 i64)
+ (func $~lib/util/number/utoa64 (param $value i64) (param $radix i32) (result i32)
+  (local $out i32)
+  (local $var$3 i32)
+  (local $var$4 i32)
+  (local $var$5 i32)
+  (local $var$6 i32)
+  (local $var$7 i32)
+  (local $var$8 i64)
   (local $9 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -3046,13 +3046,13 @@
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   i32.store $0
-  local.get $1
+  local.get $radix
   i32.const 2
   i32.lt_s
   if (result i32)
    i32.const 1
   else
-   local.get $1
+   local.get $radix
    i32.const 36
    i32.gt_s
   end
@@ -3064,7 +3064,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $0
+  local.get $value
   i64.const 0
   i64.ne
   i32.eqz
@@ -3078,77 +3078,77 @@
    local.get $9
    return
   end
-  local.get $1
+  local.get $radix
   i32.const 10
   i32.eq
   if
-   local.get $0
+   local.get $value
    global.get $~lib/builtins/u32.MAX_VALUE
    i64.extend_i32_u
    i64.le_u
    if
-    local.get $0
+    local.get $value
     i32.wrap_i64
-    local.set $3
-    local.get $3
+    local.set $var$3
+    local.get $var$3
     call $~lib/util/number/decimalCount32
-    local.set $4
+    local.set $var$4
     global.get $~lib/memory/__stack_pointer
-    local.get $4
+    local.get $var$4
     i32.const 1
     i32.shl
     i32.const 1
     call $~lib/rt/itcms/__new
-    local.tee $2
+    local.tee $out
     i32.store $0
-    local.get $2
-    local.set $7
-    local.get $3
-    local.set $6
-    local.get $4
-    local.set $5
+    local.get $out
+    local.set $var$7
+    local.get $var$3
+    local.set $var$6
+    local.get $var$4
+    local.set $var$5
     i32.const 0
     i32.const 1
     i32.ge_s
     drop
-    local.get $7
-    local.get $6
-    local.get $5
+    local.get $var$7
+    local.get $var$6
+    local.get $var$5
     call $~lib/util/number/utoa32_dec_lut
    else
-    local.get $0
+    local.get $value
     call $~lib/util/number/decimalCount64High
-    local.set $4
+    local.set $var$4
     global.get $~lib/memory/__stack_pointer
-    local.get $4
+    local.get $var$4
     i32.const 1
     i32.shl
     i32.const 1
     call $~lib/rt/itcms/__new
-    local.tee $2
+    local.tee $out
     i32.store $0
-    local.get $2
-    local.set $6
-    local.get $0
-    local.set $8
-    local.get $4
-    local.set $5
+    local.get $out
+    local.set $var$6
+    local.get $value
+    local.set $var$8
+    local.get $var$4
+    local.set $var$5
     i32.const 0
     i32.const 1
     i32.ge_s
     drop
-    local.get $6
-    local.get $8
-    local.get $5
+    local.get $var$6
+    local.get $var$8
+    local.get $var$5
     call $~lib/util/number/utoa64_dec_lut
    end
   else
-   local.get $1
+   local.get $radix
    i32.const 16
    i32.eq
    if
     i32.const 63
-    local.get $0
+    local.get $value
     i64.clz
     i32.wrap_i64
     i32.sub
@@ -3156,50 +3156,50 @@
     i32.shr_s
     i32.const 1
     i32.add
-    local.set $4
+    local.set $var$4
     global.get $~lib/memory/__stack_pointer
-    local.get $4
+    local.get $var$4
     i32.const 1
     i32.shl
     i32.const 1
     call $~lib/rt/itcms/__new
-    local.tee $2
+    local.tee $out
     i32.store $0
-    local.get $2
-    local.set $3
-    local.get $0
-    local.set $8
-    local.get $4
-    local.set $7
+    local.get $out
+    local.set $var$3
+    local.get $value
+    local.set $var$8
+    local.get $var$4
+    local.set $var$7
     i32.const 0
     i32.const 1
     i32.ge_s
     drop
-    local.get $3
-    local.get $8
-    local.get $7
+    local.get $var$3
+    local.get $var$8
+    local.get $var$7
     call $~lib/util/number/utoa_hex_lut
    else
-    local.get $0
-    local.get $1
+    local.get $value
+    local.get $radix
     call $~lib/util/number/ulog_base
-    local.set $4
+    local.set $var$4
     global.get $~lib/memory/__stack_pointer
-    local.get $4
+    local.get $var$4
     i32.const 1
     i32.shl
     i32.const 1
     call $~lib/rt/itcms/__new
-    local.tee $2
+    local.tee $out
     i32.store $0
-    local.get $2
-    local.get $0
-    local.get $4
-    local.get $1
+    local.get $out
+    local.get $value
+    local.get $var$4
+    local.get $radix
     call $~lib/util/number/utoa64_any_core
    end
   end
-  local.get $2
+  local.get $out
   local.set $9
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -3208,8 +3208,8 @@
   local.get $9
  )
  (func $resolve-access/arrayAccess (result i32)
-  (local $0 i32)
-  (local $1 i32)
+  (local $var$0 i32)
+  (local $var$1 i32)
   (local $2 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -3225,9 +3225,9 @@
   i32.const 3
   i32.const 32
   call $~lib/rt/__newArray
-  local.tee $1
+  local.tee $var$1
   i32.store $0
-  local.get $1
+  local.get $var$1
   i32.const 0
   call $~lib/array/Array<u64>#__get
   i32.const 10
@@ -3239,7 +3239,7 @@
   global.set $~lib/memory/__stack_pointer
   local.get $2
  )
- (func $resolve-access/Container#constructor (param $0 i32) (result i32)
+ (func $resolve-access/Container#constructor (param $this i32) (result i32)
   (local $1 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -3249,20 +3249,20 @@
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   i32.store $0
-  local.get $0
+  local.get $this
   i32.eqz
   if
    global.get $~lib/memory/__stack_pointer
    i32.const 8
    i32.const 5
    call $~lib/rt/itcms/__new
-   local.tee $0
+   local.tee $this
    i32.store $0
   end
-  local.get $0
+  local.get $this
   i64.const 0
   call $resolve-access/Container#set:foo
-  local.get $0
+  local.get $this
   local.set $1
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -3271,7 +3271,7 @@
   local.get $1
  )
  (func $resolve-access/fieldAccess (result i32)
-  (local $0 i32)
+  (local $var$0 i32)
   (local $1 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -3284,12 +3284,12 @@
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   call $resolve-access/Container#constructor
-  local.tee $0
+  local.tee $var$0
   i32.store $0
-  local.get $0
+  local.get $var$0
   i64.const 1
   call $resolve-access/Container#set:foo
-  local.get $0
+  local.get $var$0
   i64.load $0
   i32.const 10
   call $~lib/number/U64#toString
@@ -3300,12 +3300,12 @@
   global.set $~lib/memory/__stack_pointer
   local.get $1
  )
- (func $~lib/util/number/utoa32 (param $0 i32) (param $1 i32) (result i32)
-  (local $2 i32)
-  (local $3 i32)
-  (local $4 i32)
-  (local $5 i32)
-  (local $6 i32)
+ (func $~lib/util/number/utoa32 (param $value i32) (param $radix i32) (result i32)
+  (local $out i32)
+  (local $var$3 i32)
+  (local $var$4 i32)
+  (local $var$5 i32)
+  (local $var$6 i32)
   (local $7 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -3315,13 +3315,13 @@
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   i32.store $0
-  local.get $1
+  local.get $radix
   i32.const 2
   i32.lt_s
   if (result i32)
    i32.const 1
   else
-   local.get $1
+   local.get $radix
    i32.const 36
    i32.gt_s
   end
@@ -3333,7 +3333,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $0
+  local.get $value
   i32.eqz
   if
    i32.const 704
@@ -3345,95 +3345,95 @@
    local.get $7
    return
   end
-  local.get $1
+  local.get $radix
   i32.const 10
   i32.eq
   if
-   local.get $0
+   local.get $value
    call $~lib/util/number/decimalCount32
-   local.set $3
+   local.set $var$3
    global.get $~lib/memory/__stack_pointer
-   local.get $3
+   local.get $var$3
    i32.const 1
    i32.shl
    i32.const 1
    call $~lib/rt/itcms/__new
-   local.tee $2
+   local.tee $out
    i32.store $0
-   local.get $2
-   local.set $6
-   local.get $0
-   local.set $5
-   local.get $3
-   local.set $4
+   local.get $out
+   local.set $var$6
+   local.get $value
+   local.set $var$5
+   local.get $var$3
+   local.set $var$4
    i32.const 0
    i32.const 1
    i32.ge_s
    drop
-   local.get $6
-   local.get $5
-   local.get $4
+   local.get $var$6
+   local.get $var$5
+   local.get $var$4
    call $~lib/util/number/utoa32_dec_lut
   else
-   local.get $1
+   local.get $radix
    i32.const 16
    i32.eq
    if
     i32.const 31
-    local.get $0
+    local.get $value
     i32.clz
     i32.sub
     i32.const 2
     i32.shr_s
     i32.const 1
     i32.add
-    local.set $3
+    local.set $var$3
     global.get $~lib/memory/__stack_pointer
-    local.get $3
+    local.get $var$3
     i32.const 1
     i32.shl
     i32.const 1
     call $~lib/rt/itcms/__new
-    local.tee $2
+    local.tee $out
     i32.store $0
-    local.get $2
-    local.set $6
-    local.get $0
-    local.set $5
-    local.get $3
-    local.set $4
+    local.get $out
+    local.set $var$6
+    local.get $value
+    local.set $var$5
+    local.get $var$3
+    local.set $var$4
     i32.const 0
     i32.const 1
     i32.ge_s
     drop
-    local.get $6
-    local.get $5
+    local.get $var$6
+    local.get $var$5
     i64.extend_i32_u
-    local.get $4
+    local.get $var$4
     call $~lib/util/number/utoa_hex_lut
    else
-    local.get $0
+    local.get $value
     i64.extend_i32_u
-    local.get $1
+    local.get $radix
     call $~lib/util/number/ulog_base
-    local.set $3
+    local.set $var$3
     global.get $~lib/memory/__stack_pointer
-    local.get $3
+    local.get $var$3
     i32.const 1
     i32.shl
     i32.const 1
     call $~lib/rt/itcms/__new
-    local.tee $2
+    local.tee $out
     i32.store $0
-    local.get $2
-    local.get $0
+    local.get $out
+    local.get $value
     i64.extend_i32_u
-    local.get $3
-    local.get $1
+    local.get $var$3
+    local.get $radix
     call $~lib/util/number/utoa64_any_core
    end
   end
-  local.get $2
+  local.get $out
   local.set $7
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -3442,7 +3442,7 @@
   local.get $7
  )
  (func $resolve-access/propertyAccess (result i32)
-  (local $0 i32)
+  (local $var$0 i32)
   (local $1 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -3455,12 +3455,12 @@
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   call $resolve-access/Container#constructor
-  local.tee $0
+  local.tee $var$0
   i32.store $0
-  local.get $0
+  local.get $var$0
   i64.const 1
   call $resolve-access/Container#set:foo
-  local.get $0
+  local.get $var$0
   call $resolve-access/Container#toU32
   i32.const 10
   call $~lib/number/U32#toString

--- a/tests/compiler/resolve-binary.debug.wat
+++ b/tests/compiler/resolve-binary.debug.wat
@@ -7010,13 +7010,13 @@
   i32.add
   global.set $~lib/memory/__stack_pointer
  )
- (func $~lib/util/number/itoa32 (param $0 i32) (param $1 i32) (result i32)
-  (local $2 i32)
-  (local $3 i32)
-  (local $4 i32)
-  (local $5 i32)
-  (local $6 i32)
-  (local $7 i32)
+ (func $~lib/util/number/itoa32 (param $value i32) (param $radix i32) (result i32)
+  (local $sign i32)
+  (local $out i32)
+  (local $var$4 i32)
+  (local $var$5 i32)
+  (local $var$6 i32)
+  (local $var$7 i32)
   (local $8 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -7026,13 +7026,13 @@
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   i32.store $0
-  local.get $1
+  local.get $radix
   i32.const 2
   i32.lt_s
   if (result i32)
    i32.const 1
   else
-   local.get $1
+   local.get $radix
    i32.const 36
    i32.gt_s
   end
@@ -7044,7 +7044,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $0
+  local.get $value
   i32.eqz
   if
    i32.const 352
@@ -7056,128 +7056,128 @@
    local.get $8
    return
   end
-  local.get $0
+  local.get $value
   i32.const 31
   i32.shr_u
   i32.const 1
   i32.shl
-  local.set $2
-  local.get $2
+  local.set $sign
+  local.get $sign
   if
    i32.const 0
-   local.get $0
+   local.get $value
    i32.sub
-   local.set $0
+   local.set $value
   end
-  local.get $1
+  local.get $radix
   i32.const 10
   i32.eq
   if
-   local.get $0
+   local.get $value
    call $~lib/util/number/decimalCount32
-   local.set $4
+   local.set $var$4
    global.get $~lib/memory/__stack_pointer
-   local.get $4
+   local.get $var$4
    i32.const 1
    i32.shl
-   local.get $2
+   local.get $sign
    i32.add
    i32.const 1
    call $~lib/rt/itcms/__new
-   local.tee $3
+   local.tee $out
    i32.store $0
-   local.get $3
-   local.get $2
+   local.get $out
+   local.get $sign
    i32.add
-   local.set $7
-   local.get $0
-   local.set $6
-   local.get $4
-   local.set $5
+   local.set $var$7
+   local.get $value
+   local.set $var$6
+   local.get $var$4
+   local.set $var$5
    i32.const 0
    i32.const 1
    i32.ge_s
    drop
-   local.get $7
-   local.get $6
-   local.get $5
+   local.get $var$7
+   local.get $var$6
+   local.get $var$5
    call $~lib/util/number/utoa32_dec_lut
   else
-   local.get $1
+   local.get $radix
    i32.const 16
    i32.eq
    if
     i32.const 31
-    local.get $0
+    local.get $value
     i32.clz
     i32.sub
     i32.const 2
     i32.shr_s
     i32.const 1
     i32.add
-    local.set $4
+    local.set $var$4
     global.get $~lib/memory/__stack_pointer
-    local.get $4
+    local.get $var$4
     i32.const 1
     i32.shl
-    local.get $2
+    local.get $sign
     i32.add
     i32.const 1
     call $~lib/rt/itcms/__new
-    local.tee $3
+    local.tee $out
     i32.store $0
-    local.get $3
-    local.get $2
+    local.get $out
+    local.get $sign
     i32.add
-    local.set $7
-    local.get $0
-    local.set $6
-    local.get $4
-    local.set $5
+    local.set $var$7
+    local.get $value
+    local.set $var$6
+    local.get $var$4
+    local.set $var$5
     i32.const 0
     i32.const 1
     i32.ge_s
     drop
-    local.get $7
-    local.get $6
+    local.get $var$7
+    local.get $var$6
     i64.extend_i32_u
-    local.get $5
+    local.get $var$5
     call $~lib/util/number/utoa_hex_lut
    else
-    local.get $0
-    local.set $4
-    local.get $4
+    local.get $value
+    local.set $var$4
+    local.get $var$4
     i64.extend_i32_u
-    local.get $1
+    local.get $radix
     call $~lib/util/number/ulog_base
-    local.set $7
+    local.set $var$7
     global.get $~lib/memory/__stack_pointer
-    local.get $7
+    local.get $var$7
     i32.const 1
     i32.shl
-    local.get $2
+    local.get $sign
     i32.add
     i32.const 1
     call $~lib/rt/itcms/__new
-    local.tee $3
+    local.tee $out
     i32.store $0
-    local.get $3
-    local.get $2
+    local.get $out
+    local.get $sign
     i32.add
-    local.get $4
+    local.get $var$4
     i64.extend_i32_u
-    local.get $7
-    local.get $1
+    local.get $var$7
+    local.get $radix
     call $~lib/util/number/utoa64_any_core
    end
   end
-  local.get $2
+  local.get $sign
   if
-   local.get $3
+   local.get $out
    i32.const 45
    i32.store16 $0
   end
-  local.get $3
+  local.get $out
   local.set $8
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -7185,9 +7185,9 @@
   global.set $~lib/memory/__stack_pointer
   local.get $8
  )
- (func $~lib/util/number/dtoa (param $0 f64) (result i32)
-  (local $1 i32)
-  (local $2 i32)
+ (func $~lib/util/number/dtoa (param $value f64) (result i32)
+  (local $size i32)
+  (local $result i32)
   (local $3 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -7197,7 +7197,7 @@
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   i32.store $0
-  local.get $0
+  local.get $value
   f64.const 0
   f64.eq
   if
@@ -7210,15 +7210,15 @@
    local.get $3
    return
   end
-  local.get $0
-  local.get $0
+  local.get $value
+  local.get $value
   f64.sub
   f64.const 0
   f64.eq
   i32.eqz
   if
-   local.get $0
-   local.get $0
+   local.get $value
+   local.get $value
    f64.ne
    if
     i32.const 8592
@@ -7232,7 +7232,7 @@
    end
    i32.const 8624
    i32.const 8672
-   local.get $0
+   local.get $value
    f64.const 0
    f64.lt
    select
@@ -7245,22 +7245,22 @@
    return
   end
   i32.const 8704
-  local.get $0
+  local.get $value
   call $~lib/util/number/dtoa_core
   i32.const 1
   i32.shl
-  local.set $1
+  local.set $size
   global.get $~lib/memory/__stack_pointer
-  local.get $1
+  local.get $size
   i32.const 1
   call $~lib/rt/itcms/__new
-  local.tee $2
+  local.tee $result
   i32.store $0
-  local.get $2
+  local.get $result
   i32.const 8704
-  local.get $1
+  local.get $size
   memory.copy $0 $0
-  local.get $2
+  local.get $result
   local.set $3
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -7268,7 +7268,7 @@
   global.set $~lib/memory/__stack_pointer
   local.get $3
  )
- (func $resolve-binary/Foo#constructor (param $0 i32) (result i32)
+ (func $resolve-binary/Foo#constructor (param $this i32) (result i32)
   (local $1 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -7278,17 +7278,17 @@
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   i32.store $0
-  local.get $0
+  local.get $this
   i32.eqz
   if
    global.get $~lib/memory/__stack_pointer
    i32.const 0
    i32.const 3
    call $~lib/rt/itcms/__new
-   local.tee $0
+   local.tee $this
    i32.store $0
   end
-  local.get $0
+  local.get $this
   local.set $1
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -7296,7 +7296,7 @@
   global.set $~lib/memory/__stack_pointer
   local.get $1
  )
- (func $resolve-binary/Bar#constructor (param $0 i32) (result i32)
+ (func $resolve-binary/Bar#constructor (param $this i32) (result i32)
   (local $1 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -7306,17 +7306,17 @@
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   i32.store $0
-  local.get $0
+  local.get $this
   i32.eqz
   if
    global.get $~lib/memory/__stack_pointer
    i32.const 0
    i32.const 4
    call $~lib/rt/itcms/__new
-   local.tee $0
+   local.tee $this
    i32.store $0
   end
-  local.get $0
+  local.get $this
   local.set $1
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -7324,7 +7324,7 @@
   global.set $~lib/memory/__stack_pointer
   local.get $1
  )
- (func $resolve-binary/Baz#constructor (param $0 i32) (result i32)
+ (func $resolve-binary/Baz#constructor (param $this i32) (result i32)
   (local $1 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -7334,17 +7334,17 @@
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   i32.store $0
-  local.get $0
+  local.get $this
   i32.eqz
   if
    global.get $~lib/memory/__stack_pointer
    i32.const 0
    i32.const 5
    call $~lib/rt/itcms/__new
-   local.tee $0
+   local.tee $this
    i32.store $0
   end
-  local.get $0
+  local.get $this
   local.set $1
   global.get $~lib/memory/__stack_pointer
   i32.const 4

--- a/tests/compiler/resolve-elementaccess.debug.wat
+++ b/tests/compiler/resolve-elementaccess.debug.wat
@@ -4641,8 +4641,8 @@
   i32.add
   global.set $~lib/memory/__stack_pointer
  )
- (func $~lib/arraybuffer/ArrayBufferView#constructor (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
-  (local $3 i32)
+ (func $~lib/arraybuffer/ArrayBufferView#constructor (param $this i32) (param $length i32) (param $alignLog2 i32) (result i32)
+  (local $buffer i32)
   (local $4 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 8
@@ -4652,28 +4652,28 @@
   global.get $~lib/memory/__stack_pointer
   i64.const 0
   i64.store $0
-  local.get $0
+  local.get $this
   i32.eqz
   if
    global.get $~lib/memory/__stack_pointer
    i32.const 12
    i32.const 2
    call $~lib/rt/itcms/__new
-   local.tee $0
+   local.tee $this
    i32.store $0
   end
-  local.get $0
+  local.get $this
   i32.const 0
   call $~lib/arraybuffer/ArrayBufferView#set:buffer
-  local.get $0
+  local.get $this
   i32.const 0
   call $~lib/arraybuffer/ArrayBufferView#set:dataStart
-  local.get $0
+  local.get $this
   i32.const 0
   call $~lib/arraybuffer/ArrayBufferView#set:byteLength
-  local.get $1
+  local.get $length
   i32.const 1073741820
-  local.get $2
+  local.get $alignLog2
   i32.shr_u
   i32.gt_u
   if
@@ -4685,28 +4685,28 @@
    unreachable
   end
   global.get $~lib/memory/__stack_pointer
-  local.get $1
-  local.get $2
+  local.get $length
+  local.get $alignLog2
   i32.shl
-  local.tee $1
+  local.tee $length
   i32.const 0
   call $~lib/rt/itcms/__new
-  local.tee $3
+  local.tee $buffer
   i32.store $0 offset=4
   i32.const 2
   global.get $~lib/shared/runtime/Runtime.Incremental
   i32.ne
   drop
-  local.get $0
-  local.get $3
+  local.get $this
+  local.get $buffer
   call $~lib/arraybuffer/ArrayBufferView#set:buffer
-  local.get $0
-  local.get $3
+  local.get $this
+  local.get $buffer
   call $~lib/arraybuffer/ArrayBufferView#set:dataStart
-  local.get $0
-  local.get $1
+  local.get $this
+  local.get $length
   call $~lib/arraybuffer/ArrayBufferView#set:byteLength
-  local.get $0
+  local.get $this
   local.set $4
   global.get $~lib/memory/__stack_pointer
   i32.const 8
@@ -4714,7 +4714,7 @@
   global.set $~lib/memory/__stack_pointer
   local.get $4
  )
- (func $~lib/typedarray/Float32Array#constructor (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/typedarray/Float32Array#constructor (param $this i32) (param $length i32) (result i32)
   (local $2 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -4724,24 +4724,24 @@
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   i32.store $0
-  local.get $0
+  local.get $this
   i32.eqz
   if
    global.get $~lib/memory/__stack_pointer
    i32.const 12
    i32.const 3
    call $~lib/rt/itcms/__new
-   local.tee $0
+   local.tee $this
    i32.store $0
   end
   global.get $~lib/memory/__stack_pointer
-  local.get $0
-  local.get $1
+  local.get $this
+  local.get $length
   i32.const 2
   call $~lib/arraybuffer/ArrayBufferView#constructor
-  local.tee $0
+  local.tee $this
   i32.store $0
-  local.get $0
+  local.get $this
   local.set $2
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -4749,9 +4749,9 @@
   global.set $~lib/memory/__stack_pointer
   local.get $2
  )
- (func $~lib/util/number/dtoa (param $0 f64) (result i32)
-  (local $1 i32)
-  (local $2 i32)
+ (func $~lib/util/number/dtoa (param $value f64) (result i32)
+  (local $size i32)
+  (local $result i32)
   (local $3 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -4761,7 +4761,7 @@
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   i32.store $0
-  local.get $0
+  local.get $value
   f64.const 0
   f64.eq
   if
@@ -4774,15 +4774,15 @@
    local.get $3
    return
   end
-  local.get $0
-  local.get $0
+  local.get $value
+  local.get $value
   f64.sub
   f64.const 0
   f64.eq
   i32.eqz
   if
-   local.get $0
-   local.get $0
+   local.get $value
+   local.get $value
    f64.ne
    if
     i32.const 640
@@ -4796,7 +4796,7 @@
    end
    i32.const 672
    i32.const 720
-   local.get $0
+   local.get $value
    f64.const 0
    f64.lt
    select
@@ -4809,22 +4809,22 @@
    return
   end
   i32.const 752
-  local.get $0
+  local.get $value
   call $~lib/util/number/dtoa_core
   i32.const 1
   i32.shl
-  local.set $1
+  local.set $size
   global.get $~lib/memory/__stack_pointer
-  local.get $1
+  local.get $size
   i32.const 1
   call $~lib/rt/itcms/__new
-  local.tee $2
+  local.tee $result
   i32.store $0
-  local.get $2
+  local.get $result
   i32.const 752
-  local.get $1
+  local.get $size
   memory.copy $0 $0
-  local.get $2
+  local.get $result
   local.set $3
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -4832,7 +4832,7 @@
   global.set $~lib/memory/__stack_pointer
   local.get $3
  )
- (func $~lib/typedarray/Uint8Array#constructor (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/typedarray/Uint8Array#constructor (param $this i32) (param $length i32) (result i32)
   (local $2 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -4842,24 +4842,24 @@
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   i32.store $0
-  local.get $0
+  local.get $this
   i32.eqz
   if
    global.get $~lib/memory/__stack_pointer
    i32.const 12
    i32.const 5
    call $~lib/rt/itcms/__new
-   local.tee $0
+   local.tee $this
    i32.store $0
   end
   global.get $~lib/memory/__stack_pointer
-  local.get $0
-  local.get $1
+  local.get $this
+  local.get $length
   i32.const 0
   call $~lib/arraybuffer/ArrayBufferView#constructor
-  local.tee $0
+  local.tee $this
   i32.store $0
-  local.get $0
+  local.get $this
   local.set $2
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -4867,7 +4867,7 @@
   global.set $~lib/memory/__stack_pointer
   local.get $2
  )
- (func $resolve-elementaccess/Buffer#constructor (param $0 i32) (param $1 i32) (result i32)
+ (func $resolve-elementaccess/Buffer#constructor (param $this i32) (param $length i32) (result i32)
   (local $2 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -4877,23 +4877,23 @@
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   i32.store $0
-  local.get $0
+  local.get $this
   i32.eqz
   if
    global.get $~lib/memory/__stack_pointer
    i32.const 12
    i32.const 4
    call $~lib/rt/itcms/__new
-   local.tee $0
+   local.tee $this
    i32.store $0
   end
   global.get $~lib/memory/__stack_pointer
-  local.get $0
-  local.get $1
+  local.get $this
+  local.get $length
   call $~lib/typedarray/Uint8Array#constructor
-  local.tee $0
+  local.tee $this
   i32.store $0
-  local.get $0
+  local.get $this
   local.set $2
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -4901,12 +4901,12 @@
   global.set $~lib/memory/__stack_pointer
   local.get $2
  )
- (func $~lib/util/number/utoa32 (param $0 i32) (param $1 i32) (result i32)
-  (local $2 i32)
-  (local $3 i32)
-  (local $4 i32)
-  (local $5 i32)
-  (local $6 i32)
+ (func $~lib/util/number/utoa32 (param $value i32) (param $radix i32) (result i32)
+  (local $out i32)
+  (local $var$3 i32)
+  (local $var$4 i32)
+  (local $var$5 i32)
+  (local $var$6 i32)
   (local $7 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -4916,13 +4916,13 @@
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   i32.store $0
-  local.get $1
+  local.get $radix
   i32.const 2
   i32.lt_s
   if (result i32)
    i32.const 1
   else
-   local.get $1
+   local.get $radix
    i32.const 36
    i32.gt_s
   end
@@ -4934,7 +4934,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $0
+  local.get $value
   i32.eqz
   if
    i32.const 2512
@@ -4946,95 +4946,95 @@
    local.get $7
    return
   end
-  local.get $1
+  local.get $radix
   i32.const 10
   i32.eq
   if
-   local.get $0
+   local.get $value
    call $~lib/util/number/decimalCount32
-   local.set $3
+   local.set $var$3
    global.get $~lib/memory/__stack_pointer
-   local.get $3
+   local.get $var$3
    i32.const 1
    i32.shl
    i32.const 1
    call $~lib/rt/itcms/__new
-   local.tee $2
+   local.tee $out
    i32.store $0
-   local.get $2
-   local.set $6
-   local.get $0
-   local.set $5
-   local.get $3
-   local.set $4
+   local.get $out
+   local.set $var$6
+   local.get $value
+   local.set $var$5
+   local.get $var$3
+   local.set $var$4
    i32.const 0
    i32.const 1
    i32.ge_s
    drop
-   local.get $6
-   local.get $5
-   local.get $4
+   local.get $var$6
+   local.get $var$5
+   local.get $var$4
    call $~lib/util/number/utoa32_dec_lut
   else
-   local.get $1
+   local.get $radix
    i32.const 16
    i32.eq
    if
     i32.const 31
-    local.get $0
+    local.get $value
     i32.clz
     i32.sub
     i32.const 2
     i32.shr_s
     i32.const 1
     i32.add
-    local.set $3
+    local.set $var$3
     global.get $~lib/memory/__stack_pointer
-    local.get $3
+    local.get $var$3
     i32.const 1
     i32.shl
     i32.const 1
     call $~lib/rt/itcms/__new
-    local.tee $2
+    local.tee $out
     i32.store $0
-    local.get $2
-    local.set $6
-    local.get $0
-    local.set $5
-    local.get $3
-    local.set $4
+    local.get $out
+    local.set $var$6
+    local.get $value
+    local.set $var$5
+    local.get $var$3
+    local.set $var$4
     i32.const 0
     i32.const 1
     i32.ge_s
     drop
-    local.get $6
-    local.get $5
+    local.get $var$6
+    local.get $var$5
     i64.extend_i32_u
-    local.get $4
+    local.get $var$4
     call $~lib/util/number/utoa_hex_lut
    else
-    local.get $0
+    local.get $value
     i64.extend_i32_u
-    local.get $1
+    local.get $radix
     call $~lib/util/number/ulog_base
-    local.set $3
+    local.set $var$3
     global.get $~lib/memory/__stack_pointer
-    local.get $3
+    local.get $var$3
     i32.const 1
     i32.shl
     i32.const 1
     call $~lib/rt/itcms/__new
-    local.tee $2
+    local.tee $out
     i32.store $0
-    local.get $2
-    local.get $0
+    local.get $out
+    local.get $value
     i64.extend_i32_u
-    local.get $3
-    local.get $1
+    local.get $var$3
+    local.get $radix
     call $~lib/util/number/utoa64_any_core
    end
   end
-  local.get $2
+  local.get $out
   local.set $7
   global.get $~lib/memory/__stack_pointer
   i32.const 4

--- a/tests/compiler/resolve-function-expression.debug.wat
+++ b/tests/compiler/resolve-function-expression.debug.wat
@@ -2893,13 +2893,13 @@
   i32.add
   global.set $~lib/memory/__stack_pointer
  )
- (func $~lib/util/number/itoa32 (param $0 i32) (param $1 i32) (result i32)
-  (local $2 i32)
-  (local $3 i32)
-  (local $4 i32)
-  (local $5 i32)
-  (local $6 i32)
-  (local $7 i32)
+ (func $~lib/util/number/itoa32 (param $value i32) (param $radix i32) (result i32)
+  (local $sign i32)
+  (local $out i32)
+  (local $var$4 i32)
+  (local $var$5 i32)
+  (local $var$6 i32)
+  (local $var$7 i32)
   (local $8 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -2909,13 +2909,13 @@
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   i32.store $0
-  local.get $1
+  local.get $radix
   i32.const 2
   i32.lt_s
   if (result i32)
    i32.const 1
   else
-   local.get $1
+   local.get $radix
    i32.const 36
    i32.gt_s
   end
@@ -2927,7 +2927,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $0
+  local.get $value
   i32.eqz
   if
    i32.const 400
@@ -2939,128 +2939,128 @@
    local.get $8
    return
   end
-  local.get $0
+  local.get $value
   i32.const 31
   i32.shr_u
   i32.const 1
   i32.shl
-  local.set $2
-  local.get $2
+  local.set $sign
+  local.get $sign
   if
    i32.const 0
-   local.get $0
+   local.get $value
    i32.sub
-   local.set $0
+   local.set $value
   end
-  local.get $1
+  local.get $radix
   i32.const 10
   i32.eq
   if
-   local.get $0
+   local.get $value
    call $~lib/util/number/decimalCount32
-   local.set $4
+   local.set $var$4
    global.get $~lib/memory/__stack_pointer
-   local.get $4
+   local.get $var$4
    i32.const 1
    i32.shl
-   local.get $2
+   local.get $sign
    i32.add
    i32.const 1
    call $~lib/rt/itcms/__new
-   local.tee $3
+   local.tee $out
    i32.store $0
-   local.get $3
-   local.get $2
+   local.get $out
+   local.get $sign
    i32.add
-   local.set $7
-   local.get $0
-   local.set $6
-   local.get $4
-   local.set $5
+   local.set $var$7
+   local.get $value
+   local.set $var$6
+   local.get $var$4
+   local.set $var$5
    i32.const 0
    i32.const 1
    i32.ge_s
    drop
-   local.get $7
-   local.get $6
-   local.get $5
+   local.get $var$7
+   local.get $var$6
+   local.get $var$5
    call $~lib/util/number/utoa32_dec_lut
   else
-   local.get $1
+   local.get $radix
    i32.const 16
    i32.eq
    if
     i32.const 31
-    local.get $0
+    local.get $value
     i32.clz
     i32.sub
     i32.const 2
     i32.shr_s
     i32.const 1
     i32.add
-    local.set $4
+    local.set $var$4
     global.get $~lib/memory/__stack_pointer
-    local.get $4
+    local.get $var$4
     i32.const 1
     i32.shl
-    local.get $2
+    local.get $sign
     i32.add
     i32.const 1
     call $~lib/rt/itcms/__new
-    local.tee $3
+    local.tee $out
     i32.store $0
-    local.get $3
-    local.get $2
+    local.get $out
+    local.get $sign
     i32.add
-    local.set $7
-    local.get $0
-    local.set $6
-    local.get $4
-    local.set $5
+    local.set $var$7
+    local.get $value
+    local.set $var$6
+    local.get $var$4
+    local.set $var$5
     i32.const 0
     i32.const 1
     i32.ge_s
     drop
-    local.get $7
-    local.get $6
+    local.get $var$7
+    local.get $var$6
     i64.extend_i32_u
-    local.get $5
+    local.get $var$5
     call $~lib/util/number/utoa_hex_lut
    else
-    local.get $0
-    local.set $4
-    local.get $4
+    local.get $value
+    local.set $var$4
+    local.get $var$4
     i64.extend_i32_u
-    local.get $1
+    local.get $radix
     call $~lib/util/number/ulog_base
-    local.set $7
+    local.set $var$7
     global.get $~lib/memory/__stack_pointer
-    local.get $7
+    local.get $var$7
     i32.const 1
     i32.shl
-    local.get $2
+    local.get $sign
     i32.add
     i32.const 1
     call $~lib/rt/itcms/__new
-    local.tee $3
+    local.tee $out
     i32.store $0
-    local.get $3
-    local.get $2
+    local.get $out
+    local.get $sign
     i32.add
-    local.get $4
+    local.get $var$4
     i64.extend_i32_u
-    local.get $7
-    local.get $1
+    local.get $var$7
+    local.get $radix
     call $~lib/util/number/utoa64_any_core
    end
   end
-  local.get $2
+  local.get $sign
   if
-   local.get $3
+   local.get $out
    i32.const 45
    i32.store16 $0
   end
-  local.get $3
+  local.get $out
   local.set $8
   global.get $~lib/memory/__stack_pointer
   i32.const 4

--- a/tests/compiler/resolve-new.debug.wat
+++ b/tests/compiler/resolve-new.debug.wat
@@ -2228,7 +2228,7 @@
   i32.add
   global.set $~lib/memory/__stack_pointer
  )
- (func $resolve-new/Foo#constructor (param $0 i32) (result i32)
+ (func $resolve-new/Foo#constructor (param $this i32) (result i32)
   (local $1 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -2238,17 +2238,17 @@
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   i32.store $0
-  local.get $0
+  local.get $this
   i32.eqz
   if
    global.get $~lib/memory/__stack_pointer
    i32.const 0
    i32.const 3
    call $~lib/rt/itcms/__new
-   local.tee $0
+   local.tee $this
    i32.store $0
   end
-  local.get $0
+  local.get $this
   local.set $1
   global.get $~lib/memory/__stack_pointer
   i32.const 4

--- a/tests/compiler/resolve-propertyaccess.debug.wat
+++ b/tests/compiler/resolve-propertyaccess.debug.wat
@@ -3127,13 +3127,13 @@
   i32.add
   global.set $~lib/memory/__stack_pointer
  )
- (func $~lib/util/number/itoa32 (param $0 i32) (param $1 i32) (result i32)
-  (local $2 i32)
-  (local $3 i32)
-  (local $4 i32)
-  (local $5 i32)
-  (local $6 i32)
-  (local $7 i32)
+ (func $~lib/util/number/itoa32 (param $value i32) (param $radix i32) (result i32)
+  (local $sign i32)
+  (local $out i32)
+  (local $var$4 i32)
+  (local $var$5 i32)
+  (local $var$6 i32)
+  (local $var$7 i32)
   (local $8 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -3143,13 +3143,13 @@
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   i32.store $0
-  local.get $1
+  local.get $radix
   i32.const 2
   i32.lt_s
   if (result i32)
    i32.const 1
   else
-   local.get $1
+   local.get $radix
    i32.const 36
    i32.gt_s
   end
@@ -3161,7 +3161,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $0
+  local.get $value
   i32.eqz
   if
    i32.const 224
@@ -3173,128 +3173,128 @@
    local.get $8
    return
   end
-  local.get $0
+  local.get $value
   i32.const 31
   i32.shr_u
   i32.const 1
   i32.shl
-  local.set $2
-  local.get $2
+  local.set $sign
+  local.get $sign
   if
    i32.const 0
-   local.get $0
+   local.get $value
    i32.sub
-   local.set $0
+   local.set $value
   end
-  local.get $1
+  local.get $radix
   i32.const 10
   i32.eq
   if
-   local.get $0
+   local.get $value
    call $~lib/util/number/decimalCount32
-   local.set $4
+   local.set $var$4
    global.get $~lib/memory/__stack_pointer
-   local.get $4
+   local.get $var$4
    i32.const 1
    i32.shl
-   local.get $2
+   local.get $sign
    i32.add
    i32.const 1
    call $~lib/rt/itcms/__new
-   local.tee $3
+   local.tee $out
    i32.store $0
-   local.get $3
-   local.get $2
+   local.get $out
+   local.get $sign
    i32.add
-   local.set $7
-   local.get $0
-   local.set $6
-   local.get $4
-   local.set $5
+   local.set $var$7
+   local.get $value
+   local.set $var$6
+   local.get $var$4
+   local.set $var$5
    i32.const 0
    i32.const 1
    i32.ge_s
    drop
-   local.get $7
-   local.get $6
-   local.get $5
+   local.get $var$7
+   local.get $var$6
+   local.get $var$5
    call $~lib/util/number/utoa32_dec_lut
   else
-   local.get $1
+   local.get $radix
    i32.const 16
    i32.eq
    if
     i32.const 31
-    local.get $0
+    local.get $value
     i32.clz
     i32.sub
     i32.const 2
     i32.shr_s
     i32.const 1
     i32.add
-    local.set $4
+    local.set $var$4
     global.get $~lib/memory/__stack_pointer
-    local.get $4
+    local.get $var$4
     i32.const 1
     i32.shl
-    local.get $2
+    local.get $sign
     i32.add
     i32.const 1
     call $~lib/rt/itcms/__new
-    local.tee $3
+    local.tee $out
     i32.store $0
-    local.get $3
-    local.get $2
+    local.get $out
+    local.get $sign
     i32.add
-    local.set $7
-    local.get $0
-    local.set $6
-    local.get $4
-    local.set $5
+    local.set $var$7
+    local.get $value
+    local.set $var$6
+    local.get $var$4
+    local.set $var$5
     i32.const 0
     i32.const 1
     i32.ge_s
     drop
-    local.get $7
-    local.get $6
+    local.get $var$7
+    local.get $var$6
     i64.extend_i32_u
-    local.get $5
+    local.get $var$5
     call $~lib/util/number/utoa_hex_lut
    else
-    local.get $0
-    local.set $4
-    local.get $4
+    local.get $value
+    local.set $var$4
+    local.get $var$4
     i64.extend_i32_u
-    local.get $1
+    local.get $radix
     call $~lib/util/number/ulog_base
-    local.set $7
+    local.set $var$7
     global.get $~lib/memory/__stack_pointer
-    local.get $7
+    local.get $var$7
     i32.const 1
     i32.shl
-    local.get $2
+    local.get $sign
     i32.add
     i32.const 1
     call $~lib/rt/itcms/__new
-    local.tee $3
+    local.tee $out
     i32.store $0
-    local.get $3
-    local.get $2
+    local.get $out
+    local.get $sign
     i32.add
-    local.get $4
+    local.get $var$4
     i64.extend_i32_u
-    local.get $7
-    local.get $1
+    local.get $var$7
+    local.get $radix
     call $~lib/util/number/utoa64_any_core
    end
   end
-  local.get $2
+  local.get $sign
   if
-   local.get $3
+   local.get $out
    i32.const 45
    i32.store16 $0
   end
-  local.get $3
+  local.get $out
   local.set $8
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -3302,7 +3302,7 @@
   global.set $~lib/memory/__stack_pointer
   local.get $8
  )
- (func $resolve-propertyaccess/Class#constructor (param $0 i32) (result i32)
+ (func $resolve-propertyaccess/Class#constructor (param $this i32) (result i32)
   (local $1 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -3312,20 +3312,20 @@
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   i32.store $0
-  local.get $0
+  local.get $this
   i32.eqz
   if
    global.get $~lib/memory/__stack_pointer
    i32.const 4
    i32.const 3
    call $~lib/rt/itcms/__new
-   local.tee $0
+   local.tee $this
    i32.store $0
   end
-  local.get $0
+  local.get $this
   i32.const 6
   call $resolve-propertyaccess/Class#set:instanceField
-  local.get $0
+  local.get $this
   local.set $1
   global.get $~lib/memory/__stack_pointer
   i32.const 4

--- a/tests/compiler/resolve-ternary.debug.wat
+++ b/tests/compiler/resolve-ternary.debug.wat
@@ -4237,13 +4237,13 @@
   i32.add
   global.set $~lib/memory/__stack_pointer
  )
- (func $~lib/util/number/itoa32 (param $0 i32) (param $1 i32) (result i32)
-  (local $2 i32)
-  (local $3 i32)
-  (local $4 i32)
-  (local $5 i32)
-  (local $6 i32)
-  (local $7 i32)
+ (func $~lib/util/number/itoa32 (param $value i32) (param $radix i32) (result i32)
+  (local $sign i32)
+  (local $out i32)
+  (local $var$4 i32)
+  (local $var$5 i32)
+  (local $var$6 i32)
+  (local $var$7 i32)
   (local $8 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -4253,13 +4253,13 @@
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   i32.store $0
-  local.get $1
+  local.get $radix
   i32.const 2
   i32.lt_s
   if (result i32)
    i32.const 1
   else
-   local.get $1
+   local.get $radix
    i32.const 36
    i32.gt_s
   end
@@ -4271,7 +4271,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $0
+  local.get $value
   i32.eqz
   if
    i32.const 224
@@ -4283,128 +4283,128 @@
    local.get $8
    return
   end
-  local.get $0
+  local.get $value
   i32.const 31
   i32.shr_u
   i32.const 1
   i32.shl
-  local.set $2
-  local.get $2
+  local.set $sign
+  local.get $sign
   if
    i32.const 0
-   local.get $0
+   local.get $value
    i32.sub
-   local.set $0
+   local.set $value
   end
-  local.get $1
+  local.get $radix
   i32.const 10
   i32.eq
   if
-   local.get $0
+   local.get $value
    call $~lib/util/number/decimalCount32
-   local.set $4
+   local.set $var$4
    global.get $~lib/memory/__stack_pointer
-   local.get $4
+   local.get $var$4
    i32.const 1
    i32.shl
-   local.get $2
+   local.get $sign
    i32.add
    i32.const 1
    call $~lib/rt/itcms/__new
-   local.tee $3
+   local.tee $out
    i32.store $0
-   local.get $3
-   local.get $2
+   local.get $out
+   local.get $sign
    i32.add
-   local.set $7
-   local.get $0
-   local.set $6
-   local.get $4
-   local.set $5
+   local.set $var$7
+   local.get $value
+   local.set $var$6
+   local.get $var$4
+   local.set $var$5
    i32.const 0
    i32.const 1
    i32.ge_s
    drop
-   local.get $7
-   local.get $6
-   local.get $5
+   local.get $var$7
+   local.get $var$6
+   local.get $var$5
    call $~lib/util/number/utoa32_dec_lut
   else
-   local.get $1
+   local.get $radix
    i32.const 16
    i32.eq
    if
     i32.const 31
-    local.get $0
+    local.get $value
     i32.clz
     i32.sub
     i32.const 2
     i32.shr_s
     i32.const 1
     i32.add
-    local.set $4
+    local.set $var$4
     global.get $~lib/memory/__stack_pointer
-    local.get $4
+    local.get $var$4
     i32.const 1
     i32.shl
-    local.get $2
+    local.get $sign
     i32.add
     i32.const 1
     call $~lib/rt/itcms/__new
-    local.tee $3
+    local.tee $out
     i32.store $0
-    local.get $3
-    local.get $2
+    local.get $out
+    local.get $sign
     i32.add
-    local.set $7
-    local.get $0
-    local.set $6
-    local.get $4
-    local.set $5
+    local.set $var$7
+    local.get $value
+    local.set $var$6
+    local.get $var$4
+    local.set $var$5
     i32.const 0
     i32.const 1
     i32.ge_s
     drop
-    local.get $7
-    local.get $6
+    local.get $var$7
+    local.get $var$6
     i64.extend_i32_u
-    local.get $5
+    local.get $var$5
     call $~lib/util/number/utoa_hex_lut
    else
-    local.get $0
-    local.set $4
-    local.get $4
+    local.get $value
+    local.set $var$4
+    local.get $var$4
     i64.extend_i32_u
-    local.get $1
+    local.get $radix
     call $~lib/util/number/ulog_base
-    local.set $7
+    local.set $var$7
     global.get $~lib/memory/__stack_pointer
-    local.get $7
+    local.get $var$7
     i32.const 1
     i32.shl
-    local.get $2
+    local.get $sign
     i32.add
     i32.const 1
     call $~lib/rt/itcms/__new
-    local.tee $3
+    local.tee $out
     i32.store $0
-    local.get $3
-    local.get $2
+    local.get $out
+    local.get $sign
     i32.add
-    local.get $4
+    local.get $var$4
     i64.extend_i32_u
-    local.get $7
-    local.get $1
+    local.get $var$7
+    local.get $radix
     call $~lib/util/number/utoa64_any_core
    end
   end
-  local.get $2
+  local.get $sign
   if
-   local.get $3
+   local.get $out
    i32.const 45
    i32.store16 $0
   end
-  local.get $3
+  local.get $out
   local.set $8
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -4412,9 +4412,9 @@
   global.set $~lib/memory/__stack_pointer
   local.get $8
  )
- (func $~lib/util/number/dtoa (param $0 f64) (result i32)
-  (local $1 i32)
-  (local $2 i32)
+ (func $~lib/util/number/dtoa (param $value f64) (result i32)
+  (local $size i32)
+  (local $result i32)
   (local $3 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -4424,7 +4424,7 @@
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   i32.store $0
-  local.get $0
+  local.get $value
   f64.const 0
   f64.eq
   if
@@ -4437,15 +4437,15 @@
    local.get $3
    return
   end
-  local.get $0
-  local.get $0
+  local.get $value
+  local.get $value
   f64.sub
   f64.const 0
   f64.eq
   i32.eqz
   if
-   local.get $0
-   local.get $0
+   local.get $value
+   local.get $value
    f64.ne
    if
     i32.const 2336
@@ -4459,7 +4459,7 @@
    end
    i32.const 2368
    i32.const 2416
-   local.get $0
+   local.get $value
    f64.const 0
    f64.lt
    select
@@ -4472,22 +4472,22 @@
    return
   end
   i32.const 2448
-  local.get $0
+  local.get $value
   call $~lib/util/number/dtoa_core
   i32.const 1
   i32.shl
-  local.set $1
+  local.set $size
   global.get $~lib/memory/__stack_pointer
-  local.get $1
+  local.get $size
   i32.const 1
   call $~lib/rt/itcms/__new
-  local.tee $2
+  local.tee $result
   i32.store $0
-  local.get $2
+  local.get $result
   i32.const 2448
-  local.get $1
+  local.get $size
   memory.copy $0 $0
-  local.get $2
+  local.get $result
   local.set $3
   global.get $~lib/memory/__stack_pointer
   i32.const 4

--- a/tests/compiler/resolve-unary.debug.wat
+++ b/tests/compiler/resolve-unary.debug.wat
@@ -3551,13 +3551,13 @@
   i32.add
   global.set $~lib/memory/__stack_pointer
  )
- (func $~lib/util/number/itoa32 (param $0 i32) (param $1 i32) (result i32)
-  (local $2 i32)
-  (local $3 i32)
-  (local $4 i32)
-  (local $5 i32)
-  (local $6 i32)
-  (local $7 i32)
+ (func $~lib/util/number/itoa32 (param $value i32) (param $radix i32) (result i32)
+  (local $sign i32)
+  (local $out i32)
+  (local $var$4 i32)
+  (local $var$5 i32)
+  (local $var$6 i32)
+  (local $var$7 i32)
   (local $8 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -3567,13 +3567,13 @@
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   i32.store $0
-  local.get $1
+  local.get $radix
   i32.const 2
   i32.lt_s
   if (result i32)
    i32.const 1
   else
-   local.get $1
+   local.get $radix
    i32.const 36
    i32.gt_s
   end
@@ -3585,7 +3585,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $0
+  local.get $value
   i32.eqz
   if
    i32.const 224
@@ -3597,128 +3597,128 @@
    local.get $8
    return
   end
-  local.get $0
+  local.get $value
   i32.const 31
   i32.shr_u
   i32.const 1
   i32.shl
-  local.set $2
-  local.get $2
+  local.set $sign
+  local.get $sign
   if
    i32.const 0
-   local.get $0
+   local.get $value
    i32.sub
-   local.set $0
+   local.set $value
   end
-  local.get $1
+  local.get $radix
   i32.const 10
   i32.eq
   if
-   local.get $0
+   local.get $value
    call $~lib/util/number/decimalCount32
-   local.set $4
+   local.set $var$4
    global.get $~lib/memory/__stack_pointer
-   local.get $4
+   local.get $var$4
    i32.const 1
    i32.shl
-   local.get $2
+   local.get $sign
    i32.add
    i32.const 1
    call $~lib/rt/itcms/__new
-   local.tee $3
+   local.tee $out
    i32.store $0
-   local.get $3
-   local.get $2
+   local.get $out
+   local.get $sign
    i32.add
-   local.set $7
-   local.get $0
-   local.set $6
-   local.get $4
-   local.set $5
+   local.set $var$7
+   local.get $value
+   local.set $var$6
+   local.get $var$4
+   local.set $var$5
    i32.const 0
    i32.const 1
    i32.ge_s
    drop
-   local.get $7
-   local.get $6
-   local.get $5
+   local.get $var$7
+   local.get $var$6
+   local.get $var$5
    call $~lib/util/number/utoa32_dec_lut
   else
-   local.get $1
+   local.get $radix
    i32.const 16
    i32.eq
    if
     i32.const 31
-    local.get $0
+    local.get $value
     i32.clz
     i32.sub
     i32.const 2
     i32.shr_s
     i32.const 1
     i32.add
-    local.set $4
+    local.set $var$4
     global.get $~lib/memory/__stack_pointer
-    local.get $4
+    local.get $var$4
     i32.const 1
     i32.shl
-    local.get $2
+    local.get $sign
     i32.add
     i32.const 1
     call $~lib/rt/itcms/__new
-    local.tee $3
+    local.tee $out
     i32.store $0
-    local.get $3
-    local.get $2
+    local.get $out
+    local.get $sign
     i32.add
-    local.set $7
-    local.get $0
-    local.set $6
-    local.get $4
-    local.set $5
+    local.set $var$7
+    local.get $value
+    local.set $var$6
+    local.get $var$4
+    local.set $var$5
     i32.const 0
     i32.const 1
     i32.ge_s
     drop
-    local.get $7
-    local.get $6
+    local.get $var$7
+    local.get $var$6
     i64.extend_i32_u
-    local.get $5
+    local.get $var$5
     call $~lib/util/number/utoa_hex_lut
    else
-    local.get $0
-    local.set $4
-    local.get $4
+    local.get $value
+    local.set $var$4
+    local.get $var$4
     i64.extend_i32_u
-    local.get $1
+    local.get $radix
     call $~lib/util/number/ulog_base
-    local.set $7
+    local.set $var$7
     global.get $~lib/memory/__stack_pointer
-    local.get $7
+    local.get $var$7
     i32.const 1
     i32.shl
-    local.get $2
+    local.get $sign
     i32.add
     i32.const 1
     call $~lib/rt/itcms/__new
-    local.tee $3
+    local.tee $out
     i32.store $0
-    local.get $3
-    local.get $2
+    local.get $out
+    local.get $sign
     i32.add
-    local.get $4
+    local.get $var$4
     i64.extend_i32_u
-    local.get $7
-    local.get $1
+    local.get $var$7
+    local.get $radix
     call $~lib/util/number/utoa64_any_core
    end
   end
-  local.get $2
+  local.get $sign
   if
-   local.get $3
+   local.get $out
    i32.const 45
    i32.store16 $0
   end
-  local.get $3
+  local.get $out
   local.set $8
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -3726,7 +3726,7 @@
   global.set $~lib/memory/__stack_pointer
   local.get $8
  )
- (func $resolve-unary/Foo#constructor (param $0 i32) (result i32)
+ (func $resolve-unary/Foo#constructor (param $this i32) (result i32)
   (local $1 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -3736,17 +3736,17 @@
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   i32.store $0
-  local.get $0
+  local.get $this
   i32.eqz
   if
    global.get $~lib/memory/__stack_pointer
    i32.const 0
    i32.const 3
    call $~lib/rt/itcms/__new
-   local.tee $0
+   local.tee $this
    i32.store $0
   end
-  local.get $0
+  local.get $this
   local.set $1
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -3754,7 +3754,7 @@
   global.set $~lib/memory/__stack_pointer
   local.get $1
  )
- (func $resolve-unary/Bar#constructor (param $0 i32) (result i32)
+ (func $resolve-unary/Bar#constructor (param $this i32) (result i32)
   (local $1 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -3764,17 +3764,17 @@
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   i32.store $0
-  local.get $0
+  local.get $this
   i32.eqz
   if
    global.get $~lib/memory/__stack_pointer
    i32.const 0
    i32.const 4
    call $~lib/rt/itcms/__new
-   local.tee $0
+   local.tee $this
    i32.store $0
   end
-  local.get $0
+  local.get $this
   local.set $1
   global.get $~lib/memory/__stack_pointer
   i32.const 4

--- a/tests/compiler/return-unreachable.debug.wat
+++ b/tests/compiler/return-unreachable.debug.wat
@@ -2323,11 +2323,11 @@
    unreachable
   end
  )
- (func $~lib/array/Array<i32>#constructor (param $0 i32) (param $1 i32) (result i32)
-  (local $2 i32)
-  (local $3 i32)
-  (local $4 i32)
-  (local $5 i32)
+ (func $~lib/array/Array<i32>#constructor (param $this i32) (param $length i32) (result i32)
+  (local $var$2 i32)
+  (local $var$3 i32)
+  (local $bufferSize i32)
+  (local $buffer i32)
   (local $6 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 8
@@ -2337,29 +2337,29 @@
   global.get $~lib/memory/__stack_pointer
   i64.const 0
   i64.store $0
-  local.get $0
+  local.get $this
   i32.eqz
   if
    global.get $~lib/memory/__stack_pointer
    i32.const 16
    i32.const 3
    call $~lib/rt/itcms/__new
-   local.tee $0
+   local.tee $this
    i32.store $0
   end
-  local.get $0
+  local.get $this
   i32.const 0
   call $~lib/array/Array<i32>#set:buffer
-  local.get $0
+  local.get $this
   i32.const 0
   call $~lib/array/Array<i32>#set:dataStart
-  local.get $0
+  local.get $this
   i32.const 0
   call $~lib/array/Array<i32>#set:byteLength
-  local.get $0
+  local.get $this
   i32.const 0
   call $~lib/array/Array<i32>#set:length_
-  local.get $1
+  local.get $length
   i32.const 1073741820
   i32.const 2
   i32.shr_u
@@ -2372,40 +2372,40 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $1
-  local.tee $2
+  local.get $length
+  local.tee $var$2
   i32.const 8
-  local.tee $3
-  local.get $2
-  local.get $3
+  local.tee $var$3
+  local.get $var$2
+  local.get $var$3
   i32.gt_u
   select
   i32.const 2
   i32.shl
-  local.set $4
+  local.set $bufferSize
   global.get $~lib/memory/__stack_pointer
-  local.get $4
+  local.get $bufferSize
   i32.const 0
   call $~lib/rt/itcms/__new
-  local.tee $5
+  local.tee $buffer
   i32.store $0 offset=4
   i32.const 2
   global.get $~lib/shared/runtime/Runtime.Incremental
   i32.ne
   drop
-  local.get $0
-  local.get $5
+  local.get $this
+  local.get $buffer
   call $~lib/array/Array<i32>#set:buffer
-  local.get $0
-  local.get $5
+  local.get $this
+  local.get $buffer
   call $~lib/array/Array<i32>#set:dataStart
-  local.get $0
-  local.get $4
+  local.get $this
+  local.get $bufferSize
   call $~lib/array/Array<i32>#set:byteLength
-  local.get $0
-  local.get $1
+  local.get $this
+  local.get $length
   call $~lib/array/Array<i32>#set:length_
-  local.get $0
+  local.get $this
   local.set $6
   global.get $~lib/memory/__stack_pointer
   i32.const 8

--- a/tests/compiler/rt/finalize.debug.wat
+++ b/tests/compiler/rt/finalize.debug.wat
@@ -2288,7 +2288,7 @@
    unreachable
   end
  )
- (func $rt/finalize/Ref#constructor (param $0 i32) (result i32)
+ (func $rt/finalize/Ref#constructor (param $this i32) (result i32)
   (local $1 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -2298,17 +2298,17 @@
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   i32.store $0
-  local.get $0
+  local.get $this
   i32.eqz
   if
    global.get $~lib/memory/__stack_pointer
    i32.const 0
    i32.const 3
    call $~lib/rt/itcms/__new
-   local.tee $0
+   local.tee $this
    i32.store $0
   end
-  local.get $0
+  local.get $this
   local.set $1
   global.get $~lib/memory/__stack_pointer
   i32.const 4

--- a/tests/compiler/rt/instanceof.debug.wat
+++ b/tests/compiler/rt/instanceof.debug.wat
@@ -2836,7 +2836,7 @@
    unreachable
   end
  )
- (func $rt/instanceof/Animal#constructor (param $0 i32) (result i32)
+ (func $rt/instanceof/Animal#constructor (param $this i32) (result i32)
   (local $1 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -2846,17 +2846,17 @@
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   i32.store $0
-  local.get $0
+  local.get $this
   i32.eqz
   if
    global.get $~lib/memory/__stack_pointer
    i32.const 0
    i32.const 3
    call $~lib/rt/itcms/__new
-   local.tee $0
+   local.tee $this
    i32.store $0
   end
-  local.get $0
+  local.get $this
   local.set $1
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -2864,7 +2864,7 @@
   global.set $~lib/memory/__stack_pointer
   local.get $1
  )
- (func $rt/instanceof/Cat#constructor (param $0 i32) (result i32)
+ (func $rt/instanceof/Cat#constructor (param $this i32) (result i32)
   (local $1 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -2874,22 +2874,22 @@
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   i32.store $0
-  local.get $0
+  local.get $this
   i32.eqz
   if
    global.get $~lib/memory/__stack_pointer
    i32.const 0
    i32.const 4
    call $~lib/rt/itcms/__new
-   local.tee $0
+   local.tee $this
    i32.store $0
   end
   global.get $~lib/memory/__stack_pointer
-  local.get $0
+  local.get $this
   call $rt/instanceof/Animal#constructor
-  local.tee $0
+  local.tee $this
   i32.store $0
-  local.get $0
+  local.get $this
   local.set $1
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -2897,7 +2897,7 @@
   global.set $~lib/memory/__stack_pointer
   local.get $1
  )
- (func $rt/instanceof/BlackCat#constructor (param $0 i32) (result i32)
+ (func $rt/instanceof/BlackCat#constructor (param $this i32) (result i32)
   (local $1 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -2907,22 +2907,22 @@
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   i32.store $0
-  local.get $0
+  local.get $this
   i32.eqz
   if
    global.get $~lib/memory/__stack_pointer
    i32.const 0
    i32.const 5
    call $~lib/rt/itcms/__new
-   local.tee $0
+   local.tee $this
    i32.store $0
   end
   global.get $~lib/memory/__stack_pointer
-  local.get $0
+  local.get $this
   call $rt/instanceof/Cat#constructor
-  local.tee $0
+  local.tee $this
   i32.store $0
-  local.get $0
+  local.get $this
   local.set $1
   global.get $~lib/memory/__stack_pointer
   i32.const 4

--- a/tests/compiler/simd.debug.wat
+++ b/tests/compiler/simd.debug.wat
@@ -6760,10 +6760,10 @@
    unreachable
   end
  )
- (func $~lib/rt/__newArray (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
-  (local $4 i32)
-  (local $5 i32)
-  (local $6 i32)
+ (func $~lib/rt/__newArray (param $length i32) (param $alignLog2 i32) (param $id i32) (param $data i32) (result i32)
+  (local $bufferSize i32)
+  (local $buffer i32)
+  (local $array i32)
   (local $7 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -6773,38 +6773,38 @@
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   i32.store $0
-  local.get $0
-  local.get $1
+  local.get $length
+  local.get $alignLog2
   i32.shl
-  local.set $4
+  local.set $bufferSize
   global.get $~lib/memory/__stack_pointer
-  local.get $4
+  local.get $bufferSize
   i32.const 0
-  local.get $3
+  local.get $data
   call $~lib/rt/__newBuffer
-  local.tee $5
+  local.tee $buffer
   i32.store $0
   i32.const 16
-  local.get $2
+  local.get $id
   call $~lib/rt/itcms/__new
-  local.set $6
-  local.get $6
-  local.get $5
+  local.set $array
+  local.get $array
+  local.get $buffer
   i32.store $0
-  local.get $6
-  local.get $5
+  local.get $array
+  local.get $buffer
   i32.const 0
   call $~lib/rt/itcms/__link
-  local.get $6
-  local.get $5
+  local.get $array
+  local.get $buffer
   i32.store $0 offset=4
-  local.get $6
-  local.get $4
+  local.get $array
+  local.get $bufferSize
   i32.store $0 offset=8
-  local.get $6
-  local.get $0
+  local.get $array
+  local.get $length
   i32.store $0 offset=12
-  local.get $6
+  local.get $array
   local.set $7
   global.get $~lib/memory/__stack_pointer
   i32.const 4

--- a/tests/compiler/std/array-access.debug.wat
+++ b/tests/compiler/std/array-access.debug.wat
@@ -223,7 +223,7 @@
    unreachable
   end
  )
- (func $std/array-access/i32ArrayArrayElementAccess (param $0 i32) (result i32)
+ (func $std/array-access/i32ArrayArrayElementAccess (param $a i32) (result i32)
   (local $1 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -233,7 +233,7 @@
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   i32.store $0
-  local.get $0
+  local.get $a
   i32.const 0
   call $~lib/array/Array<~lib/array/Array<i32>>#__get
   local.set $1
@@ -250,7 +250,7 @@
   global.set $~lib/memory/__stack_pointer
   local.get $1
  )
- (func $std/array-access/stringArrayPropertyAccess (param $0 i32) (result i32)
+ (func $std/array-access/stringArrayPropertyAccess (param $a i32) (result i32)
   (local $1 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -260,7 +260,7 @@
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   i32.store $0
-  local.get $0
+  local.get $a
   i32.const 0
   call $~lib/array/Array<~lib/string/String>#__get
   local.set $1
@@ -276,7 +276,7 @@
   global.set $~lib/memory/__stack_pointer
   local.get $1
  )
- (func $std/array-access/stringArrayMethodCall (param $0 i32) (result i32)
+ (func $std/array-access/stringArrayMethodCall (param $a i32) (result i32)
   (local $1 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 8
@@ -286,7 +286,7 @@
   global.get $~lib/memory/__stack_pointer
   i64.const 0
   i64.store $0
-  local.get $0
+  local.get $a
   i32.const 0
   call $~lib/array/Array<~lib/string/String>#__get
   local.set $1
@@ -309,7 +309,7 @@
   global.set $~lib/memory/__stack_pointer
   local.get $1
  )
- (func $std/array-access/stringArrayArrayPropertyAccess (param $0 i32) (result i32)
+ (func $std/array-access/stringArrayArrayPropertyAccess (param $a i32) (result i32)
   (local $1 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 8
@@ -319,7 +319,7 @@
   global.get $~lib/memory/__stack_pointer
   i64.const 0
   i64.store $0
-  local.get $0
+  local.get $a
   i32.const 0
   call $~lib/array/Array<~lib/array/Array<~lib/string/String>>#__get
   local.set $1
@@ -342,7 +342,7 @@
   global.set $~lib/memory/__stack_pointer
   local.get $1
  )
- (func $std/array-access/stringArrayArrayMethodCall (param $0 i32) (result i32)
+ (func $std/array-access/stringArrayArrayMethodCall (param $a i32) (result i32)
   (local $1 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 12
@@ -355,7 +355,7 @@
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   i32.store $0 offset=8
-  local.get $0
+  local.get $a
   i32.const 0
   call $~lib/array/Array<~lib/array/Array<~lib/string/String>>#__get
   local.set $1
@@ -385,8 +385,8 @@
   global.set $~lib/memory/__stack_pointer
   local.get $1
  )
- (func $~lib/array/Array<~lib/array/Array<i32>>#__get (param $0 i32) (param $1 i32) (result i32)
-  (local $2 i32)
+ (func $~lib/array/Array<~lib/array/Array<i32>>#__get (param $this i32) (param $index i32) (result i32)
+  (local $value i32)
   (local $3 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -396,8 +396,8 @@
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   i32.store $0
-  local.get $1
-  local.get $0
+  local.get $index
+  local.get $this
   i32.load $0 offset=12
   i32.ge_u
   if
@@ -409,21 +409,21 @@
    unreachable
   end
   global.get $~lib/memory/__stack_pointer
-  local.get $0
+  local.get $this
   i32.load $0 offset=4
-  local.get $1
+  local.get $index
   i32.const 2
   i32.shl
   i32.add
   i32.load $0
-  local.tee $2
+  local.tee $value
   i32.store $0
   i32.const 1
   drop
   i32.const 0
   i32.eqz
   drop
-  local.get $2
+  local.get $value
   i32.eqz
   if
    i32.const 144
@@ -433,7 +433,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $2
+  local.get $value
   local.set $3
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -441,8 +441,8 @@
   global.set $~lib/memory/__stack_pointer
   local.get $3
  )
- (func $~lib/array/Array<~lib/string/String>#__get (param $0 i32) (param $1 i32) (result i32)
-  (local $2 i32)
+ (func $~lib/array/Array<~lib/string/String>#__get (param $this i32) (param $index i32) (result i32)
+  (local $value i32)
   (local $3 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -452,8 +452,8 @@
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   i32.store $0
-  local.get $1
-  local.get $0
+  local.get $index
+  local.get $this
   i32.load $0 offset=12
   i32.ge_u
   if
@@ -465,21 +465,21 @@
    unreachable
   end
   global.get $~lib/memory/__stack_pointer
-  local.get $0
+  local.get $this
   i32.load $0 offset=4
-  local.get $1
+  local.get $index
   i32.const 2
   i32.shl
   i32.add
   i32.load $0
-  local.tee $2
+  local.tee $value
   i32.store $0
   i32.const 1
   drop
   i32.const 0
   i32.eqz
   drop
-  local.get $2
+  local.get $value
   i32.eqz
   if
    i32.const 144
@@ -489,7 +489,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $2
+  local.get $value
   local.set $3
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -497,8 +497,8 @@
   global.set $~lib/memory/__stack_pointer
   local.get $3
  )
- (func $~lib/array/Array<~lib/array/Array<~lib/string/String>>#__get (param $0 i32) (param $1 i32) (result i32)
-  (local $2 i32)
+ (func $~lib/array/Array<~lib/array/Array<~lib/string/String>>#__get (param $this i32) (param $index i32) (result i32)
+  (local $value i32)
   (local $3 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -508,8 +508,8 @@
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   i32.store $0
-  local.get $1
-  local.get $0
+  local.get $index
+  local.get $this
   i32.load $0 offset=12
   i32.ge_u
   if
@@ -521,21 +521,21 @@
    unreachable
   end
   global.get $~lib/memory/__stack_pointer
-  local.get $0
+  local.get $this
   i32.load $0 offset=4
-  local.get $1
+  local.get $index
   i32.const 2
   i32.shl
   i32.add
   i32.load $0
-  local.tee $2
+  local.tee $value
   i32.store $0
   i32.const 1
   drop
   i32.const 0
   i32.eqz
   drop
-  local.get $2
+  local.get $value
   i32.eqz
   if
    i32.const 144
@@ -545,7 +545,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $2
+  local.get $value
   local.set $3
   global.get $~lib/memory/__stack_pointer
   i32.const 4

--- a/tests/compiler/std/array-literal.debug.wat
+++ b/tests/compiler/std/array-literal.debug.wat
@@ -3215,10 +3215,10 @@
   i32.add
   global.set $~lib/memory/__stack_pointer
  )
- (func $~lib/rt/__newArray (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
-  (local $4 i32)
-  (local $5 i32)
-  (local $6 i32)
+ (func $~lib/rt/__newArray (param $length i32) (param $alignLog2 i32) (param $id i32) (param $data i32) (result i32)
+  (local $bufferSize i32)
+  (local $buffer i32)
+  (local $array i32)
   (local $7 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -3228,38 +3228,38 @@
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   i32.store $0
-  local.get $0
-  local.get $1
+  local.get $length
+  local.get $alignLog2
   i32.shl
-  local.set $4
+  local.set $bufferSize
   global.get $~lib/memory/__stack_pointer
-  local.get $4
+  local.get $bufferSize
   i32.const 0
-  local.get $3
+  local.get $data
   call $~lib/rt/__newBuffer
-  local.tee $5
+  local.tee $buffer
   i32.store $0
   i32.const 16
-  local.get $2
+  local.get $id
   call $~lib/rt/itcms/__new
-  local.set $6
-  local.get $6
-  local.get $5
+  local.set $array
+  local.get $array
+  local.get $buffer
   i32.store $0
-  local.get $6
-  local.get $5
+  local.get $array
+  local.get $buffer
   i32.const 0
   call $~lib/rt/itcms/__link
-  local.get $6
-  local.get $5
+  local.get $array
+  local.get $buffer
   i32.store $0 offset=4
-  local.get $6
-  local.get $4
+  local.get $array
+  local.get $bufferSize
   i32.store $0 offset=8
-  local.get $6
-  local.get $0
+  local.get $array
+  local.get $length
   i32.store $0 offset=12
-  local.get $6
+  local.get $array
   local.set $7
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -3267,7 +3267,7 @@
   global.set $~lib/memory/__stack_pointer
   local.get $7
  )
- (func $std/array-literal/Ref#constructor (param $0 i32) (result i32)
+ (func $std/array-literal/Ref#constructor (param $this i32) (result i32)
   (local $1 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -3277,17 +3277,17 @@
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   i32.store $0
-  local.get $0
+  local.get $this
   i32.eqz
   if
    global.get $~lib/memory/__stack_pointer
    i32.const 0
    i32.const 5
    call $~lib/rt/itcms/__new
-   local.tee $0
+   local.tee $this
    i32.store $0
   end
-  local.get $0
+  local.get $this
   local.set $1
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -3295,7 +3295,7 @@
   global.set $~lib/memory/__stack_pointer
   local.get $1
  )
- (func $std/array-literal/RefWithCtor#constructor (param $0 i32) (result i32)
+ (func $std/array-literal/RefWithCtor#constructor (param $this i32) (result i32)
   (local $1 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -3305,17 +3305,17 @@
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   i32.store $0
-  local.get $0
+  local.get $this
   i32.eqz
   if
    global.get $~lib/memory/__stack_pointer
    i32.const 0
    i32.const 7
    call $~lib/rt/itcms/__new
-   local.tee $0
+   local.tee $this
    i32.store $0
   end
-  local.get $0
+  local.get $this
   local.set $1
   global.get $~lib/memory/__stack_pointer
   i32.const 4

--- a/tests/compiler/std/array.debug.wat
+++ b/tests/compiler/std/array.debug.wat
@@ -19154,7 +19154,7 @@
    unreachable
   end
  )
- (func $std/array/assertSorted<i32> (param $0 i32) (param $1 i32)
+ (func $std/array/assertSorted<i32> (param $arr i32) (param $comparator i32)
   (local $2 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -19164,15 +19164,15 @@
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   i32.store $0
-  local.get $0
-  local.get $1
+  local.get $arr
+  local.get $comparator
   call $~lib/array/Array<i32>#sort
   local.set $2
   global.get $~lib/memory/__stack_pointer
   local.get $2
   i32.store $0
   local.get $2
-  local.get $1
+  local.get $comparator
   call $std/array/isSorted<i32>
   i32.eqz
   if
@@ -19188,7 +19188,7 @@
   i32.add
   global.set $~lib/memory/__stack_pointer
  )
- (func $std/array/assertSortedDefault<i32> (param $0 i32)
+ (func $std/array/assertSortedDefault<i32> (param $arr i32)
   (local $1 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -19198,7 +19198,7 @@
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   i32.store $0
-  local.get $0
+  local.get $arr
   block $~lib/util/sort/COMPARATOR<i32>|inlined.1 (result i32)
    i32.const 1
    drop
@@ -19220,11 +19220,11 @@
   i32.add
   global.set $~lib/memory/__stack_pointer
  )
- (func $~lib/util/sort/extendRunRight<std/array/Dim> (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
-  (local $4 i32)
-  (local $5 i32)
-  (local $6 i32)
-  (local $7 i32)
+ (func $~lib/util/sort/extendRunRight<std/array/Dim> (param $ptr i32) (param $i i32) (param $right i32) (param $comparator i32) (result i32)
+  (local $j i32)
+  (local $var$5 i32)
+  (local $var$6 i32)
+  (local $tmp i32)
   (local $8 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 12
@@ -19237,11 +19237,11 @@
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   i32.store $0 offset=8
-  local.get $1
-  local.get $2
+  local.get $i
+  local.get $right
   i32.eq
   if
-   local.get $1
+   local.get $i
    local.set $8
    global.get $~lib/memory/__stack_pointer
    i32.const 12
@@ -19250,10 +19250,10 @@
    local.get $8
    return
   end
-  local.get $1
-  local.set $4
-  local.get $0
-  local.get $4
+  local.get $i
+  local.set $j
+  local.get $ptr
+  local.get $j
   i32.const 2
   i32.shl
   i32.add
@@ -19263,11 +19263,11 @@
   local.get $8
   i32.store $0
   local.get $8
-  local.get $0
-  local.get $4
+  local.get $ptr
+  local.get $j
   i32.const 1
   i32.add
-  local.tee $4
+  local.tee $j
   i32.const 2
   i32.shl
   i32.add
@@ -19279,19 +19279,19 @@
   local.get $8
   i32.const 2
   global.set $~argumentsLength
-  local.get $3
+  local.get $comparator
   i32.load $0
   call_indirect $0 (type $i32_i32_=>_i32)
   i32.const 0
   i32.gt_s
   if
    loop $while-continue|0
-    local.get $4
-    local.get $2
+    local.get $j
+    local.get $right
     i32.lt_s
     if (result i32)
-     local.get $0
-     local.get $4
+     local.get $ptr
+     local.get $j
      i32.const 2
      i32.shl
      i32.add
@@ -19301,8 +19301,8 @@
      local.get $8
      i32.store $0
      local.get $8
-     local.get $0
-     local.get $4
+     local.get $ptr
+     local.get $j
      i32.const 2
      i32.shl
      i32.add
@@ -19314,7 +19314,7 @@
      local.get $8
      i32.const 2
      global.set $~argumentsLength
-     local.get $3
+     local.get $comparator
      i32.load $0
      call_indirect $0 (type $i32_i32_=>_i32)
      i32.const 31
@@ -19322,72 +19322,72 @@
     else
      i32.const 0
     end
-    local.set $5
-    local.get $5
+    local.set $var$5
+    local.get $var$5
     if
-     local.get $4
+     local.get $j
      i32.const 1
      i32.add
-     local.set $4
+     local.set $j
      br $while-continue|0
     end
    end
-   local.get $4
-   local.set $5
+   local.get $j
+   local.set $var$5
    loop $while-continue|1
-    local.get $1
-    local.get $5
+    local.get $i
+    local.get $var$5
     i32.lt_s
-    local.set $6
-    local.get $6
+    local.set $var$6
+    local.get $var$6
     if
      global.get $~lib/memory/__stack_pointer
-     local.get $0
-     local.get $1
+     local.get $ptr
+     local.get $i
      i32.const 2
      i32.shl
      i32.add
      i32.load $0
-     local.tee $7
+     local.tee $tmp
      i32.store $0 offset=8
-     local.get $0
-     local.get $1
+     local.get $ptr
+     local.get $i
      i32.const 2
      i32.shl
      i32.add
-     local.get $0
-     local.get $5
+     local.get $ptr
+     local.get $var$5
      i32.const 2
      i32.shl
      i32.add
      i32.load $0
      i32.store $0
-     local.get $1
+     local.get $i
      i32.const 1
      i32.add
-     local.set $1
-     local.get $0
-     local.get $5
+     local.set $i
+     local.get $ptr
+     local.get $var$5
      i32.const 2
      i32.shl
      i32.add
-     local.get $7
+     local.get $tmp
      i32.store $0
-     local.get $5
+     local.get $var$5
      i32.const 1
      i32.sub
-     local.set $5
+     local.set $var$5
      br $while-continue|1
     end
    end
   else
    loop $while-continue|2
-    local.get $4
-    local.get $2
+    local.get $j
+    local.get $right
     i32.lt_s
     if (result i32)
-     local.get $0
-     local.get $4
+     local.get $ptr
+     local.get $j
      i32.const 2
      i32.shl
      i32.add
@@ -19397,8 +19397,8 @@
      local.get $8
      i32.store $0
      local.get $8
-     local.get $0
-     local.get $4
+     local.get $ptr
+     local.get $j
      i32.const 2
      i32.shl
      i32.add
@@ -19410,7 +19410,7 @@
      local.get $8
      i32.const 2
      global.set $~argumentsLength
-     local.get $3
+     local.get $comparator
      i32.load $0
      call_indirect $0 (type $i32_i32_=>_i32)
      i32.const 0
@@ -19418,18 +19418,18 @@
     else
      i32.const 0
     end
-    local.set $5
-    local.get $5
+    local.set $var$5
+    local.get $var$5
     if
-     local.get $4
+     local.get $j
      i32.const 1
      i32.add
-     local.set $4
+     local.set $j
      br $while-continue|2
     end
    end
   end
-  local.get $4
+  local.get $j
   local.set $8
   global.get $~lib/memory/__stack_pointer
   i32.const 12
@@ -19438,13 +19438,13 @@
   local.get $8
  )
  (func $std/array/assertStableSortedForComplexObjects
-  (local $0 i32)
-  (local $1 i32)
-  (local $2 i32)
-  (local $3 i32)
-  (local $4 i32)
-  (local $5 i32)
-  (local $6 i32)
+  (local $sorted i32)
+  (local $check i32)
+  (local $var$2 i32)
+  (local $var$3 i32)
+  (local $var$4 i32)
+  (local $var$5 i32)
+  (local $var$6 i32)
   (local $7 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 24
@@ -19477,12 +19477,12 @@
   i32.store $0 offset=4
   local.get $7
   call $~lib/array/Array<std/array/Dim>#sort
-  local.tee $0
+  local.tee $sorted
   i32.store $0 offset=12
   i32.const 1
-  local.set $1
+  local.set $check
   i32.const 0
-  local.set $2
+  local.set $var$2
   global.get $std/array/inputStabArr
   local.set $7
   global.get $~lib/memory/__stack_pointer
@@ -19490,20 +19490,20 @@
   i32.store $0
   local.get $7
   call $~lib/array/Array<std/array/Dim>#get:length
-  local.set $3
+  local.set $var$3
   block $for-break0
    loop $for-loop|0
-    local.get $2
-    local.get $3
+    local.get $var$2
+    local.get $var$3
     i32.lt_s
-    local.set $4
-    local.get $4
+    local.set $var$4
+    local.get $var$4
     if
      global.get $~lib/memory/__stack_pointer
-     local.get $0
-     local.get $2
+     local.get $sorted
+     local.get $var$2
      call $~lib/array/Array<std/array/Dim>#__get
-     local.tee $5
+     local.tee $var$5
      i32.store $0 offset=16
      global.get $~lib/memory/__stack_pointer
      global.get $std/array/outputStabArr
@@ -19512,38 +19512,38 @@
      local.get $7
      i32.store $0
      local.get $7
-     local.get $2
+     local.get $var$2
      call $~lib/array/Array<std/array/Dim>#__get
-     local.tee $6
+     local.tee $var$6
      i32.store $0 offset=20
-     local.get $5
+     local.get $var$5
      i32.load $0
-     local.get $6
+     local.get $var$6
      i32.load $0
      i32.ne
      if (result i32)
       i32.const 1
      else
-      local.get $5
+      local.get $var$5
       i32.load $0 offset=4
-      local.get $6
+      local.get $var$6
       i32.load $0 offset=4
       i32.ne
      end
      if
       i32.const 0
-      local.set $1
+      local.set $check
       br $for-break0
      end
-     local.get $2
+     local.get $var$2
      i32.const 1
      i32.add
-     local.set $2
+     local.set $var$2
      br $for-loop|0
     end
    end
   end
-  local.get $1
+  local.get $check
   i32.eqz
   if
    i32.const 0
@@ -19558,11 +19558,11 @@
   i32.add
   global.set $~lib/memory/__stack_pointer
  )
- (func $~lib/util/sort/extendRunRight<~lib/array/Array<i32>> (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
-  (local $4 i32)
-  (local $5 i32)
-  (local $6 i32)
-  (local $7 i32)
+ (func $~lib/util/sort/extendRunRight<~lib/array/Array<i32>> (param $ptr i32) (param $i i32) (param $right i32) (param $comparator i32) (result i32)
+  (local $j i32)
+  (local $var$5 i32)
+  (local $var$6 i32)
+  (local $tmp i32)
   (local $8 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 12
@@ -19575,11 +19575,11 @@
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   i32.store $0 offset=8
-  local.get $1
-  local.get $2
+  local.get $i
+  local.get $right
   i32.eq
   if
-   local.get $1
+   local.get $i
    local.set $8
    global.get $~lib/memory/__stack_pointer
    i32.const 12
@@ -19588,10 +19588,10 @@
    local.get $8
    return
   end
-  local.get $1
-  local.set $4
-  local.get $0
-  local.get $4
+  local.get $i
+  local.set $j
+  local.get $ptr
+  local.get $j
   i32.const 2
   i32.shl
   i32.add
@@ -19601,11 +19601,11 @@
   local.get $8
   i32.store $0
   local.get $8
-  local.get $0
-  local.get $4
+  local.get $ptr
+  local.get $j
   i32.const 1
   i32.add
-  local.tee $4
+  local.tee $j
   i32.const 2
   i32.shl
   i32.add
@@ -19617,19 +19617,19 @@
   local.get $8
   i32.const 2
   global.set $~argumentsLength
-  local.get $3
+  local.get $comparator
   i32.load $0
   call_indirect $0 (type $i32_i32_=>_i32)
   i32.const 0
   i32.gt_s
   if
    loop $while-continue|0
-    local.get $4
-    local.get $2
+    local.get $j
+    local.get $right
     i32.lt_s
     if (result i32)
-     local.get $0
-     local.get $4
+     local.get $ptr
+     local.get $j
      i32.const 2
      i32.shl
      i32.add
@@ -19639,8 +19639,8 @@
      local.get $8
      i32.store $0
      local.get $8
-     local.get $0
-     local.get $4
+     local.get $ptr
+     local.get $j
      i32.const 2
      i32.shl
      i32.add
@@ -19652,7 +19652,7 @@
      local.get $8
      i32.const 2
      global.set $~argumentsLength
-     local.get $3
+     local.get $comparator
      i32.load $0
      call_indirect $0 (type $i32_i32_=>_i32)
      i32.const 31
@@ -19660,72 +19660,72 @@
     else
      i32.const 0
     end
-    local.set $5
-    local.get $5
+    local.set $var$5
+    local.get $var$5
     if
-     local.get $4
+     local.get $j
      i32.const 1
      i32.add
-     local.set $4
+     local.set $j
      br $while-continue|0
     end
    end
-   local.get $4
-   local.set $5
+   local.get $j
+   local.set $var$5
    loop $while-continue|1
-    local.get $1
-    local.get $5
+    local.get $i
+    local.get $var$5
     i32.lt_s
-    local.set $6
-    local.get $6
+    local.set $var$6
+    local.get $var$6
     if
      global.get $~lib/memory/__stack_pointer
-     local.get $0
-     local.get $1
+     local.get $ptr
+     local.get $i
      i32.const 2
      i32.shl
      i32.add
      i32.load $0
-     local.tee $7
+     local.tee $tmp
      i32.store $0 offset=8
-     local.get $0
-     local.get $1
+     local.get $ptr
+     local.get $i
      i32.const 2
      i32.shl
      i32.add
-     local.get $0
-     local.get $5
+     local.get $ptr
+     local.get $var$5
      i32.const 2
      i32.shl
      i32.add
      i32.load $0
      i32.store $0
-     local.get $1
+     local.get $i
      i32.const 1
      i32.add
-     local.set $1
-     local.get $0
-     local.get $5
+     local.set $i
+     local.get $ptr
+     local.get $var$5
      i32.const 2
      i32.shl
      i32.add
-     local.get $7
+     local.get $tmp
      i32.store $0
-     local.get $5
+     local.get $var$5
      i32.const 1
      i32.sub
-     local.set $5
+     local.set $var$5
      br $while-continue|1
     end
    end
   else
    loop $while-continue|2
-    local.get $4
-    local.get $2
+    local.get $j
+    local.get $right
     i32.lt_s
     if (result i32)
-     local.get $0
-     local.get $4
+     local.get $ptr
+     local.get $j
      i32.const 2
      i32.shl
      i32.add
@@ -19735,8 +19735,8 @@
      local.get $8
      i32.store $0
      local.get $8
-     local.get $0
-     local.get $4
+     local.get $ptr
+     local.get $j
      i32.const 2
      i32.shl
      i32.add
@@ -19748,7 +19748,7 @@
      local.get $8
      i32.const 2
      global.set $~argumentsLength
-     local.get $3
+     local.get $comparator
      i32.load $0
      call_indirect $0 (type $i32_i32_=>_i32)
      i32.const 0
@@ -19756,18 +19756,18 @@
     else
      i32.const 0
     end
-    local.set $5
-    local.get $5
+    local.set $var$5
+    local.get $var$5
     if
-     local.get $4
+     local.get $j
      i32.const 1
      i32.add
-     local.set $4
+     local.set $j
      br $while-continue|2
     end
    end
   end
-  local.get $4
+  local.get $j
   local.set $8
   global.get $~lib/memory/__stack_pointer
   i32.const 12
@@ -19775,10 +19775,10 @@
   global.set $~lib/memory/__stack_pointer
   local.get $8
  )
- (func $std/array/isSorted<~lib/array/Array<i32>> (param $0 i32) (param $1 i32) (result i32)
-  (local $2 i32)
-  (local $3 i32)
-  (local $4 i32)
+ (func $std/array/isSorted<~lib/array/Array<i32>> (param $data i32) (param $comparator i32) (result i32)
+  (local $var$2 i32)
+  (local $var$3 i32)
+  (local $var$4 i32)
   (local $5 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 8
@@ -19789,19 +19789,19 @@
   i64.const 0
   i64.store $0
   i32.const 1
-  local.set $2
-  local.get $0
+  local.set $var$2
+  local.get $data
   call $~lib/array/Array<~lib/array/Array<i32>>#get:length
-  local.set $3
+  local.set $var$3
   loop $for-loop|0
-   local.get $2
-   local.get $3
+   local.get $var$2
+   local.get $var$3
    i32.lt_s
-   local.set $4
-   local.get $4
+   local.set $var$4
+   local.get $var$4
    if
-    local.get $0
-    local.get $2
+    local.get $data
+    local.get $var$2
     i32.const 1
     i32.sub
     call $~lib/array/Array<~lib/array/Array<i32>>#__get
@@ -19810,8 +19810,8 @@
     local.get $5
     i32.store $0
     local.get $5
-    local.get $0
-    local.get $2
+    local.get $data
+    local.get $var$2
     call $~lib/array/Array<~lib/array/Array<i32>>#__get
     local.set $5
     global.get $~lib/memory/__stack_pointer
@@ -19820,7 +19820,7 @@
     local.get $5
     i32.const 2
     global.set $~argumentsLength
-    local.get $1
+    local.get $comparator
     i32.load $0
     call_indirect $0 (type $i32_i32_=>_i32)
     i32.const 0
@@ -19835,10 +19835,10 @@
      local.get $5
      return
     end
-    local.get $2
+    local.get $var$2
     i32.const 1
     i32.add
-    local.set $2
+    local.set $var$2
     br $for-loop|0
    end
   end
@@ -19850,7 +19850,7 @@
   global.set $~lib/memory/__stack_pointer
   local.get $5
  )
- (func $std/array/assertSorted<~lib/array/Array<i32>> (param $0 i32) (param $1 i32)
+ (func $std/array/assertSorted<~lib/array/Array<i32>> (param $arr i32) (param $comparator i32)
   (local $2 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -19860,15 +19860,15 @@
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   i32.store $0
-  local.get $0
-  local.get $1
+  local.get $arr
+  local.get $comparator
   call $~lib/array/Array<~lib/array/Array<i32>>#sort
   local.set $2
   global.get $~lib/memory/__stack_pointer
   local.get $2
   i32.store $0
   local.get $2
-  local.get $1
+  local.get $comparator
   call $std/array/isSorted<~lib/array/Array<i32>>
   i32.eqz
   if
@@ -19884,10 +19884,10 @@
   i32.add
   global.set $~lib/memory/__stack_pointer
  )
- (func $std/array/createReverseOrderedElementsArray (param $0 i32) (result i32)
-  (local $1 i32)
-  (local $2 i32)
-  (local $3 i32)
+ (func $std/array/createReverseOrderedElementsArray (param $size i32) (result i32)
+  (local $arr i32)
+  (local $var$2 i32)
+  (local $var$3 i32)
   (local $4 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 8
@@ -19899,26 +19899,26 @@
   i64.store $0
   global.get $~lib/memory/__stack_pointer
   i32.const 0
-  local.get $0
+  local.get $size
   call $~lib/array/Array<std/array/Proxy<i32>>#constructor
-  local.tee $1
+  local.tee $arr
   i32.store $0
   i32.const 0
-  local.set $2
+  local.set $var$2
   loop $for-loop|0
-   local.get $2
-   local.get $0
+   local.get $var$2
+   local.get $size
    i32.lt_s
-   local.set $3
-   local.get $3
+   local.set $var$3
+   local.get $var$3
    if
-    local.get $1
-    local.get $2
+    local.get $arr
+    local.get $var$2
     i32.const 0
-    local.get $0
+    local.get $size
     i32.const 1
     i32.sub
-    local.get $2
+    local.get $var$2
     i32.sub
     call $std/array/Proxy<i32>#constructor
     local.set $4
@@ -19927,14 +19927,14 @@
     i32.store $0 offset=4
     local.get $4
     call $~lib/array/Array<std/array/Proxy<i32>>#__set
-    local.get $2
+    local.get $var$2
     i32.const 1
     i32.add
-    local.set $2
+    local.set $var$2
     br $for-loop|0
    end
   end
-  local.get $1
+  local.get $arr
   local.set $4
   global.get $~lib/memory/__stack_pointer
   i32.const 8
@@ -19942,11 +19942,11 @@
   global.set $~lib/memory/__stack_pointer
   local.get $4
  )
- (func $~lib/util/sort/extendRunRight<std/array/Proxy<i32>> (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
-  (local $4 i32)
-  (local $5 i32)
-  (local $6 i32)
-  (local $7 i32)
+ (func $~lib/util/sort/extendRunRight<std/array/Proxy<i32>> (param $ptr i32) (param $i i32) (param $right i32) (param $comparator i32) (result i32)
+  (local $j i32)
+  (local $var$5 i32)
+  (local $var$6 i32)
+  (local $tmp i32)
   (local $8 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 12
@@ -19959,11 +19959,11 @@
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   i32.store $0 offset=8
-  local.get $1
-  local.get $2
+  local.get $i
+  local.get $right
   i32.eq
   if
-   local.get $1
+   local.get $i
    local.set $8
    global.get $~lib/memory/__stack_pointer
    i32.const 12
@@ -19972,10 +19972,10 @@
    local.get $8
    return
   end
-  local.get $1
-  local.set $4
-  local.get $0
-  local.get $4
+  local.get $i
+  local.set $j
+  local.get $ptr
+  local.get $j
   i32.const 2
   i32.shl
   i32.add
@@ -19985,11 +19985,11 @@
   local.get $8
   i32.store $0
   local.get $8
-  local.get $0
-  local.get $4
+  local.get $ptr
+  local.get $j
   i32.const 1
   i32.add
-  local.tee $4
+  local.tee $j
   i32.const 2
   i32.shl
   i32.add
@@ -20001,19 +20001,19 @@
   local.get $8
   i32.const 2
   global.set $~argumentsLength
-  local.get $3
+  local.get $comparator
   i32.load $0
   call_indirect $0 (type $i32_i32_=>_i32)
   i32.const 0
   i32.gt_s
   if
    loop $while-continue|0
-    local.get $4
-    local.get $2
+    local.get $j
+    local.get $right
     i32.lt_s
     if (result i32)
-     local.get $0
-     local.get $4
+     local.get $ptr
+     local.get $j
      i32.const 2
      i32.shl
      i32.add
@@ -20023,8 +20023,8 @@
      local.get $8
      i32.store $0
      local.get $8
-     local.get $0
-     local.get $4
+     local.get $ptr
+     local.get $j
      i32.const 2
      i32.shl
      i32.add
@@ -20036,7 +20036,7 @@
      local.get $8
      i32.const 2
      global.set $~argumentsLength
-     local.get $3
+     local.get $comparator
      i32.load $0
      call_indirect $0 (type $i32_i32_=>_i32)
      i32.const 31
@@ -20044,72 +20044,72 @@
     else
      i32.const 0
     end
-    local.set $5
-    local.get $5
+    local.set $var$5
+    local.get $var$5
     if
-     local.get $4
+     local.get $j
      i32.const 1
      i32.add
-     local.set $4
+     local.set $j
      br $while-continue|0
     end
    end
-   local.get $4
-   local.set $5
+   local.get $j
+   local.set $var$5
    loop $while-continue|1
-    local.get $1
-    local.get $5
+    local.get $i
+    local.get $var$5
     i32.lt_s
-    local.set $6
-    local.get $6
+    local.set $var$6
+    local.get $var$6
     if
      global.get $~lib/memory/__stack_pointer
-     local.get $0
-     local.get $1
+     local.get $ptr
+     local.get $i
      i32.const 2
      i32.shl
      i32.add
      i32.load $0
-     local.tee $7
+     local.tee $tmp
      i32.store $0 offset=8
-     local.get $0
-     local.get $1
+     local.get $ptr
+     local.get $i
      i32.const 2
      i32.shl
      i32.add
-     local.get $0
-     local.get $5
+     local.get $ptr
+     local.get $var$5
      i32.const 2
      i32.shl
      i32.add
      i32.load $0
      i32.store $0
-     local.get $1
+     local.get $i
      i32.const 1
      i32.add
-     local.set $1
-     local.get $0
-     local.get $5
+     local.set $i
+     local.get $ptr
+     local.get $var$5
      i32.const 2
      i32.shl
      i32.add
-     local.get $7
+     local.get $tmp
      i32.store $0
-     local.get $5
+     local.get $var$5
      i32.const 1
      i32.sub
-     local.set $5
+     local.set $var$5
      br $while-continue|1
     end
    end
   else
    loop $while-continue|2
-    local.get $4
-    local.get $2
+    local.get $j
+    local.get $right
     i32.lt_s
     if (result i32)
-     local.get $0
-     local.get $4
+     local.get $ptr
+     local.get $j
      i32.const 2
      i32.shl
      i32.add
@@ -20119,8 +20119,8 @@
      local.get $8
      i32.store $0
      local.get $8
-     local.get $0
-     local.get $4
+     local.get $ptr
+     local.get $j
      i32.const 2
      i32.shl
      i32.add
@@ -20132,7 +20132,7 @@
      local.get $8
      i32.const 2
      global.set $~argumentsLength
-     local.get $3
+     local.get $comparator
      i32.load $0
      call_indirect $0 (type $i32_i32_=>_i32)
      i32.const 0
@@ -20140,18 +20140,18 @@
     else
      i32.const 0
     end
-    local.set $5
-    local.get $5
+    local.set $var$5
+    local.get $var$5
     if
-     local.get $4
+     local.get $j
      i32.const 1
      i32.add
-     local.set $4
+     local.set $j
      br $while-continue|2
     end
    end
   end
-  local.get $4
+  local.get $j
   local.set $8
   global.get $~lib/memory/__stack_pointer
   i32.const 12
@@ -20159,10 +20159,10 @@
   global.set $~lib/memory/__stack_pointer
   local.get $8
  )
- (func $std/array/isSorted<std/array/Proxy<i32>> (param $0 i32) (param $1 i32) (result i32)
-  (local $2 i32)
-  (local $3 i32)
-  (local $4 i32)
+ (func $std/array/isSorted<std/array/Proxy<i32>> (param $data i32) (param $comparator i32) (result i32)
+  (local $var$2 i32)
+  (local $var$3 i32)
+  (local $var$4 i32)
   (local $5 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 8
@@ -20173,19 +20173,19 @@
   i64.const 0
   i64.store $0
   i32.const 1
-  local.set $2
-  local.get $0
+  local.set $var$2
+  local.get $data
   call $~lib/array/Array<std/array/Proxy<i32>>#get:length
-  local.set $3
+  local.set $var$3
   loop $for-loop|0
-   local.get $2
-   local.get $3
+   local.get $var$2
+   local.get $var$3
    i32.lt_s
-   local.set $4
-   local.get $4
+   local.set $var$4
+   local.get $var$4
    if
-    local.get $0
-    local.get $2
+    local.get $data
+    local.get $var$2
     i32.const 1
     i32.sub
     call $~lib/array/Array<std/array/Proxy<i32>>#__get
@@ -20194,8 +20194,8 @@
     local.get $5
     i32.store $0
     local.get $5
-    local.get $0
-    local.get $2
+    local.get $data
+    local.get $var$2
     call $~lib/array/Array<std/array/Proxy<i32>>#__get
     local.set $5
     global.get $~lib/memory/__stack_pointer
@@ -20204,7 +20204,7 @@
     local.get $5
     i32.const 2
     global.set $~argumentsLength
-    local.get $1
+    local.get $comparator
     i32.load $0
     call_indirect $0 (type $i32_i32_=>_i32)
     i32.const 0
@@ -20219,10 +20219,10 @@
      local.get $5
      return
     end
-    local.get $2
+    local.get $var$2
     i32.const 1
     i32.add
-    local.set $2
+    local.set $var$2
     br $for-loop|0
    end
   end
@@ -20234,7 +20234,7 @@
   global.set $~lib/memory/__stack_pointer
   local.get $5
  )
- (func $std/array/assertSorted<std/array/Proxy<i32>> (param $0 i32) (param $1 i32)
+ (func $std/array/assertSorted<std/array/Proxy<i32>> (param $arr i32) (param $comparator i32)
   (local $2 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -20244,15 +20244,15 @@
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   i32.store $0
-  local.get $0
-  local.get $1
+  local.get $arr
+  local.get $comparator
   call $~lib/array/Array<std/array/Proxy<i32>>#sort
   local.set $2
   global.get $~lib/memory/__stack_pointer
   local.get $2
   i32.store $0
   local.get $2
-  local.get $1
+  local.get $comparator
   call $std/array/isSorted<std/array/Proxy<i32>>
   i32.eqz
   if
@@ -20268,11 +20268,11 @@
   i32.add
   global.set $~lib/memory/__stack_pointer
  )
- (func $~lib/util/sort/extendRunRight<~lib/string/String|null> (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
-  (local $4 i32)
-  (local $5 i32)
-  (local $6 i32)
-  (local $7 i32)
+ (func $~lib/util/sort/extendRunRight<~lib/string/String|null> (param $ptr i32) (param $i i32) (param $right i32) (param $comparator i32) (result i32)
+  (local $j i32)
+  (local $var$5 i32)
+  (local $var$6 i32)
+  (local $tmp i32)
   (local $8 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 12
@@ -20285,11 +20285,11 @@
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   i32.store $0 offset=8
-  local.get $1
-  local.get $2
+  local.get $i
+  local.get $right
   i32.eq
   if
-   local.get $1
+   local.get $i
    local.set $8
    global.get $~lib/memory/__stack_pointer
    i32.const 12
@@ -20298,10 +20298,10 @@
    local.get $8
    return
   end
-  local.get $1
-  local.set $4
-  local.get $0
-  local.get $4
+  local.get $i
+  local.set $j
+  local.get $ptr
+  local.get $j
   i32.const 2
   i32.shl
   i32.add
@@ -20311,11 +20311,11 @@
   local.get $8
   i32.store $0
   local.get $8
-  local.get $0
-  local.get $4
+  local.get $ptr
+  local.get $j
   i32.const 1
   i32.add
-  local.tee $4
+  local.tee $j
   i32.const 2
   i32.shl
   i32.add
@@ -20327,19 +20327,19 @@
   local.get $8
   i32.const 2
   global.set $~argumentsLength
-  local.get $3
+  local.get $comparator
   i32.load $0
   call_indirect $0 (type $i32_i32_=>_i32)
   i32.const 0
   i32.gt_s
   if
    loop $while-continue|0
-    local.get $4
-    local.get $2
+    local.get $j
+    local.get $right
     i32.lt_s
     if (result i32)
-     local.get $0
-     local.get $4
+     local.get $ptr
+     local.get $j
      i32.const 2
      i32.shl
      i32.add
@@ -20349,8 +20349,8 @@
      local.get $8
      i32.store $0
      local.get $8
-     local.get $0
-     local.get $4
+     local.get $ptr
+     local.get $j
      i32.const 2
      i32.shl
      i32.add
@@ -20362,7 +20362,7 @@
      local.get $8
      i32.const 2
      global.set $~argumentsLength
-     local.get $3
+     local.get $comparator
      i32.load $0
      call_indirect $0 (type $i32_i32_=>_i32)
      i32.const 31
@@ -20370,72 +20370,72 @@
     else
      i32.const 0
     end
-    local.set $5
-    local.get $5
+    local.set $var$5
+    local.get $var$5
     if
-     local.get $4
+     local.get $j
      i32.const 1
      i32.add
-     local.set $4
+     local.set $j
      br $while-continue|0
     end
    end
-   local.get $4
-   local.set $5
+   local.get $j
+   local.set $var$5
    loop $while-continue|1
-    local.get $1
-    local.get $5
+    local.get $i
+    local.get $var$5
     i32.lt_s
-    local.set $6
-    local.get $6
+    local.set $var$6
+    local.get $var$6
     if
      global.get $~lib/memory/__stack_pointer
-     local.get $0
-     local.get $1
+     local.get $ptr
+     local.get $i
      i32.const 2
      i32.shl
      i32.add
      i32.load $0
-     local.tee $7
+     local.tee $tmp
      i32.store $0 offset=8
-     local.get $0
-     local.get $1
+     local.get $ptr
+     local.get $i
      i32.const 2
      i32.shl
      i32.add
-     local.get $0
-     local.get $5
+     local.get $ptr
+     local.get $var$5
      i32.const 2
      i32.shl
      i32.add
      i32.load $0
      i32.store $0
-     local.get $1
+     local.get $i
      i32.const 1
      i32.add
-     local.set $1
-     local.get $0
-     local.get $5
+     local.set $i
+     local.get $ptr
+     local.get $var$5
      i32.const 2
      i32.shl
      i32.add
-     local.get $7
+     local.get $tmp
      i32.store $0
-     local.get $5
+     local.get $var$5
      i32.const 1
      i32.sub
-     local.set $5
+     local.set $var$5
      br $while-continue|1
     end
    end
   else
    loop $while-continue|2
-    local.get $4
-    local.get $2
+    local.get $j
+    local.get $right
     i32.lt_s
     if (result i32)
-     local.get $0
-     local.get $4
+     local.get $ptr
+     local.get $j
      i32.const 2
      i32.shl
      i32.add
@@ -20445,8 +20445,8 @@
      local.get $8
      i32.store $0
      local.get $8
-     local.get $0
-     local.get $4
+     local.get $ptr
+     local.get $j
      i32.const 2
      i32.shl
      i32.add
@@ -20458,7 +20458,7 @@
      local.get $8
      i32.const 2
      global.set $~argumentsLength
-     local.get $3
+     local.get $comparator
      i32.load $0
      call_indirect $0 (type $i32_i32_=>_i32)
      i32.const 0
@@ -20466,18 +20466,18 @@
     else
      i32.const 0
     end
-    local.set $5
-    local.get $5
+    local.set $var$5
+    local.get $var$5
     if
-     local.get $4
+     local.get $j
      i32.const 1
      i32.add
-     local.set $4
+     local.set $j
      br $while-continue|2
     end
    end
   end
-  local.get $4
+  local.get $j
   local.set $8
   global.get $~lib/memory/__stack_pointer
   i32.const 12
@@ -20485,10 +20485,10 @@
   global.set $~lib/memory/__stack_pointer
   local.get $8
  )
- (func $std/array/isSorted<~lib/string/String|null> (param $0 i32) (param $1 i32) (result i32)
-  (local $2 i32)
-  (local $3 i32)
-  (local $4 i32)
+ (func $std/array/isSorted<~lib/string/String|null> (param $data i32) (param $comparator i32) (result i32)
+  (local $var$2 i32)
+  (local $var$3 i32)
+  (local $var$4 i32)
   (local $5 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 8
@@ -20499,19 +20499,19 @@
   i64.const 0
   i64.store $0
   i32.const 1
-  local.set $2
-  local.get $0
+  local.set $var$2
+  local.get $data
   call $~lib/array/Array<~lib/string/String|null>#get:length
-  local.set $3
+  local.set $var$3
   loop $for-loop|0
-   local.get $2
-   local.get $3
+   local.get $var$2
+   local.get $var$3
    i32.lt_s
-   local.set $4
-   local.get $4
+   local.set $var$4
+   local.get $var$4
    if
-    local.get $0
-    local.get $2
+    local.get $data
+    local.get $var$2
     i32.const 1
     i32.sub
     call $~lib/array/Array<~lib/string/String|null>#__get
@@ -20520,8 +20520,8 @@
     local.get $5
     i32.store $0
     local.get $5
-    local.get $0
-    local.get $2
+    local.get $data
+    local.get $var$2
     call $~lib/array/Array<~lib/string/String|null>#__get
     local.set $5
     global.get $~lib/memory/__stack_pointer
@@ -20530,7 +20530,7 @@
     local.get $5
     i32.const 2
     global.set $~argumentsLength
-    local.get $1
+    local.get $comparator
     i32.load $0
     call_indirect $0 (type $i32_i32_=>_i32)
     i32.const 0
@@ -20545,10 +20545,10 @@
      local.get $5
      return
     end
-    local.get $2
+    local.get $var$2
     i32.const 1
     i32.add
-    local.set $2
+    local.set $var$2
     br $for-loop|0
    end
   end
@@ -20560,7 +20560,7 @@
   global.set $~lib/memory/__stack_pointer
   local.get $5
  )
- (func $std/array/assertSorted<~lib/string/String|null> (param $0 i32) (param $1 i32)
+ (func $std/array/assertSorted<~lib/string/String|null> (param $arr i32) (param $comparator i32)
   (local $2 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -20570,15 +20570,15 @@
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   i32.store $0
-  local.get $0
-  local.get $1
+  local.get $arr
+  local.get $comparator
   call $~lib/array/Array<~lib/string/String|null>#sort
   local.set $2
   global.get $~lib/memory/__stack_pointer
   local.get $2
   i32.store $0
   local.get $2
-  local.get $1
+  local.get $comparator
   call $std/array/isSorted<~lib/string/String|null>
   i32.eqz
   if
@@ -20594,9 +20594,9 @@
   i32.add
   global.set $~lib/memory/__stack_pointer
  )
- (func $std/array/isArraysEqual<~lib/string/String|null> (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
-  (local $3 i32)
-  (local $4 i32)
+ (func $std/array/isArraysEqual<~lib/string/String|null> (param $a i32) (param $b i32) (param $len i32) (result i32)
+  (local $var$3 i32)
+  (local $var$4 i32)
   (local $5 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 8
@@ -20606,14 +20606,14 @@
   global.get $~lib/memory/__stack_pointer
   i64.const 0
   i64.store $0
-  local.get $2
+  local.get $len
   i32.eqz
   if
-   local.get $0
+   local.get $a
    call $~lib/array/Array<~lib/string/String|null>#get:length
-   local.set $2
-   local.get $2
-   local.get $1
+   local.set $len
+   local.get $len
+   local.get $b
    call $~lib/array/Array<~lib/string/String|null>#get:length
    i32.ne
    if
@@ -20626,8 +20626,8 @@
     local.get $5
     return
    end
-   local.get $0
-   local.get $1
+   local.get $a
+   local.get $b
    i32.eq
    if
     i32.const 1
@@ -20641,26 +20641,26 @@
    end
   end
   i32.const 0
-  local.set $3
+  local.set $var$3
   loop $for-loop|0
-   local.get $3
-   local.get $2
+   local.get $var$3
+   local.get $len
    i32.lt_s
-   local.set $4
-   local.get $4
+   local.set $var$4
+   local.get $var$4
    if
     i32.const 0
     drop
-    local.get $0
-    local.get $3
+    local.get $a
+    local.get $var$3
     call $~lib/array/Array<~lib/string/String|null>#__get
     local.set $5
     global.get $~lib/memory/__stack_pointer
     local.get $5
     i32.store $0
     local.get $5
-    local.get $1
-    local.get $3
+    local.get $b
+    local.get $var$3
     call $~lib/array/Array<~lib/string/String|null>#__get
     local.set $5
     global.get $~lib/memory/__stack_pointer
@@ -20678,10 +20678,10 @@
      local.get $5
      return
     end
-    local.get $3
+    local.get $var$3
     i32.const 1
     i32.add
-    local.set $3
+    local.set $var$3
     br $for-loop|0
    end
   end
@@ -20693,11 +20693,11 @@
   global.set $~lib/memory/__stack_pointer
   local.get $5
  )
- (func $std/array/createRandomString (param $0 i32) (result i32)
-  (local $1 i32)
-  (local $2 i32)
-  (local $3 i32)
-  (local $4 f64)
+ (func $std/array/createRandomString (param $len i32) (result i32)
+  (local $result i32)
+  (local $var$2 i32)
+  (local $var$3 i32)
+  (local $var$4 f64)
   (local $5 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 12
@@ -20712,19 +20712,19 @@
   i32.store $0 offset=8
   global.get $~lib/memory/__stack_pointer
   i32.const 10480
-  local.tee $1
+  local.tee $result
   i32.store $0
   i32.const 0
-  local.set $2
+  local.set $var$2
   loop $for-loop|0
-   local.get $2
-   local.get $0
+   local.get $var$2
+   local.get $len
    i32.lt_s
-   local.set $3
-   local.get $3
+   local.set $var$3
+   local.get $var$3
    if
     global.get $~lib/memory/__stack_pointer
-    local.get $1
+    local.get $result
     global.get $std/array/charset
     local.set $5
     global.get $~lib/memory/__stack_pointer
@@ -20741,8 +20741,8 @@
     call $~lib/string/String#get:length
     f64.convert_i32_s
     f64.mul
-    local.set $4
-    local.get $4
+    local.set $var$4
+    local.get $var$4
     f64.floor
     i32.trunc_sat_f64_s
     call $~lib/string/String#charAt
@@ -20752,16 +20752,16 @@
     i32.store $0 offset=4
     local.get $5
     call $~lib/string/String.__concat
-    local.tee $1
+    local.tee $result
     i32.store $0
-    local.get $2
+    local.get $var$2
     i32.const 1
     i32.add
-    local.set $2
+    local.set $var$2
     br $for-loop|0
    end
   end
-  local.get $1
+  local.get $result
   local.set $5
   global.get $~lib/memory/__stack_pointer
   i32.const 12
@@ -20769,10 +20769,10 @@
   global.set $~lib/memory/__stack_pointer
   local.get $5
  )
- (func $std/array/createRandomStringArray (param $0 i32) (result i32)
-  (local $1 i32)
-  (local $2 i32)
-  (local $3 i32)
+ (func $std/array/createRandomStringArray (param $size i32) (result i32)
+  (local $arr i32)
+  (local $var$2 i32)
+  (local $var$3 i32)
   (local $4 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 8
@@ -20784,21 +20784,21 @@
   i64.store $0
   global.get $~lib/memory/__stack_pointer
   i32.const 0
-  local.get $0
+  local.get $size
   call $~lib/array/Array<~lib/string/String>#constructor
-  local.tee $1
+  local.tee $arr
   i32.store $0
   i32.const 0
-  local.set $2
+  local.set $var$2
   loop $for-loop|0
-   local.get $2
-   local.get $0
+   local.get $var$2
+   local.get $size
    i32.lt_s
-   local.set $3
-   local.get $3
+   local.set $var$3
+   local.get $var$3
    if
-    local.get $1
-    local.get $2
+    local.get $arr
+    local.get $var$2
     call $~lib/math/NativeMath.random
     f64.const 32
     f64.mul
@@ -20810,14 +20810,14 @@
     i32.store $0 offset=4
     local.get $4
     call $~lib/array/Array<~lib/string/String>#__set
-    local.get $2
+    local.get $var$2
     i32.const 1
     i32.add
-    local.set $2
+    local.set $var$2
     br $for-loop|0
    end
   end
-  local.get $1
+  local.get $arr
   local.set $4
   global.get $~lib/memory/__stack_pointer
   i32.const 8
@@ -20825,11 +20825,11 @@
   global.set $~lib/memory/__stack_pointer
   local.get $4
  )
- (func $~lib/util/sort/extendRunRight<~lib/string/String> (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
-  (local $4 i32)
-  (local $5 i32)
-  (local $6 i32)
-  (local $7 i32)
+ (func $~lib/util/sort/extendRunRight<~lib/string/String> (param $ptr i32) (param $i i32) (param $right i32) (param $comparator i32) (result i32)
+  (local $j i32)
+  (local $var$5 i32)
+  (local $var$6 i32)
+  (local $tmp i32)
   (local $8 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 12
@@ -20842,11 +20842,11 @@
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   i32.store $0 offset=8
-  local.get $1
-  local.get $2
+  local.get $i
+  local.get $right
   i32.eq
   if
-   local.get $1
+   local.get $i
    local.set $8
    global.get $~lib/memory/__stack_pointer
    i32.const 12
@@ -20855,10 +20855,10 @@
    local.get $8
    return
   end
-  local.get $1
-  local.set $4
-  local.get $0
-  local.get $4
+  local.get $i
+  local.set $j
+  local.get $ptr
+  local.get $j
   i32.const 2
   i32.shl
   i32.add
@@ -20868,11 +20868,11 @@
   local.get $8
   i32.store $0
   local.get $8
-  local.get $0
-  local.get $4
+  local.get $ptr
+  local.get $j
   i32.const 1
   i32.add
-  local.tee $4
+  local.tee $j
   i32.const 2
   i32.shl
   i32.add
@@ -20884,19 +20884,19 @@
   local.get $8
   i32.const 2
   global.set $~argumentsLength
-  local.get $3
+  local.get $comparator
   i32.load $0
   call_indirect $0 (type $i32_i32_=>_i32)
   i32.const 0
   i32.gt_s
   if
    loop $while-continue|0
-    local.get $4
-    local.get $2
+    local.get $j
+    local.get $right
     i32.lt_s
     if (result i32)
-     local.get $0
-     local.get $4
+     local.get $ptr
+     local.get $j
      i32.const 2
      i32.shl
      i32.add
@@ -20906,8 +20906,8 @@
      local.get $8
      i32.store $0
      local.get $8
-     local.get $0
-     local.get $4
+     local.get $ptr
+     local.get $j
      i32.const 2
      i32.shl
      i32.add
@@ -20919,7 +20919,7 @@
      local.get $8
      i32.const 2
      global.set $~argumentsLength
-     local.get $3
+     local.get $comparator
      i32.load $0
      call_indirect $0 (type $i32_i32_=>_i32)
      i32.const 31
@@ -20927,72 +20927,72 @@
     else
      i32.const 0
     end
-    local.set $5
-    local.get $5
+    local.set $var$5
+    local.get $var$5
     if
-     local.get $4
+     local.get $j
      i32.const 1
      i32.add
-     local.set $4
+     local.set $j
      br $while-continue|0
     end
    end
-   local.get $4
-   local.set $5
+   local.get $j
+   local.set $var$5
    loop $while-continue|1
-    local.get $1
-    local.get $5
+    local.get $i
+    local.get $var$5
     i32.lt_s
-    local.set $6
-    local.get $6
+    local.set $var$6
+    local.get $var$6
     if
      global.get $~lib/memory/__stack_pointer
-     local.get $0
-     local.get $1
+     local.get $ptr
+     local.get $i
      i32.const 2
      i32.shl
      i32.add
      i32.load $0
-     local.tee $7
+     local.tee $tmp
      i32.store $0 offset=8
-     local.get $0
-     local.get $1
+     local.get $ptr
+     local.get $i
      i32.const 2
      i32.shl
      i32.add
-     local.get $0
-     local.get $5
+     local.get $ptr
+     local.get $var$5
      i32.const 2
      i32.shl
      i32.add
      i32.load $0
      i32.store $0
-     local.get $1
+     local.get $i
      i32.const 1
      i32.add
-     local.set $1
-     local.get $0
-     local.get $5
+     local.set $i
+     local.get $ptr
+     local.get $var$5
      i32.const 2
      i32.shl
      i32.add
-     local.get $7
+     local.get $tmp
      i32.store $0
-     local.get $5
+     local.get $var$5
      i32.const 1
      i32.sub
-     local.set $5
+     local.set $var$5
      br $while-continue|1
     end
    end
   else
    loop $while-continue|2
-    local.get $4
-    local.get $2
+    local.get $j
+    local.get $right
     i32.lt_s
     if (result i32)
-     local.get $0
-     local.get $4
+     local.get $ptr
+     local.get $j
      i32.const 2
      i32.shl
      i32.add
@@ -21002,8 +21002,8 @@
      local.get $8
      i32.store $0
      local.get $8
-     local.get $0
-     local.get $4
+     local.get $ptr
+     local.get $j
      i32.const 2
      i32.shl
      i32.add
@@ -21015,7 +21015,7 @@
      local.get $8
      i32.const 2
      global.set $~argumentsLength
-     local.get $3
+     local.get $comparator
      i32.load $0
      call_indirect $0 (type $i32_i32_=>_i32)
      i32.const 0
@@ -21023,18 +21023,18 @@
     else
      i32.const 0
     end
-    local.set $5
-    local.get $5
+    local.set $var$5
+    local.get $var$5
     if
-     local.get $4
+     local.get $j
      i32.const 1
      i32.add
-     local.set $4
+     local.set $j
      br $while-continue|2
     end
    end
   end
-  local.get $4
+  local.get $j
   local.set $8
   global.get $~lib/memory/__stack_pointer
   i32.const 12
@@ -21042,10 +21042,10 @@
   global.set $~lib/memory/__stack_pointer
   local.get $8
  )
- (func $std/array/isSorted<~lib/string/String> (param $0 i32) (param $1 i32) (result i32)
-  (local $2 i32)
-  (local $3 i32)
-  (local $4 i32)
+ (func $std/array/isSorted<~lib/string/String> (param $data i32) (param $comparator i32) (result i32)
+  (local $var$2 i32)
+  (local $var$3 i32)
+  (local $var$4 i32)
   (local $5 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 8
@@ -21056,19 +21056,19 @@
   i64.const 0
   i64.store $0
   i32.const 1
-  local.set $2
-  local.get $0
+  local.set $var$2
+  local.get $data
   call $~lib/array/Array<~lib/string/String>#get:length
-  local.set $3
+  local.set $var$3
   loop $for-loop|0
-   local.get $2
-   local.get $3
+   local.get $var$2
+   local.get $var$3
    i32.lt_s
-   local.set $4
-   local.get $4
+   local.set $var$4
+   local.get $var$4
    if
-    local.get $0
-    local.get $2
+    local.get $data
+    local.get $var$2
     i32.const 1
     i32.sub
     call $~lib/array/Array<~lib/string/String>#__get
@@ -21077,8 +21077,8 @@
     local.get $5
     i32.store $0
     local.get $5
-    local.get $0
-    local.get $2
+    local.get $data
+    local.get $var$2
     call $~lib/array/Array<~lib/string/String>#__get
     local.set $5
     global.get $~lib/memory/__stack_pointer
@@ -21087,7 +21087,7 @@
     local.get $5
     i32.const 2
     global.set $~argumentsLength
-    local.get $1
+    local.get $comparator
     i32.load $0
     call_indirect $0 (type $i32_i32_=>_i32)
     i32.const 0
@@ -21102,10 +21102,10 @@
      local.get $5
      return
     end
-    local.get $2
+    local.get $var$2
     i32.const 1
     i32.add
-    local.set $2
+    local.set $var$2
     br $for-loop|0
    end
   end
@@ -21117,7 +21117,7 @@
   global.set $~lib/memory/__stack_pointer
   local.get $5
  )
- (func $std/array/assertSorted<~lib/string/String> (param $0 i32) (param $1 i32)
+ (func $std/array/assertSorted<~lib/string/String> (param $arr i32) (param $comparator i32)
   (local $2 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -21127,15 +21127,15 @@
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   i32.store $0
-  local.get $0
-  local.get $1
+  local.get $arr
+  local.get $comparator
   call $~lib/array/Array<~lib/string/String>#sort
   local.set $2
   global.get $~lib/memory/__stack_pointer
   local.get $2
   i32.store $0
   local.get $2
-  local.get $1
+  local.get $comparator
   call $std/array/isSorted<~lib/string/String>
   i32.eqz
   if
@@ -21151,13 +21151,13 @@
   i32.add
   global.set $~lib/memory/__stack_pointer
  )
- (func $~lib/util/string/joinReferenceArray<std/array/Ref|null> (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
-  (local $3 i32)
-  (local $4 i32)
-  (local $5 i32)
-  (local $6 i32)
-  (local $7 i32)
-  (local $8 i32)
+ (func $~lib/util/string/joinReferenceArray<std/array/Ref|null> (param $dataStart i32) (param $length i32) (param $separator i32) (result i32)
+  (local $lastIndex i32)
+  (local $value i32)
+  (local $result i32)
+  (local $sepLen i32)
+  (local $var$7 i32)
+  (local $var$8 i32)
   (local $9 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 12
@@ -21170,11 +21170,11 @@
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   i32.store $0 offset=8
-  local.get $1
+  local.get $length
   i32.const 1
   i32.sub
-  local.set $3
-  local.get $3
+  local.set $lastIndex
+  local.get $lastIndex
   i32.const 0
   i32.lt_s
   if
@@ -21187,19 +21187,19 @@
    local.get $9
    return
   end
-  local.get $3
+  local.get $lastIndex
   i32.eqz
   if
    global.get $~lib/memory/__stack_pointer
-   local.get $0
+   local.get $dataStart
    i32.load $0
-   local.tee $4
+   local.tee $value
    i32.store $0
-   local.get $4
+   local.get $value
    i32.const 0
    i32.ne
    if (result i32)
-    local.get $4
+    local.get $value
     call $std/array/Ref#toString
    else
     i32.const 10480
@@ -21214,36 +21214,36 @@
   end
   global.get $~lib/memory/__stack_pointer
   i32.const 10480
-  local.tee $5
+  local.tee $result
   i32.store $0 offset=4
-  local.get $2
+  local.get $separator
   call $~lib/string/String#get:length
-  local.set $6
+  local.set $sepLen
   i32.const 0
-  local.set $7
+  local.set $var$7
   loop $for-loop|0
-   local.get $7
-   local.get $3
+   local.get $var$7
+   local.get $lastIndex
    i32.lt_s
-   local.set $8
-   local.get $8
+   local.set $var$8
+   local.get $var$8
    if
     global.get $~lib/memory/__stack_pointer
-    local.get $0
-    local.get $7
+    local.get $dataStart
+    local.get $var$7
     i32.const 2
     i32.shl
     i32.add
     i32.load $0
-    local.tee $4
+    local.tee $value
     i32.store $0
-    local.get $4
+    local.get $value
     i32.const 0
     i32.ne
     if
      global.get $~lib/memory/__stack_pointer
-     local.get $5
-     local.get $4
+     local.get $result
+     local.get $value
      call $std/array/Ref#toString
      local.set $9
      global.get $~lib/memory/__stack_pointer
@@ -21251,41 +21251,41 @@
      i32.store $0 offset=8
      local.get $9
      call $~lib/string/String.__concat
-     local.tee $5
+     local.tee $result
      i32.store $0 offset=4
     end
-    local.get $6
+    local.get $sepLen
     if
      global.get $~lib/memory/__stack_pointer
-     local.get $5
-     local.get $2
+     local.get $result
+     local.get $separator
      call $~lib/string/String.__concat
-     local.tee $5
+     local.tee $result
      i32.store $0 offset=4
     end
-    local.get $7
+    local.get $var$7
     i32.const 1
     i32.add
-    local.set $7
+    local.set $var$7
     br $for-loop|0
    end
   end
   global.get $~lib/memory/__stack_pointer
-  local.get $0
-  local.get $3
+  local.get $dataStart
+  local.get $lastIndex
   i32.const 2
   i32.shl
   i32.add
   i32.load $0
-  local.tee $4
+  local.tee $value
   i32.store $0
-  local.get $4
+  local.get $value
   i32.const 0
   i32.ne
   if
    global.get $~lib/memory/__stack_pointer
-   local.get $5
-   local.get $4
+   local.get $result
+   local.get $value
    call $std/array/Ref#toString
    local.set $9
    global.get $~lib/memory/__stack_pointer
@@ -21293,10 +21293,10 @@
    i32.store $0 offset=8
    local.get $9
    call $~lib/string/String.__concat
-   local.tee $5
+   local.tee $result
    i32.store $0 offset=4
   end
-  local.get $5
+  local.get $result
   local.set $9
   global.get $~lib/memory/__stack_pointer
   i32.const 12
@@ -21304,13 +21304,13 @@
   global.set $~lib/memory/__stack_pointer
   local.get $9
  )
- (func $~lib/util/string/joinReferenceArray<std/array/Ref> (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
-  (local $3 i32)
-  (local $4 i32)
-  (local $5 i32)
-  (local $6 i32)
-  (local $7 i32)
-  (local $8 i32)
+ (func $~lib/util/string/joinReferenceArray<std/array/Ref> (param $dataStart i32) (param $length i32) (param $separator i32) (result i32)
+  (local $lastIndex i32)
+  (local $value i32)
+  (local $result i32)
+  (local $sepLen i32)
+  (local $var$7 i32)
+  (local $var$8 i32)
   (local $9 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 12
@@ -21323,11 +21323,11 @@
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   i32.store $0 offset=8
-  local.get $1
+  local.get $length
   i32.const 1
   i32.sub
-  local.set $3
-  local.get $3
+  local.set $lastIndex
+  local.get $lastIndex
   i32.const 0
   i32.lt_s
   if
@@ -21340,19 +21340,19 @@
    local.get $9
    return
   end
-  local.get $3
+  local.get $lastIndex
   i32.eqz
   if
    global.get $~lib/memory/__stack_pointer
-   local.get $0
+   local.get $dataStart
    i32.load $0
-   local.tee $4
+   local.tee $value
    i32.store $0
-   local.get $4
+   local.get $value
    i32.const 0
    i32.ne
    if (result i32)
-    local.get $4
+    local.get $value
     call $std/array/Ref#toString
    else
     i32.const 10480
@@ -21367,36 +21367,36 @@
   end
   global.get $~lib/memory/__stack_pointer
   i32.const 10480
-  local.tee $5
+  local.tee $result
   i32.store $0 offset=4
-  local.get $2
+  local.get $separator
   call $~lib/string/String#get:length
-  local.set $6
+  local.set $sepLen
   i32.const 0
-  local.set $7
+  local.set $var$7
   loop $for-loop|0
-   local.get $7
-   local.get $3
+   local.get $var$7
+   local.get $lastIndex
    i32.lt_s
-   local.set $8
-   local.get $8
+   local.set $var$8
+   local.get $var$8
    if
     global.get $~lib/memory/__stack_pointer
-    local.get $0
-    local.get $7
+    local.get $dataStart
+    local.get $var$7
     i32.const 2
     i32.shl
     i32.add
     i32.load $0
-    local.tee $4
+    local.tee $value
     i32.store $0
-    local.get $4
+    local.get $value
     i32.const 0
     i32.ne
     if
      global.get $~lib/memory/__stack_pointer
-     local.get $5
-     local.get $4
+     local.get $result
+     local.get $value
      call $std/array/Ref#toString
      local.set $9
      global.get $~lib/memory/__stack_pointer
@@ -21404,41 +21404,41 @@
      i32.store $0 offset=8
      local.get $9
      call $~lib/string/String.__concat
-     local.tee $5
+     local.tee $result
      i32.store $0 offset=4
     end
-    local.get $6
+    local.get $sepLen
     if
      global.get $~lib/memory/__stack_pointer
-     local.get $5
-     local.get $2
+     local.get $result
+     local.get $separator
      call $~lib/string/String.__concat
-     local.tee $5
+     local.tee $result
      i32.store $0 offset=4
     end
-    local.get $7
+    local.get $var$7
     i32.const 1
     i32.add
-    local.set $7
+    local.set $var$7
     br $for-loop|0
    end
   end
   global.get $~lib/memory/__stack_pointer
-  local.get $0
-  local.get $3
+  local.get $dataStart
+  local.get $lastIndex
   i32.const 2
   i32.shl
   i32.add
   i32.load $0
-  local.tee $4
+  local.tee $value
   i32.store $0
-  local.get $4
+  local.get $value
   i32.const 0
   i32.ne
   if
    global.get $~lib/memory/__stack_pointer
-   local.get $5
-   local.get $4
+   local.get $result
+   local.get $value
    call $std/array/Ref#toString
    local.set $9
    global.get $~lib/memory/__stack_pointer
@@ -21446,10 +21446,10 @@
    i32.store $0 offset=8
    local.get $9
    call $~lib/string/String.__concat
-   local.tee $5
+   local.tee $result
    i32.store $0 offset=4
   end
-  local.get $5
+  local.get $result
   local.set $9
   global.get $~lib/memory/__stack_pointer
   i32.const 12
@@ -21457,7 +21457,7 @@
   global.set $~lib/memory/__stack_pointer
   local.get $9
  )
- (func $~lib/array/Array<i32>#toString (param $0 i32) (result i32)
+ (func $~lib/array/Array<i32>#toString (param $this i32) (result i32)
   (local $1 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -21467,7 +21467,7 @@
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   i32.store $0
-  local.get $0
+  local.get $this
   i32.const 10768
   local.set $1
   global.get $~lib/memory/__stack_pointer
@@ -21482,7 +21482,7 @@
   global.set $~lib/memory/__stack_pointer
   local.get $1
  )
- (func $~lib/array/Array<i8>#toString (param $0 i32) (result i32)
+ (func $~lib/array/Array<i8>#toString (param $this i32) (result i32)
   (local $1 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -21492,7 +21492,7 @@
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   i32.store $0
-  local.get $0
+  local.get $this
   i32.const 10768
   local.set $1
   global.get $~lib/memory/__stack_pointer
@@ -21507,7 +21507,7 @@
   global.set $~lib/memory/__stack_pointer
   local.get $1
  )
- (func $~lib/array/Array<u16>#toString (param $0 i32) (result i32)
+ (func $~lib/array/Array<u16>#toString (param $this i32) (result i32)
   (local $1 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -21517,7 +21517,7 @@
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   i32.store $0
-  local.get $0
+  local.get $this
   i32.const 10768
   local.set $1
   global.get $~lib/memory/__stack_pointer
@@ -21532,7 +21532,7 @@
   global.set $~lib/memory/__stack_pointer
   local.get $1
  )
- (func $~lib/array/Array<i16>#toString (param $0 i32) (result i32)
+ (func $~lib/array/Array<i16>#toString (param $this i32) (result i32)
   (local $1 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -21542,7 +21542,7 @@
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   i32.store $0
-  local.get $0
+  local.get $this
   i32.const 10768
   local.set $1
   global.get $~lib/memory/__stack_pointer
@@ -21557,7 +21557,7 @@
   global.set $~lib/memory/__stack_pointer
   local.get $1
  )
- (func $~lib/array/Array<u64>#toString (param $0 i32) (result i32)
+ (func $~lib/array/Array<u64>#toString (param $this i32) (result i32)
   (local $1 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -21567,7 +21567,7 @@
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   i32.store $0
-  local.get $0
+  local.get $this
   i32.const 10768
   local.set $1
   global.get $~lib/memory/__stack_pointer
@@ -21582,7 +21582,7 @@
   global.set $~lib/memory/__stack_pointer
   local.get $1
  )
- (func $~lib/array/Array<i64>#toString (param $0 i32) (result i32)
+ (func $~lib/array/Array<i64>#toString (param $this i32) (result i32)
   (local $1 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -21592,7 +21592,7 @@
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   i32.store $0
-  local.get $0
+  local.get $this
   i32.const 10768
   local.set $1
   global.get $~lib/memory/__stack_pointer
@@ -21607,7 +21607,7 @@
   global.set $~lib/memory/__stack_pointer
   local.get $1
  )
- (func $~lib/array/Array<~lib/string/String|null>#toString (param $0 i32) (result i32)
+ (func $~lib/array/Array<~lib/string/String|null>#toString (param $this i32) (result i32)
   (local $1 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -21617,7 +21617,7 @@
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   i32.store $0
-  local.get $0
+  local.get $this
   i32.const 10768
   local.set $1
   global.get $~lib/memory/__stack_pointer
@@ -21632,13 +21632,13 @@
   global.set $~lib/memory/__stack_pointer
   local.get $1
  )
- (func $~lib/util/string/joinReferenceArray<~lib/array/Array<i32>> (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
-  (local $3 i32)
-  (local $4 i32)
-  (local $5 i32)
-  (local $6 i32)
-  (local $7 i32)
-  (local $8 i32)
+ (func $~lib/util/string/joinReferenceArray<~lib/array/Array<i32>> (param $dataStart i32) (param $length i32) (param $separator i32) (result i32)
+  (local $lastIndex i32)
+  (local $value i32)
+  (local $result i32)
+  (local $sepLen i32)
+  (local $var$7 i32)
+  (local $var$8 i32)
   (local $9 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 12
@@ -21651,11 +21651,11 @@
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   i32.store $0 offset=8
-  local.get $1
+  local.get $length
   i32.const 1
   i32.sub
-  local.set $3
-  local.get $3
+  local.set $lastIndex
+  local.get $lastIndex
   i32.const 0
   i32.lt_s
   if
@@ -21668,19 +21668,19 @@
    local.get $9
    return
   end
-  local.get $3
+  local.get $lastIndex
   i32.eqz
   if
    global.get $~lib/memory/__stack_pointer
-   local.get $0
+   local.get $dataStart
    i32.load $0
-   local.tee $4
+   local.tee $value
    i32.store $0
-   local.get $4
+   local.get $value
    i32.const 0
    i32.ne
    if (result i32)
-    local.get $4
+    local.get $value
     call $~lib/array/Array<i32>#toString
    else
     i32.const 10480
@@ -21695,36 +21695,36 @@
   end
   global.get $~lib/memory/__stack_pointer
   i32.const 10480
-  local.tee $5
+  local.tee $result
   i32.store $0 offset=4
-  local.get $2
+  local.get $separator
   call $~lib/string/String#get:length
-  local.set $6
+  local.set $sepLen
   i32.const 0
-  local.set $7
+  local.set $var$7
   loop $for-loop|0
-   local.get $7
-   local.get $3
+   local.get $var$7
+   local.get $lastIndex
    i32.lt_s
-   local.set $8
-   local.get $8
+   local.set $var$8
+   local.get $var$8
    if
     global.get $~lib/memory/__stack_pointer
-    local.get $0
-    local.get $7
+    local.get $dataStart
+    local.get $var$7
     i32.const 2
     i32.shl
     i32.add
     i32.load $0
-    local.tee $4
+    local.tee $value
     i32.store $0
-    local.get $4
+    local.get $value
     i32.const 0
     i32.ne
     if
      global.get $~lib/memory/__stack_pointer
-     local.get $5
-     local.get $4
+     local.get $result
+     local.get $value
      call $~lib/array/Array<i32>#toString
      local.set $9
      global.get $~lib/memory/__stack_pointer
@@ -21732,41 +21732,41 @@
      i32.store $0 offset=8
      local.get $9
      call $~lib/string/String.__concat
-     local.tee $5
+     local.tee $result
      i32.store $0 offset=4
     end
-    local.get $6
+    local.get $sepLen
     if
      global.get $~lib/memory/__stack_pointer
-     local.get $5
-     local.get $2
+     local.get $result
+     local.get $separator
      call $~lib/string/String.__concat
-     local.tee $5
+     local.tee $result
      i32.store $0 offset=4
     end
-    local.get $7
+    local.get $var$7
     i32.const 1
     i32.add
-    local.set $7
+    local.set $var$7
     br $for-loop|0
    end
   end
   global.get $~lib/memory/__stack_pointer
-  local.get $0
-  local.get $3
+  local.get $dataStart
+  local.get $lastIndex
   i32.const 2
   i32.shl
   i32.add
   i32.load $0
-  local.tee $4
+  local.tee $value
   i32.store $0
-  local.get $4
+  local.get $value
   i32.const 0
   i32.ne
   if
    global.get $~lib/memory/__stack_pointer
-   local.get $5
-   local.get $4
+   local.get $result
+   local.get $value
    call $~lib/array/Array<i32>#toString
    local.set $9
    global.get $~lib/memory/__stack_pointer
@@ -21774,10 +21774,10 @@
    i32.store $0 offset=8
    local.get $9
    call $~lib/string/String.__concat
-   local.tee $5
+   local.tee $result
    i32.store $0 offset=4
   end
-  local.get $5
+  local.get $result
   local.set $9
   global.get $~lib/memory/__stack_pointer
   i32.const 12
@@ -21785,7 +21785,7 @@
   global.set $~lib/memory/__stack_pointer
   local.get $9
  )
- (func $~lib/array/Array<~lib/array/Array<i32>>#toString (param $0 i32) (result i32)
+ (func $~lib/array/Array<~lib/array/Array<i32>>#toString (param $this i32) (result i32)
   (local $1 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -21795,7 +21795,7 @@
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   i32.store $0
-  local.get $0
+  local.get $this
   i32.const 10768
   local.set $1
   global.get $~lib/memory/__stack_pointer
@@ -21810,7 +21810,7 @@
   global.set $~lib/memory/__stack_pointer
   local.get $1
  )
- (func $~lib/array/Array<u8>#toString (param $0 i32) (result i32)
+ (func $~lib/array/Array<u8>#toString (param $this i32) (result i32)
   (local $1 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -21820,7 +21820,7 @@
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   i32.store $0
-  local.get $0
+  local.get $this
   i32.const 10768
   local.set $1
   global.get $~lib/memory/__stack_pointer
@@ -21835,13 +21835,13 @@
   global.set $~lib/memory/__stack_pointer
   local.get $1
  )
- (func $~lib/util/string/joinReferenceArray<~lib/array/Array<u8>> (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
-  (local $3 i32)
-  (local $4 i32)
-  (local $5 i32)
-  (local $6 i32)
-  (local $7 i32)
-  (local $8 i32)
+ (func $~lib/util/string/joinReferenceArray<~lib/array/Array<u8>> (param $dataStart i32) (param $length i32) (param $separator i32) (result i32)
+  (local $lastIndex i32)
+  (local $value i32)
+  (local $result i32)
+  (local $sepLen i32)
+  (local $var$7 i32)
+  (local $var$8 i32)
   (local $9 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 12
@@ -21854,11 +21854,11 @@
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   i32.store $0 offset=8
-  local.get $1
+  local.get $length
   i32.const 1
   i32.sub
-  local.set $3
-  local.get $3
+  local.set $lastIndex
+  local.get $lastIndex
   i32.const 0
   i32.lt_s
   if
@@ -21871,19 +21871,19 @@
    local.get $9
    return
   end
-  local.get $3
+  local.get $lastIndex
   i32.eqz
   if
    global.get $~lib/memory/__stack_pointer
-   local.get $0
+   local.get $dataStart
    i32.load $0
-   local.tee $4
+   local.tee $value
    i32.store $0
-   local.get $4
+   local.get $value
    i32.const 0
    i32.ne
    if (result i32)
-    local.get $4
+    local.get $value
     call $~lib/array/Array<u8>#toString
    else
     i32.const 10480
@@ -21898,36 +21898,36 @@
   end
   global.get $~lib/memory/__stack_pointer
   i32.const 10480
-  local.tee $5
+  local.tee $result
   i32.store $0 offset=4
-  local.get $2
+  local.get $separator
   call $~lib/string/String#get:length
-  local.set $6
+  local.set $sepLen
   i32.const 0
-  local.set $7
+  local.set $var$7
   loop $for-loop|0
-   local.get $7
-   local.get $3
+   local.get $var$7
+   local.get $lastIndex
    i32.lt_s
-   local.set $8
-   local.get $8
+   local.set $var$8
+   local.get $var$8
    if
     global.get $~lib/memory/__stack_pointer
-    local.get $0
-    local.get $7
+    local.get $dataStart
+    local.get $var$7
     i32.const 2
     i32.shl
     i32.add
     i32.load $0
-    local.tee $4
+    local.tee $value
     i32.store $0
-    local.get $4
+    local.get $value
     i32.const 0
     i32.ne
     if
      global.get $~lib/memory/__stack_pointer
-     local.get $5
-     local.get $4
+     local.get $result
+     local.get $value
      call $~lib/array/Array<u8>#toString
      local.set $9
      global.get $~lib/memory/__stack_pointer
@@ -21935,41 +21935,41 @@
      i32.store $0 offset=8
      local.get $9
      call $~lib/string/String.__concat
-     local.tee $5
+     local.tee $result
      i32.store $0 offset=4
     end
-    local.get $6
+    local.get $sepLen
     if
      global.get $~lib/memory/__stack_pointer
-     local.get $5
-     local.get $2
+     local.get $result
+     local.get $separator
      call $~lib/string/String.__concat
-     local.tee $5
+     local.tee $result
      i32.store $0 offset=4
     end
-    local.get $7
+    local.get $var$7
     i32.const 1
     i32.add
-    local.set $7
+    local.set $var$7
     br $for-loop|0
    end
   end
   global.get $~lib/memory/__stack_pointer
-  local.get $0
-  local.get $3
+  local.get $dataStart
+  local.get $lastIndex
   i32.const 2
   i32.shl
   i32.add
   i32.load $0
-  local.tee $4
+  local.tee $value
   i32.store $0
-  local.get $4
+  local.get $value
   i32.const 0
   i32.ne
   if
    global.get $~lib/memory/__stack_pointer
-   local.get $5
-   local.get $4
+   local.get $result
+   local.get $value
    call $~lib/array/Array<u8>#toString
    local.set $9
    global.get $~lib/memory/__stack_pointer
@@ -21977,10 +21977,10 @@
    i32.store $0 offset=8
    local.get $9
    call $~lib/string/String.__concat
-   local.tee $5
+   local.tee $result
    i32.store $0 offset=4
   end
-  local.get $5
+  local.get $result
   local.set $9
   global.get $~lib/memory/__stack_pointer
   i32.const 12
@@ -21988,7 +21988,7 @@
   global.set $~lib/memory/__stack_pointer
   local.get $9
  )
- (func $~lib/array/Array<~lib/array/Array<u8>>#toString (param $0 i32) (result i32)
+ (func $~lib/array/Array<~lib/array/Array<u8>>#toString (param $this i32) (result i32)
   (local $1 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -21998,7 +21998,7 @@
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   i32.store $0
-  local.get $0
+  local.get $this
   i32.const 10768
   local.set $1
   global.get $~lib/memory/__stack_pointer
@@ -22013,7 +22013,7 @@
   global.set $~lib/memory/__stack_pointer
   local.get $1
  )
- (func $~lib/array/Array<u32>#toString (param $0 i32) (result i32)
+ (func $~lib/array/Array<u32>#toString (param $this i32) (result i32)
   (local $1 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -22023,7 +22023,7 @@
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   i32.store $0
-  local.get $0
+  local.get $this
   i32.const 10768
   local.set $1
   global.get $~lib/memory/__stack_pointer
@@ -22038,13 +22038,13 @@
   global.set $~lib/memory/__stack_pointer
   local.get $1
  )
- (func $~lib/util/string/joinReferenceArray<~lib/array/Array<u32>> (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
-  (local $3 i32)
-  (local $4 i32)
-  (local $5 i32)
-  (local $6 i32)
-  (local $7 i32)
-  (local $8 i32)
+ (func $~lib/util/string/joinReferenceArray<~lib/array/Array<u32>> (param $dataStart i32) (param $length i32) (param $separator i32) (result i32)
+  (local $lastIndex i32)
+  (local $value i32)
+  (local $result i32)
+  (local $sepLen i32)
+  (local $var$7 i32)
+  (local $var$8 i32)
   (local $9 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 12
@@ -22057,11 +22057,11 @@
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   i32.store $0 offset=8
-  local.get $1
+  local.get $length
   i32.const 1
   i32.sub
-  local.set $3
-  local.get $3
+  local.set $lastIndex
+  local.get $lastIndex
   i32.const 0
   i32.lt_s
   if
@@ -22074,19 +22074,19 @@
    local.get $9
    return
   end
-  local.get $3
+  local.get $lastIndex
   i32.eqz
   if
    global.get $~lib/memory/__stack_pointer
-   local.get $0
+   local.get $dataStart
    i32.load $0
-   local.tee $4
+   local.tee $value
    i32.store $0
-   local.get $4
+   local.get $value
    i32.const 0
    i32.ne
    if (result i32)
-    local.get $4
+    local.get $value
     call $~lib/array/Array<u32>#toString
    else
     i32.const 10480
@@ -22101,36 +22101,36 @@
   end
   global.get $~lib/memory/__stack_pointer
   i32.const 10480
-  local.tee $5
+  local.tee $result
   i32.store $0 offset=4
-  local.get $2
+  local.get $separator
   call $~lib/string/String#get:length
-  local.set $6
+  local.set $sepLen
   i32.const 0
-  local.set $7
+  local.set $var$7
   loop $for-loop|0
-   local.get $7
-   local.get $3
+   local.get $var$7
+   local.get $lastIndex
    i32.lt_s
-   local.set $8
-   local.get $8
+   local.set $var$8
+   local.get $var$8
    if
     global.get $~lib/memory/__stack_pointer
-    local.get $0
-    local.get $7
+    local.get $dataStart
+    local.get $var$7
     i32.const 2
     i32.shl
     i32.add
     i32.load $0
-    local.tee $4
+    local.tee $value
     i32.store $0
-    local.get $4
+    local.get $value
     i32.const 0
     i32.ne
     if
      global.get $~lib/memory/__stack_pointer
-     local.get $5
-     local.get $4
+     local.get $result
+     local.get $value
      call $~lib/array/Array<u32>#toString
      local.set $9
      global.get $~lib/memory/__stack_pointer
@@ -22138,41 +22138,41 @@
      i32.store $0 offset=8
      local.get $9
      call $~lib/string/String.__concat
-     local.tee $5
+     local.tee $result
      i32.store $0 offset=4
     end
-    local.get $6
+    local.get $sepLen
     if
      global.get $~lib/memory/__stack_pointer
-     local.get $5
-     local.get $2
+     local.get $result
+     local.get $separator
      call $~lib/string/String.__concat
-     local.tee $5
+     local.tee $result
      i32.store $0 offset=4
     end
-    local.get $7
+    local.get $var$7
     i32.const 1
     i32.add
-    local.set $7
+    local.set $var$7
     br $for-loop|0
    end
   end
   global.get $~lib/memory/__stack_pointer
-  local.get $0
-  local.get $3
+  local.get $dataStart
+  local.get $lastIndex
   i32.const 2
   i32.shl
   i32.add
   i32.load $0
-  local.tee $4
+  local.tee $value
   i32.store $0
-  local.get $4
+  local.get $value
   i32.const 0
   i32.ne
   if
    global.get $~lib/memory/__stack_pointer
-   local.get $5
-   local.get $4
+   local.get $result
+   local.get $value
    call $~lib/array/Array<u32>#toString
    local.set $9
    global.get $~lib/memory/__stack_pointer
@@ -22180,10 +22180,10 @@
    i32.store $0 offset=8
    local.get $9
    call $~lib/string/String.__concat
-   local.tee $5
+   local.tee $result
    i32.store $0 offset=4
   end
-  local.get $5
+  local.get $result
   local.set $9
   global.get $~lib/memory/__stack_pointer
   i32.const 12
@@ -22191,7 +22191,7 @@
   global.set $~lib/memory/__stack_pointer
   local.get $9
  )
- (func $~lib/array/Array<~lib/array/Array<u32>>#toString (param $0 i32) (result i32)
+ (func $~lib/array/Array<~lib/array/Array<u32>>#toString (param $this i32) (result i32)
   (local $1 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -22201,7 +22201,7 @@
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   i32.store $0
-  local.get $0
+  local.get $this
   i32.const 10768
   local.set $1
   global.get $~lib/memory/__stack_pointer
@@ -22216,13 +22216,13 @@
   global.set $~lib/memory/__stack_pointer
   local.get $1
  )
- (func $~lib/util/string/joinReferenceArray<~lib/array/Array<~lib/array/Array<u32>>> (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
-  (local $3 i32)
-  (local $4 i32)
-  (local $5 i32)
-  (local $6 i32)
-  (local $7 i32)
-  (local $8 i32)
+ (func $~lib/util/string/joinReferenceArray<~lib/array/Array<~lib/array/Array<u32>>> (param $dataStart i32) (param $length i32) (param $separator i32) (result i32)
+  (local $lastIndex i32)
+  (local $value i32)
+  (local $result i32)
+  (local $sepLen i32)
+  (local $var$7 i32)
+  (local $var$8 i32)
   (local $9 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 12
@@ -22235,11 +22235,11 @@
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   i32.store $0 offset=8
-  local.get $1
+  local.get $length
   i32.const 1
   i32.sub
-  local.set $3
-  local.get $3
+  local.set $lastIndex
+  local.get $lastIndex
   i32.const 0
   i32.lt_s
   if
@@ -22252,19 +22252,19 @@
    local.get $9
    return
   end
-  local.get $3
+  local.get $lastIndex
   i32.eqz
   if
    global.get $~lib/memory/__stack_pointer
-   local.get $0
+   local.get $dataStart
    i32.load $0
-   local.tee $4
+   local.tee $value
    i32.store $0
-   local.get $4
+   local.get $value
    i32.const 0
    i32.ne
    if (result i32)
-    local.get $4
+    local.get $value
     call $~lib/array/Array<~lib/array/Array<u32>>#toString
    else
     i32.const 10480
@@ -22279,36 +22279,36 @@
   end
   global.get $~lib/memory/__stack_pointer
   i32.const 10480
-  local.tee $5
+  local.tee $result
   i32.store $0 offset=4
-  local.get $2
+  local.get $separator
   call $~lib/string/String#get:length
-  local.set $6
+  local.set $sepLen
   i32.const 0
-  local.set $7
+  local.set $var$7
   loop $for-loop|0
-   local.get $7
-   local.get $3
+   local.get $var$7
+   local.get $lastIndex
    i32.lt_s
-   local.set $8
-   local.get $8
+   local.set $var$8
+   local.get $var$8
    if
     global.get $~lib/memory/__stack_pointer
-    local.get $0
-    local.get $7
+    local.get $dataStart
+    local.get $var$7
     i32.const 2
     i32.shl
     i32.add
     i32.load $0
-    local.tee $4
+    local.tee $value
     i32.store $0
-    local.get $4
+    local.get $value
     i32.const 0
     i32.ne
     if
      global.get $~lib/memory/__stack_pointer
-     local.get $5
-     local.get $4
+     local.get $result
+     local.get $value
      call $~lib/array/Array<~lib/array/Array<u32>>#toString
      local.set $9
      global.get $~lib/memory/__stack_pointer
@@ -22316,41 +22316,41 @@
      i32.store $0 offset=8
      local.get $9
      call $~lib/string/String.__concat
-     local.tee $5
+     local.tee $result
      i32.store $0 offset=4
     end
-    local.get $6
+    local.get $sepLen
     if
      global.get $~lib/memory/__stack_pointer
-     local.get $5
-     local.get $2
+     local.get $result
+     local.get $separator
      call $~lib/string/String.__concat
-     local.tee $5
+     local.tee $result
      i32.store $0 offset=4
     end
-    local.get $7
+    local.get $var$7
     i32.const 1
     i32.add
-    local.set $7
+    local.set $var$7
     br $for-loop|0
    end
   end
   global.get $~lib/memory/__stack_pointer
-  local.get $0
-  local.get $3
+  local.get $dataStart
+  local.get $lastIndex
   i32.const 2
   i32.shl
   i32.add
   i32.load $0
-  local.tee $4
+  local.tee $value
   i32.store $0
-  local.get $4
+  local.get $value
   i32.const 0
   i32.ne
   if
    global.get $~lib/memory/__stack_pointer
-   local.get $5
-   local.get $4
+   local.get $result
+   local.get $value
    call $~lib/array/Array<~lib/array/Array<u32>>#toString
    local.set $9
    global.get $~lib/memory/__stack_pointer
@@ -22358,10 +22358,10 @@
    i32.store $0 offset=8
    local.get $9
    call $~lib/string/String.__concat
-   local.tee $5
+   local.tee $result
    i32.store $0 offset=4
   end
-  local.get $5
+  local.get $result
   local.set $9
   global.get $~lib/memory/__stack_pointer
   i32.const 12
@@ -22369,7 +22369,7 @@
   global.set $~lib/memory/__stack_pointer
   local.get $9
  )
- (func $~lib/array/Array<~lib/array/Array<~lib/array/Array<u32>>>#toString (param $0 i32) (result i32)
+ (func $~lib/array/Array<~lib/array/Array<~lib/array/Array<u32>>>#toString (param $this i32) (result i32)
   (local $1 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -22379,7 +22379,7 @@
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   i32.store $0
-  local.get $0
+  local.get $this
   i32.const 10768
   local.set $1
   global.get $~lib/memory/__stack_pointer
@@ -22394,13 +22394,13 @@
   global.set $~lib/memory/__stack_pointer
   local.get $1
  )
- (func $~lib/array/Array<~lib/array/Array<i32>>#map<~lib/array/Array<i32>> (param $0 i32) (param $1 i32) (result i32)
-  (local $2 i32)
-  (local $3 i32)
-  (local $4 i32)
-  (local $5 i32)
-  (local $6 i32)
-  (local $7 i32)
+ (func $~lib/array/Array<~lib/array/Array<i32>>#map<~lib/array/Array<i32>> (param $this i32) (param $fn i32) (result i32)
+  (local $len i32)
+  (local $out i32)
+  (local $outStart i32)
+  (local $var$5 i32)
+  (local $var$6 i32)
+  (local $var$7 i32)
   (local $8 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 12
@@ -22413,41 +22413,41 @@
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   i32.store $0 offset=8
-  local.get $0
+  local.get $this
   i32.load $0 offset=12
-  local.set $2
+  local.set $len
   global.get $~lib/memory/__stack_pointer
-  local.get $2
+  local.get $len
   i32.const 2
   i32.const 28
   i32.const 0
   call $~lib/rt/__newArray
-  local.tee $3
+  local.tee $out
   i32.store $0
-  local.get $3
+  local.get $out
   i32.load $0 offset=4
-  local.set $4
+  local.set $outStart
   i32.const 0
-  local.set $5
+  local.set $var$5
   loop $for-loop|0
-   local.get $5
-   local.get $2
-   local.tee $6
-   local.get $0
+   local.get $var$5
+   local.get $len
+   local.tee $var$6
+   local.get $this
    i32.load $0 offset=12
-   local.tee $7
-   local.get $6
-   local.get $7
+   local.tee $var$7
+   local.get $var$6
+   local.get $var$7
    i32.lt_s
    select
    i32.lt_s
-   local.set $6
-   local.get $6
+   local.set $var$6
+   local.get $var$6
    if
     global.get $~lib/memory/__stack_pointer
-    local.get $0
+    local.get $this
     i32.load $0 offset=4
-    local.get $5
+    local.get $var$5
     i32.const 2
     i32.shl
     i32.add
@@ -22457,36 +22457,36 @@
     local.get $8
     i32.store $0 offset=4
     local.get $8
-    local.get $5
-    local.get $0
+    local.get $var$5
+    local.get $this
     i32.const 3
     global.set $~argumentsLength
-    local.get $1
+    local.get $fn
     i32.load $0
     call_indirect $0 (type $i32_i32_i32_=>_i32)
-    local.tee $7
+    local.tee $var$7
     i32.store $0 offset=8
-    local.get $4
-    local.get $5
+    local.get $outStart
+    local.get $var$5
     i32.const 2
     i32.shl
     i32.add
-    local.get $7
+    local.get $var$7
     i32.store $0
     i32.const 1
     drop
-    local.get $3
-    local.get $7
+    local.get $out
+    local.get $var$7
     i32.const 1
     call $~lib/rt/itcms/__link
-    local.get $5
+    local.get $var$5
     i32.const 1
     i32.add
-    local.set $5
+    local.set $var$5
     br $for-loop|0
    end
   end
-  local.get $3
+  local.get $out
   local.set $8
   global.get $~lib/memory/__stack_pointer
   i32.const 12
@@ -31944,11 +31944,11 @@
   i32.add
   global.set $~lib/memory/__stack_pointer
  )
- (func $~lib/array/Array<i32>#constructor (param $0 i32) (param $1 i32) (result i32)
-  (local $2 i32)
-  (local $3 i32)
-  (local $4 i32)
-  (local $5 i32)
+ (func $~lib/array/Array<i32>#constructor (param $this i32) (param $length i32) (result i32)
+  (local $var$2 i32)
+  (local $var$3 i32)
+  (local $bufferSize i32)
+  (local $buffer i32)
   (local $6 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 8
@@ -31958,29 +31958,29 @@
   global.get $~lib/memory/__stack_pointer
   i64.const 0
   i64.store $0
-  local.get $0
+  local.get $this
   i32.eqz
   if
    global.get $~lib/memory/__stack_pointer
    i32.const 16
    i32.const 3
    call $~lib/rt/itcms/__new
-   local.tee $0
+   local.tee $this
    i32.store $0
   end
-  local.get $0
+  local.get $this
   i32.const 0
   call $~lib/array/Array<i32>#set:buffer
-  local.get $0
+  local.get $this
   i32.const 0
   call $~lib/array/Array<i32>#set:dataStart
-  local.get $0
+  local.get $this
   i32.const 0
   call $~lib/array/Array<i32>#set:byteLength
-  local.get $0
+  local.get $this
   i32.const 0
   call $~lib/array/Array<i32>#set:length_
-  local.get $1
+  local.get $length
   i32.const 1073741820
   i32.const 2
   i32.shr_u
@@ -31993,40 +31993,40 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $1
-  local.tee $2
+  local.get $length
+  local.tee $var$2
   i32.const 8
-  local.tee $3
-  local.get $2
-  local.get $3
+  local.tee $var$3
+  local.get $var$2
+  local.get $var$3
   i32.gt_u
   select
   i32.const 2
   i32.shl
-  local.set $4
+  local.set $bufferSize
   global.get $~lib/memory/__stack_pointer
-  local.get $4
+  local.get $bufferSize
   i32.const 0
   call $~lib/rt/itcms/__new
-  local.tee $5
+  local.tee $buffer
   i32.store $0 offset=4
   i32.const 2
   global.get $~lib/shared/runtime/Runtime.Incremental
   i32.ne
   drop
-  local.get $0
-  local.get $5
+  local.get $this
+  local.get $buffer
   call $~lib/array/Array<i32>#set:buffer
-  local.get $0
-  local.get $5
+  local.get $this
+  local.get $buffer
   call $~lib/array/Array<i32>#set:dataStart
-  local.get $0
-  local.get $4
+  local.get $this
+  local.get $bufferSize
   call $~lib/array/Array<i32>#set:byteLength
-  local.get $0
-  local.get $1
+  local.get $this
+  local.get $length
   call $~lib/array/Array<i32>#set:length_
-  local.get $0
+  local.get $this
   local.set $6
   global.get $~lib/memory/__stack_pointer
   i32.const 8
@@ -32034,7 +32034,7 @@
   global.set $~lib/memory/__stack_pointer
   local.get $6
  )
- (func $std/array/Ref#constructor (param $0 i32) (param $1 i32) (result i32)
+ (func $std/array/Ref#constructor (param $this i32) (param $v i32) (result i32)
   (local $2 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -32044,20 +32044,20 @@
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   i32.store $0
-  local.get $0
+  local.get $this
   i32.eqz
   if
    global.get $~lib/memory/__stack_pointer
    i32.const 4
    i32.const 4
    call $~lib/rt/itcms/__new
-   local.tee $0
+   local.tee $this
    i32.store $0
   end
-  local.get $0
-  local.get $1
+  local.get $this
+  local.get $v
   call $std/array/Ref#set:v
-  local.get $0
+  local.get $this
   local.set $2
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -32065,8 +32065,8 @@
   global.set $~lib/memory/__stack_pointer
   local.get $2
  )
- (func $~lib/arraybuffer/ArrayBufferView#constructor (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
-  (local $3 i32)
+ (func $~lib/arraybuffer/ArrayBufferView#constructor (param $this i32) (param $length i32) (param $alignLog2 i32) (result i32)
+  (local $buffer i32)
   (local $4 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 8
@@ -32076,28 +32076,28 @@
   global.get $~lib/memory/__stack_pointer
   i64.const 0
   i64.store $0
-  local.get $0
+  local.get $this
   i32.eqz
   if
    global.get $~lib/memory/__stack_pointer
    i32.const 12
    i32.const 2
    call $~lib/rt/itcms/__new
-   local.tee $0
+   local.tee $this
    i32.store $0
   end
-  local.get $0
+  local.get $this
   i32.const 0
   call $~lib/arraybuffer/ArrayBufferView#set:buffer
-  local.get $0
+  local.get $this
   i32.const 0
   call $~lib/arraybuffer/ArrayBufferView#set:dataStart
-  local.get $0
+  local.get $this
   i32.const 0
   call $~lib/arraybuffer/ArrayBufferView#set:byteLength
-  local.get $1
+  local.get $length
   i32.const 1073741820
-  local.get $2
+  local.get $alignLog2
   i32.shr_u
   i32.gt_u
   if
@@ -32109,28 +32109,28 @@
    unreachable
   end
   global.get $~lib/memory/__stack_pointer
-  local.get $1
-  local.get $2
+  local.get $length
+  local.get $alignLog2
   i32.shl
-  local.tee $1
+  local.tee $length
   i32.const 0
   call $~lib/rt/itcms/__new
-  local.tee $3
+  local.tee $buffer
   i32.store $0 offset=4
   i32.const 2
   global.get $~lib/shared/runtime/Runtime.Incremental
   i32.ne
   drop
-  local.get $0
-  local.get $3
+  local.get $this
+  local.get $buffer
   call $~lib/arraybuffer/ArrayBufferView#set:buffer
-  local.get $0
-  local.get $3
+  local.get $this
+  local.get $buffer
   call $~lib/arraybuffer/ArrayBufferView#set:dataStart
-  local.get $0
-  local.get $1
+  local.get $this
+  local.get $length
   call $~lib/arraybuffer/ArrayBufferView#set:byteLength
-  local.get $0
+  local.get $this
   local.set $4
   global.get $~lib/memory/__stack_pointer
   i32.const 8
@@ -32138,7 +32138,7 @@
   global.set $~lib/memory/__stack_pointer
   local.get $4
  )
- (func $~lib/typedarray/Uint8Array#constructor (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/typedarray/Uint8Array#constructor (param $this i32) (param $length i32) (result i32)
   (local $2 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -32148,24 +32148,24 @@
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   i32.store $0
-  local.get $0
+  local.get $this
   i32.eqz
   if
    global.get $~lib/memory/__stack_pointer
    i32.const 12
    i32.const 5
    call $~lib/rt/itcms/__new
-   local.tee $0
+   local.tee $this
    i32.store $0
   end
   global.get $~lib/memory/__stack_pointer
-  local.get $0
-  local.get $1
+  local.get $this
+  local.get $length
   i32.const 0
   call $~lib/arraybuffer/ArrayBufferView#constructor
-  local.tee $0
+  local.tee $this
   i32.store $0
-  local.get $0
+  local.get $this
   local.set $2
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -32173,10 +32173,10 @@
   global.set $~lib/memory/__stack_pointer
   local.get $2
  )
- (func $~lib/rt/__newArray (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
-  (local $4 i32)
-  (local $5 i32)
-  (local $6 i32)
+ (func $~lib/rt/__newArray (param $length i32) (param $alignLog2 i32) (param $id i32) (param $data i32) (result i32)
+  (local $bufferSize i32)
+  (local $buffer i32)
+  (local $array i32)
   (local $7 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -32186,38 +32186,38 @@
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   i32.store $0
-  local.get $0
-  local.get $1
+  local.get $length
+  local.get $alignLog2
   i32.shl
-  local.set $4
+  local.set $bufferSize
   global.get $~lib/memory/__stack_pointer
-  local.get $4
+  local.get $bufferSize
   i32.const 0
-  local.get $3
+  local.get $data
   call $~lib/rt/__newBuffer
-  local.tee $5
+  local.tee $buffer
   i32.store $0
   i32.const 16
-  local.get $2
+  local.get $id
   call $~lib/rt/itcms/__new
-  local.set $6
-  local.get $6
-  local.get $5
+  local.set $array
+  local.get $array
+  local.get $buffer
   i32.store $0
-  local.get $6
-  local.get $5
+  local.get $array
+  local.get $buffer
   i32.const 0
   call $~lib/rt/itcms/__link
-  local.get $6
-  local.get $5
+  local.get $array
+  local.get $buffer
   i32.store $0 offset=4
-  local.get $6
-  local.get $4
+  local.get $array
+  local.get $bufferSize
   i32.store $0 offset=8
-  local.get $6
-  local.get $0
+  local.get $array
+  local.get $length
   i32.store $0 offset=12
-  local.get $6
+  local.get $array
   local.set $7
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -32225,8 +32225,8 @@
   global.set $~lib/memory/__stack_pointer
   local.get $7
  )
- (func $std/array/internalCapacity<i32> (param $0 i32) (result i32)
-  (local $1 i32)
+ (func $std/array/internalCapacity<i32> (param $array i32) (result i32)
+  (local $buffer i32)
   (local $2 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -32237,11 +32237,11 @@
   i32.const 0
   i32.store $0
   global.get $~lib/memory/__stack_pointer
-  local.get $0
+  local.get $array
   i32.load $0
-  local.tee $1
+  local.tee $buffer
   i32.store $0
-  local.get $1
+  local.get $buffer
   call $~lib/arraybuffer/ArrayBuffer#get:byteLength
   i32.const 2
   i32.shr_s
@@ -32252,13 +32252,13 @@
   global.set $~lib/memory/__stack_pointer
   local.get $2
  )
- (func $~lib/array/Array<i32>#concat (param $0 i32) (param $1 i32) (result i32)
-  (local $2 i32)
-  (local $3 i32)
-  (local $4 i32)
-  (local $5 i32)
-  (local $6 i32)
-  (local $7 i32)
+ (func $~lib/array/Array<i32>#concat (param $this i32) (param $other i32) (result i32)
+  (local $thisLen i32)
+  (local $otherLen i32)
+  (local $outLen i32)
+  (local $out i32)
+  (local $outStart i32)
+  (local $thisSize i32)
   (local $8 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -32268,17 +32268,17 @@
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   i32.store $0
-  local.get $0
+  local.get $this
   i32.load $0 offset=12
-  local.set $2
-  local.get $1
+  local.set $thisLen
+  local.get $other
   i32.load $0 offset=12
-  local.set $3
-  local.get $2
-  local.get $3
+  local.set $otherLen
+  local.get $thisLen
+  local.get $otherLen
   i32.add
-  local.set $4
-  local.get $4
+  local.set $outLen
+  local.get $outLen
   i32.const 1073741820
   i32.const 2
   i32.shr_u
@@ -32292,37 +32292,37 @@
    unreachable
   end
   global.get $~lib/memory/__stack_pointer
-  local.get $4
+  local.get $outLen
   i32.const 2
   i32.const 3
   i32.const 0
   call $~lib/rt/__newArray
-  local.tee $5
+  local.tee $out
   i32.store $0
-  local.get $5
+  local.get $out
   i32.load $0 offset=4
-  local.set $6
-  local.get $2
+  local.set $outStart
+  local.get $thisLen
   i32.const 2
   i32.shl
-  local.set $7
+  local.set $thisSize
   i32.const 0
   drop
-  local.get $6
-  local.get $0
+  local.get $outStart
+  local.get $this
   i32.load $0 offset=4
-  local.get $7
+  local.get $thisSize
   memory.copy $0 $0
-  local.get $6
-  local.get $7
+  local.get $outStart
+  local.get $thisSize
   i32.add
-  local.get $1
+  local.get $other
   i32.load $0 offset=4
-  local.get $3
+  local.get $otherLen
   i32.const 2
   i32.shl
   memory.copy $0 $0
-  local.get $5
+  local.get $out
   local.set $8
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -32330,13 +32330,13 @@
   global.set $~lib/memory/__stack_pointer
   local.get $8
  )
- (func $~lib/array/Array<i32>#slice (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
-  (local $3 i32)
-  (local $4 i32)
-  (local $5 i32)
-  (local $6 i32)
-  (local $7 i32)
-  (local $8 i32)
+ (func $~lib/array/Array<i32>#slice (param $this i32) (param $start i32) (param $end i32) (result i32)
+  (local $len i32)
+  (local $var$4 i32)
+  (local $var$5 i32)
+  (local $slice i32)
+  (local $sliceBase i32)
+  (local $thisBase i32)
   (local $9 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -32346,97 +32346,97 @@
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   i32.store $0
-  local.get $0
+  local.get $this
   i32.load $0 offset=12
-  local.set $3
-  local.get $1
+  local.set $len
+  local.get $start
   i32.const 0
   i32.lt_s
   if (result i32)
-   local.get $1
-   local.get $3
+   local.get $start
+   local.get $len
    i32.add
-   local.tee $4
+   local.tee $var$4
    i32.const 0
-   local.tee $5
-   local.get $4
-   local.get $5
+   local.tee $var$5
+   local.get $var$4
+   local.get $var$5
    i32.gt_s
    select
   else
-   local.get $1
-   local.tee $5
-   local.get $3
-   local.tee $4
-   local.get $5
-   local.get $4
+   local.get $start
+   local.tee $var$5
+   local.get $len
+   local.tee $var$4
+   local.get $var$5
+   local.get $var$4
    i32.lt_s
    select
   end
-  local.set $1
-  local.get $2
+  local.set $start
+  local.get $end
   i32.const 0
   i32.lt_s
   if (result i32)
-   local.get $2
-   local.get $3
+   local.get $end
+   local.get $len
    i32.add
-   local.tee $4
+   local.tee $var$4
    i32.const 0
-   local.tee $5
-   local.get $4
-   local.get $5
+   local.tee $var$5
+   local.get $var$4
+   local.get $var$5
    i32.gt_s
    select
   else
-   local.get $2
-   local.tee $5
-   local.get $3
-   local.tee $4
-   local.get $5
-   local.get $4
+   local.get $end
+   local.tee $var$5
+   local.get $len
+   local.tee $var$4
+   local.get $var$5
+   local.get $var$4
    i32.lt_s
    select
   end
-  local.set $2
-  local.get $2
-  local.get $1
+  local.set $end
+  local.get $end
+  local.get $start
   i32.sub
-  local.tee $4
+  local.tee $var$4
   i32.const 0
-  local.tee $5
-  local.get $4
-  local.get $5
+  local.tee $var$5
+  local.get $var$4
+  local.get $var$5
   i32.gt_s
   select
-  local.set $3
+  local.set $len
   global.get $~lib/memory/__stack_pointer
-  local.get $3
+  local.get $len
   i32.const 2
   i32.const 3
   i32.const 0
   call $~lib/rt/__newArray
-  local.tee $6
+  local.tee $slice
   i32.store $0
-  local.get $6
+  local.get $slice
   i32.load $0 offset=4
-  local.set $7
-  local.get $0
+  local.set $sliceBase
+  local.get $this
   i32.load $0 offset=4
-  local.get $1
+  local.get $start
   i32.const 2
   i32.shl
   i32.add
-  local.set $8
+  local.set $thisBase
   i32.const 0
   drop
-  local.get $7
-  local.get $8
-  local.get $3
+  local.get $sliceBase
+  local.get $thisBase
+  local.get $len
   i32.const 2
   i32.shl
   memory.copy $0 $0
-  local.get $6
+  local.get $slice
   local.set $9
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -32444,15 +32444,15 @@
   global.set $~lib/memory/__stack_pointer
   local.get $9
  )
- (func $~lib/array/Array<i32>#splice (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
-  (local $3 i32)
-  (local $4 i32)
-  (local $5 i32)
-  (local $6 i32)
-  (local $7 i32)
-  (local $8 i32)
-  (local $9 i32)
-  (local $10 i32)
+ (func $~lib/array/Array<i32>#splice (param $this i32) (param $start i32) (param $deleteCount i32) (result i32)
+  (local $len i32)
+  (local $var$4 i32)
+  (local $var$5 i32)
+  (local $result i32)
+  (local $resultStart i32)
+  (local $thisStart i32)
+  (local $thisBase i32)
+  (local $offset i32)
   (local $11 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -32462,105 +32462,105 @@
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   i32.store $0
-  local.get $0
+  local.get $this
   i32.load $0 offset=12
-  local.set $3
-  local.get $1
+  local.set $len
+  local.get $start
   i32.const 0
   i32.lt_s
   if (result i32)
-   local.get $3
-   local.get $1
+   local.get $len
+   local.get $start
    i32.add
-   local.tee $4
+   local.tee $var$4
    i32.const 0
-   local.tee $5
-   local.get $4
-   local.get $5
+   local.tee $var$5
+   local.get $var$4
+   local.get $var$5
    i32.gt_s
    select
   else
-   local.get $1
-   local.tee $5
-   local.get $3
-   local.tee $4
-   local.get $5
-   local.get $4
+   local.get $start
+   local.tee $var$5
+   local.get $len
+   local.tee $var$4
+   local.get $var$5
+   local.get $var$4
    i32.lt_s
    select
   end
-  local.set $1
-  local.get $2
-  local.tee $4
-  local.get $3
-  local.get $1
+  local.set $start
+  local.get $deleteCount
+  local.tee $var$4
+  local.get $len
+  local.get $start
   i32.sub
-  local.tee $5
-  local.get $4
-  local.get $5
+  local.tee $var$5
+  local.get $var$4
+  local.get $var$5
   i32.lt_s
   select
-  local.tee $5
+  local.tee $var$5
   i32.const 0
-  local.tee $4
-  local.get $5
-  local.get $4
+  local.tee $var$4
+  local.get $var$5
+  local.get $var$4
   i32.gt_s
   select
-  local.set $2
+  local.set $deleteCount
   global.get $~lib/memory/__stack_pointer
-  local.get $2
+  local.get $deleteCount
   i32.const 2
   i32.const 3
   i32.const 0
   call $~lib/rt/__newArray
-  local.tee $6
+  local.tee $result
   i32.store $0
-  local.get $6
+  local.get $result
   i32.load $0 offset=4
-  local.set $7
-  local.get $0
+  local.set $resultStart
+  local.get $this
   i32.load $0 offset=4
-  local.set $8
-  local.get $8
-  local.get $1
+  local.set $thisStart
+  local.get $thisStart
+  local.get $start
   i32.const 2
   i32.shl
   i32.add
-  local.set $9
-  local.get $7
-  local.get $9
-  local.get $2
+  local.set $thisBase
+  local.get $resultStart
+  local.get $thisBase
+  local.get $deleteCount
   i32.const 2
   i32.shl
   memory.copy $0 $0
-  local.get $1
-  local.get $2
+  local.get $start
+  local.get $deleteCount
   i32.add
-  local.set $10
-  local.get $3
-  local.get $10
+  local.set $offset
+  local.get $len
+  local.get $offset
   i32.ne
   if
-   local.get $9
-   local.get $8
-   local.get $10
+   local.get $thisBase
+   local.get $thisStart
+   local.get $offset
    i32.const 2
    i32.shl
    i32.add
-   local.get $3
-   local.get $10
+   local.get $len
+   local.get $offset
    i32.sub
    i32.const 2
    i32.shl
    memory.copy $0 $0
   end
-  local.get $0
-  local.get $3
-  local.get $2
+  local.get $this
+  local.get $len
+  local.get $deleteCount
   i32.sub
   call $~lib/array/Array<i32>#set:length_
-  local.get $6
+  local.get $result
   local.set $11
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -32568,15 +32568,15 @@
   global.set $~lib/memory/__stack_pointer
   local.get $11
  )
- (func $~lib/array/Array<std/array/Ref>#splice (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
-  (local $3 i32)
-  (local $4 i32)
-  (local $5 i32)
-  (local $6 i32)
-  (local $7 i32)
-  (local $8 i32)
-  (local $9 i32)
-  (local $10 i32)
+ (func $~lib/array/Array<std/array/Ref>#splice (param $this i32) (param $start i32) (param $deleteCount i32) (result i32)
+  (local $len i32)
+  (local $var$4 i32)
+  (local $var$5 i32)
+  (local $result i32)
+  (local $resultStart i32)
+  (local $thisStart i32)
+  (local $thisBase i32)
+  (local $offset i32)
   (local $11 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -32586,105 +32586,105 @@
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   i32.store $0
-  local.get $0
+  local.get $this
   i32.load $0 offset=12
-  local.set $3
-  local.get $1
+  local.set $len
+  local.get $start
   i32.const 0
   i32.lt_s
   if (result i32)
-   local.get $3
-   local.get $1
+   local.get $len
+   local.get $start
    i32.add
-   local.tee $4
+   local.tee $var$4
    i32.const 0
-   local.tee $5
-   local.get $4
-   local.get $5
+   local.tee $var$5
+   local.get $var$4
+   local.get $var$5
    i32.gt_s
    select
   else
-   local.get $1
-   local.tee $5
-   local.get $3
-   local.tee $4
-   local.get $5
-   local.get $4
+   local.get $start
+   local.tee $var$5
+   local.get $len
+   local.tee $var$4
+   local.get $var$5
+   local.get $var$4
    i32.lt_s
    select
   end
-  local.set $1
-  local.get $2
-  local.tee $4
-  local.get $3
-  local.get $1
+  local.set $start
+  local.get $deleteCount
+  local.tee $var$4
+  local.get $len
+  local.get $start
   i32.sub
-  local.tee $5
-  local.get $4
-  local.get $5
+  local.tee $var$5
+  local.get $var$4
+  local.get $var$5
   i32.lt_s
   select
-  local.tee $5
+  local.tee $var$5
   i32.const 0
-  local.tee $4
-  local.get $5
-  local.get $4
+  local.tee $var$4
+  local.get $var$5
+  local.get $var$4
   i32.gt_s
   select
-  local.set $2
+  local.set $deleteCount
   global.get $~lib/memory/__stack_pointer
-  local.get $2
+  local.get $deleteCount
   i32.const 2
   i32.const 9
   i32.const 0
   call $~lib/rt/__newArray
-  local.tee $6
+  local.tee $result
   i32.store $0
-  local.get $6
+  local.get $result
   i32.load $0 offset=4
-  local.set $7
-  local.get $0
+  local.set $resultStart
+  local.get $this
   i32.load $0 offset=4
-  local.set $8
-  local.get $8
-  local.get $1
+  local.set $thisStart
+  local.get $thisStart
+  local.get $start
   i32.const 2
   i32.shl
   i32.add
-  local.set $9
-  local.get $7
-  local.get $9
-  local.get $2
+  local.set $thisBase
+  local.get $resultStart
+  local.get $thisBase
+  local.get $deleteCount
   i32.const 2
   i32.shl
   memory.copy $0 $0
-  local.get $1
-  local.get $2
+  local.get $start
+  local.get $deleteCount
   i32.add
-  local.set $10
-  local.get $3
-  local.get $10
+  local.set $offset
+  local.get $len
+  local.get $offset
   i32.ne
   if
-   local.get $9
-   local.get $8
-   local.get $10
+   local.get $thisBase
+   local.get $thisStart
+   local.get $offset
    i32.const 2
    i32.shl
    i32.add
-   local.get $3
-   local.get $10
+   local.get $len
+   local.get $offset
    i32.sub
    i32.const 2
    i32.shl
    memory.copy $0 $0
   end
-  local.get $0
-  local.get $3
-  local.get $2
+  local.get $this
+  local.get $len
+  local.get $deleteCount
   i32.sub
   call $~lib/array/Array<std/array/Ref>#set:length_
-  local.get $6
+  local.get $result
   local.set $11
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -32692,8 +32692,8 @@
   global.set $~lib/memory/__stack_pointer
   local.get $11
  )
- (func $~lib/array/Array<std/array/Ref>#__get (param $0 i32) (param $1 i32) (result i32)
-  (local $2 i32)
+ (func $~lib/array/Array<std/array/Ref>#__get (param $this i32) (param $index i32) (result i32)
+  (local $value i32)
   (local $3 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -32703,8 +32703,8 @@
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   i32.store $0
-  local.get $1
-  local.get $0
+  local.get $index
+  local.get $this
   i32.load $0 offset=12
   i32.ge_u
   if
@@ -32716,21 +32716,21 @@
    unreachable
   end
   global.get $~lib/memory/__stack_pointer
-  local.get $0
+  local.get $this
   i32.load $0 offset=4
-  local.get $1
+  local.get $index
   i32.const 2
   i32.shl
   i32.add
   i32.load $0
-  local.tee $2
+  local.tee $value
   i32.store $0
   i32.const 1
   drop
   i32.const 0
   i32.eqz
   drop
-  local.get $2
+  local.get $value
   i32.eqz
   if
    i32.const 5392
@@ -32740,7 +32740,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $2
+  local.get $value
   local.set $3
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -32748,15 +32748,15 @@
   global.set $~lib/memory/__stack_pointer
   local.get $3
  )
- (func $~lib/array/Array<std/array/Ref|null>#splice (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
-  (local $3 i32)
-  (local $4 i32)
-  (local $5 i32)
-  (local $6 i32)
-  (local $7 i32)
-  (local $8 i32)
-  (local $9 i32)
-  (local $10 i32)
+ (func $~lib/array/Array<std/array/Ref|null>#splice (param $this i32) (param $start i32) (param $deleteCount i32) (result i32)
+  (local $len i32)
+  (local $var$4 i32)
+  (local $var$5 i32)
+  (local $result i32)
+  (local $resultStart i32)
+  (local $thisStart i32)
+  (local $thisBase i32)
+  (local $offset i32)
   (local $11 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -32766,105 +32766,105 @@
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   i32.store $0
-  local.get $0
+  local.get $this
   i32.load $0 offset=12
-  local.set $3
-  local.get $1
+  local.set $len
+  local.get $start
   i32.const 0
   i32.lt_s
   if (result i32)
-   local.get $3
-   local.get $1
+   local.get $len
+   local.get $start
    i32.add
-   local.tee $4
+   local.tee $var$4
    i32.const 0
-   local.tee $5
-   local.get $4
-   local.get $5
+   local.tee $var$5
+   local.get $var$4
+   local.get $var$5
    i32.gt_s
    select
   else
-   local.get $1
-   local.tee $5
-   local.get $3
-   local.tee $4
-   local.get $5
-   local.get $4
+   local.get $start
+   local.tee $var$5
+   local.get $len
+   local.tee $var$4
+   local.get $var$5
+   local.get $var$4
    i32.lt_s
    select
   end
-  local.set $1
-  local.get $2
-  local.tee $4
-  local.get $3
-  local.get $1
+  local.set $start
+  local.get $deleteCount
+  local.tee $var$4
+  local.get $len
+  local.get $start
   i32.sub
-  local.tee $5
-  local.get $4
-  local.get $5
+  local.tee $var$5
+  local.get $var$4
+  local.get $var$5
   i32.lt_s
   select
-  local.tee $5
+  local.tee $var$5
   i32.const 0
-  local.tee $4
-  local.get $5
-  local.get $4
+  local.tee $var$4
+  local.get $var$5
+  local.get $var$4
   i32.gt_s
   select
-  local.set $2
+  local.set $deleteCount
   global.get $~lib/memory/__stack_pointer
-  local.get $2
+  local.get $deleteCount
   i32.const 2
   i32.const 12
   i32.const 0
   call $~lib/rt/__newArray
-  local.tee $6
+  local.tee $result
   i32.store $0
-  local.get $6
+  local.get $result
   i32.load $0 offset=4
-  local.set $7
-  local.get $0
+  local.set $resultStart
+  local.get $this
   i32.load $0 offset=4
-  local.set $8
-  local.get $8
-  local.get $1
+  local.set $thisStart
+  local.get $thisStart
+  local.get $start
   i32.const 2
   i32.shl
   i32.add
-  local.set $9
-  local.get $7
-  local.get $9
-  local.get $2
+  local.set $thisBase
+  local.get $resultStart
+  local.get $thisBase
+  local.get $deleteCount
   i32.const 2
   i32.shl
   memory.copy $0 $0
-  local.get $1
-  local.get $2
+  local.get $start
+  local.get $deleteCount
   i32.add
-  local.set $10
-  local.get $3
-  local.get $10
+  local.set $offset
+  local.get $len
+  local.get $offset
   i32.ne
   if
-   local.get $9
-   local.get $8
-   local.get $10
+   local.get $thisBase
+   local.get $thisStart
+   local.get $offset
    i32.const 2
    i32.shl
    i32.add
-   local.get $3
-   local.get $10
+   local.get $len
+   local.get $offset
    i32.sub
    i32.const 2
    i32.shl
    memory.copy $0 $0
   end
-  local.get $0
-  local.get $3
-  local.get $2
+  local.get $this
+  local.get $len
+  local.get $deleteCount
   i32.sub
   call $~lib/array/Array<std/array/Ref|null>#set:length_
-  local.get $6
+  local.get $result
   local.set $11
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -32872,8 +32872,8 @@
   global.set $~lib/memory/__stack_pointer
   local.get $11
  )
- (func $~lib/array/Array<std/array/Ref|null>#__get (param $0 i32) (param $1 i32) (result i32)
-  (local $2 i32)
+ (func $~lib/array/Array<std/array/Ref|null>#__get (param $this i32) (param $index i32) (result i32)
+  (local $value i32)
   (local $3 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -32883,8 +32883,8 @@
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   i32.store $0
-  local.get $1
-  local.get $0
+  local.get $index
+  local.get $this
   i32.load $0 offset=12
   i32.ge_u
   if
@@ -32896,21 +32896,21 @@
    unreachable
   end
   global.get $~lib/memory/__stack_pointer
-  local.get $0
+  local.get $this
   i32.load $0 offset=4
-  local.get $1
+  local.get $index
   i32.const 2
   i32.shl
   i32.add
   i32.load $0
-  local.tee $2
+  local.tee $value
   i32.store $0
   i32.const 1
   drop
   i32.const 1
   i32.eqz
   drop
-  local.get $2
+  local.get $value
   local.set $3
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -32918,13 +32918,13 @@
   global.set $~lib/memory/__stack_pointer
   local.get $3
  )
- (func $~lib/util/number/itoa32 (param $0 i32) (param $1 i32) (result i32)
-  (local $2 i32)
-  (local $3 i32)
-  (local $4 i32)
-  (local $5 i32)
-  (local $6 i32)
-  (local $7 i32)
+ (func $~lib/util/number/itoa32 (param $value i32) (param $radix i32) (result i32)
+  (local $sign i32)
+  (local $out i32)
+  (local $var$4 i32)
+  (local $var$5 i32)
+  (local $var$6 i32)
+  (local $var$7 i32)
   (local $8 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -32934,13 +32934,13 @@
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   i32.store $0
-  local.get $1
+  local.get $radix
   i32.const 2
   i32.lt_s
   if (result i32)
    i32.const 1
   else
-   local.get $1
+   local.get $radix
    i32.const 36
    i32.gt_s
   end
@@ -32952,7 +32952,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $0
+  local.get $value
   i32.eqz
   if
    i32.const 6624
@@ -32964,128 +32964,128 @@
    local.get $8
    return
   end
-  local.get $0
+  local.get $value
   i32.const 31
   i32.shr_u
   i32.const 1
   i32.shl
-  local.set $2
-  local.get $2
+  local.set $sign
+  local.get $sign
   if
    i32.const 0
-   local.get $0
+   local.get $value
    i32.sub
-   local.set $0
+   local.set $value
   end
-  local.get $1
+  local.get $radix
   i32.const 10
   i32.eq
   if
-   local.get $0
+   local.get $value
    call $~lib/util/number/decimalCount32
-   local.set $4
+   local.set $var$4
    global.get $~lib/memory/__stack_pointer
-   local.get $4
+   local.get $var$4
    i32.const 1
    i32.shl
-   local.get $2
+   local.get $sign
    i32.add
    i32.const 1
    call $~lib/rt/itcms/__new
-   local.tee $3
+   local.tee $out
    i32.store $0
-   local.get $3
-   local.get $2
+   local.get $out
+   local.get $sign
    i32.add
-   local.set $7
-   local.get $0
-   local.set $6
-   local.get $4
-   local.set $5
+   local.set $var$7
+   local.get $value
+   local.set $var$6
+   local.get $var$4
+   local.set $var$5
    i32.const 0
    i32.const 1
    i32.ge_s
    drop
-   local.get $7
-   local.get $6
-   local.get $5
+   local.get $var$7
+   local.get $var$6
+   local.get $var$5
    call $~lib/util/number/utoa32_dec_lut
   else
-   local.get $1
+   local.get $radix
    i32.const 16
    i32.eq
    if
     i32.const 31
-    local.get $0
+    local.get $value
     i32.clz
     i32.sub
     i32.const 2
     i32.shr_s
     i32.const 1
     i32.add
-    local.set $4
+    local.set $var$4
     global.get $~lib/memory/__stack_pointer
-    local.get $4
+    local.get $var$4
     i32.const 1
     i32.shl
-    local.get $2
+    local.get $sign
     i32.add
     i32.const 1
     call $~lib/rt/itcms/__new
-    local.tee $3
+    local.tee $out
     i32.store $0
-    local.get $3
-    local.get $2
+    local.get $out
+    local.get $sign
     i32.add
-    local.set $7
-    local.get $0
-    local.set $6
-    local.get $4
-    local.set $5
+    local.set $var$7
+    local.get $value
+    local.set $var$6
+    local.get $var$4
+    local.set $var$5
     i32.const 0
     i32.const 1
     i32.ge_s
     drop
-    local.get $7
-    local.get $6
+    local.get $var$7
+    local.get $var$6
     i64.extend_i32_u
-    local.get $5
+    local.get $var$5
     call $~lib/util/number/utoa_hex_lut
    else
-    local.get $0
-    local.set $4
-    local.get $4
+    local.get $value
+    local.set $var$4
+    local.get $var$4
     i64.extend_i32_u
-    local.get $1
+    local.get $radix
     call $~lib/util/number/ulog_base
-    local.set $7
+    local.set $var$7
     global.get $~lib/memory/__stack_pointer
-    local.get $7
+    local.get $var$7
     i32.const 1
     i32.shl
-    local.get $2
+    local.get $sign
     i32.add
     i32.const 1
     call $~lib/rt/itcms/__new
-    local.tee $3
+    local.tee $out
     i32.store $0
-    local.get $3
-    local.get $2
+    local.get $out
+    local.get $sign
     i32.add
-    local.get $4
+    local.get $var$4
     i64.extend_i32_u
-    local.get $7
-    local.get $1
+    local.get $var$7
+    local.get $radix
     call $~lib/util/number/utoa64_any_core
    end
   end
-  local.get $2
+  local.get $sign
   if
-   local.get $3
+   local.get $out
    i32.const 45
    i32.store16 $0
   end
-  local.get $3
+  local.get $out
   local.set $8
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -33093,13 +33093,13 @@
   global.set $~lib/memory/__stack_pointer
   local.get $8
  )
- (func $~lib/array/Array<i32>#map<~lib/string/String> (param $0 i32) (param $1 i32) (result i32)
-  (local $2 i32)
-  (local $3 i32)
-  (local $4 i32)
-  (local $5 i32)
-  (local $6 i32)
-  (local $7 i32)
+ (func $~lib/array/Array<i32>#map<~lib/string/String> (param $this i32) (param $fn i32) (result i32)
+  (local $len i32)
+  (local $out i32)
+  (local $outStart i32)
+  (local $var$5 i32)
+  (local $var$6 i32)
+  (local $var$7 i32)
   (local $8 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 8
@@ -33109,75 +33109,75 @@
   global.get $~lib/memory/__stack_pointer
   i64.const 0
   i64.store $0
-  local.get $0
+  local.get $this
   i32.load $0 offset=12
-  local.set $2
+  local.set $len
   global.get $~lib/memory/__stack_pointer
-  local.get $2
+  local.get $len
   i32.const 2
   i32.const 15
   i32.const 0
   call $~lib/rt/__newArray
-  local.tee $3
+  local.tee $out
   i32.store $0
-  local.get $3
+  local.get $out
   i32.load $0 offset=4
-  local.set $4
+  local.set $outStart
   i32.const 0
-  local.set $5
+  local.set $var$5
   loop $for-loop|0
-   local.get $5
-   local.get $2
-   local.tee $6
-   local.get $0
+   local.get $var$5
+   local.get $len
+   local.tee $var$6
+   local.get $this
    i32.load $0 offset=12
-   local.tee $7
-   local.get $6
-   local.get $7
+   local.tee $var$7
+   local.get $var$6
+   local.get $var$7
    i32.lt_s
    select
    i32.lt_s
-   local.set $6
-   local.get $6
+   local.set $var$6
+   local.get $var$6
    if
     global.get $~lib/memory/__stack_pointer
-    local.get $0
+    local.get $this
     i32.load $0 offset=4
-    local.get $5
+    local.get $var$5
     i32.const 2
     i32.shl
     i32.add
     i32.load $0
-    local.get $5
-    local.get $0
+    local.get $var$5
+    local.get $this
     i32.const 3
     global.set $~argumentsLength
-    local.get $1
+    local.get $fn
     i32.load $0
     call_indirect $0 (type $i32_i32_i32_=>_i32)
-    local.tee $7
+    local.tee $var$7
     i32.store $0 offset=4
-    local.get $4
-    local.get $5
+    local.get $outStart
+    local.get $var$5
     i32.const 2
     i32.shl
     i32.add
-    local.get $7
+    local.get $var$7
     i32.store $0
     i32.const 1
     drop
-    local.get $3
-    local.get $7
+    local.get $out
+    local.get $var$7
     i32.const 1
     call $~lib/rt/itcms/__link
-    local.get $5
+    local.get $var$5
     i32.const 1
     i32.add
-    local.set $5
+    local.set $var$5
     br $for-loop|0
    end
   end
-  local.get $3
+  local.get $out
   local.set $8
   global.get $~lib/memory/__stack_pointer
   i32.const 8
@@ -33185,14 +33185,14 @@
   global.set $~lib/memory/__stack_pointer
   local.get $8
  )
- (func $~lib/array/Array<i32>#map<f32> (param $0 i32) (param $1 i32) (result i32)
-  (local $2 i32)
-  (local $3 i32)
-  (local $4 i32)
-  (local $5 i32)
-  (local $6 i32)
-  (local $7 i32)
-  (local $8 f32)
+ (func $~lib/array/Array<i32>#map<f32> (param $this i32) (param $fn i32) (result i32)
+  (local $len i32)
+  (local $out i32)
+  (local $outStart i32)
+  (local $var$5 i32)
+  (local $var$6 i32)
+  (local $var$7 i32)
+  (local $var$8 f32)
   (local $9 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -33202,69 +33202,69 @@
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   i32.store $0
-  local.get $0
+  local.get $this
   i32.load $0 offset=12
-  local.set $2
+  local.set $len
   global.get $~lib/memory/__stack_pointer
-  local.get $2
+  local.get $len
   i32.const 2
   i32.const 8
   i32.const 0
   call $~lib/rt/__newArray
-  local.tee $3
+  local.tee $out
   i32.store $0
-  local.get $3
+  local.get $out
   i32.load $0 offset=4
-  local.set $4
+  local.set $outStart
   i32.const 0
-  local.set $5
+  local.set $var$5
   loop $for-loop|0
-   local.get $5
-   local.get $2
-   local.tee $6
-   local.get $0
+   local.get $var$5
+   local.get $len
+   local.tee $var$6
+   local.get $this
    i32.load $0 offset=12
-   local.tee $7
-   local.get $6
-   local.get $7
+   local.tee $var$7
+   local.get $var$6
+   local.get $var$7
    i32.lt_s
    select
    i32.lt_s
-   local.set $6
-   local.get $6
+   local.set $var$6
+   local.get $var$6
    if
-    local.get $0
+    local.get $this
     i32.load $0 offset=4
-    local.get $5
+    local.get $var$5
     i32.const 2
     i32.shl
     i32.add
     i32.load $0
-    local.get $5
-    local.get $0
+    local.get $var$5
+    local.get $this
     i32.const 3
     global.set $~argumentsLength
-    local.get $1
+    local.get $fn
     i32.load $0
     call_indirect $0 (type $i32_i32_i32_=>_f32)
-    local.set $8
-    local.get $4
-    local.get $5
+    local.set $var$8
+    local.get $outStart
+    local.get $var$5
     i32.const 2
     i32.shl
     i32.add
-    local.get $8
+    local.get $var$8
     f32.store $0
     i32.const 0
     drop
-    local.get $5
+    local.get $var$5
     i32.const 1
     i32.add
-    local.set $5
+    local.set $var$5
     br $for-loop|0
    end
   end
-  local.get $3
+  local.get $out
   local.set $9
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -33272,13 +33272,13 @@
   global.set $~lib/memory/__stack_pointer
   local.get $9
  )
- (func $~lib/array/Array<i32>#map<i32> (param $0 i32) (param $1 i32) (result i32)
-  (local $2 i32)
-  (local $3 i32)
-  (local $4 i32)
-  (local $5 i32)
-  (local $6 i32)
-  (local $7 i32)
+ (func $~lib/array/Array<i32>#map<i32> (param $this i32) (param $fn i32) (result i32)
+  (local $len i32)
+  (local $out i32)
+  (local $outStart i32)
+  (local $var$5 i32)
+  (local $var$6 i32)
+  (local $var$7 i32)
   (local $8 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -33288,69 +33288,69 @@
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   i32.store $0
-  local.get $0
+  local.get $this
   i32.load $0 offset=12
-  local.set $2
+  local.set $len
   global.get $~lib/memory/__stack_pointer
-  local.get $2
+  local.get $len
   i32.const 2
   i32.const 3
   i32.const 0
   call $~lib/rt/__newArray
-  local.tee $3
+  local.tee $out
   i32.store $0
-  local.get $3
+  local.get $out
   i32.load $0 offset=4
-  local.set $4
+  local.set $outStart
   i32.const 0
-  local.set $5
+  local.set $var$5
   loop $for-loop|0
-   local.get $5
-   local.get $2
-   local.tee $6
-   local.get $0
+   local.get $var$5
+   local.get $len
+   local.tee $var$6
+   local.get $this
    i32.load $0 offset=12
-   local.tee $7
-   local.get $6
-   local.get $7
+   local.tee $var$7
+   local.get $var$6
+   local.get $var$7
    i32.lt_s
    select
    i32.lt_s
-   local.set $6
-   local.get $6
+   local.set $var$6
+   local.get $var$6
    if
-    local.get $0
+    local.get $this
     i32.load $0 offset=4
-    local.get $5
+    local.get $var$5
     i32.const 2
     i32.shl
     i32.add
     i32.load $0
-    local.get $5
-    local.get $0
+    local.get $var$5
+    local.get $this
     i32.const 3
     global.set $~argumentsLength
-    local.get $1
+    local.get $fn
     i32.load $0
     call_indirect $0 (type $i32_i32_i32_=>_i32)
-    local.set $7
-    local.get $4
-    local.get $5
+    local.set $var$7
+    local.get $outStart
+    local.get $var$5
     i32.const 2
     i32.shl
     i32.add
-    local.get $7
+    local.get $var$7
     i32.store $0
     i32.const 0
     drop
-    local.get $5
+    local.get $var$5
     i32.const 1
     i32.add
-    local.set $5
+    local.set $var$5
     br $for-loop|0
    end
   end
-  local.get $3
+  local.get $out
   local.set $8
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -33358,12 +33358,12 @@
   global.set $~lib/memory/__stack_pointer
   local.get $8
  )
- (func $~lib/array/Array<i32>#filter (param $0 i32) (param $1 i32) (result i32)
-  (local $2 i32)
-  (local $3 i32)
-  (local $4 i32)
-  (local $5 i32)
-  (local $6 i32)
+ (func $~lib/array/Array<i32>#filter (param $this i32) (param $fn i32) (result i32)
+  (local $result i32)
+  (local $var$3 i32)
+  (local $var$4 i32)
+  (local $var$5 i32)
+  (local $var$6 i32)
   (local $7 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -33379,58 +33379,58 @@
   i32.const 3
   i32.const 0
   call $~lib/rt/__newArray
-  local.tee $2
+  local.tee $result
   i32.store $0
   i32.const 0
-  local.set $3
-  local.get $0
+  local.set $var$3
+  local.get $this
   i32.load $0 offset=12
-  local.set $4
+  local.set $var$4
   loop $for-loop|0
-   local.get $3
-   local.get $4
-   local.tee $5
-   local.get $0
+   local.get $var$3
+   local.get $var$4
+   local.tee $var$5
+   local.get $this
    i32.load $0 offset=12
-   local.tee $6
-   local.get $5
-   local.get $6
+   local.tee $var$6
+   local.get $var$5
+   local.get $var$6
    i32.lt_s
    select
    i32.lt_s
-   local.set $5
-   local.get $5
+   local.set $var$5
+   local.get $var$5
    if
-    local.get $0
+    local.get $this
     i32.load $0 offset=4
-    local.get $3
+    local.get $var$3
     i32.const 2
     i32.shl
     i32.add
     i32.load $0
-    local.set $6
-    local.get $6
-    local.get $3
-    local.get $0
+    local.set $var$6
+    local.get $var$6
+    local.get $var$3
+    local.get $this
     i32.const 3
     global.set $~argumentsLength
-    local.get $1
+    local.get $fn
     i32.load $0
     call_indirect $0 (type $i32_i32_i32_=>_i32)
     if
-     local.get $2
-     local.get $6
+     local.get $result
+     local.get $var$6
      call $~lib/array/Array<i32>#push
      drop
     end
-    local.get $3
+    local.get $var$3
     i32.const 1
     i32.add
-    local.set $3
+    local.set $var$3
     br $for-loop|0
    end
   end
-  local.get $2
+  local.get $result
   local.set $7
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -33438,7 +33438,7 @@
   global.set $~lib/memory/__stack_pointer
   local.get $7
  )
- (func $std/array/Dim#constructor (param $0 i32) (result i32)
+ (func $std/array/Dim#constructor (param $this i32) (result i32)
   (local $1 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -33448,23 +33448,23 @@
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   i32.store $0
-  local.get $0
+  local.get $this
   i32.eqz
   if
    global.get $~lib/memory/__stack_pointer
    i32.const 8
    i32.const 21
    call $~lib/rt/itcms/__new
-   local.tee $0
+   local.tee $this
    i32.store $0
   end
-  local.get $0
+  local.get $this
   i32.const 0
   call $std/array/Dim#set:height
-  local.get $0
+  local.get $this
   i32.const 0
   call $std/array/Dim#set:width
-  local.get $0
+  local.get $this
   local.set $1
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -33472,7 +33472,7 @@
   global.set $~lib/memory/__stack_pointer
   local.get $1
  )
- (func $~lib/array/Array<f32>#sort@varargs (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<f32>#sort@varargs (param $this i32) (param $comparator i32) (result i32)
   (local $2 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -33503,11 +33503,11 @@
     i32.const 9168
     br $~lib/util/sort/COMPARATOR<f32>|inlined.0
    end
-   local.tee $1
+   local.tee $comparator
    i32.store $0
   end
-  local.get $0
-  local.get $1
+  local.get $this
+  local.get $comparator
   call $~lib/array/Array<f32>#sort
   local.set $2
   global.get $~lib/memory/__stack_pointer
@@ -33516,7 +33516,7 @@
   global.set $~lib/memory/__stack_pointer
   local.get $2
  )
- (func $~lib/array/Array<f64>#sort@varargs (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<f64>#sort@varargs (param $this i32) (param $comparator i32) (result i32)
   (local $2 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -33547,11 +33547,11 @@
     i32.const 9456
     br $~lib/util/sort/COMPARATOR<f64>|inlined.0
    end
-   local.tee $1
+   local.tee $comparator
    i32.store $0
   end
-  local.get $0
-  local.get $1
+  local.get $this
+  local.get $comparator
   call $~lib/array/Array<f64>#sort
   local.set $2
   global.get $~lib/memory/__stack_pointer
@@ -33560,7 +33560,7 @@
   global.set $~lib/memory/__stack_pointer
   local.get $2
  )
- (func $~lib/array/Array<i32>#sort@varargs (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<i32>#sort@varargs (param $this i32) (param $comparator i32) (result i32)
   (local $2 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -33589,11 +33589,11 @@
     i32.const 9632
     br $~lib/util/sort/COMPARATOR<i32>|inlined.0
    end
-   local.tee $1
+   local.tee $comparator
    i32.store $0
   end
-  local.get $0
-  local.get $1
+  local.get $this
+  local.get $comparator
   call $~lib/array/Array<i32>#sort
   local.set $2
   global.get $~lib/memory/__stack_pointer
@@ -33602,7 +33602,7 @@
   global.set $~lib/memory/__stack_pointer
   local.get $2
  )
- (func $~lib/array/Array<u32>#sort@varargs (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<u32>#sort@varargs (param $this i32) (param $comparator i32) (result i32)
   (local $2 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -33629,11 +33629,11 @@
     i32.const 9760
     br $~lib/util/sort/COMPARATOR<u32>|inlined.0
    end
-   local.tee $1
+   local.tee $comparator
    i32.store $0
   end
-  local.get $0
-  local.get $1
+  local.get $this
+  local.get $comparator
   call $~lib/array/Array<u32>#sort
   local.set $2
   global.get $~lib/memory/__stack_pointer
@@ -33642,10 +33642,10 @@
   global.set $~lib/memory/__stack_pointer
   local.get $2
  )
- (func $std/array/createReverseOrderedArray (param $0 i32) (result i32)
-  (local $1 i32)
-  (local $2 i32)
-  (local $3 i32)
+ (func $std/array/createReverseOrderedArray (param $size i32) (result i32)
+  (local $arr i32)
+  (local $var$2 i32)
+  (local $var$3 i32)
   (local $4 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -33657,35 +33657,35 @@
   i32.store $0
   global.get $~lib/memory/__stack_pointer
   i32.const 0
-  local.get $0
+  local.get $size
   call $~lib/array/Array<i32>#constructor
-  local.tee $1
+  local.tee $arr
   i32.store $0
   i32.const 0
-  local.set $2
+  local.set $var$2
   loop $for-loop|0
-   local.get $2
-   local.get $0
+   local.get $var$2
+   local.get $size
    i32.lt_s
-   local.set $3
-   local.get $3
+   local.set $var$3
+   local.get $var$3
    if
-    local.get $1
-    local.get $2
-    local.get $0
+    local.get $arr
+    local.get $var$2
+    local.get $size
     i32.const 1
     i32.sub
-    local.get $2
+    local.get $var$2
     i32.sub
     call $~lib/array/Array<i32>#__set
-    local.get $2
+    local.get $var$2
     i32.const 1
     i32.add
-    local.set $2
+    local.set $var$2
     br $for-loop|0
    end
   end
-  local.get $1
+  local.get $arr
   local.set $4
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -33693,10 +33693,10 @@
   global.set $~lib/memory/__stack_pointer
   local.get $4
  )
- (func $std/array/createRandomOrderedArray (param $0 i32) (result i32)
-  (local $1 i32)
-  (local $2 i32)
-  (local $3 i32)
+ (func $std/array/createRandomOrderedArray (param $size i32) (result i32)
+  (local $arr i32)
+  (local $var$2 i32)
+  (local $var$3 i32)
   (local $4 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -33708,35 +33708,35 @@
   i32.store $0
   global.get $~lib/memory/__stack_pointer
   i32.const 0
-  local.get $0
+  local.get $size
   call $~lib/array/Array<i32>#constructor
-  local.tee $1
+  local.tee $arr
   i32.store $0
   i32.const 0
-  local.set $2
+  local.set $var$2
   loop $for-loop|0
-   local.get $2
-   local.get $0
+   local.get $var$2
+   local.get $size
    i32.lt_s
-   local.set $3
-   local.get $3
+   local.set $var$3
+   local.get $var$3
    if
-    local.get $1
-    local.get $2
+    local.get $arr
+    local.get $var$2
     call $~lib/math/NativeMath.random
-    local.get $0
+    local.get $size
     f64.convert_i32_s
     f64.mul
     i32.trunc_sat_f64_s
     call $~lib/array/Array<i32>#__set
-    local.get $2
+    local.get $var$2
     i32.const 1
     i32.add
-    local.set $2
+    local.set $var$2
     br $for-loop|0
    end
   end
-  local.get $1
+  local.get $arr
   local.set $4
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -33744,15 +33744,15 @@
   global.set $~lib/memory/__stack_pointer
   local.get $4
  )
- (func $~lib/array/Array<std/array/Dim>#slice (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
-  (local $3 i32)
-  (local $4 i32)
-  (local $5 i32)
-  (local $6 i32)
-  (local $7 i32)
-  (local $8 i32)
-  (local $9 i32)
-  (local $10 i32)
+ (func $~lib/array/Array<std/array/Dim>#slice (param $this i32) (param $start i32) (param $end i32) (result i32)
+  (local $len i32)
+  (local $var$4 i32)
+  (local $var$5 i32)
+  (local $slice i32)
+  (local $sliceBase i32)
+  (local $thisBase i32)
+  (local $var$9 i32)
+  (local $ref i32)
   (local $11 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -33762,125 +33762,125 @@
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   i32.store $0
-  local.get $0
+  local.get $this
   i32.load $0 offset=12
-  local.set $3
-  local.get $1
+  local.set $len
+  local.get $start
   i32.const 0
   i32.lt_s
   if (result i32)
-   local.get $1
-   local.get $3
+   local.get $start
+   local.get $len
    i32.add
-   local.tee $4
+   local.tee $var$4
    i32.const 0
-   local.tee $5
-   local.get $4
-   local.get $5
+   local.tee $var$5
+   local.get $var$4
+   local.get $var$5
    i32.gt_s
    select
   else
-   local.get $1
-   local.tee $5
-   local.get $3
-   local.tee $4
-   local.get $5
-   local.get $4
+   local.get $start
+   local.tee $var$5
+   local.get $len
+   local.tee $var$4
+   local.get $var$5
+   local.get $var$4
    i32.lt_s
    select
   end
-  local.set $1
-  local.get $2
+  local.set $start
+  local.get $end
   i32.const 0
   i32.lt_s
   if (result i32)
-   local.get $2
-   local.get $3
+   local.get $end
+   local.get $len
    i32.add
-   local.tee $4
+   local.tee $var$4
    i32.const 0
-   local.tee $5
-   local.get $4
-   local.get $5
+   local.tee $var$5
+   local.get $var$4
+   local.get $var$5
    i32.gt_s
    select
   else
-   local.get $2
-   local.tee $5
-   local.get $3
-   local.tee $4
-   local.get $5
-   local.get $4
+   local.get $end
+   local.tee $var$5
+   local.get $len
+   local.tee $var$4
+   local.get $var$5
+   local.get $var$4
    i32.lt_s
    select
   end
-  local.set $2
-  local.get $2
-  local.get $1
+  local.set $end
+  local.get $end
+  local.get $start
   i32.sub
-  local.tee $4
+  local.tee $var$4
   i32.const 0
-  local.tee $5
-  local.get $4
-  local.get $5
+  local.tee $var$5
+  local.get $var$4
+  local.get $var$5
   i32.gt_s
   select
-  local.set $3
+  local.set $len
   global.get $~lib/memory/__stack_pointer
-  local.get $3
+  local.get $len
   i32.const 2
   i32.const 22
   i32.const 0
   call $~lib/rt/__newArray
-  local.tee $6
+  local.tee $slice
   i32.store $0
-  local.get $6
+  local.get $slice
   i32.load $0 offset=4
-  local.set $7
-  local.get $0
+  local.set $sliceBase
+  local.get $this
   i32.load $0 offset=4
-  local.get $1
+  local.get $start
   i32.const 2
   i32.shl
   i32.add
-  local.set $8
+  local.set $thisBase
   i32.const 1
   drop
   i32.const 0
-  local.set $4
-  local.get $3
+  local.set $var$4
+  local.get $len
   i32.const 2
   i32.shl
-  local.set $5
+  local.set $var$5
   loop $while-continue|0
-   local.get $4
-   local.get $5
+   local.get $var$4
+   local.get $var$5
    i32.lt_u
-   local.set $9
-   local.get $9
+   local.set $var$9
+   local.get $var$9
    if
-    local.get $8
-    local.get $4
+    local.get $thisBase
+    local.get $var$4
     i32.add
     i32.load $0
-    local.set $10
-    local.get $7
-    local.get $4
+    local.set $ref
+    local.get $sliceBase
+    local.get $var$4
     i32.add
-    local.get $10
+    local.get $ref
     i32.store $0
-    local.get $6
-    local.get $10
+    local.get $slice
+    local.get $ref
     i32.const 1
     call $~lib/rt/itcms/__link
-    local.get $4
+    local.get $var$4
     i32.const 4
     i32.add
-    local.set $4
+    local.set $var$4
     br $while-continue|0
    end
   end
-  local.get $6
+  local.get $slice
   local.set $11
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -33888,8 +33888,8 @@
   global.set $~lib/memory/__stack_pointer
   local.get $11
  )
- (func $~lib/array/Array<std/array/Dim>#__get (param $0 i32) (param $1 i32) (result i32)
-  (local $2 i32)
+ (func $~lib/array/Array<std/array/Dim>#__get (param $this i32) (param $index i32) (result i32)
+  (local $value i32)
   (local $3 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -33899,8 +33899,8 @@
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   i32.store $0
-  local.get $1
-  local.get $0
+  local.get $index
+  local.get $this
   i32.load $0 offset=12
   i32.ge_u
   if
@@ -33912,21 +33912,21 @@
    unreachable
   end
   global.get $~lib/memory/__stack_pointer
-  local.get $0
+  local.get $this
   i32.load $0 offset=4
-  local.get $1
+  local.get $index
   i32.const 2
   i32.shl
   i32.add
   i32.load $0
-  local.tee $2
+  local.tee $value
   i32.store $0
   i32.const 1
   drop
   i32.const 0
   i32.eqz
   drop
-  local.get $2
+  local.get $value
   i32.eqz
   if
    i32.const 5392
@@ -33936,7 +33936,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $2
+  local.get $value
   local.set $3
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -33944,11 +33944,11 @@
   global.set $~lib/memory/__stack_pointer
   local.get $3
  )
- (func $~lib/array/Array<~lib/array/Array<i32>>#constructor (param $0 i32) (param $1 i32) (result i32)
-  (local $2 i32)
-  (local $3 i32)
-  (local $4 i32)
-  (local $5 i32)
+ (func $~lib/array/Array<~lib/array/Array<i32>>#constructor (param $this i32) (param $length i32) (result i32)
+  (local $var$2 i32)
+  (local $var$3 i32)
+  (local $bufferSize i32)
+  (local $buffer i32)
   (local $6 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 8
@@ -33958,29 +33958,29 @@
   global.get $~lib/memory/__stack_pointer
   i64.const 0
   i64.store $0
-  local.get $0
+  local.get $this
   i32.eqz
   if
    global.get $~lib/memory/__stack_pointer
    i32.const 16
    i32.const 28
    call $~lib/rt/itcms/__new
-   local.tee $0
+   local.tee $this
    i32.store $0
   end
-  local.get $0
+  local.get $this
   i32.const 0
   call $~lib/array/Array<~lib/array/Array<i32>>#set:buffer
-  local.get $0
+  local.get $this
   i32.const 0
   call $~lib/array/Array<~lib/array/Array<i32>>#set:dataStart
-  local.get $0
+  local.get $this
   i32.const 0
   call $~lib/array/Array<~lib/array/Array<i32>>#set:byteLength
-  local.get $0
+  local.get $this
   i32.const 0
   call $~lib/array/Array<~lib/array/Array<i32>>#set:length_
-  local.get $1
+  local.get $length
   i32.const 1073741820
   i32.const 2
   i32.shr_u
@@ -33993,40 +33993,40 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $1
-  local.tee $2
+  local.get $length
+  local.tee $var$2
   i32.const 8
-  local.tee $3
-  local.get $2
-  local.get $3
+  local.tee $var$3
+  local.get $var$2
+  local.get $var$3
   i32.gt_u
   select
   i32.const 2
   i32.shl
-  local.set $4
+  local.set $bufferSize
   global.get $~lib/memory/__stack_pointer
-  local.get $4
+  local.get $bufferSize
   i32.const 0
   call $~lib/rt/itcms/__new
-  local.tee $5
+  local.tee $buffer
   i32.store $0 offset=4
   i32.const 2
   global.get $~lib/shared/runtime/Runtime.Incremental
   i32.ne
   drop
-  local.get $0
-  local.get $5
+  local.get $this
+  local.get $buffer
   call $~lib/array/Array<~lib/array/Array<i32>>#set:buffer
-  local.get $0
-  local.get $5
+  local.get $this
+  local.get $buffer
   call $~lib/array/Array<~lib/array/Array<i32>>#set:dataStart
-  local.get $0
-  local.get $4
+  local.get $this
+  local.get $bufferSize
   call $~lib/array/Array<~lib/array/Array<i32>>#set:byteLength
-  local.get $0
-  local.get $1
+  local.get $this
+  local.get $length
   call $~lib/array/Array<~lib/array/Array<i32>>#set:length_
-  local.get $0
+  local.get $this
   local.set $6
   global.get $~lib/memory/__stack_pointer
   i32.const 8
@@ -34034,11 +34034,11 @@
   global.set $~lib/memory/__stack_pointer
   local.get $6
  )
- (func $std/array/createReverseOrderedNestedArray (param $0 i32) (result i32)
-  (local $1 i32)
-  (local $2 i32)
-  (local $3 i32)
-  (local $4 i32)
+ (func $std/array/createReverseOrderedNestedArray (param $size i32) (result i32)
+  (local $arr i32)
+  (local $var$2 i32)
+  (local $var$3 i32)
+  (local $var$4 i32)
   (local $5 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 8
@@ -34050,45 +34050,45 @@
   i64.store $0
   global.get $~lib/memory/__stack_pointer
   i32.const 0
-  local.get $0
+  local.get $size
   call $~lib/array/Array<~lib/array/Array<i32>>#constructor
-  local.tee $1
+  local.tee $arr
   i32.store $0
   i32.const 0
-  local.set $2
+  local.set $var$2
   loop $for-loop|0
-   local.get $2
-   local.get $0
+   local.get $var$2
+   local.get $size
    i32.lt_s
-   local.set $3
-   local.get $3
+   local.set $var$3
+   local.get $var$3
    if
     global.get $~lib/memory/__stack_pointer
     i32.const 0
     i32.const 1
     call $~lib/array/Array<i32>#constructor
-    local.tee $4
+    local.tee $var$4
     i32.store $0 offset=4
-    local.get $4
+    local.get $var$4
     i32.const 0
-    local.get $0
+    local.get $size
     i32.const 1
     i32.sub
-    local.get $2
+    local.get $var$2
     i32.sub
     call $~lib/array/Array<i32>#__set
-    local.get $1
-    local.get $2
-    local.get $4
+    local.get $arr
+    local.get $var$2
+    local.get $var$4
     call $~lib/array/Array<~lib/array/Array<i32>>#__set
-    local.get $2
+    local.get $var$2
     i32.const 1
     i32.add
-    local.set $2
+    local.set $var$2
     br $for-loop|0
    end
   end
-  local.get $1
+  local.get $arr
   local.set $5
   global.get $~lib/memory/__stack_pointer
   i32.const 8
@@ -34096,8 +34096,8 @@
   global.set $~lib/memory/__stack_pointer
   local.get $5
  )
- (func $~lib/array/Array<~lib/array/Array<i32>>#__get (param $0 i32) (param $1 i32) (result i32)
-  (local $2 i32)
+ (func $~lib/array/Array<~lib/array/Array<i32>>#__get (param $this i32) (param $index i32) (result i32)
+  (local $value i32)
   (local $3 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -34107,8 +34107,8 @@
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   i32.store $0
-  local.get $1
-  local.get $0
+  local.get $index
+  local.get $this
   i32.load $0 offset=12
   i32.ge_u
   if
@@ -34120,21 +34120,21 @@
    unreachable
   end
   global.get $~lib/memory/__stack_pointer
-  local.get $0
+  local.get $this
   i32.load $0 offset=4
-  local.get $1
+  local.get $index
   i32.const 2
   i32.shl
   i32.add
   i32.load $0
-  local.tee $2
+  local.tee $value
   i32.store $0
   i32.const 1
   drop
   i32.const 0
   i32.eqz
   drop
-  local.get $2
+  local.get $value
   i32.eqz
   if
    i32.const 5392
@@ -34144,7 +34144,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $2
+  local.get $value
   local.set $3
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -34152,11 +34152,11 @@
   global.set $~lib/memory/__stack_pointer
   local.get $3
  )
- (func $~lib/array/Array<std/array/Proxy<i32>>#constructor (param $0 i32) (param $1 i32) (result i32)
-  (local $2 i32)
-  (local $3 i32)
-  (local $4 i32)
-  (local $5 i32)
+ (func $~lib/array/Array<std/array/Proxy<i32>>#constructor (param $this i32) (param $length i32) (result i32)
+  (local $var$2 i32)
+  (local $var$3 i32)
+  (local $bufferSize i32)
+  (local $buffer i32)
   (local $6 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 8
@@ -34166,29 +34166,29 @@
   global.get $~lib/memory/__stack_pointer
   i64.const 0
   i64.store $0
-  local.get $0
+  local.get $this
   i32.eqz
   if
    global.get $~lib/memory/__stack_pointer
    i32.const 16
    i32.const 31
    call $~lib/rt/itcms/__new
-   local.tee $0
+   local.tee $this
    i32.store $0
   end
-  local.get $0
+  local.get $this
   i32.const 0
   call $~lib/array/Array<std/array/Proxy<i32>>#set:buffer
-  local.get $0
+  local.get $this
   i32.const 0
   call $~lib/array/Array<std/array/Proxy<i32>>#set:dataStart
-  local.get $0
+  local.get $this
   i32.const 0
   call $~lib/array/Array<std/array/Proxy<i32>>#set:byteLength
-  local.get $0
+  local.get $this
   i32.const 0
   call $~lib/array/Array<std/array/Proxy<i32>>#set:length_
-  local.get $1
+  local.get $length
   i32.const 1073741820
   i32.const 2
   i32.shr_u
@@ -34201,40 +34201,40 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $1
-  local.tee $2
+  local.get $length
+  local.tee $var$2
   i32.const 8
-  local.tee $3
-  local.get $2
-  local.get $3
+  local.tee $var$3
+  local.get $var$2
+  local.get $var$3
   i32.gt_u
   select
   i32.const 2
   i32.shl
-  local.set $4
+  local.set $bufferSize
   global.get $~lib/memory/__stack_pointer
-  local.get $4
+  local.get $bufferSize
   i32.const 0
   call $~lib/rt/itcms/__new
-  local.tee $5
+  local.tee $buffer
   i32.store $0 offset=4
   i32.const 2
   global.get $~lib/shared/runtime/Runtime.Incremental
   i32.ne
   drop
-  local.get $0
-  local.get $5
+  local.get $this
+  local.get $buffer
   call $~lib/array/Array<std/array/Proxy<i32>>#set:buffer
-  local.get $0
-  local.get $5
+  local.get $this
+  local.get $buffer
   call $~lib/array/Array<std/array/Proxy<i32>>#set:dataStart
-  local.get $0
-  local.get $4
+  local.get $this
+  local.get $bufferSize
   call $~lib/array/Array<std/array/Proxy<i32>>#set:byteLength
-  local.get $0
-  local.get $1
+  local.get $this
+  local.get $length
   call $~lib/array/Array<std/array/Proxy<i32>>#set:length_
-  local.get $0
+  local.get $this
   local.set $6
   global.get $~lib/memory/__stack_pointer
   i32.const 8
@@ -34242,7 +34242,7 @@
   global.set $~lib/memory/__stack_pointer
   local.get $6
  )
- (func $std/array/Proxy<i32>#constructor (param $0 i32) (param $1 i32) (result i32)
+ (func $std/array/Proxy<i32>#constructor (param $this i32) (param $x i32) (result i32)
   (local $2 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -34252,20 +34252,20 @@
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   i32.store $0
-  local.get $0
+  local.get $this
   i32.eqz
   if
    global.get $~lib/memory/__stack_pointer
    i32.const 4
    i32.const 30
    call $~lib/rt/itcms/__new
-   local.tee $0
+   local.tee $this
    i32.store $0
   end
-  local.get $0
-  local.get $1
+  local.get $this
+  local.get $x
   call $std/array/Proxy<i32>#set:x
-  local.get $0
+  local.get $this
   local.set $2
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -34273,8 +34273,8 @@
   global.set $~lib/memory/__stack_pointer
   local.get $2
  )
- (func $~lib/array/Array<std/array/Proxy<i32>>#__get (param $0 i32) (param $1 i32) (result i32)
-  (local $2 i32)
+ (func $~lib/array/Array<std/array/Proxy<i32>>#__get (param $this i32) (param $index i32) (result i32)
+  (local $value i32)
   (local $3 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -34284,8 +34284,8 @@
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   i32.store $0
-  local.get $1
-  local.get $0
+  local.get $index
+  local.get $this
   i32.load $0 offset=12
   i32.ge_u
   if
@@ -34297,21 +34297,21 @@
    unreachable
   end
   global.get $~lib/memory/__stack_pointer
-  local.get $0
+  local.get $this
   i32.load $0 offset=4
-  local.get $1
+  local.get $index
   i32.const 2
   i32.shl
   i32.add
   i32.load $0
-  local.tee $2
+  local.tee $value
   i32.store $0
   i32.const 1
   drop
   i32.const 0
   i32.eqz
   drop
-  local.get $2
+  local.get $value
   i32.eqz
   if
    i32.const 5392
@@ -34321,7 +34321,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $2
+  local.get $value
   local.set $3
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -34329,8 +34329,8 @@
   global.set $~lib/memory/__stack_pointer
   local.get $3
  )
- (func $~lib/array/Array<~lib/string/String|null>#__get (param $0 i32) (param $1 i32) (result i32)
-  (local $2 i32)
+ (func $~lib/array/Array<~lib/string/String|null>#__get (param $this i32) (param $index i32) (result i32)
+  (local $value i32)
   (local $3 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -34340,8 +34340,8 @@
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   i32.store $0
-  local.get $1
-  local.get $0
+  local.get $index
+  local.get $this
   i32.load $0 offset=12
   i32.ge_u
   if
@@ -34353,21 +34353,21 @@
    unreachable
   end
   global.get $~lib/memory/__stack_pointer
-  local.get $0
+  local.get $this
   i32.load $0 offset=4
-  local.get $1
+  local.get $index
   i32.const 2
   i32.shl
   i32.add
   i32.load $0
-  local.tee $2
+  local.tee $value
   i32.store $0
   i32.const 1
   drop
   i32.const 1
   i32.eqz
   drop
-  local.get $2
+  local.get $value
   local.set $3
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -34375,11 +34375,11 @@
   global.set $~lib/memory/__stack_pointer
   local.get $3
  )
- (func $~lib/array/Array<~lib/string/String>#constructor (param $0 i32) (param $1 i32) (result i32)
-  (local $2 i32)
-  (local $3 i32)
-  (local $4 i32)
-  (local $5 i32)
+ (func $~lib/array/Array<~lib/string/String>#constructor (param $this i32) (param $length i32) (result i32)
+  (local $var$2 i32)
+  (local $var$3 i32)
+  (local $bufferSize i32)
+  (local $buffer i32)
   (local $6 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 8
@@ -34389,29 +34389,29 @@
   global.get $~lib/memory/__stack_pointer
   i64.const 0
   i64.store $0
-  local.get $0
+  local.get $this
   i32.eqz
   if
    global.get $~lib/memory/__stack_pointer
    i32.const 16
    i32.const 15
    call $~lib/rt/itcms/__new
-   local.tee $0
+   local.tee $this
    i32.store $0
   end
-  local.get $0
+  local.get $this
   i32.const 0
   call $~lib/array/Array<~lib/string/String>#set:buffer
-  local.get $0
+  local.get $this
   i32.const 0
   call $~lib/array/Array<~lib/string/String>#set:dataStart
-  local.get $0
+  local.get $this
   i32.const 0
   call $~lib/array/Array<~lib/string/String>#set:byteLength
-  local.get $0
+  local.get $this
   i32.const 0
   call $~lib/array/Array<~lib/string/String>#set:length_
-  local.get $1
+  local.get $length
   i32.const 1073741820
   i32.const 2
   i32.shr_u
@@ -34424,40 +34424,40 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $1
-  local.tee $2
+  local.get $length
+  local.tee $var$2
   i32.const 8
-  local.tee $3
-  local.get $2
-  local.get $3
+  local.tee $var$3
+  local.get $var$2
+  local.get $var$3
   i32.gt_u
   select
   i32.const 2
   i32.shl
-  local.set $4
+  local.set $bufferSize
   global.get $~lib/memory/__stack_pointer
-  local.get $4
+  local.get $bufferSize
   i32.const 0
   call $~lib/rt/itcms/__new
-  local.tee $5
+  local.tee $buffer
   i32.store $0 offset=4
   i32.const 2
   global.get $~lib/shared/runtime/Runtime.Incremental
   i32.ne
   drop
-  local.get $0
-  local.get $5
+  local.get $this
+  local.get $buffer
   call $~lib/array/Array<~lib/string/String>#set:buffer
-  local.get $0
-  local.get $5
+  local.get $this
+  local.get $buffer
   call $~lib/array/Array<~lib/string/String>#set:dataStart
-  local.get $0
-  local.get $4
+  local.get $this
+  local.get $bufferSize
   call $~lib/array/Array<~lib/string/String>#set:byteLength
-  local.get $0
-  local.get $1
+  local.get $this
+  local.get $length
   call $~lib/array/Array<~lib/string/String>#set:length_
-  local.get $0
+  local.get $this
   local.set $6
   global.get $~lib/memory/__stack_pointer
   i32.const 8
@@ -34465,8 +34465,8 @@
   global.set $~lib/memory/__stack_pointer
   local.get $6
  )
- (func $~lib/string/String#charAt (param $0 i32) (param $1 i32) (result i32)
-  (local $2 i32)
+ (func $~lib/string/String#charAt (param $this i32) (param $pos i32) (result i32)
+  (local $out i32)
   (local $3 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -34476,8 +34476,8 @@
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   i32.store $0
-  local.get $1
-  local.get $0
+  local.get $pos
+  local.get $this
   call $~lib/string/String#get:length
   i32.ge_u
   if
@@ -34494,17 +34494,17 @@
   i32.const 2
   i32.const 1
   call $~lib/rt/itcms/__new
-  local.tee $2
+  local.tee $out
   i32.store $0
-  local.get $2
-  local.get $0
-  local.get $1
+  local.get $out
+  local.get $this
+  local.get $pos
   i32.const 1
   i32.shl
   i32.add
   i32.load16_u $0
   i32.store16 $0
-  local.get $2
+  local.get $out
   local.set $3
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -34512,11 +34512,11 @@
   global.set $~lib/memory/__stack_pointer
   local.get $3
  )
- (func $~lib/string/String#concat (param $0 i32) (param $1 i32) (result i32)
-  (local $2 i32)
-  (local $3 i32)
-  (local $4 i32)
-  (local $5 i32)
+ (func $~lib/string/String#concat (param $this i32) (param $other i32) (result i32)
+  (local $thisSize i32)
+  (local $otherSize i32)
+  (local $outSize i32)
+  (local $out i32)
   (local $6 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -34526,21 +34526,21 @@
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   i32.store $0
-  local.get $0
+  local.get $this
   call $~lib/string/String#get:length
   i32.const 1
   i32.shl
-  local.set $2
-  local.get $1
+  local.set $thisSize
+  local.get $other
   call $~lib/string/String#get:length
   i32.const 1
   i32.shl
-  local.set $3
-  local.get $2
-  local.get $3
+  local.set $otherSize
+  local.get $thisSize
+  local.get $otherSize
   i32.add
-  local.set $4
-  local.get $4
+  local.set $outSize
+  local.get $outSize
   i32.const 0
   i32.eq
   if
@@ -34554,22 +34554,22 @@
    return
   end
   global.get $~lib/memory/__stack_pointer
-  local.get $4
+  local.get $outSize
   i32.const 1
   call $~lib/rt/itcms/__new
-  local.tee $5
+  local.tee $out
   i32.store $0
-  local.get $5
-  local.get $0
-  local.get $2
+  local.get $out
+  local.get $this
+  local.get $thisSize
   memory.copy $0 $0
-  local.get $5
-  local.get $2
+  local.get $out
+  local.get $thisSize
   i32.add
-  local.get $1
-  local.get $3
+  local.get $other
+  local.get $otherSize
   memory.copy $0 $0
-  local.get $5
+  local.get $out
   local.set $6
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -34577,8 +34577,8 @@
   global.set $~lib/memory/__stack_pointer
   local.get $6
  )
- (func $~lib/array/Array<~lib/string/String>#__get (param $0 i32) (param $1 i32) (result i32)
-  (local $2 i32)
+ (func $~lib/array/Array<~lib/string/String>#__get (param $this i32) (param $index i32) (result i32)
+  (local $value i32)
   (local $3 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -34588,8 +34588,8 @@
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   i32.store $0
-  local.get $1
-  local.get $0
+  local.get $index
+  local.get $this
   i32.load $0 offset=12
   i32.ge_u
   if
@@ -34601,21 +34601,21 @@
    unreachable
   end
   global.get $~lib/memory/__stack_pointer
-  local.get $0
+  local.get $this
   i32.load $0 offset=4
-  local.get $1
+  local.get $index
   i32.const 2
   i32.shl
   i32.add
   i32.load $0
-  local.tee $2
+  local.tee $value
   i32.store $0
   i32.const 1
   drop
   i32.const 0
   i32.eqz
   drop
-  local.get $2
+  local.get $value
   i32.eqz
   if
    i32.const 5392
@@ -34625,7 +34625,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $2
+  local.get $value
   local.set $3
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -34633,16 +34633,16 @@
   global.set $~lib/memory/__stack_pointer
   local.get $3
  )
- (func $~lib/string/String#substring (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
-  (local $3 i32)
-  (local $4 i32)
-  (local $5 i32)
-  (local $6 i32)
-  (local $7 i32)
-  (local $8 i32)
-  (local $9 i32)
-  (local $10 i32)
-  (local $11 i32)
+ (func $~lib/string/String#substring (param $this i32) (param $start i32) (param $end i32) (result i32)
+  (local $len i32)
+  (local $var$4 i32)
+  (local $var$5 i32)
+  (local $finalStart i32)
+  (local $finalEnd i32)
+  (local $fromPos i32)
+  (local $toPos i32)
+  (local $size i32)
+  (local $out i32)
   (local $12 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -34652,68 +34652,68 @@
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   i32.store $0
-  local.get $0
+  local.get $this
   call $~lib/string/String#get:length
-  local.set $3
-  local.get $1
-  local.tee $4
+  local.set $len
+  local.get $start
+  local.tee $var$4
   i32.const 0
-  local.tee $5
-  local.get $4
-  local.get $5
+  local.tee $var$5
+  local.get $var$4
+  local.get $var$5
   i32.gt_s
   select
-  local.tee $5
-  local.get $3
-  local.tee $4
-  local.get $5
-  local.get $4
+  local.tee $var$5
+  local.get $len
+  local.tee $var$4
+  local.get $var$5
+  local.get $var$4
   i32.lt_s
   select
-  local.set $6
-  local.get $2
-  local.tee $4
+  local.set $finalStart
+  local.get $end
+  local.tee $var$4
   i32.const 0
-  local.tee $5
-  local.get $4
-  local.get $5
+  local.tee $var$5
+  local.get $var$4
+  local.get $var$5
   i32.gt_s
   select
-  local.tee $5
-  local.get $3
-  local.tee $4
-  local.get $5
-  local.get $4
+  local.tee $var$5
+  local.get $len
+  local.tee $var$4
+  local.get $var$5
+  local.get $var$4
   i32.lt_s
   select
-  local.set $7
-  local.get $6
-  local.tee $4
-  local.get $7
-  local.tee $5
-  local.get $4
-  local.get $5
+  local.set $finalEnd
+  local.get $finalStart
+  local.tee $var$4
+  local.get $finalEnd
+  local.tee $var$5
+  local.get $var$4
+  local.get $var$5
   i32.lt_s
   select
   i32.const 1
   i32.shl
-  local.set $8
-  local.get $6
-  local.tee $5
-  local.get $7
-  local.tee $4
-  local.get $5
-  local.get $4
+  local.set $fromPos
+  local.get $finalStart
+  local.tee $var$5
+  local.get $finalEnd
+  local.tee $var$4
+  local.get $var$5
+  local.get $var$4
   i32.gt_s
   select
   i32.const 1
   i32.shl
-  local.set $9
-  local.get $9
-  local.get $8
+  local.set $toPos
+  local.get $toPos
+  local.get $fromPos
   i32.sub
-  local.set $10
-  local.get $10
+  local.set $size
+  local.get $size
   i32.eqz
   if
    i32.const 10480
@@ -34725,11 +34725,11 @@
    local.get $12
    return
   end
-  local.get $8
+  local.get $fromPos
   i32.eqz
   if (result i32)
-   local.get $9
-   local.get $3
+   local.get $toPos
+   local.get $len
    i32.const 1
    i32.shl
    i32.eq
@@ -34737,7 +34737,7 @@
    i32.const 0
   end
   if
-   local.get $0
+   local.get $this
    local.set $12
    global.get $~lib/memory/__stack_pointer
    i32.const 4
@@ -34747,18 +34747,18 @@
    return
   end
   global.get $~lib/memory/__stack_pointer
-  local.get $10
+  local.get $size
   i32.const 1
   call $~lib/rt/itcms/__new
-  local.tee $11
+  local.tee $out
   i32.store $0
-  local.get $11
-  local.get $0
-  local.get $8
+  local.get $out
+  local.get $this
+  local.get $fromPos
   i32.add
-  local.get $10
+  local.get $size
   memory.copy $0 $0
-  local.get $11
+  local.get $out
   local.set $12
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -34766,17 +34766,17 @@
   global.set $~lib/memory/__stack_pointer
   local.get $12
  )
- (func $~lib/util/string/joinBooleanArray (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
-  (local $3 i32)
-  (local $4 i32)
-  (local $5 i32)
-  (local $6 i32)
-  (local $7 i32)
-  (local $8 i32)
-  (local $9 i32)
-  (local $10 i32)
-  (local $11 i32)
-  (local $12 i32)
+ (func $~lib/util/string/joinBooleanArray (param $dataStart i32) (param $length i32) (param $separator i32) (result i32)
+  (local $lastIndex i32)
+  (local $sepLen i32)
+  (local $valueLen i32)
+  (local $estLen i32)
+  (local $result i32)
+  (local $offset i32)
+  (local $value i32)
+  (local $var$10 i32)
+  (local $var$11 i32)
+  (local $var$12 i32)
   (local $13 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -34786,11 +34786,11 @@
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   i32.store $0
-  local.get $1
+  local.get $length
   i32.const 1
   i32.sub
-  local.set $3
-  local.get $3
+  local.set $lastIndex
+  local.get $lastIndex
   i32.const 0
   i32.lt_s
   if
@@ -34803,12 +34803,12 @@
    local.get $13
    return
   end
-  local.get $3
+  local.get $lastIndex
   i32.eqz
   if
    i32.const 10704
    i32.const 10736
-   local.get $0
+   local.get $dataStart
    i32.load8_u $0
    select
    local.set $13
@@ -34819,123 +34819,123 @@
    local.get $13
    return
   end
-  local.get $2
+  local.get $separator
   call $~lib/string/String#get:length
-  local.set $4
+  local.set $sepLen
   i32.const 5
-  local.set $5
-  local.get $5
-  local.get $4
+  local.set $valueLen
+  local.get $valueLen
+  local.get $sepLen
   i32.add
-  local.get $3
+  local.get $lastIndex
   i32.mul
-  local.get $5
+  local.get $valueLen
   i32.add
-  local.set $6
+  local.set $estLen
   global.get $~lib/memory/__stack_pointer
-  local.get $6
+  local.get $estLen
   i32.const 1
   i32.shl
   i32.const 1
   call $~lib/rt/itcms/__new
-  local.tee $7
+  local.tee $result
   i32.store $0
   i32.const 0
-  local.set $8
+  local.set $offset
   i32.const 0
-  local.set $10
+  local.set $var$10
   loop $for-loop|1
-   local.get $10
-   local.get $3
+   local.get $var$10
+   local.get $lastIndex
    i32.lt_s
-   local.set $12
-   local.get $12
+   local.set $var$12
+   local.get $var$12
    if
-    local.get $0
-    local.get $10
+    local.get $dataStart
+    local.get $var$10
     i32.add
     i32.load8_u $0
-    local.set $9
+    local.set $value
     i32.const 4
-    local.get $9
+    local.get $value
     i32.eqz
     i32.add
-    local.set $5
-    local.get $7
-    local.get $8
+    local.set $valueLen
+    local.get $result
+    local.get $offset
     i32.const 1
     i32.shl
     i32.add
     i32.const 10704
     i32.const 10736
-    local.get $9
+    local.get $value
     select
-    local.get $5
+    local.get $valueLen
     i32.const 1
     i32.shl
     memory.copy $0 $0
-    local.get $8
-    local.get $5
+    local.get $offset
+    local.get $valueLen
     i32.add
-    local.set $8
-    local.get $4
+    local.set $offset
+    local.get $sepLen
     if
-     local.get $7
-     local.get $8
+     local.get $result
+     local.get $offset
      i32.const 1
      i32.shl
      i32.add
-     local.get $2
-     local.get $4
+     local.get $separator
+     local.get $sepLen
      i32.const 1
      i32.shl
      memory.copy $0 $0
-     local.get $8
-     local.get $4
+     local.get $offset
+     local.get $sepLen
      i32.add
-     local.set $8
+     local.set $offset
     end
-    local.get $10
+    local.get $var$10
     i32.const 1
     i32.add
-    local.set $10
+    local.set $var$10
     br $for-loop|1
    end
   end
-  local.get $0
-  local.get $3
+  local.get $dataStart
+  local.get $lastIndex
   i32.add
   i32.load8_u $0
-  local.set $9
+  local.set $value
   i32.const 4
-  local.get $9
+  local.get $value
   i32.eqz
   i32.add
-  local.set $5
-  local.get $7
-  local.get $8
+  local.set $valueLen
+  local.get $result
+  local.get $offset
   i32.const 1
   i32.shl
   i32.add
   i32.const 10704
   i32.const 10736
-  local.get $9
+  local.get $value
   select
-  local.get $5
+  local.get $valueLen
   i32.const 1
   i32.shl
   memory.copy $0 $0
-  local.get $8
-  local.get $5
+  local.get $offset
+  local.get $valueLen
   i32.add
-  local.set $8
-  local.get $6
-  local.get $8
+  local.set $offset
+  local.get $estLen
+  local.get $offset
   i32.gt_s
   if
-   local.get $7
+   local.get $result
    i32.const 0
-   local.get $8
+   local.get $offset
    call $~lib/string/String#substring
    local.set $13
    global.get $~lib/memory/__stack_pointer
@@ -34945,7 +34945,7 @@
    local.get $13
    return
   end
-  local.get $7
+  local.get $result
   local.set $13
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -34953,15 +34953,15 @@
   global.set $~lib/memory/__stack_pointer
   local.get $13
  )
- (func $~lib/util/string/joinIntegerArray<i32> (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
-  (local $3 i32)
-  (local $4 i32)
-  (local $5 i32)
-  (local $6 i32)
-  (local $7 i32)
-  (local $8 i32)
-  (local $9 i32)
-  (local $10 i32)
+ (func $~lib/util/string/joinIntegerArray<i32> (param $dataStart i32) (param $length i32) (param $separator i32) (result i32)
+  (local $lastIndex i32)
+  (local $var$4 i32)
+  (local $sepLen i32)
+  (local $estLen i32)
+  (local $result i32)
+  (local $offset i32)
+  (local $value i32)
+  (local $var$10 i32)
   (local $11 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -34971,11 +34971,11 @@
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   i32.store $0
-  local.get $1
+  local.get $length
   i32.const 1
   i32.sub
-  local.set $3
-  local.get $3
+  local.set $lastIndex
+  local.get $lastIndex
   i32.const 0
   i32.lt_s
   if
@@ -34988,19 +34988,19 @@
    local.get $11
    return
   end
-  local.get $3
+  local.get $lastIndex
   i32.eqz
   if
-   local.get $0
+   local.get $dataStart
    i32.load $0
-   local.set $4
+   local.set $var$4
    i32.const 1
    drop
    i32.const 4
    i32.const 4
    i32.le_u
    drop
-   local.get $4
+   local.get $var$4
    i32.const 10
    call $~lib/util/number/itoa32
    local.set $11
@@ -35011,101 +35011,101 @@
    local.get $11
    return
   end
-  local.get $2
+  local.get $separator
   call $~lib/string/String#get:length
-  local.set $5
+  local.set $sepLen
   i32.const 11
-  local.get $5
+  local.get $sepLen
   i32.add
-  local.get $3
+  local.get $lastIndex
   i32.mul
   i32.const 11
   i32.add
-  local.set $6
+  local.set $estLen
   global.get $~lib/memory/__stack_pointer
-  local.get $6
+  local.get $estLen
   i32.const 1
   i32.shl
   i32.const 1
   call $~lib/rt/itcms/__new
-  local.tee $7
+  local.tee $result
   i32.store $0
   i32.const 0
-  local.set $8
+  local.set $offset
   i32.const 0
-  local.set $4
+  local.set $var$4
   loop $for-loop|0
-   local.get $4
-   local.get $3
+   local.get $var$4
+   local.get $lastIndex
    i32.lt_s
-   local.set $10
-   local.get $10
+   local.set $var$10
+   local.get $var$10
    if
-    local.get $0
-    local.get $4
+    local.get $dataStart
+    local.get $var$4
     i32.const 2
     i32.shl
     i32.add
     i32.load $0
-    local.set $9
-    local.get $8
-    local.get $7
-    local.get $8
+    local.set $value
+    local.get $offset
+    local.get $result
+    local.get $offset
     i32.const 1
     i32.shl
     i32.add
-    local.get $9
+    local.get $value
     call $~lib/util/number/itoa_buffered<i32>
     i32.add
-    local.set $8
-    local.get $5
+    local.set $offset
+    local.get $sepLen
     if
-     local.get $7
-     local.get $8
+     local.get $result
+     local.get $offset
      i32.const 1
      i32.shl
      i32.add
-     local.get $2
-     local.get $5
+     local.get $separator
+     local.get $sepLen
      i32.const 1
      i32.shl
      memory.copy $0 $0
-     local.get $8
-     local.get $5
+     local.get $offset
+     local.get $sepLen
      i32.add
-     local.set $8
+     local.set $offset
     end
-    local.get $4
+    local.get $var$4
     i32.const 1
     i32.add
-    local.set $4
+    local.set $var$4
     br $for-loop|0
    end
   end
-  local.get $0
-  local.get $3
+  local.get $dataStart
+  local.get $lastIndex
   i32.const 2
   i32.shl
   i32.add
   i32.load $0
-  local.set $9
-  local.get $8
-  local.get $7
-  local.get $8
+  local.set $value
+  local.get $offset
+  local.get $result
+  local.get $offset
   i32.const 1
   i32.shl
   i32.add
-  local.get $9
+  local.get $value
   call $~lib/util/number/itoa_buffered<i32>
   i32.add
-  local.set $8
-  local.get $6
-  local.get $8
+  local.set $offset
+  local.get $estLen
+  local.get $offset
   i32.gt_s
   if
-   local.get $7
+   local.get $result
    i32.const 0
-   local.get $8
+   local.get $offset
    call $~lib/string/String#substring
    local.set $11
    global.get $~lib/memory/__stack_pointer
@@ -35115,7 +35115,7 @@
    local.get $11
    return
   end
-  local.get $7
+  local.get $result
   local.set $11
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -35123,12 +35123,12 @@
   global.set $~lib/memory/__stack_pointer
   local.get $11
  )
- (func $~lib/util/number/utoa32 (param $0 i32) (param $1 i32) (result i32)
-  (local $2 i32)
-  (local $3 i32)
-  (local $4 i32)
-  (local $5 i32)
-  (local $6 i32)
+ (func $~lib/util/number/utoa32 (param $value i32) (param $radix i32) (result i32)
+  (local $out i32)
+  (local $var$3 i32)
+  (local $var$4 i32)
+  (local $var$5 i32)
+  (local $var$6 i32)
   (local $7 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -35138,13 +35138,13 @@
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   i32.store $0
-  local.get $1
+  local.get $radix
   i32.const 2
   i32.lt_s
   if (result i32)
    i32.const 1
   else
-   local.get $1
+   local.get $radix
    i32.const 36
    i32.gt_s
   end
@@ -35156,7 +35156,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $0
+  local.get $value
   i32.eqz
   if
    i32.const 6624
@@ -35168,95 +35168,95 @@
    local.get $7
    return
   end
-  local.get $1
+  local.get $radix
   i32.const 10
   i32.eq
   if
-   local.get $0
+   local.get $value
    call $~lib/util/number/decimalCount32
-   local.set $3
+   local.set $var$3
    global.get $~lib/memory/__stack_pointer
-   local.get $3
+   local.get $var$3
    i32.const 1
    i32.shl
    i32.const 1
    call $~lib/rt/itcms/__new
-   local.tee $2
+   local.tee $out
    i32.store $0
-   local.get $2
-   local.set $6
-   local.get $0
-   local.set $5
-   local.get $3
-   local.set $4
+   local.get $out
+   local.set $var$6
+   local.get $value
+   local.set $var$5
+   local.get $var$3
+   local.set $var$4
    i32.const 0
    i32.const 1
    i32.ge_s
    drop
-   local.get $6
-   local.get $5
-   local.get $4
+   local.get $var$6
+   local.get $var$5
+   local.get $var$4
    call $~lib/util/number/utoa32_dec_lut
   else
-   local.get $1
+   local.get $radix
    i32.const 16
    i32.eq
    if
     i32.const 31
-    local.get $0
+    local.get $value
     i32.clz
     i32.sub
     i32.const 2
     i32.shr_s
     i32.const 1
     i32.add
-    local.set $3
+    local.set $var$3
     global.get $~lib/memory/__stack_pointer
-    local.get $3
+    local.get $var$3
     i32.const 1
     i32.shl
     i32.const 1
     call $~lib/rt/itcms/__new
-    local.tee $2
+    local.tee $out
     i32.store $0
-    local.get $2
-    local.set $6
-    local.get $0
-    local.set $5
-    local.get $3
-    local.set $4
+    local.get $out
+    local.set $var$6
+    local.get $value
+    local.set $var$5
+    local.get $var$3
+    local.set $var$4
     i32.const 0
     i32.const 1
     i32.ge_s
     drop
-    local.get $6
-    local.get $5
+    local.get $var$6
+    local.get $var$5
     i64.extend_i32_u
-    local.get $4
+    local.get $var$4
     call $~lib/util/number/utoa_hex_lut
    else
-    local.get $0
+    local.get $value
     i64.extend_i32_u
-    local.get $1
+    local.get $radix
     call $~lib/util/number/ulog_base
-    local.set $3
+    local.set $var$3
     global.get $~lib/memory/__stack_pointer
-    local.get $3
+    local.get $var$3
     i32.const 1
     i32.shl
     i32.const 1
     call $~lib/rt/itcms/__new
-    local.tee $2
+    local.tee $out
     i32.store $0
-    local.get $2
-    local.get $0
+    local.get $out
+    local.get $value
     i64.extend_i32_u
-    local.get $3
-    local.get $1
+    local.get $var$3
+    local.get $radix
     call $~lib/util/number/utoa64_any_core
    end
   end
-  local.get $2
+  local.get $out
   local.set $7
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -35264,15 +35264,15 @@
   global.set $~lib/memory/__stack_pointer
   local.get $7
  )
- (func $~lib/util/string/joinIntegerArray<u32> (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
-  (local $3 i32)
-  (local $4 i32)
-  (local $5 i32)
-  (local $6 i32)
-  (local $7 i32)
-  (local $8 i32)
-  (local $9 i32)
-  (local $10 i32)
+ (func $~lib/util/string/joinIntegerArray<u32> (param $dataStart i32) (param $length i32) (param $separator i32) (result i32)
+  (local $lastIndex i32)
+  (local $var$4 i32)
+  (local $sepLen i32)
+  (local $estLen i32)
+  (local $result i32)
+  (local $offset i32)
+  (local $value i32)
+  (local $var$10 i32)
   (local $11 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -35282,11 +35282,11 @@
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   i32.store $0
-  local.get $1
+  local.get $length
   i32.const 1
   i32.sub
-  local.set $3
-  local.get $3
+  local.set $lastIndex
+  local.get $lastIndex
   i32.const 0
   i32.lt_s
   if
@@ -35299,19 +35299,19 @@
    local.get $11
    return
   end
-  local.get $3
+  local.get $lastIndex
   i32.eqz
   if
-   local.get $0
+   local.get $dataStart
    i32.load $0
-   local.set $4
+   local.set $var$4
    i32.const 0
    drop
    i32.const 4
    i32.const 4
    i32.le_u
    drop
-   local.get $4
+   local.get $var$4
    i32.const 10
    call $~lib/util/number/utoa32
    local.set $11
@@ -35322,101 +35322,101 @@
    local.get $11
    return
   end
-  local.get $2
+  local.get $separator
   call $~lib/string/String#get:length
-  local.set $5
+  local.set $sepLen
   i32.const 10
-  local.get $5
+  local.get $sepLen
   i32.add
-  local.get $3
+  local.get $lastIndex
   i32.mul
   i32.const 10
   i32.add
-  local.set $6
+  local.set $estLen
   global.get $~lib/memory/__stack_pointer
-  local.get $6
+  local.get $estLen
   i32.const 1
   i32.shl
   i32.const 1
   call $~lib/rt/itcms/__new
-  local.tee $7
+  local.tee $result
   i32.store $0
   i32.const 0
-  local.set $8
+  local.set $offset
   i32.const 0
-  local.set $4
+  local.set $var$4
   loop $for-loop|0
-   local.get $4
-   local.get $3
+   local.get $var$4
+   local.get $lastIndex
    i32.lt_s
-   local.set $10
-   local.get $10
+   local.set $var$10
+   local.get $var$10
    if
-    local.get $0
-    local.get $4
+    local.get $dataStart
+    local.get $var$4
     i32.const 2
     i32.shl
     i32.add
     i32.load $0
-    local.set $9
-    local.get $8
-    local.get $7
-    local.get $8
+    local.set $value
+    local.get $offset
+    local.get $result
+    local.get $offset
     i32.const 1
     i32.shl
     i32.add
-    local.get $9
+    local.get $value
     call $~lib/util/number/itoa_buffered<u32>
     i32.add
-    local.set $8
-    local.get $5
+    local.set $offset
+    local.get $sepLen
     if
-     local.get $7
-     local.get $8
+     local.get $result
+     local.get $offset
      i32.const 1
      i32.shl
      i32.add
-     local.get $2
-     local.get $5
+     local.get $separator
+     local.get $sepLen
      i32.const 1
      i32.shl
      memory.copy $0 $0
-     local.get $8
-     local.get $5
+     local.get $offset
+     local.get $sepLen
      i32.add
-     local.set $8
+     local.set $offset
     end
-    local.get $4
+    local.get $var$4
     i32.const 1
     i32.add
-    local.set $4
+    local.set $var$4
     br $for-loop|0
    end
   end
-  local.get $0
-  local.get $3
+  local.get $dataStart
+  local.get $lastIndex
   i32.const 2
   i32.shl
   i32.add
   i32.load $0
-  local.set $9
-  local.get $8
-  local.get $7
-  local.get $8
+  local.set $value
+  local.get $offset
+  local.get $result
+  local.get $offset
   i32.const 1
   i32.shl
   i32.add
-  local.get $9
+  local.get $value
   call $~lib/util/number/itoa_buffered<u32>
   i32.add
-  local.set $8
-  local.get $6
-  local.get $8
+  local.set $offset
+  local.get $estLen
+  local.get $offset
   i32.gt_s
   if
-   local.get $7
+   local.get $result
    i32.const 0
-   local.get $8
+   local.get $offset
    call $~lib/string/String#substring
    local.set $11
    global.get $~lib/memory/__stack_pointer
@@ -35426,7 +35426,7 @@
    local.get $11
    return
   end
-  local.get $7
+  local.get $result
   local.set $11
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -35434,9 +35434,9 @@
   global.set $~lib/memory/__stack_pointer
   local.get $11
  )
- (func $~lib/util/number/dtoa (param $0 f64) (result i32)
-  (local $1 i32)
-  (local $2 i32)
+ (func $~lib/util/number/dtoa (param $value f64) (result i32)
+  (local $size i32)
+  (local $result i32)
   (local $3 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -35446,7 +35446,7 @@
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   i32.store $0
-  local.get $0
+  local.get $value
   f64.const 0
   f64.eq
   if
@@ -35459,15 +35459,15 @@
    local.get $3
    return
   end
-  local.get $0
-  local.get $0
+  local.get $value
+  local.get $value
   f64.sub
   f64.const 0
   f64.eq
   i32.eqz
   if
-   local.get $0
-   local.get $0
+   local.get $value
+   local.get $value
    f64.ne
    if
     i32.const 11264
@@ -35481,7 +35481,7 @@
    end
    i32.const 11296
    i32.const 11344
-   local.get $0
+   local.get $value
    f64.const 0
    f64.lt
    select
@@ -35494,22 +35494,22 @@
    return
   end
   i32.const 11376
-  local.get $0
+  local.get $value
   call $~lib/util/number/dtoa_core
   i32.const 1
   i32.shl
-  local.set $1
+  local.set $size
   global.get $~lib/memory/__stack_pointer
-  local.get $1
+  local.get $size
   i32.const 1
   call $~lib/rt/itcms/__new
-  local.tee $2
+  local.tee $result
   i32.store $0
-  local.get $2
+  local.get $result
   i32.const 11376
-  local.get $1
+  local.get $size
   memory.copy $0 $0
-  local.get $2
+  local.get $result
   local.set $3
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -35517,15 +35517,15 @@
   global.set $~lib/memory/__stack_pointer
   local.get $3
  )
- (func $~lib/util/string/joinFloatArray<f64> (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
-  (local $3 i32)
-  (local $4 i32)
-  (local $5 i32)
-  (local $6 i32)
-  (local $7 i32)
-  (local $8 f64)
-  (local $9 i32)
-  (local $10 i32)
+ (func $~lib/util/string/joinFloatArray<f64> (param $dataStart i32) (param $length i32) (param $separator i32) (result i32)
+  (local $lastIndex i32)
+  (local $sepLen i32)
+  (local $estLen i32)
+  (local $result i32)
+  (local $offset i32)
+  (local $value f64)
+  (local $var$9 i32)
+  (local $var$10 i32)
   (local $11 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -35535,11 +35535,11 @@
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   i32.store $0
-  local.get $1
+  local.get $length
   i32.const 1
   i32.sub
-  local.set $3
-  local.get $3
+  local.set $lastIndex
+  local.get $lastIndex
   i32.const 0
   i32.lt_s
   if
@@ -35552,10 +35552,10 @@
    local.get $11
    return
   end
-  local.get $3
+  local.get $lastIndex
   i32.eqz
   if
-   local.get $0
+   local.get $dataStart
    f64.load $0
    call $~lib/util/number/dtoa
    local.set $11
@@ -35566,101 +35566,101 @@
    local.get $11
    return
   end
-  local.get $2
+  local.get $separator
   call $~lib/string/String#get:length
-  local.set $4
+  local.set $sepLen
   i32.const 28
-  local.get $4
+  local.get $sepLen
   i32.add
-  local.get $3
+  local.get $lastIndex
   i32.mul
   i32.const 28
   i32.add
-  local.set $5
+  local.set $estLen
   global.get $~lib/memory/__stack_pointer
-  local.get $5
+  local.get $estLen
   i32.const 1
   i32.shl
   i32.const 1
   call $~lib/rt/itcms/__new
-  local.tee $6
+  local.tee $result
   i32.store $0
   i32.const 0
-  local.set $7
+  local.set $offset
   i32.const 0
-  local.set $9
+  local.set $var$9
   loop $for-loop|0
-   local.get $9
-   local.get $3
+   local.get $var$9
+   local.get $lastIndex
    i32.lt_s
-   local.set $10
-   local.get $10
+   local.set $var$10
+   local.get $var$10
    if
-    local.get $0
-    local.get $9
+    local.get $dataStart
+    local.get $var$9
     i32.const 3
     i32.shl
     i32.add
     f64.load $0
-    local.set $8
-    local.get $7
-    local.get $6
-    local.get $7
+    local.set $value
+    local.get $offset
+    local.get $result
+    local.get $offset
     i32.const 1
     i32.shl
     i32.add
-    local.get $8
+    local.get $value
     call $~lib/util/number/dtoa_buffered
     i32.add
-    local.set $7
-    local.get $4
+    local.set $offset
+    local.get $sepLen
     if
-     local.get $6
-     local.get $7
+     local.get $result
+     local.get $offset
      i32.const 1
      i32.shl
      i32.add
-     local.get $2
-     local.get $4
+     local.get $separator
+     local.get $sepLen
      i32.const 1
      i32.shl
      memory.copy $0 $0
-     local.get $7
-     local.get $4
+     local.get $offset
+     local.get $sepLen
      i32.add
-     local.set $7
+     local.set $offset
     end
-    local.get $9
+    local.get $var$9
     i32.const 1
     i32.add
-    local.set $9
+    local.set $var$9
     br $for-loop|0
    end
   end
-  local.get $0
-  local.get $3
+  local.get $dataStart
+  local.get $lastIndex
   i32.const 3
   i32.shl
   i32.add
   f64.load $0
-  local.set $8
-  local.get $7
-  local.get $6
-  local.get $7
+  local.set $value
+  local.get $offset
+  local.get $result
+  local.get $offset
   i32.const 1
   i32.shl
   i32.add
-  local.get $8
+  local.get $value
   call $~lib/util/number/dtoa_buffered
   i32.add
-  local.set $7
-  local.get $5
-  local.get $7
+  local.set $offset
+  local.get $estLen
+  local.get $offset
   i32.gt_s
   if
-   local.get $6
+   local.get $result
    i32.const 0
-   local.get $7
+   local.get $offset
    call $~lib/string/String#substring
    local.set $11
    global.get $~lib/memory/__stack_pointer
@@ -35670,7 +35670,7 @@
    local.get $11
    return
   end
-  local.get $6
+  local.get $result
   local.set $11
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -35678,16 +35678,16 @@
   global.set $~lib/memory/__stack_pointer
   local.get $11
  )
- (func $~lib/util/string/joinStringArray (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
-  (local $3 i32)
-  (local $4 i32)
-  (local $5 i32)
-  (local $6 i32)
-  (local $7 i32)
-  (local $8 i32)
-  (local $9 i32)
-  (local $10 i32)
-  (local $11 i32)
+ (func $~lib/util/string/joinStringArray (param $dataStart i32) (param $length i32) (param $separator i32) (result i32)
+  (local $lastIndex i32)
+  (local $var$4 i32)
+  (local $estLen i32)
+  (local $value i32)
+  (local $var$7 i32)
+  (local $offset i32)
+  (local $sepLen i32)
+  (local $result i32)
+  (local $var$11 i32)
   (local $12 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 12
@@ -35700,11 +35700,11 @@
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   i32.store $0 offset=8
-  local.get $1
+  local.get $length
   i32.const 1
   i32.sub
-  local.set $3
-  local.get $3
+  local.set $lastIndex
+  local.get $lastIndex
   i32.const 0
   i32.lt_s
   if
@@ -35717,17 +35717,17 @@
    local.get $12
    return
   end
-  local.get $3
+  local.get $lastIndex
   i32.eqz
   if
    global.get $~lib/memory/__stack_pointer
-   local.get $0
+   local.get $dataStart
    i32.load $0
-   local.tee $4
+   local.tee $var$4
    i32.store $0
-   local.get $4
+   local.get $var$4
    if (result i32)
-    local.get $4
+    local.get $var$4
    else
     i32.const 10480
    end
@@ -35740,149 +35740,149 @@
    return
   end
   i32.const 0
-  local.set $5
+  local.set $estLen
   i32.const 0
-  local.set $4
+  local.set $var$4
   loop $for-loop|0
-   local.get $4
-   local.get $1
+   local.get $var$4
+   local.get $length
    i32.lt_s
-   local.set $7
-   local.get $7
+   local.set $var$7
+   local.get $var$7
    if
     global.get $~lib/memory/__stack_pointer
-    local.get $0
-    local.get $4
+    local.get $dataStart
+    local.get $var$4
     i32.const 2
     i32.shl
     i32.add
     i32.load $0
-    local.tee $6
+    local.tee $value
     i32.store $0 offset=4
-    local.get $6
+    local.get $value
     i32.const 0
     i32.ne
     if
-     local.get $5
-     local.get $6
+     local.get $estLen
+     local.get $value
      call $~lib/string/String#get:length
      i32.add
-     local.set $5
+     local.set $estLen
     end
-    local.get $4
+    local.get $var$4
     i32.const 1
     i32.add
-    local.set $4
+    local.set $var$4
     br $for-loop|0
    end
   end
   i32.const 0
-  local.set $8
-  local.get $2
+  local.set $offset
+  local.get $separator
   call $~lib/string/String#get:length
-  local.set $9
+  local.set $sepLen
   global.get $~lib/memory/__stack_pointer
-  local.get $5
-  local.get $9
-  local.get $3
+  local.get $estLen
+  local.get $sepLen
+  local.get $lastIndex
   i32.mul
   i32.add
   i32.const 1
   i32.shl
   i32.const 1
   call $~lib/rt/itcms/__new
-  local.tee $10
+  local.tee $result
   i32.store $0 offset=8
   i32.const 0
-  local.set $4
+  local.set $var$4
   loop $for-loop|1
-   local.get $4
-   local.get $3
+   local.get $var$4
+   local.get $lastIndex
    i32.lt_s
-   local.set $7
-   local.get $7
+   local.set $var$7
+   local.get $var$7
    if
     global.get $~lib/memory/__stack_pointer
-    local.get $0
-    local.get $4
+    local.get $dataStart
+    local.get $var$4
     i32.const 2
     i32.shl
     i32.add
     i32.load $0
-    local.tee $6
+    local.tee $value
     i32.store $0 offset=4
-    local.get $6
+    local.get $value
     i32.const 0
     i32.ne
     if
-     local.get $6
+     local.get $value
      call $~lib/string/String#get:length
-     local.set $11
-     local.get $10
-     local.get $8
+     local.set $var$11
+     local.get $result
+     local.get $offset
      i32.const 1
      i32.shl
      i32.add
-     local.get $6
-     local.get $11
+     local.get $value
+     local.get $var$11
      i32.const 1
      i32.shl
      memory.copy $0 $0
-     local.get $8
-     local.get $11
+     local.get $offset
+     local.get $var$11
      i32.add
-     local.set $8
+     local.set $offset
     end
-    local.get $9
+    local.get $sepLen
     if
-     local.get $10
-     local.get $8
+     local.get $result
+     local.get $offset
      i32.const 1
      i32.shl
      i32.add
-     local.get $2
-     local.get $9
+     local.get $separator
+     local.get $sepLen
      i32.const 1
      i32.shl
      memory.copy $0 $0
-     local.get $8
-     local.get $9
+     local.get $offset
+     local.get $sepLen
      i32.add
-     local.set $8
+     local.set $offset
     end
-    local.get $4
+    local.get $var$4
     i32.const 1
     i32.add
-    local.set $4
+    local.set $var$4
     br $for-loop|1
    end
   end
   global.get $~lib/memory/__stack_pointer
-  local.get $0
-  local.get $3
+  local.get $dataStart
+  local.get $lastIndex
   i32.const 2
   i32.shl
   i32.add
   i32.load $0
-  local.tee $6
+  local.tee $value
   i32.store $0 offset=4
-  local.get $6
+  local.get $value
   i32.const 0
   i32.ne
   if
-   local.get $10
-   local.get $8
+   local.get $result
+   local.get $offset
    i32.const 1
    i32.shl
    i32.add
-   local.get $6
-   local.get $6
+   local.get $value
+   local.get $value
    call $~lib/string/String#get:length
    i32.const 1
    i32.shl
    memory.copy $0 $0
   end
-  local.get $10
+  local.get $result
   local.set $12
   global.get $~lib/memory/__stack_pointer
   i32.const 12
@@ -35890,15 +35890,15 @@
   global.set $~lib/memory/__stack_pointer
   local.get $12
  )
- (func $~lib/util/string/joinIntegerArray<i8> (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
-  (local $3 i32)
-  (local $4 i32)
-  (local $5 i32)
-  (local $6 i32)
-  (local $7 i32)
-  (local $8 i32)
-  (local $9 i32)
-  (local $10 i32)
+ (func $~lib/util/string/joinIntegerArray<i8> (param $dataStart i32) (param $length i32) (param $separator i32) (result i32)
+  (local $lastIndex i32)
+  (local $var$4 i32)
+  (local $sepLen i32)
+  (local $estLen i32)
+  (local $result i32)
+  (local $offset i32)
+  (local $value i32)
+  (local $var$10 i32)
   (local $11 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -35908,11 +35908,11 @@
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   i32.store $0
-  local.get $1
+  local.get $length
   i32.const 1
   i32.sub
-  local.set $3
-  local.get $3
+  local.set $lastIndex
+  local.get $lastIndex
   i32.const 0
   i32.lt_s
   if
@@ -35925,19 +35925,19 @@
    local.get $11
    return
   end
-  local.get $3
+  local.get $lastIndex
   i32.eqz
   if
-   local.get $0
+   local.get $dataStart
    i32.load8_s $0
-   local.set $4
+   local.set $var$4
    i32.const 1
    drop
    i32.const 1
    i32.const 4
    i32.le_u
    drop
-   local.get $4
+   local.get $var$4
    i32.const 10
    call $~lib/util/number/itoa32
    local.set $11
@@ -35948,101 +35948,101 @@
    local.get $11
    return
   end
-  local.get $2
+  local.get $separator
   call $~lib/string/String#get:length
-  local.set $5
+  local.set $sepLen
   i32.const 11
-  local.get $5
+  local.get $sepLen
   i32.add
-  local.get $3
+  local.get $lastIndex
   i32.mul
   i32.const 11
   i32.add
-  local.set $6
+  local.set $estLen
   global.get $~lib/memory/__stack_pointer
-  local.get $6
+  local.get $estLen
   i32.const 1
   i32.shl
   i32.const 1
   call $~lib/rt/itcms/__new
-  local.tee $7
+  local.tee $result
   i32.store $0
   i32.const 0
-  local.set $8
+  local.set $offset
   i32.const 0
-  local.set $4
+  local.set $var$4
   loop $for-loop|0
-   local.get $4
-   local.get $3
+   local.get $var$4
+   local.get $lastIndex
    i32.lt_s
-   local.set $10
-   local.get $10
+   local.set $var$10
+   local.get $var$10
    if
-    local.get $0
-    local.get $4
+    local.get $dataStart
+    local.get $var$4
     i32.const 0
     i32.shl
     i32.add
     i32.load8_s $0
-    local.set $9
-    local.get $8
-    local.get $7
-    local.get $8
+    local.set $value
+    local.get $offset
+    local.get $result
+    local.get $offset
     i32.const 1
     i32.shl
     i32.add
-    local.get $9
+    local.get $value
     call $~lib/util/number/itoa_buffered<i8>
     i32.add
-    local.set $8
-    local.get $5
+    local.set $offset
+    local.get $sepLen
     if
-     local.get $7
-     local.get $8
+     local.get $result
+     local.get $offset
      i32.const 1
      i32.shl
      i32.add
-     local.get $2
-     local.get $5
+     local.get $separator
+     local.get $sepLen
      i32.const 1
      i32.shl
      memory.copy $0 $0
-     local.get $8
-     local.get $5
+     local.get $offset
+     local.get $sepLen
      i32.add
-     local.set $8
+     local.set $offset
     end
-    local.get $4
+    local.get $var$4
     i32.const 1
     i32.add
-    local.set $4
+    local.set $var$4
     br $for-loop|0
    end
   end
-  local.get $0
-  local.get $3
+  local.get $dataStart
+  local.get $lastIndex
   i32.const 0
   i32.shl
   i32.add
   i32.load8_s $0
-  local.set $9
-  local.get $8
-  local.get $7
-  local.get $8
+  local.set $value
+  local.get $offset
+  local.get $result
+  local.get $offset
   i32.const 1
   i32.shl
   i32.add
-  local.get $9
+  local.get $value
   call $~lib/util/number/itoa_buffered<i8>
   i32.add
-  local.set $8
-  local.get $6
-  local.get $8
+  local.set $offset
+  local.get $estLen
+  local.get $offset
   i32.gt_s
   if
-   local.get $7
+   local.get $result
    i32.const 0
-   local.get $8
+   local.get $offset
    call $~lib/string/String#substring
    local.set $11
    global.get $~lib/memory/__stack_pointer
@@ -36052,7 +36052,7 @@
    local.get $11
    return
   end
-  local.get $7
+  local.get $result
   local.set $11
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -36060,15 +36060,15 @@
   global.set $~lib/memory/__stack_pointer
   local.get $11
  )
- (func $~lib/util/string/joinIntegerArray<u16> (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
-  (local $3 i32)
-  (local $4 i32)
-  (local $5 i32)
-  (local $6 i32)
-  (local $7 i32)
-  (local $8 i32)
-  (local $9 i32)
-  (local $10 i32)
+ (func $~lib/util/string/joinIntegerArray<u16> (param $dataStart i32) (param $length i32) (param $separator i32) (result i32)
+  (local $lastIndex i32)
+  (local $var$4 i32)
+  (local $sepLen i32)
+  (local $estLen i32)
+  (local $result i32)
+  (local $offset i32)
+  (local $value i32)
+  (local $var$10 i32)
   (local $11 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -36078,11 +36078,11 @@
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   i32.store $0
-  local.get $1
+  local.get $length
   i32.const 1
   i32.sub
-  local.set $3
-  local.get $3
+  local.set $lastIndex
+  local.get $lastIndex
   i32.const 0
   i32.lt_s
   if
@@ -36095,19 +36095,19 @@
    local.get $11
    return
   end
-  local.get $3
+  local.get $lastIndex
   i32.eqz
   if
-   local.get $0
+   local.get $dataStart
    i32.load16_u $0
-   local.set $4
+   local.set $var$4
    i32.const 0
    drop
    i32.const 2
    i32.const 4
    i32.le_u
    drop
-   local.get $4
+   local.get $var$4
    i32.const 10
    call $~lib/util/number/utoa32
    local.set $11
@@ -36118,101 +36118,101 @@
    local.get $11
    return
   end
-  local.get $2
+  local.get $separator
   call $~lib/string/String#get:length
-  local.set $5
+  local.set $sepLen
   i32.const 10
-  local.get $5
+  local.get $sepLen
   i32.add
-  local.get $3
+  local.get $lastIndex
   i32.mul
   i32.const 10
   i32.add
-  local.set $6
+  local.set $estLen
   global.get $~lib/memory/__stack_pointer
-  local.get $6
+  local.get $estLen
   i32.const 1
   i32.shl
   i32.const 1
   call $~lib/rt/itcms/__new
-  local.tee $7
+  local.tee $result
   i32.store $0
   i32.const 0
-  local.set $8
+  local.set $offset
   i32.const 0
-  local.set $4
+  local.set $var$4
   loop $for-loop|0
-   local.get $4
-   local.get $3
+   local.get $var$4
+   local.get $lastIndex
    i32.lt_s
-   local.set $10
-   local.get $10
+   local.set $var$10
+   local.get $var$10
    if
-    local.get $0
-    local.get $4
+    local.get $dataStart
+    local.get $var$4
     i32.const 1
     i32.shl
     i32.add
     i32.load16_u $0
-    local.set $9
-    local.get $8
-    local.get $7
-    local.get $8
+    local.set $value
+    local.get $offset
+    local.get $result
+    local.get $offset
     i32.const 1
     i32.shl
     i32.add
-    local.get $9
+    local.get $value
     call $~lib/util/number/itoa_buffered<u16>
     i32.add
-    local.set $8
-    local.get $5
+    local.set $offset
+    local.get $sepLen
     if
-     local.get $7
-     local.get $8
+     local.get $result
+     local.get $offset
      i32.const 1
      i32.shl
      i32.add
-     local.get $2
-     local.get $5
+     local.get $separator
+     local.get $sepLen
      i32.const 1
      i32.shl
      memory.copy $0 $0
-     local.get $8
-     local.get $5
+     local.get $offset
+     local.get $sepLen
      i32.add
-     local.set $8
+     local.set $offset
     end
-    local.get $4
+    local.get $var$4
     i32.const 1
     i32.add
-    local.set $4
+    local.set $var$4
     br $for-loop|0
    end
   end
-  local.get $0
-  local.get $3
+  local.get $dataStart
+  local.get $lastIndex
   i32.const 1
   i32.shl
   i32.add
   i32.load16_u $0
-  local.set $9
-  local.get $8
-  local.get $7
-  local.get $8
+  local.set $value
+  local.get $offset
+  local.get $result
+  local.get $offset
   i32.const 1
   i32.shl
   i32.add
-  local.get $9
+  local.get $value
   call $~lib/util/number/itoa_buffered<u16>
   i32.add
-  local.set $8
-  local.get $6
-  local.get $8
+  local.set $offset
+  local.get $estLen
+  local.get $offset
   i32.gt_s
   if
-   local.get $7
+   local.get $result
    i32.const 0
-   local.get $8
+   local.get $offset
    call $~lib/string/String#substring
    local.set $11
    global.get $~lib/memory/__stack_pointer
@@ -36222,7 +36222,7 @@
    local.get $11
    return
   end
-  local.get $7
+  local.get $result
   local.set $11
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -36230,15 +36230,15 @@
   global.set $~lib/memory/__stack_pointer
   local.get $11
  )
- (func $~lib/util/string/joinIntegerArray<i16> (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
-  (local $3 i32)
-  (local $4 i32)
-  (local $5 i32)
-  (local $6 i32)
-  (local $7 i32)
-  (local $8 i32)
-  (local $9 i32)
-  (local $10 i32)
+ (func $~lib/util/string/joinIntegerArray<i16> (param $dataStart i32) (param $length i32) (param $separator i32) (result i32)
+  (local $lastIndex i32)
+  (local $var$4 i32)
+  (local $sepLen i32)
+  (local $estLen i32)
+  (local $result i32)
+  (local $offset i32)
+  (local $value i32)
+  (local $var$10 i32)
   (local $11 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -36248,11 +36248,11 @@
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   i32.store $0
-  local.get $1
+  local.get $length
   i32.const 1
   i32.sub
-  local.set $3
-  local.get $3
+  local.set $lastIndex
+  local.get $lastIndex
   i32.const 0
   i32.lt_s
   if
@@ -36265,19 +36265,19 @@
    local.get $11
    return
   end
-  local.get $3
+  local.get $lastIndex
   i32.eqz
   if
-   local.get $0
+   local.get $dataStart
    i32.load16_s $0
-   local.set $4
+   local.set $var$4
    i32.const 1
    drop
    i32.const 2
    i32.const 4
    i32.le_u
    drop
-   local.get $4
+   local.get $var$4
    i32.const 10
    call $~lib/util/number/itoa32
    local.set $11
@@ -36288,101 +36288,101 @@
    local.get $11
    return
   end
-  local.get $2
+  local.get $separator
   call $~lib/string/String#get:length
-  local.set $5
+  local.set $sepLen
   i32.const 11
-  local.get $5
+  local.get $sepLen
   i32.add
-  local.get $3
+  local.get $lastIndex
   i32.mul
   i32.const 11
   i32.add
-  local.set $6
+  local.set $estLen
   global.get $~lib/memory/__stack_pointer
-  local.get $6
+  local.get $estLen
   i32.const 1
   i32.shl
   i32.const 1
   call $~lib/rt/itcms/__new
-  local.tee $7
+  local.tee $result
   i32.store $0
   i32.const 0
-  local.set $8
+  local.set $offset
   i32.const 0
-  local.set $4
+  local.set $var$4
   loop $for-loop|0
-   local.get $4
-   local.get $3
+   local.get $var$4
+   local.get $lastIndex
    i32.lt_s
-   local.set $10
-   local.get $10
+   local.set $var$10
+   local.get $var$10
    if
-    local.get $0
-    local.get $4
+    local.get $dataStart
+    local.get $var$4
     i32.const 1
     i32.shl
     i32.add
     i32.load16_s $0
-    local.set $9
-    local.get $8
-    local.get $7
-    local.get $8
+    local.set $value
+    local.get $offset
+    local.get $result
+    local.get $offset
     i32.const 1
     i32.shl
     i32.add
-    local.get $9
+    local.get $value
     call $~lib/util/number/itoa_buffered<i16>
     i32.add
-    local.set $8
-    local.get $5
+    local.set $offset
+    local.get $sepLen
     if
-     local.get $7
-     local.get $8
+     local.get $result
+     local.get $offset
      i32.const 1
      i32.shl
      i32.add
-     local.get $2
-     local.get $5
+     local.get $separator
+     local.get $sepLen
      i32.const 1
      i32.shl
      memory.copy $0 $0
-     local.get $8
-     local.get $5
+     local.get $offset
+     local.get $sepLen
      i32.add
-     local.set $8
+     local.set $offset
     end
-    local.get $4
+    local.get $var$4
     i32.const 1
     i32.add
-    local.set $4
+    local.set $var$4
     br $for-loop|0
    end
   end
-  local.get $0
-  local.get $3
+  local.get $dataStart
+  local.get $lastIndex
   i32.const 1
   i32.shl
   i32.add
   i32.load16_s $0
-  local.set $9
-  local.get $8
-  local.get $7
-  local.get $8
+  local.set $value
+  local.get $offset
+  local.get $result
+  local.get $offset
   i32.const 1
   i32.shl
   i32.add
-  local.get $9
+  local.get $value
   call $~lib/util/number/itoa_buffered<i16>
   i32.add
-  local.set $8
-  local.get $6
-  local.get $8
+  local.set $offset
+  local.get $estLen
+  local.get $offset
   i32.gt_s
   if
-   local.get $7
+   local.get $result
    i32.const 0
-   local.get $8
+   local.get $offset
    call $~lib/string/String#substring
    local.set $11
    global.get $~lib/memory/__stack_pointer
@@ -36392,7 +36392,7 @@
    local.get $11
    return
   end
-  local.get $7
+  local.get $result
   local.set $11
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -36400,14 +36400,14 @@
   global.set $~lib/memory/__stack_pointer
   local.get $11
  )
- (func $~lib/util/number/utoa64 (param $0 i64) (param $1 i32) (result i32)
-  (local $2 i32)
-  (local $3 i32)
-  (local $4 i32)
-  (local $5 i32)
-  (local $6 i32)
-  (local $7 i32)
-  (local $8 i64)
+ (func $~lib/util/number/utoa64 (param $value i64) (param $radix i32) (result i32)
+  (local $out i32)
+  (local $var$3 i32)
+  (local $var$4 i32)
+  (local $var$5 i32)
+  (local $var$6 i32)
+  (local $var$7 i32)
+  (local $var$8 i64)
   (local $9 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -36417,13 +36417,13 @@
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   i32.store $0
-  local.get $1
+  local.get $radix
   i32.const 2
   i32.lt_s
   if (result i32)
    i32.const 1
   else
-   local.get $1
+   local.get $radix
    i32.const 36
    i32.gt_s
   end
@@ -36435,7 +36435,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $0
+  local.get $value
   i64.const 0
   i64.ne
   i32.eqz
@@ -36449,77 +36449,77 @@
    local.get $9
    return
   end
-  local.get $1
+  local.get $radix
   i32.const 10
   i32.eq
   if
-   local.get $0
+   local.get $value
    global.get $~lib/builtins/u32.MAX_VALUE
    i64.extend_i32_u
    i64.le_u
    if
-    local.get $0
+    local.get $value
     i32.wrap_i64
-    local.set $3
-    local.get $3
+    local.set $var$3
+    local.get $var$3
     call $~lib/util/number/decimalCount32
-    local.set $4
+    local.set $var$4
     global.get $~lib/memory/__stack_pointer
-    local.get $4
+    local.get $var$4
     i32.const 1
     i32.shl
     i32.const 1
     call $~lib/rt/itcms/__new
-    local.tee $2
+    local.tee $out
     i32.store $0
-    local.get $2
-    local.set $7
-    local.get $3
-    local.set $6
-    local.get $4
-    local.set $5
+    local.get $out
+    local.set $var$7
+    local.get $var$3
+    local.set $var$6
+    local.get $var$4
+    local.set $var$5
     i32.const 0
     i32.const 1
     i32.ge_s
     drop
-    local.get $7
-    local.get $6
-    local.get $5
+    local.get $var$7
+    local.get $var$6
+    local.get $var$5
     call $~lib/util/number/utoa32_dec_lut
    else
-    local.get $0
+    local.get $value
     call $~lib/util/number/decimalCount64High
-    local.set $4
+    local.set $var$4
     global.get $~lib/memory/__stack_pointer
-    local.get $4
+    local.get $var$4
     i32.const 1
     i32.shl
     i32.const 1
     call $~lib/rt/itcms/__new
-    local.tee $2
+    local.tee $out
     i32.store $0
-    local.get $2
-    local.set $6
-    local.get $0
-    local.set $8
-    local.get $4
-    local.set $5
+    local.get $out
+    local.set $var$6
+    local.get $value
+    local.set $var$8
+    local.get $var$4
+    local.set $var$5
     i32.const 0
     i32.const 1
     i32.ge_s
     drop
-    local.get $6
-    local.get $8
-    local.get $5
+    local.get $var$6
+    local.get $var$8
+    local.get $var$5
     call $~lib/util/number/utoa64_dec_lut
    end
   else
-   local.get $1
+   local.get $radix
    i32.const 16
    i32.eq
    if
     i32.const 63
-    local.get $0
+    local.get $value
     i64.clz
     i32.wrap_i64
     i32.sub
@@ -36527,50 +36527,50 @@
     i32.shr_s
     i32.const 1
     i32.add
-    local.set $4
+    local.set $var$4
     global.get $~lib/memory/__stack_pointer
-    local.get $4
+    local.get $var$4
     i32.const 1
     i32.shl
     i32.const 1
     call $~lib/rt/itcms/__new
-    local.tee $2
+    local.tee $out
     i32.store $0
-    local.get $2
-    local.set $3
-    local.get $0
-    local.set $8
-    local.get $4
-    local.set $7
+    local.get $out
+    local.set $var$3
+    local.get $value
+    local.set $var$8
+    local.get $var$4
+    local.set $var$7
     i32.const 0
     i32.const 1
     i32.ge_s
     drop
-    local.get $3
-    local.get $8
-    local.get $7
+    local.get $var$3
+    local.get $var$8
+    local.get $var$7
     call $~lib/util/number/utoa_hex_lut
    else
-    local.get $0
-    local.get $1
+    local.get $value
+    local.get $radix
     call $~lib/util/number/ulog_base
-    local.set $4
+    local.set $var$4
     global.get $~lib/memory/__stack_pointer
-    local.get $4
+    local.get $var$4
     i32.const 1
     i32.shl
     i32.const 1
     call $~lib/rt/itcms/__new
-    local.tee $2
+    local.tee $out
     i32.store $0
-    local.get $2
-    local.get $0
-    local.get $4
-    local.get $1
+    local.get $out
+    local.get $value
+    local.get $var$4
+    local.get $radix
     call $~lib/util/number/utoa64_any_core
    end
   end
-  local.get $2
+  local.get $out
   local.set $9
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -36578,16 +36578,16 @@
   global.set $~lib/memory/__stack_pointer
   local.get $9
  )
- (func $~lib/util/string/joinIntegerArray<u64> (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
-  (local $3 i32)
-  (local $4 i64)
-  (local $5 i32)
-  (local $6 i32)
-  (local $7 i32)
-  (local $8 i32)
-  (local $9 i64)
-  (local $10 i32)
-  (local $11 i32)
+ (func $~lib/util/string/joinIntegerArray<u64> (param $dataStart i32) (param $length i32) (param $separator i32) (result i32)
+  (local $lastIndex i32)
+  (local $var$4 i64)
+  (local $sepLen i32)
+  (local $estLen i32)
+  (local $result i32)
+  (local $offset i32)
+  (local $value i64)
+  (local $var$10 i32)
+  (local $var$11 i32)
   (local $12 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -36597,11 +36597,11 @@
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   i32.store $0
-  local.get $1
+  local.get $length
   i32.const 1
   i32.sub
-  local.set $3
-  local.get $3
+  local.set $lastIndex
+  local.get $lastIndex
   i32.const 0
   i32.lt_s
   if
@@ -36614,19 +36614,19 @@
    local.get $12
    return
   end
-  local.get $3
+  local.get $lastIndex
   i32.eqz
   if
-   local.get $0
+   local.get $dataStart
    i64.load $0
-   local.set $4
+   local.set $var$4
    i32.const 0
    drop
    i32.const 8
    i32.const 4
    i32.le_u
    drop
-   local.get $4
+   local.get $var$4
    i32.const 10
    call $~lib/util/number/utoa64
    local.set $12
@@ -36637,101 +36637,101 @@
    local.get $12
    return
   end
-  local.get $2
+  local.get $separator
   call $~lib/string/String#get:length
-  local.set $5
+  local.set $sepLen
   i32.const 20
-  local.get $5
+  local.get $sepLen
   i32.add
-  local.get $3
+  local.get $lastIndex
   i32.mul
   i32.const 20
   i32.add
-  local.set $6
+  local.set $estLen
   global.get $~lib/memory/__stack_pointer
-  local.get $6
+  local.get $estLen
   i32.const 1
   i32.shl
   i32.const 1
   call $~lib/rt/itcms/__new
-  local.tee $7
+  local.tee $result
   i32.store $0
   i32.const 0
-  local.set $8
+  local.set $offset
   i32.const 0
-  local.set $10
+  local.set $var$10
   loop $for-loop|0
-   local.get $10
-   local.get $3
+   local.get $var$10
+   local.get $lastIndex
    i32.lt_s
-   local.set $11
-   local.get $11
+   local.set $var$11
+   local.get $var$11
    if
-    local.get $0
-    local.get $10
+    local.get $dataStart
+    local.get $var$10
     i32.const 3
     i32.shl
     i32.add
     i64.load $0
-    local.set $9
-    local.get $8
-    local.get $7
-    local.get $8
+    local.set $value
+    local.get $offset
+    local.get $result
+    local.get $offset
     i32.const 1
     i32.shl
     i32.add
-    local.get $9
+    local.get $value
     call $~lib/util/number/itoa_buffered<u64>
     i32.add
-    local.set $8
-    local.get $5
+    local.set $offset
+    local.get $sepLen
     if
-     local.get $7
-     local.get $8
+     local.get $result
+     local.get $offset
      i32.const 1
      i32.shl
      i32.add
-     local.get $2
-     local.get $5
+     local.get $separator
+     local.get $sepLen
      i32.const 1
      i32.shl
      memory.copy $0 $0
-     local.get $8
-     local.get $5
+     local.get $offset
+     local.get $sepLen
      i32.add
-     local.set $8
+     local.set $offset
     end
-    local.get $10
+    local.get $var$10
     i32.const 1
     i32.add
-    local.set $10
+    local.set $var$10
     br $for-loop|0
    end
   end
-  local.get $0
-  local.get $3
+  local.get $dataStart
+  local.get $lastIndex
   i32.const 3
   i32.shl
   i32.add
   i64.load $0
-  local.set $9
-  local.get $8
-  local.get $7
-  local.get $8
+  local.set $value
+  local.get $offset
+  local.get $result
+  local.get $offset
   i32.const 1
   i32.shl
   i32.add
-  local.get $9
+  local.get $value
   call $~lib/util/number/itoa_buffered<u64>
   i32.add
-  local.set $8
-  local.get $6
-  local.get $8
+  local.set $offset
+  local.get $estLen
+  local.get $offset
   i32.gt_s
   if
-   local.get $7
+   local.get $result
    i32.const 0
-   local.get $8
+   local.get $offset
    call $~lib/string/String#substring
    local.set $12
    global.get $~lib/memory/__stack_pointer
@@ -36741,7 +36741,7 @@
    local.get $12
    return
   end
-  local.get $7
+  local.get $result
   local.set $12
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -36749,15 +36749,15 @@
   global.set $~lib/memory/__stack_pointer
   local.get $12
  )
- (func $~lib/util/number/itoa64 (param $0 i64) (param $1 i32) (result i32)
-  (local $2 i32)
-  (local $3 i32)
-  (local $4 i32)
-  (local $5 i32)
-  (local $6 i32)
-  (local $7 i32)
-  (local $8 i32)
-  (local $9 i64)
+ (func $~lib/util/number/itoa64 (param $value i64) (param $radix i32) (result i32)
+  (local $sign i32)
+  (local $out i32)
+  (local $var$4 i32)
+  (local $var$5 i32)
+  (local $var$6 i32)
+  (local $var$7 i32)
+  (local $var$8 i32)
+  (local $var$9 i64)
   (local $10 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -36767,13 +36767,13 @@
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   i32.store $0
-  local.get $1
+  local.get $radix
   i32.const 2
   i32.lt_s
   if (result i32)
    i32.const 1
   else
-   local.get $1
+   local.get $radix
    i32.const 36
    i32.gt_s
   end
@@ -36785,7 +36785,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $0
+  local.get $value
   i64.const 0
   i64.ne
   i32.eqz
@@ -36799,99 +36799,99 @@
    local.get $10
    return
   end
-  local.get $0
+  local.get $value
   i64.const 63
   i64.shr_u
   i32.wrap_i64
   i32.const 1
   i32.shl
-  local.set $2
-  local.get $2
+  local.set $sign
+  local.get $sign
   if
    i64.const 0
-   local.get $0
+   local.get $value
    i64.sub
-   local.set $0
+   local.set $value
   end
-  local.get $1
+  local.get $radix
   i32.const 10
   i32.eq
   if
-   local.get $0
+   local.get $value
    global.get $~lib/builtins/u32.MAX_VALUE
    i64.extend_i32_u
    i64.le_u
    if
-    local.get $0
+    local.get $value
     i32.wrap_i64
-    local.set $4
-    local.get $4
+    local.set $var$4
+    local.get $var$4
     call $~lib/util/number/decimalCount32
-    local.set $5
+    local.set $var$5
     global.get $~lib/memory/__stack_pointer
-    local.get $5
+    local.get $var$5
     i32.const 1
     i32.shl
-    local.get $2
+    local.get $sign
     i32.add
     i32.const 1
     call $~lib/rt/itcms/__new
-    local.tee $3
+    local.tee $out
     i32.store $0
-    local.get $3
-    local.get $2
+    local.get $out
+    local.get $sign
     i32.add
-    local.set $8
-    local.get $4
-    local.set $7
-    local.get $5
-    local.set $6
+    local.set $var$8
+    local.get $var$4
+    local.set $var$7
+    local.get $var$5
+    local.set $var$6
     i32.const 0
     i32.const 1
     i32.ge_s
     drop
-    local.get $8
-    local.get $7
-    local.get $6
+    local.get $var$8
+    local.get $var$7
+    local.get $var$6
     call $~lib/util/number/utoa32_dec_lut
    else
-    local.get $0
+    local.get $value
     call $~lib/util/number/decimalCount64High
-    local.set $5
+    local.set $var$5
     global.get $~lib/memory/__stack_pointer
-    local.get $5
+    local.get $var$5
     i32.const 1
     i32.shl
-    local.get $2
+    local.get $sign
     i32.add
     i32.const 1
     call $~lib/rt/itcms/__new
-    local.tee $3
+    local.tee $out
     i32.store $0
-    local.get $3
-    local.get $2
+    local.get $out
+    local.get $sign
     i32.add
-    local.set $7
-    local.get $0
-    local.set $9
-    local.get $5
-    local.set $6
+    local.set $var$7
+    local.get $value
+    local.set $var$9
+    local.get $var$5
+    local.set $var$6
     i32.const 0
     i32.const 1
     i32.ge_s
     drop
-    local.get $7
-    local.get $9
-    local.get $6
+    local.get $var$7
+    local.get $var$9
+    local.get $var$6
     call $~lib/util/number/utoa64_dec_lut
    end
   else
-   local.get $1
+   local.get $radix
    i32.const 16
    i32.eq
    if
     i32.const 63
-    local.get $0
+    local.get $value
     i64.clz
     i32.wrap_i64
     i32.sub
@@ -36899,64 +36899,64 @@
     i32.shr_s
     i32.const 1
     i32.add
-    local.set $5
+    local.set $var$5
     global.get $~lib/memory/__stack_pointer
-    local.get $5
+    local.get $var$5
     i32.const 1
     i32.shl
-    local.get $2
+    local.get $sign
     i32.add
     i32.const 1
     call $~lib/rt/itcms/__new
-    local.tee $3
+    local.tee $out
     i32.store $0
-    local.get $3
-    local.get $2
+    local.get $out
+    local.get $sign
     i32.add
-    local.set $4
-    local.get $0
-    local.set $9
-    local.get $5
-    local.set $8
+    local.set $var$4
+    local.get $value
+    local.set $var$9
+    local.get $var$5
+    local.set $var$8
     i32.const 0
     i32.const 1
     i32.ge_s
     drop
-    local.get $4
-    local.get $9
-    local.get $8
+    local.get $var$4
+    local.get $var$9
+    local.get $var$8
     call $~lib/util/number/utoa_hex_lut
    else
-    local.get $0
-    local.get $1
+    local.get $value
+    local.get $radix
     call $~lib/util/number/ulog_base
-    local.set $5
+    local.set $var$5
     global.get $~lib/memory/__stack_pointer
-    local.get $5
+    local.get $var$5
     i32.const 1
     i32.shl
-    local.get $2
+    local.get $sign
     i32.add
     i32.const 1
     call $~lib/rt/itcms/__new
-    local.tee $3
+    local.tee $out
     i32.store $0
-    local.get $3
-    local.get $2
+    local.get $out
+    local.get $sign
     i32.add
-    local.get $0
-    local.get $5
-    local.get $1
+    local.get $value
+    local.get $var$5
+    local.get $radix
     call $~lib/util/number/utoa64_any_core
    end
   end
-  local.get $2
+  local.get $sign
   if
-   local.get $3
+   local.get $out
    i32.const 45
    i32.store16 $0
   end
-  local.get $3
+  local.get $out
   local.set $10
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -36964,16 +36964,16 @@
   global.set $~lib/memory/__stack_pointer
   local.get $10
  )
- (func $~lib/util/string/joinIntegerArray<i64> (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
-  (local $3 i32)
-  (local $4 i64)
-  (local $5 i32)
-  (local $6 i32)
-  (local $7 i32)
-  (local $8 i32)
-  (local $9 i64)
-  (local $10 i32)
-  (local $11 i32)
+ (func $~lib/util/string/joinIntegerArray<i64> (param $dataStart i32) (param $length i32) (param $separator i32) (result i32)
+  (local $lastIndex i32)
+  (local $var$4 i64)
+  (local $sepLen i32)
+  (local $estLen i32)
+  (local $result i32)
+  (local $offset i32)
+  (local $value i64)
+  (local $var$10 i32)
+  (local $var$11 i32)
   (local $12 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -36983,11 +36983,11 @@
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   i32.store $0
-  local.get $1
+  local.get $length
   i32.const 1
   i32.sub
-  local.set $3
-  local.get $3
+  local.set $lastIndex
+  local.get $lastIndex
   i32.const 0
   i32.lt_s
   if
@@ -37000,19 +37000,19 @@
    local.get $12
    return
   end
-  local.get $3
+  local.get $lastIndex
   i32.eqz
   if
-   local.get $0
+   local.get $dataStart
    i64.load $0
-   local.set $4
+   local.set $var$4
    i32.const 1
    drop
    i32.const 8
    i32.const 4
    i32.le_u
    drop
-   local.get $4
+   local.get $var$4
    i32.wrap_i64
    i64.extend_i32_s
    i32.const 10
@@ -37025,101 +37025,101 @@
    local.get $12
    return
   end
-  local.get $2
+  local.get $separator
   call $~lib/string/String#get:length
-  local.set $5
+  local.set $sepLen
   i32.const 21
-  local.get $5
+  local.get $sepLen
   i32.add
-  local.get $3
+  local.get $lastIndex
   i32.mul
   i32.const 21
   i32.add
-  local.set $6
+  local.set $estLen
   global.get $~lib/memory/__stack_pointer
-  local.get $6
+  local.get $estLen
   i32.const 1
   i32.shl
   i32.const 1
   call $~lib/rt/itcms/__new
-  local.tee $7
+  local.tee $result
   i32.store $0
   i32.const 0
-  local.set $8
+  local.set $offset
   i32.const 0
-  local.set $10
+  local.set $var$10
   loop $for-loop|0
-   local.get $10
-   local.get $3
+   local.get $var$10
+   local.get $lastIndex
    i32.lt_s
-   local.set $11
-   local.get $11
+   local.set $var$11
+   local.get $var$11
    if
-    local.get $0
-    local.get $10
+    local.get $dataStart
+    local.get $var$10
     i32.const 3
     i32.shl
     i32.add
     i64.load $0
-    local.set $9
-    local.get $8
-    local.get $7
-    local.get $8
+    local.set $value
+    local.get $offset
+    local.get $result
+    local.get $offset
     i32.const 1
     i32.shl
     i32.add
-    local.get $9
+    local.get $value
     call $~lib/util/number/itoa_buffered<i64>
     i32.add
-    local.set $8
-    local.get $5
+    local.set $offset
+    local.get $sepLen
     if
-     local.get $7
-     local.get $8
+     local.get $result
+     local.get $offset
      i32.const 1
      i32.shl
      i32.add
-     local.get $2
-     local.get $5
+     local.get $separator
+     local.get $sepLen
      i32.const 1
      i32.shl
      memory.copy $0 $0
-     local.get $8
-     local.get $5
+     local.get $offset
+     local.get $sepLen
      i32.add
-     local.set $8
+     local.set $offset
     end
-    local.get $10
+    local.get $var$10
     i32.const 1
     i32.add
-    local.set $10
+    local.set $var$10
     br $for-loop|0
    end
   end
-  local.get $0
-  local.get $3
+  local.get $dataStart
+  local.get $lastIndex
   i32.const 3
   i32.shl
   i32.add
   i64.load $0
-  local.set $9
-  local.get $8
-  local.get $7
-  local.get $8
+  local.set $value
+  local.get $offset
+  local.get $result
+  local.get $offset
   i32.const 1
   i32.shl
   i32.add
-  local.get $9
+  local.get $value
   call $~lib/util/number/itoa_buffered<i64>
   i32.add
-  local.set $8
-  local.get $6
-  local.get $8
+  local.set $offset
+  local.get $estLen
+  local.get $offset
   i32.gt_s
   if
-   local.get $7
+   local.get $result
    i32.const 0
-   local.get $8
+   local.get $offset
    call $~lib/string/String#substring
    local.set $12
    global.get $~lib/memory/__stack_pointer
@@ -37129,7 +37129,7 @@
    local.get $12
    return
   end
-  local.get $7
+  local.get $result
   local.set $12
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -37137,15 +37137,15 @@
   global.set $~lib/memory/__stack_pointer
   local.get $12
  )
- (func $~lib/util/string/joinIntegerArray<u8> (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
-  (local $3 i32)
-  (local $4 i32)
-  (local $5 i32)
-  (local $6 i32)
-  (local $7 i32)
-  (local $8 i32)
-  (local $9 i32)
-  (local $10 i32)
+ (func $~lib/util/string/joinIntegerArray<u8> (param $dataStart i32) (param $length i32) (param $separator i32) (result i32)
+  (local $lastIndex i32)
+  (local $var$4 i32)
+  (local $sepLen i32)
+  (local $estLen i32)
+  (local $result i32)
+  (local $offset i32)
+  (local $value i32)
+  (local $var$10 i32)
   (local $11 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -37155,11 +37155,11 @@
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   i32.store $0
-  local.get $1
+  local.get $length
   i32.const 1
   i32.sub
-  local.set $3
-  local.get $3
+  local.set $lastIndex
+  local.get $lastIndex
   i32.const 0
   i32.lt_s
   if
@@ -37172,19 +37172,19 @@
    local.get $11
    return
   end
-  local.get $3
+  local.get $lastIndex
   i32.eqz
   if
-   local.get $0
+   local.get $dataStart
    i32.load8_u $0
-   local.set $4
+   local.set $var$4
    i32.const 0
    drop
    i32.const 1
    i32.const 4
    i32.le_u
    drop
-   local.get $4
+   local.get $var$4
    i32.const 10
    call $~lib/util/number/utoa32
    local.set $11
@@ -37195,101 +37195,101 @@
    local.get $11
    return
   end
-  local.get $2
+  local.get $separator
   call $~lib/string/String#get:length
-  local.set $5
+  local.set $sepLen
   i32.const 10
-  local.get $5
+  local.get $sepLen
   i32.add
-  local.get $3
+  local.get $lastIndex
   i32.mul
   i32.const 10
   i32.add
-  local.set $6
+  local.set $estLen
   global.get $~lib/memory/__stack_pointer
-  local.get $6
+  local.get $estLen
   i32.const 1
   i32.shl
   i32.const 1
   call $~lib/rt/itcms/__new
-  local.tee $7
+  local.tee $result
   i32.store $0
   i32.const 0
-  local.set $8
+  local.set $offset
   i32.const 0
-  local.set $4
+  local.set $var$4
   loop $for-loop|0
-   local.get $4
-   local.get $3
+   local.get $var$4
+   local.get $lastIndex
    i32.lt_s
-   local.set $10
-   local.get $10
+   local.set $var$10
+   local.get $var$10
    if
-    local.get $0
-    local.get $4
+    local.get $dataStart
+    local.get $var$4
     i32.const 0
     i32.shl
     i32.add
     i32.load8_u $0
-    local.set $9
-    local.get $8
-    local.get $7
-    local.get $8
+    local.set $value
+    local.get $offset
+    local.get $result
+    local.get $offset
     i32.const 1
     i32.shl
     i32.add
-    local.get $9
+    local.get $value
     call $~lib/util/number/itoa_buffered<u8>
     i32.add
-    local.set $8
-    local.get $5
+    local.set $offset
+    local.get $sepLen
     if
-     local.get $7
-     local.get $8
+     local.get $result
+     local.get $offset
      i32.const 1
      i32.shl
      i32.add
-     local.get $2
-     local.get $5
+     local.get $separator
+     local.get $sepLen
      i32.const 1
      i32.shl
      memory.copy $0 $0
-     local.get $8
-     local.get $5
+     local.get $offset
+     local.get $sepLen
      i32.add
-     local.set $8
+     local.set $offset
     end
-    local.get $4
+    local.get $var$4
     i32.const 1
     i32.add
-    local.set $4
+    local.set $var$4
     br $for-loop|0
    end
   end
-  local.get $0
-  local.get $3
+  local.get $dataStart
+  local.get $lastIndex
   i32.const 0
   i32.shl
   i32.add
   i32.load8_u $0
-  local.set $9
-  local.get $8
-  local.get $7
-  local.get $8
+  local.set $value
+  local.get $offset
+  local.get $result
+  local.get $offset
   i32.const 1
   i32.shl
   i32.add
-  local.get $9
+  local.get $value
   call $~lib/util/number/itoa_buffered<u8>
   i32.add
-  local.set $8
-  local.get $6
-  local.get $8
+  local.set $offset
+  local.get $estLen
+  local.get $offset
   i32.gt_s
   if
-   local.get $7
+   local.get $result
    i32.const 0
-   local.get $8
+   local.get $offset
    call $~lib/string/String#substring
    local.set $11
    global.get $~lib/memory/__stack_pointer
@@ -37299,7 +37299,7 @@
    local.get $11
    return
   end
-  local.get $7
+  local.get $result
   local.set $11
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -37307,18 +37307,18 @@
   global.set $~lib/memory/__stack_pointer
   local.get $11
  )
- (func $~lib/array/Array<~lib/array/Array<i32>>#flat (param $0 i32) (result i32)
-  (local $1 i32)
-  (local $2 i32)
-  (local $3 i32)
-  (local $4 i32)
-  (local $5 i32)
-  (local $6 i32)
-  (local $7 i32)
-  (local $8 i32)
-  (local $9 i32)
-  (local $10 i32)
-  (local $11 i32)
+ (func $~lib/array/Array<~lib/array/Array<i32>>#flat (param $this i32) (result i32)
+  (local $ptr i32)
+  (local $len i32)
+  (local $size i32)
+  (local $var$4 i32)
+  (local $var$5 i32)
+  (local $var$6 i32)
+  (local $byteLength i32)
+  (local $outBuffer i32)
+  (local $outArray i32)
+  (local $resultOffset i32)
+  (local $var$11 i32)
   (local $12 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 8
@@ -37331,132 +37331,132 @@
   i32.const 1
   i32.eqz
   drop
-  local.get $0
+  local.get $this
   i32.load $0 offset=4
-  local.set $1
-  local.get $0
+  local.set $ptr
+  local.get $this
   i32.load $0 offset=12
-  local.set $2
+  local.set $len
   i32.const 0
-  local.set $3
+  local.set $size
   i32.const 0
-  local.set $4
+  local.set $var$4
   loop $for-loop|0
-   local.get $4
-   local.get $2
+   local.get $var$4
+   local.get $len
    i32.lt_s
-   local.set $5
-   local.get $5
+   local.set $var$5
+   local.get $var$5
    if
-    local.get $1
-    local.get $4
+    local.get $ptr
+    local.get $var$4
     i32.const 2
     i32.shl
     i32.add
     i32.load $0
-    local.set $6
-    local.get $3
-    local.get $6
+    local.set $var$6
+    local.get $size
+    local.get $var$6
     i32.const 0
     i32.eq
     if (result i32)
      i32.const 0
     else
-     local.get $6
+     local.get $var$6
      i32.load $0 offset=12
     end
     i32.add
-    local.set $3
-    local.get $4
+    local.set $size
+    local.get $var$4
     i32.const 1
     i32.add
-    local.set $4
+    local.set $var$4
     br $for-loop|0
    end
   end
-  local.get $3
+  local.get $size
   i32.const 2
   i32.shl
-  local.set $7
+  local.set $byteLength
   global.get $~lib/memory/__stack_pointer
-  local.get $7
+  local.get $byteLength
   i32.const 0
   call $~lib/rt/itcms/__new
-  local.tee $8
+  local.tee $outBuffer
   i32.store $0
   global.get $~lib/memory/__stack_pointer
   i32.const 16
   i32.const 3
   call $~lib/rt/itcms/__new
-  local.tee $9
+  local.tee $outArray
   i32.store $0 offset=4
-  local.get $9
-  local.get $3
+  local.get $outArray
+  local.get $size
   i32.store $0 offset=12
-  local.get $9
-  local.get $7
+  local.get $outArray
+  local.get $byteLength
   i32.store $0 offset=8
-  local.get $9
-  local.get $8
+  local.get $outArray
+  local.get $outBuffer
   i32.store $0 offset=4
-  local.get $9
-  local.get $8
+  local.get $outArray
+  local.get $outBuffer
   i32.store $0
-  local.get $9
-  local.get $8
+  local.get $outArray
+  local.get $outBuffer
   i32.const 0
   call $~lib/rt/itcms/__link
   i32.const 0
-  local.set $10
+  local.set $resultOffset
   i32.const 0
-  local.set $4
+  local.set $var$4
   loop $for-loop|1
-   local.get $4
-   local.get $2
+   local.get $var$4
+   local.get $len
    i32.lt_s
-   local.set $5
-   local.get $5
+   local.set $var$5
+   local.get $var$5
    if
     block $for-continue|1
-     local.get $1
-     local.get $4
+     local.get $ptr
+     local.get $var$4
      i32.const 2
      i32.shl
      i32.add
      i32.load $0
-     local.set $6
-     local.get $6
+     local.set $var$6
+     local.get $var$6
      i32.eqz
      if
       br $for-continue|1
      end
-     local.get $6
+     local.get $var$6
      i32.load $0 offset=12
      i32.const 2
      i32.shl
-     local.set $11
-     local.get $8
-     local.get $10
+     local.set $var$11
+     local.get $outBuffer
+     local.get $resultOffset
      i32.add
-     local.get $6
+     local.get $var$6
      i32.load $0 offset=4
-     local.get $11
+     local.get $var$11
      memory.copy $0 $0
-     local.get $10
-     local.get $11
+     local.get $resultOffset
+     local.get $var$11
      i32.add
-     local.set $10
+     local.set $resultOffset
     end
-    local.get $4
+    local.get $var$4
     i32.const 1
     i32.add
-    local.set $4
+    local.set $var$4
     br $for-loop|1
    end
   end
   i32.const 0
   drop
-  local.get $9
+  local.get $outArray
   local.set $12
   global.get $~lib/memory/__stack_pointer
   i32.const 8
@@ -37464,18 +37464,18 @@
   global.set $~lib/memory/__stack_pointer
   local.get $12
  )
- (func $~lib/array/Array<~lib/array/Array<~lib/string/String|null>>#flat (param $0 i32) (result i32)
-  (local $1 i32)
-  (local $2 i32)
-  (local $3 i32)
-  (local $4 i32)
-  (local $5 i32)
-  (local $6 i32)
-  (local $7 i32)
-  (local $8 i32)
-  (local $9 i32)
-  (local $10 i32)
-  (local $11 i32)
+ (func $~lib/array/Array<~lib/array/Array<~lib/string/String|null>>#flat (param $this i32) (result i32)
+  (local $ptr i32)
+  (local $len i32)
+  (local $size i32)
+  (local $var$4 i32)
+  (local $var$5 i32)
+  (local $var$6 i32)
+  (local $byteLength i32)
+  (local $outBuffer i32)
+  (local $outArray i32)
+  (local $resultOffset i32)
+  (local $var$11 i32)
   (local $12 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 8
@@ -37488,159 +37488,159 @@
   i32.const 1
   i32.eqz
   drop
-  local.get $0
+  local.get $this
   i32.load $0 offset=4
-  local.set $1
-  local.get $0
+  local.set $ptr
+  local.get $this
   i32.load $0 offset=12
-  local.set $2
+  local.set $len
   i32.const 0
-  local.set $3
+  local.set $size
   i32.const 0
-  local.set $4
+  local.set $var$4
   loop $for-loop|0
-   local.get $4
-   local.get $2
+   local.get $var$4
+   local.get $len
    i32.lt_s
-   local.set $5
-   local.get $5
+   local.set $var$5
+   local.get $var$5
    if
-    local.get $1
-    local.get $4
+    local.get $ptr
+    local.get $var$4
     i32.const 2
     i32.shl
     i32.add
     i32.load $0
-    local.set $6
-    local.get $3
-    local.get $6
+    local.set $var$6
+    local.get $size
+    local.get $var$6
     i32.const 0
     i32.eq
     if (result i32)
      i32.const 0
     else
-     local.get $6
+     local.get $var$6
      i32.load $0 offset=12
     end
     i32.add
-    local.set $3
-    local.get $4
+    local.set $size
+    local.get $var$4
     i32.const 1
     i32.add
-    local.set $4
+    local.set $var$4
     br $for-loop|0
    end
   end
-  local.get $3
+  local.get $size
   i32.const 2
   i32.shl
-  local.set $7
+  local.set $byteLength
   global.get $~lib/memory/__stack_pointer
-  local.get $7
+  local.get $byteLength
   i32.const 0
   call $~lib/rt/itcms/__new
-  local.tee $8
+  local.tee $outBuffer
   i32.store $0
   global.get $~lib/memory/__stack_pointer
   i32.const 16
   i32.const 33
   call $~lib/rt/itcms/__new
-  local.tee $9
+  local.tee $outArray
   i32.store $0 offset=4
-  local.get $9
-  local.get $3
+  local.get $outArray
+  local.get $size
   i32.store $0 offset=12
-  local.get $9
-  local.get $7
+  local.get $outArray
+  local.get $byteLength
   i32.store $0 offset=8
-  local.get $9
-  local.get $8
+  local.get $outArray
+  local.get $outBuffer
   i32.store $0 offset=4
-  local.get $9
-  local.get $8
+  local.get $outArray
+  local.get $outBuffer
   i32.store $0
-  local.get $9
-  local.get $8
+  local.get $outArray
+  local.get $outBuffer
   i32.const 0
   call $~lib/rt/itcms/__link
   i32.const 0
-  local.set $10
+  local.set $resultOffset
   i32.const 0
-  local.set $4
+  local.set $var$4
   loop $for-loop|1
-   local.get $4
-   local.get $2
+   local.get $var$4
+   local.get $len
    i32.lt_s
-   local.set $5
-   local.get $5
+   local.set $var$5
+   local.get $var$5
    if
     block $for-continue|1
-     local.get $1
-     local.get $4
+     local.get $ptr
+     local.get $var$4
      i32.const 2
      i32.shl
      i32.add
      i32.load $0
-     local.set $6
-     local.get $6
+     local.set $var$6
+     local.get $var$6
      i32.eqz
      if
       br $for-continue|1
      end
-     local.get $6
+     local.get $var$6
      i32.load $0 offset=12
      i32.const 2
      i32.shl
-     local.set $11
-     local.get $8
-     local.get $10
+     local.set $var$11
+     local.get $outBuffer
+     local.get $resultOffset
      i32.add
-     local.get $6
+     local.get $var$6
      i32.load $0 offset=4
-     local.get $11
+     local.get $var$11
      memory.copy $0 $0
-     local.get $10
-     local.get $11
+     local.get $resultOffset
+     local.get $var$11
      i32.add
-     local.set $10
+     local.set $resultOffset
     end
-    local.get $4
+    local.get $var$4
     i32.const 1
     i32.add
-    local.set $4
+    local.set $var$4
     br $for-loop|1
    end
   end
   i32.const 1
   drop
   i32.const 0
-  local.set $4
+  local.set $var$4
   loop $for-loop|2
-   local.get $4
-   local.get $3
+   local.get $var$4
+   local.get $size
    i32.lt_s
-   local.set $5
-   local.get $5
+   local.set $var$5
+   local.get $var$5
    if
-    local.get $8
-    local.get $4
+    local.get $outBuffer
+    local.get $var$4
     i32.const 2
     i32.shl
     i32.add
     i32.load $0
-    local.set $11
-    local.get $8
-    local.get $11
+    local.set $var$11
+    local.get $outBuffer
+    local.get $var$11
     i32.const 1
     call $~lib/rt/itcms/__link
-    local.get $4
+    local.get $var$4
     i32.const 1
     i32.add
-    local.set $4
+    local.set $var$4
     br $for-loop|2
    end
   end
-  local.get $9
+  local.get $outArray
   local.set $12
   global.get $~lib/memory/__stack_pointer
   i32.const 8

--- a/tests/compiler/std/arraybuffer.debug.wat
+++ b/tests/compiler/std/arraybuffer.debug.wat
@@ -3173,8 +3173,8 @@
   i32.add
   global.set $~lib/memory/__stack_pointer
  )
- (func $~lib/arraybuffer/ArrayBuffer#constructor (param $0 i32) (param $1 i32) (result i32)
-  (local $2 i32)
+ (func $~lib/arraybuffer/ArrayBuffer#constructor (param $this i32) (param $length i32) (result i32)
+  (local $buffer i32)
   (local $3 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -3184,7 +3184,7 @@
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   i32.store $0
-  local.get $1
+  local.get $length
   i32.const 1073741820
   i32.gt_u
   if
@@ -3196,16 +3196,16 @@
    unreachable
   end
   global.get $~lib/memory/__stack_pointer
-  local.get $1
+  local.get $length
   i32.const 0
   call $~lib/rt/itcms/__new
-  local.tee $2
+  local.tee $buffer
   i32.store $0
   i32.const 2
   global.get $~lib/shared/runtime/Runtime.Incremental
   i32.ne
   drop
-  local.get $2
+  local.get $buffer
   local.set $3
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -3213,12 +3213,12 @@
   global.set $~lib/memory/__stack_pointer
   local.get $3
  )
- (func $~lib/arraybuffer/ArrayBuffer#slice (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
-  (local $3 i32)
-  (local $4 i32)
-  (local $5 i32)
-  (local $6 i32)
-  (local $7 i32)
+ (func $~lib/arraybuffer/ArrayBuffer#slice (param $this i32) (param $begin i32) (param $end i32) (result i32)
+  (local $length i32)
+  (local $var$4 i32)
+  (local $var$5 i32)
+  (local $outSize i32)
+  (local $out i32)
   (local $8 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -3228,83 +3228,83 @@
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   i32.store $0
-  local.get $0
+  local.get $this
   call $~lib/arraybuffer/ArrayBuffer#get:byteLength
-  local.set $3
-  local.get $1
+  local.set $length
+  local.get $begin
   i32.const 0
   i32.lt_s
   if (result i32)
-   local.get $3
-   local.get $1
+   local.get $length
+   local.get $begin
    i32.add
-   local.tee $4
+   local.tee $var$4
    i32.const 0
-   local.tee $5
-   local.get $4
-   local.get $5
+   local.tee $var$5
+   local.get $var$4
+   local.get $var$5
    i32.gt_s
    select
   else
-   local.get $1
-   local.tee $5
-   local.get $3
-   local.tee $4
-   local.get $5
-   local.get $4
+   local.get $begin
+   local.tee $var$5
+   local.get $length
+   local.tee $var$4
+   local.get $var$5
+   local.get $var$4
    i32.lt_s
    select
   end
-  local.set $1
-  local.get $2
+  local.set $begin
+  local.get $end
   i32.const 0
   i32.lt_s
   if (result i32)
-   local.get $3
-   local.get $2
+   local.get $length
+   local.get $end
    i32.add
-   local.tee $4
+   local.tee $var$4
    i32.const 0
-   local.tee $5
-   local.get $4
-   local.get $5
+   local.tee $var$5
+   local.get $var$4
+   local.get $var$5
    i32.gt_s
    select
   else
-   local.get $2
-   local.tee $5
-   local.get $3
-   local.tee $4
-   local.get $5
-   local.get $4
+   local.get $end
+   local.tee $var$5
+   local.get $length
+   local.tee $var$4
+   local.get $var$5
+   local.get $var$4
    i32.lt_s
    select
   end
-  local.set $2
-  local.get $2
-  local.get $1
+  local.set $end
+  local.get $end
+  local.get $begin
   i32.sub
-  local.tee $4
+  local.tee $var$4
   i32.const 0
-  local.tee $5
-  local.get $4
-  local.get $5
+  local.tee $var$5
+  local.get $var$4
+  local.get $var$5
   i32.gt_s
   select
-  local.set $6
+  local.set $outSize
   global.get $~lib/memory/__stack_pointer
-  local.get $6
+  local.get $outSize
   i32.const 0
   call $~lib/rt/itcms/__new
-  local.tee $7
+  local.tee $out
   i32.store $0
-  local.get $7
-  local.get $0
-  local.get $1
+  local.get $out
+  local.get $this
+  local.get $begin
   i32.add
-  local.get $6
+  local.get $outSize
   memory.copy $0 $0
-  local.get $7
+  local.get $out
   local.set $8
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -3312,8 +3312,8 @@
   global.set $~lib/memory/__stack_pointer
   local.get $8
  )
- (func $~lib/arraybuffer/ArrayBufferView#constructor (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
-  (local $3 i32)
+ (func $~lib/arraybuffer/ArrayBufferView#constructor (param $this i32) (param $length i32) (param $alignLog2 i32) (result i32)
+  (local $buffer i32)
   (local $4 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 8
@@ -3323,28 +3323,28 @@
   global.get $~lib/memory/__stack_pointer
   i64.const 0
   i64.store $0
-  local.get $0
+  local.get $this
   i32.eqz
   if
    global.get $~lib/memory/__stack_pointer
    i32.const 12
    i32.const 2
    call $~lib/rt/itcms/__new
-   local.tee $0
+   local.tee $this
    i32.store $0
   end
-  local.get $0
+  local.get $this
   i32.const 0
   call $~lib/arraybuffer/ArrayBufferView#set:buffer
-  local.get $0
+  local.get $this
   i32.const 0
   call $~lib/arraybuffer/ArrayBufferView#set:dataStart
-  local.get $0
+  local.get $this
   i32.const 0
   call $~lib/arraybuffer/ArrayBufferView#set:byteLength
-  local.get $1
+  local.get $length
   i32.const 1073741820
-  local.get $2
+  local.get $alignLog2
   i32.shr_u
   i32.gt_u
   if
@@ -3356,28 +3356,28 @@
    unreachable
   end
   global.get $~lib/memory/__stack_pointer
-  local.get $1
-  local.get $2
+  local.get $length
+  local.get $alignLog2
   i32.shl
-  local.tee $1
+  local.tee $length
   i32.const 0
   call $~lib/rt/itcms/__new
-  local.tee $3
+  local.tee $buffer
   i32.store $0 offset=4
   i32.const 2
   global.get $~lib/shared/runtime/Runtime.Incremental
   i32.ne
   drop
-  local.get $0
-  local.get $3
+  local.get $this
+  local.get $buffer
   call $~lib/arraybuffer/ArrayBufferView#set:buffer
-  local.get $0
-  local.get $3
+  local.get $this
+  local.get $buffer
   call $~lib/arraybuffer/ArrayBufferView#set:dataStart
-  local.get $0
-  local.get $1
+  local.get $this
+  local.get $length
   call $~lib/arraybuffer/ArrayBufferView#set:byteLength
-  local.get $0
+  local.get $this
   local.set $4
   global.get $~lib/memory/__stack_pointer
   i32.const 8
@@ -3385,7 +3385,7 @@
   global.set $~lib/memory/__stack_pointer
   local.get $4
  )
- (func $~lib/typedarray/Uint8Array#constructor (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/typedarray/Uint8Array#constructor (param $this i32) (param $length i32) (result i32)
   (local $2 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -3395,24 +3395,24 @@
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   i32.store $0
-  local.get $0
+  local.get $this
   i32.eqz
   if
    global.get $~lib/memory/__stack_pointer
    i32.const 12
    i32.const 5
    call $~lib/rt/itcms/__new
-   local.tee $0
+   local.tee $this
    i32.store $0
   end
   global.get $~lib/memory/__stack_pointer
-  local.get $0
-  local.get $1
+  local.get $this
+  local.get $length
   i32.const 0
   call $~lib/arraybuffer/ArrayBufferView#constructor
-  local.tee $0
+  local.tee $this
   i32.store $0
-  local.get $0
+  local.get $this
   local.set $2
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -3420,10 +3420,10 @@
   global.set $~lib/memory/__stack_pointer
   local.get $2
  )
- (func $~lib/rt/__newArray (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
-  (local $4 i32)
-  (local $5 i32)
-  (local $6 i32)
+ (func $~lib/rt/__newArray (param $length i32) (param $alignLog2 i32) (param $id i32) (param $data i32) (result i32)
+  (local $bufferSize i32)
+  (local $buffer i32)
+  (local $array i32)
   (local $7 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -3433,38 +3433,38 @@
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   i32.store $0
-  local.get $0
-  local.get $1
+  local.get $length
+  local.get $alignLog2
   i32.shl
-  local.set $4
+  local.set $bufferSize
   global.get $~lib/memory/__stack_pointer
-  local.get $4
+  local.get $bufferSize
   i32.const 0
-  local.get $3
+  local.get $data
   call $~lib/rt/__newBuffer
-  local.tee $5
+  local.tee $buffer
   i32.store $0
   i32.const 16
-  local.get $2
+  local.get $id
   call $~lib/rt/itcms/__new
-  local.set $6
-  local.get $6
-  local.get $5
+  local.set $array
+  local.get $array
+  local.get $buffer
   i32.store $0
-  local.get $6
-  local.get $5
+  local.get $array
+  local.get $buffer
   i32.const 0
   call $~lib/rt/itcms/__link
-  local.get $6
-  local.get $5
+  local.get $array
+  local.get $buffer
   i32.store $0 offset=4
-  local.get $6
-  local.get $4
+  local.get $array
+  local.get $bufferSize
   i32.store $0 offset=8
-  local.get $6
-  local.get $0
+  local.get $array
+  local.get $length
   i32.store $0 offset=12
-  local.get $6
+  local.get $array
   local.set $7
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -3472,7 +3472,7 @@
   global.set $~lib/memory/__stack_pointer
   local.get $7
  )
- (func $~lib/typedarray/Int32Array#constructor (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/typedarray/Int32Array#constructor (param $this i32) (param $length i32) (result i32)
   (local $2 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -3482,24 +3482,24 @@
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   i32.store $0
-  local.get $0
+  local.get $this
   i32.eqz
   if
    global.get $~lib/memory/__stack_pointer
    i32.const 12
    i32.const 9
    call $~lib/rt/itcms/__new
-   local.tee $0
+   local.tee $this
    i32.store $0
   end
   global.get $~lib/memory/__stack_pointer
-  local.get $0
-  local.get $1
+  local.get $this
+  local.get $length
   i32.const 2
   call $~lib/arraybuffer/ArrayBufferView#constructor
-  local.tee $0
+  local.tee $this
   i32.store $0
-  local.get $0
+  local.get $this
   local.set $2
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -3507,8 +3507,8 @@
   global.set $~lib/memory/__stack_pointer
   local.get $2
  )
- (func $~lib/dataview/DataView#constructor (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
-  (local $4 i32)
+ (func $~lib/dataview/DataView#constructor (param $this i32) (param $buffer i32) (param $byteOffset i32) (param $byteLength i32) (result i32)
+  (local $dataStart i32)
   (local $5 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -3518,32 +3518,32 @@
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   i32.store $0
-  local.get $0
+  local.get $this
   i32.eqz
   if
    global.get $~lib/memory/__stack_pointer
    i32.const 12
    i32.const 15
    call $~lib/rt/itcms/__new
-   local.tee $0
+   local.tee $this
    i32.store $0
   end
-  local.get $0
+  local.get $this
   i32.const 0
   call $~lib/dataview/DataView#set:buffer
-  local.get $0
+  local.get $this
   i32.const 0
   call $~lib/dataview/DataView#set:dataStart
-  local.get $0
+  local.get $this
   i32.const 0
   call $~lib/dataview/DataView#set:byteLength
-  local.get $3
+  local.get $byteLength
   i32.const 1073741820
   i32.gt_u
-  local.get $2
-  local.get $3
+  local.get $byteOffset
+  local.get $byteLength
   i32.add
-  local.get $1
+  local.get $buffer
   call $~lib/arraybuffer/ArrayBuffer#get:byteLength
   i32.gt_u
   i32.or
@@ -3555,20 +3555,20 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $0
-  local.get $1
+  local.get $this
+  local.get $buffer
   call $~lib/dataview/DataView#set:buffer
-  local.get $1
-  local.get $2
+  local.get $buffer
+  local.get $byteOffset
   i32.add
-  local.set $4
-  local.get $0
-  local.get $4
+  local.set $dataStart
+  local.get $this
+  local.get $dataStart
   call $~lib/dataview/DataView#set:dataStart
-  local.get $0
-  local.get $3
+  local.get $this
+  local.get $byteLength
   call $~lib/dataview/DataView#set:byteLength
-  local.get $0
+  local.get $this
   local.set $5
   global.get $~lib/memory/__stack_pointer
   i32.const 4

--- a/tests/compiler/std/dataview.debug.wat
+++ b/tests/compiler/std/dataview.debug.wat
@@ -5034,8 +5034,8 @@
   i32.add
   global.set $~lib/memory/__stack_pointer
  )
- (func $~lib/arraybuffer/ArrayBufferView#constructor (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
-  (local $3 i32)
+ (func $~lib/arraybuffer/ArrayBufferView#constructor (param $this i32) (param $length i32) (param $alignLog2 i32) (result i32)
+  (local $buffer i32)
   (local $4 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 8
@@ -5045,28 +5045,28 @@
   global.get $~lib/memory/__stack_pointer
   i64.const 0
   i64.store $0
-  local.get $0
+  local.get $this
   i32.eqz
   if
    global.get $~lib/memory/__stack_pointer
    i32.const 12
    i32.const 2
    call $~lib/rt/itcms/__new
-   local.tee $0
+   local.tee $this
    i32.store $0
   end
-  local.get $0
+  local.get $this
   i32.const 0
   call $~lib/arraybuffer/ArrayBufferView#set:buffer
-  local.get $0
+  local.get $this
   i32.const 0
   call $~lib/arraybuffer/ArrayBufferView#set:dataStart
-  local.get $0
+  local.get $this
   i32.const 0
   call $~lib/arraybuffer/ArrayBufferView#set:byteLength
-  local.get $1
+  local.get $length
   i32.const 1073741820
-  local.get $2
+  local.get $alignLog2
   i32.shr_u
   i32.gt_u
   if
@@ -5078,28 +5078,28 @@
    unreachable
   end
   global.get $~lib/memory/__stack_pointer
-  local.get $1
-  local.get $2
+  local.get $length
+  local.get $alignLog2
   i32.shl
-  local.tee $1
+  local.tee $length
   i32.const 0
   call $~lib/rt/itcms/__new
-  local.tee $3
+  local.tee $buffer
   i32.store $0 offset=4
   i32.const 2
   global.get $~lib/shared/runtime/Runtime.Incremental
   i32.ne
   drop
-  local.get $0
-  local.get $3
+  local.get $this
+  local.get $buffer
   call $~lib/arraybuffer/ArrayBufferView#set:buffer
-  local.get $0
-  local.get $3
+  local.get $this
+  local.get $buffer
   call $~lib/arraybuffer/ArrayBufferView#set:dataStart
-  local.get $0
-  local.get $1
+  local.get $this
+  local.get $length
   call $~lib/arraybuffer/ArrayBufferView#set:byteLength
-  local.get $0
+  local.get $this
   local.set $4
   global.get $~lib/memory/__stack_pointer
   i32.const 8
@@ -5107,7 +5107,7 @@
   global.set $~lib/memory/__stack_pointer
   local.get $4
  )
- (func $~lib/typedarray/Uint8Array#constructor (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/typedarray/Uint8Array#constructor (param $this i32) (param $length i32) (result i32)
   (local $2 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -5117,24 +5117,24 @@
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   i32.store $0
-  local.get $0
+  local.get $this
   i32.eqz
   if
    global.get $~lib/memory/__stack_pointer
    i32.const 12
    i32.const 3
    call $~lib/rt/itcms/__new
-   local.tee $0
+   local.tee $this
    i32.store $0
   end
   global.get $~lib/memory/__stack_pointer
-  local.get $0
-  local.get $1
+  local.get $this
+  local.get $length
   i32.const 0
   call $~lib/arraybuffer/ArrayBufferView#constructor
-  local.tee $0
+  local.tee $this
   i32.store $0
-  local.get $0
+  local.get $this
   local.set $2
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -5142,8 +5142,8 @@
   global.set $~lib/memory/__stack_pointer
   local.get $2
  )
- (func $~lib/dataview/DataView#constructor (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
-  (local $4 i32)
+ (func $~lib/dataview/DataView#constructor (param $this i32) (param $buffer i32) (param $byteOffset i32) (param $byteLength i32) (result i32)
+  (local $dataStart i32)
   (local $5 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -5153,32 +5153,32 @@
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   i32.store $0
-  local.get $0
+  local.get $this
   i32.eqz
   if
    global.get $~lib/memory/__stack_pointer
    i32.const 12
    i32.const 4
    call $~lib/rt/itcms/__new
-   local.tee $0
+   local.tee $this
    i32.store $0
   end
-  local.get $0
+  local.get $this
   i32.const 0
   call $~lib/dataview/DataView#set:buffer
-  local.get $0
+  local.get $this
   i32.const 0
   call $~lib/dataview/DataView#set:dataStart
-  local.get $0
+  local.get $this
   i32.const 0
   call $~lib/dataview/DataView#set:byteLength
-  local.get $3
+  local.get $byteLength
   i32.const 1073741820
   i32.gt_u
-  local.get $2
-  local.get $3
+  local.get $byteOffset
+  local.get $byteLength
   i32.add
-  local.get $1
+  local.get $buffer
   call $~lib/arraybuffer/ArrayBuffer#get:byteLength
   i32.gt_u
   i32.or
@@ -5190,20 +5190,20 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $0
-  local.get $1
+  local.get $this
+  local.get $buffer
   call $~lib/dataview/DataView#set:buffer
-  local.get $1
-  local.get $2
+  local.get $buffer
+  local.get $byteOffset
   i32.add
-  local.set $4
-  local.get $0
-  local.get $4
+  local.set $dataStart
+  local.get $this
+  local.get $dataStart
   call $~lib/dataview/DataView#set:dataStart
-  local.get $0
-  local.get $3
+  local.get $this
+  local.get $byteLength
   call $~lib/dataview/DataView#set:byteLength
-  local.get $0
+  local.get $this
   local.set $5
   global.get $~lib/memory/__stack_pointer
   i32.const 4

--- a/tests/compiler/std/date.debug.wat
+++ b/tests/compiler/std/date.debug.wat
@@ -4520,7 +4520,7 @@
    unreachable
   end
  )
- (func $~lib/date/stringify (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/date/stringify (param $value i32) (param $padding i32) (result i32)
   (local $2 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 8
@@ -4530,7 +4530,7 @@
   global.get $~lib/memory/__stack_pointer
   i64.const 0
   i64.store $0
-  local.get $0
+  local.get $value
   i32.const 10
   call $~lib/number/I32#toString
   local.set $2
@@ -4538,7 +4538,7 @@
   local.get $2
   i32.store $0
   local.get $2
-  local.get $1
+  local.get $padding
   i32.const 848
   local.set $2
   global.get $~lib/memory/__stack_pointer
@@ -4553,23 +4553,23 @@
   global.set $~lib/memory/__stack_pointer
   local.get $2
  )
- (func $~lib/date/Date#toISOString (param $0 i32) (result i32)
-  (local $1 i32)
-  (local $2 i32)
-  (local $3 i32)
-  (local $4 i32)
-  (local $5 i32)
-  (local $6 i32)
-  (local $7 i32)
-  (local $8 i32)
-  (local $9 i32)
-  (local $10 i32)
-  (local $11 i32)
-  (local $12 i32)
-  (local $13 i32)
-  (local $14 i32)
-  (local $15 i32)
-  (local $16 i32)
+ (func $~lib/date/Date#toISOString (param $this i32) (result i32)
+  (local $yr i32)
+  (local $isNeg i32)
+  (local $var$3 i32)
+  (local $var$4 i32)
+  (local $year i32)
+  (local $month i32)
+  (local $day i32)
+  (local $hours i32)
+  (local $mins i32)
+  (local $secs i32)
+  (local $ms i32)
+  (local $var$12 i32)
+  (local $var$13 i32)
+  (local $var$14 i32)
+  (local $var$15 i32)
+  (local $var$16 i32)
   (local $17 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 36
@@ -4580,24 +4580,24 @@
   i32.const 0
   i32.const 36
   memory.fill $0
-  local.get $0
+  local.get $this
   i32.load $0
-  local.set $1
-  local.get $1
+  local.set $yr
+  local.get $yr
   i32.const 0
   i32.lt_s
-  local.set $2
+  local.set $isNeg
   global.get $~lib/memory/__stack_pointer
-  local.get $2
+  local.get $isNeg
   if (result i32)
    i32.const 1
   else
-   local.get $1
+   local.get $yr
    i32.const 10000
    i32.ge_s
   end
   if (result i32)
-   local.get $2
+   local.get $isNeg
    if (result i32)
     i32.const 592
    else
@@ -4608,14 +4608,14 @@
    local.get $17
    i32.store $0
    local.get $17
-   local.get $1
-   local.tee $3
+   local.get $yr
+   local.tee $var$3
    i32.const 31
    i32.shr_s
-   local.tee $4
-   local.get $3
+   local.tee $var$4
+   local.get $var$3
    i32.add
-   local.get $4
+   local.get $var$4
    i32.xor
    i32.const 6
    call $~lib/date/stringify
@@ -4626,68 +4626,68 @@
    local.get $17
    call $~lib/string/String.__concat
   else
-   local.get $1
+   local.get $yr
    i32.const 4
    call $~lib/date/stringify
   end
-  local.tee $5
+  local.tee $year
   i32.store $0 offset=8
   global.get $~lib/memory/__stack_pointer
-  local.get $0
+  local.get $this
   i32.load $0 offset=4
   i32.const 2
   call $~lib/date/stringify
-  local.tee $6
+  local.tee $month
   i32.store $0 offset=12
   global.get $~lib/memory/__stack_pointer
-  local.get $0
+  local.get $this
   i32.load $0 offset=8
   i32.const 2
   call $~lib/date/stringify
-  local.tee $7
+  local.tee $day
   i32.store $0 offset=16
   global.get $~lib/memory/__stack_pointer
-  local.get $0
+  local.get $this
   call $~lib/date/Date#getUTCHours
   i32.const 2
   call $~lib/date/stringify
-  local.tee $8
+  local.tee $hours
   i32.store $0 offset=20
   global.get $~lib/memory/__stack_pointer
-  local.get $0
+  local.get $this
   call $~lib/date/Date#getUTCMinutes
   i32.const 2
   call $~lib/date/stringify
-  local.tee $9
+  local.tee $mins
   i32.store $0 offset=24
   global.get $~lib/memory/__stack_pointer
-  local.get $0
+  local.get $this
   call $~lib/date/Date#getUTCSeconds
   i32.const 2
   call $~lib/date/stringify
-  local.tee $10
+  local.tee $secs
   i32.store $0 offset=28
   global.get $~lib/memory/__stack_pointer
-  local.get $0
+  local.get $this
   call $~lib/date/Date#getUTCMilliseconds
   i32.const 3
   call $~lib/date/stringify
-  local.tee $11
+  local.tee $ms
   i32.store $0 offset=32
-  local.get $5
-  local.set $3
-  local.get $6
-  local.set $4
-  local.get $7
-  local.set $12
-  local.get $8
-  local.set $13
-  local.get $9
-  local.set $14
-  local.get $10
-  local.set $15
-  local.get $11
-  local.set $16
+  local.get $year
+  local.set $var$3
+  local.get $month
+  local.set $var$4
+  local.get $day
+  local.set $var$12
+  local.get $hours
+  local.set $var$13
+  local.get $mins
+  local.set $var$14
+  local.get $secs
+  local.set $var$15
+  local.get $ms
+  local.set $var$16
   i32.const 2592
   local.set $17
   global.get $~lib/memory/__stack_pointer
@@ -4695,7 +4695,7 @@
   i32.store $0
   local.get $17
   i32.const 0
-  local.get $3
+  local.get $var$3
   call $~lib/staticarray/StaticArray<~lib/string/String>#__uset
   i32.const 2592
   local.set $17
@@ -4704,7 +4704,7 @@
   i32.store $0
   local.get $17
   i32.const 2
-  local.get $4
+  local.get $var$4
   call $~lib/staticarray/StaticArray<~lib/string/String>#__uset
   i32.const 2592
   local.set $17
@@ -4713,7 +4713,7 @@
   i32.store $0
   local.get $17
   i32.const 4
-  local.get $12
+  local.get $var$12
   call $~lib/staticarray/StaticArray<~lib/string/String>#__uset
   i32.const 2592
   local.set $17
@@ -4722,7 +4722,7 @@
   i32.store $0
   local.get $17
   i32.const 6
-  local.get $13
+  local.get $var$13
   call $~lib/staticarray/StaticArray<~lib/string/String>#__uset
   i32.const 2592
   local.set $17
@@ -4731,7 +4731,7 @@
   i32.store $0
   local.get $17
   i32.const 8
-  local.get $14
+  local.get $var$14
   call $~lib/staticarray/StaticArray<~lib/string/String>#__uset
   i32.const 2592
   local.set $17
@@ -4740,7 +4740,7 @@
   i32.store $0
   local.get $17
   i32.const 10
-  local.get $15
+  local.get $var$15
   call $~lib/staticarray/StaticArray<~lib/string/String>#__uset
   i32.const 2592
   local.set $17
@@ -4749,7 +4749,7 @@
   i32.store $0
   local.get $17
   i32.const 12
-  local.get $16
+  local.get $var$16
   call $~lib/staticarray/StaticArray<~lib/string/String>#__uset
   i32.const 2592
   local.set $17
@@ -4771,22 +4771,22 @@
   global.set $~lib/memory/__stack_pointer
   local.get $17
  )
- (func $~lib/date/Date#toDateString (param $0 i32) (result i32)
-  (local $1 i32)
-  (local $2 i32)
-  (local $3 i32)
-  (local $4 i32)
-  (local $5 i32)
-  (local $6 i32)
-  (local $7 i32)
-  (local $8 i32)
-  (local $9 i32)
-  (local $10 i32)
-  (local $11 i32)
-  (local $12 i32)
-  (local $13 i32)
-  (local $14 i32)
-  (local $15 i32)
+ (func $~lib/date/Date#toDateString (param $this i32) (result i32)
+  (local $var$1 i32)
+  (local $var$2 i32)
+  (local $mo i32)
+  (local $da i32)
+  (local $yr i32)
+  (local $wd i32)
+  (local $var$7 i32)
+  (local $var$8 i32)
+  (local $year i32)
+  (local $month i32)
+  (local $week i32)
+  (local $day i32)
+  (local $var$13 i32)
+  (local $var$14 i32)
+  (local $var$15 i32)
   (local $16 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 36
@@ -4802,71 +4802,71 @@
   i32.const 4
   i32.const 3616
   call $~lib/rt/__newBuffer
-  local.tee $1
+  local.tee $var$1
   i32.store $0
   global.get $~lib/memory/__stack_pointer
   i32.const 48
   i32.const 4
   i32.const 4048
   call $~lib/rt/__newBuffer
-  local.tee $2
+  local.tee $var$2
   i32.store $0 offset=4
-  local.get $0
+  local.get $this
   i32.load $0 offset=4
-  local.set $3
-  local.get $0
+  local.set $mo
+  local.get $this
   i32.load $0 offset=8
-  local.set $4
-  local.get $0
+  local.set $da
+  local.get $this
   i32.load $0
-  local.set $5
-  local.get $5
-  local.get $3
-  local.get $4
+  local.set $yr
+  local.get $yr
+  local.get $mo
+  local.get $da
   call $~lib/date/dayOfWeek
-  local.set $6
+  local.set $wd
   global.get $~lib/memory/__stack_pointer
-  local.get $5
-  local.tee $7
+  local.get $yr
+  local.tee $var$7
   i32.const 31
   i32.shr_s
-  local.tee $8
-  local.get $7
+  local.tee $var$8
+  local.get $var$7
   i32.add
-  local.get $8
+  local.get $var$8
   i32.xor
   i32.const 4
   call $~lib/date/stringify
-  local.tee $9
+  local.tee $year
   i32.store $0 offset=8
   global.get $~lib/memory/__stack_pointer
-  local.get $2
-  local.get $3
+  local.get $var$2
+  local.get $mo
   i32.const 1
   i32.sub
   call $~lib/staticarray/StaticArray<~lib/string/String>#__uget
-  local.tee $10
+  local.tee $month
   i32.store $0 offset=12
   global.get $~lib/memory/__stack_pointer
-  local.get $1
-  local.get $6
+  local.get $var$1
+  local.get $wd
   call $~lib/staticarray/StaticArray<~lib/string/String>#__uget
-  local.tee $11
+  local.tee $week
   i32.store $0 offset=16
   global.get $~lib/memory/__stack_pointer
-  local.get $4
+  local.get $da
   i32.const 2
   call $~lib/date/stringify
-  local.tee $12
+  local.tee $day
   i32.store $0 offset=20
-  local.get $11
-  local.set $7
-  local.get $10
-  local.set $8
-  local.get $12
-  local.set $13
+  local.get $week
+  local.set $var$7
+  local.get $month
+  local.set $var$8
+  local.get $day
+  local.set $var$13
   global.get $~lib/memory/__stack_pointer
-  local.get $5
+  local.get $yr
   i32.const 0
   i32.lt_s
   if (result i32)
@@ -4874,10 +4874,10 @@
   else
    i32.const 4208
   end
-  local.tee $14
+  local.tee $var$14
   i32.store $0 offset=24
-  local.get $9
-  local.set $15
+  local.get $year
+  local.set $var$15
   i32.const 4128
   local.set $16
   global.get $~lib/memory/__stack_pointer
@@ -4885,7 +4885,7 @@
   i32.store $0 offset=28
   local.get $16
   i32.const 0
-  local.get $7
+  local.get $var$7
   call $~lib/staticarray/StaticArray<~lib/string/String>#__uset
   i32.const 4128
   local.set $16
@@ -4894,7 +4894,7 @@
   i32.store $0 offset=28
   local.get $16
   i32.const 1
-  local.get $8
+  local.get $var$8
   call $~lib/staticarray/StaticArray<~lib/string/String>#__uset
   i32.const 4128
   local.set $16
@@ -4903,7 +4903,7 @@
   i32.store $0 offset=28
   local.get $16
   i32.const 2
-  local.get $13
+  local.get $var$13
   call $~lib/staticarray/StaticArray<~lib/string/String>#__uset
   i32.const 4128
   local.set $16
@@ -4912,7 +4912,7 @@
   i32.store $0 offset=28
   local.get $16
   i32.const 3
-  local.get $14
+  local.get $var$14
   call $~lib/staticarray/StaticArray<~lib/string/String>#__uset
   i32.const 4128
   local.set $16
@@ -4921,7 +4921,7 @@
   i32.store $0 offset=28
   local.get $16
   i32.const 4
-  local.get $15
+  local.get $var$15
   call $~lib/staticarray/StaticArray<~lib/string/String>#__uset
   i32.const 4128
   local.set $16
@@ -4943,13 +4943,13 @@
   global.set $~lib/memory/__stack_pointer
   local.get $16
  )
- (func $~lib/date/Date#toTimeString (param $0 i32) (result i32)
-  (local $1 i32)
-  (local $2 i32)
-  (local $3 i32)
-  (local $4 i32)
-  (local $5 i32)
-  (local $6 i32)
+ (func $~lib/date/Date#toTimeString (param $this i32) (result i32)
+  (local $hours i32)
+  (local $mins i32)
+  (local $secs i32)
+  (local $var$4 i32)
+  (local $var$5 i32)
+  (local $var$6 i32)
   (local $7 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 20
@@ -4961,32 +4961,32 @@
   i32.const 20
   memory.fill $0
   global.get $~lib/memory/__stack_pointer
-  local.get $0
+  local.get $this
   call $~lib/date/Date#getUTCHours
   i32.const 2
   call $~lib/date/stringify
-  local.tee $1
+  local.tee $hours
   i32.store $0
   global.get $~lib/memory/__stack_pointer
-  local.get $0
+  local.get $this
   call $~lib/date/Date#getUTCMinutes
   i32.const 2
   call $~lib/date/stringify
-  local.tee $2
+  local.tee $mins
   i32.store $0 offset=4
   global.get $~lib/memory/__stack_pointer
-  local.get $0
+  local.get $this
   call $~lib/date/Date#getUTCSeconds
   i32.const 2
   call $~lib/date/stringify
-  local.tee $3
+  local.tee $secs
   i32.store $0 offset=8
-  local.get $1
-  local.set $4
-  local.get $2
-  local.set $5
-  local.get $3
-  local.set $6
+  local.get $hours
+  local.set $var$4
+  local.get $mins
+  local.set $var$5
+  local.get $secs
+  local.set $var$6
   i32.const 4432
   local.set $7
   global.get $~lib/memory/__stack_pointer
@@ -4994,7 +4994,7 @@
   i32.store $0 offset=12
   local.get $7
   i32.const 0
-  local.get $4
+  local.get $var$4
   call $~lib/staticarray/StaticArray<~lib/string/String>#__uset
   i32.const 4432
   local.set $7
@@ -5003,7 +5003,7 @@
   i32.store $0 offset=12
   local.get $7
   i32.const 2
-  local.get $5
+  local.get $var$5
   call $~lib/staticarray/StaticArray<~lib/string/String>#__uset
   i32.const 4432
   local.set $7
@@ -5012,7 +5012,7 @@
   i32.store $0 offset=12
   local.get $7
   i32.const 4
-  local.get $6
+  local.get $var$6
   call $~lib/staticarray/StaticArray<~lib/string/String>#__uset
   i32.const 4432
   local.set $7
@@ -5034,28 +5034,28 @@
   global.set $~lib/memory/__stack_pointer
   local.get $7
  )
- (func $~lib/date/Date#toUTCString (param $0 i32) (result i32)
-  (local $1 i32)
-  (local $2 i32)
-  (local $3 i32)
-  (local $4 i32)
-  (local $5 i32)
-  (local $6 i32)
-  (local $7 i32)
-  (local $8 i32)
-  (local $9 i32)
-  (local $10 i32)
-  (local $11 i32)
-  (local $12 i32)
-  (local $13 i32)
-  (local $14 i32)
-  (local $15 i32)
-  (local $16 i32)
-  (local $17 i32)
-  (local $18 i32)
-  (local $19 i32)
-  (local $20 i32)
-  (local $21 i32)
+ (func $~lib/date/Date#toUTCString (param $this i32) (result i32)
+  (local $var$1 i32)
+  (local $var$2 i32)
+  (local $mo i32)
+  (local $da i32)
+  (local $yr i32)
+  (local $wd i32)
+  (local $var$7 i32)
+  (local $var$8 i32)
+  (local $year i32)
+  (local $month i32)
+  (local $week i32)
+  (local $day i32)
+  (local $hours i32)
+  (local $mins i32)
+  (local $secs i32)
+  (local $var$16 i32)
+  (local $var$17 i32)
+  (local $var$18 i32)
+  (local $var$19 i32)
+  (local $var$20 i32)
+  (local $var$21 i32)
   (local $22 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 48
@@ -5071,92 +5071,92 @@
   i32.const 4
   i32.const 4800
   call $~lib/rt/__newBuffer
-  local.tee $1
+  local.tee $var$1
   i32.store $0
   global.get $~lib/memory/__stack_pointer
   i32.const 48
   i32.const 4
   i32.const 5232
   call $~lib/rt/__newBuffer
-  local.tee $2
+  local.tee $var$2
   i32.store $0 offset=4
-  local.get $0
+  local.get $this
   i32.load $0 offset=4
-  local.set $3
-  local.get $0
+  local.set $mo
+  local.get $this
   i32.load $0 offset=8
-  local.set $4
-  local.get $0
+  local.set $da
+  local.get $this
   i32.load $0
-  local.set $5
-  local.get $5
-  local.get $3
-  local.get $4
+  local.set $yr
+  local.get $yr
+  local.get $mo
+  local.get $da
   call $~lib/date/dayOfWeek
-  local.set $6
+  local.set $wd
   global.get $~lib/memory/__stack_pointer
-  local.get $5
-  local.tee $7
+  local.get $yr
+  local.tee $var$7
   i32.const 31
   i32.shr_s
-  local.tee $8
-  local.get $7
+  local.tee $var$8
+  local.get $var$7
   i32.add
-  local.get $8
+  local.get $var$8
   i32.xor
   i32.const 4
   call $~lib/date/stringify
-  local.tee $9
+  local.tee $year
   i32.store $0 offset=8
   global.get $~lib/memory/__stack_pointer
-  local.get $2
-  local.get $3
+  local.get $var$2
+  local.get $mo
   i32.const 1
   i32.sub
   call $~lib/staticarray/StaticArray<~lib/string/String>#__uget
-  local.tee $10
+  local.tee $month
   i32.store $0 offset=12
   global.get $~lib/memory/__stack_pointer
-  local.get $1
-  local.get $6
+  local.get $var$1
+  local.get $wd
   call $~lib/staticarray/StaticArray<~lib/string/String>#__uget
-  local.tee $11
+  local.tee $week
   i32.store $0 offset=16
   global.get $~lib/memory/__stack_pointer
-  local.get $4
+  local.get $da
   i32.const 2
   call $~lib/date/stringify
-  local.tee $12
+  local.tee $day
   i32.store $0 offset=20
   global.get $~lib/memory/__stack_pointer
-  local.get $0
+  local.get $this
   call $~lib/date/Date#getUTCHours
   i32.const 2
   call $~lib/date/stringify
-  local.tee $13
+  local.tee $hours
   i32.store $0 offset=24
   global.get $~lib/memory/__stack_pointer
-  local.get $0
+  local.get $this
   call $~lib/date/Date#getUTCMinutes
   i32.const 2
   call $~lib/date/stringify
-  local.tee $14
+  local.tee $mins
   i32.store $0 offset=28
   global.get $~lib/memory/__stack_pointer
-  local.get $0
+  local.get $this
   call $~lib/date/Date#getUTCSeconds
   i32.const 2
   call $~lib/date/stringify
-  local.tee $15
+  local.tee $secs
   i32.store $0 offset=32
-  local.get $11
-  local.set $7
-  local.get $12
-  local.set $8
-  local.get $10
-  local.set $16
+  local.get $week
+  local.set $var$7
+  local.get $day
+  local.set $var$8
+  local.get $month
+  local.set $var$16
   global.get $~lib/memory/__stack_pointer
-  local.get $5
+  local.get $yr
   i32.const 0
   i32.lt_s
   if (result i32)
@@ -5164,16 +5164,16 @@
   else
    i32.const 2432
   end
-  local.tee $17
+  local.tee $var$17
   i32.store $0 offset=36
-  local.get $9
-  local.set $18
-  local.get $13
-  local.set $19
-  local.get $14
-  local.set $20
-  local.get $15
-  local.set $21
+  local.get $year
+  local.set $var$18
+  local.get $hours
+  local.set $var$19
+  local.get $mins
+  local.set $var$20
+  local.get $secs
+  local.set $var$21
   i32.const 5344
   local.set $22
   global.get $~lib/memory/__stack_pointer
@@ -5181,7 +5181,7 @@
   i32.store $0 offset=40
   local.get $22
   i32.const 0
-  local.get $7
+  local.get $var$7
   call $~lib/staticarray/StaticArray<~lib/string/String>#__uset
   i32.const 5344
   local.set $22
@@ -5190,7 +5190,7 @@
   i32.store $0 offset=40
   local.get $22
   i32.const 1
-  local.get $8
+  local.get $var$8
   call $~lib/staticarray/StaticArray<~lib/string/String>#__uset
   i32.const 5344
   local.set $22
@@ -5199,7 +5199,7 @@
   i32.store $0 offset=40
   local.get $22
   i32.const 2
-  local.get $16
+  local.get $var$16
   call $~lib/staticarray/StaticArray<~lib/string/String>#__uset
   i32.const 5344
   local.set $22
@@ -5208,7 +5208,7 @@
   i32.store $0 offset=40
   local.get $22
   i32.const 3
-  local.get $17
+  local.get $var$17
   call $~lib/staticarray/StaticArray<~lib/string/String>#__uset
   i32.const 5344
   local.set $22
@@ -5217,7 +5217,7 @@
   i32.store $0 offset=40
   local.get $22
   i32.const 4
-  local.get $18
+  local.get $var$18
   call $~lib/staticarray/StaticArray<~lib/string/String>#__uset
   i32.const 5344
   local.set $22
@@ -5226,7 +5226,7 @@
   i32.store $0 offset=40
   local.get $22
   i32.const 6
-  local.get $19
+  local.get $var$19
   call $~lib/staticarray/StaticArray<~lib/string/String>#__uset
   i32.const 5344
   local.set $22
@@ -5235,7 +5235,7 @@
   i32.store $0 offset=40
   local.get $22
   i32.const 8
-  local.get $20
+  local.get $var$20
   call $~lib/staticarray/StaticArray<~lib/string/String>#__uset
   i32.const 5344
   local.set $22
@@ -5244,7 +5244,7 @@
   i32.store $0 offset=40
   local.get $22
   i32.const 10
-  local.get $21
+  local.get $var$21
   call $~lib/staticarray/StaticArray<~lib/string/String>#__uset
   i32.const 5344
   local.set $22
@@ -5266,19 +5266,19 @@
   global.set $~lib/memory/__stack_pointer
   local.get $22
  )
- (func $~lib/string/String#split (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
-  (local $3 i32)
-  (local $4 i32)
-  (local $5 i32)
-  (local $6 i32)
-  (local $7 i32)
-  (local $8 i32)
-  (local $9 i32)
-  (local $10 i32)
-  (local $11 i32)
-  (local $12 i32)
-  (local $13 i32)
-  (local $14 i32)
+ (func $~lib/string/String#split (param $this i32) (param $separator i32) (param $limit i32) (result i32)
+  (local $len i32)
+  (local $var$4 i32)
+  (local $length i32)
+  (local $sepLen i32)
+  (local $var$7 i32)
+  (local $var$8 i32)
+  (local $var$9 i32)
+  (local $result i32)
+  (local $end i32)
+  (local $start i32)
+  (local $i i32)
+  (local $len_0 i32)
   (local $15 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 24
@@ -5289,7 +5289,7 @@
   i32.const 0
   i32.const 24
   memory.fill $0
-  local.get $2
+  local.get $limit
   i32.eqz
   if
    i32.const 0
@@ -5305,7 +5305,7 @@
    local.get $15
    return
   end
-  local.get $1
+  local.get $separator
   i32.const 0
   i32.eq
   if
@@ -5315,18 +5315,18 @@
    i32.const 5
    i32.const 0
    call $~lib/rt/__newArray
-   local.tee $3
+   local.tee $len
    i32.store $0
    global.get $~lib/memory/__stack_pointer
-   local.get $3
+   local.get $len
    i32.load $0 offset=4
-   local.tee $4
+   local.tee $var$4
    i32.store $0 offset=4
-   local.get $3
+   local.get $len
    i32.const 0
-   local.get $0
+   local.get $this
    call $~lib/array/Array<~lib/string/String>#__uset
-   local.get $3
+   local.get $len
    local.set $15
    global.get $~lib/memory/__stack_pointer
    i32.const 24
@@ -5335,23 +5335,23 @@
    local.get $15
    return
   end
-  local.get $0
+  local.get $this
   call $~lib/string/String#get:length
-  local.set $5
-  local.get $1
+  local.set $length
+  local.get $separator
   call $~lib/string/String#get:length
-  local.set $6
-  local.get $2
+  local.set $sepLen
+  local.get $limit
   i32.const 0
   i32.lt_s
   if
    global.get $~lib/builtins/i32.MAX_VALUE
-   local.set $2
+   local.set $limit
   end
-  local.get $6
+  local.get $sepLen
   i32.eqz
   if
-   local.get $5
+   local.get $length
    i32.eqz
    if
     i32.const 0
@@ -5367,68 +5367,68 @@
     local.get $15
     return
    end
-   local.get $5
-   local.tee $3
-   local.get $2
-   local.tee $4
-   local.get $3
-   local.get $4
+   local.get $length
+   local.tee $len
+   local.get $limit
+   local.tee $var$4
+   local.get $len
+   local.get $var$4
    i32.lt_s
    select
-   local.set $5
+   local.set $length
    global.get $~lib/memory/__stack_pointer
-   local.get $5
+   local.get $length
    i32.const 2
    i32.const 5
    i32.const 0
    call $~lib/rt/__newArray
-   local.tee $3
+   local.tee $len
    i32.store $0
-   local.get $3
+   local.get $len
    i32.load $0 offset=4
-   local.set $4
+   local.set $var$4
    i32.const 0
-   local.set $7
+   local.set $var$7
    loop $for-loop|0
-    local.get $7
-    local.get $5
+    local.get $var$7
+    local.get $length
     i32.lt_s
-    local.set $8
-    local.get $8
+    local.set $var$8
+    local.get $var$8
     if
      global.get $~lib/memory/__stack_pointer
      i32.const 2
      i32.const 1
      call $~lib/rt/itcms/__new
-     local.tee $9
+     local.tee $var$9
      i32.store $0 offset=8
-     local.get $9
-     local.get $0
-     local.get $7
+     local.get $var$9
+     local.get $this
+     local.get $var$7
      i32.const 1
      i32.shl
      i32.add
      i32.load16_u $0
      i32.store16 $0
-     local.get $4
-     local.get $7
+     local.get $var$4
+     local.get $var$7
      i32.const 2
      i32.shl
      i32.add
-     local.get $9
+     local.get $var$9
      i32.store $0
-     local.get $3
-     local.get $9
+     local.get $len
+     local.get $var$9
      i32.const 1
      call $~lib/rt/itcms/__link
-     local.get $7
+     local.get $var$7
      i32.const 1
      i32.add
-     local.set $7
+     local.set $var$7
      br $for-loop|0
     end
    end
-   local.get $3
+   local.get $len
    local.set $15
    global.get $~lib/memory/__stack_pointer
    i32.const 24
@@ -5437,7 +5437,7 @@
    local.get $15
    return
   else
-   local.get $5
+   local.get $length
    i32.eqz
    if
     global.get $~lib/memory/__stack_pointer
@@ -5446,13 +5446,13 @@
     i32.const 5
     i32.const 0
     call $~lib/rt/__newArray
-    local.tee $4
+    local.tee $var$4
     i32.store $0 offset=4
-    local.get $4
+    local.get $var$4
     i32.load $0 offset=4
     i32.const 2432
     i32.store $0
-    local.get $4
+    local.get $var$4
     local.set $15
     global.get $~lib/memory/__stack_pointer
     i32.const 24
@@ -5468,57 +5468,57 @@
   i32.const 5
   i32.const 0
   call $~lib/rt/__newArray
-  local.tee $10
+  local.tee $result
   i32.store $0 offset=12
   i32.const 0
-  local.set $11
+  local.set $end
   i32.const 0
-  local.set $12
+  local.set $start
   i32.const 0
-  local.set $13
+  local.set $i
   loop $while-continue|1
-   local.get $0
-   local.get $1
-   local.get $12
+   local.get $this
+   local.get $separator
+   local.get $start
    call $~lib/string/String#indexOf
-   local.tee $11
+   local.tee $end
    i32.const -1
    i32.xor
-   local.set $4
-   local.get $4
+   local.set $var$4
+   local.get $var$4
    if
-    local.get $11
-    local.get $12
+    local.get $end
+    local.get $start
     i32.sub
-    local.set $3
-    local.get $3
+    local.set $len
+    local.get $len
     i32.const 0
     i32.gt_s
     if
      global.get $~lib/memory/__stack_pointer
-     local.get $3
+     local.get $len
      i32.const 1
      i32.shl
      i32.const 1
      call $~lib/rt/itcms/__new
-     local.tee $7
+     local.tee $var$7
      i32.store $0 offset=16
-     local.get $7
-     local.get $0
-     local.get $12
+     local.get $var$7
+     local.get $this
+     local.get $start
      i32.const 1
      i32.shl
      i32.add
-     local.get $3
+     local.get $len
      i32.const 1
      i32.shl
      memory.copy $0 $0
-     local.get $10
-     local.get $7
+     local.get $result
+     local.get $var$7
      call $~lib/array/Array<~lib/string/String>#push
      drop
     else
-     local.get $10
+     local.get $result
      i32.const 2432
      local.set $15
      global.get $~lib/memory/__stack_pointer
@@ -5528,14 +5528,14 @@
      call $~lib/array/Array<~lib/string/String>#push
      drop
     end
-    local.get $13
+    local.get $i
     i32.const 1
     i32.add
-    local.tee $13
-    local.get $2
+    local.tee $i
+    local.get $limit
     i32.eq
     if
-     local.get $10
+     local.get $result
      local.set $15
      global.get $~lib/memory/__stack_pointer
      i32.const 24
@@ -5544,21 +5544,21 @@
      local.get $15
      return
     end
-    local.get $11
-    local.get $6
+    local.get $end
+    local.get $sepLen
     i32.add
-    local.set $12
+    local.set $start
     br $while-continue|1
    end
   end
-  local.get $12
+  local.get $start
   i32.eqz
   if
-   local.get $10
-   local.get $0
+   local.get $result
+   local.get $this
    call $~lib/array/Array<~lib/string/String>#push
    drop
-   local.get $10
+   local.get $result
    local.set $15
    global.get $~lib/memory/__stack_pointer
    i32.const 24
@@ -5567,38 +5567,38 @@
    local.get $15
    return
   end
-  local.get $5
-  local.get $12
+  local.get $length
+  local.get $start
   i32.sub
-  local.set $14
-  local.get $14
+  local.set $len_0
+  local.get $len_0
   i32.const 0
   i32.gt_s
   if
    global.get $~lib/memory/__stack_pointer
-   local.get $14
+   local.get $len_0
    i32.const 1
    i32.shl
    i32.const 1
    call $~lib/rt/itcms/__new
-   local.tee $4
+   local.tee $var$4
    i32.store $0 offset=4
-   local.get $4
-   local.get $0
-   local.get $12
+   local.get $var$4
+   local.get $this
+   local.get $start
    i32.const 1
    i32.shl
    i32.add
-   local.get $14
+   local.get $len_0
    i32.const 1
    i32.shl
    memory.copy $0 $0
-   local.get $10
-   local.get $4
+   local.get $result
+   local.get $var$4
    call $~lib/array/Array<~lib/string/String>#push
    drop
   else
-   local.get $10
+   local.get $result
    i32.const 2432
    local.set $15
    global.get $~lib/memory/__stack_pointer
@@ -5608,7 +5608,7 @@
    call $~lib/array/Array<~lib/string/String>#push
    drop
   end
-  local.get $10
+  local.get $result
   local.set $15
   global.get $~lib/memory/__stack_pointer
   i32.const 24
@@ -5616,23 +5616,23 @@
   global.set $~lib/memory/__stack_pointer
   local.get $15
  )
- (func $~lib/date/Date.fromString (param $0 i32) (result i32)
-  (local $1 i32)
-  (local $2 i32)
-  (local $3 i32)
-  (local $4 i32)
-  (local $5 i32)
-  (local $6 i32)
-  (local $7 i32)
-  (local $8 i32)
-  (local $9 i32)
-  (local $10 i32)
-  (local $11 i32)
-  (local $12 i32)
-  (local $13 i32)
-  (local $14 i32)
-  (local $15 i32)
-  (local $16 i32)
+ (func $~lib/date/Date.fromString (param $dateTimeString i32) (result i32)
+  (local $hour i32)
+  (local $min i32)
+  (local $sec i32)
+  (local $ms i32)
+  (local $dateString i32)
+  (local $posT i32)
+  (local $var$7 i32)
+  (local $var$8 i32)
+  (local $var$9 i32)
+  (local $var$10 i32)
+  (local $var$11 i32)
+  (local $parts i32)
+  (local $year i32)
+  (local $month i32)
+  (local $day i32)
+  (local $len i32)
   (local $17 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 28
@@ -5643,7 +5643,7 @@
   i32.const 0
   i32.const 28
   memory.fill $0
-  local.get $0
+  local.get $dateTimeString
   call $~lib/string/String#get:length
   i32.eqz
   if
@@ -5655,16 +5655,16 @@
    unreachable
   end
   i32.const 0
-  local.set $1
+  local.set $hour
   i32.const 0
-  local.set $2
+  local.set $min
   i32.const 0
-  local.set $3
+  local.set $sec
   i32.const 0
-  local.set $4
-  local.get $0
-  local.set $5
-  local.get $0
+  local.set $ms
+  local.get $dateTimeString
+  local.set $dateString
+  local.get $dateTimeString
   i32.const 2464
   local.set $17
   global.get $~lib/memory/__stack_pointer
@@ -5673,29 +5673,29 @@
   local.get $17
   i32.const 0
   call $~lib/string/String#indexOf
-  local.set $6
-  local.get $6
+  local.set $posT
+  local.get $posT
   i32.const -1
   i32.xor
   if
    global.get $~lib/memory/__stack_pointer
-   local.get $0
+   local.get $dateTimeString
    i32.const 0
-   local.get $6
+   local.get $posT
    call $~lib/string/String#substring
-   local.tee $5
+   local.tee $dateString
    i32.store $0 offset=4
    global.get $~lib/memory/__stack_pointer
-   local.get $0
-   local.get $6
+   local.get $dateTimeString
+   local.get $posT
    i32.const 1
    i32.add
    global.get $~lib/builtins/i32.MAX_VALUE
    call $~lib/string/String#substring
-   local.tee $7
+   local.tee $var$7
    i32.store $0 offset=8
    global.get $~lib/memory/__stack_pointer
-   local.get $7
+   local.get $var$7
    i32.const 2496
    local.set $17
    global.get $~lib/memory/__stack_pointer
@@ -5704,12 +5704,12 @@
    local.get $17
    global.get $~lib/builtins/i32.MAX_VALUE
    call $~lib/string/String#split
-   local.tee $8
+   local.tee $var$8
    i32.store $0 offset=12
-   local.get $8
+   local.get $var$8
    call $~lib/array/Array<~lib/string/String>#get:length
-   local.set $9
-   local.get $9
+   local.set $var$9
+   local.get $var$9
    i32.const 1
    i32.le_s
    if
@@ -5720,7 +5720,7 @@
     call $~lib/builtins/abort
     unreachable
    end
-   local.get $8
+   local.get $var$8
    i32.const 0
    call $~lib/array/Array<~lib/string/String>#__get
    local.set $17
@@ -5730,8 +5730,8 @@
    local.get $17
    i32.const 0
    call $~lib/number/I32.parseInt
-   local.set $1
-   local.get $8
+   local.set $hour
+   local.get $var$8
    i32.const 1
    call $~lib/array/Array<~lib/string/String>#__get
    local.set $17
@@ -5741,18 +5741,18 @@
    local.get $17
    i32.const 0
    call $~lib/number/I32.parseInt
-   local.set $2
-   local.get $9
+   local.set $min
+   local.get $var$9
    i32.const 3
    i32.ge_s
    if
     global.get $~lib/memory/__stack_pointer
-    local.get $8
+    local.get $var$8
     i32.const 2
     call $~lib/array/Array<~lib/string/String>#__get
-    local.tee $10
+    local.tee $var$10
     i32.store $0 offset=20
-    local.get $10
+    local.get $var$10
     i32.const 2528
     local.set $17
     global.get $~lib/memory/__stack_pointer
@@ -5761,14 +5761,14 @@
     local.get $17
     i32.const 0
     call $~lib/string/String#indexOf
-    local.set $11
-    local.get $11
+    local.set $var$11
+    local.get $var$11
     i32.const -1
     i32.xor
     if
-     local.get $10
+     local.get $var$10
      i32.const 0
-     local.get $11
+     local.get $var$11
      call $~lib/string/String#substring
      local.set $17
      global.get $~lib/memory/__stack_pointer
@@ -5777,9 +5777,9 @@
      local.get $17
      i32.const 0
      call $~lib/number/I32.parseInt
-     local.set $3
-     local.get $10
-     local.get $11
+     local.set $sec
+     local.get $var$10
+     local.get $var$11
      i32.const 1
      i32.add
      global.get $~lib/builtins/i32.MAX_VALUE
@@ -5791,17 +5791,17 @@
      local.get $17
      i32.const 0
      call $~lib/number/I32.parseInt
-     local.set $4
+     local.set $ms
     else
-     local.get $10
+     local.get $var$10
      i32.const 0
      call $~lib/number/I32.parseInt
-     local.set $3
+     local.set $sec
     end
    end
   end
   global.get $~lib/memory/__stack_pointer
-  local.get $5
+  local.get $dateString
   i32.const 592
   local.set $17
   global.get $~lib/memory/__stack_pointer
@@ -5810,9 +5810,9 @@
   local.get $17
   global.get $~lib/builtins/i32.MAX_VALUE
   call $~lib/string/String#split
-  local.tee $12
+  local.tee $parts
   i32.store $0 offset=24
-  local.get $12
+  local.get $parts
   i32.const 0
   call $~lib/array/Array<~lib/string/String>#__get
   local.set $17
@@ -5822,19 +5822,19 @@
   local.get $17
   i32.const 0
   call $~lib/number/I32.parseInt
-  local.set $13
+  local.set $year
   i32.const 1
-  local.set $14
+  local.set $month
   i32.const 1
-  local.set $15
-  local.get $12
+  local.set $day
+  local.get $parts
   call $~lib/array/Array<~lib/string/String>#get:length
-  local.set $16
-  local.get $16
+  local.set $len
+  local.get $len
   i32.const 2
   i32.ge_s
   if
-   local.get $12
+   local.get $parts
    i32.const 1
    call $~lib/array/Array<~lib/string/String>#__get
    local.set $17
@@ -5844,12 +5844,12 @@
    local.get $17
    i32.const 0
    call $~lib/number/I32.parseInt
-   local.set $14
-   local.get $16
+   local.set $month
+   local.get $len
    i32.const 3
    i32.ge_s
    if
-    local.get $12
+    local.get $parts
     i32.const 2
     call $~lib/array/Array<~lib/string/String>#__get
     local.set $17
@@ -5859,17 +5859,17 @@
     local.get $17
     i32.const 0
     call $~lib/number/I32.parseInt
-    local.set $15
+    local.set $day
    end
   end
   i32.const 0
-  local.get $13
-  local.get $14
-  local.get $15
-  local.get $1
-  local.get $2
-  local.get $3
-  local.get $4
+  local.get $year
+  local.get $month
+  local.get $day
+  local.get $hour
+  local.get $min
+  local.get $sec
+  local.get $ms
   call $~lib/date/epochMillis
   call $~lib/date/Date#constructor
   local.set $17
@@ -9069,7 +9069,7 @@
   i32.add
   global.set $~lib/memory/__stack_pointer
  )
- (func $~lib/date/Date#constructor (param $0 i32) (param $1 i64) (result i32)
+ (func $~lib/date/Date#constructor (param $this i32) (param $epochMillis i64) (result i32)
   (local $2 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -9079,29 +9079,29 @@
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   i32.store $0
-  local.get $0
+  local.get $this
   i32.eqz
   if
    global.get $~lib/memory/__stack_pointer
    i32.const 24
    i32.const 3
    call $~lib/rt/itcms/__new
-   local.tee $0
+   local.tee $this
    i32.store $0
   end
-  local.get $0
-  local.get $1
+  local.get $this
+  local.get $epochMillis
   call $~lib/date/Date#set:epochMillis
-  local.get $0
+  local.get $this
   i32.const 0
   call $~lib/date/Date#set:year
-  local.get $0
+  local.get $this
   i32.const 0
   call $~lib/date/Date#set:month
-  local.get $0
+  local.get $this
   i32.const 0
   call $~lib/date/Date#set:day
-  local.get $1
+  local.get $epochMillis
   call $~lib/date/invalidDate
   if
    i32.const 32
@@ -9111,17 +9111,17 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $0
-  local.get $1
+  local.get $this
+  local.get $epochMillis
   call $~lib/date/dateFromEpoch
   call $~lib/date/Date#set:year
-  local.get $0
+  local.get $this
   global.get $~lib/date/_month
   call $~lib/date/Date#set:month
-  local.get $0
+  local.get $this
   global.get $~lib/date/_day
   call $~lib/date/Date#set:day
-  local.get $0
+  local.get $this
   local.set $2
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -9129,13 +9129,13 @@
   global.set $~lib/memory/__stack_pointer
   local.get $2
  )
- (func $~lib/util/number/itoa32 (param $0 i32) (param $1 i32) (result i32)
-  (local $2 i32)
-  (local $3 i32)
-  (local $4 i32)
-  (local $5 i32)
-  (local $6 i32)
-  (local $7 i32)
+ (func $~lib/util/number/itoa32 (param $value i32) (param $radix i32) (result i32)
+  (local $sign i32)
+  (local $out i32)
+  (local $var$4 i32)
+  (local $var$5 i32)
+  (local $var$6 i32)
+  (local $var$7 i32)
   (local $8 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -9145,13 +9145,13 @@
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   i32.store $0
-  local.get $1
+  local.get $radix
   i32.const 2
   i32.lt_s
   if (result i32)
    i32.const 1
   else
-   local.get $1
+   local.get $radix
    i32.const 36
    i32.gt_s
   end
@@ -9163,7 +9163,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $0
+  local.get $value
   i32.eqz
   if
    i32.const 848
@@ -9175,128 +9175,128 @@
    local.get $8
    return
   end
-  local.get $0
+  local.get $value
   i32.const 31
   i32.shr_u
   i32.const 1
   i32.shl
-  local.set $2
-  local.get $2
+  local.set $sign
+  local.get $sign
   if
    i32.const 0
-   local.get $0
+   local.get $value
    i32.sub
-   local.set $0
+   local.set $value
   end
-  local.get $1
+  local.get $radix
   i32.const 10
   i32.eq
   if
-   local.get $0
+   local.get $value
    call $~lib/util/number/decimalCount32
-   local.set $4
+   local.set $var$4
    global.get $~lib/memory/__stack_pointer
-   local.get $4
+   local.get $var$4
    i32.const 1
    i32.shl
-   local.get $2
+   local.get $sign
    i32.add
    i32.const 1
    call $~lib/rt/itcms/__new
-   local.tee $3
+   local.tee $out
    i32.store $0
-   local.get $3
-   local.get $2
+   local.get $out
+   local.get $sign
    i32.add
-   local.set $7
-   local.get $0
-   local.set $6
-   local.get $4
-   local.set $5
+   local.set $var$7
+   local.get $value
+   local.set $var$6
+   local.get $var$4
+   local.set $var$5
    i32.const 0
    i32.const 1
    i32.ge_s
    drop
-   local.get $7
-   local.get $6
-   local.get $5
+   local.get $var$7
+   local.get $var$6
+   local.get $var$5
    call $~lib/util/number/utoa32_dec_lut
   else
-   local.get $1
+   local.get $radix
    i32.const 16
    i32.eq
    if
     i32.const 31
-    local.get $0
+    local.get $value
     i32.clz
     i32.sub
     i32.const 2
     i32.shr_s
     i32.const 1
     i32.add
-    local.set $4
+    local.set $var$4
     global.get $~lib/memory/__stack_pointer
-    local.get $4
+    local.get $var$4
     i32.const 1
     i32.shl
-    local.get $2
+    local.get $sign
     i32.add
     i32.const 1
     call $~lib/rt/itcms/__new
-    local.tee $3
+    local.tee $out
     i32.store $0
-    local.get $3
-    local.get $2
+    local.get $out
+    local.get $sign
     i32.add
-    local.set $7
-    local.get $0
-    local.set $6
-    local.get $4
-    local.set $5
+    local.set $var$7
+    local.get $value
+    local.set $var$6
+    local.get $var$4
+    local.set $var$5
     i32.const 0
     i32.const 1
     i32.ge_s
     drop
-    local.get $7
-    local.get $6
+    local.get $var$7
+    local.get $var$6
     i64.extend_i32_u
-    local.get $5
+    local.get $var$5
     call $~lib/util/number/utoa_hex_lut
    else
-    local.get $0
-    local.set $4
-    local.get $4
+    local.get $value
+    local.set $var$4
+    local.get $var$4
     i64.extend_i32_u
-    local.get $1
+    local.get $radix
     call $~lib/util/number/ulog_base
-    local.set $7
+    local.set $var$7
     global.get $~lib/memory/__stack_pointer
-    local.get $7
+    local.get $var$7
     i32.const 1
     i32.shl
-    local.get $2
+    local.get $sign
     i32.add
     i32.const 1
     call $~lib/rt/itcms/__new
-    local.tee $3
+    local.tee $out
     i32.store $0
-    local.get $3
-    local.get $2
+    local.get $out
+    local.get $sign
     i32.add
-    local.get $4
+    local.get $var$4
     i64.extend_i32_u
-    local.get $7
-    local.get $1
+    local.get $var$7
+    local.get $radix
     call $~lib/util/number/utoa64_any_core
    end
   end
-  local.get $2
+  local.get $sign
   if
-   local.get $3
+   local.get $out
    i32.const 45
    i32.store16 $0
   end
-  local.get $3
+  local.get $out
   local.set $8
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -9304,15 +9304,15 @@
   global.set $~lib/memory/__stack_pointer
   local.get $8
  )
- (func $~lib/string/String#padStart (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
-  (local $3 i32)
-  (local $4 i32)
-  (local $5 i32)
-  (local $6 i32)
-  (local $7 i32)
-  (local $8 i32)
-  (local $9 i32)
-  (local $10 i32)
+ (func $~lib/string/String#padStart (param $this i32) (param $length i32) (param $pad i32) (result i32)
+  (local $thisSize i32)
+  (local $targetSize i32)
+  (local $padSize i32)
+  (local $prependSize i32)
+  (local $out i32)
+  (local $var$8 i32)
+  (local $var$9 i32)
+  (local $var$10 i32)
   (local $11 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -9322,31 +9322,31 @@
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   i32.store $0
-  local.get $0
+  local.get $this
   call $~lib/string/String#get:length
   i32.const 1
   i32.shl
-  local.set $3
-  local.get $1
+  local.set $thisSize
+  local.get $length
   i32.const 1
   i32.shl
-  local.set $4
-  local.get $2
+  local.set $targetSize
+  local.get $pad
   call $~lib/string/String#get:length
   i32.const 1
   i32.shl
-  local.set $5
-  local.get $4
-  local.get $3
+  local.set $padSize
+  local.get $targetSize
+  local.get $thisSize
   i32.lt_u
   if (result i32)
    i32.const 1
   else
-   local.get $5
+   local.get $padSize
    i32.eqz
   end
   if
-   local.get $0
+   local.get $this
    local.set $11
    global.get $~lib/memory/__stack_pointer
    i32.const 4
@@ -9355,58 +9355,58 @@
    local.get $11
    return
   end
-  local.get $4
-  local.get $3
+  local.get $targetSize
+  local.get $thisSize
   i32.sub
-  local.set $6
+  local.set $prependSize
   global.get $~lib/memory/__stack_pointer
-  local.get $4
+  local.get $targetSize
   i32.const 1
   call $~lib/rt/itcms/__new
-  local.tee $7
+  local.tee $out
   i32.store $0
-  local.get $6
-  local.get $5
+  local.get $prependSize
+  local.get $padSize
   i32.gt_u
   if
-   local.get $6
+   local.get $prependSize
    i32.const 2
    i32.sub
-   local.get $5
+   local.get $padSize
    i32.div_u
-   local.set $8
-   local.get $8
-   local.get $5
+   local.set $var$8
+   local.get $var$8
+   local.get $padSize
    i32.mul
-   local.set $9
-   local.get $6
-   local.get $9
+   local.set $var$9
+   local.get $prependSize
+   local.get $var$9
    i32.sub
-   local.set $10
-   local.get $7
-   local.get $2
-   local.get $5
-   local.get $8
+   local.set $var$10
+   local.get $out
+   local.get $pad
+   local.get $padSize
+   local.get $var$8
    call $~lib/memory/memory.repeat
-   local.get $7
-   local.get $9
+   local.get $out
+   local.get $var$9
    i32.add
-   local.get $2
-   local.get $10
+   local.get $pad
+   local.get $var$10
    memory.copy $0 $0
   else
-   local.get $7
-   local.get $2
-   local.get $6
+   local.get $out
+   local.get $pad
+   local.get $prependSize
    memory.copy $0 $0
   end
-  local.get $7
-  local.get $6
+  local.get $out
+  local.get $prependSize
   i32.add
-  local.get $0
-  local.get $3
+  local.get $this
+  local.get $thisSize
   memory.copy $0 $0
-  local.get $7
+  local.get $out
   local.set $11
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -9414,11 +9414,11 @@
   global.set $~lib/memory/__stack_pointer
   local.get $11
  )
- (func $~lib/string/String#concat (param $0 i32) (param $1 i32) (result i32)
-  (local $2 i32)
-  (local $3 i32)
-  (local $4 i32)
-  (local $5 i32)
+ (func $~lib/string/String#concat (param $this i32) (param $other i32) (result i32)
+  (local $thisSize i32)
+  (local $otherSize i32)
+  (local $outSize i32)
+  (local $out i32)
   (local $6 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -9428,21 +9428,21 @@
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   i32.store $0
-  local.get $0
+  local.get $this
   call $~lib/string/String#get:length
   i32.const 1
   i32.shl
-  local.set $2
-  local.get $1
+  local.set $thisSize
+  local.get $other
   call $~lib/string/String#get:length
   i32.const 1
   i32.shl
-  local.set $3
-  local.get $2
-  local.get $3
+  local.set $otherSize
+  local.get $thisSize
+  local.get $otherSize
   i32.add
-  local.set $4
-  local.get $4
+  local.set $outSize
+  local.get $outSize
   i32.const 0
   i32.eq
   if
@@ -9456,22 +9456,22 @@
    return
   end
   global.get $~lib/memory/__stack_pointer
-  local.get $4
+  local.get $outSize
   i32.const 1
   call $~lib/rt/itcms/__new
-  local.tee $5
+  local.tee $out
   i32.store $0
-  local.get $5
-  local.get $0
-  local.get $2
+  local.get $out
+  local.get $this
+  local.get $thisSize
   memory.copy $0 $0
-  local.get $5
-  local.get $2
+  local.get $out
+  local.get $thisSize
   i32.add
-  local.get $1
-  local.get $3
+  local.get $other
+  local.get $otherSize
   memory.copy $0 $0
-  local.get $5
+  local.get $out
   local.set $6
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -9479,16 +9479,16 @@
   global.set $~lib/memory/__stack_pointer
   local.get $6
  )
- (func $~lib/util/string/joinStringArray (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
-  (local $3 i32)
-  (local $4 i32)
-  (local $5 i32)
-  (local $6 i32)
-  (local $7 i32)
-  (local $8 i32)
-  (local $9 i32)
-  (local $10 i32)
-  (local $11 i32)
+ (func $~lib/util/string/joinStringArray (param $dataStart i32) (param $length i32) (param $separator i32) (result i32)
+  (local $lastIndex i32)
+  (local $var$4 i32)
+  (local $estLen i32)
+  (local $value i32)
+  (local $var$7 i32)
+  (local $offset i32)
+  (local $sepLen i32)
+  (local $result i32)
+  (local $var$11 i32)
   (local $12 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 12
@@ -9501,11 +9501,11 @@
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   i32.store $0 offset=8
-  local.get $1
+  local.get $length
   i32.const 1
   i32.sub
-  local.set $3
-  local.get $3
+  local.set $lastIndex
+  local.get $lastIndex
   i32.const 0
   i32.lt_s
   if
@@ -9518,17 +9518,17 @@
    local.get $12
    return
   end
-  local.get $3
+  local.get $lastIndex
   i32.eqz
   if
    global.get $~lib/memory/__stack_pointer
-   local.get $0
+   local.get $dataStart
    i32.load $0
-   local.tee $4
+   local.tee $var$4
    i32.store $0
-   local.get $4
+   local.get $var$4
    if (result i32)
-    local.get $4
+    local.get $var$4
    else
     i32.const 2432
    end
@@ -9541,149 +9541,149 @@
    return
   end
   i32.const 0
-  local.set $5
+  local.set $estLen
   i32.const 0
-  local.set $4
+  local.set $var$4
   loop $for-loop|0
-   local.get $4
-   local.get $1
+   local.get $var$4
+   local.get $length
    i32.lt_s
-   local.set $7
-   local.get $7
+   local.set $var$7
+   local.get $var$7
    if
     global.get $~lib/memory/__stack_pointer
-    local.get $0
-    local.get $4
+    local.get $dataStart
+    local.get $var$4
     i32.const 2
     i32.shl
     i32.add
     i32.load $0
-    local.tee $6
+    local.tee $value
     i32.store $0 offset=4
-    local.get $6
+    local.get $value
     i32.const 0
     i32.ne
     if
-     local.get $5
-     local.get $6
+     local.get $estLen
+     local.get $value
      call $~lib/string/String#get:length
      i32.add
-     local.set $5
+     local.set $estLen
     end
-    local.get $4
+    local.get $var$4
     i32.const 1
     i32.add
-    local.set $4
+    local.set $var$4
     br $for-loop|0
    end
   end
   i32.const 0
-  local.set $8
-  local.get $2
+  local.set $offset
+  local.get $separator
   call $~lib/string/String#get:length
-  local.set $9
+  local.set $sepLen
   global.get $~lib/memory/__stack_pointer
-  local.get $5
-  local.get $9
-  local.get $3
+  local.get $estLen
+  local.get $sepLen
+  local.get $lastIndex
   i32.mul
   i32.add
   i32.const 1
   i32.shl
   i32.const 1
   call $~lib/rt/itcms/__new
-  local.tee $10
+  local.tee $result
   i32.store $0 offset=8
   i32.const 0
-  local.set $4
+  local.set $var$4
   loop $for-loop|1
-   local.get $4
-   local.get $3
+   local.get $var$4
+   local.get $lastIndex
    i32.lt_s
-   local.set $7
-   local.get $7
+   local.set $var$7
+   local.get $var$7
    if
     global.get $~lib/memory/__stack_pointer
-    local.get $0
-    local.get $4
+    local.get $dataStart
+    local.get $var$4
     i32.const 2
     i32.shl
     i32.add
     i32.load $0
-    local.tee $6
+    local.tee $value
     i32.store $0 offset=4
-    local.get $6
+    local.get $value
     i32.const 0
     i32.ne
     if
-     local.get $6
+     local.get $value
      call $~lib/string/String#get:length
-     local.set $11
-     local.get $10
-     local.get $8
+     local.set $var$11
+     local.get $result
+     local.get $offset
      i32.const 1
      i32.shl
      i32.add
-     local.get $6
-     local.get $11
+     local.get $value
+     local.get $var$11
      i32.const 1
      i32.shl
      memory.copy $0 $0
-     local.get $8
-     local.get $11
+     local.get $offset
+     local.get $var$11
      i32.add
-     local.set $8
+     local.set $offset
     end
-    local.get $9
+    local.get $sepLen
     if
-     local.get $10
-     local.get $8
+     local.get $result
+     local.get $offset
      i32.const 1
      i32.shl
      i32.add
-     local.get $2
-     local.get $9
+     local.get $separator
+     local.get $sepLen
      i32.const 1
      i32.shl
      memory.copy $0 $0
-     local.get $8
-     local.get $9
+     local.get $offset
+     local.get $sepLen
      i32.add
-     local.set $8
+     local.set $offset
     end
-    local.get $4
+    local.get $var$4
     i32.const 1
     i32.add
-    local.set $4
+    local.set $var$4
     br $for-loop|1
    end
   end
   global.get $~lib/memory/__stack_pointer
-  local.get $0
-  local.get $3
+  local.get $dataStart
+  local.get $lastIndex
   i32.const 2
   i32.shl
   i32.add
   i32.load $0
-  local.tee $6
+  local.tee $value
   i32.store $0 offset=4
-  local.get $6
+  local.get $value
   i32.const 0
   i32.ne
   if
-   local.get $10
-   local.get $8
+   local.get $result
+   local.get $offset
    i32.const 1
    i32.shl
    i32.add
-   local.get $6
-   local.get $6
+   local.get $value
+   local.get $value
    call $~lib/string/String#get:length
    i32.const 1
    i32.shl
    memory.copy $0 $0
   end
-  local.get $10
+  local.get $result
   local.set $12
   global.get $~lib/memory/__stack_pointer
   i32.const 12
@@ -9691,16 +9691,16 @@
   global.set $~lib/memory/__stack_pointer
   local.get $12
  )
- (func $~lib/string/String#substring (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
-  (local $3 i32)
-  (local $4 i32)
-  (local $5 i32)
-  (local $6 i32)
-  (local $7 i32)
-  (local $8 i32)
-  (local $9 i32)
-  (local $10 i32)
-  (local $11 i32)
+ (func $~lib/string/String#substring (param $this i32) (param $start i32) (param $end i32) (result i32)
+  (local $len i32)
+  (local $var$4 i32)
+  (local $var$5 i32)
+  (local $finalStart i32)
+  (local $finalEnd i32)
+  (local $fromPos i32)
+  (local $toPos i32)
+  (local $size i32)
+  (local $out i32)
   (local $12 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -9710,68 +9710,68 @@
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   i32.store $0
-  local.get $0
+  local.get $this
   call $~lib/string/String#get:length
-  local.set $3
-  local.get $1
-  local.tee $4
+  local.set $len
+  local.get $start
+  local.tee $var$4
   i32.const 0
-  local.tee $5
-  local.get $4
-  local.get $5
+  local.tee $var$5
+  local.get $var$4
+  local.get $var$5
   i32.gt_s
   select
-  local.tee $5
-  local.get $3
-  local.tee $4
-  local.get $5
-  local.get $4
+  local.tee $var$5
+  local.get $len
+  local.tee $var$4
+  local.get $var$5
+  local.get $var$4
   i32.lt_s
   select
-  local.set $6
-  local.get $2
-  local.tee $4
+  local.set $finalStart
+  local.get $end
+  local.tee $var$4
   i32.const 0
-  local.tee $5
-  local.get $4
-  local.get $5
+  local.tee $var$5
+  local.get $var$4
+  local.get $var$5
   i32.gt_s
   select
-  local.tee $5
-  local.get $3
-  local.tee $4
-  local.get $5
-  local.get $4
+  local.tee $var$5
+  local.get $len
+  local.tee $var$4
+  local.get $var$5
+  local.get $var$4
   i32.lt_s
   select
-  local.set $7
-  local.get $6
-  local.tee $4
-  local.get $7
-  local.tee $5
-  local.get $4
-  local.get $5
+  local.set $finalEnd
+  local.get $finalStart
+  local.tee $var$4
+  local.get $finalEnd
+  local.tee $var$5
+  local.get $var$4
+  local.get $var$5
   i32.lt_s
   select
   i32.const 1
   i32.shl
-  local.set $8
-  local.get $6
-  local.tee $5
-  local.get $7
-  local.tee $4
-  local.get $5
-  local.get $4
+  local.set $fromPos
+  local.get $finalStart
+  local.tee $var$5
+  local.get $finalEnd
+  local.tee $var$4
+  local.get $var$5
+  local.get $var$4
   i32.gt_s
   select
   i32.const 1
   i32.shl
-  local.set $9
-  local.get $9
-  local.get $8
+  local.set $toPos
+  local.get $toPos
+  local.get $fromPos
   i32.sub
-  local.set $10
-  local.get $10
+  local.set $size
+  local.get $size
   i32.eqz
   if
    i32.const 2432
@@ -9783,11 +9783,11 @@
    local.get $12
    return
   end
-  local.get $8
+  local.get $fromPos
   i32.eqz
   if (result i32)
-   local.get $9
-   local.get $3
+   local.get $toPos
+   local.get $len
    i32.const 1
    i32.shl
    i32.eq
@@ -9795,7 +9795,7 @@
    i32.const 0
   end
   if
-   local.get $0
+   local.get $this
    local.set $12
    global.get $~lib/memory/__stack_pointer
    i32.const 4
@@ -9805,18 +9805,18 @@
    return
   end
   global.get $~lib/memory/__stack_pointer
-  local.get $10
+  local.get $size
   i32.const 1
   call $~lib/rt/itcms/__new
-  local.tee $11
+  local.tee $out
   i32.store $0
-  local.get $11
-  local.get $0
-  local.get $8
+  local.get $out
+  local.get $this
+  local.get $fromPos
   i32.add
-  local.get $10
+  local.get $size
   memory.copy $0 $0
-  local.get $11
+  local.get $out
   local.set $12
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -9824,10 +9824,10 @@
   global.set $~lib/memory/__stack_pointer
   local.get $12
  )
- (func $~lib/rt/__newArray (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
-  (local $4 i32)
-  (local $5 i32)
-  (local $6 i32)
+ (func $~lib/rt/__newArray (param $length i32) (param $alignLog2 i32) (param $id i32) (param $data i32) (result i32)
+  (local $bufferSize i32)
+  (local $buffer i32)
+  (local $array i32)
   (local $7 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -9837,38 +9837,38 @@
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   i32.store $0
-  local.get $0
-  local.get $1
+  local.get $length
+  local.get $alignLog2
   i32.shl
-  local.set $4
+  local.set $bufferSize
   global.get $~lib/memory/__stack_pointer
-  local.get $4
+  local.get $bufferSize
   i32.const 0
-  local.get $3
+  local.get $data
   call $~lib/rt/__newBuffer
-  local.tee $5
+  local.tee $buffer
   i32.store $0
   i32.const 16
-  local.get $2
+  local.get $id
   call $~lib/rt/itcms/__new
-  local.set $6
-  local.get $6
-  local.get $5
+  local.set $array
+  local.get $array
+  local.get $buffer
   i32.store $0
-  local.get $6
-  local.get $5
+  local.get $array
+  local.get $buffer
   i32.const 0
   call $~lib/rt/itcms/__link
-  local.get $6
-  local.get $5
+  local.get $array
+  local.get $buffer
   i32.store $0 offset=4
-  local.get $6
-  local.get $4
+  local.get $array
+  local.get $bufferSize
   i32.store $0 offset=8
-  local.get $6
-  local.get $0
+  local.get $array
+  local.get $length
   i32.store $0 offset=12
-  local.get $6
+  local.get $array
   local.set $7
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -9876,8 +9876,8 @@
   global.set $~lib/memory/__stack_pointer
   local.get $7
  )
- (func $~lib/array/Array<~lib/string/String>#__get (param $0 i32) (param $1 i32) (result i32)
-  (local $2 i32)
+ (func $~lib/array/Array<~lib/string/String>#__get (param $this i32) (param $index i32) (result i32)
+  (local $value i32)
   (local $3 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -9887,8 +9887,8 @@
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   i32.store $0
-  local.get $1
-  local.get $0
+  local.get $index
+  local.get $this
   i32.load $0 offset=12
   i32.ge_u
   if
@@ -9900,21 +9900,21 @@
    unreachable
   end
   global.get $~lib/memory/__stack_pointer
-  local.get $0
+  local.get $this
   i32.load $0 offset=4
-  local.get $1
+  local.get $index
   i32.const 2
   i32.shl
   i32.add
   i32.load $0
-  local.tee $2
+  local.tee $value
   i32.store $0
   i32.const 1
   drop
   i32.const 0
   i32.eqz
   drop
-  local.get $2
+  local.get $value
   i32.eqz
   if
    i32.const 5808
@@ -9924,7 +9924,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $2
+  local.get $value
   local.set $3
   global.get $~lib/memory/__stack_pointer
   i32.const 4

--- a/tests/compiler/std/map.debug.wat
+++ b/tests/compiler/std/map.debug.wat
@@ -15446,8 +15446,8 @@
    unreachable
   end
  )
- (func $~lib/arraybuffer/ArrayBuffer#constructor (param $0 i32) (param $1 i32) (result i32)
-  (local $2 i32)
+ (func $~lib/arraybuffer/ArrayBuffer#constructor (param $this i32) (param $length i32) (result i32)
+  (local $buffer i32)
   (local $3 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -15457,7 +15457,7 @@
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   i32.store $0
-  local.get $1
+  local.get $length
   i32.const 1073741820
   i32.gt_u
   if
@@ -15469,16 +15469,16 @@
    unreachable
   end
   global.get $~lib/memory/__stack_pointer
-  local.get $1
+  local.get $length
   i32.const 0
   call $~lib/rt/itcms/__new
-  local.tee $2
+  local.tee $buffer
   i32.store $0
   i32.const 2
   global.get $~lib/shared/runtime/Runtime.Incremental
   i32.ne
   drop
-  local.get $2
+  local.get $buffer
   local.set $3
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -15486,7 +15486,7 @@
   global.set $~lib/memory/__stack_pointer
   local.get $3
  )
- (func $~lib/map/Map<i8,i32>#constructor (param $0 i32) (result i32)
+ (func $~lib/map/Map<i8,i32>#constructor (param $this i32) (result i32)
   (local $1 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -15496,45 +15496,45 @@
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   i32.store $0
-  local.get $0
+  local.get $this
   i32.eqz
   if
    global.get $~lib/memory/__stack_pointer
    i32.const 24
    i32.const 3
    call $~lib/rt/itcms/__new
-   local.tee $0
+   local.tee $this
    i32.store $0
   end
-  local.get $0
+  local.get $this
   i32.const 0
   i32.const 4
   i32.const 4
   i32.mul
   call $~lib/arraybuffer/ArrayBuffer#constructor
   call $~lib/map/Map<i8,i32>#set:buckets
-  local.get $0
+  local.get $this
   i32.const 4
   i32.const 1
   i32.sub
   call $~lib/map/Map<i8,i32>#set:bucketsMask
-  local.get $0
+  local.get $this
   i32.const 0
   i32.const 4
   i32.const 12
   i32.mul
   call $~lib/arraybuffer/ArrayBuffer#constructor
   call $~lib/map/Map<i8,i32>#set:entries
-  local.get $0
+  local.get $this
   i32.const 4
   call $~lib/map/Map<i8,i32>#set:entriesCapacity
-  local.get $0
+  local.get $this
   i32.const 0
   call $~lib/map/Map<i8,i32>#set:entriesOffset
-  local.get $0
+  local.get $this
   i32.const 0
   call $~lib/map/Map<i8,i32>#set:entriesCount
-  local.get $0
+  local.get $this
   local.set $1
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -15542,11 +15542,11 @@
   global.set $~lib/memory/__stack_pointer
   local.get $1
  )
- (func $~lib/map/Map<i8,i32>#set (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
-  (local $3 i32)
-  (local $4 i32)
-  (local $5 i32)
-  (local $6 i32)
+ (func $~lib/map/Map<i8,i32>#set (param $this i32) (param $key i32) (param $value i32) (result i32)
+  (local $hashCode i32)
+  (local $entry i32)
+  (local $var$5 i32)
+  (local $var$6 i32)
   (local $7 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -15556,32 +15556,32 @@
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   i32.store $0
-  local.get $1
+  local.get $key
   call $~lib/util/hash/HASH<i8>
-  local.set $3
-  local.get $0
-  local.get $1
-  local.get $3
+  local.set $hashCode
+  local.get $this
+  local.get $key
+  local.get $hashCode
   call $~lib/map/Map<i8,i32>#find
-  local.set $4
-  local.get $4
+  local.set $entry
+  local.get $entry
   if
-   local.get $4
-   local.get $2
+   local.get $entry
+   local.get $value
    call $~lib/map/MapEntry<i8,i32>#set:value
    i32.const 0
    drop
   else
-   local.get $0
+   local.get $this
    i32.load $0 offset=16
-   local.get $0
+   local.get $this
    i32.load $0 offset=12
    i32.eq
    if
-    local.get $0
-    local.get $0
+    local.get $this
+    local.get $this
     i32.load $0 offset=20
-    local.get $0
+    local.get $this
     i32.load $0 offset=12
     i32.const 3
     i32.mul
@@ -15589,10 +15589,10 @@
     i32.div_s
     i32.lt_s
     if (result i32)
-     local.get $0
+     local.get $this
      i32.load $0 offset=4
     else
-     local.get $0
+     local.get $this
      i32.load $0 offset=4
      i32.const 1
      i32.shl
@@ -15602,58 +15602,58 @@
     call $~lib/map/Map<i8,i32>#rehash
    end
    global.get $~lib/memory/__stack_pointer
-   local.get $0
+   local.get $this
    i32.load $0 offset=8
-   local.tee $5
+   local.tee $var$5
    i32.store $0
-   local.get $5
-   local.get $0
-   local.get $0
+   local.get $var$5
+   local.get $this
+   local.get $this
    i32.load $0 offset=16
-   local.tee $6
+   local.tee $var$6
    i32.const 1
    i32.add
    call $~lib/map/Map<i8,i32>#set:entriesOffset
-   local.get $6
+   local.get $var$6
    i32.const 12
    i32.mul
    i32.add
-   local.set $4
-   local.get $4
-   local.get $1
+   local.set $entry
+   local.get $entry
+   local.get $key
    call $~lib/map/MapEntry<i8,i32>#set:key
    i32.const 0
    drop
-   local.get $4
-   local.get $2
+   local.get $entry
+   local.get $value
    call $~lib/map/MapEntry<i8,i32>#set:value
    i32.const 0
    drop
-   local.get $0
-   local.get $0
+   local.get $this
+   local.get $this
    i32.load $0 offset=20
    i32.const 1
    i32.add
    call $~lib/map/Map<i8,i32>#set:entriesCount
-   local.get $0
+   local.get $this
    i32.load $0
-   local.get $3
-   local.get $0
+   local.get $hashCode
+   local.get $this
    i32.load $0 offset=4
    i32.and
    i32.const 4
    i32.mul
    i32.add
-   local.set $6
-   local.get $4
-   local.get $6
+   local.set $var$6
+   local.get $entry
+   local.get $var$6
    i32.load $0
    call $~lib/map/MapEntry<i8,i32>#set:taggedNext
-   local.get $6
-   local.get $4
+   local.get $var$6
+   local.get $entry
    i32.store $0
   end
-  local.get $0
+  local.get $this
   local.set $7
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -15661,11 +15661,11 @@
   global.set $~lib/memory/__stack_pointer
   local.get $7
  )
- (func $~lib/array/Array<i8>#constructor (param $0 i32) (param $1 i32) (result i32)
-  (local $2 i32)
-  (local $3 i32)
-  (local $4 i32)
-  (local $5 i32)
+ (func $~lib/array/Array<i8>#constructor (param $this i32) (param $length i32) (result i32)
+  (local $var$2 i32)
+  (local $var$3 i32)
+  (local $bufferSize i32)
+  (local $buffer i32)
   (local $6 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 8
@@ -15675,29 +15675,29 @@
   global.get $~lib/memory/__stack_pointer
   i64.const 0
   i64.store $0
-  local.get $0
+  local.get $this
   i32.eqz
   if
    global.get $~lib/memory/__stack_pointer
    i32.const 16
    i32.const 4
    call $~lib/rt/itcms/__new
-   local.tee $0
+   local.tee $this
    i32.store $0
   end
-  local.get $0
+  local.get $this
   i32.const 0
   call $~lib/array/Array<i8>#set:buffer
-  local.get $0
+  local.get $this
   i32.const 0
   call $~lib/array/Array<i8>#set:dataStart
-  local.get $0
+  local.get $this
   i32.const 0
   call $~lib/array/Array<i8>#set:byteLength
-  local.get $0
+  local.get $this
   i32.const 0
   call $~lib/array/Array<i8>#set:length_
-  local.get $1
+  local.get $length
   i32.const 1073741820
   i32.const 0
   i32.shr_u
@@ -15710,40 +15710,40 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $1
-  local.tee $2
+  local.get $length
+  local.tee $var$2
   i32.const 8
-  local.tee $3
-  local.get $2
-  local.get $3
+  local.tee $var$3
+  local.get $var$2
+  local.get $var$3
   i32.gt_u
   select
   i32.const 0
   i32.shl
-  local.set $4
+  local.set $bufferSize
   global.get $~lib/memory/__stack_pointer
-  local.get $4
+  local.get $bufferSize
   i32.const 0
   call $~lib/rt/itcms/__new
-  local.tee $5
+  local.tee $buffer
   i32.store $0 offset=4
   i32.const 2
   global.get $~lib/shared/runtime/Runtime.Incremental
   i32.ne
   drop
-  local.get $0
-  local.get $5
+  local.get $this
+  local.get $buffer
   call $~lib/array/Array<i8>#set:buffer
-  local.get $0
-  local.get $5
+  local.get $this
+  local.get $buffer
   call $~lib/array/Array<i8>#set:dataStart
-  local.get $0
-  local.get $4
+  local.get $this
+  local.get $bufferSize
   call $~lib/array/Array<i8>#set:byteLength
-  local.get $0
-  local.get $1
+  local.get $this
+  local.get $length
   call $~lib/array/Array<i8>#set:length_
-  local.get $0
+  local.get $this
   local.set $6
   global.get $~lib/memory/__stack_pointer
   i32.const 8
@@ -15751,15 +15751,15 @@
   global.set $~lib/memory/__stack_pointer
   local.get $6
  )
- (func $~lib/map/Map<i8,i32>#keys (param $0 i32) (result i32)
-  (local $1 i32)
-  (local $2 i32)
-  (local $3 i32)
-  (local $4 i32)
-  (local $5 i32)
-  (local $6 i32)
-  (local $7 i32)
-  (local $8 i32)
+ (func $~lib/map/Map<i8,i32>#keys (param $this i32) (result i32)
+  (local $start i32)
+  (local $size i32)
+  (local $keys i32)
+  (local $length i32)
+  (local $var$5 i32)
+  (local $var$6 i32)
+  (local $var$7 i32)
+  (local $var$8 i32)
   (local $9 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -15769,63 +15769,63 @@
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   i32.store $0
-  local.get $0
+  local.get $this
   i32.load $0 offset=8
-  local.set $1
-  local.get $0
+  local.set $start
+  local.get $this
   i32.load $0 offset=16
-  local.set $2
+  local.set $size
   global.get $~lib/memory/__stack_pointer
   i32.const 0
-  local.get $2
+  local.get $size
   call $~lib/array/Array<i8>#constructor
-  local.tee $3
+  local.tee $keys
   i32.store $0
   i32.const 0
-  local.set $4
+  local.set $length
   i32.const 0
-  local.set $5
+  local.set $var$5
   loop $for-loop|0
-   local.get $5
-   local.get $2
+   local.get $var$5
+   local.get $size
    i32.lt_s
-   local.set $6
-   local.get $6
+   local.set $var$6
+   local.get $var$6
    if
-    local.get $1
-    local.get $5
+    local.get $start
+    local.get $var$5
     i32.const 12
     i32.mul
     i32.add
-    local.set $7
-    local.get $7
+    local.set $var$7
+    local.get $var$7
     i32.load $0 offset=8
     i32.const 1
     i32.and
     i32.eqz
     if
-     local.get $3
-     local.get $4
-     local.tee $8
+     local.get $keys
+     local.get $length
+     local.tee $var$8
      i32.const 1
      i32.add
-     local.set $4
-     local.get $8
-     local.get $7
+     local.set $length
+     local.get $var$8
+     local.get $var$7
      i32.load8_s $0
      call $~lib/array/Array<i8>#__uset
     end
-    local.get $5
+    local.get $var$5
     i32.const 1
     i32.add
-    local.set $5
+    local.set $var$5
     br $for-loop|0
    end
   end
-  local.get $3
-  local.get $4
+  local.get $keys
+  local.get $length
   call $~lib/array/Array<i8>#set:length
-  local.get $3
+  local.get $keys
   local.set $9
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -15833,11 +15833,11 @@
   global.set $~lib/memory/__stack_pointer
   local.get $9
  )
- (func $~lib/array/Array<i32>#constructor (param $0 i32) (param $1 i32) (result i32)
-  (local $2 i32)
-  (local $3 i32)
-  (local $4 i32)
-  (local $5 i32)
+ (func $~lib/array/Array<i32>#constructor (param $this i32) (param $length i32) (result i32)
+  (local $var$2 i32)
+  (local $var$3 i32)
+  (local $bufferSize i32)
+  (local $buffer i32)
   (local $6 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 8
@@ -15847,29 +15847,29 @@
   global.get $~lib/memory/__stack_pointer
   i64.const 0
   i64.store $0
-  local.get $0
+  local.get $this
   i32.eqz
   if
    global.get $~lib/memory/__stack_pointer
    i32.const 16
    i32.const 5
    call $~lib/rt/itcms/__new
-   local.tee $0
+   local.tee $this
    i32.store $0
   end
-  local.get $0
+  local.get $this
   i32.const 0
   call $~lib/array/Array<i32>#set:buffer
-  local.get $0
+  local.get $this
   i32.const 0
   call $~lib/array/Array<i32>#set:dataStart
-  local.get $0
+  local.get $this
   i32.const 0
   call $~lib/array/Array<i32>#set:byteLength
-  local.get $0
+  local.get $this
   i32.const 0
   call $~lib/array/Array<i32>#set:length_
-  local.get $1
+  local.get $length
   i32.const 1073741820
   i32.const 2
   i32.shr_u
@@ -15882,40 +15882,40 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $1
-  local.tee $2
+  local.get $length
+  local.tee $var$2
   i32.const 8
-  local.tee $3
-  local.get $2
-  local.get $3
+  local.tee $var$3
+  local.get $var$2
+  local.get $var$3
   i32.gt_u
   select
   i32.const 2
   i32.shl
-  local.set $4
+  local.set $bufferSize
   global.get $~lib/memory/__stack_pointer
-  local.get $4
+  local.get $bufferSize
   i32.const 0
   call $~lib/rt/itcms/__new
-  local.tee $5
+  local.tee $buffer
   i32.store $0 offset=4
   i32.const 2
   global.get $~lib/shared/runtime/Runtime.Incremental
   i32.ne
   drop
-  local.get $0
-  local.get $5
+  local.get $this
+  local.get $buffer
   call $~lib/array/Array<i32>#set:buffer
-  local.get $0
-  local.get $5
+  local.get $this
+  local.get $buffer
   call $~lib/array/Array<i32>#set:dataStart
-  local.get $0
-  local.get $4
+  local.get $this
+  local.get $bufferSize
   call $~lib/array/Array<i32>#set:byteLength
-  local.get $0
-  local.get $1
+  local.get $this
+  local.get $length
   call $~lib/array/Array<i32>#set:length_
-  local.get $0
+  local.get $this
   local.set $6
   global.get $~lib/memory/__stack_pointer
   i32.const 8
@@ -15923,15 +15923,15 @@
   global.set $~lib/memory/__stack_pointer
   local.get $6
  )
- (func $~lib/map/Map<i8,i32>#values (param $0 i32) (result i32)
-  (local $1 i32)
-  (local $2 i32)
-  (local $3 i32)
-  (local $4 i32)
-  (local $5 i32)
-  (local $6 i32)
-  (local $7 i32)
-  (local $8 i32)
+ (func $~lib/map/Map<i8,i32>#values (param $this i32) (result i32)
+  (local $start i32)
+  (local $size i32)
+  (local $values i32)
+  (local $length i32)
+  (local $var$5 i32)
+  (local $var$6 i32)
+  (local $var$7 i32)
+  (local $var$8 i32)
   (local $9 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -15941,63 +15941,63 @@
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   i32.store $0
-  local.get $0
+  local.get $this
   i32.load $0 offset=8
-  local.set $1
-  local.get $0
+  local.set $start
+  local.get $this
   i32.load $0 offset=16
-  local.set $2
+  local.set $size
   global.get $~lib/memory/__stack_pointer
   i32.const 0
-  local.get $2
+  local.get $size
   call $~lib/array/Array<i32>#constructor
-  local.tee $3
+  local.tee $values
   i32.store $0
   i32.const 0
-  local.set $4
+  local.set $length
   i32.const 0
-  local.set $5
+  local.set $var$5
   loop $for-loop|0
-   local.get $5
-   local.get $2
+   local.get $var$5
+   local.get $size
    i32.lt_s
-   local.set $6
-   local.get $6
+   local.set $var$6
+   local.get $var$6
    if
-    local.get $1
-    local.get $5
+    local.get $start
+    local.get $var$5
     i32.const 12
     i32.mul
     i32.add
-    local.set $7
-    local.get $7
+    local.set $var$7
+    local.get $var$7
     i32.load $0 offset=8
     i32.const 1
     i32.and
     i32.eqz
     if
-     local.get $3
-     local.get $4
-     local.tee $8
+     local.get $values
+     local.get $length
+     local.tee $var$8
      i32.const 1
      i32.add
-     local.set $4
-     local.get $8
-     local.get $7
+     local.set $length
+     local.get $var$8
+     local.get $var$7
      i32.load $0 offset=4
      call $~lib/array/Array<i32>#__uset
     end
-    local.get $5
+    local.get $var$5
     i32.const 1
     i32.add
-    local.set $5
+    local.set $var$5
     br $for-loop|0
    end
   end
-  local.get $3
-  local.get $4
+  local.get $values
+  local.get $length
   call $~lib/array/Array<i32>#set:length
-  local.get $3
+  local.get $values
   local.set $9
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -16005,7 +16005,7 @@
   global.set $~lib/memory/__stack_pointer
   local.get $9
  )
- (func $~lib/map/Map<i8,i8>#constructor (param $0 i32) (result i32)
+ (func $~lib/map/Map<i8,i8>#constructor (param $this i32) (result i32)
   (local $1 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -16015,45 +16015,45 @@
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   i32.store $0
-  local.get $0
+  local.get $this
   i32.eqz
   if
    global.get $~lib/memory/__stack_pointer
    i32.const 24
    i32.const 6
    call $~lib/rt/itcms/__new
-   local.tee $0
+   local.tee $this
    i32.store $0
   end
-  local.get $0
+  local.get $this
   i32.const 0
   i32.const 4
   i32.const 4
   i32.mul
   call $~lib/arraybuffer/ArrayBuffer#constructor
   call $~lib/map/Map<i8,i8>#set:buckets
-  local.get $0
+  local.get $this
   i32.const 4
   i32.const 1
   i32.sub
   call $~lib/map/Map<i8,i8>#set:bucketsMask
-  local.get $0
+  local.get $this
   i32.const 0
   i32.const 4
   i32.const 8
   i32.mul
   call $~lib/arraybuffer/ArrayBuffer#constructor
   call $~lib/map/Map<i8,i8>#set:entries
-  local.get $0
+  local.get $this
   i32.const 4
   call $~lib/map/Map<i8,i8>#set:entriesCapacity
-  local.get $0
+  local.get $this
   i32.const 0
   call $~lib/map/Map<i8,i8>#set:entriesOffset
-  local.get $0
+  local.get $this
   i32.const 0
   call $~lib/map/Map<i8,i8>#set:entriesCount
-  local.get $0
+  local.get $this
   local.set $1
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -16061,7 +16061,7 @@
   global.set $~lib/memory/__stack_pointer
   local.get $1
  )
- (func $~lib/map/Map<i32,i32>#constructor (param $0 i32) (result i32)
+ (func $~lib/map/Map<i32,i32>#constructor (param $this i32) (result i32)
   (local $1 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -16071,45 +16071,45 @@
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   i32.store $0
-  local.get $0
+  local.get $this
   i32.eqz
   if
    global.get $~lib/memory/__stack_pointer
    i32.const 24
    i32.const 7
    call $~lib/rt/itcms/__new
-   local.tee $0
+   local.tee $this
    i32.store $0
   end
-  local.get $0
+  local.get $this
   i32.const 0
   i32.const 4
   i32.const 4
   i32.mul
   call $~lib/arraybuffer/ArrayBuffer#constructor
   call $~lib/map/Map<i32,i32>#set:buckets
-  local.get $0
+  local.get $this
   i32.const 4
   i32.const 1
   i32.sub
   call $~lib/map/Map<i32,i32>#set:bucketsMask
-  local.get $0
+  local.get $this
   i32.const 0
   i32.const 4
   i32.const 12
   i32.mul
   call $~lib/arraybuffer/ArrayBuffer#constructor
   call $~lib/map/Map<i32,i32>#set:entries
-  local.get $0
+  local.get $this
   i32.const 4
   call $~lib/map/Map<i32,i32>#set:entriesCapacity
-  local.get $0
+  local.get $this
   i32.const 0
   call $~lib/map/Map<i32,i32>#set:entriesOffset
-  local.get $0
+  local.get $this
   i32.const 0
   call $~lib/map/Map<i32,i32>#set:entriesCount
-  local.get $0
+  local.get $this
   local.set $1
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -16117,11 +16117,11 @@
   global.set $~lib/memory/__stack_pointer
   local.get $1
  )
- (func $~lib/map/Map<i8,i8>#set (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
-  (local $3 i32)
-  (local $4 i32)
-  (local $5 i32)
-  (local $6 i32)
+ (func $~lib/map/Map<i8,i8>#set (param $this i32) (param $key i32) (param $value i32) (result i32)
+  (local $hashCode i32)
+  (local $entry i32)
+  (local $var$5 i32)
+  (local $var$6 i32)
   (local $7 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -16131,32 +16131,32 @@
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   i32.store $0
-  local.get $1
+  local.get $key
   call $~lib/util/hash/HASH<i8>
-  local.set $3
-  local.get $0
-  local.get $1
-  local.get $3
+  local.set $hashCode
+  local.get $this
+  local.get $key
+  local.get $hashCode
   call $~lib/map/Map<i8,i8>#find
-  local.set $4
-  local.get $4
+  local.set $entry
+  local.get $entry
   if
-   local.get $4
-   local.get $2
+   local.get $entry
+   local.get $value
    call $~lib/map/MapEntry<i8,i8>#set:value
    i32.const 0
    drop
   else
-   local.get $0
+   local.get $this
    i32.load $0 offset=16
-   local.get $0
+   local.get $this
    i32.load $0 offset=12
    i32.eq
    if
-    local.get $0
-    local.get $0
+    local.get $this
+    local.get $this
     i32.load $0 offset=20
-    local.get $0
+    local.get $this
     i32.load $0 offset=12
     i32.const 3
     i32.mul
@@ -16164,10 +16164,10 @@
     i32.div_s
     i32.lt_s
     if (result i32)
-     local.get $0
+     local.get $this
      i32.load $0 offset=4
     else
-     local.get $0
+     local.get $this
      i32.load $0 offset=4
      i32.const 1
      i32.shl
@@ -16177,58 +16177,58 @@
     call $~lib/map/Map<i8,i8>#rehash
    end
    global.get $~lib/memory/__stack_pointer
-   local.get $0
+   local.get $this
    i32.load $0 offset=8
-   local.tee $5
+   local.tee $var$5
    i32.store $0
-   local.get $5
-   local.get $0
-   local.get $0
+   local.get $var$5
+   local.get $this
+   local.get $this
    i32.load $0 offset=16
-   local.tee $6
+   local.tee $var$6
    i32.const 1
    i32.add
    call $~lib/map/Map<i8,i8>#set:entriesOffset
-   local.get $6
+   local.get $var$6
    i32.const 8
    i32.mul
    i32.add
-   local.set $4
-   local.get $4
-   local.get $1
+   local.set $entry
+   local.get $entry
+   local.get $key
    call $~lib/map/MapEntry<i8,i8>#set:key
    i32.const 0
    drop
-   local.get $4
-   local.get $2
+   local.get $entry
+   local.get $value
    call $~lib/map/MapEntry<i8,i8>#set:value
    i32.const 0
    drop
-   local.get $0
-   local.get $0
+   local.get $this
+   local.get $this
    i32.load $0 offset=20
    i32.const 1
    i32.add
    call $~lib/map/Map<i8,i8>#set:entriesCount
-   local.get $0
+   local.get $this
    i32.load $0
-   local.get $3
-   local.get $0
+   local.get $hashCode
+   local.get $this
    i32.load $0 offset=4
    i32.and
    i32.const 4
    i32.mul
    i32.add
-   local.set $6
-   local.get $4
-   local.get $6
+   local.set $var$6
+   local.get $entry
+   local.get $var$6
    i32.load $0
    call $~lib/map/MapEntry<i8,i8>#set:taggedNext
-   local.get $6
-   local.get $4
+   local.get $var$6
+   local.get $entry
    i32.store $0
   end
-  local.get $0
+  local.get $this
   local.set $7
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -16236,11 +16236,11 @@
   global.set $~lib/memory/__stack_pointer
   local.get $7
  )
- (func $~lib/map/Map<i32,i32>#set (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
-  (local $3 i32)
-  (local $4 i32)
-  (local $5 i32)
-  (local $6 i32)
+ (func $~lib/map/Map<i32,i32>#set (param $this i32) (param $key i32) (param $value i32) (result i32)
+  (local $hashCode i32)
+  (local $entry i32)
+  (local $var$5 i32)
+  (local $var$6 i32)
   (local $7 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -16250,32 +16250,32 @@
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   i32.store $0
-  local.get $1
+  local.get $key
   call $~lib/util/hash/HASH<i32>
-  local.set $3
-  local.get $0
-  local.get $1
-  local.get $3
+  local.set $hashCode
+  local.get $this
+  local.get $key
+  local.get $hashCode
   call $~lib/map/Map<i32,i32>#find
-  local.set $4
-  local.get $4
+  local.set $entry
+  local.get $entry
   if
-   local.get $4
-   local.get $2
+   local.get $entry
+   local.get $value
    call $~lib/map/MapEntry<i32,i32>#set:value
    i32.const 0
    drop
   else
-   local.get $0
+   local.get $this
    i32.load $0 offset=16
-   local.get $0
+   local.get $this
    i32.load $0 offset=12
    i32.eq
    if
-    local.get $0
-    local.get $0
+    local.get $this
+    local.get $this
     i32.load $0 offset=20
-    local.get $0
+    local.get $this
     i32.load $0 offset=12
     i32.const 3
     i32.mul
@@ -16283,10 +16283,10 @@
     i32.div_s
     i32.lt_s
     if (result i32)
-     local.get $0
+     local.get $this
      i32.load $0 offset=4
     else
-     local.get $0
+     local.get $this
      i32.load $0 offset=4
      i32.const 1
      i32.shl
@@ -16296,58 +16296,58 @@
     call $~lib/map/Map<i32,i32>#rehash
    end
    global.get $~lib/memory/__stack_pointer
-   local.get $0
+   local.get $this
    i32.load $0 offset=8
-   local.tee $5
+   local.tee $var$5
    i32.store $0
-   local.get $5
-   local.get $0
-   local.get $0
+   local.get $var$5
+   local.get $this
+   local.get $this
    i32.load $0 offset=16
-   local.tee $6
+   local.tee $var$6
    i32.const 1
    i32.add
    call $~lib/map/Map<i32,i32>#set:entriesOffset
-   local.get $6
+   local.get $var$6
    i32.const 12
    i32.mul
    i32.add
-   local.set $4
-   local.get $4
-   local.get $1
+   local.set $entry
+   local.get $entry
+   local.get $key
    call $~lib/map/MapEntry<i32,i32>#set:key
    i32.const 0
    drop
-   local.get $4
-   local.get $2
+   local.get $entry
+   local.get $value
    call $~lib/map/MapEntry<i32,i32>#set:value
    i32.const 0
    drop
-   local.get $0
-   local.get $0
+   local.get $this
+   local.get $this
    i32.load $0 offset=20
    i32.const 1
    i32.add
    call $~lib/map/Map<i32,i32>#set:entriesCount
-   local.get $0
+   local.get $this
    i32.load $0
-   local.get $3
-   local.get $0
+   local.get $hashCode
+   local.get $this
    i32.load $0 offset=4
    i32.and
    i32.const 4
    i32.mul
    i32.add
-   local.set $6
-   local.get $4
-   local.get $6
+   local.set $var$6
+   local.get $entry
+   local.get $var$6
    i32.load $0
    call $~lib/map/MapEntry<i32,i32>#set:taggedNext
-   local.get $6
-   local.get $4
+   local.get $var$6
+   local.get $entry
    i32.store $0
   end
-  local.get $0
+  local.get $this
   local.set $7
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -16355,7 +16355,7 @@
   global.set $~lib/memory/__stack_pointer
   local.get $7
  )
- (func $~lib/map/Map<u8,i32>#constructor (param $0 i32) (result i32)
+ (func $~lib/map/Map<u8,i32>#constructor (param $this i32) (result i32)
   (local $1 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -16365,45 +16365,45 @@
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   i32.store $0
-  local.get $0
+  local.get $this
   i32.eqz
   if
    global.get $~lib/memory/__stack_pointer
    i32.const 24
    i32.const 8
    call $~lib/rt/itcms/__new
-   local.tee $0
+   local.tee $this
    i32.store $0
   end
-  local.get $0
+  local.get $this
   i32.const 0
   i32.const 4
   i32.const 4
   i32.mul
   call $~lib/arraybuffer/ArrayBuffer#constructor
   call $~lib/map/Map<u8,i32>#set:buckets
-  local.get $0
+  local.get $this
   i32.const 4
   i32.const 1
   i32.sub
   call $~lib/map/Map<u8,i32>#set:bucketsMask
-  local.get $0
+  local.get $this
   i32.const 0
   i32.const 4
   i32.const 12
   i32.mul
   call $~lib/arraybuffer/ArrayBuffer#constructor
   call $~lib/map/Map<u8,i32>#set:entries
-  local.get $0
+  local.get $this
   i32.const 4
   call $~lib/map/Map<u8,i32>#set:entriesCapacity
-  local.get $0
+  local.get $this
   i32.const 0
   call $~lib/map/Map<u8,i32>#set:entriesOffset
-  local.get $0
+  local.get $this
   i32.const 0
   call $~lib/map/Map<u8,i32>#set:entriesCount
-  local.get $0
+  local.get $this
   local.set $1
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -16411,11 +16411,11 @@
   global.set $~lib/memory/__stack_pointer
   local.get $1
  )
- (func $~lib/map/Map<u8,i32>#set (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
-  (local $3 i32)
-  (local $4 i32)
-  (local $5 i32)
-  (local $6 i32)
+ (func $~lib/map/Map<u8,i32>#set (param $this i32) (param $key i32) (param $value i32) (result i32)
+  (local $hashCode i32)
+  (local $entry i32)
+  (local $var$5 i32)
+  (local $var$6 i32)
   (local $7 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -16425,32 +16425,32 @@
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   i32.store $0
-  local.get $1
+  local.get $key
   call $~lib/util/hash/HASH<u8>
-  local.set $3
-  local.get $0
-  local.get $1
-  local.get $3
+  local.set $hashCode
+  local.get $this
+  local.get $key
+  local.get $hashCode
   call $~lib/map/Map<u8,i32>#find
-  local.set $4
-  local.get $4
+  local.set $entry
+  local.get $entry
   if
-   local.get $4
-   local.get $2
+   local.get $entry
+   local.get $value
    call $~lib/map/MapEntry<u8,i32>#set:value
    i32.const 0
    drop
   else
-   local.get $0
+   local.get $this
    i32.load $0 offset=16
-   local.get $0
+   local.get $this
    i32.load $0 offset=12
    i32.eq
    if
-    local.get $0
-    local.get $0
+    local.get $this
+    local.get $this
     i32.load $0 offset=20
-    local.get $0
+    local.get $this
     i32.load $0 offset=12
     i32.const 3
     i32.mul
@@ -16458,10 +16458,10 @@
     i32.div_s
     i32.lt_s
     if (result i32)
-     local.get $0
+     local.get $this
      i32.load $0 offset=4
     else
-     local.get $0
+     local.get $this
      i32.load $0 offset=4
      i32.const 1
      i32.shl
@@ -16471,58 +16471,58 @@
     call $~lib/map/Map<u8,i32>#rehash
    end
    global.get $~lib/memory/__stack_pointer
-   local.get $0
+   local.get $this
    i32.load $0 offset=8
-   local.tee $5
+   local.tee $var$5
    i32.store $0
-   local.get $5
-   local.get $0
-   local.get $0
+   local.get $var$5
+   local.get $this
+   local.get $this
    i32.load $0 offset=16
-   local.tee $6
+   local.tee $var$6
    i32.const 1
    i32.add
    call $~lib/map/Map<u8,i32>#set:entriesOffset
-   local.get $6
+   local.get $var$6
    i32.const 12
    i32.mul
    i32.add
-   local.set $4
-   local.get $4
-   local.get $1
+   local.set $entry
+   local.get $entry
+   local.get $key
    call $~lib/map/MapEntry<u8,i32>#set:key
    i32.const 0
    drop
-   local.get $4
-   local.get $2
+   local.get $entry
+   local.get $value
    call $~lib/map/MapEntry<u8,i32>#set:value
    i32.const 0
    drop
-   local.get $0
-   local.get $0
+   local.get $this
+   local.get $this
    i32.load $0 offset=20
    i32.const 1
    i32.add
    call $~lib/map/Map<u8,i32>#set:entriesCount
-   local.get $0
+   local.get $this
    i32.load $0
-   local.get $3
-   local.get $0
+   local.get $hashCode
+   local.get $this
    i32.load $0 offset=4
    i32.and
    i32.const 4
    i32.mul
    i32.add
-   local.set $6
-   local.get $4
-   local.get $6
+   local.set $var$6
+   local.get $entry
+   local.get $var$6
    i32.load $0
    call $~lib/map/MapEntry<u8,i32>#set:taggedNext
-   local.get $6
-   local.get $4
+   local.get $var$6
+   local.get $entry
    i32.store $0
   end
-  local.get $0
+  local.get $this
   local.set $7
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -16530,11 +16530,11 @@
   global.set $~lib/memory/__stack_pointer
   local.get $7
  )
- (func $~lib/array/Array<u8>#constructor (param $0 i32) (param $1 i32) (result i32)
-  (local $2 i32)
-  (local $3 i32)
-  (local $4 i32)
-  (local $5 i32)
+ (func $~lib/array/Array<u8>#constructor (param $this i32) (param $length i32) (result i32)
+  (local $var$2 i32)
+  (local $var$3 i32)
+  (local $bufferSize i32)
+  (local $buffer i32)
   (local $6 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 8
@@ -16544,29 +16544,29 @@
   global.get $~lib/memory/__stack_pointer
   i64.const 0
   i64.store $0
-  local.get $0
+  local.get $this
   i32.eqz
   if
    global.get $~lib/memory/__stack_pointer
    i32.const 16
    i32.const 9
    call $~lib/rt/itcms/__new
-   local.tee $0
+   local.tee $this
    i32.store $0
   end
-  local.get $0
+  local.get $this
   i32.const 0
   call $~lib/array/Array<u8>#set:buffer
-  local.get $0
+  local.get $this
   i32.const 0
   call $~lib/array/Array<u8>#set:dataStart
-  local.get $0
+  local.get $this
   i32.const 0
   call $~lib/array/Array<u8>#set:byteLength
-  local.get $0
+  local.get $this
   i32.const 0
   call $~lib/array/Array<u8>#set:length_
-  local.get $1
+  local.get $length
   i32.const 1073741820
   i32.const 0
   i32.shr_u
@@ -16579,40 +16579,40 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $1
-  local.tee $2
+  local.get $length
+  local.tee $var$2
   i32.const 8
-  local.tee $3
-  local.get $2
-  local.get $3
+  local.tee $var$3
+  local.get $var$2
+  local.get $var$3
   i32.gt_u
   select
   i32.const 0
   i32.shl
-  local.set $4
+  local.set $bufferSize
   global.get $~lib/memory/__stack_pointer
-  local.get $4
+  local.get $bufferSize
   i32.const 0
   call $~lib/rt/itcms/__new
-  local.tee $5
+  local.tee $buffer
   i32.store $0 offset=4
   i32.const 2
   global.get $~lib/shared/runtime/Runtime.Incremental
   i32.ne
   drop
-  local.get $0
-  local.get $5
+  local.get $this
+  local.get $buffer
   call $~lib/array/Array<u8>#set:buffer
-  local.get $0
-  local.get $5
+  local.get $this
+  local.get $buffer
   call $~lib/array/Array<u8>#set:dataStart
-  local.get $0
-  local.get $4
+  local.get $this
+  local.get $bufferSize
   call $~lib/array/Array<u8>#set:byteLength
-  local.get $0
-  local.get $1
+  local.get $this
+  local.get $length
   call $~lib/array/Array<u8>#set:length_
-  local.get $0
+  local.get $this
   local.set $6
   global.get $~lib/memory/__stack_pointer
   i32.const 8
@@ -16620,15 +16620,15 @@
   global.set $~lib/memory/__stack_pointer
   local.get $6
  )
- (func $~lib/map/Map<u8,i32>#keys (param $0 i32) (result i32)
-  (local $1 i32)
-  (local $2 i32)
-  (local $3 i32)
-  (local $4 i32)
-  (local $5 i32)
-  (local $6 i32)
-  (local $7 i32)
-  (local $8 i32)
+ (func $~lib/map/Map<u8,i32>#keys (param $this i32) (result i32)
+  (local $start i32)
+  (local $size i32)
+  (local $keys i32)
+  (local $length i32)
+  (local $var$5 i32)
+  (local $var$6 i32)
+  (local $var$7 i32)
+  (local $var$8 i32)
   (local $9 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -16638,63 +16638,63 @@
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   i32.store $0
-  local.get $0
+  local.get $this
   i32.load $0 offset=8
-  local.set $1
-  local.get $0
+  local.set $start
+  local.get $this
   i32.load $0 offset=16
-  local.set $2
+  local.set $size
   global.get $~lib/memory/__stack_pointer
   i32.const 0
-  local.get $2
+  local.get $size
   call $~lib/array/Array<u8>#constructor
-  local.tee $3
+  local.tee $keys
   i32.store $0
   i32.const 0
-  local.set $4
+  local.set $length
   i32.const 0
-  local.set $5
+  local.set $var$5
   loop $for-loop|0
-   local.get $5
-   local.get $2
+   local.get $var$5
+   local.get $size
    i32.lt_s
-   local.set $6
-   local.get $6
+   local.set $var$6
+   local.get $var$6
    if
-    local.get $1
-    local.get $5
+    local.get $start
+    local.get $var$5
     i32.const 12
     i32.mul
     i32.add
-    local.set $7
-    local.get $7
+    local.set $var$7
+    local.get $var$7
     i32.load $0 offset=8
     i32.const 1
     i32.and
     i32.eqz
     if
-     local.get $3
-     local.get $4
-     local.tee $8
+     local.get $keys
+     local.get $length
+     local.tee $var$8
      i32.const 1
      i32.add
-     local.set $4
-     local.get $8
-     local.get $7
+     local.set $length
+     local.get $var$8
+     local.get $var$7
      i32.load8_u $0
      call $~lib/array/Array<u8>#__uset
     end
-    local.get $5
+    local.get $var$5
     i32.const 1
     i32.add
-    local.set $5
+    local.set $var$5
     br $for-loop|0
    end
   end
-  local.get $3
-  local.get $4
+  local.get $keys
+  local.get $length
   call $~lib/array/Array<u8>#set:length
-  local.get $3
+  local.get $keys
   local.set $9
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -16702,15 +16702,15 @@
   global.set $~lib/memory/__stack_pointer
   local.get $9
  )
- (func $~lib/map/Map<u8,i32>#values (param $0 i32) (result i32)
-  (local $1 i32)
-  (local $2 i32)
-  (local $3 i32)
-  (local $4 i32)
-  (local $5 i32)
-  (local $6 i32)
-  (local $7 i32)
-  (local $8 i32)
+ (func $~lib/map/Map<u8,i32>#values (param $this i32) (result i32)
+  (local $start i32)
+  (local $size i32)
+  (local $values i32)
+  (local $length i32)
+  (local $var$5 i32)
+  (local $var$6 i32)
+  (local $var$7 i32)
+  (local $var$8 i32)
   (local $9 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -16720,63 +16720,63 @@
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   i32.store $0
-  local.get $0
+  local.get $this
   i32.load $0 offset=8
-  local.set $1
-  local.get $0
+  local.set $start
+  local.get $this
   i32.load $0 offset=16
-  local.set $2
+  local.set $size
   global.get $~lib/memory/__stack_pointer
   i32.const 0
-  local.get $2
+  local.get $size
   call $~lib/array/Array<i32>#constructor
-  local.tee $3
+  local.tee $values
   i32.store $0
   i32.const 0
-  local.set $4
+  local.set $length
   i32.const 0
-  local.set $5
+  local.set $var$5
   loop $for-loop|0
-   local.get $5
-   local.get $2
+   local.get $var$5
+   local.get $size
    i32.lt_s
-   local.set $6
-   local.get $6
+   local.set $var$6
+   local.get $var$6
    if
-    local.get $1
-    local.get $5
+    local.get $start
+    local.get $var$5
     i32.const 12
     i32.mul
     i32.add
-    local.set $7
-    local.get $7
+    local.set $var$7
+    local.get $var$7
     i32.load $0 offset=8
     i32.const 1
     i32.and
     i32.eqz
     if
-     local.get $3
-     local.get $4
-     local.tee $8
+     local.get $values
+     local.get $length
+     local.tee $var$8
      i32.const 1
      i32.add
-     local.set $4
-     local.get $8
-     local.get $7
+     local.set $length
+     local.get $var$8
+     local.get $var$7
      i32.load $0 offset=4
      call $~lib/array/Array<i32>#__uset
     end
-    local.get $5
+    local.get $var$5
     i32.const 1
     i32.add
-    local.set $5
+    local.set $var$5
     br $for-loop|0
    end
   end
-  local.get $3
-  local.get $4
+  local.get $values
+  local.get $length
   call $~lib/array/Array<i32>#set:length
-  local.get $3
+  local.get $values
   local.set $9
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -16784,7 +16784,7 @@
   global.set $~lib/memory/__stack_pointer
   local.get $9
  )
- (func $~lib/map/Map<u8,u8>#constructor (param $0 i32) (result i32)
+ (func $~lib/map/Map<u8,u8>#constructor (param $this i32) (result i32)
   (local $1 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -16794,45 +16794,45 @@
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   i32.store $0
-  local.get $0
+  local.get $this
   i32.eqz
   if
    global.get $~lib/memory/__stack_pointer
    i32.const 24
    i32.const 10
    call $~lib/rt/itcms/__new
-   local.tee $0
+   local.tee $this
    i32.store $0
   end
-  local.get $0
+  local.get $this
   i32.const 0
   i32.const 4
   i32.const 4
   i32.mul
   call $~lib/arraybuffer/ArrayBuffer#constructor
   call $~lib/map/Map<u8,u8>#set:buckets
-  local.get $0
+  local.get $this
   i32.const 4
   i32.const 1
   i32.sub
   call $~lib/map/Map<u8,u8>#set:bucketsMask
-  local.get $0
+  local.get $this
   i32.const 0
   i32.const 4
   i32.const 8
   i32.mul
   call $~lib/arraybuffer/ArrayBuffer#constructor
   call $~lib/map/Map<u8,u8>#set:entries
-  local.get $0
+  local.get $this
   i32.const 4
   call $~lib/map/Map<u8,u8>#set:entriesCapacity
-  local.get $0
+  local.get $this
   i32.const 0
   call $~lib/map/Map<u8,u8>#set:entriesOffset
-  local.get $0
+  local.get $this
   i32.const 0
   call $~lib/map/Map<u8,u8>#set:entriesCount
-  local.get $0
+  local.get $this
   local.set $1
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -16840,11 +16840,11 @@
   global.set $~lib/memory/__stack_pointer
   local.get $1
  )
- (func $~lib/map/Map<u8,u8>#set (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
-  (local $3 i32)
-  (local $4 i32)
-  (local $5 i32)
-  (local $6 i32)
+ (func $~lib/map/Map<u8,u8>#set (param $this i32) (param $key i32) (param $value i32) (result i32)
+  (local $hashCode i32)
+  (local $entry i32)
+  (local $var$5 i32)
+  (local $var$6 i32)
   (local $7 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -16854,32 +16854,32 @@
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   i32.store $0
-  local.get $1
+  local.get $key
   call $~lib/util/hash/HASH<u8>
-  local.set $3
-  local.get $0
-  local.get $1
-  local.get $3
+  local.set $hashCode
+  local.get $this
+  local.get $key
+  local.get $hashCode
   call $~lib/map/Map<u8,u8>#find
-  local.set $4
-  local.get $4
+  local.set $entry
+  local.get $entry
   if
-   local.get $4
-   local.get $2
+   local.get $entry
+   local.get $value
    call $~lib/map/MapEntry<u8,u8>#set:value
    i32.const 0
    drop
   else
-   local.get $0
+   local.get $this
    i32.load $0 offset=16
-   local.get $0
+   local.get $this
    i32.load $0 offset=12
    i32.eq
    if
-    local.get $0
-    local.get $0
+    local.get $this
+    local.get $this
     i32.load $0 offset=20
-    local.get $0
+    local.get $this
     i32.load $0 offset=12
     i32.const 3
     i32.mul
@@ -16887,10 +16887,10 @@
     i32.div_s
     i32.lt_s
     if (result i32)
-     local.get $0
+     local.get $this
      i32.load $0 offset=4
     else
-     local.get $0
+     local.get $this
      i32.load $0 offset=4
      i32.const 1
      i32.shl
@@ -16900,58 +16900,58 @@
     call $~lib/map/Map<u8,u8>#rehash
    end
    global.get $~lib/memory/__stack_pointer
-   local.get $0
+   local.get $this
    i32.load $0 offset=8
-   local.tee $5
+   local.tee $var$5
    i32.store $0
-   local.get $5
-   local.get $0
-   local.get $0
+   local.get $var$5
+   local.get $this
+   local.get $this
    i32.load $0 offset=16
-   local.tee $6
+   local.tee $var$6
    i32.const 1
    i32.add
    call $~lib/map/Map<u8,u8>#set:entriesOffset
-   local.get $6
+   local.get $var$6
    i32.const 8
    i32.mul
    i32.add
-   local.set $4
-   local.get $4
-   local.get $1
+   local.set $entry
+   local.get $entry
+   local.get $key
    call $~lib/map/MapEntry<u8,u8>#set:key
    i32.const 0
    drop
-   local.get $4
-   local.get $2
+   local.get $entry
+   local.get $value
    call $~lib/map/MapEntry<u8,u8>#set:value
    i32.const 0
    drop
-   local.get $0
-   local.get $0
+   local.get $this
+   local.get $this
    i32.load $0 offset=20
    i32.const 1
    i32.add
    call $~lib/map/Map<u8,u8>#set:entriesCount
-   local.get $0
+   local.get $this
    i32.load $0
-   local.get $3
-   local.get $0
+   local.get $hashCode
+   local.get $this
    i32.load $0 offset=4
    i32.and
    i32.const 4
    i32.mul
    i32.add
-   local.set $6
-   local.get $4
-   local.get $6
+   local.set $var$6
+   local.get $entry
+   local.get $var$6
    i32.load $0
    call $~lib/map/MapEntry<u8,u8>#set:taggedNext
-   local.get $6
-   local.get $4
+   local.get $var$6
+   local.get $entry
    i32.store $0
   end
-  local.get $0
+  local.get $this
   local.set $7
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -16959,7 +16959,7 @@
   global.set $~lib/memory/__stack_pointer
   local.get $7
  )
- (func $~lib/map/Map<i16,i32>#constructor (param $0 i32) (result i32)
+ (func $~lib/map/Map<i16,i32>#constructor (param $this i32) (result i32)
   (local $1 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -16969,45 +16969,45 @@
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   i32.store $0
-  local.get $0
+  local.get $this
   i32.eqz
   if
    global.get $~lib/memory/__stack_pointer
    i32.const 24
    i32.const 11
    call $~lib/rt/itcms/__new
-   local.tee $0
+   local.tee $this
    i32.store $0
   end
-  local.get $0
+  local.get $this
   i32.const 0
   i32.const 4
   i32.const 4
   i32.mul
   call $~lib/arraybuffer/ArrayBuffer#constructor
   call $~lib/map/Map<i16,i32>#set:buckets
-  local.get $0
+  local.get $this
   i32.const 4
   i32.const 1
   i32.sub
   call $~lib/map/Map<i16,i32>#set:bucketsMask
-  local.get $0
+  local.get $this
   i32.const 0
   i32.const 4
   i32.const 12
   i32.mul
   call $~lib/arraybuffer/ArrayBuffer#constructor
   call $~lib/map/Map<i16,i32>#set:entries
-  local.get $0
+  local.get $this
   i32.const 4
   call $~lib/map/Map<i16,i32>#set:entriesCapacity
-  local.get $0
+  local.get $this
   i32.const 0
   call $~lib/map/Map<i16,i32>#set:entriesOffset
-  local.get $0
+  local.get $this
   i32.const 0
   call $~lib/map/Map<i16,i32>#set:entriesCount
-  local.get $0
+  local.get $this
   local.set $1
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -17015,11 +17015,11 @@
   global.set $~lib/memory/__stack_pointer
   local.get $1
  )
- (func $~lib/map/Map<i16,i32>#set (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
-  (local $3 i32)
-  (local $4 i32)
-  (local $5 i32)
-  (local $6 i32)
+ (func $~lib/map/Map<i16,i32>#set (param $this i32) (param $key i32) (param $value i32) (result i32)
+  (local $hashCode i32)
+  (local $entry i32)
+  (local $var$5 i32)
+  (local $var$6 i32)
   (local $7 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -17029,32 +17029,32 @@
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   i32.store $0
-  local.get $1
+  local.get $key
   call $~lib/util/hash/HASH<i16>
-  local.set $3
-  local.get $0
-  local.get $1
-  local.get $3
+  local.set $hashCode
+  local.get $this
+  local.get $key
+  local.get $hashCode
   call $~lib/map/Map<i16,i32>#find
-  local.set $4
-  local.get $4
+  local.set $entry
+  local.get $entry
   if
-   local.get $4
-   local.get $2
+   local.get $entry
+   local.get $value
    call $~lib/map/MapEntry<i16,i32>#set:value
    i32.const 0
    drop
   else
-   local.get $0
+   local.get $this
    i32.load $0 offset=16
-   local.get $0
+   local.get $this
    i32.load $0 offset=12
    i32.eq
    if
-    local.get $0
-    local.get $0
+    local.get $this
+    local.get $this
     i32.load $0 offset=20
-    local.get $0
+    local.get $this
     i32.load $0 offset=12
     i32.const 3
     i32.mul
@@ -17062,10 +17062,10 @@
     i32.div_s
     i32.lt_s
     if (result i32)
-     local.get $0
+     local.get $this
      i32.load $0 offset=4
     else
-     local.get $0
+     local.get $this
      i32.load $0 offset=4
      i32.const 1
      i32.shl
@@ -17075,58 +17075,58 @@
     call $~lib/map/Map<i16,i32>#rehash
    end
    global.get $~lib/memory/__stack_pointer
-   local.get $0
+   local.get $this
    i32.load $0 offset=8
-   local.tee $5
+   local.tee $var$5
    i32.store $0
-   local.get $5
-   local.get $0
-   local.get $0
+   local.get $var$5
+   local.get $this
+   local.get $this
    i32.load $0 offset=16
-   local.tee $6
+   local.tee $var$6
    i32.const 1
    i32.add
    call $~lib/map/Map<i16,i32>#set:entriesOffset
-   local.get $6
+   local.get $var$6
    i32.const 12
    i32.mul
    i32.add
-   local.set $4
-   local.get $4
-   local.get $1
+   local.set $entry
+   local.get $entry
+   local.get $key
    call $~lib/map/MapEntry<i16,i32>#set:key
    i32.const 0
    drop
-   local.get $4
-   local.get $2
+   local.get $entry
+   local.get $value
    call $~lib/map/MapEntry<i16,i32>#set:value
    i32.const 0
    drop
-   local.get $0
-   local.get $0
+   local.get $this
+   local.get $this
    i32.load $0 offset=20
    i32.const 1
    i32.add
    call $~lib/map/Map<i16,i32>#set:entriesCount
-   local.get $0
+   local.get $this
    i32.load $0
-   local.get $3
-   local.get $0
+   local.get $hashCode
+   local.get $this
    i32.load $0 offset=4
    i32.and
    i32.const 4
    i32.mul
    i32.add
-   local.set $6
-   local.get $4
-   local.get $6
+   local.set $var$6
+   local.get $entry
+   local.get $var$6
    i32.load $0
    call $~lib/map/MapEntry<i16,i32>#set:taggedNext
-   local.get $6
-   local.get $4
+   local.get $var$6
+   local.get $entry
    i32.store $0
   end
-  local.get $0
+  local.get $this
   local.set $7
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -17134,11 +17134,11 @@
   global.set $~lib/memory/__stack_pointer
   local.get $7
  )
- (func $~lib/array/Array<i16>#constructor (param $0 i32) (param $1 i32) (result i32)
-  (local $2 i32)
-  (local $3 i32)
-  (local $4 i32)
-  (local $5 i32)
+ (func $~lib/array/Array<i16>#constructor (param $this i32) (param $length i32) (result i32)
+  (local $var$2 i32)
+  (local $var$3 i32)
+  (local $bufferSize i32)
+  (local $buffer i32)
   (local $6 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 8
@@ -17148,29 +17148,29 @@
   global.get $~lib/memory/__stack_pointer
   i64.const 0
   i64.store $0
-  local.get $0
+  local.get $this
   i32.eqz
   if
    global.get $~lib/memory/__stack_pointer
    i32.const 16
    i32.const 12
    call $~lib/rt/itcms/__new
-   local.tee $0
+   local.tee $this
    i32.store $0
   end
-  local.get $0
+  local.get $this
   i32.const 0
   call $~lib/array/Array<i16>#set:buffer
-  local.get $0
+  local.get $this
   i32.const 0
   call $~lib/array/Array<i16>#set:dataStart
-  local.get $0
+  local.get $this
   i32.const 0
   call $~lib/array/Array<i16>#set:byteLength
-  local.get $0
+  local.get $this
   i32.const 0
   call $~lib/array/Array<i16>#set:length_
-  local.get $1
+  local.get $length
   i32.const 1073741820
   i32.const 1
   i32.shr_u
@@ -17183,40 +17183,40 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $1
-  local.tee $2
+  local.get $length
+  local.tee $var$2
   i32.const 8
-  local.tee $3
-  local.get $2
-  local.get $3
+  local.tee $var$3
+  local.get $var$2
+  local.get $var$3
   i32.gt_u
   select
   i32.const 1
   i32.shl
-  local.set $4
+  local.set $bufferSize
   global.get $~lib/memory/__stack_pointer
-  local.get $4
+  local.get $bufferSize
   i32.const 0
   call $~lib/rt/itcms/__new
-  local.tee $5
+  local.tee $buffer
   i32.store $0 offset=4
   i32.const 2
   global.get $~lib/shared/runtime/Runtime.Incremental
   i32.ne
   drop
-  local.get $0
-  local.get $5
+  local.get $this
+  local.get $buffer
   call $~lib/array/Array<i16>#set:buffer
-  local.get $0
-  local.get $5
+  local.get $this
+  local.get $buffer
   call $~lib/array/Array<i16>#set:dataStart
-  local.get $0
-  local.get $4
+  local.get $this
+  local.get $bufferSize
   call $~lib/array/Array<i16>#set:byteLength
-  local.get $0
-  local.get $1
+  local.get $this
+  local.get $length
   call $~lib/array/Array<i16>#set:length_
-  local.get $0
+  local.get $this
   local.set $6
   global.get $~lib/memory/__stack_pointer
   i32.const 8
@@ -17224,15 +17224,15 @@
   global.set $~lib/memory/__stack_pointer
   local.get $6
  )
- (func $~lib/map/Map<i16,i32>#keys (param $0 i32) (result i32)
-  (local $1 i32)
-  (local $2 i32)
-  (local $3 i32)
-  (local $4 i32)
-  (local $5 i32)
-  (local $6 i32)
-  (local $7 i32)
-  (local $8 i32)
+ (func $~lib/map/Map<i16,i32>#keys (param $this i32) (result i32)
+  (local $start i32)
+  (local $size i32)
+  (local $keys i32)
+  (local $length i32)
+  (local $var$5 i32)
+  (local $var$6 i32)
+  (local $var$7 i32)
+  (local $var$8 i32)
   (local $9 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -17242,63 +17242,63 @@
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   i32.store $0
-  local.get $0
+  local.get $this
   i32.load $0 offset=8
-  local.set $1
-  local.get $0
+  local.set $start
+  local.get $this
   i32.load $0 offset=16
-  local.set $2
+  local.set $size
   global.get $~lib/memory/__stack_pointer
   i32.const 0
-  local.get $2
+  local.get $size
   call $~lib/array/Array<i16>#constructor
-  local.tee $3
+  local.tee $keys
   i32.store $0
   i32.const 0
-  local.set $4
+  local.set $length
   i32.const 0
-  local.set $5
+  local.set $var$5
   loop $for-loop|0
-   local.get $5
-   local.get $2
+   local.get $var$5
+   local.get $size
    i32.lt_s
-   local.set $6
-   local.get $6
+   local.set $var$6
+   local.get $var$6
    if
-    local.get $1
-    local.get $5
+    local.get $start
+    local.get $var$5
     i32.const 12
     i32.mul
     i32.add
-    local.set $7
-    local.get $7
+    local.set $var$7
+    local.get $var$7
     i32.load $0 offset=8
     i32.const 1
     i32.and
     i32.eqz
     if
-     local.get $3
-     local.get $4
-     local.tee $8
+     local.get $keys
+     local.get $length
+     local.tee $var$8
      i32.const 1
      i32.add
-     local.set $4
-     local.get $8
-     local.get $7
+     local.set $length
+     local.get $var$8
+     local.get $var$7
      i32.load16_s $0
      call $~lib/array/Array<i16>#__uset
     end
-    local.get $5
+    local.get $var$5
     i32.const 1
     i32.add
-    local.set $5
+    local.set $var$5
     br $for-loop|0
    end
   end
-  local.get $3
-  local.get $4
+  local.get $keys
+  local.get $length
   call $~lib/array/Array<i16>#set:length
-  local.get $3
+  local.get $keys
   local.set $9
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -17306,15 +17306,15 @@
   global.set $~lib/memory/__stack_pointer
   local.get $9
  )
- (func $~lib/map/Map<i16,i32>#values (param $0 i32) (result i32)
-  (local $1 i32)
-  (local $2 i32)
-  (local $3 i32)
-  (local $4 i32)
-  (local $5 i32)
-  (local $6 i32)
-  (local $7 i32)
-  (local $8 i32)
+ (func $~lib/map/Map<i16,i32>#values (param $this i32) (result i32)
+  (local $start i32)
+  (local $size i32)
+  (local $values i32)
+  (local $length i32)
+  (local $var$5 i32)
+  (local $var$6 i32)
+  (local $var$7 i32)
+  (local $var$8 i32)
   (local $9 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -17324,63 +17324,63 @@
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   i32.store $0
-  local.get $0
+  local.get $this
   i32.load $0 offset=8
-  local.set $1
-  local.get $0
+  local.set $start
+  local.get $this
   i32.load $0 offset=16
-  local.set $2
+  local.set $size
   global.get $~lib/memory/__stack_pointer
   i32.const 0
-  local.get $2
+  local.get $size
   call $~lib/array/Array<i32>#constructor
-  local.tee $3
+  local.tee $values
   i32.store $0
   i32.const 0
-  local.set $4
+  local.set $length
   i32.const 0
-  local.set $5
+  local.set $var$5
   loop $for-loop|0
-   local.get $5
-   local.get $2
+   local.get $var$5
+   local.get $size
    i32.lt_s
-   local.set $6
-   local.get $6
+   local.set $var$6
+   local.get $var$6
    if
-    local.get $1
-    local.get $5
+    local.get $start
+    local.get $var$5
     i32.const 12
     i32.mul
     i32.add
-    local.set $7
-    local.get $7
+    local.set $var$7
+    local.get $var$7
     i32.load $0 offset=8
     i32.const 1
     i32.and
     i32.eqz
     if
-     local.get $3
-     local.get $4
-     local.tee $8
+     local.get $values
+     local.get $length
+     local.tee $var$8
      i32.const 1
      i32.add
-     local.set $4
-     local.get $8
-     local.get $7
+     local.set $length
+     local.get $var$8
+     local.get $var$7
      i32.load $0 offset=4
      call $~lib/array/Array<i32>#__uset
     end
-    local.get $5
+    local.get $var$5
     i32.const 1
     i32.add
-    local.set $5
+    local.set $var$5
     br $for-loop|0
    end
   end
-  local.get $3
-  local.get $4
+  local.get $values
+  local.get $length
   call $~lib/array/Array<i32>#set:length
-  local.get $3
+  local.get $values
   local.set $9
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -17388,7 +17388,7 @@
   global.set $~lib/memory/__stack_pointer
   local.get $9
  )
- (func $~lib/map/Map<i16,i16>#constructor (param $0 i32) (result i32)
+ (func $~lib/map/Map<i16,i16>#constructor (param $this i32) (result i32)
   (local $1 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -17398,45 +17398,45 @@
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   i32.store $0
-  local.get $0
+  local.get $this
   i32.eqz
   if
    global.get $~lib/memory/__stack_pointer
    i32.const 24
    i32.const 13
    call $~lib/rt/itcms/__new
-   local.tee $0
+   local.tee $this
    i32.store $0
   end
-  local.get $0
+  local.get $this
   i32.const 0
   i32.const 4
   i32.const 4
   i32.mul
   call $~lib/arraybuffer/ArrayBuffer#constructor
   call $~lib/map/Map<i16,i16>#set:buckets
-  local.get $0
+  local.get $this
   i32.const 4
   i32.const 1
   i32.sub
   call $~lib/map/Map<i16,i16>#set:bucketsMask
-  local.get $0
+  local.get $this
   i32.const 0
   i32.const 4
   i32.const 8
   i32.mul
   call $~lib/arraybuffer/ArrayBuffer#constructor
   call $~lib/map/Map<i16,i16>#set:entries
-  local.get $0
+  local.get $this
   i32.const 4
   call $~lib/map/Map<i16,i16>#set:entriesCapacity
-  local.get $0
+  local.get $this
   i32.const 0
   call $~lib/map/Map<i16,i16>#set:entriesOffset
-  local.get $0
+  local.get $this
   i32.const 0
   call $~lib/map/Map<i16,i16>#set:entriesCount
-  local.get $0
+  local.get $this
   local.set $1
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -17444,11 +17444,11 @@
   global.set $~lib/memory/__stack_pointer
   local.get $1
  )
- (func $~lib/map/Map<i16,i16>#set (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
-  (local $3 i32)
-  (local $4 i32)
-  (local $5 i32)
-  (local $6 i32)
+ (func $~lib/map/Map<i16,i16>#set (param $this i32) (param $key i32) (param $value i32) (result i32)
+  (local $hashCode i32)
+  (local $entry i32)
+  (local $var$5 i32)
+  (local $var$6 i32)
   (local $7 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -17458,32 +17458,32 @@
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   i32.store $0
-  local.get $1
+  local.get $key
   call $~lib/util/hash/HASH<i16>
-  local.set $3
-  local.get $0
-  local.get $1
-  local.get $3
+  local.set $hashCode
+  local.get $this
+  local.get $key
+  local.get $hashCode
   call $~lib/map/Map<i16,i16>#find
-  local.set $4
-  local.get $4
+  local.set $entry
+  local.get $entry
   if
-   local.get $4
-   local.get $2
+   local.get $entry
+   local.get $value
    call $~lib/map/MapEntry<i16,i16>#set:value
    i32.const 0
    drop
   else
-   local.get $0
+   local.get $this
    i32.load $0 offset=16
-   local.get $0
+   local.get $this
    i32.load $0 offset=12
    i32.eq
    if
-    local.get $0
-    local.get $0
+    local.get $this
+    local.get $this
     i32.load $0 offset=20
-    local.get $0
+    local.get $this
     i32.load $0 offset=12
     i32.const 3
     i32.mul
@@ -17491,10 +17491,10 @@
     i32.div_s
     i32.lt_s
     if (result i32)
-     local.get $0
+     local.get $this
      i32.load $0 offset=4
     else
-     local.get $0
+     local.get $this
      i32.load $0 offset=4
      i32.const 1
      i32.shl
@@ -17504,58 +17504,58 @@
     call $~lib/map/Map<i16,i16>#rehash
    end
    global.get $~lib/memory/__stack_pointer
-   local.get $0
+   local.get $this
    i32.load $0 offset=8
-   local.tee $5
+   local.tee $var$5
    i32.store $0
-   local.get $5
-   local.get $0
-   local.get $0
+   local.get $var$5
+   local.get $this
+   local.get $this
    i32.load $0 offset=16
-   local.tee $6
+   local.tee $var$6
    i32.const 1
    i32.add
    call $~lib/map/Map<i16,i16>#set:entriesOffset
-   local.get $6
+   local.get $var$6
    i32.const 8
    i32.mul
    i32.add
-   local.set $4
-   local.get $4
-   local.get $1
+   local.set $entry
+   local.get $entry
+   local.get $key
    call $~lib/map/MapEntry<i16,i16>#set:key
    i32.const 0
    drop
-   local.get $4
-   local.get $2
+   local.get $entry
+   local.get $value
    call $~lib/map/MapEntry<i16,i16>#set:value
    i32.const 0
    drop
-   local.get $0
-   local.get $0
+   local.get $this
+   local.get $this
    i32.load $0 offset=20
    i32.const 1
    i32.add
    call $~lib/map/Map<i16,i16>#set:entriesCount
-   local.get $0
+   local.get $this
    i32.load $0
-   local.get $3
-   local.get $0
+   local.get $hashCode
+   local.get $this
    i32.load $0 offset=4
    i32.and
    i32.const 4
    i32.mul
    i32.add
-   local.set $6
-   local.get $4
-   local.get $6
+   local.set $var$6
+   local.get $entry
+   local.get $var$6
    i32.load $0
    call $~lib/map/MapEntry<i16,i16>#set:taggedNext
-   local.get $6
-   local.get $4
+   local.get $var$6
+   local.get $entry
    i32.store $0
   end
-  local.get $0
+  local.get $this
   local.set $7
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -17563,7 +17563,7 @@
   global.set $~lib/memory/__stack_pointer
   local.get $7
  )
- (func $~lib/map/Map<u16,i32>#constructor (param $0 i32) (result i32)
+ (func $~lib/map/Map<u16,i32>#constructor (param $this i32) (result i32)
   (local $1 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -17573,45 +17573,45 @@
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   i32.store $0
-  local.get $0
+  local.get $this
   i32.eqz
   if
    global.get $~lib/memory/__stack_pointer
    i32.const 24
    i32.const 14
    call $~lib/rt/itcms/__new
-   local.tee $0
+   local.tee $this
    i32.store $0
   end
-  local.get $0
+  local.get $this
   i32.const 0
   i32.const 4
   i32.const 4
   i32.mul
   call $~lib/arraybuffer/ArrayBuffer#constructor
   call $~lib/map/Map<u16,i32>#set:buckets
-  local.get $0
+  local.get $this
   i32.const 4
   i32.const 1
   i32.sub
   call $~lib/map/Map<u16,i32>#set:bucketsMask
-  local.get $0
+  local.get $this
   i32.const 0
   i32.const 4
   i32.const 12
   i32.mul
   call $~lib/arraybuffer/ArrayBuffer#constructor
   call $~lib/map/Map<u16,i32>#set:entries
-  local.get $0
+  local.get $this
   i32.const 4
   call $~lib/map/Map<u16,i32>#set:entriesCapacity
-  local.get $0
+  local.get $this
   i32.const 0
   call $~lib/map/Map<u16,i32>#set:entriesOffset
-  local.get $0
+  local.get $this
   i32.const 0
   call $~lib/map/Map<u16,i32>#set:entriesCount
-  local.get $0
+  local.get $this
   local.set $1
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -17619,11 +17619,11 @@
   global.set $~lib/memory/__stack_pointer
   local.get $1
  )
- (func $~lib/map/Map<u16,i32>#set (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
-  (local $3 i32)
-  (local $4 i32)
-  (local $5 i32)
-  (local $6 i32)
+ (func $~lib/map/Map<u16,i32>#set (param $this i32) (param $key i32) (param $value i32) (result i32)
+  (local $hashCode i32)
+  (local $entry i32)
+  (local $var$5 i32)
+  (local $var$6 i32)
   (local $7 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -17633,32 +17633,32 @@
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   i32.store $0
-  local.get $1
+  local.get $key
   call $~lib/util/hash/HASH<u16>
-  local.set $3
-  local.get $0
-  local.get $1
-  local.get $3
+  local.set $hashCode
+  local.get $this
+  local.get $key
+  local.get $hashCode
   call $~lib/map/Map<u16,i32>#find
-  local.set $4
-  local.get $4
+  local.set $entry
+  local.get $entry
   if
-   local.get $4
-   local.get $2
+   local.get $entry
+   local.get $value
    call $~lib/map/MapEntry<u16,i32>#set:value
    i32.const 0
    drop
   else
-   local.get $0
+   local.get $this
    i32.load $0 offset=16
-   local.get $0
+   local.get $this
    i32.load $0 offset=12
    i32.eq
    if
-    local.get $0
-    local.get $0
+    local.get $this
+    local.get $this
     i32.load $0 offset=20
-    local.get $0
+    local.get $this
     i32.load $0 offset=12
     i32.const 3
     i32.mul
@@ -17666,10 +17666,10 @@
     i32.div_s
     i32.lt_s
     if (result i32)
-     local.get $0
+     local.get $this
      i32.load $0 offset=4
     else
-     local.get $0
+     local.get $this
      i32.load $0 offset=4
      i32.const 1
      i32.shl
@@ -17679,58 +17679,58 @@
     call $~lib/map/Map<u16,i32>#rehash
    end
    global.get $~lib/memory/__stack_pointer
-   local.get $0
+   local.get $this
    i32.load $0 offset=8
-   local.tee $5
+   local.tee $var$5
    i32.store $0
-   local.get $5
-   local.get $0
-   local.get $0
+   local.get $var$5
+   local.get $this
+   local.get $this
    i32.load $0 offset=16
-   local.tee $6
+   local.tee $var$6
    i32.const 1
    i32.add
    call $~lib/map/Map<u16,i32>#set:entriesOffset
-   local.get $6
+   local.get $var$6
    i32.const 12
    i32.mul
    i32.add
-   local.set $4
-   local.get $4
-   local.get $1
+   local.set $entry
+   local.get $entry
+   local.get $key
    call $~lib/map/MapEntry<u16,i32>#set:key
    i32.const 0
    drop
-   local.get $4
-   local.get $2
+   local.get $entry
+   local.get $value
    call $~lib/map/MapEntry<u16,i32>#set:value
    i32.const 0
    drop
-   local.get $0
-   local.get $0
+   local.get $this
+   local.get $this
    i32.load $0 offset=20
    i32.const 1
    i32.add
    call $~lib/map/Map<u16,i32>#set:entriesCount
-   local.get $0
+   local.get $this
    i32.load $0
-   local.get $3
-   local.get $0
+   local.get $hashCode
+   local.get $this
    i32.load $0 offset=4
    i32.and
    i32.const 4
    i32.mul
    i32.add
-   local.set $6
-   local.get $4
-   local.get $6
+   local.set $var$6
+   local.get $entry
+   local.get $var$6
    i32.load $0
    call $~lib/map/MapEntry<u16,i32>#set:taggedNext
-   local.get $6
-   local.get $4
+   local.get $var$6
+   local.get $entry
    i32.store $0
   end
-  local.get $0
+  local.get $this
   local.set $7
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -17738,11 +17738,11 @@
   global.set $~lib/memory/__stack_pointer
   local.get $7
  )
- (func $~lib/array/Array<u16>#constructor (param $0 i32) (param $1 i32) (result i32)
-  (local $2 i32)
-  (local $3 i32)
-  (local $4 i32)
-  (local $5 i32)
+ (func $~lib/array/Array<u16>#constructor (param $this i32) (param $length i32) (result i32)
+  (local $var$2 i32)
+  (local $var$3 i32)
+  (local $bufferSize i32)
+  (local $buffer i32)
   (local $6 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 8
@@ -17752,29 +17752,29 @@
   global.get $~lib/memory/__stack_pointer
   i64.const 0
   i64.store $0
-  local.get $0
+  local.get $this
   i32.eqz
   if
    global.get $~lib/memory/__stack_pointer
    i32.const 16
    i32.const 15
    call $~lib/rt/itcms/__new
-   local.tee $0
+   local.tee $this
    i32.store $0
   end
-  local.get $0
+  local.get $this
   i32.const 0
   call $~lib/array/Array<u16>#set:buffer
-  local.get $0
+  local.get $this
   i32.const 0
   call $~lib/array/Array<u16>#set:dataStart
-  local.get $0
+  local.get $this
   i32.const 0
   call $~lib/array/Array<u16>#set:byteLength
-  local.get $0
+  local.get $this
   i32.const 0
   call $~lib/array/Array<u16>#set:length_
-  local.get $1
+  local.get $length
   i32.const 1073741820
   i32.const 1
   i32.shr_u
@@ -17787,40 +17787,40 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $1
-  local.tee $2
+  local.get $length
+  local.tee $var$2
   i32.const 8
-  local.tee $3
-  local.get $2
-  local.get $3
+  local.tee $var$3
+  local.get $var$2
+  local.get $var$3
   i32.gt_u
   select
   i32.const 1
   i32.shl
-  local.set $4
+  local.set $bufferSize
   global.get $~lib/memory/__stack_pointer
-  local.get $4
+  local.get $bufferSize
   i32.const 0
   call $~lib/rt/itcms/__new
-  local.tee $5
+  local.tee $buffer
   i32.store $0 offset=4
   i32.const 2
   global.get $~lib/shared/runtime/Runtime.Incremental
   i32.ne
   drop
-  local.get $0
-  local.get $5
+  local.get $this
+  local.get $buffer
   call $~lib/array/Array<u16>#set:buffer
-  local.get $0
-  local.get $5
+  local.get $this
+  local.get $buffer
   call $~lib/array/Array<u16>#set:dataStart
-  local.get $0
-  local.get $4
+  local.get $this
+  local.get $bufferSize
   call $~lib/array/Array<u16>#set:byteLength
-  local.get $0
-  local.get $1
+  local.get $this
+  local.get $length
   call $~lib/array/Array<u16>#set:length_
-  local.get $0
+  local.get $this
   local.set $6
   global.get $~lib/memory/__stack_pointer
   i32.const 8
@@ -17828,15 +17828,15 @@
   global.set $~lib/memory/__stack_pointer
   local.get $6
  )
- (func $~lib/map/Map<u16,i32>#keys (param $0 i32) (result i32)
-  (local $1 i32)
-  (local $2 i32)
-  (local $3 i32)
-  (local $4 i32)
-  (local $5 i32)
-  (local $6 i32)
-  (local $7 i32)
-  (local $8 i32)
+ (func $~lib/map/Map<u16,i32>#keys (param $this i32) (result i32)
+  (local $start i32)
+  (local $size i32)
+  (local $keys i32)
+  (local $length i32)
+  (local $var$5 i32)
+  (local $var$6 i32)
+  (local $var$7 i32)
+  (local $var$8 i32)
   (local $9 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -17846,63 +17846,63 @@
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   i32.store $0
-  local.get $0
+  local.get $this
   i32.load $0 offset=8
-  local.set $1
-  local.get $0
+  local.set $start
+  local.get $this
   i32.load $0 offset=16
-  local.set $2
+  local.set $size
   global.get $~lib/memory/__stack_pointer
   i32.const 0
-  local.get $2
+  local.get $size
   call $~lib/array/Array<u16>#constructor
-  local.tee $3
+  local.tee $keys
   i32.store $0
   i32.const 0
-  local.set $4
+  local.set $length
   i32.const 0
-  local.set $5
+  local.set $var$5
   loop $for-loop|0
-   local.get $5
-   local.get $2
+   local.get $var$5
+   local.get $size
    i32.lt_s
-   local.set $6
-   local.get $6
+   local.set $var$6
+   local.get $var$6
    if
-    local.get $1
-    local.get $5
+    local.get $start
+    local.get $var$5
     i32.const 12
     i32.mul
     i32.add
-    local.set $7
-    local.get $7
+    local.set $var$7
+    local.get $var$7
     i32.load $0 offset=8
     i32.const 1
     i32.and
     i32.eqz
     if
-     local.get $3
-     local.get $4
-     local.tee $8
+     local.get $keys
+     local.get $length
+     local.tee $var$8
      i32.const 1
      i32.add
-     local.set $4
-     local.get $8
-     local.get $7
+     local.set $length
+     local.get $var$8
+     local.get $var$7
      i32.load16_u $0
      call $~lib/array/Array<u16>#__uset
     end
-    local.get $5
+    local.get $var$5
     i32.const 1
     i32.add
-    local.set $5
+    local.set $var$5
     br $for-loop|0
    end
   end
-  local.get $3
-  local.get $4
+  local.get $keys
+  local.get $length
   call $~lib/array/Array<u16>#set:length
-  local.get $3
+  local.get $keys
   local.set $9
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -17910,15 +17910,15 @@
   global.set $~lib/memory/__stack_pointer
   local.get $9
  )
- (func $~lib/map/Map<u16,i32>#values (param $0 i32) (result i32)
-  (local $1 i32)
-  (local $2 i32)
-  (local $3 i32)
-  (local $4 i32)
-  (local $5 i32)
-  (local $6 i32)
-  (local $7 i32)
-  (local $8 i32)
+ (func $~lib/map/Map<u16,i32>#values (param $this i32) (result i32)
+  (local $start i32)
+  (local $size i32)
+  (local $values i32)
+  (local $length i32)
+  (local $var$5 i32)
+  (local $var$6 i32)
+  (local $var$7 i32)
+  (local $var$8 i32)
   (local $9 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -17928,63 +17928,63 @@
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   i32.store $0
-  local.get $0
+  local.get $this
   i32.load $0 offset=8
-  local.set $1
-  local.get $0
+  local.set $start
+  local.get $this
   i32.load $0 offset=16
-  local.set $2
+  local.set $size
   global.get $~lib/memory/__stack_pointer
   i32.const 0
-  local.get $2
+  local.get $size
   call $~lib/array/Array<i32>#constructor
-  local.tee $3
+  local.tee $values
   i32.store $0
   i32.const 0
-  local.set $4
+  local.set $length
   i32.const 0
-  local.set $5
+  local.set $var$5
   loop $for-loop|0
-   local.get $5
-   local.get $2
+   local.get $var$5
+   local.get $size
    i32.lt_s
-   local.set $6
-   local.get $6
+   local.set $var$6
+   local.get $var$6
    if
-    local.get $1
-    local.get $5
+    local.get $start
+    local.get $var$5
     i32.const 12
     i32.mul
     i32.add
-    local.set $7
-    local.get $7
+    local.set $var$7
+    local.get $var$7
     i32.load $0 offset=8
     i32.const 1
     i32.and
     i32.eqz
     if
-     local.get $3
-     local.get $4
-     local.tee $8
+     local.get $values
+     local.get $length
+     local.tee $var$8
      i32.const 1
      i32.add
-     local.set $4
-     local.get $8
-     local.get $7
+     local.set $length
+     local.get $var$8
+     local.get $var$7
      i32.load $0 offset=4
      call $~lib/array/Array<i32>#__uset
     end
-    local.get $5
+    local.get $var$5
     i32.const 1
     i32.add
-    local.set $5
+    local.set $var$5
     br $for-loop|0
    end
   end
-  local.get $3
-  local.get $4
+  local.get $values
+  local.get $length
   call $~lib/array/Array<i32>#set:length
-  local.get $3
+  local.get $values
   local.set $9
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -17992,7 +17992,7 @@
   global.set $~lib/memory/__stack_pointer
   local.get $9
  )
- (func $~lib/map/Map<u16,u16>#constructor (param $0 i32) (result i32)
+ (func $~lib/map/Map<u16,u16>#constructor (param $this i32) (result i32)
   (local $1 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -18002,45 +18002,45 @@
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   i32.store $0
-  local.get $0
+  local.get $this
   i32.eqz
   if
    global.get $~lib/memory/__stack_pointer
    i32.const 24
    i32.const 16
    call $~lib/rt/itcms/__new
-   local.tee $0
+   local.tee $this
    i32.store $0
   end
-  local.get $0
+  local.get $this
   i32.const 0
   i32.const 4
   i32.const 4
   i32.mul
   call $~lib/arraybuffer/ArrayBuffer#constructor
   call $~lib/map/Map<u16,u16>#set:buckets
-  local.get $0
+  local.get $this
   i32.const 4
   i32.const 1
   i32.sub
   call $~lib/map/Map<u16,u16>#set:bucketsMask
-  local.get $0
+  local.get $this
   i32.const 0
   i32.const 4
   i32.const 8
   i32.mul
   call $~lib/arraybuffer/ArrayBuffer#constructor
   call $~lib/map/Map<u16,u16>#set:entries
-  local.get $0
+  local.get $this
   i32.const 4
   call $~lib/map/Map<u16,u16>#set:entriesCapacity
-  local.get $0
+  local.get $this
   i32.const 0
   call $~lib/map/Map<u16,u16>#set:entriesOffset
-  local.get $0
+  local.get $this
   i32.const 0
   call $~lib/map/Map<u16,u16>#set:entriesCount
-  local.get $0
+  local.get $this
   local.set $1
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -18048,11 +18048,11 @@
   global.set $~lib/memory/__stack_pointer
   local.get $1
  )
- (func $~lib/map/Map<u16,u16>#set (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
-  (local $3 i32)
-  (local $4 i32)
-  (local $5 i32)
-  (local $6 i32)
+ (func $~lib/map/Map<u16,u16>#set (param $this i32) (param $key i32) (param $value i32) (result i32)
+  (local $hashCode i32)
+  (local $entry i32)
+  (local $var$5 i32)
+  (local $var$6 i32)
   (local $7 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -18062,32 +18062,32 @@
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   i32.store $0
-  local.get $1
+  local.get $key
   call $~lib/util/hash/HASH<u16>
-  local.set $3
-  local.get $0
-  local.get $1
-  local.get $3
+  local.set $hashCode
+  local.get $this
+  local.get $key
+  local.get $hashCode
   call $~lib/map/Map<u16,u16>#find
-  local.set $4
-  local.get $4
+  local.set $entry
+  local.get $entry
   if
-   local.get $4
-   local.get $2
+   local.get $entry
+   local.get $value
    call $~lib/map/MapEntry<u16,u16>#set:value
    i32.const 0
    drop
   else
-   local.get $0
+   local.get $this
    i32.load $0 offset=16
-   local.get $0
+   local.get $this
    i32.load $0 offset=12
    i32.eq
    if
-    local.get $0
-    local.get $0
+    local.get $this
+    local.get $this
     i32.load $0 offset=20
-    local.get $0
+    local.get $this
     i32.load $0 offset=12
     i32.const 3
     i32.mul
@@ -18095,10 +18095,10 @@
     i32.div_s
     i32.lt_s
     if (result i32)
-     local.get $0
+     local.get $this
      i32.load $0 offset=4
     else
-     local.get $0
+     local.get $this
      i32.load $0 offset=4
      i32.const 1
      i32.shl
@@ -18108,58 +18108,58 @@
     call $~lib/map/Map<u16,u16>#rehash
    end
    global.get $~lib/memory/__stack_pointer
-   local.get $0
+   local.get $this
    i32.load $0 offset=8
-   local.tee $5
+   local.tee $var$5
    i32.store $0
-   local.get $5
-   local.get $0
-   local.get $0
+   local.get $var$5
+   local.get $this
+   local.get $this
    i32.load $0 offset=16
-   local.tee $6
+   local.tee $var$6
    i32.const 1
    i32.add
    call $~lib/map/Map<u16,u16>#set:entriesOffset
-   local.get $6
+   local.get $var$6
    i32.const 8
    i32.mul
    i32.add
-   local.set $4
-   local.get $4
-   local.get $1
+   local.set $entry
+   local.get $entry
+   local.get $key
    call $~lib/map/MapEntry<u16,u16>#set:key
    i32.const 0
    drop
-   local.get $4
-   local.get $2
+   local.get $entry
+   local.get $value
    call $~lib/map/MapEntry<u16,u16>#set:value
    i32.const 0
    drop
-   local.get $0
-   local.get $0
+   local.get $this
+   local.get $this
    i32.load $0 offset=20
    i32.const 1
    i32.add
    call $~lib/map/Map<u16,u16>#set:entriesCount
-   local.get $0
+   local.get $this
    i32.load $0
-   local.get $3
-   local.get $0
+   local.get $hashCode
+   local.get $this
    i32.load $0 offset=4
    i32.and
    i32.const 4
    i32.mul
    i32.add
-   local.set $6
-   local.get $4
-   local.get $6
+   local.set $var$6
+   local.get $entry
+   local.get $var$6
    i32.load $0
    call $~lib/map/MapEntry<u16,u16>#set:taggedNext
-   local.get $6
-   local.get $4
+   local.get $var$6
+   local.get $entry
    i32.store $0
   end
-  local.get $0
+  local.get $this
   local.set $7
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -18167,15 +18167,15 @@
   global.set $~lib/memory/__stack_pointer
   local.get $7
  )
- (func $~lib/map/Map<i32,i32>#keys (param $0 i32) (result i32)
-  (local $1 i32)
-  (local $2 i32)
-  (local $3 i32)
-  (local $4 i32)
-  (local $5 i32)
-  (local $6 i32)
-  (local $7 i32)
-  (local $8 i32)
+ (func $~lib/map/Map<i32,i32>#keys (param $this i32) (result i32)
+  (local $start i32)
+  (local $size i32)
+  (local $keys i32)
+  (local $length i32)
+  (local $var$5 i32)
+  (local $var$6 i32)
+  (local $var$7 i32)
+  (local $var$8 i32)
   (local $9 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -18185,63 +18185,63 @@
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   i32.store $0
-  local.get $0
+  local.get $this
   i32.load $0 offset=8
-  local.set $1
-  local.get $0
+  local.set $start
+  local.get $this
   i32.load $0 offset=16
-  local.set $2
+  local.set $size
   global.get $~lib/memory/__stack_pointer
   i32.const 0
-  local.get $2
+  local.get $size
   call $~lib/array/Array<i32>#constructor
-  local.tee $3
+  local.tee $keys
   i32.store $0
   i32.const 0
-  local.set $4
+  local.set $length
   i32.const 0
-  local.set $5
+  local.set $var$5
   loop $for-loop|0
-   local.get $5
-   local.get $2
+   local.get $var$5
+   local.get $size
    i32.lt_s
-   local.set $6
-   local.get $6
+   local.set $var$6
+   local.get $var$6
    if
-    local.get $1
-    local.get $5
+    local.get $start
+    local.get $var$5
     i32.const 12
     i32.mul
     i32.add
-    local.set $7
-    local.get $7
+    local.set $var$7
+    local.get $var$7
     i32.load $0 offset=8
     i32.const 1
     i32.and
     i32.eqz
     if
-     local.get $3
-     local.get $4
-     local.tee $8
+     local.get $keys
+     local.get $length
+     local.tee $var$8
      i32.const 1
      i32.add
-     local.set $4
-     local.get $8
-     local.get $7
+     local.set $length
+     local.get $var$8
+     local.get $var$7
      i32.load $0
      call $~lib/array/Array<i32>#__uset
     end
-    local.get $5
+    local.get $var$5
     i32.const 1
     i32.add
-    local.set $5
+    local.set $var$5
     br $for-loop|0
    end
   end
-  local.get $3
-  local.get $4
+  local.get $keys
+  local.get $length
   call $~lib/array/Array<i32>#set:length
-  local.get $3
+  local.get $keys
   local.set $9
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -18249,15 +18249,15 @@
   global.set $~lib/memory/__stack_pointer
   local.get $9
  )
- (func $~lib/map/Map<i32,i32>#values (param $0 i32) (result i32)
-  (local $1 i32)
-  (local $2 i32)
-  (local $3 i32)
-  (local $4 i32)
-  (local $5 i32)
-  (local $6 i32)
-  (local $7 i32)
-  (local $8 i32)
+ (func $~lib/map/Map<i32,i32>#values (param $this i32) (result i32)
+  (local $start i32)
+  (local $size i32)
+  (local $values i32)
+  (local $length i32)
+  (local $var$5 i32)
+  (local $var$6 i32)
+  (local $var$7 i32)
+  (local $var$8 i32)
   (local $9 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -18267,63 +18267,63 @@
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   i32.store $0
-  local.get $0
+  local.get $this
   i32.load $0 offset=8
-  local.set $1
-  local.get $0
+  local.set $start
+  local.get $this
   i32.load $0 offset=16
-  local.set $2
+  local.set $size
   global.get $~lib/memory/__stack_pointer
   i32.const 0
-  local.get $2
+  local.get $size
   call $~lib/array/Array<i32>#constructor
-  local.tee $3
+  local.tee $values
   i32.store $0
   i32.const 0
-  local.set $4
+  local.set $length
   i32.const 0
-  local.set $5
+  local.set $var$5
   loop $for-loop|0
-   local.get $5
-   local.get $2
+   local.get $var$5
+   local.get $size
    i32.lt_s
-   local.set $6
-   local.get $6
+   local.set $var$6
+   local.get $var$6
    if
-    local.get $1
-    local.get $5
+    local.get $start
+    local.get $var$5
     i32.const 12
     i32.mul
     i32.add
-    local.set $7
-    local.get $7
+    local.set $var$7
+    local.get $var$7
     i32.load $0 offset=8
     i32.const 1
     i32.and
     i32.eqz
     if
-     local.get $3
-     local.get $4
-     local.tee $8
+     local.get $values
+     local.get $length
+     local.tee $var$8
      i32.const 1
      i32.add
-     local.set $4
-     local.get $8
-     local.get $7
+     local.set $length
+     local.get $var$8
+     local.get $var$7
      i32.load $0 offset=4
      call $~lib/array/Array<i32>#__uset
     end
-    local.get $5
+    local.get $var$5
     i32.const 1
     i32.add
-    local.set $5
+    local.set $var$5
     br $for-loop|0
    end
   end
-  local.get $3
-  local.get $4
+  local.get $values
+  local.get $length
   call $~lib/array/Array<i32>#set:length
-  local.get $3
+  local.get $values
   local.set $9
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -18331,7 +18331,7 @@
   global.set $~lib/memory/__stack_pointer
   local.get $9
  )
- (func $~lib/map/Map<u32,i32>#constructor (param $0 i32) (result i32)
+ (func $~lib/map/Map<u32,i32>#constructor (param $this i32) (result i32)
   (local $1 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -18341,45 +18341,45 @@
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   i32.store $0
-  local.get $0
+  local.get $this
   i32.eqz
   if
    global.get $~lib/memory/__stack_pointer
    i32.const 24
    i32.const 17
    call $~lib/rt/itcms/__new
-   local.tee $0
+   local.tee $this
    i32.store $0
   end
-  local.get $0
+  local.get $this
   i32.const 0
   i32.const 4
   i32.const 4
   i32.mul
   call $~lib/arraybuffer/ArrayBuffer#constructor
   call $~lib/map/Map<u32,i32>#set:buckets
-  local.get $0
+  local.get $this
   i32.const 4
   i32.const 1
   i32.sub
   call $~lib/map/Map<u32,i32>#set:bucketsMask
-  local.get $0
+  local.get $this
   i32.const 0
   i32.const 4
   i32.const 12
   i32.mul
   call $~lib/arraybuffer/ArrayBuffer#constructor
   call $~lib/map/Map<u32,i32>#set:entries
-  local.get $0
+  local.get $this
   i32.const 4
   call $~lib/map/Map<u32,i32>#set:entriesCapacity
-  local.get $0
+  local.get $this
   i32.const 0
   call $~lib/map/Map<u32,i32>#set:entriesOffset
-  local.get $0
+  local.get $this
   i32.const 0
   call $~lib/map/Map<u32,i32>#set:entriesCount
-  local.get $0
+  local.get $this
   local.set $1
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -18387,11 +18387,11 @@
   global.set $~lib/memory/__stack_pointer
   local.get $1
  )
- (func $~lib/map/Map<u32,i32>#set (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
-  (local $3 i32)
-  (local $4 i32)
-  (local $5 i32)
-  (local $6 i32)
+ (func $~lib/map/Map<u32,i32>#set (param $this i32) (param $key i32) (param $value i32) (result i32)
+  (local $hashCode i32)
+  (local $entry i32)
+  (local $var$5 i32)
+  (local $var$6 i32)
   (local $7 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -18401,32 +18401,32 @@
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   i32.store $0
-  local.get $1
+  local.get $key
   call $~lib/util/hash/HASH<u32>
-  local.set $3
-  local.get $0
-  local.get $1
-  local.get $3
+  local.set $hashCode
+  local.get $this
+  local.get $key
+  local.get $hashCode
   call $~lib/map/Map<u32,i32>#find
-  local.set $4
-  local.get $4
+  local.set $entry
+  local.get $entry
   if
-   local.get $4
-   local.get $2
+   local.get $entry
+   local.get $value
    call $~lib/map/MapEntry<u32,i32>#set:value
    i32.const 0
    drop
   else
-   local.get $0
+   local.get $this
    i32.load $0 offset=16
-   local.get $0
+   local.get $this
    i32.load $0 offset=12
    i32.eq
    if
-    local.get $0
-    local.get $0
+    local.get $this
+    local.get $this
     i32.load $0 offset=20
-    local.get $0
+    local.get $this
     i32.load $0 offset=12
     i32.const 3
     i32.mul
@@ -18434,10 +18434,10 @@
     i32.div_s
     i32.lt_s
     if (result i32)
-     local.get $0
+     local.get $this
      i32.load $0 offset=4
     else
-     local.get $0
+     local.get $this
      i32.load $0 offset=4
      i32.const 1
      i32.shl
@@ -18447,58 +18447,58 @@
     call $~lib/map/Map<u32,i32>#rehash
    end
    global.get $~lib/memory/__stack_pointer
-   local.get $0
+   local.get $this
    i32.load $0 offset=8
-   local.tee $5
+   local.tee $var$5
    i32.store $0
-   local.get $5
-   local.get $0
-   local.get $0
+   local.get $var$5
+   local.get $this
+   local.get $this
    i32.load $0 offset=16
-   local.tee $6
+   local.tee $var$6
    i32.const 1
    i32.add
    call $~lib/map/Map<u32,i32>#set:entriesOffset
-   local.get $6
+   local.get $var$6
    i32.const 12
    i32.mul
    i32.add
-   local.set $4
-   local.get $4
-   local.get $1
+   local.set $entry
+   local.get $entry
+   local.get $key
    call $~lib/map/MapEntry<u32,i32>#set:key
    i32.const 0
    drop
-   local.get $4
-   local.get $2
+   local.get $entry
+   local.get $value
    call $~lib/map/MapEntry<u32,i32>#set:value
    i32.const 0
    drop
-   local.get $0
-   local.get $0
+   local.get $this
+   local.get $this
    i32.load $0 offset=20
    i32.const 1
    i32.add
    call $~lib/map/Map<u32,i32>#set:entriesCount
-   local.get $0
+   local.get $this
    i32.load $0
-   local.get $3
-   local.get $0
+   local.get $hashCode
+   local.get $this
    i32.load $0 offset=4
    i32.and
    i32.const 4
    i32.mul
    i32.add
-   local.set $6
-   local.get $4
-   local.get $6
+   local.set $var$6
+   local.get $entry
+   local.get $var$6
    i32.load $0
    call $~lib/map/MapEntry<u32,i32>#set:taggedNext
-   local.get $6
-   local.get $4
+   local.get $var$6
+   local.get $entry
    i32.store $0
   end
-  local.get $0
+  local.get $this
   local.set $7
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -18506,11 +18506,11 @@
   global.set $~lib/memory/__stack_pointer
   local.get $7
  )
- (func $~lib/array/Array<u32>#constructor (param $0 i32) (param $1 i32) (result i32)
-  (local $2 i32)
-  (local $3 i32)
-  (local $4 i32)
-  (local $5 i32)
+ (func $~lib/array/Array<u32>#constructor (param $this i32) (param $length i32) (result i32)
+  (local $var$2 i32)
+  (local $var$3 i32)
+  (local $bufferSize i32)
+  (local $buffer i32)
   (local $6 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 8
@@ -18520,29 +18520,29 @@
   global.get $~lib/memory/__stack_pointer
   i64.const 0
   i64.store $0
-  local.get $0
+  local.get $this
   i32.eqz
   if
    global.get $~lib/memory/__stack_pointer
    i32.const 16
    i32.const 18
    call $~lib/rt/itcms/__new
-   local.tee $0
+   local.tee $this
    i32.store $0
   end
-  local.get $0
+  local.get $this
   i32.const 0
   call $~lib/array/Array<u32>#set:buffer
-  local.get $0
+  local.get $this
   i32.const 0
   call $~lib/array/Array<u32>#set:dataStart
-  local.get $0
+  local.get $this
   i32.const 0
   call $~lib/array/Array<u32>#set:byteLength
-  local.get $0
+  local.get $this
   i32.const 0
   call $~lib/array/Array<u32>#set:length_
-  local.get $1
+  local.get $length
   i32.const 1073741820
   i32.const 2
   i32.shr_u
@@ -18555,40 +18555,40 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $1
-  local.tee $2
+  local.get $length
+  local.tee $var$2
   i32.const 8
-  local.tee $3
-  local.get $2
-  local.get $3
+  local.tee $var$3
+  local.get $var$2
+  local.get $var$3
   i32.gt_u
   select
   i32.const 2
   i32.shl
-  local.set $4
+  local.set $bufferSize
   global.get $~lib/memory/__stack_pointer
-  local.get $4
+  local.get $bufferSize
   i32.const 0
   call $~lib/rt/itcms/__new
-  local.tee $5
+  local.tee $buffer
   i32.store $0 offset=4
   i32.const 2
   global.get $~lib/shared/runtime/Runtime.Incremental
   i32.ne
   drop
-  local.get $0
-  local.get $5
+  local.get $this
+  local.get $buffer
   call $~lib/array/Array<u32>#set:buffer
-  local.get $0
-  local.get $5
+  local.get $this
+  local.get $buffer
   call $~lib/array/Array<u32>#set:dataStart
-  local.get $0
-  local.get $4
+  local.get $this
+  local.get $bufferSize
   call $~lib/array/Array<u32>#set:byteLength
-  local.get $0
-  local.get $1
+  local.get $this
+  local.get $length
   call $~lib/array/Array<u32>#set:length_
-  local.get $0
+  local.get $this
   local.set $6
   global.get $~lib/memory/__stack_pointer
   i32.const 8
@@ -18596,15 +18596,15 @@
   global.set $~lib/memory/__stack_pointer
   local.get $6
  )
- (func $~lib/map/Map<u32,i32>#keys (param $0 i32) (result i32)
-  (local $1 i32)
-  (local $2 i32)
-  (local $3 i32)
-  (local $4 i32)
-  (local $5 i32)
-  (local $6 i32)
-  (local $7 i32)
-  (local $8 i32)
+ (func $~lib/map/Map<u32,i32>#keys (param $this i32) (result i32)
+  (local $start i32)
+  (local $size i32)
+  (local $keys i32)
+  (local $length i32)
+  (local $var$5 i32)
+  (local $var$6 i32)
+  (local $var$7 i32)
+  (local $var$8 i32)
   (local $9 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -18614,63 +18614,63 @@
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   i32.store $0
-  local.get $0
+  local.get $this
   i32.load $0 offset=8
-  local.set $1
-  local.get $0
+  local.set $start
+  local.get $this
   i32.load $0 offset=16
-  local.set $2
+  local.set $size
   global.get $~lib/memory/__stack_pointer
   i32.const 0
-  local.get $2
+  local.get $size
   call $~lib/array/Array<u32>#constructor
-  local.tee $3
+  local.tee $keys
   i32.store $0
   i32.const 0
-  local.set $4
+  local.set $length
   i32.const 0
-  local.set $5
+  local.set $var$5
   loop $for-loop|0
-   local.get $5
-   local.get $2
+   local.get $var$5
+   local.get $size
    i32.lt_s
-   local.set $6
-   local.get $6
+   local.set $var$6
+   local.get $var$6
    if
-    local.get $1
-    local.get $5
+    local.get $start
+    local.get $var$5
     i32.const 12
     i32.mul
     i32.add
-    local.set $7
-    local.get $7
+    local.set $var$7
+    local.get $var$7
     i32.load $0 offset=8
     i32.const 1
     i32.and
     i32.eqz
     if
-     local.get $3
-     local.get $4
-     local.tee $8
+     local.get $keys
+     local.get $length
+     local.tee $var$8
      i32.const 1
      i32.add
-     local.set $4
-     local.get $8
-     local.get $7
+     local.set $length
+     local.get $var$8
+     local.get $var$7
      i32.load $0
      call $~lib/array/Array<u32>#__uset
     end
-    local.get $5
+    local.get $var$5
     i32.const 1
     i32.add
-    local.set $5
+    local.set $var$5
     br $for-loop|0
    end
   end
-  local.get $3
-  local.get $4
+  local.get $keys
+  local.get $length
   call $~lib/array/Array<u32>#set:length
-  local.get $3
+  local.get $keys
   local.set $9
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -18678,15 +18678,15 @@
   global.set $~lib/memory/__stack_pointer
   local.get $9
  )
- (func $~lib/map/Map<u32,i32>#values (param $0 i32) (result i32)
-  (local $1 i32)
-  (local $2 i32)
-  (local $3 i32)
-  (local $4 i32)
-  (local $5 i32)
-  (local $6 i32)
-  (local $7 i32)
-  (local $8 i32)
+ (func $~lib/map/Map<u32,i32>#values (param $this i32) (result i32)
+  (local $start i32)
+  (local $size i32)
+  (local $values i32)
+  (local $length i32)
+  (local $var$5 i32)
+  (local $var$6 i32)
+  (local $var$7 i32)
+  (local $var$8 i32)
   (local $9 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -18696,63 +18696,63 @@
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   i32.store $0
-  local.get $0
+  local.get $this
   i32.load $0 offset=8
-  local.set $1
-  local.get $0
+  local.set $start
+  local.get $this
   i32.load $0 offset=16
-  local.set $2
+  local.set $size
   global.get $~lib/memory/__stack_pointer
   i32.const 0
-  local.get $2
+  local.get $size
   call $~lib/array/Array<i32>#constructor
-  local.tee $3
+  local.tee $values
   i32.store $0
   i32.const 0
-  local.set $4
+  local.set $length
   i32.const 0
-  local.set $5
+  local.set $var$5
   loop $for-loop|0
-   local.get $5
-   local.get $2
+   local.get $var$5
+   local.get $size
    i32.lt_s
-   local.set $6
-   local.get $6
+   local.set $var$6
+   local.get $var$6
    if
-    local.get $1
-    local.get $5
+    local.get $start
+    local.get $var$5
     i32.const 12
     i32.mul
     i32.add
-    local.set $7
-    local.get $7
+    local.set $var$7
+    local.get $var$7
     i32.load $0 offset=8
     i32.const 1
     i32.and
     i32.eqz
     if
-     local.get $3
-     local.get $4
-     local.tee $8
+     local.get $values
+     local.get $length
+     local.tee $var$8
      i32.const 1
      i32.add
-     local.set $4
-     local.get $8
-     local.get $7
+     local.set $length
+     local.get $var$8
+     local.get $var$7
      i32.load $0 offset=4
      call $~lib/array/Array<i32>#__uset
     end
-    local.get $5
+    local.get $var$5
     i32.const 1
     i32.add
-    local.set $5
+    local.set $var$5
     br $for-loop|0
    end
   end
-  local.get $3
-  local.get $4
+  local.get $values
+  local.get $length
   call $~lib/array/Array<i32>#set:length
-  local.get $3
+  local.get $values
   local.set $9
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -18760,7 +18760,7 @@
   global.set $~lib/memory/__stack_pointer
   local.get $9
  )
- (func $~lib/map/Map<u32,u32>#constructor (param $0 i32) (result i32)
+ (func $~lib/map/Map<u32,u32>#constructor (param $this i32) (result i32)
   (local $1 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -18770,45 +18770,45 @@
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   i32.store $0
-  local.get $0
+  local.get $this
   i32.eqz
   if
    global.get $~lib/memory/__stack_pointer
    i32.const 24
    i32.const 19
    call $~lib/rt/itcms/__new
-   local.tee $0
+   local.tee $this
    i32.store $0
   end
-  local.get $0
+  local.get $this
   i32.const 0
   i32.const 4
   i32.const 4
   i32.mul
   call $~lib/arraybuffer/ArrayBuffer#constructor
   call $~lib/map/Map<u32,u32>#set:buckets
-  local.get $0
+  local.get $this
   i32.const 4
   i32.const 1
   i32.sub
   call $~lib/map/Map<u32,u32>#set:bucketsMask
-  local.get $0
+  local.get $this
   i32.const 0
   i32.const 4
   i32.const 12
   i32.mul
   call $~lib/arraybuffer/ArrayBuffer#constructor
   call $~lib/map/Map<u32,u32>#set:entries
-  local.get $0
+  local.get $this
   i32.const 4
   call $~lib/map/Map<u32,u32>#set:entriesCapacity
-  local.get $0
+  local.get $this
   i32.const 0
   call $~lib/map/Map<u32,u32>#set:entriesOffset
-  local.get $0
+  local.get $this
   i32.const 0
   call $~lib/map/Map<u32,u32>#set:entriesCount
-  local.get $0
+  local.get $this
   local.set $1
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -18816,11 +18816,11 @@
   global.set $~lib/memory/__stack_pointer
   local.get $1
  )
- (func $~lib/map/Map<u32,u32>#set (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
-  (local $3 i32)
-  (local $4 i32)
-  (local $5 i32)
-  (local $6 i32)
+ (func $~lib/map/Map<u32,u32>#set (param $this i32) (param $key i32) (param $value i32) (result i32)
+  (local $hashCode i32)
+  (local $entry i32)
+  (local $var$5 i32)
+  (local $var$6 i32)
   (local $7 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -18830,32 +18830,32 @@
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   i32.store $0
-  local.get $1
+  local.get $key
   call $~lib/util/hash/HASH<u32>
-  local.set $3
-  local.get $0
-  local.get $1
-  local.get $3
+  local.set $hashCode
+  local.get $this
+  local.get $key
+  local.get $hashCode
   call $~lib/map/Map<u32,u32>#find
-  local.set $4
-  local.get $4
+  local.set $entry
+  local.get $entry
   if
-   local.get $4
-   local.get $2
+   local.get $entry
+   local.get $value
    call $~lib/map/MapEntry<u32,u32>#set:value
    i32.const 0
    drop
   else
-   local.get $0
+   local.get $this
    i32.load $0 offset=16
-   local.get $0
+   local.get $this
    i32.load $0 offset=12
    i32.eq
    if
-    local.get $0
-    local.get $0
+    local.get $this
+    local.get $this
     i32.load $0 offset=20
-    local.get $0
+    local.get $this
     i32.load $0 offset=12
     i32.const 3
     i32.mul
@@ -18863,10 +18863,10 @@
     i32.div_s
     i32.lt_s
     if (result i32)
-     local.get $0
+     local.get $this
      i32.load $0 offset=4
     else
-     local.get $0
+     local.get $this
      i32.load $0 offset=4
      i32.const 1
      i32.shl
@@ -18876,58 +18876,58 @@
     call $~lib/map/Map<u32,u32>#rehash
    end
    global.get $~lib/memory/__stack_pointer
-   local.get $0
+   local.get $this
    i32.load $0 offset=8
-   local.tee $5
+   local.tee $var$5
    i32.store $0
-   local.get $5
-   local.get $0
-   local.get $0
+   local.get $var$5
+   local.get $this
+   local.get $this
    i32.load $0 offset=16
-   local.tee $6
+   local.tee $var$6
    i32.const 1
    i32.add
    call $~lib/map/Map<u32,u32>#set:entriesOffset
-   local.get $6
+   local.get $var$6
    i32.const 12
    i32.mul
    i32.add
-   local.set $4
-   local.get $4
-   local.get $1
+   local.set $entry
+   local.get $entry
+   local.get $key
    call $~lib/map/MapEntry<u32,u32>#set:key
    i32.const 0
    drop
-   local.get $4
-   local.get $2
+   local.get $entry
+   local.get $value
    call $~lib/map/MapEntry<u32,u32>#set:value
    i32.const 0
    drop
-   local.get $0
-   local.get $0
+   local.get $this
+   local.get $this
    i32.load $0 offset=20
    i32.const 1
    i32.add
    call $~lib/map/Map<u32,u32>#set:entriesCount
-   local.get $0
+   local.get $this
    i32.load $0
-   local.get $3
-   local.get $0
+   local.get $hashCode
+   local.get $this
    i32.load $0 offset=4
    i32.and
    i32.const 4
    i32.mul
    i32.add
-   local.set $6
-   local.get $4
-   local.get $6
+   local.set $var$6
+   local.get $entry
+   local.get $var$6
    i32.load $0
    call $~lib/map/MapEntry<u32,u32>#set:taggedNext
-   local.get $6
-   local.get $4
+   local.get $var$6
+   local.get $entry
    i32.store $0
   end
-  local.get $0
+  local.get $this
   local.set $7
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -18935,7 +18935,7 @@
   global.set $~lib/memory/__stack_pointer
   local.get $7
  )
- (func $~lib/map/Map<i64,i32>#constructor (param $0 i32) (result i32)
+ (func $~lib/map/Map<i64,i32>#constructor (param $this i32) (result i32)
   (local $1 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -18945,45 +18945,45 @@
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   i32.store $0
-  local.get $0
+  local.get $this
   i32.eqz
   if
    global.get $~lib/memory/__stack_pointer
    i32.const 24
    i32.const 20
    call $~lib/rt/itcms/__new
-   local.tee $0
+   local.tee $this
    i32.store $0
   end
-  local.get $0
+  local.get $this
   i32.const 0
   i32.const 4
   i32.const 4
   i32.mul
   call $~lib/arraybuffer/ArrayBuffer#constructor
   call $~lib/map/Map<i64,i32>#set:buckets
-  local.get $0
+  local.get $this
   i32.const 4
   i32.const 1
   i32.sub
   call $~lib/map/Map<i64,i32>#set:bucketsMask
-  local.get $0
+  local.get $this
   i32.const 0
   i32.const 4
   i32.const 16
   i32.mul
   call $~lib/arraybuffer/ArrayBuffer#constructor
   call $~lib/map/Map<i64,i32>#set:entries
-  local.get $0
+  local.get $this
   i32.const 4
   call $~lib/map/Map<i64,i32>#set:entriesCapacity
-  local.get $0
+  local.get $this
   i32.const 0
   call $~lib/map/Map<i64,i32>#set:entriesOffset
-  local.get $0
+  local.get $this
   i32.const 0
   call $~lib/map/Map<i64,i32>#set:entriesCount
-  local.get $0
+  local.get $this
   local.set $1
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -18991,11 +18991,11 @@
   global.set $~lib/memory/__stack_pointer
   local.get $1
  )
- (func $~lib/map/Map<i64,i32>#set (param $0 i32) (param $1 i64) (param $2 i32) (result i32)
-  (local $3 i32)
-  (local $4 i32)
-  (local $5 i32)
-  (local $6 i32)
+ (func $~lib/map/Map<i64,i32>#set (param $this i32) (param $key i64) (param $value i32) (result i32)
+  (local $hashCode i32)
+  (local $entry i32)
+  (local $var$5 i32)
+  (local $var$6 i32)
   (local $7 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -19005,32 +19005,32 @@
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   i32.store $0
-  local.get $1
+  local.get $key
   call $~lib/util/hash/HASH<i64>
-  local.set $3
-  local.get $0
-  local.get $1
-  local.get $3
+  local.set $hashCode
+  local.get $this
+  local.get $key
+  local.get $hashCode
   call $~lib/map/Map<i64,i32>#find
-  local.set $4
-  local.get $4
+  local.set $entry
+  local.get $entry
   if
-   local.get $4
-   local.get $2
+   local.get $entry
+   local.get $value
    call $~lib/map/MapEntry<i64,i32>#set:value
    i32.const 0
    drop
   else
-   local.get $0
+   local.get $this
    i32.load $0 offset=16
-   local.get $0
+   local.get $this
    i32.load $0 offset=12
    i32.eq
    if
-    local.get $0
-    local.get $0
+    local.get $this
+    local.get $this
     i32.load $0 offset=20
-    local.get $0
+    local.get $this
     i32.load $0 offset=12
     i32.const 3
     i32.mul
@@ -19038,10 +19038,10 @@
     i32.div_s
     i32.lt_s
     if (result i32)
-     local.get $0
+     local.get $this
      i32.load $0 offset=4
     else
-     local.get $0
+     local.get $this
      i32.load $0 offset=4
      i32.const 1
      i32.shl
@@ -19051,58 +19051,58 @@
     call $~lib/map/Map<i64,i32>#rehash
    end
    global.get $~lib/memory/__stack_pointer
-   local.get $0
+   local.get $this
    i32.load $0 offset=8
-   local.tee $5
+   local.tee $var$5
    i32.store $0
-   local.get $5
-   local.get $0
-   local.get $0
+   local.get $var$5
+   local.get $this
+   local.get $this
    i32.load $0 offset=16
-   local.tee $6
+   local.tee $var$6
    i32.const 1
    i32.add
    call $~lib/map/Map<i64,i32>#set:entriesOffset
-   local.get $6
+   local.get $var$6
    i32.const 16
    i32.mul
    i32.add
-   local.set $4
-   local.get $4
-   local.get $1
+   local.set $entry
+   local.get $entry
+   local.get $key
    call $~lib/map/MapEntry<i64,i32>#set:key
    i32.const 0
    drop
-   local.get $4
-   local.get $2
+   local.get $entry
+   local.get $value
    call $~lib/map/MapEntry<i64,i32>#set:value
    i32.const 0
    drop
-   local.get $0
-   local.get $0
+   local.get $this
+   local.get $this
    i32.load $0 offset=20
    i32.const 1
    i32.add
    call $~lib/map/Map<i64,i32>#set:entriesCount
-   local.get $0
+   local.get $this
    i32.load $0
-   local.get $3
-   local.get $0
+   local.get $hashCode
+   local.get $this
    i32.load $0 offset=4
    i32.and
    i32.const 4
    i32.mul
    i32.add
-   local.set $6
-   local.get $4
-   local.get $6
+   local.set $var$6
+   local.get $entry
+   local.get $var$6
    i32.load $0
    call $~lib/map/MapEntry<i64,i32>#set:taggedNext
-   local.get $6
-   local.get $4
+   local.get $var$6
+   local.get $entry
    i32.store $0
   end
-  local.get $0
+  local.get $this
   local.set $7
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -19110,11 +19110,11 @@
   global.set $~lib/memory/__stack_pointer
   local.get $7
  )
- (func $~lib/array/Array<i64>#constructor (param $0 i32) (param $1 i32) (result i32)
-  (local $2 i32)
-  (local $3 i32)
-  (local $4 i32)
-  (local $5 i32)
+ (func $~lib/array/Array<i64>#constructor (param $this i32) (param $length i32) (result i32)
+  (local $var$2 i32)
+  (local $var$3 i32)
+  (local $bufferSize i32)
+  (local $buffer i32)
   (local $6 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 8
@@ -19124,29 +19124,29 @@
   global.get $~lib/memory/__stack_pointer
   i64.const 0
   i64.store $0
-  local.get $0
+  local.get $this
   i32.eqz
   if
    global.get $~lib/memory/__stack_pointer
    i32.const 16
    i32.const 21
    call $~lib/rt/itcms/__new
-   local.tee $0
+   local.tee $this
    i32.store $0
   end
-  local.get $0
+  local.get $this
   i32.const 0
   call $~lib/array/Array<i64>#set:buffer
-  local.get $0
+  local.get $this
   i32.const 0
   call $~lib/array/Array<i64>#set:dataStart
-  local.get $0
+  local.get $this
   i32.const 0
   call $~lib/array/Array<i64>#set:byteLength
-  local.get $0
+  local.get $this
   i32.const 0
   call $~lib/array/Array<i64>#set:length_
-  local.get $1
+  local.get $length
   i32.const 1073741820
   i32.const 3
   i32.shr_u
@@ -19159,40 +19159,40 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $1
-  local.tee $2
+  local.get $length
+  local.tee $var$2
   i32.const 8
-  local.tee $3
-  local.get $2
-  local.get $3
+  local.tee $var$3
+  local.get $var$2
+  local.get $var$3
   i32.gt_u
   select
   i32.const 3
   i32.shl
-  local.set $4
+  local.set $bufferSize
   global.get $~lib/memory/__stack_pointer
-  local.get $4
+  local.get $bufferSize
   i32.const 0
   call $~lib/rt/itcms/__new
-  local.tee $5
+  local.tee $buffer
   i32.store $0 offset=4
   i32.const 2
   global.get $~lib/shared/runtime/Runtime.Incremental
   i32.ne
   drop
-  local.get $0
-  local.get $5
+  local.get $this
+  local.get $buffer
   call $~lib/array/Array<i64>#set:buffer
-  local.get $0
-  local.get $5
+  local.get $this
+  local.get $buffer
   call $~lib/array/Array<i64>#set:dataStart
-  local.get $0
-  local.get $4
+  local.get $this
+  local.get $bufferSize
   call $~lib/array/Array<i64>#set:byteLength
-  local.get $0
-  local.get $1
+  local.get $this
+  local.get $length
   call $~lib/array/Array<i64>#set:length_
-  local.get $0
+  local.get $this
   local.set $6
   global.get $~lib/memory/__stack_pointer
   i32.const 8
@@ -19200,15 +19200,15 @@
   global.set $~lib/memory/__stack_pointer
   local.get $6
  )
- (func $~lib/map/Map<i64,i32>#keys (param $0 i32) (result i32)
-  (local $1 i32)
-  (local $2 i32)
-  (local $3 i32)
-  (local $4 i32)
-  (local $5 i32)
-  (local $6 i32)
-  (local $7 i32)
-  (local $8 i32)
+ (func $~lib/map/Map<i64,i32>#keys (param $this i32) (result i32)
+  (local $start i32)
+  (local $size i32)
+  (local $keys i32)
+  (local $length i32)
+  (local $var$5 i32)
+  (local $var$6 i32)
+  (local $var$7 i32)
+  (local $var$8 i32)
   (local $9 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -19218,63 +19218,63 @@
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   i32.store $0
-  local.get $0
+  local.get $this
   i32.load $0 offset=8
-  local.set $1
-  local.get $0
+  local.set $start
+  local.get $this
   i32.load $0 offset=16
-  local.set $2
+  local.set $size
   global.get $~lib/memory/__stack_pointer
   i32.const 0
-  local.get $2
+  local.get $size
   call $~lib/array/Array<i64>#constructor
-  local.tee $3
+  local.tee $keys
   i32.store $0
   i32.const 0
-  local.set $4
+  local.set $length
   i32.const 0
-  local.set $5
+  local.set $var$5
   loop $for-loop|0
-   local.get $5
-   local.get $2
+   local.get $var$5
+   local.get $size
    i32.lt_s
-   local.set $6
-   local.get $6
+   local.set $var$6
+   local.get $var$6
    if
-    local.get $1
-    local.get $5
+    local.get $start
+    local.get $var$5
     i32.const 16
     i32.mul
     i32.add
-    local.set $7
-    local.get $7
+    local.set $var$7
+    local.get $var$7
     i32.load $0 offset=12
     i32.const 1
     i32.and
     i32.eqz
     if
-     local.get $3
-     local.get $4
-     local.tee $8
+     local.get $keys
+     local.get $length
+     local.tee $var$8
      i32.const 1
      i32.add
-     local.set $4
-     local.get $8
-     local.get $7
+     local.set $length
+     local.get $var$8
+     local.get $var$7
      i64.load $0
      call $~lib/array/Array<i64>#__uset
     end
-    local.get $5
+    local.get $var$5
     i32.const 1
     i32.add
-    local.set $5
+    local.set $var$5
     br $for-loop|0
    end
   end
-  local.get $3
-  local.get $4
+  local.get $keys
+  local.get $length
   call $~lib/array/Array<i64>#set:length
-  local.get $3
+  local.get $keys
   local.set $9
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -19282,15 +19282,15 @@
   global.set $~lib/memory/__stack_pointer
   local.get $9
  )
- (func $~lib/map/Map<i64,i32>#values (param $0 i32) (result i32)
-  (local $1 i32)
-  (local $2 i32)
-  (local $3 i32)
-  (local $4 i32)
-  (local $5 i32)
-  (local $6 i32)
-  (local $7 i32)
-  (local $8 i32)
+ (func $~lib/map/Map<i64,i32>#values (param $this i32) (result i32)
+  (local $start i32)
+  (local $size i32)
+  (local $values i32)
+  (local $length i32)
+  (local $var$5 i32)
+  (local $var$6 i32)
+  (local $var$7 i32)
+  (local $var$8 i32)
   (local $9 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -19300,63 +19300,63 @@
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   i32.store $0
-  local.get $0
+  local.get $this
   i32.load $0 offset=8
-  local.set $1
-  local.get $0
+  local.set $start
+  local.get $this
   i32.load $0 offset=16
-  local.set $2
+  local.set $size
   global.get $~lib/memory/__stack_pointer
   i32.const 0
-  local.get $2
+  local.get $size
   call $~lib/array/Array<i32>#constructor
-  local.tee $3
+  local.tee $values
   i32.store $0
   i32.const 0
-  local.set $4
+  local.set $length
   i32.const 0
-  local.set $5
+  local.set $var$5
   loop $for-loop|0
-   local.get $5
-   local.get $2
+   local.get $var$5
+   local.get $size
    i32.lt_s
-   local.set $6
-   local.get $6
+   local.set $var$6
+   local.get $var$6
    if
-    local.get $1
-    local.get $5
+    local.get $start
+    local.get $var$5
     i32.const 16
     i32.mul
     i32.add
-    local.set $7
-    local.get $7
+    local.set $var$7
+    local.get $var$7
     i32.load $0 offset=12
     i32.const 1
     i32.and
     i32.eqz
     if
-     local.get $3
-     local.get $4
-     local.tee $8
+     local.get $values
+     local.get $length
+     local.tee $var$8
      i32.const 1
      i32.add
-     local.set $4
-     local.get $8
-     local.get $7
+     local.set $length
+     local.get $var$8
+     local.get $var$7
      i32.load $0 offset=8
      call $~lib/array/Array<i32>#__uset
     end
-    local.get $5
+    local.get $var$5
     i32.const 1
     i32.add
-    local.set $5
+    local.set $var$5
     br $for-loop|0
    end
   end
-  local.get $3
-  local.get $4
+  local.get $values
+  local.get $length
   call $~lib/array/Array<i32>#set:length
-  local.get $3
+  local.get $values
   local.set $9
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -19364,7 +19364,7 @@
   global.set $~lib/memory/__stack_pointer
   local.get $9
  )
- (func $~lib/map/Map<i64,i64>#constructor (param $0 i32) (result i32)
+ (func $~lib/map/Map<i64,i64>#constructor (param $this i32) (result i32)
   (local $1 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -19374,45 +19374,45 @@
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   i32.store $0
-  local.get $0
+  local.get $this
   i32.eqz
   if
    global.get $~lib/memory/__stack_pointer
    i32.const 24
    i32.const 22
    call $~lib/rt/itcms/__new
-   local.tee $0
+   local.tee $this
    i32.store $0
   end
-  local.get $0
+  local.get $this
   i32.const 0
   i32.const 4
   i32.const 4
   i32.mul
   call $~lib/arraybuffer/ArrayBuffer#constructor
   call $~lib/map/Map<i64,i64>#set:buckets
-  local.get $0
+  local.get $this
   i32.const 4
   i32.const 1
   i32.sub
   call $~lib/map/Map<i64,i64>#set:bucketsMask
-  local.get $0
+  local.get $this
   i32.const 0
   i32.const 4
   i32.const 24
   i32.mul
   call $~lib/arraybuffer/ArrayBuffer#constructor
   call $~lib/map/Map<i64,i64>#set:entries
-  local.get $0
+  local.get $this
   i32.const 4
   call $~lib/map/Map<i64,i64>#set:entriesCapacity
-  local.get $0
+  local.get $this
   i32.const 0
   call $~lib/map/Map<i64,i64>#set:entriesOffset
-  local.get $0
+  local.get $this
   i32.const 0
   call $~lib/map/Map<i64,i64>#set:entriesCount
-  local.get $0
+  local.get $this
   local.set $1
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -19420,11 +19420,11 @@
   global.set $~lib/memory/__stack_pointer
   local.get $1
  )
- (func $~lib/map/Map<i64,i64>#set (param $0 i32) (param $1 i64) (param $2 i64) (result i32)
-  (local $3 i32)
-  (local $4 i32)
-  (local $5 i32)
-  (local $6 i32)
+ (func $~lib/map/Map<i64,i64>#set (param $this i32) (param $key i64) (param $value i64) (result i32)
+  (local $hashCode i32)
+  (local $entry i32)
+  (local $var$5 i32)
+  (local $var$6 i32)
   (local $7 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -19434,32 +19434,32 @@
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   i32.store $0
-  local.get $1
+  local.get $key
   call $~lib/util/hash/HASH<i64>
-  local.set $3
-  local.get $0
-  local.get $1
-  local.get $3
+  local.set $hashCode
+  local.get $this
+  local.get $key
+  local.get $hashCode
   call $~lib/map/Map<i64,i64>#find
-  local.set $4
-  local.get $4
+  local.set $entry
+  local.get $entry
   if
-   local.get $4
-   local.get $2
+   local.get $entry
+   local.get $value
    call $~lib/map/MapEntry<i64,i64>#set:value
    i32.const 0
    drop
   else
-   local.get $0
+   local.get $this
    i32.load $0 offset=16
-   local.get $0
+   local.get $this
    i32.load $0 offset=12
    i32.eq
    if
-    local.get $0
-    local.get $0
+    local.get $this
+    local.get $this
     i32.load $0 offset=20
-    local.get $0
+    local.get $this
     i32.load $0 offset=12
     i32.const 3
     i32.mul
@@ -19467,10 +19467,10 @@
     i32.div_s
     i32.lt_s
     if (result i32)
-     local.get $0
+     local.get $this
      i32.load $0 offset=4
     else
-     local.get $0
+     local.get $this
      i32.load $0 offset=4
      i32.const 1
      i32.shl
@@ -19480,58 +19480,58 @@
     call $~lib/map/Map<i64,i64>#rehash
    end
    global.get $~lib/memory/__stack_pointer
-   local.get $0
+   local.get $this
    i32.load $0 offset=8
-   local.tee $5
+   local.tee $var$5
    i32.store $0
-   local.get $5
-   local.get $0
-   local.get $0
+   local.get $var$5
+   local.get $this
+   local.get $this
    i32.load $0 offset=16
-   local.tee $6
+   local.tee $var$6
    i32.const 1
    i32.add
    call $~lib/map/Map<i64,i64>#set:entriesOffset
-   local.get $6
+   local.get $var$6
    i32.const 24
    i32.mul
    i32.add
-   local.set $4
-   local.get $4
-   local.get $1
+   local.set $entry
+   local.get $entry
+   local.get $key
    call $~lib/map/MapEntry<i64,i64>#set:key
    i32.const 0
    drop
-   local.get $4
-   local.get $2
+   local.get $entry
+   local.get $value
    call $~lib/map/MapEntry<i64,i64>#set:value
    i32.const 0
    drop
-   local.get $0
-   local.get $0
+   local.get $this
+   local.get $this
    i32.load $0 offset=20
    i32.const 1
    i32.add
    call $~lib/map/Map<i64,i64>#set:entriesCount
-   local.get $0
+   local.get $this
    i32.load $0
-   local.get $3
-   local.get $0
+   local.get $hashCode
+   local.get $this
    i32.load $0 offset=4
    i32.and
    i32.const 4
    i32.mul
    i32.add
-   local.set $6
-   local.get $4
-   local.get $6
+   local.set $var$6
+   local.get $entry
+   local.get $var$6
    i32.load $0
    call $~lib/map/MapEntry<i64,i64>#set:taggedNext
-   local.get $6
-   local.get $4
+   local.get $var$6
+   local.get $entry
    i32.store $0
   end
-  local.get $0
+  local.get $this
   local.set $7
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -19539,7 +19539,7 @@
   global.set $~lib/memory/__stack_pointer
   local.get $7
  )
- (func $~lib/map/Map<u64,i32>#constructor (param $0 i32) (result i32)
+ (func $~lib/map/Map<u64,i32>#constructor (param $this i32) (result i32)
   (local $1 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -19549,45 +19549,45 @@
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   i32.store $0
-  local.get $0
+  local.get $this
   i32.eqz
   if
    global.get $~lib/memory/__stack_pointer
    i32.const 24
    i32.const 23
    call $~lib/rt/itcms/__new
-   local.tee $0
+   local.tee $this
    i32.store $0
   end
-  local.get $0
+  local.get $this
   i32.const 0
   i32.const 4
   i32.const 4
   i32.mul
   call $~lib/arraybuffer/ArrayBuffer#constructor
   call $~lib/map/Map<u64,i32>#set:buckets
-  local.get $0
+  local.get $this
   i32.const 4
   i32.const 1
   i32.sub
   call $~lib/map/Map<u64,i32>#set:bucketsMask
-  local.get $0
+  local.get $this
   i32.const 0
   i32.const 4
   i32.const 16
   i32.mul
   call $~lib/arraybuffer/ArrayBuffer#constructor
   call $~lib/map/Map<u64,i32>#set:entries
-  local.get $0
+  local.get $this
   i32.const 4
   call $~lib/map/Map<u64,i32>#set:entriesCapacity
-  local.get $0
+  local.get $this
   i32.const 0
   call $~lib/map/Map<u64,i32>#set:entriesOffset
-  local.get $0
+  local.get $this
   i32.const 0
   call $~lib/map/Map<u64,i32>#set:entriesCount
-  local.get $0
+  local.get $this
   local.set $1
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -19595,11 +19595,11 @@
   global.set $~lib/memory/__stack_pointer
   local.get $1
  )
- (func $~lib/map/Map<u64,i32>#set (param $0 i32) (param $1 i64) (param $2 i32) (result i32)
-  (local $3 i32)
-  (local $4 i32)
-  (local $5 i32)
-  (local $6 i32)
+ (func $~lib/map/Map<u64,i32>#set (param $this i32) (param $key i64) (param $value i32) (result i32)
+  (local $hashCode i32)
+  (local $entry i32)
+  (local $var$5 i32)
+  (local $var$6 i32)
   (local $7 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -19609,32 +19609,32 @@
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   i32.store $0
-  local.get $1
+  local.get $key
   call $~lib/util/hash/HASH<u64>
-  local.set $3
-  local.get $0
-  local.get $1
-  local.get $3
+  local.set $hashCode
+  local.get $this
+  local.get $key
+  local.get $hashCode
   call $~lib/map/Map<u64,i32>#find
-  local.set $4
-  local.get $4
+  local.set $entry
+  local.get $entry
   if
-   local.get $4
-   local.get $2
+   local.get $entry
+   local.get $value
    call $~lib/map/MapEntry<u64,i32>#set:value
    i32.const 0
    drop
   else
-   local.get $0
+   local.get $this
    i32.load $0 offset=16
-   local.get $0
+   local.get $this
    i32.load $0 offset=12
    i32.eq
    if
-    local.get $0
-    local.get $0
+    local.get $this
+    local.get $this
     i32.load $0 offset=20
-    local.get $0
+    local.get $this
     i32.load $0 offset=12
     i32.const 3
     i32.mul
@@ -19642,10 +19642,10 @@
     i32.div_s
     i32.lt_s
     if (result i32)
-     local.get $0
+     local.get $this
      i32.load $0 offset=4
     else
-     local.get $0
+     local.get $this
      i32.load $0 offset=4
      i32.const 1
      i32.shl
@@ -19655,58 +19655,58 @@
     call $~lib/map/Map<u64,i32>#rehash
    end
    global.get $~lib/memory/__stack_pointer
-   local.get $0
+   local.get $this
    i32.load $0 offset=8
-   local.tee $5
+   local.tee $var$5
    i32.store $0
-   local.get $5
-   local.get $0
-   local.get $0
+   local.get $var$5
+   local.get $this
+   local.get $this
    i32.load $0 offset=16
-   local.tee $6
+   local.tee $var$6
    i32.const 1
    i32.add
    call $~lib/map/Map<u64,i32>#set:entriesOffset
-   local.get $6
+   local.get $var$6
    i32.const 16
    i32.mul
    i32.add
-   local.set $4
-   local.get $4
-   local.get $1
+   local.set $entry
+   local.get $entry
+   local.get $key
    call $~lib/map/MapEntry<u64,i32>#set:key
    i32.const 0
    drop
-   local.get $4
-   local.get $2
+   local.get $entry
+   local.get $value
    call $~lib/map/MapEntry<u64,i32>#set:value
    i32.const 0
    drop
-   local.get $0
-   local.get $0
+   local.get $this
+   local.get $this
    i32.load $0 offset=20
    i32.const 1
    i32.add
    call $~lib/map/Map<u64,i32>#set:entriesCount
-   local.get $0
+   local.get $this
    i32.load $0
-   local.get $3
-   local.get $0
+   local.get $hashCode
+   local.get $this
    i32.load $0 offset=4
    i32.and
    i32.const 4
    i32.mul
    i32.add
-   local.set $6
-   local.get $4
-   local.get $6
+   local.set $var$6
+   local.get $entry
+   local.get $var$6
    i32.load $0
    call $~lib/map/MapEntry<u64,i32>#set:taggedNext
-   local.get $6
-   local.get $4
+   local.get $var$6
+   local.get $entry
    i32.store $0
   end
-  local.get $0
+  local.get $this
   local.set $7
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -19714,11 +19714,11 @@
   global.set $~lib/memory/__stack_pointer
   local.get $7
  )
- (func $~lib/array/Array<u64>#constructor (param $0 i32) (param $1 i32) (result i32)
-  (local $2 i32)
-  (local $3 i32)
-  (local $4 i32)
-  (local $5 i32)
+ (func $~lib/array/Array<u64>#constructor (param $this i32) (param $length i32) (result i32)
+  (local $var$2 i32)
+  (local $var$3 i32)
+  (local $bufferSize i32)
+  (local $buffer i32)
   (local $6 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 8
@@ -19728,29 +19728,29 @@
   global.get $~lib/memory/__stack_pointer
   i64.const 0
   i64.store $0
-  local.get $0
+  local.get $this
   i32.eqz
   if
    global.get $~lib/memory/__stack_pointer
    i32.const 16
    i32.const 24
    call $~lib/rt/itcms/__new
-   local.tee $0
+   local.tee $this
    i32.store $0
   end
-  local.get $0
+  local.get $this
   i32.const 0
   call $~lib/array/Array<u64>#set:buffer
-  local.get $0
+  local.get $this
   i32.const 0
   call $~lib/array/Array<u64>#set:dataStart
-  local.get $0
+  local.get $this
   i32.const 0
   call $~lib/array/Array<u64>#set:byteLength
-  local.get $0
+  local.get $this
   i32.const 0
   call $~lib/array/Array<u64>#set:length_
-  local.get $1
+  local.get $length
   i32.const 1073741820
   i32.const 3
   i32.shr_u
@@ -19763,40 +19763,40 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $1
-  local.tee $2
+  local.get $length
+  local.tee $var$2
   i32.const 8
-  local.tee $3
-  local.get $2
-  local.get $3
+  local.tee $var$3
+  local.get $var$2
+  local.get $var$3
   i32.gt_u
   select
   i32.const 3
   i32.shl
-  local.set $4
+  local.set $bufferSize
   global.get $~lib/memory/__stack_pointer
-  local.get $4
+  local.get $bufferSize
   i32.const 0
   call $~lib/rt/itcms/__new
-  local.tee $5
+  local.tee $buffer
   i32.store $0 offset=4
   i32.const 2
   global.get $~lib/shared/runtime/Runtime.Incremental
   i32.ne
   drop
-  local.get $0
-  local.get $5
+  local.get $this
+  local.get $buffer
   call $~lib/array/Array<u64>#set:buffer
-  local.get $0
-  local.get $5
+  local.get $this
+  local.get $buffer
   call $~lib/array/Array<u64>#set:dataStart
-  local.get $0
-  local.get $4
+  local.get $this
+  local.get $bufferSize
   call $~lib/array/Array<u64>#set:byteLength
-  local.get $0
-  local.get $1
+  local.get $this
+  local.get $length
   call $~lib/array/Array<u64>#set:length_
-  local.get $0
+  local.get $this
   local.set $6
   global.get $~lib/memory/__stack_pointer
   i32.const 8
@@ -19804,15 +19804,15 @@
   global.set $~lib/memory/__stack_pointer
   local.get $6
  )
- (func $~lib/map/Map<u64,i32>#keys (param $0 i32) (result i32)
-  (local $1 i32)
-  (local $2 i32)
-  (local $3 i32)
-  (local $4 i32)
-  (local $5 i32)
-  (local $6 i32)
-  (local $7 i32)
-  (local $8 i32)
+ (func $~lib/map/Map<u64,i32>#keys (param $this i32) (result i32)
+  (local $start i32)
+  (local $size i32)
+  (local $keys i32)
+  (local $length i32)
+  (local $var$5 i32)
+  (local $var$6 i32)
+  (local $var$7 i32)
+  (local $var$8 i32)
   (local $9 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -19822,63 +19822,63 @@
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   i32.store $0
-  local.get $0
+  local.get $this
   i32.load $0 offset=8
-  local.set $1
-  local.get $0
+  local.set $start
+  local.get $this
   i32.load $0 offset=16
-  local.set $2
+  local.set $size
   global.get $~lib/memory/__stack_pointer
   i32.const 0
-  local.get $2
+  local.get $size
   call $~lib/array/Array<u64>#constructor
-  local.tee $3
+  local.tee $keys
   i32.store $0
   i32.const 0
-  local.set $4
+  local.set $length
   i32.const 0
-  local.set $5
+  local.set $var$5
   loop $for-loop|0
-   local.get $5
-   local.get $2
+   local.get $var$5
+   local.get $size
    i32.lt_s
-   local.set $6
-   local.get $6
+   local.set $var$6
+   local.get $var$6
    if
-    local.get $1
-    local.get $5
+    local.get $start
+    local.get $var$5
     i32.const 16
     i32.mul
     i32.add
-    local.set $7
-    local.get $7
+    local.set $var$7
+    local.get $var$7
     i32.load $0 offset=12
     i32.const 1
     i32.and
     i32.eqz
     if
-     local.get $3
-     local.get $4
-     local.tee $8
+     local.get $keys
+     local.get $length
+     local.tee $var$8
      i32.const 1
      i32.add
-     local.set $4
-     local.get $8
-     local.get $7
+     local.set $length
+     local.get $var$8
+     local.get $var$7
      i64.load $0
      call $~lib/array/Array<u64>#__uset
     end
-    local.get $5
+    local.get $var$5
     i32.const 1
     i32.add
-    local.set $5
+    local.set $var$5
     br $for-loop|0
    end
   end
-  local.get $3
-  local.get $4
+  local.get $keys
+  local.get $length
   call $~lib/array/Array<u64>#set:length
-  local.get $3
+  local.get $keys
   local.set $9
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -19886,15 +19886,15 @@
   global.set $~lib/memory/__stack_pointer
   local.get $9
  )
- (func $~lib/map/Map<u64,i32>#values (param $0 i32) (result i32)
-  (local $1 i32)
-  (local $2 i32)
-  (local $3 i32)
-  (local $4 i32)
-  (local $5 i32)
-  (local $6 i32)
-  (local $7 i32)
-  (local $8 i32)
+ (func $~lib/map/Map<u64,i32>#values (param $this i32) (result i32)
+  (local $start i32)
+  (local $size i32)
+  (local $values i32)
+  (local $length i32)
+  (local $var$5 i32)
+  (local $var$6 i32)
+  (local $var$7 i32)
+  (local $var$8 i32)
   (local $9 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -19904,63 +19904,63 @@
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   i32.store $0
-  local.get $0
+  local.get $this
   i32.load $0 offset=8
-  local.set $1
-  local.get $0
+  local.set $start
+  local.get $this
   i32.load $0 offset=16
-  local.set $2
+  local.set $size
   global.get $~lib/memory/__stack_pointer
   i32.const 0
-  local.get $2
+  local.get $size
   call $~lib/array/Array<i32>#constructor
-  local.tee $3
+  local.tee $values
   i32.store $0
   i32.const 0
-  local.set $4
+  local.set $length
   i32.const 0
-  local.set $5
+  local.set $var$5
   loop $for-loop|0
-   local.get $5
-   local.get $2
+   local.get $var$5
+   local.get $size
    i32.lt_s
-   local.set $6
-   local.get $6
+   local.set $var$6
+   local.get $var$6
    if
-    local.get $1
-    local.get $5
+    local.get $start
+    local.get $var$5
     i32.const 16
     i32.mul
     i32.add
-    local.set $7
-    local.get $7
+    local.set $var$7
+    local.get $var$7
     i32.load $0 offset=12
     i32.const 1
     i32.and
     i32.eqz
     if
-     local.get $3
-     local.get $4
-     local.tee $8
+     local.get $values
+     local.get $length
+     local.tee $var$8
      i32.const 1
      i32.add
-     local.set $4
-     local.get $8
-     local.get $7
+     local.set $length
+     local.get $var$8
+     local.get $var$7
      i32.load $0 offset=8
      call $~lib/array/Array<i32>#__uset
     end
-    local.get $5
+    local.get $var$5
     i32.const 1
     i32.add
-    local.set $5
+    local.set $var$5
     br $for-loop|0
    end
   end
-  local.get $3
-  local.get $4
+  local.get $values
+  local.get $length
   call $~lib/array/Array<i32>#set:length
-  local.get $3
+  local.get $values
   local.set $9
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -19968,7 +19968,7 @@
   global.set $~lib/memory/__stack_pointer
   local.get $9
  )
- (func $~lib/map/Map<u64,u64>#constructor (param $0 i32) (result i32)
+ (func $~lib/map/Map<u64,u64>#constructor (param $this i32) (result i32)
   (local $1 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -19978,45 +19978,45 @@
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   i32.store $0
-  local.get $0
+  local.get $this
   i32.eqz
   if
    global.get $~lib/memory/__stack_pointer
    i32.const 24
    i32.const 25
    call $~lib/rt/itcms/__new
-   local.tee $0
+   local.tee $this
    i32.store $0
   end
-  local.get $0
+  local.get $this
   i32.const 0
   i32.const 4
   i32.const 4
   i32.mul
   call $~lib/arraybuffer/ArrayBuffer#constructor
   call $~lib/map/Map<u64,u64>#set:buckets
-  local.get $0
+  local.get $this
   i32.const 4
   i32.const 1
   i32.sub
   call $~lib/map/Map<u64,u64>#set:bucketsMask
-  local.get $0
+  local.get $this
   i32.const 0
   i32.const 4
   i32.const 24
   i32.mul
   call $~lib/arraybuffer/ArrayBuffer#constructor
   call $~lib/map/Map<u64,u64>#set:entries
-  local.get $0
+  local.get $this
   i32.const 4
   call $~lib/map/Map<u64,u64>#set:entriesCapacity
-  local.get $0
+  local.get $this
   i32.const 0
   call $~lib/map/Map<u64,u64>#set:entriesOffset
-  local.get $0
+  local.get $this
   i32.const 0
   call $~lib/map/Map<u64,u64>#set:entriesCount
-  local.get $0
+  local.get $this
   local.set $1
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -20024,11 +20024,11 @@
   global.set $~lib/memory/__stack_pointer
   local.get $1
  )
- (func $~lib/map/Map<u64,u64>#set (param $0 i32) (param $1 i64) (param $2 i64) (result i32)
-  (local $3 i32)
-  (local $4 i32)
-  (local $5 i32)
-  (local $6 i32)
+ (func $~lib/map/Map<u64,u64>#set (param $this i32) (param $key i64) (param $value i64) (result i32)
+  (local $hashCode i32)
+  (local $entry i32)
+  (local $var$5 i32)
+  (local $var$6 i32)
   (local $7 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -20038,32 +20038,32 @@
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   i32.store $0
-  local.get $1
+  local.get $key
   call $~lib/util/hash/HASH<u64>
-  local.set $3
-  local.get $0
-  local.get $1
-  local.get $3
+  local.set $hashCode
+  local.get $this
+  local.get $key
+  local.get $hashCode
   call $~lib/map/Map<u64,u64>#find
-  local.set $4
-  local.get $4
+  local.set $entry
+  local.get $entry
   if
-   local.get $4
-   local.get $2
+   local.get $entry
+   local.get $value
    call $~lib/map/MapEntry<u64,u64>#set:value
    i32.const 0
    drop
   else
-   local.get $0
+   local.get $this
    i32.load $0 offset=16
-   local.get $0
+   local.get $this
    i32.load $0 offset=12
    i32.eq
    if
-    local.get $0
-    local.get $0
+    local.get $this
+    local.get $this
     i32.load $0 offset=20
-    local.get $0
+    local.get $this
     i32.load $0 offset=12
     i32.const 3
     i32.mul
@@ -20071,10 +20071,10 @@
     i32.div_s
     i32.lt_s
     if (result i32)
-     local.get $0
+     local.get $this
      i32.load $0 offset=4
     else
-     local.get $0
+     local.get $this
      i32.load $0 offset=4
      i32.const 1
      i32.shl
@@ -20084,58 +20084,58 @@
     call $~lib/map/Map<u64,u64>#rehash
    end
    global.get $~lib/memory/__stack_pointer
-   local.get $0
+   local.get $this
    i32.load $0 offset=8
-   local.tee $5
+   local.tee $var$5
    i32.store $0
-   local.get $5
-   local.get $0
-   local.get $0
+   local.get $var$5
+   local.get $this
+   local.get $this
    i32.load $0 offset=16
-   local.tee $6
+   local.tee $var$6
    i32.const 1
    i32.add
    call $~lib/map/Map<u64,u64>#set:entriesOffset
-   local.get $6
+   local.get $var$6
    i32.const 24
    i32.mul
    i32.add
-   local.set $4
-   local.get $4
-   local.get $1
+   local.set $entry
+   local.get $entry
+   local.get $key
    call $~lib/map/MapEntry<u64,u64>#set:key
    i32.const 0
    drop
-   local.get $4
-   local.get $2
+   local.get $entry
+   local.get $value
    call $~lib/map/MapEntry<u64,u64>#set:value
    i32.const 0
    drop
-   local.get $0
-   local.get $0
+   local.get $this
+   local.get $this
    i32.load $0 offset=20
    i32.const 1
    i32.add
    call $~lib/map/Map<u64,u64>#set:entriesCount
-   local.get $0
+   local.get $this
    i32.load $0
-   local.get $3
-   local.get $0
+   local.get $hashCode
+   local.get $this
    i32.load $0 offset=4
    i32.and
    i32.const 4
    i32.mul
    i32.add
-   local.set $6
-   local.get $4
-   local.get $6
+   local.set $var$6
+   local.get $entry
+   local.get $var$6
    i32.load $0
    call $~lib/map/MapEntry<u64,u64>#set:taggedNext
-   local.get $6
-   local.get $4
+   local.get $var$6
+   local.get $entry
    i32.store $0
   end
-  local.get $0
+  local.get $this
   local.set $7
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -20143,7 +20143,7 @@
   global.set $~lib/memory/__stack_pointer
   local.get $7
  )
- (func $~lib/map/Map<f32,i32>#constructor (param $0 i32) (result i32)
+ (func $~lib/map/Map<f32,i32>#constructor (param $this i32) (result i32)
   (local $1 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -20153,45 +20153,45 @@
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   i32.store $0
-  local.get $0
+  local.get $this
   i32.eqz
   if
    global.get $~lib/memory/__stack_pointer
    i32.const 24
    i32.const 26
    call $~lib/rt/itcms/__new
-   local.tee $0
+   local.tee $this
    i32.store $0
   end
-  local.get $0
+  local.get $this
   i32.const 0
   i32.const 4
   i32.const 4
   i32.mul
   call $~lib/arraybuffer/ArrayBuffer#constructor
   call $~lib/map/Map<f32,i32>#set:buckets
-  local.get $0
+  local.get $this
   i32.const 4
   i32.const 1
   i32.sub
   call $~lib/map/Map<f32,i32>#set:bucketsMask
-  local.get $0
+  local.get $this
   i32.const 0
   i32.const 4
   i32.const 12
   i32.mul
   call $~lib/arraybuffer/ArrayBuffer#constructor
   call $~lib/map/Map<f32,i32>#set:entries
-  local.get $0
+  local.get $this
   i32.const 4
   call $~lib/map/Map<f32,i32>#set:entriesCapacity
-  local.get $0
+  local.get $this
   i32.const 0
   call $~lib/map/Map<f32,i32>#set:entriesOffset
-  local.get $0
+  local.get $this
   i32.const 0
   call $~lib/map/Map<f32,i32>#set:entriesCount
-  local.get $0
+  local.get $this
   local.set $1
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -20199,11 +20199,11 @@
   global.set $~lib/memory/__stack_pointer
   local.get $1
  )
- (func $~lib/map/Map<f32,i32>#set (param $0 i32) (param $1 f32) (param $2 i32) (result i32)
-  (local $3 i32)
-  (local $4 i32)
-  (local $5 i32)
-  (local $6 i32)
+ (func $~lib/map/Map<f32,i32>#set (param $this i32) (param $key f32) (param $value i32) (result i32)
+  (local $hashCode i32)
+  (local $entry i32)
+  (local $var$5 i32)
+  (local $var$6 i32)
   (local $7 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -20213,32 +20213,32 @@
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   i32.store $0
-  local.get $1
+  local.get $key
   call $~lib/util/hash/HASH<f32>
-  local.set $3
-  local.get $0
-  local.get $1
-  local.get $3
+  local.set $hashCode
+  local.get $this
+  local.get $key
+  local.get $hashCode
   call $~lib/map/Map<f32,i32>#find
-  local.set $4
-  local.get $4
+  local.set $entry
+  local.get $entry
   if
-   local.get $4
-   local.get $2
+   local.get $entry
+   local.get $value
    call $~lib/map/MapEntry<f32,i32>#set:value
    i32.const 0
    drop
   else
-   local.get $0
+   local.get $this
    i32.load $0 offset=16
-   local.get $0
+   local.get $this
    i32.load $0 offset=12
    i32.eq
    if
-    local.get $0
-    local.get $0
+    local.get $this
+    local.get $this
     i32.load $0 offset=20
-    local.get $0
+    local.get $this
     i32.load $0 offset=12
     i32.const 3
     i32.mul
@@ -20246,10 +20246,10 @@
     i32.div_s
     i32.lt_s
     if (result i32)
-     local.get $0
+     local.get $this
      i32.load $0 offset=4
     else
-     local.get $0
+     local.get $this
      i32.load $0 offset=4
      i32.const 1
      i32.shl
@@ -20259,58 +20259,58 @@
     call $~lib/map/Map<f32,i32>#rehash
    end
    global.get $~lib/memory/__stack_pointer
-   local.get $0
+   local.get $this
    i32.load $0 offset=8
-   local.tee $5
+   local.tee $var$5
    i32.store $0
-   local.get $5
-   local.get $0
-   local.get $0
+   local.get $var$5
+   local.get $this
+   local.get $this
    i32.load $0 offset=16
-   local.tee $6
+   local.tee $var$6
    i32.const 1
    i32.add
    call $~lib/map/Map<f32,i32>#set:entriesOffset
-   local.get $6
+   local.get $var$6
    i32.const 12
    i32.mul
    i32.add
-   local.set $4
-   local.get $4
-   local.get $1
+   local.set $entry
+   local.get $entry
+   local.get $key
    call $~lib/map/MapEntry<f32,i32>#set:key
    i32.const 0
    drop
-   local.get $4
-   local.get $2
+   local.get $entry
+   local.get $value
    call $~lib/map/MapEntry<f32,i32>#set:value
    i32.const 0
    drop
-   local.get $0
-   local.get $0
+   local.get $this
+   local.get $this
    i32.load $0 offset=20
    i32.const 1
    i32.add
    call $~lib/map/Map<f32,i32>#set:entriesCount
-   local.get $0
+   local.get $this
    i32.load $0
-   local.get $3
-   local.get $0
+   local.get $hashCode
+   local.get $this
    i32.load $0 offset=4
    i32.and
    i32.const 4
    i32.mul
    i32.add
-   local.set $6
-   local.get $4
-   local.get $6
+   local.set $var$6
+   local.get $entry
+   local.get $var$6
    i32.load $0
    call $~lib/map/MapEntry<f32,i32>#set:taggedNext
-   local.get $6
-   local.get $4
+   local.get $var$6
+   local.get $entry
    i32.store $0
   end
-  local.get $0
+  local.get $this
   local.set $7
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -20318,11 +20318,11 @@
   global.set $~lib/memory/__stack_pointer
   local.get $7
  )
- (func $~lib/array/Array<f32>#constructor (param $0 i32) (param $1 i32) (result i32)
-  (local $2 i32)
-  (local $3 i32)
-  (local $4 i32)
-  (local $5 i32)
+ (func $~lib/array/Array<f32>#constructor (param $this i32) (param $length i32) (result i32)
+  (local $var$2 i32)
+  (local $var$3 i32)
+  (local $bufferSize i32)
+  (local $buffer i32)
   (local $6 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 8
@@ -20332,29 +20332,29 @@
   global.get $~lib/memory/__stack_pointer
   i64.const 0
   i64.store $0
-  local.get $0
+  local.get $this
   i32.eqz
   if
    global.get $~lib/memory/__stack_pointer
    i32.const 16
    i32.const 27
    call $~lib/rt/itcms/__new
-   local.tee $0
+   local.tee $this
    i32.store $0
   end
-  local.get $0
+  local.get $this
   i32.const 0
   call $~lib/array/Array<f32>#set:buffer
-  local.get $0
+  local.get $this
   i32.const 0
   call $~lib/array/Array<f32>#set:dataStart
-  local.get $0
+  local.get $this
   i32.const 0
   call $~lib/array/Array<f32>#set:byteLength
-  local.get $0
+  local.get $this
   i32.const 0
   call $~lib/array/Array<f32>#set:length_
-  local.get $1
+  local.get $length
   i32.const 1073741820
   i32.const 2
   i32.shr_u
@@ -20367,40 +20367,40 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $1
-  local.tee $2
+  local.get $length
+  local.tee $var$2
   i32.const 8
-  local.tee $3
-  local.get $2
-  local.get $3
+  local.tee $var$3
+  local.get $var$2
+  local.get $var$3
   i32.gt_u
   select
   i32.const 2
   i32.shl
-  local.set $4
+  local.set $bufferSize
   global.get $~lib/memory/__stack_pointer
-  local.get $4
+  local.get $bufferSize
   i32.const 0
   call $~lib/rt/itcms/__new
-  local.tee $5
+  local.tee $buffer
   i32.store $0 offset=4
   i32.const 2
   global.get $~lib/shared/runtime/Runtime.Incremental
   i32.ne
   drop
-  local.get $0
-  local.get $5
+  local.get $this
+  local.get $buffer
   call $~lib/array/Array<f32>#set:buffer
-  local.get $0
-  local.get $5
+  local.get $this
+  local.get $buffer
   call $~lib/array/Array<f32>#set:dataStart
-  local.get $0
-  local.get $4
+  local.get $this
+  local.get $bufferSize
   call $~lib/array/Array<f32>#set:byteLength
-  local.get $0
-  local.get $1
+  local.get $this
+  local.get $length
   call $~lib/array/Array<f32>#set:length_
-  local.get $0
+  local.get $this
   local.set $6
   global.get $~lib/memory/__stack_pointer
   i32.const 8
@@ -20408,15 +20408,15 @@
   global.set $~lib/memory/__stack_pointer
   local.get $6
  )
- (func $~lib/map/Map<f32,i32>#keys (param $0 i32) (result i32)
-  (local $1 i32)
-  (local $2 i32)
-  (local $3 i32)
-  (local $4 i32)
-  (local $5 i32)
-  (local $6 i32)
-  (local $7 i32)
-  (local $8 i32)
+ (func $~lib/map/Map<f32,i32>#keys (param $this i32) (result i32)
+  (local $start i32)
+  (local $size i32)
+  (local $keys i32)
+  (local $length i32)
+  (local $var$5 i32)
+  (local $var$6 i32)
+  (local $var$7 i32)
+  (local $var$8 i32)
   (local $9 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -20426,63 +20426,63 @@
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   i32.store $0
-  local.get $0
+  local.get $this
   i32.load $0 offset=8
-  local.set $1
-  local.get $0
+  local.set $start
+  local.get $this
   i32.load $0 offset=16
-  local.set $2
+  local.set $size
   global.get $~lib/memory/__stack_pointer
   i32.const 0
-  local.get $2
+  local.get $size
   call $~lib/array/Array<f32>#constructor
-  local.tee $3
+  local.tee $keys
   i32.store $0
   i32.const 0
-  local.set $4
+  local.set $length
   i32.const 0
-  local.set $5
+  local.set $var$5
   loop $for-loop|0
-   local.get $5
-   local.get $2
+   local.get $var$5
+   local.get $size
    i32.lt_s
-   local.set $6
-   local.get $6
+   local.set $var$6
+   local.get $var$6
    if
-    local.get $1
-    local.get $5
+    local.get $start
+    local.get $var$5
     i32.const 12
     i32.mul
     i32.add
-    local.set $7
-    local.get $7
+    local.set $var$7
+    local.get $var$7
     i32.load $0 offset=8
     i32.const 1
     i32.and
     i32.eqz
     if
-     local.get $3
-     local.get $4
-     local.tee $8
+     local.get $keys
+     local.get $length
+     local.tee $var$8
      i32.const 1
      i32.add
-     local.set $4
-     local.get $8
-     local.get $7
+     local.set $length
+     local.get $var$8
+     local.get $var$7
      f32.load $0
      call $~lib/array/Array<f32>#__uset
     end
-    local.get $5
+    local.get $var$5
     i32.const 1
     i32.add
-    local.set $5
+    local.set $var$5
     br $for-loop|0
    end
   end
-  local.get $3
-  local.get $4
+  local.get $keys
+  local.get $length
   call $~lib/array/Array<f32>#set:length
-  local.get $3
+  local.get $keys
   local.set $9
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -20490,15 +20490,15 @@
   global.set $~lib/memory/__stack_pointer
   local.get $9
  )
- (func $~lib/map/Map<f32,i32>#values (param $0 i32) (result i32)
-  (local $1 i32)
-  (local $2 i32)
-  (local $3 i32)
-  (local $4 i32)
-  (local $5 i32)
-  (local $6 i32)
-  (local $7 i32)
-  (local $8 i32)
+ (func $~lib/map/Map<f32,i32>#values (param $this i32) (result i32)
+  (local $start i32)
+  (local $size i32)
+  (local $values i32)
+  (local $length i32)
+  (local $var$5 i32)
+  (local $var$6 i32)
+  (local $var$7 i32)
+  (local $var$8 i32)
   (local $9 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -20508,63 +20508,63 @@
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   i32.store $0
-  local.get $0
+  local.get $this
   i32.load $0 offset=8
-  local.set $1
-  local.get $0
+  local.set $start
+  local.get $this
   i32.load $0 offset=16
-  local.set $2
+  local.set $size
   global.get $~lib/memory/__stack_pointer
   i32.const 0
-  local.get $2
+  local.get $size
   call $~lib/array/Array<i32>#constructor
-  local.tee $3
+  local.tee $values
   i32.store $0
   i32.const 0
-  local.set $4
+  local.set $length
   i32.const 0
-  local.set $5
+  local.set $var$5
   loop $for-loop|0
-   local.get $5
-   local.get $2
+   local.get $var$5
+   local.get $size
    i32.lt_s
-   local.set $6
-   local.get $6
+   local.set $var$6
+   local.get $var$6
    if
-    local.get $1
-    local.get $5
+    local.get $start
+    local.get $var$5
     i32.const 12
     i32.mul
     i32.add
-    local.set $7
-    local.get $7
+    local.set $var$7
+    local.get $var$7
     i32.load $0 offset=8
     i32.const 1
     i32.and
     i32.eqz
     if
-     local.get $3
-     local.get $4
-     local.tee $8
+     local.get $values
+     local.get $length
+     local.tee $var$8
      i32.const 1
      i32.add
-     local.set $4
-     local.get $8
-     local.get $7
+     local.set $length
+     local.get $var$8
+     local.get $var$7
      i32.load $0 offset=4
      call $~lib/array/Array<i32>#__uset
     end
-    local.get $5
+    local.get $var$5
     i32.const 1
     i32.add
-    local.set $5
+    local.set $var$5
     br $for-loop|0
    end
   end
-  local.get $3
-  local.get $4
+  local.get $values
+  local.get $length
   call $~lib/array/Array<i32>#set:length
-  local.get $3
+  local.get $values
   local.set $9
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -20572,7 +20572,7 @@
   global.set $~lib/memory/__stack_pointer
   local.get $9
  )
- (func $~lib/map/Map<f32,f32>#constructor (param $0 i32) (result i32)
+ (func $~lib/map/Map<f32,f32>#constructor (param $this i32) (result i32)
   (local $1 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -20582,45 +20582,45 @@
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   i32.store $0
-  local.get $0
+  local.get $this
   i32.eqz
   if
    global.get $~lib/memory/__stack_pointer
    i32.const 24
    i32.const 28
    call $~lib/rt/itcms/__new
-   local.tee $0
+   local.tee $this
    i32.store $0
   end
-  local.get $0
+  local.get $this
   i32.const 0
   i32.const 4
   i32.const 4
   i32.mul
   call $~lib/arraybuffer/ArrayBuffer#constructor
   call $~lib/map/Map<f32,f32>#set:buckets
-  local.get $0
+  local.get $this
   i32.const 4
   i32.const 1
   i32.sub
   call $~lib/map/Map<f32,f32>#set:bucketsMask
-  local.get $0
+  local.get $this
   i32.const 0
   i32.const 4
   i32.const 12
   i32.mul
   call $~lib/arraybuffer/ArrayBuffer#constructor
   call $~lib/map/Map<f32,f32>#set:entries
-  local.get $0
+  local.get $this
   i32.const 4
   call $~lib/map/Map<f32,f32>#set:entriesCapacity
-  local.get $0
+  local.get $this
   i32.const 0
   call $~lib/map/Map<f32,f32>#set:entriesOffset
-  local.get $0
+  local.get $this
   i32.const 0
   call $~lib/map/Map<f32,f32>#set:entriesCount
-  local.get $0
+  local.get $this
   local.set $1
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -20628,11 +20628,11 @@
   global.set $~lib/memory/__stack_pointer
   local.get $1
  )
- (func $~lib/map/Map<f32,f32>#set (param $0 i32) (param $1 f32) (param $2 f32) (result i32)
-  (local $3 i32)
-  (local $4 i32)
-  (local $5 i32)
-  (local $6 i32)
+ (func $~lib/map/Map<f32,f32>#set (param $this i32) (param $key f32) (param $value f32) (result i32)
+  (local $hashCode i32)
+  (local $entry i32)
+  (local $var$5 i32)
+  (local $var$6 i32)
   (local $7 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -20642,32 +20642,32 @@
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   i32.store $0
-  local.get $1
+  local.get $key
   call $~lib/util/hash/HASH<f32>
-  local.set $3
-  local.get $0
-  local.get $1
-  local.get $3
+  local.set $hashCode
+  local.get $this
+  local.get $key
+  local.get $hashCode
   call $~lib/map/Map<f32,f32>#find
-  local.set $4
-  local.get $4
+  local.set $entry
+  local.get $entry
   if
-   local.get $4
-   local.get $2
+   local.get $entry
+   local.get $value
    call $~lib/map/MapEntry<f32,f32>#set:value
    i32.const 0
    drop
   else
-   local.get $0
+   local.get $this
    i32.load $0 offset=16
-   local.get $0
+   local.get $this
    i32.load $0 offset=12
    i32.eq
    if
-    local.get $0
-    local.get $0
+    local.get $this
+    local.get $this
     i32.load $0 offset=20
-    local.get $0
+    local.get $this
     i32.load $0 offset=12
     i32.const 3
     i32.mul
@@ -20675,10 +20675,10 @@
     i32.div_s
     i32.lt_s
     if (result i32)
-     local.get $0
+     local.get $this
      i32.load $0 offset=4
     else
-     local.get $0
+     local.get $this
      i32.load $0 offset=4
      i32.const 1
      i32.shl
@@ -20688,58 +20688,58 @@
     call $~lib/map/Map<f32,f32>#rehash
    end
    global.get $~lib/memory/__stack_pointer
-   local.get $0
+   local.get $this
    i32.load $0 offset=8
-   local.tee $5
+   local.tee $var$5
    i32.store $0
-   local.get $5
-   local.get $0
-   local.get $0
+   local.get $var$5
+   local.get $this
+   local.get $this
    i32.load $0 offset=16
-   local.tee $6
+   local.tee $var$6
    i32.const 1
    i32.add
    call $~lib/map/Map<f32,f32>#set:entriesOffset
-   local.get $6
+   local.get $var$6
    i32.const 12
    i32.mul
    i32.add
-   local.set $4
-   local.get $4
-   local.get $1
+   local.set $entry
+   local.get $entry
+   local.get $key
    call $~lib/map/MapEntry<f32,f32>#set:key
    i32.const 0
    drop
-   local.get $4
-   local.get $2
+   local.get $entry
+   local.get $value
    call $~lib/map/MapEntry<f32,f32>#set:value
    i32.const 0
    drop
-   local.get $0
-   local.get $0
+   local.get $this
+   local.get $this
    i32.load $0 offset=20
    i32.const 1
    i32.add
    call $~lib/map/Map<f32,f32>#set:entriesCount
-   local.get $0
+   local.get $this
    i32.load $0
-   local.get $3
-   local.get $0
+   local.get $hashCode
+   local.get $this
    i32.load $0 offset=4
    i32.and
    i32.const 4
    i32.mul
    i32.add
-   local.set $6
-   local.get $4
-   local.get $6
+   local.set $var$6
+   local.get $entry
+   local.get $var$6
    i32.load $0
    call $~lib/map/MapEntry<f32,f32>#set:taggedNext
-   local.get $6
-   local.get $4
+   local.get $var$6
+   local.get $entry
    i32.store $0
   end
-  local.get $0
+  local.get $this
   local.set $7
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -20747,7 +20747,7 @@
   global.set $~lib/memory/__stack_pointer
   local.get $7
  )
- (func $~lib/map/Map<f64,i32>#constructor (param $0 i32) (result i32)
+ (func $~lib/map/Map<f64,i32>#constructor (param $this i32) (result i32)
   (local $1 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -20757,45 +20757,45 @@
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   i32.store $0
-  local.get $0
+  local.get $this
   i32.eqz
   if
    global.get $~lib/memory/__stack_pointer
    i32.const 24
    i32.const 29
    call $~lib/rt/itcms/__new
-   local.tee $0
+   local.tee $this
    i32.store $0
   end
-  local.get $0
+  local.get $this
   i32.const 0
   i32.const 4
   i32.const 4
   i32.mul
   call $~lib/arraybuffer/ArrayBuffer#constructor
   call $~lib/map/Map<f64,i32>#set:buckets
-  local.get $0
+  local.get $this
   i32.const 4
   i32.const 1
   i32.sub
   call $~lib/map/Map<f64,i32>#set:bucketsMask
-  local.get $0
+  local.get $this
   i32.const 0
   i32.const 4
   i32.const 16
   i32.mul
   call $~lib/arraybuffer/ArrayBuffer#constructor
   call $~lib/map/Map<f64,i32>#set:entries
-  local.get $0
+  local.get $this
   i32.const 4
   call $~lib/map/Map<f64,i32>#set:entriesCapacity
-  local.get $0
+  local.get $this
   i32.const 0
   call $~lib/map/Map<f64,i32>#set:entriesOffset
-  local.get $0
+  local.get $this
   i32.const 0
   call $~lib/map/Map<f64,i32>#set:entriesCount
-  local.get $0
+  local.get $this
   local.set $1
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -20803,11 +20803,11 @@
   global.set $~lib/memory/__stack_pointer
   local.get $1
  )
- (func $~lib/map/Map<f64,i32>#set (param $0 i32) (param $1 f64) (param $2 i32) (result i32)
-  (local $3 i32)
-  (local $4 i32)
-  (local $5 i32)
-  (local $6 i32)
+ (func $~lib/map/Map<f64,i32>#set (param $this i32) (param $key f64) (param $value i32) (result i32)
+  (local $hashCode i32)
+  (local $entry i32)
+  (local $var$5 i32)
+  (local $var$6 i32)
   (local $7 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -20817,32 +20817,32 @@
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   i32.store $0
-  local.get $1
+  local.get $key
   call $~lib/util/hash/HASH<f64>
-  local.set $3
-  local.get $0
-  local.get $1
-  local.get $3
+  local.set $hashCode
+  local.get $this
+  local.get $key
+  local.get $hashCode
   call $~lib/map/Map<f64,i32>#find
-  local.set $4
-  local.get $4
+  local.set $entry
+  local.get $entry
   if
-   local.get $4
-   local.get $2
+   local.get $entry
+   local.get $value
    call $~lib/map/MapEntry<f64,i32>#set:value
    i32.const 0
    drop
   else
-   local.get $0
+   local.get $this
    i32.load $0 offset=16
-   local.get $0
+   local.get $this
    i32.load $0 offset=12
    i32.eq
    if
-    local.get $0
-    local.get $0
+    local.get $this
+    local.get $this
     i32.load $0 offset=20
-    local.get $0
+    local.get $this
     i32.load $0 offset=12
     i32.const 3
     i32.mul
@@ -20850,10 +20850,10 @@
     i32.div_s
     i32.lt_s
     if (result i32)
-     local.get $0
+     local.get $this
      i32.load $0 offset=4
     else
-     local.get $0
+     local.get $this
      i32.load $0 offset=4
      i32.const 1
      i32.shl
@@ -20863,58 +20863,58 @@
     call $~lib/map/Map<f64,i32>#rehash
    end
    global.get $~lib/memory/__stack_pointer
-   local.get $0
+   local.get $this
    i32.load $0 offset=8
-   local.tee $5
+   local.tee $var$5
    i32.store $0
-   local.get $5
-   local.get $0
-   local.get $0
+   local.get $var$5
+   local.get $this
+   local.get $this
    i32.load $0 offset=16
-   local.tee $6
+   local.tee $var$6
    i32.const 1
    i32.add
    call $~lib/map/Map<f64,i32>#set:entriesOffset
-   local.get $6
+   local.get $var$6
    i32.const 16
    i32.mul
    i32.add
-   local.set $4
-   local.get $4
-   local.get $1
+   local.set $entry
+   local.get $entry
+   local.get $key
    call $~lib/map/MapEntry<f64,i32>#set:key
    i32.const 0
    drop
-   local.get $4
-   local.get $2
+   local.get $entry
+   local.get $value
    call $~lib/map/MapEntry<f64,i32>#set:value
    i32.const 0
    drop
-   local.get $0
-   local.get $0
+   local.get $this
+   local.get $this
    i32.load $0 offset=20
    i32.const 1
    i32.add
    call $~lib/map/Map<f64,i32>#set:entriesCount
-   local.get $0
+   local.get $this
    i32.load $0
-   local.get $3
-   local.get $0
+   local.get $hashCode
+   local.get $this
    i32.load $0 offset=4
    i32.and
    i32.const 4
    i32.mul
    i32.add
-   local.set $6
-   local.get $4
-   local.get $6
+   local.set $var$6
+   local.get $entry
+   local.get $var$6
    i32.load $0
    call $~lib/map/MapEntry<f64,i32>#set:taggedNext
-   local.get $6
-   local.get $4
+   local.get $var$6
+   local.get $entry
    i32.store $0
   end
-  local.get $0
+  local.get $this
   local.set $7
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -20922,11 +20922,11 @@
   global.set $~lib/memory/__stack_pointer
   local.get $7
  )
- (func $~lib/array/Array<f64>#constructor (param $0 i32) (param $1 i32) (result i32)
-  (local $2 i32)
-  (local $3 i32)
-  (local $4 i32)
-  (local $5 i32)
+ (func $~lib/array/Array<f64>#constructor (param $this i32) (param $length i32) (result i32)
+  (local $var$2 i32)
+  (local $var$3 i32)
+  (local $bufferSize i32)
+  (local $buffer i32)
   (local $6 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 8
@@ -20936,29 +20936,29 @@
   global.get $~lib/memory/__stack_pointer
   i64.const 0
   i64.store $0
-  local.get $0
+  local.get $this
   i32.eqz
   if
    global.get $~lib/memory/__stack_pointer
    i32.const 16
    i32.const 30
    call $~lib/rt/itcms/__new
-   local.tee $0
+   local.tee $this
    i32.store $0
   end
-  local.get $0
+  local.get $this
   i32.const 0
   call $~lib/array/Array<f64>#set:buffer
-  local.get $0
+  local.get $this
   i32.const 0
   call $~lib/array/Array<f64>#set:dataStart
-  local.get $0
+  local.get $this
   i32.const 0
   call $~lib/array/Array<f64>#set:byteLength
-  local.get $0
+  local.get $this
   i32.const 0
   call $~lib/array/Array<f64>#set:length_
-  local.get $1
+  local.get $length
   i32.const 1073741820
   i32.const 3
   i32.shr_u
@@ -20971,40 +20971,40 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $1
-  local.tee $2
+  local.get $length
+  local.tee $var$2
   i32.const 8
-  local.tee $3
-  local.get $2
-  local.get $3
+  local.tee $var$3
+  local.get $var$2
+  local.get $var$3
   i32.gt_u
   select
   i32.const 3
   i32.shl
-  local.set $4
+  local.set $bufferSize
   global.get $~lib/memory/__stack_pointer
-  local.get $4
+  local.get $bufferSize
   i32.const 0
   call $~lib/rt/itcms/__new
-  local.tee $5
+  local.tee $buffer
   i32.store $0 offset=4
   i32.const 2
   global.get $~lib/shared/runtime/Runtime.Incremental
   i32.ne
   drop
-  local.get $0
-  local.get $5
+  local.get $this
+  local.get $buffer
   call $~lib/array/Array<f64>#set:buffer
-  local.get $0
-  local.get $5
+  local.get $this
+  local.get $buffer
   call $~lib/array/Array<f64>#set:dataStart
-  local.get $0
-  local.get $4
+  local.get $this
+  local.get $bufferSize
   call $~lib/array/Array<f64>#set:byteLength
-  local.get $0
-  local.get $1
+  local.get $this
+  local.get $length
   call $~lib/array/Array<f64>#set:length_
-  local.get $0
+  local.get $this
   local.set $6
   global.get $~lib/memory/__stack_pointer
   i32.const 8
@@ -21012,15 +21012,15 @@
   global.set $~lib/memory/__stack_pointer
   local.get $6
  )
- (func $~lib/map/Map<f64,i32>#keys (param $0 i32) (result i32)
-  (local $1 i32)
-  (local $2 i32)
-  (local $3 i32)
-  (local $4 i32)
-  (local $5 i32)
-  (local $6 i32)
-  (local $7 i32)
-  (local $8 i32)
+ (func $~lib/map/Map<f64,i32>#keys (param $this i32) (result i32)
+  (local $start i32)
+  (local $size i32)
+  (local $keys i32)
+  (local $length i32)
+  (local $var$5 i32)
+  (local $var$6 i32)
+  (local $var$7 i32)
+  (local $var$8 i32)
   (local $9 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -21030,63 +21030,63 @@
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   i32.store $0
-  local.get $0
+  local.get $this
   i32.load $0 offset=8
-  local.set $1
-  local.get $0
+  local.set $start
+  local.get $this
   i32.load $0 offset=16
-  local.set $2
+  local.set $size
   global.get $~lib/memory/__stack_pointer
   i32.const 0
-  local.get $2
+  local.get $size
   call $~lib/array/Array<f64>#constructor
-  local.tee $3
+  local.tee $keys
   i32.store $0
   i32.const 0
-  local.set $4
+  local.set $length
   i32.const 0
-  local.set $5
+  local.set $var$5
   loop $for-loop|0
-   local.get $5
-   local.get $2
+   local.get $var$5
+   local.get $size
    i32.lt_s
-   local.set $6
-   local.get $6
+   local.set $var$6
+   local.get $var$6
    if
-    local.get $1
-    local.get $5
+    local.get $start
+    local.get $var$5
     i32.const 16
     i32.mul
     i32.add
-    local.set $7
-    local.get $7
+    local.set $var$7
+    local.get $var$7
     i32.load $0 offset=12
     i32.const 1
     i32.and
     i32.eqz
     if
-     local.get $3
-     local.get $4
-     local.tee $8
+     local.get $keys
+     local.get $length
+     local.tee $var$8
      i32.const 1
      i32.add
-     local.set $4
-     local.get $8
-     local.get $7
+     local.set $length
+     local.get $var$8
+     local.get $var$7
      f64.load $0
      call $~lib/array/Array<f64>#__uset
     end
-    local.get $5
+    local.get $var$5
     i32.const 1
     i32.add
-    local.set $5
+    local.set $var$5
     br $for-loop|0
    end
   end
-  local.get $3
-  local.get $4
+  local.get $keys
+  local.get $length
   call $~lib/array/Array<f64>#set:length
-  local.get $3
+  local.get $keys
   local.set $9
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -21094,15 +21094,15 @@
   global.set $~lib/memory/__stack_pointer
   local.get $9
  )
- (func $~lib/map/Map<f64,i32>#values (param $0 i32) (result i32)
-  (local $1 i32)
-  (local $2 i32)
-  (local $3 i32)
-  (local $4 i32)
-  (local $5 i32)
-  (local $6 i32)
-  (local $7 i32)
-  (local $8 i32)
+ (func $~lib/map/Map<f64,i32>#values (param $this i32) (result i32)
+  (local $start i32)
+  (local $size i32)
+  (local $values i32)
+  (local $length i32)
+  (local $var$5 i32)
+  (local $var$6 i32)
+  (local $var$7 i32)
+  (local $var$8 i32)
   (local $9 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -21112,63 +21112,63 @@
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   i32.store $0
-  local.get $0
+  local.get $this
   i32.load $0 offset=8
-  local.set $1
-  local.get $0
+  local.set $start
+  local.get $this
   i32.load $0 offset=16
-  local.set $2
+  local.set $size
   global.get $~lib/memory/__stack_pointer
   i32.const 0
-  local.get $2
+  local.get $size
   call $~lib/array/Array<i32>#constructor
-  local.tee $3
+  local.tee $values
   i32.store $0
   i32.const 0
-  local.set $4
+  local.set $length
   i32.const 0
-  local.set $5
+  local.set $var$5
   loop $for-loop|0
-   local.get $5
-   local.get $2
+   local.get $var$5
+   local.get $size
    i32.lt_s
-   local.set $6
-   local.get $6
+   local.set $var$6
+   local.get $var$6
    if
-    local.get $1
-    local.get $5
+    local.get $start
+    local.get $var$5
     i32.const 16
     i32.mul
     i32.add
-    local.set $7
-    local.get $7
+    local.set $var$7
+    local.get $var$7
     i32.load $0 offset=12
     i32.const 1
     i32.and
     i32.eqz
     if
-     local.get $3
-     local.get $4
-     local.tee $8
+     local.get $values
+     local.get $length
+     local.tee $var$8
      i32.const 1
      i32.add
-     local.set $4
-     local.get $8
-     local.get $7
+     local.set $length
+     local.get $var$8
+     local.get $var$7
      i32.load $0 offset=8
      call $~lib/array/Array<i32>#__uset
     end
-    local.get $5
+    local.get $var$5
     i32.const 1
     i32.add
-    local.set $5
+    local.set $var$5
     br $for-loop|0
    end
   end
-  local.get $3
-  local.get $4
+  local.get $values
+  local.get $length
   call $~lib/array/Array<i32>#set:length
-  local.get $3
+  local.get $values
   local.set $9
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -21176,7 +21176,7 @@
   global.set $~lib/memory/__stack_pointer
   local.get $9
  )
- (func $~lib/map/Map<f64,f64>#constructor (param $0 i32) (result i32)
+ (func $~lib/map/Map<f64,f64>#constructor (param $this i32) (result i32)
   (local $1 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -21186,45 +21186,45 @@
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   i32.store $0
-  local.get $0
+  local.get $this
   i32.eqz
   if
    global.get $~lib/memory/__stack_pointer
    i32.const 24
    i32.const 31
    call $~lib/rt/itcms/__new
-   local.tee $0
+   local.tee $this
    i32.store $0
   end
-  local.get $0
+  local.get $this
   i32.const 0
   i32.const 4
   i32.const 4
   i32.mul
   call $~lib/arraybuffer/ArrayBuffer#constructor
   call $~lib/map/Map<f64,f64>#set:buckets
-  local.get $0
+  local.get $this
   i32.const 4
   i32.const 1
   i32.sub
   call $~lib/map/Map<f64,f64>#set:bucketsMask
-  local.get $0
+  local.get $this
   i32.const 0
   i32.const 4
   i32.const 24
   i32.mul
   call $~lib/arraybuffer/ArrayBuffer#constructor
   call $~lib/map/Map<f64,f64>#set:entries
-  local.get $0
+  local.get $this
   i32.const 4
   call $~lib/map/Map<f64,f64>#set:entriesCapacity
-  local.get $0
+  local.get $this
   i32.const 0
   call $~lib/map/Map<f64,f64>#set:entriesOffset
-  local.get $0
+  local.get $this
   i32.const 0
   call $~lib/map/Map<f64,f64>#set:entriesCount
-  local.get $0
+  local.get $this
   local.set $1
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -21232,11 +21232,11 @@
   global.set $~lib/memory/__stack_pointer
   local.get $1
  )
- (func $~lib/map/Map<f64,f64>#set (param $0 i32) (param $1 f64) (param $2 f64) (result i32)
-  (local $3 i32)
-  (local $4 i32)
-  (local $5 i32)
-  (local $6 i32)
+ (func $~lib/map/Map<f64,f64>#set (param $this i32) (param $key f64) (param $value f64) (result i32)
+  (local $hashCode i32)
+  (local $entry i32)
+  (local $var$5 i32)
+  (local $var$6 i32)
   (local $7 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -21246,32 +21246,32 @@
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   i32.store $0
-  local.get $1
+  local.get $key
   call $~lib/util/hash/HASH<f64>
-  local.set $3
-  local.get $0
-  local.get $1
-  local.get $3
+  local.set $hashCode
+  local.get $this
+  local.get $key
+  local.get $hashCode
   call $~lib/map/Map<f64,f64>#find
-  local.set $4
-  local.get $4
+  local.set $entry
+  local.get $entry
   if
-   local.get $4
-   local.get $2
+   local.get $entry
+   local.get $value
    call $~lib/map/MapEntry<f64,f64>#set:value
    i32.const 0
    drop
   else
-   local.get $0
+   local.get $this
    i32.load $0 offset=16
-   local.get $0
+   local.get $this
    i32.load $0 offset=12
    i32.eq
    if
-    local.get $0
-    local.get $0
+    local.get $this
+    local.get $this
     i32.load $0 offset=20
-    local.get $0
+    local.get $this
     i32.load $0 offset=12
     i32.const 3
     i32.mul
@@ -21279,10 +21279,10 @@
     i32.div_s
     i32.lt_s
     if (result i32)
-     local.get $0
+     local.get $this
      i32.load $0 offset=4
     else
-     local.get $0
+     local.get $this
      i32.load $0 offset=4
      i32.const 1
      i32.shl
@@ -21292,58 +21292,58 @@
     call $~lib/map/Map<f64,f64>#rehash
    end
    global.get $~lib/memory/__stack_pointer
-   local.get $0
+   local.get $this
    i32.load $0 offset=8
-   local.tee $5
+   local.tee $var$5
    i32.store $0
-   local.get $5
-   local.get $0
-   local.get $0
+   local.get $var$5
+   local.get $this
+   local.get $this
    i32.load $0 offset=16
-   local.tee $6
+   local.tee $var$6
    i32.const 1
    i32.add
    call $~lib/map/Map<f64,f64>#set:entriesOffset
-   local.get $6
+   local.get $var$6
    i32.const 24
    i32.mul
    i32.add
-   local.set $4
-   local.get $4
-   local.get $1
+   local.set $entry
+   local.get $entry
+   local.get $key
    call $~lib/map/MapEntry<f64,f64>#set:key
    i32.const 0
    drop
-   local.get $4
-   local.get $2
+   local.get $entry
+   local.get $value
    call $~lib/map/MapEntry<f64,f64>#set:value
    i32.const 0
    drop
-   local.get $0
-   local.get $0
+   local.get $this
+   local.get $this
    i32.load $0 offset=20
    i32.const 1
    i32.add
    call $~lib/map/Map<f64,f64>#set:entriesCount
-   local.get $0
+   local.get $this
    i32.load $0
-   local.get $3
-   local.get $0
+   local.get $hashCode
+   local.get $this
    i32.load $0 offset=4
    i32.and
    i32.const 4
    i32.mul
    i32.add
-   local.set $6
-   local.get $4
-   local.get $6
+   local.set $var$6
+   local.get $entry
+   local.get $var$6
    i32.load $0
    call $~lib/map/MapEntry<f64,f64>#set:taggedNext
-   local.get $6
-   local.get $4
+   local.get $var$6
+   local.get $entry
    i32.store $0
   end
-  local.get $0
+  local.get $this
   local.set $7
   global.get $~lib/memory/__stack_pointer
   i32.const 4

--- a/tests/compiler/std/new.debug.wat
+++ b/tests/compiler/std/new.debug.wat
@@ -2218,7 +2218,7 @@
    unreachable
   end
  )
- (func $std/new/AClass#constructor (param $0 i32) (param $1 f32) (result i32)
+ (func $std/new/AClass#constructor (param $this i32) (param $value f32) (result i32)
   (local $2 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -2228,32 +2228,32 @@
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   i32.store $0
-  local.get $0
+  local.get $this
   i32.eqz
   if
    global.get $~lib/memory/__stack_pointer
    i32.const 8
    i32.const 3
    call $~lib/rt/itcms/__new
-   local.tee $0
+   local.tee $this
    i32.store $0
   end
-  local.get $0
+  local.get $this
   i32.const 1
   call $std/new/AClass#set:aField
-  local.get $0
+  local.get $this
   f32.const 2
   call $std/new/AClass#set:anotherField
-  local.get $0
-  local.get $0
+  local.get $this
+  local.get $this
   i32.load $0
   i32.const 1
   i32.add
   call $std/new/AClass#set:aField
-  local.get $0
-  local.get $1
+  local.get $this
+  local.get $value
   call $std/new/AClass#set:anotherField
-  local.get $0
+  local.get $this
   local.set $2
   global.get $~lib/memory/__stack_pointer
   i32.const 4

--- a/tests/compiler/std/operator-overloading.debug.wat
+++ b/tests/compiler/std/operator-overloading.debug.wat
@@ -3446,7 +3446,7 @@
    unreachable
   end
  )
- (func $std/operator-overloading/TesterElementAccess#__set (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $std/operator-overloading/TesterElementAccess#__set (param $this i32) (param $key i32) (param $value i32)
   (local $3 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -3456,7 +3456,7 @@
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   i32.store $0
-  local.get $1
+  local.get $key
   i32.const 512
   local.set $3
   global.get $~lib/memory/__stack_pointer
@@ -3465,12 +3465,12 @@
   local.get $3
   call $~lib/string/String.__eq
   if
-   local.get $0
-   local.get $2
+   local.get $this
+   local.get $value
    call $std/operator-overloading/TesterElementAccess#set:x
   else
-   local.get $0
-   local.get $2
+   local.get $this
+   local.get $value
    call $std/operator-overloading/TesterElementAccess#set:y
   end
   global.get $~lib/memory/__stack_pointer
@@ -3478,7 +3478,7 @@
   i32.add
   global.set $~lib/memory/__stack_pointer
  )
- (func $std/operator-overloading/TesterElementAccess#__get (param $0 i32) (param $1 i32) (result i32)
+ (func $std/operator-overloading/TesterElementAccess#__get (param $this i32) (param $key i32) (result i32)
   (local $2 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -3488,7 +3488,7 @@
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   i32.store $0
-  local.get $1
+  local.get $key
   i32.const 512
   local.set $2
   global.get $~lib/memory/__stack_pointer
@@ -3497,10 +3497,10 @@
   local.get $2
   call $~lib/string/String.__eq
   if (result i32)
-   local.get $0
+   local.get $this
    i32.load $0
   else
-   local.get $0
+   local.get $this
    i32.load $0 offset=4
   end
   local.set $2
@@ -5005,7 +5005,7 @@
   i32.add
   global.set $~lib/memory/__stack_pointer
  )
- (func $std/operator-overloading/Tester#constructor (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/operator-overloading/Tester#constructor (param $this i32) (param $x i32) (param $y i32) (result i32)
   (local $3 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -5015,23 +5015,23 @@
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   i32.store $0
-  local.get $0
+  local.get $this
   i32.eqz
   if
    global.get $~lib/memory/__stack_pointer
    i32.const 8
    i32.const 3
    call $~lib/rt/itcms/__new
-   local.tee $0
+   local.tee $this
    i32.store $0
   end
-  local.get $0
-  local.get $1
+  local.get $this
+  local.get $x
   call $std/operator-overloading/Tester#set:x
-  local.get $0
-  local.get $2
+  local.get $this
+  local.get $y
   call $std/operator-overloading/Tester#set:y
-  local.get $0
+  local.get $this
   local.set $3
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -5039,7 +5039,7 @@
   global.set $~lib/memory/__stack_pointer
   local.get $3
  )
- (func $std/operator-overloading/TesterInlineStatic#constructor (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/operator-overloading/TesterInlineStatic#constructor (param $this i32) (param $x i32) (param $y i32) (result i32)
   (local $3 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -5049,23 +5049,23 @@
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   i32.store $0
-  local.get $0
+  local.get $this
   i32.eqz
   if
    global.get $~lib/memory/__stack_pointer
    i32.const 8
    i32.const 4
    call $~lib/rt/itcms/__new
-   local.tee $0
+   local.tee $this
    i32.store $0
   end
-  local.get $0
-  local.get $1
+  local.get $this
+  local.get $x
   call $std/operator-overloading/TesterInlineStatic#set:x
-  local.get $0
-  local.get $2
+  local.get $this
+  local.get $y
   call $std/operator-overloading/TesterInlineStatic#set:y
-  local.get $0
+  local.get $this
   local.set $3
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -5073,7 +5073,7 @@
   global.set $~lib/memory/__stack_pointer
   local.get $3
  )
- (func $std/operator-overloading/TesterInlineInstance#constructor (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/operator-overloading/TesterInlineInstance#constructor (param $this i32) (param $x i32) (param $y i32) (result i32)
   (local $3 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -5083,23 +5083,23 @@
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   i32.store $0
-  local.get $0
+  local.get $this
   i32.eqz
   if
    global.get $~lib/memory/__stack_pointer
    i32.const 8
    i32.const 5
    call $~lib/rt/itcms/__new
-   local.tee $0
+   local.tee $this
    i32.store $0
   end
-  local.get $0
-  local.get $1
+  local.get $this
+  local.get $x
   call $std/operator-overloading/TesterInlineInstance#set:x
-  local.get $0
-  local.get $2
+  local.get $this
+  local.get $y
   call $std/operator-overloading/TesterInlineInstance#set:y
-  local.get $0
+  local.get $this
   local.set $3
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -5107,7 +5107,7 @@
   global.set $~lib/memory/__stack_pointer
   local.get $3
  )
- (func $std/operator-overloading/TesterElementAccess#constructor (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/operator-overloading/TesterElementAccess#constructor (param $this i32) (param $x i32) (param $y i32) (result i32)
   (local $3 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -5117,23 +5117,23 @@
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   i32.store $0
-  local.get $0
+  local.get $this
   i32.eqz
   if
    global.get $~lib/memory/__stack_pointer
    i32.const 8
    i32.const 6
    call $~lib/rt/itcms/__new
-   local.tee $0
+   local.tee $this
    i32.store $0
   end
-  local.get $0
-  local.get $1
+  local.get $this
+  local.get $x
   call $std/operator-overloading/TesterElementAccess#set:x
-  local.get $0
-  local.get $2
+  local.get $this
+  local.get $y
   call $std/operator-overloading/TesterElementAccess#set:y
-  local.get $0
+  local.get $this
   local.set $3
   global.get $~lib/memory/__stack_pointer
   i32.const 4

--- a/tests/compiler/std/set.debug.wat
+++ b/tests/compiler/std/set.debug.wat
@@ -12271,8 +12271,8 @@
    unreachable
   end
  )
- (func $~lib/arraybuffer/ArrayBuffer#constructor (param $0 i32) (param $1 i32) (result i32)
-  (local $2 i32)
+ (func $~lib/arraybuffer/ArrayBuffer#constructor (param $this i32) (param $length i32) (result i32)
+  (local $buffer i32)
   (local $3 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -12282,7 +12282,7 @@
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   i32.store $0
-  local.get $1
+  local.get $length
   i32.const 1073741820
   i32.gt_u
   if
@@ -12294,16 +12294,16 @@
    unreachable
   end
   global.get $~lib/memory/__stack_pointer
-  local.get $1
+  local.get $length
   i32.const 0
   call $~lib/rt/itcms/__new
-  local.tee $2
+  local.tee $buffer
   i32.store $0
   i32.const 2
   global.get $~lib/shared/runtime/Runtime.Incremental
   i32.ne
   drop
-  local.get $2
+  local.get $buffer
   local.set $3
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -12311,7 +12311,7 @@
   global.set $~lib/memory/__stack_pointer
   local.get $3
  )
- (func $~lib/set/Set<i8>#constructor (param $0 i32) (result i32)
+ (func $~lib/set/Set<i8>#constructor (param $this i32) (result i32)
   (local $1 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -12321,45 +12321,45 @@
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   i32.store $0
-  local.get $0
+  local.get $this
   i32.eqz
   if
    global.get $~lib/memory/__stack_pointer
    i32.const 24
    i32.const 3
    call $~lib/rt/itcms/__new
-   local.tee $0
+   local.tee $this
    i32.store $0
   end
-  local.get $0
+  local.get $this
   i32.const 0
   i32.const 4
   i32.const 4
   i32.mul
   call $~lib/arraybuffer/ArrayBuffer#constructor
   call $~lib/set/Set<i8>#set:buckets
-  local.get $0
+  local.get $this
   i32.const 4
   i32.const 1
   i32.sub
   call $~lib/set/Set<i8>#set:bucketsMask
-  local.get $0
+  local.get $this
   i32.const 0
   i32.const 4
   i32.const 8
   i32.mul
   call $~lib/arraybuffer/ArrayBuffer#constructor
   call $~lib/set/Set<i8>#set:entries
-  local.get $0
+  local.get $this
   i32.const 4
   call $~lib/set/Set<i8>#set:entriesCapacity
-  local.get $0
+  local.get $this
   i32.const 0
   call $~lib/set/Set<i8>#set:entriesOffset
-  local.get $0
+  local.get $this
   i32.const 0
   call $~lib/set/Set<i8>#set:entriesCount
-  local.get $0
+  local.get $this
   local.set $1
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -12367,11 +12367,11 @@
   global.set $~lib/memory/__stack_pointer
   local.get $1
  )
- (func $~lib/array/Array<i8>#constructor (param $0 i32) (param $1 i32) (result i32)
-  (local $2 i32)
-  (local $3 i32)
-  (local $4 i32)
-  (local $5 i32)
+ (func $~lib/array/Array<i8>#constructor (param $this i32) (param $length i32) (result i32)
+  (local $var$2 i32)
+  (local $var$3 i32)
+  (local $bufferSize i32)
+  (local $buffer i32)
   (local $6 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 8
@@ -12381,29 +12381,29 @@
   global.get $~lib/memory/__stack_pointer
   i64.const 0
   i64.store $0
-  local.get $0
+  local.get $this
   i32.eqz
   if
    global.get $~lib/memory/__stack_pointer
    i32.const 16
    i32.const 4
    call $~lib/rt/itcms/__new
-   local.tee $0
+   local.tee $this
    i32.store $0
   end
-  local.get $0
+  local.get $this
   i32.const 0
   call $~lib/array/Array<i8>#set:buffer
-  local.get $0
+  local.get $this
   i32.const 0
   call $~lib/array/Array<i8>#set:dataStart
-  local.get $0
+  local.get $this
   i32.const 0
   call $~lib/array/Array<i8>#set:byteLength
-  local.get $0
+  local.get $this
   i32.const 0
   call $~lib/array/Array<i8>#set:length_
-  local.get $1
+  local.get $length
   i32.const 1073741820
   i32.const 0
   i32.shr_u
@@ -12416,40 +12416,40 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $1
-  local.tee $2
+  local.get $length
+  local.tee $var$2
   i32.const 8
-  local.tee $3
-  local.get $2
-  local.get $3
+  local.tee $var$3
+  local.get $var$2
+  local.get $var$3
   i32.gt_u
   select
   i32.const 0
   i32.shl
-  local.set $4
+  local.set $bufferSize
   global.get $~lib/memory/__stack_pointer
-  local.get $4
+  local.get $bufferSize
   i32.const 0
   call $~lib/rt/itcms/__new
-  local.tee $5
+  local.tee $buffer
   i32.store $0 offset=4
   i32.const 2
   global.get $~lib/shared/runtime/Runtime.Incremental
   i32.ne
   drop
-  local.get $0
-  local.get $5
+  local.get $this
+  local.get $buffer
   call $~lib/array/Array<i8>#set:buffer
-  local.get $0
-  local.get $5
+  local.get $this
+  local.get $buffer
   call $~lib/array/Array<i8>#set:dataStart
-  local.get $0
-  local.get $4
+  local.get $this
+  local.get $bufferSize
   call $~lib/array/Array<i8>#set:byteLength
-  local.get $0
-  local.get $1
+  local.get $this
+  local.get $length
   call $~lib/array/Array<i8>#set:length_
-  local.get $0
+  local.get $this
   local.set $6
   global.get $~lib/memory/__stack_pointer
   i32.const 8
@@ -12457,15 +12457,15 @@
   global.set $~lib/memory/__stack_pointer
   local.get $6
  )
- (func $~lib/set/Set<i8>#values (param $0 i32) (result i32)
-  (local $1 i32)
-  (local $2 i32)
-  (local $3 i32)
-  (local $4 i32)
-  (local $5 i32)
-  (local $6 i32)
-  (local $7 i32)
-  (local $8 i32)
+ (func $~lib/set/Set<i8>#values (param $this i32) (result i32)
+  (local $start i32)
+  (local $size i32)
+  (local $values i32)
+  (local $length i32)
+  (local $var$5 i32)
+  (local $var$6 i32)
+  (local $var$7 i32)
+  (local $var$8 i32)
   (local $9 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -12475,63 +12475,63 @@
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   i32.store $0
-  local.get $0
+  local.get $this
   i32.load $0 offset=8
-  local.set $1
-  local.get $0
+  local.set $start
+  local.get $this
   i32.load $0 offset=16
-  local.set $2
+  local.set $size
   global.get $~lib/memory/__stack_pointer
   i32.const 0
-  local.get $2
+  local.get $size
   call $~lib/array/Array<i8>#constructor
-  local.tee $3
+  local.tee $values
   i32.store $0
   i32.const 0
-  local.set $4
+  local.set $length
   i32.const 0
-  local.set $5
+  local.set $var$5
   loop $for-loop|0
-   local.get $5
-   local.get $2
+   local.get $var$5
+   local.get $size
    i32.lt_s
-   local.set $6
-   local.get $6
+   local.set $var$6
+   local.get $var$6
    if
-    local.get $1
-    local.get $5
+    local.get $start
+    local.get $var$5
     i32.const 8
     i32.mul
     i32.add
-    local.set $7
-    local.get $7
+    local.set $var$7
+    local.get $var$7
     i32.load $0 offset=4
     i32.const 1
     i32.and
     i32.eqz
     if
-     local.get $3
-     local.get $4
-     local.tee $8
+     local.get $values
+     local.get $length
+     local.tee $var$8
      i32.const 1
      i32.add
-     local.set $4
-     local.get $8
-     local.get $7
+     local.set $length
+     local.get $var$8
+     local.get $var$7
      i32.load8_s $0
      call $~lib/array/Array<i8>#__uset
     end
-    local.get $5
+    local.get $var$5
     i32.const 1
     i32.add
-    local.set $5
+    local.set $var$5
     br $for-loop|0
    end
   end
-  local.get $3
-  local.get $4
+  local.get $values
+  local.get $length
   call $~lib/array/Array<i8>#set:length
-  local.get $3
+  local.get $values
   local.set $9
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -12539,7 +12539,7 @@
   global.set $~lib/memory/__stack_pointer
   local.get $9
  )
- (func $~lib/set/Set<u8>#constructor (param $0 i32) (result i32)
+ (func $~lib/set/Set<u8>#constructor (param $this i32) (result i32)
   (local $1 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -12549,45 +12549,45 @@
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   i32.store $0
-  local.get $0
+  local.get $this
   i32.eqz
   if
    global.get $~lib/memory/__stack_pointer
    i32.const 24
    i32.const 5
    call $~lib/rt/itcms/__new
-   local.tee $0
+   local.tee $this
    i32.store $0
   end
-  local.get $0
+  local.get $this
   i32.const 0
   i32.const 4
   i32.const 4
   i32.mul
   call $~lib/arraybuffer/ArrayBuffer#constructor
   call $~lib/set/Set<u8>#set:buckets
-  local.get $0
+  local.get $this
   i32.const 4
   i32.const 1
   i32.sub
   call $~lib/set/Set<u8>#set:bucketsMask
-  local.get $0
+  local.get $this
   i32.const 0
   i32.const 4
   i32.const 8
   i32.mul
   call $~lib/arraybuffer/ArrayBuffer#constructor
   call $~lib/set/Set<u8>#set:entries
-  local.get $0
+  local.get $this
   i32.const 4
   call $~lib/set/Set<u8>#set:entriesCapacity
-  local.get $0
+  local.get $this
   i32.const 0
   call $~lib/set/Set<u8>#set:entriesOffset
-  local.get $0
+  local.get $this
   i32.const 0
   call $~lib/set/Set<u8>#set:entriesCount
-  local.get $0
+  local.get $this
   local.set $1
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -12595,11 +12595,11 @@
   global.set $~lib/memory/__stack_pointer
   local.get $1
  )
- (func $~lib/array/Array<u8>#constructor (param $0 i32) (param $1 i32) (result i32)
-  (local $2 i32)
-  (local $3 i32)
-  (local $4 i32)
-  (local $5 i32)
+ (func $~lib/array/Array<u8>#constructor (param $this i32) (param $length i32) (result i32)
+  (local $var$2 i32)
+  (local $var$3 i32)
+  (local $bufferSize i32)
+  (local $buffer i32)
   (local $6 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 8
@@ -12609,29 +12609,29 @@
   global.get $~lib/memory/__stack_pointer
   i64.const 0
   i64.store $0
-  local.get $0
+  local.get $this
   i32.eqz
   if
    global.get $~lib/memory/__stack_pointer
    i32.const 16
    i32.const 6
    call $~lib/rt/itcms/__new
-   local.tee $0
+   local.tee $this
    i32.store $0
   end
-  local.get $0
+  local.get $this
   i32.const 0
   call $~lib/array/Array<u8>#set:buffer
-  local.get $0
+  local.get $this
   i32.const 0
   call $~lib/array/Array<u8>#set:dataStart
-  local.get $0
+  local.get $this
   i32.const 0
   call $~lib/array/Array<u8>#set:byteLength
-  local.get $0
+  local.get $this
   i32.const 0
   call $~lib/array/Array<u8>#set:length_
-  local.get $1
+  local.get $length
   i32.const 1073741820
   i32.const 0
   i32.shr_u
@@ -12644,40 +12644,40 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $1
-  local.tee $2
+  local.get $length
+  local.tee $var$2
   i32.const 8
-  local.tee $3
-  local.get $2
-  local.get $3
+  local.tee $var$3
+  local.get $var$2
+  local.get $var$3
   i32.gt_u
   select
   i32.const 0
   i32.shl
-  local.set $4
+  local.set $bufferSize
   global.get $~lib/memory/__stack_pointer
-  local.get $4
+  local.get $bufferSize
   i32.const 0
   call $~lib/rt/itcms/__new
-  local.tee $5
+  local.tee $buffer
   i32.store $0 offset=4
   i32.const 2
   global.get $~lib/shared/runtime/Runtime.Incremental
   i32.ne
   drop
-  local.get $0
-  local.get $5
+  local.get $this
+  local.get $buffer
   call $~lib/array/Array<u8>#set:buffer
-  local.get $0
-  local.get $5
+  local.get $this
+  local.get $buffer
   call $~lib/array/Array<u8>#set:dataStart
-  local.get $0
-  local.get $4
+  local.get $this
+  local.get $bufferSize
   call $~lib/array/Array<u8>#set:byteLength
-  local.get $0
-  local.get $1
+  local.get $this
+  local.get $length
   call $~lib/array/Array<u8>#set:length_
-  local.get $0
+  local.get $this
   local.set $6
   global.get $~lib/memory/__stack_pointer
   i32.const 8
@@ -12685,15 +12685,15 @@
   global.set $~lib/memory/__stack_pointer
   local.get $6
  )
- (func $~lib/set/Set<u8>#values (param $0 i32) (result i32)
-  (local $1 i32)
-  (local $2 i32)
-  (local $3 i32)
-  (local $4 i32)
-  (local $5 i32)
-  (local $6 i32)
-  (local $7 i32)
-  (local $8 i32)
+ (func $~lib/set/Set<u8>#values (param $this i32) (result i32)
+  (local $start i32)
+  (local $size i32)
+  (local $values i32)
+  (local $length i32)
+  (local $var$5 i32)
+  (local $var$6 i32)
+  (local $var$7 i32)
+  (local $var$8 i32)
   (local $9 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -12703,63 +12703,63 @@
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   i32.store $0
-  local.get $0
+  local.get $this
   i32.load $0 offset=8
-  local.set $1
-  local.get $0
+  local.set $start
+  local.get $this
   i32.load $0 offset=16
-  local.set $2
+  local.set $size
   global.get $~lib/memory/__stack_pointer
   i32.const 0
-  local.get $2
+  local.get $size
   call $~lib/array/Array<u8>#constructor
-  local.tee $3
+  local.tee $values
   i32.store $0
   i32.const 0
-  local.set $4
+  local.set $length
   i32.const 0
-  local.set $5
+  local.set $var$5
   loop $for-loop|0
-   local.get $5
-   local.get $2
+   local.get $var$5
+   local.get $size
    i32.lt_s
-   local.set $6
-   local.get $6
+   local.set $var$6
+   local.get $var$6
    if
-    local.get $1
-    local.get $5
+    local.get $start
+    local.get $var$5
     i32.const 8
     i32.mul
     i32.add
-    local.set $7
-    local.get $7
+    local.set $var$7
+    local.get $var$7
     i32.load $0 offset=4
     i32.const 1
     i32.and
     i32.eqz
     if
-     local.get $3
-     local.get $4
-     local.tee $8
+     local.get $values
+     local.get $length
+     local.tee $var$8
      i32.const 1
      i32.add
-     local.set $4
-     local.get $8
-     local.get $7
+     local.set $length
+     local.get $var$8
+     local.get $var$7
      i32.load8_u $0
      call $~lib/array/Array<u8>#__uset
     end
-    local.get $5
+    local.get $var$5
     i32.const 1
     i32.add
-    local.set $5
+    local.set $var$5
     br $for-loop|0
    end
   end
-  local.get $3
-  local.get $4
+  local.get $values
+  local.get $length
   call $~lib/array/Array<u8>#set:length
-  local.get $3
+  local.get $values
   local.set $9
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -12767,7 +12767,7 @@
   global.set $~lib/memory/__stack_pointer
   local.get $9
  )
- (func $~lib/set/Set<i16>#constructor (param $0 i32) (result i32)
+ (func $~lib/set/Set<i16>#constructor (param $this i32) (result i32)
   (local $1 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -12777,45 +12777,45 @@
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   i32.store $0
-  local.get $0
+  local.get $this
   i32.eqz
   if
    global.get $~lib/memory/__stack_pointer
    i32.const 24
    i32.const 7
    call $~lib/rt/itcms/__new
-   local.tee $0
+   local.tee $this
    i32.store $0
   end
-  local.get $0
+  local.get $this
   i32.const 0
   i32.const 4
   i32.const 4
   i32.mul
   call $~lib/arraybuffer/ArrayBuffer#constructor
   call $~lib/set/Set<i16>#set:buckets
-  local.get $0
+  local.get $this
   i32.const 4
   i32.const 1
   i32.sub
   call $~lib/set/Set<i16>#set:bucketsMask
-  local.get $0
+  local.get $this
   i32.const 0
   i32.const 4
   i32.const 8
   i32.mul
   call $~lib/arraybuffer/ArrayBuffer#constructor
   call $~lib/set/Set<i16>#set:entries
-  local.get $0
+  local.get $this
   i32.const 4
   call $~lib/set/Set<i16>#set:entriesCapacity
-  local.get $0
+  local.get $this
   i32.const 0
   call $~lib/set/Set<i16>#set:entriesOffset
-  local.get $0
+  local.get $this
   i32.const 0
   call $~lib/set/Set<i16>#set:entriesCount
-  local.get $0
+  local.get $this
   local.set $1
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -12823,11 +12823,11 @@
   global.set $~lib/memory/__stack_pointer
   local.get $1
  )
- (func $~lib/array/Array<i16>#constructor (param $0 i32) (param $1 i32) (result i32)
-  (local $2 i32)
-  (local $3 i32)
-  (local $4 i32)
-  (local $5 i32)
+ (func $~lib/array/Array<i16>#constructor (param $this i32) (param $length i32) (result i32)
+  (local $var$2 i32)
+  (local $var$3 i32)
+  (local $bufferSize i32)
+  (local $buffer i32)
   (local $6 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 8
@@ -12837,29 +12837,29 @@
   global.get $~lib/memory/__stack_pointer
   i64.const 0
   i64.store $0
-  local.get $0
+  local.get $this
   i32.eqz
   if
    global.get $~lib/memory/__stack_pointer
    i32.const 16
    i32.const 8
    call $~lib/rt/itcms/__new
-   local.tee $0
+   local.tee $this
    i32.store $0
   end
-  local.get $0
+  local.get $this
   i32.const 0
   call $~lib/array/Array<i16>#set:buffer
-  local.get $0
+  local.get $this
   i32.const 0
   call $~lib/array/Array<i16>#set:dataStart
-  local.get $0
+  local.get $this
   i32.const 0
   call $~lib/array/Array<i16>#set:byteLength
-  local.get $0
+  local.get $this
   i32.const 0
   call $~lib/array/Array<i16>#set:length_
-  local.get $1
+  local.get $length
   i32.const 1073741820
   i32.const 1
   i32.shr_u
@@ -12872,40 +12872,40 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $1
-  local.tee $2
+  local.get $length
+  local.tee $var$2
   i32.const 8
-  local.tee $3
-  local.get $2
-  local.get $3
+  local.tee $var$3
+  local.get $var$2
+  local.get $var$3
   i32.gt_u
   select
   i32.const 1
   i32.shl
-  local.set $4
+  local.set $bufferSize
   global.get $~lib/memory/__stack_pointer
-  local.get $4
+  local.get $bufferSize
   i32.const 0
   call $~lib/rt/itcms/__new
-  local.tee $5
+  local.tee $buffer
   i32.store $0 offset=4
   i32.const 2
   global.get $~lib/shared/runtime/Runtime.Incremental
   i32.ne
   drop
-  local.get $0
-  local.get $5
+  local.get $this
+  local.get $buffer
   call $~lib/array/Array<i16>#set:buffer
-  local.get $0
-  local.get $5
+  local.get $this
+  local.get $buffer
   call $~lib/array/Array<i16>#set:dataStart
-  local.get $0
-  local.get $4
+  local.get $this
+  local.get $bufferSize
   call $~lib/array/Array<i16>#set:byteLength
-  local.get $0
-  local.get $1
+  local.get $this
+  local.get $length
   call $~lib/array/Array<i16>#set:length_
-  local.get $0
+  local.get $this
   local.set $6
   global.get $~lib/memory/__stack_pointer
   i32.const 8
@@ -12913,15 +12913,15 @@
   global.set $~lib/memory/__stack_pointer
   local.get $6
  )
- (func $~lib/set/Set<i16>#values (param $0 i32) (result i32)
-  (local $1 i32)
-  (local $2 i32)
-  (local $3 i32)
-  (local $4 i32)
-  (local $5 i32)
-  (local $6 i32)
-  (local $7 i32)
-  (local $8 i32)
+ (func $~lib/set/Set<i16>#values (param $this i32) (result i32)
+  (local $start i32)
+  (local $size i32)
+  (local $values i32)
+  (local $length i32)
+  (local $var$5 i32)
+  (local $var$6 i32)
+  (local $var$7 i32)
+  (local $var$8 i32)
   (local $9 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -12931,63 +12931,63 @@
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   i32.store $0
-  local.get $0
+  local.get $this
   i32.load $0 offset=8
-  local.set $1
-  local.get $0
+  local.set $start
+  local.get $this
   i32.load $0 offset=16
-  local.set $2
+  local.set $size
   global.get $~lib/memory/__stack_pointer
   i32.const 0
-  local.get $2
+  local.get $size
   call $~lib/array/Array<i16>#constructor
-  local.tee $3
+  local.tee $values
   i32.store $0
   i32.const 0
-  local.set $4
+  local.set $length
   i32.const 0
-  local.set $5
+  local.set $var$5
   loop $for-loop|0
-   local.get $5
-   local.get $2
+   local.get $var$5
+   local.get $size
    i32.lt_s
-   local.set $6
-   local.get $6
+   local.set $var$6
+   local.get $var$6
    if
-    local.get $1
-    local.get $5
+    local.get $start
+    local.get $var$5
     i32.const 8
     i32.mul
     i32.add
-    local.set $7
-    local.get $7
+    local.set $var$7
+    local.get $var$7
     i32.load $0 offset=4
     i32.const 1
     i32.and
     i32.eqz
     if
-     local.get $3
-     local.get $4
-     local.tee $8
+     local.get $values
+     local.get $length
+     local.tee $var$8
      i32.const 1
      i32.add
-     local.set $4
-     local.get $8
-     local.get $7
+     local.set $length
+     local.get $var$8
+     local.get $var$7
      i32.load16_s $0
      call $~lib/array/Array<i16>#__uset
     end
-    local.get $5
+    local.get $var$5
     i32.const 1
     i32.add
-    local.set $5
+    local.set $var$5
     br $for-loop|0
    end
   end
-  local.get $3
-  local.get $4
+  local.get $values
+  local.get $length
   call $~lib/array/Array<i16>#set:length
-  local.get $3
+  local.get $values
   local.set $9
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -12995,7 +12995,7 @@
   global.set $~lib/memory/__stack_pointer
   local.get $9
  )
- (func $~lib/set/Set<u16>#constructor (param $0 i32) (result i32)
+ (func $~lib/set/Set<u16>#constructor (param $this i32) (result i32)
   (local $1 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -13005,45 +13005,45 @@
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   i32.store $0
-  local.get $0
+  local.get $this
   i32.eqz
   if
    global.get $~lib/memory/__stack_pointer
    i32.const 24
    i32.const 9
    call $~lib/rt/itcms/__new
-   local.tee $0
+   local.tee $this
    i32.store $0
   end
-  local.get $0
+  local.get $this
   i32.const 0
   i32.const 4
   i32.const 4
   i32.mul
   call $~lib/arraybuffer/ArrayBuffer#constructor
   call $~lib/set/Set<u16>#set:buckets
-  local.get $0
+  local.get $this
   i32.const 4
   i32.const 1
   i32.sub
   call $~lib/set/Set<u16>#set:bucketsMask
-  local.get $0
+  local.get $this
   i32.const 0
   i32.const 4
   i32.const 8
   i32.mul
   call $~lib/arraybuffer/ArrayBuffer#constructor
   call $~lib/set/Set<u16>#set:entries
-  local.get $0
+  local.get $this
   i32.const 4
   call $~lib/set/Set<u16>#set:entriesCapacity
-  local.get $0
+  local.get $this
   i32.const 0
   call $~lib/set/Set<u16>#set:entriesOffset
-  local.get $0
+  local.get $this
   i32.const 0
   call $~lib/set/Set<u16>#set:entriesCount
-  local.get $0
+  local.get $this
   local.set $1
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -13051,11 +13051,11 @@
   global.set $~lib/memory/__stack_pointer
   local.get $1
  )
- (func $~lib/array/Array<u16>#constructor (param $0 i32) (param $1 i32) (result i32)
-  (local $2 i32)
-  (local $3 i32)
-  (local $4 i32)
-  (local $5 i32)
+ (func $~lib/array/Array<u16>#constructor (param $this i32) (param $length i32) (result i32)
+  (local $var$2 i32)
+  (local $var$3 i32)
+  (local $bufferSize i32)
+  (local $buffer i32)
   (local $6 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 8
@@ -13065,29 +13065,29 @@
   global.get $~lib/memory/__stack_pointer
   i64.const 0
   i64.store $0
-  local.get $0
+  local.get $this
   i32.eqz
   if
    global.get $~lib/memory/__stack_pointer
    i32.const 16
    i32.const 10
    call $~lib/rt/itcms/__new
-   local.tee $0
+   local.tee $this
    i32.store $0
   end
-  local.get $0
+  local.get $this
   i32.const 0
   call $~lib/array/Array<u16>#set:buffer
-  local.get $0
+  local.get $this
   i32.const 0
   call $~lib/array/Array<u16>#set:dataStart
-  local.get $0
+  local.get $this
   i32.const 0
   call $~lib/array/Array<u16>#set:byteLength
-  local.get $0
+  local.get $this
   i32.const 0
   call $~lib/array/Array<u16>#set:length_
-  local.get $1
+  local.get $length
   i32.const 1073741820
   i32.const 1
   i32.shr_u
@@ -13100,40 +13100,40 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $1
-  local.tee $2
+  local.get $length
+  local.tee $var$2
   i32.const 8
-  local.tee $3
-  local.get $2
-  local.get $3
+  local.tee $var$3
+  local.get $var$2
+  local.get $var$3
   i32.gt_u
   select
   i32.const 1
   i32.shl
-  local.set $4
+  local.set $bufferSize
   global.get $~lib/memory/__stack_pointer
-  local.get $4
+  local.get $bufferSize
   i32.const 0
   call $~lib/rt/itcms/__new
-  local.tee $5
+  local.tee $buffer
   i32.store $0 offset=4
   i32.const 2
   global.get $~lib/shared/runtime/Runtime.Incremental
   i32.ne
   drop
-  local.get $0
-  local.get $5
+  local.get $this
+  local.get $buffer
   call $~lib/array/Array<u16>#set:buffer
-  local.get $0
-  local.get $5
+  local.get $this
+  local.get $buffer
   call $~lib/array/Array<u16>#set:dataStart
-  local.get $0
-  local.get $4
+  local.get $this
+  local.get $bufferSize
   call $~lib/array/Array<u16>#set:byteLength
-  local.get $0
-  local.get $1
+  local.get $this
+  local.get $length
   call $~lib/array/Array<u16>#set:length_
-  local.get $0
+  local.get $this
   local.set $6
   global.get $~lib/memory/__stack_pointer
   i32.const 8
@@ -13141,15 +13141,15 @@
   global.set $~lib/memory/__stack_pointer
   local.get $6
  )
- (func $~lib/set/Set<u16>#values (param $0 i32) (result i32)
-  (local $1 i32)
-  (local $2 i32)
-  (local $3 i32)
-  (local $4 i32)
-  (local $5 i32)
-  (local $6 i32)
-  (local $7 i32)
-  (local $8 i32)
+ (func $~lib/set/Set<u16>#values (param $this i32) (result i32)
+  (local $start i32)
+  (local $size i32)
+  (local $values i32)
+  (local $length i32)
+  (local $var$5 i32)
+  (local $var$6 i32)
+  (local $var$7 i32)
+  (local $var$8 i32)
   (local $9 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -13159,63 +13159,63 @@
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   i32.store $0
-  local.get $0
+  local.get $this
   i32.load $0 offset=8
-  local.set $1
-  local.get $0
+  local.set $start
+  local.get $this
   i32.load $0 offset=16
-  local.set $2
+  local.set $size
   global.get $~lib/memory/__stack_pointer
   i32.const 0
-  local.get $2
+  local.get $size
   call $~lib/array/Array<u16>#constructor
-  local.tee $3
+  local.tee $values
   i32.store $0
   i32.const 0
-  local.set $4
+  local.set $length
   i32.const 0
-  local.set $5
+  local.set $var$5
   loop $for-loop|0
-   local.get $5
-   local.get $2
+   local.get $var$5
+   local.get $size
    i32.lt_s
-   local.set $6
-   local.get $6
+   local.set $var$6
+   local.get $var$6
    if
-    local.get $1
-    local.get $5
+    local.get $start
+    local.get $var$5
     i32.const 8
     i32.mul
     i32.add
-    local.set $7
-    local.get $7
+    local.set $var$7
+    local.get $var$7
     i32.load $0 offset=4
     i32.const 1
     i32.and
     i32.eqz
     if
-     local.get $3
-     local.get $4
-     local.tee $8
+     local.get $values
+     local.get $length
+     local.tee $var$8
      i32.const 1
      i32.add
-     local.set $4
-     local.get $8
-     local.get $7
+     local.set $length
+     local.get $var$8
+     local.get $var$7
      i32.load16_u $0
      call $~lib/array/Array<u16>#__uset
     end
-    local.get $5
+    local.get $var$5
     i32.const 1
     i32.add
-    local.set $5
+    local.set $var$5
     br $for-loop|0
    end
   end
-  local.get $3
-  local.get $4
+  local.get $values
+  local.get $length
   call $~lib/array/Array<u16>#set:length
-  local.get $3
+  local.get $values
   local.set $9
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -13223,7 +13223,7 @@
   global.set $~lib/memory/__stack_pointer
   local.get $9
  )
- (func $~lib/set/Set<i32>#constructor (param $0 i32) (result i32)
+ (func $~lib/set/Set<i32>#constructor (param $this i32) (result i32)
   (local $1 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -13233,45 +13233,45 @@
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   i32.store $0
-  local.get $0
+  local.get $this
   i32.eqz
   if
    global.get $~lib/memory/__stack_pointer
    i32.const 24
    i32.const 11
    call $~lib/rt/itcms/__new
-   local.tee $0
+   local.tee $this
    i32.store $0
   end
-  local.get $0
+  local.get $this
   i32.const 0
   i32.const 4
   i32.const 4
   i32.mul
   call $~lib/arraybuffer/ArrayBuffer#constructor
   call $~lib/set/Set<i32>#set:buckets
-  local.get $0
+  local.get $this
   i32.const 4
   i32.const 1
   i32.sub
   call $~lib/set/Set<i32>#set:bucketsMask
-  local.get $0
+  local.get $this
   i32.const 0
   i32.const 4
   i32.const 8
   i32.mul
   call $~lib/arraybuffer/ArrayBuffer#constructor
   call $~lib/set/Set<i32>#set:entries
-  local.get $0
+  local.get $this
   i32.const 4
   call $~lib/set/Set<i32>#set:entriesCapacity
-  local.get $0
+  local.get $this
   i32.const 0
   call $~lib/set/Set<i32>#set:entriesOffset
-  local.get $0
+  local.get $this
   i32.const 0
   call $~lib/set/Set<i32>#set:entriesCount
-  local.get $0
+  local.get $this
   local.set $1
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -13279,11 +13279,11 @@
   global.set $~lib/memory/__stack_pointer
   local.get $1
  )
- (func $~lib/array/Array<i32>#constructor (param $0 i32) (param $1 i32) (result i32)
-  (local $2 i32)
-  (local $3 i32)
-  (local $4 i32)
-  (local $5 i32)
+ (func $~lib/array/Array<i32>#constructor (param $this i32) (param $length i32) (result i32)
+  (local $var$2 i32)
+  (local $var$3 i32)
+  (local $bufferSize i32)
+  (local $buffer i32)
   (local $6 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 8
@@ -13293,29 +13293,29 @@
   global.get $~lib/memory/__stack_pointer
   i64.const 0
   i64.store $0
-  local.get $0
+  local.get $this
   i32.eqz
   if
    global.get $~lib/memory/__stack_pointer
    i32.const 16
    i32.const 12
    call $~lib/rt/itcms/__new
-   local.tee $0
+   local.tee $this
    i32.store $0
   end
-  local.get $0
+  local.get $this
   i32.const 0
   call $~lib/array/Array<i32>#set:buffer
-  local.get $0
+  local.get $this
   i32.const 0
   call $~lib/array/Array<i32>#set:dataStart
-  local.get $0
+  local.get $this
   i32.const 0
   call $~lib/array/Array<i32>#set:byteLength
-  local.get $0
+  local.get $this
   i32.const 0
   call $~lib/array/Array<i32>#set:length_
-  local.get $1
+  local.get $length
   i32.const 1073741820
   i32.const 2
   i32.shr_u
@@ -13328,40 +13328,40 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $1
-  local.tee $2
+  local.get $length
+  local.tee $var$2
   i32.const 8
-  local.tee $3
-  local.get $2
-  local.get $3
+  local.tee $var$3
+  local.get $var$2
+  local.get $var$3
   i32.gt_u
   select
   i32.const 2
   i32.shl
-  local.set $4
+  local.set $bufferSize
   global.get $~lib/memory/__stack_pointer
-  local.get $4
+  local.get $bufferSize
   i32.const 0
   call $~lib/rt/itcms/__new
-  local.tee $5
+  local.tee $buffer
   i32.store $0 offset=4
   i32.const 2
   global.get $~lib/shared/runtime/Runtime.Incremental
   i32.ne
   drop
-  local.get $0
-  local.get $5
+  local.get $this
+  local.get $buffer
   call $~lib/array/Array<i32>#set:buffer
-  local.get $0
-  local.get $5
+  local.get $this
+  local.get $buffer
   call $~lib/array/Array<i32>#set:dataStart
-  local.get $0
-  local.get $4
+  local.get $this
+  local.get $bufferSize
   call $~lib/array/Array<i32>#set:byteLength
-  local.get $0
-  local.get $1
+  local.get $this
+  local.get $length
   call $~lib/array/Array<i32>#set:length_
-  local.get $0
+  local.get $this
   local.set $6
   global.get $~lib/memory/__stack_pointer
   i32.const 8
@@ -13369,15 +13369,15 @@
   global.set $~lib/memory/__stack_pointer
   local.get $6
  )
- (func $~lib/set/Set<i32>#values (param $0 i32) (result i32)
-  (local $1 i32)
-  (local $2 i32)
-  (local $3 i32)
-  (local $4 i32)
-  (local $5 i32)
-  (local $6 i32)
-  (local $7 i32)
-  (local $8 i32)
+ (func $~lib/set/Set<i32>#values (param $this i32) (result i32)
+  (local $start i32)
+  (local $size i32)
+  (local $values i32)
+  (local $length i32)
+  (local $var$5 i32)
+  (local $var$6 i32)
+  (local $var$7 i32)
+  (local $var$8 i32)
   (local $9 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -13387,63 +13387,63 @@
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   i32.store $0
-  local.get $0
+  local.get $this
   i32.load $0 offset=8
-  local.set $1
-  local.get $0
+  local.set $start
+  local.get $this
   i32.load $0 offset=16
-  local.set $2
+  local.set $size
   global.get $~lib/memory/__stack_pointer
   i32.const 0
-  local.get $2
+  local.get $size
   call $~lib/array/Array<i32>#constructor
-  local.tee $3
+  local.tee $values
   i32.store $0
   i32.const 0
-  local.set $4
+  local.set $length
   i32.const 0
-  local.set $5
+  local.set $var$5
   loop $for-loop|0
-   local.get $5
-   local.get $2
+   local.get $var$5
+   local.get $size
    i32.lt_s
-   local.set $6
-   local.get $6
+   local.set $var$6
+   local.get $var$6
    if
-    local.get $1
-    local.get $5
+    local.get $start
+    local.get $var$5
     i32.const 8
     i32.mul
     i32.add
-    local.set $7
-    local.get $7
+    local.set $var$7
+    local.get $var$7
     i32.load $0 offset=4
     i32.const 1
     i32.and
     i32.eqz
     if
-     local.get $3
-     local.get $4
-     local.tee $8
+     local.get $values
+     local.get $length
+     local.tee $var$8
      i32.const 1
      i32.add
-     local.set $4
-     local.get $8
-     local.get $7
+     local.set $length
+     local.get $var$8
+     local.get $var$7
      i32.load $0
      call $~lib/array/Array<i32>#__uset
     end
-    local.get $5
+    local.get $var$5
     i32.const 1
     i32.add
-    local.set $5
+    local.set $var$5
     br $for-loop|0
    end
   end
-  local.get $3
-  local.get $4
+  local.get $values
+  local.get $length
   call $~lib/array/Array<i32>#set:length
-  local.get $3
+  local.get $values
   local.set $9
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -13451,7 +13451,7 @@
   global.set $~lib/memory/__stack_pointer
   local.get $9
  )
- (func $~lib/set/Set<u32>#constructor (param $0 i32) (result i32)
+ (func $~lib/set/Set<u32>#constructor (param $this i32) (result i32)
   (local $1 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -13461,45 +13461,45 @@
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   i32.store $0
-  local.get $0
+  local.get $this
   i32.eqz
   if
    global.get $~lib/memory/__stack_pointer
    i32.const 24
    i32.const 13
    call $~lib/rt/itcms/__new
-   local.tee $0
+   local.tee $this
    i32.store $0
   end
-  local.get $0
+  local.get $this
   i32.const 0
   i32.const 4
   i32.const 4
   i32.mul
   call $~lib/arraybuffer/ArrayBuffer#constructor
   call $~lib/set/Set<u32>#set:buckets
-  local.get $0
+  local.get $this
   i32.const 4
   i32.const 1
   i32.sub
   call $~lib/set/Set<u32>#set:bucketsMask
-  local.get $0
+  local.get $this
   i32.const 0
   i32.const 4
   i32.const 8
   i32.mul
   call $~lib/arraybuffer/ArrayBuffer#constructor
   call $~lib/set/Set<u32>#set:entries
-  local.get $0
+  local.get $this
   i32.const 4
   call $~lib/set/Set<u32>#set:entriesCapacity
-  local.get $0
+  local.get $this
   i32.const 0
   call $~lib/set/Set<u32>#set:entriesOffset
-  local.get $0
+  local.get $this
   i32.const 0
   call $~lib/set/Set<u32>#set:entriesCount
-  local.get $0
+  local.get $this
   local.set $1
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -13507,11 +13507,11 @@
   global.set $~lib/memory/__stack_pointer
   local.get $1
  )
- (func $~lib/array/Array<u32>#constructor (param $0 i32) (param $1 i32) (result i32)
-  (local $2 i32)
-  (local $3 i32)
-  (local $4 i32)
-  (local $5 i32)
+ (func $~lib/array/Array<u32>#constructor (param $this i32) (param $length i32) (result i32)
+  (local $var$2 i32)
+  (local $var$3 i32)
+  (local $bufferSize i32)
+  (local $buffer i32)
   (local $6 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 8
@@ -13521,29 +13521,29 @@
   global.get $~lib/memory/__stack_pointer
   i64.const 0
   i64.store $0
-  local.get $0
+  local.get $this
   i32.eqz
   if
    global.get $~lib/memory/__stack_pointer
    i32.const 16
    i32.const 14
    call $~lib/rt/itcms/__new
-   local.tee $0
+   local.tee $this
    i32.store $0
   end
-  local.get $0
+  local.get $this
   i32.const 0
   call $~lib/array/Array<u32>#set:buffer
-  local.get $0
+  local.get $this
   i32.const 0
   call $~lib/array/Array<u32>#set:dataStart
-  local.get $0
+  local.get $this
   i32.const 0
   call $~lib/array/Array<u32>#set:byteLength
-  local.get $0
+  local.get $this
   i32.const 0
   call $~lib/array/Array<u32>#set:length_
-  local.get $1
+  local.get $length
   i32.const 1073741820
   i32.const 2
   i32.shr_u
@@ -13556,40 +13556,40 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $1
-  local.tee $2
+  local.get $length
+  local.tee $var$2
   i32.const 8
-  local.tee $3
-  local.get $2
-  local.get $3
+  local.tee $var$3
+  local.get $var$2
+  local.get $var$3
   i32.gt_u
   select
   i32.const 2
   i32.shl
-  local.set $4
+  local.set $bufferSize
   global.get $~lib/memory/__stack_pointer
-  local.get $4
+  local.get $bufferSize
   i32.const 0
   call $~lib/rt/itcms/__new
-  local.tee $5
+  local.tee $buffer
   i32.store $0 offset=4
   i32.const 2
   global.get $~lib/shared/runtime/Runtime.Incremental
   i32.ne
   drop
-  local.get $0
-  local.get $5
+  local.get $this
+  local.get $buffer
   call $~lib/array/Array<u32>#set:buffer
-  local.get $0
-  local.get $5
+  local.get $this
+  local.get $buffer
   call $~lib/array/Array<u32>#set:dataStart
-  local.get $0
-  local.get $4
+  local.get $this
+  local.get $bufferSize
   call $~lib/array/Array<u32>#set:byteLength
-  local.get $0
-  local.get $1
+  local.get $this
+  local.get $length
   call $~lib/array/Array<u32>#set:length_
-  local.get $0
+  local.get $this
   local.set $6
   global.get $~lib/memory/__stack_pointer
   i32.const 8
@@ -13597,15 +13597,15 @@
   global.set $~lib/memory/__stack_pointer
   local.get $6
  )
- (func $~lib/set/Set<u32>#values (param $0 i32) (result i32)
-  (local $1 i32)
-  (local $2 i32)
-  (local $3 i32)
-  (local $4 i32)
-  (local $5 i32)
-  (local $6 i32)
-  (local $7 i32)
-  (local $8 i32)
+ (func $~lib/set/Set<u32>#values (param $this i32) (result i32)
+  (local $start i32)
+  (local $size i32)
+  (local $values i32)
+  (local $length i32)
+  (local $var$5 i32)
+  (local $var$6 i32)
+  (local $var$7 i32)
+  (local $var$8 i32)
   (local $9 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -13615,63 +13615,63 @@
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   i32.store $0
-  local.get $0
+  local.get $this
   i32.load $0 offset=8
-  local.set $1
-  local.get $0
+  local.set $start
+  local.get $this
   i32.load $0 offset=16
-  local.set $2
+  local.set $size
   global.get $~lib/memory/__stack_pointer
   i32.const 0
-  local.get $2
+  local.get $size
   call $~lib/array/Array<u32>#constructor
-  local.tee $3
+  local.tee $values
   i32.store $0
   i32.const 0
-  local.set $4
+  local.set $length
   i32.const 0
-  local.set $5
+  local.set $var$5
   loop $for-loop|0
-   local.get $5
-   local.get $2
+   local.get $var$5
+   local.get $size
    i32.lt_s
-   local.set $6
-   local.get $6
+   local.set $var$6
+   local.get $var$6
    if
-    local.get $1
-    local.get $5
+    local.get $start
+    local.get $var$5
     i32.const 8
     i32.mul
     i32.add
-    local.set $7
-    local.get $7
+    local.set $var$7
+    local.get $var$7
     i32.load $0 offset=4
     i32.const 1
     i32.and
     i32.eqz
     if
-     local.get $3
-     local.get $4
-     local.tee $8
+     local.get $values
+     local.get $length
+     local.tee $var$8
      i32.const 1
      i32.add
-     local.set $4
-     local.get $8
-     local.get $7
+     local.set $length
+     local.get $var$8
+     local.get $var$7
      i32.load $0
      call $~lib/array/Array<u32>#__uset
     end
-    local.get $5
+    local.get $var$5
     i32.const 1
     i32.add
-    local.set $5
+    local.set $var$5
     br $for-loop|0
    end
   end
-  local.get $3
-  local.get $4
+  local.get $values
+  local.get $length
   call $~lib/array/Array<u32>#set:length
-  local.get $3
+  local.get $values
   local.set $9
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -13679,7 +13679,7 @@
   global.set $~lib/memory/__stack_pointer
   local.get $9
  )
- (func $~lib/set/Set<i64>#constructor (param $0 i32) (result i32)
+ (func $~lib/set/Set<i64>#constructor (param $this i32) (result i32)
   (local $1 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -13689,45 +13689,45 @@
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   i32.store $0
-  local.get $0
+  local.get $this
   i32.eqz
   if
    global.get $~lib/memory/__stack_pointer
    i32.const 24
    i32.const 15
    call $~lib/rt/itcms/__new
-   local.tee $0
+   local.tee $this
    i32.store $0
   end
-  local.get $0
+  local.get $this
   i32.const 0
   i32.const 4
   i32.const 4
   i32.mul
   call $~lib/arraybuffer/ArrayBuffer#constructor
   call $~lib/set/Set<i64>#set:buckets
-  local.get $0
+  local.get $this
   i32.const 4
   i32.const 1
   i32.sub
   call $~lib/set/Set<i64>#set:bucketsMask
-  local.get $0
+  local.get $this
   i32.const 0
   i32.const 4
   i32.const 16
   i32.mul
   call $~lib/arraybuffer/ArrayBuffer#constructor
   call $~lib/set/Set<i64>#set:entries
-  local.get $0
+  local.get $this
   i32.const 4
   call $~lib/set/Set<i64>#set:entriesCapacity
-  local.get $0
+  local.get $this
   i32.const 0
   call $~lib/set/Set<i64>#set:entriesOffset
-  local.get $0
+  local.get $this
   i32.const 0
   call $~lib/set/Set<i64>#set:entriesCount
-  local.get $0
+  local.get $this
   local.set $1
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -13735,11 +13735,11 @@
   global.set $~lib/memory/__stack_pointer
   local.get $1
  )
- (func $~lib/array/Array<i64>#constructor (param $0 i32) (param $1 i32) (result i32)
-  (local $2 i32)
-  (local $3 i32)
-  (local $4 i32)
-  (local $5 i32)
+ (func $~lib/array/Array<i64>#constructor (param $this i32) (param $length i32) (result i32)
+  (local $var$2 i32)
+  (local $var$3 i32)
+  (local $bufferSize i32)
+  (local $buffer i32)
   (local $6 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 8
@@ -13749,29 +13749,29 @@
   global.get $~lib/memory/__stack_pointer
   i64.const 0
   i64.store $0
-  local.get $0
+  local.get $this
   i32.eqz
   if
    global.get $~lib/memory/__stack_pointer
    i32.const 16
    i32.const 16
    call $~lib/rt/itcms/__new
-   local.tee $0
+   local.tee $this
    i32.store $0
   end
-  local.get $0
+  local.get $this
   i32.const 0
   call $~lib/array/Array<i64>#set:buffer
-  local.get $0
+  local.get $this
   i32.const 0
   call $~lib/array/Array<i64>#set:dataStart
-  local.get $0
+  local.get $this
   i32.const 0
   call $~lib/array/Array<i64>#set:byteLength
-  local.get $0
+  local.get $this
   i32.const 0
   call $~lib/array/Array<i64>#set:length_
-  local.get $1
+  local.get $length
   i32.const 1073741820
   i32.const 3
   i32.shr_u
@@ -13784,40 +13784,40 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $1
-  local.tee $2
+  local.get $length
+  local.tee $var$2
   i32.const 8
-  local.tee $3
-  local.get $2
-  local.get $3
+  local.tee $var$3
+  local.get $var$2
+  local.get $var$3
   i32.gt_u
   select
   i32.const 3
   i32.shl
-  local.set $4
+  local.set $bufferSize
   global.get $~lib/memory/__stack_pointer
-  local.get $4
+  local.get $bufferSize
   i32.const 0
   call $~lib/rt/itcms/__new
-  local.tee $5
+  local.tee $buffer
   i32.store $0 offset=4
   i32.const 2
   global.get $~lib/shared/runtime/Runtime.Incremental
   i32.ne
   drop
-  local.get $0
-  local.get $5
+  local.get $this
+  local.get $buffer
   call $~lib/array/Array<i64>#set:buffer
-  local.get $0
-  local.get $5
+  local.get $this
+  local.get $buffer
   call $~lib/array/Array<i64>#set:dataStart
-  local.get $0
-  local.get $4
+  local.get $this
+  local.get $bufferSize
   call $~lib/array/Array<i64>#set:byteLength
-  local.get $0
-  local.get $1
+  local.get $this
+  local.get $length
   call $~lib/array/Array<i64>#set:length_
-  local.get $0
+  local.get $this
   local.set $6
   global.get $~lib/memory/__stack_pointer
   i32.const 8
@@ -13825,15 +13825,15 @@
   global.set $~lib/memory/__stack_pointer
   local.get $6
  )
- (func $~lib/set/Set<i64>#values (param $0 i32) (result i32)
-  (local $1 i32)
-  (local $2 i32)
-  (local $3 i32)
-  (local $4 i32)
-  (local $5 i32)
-  (local $6 i32)
-  (local $7 i32)
-  (local $8 i32)
+ (func $~lib/set/Set<i64>#values (param $this i32) (result i32)
+  (local $start i32)
+  (local $size i32)
+  (local $values i32)
+  (local $length i32)
+  (local $var$5 i32)
+  (local $var$6 i32)
+  (local $var$7 i32)
+  (local $var$8 i32)
   (local $9 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -13843,63 +13843,63 @@
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   i32.store $0
-  local.get $0
+  local.get $this
   i32.load $0 offset=8
-  local.set $1
-  local.get $0
+  local.set $start
+  local.get $this
   i32.load $0 offset=16
-  local.set $2
+  local.set $size
   global.get $~lib/memory/__stack_pointer
   i32.const 0
-  local.get $2
+  local.get $size
   call $~lib/array/Array<i64>#constructor
-  local.tee $3
+  local.tee $values
   i32.store $0
   i32.const 0
-  local.set $4
+  local.set $length
   i32.const 0
-  local.set $5
+  local.set $var$5
   loop $for-loop|0
-   local.get $5
-   local.get $2
+   local.get $var$5
+   local.get $size
    i32.lt_s
-   local.set $6
-   local.get $6
+   local.set $var$6
+   local.get $var$6
    if
-    local.get $1
-    local.get $5
+    local.get $start
+    local.get $var$5
     i32.const 16
     i32.mul
     i32.add
-    local.set $7
-    local.get $7
+    local.set $var$7
+    local.get $var$7
     i32.load $0 offset=8
     i32.const 1
     i32.and
     i32.eqz
     if
-     local.get $3
-     local.get $4
-     local.tee $8
+     local.get $values
+     local.get $length
+     local.tee $var$8
      i32.const 1
      i32.add
-     local.set $4
-     local.get $8
-     local.get $7
+     local.set $length
+     local.get $var$8
+     local.get $var$7
      i64.load $0
      call $~lib/array/Array<i64>#__uset
     end
-    local.get $5
+    local.get $var$5
     i32.const 1
     i32.add
-    local.set $5
+    local.set $var$5
     br $for-loop|0
    end
   end
-  local.get $3
-  local.get $4
+  local.get $values
+  local.get $length
   call $~lib/array/Array<i64>#set:length
-  local.get $3
+  local.get $values
   local.set $9
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -13907,7 +13907,7 @@
   global.set $~lib/memory/__stack_pointer
   local.get $9
  )
- (func $~lib/set/Set<u64>#constructor (param $0 i32) (result i32)
+ (func $~lib/set/Set<u64>#constructor (param $this i32) (result i32)
   (local $1 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -13917,45 +13917,45 @@
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   i32.store $0
-  local.get $0
+  local.get $this
   i32.eqz
   if
    global.get $~lib/memory/__stack_pointer
    i32.const 24
    i32.const 17
    call $~lib/rt/itcms/__new
-   local.tee $0
+   local.tee $this
    i32.store $0
   end
-  local.get $0
+  local.get $this
   i32.const 0
   i32.const 4
   i32.const 4
   i32.mul
   call $~lib/arraybuffer/ArrayBuffer#constructor
   call $~lib/set/Set<u64>#set:buckets
-  local.get $0
+  local.get $this
   i32.const 4
   i32.const 1
   i32.sub
   call $~lib/set/Set<u64>#set:bucketsMask
-  local.get $0
+  local.get $this
   i32.const 0
   i32.const 4
   i32.const 16
   i32.mul
   call $~lib/arraybuffer/ArrayBuffer#constructor
   call $~lib/set/Set<u64>#set:entries
-  local.get $0
+  local.get $this
   i32.const 4
   call $~lib/set/Set<u64>#set:entriesCapacity
-  local.get $0
+  local.get $this
   i32.const 0
   call $~lib/set/Set<u64>#set:entriesOffset
-  local.get $0
+  local.get $this
   i32.const 0
   call $~lib/set/Set<u64>#set:entriesCount
-  local.get $0
+  local.get $this
   local.set $1
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -13963,11 +13963,11 @@
   global.set $~lib/memory/__stack_pointer
   local.get $1
  )
- (func $~lib/array/Array<u64>#constructor (param $0 i32) (param $1 i32) (result i32)
-  (local $2 i32)
-  (local $3 i32)
-  (local $4 i32)
-  (local $5 i32)
+ (func $~lib/array/Array<u64>#constructor (param $this i32) (param $length i32) (result i32)
+  (local $var$2 i32)
+  (local $var$3 i32)
+  (local $bufferSize i32)
+  (local $buffer i32)
   (local $6 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 8
@@ -13977,29 +13977,29 @@
   global.get $~lib/memory/__stack_pointer
   i64.const 0
   i64.store $0
-  local.get $0
+  local.get $this
   i32.eqz
   if
    global.get $~lib/memory/__stack_pointer
    i32.const 16
    i32.const 18
    call $~lib/rt/itcms/__new
-   local.tee $0
+   local.tee $this
    i32.store $0
   end
-  local.get $0
+  local.get $this
   i32.const 0
   call $~lib/array/Array<u64>#set:buffer
-  local.get $0
+  local.get $this
   i32.const 0
   call $~lib/array/Array<u64>#set:dataStart
-  local.get $0
+  local.get $this
   i32.const 0
   call $~lib/array/Array<u64>#set:byteLength
-  local.get $0
+  local.get $this
   i32.const 0
   call $~lib/array/Array<u64>#set:length_
-  local.get $1
+  local.get $length
   i32.const 1073741820
   i32.const 3
   i32.shr_u
@@ -14012,40 +14012,40 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $1
-  local.tee $2
+  local.get $length
+  local.tee $var$2
   i32.const 8
-  local.tee $3
-  local.get $2
-  local.get $3
+  local.tee $var$3
+  local.get $var$2
+  local.get $var$3
   i32.gt_u
   select
   i32.const 3
   i32.shl
-  local.set $4
+  local.set $bufferSize
   global.get $~lib/memory/__stack_pointer
-  local.get $4
+  local.get $bufferSize
   i32.const 0
   call $~lib/rt/itcms/__new
-  local.tee $5
+  local.tee $buffer
   i32.store $0 offset=4
   i32.const 2
   global.get $~lib/shared/runtime/Runtime.Incremental
   i32.ne
   drop
-  local.get $0
-  local.get $5
+  local.get $this
+  local.get $buffer
   call $~lib/array/Array<u64>#set:buffer
-  local.get $0
-  local.get $5
+  local.get $this
+  local.get $buffer
   call $~lib/array/Array<u64>#set:dataStart
-  local.get $0
-  local.get $4
+  local.get $this
+  local.get $bufferSize
   call $~lib/array/Array<u64>#set:byteLength
-  local.get $0
-  local.get $1
+  local.get $this
+  local.get $length
   call $~lib/array/Array<u64>#set:length_
-  local.get $0
+  local.get $this
   local.set $6
   global.get $~lib/memory/__stack_pointer
   i32.const 8
@@ -14053,15 +14053,15 @@
   global.set $~lib/memory/__stack_pointer
   local.get $6
  )
- (func $~lib/set/Set<u64>#values (param $0 i32) (result i32)
-  (local $1 i32)
-  (local $2 i32)
-  (local $3 i32)
-  (local $4 i32)
-  (local $5 i32)
-  (local $6 i32)
-  (local $7 i32)
-  (local $8 i32)
+ (func $~lib/set/Set<u64>#values (param $this i32) (result i32)
+  (local $start i32)
+  (local $size i32)
+  (local $values i32)
+  (local $length i32)
+  (local $var$5 i32)
+  (local $var$6 i32)
+  (local $var$7 i32)
+  (local $var$8 i32)
   (local $9 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -14071,63 +14071,63 @@
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   i32.store $0
-  local.get $0
+  local.get $this
   i32.load $0 offset=8
-  local.set $1
-  local.get $0
+  local.set $start
+  local.get $this
   i32.load $0 offset=16
-  local.set $2
+  local.set $size
   global.get $~lib/memory/__stack_pointer
   i32.const 0
-  local.get $2
+  local.get $size
   call $~lib/array/Array<u64>#constructor
-  local.tee $3
+  local.tee $values
   i32.store $0
   i32.const 0
-  local.set $4
+  local.set $length
   i32.const 0
-  local.set $5
+  local.set $var$5
   loop $for-loop|0
-   local.get $5
-   local.get $2
+   local.get $var$5
+   local.get $size
    i32.lt_s
-   local.set $6
-   local.get $6
+   local.set $var$6
+   local.get $var$6
    if
-    local.get $1
-    local.get $5
+    local.get $start
+    local.get $var$5
     i32.const 16
     i32.mul
     i32.add
-    local.set $7
-    local.get $7
+    local.set $var$7
+    local.get $var$7
     i32.load $0 offset=8
     i32.const 1
     i32.and
     i32.eqz
     if
-     local.get $3
-     local.get $4
-     local.tee $8
+     local.get $values
+     local.get $length
+     local.tee $var$8
      i32.const 1
      i32.add
-     local.set $4
-     local.get $8
-     local.get $7
+     local.set $length
+     local.get $var$8
+     local.get $var$7
      i64.load $0
      call $~lib/array/Array<u64>#__uset
     end
-    local.get $5
+    local.get $var$5
     i32.const 1
     i32.add
-    local.set $5
+    local.set $var$5
     br $for-loop|0
    end
   end
-  local.get $3
-  local.get $4
+  local.get $values
+  local.get $length
   call $~lib/array/Array<u64>#set:length
-  local.get $3
+  local.get $values
   local.set $9
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -14135,7 +14135,7 @@
   global.set $~lib/memory/__stack_pointer
   local.get $9
  )
- (func $~lib/set/Set<f32>#constructor (param $0 i32) (result i32)
+ (func $~lib/set/Set<f32>#constructor (param $this i32) (result i32)
   (local $1 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -14145,45 +14145,45 @@
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   i32.store $0
-  local.get $0
+  local.get $this
   i32.eqz
   if
    global.get $~lib/memory/__stack_pointer
    i32.const 24
    i32.const 19
    call $~lib/rt/itcms/__new
-   local.tee $0
+   local.tee $this
    i32.store $0
   end
-  local.get $0
+  local.get $this
   i32.const 0
   i32.const 4
   i32.const 4
   i32.mul
   call $~lib/arraybuffer/ArrayBuffer#constructor
   call $~lib/set/Set<f32>#set:buckets
-  local.get $0
+  local.get $this
   i32.const 4
   i32.const 1
   i32.sub
   call $~lib/set/Set<f32>#set:bucketsMask
-  local.get $0
+  local.get $this
   i32.const 0
   i32.const 4
   i32.const 8
   i32.mul
   call $~lib/arraybuffer/ArrayBuffer#constructor
   call $~lib/set/Set<f32>#set:entries
-  local.get $0
+  local.get $this
   i32.const 4
   call $~lib/set/Set<f32>#set:entriesCapacity
-  local.get $0
+  local.get $this
   i32.const 0
   call $~lib/set/Set<f32>#set:entriesOffset
-  local.get $0
+  local.get $this
   i32.const 0
   call $~lib/set/Set<f32>#set:entriesCount
-  local.get $0
+  local.get $this
   local.set $1
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -14191,11 +14191,11 @@
   global.set $~lib/memory/__stack_pointer
   local.get $1
  )
- (func $~lib/array/Array<f32>#constructor (param $0 i32) (param $1 i32) (result i32)
-  (local $2 i32)
-  (local $3 i32)
-  (local $4 i32)
-  (local $5 i32)
+ (func $~lib/array/Array<f32>#constructor (param $this i32) (param $length i32) (result i32)
+  (local $var$2 i32)
+  (local $var$3 i32)
+  (local $bufferSize i32)
+  (local $buffer i32)
   (local $6 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 8
@@ -14205,29 +14205,29 @@
   global.get $~lib/memory/__stack_pointer
   i64.const 0
   i64.store $0
-  local.get $0
+  local.get $this
   i32.eqz
   if
    global.get $~lib/memory/__stack_pointer
    i32.const 16
    i32.const 20
    call $~lib/rt/itcms/__new
-   local.tee $0
+   local.tee $this
    i32.store $0
   end
-  local.get $0
+  local.get $this
   i32.const 0
   call $~lib/array/Array<f32>#set:buffer
-  local.get $0
+  local.get $this
   i32.const 0
   call $~lib/array/Array<f32>#set:dataStart
-  local.get $0
+  local.get $this
   i32.const 0
   call $~lib/array/Array<f32>#set:byteLength
-  local.get $0
+  local.get $this
   i32.const 0
   call $~lib/array/Array<f32>#set:length_
-  local.get $1
+  local.get $length
   i32.const 1073741820
   i32.const 2
   i32.shr_u
@@ -14240,40 +14240,40 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $1
-  local.tee $2
+  local.get $length
+  local.tee $var$2
   i32.const 8
-  local.tee $3
-  local.get $2
-  local.get $3
+  local.tee $var$3
+  local.get $var$2
+  local.get $var$3
   i32.gt_u
   select
   i32.const 2
   i32.shl
-  local.set $4
+  local.set $bufferSize
   global.get $~lib/memory/__stack_pointer
-  local.get $4
+  local.get $bufferSize
   i32.const 0
   call $~lib/rt/itcms/__new
-  local.tee $5
+  local.tee $buffer
   i32.store $0 offset=4
   i32.const 2
   global.get $~lib/shared/runtime/Runtime.Incremental
   i32.ne
   drop
-  local.get $0
-  local.get $5
+  local.get $this
+  local.get $buffer
   call $~lib/array/Array<f32>#set:buffer
-  local.get $0
-  local.get $5
+  local.get $this
+  local.get $buffer
   call $~lib/array/Array<f32>#set:dataStart
-  local.get $0
-  local.get $4
+  local.get $this
+  local.get $bufferSize
   call $~lib/array/Array<f32>#set:byteLength
-  local.get $0
-  local.get $1
+  local.get $this
+  local.get $length
   call $~lib/array/Array<f32>#set:length_
-  local.get $0
+  local.get $this
   local.set $6
   global.get $~lib/memory/__stack_pointer
   i32.const 8
@@ -14281,15 +14281,15 @@
   global.set $~lib/memory/__stack_pointer
   local.get $6
  )
- (func $~lib/set/Set<f32>#values (param $0 i32) (result i32)
-  (local $1 i32)
-  (local $2 i32)
-  (local $3 i32)
-  (local $4 i32)
-  (local $5 i32)
-  (local $6 i32)
-  (local $7 i32)
-  (local $8 i32)
+ (func $~lib/set/Set<f32>#values (param $this i32) (result i32)
+  (local $start i32)
+  (local $size i32)
+  (local $values i32)
+  (local $length i32)
+  (local $var$5 i32)
+  (local $var$6 i32)
+  (local $var$7 i32)
+  (local $var$8 i32)
   (local $9 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -14299,63 +14299,63 @@
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   i32.store $0
-  local.get $0
+  local.get $this
   i32.load $0 offset=8
-  local.set $1
-  local.get $0
+  local.set $start
+  local.get $this
   i32.load $0 offset=16
-  local.set $2
+  local.set $size
   global.get $~lib/memory/__stack_pointer
   i32.const 0
-  local.get $2
+  local.get $size
   call $~lib/array/Array<f32>#constructor
-  local.tee $3
+  local.tee $values
   i32.store $0
   i32.const 0
-  local.set $4
+  local.set $length
   i32.const 0
-  local.set $5
+  local.set $var$5
   loop $for-loop|0
-   local.get $5
-   local.get $2
+   local.get $var$5
+   local.get $size
    i32.lt_s
-   local.set $6
-   local.get $6
+   local.set $var$6
+   local.get $var$6
    if
-    local.get $1
-    local.get $5
+    local.get $start
+    local.get $var$5
     i32.const 8
     i32.mul
     i32.add
-    local.set $7
-    local.get $7
+    local.set $var$7
+    local.get $var$7
     i32.load $0 offset=4
     i32.const 1
     i32.and
     i32.eqz
     if
-     local.get $3
-     local.get $4
-     local.tee $8
+     local.get $values
+     local.get $length
+     local.tee $var$8
      i32.const 1
      i32.add
-     local.set $4
-     local.get $8
-     local.get $7
+     local.set $length
+     local.get $var$8
+     local.get $var$7
      f32.load $0
      call $~lib/array/Array<f32>#__uset
     end
-    local.get $5
+    local.get $var$5
     i32.const 1
     i32.add
-    local.set $5
+    local.set $var$5
     br $for-loop|0
    end
   end
-  local.get $3
-  local.get $4
+  local.get $values
+  local.get $length
   call $~lib/array/Array<f32>#set:length
-  local.get $3
+  local.get $values
   local.set $9
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -14363,7 +14363,7 @@
   global.set $~lib/memory/__stack_pointer
   local.get $9
  )
- (func $~lib/set/Set<f64>#constructor (param $0 i32) (result i32)
+ (func $~lib/set/Set<f64>#constructor (param $this i32) (result i32)
   (local $1 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -14373,45 +14373,45 @@
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   i32.store $0
-  local.get $0
+  local.get $this
   i32.eqz
   if
    global.get $~lib/memory/__stack_pointer
    i32.const 24
    i32.const 21
    call $~lib/rt/itcms/__new
-   local.tee $0
+   local.tee $this
    i32.store $0
   end
-  local.get $0
+  local.get $this
   i32.const 0
   i32.const 4
   i32.const 4
   i32.mul
   call $~lib/arraybuffer/ArrayBuffer#constructor
   call $~lib/set/Set<f64>#set:buckets
-  local.get $0
+  local.get $this
   i32.const 4
   i32.const 1
   i32.sub
   call $~lib/set/Set<f64>#set:bucketsMask
-  local.get $0
+  local.get $this
   i32.const 0
   i32.const 4
   i32.const 16
   i32.mul
   call $~lib/arraybuffer/ArrayBuffer#constructor
   call $~lib/set/Set<f64>#set:entries
-  local.get $0
+  local.get $this
   i32.const 4
   call $~lib/set/Set<f64>#set:entriesCapacity
-  local.get $0
+  local.get $this
   i32.const 0
   call $~lib/set/Set<f64>#set:entriesOffset
-  local.get $0
+  local.get $this
   i32.const 0
   call $~lib/set/Set<f64>#set:entriesCount
-  local.get $0
+  local.get $this
   local.set $1
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -14419,11 +14419,11 @@
   global.set $~lib/memory/__stack_pointer
   local.get $1
  )
- (func $~lib/array/Array<f64>#constructor (param $0 i32) (param $1 i32) (result i32)
-  (local $2 i32)
-  (local $3 i32)
-  (local $4 i32)
-  (local $5 i32)
+ (func $~lib/array/Array<f64>#constructor (param $this i32) (param $length i32) (result i32)
+  (local $var$2 i32)
+  (local $var$3 i32)
+  (local $bufferSize i32)
+  (local $buffer i32)
   (local $6 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 8
@@ -14433,29 +14433,29 @@
   global.get $~lib/memory/__stack_pointer
   i64.const 0
   i64.store $0
-  local.get $0
+  local.get $this
   i32.eqz
   if
    global.get $~lib/memory/__stack_pointer
    i32.const 16
    i32.const 22
    call $~lib/rt/itcms/__new
-   local.tee $0
+   local.tee $this
    i32.store $0
   end
-  local.get $0
+  local.get $this
   i32.const 0
   call $~lib/array/Array<f64>#set:buffer
-  local.get $0
+  local.get $this
   i32.const 0
   call $~lib/array/Array<f64>#set:dataStart
-  local.get $0
+  local.get $this
   i32.const 0
   call $~lib/array/Array<f64>#set:byteLength
-  local.get $0
+  local.get $this
   i32.const 0
   call $~lib/array/Array<f64>#set:length_
-  local.get $1
+  local.get $length
   i32.const 1073741820
   i32.const 3
   i32.shr_u
@@ -14468,40 +14468,40 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $1
-  local.tee $2
+  local.get $length
+  local.tee $var$2
   i32.const 8
-  local.tee $3
-  local.get $2
-  local.get $3
+  local.tee $var$3
+  local.get $var$2
+  local.get $var$3
   i32.gt_u
   select
   i32.const 3
   i32.shl
-  local.set $4
+  local.set $bufferSize
   global.get $~lib/memory/__stack_pointer
-  local.get $4
+  local.get $bufferSize
   i32.const 0
   call $~lib/rt/itcms/__new
-  local.tee $5
+  local.tee $buffer
   i32.store $0 offset=4
   i32.const 2
   global.get $~lib/shared/runtime/Runtime.Incremental
   i32.ne
   drop
-  local.get $0
-  local.get $5
+  local.get $this
+  local.get $buffer
   call $~lib/array/Array<f64>#set:buffer
-  local.get $0
-  local.get $5
+  local.get $this
+  local.get $buffer
   call $~lib/array/Array<f64>#set:dataStart
-  local.get $0
-  local.get $4
+  local.get $this
+  local.get $bufferSize
   call $~lib/array/Array<f64>#set:byteLength
-  local.get $0
-  local.get $1
+  local.get $this
+  local.get $length
   call $~lib/array/Array<f64>#set:length_
-  local.get $0
+  local.get $this
   local.set $6
   global.get $~lib/memory/__stack_pointer
   i32.const 8
@@ -14509,15 +14509,15 @@
   global.set $~lib/memory/__stack_pointer
   local.get $6
  )
- (func $~lib/set/Set<f64>#values (param $0 i32) (result i32)
-  (local $1 i32)
-  (local $2 i32)
-  (local $3 i32)
-  (local $4 i32)
-  (local $5 i32)
-  (local $6 i32)
-  (local $7 i32)
-  (local $8 i32)
+ (func $~lib/set/Set<f64>#values (param $this i32) (result i32)
+  (local $start i32)
+  (local $size i32)
+  (local $values i32)
+  (local $length i32)
+  (local $var$5 i32)
+  (local $var$6 i32)
+  (local $var$7 i32)
+  (local $var$8 i32)
   (local $9 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -14527,63 +14527,63 @@
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   i32.store $0
-  local.get $0
+  local.get $this
   i32.load $0 offset=8
-  local.set $1
-  local.get $0
+  local.set $start
+  local.get $this
   i32.load $0 offset=16
-  local.set $2
+  local.set $size
   global.get $~lib/memory/__stack_pointer
   i32.const 0
-  local.get $2
+  local.get $size
   call $~lib/array/Array<f64>#constructor
-  local.tee $3
+  local.tee $values
   i32.store $0
   i32.const 0
-  local.set $4
+  local.set $length
   i32.const 0
-  local.set $5
+  local.set $var$5
   loop $for-loop|0
-   local.get $5
-   local.get $2
+   local.get $var$5
+   local.get $size
    i32.lt_s
-   local.set $6
-   local.get $6
+   local.set $var$6
+   local.get $var$6
    if
-    local.get $1
-    local.get $5
+    local.get $start
+    local.get $var$5
     i32.const 16
     i32.mul
     i32.add
-    local.set $7
-    local.get $7
+    local.set $var$7
+    local.get $var$7
     i32.load $0 offset=8
     i32.const 1
     i32.and
     i32.eqz
     if
-     local.get $3
-     local.get $4
-     local.tee $8
+     local.get $values
+     local.get $length
+     local.tee $var$8
      i32.const 1
      i32.add
-     local.set $4
-     local.get $8
-     local.get $7
+     local.set $length
+     local.get $var$8
+     local.get $var$7
      f64.load $0
      call $~lib/array/Array<f64>#__uset
     end
-    local.get $5
+    local.get $var$5
     i32.const 1
     i32.add
-    local.set $5
+    local.set $var$5
     br $for-loop|0
    end
   end
-  local.get $3
-  local.get $4
+  local.get $values
+  local.get $length
   call $~lib/array/Array<f64>#set:length
-  local.get $3
+  local.get $values
   local.set $9
   global.get $~lib/memory/__stack_pointer
   i32.const 4

--- a/tests/compiler/std/staticarray.debug.wat
+++ b/tests/compiler/std/staticarray.debug.wat
@@ -5155,10 +5155,10 @@
    unreachable
   end
  )
- (func $~lib/staticarray/StaticArray<~lib/string/String>#indexOf (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
-  (local $3 i32)
-  (local $4 i32)
-  (local $5 i32)
+ (func $~lib/staticarray/StaticArray<~lib/string/String>#indexOf (param $this i32) (param $value i32) (param $fromIndex i32) (result i32)
+  (local $length i32)
+  (local $var$4 i32)
+  (local $var$5 i32)
   (local $6 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -5168,17 +5168,17 @@
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   i32.store $0
-  local.get $0
+  local.get $this
   call $~lib/staticarray/StaticArray<~lib/string/String>#get:length
-  local.set $3
-  local.get $3
+  local.set $length
+  local.get $length
   i32.const 0
   i32.eq
   if (result i32)
    i32.const 1
   else
-   local.get $2
-   local.get $3
+   local.get $fromIndex
+   local.get $length
    i32.ge_s
   end
   if
@@ -5191,31 +5191,31 @@
    local.get $6
    return
   end
-  local.get $2
+  local.get $fromIndex
   i32.const 0
   i32.lt_s
   if
-   local.get $3
-   local.get $2
+   local.get $length
+   local.get $fromIndex
    i32.add
-   local.tee $4
+   local.tee $var$4
    i32.const 0
-   local.tee $5
-   local.get $4
-   local.get $5
+   local.tee $var$5
+   local.get $var$4
+   local.get $var$5
    i32.gt_s
    select
-   local.set $2
+   local.set $fromIndex
   end
   loop $while-continue|0
-   local.get $2
-   local.get $3
+   local.get $fromIndex
+   local.get $length
    i32.lt_s
-   local.set $4
-   local.get $4
+   local.set $var$4
+   local.get $var$4
    if
-    local.get $0
-    local.get $2
+    local.get $this
+    local.get $fromIndex
     i32.const 2
     i32.shl
     i32.add
@@ -5225,10 +5225,10 @@
     local.get $6
     i32.store $0
     local.get $6
-    local.get $1
+    local.get $value
     call $~lib/string/String.__eq
     if
-     local.get $2
+     local.get $fromIndex
      local.set $6
      global.get $~lib/memory/__stack_pointer
      i32.const 4
@@ -5237,10 +5237,10 @@
      local.get $6
      return
     end
-    local.get $2
+    local.get $fromIndex
     i32.const 1
     i32.add
-    local.set $2
+    local.set $fromIndex
     br $while-continue|0
    end
   end
@@ -5252,7 +5252,7 @@
   global.set $~lib/memory/__stack_pointer
   local.get $6
  )
- (func $~lib/staticarray/StaticArray<~lib/string/String>#toString (param $0 i32) (result i32)
+ (func $~lib/staticarray/StaticArray<~lib/string/String>#toString (param $this i32) (result i32)
   (local $1 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -5262,7 +5262,7 @@
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   i32.store $0
-  local.get $0
+  local.get $this
   i32.const 1776
   local.set $1
   global.get $~lib/memory/__stack_pointer
@@ -7229,7 +7229,7 @@
   i32.add
   global.set $~lib/memory/__stack_pointer
  )
- (func $std/staticarray/Ref#constructor (param $0 i32) (result i32)
+ (func $std/staticarray/Ref#constructor (param $this i32) (result i32)
   (local $1 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -7239,17 +7239,17 @@
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   i32.store $0
-  local.get $0
+  local.get $this
   i32.eqz
   if
    global.get $~lib/memory/__stack_pointer
    i32.const 0
    i32.const 4
    call $~lib/rt/itcms/__new
-   local.tee $0
+   local.tee $this
    i32.store $0
   end
-  local.get $0
+  local.get $this
   local.set $1
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -7257,9 +7257,9 @@
   global.set $~lib/memory/__stack_pointer
   local.get $1
  )
- (func $~lib/staticarray/StaticArray<i32>#constructor (param $0 i32) (param $1 i32) (result i32)
-  (local $2 i32)
-  (local $3 i32)
+ (func $~lib/staticarray/StaticArray<i32>#constructor (param $this i32) (param $length i32) (result i32)
+  (local $outSize i32)
+  (local $out i32)
   (local $4 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -7269,7 +7269,7 @@
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   i32.store $0
-  local.get $1
+  local.get $length
   i32.const 1073741820
   i32.const 2
   i32.shr_u
@@ -7282,21 +7282,21 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $1
+  local.get $length
   i32.const 2
   i32.shl
-  local.set $2
+  local.set $outSize
   global.get $~lib/memory/__stack_pointer
-  local.get $2
+  local.get $outSize
   i32.const 3
   call $~lib/rt/itcms/__new
-  local.tee $3
+  local.tee $out
   i32.store $0
   i32.const 2
   global.get $~lib/shared/runtime/Runtime.Incremental
   i32.ne
   drop
-  local.get $3
+  local.get $out
   local.set $4
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -7304,10 +7304,10 @@
   global.set $~lib/memory/__stack_pointer
   local.get $4
  )
- (func $~lib/rt/__newArray (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
-  (local $4 i32)
-  (local $5 i32)
-  (local $6 i32)
+ (func $~lib/rt/__newArray (param $length i32) (param $alignLog2 i32) (param $id i32) (param $data i32) (result i32)
+  (local $bufferSize i32)
+  (local $buffer i32)
+  (local $array i32)
   (local $7 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -7317,38 +7317,38 @@
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   i32.store $0
-  local.get $0
-  local.get $1
+  local.get $length
+  local.get $alignLog2
   i32.shl
-  local.set $4
+  local.set $bufferSize
   global.get $~lib/memory/__stack_pointer
-  local.get $4
+  local.get $bufferSize
   i32.const 0
-  local.get $3
+  local.get $data
   call $~lib/rt/__newBuffer
-  local.tee $5
+  local.tee $buffer
   i32.store $0
   i32.const 16
-  local.get $2
+  local.get $id
   call $~lib/rt/itcms/__new
-  local.set $6
-  local.get $6
-  local.get $5
+  local.set $array
+  local.get $array
+  local.get $buffer
   i32.store $0
-  local.get $6
-  local.get $5
+  local.get $array
+  local.get $buffer
   i32.const 0
   call $~lib/rt/itcms/__link
-  local.get $6
-  local.get $5
+  local.get $array
+  local.get $buffer
   i32.store $0 offset=4
-  local.get $6
-  local.get $4
+  local.get $array
+  local.get $bufferSize
   i32.store $0 offset=8
-  local.get $6
-  local.get $0
+  local.get $array
+  local.get $length
   i32.store $0 offset=12
-  local.get $6
+  local.get $array
   local.set $7
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -7356,10 +7356,10 @@
   global.set $~lib/memory/__stack_pointer
   local.get $7
  )
- (func $~lib/staticarray/StaticArray.fromArray<i32> (param $0 i32) (result i32)
-  (local $1 i32)
-  (local $2 i32)
-  (local $3 i32)
+ (func $~lib/staticarray/StaticArray.fromArray<i32> (param $source i32) (result i32)
+  (local $length i32)
+  (local $outSize i32)
+  (local $out i32)
   (local $4 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -7369,27 +7369,27 @@
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   i32.store $0
-  local.get $0
+  local.get $source
   call $~lib/array/Array<i32>#get:length
-  local.set $1
-  local.get $1
+  local.set $length
+  local.get $length
   i32.const 2
   i32.shl
-  local.set $2
+  local.set $outSize
   global.get $~lib/memory/__stack_pointer
-  local.get $2
+  local.get $outSize
   i32.const 3
   call $~lib/rt/itcms/__new
-  local.tee $3
+  local.tee $out
   i32.store $0
   i32.const 0
   drop
-  local.get $3
-  local.get $0
+  local.get $out
+  local.get $source
   i32.load $0 offset=4
-  local.get $2
+  local.get $outSize
   memory.copy $0 $0
-  local.get $3
+  local.get $out
   local.set $4
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -7397,15 +7397,15 @@
   global.set $~lib/memory/__stack_pointer
   local.get $4
  )
- (func $~lib/staticarray/StaticArray<i32>#concat<~lib/staticarray/StaticArray<i32>> (param $0 i32) (param $1 i32) (result i32)
-  (local $2 i32)
-  (local $3 i32)
-  (local $4 i32)
-  (local $5 i32)
-  (local $6 i32)
-  (local $7 i32)
-  (local $8 i32)
-  (local $9 i32)
+ (func $~lib/staticarray/StaticArray<i32>#concat<~lib/staticarray/StaticArray<i32>> (param $this i32) (param $other i32) (result i32)
+  (local $var$2 i32)
+  (local $var$3 i32)
+  (local $var$4 i32)
+  (local $var$5 i32)
+  (local $var$6 i32)
+  (local $var$7 i32)
+  (local $var$8 i32)
+  (local $var$9 i32)
   (local $10 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -7415,17 +7415,17 @@
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   i32.store $0
-  local.get $0
+  local.get $this
   call $~lib/staticarray/StaticArray<i32>#get:length
-  local.set $2
-  local.get $1
+  local.set $var$2
+  local.get $other
   call $~lib/staticarray/StaticArray<i32>#get:length
-  local.set $3
-  local.get $2
-  local.get $3
+  local.set $var$3
+  local.get $var$2
+  local.get $var$3
   i32.add
-  local.set $4
-  local.get $4
+  local.set $var$4
+  local.get $var$4
   i32.const 1073741820
   i32.const 2
   i32.shr_u
@@ -7438,43 +7438,43 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $2
+  local.get $var$2
   i32.const 2
   i32.shl
-  local.set $5
+  local.set $var$5
   i32.const 0
   drop
   i32.const 1
   drop
   global.get $~lib/memory/__stack_pointer
-  local.get $4
+  local.get $var$4
   i32.const 2
   i32.shl
   i32.const 3
   call $~lib/rt/itcms/__new
-  local.tee $6
+  local.tee $var$6
   i32.store $0
-  local.get $6
-  local.set $7
-  local.get $1
-  local.set $8
-  local.get $0
-  local.set $9
+  local.get $var$6
+  local.set $var$7
+  local.get $other
+  local.set $var$8
+  local.get $this
+  local.set $var$9
   i32.const 0
   drop
-  local.get $7
-  local.get $9
-  local.get $5
+  local.get $var$7
+  local.get $var$9
+  local.get $var$5
   memory.copy $0 $0
-  local.get $7
-  local.get $5
+  local.get $var$7
+  local.get $var$5
   i32.add
-  local.get $8
-  local.get $3
+  local.get $var$8
+  local.get $var$3
   i32.const 2
   i32.shl
   memory.copy $0 $0
-  local.get $6
+  local.get $var$6
   local.set $10
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -7482,15 +7482,15 @@
   global.set $~lib/memory/__stack_pointer
   local.get $10
  )
- (func $~lib/staticarray/StaticArray<~lib/string/String>#slice<~lib/staticarray/StaticArray<~lib/string/String>> (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
-  (local $3 i32)
-  (local $4 i32)
-  (local $5 i32)
-  (local $6 i32)
-  (local $7 i32)
-  (local $8 i32)
-  (local $9 i32)
-  (local $10 i32)
+ (func $~lib/staticarray/StaticArray<~lib/string/String>#slice<~lib/staticarray/StaticArray<~lib/string/String>> (param $this i32) (param $start i32) (param $end i32) (result i32)
+  (local $length i32)
+  (local $var$4 i32)
+  (local $var$5 i32)
+  (local $sourceStart i32)
+  (local $size i32)
+  (local $var$8 i32)
+  (local $var$9 i32)
+  (local $ref i32)
   (local $11 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -7500,125 +7500,125 @@
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   i32.store $0
-  local.get $0
+  local.get $this
   call $~lib/staticarray/StaticArray<~lib/string/String>#get:length
-  local.set $3
-  local.get $1
+  local.set $length
+  local.get $start
   i32.const 0
   i32.lt_s
   if (result i32)
-   local.get $1
-   local.get $3
+   local.get $start
+   local.get $length
    i32.add
-   local.tee $4
+   local.tee $var$4
    i32.const 0
-   local.tee $5
-   local.get $4
-   local.get $5
+   local.tee $var$5
+   local.get $var$4
+   local.get $var$5
    i32.gt_s
    select
   else
-   local.get $1
-   local.tee $5
-   local.get $3
-   local.tee $4
-   local.get $5
-   local.get $4
+   local.get $start
+   local.tee $var$5
+   local.get $length
+   local.tee $var$4
+   local.get $var$5
+   local.get $var$4
    i32.lt_s
    select
   end
-  local.set $1
-  local.get $2
+  local.set $start
+  local.get $end
   i32.const 0
   i32.lt_s
   if (result i32)
-   local.get $2
-   local.get $3
+   local.get $end
+   local.get $length
    i32.add
-   local.tee $4
+   local.tee $var$4
    i32.const 0
-   local.tee $5
-   local.get $4
-   local.get $5
+   local.tee $var$5
+   local.get $var$4
+   local.get $var$5
    i32.gt_s
    select
   else
-   local.get $2
-   local.tee $5
-   local.get $3
-   local.tee $4
-   local.get $5
-   local.get $4
+   local.get $end
+   local.tee $var$5
+   local.get $length
+   local.tee $var$4
+   local.get $var$5
+   local.get $var$4
    i32.lt_s
    select
   end
-  local.set $2
-  local.get $2
-  local.get $1
+  local.set $end
+  local.get $end
+  local.get $start
   i32.sub
-  local.tee $4
+  local.tee $var$4
   i32.const 0
-  local.tee $5
-  local.get $4
-  local.get $5
+  local.tee $var$5
+  local.get $var$4
+  local.get $var$5
   i32.gt_s
   select
-  local.set $3
-  local.get $0
-  local.get $1
+  local.set $length
+  local.get $this
+  local.get $start
   i32.const 2
   i32.shl
   i32.add
-  local.set $6
-  local.get $3
+  local.set $sourceStart
+  local.get $length
   i32.const 2
   i32.shl
-  local.set $7
+  local.set $size
   i32.const 0
   drop
   i32.const 1
   drop
   global.get $~lib/memory/__stack_pointer
-  local.get $7
+  local.get $size
   i32.const 7
   call $~lib/rt/itcms/__new
-  local.tee $4
+  local.tee $var$4
   i32.store $0
-  local.get $4
-  local.set $5
+  local.get $var$4
+  local.set $var$5
   i32.const 1
   drop
   i32.const 0
-  local.set $8
+  local.set $var$8
   loop $while-continue|0
-   local.get $8
-   local.get $7
+   local.get $var$8
+   local.get $size
    i32.lt_u
-   local.set $9
-   local.get $9
+   local.set $var$9
+   local.get $var$9
    if
-    local.get $6
-    local.get $8
+    local.get $sourceStart
+    local.get $var$8
     i32.add
     i32.load $0
-    local.set $10
-    local.get $5
-    local.get $8
+    local.set $ref
+    local.get $var$5
+    local.get $var$8
     i32.add
-    local.get $10
+    local.get $ref
     i32.store $0
-    local.get $5
-    local.get $10
+    local.get $var$5
+    local.get $ref
     i32.const 1
     call $~lib/rt/itcms/__link
-    local.get $8
+    local.get $var$8
     i32.const 4
     i32.add
-    local.set $8
+    local.set $var$8
     br $while-continue|0
    end
   end
-  local.get $4
+  local.get $var$4
   local.set $11
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -7626,8 +7626,8 @@
   global.set $~lib/memory/__stack_pointer
   local.get $11
  )
- (func $~lib/staticarray/StaticArray<~lib/string/String>#__get (param $0 i32) (param $1 i32) (result i32)
-  (local $2 i32)
+ (func $~lib/staticarray/StaticArray<~lib/string/String>#__get (param $this i32) (param $index i32) (result i32)
+  (local $value i32)
   (local $3 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -7637,8 +7637,8 @@
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   i32.store $0
-  local.get $1
-  local.get $0
+  local.get $index
+  local.get $this
   call $~lib/staticarray/StaticArray<~lib/string/String>#get:length
   i32.ge_u
   if
@@ -7650,20 +7650,20 @@
    unreachable
   end
   global.get $~lib/memory/__stack_pointer
-  local.get $0
-  local.get $1
+  local.get $this
+  local.get $index
   i32.const 2
   i32.shl
   i32.add
   i32.load $0
-  local.tee $2
+  local.tee $value
   i32.store $0
   i32.const 1
   drop
   i32.const 0
   i32.eqz
   drop
-  local.get $2
+  local.get $value
   i32.eqz
   if
    i32.const 1152
@@ -7673,7 +7673,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $2
+  local.get $value
   local.set $3
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -7681,19 +7681,19 @@
   global.set $~lib/memory/__stack_pointer
   local.get $3
  )
- (func $~lib/staticarray/StaticArray<~lib/string/String>#concat<~lib/array/Array<~lib/string/String>> (param $0 i32) (param $1 i32) (result i32)
-  (local $2 i32)
-  (local $3 i32)
-  (local $4 i32)
-  (local $5 i32)
-  (local $6 i32)
-  (local $7 i32)
-  (local $8 i32)
-  (local $9 i32)
-  (local $10 i32)
-  (local $11 i32)
-  (local $12 i32)
-  (local $13 i32)
+ (func $~lib/staticarray/StaticArray<~lib/string/String>#concat<~lib/array/Array<~lib/string/String>> (param $this i32) (param $other i32) (result i32)
+  (local $var$2 i32)
+  (local $var$3 i32)
+  (local $var$4 i32)
+  (local $var$5 i32)
+  (local $var$6 i32)
+  (local $var$7 i32)
+  (local $var$8 i32)
+  (local $var$9 i32)
+  (local $var$10 i32)
+  (local $var$11 i32)
+  (local $var$12 i32)
+  (local $var$13 i32)
   (local $14 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -7703,17 +7703,17 @@
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   i32.store $0
-  local.get $0
+  local.get $this
   call $~lib/staticarray/StaticArray<~lib/string/String>#get:length
-  local.set $2
-  local.get $1
+  local.set $var$2
+  local.get $other
   call $~lib/array/Array<~lib/string/String>#get:length
-  local.set $3
-  local.get $2
-  local.get $3
+  local.set $var$3
+  local.get $var$2
+  local.get $var$3
   i32.add
-  local.set $4
-  local.get $4
+  local.set $var$4
+  local.get $var$4
   i32.const 1073741820
   i32.const 2
   i32.shr_u
@@ -7726,99 +7726,99 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $2
+  local.get $var$2
   i32.const 2
   i32.shl
-  local.set $5
+  local.set $var$5
   i32.const 1
   drop
   global.get $~lib/memory/__stack_pointer
-  local.get $4
+  local.get $var$4
   i32.const 2
   i32.const 8
   i32.const 0
   call $~lib/rt/__newArray
-  local.tee $6
+  local.tee $var$6
   i32.store $0
-  local.get $6
+  local.get $var$6
   i32.load $0 offset=4
-  local.set $7
-  local.get $1
+  local.set $var$7
+  local.get $other
   i32.load $0 offset=4
-  local.set $8
-  local.get $0
-  local.set $9
+  local.set $var$8
+  local.get $this
+  local.set $var$9
   i32.const 1
   drop
   i32.const 0
-  local.set $10
+  local.set $var$10
   loop $for-loop|0
-   local.get $10
-   local.get $5
+   local.get $var$10
+   local.get $var$5
    i32.lt_u
-   local.set $11
-   local.get $11
+   local.set $var$11
+   local.get $var$11
    if
-    local.get $9
-    local.get $10
+    local.get $var$9
+    local.get $var$10
     i32.add
     i32.load $0
-    local.set $12
-    local.get $7
-    local.get $10
+    local.set $var$12
+    local.get $var$7
+    local.get $var$10
     i32.add
-    local.get $12
+    local.get $var$12
     i32.store $0
-    local.get $6
-    local.get $12
+    local.get $var$6
+    local.get $var$12
     i32.const 1
     call $~lib/rt/itcms/__link
-    local.get $10
+    local.get $var$10
     i32.const 4
     i32.add
-    local.set $10
+    local.set $var$10
     br $for-loop|0
    end
   end
-  local.get $7
-  local.get $5
+  local.get $var$7
+  local.get $var$5
   i32.add
-  local.set $7
-  local.get $3
+  local.set $var$7
+  local.get $var$3
   i32.const 2
   i32.shl
-  local.set $10
+  local.set $var$10
   i32.const 0
-  local.set $11
+  local.set $var$11
   loop $for-loop|1
-   local.get $11
-   local.get $10
+   local.get $var$11
+   local.get $var$10
    i32.lt_u
-   local.set $12
-   local.get $12
+   local.set $var$12
+   local.get $var$12
    if
-    local.get $8
-    local.get $11
+    local.get $var$8
+    local.get $var$11
     i32.add
     i32.load $0
-    local.set $13
-    local.get $7
-    local.get $11
+    local.set $var$13
+    local.get $var$7
+    local.get $var$11
     i32.add
-    local.get $13
+    local.get $var$13
     i32.store $0
-    local.get $6
-    local.get $13
+    local.get $var$6
+    local.get $var$13
     i32.const 1
     call $~lib/rt/itcms/__link
-    local.get $11
+    local.get $var$11
     i32.const 4
     i32.add
-    local.set $11
+    local.set $var$11
     br $for-loop|1
    end
   end
-  local.get $6
+  local.get $var$6
   local.set $14
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -7826,16 +7826,16 @@
   global.set $~lib/memory/__stack_pointer
   local.get $14
  )
- (func $~lib/util/string/joinStringArray (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
-  (local $3 i32)
-  (local $4 i32)
-  (local $5 i32)
-  (local $6 i32)
-  (local $7 i32)
-  (local $8 i32)
-  (local $9 i32)
-  (local $10 i32)
-  (local $11 i32)
+ (func $~lib/util/string/joinStringArray (param $dataStart i32) (param $length i32) (param $separator i32) (result i32)
+  (local $lastIndex i32)
+  (local $var$4 i32)
+  (local $estLen i32)
+  (local $value i32)
+  (local $var$7 i32)
+  (local $offset i32)
+  (local $sepLen i32)
+  (local $result i32)
+  (local $var$11 i32)
   (local $12 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 12
@@ -7848,11 +7848,11 @@
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   i32.store $0 offset=8
-  local.get $1
+  local.get $length
   i32.const 1
   i32.sub
-  local.set $3
-  local.get $3
+  local.set $lastIndex
+  local.get $lastIndex
   i32.const 0
   i32.lt_s
   if
@@ -7865,17 +7865,17 @@
    local.get $12
    return
   end
-  local.get $3
+  local.get $lastIndex
   i32.eqz
   if
    global.get $~lib/memory/__stack_pointer
-   local.get $0
+   local.get $dataStart
    i32.load $0
-   local.tee $4
+   local.tee $var$4
    i32.store $0
-   local.get $4
+   local.get $var$4
    if (result i32)
-    local.get $4
+    local.get $var$4
    else
     i32.const 1744
    end
@@ -7888,149 +7888,149 @@
    return
   end
   i32.const 0
-  local.set $5
+  local.set $estLen
   i32.const 0
-  local.set $4
+  local.set $var$4
   loop $for-loop|0
-   local.get $4
-   local.get $1
+   local.get $var$4
+   local.get $length
    i32.lt_s
-   local.set $7
-   local.get $7
+   local.set $var$7
+   local.get $var$7
    if
     global.get $~lib/memory/__stack_pointer
-    local.get $0
-    local.get $4
+    local.get $dataStart
+    local.get $var$4
     i32.const 2
     i32.shl
     i32.add
     i32.load $0
-    local.tee $6
+    local.tee $value
     i32.store $0 offset=4
-    local.get $6
+    local.get $value
     i32.const 0
     i32.ne
     if
-     local.get $5
-     local.get $6
+     local.get $estLen
+     local.get $value
      call $~lib/string/String#get:length
      i32.add
-     local.set $5
+     local.set $estLen
     end
-    local.get $4
+    local.get $var$4
     i32.const 1
     i32.add
-    local.set $4
+    local.set $var$4
     br $for-loop|0
    end
   end
   i32.const 0
-  local.set $8
-  local.get $2
+  local.set $offset
+  local.get $separator
   call $~lib/string/String#get:length
-  local.set $9
+  local.set $sepLen
   global.get $~lib/memory/__stack_pointer
-  local.get $5
-  local.get $9
-  local.get $3
+  local.get $estLen
+  local.get $sepLen
+  local.get $lastIndex
   i32.mul
   i32.add
   i32.const 1
   i32.shl
   i32.const 1
   call $~lib/rt/itcms/__new
-  local.tee $10
+  local.tee $result
   i32.store $0 offset=8
   i32.const 0
-  local.set $4
+  local.set $var$4
   loop $for-loop|1
-   local.get $4
-   local.get $3
+   local.get $var$4
+   local.get $lastIndex
    i32.lt_s
-   local.set $7
-   local.get $7
+   local.set $var$7
+   local.get $var$7
    if
     global.get $~lib/memory/__stack_pointer
-    local.get $0
-    local.get $4
+    local.get $dataStart
+    local.get $var$4
     i32.const 2
     i32.shl
     i32.add
     i32.load $0
-    local.tee $6
+    local.tee $value
     i32.store $0 offset=4
-    local.get $6
+    local.get $value
     i32.const 0
     i32.ne
     if
-     local.get $6
+     local.get $value
      call $~lib/string/String#get:length
-     local.set $11
-     local.get $10
-     local.get $8
+     local.set $var$11
+     local.get $result
+     local.get $offset
      i32.const 1
      i32.shl
      i32.add
-     local.get $6
-     local.get $11
+     local.get $value
+     local.get $var$11
      i32.const 1
      i32.shl
      memory.copy $0 $0
-     local.get $8
-     local.get $11
+     local.get $offset
+     local.get $var$11
      i32.add
-     local.set $8
+     local.set $offset
     end
-    local.get $9
+    local.get $sepLen
     if
-     local.get $10
-     local.get $8
+     local.get $result
+     local.get $offset
      i32.const 1
      i32.shl
      i32.add
-     local.get $2
-     local.get $9
+     local.get $separator
+     local.get $sepLen
      i32.const 1
      i32.shl
      memory.copy $0 $0
-     local.get $8
-     local.get $9
+     local.get $offset
+     local.get $sepLen
      i32.add
-     local.set $8
+     local.set $offset
     end
-    local.get $4
+    local.get $var$4
     i32.const 1
     i32.add
-    local.set $4
+    local.set $var$4
     br $for-loop|1
    end
   end
   global.get $~lib/memory/__stack_pointer
-  local.get $0
-  local.get $3
+  local.get $dataStart
+  local.get $lastIndex
   i32.const 2
   i32.shl
   i32.add
   i32.load $0
-  local.tee $6
+  local.tee $value
   i32.store $0 offset=4
-  local.get $6
+  local.get $value
   i32.const 0
   i32.ne
   if
-   local.get $10
-   local.get $8
+   local.get $result
+   local.get $offset
    i32.const 1
    i32.shl
    i32.add
-   local.get $6
-   local.get $6
+   local.get $value
+   local.get $value
    call $~lib/string/String#get:length
    i32.const 1
    i32.shl
    memory.copy $0 $0
   end
-  local.get $10
+  local.get $result
   local.set $12
   global.get $~lib/memory/__stack_pointer
   i32.const 12
@@ -8038,13 +8038,13 @@
   global.set $~lib/memory/__stack_pointer
   local.get $12
  )
- (func $~lib/staticarray/StaticArray<i32>#map<i32> (param $0 i32) (param $1 i32) (result i32)
-  (local $2 i32)
-  (local $3 i32)
-  (local $4 i32)
-  (local $5 i32)
-  (local $6 i32)
-  (local $7 i32)
+ (func $~lib/staticarray/StaticArray<i32>#map<i32> (param $this i32) (param $fn i32) (result i32)
+  (local $len i32)
+  (local $out i32)
+  (local $outStart i32)
+  (local $var$5 i32)
+  (local $var$6 i32)
+  (local $var$7 i32)
   (local $8 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -8054,60 +8054,60 @@
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   i32.store $0
-  local.get $0
+  local.get $this
   call $~lib/staticarray/StaticArray<i32>#get:length
-  local.set $2
+  local.set $len
   global.get $~lib/memory/__stack_pointer
-  local.get $2
+  local.get $len
   i32.const 2
   i32.const 6
   i32.const 0
   call $~lib/rt/__newArray
-  local.tee $3
+  local.tee $out
   i32.store $0
-  local.get $3
+  local.get $out
   i32.load $0 offset=4
-  local.set $4
+  local.set $outStart
   i32.const 0
-  local.set $5
+  local.set $var$5
   loop $for-loop|0
-   local.get $5
-   local.get $2
+   local.get $var$5
+   local.get $len
    i32.lt_s
-   local.set $6
-   local.get $6
+   local.set $var$6
+   local.get $var$6
    if
-    local.get $0
-    local.get $5
+    local.get $this
+    local.get $var$5
     i32.const 2
     i32.shl
     i32.add
     i32.load $0
-    local.get $5
-    local.get $0
+    local.get $var$5
+    local.get $this
     i32.const 3
     global.set $~argumentsLength
-    local.get $1
+    local.get $fn
     i32.load $0
     call_indirect $0 (type $i32_i32_i32_=>_i32)
-    local.set $7
-    local.get $4
-    local.get $5
+    local.set $var$7
+    local.get $outStart
+    local.get $var$5
     i32.const 2
     i32.shl
     i32.add
-    local.get $7
+    local.get $var$7
     i32.store $0
     i32.const 0
     drop
-    local.get $5
+    local.get $var$5
     i32.const 1
     i32.add
-    local.set $5
+    local.set $var$5
     br $for-loop|0
    end
   end
-  local.get $3
+  local.get $out
   local.set $8
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -8115,12 +8115,12 @@
   global.set $~lib/memory/__stack_pointer
   local.get $8
  )
- (func $~lib/staticarray/StaticArray<i32>#filter (param $0 i32) (param $1 i32) (result i32)
-  (local $2 i32)
-  (local $3 i32)
-  (local $4 i32)
-  (local $5 i32)
-  (local $6 i32)
+ (func $~lib/staticarray/StaticArray<i32>#filter (param $this i32) (param $fn i32) (result i32)
+  (local $result i32)
+  (local $var$3 i32)
+  (local $var$4 i32)
+  (local $var$5 i32)
+  (local $var$6 i32)
   (local $7 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -8136,49 +8136,49 @@
   i32.const 6
   i32.const 0
   call $~lib/rt/__newArray
-  local.tee $2
+  local.tee $result
   i32.store $0
   i32.const 0
-  local.set $3
-  local.get $0
+  local.set $var$3
+  local.get $this
   call $~lib/staticarray/StaticArray<i32>#get:length
-  local.set $4
+  local.set $var$4
   loop $for-loop|0
-   local.get $3
-   local.get $4
+   local.get $var$3
+   local.get $var$4
    i32.lt_s
-   local.set $5
-   local.get $5
+   local.set $var$5
+   local.get $var$5
    if
-    local.get $0
-    local.get $3
+    local.get $this
+    local.get $var$3
     i32.const 2
     i32.shl
     i32.add
     i32.load $0
-    local.set $6
-    local.get $6
-    local.get $3
-    local.get $0
+    local.set $var$6
+    local.get $var$6
+    local.get $var$3
+    local.get $this
     i32.const 3
     global.set $~argumentsLength
-    local.get $1
+    local.get $fn
     i32.load $0
     call_indirect $0 (type $i32_i32_i32_=>_i32)
     if
-     local.get $2
-     local.get $6
+     local.get $result
+     local.get $var$6
      call $~lib/array/Array<i32>#push
      drop
     end
-    local.get $3
+    local.get $var$3
     i32.const 1
     i32.add
-    local.set $3
+    local.set $var$3
     br $for-loop|0
    end
   end
-  local.get $2
+  local.get $result
   local.set $7
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -8186,7 +8186,7 @@
   global.set $~lib/memory/__stack_pointer
   local.get $7
  )
- (func $~lib/staticarray/StaticArray<i32>#sort@varargs (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/staticarray/StaticArray<i32>#sort@varargs (param $this i32) (param $comparator i32) (result i32)
   (local $2 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -8215,11 +8215,11 @@
     i32.const 2688
     br $~lib/util/sort/COMPARATOR<i32>|inlined.0
    end
-   local.tee $1
+   local.tee $comparator
    i32.store $0
   end
-  local.get $0
-  local.get $1
+  local.get $this
+  local.get $comparator
   call $~lib/staticarray/StaticArray<i32>#sort
   local.set $2
   global.get $~lib/memory/__stack_pointer

--- a/tests/compiler/std/string-casemapping.debug.wat
+++ b/tests/compiler/std/string-casemapping.debug.wat
@@ -3463,23 +3463,23 @@
    unreachable
   end
  )
- (func $~lib/string/String#toUpperCase (param $0 i32) (result i32)
-  (local $1 i32)
-  (local $2 i32)
-  (local $3 i32)
-  (local $4 i32)
-  (local $5 i32)
-  (local $6 i32)
-  (local $7 i32)
-  (local $8 i32)
-  (local $9 i32)
-  (local $10 i32)
-  (local $11 i32)
-  (local $12 i32)
-  (local $13 i32)
-  (local $14 i32)
-  (local $15 i32)
-  (local $16 i32)
+ (func $~lib/string/String#toUpperCase (param $this i32) (result i32)
+  (local $len i32)
+  (local $codes i32)
+  (local $specialsPtr i32)
+  (local $specialsLen i32)
+  (local $j i32)
+  (local $var$6 i32)
+  (local $var$7 i32)
+  (local $var$8 i32)
+  (local $var$9 i32)
+  (local $var$10 i32)
+  (local $var$11 i32)
+  (local $var$12 i32)
+  (local $var$13 i32)
+  (local $var$14 i32)
+  (local $mid i32)
+  (local $cmp i32)
   (local $17 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 8
@@ -3489,13 +3489,13 @@
   global.get $~lib/memory/__stack_pointer
   i64.const 0
   i64.store $0
-  local.get $0
+  local.get $this
   call $~lib/string/String#get:length
-  local.set $1
-  local.get $1
+  local.set $len
+  local.get $len
   i32.eqz
   if
-   local.get $0
+   local.get $this
    local.set $17
    global.get $~lib/memory/__stack_pointer
    i32.const 8
@@ -3505,17 +3505,17 @@
    return
   end
   global.get $~lib/memory/__stack_pointer
-  local.get $1
+  local.get $len
   i32.const 3
   i32.mul
   i32.const 2
   i32.mul
   i32.const 1
   call $~lib/rt/itcms/__new
-  local.tee $2
+  local.tee $codes
   i32.store $0
   global.get $~lib/util/casemap/SPECIALS_UPPER
-  local.set $3
+  local.set $specialsPtr
   global.get $~lib/util/casemap/SPECIALS_UPPER
   local.set $17
   global.get $~lib/memory/__stack_pointer
@@ -3523,54 +3523,54 @@
   i32.store $0 offset=4
   local.get $17
   call $~lib/staticarray/StaticArray<u16>#get:length
-  local.set $4
+  local.set $specialsLen
   i32.const 0
-  local.set $5
+  local.set $j
   i32.const 0
-  local.set $6
+  local.set $var$6
   loop $for-loop|0
-   local.get $6
-   local.get $1
+   local.get $var$6
+   local.get $len
    i32.lt_u
-   local.set $7
-   local.get $7
+   local.set $var$7
+   local.get $var$7
    if
     block $for-continue|0
-     local.get $0
-     local.get $6
+     local.get $this
+     local.get $var$6
      i32.const 1
      i32.shl
      i32.add
      i32.load16_u $0
-     local.set $8
-     local.get $8
-     local.set $9
-     local.get $9
+     local.set $var$8
+     local.get $var$8
+     local.set $var$9
+     local.get $var$9
      i32.const 7
      i32.shr_u
      i32.eqz
      if
-      local.get $2
-      local.get $5
+      local.get $codes
+      local.get $j
       i32.const 1
       i32.shl
       i32.add
       block $~lib/util/string/toUpper8|inlined.0 (result i32)
-       local.get $8
-       local.set $9
+       local.get $var$8
+       local.set $var$9
        i32.const 0
        i32.const 0
        i32.gt_s
        drop
        i32.const 1292
-       local.get $9
+       local.get $var$9
        i32.add
        i32.load8_u $0
        br $~lib/util/string/toUpper8|inlined.0
       end
       i32.store16 $0
      else
-      local.get $8
+      local.get $var$8
       i32.const 55295
       i32.sub
       i32.const 56320
@@ -3578,8 +3578,8 @@
       i32.sub
       i32.lt_u
       if (result i32)
-       local.get $6
-       local.get $1
+       local.get $var$6
+       local.get $len
        i32.const 1
        i32.sub
        i32.lt_u
@@ -3587,14 +3587,14 @@
        i32.const 0
       end
       if
-       local.get $0
-       local.get $6
+       local.get $this
+       local.get $var$6
        i32.const 1
        i32.shl
        i32.add
        i32.load16_u $0 offset=2
-       local.set $9
-       local.get $9
+       local.set $var$9
+       local.get $var$9
        i32.const 56319
        i32.sub
        i32.const 57344
@@ -3602,48 +3602,48 @@
        i32.sub
        i32.lt_u
        if
-        local.get $8
-        local.set $10
-        local.get $8
+        local.get $var$8
+        local.set $var$10
+        local.get $var$8
         i32.const 1023
         i32.and
         i32.const 10
         i32.shl
-        local.get $9
+        local.get $var$9
         i32.const 1023
         i32.and
         i32.or
         i32.const 65536
         i32.add
-        local.set $8
-        local.get $6
+        local.set $var$8
+        local.get $var$6
         i32.const 1
         i32.add
-        local.set $6
-        local.get $8
+        local.set $var$6
+        local.get $var$8
         i32.const 131072
         i32.ge_u
         if
-         local.get $2
-         local.get $5
+         local.get $codes
+         local.get $j
          i32.const 1
          i32.shl
          i32.add
-         local.get $10
-         local.get $9
+         local.get $var$10
+         local.get $var$9
          i32.const 16
          i32.shl
          i32.or
          i32.store $0
-         local.get $5
+         local.get $j
          i32.const 1
          i32.add
-         local.set $5
+         local.set $j
          br $for-continue|0
         end
        end
       end
-      local.get $8
+      local.get $var$8
       i32.const 9424
       i32.sub
       i32.const 9449
@@ -3651,19 +3651,19 @@
       i32.sub
       i32.le_u
       if
-       local.get $2
-       local.get $5
+       local.get $codes
+       local.get $j
        i32.const 1
        i32.shl
        i32.add
-       local.get $8
+       local.get $var$8
        i32.const 26
        i32.sub
        i32.store16 $0
       else
        i32.const -1
-       local.set $9
-       local.get $8
+       local.set $var$9
+       local.get $var$8
        i32.const 223
        i32.sub
        i32.const 64279
@@ -3672,58 +3672,58 @@
        i32.le_u
        if
         block $~lib/util/casemap/bsearch|inlined.0 (result i32)
-         local.get $8
-         local.set $12
-         local.get $3
-         local.set $11
-         local.get $4
-         local.set $10
+         local.get $var$8
+         local.set $var$12
+         local.get $specialsPtr
+         local.set $var$11
+         local.get $specialsLen
+         local.set $var$10
          i32.const 0
-         local.set $13
+         local.set $var$13
          loop $while-continue|1
-          local.get $13
-          local.get $10
+          local.get $var$13
+          local.get $var$10
           i32.le_s
-          local.set $14
-          local.get $14
+          local.set $var$14
+          local.get $var$14
           if
-           local.get $13
-           local.get $10
+           local.get $var$13
+           local.get $var$10
            i32.add
            i32.const 3
            i32.shr_u
            i32.const 2
            i32.shl
-           local.set $15
-           local.get $11
-           local.get $15
+           local.set $mid
+           local.get $var$11
+           local.get $mid
            i32.const 1
            i32.shl
            i32.add
            i32.load16_u $0
-           local.get $12
+           local.get $var$12
            i32.sub
-           local.set $16
-           local.get $16
+           local.set $cmp
+           local.get $cmp
            i32.const 0
            i32.eq
            if
-            local.get $15
+            local.get $mid
             br $~lib/util/casemap/bsearch|inlined.0
            else
-            local.get $16
+            local.get $cmp
             i32.const 31
             i32.shr_u
             if
-             local.get $15
+             local.get $mid
              i32.const 4
              i32.add
-             local.set $13
+             local.set $var$13
             else
-             local.get $15
+             local.get $mid
              i32.const 4
              i32.sub
-             local.set $10
+             local.set $var$10
             end
            end
            br $while-continue|1
@@ -3731,116 +3731,116 @@
          end
          i32.const -1
         end
-        local.set $9
+        local.set $var$9
        end
-       local.get $9
+       local.get $var$9
        i32.const -1
        i32.xor
        if
-        local.get $3
-        local.get $9
+        local.get $specialsPtr
+        local.get $var$9
         i32.const 1
         i32.shl
         i32.add
         i32.load $0 offset=2
-        local.set $13
-        local.get $3
-        local.get $9
+        local.set $var$13
+        local.get $specialsPtr
+        local.get $var$9
         i32.const 1
         i32.shl
         i32.add
         i32.load16_u $0 offset=6
-        local.set $12
-        local.get $2
-        local.get $5
+        local.set $var$12
+        local.get $codes
+        local.get $j
         i32.const 1
         i32.shl
         i32.add
-        local.get $13
+        local.get $var$13
         i32.store $0
-        local.get $2
-        local.get $5
+        local.get $codes
+        local.get $j
         i32.const 1
         i32.shl
         i32.add
-        local.get $12
+        local.get $var$12
         i32.store16 $0 offset=4
-        local.get $5
+        local.get $j
         i32.const 1
-        local.get $12
+        local.get $var$12
         i32.const 0
         i32.ne
         i32.add
         i32.add
-        local.set $5
+        local.set $j
        else
-        local.get $8
+        local.get $var$8
         i32.const 1
         call $~lib/util/casemap/casemap
         i32.const 2097151
         i32.and
-        local.set $12
-        local.get $12
+        local.set $var$12
+        local.get $var$12
         i32.const 65536
         i32.lt_s
         if
-         local.get $2
-         local.get $5
+         local.get $codes
+         local.get $j
          i32.const 1
          i32.shl
          i32.add
-         local.get $12
+         local.get $var$12
          i32.store16 $0
         else
-         local.get $12
+         local.get $var$12
          i32.const 65536
          i32.sub
-         local.set $12
-         local.get $12
+         local.set $var$12
+         local.get $var$12
          i32.const 10
          i32.shr_u
          i32.const 55296
          i32.or
-         local.set $13
-         local.get $12
+         local.set $var$13
+         local.get $var$12
          i32.const 1023
          i32.and
          i32.const 56320
          i32.or
-         local.set $11
-         local.get $2
-         local.get $5
+         local.set $var$11
+         local.get $codes
+         local.get $j
          i32.const 1
          i32.shl
          i32.add
-         local.get $13
-         local.get $11
+         local.get $var$13
+         local.get $var$11
          i32.const 16
          i32.shl
          i32.or
          i32.store $0
-         local.get $5
+         local.get $j
          i32.const 1
          i32.add
-         local.set $5
+         local.set $j
         end
        end
       end
      end
     end
-    local.get $6
+    local.get $var$6
     i32.const 1
     i32.add
-    local.set $6
-    local.get $5
+    local.set $var$6
+    local.get $j
     i32.const 1
     i32.add
-    local.set $5
+    local.set $j
     br $for-loop|0
    end
   end
-  local.get $2
-  local.get $5
+  local.get $codes
+  local.get $j
   i32.const 1
   i32.shl
   call $~lib/rt/itcms/__renew
@@ -6500,25 +6500,25 @@
   i32.add
   global.set $~lib/memory/__stack_pointer
  )
- (func $~lib/string/String#toLowerCase (param $0 i32) (result i32)
-  (local $1 i32)
-  (local $2 i32)
-  (local $3 i32)
-  (local $4 i32)
-  (local $5 i32)
-  (local $6 i32)
-  (local $7 i32)
-  (local $8 i32)
-  (local $9 i32)
-  (local $10 i32)
-  (local $11 i32)
-  (local $12 i32)
-  (local $13 i32)
-  (local $14 i32)
-  (local $15 i32)
-  (local $16 i32)
-  (local $17 i32)
-  (local $18 i32)
+ (func $~lib/string/String#toLowerCase (param $this i32) (result i32)
+  (local $len i32)
+  (local $codes i32)
+  (local $j i32)
+  (local $var$4 i32)
+  (local $var$5 i32)
+  (local $var$6 i32)
+  (local $var$7 i32)
+  (local $var$8 i32)
+  (local $var$9 i32)
+  (local $var$10 i32)
+  (local $var$11 i32)
+  (local $var$12 i32)
+  (local $var$13 i32)
+  (local $var$14 i32)
+  (local $c i32)
+  (local $var$16 i32)
+  (local $c_0 i32)
+  (local $var$18 i32)
   (local $19 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -6528,13 +6528,13 @@
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   i32.store $0
-  local.get $0
+  local.get $this
   call $~lib/string/String#get:length
-  local.set $1
-  local.get $1
+  local.set $len
+  local.get $len
   i32.eqz
   if
-   local.get $0
+   local.get $this
    local.set $19
    global.get $~lib/memory/__stack_pointer
    i32.const 4
@@ -6544,62 +6544,62 @@
    return
   end
   global.get $~lib/memory/__stack_pointer
-  local.get $1
+  local.get $len
   i32.const 2
   i32.mul
   i32.const 2
   i32.mul
   i32.const 1
   call $~lib/rt/itcms/__new
-  local.tee $2
+  local.tee $codes
   i32.store $0
   i32.const 0
-  local.set $3
+  local.set $j
   i32.const 0
-  local.set $4
+  local.set $var$4
   loop $for-loop|0
-   local.get $4
-   local.get $1
+   local.get $var$4
+   local.get $len
    i32.lt_u
-   local.set $5
-   local.get $5
+   local.set $var$5
+   local.get $var$5
    if
     block $for-continue|0
-     local.get $0
-     local.get $4
+     local.get $this
+     local.get $var$4
      i32.const 1
      i32.shl
      i32.add
      i32.load16_u $0
-     local.set $6
-     local.get $6
-     local.set $7
-     local.get $7
+     local.set $var$6
+     local.get $var$6
+     local.set $var$7
+     local.get $var$7
      i32.const 7
      i32.shr_u
      i32.eqz
      if
-      local.get $2
-      local.get $3
+      local.get $codes
+      local.get $j
       i32.const 1
       i32.shl
       i32.add
       block $~lib/util/string/toLower8|inlined.0 (result i32)
-       local.get $6
-       local.set $7
+       local.get $var$6
+       local.set $var$7
        i32.const 0
        i32.const 0
        i32.gt_s
        drop
        i32.const 6060
-       local.get $7
+       local.get $var$7
        i32.add
        i32.load8_u $0
        br $~lib/util/string/toLower8|inlined.0
       end
       i32.store16 $0
      else
-      local.get $6
+      local.get $var$6
       i32.const 55295
       i32.sub
       i32.const 56320
@@ -6607,8 +6607,8 @@
       i32.sub
       i32.lt_u
       if (result i32)
-       local.get $4
-       local.get $1
+       local.get $var$4
+       local.get $len
        i32.const 1
        i32.sub
        i32.lt_u
@@ -6616,14 +6616,14 @@
        i32.const 0
       end
       if
-       local.get $0
-       local.get $4
+       local.get $this
+       local.get $var$4
        i32.const 1
        i32.shl
        i32.add
        i32.load16_u $0 offset=2
-       local.set $7
-       local.get $7
+       local.set $var$7
+       local.get $var$7
        i32.const 56319
        i32.sub
        i32.const 57344
@@ -6631,53 +6631,53 @@
        i32.sub
        i32.lt_u
        if
-        local.get $6
-        local.set $8
-        local.get $6
+        local.get $var$6
+        local.set $var$8
+        local.get $var$6
         i32.const 1023
         i32.and
         i32.const 10
         i32.shl
-        local.get $7
+        local.get $var$7
         i32.const 1023
         i32.and
         i32.or
         i32.const 65536
         i32.add
-        local.set $6
-        local.get $4
+        local.set $var$6
+        local.get $var$4
         i32.const 1
         i32.add
-        local.set $4
-        local.get $6
+        local.set $var$4
+        local.get $var$6
         i32.const 131072
         i32.ge_u
         if
-         local.get $2
-         local.get $3
+         local.get $codes
+         local.get $j
          i32.const 1
          i32.shl
          i32.add
-         local.get $8
-         local.get $7
+         local.get $var$8
+         local.get $var$7
          i32.const 16
          i32.shl
          i32.or
          i32.store $0
-         local.get $3
+         local.get $j
          i32.const 1
          i32.add
-         local.set $3
+         local.set $j
          br $for-continue|0
         end
        end
       end
-      local.get $6
+      local.get $var$6
       i32.const 304
       i32.eq
       if
-       local.get $2
-       local.get $3
+       local.get $codes
+       local.get $j
        i32.const 1
        i32.shl
        i32.add
@@ -6687,104 +6687,104 @@
        i32.const 105
        i32.or
        i32.store $0
-       local.get $3
+       local.get $j
        i32.const 1
        i32.add
-       local.set $3
+       local.set $j
       else
-       local.get $6
+       local.get $var$6
        i32.const 931
        i32.eq
        if
         i32.const 963
-        local.set $7
-        local.get $1
+        local.set $var$7
+        local.get $len
         i32.const 1
         i32.gt_u
         if (result i32)
          block $~lib/util/string/isFinalSigma|inlined.0 (result i32)
-          local.get $0
-          local.set $10
-          local.get $4
-          local.set $9
-          local.get $1
-          local.set $8
+          local.get $this
+          local.set $var$10
+          local.get $var$4
+          local.set $var$9
+          local.get $len
+          local.set $var$8
           i32.const 0
-          local.set $11
-          local.get $9
-          local.set $12
+          local.set $var$11
+          local.get $var$9
+          local.set $var$12
           i32.const 0
-          local.tee $13
-          local.get $12
+          local.tee $var$13
+          local.get $var$12
           i32.const 30
           i32.sub
-          local.tee $14
-          local.get $13
-          local.get $14
+          local.tee $var$14
+          local.get $var$13
+          local.get $var$14
           i32.gt_s
           select
-          local.set $13
+          local.set $var$13
           loop $while-continue|1
-           local.get $12
-           local.get $13
+           local.get $var$12
+           local.get $var$13
            i32.gt_s
-           local.set $14
-           local.get $14
+           local.set $var$14
+           local.get $var$14
            if
             block $~lib/util/string/codePointBefore|inlined.0 (result i32)
-             local.get $10
-             local.set $16
-             local.get $12
-             local.set $15
-             local.get $15
+             local.get $var$10
+             local.set $var$16
+             local.get $var$12
+             local.set $c
+             local.get $c
              i32.const 0
              i32.le_s
              if
               i32.const -1
               br $~lib/util/string/codePointBefore|inlined.0
              end
-             local.get $16
-             local.get $15
+             local.get $var$16
+             local.get $c
              i32.const 1
              i32.sub
              i32.const 1
              i32.shl
              i32.add
              i32.load16_u $0
-             local.set $17
-             local.get $17
+             local.set $c_0
+             local.get $c_0
              i32.const 64512
              i32.and
              i32.const 56320
              i32.eq
-             local.get $15
+             local.get $c
              i32.const 2
              i32.sub
              i32.const 0
              i32.ge_s
              i32.and
              if
-              local.get $16
-              local.get $15
+              local.get $var$16
+              local.get $c
               i32.const 2
               i32.sub
               i32.const 1
               i32.shl
               i32.add
               i32.load16_u $0
-              local.set $18
-              local.get $18
+              local.set $var$18
+              local.get $var$18
               i32.const 64512
               i32.and
               i32.const 55296
               i32.eq
               if
-               local.get $18
+               local.get $var$18
                i32.const 1023
                i32.and
                i32.const 10
                i32.shl
-               local.get $17
+               local.get $c_0
                i32.const 1023
                i32.and
                i32.add
@@ -6793,7 +6793,7 @@
                br $~lib/util/string/codePointBefore|inlined.0
               end
              end
-             local.get $17
+             local.get $c_0
              i32.const 63488
              i32.and
              i32.const 55296
@@ -6801,151 +6801,151 @@
              if (result i32)
               i32.const 65533
              else
-              local.get $17
+              local.get $c_0
              end
             end
-            local.set $17
-            local.get $17
-            local.set $18
-            local.get $18
+            local.set $c_0
+            local.get $c_0
+            local.set $var$18
+            local.get $var$18
             i32.const 918000
             i32.lt_u
             if (result i32)
              i32.const 6188
-             local.get $18
+             local.get $var$18
              call $~lib/util/string/stagedBinaryLookup
             else
              i32.const 0
             end
             i32.eqz
             if
-             local.get $17
-             local.set $15
-             local.get $15
+             local.get $c_0
+             local.set $c
+             local.get $c
              i32.const 127370
              i32.lt_u
              if (result i32)
               i32.const 9196
-              local.get $15
+              local.get $c
               call $~lib/util/string/stagedBinaryLookup
              else
               i32.const 0
              end
              if
               i32.const 1
-              local.set $11
+              local.set $var$11
              else
               i32.const 0
               br $~lib/util/string/isFinalSigma|inlined.0
              end
             end
-            local.get $12
-            local.get $17
+            local.get $var$12
+            local.get $c_0
             i32.const 65536
             i32.ge_s
             i32.const 1
             i32.add
             i32.sub
-            local.set $12
+            local.set $var$12
             br $while-continue|1
            end
           end
-          local.get $11
+          local.get $var$11
           i32.eqz
           if
            i32.const 0
            br $~lib/util/string/isFinalSigma|inlined.0
           end
-          local.get $9
+          local.get $var$9
           i32.const 1
           i32.add
-          local.set $12
-          local.get $12
+          local.set $var$12
+          local.get $var$12
           i32.const 30
           i32.add
-          local.tee $16
-          local.get $8
-          local.tee $14
-          local.get $16
-          local.get $14
+          local.tee $var$16
+          local.get $var$8
+          local.tee $var$14
+          local.get $var$16
+          local.get $var$14
           i32.lt_s
           select
-          local.set $16
+          local.set $var$16
           loop $while-continue|2
-           local.get $12
-           local.get $16
+           local.get $var$12
+           local.get $var$16
            i32.lt_s
-           local.set $14
-           local.get $14
+           local.set $var$14
+           local.get $var$14
            if
-            local.get $10
-            local.get $12
+            local.get $var$10
+            local.get $var$12
             i32.const 1
             i32.shl
             i32.add
             i32.load16_u $0
-            local.set $15
-            local.get $15
+            local.set $c
+            local.get $c
             i32.const 64512
             i32.and
             i32.const 55296
             i32.eq
-            local.get $12
+            local.get $var$12
             i32.const 1
             i32.add
-            local.get $8
+            local.get $var$8
             i32.ne
             i32.and
             if
-             local.get $10
-             local.get $12
+             local.get $var$10
+             local.get $var$12
              i32.const 1
              i32.shl
              i32.add
              i32.load16_u $0 offset=2
-             local.set $18
-             local.get $18
+             local.set $var$18
+             local.get $var$18
              i32.const 64512
              i32.and
              i32.const 56320
              i32.eq
              if
-              local.get $15
+              local.get $c
               i32.const 55296
               i32.sub
               i32.const 10
               i32.shl
-              local.get $18
+              local.get $var$18
               i32.const 56320
               i32.sub
               i32.add
               i32.const 65536
               i32.add
-              local.set $15
+              local.set $c
              end
             end
-            local.get $15
-            local.set $18
-            local.get $18
+            local.get $c
+            local.set $var$18
+            local.get $var$18
             i32.const 918000
             i32.lt_u
             if (result i32)
              i32.const 6188
-             local.get $18
+             local.get $var$18
              call $~lib/util/string/stagedBinaryLookup
             else
              i32.const 0
             end
             i32.eqz
             if
-             local.get $15
-             local.set $18
-             local.get $18
+             local.get $c
+             local.set $var$18
+             local.get $var$18
              i32.const 127370
              i32.lt_u
              if (result i32)
               i32.const 9196
-              local.get $18
+              local.get $var$18
               call $~lib/util/string/stagedBinaryLookup
              else
               i32.const 0
@@ -6953,14 +6953,14 @@
              i32.eqz
              br $~lib/util/string/isFinalSigma|inlined.0
             end
-            local.get $12
-            local.get $15
+            local.get $var$12
+            local.get $c
             i32.const 65536
             i32.ge_u
             i32.const 1
             i32.add
             i32.add
-            local.set $12
+            local.set $var$12
             br $while-continue|2
            end
           end
@@ -6971,17 +6971,17 @@
         end
         if
          i32.const 962
-         local.set $7
+         local.set $var$7
         end
-        local.get $2
-        local.get $3
+        local.get $codes
+        local.get $j
         i32.const 1
         i32.shl
         i32.add
-        local.get $7
+        local.get $var$7
         i32.store16 $0
        else
-        local.get $6
+        local.get $var$6
         i32.const 9398
         i32.sub
         i32.const 9423
@@ -6989,84 +6989,84 @@
         i32.sub
         i32.le_u
         if
-         local.get $2
-         local.get $3
+         local.get $codes
+         local.get $j
          i32.const 1
          i32.shl
          i32.add
-         local.get $6
+         local.get $var$6
          i32.const 26
          i32.add
          i32.store16 $0
         else
-         local.get $6
+         local.get $var$6
          i32.const 0
          call $~lib/util/casemap/casemap
          i32.const 2097151
          i32.and
-         local.set $7
-         local.get $7
+         local.set $var$7
+         local.get $var$7
          i32.const 65536
          i32.lt_s
          if
-          local.get $2
-          local.get $3
+          local.get $codes
+          local.get $j
           i32.const 1
           i32.shl
           i32.add
-          local.get $7
+          local.get $var$7
           i32.store16 $0
          else
-          local.get $7
+          local.get $var$7
           i32.const 65536
           i32.sub
-          local.set $7
-          local.get $7
+          local.set $var$7
+          local.get $var$7
           i32.const 10
           i32.shr_u
           i32.const 55296
           i32.or
-          local.set $16
-          local.get $7
+          local.set $var$16
+          local.get $var$7
           i32.const 1023
           i32.and
           i32.const 56320
           i32.or
-          local.set $13
-          local.get $2
-          local.get $3
+          local.set $var$13
+          local.get $codes
+          local.get $j
           i32.const 1
           i32.shl
           i32.add
-          local.get $16
-          local.get $13
+          local.get $var$16
+          local.get $var$13
           i32.const 16
           i32.shl
           i32.or
           i32.store $0
-          local.get $3
+          local.get $j
           i32.const 1
           i32.add
-          local.set $3
+          local.set $j
          end
         end
        end
       end
      end
     end
-    local.get $4
+    local.get $var$4
     i32.const 1
     i32.add
-    local.set $4
-    local.get $3
+    local.set $var$4
+    local.get $j
     i32.const 1
     i32.add
-    local.set $3
+    local.set $j
     br $for-loop|0
    end
   end
-  local.get $2
-  local.get $3
+  local.get $codes
+  local.get $j
   i32.const 1
   i32.shl
   call $~lib/rt/itcms/__renew
@@ -7077,11 +7077,11 @@
   global.set $~lib/memory/__stack_pointer
   local.get $19
  )
- (func $~lib/string/String.fromCodePoint (param $0 i32) (result i32)
-  (local $1 i32)
-  (local $2 i32)
-  (local $3 i32)
-  (local $4 i32)
+ (func $~lib/string/String.fromCodePoint (param $code i32) (result i32)
+  (local $hasSur i32)
+  (local $out i32)
+  (local $var$3 i32)
+  (local $var$4 i32)
   (local $5 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -7091,26 +7091,26 @@
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   i32.store $0
-  local.get $0
+  local.get $code
   i32.const 65535
   i32.gt_u
-  local.set $1
+  local.set $hasSur
   global.get $~lib/memory/__stack_pointer
   i32.const 2
-  local.get $1
+  local.get $hasSur
   i32.shl
   i32.const 1
   call $~lib/rt/itcms/__new
-  local.tee $2
+  local.tee $out
   i32.store $0
-  local.get $1
+  local.get $hasSur
   i32.eqz
   if
-   local.get $2
-   local.get $0
+   local.get $out
+   local.get $code
    i32.store16 $0
   else
-   local.get $0
+   local.get $code
    i32.const 1114111
    i32.le_u
    i32.eqz
@@ -7122,31 +7122,31 @@
     call $~lib/builtins/abort
     unreachable
    end
-   local.get $0
+   local.get $code
    i32.const 65536
    i32.sub
-   local.set $0
-   local.get $0
+   local.set $code
+   local.get $code
    i32.const 1023
    i32.and
    i32.const 56320
    i32.or
-   local.set $3
-   local.get $0
+   local.set $var$3
+   local.get $code
    i32.const 10
    i32.shr_u
    i32.const 55296
    i32.or
-   local.set $4
-   local.get $2
-   local.get $4
-   local.get $3
+   local.set $var$4
+   local.get $out
+   local.get $var$4
+   local.get $var$3
    i32.const 16
    i32.shl
    i32.or
    i32.store $0
   end
-  local.get $2
+  local.get $out
   local.set $5
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -7154,15 +7154,15 @@
   global.set $~lib/memory/__stack_pointer
   local.get $5
  )
- (func $~lib/util/number/itoa64 (param $0 i64) (param $1 i32) (result i32)
-  (local $2 i32)
-  (local $3 i32)
-  (local $4 i32)
-  (local $5 i32)
-  (local $6 i32)
-  (local $7 i32)
-  (local $8 i32)
-  (local $9 i64)
+ (func $~lib/util/number/itoa64 (param $value i64) (param $radix i32) (result i32)
+  (local $sign i32)
+  (local $out i32)
+  (local $var$4 i32)
+  (local $var$5 i32)
+  (local $var$6 i32)
+  (local $var$7 i32)
+  (local $var$8 i32)
+  (local $var$9 i64)
   (local $10 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -7172,13 +7172,13 @@
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   i32.store $0
-  local.get $1
+  local.get $radix
   i32.const 2
   i32.lt_s
   if (result i32)
    i32.const 1
   else
-   local.get $1
+   local.get $radix
    i32.const 36
    i32.gt_s
   end
@@ -7190,7 +7190,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $0
+  local.get $value
   i64.const 0
   i64.ne
   i32.eqz
@@ -7204,99 +7204,99 @@
    local.get $10
    return
   end
-  local.get $0
+  local.get $value
   i64.const 63
   i64.shr_u
   i32.wrap_i64
   i32.const 1
   i32.shl
-  local.set $2
-  local.get $2
+  local.set $sign
+  local.get $sign
   if
    i64.const 0
-   local.get $0
+   local.get $value
    i64.sub
-   local.set $0
+   local.set $value
   end
-  local.get $1
+  local.get $radix
   i32.const 10
   i32.eq
   if
-   local.get $0
+   local.get $value
    global.get $~lib/builtins/u32.MAX_VALUE
    i64.extend_i32_u
    i64.le_u
    if
-    local.get $0
+    local.get $value
     i32.wrap_i64
-    local.set $4
-    local.get $4
+    local.set $var$4
+    local.get $var$4
     call $~lib/util/number/decimalCount32
-    local.set $5
+    local.set $var$5
     global.get $~lib/memory/__stack_pointer
-    local.get $5
+    local.get $var$5
     i32.const 1
     i32.shl
-    local.get $2
+    local.get $sign
     i32.add
     i32.const 1
     call $~lib/rt/itcms/__new
-    local.tee $3
+    local.tee $out
     i32.store $0
-    local.get $3
-    local.get $2
+    local.get $out
+    local.get $sign
     i32.add
-    local.set $8
-    local.get $4
-    local.set $7
-    local.get $5
-    local.set $6
+    local.set $var$8
+    local.get $var$4
+    local.set $var$7
+    local.get $var$5
+    local.set $var$6
     i32.const 0
     i32.const 1
     i32.ge_s
     drop
-    local.get $8
-    local.get $7
-    local.get $6
+    local.get $var$8
+    local.get $var$7
+    local.get $var$6
     call $~lib/util/number/utoa32_dec_lut
    else
-    local.get $0
+    local.get $value
     call $~lib/util/number/decimalCount64High
-    local.set $5
+    local.set $var$5
     global.get $~lib/memory/__stack_pointer
-    local.get $5
+    local.get $var$5
     i32.const 1
     i32.shl
-    local.get $2
+    local.get $sign
     i32.add
     i32.const 1
     call $~lib/rt/itcms/__new
-    local.tee $3
+    local.tee $out
     i32.store $0
-    local.get $3
-    local.get $2
+    local.get $out
+    local.get $sign
     i32.add
-    local.set $7
-    local.get $0
-    local.set $9
-    local.get $5
-    local.set $6
+    local.set $var$7
+    local.get $value
+    local.set $var$9
+    local.get $var$5
+    local.set $var$6
     i32.const 0
     i32.const 1
     i32.ge_s
     drop
-    local.get $7
-    local.get $9
-    local.get $6
+    local.get $var$7
+    local.get $var$9
+    local.get $var$6
     call $~lib/util/number/utoa64_dec_lut
    end
   else
-   local.get $1
+   local.get $radix
    i32.const 16
    i32.eq
    if
     i32.const 63
-    local.get $0
+    local.get $value
     i64.clz
     i32.wrap_i64
     i32.sub
@@ -7304,64 +7304,64 @@
     i32.shr_s
     i32.const 1
     i32.add
-    local.set $5
+    local.set $var$5
     global.get $~lib/memory/__stack_pointer
-    local.get $5
+    local.get $var$5
     i32.const 1
     i32.shl
-    local.get $2
+    local.get $sign
     i32.add
     i32.const 1
     call $~lib/rt/itcms/__new
-    local.tee $3
+    local.tee $out
     i32.store $0
-    local.get $3
-    local.get $2
+    local.get $out
+    local.get $sign
     i32.add
-    local.set $4
-    local.get $0
-    local.set $9
-    local.get $5
-    local.set $8
+    local.set $var$4
+    local.get $value
+    local.set $var$9
+    local.get $var$5
+    local.set $var$8
     i32.const 0
     i32.const 1
     i32.ge_s
     drop
-    local.get $4
-    local.get $9
-    local.get $8
+    local.get $var$4
+    local.get $var$9
+    local.get $var$8
     call $~lib/util/number/utoa_hex_lut
    else
-    local.get $0
-    local.get $1
+    local.get $value
+    local.get $radix
     call $~lib/util/number/ulog_base
-    local.set $5
+    local.set $var$5
     global.get $~lib/memory/__stack_pointer
-    local.get $5
+    local.get $var$5
     i32.const 1
     i32.shl
-    local.get $2
+    local.get $sign
     i32.add
     i32.const 1
     call $~lib/rt/itcms/__new
-    local.tee $3
+    local.tee $out
     i32.store $0
-    local.get $3
-    local.get $2
+    local.get $out
+    local.get $sign
     i32.add
-    local.get $0
-    local.get $5
-    local.get $1
+    local.get $value
+    local.get $var$5
+    local.get $radix
     call $~lib/util/number/utoa64_any_core
    end
   end
-  local.get $2
+  local.get $sign
   if
-   local.get $3
+   local.get $out
    i32.const 45
    i32.store16 $0
   end
-  local.get $3
+  local.get $out
   local.set $10
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -7369,11 +7369,11 @@
   global.set $~lib/memory/__stack_pointer
   local.get $10
  )
- (func $~lib/string/String#concat (param $0 i32) (param $1 i32) (result i32)
-  (local $2 i32)
-  (local $3 i32)
-  (local $4 i32)
-  (local $5 i32)
+ (func $~lib/string/String#concat (param $this i32) (param $other i32) (result i32)
+  (local $thisSize i32)
+  (local $otherSize i32)
+  (local $outSize i32)
+  (local $out i32)
   (local $6 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -7383,21 +7383,21 @@
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   i32.store $0
-  local.get $0
+  local.get $this
   call $~lib/string/String#get:length
   i32.const 1
   i32.shl
-  local.set $2
-  local.get $1
+  local.set $thisSize
+  local.get $other
   call $~lib/string/String#get:length
   i32.const 1
   i32.shl
-  local.set $3
-  local.get $2
-  local.get $3
+  local.set $otherSize
+  local.get $thisSize
+  local.get $otherSize
   i32.add
-  local.set $4
-  local.get $4
+  local.set $outSize
+  local.get $outSize
   i32.const 0
   i32.eq
   if
@@ -7411,22 +7411,22 @@
    return
   end
   global.get $~lib/memory/__stack_pointer
-  local.get $4
+  local.get $outSize
   i32.const 1
   call $~lib/rt/itcms/__new
-  local.tee $5
+  local.tee $out
   i32.store $0
-  local.get $5
-  local.get $0
-  local.get $2
+  local.get $out
+  local.get $this
+  local.get $thisSize
   memory.copy $0 $0
-  local.get $5
-  local.get $2
+  local.get $out
+  local.get $thisSize
   i32.add
-  local.get $1
-  local.get $3
+  local.get $other
+  local.get $otherSize
   memory.copy $0 $0
-  local.get $5
+  local.get $out
   local.set $6
   global.get $~lib/memory/__stack_pointer
   i32.const 4

--- a/tests/compiler/std/string-encoding.debug.wat
+++ b/tests/compiler/std/string-encoding.debug.wat
@@ -2901,8 +2901,8 @@
   global.set $~lib/memory/__stack_pointer
  )
  (func $std/string-encoding/testUTF16Encode
-  (local $0 i32)
-  (local $1 i32)
+  (local $buf i32)
+  (local $ptr i32)
   (local $2 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 8
@@ -2920,11 +2920,11 @@
   i32.store $0
   local.get $2
   call $~lib/string/String.UTF16.encode
-  local.tee $0
+  local.tee $buf
   i32.store $0 offset=4
-  local.get $0
-  local.set $1
-  local.get $0
+  local.get $buf
+  local.set $ptr
+  local.get $buf
   call $~lib/arraybuffer/ArrayBuffer#get:byteLength
   i32.const 12
   i32.eq
@@ -2937,7 +2937,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $1
+  local.get $ptr
   i32.load8_u $0
   i32.const 1
   i32.eq
@@ -2950,7 +2950,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $1
+  local.get $ptr
   i32.load8_u $0 offset=1
   i32.const 216
   i32.eq
@@ -2963,7 +2963,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $1
+  local.get $ptr
   i32.load8_u $0 offset=2
   i32.const 55
   i32.eq
@@ -2976,7 +2976,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $1
+  local.get $ptr
   i32.load8_u $0 offset=3
   i32.const 220
   i32.eq
@@ -2989,7 +2989,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $1
+  local.get $ptr
   i32.load8_u $0 offset=4
   i32.const 104
   i32.eq
@@ -3002,7 +3002,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $1
+  local.get $ptr
   i32.load8_u $0 offset=5
   i32.const 0
   i32.eq
@@ -3015,7 +3015,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $1
+  local.get $ptr
   i32.load8_u $0 offset=6
   i32.const 105
   i32.eq
@@ -3028,7 +3028,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $1
+  local.get $ptr
   i32.load8_u $0 offset=7
   i32.const 0
   i32.eq
@@ -3041,7 +3041,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $1
+  local.get $ptr
   i32.load8_u $0 offset=8
   i32.const 82
   i32.eq
@@ -3054,7 +3054,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $1
+  local.get $ptr
   i32.load8_u $0 offset=9
   i32.const 216
   i32.eq
@@ -3067,7 +3067,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $1
+  local.get $ptr
   i32.load8_u $0 offset=10
   i32.const 98
   i32.eq
@@ -3080,7 +3080,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $1
+  local.get $ptr
   i32.load8_u $0 offset=11
   i32.const 223
   i32.eq
@@ -3099,7 +3099,7 @@
   global.set $~lib/memory/__stack_pointer
  )
  (func $std/string-encoding/testUTF16Decode
-  (local $0 i32)
+  (local $buf i32)
   (local $1 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 12
@@ -3120,9 +3120,9 @@
   i32.store $0
   local.get $1
   call $~lib/string/String.UTF16.encode
-  local.tee $0
+  local.tee $buf
   i32.store $0 offset=4
-  local.get $0
+  local.get $buf
   call $~lib/string/String.UTF16.decode
   local.set $1
   global.get $~lib/memory/__stack_pointer
@@ -3151,9 +3151,9 @@
   global.set $~lib/memory/__stack_pointer
  )
  (func $std/string-encoding/testUTF16DecodeUnsafe
-  (local $0 i32)
-  (local $1 i32)
-  (local $2 i32)
+  (local $buf i32)
+  (local $len i32)
+  (local $ptr i32)
   (local $3 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 12
@@ -3174,7 +3174,7 @@
   i32.store $0
   local.get $3
   call $~lib/string/String.UTF16.encode
-  local.tee $0
+  local.tee $buf
   i32.store $0 offset=4
   global.get $std/string-encoding/str
   local.set $3
@@ -3183,10 +3183,10 @@
   i32.store $0
   local.get $3
   call $~lib/string/String.UTF16.byteLength
-  local.set $1
-  local.get $0
-  local.set $2
-  local.get $2
+  local.set $len
+  local.get $buf
+  local.set $ptr
+  local.get $ptr
   i32.const 0
   call $~lib/string/String.UTF16.decodeUnsafe
   local.set $3
@@ -3210,8 +3210,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $2
-  local.get $1
+  local.get $ptr
+  local.get $len
   call $~lib/string/String.UTF16.decodeUnsafe
   local.set $3
   global.get $~lib/memory/__stack_pointer
@@ -3234,7 +3234,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $2
+  local.get $ptr
   i32.const 4
   call $~lib/string/String.UTF16.decodeUnsafe
   local.set $3
@@ -3258,7 +3258,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $2
+  local.get $ptr
   i32.const 4
   i32.add
   i32.const 2
@@ -3284,7 +3284,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $2
+  local.get $ptr
   i32.const 4
   i32.add
   i32.const 4
@@ -3310,7 +3310,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $2
+  local.get $ptr
   i32.const 8
   i32.add
   i32.const 4
@@ -3336,7 +3336,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $2
+  local.get $ptr
   i32.const 12
   i32.add
   i32.const 0
@@ -3421,8 +3421,8 @@
   global.set $~lib/memory/__stack_pointer
  )
  (func $std/string-encoding/testUTF8Encode
-  (local $0 i32)
-  (local $1 i32)
+  (local $buf i32)
+  (local $ptr i32)
   (local $2 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 8
@@ -3444,11 +3444,11 @@
   global.set $~argumentsLength
   i32.const 0
   call $~lib/string/String.UTF8.encode@varargs
-  local.tee $0
+  local.tee $buf
   i32.store $0 offset=4
-  local.get $0
-  local.set $1
-  local.get $0
+  local.get $buf
+  local.set $ptr
+  local.get $buf
   call $~lib/arraybuffer/ArrayBuffer#get:byteLength
   i32.const 10
   i32.eq
@@ -3461,7 +3461,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $1
+  local.get $ptr
   i32.load8_u $0
   i32.const 240
   i32.eq
@@ -3474,7 +3474,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $1
+  local.get $ptr
   i32.load8_u $0 offset=1
   i32.const 144
   i32.eq
@@ -3487,7 +3487,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $1
+  local.get $ptr
   i32.load8_u $0 offset=2
   i32.const 144
   i32.eq
@@ -3500,7 +3500,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $1
+  local.get $ptr
   i32.load8_u $0 offset=3
   i32.const 183
   i32.eq
@@ -3513,7 +3513,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $1
+  local.get $ptr
   i32.load8_u $0 offset=4
   i32.const 104
   i32.eq
@@ -3526,7 +3526,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $1
+  local.get $ptr
   i32.load8_u $0 offset=5
   i32.const 105
   i32.eq
@@ -3539,7 +3539,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $1
+  local.get $ptr
   i32.load8_u $0 offset=6
   i32.const 240
   i32.eq
@@ -3552,7 +3552,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $1
+  local.get $ptr
   i32.load8_u $0 offset=7
   i32.const 164
   i32.eq
@@ -3565,7 +3565,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $1
+  local.get $ptr
   i32.load8_u $0 offset=8
   i32.const 173
   i32.eq
@@ -3578,7 +3578,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $1
+  local.get $ptr
   i32.load8_u $0 offset=9
   i32.const 162
   i32.eq
@@ -3597,10 +3597,10 @@
   global.set $~lib/memory/__stack_pointer
  )
  (func $std/string-encoding/testUTF8EncodeNullTerminated
-  (local $0 i32)
-  (local $1 i32)
-  (local $2 i32)
-  (local $3 i32)
+  (local $buf i32)
+  (local $ptr i32)
+  (local $str2 i32)
+  (local $buf2 i32)
   (local $4 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 16
@@ -3625,11 +3625,11 @@
   global.set $~argumentsLength
   i32.const 0
   call $~lib/string/String.UTF8.encode@varargs
-  local.tee $0
+  local.tee $buf
   i32.store $0 offset=4
-  local.get $0
-  local.set $1
-  local.get $0
+  local.get $buf
+  local.set $ptr
+  local.get $buf
   call $~lib/arraybuffer/ArrayBuffer#get:byteLength
   i32.const 11
   i32.eq
@@ -3642,7 +3642,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $1
+  local.get $ptr
   i32.load8_u $0
   i32.const 240
   i32.eq
@@ -3655,7 +3655,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $1
+  local.get $ptr
   i32.load8_u $0 offset=1
   i32.const 144
   i32.eq
@@ -3668,7 +3668,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $1
+  local.get $ptr
   i32.load8_u $0 offset=2
   i32.const 144
   i32.eq
@@ -3681,7 +3681,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $1
+  local.get $ptr
   i32.load8_u $0 offset=3
   i32.const 183
   i32.eq
@@ -3694,7 +3694,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $1
+  local.get $ptr
   i32.load8_u $0 offset=4
   i32.const 104
   i32.eq
@@ -3707,7 +3707,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $1
+  local.get $ptr
   i32.load8_u $0 offset=5
   i32.const 105
   i32.eq
@@ -3720,7 +3720,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $1
+  local.get $ptr
   i32.load8_u $0 offset=6
   i32.const 240
   i32.eq
@@ -3733,7 +3733,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $1
+  local.get $ptr
   i32.load8_u $0 offset=7
   i32.const 164
   i32.eq
@@ -3746,7 +3746,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $1
+  local.get $ptr
   i32.load8_u $0 offset=8
   i32.const 173
   i32.eq
@@ -3759,7 +3759,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $1
+  local.get $ptr
   i32.load8_u $0 offset=9
   i32.const 162
   i32.eq
@@ -3772,7 +3772,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $1
+  local.get $ptr
   i32.load8_u $0 offset=10
   i32.const 0
   i32.eq
@@ -3787,20 +3787,20 @@
   end
   global.get $~lib/memory/__stack_pointer
   i32.const 800
-  local.tee $2
+  local.tee $str2
   i32.store $0 offset=8
   global.get $~lib/memory/__stack_pointer
-  local.get $2
+  local.get $str2
   i32.const 1
   i32.const 2
   global.set $~argumentsLength
   i32.const 0
   call $~lib/string/String.UTF8.encode@varargs
-  local.tee $3
+  local.tee $buf2
   i32.store $0 offset=12
-  local.get $3
+  local.get $buf2
   call $~lib/arraybuffer/ArrayBuffer#get:byteLength
-  local.get $2
+  local.get $str2
   i32.const 1
   call $~lib/string/String.UTF8.byteLength
   i32.eq
@@ -3819,7 +3819,7 @@
   global.set $~lib/memory/__stack_pointer
  )
  (func $std/string-encoding/testUTF8ErrorMode
-  (local $0 i32)
+  (local $str i32)
   (local $1 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 12
@@ -3849,9 +3849,9 @@
   local.get $1
   i32.const 0
   call $~lib/string/String.UTF8.decode
-  local.tee $0
+  local.tee $str
   i32.store $0 offset=8
-  local.get $0
+  local.get $str
   i32.const 880
   local.set $1
   global.get $~lib/memory/__stack_pointer
@@ -3885,9 +3885,9 @@
   local.get $1
   i32.const 0
   call $~lib/string/String.UTF8.decode
-  local.tee $0
+  local.tee $str
   i32.store $0 offset=8
-  local.get $0
+  local.get $str
   i32.const 912
   local.set $1
   global.get $~lib/memory/__stack_pointer
@@ -3921,9 +3921,9 @@
   local.get $1
   i32.const 0
   call $~lib/string/String.UTF8.decode
-  local.tee $0
+  local.tee $str
   i32.store $0 offset=8
-  local.get $0
+  local.get $str
   i32.const 944
   local.set $1
   global.get $~lib/memory/__stack_pointer
@@ -3957,9 +3957,9 @@
   local.get $1
   i32.const 0
   call $~lib/string/String.UTF8.decode
-  local.tee $0
+  local.tee $str
   i32.store $0 offset=8
-  local.get $0
+  local.get $str
   i32.const 912
   local.set $1
   global.get $~lib/memory/__stack_pointer
@@ -3982,7 +3982,7 @@
   global.set $~lib/memory/__stack_pointer
  )
  (func $std/string-encoding/testUTF8Decode
-  (local $0 i32)
+  (local $buf i32)
   (local $1 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 12
@@ -4007,9 +4007,9 @@
   global.set $~argumentsLength
   i32.const 0
   call $~lib/string/String.UTF8.encode@varargs
-  local.tee $0
+  local.tee $buf
   i32.store $0 offset=4
-  local.get $0
+  local.get $buf
   i32.const 0
   call $~lib/string/String.UTF8.decode
   local.set $1
@@ -4039,11 +4039,11 @@
   global.set $~lib/memory/__stack_pointer
  )
  (func $std/string-encoding/testUTF8DecodeNullTerminated
-  (local $0 i32)
-  (local $1 i32)
-  (local $2 i32)
-  (local $3 i32)
-  (local $4 i32)
+  (local $buf i32)
+  (local $str2 i32)
+  (local $buf2 i32)
+  (local $str3 i32)
+  (local $buf3 i32)
   (local $5 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 28
@@ -4066,9 +4066,9 @@
   global.set $~argumentsLength
   i32.const 0
   call $~lib/string/String.UTF8.encode@varargs
-  local.tee $0
+  local.tee $buf
   i32.store $0 offset=4
-  local.get $0
+  local.get $buf
   i32.const 1
   call $~lib/string/String.UTF8.decode
   local.set $5
@@ -4094,9 +4094,9 @@
   end
   global.get $~lib/memory/__stack_pointer
   i32.const 976
-  local.tee $1
+  local.tee $str2
   i32.store $0 offset=12
-  local.get $1
+  local.get $str2
   i32.const 1
   call $~lib/string/String.UTF8.byteLength
   i32.const 4
@@ -4111,15 +4111,15 @@
    unreachable
   end
   global.get $~lib/memory/__stack_pointer
-  local.get $1
+  local.get $str2
   i32.const 1
   i32.const 2
   global.set $~argumentsLength
   i32.const 0
   call $~lib/string/String.UTF8.encode@varargs
-  local.tee $2
+  local.tee $buf2
   i32.store $0 offset=16
-  local.get $2
+  local.get $buf2
   call $~lib/arraybuffer/ArrayBuffer#get:byteLength
   i32.const 4
   i32.eq
@@ -4134,9 +4134,9 @@
   end
   global.get $~lib/memory/__stack_pointer
   i32.const 1024
-  local.tee $3
+  local.tee $str3
   i32.store $0 offset=20
-  local.get $3
+  local.get $str3
   i32.const 1
   call $~lib/string/String.UTF8.byteLength
   i32.const 4
@@ -4150,7 +4150,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $2
+  local.get $buf2
   i32.const 1
   call $~lib/string/String.UTF8.decode
   local.set $5
@@ -4158,7 +4158,7 @@
   local.get $5
   i32.store $0
   local.get $5
-  local.get $3
+  local.get $str3
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -4170,15 +4170,15 @@
    unreachable
   end
   global.get $~lib/memory/__stack_pointer
-  local.get $1
+  local.get $str2
   i32.const 0
   i32.const 2
   global.set $~argumentsLength
   i32.const 0
   call $~lib/string/String.UTF8.encode@varargs
-  local.tee $4
+  local.tee $buf3
   i32.store $0 offset=24
-  local.get $4
+  local.get $buf3
   i32.const 1
   call $~lib/string/String.UTF8.decode
   local.set $5
@@ -4186,7 +4186,7 @@
   local.get $5
   i32.store $0
   local.get $5
-  local.get $3
+  local.get $str3
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -4203,9 +4203,9 @@
   global.set $~lib/memory/__stack_pointer
  )
  (func $std/string-encoding/testUTF8DecodeUnsafe
-  (local $0 i32)
-  (local $1 i32)
-  (local $2 i32)
+  (local $buf i32)
+  (local $len i32)
+  (local $ptr i32)
   (local $3 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 12
@@ -4230,7 +4230,7 @@
   global.set $~argumentsLength
   i32.const 0
   call $~lib/string/String.UTF8.encode@varargs
-  local.tee $0
+  local.tee $buf
   i32.store $0 offset=4
   global.get $std/string-encoding/str
   local.set $3
@@ -4240,10 +4240,10 @@
   local.get $3
   i32.const 0
   call $~lib/string/String.UTF8.byteLength
-  local.set $1
-  local.get $0
-  local.set $2
-  local.get $2
+  local.set $len
+  local.get $buf
+  local.set $ptr
+  local.get $ptr
   i32.const 0
   i32.const 0
   call $~lib/string/String.UTF8.decodeUnsafe
@@ -4268,8 +4268,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $2
-  local.get $1
+  local.get $ptr
+  local.get $len
   i32.const 0
   call $~lib/string/String.UTF8.decodeUnsafe
   local.set $3
@@ -4293,7 +4293,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $2
+  local.get $ptr
   i32.const 4
   i32.const 0
   call $~lib/string/String.UTF8.decodeUnsafe
@@ -4318,7 +4318,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $2
+  local.get $ptr
   i32.const 4
   i32.add
   i32.const 2
@@ -4345,7 +4345,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $2
+  local.get $ptr
   i32.const 6
   i32.add
   i32.const 4
@@ -4372,7 +4372,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $2
+  local.get $ptr
   i32.const 10
   i32.add
   i32.const 0
@@ -4399,7 +4399,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $2
+  local.get $ptr
   i32.const 4
   i32.add
   i32.const 100
@@ -4426,7 +4426,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $2
+  local.get $ptr
   i32.const 6
   i32.add
   i32.const 100
@@ -4453,7 +4453,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $2
+  local.get $ptr
   i32.const 10
   i32.add
   i32.const 100
@@ -4485,9 +4485,9 @@
   i32.add
   global.set $~lib/memory/__stack_pointer
  )
- (func $std/string-encoding/testLarge (param $0 i32)
-  (local $1 i32)
-  (local $2 i32)
+ (func $std/string-encoding/testLarge (param $str i32)
+  (local $buf8 i32)
+  (local $buf16 i32)
   (local $3 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 12
@@ -4501,15 +4501,15 @@
   i32.const 0
   i32.store $0 offset=8
   global.get $~lib/memory/__stack_pointer
-  local.get $0
+  local.get $str
   i32.const 0
   i32.const 1
   global.set $~argumentsLength
   i32.const 0
   call $~lib/string/String.UTF8.encode@varargs
-  local.tee $1
+  local.tee $buf8
   i32.store $0
-  local.get $1
+  local.get $buf8
   i32.const 0
   call $~lib/string/String.UTF8.decode
   local.set $3
@@ -4517,7 +4517,7 @@
   local.get $3
   i32.store $0 offset=4
   local.get $3
-  local.get $0
+  local.get $str
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -4529,18 +4529,18 @@
    unreachable
   end
   global.get $~lib/memory/__stack_pointer
-  local.get $0
+  local.get $str
   call $~lib/string/String.UTF16.encode
-  local.tee $2
+  local.tee $buf16
   i32.store $0 offset=8
-  local.get $2
+  local.get $buf16
   call $~lib/string/String.UTF16.decode
   local.set $3
   global.get $~lib/memory/__stack_pointer
   local.get $3
   i32.store $0 offset=4
   local.get $3
-  local.get $0
+  local.get $str
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -4614,8 +4614,8 @@
   i32.add
   global.set $~lib/memory/__stack_pointer
  )
- (func $~lib/string/String.UTF16.encode (param $0 i32) (result i32)
-  (local $1 i32)
+ (func $~lib/string/String.UTF16.encode (param $str i32) (result i32)
+  (local $buf i32)
   (local $2 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -4626,19 +4626,19 @@
   i32.const 0
   i32.store $0
   global.get $~lib/memory/__stack_pointer
-  local.get $0
+  local.get $str
   call $~lib/string/String.UTF16.byteLength
   i32.const 0
   call $~lib/rt/itcms/__new
-  local.tee $1
+  local.tee $buf
   i32.store $0
-  local.get $0
-  local.get $0
+  local.get $str
+  local.get $str
   call $~lib/string/String#get:length
-  local.get $1
+  local.get $buf
   call $~lib/string/String.UTF16.encodeUnsafe
   drop
-  local.get $1
+  local.get $buf
   local.set $2
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -4646,8 +4646,8 @@
   global.set $~lib/memory/__stack_pointer
   local.get $2
  )
- (func $~lib/string/String.UTF16.decodeUnsafe (param $0 i32) (param $1 i32) (result i32)
-  (local $2 i32)
+ (func $~lib/string/String.UTF16.decodeUnsafe (param $buf i32) (param $len i32) (result i32)
+  (local $str i32)
   (local $3 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -4658,21 +4658,21 @@
   i32.const 0
   i32.store $0
   global.get $~lib/memory/__stack_pointer
-  local.get $1
+  local.get $len
   i32.const 1
   i32.const -1
   i32.xor
   i32.and
-  local.tee $1
+  local.tee $len
   i32.const 1
   call $~lib/rt/itcms/__new
-  local.tee $2
+  local.tee $str
   i32.store $0
-  local.get $2
-  local.get $0
-  local.get $1
+  local.get $str
+  local.get $buf
+  local.get $len
   memory.copy $0 $0
-  local.get $2
+  local.get $str
   local.set $3
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -4680,8 +4680,8 @@
   global.set $~lib/memory/__stack_pointer
   local.get $3
  )
- (func $~lib/string/String.UTF8.encode (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
-  (local $3 i32)
+ (func $~lib/string/String.UTF8.encode (param $str i32) (param $nullTerminated i32) (param $errorMode i32) (result i32)
+  (local $buf i32)
   (local $4 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -4692,22 +4692,22 @@
   i32.const 0
   i32.store $0
   global.get $~lib/memory/__stack_pointer
-  local.get $0
-  local.get $1
+  local.get $str
+  local.get $nullTerminated
   call $~lib/string/String.UTF8.byteLength
   i32.const 0
   call $~lib/rt/itcms/__new
-  local.tee $3
+  local.tee $buf
   i32.store $0
-  local.get $0
-  local.get $0
+  local.get $str
+  local.get $str
   call $~lib/string/String#get:length
-  local.get $3
-  local.get $1
-  local.get $2
+  local.get $buf
+  local.get $nullTerminated
+  local.get $errorMode
   call $~lib/string/String.UTF8.encodeUnsafe
   drop
-  local.get $3
+  local.get $buf
   local.set $4
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -4715,17 +4715,17 @@
   global.set $~lib/memory/__stack_pointer
   local.get $4
  )
- (func $~lib/string/String.UTF8.decodeUnsafe (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
-  (local $3 i32)
-  (local $4 i32)
-  (local $5 i32)
-  (local $6 i32)
-  (local $7 i32)
-  (local $8 i32)
-  (local $9 i32)
-  (local $10 i32)
-  (local $11 i32)
-  (local $12 i32)
+ (func $~lib/string/String.UTF8.decodeUnsafe (param $buf i32) (param $len i32) (param $nullTerminated i32) (result i32)
+  (local $bufOff i32)
+  (local $bufEnd i32)
+  (local $str i32)
+  (local $strOff i32)
+  (local $var$7 i32)
+  (local $u0 i32)
+  (local $var$9 i32)
+  (local $var$10 i32)
+  (local $var$11 i32)
+  (local $var$12 i32)
   (local $13 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -4735,14 +4735,14 @@
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   i32.store $0
-  local.get $0
-  local.set $3
-  local.get $0
-  local.get $1
+  local.get $buf
+  local.set $bufOff
+  local.get $buf
+  local.get $len
   i32.add
-  local.set $4
-  local.get $4
-  local.get $3
+  local.set $bufEnd
+  local.get $bufEnd
+  local.get $bufOff
   i32.ge_u
   i32.eqz
   if
@@ -4754,190 +4754,190 @@
    unreachable
   end
   global.get $~lib/memory/__stack_pointer
-  local.get $1
+  local.get $len
   i32.const 1
   i32.shl
   i32.const 1
   call $~lib/rt/itcms/__new
-  local.tee $5
+  local.tee $str
   i32.store $0
-  local.get $5
-  local.set $6
+  local.get $str
+  local.set $strOff
   block $while-break|0
    loop $while-continue|0
-    local.get $3
-    local.get $4
+    local.get $bufOff
+    local.get $bufEnd
     i32.lt_u
-    local.set $7
-    local.get $7
+    local.set $var$7
+    local.get $var$7
     if
-     local.get $3
+     local.get $bufOff
      i32.load8_u $0
-     local.set $8
-     local.get $3
+     local.set $u0
+     local.get $bufOff
      i32.const 1
      i32.add
-     local.set $3
-     local.get $8
+     local.set $bufOff
+     local.get $u0
      i32.const 128
      i32.and
      i32.eqz
      if
-      local.get $2
-      local.get $8
+      local.get $nullTerminated
+      local.get $u0
       i32.eqz
       i32.and
       if
        br $while-break|0
       end
-      local.get $6
-      local.get $8
+      local.get $strOff
+      local.get $u0
       i32.store16 $0
      else
-      local.get $4
-      local.get $3
+      local.get $bufEnd
+      local.get $bufOff
       i32.eq
       if
        br $while-break|0
       end
-      local.get $3
+      local.get $bufOff
       i32.load8_u $0
       i32.const 63
       i32.and
-      local.set $9
-      local.get $3
+      local.set $var$9
+      local.get $bufOff
       i32.const 1
       i32.add
-      local.set $3
-      local.get $8
+      local.set $bufOff
+      local.get $u0
       i32.const 224
       i32.and
       i32.const 192
       i32.eq
       if
-       local.get $6
-       local.get $8
+       local.get $strOff
+       local.get $u0
        i32.const 31
        i32.and
        i32.const 6
        i32.shl
-       local.get $9
+       local.get $var$9
        i32.or
        i32.store16 $0
       else
-       local.get $4
-       local.get $3
+       local.get $bufEnd
+       local.get $bufOff
        i32.eq
        if
         br $while-break|0
        end
-       local.get $3
+       local.get $bufOff
        i32.load8_u $0
        i32.const 63
        i32.and
-       local.set $10
-       local.get $3
+       local.set $var$10
+       local.get $bufOff
        i32.const 1
        i32.add
-       local.set $3
-       local.get $8
+       local.set $bufOff
+       local.get $u0
        i32.const 240
        i32.and
        i32.const 224
        i32.eq
        if
-        local.get $8
+        local.get $u0
         i32.const 15
         i32.and
         i32.const 12
         i32.shl
-        local.get $9
+        local.get $var$9
         i32.const 6
         i32.shl
         i32.or
-        local.get $10
+        local.get $var$10
         i32.or
-        local.set $8
+        local.set $u0
        else
-        local.get $4
-        local.get $3
+        local.get $bufEnd
+        local.get $bufOff
         i32.eq
         if
          br $while-break|0
         end
-        local.get $8
+        local.get $u0
         i32.const 7
         i32.and
         i32.const 18
         i32.shl
-        local.get $9
+        local.get $var$9
         i32.const 12
         i32.shl
         i32.or
-        local.get $10
+        local.get $var$10
         i32.const 6
         i32.shl
         i32.or
-        local.get $3
+        local.get $bufOff
         i32.load8_u $0
         i32.const 63
         i32.and
         i32.or
-        local.set $8
-        local.get $3
+        local.set $u0
+        local.get $bufOff
         i32.const 1
         i32.add
-        local.set $3
+        local.set $bufOff
        end
-       local.get $8
+       local.get $u0
        i32.const 65536
        i32.lt_u
        if
-        local.get $6
-        local.get $8
+        local.get $strOff
+        local.get $u0
         i32.store16 $0
        else
-        local.get $8
+        local.get $u0
         i32.const 65536
         i32.sub
-        local.set $8
-        local.get $8
+        local.set $u0
+        local.get $u0
         i32.const 10
         i32.shr_u
         i32.const 55296
         i32.or
-        local.set $11
-        local.get $8
+        local.set $var$11
+        local.get $u0
         i32.const 1023
         i32.and
         i32.const 56320
         i32.or
-        local.set $12
-        local.get $6
-        local.get $11
-        local.get $12
+        local.set $var$12
+        local.get $strOff
+        local.get $var$11
+        local.get $var$12
         i32.const 16
         i32.shl
         i32.or
         i32.store $0
-        local.get $6
+        local.get $strOff
         i32.const 2
         i32.add
-        local.set $6
+        local.set $strOff
        end
       end
      end
-     local.get $6
+     local.get $strOff
      i32.const 2
      i32.add
-     local.set $6
+     local.set $strOff
      br $while-continue|0
     end
    end
   end
-  local.get $5
-  local.get $6
-  local.get $5
+  local.get $str
+  local.get $strOff
+  local.get $str
   i32.sub
   call $~lib/rt/itcms/__renew
   local.set $13

--- a/tests/compiler/std/string.debug.wat
+++ b/tests/compiler/std/string.debug.wat
@@ -8110,19 +8110,19 @@
    unreachable
   end
  )
- (func $~lib/string/String#split (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
-  (local $3 i32)
-  (local $4 i32)
-  (local $5 i32)
-  (local $6 i32)
-  (local $7 i32)
-  (local $8 i32)
-  (local $9 i32)
-  (local $10 i32)
-  (local $11 i32)
-  (local $12 i32)
-  (local $13 i32)
-  (local $14 i32)
+ (func $~lib/string/String#split (param $this i32) (param $separator i32) (param $limit i32) (result i32)
+  (local $len i32)
+  (local $var$4 i32)
+  (local $length i32)
+  (local $sepLen i32)
+  (local $var$7 i32)
+  (local $var$8 i32)
+  (local $var$9 i32)
+  (local $result i32)
+  (local $end i32)
+  (local $start i32)
+  (local $i i32)
+  (local $len_0 i32)
   (local $15 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 24
@@ -8133,7 +8133,7 @@
   i32.const 0
   i32.const 24
   memory.fill $0
-  local.get $2
+  local.get $limit
   i32.eqz
   if
    i32.const 0
@@ -8149,7 +8149,7 @@
    local.get $15
    return
   end
-  local.get $1
+  local.get $separator
   i32.const 0
   i32.eq
   if
@@ -8159,18 +8159,18 @@
    i32.const 4
    i32.const 0
    call $~lib/rt/__newArray
-   local.tee $3
+   local.tee $len
    i32.store $0
    global.get $~lib/memory/__stack_pointer
-   local.get $3
+   local.get $len
    i32.load $0 offset=4
-   local.tee $4
+   local.tee $var$4
    i32.store $0 offset=4
-   local.get $3
+   local.get $len
    i32.const 0
-   local.get $0
+   local.get $this
    call $~lib/array/Array<~lib/string/String>#__uset
-   local.get $3
+   local.get $len
    local.set $15
    global.get $~lib/memory/__stack_pointer
    i32.const 24
@@ -8179,23 +8179,23 @@
    local.get $15
    return
   end
-  local.get $0
+  local.get $this
   call $~lib/string/String#get:length
-  local.set $5
-  local.get $1
+  local.set $length
+  local.get $separator
   call $~lib/string/String#get:length
-  local.set $6
-  local.get $2
+  local.set $sepLen
+  local.get $limit
   i32.const 0
   i32.lt_s
   if
    global.get $~lib/builtins/i32.MAX_VALUE
-   local.set $2
+   local.set $limit
   end
-  local.get $6
+  local.get $sepLen
   i32.eqz
   if
-   local.get $5
+   local.get $length
    i32.eqz
    if
     i32.const 0
@@ -8211,68 +8211,68 @@
     local.get $15
     return
    end
-   local.get $5
-   local.tee $3
-   local.get $2
-   local.tee $4
-   local.get $3
-   local.get $4
+   local.get $length
+   local.tee $len
+   local.get $limit
+   local.tee $var$4
+   local.get $len
+   local.get $var$4
    i32.lt_s
    select
-   local.set $5
+   local.set $length
    global.get $~lib/memory/__stack_pointer
-   local.get $5
+   local.get $length
    i32.const 2
    i32.const 4
    i32.const 0
    call $~lib/rt/__newArray
-   local.tee $3
+   local.tee $len
    i32.store $0
-   local.get $3
+   local.get $len
    i32.load $0 offset=4
-   local.set $4
+   local.set $var$4
    i32.const 0
-   local.set $7
+   local.set $var$7
    loop $for-loop|0
-    local.get $7
-    local.get $5
+    local.get $var$7
+    local.get $length
     i32.lt_s
-    local.set $8
-    local.get $8
+    local.set $var$8
+    local.get $var$8
     if
      global.get $~lib/memory/__stack_pointer
      i32.const 2
      i32.const 1
      call $~lib/rt/itcms/__new
-     local.tee $9
+     local.tee $var$9
      i32.store $0 offset=8
-     local.get $9
-     local.get $0
-     local.get $7
+     local.get $var$9
+     local.get $this
+     local.get $var$7
      i32.const 1
      i32.shl
      i32.add
      i32.load16_u $0
      i32.store16 $0
-     local.get $4
-     local.get $7
+     local.get $var$4
+     local.get $var$7
      i32.const 2
      i32.shl
      i32.add
-     local.get $9
+     local.get $var$9
      i32.store $0
-     local.get $3
-     local.get $9
+     local.get $len
+     local.get $var$9
      i32.const 1
      call $~lib/rt/itcms/__link
-     local.get $7
+     local.get $var$7
      i32.const 1
      i32.add
-     local.set $7
+     local.set $var$7
      br $for-loop|0
     end
    end
-   local.get $3
+   local.get $len
    local.set $15
    global.get $~lib/memory/__stack_pointer
    i32.const 24
@@ -8281,7 +8281,7 @@
    local.get $15
    return
   else
-   local.get $5
+   local.get $length
    i32.eqz
    if
     global.get $~lib/memory/__stack_pointer
@@ -8290,13 +8290,13 @@
     i32.const 4
     i32.const 0
     call $~lib/rt/__newArray
-    local.tee $4
+    local.tee $var$4
     i32.store $0 offset=4
-    local.get $4
+    local.get $var$4
     i32.load $0 offset=4
     i32.const 688
     i32.store $0
-    local.get $4
+    local.get $var$4
     local.set $15
     global.get $~lib/memory/__stack_pointer
     i32.const 24
@@ -8312,57 +8312,57 @@
   i32.const 4
   i32.const 0
   call $~lib/rt/__newArray
-  local.tee $10
+  local.tee $result
   i32.store $0 offset=12
   i32.const 0
-  local.set $11
+  local.set $end
   i32.const 0
-  local.set $12
+  local.set $start
   i32.const 0
-  local.set $13
+  local.set $i
   loop $while-continue|1
-   local.get $0
-   local.get $1
-   local.get $12
+   local.get $this
+   local.get $separator
+   local.get $start
    call $~lib/string/String#indexOf
-   local.tee $11
+   local.tee $end
    i32.const -1
    i32.xor
-   local.set $4
-   local.get $4
+   local.set $var$4
+   local.get $var$4
    if
-    local.get $11
-    local.get $12
+    local.get $end
+    local.get $start
     i32.sub
-    local.set $3
-    local.get $3
+    local.set $len
+    local.get $len
     i32.const 0
     i32.gt_s
     if
      global.get $~lib/memory/__stack_pointer
-     local.get $3
+     local.get $len
      i32.const 1
      i32.shl
      i32.const 1
      call $~lib/rt/itcms/__new
-     local.tee $7
+     local.tee $var$7
      i32.store $0 offset=16
-     local.get $7
-     local.get $0
-     local.get $12
+     local.get $var$7
+     local.get $this
+     local.get $start
      i32.const 1
      i32.shl
      i32.add
-     local.get $3
+     local.get $len
      i32.const 1
      i32.shl
      memory.copy $0 $0
-     local.get $10
-     local.get $7
+     local.get $result
+     local.get $var$7
      call $~lib/array/Array<~lib/string/String>#push
      drop
     else
-     local.get $10
+     local.get $result
      i32.const 688
      local.set $15
      global.get $~lib/memory/__stack_pointer
@@ -8372,14 +8372,14 @@
      call $~lib/array/Array<~lib/string/String>#push
      drop
     end
-    local.get $13
+    local.get $i
     i32.const 1
     i32.add
-    local.tee $13
-    local.get $2
+    local.tee $i
+    local.get $limit
     i32.eq
     if
-     local.get $10
+     local.get $result
      local.set $15
      global.get $~lib/memory/__stack_pointer
      i32.const 24
@@ -8388,21 +8388,21 @@
      local.get $15
      return
     end
-    local.get $11
-    local.get $6
+    local.get $end
+    local.get $sepLen
     i32.add
-    local.set $12
+    local.set $start
     br $while-continue|1
    end
   end
-  local.get $12
+  local.get $start
   i32.eqz
   if
-   local.get $10
-   local.get $0
+   local.get $result
+   local.get $this
    call $~lib/array/Array<~lib/string/String>#push
    drop
-   local.get $10
+   local.get $result
    local.set $15
    global.get $~lib/memory/__stack_pointer
    i32.const 24
@@ -8411,38 +8411,38 @@
    local.get $15
    return
   end
-  local.get $5
-  local.get $12
+  local.get $length
+  local.get $start
   i32.sub
-  local.set $14
-  local.get $14
+  local.set $len_0
+  local.get $len_0
   i32.const 0
   i32.gt_s
   if
    global.get $~lib/memory/__stack_pointer
-   local.get $14
+   local.get $len_0
    i32.const 1
    i32.shl
    i32.const 1
    call $~lib/rt/itcms/__new
-   local.tee $4
+   local.tee $var$4
    i32.store $0 offset=4
-   local.get $4
-   local.get $0
-   local.get $12
+   local.get $var$4
+   local.get $this
+   local.get $start
    i32.const 1
    i32.shl
    i32.add
-   local.get $14
+   local.get $len_0
    i32.const 1
    i32.shl
    memory.copy $0 $0
-   local.get $10
-   local.get $4
+   local.get $result
+   local.get $var$4
    call $~lib/array/Array<~lib/string/String>#push
    drop
   else
-   local.get $10
+   local.get $result
    i32.const 688
    local.set $15
    global.get $~lib/memory/__stack_pointer
@@ -8452,7 +8452,7 @@
    call $~lib/array/Array<~lib/string/String>#push
    drop
   end
-  local.get $10
+  local.get $result
   local.set $15
   global.get $~lib/memory/__stack_pointer
   i32.const 24
@@ -24248,8 +24248,8 @@
   i32.add
   global.set $~lib/memory/__stack_pointer
  )
- (func $~lib/string/String#charAt (param $0 i32) (param $1 i32) (result i32)
-  (local $2 i32)
+ (func $~lib/string/String#charAt (param $this i32) (param $pos i32) (result i32)
+  (local $out i32)
   (local $3 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -24259,8 +24259,8 @@
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   i32.store $0
-  local.get $1
-  local.get $0
+  local.get $pos
+  local.get $this
   call $~lib/string/String#get:length
   i32.ge_u
   if
@@ -24277,17 +24277,17 @@
   i32.const 2
   i32.const 1
   call $~lib/rt/itcms/__new
-  local.tee $2
+  local.tee $out
   i32.store $0
-  local.get $2
-  local.get $0
-  local.get $1
+  local.get $out
+  local.get $this
+  local.get $pos
   i32.const 1
   i32.shl
   i32.add
   i32.load16_u $0
   i32.store16 $0
-  local.get $2
+  local.get $out
   local.set $3
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -24295,9 +24295,9 @@
   global.set $~lib/memory/__stack_pointer
   local.get $3
  )
- (func $~lib/string/String.fromCharCode (param $0 i32) (param $1 i32) (result i32)
-  (local $2 i32)
-  (local $3 i32)
+ (func $~lib/string/String.fromCharCode (param $unit i32) (param $surr i32) (result i32)
+  (local $hasSur i32)
+  (local $out i32)
   (local $4 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -24307,28 +24307,28 @@
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   i32.store $0
-  local.get $1
+  local.get $surr
   i32.const 0
   i32.gt_s
-  local.set $2
+  local.set $hasSur
   global.get $~lib/memory/__stack_pointer
   i32.const 2
-  local.get $2
+  local.get $hasSur
   i32.shl
   i32.const 1
   call $~lib/rt/itcms/__new
-  local.tee $3
+  local.tee $out
   i32.store $0
-  local.get $3
-  local.get $0
+  local.get $out
+  local.get $unit
   i32.store16 $0
-  local.get $2
+  local.get $hasSur
   if
-   local.get $3
-   local.get $1
+   local.get $out
+   local.get $surr
    i32.store16 $0 offset=2
   end
-  local.get $3
+  local.get $out
   local.set $4
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -24336,10 +24336,10 @@
   global.set $~lib/memory/__stack_pointer
   local.get $4
  )
- (func $~lib/rt/__newArray (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
-  (local $4 i32)
-  (local $5 i32)
-  (local $6 i32)
+ (func $~lib/rt/__newArray (param $length i32) (param $alignLog2 i32) (param $id i32) (param $data i32) (result i32)
+  (local $bufferSize i32)
+  (local $buffer i32)
+  (local $array i32)
   (local $7 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -24349,38 +24349,38 @@
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   i32.store $0
-  local.get $0
-  local.get $1
+  local.get $length
+  local.get $alignLog2
   i32.shl
-  local.set $4
+  local.set $bufferSize
   global.get $~lib/memory/__stack_pointer
-  local.get $4
+  local.get $bufferSize
   i32.const 0
-  local.get $3
+  local.get $data
   call $~lib/rt/__newBuffer
-  local.tee $5
+  local.tee $buffer
   i32.store $0
   i32.const 16
-  local.get $2
+  local.get $id
   call $~lib/rt/itcms/__new
-  local.set $6
-  local.get $6
-  local.get $5
+  local.set $array
+  local.get $array
+  local.get $buffer
   i32.store $0
-  local.get $6
-  local.get $5
+  local.get $array
+  local.get $buffer
   i32.const 0
   call $~lib/rt/itcms/__link
-  local.get $6
-  local.get $5
+  local.get $array
+  local.get $buffer
   i32.store $0 offset=4
-  local.get $6
-  local.get $4
+  local.get $array
+  local.get $bufferSize
   i32.store $0 offset=8
-  local.get $6
-  local.get $0
+  local.get $array
+  local.get $length
   i32.store $0 offset=12
-  local.get $6
+  local.get $array
   local.set $7
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -24388,12 +24388,12 @@
   global.set $~lib/memory/__stack_pointer
   local.get $7
  )
- (func $~lib/string/String.fromCharCodes (param $0 i32) (result i32)
-  (local $1 i32)
-  (local $2 i32)
-  (local $3 i32)
-  (local $4 i32)
-  (local $5 i32)
+ (func $~lib/string/String.fromCharCodes (param $units i32) (result i32)
+  (local $length i32)
+  (local $out i32)
+  (local $ptr i32)
+  (local $var$4 i32)
+  (local $var$5 i32)
   (local $6 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -24403,49 +24403,49 @@
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   i32.store $0
-  local.get $0
+  local.get $units
   call $~lib/array/Array<i32>#get:length
-  local.set $1
+  local.set $length
   global.get $~lib/memory/__stack_pointer
-  local.get $1
+  local.get $length
   i32.const 1
   i32.shl
   i32.const 1
   call $~lib/rt/itcms/__new
-  local.tee $2
+  local.tee $out
   i32.store $0
-  local.get $0
+  local.get $units
   i32.load $0 offset=4
-  local.set $3
+  local.set $ptr
   i32.const 0
-  local.set $4
+  local.set $var$4
   loop $for-loop|0
-   local.get $4
-   local.get $1
+   local.get $var$4
+   local.get $length
    i32.lt_s
-   local.set $5
-   local.get $5
+   local.set $var$5
+   local.get $var$5
    if
-    local.get $2
-    local.get $4
+    local.get $out
+    local.get $var$4
     i32.const 1
     i32.shl
     i32.add
-    local.get $3
-    local.get $4
+    local.get $ptr
+    local.get $var$4
     i32.const 2
     i32.shl
     i32.add
     i32.load $0
     i32.store16 $0
-    local.get $4
+    local.get $var$4
     i32.const 1
     i32.add
-    local.set $4
+    local.set $var$4
     br $for-loop|0
    end
   end
-  local.get $2
+  local.get $out
   local.set $6
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -24453,11 +24453,11 @@
   global.set $~lib/memory/__stack_pointer
   local.get $6
  )
- (func $~lib/string/String.fromCodePoint (param $0 i32) (result i32)
-  (local $1 i32)
-  (local $2 i32)
-  (local $3 i32)
-  (local $4 i32)
+ (func $~lib/string/String.fromCodePoint (param $code i32) (result i32)
+  (local $hasSur i32)
+  (local $out i32)
+  (local $var$3 i32)
+  (local $var$4 i32)
   (local $5 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -24467,26 +24467,26 @@
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   i32.store $0
-  local.get $0
+  local.get $code
   i32.const 65535
   i32.gt_u
-  local.set $1
+  local.set $hasSur
   global.get $~lib/memory/__stack_pointer
   i32.const 2
-  local.get $1
+  local.get $hasSur
   i32.shl
   i32.const 1
   call $~lib/rt/itcms/__new
-  local.tee $2
+  local.tee $out
   i32.store $0
-  local.get $1
+  local.get $hasSur
   i32.eqz
   if
-   local.get $2
-   local.get $0
+   local.get $out
+   local.get $code
    i32.store16 $0
   else
-   local.get $0
+   local.get $code
    i32.const 1114111
    i32.le_u
    i32.eqz
@@ -24498,31 +24498,31 @@
     call $~lib/builtins/abort
     unreachable
    end
-   local.get $0
+   local.get $code
    i32.const 65536
    i32.sub
-   local.set $0
-   local.get $0
+   local.set $code
+   local.get $code
    i32.const 1023
    i32.and
    i32.const 56320
    i32.or
-   local.set $3
-   local.get $0
+   local.set $var$3
+   local.get $code
    i32.const 10
    i32.shr_u
    i32.const 55296
    i32.or
-   local.set $4
-   local.get $2
-   local.get $4
-   local.get $3
+   local.set $var$4
+   local.get $out
+   local.get $var$4
+   local.get $var$3
    i32.const 16
    i32.shl
    i32.or
    i32.store $0
   end
-  local.get $2
+  local.get $out
   local.set $5
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -24530,15 +24530,15 @@
   global.set $~lib/memory/__stack_pointer
   local.get $5
  )
- (func $~lib/string/String#padStart (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
-  (local $3 i32)
-  (local $4 i32)
-  (local $5 i32)
-  (local $6 i32)
-  (local $7 i32)
-  (local $8 i32)
-  (local $9 i32)
-  (local $10 i32)
+ (func $~lib/string/String#padStart (param $this i32) (param $length i32) (param $pad i32) (result i32)
+  (local $thisSize i32)
+  (local $targetSize i32)
+  (local $padSize i32)
+  (local $prependSize i32)
+  (local $out i32)
+  (local $var$8 i32)
+  (local $var$9 i32)
+  (local $var$10 i32)
   (local $11 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -24548,31 +24548,31 @@
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   i32.store $0
-  local.get $0
+  local.get $this
   call $~lib/string/String#get:length
   i32.const 1
   i32.shl
-  local.set $3
-  local.get $1
+  local.set $thisSize
+  local.get $length
   i32.const 1
   i32.shl
-  local.set $4
-  local.get $2
+  local.set $targetSize
+  local.get $pad
   call $~lib/string/String#get:length
   i32.const 1
   i32.shl
-  local.set $5
-  local.get $4
-  local.get $3
+  local.set $padSize
+  local.get $targetSize
+  local.get $thisSize
   i32.lt_u
   if (result i32)
    i32.const 1
   else
-   local.get $5
+   local.get $padSize
    i32.eqz
   end
   if
-   local.get $0
+   local.get $this
    local.set $11
    global.get $~lib/memory/__stack_pointer
    i32.const 4
@@ -24581,58 +24581,58 @@
    local.get $11
    return
   end
-  local.get $4
-  local.get $3
+  local.get $targetSize
+  local.get $thisSize
   i32.sub
-  local.set $6
+  local.set $prependSize
   global.get $~lib/memory/__stack_pointer
-  local.get $4
+  local.get $targetSize
   i32.const 1
   call $~lib/rt/itcms/__new
-  local.tee $7
+  local.tee $out
   i32.store $0
-  local.get $6
-  local.get $5
+  local.get $prependSize
+  local.get $padSize
   i32.gt_u
   if
-   local.get $6
+   local.get $prependSize
    i32.const 2
    i32.sub
-   local.get $5
+   local.get $padSize
    i32.div_u
-   local.set $8
-   local.get $8
-   local.get $5
+   local.set $var$8
+   local.get $var$8
+   local.get $padSize
    i32.mul
-   local.set $9
-   local.get $6
-   local.get $9
+   local.set $var$9
+   local.get $prependSize
+   local.get $var$9
    i32.sub
-   local.set $10
-   local.get $7
-   local.get $2
-   local.get $5
-   local.get $8
+   local.set $var$10
+   local.get $out
+   local.get $pad
+   local.get $padSize
+   local.get $var$8
    call $~lib/memory/memory.repeat
-   local.get $7
-   local.get $9
+   local.get $out
+   local.get $var$9
    i32.add
-   local.get $2
-   local.get $10
+   local.get $pad
+   local.get $var$10
    memory.copy $0 $0
   else
-   local.get $7
-   local.get $2
-   local.get $6
+   local.get $out
+   local.get $pad
+   local.get $prependSize
    memory.copy $0 $0
   end
-  local.get $7
-  local.get $6
+  local.get $out
+  local.get $prependSize
   i32.add
-  local.get $0
-  local.get $3
+  local.get $this
+  local.get $thisSize
   memory.copy $0 $0
-  local.get $7
+  local.get $out
   local.set $11
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -24640,15 +24640,15 @@
   global.set $~lib/memory/__stack_pointer
   local.get $11
  )
- (func $~lib/string/String#padEnd (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
-  (local $3 i32)
-  (local $4 i32)
-  (local $5 i32)
-  (local $6 i32)
-  (local $7 i32)
-  (local $8 i32)
-  (local $9 i32)
-  (local $10 i32)
+ (func $~lib/string/String#padEnd (param $this i32) (param $length i32) (param $pad i32) (result i32)
+  (local $thisSize i32)
+  (local $targetSize i32)
+  (local $padSize i32)
+  (local $appendSize i32)
+  (local $out i32)
+  (local $var$8 i32)
+  (local $var$9 i32)
+  (local $var$10 i32)
   (local $11 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -24658,31 +24658,31 @@
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   i32.store $0
-  local.get $0
+  local.get $this
   call $~lib/string/String#get:length
   i32.const 1
   i32.shl
-  local.set $3
-  local.get $1
+  local.set $thisSize
+  local.get $length
   i32.const 1
   i32.shl
-  local.set $4
-  local.get $2
+  local.set $targetSize
+  local.get $pad
   call $~lib/string/String#get:length
   i32.const 1
   i32.shl
-  local.set $5
-  local.get $4
-  local.get $3
+  local.set $padSize
+  local.get $targetSize
+  local.get $thisSize
   i32.lt_u
   if (result i32)
    i32.const 1
   else
-   local.get $5
+   local.get $padSize
    i32.eqz
   end
   if
-   local.get $0
+   local.get $this
    local.set $11
    global.get $~lib/memory/__stack_pointer
    i32.const 4
@@ -24691,62 +24691,62 @@
    local.get $11
    return
   end
-  local.get $4
-  local.get $3
+  local.get $targetSize
+  local.get $thisSize
   i32.sub
-  local.set $6
+  local.set $appendSize
   global.get $~lib/memory/__stack_pointer
-  local.get $4
+  local.get $targetSize
   i32.const 1
   call $~lib/rt/itcms/__new
-  local.tee $7
+  local.tee $out
   i32.store $0
-  local.get $7
-  local.get $0
-  local.get $3
+  local.get $out
+  local.get $this
+  local.get $thisSize
   memory.copy $0 $0
-  local.get $6
-  local.get $5
+  local.get $appendSize
+  local.get $padSize
   i32.gt_u
   if
-   local.get $6
+   local.get $appendSize
    i32.const 2
    i32.sub
-   local.get $5
+   local.get $padSize
    i32.div_u
-   local.set $8
-   local.get $8
-   local.get $5
+   local.set $var$8
+   local.get $var$8
+   local.get $padSize
    i32.mul
-   local.set $9
-   local.get $6
-   local.get $9
+   local.set $var$9
+   local.get $appendSize
+   local.get $var$9
    i32.sub
-   local.set $10
-   local.get $7
-   local.get $3
+   local.set $var$10
+   local.get $out
+   local.get $thisSize
    i32.add
-   local.get $2
-   local.get $5
-   local.get $8
+   local.get $pad
+   local.get $padSize
+   local.get $var$8
    call $~lib/memory/memory.repeat
-   local.get $7
-   local.get $3
+   local.get $out
+   local.get $thisSize
    i32.add
-   local.get $9
+   local.get $var$9
    i32.add
-   local.get $2
-   local.get $10
+   local.get $pad
+   local.get $var$10
    memory.copy $0 $0
   else
-   local.get $7
-   local.get $3
+   local.get $out
+   local.get $thisSize
    i32.add
-   local.get $2
-   local.get $6
+   local.get $pad
+   local.get $appendSize
    memory.copy $0 $0
   end
-  local.get $7
+  local.get $out
   local.set $11
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -24754,11 +24754,11 @@
   global.set $~lib/memory/__stack_pointer
   local.get $11
  )
- (func $~lib/string/String#trimStart (param $0 i32) (result i32)
-  (local $1 i32)
-  (local $2 i32)
-  (local $3 i32)
-  (local $4 i32)
+ (func $~lib/string/String#trimStart (param $this i32) (result i32)
+  (local $size i32)
+  (local $offset i32)
+  (local $var$3 i32)
+  (local $out i32)
   (local $5 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -24768,40 +24768,40 @@
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   i32.store $0
-  local.get $0
+  local.get $this
   call $~lib/string/String#get:length
   i32.const 1
   i32.shl
-  local.set $1
+  local.set $size
   i32.const 0
-  local.set $2
+  local.set $offset
   loop $while-continue|0
-   local.get $2
-   local.get $1
+   local.get $offset
+   local.get $size
    i32.lt_u
    if (result i32)
-    local.get $0
-    local.get $2
+    local.get $this
+    local.get $offset
     i32.add
     i32.load16_u $0
     call $~lib/util/string/isSpace
    else
     i32.const 0
    end
-   local.set $3
-   local.get $3
+   local.set $var$3
+   local.get $var$3
    if
-    local.get $2
+    local.get $offset
     i32.const 2
     i32.add
-    local.set $2
+    local.set $offset
     br $while-continue|0
    end
   end
-  local.get $2
+  local.get $offset
   i32.eqz
   if
-   local.get $0
+   local.get $this
    local.set $5
    global.get $~lib/memory/__stack_pointer
    i32.const 4
@@ -24810,11 +24810,11 @@
    local.get $5
    return
   end
-  local.get $1
-  local.get $2
+  local.get $size
+  local.get $offset
   i32.sub
-  local.set $1
-  local.get $1
+  local.set $size
+  local.get $size
   i32.eqz
   if
    i32.const 688
@@ -24827,18 +24827,18 @@
    return
   end
   global.get $~lib/memory/__stack_pointer
-  local.get $1
+  local.get $size
   i32.const 1
   call $~lib/rt/itcms/__new
-  local.tee $4
+  local.tee $out
   i32.store $0
-  local.get $4
-  local.get $0
-  local.get $2
+  local.get $out
+  local.get $this
+  local.get $offset
   i32.add
-  local.get $1
+  local.get $size
   memory.copy $0 $0
-  local.get $4
+  local.get $out
   local.set $5
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -24846,11 +24846,11 @@
   global.set $~lib/memory/__stack_pointer
   local.get $5
  )
- (func $~lib/string/String#trimEnd (param $0 i32) (result i32)
-  (local $1 i32)
-  (local $2 i32)
-  (local $3 i32)
-  (local $4 i32)
+ (func $~lib/string/String#trimEnd (param $this i32) (result i32)
+  (local $originalSize i32)
+  (local $size i32)
+  (local $var$3 i32)
+  (local $out i32)
   (local $5 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -24860,18 +24860,18 @@
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   i32.store $0
-  local.get $0
+  local.get $this
   call $~lib/string/String#get:length
   i32.const 1
   i32.shl
-  local.set $1
-  local.get $1
-  local.set $2
+  local.set $originalSize
+  local.get $originalSize
+  local.set $size
   loop $while-continue|0
-   local.get $2
+   local.get $size
    if (result i32)
-    local.get $0
-    local.get $2
+    local.get $this
+    local.get $size
     i32.add
     i32.const 2
     i32.sub
@@ -24880,17 +24880,17 @@
    else
     i32.const 0
    end
-   local.set $3
-   local.get $3
+   local.set $var$3
+   local.get $var$3
    if
-    local.get $2
+    local.get $size
     i32.const 2
     i32.sub
-    local.set $2
+    local.set $size
     br $while-continue|0
    end
   end
-  local.get $2
+  local.get $size
   i32.eqz
   if
    i32.const 688
@@ -24902,11 +24902,11 @@
    local.get $5
    return
   end
-  local.get $2
-  local.get $1
+  local.get $size
+  local.get $originalSize
   i32.eq
   if
-   local.get $0
+   local.get $this
    local.set $5
    global.get $~lib/memory/__stack_pointer
    i32.const 4
@@ -24916,16 +24916,16 @@
    return
   end
   global.get $~lib/memory/__stack_pointer
-  local.get $2
+  local.get $size
   i32.const 1
   call $~lib/rt/itcms/__new
-  local.tee $4
+  local.tee $out
   i32.store $0
-  local.get $4
-  local.get $0
-  local.get $2
+  local.get $out
+  local.get $this
+  local.get $size
   memory.copy $0 $0
-  local.get $4
+  local.get $out
   local.set $5
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -24933,12 +24933,12 @@
   global.set $~lib/memory/__stack_pointer
   local.get $5
  )
- (func $~lib/string/String#trim (param $0 i32) (result i32)
-  (local $1 i32)
-  (local $2 i32)
-  (local $3 i32)
-  (local $4 i32)
-  (local $5 i32)
+ (func $~lib/string/String#trim (param $this i32) (result i32)
+  (local $len i32)
+  (local $size i32)
+  (local $var$3 i32)
+  (local $offset i32)
+  (local $out i32)
   (local $6 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -24948,18 +24948,18 @@
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   i32.store $0
-  local.get $0
+  local.get $this
   call $~lib/string/String#get:length
-  local.set $1
-  local.get $1
+  local.set $len
+  local.get $len
   i32.const 1
   i32.shl
-  local.set $2
+  local.set $size
   loop $while-continue|0
-   local.get $2
+   local.get $size
    if (result i32)
-    local.get $0
-    local.get $2
+    local.get $this
+    local.get $size
     i32.add
     i32.const 2
     i32.sub
@@ -24968,46 +24968,46 @@
    else
     i32.const 0
    end
-   local.set $3
-   local.get $3
+   local.set $var$3
+   local.get $var$3
    if
-    local.get $2
+    local.get $size
     i32.const 2
     i32.sub
-    local.set $2
+    local.set $size
     br $while-continue|0
    end
   end
   i32.const 0
-  local.set $4
+  local.set $offset
   loop $while-continue|1
-   local.get $4
-   local.get $2
+   local.get $offset
+   local.get $size
    i32.lt_u
    if (result i32)
-    local.get $0
-    local.get $4
+    local.get $this
+    local.get $offset
     i32.add
     i32.load16_u $0
     call $~lib/util/string/isSpace
    else
     i32.const 0
    end
-   local.set $3
-   local.get $3
+   local.set $var$3
+   local.get $var$3
    if
-    local.get $4
+    local.get $offset
     i32.const 2
     i32.add
-    local.set $4
-    local.get $2
+    local.set $offset
+    local.get $size
     i32.const 2
     i32.sub
-    local.set $2
+    local.set $size
     br $while-continue|1
    end
   end
-  local.get $2
+  local.get $size
   i32.eqz
   if
    i32.const 688
@@ -25019,11 +25019,11 @@
    local.get $6
    return
   end
-  local.get $4
+  local.get $offset
   i32.eqz
   if (result i32)
-   local.get $2
-   local.get $1
+   local.get $size
+   local.get $len
    i32.const 1
    i32.shl
    i32.eq
@@ -25031,7 +25031,7 @@
    i32.const 0
   end
   if
-   local.get $0
+   local.get $this
    local.set $6
    global.get $~lib/memory/__stack_pointer
    i32.const 4
@@ -25041,18 +25041,18 @@
    return
   end
   global.get $~lib/memory/__stack_pointer
-  local.get $2
+  local.get $size
   i32.const 1
   call $~lib/rt/itcms/__new
-  local.tee $5
+  local.tee $out
   i32.store $0
-  local.get $5
-  local.get $0
-  local.get $4
+  local.get $out
+  local.get $this
+  local.get $offset
   i32.add
-  local.get $2
+  local.get $size
   memory.copy $0 $0
-  local.get $5
+  local.get $out
   local.set $6
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -25060,11 +25060,11 @@
   global.set $~lib/memory/__stack_pointer
   local.get $6
  )
- (func $~lib/string/String#concat (param $0 i32) (param $1 i32) (result i32)
-  (local $2 i32)
-  (local $3 i32)
-  (local $4 i32)
-  (local $5 i32)
+ (func $~lib/string/String#concat (param $this i32) (param $other i32) (result i32)
+  (local $thisSize i32)
+  (local $otherSize i32)
+  (local $outSize i32)
+  (local $out i32)
   (local $6 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -25074,21 +25074,21 @@
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   i32.store $0
-  local.get $0
+  local.get $this
   call $~lib/string/String#get:length
   i32.const 1
   i32.shl
-  local.set $2
-  local.get $1
+  local.set $thisSize
+  local.get $other
   call $~lib/string/String#get:length
   i32.const 1
   i32.shl
-  local.set $3
-  local.get $2
-  local.get $3
+  local.set $otherSize
+  local.get $thisSize
+  local.get $otherSize
   i32.add
-  local.set $4
-  local.get $4
+  local.set $outSize
+  local.get $outSize
   i32.const 0
   i32.eq
   if
@@ -25102,22 +25102,22 @@
    return
   end
   global.get $~lib/memory/__stack_pointer
-  local.get $4
+  local.get $outSize
   i32.const 1
   call $~lib/rt/itcms/__new
-  local.tee $5
+  local.tee $out
   i32.store $0
-  local.get $5
-  local.get $0
-  local.get $2
+  local.get $out
+  local.get $this
+  local.get $thisSize
   memory.copy $0 $0
-  local.get $5
-  local.get $2
+  local.get $out
+  local.get $thisSize
   i32.add
-  local.get $1
-  local.get $3
+  local.get $other
+  local.get $otherSize
   memory.copy $0 $0
-  local.get $5
+  local.get $out
   local.set $6
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -25125,9 +25125,9 @@
   global.set $~lib/memory/__stack_pointer
   local.get $6
  )
- (func $~lib/string/String#repeat (param $0 i32) (param $1 i32) (result i32)
-  (local $2 i32)
-  (local $3 i32)
+ (func $~lib/string/String#repeat (param $this i32) (param $count i32) (result i32)
+  (local $length i32)
+  (local $out i32)
   (local $4 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -25137,18 +25137,18 @@
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   i32.store $0
-  local.get $0
+  local.get $this
   call $~lib/string/String#get:length
-  local.set $2
-  local.get $1
+  local.set $length
+  local.get $count
   i32.const 0
   i32.lt_s
   if (result i32)
    i32.const 1
   else
-   local.get $2
+   local.get $length
    i64.extend_i32_s
-   local.get $1
+   local.get $count
    i64.extend_i32_s
    i64.mul
    i64.const 1
@@ -25164,13 +25164,13 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $1
+  local.get $count
   i32.const 0
   i32.eq
   if (result i32)
    i32.const 1
   else
-   local.get $2
+   local.get $length
    i32.eqz
   end
   if
@@ -25183,11 +25183,11 @@
    local.get $4
    return
   end
-  local.get $1
+  local.get $count
   i32.const 1
   i32.eq
   if
-   local.get $0
+   local.get $this
    local.set $4
    global.get $~lib/memory/__stack_pointer
    i32.const 4
@@ -25197,23 +25197,23 @@
    return
   end
   global.get $~lib/memory/__stack_pointer
-  local.get $2
-  local.get $1
+  local.get $length
+  local.get $count
   i32.mul
   i32.const 1
   i32.shl
   i32.const 1
   call $~lib/rt/itcms/__new
-  local.tee $3
+  local.tee $out
   i32.store $0
-  local.get $3
-  local.get $0
-  local.get $2
+  local.get $out
+  local.get $this
+  local.get $length
   i32.const 1
   i32.shl
-  local.get $1
+  local.get $count
   call $~lib/memory/memory.repeat
-  local.get $3
+  local.get $out
   local.set $4
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -25221,13 +25221,13 @@
   global.set $~lib/memory/__stack_pointer
   local.get $4
  )
- (func $~lib/string/String#replace (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
-  (local $3 i32)
-  (local $4 i32)
-  (local $5 i32)
-  (local $6 i32)
-  (local $7 i32)
-  (local $8 i32)
+ (func $~lib/string/String#replace (param $this i32) (param $search i32) (param $replacement i32) (result i32)
+  (local $len i32)
+  (local $slen i32)
+  (local $index i32)
+  (local $var$6 i32)
+  (local $var$7 i32)
+  (local $var$8 i32)
   (local $9 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -25237,26 +25237,26 @@
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   i32.store $0
-  local.get $0
+  local.get $this
   call $~lib/string/String#get:length
-  local.set $3
-  local.get $1
+  local.set $len
+  local.get $search
   call $~lib/string/String#get:length
-  local.set $4
-  local.get $3
-  local.get $4
+  local.set $slen
+  local.get $len
+  local.get $slen
   i32.le_u
   if
-   local.get $3
-   local.get $4
+   local.get $len
+   local.get $slen
    i32.lt_u
    if (result i32)
-    local.get $0
+    local.get $this
    else
-    local.get $2
-    local.get $0
-    local.get $1
-    local.get $0
+    local.get $replacement
+    local.get $this
+    local.get $search
+    local.get $this
     call $~lib/string/String.__eq
     select
    end
@@ -25268,73 +25268,73 @@
    local.get $9
    return
   end
-  local.get $0
-  local.get $1
+  local.get $this
+  local.get $search
   i32.const 0
   call $~lib/string/String#indexOf
-  local.set $5
-  local.get $5
+  local.set $index
+  local.get $index
   i32.const -1
   i32.xor
   if
-   local.get $2
+   local.get $replacement
    call $~lib/string/String#get:length
-   local.set $6
-   local.get $3
-   local.get $4
+   local.set $var$6
+   local.get $len
+   local.get $slen
    i32.sub
-   local.set $3
-   local.get $3
-   local.get $6
+   local.set $len
+   local.get $len
+   local.get $var$6
    i32.add
-   local.set $7
-   local.get $7
+   local.set $var$7
+   local.get $var$7
    if
     global.get $~lib/memory/__stack_pointer
-    local.get $7
+    local.get $var$7
     i32.const 1
     i32.shl
     i32.const 1
     call $~lib/rt/itcms/__new
-    local.tee $8
+    local.tee $var$8
     i32.store $0
-    local.get $8
-    local.get $0
-    local.get $5
+    local.get $var$8
+    local.get $this
+    local.get $index
     i32.const 1
     i32.shl
     memory.copy $0 $0
-    local.get $8
-    local.get $5
+    local.get $var$8
+    local.get $index
     i32.const 1
     i32.shl
     i32.add
-    local.get $2
-    local.get $6
+    local.get $replacement
+    local.get $var$6
     i32.const 1
     i32.shl
     memory.copy $0 $0
-    local.get $8
-    local.get $5
-    local.get $6
+    local.get $var$8
+    local.get $index
+    local.get $var$6
     i32.add
     i32.const 1
     i32.shl
     i32.add
-    local.get $0
-    local.get $5
-    local.get $4
+    local.get $this
+    local.get $index
+    local.get $slen
     i32.add
     i32.const 1
     i32.shl
     i32.add
-    local.get $3
-    local.get $5
+    local.get $len
+    local.get $index
     i32.sub
     i32.const 1
     i32.shl
     memory.copy $0 $0
-    local.get $8
+    local.get $var$8
     local.set $9
     global.get $~lib/memory/__stack_pointer
     i32.const 4
@@ -25344,7 +25344,7 @@
     return
    end
   end
-  local.get $0
+  local.get $this
   local.set $9
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -25352,20 +25352,20 @@
   global.set $~lib/memory/__stack_pointer
   local.get $9
  )
- (func $~lib/string/String#replaceAll (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
-  (local $3 i32)
-  (local $4 i32)
-  (local $5 i32)
-  (local $6 i32)
-  (local $7 i32)
-  (local $8 i32)
-  (local $9 i32)
-  (local $10 i32)
-  (local $11 i32)
-  (local $12 i32)
-  (local $13 i32)
-  (local $14 i32)
-  (local $15 i32)
+ (func $~lib/string/String#replaceAll (param $this i32) (param $search i32) (param $replacement i32) (result i32)
+  (local $thisLen i32)
+  (local $searchLen i32)
+  (local $replaceLen i32)
+  (local $var$6 i32)
+  (local $chunk i32)
+  (local $var$8 i32)
+  (local $var$9 i32)
+  (local $var$10 i32)
+  (local $prev i32)
+  (local $next i32)
+  (local $out i32)
+  (local $offset i32)
+  (local $outSize i32)
   (local $16 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 8
@@ -25375,26 +25375,26 @@
   global.get $~lib/memory/__stack_pointer
   i64.const 0
   i64.store $0
-  local.get $0
+  local.get $this
   call $~lib/string/String#get:length
-  local.set $3
-  local.get $1
+  local.set $thisLen
+  local.get $search
   call $~lib/string/String#get:length
-  local.set $4
-  local.get $3
-  local.get $4
+  local.set $searchLen
+  local.get $thisLen
+  local.get $searchLen
   i32.le_u
   if
-   local.get $3
-   local.get $4
+   local.get $thisLen
+   local.get $searchLen
    i32.lt_u
    if (result i32)
-    local.get $0
+    local.get $this
    else
-    local.get $2
-    local.get $0
-    local.get $1
-    local.get $0
+    local.get $replacement
+    local.get $this
+    local.get $search
+    local.get $this
     call $~lib/string/String.__eq
     select
    end
@@ -25406,16 +25406,16 @@
    local.get $16
    return
   end
-  local.get $2
+  local.get $replacement
   call $~lib/string/String#get:length
-  local.set $5
-  local.get $4
+  local.set $replaceLen
+  local.get $searchLen
   i32.eqz
   if
-   local.get $5
+   local.get $replaceLen
    i32.eqz
    if
-    local.get $0
+    local.get $this
     local.set $16
     global.get $~lib/memory/__stack_pointer
     i32.const 8
@@ -25425,75 +25425,75 @@
     return
    end
    global.get $~lib/memory/__stack_pointer
-   local.get $3
-   local.get $3
+   local.get $thisLen
+   local.get $thisLen
    i32.const 1
    i32.add
-   local.get $5
+   local.get $replaceLen
    i32.mul
    i32.add
    i32.const 1
    i32.shl
    i32.const 1
    call $~lib/rt/itcms/__new
-   local.tee $6
+   local.tee $var$6
    i32.store $0
-   local.get $6
-   local.get $2
-   local.get $5
+   local.get $var$6
+   local.get $replacement
+   local.get $replaceLen
    i32.const 1
    i32.shl
    memory.copy $0 $0
-   local.get $5
-   local.set $7
+   local.get $replaceLen
+   local.set $chunk
    i32.const 0
-   local.set $8
+   local.set $var$8
    loop $for-loop|0
-    local.get $8
-    local.get $3
+    local.get $var$8
+    local.get $thisLen
     i32.lt_u
-    local.set $9
-    local.get $9
+    local.set $var$9
+    local.get $var$9
     if
-     local.get $6
-     local.get $7
-     local.tee $10
+     local.get $var$6
+     local.get $chunk
+     local.tee $var$10
      i32.const 1
      i32.add
-     local.set $7
-     local.get $10
+     local.set $chunk
+     local.get $var$10
      i32.const 1
      i32.shl
      i32.add
-     local.get $0
-     local.get $8
+     local.get $this
+     local.get $var$8
      i32.const 1
      i32.shl
      i32.add
      i32.load16_u $0
      i32.store16 $0
-     local.get $6
-     local.get $7
+     local.get $var$6
+     local.get $chunk
      i32.const 1
      i32.shl
      i32.add
-     local.get $2
-     local.get $5
+     local.get $replacement
+     local.get $replaceLen
      i32.const 1
      i32.shl
      memory.copy $0 $0
-     local.get $7
-     local.get $5
+     local.get $chunk
+     local.get $replaceLen
      i32.add
-     local.set $7
-     local.get $8
+     local.set $chunk
+     local.get $var$8
      i32.const 1
      i32.add
-     local.set $8
+     local.set $var$8
      br $for-loop|0
     end
    end
-   local.get $6
+   local.get $var$6
    local.set $16
    global.get $~lib/memory/__stack_pointer
    i32.const 8
@@ -25503,56 +25503,56 @@
    return
   end
   i32.const 0
-  local.set $11
+  local.set $prev
   i32.const 0
-  local.set $12
-  local.get $4
-  local.get $5
+  local.set $next
+  local.get $searchLen
+  local.get $replaceLen
   i32.eq
   if
-   local.get $3
+   local.get $thisLen
    i32.const 1
    i32.shl
-   local.set $7
+   local.set $chunk
    global.get $~lib/memory/__stack_pointer
-   local.get $7
+   local.get $chunk
    i32.const 1
    call $~lib/rt/itcms/__new
-   local.tee $6
+   local.tee $var$6
    i32.store $0
-   local.get $6
-   local.get $0
-   local.get $7
+   local.get $var$6
+   local.get $this
+   local.get $chunk
    memory.copy $0 $0
    loop $while-continue|1
-    local.get $0
-    local.get $1
-    local.get $11
+    local.get $this
+    local.get $search
+    local.get $prev
     call $~lib/string/String#indexOf
-    local.tee $12
+    local.tee $next
     i32.const -1
     i32.xor
-    local.set $8
-    local.get $8
+    local.set $var$8
+    local.get $var$8
     if
-     local.get $6
-     local.get $12
+     local.get $var$6
+     local.get $next
      i32.const 1
      i32.shl
      i32.add
-     local.get $2
-     local.get $5
+     local.get $replacement
+     local.get $replaceLen
      i32.const 1
      i32.shl
      memory.copy $0 $0
-     local.get $12
-     local.get $4
+     local.get $next
+     local.get $searchLen
      i32.add
-     local.set $11
+     local.set $prev
      br $while-continue|1
     end
    end
-   local.get $6
+   local.get $var$6
    local.set $16
    global.get $~lib/memory/__stack_pointer
    i32.const 8
@@ -25562,158 +25562,158 @@
    return
   end
   i32.const 0
-  local.set $13
+  local.set $out
   i32.const 0
-  local.set $14
-  local.get $3
-  local.set $15
+  local.set $offset
+  local.get $thisLen
+  local.set $outSize
   loop $while-continue|2
-   local.get $0
-   local.get $1
-   local.get $11
+   local.get $this
+   local.get $search
+   local.get $prev
    call $~lib/string/String#indexOf
-   local.tee $12
+   local.tee $next
    i32.const -1
    i32.xor
-   local.set $6
-   local.get $6
+   local.set $var$6
+   local.get $var$6
    if
-    local.get $13
+    local.get $out
     call $~lib/string/String.__not
     if
      global.get $~lib/memory/__stack_pointer
-     local.get $3
+     local.get $thisLen
      i32.const 1
      i32.shl
      i32.const 1
      call $~lib/rt/itcms/__new
-     local.tee $13
+     local.tee $out
      i32.store $0 offset=4
     end
-    local.get $12
-    local.get $11
+    local.get $next
+    local.get $prev
     i32.sub
-    local.set $7
-    local.get $14
-    local.get $7
+    local.set $chunk
+    local.get $offset
+    local.get $chunk
     i32.add
-    local.get $5
+    local.get $replaceLen
     i32.add
-    local.get $15
+    local.get $outSize
     i32.gt_u
     if
-     local.get $15
+     local.get $outSize
      i32.const 1
      i32.shl
-     local.set $15
+     local.set $outSize
      global.get $~lib/memory/__stack_pointer
-     local.get $13
-     local.get $15
+     local.get $out
+     local.get $outSize
      i32.const 1
      i32.shl
      call $~lib/rt/itcms/__renew
-     local.tee $13
+     local.tee $out
      i32.store $0 offset=4
     end
-    local.get $13
-    local.get $14
+    local.get $out
+    local.get $offset
     i32.const 1
     i32.shl
     i32.add
-    local.get $0
-    local.get $11
+    local.get $this
+    local.get $prev
     i32.const 1
     i32.shl
     i32.add
-    local.get $7
-    i32.const 1
-    i32.shl
-    memory.copy $0 $0
-    local.get $14
-    local.get $7
-    i32.add
-    local.set $14
-    local.get $13
-    local.get $14
-    i32.const 1
-    i32.shl
-    i32.add
-    local.get $2
-    local.get $5
+    local.get $chunk
     i32.const 1
     i32.shl
     memory.copy $0 $0
-    local.get $14
-    local.get $5
+    local.get $offset
+    local.get $chunk
     i32.add
-    local.set $14
-    local.get $12
-    local.get $4
+    local.set $offset
+    local.get $out
+    local.get $offset
+    i32.const 1
+    i32.shl
     i32.add
-    local.set $11
+    local.get $replacement
+    local.get $replaceLen
+    i32.const 1
+    i32.shl
+    memory.copy $0 $0
+    local.get $offset
+    local.get $replaceLen
+    i32.add
+    local.set $offset
+    local.get $next
+    local.get $searchLen
+    i32.add
+    local.set $prev
     br $while-continue|2
    end
   end
-  local.get $13
+  local.get $out
   if
-   local.get $3
-   local.get $11
+   local.get $thisLen
+   local.get $prev
    i32.sub
-   local.set $6
-   local.get $14
-   local.get $6
+   local.set $var$6
+   local.get $offset
+   local.get $var$6
    i32.add
-   local.get $15
+   local.get $outSize
    i32.gt_u
    if
-    local.get $15
+    local.get $outSize
     i32.const 1
     i32.shl
-    local.set $15
+    local.set $outSize
     global.get $~lib/memory/__stack_pointer
-    local.get $13
-    local.get $15
+    local.get $out
+    local.get $outSize
     i32.const 1
     i32.shl
     call $~lib/rt/itcms/__renew
-    local.tee $13
+    local.tee $out
     i32.store $0 offset=4
    end
-   local.get $6
+   local.get $var$6
    if
-    local.get $13
-    local.get $14
+    local.get $out
+    local.get $offset
     i32.const 1
     i32.shl
     i32.add
-    local.get $0
-    local.get $11
+    local.get $this
+    local.get $prev
     i32.const 1
     i32.shl
     i32.add
-    local.get $6
+    local.get $var$6
     i32.const 1
     i32.shl
     memory.copy $0 $0
    end
-   local.get $6
-   local.get $14
+   local.get $var$6
+   local.get $offset
    i32.add
-   local.set $6
-   local.get $15
-   local.get $6
+   local.set $var$6
+   local.get $outSize
+   local.get $var$6
    i32.gt_u
    if
     global.get $~lib/memory/__stack_pointer
-    local.get $13
-    local.get $6
+    local.get $out
+    local.get $var$6
     i32.const 1
     i32.shl
     call $~lib/rt/itcms/__renew
-    local.tee $13
+    local.tee $out
     i32.store $0 offset=4
    end
-   local.get $13
+   local.get $out
    local.set $16
    global.get $~lib/memory/__stack_pointer
    i32.const 8
@@ -25722,7 +25722,7 @@
    local.get $16
    return
   end
-  local.get $0
+  local.get $this
   local.set $16
   global.get $~lib/memory/__stack_pointer
   i32.const 8
@@ -25730,11 +25730,11 @@
   global.set $~lib/memory/__stack_pointer
   local.get $16
  )
- (func $~lib/string/String#slice (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
-  (local $3 i32)
-  (local $4 i32)
-  (local $5 i32)
-  (local $6 i32)
+ (func $~lib/string/String#slice (param $this i32) (param $start i32) (param $end i32) (result i32)
+  (local $len i32)
+  (local $var$4 i32)
+  (local $var$5 i32)
+  (local $out i32)
   (local $7 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -25744,64 +25744,64 @@
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   i32.store $0
-  local.get $0
+  local.get $this
   call $~lib/string/String#get:length
-  local.set $3
-  local.get $1
+  local.set $len
+  local.get $start
   i32.const 0
   i32.lt_s
   if (result i32)
-   local.get $1
-   local.get $3
+   local.get $start
+   local.get $len
    i32.add
-   local.tee $4
+   local.tee $var$4
    i32.const 0
-   local.tee $5
-   local.get $4
-   local.get $5
+   local.tee $var$5
+   local.get $var$4
+   local.get $var$5
    i32.gt_s
    select
   else
-   local.get $1
-   local.tee $5
-   local.get $3
-   local.tee $4
-   local.get $5
-   local.get $4
+   local.get $start
+   local.tee $var$5
+   local.get $len
+   local.tee $var$4
+   local.get $var$5
+   local.get $var$4
    i32.lt_s
    select
   end
-  local.set $1
-  local.get $2
+  local.set $start
+  local.get $end
   i32.const 0
   i32.lt_s
   if (result i32)
-   local.get $2
-   local.get $3
+   local.get $end
+   local.get $len
    i32.add
-   local.tee $4
+   local.tee $var$4
    i32.const 0
-   local.tee $5
-   local.get $4
-   local.get $5
+   local.tee $var$5
+   local.get $var$4
+   local.get $var$5
    i32.gt_s
    select
   else
-   local.get $2
-   local.tee $5
-   local.get $3
-   local.tee $4
-   local.get $5
-   local.get $4
+   local.get $end
+   local.tee $var$5
+   local.get $len
+   local.tee $var$4
+   local.get $var$5
+   local.get $var$4
    i32.lt_s
    select
   end
-  local.set $2
-  local.get $2
-  local.get $1
+  local.set $end
+  local.get $end
+  local.get $start
   i32.sub
-  local.set $3
-  local.get $3
+  local.set $len
+  local.get $len
   i32.const 0
   i32.le_s
   if
@@ -25815,24 +25815,24 @@
    return
   end
   global.get $~lib/memory/__stack_pointer
-  local.get $3
+  local.get $len
   i32.const 1
   i32.shl
   i32.const 1
   call $~lib/rt/itcms/__new
-  local.tee $6
+  local.tee $out
   i32.store $0
-  local.get $6
-  local.get $0
-  local.get $1
+  local.get $out
+  local.get $this
+  local.get $start
   i32.const 1
   i32.shl
   i32.add
-  local.get $3
+  local.get $len
   i32.const 1
   i32.shl
   memory.copy $0 $0
-  local.get $6
+  local.get $out
   local.set $7
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -25840,14 +25840,14 @@
   global.set $~lib/memory/__stack_pointer
   local.get $7
  )
- (func $~lib/string/String#substr (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
-  (local $3 i32)
-  (local $4 i32)
-  (local $5 i32)
-  (local $6 i32)
-  (local $7 i32)
-  (local $8 i32)
-  (local $9 i32)
+ (func $~lib/string/String#substr (param $this i32) (param $start i32) (param $length i32) (result i32)
+  (local $intStart i32)
+  (local $end i32)
+  (local $len i32)
+  (local $var$6 i32)
+  (local $var$7 i32)
+  (local $size i32)
+  (local $out i32)
   (local $10 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -25857,50 +25857,50 @@
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   i32.store $0
-  local.get $1
-  local.set $3
-  local.get $2
-  local.set $4
-  local.get $0
+  local.get $start
+  local.set $intStart
+  local.get $length
+  local.set $end
+  local.get $this
   call $~lib/string/String#get:length
-  local.set $5
-  local.get $3
+  local.set $len
+  local.get $intStart
   i32.const 0
   i32.lt_s
   if
-   local.get $5
-   local.get $3
+   local.get $len
+   local.get $intStart
    i32.add
-   local.tee $6
+   local.tee $var$6
    i32.const 0
-   local.tee $7
-   local.get $6
-   local.get $7
+   local.tee $var$7
+   local.get $var$6
+   local.get $var$7
    i32.gt_s
    select
-   local.set $3
+   local.set $intStart
   end
-  local.get $4
-  local.tee $7
+  local.get $end
+  local.tee $var$7
   i32.const 0
-  local.tee $6
-  local.get $7
-  local.get $6
+  local.tee $var$6
+  local.get $var$7
+  local.get $var$6
   i32.gt_s
   select
-  local.tee $6
-  local.get $5
-  local.get $3
+  local.tee $var$6
+  local.get $len
+  local.get $intStart
   i32.sub
-  local.tee $7
-  local.get $6
-  local.get $7
+  local.tee $var$7
+  local.get $var$6
+  local.get $var$7
   i32.lt_s
   select
   i32.const 1
   i32.shl
-  local.set $8
-  local.get $8
+  local.set $size
+  local.get $size
   i32.const 0
   i32.le_s
   if
@@ -25914,20 +25914,20 @@
    return
   end
   global.get $~lib/memory/__stack_pointer
-  local.get $8
+  local.get $size
   i32.const 1
   call $~lib/rt/itcms/__new
-  local.tee $9
+  local.tee $out
   i32.store $0
-  local.get $9
-  local.get $0
-  local.get $3
+  local.get $out
+  local.get $this
+  local.get $intStart
   i32.const 1
   i32.shl
   i32.add
-  local.get $8
+  local.get $size
   memory.copy $0 $0
-  local.get $9
+  local.get $out
   local.set $10
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -25935,16 +25935,16 @@
   global.set $~lib/memory/__stack_pointer
   local.get $10
  )
- (func $~lib/string/String#substring (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
-  (local $3 i32)
-  (local $4 i32)
-  (local $5 i32)
-  (local $6 i32)
-  (local $7 i32)
-  (local $8 i32)
-  (local $9 i32)
-  (local $10 i32)
-  (local $11 i32)
+ (func $~lib/string/String#substring (param $this i32) (param $start i32) (param $end i32) (result i32)
+  (local $len i32)
+  (local $var$4 i32)
+  (local $var$5 i32)
+  (local $finalStart i32)
+  (local $finalEnd i32)
+  (local $fromPos i32)
+  (local $toPos i32)
+  (local $size i32)
+  (local $out i32)
   (local $12 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -25954,68 +25954,68 @@
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   i32.store $0
-  local.get $0
+  local.get $this
   call $~lib/string/String#get:length
-  local.set $3
-  local.get $1
-  local.tee $4
+  local.set $len
+  local.get $start
+  local.tee $var$4
   i32.const 0
-  local.tee $5
-  local.get $4
-  local.get $5
+  local.tee $var$5
+  local.get $var$4
+  local.get $var$5
   i32.gt_s
   select
-  local.tee $5
-  local.get $3
-  local.tee $4
-  local.get $5
-  local.get $4
+  local.tee $var$5
+  local.get $len
+  local.tee $var$4
+  local.get $var$5
+  local.get $var$4
   i32.lt_s
   select
-  local.set $6
-  local.get $2
-  local.tee $4
+  local.set $finalStart
+  local.get $end
+  local.tee $var$4
   i32.const 0
-  local.tee $5
-  local.get $4
-  local.get $5
+  local.tee $var$5
+  local.get $var$4
+  local.get $var$5
   i32.gt_s
   select
-  local.tee $5
-  local.get $3
-  local.tee $4
-  local.get $5
-  local.get $4
+  local.tee $var$5
+  local.get $len
+  local.tee $var$4
+  local.get $var$5
+  local.get $var$4
   i32.lt_s
   select
-  local.set $7
-  local.get $6
-  local.tee $4
-  local.get $7
-  local.tee $5
-  local.get $4
-  local.get $5
+  local.set $finalEnd
+  local.get $finalStart
+  local.tee $var$4
+  local.get $finalEnd
+  local.tee $var$5
+  local.get $var$4
+  local.get $var$5
   i32.lt_s
   select
   i32.const 1
   i32.shl
-  local.set $8
-  local.get $6
-  local.tee $5
-  local.get $7
-  local.tee $4
-  local.get $5
-  local.get $4
+  local.set $fromPos
+  local.get $finalStart
+  local.tee $var$5
+  local.get $finalEnd
+  local.tee $var$4
+  local.get $var$5
+  local.get $var$4
   i32.gt_s
   select
   i32.const 1
   i32.shl
-  local.set $9
-  local.get $9
-  local.get $8
+  local.set $toPos
+  local.get $toPos
+  local.get $fromPos
   i32.sub
-  local.set $10
-  local.get $10
+  local.set $size
+  local.get $size
   i32.eqz
   if
    i32.const 688
@@ -26027,11 +26027,11 @@
    local.get $12
    return
   end
-  local.get $8
+  local.get $fromPos
   i32.eqz
   if (result i32)
-   local.get $9
-   local.get $3
+   local.get $toPos
+   local.get $len
    i32.const 1
    i32.shl
    i32.eq
@@ -26039,7 +26039,7 @@
    i32.const 0
   end
   if
-   local.get $0
+   local.get $this
    local.set $12
    global.get $~lib/memory/__stack_pointer
    i32.const 4
@@ -26049,18 +26049,18 @@
    return
   end
   global.get $~lib/memory/__stack_pointer
-  local.get $10
+  local.get $size
   i32.const 1
   call $~lib/rt/itcms/__new
-  local.tee $11
+  local.tee $out
   i32.store $0
-  local.get $11
-  local.get $0
-  local.get $8
+  local.get $out
+  local.get $this
+  local.get $fromPos
   i32.add
-  local.get $10
+  local.get $size
   memory.copy $0 $0
-  local.get $11
+  local.get $out
   local.set $12
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -26068,8 +26068,8 @@
   global.set $~lib/memory/__stack_pointer
   local.get $12
  )
- (func $~lib/array/Array<~lib/string/String>#__get (param $0 i32) (param $1 i32) (result i32)
-  (local $2 i32)
+ (func $~lib/array/Array<~lib/string/String>#__get (param $this i32) (param $index i32) (result i32)
+  (local $value i32)
   (local $3 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -26079,8 +26079,8 @@
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   i32.store $0
-  local.get $1
-  local.get $0
+  local.get $index
+  local.get $this
   i32.load $0 offset=12
   i32.ge_u
   if
@@ -26092,21 +26092,21 @@
    unreachable
   end
   global.get $~lib/memory/__stack_pointer
-  local.get $0
+  local.get $this
   i32.load $0 offset=4
-  local.get $1
+  local.get $index
   i32.const 2
   i32.shl
   i32.add
   i32.load $0
-  local.tee $2
+  local.tee $value
   i32.store $0
   i32.const 1
   drop
   i32.const 0
   i32.eqz
   drop
-  local.get $2
+  local.get $value
   i32.eqz
   if
    i32.const 14688
@@ -26116,7 +26116,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $2
+  local.get $value
   local.set $3
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -26124,13 +26124,13 @@
   global.set $~lib/memory/__stack_pointer
   local.get $3
  )
- (func $~lib/util/number/itoa32 (param $0 i32) (param $1 i32) (result i32)
-  (local $2 i32)
-  (local $3 i32)
-  (local $4 i32)
-  (local $5 i32)
-  (local $6 i32)
-  (local $7 i32)
+ (func $~lib/util/number/itoa32 (param $value i32) (param $radix i32) (result i32)
+  (local $sign i32)
+  (local $out i32)
+  (local $var$4 i32)
+  (local $var$5 i32)
+  (local $var$6 i32)
+  (local $var$7 i32)
   (local $8 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -26140,13 +26140,13 @@
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   i32.store $0
-  local.get $1
+  local.get $radix
   i32.const 2
   i32.lt_s
   if (result i32)
    i32.const 1
   else
-   local.get $1
+   local.get $radix
    i32.const 36
    i32.gt_s
   end
@@ -26158,7 +26158,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $0
+  local.get $value
   i32.eqz
   if
    i32.const 2368
@@ -26170,128 +26170,128 @@
    local.get $8
    return
   end
-  local.get $0
+  local.get $value
   i32.const 31
   i32.shr_u
   i32.const 1
   i32.shl
-  local.set $2
-  local.get $2
+  local.set $sign
+  local.get $sign
   if
    i32.const 0
-   local.get $0
+   local.get $value
    i32.sub
-   local.set $0
+   local.set $value
   end
-  local.get $1
+  local.get $radix
   i32.const 10
   i32.eq
   if
-   local.get $0
+   local.get $value
    call $~lib/util/number/decimalCount32
-   local.set $4
+   local.set $var$4
    global.get $~lib/memory/__stack_pointer
-   local.get $4
+   local.get $var$4
    i32.const 1
    i32.shl
-   local.get $2
+   local.get $sign
    i32.add
    i32.const 1
    call $~lib/rt/itcms/__new
-   local.tee $3
+   local.tee $out
    i32.store $0
-   local.get $3
-   local.get $2
+   local.get $out
+   local.get $sign
    i32.add
-   local.set $7
-   local.get $0
-   local.set $6
-   local.get $4
-   local.set $5
+   local.set $var$7
+   local.get $value
+   local.set $var$6
+   local.get $var$4
+   local.set $var$5
    i32.const 0
    i32.const 1
    i32.ge_s
    drop
-   local.get $7
-   local.get $6
-   local.get $5
+   local.get $var$7
+   local.get $var$6
+   local.get $var$5
    call $~lib/util/number/utoa32_dec_lut
   else
-   local.get $1
+   local.get $radix
    i32.const 16
    i32.eq
    if
     i32.const 31
-    local.get $0
+    local.get $value
     i32.clz
     i32.sub
     i32.const 2
     i32.shr_s
     i32.const 1
     i32.add
-    local.set $4
+    local.set $var$4
     global.get $~lib/memory/__stack_pointer
-    local.get $4
+    local.get $var$4
     i32.const 1
     i32.shl
-    local.get $2
+    local.get $sign
     i32.add
     i32.const 1
     call $~lib/rt/itcms/__new
-    local.tee $3
+    local.tee $out
     i32.store $0
-    local.get $3
-    local.get $2
+    local.get $out
+    local.get $sign
     i32.add
-    local.set $7
-    local.get $0
-    local.set $6
-    local.get $4
-    local.set $5
+    local.set $var$7
+    local.get $value
+    local.set $var$6
+    local.get $var$4
+    local.set $var$5
     i32.const 0
     i32.const 1
     i32.ge_s
     drop
-    local.get $7
-    local.get $6
+    local.get $var$7
+    local.get $var$6
     i64.extend_i32_u
-    local.get $5
+    local.get $var$5
     call $~lib/util/number/utoa_hex_lut
    else
-    local.get $0
-    local.set $4
-    local.get $4
+    local.get $value
+    local.set $var$4
+    local.get $var$4
     i64.extend_i32_u
-    local.get $1
+    local.get $radix
     call $~lib/util/number/ulog_base
-    local.set $7
+    local.set $var$7
     global.get $~lib/memory/__stack_pointer
-    local.get $7
+    local.get $var$7
     i32.const 1
     i32.shl
-    local.get $2
+    local.get $sign
     i32.add
     i32.const 1
     call $~lib/rt/itcms/__new
-    local.tee $3
+    local.tee $out
     i32.store $0
-    local.get $3
-    local.get $2
+    local.get $out
+    local.get $sign
     i32.add
-    local.get $4
+    local.get $var$4
     i64.extend_i32_u
-    local.get $7
-    local.get $1
+    local.get $var$7
+    local.get $radix
     call $~lib/util/number/utoa64_any_core
    end
   end
-  local.get $2
+  local.get $sign
   if
-   local.get $3
+   local.get $out
    i32.const 45
    i32.store16 $0
   end
-  local.get $3
+  local.get $out
   local.set $8
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -26299,12 +26299,12 @@
   global.set $~lib/memory/__stack_pointer
   local.get $8
  )
- (func $~lib/util/number/utoa32 (param $0 i32) (param $1 i32) (result i32)
-  (local $2 i32)
-  (local $3 i32)
-  (local $4 i32)
-  (local $5 i32)
-  (local $6 i32)
+ (func $~lib/util/number/utoa32 (param $value i32) (param $radix i32) (result i32)
+  (local $out i32)
+  (local $var$3 i32)
+  (local $var$4 i32)
+  (local $var$5 i32)
+  (local $var$6 i32)
   (local $7 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -26314,13 +26314,13 @@
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   i32.store $0
-  local.get $1
+  local.get $radix
   i32.const 2
   i32.lt_s
   if (result i32)
    i32.const 1
   else
-   local.get $1
+   local.get $radix
    i32.const 36
    i32.gt_s
   end
@@ -26332,7 +26332,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $0
+  local.get $value
   i32.eqz
   if
    i32.const 2368
@@ -26344,95 +26344,95 @@
    local.get $7
    return
   end
-  local.get $1
+  local.get $radix
   i32.const 10
   i32.eq
   if
-   local.get $0
+   local.get $value
    call $~lib/util/number/decimalCount32
-   local.set $3
+   local.set $var$3
    global.get $~lib/memory/__stack_pointer
-   local.get $3
+   local.get $var$3
    i32.const 1
    i32.shl
    i32.const 1
    call $~lib/rt/itcms/__new
-   local.tee $2
+   local.tee $out
    i32.store $0
-   local.get $2
-   local.set $6
-   local.get $0
-   local.set $5
-   local.get $3
-   local.set $4
+   local.get $out
+   local.set $var$6
+   local.get $value
+   local.set $var$5
+   local.get $var$3
+   local.set $var$4
    i32.const 0
    i32.const 1
    i32.ge_s
    drop
-   local.get $6
-   local.get $5
-   local.get $4
+   local.get $var$6
+   local.get $var$5
+   local.get $var$4
    call $~lib/util/number/utoa32_dec_lut
   else
-   local.get $1
+   local.get $radix
    i32.const 16
    i32.eq
    if
     i32.const 31
-    local.get $0
+    local.get $value
     i32.clz
     i32.sub
     i32.const 2
     i32.shr_s
     i32.const 1
     i32.add
-    local.set $3
+    local.set $var$3
     global.get $~lib/memory/__stack_pointer
-    local.get $3
+    local.get $var$3
     i32.const 1
     i32.shl
     i32.const 1
     call $~lib/rt/itcms/__new
-    local.tee $2
+    local.tee $out
     i32.store $0
-    local.get $2
-    local.set $6
-    local.get $0
-    local.set $5
-    local.get $3
-    local.set $4
+    local.get $out
+    local.set $var$6
+    local.get $value
+    local.set $var$5
+    local.get $var$3
+    local.set $var$4
     i32.const 0
     i32.const 1
     i32.ge_s
     drop
-    local.get $6
-    local.get $5
+    local.get $var$6
+    local.get $var$5
     i64.extend_i32_u
-    local.get $4
+    local.get $var$4
     call $~lib/util/number/utoa_hex_lut
    else
-    local.get $0
+    local.get $value
     i64.extend_i32_u
-    local.get $1
+    local.get $radix
     call $~lib/util/number/ulog_base
-    local.set $3
+    local.set $var$3
     global.get $~lib/memory/__stack_pointer
-    local.get $3
+    local.get $var$3
     i32.const 1
     i32.shl
     i32.const 1
     call $~lib/rt/itcms/__new
-    local.tee $2
+    local.tee $out
     i32.store $0
-    local.get $2
-    local.get $0
+    local.get $out
+    local.get $value
     i64.extend_i32_u
-    local.get $3
-    local.get $1
+    local.get $var$3
+    local.get $radix
     call $~lib/util/number/utoa64_any_core
    end
   end
-  local.get $2
+  local.get $out
   local.set $7
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -26440,14 +26440,14 @@
   global.set $~lib/memory/__stack_pointer
   local.get $7
  )
- (func $~lib/util/number/utoa64 (param $0 i64) (param $1 i32) (result i32)
-  (local $2 i32)
-  (local $3 i32)
-  (local $4 i32)
-  (local $5 i32)
-  (local $6 i32)
-  (local $7 i32)
-  (local $8 i64)
+ (func $~lib/util/number/utoa64 (param $value i64) (param $radix i32) (result i32)
+  (local $out i32)
+  (local $var$3 i32)
+  (local $var$4 i32)
+  (local $var$5 i32)
+  (local $var$6 i32)
+  (local $var$7 i32)
+  (local $var$8 i64)
   (local $9 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -26457,13 +26457,13 @@
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   i32.store $0
-  local.get $1
+  local.get $radix
   i32.const 2
   i32.lt_s
   if (result i32)
    i32.const 1
   else
-   local.get $1
+   local.get $radix
    i32.const 36
    i32.gt_s
   end
@@ -26475,7 +26475,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $0
+  local.get $value
   i64.const 0
   i64.ne
   i32.eqz
@@ -26489,77 +26489,77 @@
    local.get $9
    return
   end
-  local.get $1
+  local.get $radix
   i32.const 10
   i32.eq
   if
-   local.get $0
+   local.get $value
    global.get $~lib/builtins/u32.MAX_VALUE
    i64.extend_i32_u
    i64.le_u
    if
-    local.get $0
+    local.get $value
     i32.wrap_i64
-    local.set $3
-    local.get $3
+    local.set $var$3
+    local.get $var$3
     call $~lib/util/number/decimalCount32
-    local.set $4
+    local.set $var$4
     global.get $~lib/memory/__stack_pointer
-    local.get $4
+    local.get $var$4
     i32.const 1
     i32.shl
     i32.const 1
     call $~lib/rt/itcms/__new
-    local.tee $2
+    local.tee $out
     i32.store $0
-    local.get $2
-    local.set $7
-    local.get $3
-    local.set $6
-    local.get $4
-    local.set $5
+    local.get $out
+    local.set $var$7
+    local.get $var$3
+    local.set $var$6
+    local.get $var$4
+    local.set $var$5
     i32.const 0
     i32.const 1
     i32.ge_s
     drop
-    local.get $7
-    local.get $6
-    local.get $5
+    local.get $var$7
+    local.get $var$6
+    local.get $var$5
     call $~lib/util/number/utoa32_dec_lut
    else
-    local.get $0
+    local.get $value
     call $~lib/util/number/decimalCount64High
-    local.set $4
+    local.set $var$4
     global.get $~lib/memory/__stack_pointer
-    local.get $4
+    local.get $var$4
     i32.const 1
     i32.shl
     i32.const 1
     call $~lib/rt/itcms/__new
-    local.tee $2
+    local.tee $out
     i32.store $0
-    local.get $2
-    local.set $6
-    local.get $0
-    local.set $8
-    local.get $4
-    local.set $5
+    local.get $out
+    local.set $var$6
+    local.get $value
+    local.set $var$8
+    local.get $var$4
+    local.set $var$5
     i32.const 0
     i32.const 1
     i32.ge_s
     drop
-    local.get $6
-    local.get $8
-    local.get $5
+    local.get $var$6
+    local.get $var$8
+    local.get $var$5
     call $~lib/util/number/utoa64_dec_lut
    end
   else
-   local.get $1
+   local.get $radix
    i32.const 16
    i32.eq
    if
     i32.const 63
-    local.get $0
+    local.get $value
     i64.clz
     i32.wrap_i64
     i32.sub
@@ -26567,50 +26567,50 @@
     i32.shr_s
     i32.const 1
     i32.add
-    local.set $4
+    local.set $var$4
     global.get $~lib/memory/__stack_pointer
-    local.get $4
+    local.get $var$4
     i32.const 1
     i32.shl
     i32.const 1
     call $~lib/rt/itcms/__new
-    local.tee $2
+    local.tee $out
     i32.store $0
-    local.get $2
-    local.set $3
-    local.get $0
-    local.set $8
-    local.get $4
-    local.set $7
+    local.get $out
+    local.set $var$3
+    local.get $value
+    local.set $var$8
+    local.get $var$4
+    local.set $var$7
     i32.const 0
     i32.const 1
     i32.ge_s
     drop
-    local.get $3
-    local.get $8
-    local.get $7
+    local.get $var$3
+    local.get $var$8
+    local.get $var$7
     call $~lib/util/number/utoa_hex_lut
    else
-    local.get $0
-    local.get $1
+    local.get $value
+    local.get $radix
     call $~lib/util/number/ulog_base
-    local.set $4
+    local.set $var$4
     global.get $~lib/memory/__stack_pointer
-    local.get $4
+    local.get $var$4
     i32.const 1
     i32.shl
     i32.const 1
     call $~lib/rt/itcms/__new
-    local.tee $2
+    local.tee $out
     i32.store $0
-    local.get $2
-    local.get $0
-    local.get $4
-    local.get $1
+    local.get $out
+    local.get $value
+    local.get $var$4
+    local.get $radix
     call $~lib/util/number/utoa64_any_core
    end
   end
-  local.get $2
+  local.get $out
   local.set $9
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -26618,15 +26618,15 @@
   global.set $~lib/memory/__stack_pointer
   local.get $9
  )
- (func $~lib/util/number/itoa64 (param $0 i64) (param $1 i32) (result i32)
-  (local $2 i32)
-  (local $3 i32)
-  (local $4 i32)
-  (local $5 i32)
-  (local $6 i32)
-  (local $7 i32)
-  (local $8 i32)
-  (local $9 i64)
+ (func $~lib/util/number/itoa64 (param $value i64) (param $radix i32) (result i32)
+  (local $sign i32)
+  (local $out i32)
+  (local $var$4 i32)
+  (local $var$5 i32)
+  (local $var$6 i32)
+  (local $var$7 i32)
+  (local $var$8 i32)
+  (local $var$9 i64)
   (local $10 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -26636,13 +26636,13 @@
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   i32.store $0
-  local.get $1
+  local.get $radix
   i32.const 2
   i32.lt_s
   if (result i32)
    i32.const 1
   else
-   local.get $1
+   local.get $radix
    i32.const 36
    i32.gt_s
   end
@@ -26654,7 +26654,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $0
+  local.get $value
   i64.const 0
   i64.ne
   i32.eqz
@@ -26668,99 +26668,99 @@
    local.get $10
    return
   end
-  local.get $0
+  local.get $value
   i64.const 63
   i64.shr_u
   i32.wrap_i64
   i32.const 1
   i32.shl
-  local.set $2
-  local.get $2
+  local.set $sign
+  local.get $sign
   if
    i64.const 0
-   local.get $0
+   local.get $value
    i64.sub
-   local.set $0
+   local.set $value
   end
-  local.get $1
+  local.get $radix
   i32.const 10
   i32.eq
   if
-   local.get $0
+   local.get $value
    global.get $~lib/builtins/u32.MAX_VALUE
    i64.extend_i32_u
    i64.le_u
    if
-    local.get $0
+    local.get $value
     i32.wrap_i64
-    local.set $4
-    local.get $4
+    local.set $var$4
+    local.get $var$4
     call $~lib/util/number/decimalCount32
-    local.set $5
+    local.set $var$5
     global.get $~lib/memory/__stack_pointer
-    local.get $5
+    local.get $var$5
     i32.const 1
     i32.shl
-    local.get $2
+    local.get $sign
     i32.add
     i32.const 1
     call $~lib/rt/itcms/__new
-    local.tee $3
+    local.tee $out
     i32.store $0
-    local.get $3
-    local.get $2
+    local.get $out
+    local.get $sign
     i32.add
-    local.set $8
-    local.get $4
-    local.set $7
-    local.get $5
-    local.set $6
+    local.set $var$8
+    local.get $var$4
+    local.set $var$7
+    local.get $var$5
+    local.set $var$6
     i32.const 0
     i32.const 1
     i32.ge_s
     drop
-    local.get $8
-    local.get $7
-    local.get $6
+    local.get $var$8
+    local.get $var$7
+    local.get $var$6
     call $~lib/util/number/utoa32_dec_lut
    else
-    local.get $0
+    local.get $value
     call $~lib/util/number/decimalCount64High
-    local.set $5
+    local.set $var$5
     global.get $~lib/memory/__stack_pointer
-    local.get $5
+    local.get $var$5
     i32.const 1
     i32.shl
-    local.get $2
+    local.get $sign
     i32.add
     i32.const 1
     call $~lib/rt/itcms/__new
-    local.tee $3
+    local.tee $out
     i32.store $0
-    local.get $3
-    local.get $2
+    local.get $out
+    local.get $sign
     i32.add
-    local.set $7
-    local.get $0
-    local.set $9
-    local.get $5
-    local.set $6
+    local.set $var$7
+    local.get $value
+    local.set $var$9
+    local.get $var$5
+    local.set $var$6
     i32.const 0
     i32.const 1
     i32.ge_s
     drop
-    local.get $7
-    local.get $9
-    local.get $6
+    local.get $var$7
+    local.get $var$9
+    local.get $var$6
     call $~lib/util/number/utoa64_dec_lut
    end
   else
-   local.get $1
+   local.get $radix
    i32.const 16
    i32.eq
    if
     i32.const 63
-    local.get $0
+    local.get $value
     i64.clz
     i32.wrap_i64
     i32.sub
@@ -26768,64 +26768,64 @@
     i32.shr_s
     i32.const 1
     i32.add
-    local.set $5
+    local.set $var$5
     global.get $~lib/memory/__stack_pointer
-    local.get $5
+    local.get $var$5
     i32.const 1
     i32.shl
-    local.get $2
+    local.get $sign
     i32.add
     i32.const 1
     call $~lib/rt/itcms/__new
-    local.tee $3
+    local.tee $out
     i32.store $0
-    local.get $3
-    local.get $2
+    local.get $out
+    local.get $sign
     i32.add
-    local.set $4
-    local.get $0
-    local.set $9
-    local.get $5
-    local.set $8
+    local.set $var$4
+    local.get $value
+    local.set $var$9
+    local.get $var$5
+    local.set $var$8
     i32.const 0
     i32.const 1
     i32.ge_s
     drop
-    local.get $4
-    local.get $9
-    local.get $8
+    local.get $var$4
+    local.get $var$9
+    local.get $var$8
     call $~lib/util/number/utoa_hex_lut
    else
-    local.get $0
-    local.get $1
+    local.get $value
+    local.get $radix
     call $~lib/util/number/ulog_base
-    local.set $5
+    local.set $var$5
     global.get $~lib/memory/__stack_pointer
-    local.get $5
+    local.get $var$5
     i32.const 1
     i32.shl
-    local.get $2
+    local.get $sign
     i32.add
     i32.const 1
     call $~lib/rt/itcms/__new
-    local.tee $3
+    local.tee $out
     i32.store $0
-    local.get $3
-    local.get $2
+    local.get $out
+    local.get $sign
     i32.add
-    local.get $0
-    local.get $5
-    local.get $1
+    local.get $value
+    local.get $var$5
+    local.get $radix
     call $~lib/util/number/utoa64_any_core
    end
   end
-  local.get $2
+  local.get $sign
   if
-   local.get $3
+   local.get $out
    i32.const 45
    i32.store16 $0
   end
-  local.get $3
+  local.get $out
   local.set $10
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -26833,9 +26833,9 @@
   global.set $~lib/memory/__stack_pointer
   local.get $10
  )
- (func $~lib/util/number/dtoa (param $0 f64) (result i32)
-  (local $1 i32)
-  (local $2 i32)
+ (func $~lib/util/number/dtoa (param $value f64) (result i32)
+  (local $size i32)
+  (local $result i32)
   (local $3 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -26845,7 +26845,7 @@
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   i32.store $0
-  local.get $0
+  local.get $value
   f64.const 0
   f64.eq
   if
@@ -26858,15 +26858,15 @@
    local.get $3
    return
   end
-  local.get $0
-  local.get $0
+  local.get $value
+  local.get $value
   f64.sub
   f64.const 0
   f64.eq
   i32.eqz
   if
-   local.get $0
-   local.get $0
+   local.get $value
+   local.get $value
    f64.ne
    if
     i32.const 6672
@@ -26880,7 +26880,7 @@
    end
    i32.const 7936
    i32.const 22288
-   local.get $0
+   local.get $value
    f64.const 0
    f64.lt
    select
@@ -26893,22 +26893,22 @@
    return
   end
   i32.const 22320
-  local.get $0
+  local.get $value
   call $~lib/util/number/dtoa_core
   i32.const 1
   i32.shl
-  local.set $1
+  local.set $size
   global.get $~lib/memory/__stack_pointer
-  local.get $1
+  local.get $size
   i32.const 1
   call $~lib/rt/itcms/__new
-  local.tee $2
+  local.tee $result
   i32.store $0
-  local.get $2
+  local.get $result
   i32.const 22320
-  local.get $1
+  local.get $size
   memory.copy $0 $0
-  local.get $2
+  local.get $result
   local.set $3
   global.get $~lib/memory/__stack_pointer
   i32.const 4

--- a/tests/compiler/std/symbol.debug.wat
+++ b/tests/compiler/std/symbol.debug.wat
@@ -3480,10 +3480,10 @@
    unreachable
   end
  )
- (func $~lib/map/Map<~lib/string/String,usize>#find (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
-  (local $3 i32)
-  (local $4 i32)
-  (local $5 i32)
+ (func $~lib/map/Map<~lib/string/String,usize>#find (param $this i32) (param $key i32) (param $hashCode i32) (result i32)
+  (local $entry i32)
+  (local $var$4 i32)
+  (local $taggedNext i32)
   (local $6 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -3493,44 +3493,44 @@
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   i32.store $0
-  local.get $0
+  local.get $this
   i32.load $0
-  local.get $2
-  local.get $0
+  local.get $hashCode
+  local.get $this
   i32.load $0 offset=4
   i32.and
   i32.const 4
   i32.mul
   i32.add
   i32.load $0
-  local.set $3
+  local.set $entry
   loop $while-continue|0
-   local.get $3
-   local.set $4
-   local.get $4
+   local.get $entry
+   local.set $var$4
+   local.get $var$4
    if
-    local.get $3
+    local.get $entry
     i32.load $0 offset=8
-    local.set $5
-    local.get $5
+    local.set $taggedNext
+    local.get $taggedNext
     i32.const 1
     i32.and
     i32.eqz
     if (result i32)
-     local.get $3
+     local.get $entry
      i32.load $0
      local.set $6
      global.get $~lib/memory/__stack_pointer
      local.get $6
      i32.store $0
      local.get $6
-     local.get $1
+     local.get $key
      call $~lib/string/String.__eq
     else
      i32.const 0
     end
     if
-     local.get $3
+     local.get $entry
      local.set $6
      global.get $~lib/memory/__stack_pointer
      i32.const 4
@@ -3539,12 +3539,12 @@
      local.get $6
      return
     end
-    local.get $5
+    local.get $taggedNext
     i32.const 1
     i32.const -1
     i32.xor
     i32.and
-    local.set $3
+    local.set $entry
     br $while-continue|0
    end
   end
@@ -3556,9 +3556,9 @@
   global.set $~lib/memory/__stack_pointer
   local.get $6
  )
- (func $~lib/symbol/_Symbol.for (param $0 i32) (result i32)
-  (local $1 i32)
-  (local $2 i32)
+ (func $~lib/symbol/_Symbol.for (param $key i32) (result i32)
+  (local $var$1 i32)
+  (local $id i32)
   (local $3 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -3584,7 +3584,7 @@
    local.get $3
    i32.store $0
    local.get $3
-   local.get $0
+   local.get $key
    call $~lib/map/Map<~lib/string/String,usize>#has
    if
     global.get $~lib/symbol/stringToId
@@ -3593,7 +3593,7 @@
     local.get $3
     i32.store $0
     local.get $3
-    local.get $0
+    local.get $key
     call $~lib/map/Map<~lib/string/String,usize>#get
     local.set $3
     global.get $~lib/memory/__stack_pointer
@@ -3605,13 +3605,13 @@
    end
   end
   global.get $~lib/symbol/nextId
-  local.tee $1
+  local.tee $var$1
   i32.const 1
   i32.add
   global.set $~lib/symbol/nextId
-  local.get $1
-  local.set $2
-  local.get $2
+  local.get $var$1
+  local.set $id
+  local.get $id
   i32.eqz
   if
    unreachable
@@ -3622,8 +3622,8 @@
   local.get $3
   i32.store $0
   local.get $3
-  local.get $0
-  local.get $2
+  local.get $key
+  local.get $id
   call $~lib/map/Map<~lib/string/String,usize>#set
   drop
   global.get $~lib/symbol/idToString
@@ -3632,11 +3632,11 @@
   local.get $3
   i32.store $0
   local.get $3
-  local.get $2
-  local.get $0
+  local.get $id
+  local.get $key
   call $~lib/map/Map<usize,~lib/string/String>#set
   drop
-  local.get $2
+  local.get $id
   local.set $3
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -3644,7 +3644,7 @@
   global.set $~lib/memory/__stack_pointer
   local.get $3
  )
- (func $~lib/symbol/_Symbol.keyFor (param $0 i32) (result i32)
+ (func $~lib/symbol/_Symbol.keyFor (param $sym i32) (result i32)
   (local $1 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -3664,7 +3664,7 @@
    local.get $1
    i32.store $0
    local.get $1
-   local.get $0
+   local.get $sym
    call $~lib/map/Map<usize,~lib/string/String>#has
   else
    i32.const 0
@@ -3676,7 +3676,7 @@
    local.get $1
    i32.store $0
    local.get $1
-   local.get $0
+   local.get $sym
    call $~lib/map/Map<usize,~lib/string/String>#get
   else
    i32.const 0
@@ -3688,10 +3688,10 @@
   global.set $~lib/memory/__stack_pointer
   local.get $1
  )
- (func $~lib/symbol/_Symbol#toString (param $0 i32) (result i32)
-  (local $1 i32)
-  (local $2 i32)
-  (local $3 i32)
+ (func $~lib/symbol/_Symbol#toString (param $this i32) (result i32)
+  (local $id i32)
+  (local $str i32)
+  (local $var$3 i32)
   (local $4 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 16
@@ -3704,11 +3704,11 @@
   global.get $~lib/memory/__stack_pointer
   i64.const 0
   i64.store $0 offset=8
-  local.get $0
-  local.set $1
+  local.get $this
+  local.set $id
   global.get $~lib/memory/__stack_pointer
   i32.const 800
-  local.tee $2
+  local.tee $str
   i32.store $0
   block $break|0
    block $case11|0
@@ -3723,49 +3723,49 @@
             block $case2|0
              block $case1|0
               block $case0|0
-               local.get $1
-               local.set $3
-               local.get $3
+               local.get $id
+               local.set $var$3
+               local.get $var$3
                i32.const 1
                i32.eq
                br_if $case0|0
-               local.get $3
+               local.get $var$3
                i32.const 2
                i32.eq
                br_if $case1|0
-               local.get $3
+               local.get $var$3
                i32.const 3
                i32.eq
                br_if $case2|0
-               local.get $3
+               local.get $var$3
                i32.const 4
                i32.eq
                br_if $case3|0
-               local.get $3
+               local.get $var$3
                i32.const 5
                i32.eq
                br_if $case4|0
-               local.get $3
+               local.get $var$3
                i32.const 6
                i32.eq
                br_if $case5|0
-               local.get $3
+               local.get $var$3
                i32.const 7
                i32.eq
                br_if $case6|0
-               local.get $3
+               local.get $var$3
                i32.const 8
                i32.eq
                br_if $case7|0
-               local.get $3
+               local.get $var$3
                i32.const 9
                i32.eq
                br_if $case8|0
-               local.get $3
+               local.get $var$3
                i32.const 10
                i32.eq
                br_if $case9|0
-               local.get $3
+               local.get $var$3
                i32.const 11
                i32.eq
                br_if $case10|0
@@ -3773,67 +3773,67 @@
               end
               global.get $~lib/memory/__stack_pointer
               i32.const 832
-              local.tee $2
+              local.tee $str
               i32.store $0
               br $break|0
              end
              global.get $~lib/memory/__stack_pointer
              i32.const 880
-             local.tee $2
+             local.tee $str
              i32.store $0
              br $break|0
             end
             global.get $~lib/memory/__stack_pointer
             i32.const 944
-            local.tee $2
+            local.tee $str
             i32.store $0
             br $break|0
            end
            global.get $~lib/memory/__stack_pointer
            i32.const 992
-           local.tee $2
+           local.tee $str
            i32.store $0
            br $break|0
           end
           global.get $~lib/memory/__stack_pointer
           i32.const 1024
-          local.tee $2
+          local.tee $str
           i32.store $0
           br $break|0
          end
          global.get $~lib/memory/__stack_pointer
          i32.const 1072
-         local.tee $2
+         local.tee $str
          i32.store $0
          br $break|0
         end
         global.get $~lib/memory/__stack_pointer
         i32.const 1104
-        local.tee $2
+        local.tee $str
         i32.store $0
         br $break|0
        end
        global.get $~lib/memory/__stack_pointer
        i32.const 1152
-       local.tee $2
+       local.tee $str
        i32.store $0
        br $break|0
       end
       global.get $~lib/memory/__stack_pointer
       i32.const 1184
-      local.tee $2
+      local.tee $str
       i32.store $0
       br $break|0
      end
      global.get $~lib/memory/__stack_pointer
      i32.const 1232
-     local.tee $2
+     local.tee $str
      i32.store $0
      br $break|0
     end
     global.get $~lib/memory/__stack_pointer
     i32.const 1280
-    local.tee $2
+    local.tee $str
     i32.store $0
     br $break|0
    end
@@ -3847,7 +3847,7 @@
     local.get $4
     i32.store $0 offset=4
     local.get $4
-    local.get $1
+    local.get $id
     call $~lib/map/Map<usize,~lib/string/String>#has
    else
     i32.const 0
@@ -3860,9 +3860,9 @@
     local.get $4
     i32.store $0 offset=4
     local.get $4
-    local.get $1
+    local.get $id
     call $~lib/map/Map<usize,~lib/string/String>#get
-    local.tee $2
+    local.tee $str
     i32.store $0
    end
    br $break|0
@@ -3873,7 +3873,7 @@
   local.get $4
   i32.store $0 offset=12
   local.get $4
-  local.get $2
+  local.get $str
   call $~lib/string/String.__concat
   local.set $4
   global.get $~lib/memory/__stack_pointer
@@ -4205,8 +4205,8 @@
   i32.add
   global.set $~lib/memory/__stack_pointer
  )
- (func $~lib/arraybuffer/ArrayBuffer#constructor (param $0 i32) (param $1 i32) (result i32)
-  (local $2 i32)
+ (func $~lib/arraybuffer/ArrayBuffer#constructor (param $this i32) (param $length i32) (result i32)
+  (local $buffer i32)
   (local $3 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -4216,7 +4216,7 @@
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   i32.store $0
-  local.get $1
+  local.get $length
   i32.const 1073741820
   i32.gt_u
   if
@@ -4228,16 +4228,16 @@
    unreachable
   end
   global.get $~lib/memory/__stack_pointer
-  local.get $1
+  local.get $length
   i32.const 0
   call $~lib/rt/itcms/__new
-  local.tee $2
+  local.tee $buffer
   i32.store $0
   i32.const 2
   global.get $~lib/shared/runtime/Runtime.Incremental
   i32.ne
   drop
-  local.get $2
+  local.get $buffer
   local.set $3
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -4245,7 +4245,7 @@
   global.set $~lib/memory/__stack_pointer
   local.get $3
  )
- (func $~lib/map/Map<~lib/string/String,usize>#constructor (param $0 i32) (result i32)
+ (func $~lib/map/Map<~lib/string/String,usize>#constructor (param $this i32) (result i32)
   (local $1 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -4255,45 +4255,45 @@
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   i32.store $0
-  local.get $0
+  local.get $this
   i32.eqz
   if
    global.get $~lib/memory/__stack_pointer
    i32.const 24
    i32.const 3
    call $~lib/rt/itcms/__new
-   local.tee $0
+   local.tee $this
    i32.store $0
   end
-  local.get $0
+  local.get $this
   i32.const 0
   i32.const 4
   i32.const 4
   i32.mul
   call $~lib/arraybuffer/ArrayBuffer#constructor
   call $~lib/map/Map<~lib/string/String,usize>#set:buckets
-  local.get $0
+  local.get $this
   i32.const 4
   i32.const 1
   i32.sub
   call $~lib/map/Map<~lib/string/String,usize>#set:bucketsMask
-  local.get $0
+  local.get $this
   i32.const 0
   i32.const 4
   i32.const 12
   i32.mul
   call $~lib/arraybuffer/ArrayBuffer#constructor
   call $~lib/map/Map<~lib/string/String,usize>#set:entries
-  local.get $0
+  local.get $this
   i32.const 4
   call $~lib/map/Map<~lib/string/String,usize>#set:entriesCapacity
-  local.get $0
+  local.get $this
   i32.const 0
   call $~lib/map/Map<~lib/string/String,usize>#set:entriesOffset
-  local.get $0
+  local.get $this
   i32.const 0
   call $~lib/map/Map<~lib/string/String,usize>#set:entriesCount
-  local.get $0
+  local.get $this
   local.set $1
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -4301,7 +4301,7 @@
   global.set $~lib/memory/__stack_pointer
   local.get $1
  )
- (func $~lib/map/Map<usize,~lib/string/String>#constructor (param $0 i32) (result i32)
+ (func $~lib/map/Map<usize,~lib/string/String>#constructor (param $this i32) (result i32)
   (local $1 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -4311,45 +4311,45 @@
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   i32.store $0
-  local.get $0
+  local.get $this
   i32.eqz
   if
    global.get $~lib/memory/__stack_pointer
    i32.const 24
    i32.const 4
    call $~lib/rt/itcms/__new
-   local.tee $0
+   local.tee $this
    i32.store $0
   end
-  local.get $0
+  local.get $this
   i32.const 0
   i32.const 4
   i32.const 4
   i32.mul
   call $~lib/arraybuffer/ArrayBuffer#constructor
   call $~lib/map/Map<usize,~lib/string/String>#set:buckets
-  local.get $0
+  local.get $this
   i32.const 4
   i32.const 1
   i32.sub
   call $~lib/map/Map<usize,~lib/string/String>#set:bucketsMask
-  local.get $0
+  local.get $this
   i32.const 0
   i32.const 4
   i32.const 12
   i32.mul
   call $~lib/arraybuffer/ArrayBuffer#constructor
   call $~lib/map/Map<usize,~lib/string/String>#set:entries
-  local.get $0
+  local.get $this
   i32.const 4
   call $~lib/map/Map<usize,~lib/string/String>#set:entriesCapacity
-  local.get $0
+  local.get $this
   i32.const 0
   call $~lib/map/Map<usize,~lib/string/String>#set:entriesOffset
-  local.get $0
+  local.get $this
   i32.const 0
   call $~lib/map/Map<usize,~lib/string/String>#set:entriesCount
-  local.get $0
+  local.get $this
   local.set $1
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -4357,11 +4357,11 @@
   global.set $~lib/memory/__stack_pointer
   local.get $1
  )
- (func $~lib/map/Map<~lib/string/String,usize>#set (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
-  (local $3 i32)
-  (local $4 i32)
-  (local $5 i32)
-  (local $6 i32)
+ (func $~lib/map/Map<~lib/string/String,usize>#set (param $this i32) (param $key i32) (param $value i32) (result i32)
+  (local $hashCode i32)
+  (local $entry i32)
+  (local $var$5 i32)
+  (local $var$6 i32)
   (local $7 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -4371,32 +4371,32 @@
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   i32.store $0
-  local.get $1
+  local.get $key
   call $~lib/util/hash/HASH<~lib/string/String>
-  local.set $3
-  local.get $0
-  local.get $1
-  local.get $3
+  local.set $hashCode
+  local.get $this
+  local.get $key
+  local.get $hashCode
   call $~lib/map/Map<~lib/string/String,usize>#find
-  local.set $4
-  local.get $4
+  local.set $entry
+  local.get $entry
   if
-   local.get $4
-   local.get $2
+   local.get $entry
+   local.get $value
    call $~lib/map/MapEntry<~lib/string/String,usize>#set:value
    i32.const 0
    drop
   else
-   local.get $0
+   local.get $this
    i32.load $0 offset=16
-   local.get $0
+   local.get $this
    i32.load $0 offset=12
    i32.eq
    if
-    local.get $0
-    local.get $0
+    local.get $this
+    local.get $this
     i32.load $0 offset=20
-    local.get $0
+    local.get $this
     i32.load $0 offset=12
     i32.const 3
     i32.mul
@@ -4404,10 +4404,10 @@
     i32.div_s
     i32.lt_s
     if (result i32)
-     local.get $0
+     local.get $this
      i32.load $0 offset=4
     else
-     local.get $0
+     local.get $this
      i32.load $0 offset=4
      i32.const 1
      i32.shl
@@ -4417,62 +4417,62 @@
     call $~lib/map/Map<~lib/string/String,usize>#rehash
    end
    global.get $~lib/memory/__stack_pointer
-   local.get $0
+   local.get $this
    i32.load $0 offset=8
-   local.tee $5
+   local.tee $var$5
    i32.store $0
-   local.get $5
-   local.get $0
-   local.get $0
+   local.get $var$5
+   local.get $this
+   local.get $this
    i32.load $0 offset=16
-   local.tee $6
+   local.tee $var$6
    i32.const 1
    i32.add
    call $~lib/map/Map<~lib/string/String,usize>#set:entriesOffset
-   local.get $6
+   local.get $var$6
    i32.const 12
    i32.mul
    i32.add
-   local.set $4
-   local.get $4
-   local.get $1
+   local.set $entry
+   local.get $entry
+   local.get $key
    call $~lib/map/MapEntry<~lib/string/String,usize>#set:key
    i32.const 1
    drop
-   local.get $0
-   local.get $1
+   local.get $this
+   local.get $key
    i32.const 1
    call $~lib/rt/itcms/__link
-   local.get $4
-   local.get $2
+   local.get $entry
+   local.get $value
    call $~lib/map/MapEntry<~lib/string/String,usize>#set:value
    i32.const 0
    drop
-   local.get $0
-   local.get $0
+   local.get $this
+   local.get $this
    i32.load $0 offset=20
    i32.const 1
    i32.add
    call $~lib/map/Map<~lib/string/String,usize>#set:entriesCount
-   local.get $0
+   local.get $this
    i32.load $0
-   local.get $3
-   local.get $0
+   local.get $hashCode
+   local.get $this
    i32.load $0 offset=4
    i32.and
    i32.const 4
    i32.mul
    i32.add
-   local.set $6
-   local.get $4
-   local.get $6
+   local.set $var$6
+   local.get $entry
+   local.get $var$6
    i32.load $0
    call $~lib/map/MapEntry<~lib/string/String,usize>#set:taggedNext
-   local.get $6
-   local.get $4
+   local.get $var$6
+   local.get $entry
    i32.store $0
   end
-  local.get $0
+  local.get $this
   local.set $7
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -4480,11 +4480,11 @@
   global.set $~lib/memory/__stack_pointer
   local.get $7
  )
- (func $~lib/map/Map<usize,~lib/string/String>#set (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
-  (local $3 i32)
-  (local $4 i32)
-  (local $5 i32)
-  (local $6 i32)
+ (func $~lib/map/Map<usize,~lib/string/String>#set (param $this i32) (param $key i32) (param $value i32) (result i32)
+  (local $hashCode i32)
+  (local $entry i32)
+  (local $var$5 i32)
+  (local $var$6 i32)
   (local $7 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -4494,36 +4494,36 @@
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   i32.store $0
-  local.get $1
+  local.get $key
   call $~lib/util/hash/HASH<usize>
-  local.set $3
-  local.get $0
-  local.get $1
-  local.get $3
+  local.set $hashCode
+  local.get $this
+  local.get $key
+  local.get $hashCode
   call $~lib/map/Map<usize,~lib/string/String>#find
-  local.set $4
-  local.get $4
+  local.set $entry
+  local.get $entry
   if
-   local.get $4
-   local.get $2
+   local.get $entry
+   local.get $value
    call $~lib/map/MapEntry<usize,~lib/string/String>#set:value
    i32.const 1
    drop
-   local.get $0
-   local.get $2
+   local.get $this
+   local.get $value
    i32.const 1
    call $~lib/rt/itcms/__link
   else
-   local.get $0
+   local.get $this
    i32.load $0 offset=16
-   local.get $0
+   local.get $this
    i32.load $0 offset=12
    i32.eq
    if
-    local.get $0
-    local.get $0
+    local.get $this
+    local.get $this
     i32.load $0 offset=20
-    local.get $0
+    local.get $this
     i32.load $0 offset=12
     i32.const 3
     i32.mul
@@ -4531,10 +4531,10 @@
     i32.div_s
     i32.lt_s
     if (result i32)
-     local.get $0
+     local.get $this
      i32.load $0 offset=4
     else
-     local.get $0
+     local.get $this
      i32.load $0 offset=4
      i32.const 1
      i32.shl
@@ -4544,62 +4544,62 @@
     call $~lib/map/Map<usize,~lib/string/String>#rehash
    end
    global.get $~lib/memory/__stack_pointer
-   local.get $0
+   local.get $this
    i32.load $0 offset=8
-   local.tee $5
+   local.tee $var$5
    i32.store $0
-   local.get $5
-   local.get $0
-   local.get $0
+   local.get $var$5
+   local.get $this
+   local.get $this
    i32.load $0 offset=16
-   local.tee $6
+   local.tee $var$6
    i32.const 1
    i32.add
    call $~lib/map/Map<usize,~lib/string/String>#set:entriesOffset
-   local.get $6
+   local.get $var$6
    i32.const 12
    i32.mul
    i32.add
-   local.set $4
-   local.get $4
-   local.get $1
+   local.set $entry
+   local.get $entry
+   local.get $key
    call $~lib/map/MapEntry<usize,~lib/string/String>#set:key
    i32.const 0
    drop
-   local.get $4
-   local.get $2
+   local.get $entry
+   local.get $value
    call $~lib/map/MapEntry<usize,~lib/string/String>#set:value
    i32.const 1
    drop
-   local.get $0
-   local.get $2
+   local.get $this
+   local.get $value
    i32.const 1
    call $~lib/rt/itcms/__link
-   local.get $0
-   local.get $0
+   local.get $this
+   local.get $this
    i32.load $0 offset=20
    i32.const 1
    i32.add
    call $~lib/map/Map<usize,~lib/string/String>#set:entriesCount
-   local.get $0
+   local.get $this
    i32.load $0
-   local.get $3
-   local.get $0
+   local.get $hashCode
+   local.get $this
    i32.load $0 offset=4
    i32.and
    i32.const 4
    i32.mul
    i32.add
-   local.set $6
-   local.get $4
-   local.get $6
+   local.set $var$6
+   local.get $entry
+   local.get $var$6
    i32.load $0
    call $~lib/map/MapEntry<usize,~lib/string/String>#set:taggedNext
-   local.get $6
-   local.get $4
+   local.get $var$6
+   local.get $entry
    i32.store $0
   end
-  local.get $0
+  local.get $this
   local.set $7
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -4607,11 +4607,11 @@
   global.set $~lib/memory/__stack_pointer
   local.get $7
  )
- (func $~lib/string/String#concat (param $0 i32) (param $1 i32) (result i32)
-  (local $2 i32)
-  (local $3 i32)
-  (local $4 i32)
-  (local $5 i32)
+ (func $~lib/string/String#concat (param $this i32) (param $other i32) (result i32)
+  (local $thisSize i32)
+  (local $otherSize i32)
+  (local $outSize i32)
+  (local $out i32)
   (local $6 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -4621,21 +4621,21 @@
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   i32.store $0
-  local.get $0
+  local.get $this
   call $~lib/string/String#get:length
   i32.const 1
   i32.shl
-  local.set $2
-  local.get $1
+  local.set $thisSize
+  local.get $other
   call $~lib/string/String#get:length
   i32.const 1
   i32.shl
-  local.set $3
-  local.get $2
-  local.get $3
+  local.set $otherSize
+  local.get $thisSize
+  local.get $otherSize
   i32.add
-  local.set $4
-  local.get $4
+  local.set $outSize
+  local.get $outSize
   i32.const 0
   i32.eq
   if
@@ -4649,22 +4649,22 @@
    return
   end
   global.get $~lib/memory/__stack_pointer
-  local.get $4
+  local.get $outSize
   i32.const 1
   call $~lib/rt/itcms/__new
-  local.tee $5
+  local.tee $out
   i32.store $0
-  local.get $5
-  local.get $0
-  local.get $2
+  local.get $out
+  local.get $this
+  local.get $thisSize
   memory.copy $0 $0
-  local.get $5
-  local.get $2
+  local.get $out
+  local.get $thisSize
   i32.add
-  local.get $1
-  local.get $3
+  local.get $other
+  local.get $otherSize
   memory.copy $0 $0
-  local.get $5
+  local.get $out
   local.set $6
   global.get $~lib/memory/__stack_pointer
   i32.const 4

--- a/tests/compiler/std/typedarray.debug.wat
+++ b/tests/compiler/std/typedarray.debug.wat
@@ -40534,8 +40534,8 @@
   end
  )
  (func $std/typedarray/testReduce<~lib/typedarray/Int8Array,i8>
-  (local $0 i32)
-  (local $1 i32)
+  (local $array i32)
+  (local $result i32)
   (local $2 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 8
@@ -40549,21 +40549,21 @@
   i32.const 0
   i32.const 3
   call $~lib/typedarray/Int8Array#constructor
-  local.tee $0
+  local.tee $array
   i32.store $0
-  local.get $0
+  local.get $array
   i32.const 0
   i32.const 1
   call $~lib/typedarray/Int8Array#__set
-  local.get $0
+  local.get $array
   i32.const 1
   i32.const 2
   call $~lib/typedarray/Int8Array#__set
-  local.get $0
+  local.get $array
   i32.const 2
   i32.const 3
   call $~lib/typedarray/Int8Array#__set
-  local.get $0
+  local.get $array
   i32.const 1872
   local.set $2
   global.get $~lib/memory/__stack_pointer
@@ -40572,8 +40572,8 @@
   local.get $2
   i32.const 0
   call $~lib/typedarray/Int8Array#reduce<i8>
-  local.set $1
-  local.get $1
+  local.set $result
+  local.get $result
   i32.extend8_s
   i32.const 6
   i32.eq
@@ -40592,8 +40592,8 @@
   global.set $~lib/memory/__stack_pointer
  )
  (func $std/typedarray/testReduce<~lib/typedarray/Uint8Array,u8>
-  (local $0 i32)
-  (local $1 i32)
+  (local $array i32)
+  (local $result i32)
   (local $2 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 8
@@ -40607,21 +40607,21 @@
   i32.const 0
   i32.const 3
   call $~lib/typedarray/Uint8Array#constructor
-  local.tee $0
+  local.tee $array
   i32.store $0
-  local.get $0
+  local.get $array
   i32.const 0
   i32.const 1
   call $~lib/typedarray/Uint8Array#__set
-  local.get $0
+  local.get $array
   i32.const 1
   i32.const 2
   call $~lib/typedarray/Uint8Array#__set
-  local.get $0
+  local.get $array
   i32.const 2
   i32.const 3
   call $~lib/typedarray/Uint8Array#__set
-  local.get $0
+  local.get $array
   i32.const 1904
   local.set $2
   global.get $~lib/memory/__stack_pointer
@@ -40630,8 +40630,8 @@
   local.get $2
   i32.const 0
   call $~lib/typedarray/Uint8Array#reduce<u8>
-  local.set $1
-  local.get $1
+  local.set $result
+  local.get $result
   i32.const 255
   i32.and
   i32.const 6
@@ -40651,8 +40651,8 @@
   global.set $~lib/memory/__stack_pointer
  )
  (func $std/typedarray/testReduce<~lib/typedarray/Uint8ClampedArray,u8>
-  (local $0 i32)
-  (local $1 i32)
+  (local $array i32)
+  (local $result i32)
   (local $2 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 8
@@ -40666,21 +40666,21 @@
   i32.const 0
   i32.const 3
   call $~lib/typedarray/Uint8ClampedArray#constructor
-  local.tee $0
+  local.tee $array
   i32.store $0
-  local.get $0
+  local.get $array
   i32.const 0
   i32.const 1
   call $~lib/typedarray/Uint8ClampedArray#__set
-  local.get $0
+  local.get $array
   i32.const 1
   i32.const 2
   call $~lib/typedarray/Uint8ClampedArray#__set
-  local.get $0
+  local.get $array
   i32.const 2
   i32.const 3
   call $~lib/typedarray/Uint8ClampedArray#__set
-  local.get $0
+  local.get $array
   i32.const 1936
   local.set $2
   global.get $~lib/memory/__stack_pointer
@@ -40689,8 +40689,8 @@
   local.get $2
   i32.const 0
   call $~lib/typedarray/Uint8ClampedArray#reduce<u8>
-  local.set $1
-  local.get $1
+  local.set $result
+  local.get $result
   i32.const 255
   i32.and
   i32.const 6
@@ -40710,8 +40710,8 @@
   global.set $~lib/memory/__stack_pointer
  )
  (func $std/typedarray/testReduce<~lib/typedarray/Int16Array,i16>
-  (local $0 i32)
-  (local $1 i32)
+  (local $array i32)
+  (local $result i32)
   (local $2 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 8
@@ -40725,21 +40725,21 @@
   i32.const 0
   i32.const 3
   call $~lib/typedarray/Int16Array#constructor
-  local.tee $0
+  local.tee $array
   i32.store $0
-  local.get $0
+  local.get $array
   i32.const 0
   i32.const 1
   call $~lib/typedarray/Int16Array#__set
-  local.get $0
+  local.get $array
   i32.const 1
   i32.const 2
   call $~lib/typedarray/Int16Array#__set
-  local.get $0
+  local.get $array
   i32.const 2
   i32.const 3
   call $~lib/typedarray/Int16Array#__set
-  local.get $0
+  local.get $array
   i32.const 1968
   local.set $2
   global.get $~lib/memory/__stack_pointer
@@ -40748,8 +40748,8 @@
   local.get $2
   i32.const 0
   call $~lib/typedarray/Int16Array#reduce<i16>
-  local.set $1
-  local.get $1
+  local.set $result
+  local.get $result
   i32.extend16_s
   i32.const 6
   i32.eq
@@ -40768,8 +40768,8 @@
   global.set $~lib/memory/__stack_pointer
  )
  (func $std/typedarray/testReduce<~lib/typedarray/Uint16Array,u16>
-  (local $0 i32)
-  (local $1 i32)
+  (local $array i32)
+  (local $result i32)
   (local $2 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 8
@@ -40783,21 +40783,21 @@
   i32.const 0
   i32.const 3
   call $~lib/typedarray/Uint16Array#constructor
-  local.tee $0
+  local.tee $array
   i32.store $0
-  local.get $0
+  local.get $array
   i32.const 0
   i32.const 1
   call $~lib/typedarray/Uint16Array#__set
-  local.get $0
+  local.get $array
   i32.const 1
   i32.const 2
   call $~lib/typedarray/Uint16Array#__set
-  local.get $0
+  local.get $array
   i32.const 2
   i32.const 3
   call $~lib/typedarray/Uint16Array#__set
-  local.get $0
+  local.get $array
   i32.const 2000
   local.set $2
   global.get $~lib/memory/__stack_pointer
@@ -40806,8 +40806,8 @@
   local.get $2
   i32.const 0
   call $~lib/typedarray/Uint16Array#reduce<u16>
-  local.set $1
-  local.get $1
+  local.set $result
+  local.get $result
   i32.const 65535
   i32.and
   i32.const 6
@@ -40827,8 +40827,8 @@
   global.set $~lib/memory/__stack_pointer
  )
  (func $std/typedarray/testReduce<~lib/typedarray/Int32Array,i32>
-  (local $0 i32)
-  (local $1 i32)
+  (local $array i32)
+  (local $result i32)
   (local $2 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 8
@@ -40842,21 +40842,21 @@
   i32.const 0
   i32.const 3
   call $~lib/typedarray/Int32Array#constructor
-  local.tee $0
+  local.tee $array
   i32.store $0
-  local.get $0
+  local.get $array
   i32.const 0
   i32.const 1
   call $~lib/typedarray/Int32Array#__set
-  local.get $0
+  local.get $array
   i32.const 1
   i32.const 2
   call $~lib/typedarray/Int32Array#__set
-  local.get $0
+  local.get $array
   i32.const 2
   i32.const 3
   call $~lib/typedarray/Int32Array#__set
-  local.get $0
+  local.get $array
   i32.const 2032
   local.set $2
   global.get $~lib/memory/__stack_pointer
@@ -40865,8 +40865,8 @@
   local.get $2
   i32.const 0
   call $~lib/typedarray/Int32Array#reduce<i32>
-  local.set $1
-  local.get $1
+  local.set $result
+  local.get $result
   i32.const 6
   i32.eq
   i32.eqz
@@ -40884,8 +40884,8 @@
   global.set $~lib/memory/__stack_pointer
  )
  (func $std/typedarray/testReduce<~lib/typedarray/Uint32Array,u32>
-  (local $0 i32)
-  (local $1 i32)
+  (local $array i32)
+  (local $result i32)
   (local $2 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 8
@@ -40899,21 +40899,21 @@
   i32.const 0
   i32.const 3
   call $~lib/typedarray/Uint32Array#constructor
-  local.tee $0
+  local.tee $array
   i32.store $0
-  local.get $0
+  local.get $array
   i32.const 0
   i32.const 1
   call $~lib/typedarray/Uint32Array#__set
-  local.get $0
+  local.get $array
   i32.const 1
   i32.const 2
   call $~lib/typedarray/Uint32Array#__set
-  local.get $0
+  local.get $array
   i32.const 2
   i32.const 3
   call $~lib/typedarray/Uint32Array#__set
-  local.get $0
+  local.get $array
   i32.const 2064
   local.set $2
   global.get $~lib/memory/__stack_pointer
@@ -40922,8 +40922,8 @@
   local.get $2
   i32.const 0
   call $~lib/typedarray/Uint32Array#reduce<u32>
-  local.set $1
-  local.get $1
+  local.set $result
+  local.get $result
   i32.const 6
   i32.eq
   i32.eqz
@@ -40941,8 +40941,8 @@
   global.set $~lib/memory/__stack_pointer
  )
  (func $std/typedarray/testReduce<~lib/typedarray/Int64Array,i64>
-  (local $0 i32)
-  (local $1 i64)
+  (local $array i32)
+  (local $result i64)
   (local $2 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 8
@@ -40956,21 +40956,21 @@
   i32.const 0
   i32.const 3
   call $~lib/typedarray/Int64Array#constructor
-  local.tee $0
+  local.tee $array
   i32.store $0
-  local.get $0
+  local.get $array
   i32.const 0
   i64.const 1
   call $~lib/typedarray/Int64Array#__set
-  local.get $0
+  local.get $array
   i32.const 1
   i64.const 2
   call $~lib/typedarray/Int64Array#__set
-  local.get $0
+  local.get $array
   i32.const 2
   i64.const 3
   call $~lib/typedarray/Int64Array#__set
-  local.get $0
+  local.get $array
   i32.const 2096
   local.set $2
   global.get $~lib/memory/__stack_pointer
@@ -40979,8 +40979,8 @@
   local.get $2
   i64.const 0
   call $~lib/typedarray/Int64Array#reduce<i64>
-  local.set $1
-  local.get $1
+  local.set $result
+  local.get $result
   i64.const 6
   i64.eq
   i32.eqz
@@ -40998,8 +40998,8 @@
   global.set $~lib/memory/__stack_pointer
  )
  (func $std/typedarray/testReduce<~lib/typedarray/Uint64Array,u64>
-  (local $0 i32)
-  (local $1 i64)
+  (local $array i32)
+  (local $result i64)
   (local $2 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 8
@@ -41013,21 +41013,21 @@
   i32.const 0
   i32.const 3
   call $~lib/typedarray/Uint64Array#constructor
-  local.tee $0
+  local.tee $array
   i32.store $0
-  local.get $0
+  local.get $array
   i32.const 0
   i64.const 1
   call $~lib/typedarray/Uint64Array#__set
-  local.get $0
+  local.get $array
   i32.const 1
   i64.const 2
   call $~lib/typedarray/Uint64Array#__set
-  local.get $0
+  local.get $array
   i32.const 2
   i64.const 3
   call $~lib/typedarray/Uint64Array#__set
-  local.get $0
+  local.get $array
   i32.const 2128
   local.set $2
   global.get $~lib/memory/__stack_pointer
@@ -41036,8 +41036,8 @@
   local.get $2
   i64.const 0
   call $~lib/typedarray/Uint64Array#reduce<u64>
-  local.set $1
-  local.get $1
+  local.set $result
+  local.get $result
   i64.const 6
   i64.eq
   i32.eqz
@@ -41055,8 +41055,8 @@
   global.set $~lib/memory/__stack_pointer
  )
  (func $std/typedarray/testReduce<~lib/typedarray/Float32Array,f32>
-  (local $0 i32)
-  (local $1 f32)
+  (local $array i32)
+  (local $result f32)
   (local $2 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 8
@@ -41070,21 +41070,21 @@
   i32.const 0
   i32.const 3
   call $~lib/typedarray/Float32Array#constructor
-  local.tee $0
+  local.tee $array
   i32.store $0
-  local.get $0
+  local.get $array
   i32.const 0
   f32.const 1
   call $~lib/typedarray/Float32Array#__set
-  local.get $0
+  local.get $array
   i32.const 1
   f32.const 2
   call $~lib/typedarray/Float32Array#__set
-  local.get $0
+  local.get $array
   i32.const 2
   f32.const 3
   call $~lib/typedarray/Float32Array#__set
-  local.get $0
+  local.get $array
   i32.const 2160
   local.set $2
   global.get $~lib/memory/__stack_pointer
@@ -41093,8 +41093,8 @@
   local.get $2
   f32.const 0
   call $~lib/typedarray/Float32Array#reduce<f32>
-  local.set $1
-  local.get $1
+  local.set $result
+  local.get $result
   f32.const 6
   f32.eq
   i32.eqz
@@ -41112,8 +41112,8 @@
   global.set $~lib/memory/__stack_pointer
  )
  (func $std/typedarray/testReduce<~lib/typedarray/Float64Array,f64>
-  (local $0 i32)
-  (local $1 f64)
+  (local $array i32)
+  (local $result f64)
   (local $2 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 8
@@ -41127,21 +41127,21 @@
   i32.const 0
   i32.const 3
   call $~lib/typedarray/Float64Array#constructor
-  local.tee $0
+  local.tee $array
   i32.store $0
-  local.get $0
+  local.get $array
   i32.const 0
   f64.const 1
   call $~lib/typedarray/Float64Array#__set
-  local.get $0
+  local.get $array
   i32.const 1
   f64.const 2
   call $~lib/typedarray/Float64Array#__set
-  local.get $0
+  local.get $array
   i32.const 2
   f64.const 3
   call $~lib/typedarray/Float64Array#__set
-  local.get $0
+  local.get $array
   i32.const 2192
   local.set $2
   global.get $~lib/memory/__stack_pointer
@@ -41150,8 +41150,8 @@
   local.get $2
   f64.const 0
   call $~lib/typedarray/Float64Array#reduce<f64>
-  local.set $1
-  local.get $1
+  local.set $result
+  local.get $result
   f64.const 6
   f64.eq
   i32.eqz
@@ -41169,8 +41169,8 @@
   global.set $~lib/memory/__stack_pointer
  )
  (func $std/typedarray/testReduceRight<~lib/typedarray/Int8Array,i8>
-  (local $0 i32)
-  (local $1 i32)
+  (local $array i32)
+  (local $result i32)
   (local $2 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 8
@@ -41184,21 +41184,21 @@
   i32.const 0
   i32.const 3
   call $~lib/typedarray/Int8Array#constructor
-  local.tee $0
+  local.tee $array
   i32.store $0
-  local.get $0
+  local.get $array
   i32.const 0
   i32.const 1
   call $~lib/typedarray/Int8Array#__set
-  local.get $0
+  local.get $array
   i32.const 1
   i32.const 2
   call $~lib/typedarray/Int8Array#__set
-  local.get $0
+  local.get $array
   i32.const 2
   i32.const 3
   call $~lib/typedarray/Int8Array#__set
-  local.get $0
+  local.get $array
   i32.const 2224
   local.set $2
   global.get $~lib/memory/__stack_pointer
@@ -41207,8 +41207,8 @@
   local.get $2
   i32.const 0
   call $~lib/typedarray/Int8Array#reduceRight<i8>
-  local.set $1
-  local.get $1
+  local.set $result
+  local.get $result
   i32.extend8_s
   i32.const 6
   i32.eq
@@ -41227,8 +41227,8 @@
   global.set $~lib/memory/__stack_pointer
  )
  (func $std/typedarray/testReduceRight<~lib/typedarray/Uint8Array,u8>
-  (local $0 i32)
-  (local $1 i32)
+  (local $array i32)
+  (local $result i32)
   (local $2 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 8
@@ -41242,21 +41242,21 @@
   i32.const 0
   i32.const 3
   call $~lib/typedarray/Uint8Array#constructor
-  local.tee $0
+  local.tee $array
   i32.store $0
-  local.get $0
+  local.get $array
   i32.const 0
   i32.const 1
   call $~lib/typedarray/Uint8Array#__set
-  local.get $0
+  local.get $array
   i32.const 1
   i32.const 2
   call $~lib/typedarray/Uint8Array#__set
-  local.get $0
+  local.get $array
   i32.const 2
   i32.const 3
   call $~lib/typedarray/Uint8Array#__set
-  local.get $0
+  local.get $array
   i32.const 2256
   local.set $2
   global.get $~lib/memory/__stack_pointer
@@ -41265,8 +41265,8 @@
   local.get $2
   i32.const 0
   call $~lib/typedarray/Uint8Array#reduceRight<u8>
-  local.set $1
-  local.get $1
+  local.set $result
+  local.get $result
   i32.const 255
   i32.and
   i32.const 6
@@ -41286,8 +41286,8 @@
   global.set $~lib/memory/__stack_pointer
  )
  (func $std/typedarray/testReduceRight<~lib/typedarray/Uint8ClampedArray,u8>
-  (local $0 i32)
-  (local $1 i32)
+  (local $array i32)
+  (local $result i32)
   (local $2 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 8
@@ -41301,21 +41301,21 @@
   i32.const 0
   i32.const 3
   call $~lib/typedarray/Uint8ClampedArray#constructor
-  local.tee $0
+  local.tee $array
   i32.store $0
-  local.get $0
+  local.get $array
   i32.const 0
   i32.const 1
   call $~lib/typedarray/Uint8ClampedArray#__set
-  local.get $0
+  local.get $array
   i32.const 1
   i32.const 2
   call $~lib/typedarray/Uint8ClampedArray#__set
-  local.get $0
+  local.get $array
   i32.const 2
   i32.const 3
   call $~lib/typedarray/Uint8ClampedArray#__set
-  local.get $0
+  local.get $array
   i32.const 2288
   local.set $2
   global.get $~lib/memory/__stack_pointer
@@ -41324,8 +41324,8 @@
   local.get $2
   i32.const 0
   call $~lib/typedarray/Uint8ClampedArray#reduceRight<u8>
-  local.set $1
-  local.get $1
+  local.set $result
+  local.get $result
   i32.const 255
   i32.and
   i32.const 6
@@ -41345,8 +41345,8 @@
   global.set $~lib/memory/__stack_pointer
  )
  (func $std/typedarray/testReduceRight<~lib/typedarray/Int16Array,i16>
-  (local $0 i32)
-  (local $1 i32)
+  (local $array i32)
+  (local $result i32)
   (local $2 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 8
@@ -41360,21 +41360,21 @@
   i32.const 0
   i32.const 3
   call $~lib/typedarray/Int16Array#constructor
-  local.tee $0
+  local.tee $array
   i32.store $0
-  local.get $0
+  local.get $array
   i32.const 0
   i32.const 1
   call $~lib/typedarray/Int16Array#__set
-  local.get $0
+  local.get $array
   i32.const 1
   i32.const 2
   call $~lib/typedarray/Int16Array#__set
-  local.get $0
+  local.get $array
   i32.const 2
   i32.const 3
   call $~lib/typedarray/Int16Array#__set
-  local.get $0
+  local.get $array
   i32.const 2320
   local.set $2
   global.get $~lib/memory/__stack_pointer
@@ -41383,8 +41383,8 @@
   local.get $2
   i32.const 0
   call $~lib/typedarray/Int16Array#reduceRight<i16>
-  local.set $1
-  local.get $1
+  local.set $result
+  local.get $result
   i32.extend16_s
   i32.const 6
   i32.eq
@@ -41403,8 +41403,8 @@
   global.set $~lib/memory/__stack_pointer
  )
  (func $std/typedarray/testReduceRight<~lib/typedarray/Uint16Array,u16>
-  (local $0 i32)
-  (local $1 i32)
+  (local $array i32)
+  (local $result i32)
   (local $2 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 8
@@ -41418,21 +41418,21 @@
   i32.const 0
   i32.const 3
   call $~lib/typedarray/Uint16Array#constructor
-  local.tee $0
+  local.tee $array
   i32.store $0
-  local.get $0
+  local.get $array
   i32.const 0
   i32.const 1
   call $~lib/typedarray/Uint16Array#__set
-  local.get $0
+  local.get $array
   i32.const 1
   i32.const 2
   call $~lib/typedarray/Uint16Array#__set
-  local.get $0
+  local.get $array
   i32.const 2
   i32.const 3
   call $~lib/typedarray/Uint16Array#__set
-  local.get $0
+  local.get $array
   i32.const 2352
   local.set $2
   global.get $~lib/memory/__stack_pointer
@@ -41441,8 +41441,8 @@
   local.get $2
   i32.const 0
   call $~lib/typedarray/Uint16Array#reduceRight<u16>
-  local.set $1
-  local.get $1
+  local.set $result
+  local.get $result
   i32.const 65535
   i32.and
   i32.const 6
@@ -41462,8 +41462,8 @@
   global.set $~lib/memory/__stack_pointer
  )
  (func $std/typedarray/testReduceRight<~lib/typedarray/Int32Array,i32>
-  (local $0 i32)
-  (local $1 i32)
+  (local $array i32)
+  (local $result i32)
   (local $2 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 8
@@ -41477,21 +41477,21 @@
   i32.const 0
   i32.const 3
   call $~lib/typedarray/Int32Array#constructor
-  local.tee $0
+  local.tee $array
   i32.store $0
-  local.get $0
+  local.get $array
   i32.const 0
   i32.const 1
   call $~lib/typedarray/Int32Array#__set
-  local.get $0
+  local.get $array
   i32.const 1
   i32.const 2
   call $~lib/typedarray/Int32Array#__set
-  local.get $0
+  local.get $array
   i32.const 2
   i32.const 3
   call $~lib/typedarray/Int32Array#__set
-  local.get $0
+  local.get $array
   i32.const 2384
   local.set $2
   global.get $~lib/memory/__stack_pointer
@@ -41500,8 +41500,8 @@
   local.get $2
   i32.const 0
   call $~lib/typedarray/Int32Array#reduceRight<i32>
-  local.set $1
-  local.get $1
+  local.set $result
+  local.get $result
   i32.const 6
   i32.eq
   i32.eqz
@@ -41519,8 +41519,8 @@
   global.set $~lib/memory/__stack_pointer
  )
  (func $std/typedarray/testReduceRight<~lib/typedarray/Uint32Array,u32>
-  (local $0 i32)
-  (local $1 i32)
+  (local $array i32)
+  (local $result i32)
   (local $2 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 8
@@ -41534,21 +41534,21 @@
   i32.const 0
   i32.const 3
   call $~lib/typedarray/Uint32Array#constructor
-  local.tee $0
+  local.tee $array
   i32.store $0
-  local.get $0
+  local.get $array
   i32.const 0
   i32.const 1
   call $~lib/typedarray/Uint32Array#__set
-  local.get $0
+  local.get $array
   i32.const 1
   i32.const 2
   call $~lib/typedarray/Uint32Array#__set
-  local.get $0
+  local.get $array
   i32.const 2
   i32.const 3
   call $~lib/typedarray/Uint32Array#__set
-  local.get $0
+  local.get $array
   i32.const 2416
   local.set $2
   global.get $~lib/memory/__stack_pointer
@@ -41557,8 +41557,8 @@
   local.get $2
   i32.const 0
   call $~lib/typedarray/Uint32Array#reduceRight<u32>
-  local.set $1
-  local.get $1
+  local.set $result
+  local.get $result
   i32.const 6
   i32.eq
   i32.eqz
@@ -41576,8 +41576,8 @@
   global.set $~lib/memory/__stack_pointer
  )
  (func $std/typedarray/testReduceRight<~lib/typedarray/Int64Array,i64>
-  (local $0 i32)
-  (local $1 i64)
+  (local $array i32)
+  (local $result i64)
   (local $2 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 8
@@ -41591,21 +41591,21 @@
   i32.const 0
   i32.const 3
   call $~lib/typedarray/Int64Array#constructor
-  local.tee $0
+  local.tee $array
   i32.store $0
-  local.get $0
+  local.get $array
   i32.const 0
   i64.const 1
   call $~lib/typedarray/Int64Array#__set
-  local.get $0
+  local.get $array
   i32.const 1
   i64.const 2
   call $~lib/typedarray/Int64Array#__set
-  local.get $0
+  local.get $array
   i32.const 2
   i64.const 3
   call $~lib/typedarray/Int64Array#__set
-  local.get $0
+  local.get $array
   i32.const 2448
   local.set $2
   global.get $~lib/memory/__stack_pointer
@@ -41614,8 +41614,8 @@
   local.get $2
   i64.const 0
   call $~lib/typedarray/Int64Array#reduceRight<i64>
-  local.set $1
-  local.get $1
+  local.set $result
+  local.get $result
   i64.const 6
   i64.eq
   i32.eqz
@@ -41633,8 +41633,8 @@
   global.set $~lib/memory/__stack_pointer
  )
  (func $std/typedarray/testReduceRight<~lib/typedarray/Uint64Array,u64>
-  (local $0 i32)
-  (local $1 i64)
+  (local $array i32)
+  (local $result i64)
   (local $2 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 8
@@ -41648,21 +41648,21 @@
   i32.const 0
   i32.const 3
   call $~lib/typedarray/Uint64Array#constructor
-  local.tee $0
+  local.tee $array
   i32.store $0
-  local.get $0
+  local.get $array
   i32.const 0
   i64.const 1
   call $~lib/typedarray/Uint64Array#__set
-  local.get $0
+  local.get $array
   i32.const 1
   i64.const 2
   call $~lib/typedarray/Uint64Array#__set
-  local.get $0
+  local.get $array
   i32.const 2
   i64.const 3
   call $~lib/typedarray/Uint64Array#__set
-  local.get $0
+  local.get $array
   i32.const 2480
   local.set $2
   global.get $~lib/memory/__stack_pointer
@@ -41671,8 +41671,8 @@
   local.get $2
   i64.const 0
   call $~lib/typedarray/Uint64Array#reduceRight<u64>
-  local.set $1
-  local.get $1
+  local.set $result
+  local.get $result
   i64.const 6
   i64.eq
   i32.eqz
@@ -41690,8 +41690,8 @@
   global.set $~lib/memory/__stack_pointer
  )
  (func $std/typedarray/testReduceRight<~lib/typedarray/Float32Array,f32>
-  (local $0 i32)
-  (local $1 f32)
+  (local $array i32)
+  (local $result f32)
   (local $2 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 8
@@ -41705,21 +41705,21 @@
   i32.const 0
   i32.const 3
   call $~lib/typedarray/Float32Array#constructor
-  local.tee $0
+  local.tee $array
   i32.store $0
-  local.get $0
+  local.get $array
   i32.const 0
   f32.const 1
   call $~lib/typedarray/Float32Array#__set
-  local.get $0
+  local.get $array
   i32.const 1
   f32.const 2
   call $~lib/typedarray/Float32Array#__set
-  local.get $0
+  local.get $array
   i32.const 2
   f32.const 3
   call $~lib/typedarray/Float32Array#__set
-  local.get $0
+  local.get $array
   i32.const 2512
   local.set $2
   global.get $~lib/memory/__stack_pointer
@@ -41728,8 +41728,8 @@
   local.get $2
   f32.const 0
   call $~lib/typedarray/Float32Array#reduceRight<f32>
-  local.set $1
-  local.get $1
+  local.set $result
+  local.get $result
   f32.const 6
   f32.eq
   i32.eqz
@@ -41747,8 +41747,8 @@
   global.set $~lib/memory/__stack_pointer
  )
  (func $std/typedarray/testReduceRight<~lib/typedarray/Float64Array,f64>
-  (local $0 i32)
-  (local $1 f64)
+  (local $array i32)
+  (local $result f64)
   (local $2 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 8
@@ -41762,21 +41762,21 @@
   i32.const 0
   i32.const 3
   call $~lib/typedarray/Float64Array#constructor
-  local.tee $0
+  local.tee $array
   i32.store $0
-  local.get $0
+  local.get $array
   i32.const 0
   f64.const 1
   call $~lib/typedarray/Float64Array#__set
-  local.get $0
+  local.get $array
   i32.const 1
   f64.const 2
   call $~lib/typedarray/Float64Array#__set
-  local.get $0
+  local.get $array
   i32.const 2
   f64.const 3
   call $~lib/typedarray/Float64Array#__set
-  local.get $0
+  local.get $array
   i32.const 2544
   local.set $2
   global.get $~lib/memory/__stack_pointer
@@ -41785,8 +41785,8 @@
   local.get $2
   f64.const 0
   call $~lib/typedarray/Float64Array#reduceRight<f64>
-  local.set $1
-  local.get $1
+  local.set $result
+  local.get $result
   f64.const 6
   f64.eq
   i32.eqz
@@ -41804,8 +41804,8 @@
   global.set $~lib/memory/__stack_pointer
  )
  (func $std/typedarray/testArrayMap<~lib/typedarray/Int8Array,i8>
-  (local $0 i32)
-  (local $1 i32)
+  (local $source i32)
+  (local $result i32)
   (local $2 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 12
@@ -41822,22 +41822,22 @@
   i32.const 0
   i32.const 3
   call $~lib/typedarray/Int8Array#constructor
-  local.tee $0
+  local.tee $source
   i32.store $0
-  local.get $0
+  local.get $source
   i32.const 0
   i32.const 1
   call $~lib/typedarray/Int8Array#__set
-  local.get $0
+  local.get $source
   i32.const 1
   i32.const 2
   call $~lib/typedarray/Int8Array#__set
-  local.get $0
+  local.get $source
   i32.const 2
   i32.const 3
   call $~lib/typedarray/Int8Array#__set
   global.get $~lib/memory/__stack_pointer
-  local.get $0
+  local.get $source
   i32.const 2576
   local.set $2
   global.get $~lib/memory/__stack_pointer
@@ -41845,9 +41845,9 @@
   i32.store $0 offset=4
   local.get $2
   call $~lib/typedarray/Int8Array#map
-  local.tee $1
+  local.tee $result
   i32.store $0 offset=8
-  local.get $1
+  local.get $result
   i32.const 0
   call $~lib/typedarray/Int8Array#__get
   i32.const 1
@@ -41861,7 +41861,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $1
+  local.get $result
   i32.const 1
   call $~lib/typedarray/Int8Array#__get
   i32.const 4
@@ -41875,7 +41875,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $1
+  local.get $result
   i32.const 2
   call $~lib/typedarray/Int8Array#__get
   i32.const 9
@@ -41895,8 +41895,8 @@
   global.set $~lib/memory/__stack_pointer
  )
  (func $std/typedarray/testArrayMap<~lib/typedarray/Uint8Array,u8>
-  (local $0 i32)
-  (local $1 i32)
+  (local $source i32)
+  (local $result i32)
   (local $2 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 12
@@ -41913,22 +41913,22 @@
   i32.const 0
   i32.const 3
   call $~lib/typedarray/Uint8Array#constructor
-  local.tee $0
+  local.tee $source
   i32.store $0
-  local.get $0
+  local.get $source
   i32.const 0
   i32.const 1
   call $~lib/typedarray/Uint8Array#__set
-  local.get $0
+  local.get $source
   i32.const 1
   i32.const 2
   call $~lib/typedarray/Uint8Array#__set
-  local.get $0
+  local.get $source
   i32.const 2
   i32.const 3
   call $~lib/typedarray/Uint8Array#__set
   global.get $~lib/memory/__stack_pointer
-  local.get $0
+  local.get $source
   i32.const 2608
   local.set $2
   global.get $~lib/memory/__stack_pointer
@@ -41936,9 +41936,9 @@
   i32.store $0 offset=4
   local.get $2
   call $~lib/typedarray/Uint8Array#map
-  local.tee $1
+  local.tee $result
   i32.store $0 offset=8
-  local.get $1
+  local.get $result
   i32.const 0
   call $~lib/typedarray/Uint8Array#__get
   i32.const 1
@@ -41952,7 +41952,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $1
+  local.get $result
   i32.const 1
   call $~lib/typedarray/Uint8Array#__get
   i32.const 4
@@ -41966,7 +41966,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $1
+  local.get $result
   i32.const 2
   call $~lib/typedarray/Uint8Array#__get
   i32.const 9
@@ -41986,8 +41986,8 @@
   global.set $~lib/memory/__stack_pointer
  )
  (func $std/typedarray/testArrayMap<~lib/typedarray/Uint8ClampedArray,u8>
-  (local $0 i32)
-  (local $1 i32)
+  (local $source i32)
+  (local $result i32)
   (local $2 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 12
@@ -42004,22 +42004,22 @@
   i32.const 0
   i32.const 3
   call $~lib/typedarray/Uint8ClampedArray#constructor
-  local.tee $0
+  local.tee $source
   i32.store $0
-  local.get $0
+  local.get $source
   i32.const 0
   i32.const 1
   call $~lib/typedarray/Uint8ClampedArray#__set
-  local.get $0
+  local.get $source
   i32.const 1
   i32.const 2
   call $~lib/typedarray/Uint8ClampedArray#__set
-  local.get $0
+  local.get $source
   i32.const 2
   i32.const 3
   call $~lib/typedarray/Uint8ClampedArray#__set
   global.get $~lib/memory/__stack_pointer
-  local.get $0
+  local.get $source
   i32.const 2640
   local.set $2
   global.get $~lib/memory/__stack_pointer
@@ -42027,9 +42027,9 @@
   i32.store $0 offset=4
   local.get $2
   call $~lib/typedarray/Uint8ClampedArray#map
-  local.tee $1
+  local.tee $result
   i32.store $0 offset=8
-  local.get $1
+  local.get $result
   i32.const 0
   call $~lib/typedarray/Uint8ClampedArray#__get
   i32.const 1
@@ -42043,7 +42043,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $1
+  local.get $result
   i32.const 1
   call $~lib/typedarray/Uint8ClampedArray#__get
   i32.const 4
@@ -42057,7 +42057,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $1
+  local.get $result
   i32.const 2
   call $~lib/typedarray/Uint8ClampedArray#__get
   i32.const 9
@@ -42077,8 +42077,8 @@
   global.set $~lib/memory/__stack_pointer
  )
  (func $std/typedarray/testArrayMap<~lib/typedarray/Int16Array,i16>
-  (local $0 i32)
-  (local $1 i32)
+  (local $source i32)
+  (local $result i32)
   (local $2 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 12
@@ -42095,22 +42095,22 @@
   i32.const 0
   i32.const 3
   call $~lib/typedarray/Int16Array#constructor
-  local.tee $0
+  local.tee $source
   i32.store $0
-  local.get $0
+  local.get $source
   i32.const 0
   i32.const 1
   call $~lib/typedarray/Int16Array#__set
-  local.get $0
+  local.get $source
   i32.const 1
   i32.const 2
   call $~lib/typedarray/Int16Array#__set
-  local.get $0
+  local.get $source
   i32.const 2
   i32.const 3
   call $~lib/typedarray/Int16Array#__set
   global.get $~lib/memory/__stack_pointer
-  local.get $0
+  local.get $source
   i32.const 2672
   local.set $2
   global.get $~lib/memory/__stack_pointer
@@ -42118,9 +42118,9 @@
   i32.store $0 offset=4
   local.get $2
   call $~lib/typedarray/Int16Array#map
-  local.tee $1
+  local.tee $result
   i32.store $0 offset=8
-  local.get $1
+  local.get $result
   i32.const 0
   call $~lib/typedarray/Int16Array#__get
   i32.const 1
@@ -42134,7 +42134,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $1
+  local.get $result
   i32.const 1
   call $~lib/typedarray/Int16Array#__get
   i32.const 4
@@ -42148,7 +42148,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $1
+  local.get $result
   i32.const 2
   call $~lib/typedarray/Int16Array#__get
   i32.const 9
@@ -42168,8 +42168,8 @@
   global.set $~lib/memory/__stack_pointer
  )
  (func $std/typedarray/testArrayMap<~lib/typedarray/Uint16Array,u16>
-  (local $0 i32)
-  (local $1 i32)
+  (local $source i32)
+  (local $result i32)
   (local $2 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 12
@@ -42186,22 +42186,22 @@
   i32.const 0
   i32.const 3
   call $~lib/typedarray/Uint16Array#constructor
-  local.tee $0
+  local.tee $source
   i32.store $0
-  local.get $0
+  local.get $source
   i32.const 0
   i32.const 1
   call $~lib/typedarray/Uint16Array#__set
-  local.get $0
+  local.get $source
   i32.const 1
   i32.const 2
   call $~lib/typedarray/Uint16Array#__set
-  local.get $0
+  local.get $source
   i32.const 2
   i32.const 3
   call $~lib/typedarray/Uint16Array#__set
   global.get $~lib/memory/__stack_pointer
-  local.get $0
+  local.get $source
   i32.const 2704
   local.set $2
   global.get $~lib/memory/__stack_pointer
@@ -42209,9 +42209,9 @@
   i32.store $0 offset=4
   local.get $2
   call $~lib/typedarray/Uint16Array#map
-  local.tee $1
+  local.tee $result
   i32.store $0 offset=8
-  local.get $1
+  local.get $result
   i32.const 0
   call $~lib/typedarray/Uint16Array#__get
   i32.const 1
@@ -42225,7 +42225,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $1
+  local.get $result
   i32.const 1
   call $~lib/typedarray/Uint16Array#__get
   i32.const 4
@@ -42239,7 +42239,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $1
+  local.get $result
   i32.const 2
   call $~lib/typedarray/Uint16Array#__get
   i32.const 9
@@ -42259,8 +42259,8 @@
   global.set $~lib/memory/__stack_pointer
  )
  (func $std/typedarray/testArrayMap<~lib/typedarray/Int32Array,i32>
-  (local $0 i32)
-  (local $1 i32)
+  (local $source i32)
+  (local $result i32)
   (local $2 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 12
@@ -42277,22 +42277,22 @@
   i32.const 0
   i32.const 3
   call $~lib/typedarray/Int32Array#constructor
-  local.tee $0
+  local.tee $source
   i32.store $0
-  local.get $0
+  local.get $source
   i32.const 0
   i32.const 1
   call $~lib/typedarray/Int32Array#__set
-  local.get $0
+  local.get $source
   i32.const 1
   i32.const 2
   call $~lib/typedarray/Int32Array#__set
-  local.get $0
+  local.get $source
   i32.const 2
   i32.const 3
   call $~lib/typedarray/Int32Array#__set
   global.get $~lib/memory/__stack_pointer
-  local.get $0
+  local.get $source
   i32.const 2736
   local.set $2
   global.get $~lib/memory/__stack_pointer
@@ -42300,9 +42300,9 @@
   i32.store $0 offset=4
   local.get $2
   call $~lib/typedarray/Int32Array#map
-  local.tee $1
+  local.tee $result
   i32.store $0 offset=8
-  local.get $1
+  local.get $result
   i32.const 0
   call $~lib/typedarray/Int32Array#__get
   i32.const 1
@@ -42316,7 +42316,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $1
+  local.get $result
   i32.const 1
   call $~lib/typedarray/Int32Array#__get
   i32.const 4
@@ -42330,7 +42330,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $1
+  local.get $result
   i32.const 2
   call $~lib/typedarray/Int32Array#__get
   i32.const 9
@@ -42350,8 +42350,8 @@
   global.set $~lib/memory/__stack_pointer
  )
  (func $std/typedarray/testArrayMap<~lib/typedarray/Uint32Array,u32>
-  (local $0 i32)
-  (local $1 i32)
+  (local $source i32)
+  (local $result i32)
   (local $2 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 12
@@ -42368,22 +42368,22 @@
   i32.const 0
   i32.const 3
   call $~lib/typedarray/Uint32Array#constructor
-  local.tee $0
+  local.tee $source
   i32.store $0
-  local.get $0
+  local.get $source
   i32.const 0
   i32.const 1
   call $~lib/typedarray/Uint32Array#__set
-  local.get $0
+  local.get $source
   i32.const 1
   i32.const 2
   call $~lib/typedarray/Uint32Array#__set
-  local.get $0
+  local.get $source
   i32.const 2
   i32.const 3
   call $~lib/typedarray/Uint32Array#__set
   global.get $~lib/memory/__stack_pointer
-  local.get $0
+  local.get $source
   i32.const 2768
   local.set $2
   global.get $~lib/memory/__stack_pointer
@@ -42391,9 +42391,9 @@
   i32.store $0 offset=4
   local.get $2
   call $~lib/typedarray/Uint32Array#map
-  local.tee $1
+  local.tee $result
   i32.store $0 offset=8
-  local.get $1
+  local.get $result
   i32.const 0
   call $~lib/typedarray/Uint32Array#__get
   i32.const 1
@@ -42407,7 +42407,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $1
+  local.get $result
   i32.const 1
   call $~lib/typedarray/Uint32Array#__get
   i32.const 4
@@ -42421,7 +42421,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $1
+  local.get $result
   i32.const 2
   call $~lib/typedarray/Uint32Array#__get
   i32.const 9
@@ -42441,8 +42441,8 @@
   global.set $~lib/memory/__stack_pointer
  )
  (func $std/typedarray/testArrayMap<~lib/typedarray/Int64Array,i64>
-  (local $0 i32)
-  (local $1 i32)
+  (local $source i32)
+  (local $result i32)
   (local $2 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 12
@@ -42459,22 +42459,22 @@
   i32.const 0
   i32.const 3
   call $~lib/typedarray/Int64Array#constructor
-  local.tee $0
+  local.tee $source
   i32.store $0
-  local.get $0
+  local.get $source
   i32.const 0
   i64.const 1
   call $~lib/typedarray/Int64Array#__set
-  local.get $0
+  local.get $source
   i32.const 1
   i64.const 2
   call $~lib/typedarray/Int64Array#__set
-  local.get $0
+  local.get $source
   i32.const 2
   i64.const 3
   call $~lib/typedarray/Int64Array#__set
   global.get $~lib/memory/__stack_pointer
-  local.get $0
+  local.get $source
   i32.const 2800
   local.set $2
   global.get $~lib/memory/__stack_pointer
@@ -42482,9 +42482,9 @@
   i32.store $0 offset=4
   local.get $2
   call $~lib/typedarray/Int64Array#map
-  local.tee $1
+  local.tee $result
   i32.store $0 offset=8
-  local.get $1
+  local.get $result
   i32.const 0
   call $~lib/typedarray/Int64Array#__get
   i64.const 1
@@ -42498,7 +42498,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $1
+  local.get $result
   i32.const 1
   call $~lib/typedarray/Int64Array#__get
   i64.const 4
@@ -42512,7 +42512,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $1
+  local.get $result
   i32.const 2
   call $~lib/typedarray/Int64Array#__get
   i64.const 9
@@ -42532,8 +42532,8 @@
   global.set $~lib/memory/__stack_pointer
  )
  (func $std/typedarray/testArrayMap<~lib/typedarray/Uint64Array,u64>
-  (local $0 i32)
-  (local $1 i32)
+  (local $source i32)
+  (local $result i32)
   (local $2 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 12
@@ -42550,22 +42550,22 @@
   i32.const 0
   i32.const 3
   call $~lib/typedarray/Uint64Array#constructor
-  local.tee $0
+  local.tee $source
   i32.store $0
-  local.get $0
+  local.get $source
   i32.const 0
   i64.const 1
   call $~lib/typedarray/Uint64Array#__set
-  local.get $0
+  local.get $source
   i32.const 1
   i64.const 2
   call $~lib/typedarray/Uint64Array#__set
-  local.get $0
+  local.get $source
   i32.const 2
   i64.const 3
   call $~lib/typedarray/Uint64Array#__set
   global.get $~lib/memory/__stack_pointer
-  local.get $0
+  local.get $source
   i32.const 2832
   local.set $2
   global.get $~lib/memory/__stack_pointer
@@ -42573,9 +42573,9 @@
   i32.store $0 offset=4
   local.get $2
   call $~lib/typedarray/Uint64Array#map
-  local.tee $1
+  local.tee $result
   i32.store $0 offset=8
-  local.get $1
+  local.get $result
   i32.const 0
   call $~lib/typedarray/Uint64Array#__get
   i64.const 1
@@ -42589,7 +42589,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $1
+  local.get $result
   i32.const 1
   call $~lib/typedarray/Uint64Array#__get
   i64.const 4
@@ -42603,7 +42603,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $1
+  local.get $result
   i32.const 2
   call $~lib/typedarray/Uint64Array#__get
   i64.const 9
@@ -42623,8 +42623,8 @@
   global.set $~lib/memory/__stack_pointer
  )
  (func $std/typedarray/testArrayMap<~lib/typedarray/Float32Array,f32>
-  (local $0 i32)
-  (local $1 i32)
+  (local $source i32)
+  (local $result i32)
   (local $2 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 12
@@ -42641,22 +42641,22 @@
   i32.const 0
   i32.const 3
   call $~lib/typedarray/Float32Array#constructor
-  local.tee $0
+  local.tee $source
   i32.store $0
-  local.get $0
+  local.get $source
   i32.const 0
   f32.const 1
   call $~lib/typedarray/Float32Array#__set
-  local.get $0
+  local.get $source
   i32.const 1
   f32.const 2
   call $~lib/typedarray/Float32Array#__set
-  local.get $0
+  local.get $source
   i32.const 2
   f32.const 3
   call $~lib/typedarray/Float32Array#__set
   global.get $~lib/memory/__stack_pointer
-  local.get $0
+  local.get $source
   i32.const 2864
   local.set $2
   global.get $~lib/memory/__stack_pointer
@@ -42664,9 +42664,9 @@
   i32.store $0 offset=4
   local.get $2
   call $~lib/typedarray/Float32Array#map
-  local.tee $1
+  local.tee $result
   i32.store $0 offset=8
-  local.get $1
+  local.get $result
   i32.const 0
   call $~lib/typedarray/Float32Array#__get
   f32.const 1
@@ -42680,7 +42680,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $1
+  local.get $result
   i32.const 1
   call $~lib/typedarray/Float32Array#__get
   f32.const 4
@@ -42694,7 +42694,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $1
+  local.get $result
   i32.const 2
   call $~lib/typedarray/Float32Array#__get
   f32.const 9
@@ -42714,8 +42714,8 @@
   global.set $~lib/memory/__stack_pointer
  )
  (func $std/typedarray/testArrayMap<~lib/typedarray/Float64Array,f64>
-  (local $0 i32)
-  (local $1 i32)
+  (local $source i32)
+  (local $result i32)
   (local $2 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 12
@@ -42732,22 +42732,22 @@
   i32.const 0
   i32.const 3
   call $~lib/typedarray/Float64Array#constructor
-  local.tee $0
+  local.tee $source
   i32.store $0
-  local.get $0
+  local.get $source
   i32.const 0
   f64.const 1
   call $~lib/typedarray/Float64Array#__set
-  local.get $0
+  local.get $source
   i32.const 1
   f64.const 2
   call $~lib/typedarray/Float64Array#__set
-  local.get $0
+  local.get $source
   i32.const 2
   f64.const 3
   call $~lib/typedarray/Float64Array#__set
   global.get $~lib/memory/__stack_pointer
-  local.get $0
+  local.get $source
   i32.const 2896
   local.set $2
   global.get $~lib/memory/__stack_pointer
@@ -42755,9 +42755,9 @@
   i32.store $0 offset=4
   local.get $2
   call $~lib/typedarray/Float64Array#map
-  local.tee $1
+  local.tee $result
   i32.store $0 offset=8
-  local.get $1
+  local.get $result
   i32.const 0
   call $~lib/typedarray/Float64Array#__get
   f64.const 1
@@ -42771,7 +42771,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $1
+  local.get $result
   i32.const 1
   call $~lib/typedarray/Float64Array#__get
   f64.const 4
@@ -42785,7 +42785,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $1
+  local.get $result
   i32.const 2
   call $~lib/typedarray/Float64Array#__get
   f64.const 9
@@ -42805,8 +42805,8 @@
   global.set $~lib/memory/__stack_pointer
  )
  (func $std/typedarray/testArrayFilter<~lib/typedarray/Int8Array,i8>
-  (local $0 i32)
-  (local $1 i32)
+  (local $source i32)
+  (local $result i32)
   (local $2 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 12
@@ -42823,30 +42823,30 @@
   i32.const 0
   i32.const 6
   call $~lib/typedarray/Int8Array#constructor
-  local.tee $0
+  local.tee $source
   i32.store $0
-  local.get $0
+  local.get $source
   i32.const 0
   i32.const 1
   call $~lib/typedarray/Int8Array#__set
-  local.get $0
+  local.get $source
   i32.const 1
   i32.const 2
   call $~lib/typedarray/Int8Array#__set
-  local.get $0
+  local.get $source
   i32.const 2
   i32.const 3
   call $~lib/typedarray/Int8Array#__set
-  local.get $0
+  local.get $source
   i32.const 3
   i32.const 4
   call $~lib/typedarray/Int8Array#__set
-  local.get $0
+  local.get $source
   i32.const 5
   i32.const 5
   call $~lib/typedarray/Int8Array#__set
   global.get $~lib/memory/__stack_pointer
-  local.get $0
+  local.get $source
   i32.const 2928
   local.set $2
   global.get $~lib/memory/__stack_pointer
@@ -42854,9 +42854,9 @@
   i32.store $0 offset=4
   local.get $2
   call $~lib/typedarray/Int8Array#filter
-  local.tee $1
+  local.tee $result
   i32.store $0 offset=8
-  local.get $1
+  local.get $result
   call $~lib/arraybuffer/ArrayBufferView#get:byteOffset
   i32.const 0
   i32.eq
@@ -42869,7 +42869,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $1
+  local.get $result
   call $~lib/typedarray/Int8Array#get:length
   i32.const 3
   i32.eq
@@ -42882,7 +42882,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $1
+  local.get $result
   i32.const 0
   call $~lib/typedarray/Int8Array#__get
   i32.const 3
@@ -42896,7 +42896,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $1
+  local.get $result
   i32.const 1
   call $~lib/typedarray/Int8Array#__get
   i32.const 4
@@ -42910,7 +42910,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $1
+  local.get $result
   i32.const 2
   call $~lib/typedarray/Int8Array#__get
   i32.const 5
@@ -42930,8 +42930,8 @@
   global.set $~lib/memory/__stack_pointer
  )
  (func $std/typedarray/testArrayFilter<~lib/typedarray/Uint8Array,u8>
-  (local $0 i32)
-  (local $1 i32)
+  (local $source i32)
+  (local $result i32)
   (local $2 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 12
@@ -42948,30 +42948,30 @@
   i32.const 0
   i32.const 6
   call $~lib/typedarray/Uint8Array#constructor
-  local.tee $0
+  local.tee $source
   i32.store $0
-  local.get $0
+  local.get $source
   i32.const 0
   i32.const 1
   call $~lib/typedarray/Uint8Array#__set
-  local.get $0
+  local.get $source
   i32.const 1
   i32.const 2
   call $~lib/typedarray/Uint8Array#__set
-  local.get $0
+  local.get $source
   i32.const 2
   i32.const 3
   call $~lib/typedarray/Uint8Array#__set
-  local.get $0
+  local.get $source
   i32.const 3
   i32.const 4
   call $~lib/typedarray/Uint8Array#__set
-  local.get $0
+  local.get $source
   i32.const 5
   i32.const 5
   call $~lib/typedarray/Uint8Array#__set
   global.get $~lib/memory/__stack_pointer
-  local.get $0
+  local.get $source
   i32.const 2960
   local.set $2
   global.get $~lib/memory/__stack_pointer
@@ -42979,9 +42979,9 @@
   i32.store $0 offset=4
   local.get $2
   call $~lib/typedarray/Uint8Array#filter
-  local.tee $1
+  local.tee $result
   i32.store $0 offset=8
-  local.get $1
+  local.get $result
   call $~lib/arraybuffer/ArrayBufferView#get:byteOffset
   i32.const 0
   i32.eq
@@ -42994,7 +42994,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $1
+  local.get $result
   call $~lib/typedarray/Uint8Array#get:length
   i32.const 3
   i32.eq
@@ -43007,7 +43007,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $1
+  local.get $result
   i32.const 0
   call $~lib/typedarray/Uint8Array#__get
   i32.const 3
@@ -43021,7 +43021,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $1
+  local.get $result
   i32.const 1
   call $~lib/typedarray/Uint8Array#__get
   i32.const 4
@@ -43035,7 +43035,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $1
+  local.get $result
   i32.const 2
   call $~lib/typedarray/Uint8Array#__get
   i32.const 5
@@ -43055,8 +43055,8 @@
   global.set $~lib/memory/__stack_pointer
  )
  (func $std/typedarray/testArrayFilter<~lib/typedarray/Uint8ClampedArray,u8>
-  (local $0 i32)
-  (local $1 i32)
+  (local $source i32)
+  (local $result i32)
   (local $2 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 12
@@ -43073,30 +43073,30 @@
   i32.const 0
   i32.const 6
   call $~lib/typedarray/Uint8ClampedArray#constructor
-  local.tee $0
+  local.tee $source
   i32.store $0
-  local.get $0
+  local.get $source
   i32.const 0
   i32.const 1
   call $~lib/typedarray/Uint8ClampedArray#__set
-  local.get $0
+  local.get $source
   i32.const 1
   i32.const 2
   call $~lib/typedarray/Uint8ClampedArray#__set
-  local.get $0
+  local.get $source
   i32.const 2
   i32.const 3
   call $~lib/typedarray/Uint8ClampedArray#__set
-  local.get $0
+  local.get $source
   i32.const 3
   i32.const 4
   call $~lib/typedarray/Uint8ClampedArray#__set
-  local.get $0
+  local.get $source
   i32.const 5
   i32.const 5
   call $~lib/typedarray/Uint8ClampedArray#__set
   global.get $~lib/memory/__stack_pointer
-  local.get $0
+  local.get $source
   i32.const 2992
   local.set $2
   global.get $~lib/memory/__stack_pointer
@@ -43104,9 +43104,9 @@
   i32.store $0 offset=4
   local.get $2
   call $~lib/typedarray/Uint8ClampedArray#filter
-  local.tee $1
+  local.tee $result
   i32.store $0 offset=8
-  local.get $1
+  local.get $result
   call $~lib/arraybuffer/ArrayBufferView#get:byteOffset
   i32.const 0
   i32.eq
@@ -43119,7 +43119,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $1
+  local.get $result
   call $~lib/typedarray/Uint8ClampedArray#get:length
   i32.const 3
   i32.eq
@@ -43132,7 +43132,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $1
+  local.get $result
   i32.const 0
   call $~lib/typedarray/Uint8ClampedArray#__get
   i32.const 3
@@ -43146,7 +43146,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $1
+  local.get $result
   i32.const 1
   call $~lib/typedarray/Uint8ClampedArray#__get
   i32.const 4
@@ -43160,7 +43160,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $1
+  local.get $result
   i32.const 2
   call $~lib/typedarray/Uint8ClampedArray#__get
   i32.const 5
@@ -43180,8 +43180,8 @@
   global.set $~lib/memory/__stack_pointer
  )
  (func $std/typedarray/testArrayFilter<~lib/typedarray/Int16Array,i16>
-  (local $0 i32)
-  (local $1 i32)
+  (local $source i32)
+  (local $result i32)
   (local $2 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 12
@@ -43198,30 +43198,30 @@
   i32.const 0
   i32.const 6
   call $~lib/typedarray/Int16Array#constructor
-  local.tee $0
+  local.tee $source
   i32.store $0
-  local.get $0
+  local.get $source
   i32.const 0
   i32.const 1
   call $~lib/typedarray/Int16Array#__set
-  local.get $0
+  local.get $source
   i32.const 1
   i32.const 2
   call $~lib/typedarray/Int16Array#__set
-  local.get $0
+  local.get $source
   i32.const 2
   i32.const 3
   call $~lib/typedarray/Int16Array#__set
-  local.get $0
+  local.get $source
   i32.const 3
   i32.const 4
   call $~lib/typedarray/Int16Array#__set
-  local.get $0
+  local.get $source
   i32.const 5
   i32.const 5
   call $~lib/typedarray/Int16Array#__set
   global.get $~lib/memory/__stack_pointer
-  local.get $0
+  local.get $source
   i32.const 3024
   local.set $2
   global.get $~lib/memory/__stack_pointer
@@ -43229,9 +43229,9 @@
   i32.store $0 offset=4
   local.get $2
   call $~lib/typedarray/Int16Array#filter
-  local.tee $1
+  local.tee $result
   i32.store $0 offset=8
-  local.get $1
+  local.get $result
   call $~lib/arraybuffer/ArrayBufferView#get:byteOffset
   i32.const 0
   i32.eq
@@ -43244,7 +43244,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $1
+  local.get $result
   call $~lib/typedarray/Int16Array#get:length
   i32.const 3
   i32.eq
@@ -43257,7 +43257,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $1
+  local.get $result
   i32.const 0
   call $~lib/typedarray/Int16Array#__get
   i32.const 3
@@ -43271,7 +43271,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $1
+  local.get $result
   i32.const 1
   call $~lib/typedarray/Int16Array#__get
   i32.const 4
@@ -43285,7 +43285,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $1
+  local.get $result
   i32.const 2
   call $~lib/typedarray/Int16Array#__get
   i32.const 5
@@ -43305,8 +43305,8 @@
   global.set $~lib/memory/__stack_pointer
  )
  (func $std/typedarray/testArrayFilter<~lib/typedarray/Uint16Array,u16>
-  (local $0 i32)
-  (local $1 i32)
+  (local $source i32)
+  (local $result i32)
   (local $2 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 12
@@ -43323,30 +43323,30 @@
   i32.const 0
   i32.const 6
   call $~lib/typedarray/Uint16Array#constructor
-  local.tee $0
+  local.tee $source
   i32.store $0
-  local.get $0
+  local.get $source
   i32.const 0
   i32.const 1
   call $~lib/typedarray/Uint16Array#__set
-  local.get $0
+  local.get $source
   i32.const 1
   i32.const 2
   call $~lib/typedarray/Uint16Array#__set
-  local.get $0
+  local.get $source
   i32.const 2
   i32.const 3
   call $~lib/typedarray/Uint16Array#__set
-  local.get $0
+  local.get $source
   i32.const 3
   i32.const 4
   call $~lib/typedarray/Uint16Array#__set
-  local.get $0
+  local.get $source
   i32.const 5
   i32.const 5
   call $~lib/typedarray/Uint16Array#__set
   global.get $~lib/memory/__stack_pointer
-  local.get $0
+  local.get $source
   i32.const 3056
   local.set $2
   global.get $~lib/memory/__stack_pointer
@@ -43354,9 +43354,9 @@
   i32.store $0 offset=4
   local.get $2
   call $~lib/typedarray/Uint16Array#filter
-  local.tee $1
+  local.tee $result
   i32.store $0 offset=8
-  local.get $1
+  local.get $result
   call $~lib/arraybuffer/ArrayBufferView#get:byteOffset
   i32.const 0
   i32.eq
@@ -43369,7 +43369,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $1
+  local.get $result
   call $~lib/typedarray/Uint16Array#get:length
   i32.const 3
   i32.eq
@@ -43382,7 +43382,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $1
+  local.get $result
   i32.const 0
   call $~lib/typedarray/Uint16Array#__get
   i32.const 3
@@ -43396,7 +43396,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $1
+  local.get $result
   i32.const 1
   call $~lib/typedarray/Uint16Array#__get
   i32.const 4
@@ -43410,7 +43410,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $1
+  local.get $result
   i32.const 2
   call $~lib/typedarray/Uint16Array#__get
   i32.const 5
@@ -43430,8 +43430,8 @@
   global.set $~lib/memory/__stack_pointer
  )
  (func $std/typedarray/testArrayFilter<~lib/typedarray/Int32Array,i32>
-  (local $0 i32)
-  (local $1 i32)
+  (local $source i32)
+  (local $result i32)
   (local $2 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 12
@@ -43448,30 +43448,30 @@
   i32.const 0
   i32.const 6
   call $~lib/typedarray/Int32Array#constructor
-  local.tee $0
+  local.tee $source
   i32.store $0
-  local.get $0
+  local.get $source
   i32.const 0
   i32.const 1
   call $~lib/typedarray/Int32Array#__set
-  local.get $0
+  local.get $source
   i32.const 1
   i32.const 2
   call $~lib/typedarray/Int32Array#__set
-  local.get $0
+  local.get $source
   i32.const 2
   i32.const 3
   call $~lib/typedarray/Int32Array#__set
-  local.get $0
+  local.get $source
   i32.const 3
   i32.const 4
   call $~lib/typedarray/Int32Array#__set
-  local.get $0
+  local.get $source
   i32.const 5
   i32.const 5
   call $~lib/typedarray/Int32Array#__set
   global.get $~lib/memory/__stack_pointer
-  local.get $0
+  local.get $source
   i32.const 3088
   local.set $2
   global.get $~lib/memory/__stack_pointer
@@ -43479,9 +43479,9 @@
   i32.store $0 offset=4
   local.get $2
   call $~lib/typedarray/Int32Array#filter
-  local.tee $1
+  local.tee $result
   i32.store $0 offset=8
-  local.get $1
+  local.get $result
   call $~lib/arraybuffer/ArrayBufferView#get:byteOffset
   i32.const 0
   i32.eq
@@ -43494,7 +43494,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $1
+  local.get $result
   call $~lib/typedarray/Int32Array#get:length
   i32.const 3
   i32.eq
@@ -43507,7 +43507,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $1
+  local.get $result
   i32.const 0
   call $~lib/typedarray/Int32Array#__get
   i32.const 3
@@ -43521,7 +43521,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $1
+  local.get $result
   i32.const 1
   call $~lib/typedarray/Int32Array#__get
   i32.const 4
@@ -43535,7 +43535,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $1
+  local.get $result
   i32.const 2
   call $~lib/typedarray/Int32Array#__get
   i32.const 5
@@ -43555,8 +43555,8 @@
   global.set $~lib/memory/__stack_pointer
  )
  (func $std/typedarray/testArrayFilter<~lib/typedarray/Uint32Array,u32>
-  (local $0 i32)
-  (local $1 i32)
+  (local $source i32)
+  (local $result i32)
   (local $2 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 12
@@ -43573,30 +43573,30 @@
   i32.const 0
   i32.const 6
   call $~lib/typedarray/Uint32Array#constructor
-  local.tee $0
+  local.tee $source
   i32.store $0
-  local.get $0
+  local.get $source
   i32.const 0
   i32.const 1
   call $~lib/typedarray/Uint32Array#__set
-  local.get $0
+  local.get $source
   i32.const 1
   i32.const 2
   call $~lib/typedarray/Uint32Array#__set
-  local.get $0
+  local.get $source
   i32.const 2
   i32.const 3
   call $~lib/typedarray/Uint32Array#__set
-  local.get $0
+  local.get $source
   i32.const 3
   i32.const 4
   call $~lib/typedarray/Uint32Array#__set
-  local.get $0
+  local.get $source
   i32.const 5
   i32.const 5
   call $~lib/typedarray/Uint32Array#__set
   global.get $~lib/memory/__stack_pointer
-  local.get $0
+  local.get $source
   i32.const 3120
   local.set $2
   global.get $~lib/memory/__stack_pointer
@@ -43604,9 +43604,9 @@
   i32.store $0 offset=4
   local.get $2
   call $~lib/typedarray/Uint32Array#filter
-  local.tee $1
+  local.tee $result
   i32.store $0 offset=8
-  local.get $1
+  local.get $result
   call $~lib/arraybuffer/ArrayBufferView#get:byteOffset
   i32.const 0
   i32.eq
@@ -43619,7 +43619,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $1
+  local.get $result
   call $~lib/typedarray/Uint32Array#get:length
   i32.const 3
   i32.eq
@@ -43632,7 +43632,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $1
+  local.get $result
   i32.const 0
   call $~lib/typedarray/Uint32Array#__get
   i32.const 3
@@ -43646,7 +43646,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $1
+  local.get $result
   i32.const 1
   call $~lib/typedarray/Uint32Array#__get
   i32.const 4
@@ -43660,7 +43660,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $1
+  local.get $result
   i32.const 2
   call $~lib/typedarray/Uint32Array#__get
   i32.const 5
@@ -43680,8 +43680,8 @@
   global.set $~lib/memory/__stack_pointer
  )
  (func $std/typedarray/testArrayFilter<~lib/typedarray/Int64Array,i64>
-  (local $0 i32)
-  (local $1 i32)
+  (local $source i32)
+  (local $result i32)
   (local $2 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 12
@@ -43698,30 +43698,30 @@
   i32.const 0
   i32.const 6
   call $~lib/typedarray/Int64Array#constructor
-  local.tee $0
+  local.tee $source
   i32.store $0
-  local.get $0
+  local.get $source
   i32.const 0
   i64.const 1
   call $~lib/typedarray/Int64Array#__set
-  local.get $0
+  local.get $source
   i32.const 1
   i64.const 2
   call $~lib/typedarray/Int64Array#__set
-  local.get $0
+  local.get $source
   i32.const 2
   i64.const 3
   call $~lib/typedarray/Int64Array#__set
-  local.get $0
+  local.get $source
   i32.const 3
   i64.const 4
   call $~lib/typedarray/Int64Array#__set
-  local.get $0
+  local.get $source
   i32.const 5
   i64.const 5
   call $~lib/typedarray/Int64Array#__set
   global.get $~lib/memory/__stack_pointer
-  local.get $0
+  local.get $source
   i32.const 3152
   local.set $2
   global.get $~lib/memory/__stack_pointer
@@ -43729,9 +43729,9 @@
   i32.store $0 offset=4
   local.get $2
   call $~lib/typedarray/Int64Array#filter
-  local.tee $1
+  local.tee $result
   i32.store $0 offset=8
-  local.get $1
+  local.get $result
   call $~lib/arraybuffer/ArrayBufferView#get:byteOffset
   i32.const 0
   i32.eq
@@ -43744,7 +43744,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $1
+  local.get $result
   call $~lib/typedarray/Int64Array#get:length
   i32.const 3
   i32.eq
@@ -43757,7 +43757,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $1
+  local.get $result
   i32.const 0
   call $~lib/typedarray/Int64Array#__get
   i64.const 3
@@ -43771,7 +43771,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $1
+  local.get $result
   i32.const 1
   call $~lib/typedarray/Int64Array#__get
   i64.const 4
@@ -43785,7 +43785,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $1
+  local.get $result
   i32.const 2
   call $~lib/typedarray/Int64Array#__get
   i64.const 5
@@ -43805,8 +43805,8 @@
   global.set $~lib/memory/__stack_pointer
  )
  (func $std/typedarray/testArrayFilter<~lib/typedarray/Uint64Array,u64>
-  (local $0 i32)
-  (local $1 i32)
+  (local $source i32)
+  (local $result i32)
   (local $2 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 12
@@ -43823,30 +43823,30 @@
   i32.const 0
   i32.const 6
   call $~lib/typedarray/Uint64Array#constructor
-  local.tee $0
+  local.tee $source
   i32.store $0
-  local.get $0
+  local.get $source
   i32.const 0
   i64.const 1
   call $~lib/typedarray/Uint64Array#__set
-  local.get $0
+  local.get $source
   i32.const 1
   i64.const 2
   call $~lib/typedarray/Uint64Array#__set
-  local.get $0
+  local.get $source
   i32.const 2
   i64.const 3
   call $~lib/typedarray/Uint64Array#__set
-  local.get $0
+  local.get $source
   i32.const 3
   i64.const 4
   call $~lib/typedarray/Uint64Array#__set
-  local.get $0
+  local.get $source
   i32.const 5
   i64.const 5
   call $~lib/typedarray/Uint64Array#__set
   global.get $~lib/memory/__stack_pointer
-  local.get $0
+  local.get $source
   i32.const 3184
   local.set $2
   global.get $~lib/memory/__stack_pointer
@@ -43854,9 +43854,9 @@
   i32.store $0 offset=4
   local.get $2
   call $~lib/typedarray/Uint64Array#filter
-  local.tee $1
+  local.tee $result
   i32.store $0 offset=8
-  local.get $1
+  local.get $result
   call $~lib/arraybuffer/ArrayBufferView#get:byteOffset
   i32.const 0
   i32.eq
@@ -43869,7 +43869,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $1
+  local.get $result
   call $~lib/typedarray/Uint64Array#get:length
   i32.const 3
   i32.eq
@@ -43882,7 +43882,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $1
+  local.get $result
   i32.const 0
   call $~lib/typedarray/Uint64Array#__get
   i64.const 3
@@ -43896,7 +43896,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $1
+  local.get $result
   i32.const 1
   call $~lib/typedarray/Uint64Array#__get
   i64.const 4
@@ -43910,7 +43910,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $1
+  local.get $result
   i32.const 2
   call $~lib/typedarray/Uint64Array#__get
   i64.const 5
@@ -43930,8 +43930,8 @@
   global.set $~lib/memory/__stack_pointer
  )
  (func $std/typedarray/testArrayFilter<~lib/typedarray/Float32Array,f32>
-  (local $0 i32)
-  (local $1 i32)
+  (local $source i32)
+  (local $result i32)
   (local $2 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 12
@@ -43948,30 +43948,30 @@
   i32.const 0
   i32.const 6
   call $~lib/typedarray/Float32Array#constructor
-  local.tee $0
+  local.tee $source
   i32.store $0
-  local.get $0
+  local.get $source
   i32.const 0
   f32.const 1
   call $~lib/typedarray/Float32Array#__set
-  local.get $0
+  local.get $source
   i32.const 1
   f32.const 2
   call $~lib/typedarray/Float32Array#__set
-  local.get $0
+  local.get $source
   i32.const 2
   f32.const 3
   call $~lib/typedarray/Float32Array#__set
-  local.get $0
+  local.get $source
   i32.const 3
   f32.const 4
   call $~lib/typedarray/Float32Array#__set
-  local.get $0
+  local.get $source
   i32.const 5
   f32.const 5
   call $~lib/typedarray/Float32Array#__set
   global.get $~lib/memory/__stack_pointer
-  local.get $0
+  local.get $source
   i32.const 3216
   local.set $2
   global.get $~lib/memory/__stack_pointer
@@ -43979,9 +43979,9 @@
   i32.store $0 offset=4
   local.get $2
   call $~lib/typedarray/Float32Array#filter
-  local.tee $1
+  local.tee $result
   i32.store $0 offset=8
-  local.get $1
+  local.get $result
   call $~lib/arraybuffer/ArrayBufferView#get:byteOffset
   i32.const 0
   i32.eq
@@ -43994,7 +43994,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $1
+  local.get $result
   call $~lib/typedarray/Float32Array#get:length
   i32.const 3
   i32.eq
@@ -44007,7 +44007,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $1
+  local.get $result
   i32.const 0
   call $~lib/typedarray/Float32Array#__get
   f32.const 3
@@ -44021,7 +44021,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $1
+  local.get $result
   i32.const 1
   call $~lib/typedarray/Float32Array#__get
   f32.const 4
@@ -44035,7 +44035,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $1
+  local.get $result
   i32.const 2
   call $~lib/typedarray/Float32Array#__get
   f32.const 5
@@ -44055,8 +44055,8 @@
   global.set $~lib/memory/__stack_pointer
  )
  (func $std/typedarray/testArrayFilter<~lib/typedarray/Float64Array,f64>
-  (local $0 i32)
-  (local $1 i32)
+  (local $source i32)
+  (local $result i32)
   (local $2 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 12
@@ -44073,30 +44073,30 @@
   i32.const 0
   i32.const 6
   call $~lib/typedarray/Float64Array#constructor
-  local.tee $0
+  local.tee $source
   i32.store $0
-  local.get $0
+  local.get $source
   i32.const 0
   f64.const 1
   call $~lib/typedarray/Float64Array#__set
-  local.get $0
+  local.get $source
   i32.const 1
   f64.const 2
   call $~lib/typedarray/Float64Array#__set
-  local.get $0
+  local.get $source
   i32.const 2
   f64.const 3
   call $~lib/typedarray/Float64Array#__set
-  local.get $0
+  local.get $source
   i32.const 3
   f64.const 4
   call $~lib/typedarray/Float64Array#__set
-  local.get $0
+  local.get $source
   i32.const 5
   f64.const 5
   call $~lib/typedarray/Float64Array#__set
   global.get $~lib/memory/__stack_pointer
-  local.get $0
+  local.get $source
   i32.const 3248
   local.set $2
   global.get $~lib/memory/__stack_pointer
@@ -44104,9 +44104,9 @@
   i32.store $0 offset=4
   local.get $2
   call $~lib/typedarray/Float64Array#filter
-  local.tee $1
+  local.tee $result
   i32.store $0 offset=8
-  local.get $1
+  local.get $result
   call $~lib/arraybuffer/ArrayBufferView#get:byteOffset
   i32.const 0
   i32.eq
@@ -44119,7 +44119,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $1
+  local.get $result
   call $~lib/typedarray/Float64Array#get:length
   i32.const 3
   i32.eq
@@ -44132,7 +44132,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $1
+  local.get $result
   i32.const 0
   call $~lib/typedarray/Float64Array#__get
   f64.const 3
@@ -44146,7 +44146,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $1
+  local.get $result
   i32.const 1
   call $~lib/typedarray/Float64Array#__get
   f64.const 4
@@ -44160,7 +44160,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $1
+  local.get $result
   i32.const 2
   call $~lib/typedarray/Float64Array#__get
   f64.const 5
@@ -44180,9 +44180,9 @@
   global.set $~lib/memory/__stack_pointer
  )
  (func $std/typedarray/testArraySome<~lib/typedarray/Int8Array,i8>
-  (local $0 i32)
-  (local $1 i32)
-  (local $2 i32)
+  (local $source i32)
+  (local $result i32)
+  (local $failResult i32)
   (local $3 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 8
@@ -44196,21 +44196,21 @@
   i32.const 0
   i32.const 3
   call $~lib/typedarray/Int8Array#constructor
-  local.tee $0
+  local.tee $source
   i32.store $0
-  local.get $0
+  local.get $source
   i32.const 0
   i32.const 2
   call $~lib/typedarray/Int8Array#__set
-  local.get $0
+  local.get $source
   i32.const 1
   i32.const 4
   call $~lib/typedarray/Int8Array#__set
-  local.get $0
+  local.get $source
   i32.const 2
   i32.const 6
   call $~lib/typedarray/Int8Array#__set
-  local.get $0
+  local.get $source
   i32.const 3280
   local.set $3
   global.get $~lib/memory/__stack_pointer
@@ -44218,8 +44218,8 @@
   i32.store $0 offset=4
   local.get $3
   call $~lib/typedarray/Int8Array#some
-  local.set $1
-  local.get $1
+  local.set $result
+  local.get $result
   i32.const 0
   i32.ne
   i32.eqz
@@ -44231,7 +44231,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $0
+  local.get $source
   i32.const 3312
   local.set $3
   global.get $~lib/memory/__stack_pointer
@@ -44239,8 +44239,8 @@
   i32.store $0 offset=4
   local.get $3
   call $~lib/typedarray/Int8Array#some
-  local.set $2
-  local.get $2
+  local.set $failResult
+  local.get $failResult
   i32.eqz
   i32.eqz
   if
@@ -44257,9 +44257,9 @@
   global.set $~lib/memory/__stack_pointer
  )
  (func $std/typedarray/testArraySome<~lib/typedarray/Uint8Array,u8>
-  (local $0 i32)
-  (local $1 i32)
-  (local $2 i32)
+  (local $source i32)
+  (local $result i32)
+  (local $failResult i32)
   (local $3 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 8
@@ -44273,21 +44273,21 @@
   i32.const 0
   i32.const 3
   call $~lib/typedarray/Uint8Array#constructor
-  local.tee $0
+  local.tee $source
   i32.store $0
-  local.get $0
+  local.get $source
   i32.const 0
   i32.const 2
   call $~lib/typedarray/Uint8Array#__set
-  local.get $0
+  local.get $source
   i32.const 1
   i32.const 4
   call $~lib/typedarray/Uint8Array#__set
-  local.get $0
+  local.get $source
   i32.const 2
   i32.const 6
   call $~lib/typedarray/Uint8Array#__set
-  local.get $0
+  local.get $source
   i32.const 3344
   local.set $3
   global.get $~lib/memory/__stack_pointer
@@ -44295,8 +44295,8 @@
   i32.store $0 offset=4
   local.get $3
   call $~lib/typedarray/Uint8Array#some
-  local.set $1
-  local.get $1
+  local.set $result
+  local.get $result
   i32.const 0
   i32.ne
   i32.eqz
@@ -44308,7 +44308,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $0
+  local.get $source
   i32.const 3376
   local.set $3
   global.get $~lib/memory/__stack_pointer
@@ -44316,8 +44316,8 @@
   i32.store $0 offset=4
   local.get $3
   call $~lib/typedarray/Uint8Array#some
-  local.set $2
-  local.get $2
+  local.set $failResult
+  local.get $failResult
   i32.eqz
   i32.eqz
   if
@@ -44334,9 +44334,9 @@
   global.set $~lib/memory/__stack_pointer
  )
  (func $std/typedarray/testArraySome<~lib/typedarray/Uint8ClampedArray,u8>
-  (local $0 i32)
-  (local $1 i32)
-  (local $2 i32)
+  (local $source i32)
+  (local $result i32)
+  (local $failResult i32)
   (local $3 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 8
@@ -44350,21 +44350,21 @@
   i32.const 0
   i32.const 3
   call $~lib/typedarray/Uint8ClampedArray#constructor
-  local.tee $0
+  local.tee $source
   i32.store $0
-  local.get $0
+  local.get $source
   i32.const 0
   i32.const 2
   call $~lib/typedarray/Uint8ClampedArray#__set
-  local.get $0
+  local.get $source
   i32.const 1
   i32.const 4
   call $~lib/typedarray/Uint8ClampedArray#__set
-  local.get $0
+  local.get $source
   i32.const 2
   i32.const 6
   call $~lib/typedarray/Uint8ClampedArray#__set
-  local.get $0
+  local.get $source
   i32.const 3408
   local.set $3
   global.get $~lib/memory/__stack_pointer
@@ -44372,8 +44372,8 @@
   i32.store $0 offset=4
   local.get $3
   call $~lib/typedarray/Uint8ClampedArray#some
-  local.set $1
-  local.get $1
+  local.set $result
+  local.get $result
   i32.const 0
   i32.ne
   i32.eqz
@@ -44385,7 +44385,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $0
+  local.get $source
   i32.const 3440
   local.set $3
   global.get $~lib/memory/__stack_pointer
@@ -44393,8 +44393,8 @@
   i32.store $0 offset=4
   local.get $3
   call $~lib/typedarray/Uint8ClampedArray#some
-  local.set $2
-  local.get $2
+  local.set $failResult
+  local.get $failResult
   i32.eqz
   i32.eqz
   if
@@ -44411,9 +44411,9 @@
   global.set $~lib/memory/__stack_pointer
  )
  (func $std/typedarray/testArraySome<~lib/typedarray/Int16Array,i16>
-  (local $0 i32)
-  (local $1 i32)
-  (local $2 i32)
+  (local $source i32)
+  (local $result i32)
+  (local $failResult i32)
   (local $3 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 8
@@ -44427,21 +44427,21 @@
   i32.const 0
   i32.const 3
   call $~lib/typedarray/Int16Array#constructor
-  local.tee $0
+  local.tee $source
   i32.store $0
-  local.get $0
+  local.get $source
   i32.const 0
   i32.const 2
   call $~lib/typedarray/Int16Array#__set
-  local.get $0
+  local.get $source
   i32.const 1
   i32.const 4
   call $~lib/typedarray/Int16Array#__set
-  local.get $0
+  local.get $source
   i32.const 2
   i32.const 6
   call $~lib/typedarray/Int16Array#__set
-  local.get $0
+  local.get $source
   i32.const 3472
   local.set $3
   global.get $~lib/memory/__stack_pointer
@@ -44449,8 +44449,8 @@
   i32.store $0 offset=4
   local.get $3
   call $~lib/typedarray/Int16Array#some
-  local.set $1
-  local.get $1
+  local.set $result
+  local.get $result
   i32.const 0
   i32.ne
   i32.eqz
@@ -44462,7 +44462,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $0
+  local.get $source
   i32.const 3504
   local.set $3
   global.get $~lib/memory/__stack_pointer
@@ -44470,8 +44470,8 @@
   i32.store $0 offset=4
   local.get $3
   call $~lib/typedarray/Int16Array#some
-  local.set $2
-  local.get $2
+  local.set $failResult
+  local.get $failResult
   i32.eqz
   i32.eqz
   if
@@ -44488,9 +44488,9 @@
   global.set $~lib/memory/__stack_pointer
  )
  (func $std/typedarray/testArraySome<~lib/typedarray/Uint16Array,u16>
-  (local $0 i32)
-  (local $1 i32)
-  (local $2 i32)
+  (local $source i32)
+  (local $result i32)
+  (local $failResult i32)
   (local $3 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 8
@@ -44504,21 +44504,21 @@
   i32.const 0
   i32.const 3
   call $~lib/typedarray/Uint16Array#constructor
-  local.tee $0
+  local.tee $source
   i32.store $0
-  local.get $0
+  local.get $source
   i32.const 0
   i32.const 2
   call $~lib/typedarray/Uint16Array#__set
-  local.get $0
+  local.get $source
   i32.const 1
   i32.const 4
   call $~lib/typedarray/Uint16Array#__set
-  local.get $0
+  local.get $source
   i32.const 2
   i32.const 6
   call $~lib/typedarray/Uint16Array#__set
-  local.get $0
+  local.get $source
   i32.const 3536
   local.set $3
   global.get $~lib/memory/__stack_pointer
@@ -44526,8 +44526,8 @@
   i32.store $0 offset=4
   local.get $3
   call $~lib/typedarray/Uint16Array#some
-  local.set $1
-  local.get $1
+  local.set $result
+  local.get $result
   i32.const 0
   i32.ne
   i32.eqz
@@ -44539,7 +44539,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $0
+  local.get $source
   i32.const 3568
   local.set $3
   global.get $~lib/memory/__stack_pointer
@@ -44547,8 +44547,8 @@
   i32.store $0 offset=4
   local.get $3
   call $~lib/typedarray/Uint16Array#some
-  local.set $2
-  local.get $2
+  local.set $failResult
+  local.get $failResult
   i32.eqz
   i32.eqz
   if
@@ -44565,9 +44565,9 @@
   global.set $~lib/memory/__stack_pointer
  )
  (func $std/typedarray/testArraySome<~lib/typedarray/Int32Array,i32>
-  (local $0 i32)
-  (local $1 i32)
-  (local $2 i32)
+  (local $source i32)
+  (local $result i32)
+  (local $failResult i32)
   (local $3 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 8
@@ -44581,21 +44581,21 @@
   i32.const 0
   i32.const 3
   call $~lib/typedarray/Int32Array#constructor
-  local.tee $0
+  local.tee $source
   i32.store $0
-  local.get $0
+  local.get $source
   i32.const 0
   i32.const 2
   call $~lib/typedarray/Int32Array#__set
-  local.get $0
+  local.get $source
   i32.const 1
   i32.const 4
   call $~lib/typedarray/Int32Array#__set
-  local.get $0
+  local.get $source
   i32.const 2
   i32.const 6
   call $~lib/typedarray/Int32Array#__set
-  local.get $0
+  local.get $source
   i32.const 3600
   local.set $3
   global.get $~lib/memory/__stack_pointer
@@ -44603,8 +44603,8 @@
   i32.store $0 offset=4
   local.get $3
   call $~lib/typedarray/Int32Array#some
-  local.set $1
-  local.get $1
+  local.set $result
+  local.get $result
   i32.const 0
   i32.ne
   i32.eqz
@@ -44616,7 +44616,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $0
+  local.get $source
   i32.const 3632
   local.set $3
   global.get $~lib/memory/__stack_pointer
@@ -44624,8 +44624,8 @@
   i32.store $0 offset=4
   local.get $3
   call $~lib/typedarray/Int32Array#some
-  local.set $2
-  local.get $2
+  local.set $failResult
+  local.get $failResult
   i32.eqz
   i32.eqz
   if
@@ -44642,9 +44642,9 @@
   global.set $~lib/memory/__stack_pointer
  )
  (func $std/typedarray/testArraySome<~lib/typedarray/Uint32Array,u32>
-  (local $0 i32)
-  (local $1 i32)
-  (local $2 i32)
+  (local $source i32)
+  (local $result i32)
+  (local $failResult i32)
   (local $3 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 8
@@ -44658,21 +44658,21 @@
   i32.const 0
   i32.const 3
   call $~lib/typedarray/Uint32Array#constructor
-  local.tee $0
+  local.tee $source
   i32.store $0
-  local.get $0
+  local.get $source
   i32.const 0
   i32.const 2
   call $~lib/typedarray/Uint32Array#__set
-  local.get $0
+  local.get $source
   i32.const 1
   i32.const 4
   call $~lib/typedarray/Uint32Array#__set
-  local.get $0
+  local.get $source
   i32.const 2
   i32.const 6
   call $~lib/typedarray/Uint32Array#__set
-  local.get $0
+  local.get $source
   i32.const 3664
   local.set $3
   global.get $~lib/memory/__stack_pointer
@@ -44680,8 +44680,8 @@
   i32.store $0 offset=4
   local.get $3
   call $~lib/typedarray/Uint32Array#some
-  local.set $1
-  local.get $1
+  local.set $result
+  local.get $result
   i32.const 0
   i32.ne
   i32.eqz
@@ -44693,7 +44693,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $0
+  local.get $source
   i32.const 3696
   local.set $3
   global.get $~lib/memory/__stack_pointer
@@ -44701,8 +44701,8 @@
   i32.store $0 offset=4
   local.get $3
   call $~lib/typedarray/Uint32Array#some
-  local.set $2
-  local.get $2
+  local.set $failResult
+  local.get $failResult
   i32.eqz
   i32.eqz
   if
@@ -44719,9 +44719,9 @@
   global.set $~lib/memory/__stack_pointer
  )
  (func $std/typedarray/testArraySome<~lib/typedarray/Int64Array,i64>
-  (local $0 i32)
-  (local $1 i32)
-  (local $2 i32)
+  (local $source i32)
+  (local $result i32)
+  (local $failResult i32)
   (local $3 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 8
@@ -44735,21 +44735,21 @@
   i32.const 0
   i32.const 3
   call $~lib/typedarray/Int64Array#constructor
-  local.tee $0
+  local.tee $source
   i32.store $0
-  local.get $0
+  local.get $source
   i32.const 0
   i64.const 2
   call $~lib/typedarray/Int64Array#__set
-  local.get $0
+  local.get $source
   i32.const 1
   i64.const 4
   call $~lib/typedarray/Int64Array#__set
-  local.get $0
+  local.get $source
   i32.const 2
   i64.const 6
   call $~lib/typedarray/Int64Array#__set
-  local.get $0
+  local.get $source
   i32.const 3728
   local.set $3
   global.get $~lib/memory/__stack_pointer
@@ -44757,8 +44757,8 @@
   i32.store $0 offset=4
   local.get $3
   call $~lib/typedarray/Int64Array#some
-  local.set $1
-  local.get $1
+  local.set $result
+  local.get $result
   i32.const 0
   i32.ne
   i32.eqz
@@ -44770,7 +44770,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $0
+  local.get $source
   i32.const 3760
   local.set $3
   global.get $~lib/memory/__stack_pointer
@@ -44778,8 +44778,8 @@
   i32.store $0 offset=4
   local.get $3
   call $~lib/typedarray/Int64Array#some
-  local.set $2
-  local.get $2
+  local.set $failResult
+  local.get $failResult
   i32.eqz
   i32.eqz
   if
@@ -44796,9 +44796,9 @@
   global.set $~lib/memory/__stack_pointer
  )
  (func $std/typedarray/testArraySome<~lib/typedarray/Uint64Array,u64>
-  (local $0 i32)
-  (local $1 i32)
-  (local $2 i32)
+  (local $source i32)
+  (local $result i32)
+  (local $failResult i32)
   (local $3 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 8
@@ -44812,21 +44812,21 @@
   i32.const 0
   i32.const 3
   call $~lib/typedarray/Uint64Array#constructor
-  local.tee $0
+  local.tee $source
   i32.store $0
-  local.get $0
+  local.get $source
   i32.const 0
   i64.const 2
   call $~lib/typedarray/Uint64Array#__set
-  local.get $0
+  local.get $source
   i32.const 1
   i64.const 4
   call $~lib/typedarray/Uint64Array#__set
-  local.get $0
+  local.get $source
   i32.const 2
   i64.const 6
   call $~lib/typedarray/Uint64Array#__set
-  local.get $0
+  local.get $source
   i32.const 3792
   local.set $3
   global.get $~lib/memory/__stack_pointer
@@ -44834,8 +44834,8 @@
   i32.store $0 offset=4
   local.get $3
   call $~lib/typedarray/Uint64Array#some
-  local.set $1
-  local.get $1
+  local.set $result
+  local.get $result
   i32.const 0
   i32.ne
   i32.eqz
@@ -44847,7 +44847,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $0
+  local.get $source
   i32.const 3824
   local.set $3
   global.get $~lib/memory/__stack_pointer
@@ -44855,8 +44855,8 @@
   i32.store $0 offset=4
   local.get $3
   call $~lib/typedarray/Uint64Array#some
-  local.set $2
-  local.get $2
+  local.set $failResult
+  local.get $failResult
   i32.eqz
   i32.eqz
   if
@@ -44873,9 +44873,9 @@
   global.set $~lib/memory/__stack_pointer
  )
  (func $std/typedarray/testArraySome<~lib/typedarray/Float32Array,f32>
-  (local $0 i32)
-  (local $1 i32)
-  (local $2 i32)
+  (local $source i32)
+  (local $result i32)
+  (local $failResult i32)
   (local $3 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 8
@@ -44889,21 +44889,21 @@
   i32.const 0
   i32.const 3
   call $~lib/typedarray/Float32Array#constructor
-  local.tee $0
+  local.tee $source
   i32.store $0
-  local.get $0
+  local.get $source
   i32.const 0
   f32.const 2
   call $~lib/typedarray/Float32Array#__set
-  local.get $0
+  local.get $source
   i32.const 1
   f32.const 4
   call $~lib/typedarray/Float32Array#__set
-  local.get $0
+  local.get $source
   i32.const 2
   f32.const 6
   call $~lib/typedarray/Float32Array#__set
-  local.get $0
+  local.get $source
   i32.const 3856
   local.set $3
   global.get $~lib/memory/__stack_pointer
@@ -44911,8 +44911,8 @@
   i32.store $0 offset=4
   local.get $3
   call $~lib/typedarray/Float32Array#some
-  local.set $1
-  local.get $1
+  local.set $result
+  local.get $result
   i32.const 0
   i32.ne
   i32.eqz
@@ -44924,7 +44924,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $0
+  local.get $source
   i32.const 3888
   local.set $3
   global.get $~lib/memory/__stack_pointer
@@ -44932,8 +44932,8 @@
   i32.store $0 offset=4
   local.get $3
   call $~lib/typedarray/Float32Array#some
-  local.set $2
-  local.get $2
+  local.set $failResult
+  local.get $failResult
   i32.eqz
   i32.eqz
   if
@@ -44950,9 +44950,9 @@
   global.set $~lib/memory/__stack_pointer
  )
  (func $std/typedarray/testArraySome<~lib/typedarray/Float64Array,f64>
-  (local $0 i32)
-  (local $1 i32)
-  (local $2 i32)
+  (local $source i32)
+  (local $result i32)
+  (local $failResult i32)
   (local $3 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 8
@@ -44966,21 +44966,21 @@
   i32.const 0
   i32.const 3
   call $~lib/typedarray/Float64Array#constructor
-  local.tee $0
+  local.tee $source
   i32.store $0
-  local.get $0
+  local.get $source
   i32.const 0
   f64.const 2
   call $~lib/typedarray/Float64Array#__set
-  local.get $0
+  local.get $source
   i32.const 1
   f64.const 4
   call $~lib/typedarray/Float64Array#__set
-  local.get $0
+  local.get $source
   i32.const 2
   f64.const 6
   call $~lib/typedarray/Float64Array#__set
-  local.get $0
+  local.get $source
   i32.const 3920
   local.set $3
   global.get $~lib/memory/__stack_pointer
@@ -44988,8 +44988,8 @@
   i32.store $0 offset=4
   local.get $3
   call $~lib/typedarray/Float64Array#some
-  local.set $1
-  local.get $1
+  local.set $result
+  local.get $result
   i32.const 0
   i32.ne
   i32.eqz
@@ -45001,7 +45001,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $0
+  local.get $source
   i32.const 3952
   local.set $3
   global.get $~lib/memory/__stack_pointer
@@ -45009,8 +45009,8 @@
   i32.store $0 offset=4
   local.get $3
   call $~lib/typedarray/Float64Array#some
-  local.set $2
-  local.get $2
+  local.set $failResult
+  local.get $failResult
   i32.eqz
   i32.eqz
   if
@@ -45027,9 +45027,9 @@
   global.set $~lib/memory/__stack_pointer
  )
  (func $std/typedarray/testArrayFindIndex<~lib/typedarray/Int8Array,i8>
-  (local $0 i32)
-  (local $1 i32)
-  (local $2 i32)
+  (local $source i32)
+  (local $result i32)
+  (local $failResult i32)
   (local $3 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 8
@@ -45043,21 +45043,21 @@
   i32.const 0
   i32.const 3
   call $~lib/typedarray/Int8Array#constructor
-  local.tee $0
+  local.tee $source
   i32.store $0
-  local.get $0
+  local.get $source
   i32.const 0
   i32.const 1
   call $~lib/typedarray/Int8Array#__set
-  local.get $0
+  local.get $source
   i32.const 1
   i32.const 2
   call $~lib/typedarray/Int8Array#__set
-  local.get $0
+  local.get $source
   i32.const 2
   i32.const 3
   call $~lib/typedarray/Int8Array#__set
-  local.get $0
+  local.get $source
   i32.const 3984
   local.set $3
   global.get $~lib/memory/__stack_pointer
@@ -45065,8 +45065,8 @@
   i32.store $0 offset=4
   local.get $3
   call $~lib/typedarray/Int8Array#findIndex
-  local.set $1
-  local.get $1
+  local.set $result
+  local.get $result
   i32.const 1
   i32.eq
   i32.eqz
@@ -45078,7 +45078,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $0
+  local.get $source
   i32.const 4016
   local.set $3
   global.get $~lib/memory/__stack_pointer
@@ -45086,8 +45086,8 @@
   i32.store $0 offset=4
   local.get $3
   call $~lib/typedarray/Int8Array#findIndex
-  local.set $2
-  local.get $2
+  local.set $failResult
+  local.get $failResult
   i32.const -1
   i32.eq
   i32.eqz
@@ -45105,9 +45105,9 @@
   global.set $~lib/memory/__stack_pointer
  )
  (func $std/typedarray/testArrayFindIndex<~lib/typedarray/Uint8Array,u8>
-  (local $0 i32)
-  (local $1 i32)
-  (local $2 i32)
+  (local $source i32)
+  (local $result i32)
+  (local $failResult i32)
   (local $3 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 8
@@ -45121,21 +45121,21 @@
   i32.const 0
   i32.const 3
   call $~lib/typedarray/Uint8Array#constructor
-  local.tee $0
+  local.tee $source
   i32.store $0
-  local.get $0
+  local.get $source
   i32.const 0
   i32.const 1
   call $~lib/typedarray/Uint8Array#__set
-  local.get $0
+  local.get $source
   i32.const 1
   i32.const 2
   call $~lib/typedarray/Uint8Array#__set
-  local.get $0
+  local.get $source
   i32.const 2
   i32.const 3
   call $~lib/typedarray/Uint8Array#__set
-  local.get $0
+  local.get $source
   i32.const 4048
   local.set $3
   global.get $~lib/memory/__stack_pointer
@@ -45143,8 +45143,8 @@
   i32.store $0 offset=4
   local.get $3
   call $~lib/typedarray/Uint8Array#findIndex
-  local.set $1
-  local.get $1
+  local.set $result
+  local.get $result
   i32.const 1
   i32.eq
   i32.eqz
@@ -45156,7 +45156,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $0
+  local.get $source
   i32.const 4080
   local.set $3
   global.get $~lib/memory/__stack_pointer
@@ -45164,8 +45164,8 @@
   i32.store $0 offset=4
   local.get $3
   call $~lib/typedarray/Uint8Array#findIndex
-  local.set $2
-  local.get $2
+  local.set $failResult
+  local.get $failResult
   i32.const -1
   i32.eq
   i32.eqz
@@ -45183,9 +45183,9 @@
   global.set $~lib/memory/__stack_pointer
  )
  (func $std/typedarray/testArrayFindIndex<~lib/typedarray/Uint8ClampedArray,u8>
-  (local $0 i32)
-  (local $1 i32)
-  (local $2 i32)
+  (local $source i32)
+  (local $result i32)
+  (local $failResult i32)
   (local $3 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 8
@@ -45199,21 +45199,21 @@
   i32.const 0
   i32.const 3
   call $~lib/typedarray/Uint8ClampedArray#constructor
-  local.tee $0
+  local.tee $source
   i32.store $0
-  local.get $0
+  local.get $source
   i32.const 0
   i32.const 1
   call $~lib/typedarray/Uint8ClampedArray#__set
-  local.get $0
+  local.get $source
   i32.const 1
   i32.const 2
   call $~lib/typedarray/Uint8ClampedArray#__set
-  local.get $0
+  local.get $source
   i32.const 2
   i32.const 3
   call $~lib/typedarray/Uint8ClampedArray#__set
-  local.get $0
+  local.get $source
   i32.const 4112
   local.set $3
   global.get $~lib/memory/__stack_pointer
@@ -45221,8 +45221,8 @@
   i32.store $0 offset=4
   local.get $3
   call $~lib/typedarray/Uint8ClampedArray#findIndex
-  local.set $1
-  local.get $1
+  local.set $result
+  local.get $result
   i32.const 1
   i32.eq
   i32.eqz
@@ -45234,7 +45234,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $0
+  local.get $source
   i32.const 4144
   local.set $3
   global.get $~lib/memory/__stack_pointer
@@ -45242,8 +45242,8 @@
   i32.store $0 offset=4
   local.get $3
   call $~lib/typedarray/Uint8ClampedArray#findIndex
-  local.set $2
-  local.get $2
+  local.set $failResult
+  local.get $failResult
   i32.const -1
   i32.eq
   i32.eqz
@@ -45261,9 +45261,9 @@
   global.set $~lib/memory/__stack_pointer
  )
  (func $std/typedarray/testArrayFindIndex<~lib/typedarray/Int16Array,i16>
-  (local $0 i32)
-  (local $1 i32)
-  (local $2 i32)
+  (local $source i32)
+  (local $result i32)
+  (local $failResult i32)
   (local $3 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 8
@@ -45277,21 +45277,21 @@
   i32.const 0
   i32.const 3
   call $~lib/typedarray/Int16Array#constructor
-  local.tee $0
+  local.tee $source
   i32.store $0
-  local.get $0
+  local.get $source
   i32.const 0
   i32.const 1
   call $~lib/typedarray/Int16Array#__set
-  local.get $0
+  local.get $source
   i32.const 1
   i32.const 2
   call $~lib/typedarray/Int16Array#__set
-  local.get $0
+  local.get $source
   i32.const 2
   i32.const 3
   call $~lib/typedarray/Int16Array#__set
-  local.get $0
+  local.get $source
   i32.const 4176
   local.set $3
   global.get $~lib/memory/__stack_pointer
@@ -45299,8 +45299,8 @@
   i32.store $0 offset=4
   local.get $3
   call $~lib/typedarray/Int16Array#findIndex
-  local.set $1
-  local.get $1
+  local.set $result
+  local.get $result
   i32.const 1
   i32.eq
   i32.eqz
@@ -45312,7 +45312,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $0
+  local.get $source
   i32.const 4208
   local.set $3
   global.get $~lib/memory/__stack_pointer
@@ -45320,8 +45320,8 @@
   i32.store $0 offset=4
   local.get $3
   call $~lib/typedarray/Int16Array#findIndex
-  local.set $2
-  local.get $2
+  local.set $failResult
+  local.get $failResult
   i32.const -1
   i32.eq
   i32.eqz
@@ -45339,9 +45339,9 @@
   global.set $~lib/memory/__stack_pointer
  )
  (func $std/typedarray/testArrayFindIndex<~lib/typedarray/Uint16Array,u16>
-  (local $0 i32)
-  (local $1 i32)
-  (local $2 i32)
+  (local $source i32)
+  (local $result i32)
+  (local $failResult i32)
   (local $3 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 8
@@ -45355,21 +45355,21 @@
   i32.const 0
   i32.const 3
   call $~lib/typedarray/Uint16Array#constructor
-  local.tee $0
+  local.tee $source
   i32.store $0
-  local.get $0
+  local.get $source
   i32.const 0
   i32.const 1
   call $~lib/typedarray/Uint16Array#__set
-  local.get $0
+  local.get $source
   i32.const 1
   i32.const 2
   call $~lib/typedarray/Uint16Array#__set
-  local.get $0
+  local.get $source
   i32.const 2
   i32.const 3
   call $~lib/typedarray/Uint16Array#__set
-  local.get $0
+  local.get $source
   i32.const 4240
   local.set $3
   global.get $~lib/memory/__stack_pointer
@@ -45377,8 +45377,8 @@
   i32.store $0 offset=4
   local.get $3
   call $~lib/typedarray/Uint16Array#findIndex
-  local.set $1
-  local.get $1
+  local.set $result
+  local.get $result
   i32.const 1
   i32.eq
   i32.eqz
@@ -45390,7 +45390,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $0
+  local.get $source
   i32.const 4272
   local.set $3
   global.get $~lib/memory/__stack_pointer
@@ -45398,8 +45398,8 @@
   i32.store $0 offset=4
   local.get $3
   call $~lib/typedarray/Uint16Array#findIndex
-  local.set $2
-  local.get $2
+  local.set $failResult
+  local.get $failResult
   i32.const -1
   i32.eq
   i32.eqz
@@ -45417,9 +45417,9 @@
   global.set $~lib/memory/__stack_pointer
  )
  (func $std/typedarray/testArrayFindIndex<~lib/typedarray/Int32Array,i32>
-  (local $0 i32)
-  (local $1 i32)
-  (local $2 i32)
+  (local $source i32)
+  (local $result i32)
+  (local $failResult i32)
   (local $3 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 8
@@ -45433,21 +45433,21 @@
   i32.const 0
   i32.const 3
   call $~lib/typedarray/Int32Array#constructor
-  local.tee $0
+  local.tee $source
   i32.store $0
-  local.get $0
+  local.get $source
   i32.const 0
   i32.const 1
   call $~lib/typedarray/Int32Array#__set
-  local.get $0
+  local.get $source
   i32.const 1
   i32.const 2
   call $~lib/typedarray/Int32Array#__set
-  local.get $0
+  local.get $source
   i32.const 2
   i32.const 3
   call $~lib/typedarray/Int32Array#__set
-  local.get $0
+  local.get $source
   i32.const 4304
   local.set $3
   global.get $~lib/memory/__stack_pointer
@@ -45455,8 +45455,8 @@
   i32.store $0 offset=4
   local.get $3
   call $~lib/typedarray/Int32Array#findIndex
-  local.set $1
-  local.get $1
+  local.set $result
+  local.get $result
   i32.const 1
   i32.eq
   i32.eqz
@@ -45468,7 +45468,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $0
+  local.get $source
   i32.const 4336
   local.set $3
   global.get $~lib/memory/__stack_pointer
@@ -45476,8 +45476,8 @@
   i32.store $0 offset=4
   local.get $3
   call $~lib/typedarray/Int32Array#findIndex
-  local.set $2
-  local.get $2
+  local.set $failResult
+  local.get $failResult
   i32.const -1
   i32.eq
   i32.eqz
@@ -45495,9 +45495,9 @@
   global.set $~lib/memory/__stack_pointer
  )
  (func $std/typedarray/testArrayFindIndex<~lib/typedarray/Uint32Array,u32>
-  (local $0 i32)
-  (local $1 i32)
-  (local $2 i32)
+  (local $source i32)
+  (local $result i32)
+  (local $failResult i32)
   (local $3 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 8
@@ -45511,21 +45511,21 @@
   i32.const 0
   i32.const 3
   call $~lib/typedarray/Uint32Array#constructor
-  local.tee $0
+  local.tee $source
   i32.store $0
-  local.get $0
+  local.get $source
   i32.const 0
   i32.const 1
   call $~lib/typedarray/Uint32Array#__set
-  local.get $0
+  local.get $source
   i32.const 1
   i32.const 2
   call $~lib/typedarray/Uint32Array#__set
-  local.get $0
+  local.get $source
   i32.const 2
   i32.const 3
   call $~lib/typedarray/Uint32Array#__set
-  local.get $0
+  local.get $source
   i32.const 4368
   local.set $3
   global.get $~lib/memory/__stack_pointer
@@ -45533,8 +45533,8 @@
   i32.store $0 offset=4
   local.get $3
   call $~lib/typedarray/Uint32Array#findIndex
-  local.set $1
-  local.get $1
+  local.set $result
+  local.get $result
   i32.const 1
   i32.eq
   i32.eqz
@@ -45546,7 +45546,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $0
+  local.get $source
   i32.const 4400
   local.set $3
   global.get $~lib/memory/__stack_pointer
@@ -45554,8 +45554,8 @@
   i32.store $0 offset=4
   local.get $3
   call $~lib/typedarray/Uint32Array#findIndex
-  local.set $2
-  local.get $2
+  local.set $failResult
+  local.get $failResult
   i32.const -1
   i32.eq
   i32.eqz
@@ -45573,9 +45573,9 @@
   global.set $~lib/memory/__stack_pointer
  )
  (func $std/typedarray/testArrayFindIndex<~lib/typedarray/Int64Array,i64>
-  (local $0 i32)
-  (local $1 i32)
-  (local $2 i32)
+  (local $source i32)
+  (local $result i32)
+  (local $failResult i32)
   (local $3 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 8
@@ -45589,21 +45589,21 @@
   i32.const 0
   i32.const 3
   call $~lib/typedarray/Int64Array#constructor
-  local.tee $0
+  local.tee $source
   i32.store $0
-  local.get $0
+  local.get $source
   i32.const 0
   i64.const 1
   call $~lib/typedarray/Int64Array#__set
-  local.get $0
+  local.get $source
   i32.const 1
   i64.const 2
   call $~lib/typedarray/Int64Array#__set
-  local.get $0
+  local.get $source
   i32.const 2
   i64.const 3
   call $~lib/typedarray/Int64Array#__set
-  local.get $0
+  local.get $source
   i32.const 4432
   local.set $3
   global.get $~lib/memory/__stack_pointer
@@ -45611,8 +45611,8 @@
   i32.store $0 offset=4
   local.get $3
   call $~lib/typedarray/Int64Array#findIndex
-  local.set $1
-  local.get $1
+  local.set $result
+  local.get $result
   i32.const 1
   i32.eq
   i32.eqz
@@ -45624,7 +45624,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $0
+  local.get $source
   i32.const 4464
   local.set $3
   global.get $~lib/memory/__stack_pointer
@@ -45632,8 +45632,8 @@
   i32.store $0 offset=4
   local.get $3
   call $~lib/typedarray/Int64Array#findIndex
-  local.set $2
-  local.get $2
+  local.set $failResult
+  local.get $failResult
   i32.const -1
   i32.eq
   i32.eqz
@@ -45651,9 +45651,9 @@
   global.set $~lib/memory/__stack_pointer
  )
  (func $std/typedarray/testArrayFindIndex<~lib/typedarray/Uint64Array,u64>
-  (local $0 i32)
-  (local $1 i32)
-  (local $2 i32)
+  (local $source i32)
+  (local $result i32)
+  (local $failResult i32)
   (local $3 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 8
@@ -45667,21 +45667,21 @@
   i32.const 0
   i32.const 3
   call $~lib/typedarray/Uint64Array#constructor
-  local.tee $0
+  local.tee $source
   i32.store $0
-  local.get $0
+  local.get $source
   i32.const 0
   i64.const 1
   call $~lib/typedarray/Uint64Array#__set
-  local.get $0
+  local.get $source
   i32.const 1
   i64.const 2
   call $~lib/typedarray/Uint64Array#__set
-  local.get $0
+  local.get $source
   i32.const 2
   i64.const 3
   call $~lib/typedarray/Uint64Array#__set
-  local.get $0
+  local.get $source
   i32.const 4496
   local.set $3
   global.get $~lib/memory/__stack_pointer
@@ -45689,8 +45689,8 @@
   i32.store $0 offset=4
   local.get $3
   call $~lib/typedarray/Uint64Array#findIndex
-  local.set $1
-  local.get $1
+  local.set $result
+  local.get $result
   i32.const 1
   i32.eq
   i32.eqz
@@ -45702,7 +45702,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $0
+  local.get $source
   i32.const 4528
   local.set $3
   global.get $~lib/memory/__stack_pointer
@@ -45710,8 +45710,8 @@
   i32.store $0 offset=4
   local.get $3
   call $~lib/typedarray/Uint64Array#findIndex
-  local.set $2
-  local.get $2
+  local.set $failResult
+  local.get $failResult
   i32.const -1
   i32.eq
   i32.eqz
@@ -45729,9 +45729,9 @@
   global.set $~lib/memory/__stack_pointer
  )
  (func $std/typedarray/testArrayFindIndex<~lib/typedarray/Float32Array,f32>
-  (local $0 i32)
-  (local $1 i32)
-  (local $2 i32)
+  (local $source i32)
+  (local $result i32)
+  (local $failResult i32)
   (local $3 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 8
@@ -45745,21 +45745,21 @@
   i32.const 0
   i32.const 3
   call $~lib/typedarray/Float32Array#constructor
-  local.tee $0
+  local.tee $source
   i32.store $0
-  local.get $0
+  local.get $source
   i32.const 0
   f32.const 1
   call $~lib/typedarray/Float32Array#__set
-  local.get $0
+  local.get $source
   i32.const 1
   f32.const 2
   call $~lib/typedarray/Float32Array#__set
-  local.get $0
+  local.get $source
   i32.const 2
   f32.const 3
   call $~lib/typedarray/Float32Array#__set
-  local.get $0
+  local.get $source
   i32.const 4560
   local.set $3
   global.get $~lib/memory/__stack_pointer
@@ -45767,8 +45767,8 @@
   i32.store $0 offset=4
   local.get $3
   call $~lib/typedarray/Float32Array#findIndex
-  local.set $1
-  local.get $1
+  local.set $result
+  local.get $result
   i32.const 1
   i32.eq
   i32.eqz
@@ -45780,7 +45780,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $0
+  local.get $source
   i32.const 4592
   local.set $3
   global.get $~lib/memory/__stack_pointer
@@ -45788,8 +45788,8 @@
   i32.store $0 offset=4
   local.get $3
   call $~lib/typedarray/Float32Array#findIndex
-  local.set $2
-  local.get $2
+  local.set $failResult
+  local.get $failResult
   i32.const -1
   i32.eq
   i32.eqz
@@ -45807,9 +45807,9 @@
   global.set $~lib/memory/__stack_pointer
  )
  (func $std/typedarray/testArrayFindIndex<~lib/typedarray/Float64Array,f64>
-  (local $0 i32)
-  (local $1 i32)
-  (local $2 i32)
+  (local $source i32)
+  (local $result i32)
+  (local $failResult i32)
   (local $3 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 8
@@ -45823,21 +45823,21 @@
   i32.const 0
   i32.const 3
   call $~lib/typedarray/Float64Array#constructor
-  local.tee $0
+  local.tee $source
   i32.store $0
-  local.get $0
+  local.get $source
   i32.const 0
   f64.const 1
   call $~lib/typedarray/Float64Array#__set
-  local.get $0
+  local.get $source
   i32.const 1
   f64.const 2
   call $~lib/typedarray/Float64Array#__set
-  local.get $0
+  local.get $source
   i32.const 2
   f64.const 3
   call $~lib/typedarray/Float64Array#__set
-  local.get $0
+  local.get $source
   i32.const 4624
   local.set $3
   global.get $~lib/memory/__stack_pointer
@@ -45845,8 +45845,8 @@
   i32.store $0 offset=4
   local.get $3
   call $~lib/typedarray/Float64Array#findIndex
-  local.set $1
-  local.get $1
+  local.set $result
+  local.get $result
   i32.const 1
   i32.eq
   i32.eqz
@@ -45858,7 +45858,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $0
+  local.get $source
   i32.const 4656
   local.set $3
   global.get $~lib/memory/__stack_pointer
@@ -45866,8 +45866,8 @@
   i32.store $0 offset=4
   local.get $3
   call $~lib/typedarray/Float64Array#findIndex
-  local.set $2
-  local.get $2
+  local.set $failResult
+  local.get $failResult
   i32.const -1
   i32.eq
   i32.eqz
@@ -45885,9 +45885,9 @@
   global.set $~lib/memory/__stack_pointer
  )
  (func $std/typedarray/testArrayFindLastIndex<~lib/typedarray/Int8Array,i8>
-  (local $0 i32)
-  (local $1 i32)
-  (local $2 i32)
+  (local $source i32)
+  (local $result i32)
+  (local $failResult i32)
   (local $3 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 8
@@ -45901,21 +45901,21 @@
   i32.const 0
   i32.const 3
   call $~lib/typedarray/Int8Array#constructor
-  local.tee $0
+  local.tee $source
   i32.store $0
-  local.get $0
+  local.get $source
   i32.const 0
   i32.const 1
   call $~lib/typedarray/Int8Array#__set
-  local.get $0
+  local.get $source
   i32.const 1
   i32.const 2
   call $~lib/typedarray/Int8Array#__set
-  local.get $0
+  local.get $source
   i32.const 2
   i32.const 3
   call $~lib/typedarray/Int8Array#__set
-  local.get $0
+  local.get $source
   i32.const 4688
   local.set $3
   global.get $~lib/memory/__stack_pointer
@@ -45923,8 +45923,8 @@
   i32.store $0 offset=4
   local.get $3
   call $~lib/typedarray/Int8Array#findLastIndex
-  local.set $1
-  local.get $1
+  local.set $result
+  local.get $result
   i32.const 1
   i32.eq
   i32.eqz
@@ -45936,7 +45936,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $0
+  local.get $source
   i32.const 4720
   local.set $3
   global.get $~lib/memory/__stack_pointer
@@ -45944,8 +45944,8 @@
   i32.store $0 offset=4
   local.get $3
   call $~lib/typedarray/Int8Array#findLastIndex
-  local.set $2
-  local.get $2
+  local.set $failResult
+  local.get $failResult
   i32.const -1
   i32.eq
   i32.eqz
@@ -45963,9 +45963,9 @@
   global.set $~lib/memory/__stack_pointer
  )
  (func $std/typedarray/testArrayFindLastIndex<~lib/typedarray/Uint8Array,u8>
-  (local $0 i32)
-  (local $1 i32)
-  (local $2 i32)
+  (local $source i32)
+  (local $result i32)
+  (local $failResult i32)
   (local $3 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 8
@@ -45979,21 +45979,21 @@
   i32.const 0
   i32.const 3
   call $~lib/typedarray/Uint8Array#constructor
-  local.tee $0
+  local.tee $source
   i32.store $0
-  local.get $0
+  local.get $source
   i32.const 0
   i32.const 1
   call $~lib/typedarray/Uint8Array#__set
-  local.get $0
+  local.get $source
   i32.const 1
   i32.const 2
   call $~lib/typedarray/Uint8Array#__set
-  local.get $0
+  local.get $source
   i32.const 2
   i32.const 3
   call $~lib/typedarray/Uint8Array#__set
-  local.get $0
+  local.get $source
   i32.const 4752
   local.set $3
   global.get $~lib/memory/__stack_pointer
@@ -46001,8 +46001,8 @@
   i32.store $0 offset=4
   local.get $3
   call $~lib/typedarray/Uint8Array#findLastIndex
-  local.set $1
-  local.get $1
+  local.set $result
+  local.get $result
   i32.const 1
   i32.eq
   i32.eqz
@@ -46014,7 +46014,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $0
+  local.get $source
   i32.const 4784
   local.set $3
   global.get $~lib/memory/__stack_pointer
@@ -46022,8 +46022,8 @@
   i32.store $0 offset=4
   local.get $3
   call $~lib/typedarray/Uint8Array#findLastIndex
-  local.set $2
-  local.get $2
+  local.set $failResult
+  local.get $failResult
   i32.const -1
   i32.eq
   i32.eqz
@@ -46041,9 +46041,9 @@
   global.set $~lib/memory/__stack_pointer
  )
  (func $std/typedarray/testArrayFindLastIndex<~lib/typedarray/Uint8ClampedArray,u8>
-  (local $0 i32)
-  (local $1 i32)
-  (local $2 i32)
+  (local $source i32)
+  (local $result i32)
+  (local $failResult i32)
   (local $3 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 8
@@ -46057,21 +46057,21 @@
   i32.const 0
   i32.const 3
   call $~lib/typedarray/Uint8ClampedArray#constructor
-  local.tee $0
+  local.tee $source
   i32.store $0
-  local.get $0
+  local.get $source
   i32.const 0
   i32.const 1
   call $~lib/typedarray/Uint8ClampedArray#__set
-  local.get $0
+  local.get $source
   i32.const 1
   i32.const 2
   call $~lib/typedarray/Uint8ClampedArray#__set
-  local.get $0
+  local.get $source
   i32.const 2
   i32.const 3
   call $~lib/typedarray/Uint8ClampedArray#__set
-  local.get $0
+  local.get $source
   i32.const 4816
   local.set $3
   global.get $~lib/memory/__stack_pointer
@@ -46079,8 +46079,8 @@
   i32.store $0 offset=4
   local.get $3
   call $~lib/typedarray/Uint8ClampedArray#findLastIndex
-  local.set $1
-  local.get $1
+  local.set $result
+  local.get $result
   i32.const 1
   i32.eq
   i32.eqz
@@ -46092,7 +46092,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $0
+  local.get $source
   i32.const 4848
   local.set $3
   global.get $~lib/memory/__stack_pointer
@@ -46100,8 +46100,8 @@
   i32.store $0 offset=4
   local.get $3
   call $~lib/typedarray/Uint8ClampedArray#findLastIndex
-  local.set $2
-  local.get $2
+  local.set $failResult
+  local.get $failResult
   i32.const -1
   i32.eq
   i32.eqz
@@ -46119,9 +46119,9 @@
   global.set $~lib/memory/__stack_pointer
  )
  (func $std/typedarray/testArrayFindLastIndex<~lib/typedarray/Int16Array,i16>
-  (local $0 i32)
-  (local $1 i32)
-  (local $2 i32)
+  (local $source i32)
+  (local $result i32)
+  (local $failResult i32)
   (local $3 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 8
@@ -46135,21 +46135,21 @@
   i32.const 0
   i32.const 3
   call $~lib/typedarray/Int16Array#constructor
-  local.tee $0
+  local.tee $source
   i32.store $0
-  local.get $0
+  local.get $source
   i32.const 0
   i32.const 1
   call $~lib/typedarray/Int16Array#__set
-  local.get $0
+  local.get $source
   i32.const 1
   i32.const 2
   call $~lib/typedarray/Int16Array#__set
-  local.get $0
+  local.get $source
   i32.const 2
   i32.const 3
   call $~lib/typedarray/Int16Array#__set
-  local.get $0
+  local.get $source
   i32.const 4880
   local.set $3
   global.get $~lib/memory/__stack_pointer
@@ -46157,8 +46157,8 @@
   i32.store $0 offset=4
   local.get $3
   call $~lib/typedarray/Int16Array#findLastIndex
-  local.set $1
-  local.get $1
+  local.set $result
+  local.get $result
   i32.const 1
   i32.eq
   i32.eqz
@@ -46170,7 +46170,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $0
+  local.get $source
   i32.const 4912
   local.set $3
   global.get $~lib/memory/__stack_pointer
@@ -46178,8 +46178,8 @@
   i32.store $0 offset=4
   local.get $3
   call $~lib/typedarray/Int16Array#findLastIndex
-  local.set $2
-  local.get $2
+  local.set $failResult
+  local.get $failResult
   i32.const -1
   i32.eq
   i32.eqz
@@ -46197,9 +46197,9 @@
   global.set $~lib/memory/__stack_pointer
  )
  (func $std/typedarray/testArrayFindLastIndex<~lib/typedarray/Uint16Array,u16>
-  (local $0 i32)
-  (local $1 i32)
-  (local $2 i32)
+  (local $source i32)
+  (local $result i32)
+  (local $failResult i32)
   (local $3 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 8
@@ -46213,21 +46213,21 @@
   i32.const 0
   i32.const 3
   call $~lib/typedarray/Uint16Array#constructor
-  local.tee $0
+  local.tee $source
   i32.store $0
-  local.get $0
+  local.get $source
   i32.const 0
   i32.const 1
   call $~lib/typedarray/Uint16Array#__set
-  local.get $0
+  local.get $source
   i32.const 1
   i32.const 2
   call $~lib/typedarray/Uint16Array#__set
-  local.get $0
+  local.get $source
   i32.const 2
   i32.const 3
   call $~lib/typedarray/Uint16Array#__set
-  local.get $0
+  local.get $source
   i32.const 4944
   local.set $3
   global.get $~lib/memory/__stack_pointer
@@ -46235,8 +46235,8 @@
   i32.store $0 offset=4
   local.get $3
   call $~lib/typedarray/Uint16Array#findLastIndex
-  local.set $1
-  local.get $1
+  local.set $result
+  local.get $result
   i32.const 1
   i32.eq
   i32.eqz
@@ -46248,7 +46248,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $0
+  local.get $source
   i32.const 4976
   local.set $3
   global.get $~lib/memory/__stack_pointer
@@ -46256,8 +46256,8 @@
   i32.store $0 offset=4
   local.get $3
   call $~lib/typedarray/Uint16Array#findLastIndex
-  local.set $2
-  local.get $2
+  local.set $failResult
+  local.get $failResult
   i32.const -1
   i32.eq
   i32.eqz
@@ -46275,9 +46275,9 @@
   global.set $~lib/memory/__stack_pointer
  )
  (func $std/typedarray/testArrayFindLastIndex<~lib/typedarray/Int32Array,i32>
-  (local $0 i32)
-  (local $1 i32)
-  (local $2 i32)
+  (local $source i32)
+  (local $result i32)
+  (local $failResult i32)
   (local $3 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 8
@@ -46291,21 +46291,21 @@
   i32.const 0
   i32.const 3
   call $~lib/typedarray/Int32Array#constructor
-  local.tee $0
+  local.tee $source
   i32.store $0
-  local.get $0
+  local.get $source
   i32.const 0
   i32.const 1
   call $~lib/typedarray/Int32Array#__set
-  local.get $0
+  local.get $source
   i32.const 1
   i32.const 2
   call $~lib/typedarray/Int32Array#__set
-  local.get $0
+  local.get $source
   i32.const 2
   i32.const 3
   call $~lib/typedarray/Int32Array#__set
-  local.get $0
+  local.get $source
   i32.const 5008
   local.set $3
   global.get $~lib/memory/__stack_pointer
@@ -46313,8 +46313,8 @@
   i32.store $0 offset=4
   local.get $3
   call $~lib/typedarray/Int32Array#findLastIndex
-  local.set $1
-  local.get $1
+  local.set $result
+  local.get $result
   i32.const 1
   i32.eq
   i32.eqz
@@ -46326,7 +46326,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $0
+  local.get $source
   i32.const 5040
   local.set $3
   global.get $~lib/memory/__stack_pointer
@@ -46334,8 +46334,8 @@
   i32.store $0 offset=4
   local.get $3
   call $~lib/typedarray/Int32Array#findLastIndex
-  local.set $2
-  local.get $2
+  local.set $failResult
+  local.get $failResult
   i32.const -1
   i32.eq
   i32.eqz
@@ -46353,9 +46353,9 @@
   global.set $~lib/memory/__stack_pointer
  )
  (func $std/typedarray/testArrayFindLastIndex<~lib/typedarray/Uint32Array,u32>
-  (local $0 i32)
-  (local $1 i32)
-  (local $2 i32)
+  (local $source i32)
+  (local $result i32)
+  (local $failResult i32)
   (local $3 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 8
@@ -46369,21 +46369,21 @@
   i32.const 0
   i32.const 3
   call $~lib/typedarray/Uint32Array#constructor
-  local.tee $0
+  local.tee $source
   i32.store $0
-  local.get $0
+  local.get $source
   i32.const 0
   i32.const 1
   call $~lib/typedarray/Uint32Array#__set
-  local.get $0
+  local.get $source
   i32.const 1
   i32.const 2
   call $~lib/typedarray/Uint32Array#__set
-  local.get $0
+  local.get $source
   i32.const 2
   i32.const 3
   call $~lib/typedarray/Uint32Array#__set
-  local.get $0
+  local.get $source
   i32.const 5072
   local.set $3
   global.get $~lib/memory/__stack_pointer
@@ -46391,8 +46391,8 @@
   i32.store $0 offset=4
   local.get $3
   call $~lib/typedarray/Uint32Array#findLastIndex
-  local.set $1
-  local.get $1
+  local.set $result
+  local.get $result
   i32.const 1
   i32.eq
   i32.eqz
@@ -46404,7 +46404,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $0
+  local.get $source
   i32.const 5104
   local.set $3
   global.get $~lib/memory/__stack_pointer
@@ -46412,8 +46412,8 @@
   i32.store $0 offset=4
   local.get $3
   call $~lib/typedarray/Uint32Array#findLastIndex
-  local.set $2
-  local.get $2
+  local.set $failResult
+  local.get $failResult
   i32.const -1
   i32.eq
   i32.eqz
@@ -46431,9 +46431,9 @@
   global.set $~lib/memory/__stack_pointer
  )
  (func $std/typedarray/testArrayFindLastIndex<~lib/typedarray/Int64Array,i64>
-  (local $0 i32)
-  (local $1 i32)
-  (local $2 i32)
+  (local $source i32)
+  (local $result i32)
+  (local $failResult i32)
   (local $3 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 8
@@ -46447,21 +46447,21 @@
   i32.const 0
   i32.const 3
   call $~lib/typedarray/Int64Array#constructor
-  local.tee $0
+  local.tee $source
   i32.store $0
-  local.get $0
+  local.get $source
   i32.const 0
   i64.const 1
   call $~lib/typedarray/Int64Array#__set
-  local.get $0
+  local.get $source
   i32.const 1
   i64.const 2
   call $~lib/typedarray/Int64Array#__set
-  local.get $0
+  local.get $source
   i32.const 2
   i64.const 3
   call $~lib/typedarray/Int64Array#__set
-  local.get $0
+  local.get $source
   i32.const 5136
   local.set $3
   global.get $~lib/memory/__stack_pointer
@@ -46469,8 +46469,8 @@
   i32.store $0 offset=4
   local.get $3
   call $~lib/typedarray/Int64Array#findLastIndex
-  local.set $1
-  local.get $1
+  local.set $result
+  local.get $result
   i32.const 1
   i32.eq
   i32.eqz
@@ -46482,7 +46482,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $0
+  local.get $source
   i32.const 5168
   local.set $3
   global.get $~lib/memory/__stack_pointer
@@ -46490,8 +46490,8 @@
   i32.store $0 offset=4
   local.get $3
   call $~lib/typedarray/Int64Array#findLastIndex
-  local.set $2
-  local.get $2
+  local.set $failResult
+  local.get $failResult
   i32.const -1
   i32.eq
   i32.eqz
@@ -46509,9 +46509,9 @@
   global.set $~lib/memory/__stack_pointer
  )
  (func $std/typedarray/testArrayFindLastIndex<~lib/typedarray/Uint64Array,u64>
-  (local $0 i32)
-  (local $1 i32)
-  (local $2 i32)
+  (local $source i32)
+  (local $result i32)
+  (local $failResult i32)
   (local $3 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 8
@@ -46525,21 +46525,21 @@
   i32.const 0
   i32.const 3
   call $~lib/typedarray/Uint64Array#constructor
-  local.tee $0
+  local.tee $source
   i32.store $0
-  local.get $0
+  local.get $source
   i32.const 0
   i64.const 1
   call $~lib/typedarray/Uint64Array#__set
-  local.get $0
+  local.get $source
   i32.const 1
   i64.const 2
   call $~lib/typedarray/Uint64Array#__set
-  local.get $0
+  local.get $source
   i32.const 2
   i64.const 3
   call $~lib/typedarray/Uint64Array#__set
-  local.get $0
+  local.get $source
   i32.const 5200
   local.set $3
   global.get $~lib/memory/__stack_pointer
@@ -46547,8 +46547,8 @@
   i32.store $0 offset=4
   local.get $3
   call $~lib/typedarray/Uint64Array#findLastIndex
-  local.set $1
-  local.get $1
+  local.set $result
+  local.get $result
   i32.const 1
   i32.eq
   i32.eqz
@@ -46560,7 +46560,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $0
+  local.get $source
   i32.const 5232
   local.set $3
   global.get $~lib/memory/__stack_pointer
@@ -46568,8 +46568,8 @@
   i32.store $0 offset=4
   local.get $3
   call $~lib/typedarray/Uint64Array#findLastIndex
-  local.set $2
-  local.get $2
+  local.set $failResult
+  local.get $failResult
   i32.const -1
   i32.eq
   i32.eqz
@@ -46587,9 +46587,9 @@
   global.set $~lib/memory/__stack_pointer
  )
  (func $std/typedarray/testArrayFindLastIndex<~lib/typedarray/Float32Array,f32>
-  (local $0 i32)
-  (local $1 i32)
-  (local $2 i32)
+  (local $source i32)
+  (local $result i32)
+  (local $failResult i32)
   (local $3 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 8
@@ -46603,21 +46603,21 @@
   i32.const 0
   i32.const 3
   call $~lib/typedarray/Float32Array#constructor
-  local.tee $0
+  local.tee $source
   i32.store $0
-  local.get $0
+  local.get $source
   i32.const 0
   f32.const 1
   call $~lib/typedarray/Float32Array#__set
-  local.get $0
+  local.get $source
   i32.const 1
   f32.const 2
   call $~lib/typedarray/Float32Array#__set
-  local.get $0
+  local.get $source
   i32.const 2
   f32.const 3
   call $~lib/typedarray/Float32Array#__set
-  local.get $0
+  local.get $source
   i32.const 5264
   local.set $3
   global.get $~lib/memory/__stack_pointer
@@ -46625,8 +46625,8 @@
   i32.store $0 offset=4
   local.get $3
   call $~lib/typedarray/Float32Array#findLastIndex
-  local.set $1
-  local.get $1
+  local.set $result
+  local.get $result
   i32.const 1
   i32.eq
   i32.eqz
@@ -46638,7 +46638,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $0
+  local.get $source
   i32.const 5296
   local.set $3
   global.get $~lib/memory/__stack_pointer
@@ -46646,8 +46646,8 @@
   i32.store $0 offset=4
   local.get $3
   call $~lib/typedarray/Float32Array#findLastIndex
-  local.set $2
-  local.get $2
+  local.set $failResult
+  local.get $failResult
   i32.const -1
   i32.eq
   i32.eqz
@@ -46665,9 +46665,9 @@
   global.set $~lib/memory/__stack_pointer
  )
  (func $std/typedarray/testArrayFindLastIndex<~lib/typedarray/Float64Array,f64>
-  (local $0 i32)
-  (local $1 i32)
-  (local $2 i32)
+  (local $source i32)
+  (local $result i32)
+  (local $failResult i32)
   (local $3 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 8
@@ -46681,21 +46681,21 @@
   i32.const 0
   i32.const 3
   call $~lib/typedarray/Float64Array#constructor
-  local.tee $0
+  local.tee $source
   i32.store $0
-  local.get $0
+  local.get $source
   i32.const 0
   f64.const 1
   call $~lib/typedarray/Float64Array#__set
-  local.get $0
+  local.get $source
   i32.const 1
   f64.const 2
   call $~lib/typedarray/Float64Array#__set
-  local.get $0
+  local.get $source
   i32.const 2
   f64.const 3
   call $~lib/typedarray/Float64Array#__set
-  local.get $0
+  local.get $source
   i32.const 5328
   local.set $3
   global.get $~lib/memory/__stack_pointer
@@ -46703,8 +46703,8 @@
   i32.store $0 offset=4
   local.get $3
   call $~lib/typedarray/Float64Array#findLastIndex
-  local.set $1
-  local.get $1
+  local.set $result
+  local.get $result
   i32.const 1
   i32.eq
   i32.eqz
@@ -46716,7 +46716,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $0
+  local.get $source
   i32.const 5360
   local.set $3
   global.get $~lib/memory/__stack_pointer
@@ -46724,8 +46724,8 @@
   i32.store $0 offset=4
   local.get $3
   call $~lib/typedarray/Float64Array#findLastIndex
-  local.set $2
-  local.get $2
+  local.set $failResult
+  local.get $failResult
   i32.const -1
   i32.eq
   i32.eqz
@@ -46743,9 +46743,9 @@
   global.set $~lib/memory/__stack_pointer
  )
  (func $std/typedarray/testArrayEvery<~lib/typedarray/Int8Array,i8>
-  (local $0 i32)
-  (local $1 i32)
-  (local $2 i32)
+  (local $source i32)
+  (local $result i32)
+  (local $failResult i32)
   (local $3 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 8
@@ -46759,21 +46759,21 @@
   i32.const 0
   i32.const 3
   call $~lib/typedarray/Int8Array#constructor
-  local.tee $0
+  local.tee $source
   i32.store $0
-  local.get $0
+  local.get $source
   i32.const 0
   i32.const 2
   call $~lib/typedarray/Int8Array#__set
-  local.get $0
+  local.get $source
   i32.const 1
   i32.const 4
   call $~lib/typedarray/Int8Array#__set
-  local.get $0
+  local.get $source
   i32.const 2
   i32.const 6
   call $~lib/typedarray/Int8Array#__set
-  local.get $0
+  local.get $source
   i32.const 5392
   local.set $3
   global.get $~lib/memory/__stack_pointer
@@ -46781,8 +46781,8 @@
   i32.store $0 offset=4
   local.get $3
   call $~lib/typedarray/Int8Array#every
-  local.set $1
-  local.get $1
+  local.set $result
+  local.get $result
   i32.const 0
   i32.ne
   i32.eqz
@@ -46794,7 +46794,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $0
+  local.get $source
   i32.const 5424
   local.set $3
   global.get $~lib/memory/__stack_pointer
@@ -46802,8 +46802,8 @@
   i32.store $0 offset=4
   local.get $3
   call $~lib/typedarray/Int8Array#every
-  local.set $2
-  local.get $2
+  local.set $failResult
+  local.get $failResult
   i32.eqz
   i32.eqz
   if
@@ -46820,9 +46820,9 @@
   global.set $~lib/memory/__stack_pointer
  )
  (func $std/typedarray/testArrayEvery<~lib/typedarray/Uint8Array,u8>
-  (local $0 i32)
-  (local $1 i32)
-  (local $2 i32)
+  (local $source i32)
+  (local $result i32)
+  (local $failResult i32)
   (local $3 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 8
@@ -46836,21 +46836,21 @@
   i32.const 0
   i32.const 3
   call $~lib/typedarray/Uint8Array#constructor
-  local.tee $0
+  local.tee $source
   i32.store $0
-  local.get $0
+  local.get $source
   i32.const 0
   i32.const 2
   call $~lib/typedarray/Uint8Array#__set
-  local.get $0
+  local.get $source
   i32.const 1
   i32.const 4
   call $~lib/typedarray/Uint8Array#__set
-  local.get $0
+  local.get $source
   i32.const 2
   i32.const 6
   call $~lib/typedarray/Uint8Array#__set
-  local.get $0
+  local.get $source
   i32.const 5456
   local.set $3
   global.get $~lib/memory/__stack_pointer
@@ -46858,8 +46858,8 @@
   i32.store $0 offset=4
   local.get $3
   call $~lib/typedarray/Uint8Array#every
-  local.set $1
-  local.get $1
+  local.set $result
+  local.get $result
   i32.const 0
   i32.ne
   i32.eqz
@@ -46871,7 +46871,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $0
+  local.get $source
   i32.const 5488
   local.set $3
   global.get $~lib/memory/__stack_pointer
@@ -46879,8 +46879,8 @@
   i32.store $0 offset=4
   local.get $3
   call $~lib/typedarray/Uint8Array#every
-  local.set $2
-  local.get $2
+  local.set $failResult
+  local.get $failResult
   i32.eqz
   i32.eqz
   if
@@ -46897,9 +46897,9 @@
   global.set $~lib/memory/__stack_pointer
  )
  (func $std/typedarray/testArrayEvery<~lib/typedarray/Uint8ClampedArray,u8>
-  (local $0 i32)
-  (local $1 i32)
-  (local $2 i32)
+  (local $source i32)
+  (local $result i32)
+  (local $failResult i32)
   (local $3 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 8
@@ -46913,21 +46913,21 @@
   i32.const 0
   i32.const 3
   call $~lib/typedarray/Uint8ClampedArray#constructor
-  local.tee $0
+  local.tee $source
   i32.store $0
-  local.get $0
+  local.get $source
   i32.const 0
   i32.const 2
   call $~lib/typedarray/Uint8ClampedArray#__set
-  local.get $0
+  local.get $source
   i32.const 1
   i32.const 4
   call $~lib/typedarray/Uint8ClampedArray#__set
-  local.get $0
+  local.get $source
   i32.const 2
   i32.const 6
   call $~lib/typedarray/Uint8ClampedArray#__set
-  local.get $0
+  local.get $source
   i32.const 5520
   local.set $3
   global.get $~lib/memory/__stack_pointer
@@ -46935,8 +46935,8 @@
   i32.store $0 offset=4
   local.get $3
   call $~lib/typedarray/Uint8ClampedArray#every
-  local.set $1
-  local.get $1
+  local.set $result
+  local.get $result
   i32.const 0
   i32.ne
   i32.eqz
@@ -46948,7 +46948,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $0
+  local.get $source
   i32.const 5552
   local.set $3
   global.get $~lib/memory/__stack_pointer
@@ -46956,8 +46956,8 @@
   i32.store $0 offset=4
   local.get $3
   call $~lib/typedarray/Uint8ClampedArray#every
-  local.set $2
-  local.get $2
+  local.set $failResult
+  local.get $failResult
   i32.eqz
   i32.eqz
   if
@@ -46974,9 +46974,9 @@
   global.set $~lib/memory/__stack_pointer
  )
  (func $std/typedarray/testArrayEvery<~lib/typedarray/Int16Array,i16>
-  (local $0 i32)
-  (local $1 i32)
-  (local $2 i32)
+  (local $source i32)
+  (local $result i32)
+  (local $failResult i32)
   (local $3 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 8
@@ -46990,21 +46990,21 @@
   i32.const 0
   i32.const 3
   call $~lib/typedarray/Int16Array#constructor
-  local.tee $0
+  local.tee $source
   i32.store $0
-  local.get $0
+  local.get $source
   i32.const 0
   i32.const 2
   call $~lib/typedarray/Int16Array#__set
-  local.get $0
+  local.get $source
   i32.const 1
   i32.const 4
   call $~lib/typedarray/Int16Array#__set
-  local.get $0
+  local.get $source
   i32.const 2
   i32.const 6
   call $~lib/typedarray/Int16Array#__set
-  local.get $0
+  local.get $source
   i32.const 5584
   local.set $3
   global.get $~lib/memory/__stack_pointer
@@ -47012,8 +47012,8 @@
   i32.store $0 offset=4
   local.get $3
   call $~lib/typedarray/Int16Array#every
-  local.set $1
-  local.get $1
+  local.set $result
+  local.get $result
   i32.const 0
   i32.ne
   i32.eqz
@@ -47025,7 +47025,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $0
+  local.get $source
   i32.const 5616
   local.set $3
   global.get $~lib/memory/__stack_pointer
@@ -47033,8 +47033,8 @@
   i32.store $0 offset=4
   local.get $3
   call $~lib/typedarray/Int16Array#every
-  local.set $2
-  local.get $2
+  local.set $failResult
+  local.get $failResult
   i32.eqz
   i32.eqz
   if
@@ -47051,9 +47051,9 @@
   global.set $~lib/memory/__stack_pointer
  )
  (func $std/typedarray/testArrayEvery<~lib/typedarray/Uint16Array,u16>
-  (local $0 i32)
-  (local $1 i32)
-  (local $2 i32)
+  (local $source i32)
+  (local $result i32)
+  (local $failResult i32)
   (local $3 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 8
@@ -47067,21 +47067,21 @@
   i32.const 0
   i32.const 3
   call $~lib/typedarray/Uint16Array#constructor
-  local.tee $0
+  local.tee $source
   i32.store $0
-  local.get $0
+  local.get $source
   i32.const 0
   i32.const 2
   call $~lib/typedarray/Uint16Array#__set
-  local.get $0
+  local.get $source
   i32.const 1
   i32.const 4
   call $~lib/typedarray/Uint16Array#__set
-  local.get $0
+  local.get $source
   i32.const 2
   i32.const 6
   call $~lib/typedarray/Uint16Array#__set
-  local.get $0
+  local.get $source
   i32.const 5648
   local.set $3
   global.get $~lib/memory/__stack_pointer
@@ -47089,8 +47089,8 @@
   i32.store $0 offset=4
   local.get $3
   call $~lib/typedarray/Uint16Array#every
-  local.set $1
-  local.get $1
+  local.set $result
+  local.get $result
   i32.const 0
   i32.ne
   i32.eqz
@@ -47102,7 +47102,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $0
+  local.get $source
   i32.const 5680
   local.set $3
   global.get $~lib/memory/__stack_pointer
@@ -47110,8 +47110,8 @@
   i32.store $0 offset=4
   local.get $3
   call $~lib/typedarray/Uint16Array#every
-  local.set $2
-  local.get $2
+  local.set $failResult
+  local.get $failResult
   i32.eqz
   i32.eqz
   if
@@ -47128,9 +47128,9 @@
   global.set $~lib/memory/__stack_pointer
  )
  (func $std/typedarray/testArrayEvery<~lib/typedarray/Int32Array,i32>
-  (local $0 i32)
-  (local $1 i32)
-  (local $2 i32)
+  (local $source i32)
+  (local $result i32)
+  (local $failResult i32)
   (local $3 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 8
@@ -47144,21 +47144,21 @@
   i32.const 0
   i32.const 3
   call $~lib/typedarray/Int32Array#constructor
-  local.tee $0
+  local.tee $source
   i32.store $0
-  local.get $0
+  local.get $source
   i32.const 0
   i32.const 2
   call $~lib/typedarray/Int32Array#__set
-  local.get $0
+  local.get $source
   i32.const 1
   i32.const 4
   call $~lib/typedarray/Int32Array#__set
-  local.get $0
+  local.get $source
   i32.const 2
   i32.const 6
   call $~lib/typedarray/Int32Array#__set
-  local.get $0
+  local.get $source
   i32.const 5712
   local.set $3
   global.get $~lib/memory/__stack_pointer
@@ -47166,8 +47166,8 @@
   i32.store $0 offset=4
   local.get $3
   call $~lib/typedarray/Int32Array#every
-  local.set $1
-  local.get $1
+  local.set $result
+  local.get $result
   i32.const 0
   i32.ne
   i32.eqz
@@ -47179,7 +47179,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $0
+  local.get $source
   i32.const 5744
   local.set $3
   global.get $~lib/memory/__stack_pointer
@@ -47187,8 +47187,8 @@
   i32.store $0 offset=4
   local.get $3
   call $~lib/typedarray/Int32Array#every
-  local.set $2
-  local.get $2
+  local.set $failResult
+  local.get $failResult
   i32.eqz
   i32.eqz
   if
@@ -47205,9 +47205,9 @@
   global.set $~lib/memory/__stack_pointer
  )
  (func $std/typedarray/testArrayEvery<~lib/typedarray/Uint32Array,u32>
-  (local $0 i32)
-  (local $1 i32)
-  (local $2 i32)
+  (local $source i32)
+  (local $result i32)
+  (local $failResult i32)
   (local $3 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 8
@@ -47221,21 +47221,21 @@
   i32.const 0
   i32.const 3
   call $~lib/typedarray/Uint32Array#constructor
-  local.tee $0
+  local.tee $source
   i32.store $0
-  local.get $0
+  local.get $source
   i32.const 0
   i32.const 2
   call $~lib/typedarray/Uint32Array#__set
-  local.get $0
+  local.get $source
   i32.const 1
   i32.const 4
   call $~lib/typedarray/Uint32Array#__set
-  local.get $0
+  local.get $source
   i32.const 2
   i32.const 6
   call $~lib/typedarray/Uint32Array#__set
-  local.get $0
+  local.get $source
   i32.const 5776
   local.set $3
   global.get $~lib/memory/__stack_pointer
@@ -47243,8 +47243,8 @@
   i32.store $0 offset=4
   local.get $3
   call $~lib/typedarray/Uint32Array#every
-  local.set $1
-  local.get $1
+  local.set $result
+  local.get $result
   i32.const 0
   i32.ne
   i32.eqz
@@ -47256,7 +47256,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $0
+  local.get $source
   i32.const 5808
   local.set $3
   global.get $~lib/memory/__stack_pointer
@@ -47264,8 +47264,8 @@
   i32.store $0 offset=4
   local.get $3
   call $~lib/typedarray/Uint32Array#every
-  local.set $2
-  local.get $2
+  local.set $failResult
+  local.get $failResult
   i32.eqz
   i32.eqz
   if
@@ -47282,9 +47282,9 @@
   global.set $~lib/memory/__stack_pointer
  )
  (func $std/typedarray/testArrayEvery<~lib/typedarray/Int64Array,i64>
-  (local $0 i32)
-  (local $1 i32)
-  (local $2 i32)
+  (local $source i32)
+  (local $result i32)
+  (local $failResult i32)
   (local $3 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 8
@@ -47298,21 +47298,21 @@
   i32.const 0
   i32.const 3
   call $~lib/typedarray/Int64Array#constructor
-  local.tee $0
+  local.tee $source
   i32.store $0
-  local.get $0
+  local.get $source
   i32.const 0
   i64.const 2
   call $~lib/typedarray/Int64Array#__set
-  local.get $0
+  local.get $source
   i32.const 1
   i64.const 4
   call $~lib/typedarray/Int64Array#__set
-  local.get $0
+  local.get $source
   i32.const 2
   i64.const 6
   call $~lib/typedarray/Int64Array#__set
-  local.get $0
+  local.get $source
   i32.const 5840
   local.set $3
   global.get $~lib/memory/__stack_pointer
@@ -47320,8 +47320,8 @@
   i32.store $0 offset=4
   local.get $3
   call $~lib/typedarray/Int64Array#every
-  local.set $1
-  local.get $1
+  local.set $result
+  local.get $result
   i32.const 0
   i32.ne
   i32.eqz
@@ -47333,7 +47333,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $0
+  local.get $source
   i32.const 5872
   local.set $3
   global.get $~lib/memory/__stack_pointer
@@ -47341,8 +47341,8 @@
   i32.store $0 offset=4
   local.get $3
   call $~lib/typedarray/Int64Array#every
-  local.set $2
-  local.get $2
+  local.set $failResult
+  local.get $failResult
   i32.eqz
   i32.eqz
   if
@@ -47359,9 +47359,9 @@
   global.set $~lib/memory/__stack_pointer
  )
  (func $std/typedarray/testArrayEvery<~lib/typedarray/Uint64Array,u64>
-  (local $0 i32)
-  (local $1 i32)
-  (local $2 i32)
+  (local $source i32)
+  (local $result i32)
+  (local $failResult i32)
   (local $3 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 8
@@ -47375,21 +47375,21 @@
   i32.const 0
   i32.const 3
   call $~lib/typedarray/Uint64Array#constructor
-  local.tee $0
+  local.tee $source
   i32.store $0
-  local.get $0
+  local.get $source
   i32.const 0
   i64.const 2
   call $~lib/typedarray/Uint64Array#__set
-  local.get $0
+  local.get $source
   i32.const 1
   i64.const 4
   call $~lib/typedarray/Uint64Array#__set
-  local.get $0
+  local.get $source
   i32.const 2
   i64.const 6
   call $~lib/typedarray/Uint64Array#__set
-  local.get $0
+  local.get $source
   i32.const 5904
   local.set $3
   global.get $~lib/memory/__stack_pointer
@@ -47397,8 +47397,8 @@
   i32.store $0 offset=4
   local.get $3
   call $~lib/typedarray/Uint64Array#every
-  local.set $1
-  local.get $1
+  local.set $result
+  local.get $result
   i32.const 0
   i32.ne
   i32.eqz
@@ -47410,7 +47410,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $0
+  local.get $source
   i32.const 5936
   local.set $3
   global.get $~lib/memory/__stack_pointer
@@ -47418,8 +47418,8 @@
   i32.store $0 offset=4
   local.get $3
   call $~lib/typedarray/Uint64Array#every
-  local.set $2
-  local.get $2
+  local.set $failResult
+  local.get $failResult
   i32.eqz
   i32.eqz
   if
@@ -47436,9 +47436,9 @@
   global.set $~lib/memory/__stack_pointer
  )
  (func $std/typedarray/testArrayEvery<~lib/typedarray/Float32Array,f32>
-  (local $0 i32)
-  (local $1 i32)
-  (local $2 i32)
+  (local $source i32)
+  (local $result i32)
+  (local $failResult i32)
   (local $3 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 8
@@ -47452,21 +47452,21 @@
   i32.const 0
   i32.const 3
   call $~lib/typedarray/Float32Array#constructor
-  local.tee $0
+  local.tee $source
   i32.store $0
-  local.get $0
+  local.get $source
   i32.const 0
   f32.const 2
   call $~lib/typedarray/Float32Array#__set
-  local.get $0
+  local.get $source
   i32.const 1
   f32.const 4
   call $~lib/typedarray/Float32Array#__set
-  local.get $0
+  local.get $source
   i32.const 2
   f32.const 6
   call $~lib/typedarray/Float32Array#__set
-  local.get $0
+  local.get $source
   i32.const 5968
   local.set $3
   global.get $~lib/memory/__stack_pointer
@@ -47474,8 +47474,8 @@
   i32.store $0 offset=4
   local.get $3
   call $~lib/typedarray/Float32Array#every
-  local.set $1
-  local.get $1
+  local.set $result
+  local.get $result
   i32.const 0
   i32.ne
   i32.eqz
@@ -47487,7 +47487,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $0
+  local.get $source
   i32.const 6000
   local.set $3
   global.get $~lib/memory/__stack_pointer
@@ -47495,8 +47495,8 @@
   i32.store $0 offset=4
   local.get $3
   call $~lib/typedarray/Float32Array#every
-  local.set $2
-  local.get $2
+  local.set $failResult
+  local.get $failResult
   i32.eqz
   i32.eqz
   if
@@ -47513,9 +47513,9 @@
   global.set $~lib/memory/__stack_pointer
  )
  (func $std/typedarray/testArrayEvery<~lib/typedarray/Float64Array,f64>
-  (local $0 i32)
-  (local $1 i32)
-  (local $2 i32)
+  (local $source i32)
+  (local $result i32)
+  (local $failResult i32)
   (local $3 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 8
@@ -47529,21 +47529,21 @@
   i32.const 0
   i32.const 3
   call $~lib/typedarray/Float64Array#constructor
-  local.tee $0
+  local.tee $source
   i32.store $0
-  local.get $0
+  local.get $source
   i32.const 0
   f64.const 2
   call $~lib/typedarray/Float64Array#__set
-  local.get $0
+  local.get $source
   i32.const 1
   f64.const 4
   call $~lib/typedarray/Float64Array#__set
-  local.get $0
+  local.get $source
   i32.const 2
   f64.const 6
   call $~lib/typedarray/Float64Array#__set
-  local.get $0
+  local.get $source
   i32.const 6032
   local.set $3
   global.get $~lib/memory/__stack_pointer
@@ -47551,8 +47551,8 @@
   i32.store $0 offset=4
   local.get $3
   call $~lib/typedarray/Float64Array#every
-  local.set $1
-  local.get $1
+  local.set $result
+  local.get $result
   i32.const 0
   i32.ne
   i32.eqz
@@ -47564,7 +47564,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $0
+  local.get $source
   i32.const 6064
   local.set $3
   global.get $~lib/memory/__stack_pointer
@@ -47572,8 +47572,8 @@
   i32.store $0 offset=4
   local.get $3
   call $~lib/typedarray/Float64Array#every
-  local.set $2
-  local.get $2
+  local.set $failResult
+  local.get $failResult
   i32.eqz
   i32.eqz
   if
@@ -47589,8 +47589,8 @@
   i32.add
   global.set $~lib/memory/__stack_pointer
  )
- (func $std/typedarray/testArrayForEach<~lib/typedarray/Int8Array,i8>~anonymous|0 (param $0 i32) (param $1 i32) (param $2 i32)
-  (local $3 i32)
+ (func $std/typedarray/testArrayForEach<~lib/typedarray/Int8Array,i8>~anonymous|0 (param $value i32) (param $index i32) (param $self i32)
+  (local $matchedValue i32)
   (local $4 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -47606,12 +47606,12 @@
   local.get $4
   i32.store $0
   local.get $4
-  local.get $1
+  local.get $index
   call $~lib/array/Array<i32>#__get
-  local.set $3
-  local.get $0
+  local.set $matchedValue
+  local.get $value
   i32.extend8_s
-  local.get $3
+  local.get $matchedValue
   i32.extend8_s
   i32.eq
   i32.eqz
@@ -47623,7 +47623,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $1
+  local.get $index
   global.get $std/typedarray/forEachCallCount
   i32.eq
   i32.eqz
@@ -47636,7 +47636,7 @@
    unreachable
   end
   global.get $std/typedarray/forEachSelf
-  local.get $2
+  local.get $self
   i32.eq
   i32.eqz
   if
@@ -47657,7 +47657,7 @@
   global.set $~lib/memory/__stack_pointer
  )
  (func $std/typedarray/testArrayForEach<~lib/typedarray/Int8Array,i8>
-  (local $0 i32)
+  (local $array i32)
   (local $1 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 12
@@ -47676,11 +47676,11 @@
   i32.const 0
   i32.const 3
   call $~lib/typedarray/Int8Array#constructor
-  local.tee $0
+  local.tee $array
   i32.store $0
-  local.get $0
+  local.get $array
   global.set $std/typedarray/forEachSelf
-  local.get $0
+  local.get $array
   i32.const 0
   global.get $std/typedarray/forEachValues
   local.set $1
@@ -47692,7 +47692,7 @@
   call $~lib/array/Array<i32>#__get
   i32.extend8_s
   call $~lib/typedarray/Int8Array#__set
-  local.get $0
+  local.get $array
   i32.const 1
   global.get $std/typedarray/forEachValues
   local.set $1
@@ -47704,7 +47704,7 @@
   call $~lib/array/Array<i32>#__get
   i32.extend8_s
   call $~lib/typedarray/Int8Array#__set
-  local.get $0
+  local.get $array
   i32.const 2
   global.get $std/typedarray/forEachValues
   local.set $1
@@ -47716,7 +47716,7 @@
   call $~lib/array/Array<i32>#__get
   i32.extend8_s
   call $~lib/typedarray/Int8Array#__set
-  local.get $0
+  local.get $array
   i32.const 6176
   local.set $1
   global.get $~lib/memory/__stack_pointer
@@ -47741,8 +47741,8 @@
   i32.add
   global.set $~lib/memory/__stack_pointer
  )
- (func $std/typedarray/testArrayForEach<~lib/typedarray/Uint8Array,u8>~anonymous|0 (param $0 i32) (param $1 i32) (param $2 i32)
-  (local $3 i32)
+ (func $std/typedarray/testArrayForEach<~lib/typedarray/Uint8Array,u8>~anonymous|0 (param $value i32) (param $index i32) (param $self i32)
+  (local $matchedValue i32)
   (local $4 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -47758,13 +47758,13 @@
   local.get $4
   i32.store $0
   local.get $4
-  local.get $1
+  local.get $index
   call $~lib/array/Array<i32>#__get
-  local.set $3
-  local.get $0
+  local.set $matchedValue
+  local.get $value
   i32.const 255
   i32.and
-  local.get $3
+  local.get $matchedValue
   i32.const 255
   i32.and
   i32.eq
@@ -47777,7 +47777,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $1
+  local.get $index
   global.get $std/typedarray/forEachCallCount
   i32.eq
   i32.eqz
@@ -47790,7 +47790,7 @@
    unreachable
   end
   global.get $std/typedarray/forEachSelf
-  local.get $2
+  local.get $self
   i32.eq
   i32.eqz
   if
@@ -47811,7 +47811,7 @@
   global.set $~lib/memory/__stack_pointer
  )
  (func $std/typedarray/testArrayForEach<~lib/typedarray/Uint8Array,u8>
-  (local $0 i32)
+  (local $array i32)
   (local $1 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 12
@@ -47830,11 +47830,11 @@
   i32.const 0
   i32.const 3
   call $~lib/typedarray/Uint8Array#constructor
-  local.tee $0
+  local.tee $array
   i32.store $0
-  local.get $0
+  local.get $array
   global.set $std/typedarray/forEachSelf
-  local.get $0
+  local.get $array
   i32.const 0
   global.get $std/typedarray/forEachValues
   local.set $1
@@ -47847,7 +47847,7 @@
   i32.const 255
   i32.and
   call $~lib/typedarray/Uint8Array#__set
-  local.get $0
+  local.get $array
   i32.const 1
   global.get $std/typedarray/forEachValues
   local.set $1
@@ -47860,7 +47860,7 @@
   i32.const 255
   i32.and
   call $~lib/typedarray/Uint8Array#__set
-  local.get $0
+  local.get $array
   i32.const 2
   global.get $std/typedarray/forEachValues
   local.set $1
@@ -47873,7 +47873,7 @@
   i32.const 255
   i32.and
   call $~lib/typedarray/Uint8Array#__set
-  local.get $0
+  local.get $array
   i32.const 6208
   local.set $1
   global.get $~lib/memory/__stack_pointer
@@ -47898,8 +47898,8 @@
   i32.add
   global.set $~lib/memory/__stack_pointer
  )
- (func $std/typedarray/testArrayForEach<~lib/typedarray/Uint8ClampedArray,u8>~anonymous|0 (param $0 i32) (param $1 i32) (param $2 i32)
-  (local $3 i32)
+ (func $std/typedarray/testArrayForEach<~lib/typedarray/Uint8ClampedArray,u8>~anonymous|0 (param $value i32) (param $index i32) (param $self i32)
+  (local $matchedValue i32)
   (local $4 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -47915,13 +47915,13 @@
   local.get $4
   i32.store $0
   local.get $4
-  local.get $1
+  local.get $index
   call $~lib/array/Array<i32>#__get
-  local.set $3
-  local.get $0
+  local.set $matchedValue
+  local.get $value
   i32.const 255
   i32.and
-  local.get $3
+  local.get $matchedValue
   i32.const 255
   i32.and
   i32.eq
@@ -47934,7 +47934,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $1
+  local.get $index
   global.get $std/typedarray/forEachCallCount
   i32.eq
   i32.eqz
@@ -47947,7 +47947,7 @@
    unreachable
   end
   global.get $std/typedarray/forEachSelf
-  local.get $2
+  local.get $self
   i32.eq
   i32.eqz
   if
@@ -47968,7 +47968,7 @@
   global.set $~lib/memory/__stack_pointer
  )
  (func $std/typedarray/testArrayForEach<~lib/typedarray/Uint8ClampedArray,u8>
-  (local $0 i32)
+  (local $array i32)
   (local $1 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 12
@@ -47987,11 +47987,11 @@
   i32.const 0
   i32.const 3
   call $~lib/typedarray/Uint8ClampedArray#constructor
-  local.tee $0
+  local.tee $array
   i32.store $0
-  local.get $0
+  local.get $array
   global.set $std/typedarray/forEachSelf
-  local.get $0
+  local.get $array
   i32.const 0
   global.get $std/typedarray/forEachValues
   local.set $1
@@ -48004,7 +48004,7 @@
   i32.const 255
   i32.and
   call $~lib/typedarray/Uint8ClampedArray#__set
-  local.get $0
+  local.get $array
   i32.const 1
   global.get $std/typedarray/forEachValues
   local.set $1
@@ -48017,7 +48017,7 @@
   i32.const 255
   i32.and
   call $~lib/typedarray/Uint8ClampedArray#__set
-  local.get $0
+  local.get $array
   i32.const 2
   global.get $std/typedarray/forEachValues
   local.set $1
@@ -48030,7 +48030,7 @@
   i32.const 255
   i32.and
   call $~lib/typedarray/Uint8ClampedArray#__set
-  local.get $0
+  local.get $array
   i32.const 6240
   local.set $1
   global.get $~lib/memory/__stack_pointer
@@ -48055,8 +48055,8 @@
   i32.add
   global.set $~lib/memory/__stack_pointer
  )
- (func $std/typedarray/testArrayForEach<~lib/typedarray/Int16Array,i16>~anonymous|0 (param $0 i32) (param $1 i32) (param $2 i32)
-  (local $3 i32)
+ (func $std/typedarray/testArrayForEach<~lib/typedarray/Int16Array,i16>~anonymous|0 (param $value i32) (param $index i32) (param $self i32)
+  (local $matchedValue i32)
   (local $4 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -48072,12 +48072,12 @@
   local.get $4
   i32.store $0
   local.get $4
-  local.get $1
+  local.get $index
   call $~lib/array/Array<i32>#__get
-  local.set $3
-  local.get $0
+  local.set $matchedValue
+  local.get $value
   i32.extend16_s
-  local.get $3
+  local.get $matchedValue
   i32.extend16_s
   i32.eq
   i32.eqz
@@ -48089,7 +48089,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $1
+  local.get $index
   global.get $std/typedarray/forEachCallCount
   i32.eq
   i32.eqz
@@ -48102,7 +48102,7 @@
    unreachable
   end
   global.get $std/typedarray/forEachSelf
-  local.get $2
+  local.get $self
   i32.eq
   i32.eqz
   if
@@ -48123,7 +48123,7 @@
   global.set $~lib/memory/__stack_pointer
  )
  (func $std/typedarray/testArrayForEach<~lib/typedarray/Int16Array,i16>
-  (local $0 i32)
+  (local $array i32)
   (local $1 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 12
@@ -48142,11 +48142,11 @@
   i32.const 0
   i32.const 3
   call $~lib/typedarray/Int16Array#constructor
-  local.tee $0
+  local.tee $array
   i32.store $0
-  local.get $0
+  local.get $array
   global.set $std/typedarray/forEachSelf
-  local.get $0
+  local.get $array
   i32.const 0
   global.get $std/typedarray/forEachValues
   local.set $1
@@ -48158,7 +48158,7 @@
   call $~lib/array/Array<i32>#__get
   i32.extend16_s
   call $~lib/typedarray/Int16Array#__set
-  local.get $0
+  local.get $array
   i32.const 1
   global.get $std/typedarray/forEachValues
   local.set $1
@@ -48170,7 +48170,7 @@
   call $~lib/array/Array<i32>#__get
   i32.extend16_s
   call $~lib/typedarray/Int16Array#__set
-  local.get $0
+  local.get $array
   i32.const 2
   global.get $std/typedarray/forEachValues
   local.set $1
@@ -48182,7 +48182,7 @@
   call $~lib/array/Array<i32>#__get
   i32.extend16_s
   call $~lib/typedarray/Int16Array#__set
-  local.get $0
+  local.get $array
   i32.const 6272
   local.set $1
   global.get $~lib/memory/__stack_pointer
@@ -48207,8 +48207,8 @@
   i32.add
   global.set $~lib/memory/__stack_pointer
  )
- (func $std/typedarray/testArrayForEach<~lib/typedarray/Uint16Array,u16>~anonymous|0 (param $0 i32) (param $1 i32) (param $2 i32)
-  (local $3 i32)
+ (func $std/typedarray/testArrayForEach<~lib/typedarray/Uint16Array,u16>~anonymous|0 (param $value i32) (param $index i32) (param $self i32)
+  (local $matchedValue i32)
   (local $4 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -48224,13 +48224,13 @@
   local.get $4
   i32.store $0
   local.get $4
-  local.get $1
+  local.get $index
   call $~lib/array/Array<i32>#__get
-  local.set $3
-  local.get $0
+  local.set $matchedValue
+  local.get $value
   i32.const 65535
   i32.and
-  local.get $3
+  local.get $matchedValue
   i32.const 65535
   i32.and
   i32.eq
@@ -48243,7 +48243,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $1
+  local.get $index
   global.get $std/typedarray/forEachCallCount
   i32.eq
   i32.eqz
@@ -48256,7 +48256,7 @@
    unreachable
   end
   global.get $std/typedarray/forEachSelf
-  local.get $2
+  local.get $self
   i32.eq
   i32.eqz
   if
@@ -48277,7 +48277,7 @@
   global.set $~lib/memory/__stack_pointer
  )
  (func $std/typedarray/testArrayForEach<~lib/typedarray/Uint16Array,u16>
-  (local $0 i32)
+  (local $array i32)
   (local $1 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 12
@@ -48296,11 +48296,11 @@
   i32.const 0
   i32.const 3
   call $~lib/typedarray/Uint16Array#constructor
-  local.tee $0
+  local.tee $array
   i32.store $0
-  local.get $0
+  local.get $array
   global.set $std/typedarray/forEachSelf
-  local.get $0
+  local.get $array
   i32.const 0
   global.get $std/typedarray/forEachValues
   local.set $1
@@ -48313,7 +48313,7 @@
   i32.const 65535
   i32.and
   call $~lib/typedarray/Uint16Array#__set
-  local.get $0
+  local.get $array
   i32.const 1
   global.get $std/typedarray/forEachValues
   local.set $1
@@ -48326,7 +48326,7 @@
   i32.const 65535
   i32.and
   call $~lib/typedarray/Uint16Array#__set
-  local.get $0
+  local.get $array
   i32.const 2
   global.get $std/typedarray/forEachValues
   local.set $1
@@ -48339,7 +48339,7 @@
   i32.const 65535
   i32.and
   call $~lib/typedarray/Uint16Array#__set
-  local.get $0
+  local.get $array
   i32.const 6304
   local.set $1
   global.get $~lib/memory/__stack_pointer
@@ -48364,8 +48364,8 @@
   i32.add
   global.set $~lib/memory/__stack_pointer
  )
- (func $std/typedarray/testArrayForEach<~lib/typedarray/Int32Array,i32>~anonymous|0 (param $0 i32) (param $1 i32) (param $2 i32)
-  (local $3 i32)
+ (func $std/typedarray/testArrayForEach<~lib/typedarray/Int32Array,i32>~anonymous|0 (param $value i32) (param $index i32) (param $self i32)
+  (local $matchedValue i32)
   (local $4 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -48381,11 +48381,11 @@
   local.get $4
   i32.store $0
   local.get $4
-  local.get $1
+  local.get $index
   call $~lib/array/Array<i32>#__get
-  local.set $3
-  local.get $0
-  local.get $3
+  local.set $matchedValue
+  local.get $value
+  local.get $matchedValue
   i32.eq
   i32.eqz
   if
@@ -48396,7 +48396,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $1
+  local.get $index
   global.get $std/typedarray/forEachCallCount
   i32.eq
   i32.eqz
@@ -48409,7 +48409,7 @@
    unreachable
   end
   global.get $std/typedarray/forEachSelf
-  local.get $2
+  local.get $self
   i32.eq
   i32.eqz
   if
@@ -48430,7 +48430,7 @@
   global.set $~lib/memory/__stack_pointer
  )
  (func $std/typedarray/testArrayForEach<~lib/typedarray/Int32Array,i32>
-  (local $0 i32)
+  (local $array i32)
   (local $1 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 12
@@ -48449,11 +48449,11 @@
   i32.const 0
   i32.const 3
   call $~lib/typedarray/Int32Array#constructor
-  local.tee $0
+  local.tee $array
   i32.store $0
-  local.get $0
+  local.get $array
   global.set $std/typedarray/forEachSelf
-  local.get $0
+  local.get $array
   i32.const 0
   global.get $std/typedarray/forEachValues
   local.set $1
@@ -48464,7 +48464,7 @@
   i32.const 0
   call $~lib/array/Array<i32>#__get
   call $~lib/typedarray/Int32Array#__set
-  local.get $0
+  local.get $array
   i32.const 1
   global.get $std/typedarray/forEachValues
   local.set $1
@@ -48475,7 +48475,7 @@
   i32.const 1
   call $~lib/array/Array<i32>#__get
   call $~lib/typedarray/Int32Array#__set
-  local.get $0
+  local.get $array
   i32.const 2
   global.get $std/typedarray/forEachValues
   local.set $1
@@ -48486,7 +48486,7 @@
   i32.const 2
   call $~lib/array/Array<i32>#__get
   call $~lib/typedarray/Int32Array#__set
-  local.get $0
+  local.get $array
   i32.const 6336
   local.set $1
   global.get $~lib/memory/__stack_pointer
@@ -48511,8 +48511,8 @@
   i32.add
   global.set $~lib/memory/__stack_pointer
  )
- (func $std/typedarray/testArrayForEach<~lib/typedarray/Uint32Array,u32>~anonymous|0 (param $0 i32) (param $1 i32) (param $2 i32)
-  (local $3 i32)
+ (func $std/typedarray/testArrayForEach<~lib/typedarray/Uint32Array,u32>~anonymous|0 (param $value i32) (param $index i32) (param $self i32)
+  (local $matchedValue i32)
   (local $4 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -48528,11 +48528,11 @@
   local.get $4
   i32.store $0
   local.get $4
-  local.get $1
+  local.get $index
   call $~lib/array/Array<i32>#__get
-  local.set $3
-  local.get $0
-  local.get $3
+  local.set $matchedValue
+  local.get $value
+  local.get $matchedValue
   i32.eq
   i32.eqz
   if
@@ -48543,7 +48543,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $1
+  local.get $index
   global.get $std/typedarray/forEachCallCount
   i32.eq
   i32.eqz
@@ -48556,7 +48556,7 @@
    unreachable
   end
   global.get $std/typedarray/forEachSelf
-  local.get $2
+  local.get $self
   i32.eq
   i32.eqz
   if
@@ -48577,7 +48577,7 @@
   global.set $~lib/memory/__stack_pointer
  )
  (func $std/typedarray/testArrayForEach<~lib/typedarray/Uint32Array,u32>
-  (local $0 i32)
+  (local $array i32)
   (local $1 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 12
@@ -48596,11 +48596,11 @@
   i32.const 0
   i32.const 3
   call $~lib/typedarray/Uint32Array#constructor
-  local.tee $0
+  local.tee $array
   i32.store $0
-  local.get $0
+  local.get $array
   global.set $std/typedarray/forEachSelf
-  local.get $0
+  local.get $array
   i32.const 0
   global.get $std/typedarray/forEachValues
   local.set $1
@@ -48611,7 +48611,7 @@
   i32.const 0
   call $~lib/array/Array<i32>#__get
   call $~lib/typedarray/Uint32Array#__set
-  local.get $0
+  local.get $array
   i32.const 1
   global.get $std/typedarray/forEachValues
   local.set $1
@@ -48622,7 +48622,7 @@
   i32.const 1
   call $~lib/array/Array<i32>#__get
   call $~lib/typedarray/Uint32Array#__set
-  local.get $0
+  local.get $array
   i32.const 2
   global.get $std/typedarray/forEachValues
   local.set $1
@@ -48633,7 +48633,7 @@
   i32.const 2
   call $~lib/array/Array<i32>#__get
   call $~lib/typedarray/Uint32Array#__set
-  local.get $0
+  local.get $array
   i32.const 6368
   local.set $1
   global.get $~lib/memory/__stack_pointer
@@ -48658,8 +48658,8 @@
   i32.add
   global.set $~lib/memory/__stack_pointer
  )
- (func $std/typedarray/testArrayForEach<~lib/typedarray/Int64Array,i64>~anonymous|0 (param $0 i64) (param $1 i32) (param $2 i32)
-  (local $3 i32)
+ (func $std/typedarray/testArrayForEach<~lib/typedarray/Int64Array,i64>~anonymous|0 (param $value i64) (param $index i32) (param $self i32)
+  (local $matchedValue i32)
   (local $4 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -48675,11 +48675,11 @@
   local.get $4
   i32.store $0
   local.get $4
-  local.get $1
+  local.get $index
   call $~lib/array/Array<i32>#__get
-  local.set $3
-  local.get $0
-  local.get $3
+  local.set $matchedValue
+  local.get $value
+  local.get $matchedValue
   i64.extend_i32_s
   i64.eq
   i32.eqz
@@ -48691,7 +48691,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $1
+  local.get $index
   global.get $std/typedarray/forEachCallCount
   i32.eq
   i32.eqz
@@ -48704,7 +48704,7 @@
    unreachable
   end
   global.get $std/typedarray/forEachSelf
-  local.get $2
+  local.get $self
   i32.eq
   i32.eqz
   if
@@ -48725,7 +48725,7 @@
   global.set $~lib/memory/__stack_pointer
  )
  (func $std/typedarray/testArrayForEach<~lib/typedarray/Int64Array,i64>
-  (local $0 i32)
+  (local $array i32)
   (local $1 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 12
@@ -48744,11 +48744,11 @@
   i32.const 0
   i32.const 3
   call $~lib/typedarray/Int64Array#constructor
-  local.tee $0
+  local.tee $array
   i32.store $0
-  local.get $0
+  local.get $array
   global.set $std/typedarray/forEachSelf
-  local.get $0
+  local.get $array
   i32.const 0
   global.get $std/typedarray/forEachValues
   local.set $1
@@ -48760,7 +48760,7 @@
   call $~lib/array/Array<i32>#__get
   i64.extend_i32_s
   call $~lib/typedarray/Int64Array#__set
-  local.get $0
+  local.get $array
   i32.const 1
   global.get $std/typedarray/forEachValues
   local.set $1
@@ -48772,7 +48772,7 @@
   call $~lib/array/Array<i32>#__get
   i64.extend_i32_s
   call $~lib/typedarray/Int64Array#__set
-  local.get $0
+  local.get $array
   i32.const 2
   global.get $std/typedarray/forEachValues
   local.set $1
@@ -48784,7 +48784,7 @@
   call $~lib/array/Array<i32>#__get
   i64.extend_i32_s
   call $~lib/typedarray/Int64Array#__set
-  local.get $0
+  local.get $array
   i32.const 6400
   local.set $1
   global.get $~lib/memory/__stack_pointer
@@ -48809,8 +48809,8 @@
   i32.add
   global.set $~lib/memory/__stack_pointer
  )
- (func $std/typedarray/testArrayForEach<~lib/typedarray/Uint64Array,u64>~anonymous|0 (param $0 i64) (param $1 i32) (param $2 i32)
-  (local $3 i32)
+ (func $std/typedarray/testArrayForEach<~lib/typedarray/Uint64Array,u64>~anonymous|0 (param $value i64) (param $index i32) (param $self i32)
+  (local $matchedValue i32)
   (local $4 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -48826,11 +48826,11 @@
   local.get $4
   i32.store $0
   local.get $4
-  local.get $1
+  local.get $index
   call $~lib/array/Array<i32>#__get
-  local.set $3
-  local.get $0
-  local.get $3
+  local.set $matchedValue
+  local.get $value
+  local.get $matchedValue
   i64.extend_i32_s
   i64.eq
   i32.eqz
@@ -48842,7 +48842,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $1
+  local.get $index
   global.get $std/typedarray/forEachCallCount
   i32.eq
   i32.eqz
@@ -48855,7 +48855,7 @@
    unreachable
   end
   global.get $std/typedarray/forEachSelf
-  local.get $2
+  local.get $self
   i32.eq
   i32.eqz
   if
@@ -48876,7 +48876,7 @@
   global.set $~lib/memory/__stack_pointer
  )
  (func $std/typedarray/testArrayForEach<~lib/typedarray/Uint64Array,u64>
-  (local $0 i32)
+  (local $array i32)
   (local $1 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 12
@@ -48895,11 +48895,11 @@
   i32.const 0
   i32.const 3
   call $~lib/typedarray/Uint64Array#constructor
-  local.tee $0
+  local.tee $array
   i32.store $0
-  local.get $0
+  local.get $array
   global.set $std/typedarray/forEachSelf
-  local.get $0
+  local.get $array
   i32.const 0
   global.get $std/typedarray/forEachValues
   local.set $1
@@ -48911,7 +48911,7 @@
   call $~lib/array/Array<i32>#__get
   i64.extend_i32_s
   call $~lib/typedarray/Uint64Array#__set
-  local.get $0
+  local.get $array
   i32.const 1
   global.get $std/typedarray/forEachValues
   local.set $1
@@ -48923,7 +48923,7 @@
   call $~lib/array/Array<i32>#__get
   i64.extend_i32_s
   call $~lib/typedarray/Uint64Array#__set
-  local.get $0
+  local.get $array
   i32.const 2
   global.get $std/typedarray/forEachValues
   local.set $1
@@ -48935,7 +48935,7 @@
   call $~lib/array/Array<i32>#__get
   i64.extend_i32_s
   call $~lib/typedarray/Uint64Array#__set
-  local.get $0
+  local.get $array
   i32.const 6432
   local.set $1
   global.get $~lib/memory/__stack_pointer
@@ -48960,8 +48960,8 @@
   i32.add
   global.set $~lib/memory/__stack_pointer
  )
- (func $std/typedarray/testArrayForEach<~lib/typedarray/Float32Array,f32>~anonymous|0 (param $0 f32) (param $1 i32) (param $2 i32)
-  (local $3 i32)
+ (func $std/typedarray/testArrayForEach<~lib/typedarray/Float32Array,f32>~anonymous|0 (param $value f32) (param $index i32) (param $self i32)
+  (local $matchedValue i32)
   (local $4 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -48977,11 +48977,11 @@
   local.get $4
   i32.store $0
   local.get $4
-  local.get $1
+  local.get $index
   call $~lib/array/Array<i32>#__get
-  local.set $3
-  local.get $0
-  local.get $3
+  local.set $matchedValue
+  local.get $value
+  local.get $matchedValue
   f32.convert_i32_s
   f32.eq
   i32.eqz
@@ -48993,7 +48993,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $1
+  local.get $index
   global.get $std/typedarray/forEachCallCount
   i32.eq
   i32.eqz
@@ -49006,7 +49006,7 @@
    unreachable
   end
   global.get $std/typedarray/forEachSelf
-  local.get $2
+  local.get $self
   i32.eq
   i32.eqz
   if
@@ -49027,7 +49027,7 @@
   global.set $~lib/memory/__stack_pointer
  )
  (func $std/typedarray/testArrayForEach<~lib/typedarray/Float32Array,f32>
-  (local $0 i32)
+  (local $array i32)
   (local $1 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 12
@@ -49046,11 +49046,11 @@
   i32.const 0
   i32.const 3
   call $~lib/typedarray/Float32Array#constructor
-  local.tee $0
+  local.tee $array
   i32.store $0
-  local.get $0
+  local.get $array
   global.set $std/typedarray/forEachSelf
-  local.get $0
+  local.get $array
   i32.const 0
   global.get $std/typedarray/forEachValues
   local.set $1
@@ -49062,7 +49062,7 @@
   call $~lib/array/Array<i32>#__get
   f32.convert_i32_s
   call $~lib/typedarray/Float32Array#__set
-  local.get $0
+  local.get $array
   i32.const 1
   global.get $std/typedarray/forEachValues
   local.set $1
@@ -49074,7 +49074,7 @@
   call $~lib/array/Array<i32>#__get
   f32.convert_i32_s
   call $~lib/typedarray/Float32Array#__set
-  local.get $0
+  local.get $array
   i32.const 2
   global.get $std/typedarray/forEachValues
   local.set $1
@@ -49086,7 +49086,7 @@
   call $~lib/array/Array<i32>#__get
   f32.convert_i32_s
   call $~lib/typedarray/Float32Array#__set
-  local.get $0
+  local.get $array
   i32.const 6464
   local.set $1
   global.get $~lib/memory/__stack_pointer
@@ -49111,8 +49111,8 @@
   i32.add
   global.set $~lib/memory/__stack_pointer
  )
- (func $std/typedarray/testArrayForEach<~lib/typedarray/Float64Array,f64>~anonymous|0 (param $0 f64) (param $1 i32) (param $2 i32)
-  (local $3 i32)
+ (func $std/typedarray/testArrayForEach<~lib/typedarray/Float64Array,f64>~anonymous|0 (param $value f64) (param $index i32) (param $self i32)
+  (local $matchedValue i32)
   (local $4 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -49128,11 +49128,11 @@
   local.get $4
   i32.store $0
   local.get $4
-  local.get $1
+  local.get $index
   call $~lib/array/Array<i32>#__get
-  local.set $3
-  local.get $0
-  local.get $3
+  local.set $matchedValue
+  local.get $value
+  local.get $matchedValue
   f64.convert_i32_s
   f64.eq
   i32.eqz
@@ -49144,7 +49144,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $1
+  local.get $index
   global.get $std/typedarray/forEachCallCount
   i32.eq
   i32.eqz
@@ -49157,7 +49157,7 @@
    unreachable
   end
   global.get $std/typedarray/forEachSelf
-  local.get $2
+  local.get $self
   i32.eq
   i32.eqz
   if
@@ -49178,7 +49178,7 @@
   global.set $~lib/memory/__stack_pointer
  )
  (func $std/typedarray/testArrayForEach<~lib/typedarray/Float64Array,f64>
-  (local $0 i32)
+  (local $array i32)
   (local $1 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 12
@@ -49197,11 +49197,11 @@
   i32.const 0
   i32.const 3
   call $~lib/typedarray/Float64Array#constructor
-  local.tee $0
+  local.tee $array
   i32.store $0
-  local.get $0
+  local.get $array
   global.set $std/typedarray/forEachSelf
-  local.get $0
+  local.get $array
   i32.const 0
   global.get $std/typedarray/forEachValues
   local.set $1
@@ -49213,7 +49213,7 @@
   call $~lib/array/Array<i32>#__get
   f64.convert_i32_s
   call $~lib/typedarray/Float64Array#__set
-  local.get $0
+  local.get $array
   i32.const 1
   global.get $std/typedarray/forEachValues
   local.set $1
@@ -49225,7 +49225,7 @@
   call $~lib/array/Array<i32>#__get
   f64.convert_i32_s
   call $~lib/typedarray/Float64Array#__set
-  local.get $0
+  local.get $array
   i32.const 2
   global.get $std/typedarray/forEachValues
   local.set $1
@@ -49237,7 +49237,7 @@
   call $~lib/array/Array<i32>#__get
   f64.convert_i32_s
   call $~lib/typedarray/Float64Array#__set
-  local.get $0
+  local.get $array
   i32.const 6496
   local.set $1
   global.get $~lib/memory/__stack_pointer
@@ -49263,13 +49263,13 @@
   global.set $~lib/memory/__stack_pointer
  )
  (func $std/typedarray/testArrayReverse<~lib/typedarray/Int8Array,i8>
-  (local $0 i32)
-  (local $1 i32)
-  (local $2 i32)
-  (local $3 i32)
-  (local $4 i32)
-  (local $5 i32)
-  (local $6 i32)
+  (local $values i32)
+  (local $length i32)
+  (local $array i32)
+  (local $arrayWithOffset i32)
+  (local $var$4 i32)
+  (local $var$5 i32)
+  (local $reversedSlice i32)
   (local $7 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 20
@@ -49282,73 +49282,73 @@
   memory.fill $0
   global.get $~lib/memory/__stack_pointer
   global.get $std/typedarray/testArrayReverseValues
-  local.tee $0
+  local.tee $values
   i32.store $0
-  local.get $0
+  local.get $values
   call $~lib/array/Array<i32>#get:length
-  local.set $1
+  local.set $length
   global.get $~lib/memory/__stack_pointer
   i32.const 0
-  local.get $1
+  local.get $length
   call $~lib/typedarray/Int8Array#constructor
-  local.tee $2
+  local.tee $array
   i32.store $0 offset=4
   global.get $~lib/memory/__stack_pointer
   i32.const 0
-  local.get $1
+  local.get $length
   call $~lib/typedarray/Int8Array#constructor
-  local.tee $3
+  local.tee $arrayWithOffset
   i32.store $0 offset=8
   i32.const 0
-  local.set $4
+  local.set $var$4
   loop $for-loop|0
-   local.get $4
-   local.get $1
+   local.get $var$4
+   local.get $length
    i32.lt_s
-   local.set $5
-   local.get $5
+   local.set $var$5
+   local.get $var$5
    if
-    local.get $2
-    local.get $4
-    local.get $0
-    local.get $4
+    local.get $array
+    local.get $var$4
+    local.get $values
+    local.get $var$4
     call $~lib/array/Array<i32>#__get
     i32.extend8_s
     call $~lib/typedarray/Int8Array#__set
-    local.get $3
-    local.get $4
-    local.get $0
-    local.get $4
+    local.get $arrayWithOffset
+    local.get $var$4
+    local.get $values
+    local.get $var$4
     call $~lib/array/Array<i32>#__get
     i32.extend8_s
     call $~lib/typedarray/Int8Array#__set
-    local.get $4
+    local.get $var$4
     i32.const 1
     i32.add
-    local.set $4
+    local.set $var$4
     br $for-loop|0
    end
   end
-  local.get $2
+  local.get $array
   call $~lib/typedarray/Int8Array#reverse
   drop
   i32.const 0
-  local.set $4
+  local.set $var$4
   loop $for-loop|1
-   local.get $4
-   local.get $1
+   local.get $var$4
+   local.get $length
    i32.lt_s
-   local.set $5
-   local.get $5
+   local.set $var$5
+   local.get $var$5
    if
-    local.get $2
-    local.get $4
+    local.get $array
+    local.get $var$4
     call $~lib/typedarray/Int8Array#__get
-    local.get $0
-    local.get $1
+    local.get $values
+    local.get $length
     i32.const 1
     i32.sub
-    local.get $4
+    local.get $var$4
     i32.sub
     call $~lib/array/Array<i32>#__get
     i32.extend8_s
@@ -49362,15 +49362,15 @@
      call $~lib/builtins/abort
      unreachable
     end
-    local.get $4
+    local.get $var$4
     i32.const 1
     i32.add
-    local.set $4
+    local.set $var$4
     br $for-loop|1
    end
   end
   global.get $~lib/memory/__stack_pointer
-  local.get $3
+  local.get $arrayWithOffset
   i32.const 4
   i32.const 8
   call $~lib/typedarray/Int8Array#subarray
@@ -49380,9 +49380,9 @@
   i32.store $0 offset=12
   local.get $7
   call $~lib/typedarray/Int8Array#reverse
-  local.tee $6
+  local.tee $reversedSlice
   i32.store $0 offset=16
-  local.get $6
+  local.get $reversedSlice
   i32.const 0
   call $~lib/typedarray/Int8Array#__get
   i32.const 8
@@ -49396,7 +49396,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $6
+  local.get $reversedSlice
   i32.const 1
   call $~lib/typedarray/Int8Array#__get
   i32.const 7
@@ -49410,7 +49410,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $6
+  local.get $reversedSlice
   i32.const 2
   call $~lib/typedarray/Int8Array#__get
   i32.const 6
@@ -49424,7 +49424,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $6
+  local.get $reversedSlice
   i32.const 3
   call $~lib/typedarray/Int8Array#__get
   i32.const 5
@@ -49444,13 +49444,13 @@
   global.set $~lib/memory/__stack_pointer
  )
  (func $std/typedarray/testArrayReverse<~lib/typedarray/Uint8Array,u8>
-  (local $0 i32)
-  (local $1 i32)
-  (local $2 i32)
-  (local $3 i32)
-  (local $4 i32)
-  (local $5 i32)
-  (local $6 i32)
+  (local $values i32)
+  (local $length i32)
+  (local $array i32)
+  (local $arrayWithOffset i32)
+  (local $var$4 i32)
+  (local $var$5 i32)
+  (local $reversedSlice i32)
   (local $7 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 20
@@ -49463,75 +49463,75 @@
   memory.fill $0
   global.get $~lib/memory/__stack_pointer
   global.get $std/typedarray/testArrayReverseValues
-  local.tee $0
+  local.tee $values
   i32.store $0
-  local.get $0
+  local.get $values
   call $~lib/array/Array<i32>#get:length
-  local.set $1
+  local.set $length
   global.get $~lib/memory/__stack_pointer
   i32.const 0
-  local.get $1
+  local.get $length
   call $~lib/typedarray/Uint8Array#constructor
-  local.tee $2
+  local.tee $array
   i32.store $0 offset=4
   global.get $~lib/memory/__stack_pointer
   i32.const 0
-  local.get $1
+  local.get $length
   call $~lib/typedarray/Uint8Array#constructor
-  local.tee $3
+  local.tee $arrayWithOffset
   i32.store $0 offset=8
   i32.const 0
-  local.set $4
+  local.set $var$4
   loop $for-loop|0
-   local.get $4
-   local.get $1
+   local.get $var$4
+   local.get $length
    i32.lt_s
-   local.set $5
-   local.get $5
+   local.set $var$5
+   local.get $var$5
    if
-    local.get $2
-    local.get $4
-    local.get $0
-    local.get $4
+    local.get $array
+    local.get $var$4
+    local.get $values
+    local.get $var$4
     call $~lib/array/Array<i32>#__get
     i32.const 255
     i32.and
     call $~lib/typedarray/Uint8Array#__set
-    local.get $3
-    local.get $4
-    local.get $0
-    local.get $4
+    local.get $arrayWithOffset
+    local.get $var$4
+    local.get $values
+    local.get $var$4
     call $~lib/array/Array<i32>#__get
     i32.const 255
     i32.and
     call $~lib/typedarray/Uint8Array#__set
-    local.get $4
+    local.get $var$4
     i32.const 1
     i32.add
-    local.set $4
+    local.set $var$4
     br $for-loop|0
    end
   end
-  local.get $2
+  local.get $array
   call $~lib/typedarray/Uint8Array#reverse
   drop
   i32.const 0
-  local.set $4
+  local.set $var$4
   loop $for-loop|1
-   local.get $4
-   local.get $1
+   local.get $var$4
+   local.get $length
    i32.lt_s
-   local.set $5
-   local.get $5
+   local.set $var$5
+   local.get $var$5
    if
-    local.get $2
-    local.get $4
+    local.get $array
+    local.get $var$4
     call $~lib/typedarray/Uint8Array#__get
-    local.get $0
-    local.get $1
+    local.get $values
+    local.get $length
     i32.const 1
     i32.sub
-    local.get $4
+    local.get $var$4
     i32.sub
     call $~lib/array/Array<i32>#__get
     i32.const 255
@@ -49546,15 +49546,15 @@
      call $~lib/builtins/abort
      unreachable
     end
-    local.get $4
+    local.get $var$4
     i32.const 1
     i32.add
-    local.set $4
+    local.set $var$4
     br $for-loop|1
    end
   end
   global.get $~lib/memory/__stack_pointer
-  local.get $3
+  local.get $arrayWithOffset
   i32.const 4
   i32.const 8
   call $~lib/typedarray/Uint8Array#subarray
@@ -49564,9 +49564,9 @@
   i32.store $0 offset=12
   local.get $7
   call $~lib/typedarray/Uint8Array#reverse
-  local.tee $6
+  local.tee $reversedSlice
   i32.store $0 offset=16
-  local.get $6
+  local.get $reversedSlice
   i32.const 0
   call $~lib/typedarray/Uint8Array#__get
   i32.const 8
@@ -49580,7 +49580,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $6
+  local.get $reversedSlice
   i32.const 1
   call $~lib/typedarray/Uint8Array#__get
   i32.const 7
@@ -49594,7 +49594,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $6
+  local.get $reversedSlice
   i32.const 2
   call $~lib/typedarray/Uint8Array#__get
   i32.const 6
@@ -49608,7 +49608,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $6
+  local.get $reversedSlice
   i32.const 3
   call $~lib/typedarray/Uint8Array#__get
   i32.const 5
@@ -49628,13 +49628,13 @@
   global.set $~lib/memory/__stack_pointer
  )
  (func $std/typedarray/testArrayReverse<~lib/typedarray/Uint8ClampedArray,u8>
-  (local $0 i32)
-  (local $1 i32)
-  (local $2 i32)
-  (local $3 i32)
-  (local $4 i32)
-  (local $5 i32)
-  (local $6 i32)
+  (local $values i32)
+  (local $length i32)
+  (local $array i32)
+  (local $arrayWithOffset i32)
+  (local $var$4 i32)
+  (local $var$5 i32)
+  (local $reversedSlice i32)
   (local $7 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 20
@@ -49647,75 +49647,75 @@
   memory.fill $0
   global.get $~lib/memory/__stack_pointer
   global.get $std/typedarray/testArrayReverseValues
-  local.tee $0
+  local.tee $values
   i32.store $0
-  local.get $0
+  local.get $values
   call $~lib/array/Array<i32>#get:length
-  local.set $1
+  local.set $length
   global.get $~lib/memory/__stack_pointer
   i32.const 0
-  local.get $1
+  local.get $length
   call $~lib/typedarray/Uint8ClampedArray#constructor
-  local.tee $2
+  local.tee $array
   i32.store $0 offset=4
   global.get $~lib/memory/__stack_pointer
   i32.const 0
-  local.get $1
+  local.get $length
   call $~lib/typedarray/Uint8ClampedArray#constructor
-  local.tee $3
+  local.tee $arrayWithOffset
   i32.store $0 offset=8
   i32.const 0
-  local.set $4
+  local.set $var$4
   loop $for-loop|0
-   local.get $4
-   local.get $1
+   local.get $var$4
+   local.get $length
    i32.lt_s
-   local.set $5
-   local.get $5
+   local.set $var$5
+   local.get $var$5
    if
-    local.get $2
-    local.get $4
-    local.get $0
-    local.get $4
+    local.get $array
+    local.get $var$4
+    local.get $values
+    local.get $var$4
     call $~lib/array/Array<i32>#__get
     i32.const 255
     i32.and
     call $~lib/typedarray/Uint8ClampedArray#__set
-    local.get $3
-    local.get $4
-    local.get $0
-    local.get $4
+    local.get $arrayWithOffset
+    local.get $var$4
+    local.get $values
+    local.get $var$4
     call $~lib/array/Array<i32>#__get
     i32.const 255
     i32.and
     call $~lib/typedarray/Uint8ClampedArray#__set
-    local.get $4
+    local.get $var$4
     i32.const 1
     i32.add
-    local.set $4
+    local.set $var$4
     br $for-loop|0
    end
   end
-  local.get $2
+  local.get $array
   call $~lib/typedarray/Uint8ClampedArray#reverse
   drop
   i32.const 0
-  local.set $4
+  local.set $var$4
   loop $for-loop|1
-   local.get $4
-   local.get $1
+   local.get $var$4
+   local.get $length
    i32.lt_s
-   local.set $5
-   local.get $5
+   local.set $var$5
+   local.get $var$5
    if
-    local.get $2
-    local.get $4
+    local.get $array
+    local.get $var$4
     call $~lib/typedarray/Uint8ClampedArray#__get
-    local.get $0
-    local.get $1
+    local.get $values
+    local.get $length
     i32.const 1
     i32.sub
-    local.get $4
+    local.get $var$4
     i32.sub
     call $~lib/array/Array<i32>#__get
     i32.const 255
@@ -49730,15 +49730,15 @@
      call $~lib/builtins/abort
      unreachable
     end
-    local.get $4
+    local.get $var$4
     i32.const 1
     i32.add
-    local.set $4
+    local.set $var$4
     br $for-loop|1
    end
   end
   global.get $~lib/memory/__stack_pointer
-  local.get $3
+  local.get $arrayWithOffset
   i32.const 4
   i32.const 8
   call $~lib/typedarray/Uint8ClampedArray#subarray
@@ -49748,9 +49748,9 @@
   i32.store $0 offset=12
   local.get $7
   call $~lib/typedarray/Uint8ClampedArray#reverse
-  local.tee $6
+  local.tee $reversedSlice
   i32.store $0 offset=16
-  local.get $6
+  local.get $reversedSlice
   i32.const 0
   call $~lib/typedarray/Uint8ClampedArray#__get
   i32.const 8
@@ -49764,7 +49764,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $6
+  local.get $reversedSlice
   i32.const 1
   call $~lib/typedarray/Uint8ClampedArray#__get
   i32.const 7
@@ -49778,7 +49778,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $6
+  local.get $reversedSlice
   i32.const 2
   call $~lib/typedarray/Uint8ClampedArray#__get
   i32.const 6
@@ -49792,7 +49792,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $6
+  local.get $reversedSlice
   i32.const 3
   call $~lib/typedarray/Uint8ClampedArray#__get
   i32.const 5
@@ -49812,13 +49812,13 @@
   global.set $~lib/memory/__stack_pointer
  )
  (func $std/typedarray/testArrayReverse<~lib/typedarray/Int16Array,i16>
-  (local $0 i32)
-  (local $1 i32)
-  (local $2 i32)
-  (local $3 i32)
-  (local $4 i32)
-  (local $5 i32)
-  (local $6 i32)
+  (local $values i32)
+  (local $length i32)
+  (local $array i32)
+  (local $arrayWithOffset i32)
+  (local $var$4 i32)
+  (local $var$5 i32)
+  (local $reversedSlice i32)
   (local $7 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 20
@@ -49831,73 +49831,73 @@
   memory.fill $0
   global.get $~lib/memory/__stack_pointer
   global.get $std/typedarray/testArrayReverseValues
-  local.tee $0
+  local.tee $values
   i32.store $0
-  local.get $0
+  local.get $values
   call $~lib/array/Array<i32>#get:length
-  local.set $1
+  local.set $length
   global.get $~lib/memory/__stack_pointer
   i32.const 0
-  local.get $1
+  local.get $length
   call $~lib/typedarray/Int16Array#constructor
-  local.tee $2
+  local.tee $array
   i32.store $0 offset=4
   global.get $~lib/memory/__stack_pointer
   i32.const 0
-  local.get $1
+  local.get $length
   call $~lib/typedarray/Int16Array#constructor
-  local.tee $3
+  local.tee $arrayWithOffset
   i32.store $0 offset=8
   i32.const 0
-  local.set $4
+  local.set $var$4
   loop $for-loop|0
-   local.get $4
-   local.get $1
+   local.get $var$4
+   local.get $length
    i32.lt_s
-   local.set $5
-   local.get $5
+   local.set $var$5
+   local.get $var$5
    if
-    local.get $2
-    local.get $4
-    local.get $0
-    local.get $4
+    local.get $array
+    local.get $var$4
+    local.get $values
+    local.get $var$4
     call $~lib/array/Array<i32>#__get
     i32.extend16_s
     call $~lib/typedarray/Int16Array#__set
-    local.get $3
-    local.get $4
-    local.get $0
-    local.get $4
+    local.get $arrayWithOffset
+    local.get $var$4
+    local.get $values
+    local.get $var$4
     call $~lib/array/Array<i32>#__get
     i32.extend16_s
     call $~lib/typedarray/Int16Array#__set
-    local.get $4
+    local.get $var$4
     i32.const 1
     i32.add
-    local.set $4
+    local.set $var$4
     br $for-loop|0
    end
   end
-  local.get $2
+  local.get $array
   call $~lib/typedarray/Int16Array#reverse
   drop
   i32.const 0
-  local.set $4
+  local.set $var$4
   loop $for-loop|1
-   local.get $4
-   local.get $1
+   local.get $var$4
+   local.get $length
    i32.lt_s
-   local.set $5
-   local.get $5
+   local.set $var$5
+   local.get $var$5
    if
-    local.get $2
-    local.get $4
+    local.get $array
+    local.get $var$4
     call $~lib/typedarray/Int16Array#__get
-    local.get $0
-    local.get $1
+    local.get $values
+    local.get $length
     i32.const 1
     i32.sub
-    local.get $4
+    local.get $var$4
     i32.sub
     call $~lib/array/Array<i32>#__get
     i32.extend16_s
@@ -49911,15 +49911,15 @@
      call $~lib/builtins/abort
      unreachable
     end
-    local.get $4
+    local.get $var$4
     i32.const 1
     i32.add
-    local.set $4
+    local.set $var$4
     br $for-loop|1
    end
   end
   global.get $~lib/memory/__stack_pointer
-  local.get $3
+  local.get $arrayWithOffset
   i32.const 4
   i32.const 8
   call $~lib/typedarray/Int16Array#subarray
@@ -49929,9 +49929,9 @@
   i32.store $0 offset=12
   local.get $7
   call $~lib/typedarray/Int16Array#reverse
-  local.tee $6
+  local.tee $reversedSlice
   i32.store $0 offset=16
-  local.get $6
+  local.get $reversedSlice
   i32.const 0
   call $~lib/typedarray/Int16Array#__get
   i32.const 8
@@ -49945,7 +49945,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $6
+  local.get $reversedSlice
   i32.const 1
   call $~lib/typedarray/Int16Array#__get
   i32.const 7
@@ -49959,7 +49959,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $6
+  local.get $reversedSlice
   i32.const 2
   call $~lib/typedarray/Int16Array#__get
   i32.const 6
@@ -49973,7 +49973,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $6
+  local.get $reversedSlice
   i32.const 3
   call $~lib/typedarray/Int16Array#__get
   i32.const 5
@@ -49993,13 +49993,13 @@
   global.set $~lib/memory/__stack_pointer
  )
  (func $std/typedarray/testArrayReverse<~lib/typedarray/Uint16Array,u16>
-  (local $0 i32)
-  (local $1 i32)
-  (local $2 i32)
-  (local $3 i32)
-  (local $4 i32)
-  (local $5 i32)
-  (local $6 i32)
+  (local $values i32)
+  (local $length i32)
+  (local $array i32)
+  (local $arrayWithOffset i32)
+  (local $var$4 i32)
+  (local $var$5 i32)
+  (local $reversedSlice i32)
   (local $7 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 20
@@ -50012,75 +50012,75 @@
   memory.fill $0
   global.get $~lib/memory/__stack_pointer
   global.get $std/typedarray/testArrayReverseValues
-  local.tee $0
+  local.tee $values
   i32.store $0
-  local.get $0
+  local.get $values
   call $~lib/array/Array<i32>#get:length
-  local.set $1
+  local.set $length
   global.get $~lib/memory/__stack_pointer
   i32.const 0
-  local.get $1
+  local.get $length
   call $~lib/typedarray/Uint16Array#constructor
-  local.tee $2
+  local.tee $array
   i32.store $0 offset=4
   global.get $~lib/memory/__stack_pointer
   i32.const 0
-  local.get $1
+  local.get $length
   call $~lib/typedarray/Uint16Array#constructor
-  local.tee $3
+  local.tee $arrayWithOffset
   i32.store $0 offset=8
   i32.const 0
-  local.set $4
+  local.set $var$4
   loop $for-loop|0
-   local.get $4
-   local.get $1
+   local.get $var$4
+   local.get $length
    i32.lt_s
-   local.set $5
-   local.get $5
+   local.set $var$5
+   local.get $var$5
    if
-    local.get $2
-    local.get $4
-    local.get $0
-    local.get $4
+    local.get $array
+    local.get $var$4
+    local.get $values
+    local.get $var$4
     call $~lib/array/Array<i32>#__get
     i32.const 65535
     i32.and
     call $~lib/typedarray/Uint16Array#__set
-    local.get $3
-    local.get $4
-    local.get $0
-    local.get $4
+    local.get $arrayWithOffset
+    local.get $var$4
+    local.get $values
+    local.get $var$4
     call $~lib/array/Array<i32>#__get
     i32.const 65535
     i32.and
     call $~lib/typedarray/Uint16Array#__set
-    local.get $4
+    local.get $var$4
     i32.const 1
     i32.add
-    local.set $4
+    local.set $var$4
     br $for-loop|0
    end
   end
-  local.get $2
+  local.get $array
   call $~lib/typedarray/Uint16Array#reverse
   drop
   i32.const 0
-  local.set $4
+  local.set $var$4
   loop $for-loop|1
-   local.get $4
-   local.get $1
+   local.get $var$4
+   local.get $length
    i32.lt_s
-   local.set $5
-   local.get $5
+   local.set $var$5
+   local.get $var$5
    if
-    local.get $2
-    local.get $4
+    local.get $array
+    local.get $var$4
     call $~lib/typedarray/Uint16Array#__get
-    local.get $0
-    local.get $1
+    local.get $values
+    local.get $length
     i32.const 1
     i32.sub
-    local.get $4
+    local.get $var$4
     i32.sub
     call $~lib/array/Array<i32>#__get
     i32.const 65535
@@ -50095,15 +50095,15 @@
      call $~lib/builtins/abort
      unreachable
     end
-    local.get $4
+    local.get $var$4
     i32.const 1
     i32.add
-    local.set $4
+    local.set $var$4
     br $for-loop|1
    end
   end
   global.get $~lib/memory/__stack_pointer
-  local.get $3
+  local.get $arrayWithOffset
   i32.const 4
   i32.const 8
   call $~lib/typedarray/Uint16Array#subarray
@@ -50113,9 +50113,9 @@
   i32.store $0 offset=12
   local.get $7
   call $~lib/typedarray/Uint16Array#reverse
-  local.tee $6
+  local.tee $reversedSlice
   i32.store $0 offset=16
-  local.get $6
+  local.get $reversedSlice
   i32.const 0
   call $~lib/typedarray/Uint16Array#__get
   i32.const 8
@@ -50129,7 +50129,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $6
+  local.get $reversedSlice
   i32.const 1
   call $~lib/typedarray/Uint16Array#__get
   i32.const 7
@@ -50143,7 +50143,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $6
+  local.get $reversedSlice
   i32.const 2
   call $~lib/typedarray/Uint16Array#__get
   i32.const 6
@@ -50157,7 +50157,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $6
+  local.get $reversedSlice
   i32.const 3
   call $~lib/typedarray/Uint16Array#__get
   i32.const 5
@@ -50177,13 +50177,13 @@
   global.set $~lib/memory/__stack_pointer
  )
  (func $std/typedarray/testArrayReverse<~lib/typedarray/Int32Array,i32>
-  (local $0 i32)
-  (local $1 i32)
-  (local $2 i32)
-  (local $3 i32)
-  (local $4 i32)
-  (local $5 i32)
-  (local $6 i32)
+  (local $values i32)
+  (local $length i32)
+  (local $array i32)
+  (local $arrayWithOffset i32)
+  (local $var$4 i32)
+  (local $var$5 i32)
+  (local $reversedSlice i32)
   (local $7 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 20
@@ -50196,71 +50196,71 @@
   memory.fill $0
   global.get $~lib/memory/__stack_pointer
   global.get $std/typedarray/testArrayReverseValues
-  local.tee $0
+  local.tee $values
   i32.store $0
-  local.get $0
+  local.get $values
   call $~lib/array/Array<i32>#get:length
-  local.set $1
+  local.set $length
   global.get $~lib/memory/__stack_pointer
   i32.const 0
-  local.get $1
+  local.get $length
   call $~lib/typedarray/Int32Array#constructor
-  local.tee $2
+  local.tee $array
   i32.store $0 offset=4
   global.get $~lib/memory/__stack_pointer
   i32.const 0
-  local.get $1
+  local.get $length
   call $~lib/typedarray/Int32Array#constructor
-  local.tee $3
+  local.tee $arrayWithOffset
   i32.store $0 offset=8
   i32.const 0
-  local.set $4
+  local.set $var$4
   loop $for-loop|0
-   local.get $4
-   local.get $1
+   local.get $var$4
+   local.get $length
    i32.lt_s
-   local.set $5
-   local.get $5
+   local.set $var$5
+   local.get $var$5
    if
-    local.get $2
-    local.get $4
-    local.get $0
-    local.get $4
+    local.get $array
+    local.get $var$4
+    local.get $values
+    local.get $var$4
     call $~lib/array/Array<i32>#__get
     call $~lib/typedarray/Int32Array#__set
-    local.get $3
-    local.get $4
-    local.get $0
-    local.get $4
+    local.get $arrayWithOffset
+    local.get $var$4
+    local.get $values
+    local.get $var$4
     call $~lib/array/Array<i32>#__get
     call $~lib/typedarray/Int32Array#__set
-    local.get $4
+    local.get $var$4
     i32.const 1
     i32.add
-    local.set $4
+    local.set $var$4
     br $for-loop|0
    end
   end
-  local.get $2
+  local.get $array
   call $~lib/typedarray/Int32Array#reverse
   drop
   i32.const 0
-  local.set $4
+  local.set $var$4
   loop $for-loop|1
-   local.get $4
-   local.get $1
+   local.get $var$4
+   local.get $length
    i32.lt_s
-   local.set $5
-   local.get $5
+   local.set $var$5
+   local.get $var$5
    if
-    local.get $2
-    local.get $4
+    local.get $array
+    local.get $var$4
     call $~lib/typedarray/Int32Array#__get
-    local.get $0
-    local.get $1
+    local.get $values
+    local.get $length
     i32.const 1
     i32.sub
-    local.get $4
+    local.get $var$4
     i32.sub
     call $~lib/array/Array<i32>#__get
     i32.eq
@@ -50273,15 +50273,15 @@
      call $~lib/builtins/abort
      unreachable
     end
-    local.get $4
+    local.get $var$4
     i32.const 1
     i32.add
-    local.set $4
+    local.set $var$4
     br $for-loop|1
    end
   end
   global.get $~lib/memory/__stack_pointer
-  local.get $3
+  local.get $arrayWithOffset
   i32.const 4
   i32.const 8
   call $~lib/typedarray/Int32Array#subarray
@@ -50291,9 +50291,9 @@
   i32.store $0 offset=12
   local.get $7
   call $~lib/typedarray/Int32Array#reverse
-  local.tee $6
+  local.tee $reversedSlice
   i32.store $0 offset=16
-  local.get $6
+  local.get $reversedSlice
   i32.const 0
   call $~lib/typedarray/Int32Array#__get
   i32.const 8
@@ -50307,7 +50307,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $6
+  local.get $reversedSlice
   i32.const 1
   call $~lib/typedarray/Int32Array#__get
   i32.const 7
@@ -50321,7 +50321,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $6
+  local.get $reversedSlice
   i32.const 2
   call $~lib/typedarray/Int32Array#__get
   i32.const 6
@@ -50335,7 +50335,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $6
+  local.get $reversedSlice
   i32.const 3
   call $~lib/typedarray/Int32Array#__get
   i32.const 5
@@ -50355,13 +50355,13 @@
   global.set $~lib/memory/__stack_pointer
  )
  (func $std/typedarray/testArrayReverse<~lib/typedarray/Uint32Array,u32>
-  (local $0 i32)
-  (local $1 i32)
-  (local $2 i32)
-  (local $3 i32)
-  (local $4 i32)
-  (local $5 i32)
-  (local $6 i32)
+  (local $values i32)
+  (local $length i32)
+  (local $array i32)
+  (local $arrayWithOffset i32)
+  (local $var$4 i32)
+  (local $var$5 i32)
+  (local $reversedSlice i32)
   (local $7 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 20
@@ -50374,71 +50374,71 @@
   memory.fill $0
   global.get $~lib/memory/__stack_pointer
   global.get $std/typedarray/testArrayReverseValues
-  local.tee $0
+  local.tee $values
   i32.store $0
-  local.get $0
+  local.get $values
   call $~lib/array/Array<i32>#get:length
-  local.set $1
+  local.set $length
   global.get $~lib/memory/__stack_pointer
   i32.const 0
-  local.get $1
+  local.get $length
   call $~lib/typedarray/Uint32Array#constructor
-  local.tee $2
+  local.tee $array
   i32.store $0 offset=4
   global.get $~lib/memory/__stack_pointer
   i32.const 0
-  local.get $1
+  local.get $length
   call $~lib/typedarray/Uint32Array#constructor
-  local.tee $3
+  local.tee $arrayWithOffset
   i32.store $0 offset=8
   i32.const 0
-  local.set $4
+  local.set $var$4
   loop $for-loop|0
-   local.get $4
-   local.get $1
+   local.get $var$4
+   local.get $length
    i32.lt_s
-   local.set $5
-   local.get $5
+   local.set $var$5
+   local.get $var$5
    if
-    local.get $2
-    local.get $4
-    local.get $0
-    local.get $4
+    local.get $array
+    local.get $var$4
+    local.get $values
+    local.get $var$4
     call $~lib/array/Array<i32>#__get
     call $~lib/typedarray/Uint32Array#__set
-    local.get $3
-    local.get $4
-    local.get $0
-    local.get $4
+    local.get $arrayWithOffset
+    local.get $var$4
+    local.get $values
+    local.get $var$4
     call $~lib/array/Array<i32>#__get
     call $~lib/typedarray/Uint32Array#__set
-    local.get $4
+    local.get $var$4
     i32.const 1
     i32.add
-    local.set $4
+    local.set $var$4
     br $for-loop|0
    end
   end
-  local.get $2
+  local.get $array
   call $~lib/typedarray/Uint32Array#reverse
   drop
   i32.const 0
-  local.set $4
+  local.set $var$4
   loop $for-loop|1
-   local.get $4
-   local.get $1
+   local.get $var$4
+   local.get $length
    i32.lt_s
-   local.set $5
-   local.get $5
+   local.set $var$5
+   local.get $var$5
    if
-    local.get $2
-    local.get $4
+    local.get $array
+    local.get $var$4
     call $~lib/typedarray/Uint32Array#__get
-    local.get $0
-    local.get $1
+    local.get $values
+    local.get $length
     i32.const 1
     i32.sub
-    local.get $4
+    local.get $var$4
     i32.sub
     call $~lib/array/Array<i32>#__get
     i32.eq
@@ -50451,15 +50451,15 @@
      call $~lib/builtins/abort
      unreachable
     end
-    local.get $4
+    local.get $var$4
     i32.const 1
     i32.add
-    local.set $4
+    local.set $var$4
     br $for-loop|1
    end
   end
   global.get $~lib/memory/__stack_pointer
-  local.get $3
+  local.get $arrayWithOffset
   i32.const 4
   i32.const 8
   call $~lib/typedarray/Uint32Array#subarray
@@ -50469,9 +50469,9 @@
   i32.store $0 offset=12
   local.get $7
   call $~lib/typedarray/Uint32Array#reverse
-  local.tee $6
+  local.tee $reversedSlice
   i32.store $0 offset=16
-  local.get $6
+  local.get $reversedSlice
   i32.const 0
   call $~lib/typedarray/Uint32Array#__get
   i32.const 8
@@ -50485,7 +50485,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $6
+  local.get $reversedSlice
   i32.const 1
   call $~lib/typedarray/Uint32Array#__get
   i32.const 7
@@ -50499,7 +50499,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $6
+  local.get $reversedSlice
   i32.const 2
   call $~lib/typedarray/Uint32Array#__get
   i32.const 6
@@ -50513,7 +50513,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $6
+  local.get $reversedSlice
   i32.const 3
   call $~lib/typedarray/Uint32Array#__get
   i32.const 5
@@ -50533,13 +50533,13 @@
   global.set $~lib/memory/__stack_pointer
  )
  (func $std/typedarray/testArrayReverse<~lib/typedarray/Int64Array,i64>
-  (local $0 i32)
-  (local $1 i32)
-  (local $2 i32)
-  (local $3 i32)
-  (local $4 i32)
-  (local $5 i32)
-  (local $6 i32)
+  (local $values i32)
+  (local $length i32)
+  (local $array i32)
+  (local $arrayWithOffset i32)
+  (local $var$4 i32)
+  (local $var$5 i32)
+  (local $reversedSlice i32)
   (local $7 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 20
@@ -50552,73 +50552,73 @@
   memory.fill $0
   global.get $~lib/memory/__stack_pointer
   global.get $std/typedarray/testArrayReverseValues
-  local.tee $0
+  local.tee $values
   i32.store $0
-  local.get $0
+  local.get $values
   call $~lib/array/Array<i32>#get:length
-  local.set $1
+  local.set $length
   global.get $~lib/memory/__stack_pointer
   i32.const 0
-  local.get $1
+  local.get $length
   call $~lib/typedarray/Int64Array#constructor
-  local.tee $2
+  local.tee $array
   i32.store $0 offset=4
   global.get $~lib/memory/__stack_pointer
   i32.const 0
-  local.get $1
+  local.get $length
   call $~lib/typedarray/Int64Array#constructor
-  local.tee $3
+  local.tee $arrayWithOffset
   i32.store $0 offset=8
   i32.const 0
-  local.set $4
+  local.set $var$4
   loop $for-loop|0
-   local.get $4
-   local.get $1
+   local.get $var$4
+   local.get $length
    i32.lt_s
-   local.set $5
-   local.get $5
+   local.set $var$5
+   local.get $var$5
    if
-    local.get $2
-    local.get $4
-    local.get $0
-    local.get $4
+    local.get $array
+    local.get $var$4
+    local.get $values
+    local.get $var$4
     call $~lib/array/Array<i32>#__get
     i64.extend_i32_s
     call $~lib/typedarray/Int64Array#__set
-    local.get $3
-    local.get $4
-    local.get $0
-    local.get $4
+    local.get $arrayWithOffset
+    local.get $var$4
+    local.get $values
+    local.get $var$4
     call $~lib/array/Array<i32>#__get
     i64.extend_i32_s
     call $~lib/typedarray/Int64Array#__set
-    local.get $4
+    local.get $var$4
     i32.const 1
     i32.add
-    local.set $4
+    local.set $var$4
     br $for-loop|0
    end
   end
-  local.get $2
+  local.get $array
   call $~lib/typedarray/Int64Array#reverse
   drop
   i32.const 0
-  local.set $4
+  local.set $var$4
   loop $for-loop|1
-   local.get $4
-   local.get $1
+   local.get $var$4
+   local.get $length
    i32.lt_s
-   local.set $5
-   local.get $5
+   local.set $var$5
+   local.get $var$5
    if
-    local.get $2
-    local.get $4
+    local.get $array
+    local.get $var$4
     call $~lib/typedarray/Int64Array#__get
-    local.get $0
-    local.get $1
+    local.get $values
+    local.get $length
     i32.const 1
     i32.sub
-    local.get $4
+    local.get $var$4
     i32.sub
     call $~lib/array/Array<i32>#__get
     i64.extend_i32_s
@@ -50632,15 +50632,15 @@
      call $~lib/builtins/abort
      unreachable
     end
-    local.get $4
+    local.get $var$4
     i32.const 1
     i32.add
-    local.set $4
+    local.set $var$4
     br $for-loop|1
    end
   end
   global.get $~lib/memory/__stack_pointer
-  local.get $3
+  local.get $arrayWithOffset
   i32.const 4
   i32.const 8
   call $~lib/typedarray/Int64Array#subarray
@@ -50650,9 +50650,9 @@
   i32.store $0 offset=12
   local.get $7
   call $~lib/typedarray/Int64Array#reverse
-  local.tee $6
+  local.tee $reversedSlice
   i32.store $0 offset=16
-  local.get $6
+  local.get $reversedSlice
   i32.const 0
   call $~lib/typedarray/Int64Array#__get
   i64.const 8
@@ -50666,7 +50666,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $6
+  local.get $reversedSlice
   i32.const 1
   call $~lib/typedarray/Int64Array#__get
   i64.const 7
@@ -50680,7 +50680,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $6
+  local.get $reversedSlice
   i32.const 2
   call $~lib/typedarray/Int64Array#__get
   i64.const 6
@@ -50694,7 +50694,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $6
+  local.get $reversedSlice
   i32.const 3
   call $~lib/typedarray/Int64Array#__get
   i64.const 5
@@ -50714,13 +50714,13 @@
   global.set $~lib/memory/__stack_pointer
  )
  (func $std/typedarray/testArrayReverse<~lib/typedarray/Uint64Array,u64>
-  (local $0 i32)
-  (local $1 i32)
-  (local $2 i32)
-  (local $3 i32)
-  (local $4 i32)
-  (local $5 i32)
-  (local $6 i32)
+  (local $values i32)
+  (local $length i32)
+  (local $array i32)
+  (local $arrayWithOffset i32)
+  (local $var$4 i32)
+  (local $var$5 i32)
+  (local $reversedSlice i32)
   (local $7 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 20
@@ -50733,73 +50733,73 @@
   memory.fill $0
   global.get $~lib/memory/__stack_pointer
   global.get $std/typedarray/testArrayReverseValues
-  local.tee $0
+  local.tee $values
   i32.store $0
-  local.get $0
+  local.get $values
   call $~lib/array/Array<i32>#get:length
-  local.set $1
+  local.set $length
   global.get $~lib/memory/__stack_pointer
   i32.const 0
-  local.get $1
+  local.get $length
   call $~lib/typedarray/Uint64Array#constructor
-  local.tee $2
+  local.tee $array
   i32.store $0 offset=4
   global.get $~lib/memory/__stack_pointer
   i32.const 0
-  local.get $1
+  local.get $length
   call $~lib/typedarray/Uint64Array#constructor
-  local.tee $3
+  local.tee $arrayWithOffset
   i32.store $0 offset=8
   i32.const 0
-  local.set $4
+  local.set $var$4
   loop $for-loop|0
-   local.get $4
-   local.get $1
+   local.get $var$4
+   local.get $length
    i32.lt_s
-   local.set $5
-   local.get $5
+   local.set $var$5
+   local.get $var$5
    if
-    local.get $2
-    local.get $4
-    local.get $0
-    local.get $4
+    local.get $array
+    local.get $var$4
+    local.get $values
+    local.get $var$4
     call $~lib/array/Array<i32>#__get
     i64.extend_i32_s
     call $~lib/typedarray/Uint64Array#__set
-    local.get $3
-    local.get $4
-    local.get $0
-    local.get $4
+    local.get $arrayWithOffset
+    local.get $var$4
+    local.get $values
+    local.get $var$4
     call $~lib/array/Array<i32>#__get
     i64.extend_i32_s
     call $~lib/typedarray/Uint64Array#__set
-    local.get $4
+    local.get $var$4
     i32.const 1
     i32.add
-    local.set $4
+    local.set $var$4
     br $for-loop|0
    end
   end
-  local.get $2
+  local.get $array
   call $~lib/typedarray/Uint64Array#reverse
   drop
   i32.const 0
-  local.set $4
+  local.set $var$4
   loop $for-loop|1
-   local.get $4
-   local.get $1
+   local.get $var$4
+   local.get $length
    i32.lt_s
-   local.set $5
-   local.get $5
+   local.set $var$5
+   local.get $var$5
    if
-    local.get $2
-    local.get $4
+    local.get $array
+    local.get $var$4
     call $~lib/typedarray/Uint64Array#__get
-    local.get $0
-    local.get $1
+    local.get $values
+    local.get $length
     i32.const 1
     i32.sub
-    local.get $4
+    local.get $var$4
     i32.sub
     call $~lib/array/Array<i32>#__get
     i64.extend_i32_s
@@ -50813,15 +50813,15 @@
      call $~lib/builtins/abort
      unreachable
     end
-    local.get $4
+    local.get $var$4
     i32.const 1
     i32.add
-    local.set $4
+    local.set $var$4
     br $for-loop|1
    end
   end
   global.get $~lib/memory/__stack_pointer
-  local.get $3
+  local.get $arrayWithOffset
   i32.const 4
   i32.const 8
   call $~lib/typedarray/Uint64Array#subarray
@@ -50831,9 +50831,9 @@
   i32.store $0 offset=12
   local.get $7
   call $~lib/typedarray/Uint64Array#reverse
-  local.tee $6
+  local.tee $reversedSlice
   i32.store $0 offset=16
-  local.get $6
+  local.get $reversedSlice
   i32.const 0
   call $~lib/typedarray/Uint64Array#__get
   i64.const 8
@@ -50847,7 +50847,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $6
+  local.get $reversedSlice
   i32.const 1
   call $~lib/typedarray/Uint64Array#__get
   i64.const 7
@@ -50861,7 +50861,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $6
+  local.get $reversedSlice
   i32.const 2
   call $~lib/typedarray/Uint64Array#__get
   i64.const 6
@@ -50875,7 +50875,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $6
+  local.get $reversedSlice
   i32.const 3
   call $~lib/typedarray/Uint64Array#__get
   i64.const 5
@@ -50895,13 +50895,13 @@
   global.set $~lib/memory/__stack_pointer
  )
  (func $std/typedarray/testArrayReverse<~lib/typedarray/Float32Array,f32>
-  (local $0 i32)
-  (local $1 i32)
-  (local $2 i32)
-  (local $3 i32)
-  (local $4 i32)
-  (local $5 i32)
-  (local $6 i32)
+  (local $values i32)
+  (local $length i32)
+  (local $array i32)
+  (local $arrayWithOffset i32)
+  (local $var$4 i32)
+  (local $var$5 i32)
+  (local $reversedSlice i32)
   (local $7 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 20
@@ -50914,73 +50914,73 @@
   memory.fill $0
   global.get $~lib/memory/__stack_pointer
   global.get $std/typedarray/testArrayReverseValues
-  local.tee $0
+  local.tee $values
   i32.store $0
-  local.get $0
+  local.get $values
   call $~lib/array/Array<i32>#get:length
-  local.set $1
+  local.set $length
   global.get $~lib/memory/__stack_pointer
   i32.const 0
-  local.get $1
+  local.get $length
   call $~lib/typedarray/Float32Array#constructor
-  local.tee $2
+  local.tee $array
   i32.store $0 offset=4
   global.get $~lib/memory/__stack_pointer
   i32.const 0
-  local.get $1
+  local.get $length
   call $~lib/typedarray/Float32Array#constructor
-  local.tee $3
+  local.tee $arrayWithOffset
   i32.store $0 offset=8
   i32.const 0
-  local.set $4
+  local.set $var$4
   loop $for-loop|0
-   local.get $4
-   local.get $1
+   local.get $var$4
+   local.get $length
    i32.lt_s
-   local.set $5
-   local.get $5
+   local.set $var$5
+   local.get $var$5
    if
-    local.get $2
-    local.get $4
-    local.get $0
-    local.get $4
+    local.get $array
+    local.get $var$4
+    local.get $values
+    local.get $var$4
     call $~lib/array/Array<i32>#__get
     f32.convert_i32_s
     call $~lib/typedarray/Float32Array#__set
-    local.get $3
-    local.get $4
-    local.get $0
-    local.get $4
+    local.get $arrayWithOffset
+    local.get $var$4
+    local.get $values
+    local.get $var$4
     call $~lib/array/Array<i32>#__get
     f32.convert_i32_s
     call $~lib/typedarray/Float32Array#__set
-    local.get $4
+    local.get $var$4
     i32.const 1
     i32.add
-    local.set $4
+    local.set $var$4
     br $for-loop|0
    end
   end
-  local.get $2
+  local.get $array
   call $~lib/typedarray/Float32Array#reverse
   drop
   i32.const 0
-  local.set $4
+  local.set $var$4
   loop $for-loop|1
-   local.get $4
-   local.get $1
+   local.get $var$4
+   local.get $length
    i32.lt_s
-   local.set $5
-   local.get $5
+   local.set $var$5
+   local.get $var$5
    if
-    local.get $2
-    local.get $4
+    local.get $array
+    local.get $var$4
     call $~lib/typedarray/Float32Array#__get
-    local.get $0
-    local.get $1
+    local.get $values
+    local.get $length
     i32.const 1
     i32.sub
-    local.get $4
+    local.get $var$4
     i32.sub
     call $~lib/array/Array<i32>#__get
     f32.convert_i32_s
@@ -50994,15 +50994,15 @@
      call $~lib/builtins/abort
      unreachable
     end
-    local.get $4
+    local.get $var$4
     i32.const 1
     i32.add
-    local.set $4
+    local.set $var$4
     br $for-loop|1
    end
   end
   global.get $~lib/memory/__stack_pointer
-  local.get $3
+  local.get $arrayWithOffset
   i32.const 4
   i32.const 8
   call $~lib/typedarray/Float32Array#subarray
@@ -51012,9 +51012,9 @@
   i32.store $0 offset=12
   local.get $7
   call $~lib/typedarray/Float32Array#reverse
-  local.tee $6
+  local.tee $reversedSlice
   i32.store $0 offset=16
-  local.get $6
+  local.get $reversedSlice
   i32.const 0
   call $~lib/typedarray/Float32Array#__get
   f32.const 8
@@ -51028,7 +51028,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $6
+  local.get $reversedSlice
   i32.const 1
   call $~lib/typedarray/Float32Array#__get
   f32.const 7
@@ -51042,7 +51042,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $6
+  local.get $reversedSlice
   i32.const 2
   call $~lib/typedarray/Float32Array#__get
   f32.const 6
@@ -51056,7 +51056,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $6
+  local.get $reversedSlice
   i32.const 3
   call $~lib/typedarray/Float32Array#__get
   f32.const 5
@@ -51076,13 +51076,13 @@
   global.set $~lib/memory/__stack_pointer
  )
  (func $std/typedarray/testArrayReverse<~lib/typedarray/Float64Array,f64>
-  (local $0 i32)
-  (local $1 i32)
-  (local $2 i32)
-  (local $3 i32)
-  (local $4 i32)
-  (local $5 i32)
-  (local $6 i32)
+  (local $values i32)
+  (local $length i32)
+  (local $array i32)
+  (local $arrayWithOffset i32)
+  (local $var$4 i32)
+  (local $var$5 i32)
+  (local $reversedSlice i32)
   (local $7 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 20
@@ -51095,73 +51095,73 @@
   memory.fill $0
   global.get $~lib/memory/__stack_pointer
   global.get $std/typedarray/testArrayReverseValues
-  local.tee $0
+  local.tee $values
   i32.store $0
-  local.get $0
+  local.get $values
   call $~lib/array/Array<i32>#get:length
-  local.set $1
+  local.set $length
   global.get $~lib/memory/__stack_pointer
   i32.const 0
-  local.get $1
+  local.get $length
   call $~lib/typedarray/Float64Array#constructor
-  local.tee $2
+  local.tee $array
   i32.store $0 offset=4
   global.get $~lib/memory/__stack_pointer
   i32.const 0
-  local.get $1
+  local.get $length
   call $~lib/typedarray/Float64Array#constructor
-  local.tee $3
+  local.tee $arrayWithOffset
   i32.store $0 offset=8
   i32.const 0
-  local.set $4
+  local.set $var$4
   loop $for-loop|0
-   local.get $4
-   local.get $1
+   local.get $var$4
+   local.get $length
    i32.lt_s
-   local.set $5
-   local.get $5
+   local.set $var$5
+   local.get $var$5
    if
-    local.get $2
-    local.get $4
-    local.get $0
-    local.get $4
+    local.get $array
+    local.get $var$4
+    local.get $values
+    local.get $var$4
     call $~lib/array/Array<i32>#__get
     f64.convert_i32_s
     call $~lib/typedarray/Float64Array#__set
-    local.get $3
-    local.get $4
-    local.get $0
-    local.get $4
+    local.get $arrayWithOffset
+    local.get $var$4
+    local.get $values
+    local.get $var$4
     call $~lib/array/Array<i32>#__get
     f64.convert_i32_s
     call $~lib/typedarray/Float64Array#__set
-    local.get $4
+    local.get $var$4
     i32.const 1
     i32.add
-    local.set $4
+    local.set $var$4
     br $for-loop|0
    end
   end
-  local.get $2
+  local.get $array
   call $~lib/typedarray/Float64Array#reverse
   drop
   i32.const 0
-  local.set $4
+  local.set $var$4
   loop $for-loop|1
-   local.get $4
-   local.get $1
+   local.get $var$4
+   local.get $length
    i32.lt_s
-   local.set $5
-   local.get $5
+   local.set $var$5
+   local.get $var$5
    if
-    local.get $2
-    local.get $4
+    local.get $array
+    local.get $var$4
     call $~lib/typedarray/Float64Array#__get
-    local.get $0
-    local.get $1
+    local.get $values
+    local.get $length
     i32.const 1
     i32.sub
-    local.get $4
+    local.get $var$4
     i32.sub
     call $~lib/array/Array<i32>#__get
     f64.convert_i32_s
@@ -51175,15 +51175,15 @@
      call $~lib/builtins/abort
      unreachable
     end
-    local.get $4
+    local.get $var$4
     i32.const 1
     i32.add
-    local.set $4
+    local.set $var$4
     br $for-loop|1
    end
   end
   global.get $~lib/memory/__stack_pointer
-  local.get $3
+  local.get $arrayWithOffset
   i32.const 4
   i32.const 8
   call $~lib/typedarray/Float64Array#subarray
@@ -51193,9 +51193,9 @@
   i32.store $0 offset=12
   local.get $7
   call $~lib/typedarray/Float64Array#reverse
-  local.tee $6
+  local.tee $reversedSlice
   i32.store $0 offset=16
-  local.get $6
+  local.get $reversedSlice
   i32.const 0
   call $~lib/typedarray/Float64Array#__get
   f64.const 8
@@ -51209,7 +51209,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $6
+  local.get $reversedSlice
   i32.const 1
   call $~lib/typedarray/Float64Array#__get
   f64.const 7
@@ -51223,7 +51223,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $6
+  local.get $reversedSlice
   i32.const 2
   call $~lib/typedarray/Float64Array#__get
   f64.const 6
@@ -51237,7 +51237,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $6
+  local.get $reversedSlice
   i32.const 3
   call $~lib/typedarray/Float64Array#__get
   f64.const 5
@@ -51256,7 +51256,7 @@
   i32.add
   global.set $~lib/memory/__stack_pointer
  )
- (func $~lib/typedarray/Int8Array#toString (param $0 i32) (result i32)
+ (func $~lib/typedarray/Int8Array#toString (param $this i32) (result i32)
   (local $1 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -51266,7 +51266,7 @@
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   i32.store $0
-  local.get $0
+  local.get $this
   i32.const 8560
   local.set $1
   global.get $~lib/memory/__stack_pointer
@@ -51282,7 +51282,7 @@
   local.get $1
  )
  (func $std/typedarray/testArrayJoinAndToString<~lib/typedarray/Int8Array,i8>
-  (local $0 i32)
+  (local $array i32)
   (local $1 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 16
@@ -51299,31 +51299,31 @@
   i32.const 0
   i32.const 5
   call $~lib/typedarray/Int8Array#constructor
-  local.tee $0
+  local.tee $array
   i32.store $0
-  local.get $0
+  local.get $array
   i32.const 0
   i32.const 1
   call $~lib/typedarray/Int8Array#__set
-  local.get $0
+  local.get $array
   i32.const 1
   i32.const 2
   call $~lib/typedarray/Int8Array#__set
-  local.get $0
+  local.get $array
   i32.const 2
   i32.const 3
   call $~lib/typedarray/Int8Array#__set
-  local.get $0
+  local.get $array
   i32.const 3
   i32.const 4
   call $~lib/typedarray/Int8Array#__set
-  local.get $0
+  local.get $array
   i32.const 4
   i32.const 5
   call $~lib/typedarray/Int8Array#__set
   i32.const 0
   drop
-  local.get $0
+  local.get $array
   i32.const 8560
   local.set $1
   global.get $~lib/memory/__stack_pointer
@@ -51352,7 +51352,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $0
+  local.get $array
   call $~lib/typedarray/Int8Array#toString
   local.set $1
   global.get $~lib/memory/__stack_pointer
@@ -51380,7 +51380,7 @@
   i32.add
   global.set $~lib/memory/__stack_pointer
  )
- (func $~lib/typedarray/Uint8Array#toString (param $0 i32) (result i32)
+ (func $~lib/typedarray/Uint8Array#toString (param $this i32) (result i32)
   (local $1 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -51390,7 +51390,7 @@
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   i32.store $0
-  local.get $0
+  local.get $this
   i32.const 8560
   local.set $1
   global.get $~lib/memory/__stack_pointer
@@ -51406,7 +51406,7 @@
   local.get $1
  )
  (func $std/typedarray/testArrayJoinAndToString<~lib/typedarray/Uint8Array,u8>
-  (local $0 i32)
+  (local $array i32)
   (local $1 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 16
@@ -51423,31 +51423,31 @@
   i32.const 0
   i32.const 5
   call $~lib/typedarray/Uint8Array#constructor
-  local.tee $0
+  local.tee $array
   i32.store $0
-  local.get $0
+  local.get $array
   i32.const 0
   i32.const 1
   call $~lib/typedarray/Uint8Array#__set
-  local.get $0
+  local.get $array
   i32.const 1
   i32.const 2
   call $~lib/typedarray/Uint8Array#__set
-  local.get $0
+  local.get $array
   i32.const 2
   i32.const 3
   call $~lib/typedarray/Uint8Array#__set
-  local.get $0
+  local.get $array
   i32.const 3
   i32.const 4
   call $~lib/typedarray/Uint8Array#__set
-  local.get $0
+  local.get $array
   i32.const 4
   i32.const 5
   call $~lib/typedarray/Uint8Array#__set
   i32.const 0
   drop
-  local.get $0
+  local.get $array
   i32.const 8560
   local.set $1
   global.get $~lib/memory/__stack_pointer
@@ -51476,7 +51476,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $0
+  local.get $array
   call $~lib/typedarray/Uint8Array#toString
   local.set $1
   global.get $~lib/memory/__stack_pointer
@@ -51504,7 +51504,7 @@
   i32.add
   global.set $~lib/memory/__stack_pointer
  )
- (func $~lib/typedarray/Uint8ClampedArray#toString (param $0 i32) (result i32)
+ (func $~lib/typedarray/Uint8ClampedArray#toString (param $this i32) (result i32)
   (local $1 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -51514,7 +51514,7 @@
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   i32.store $0
-  local.get $0
+  local.get $this
   i32.const 8560
   local.set $1
   global.get $~lib/memory/__stack_pointer
@@ -51530,7 +51530,7 @@
   local.get $1
  )
  (func $std/typedarray/testArrayJoinAndToString<~lib/typedarray/Uint8ClampedArray,u8>
-  (local $0 i32)
+  (local $array i32)
   (local $1 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 16
@@ -51547,31 +51547,31 @@
   i32.const 0
   i32.const 5
   call $~lib/typedarray/Uint8ClampedArray#constructor
-  local.tee $0
+  local.tee $array
   i32.store $0
-  local.get $0
+  local.get $array
   i32.const 0
   i32.const 1
   call $~lib/typedarray/Uint8ClampedArray#__set
-  local.get $0
+  local.get $array
   i32.const 1
   i32.const 2
   call $~lib/typedarray/Uint8ClampedArray#__set
-  local.get $0
+  local.get $array
   i32.const 2
   i32.const 3
   call $~lib/typedarray/Uint8ClampedArray#__set
-  local.get $0
+  local.get $array
   i32.const 3
   i32.const 4
   call $~lib/typedarray/Uint8ClampedArray#__set
-  local.get $0
+  local.get $array
   i32.const 4
   i32.const 5
   call $~lib/typedarray/Uint8ClampedArray#__set
   i32.const 0
   drop
-  local.get $0
+  local.get $array
   i32.const 8560
   local.set $1
   global.get $~lib/memory/__stack_pointer
@@ -51600,7 +51600,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $0
+  local.get $array
   call $~lib/typedarray/Uint8ClampedArray#toString
   local.set $1
   global.get $~lib/memory/__stack_pointer
@@ -51628,7 +51628,7 @@
   i32.add
   global.set $~lib/memory/__stack_pointer
  )
- (func $~lib/typedarray/Int16Array#toString (param $0 i32) (result i32)
+ (func $~lib/typedarray/Int16Array#toString (param $this i32) (result i32)
   (local $1 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -51638,7 +51638,7 @@
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   i32.store $0
-  local.get $0
+  local.get $this
   i32.const 8560
   local.set $1
   global.get $~lib/memory/__stack_pointer
@@ -51654,7 +51654,7 @@
   local.get $1
  )
  (func $std/typedarray/testArrayJoinAndToString<~lib/typedarray/Int16Array,i16>
-  (local $0 i32)
+  (local $array i32)
   (local $1 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 16
@@ -51671,31 +51671,31 @@
   i32.const 0
   i32.const 5
   call $~lib/typedarray/Int16Array#constructor
-  local.tee $0
+  local.tee $array
   i32.store $0
-  local.get $0
+  local.get $array
   i32.const 0
   i32.const 1
   call $~lib/typedarray/Int16Array#__set
-  local.get $0
+  local.get $array
   i32.const 1
   i32.const 2
   call $~lib/typedarray/Int16Array#__set
-  local.get $0
+  local.get $array
   i32.const 2
   i32.const 3
   call $~lib/typedarray/Int16Array#__set
-  local.get $0
+  local.get $array
   i32.const 3
   i32.const 4
   call $~lib/typedarray/Int16Array#__set
-  local.get $0
+  local.get $array
   i32.const 4
   i32.const 5
   call $~lib/typedarray/Int16Array#__set
   i32.const 0
   drop
-  local.get $0
+  local.get $array
   i32.const 8560
   local.set $1
   global.get $~lib/memory/__stack_pointer
@@ -51724,7 +51724,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $0
+  local.get $array
   call $~lib/typedarray/Int16Array#toString
   local.set $1
   global.get $~lib/memory/__stack_pointer
@@ -51752,7 +51752,7 @@
   i32.add
   global.set $~lib/memory/__stack_pointer
  )
- (func $~lib/typedarray/Uint16Array#toString (param $0 i32) (result i32)
+ (func $~lib/typedarray/Uint16Array#toString (param $this i32) (result i32)
   (local $1 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -51762,7 +51762,7 @@
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   i32.store $0
-  local.get $0
+  local.get $this
   i32.const 8560
   local.set $1
   global.get $~lib/memory/__stack_pointer
@@ -51778,7 +51778,7 @@
   local.get $1
  )
  (func $std/typedarray/testArrayJoinAndToString<~lib/typedarray/Uint16Array,u16>
-  (local $0 i32)
+  (local $array i32)
   (local $1 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 16
@@ -51795,31 +51795,31 @@
   i32.const 0
   i32.const 5
   call $~lib/typedarray/Uint16Array#constructor
-  local.tee $0
+  local.tee $array
   i32.store $0
-  local.get $0
+  local.get $array
   i32.const 0
   i32.const 1
   call $~lib/typedarray/Uint16Array#__set
-  local.get $0
+  local.get $array
   i32.const 1
   i32.const 2
   call $~lib/typedarray/Uint16Array#__set
-  local.get $0
+  local.get $array
   i32.const 2
   i32.const 3
   call $~lib/typedarray/Uint16Array#__set
-  local.get $0
+  local.get $array
   i32.const 3
   i32.const 4
   call $~lib/typedarray/Uint16Array#__set
-  local.get $0
+  local.get $array
   i32.const 4
   i32.const 5
   call $~lib/typedarray/Uint16Array#__set
   i32.const 0
   drop
-  local.get $0
+  local.get $array
   i32.const 8560
   local.set $1
   global.get $~lib/memory/__stack_pointer
@@ -51848,7 +51848,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $0
+  local.get $array
   call $~lib/typedarray/Uint16Array#toString
   local.set $1
   global.get $~lib/memory/__stack_pointer
@@ -51876,7 +51876,7 @@
   i32.add
   global.set $~lib/memory/__stack_pointer
  )
- (func $~lib/typedarray/Int32Array#toString (param $0 i32) (result i32)
+ (func $~lib/typedarray/Int32Array#toString (param $this i32) (result i32)
   (local $1 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -51886,7 +51886,7 @@
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   i32.store $0
-  local.get $0
+  local.get $this
   i32.const 8560
   local.set $1
   global.get $~lib/memory/__stack_pointer
@@ -51902,7 +51902,7 @@
   local.get $1
  )
  (func $std/typedarray/testArrayJoinAndToString<~lib/typedarray/Int32Array,i32>
-  (local $0 i32)
+  (local $array i32)
   (local $1 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 16
@@ -51919,31 +51919,31 @@
   i32.const 0
   i32.const 5
   call $~lib/typedarray/Int32Array#constructor
-  local.tee $0
+  local.tee $array
   i32.store $0
-  local.get $0
+  local.get $array
   i32.const 0
   i32.const 1
   call $~lib/typedarray/Int32Array#__set
-  local.get $0
+  local.get $array
   i32.const 1
   i32.const 2
   call $~lib/typedarray/Int32Array#__set
-  local.get $0
+  local.get $array
   i32.const 2
   i32.const 3
   call $~lib/typedarray/Int32Array#__set
-  local.get $0
+  local.get $array
   i32.const 3
   i32.const 4
   call $~lib/typedarray/Int32Array#__set
-  local.get $0
+  local.get $array
   i32.const 4
   i32.const 5
   call $~lib/typedarray/Int32Array#__set
   i32.const 0
   drop
-  local.get $0
+  local.get $array
   i32.const 8560
   local.set $1
   global.get $~lib/memory/__stack_pointer
@@ -51972,7 +51972,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $0
+  local.get $array
   call $~lib/typedarray/Int32Array#toString
   local.set $1
   global.get $~lib/memory/__stack_pointer
@@ -52000,7 +52000,7 @@
   i32.add
   global.set $~lib/memory/__stack_pointer
  )
- (func $~lib/typedarray/Uint32Array#toString (param $0 i32) (result i32)
+ (func $~lib/typedarray/Uint32Array#toString (param $this i32) (result i32)
   (local $1 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -52010,7 +52010,7 @@
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   i32.store $0
-  local.get $0
+  local.get $this
   i32.const 8560
   local.set $1
   global.get $~lib/memory/__stack_pointer
@@ -52026,7 +52026,7 @@
   local.get $1
  )
  (func $std/typedarray/testArrayJoinAndToString<~lib/typedarray/Uint32Array,u32>
-  (local $0 i32)
+  (local $array i32)
   (local $1 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 16
@@ -52043,31 +52043,31 @@
   i32.const 0
   i32.const 5
   call $~lib/typedarray/Uint32Array#constructor
-  local.tee $0
+  local.tee $array
   i32.store $0
-  local.get $0
+  local.get $array
   i32.const 0
   i32.const 1
   call $~lib/typedarray/Uint32Array#__set
-  local.get $0
+  local.get $array
   i32.const 1
   i32.const 2
   call $~lib/typedarray/Uint32Array#__set
-  local.get $0
+  local.get $array
   i32.const 2
   i32.const 3
   call $~lib/typedarray/Uint32Array#__set
-  local.get $0
+  local.get $array
   i32.const 3
   i32.const 4
   call $~lib/typedarray/Uint32Array#__set
-  local.get $0
+  local.get $array
   i32.const 4
   i32.const 5
   call $~lib/typedarray/Uint32Array#__set
   i32.const 0
   drop
-  local.get $0
+  local.get $array
   i32.const 8560
   local.set $1
   global.get $~lib/memory/__stack_pointer
@@ -52096,7 +52096,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $0
+  local.get $array
   call $~lib/typedarray/Uint32Array#toString
   local.set $1
   global.get $~lib/memory/__stack_pointer
@@ -52124,7 +52124,7 @@
   i32.add
   global.set $~lib/memory/__stack_pointer
  )
- (func $~lib/typedarray/Int64Array#toString (param $0 i32) (result i32)
+ (func $~lib/typedarray/Int64Array#toString (param $this i32) (result i32)
   (local $1 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -52134,7 +52134,7 @@
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   i32.store $0
-  local.get $0
+  local.get $this
   i32.const 8560
   local.set $1
   global.get $~lib/memory/__stack_pointer
@@ -52150,7 +52150,7 @@
   local.get $1
  )
  (func $std/typedarray/testArrayJoinAndToString<~lib/typedarray/Int64Array,i64>
-  (local $0 i32)
+  (local $array i32)
   (local $1 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 16
@@ -52167,31 +52167,31 @@
   i32.const 0
   i32.const 5
   call $~lib/typedarray/Int64Array#constructor
-  local.tee $0
+  local.tee $array
   i32.store $0
-  local.get $0
+  local.get $array
   i32.const 0
   i64.const 1
   call $~lib/typedarray/Int64Array#__set
-  local.get $0
+  local.get $array
   i32.const 1
   i64.const 2
   call $~lib/typedarray/Int64Array#__set
-  local.get $0
+  local.get $array
   i32.const 2
   i64.const 3
   call $~lib/typedarray/Int64Array#__set
-  local.get $0
+  local.get $array
   i32.const 3
   i64.const 4
   call $~lib/typedarray/Int64Array#__set
-  local.get $0
+  local.get $array
   i32.const 4
   i64.const 5
   call $~lib/typedarray/Int64Array#__set
   i32.const 0
   drop
-  local.get $0
+  local.get $array
   i32.const 8560
   local.set $1
   global.get $~lib/memory/__stack_pointer
@@ -52220,7 +52220,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $0
+  local.get $array
   call $~lib/typedarray/Int64Array#toString
   local.set $1
   global.get $~lib/memory/__stack_pointer
@@ -52248,7 +52248,7 @@
   i32.add
   global.set $~lib/memory/__stack_pointer
  )
- (func $~lib/typedarray/Uint64Array#toString (param $0 i32) (result i32)
+ (func $~lib/typedarray/Uint64Array#toString (param $this i32) (result i32)
   (local $1 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -52258,7 +52258,7 @@
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   i32.store $0
-  local.get $0
+  local.get $this
   i32.const 8560
   local.set $1
   global.get $~lib/memory/__stack_pointer
@@ -52274,7 +52274,7 @@
   local.get $1
  )
  (func $std/typedarray/testArrayJoinAndToString<~lib/typedarray/Uint64Array,u64>
-  (local $0 i32)
+  (local $array i32)
   (local $1 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 16
@@ -52291,31 +52291,31 @@
   i32.const 0
   i32.const 5
   call $~lib/typedarray/Uint64Array#constructor
-  local.tee $0
+  local.tee $array
   i32.store $0
-  local.get $0
+  local.get $array
   i32.const 0
   i64.const 1
   call $~lib/typedarray/Uint64Array#__set
-  local.get $0
+  local.get $array
   i32.const 1
   i64.const 2
   call $~lib/typedarray/Uint64Array#__set
-  local.get $0
+  local.get $array
   i32.const 2
   i64.const 3
   call $~lib/typedarray/Uint64Array#__set
-  local.get $0
+  local.get $array
   i32.const 3
   i64.const 4
   call $~lib/typedarray/Uint64Array#__set
-  local.get $0
+  local.get $array
   i32.const 4
   i64.const 5
   call $~lib/typedarray/Uint64Array#__set
   i32.const 0
   drop
-  local.get $0
+  local.get $array
   i32.const 8560
   local.set $1
   global.get $~lib/memory/__stack_pointer
@@ -52344,7 +52344,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $0
+  local.get $array
   call $~lib/typedarray/Uint64Array#toString
   local.set $1
   global.get $~lib/memory/__stack_pointer
@@ -52372,7 +52372,7 @@
   i32.add
   global.set $~lib/memory/__stack_pointer
  )
- (func $~lib/typedarray/Float32Array#toString (param $0 i32) (result i32)
+ (func $~lib/typedarray/Float32Array#toString (param $this i32) (result i32)
   (local $1 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -52382,7 +52382,7 @@
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   i32.store $0
-  local.get $0
+  local.get $this
   i32.const 8560
   local.set $1
   global.get $~lib/memory/__stack_pointer
@@ -52398,7 +52398,7 @@
   local.get $1
  )
  (func $std/typedarray/testArrayJoinAndToString<~lib/typedarray/Float32Array,f32>
-  (local $0 i32)
+  (local $array i32)
   (local $1 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 16
@@ -52415,31 +52415,31 @@
   i32.const 0
   i32.const 5
   call $~lib/typedarray/Float32Array#constructor
-  local.tee $0
+  local.tee $array
   i32.store $0
-  local.get $0
+  local.get $array
   i32.const 0
   f32.const 1
   call $~lib/typedarray/Float32Array#__set
-  local.get $0
+  local.get $array
   i32.const 1
   f32.const 2
   call $~lib/typedarray/Float32Array#__set
-  local.get $0
+  local.get $array
   i32.const 2
   f32.const 3
   call $~lib/typedarray/Float32Array#__set
-  local.get $0
+  local.get $array
   i32.const 3
   f32.const 4
   call $~lib/typedarray/Float32Array#__set
-  local.get $0
+  local.get $array
   i32.const 4
   f32.const 5
   call $~lib/typedarray/Float32Array#__set
   i32.const 1
   drop
-  local.get $0
+  local.get $array
   i32.const 8560
   local.set $1
   global.get $~lib/memory/__stack_pointer
@@ -52468,7 +52468,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $0
+  local.get $array
   call $~lib/typedarray/Float32Array#toString
   local.set $1
   global.get $~lib/memory/__stack_pointer
@@ -52496,7 +52496,7 @@
   i32.add
   global.set $~lib/memory/__stack_pointer
  )
- (func $~lib/typedarray/Float64Array#toString (param $0 i32) (result i32)
+ (func $~lib/typedarray/Float64Array#toString (param $this i32) (result i32)
   (local $1 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -52506,7 +52506,7 @@
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   i32.store $0
-  local.get $0
+  local.get $this
   i32.const 8560
   local.set $1
   global.get $~lib/memory/__stack_pointer
@@ -52522,7 +52522,7 @@
   local.get $1
  )
  (func $std/typedarray/testArrayJoinAndToString<~lib/typedarray/Float64Array,f64>
-  (local $0 i32)
+  (local $array i32)
   (local $1 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 16
@@ -52539,31 +52539,31 @@
   i32.const 0
   i32.const 5
   call $~lib/typedarray/Float64Array#constructor
-  local.tee $0
+  local.tee $array
   i32.store $0
-  local.get $0
+  local.get $array
   i32.const 0
   f64.const 1
   call $~lib/typedarray/Float64Array#__set
-  local.get $0
+  local.get $array
   i32.const 1
   f64.const 2
   call $~lib/typedarray/Float64Array#__set
-  local.get $0
+  local.get $array
   i32.const 2
   f64.const 3
   call $~lib/typedarray/Float64Array#__set
-  local.get $0
+  local.get $array
   i32.const 3
   f64.const 4
   call $~lib/typedarray/Float64Array#__set
-  local.get $0
+  local.get $array
   i32.const 4
   f64.const 5
   call $~lib/typedarray/Float64Array#__set
   i32.const 1
   drop
-  local.get $0
+  local.get $array
   i32.const 8560
   local.set $1
   global.get $~lib/memory/__stack_pointer
@@ -52592,7 +52592,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $0
+  local.get $array
   call $~lib/typedarray/Float64Array#toString
   local.set $1
   global.get $~lib/memory/__stack_pointer
@@ -52621,13 +52621,13 @@
   global.set $~lib/memory/__stack_pointer
  )
  (func $std/typedarray/testArrayWrap<~lib/typedarray/Int8Array,i8>
-  (local $0 i32)
-  (local $1 i32)
-  (local $2 i32)
-  (local $3 i32)
-  (local $4 i32)
-  (local $5 i32)
-  (local $6 i32)
+  (local $values i32)
+  (local $length i32)
+  (local $array i32)
+  (local $var$3 i32)
+  (local $var$4 i32)
+  (local $buffer i32)
+  (local $result i32)
   (local $7 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 20
@@ -52640,83 +52640,83 @@
   memory.fill $0
   global.get $~lib/memory/__stack_pointer
   global.get $std/typedarray/testArrayWrapValues
-  local.tee $0
+  local.tee $values
   i32.store $0
-  local.get $0
+  local.get $values
   call $~lib/array/Array<i32>#get:length
-  local.set $1
+  local.set $length
   global.get $~lib/memory/__stack_pointer
   i32.const 0
-  local.get $1
+  local.get $length
   call $~lib/typedarray/Int8Array#constructor
-  local.tee $2
+  local.tee $array
   i32.store $0 offset=4
   i32.const 0
-  local.set $3
+  local.set $var$3
   loop $for-loop|0
-   local.get $3
-   local.get $1
+   local.get $var$3
+   local.get $length
    i32.lt_s
-   local.set $4
-   local.get $4
+   local.set $var$4
+   local.get $var$4
    if
-    local.get $2
-    local.get $3
-    local.get $0
-    local.get $3
+    local.get $array
+    local.get $var$3
+    local.get $values
+    local.get $var$3
     call $~lib/array/Array<i32>#__get
     i32.extend8_s
     call $~lib/typedarray/Int8Array#__set
-    local.get $3
+    local.get $var$3
     i32.const 1
     i32.add
-    local.set $3
+    local.set $var$3
     br $for-loop|0
    end
   end
   global.get $~lib/memory/__stack_pointer
-  local.get $2
+  local.get $array
   i32.load $0
   local.set $7
   global.get $~lib/memory/__stack_pointer
   local.get $7
   i32.store $0 offset=8
   local.get $7
-  local.get $2
+  local.get $array
   call $~lib/arraybuffer/ArrayBufferView#get:byteOffset
-  local.get $2
+  local.get $array
   call $~lib/arraybuffer/ArrayBufferView#get:byteOffset
-  local.get $2
+  local.get $array
   i32.load $0 offset=8
   i32.add
   call $~lib/arraybuffer/ArrayBuffer#slice
-  local.tee $5
+  local.tee $buffer
   i32.store $0 offset=12
   i32.const 1
   drop
   global.get $~lib/memory/__stack_pointer
-  local.get $5
+  local.get $buffer
   i32.const 0
   i32.const 1
   global.set $~argumentsLength
   i32.const 0
   call $~lib/typedarray/Int8Array.wrap@varargs
-  local.tee $6
+  local.tee $result
   i32.store $0 offset=16
   i32.const 0
-  local.set $3
+  local.set $var$3
   loop $for-loop|1
-   local.get $3
-   local.get $1
+   local.get $var$3
+   local.get $length
    i32.lt_s
-   local.set $4
-   local.get $4
+   local.set $var$4
+   local.get $var$4
    if
-    local.get $2
-    local.get $3
+    local.get $array
+    local.get $var$3
     call $~lib/typedarray/Int8Array#__get
-    local.get $6
-    local.get $3
+    local.get $result
+    local.get $var$3
     call $~lib/typedarray/Int8Array#__get
     i32.eq
     i32.eqz
@@ -52728,10 +52728,10 @@
      call $~lib/builtins/abort
      unreachable
     end
-    local.get $3
+    local.get $var$3
     i32.const 1
     i32.add
-    local.set $3
+    local.set $var$3
     br $for-loop|1
    end
   end
@@ -52741,13 +52741,13 @@
   global.set $~lib/memory/__stack_pointer
  )
  (func $std/typedarray/testArrayWrap<~lib/typedarray/Uint8Array,u8>
-  (local $0 i32)
-  (local $1 i32)
-  (local $2 i32)
-  (local $3 i32)
-  (local $4 i32)
-  (local $5 i32)
-  (local $6 i32)
+  (local $values i32)
+  (local $length i32)
+  (local $array i32)
+  (local $var$3 i32)
+  (local $var$4 i32)
+  (local $buffer i32)
+  (local $result i32)
   (local $7 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 20
@@ -52760,86 +52760,86 @@
   memory.fill $0
   global.get $~lib/memory/__stack_pointer
   global.get $std/typedarray/testArrayWrapValues
-  local.tee $0
+  local.tee $values
   i32.store $0
-  local.get $0
+  local.get $values
   call $~lib/array/Array<i32>#get:length
-  local.set $1
+  local.set $length
   global.get $~lib/memory/__stack_pointer
   i32.const 0
-  local.get $1
+  local.get $length
   call $~lib/typedarray/Uint8Array#constructor
-  local.tee $2
+  local.tee $array
   i32.store $0 offset=4
   i32.const 0
-  local.set $3
+  local.set $var$3
   loop $for-loop|0
-   local.get $3
-   local.get $1
+   local.get $var$3
+   local.get $length
    i32.lt_s
-   local.set $4
-   local.get $4
+   local.set $var$4
+   local.get $var$4
    if
-    local.get $2
-    local.get $3
-    local.get $0
-    local.get $3
+    local.get $array
+    local.get $var$3
+    local.get $values
+    local.get $var$3
     call $~lib/array/Array<i32>#__get
     i32.const 255
     i32.and
     call $~lib/typedarray/Uint8Array#__set
-    local.get $3
+    local.get $var$3
     i32.const 1
     i32.add
-    local.set $3
+    local.set $var$3
     br $for-loop|0
    end
   end
   global.get $~lib/memory/__stack_pointer
-  local.get $2
+  local.get $array
   i32.load $0
   local.set $7
   global.get $~lib/memory/__stack_pointer
   local.get $7
   i32.store $0 offset=8
   local.get $7
-  local.get $2
+  local.get $array
   call $~lib/arraybuffer/ArrayBufferView#get:byteOffset
-  local.get $2
+  local.get $array
   call $~lib/arraybuffer/ArrayBufferView#get:byteOffset
-  local.get $2
+  local.get $array
   i32.load $0 offset=8
   i32.add
   call $~lib/arraybuffer/ArrayBuffer#slice
-  local.tee $5
+  local.tee $buffer
   i32.store $0 offset=12
   i32.const 0
   drop
   i32.const 1
   drop
   global.get $~lib/memory/__stack_pointer
-  local.get $5
+  local.get $buffer
   i32.const 0
   i32.const 1
   global.set $~argumentsLength
   i32.const 0
   call $~lib/typedarray/Uint8Array.wrap@varargs
-  local.tee $6
+  local.tee $result
   i32.store $0 offset=16
   i32.const 0
-  local.set $3
+  local.set $var$3
   loop $for-loop|1
-   local.get $3
-   local.get $1
+   local.get $var$3
+   local.get $length
    i32.lt_s
-   local.set $4
-   local.get $4
+   local.set $var$4
+   local.get $var$4
    if
-    local.get $2
-    local.get $3
+    local.get $array
+    local.get $var$3
     call $~lib/typedarray/Uint8Array#__get
-    local.get $6
-    local.get $3
+    local.get $result
+    local.get $var$3
     call $~lib/typedarray/Uint8Array#__get
     i32.eq
     i32.eqz
@@ -52851,10 +52851,10 @@
      call $~lib/builtins/abort
      unreachable
     end
-    local.get $3
+    local.get $var$3
     i32.const 1
     i32.add
-    local.set $3
+    local.set $var$3
     br $for-loop|1
    end
   end
@@ -52864,13 +52864,13 @@
   global.set $~lib/memory/__stack_pointer
  )
  (func $std/typedarray/testArrayWrap<~lib/typedarray/Uint8ClampedArray,u8>
-  (local $0 i32)
-  (local $1 i32)
-  (local $2 i32)
-  (local $3 i32)
-  (local $4 i32)
-  (local $5 i32)
-  (local $6 i32)
+  (local $values i32)
+  (local $length i32)
+  (local $array i32)
+  (local $var$3 i32)
+  (local $var$4 i32)
+  (local $buffer i32)
+  (local $result i32)
   (local $7 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 20
@@ -52883,58 +52883,58 @@
   memory.fill $0
   global.get $~lib/memory/__stack_pointer
   global.get $std/typedarray/testArrayWrapValues
-  local.tee $0
+  local.tee $values
   i32.store $0
-  local.get $0
+  local.get $values
   call $~lib/array/Array<i32>#get:length
-  local.set $1
+  local.set $length
   global.get $~lib/memory/__stack_pointer
   i32.const 0
-  local.get $1
+  local.get $length
   call $~lib/typedarray/Uint8ClampedArray#constructor
-  local.tee $2
+  local.tee $array
   i32.store $0 offset=4
   i32.const 0
-  local.set $3
+  local.set $var$3
   loop $for-loop|0
-   local.get $3
-   local.get $1
+   local.get $var$3
+   local.get $length
    i32.lt_s
-   local.set $4
-   local.get $4
+   local.set $var$4
+   local.get $var$4
    if
-    local.get $2
-    local.get $3
-    local.get $0
-    local.get $3
+    local.get $array
+    local.get $var$3
+    local.get $values
+    local.get $var$3
     call $~lib/array/Array<i32>#__get
     i32.const 255
     i32.and
     call $~lib/typedarray/Uint8ClampedArray#__set
-    local.get $3
+    local.get $var$3
     i32.const 1
     i32.add
-    local.set $3
+    local.set $var$3
     br $for-loop|0
    end
   end
   global.get $~lib/memory/__stack_pointer
-  local.get $2
+  local.get $array
   i32.load $0
   local.set $7
   global.get $~lib/memory/__stack_pointer
   local.get $7
   i32.store $0 offset=8
   local.get $7
-  local.get $2
+  local.get $array
   call $~lib/arraybuffer/ArrayBufferView#get:byteOffset
-  local.get $2
+  local.get $array
   call $~lib/arraybuffer/ArrayBufferView#get:byteOffset
-  local.get $2
+  local.get $array
   i32.load $0 offset=8
   i32.add
   call $~lib/arraybuffer/ArrayBuffer#slice
-  local.tee $5
+  local.tee $buffer
   i32.store $0 offset=12
   i32.const 0
   drop
@@ -52943,28 +52943,28 @@
   i32.const 1
   drop
   global.get $~lib/memory/__stack_pointer
-  local.get $5
+  local.get $buffer
   i32.const 0
   i32.const 1
   global.set $~argumentsLength
   i32.const 0
   call $~lib/typedarray/Uint8ClampedArray.wrap@varargs
-  local.tee $6
+  local.tee $result
   i32.store $0 offset=16
   i32.const 0
-  local.set $3
+  local.set $var$3
   loop $for-loop|1
-   local.get $3
-   local.get $1
+   local.get $var$3
+   local.get $length
    i32.lt_s
-   local.set $4
-   local.get $4
+   local.set $var$4
+   local.get $var$4
    if
-    local.get $2
-    local.get $3
+    local.get $array
+    local.get $var$3
     call $~lib/typedarray/Uint8ClampedArray#__get
-    local.get $6
-    local.get $3
+    local.get $result
+    local.get $var$3
     call $~lib/typedarray/Uint8ClampedArray#__get
     i32.eq
     i32.eqz
@@ -52976,10 +52976,10 @@
      call $~lib/builtins/abort
      unreachable
     end
-    local.get $3
+    local.get $var$3
     i32.const 1
     i32.add
-    local.set $3
+    local.set $var$3
     br $for-loop|1
    end
   end
@@ -52989,13 +52989,13 @@
   global.set $~lib/memory/__stack_pointer
  )
  (func $std/typedarray/testArrayWrap<~lib/typedarray/Int16Array,i16>
-  (local $0 i32)
-  (local $1 i32)
-  (local $2 i32)
-  (local $3 i32)
-  (local $4 i32)
-  (local $5 i32)
-  (local $6 i32)
+  (local $values i32)
+  (local $length i32)
+  (local $array i32)
+  (local $var$3 i32)
+  (local $var$4 i32)
+  (local $buffer i32)
+  (local $result i32)
   (local $7 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 20
@@ -53008,57 +53008,57 @@
   memory.fill $0
   global.get $~lib/memory/__stack_pointer
   global.get $std/typedarray/testArrayWrapValues
-  local.tee $0
+  local.tee $values
   i32.store $0
-  local.get $0
+  local.get $values
   call $~lib/array/Array<i32>#get:length
-  local.set $1
+  local.set $length
   global.get $~lib/memory/__stack_pointer
   i32.const 0
-  local.get $1
+  local.get $length
   call $~lib/typedarray/Int16Array#constructor
-  local.tee $2
+  local.tee $array
   i32.store $0 offset=4
   i32.const 0
-  local.set $3
+  local.set $var$3
   loop $for-loop|0
-   local.get $3
-   local.get $1
+   local.get $var$3
+   local.get $length
    i32.lt_s
-   local.set $4
-   local.get $4
+   local.set $var$4
+   local.get $var$4
    if
-    local.get $2
-    local.get $3
-    local.get $0
-    local.get $3
+    local.get $array
+    local.get $var$3
+    local.get $values
+    local.get $var$3
     call $~lib/array/Array<i32>#__get
     i32.extend16_s
     call $~lib/typedarray/Int16Array#__set
-    local.get $3
+    local.get $var$3
     i32.const 1
     i32.add
-    local.set $3
+    local.set $var$3
     br $for-loop|0
    end
   end
   global.get $~lib/memory/__stack_pointer
-  local.get $2
+  local.get $array
   i32.load $0
   local.set $7
   global.get $~lib/memory/__stack_pointer
   local.get $7
   i32.store $0 offset=8
   local.get $7
-  local.get $2
+  local.get $array
   call $~lib/arraybuffer/ArrayBufferView#get:byteOffset
-  local.get $2
+  local.get $array
   call $~lib/arraybuffer/ArrayBufferView#get:byteOffset
-  local.get $2
+  local.get $array
   i32.load $0 offset=8
   i32.add
   call $~lib/arraybuffer/ArrayBuffer#slice
-  local.tee $5
+  local.tee $buffer
   i32.store $0 offset=12
   i32.const 0
   drop
@@ -53069,28 +53069,28 @@
   i32.const 1
   drop
   global.get $~lib/memory/__stack_pointer
-  local.get $5
+  local.get $buffer
   i32.const 0
   i32.const 1
   global.set $~argumentsLength
   i32.const 0
   call $~lib/typedarray/Int16Array.wrap@varargs
-  local.tee $6
+  local.tee $result
   i32.store $0 offset=16
   i32.const 0
-  local.set $3
+  local.set $var$3
   loop $for-loop|1
-   local.get $3
-   local.get $1
+   local.get $var$3
+   local.get $length
    i32.lt_s
-   local.set $4
-   local.get $4
+   local.set $var$4
+   local.get $var$4
    if
-    local.get $2
-    local.get $3
+    local.get $array
+    local.get $var$3
     call $~lib/typedarray/Int16Array#__get
-    local.get $6
-    local.get $3
+    local.get $result
+    local.get $var$3
     call $~lib/typedarray/Int16Array#__get
     i32.eq
     i32.eqz
@@ -53102,10 +53102,10 @@
      call $~lib/builtins/abort
      unreachable
     end
-    local.get $3
+    local.get $var$3
     i32.const 1
     i32.add
-    local.set $3
+    local.set $var$3
     br $for-loop|1
    end
   end
@@ -53115,13 +53115,13 @@
   global.set $~lib/memory/__stack_pointer
  )
  (func $std/typedarray/testArrayWrap<~lib/typedarray/Uint16Array,u16>
-  (local $0 i32)
-  (local $1 i32)
-  (local $2 i32)
-  (local $3 i32)
-  (local $4 i32)
-  (local $5 i32)
-  (local $6 i32)
+  (local $values i32)
+  (local $length i32)
+  (local $array i32)
+  (local $var$3 i32)
+  (local $var$4 i32)
+  (local $buffer i32)
+  (local $result i32)
   (local $7 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 20
@@ -53134,58 +53134,58 @@
   memory.fill $0
   global.get $~lib/memory/__stack_pointer
   global.get $std/typedarray/testArrayWrapValues
-  local.tee $0
+  local.tee $values
   i32.store $0
-  local.get $0
+  local.get $values
   call $~lib/array/Array<i32>#get:length
-  local.set $1
+  local.set $length
   global.get $~lib/memory/__stack_pointer
   i32.const 0
-  local.get $1
+  local.get $length
   call $~lib/typedarray/Uint16Array#constructor
-  local.tee $2
+  local.tee $array
   i32.store $0 offset=4
   i32.const 0
-  local.set $3
+  local.set $var$3
   loop $for-loop|0
-   local.get $3
-   local.get $1
+   local.get $var$3
+   local.get $length
    i32.lt_s
-   local.set $4
-   local.get $4
+   local.set $var$4
+   local.get $var$4
    if
-    local.get $2
-    local.get $3
-    local.get $0
-    local.get $3
+    local.get $array
+    local.get $var$3
+    local.get $values
+    local.get $var$3
     call $~lib/array/Array<i32>#__get
     i32.const 65535
     i32.and
     call $~lib/typedarray/Uint16Array#__set
-    local.get $3
+    local.get $var$3
     i32.const 1
     i32.add
-    local.set $3
+    local.set $var$3
     br $for-loop|0
    end
   end
   global.get $~lib/memory/__stack_pointer
-  local.get $2
+  local.get $array
   i32.load $0
   local.set $7
   global.get $~lib/memory/__stack_pointer
   local.get $7
   i32.store $0 offset=8
   local.get $7
-  local.get $2
+  local.get $array
   call $~lib/arraybuffer/ArrayBufferView#get:byteOffset
-  local.get $2
+  local.get $array
   call $~lib/arraybuffer/ArrayBufferView#get:byteOffset
-  local.get $2
+  local.get $array
   i32.load $0 offset=8
   i32.add
   call $~lib/arraybuffer/ArrayBuffer#slice
-  local.tee $5
+  local.tee $buffer
   i32.store $0 offset=12
   i32.const 0
   drop
@@ -53198,28 +53198,28 @@
   i32.const 1
   drop
   global.get $~lib/memory/__stack_pointer
-  local.get $5
+  local.get $buffer
   i32.const 0
   i32.const 1
   global.set $~argumentsLength
   i32.const 0
   call $~lib/typedarray/Uint16Array.wrap@varargs
-  local.tee $6
+  local.tee $result
   i32.store $0 offset=16
   i32.const 0
-  local.set $3
+  local.set $var$3
   loop $for-loop|1
-   local.get $3
-   local.get $1
+   local.get $var$3
+   local.get $length
    i32.lt_s
-   local.set $4
-   local.get $4
+   local.set $var$4
+   local.get $var$4
    if
-    local.get $2
-    local.get $3
+    local.get $array
+    local.get $var$3
     call $~lib/typedarray/Uint16Array#__get
-    local.get $6
-    local.get $3
+    local.get $result
+    local.get $var$3
     call $~lib/typedarray/Uint16Array#__get
     i32.eq
     i32.eqz
@@ -53231,10 +53231,10 @@
      call $~lib/builtins/abort
      unreachable
     end
-    local.get $3
+    local.get $var$3
     i32.const 1
     i32.add
-    local.set $3
+    local.set $var$3
     br $for-loop|1
    end
   end
@@ -53244,13 +53244,13 @@
   global.set $~lib/memory/__stack_pointer
  )
  (func $std/typedarray/testArrayWrap<~lib/typedarray/Int32Array,i32>
-  (local $0 i32)
-  (local $1 i32)
-  (local $2 i32)
-  (local $3 i32)
-  (local $4 i32)
-  (local $5 i32)
-  (local $6 i32)
+  (local $values i32)
+  (local $length i32)
+  (local $array i32)
+  (local $var$3 i32)
+  (local $var$4 i32)
+  (local $buffer i32)
+  (local $result i32)
   (local $7 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 20
@@ -53263,56 +53263,56 @@
   memory.fill $0
   global.get $~lib/memory/__stack_pointer
   global.get $std/typedarray/testArrayWrapValues
-  local.tee $0
+  local.tee $values
   i32.store $0
-  local.get $0
+  local.get $values
   call $~lib/array/Array<i32>#get:length
-  local.set $1
+  local.set $length
   global.get $~lib/memory/__stack_pointer
   i32.const 0
-  local.get $1
+  local.get $length
   call $~lib/typedarray/Int32Array#constructor
-  local.tee $2
+  local.tee $array
   i32.store $0 offset=4
   i32.const 0
-  local.set $3
+  local.set $var$3
   loop $for-loop|0
-   local.get $3
-   local.get $1
+   local.get $var$3
+   local.get $length
    i32.lt_s
-   local.set $4
-   local.get $4
+   local.set $var$4
+   local.get $var$4
    if
-    local.get $2
-    local.get $3
-    local.get $0
-    local.get $3
+    local.get $array
+    local.get $var$3
+    local.get $values
+    local.get $var$3
     call $~lib/array/Array<i32>#__get
     call $~lib/typedarray/Int32Array#__set
-    local.get $3
+    local.get $var$3
     i32.const 1
     i32.add
-    local.set $3
+    local.set $var$3
     br $for-loop|0
    end
   end
   global.get $~lib/memory/__stack_pointer
-  local.get $2
+  local.get $array
   i32.load $0
   local.set $7
   global.get $~lib/memory/__stack_pointer
   local.get $7
   i32.store $0 offset=8
   local.get $7
-  local.get $2
+  local.get $array
   call $~lib/arraybuffer/ArrayBufferView#get:byteOffset
-  local.get $2
+  local.get $array
   call $~lib/arraybuffer/ArrayBufferView#get:byteOffset
-  local.get $2
+  local.get $array
   i32.load $0 offset=8
   i32.add
   call $~lib/arraybuffer/ArrayBuffer#slice
-  local.tee $5
+  local.tee $buffer
   i32.store $0 offset=12
   i32.const 0
   drop
@@ -53327,28 +53327,28 @@
   i32.const 1
   drop
   global.get $~lib/memory/__stack_pointer
-  local.get $5
+  local.get $buffer
   i32.const 0
   i32.const 1
   global.set $~argumentsLength
   i32.const 0
   call $~lib/typedarray/Int32Array.wrap@varargs
-  local.tee $6
+  local.tee $result
   i32.store $0 offset=16
   i32.const 0
-  local.set $3
+  local.set $var$3
   loop $for-loop|1
-   local.get $3
-   local.get $1
+   local.get $var$3
+   local.get $length
    i32.lt_s
-   local.set $4
-   local.get $4
+   local.set $var$4
+   local.get $var$4
    if
-    local.get $2
-    local.get $3
+    local.get $array
+    local.get $var$3
     call $~lib/typedarray/Int32Array#__get
-    local.get $6
-    local.get $3
+    local.get $result
+    local.get $var$3
     call $~lib/typedarray/Int32Array#__get
     i32.eq
     i32.eqz
@@ -53360,10 +53360,10 @@
      call $~lib/builtins/abort
      unreachable
     end
-    local.get $3
+    local.get $var$3
     i32.const 1
     i32.add
-    local.set $3
+    local.set $var$3
     br $for-loop|1
    end
   end
@@ -53373,13 +53373,13 @@
   global.set $~lib/memory/__stack_pointer
  )
  (func $std/typedarray/testArrayWrap<~lib/typedarray/Uint32Array,u32>
-  (local $0 i32)
-  (local $1 i32)
-  (local $2 i32)
-  (local $3 i32)
-  (local $4 i32)
-  (local $5 i32)
-  (local $6 i32)
+  (local $values i32)
+  (local $length i32)
+  (local $array i32)
+  (local $var$3 i32)
+  (local $var$4 i32)
+  (local $buffer i32)
+  (local $result i32)
   (local $7 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 20
@@ -53392,56 +53392,56 @@
   memory.fill $0
   global.get $~lib/memory/__stack_pointer
   global.get $std/typedarray/testArrayWrapValues
-  local.tee $0
+  local.tee $values
   i32.store $0
-  local.get $0
+  local.get $values
   call $~lib/array/Array<i32>#get:length
-  local.set $1
+  local.set $length
   global.get $~lib/memory/__stack_pointer
   i32.const 0
-  local.get $1
+  local.get $length
   call $~lib/typedarray/Uint32Array#constructor
-  local.tee $2
+  local.tee $array
   i32.store $0 offset=4
   i32.const 0
-  local.set $3
+  local.set $var$3
   loop $for-loop|0
-   local.get $3
-   local.get $1
+   local.get $var$3
+   local.get $length
    i32.lt_s
-   local.set $4
-   local.get $4
+   local.set $var$4
+   local.get $var$4
    if
-    local.get $2
-    local.get $3
-    local.get $0
-    local.get $3
+    local.get $array
+    local.get $var$3
+    local.get $values
+    local.get $var$3
     call $~lib/array/Array<i32>#__get
     call $~lib/typedarray/Uint32Array#__set
-    local.get $3
+    local.get $var$3
     i32.const 1
     i32.add
-    local.set $3
+    local.set $var$3
     br $for-loop|0
    end
   end
   global.get $~lib/memory/__stack_pointer
-  local.get $2
+  local.get $array
   i32.load $0
   local.set $7
   global.get $~lib/memory/__stack_pointer
   local.get $7
   i32.store $0 offset=8
   local.get $7
-  local.get $2
+  local.get $array
   call $~lib/arraybuffer/ArrayBufferView#get:byteOffset
-  local.get $2
+  local.get $array
   call $~lib/arraybuffer/ArrayBufferView#get:byteOffset
-  local.get $2
+  local.get $array
   i32.load $0 offset=8
   i32.add
   call $~lib/arraybuffer/ArrayBuffer#slice
-  local.tee $5
+  local.tee $buffer
   i32.store $0 offset=12
   i32.const 0
   drop
@@ -53458,28 +53458,28 @@
   i32.const 1
   drop
   global.get $~lib/memory/__stack_pointer
-  local.get $5
+  local.get $buffer
   i32.const 0
   i32.const 1
   global.set $~argumentsLength
   i32.const 0
   call $~lib/typedarray/Uint32Array.wrap@varargs
-  local.tee $6
+  local.tee $result
   i32.store $0 offset=16
   i32.const 0
-  local.set $3
+  local.set $var$3
   loop $for-loop|1
-   local.get $3
-   local.get $1
+   local.get $var$3
+   local.get $length
    i32.lt_s
-   local.set $4
-   local.get $4
+   local.set $var$4
+   local.get $var$4
    if
-    local.get $2
-    local.get $3
+    local.get $array
+    local.get $var$3
     call $~lib/typedarray/Uint32Array#__get
-    local.get $6
-    local.get $3
+    local.get $result
+    local.get $var$3
     call $~lib/typedarray/Uint32Array#__get
     i32.eq
     i32.eqz
@@ -53491,10 +53491,10 @@
      call $~lib/builtins/abort
      unreachable
     end
-    local.get $3
+    local.get $var$3
     i32.const 1
     i32.add
-    local.set $3
+    local.set $var$3
     br $for-loop|1
    end
   end
@@ -53504,13 +53504,13 @@
   global.set $~lib/memory/__stack_pointer
  )
  (func $std/typedarray/testArrayWrap<~lib/typedarray/Int64Array,i64>
-  (local $0 i32)
-  (local $1 i32)
-  (local $2 i32)
-  (local $3 i32)
-  (local $4 i32)
-  (local $5 i32)
-  (local $6 i32)
+  (local $values i32)
+  (local $length i32)
+  (local $array i32)
+  (local $var$3 i32)
+  (local $var$4 i32)
+  (local $buffer i32)
+  (local $result i32)
   (local $7 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 20
@@ -53523,57 +53523,57 @@
   memory.fill $0
   global.get $~lib/memory/__stack_pointer
   global.get $std/typedarray/testArrayWrapValues
-  local.tee $0
+  local.tee $values
   i32.store $0
-  local.get $0
+  local.get $values
   call $~lib/array/Array<i32>#get:length
-  local.set $1
+  local.set $length
   global.get $~lib/memory/__stack_pointer
   i32.const 0
-  local.get $1
+  local.get $length
   call $~lib/typedarray/Int64Array#constructor
-  local.tee $2
+  local.tee $array
   i32.store $0 offset=4
   i32.const 0
-  local.set $3
+  local.set $var$3
   loop $for-loop|0
-   local.get $3
-   local.get $1
+   local.get $var$3
+   local.get $length
    i32.lt_s
-   local.set $4
-   local.get $4
+   local.set $var$4
+   local.get $var$4
    if
-    local.get $2
-    local.get $3
-    local.get $0
-    local.get $3
+    local.get $array
+    local.get $var$3
+    local.get $values
+    local.get $var$3
     call $~lib/array/Array<i32>#__get
     i64.extend_i32_s
     call $~lib/typedarray/Int64Array#__set
-    local.get $3
+    local.get $var$3
     i32.const 1
     i32.add
-    local.set $3
+    local.set $var$3
     br $for-loop|0
    end
   end
   global.get $~lib/memory/__stack_pointer
-  local.get $2
+  local.get $array
   i32.load $0
   local.set $7
   global.get $~lib/memory/__stack_pointer
   local.get $7
   i32.store $0 offset=8
   local.get $7
-  local.get $2
+  local.get $array
   call $~lib/arraybuffer/ArrayBufferView#get:byteOffset
-  local.get $2
+  local.get $array
   call $~lib/arraybuffer/ArrayBufferView#get:byteOffset
-  local.get $2
+  local.get $array
   i32.load $0 offset=8
   i32.add
   call $~lib/arraybuffer/ArrayBuffer#slice
-  local.tee $5
+  local.tee $buffer
   i32.store $0 offset=12
   i32.const 0
   drop
@@ -53592,28 +53592,28 @@
   i32.const 1
   drop
   global.get $~lib/memory/__stack_pointer
-  local.get $5
+  local.get $buffer
   i32.const 0
   i32.const 1
   global.set $~argumentsLength
   i32.const 0
   call $~lib/typedarray/Int64Array.wrap@varargs
-  local.tee $6
+  local.tee $result
   i32.store $0 offset=16
   i32.const 0
-  local.set $3
+  local.set $var$3
   loop $for-loop|1
-   local.get $3
-   local.get $1
+   local.get $var$3
+   local.get $length
    i32.lt_s
-   local.set $4
-   local.get $4
+   local.set $var$4
+   local.get $var$4
    if
-    local.get $2
-    local.get $3
+    local.get $array
+    local.get $var$3
     call $~lib/typedarray/Int64Array#__get
-    local.get $6
-    local.get $3
+    local.get $result
+    local.get $var$3
     call $~lib/typedarray/Int64Array#__get
     i64.eq
     i32.eqz
@@ -53625,10 +53625,10 @@
      call $~lib/builtins/abort
      unreachable
     end
-    local.get $3
+    local.get $var$3
     i32.const 1
     i32.add
-    local.set $3
+    local.set $var$3
     br $for-loop|1
    end
   end
@@ -53638,13 +53638,13 @@
   global.set $~lib/memory/__stack_pointer
  )
  (func $std/typedarray/testArrayWrap<~lib/typedarray/Uint64Array,u64>
-  (local $0 i32)
-  (local $1 i32)
-  (local $2 i32)
-  (local $3 i32)
-  (local $4 i32)
-  (local $5 i32)
-  (local $6 i32)
+  (local $values i32)
+  (local $length i32)
+  (local $array i32)
+  (local $var$3 i32)
+  (local $var$4 i32)
+  (local $buffer i32)
+  (local $result i32)
   (local $7 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 20
@@ -53657,57 +53657,57 @@
   memory.fill $0
   global.get $~lib/memory/__stack_pointer
   global.get $std/typedarray/testArrayWrapValues
-  local.tee $0
+  local.tee $values
   i32.store $0
-  local.get $0
+  local.get $values
   call $~lib/array/Array<i32>#get:length
-  local.set $1
+  local.set $length
   global.get $~lib/memory/__stack_pointer
   i32.const 0
-  local.get $1
+  local.get $length
   call $~lib/typedarray/Uint64Array#constructor
-  local.tee $2
+  local.tee $array
   i32.store $0 offset=4
   i32.const 0
-  local.set $3
+  local.set $var$3
   loop $for-loop|0
-   local.get $3
-   local.get $1
+   local.get $var$3
+   local.get $length
    i32.lt_s
-   local.set $4
-   local.get $4
+   local.set $var$4
+   local.get $var$4
    if
-    local.get $2
-    local.get $3
-    local.get $0
-    local.get $3
+    local.get $array
+    local.get $var$3
+    local.get $values
+    local.get $var$3
     call $~lib/array/Array<i32>#__get
     i64.extend_i32_s
     call $~lib/typedarray/Uint64Array#__set
-    local.get $3
+    local.get $var$3
     i32.const 1
     i32.add
-    local.set $3
+    local.set $var$3
     br $for-loop|0
    end
   end
   global.get $~lib/memory/__stack_pointer
-  local.get $2
+  local.get $array
   i32.load $0
   local.set $7
   global.get $~lib/memory/__stack_pointer
   local.get $7
   i32.store $0 offset=8
   local.get $7
-  local.get $2
+  local.get $array
   call $~lib/arraybuffer/ArrayBufferView#get:byteOffset
-  local.get $2
+  local.get $array
   call $~lib/arraybuffer/ArrayBufferView#get:byteOffset
-  local.get $2
+  local.get $array
   i32.load $0 offset=8
   i32.add
   call $~lib/arraybuffer/ArrayBuffer#slice
-  local.tee $5
+  local.tee $buffer
   i32.store $0 offset=12
   i32.const 0
   drop
@@ -53728,28 +53728,28 @@
   i32.const 1
   drop
   global.get $~lib/memory/__stack_pointer
-  local.get $5
+  local.get $buffer
   i32.const 0
   i32.const 1
   global.set $~argumentsLength
   i32.const 0
   call $~lib/typedarray/Uint64Array.wrap@varargs
-  local.tee $6
+  local.tee $result
   i32.store $0 offset=16
   i32.const 0
-  local.set $3
+  local.set $var$3
   loop $for-loop|1
-   local.get $3
-   local.get $1
+   local.get $var$3
+   local.get $length
    i32.lt_s
-   local.set $4
-   local.get $4
+   local.set $var$4
+   local.get $var$4
    if
-    local.get $2
-    local.get $3
+    local.get $array
+    local.get $var$3
     call $~lib/typedarray/Uint64Array#__get
-    local.get $6
-    local.get $3
+    local.get $result
+    local.get $var$3
     call $~lib/typedarray/Uint64Array#__get
     i64.eq
     i32.eqz
@@ -53761,10 +53761,10 @@
      call $~lib/builtins/abort
      unreachable
     end
-    local.get $3
+    local.get $var$3
     i32.const 1
     i32.add
-    local.set $3
+    local.set $var$3
     br $for-loop|1
    end
   end
@@ -53774,13 +53774,13 @@
   global.set $~lib/memory/__stack_pointer
  )
  (func $std/typedarray/testArrayWrap<~lib/typedarray/Float32Array,f32>
-  (local $0 i32)
-  (local $1 i32)
-  (local $2 i32)
-  (local $3 i32)
-  (local $4 i32)
-  (local $5 i32)
-  (local $6 i32)
+  (local $values i32)
+  (local $length i32)
+  (local $array i32)
+  (local $var$3 i32)
+  (local $var$4 i32)
+  (local $buffer i32)
+  (local $result i32)
   (local $7 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 20
@@ -53793,57 +53793,57 @@
   memory.fill $0
   global.get $~lib/memory/__stack_pointer
   global.get $std/typedarray/testArrayWrapValues
-  local.tee $0
+  local.tee $values
   i32.store $0
-  local.get $0
+  local.get $values
   call $~lib/array/Array<i32>#get:length
-  local.set $1
+  local.set $length
   global.get $~lib/memory/__stack_pointer
   i32.const 0
-  local.get $1
+  local.get $length
   call $~lib/typedarray/Float32Array#constructor
-  local.tee $2
+  local.tee $array
   i32.store $0 offset=4
   i32.const 0
-  local.set $3
+  local.set $var$3
   loop $for-loop|0
-   local.get $3
-   local.get $1
+   local.get $var$3
+   local.get $length
    i32.lt_s
-   local.set $4
-   local.get $4
+   local.set $var$4
+   local.get $var$4
    if
-    local.get $2
-    local.get $3
-    local.get $0
-    local.get $3
+    local.get $array
+    local.get $var$3
+    local.get $values
+    local.get $var$3
     call $~lib/array/Array<i32>#__get
     f32.convert_i32_s
     call $~lib/typedarray/Float32Array#__set
-    local.get $3
+    local.get $var$3
     i32.const 1
     i32.add
-    local.set $3
+    local.set $var$3
     br $for-loop|0
    end
   end
   global.get $~lib/memory/__stack_pointer
-  local.get $2
+  local.get $array
   i32.load $0
   local.set $7
   global.get $~lib/memory/__stack_pointer
   local.get $7
   i32.store $0 offset=8
   local.get $7
-  local.get $2
+  local.get $array
   call $~lib/arraybuffer/ArrayBufferView#get:byteOffset
-  local.get $2
+  local.get $array
   call $~lib/arraybuffer/ArrayBufferView#get:byteOffset
-  local.get $2
+  local.get $array
   i32.load $0 offset=8
   i32.add
   call $~lib/arraybuffer/ArrayBuffer#slice
-  local.tee $5
+  local.tee $buffer
   i32.store $0 offset=12
   i32.const 0
   drop
@@ -53866,28 +53866,28 @@
   i32.const 1
   drop
   global.get $~lib/memory/__stack_pointer
-  local.get $5
+  local.get $buffer
   i32.const 0
   i32.const 1
   global.set $~argumentsLength
   i32.const 0
   call $~lib/typedarray/Float32Array.wrap@varargs
-  local.tee $6
+  local.tee $result
   i32.store $0 offset=16
   i32.const 0
-  local.set $3
+  local.set $var$3
   loop $for-loop|1
-   local.get $3
-   local.get $1
+   local.get $var$3
+   local.get $length
    i32.lt_s
-   local.set $4
-   local.get $4
+   local.set $var$4
+   local.get $var$4
    if
-    local.get $2
-    local.get $3
+    local.get $array
+    local.get $var$3
     call $~lib/typedarray/Float32Array#__get
-    local.get $6
-    local.get $3
+    local.get $result
+    local.get $var$3
     call $~lib/typedarray/Float32Array#__get
     f32.eq
     i32.eqz
@@ -53899,10 +53899,10 @@
      call $~lib/builtins/abort
      unreachable
     end
-    local.get $3
+    local.get $var$3
     i32.const 1
     i32.add
-    local.set $3
+    local.set $var$3
     br $for-loop|1
    end
   end
@@ -53912,13 +53912,13 @@
   global.set $~lib/memory/__stack_pointer
  )
  (func $std/typedarray/testArrayWrap<~lib/typedarray/Float64Array,f64>
-  (local $0 i32)
-  (local $1 i32)
-  (local $2 i32)
-  (local $3 i32)
-  (local $4 i32)
-  (local $5 i32)
-  (local $6 i32)
+  (local $values i32)
+  (local $length i32)
+  (local $array i32)
+  (local $var$3 i32)
+  (local $var$4 i32)
+  (local $buffer i32)
+  (local $result i32)
   (local $7 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 20
@@ -53931,57 +53931,57 @@
   memory.fill $0
   global.get $~lib/memory/__stack_pointer
   global.get $std/typedarray/testArrayWrapValues
-  local.tee $0
+  local.tee $values
   i32.store $0
-  local.get $0
+  local.get $values
   call $~lib/array/Array<i32>#get:length
-  local.set $1
+  local.set $length
   global.get $~lib/memory/__stack_pointer
   i32.const 0
-  local.get $1
+  local.get $length
   call $~lib/typedarray/Float64Array#constructor
-  local.tee $2
+  local.tee $array
   i32.store $0 offset=4
   i32.const 0
-  local.set $3
+  local.set $var$3
   loop $for-loop|0
-   local.get $3
-   local.get $1
+   local.get $var$3
+   local.get $length
    i32.lt_s
-   local.set $4
-   local.get $4
+   local.set $var$4
+   local.get $var$4
    if
-    local.get $2
-    local.get $3
-    local.get $0
-    local.get $3
+    local.get $array
+    local.get $var$3
+    local.get $values
+    local.get $var$3
     call $~lib/array/Array<i32>#__get
     f64.convert_i32_s
     call $~lib/typedarray/Float64Array#__set
-    local.get $3
+    local.get $var$3
     i32.const 1
     i32.add
-    local.set $3
+    local.set $var$3
     br $for-loop|0
    end
   end
   global.get $~lib/memory/__stack_pointer
-  local.get $2
+  local.get $array
   i32.load $0
   local.set $7
   global.get $~lib/memory/__stack_pointer
   local.get $7
   i32.store $0 offset=8
   local.get $7
-  local.get $2
+  local.get $array
   call $~lib/arraybuffer/ArrayBufferView#get:byteOffset
-  local.get $2
+  local.get $array
   call $~lib/arraybuffer/ArrayBufferView#get:byteOffset
-  local.get $2
+  local.get $array
   i32.load $0 offset=8
   i32.add
   call $~lib/arraybuffer/ArrayBuffer#slice
-  local.tee $5
+  local.tee $buffer
   i32.store $0 offset=12
   i32.const 0
   drop
@@ -54006,28 +54006,28 @@
   i32.const 1
   drop
   global.get $~lib/memory/__stack_pointer
-  local.get $5
+  local.get $buffer
   i32.const 0
   i32.const 1
   global.set $~argumentsLength
   i32.const 0
   call $~lib/typedarray/Float64Array.wrap@varargs
-  local.tee $6
+  local.tee $result
   i32.store $0 offset=16
   i32.const 0
-  local.set $3
+  local.set $var$3
   loop $for-loop|1
-   local.get $3
-   local.get $1
+   local.get $var$3
+   local.get $length
    i32.lt_s
-   local.set $4
-   local.get $4
+   local.set $var$4
+   local.get $var$4
    if
-    local.get $2
-    local.get $3
+    local.get $array
+    local.get $var$3
     call $~lib/typedarray/Float64Array#__get
-    local.get $6
-    local.get $3
+    local.get $result
+    local.get $var$3
     call $~lib/typedarray/Float64Array#__get
     f64.eq
     i32.eqz
@@ -54039,10 +54039,10 @@
      call $~lib/builtins/abort
      unreachable
     end
-    local.get $3
+    local.get $var$3
     i32.const 1
     i32.add
-    local.set $3
+    local.set $var$3
     br $for-loop|1
    end
   end
@@ -54051,12 +54051,12 @@
   i32.add
   global.set $~lib/memory/__stack_pointer
  )
- (func $std/typedarray/valuesEqual<~lib/typedarray/Int8Array> (param $0 i32) (param $1 i32)
-  (local $2 i32)
-  (local $3 i32)
-  (local $4 i32)
-  (local $5 i32)
-  (local $6 i32)
+ (func $std/typedarray/valuesEqual<~lib/typedarray/Int8Array> (param $target i32) (param $compare i32)
+  (local $len i32)
+  (local $var$3 i32)
+  (local $var$4 i32)
+  (local $var$5 i32)
+  (local $var$6 i32)
   (local $7 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -54066,11 +54066,11 @@
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   i32.store $0
-  local.get $0
+  local.get $target
   call $~lib/typedarray/Int8Array#get:length
-  local.set $2
-  local.get $2
-  local.get $1
+  local.set $len
+  local.get $len
+  local.get $compare
   call $~lib/array/Array<i8>#get:length
   i32.eq
   i32.eqz
@@ -54083,24 +54083,24 @@
    unreachable
   end
   i32.const 0
-  local.set $3
+  local.set $var$3
   loop $for-loop|0
-   local.get $3
-   local.get $2
+   local.get $var$3
+   local.get $len
    i32.lt_s
-   local.set $4
-   local.get $4
+   local.set $var$4
+   local.get $var$4
    if
-    local.get $0
-    local.get $3
+    local.get $target
+    local.get $var$3
     call $~lib/typedarray/Int8Array#__uget
-    local.set $5
-    local.get $1
-    local.get $3
+    local.set $var$5
+    local.get $compare
+    local.get $var$3
     call $~lib/array/Array<i8>#__uget
-    local.set $6
-    local.get $5
-    local.get $6
+    local.set $var$6
+    local.get $var$5
+    local.get $var$6
     i32.ne
     if
      i32.const 10320
@@ -54110,11 +54110,11 @@
      i32.store $0
      local.get $7
      i32.const 3
-     local.get $3
+     local.get $var$3
      f64.convert_i32_s
-     local.get $5
+     local.get $var$5
      f64.convert_i32_s
-     local.get $6
+     local.get $var$6
      f64.convert_i32_s
      f64.const 0
      f64.const 0
@@ -54130,10 +54130,10 @@
       unreachable
      end
     end
-    local.get $3
+    local.get $var$3
     i32.const 1
     i32.add
-    local.set $3
+    local.set $var$3
     br $for-loop|0
    end
   end
@@ -54143,12 +54143,12 @@
   global.set $~lib/memory/__stack_pointer
  )
  (func $std/typedarray/testTypedArraySet<~lib/typedarray/Int8Array>
-  (local $0 i32)
-  (local $1 i32)
-  (local $2 i32)
-  (local $3 i32)
-  (local $4 i32)
-  (local $5 i32)
+  (local $setSource4 i32)
+  (local $setSource5 i32)
+  (local $setSource6 i32)
+  (local $a i32)
+  (local $var$4 i32)
+  (local $var$5 i32)
   (local $6 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 20
@@ -54163,17 +54163,17 @@
   i32.const 0
   i32.const 3
   call $~lib/typedarray/Int64Array#constructor
-  local.tee $0
+  local.tee $setSource4
   i32.store $0
-  local.get $0
+  local.get $setSource4
   i32.const 0
   i64.const 7
   call $~lib/typedarray/Int64Array#__set
-  local.get $0
+  local.get $setSource4
   i32.const 1
   i64.const 8
   call $~lib/typedarray/Int64Array#__set
-  local.get $0
+  local.get $setSource4
   i32.const 2
   i64.const 9
   call $~lib/typedarray/Int64Array#__set
@@ -54181,21 +54181,21 @@
   i32.const 0
   i32.const 4
   call $~lib/typedarray/Uint8Array#constructor
-  local.tee $1
+  local.tee $setSource5
   i32.store $0 offset=4
-  local.get $1
+  local.get $setSource5
   i32.const 0
   i32.const 100
   call $~lib/typedarray/Uint8Array#__set
-  local.get $1
+  local.get $setSource5
   i32.const 1
   i32.const 101
   call $~lib/typedarray/Uint8Array#__set
-  local.get $1
+  local.get $setSource5
   i32.const 2
   i32.const 102
   call $~lib/typedarray/Uint8Array#__set
-  local.get $1
+  local.get $setSource5
   i32.const 3
   i32.const 103
   call $~lib/typedarray/Uint8Array#__set
@@ -54203,17 +54203,17 @@
   i32.const 0
   i32.const 3
   call $~lib/typedarray/Int16Array#constructor
-  local.tee $2
+  local.tee $setSource6
   i32.store $0 offset=8
-  local.get $2
+  local.get $setSource6
   i32.const 0
   i32.const 1000
   call $~lib/typedarray/Int16Array#__set
-  local.get $2
+  local.get $setSource6
   i32.const 1
   i32.const 1001
   call $~lib/typedarray/Int16Array#__set
-  local.get $2
+  local.get $setSource6
   i32.const 2
   i32.const 1002
   call $~lib/typedarray/Int16Array#__set
@@ -54221,9 +54221,9 @@
   i32.const 0
   i32.const 10
   call $~lib/typedarray/Int8Array#constructor
-  local.tee $3
+  local.tee $a
   i32.store $0 offset=12
-  local.get $3
+  local.get $a
   global.get $std/typedarray/setSource1
   local.set $6
   global.get $~lib/memory/__stack_pointer
@@ -54232,7 +54232,7 @@
   local.get $6
   i32.const 0
   call $~lib/typedarray/Int8Array#set<~lib/array/Array<i32>>
-  local.get $3
+  local.get $a
   i32.const 10
   i32.const 0
   i32.const 15
@@ -54244,7 +54244,7 @@
   i32.store $0 offset=16
   local.get $6
   call $std/typedarray/valuesEqual<~lib/typedarray/Int8Array>
-  local.get $3
+  local.get $a
   global.get $std/typedarray/setSource2
   local.set $6
   global.get $~lib/memory/__stack_pointer
@@ -54253,7 +54253,7 @@
   local.get $6
   i32.const 3
   call $~lib/typedarray/Int8Array#set<~lib/array/Array<f32>>
-  local.get $3
+  local.get $a
   i32.const 10
   i32.const 0
   i32.const 15
@@ -54265,11 +54265,11 @@
   i32.store $0 offset=16
   local.get $6
   call $std/typedarray/valuesEqual<~lib/typedarray/Int8Array>
-  local.get $3
-  local.get $0
+  local.get $a
+  local.get $setSource4
   i32.const 6
   call $~lib/typedarray/Int8Array#set<~lib/typedarray/Int64Array>
-  local.get $3
+  local.get $a
   i32.const 10
   i32.const 0
   i32.const 15
@@ -54283,7 +54283,7 @@
   call $std/typedarray/valuesEqual<~lib/typedarray/Int8Array>
   i32.const 1
   drop
-  local.get $3
+  local.get $a
   global.get $std/typedarray/setSource3
   local.set $6
   global.get $~lib/memory/__stack_pointer
@@ -54292,7 +54292,7 @@
   local.get $6
   i32.const 2
   call $~lib/typedarray/Int8Array#set<~lib/array/Array<f64>>
-  local.get $3
+  local.get $a
   i32.const 10
   i32.const 0
   i32.const 15
@@ -54304,15 +54304,15 @@
   i32.store $0 offset=16
   local.get $6
   call $std/typedarray/valuesEqual<~lib/typedarray/Int8Array>
-  local.get $3
-  local.get $1
+  local.get $a
+  local.get $setSource5
   i32.const 0
   call $~lib/typedarray/Int8Array#set<~lib/typedarray/Uint8Array>
-  local.get $3
-  local.get $2
+  local.get $a
+  local.get $setSource6
   i32.const 4
   call $~lib/typedarray/Int8Array#set<~lib/typedarray/Int16Array>
-  local.get $3
+  local.get $a
   global.get $std/typedarray/setSource7
   local.set $6
   global.get $~lib/memory/__stack_pointer
@@ -54323,7 +54323,7 @@
   call $~lib/typedarray/Int8Array#set<~lib/array/Array<i8>>
   i32.const 0
   drop
-  local.get $3
+  local.get $a
   i32.const 10
   i32.const 0
   i32.const 15
@@ -54340,12 +54340,12 @@
   i32.add
   global.set $~lib/memory/__stack_pointer
  )
- (func $std/typedarray/valuesEqual<~lib/typedarray/Uint8Array> (param $0 i32) (param $1 i32)
-  (local $2 i32)
-  (local $3 i32)
-  (local $4 i32)
-  (local $5 i32)
-  (local $6 i32)
+ (func $std/typedarray/valuesEqual<~lib/typedarray/Uint8Array> (param $target i32) (param $compare i32)
+  (local $len i32)
+  (local $var$3 i32)
+  (local $var$4 i32)
+  (local $var$5 i32)
+  (local $var$6 i32)
   (local $7 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -54355,11 +54355,11 @@
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   i32.store $0
-  local.get $0
+  local.get $target
   call $~lib/typedarray/Uint8Array#get:length
-  local.set $2
-  local.get $2
-  local.get $1
+  local.set $len
+  local.get $len
+  local.get $compare
   call $~lib/array/Array<u8>#get:length
   i32.eq
   i32.eqz
@@ -54372,24 +54372,24 @@
    unreachable
   end
   i32.const 0
-  local.set $3
+  local.set $var$3
   loop $for-loop|0
-   local.get $3
-   local.get $2
+   local.get $var$3
+   local.get $len
    i32.lt_s
-   local.set $4
-   local.get $4
+   local.set $var$4
+   local.get $var$4
    if
-    local.get $0
-    local.get $3
+    local.get $target
+    local.get $var$3
     call $~lib/typedarray/Uint8Array#__uget
-    local.set $5
-    local.get $1
-    local.get $3
+    local.set $var$5
+    local.get $compare
+    local.get $var$3
     call $~lib/array/Array<u8>#__uget
-    local.set $6
-    local.get $5
-    local.get $6
+    local.set $var$6
+    local.get $var$5
+    local.get $var$6
     i32.ne
     if
      i32.const 10528
@@ -54399,11 +54399,11 @@
      i32.store $0
      local.get $7
      i32.const 3
-     local.get $3
+     local.get $var$3
      f64.convert_i32_s
-     local.get $5
+     local.get $var$5
      f64.convert_i32_u
-     local.get $6
+     local.get $var$6
      f64.convert_i32_u
      f64.const 0
      f64.const 0
@@ -54419,10 +54419,10 @@
       unreachable
      end
     end
-    local.get $3
+    local.get $var$3
     i32.const 1
     i32.add
-    local.set $3
+    local.set $var$3
     br $for-loop|0
    end
   end
@@ -54432,12 +54432,12 @@
   global.set $~lib/memory/__stack_pointer
  )
  (func $std/typedarray/testTypedArraySet<~lib/typedarray/Uint8Array>
-  (local $0 i32)
-  (local $1 i32)
-  (local $2 i32)
-  (local $3 i32)
-  (local $4 i32)
-  (local $5 i32)
+  (local $setSource4 i32)
+  (local $setSource5 i32)
+  (local $setSource6 i32)
+  (local $a i32)
+  (local $var$4 i32)
+  (local $var$5 i32)
   (local $6 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 20
@@ -54452,17 +54452,17 @@
   i32.const 0
   i32.const 3
   call $~lib/typedarray/Int64Array#constructor
-  local.tee $0
+  local.tee $setSource4
   i32.store $0
-  local.get $0
+  local.get $setSource4
   i32.const 0
   i64.const 7
   call $~lib/typedarray/Int64Array#__set
-  local.get $0
+  local.get $setSource4
   i32.const 1
   i64.const 8
   call $~lib/typedarray/Int64Array#__set
-  local.get $0
+  local.get $setSource4
   i32.const 2
   i64.const 9
   call $~lib/typedarray/Int64Array#__set
@@ -54470,21 +54470,21 @@
   i32.const 0
   i32.const 4
   call $~lib/typedarray/Uint8Array#constructor
-  local.tee $1
+  local.tee $setSource5
   i32.store $0 offset=4
-  local.get $1
+  local.get $setSource5
   i32.const 0
   i32.const 100
   call $~lib/typedarray/Uint8Array#__set
-  local.get $1
+  local.get $setSource5
   i32.const 1
   i32.const 101
   call $~lib/typedarray/Uint8Array#__set
-  local.get $1
+  local.get $setSource5
   i32.const 2
   i32.const 102
   call $~lib/typedarray/Uint8Array#__set
-  local.get $1
+  local.get $setSource5
   i32.const 3
   i32.const 103
   call $~lib/typedarray/Uint8Array#__set
@@ -54492,17 +54492,17 @@
   i32.const 0
   i32.const 3
   call $~lib/typedarray/Int16Array#constructor
-  local.tee $2
+  local.tee $setSource6
   i32.store $0 offset=8
-  local.get $2
+  local.get $setSource6
   i32.const 0
   i32.const 1000
   call $~lib/typedarray/Int16Array#__set
-  local.get $2
+  local.get $setSource6
   i32.const 1
   i32.const 1001
   call $~lib/typedarray/Int16Array#__set
-  local.get $2
+  local.get $setSource6
   i32.const 2
   i32.const 1002
   call $~lib/typedarray/Int16Array#__set
@@ -54510,9 +54510,9 @@
   i32.const 0
   i32.const 10
   call $~lib/typedarray/Uint8Array#constructor
-  local.tee $3
+  local.tee $a
   i32.store $0 offset=12
-  local.get $3
+  local.get $a
   global.get $std/typedarray/setSource1
   local.set $6
   global.get $~lib/memory/__stack_pointer
@@ -54521,7 +54521,7 @@
   local.get $6
   i32.const 0
   call $~lib/typedarray/Uint8Array#set<~lib/array/Array<i32>>
-  local.get $3
+  local.get $a
   i32.const 10
   i32.const 0
   i32.const 63
@@ -54533,7 +54533,7 @@
   i32.store $0 offset=16
   local.get $6
   call $std/typedarray/valuesEqual<~lib/typedarray/Uint8Array>
-  local.get $3
+  local.get $a
   global.get $std/typedarray/setSource2
   local.set $6
   global.get $~lib/memory/__stack_pointer
@@ -54542,7 +54542,7 @@
   local.get $6
   i32.const 3
   call $~lib/typedarray/Uint8Array#set<~lib/array/Array<f32>>
-  local.get $3
+  local.get $a
   i32.const 10
   i32.const 0
   i32.const 63
@@ -54554,11 +54554,11 @@
   i32.store $0 offset=16
   local.get $6
   call $std/typedarray/valuesEqual<~lib/typedarray/Uint8Array>
-  local.get $3
-  local.get $0
+  local.get $a
+  local.get $setSource4
   i32.const 6
   call $~lib/typedarray/Uint8Array#set<~lib/typedarray/Int64Array>
-  local.get $3
+  local.get $a
   i32.const 10
   i32.const 0
   i32.const 63
@@ -54572,7 +54572,7 @@
   call $std/typedarray/valuesEqual<~lib/typedarray/Uint8Array>
   i32.const 1
   drop
-  local.get $3
+  local.get $a
   global.get $std/typedarray/setSource3
   local.set $6
   global.get $~lib/memory/__stack_pointer
@@ -54581,7 +54581,7 @@
   local.get $6
   i32.const 2
   call $~lib/typedarray/Uint8Array#set<~lib/array/Array<f64>>
-  local.get $3
+  local.get $a
   i32.const 10
   i32.const 0
   i32.const 63
@@ -54593,15 +54593,15 @@
   i32.store $0 offset=16
   local.get $6
   call $std/typedarray/valuesEqual<~lib/typedarray/Uint8Array>
-  local.get $3
-  local.get $1
+  local.get $a
+  local.get $setSource5
   i32.const 0
   call $~lib/typedarray/Uint8Array#set<~lib/typedarray/Uint8Array>
-  local.get $3
-  local.get $2
+  local.get $a
+  local.get $setSource6
   i32.const 4
   call $~lib/typedarray/Uint8Array#set<~lib/typedarray/Int16Array>
-  local.get $3
+  local.get $a
   global.get $std/typedarray/setSource7
   local.set $6
   global.get $~lib/memory/__stack_pointer
@@ -54612,7 +54612,7 @@
   call $~lib/typedarray/Uint8Array#set<~lib/array/Array<i8>>
   i32.const 0
   drop
-  local.get $3
+  local.get $a
   i32.const 10
   i32.const 0
   i32.const 63
@@ -54629,12 +54629,12 @@
   i32.add
   global.set $~lib/memory/__stack_pointer
  )
- (func $std/typedarray/valuesEqual<~lib/typedarray/Uint8ClampedArray> (param $0 i32) (param $1 i32)
-  (local $2 i32)
-  (local $3 i32)
-  (local $4 i32)
-  (local $5 i32)
-  (local $6 i32)
+ (func $std/typedarray/valuesEqual<~lib/typedarray/Uint8ClampedArray> (param $target i32) (param $compare i32)
+  (local $len i32)
+  (local $var$3 i32)
+  (local $var$4 i32)
+  (local $var$5 i32)
+  (local $var$6 i32)
   (local $7 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -54644,11 +54644,11 @@
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   i32.store $0
-  local.get $0
+  local.get $target
   call $~lib/typedarray/Uint8ClampedArray#get:length
-  local.set $2
-  local.get $2
-  local.get $1
+  local.set $len
+  local.get $len
+  local.get $compare
   call $~lib/array/Array<u8>#get:length
   i32.eq
   i32.eqz
@@ -54661,24 +54661,24 @@
    unreachable
   end
   i32.const 0
-  local.set $3
+  local.set $var$3
   loop $for-loop|0
-   local.get $3
-   local.get $2
+   local.get $var$3
+   local.get $len
    i32.lt_s
-   local.set $4
-   local.get $4
+   local.set $var$4
+   local.get $var$4
    if
-    local.get $0
-    local.get $3
+    local.get $target
+    local.get $var$3
     call $~lib/typedarray/Uint8ClampedArray#__uget
-    local.set $5
-    local.get $1
-    local.get $3
+    local.set $var$5
+    local.get $compare
+    local.get $var$3
     call $~lib/array/Array<u8>#__uget
-    local.set $6
-    local.get $5
-    local.get $6
+    local.set $var$6
+    local.get $var$5
+    local.get $var$6
     i32.ne
     if
      i32.const 10736
@@ -54688,11 +54688,11 @@
      i32.store $0
      local.get $7
      i32.const 3
-     local.get $3
+     local.get $var$3
      f64.convert_i32_s
-     local.get $5
+     local.get $var$5
      f64.convert_i32_u
-     local.get $6
+     local.get $var$6
      f64.convert_i32_u
      f64.const 0
      f64.const 0
@@ -54708,10 +54708,10 @@
       unreachable
      end
     end
-    local.get $3
+    local.get $var$3
     i32.const 1
     i32.add
-    local.set $3
+    local.set $var$3
     br $for-loop|0
    end
   end
@@ -54721,12 +54721,12 @@
   global.set $~lib/memory/__stack_pointer
  )
  (func $std/typedarray/testTypedArraySet<~lib/typedarray/Uint8ClampedArray>
-  (local $0 i32)
-  (local $1 i32)
-  (local $2 i32)
-  (local $3 i32)
-  (local $4 i32)
-  (local $5 i32)
+  (local $setSource4 i32)
+  (local $setSource5 i32)
+  (local $setSource6 i32)
+  (local $a i32)
+  (local $var$4 i32)
+  (local $var$5 i32)
   (local $6 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 20
@@ -54741,17 +54741,17 @@
   i32.const 0
   i32.const 3
   call $~lib/typedarray/Int64Array#constructor
-  local.tee $0
+  local.tee $setSource4
   i32.store $0
-  local.get $0
+  local.get $setSource4
   i32.const 0
   i64.const 7
   call $~lib/typedarray/Int64Array#__set
-  local.get $0
+  local.get $setSource4
   i32.const 1
   i64.const 8
   call $~lib/typedarray/Int64Array#__set
-  local.get $0
+  local.get $setSource4
   i32.const 2
   i64.const 9
   call $~lib/typedarray/Int64Array#__set
@@ -54759,21 +54759,21 @@
   i32.const 0
   i32.const 4
   call $~lib/typedarray/Uint8Array#constructor
-  local.tee $1
+  local.tee $setSource5
   i32.store $0 offset=4
-  local.get $1
+  local.get $setSource5
   i32.const 0
   i32.const 100
   call $~lib/typedarray/Uint8Array#__set
-  local.get $1
+  local.get $setSource5
   i32.const 1
   i32.const 101
   call $~lib/typedarray/Uint8Array#__set
-  local.get $1
+  local.get $setSource5
   i32.const 2
   i32.const 102
   call $~lib/typedarray/Uint8Array#__set
-  local.get $1
+  local.get $setSource5
   i32.const 3
   i32.const 103
   call $~lib/typedarray/Uint8Array#__set
@@ -54781,17 +54781,17 @@
   i32.const 0
   i32.const 3
   call $~lib/typedarray/Int16Array#constructor
-  local.tee $2
+  local.tee $setSource6
   i32.store $0 offset=8
-  local.get $2
+  local.get $setSource6
   i32.const 0
   i32.const 1000
   call $~lib/typedarray/Int16Array#__set
-  local.get $2
+  local.get $setSource6
   i32.const 1
   i32.const 1001
   call $~lib/typedarray/Int16Array#__set
-  local.get $2
+  local.get $setSource6
   i32.const 2
   i32.const 1002
   call $~lib/typedarray/Int16Array#__set
@@ -54799,9 +54799,9 @@
   i32.const 0
   i32.const 10
   call $~lib/typedarray/Uint8ClampedArray#constructor
-  local.tee $3
+  local.tee $a
   i32.store $0 offset=12
-  local.get $3
+  local.get $a
   global.get $std/typedarray/setSource1
   local.set $6
   global.get $~lib/memory/__stack_pointer
@@ -54810,7 +54810,7 @@
   local.get $6
   i32.const 0
   call $~lib/typedarray/Uint8ClampedArray#set<~lib/array/Array<i32>>
-  local.get $3
+  local.get $a
   i32.const 10
   i32.const 0
   i32.const 63
@@ -54822,7 +54822,7 @@
   i32.store $0 offset=16
   local.get $6
   call $std/typedarray/valuesEqual<~lib/typedarray/Uint8ClampedArray>
-  local.get $3
+  local.get $a
   global.get $std/typedarray/setSource2
   local.set $6
   global.get $~lib/memory/__stack_pointer
@@ -54831,7 +54831,7 @@
   local.get $6
   i32.const 3
   call $~lib/typedarray/Uint8ClampedArray#set<~lib/array/Array<f32>>
-  local.get $3
+  local.get $a
   i32.const 10
   i32.const 0
   i32.const 63
@@ -54843,11 +54843,11 @@
   i32.store $0 offset=16
   local.get $6
   call $std/typedarray/valuesEqual<~lib/typedarray/Uint8ClampedArray>
-  local.get $3
-  local.get $0
+  local.get $a
+  local.get $setSource4
   i32.const 6
   call $~lib/typedarray/Uint8ClampedArray#set<~lib/typedarray/Int64Array>
-  local.get $3
+  local.get $a
   i32.const 10
   i32.const 0
   i32.const 63
@@ -54861,7 +54861,7 @@
   call $std/typedarray/valuesEqual<~lib/typedarray/Uint8ClampedArray>
   i32.const 1
   drop
-  local.get $3
+  local.get $a
   global.get $std/typedarray/setSource3
   local.set $6
   global.get $~lib/memory/__stack_pointer
@@ -54870,7 +54870,7 @@
   local.get $6
   i32.const 2
   call $~lib/typedarray/Uint8ClampedArray#set<~lib/array/Array<f64>>
-  local.get $3
+  local.get $a
   i32.const 10
   i32.const 0
   i32.const 63
@@ -54882,15 +54882,15 @@
   i32.store $0 offset=16
   local.get $6
   call $std/typedarray/valuesEqual<~lib/typedarray/Uint8ClampedArray>
-  local.get $3
-  local.get $1
+  local.get $a
+  local.get $setSource5
   i32.const 0
   call $~lib/typedarray/Uint8ClampedArray#set<~lib/typedarray/Uint8Array>
-  local.get $3
-  local.get $2
+  local.get $a
+  local.get $setSource6
   i32.const 4
   call $~lib/typedarray/Uint8ClampedArray#set<~lib/typedarray/Int16Array>
-  local.get $3
+  local.get $a
   global.get $std/typedarray/setSource7
   local.set $6
   global.get $~lib/memory/__stack_pointer
@@ -54901,7 +54901,7 @@
   call $~lib/typedarray/Uint8ClampedArray#set<~lib/array/Array<i8>>
   i32.const 1
   drop
-  local.get $3
+  local.get $a
   i32.const 10
   i32.const 0
   i32.const 63
@@ -54918,12 +54918,12 @@
   i32.add
   global.set $~lib/memory/__stack_pointer
  )
- (func $std/typedarray/valuesEqual<~lib/typedarray/Int16Array> (param $0 i32) (param $1 i32)
-  (local $2 i32)
-  (local $3 i32)
-  (local $4 i32)
-  (local $5 i32)
-  (local $6 i32)
+ (func $std/typedarray/valuesEqual<~lib/typedarray/Int16Array> (param $target i32) (param $compare i32)
+  (local $len i32)
+  (local $var$3 i32)
+  (local $var$4 i32)
+  (local $var$5 i32)
+  (local $var$6 i32)
   (local $7 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -54933,11 +54933,11 @@
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   i32.store $0
-  local.get $0
+  local.get $target
   call $~lib/typedarray/Int16Array#get:length
-  local.set $2
-  local.get $2
-  local.get $1
+  local.set $len
+  local.get $len
+  local.get $compare
   call $~lib/array/Array<i16>#get:length
   i32.eq
   i32.eqz
@@ -54950,24 +54950,24 @@
    unreachable
   end
   i32.const 0
-  local.set $3
+  local.set $var$3
   loop $for-loop|0
-   local.get $3
-   local.get $2
+   local.get $var$3
+   local.get $len
    i32.lt_s
-   local.set $4
-   local.get $4
+   local.set $var$4
+   local.get $var$4
    if
-    local.get $0
-    local.get $3
+    local.get $target
+    local.get $var$3
     call $~lib/typedarray/Int16Array#__uget
-    local.set $5
-    local.get $1
-    local.get $3
+    local.set $var$5
+    local.get $compare
+    local.get $var$3
     call $~lib/array/Array<i16>#__uget
-    local.set $6
-    local.get $5
-    local.get $6
+    local.set $var$6
+    local.get $var$5
+    local.get $var$6
     i32.ne
     if
      i32.const 10976
@@ -54977,11 +54977,11 @@
      i32.store $0
      local.get $7
      i32.const 3
-     local.get $3
+     local.get $var$3
      f64.convert_i32_s
-     local.get $5
+     local.get $var$5
      f64.convert_i32_s
-     local.get $6
+     local.get $var$6
      f64.convert_i32_s
      f64.const 0
      f64.const 0
@@ -54997,10 +54997,10 @@
       unreachable
      end
     end
-    local.get $3
+    local.get $var$3
     i32.const 1
     i32.add
-    local.set $3
+    local.set $var$3
     br $for-loop|0
    end
   end
@@ -55010,12 +55010,12 @@
   global.set $~lib/memory/__stack_pointer
  )
  (func $std/typedarray/testTypedArraySet<~lib/typedarray/Int16Array>
-  (local $0 i32)
-  (local $1 i32)
-  (local $2 i32)
-  (local $3 i32)
-  (local $4 i32)
-  (local $5 i32)
+  (local $setSource4 i32)
+  (local $setSource5 i32)
+  (local $setSource6 i32)
+  (local $a i32)
+  (local $var$4 i32)
+  (local $var$5 i32)
   (local $6 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 20
@@ -55030,17 +55030,17 @@
   i32.const 0
   i32.const 3
   call $~lib/typedarray/Int64Array#constructor
-  local.tee $0
+  local.tee $setSource4
   i32.store $0
-  local.get $0
+  local.get $setSource4
   i32.const 0
   i64.const 7
   call $~lib/typedarray/Int64Array#__set
-  local.get $0
+  local.get $setSource4
   i32.const 1
   i64.const 8
   call $~lib/typedarray/Int64Array#__set
-  local.get $0
+  local.get $setSource4
   i32.const 2
   i64.const 9
   call $~lib/typedarray/Int64Array#__set
@@ -55048,21 +55048,21 @@
   i32.const 0
   i32.const 4
   call $~lib/typedarray/Uint8Array#constructor
-  local.tee $1
+  local.tee $setSource5
   i32.store $0 offset=4
-  local.get $1
+  local.get $setSource5
   i32.const 0
   i32.const 100
   call $~lib/typedarray/Uint8Array#__set
-  local.get $1
+  local.get $setSource5
   i32.const 1
   i32.const 101
   call $~lib/typedarray/Uint8Array#__set
-  local.get $1
+  local.get $setSource5
   i32.const 2
   i32.const 102
   call $~lib/typedarray/Uint8Array#__set
-  local.get $1
+  local.get $setSource5
   i32.const 3
   i32.const 103
   call $~lib/typedarray/Uint8Array#__set
@@ -55070,17 +55070,17 @@
   i32.const 0
   i32.const 3
   call $~lib/typedarray/Int16Array#constructor
-  local.tee $2
+  local.tee $setSource6
   i32.store $0 offset=8
-  local.get $2
+  local.get $setSource6
   i32.const 0
   i32.const 1000
   call $~lib/typedarray/Int16Array#__set
-  local.get $2
+  local.get $setSource6
   i32.const 1
   i32.const 1001
   call $~lib/typedarray/Int16Array#__set
-  local.get $2
+  local.get $setSource6
   i32.const 2
   i32.const 1002
   call $~lib/typedarray/Int16Array#__set
@@ -55088,9 +55088,9 @@
   i32.const 0
   i32.const 10
   call $~lib/typedarray/Int16Array#constructor
-  local.tee $3
+  local.tee $a
   i32.store $0 offset=12
-  local.get $3
+  local.get $a
   global.get $std/typedarray/setSource1
   local.set $6
   global.get $~lib/memory/__stack_pointer
@@ -55099,7 +55099,7 @@
   local.get $6
   i32.const 0
   call $~lib/typedarray/Int16Array#set<~lib/array/Array<i32>>
-  local.get $3
+  local.get $a
   i32.const 10
   i32.const 1
   i32.const 64
@@ -55111,7 +55111,7 @@
   i32.store $0 offset=16
   local.get $6
   call $std/typedarray/valuesEqual<~lib/typedarray/Int16Array>
-  local.get $3
+  local.get $a
   global.get $std/typedarray/setSource2
   local.set $6
   global.get $~lib/memory/__stack_pointer
@@ -55120,7 +55120,7 @@
   local.get $6
   i32.const 3
   call $~lib/typedarray/Int16Array#set<~lib/array/Array<f32>>
-  local.get $3
+  local.get $a
   i32.const 10
   i32.const 1
   i32.const 64
@@ -55132,11 +55132,11 @@
   i32.store $0 offset=16
   local.get $6
   call $std/typedarray/valuesEqual<~lib/typedarray/Int16Array>
-  local.get $3
-  local.get $0
+  local.get $a
+  local.get $setSource4
   i32.const 6
   call $~lib/typedarray/Int16Array#set<~lib/typedarray/Int64Array>
-  local.get $3
+  local.get $a
   i32.const 10
   i32.const 1
   i32.const 64
@@ -55150,7 +55150,7 @@
   call $std/typedarray/valuesEqual<~lib/typedarray/Int16Array>
   i32.const 1
   drop
-  local.get $3
+  local.get $a
   global.get $std/typedarray/setSource3
   local.set $6
   global.get $~lib/memory/__stack_pointer
@@ -55159,7 +55159,7 @@
   local.get $6
   i32.const 2
   call $~lib/typedarray/Int16Array#set<~lib/array/Array<f64>>
-  local.get $3
+  local.get $a
   i32.const 10
   i32.const 1
   i32.const 64
@@ -55171,15 +55171,15 @@
   i32.store $0 offset=16
   local.get $6
   call $std/typedarray/valuesEqual<~lib/typedarray/Int16Array>
-  local.get $3
-  local.get $1
+  local.get $a
+  local.get $setSource5
   i32.const 0
   call $~lib/typedarray/Int16Array#set<~lib/typedarray/Uint8Array>
-  local.get $3
-  local.get $2
+  local.get $a
+  local.get $setSource6
   i32.const 4
   call $~lib/typedarray/Int16Array#set<~lib/typedarray/Int16Array>
-  local.get $3
+  local.get $a
   global.get $std/typedarray/setSource7
   local.set $6
   global.get $~lib/memory/__stack_pointer
@@ -55190,7 +55190,7 @@
   call $~lib/typedarray/Int16Array#set<~lib/array/Array<i8>>
   i32.const 0
   drop
-  local.get $3
+  local.get $a
   i32.const 10
   i32.const 1
   i32.const 64
@@ -55207,12 +55207,12 @@
   i32.add
   global.set $~lib/memory/__stack_pointer
  )
- (func $std/typedarray/valuesEqual<~lib/typedarray/Uint16Array> (param $0 i32) (param $1 i32)
-  (local $2 i32)
-  (local $3 i32)
-  (local $4 i32)
-  (local $5 i32)
-  (local $6 i32)
+ (func $std/typedarray/valuesEqual<~lib/typedarray/Uint16Array> (param $target i32) (param $compare i32)
+  (local $len i32)
+  (local $var$3 i32)
+  (local $var$4 i32)
+  (local $var$5 i32)
+  (local $var$6 i32)
   (local $7 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -55222,11 +55222,11 @@
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   i32.store $0
-  local.get $0
+  local.get $target
   call $~lib/typedarray/Uint16Array#get:length
-  local.set $2
-  local.get $2
-  local.get $1
+  local.set $len
+  local.get $len
+  local.get $compare
   call $~lib/array/Array<u16>#get:length
   i32.eq
   i32.eqz
@@ -55239,24 +55239,24 @@
    unreachable
   end
   i32.const 0
-  local.set $3
+  local.set $var$3
   loop $for-loop|0
-   local.get $3
-   local.get $2
+   local.get $var$3
+   local.get $len
    i32.lt_s
-   local.set $4
-   local.get $4
+   local.set $var$4
+   local.get $var$4
    if
-    local.get $0
-    local.get $3
+    local.get $target
+    local.get $var$3
     call $~lib/typedarray/Uint16Array#__uget
-    local.set $5
-    local.get $1
-    local.get $3
+    local.set $var$5
+    local.get $compare
+    local.get $var$3
     call $~lib/array/Array<u16>#__uget
-    local.set $6
-    local.get $5
-    local.get $6
+    local.set $var$6
+    local.get $var$5
+    local.get $var$6
     i32.ne
     if
      i32.const 11264
@@ -55266,11 +55266,11 @@
      i32.store $0
      local.get $7
      i32.const 3
-     local.get $3
+     local.get $var$3
      f64.convert_i32_s
-     local.get $5
+     local.get $var$5
      f64.convert_i32_u
-     local.get $6
+     local.get $var$6
      f64.convert_i32_u
      f64.const 0
      f64.const 0
@@ -55286,10 +55286,10 @@
       unreachable
      end
     end
-    local.get $3
+    local.get $var$3
     i32.const 1
     i32.add
-    local.set $3
+    local.set $var$3
     br $for-loop|0
    end
   end
@@ -55299,12 +55299,12 @@
   global.set $~lib/memory/__stack_pointer
  )
  (func $std/typedarray/testTypedArraySet<~lib/typedarray/Uint16Array>
-  (local $0 i32)
-  (local $1 i32)
-  (local $2 i32)
-  (local $3 i32)
-  (local $4 i32)
-  (local $5 i32)
+  (local $setSource4 i32)
+  (local $setSource5 i32)
+  (local $setSource6 i32)
+  (local $a i32)
+  (local $var$4 i32)
+  (local $var$5 i32)
   (local $6 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 20
@@ -55319,17 +55319,17 @@
   i32.const 0
   i32.const 3
   call $~lib/typedarray/Int64Array#constructor
-  local.tee $0
+  local.tee $setSource4
   i32.store $0
-  local.get $0
+  local.get $setSource4
   i32.const 0
   i64.const 7
   call $~lib/typedarray/Int64Array#__set
-  local.get $0
+  local.get $setSource4
   i32.const 1
   i64.const 8
   call $~lib/typedarray/Int64Array#__set
-  local.get $0
+  local.get $setSource4
   i32.const 2
   i64.const 9
   call $~lib/typedarray/Int64Array#__set
@@ -55337,21 +55337,21 @@
   i32.const 0
   i32.const 4
   call $~lib/typedarray/Uint8Array#constructor
-  local.tee $1
+  local.tee $setSource5
   i32.store $0 offset=4
-  local.get $1
+  local.get $setSource5
   i32.const 0
   i32.const 100
   call $~lib/typedarray/Uint8Array#__set
-  local.get $1
+  local.get $setSource5
   i32.const 1
   i32.const 101
   call $~lib/typedarray/Uint8Array#__set
-  local.get $1
+  local.get $setSource5
   i32.const 2
   i32.const 102
   call $~lib/typedarray/Uint8Array#__set
-  local.get $1
+  local.get $setSource5
   i32.const 3
   i32.const 103
   call $~lib/typedarray/Uint8Array#__set
@@ -55359,17 +55359,17 @@
   i32.const 0
   i32.const 3
   call $~lib/typedarray/Int16Array#constructor
-  local.tee $2
+  local.tee $setSource6
   i32.store $0 offset=8
-  local.get $2
+  local.get $setSource6
   i32.const 0
   i32.const 1000
   call $~lib/typedarray/Int16Array#__set
-  local.get $2
+  local.get $setSource6
   i32.const 1
   i32.const 1001
   call $~lib/typedarray/Int16Array#__set
-  local.get $2
+  local.get $setSource6
   i32.const 2
   i32.const 1002
   call $~lib/typedarray/Int16Array#__set
@@ -55377,9 +55377,9 @@
   i32.const 0
   i32.const 10
   call $~lib/typedarray/Uint16Array#constructor
-  local.tee $3
+  local.tee $a
   i32.store $0 offset=12
-  local.get $3
+  local.get $a
   global.get $std/typedarray/setSource1
   local.set $6
   global.get $~lib/memory/__stack_pointer
@@ -55388,7 +55388,7 @@
   local.get $6
   i32.const 0
   call $~lib/typedarray/Uint16Array#set<~lib/array/Array<i32>>
-  local.get $3
+  local.get $a
   i32.const 10
   i32.const 1
   i32.const 65
@@ -55400,7 +55400,7 @@
   i32.store $0 offset=16
   local.get $6
   call $std/typedarray/valuesEqual<~lib/typedarray/Uint16Array>
-  local.get $3
+  local.get $a
   global.get $std/typedarray/setSource2
   local.set $6
   global.get $~lib/memory/__stack_pointer
@@ -55409,7 +55409,7 @@
   local.get $6
   i32.const 3
   call $~lib/typedarray/Uint16Array#set<~lib/array/Array<f32>>
-  local.get $3
+  local.get $a
   i32.const 10
   i32.const 1
   i32.const 65
@@ -55421,11 +55421,11 @@
   i32.store $0 offset=16
   local.get $6
   call $std/typedarray/valuesEqual<~lib/typedarray/Uint16Array>
-  local.get $3
-  local.get $0
+  local.get $a
+  local.get $setSource4
   i32.const 6
   call $~lib/typedarray/Uint16Array#set<~lib/typedarray/Int64Array>
-  local.get $3
+  local.get $a
   i32.const 10
   i32.const 1
   i32.const 65
@@ -55439,7 +55439,7 @@
   call $std/typedarray/valuesEqual<~lib/typedarray/Uint16Array>
   i32.const 1
   drop
-  local.get $3
+  local.get $a
   global.get $std/typedarray/setSource3
   local.set $6
   global.get $~lib/memory/__stack_pointer
@@ -55448,7 +55448,7 @@
   local.get $6
   i32.const 2
   call $~lib/typedarray/Uint16Array#set<~lib/array/Array<f64>>
-  local.get $3
+  local.get $a
   i32.const 10
   i32.const 1
   i32.const 65
@@ -55460,15 +55460,15 @@
   i32.store $0 offset=16
   local.get $6
   call $std/typedarray/valuesEqual<~lib/typedarray/Uint16Array>
-  local.get $3
-  local.get $1
+  local.get $a
+  local.get $setSource5
   i32.const 0
   call $~lib/typedarray/Uint16Array#set<~lib/typedarray/Uint8Array>
-  local.get $3
-  local.get $2
+  local.get $a
+  local.get $setSource6
   i32.const 4
   call $~lib/typedarray/Uint16Array#set<~lib/typedarray/Int16Array>
-  local.get $3
+  local.get $a
   global.get $std/typedarray/setSource7
   local.set $6
   global.get $~lib/memory/__stack_pointer
@@ -55479,7 +55479,7 @@
   call $~lib/typedarray/Uint16Array#set<~lib/array/Array<i8>>
   i32.const 0
   drop
-  local.get $3
+  local.get $a
   i32.const 10
   i32.const 1
   i32.const 65
@@ -55496,12 +55496,12 @@
   i32.add
   global.set $~lib/memory/__stack_pointer
  )
- (func $std/typedarray/valuesEqual<~lib/typedarray/Int32Array> (param $0 i32) (param $1 i32)
-  (local $2 i32)
-  (local $3 i32)
-  (local $4 i32)
-  (local $5 i32)
-  (local $6 i32)
+ (func $std/typedarray/valuesEqual<~lib/typedarray/Int32Array> (param $target i32) (param $compare i32)
+  (local $len i32)
+  (local $var$3 i32)
+  (local $var$4 i32)
+  (local $var$5 i32)
+  (local $var$6 i32)
   (local $7 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -55511,11 +55511,11 @@
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   i32.store $0
-  local.get $0
+  local.get $target
   call $~lib/typedarray/Int32Array#get:length
-  local.set $2
-  local.get $2
-  local.get $1
+  local.set $len
+  local.get $len
+  local.get $compare
   call $~lib/array/Array<i32>#get:length
   i32.eq
   i32.eqz
@@ -55528,24 +55528,24 @@
    unreachable
   end
   i32.const 0
-  local.set $3
+  local.set $var$3
   loop $for-loop|0
-   local.get $3
-   local.get $2
+   local.get $var$3
+   local.get $len
    i32.lt_s
-   local.set $4
-   local.get $4
+   local.set $var$4
+   local.get $var$4
    if
-    local.get $0
-    local.get $3
+    local.get $target
+    local.get $var$3
     call $~lib/typedarray/Int32Array#__uget
-    local.set $5
-    local.get $1
-    local.get $3
+    local.set $var$5
+    local.get $compare
+    local.get $var$3
     call $~lib/array/Array<i32>#__uget
-    local.set $6
-    local.get $5
-    local.get $6
+    local.set $var$6
+    local.get $var$5
+    local.get $var$6
     i32.ne
     if
      i32.const 11568
@@ -55555,11 +55555,11 @@
      i32.store $0
      local.get $7
      i32.const 3
-     local.get $3
+     local.get $var$3
      f64.convert_i32_s
-     local.get $5
+     local.get $var$5
      f64.convert_i32_s
-     local.get $6
+     local.get $var$6
      f64.convert_i32_s
      f64.const 0
      f64.const 0
@@ -55575,10 +55575,10 @@
       unreachable
      end
     end
-    local.get $3
+    local.get $var$3
     i32.const 1
     i32.add
-    local.set $3
+    local.set $var$3
     br $for-loop|0
    end
   end
@@ -55588,12 +55588,12 @@
   global.set $~lib/memory/__stack_pointer
  )
  (func $std/typedarray/testTypedArraySet<~lib/typedarray/Int32Array>
-  (local $0 i32)
-  (local $1 i32)
-  (local $2 i32)
-  (local $3 i32)
-  (local $4 i32)
-  (local $5 i32)
+  (local $setSource4 i32)
+  (local $setSource5 i32)
+  (local $setSource6 i32)
+  (local $a i32)
+  (local $var$4 i32)
+  (local $var$5 i32)
   (local $6 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 20
@@ -55608,17 +55608,17 @@
   i32.const 0
   i32.const 3
   call $~lib/typedarray/Int64Array#constructor
-  local.tee $0
+  local.tee $setSource4
   i32.store $0
-  local.get $0
+  local.get $setSource4
   i32.const 0
   i64.const 7
   call $~lib/typedarray/Int64Array#__set
-  local.get $0
+  local.get $setSource4
   i32.const 1
   i64.const 8
   call $~lib/typedarray/Int64Array#__set
-  local.get $0
+  local.get $setSource4
   i32.const 2
   i64.const 9
   call $~lib/typedarray/Int64Array#__set
@@ -55626,21 +55626,21 @@
   i32.const 0
   i32.const 4
   call $~lib/typedarray/Uint8Array#constructor
-  local.tee $1
+  local.tee $setSource5
   i32.store $0 offset=4
-  local.get $1
+  local.get $setSource5
   i32.const 0
   i32.const 100
   call $~lib/typedarray/Uint8Array#__set
-  local.get $1
+  local.get $setSource5
   i32.const 1
   i32.const 101
   call $~lib/typedarray/Uint8Array#__set
-  local.get $1
+  local.get $setSource5
   i32.const 2
   i32.const 102
   call $~lib/typedarray/Uint8Array#__set
-  local.get $1
+  local.get $setSource5
   i32.const 3
   i32.const 103
   call $~lib/typedarray/Uint8Array#__set
@@ -55648,17 +55648,17 @@
   i32.const 0
   i32.const 3
   call $~lib/typedarray/Int16Array#constructor
-  local.tee $2
+  local.tee $setSource6
   i32.store $0 offset=8
-  local.get $2
+  local.get $setSource6
   i32.const 0
   i32.const 1000
   call $~lib/typedarray/Int16Array#__set
-  local.get $2
+  local.get $setSource6
   i32.const 1
   i32.const 1001
   call $~lib/typedarray/Int16Array#__set
-  local.get $2
+  local.get $setSource6
   i32.const 2
   i32.const 1002
   call $~lib/typedarray/Int16Array#__set
@@ -55666,9 +55666,9 @@
   i32.const 0
   i32.const 10
   call $~lib/typedarray/Int32Array#constructor
-  local.tee $3
+  local.tee $a
   i32.store $0 offset=12
-  local.get $3
+  local.get $a
   global.get $std/typedarray/setSource1
   local.set $6
   global.get $~lib/memory/__stack_pointer
@@ -55677,7 +55677,7 @@
   local.get $6
   i32.const 0
   call $~lib/typedarray/Int32Array#set<~lib/array/Array<i32>>
-  local.get $3
+  local.get $a
   i32.const 10
   i32.const 2
   i32.const 16
@@ -55689,7 +55689,7 @@
   i32.store $0 offset=16
   local.get $6
   call $std/typedarray/valuesEqual<~lib/typedarray/Int32Array>
-  local.get $3
+  local.get $a
   global.get $std/typedarray/setSource2
   local.set $6
   global.get $~lib/memory/__stack_pointer
@@ -55698,7 +55698,7 @@
   local.get $6
   i32.const 3
   call $~lib/typedarray/Int32Array#set<~lib/array/Array<f32>>
-  local.get $3
+  local.get $a
   i32.const 10
   i32.const 2
   i32.const 16
@@ -55710,11 +55710,11 @@
   i32.store $0 offset=16
   local.get $6
   call $std/typedarray/valuesEqual<~lib/typedarray/Int32Array>
-  local.get $3
-  local.get $0
+  local.get $a
+  local.get $setSource4
   i32.const 6
   call $~lib/typedarray/Int32Array#set<~lib/typedarray/Int64Array>
-  local.get $3
+  local.get $a
   i32.const 10
   i32.const 2
   i32.const 16
@@ -55728,7 +55728,7 @@
   call $std/typedarray/valuesEqual<~lib/typedarray/Int32Array>
   i32.const 1
   drop
-  local.get $3
+  local.get $a
   global.get $std/typedarray/setSource3
   local.set $6
   global.get $~lib/memory/__stack_pointer
@@ -55737,7 +55737,7 @@
   local.get $6
   i32.const 2
   call $~lib/typedarray/Int32Array#set<~lib/array/Array<f64>>
-  local.get $3
+  local.get $a
   i32.const 10
   i32.const 2
   i32.const 16
@@ -55749,15 +55749,15 @@
   i32.store $0 offset=16
   local.get $6
   call $std/typedarray/valuesEqual<~lib/typedarray/Int32Array>
-  local.get $3
-  local.get $1
+  local.get $a
+  local.get $setSource5
   i32.const 0
   call $~lib/typedarray/Int32Array#set<~lib/typedarray/Uint8Array>
-  local.get $3
-  local.get $2
+  local.get $a
+  local.get $setSource6
   i32.const 4
   call $~lib/typedarray/Int32Array#set<~lib/typedarray/Int16Array>
-  local.get $3
+  local.get $a
   global.get $std/typedarray/setSource7
   local.set $6
   global.get $~lib/memory/__stack_pointer
@@ -55768,7 +55768,7 @@
   call $~lib/typedarray/Int32Array#set<~lib/array/Array<i8>>
   i32.const 0
   drop
-  local.get $3
+  local.get $a
   i32.const 10
   i32.const 2
   i32.const 16
@@ -55785,12 +55785,12 @@
   i32.add
   global.set $~lib/memory/__stack_pointer
  )
- (func $std/typedarray/valuesEqual<~lib/typedarray/Uint32Array> (param $0 i32) (param $1 i32)
-  (local $2 i32)
-  (local $3 i32)
-  (local $4 i32)
-  (local $5 i32)
-  (local $6 i32)
+ (func $std/typedarray/valuesEqual<~lib/typedarray/Uint32Array> (param $target i32) (param $compare i32)
+  (local $len i32)
+  (local $var$3 i32)
+  (local $var$4 i32)
+  (local $var$5 i32)
+  (local $var$6 i32)
   (local $7 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -55800,11 +55800,11 @@
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   i32.store $0
-  local.get $0
+  local.get $target
   call $~lib/typedarray/Uint32Array#get:length
-  local.set $2
-  local.get $2
-  local.get $1
+  local.set $len
+  local.get $len
+  local.get $compare
   call $~lib/array/Array<u32>#get:length
   i32.eq
   i32.eqz
@@ -55817,24 +55817,24 @@
    unreachable
   end
   i32.const 0
-  local.set $3
+  local.set $var$3
   loop $for-loop|0
-   local.get $3
-   local.get $2
+   local.get $var$3
+   local.get $len
    i32.lt_s
-   local.set $4
-   local.get $4
+   local.set $var$4
+   local.get $var$4
    if
-    local.get $0
-    local.get $3
+    local.get $target
+    local.get $var$3
     call $~lib/typedarray/Uint32Array#__uget
-    local.set $5
-    local.get $1
-    local.get $3
+    local.set $var$5
+    local.get $compare
+    local.get $var$3
     call $~lib/array/Array<u32>#__uget
-    local.set $6
-    local.get $5
-    local.get $6
+    local.set $var$6
+    local.get $var$5
+    local.get $var$6
     i32.ne
     if
      i32.const 11936
@@ -55844,11 +55844,11 @@
      i32.store $0
      local.get $7
      i32.const 3
-     local.get $3
+     local.get $var$3
      f64.convert_i32_s
-     local.get $5
+     local.get $var$5
      f64.convert_i32_u
-     local.get $6
+     local.get $var$6
      f64.convert_i32_u
      f64.const 0
      f64.const 0
@@ -55864,10 +55864,10 @@
       unreachable
      end
     end
-    local.get $3
+    local.get $var$3
     i32.const 1
     i32.add
-    local.set $3
+    local.set $var$3
     br $for-loop|0
    end
   end
@@ -55877,12 +55877,12 @@
   global.set $~lib/memory/__stack_pointer
  )
  (func $std/typedarray/testTypedArraySet<~lib/typedarray/Uint32Array>
-  (local $0 i32)
-  (local $1 i32)
-  (local $2 i32)
-  (local $3 i32)
-  (local $4 i32)
-  (local $5 i32)
+  (local $setSource4 i32)
+  (local $setSource5 i32)
+  (local $setSource6 i32)
+  (local $a i32)
+  (local $var$4 i32)
+  (local $var$5 i32)
   (local $6 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 20
@@ -55897,17 +55897,17 @@
   i32.const 0
   i32.const 3
   call $~lib/typedarray/Int64Array#constructor
-  local.tee $0
+  local.tee $setSource4
   i32.store $0
-  local.get $0
+  local.get $setSource4
   i32.const 0
   i64.const 7
   call $~lib/typedarray/Int64Array#__set
-  local.get $0
+  local.get $setSource4
   i32.const 1
   i64.const 8
   call $~lib/typedarray/Int64Array#__set
-  local.get $0
+  local.get $setSource4
   i32.const 2
   i64.const 9
   call $~lib/typedarray/Int64Array#__set
@@ -55915,21 +55915,21 @@
   i32.const 0
   i32.const 4
   call $~lib/typedarray/Uint8Array#constructor
-  local.tee $1
+  local.tee $setSource5
   i32.store $0 offset=4
-  local.get $1
+  local.get $setSource5
   i32.const 0
   i32.const 100
   call $~lib/typedarray/Uint8Array#__set
-  local.get $1
+  local.get $setSource5
   i32.const 1
   i32.const 101
   call $~lib/typedarray/Uint8Array#__set
-  local.get $1
+  local.get $setSource5
   i32.const 2
   i32.const 102
   call $~lib/typedarray/Uint8Array#__set
-  local.get $1
+  local.get $setSource5
   i32.const 3
   i32.const 103
   call $~lib/typedarray/Uint8Array#__set
@@ -55937,17 +55937,17 @@
   i32.const 0
   i32.const 3
   call $~lib/typedarray/Int16Array#constructor
-  local.tee $2
+  local.tee $setSource6
   i32.store $0 offset=8
-  local.get $2
+  local.get $setSource6
   i32.const 0
   i32.const 1000
   call $~lib/typedarray/Int16Array#__set
-  local.get $2
+  local.get $setSource6
   i32.const 1
   i32.const 1001
   call $~lib/typedarray/Int16Array#__set
-  local.get $2
+  local.get $setSource6
   i32.const 2
   i32.const 1002
   call $~lib/typedarray/Int16Array#__set
@@ -55955,9 +55955,9 @@
   i32.const 0
   i32.const 10
   call $~lib/typedarray/Uint32Array#constructor
-  local.tee $3
+  local.tee $a
   i32.store $0 offset=12
-  local.get $3
+  local.get $a
   global.get $std/typedarray/setSource1
   local.set $6
   global.get $~lib/memory/__stack_pointer
@@ -55966,7 +55966,7 @@
   local.get $6
   i32.const 0
   call $~lib/typedarray/Uint32Array#set<~lib/array/Array<i32>>
-  local.get $3
+  local.get $a
   i32.const 10
   i32.const 2
   i32.const 66
@@ -55978,7 +55978,7 @@
   i32.store $0 offset=16
   local.get $6
   call $std/typedarray/valuesEqual<~lib/typedarray/Uint32Array>
-  local.get $3
+  local.get $a
   global.get $std/typedarray/setSource2
   local.set $6
   global.get $~lib/memory/__stack_pointer
@@ -55987,7 +55987,7 @@
   local.get $6
   i32.const 3
   call $~lib/typedarray/Uint32Array#set<~lib/array/Array<f32>>
-  local.get $3
+  local.get $a
   i32.const 10
   i32.const 2
   i32.const 66
@@ -55999,11 +55999,11 @@
   i32.store $0 offset=16
   local.get $6
   call $std/typedarray/valuesEqual<~lib/typedarray/Uint32Array>
-  local.get $3
-  local.get $0
+  local.get $a
+  local.get $setSource4
   i32.const 6
   call $~lib/typedarray/Uint32Array#set<~lib/typedarray/Int64Array>
-  local.get $3
+  local.get $a
   i32.const 10
   i32.const 2
   i32.const 66
@@ -56017,7 +56017,7 @@
   call $std/typedarray/valuesEqual<~lib/typedarray/Uint32Array>
   i32.const 1
   drop
-  local.get $3
+  local.get $a
   global.get $std/typedarray/setSource3
   local.set $6
   global.get $~lib/memory/__stack_pointer
@@ -56026,7 +56026,7 @@
   local.get $6
   i32.const 2
   call $~lib/typedarray/Uint32Array#set<~lib/array/Array<f64>>
-  local.get $3
+  local.get $a
   i32.const 10
   i32.const 2
   i32.const 66
@@ -56038,15 +56038,15 @@
   i32.store $0 offset=16
   local.get $6
   call $std/typedarray/valuesEqual<~lib/typedarray/Uint32Array>
-  local.get $3
-  local.get $1
+  local.get $a
+  local.get $setSource5
   i32.const 0
   call $~lib/typedarray/Uint32Array#set<~lib/typedarray/Uint8Array>
-  local.get $3
-  local.get $2
+  local.get $a
+  local.get $setSource6
   i32.const 4
   call $~lib/typedarray/Uint32Array#set<~lib/typedarray/Int16Array>
-  local.get $3
+  local.get $a
   global.get $std/typedarray/setSource7
   local.set $6
   global.get $~lib/memory/__stack_pointer
@@ -56057,7 +56057,7 @@
   call $~lib/typedarray/Uint32Array#set<~lib/array/Array<i8>>
   i32.const 0
   drop
-  local.get $3
+  local.get $a
   i32.const 10
   i32.const 2
   i32.const 66
@@ -56074,12 +56074,12 @@
   i32.add
   global.set $~lib/memory/__stack_pointer
  )
- (func $std/typedarray/valuesEqual<~lib/typedarray/Int64Array> (param $0 i32) (param $1 i32)
-  (local $2 i32)
-  (local $3 i32)
-  (local $4 i32)
-  (local $5 i64)
-  (local $6 i64)
+ (func $std/typedarray/valuesEqual<~lib/typedarray/Int64Array> (param $target i32) (param $compare i32)
+  (local $len i32)
+  (local $var$3 i32)
+  (local $var$4 i32)
+  (local $var$5 i64)
+  (local $var$6 i64)
   (local $7 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -56089,11 +56089,11 @@
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   i32.store $0
-  local.get $0
+  local.get $target
   call $~lib/typedarray/Int64Array#get:length
-  local.set $2
-  local.get $2
-  local.get $1
+  local.set $len
+  local.get $len
+  local.get $compare
   call $~lib/array/Array<i64>#get:length
   i32.eq
   i32.eqz
@@ -56106,24 +56106,24 @@
    unreachable
   end
   i32.const 0
-  local.set $3
+  local.set $var$3
   loop $for-loop|0
-   local.get $3
-   local.get $2
+   local.get $var$3
+   local.get $len
    i32.lt_s
-   local.set $4
-   local.get $4
+   local.set $var$4
+   local.get $var$4
    if
-    local.get $0
-    local.get $3
+    local.get $target
+    local.get $var$3
     call $~lib/typedarray/Int64Array#__uget
-    local.set $5
-    local.get $1
-    local.get $3
+    local.set $var$5
+    local.get $compare
+    local.get $var$3
     call $~lib/array/Array<i64>#__uget
-    local.set $6
-    local.get $5
-    local.get $6
+    local.set $var$6
+    local.get $var$5
+    local.get $var$6
     i64.ne
     if
      i32.const 12352
@@ -56133,11 +56133,11 @@
      i32.store $0
      local.get $7
      i32.const 3
-     local.get $3
+     local.get $var$3
      f64.convert_i32_s
-     local.get $5
+     local.get $var$5
      f64.convert_i64_s
-     local.get $6
+     local.get $var$6
      f64.convert_i64_s
      f64.const 0
      f64.const 0
@@ -56153,10 +56153,10 @@
       unreachable
      end
     end
-    local.get $3
+    local.get $var$3
     i32.const 1
     i32.add
-    local.set $3
+    local.set $var$3
     br $for-loop|0
    end
   end
@@ -56166,12 +56166,12 @@
   global.set $~lib/memory/__stack_pointer
  )
  (func $std/typedarray/testTypedArraySet<~lib/typedarray/Int64Array>
-  (local $0 i32)
-  (local $1 i32)
-  (local $2 i32)
-  (local $3 i32)
-  (local $4 i32)
-  (local $5 i32)
+  (local $setSource4 i32)
+  (local $setSource5 i32)
+  (local $setSource6 i32)
+  (local $a i32)
+  (local $var$4 i32)
+  (local $var$5 i32)
   (local $6 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 20
@@ -56186,17 +56186,17 @@
   i32.const 0
   i32.const 3
   call $~lib/typedarray/Int64Array#constructor
-  local.tee $0
+  local.tee $setSource4
   i32.store $0
-  local.get $0
+  local.get $setSource4
   i32.const 0
   i64.const 7
   call $~lib/typedarray/Int64Array#__set
-  local.get $0
+  local.get $setSource4
   i32.const 1
   i64.const 8
   call $~lib/typedarray/Int64Array#__set
-  local.get $0
+  local.get $setSource4
   i32.const 2
   i64.const 9
   call $~lib/typedarray/Int64Array#__set
@@ -56204,21 +56204,21 @@
   i32.const 0
   i32.const 4
   call $~lib/typedarray/Uint8Array#constructor
-  local.tee $1
+  local.tee $setSource5
   i32.store $0 offset=4
-  local.get $1
+  local.get $setSource5
   i32.const 0
   i32.const 100
   call $~lib/typedarray/Uint8Array#__set
-  local.get $1
+  local.get $setSource5
   i32.const 1
   i32.const 101
   call $~lib/typedarray/Uint8Array#__set
-  local.get $1
+  local.get $setSource5
   i32.const 2
   i32.const 102
   call $~lib/typedarray/Uint8Array#__set
-  local.get $1
+  local.get $setSource5
   i32.const 3
   i32.const 103
   call $~lib/typedarray/Uint8Array#__set
@@ -56226,17 +56226,17 @@
   i32.const 0
   i32.const 3
   call $~lib/typedarray/Int16Array#constructor
-  local.tee $2
+  local.tee $setSource6
   i32.store $0 offset=8
-  local.get $2
+  local.get $setSource6
   i32.const 0
   i32.const 1000
   call $~lib/typedarray/Int16Array#__set
-  local.get $2
+  local.get $setSource6
   i32.const 1
   i32.const 1001
   call $~lib/typedarray/Int16Array#__set
-  local.get $2
+  local.get $setSource6
   i32.const 2
   i32.const 1002
   call $~lib/typedarray/Int16Array#__set
@@ -56244,9 +56244,9 @@
   i32.const 0
   i32.const 10
   call $~lib/typedarray/Int64Array#constructor
-  local.tee $3
+  local.tee $a
   i32.store $0 offset=12
-  local.get $3
+  local.get $a
   global.get $std/typedarray/setSource1
   local.set $6
   global.get $~lib/memory/__stack_pointer
@@ -56255,7 +56255,7 @@
   local.get $6
   i32.const 0
   call $~lib/typedarray/Int64Array#set<~lib/array/Array<i32>>
-  local.get $3
+  local.get $a
   i32.const 10
   i32.const 3
   i32.const 67
@@ -56267,7 +56267,7 @@
   i32.store $0 offset=16
   local.get $6
   call $std/typedarray/valuesEqual<~lib/typedarray/Int64Array>
-  local.get $3
+  local.get $a
   global.get $std/typedarray/setSource2
   local.set $6
   global.get $~lib/memory/__stack_pointer
@@ -56276,7 +56276,7 @@
   local.get $6
   i32.const 3
   call $~lib/typedarray/Int64Array#set<~lib/array/Array<f32>>
-  local.get $3
+  local.get $a
   i32.const 10
   i32.const 3
   i32.const 67
@@ -56288,11 +56288,11 @@
   i32.store $0 offset=16
   local.get $6
   call $std/typedarray/valuesEqual<~lib/typedarray/Int64Array>
-  local.get $3
-  local.get $0
+  local.get $a
+  local.get $setSource4
   i32.const 6
   call $~lib/typedarray/Int64Array#set<~lib/typedarray/Int64Array>
-  local.get $3
+  local.get $a
   i32.const 10
   i32.const 3
   i32.const 67
@@ -56306,7 +56306,7 @@
   call $std/typedarray/valuesEqual<~lib/typedarray/Int64Array>
   i32.const 1
   drop
-  local.get $3
+  local.get $a
   global.get $std/typedarray/setSource3
   local.set $6
   global.get $~lib/memory/__stack_pointer
@@ -56315,7 +56315,7 @@
   local.get $6
   i32.const 2
   call $~lib/typedarray/Int64Array#set<~lib/array/Array<f64>>
-  local.get $3
+  local.get $a
   i32.const 10
   i32.const 3
   i32.const 67
@@ -56327,15 +56327,15 @@
   i32.store $0 offset=16
   local.get $6
   call $std/typedarray/valuesEqual<~lib/typedarray/Int64Array>
-  local.get $3
-  local.get $1
+  local.get $a
+  local.get $setSource5
   i32.const 0
   call $~lib/typedarray/Int64Array#set<~lib/typedarray/Uint8Array>
-  local.get $3
-  local.get $2
+  local.get $a
+  local.get $setSource6
   i32.const 4
   call $~lib/typedarray/Int64Array#set<~lib/typedarray/Int16Array>
-  local.get $3
+  local.get $a
   global.get $std/typedarray/setSource7
   local.set $6
   global.get $~lib/memory/__stack_pointer
@@ -56346,7 +56346,7 @@
   call $~lib/typedarray/Int64Array#set<~lib/array/Array<i8>>
   i32.const 0
   drop
-  local.get $3
+  local.get $a
   i32.const 10
   i32.const 3
   i32.const 67
@@ -56363,12 +56363,12 @@
   i32.add
   global.set $~lib/memory/__stack_pointer
  )
- (func $std/typedarray/valuesEqual<~lib/typedarray/Uint64Array> (param $0 i32) (param $1 i32)
-  (local $2 i32)
-  (local $3 i32)
-  (local $4 i32)
-  (local $5 i64)
-  (local $6 i64)
+ (func $std/typedarray/valuesEqual<~lib/typedarray/Uint64Array> (param $target i32) (param $compare i32)
+  (local $len i32)
+  (local $var$3 i32)
+  (local $var$4 i32)
+  (local $var$5 i64)
+  (local $var$6 i64)
   (local $7 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -56378,11 +56378,11 @@
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   i32.store $0
-  local.get $0
+  local.get $target
   call $~lib/typedarray/Uint64Array#get:length
-  local.set $2
-  local.get $2
-  local.get $1
+  local.set $len
+  local.get $len
+  local.get $compare
   call $~lib/array/Array<u64>#get:length
   i32.eq
   i32.eqz
@@ -56395,24 +56395,24 @@
    unreachable
   end
   i32.const 0
-  local.set $3
+  local.set $var$3
   loop $for-loop|0
-   local.get $3
-   local.get $2
+   local.get $var$3
+   local.get $len
    i32.lt_s
-   local.set $4
-   local.get $4
+   local.set $var$4
+   local.get $var$4
    if
-    local.get $0
-    local.get $3
+    local.get $target
+    local.get $var$3
     call $~lib/typedarray/Uint64Array#__uget
-    local.set $5
-    local.get $1
-    local.get $3
+    local.set $var$5
+    local.get $compare
+    local.get $var$3
     call $~lib/array/Array<u64>#__uget
-    local.set $6
-    local.get $5
-    local.get $6
+    local.set $var$6
+    local.get $var$5
+    local.get $var$6
     i64.ne
     if
      i32.const 12960
@@ -56422,11 +56422,11 @@
      i32.store $0
      local.get $7
      i32.const 3
-     local.get $3
+     local.get $var$3
      f64.convert_i32_s
-     local.get $5
+     local.get $var$5
      f64.convert_i64_u
-     local.get $6
+     local.get $var$6
      f64.convert_i64_u
      f64.const 0
      f64.const 0
@@ -56442,10 +56442,10 @@
       unreachable
      end
     end
-    local.get $3
+    local.get $var$3
     i32.const 1
     i32.add
-    local.set $3
+    local.set $var$3
     br $for-loop|0
    end
   end
@@ -56455,12 +56455,12 @@
   global.set $~lib/memory/__stack_pointer
  )
  (func $std/typedarray/testTypedArraySet<~lib/typedarray/Uint64Array>
-  (local $0 i32)
-  (local $1 i32)
-  (local $2 i32)
-  (local $3 i32)
-  (local $4 i32)
-  (local $5 i32)
+  (local $setSource4 i32)
+  (local $setSource5 i32)
+  (local $setSource6 i32)
+  (local $a i32)
+  (local $var$4 i32)
+  (local $var$5 i32)
   (local $6 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 20
@@ -56475,17 +56475,17 @@
   i32.const 0
   i32.const 3
   call $~lib/typedarray/Int64Array#constructor
-  local.tee $0
+  local.tee $setSource4
   i32.store $0
-  local.get $0
+  local.get $setSource4
   i32.const 0
   i64.const 7
   call $~lib/typedarray/Int64Array#__set
-  local.get $0
+  local.get $setSource4
   i32.const 1
   i64.const 8
   call $~lib/typedarray/Int64Array#__set
-  local.get $0
+  local.get $setSource4
   i32.const 2
   i64.const 9
   call $~lib/typedarray/Int64Array#__set
@@ -56493,21 +56493,21 @@
   i32.const 0
   i32.const 4
   call $~lib/typedarray/Uint8Array#constructor
-  local.tee $1
+  local.tee $setSource5
   i32.store $0 offset=4
-  local.get $1
+  local.get $setSource5
   i32.const 0
   i32.const 100
   call $~lib/typedarray/Uint8Array#__set
-  local.get $1
+  local.get $setSource5
   i32.const 1
   i32.const 101
   call $~lib/typedarray/Uint8Array#__set
-  local.get $1
+  local.get $setSource5
   i32.const 2
   i32.const 102
   call $~lib/typedarray/Uint8Array#__set
-  local.get $1
+  local.get $setSource5
   i32.const 3
   i32.const 103
   call $~lib/typedarray/Uint8Array#__set
@@ -56515,17 +56515,17 @@
   i32.const 0
   i32.const 3
   call $~lib/typedarray/Int16Array#constructor
-  local.tee $2
+  local.tee $setSource6
   i32.store $0 offset=8
-  local.get $2
+  local.get $setSource6
   i32.const 0
   i32.const 1000
   call $~lib/typedarray/Int16Array#__set
-  local.get $2
+  local.get $setSource6
   i32.const 1
   i32.const 1001
   call $~lib/typedarray/Int16Array#__set
-  local.get $2
+  local.get $setSource6
   i32.const 2
   i32.const 1002
   call $~lib/typedarray/Int16Array#__set
@@ -56533,9 +56533,9 @@
   i32.const 0
   i32.const 10
   call $~lib/typedarray/Uint64Array#constructor
-  local.tee $3
+  local.tee $a
   i32.store $0 offset=12
-  local.get $3
+  local.get $a
   global.get $std/typedarray/setSource1
   local.set $6
   global.get $~lib/memory/__stack_pointer
@@ -56544,7 +56544,7 @@
   local.get $6
   i32.const 0
   call $~lib/typedarray/Uint64Array#set<~lib/array/Array<i32>>
-  local.get $3
+  local.get $a
   i32.const 10
   i32.const 3
   i32.const 68
@@ -56556,7 +56556,7 @@
   i32.store $0 offset=16
   local.get $6
   call $std/typedarray/valuesEqual<~lib/typedarray/Uint64Array>
-  local.get $3
+  local.get $a
   global.get $std/typedarray/setSource2
   local.set $6
   global.get $~lib/memory/__stack_pointer
@@ -56565,7 +56565,7 @@
   local.get $6
   i32.const 3
   call $~lib/typedarray/Uint64Array#set<~lib/array/Array<f32>>
-  local.get $3
+  local.get $a
   i32.const 10
   i32.const 3
   i32.const 68
@@ -56577,11 +56577,11 @@
   i32.store $0 offset=16
   local.get $6
   call $std/typedarray/valuesEqual<~lib/typedarray/Uint64Array>
-  local.get $3
-  local.get $0
+  local.get $a
+  local.get $setSource4
   i32.const 6
   call $~lib/typedarray/Uint64Array#set<~lib/typedarray/Int64Array>
-  local.get $3
+  local.get $a
   i32.const 10
   i32.const 3
   i32.const 68
@@ -56595,7 +56595,7 @@
   call $std/typedarray/valuesEqual<~lib/typedarray/Uint64Array>
   i32.const 1
   drop
-  local.get $3
+  local.get $a
   global.get $std/typedarray/setSource3
   local.set $6
   global.get $~lib/memory/__stack_pointer
@@ -56604,7 +56604,7 @@
   local.get $6
   i32.const 2
   call $~lib/typedarray/Uint64Array#set<~lib/array/Array<f64>>
-  local.get $3
+  local.get $a
   i32.const 10
   i32.const 3
   i32.const 68
@@ -56616,15 +56616,15 @@
   i32.store $0 offset=16
   local.get $6
   call $std/typedarray/valuesEqual<~lib/typedarray/Uint64Array>
-  local.get $3
-  local.get $1
+  local.get $a
+  local.get $setSource5
   i32.const 0
   call $~lib/typedarray/Uint64Array#set<~lib/typedarray/Uint8Array>
-  local.get $3
-  local.get $2
+  local.get $a
+  local.get $setSource6
   i32.const 4
   call $~lib/typedarray/Uint64Array#set<~lib/typedarray/Int16Array>
-  local.get $3
+  local.get $a
   global.get $std/typedarray/setSource7
   local.set $6
   global.get $~lib/memory/__stack_pointer
@@ -56635,7 +56635,7 @@
   call $~lib/typedarray/Uint64Array#set<~lib/array/Array<i8>>
   i32.const 0
   drop
-  local.get $3
+  local.get $a
   i32.const 10
   i32.const 3
   i32.const 68
@@ -56652,12 +56652,12 @@
   i32.add
   global.set $~lib/memory/__stack_pointer
  )
- (func $std/typedarray/valuesEqual<~lib/typedarray/Float32Array> (param $0 i32) (param $1 i32)
-  (local $2 i32)
-  (local $3 i32)
-  (local $4 i32)
-  (local $5 f32)
-  (local $6 f32)
+ (func $std/typedarray/valuesEqual<~lib/typedarray/Float32Array> (param $target i32) (param $compare i32)
+  (local $len i32)
+  (local $var$3 i32)
+  (local $var$4 i32)
+  (local $var$5 f32)
+  (local $var$6 f32)
   (local $7 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -56667,11 +56667,11 @@
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   i32.store $0
-  local.get $0
+  local.get $target
   call $~lib/typedarray/Float32Array#get:length
-  local.set $2
-  local.get $2
-  local.get $1
+  local.set $len
+  local.get $len
+  local.get $compare
   call $~lib/array/Array<f32>#get:length
   i32.eq
   i32.eqz
@@ -56684,24 +56684,24 @@
    unreachable
   end
   i32.const 0
-  local.set $3
+  local.set $var$3
   loop $for-loop|0
-   local.get $3
-   local.get $2
+   local.get $var$3
+   local.get $len
    i32.lt_s
-   local.set $4
-   local.get $4
+   local.set $var$4
+   local.get $var$4
    if
-    local.get $0
-    local.get $3
+    local.get $target
+    local.get $var$3
     call $~lib/typedarray/Float32Array#__uget
-    local.set $5
-    local.get $1
-    local.get $3
+    local.set $var$5
+    local.get $compare
+    local.get $var$3
     call $~lib/array/Array<f32>#__uget
-    local.set $6
-    local.get $5
-    local.get $6
+    local.set $var$6
+    local.get $var$5
+    local.get $var$6
     f32.ne
     if
      i32.const 13520
@@ -56711,11 +56711,11 @@
      i32.store $0
      local.get $7
      i32.const 3
-     local.get $3
+     local.get $var$3
      f64.convert_i32_s
-     local.get $5
+     local.get $var$5
      f64.promote_f32
-     local.get $6
+     local.get $var$6
      f64.promote_f32
      f64.const 0
      f64.const 0
@@ -56731,10 +56731,10 @@
       unreachable
      end
     end
-    local.get $3
+    local.get $var$3
     i32.const 1
     i32.add
-    local.set $3
+    local.set $var$3
     br $for-loop|0
    end
   end
@@ -56744,12 +56744,12 @@
   global.set $~lib/memory/__stack_pointer
  )
  (func $std/typedarray/testTypedArraySet<~lib/typedarray/Float32Array>
-  (local $0 i32)
-  (local $1 i32)
-  (local $2 i32)
-  (local $3 i32)
-  (local $4 i32)
-  (local $5 i32)
+  (local $setSource4 i32)
+  (local $setSource5 i32)
+  (local $setSource6 i32)
+  (local $a i32)
+  (local $var$4 i32)
+  (local $var$5 i32)
   (local $6 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 20
@@ -56764,17 +56764,17 @@
   i32.const 0
   i32.const 3
   call $~lib/typedarray/Int64Array#constructor
-  local.tee $0
+  local.tee $setSource4
   i32.store $0
-  local.get $0
+  local.get $setSource4
   i32.const 0
   i64.const 7
   call $~lib/typedarray/Int64Array#__set
-  local.get $0
+  local.get $setSource4
   i32.const 1
   i64.const 8
   call $~lib/typedarray/Int64Array#__set
-  local.get $0
+  local.get $setSource4
   i32.const 2
   i64.const 9
   call $~lib/typedarray/Int64Array#__set
@@ -56782,21 +56782,21 @@
   i32.const 0
   i32.const 4
   call $~lib/typedarray/Uint8Array#constructor
-  local.tee $1
+  local.tee $setSource5
   i32.store $0 offset=4
-  local.get $1
+  local.get $setSource5
   i32.const 0
   i32.const 100
   call $~lib/typedarray/Uint8Array#__set
-  local.get $1
+  local.get $setSource5
   i32.const 1
   i32.const 101
   call $~lib/typedarray/Uint8Array#__set
-  local.get $1
+  local.get $setSource5
   i32.const 2
   i32.const 102
   call $~lib/typedarray/Uint8Array#__set
-  local.get $1
+  local.get $setSource5
   i32.const 3
   i32.const 103
   call $~lib/typedarray/Uint8Array#__set
@@ -56804,17 +56804,17 @@
   i32.const 0
   i32.const 3
   call $~lib/typedarray/Int16Array#constructor
-  local.tee $2
+  local.tee $setSource6
   i32.store $0 offset=8
-  local.get $2
+  local.get $setSource6
   i32.const 0
   i32.const 1000
   call $~lib/typedarray/Int16Array#__set
-  local.get $2
+  local.get $setSource6
   i32.const 1
   i32.const 1001
   call $~lib/typedarray/Int16Array#__set
-  local.get $2
+  local.get $setSource6
   i32.const 2
   i32.const 1002
   call $~lib/typedarray/Int16Array#__set
@@ -56822,9 +56822,9 @@
   i32.const 0
   i32.const 10
   call $~lib/typedarray/Float32Array#constructor
-  local.tee $3
+  local.tee $a
   i32.store $0 offset=12
-  local.get $3
+  local.get $a
   global.get $std/typedarray/setSource1
   local.set $6
   global.get $~lib/memory/__stack_pointer
@@ -56833,7 +56833,7 @@
   local.get $6
   i32.const 0
   call $~lib/typedarray/Float32Array#set<~lib/array/Array<i32>>
-  local.get $3
+  local.get $a
   i32.const 10
   i32.const 2
   i32.const 61
@@ -56845,7 +56845,7 @@
   i32.store $0 offset=16
   local.get $6
   call $std/typedarray/valuesEqual<~lib/typedarray/Float32Array>
-  local.get $3
+  local.get $a
   global.get $std/typedarray/setSource2
   local.set $6
   global.get $~lib/memory/__stack_pointer
@@ -56854,7 +56854,7 @@
   local.get $6
   i32.const 3
   call $~lib/typedarray/Float32Array#set<~lib/array/Array<f32>>
-  local.get $3
+  local.get $a
   i32.const 10
   i32.const 2
   i32.const 61
@@ -56866,11 +56866,11 @@
   i32.store $0 offset=16
   local.get $6
   call $std/typedarray/valuesEqual<~lib/typedarray/Float32Array>
-  local.get $3
-  local.get $0
+  local.get $a
+  local.get $setSource4
   i32.const 6
   call $~lib/typedarray/Float32Array#set<~lib/typedarray/Int64Array>
-  local.get $3
+  local.get $a
   i32.const 10
   i32.const 2
   i32.const 61
@@ -56884,15 +56884,15 @@
   call $std/typedarray/valuesEqual<~lib/typedarray/Float32Array>
   i32.const 0
   drop
-  local.get $3
-  local.get $1
+  local.get $a
+  local.get $setSource5
   i32.const 0
   call $~lib/typedarray/Float32Array#set<~lib/typedarray/Uint8Array>
-  local.get $3
-  local.get $2
+  local.get $a
+  local.get $setSource6
   i32.const 4
   call $~lib/typedarray/Float32Array#set<~lib/typedarray/Int16Array>
-  local.get $3
+  local.get $a
   global.get $std/typedarray/setSource7
   local.set $6
   global.get $~lib/memory/__stack_pointer
@@ -56903,7 +56903,7 @@
   call $~lib/typedarray/Float32Array#set<~lib/array/Array<i8>>
   i32.const 0
   drop
-  local.get $3
+  local.get $a
   i32.const 10
   i32.const 2
   i32.const 61
@@ -56920,12 +56920,12 @@
   i32.add
   global.set $~lib/memory/__stack_pointer
  )
- (func $std/typedarray/valuesEqual<~lib/typedarray/Float64Array> (param $0 i32) (param $1 i32)
-  (local $2 i32)
-  (local $3 i32)
-  (local $4 i32)
-  (local $5 f64)
-  (local $6 f64)
+ (func $std/typedarray/valuesEqual<~lib/typedarray/Float64Array> (param $target i32) (param $compare i32)
+  (local $len i32)
+  (local $var$3 i32)
+  (local $var$4 i32)
+  (local $var$5 f64)
+  (local $var$6 f64)
   (local $7 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -56935,11 +56935,11 @@
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   i32.store $0
-  local.get $0
+  local.get $target
   call $~lib/typedarray/Float64Array#get:length
-  local.set $2
-  local.get $2
-  local.get $1
+  local.set $len
+  local.get $len
+  local.get $compare
   call $~lib/array/Array<f64>#get:length
   i32.eq
   i32.eqz
@@ -56952,24 +56952,24 @@
    unreachable
   end
   i32.const 0
-  local.set $3
+  local.set $var$3
   loop $for-loop|0
-   local.get $3
-   local.get $2
+   local.get $var$3
+   local.get $len
    i32.lt_s
-   local.set $4
-   local.get $4
+   local.set $var$4
+   local.get $var$4
    if
-    local.get $0
-    local.get $3
+    local.get $target
+    local.get $var$3
     call $~lib/typedarray/Float64Array#__uget
-    local.set $5
-    local.get $1
-    local.get $3
+    local.set $var$5
+    local.get $compare
+    local.get $var$3
     call $~lib/array/Array<f64>#__uget
-    local.set $6
-    local.get $5
-    local.get $6
+    local.set $var$6
+    local.get $var$5
+    local.get $var$6
     f64.ne
     if
      i32.const 13872
@@ -56979,10 +56979,10 @@
      i32.store $0
      local.get $7
      i32.const 3
-     local.get $3
+     local.get $var$3
      f64.convert_i32_s
-     local.get $5
-     local.get $6
+     local.get $var$5
+     local.get $var$6
      f64.const 0
      f64.const 0
      call $~lib/builtins/trace
@@ -56997,10 +56997,10 @@
       unreachable
      end
     end
-    local.get $3
+    local.get $var$3
     i32.const 1
     i32.add
-    local.set $3
+    local.set $var$3
     br $for-loop|0
    end
   end
@@ -57010,12 +57010,12 @@
   global.set $~lib/memory/__stack_pointer
  )
  (func $std/typedarray/testTypedArraySet<~lib/typedarray/Float64Array>
-  (local $0 i32)
-  (local $1 i32)
-  (local $2 i32)
-  (local $3 i32)
-  (local $4 i32)
-  (local $5 i32)
+  (local $setSource4 i32)
+  (local $setSource5 i32)
+  (local $setSource6 i32)
+  (local $a i32)
+  (local $var$4 i32)
+  (local $var$5 i32)
   (local $6 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 20
@@ -57030,17 +57030,17 @@
   i32.const 0
   i32.const 3
   call $~lib/typedarray/Int64Array#constructor
-  local.tee $0
+  local.tee $setSource4
   i32.store $0
-  local.get $0
+  local.get $setSource4
   i32.const 0
   i64.const 7
   call $~lib/typedarray/Int64Array#__set
-  local.get $0
+  local.get $setSource4
   i32.const 1
   i64.const 8
   call $~lib/typedarray/Int64Array#__set
-  local.get $0
+  local.get $setSource4
   i32.const 2
   i64.const 9
   call $~lib/typedarray/Int64Array#__set
@@ -57048,21 +57048,21 @@
   i32.const 0
   i32.const 4
   call $~lib/typedarray/Uint8Array#constructor
-  local.tee $1
+  local.tee $setSource5
   i32.store $0 offset=4
-  local.get $1
+  local.get $setSource5
   i32.const 0
   i32.const 100
   call $~lib/typedarray/Uint8Array#__set
-  local.get $1
+  local.get $setSource5
   i32.const 1
   i32.const 101
   call $~lib/typedarray/Uint8Array#__set
-  local.get $1
+  local.get $setSource5
   i32.const 2
   i32.const 102
   call $~lib/typedarray/Uint8Array#__set
-  local.get $1
+  local.get $setSource5
   i32.const 3
   i32.const 103
   call $~lib/typedarray/Uint8Array#__set
@@ -57070,17 +57070,17 @@
   i32.const 0
   i32.const 3
   call $~lib/typedarray/Int16Array#constructor
-  local.tee $2
+  local.tee $setSource6
   i32.store $0 offset=8
-  local.get $2
+  local.get $setSource6
   i32.const 0
   i32.const 1000
   call $~lib/typedarray/Int16Array#__set
-  local.get $2
+  local.get $setSource6
   i32.const 1
   i32.const 1001
   call $~lib/typedarray/Int16Array#__set
-  local.get $2
+  local.get $setSource6
   i32.const 2
   i32.const 1002
   call $~lib/typedarray/Int16Array#__set
@@ -57088,9 +57088,9 @@
   i32.const 0
   i32.const 10
   call $~lib/typedarray/Float64Array#constructor
-  local.tee $3
+  local.tee $a
   i32.store $0 offset=12
-  local.get $3
+  local.get $a
   global.get $std/typedarray/setSource1
   local.set $6
   global.get $~lib/memory/__stack_pointer
@@ -57099,7 +57099,7 @@
   local.get $6
   i32.const 0
   call $~lib/typedarray/Float64Array#set<~lib/array/Array<i32>>
-  local.get $3
+  local.get $a
   i32.const 10
   i32.const 3
   i32.const 62
@@ -57111,7 +57111,7 @@
   i32.store $0 offset=16
   local.get $6
   call $std/typedarray/valuesEqual<~lib/typedarray/Float64Array>
-  local.get $3
+  local.get $a
   global.get $std/typedarray/setSource2
   local.set $6
   global.get $~lib/memory/__stack_pointer
@@ -57120,7 +57120,7 @@
   local.get $6
   i32.const 3
   call $~lib/typedarray/Float64Array#set<~lib/array/Array<f32>>
-  local.get $3
+  local.get $a
   i32.const 10
   i32.const 3
   i32.const 62
@@ -57132,11 +57132,11 @@
   i32.store $0 offset=16
   local.get $6
   call $std/typedarray/valuesEqual<~lib/typedarray/Float64Array>
-  local.get $3
-  local.get $0
+  local.get $a
+  local.get $setSource4
   i32.const 6
   call $~lib/typedarray/Float64Array#set<~lib/typedarray/Int64Array>
-  local.get $3
+  local.get $a
   i32.const 10
   i32.const 3
   i32.const 62
@@ -57150,15 +57150,15 @@
   call $std/typedarray/valuesEqual<~lib/typedarray/Float64Array>
   i32.const 0
   drop
-  local.get $3
-  local.get $1
+  local.get $a
+  local.get $setSource5
   i32.const 0
   call $~lib/typedarray/Float64Array#set<~lib/typedarray/Uint8Array>
-  local.get $3
-  local.get $2
+  local.get $a
+  local.get $setSource6
   i32.const 4
   call $~lib/typedarray/Float64Array#set<~lib/typedarray/Int16Array>
-  local.get $3
+  local.get $a
   global.get $std/typedarray/setSource7
   local.set $6
   global.get $~lib/memory/__stack_pointer
@@ -57169,7 +57169,7 @@
   call $~lib/typedarray/Float64Array#set<~lib/array/Array<i8>>
   i32.const 0
   drop
-  local.get $3
+  local.get $a
   i32.const 10
   i32.const 3
   i32.const 62
@@ -57187,8 +57187,8 @@
   global.set $~lib/memory/__stack_pointer
  )
  (func $std/typedarray/testArraySort<~lib/typedarray/Int8Array,i8>
-  (local $0 i32)
-  (local $1 i32)
+  (local $source i32)
+  (local $result i32)
   (local $2 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 12
@@ -57205,29 +57205,29 @@
   i32.const 0
   i32.const 3
   call $~lib/typedarray/Int8Array#constructor
-  local.tee $0
+  local.tee $source
   i32.store $0
-  local.get $0
+  local.get $source
   i32.const 2
   i32.const 1
   call $~lib/typedarray/Int8Array#__set
-  local.get $0
+  local.get $source
   i32.const 1
   i32.const 2
   call $~lib/typedarray/Int8Array#__set
-  local.get $0
+  local.get $source
   i32.const 0
   i32.const 3
   call $~lib/typedarray/Int8Array#__set
   global.get $~lib/memory/__stack_pointer
-  local.get $0
+  local.get $source
   i32.const 0
   global.set $~argumentsLength
   i32.const 0
   call $~lib/typedarray/Int8Array#sort@varargs
-  local.tee $1
+  local.tee $result
   i32.store $0 offset=4
-  local.get $1
+  local.get $result
   i32.const 0
   call $~lib/typedarray/Int8Array#__get
   i32.const 1
@@ -57241,7 +57241,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $1
+  local.get $result
   i32.const 1
   call $~lib/typedarray/Int8Array#__get
   i32.const 2
@@ -57255,7 +57255,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $1
+  local.get $result
   i32.const 2
   call $~lib/typedarray/Int8Array#__get
   i32.const 3
@@ -57269,7 +57269,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $1
+  local.get $result
   i32.const 14352
   local.set $2
   global.get $~lib/memory/__stack_pointer
@@ -57278,7 +57278,7 @@
   local.get $2
   call $~lib/typedarray/Int8Array#sort
   drop
-  local.get $1
+  local.get $result
   i32.const 0
   call $~lib/typedarray/Int8Array#__get
   i32.const 3
@@ -57292,7 +57292,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $1
+  local.get $result
   i32.const 1
   call $~lib/typedarray/Int8Array#__get
   i32.const 2
@@ -57306,7 +57306,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $1
+  local.get $result
   i32.const 2
   call $~lib/typedarray/Int8Array#__get
   i32.const 1
@@ -57326,8 +57326,8 @@
   global.set $~lib/memory/__stack_pointer
  )
  (func $std/typedarray/testArraySort<~lib/typedarray/Uint8Array,u8>
-  (local $0 i32)
-  (local $1 i32)
+  (local $source i32)
+  (local $result i32)
   (local $2 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 12
@@ -57344,29 +57344,29 @@
   i32.const 0
   i32.const 3
   call $~lib/typedarray/Uint8Array#constructor
-  local.tee $0
+  local.tee $source
   i32.store $0
-  local.get $0
+  local.get $source
   i32.const 2
   i32.const 1
   call $~lib/typedarray/Uint8Array#__set
-  local.get $0
+  local.get $source
   i32.const 1
   i32.const 2
   call $~lib/typedarray/Uint8Array#__set
-  local.get $0
+  local.get $source
   i32.const 0
   i32.const 3
   call $~lib/typedarray/Uint8Array#__set
   global.get $~lib/memory/__stack_pointer
-  local.get $0
+  local.get $source
   i32.const 0
   global.set $~argumentsLength
   i32.const 0
   call $~lib/typedarray/Uint8Array#sort@varargs
-  local.tee $1
+  local.tee $result
   i32.store $0 offset=4
-  local.get $1
+  local.get $result
   i32.const 0
   call $~lib/typedarray/Uint8Array#__get
   i32.const 1
@@ -57380,7 +57380,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $1
+  local.get $result
   i32.const 1
   call $~lib/typedarray/Uint8Array#__get
   i32.const 2
@@ -57394,7 +57394,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $1
+  local.get $result
   i32.const 2
   call $~lib/typedarray/Uint8Array#__get
   i32.const 3
@@ -57408,7 +57408,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $1
+  local.get $result
   i32.const 14416
   local.set $2
   global.get $~lib/memory/__stack_pointer
@@ -57417,7 +57417,7 @@
   local.get $2
   call $~lib/typedarray/Uint8Array#sort
   drop
-  local.get $1
+  local.get $result
   i32.const 0
   call $~lib/typedarray/Uint8Array#__get
   i32.const 3
@@ -57431,7 +57431,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $1
+  local.get $result
   i32.const 1
   call $~lib/typedarray/Uint8Array#__get
   i32.const 2
@@ -57445,7 +57445,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $1
+  local.get $result
   i32.const 2
   call $~lib/typedarray/Uint8Array#__get
   i32.const 1
@@ -57465,8 +57465,8 @@
   global.set $~lib/memory/__stack_pointer
  )
  (func $std/typedarray/testArraySort<~lib/typedarray/Uint8ClampedArray,u8>
-  (local $0 i32)
-  (local $1 i32)
+  (local $source i32)
+  (local $result i32)
   (local $2 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 12
@@ -57483,29 +57483,29 @@
   i32.const 0
   i32.const 3
   call $~lib/typedarray/Uint8ClampedArray#constructor
-  local.tee $0
+  local.tee $source
   i32.store $0
-  local.get $0
+  local.get $source
   i32.const 2
   i32.const 1
   call $~lib/typedarray/Uint8ClampedArray#__set
-  local.get $0
+  local.get $source
   i32.const 1
   i32.const 2
   call $~lib/typedarray/Uint8ClampedArray#__set
-  local.get $0
+  local.get $source
   i32.const 0
   i32.const 3
   call $~lib/typedarray/Uint8ClampedArray#__set
   global.get $~lib/memory/__stack_pointer
-  local.get $0
+  local.get $source
   i32.const 0
   global.set $~argumentsLength
   i32.const 0
   call $~lib/typedarray/Uint8ClampedArray#sort@varargs
-  local.tee $1
+  local.tee $result
   i32.store $0 offset=4
-  local.get $1
+  local.get $result
   i32.const 0
   call $~lib/typedarray/Uint8ClampedArray#__get
   i32.const 1
@@ -57519,7 +57519,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $1
+  local.get $result
   i32.const 1
   call $~lib/typedarray/Uint8ClampedArray#__get
   i32.const 2
@@ -57533,7 +57533,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $1
+  local.get $result
   i32.const 2
   call $~lib/typedarray/Uint8ClampedArray#__get
   i32.const 3
@@ -57547,7 +57547,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $1
+  local.get $result
   i32.const 14480
   local.set $2
   global.get $~lib/memory/__stack_pointer
@@ -57556,7 +57556,7 @@
   local.get $2
   call $~lib/typedarray/Uint8ClampedArray#sort
   drop
-  local.get $1
+  local.get $result
   i32.const 0
   call $~lib/typedarray/Uint8ClampedArray#__get
   i32.const 3
@@ -57570,7 +57570,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $1
+  local.get $result
   i32.const 1
   call $~lib/typedarray/Uint8ClampedArray#__get
   i32.const 2
@@ -57584,7 +57584,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $1
+  local.get $result
   i32.const 2
   call $~lib/typedarray/Uint8ClampedArray#__get
   i32.const 1
@@ -57604,8 +57604,8 @@
   global.set $~lib/memory/__stack_pointer
  )
  (func $std/typedarray/testArraySort<~lib/typedarray/Int16Array,i16>
-  (local $0 i32)
-  (local $1 i32)
+  (local $source i32)
+  (local $result i32)
   (local $2 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 12
@@ -57622,29 +57622,29 @@
   i32.const 0
   i32.const 3
   call $~lib/typedarray/Int16Array#constructor
-  local.tee $0
+  local.tee $source
   i32.store $0
-  local.get $0
+  local.get $source
   i32.const 2
   i32.const 1
   call $~lib/typedarray/Int16Array#__set
-  local.get $0
+  local.get $source
   i32.const 1
   i32.const 2
   call $~lib/typedarray/Int16Array#__set
-  local.get $0
+  local.get $source
   i32.const 0
   i32.const 3
   call $~lib/typedarray/Int16Array#__set
   global.get $~lib/memory/__stack_pointer
-  local.get $0
+  local.get $source
   i32.const 0
   global.set $~argumentsLength
   i32.const 0
   call $~lib/typedarray/Int16Array#sort@varargs
-  local.tee $1
+  local.tee $result
   i32.store $0 offset=4
-  local.get $1
+  local.get $result
   i32.const 0
   call $~lib/typedarray/Int16Array#__get
   i32.const 1
@@ -57658,7 +57658,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $1
+  local.get $result
   i32.const 1
   call $~lib/typedarray/Int16Array#__get
   i32.const 2
@@ -57672,7 +57672,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $1
+  local.get $result
   i32.const 2
   call $~lib/typedarray/Int16Array#__get
   i32.const 3
@@ -57686,7 +57686,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $1
+  local.get $result
   i32.const 14544
   local.set $2
   global.get $~lib/memory/__stack_pointer
@@ -57695,7 +57695,7 @@
   local.get $2
   call $~lib/typedarray/Int16Array#sort
   drop
-  local.get $1
+  local.get $result
   i32.const 0
   call $~lib/typedarray/Int16Array#__get
   i32.const 3
@@ -57709,7 +57709,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $1
+  local.get $result
   i32.const 1
   call $~lib/typedarray/Int16Array#__get
   i32.const 2
@@ -57723,7 +57723,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $1
+  local.get $result
   i32.const 2
   call $~lib/typedarray/Int16Array#__get
   i32.const 1
@@ -57743,8 +57743,8 @@
   global.set $~lib/memory/__stack_pointer
  )
  (func $std/typedarray/testArraySort<~lib/typedarray/Uint16Array,u16>
-  (local $0 i32)
-  (local $1 i32)
+  (local $source i32)
+  (local $result i32)
   (local $2 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 12
@@ -57761,29 +57761,29 @@
   i32.const 0
   i32.const 3
   call $~lib/typedarray/Uint16Array#constructor
-  local.tee $0
+  local.tee $source
   i32.store $0
-  local.get $0
+  local.get $source
   i32.const 2
   i32.const 1
   call $~lib/typedarray/Uint16Array#__set
-  local.get $0
+  local.get $source
   i32.const 1
   i32.const 2
   call $~lib/typedarray/Uint16Array#__set
-  local.get $0
+  local.get $source
   i32.const 0
   i32.const 3
   call $~lib/typedarray/Uint16Array#__set
   global.get $~lib/memory/__stack_pointer
-  local.get $0
+  local.get $source
   i32.const 0
   global.set $~argumentsLength
   i32.const 0
   call $~lib/typedarray/Uint16Array#sort@varargs
-  local.tee $1
+  local.tee $result
   i32.store $0 offset=4
-  local.get $1
+  local.get $result
   i32.const 0
   call $~lib/typedarray/Uint16Array#__get
   i32.const 1
@@ -57797,7 +57797,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $1
+  local.get $result
   i32.const 1
   call $~lib/typedarray/Uint16Array#__get
   i32.const 2
@@ -57811,7 +57811,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $1
+  local.get $result
   i32.const 2
   call $~lib/typedarray/Uint16Array#__get
   i32.const 3
@@ -57825,7 +57825,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $1
+  local.get $result
   i32.const 14608
   local.set $2
   global.get $~lib/memory/__stack_pointer
@@ -57834,7 +57834,7 @@
   local.get $2
   call $~lib/typedarray/Uint16Array#sort
   drop
-  local.get $1
+  local.get $result
   i32.const 0
   call $~lib/typedarray/Uint16Array#__get
   i32.const 3
@@ -57848,7 +57848,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $1
+  local.get $result
   i32.const 1
   call $~lib/typedarray/Uint16Array#__get
   i32.const 2
@@ -57862,7 +57862,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $1
+  local.get $result
   i32.const 2
   call $~lib/typedarray/Uint16Array#__get
   i32.const 1
@@ -57882,8 +57882,8 @@
   global.set $~lib/memory/__stack_pointer
  )
  (func $std/typedarray/testArraySort<~lib/typedarray/Int32Array,i32>
-  (local $0 i32)
-  (local $1 i32)
+  (local $source i32)
+  (local $result i32)
   (local $2 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 12
@@ -57900,29 +57900,29 @@
   i32.const 0
   i32.const 3
   call $~lib/typedarray/Int32Array#constructor
-  local.tee $0
+  local.tee $source
   i32.store $0
-  local.get $0
+  local.get $source
   i32.const 2
   i32.const 1
   call $~lib/typedarray/Int32Array#__set
-  local.get $0
+  local.get $source
   i32.const 1
   i32.const 2
   call $~lib/typedarray/Int32Array#__set
-  local.get $0
+  local.get $source
   i32.const 0
   i32.const 3
   call $~lib/typedarray/Int32Array#__set
   global.get $~lib/memory/__stack_pointer
-  local.get $0
+  local.get $source
   i32.const 0
   global.set $~argumentsLength
   i32.const 0
   call $~lib/typedarray/Int32Array#sort@varargs
-  local.tee $1
+  local.tee $result
   i32.store $0 offset=4
-  local.get $1
+  local.get $result
   i32.const 0
   call $~lib/typedarray/Int32Array#__get
   i32.const 1
@@ -57936,7 +57936,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $1
+  local.get $result
   i32.const 1
   call $~lib/typedarray/Int32Array#__get
   i32.const 2
@@ -57950,7 +57950,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $1
+  local.get $result
   i32.const 2
   call $~lib/typedarray/Int32Array#__get
   i32.const 3
@@ -57964,7 +57964,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $1
+  local.get $result
   i32.const 14672
   local.set $2
   global.get $~lib/memory/__stack_pointer
@@ -57973,7 +57973,7 @@
   local.get $2
   call $~lib/typedarray/Int32Array#sort
   drop
-  local.get $1
+  local.get $result
   i32.const 0
   call $~lib/typedarray/Int32Array#__get
   i32.const 3
@@ -57987,7 +57987,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $1
+  local.get $result
   i32.const 1
   call $~lib/typedarray/Int32Array#__get
   i32.const 2
@@ -58001,7 +58001,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $1
+  local.get $result
   i32.const 2
   call $~lib/typedarray/Int32Array#__get
   i32.const 1
@@ -58021,8 +58021,8 @@
   global.set $~lib/memory/__stack_pointer
  )
  (func $std/typedarray/testArraySort<~lib/typedarray/Uint32Array,u32>
-  (local $0 i32)
-  (local $1 i32)
+  (local $source i32)
+  (local $result i32)
   (local $2 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 12
@@ -58039,29 +58039,29 @@
   i32.const 0
   i32.const 3
   call $~lib/typedarray/Uint32Array#constructor
-  local.tee $0
+  local.tee $source
   i32.store $0
-  local.get $0
+  local.get $source
   i32.const 2
   i32.const 1
   call $~lib/typedarray/Uint32Array#__set
-  local.get $0
+  local.get $source
   i32.const 1
   i32.const 2
   call $~lib/typedarray/Uint32Array#__set
-  local.get $0
+  local.get $source
   i32.const 0
   i32.const 3
   call $~lib/typedarray/Uint32Array#__set
   global.get $~lib/memory/__stack_pointer
-  local.get $0
+  local.get $source
   i32.const 0
   global.set $~argumentsLength
   i32.const 0
   call $~lib/typedarray/Uint32Array#sort@varargs
-  local.tee $1
+  local.tee $result
   i32.store $0 offset=4
-  local.get $1
+  local.get $result
   i32.const 0
   call $~lib/typedarray/Uint32Array#__get
   i32.const 1
@@ -58075,7 +58075,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $1
+  local.get $result
   i32.const 1
   call $~lib/typedarray/Uint32Array#__get
   i32.const 2
@@ -58089,7 +58089,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $1
+  local.get $result
   i32.const 2
   call $~lib/typedarray/Uint32Array#__get
   i32.const 3
@@ -58103,7 +58103,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $1
+  local.get $result
   i32.const 14736
   local.set $2
   global.get $~lib/memory/__stack_pointer
@@ -58112,7 +58112,7 @@
   local.get $2
   call $~lib/typedarray/Uint32Array#sort
   drop
-  local.get $1
+  local.get $result
   i32.const 0
   call $~lib/typedarray/Uint32Array#__get
   i32.const 3
@@ -58126,7 +58126,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $1
+  local.get $result
   i32.const 1
   call $~lib/typedarray/Uint32Array#__get
   i32.const 2
@@ -58140,7 +58140,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $1
+  local.get $result
   i32.const 2
   call $~lib/typedarray/Uint32Array#__get
   i32.const 1
@@ -58160,8 +58160,8 @@
   global.set $~lib/memory/__stack_pointer
  )
  (func $std/typedarray/testArraySort<~lib/typedarray/Int64Array,i64>
-  (local $0 i32)
-  (local $1 i32)
+  (local $source i32)
+  (local $result i32)
   (local $2 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 12
@@ -58178,29 +58178,29 @@
   i32.const 0
   i32.const 3
   call $~lib/typedarray/Int64Array#constructor
-  local.tee $0
+  local.tee $source
   i32.store $0
-  local.get $0
+  local.get $source
   i32.const 2
   i64.const 1
   call $~lib/typedarray/Int64Array#__set
-  local.get $0
+  local.get $source
   i32.const 1
   i64.const 2
   call $~lib/typedarray/Int64Array#__set
-  local.get $0
+  local.get $source
   i32.const 0
   i64.const 3
   call $~lib/typedarray/Int64Array#__set
   global.get $~lib/memory/__stack_pointer
-  local.get $0
+  local.get $source
   i32.const 0
   global.set $~argumentsLength
   i32.const 0
   call $~lib/typedarray/Int64Array#sort@varargs
-  local.tee $1
+  local.tee $result
   i32.store $0 offset=4
-  local.get $1
+  local.get $result
   i32.const 0
   call $~lib/typedarray/Int64Array#__get
   i64.const 1
@@ -58214,7 +58214,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $1
+  local.get $result
   i32.const 1
   call $~lib/typedarray/Int64Array#__get
   i64.const 2
@@ -58228,7 +58228,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $1
+  local.get $result
   i32.const 2
   call $~lib/typedarray/Int64Array#__get
   i64.const 3
@@ -58242,7 +58242,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $1
+  local.get $result
   i32.const 14800
   local.set $2
   global.get $~lib/memory/__stack_pointer
@@ -58251,7 +58251,7 @@
   local.get $2
   call $~lib/typedarray/Int64Array#sort
   drop
-  local.get $1
+  local.get $result
   i32.const 0
   call $~lib/typedarray/Int64Array#__get
   i64.const 3
@@ -58265,7 +58265,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $1
+  local.get $result
   i32.const 1
   call $~lib/typedarray/Int64Array#__get
   i64.const 2
@@ -58279,7 +58279,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $1
+  local.get $result
   i32.const 2
   call $~lib/typedarray/Int64Array#__get
   i64.const 1
@@ -58299,8 +58299,8 @@
   global.set $~lib/memory/__stack_pointer
  )
  (func $std/typedarray/testArraySort<~lib/typedarray/Uint64Array,u64>
-  (local $0 i32)
-  (local $1 i32)
+  (local $source i32)
+  (local $result i32)
   (local $2 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 12
@@ -58317,29 +58317,29 @@
   i32.const 0
   i32.const 3
   call $~lib/typedarray/Uint64Array#constructor
-  local.tee $0
+  local.tee $source
   i32.store $0
-  local.get $0
+  local.get $source
   i32.const 2
   i64.const 1
   call $~lib/typedarray/Uint64Array#__set
-  local.get $0
+  local.get $source
   i32.const 1
   i64.const 2
   call $~lib/typedarray/Uint64Array#__set
-  local.get $0
+  local.get $source
   i32.const 0
   i64.const 3
   call $~lib/typedarray/Uint64Array#__set
   global.get $~lib/memory/__stack_pointer
-  local.get $0
+  local.get $source
   i32.const 0
   global.set $~argumentsLength
   i32.const 0
   call $~lib/typedarray/Uint64Array#sort@varargs
-  local.tee $1
+  local.tee $result
   i32.store $0 offset=4
-  local.get $1
+  local.get $result
   i32.const 0
   call $~lib/typedarray/Uint64Array#__get
   i64.const 1
@@ -58353,7 +58353,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $1
+  local.get $result
   i32.const 1
   call $~lib/typedarray/Uint64Array#__get
   i64.const 2
@@ -58367,7 +58367,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $1
+  local.get $result
   i32.const 2
   call $~lib/typedarray/Uint64Array#__get
   i64.const 3
@@ -58381,7 +58381,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $1
+  local.get $result
   i32.const 14864
   local.set $2
   global.get $~lib/memory/__stack_pointer
@@ -58390,7 +58390,7 @@
   local.get $2
   call $~lib/typedarray/Uint64Array#sort
   drop
-  local.get $1
+  local.get $result
   i32.const 0
   call $~lib/typedarray/Uint64Array#__get
   i64.const 3
@@ -58404,7 +58404,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $1
+  local.get $result
   i32.const 1
   call $~lib/typedarray/Uint64Array#__get
   i64.const 2
@@ -58418,7 +58418,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $1
+  local.get $result
   i32.const 2
   call $~lib/typedarray/Uint64Array#__get
   i64.const 1
@@ -58438,8 +58438,8 @@
   global.set $~lib/memory/__stack_pointer
  )
  (func $std/typedarray/testArraySort<~lib/typedarray/Float32Array,f32>
-  (local $0 i32)
-  (local $1 i32)
+  (local $source i32)
+  (local $result i32)
   (local $2 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 12
@@ -58456,29 +58456,29 @@
   i32.const 0
   i32.const 3
   call $~lib/typedarray/Float32Array#constructor
-  local.tee $0
+  local.tee $source
   i32.store $0
-  local.get $0
+  local.get $source
   i32.const 2
   f32.const 1
   call $~lib/typedarray/Float32Array#__set
-  local.get $0
+  local.get $source
   i32.const 1
   f32.const 2
   call $~lib/typedarray/Float32Array#__set
-  local.get $0
+  local.get $source
   i32.const 0
   f32.const 3
   call $~lib/typedarray/Float32Array#__set
   global.get $~lib/memory/__stack_pointer
-  local.get $0
+  local.get $source
   i32.const 0
   global.set $~argumentsLength
   i32.const 0
   call $~lib/typedarray/Float32Array#sort@varargs
-  local.tee $1
+  local.tee $result
   i32.store $0 offset=4
-  local.get $1
+  local.get $result
   i32.const 0
   call $~lib/typedarray/Float32Array#__get
   f32.const 1
@@ -58492,7 +58492,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $1
+  local.get $result
   i32.const 1
   call $~lib/typedarray/Float32Array#__get
   f32.const 2
@@ -58506,7 +58506,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $1
+  local.get $result
   i32.const 2
   call $~lib/typedarray/Float32Array#__get
   f32.const 3
@@ -58520,7 +58520,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $1
+  local.get $result
   i32.const 14928
   local.set $2
   global.get $~lib/memory/__stack_pointer
@@ -58529,7 +58529,7 @@
   local.get $2
   call $~lib/typedarray/Float32Array#sort
   drop
-  local.get $1
+  local.get $result
   i32.const 0
   call $~lib/typedarray/Float32Array#__get
   f32.const 3
@@ -58543,7 +58543,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $1
+  local.get $result
   i32.const 1
   call $~lib/typedarray/Float32Array#__get
   f32.const 2
@@ -58557,7 +58557,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $1
+  local.get $result
   i32.const 2
   call $~lib/typedarray/Float32Array#__get
   f32.const 1
@@ -58577,8 +58577,8 @@
   global.set $~lib/memory/__stack_pointer
  )
  (func $std/typedarray/testArraySort<~lib/typedarray/Float64Array,f64>
-  (local $0 i32)
-  (local $1 i32)
+  (local $source i32)
+  (local $result i32)
   (local $2 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 12
@@ -58595,29 +58595,29 @@
   i32.const 0
   i32.const 3
   call $~lib/typedarray/Float64Array#constructor
-  local.tee $0
+  local.tee $source
   i32.store $0
-  local.get $0
+  local.get $source
   i32.const 2
   f64.const 1
   call $~lib/typedarray/Float64Array#__set
-  local.get $0
+  local.get $source
   i32.const 1
   f64.const 2
   call $~lib/typedarray/Float64Array#__set
-  local.get $0
+  local.get $source
   i32.const 0
   f64.const 3
   call $~lib/typedarray/Float64Array#__set
   global.get $~lib/memory/__stack_pointer
-  local.get $0
+  local.get $source
   i32.const 0
   global.set $~argumentsLength
   i32.const 0
   call $~lib/typedarray/Float64Array#sort@varargs
-  local.tee $1
+  local.tee $result
   i32.store $0 offset=4
-  local.get $1
+  local.get $result
   i32.const 0
   call $~lib/typedarray/Float64Array#__get
   f64.const 1
@@ -58631,7 +58631,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $1
+  local.get $result
   i32.const 1
   call $~lib/typedarray/Float64Array#__get
   f64.const 2
@@ -58645,7 +58645,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $1
+  local.get $result
   i32.const 2
   call $~lib/typedarray/Float64Array#__get
   f64.const 3
@@ -58659,7 +58659,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $1
+  local.get $result
   i32.const 14960
   local.set $2
   global.get $~lib/memory/__stack_pointer
@@ -58668,7 +58668,7 @@
   local.get $2
   call $~lib/typedarray/Float64Array#sort
   drop
-  local.get $1
+  local.get $result
   i32.const 0
   call $~lib/typedarray/Float64Array#__get
   f64.const 3
@@ -58682,7 +58682,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $1
+  local.get $result
   i32.const 1
   call $~lib/typedarray/Float64Array#__get
   f64.const 2
@@ -58696,7 +58696,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $1
+  local.get $result
   i32.const 2
   call $~lib/typedarray/Float64Array#__get
   f64.const 1
@@ -61092,8 +61092,8 @@
   i32.add
   global.set $~lib/memory/__stack_pointer
  )
- (func $~lib/arraybuffer/ArrayBufferView#constructor (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
-  (local $3 i32)
+ (func $~lib/arraybuffer/ArrayBufferView#constructor (param $this i32) (param $length i32) (param $alignLog2 i32) (result i32)
+  (local $buffer i32)
   (local $4 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 8
@@ -61103,28 +61103,28 @@
   global.get $~lib/memory/__stack_pointer
   i64.const 0
   i64.store $0
-  local.get $0
+  local.get $this
   i32.eqz
   if
    global.get $~lib/memory/__stack_pointer
    i32.const 12
    i32.const 2
    call $~lib/rt/itcms/__new
-   local.tee $0
+   local.tee $this
    i32.store $0
   end
-  local.get $0
+  local.get $this
   i32.const 0
   call $~lib/arraybuffer/ArrayBufferView#set:buffer
-  local.get $0
+  local.get $this
   i32.const 0
   call $~lib/arraybuffer/ArrayBufferView#set:dataStart
-  local.get $0
+  local.get $this
   i32.const 0
   call $~lib/arraybuffer/ArrayBufferView#set:byteLength
-  local.get $1
+  local.get $length
   i32.const 1073741820
-  local.get $2
+  local.get $alignLog2
   i32.shr_u
   i32.gt_u
   if
@@ -61136,28 +61136,28 @@
    unreachable
   end
   global.get $~lib/memory/__stack_pointer
-  local.get $1
-  local.get $2
+  local.get $length
+  local.get $alignLog2
   i32.shl
-  local.tee $1
+  local.tee $length
   i32.const 0
   call $~lib/rt/itcms/__new
-  local.tee $3
+  local.tee $buffer
   i32.store $0 offset=4
   i32.const 2
   global.get $~lib/shared/runtime/Runtime.Incremental
   i32.ne
   drop
-  local.get $0
-  local.get $3
+  local.get $this
+  local.get $buffer
   call $~lib/arraybuffer/ArrayBufferView#set:buffer
-  local.get $0
-  local.get $3
+  local.get $this
+  local.get $buffer
   call $~lib/arraybuffer/ArrayBufferView#set:dataStart
-  local.get $0
-  local.get $1
+  local.get $this
+  local.get $length
   call $~lib/arraybuffer/ArrayBufferView#set:byteLength
-  local.get $0
+  local.get $this
   local.set $4
   global.get $~lib/memory/__stack_pointer
   i32.const 8
@@ -61165,7 +61165,7 @@
   global.set $~lib/memory/__stack_pointer
   local.get $4
  )
- (func $~lib/typedarray/Int8Array#constructor (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/typedarray/Int8Array#constructor (param $this i32) (param $length i32) (result i32)
   (local $2 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -61175,24 +61175,24 @@
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   i32.store $0
-  local.get $0
+  local.get $this
   i32.eqz
   if
    global.get $~lib/memory/__stack_pointer
    i32.const 12
    i32.const 3
    call $~lib/rt/itcms/__new
-   local.tee $0
+   local.tee $this
    i32.store $0
   end
   global.get $~lib/memory/__stack_pointer
-  local.get $0
-  local.get $1
+  local.get $this
+  local.get $length
   i32.const 0
   call $~lib/arraybuffer/ArrayBufferView#constructor
-  local.tee $0
+  local.tee $this
   i32.store $0
-  local.get $0
+  local.get $this
   local.set $2
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -61200,7 +61200,7 @@
   global.set $~lib/memory/__stack_pointer
   local.get $2
  )
- (func $~lib/typedarray/Uint8Array#constructor (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/typedarray/Uint8Array#constructor (param $this i32) (param $length i32) (result i32)
   (local $2 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -61210,24 +61210,24 @@
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   i32.store $0
-  local.get $0
+  local.get $this
   i32.eqz
   if
    global.get $~lib/memory/__stack_pointer
    i32.const 12
    i32.const 4
    call $~lib/rt/itcms/__new
-   local.tee $0
+   local.tee $this
    i32.store $0
   end
   global.get $~lib/memory/__stack_pointer
-  local.get $0
-  local.get $1
+  local.get $this
+  local.get $length
   i32.const 0
   call $~lib/arraybuffer/ArrayBufferView#constructor
-  local.tee $0
+  local.tee $this
   i32.store $0
-  local.get $0
+  local.get $this
   local.set $2
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -61235,7 +61235,7 @@
   global.set $~lib/memory/__stack_pointer
   local.get $2
  )
- (func $~lib/typedarray/Uint8ClampedArray#constructor (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/typedarray/Uint8ClampedArray#constructor (param $this i32) (param $length i32) (result i32)
   (local $2 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -61245,24 +61245,24 @@
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   i32.store $0
-  local.get $0
+  local.get $this
   i32.eqz
   if
    global.get $~lib/memory/__stack_pointer
    i32.const 12
    i32.const 5
    call $~lib/rt/itcms/__new
-   local.tee $0
+   local.tee $this
    i32.store $0
   end
   global.get $~lib/memory/__stack_pointer
-  local.get $0
-  local.get $1
+  local.get $this
+  local.get $length
   i32.const 0
   call $~lib/arraybuffer/ArrayBufferView#constructor
-  local.tee $0
+  local.tee $this
   i32.store $0
-  local.get $0
+  local.get $this
   local.set $2
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -61270,7 +61270,7 @@
   global.set $~lib/memory/__stack_pointer
   local.get $2
  )
- (func $~lib/typedarray/Int16Array#constructor (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/typedarray/Int16Array#constructor (param $this i32) (param $length i32) (result i32)
   (local $2 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -61280,24 +61280,24 @@
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   i32.store $0
-  local.get $0
+  local.get $this
   i32.eqz
   if
    global.get $~lib/memory/__stack_pointer
    i32.const 12
    i32.const 6
    call $~lib/rt/itcms/__new
-   local.tee $0
+   local.tee $this
    i32.store $0
   end
   global.get $~lib/memory/__stack_pointer
-  local.get $0
-  local.get $1
+  local.get $this
+  local.get $length
   i32.const 1
   call $~lib/arraybuffer/ArrayBufferView#constructor
-  local.tee $0
+  local.tee $this
   i32.store $0
-  local.get $0
+  local.get $this
   local.set $2
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -61305,7 +61305,7 @@
   global.set $~lib/memory/__stack_pointer
   local.get $2
  )
- (func $~lib/typedarray/Uint16Array#constructor (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/typedarray/Uint16Array#constructor (param $this i32) (param $length i32) (result i32)
   (local $2 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -61315,24 +61315,24 @@
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   i32.store $0
-  local.get $0
+  local.get $this
   i32.eqz
   if
    global.get $~lib/memory/__stack_pointer
    i32.const 12
    i32.const 7
    call $~lib/rt/itcms/__new
-   local.tee $0
+   local.tee $this
    i32.store $0
   end
   global.get $~lib/memory/__stack_pointer
-  local.get $0
-  local.get $1
+  local.get $this
+  local.get $length
   i32.const 1
   call $~lib/arraybuffer/ArrayBufferView#constructor
-  local.tee $0
+  local.tee $this
   i32.store $0
-  local.get $0
+  local.get $this
   local.set $2
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -61340,7 +61340,7 @@
   global.set $~lib/memory/__stack_pointer
   local.get $2
  )
- (func $~lib/typedarray/Int32Array#constructor (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/typedarray/Int32Array#constructor (param $this i32) (param $length i32) (result i32)
   (local $2 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -61350,24 +61350,24 @@
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   i32.store $0
-  local.get $0
+  local.get $this
   i32.eqz
   if
    global.get $~lib/memory/__stack_pointer
    i32.const 12
    i32.const 8
    call $~lib/rt/itcms/__new
-   local.tee $0
+   local.tee $this
    i32.store $0
   end
   global.get $~lib/memory/__stack_pointer
-  local.get $0
-  local.get $1
+  local.get $this
+  local.get $length
   i32.const 2
   call $~lib/arraybuffer/ArrayBufferView#constructor
-  local.tee $0
+  local.tee $this
   i32.store $0
-  local.get $0
+  local.get $this
   local.set $2
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -61375,7 +61375,7 @@
   global.set $~lib/memory/__stack_pointer
   local.get $2
  )
- (func $~lib/typedarray/Uint32Array#constructor (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/typedarray/Uint32Array#constructor (param $this i32) (param $length i32) (result i32)
   (local $2 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -61385,24 +61385,24 @@
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   i32.store $0
-  local.get $0
+  local.get $this
   i32.eqz
   if
    global.get $~lib/memory/__stack_pointer
    i32.const 12
    i32.const 9
    call $~lib/rt/itcms/__new
-   local.tee $0
+   local.tee $this
    i32.store $0
   end
   global.get $~lib/memory/__stack_pointer
-  local.get $0
-  local.get $1
+  local.get $this
+  local.get $length
   i32.const 2
   call $~lib/arraybuffer/ArrayBufferView#constructor
-  local.tee $0
+  local.tee $this
   i32.store $0
-  local.get $0
+  local.get $this
   local.set $2
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -61410,7 +61410,7 @@
   global.set $~lib/memory/__stack_pointer
   local.get $2
  )
- (func $~lib/typedarray/Int64Array#constructor (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/typedarray/Int64Array#constructor (param $this i32) (param $length i32) (result i32)
   (local $2 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -61420,24 +61420,24 @@
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   i32.store $0
-  local.get $0
+  local.get $this
   i32.eqz
   if
    global.get $~lib/memory/__stack_pointer
    i32.const 12
    i32.const 10
    call $~lib/rt/itcms/__new
-   local.tee $0
+   local.tee $this
    i32.store $0
   end
   global.get $~lib/memory/__stack_pointer
-  local.get $0
-  local.get $1
+  local.get $this
+  local.get $length
   i32.const 3
   call $~lib/arraybuffer/ArrayBufferView#constructor
-  local.tee $0
+  local.tee $this
   i32.store $0
-  local.get $0
+  local.get $this
   local.set $2
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -61445,7 +61445,7 @@
   global.set $~lib/memory/__stack_pointer
   local.get $2
  )
- (func $~lib/typedarray/Uint64Array#constructor (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/typedarray/Uint64Array#constructor (param $this i32) (param $length i32) (result i32)
   (local $2 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -61455,24 +61455,24 @@
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   i32.store $0
-  local.get $0
+  local.get $this
   i32.eqz
   if
    global.get $~lib/memory/__stack_pointer
    i32.const 12
    i32.const 11
    call $~lib/rt/itcms/__new
-   local.tee $0
+   local.tee $this
    i32.store $0
   end
   global.get $~lib/memory/__stack_pointer
-  local.get $0
-  local.get $1
+  local.get $this
+  local.get $length
   i32.const 3
   call $~lib/arraybuffer/ArrayBufferView#constructor
-  local.tee $0
+  local.tee $this
   i32.store $0
-  local.get $0
+  local.get $this
   local.set $2
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -61480,7 +61480,7 @@
   global.set $~lib/memory/__stack_pointer
   local.get $2
  )
- (func $~lib/typedarray/Float32Array#constructor (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/typedarray/Float32Array#constructor (param $this i32) (param $length i32) (result i32)
   (local $2 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -61490,24 +61490,24 @@
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   i32.store $0
-  local.get $0
+  local.get $this
   i32.eqz
   if
    global.get $~lib/memory/__stack_pointer
    i32.const 12
    i32.const 12
    call $~lib/rt/itcms/__new
-   local.tee $0
+   local.tee $this
    i32.store $0
   end
   global.get $~lib/memory/__stack_pointer
-  local.get $0
-  local.get $1
+  local.get $this
+  local.get $length
   i32.const 2
   call $~lib/arraybuffer/ArrayBufferView#constructor
-  local.tee $0
+  local.tee $this
   i32.store $0
-  local.get $0
+  local.get $this
   local.set $2
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -61515,7 +61515,7 @@
   global.set $~lib/memory/__stack_pointer
   local.get $2
  )
- (func $~lib/typedarray/Float64Array#constructor (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/typedarray/Float64Array#constructor (param $this i32) (param $length i32) (result i32)
   (local $2 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -61525,24 +61525,24 @@
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   i32.store $0
-  local.get $0
+  local.get $this
   i32.eqz
   if
    global.get $~lib/memory/__stack_pointer
    i32.const 12
    i32.const 13
    call $~lib/rt/itcms/__new
-   local.tee $0
+   local.tee $this
    i32.store $0
   end
   global.get $~lib/memory/__stack_pointer
-  local.get $0
-  local.get $1
+  local.get $this
+  local.get $length
   i32.const 3
   call $~lib/arraybuffer/ArrayBufferView#constructor
-  local.tee $0
+  local.tee $this
   i32.store $0
-  local.get $0
+  local.get $this
   local.set $2
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -61550,13 +61550,13 @@
   global.set $~lib/memory/__stack_pointer
   local.get $2
  )
- (func $~lib/typedarray/Int32Array#subarray (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
-  (local $3 i32)
-  (local $4 i32)
-  (local $5 i32)
-  (local $6 i32)
-  (local $7 i32)
-  (local $8 i32)
+ (func $~lib/typedarray/Int32Array#subarray (param $this i32) (param $begin i32) (param $end i32) (result i32)
+  (local $var$3 i32)
+  (local $var$4 i32)
+  (local $var$5 i32)
+  (local $var$6 i32)
+  (local $var$7 i32)
+  (local $var$8 i32)
   (local $9 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -61566,106 +61566,106 @@
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   i32.store $0
-  local.get $0
-  local.set $5
-  local.get $1
-  local.set $4
-  local.get $2
-  local.set $3
-  local.get $5
+  local.get $this
+  local.set $var$5
+  local.get $begin
+  local.set $var$4
+  local.get $end
+  local.set $var$3
+  local.get $var$5
   call $~lib/typedarray/Int32Array#get:length
-  local.set $6
-  local.get $4
+  local.set $var$6
+  local.get $var$4
   i32.const 0
   i32.lt_s
   if (result i32)
-   local.get $6
-   local.get $4
+   local.get $var$6
+   local.get $var$4
    i32.add
-   local.tee $7
+   local.tee $var$7
    i32.const 0
-   local.tee $8
-   local.get $7
-   local.get $8
+   local.tee $var$8
+   local.get $var$7
+   local.get $var$8
    i32.gt_s
    select
   else
-   local.get $4
-   local.tee $8
-   local.get $6
-   local.tee $7
-   local.get $8
-   local.get $7
+   local.get $var$4
+   local.tee $var$8
+   local.get $var$6
+   local.tee $var$7
+   local.get $var$8
+   local.get $var$7
    i32.lt_s
    select
   end
-  local.set $4
-  local.get $3
+  local.set $var$4
+  local.get $var$3
   i32.const 0
   i32.lt_s
   if (result i32)
-   local.get $6
-   local.get $3
+   local.get $var$6
+   local.get $var$3
    i32.add
-   local.tee $7
+   local.tee $var$7
    i32.const 0
-   local.tee $8
-   local.get $7
-   local.get $8
+   local.tee $var$8
+   local.get $var$7
+   local.get $var$8
    i32.gt_s
    select
   else
-   local.get $3
-   local.tee $8
-   local.get $6
-   local.tee $7
-   local.get $8
-   local.get $7
+   local.get $var$3
+   local.tee $var$8
+   local.get $var$6
+   local.tee $var$7
+   local.get $var$8
+   local.get $var$7
    i32.lt_s
    select
   end
-  local.set $3
-  local.get $3
-  local.tee $7
-  local.get $4
-  local.tee $8
-  local.get $7
-  local.get $8
+  local.set $var$3
+  local.get $var$3
+  local.tee $var$7
+  local.get $var$4
+  local.tee $var$8
+  local.get $var$7
+  local.get $var$8
   i32.gt_s
   select
-  local.set $3
+  local.set $var$3
   global.get $~lib/memory/__stack_pointer
   i32.const 12
   i32.const 8
   call $~lib/rt/itcms/__new
-  local.tee $7
+  local.tee $var$7
   i32.store $0
-  local.get $5
+  local.get $var$5
   i32.load $0
-  local.set $8
-  local.get $7
-  local.get $8
+  local.set $var$8
+  local.get $var$7
+  local.get $var$8
   i32.store $0
-  local.get $7
-  local.get $8
+  local.get $var$7
+  local.get $var$8
   i32.const 0
   call $~lib/rt/itcms/__link
-  local.get $7
-  local.get $5
+  local.get $var$7
+  local.get $var$5
   i32.load $0 offset=4
-  local.get $4
+  local.get $var$4
   i32.const 2
   i32.shl
   i32.add
   i32.store $0 offset=4
-  local.get $7
-  local.get $3
-  local.get $4
+  local.get $var$7
+  local.get $var$3
+  local.get $var$4
   i32.sub
   i32.const 2
   i32.shl
   i32.store $0 offset=8
-  local.get $7
+  local.get $var$7
   local.set $9
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -61673,13 +61673,13 @@
   global.set $~lib/memory/__stack_pointer
   local.get $9
  )
- (func $~lib/typedarray/Float64Array#subarray (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
-  (local $3 i32)
-  (local $4 i32)
-  (local $5 i32)
-  (local $6 i32)
-  (local $7 i32)
-  (local $8 i32)
+ (func $~lib/typedarray/Float64Array#subarray (param $this i32) (param $begin i32) (param $end i32) (result i32)
+  (local $var$3 i32)
+  (local $var$4 i32)
+  (local $var$5 i32)
+  (local $var$6 i32)
+  (local $var$7 i32)
+  (local $var$8 i32)
   (local $9 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -61689,106 +61689,106 @@
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   i32.store $0
-  local.get $0
-  local.set $5
-  local.get $1
-  local.set $4
-  local.get $2
-  local.set $3
-  local.get $5
+  local.get $this
+  local.set $var$5
+  local.get $begin
+  local.set $var$4
+  local.get $end
+  local.set $var$3
+  local.get $var$5
   call $~lib/typedarray/Float64Array#get:length
-  local.set $6
-  local.get $4
+  local.set $var$6
+  local.get $var$4
   i32.const 0
   i32.lt_s
   if (result i32)
-   local.get $6
-   local.get $4
+   local.get $var$6
+   local.get $var$4
    i32.add
-   local.tee $7
+   local.tee $var$7
    i32.const 0
-   local.tee $8
-   local.get $7
-   local.get $8
+   local.tee $var$8
+   local.get $var$7
+   local.get $var$8
    i32.gt_s
    select
   else
-   local.get $4
-   local.tee $8
-   local.get $6
-   local.tee $7
-   local.get $8
-   local.get $7
+   local.get $var$4
+   local.tee $var$8
+   local.get $var$6
+   local.tee $var$7
+   local.get $var$8
+   local.get $var$7
    i32.lt_s
    select
   end
-  local.set $4
-  local.get $3
+  local.set $var$4
+  local.get $var$3
   i32.const 0
   i32.lt_s
   if (result i32)
-   local.get $6
-   local.get $3
+   local.get $var$6
+   local.get $var$3
    i32.add
-   local.tee $7
+   local.tee $var$7
    i32.const 0
-   local.tee $8
-   local.get $7
-   local.get $8
+   local.tee $var$8
+   local.get $var$7
+   local.get $var$8
    i32.gt_s
    select
   else
-   local.get $3
-   local.tee $8
-   local.get $6
-   local.tee $7
-   local.get $8
-   local.get $7
+   local.get $var$3
+   local.tee $var$8
+   local.get $var$6
+   local.tee $var$7
+   local.get $var$8
+   local.get $var$7
    i32.lt_s
    select
   end
-  local.set $3
-  local.get $3
-  local.tee $7
-  local.get $4
-  local.tee $8
-  local.get $7
-  local.get $8
+  local.set $var$3
+  local.get $var$3
+  local.tee $var$7
+  local.get $var$4
+  local.tee $var$8
+  local.get $var$7
+  local.get $var$8
   i32.gt_s
   select
-  local.set $3
+  local.set $var$3
   global.get $~lib/memory/__stack_pointer
   i32.const 12
   i32.const 13
   call $~lib/rt/itcms/__new
-  local.tee $7
+  local.tee $var$7
   i32.store $0
-  local.get $5
+  local.get $var$5
   i32.load $0
-  local.set $8
-  local.get $7
-  local.get $8
+  local.set $var$8
+  local.get $var$7
+  local.get $var$8
   i32.store $0
-  local.get $7
-  local.get $8
+  local.get $var$7
+  local.get $var$8
   i32.const 0
   call $~lib/rt/itcms/__link
-  local.get $7
-  local.get $5
+  local.get $var$7
+  local.get $var$5
   i32.load $0 offset=4
-  local.get $4
+  local.get $var$4
   i32.const 3
   i32.shl
   i32.add
   i32.store $0 offset=4
-  local.get $7
-  local.get $3
-  local.get $4
+  local.get $var$7
+  local.get $var$3
+  local.get $var$4
   i32.sub
   i32.const 3
   i32.shl
   i32.store $0 offset=8
-  local.get $7
+  local.get $var$7
   local.set $9
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -61796,7 +61796,7 @@
   global.set $~lib/memory/__stack_pointer
   local.get $9
  )
- (func $~lib/typedarray/Float64Array#sort@varargs (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/typedarray/Float64Array#sort@varargs (param $this i32) (param $comparator i32) (result i32)
   (local $2 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -61827,11 +61827,11 @@
     i32.const 672
     br $~lib/util/sort/COMPARATOR<f64>|inlined.0
    end
-   local.tee $1
+   local.tee $comparator
    i32.store $0
   end
-  local.get $0
-  local.get $1
+  local.get $this
+  local.get $comparator
   call $~lib/typedarray/Float64Array#sort
   local.set $2
   global.get $~lib/memory/__stack_pointer
@@ -61840,10 +61840,10 @@
   global.set $~lib/memory/__stack_pointer
   local.get $2
  )
- (func $~lib/rt/__newArray (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
-  (local $4 i32)
-  (local $5 i32)
-  (local $6 i32)
+ (func $~lib/rt/__newArray (param $length i32) (param $alignLog2 i32) (param $id i32) (param $data i32) (result i32)
+  (local $bufferSize i32)
+  (local $buffer i32)
+  (local $array i32)
   (local $7 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -61853,38 +61853,38 @@
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   i32.store $0
-  local.get $0
-  local.get $1
+  local.get $length
+  local.get $alignLog2
   i32.shl
-  local.set $4
+  local.set $bufferSize
   global.get $~lib/memory/__stack_pointer
-  local.get $4
+  local.get $bufferSize
   i32.const 0
-  local.get $3
+  local.get $data
   call $~lib/rt/__newBuffer
-  local.tee $5
+  local.tee $buffer
   i32.store $0
   i32.const 16
-  local.get $2
+  local.get $id
   call $~lib/rt/itcms/__new
-  local.set $6
-  local.get $6
-  local.get $5
+  local.set $array
+  local.get $array
+  local.get $buffer
   i32.store $0
-  local.get $6
-  local.get $5
+  local.get $array
+  local.get $buffer
   i32.const 0
   call $~lib/rt/itcms/__link
-  local.get $6
-  local.get $5
+  local.get $array
+  local.get $buffer
   i32.store $0 offset=4
-  local.get $6
-  local.get $4
+  local.get $array
+  local.get $bufferSize
   i32.store $0 offset=8
-  local.get $6
-  local.get $0
+  local.get $array
+  local.get $length
   i32.store $0 offset=12
-  local.get $6
+  local.get $array
   local.set $7
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -61892,13 +61892,13 @@
   global.set $~lib/memory/__stack_pointer
   local.get $7
  )
- (func $~lib/typedarray/Int8Array#subarray (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
-  (local $3 i32)
-  (local $4 i32)
-  (local $5 i32)
-  (local $6 i32)
-  (local $7 i32)
-  (local $8 i32)
+ (func $~lib/typedarray/Int8Array#subarray (param $this i32) (param $begin i32) (param $end i32) (result i32)
+  (local $var$3 i32)
+  (local $var$4 i32)
+  (local $var$5 i32)
+  (local $var$6 i32)
+  (local $var$7 i32)
+  (local $var$8 i32)
   (local $9 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -61908,106 +61908,106 @@
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   i32.store $0
-  local.get $0
-  local.set $5
-  local.get $1
-  local.set $4
-  local.get $2
-  local.set $3
-  local.get $5
+  local.get $this
+  local.set $var$5
+  local.get $begin
+  local.set $var$4
+  local.get $end
+  local.set $var$3
+  local.get $var$5
   call $~lib/typedarray/Int8Array#get:length
-  local.set $6
-  local.get $4
+  local.set $var$6
+  local.get $var$4
   i32.const 0
   i32.lt_s
   if (result i32)
-   local.get $6
-   local.get $4
+   local.get $var$6
+   local.get $var$4
    i32.add
-   local.tee $7
+   local.tee $var$7
    i32.const 0
-   local.tee $8
-   local.get $7
-   local.get $8
+   local.tee $var$8
+   local.get $var$7
+   local.get $var$8
    i32.gt_s
    select
   else
-   local.get $4
-   local.tee $8
-   local.get $6
-   local.tee $7
-   local.get $8
-   local.get $7
+   local.get $var$4
+   local.tee $var$8
+   local.get $var$6
+   local.tee $var$7
+   local.get $var$8
+   local.get $var$7
    i32.lt_s
    select
   end
-  local.set $4
-  local.get $3
+  local.set $var$4
+  local.get $var$3
   i32.const 0
   i32.lt_s
   if (result i32)
-   local.get $6
-   local.get $3
+   local.get $var$6
+   local.get $var$3
    i32.add
-   local.tee $7
+   local.tee $var$7
    i32.const 0
-   local.tee $8
-   local.get $7
-   local.get $8
+   local.tee $var$8
+   local.get $var$7
+   local.get $var$8
    i32.gt_s
    select
   else
-   local.get $3
-   local.tee $8
-   local.get $6
-   local.tee $7
-   local.get $8
-   local.get $7
+   local.get $var$3
+   local.tee $var$8
+   local.get $var$6
+   local.tee $var$7
+   local.get $var$8
+   local.get $var$7
    i32.lt_s
    select
   end
-  local.set $3
-  local.get $3
-  local.tee $7
-  local.get $4
-  local.tee $8
-  local.get $7
-  local.get $8
+  local.set $var$3
+  local.get $var$3
+  local.tee $var$7
+  local.get $var$4
+  local.tee $var$8
+  local.get $var$7
+  local.get $var$8
   i32.gt_s
   select
-  local.set $3
+  local.set $var$3
   global.get $~lib/memory/__stack_pointer
   i32.const 12
   i32.const 3
   call $~lib/rt/itcms/__new
-  local.tee $7
+  local.tee $var$7
   i32.store $0
-  local.get $5
+  local.get $var$5
   i32.load $0
-  local.set $8
-  local.get $7
-  local.get $8
+  local.set $var$8
+  local.get $var$7
+  local.get $var$8
   i32.store $0
-  local.get $7
-  local.get $8
+  local.get $var$7
+  local.get $var$8
   i32.const 0
   call $~lib/rt/itcms/__link
-  local.get $7
-  local.get $5
+  local.get $var$7
+  local.get $var$5
   i32.load $0 offset=4
-  local.get $4
+  local.get $var$4
   i32.const 0
   i32.shl
   i32.add
   i32.store $0 offset=4
-  local.get $7
-  local.get $3
-  local.get $4
+  local.get $var$7
+  local.get $var$3
+  local.get $var$4
   i32.sub
   i32.const 0
   i32.shl
   i32.store $0 offset=8
-  local.get $7
+  local.get $var$7
   local.set $9
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -62015,13 +62015,13 @@
   global.set $~lib/memory/__stack_pointer
   local.get $9
  )
- (func $~lib/typedarray/Int32Array#slice (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
-  (local $3 i32)
-  (local $4 i32)
-  (local $5 i32)
-  (local $6 i32)
-  (local $7 i32)
-  (local $8 i32)
+ (func $~lib/typedarray/Int32Array#slice (param $this i32) (param $begin i32) (param $end i32) (result i32)
+  (local $var$3 i32)
+  (local $var$4 i32)
+  (local $var$5 i32)
+  (local $var$6 i32)
+  (local $var$7 i32)
+  (local $var$8 i32)
   (local $9 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -62031,95 +62031,95 @@
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   i32.store $0
-  local.get $0
-  local.set $5
-  local.get $1
-  local.set $4
-  local.get $2
-  local.set $3
-  local.get $5
+  local.get $this
+  local.set $var$5
+  local.get $begin
+  local.set $var$4
+  local.get $end
+  local.set $var$3
+  local.get $var$5
   call $~lib/typedarray/Int32Array#get:length
-  local.set $6
-  local.get $4
+  local.set $var$6
+  local.get $var$4
   i32.const 0
   i32.lt_s
   if (result i32)
-   local.get $4
-   local.get $6
+   local.get $var$4
+   local.get $var$6
    i32.add
-   local.tee $7
+   local.tee $var$7
    i32.const 0
-   local.tee $8
-   local.get $7
-   local.get $8
+   local.tee $var$8
+   local.get $var$7
+   local.get $var$8
    i32.gt_s
    select
   else
-   local.get $4
-   local.tee $8
-   local.get $6
-   local.tee $7
-   local.get $8
-   local.get $7
+   local.get $var$4
+   local.tee $var$8
+   local.get $var$6
+   local.tee $var$7
+   local.get $var$8
+   local.get $var$7
    i32.lt_s
    select
   end
-  local.set $4
-  local.get $3
+  local.set $var$4
+  local.get $var$3
   i32.const 0
   i32.lt_s
   if (result i32)
-   local.get $3
-   local.get $6
+   local.get $var$3
+   local.get $var$6
    i32.add
-   local.tee $7
+   local.tee $var$7
    i32.const 0
-   local.tee $8
-   local.get $7
-   local.get $8
+   local.tee $var$8
+   local.get $var$7
+   local.get $var$8
    i32.gt_s
    select
   else
-   local.get $3
-   local.tee $8
-   local.get $6
-   local.tee $7
-   local.get $8
-   local.get $7
+   local.get $var$3
+   local.tee $var$8
+   local.get $var$6
+   local.tee $var$7
+   local.get $var$8
+   local.get $var$7
    i32.lt_s
    select
   end
-  local.set $3
-  local.get $3
-  local.get $4
+  local.set $var$3
+  local.get $var$3
+  local.get $var$4
   i32.sub
-  local.tee $7
+  local.tee $var$7
   i32.const 0
-  local.tee $8
-  local.get $7
-  local.get $8
+  local.tee $var$8
+  local.get $var$7
+  local.get $var$8
   i32.gt_s
   select
-  local.set $6
+  local.set $var$6
   global.get $~lib/memory/__stack_pointer
   i32.const 0
-  local.get $6
+  local.get $var$6
   call $~lib/typedarray/Int32Array#constructor
-  local.tee $7
+  local.tee $var$7
   i32.store $0
-  local.get $7
+  local.get $var$7
   i32.load $0 offset=4
-  local.get $5
+  local.get $var$5
   i32.load $0 offset=4
-  local.get $4
+  local.get $var$4
   i32.const 2
   i32.shl
   i32.add
-  local.get $6
+  local.get $var$6
   i32.const 2
   i32.shl
   memory.copy $0 $0
-  local.get $7
+  local.get $var$7
   local.set $9
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -62127,16 +62127,16 @@
   global.set $~lib/memory/__stack_pointer
   local.get $9
  )
- (func $~lib/typedarray/Int8Array#map (param $0 i32) (param $1 i32) (result i32)
-  (local $2 i32)
-  (local $3 i32)
-  (local $4 i32)
-  (local $5 i32)
-  (local $6 i32)
-  (local $7 i32)
-  (local $8 i32)
-  (local $9 i32)
-  (local $10 i32)
+ (func $~lib/typedarray/Int8Array#map (param $this i32) (param $fn i32) (result i32)
+  (local $var$2 i32)
+  (local $var$3 i32)
+  (local $var$4 i32)
+  (local $var$5 i32)
+  (local $var$6 i32)
+  (local $var$7 i32)
+  (local $var$8 i32)
+  (local $var$9 i32)
+  (local $var$10 i32)
   (local $11 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 8
@@ -62146,81 +62146,81 @@
   global.get $~lib/memory/__stack_pointer
   i64.const 0
   i64.store $0
-  local.get $0
-  local.set $3
-  local.get $1
-  local.set $2
-  local.get $3
+  local.get $this
+  local.set $var$3
+  local.get $fn
+  local.set $var$2
+  local.get $var$3
   call $~lib/typedarray/Int8Array#get:length
-  local.set $4
-  local.get $3
+  local.set $var$4
+  local.get $var$3
   i32.load $0 offset=4
-  local.set $5
-  local.get $4
+  local.set $var$5
+  local.get $var$4
   i32.const 0
   i32.shl
-  local.set $6
+  local.set $var$6
   global.get $~lib/memory/__stack_pointer
   i32.const 12
   i32.const 3
   call $~lib/rt/itcms/__new
-  local.tee $7
+  local.tee $var$7
   i32.store $0
   global.get $~lib/memory/__stack_pointer
-  local.get $6
+  local.get $var$6
   i32.const 0
   call $~lib/rt/itcms/__new
-  local.tee $8
+  local.tee $var$8
   i32.store $0 offset=4
   i32.const 0
-  local.set $9
+  local.set $var$9
   loop $for-loop|0
-   local.get $9
-   local.get $4
+   local.get $var$9
+   local.get $var$4
    i32.lt_s
-   local.set $10
-   local.get $10
+   local.set $var$10
+   local.get $var$10
    if
-    local.get $8
-    local.get $9
+    local.get $var$8
+    local.get $var$9
     i32.const 0
     i32.shl
     i32.add
-    local.get $5
-    local.get $9
+    local.get $var$5
+    local.get $var$9
     i32.const 0
     i32.shl
     i32.add
     i32.load8_s $0
-    local.get $9
-    local.get $3
+    local.get $var$9
+    local.get $var$3
     i32.const 3
     global.set $~argumentsLength
-    local.get $2
+    local.get $var$2
     i32.load $0
     call_indirect $0 (type $i32_i32_i32_=>_i32)
     i32.store8 $0
-    local.get $9
+    local.get $var$9
     i32.const 1
     i32.add
-    local.set $9
+    local.set $var$9
     br $for-loop|0
    end
   end
-  local.get $7
-  local.get $8
+  local.get $var$7
+  local.get $var$8
   i32.store $0
-  local.get $7
-  local.get $8
+  local.get $var$7
+  local.get $var$8
   i32.const 0
   call $~lib/rt/itcms/__link
-  local.get $7
-  local.get $8
+  local.get $var$7
+  local.get $var$8
   i32.store $0 offset=4
-  local.get $7
-  local.get $6
+  local.get $var$7
+  local.get $var$6
   i32.store $0 offset=8
-  local.get $7
+  local.get $var$7
   local.set $11
   global.get $~lib/memory/__stack_pointer
   i32.const 8
@@ -62228,16 +62228,16 @@
   global.set $~lib/memory/__stack_pointer
   local.get $11
  )
- (func $~lib/typedarray/Uint8Array#map (param $0 i32) (param $1 i32) (result i32)
-  (local $2 i32)
-  (local $3 i32)
-  (local $4 i32)
-  (local $5 i32)
-  (local $6 i32)
-  (local $7 i32)
-  (local $8 i32)
-  (local $9 i32)
-  (local $10 i32)
+ (func $~lib/typedarray/Uint8Array#map (param $this i32) (param $fn i32) (result i32)
+  (local $var$2 i32)
+  (local $var$3 i32)
+  (local $var$4 i32)
+  (local $var$5 i32)
+  (local $var$6 i32)
+  (local $var$7 i32)
+  (local $var$8 i32)
+  (local $var$9 i32)
+  (local $var$10 i32)
   (local $11 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 8
@@ -62247,81 +62247,81 @@
   global.get $~lib/memory/__stack_pointer
   i64.const 0
   i64.store $0
-  local.get $0
-  local.set $3
-  local.get $1
-  local.set $2
-  local.get $3
+  local.get $this
+  local.set $var$3
+  local.get $fn
+  local.set $var$2
+  local.get $var$3
   call $~lib/typedarray/Uint8Array#get:length
-  local.set $4
-  local.get $3
+  local.set $var$4
+  local.get $var$3
   i32.load $0 offset=4
-  local.set $5
-  local.get $4
+  local.set $var$5
+  local.get $var$4
   i32.const 0
   i32.shl
-  local.set $6
+  local.set $var$6
   global.get $~lib/memory/__stack_pointer
   i32.const 12
   i32.const 4
   call $~lib/rt/itcms/__new
-  local.tee $7
+  local.tee $var$7
   i32.store $0
   global.get $~lib/memory/__stack_pointer
-  local.get $6
+  local.get $var$6
   i32.const 0
   call $~lib/rt/itcms/__new
-  local.tee $8
+  local.tee $var$8
   i32.store $0 offset=4
   i32.const 0
-  local.set $9
+  local.set $var$9
   loop $for-loop|0
-   local.get $9
-   local.get $4
+   local.get $var$9
+   local.get $var$4
    i32.lt_s
-   local.set $10
-   local.get $10
+   local.set $var$10
+   local.get $var$10
    if
-    local.get $8
-    local.get $9
+    local.get $var$8
+    local.get $var$9
     i32.const 0
     i32.shl
     i32.add
-    local.get $5
-    local.get $9
+    local.get $var$5
+    local.get $var$9
     i32.const 0
     i32.shl
     i32.add
     i32.load8_u $0
-    local.get $9
-    local.get $3
+    local.get $var$9
+    local.get $var$3
     i32.const 3
     global.set $~argumentsLength
-    local.get $2
+    local.get $var$2
     i32.load $0
     call_indirect $0 (type $i32_i32_i32_=>_i32)
     i32.store8 $0
-    local.get $9
+    local.get $var$9
     i32.const 1
     i32.add
-    local.set $9
+    local.set $var$9
     br $for-loop|0
    end
   end
-  local.get $7
-  local.get $8
+  local.get $var$7
+  local.get $var$8
   i32.store $0
-  local.get $7
-  local.get $8
+  local.get $var$7
+  local.get $var$8
   i32.const 0
   call $~lib/rt/itcms/__link
-  local.get $7
-  local.get $8
+  local.get $var$7
+  local.get $var$8
   i32.store $0 offset=4
-  local.get $7
-  local.get $6
+  local.get $var$7
+  local.get $var$6
   i32.store $0 offset=8
-  local.get $7
+  local.get $var$7
   local.set $11
   global.get $~lib/memory/__stack_pointer
   i32.const 8
@@ -62329,16 +62329,16 @@
   global.set $~lib/memory/__stack_pointer
   local.get $11
  )
- (func $~lib/typedarray/Uint8ClampedArray#map (param $0 i32) (param $1 i32) (result i32)
-  (local $2 i32)
-  (local $3 i32)
-  (local $4 i32)
-  (local $5 i32)
-  (local $6 i32)
-  (local $7 i32)
-  (local $8 i32)
-  (local $9 i32)
-  (local $10 i32)
+ (func $~lib/typedarray/Uint8ClampedArray#map (param $this i32) (param $fn i32) (result i32)
+  (local $var$2 i32)
+  (local $var$3 i32)
+  (local $var$4 i32)
+  (local $var$5 i32)
+  (local $var$6 i32)
+  (local $var$7 i32)
+  (local $var$8 i32)
+  (local $var$9 i32)
+  (local $var$10 i32)
   (local $11 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 8
@@ -62348,81 +62348,81 @@
   global.get $~lib/memory/__stack_pointer
   i64.const 0
   i64.store $0
-  local.get $0
-  local.set $3
-  local.get $1
-  local.set $2
-  local.get $3
+  local.get $this
+  local.set $var$3
+  local.get $fn
+  local.set $var$2
+  local.get $var$3
   call $~lib/typedarray/Uint8ClampedArray#get:length
-  local.set $4
-  local.get $3
+  local.set $var$4
+  local.get $var$3
   i32.load $0 offset=4
-  local.set $5
-  local.get $4
+  local.set $var$5
+  local.get $var$4
   i32.const 0
   i32.shl
-  local.set $6
+  local.set $var$6
   global.get $~lib/memory/__stack_pointer
   i32.const 12
   i32.const 5
   call $~lib/rt/itcms/__new
-  local.tee $7
+  local.tee $var$7
   i32.store $0
   global.get $~lib/memory/__stack_pointer
-  local.get $6
+  local.get $var$6
   i32.const 0
   call $~lib/rt/itcms/__new
-  local.tee $8
+  local.tee $var$8
   i32.store $0 offset=4
   i32.const 0
-  local.set $9
+  local.set $var$9
   loop $for-loop|0
-   local.get $9
-   local.get $4
+   local.get $var$9
+   local.get $var$4
    i32.lt_s
-   local.set $10
-   local.get $10
+   local.set $var$10
+   local.get $var$10
    if
-    local.get $8
-    local.get $9
+    local.get $var$8
+    local.get $var$9
     i32.const 0
     i32.shl
     i32.add
-    local.get $5
-    local.get $9
+    local.get $var$5
+    local.get $var$9
     i32.const 0
     i32.shl
     i32.add
     i32.load8_u $0
-    local.get $9
-    local.get $3
+    local.get $var$9
+    local.get $var$3
     i32.const 3
     global.set $~argumentsLength
-    local.get $2
+    local.get $var$2
     i32.load $0
     call_indirect $0 (type $i32_i32_i32_=>_i32)
     i32.store8 $0
-    local.get $9
+    local.get $var$9
     i32.const 1
     i32.add
-    local.set $9
+    local.set $var$9
     br $for-loop|0
    end
   end
-  local.get $7
-  local.get $8
+  local.get $var$7
+  local.get $var$8
   i32.store $0
-  local.get $7
-  local.get $8
+  local.get $var$7
+  local.get $var$8
   i32.const 0
   call $~lib/rt/itcms/__link
-  local.get $7
-  local.get $8
+  local.get $var$7
+  local.get $var$8
   i32.store $0 offset=4
-  local.get $7
-  local.get $6
+  local.get $var$7
+  local.get $var$6
   i32.store $0 offset=8
-  local.get $7
+  local.get $var$7
   local.set $11
   global.get $~lib/memory/__stack_pointer
   i32.const 8
@@ -62430,16 +62430,16 @@
   global.set $~lib/memory/__stack_pointer
   local.get $11
  )
- (func $~lib/typedarray/Int16Array#map (param $0 i32) (param $1 i32) (result i32)
-  (local $2 i32)
-  (local $3 i32)
-  (local $4 i32)
-  (local $5 i32)
-  (local $6 i32)
-  (local $7 i32)
-  (local $8 i32)
-  (local $9 i32)
-  (local $10 i32)
+ (func $~lib/typedarray/Int16Array#map (param $this i32) (param $fn i32) (result i32)
+  (local $var$2 i32)
+  (local $var$3 i32)
+  (local $var$4 i32)
+  (local $var$5 i32)
+  (local $var$6 i32)
+  (local $var$7 i32)
+  (local $var$8 i32)
+  (local $var$9 i32)
+  (local $var$10 i32)
   (local $11 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 8
@@ -62449,81 +62449,81 @@
   global.get $~lib/memory/__stack_pointer
   i64.const 0
   i64.store $0
-  local.get $0
-  local.set $3
-  local.get $1
-  local.set $2
-  local.get $3
+  local.get $this
+  local.set $var$3
+  local.get $fn
+  local.set $var$2
+  local.get $var$3
   call $~lib/typedarray/Int16Array#get:length
-  local.set $4
-  local.get $3
+  local.set $var$4
+  local.get $var$3
   i32.load $0 offset=4
-  local.set $5
-  local.get $4
+  local.set $var$5
+  local.get $var$4
   i32.const 1
   i32.shl
-  local.set $6
+  local.set $var$6
   global.get $~lib/memory/__stack_pointer
   i32.const 12
   i32.const 6
   call $~lib/rt/itcms/__new
-  local.tee $7
+  local.tee $var$7
   i32.store $0
   global.get $~lib/memory/__stack_pointer
-  local.get $6
+  local.get $var$6
   i32.const 0
   call $~lib/rt/itcms/__new
-  local.tee $8
+  local.tee $var$8
   i32.store $0 offset=4
   i32.const 0
-  local.set $9
+  local.set $var$9
   loop $for-loop|0
-   local.get $9
-   local.get $4
+   local.get $var$9
+   local.get $var$4
    i32.lt_s
-   local.set $10
-   local.get $10
+   local.set $var$10
+   local.get $var$10
    if
-    local.get $8
-    local.get $9
+    local.get $var$8
+    local.get $var$9
     i32.const 1
     i32.shl
     i32.add
-    local.get $5
-    local.get $9
+    local.get $var$5
+    local.get $var$9
     i32.const 1
     i32.shl
     i32.add
     i32.load16_s $0
-    local.get $9
-    local.get $3
+    local.get $var$9
+    local.get $var$3
     i32.const 3
     global.set $~argumentsLength
-    local.get $2
+    local.get $var$2
     i32.load $0
     call_indirect $0 (type $i32_i32_i32_=>_i32)
     i32.store16 $0
-    local.get $9
+    local.get $var$9
     i32.const 1
     i32.add
-    local.set $9
+    local.set $var$9
     br $for-loop|0
    end
   end
-  local.get $7
-  local.get $8
+  local.get $var$7
+  local.get $var$8
   i32.store $0
-  local.get $7
-  local.get $8
+  local.get $var$7
+  local.get $var$8
   i32.const 0
   call $~lib/rt/itcms/__link
-  local.get $7
-  local.get $8
+  local.get $var$7
+  local.get $var$8
   i32.store $0 offset=4
-  local.get $7
-  local.get $6
+  local.get $var$7
+  local.get $var$6
   i32.store $0 offset=8
-  local.get $7
+  local.get $var$7
   local.set $11
   global.get $~lib/memory/__stack_pointer
   i32.const 8
@@ -62531,16 +62531,16 @@
   global.set $~lib/memory/__stack_pointer
   local.get $11
  )
- (func $~lib/typedarray/Uint16Array#map (param $0 i32) (param $1 i32) (result i32)
-  (local $2 i32)
-  (local $3 i32)
-  (local $4 i32)
-  (local $5 i32)
-  (local $6 i32)
-  (local $7 i32)
-  (local $8 i32)
-  (local $9 i32)
-  (local $10 i32)
+ (func $~lib/typedarray/Uint16Array#map (param $this i32) (param $fn i32) (result i32)
+  (local $var$2 i32)
+  (local $var$3 i32)
+  (local $var$4 i32)
+  (local $var$5 i32)
+  (local $var$6 i32)
+  (local $var$7 i32)
+  (local $var$8 i32)
+  (local $var$9 i32)
+  (local $var$10 i32)
   (local $11 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 8
@@ -62550,81 +62550,81 @@
   global.get $~lib/memory/__stack_pointer
   i64.const 0
   i64.store $0
-  local.get $0
-  local.set $3
-  local.get $1
-  local.set $2
-  local.get $3
+  local.get $this
+  local.set $var$3
+  local.get $fn
+  local.set $var$2
+  local.get $var$3
   call $~lib/typedarray/Uint16Array#get:length
-  local.set $4
-  local.get $3
+  local.set $var$4
+  local.get $var$3
   i32.load $0 offset=4
-  local.set $5
-  local.get $4
+  local.set $var$5
+  local.get $var$4
   i32.const 1
   i32.shl
-  local.set $6
+  local.set $var$6
   global.get $~lib/memory/__stack_pointer
   i32.const 12
   i32.const 7
   call $~lib/rt/itcms/__new
-  local.tee $7
+  local.tee $var$7
   i32.store $0
   global.get $~lib/memory/__stack_pointer
-  local.get $6
+  local.get $var$6
   i32.const 0
   call $~lib/rt/itcms/__new
-  local.tee $8
+  local.tee $var$8
   i32.store $0 offset=4
   i32.const 0
-  local.set $9
+  local.set $var$9
   loop $for-loop|0
-   local.get $9
-   local.get $4
+   local.get $var$9
+   local.get $var$4
    i32.lt_s
-   local.set $10
-   local.get $10
+   local.set $var$10
+   local.get $var$10
    if
-    local.get $8
-    local.get $9
+    local.get $var$8
+    local.get $var$9
     i32.const 1
     i32.shl
     i32.add
-    local.get $5
-    local.get $9
+    local.get $var$5
+    local.get $var$9
     i32.const 1
     i32.shl
     i32.add
     i32.load16_u $0
-    local.get $9
-    local.get $3
+    local.get $var$9
+    local.get $var$3
     i32.const 3
     global.set $~argumentsLength
-    local.get $2
+    local.get $var$2
     i32.load $0
     call_indirect $0 (type $i32_i32_i32_=>_i32)
     i32.store16 $0
-    local.get $9
+    local.get $var$9
     i32.const 1
     i32.add
-    local.set $9
+    local.set $var$9
     br $for-loop|0
    end
   end
-  local.get $7
-  local.get $8
+  local.get $var$7
+  local.get $var$8
   i32.store $0
-  local.get $7
-  local.get $8
+  local.get $var$7
+  local.get $var$8
   i32.const 0
   call $~lib/rt/itcms/__link
-  local.get $7
-  local.get $8
+  local.get $var$7
+  local.get $var$8
   i32.store $0 offset=4
-  local.get $7
-  local.get $6
+  local.get $var$7
+  local.get $var$6
   i32.store $0 offset=8
-  local.get $7
+  local.get $var$7
   local.set $11
   global.get $~lib/memory/__stack_pointer
   i32.const 8
@@ -62632,16 +62632,16 @@
   global.set $~lib/memory/__stack_pointer
   local.get $11
  )
- (func $~lib/typedarray/Int32Array#map (param $0 i32) (param $1 i32) (result i32)
-  (local $2 i32)
-  (local $3 i32)
-  (local $4 i32)
-  (local $5 i32)
-  (local $6 i32)
-  (local $7 i32)
-  (local $8 i32)
-  (local $9 i32)
-  (local $10 i32)
+ (func $~lib/typedarray/Int32Array#map (param $this i32) (param $fn i32) (result i32)
+  (local $var$2 i32)
+  (local $var$3 i32)
+  (local $var$4 i32)
+  (local $var$5 i32)
+  (local $var$6 i32)
+  (local $var$7 i32)
+  (local $var$8 i32)
+  (local $var$9 i32)
+  (local $var$10 i32)
   (local $11 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 8
@@ -62651,81 +62651,81 @@
   global.get $~lib/memory/__stack_pointer
   i64.const 0
   i64.store $0
-  local.get $0
-  local.set $3
-  local.get $1
-  local.set $2
-  local.get $3
+  local.get $this
+  local.set $var$3
+  local.get $fn
+  local.set $var$2
+  local.get $var$3
   call $~lib/typedarray/Int32Array#get:length
-  local.set $4
-  local.get $3
+  local.set $var$4
+  local.get $var$3
   i32.load $0 offset=4
-  local.set $5
-  local.get $4
+  local.set $var$5
+  local.get $var$4
   i32.const 2
   i32.shl
-  local.set $6
+  local.set $var$6
   global.get $~lib/memory/__stack_pointer
   i32.const 12
   i32.const 8
   call $~lib/rt/itcms/__new
-  local.tee $7
+  local.tee $var$7
   i32.store $0
   global.get $~lib/memory/__stack_pointer
-  local.get $6
+  local.get $var$6
   i32.const 0
   call $~lib/rt/itcms/__new
-  local.tee $8
+  local.tee $var$8
   i32.store $0 offset=4
   i32.const 0
-  local.set $9
+  local.set $var$9
   loop $for-loop|0
-   local.get $9
-   local.get $4
+   local.get $var$9
+   local.get $var$4
    i32.lt_s
-   local.set $10
-   local.get $10
+   local.set $var$10
+   local.get $var$10
    if
-    local.get $8
-    local.get $9
+    local.get $var$8
+    local.get $var$9
     i32.const 2
     i32.shl
     i32.add
-    local.get $5
-    local.get $9
+    local.get $var$5
+    local.get $var$9
     i32.const 2
     i32.shl
     i32.add
     i32.load $0
-    local.get $9
-    local.get $3
+    local.get $var$9
+    local.get $var$3
     i32.const 3
     global.set $~argumentsLength
-    local.get $2
+    local.get $var$2
     i32.load $0
     call_indirect $0 (type $i32_i32_i32_=>_i32)
     i32.store $0
-    local.get $9
+    local.get $var$9
     i32.const 1
     i32.add
-    local.set $9
+    local.set $var$9
     br $for-loop|0
    end
   end
-  local.get $7
-  local.get $8
+  local.get $var$7
+  local.get $var$8
   i32.store $0
-  local.get $7
-  local.get $8
+  local.get $var$7
+  local.get $var$8
   i32.const 0
   call $~lib/rt/itcms/__link
-  local.get $7
-  local.get $8
+  local.get $var$7
+  local.get $var$8
   i32.store $0 offset=4
-  local.get $7
-  local.get $6
+  local.get $var$7
+  local.get $var$6
   i32.store $0 offset=8
-  local.get $7
+  local.get $var$7
   local.set $11
   global.get $~lib/memory/__stack_pointer
   i32.const 8
@@ -62733,16 +62733,16 @@
   global.set $~lib/memory/__stack_pointer
   local.get $11
  )
- (func $~lib/typedarray/Uint32Array#map (param $0 i32) (param $1 i32) (result i32)
-  (local $2 i32)
-  (local $3 i32)
-  (local $4 i32)
-  (local $5 i32)
-  (local $6 i32)
-  (local $7 i32)
-  (local $8 i32)
-  (local $9 i32)
-  (local $10 i32)
+ (func $~lib/typedarray/Uint32Array#map (param $this i32) (param $fn i32) (result i32)
+  (local $var$2 i32)
+  (local $var$3 i32)
+  (local $var$4 i32)
+  (local $var$5 i32)
+  (local $var$6 i32)
+  (local $var$7 i32)
+  (local $var$8 i32)
+  (local $var$9 i32)
+  (local $var$10 i32)
   (local $11 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 8
@@ -62752,81 +62752,81 @@
   global.get $~lib/memory/__stack_pointer
   i64.const 0
   i64.store $0
-  local.get $0
-  local.set $3
-  local.get $1
-  local.set $2
-  local.get $3
+  local.get $this
+  local.set $var$3
+  local.get $fn
+  local.set $var$2
+  local.get $var$3
   call $~lib/typedarray/Uint32Array#get:length
-  local.set $4
-  local.get $3
+  local.set $var$4
+  local.get $var$3
   i32.load $0 offset=4
-  local.set $5
-  local.get $4
+  local.set $var$5
+  local.get $var$4
   i32.const 2
   i32.shl
-  local.set $6
+  local.set $var$6
   global.get $~lib/memory/__stack_pointer
   i32.const 12
   i32.const 9
   call $~lib/rt/itcms/__new
-  local.tee $7
+  local.tee $var$7
   i32.store $0
   global.get $~lib/memory/__stack_pointer
-  local.get $6
+  local.get $var$6
   i32.const 0
   call $~lib/rt/itcms/__new
-  local.tee $8
+  local.tee $var$8
   i32.store $0 offset=4
   i32.const 0
-  local.set $9
+  local.set $var$9
   loop $for-loop|0
-   local.get $9
-   local.get $4
+   local.get $var$9
+   local.get $var$4
    i32.lt_s
-   local.set $10
-   local.get $10
+   local.set $var$10
+   local.get $var$10
    if
-    local.get $8
-    local.get $9
+    local.get $var$8
+    local.get $var$9
     i32.const 2
     i32.shl
     i32.add
-    local.get $5
-    local.get $9
+    local.get $var$5
+    local.get $var$9
     i32.const 2
     i32.shl
     i32.add
     i32.load $0
-    local.get $9
-    local.get $3
+    local.get $var$9
+    local.get $var$3
     i32.const 3
     global.set $~argumentsLength
-    local.get $2
+    local.get $var$2
     i32.load $0
     call_indirect $0 (type $i32_i32_i32_=>_i32)
     i32.store $0
-    local.get $9
+    local.get $var$9
     i32.const 1
     i32.add
-    local.set $9
+    local.set $var$9
     br $for-loop|0
    end
   end
-  local.get $7
-  local.get $8
+  local.get $var$7
+  local.get $var$8
   i32.store $0
-  local.get $7
-  local.get $8
+  local.get $var$7
+  local.get $var$8
   i32.const 0
   call $~lib/rt/itcms/__link
-  local.get $7
-  local.get $8
+  local.get $var$7
+  local.get $var$8
   i32.store $0 offset=4
-  local.get $7
-  local.get $6
+  local.get $var$7
+  local.get $var$6
   i32.store $0 offset=8
-  local.get $7
+  local.get $var$7
   local.set $11
   global.get $~lib/memory/__stack_pointer
   i32.const 8
@@ -62834,16 +62834,16 @@
   global.set $~lib/memory/__stack_pointer
   local.get $11
  )
- (func $~lib/typedarray/Int64Array#map (param $0 i32) (param $1 i32) (result i32)
-  (local $2 i32)
-  (local $3 i32)
-  (local $4 i32)
-  (local $5 i32)
-  (local $6 i32)
-  (local $7 i32)
-  (local $8 i32)
-  (local $9 i32)
-  (local $10 i32)
+ (func $~lib/typedarray/Int64Array#map (param $this i32) (param $fn i32) (result i32)
+  (local $var$2 i32)
+  (local $var$3 i32)
+  (local $var$4 i32)
+  (local $var$5 i32)
+  (local $var$6 i32)
+  (local $var$7 i32)
+  (local $var$8 i32)
+  (local $var$9 i32)
+  (local $var$10 i32)
   (local $11 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 8
@@ -62853,81 +62853,81 @@
   global.get $~lib/memory/__stack_pointer
   i64.const 0
   i64.store $0
-  local.get $0
-  local.set $3
-  local.get $1
-  local.set $2
-  local.get $3
+  local.get $this
+  local.set $var$3
+  local.get $fn
+  local.set $var$2
+  local.get $var$3
   call $~lib/typedarray/Int64Array#get:length
-  local.set $4
-  local.get $3
+  local.set $var$4
+  local.get $var$3
   i32.load $0 offset=4
-  local.set $5
-  local.get $4
+  local.set $var$5
+  local.get $var$4
   i32.const 3
   i32.shl
-  local.set $6
+  local.set $var$6
   global.get $~lib/memory/__stack_pointer
   i32.const 12
   i32.const 10
   call $~lib/rt/itcms/__new
-  local.tee $7
+  local.tee $var$7
   i32.store $0
   global.get $~lib/memory/__stack_pointer
-  local.get $6
+  local.get $var$6
   i32.const 0
   call $~lib/rt/itcms/__new
-  local.tee $8
+  local.tee $var$8
   i32.store $0 offset=4
   i32.const 0
-  local.set $9
+  local.set $var$9
   loop $for-loop|0
-   local.get $9
-   local.get $4
+   local.get $var$9
+   local.get $var$4
    i32.lt_s
-   local.set $10
-   local.get $10
+   local.set $var$10
+   local.get $var$10
    if
-    local.get $8
-    local.get $9
+    local.get $var$8
+    local.get $var$9
     i32.const 3
     i32.shl
     i32.add
-    local.get $5
-    local.get $9
+    local.get $var$5
+    local.get $var$9
     i32.const 3
     i32.shl
     i32.add
     i64.load $0
-    local.get $9
-    local.get $3
+    local.get $var$9
+    local.get $var$3
     i32.const 3
     global.set $~argumentsLength
-    local.get $2
+    local.get $var$2
     i32.load $0
     call_indirect $0 (type $i64_i32_i32_=>_i64)
     i64.store $0
-    local.get $9
+    local.get $var$9
     i32.const 1
     i32.add
-    local.set $9
+    local.set $var$9
     br $for-loop|0
    end
   end
-  local.get $7
-  local.get $8
+  local.get $var$7
+  local.get $var$8
   i32.store $0
-  local.get $7
-  local.get $8
+  local.get $var$7
+  local.get $var$8
   i32.const 0
   call $~lib/rt/itcms/__link
-  local.get $7
-  local.get $8
+  local.get $var$7
+  local.get $var$8
   i32.store $0 offset=4
-  local.get $7
-  local.get $6
+  local.get $var$7
+  local.get $var$6
   i32.store $0 offset=8
-  local.get $7
+  local.get $var$7
   local.set $11
   global.get $~lib/memory/__stack_pointer
   i32.const 8
@@ -62935,16 +62935,16 @@
   global.set $~lib/memory/__stack_pointer
   local.get $11
  )
- (func $~lib/typedarray/Uint64Array#map (param $0 i32) (param $1 i32) (result i32)
-  (local $2 i32)
-  (local $3 i32)
-  (local $4 i32)
-  (local $5 i32)
-  (local $6 i32)
-  (local $7 i32)
-  (local $8 i32)
-  (local $9 i32)
-  (local $10 i32)
+ (func $~lib/typedarray/Uint64Array#map (param $this i32) (param $fn i32) (result i32)
+  (local $var$2 i32)
+  (local $var$3 i32)
+  (local $var$4 i32)
+  (local $var$5 i32)
+  (local $var$6 i32)
+  (local $var$7 i32)
+  (local $var$8 i32)
+  (local $var$9 i32)
+  (local $var$10 i32)
   (local $11 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 8
@@ -62954,81 +62954,81 @@
   global.get $~lib/memory/__stack_pointer
   i64.const 0
   i64.store $0
-  local.get $0
-  local.set $3
-  local.get $1
-  local.set $2
-  local.get $3
+  local.get $this
+  local.set $var$3
+  local.get $fn
+  local.set $var$2
+  local.get $var$3
   call $~lib/typedarray/Uint64Array#get:length
-  local.set $4
-  local.get $3
+  local.set $var$4
+  local.get $var$3
   i32.load $0 offset=4
-  local.set $5
-  local.get $4
+  local.set $var$5
+  local.get $var$4
   i32.const 3
   i32.shl
-  local.set $6
+  local.set $var$6
   global.get $~lib/memory/__stack_pointer
   i32.const 12
   i32.const 11
   call $~lib/rt/itcms/__new
-  local.tee $7
+  local.tee $var$7
   i32.store $0
   global.get $~lib/memory/__stack_pointer
-  local.get $6
+  local.get $var$6
   i32.const 0
   call $~lib/rt/itcms/__new
-  local.tee $8
+  local.tee $var$8
   i32.store $0 offset=4
   i32.const 0
-  local.set $9
+  local.set $var$9
   loop $for-loop|0
-   local.get $9
-   local.get $4
+   local.get $var$9
+   local.get $var$4
    i32.lt_s
-   local.set $10
-   local.get $10
+   local.set $var$10
+   local.get $var$10
    if
-    local.get $8
-    local.get $9
+    local.get $var$8
+    local.get $var$9
     i32.const 3
     i32.shl
     i32.add
-    local.get $5
-    local.get $9
+    local.get $var$5
+    local.get $var$9
     i32.const 3
     i32.shl
     i32.add
     i64.load $0
-    local.get $9
-    local.get $3
+    local.get $var$9
+    local.get $var$3
     i32.const 3
     global.set $~argumentsLength
-    local.get $2
+    local.get $var$2
     i32.load $0
     call_indirect $0 (type $i64_i32_i32_=>_i64)
     i64.store $0
-    local.get $9
+    local.get $var$9
     i32.const 1
     i32.add
-    local.set $9
+    local.set $var$9
     br $for-loop|0
    end
   end
-  local.get $7
-  local.get $8
+  local.get $var$7
+  local.get $var$8
   i32.store $0
-  local.get $7
-  local.get $8
+  local.get $var$7
+  local.get $var$8
   i32.const 0
   call $~lib/rt/itcms/__link
-  local.get $7
-  local.get $8
+  local.get $var$7
+  local.get $var$8
   i32.store $0 offset=4
-  local.get $7
-  local.get $6
+  local.get $var$7
+  local.get $var$6
   i32.store $0 offset=8
-  local.get $7
+  local.get $var$7
   local.set $11
   global.get $~lib/memory/__stack_pointer
   i32.const 8
@@ -63036,16 +63036,16 @@
   global.set $~lib/memory/__stack_pointer
   local.get $11
  )
- (func $~lib/typedarray/Float32Array#map (param $0 i32) (param $1 i32) (result i32)
-  (local $2 i32)
-  (local $3 i32)
-  (local $4 i32)
-  (local $5 i32)
-  (local $6 i32)
-  (local $7 i32)
-  (local $8 i32)
-  (local $9 i32)
-  (local $10 i32)
+ (func $~lib/typedarray/Float32Array#map (param $this i32) (param $fn i32) (result i32)
+  (local $var$2 i32)
+  (local $var$3 i32)
+  (local $var$4 i32)
+  (local $var$5 i32)
+  (local $var$6 i32)
+  (local $var$7 i32)
+  (local $var$8 i32)
+  (local $var$9 i32)
+  (local $var$10 i32)
   (local $11 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 8
@@ -63055,81 +63055,81 @@
   global.get $~lib/memory/__stack_pointer
   i64.const 0
   i64.store $0
-  local.get $0
-  local.set $3
-  local.get $1
-  local.set $2
-  local.get $3
+  local.get $this
+  local.set $var$3
+  local.get $fn
+  local.set $var$2
+  local.get $var$3
   call $~lib/typedarray/Float32Array#get:length
-  local.set $4
-  local.get $3
+  local.set $var$4
+  local.get $var$3
   i32.load $0 offset=4
-  local.set $5
-  local.get $4
+  local.set $var$5
+  local.get $var$4
   i32.const 2
   i32.shl
-  local.set $6
+  local.set $var$6
   global.get $~lib/memory/__stack_pointer
   i32.const 12
   i32.const 12
   call $~lib/rt/itcms/__new
-  local.tee $7
+  local.tee $var$7
   i32.store $0
   global.get $~lib/memory/__stack_pointer
-  local.get $6
+  local.get $var$6
   i32.const 0
   call $~lib/rt/itcms/__new
-  local.tee $8
+  local.tee $var$8
   i32.store $0 offset=4
   i32.const 0
-  local.set $9
+  local.set $var$9
   loop $for-loop|0
-   local.get $9
-   local.get $4
+   local.get $var$9
+   local.get $var$4
    i32.lt_s
-   local.set $10
-   local.get $10
+   local.set $var$10
+   local.get $var$10
    if
-    local.get $8
-    local.get $9
+    local.get $var$8
+    local.get $var$9
     i32.const 2
     i32.shl
     i32.add
-    local.get $5
-    local.get $9
+    local.get $var$5
+    local.get $var$9
     i32.const 2
     i32.shl
     i32.add
     f32.load $0
-    local.get $9
-    local.get $3
+    local.get $var$9
+    local.get $var$3
     i32.const 3
     global.set $~argumentsLength
-    local.get $2
+    local.get $var$2
     i32.load $0
     call_indirect $0 (type $f32_i32_i32_=>_f32)
     f32.store $0
-    local.get $9
+    local.get $var$9
     i32.const 1
     i32.add
-    local.set $9
+    local.set $var$9
     br $for-loop|0
    end
   end
-  local.get $7
-  local.get $8
+  local.get $var$7
+  local.get $var$8
   i32.store $0
-  local.get $7
-  local.get $8
+  local.get $var$7
+  local.get $var$8
   i32.const 0
   call $~lib/rt/itcms/__link
-  local.get $7
-  local.get $8
+  local.get $var$7
+  local.get $var$8
   i32.store $0 offset=4
-  local.get $7
-  local.get $6
+  local.get $var$7
+  local.get $var$6
   i32.store $0 offset=8
-  local.get $7
+  local.get $var$7
   local.set $11
   global.get $~lib/memory/__stack_pointer
   i32.const 8
@@ -63137,16 +63137,16 @@
   global.set $~lib/memory/__stack_pointer
   local.get $11
  )
- (func $~lib/typedarray/Float64Array#map (param $0 i32) (param $1 i32) (result i32)
-  (local $2 i32)
-  (local $3 i32)
-  (local $4 i32)
-  (local $5 i32)
-  (local $6 i32)
-  (local $7 i32)
-  (local $8 i32)
-  (local $9 i32)
-  (local $10 i32)
+ (func $~lib/typedarray/Float64Array#map (param $this i32) (param $fn i32) (result i32)
+  (local $var$2 i32)
+  (local $var$3 i32)
+  (local $var$4 i32)
+  (local $var$5 i32)
+  (local $var$6 i32)
+  (local $var$7 i32)
+  (local $var$8 i32)
+  (local $var$9 i32)
+  (local $var$10 i32)
   (local $11 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 8
@@ -63156,81 +63156,81 @@
   global.get $~lib/memory/__stack_pointer
   i64.const 0
   i64.store $0
-  local.get $0
-  local.set $3
-  local.get $1
-  local.set $2
-  local.get $3
+  local.get $this
+  local.set $var$3
+  local.get $fn
+  local.set $var$2
+  local.get $var$3
   call $~lib/typedarray/Float64Array#get:length
-  local.set $4
-  local.get $3
+  local.set $var$4
+  local.get $var$3
   i32.load $0 offset=4
-  local.set $5
-  local.get $4
+  local.set $var$5
+  local.get $var$4
   i32.const 3
   i32.shl
-  local.set $6
+  local.set $var$6
   global.get $~lib/memory/__stack_pointer
   i32.const 12
   i32.const 13
   call $~lib/rt/itcms/__new
-  local.tee $7
+  local.tee $var$7
   i32.store $0
   global.get $~lib/memory/__stack_pointer
-  local.get $6
+  local.get $var$6
   i32.const 0
   call $~lib/rt/itcms/__new
-  local.tee $8
+  local.tee $var$8
   i32.store $0 offset=4
   i32.const 0
-  local.set $9
+  local.set $var$9
   loop $for-loop|0
-   local.get $9
-   local.get $4
+   local.get $var$9
+   local.get $var$4
    i32.lt_s
-   local.set $10
-   local.get $10
+   local.set $var$10
+   local.get $var$10
    if
-    local.get $8
-    local.get $9
+    local.get $var$8
+    local.get $var$9
     i32.const 3
     i32.shl
     i32.add
-    local.get $5
-    local.get $9
+    local.get $var$5
+    local.get $var$9
     i32.const 3
     i32.shl
     i32.add
     f64.load $0
-    local.get $9
-    local.get $3
+    local.get $var$9
+    local.get $var$3
     i32.const 3
     global.set $~argumentsLength
-    local.get $2
+    local.get $var$2
     i32.load $0
     call_indirect $0 (type $f64_i32_i32_=>_f64)
     f64.store $0
-    local.get $9
+    local.get $var$9
     i32.const 1
     i32.add
-    local.set $9
+    local.set $var$9
     br $for-loop|0
    end
   end
-  local.get $7
-  local.get $8
+  local.get $var$7
+  local.get $var$8
   i32.store $0
-  local.get $7
-  local.get $8
+  local.get $var$7
+  local.get $var$8
   i32.const 0
   call $~lib/rt/itcms/__link
-  local.get $7
-  local.get $8
+  local.get $var$7
+  local.get $var$8
   i32.store $0 offset=4
-  local.get $7
-  local.get $6
+  local.get $var$7
+  local.get $var$6
   i32.store $0 offset=8
-  local.get $7
+  local.get $var$7
   local.set $11
   global.get $~lib/memory/__stack_pointer
   i32.const 8
@@ -63238,18 +63238,18 @@
   global.set $~lib/memory/__stack_pointer
   local.get $11
  )
- (func $~lib/typedarray/Int8Array#filter (param $0 i32) (param $1 i32) (result i32)
-  (local $2 i32)
-  (local $3 i32)
-  (local $4 i32)
-  (local $5 i32)
-  (local $6 i32)
-  (local $7 i32)
-  (local $8 i32)
-  (local $9 i32)
-  (local $10 i32)
-  (local $11 i32)
-  (local $12 i32)
+ (func $~lib/typedarray/Int8Array#filter (param $this i32) (param $fn i32) (result i32)
+  (local $var$2 i32)
+  (local $var$3 i32)
+  (local $var$4 i32)
+  (local $var$5 i32)
+  (local $var$6 i32)
+  (local $var$7 i32)
+  (local $var$8 i32)
+  (local $var$9 i32)
+  (local $var$10 i32)
+  (local $var$11 i32)
+  (local $var$12 i32)
   (local $13 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 8
@@ -63259,99 +63259,99 @@
   global.get $~lib/memory/__stack_pointer
   i64.const 0
   i64.store $0
-  local.get $0
-  local.set $3
-  local.get $1
-  local.set $2
-  local.get $3
+  local.get $this
+  local.set $var$3
+  local.get $fn
+  local.set $var$2
+  local.get $var$3
   call $~lib/typedarray/Int8Array#get:length
-  local.set $4
+  local.set $var$4
   global.get $~lib/memory/__stack_pointer
   i32.const 12
   i32.const 3
   call $~lib/rt/itcms/__new
-  local.tee $5
+  local.tee $var$5
   i32.store $0
   global.get $~lib/memory/__stack_pointer
-  local.get $4
+  local.get $var$4
   i32.const 0
   i32.shl
   i32.const 0
   call $~lib/rt/itcms/__new
-  local.tee $6
+  local.tee $var$6
   i32.store $0 offset=4
-  local.get $3
+  local.get $var$3
   i32.load $0 offset=4
-  local.set $7
+  local.set $var$7
   i32.const 0
-  local.set $8
+  local.set $var$8
   i32.const 0
-  local.set $9
+  local.set $var$9
   loop $for-loop|0
-   local.get $9
-   local.get $4
+   local.get $var$9
+   local.get $var$4
    i32.lt_s
-   local.set $10
-   local.get $10
+   local.set $var$10
+   local.get $var$10
    if
-    local.get $7
-    local.get $9
+    local.get $var$7
+    local.get $var$9
     i32.const 0
     i32.shl
     i32.add
     i32.load8_s $0
-    local.set $11
-    local.get $11
-    local.get $9
-    local.get $3
+    local.set $var$11
+    local.get $var$11
+    local.get $var$9
+    local.get $var$3
     i32.const 3
     global.set $~argumentsLength
-    local.get $2
+    local.get $var$2
     i32.load $0
     call_indirect $0 (type $i32_i32_i32_=>_i32)
     if
-     local.get $6
-     local.get $8
-     local.tee $12
+     local.get $var$6
+     local.get $var$8
+     local.tee $var$12
      i32.const 1
      i32.add
-     local.set $8
-     local.get $12
+     local.set $var$8
+     local.get $var$12
      i32.const 0
      i32.shl
      i32.add
-     local.get $11
+     local.get $var$11
      i32.store8 $0
     end
-    local.get $9
+    local.get $var$9
     i32.const 1
     i32.add
-    local.set $9
+    local.set $var$9
     br $for-loop|0
    end
   end
-  local.get $8
+  local.get $var$8
   i32.const 0
   i32.shl
-  local.set $9
-  local.get $6
-  local.get $9
+  local.set $var$9
+  local.get $var$6
+  local.get $var$9
   call $~lib/rt/itcms/__renew
-  local.set $10
-  local.get $5
-  local.get $10
+  local.set $var$10
+  local.get $var$5
+  local.get $var$10
   i32.store $0
-  local.get $5
-  local.get $10
+  local.get $var$5
+  local.get $var$10
   i32.const 0
   call $~lib/rt/itcms/__link
-  local.get $5
-  local.get $9
+  local.get $var$5
+  local.get $var$9
   i32.store $0 offset=8
-  local.get $5
-  local.get $10
+  local.get $var$5
+  local.get $var$10
   i32.store $0 offset=4
-  local.get $5
+  local.get $var$5
   local.set $13
   global.get $~lib/memory/__stack_pointer
   i32.const 8
@@ -63359,18 +63359,18 @@
   global.set $~lib/memory/__stack_pointer
   local.get $13
  )
- (func $~lib/typedarray/Uint8Array#filter (param $0 i32) (param $1 i32) (result i32)
-  (local $2 i32)
-  (local $3 i32)
-  (local $4 i32)
-  (local $5 i32)
-  (local $6 i32)
-  (local $7 i32)
-  (local $8 i32)
-  (local $9 i32)
-  (local $10 i32)
-  (local $11 i32)
-  (local $12 i32)
+ (func $~lib/typedarray/Uint8Array#filter (param $this i32) (param $fn i32) (result i32)
+  (local $var$2 i32)
+  (local $var$3 i32)
+  (local $var$4 i32)
+  (local $var$5 i32)
+  (local $var$6 i32)
+  (local $var$7 i32)
+  (local $var$8 i32)
+  (local $var$9 i32)
+  (local $var$10 i32)
+  (local $var$11 i32)
+  (local $var$12 i32)
   (local $13 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 8
@@ -63380,99 +63380,99 @@
   global.get $~lib/memory/__stack_pointer
   i64.const 0
   i64.store $0
-  local.get $0
-  local.set $3
-  local.get $1
-  local.set $2
-  local.get $3
+  local.get $this
+  local.set $var$3
+  local.get $fn
+  local.set $var$2
+  local.get $var$3
   call $~lib/typedarray/Uint8Array#get:length
-  local.set $4
+  local.set $var$4
   global.get $~lib/memory/__stack_pointer
   i32.const 12
   i32.const 4
   call $~lib/rt/itcms/__new
-  local.tee $5
+  local.tee $var$5
   i32.store $0
   global.get $~lib/memory/__stack_pointer
-  local.get $4
+  local.get $var$4
   i32.const 0
   i32.shl
   i32.const 0
   call $~lib/rt/itcms/__new
-  local.tee $6
+  local.tee $var$6
   i32.store $0 offset=4
-  local.get $3
+  local.get $var$3
   i32.load $0 offset=4
-  local.set $7
+  local.set $var$7
   i32.const 0
-  local.set $8
+  local.set $var$8
   i32.const 0
-  local.set $9
+  local.set $var$9
   loop $for-loop|0
-   local.get $9
-   local.get $4
+   local.get $var$9
+   local.get $var$4
    i32.lt_s
-   local.set $10
-   local.get $10
+   local.set $var$10
+   local.get $var$10
    if
-    local.get $7
-    local.get $9
+    local.get $var$7
+    local.get $var$9
     i32.const 0
     i32.shl
     i32.add
     i32.load8_u $0
-    local.set $11
-    local.get $11
-    local.get $9
-    local.get $3
+    local.set $var$11
+    local.get $var$11
+    local.get $var$9
+    local.get $var$3
     i32.const 3
     global.set $~argumentsLength
-    local.get $2
+    local.get $var$2
     i32.load $0
     call_indirect $0 (type $i32_i32_i32_=>_i32)
     if
-     local.get $6
-     local.get $8
-     local.tee $12
+     local.get $var$6
+     local.get $var$8
+     local.tee $var$12
      i32.const 1
      i32.add
-     local.set $8
-     local.get $12
+     local.set $var$8
+     local.get $var$12
      i32.const 0
      i32.shl
      i32.add
-     local.get $11
+     local.get $var$11
      i32.store8 $0
     end
-    local.get $9
+    local.get $var$9
     i32.const 1
     i32.add
-    local.set $9
+    local.set $var$9
     br $for-loop|0
    end
   end
-  local.get $8
+  local.get $var$8
   i32.const 0
   i32.shl
-  local.set $9
-  local.get $6
-  local.get $9
+  local.set $var$9
+  local.get $var$6
+  local.get $var$9
   call $~lib/rt/itcms/__renew
-  local.set $10
-  local.get $5
-  local.get $10
+  local.set $var$10
+  local.get $var$5
+  local.get $var$10
   i32.store $0
-  local.get $5
-  local.get $10
+  local.get $var$5
+  local.get $var$10
   i32.const 0
   call $~lib/rt/itcms/__link
-  local.get $5
-  local.get $9
+  local.get $var$5
+  local.get $var$9
   i32.store $0 offset=8
-  local.get $5
-  local.get $10
+  local.get $var$5
+  local.get $var$10
   i32.store $0 offset=4
-  local.get $5
+  local.get $var$5
   local.set $13
   global.get $~lib/memory/__stack_pointer
   i32.const 8
@@ -63480,18 +63480,18 @@
   global.set $~lib/memory/__stack_pointer
   local.get $13
  )
- (func $~lib/typedarray/Uint8ClampedArray#filter (param $0 i32) (param $1 i32) (result i32)
-  (local $2 i32)
-  (local $3 i32)
-  (local $4 i32)
-  (local $5 i32)
-  (local $6 i32)
-  (local $7 i32)
-  (local $8 i32)
-  (local $9 i32)
-  (local $10 i32)
-  (local $11 i32)
-  (local $12 i32)
+ (func $~lib/typedarray/Uint8ClampedArray#filter (param $this i32) (param $fn i32) (result i32)
+  (local $var$2 i32)
+  (local $var$3 i32)
+  (local $var$4 i32)
+  (local $var$5 i32)
+  (local $var$6 i32)
+  (local $var$7 i32)
+  (local $var$8 i32)
+  (local $var$9 i32)
+  (local $var$10 i32)
+  (local $var$11 i32)
+  (local $var$12 i32)
   (local $13 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 8
@@ -63501,99 +63501,99 @@
   global.get $~lib/memory/__stack_pointer
   i64.const 0
   i64.store $0
-  local.get $0
-  local.set $3
-  local.get $1
-  local.set $2
-  local.get $3
+  local.get $this
+  local.set $var$3
+  local.get $fn
+  local.set $var$2
+  local.get $var$3
   call $~lib/typedarray/Uint8ClampedArray#get:length
-  local.set $4
+  local.set $var$4
   global.get $~lib/memory/__stack_pointer
   i32.const 12
   i32.const 5
   call $~lib/rt/itcms/__new
-  local.tee $5
+  local.tee $var$5
   i32.store $0
   global.get $~lib/memory/__stack_pointer
-  local.get $4
+  local.get $var$4
   i32.const 0
   i32.shl
   i32.const 0
   call $~lib/rt/itcms/__new
-  local.tee $6
+  local.tee $var$6
   i32.store $0 offset=4
-  local.get $3
+  local.get $var$3
   i32.load $0 offset=4
-  local.set $7
+  local.set $var$7
   i32.const 0
-  local.set $8
+  local.set $var$8
   i32.const 0
-  local.set $9
+  local.set $var$9
   loop $for-loop|0
-   local.get $9
-   local.get $4
+   local.get $var$9
+   local.get $var$4
    i32.lt_s
-   local.set $10
-   local.get $10
+   local.set $var$10
+   local.get $var$10
    if
-    local.get $7
-    local.get $9
+    local.get $var$7
+    local.get $var$9
     i32.const 0
     i32.shl
     i32.add
     i32.load8_u $0
-    local.set $11
-    local.get $11
-    local.get $9
-    local.get $3
+    local.set $var$11
+    local.get $var$11
+    local.get $var$9
+    local.get $var$3
     i32.const 3
     global.set $~argumentsLength
-    local.get $2
+    local.get $var$2
     i32.load $0
     call_indirect $0 (type $i32_i32_i32_=>_i32)
     if
-     local.get $6
-     local.get $8
-     local.tee $12
+     local.get $var$6
+     local.get $var$8
+     local.tee $var$12
      i32.const 1
      i32.add
-     local.set $8
-     local.get $12
+     local.set $var$8
+     local.get $var$12
      i32.const 0
      i32.shl
      i32.add
-     local.get $11
+     local.get $var$11
      i32.store8 $0
     end
-    local.get $9
+    local.get $var$9
     i32.const 1
     i32.add
-    local.set $9
+    local.set $var$9
     br $for-loop|0
    end
   end
-  local.get $8
+  local.get $var$8
   i32.const 0
   i32.shl
-  local.set $9
-  local.get $6
-  local.get $9
+  local.set $var$9
+  local.get $var$6
+  local.get $var$9
   call $~lib/rt/itcms/__renew
-  local.set $10
-  local.get $5
-  local.get $10
+  local.set $var$10
+  local.get $var$5
+  local.get $var$10
   i32.store $0
-  local.get $5
-  local.get $10
+  local.get $var$5
+  local.get $var$10
   i32.const 0
   call $~lib/rt/itcms/__link
-  local.get $5
-  local.get $9
+  local.get $var$5
+  local.get $var$9
   i32.store $0 offset=8
-  local.get $5
-  local.get $10
+  local.get $var$5
+  local.get $var$10
   i32.store $0 offset=4
-  local.get $5
+  local.get $var$5
   local.set $13
   global.get $~lib/memory/__stack_pointer
   i32.const 8
@@ -63601,18 +63601,18 @@
   global.set $~lib/memory/__stack_pointer
   local.get $13
  )
- (func $~lib/typedarray/Int16Array#filter (param $0 i32) (param $1 i32) (result i32)
-  (local $2 i32)
-  (local $3 i32)
-  (local $4 i32)
-  (local $5 i32)
-  (local $6 i32)
-  (local $7 i32)
-  (local $8 i32)
-  (local $9 i32)
-  (local $10 i32)
-  (local $11 i32)
-  (local $12 i32)
+ (func $~lib/typedarray/Int16Array#filter (param $this i32) (param $fn i32) (result i32)
+  (local $var$2 i32)
+  (local $var$3 i32)
+  (local $var$4 i32)
+  (local $var$5 i32)
+  (local $var$6 i32)
+  (local $var$7 i32)
+  (local $var$8 i32)
+  (local $var$9 i32)
+  (local $var$10 i32)
+  (local $var$11 i32)
+  (local $var$12 i32)
   (local $13 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 8
@@ -63622,99 +63622,99 @@
   global.get $~lib/memory/__stack_pointer
   i64.const 0
   i64.store $0
-  local.get $0
-  local.set $3
-  local.get $1
-  local.set $2
-  local.get $3
+  local.get $this
+  local.set $var$3
+  local.get $fn
+  local.set $var$2
+  local.get $var$3
   call $~lib/typedarray/Int16Array#get:length
-  local.set $4
+  local.set $var$4
   global.get $~lib/memory/__stack_pointer
   i32.const 12
   i32.const 6
   call $~lib/rt/itcms/__new
-  local.tee $5
+  local.tee $var$5
   i32.store $0
   global.get $~lib/memory/__stack_pointer
-  local.get $4
+  local.get $var$4
   i32.const 1
   i32.shl
   i32.const 0
   call $~lib/rt/itcms/__new
-  local.tee $6
+  local.tee $var$6
   i32.store $0 offset=4
-  local.get $3
+  local.get $var$3
   i32.load $0 offset=4
-  local.set $7
+  local.set $var$7
   i32.const 0
-  local.set $8
+  local.set $var$8
   i32.const 0
-  local.set $9
+  local.set $var$9
   loop $for-loop|0
-   local.get $9
-   local.get $4
+   local.get $var$9
+   local.get $var$4
    i32.lt_s
-   local.set $10
-   local.get $10
+   local.set $var$10
+   local.get $var$10
    if
-    local.get $7
-    local.get $9
+    local.get $var$7
+    local.get $var$9
     i32.const 1
     i32.shl
     i32.add
     i32.load16_s $0
-    local.set $11
-    local.get $11
-    local.get $9
-    local.get $3
+    local.set $var$11
+    local.get $var$11
+    local.get $var$9
+    local.get $var$3
     i32.const 3
     global.set $~argumentsLength
-    local.get $2
+    local.get $var$2
     i32.load $0
     call_indirect $0 (type $i32_i32_i32_=>_i32)
     if
-     local.get $6
-     local.get $8
-     local.tee $12
+     local.get $var$6
+     local.get $var$8
+     local.tee $var$12
      i32.const 1
      i32.add
-     local.set $8
-     local.get $12
+     local.set $var$8
+     local.get $var$12
      i32.const 1
      i32.shl
      i32.add
-     local.get $11
+     local.get $var$11
      i32.store16 $0
     end
-    local.get $9
+    local.get $var$9
     i32.const 1
     i32.add
-    local.set $9
+    local.set $var$9
     br $for-loop|0
    end
   end
-  local.get $8
+  local.get $var$8
   i32.const 1
   i32.shl
-  local.set $9
-  local.get $6
-  local.get $9
+  local.set $var$9
+  local.get $var$6
+  local.get $var$9
   call $~lib/rt/itcms/__renew
-  local.set $10
-  local.get $5
-  local.get $10
+  local.set $var$10
+  local.get $var$5
+  local.get $var$10
   i32.store $0
-  local.get $5
-  local.get $10
+  local.get $var$5
+  local.get $var$10
   i32.const 0
   call $~lib/rt/itcms/__link
-  local.get $5
-  local.get $9
+  local.get $var$5
+  local.get $var$9
   i32.store $0 offset=8
-  local.get $5
-  local.get $10
+  local.get $var$5
+  local.get $var$10
   i32.store $0 offset=4
-  local.get $5
+  local.get $var$5
   local.set $13
   global.get $~lib/memory/__stack_pointer
   i32.const 8
@@ -63722,18 +63722,18 @@
   global.set $~lib/memory/__stack_pointer
   local.get $13
  )
- (func $~lib/typedarray/Uint16Array#filter (param $0 i32) (param $1 i32) (result i32)
-  (local $2 i32)
-  (local $3 i32)
-  (local $4 i32)
-  (local $5 i32)
-  (local $6 i32)
-  (local $7 i32)
-  (local $8 i32)
-  (local $9 i32)
-  (local $10 i32)
-  (local $11 i32)
-  (local $12 i32)
+ (func $~lib/typedarray/Uint16Array#filter (param $this i32) (param $fn i32) (result i32)
+  (local $var$2 i32)
+  (local $var$3 i32)
+  (local $var$4 i32)
+  (local $var$5 i32)
+  (local $var$6 i32)
+  (local $var$7 i32)
+  (local $var$8 i32)
+  (local $var$9 i32)
+  (local $var$10 i32)
+  (local $var$11 i32)
+  (local $var$12 i32)
   (local $13 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 8
@@ -63743,99 +63743,99 @@
   global.get $~lib/memory/__stack_pointer
   i64.const 0
   i64.store $0
-  local.get $0
-  local.set $3
-  local.get $1
-  local.set $2
-  local.get $3
+  local.get $this
+  local.set $var$3
+  local.get $fn
+  local.set $var$2
+  local.get $var$3
   call $~lib/typedarray/Uint16Array#get:length
-  local.set $4
+  local.set $var$4
   global.get $~lib/memory/__stack_pointer
   i32.const 12
   i32.const 7
   call $~lib/rt/itcms/__new
-  local.tee $5
+  local.tee $var$5
   i32.store $0
   global.get $~lib/memory/__stack_pointer
-  local.get $4
+  local.get $var$4
   i32.const 1
   i32.shl
   i32.const 0
   call $~lib/rt/itcms/__new
-  local.tee $6
+  local.tee $var$6
   i32.store $0 offset=4
-  local.get $3
+  local.get $var$3
   i32.load $0 offset=4
-  local.set $7
+  local.set $var$7
   i32.const 0
-  local.set $8
+  local.set $var$8
   i32.const 0
-  local.set $9
+  local.set $var$9
   loop $for-loop|0
-   local.get $9
-   local.get $4
+   local.get $var$9
+   local.get $var$4
    i32.lt_s
-   local.set $10
-   local.get $10
+   local.set $var$10
+   local.get $var$10
    if
-    local.get $7
-    local.get $9
+    local.get $var$7
+    local.get $var$9
     i32.const 1
     i32.shl
     i32.add
     i32.load16_u $0
-    local.set $11
-    local.get $11
-    local.get $9
-    local.get $3
+    local.set $var$11
+    local.get $var$11
+    local.get $var$9
+    local.get $var$3
     i32.const 3
     global.set $~argumentsLength
-    local.get $2
+    local.get $var$2
     i32.load $0
     call_indirect $0 (type $i32_i32_i32_=>_i32)
     if
-     local.get $6
-     local.get $8
-     local.tee $12
+     local.get $var$6
+     local.get $var$8
+     local.tee $var$12
      i32.const 1
      i32.add
-     local.set $8
-     local.get $12
+     local.set $var$8
+     local.get $var$12
      i32.const 1
      i32.shl
      i32.add
-     local.get $11
+     local.get $var$11
      i32.store16 $0
     end
-    local.get $9
+    local.get $var$9
     i32.const 1
     i32.add
-    local.set $9
+    local.set $var$9
     br $for-loop|0
    end
   end
-  local.get $8
+  local.get $var$8
   i32.const 1
   i32.shl
-  local.set $9
-  local.get $6
-  local.get $9
+  local.set $var$9
+  local.get $var$6
+  local.get $var$9
   call $~lib/rt/itcms/__renew
-  local.set $10
-  local.get $5
-  local.get $10
+  local.set $var$10
+  local.get $var$5
+  local.get $var$10
   i32.store $0
-  local.get $5
-  local.get $10
+  local.get $var$5
+  local.get $var$10
   i32.const 0
   call $~lib/rt/itcms/__link
-  local.get $5
-  local.get $9
+  local.get $var$5
+  local.get $var$9
   i32.store $0 offset=8
-  local.get $5
-  local.get $10
+  local.get $var$5
+  local.get $var$10
   i32.store $0 offset=4
-  local.get $5
+  local.get $var$5
   local.set $13
   global.get $~lib/memory/__stack_pointer
   i32.const 8
@@ -63843,18 +63843,18 @@
   global.set $~lib/memory/__stack_pointer
   local.get $13
  )
- (func $~lib/typedarray/Int32Array#filter (param $0 i32) (param $1 i32) (result i32)
-  (local $2 i32)
-  (local $3 i32)
-  (local $4 i32)
-  (local $5 i32)
-  (local $6 i32)
-  (local $7 i32)
-  (local $8 i32)
-  (local $9 i32)
-  (local $10 i32)
-  (local $11 i32)
-  (local $12 i32)
+ (func $~lib/typedarray/Int32Array#filter (param $this i32) (param $fn i32) (result i32)
+  (local $var$2 i32)
+  (local $var$3 i32)
+  (local $var$4 i32)
+  (local $var$5 i32)
+  (local $var$6 i32)
+  (local $var$7 i32)
+  (local $var$8 i32)
+  (local $var$9 i32)
+  (local $var$10 i32)
+  (local $var$11 i32)
+  (local $var$12 i32)
   (local $13 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 8
@@ -63864,99 +63864,99 @@
   global.get $~lib/memory/__stack_pointer
   i64.const 0
   i64.store $0
-  local.get $0
-  local.set $3
-  local.get $1
-  local.set $2
-  local.get $3
+  local.get $this
+  local.set $var$3
+  local.get $fn
+  local.set $var$2
+  local.get $var$3
   call $~lib/typedarray/Int32Array#get:length
-  local.set $4
+  local.set $var$4
   global.get $~lib/memory/__stack_pointer
   i32.const 12
   i32.const 8
   call $~lib/rt/itcms/__new
-  local.tee $5
+  local.tee $var$5
   i32.store $0
   global.get $~lib/memory/__stack_pointer
-  local.get $4
+  local.get $var$4
   i32.const 2
   i32.shl
   i32.const 0
   call $~lib/rt/itcms/__new
-  local.tee $6
+  local.tee $var$6
   i32.store $0 offset=4
-  local.get $3
+  local.get $var$3
   i32.load $0 offset=4
-  local.set $7
+  local.set $var$7
   i32.const 0
-  local.set $8
+  local.set $var$8
   i32.const 0
-  local.set $9
+  local.set $var$9
   loop $for-loop|0
-   local.get $9
-   local.get $4
+   local.get $var$9
+   local.get $var$4
    i32.lt_s
-   local.set $10
-   local.get $10
+   local.set $var$10
+   local.get $var$10
    if
-    local.get $7
-    local.get $9
+    local.get $var$7
+    local.get $var$9
     i32.const 2
     i32.shl
     i32.add
     i32.load $0
-    local.set $11
-    local.get $11
-    local.get $9
-    local.get $3
+    local.set $var$11
+    local.get $var$11
+    local.get $var$9
+    local.get $var$3
     i32.const 3
     global.set $~argumentsLength
-    local.get $2
+    local.get $var$2
     i32.load $0
     call_indirect $0 (type $i32_i32_i32_=>_i32)
     if
-     local.get $6
-     local.get $8
-     local.tee $12
+     local.get $var$6
+     local.get $var$8
+     local.tee $var$12
      i32.const 1
      i32.add
-     local.set $8
-     local.get $12
+     local.set $var$8
+     local.get $var$12
      i32.const 2
      i32.shl
      i32.add
-     local.get $11
+     local.get $var$11
      i32.store $0
     end
-    local.get $9
+    local.get $var$9
     i32.const 1
     i32.add
-    local.set $9
+    local.set $var$9
     br $for-loop|0
    end
   end
-  local.get $8
+  local.get $var$8
   i32.const 2
   i32.shl
-  local.set $9
-  local.get $6
-  local.get $9
+  local.set $var$9
+  local.get $var$6
+  local.get $var$9
   call $~lib/rt/itcms/__renew
-  local.set $10
-  local.get $5
-  local.get $10
+  local.set $var$10
+  local.get $var$5
+  local.get $var$10
   i32.store $0
-  local.get $5
-  local.get $10
+  local.get $var$5
+  local.get $var$10
   i32.const 0
   call $~lib/rt/itcms/__link
-  local.get $5
-  local.get $9
+  local.get $var$5
+  local.get $var$9
   i32.store $0 offset=8
-  local.get $5
-  local.get $10
+  local.get $var$5
+  local.get $var$10
   i32.store $0 offset=4
-  local.get $5
+  local.get $var$5
   local.set $13
   global.get $~lib/memory/__stack_pointer
   i32.const 8
@@ -63964,18 +63964,18 @@
   global.set $~lib/memory/__stack_pointer
   local.get $13
  )
- (func $~lib/typedarray/Uint32Array#filter (param $0 i32) (param $1 i32) (result i32)
-  (local $2 i32)
-  (local $3 i32)
-  (local $4 i32)
-  (local $5 i32)
-  (local $6 i32)
-  (local $7 i32)
-  (local $8 i32)
-  (local $9 i32)
-  (local $10 i32)
-  (local $11 i32)
-  (local $12 i32)
+ (func $~lib/typedarray/Uint32Array#filter (param $this i32) (param $fn i32) (result i32)
+  (local $var$2 i32)
+  (local $var$3 i32)
+  (local $var$4 i32)
+  (local $var$5 i32)
+  (local $var$6 i32)
+  (local $var$7 i32)
+  (local $var$8 i32)
+  (local $var$9 i32)
+  (local $var$10 i32)
+  (local $var$11 i32)
+  (local $var$12 i32)
   (local $13 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 8
@@ -63985,99 +63985,99 @@
   global.get $~lib/memory/__stack_pointer
   i64.const 0
   i64.store $0
-  local.get $0
-  local.set $3
-  local.get $1
-  local.set $2
-  local.get $3
+  local.get $this
+  local.set $var$3
+  local.get $fn
+  local.set $var$2
+  local.get $var$3
   call $~lib/typedarray/Uint32Array#get:length
-  local.set $4
+  local.set $var$4
   global.get $~lib/memory/__stack_pointer
   i32.const 12
   i32.const 9
   call $~lib/rt/itcms/__new
-  local.tee $5
+  local.tee $var$5
   i32.store $0
   global.get $~lib/memory/__stack_pointer
-  local.get $4
+  local.get $var$4
   i32.const 2
   i32.shl
   i32.const 0
   call $~lib/rt/itcms/__new
-  local.tee $6
+  local.tee $var$6
   i32.store $0 offset=4
-  local.get $3
+  local.get $var$3
   i32.load $0 offset=4
-  local.set $7
+  local.set $var$7
   i32.const 0
-  local.set $8
+  local.set $var$8
   i32.const 0
-  local.set $9
+  local.set $var$9
   loop $for-loop|0
-   local.get $9
-   local.get $4
+   local.get $var$9
+   local.get $var$4
    i32.lt_s
-   local.set $10
-   local.get $10
+   local.set $var$10
+   local.get $var$10
    if
-    local.get $7
-    local.get $9
+    local.get $var$7
+    local.get $var$9
     i32.const 2
     i32.shl
     i32.add
     i32.load $0
-    local.set $11
-    local.get $11
-    local.get $9
-    local.get $3
+    local.set $var$11
+    local.get $var$11
+    local.get $var$9
+    local.get $var$3
     i32.const 3
     global.set $~argumentsLength
-    local.get $2
+    local.get $var$2
     i32.load $0
     call_indirect $0 (type $i32_i32_i32_=>_i32)
     if
-     local.get $6
-     local.get $8
-     local.tee $12
+     local.get $var$6
+     local.get $var$8
+     local.tee $var$12
      i32.const 1
      i32.add
-     local.set $8
-     local.get $12
+     local.set $var$8
+     local.get $var$12
      i32.const 2
      i32.shl
      i32.add
-     local.get $11
+     local.get $var$11
      i32.store $0
     end
-    local.get $9
+    local.get $var$9
     i32.const 1
     i32.add
-    local.set $9
+    local.set $var$9
     br $for-loop|0
    end
   end
-  local.get $8
+  local.get $var$8
   i32.const 2
   i32.shl
-  local.set $9
-  local.get $6
-  local.get $9
+  local.set $var$9
+  local.get $var$6
+  local.get $var$9
   call $~lib/rt/itcms/__renew
-  local.set $10
-  local.get $5
-  local.get $10
+  local.set $var$10
+  local.get $var$5
+  local.get $var$10
   i32.store $0
-  local.get $5
-  local.get $10
+  local.get $var$5
+  local.get $var$10
   i32.const 0
   call $~lib/rt/itcms/__link
-  local.get $5
-  local.get $9
+  local.get $var$5
+  local.get $var$9
   i32.store $0 offset=8
-  local.get $5
-  local.get $10
+  local.get $var$5
+  local.get $var$10
   i32.store $0 offset=4
-  local.get $5
+  local.get $var$5
   local.set $13
   global.get $~lib/memory/__stack_pointer
   i32.const 8
@@ -64085,18 +64085,18 @@
   global.set $~lib/memory/__stack_pointer
   local.get $13
  )
- (func $~lib/typedarray/Int64Array#filter (param $0 i32) (param $1 i32) (result i32)
-  (local $2 i32)
-  (local $3 i32)
-  (local $4 i32)
-  (local $5 i32)
-  (local $6 i32)
-  (local $7 i32)
-  (local $8 i32)
-  (local $9 i32)
-  (local $10 i32)
-  (local $11 i64)
-  (local $12 i32)
+ (func $~lib/typedarray/Int64Array#filter (param $this i32) (param $fn i32) (result i32)
+  (local $var$2 i32)
+  (local $var$3 i32)
+  (local $var$4 i32)
+  (local $var$5 i32)
+  (local $var$6 i32)
+  (local $var$7 i32)
+  (local $var$8 i32)
+  (local $var$9 i32)
+  (local $var$10 i32)
+  (local $var$11 i64)
+  (local $var$12 i32)
   (local $13 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 8
@@ -64106,99 +64106,99 @@
   global.get $~lib/memory/__stack_pointer
   i64.const 0
   i64.store $0
-  local.get $0
-  local.set $3
-  local.get $1
-  local.set $2
-  local.get $3
+  local.get $this
+  local.set $var$3
+  local.get $fn
+  local.set $var$2
+  local.get $var$3
   call $~lib/typedarray/Int64Array#get:length
-  local.set $4
+  local.set $var$4
   global.get $~lib/memory/__stack_pointer
   i32.const 12
   i32.const 10
   call $~lib/rt/itcms/__new
-  local.tee $5
+  local.tee $var$5
   i32.store $0
   global.get $~lib/memory/__stack_pointer
-  local.get $4
+  local.get $var$4
   i32.const 3
   i32.shl
   i32.const 0
   call $~lib/rt/itcms/__new
-  local.tee $6
+  local.tee $var$6
   i32.store $0 offset=4
-  local.get $3
+  local.get $var$3
   i32.load $0 offset=4
-  local.set $7
+  local.set $var$7
   i32.const 0
-  local.set $8
+  local.set $var$8
   i32.const 0
-  local.set $9
+  local.set $var$9
   loop $for-loop|0
-   local.get $9
-   local.get $4
+   local.get $var$9
+   local.get $var$4
    i32.lt_s
-   local.set $10
-   local.get $10
+   local.set $var$10
+   local.get $var$10
    if
-    local.get $7
-    local.get $9
+    local.get $var$7
+    local.get $var$9
     i32.const 3
     i32.shl
     i32.add
     i64.load $0
-    local.set $11
-    local.get $11
-    local.get $9
-    local.get $3
+    local.set $var$11
+    local.get $var$11
+    local.get $var$9
+    local.get $var$3
     i32.const 3
     global.set $~argumentsLength
-    local.get $2
+    local.get $var$2
     i32.load $0
     call_indirect $0 (type $i64_i32_i32_=>_i32)
     if
-     local.get $6
-     local.get $8
-     local.tee $12
+     local.get $var$6
+     local.get $var$8
+     local.tee $var$12
      i32.const 1
      i32.add
-     local.set $8
-     local.get $12
+     local.set $var$8
+     local.get $var$12
      i32.const 3
      i32.shl
      i32.add
-     local.get $11
+     local.get $var$11
      i64.store $0
     end
-    local.get $9
+    local.get $var$9
     i32.const 1
     i32.add
-    local.set $9
+    local.set $var$9
     br $for-loop|0
    end
   end
-  local.get $8
+  local.get $var$8
   i32.const 3
   i32.shl
-  local.set $9
-  local.get $6
-  local.get $9
+  local.set $var$9
+  local.get $var$6
+  local.get $var$9
   call $~lib/rt/itcms/__renew
-  local.set $10
-  local.get $5
-  local.get $10
+  local.set $var$10
+  local.get $var$5
+  local.get $var$10
   i32.store $0
-  local.get $5
-  local.get $10
+  local.get $var$5
+  local.get $var$10
   i32.const 0
   call $~lib/rt/itcms/__link
-  local.get $5
-  local.get $9
+  local.get $var$5
+  local.get $var$9
   i32.store $0 offset=8
-  local.get $5
-  local.get $10
+  local.get $var$5
+  local.get $var$10
   i32.store $0 offset=4
-  local.get $5
+  local.get $var$5
   local.set $13
   global.get $~lib/memory/__stack_pointer
   i32.const 8
@@ -64206,18 +64206,18 @@
   global.set $~lib/memory/__stack_pointer
   local.get $13
  )
- (func $~lib/typedarray/Uint64Array#filter (param $0 i32) (param $1 i32) (result i32)
-  (local $2 i32)
-  (local $3 i32)
-  (local $4 i32)
-  (local $5 i32)
-  (local $6 i32)
-  (local $7 i32)
-  (local $8 i32)
-  (local $9 i32)
-  (local $10 i32)
-  (local $11 i64)
-  (local $12 i32)
+ (func $~lib/typedarray/Uint64Array#filter (param $this i32) (param $fn i32) (result i32)
+  (local $var$2 i32)
+  (local $var$3 i32)
+  (local $var$4 i32)
+  (local $var$5 i32)
+  (local $var$6 i32)
+  (local $var$7 i32)
+  (local $var$8 i32)
+  (local $var$9 i32)
+  (local $var$10 i32)
+  (local $var$11 i64)
+  (local $var$12 i32)
   (local $13 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 8
@@ -64227,99 +64227,99 @@
   global.get $~lib/memory/__stack_pointer
   i64.const 0
   i64.store $0
-  local.get $0
-  local.set $3
-  local.get $1
-  local.set $2
-  local.get $3
+  local.get $this
+  local.set $var$3
+  local.get $fn
+  local.set $var$2
+  local.get $var$3
   call $~lib/typedarray/Uint64Array#get:length
-  local.set $4
+  local.set $var$4
   global.get $~lib/memory/__stack_pointer
   i32.const 12
   i32.const 11
   call $~lib/rt/itcms/__new
-  local.tee $5
+  local.tee $var$5
   i32.store $0
   global.get $~lib/memory/__stack_pointer
-  local.get $4
+  local.get $var$4
   i32.const 3
   i32.shl
   i32.const 0
   call $~lib/rt/itcms/__new
-  local.tee $6
+  local.tee $var$6
   i32.store $0 offset=4
-  local.get $3
+  local.get $var$3
   i32.load $0 offset=4
-  local.set $7
+  local.set $var$7
   i32.const 0
-  local.set $8
+  local.set $var$8
   i32.const 0
-  local.set $9
+  local.set $var$9
   loop $for-loop|0
-   local.get $9
-   local.get $4
+   local.get $var$9
+   local.get $var$4
    i32.lt_s
-   local.set $10
-   local.get $10
+   local.set $var$10
+   local.get $var$10
    if
-    local.get $7
-    local.get $9
+    local.get $var$7
+    local.get $var$9
     i32.const 3
     i32.shl
     i32.add
     i64.load $0
-    local.set $11
-    local.get $11
-    local.get $9
-    local.get $3
+    local.set $var$11
+    local.get $var$11
+    local.get $var$9
+    local.get $var$3
     i32.const 3
     global.set $~argumentsLength
-    local.get $2
+    local.get $var$2
     i32.load $0
     call_indirect $0 (type $i64_i32_i32_=>_i32)
     if
-     local.get $6
-     local.get $8
-     local.tee $12
+     local.get $var$6
+     local.get $var$8
+     local.tee $var$12
      i32.const 1
      i32.add
-     local.set $8
-     local.get $12
+     local.set $var$8
+     local.get $var$12
      i32.const 3
      i32.shl
      i32.add
-     local.get $11
+     local.get $var$11
      i64.store $0
     end
-    local.get $9
+    local.get $var$9
     i32.const 1
     i32.add
-    local.set $9
+    local.set $var$9
     br $for-loop|0
    end
   end
-  local.get $8
+  local.get $var$8
   i32.const 3
   i32.shl
-  local.set $9
-  local.get $6
-  local.get $9
+  local.set $var$9
+  local.get $var$6
+  local.get $var$9
   call $~lib/rt/itcms/__renew
-  local.set $10
-  local.get $5
-  local.get $10
+  local.set $var$10
+  local.get $var$5
+  local.get $var$10
   i32.store $0
-  local.get $5
-  local.get $10
+  local.get $var$5
+  local.get $var$10
   i32.const 0
   call $~lib/rt/itcms/__link
-  local.get $5
-  local.get $9
+  local.get $var$5
+  local.get $var$9
   i32.store $0 offset=8
-  local.get $5
-  local.get $10
+  local.get $var$5
+  local.get $var$10
   i32.store $0 offset=4
-  local.get $5
+  local.get $var$5
   local.set $13
   global.get $~lib/memory/__stack_pointer
   i32.const 8
@@ -64327,18 +64327,18 @@
   global.set $~lib/memory/__stack_pointer
   local.get $13
  )
- (func $~lib/typedarray/Float32Array#filter (param $0 i32) (param $1 i32) (result i32)
-  (local $2 i32)
-  (local $3 i32)
-  (local $4 i32)
-  (local $5 i32)
-  (local $6 i32)
-  (local $7 i32)
-  (local $8 i32)
-  (local $9 i32)
-  (local $10 i32)
-  (local $11 f32)
-  (local $12 i32)
+ (func $~lib/typedarray/Float32Array#filter (param $this i32) (param $fn i32) (result i32)
+  (local $var$2 i32)
+  (local $var$3 i32)
+  (local $var$4 i32)
+  (local $var$5 i32)
+  (local $var$6 i32)
+  (local $var$7 i32)
+  (local $var$8 i32)
+  (local $var$9 i32)
+  (local $var$10 i32)
+  (local $var$11 f32)
+  (local $var$12 i32)
   (local $13 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 8
@@ -64348,99 +64348,99 @@
   global.get $~lib/memory/__stack_pointer
   i64.const 0
   i64.store $0
-  local.get $0
-  local.set $3
-  local.get $1
-  local.set $2
-  local.get $3
+  local.get $this
+  local.set $var$3
+  local.get $fn
+  local.set $var$2
+  local.get $var$3
   call $~lib/typedarray/Float32Array#get:length
-  local.set $4
+  local.set $var$4
   global.get $~lib/memory/__stack_pointer
   i32.const 12
   i32.const 12
   call $~lib/rt/itcms/__new
-  local.tee $5
+  local.tee $var$5
   i32.store $0
   global.get $~lib/memory/__stack_pointer
-  local.get $4
+  local.get $var$4
   i32.const 2
   i32.shl
   i32.const 0
   call $~lib/rt/itcms/__new
-  local.tee $6
+  local.tee $var$6
   i32.store $0 offset=4
-  local.get $3
+  local.get $var$3
   i32.load $0 offset=4
-  local.set $7
+  local.set $var$7
   i32.const 0
-  local.set $8
+  local.set $var$8
   i32.const 0
-  local.set $9
+  local.set $var$9
   loop $for-loop|0
-   local.get $9
-   local.get $4
+   local.get $var$9
+   local.get $var$4
    i32.lt_s
-   local.set $10
-   local.get $10
+   local.set $var$10
+   local.get $var$10
    if
-    local.get $7
-    local.get $9
+    local.get $var$7
+    local.get $var$9
     i32.const 2
     i32.shl
     i32.add
     f32.load $0
-    local.set $11
-    local.get $11
-    local.get $9
-    local.get $3
+    local.set $var$11
+    local.get $var$11
+    local.get $var$9
+    local.get $var$3
     i32.const 3
     global.set $~argumentsLength
-    local.get $2
+    local.get $var$2
     i32.load $0
     call_indirect $0 (type $f32_i32_i32_=>_i32)
     if
-     local.get $6
-     local.get $8
-     local.tee $12
+     local.get $var$6
+     local.get $var$8
+     local.tee $var$12
      i32.const 1
      i32.add
-     local.set $8
-     local.get $12
+     local.set $var$8
+     local.get $var$12
      i32.const 2
      i32.shl
      i32.add
-     local.get $11
+     local.get $var$11
      f32.store $0
     end
-    local.get $9
+    local.get $var$9
     i32.const 1
     i32.add
-    local.set $9
+    local.set $var$9
     br $for-loop|0
    end
   end
-  local.get $8
+  local.get $var$8
   i32.const 2
   i32.shl
-  local.set $9
-  local.get $6
-  local.get $9
+  local.set $var$9
+  local.get $var$6
+  local.get $var$9
   call $~lib/rt/itcms/__renew
-  local.set $10
-  local.get $5
-  local.get $10
+  local.set $var$10
+  local.get $var$5
+  local.get $var$10
   i32.store $0
-  local.get $5
-  local.get $10
+  local.get $var$5
+  local.get $var$10
   i32.const 0
   call $~lib/rt/itcms/__link
-  local.get $5
-  local.get $9
+  local.get $var$5
+  local.get $var$9
   i32.store $0 offset=8
-  local.get $5
-  local.get $10
+  local.get $var$5
+  local.get $var$10
   i32.store $0 offset=4
-  local.get $5
+  local.get $var$5
   local.set $13
   global.get $~lib/memory/__stack_pointer
   i32.const 8
@@ -64448,18 +64448,18 @@
   global.set $~lib/memory/__stack_pointer
   local.get $13
  )
- (func $~lib/typedarray/Float64Array#filter (param $0 i32) (param $1 i32) (result i32)
-  (local $2 i32)
-  (local $3 i32)
-  (local $4 i32)
-  (local $5 i32)
-  (local $6 i32)
-  (local $7 i32)
-  (local $8 i32)
-  (local $9 i32)
-  (local $10 i32)
-  (local $11 f64)
-  (local $12 i32)
+ (func $~lib/typedarray/Float64Array#filter (param $this i32) (param $fn i32) (result i32)
+  (local $var$2 i32)
+  (local $var$3 i32)
+  (local $var$4 i32)
+  (local $var$5 i32)
+  (local $var$6 i32)
+  (local $var$7 i32)
+  (local $var$8 i32)
+  (local $var$9 i32)
+  (local $var$10 i32)
+  (local $var$11 f64)
+  (local $var$12 i32)
   (local $13 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 8
@@ -64469,99 +64469,99 @@
   global.get $~lib/memory/__stack_pointer
   i64.const 0
   i64.store $0
-  local.get $0
-  local.set $3
-  local.get $1
-  local.set $2
-  local.get $3
+  local.get $this
+  local.set $var$3
+  local.get $fn
+  local.set $var$2
+  local.get $var$3
   call $~lib/typedarray/Float64Array#get:length
-  local.set $4
+  local.set $var$4
   global.get $~lib/memory/__stack_pointer
   i32.const 12
   i32.const 13
   call $~lib/rt/itcms/__new
-  local.tee $5
+  local.tee $var$5
   i32.store $0
   global.get $~lib/memory/__stack_pointer
-  local.get $4
+  local.get $var$4
   i32.const 3
   i32.shl
   i32.const 0
   call $~lib/rt/itcms/__new
-  local.tee $6
+  local.tee $var$6
   i32.store $0 offset=4
-  local.get $3
+  local.get $var$3
   i32.load $0 offset=4
-  local.set $7
+  local.set $var$7
   i32.const 0
-  local.set $8
+  local.set $var$8
   i32.const 0
-  local.set $9
+  local.set $var$9
   loop $for-loop|0
-   local.get $9
-   local.get $4
+   local.get $var$9
+   local.get $var$4
    i32.lt_s
-   local.set $10
-   local.get $10
+   local.set $var$10
+   local.get $var$10
    if
-    local.get $7
-    local.get $9
+    local.get $var$7
+    local.get $var$9
     i32.const 3
     i32.shl
     i32.add
     f64.load $0
-    local.set $11
-    local.get $11
-    local.get $9
-    local.get $3
+    local.set $var$11
+    local.get $var$11
+    local.get $var$9
+    local.get $var$3
     i32.const 3
     global.set $~argumentsLength
-    local.get $2
+    local.get $var$2
     i32.load $0
     call_indirect $0 (type $f64_i32_i32_=>_i32)
     if
-     local.get $6
-     local.get $8
-     local.tee $12
+     local.get $var$6
+     local.get $var$8
+     local.tee $var$12
      i32.const 1
      i32.add
-     local.set $8
-     local.get $12
+     local.set $var$8
+     local.get $var$12
      i32.const 3
      i32.shl
      i32.add
-     local.get $11
+     local.get $var$11
      f64.store $0
     end
-    local.get $9
+    local.get $var$9
     i32.const 1
     i32.add
-    local.set $9
+    local.set $var$9
     br $for-loop|0
    end
   end
-  local.get $8
+  local.get $var$8
   i32.const 3
   i32.shl
-  local.set $9
-  local.get $6
-  local.get $9
+  local.set $var$9
+  local.get $var$6
+  local.get $var$9
   call $~lib/rt/itcms/__renew
-  local.set $10
-  local.get $5
-  local.get $10
+  local.set $var$10
+  local.get $var$5
+  local.get $var$10
   i32.store $0
-  local.get $5
-  local.get $10
+  local.get $var$5
+  local.get $var$10
   i32.const 0
   call $~lib/rt/itcms/__link
-  local.get $5
-  local.get $9
+  local.get $var$5
+  local.get $var$9
   i32.store $0 offset=8
-  local.get $5
-  local.get $10
+  local.get $var$5
+  local.get $var$10
   i32.store $0 offset=4
-  local.get $5
+  local.get $var$5
   local.set $13
   global.get $~lib/memory/__stack_pointer
   i32.const 8
@@ -64569,13 +64569,13 @@
   global.set $~lib/memory/__stack_pointer
   local.get $13
  )
- (func $~lib/typedarray/Uint8Array#subarray (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
-  (local $3 i32)
-  (local $4 i32)
-  (local $5 i32)
-  (local $6 i32)
-  (local $7 i32)
-  (local $8 i32)
+ (func $~lib/typedarray/Uint8Array#subarray (param $this i32) (param $begin i32) (param $end i32) (result i32)
+  (local $var$3 i32)
+  (local $var$4 i32)
+  (local $var$5 i32)
+  (local $var$6 i32)
+  (local $var$7 i32)
+  (local $var$8 i32)
   (local $9 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -64585,106 +64585,106 @@
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   i32.store $0
-  local.get $0
-  local.set $5
-  local.get $1
-  local.set $4
-  local.get $2
-  local.set $3
-  local.get $5
+  local.get $this
+  local.set $var$5
+  local.get $begin
+  local.set $var$4
+  local.get $end
+  local.set $var$3
+  local.get $var$5
   call $~lib/typedarray/Uint8Array#get:length
-  local.set $6
-  local.get $4
+  local.set $var$6
+  local.get $var$4
   i32.const 0
   i32.lt_s
   if (result i32)
-   local.get $6
-   local.get $4
+   local.get $var$6
+   local.get $var$4
    i32.add
-   local.tee $7
+   local.tee $var$7
    i32.const 0
-   local.tee $8
-   local.get $7
-   local.get $8
+   local.tee $var$8
+   local.get $var$7
+   local.get $var$8
    i32.gt_s
    select
   else
-   local.get $4
-   local.tee $8
-   local.get $6
-   local.tee $7
-   local.get $8
-   local.get $7
+   local.get $var$4
+   local.tee $var$8
+   local.get $var$6
+   local.tee $var$7
+   local.get $var$8
+   local.get $var$7
    i32.lt_s
    select
   end
-  local.set $4
-  local.get $3
+  local.set $var$4
+  local.get $var$3
   i32.const 0
   i32.lt_s
   if (result i32)
-   local.get $6
-   local.get $3
+   local.get $var$6
+   local.get $var$3
    i32.add
-   local.tee $7
+   local.tee $var$7
    i32.const 0
-   local.tee $8
-   local.get $7
-   local.get $8
+   local.tee $var$8
+   local.get $var$7
+   local.get $var$8
    i32.gt_s
    select
   else
-   local.get $3
-   local.tee $8
-   local.get $6
-   local.tee $7
-   local.get $8
-   local.get $7
+   local.get $var$3
+   local.tee $var$8
+   local.get $var$6
+   local.tee $var$7
+   local.get $var$8
+   local.get $var$7
    i32.lt_s
    select
   end
-  local.set $3
-  local.get $3
-  local.tee $7
-  local.get $4
-  local.tee $8
-  local.get $7
-  local.get $8
+  local.set $var$3
+  local.get $var$3
+  local.tee $var$7
+  local.get $var$4
+  local.tee $var$8
+  local.get $var$7
+  local.get $var$8
   i32.gt_s
   select
-  local.set $3
+  local.set $var$3
   global.get $~lib/memory/__stack_pointer
   i32.const 12
   i32.const 4
   call $~lib/rt/itcms/__new
-  local.tee $7
+  local.tee $var$7
   i32.store $0
-  local.get $5
+  local.get $var$5
   i32.load $0
-  local.set $8
-  local.get $7
-  local.get $8
+  local.set $var$8
+  local.get $var$7
+  local.get $var$8
   i32.store $0
-  local.get $7
-  local.get $8
+  local.get $var$7
+  local.get $var$8
   i32.const 0
   call $~lib/rt/itcms/__link
-  local.get $7
-  local.get $5
+  local.get $var$7
+  local.get $var$5
   i32.load $0 offset=4
-  local.get $4
+  local.get $var$4
   i32.const 0
   i32.shl
   i32.add
   i32.store $0 offset=4
-  local.get $7
-  local.get $3
-  local.get $4
+  local.get $var$7
+  local.get $var$3
+  local.get $var$4
   i32.sub
   i32.const 0
   i32.shl
   i32.store $0 offset=8
-  local.get $7
+  local.get $var$7
   local.set $9
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -64692,13 +64692,13 @@
   global.set $~lib/memory/__stack_pointer
   local.get $9
  )
- (func $~lib/typedarray/Uint8ClampedArray#subarray (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
-  (local $3 i32)
-  (local $4 i32)
-  (local $5 i32)
-  (local $6 i32)
-  (local $7 i32)
-  (local $8 i32)
+ (func $~lib/typedarray/Uint8ClampedArray#subarray (param $this i32) (param $start i32) (param $end i32) (result i32)
+  (local $var$3 i32)
+  (local $var$4 i32)
+  (local $var$5 i32)
+  (local $var$6 i32)
+  (local $var$7 i32)
+  (local $var$8 i32)
   (local $9 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -64708,106 +64708,106 @@
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   i32.store $0
-  local.get $0
-  local.set $5
-  local.get $1
-  local.set $4
-  local.get $2
-  local.set $3
-  local.get $5
+  local.get $this
+  local.set $var$5
+  local.get $start
+  local.set $var$4
+  local.get $end
+  local.set $var$3
+  local.get $var$5
   call $~lib/typedarray/Uint8ClampedArray#get:length
-  local.set $6
-  local.get $4
+  local.set $var$6
+  local.get $var$4
   i32.const 0
   i32.lt_s
   if (result i32)
-   local.get $6
-   local.get $4
+   local.get $var$6
+   local.get $var$4
    i32.add
-   local.tee $7
+   local.tee $var$7
    i32.const 0
-   local.tee $8
-   local.get $7
-   local.get $8
+   local.tee $var$8
+   local.get $var$7
+   local.get $var$8
    i32.gt_s
    select
   else
-   local.get $4
-   local.tee $8
-   local.get $6
-   local.tee $7
-   local.get $8
-   local.get $7
+   local.get $var$4
+   local.tee $var$8
+   local.get $var$6
+   local.tee $var$7
+   local.get $var$8
+   local.get $var$7
    i32.lt_s
    select
   end
-  local.set $4
-  local.get $3
+  local.set $var$4
+  local.get $var$3
   i32.const 0
   i32.lt_s
   if (result i32)
-   local.get $6
-   local.get $3
+   local.get $var$6
+   local.get $var$3
    i32.add
-   local.tee $7
+   local.tee $var$7
    i32.const 0
-   local.tee $8
-   local.get $7
-   local.get $8
+   local.tee $var$8
+   local.get $var$7
+   local.get $var$8
    i32.gt_s
    select
   else
-   local.get $3
-   local.tee $8
-   local.get $6
-   local.tee $7
-   local.get $8
-   local.get $7
+   local.get $var$3
+   local.tee $var$8
+   local.get $var$6
+   local.tee $var$7
+   local.get $var$8
+   local.get $var$7
    i32.lt_s
    select
   end
-  local.set $3
-  local.get $3
-  local.tee $7
-  local.get $4
-  local.tee $8
-  local.get $7
-  local.get $8
+  local.set $var$3
+  local.get $var$3
+  local.tee $var$7
+  local.get $var$4
+  local.tee $var$8
+  local.get $var$7
+  local.get $var$8
   i32.gt_s
   select
-  local.set $3
+  local.set $var$3
   global.get $~lib/memory/__stack_pointer
   i32.const 12
   i32.const 5
   call $~lib/rt/itcms/__new
-  local.tee $7
+  local.tee $var$7
   i32.store $0
-  local.get $5
+  local.get $var$5
   i32.load $0
-  local.set $8
-  local.get $7
-  local.get $8
+  local.set $var$8
+  local.get $var$7
+  local.get $var$8
   i32.store $0
-  local.get $7
-  local.get $8
+  local.get $var$7
+  local.get $var$8
   i32.const 0
   call $~lib/rt/itcms/__link
-  local.get $7
-  local.get $5
+  local.get $var$7
+  local.get $var$5
   i32.load $0 offset=4
-  local.get $4
+  local.get $var$4
   i32.const 0
   i32.shl
   i32.add
   i32.store $0 offset=4
-  local.get $7
-  local.get $3
-  local.get $4
+  local.get $var$7
+  local.get $var$3
+  local.get $var$4
   i32.sub
   i32.const 0
   i32.shl
   i32.store $0 offset=8
-  local.get $7
+  local.get $var$7
   local.set $9
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -64815,13 +64815,13 @@
   global.set $~lib/memory/__stack_pointer
   local.get $9
  )
- (func $~lib/typedarray/Int16Array#subarray (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
-  (local $3 i32)
-  (local $4 i32)
-  (local $5 i32)
-  (local $6 i32)
-  (local $7 i32)
-  (local $8 i32)
+ (func $~lib/typedarray/Int16Array#subarray (param $this i32) (param $begin i32) (param $end i32) (result i32)
+  (local $var$3 i32)
+  (local $var$4 i32)
+  (local $var$5 i32)
+  (local $var$6 i32)
+  (local $var$7 i32)
+  (local $var$8 i32)
   (local $9 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -64831,106 +64831,106 @@
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   i32.store $0
-  local.get $0
-  local.set $5
-  local.get $1
-  local.set $4
-  local.get $2
-  local.set $3
-  local.get $5
+  local.get $this
+  local.set $var$5
+  local.get $begin
+  local.set $var$4
+  local.get $end
+  local.set $var$3
+  local.get $var$5
   call $~lib/typedarray/Int16Array#get:length
-  local.set $6
-  local.get $4
+  local.set $var$6
+  local.get $var$4
   i32.const 0
   i32.lt_s
   if (result i32)
-   local.get $6
-   local.get $4
+   local.get $var$6
+   local.get $var$4
    i32.add
-   local.tee $7
+   local.tee $var$7
    i32.const 0
-   local.tee $8
-   local.get $7
-   local.get $8
+   local.tee $var$8
+   local.get $var$7
+   local.get $var$8
    i32.gt_s
    select
   else
-   local.get $4
-   local.tee $8
-   local.get $6
-   local.tee $7
-   local.get $8
-   local.get $7
+   local.get $var$4
+   local.tee $var$8
+   local.get $var$6
+   local.tee $var$7
+   local.get $var$8
+   local.get $var$7
    i32.lt_s
    select
   end
-  local.set $4
-  local.get $3
+  local.set $var$4
+  local.get $var$3
   i32.const 0
   i32.lt_s
   if (result i32)
-   local.get $6
-   local.get $3
+   local.get $var$6
+   local.get $var$3
    i32.add
-   local.tee $7
+   local.tee $var$7
    i32.const 0
-   local.tee $8
-   local.get $7
-   local.get $8
+   local.tee $var$8
+   local.get $var$7
+   local.get $var$8
    i32.gt_s
    select
   else
-   local.get $3
-   local.tee $8
-   local.get $6
-   local.tee $7
-   local.get $8
-   local.get $7
+   local.get $var$3
+   local.tee $var$8
+   local.get $var$6
+   local.tee $var$7
+   local.get $var$8
+   local.get $var$7
    i32.lt_s
    select
   end
-  local.set $3
-  local.get $3
-  local.tee $7
-  local.get $4
-  local.tee $8
-  local.get $7
-  local.get $8
+  local.set $var$3
+  local.get $var$3
+  local.tee $var$7
+  local.get $var$4
+  local.tee $var$8
+  local.get $var$7
+  local.get $var$8
   i32.gt_s
   select
-  local.set $3
+  local.set $var$3
   global.get $~lib/memory/__stack_pointer
   i32.const 12
   i32.const 6
   call $~lib/rt/itcms/__new
-  local.tee $7
+  local.tee $var$7
   i32.store $0
-  local.get $5
+  local.get $var$5
   i32.load $0
-  local.set $8
-  local.get $7
-  local.get $8
+  local.set $var$8
+  local.get $var$7
+  local.get $var$8
   i32.store $0
-  local.get $7
-  local.get $8
+  local.get $var$7
+  local.get $var$8
   i32.const 0
   call $~lib/rt/itcms/__link
-  local.get $7
-  local.get $5
+  local.get $var$7
+  local.get $var$5
   i32.load $0 offset=4
-  local.get $4
+  local.get $var$4
   i32.const 1
   i32.shl
   i32.add
   i32.store $0 offset=4
-  local.get $7
-  local.get $3
-  local.get $4
+  local.get $var$7
+  local.get $var$3
+  local.get $var$4
   i32.sub
   i32.const 1
   i32.shl
   i32.store $0 offset=8
-  local.get $7
+  local.get $var$7
   local.set $9
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -64938,13 +64938,13 @@
   global.set $~lib/memory/__stack_pointer
   local.get $9
  )
- (func $~lib/typedarray/Uint16Array#subarray (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
-  (local $3 i32)
-  (local $4 i32)
-  (local $5 i32)
-  (local $6 i32)
-  (local $7 i32)
-  (local $8 i32)
+ (func $~lib/typedarray/Uint16Array#subarray (param $this i32) (param $begin i32) (param $end i32) (result i32)
+  (local $var$3 i32)
+  (local $var$4 i32)
+  (local $var$5 i32)
+  (local $var$6 i32)
+  (local $var$7 i32)
+  (local $var$8 i32)
   (local $9 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -64954,106 +64954,106 @@
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   i32.store $0
-  local.get $0
-  local.set $5
-  local.get $1
-  local.set $4
-  local.get $2
-  local.set $3
-  local.get $5
+  local.get $this
+  local.set $var$5
+  local.get $begin
+  local.set $var$4
+  local.get $end
+  local.set $var$3
+  local.get $var$5
   call $~lib/typedarray/Uint16Array#get:length
-  local.set $6
-  local.get $4
+  local.set $var$6
+  local.get $var$4
   i32.const 0
   i32.lt_s
   if (result i32)
-   local.get $6
-   local.get $4
+   local.get $var$6
+   local.get $var$4
    i32.add
-   local.tee $7
+   local.tee $var$7
    i32.const 0
-   local.tee $8
-   local.get $7
-   local.get $8
+   local.tee $var$8
+   local.get $var$7
+   local.get $var$8
    i32.gt_s
    select
   else
-   local.get $4
-   local.tee $8
-   local.get $6
-   local.tee $7
-   local.get $8
-   local.get $7
+   local.get $var$4
+   local.tee $var$8
+   local.get $var$6
+   local.tee $var$7
+   local.get $var$8
+   local.get $var$7
    i32.lt_s
    select
   end
-  local.set $4
-  local.get $3
+  local.set $var$4
+  local.get $var$3
   i32.const 0
   i32.lt_s
   if (result i32)
-   local.get $6
-   local.get $3
+   local.get $var$6
+   local.get $var$3
    i32.add
-   local.tee $7
+   local.tee $var$7
    i32.const 0
-   local.tee $8
-   local.get $7
-   local.get $8
+   local.tee $var$8
+   local.get $var$7
+   local.get $var$8
    i32.gt_s
    select
   else
-   local.get $3
-   local.tee $8
-   local.get $6
-   local.tee $7
-   local.get $8
-   local.get $7
+   local.get $var$3
+   local.tee $var$8
+   local.get $var$6
+   local.tee $var$7
+   local.get $var$8
+   local.get $var$7
    i32.lt_s
    select
   end
-  local.set $3
-  local.get $3
-  local.tee $7
-  local.get $4
-  local.tee $8
-  local.get $7
-  local.get $8
+  local.set $var$3
+  local.get $var$3
+  local.tee $var$7
+  local.get $var$4
+  local.tee $var$8
+  local.get $var$7
+  local.get $var$8
   i32.gt_s
   select
-  local.set $3
+  local.set $var$3
   global.get $~lib/memory/__stack_pointer
   i32.const 12
   i32.const 7
   call $~lib/rt/itcms/__new
-  local.tee $7
+  local.tee $var$7
   i32.store $0
-  local.get $5
+  local.get $var$5
   i32.load $0
-  local.set $8
-  local.get $7
-  local.get $8
+  local.set $var$8
+  local.get $var$7
+  local.get $var$8
   i32.store $0
-  local.get $7
-  local.get $8
+  local.get $var$7
+  local.get $var$8
   i32.const 0
   call $~lib/rt/itcms/__link
-  local.get $7
-  local.get $5
+  local.get $var$7
+  local.get $var$5
   i32.load $0 offset=4
-  local.get $4
+  local.get $var$4
   i32.const 1
   i32.shl
   i32.add
   i32.store $0 offset=4
-  local.get $7
-  local.get $3
-  local.get $4
+  local.get $var$7
+  local.get $var$3
+  local.get $var$4
   i32.sub
   i32.const 1
   i32.shl
   i32.store $0 offset=8
-  local.get $7
+  local.get $var$7
   local.set $9
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -65061,13 +65061,13 @@
   global.set $~lib/memory/__stack_pointer
   local.get $9
  )
- (func $~lib/typedarray/Uint32Array#subarray (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
-  (local $3 i32)
-  (local $4 i32)
-  (local $5 i32)
-  (local $6 i32)
-  (local $7 i32)
-  (local $8 i32)
+ (func $~lib/typedarray/Uint32Array#subarray (param $this i32) (param $begin i32) (param $end i32) (result i32)
+  (local $var$3 i32)
+  (local $var$4 i32)
+  (local $var$5 i32)
+  (local $var$6 i32)
+  (local $var$7 i32)
+  (local $var$8 i32)
   (local $9 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -65077,106 +65077,106 @@
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   i32.store $0
-  local.get $0
-  local.set $5
-  local.get $1
-  local.set $4
-  local.get $2
-  local.set $3
-  local.get $5
+  local.get $this
+  local.set $var$5
+  local.get $begin
+  local.set $var$4
+  local.get $end
+  local.set $var$3
+  local.get $var$5
   call $~lib/typedarray/Uint32Array#get:length
-  local.set $6
-  local.get $4
+  local.set $var$6
+  local.get $var$4
   i32.const 0
   i32.lt_s
   if (result i32)
-   local.get $6
-   local.get $4
+   local.get $var$6
+   local.get $var$4
    i32.add
-   local.tee $7
+   local.tee $var$7
    i32.const 0
-   local.tee $8
-   local.get $7
-   local.get $8
+   local.tee $var$8
+   local.get $var$7
+   local.get $var$8
    i32.gt_s
    select
   else
-   local.get $4
-   local.tee $8
-   local.get $6
-   local.tee $7
-   local.get $8
-   local.get $7
+   local.get $var$4
+   local.tee $var$8
+   local.get $var$6
+   local.tee $var$7
+   local.get $var$8
+   local.get $var$7
    i32.lt_s
    select
   end
-  local.set $4
-  local.get $3
+  local.set $var$4
+  local.get $var$3
   i32.const 0
   i32.lt_s
   if (result i32)
-   local.get $6
-   local.get $3
+   local.get $var$6
+   local.get $var$3
    i32.add
-   local.tee $7
+   local.tee $var$7
    i32.const 0
-   local.tee $8
-   local.get $7
-   local.get $8
+   local.tee $var$8
+   local.get $var$7
+   local.get $var$8
    i32.gt_s
    select
   else
-   local.get $3
-   local.tee $8
-   local.get $6
-   local.tee $7
-   local.get $8
-   local.get $7
+   local.get $var$3
+   local.tee $var$8
+   local.get $var$6
+   local.tee $var$7
+   local.get $var$8
+   local.get $var$7
    i32.lt_s
    select
   end
-  local.set $3
-  local.get $3
-  local.tee $7
-  local.get $4
-  local.tee $8
-  local.get $7
-  local.get $8
+  local.set $var$3
+  local.get $var$3
+  local.tee $var$7
+  local.get $var$4
+  local.tee $var$8
+  local.get $var$7
+  local.get $var$8
   i32.gt_s
   select
-  local.set $3
+  local.set $var$3
   global.get $~lib/memory/__stack_pointer
   i32.const 12
   i32.const 9
   call $~lib/rt/itcms/__new
-  local.tee $7
+  local.tee $var$7
   i32.store $0
-  local.get $5
+  local.get $var$5
   i32.load $0
-  local.set $8
-  local.get $7
-  local.get $8
+  local.set $var$8
+  local.get $var$7
+  local.get $var$8
   i32.store $0
-  local.get $7
-  local.get $8
+  local.get $var$7
+  local.get $var$8
   i32.const 0
   call $~lib/rt/itcms/__link
-  local.get $7
-  local.get $5
+  local.get $var$7
+  local.get $var$5
   i32.load $0 offset=4
-  local.get $4
+  local.get $var$4
   i32.const 2
   i32.shl
   i32.add
   i32.store $0 offset=4
-  local.get $7
-  local.get $3
-  local.get $4
+  local.get $var$7
+  local.get $var$3
+  local.get $var$4
   i32.sub
   i32.const 2
   i32.shl
   i32.store $0 offset=8
-  local.get $7
+  local.get $var$7
   local.set $9
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -65184,13 +65184,13 @@
   global.set $~lib/memory/__stack_pointer
   local.get $9
  )
- (func $~lib/typedarray/Int64Array#subarray (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
-  (local $3 i32)
-  (local $4 i32)
-  (local $5 i32)
-  (local $6 i32)
-  (local $7 i32)
-  (local $8 i32)
+ (func $~lib/typedarray/Int64Array#subarray (param $this i32) (param $begin i32) (param $end i32) (result i32)
+  (local $var$3 i32)
+  (local $var$4 i32)
+  (local $var$5 i32)
+  (local $var$6 i32)
+  (local $var$7 i32)
+  (local $var$8 i32)
   (local $9 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -65200,106 +65200,106 @@
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   i32.store $0
-  local.get $0
-  local.set $5
-  local.get $1
-  local.set $4
-  local.get $2
-  local.set $3
-  local.get $5
+  local.get $this
+  local.set $var$5
+  local.get $begin
+  local.set $var$4
+  local.get $end
+  local.set $var$3
+  local.get $var$5
   call $~lib/typedarray/Int64Array#get:length
-  local.set $6
-  local.get $4
+  local.set $var$6
+  local.get $var$4
   i32.const 0
   i32.lt_s
   if (result i32)
-   local.get $6
-   local.get $4
+   local.get $var$6
+   local.get $var$4
    i32.add
-   local.tee $7
+   local.tee $var$7
    i32.const 0
-   local.tee $8
-   local.get $7
-   local.get $8
+   local.tee $var$8
+   local.get $var$7
+   local.get $var$8
    i32.gt_s
    select
   else
-   local.get $4
-   local.tee $8
-   local.get $6
-   local.tee $7
-   local.get $8
-   local.get $7
+   local.get $var$4
+   local.tee $var$8
+   local.get $var$6
+   local.tee $var$7
+   local.get $var$8
+   local.get $var$7
    i32.lt_s
    select
   end
-  local.set $4
-  local.get $3
+  local.set $var$4
+  local.get $var$3
   i32.const 0
   i32.lt_s
   if (result i32)
-   local.get $6
-   local.get $3
+   local.get $var$6
+   local.get $var$3
    i32.add
-   local.tee $7
+   local.tee $var$7
    i32.const 0
-   local.tee $8
-   local.get $7
-   local.get $8
+   local.tee $var$8
+   local.get $var$7
+   local.get $var$8
    i32.gt_s
    select
   else
-   local.get $3
-   local.tee $8
-   local.get $6
-   local.tee $7
-   local.get $8
-   local.get $7
+   local.get $var$3
+   local.tee $var$8
+   local.get $var$6
+   local.tee $var$7
+   local.get $var$8
+   local.get $var$7
    i32.lt_s
    select
   end
-  local.set $3
-  local.get $3
-  local.tee $7
-  local.get $4
-  local.tee $8
-  local.get $7
-  local.get $8
+  local.set $var$3
+  local.get $var$3
+  local.tee $var$7
+  local.get $var$4
+  local.tee $var$8
+  local.get $var$7
+  local.get $var$8
   i32.gt_s
   select
-  local.set $3
+  local.set $var$3
   global.get $~lib/memory/__stack_pointer
   i32.const 12
   i32.const 10
   call $~lib/rt/itcms/__new
-  local.tee $7
+  local.tee $var$7
   i32.store $0
-  local.get $5
+  local.get $var$5
   i32.load $0
-  local.set $8
-  local.get $7
-  local.get $8
+  local.set $var$8
+  local.get $var$7
+  local.get $var$8
   i32.store $0
-  local.get $7
-  local.get $8
+  local.get $var$7
+  local.get $var$8
   i32.const 0
   call $~lib/rt/itcms/__link
-  local.get $7
-  local.get $5
+  local.get $var$7
+  local.get $var$5
   i32.load $0 offset=4
-  local.get $4
+  local.get $var$4
   i32.const 3
   i32.shl
   i32.add
   i32.store $0 offset=4
-  local.get $7
-  local.get $3
-  local.get $4
+  local.get $var$7
+  local.get $var$3
+  local.get $var$4
   i32.sub
   i32.const 3
   i32.shl
   i32.store $0 offset=8
-  local.get $7
+  local.get $var$7
   local.set $9
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -65307,13 +65307,13 @@
   global.set $~lib/memory/__stack_pointer
   local.get $9
  )
- (func $~lib/typedarray/Uint64Array#subarray (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
-  (local $3 i32)
-  (local $4 i32)
-  (local $5 i32)
-  (local $6 i32)
-  (local $7 i32)
-  (local $8 i32)
+ (func $~lib/typedarray/Uint64Array#subarray (param $this i32) (param $begin i32) (param $end i32) (result i32)
+  (local $var$3 i32)
+  (local $var$4 i32)
+  (local $var$5 i32)
+  (local $var$6 i32)
+  (local $var$7 i32)
+  (local $var$8 i32)
   (local $9 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -65323,106 +65323,106 @@
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   i32.store $0
-  local.get $0
-  local.set $5
-  local.get $1
-  local.set $4
-  local.get $2
-  local.set $3
-  local.get $5
+  local.get $this
+  local.set $var$5
+  local.get $begin
+  local.set $var$4
+  local.get $end
+  local.set $var$3
+  local.get $var$5
   call $~lib/typedarray/Uint64Array#get:length
-  local.set $6
-  local.get $4
+  local.set $var$6
+  local.get $var$4
   i32.const 0
   i32.lt_s
   if (result i32)
-   local.get $6
-   local.get $4
+   local.get $var$6
+   local.get $var$4
    i32.add
-   local.tee $7
+   local.tee $var$7
    i32.const 0
-   local.tee $8
-   local.get $7
-   local.get $8
+   local.tee $var$8
+   local.get $var$7
+   local.get $var$8
    i32.gt_s
    select
   else
-   local.get $4
-   local.tee $8
-   local.get $6
-   local.tee $7
-   local.get $8
-   local.get $7
+   local.get $var$4
+   local.tee $var$8
+   local.get $var$6
+   local.tee $var$7
+   local.get $var$8
+   local.get $var$7
    i32.lt_s
    select
   end
-  local.set $4
-  local.get $3
+  local.set $var$4
+  local.get $var$3
   i32.const 0
   i32.lt_s
   if (result i32)
-   local.get $6
-   local.get $3
+   local.get $var$6
+   local.get $var$3
    i32.add
-   local.tee $7
+   local.tee $var$7
    i32.const 0
-   local.tee $8
-   local.get $7
-   local.get $8
+   local.tee $var$8
+   local.get $var$7
+   local.get $var$8
    i32.gt_s
    select
   else
-   local.get $3
-   local.tee $8
-   local.get $6
-   local.tee $7
-   local.get $8
-   local.get $7
+   local.get $var$3
+   local.tee $var$8
+   local.get $var$6
+   local.tee $var$7
+   local.get $var$8
+   local.get $var$7
    i32.lt_s
    select
   end
-  local.set $3
-  local.get $3
-  local.tee $7
-  local.get $4
-  local.tee $8
-  local.get $7
-  local.get $8
+  local.set $var$3
+  local.get $var$3
+  local.tee $var$7
+  local.get $var$4
+  local.tee $var$8
+  local.get $var$7
+  local.get $var$8
   i32.gt_s
   select
-  local.set $3
+  local.set $var$3
   global.get $~lib/memory/__stack_pointer
   i32.const 12
   i32.const 11
   call $~lib/rt/itcms/__new
-  local.tee $7
+  local.tee $var$7
   i32.store $0
-  local.get $5
+  local.get $var$5
   i32.load $0
-  local.set $8
-  local.get $7
-  local.get $8
+  local.set $var$8
+  local.get $var$7
+  local.get $var$8
   i32.store $0
-  local.get $7
-  local.get $8
+  local.get $var$7
+  local.get $var$8
   i32.const 0
   call $~lib/rt/itcms/__link
-  local.get $7
-  local.get $5
+  local.get $var$7
+  local.get $var$5
   i32.load $0 offset=4
-  local.get $4
+  local.get $var$4
   i32.const 3
   i32.shl
   i32.add
   i32.store $0 offset=4
-  local.get $7
-  local.get $3
-  local.get $4
+  local.get $var$7
+  local.get $var$3
+  local.get $var$4
   i32.sub
   i32.const 3
   i32.shl
   i32.store $0 offset=8
-  local.get $7
+  local.get $var$7
   local.set $9
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -65430,13 +65430,13 @@
   global.set $~lib/memory/__stack_pointer
   local.get $9
  )
- (func $~lib/typedarray/Float32Array#subarray (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
-  (local $3 i32)
-  (local $4 i32)
-  (local $5 i32)
-  (local $6 i32)
-  (local $7 i32)
-  (local $8 i32)
+ (func $~lib/typedarray/Float32Array#subarray (param $this i32) (param $begin i32) (param $end i32) (result i32)
+  (local $var$3 i32)
+  (local $var$4 i32)
+  (local $var$5 i32)
+  (local $var$6 i32)
+  (local $var$7 i32)
+  (local $var$8 i32)
   (local $9 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -65446,106 +65446,106 @@
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   i32.store $0
-  local.get $0
-  local.set $5
-  local.get $1
-  local.set $4
-  local.get $2
-  local.set $3
-  local.get $5
+  local.get $this
+  local.set $var$5
+  local.get $begin
+  local.set $var$4
+  local.get $end
+  local.set $var$3
+  local.get $var$5
   call $~lib/typedarray/Float32Array#get:length
-  local.set $6
-  local.get $4
+  local.set $var$6
+  local.get $var$4
   i32.const 0
   i32.lt_s
   if (result i32)
-   local.get $6
-   local.get $4
+   local.get $var$6
+   local.get $var$4
    i32.add
-   local.tee $7
+   local.tee $var$7
    i32.const 0
-   local.tee $8
-   local.get $7
-   local.get $8
+   local.tee $var$8
+   local.get $var$7
+   local.get $var$8
    i32.gt_s
    select
   else
-   local.get $4
-   local.tee $8
-   local.get $6
-   local.tee $7
-   local.get $8
-   local.get $7
+   local.get $var$4
+   local.tee $var$8
+   local.get $var$6
+   local.tee $var$7
+   local.get $var$8
+   local.get $var$7
    i32.lt_s
    select
   end
-  local.set $4
-  local.get $3
+  local.set $var$4
+  local.get $var$3
   i32.const 0
   i32.lt_s
   if (result i32)
-   local.get $6
-   local.get $3
+   local.get $var$6
+   local.get $var$3
    i32.add
-   local.tee $7
+   local.tee $var$7
    i32.const 0
-   local.tee $8
-   local.get $7
-   local.get $8
+   local.tee $var$8
+   local.get $var$7
+   local.get $var$8
    i32.gt_s
    select
   else
-   local.get $3
-   local.tee $8
-   local.get $6
-   local.tee $7
-   local.get $8
-   local.get $7
+   local.get $var$3
+   local.tee $var$8
+   local.get $var$6
+   local.tee $var$7
+   local.get $var$8
+   local.get $var$7
    i32.lt_s
    select
   end
-  local.set $3
-  local.get $3
-  local.tee $7
-  local.get $4
-  local.tee $8
-  local.get $7
-  local.get $8
+  local.set $var$3
+  local.get $var$3
+  local.tee $var$7
+  local.get $var$4
+  local.tee $var$8
+  local.get $var$7
+  local.get $var$8
   i32.gt_s
   select
-  local.set $3
+  local.set $var$3
   global.get $~lib/memory/__stack_pointer
   i32.const 12
   i32.const 12
   call $~lib/rt/itcms/__new
-  local.tee $7
+  local.tee $var$7
   i32.store $0
-  local.get $5
+  local.get $var$5
   i32.load $0
-  local.set $8
-  local.get $7
-  local.get $8
+  local.set $var$8
+  local.get $var$7
+  local.get $var$8
   i32.store $0
-  local.get $7
-  local.get $8
+  local.get $var$7
+  local.get $var$8
   i32.const 0
   call $~lib/rt/itcms/__link
-  local.get $7
-  local.get $5
+  local.get $var$7
+  local.get $var$5
   i32.load $0 offset=4
-  local.get $4
+  local.get $var$4
   i32.const 2
   i32.shl
   i32.add
   i32.store $0 offset=4
-  local.get $7
-  local.get $3
-  local.get $4
+  local.get $var$7
+  local.get $var$3
+  local.get $var$4
   i32.sub
   i32.const 2
   i32.shl
   i32.store $0 offset=8
-  local.get $7
+  local.get $var$7
   local.set $9
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -65553,13 +65553,13 @@
   global.set $~lib/memory/__stack_pointer
   local.get $9
  )
- (func $~lib/util/number/itoa32 (param $0 i32) (param $1 i32) (result i32)
-  (local $2 i32)
-  (local $3 i32)
-  (local $4 i32)
-  (local $5 i32)
-  (local $6 i32)
-  (local $7 i32)
+ (func $~lib/util/number/itoa32 (param $value i32) (param $radix i32) (result i32)
+  (local $sign i32)
+  (local $out i32)
+  (local $var$4 i32)
+  (local $var$5 i32)
+  (local $var$6 i32)
+  (local $var$7 i32)
   (local $8 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -65569,13 +65569,13 @@
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   i32.store $0
-  local.get $1
+  local.get $radix
   i32.const 2
   i32.lt_s
   if (result i32)
    i32.const 1
   else
-   local.get $1
+   local.get $radix
    i32.const 36
    i32.gt_s
   end
@@ -65587,7 +65587,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $0
+  local.get $value
   i32.eqz
   if
    i32.const 6976
@@ -65599,128 +65599,128 @@
    local.get $8
    return
   end
-  local.get $0
+  local.get $value
   i32.const 31
   i32.shr_u
   i32.const 1
   i32.shl
-  local.set $2
-  local.get $2
+  local.set $sign
+  local.get $sign
   if
    i32.const 0
-   local.get $0
+   local.get $value
    i32.sub
-   local.set $0
+   local.set $value
   end
-  local.get $1
+  local.get $radix
   i32.const 10
   i32.eq
   if
-   local.get $0
+   local.get $value
    call $~lib/util/number/decimalCount32
-   local.set $4
+   local.set $var$4
    global.get $~lib/memory/__stack_pointer
-   local.get $4
+   local.get $var$4
    i32.const 1
    i32.shl
-   local.get $2
+   local.get $sign
    i32.add
    i32.const 1
    call $~lib/rt/itcms/__new
-   local.tee $3
+   local.tee $out
    i32.store $0
-   local.get $3
-   local.get $2
+   local.get $out
+   local.get $sign
    i32.add
-   local.set $7
-   local.get $0
-   local.set $6
-   local.get $4
-   local.set $5
+   local.set $var$7
+   local.get $value
+   local.set $var$6
+   local.get $var$4
+   local.set $var$5
    i32.const 0
    i32.const 1
    i32.ge_s
    drop
-   local.get $7
-   local.get $6
-   local.get $5
+   local.get $var$7
+   local.get $var$6
+   local.get $var$5
    call $~lib/util/number/utoa32_dec_lut
   else
-   local.get $1
+   local.get $radix
    i32.const 16
    i32.eq
    if
     i32.const 31
-    local.get $0
+    local.get $value
     i32.clz
     i32.sub
     i32.const 2
     i32.shr_s
     i32.const 1
     i32.add
-    local.set $4
+    local.set $var$4
     global.get $~lib/memory/__stack_pointer
-    local.get $4
+    local.get $var$4
     i32.const 1
     i32.shl
-    local.get $2
+    local.get $sign
     i32.add
     i32.const 1
     call $~lib/rt/itcms/__new
-    local.tee $3
+    local.tee $out
     i32.store $0
-    local.get $3
-    local.get $2
+    local.get $out
+    local.get $sign
     i32.add
-    local.set $7
-    local.get $0
-    local.set $6
-    local.get $4
-    local.set $5
+    local.set $var$7
+    local.get $value
+    local.set $var$6
+    local.get $var$4
+    local.set $var$5
     i32.const 0
     i32.const 1
     i32.ge_s
     drop
-    local.get $7
-    local.get $6
+    local.get $var$7
+    local.get $var$6
     i64.extend_i32_u
-    local.get $5
+    local.get $var$5
     call $~lib/util/number/utoa_hex_lut
    else
-    local.get $0
-    local.set $4
-    local.get $4
+    local.get $value
+    local.set $var$4
+    local.get $var$4
     i64.extend_i32_u
-    local.get $1
+    local.get $radix
     call $~lib/util/number/ulog_base
-    local.set $7
+    local.set $var$7
     global.get $~lib/memory/__stack_pointer
-    local.get $7
+    local.get $var$7
     i32.const 1
     i32.shl
-    local.get $2
+    local.get $sign
     i32.add
     i32.const 1
     call $~lib/rt/itcms/__new
-    local.tee $3
+    local.tee $out
     i32.store $0
-    local.get $3
-    local.get $2
+    local.get $out
+    local.get $sign
     i32.add
-    local.get $4
+    local.get $var$4
     i64.extend_i32_u
-    local.get $7
-    local.get $1
+    local.get $var$7
+    local.get $radix
     call $~lib/util/number/utoa64_any_core
    end
   end
-  local.get $2
+  local.get $sign
   if
-   local.get $3
+   local.get $out
    i32.const 45
    i32.store16 $0
   end
-  local.get $3
+  local.get $out
   local.set $8
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -65728,16 +65728,16 @@
   global.set $~lib/memory/__stack_pointer
   local.get $8
  )
- (func $~lib/string/String#substring (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
-  (local $3 i32)
-  (local $4 i32)
-  (local $5 i32)
-  (local $6 i32)
-  (local $7 i32)
-  (local $8 i32)
-  (local $9 i32)
-  (local $10 i32)
-  (local $11 i32)
+ (func $~lib/string/String#substring (param $this i32) (param $start i32) (param $end i32) (result i32)
+  (local $len i32)
+  (local $var$4 i32)
+  (local $var$5 i32)
+  (local $finalStart i32)
+  (local $finalEnd i32)
+  (local $fromPos i32)
+  (local $toPos i32)
+  (local $size i32)
+  (local $out i32)
   (local $12 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -65747,68 +65747,68 @@
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   i32.store $0
-  local.get $0
+  local.get $this
   call $~lib/string/String#get:length
-  local.set $3
-  local.get $1
-  local.tee $4
+  local.set $len
+  local.get $start
+  local.tee $var$4
   i32.const 0
-  local.tee $5
-  local.get $4
-  local.get $5
+  local.tee $var$5
+  local.get $var$4
+  local.get $var$5
   i32.gt_s
   select
-  local.tee $5
-  local.get $3
-  local.tee $4
-  local.get $5
-  local.get $4
+  local.tee $var$5
+  local.get $len
+  local.tee $var$4
+  local.get $var$5
+  local.get $var$4
   i32.lt_s
   select
-  local.set $6
-  local.get $2
-  local.tee $4
+  local.set $finalStart
+  local.get $end
+  local.tee $var$4
   i32.const 0
-  local.tee $5
-  local.get $4
-  local.get $5
+  local.tee $var$5
+  local.get $var$4
+  local.get $var$5
   i32.gt_s
   select
-  local.tee $5
-  local.get $3
-  local.tee $4
-  local.get $5
-  local.get $4
+  local.tee $var$5
+  local.get $len
+  local.tee $var$4
+  local.get $var$5
+  local.get $var$4
   i32.lt_s
   select
-  local.set $7
-  local.get $6
-  local.tee $4
-  local.get $7
-  local.tee $5
-  local.get $4
-  local.get $5
+  local.set $finalEnd
+  local.get $finalStart
+  local.tee $var$4
+  local.get $finalEnd
+  local.tee $var$5
+  local.get $var$4
+  local.get $var$5
   i32.lt_s
   select
   i32.const 1
   i32.shl
-  local.set $8
-  local.get $6
-  local.tee $5
-  local.get $7
-  local.tee $4
-  local.get $5
-  local.get $4
+  local.set $fromPos
+  local.get $finalStart
+  local.tee $var$5
+  local.get $finalEnd
+  local.tee $var$4
+  local.get $var$5
+  local.get $var$4
   i32.gt_s
   select
   i32.const 1
   i32.shl
-  local.set $9
-  local.get $9
-  local.get $8
+  local.set $toPos
+  local.get $toPos
+  local.get $fromPos
   i32.sub
-  local.set $10
-  local.get $10
+  local.set $size
+  local.get $size
   i32.eqz
   if
    i32.const 6752
@@ -65820,11 +65820,11 @@
    local.get $12
    return
   end
-  local.get $8
+  local.get $fromPos
   i32.eqz
   if (result i32)
-   local.get $9
-   local.get $3
+   local.get $toPos
+   local.get $len
    i32.const 1
    i32.shl
    i32.eq
@@ -65832,7 +65832,7 @@
    i32.const 0
   end
   if
-   local.get $0
+   local.get $this
    local.set $12
    global.get $~lib/memory/__stack_pointer
    i32.const 4
@@ -65842,18 +65842,18 @@
    return
   end
   global.get $~lib/memory/__stack_pointer
-  local.get $10
+  local.get $size
   i32.const 1
   call $~lib/rt/itcms/__new
-  local.tee $11
+  local.tee $out
   i32.store $0
-  local.get $11
-  local.get $0
-  local.get $8
+  local.get $out
+  local.get $this
+  local.get $fromPos
   i32.add
-  local.get $10
+  local.get $size
   memory.copy $0 $0
-  local.get $11
+  local.get $out
   local.set $12
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -65861,15 +65861,15 @@
   global.set $~lib/memory/__stack_pointer
   local.get $12
  )
- (func $~lib/util/string/joinIntegerArray<i8> (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
-  (local $3 i32)
-  (local $4 i32)
-  (local $5 i32)
-  (local $6 i32)
-  (local $7 i32)
-  (local $8 i32)
-  (local $9 i32)
-  (local $10 i32)
+ (func $~lib/util/string/joinIntegerArray<i8> (param $dataStart i32) (param $length i32) (param $separator i32) (result i32)
+  (local $lastIndex i32)
+  (local $var$4 i32)
+  (local $sepLen i32)
+  (local $estLen i32)
+  (local $result i32)
+  (local $offset i32)
+  (local $value i32)
+  (local $var$10 i32)
   (local $11 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -65879,11 +65879,11 @@
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   i32.store $0
-  local.get $1
+  local.get $length
   i32.const 1
   i32.sub
-  local.set $3
-  local.get $3
+  local.set $lastIndex
+  local.get $lastIndex
   i32.const 0
   i32.lt_s
   if
@@ -65896,19 +65896,19 @@
    local.get $11
    return
   end
-  local.get $3
+  local.get $lastIndex
   i32.eqz
   if
-   local.get $0
+   local.get $dataStart
    i32.load8_s $0
-   local.set $4
+   local.set $var$4
    i32.const 1
    drop
    i32.const 1
    i32.const 4
    i32.le_u
    drop
-   local.get $4
+   local.get $var$4
    i32.const 10
    call $~lib/util/number/itoa32
    local.set $11
@@ -65919,101 +65919,101 @@
    local.get $11
    return
   end
-  local.get $2
+  local.get $separator
   call $~lib/string/String#get:length
-  local.set $5
+  local.set $sepLen
   i32.const 11
-  local.get $5
+  local.get $sepLen
   i32.add
-  local.get $3
+  local.get $lastIndex
   i32.mul
   i32.const 11
   i32.add
-  local.set $6
+  local.set $estLen
   global.get $~lib/memory/__stack_pointer
-  local.get $6
+  local.get $estLen
   i32.const 1
   i32.shl
   i32.const 1
   call $~lib/rt/itcms/__new
-  local.tee $7
+  local.tee $result
   i32.store $0
   i32.const 0
-  local.set $8
+  local.set $offset
   i32.const 0
-  local.set $4
+  local.set $var$4
   loop $for-loop|0
-   local.get $4
-   local.get $3
+   local.get $var$4
+   local.get $lastIndex
    i32.lt_s
-   local.set $10
-   local.get $10
+   local.set $var$10
+   local.get $var$10
    if
-    local.get $0
-    local.get $4
+    local.get $dataStart
+    local.get $var$4
     i32.const 0
     i32.shl
     i32.add
     i32.load8_s $0
-    local.set $9
-    local.get $8
-    local.get $7
-    local.get $8
+    local.set $value
+    local.get $offset
+    local.get $result
+    local.get $offset
     i32.const 1
     i32.shl
     i32.add
-    local.get $9
+    local.get $value
     call $~lib/util/number/itoa_buffered<i8>
     i32.add
-    local.set $8
-    local.get $5
+    local.set $offset
+    local.get $sepLen
     if
-     local.get $7
-     local.get $8
+     local.get $result
+     local.get $offset
      i32.const 1
      i32.shl
      i32.add
-     local.get $2
-     local.get $5
+     local.get $separator
+     local.get $sepLen
      i32.const 1
      i32.shl
      memory.copy $0 $0
-     local.get $8
-     local.get $5
+     local.get $offset
+     local.get $sepLen
      i32.add
-     local.set $8
+     local.set $offset
     end
-    local.get $4
+    local.get $var$4
     i32.const 1
     i32.add
-    local.set $4
+    local.set $var$4
     br $for-loop|0
    end
   end
-  local.get $0
-  local.get $3
+  local.get $dataStart
+  local.get $lastIndex
   i32.const 0
   i32.shl
   i32.add
   i32.load8_s $0
-  local.set $9
-  local.get $8
-  local.get $7
-  local.get $8
+  local.set $value
+  local.get $offset
+  local.get $result
+  local.get $offset
   i32.const 1
   i32.shl
   i32.add
-  local.get $9
+  local.get $value
   call $~lib/util/number/itoa_buffered<i8>
   i32.add
-  local.set $8
-  local.get $6
-  local.get $8
+  local.set $offset
+  local.get $estLen
+  local.get $offset
   i32.gt_s
   if
-   local.get $7
+   local.get $result
    i32.const 0
-   local.get $8
+   local.get $offset
    call $~lib/string/String#substring
    local.set $11
    global.get $~lib/memory/__stack_pointer
@@ -66023,7 +66023,7 @@
    local.get $11
    return
   end
-  local.get $7
+  local.get $result
   local.set $11
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -66031,12 +66031,12 @@
   global.set $~lib/memory/__stack_pointer
   local.get $11
  )
- (func $~lib/util/number/utoa32 (param $0 i32) (param $1 i32) (result i32)
-  (local $2 i32)
-  (local $3 i32)
-  (local $4 i32)
-  (local $5 i32)
-  (local $6 i32)
+ (func $~lib/util/number/utoa32 (param $value i32) (param $radix i32) (result i32)
+  (local $out i32)
+  (local $var$3 i32)
+  (local $var$4 i32)
+  (local $var$5 i32)
+  (local $var$6 i32)
   (local $7 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -66046,13 +66046,13 @@
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   i32.store $0
-  local.get $1
+  local.get $radix
   i32.const 2
   i32.lt_s
   if (result i32)
    i32.const 1
   else
-   local.get $1
+   local.get $radix
    i32.const 36
    i32.gt_s
   end
@@ -66064,7 +66064,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $0
+  local.get $value
   i32.eqz
   if
    i32.const 6976
@@ -66076,95 +66076,95 @@
    local.get $7
    return
   end
-  local.get $1
+  local.get $radix
   i32.const 10
   i32.eq
   if
-   local.get $0
+   local.get $value
    call $~lib/util/number/decimalCount32
-   local.set $3
+   local.set $var$3
    global.get $~lib/memory/__stack_pointer
-   local.get $3
+   local.get $var$3
    i32.const 1
    i32.shl
    i32.const 1
    call $~lib/rt/itcms/__new
-   local.tee $2
+   local.tee $out
    i32.store $0
-   local.get $2
-   local.set $6
-   local.get $0
-   local.set $5
-   local.get $3
-   local.set $4
+   local.get $out
+   local.set $var$6
+   local.get $value
+   local.set $var$5
+   local.get $var$3
+   local.set $var$4
    i32.const 0
    i32.const 1
    i32.ge_s
    drop
-   local.get $6
-   local.get $5
-   local.get $4
+   local.get $var$6
+   local.get $var$5
+   local.get $var$4
    call $~lib/util/number/utoa32_dec_lut
   else
-   local.get $1
+   local.get $radix
    i32.const 16
    i32.eq
    if
     i32.const 31
-    local.get $0
+    local.get $value
     i32.clz
     i32.sub
     i32.const 2
     i32.shr_s
     i32.const 1
     i32.add
-    local.set $3
+    local.set $var$3
     global.get $~lib/memory/__stack_pointer
-    local.get $3
+    local.get $var$3
     i32.const 1
     i32.shl
     i32.const 1
     call $~lib/rt/itcms/__new
-    local.tee $2
+    local.tee $out
     i32.store $0
-    local.get $2
-    local.set $6
-    local.get $0
-    local.set $5
-    local.get $3
-    local.set $4
+    local.get $out
+    local.set $var$6
+    local.get $value
+    local.set $var$5
+    local.get $var$3
+    local.set $var$4
     i32.const 0
     i32.const 1
     i32.ge_s
     drop
-    local.get $6
-    local.get $5
+    local.get $var$6
+    local.get $var$5
     i64.extend_i32_u
-    local.get $4
+    local.get $var$4
     call $~lib/util/number/utoa_hex_lut
    else
-    local.get $0
+    local.get $value
     i64.extend_i32_u
-    local.get $1
+    local.get $radix
     call $~lib/util/number/ulog_base
-    local.set $3
+    local.set $var$3
     global.get $~lib/memory/__stack_pointer
-    local.get $3
+    local.get $var$3
     i32.const 1
     i32.shl
     i32.const 1
     call $~lib/rt/itcms/__new
-    local.tee $2
+    local.tee $out
     i32.store $0
-    local.get $2
-    local.get $0
+    local.get $out
+    local.get $value
     i64.extend_i32_u
-    local.get $3
-    local.get $1
+    local.get $var$3
+    local.get $radix
     call $~lib/util/number/utoa64_any_core
    end
   end
-  local.get $2
+  local.get $out
   local.set $7
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -66172,15 +66172,15 @@
   global.set $~lib/memory/__stack_pointer
   local.get $7
  )
- (func $~lib/util/string/joinIntegerArray<u8> (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
-  (local $3 i32)
-  (local $4 i32)
-  (local $5 i32)
-  (local $6 i32)
-  (local $7 i32)
-  (local $8 i32)
-  (local $9 i32)
-  (local $10 i32)
+ (func $~lib/util/string/joinIntegerArray<u8> (param $dataStart i32) (param $length i32) (param $separator i32) (result i32)
+  (local $lastIndex i32)
+  (local $var$4 i32)
+  (local $sepLen i32)
+  (local $estLen i32)
+  (local $result i32)
+  (local $offset i32)
+  (local $value i32)
+  (local $var$10 i32)
   (local $11 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -66190,11 +66190,11 @@
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   i32.store $0
-  local.get $1
+  local.get $length
   i32.const 1
   i32.sub
-  local.set $3
-  local.get $3
+  local.set $lastIndex
+  local.get $lastIndex
   i32.const 0
   i32.lt_s
   if
@@ -66207,19 +66207,19 @@
    local.get $11
    return
   end
-  local.get $3
+  local.get $lastIndex
   i32.eqz
   if
-   local.get $0
+   local.get $dataStart
    i32.load8_u $0
-   local.set $4
+   local.set $var$4
    i32.const 0
    drop
    i32.const 1
    i32.const 4
    i32.le_u
    drop
-   local.get $4
+   local.get $var$4
    i32.const 10
    call $~lib/util/number/utoa32
    local.set $11
@@ -66230,101 +66230,101 @@
    local.get $11
    return
   end
-  local.get $2
+  local.get $separator
   call $~lib/string/String#get:length
-  local.set $5
+  local.set $sepLen
   i32.const 10
-  local.get $5
+  local.get $sepLen
   i32.add
-  local.get $3
+  local.get $lastIndex
   i32.mul
   i32.const 10
   i32.add
-  local.set $6
+  local.set $estLen
   global.get $~lib/memory/__stack_pointer
-  local.get $6
+  local.get $estLen
   i32.const 1
   i32.shl
   i32.const 1
   call $~lib/rt/itcms/__new
-  local.tee $7
+  local.tee $result
   i32.store $0
   i32.const 0
-  local.set $8
+  local.set $offset
   i32.const 0
-  local.set $4
+  local.set $var$4
   loop $for-loop|0
-   local.get $4
-   local.get $3
+   local.get $var$4
+   local.get $lastIndex
    i32.lt_s
-   local.set $10
-   local.get $10
+   local.set $var$10
+   local.get $var$10
    if
-    local.get $0
-    local.get $4
+    local.get $dataStart
+    local.get $var$4
     i32.const 0
     i32.shl
     i32.add
     i32.load8_u $0
-    local.set $9
-    local.get $8
-    local.get $7
-    local.get $8
+    local.set $value
+    local.get $offset
+    local.get $result
+    local.get $offset
     i32.const 1
     i32.shl
     i32.add
-    local.get $9
+    local.get $value
     call $~lib/util/number/itoa_buffered<u8>
     i32.add
-    local.set $8
-    local.get $5
+    local.set $offset
+    local.get $sepLen
     if
-     local.get $7
-     local.get $8
+     local.get $result
+     local.get $offset
      i32.const 1
      i32.shl
      i32.add
-     local.get $2
-     local.get $5
+     local.get $separator
+     local.get $sepLen
      i32.const 1
      i32.shl
      memory.copy $0 $0
-     local.get $8
-     local.get $5
+     local.get $offset
+     local.get $sepLen
      i32.add
-     local.set $8
+     local.set $offset
     end
-    local.get $4
+    local.get $var$4
     i32.const 1
     i32.add
-    local.set $4
+    local.set $var$4
     br $for-loop|0
    end
   end
-  local.get $0
-  local.get $3
+  local.get $dataStart
+  local.get $lastIndex
   i32.const 0
   i32.shl
   i32.add
   i32.load8_u $0
-  local.set $9
-  local.get $8
-  local.get $7
-  local.get $8
+  local.set $value
+  local.get $offset
+  local.get $result
+  local.get $offset
   i32.const 1
   i32.shl
   i32.add
-  local.get $9
+  local.get $value
   call $~lib/util/number/itoa_buffered<u8>
   i32.add
-  local.set $8
-  local.get $6
-  local.get $8
+  local.set $offset
+  local.get $estLen
+  local.get $offset
   i32.gt_s
   if
-   local.get $7
+   local.get $result
    i32.const 0
-   local.get $8
+   local.get $offset
    call $~lib/string/String#substring
    local.set $11
    global.get $~lib/memory/__stack_pointer
@@ -66334,7 +66334,7 @@
    local.get $11
    return
   end
-  local.get $7
+  local.get $result
   local.set $11
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -66342,15 +66342,15 @@
   global.set $~lib/memory/__stack_pointer
   local.get $11
  )
- (func $~lib/util/string/joinIntegerArray<i16> (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
-  (local $3 i32)
-  (local $4 i32)
-  (local $5 i32)
-  (local $6 i32)
-  (local $7 i32)
-  (local $8 i32)
-  (local $9 i32)
-  (local $10 i32)
+ (func $~lib/util/string/joinIntegerArray<i16> (param $dataStart i32) (param $length i32) (param $separator i32) (result i32)
+  (local $lastIndex i32)
+  (local $var$4 i32)
+  (local $sepLen i32)
+  (local $estLen i32)
+  (local $result i32)
+  (local $offset i32)
+  (local $value i32)
+  (local $var$10 i32)
   (local $11 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -66360,11 +66360,11 @@
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   i32.store $0
-  local.get $1
+  local.get $length
   i32.const 1
   i32.sub
-  local.set $3
-  local.get $3
+  local.set $lastIndex
+  local.get $lastIndex
   i32.const 0
   i32.lt_s
   if
@@ -66377,19 +66377,19 @@
    local.get $11
    return
   end
-  local.get $3
+  local.get $lastIndex
   i32.eqz
   if
-   local.get $0
+   local.get $dataStart
    i32.load16_s $0
-   local.set $4
+   local.set $var$4
    i32.const 1
    drop
    i32.const 2
    i32.const 4
    i32.le_u
    drop
-   local.get $4
+   local.get $var$4
    i32.const 10
    call $~lib/util/number/itoa32
    local.set $11
@@ -66400,101 +66400,101 @@
    local.get $11
    return
   end
-  local.get $2
+  local.get $separator
   call $~lib/string/String#get:length
-  local.set $5
+  local.set $sepLen
   i32.const 11
-  local.get $5
+  local.get $sepLen
   i32.add
-  local.get $3
+  local.get $lastIndex
   i32.mul
   i32.const 11
   i32.add
-  local.set $6
+  local.set $estLen
   global.get $~lib/memory/__stack_pointer
-  local.get $6
+  local.get $estLen
   i32.const 1
   i32.shl
   i32.const 1
   call $~lib/rt/itcms/__new
-  local.tee $7
+  local.tee $result
   i32.store $0
   i32.const 0
-  local.set $8
+  local.set $offset
   i32.const 0
-  local.set $4
+  local.set $var$4
   loop $for-loop|0
-   local.get $4
-   local.get $3
+   local.get $var$4
+   local.get $lastIndex
    i32.lt_s
-   local.set $10
-   local.get $10
+   local.set $var$10
+   local.get $var$10
    if
-    local.get $0
-    local.get $4
+    local.get $dataStart
+    local.get $var$4
     i32.const 1
     i32.shl
     i32.add
     i32.load16_s $0
-    local.set $9
-    local.get $8
-    local.get $7
-    local.get $8
+    local.set $value
+    local.get $offset
+    local.get $result
+    local.get $offset
     i32.const 1
     i32.shl
     i32.add
-    local.get $9
+    local.get $value
     call $~lib/util/number/itoa_buffered<i16>
     i32.add
-    local.set $8
-    local.get $5
+    local.set $offset
+    local.get $sepLen
     if
-     local.get $7
-     local.get $8
+     local.get $result
+     local.get $offset
      i32.const 1
      i32.shl
      i32.add
-     local.get $2
-     local.get $5
+     local.get $separator
+     local.get $sepLen
      i32.const 1
      i32.shl
      memory.copy $0 $0
-     local.get $8
-     local.get $5
+     local.get $offset
+     local.get $sepLen
      i32.add
-     local.set $8
+     local.set $offset
     end
-    local.get $4
+    local.get $var$4
     i32.const 1
     i32.add
-    local.set $4
+    local.set $var$4
     br $for-loop|0
    end
   end
-  local.get $0
-  local.get $3
+  local.get $dataStart
+  local.get $lastIndex
   i32.const 1
   i32.shl
   i32.add
   i32.load16_s $0
-  local.set $9
-  local.get $8
-  local.get $7
-  local.get $8
+  local.set $value
+  local.get $offset
+  local.get $result
+  local.get $offset
   i32.const 1
   i32.shl
   i32.add
-  local.get $9
+  local.get $value
   call $~lib/util/number/itoa_buffered<i16>
   i32.add
-  local.set $8
-  local.get $6
-  local.get $8
+  local.set $offset
+  local.get $estLen
+  local.get $offset
   i32.gt_s
   if
-   local.get $7
+   local.get $result
    i32.const 0
-   local.get $8
+   local.get $offset
    call $~lib/string/String#substring
    local.set $11
    global.get $~lib/memory/__stack_pointer
@@ -66504,7 +66504,7 @@
    local.get $11
    return
   end
-  local.get $7
+  local.get $result
   local.set $11
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -66512,15 +66512,15 @@
   global.set $~lib/memory/__stack_pointer
   local.get $11
  )
- (func $~lib/util/string/joinIntegerArray<u16> (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
-  (local $3 i32)
-  (local $4 i32)
-  (local $5 i32)
-  (local $6 i32)
-  (local $7 i32)
-  (local $8 i32)
-  (local $9 i32)
-  (local $10 i32)
+ (func $~lib/util/string/joinIntegerArray<u16> (param $dataStart i32) (param $length i32) (param $separator i32) (result i32)
+  (local $lastIndex i32)
+  (local $var$4 i32)
+  (local $sepLen i32)
+  (local $estLen i32)
+  (local $result i32)
+  (local $offset i32)
+  (local $value i32)
+  (local $var$10 i32)
   (local $11 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -66530,11 +66530,11 @@
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   i32.store $0
-  local.get $1
+  local.get $length
   i32.const 1
   i32.sub
-  local.set $3
-  local.get $3
+  local.set $lastIndex
+  local.get $lastIndex
   i32.const 0
   i32.lt_s
   if
@@ -66547,19 +66547,19 @@
    local.get $11
    return
   end
-  local.get $3
+  local.get $lastIndex
   i32.eqz
   if
-   local.get $0
+   local.get $dataStart
    i32.load16_u $0
-   local.set $4
+   local.set $var$4
    i32.const 0
    drop
    i32.const 2
    i32.const 4
    i32.le_u
    drop
-   local.get $4
+   local.get $var$4
    i32.const 10
    call $~lib/util/number/utoa32
    local.set $11
@@ -66570,101 +66570,101 @@
    local.get $11
    return
   end
-  local.get $2
+  local.get $separator
   call $~lib/string/String#get:length
-  local.set $5
+  local.set $sepLen
   i32.const 10
-  local.get $5
+  local.get $sepLen
   i32.add
-  local.get $3
+  local.get $lastIndex
   i32.mul
   i32.const 10
   i32.add
-  local.set $6
+  local.set $estLen
   global.get $~lib/memory/__stack_pointer
-  local.get $6
+  local.get $estLen
   i32.const 1
   i32.shl
   i32.const 1
   call $~lib/rt/itcms/__new
-  local.tee $7
+  local.tee $result
   i32.store $0
   i32.const 0
-  local.set $8
+  local.set $offset
   i32.const 0
-  local.set $4
+  local.set $var$4
   loop $for-loop|0
-   local.get $4
-   local.get $3
+   local.get $var$4
+   local.get $lastIndex
    i32.lt_s
-   local.set $10
-   local.get $10
+   local.set $var$10
+   local.get $var$10
    if
-    local.get $0
-    local.get $4
+    local.get $dataStart
+    local.get $var$4
     i32.const 1
     i32.shl
     i32.add
     i32.load16_u $0
-    local.set $9
-    local.get $8
-    local.get $7
-    local.get $8
+    local.set $value
+    local.get $offset
+    local.get $result
+    local.get $offset
     i32.const 1
     i32.shl
     i32.add
-    local.get $9
+    local.get $value
     call $~lib/util/number/itoa_buffered<u16>
     i32.add
-    local.set $8
-    local.get $5
+    local.set $offset
+    local.get $sepLen
     if
-     local.get $7
-     local.get $8
+     local.get $result
+     local.get $offset
      i32.const 1
      i32.shl
      i32.add
-     local.get $2
-     local.get $5
+     local.get $separator
+     local.get $sepLen
      i32.const 1
      i32.shl
      memory.copy $0 $0
-     local.get $8
-     local.get $5
+     local.get $offset
+     local.get $sepLen
      i32.add
-     local.set $8
+     local.set $offset
     end
-    local.get $4
+    local.get $var$4
     i32.const 1
     i32.add
-    local.set $4
+    local.set $var$4
     br $for-loop|0
    end
   end
-  local.get $0
-  local.get $3
+  local.get $dataStart
+  local.get $lastIndex
   i32.const 1
   i32.shl
   i32.add
   i32.load16_u $0
-  local.set $9
-  local.get $8
-  local.get $7
-  local.get $8
+  local.set $value
+  local.get $offset
+  local.get $result
+  local.get $offset
   i32.const 1
   i32.shl
   i32.add
-  local.get $9
+  local.get $value
   call $~lib/util/number/itoa_buffered<u16>
   i32.add
-  local.set $8
-  local.get $6
-  local.get $8
+  local.set $offset
+  local.get $estLen
+  local.get $offset
   i32.gt_s
   if
-   local.get $7
+   local.get $result
    i32.const 0
-   local.get $8
+   local.get $offset
    call $~lib/string/String#substring
    local.set $11
    global.get $~lib/memory/__stack_pointer
@@ -66674,7 +66674,7 @@
    local.get $11
    return
   end
-  local.get $7
+  local.get $result
   local.set $11
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -66682,15 +66682,15 @@
   global.set $~lib/memory/__stack_pointer
   local.get $11
  )
- (func $~lib/util/string/joinIntegerArray<i32> (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
-  (local $3 i32)
-  (local $4 i32)
-  (local $5 i32)
-  (local $6 i32)
-  (local $7 i32)
-  (local $8 i32)
-  (local $9 i32)
-  (local $10 i32)
+ (func $~lib/util/string/joinIntegerArray<i32> (param $dataStart i32) (param $length i32) (param $separator i32) (result i32)
+  (local $lastIndex i32)
+  (local $var$4 i32)
+  (local $sepLen i32)
+  (local $estLen i32)
+  (local $result i32)
+  (local $offset i32)
+  (local $value i32)
+  (local $var$10 i32)
   (local $11 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -66700,11 +66700,11 @@
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   i32.store $0
-  local.get $1
+  local.get $length
   i32.const 1
   i32.sub
-  local.set $3
-  local.get $3
+  local.set $lastIndex
+  local.get $lastIndex
   i32.const 0
   i32.lt_s
   if
@@ -66717,19 +66717,19 @@
    local.get $11
    return
   end
-  local.get $3
+  local.get $lastIndex
   i32.eqz
   if
-   local.get $0
+   local.get $dataStart
    i32.load $0
-   local.set $4
+   local.set $var$4
    i32.const 1
    drop
    i32.const 4
    i32.const 4
    i32.le_u
    drop
-   local.get $4
+   local.get $var$4
    i32.const 10
    call $~lib/util/number/itoa32
    local.set $11
@@ -66740,101 +66740,101 @@
    local.get $11
    return
   end
-  local.get $2
+  local.get $separator
   call $~lib/string/String#get:length
-  local.set $5
+  local.set $sepLen
   i32.const 11
-  local.get $5
+  local.get $sepLen
   i32.add
-  local.get $3
+  local.get $lastIndex
   i32.mul
   i32.const 11
   i32.add
-  local.set $6
+  local.set $estLen
   global.get $~lib/memory/__stack_pointer
-  local.get $6
+  local.get $estLen
   i32.const 1
   i32.shl
   i32.const 1
   call $~lib/rt/itcms/__new
-  local.tee $7
+  local.tee $result
   i32.store $0
   i32.const 0
-  local.set $8
+  local.set $offset
   i32.const 0
-  local.set $4
+  local.set $var$4
   loop $for-loop|0
-   local.get $4
-   local.get $3
+   local.get $var$4
+   local.get $lastIndex
    i32.lt_s
-   local.set $10
-   local.get $10
+   local.set $var$10
+   local.get $var$10
    if
-    local.get $0
-    local.get $4
+    local.get $dataStart
+    local.get $var$4
     i32.const 2
     i32.shl
     i32.add
     i32.load $0
-    local.set $9
-    local.get $8
-    local.get $7
-    local.get $8
+    local.set $value
+    local.get $offset
+    local.get $result
+    local.get $offset
     i32.const 1
     i32.shl
     i32.add
-    local.get $9
+    local.get $value
     call $~lib/util/number/itoa_buffered<i32>
     i32.add
-    local.set $8
-    local.get $5
+    local.set $offset
+    local.get $sepLen
     if
-     local.get $7
-     local.get $8
+     local.get $result
+     local.get $offset
      i32.const 1
      i32.shl
      i32.add
-     local.get $2
-     local.get $5
+     local.get $separator
+     local.get $sepLen
      i32.const 1
      i32.shl
      memory.copy $0 $0
-     local.get $8
-     local.get $5
+     local.get $offset
+     local.get $sepLen
      i32.add
-     local.set $8
+     local.set $offset
     end
-    local.get $4
+    local.get $var$4
     i32.const 1
     i32.add
-    local.set $4
+    local.set $var$4
     br $for-loop|0
    end
   end
-  local.get $0
-  local.get $3
+  local.get $dataStart
+  local.get $lastIndex
   i32.const 2
   i32.shl
   i32.add
   i32.load $0
-  local.set $9
-  local.get $8
-  local.get $7
-  local.get $8
+  local.set $value
+  local.get $offset
+  local.get $result
+  local.get $offset
   i32.const 1
   i32.shl
   i32.add
-  local.get $9
+  local.get $value
   call $~lib/util/number/itoa_buffered<i32>
   i32.add
-  local.set $8
-  local.get $6
-  local.get $8
+  local.set $offset
+  local.get $estLen
+  local.get $offset
   i32.gt_s
   if
-   local.get $7
+   local.get $result
    i32.const 0
-   local.get $8
+   local.get $offset
    call $~lib/string/String#substring
    local.set $11
    global.get $~lib/memory/__stack_pointer
@@ -66844,7 +66844,7 @@
    local.get $11
    return
   end
-  local.get $7
+  local.get $result
   local.set $11
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -66852,15 +66852,15 @@
   global.set $~lib/memory/__stack_pointer
   local.get $11
  )
- (func $~lib/util/string/joinIntegerArray<u32> (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
-  (local $3 i32)
-  (local $4 i32)
-  (local $5 i32)
-  (local $6 i32)
-  (local $7 i32)
-  (local $8 i32)
-  (local $9 i32)
-  (local $10 i32)
+ (func $~lib/util/string/joinIntegerArray<u32> (param $dataStart i32) (param $length i32) (param $separator i32) (result i32)
+  (local $lastIndex i32)
+  (local $var$4 i32)
+  (local $sepLen i32)
+  (local $estLen i32)
+  (local $result i32)
+  (local $offset i32)
+  (local $value i32)
+  (local $var$10 i32)
   (local $11 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -66870,11 +66870,11 @@
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   i32.store $0
-  local.get $1
+  local.get $length
   i32.const 1
   i32.sub
-  local.set $3
-  local.get $3
+  local.set $lastIndex
+  local.get $lastIndex
   i32.const 0
   i32.lt_s
   if
@@ -66887,19 +66887,19 @@
    local.get $11
    return
   end
-  local.get $3
+  local.get $lastIndex
   i32.eqz
   if
-   local.get $0
+   local.get $dataStart
    i32.load $0
-   local.set $4
+   local.set $var$4
    i32.const 0
    drop
    i32.const 4
    i32.const 4
    i32.le_u
    drop
-   local.get $4
+   local.get $var$4
    i32.const 10
    call $~lib/util/number/utoa32
    local.set $11
@@ -66910,101 +66910,101 @@
    local.get $11
    return
   end
-  local.get $2
+  local.get $separator
   call $~lib/string/String#get:length
-  local.set $5
+  local.set $sepLen
   i32.const 10
-  local.get $5
+  local.get $sepLen
   i32.add
-  local.get $3
+  local.get $lastIndex
   i32.mul
   i32.const 10
   i32.add
-  local.set $6
+  local.set $estLen
   global.get $~lib/memory/__stack_pointer
-  local.get $6
+  local.get $estLen
   i32.const 1
   i32.shl
   i32.const 1
   call $~lib/rt/itcms/__new
-  local.tee $7
+  local.tee $result
   i32.store $0
   i32.const 0
-  local.set $8
+  local.set $offset
   i32.const 0
-  local.set $4
+  local.set $var$4
   loop $for-loop|0
-   local.get $4
-   local.get $3
+   local.get $var$4
+   local.get $lastIndex
    i32.lt_s
-   local.set $10
-   local.get $10
+   local.set $var$10
+   local.get $var$10
    if
-    local.get $0
-    local.get $4
+    local.get $dataStart
+    local.get $var$4
     i32.const 2
     i32.shl
     i32.add
     i32.load $0
-    local.set $9
-    local.get $8
-    local.get $7
-    local.get $8
+    local.set $value
+    local.get $offset
+    local.get $result
+    local.get $offset
     i32.const 1
     i32.shl
     i32.add
-    local.get $9
+    local.get $value
     call $~lib/util/number/itoa_buffered<u32>
     i32.add
-    local.set $8
-    local.get $5
+    local.set $offset
+    local.get $sepLen
     if
-     local.get $7
-     local.get $8
+     local.get $result
+     local.get $offset
      i32.const 1
      i32.shl
      i32.add
-     local.get $2
-     local.get $5
+     local.get $separator
+     local.get $sepLen
      i32.const 1
      i32.shl
      memory.copy $0 $0
-     local.get $8
-     local.get $5
+     local.get $offset
+     local.get $sepLen
      i32.add
-     local.set $8
+     local.set $offset
     end
-    local.get $4
+    local.get $var$4
     i32.const 1
     i32.add
-    local.set $4
+    local.set $var$4
     br $for-loop|0
    end
   end
-  local.get $0
-  local.get $3
+  local.get $dataStart
+  local.get $lastIndex
   i32.const 2
   i32.shl
   i32.add
   i32.load $0
-  local.set $9
-  local.get $8
-  local.get $7
-  local.get $8
+  local.set $value
+  local.get $offset
+  local.get $result
+  local.get $offset
   i32.const 1
   i32.shl
   i32.add
-  local.get $9
+  local.get $value
   call $~lib/util/number/itoa_buffered<u32>
   i32.add
-  local.set $8
-  local.get $6
-  local.get $8
+  local.set $offset
+  local.get $estLen
+  local.get $offset
   i32.gt_s
   if
-   local.get $7
+   local.get $result
    i32.const 0
-   local.get $8
+   local.get $offset
    call $~lib/string/String#substring
    local.set $11
    global.get $~lib/memory/__stack_pointer
@@ -67014,7 +67014,7 @@
    local.get $11
    return
   end
-  local.get $7
+  local.get $result
   local.set $11
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -67022,15 +67022,15 @@
   global.set $~lib/memory/__stack_pointer
   local.get $11
  )
- (func $~lib/util/number/itoa64 (param $0 i64) (param $1 i32) (result i32)
-  (local $2 i32)
-  (local $3 i32)
-  (local $4 i32)
-  (local $5 i32)
-  (local $6 i32)
-  (local $7 i32)
-  (local $8 i32)
-  (local $9 i64)
+ (func $~lib/util/number/itoa64 (param $value i64) (param $radix i32) (result i32)
+  (local $sign i32)
+  (local $out i32)
+  (local $var$4 i32)
+  (local $var$5 i32)
+  (local $var$6 i32)
+  (local $var$7 i32)
+  (local $var$8 i32)
+  (local $var$9 i64)
   (local $10 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -67040,13 +67040,13 @@
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   i32.store $0
-  local.get $1
+  local.get $radix
   i32.const 2
   i32.lt_s
   if (result i32)
    i32.const 1
   else
-   local.get $1
+   local.get $radix
    i32.const 36
    i32.gt_s
   end
@@ -67058,7 +67058,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $0
+  local.get $value
   i64.const 0
   i64.ne
   i32.eqz
@@ -67072,99 +67072,99 @@
    local.get $10
    return
   end
-  local.get $0
+  local.get $value
   i64.const 63
   i64.shr_u
   i32.wrap_i64
   i32.const 1
   i32.shl
-  local.set $2
-  local.get $2
+  local.set $sign
+  local.get $sign
   if
    i64.const 0
-   local.get $0
+   local.get $value
    i64.sub
-   local.set $0
+   local.set $value
   end
-  local.get $1
+  local.get $radix
   i32.const 10
   i32.eq
   if
-   local.get $0
+   local.get $value
    global.get $~lib/builtins/u32.MAX_VALUE
    i64.extend_i32_u
    i64.le_u
    if
-    local.get $0
+    local.get $value
     i32.wrap_i64
-    local.set $4
-    local.get $4
+    local.set $var$4
+    local.get $var$4
     call $~lib/util/number/decimalCount32
-    local.set $5
+    local.set $var$5
     global.get $~lib/memory/__stack_pointer
-    local.get $5
+    local.get $var$5
     i32.const 1
     i32.shl
-    local.get $2
+    local.get $sign
     i32.add
     i32.const 1
     call $~lib/rt/itcms/__new
-    local.tee $3
+    local.tee $out
     i32.store $0
-    local.get $3
-    local.get $2
+    local.get $out
+    local.get $sign
     i32.add
-    local.set $8
-    local.get $4
-    local.set $7
-    local.get $5
-    local.set $6
+    local.set $var$8
+    local.get $var$4
+    local.set $var$7
+    local.get $var$5
+    local.set $var$6
     i32.const 0
     i32.const 1
     i32.ge_s
     drop
-    local.get $8
-    local.get $7
-    local.get $6
+    local.get $var$8
+    local.get $var$7
+    local.get $var$6
     call $~lib/util/number/utoa32_dec_lut
    else
-    local.get $0
+    local.get $value
     call $~lib/util/number/decimalCount64High
-    local.set $5
+    local.set $var$5
     global.get $~lib/memory/__stack_pointer
-    local.get $5
+    local.get $var$5
     i32.const 1
     i32.shl
-    local.get $2
+    local.get $sign
     i32.add
     i32.const 1
     call $~lib/rt/itcms/__new
-    local.tee $3
+    local.tee $out
     i32.store $0
-    local.get $3
-    local.get $2
+    local.get $out
+    local.get $sign
     i32.add
-    local.set $7
-    local.get $0
-    local.set $9
-    local.get $5
-    local.set $6
+    local.set $var$7
+    local.get $value
+    local.set $var$9
+    local.get $var$5
+    local.set $var$6
     i32.const 0
     i32.const 1
     i32.ge_s
     drop
-    local.get $7
-    local.get $9
-    local.get $6
+    local.get $var$7
+    local.get $var$9
+    local.get $var$6
     call $~lib/util/number/utoa64_dec_lut
    end
   else
-   local.get $1
+   local.get $radix
    i32.const 16
    i32.eq
    if
     i32.const 63
-    local.get $0
+    local.get $value
     i64.clz
     i32.wrap_i64
     i32.sub
@@ -67172,64 +67172,64 @@
     i32.shr_s
     i32.const 1
     i32.add
-    local.set $5
+    local.set $var$5
     global.get $~lib/memory/__stack_pointer
-    local.get $5
+    local.get $var$5
     i32.const 1
     i32.shl
-    local.get $2
+    local.get $sign
     i32.add
     i32.const 1
     call $~lib/rt/itcms/__new
-    local.tee $3
+    local.tee $out
     i32.store $0
-    local.get $3
-    local.get $2
+    local.get $out
+    local.get $sign
     i32.add
-    local.set $4
-    local.get $0
-    local.set $9
-    local.get $5
-    local.set $8
+    local.set $var$4
+    local.get $value
+    local.set $var$9
+    local.get $var$5
+    local.set $var$8
     i32.const 0
     i32.const 1
     i32.ge_s
     drop
-    local.get $4
-    local.get $9
-    local.get $8
+    local.get $var$4
+    local.get $var$9
+    local.get $var$8
     call $~lib/util/number/utoa_hex_lut
    else
-    local.get $0
-    local.get $1
+    local.get $value
+    local.get $radix
     call $~lib/util/number/ulog_base
-    local.set $5
+    local.set $var$5
     global.get $~lib/memory/__stack_pointer
-    local.get $5
+    local.get $var$5
     i32.const 1
     i32.shl
-    local.get $2
+    local.get $sign
     i32.add
     i32.const 1
     call $~lib/rt/itcms/__new
-    local.tee $3
+    local.tee $out
     i32.store $0
-    local.get $3
-    local.get $2
+    local.get $out
+    local.get $sign
     i32.add
-    local.get $0
-    local.get $5
-    local.get $1
+    local.get $value
+    local.get $var$5
+    local.get $radix
     call $~lib/util/number/utoa64_any_core
    end
   end
-  local.get $2
+  local.get $sign
   if
-   local.get $3
+   local.get $out
    i32.const 45
    i32.store16 $0
   end
-  local.get $3
+  local.get $out
   local.set $10
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -67237,16 +67237,16 @@
   global.set $~lib/memory/__stack_pointer
   local.get $10
  )
- (func $~lib/util/string/joinIntegerArray<i64> (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
-  (local $3 i32)
-  (local $4 i64)
-  (local $5 i32)
-  (local $6 i32)
-  (local $7 i32)
-  (local $8 i32)
-  (local $9 i64)
-  (local $10 i32)
-  (local $11 i32)
+ (func $~lib/util/string/joinIntegerArray<i64> (param $dataStart i32) (param $length i32) (param $separator i32) (result i32)
+  (local $lastIndex i32)
+  (local $var$4 i64)
+  (local $sepLen i32)
+  (local $estLen i32)
+  (local $result i32)
+  (local $offset i32)
+  (local $value i64)
+  (local $var$10 i32)
+  (local $var$11 i32)
   (local $12 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -67256,11 +67256,11 @@
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   i32.store $0
-  local.get $1
+  local.get $length
   i32.const 1
   i32.sub
-  local.set $3
-  local.get $3
+  local.set $lastIndex
+  local.get $lastIndex
   i32.const 0
   i32.lt_s
   if
@@ -67273,19 +67273,19 @@
    local.get $12
    return
   end
-  local.get $3
+  local.get $lastIndex
   i32.eqz
   if
-   local.get $0
+   local.get $dataStart
    i64.load $0
-   local.set $4
+   local.set $var$4
    i32.const 1
    drop
    i32.const 8
    i32.const 4
    i32.le_u
    drop
-   local.get $4
+   local.get $var$4
    i32.wrap_i64
    i64.extend_i32_s
    i32.const 10
@@ -67298,101 +67298,101 @@
    local.get $12
    return
   end
-  local.get $2
+  local.get $separator
   call $~lib/string/String#get:length
-  local.set $5
+  local.set $sepLen
   i32.const 21
-  local.get $5
+  local.get $sepLen
   i32.add
-  local.get $3
+  local.get $lastIndex
   i32.mul
   i32.const 21
   i32.add
-  local.set $6
+  local.set $estLen
   global.get $~lib/memory/__stack_pointer
-  local.get $6
+  local.get $estLen
   i32.const 1
   i32.shl
   i32.const 1
   call $~lib/rt/itcms/__new
-  local.tee $7
+  local.tee $result
   i32.store $0
   i32.const 0
-  local.set $8
+  local.set $offset
   i32.const 0
-  local.set $10
+  local.set $var$10
   loop $for-loop|0
-   local.get $10
-   local.get $3
+   local.get $var$10
+   local.get $lastIndex
    i32.lt_s
-   local.set $11
-   local.get $11
+   local.set $var$11
+   local.get $var$11
    if
-    local.get $0
-    local.get $10
+    local.get $dataStart
+    local.get $var$10
     i32.const 3
     i32.shl
     i32.add
     i64.load $0
-    local.set $9
-    local.get $8
-    local.get $7
-    local.get $8
+    local.set $value
+    local.get $offset
+    local.get $result
+    local.get $offset
     i32.const 1
     i32.shl
     i32.add
-    local.get $9
+    local.get $value
     call $~lib/util/number/itoa_buffered<i64>
     i32.add
-    local.set $8
-    local.get $5
+    local.set $offset
+    local.get $sepLen
     if
-     local.get $7
-     local.get $8
+     local.get $result
+     local.get $offset
      i32.const 1
      i32.shl
      i32.add
-     local.get $2
-     local.get $5
+     local.get $separator
+     local.get $sepLen
      i32.const 1
      i32.shl
      memory.copy $0 $0
-     local.get $8
-     local.get $5
+     local.get $offset
+     local.get $sepLen
      i32.add
-     local.set $8
+     local.set $offset
     end
-    local.get $10
+    local.get $var$10
     i32.const 1
     i32.add
-    local.set $10
+    local.set $var$10
     br $for-loop|0
    end
   end
-  local.get $0
-  local.get $3
+  local.get $dataStart
+  local.get $lastIndex
   i32.const 3
   i32.shl
   i32.add
   i64.load $0
-  local.set $9
-  local.get $8
-  local.get $7
-  local.get $8
+  local.set $value
+  local.get $offset
+  local.get $result
+  local.get $offset
   i32.const 1
   i32.shl
   i32.add
-  local.get $9
+  local.get $value
   call $~lib/util/number/itoa_buffered<i64>
   i32.add
-  local.set $8
-  local.get $6
-  local.get $8
+  local.set $offset
+  local.get $estLen
+  local.get $offset
   i32.gt_s
   if
-   local.get $7
+   local.get $result
    i32.const 0
-   local.get $8
+   local.get $offset
    call $~lib/string/String#substring
    local.set $12
    global.get $~lib/memory/__stack_pointer
@@ -67402,7 +67402,7 @@
    local.get $12
    return
   end
-  local.get $7
+  local.get $result
   local.set $12
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -67410,14 +67410,14 @@
   global.set $~lib/memory/__stack_pointer
   local.get $12
  )
- (func $~lib/util/number/utoa64 (param $0 i64) (param $1 i32) (result i32)
-  (local $2 i32)
-  (local $3 i32)
-  (local $4 i32)
-  (local $5 i32)
-  (local $6 i32)
-  (local $7 i32)
-  (local $8 i64)
+ (func $~lib/util/number/utoa64 (param $value i64) (param $radix i32) (result i32)
+  (local $out i32)
+  (local $var$3 i32)
+  (local $var$4 i32)
+  (local $var$5 i32)
+  (local $var$6 i32)
+  (local $var$7 i32)
+  (local $var$8 i64)
   (local $9 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -67427,13 +67427,13 @@
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   i32.store $0
-  local.get $1
+  local.get $radix
   i32.const 2
   i32.lt_s
   if (result i32)
    i32.const 1
   else
-   local.get $1
+   local.get $radix
    i32.const 36
    i32.gt_s
   end
@@ -67445,7 +67445,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $0
+  local.get $value
   i64.const 0
   i64.ne
   i32.eqz
@@ -67459,77 +67459,77 @@
    local.get $9
    return
   end
-  local.get $1
+  local.get $radix
   i32.const 10
   i32.eq
   if
-   local.get $0
+   local.get $value
    global.get $~lib/builtins/u32.MAX_VALUE
    i64.extend_i32_u
    i64.le_u
    if
-    local.get $0
+    local.get $value
     i32.wrap_i64
-    local.set $3
-    local.get $3
+    local.set $var$3
+    local.get $var$3
     call $~lib/util/number/decimalCount32
-    local.set $4
+    local.set $var$4
     global.get $~lib/memory/__stack_pointer
-    local.get $4
+    local.get $var$4
     i32.const 1
     i32.shl
     i32.const 1
     call $~lib/rt/itcms/__new
-    local.tee $2
+    local.tee $out
     i32.store $0
-    local.get $2
-    local.set $7
-    local.get $3
-    local.set $6
-    local.get $4
-    local.set $5
+    local.get $out
+    local.set $var$7
+    local.get $var$3
+    local.set $var$6
+    local.get $var$4
+    local.set $var$5
     i32.const 0
     i32.const 1
     i32.ge_s
     drop
-    local.get $7
-    local.get $6
-    local.get $5
+    local.get $var$7
+    local.get $var$6
+    local.get $var$5
     call $~lib/util/number/utoa32_dec_lut
    else
-    local.get $0
+    local.get $value
     call $~lib/util/number/decimalCount64High
-    local.set $4
+    local.set $var$4
     global.get $~lib/memory/__stack_pointer
-    local.get $4
+    local.get $var$4
     i32.const 1
     i32.shl
     i32.const 1
     call $~lib/rt/itcms/__new
-    local.tee $2
+    local.tee $out
     i32.store $0
-    local.get $2
-    local.set $6
-    local.get $0
-    local.set $8
-    local.get $4
-    local.set $5
+    local.get $out
+    local.set $var$6
+    local.get $value
+    local.set $var$8
+    local.get $var$4
+    local.set $var$5
     i32.const 0
     i32.const 1
     i32.ge_s
     drop
-    local.get $6
-    local.get $8
-    local.get $5
+    local.get $var$6
+    local.get $var$8
+    local.get $var$5
     call $~lib/util/number/utoa64_dec_lut
    end
   else
-   local.get $1
+   local.get $radix
    i32.const 16
    i32.eq
    if
     i32.const 63
-    local.get $0
+    local.get $value
     i64.clz
     i32.wrap_i64
     i32.sub
@@ -67537,50 +67537,50 @@
     i32.shr_s
     i32.const 1
     i32.add
-    local.set $4
+    local.set $var$4
     global.get $~lib/memory/__stack_pointer
-    local.get $4
+    local.get $var$4
     i32.const 1
     i32.shl
     i32.const 1
     call $~lib/rt/itcms/__new
-    local.tee $2
+    local.tee $out
     i32.store $0
-    local.get $2
-    local.set $3
-    local.get $0
-    local.set $8
-    local.get $4
-    local.set $7
+    local.get $out
+    local.set $var$3
+    local.get $value
+    local.set $var$8
+    local.get $var$4
+    local.set $var$7
     i32.const 0
     i32.const 1
     i32.ge_s
     drop
-    local.get $3
-    local.get $8
-    local.get $7
+    local.get $var$3
+    local.get $var$8
+    local.get $var$7
     call $~lib/util/number/utoa_hex_lut
    else
-    local.get $0
-    local.get $1
+    local.get $value
+    local.get $radix
     call $~lib/util/number/ulog_base
-    local.set $4
+    local.set $var$4
     global.get $~lib/memory/__stack_pointer
-    local.get $4
+    local.get $var$4
     i32.const 1
     i32.shl
     i32.const 1
     call $~lib/rt/itcms/__new
-    local.tee $2
+    local.tee $out
     i32.store $0
-    local.get $2
-    local.get $0
-    local.get $4
-    local.get $1
+    local.get $out
+    local.get $value
+    local.get $var$4
+    local.get $radix
     call $~lib/util/number/utoa64_any_core
    end
   end
-  local.get $2
+  local.get $out
   local.set $9
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -67588,16 +67588,16 @@
   global.set $~lib/memory/__stack_pointer
   local.get $9
  )
- (func $~lib/util/string/joinIntegerArray<u64> (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
-  (local $3 i32)
-  (local $4 i64)
-  (local $5 i32)
-  (local $6 i32)
-  (local $7 i32)
-  (local $8 i32)
-  (local $9 i64)
-  (local $10 i32)
-  (local $11 i32)
+ (func $~lib/util/string/joinIntegerArray<u64> (param $dataStart i32) (param $length i32) (param $separator i32) (result i32)
+  (local $lastIndex i32)
+  (local $var$4 i64)
+  (local $sepLen i32)
+  (local $estLen i32)
+  (local $result i32)
+  (local $offset i32)
+  (local $value i64)
+  (local $var$10 i32)
+  (local $var$11 i32)
   (local $12 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -67607,11 +67607,11 @@
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   i32.store $0
-  local.get $1
+  local.get $length
   i32.const 1
   i32.sub
-  local.set $3
-  local.get $3
+  local.set $lastIndex
+  local.get $lastIndex
   i32.const 0
   i32.lt_s
   if
@@ -67624,19 +67624,19 @@
    local.get $12
    return
   end
-  local.get $3
+  local.get $lastIndex
   i32.eqz
   if
-   local.get $0
+   local.get $dataStart
    i64.load $0
-   local.set $4
+   local.set $var$4
    i32.const 0
    drop
    i32.const 8
    i32.const 4
    i32.le_u
    drop
-   local.get $4
+   local.get $var$4
    i32.const 10
    call $~lib/util/number/utoa64
    local.set $12
@@ -67647,101 +67647,101 @@
    local.get $12
    return
   end
-  local.get $2
+  local.get $separator
   call $~lib/string/String#get:length
-  local.set $5
+  local.set $sepLen
   i32.const 20
-  local.get $5
+  local.get $sepLen
   i32.add
-  local.get $3
+  local.get $lastIndex
   i32.mul
   i32.const 20
   i32.add
-  local.set $6
+  local.set $estLen
   global.get $~lib/memory/__stack_pointer
-  local.get $6
+  local.get $estLen
   i32.const 1
   i32.shl
   i32.const 1
   call $~lib/rt/itcms/__new
-  local.tee $7
+  local.tee $result
   i32.store $0
   i32.const 0
-  local.set $8
+  local.set $offset
   i32.const 0
-  local.set $10
+  local.set $var$10
   loop $for-loop|0
-   local.get $10
-   local.get $3
+   local.get $var$10
+   local.get $lastIndex
    i32.lt_s
-   local.set $11
-   local.get $11
+   local.set $var$11
+   local.get $var$11
    if
-    local.get $0
-    local.get $10
+    local.get $dataStart
+    local.get $var$10
     i32.const 3
     i32.shl
     i32.add
     i64.load $0
-    local.set $9
-    local.get $8
-    local.get $7
-    local.get $8
+    local.set $value
+    local.get $offset
+    local.get $result
+    local.get $offset
     i32.const 1
     i32.shl
     i32.add
-    local.get $9
+    local.get $value
     call $~lib/util/number/itoa_buffered<u64>
     i32.add
-    local.set $8
-    local.get $5
+    local.set $offset
+    local.get $sepLen
     if
-     local.get $7
-     local.get $8
+     local.get $result
+     local.get $offset
      i32.const 1
      i32.shl
      i32.add
-     local.get $2
-     local.get $5
+     local.get $separator
+     local.get $sepLen
      i32.const 1
      i32.shl
      memory.copy $0 $0
-     local.get $8
-     local.get $5
+     local.get $offset
+     local.get $sepLen
      i32.add
-     local.set $8
+     local.set $offset
     end
-    local.get $10
+    local.get $var$10
     i32.const 1
     i32.add
-    local.set $10
+    local.set $var$10
     br $for-loop|0
    end
   end
-  local.get $0
-  local.get $3
+  local.get $dataStart
+  local.get $lastIndex
   i32.const 3
   i32.shl
   i32.add
   i64.load $0
-  local.set $9
-  local.get $8
-  local.get $7
-  local.get $8
+  local.set $value
+  local.get $offset
+  local.get $result
+  local.get $offset
   i32.const 1
   i32.shl
   i32.add
-  local.get $9
+  local.get $value
   call $~lib/util/number/itoa_buffered<u64>
   i32.add
-  local.set $8
-  local.get $6
-  local.get $8
+  local.set $offset
+  local.get $estLen
+  local.get $offset
   i32.gt_s
   if
-   local.get $7
+   local.get $result
    i32.const 0
-   local.get $8
+   local.get $offset
    call $~lib/string/String#substring
    local.set $12
    global.get $~lib/memory/__stack_pointer
@@ -67751,7 +67751,7 @@
    local.get $12
    return
   end
-  local.get $7
+  local.get $result
   local.set $12
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -67759,9 +67759,9 @@
   global.set $~lib/memory/__stack_pointer
   local.get $12
  )
- (func $~lib/util/number/dtoa (param $0 f64) (result i32)
-  (local $1 i32)
-  (local $2 i32)
+ (func $~lib/util/number/dtoa (param $value f64) (result i32)
+  (local $size i32)
+  (local $result i32)
   (local $3 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -67771,7 +67771,7 @@
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   i32.store $0
-  local.get $0
+  local.get $value
   f64.const 0
   f64.eq
   if
@@ -67784,15 +67784,15 @@
    local.get $3
    return
   end
-  local.get $0
-  local.get $0
+  local.get $value
+  local.get $value
   f64.sub
   f64.const 0
   f64.eq
   i32.eqz
   if
-   local.get $0
-   local.get $0
+   local.get $value
+   local.get $value
    f64.ne
    if
     i32.const 8672
@@ -67806,7 +67806,7 @@
    end
    i32.const 8704
    i32.const 8752
-   local.get $0
+   local.get $value
    f64.const 0
    f64.lt
    select
@@ -67819,22 +67819,22 @@
    return
   end
   i32.const 8784
-  local.get $0
+  local.get $value
   call $~lib/util/number/dtoa_core
   i32.const 1
   i32.shl
-  local.set $1
+  local.set $size
   global.get $~lib/memory/__stack_pointer
-  local.get $1
+  local.get $size
   i32.const 1
   call $~lib/rt/itcms/__new
-  local.tee $2
+  local.tee $result
   i32.store $0
-  local.get $2
+  local.get $result
   i32.const 8784
-  local.get $1
+  local.get $size
   memory.copy $0 $0
-  local.get $2
+  local.get $result
   local.set $3
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -67842,15 +67842,15 @@
   global.set $~lib/memory/__stack_pointer
   local.get $3
  )
- (func $~lib/util/string/joinFloatArray<f32> (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
-  (local $3 i32)
-  (local $4 i32)
-  (local $5 i32)
-  (local $6 i32)
-  (local $7 i32)
-  (local $8 f32)
-  (local $9 i32)
-  (local $10 i32)
+ (func $~lib/util/string/joinFloatArray<f32> (param $dataStart i32) (param $length i32) (param $separator i32) (result i32)
+  (local $lastIndex i32)
+  (local $sepLen i32)
+  (local $estLen i32)
+  (local $result i32)
+  (local $offset i32)
+  (local $value f32)
+  (local $var$9 i32)
+  (local $var$10 i32)
   (local $11 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -67860,11 +67860,11 @@
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   i32.store $0
-  local.get $1
+  local.get $length
   i32.const 1
   i32.sub
-  local.set $3
-  local.get $3
+  local.set $lastIndex
+  local.get $lastIndex
   i32.const 0
   i32.lt_s
   if
@@ -67877,10 +67877,10 @@
    local.get $11
    return
   end
-  local.get $3
+  local.get $lastIndex
   i32.eqz
   if
-   local.get $0
+   local.get $dataStart
    f32.load $0
    f64.promote_f32
    call $~lib/util/number/dtoa
@@ -67892,103 +67892,103 @@
    local.get $11
    return
   end
-  local.get $2
+  local.get $separator
   call $~lib/string/String#get:length
-  local.set $4
+  local.set $sepLen
   i32.const 28
-  local.get $4
+  local.get $sepLen
   i32.add
-  local.get $3
+  local.get $lastIndex
   i32.mul
   i32.const 28
   i32.add
-  local.set $5
+  local.set $estLen
   global.get $~lib/memory/__stack_pointer
-  local.get $5
+  local.get $estLen
   i32.const 1
   i32.shl
   i32.const 1
   call $~lib/rt/itcms/__new
-  local.tee $6
+  local.tee $result
   i32.store $0
   i32.const 0
-  local.set $7
+  local.set $offset
   i32.const 0
-  local.set $9
+  local.set $var$9
   loop $for-loop|0
-   local.get $9
-   local.get $3
+   local.get $var$9
+   local.get $lastIndex
    i32.lt_s
-   local.set $10
-   local.get $10
+   local.set $var$10
+   local.get $var$10
    if
-    local.get $0
-    local.get $9
+    local.get $dataStart
+    local.get $var$9
     i32.const 2
     i32.shl
     i32.add
     f32.load $0
-    local.set $8
-    local.get $7
-    local.get $6
-    local.get $7
+    local.set $value
+    local.get $offset
+    local.get $result
+    local.get $offset
     i32.const 1
     i32.shl
     i32.add
-    local.get $8
+    local.get $value
     f64.promote_f32
     call $~lib/util/number/dtoa_buffered
     i32.add
-    local.set $7
-    local.get $4
+    local.set $offset
+    local.get $sepLen
     if
-     local.get $6
-     local.get $7
+     local.get $result
+     local.get $offset
      i32.const 1
      i32.shl
      i32.add
-     local.get $2
-     local.get $4
+     local.get $separator
+     local.get $sepLen
      i32.const 1
      i32.shl
      memory.copy $0 $0
-     local.get $7
-     local.get $4
+     local.get $offset
+     local.get $sepLen
      i32.add
-     local.set $7
+     local.set $offset
     end
-    local.get $9
+    local.get $var$9
     i32.const 1
     i32.add
-    local.set $9
+    local.set $var$9
     br $for-loop|0
    end
   end
-  local.get $0
-  local.get $3
+  local.get $dataStart
+  local.get $lastIndex
   i32.const 2
   i32.shl
   i32.add
   f32.load $0
-  local.set $8
-  local.get $7
-  local.get $6
-  local.get $7
+  local.set $value
+  local.get $offset
+  local.get $result
+  local.get $offset
   i32.const 1
   i32.shl
   i32.add
-  local.get $8
+  local.get $value
   f64.promote_f32
   call $~lib/util/number/dtoa_buffered
   i32.add
-  local.set $7
-  local.get $5
-  local.get $7
+  local.set $offset
+  local.get $estLen
+  local.get $offset
   i32.gt_s
   if
-   local.get $6
+   local.get $result
    i32.const 0
-   local.get $7
+   local.get $offset
    call $~lib/string/String#substring
    local.set $11
    global.get $~lib/memory/__stack_pointer
@@ -67998,7 +67998,7 @@
    local.get $11
    return
   end
-  local.get $6
+  local.get $result
   local.set $11
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -68006,15 +68006,15 @@
   global.set $~lib/memory/__stack_pointer
   local.get $11
  )
- (func $~lib/util/string/joinFloatArray<f64> (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
-  (local $3 i32)
-  (local $4 i32)
-  (local $5 i32)
-  (local $6 i32)
-  (local $7 i32)
-  (local $8 f64)
-  (local $9 i32)
-  (local $10 i32)
+ (func $~lib/util/string/joinFloatArray<f64> (param $dataStart i32) (param $length i32) (param $separator i32) (result i32)
+  (local $lastIndex i32)
+  (local $sepLen i32)
+  (local $estLen i32)
+  (local $result i32)
+  (local $offset i32)
+  (local $value f64)
+  (local $var$9 i32)
+  (local $var$10 i32)
   (local $11 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -68024,11 +68024,11 @@
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   i32.store $0
-  local.get $1
+  local.get $length
   i32.const 1
   i32.sub
-  local.set $3
-  local.get $3
+  local.set $lastIndex
+  local.get $lastIndex
   i32.const 0
   i32.lt_s
   if
@@ -68041,10 +68041,10 @@
    local.get $11
    return
   end
-  local.get $3
+  local.get $lastIndex
   i32.eqz
   if
-   local.get $0
+   local.get $dataStart
    f64.load $0
    call $~lib/util/number/dtoa
    local.set $11
@@ -68055,101 +68055,101 @@
    local.get $11
    return
   end
-  local.get $2
+  local.get $separator
   call $~lib/string/String#get:length
-  local.set $4
+  local.set $sepLen
   i32.const 28
-  local.get $4
+  local.get $sepLen
   i32.add
-  local.get $3
+  local.get $lastIndex
   i32.mul
   i32.const 28
   i32.add
-  local.set $5
+  local.set $estLen
   global.get $~lib/memory/__stack_pointer
-  local.get $5
+  local.get $estLen
   i32.const 1
   i32.shl
   i32.const 1
   call $~lib/rt/itcms/__new
-  local.tee $6
+  local.tee $result
   i32.store $0
   i32.const 0
-  local.set $7
+  local.set $offset
   i32.const 0
-  local.set $9
+  local.set $var$9
   loop $for-loop|0
-   local.get $9
-   local.get $3
+   local.get $var$9
+   local.get $lastIndex
    i32.lt_s
-   local.set $10
-   local.get $10
+   local.set $var$10
+   local.get $var$10
    if
-    local.get $0
-    local.get $9
+    local.get $dataStart
+    local.get $var$9
     i32.const 3
     i32.shl
     i32.add
     f64.load $0
-    local.set $8
-    local.get $7
-    local.get $6
-    local.get $7
+    local.set $value
+    local.get $offset
+    local.get $result
+    local.get $offset
     i32.const 1
     i32.shl
     i32.add
-    local.get $8
+    local.get $value
     call $~lib/util/number/dtoa_buffered
     i32.add
-    local.set $7
-    local.get $4
+    local.set $offset
+    local.get $sepLen
     if
-     local.get $6
-     local.get $7
+     local.get $result
+     local.get $offset
      i32.const 1
      i32.shl
      i32.add
-     local.get $2
-     local.get $4
+     local.get $separator
+     local.get $sepLen
      i32.const 1
      i32.shl
      memory.copy $0 $0
-     local.get $7
-     local.get $4
+     local.get $offset
+     local.get $sepLen
      i32.add
-     local.set $7
+     local.set $offset
     end
-    local.get $9
+    local.get $var$9
     i32.const 1
     i32.add
-    local.set $9
+    local.set $var$9
     br $for-loop|0
    end
   end
-  local.get $0
-  local.get $3
+  local.get $dataStart
+  local.get $lastIndex
   i32.const 3
   i32.shl
   i32.add
   f64.load $0
-  local.set $8
-  local.get $7
-  local.get $6
-  local.get $7
+  local.set $value
+  local.get $offset
+  local.get $result
+  local.get $offset
   i32.const 1
   i32.shl
   i32.add
-  local.get $8
+  local.get $value
   call $~lib/util/number/dtoa_buffered
   i32.add
-  local.set $7
-  local.get $5
-  local.get $7
+  local.set $offset
+  local.get $estLen
+  local.get $offset
   i32.gt_s
   if
-   local.get $6
+   local.get $result
    i32.const 0
-   local.get $7
+   local.get $offset
    call $~lib/string/String#substring
    local.set $11
    global.get $~lib/memory/__stack_pointer
@@ -68159,7 +68159,7 @@
    local.get $11
    return
   end
-  local.get $6
+  local.get $result
   local.set $11
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -68167,8 +68167,8 @@
   global.set $~lib/memory/__stack_pointer
   local.get $11
  )
- (func $~lib/arraybuffer/ArrayBuffer#constructor (param $0 i32) (param $1 i32) (result i32)
-  (local $2 i32)
+ (func $~lib/arraybuffer/ArrayBuffer#constructor (param $this i32) (param $length i32) (result i32)
+  (local $buffer i32)
   (local $3 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -68178,7 +68178,7 @@
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   i32.store $0
-  local.get $1
+  local.get $length
   i32.const 1073741820
   i32.gt_u
   if
@@ -68190,16 +68190,16 @@
    unreachable
   end
   global.get $~lib/memory/__stack_pointer
-  local.get $1
+  local.get $length
   i32.const 0
   call $~lib/rt/itcms/__new
-  local.tee $2
+  local.tee $buffer
   i32.store $0
   i32.const 2
   global.get $~lib/shared/runtime/Runtime.Incremental
   i32.ne
   drop
-  local.get $2
+  local.get $buffer
   local.set $3
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -68207,13 +68207,13 @@
   global.set $~lib/memory/__stack_pointer
   local.get $3
  )
- (func $~lib/typedarray/Uint8Array.wrap (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
-  (local $3 i32)
-  (local $4 i32)
-  (local $5 i32)
-  (local $6 i32)
-  (local $7 i32)
-  (local $8 i32)
+ (func $~lib/typedarray/Uint8Array.wrap (param $buffer i32) (param $byteOffset i32) (param $length i32) (result i32)
+  (local $var$3 i32)
+  (local $var$4 i32)
+  (local $var$5 i32)
+  (local $var$6 i32)
+  (local $var$7 i32)
+  (local $var$8 i32)
   (local $9 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -68223,19 +68223,19 @@
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   i32.store $0
-  local.get $0
-  local.set $5
-  local.get $1
-  local.set $4
-  local.get $2
-  local.set $3
-  local.get $5
+  local.get $buffer
+  local.set $var$5
+  local.get $byteOffset
+  local.set $var$4
+  local.get $length
+  local.set $var$3
+  local.get $var$5
   call $~lib/arraybuffer/ArrayBuffer#get:byteLength
-  local.set $7
-  local.get $4
-  local.get $7
+  local.set $var$7
+  local.get $var$4
+  local.get $var$7
   i32.gt_u
-  local.get $4
+  local.get $var$4
   i32.const 0
   i32.and
   i32.or
@@ -68247,15 +68247,15 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $3
+  local.get $var$3
   i32.const 0
   i32.lt_s
   if
-   local.get $3
+   local.get $var$3
    i32.const -1
    i32.eq
    if
-    local.get $7
+    local.get $var$7
     i32.const 0
     i32.and
     if
@@ -68266,10 +68266,10 @@
      call $~lib/builtins/abort
      unreachable
     end
-    local.get $7
-    local.get $4
+    local.get $var$7
+    local.get $var$4
     i32.sub
-    local.set $6
+    local.set $var$6
    else
     i32.const 32
     i32.const 608
@@ -68279,14 +68279,14 @@
     unreachable
    end
   else
-   local.get $3
+   local.get $var$3
    i32.const 0
    i32.shl
-   local.set $6
-   local.get $4
-   local.get $6
+   local.set $var$6
+   local.get $var$4
+   local.get $var$6
    i32.add
-   local.get $7
+   local.get $var$7
    i32.gt_s
    if
     i32.const 32
@@ -68301,24 +68301,24 @@
   i32.const 12
   i32.const 4
   call $~lib/rt/itcms/__new
-  local.tee $8
+  local.tee $var$8
   i32.store $0
-  local.get $8
-  local.get $5
+  local.get $var$8
+  local.get $var$5
   i32.store $0
-  local.get $8
-  local.get $5
+  local.get $var$8
+  local.get $var$5
   i32.const 0
   call $~lib/rt/itcms/__link
-  local.get $8
-  local.get $6
+  local.get $var$8
+  local.get $var$6
   i32.store $0 offset=8
-  local.get $8
-  local.get $5
-  local.get $4
+  local.get $var$8
+  local.get $var$5
+  local.get $var$4
   i32.add
   i32.store $0 offset=4
-  local.get $8
+  local.get $var$8
   local.set $9
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -68326,12 +68326,12 @@
   global.set $~lib/memory/__stack_pointer
   local.get $9
  )
- (func $~lib/arraybuffer/ArrayBuffer#slice (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
-  (local $3 i32)
-  (local $4 i32)
-  (local $5 i32)
-  (local $6 i32)
-  (local $7 i32)
+ (func $~lib/arraybuffer/ArrayBuffer#slice (param $this i32) (param $begin i32) (param $end i32) (result i32)
+  (local $length i32)
+  (local $var$4 i32)
+  (local $var$5 i32)
+  (local $outSize i32)
+  (local $out i32)
   (local $8 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -68341,83 +68341,83 @@
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   i32.store $0
-  local.get $0
+  local.get $this
   call $~lib/arraybuffer/ArrayBuffer#get:byteLength
-  local.set $3
-  local.get $1
+  local.set $length
+  local.get $begin
   i32.const 0
   i32.lt_s
   if (result i32)
-   local.get $3
-   local.get $1
+   local.get $length
+   local.get $begin
    i32.add
-   local.tee $4
+   local.tee $var$4
    i32.const 0
-   local.tee $5
-   local.get $4
-   local.get $5
+   local.tee $var$5
+   local.get $var$4
+   local.get $var$5
    i32.gt_s
    select
   else
-   local.get $1
-   local.tee $5
-   local.get $3
-   local.tee $4
-   local.get $5
-   local.get $4
+   local.get $begin
+   local.tee $var$5
+   local.get $length
+   local.tee $var$4
+   local.get $var$5
+   local.get $var$4
    i32.lt_s
    select
   end
-  local.set $1
-  local.get $2
+  local.set $begin
+  local.get $end
   i32.const 0
   i32.lt_s
   if (result i32)
-   local.get $3
-   local.get $2
+   local.get $length
+   local.get $end
    i32.add
-   local.tee $4
+   local.tee $var$4
    i32.const 0
-   local.tee $5
-   local.get $4
-   local.get $5
+   local.tee $var$5
+   local.get $var$4
+   local.get $var$5
    i32.gt_s
    select
   else
-   local.get $2
-   local.tee $5
-   local.get $3
-   local.tee $4
-   local.get $5
-   local.get $4
+   local.get $end
+   local.tee $var$5
+   local.get $length
+   local.tee $var$4
+   local.get $var$5
+   local.get $var$4
    i32.lt_s
    select
   end
-  local.set $2
-  local.get $2
-  local.get $1
+  local.set $end
+  local.get $end
+  local.get $begin
   i32.sub
-  local.tee $4
+  local.tee $var$4
   i32.const 0
-  local.tee $5
-  local.get $4
-  local.get $5
+  local.tee $var$5
+  local.get $var$4
+  local.get $var$5
   i32.gt_s
   select
-  local.set $6
+  local.set $outSize
   global.get $~lib/memory/__stack_pointer
-  local.get $6
+  local.get $outSize
   i32.const 0
   call $~lib/rt/itcms/__new
-  local.tee $7
+  local.tee $out
   i32.store $0
-  local.get $7
-  local.get $0
-  local.get $1
+  local.get $out
+  local.get $this
+  local.get $begin
   i32.add
-  local.get $6
+  local.get $outSize
   memory.copy $0 $0
-  local.get $7
+  local.get $out
   local.set $8
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -68425,13 +68425,13 @@
   global.set $~lib/memory/__stack_pointer
   local.get $8
  )
- (func $~lib/typedarray/Int8Array.wrap (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
-  (local $3 i32)
-  (local $4 i32)
-  (local $5 i32)
-  (local $6 i32)
-  (local $7 i32)
-  (local $8 i32)
+ (func $~lib/typedarray/Int8Array.wrap (param $buffer i32) (param $byteOffset i32) (param $length i32) (result i32)
+  (local $var$3 i32)
+  (local $var$4 i32)
+  (local $var$5 i32)
+  (local $var$6 i32)
+  (local $var$7 i32)
+  (local $var$8 i32)
   (local $9 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -68441,19 +68441,19 @@
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   i32.store $0
-  local.get $0
-  local.set $5
-  local.get $1
-  local.set $4
-  local.get $2
-  local.set $3
-  local.get $5
+  local.get $buffer
+  local.set $var$5
+  local.get $byteOffset
+  local.set $var$4
+  local.get $length
+  local.set $var$3
+  local.get $var$5
   call $~lib/arraybuffer/ArrayBuffer#get:byteLength
-  local.set $7
-  local.get $4
-  local.get $7
+  local.set $var$7
+  local.get $var$4
+  local.get $var$7
   i32.gt_u
-  local.get $4
+  local.get $var$4
   i32.const 0
   i32.and
   i32.or
@@ -68465,15 +68465,15 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $3
+  local.get $var$3
   i32.const 0
   i32.lt_s
   if
-   local.get $3
+   local.get $var$3
    i32.const -1
    i32.eq
    if
-    local.get $7
+    local.get $var$7
     i32.const 0
     i32.and
     if
@@ -68484,10 +68484,10 @@
      call $~lib/builtins/abort
      unreachable
     end
-    local.get $7
-    local.get $4
+    local.get $var$7
+    local.get $var$4
     i32.sub
-    local.set $6
+    local.set $var$6
    else
     i32.const 32
     i32.const 608
@@ -68497,14 +68497,14 @@
     unreachable
    end
   else
-   local.get $3
+   local.get $var$3
    i32.const 0
    i32.shl
-   local.set $6
-   local.get $4
-   local.get $6
+   local.set $var$6
+   local.get $var$4
+   local.get $var$6
    i32.add
-   local.get $7
+   local.get $var$7
    i32.gt_s
    if
     i32.const 32
@@ -68519,24 +68519,24 @@
   i32.const 12
   i32.const 3
   call $~lib/rt/itcms/__new
-  local.tee $8
+  local.tee $var$8
   i32.store $0
-  local.get $8
-  local.get $5
+  local.get $var$8
+  local.get $var$5
   i32.store $0
-  local.get $8
-  local.get $5
+  local.get $var$8
+  local.get $var$5
   i32.const 0
   call $~lib/rt/itcms/__link
-  local.get $8
-  local.get $6
+  local.get $var$8
+  local.get $var$6
   i32.store $0 offset=8
-  local.get $8
-  local.get $5
-  local.get $4
+  local.get $var$8
+  local.get $var$5
+  local.get $var$4
   i32.add
   i32.store $0 offset=4
-  local.get $8
+  local.get $var$8
   local.set $9
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -68544,13 +68544,13 @@
   global.set $~lib/memory/__stack_pointer
   local.get $9
  )
- (func $~lib/typedarray/Uint8ClampedArray.wrap (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
-  (local $3 i32)
-  (local $4 i32)
-  (local $5 i32)
-  (local $6 i32)
-  (local $7 i32)
-  (local $8 i32)
+ (func $~lib/typedarray/Uint8ClampedArray.wrap (param $buffer i32) (param $byteOffset i32) (param $length i32) (result i32)
+  (local $var$3 i32)
+  (local $var$4 i32)
+  (local $var$5 i32)
+  (local $var$6 i32)
+  (local $var$7 i32)
+  (local $var$8 i32)
   (local $9 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -68560,19 +68560,19 @@
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   i32.store $0
-  local.get $0
-  local.set $5
-  local.get $1
-  local.set $4
-  local.get $2
-  local.set $3
-  local.get $5
+  local.get $buffer
+  local.set $var$5
+  local.get $byteOffset
+  local.set $var$4
+  local.get $length
+  local.set $var$3
+  local.get $var$5
   call $~lib/arraybuffer/ArrayBuffer#get:byteLength
-  local.set $7
-  local.get $4
-  local.get $7
+  local.set $var$7
+  local.get $var$4
+  local.get $var$7
   i32.gt_u
-  local.get $4
+  local.get $var$4
   i32.const 0
   i32.and
   i32.or
@@ -68584,15 +68584,15 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $3
+  local.get $var$3
   i32.const 0
   i32.lt_s
   if
-   local.get $3
+   local.get $var$3
    i32.const -1
    i32.eq
    if
-    local.get $7
+    local.get $var$7
     i32.const 0
     i32.and
     if
@@ -68603,10 +68603,10 @@
      call $~lib/builtins/abort
      unreachable
     end
-    local.get $7
-    local.get $4
+    local.get $var$7
+    local.get $var$4
     i32.sub
-    local.set $6
+    local.set $var$6
    else
     i32.const 32
     i32.const 608
@@ -68616,14 +68616,14 @@
     unreachable
    end
   else
-   local.get $3
+   local.get $var$3
    i32.const 0
    i32.shl
-   local.set $6
-   local.get $4
-   local.get $6
+   local.set $var$6
+   local.get $var$4
+   local.get $var$6
    i32.add
-   local.get $7
+   local.get $var$7
    i32.gt_s
    if
     i32.const 32
@@ -68638,24 +68638,24 @@
   i32.const 12
   i32.const 5
   call $~lib/rt/itcms/__new
-  local.tee $8
+  local.tee $var$8
   i32.store $0
-  local.get $8
-  local.get $5
+  local.get $var$8
+  local.get $var$5
   i32.store $0
-  local.get $8
-  local.get $5
+  local.get $var$8
+  local.get $var$5
   i32.const 0
   call $~lib/rt/itcms/__link
-  local.get $8
-  local.get $6
+  local.get $var$8
+  local.get $var$6
   i32.store $0 offset=8
-  local.get $8
-  local.get $5
-  local.get $4
+  local.get $var$8
+  local.get $var$5
+  local.get $var$4
   i32.add
   i32.store $0 offset=4
-  local.get $8
+  local.get $var$8
   local.set $9
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -68663,13 +68663,13 @@
   global.set $~lib/memory/__stack_pointer
   local.get $9
  )
- (func $~lib/typedarray/Int16Array.wrap (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
-  (local $3 i32)
-  (local $4 i32)
-  (local $5 i32)
-  (local $6 i32)
-  (local $7 i32)
-  (local $8 i32)
+ (func $~lib/typedarray/Int16Array.wrap (param $buffer i32) (param $byteOffset i32) (param $length i32) (result i32)
+  (local $var$3 i32)
+  (local $var$4 i32)
+  (local $var$5 i32)
+  (local $var$6 i32)
+  (local $var$7 i32)
+  (local $var$8 i32)
   (local $9 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -68679,19 +68679,19 @@
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   i32.store $0
-  local.get $0
-  local.set $5
-  local.get $1
-  local.set $4
-  local.get $2
-  local.set $3
-  local.get $5
+  local.get $buffer
+  local.set $var$5
+  local.get $byteOffset
+  local.set $var$4
+  local.get $length
+  local.set $var$3
+  local.get $var$5
   call $~lib/arraybuffer/ArrayBuffer#get:byteLength
-  local.set $7
-  local.get $4
-  local.get $7
+  local.set $var$7
+  local.get $var$4
+  local.get $var$7
   i32.gt_u
-  local.get $4
+  local.get $var$4
   i32.const 1
   i32.and
   i32.or
@@ -68703,15 +68703,15 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $3
+  local.get $var$3
   i32.const 0
   i32.lt_s
   if
-   local.get $3
+   local.get $var$3
    i32.const -1
    i32.eq
    if
-    local.get $7
+    local.get $var$7
     i32.const 1
     i32.and
     if
@@ -68722,10 +68722,10 @@
      call $~lib/builtins/abort
      unreachable
     end
-    local.get $7
-    local.get $4
+    local.get $var$7
+    local.get $var$4
     i32.sub
-    local.set $6
+    local.set $var$6
    else
     i32.const 32
     i32.const 608
@@ -68735,14 +68735,14 @@
     unreachable
    end
   else
-   local.get $3
+   local.get $var$3
    i32.const 1
    i32.shl
-   local.set $6
-   local.get $4
-   local.get $6
+   local.set $var$6
+   local.get $var$4
+   local.get $var$6
    i32.add
-   local.get $7
+   local.get $var$7
    i32.gt_s
    if
     i32.const 32
@@ -68757,24 +68757,24 @@
   i32.const 12
   i32.const 6
   call $~lib/rt/itcms/__new
-  local.tee $8
+  local.tee $var$8
   i32.store $0
-  local.get $8
-  local.get $5
+  local.get $var$8
+  local.get $var$5
   i32.store $0
-  local.get $8
-  local.get $5
+  local.get $var$8
+  local.get $var$5
   i32.const 0
   call $~lib/rt/itcms/__link
-  local.get $8
-  local.get $6
+  local.get $var$8
+  local.get $var$6
   i32.store $0 offset=8
-  local.get $8
-  local.get $5
-  local.get $4
+  local.get $var$8
+  local.get $var$5
+  local.get $var$4
   i32.add
   i32.store $0 offset=4
-  local.get $8
+  local.get $var$8
   local.set $9
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -68782,13 +68782,13 @@
   global.set $~lib/memory/__stack_pointer
   local.get $9
  )
- (func $~lib/typedarray/Uint16Array.wrap (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
-  (local $3 i32)
-  (local $4 i32)
-  (local $5 i32)
-  (local $6 i32)
-  (local $7 i32)
-  (local $8 i32)
+ (func $~lib/typedarray/Uint16Array.wrap (param $buffer i32) (param $byteOffset i32) (param $length i32) (result i32)
+  (local $var$3 i32)
+  (local $var$4 i32)
+  (local $var$5 i32)
+  (local $var$6 i32)
+  (local $var$7 i32)
+  (local $var$8 i32)
   (local $9 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -68798,19 +68798,19 @@
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   i32.store $0
-  local.get $0
-  local.set $5
-  local.get $1
-  local.set $4
-  local.get $2
-  local.set $3
-  local.get $5
+  local.get $buffer
+  local.set $var$5
+  local.get $byteOffset
+  local.set $var$4
+  local.get $length
+  local.set $var$3
+  local.get $var$5
   call $~lib/arraybuffer/ArrayBuffer#get:byteLength
-  local.set $7
-  local.get $4
-  local.get $7
+  local.set $var$7
+  local.get $var$4
+  local.get $var$7
   i32.gt_u
-  local.get $4
+  local.get $var$4
   i32.const 1
   i32.and
   i32.or
@@ -68822,15 +68822,15 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $3
+  local.get $var$3
   i32.const 0
   i32.lt_s
   if
-   local.get $3
+   local.get $var$3
    i32.const -1
    i32.eq
    if
-    local.get $7
+    local.get $var$7
     i32.const 1
     i32.and
     if
@@ -68841,10 +68841,10 @@
      call $~lib/builtins/abort
      unreachable
     end
-    local.get $7
-    local.get $4
+    local.get $var$7
+    local.get $var$4
     i32.sub
-    local.set $6
+    local.set $var$6
    else
     i32.const 32
     i32.const 608
@@ -68854,14 +68854,14 @@
     unreachable
    end
   else
-   local.get $3
+   local.get $var$3
    i32.const 1
    i32.shl
-   local.set $6
-   local.get $4
-   local.get $6
+   local.set $var$6
+   local.get $var$4
+   local.get $var$6
    i32.add
-   local.get $7
+   local.get $var$7
    i32.gt_s
    if
     i32.const 32
@@ -68876,24 +68876,24 @@
   i32.const 12
   i32.const 7
   call $~lib/rt/itcms/__new
-  local.tee $8
+  local.tee $var$8
   i32.store $0
-  local.get $8
-  local.get $5
+  local.get $var$8
+  local.get $var$5
   i32.store $0
-  local.get $8
-  local.get $5
+  local.get $var$8
+  local.get $var$5
   i32.const 0
   call $~lib/rt/itcms/__link
-  local.get $8
-  local.get $6
+  local.get $var$8
+  local.get $var$6
   i32.store $0 offset=8
-  local.get $8
-  local.get $5
-  local.get $4
+  local.get $var$8
+  local.get $var$5
+  local.get $var$4
   i32.add
   i32.store $0 offset=4
-  local.get $8
+  local.get $var$8
   local.set $9
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -68901,13 +68901,13 @@
   global.set $~lib/memory/__stack_pointer
   local.get $9
  )
- (func $~lib/typedarray/Int32Array.wrap (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
-  (local $3 i32)
-  (local $4 i32)
-  (local $5 i32)
-  (local $6 i32)
-  (local $7 i32)
-  (local $8 i32)
+ (func $~lib/typedarray/Int32Array.wrap (param $buffer i32) (param $byteOffset i32) (param $length i32) (result i32)
+  (local $var$3 i32)
+  (local $var$4 i32)
+  (local $var$5 i32)
+  (local $var$6 i32)
+  (local $var$7 i32)
+  (local $var$8 i32)
   (local $9 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -68917,19 +68917,19 @@
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   i32.store $0
-  local.get $0
-  local.set $5
-  local.get $1
-  local.set $4
-  local.get $2
-  local.set $3
-  local.get $5
+  local.get $buffer
+  local.set $var$5
+  local.get $byteOffset
+  local.set $var$4
+  local.get $length
+  local.set $var$3
+  local.get $var$5
   call $~lib/arraybuffer/ArrayBuffer#get:byteLength
-  local.set $7
-  local.get $4
-  local.get $7
+  local.set $var$7
+  local.get $var$4
+  local.get $var$7
   i32.gt_u
-  local.get $4
+  local.get $var$4
   i32.const 3
   i32.and
   i32.or
@@ -68941,15 +68941,15 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $3
+  local.get $var$3
   i32.const 0
   i32.lt_s
   if
-   local.get $3
+   local.get $var$3
    i32.const -1
    i32.eq
    if
-    local.get $7
+    local.get $var$7
     i32.const 3
     i32.and
     if
@@ -68960,10 +68960,10 @@
      call $~lib/builtins/abort
      unreachable
     end
-    local.get $7
-    local.get $4
+    local.get $var$7
+    local.get $var$4
     i32.sub
-    local.set $6
+    local.set $var$6
    else
     i32.const 32
     i32.const 608
@@ -68973,14 +68973,14 @@
     unreachable
    end
   else
-   local.get $3
+   local.get $var$3
    i32.const 2
    i32.shl
-   local.set $6
-   local.get $4
-   local.get $6
+   local.set $var$6
+   local.get $var$4
+   local.get $var$6
    i32.add
-   local.get $7
+   local.get $var$7
    i32.gt_s
    if
     i32.const 32
@@ -68995,24 +68995,24 @@
   i32.const 12
   i32.const 8
   call $~lib/rt/itcms/__new
-  local.tee $8
+  local.tee $var$8
   i32.store $0
-  local.get $8
-  local.get $5
+  local.get $var$8
+  local.get $var$5
   i32.store $0
-  local.get $8
-  local.get $5
+  local.get $var$8
+  local.get $var$5
   i32.const 0
   call $~lib/rt/itcms/__link
-  local.get $8
-  local.get $6
+  local.get $var$8
+  local.get $var$6
   i32.store $0 offset=8
-  local.get $8
-  local.get $5
-  local.get $4
+  local.get $var$8
+  local.get $var$5
+  local.get $var$4
   i32.add
   i32.store $0 offset=4
-  local.get $8
+  local.get $var$8
   local.set $9
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -69020,13 +69020,13 @@
   global.set $~lib/memory/__stack_pointer
   local.get $9
  )
- (func $~lib/typedarray/Uint32Array.wrap (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
-  (local $3 i32)
-  (local $4 i32)
-  (local $5 i32)
-  (local $6 i32)
-  (local $7 i32)
-  (local $8 i32)
+ (func $~lib/typedarray/Uint32Array.wrap (param $buffer i32) (param $byteOffset i32) (param $length i32) (result i32)
+  (local $var$3 i32)
+  (local $var$4 i32)
+  (local $var$5 i32)
+  (local $var$6 i32)
+  (local $var$7 i32)
+  (local $var$8 i32)
   (local $9 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -69036,19 +69036,19 @@
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   i32.store $0
-  local.get $0
-  local.set $5
-  local.get $1
-  local.set $4
-  local.get $2
-  local.set $3
-  local.get $5
+  local.get $buffer
+  local.set $var$5
+  local.get $byteOffset
+  local.set $var$4
+  local.get $length
+  local.set $var$3
+  local.get $var$5
   call $~lib/arraybuffer/ArrayBuffer#get:byteLength
-  local.set $7
-  local.get $4
-  local.get $7
+  local.set $var$7
+  local.get $var$4
+  local.get $var$7
   i32.gt_u
-  local.get $4
+  local.get $var$4
   i32.const 3
   i32.and
   i32.or
@@ -69060,15 +69060,15 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $3
+  local.get $var$3
   i32.const 0
   i32.lt_s
   if
-   local.get $3
+   local.get $var$3
    i32.const -1
    i32.eq
    if
-    local.get $7
+    local.get $var$7
     i32.const 3
     i32.and
     if
@@ -69079,10 +69079,10 @@
      call $~lib/builtins/abort
      unreachable
     end
-    local.get $7
-    local.get $4
+    local.get $var$7
+    local.get $var$4
     i32.sub
-    local.set $6
+    local.set $var$6
    else
     i32.const 32
     i32.const 608
@@ -69092,14 +69092,14 @@
     unreachable
    end
   else
-   local.get $3
+   local.get $var$3
    i32.const 2
    i32.shl
-   local.set $6
-   local.get $4
-   local.get $6
+   local.set $var$6
+   local.get $var$4
+   local.get $var$6
    i32.add
-   local.get $7
+   local.get $var$7
    i32.gt_s
    if
     i32.const 32
@@ -69114,24 +69114,24 @@
   i32.const 12
   i32.const 9
   call $~lib/rt/itcms/__new
-  local.tee $8
+  local.tee $var$8
   i32.store $0
-  local.get $8
-  local.get $5
+  local.get $var$8
+  local.get $var$5
   i32.store $0
-  local.get $8
-  local.get $5
+  local.get $var$8
+  local.get $var$5
   i32.const 0
   call $~lib/rt/itcms/__link
-  local.get $8
-  local.get $6
+  local.get $var$8
+  local.get $var$6
   i32.store $0 offset=8
-  local.get $8
-  local.get $5
-  local.get $4
+  local.get $var$8
+  local.get $var$5
+  local.get $var$4
   i32.add
   i32.store $0 offset=4
-  local.get $8
+  local.get $var$8
   local.set $9
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -69139,13 +69139,13 @@
   global.set $~lib/memory/__stack_pointer
   local.get $9
  )
- (func $~lib/typedarray/Int64Array.wrap (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
-  (local $3 i32)
-  (local $4 i32)
-  (local $5 i32)
-  (local $6 i32)
-  (local $7 i32)
-  (local $8 i32)
+ (func $~lib/typedarray/Int64Array.wrap (param $buffer i32) (param $byteOffset i32) (param $length i32) (result i32)
+  (local $var$3 i32)
+  (local $var$4 i32)
+  (local $var$5 i32)
+  (local $var$6 i32)
+  (local $var$7 i32)
+  (local $var$8 i32)
   (local $9 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -69155,19 +69155,19 @@
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   i32.store $0
-  local.get $0
-  local.set $5
-  local.get $1
-  local.set $4
-  local.get $2
-  local.set $3
-  local.get $5
+  local.get $buffer
+  local.set $var$5
+  local.get $byteOffset
+  local.set $var$4
+  local.get $length
+  local.set $var$3
+  local.get $var$5
   call $~lib/arraybuffer/ArrayBuffer#get:byteLength
-  local.set $7
-  local.get $4
-  local.get $7
+  local.set $var$7
+  local.get $var$4
+  local.get $var$7
   i32.gt_u
-  local.get $4
+  local.get $var$4
   i32.const 7
   i32.and
   i32.or
@@ -69179,15 +69179,15 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $3
+  local.get $var$3
   i32.const 0
   i32.lt_s
   if
-   local.get $3
+   local.get $var$3
    i32.const -1
    i32.eq
    if
-    local.get $7
+    local.get $var$7
     i32.const 7
     i32.and
     if
@@ -69198,10 +69198,10 @@
      call $~lib/builtins/abort
      unreachable
     end
-    local.get $7
-    local.get $4
+    local.get $var$7
+    local.get $var$4
     i32.sub
-    local.set $6
+    local.set $var$6
    else
     i32.const 32
     i32.const 608
@@ -69211,14 +69211,14 @@
     unreachable
    end
   else
-   local.get $3
+   local.get $var$3
    i32.const 3
    i32.shl
-   local.set $6
-   local.get $4
-   local.get $6
+   local.set $var$6
+   local.get $var$4
+   local.get $var$6
    i32.add
-   local.get $7
+   local.get $var$7
    i32.gt_s
    if
     i32.const 32
@@ -69233,24 +69233,24 @@
   i32.const 12
   i32.const 10
   call $~lib/rt/itcms/__new
-  local.tee $8
+  local.tee $var$8
   i32.store $0
-  local.get $8
-  local.get $5
+  local.get $var$8
+  local.get $var$5
   i32.store $0
-  local.get $8
-  local.get $5
+  local.get $var$8
+  local.get $var$5
   i32.const 0
   call $~lib/rt/itcms/__link
-  local.get $8
-  local.get $6
+  local.get $var$8
+  local.get $var$6
   i32.store $0 offset=8
-  local.get $8
-  local.get $5
-  local.get $4
+  local.get $var$8
+  local.get $var$5
+  local.get $var$4
   i32.add
   i32.store $0 offset=4
-  local.get $8
+  local.get $var$8
   local.set $9
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -69258,13 +69258,13 @@
   global.set $~lib/memory/__stack_pointer
   local.get $9
  )
- (func $~lib/typedarray/Uint64Array.wrap (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
-  (local $3 i32)
-  (local $4 i32)
-  (local $5 i32)
-  (local $6 i32)
-  (local $7 i32)
-  (local $8 i32)
+ (func $~lib/typedarray/Uint64Array.wrap (param $buffer i32) (param $byteOffset i32) (param $length i32) (result i32)
+  (local $var$3 i32)
+  (local $var$4 i32)
+  (local $var$5 i32)
+  (local $var$6 i32)
+  (local $var$7 i32)
+  (local $var$8 i32)
   (local $9 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -69274,19 +69274,19 @@
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   i32.store $0
-  local.get $0
-  local.set $5
-  local.get $1
-  local.set $4
-  local.get $2
-  local.set $3
-  local.get $5
+  local.get $buffer
+  local.set $var$5
+  local.get $byteOffset
+  local.set $var$4
+  local.get $length
+  local.set $var$3
+  local.get $var$5
   call $~lib/arraybuffer/ArrayBuffer#get:byteLength
-  local.set $7
-  local.get $4
-  local.get $7
+  local.set $var$7
+  local.get $var$4
+  local.get $var$7
   i32.gt_u
-  local.get $4
+  local.get $var$4
   i32.const 7
   i32.and
   i32.or
@@ -69298,15 +69298,15 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $3
+  local.get $var$3
   i32.const 0
   i32.lt_s
   if
-   local.get $3
+   local.get $var$3
    i32.const -1
    i32.eq
    if
-    local.get $7
+    local.get $var$7
     i32.const 7
     i32.and
     if
@@ -69317,10 +69317,10 @@
      call $~lib/builtins/abort
      unreachable
     end
-    local.get $7
-    local.get $4
+    local.get $var$7
+    local.get $var$4
     i32.sub
-    local.set $6
+    local.set $var$6
    else
     i32.const 32
     i32.const 608
@@ -69330,14 +69330,14 @@
     unreachable
    end
   else
-   local.get $3
+   local.get $var$3
    i32.const 3
    i32.shl
-   local.set $6
-   local.get $4
-   local.get $6
+   local.set $var$6
+   local.get $var$4
+   local.get $var$6
    i32.add
-   local.get $7
+   local.get $var$7
    i32.gt_s
    if
     i32.const 32
@@ -69352,24 +69352,24 @@
   i32.const 12
   i32.const 11
   call $~lib/rt/itcms/__new
-  local.tee $8
+  local.tee $var$8
   i32.store $0
-  local.get $8
-  local.get $5
+  local.get $var$8
+  local.get $var$5
   i32.store $0
-  local.get $8
-  local.get $5
+  local.get $var$8
+  local.get $var$5
   i32.const 0
   call $~lib/rt/itcms/__link
-  local.get $8
-  local.get $6
+  local.get $var$8
+  local.get $var$6
   i32.store $0 offset=8
-  local.get $8
-  local.get $5
-  local.get $4
+  local.get $var$8
+  local.get $var$5
+  local.get $var$4
   i32.add
   i32.store $0 offset=4
-  local.get $8
+  local.get $var$8
   local.set $9
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -69377,13 +69377,13 @@
   global.set $~lib/memory/__stack_pointer
   local.get $9
  )
- (func $~lib/typedarray/Float32Array.wrap (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
-  (local $3 i32)
-  (local $4 i32)
-  (local $5 i32)
-  (local $6 i32)
-  (local $7 i32)
-  (local $8 i32)
+ (func $~lib/typedarray/Float32Array.wrap (param $buffer i32) (param $byteOffset i32) (param $length i32) (result i32)
+  (local $var$3 i32)
+  (local $var$4 i32)
+  (local $var$5 i32)
+  (local $var$6 i32)
+  (local $var$7 i32)
+  (local $var$8 i32)
   (local $9 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -69393,19 +69393,19 @@
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   i32.store $0
-  local.get $0
-  local.set $5
-  local.get $1
-  local.set $4
-  local.get $2
-  local.set $3
-  local.get $5
+  local.get $buffer
+  local.set $var$5
+  local.get $byteOffset
+  local.set $var$4
+  local.get $length
+  local.set $var$3
+  local.get $var$5
   call $~lib/arraybuffer/ArrayBuffer#get:byteLength
-  local.set $7
-  local.get $4
-  local.get $7
+  local.set $var$7
+  local.get $var$4
+  local.get $var$7
   i32.gt_u
-  local.get $4
+  local.get $var$4
   i32.const 3
   i32.and
   i32.or
@@ -69417,15 +69417,15 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $3
+  local.get $var$3
   i32.const 0
   i32.lt_s
   if
-   local.get $3
+   local.get $var$3
    i32.const -1
    i32.eq
    if
-    local.get $7
+    local.get $var$7
     i32.const 3
     i32.and
     if
@@ -69436,10 +69436,10 @@
      call $~lib/builtins/abort
      unreachable
     end
-    local.get $7
-    local.get $4
+    local.get $var$7
+    local.get $var$4
     i32.sub
-    local.set $6
+    local.set $var$6
    else
     i32.const 32
     i32.const 608
@@ -69449,14 +69449,14 @@
     unreachable
    end
   else
-   local.get $3
+   local.get $var$3
    i32.const 2
    i32.shl
-   local.set $6
-   local.get $4
-   local.get $6
+   local.set $var$6
+   local.get $var$4
+   local.get $var$6
    i32.add
-   local.get $7
+   local.get $var$7
    i32.gt_s
    if
     i32.const 32
@@ -69471,24 +69471,24 @@
   i32.const 12
   i32.const 12
   call $~lib/rt/itcms/__new
-  local.tee $8
+  local.tee $var$8
   i32.store $0
-  local.get $8
-  local.get $5
+  local.get $var$8
+  local.get $var$5
   i32.store $0
-  local.get $8
-  local.get $5
+  local.get $var$8
+  local.get $var$5
   i32.const 0
   call $~lib/rt/itcms/__link
-  local.get $8
-  local.get $6
+  local.get $var$8
+  local.get $var$6
   i32.store $0 offset=8
-  local.get $8
-  local.get $5
-  local.get $4
+  local.get $var$8
+  local.get $var$5
+  local.get $var$4
   i32.add
   i32.store $0 offset=4
-  local.get $8
+  local.get $var$8
   local.set $9
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -69496,13 +69496,13 @@
   global.set $~lib/memory/__stack_pointer
   local.get $9
  )
- (func $~lib/typedarray/Float64Array.wrap (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
-  (local $3 i32)
-  (local $4 i32)
-  (local $5 i32)
-  (local $6 i32)
-  (local $7 i32)
-  (local $8 i32)
+ (func $~lib/typedarray/Float64Array.wrap (param $buffer i32) (param $byteOffset i32) (param $length i32) (result i32)
+  (local $var$3 i32)
+  (local $var$4 i32)
+  (local $var$5 i32)
+  (local $var$6 i32)
+  (local $var$7 i32)
+  (local $var$8 i32)
   (local $9 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -69512,19 +69512,19 @@
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   i32.store $0
-  local.get $0
-  local.set $5
-  local.get $1
-  local.set $4
-  local.get $2
-  local.set $3
-  local.get $5
+  local.get $buffer
+  local.set $var$5
+  local.get $byteOffset
+  local.set $var$4
+  local.get $length
+  local.set $var$3
+  local.get $var$5
   call $~lib/arraybuffer/ArrayBuffer#get:byteLength
-  local.set $7
-  local.get $4
-  local.get $7
+  local.set $var$7
+  local.get $var$4
+  local.get $var$7
   i32.gt_u
-  local.get $4
+  local.get $var$4
   i32.const 7
   i32.and
   i32.or
@@ -69536,15 +69536,15 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $3
+  local.get $var$3
   i32.const 0
   i32.lt_s
   if
-   local.get $3
+   local.get $var$3
    i32.const -1
    i32.eq
    if
-    local.get $7
+    local.get $var$7
     i32.const 7
     i32.and
     if
@@ -69555,10 +69555,10 @@
      call $~lib/builtins/abort
      unreachable
     end
-    local.get $7
-    local.get $4
+    local.get $var$7
+    local.get $var$4
     i32.sub
-    local.set $6
+    local.set $var$6
    else
     i32.const 32
     i32.const 608
@@ -69568,14 +69568,14 @@
     unreachable
    end
   else
-   local.get $3
+   local.get $var$3
    i32.const 3
    i32.shl
-   local.set $6
-   local.get $4
-   local.get $6
+   local.set $var$6
+   local.get $var$4
+   local.get $var$6
    i32.add
-   local.get $7
+   local.get $var$7
    i32.gt_s
    if
     i32.const 32
@@ -69590,24 +69590,24 @@
   i32.const 12
   i32.const 13
   call $~lib/rt/itcms/__new
-  local.tee $8
+  local.tee $var$8
   i32.store $0
-  local.get $8
-  local.get $5
+  local.get $var$8
+  local.get $var$5
   i32.store $0
-  local.get $8
-  local.get $5
+  local.get $var$8
+  local.get $var$5
   i32.const 0
   call $~lib/rt/itcms/__link
-  local.get $8
-  local.get $6
+  local.get $var$8
+  local.get $var$6
   i32.store $0 offset=8
-  local.get $8
-  local.get $5
-  local.get $4
+  local.get $var$8
+  local.get $var$5
+  local.get $var$4
   i32.add
   i32.store $0 offset=4
-  local.get $8
+  local.get $var$8
   local.set $9
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -69615,7 +69615,7 @@
   global.set $~lib/memory/__stack_pointer
   local.get $9
  )
- (func $~lib/typedarray/Int8Array#sort@varargs (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/typedarray/Int8Array#sort@varargs (param $this i32) (param $comparator i32) (result i32)
   (local $2 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -69644,11 +69644,11 @@
     i32.const 14320
     br $~lib/util/sort/COMPARATOR<i8>|inlined.0
    end
-   local.tee $1
+   local.tee $comparator
    i32.store $0
   end
-  local.get $0
-  local.get $1
+  local.get $this
+  local.get $comparator
   call $~lib/typedarray/Int8Array#sort
   local.set $2
   global.get $~lib/memory/__stack_pointer
@@ -69657,7 +69657,7 @@
   global.set $~lib/memory/__stack_pointer
   local.get $2
  )
- (func $~lib/typedarray/Uint8Array#sort@varargs (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/typedarray/Uint8Array#sort@varargs (param $this i32) (param $comparator i32) (result i32)
   (local $2 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -69684,11 +69684,11 @@
     i32.const 14384
     br $~lib/util/sort/COMPARATOR<u8>|inlined.0
    end
-   local.tee $1
+   local.tee $comparator
    i32.store $0
   end
-  local.get $0
-  local.get $1
+  local.get $this
+  local.get $comparator
   call $~lib/typedarray/Uint8Array#sort
   local.set $2
   global.get $~lib/memory/__stack_pointer
@@ -69697,7 +69697,7 @@
   global.set $~lib/memory/__stack_pointer
   local.get $2
  )
- (func $~lib/typedarray/Uint8ClampedArray#sort@varargs (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/typedarray/Uint8ClampedArray#sort@varargs (param $this i32) (param $comparator i32) (result i32)
   (local $2 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -69724,11 +69724,11 @@
     i32.const 14448
     br $~lib/util/sort/COMPARATOR<u8>|inlined.1
    end
-   local.tee $1
+   local.tee $comparator
    i32.store $0
   end
-  local.get $0
-  local.get $1
+  local.get $this
+  local.get $comparator
   call $~lib/typedarray/Uint8ClampedArray#sort
   local.set $2
   global.get $~lib/memory/__stack_pointer
@@ -69737,7 +69737,7 @@
   global.set $~lib/memory/__stack_pointer
   local.get $2
  )
- (func $~lib/typedarray/Int16Array#sort@varargs (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/typedarray/Int16Array#sort@varargs (param $this i32) (param $comparator i32) (result i32)
   (local $2 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -69766,11 +69766,11 @@
     i32.const 14512
     br $~lib/util/sort/COMPARATOR<i16>|inlined.0
    end
-   local.tee $1
+   local.tee $comparator
    i32.store $0
   end
-  local.get $0
-  local.get $1
+  local.get $this
+  local.get $comparator
   call $~lib/typedarray/Int16Array#sort
   local.set $2
   global.get $~lib/memory/__stack_pointer
@@ -69779,7 +69779,7 @@
   global.set $~lib/memory/__stack_pointer
   local.get $2
  )
- (func $~lib/typedarray/Uint16Array#sort@varargs (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/typedarray/Uint16Array#sort@varargs (param $this i32) (param $comparator i32) (result i32)
   (local $2 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -69806,11 +69806,11 @@
     i32.const 14576
     br $~lib/util/sort/COMPARATOR<u16>|inlined.0
    end
-   local.tee $1
+   local.tee $comparator
    i32.store $0
   end
-  local.get $0
-  local.get $1
+  local.get $this
+  local.get $comparator
   call $~lib/typedarray/Uint16Array#sort
   local.set $2
   global.get $~lib/memory/__stack_pointer
@@ -69819,7 +69819,7 @@
   global.set $~lib/memory/__stack_pointer
   local.get $2
  )
- (func $~lib/typedarray/Int32Array#sort@varargs (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/typedarray/Int32Array#sort@varargs (param $this i32) (param $comparator i32) (result i32)
   (local $2 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -69848,11 +69848,11 @@
     i32.const 14640
     br $~lib/util/sort/COMPARATOR<i32>|inlined.0
    end
-   local.tee $1
+   local.tee $comparator
    i32.store $0
   end
-  local.get $0
-  local.get $1
+  local.get $this
+  local.get $comparator
   call $~lib/typedarray/Int32Array#sort
   local.set $2
   global.get $~lib/memory/__stack_pointer
@@ -69861,7 +69861,7 @@
   global.set $~lib/memory/__stack_pointer
   local.get $2
  )
- (func $~lib/typedarray/Uint32Array#sort@varargs (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/typedarray/Uint32Array#sort@varargs (param $this i32) (param $comparator i32) (result i32)
   (local $2 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -69888,11 +69888,11 @@
     i32.const 14704
     br $~lib/util/sort/COMPARATOR<u32>|inlined.0
    end
-   local.tee $1
+   local.tee $comparator
    i32.store $0
   end
-  local.get $0
-  local.get $1
+  local.get $this
+  local.get $comparator
   call $~lib/typedarray/Uint32Array#sort
   local.set $2
   global.get $~lib/memory/__stack_pointer
@@ -69901,7 +69901,7 @@
   global.set $~lib/memory/__stack_pointer
   local.get $2
  )
- (func $~lib/typedarray/Int64Array#sort@varargs (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/typedarray/Int64Array#sort@varargs (param $this i32) (param $comparator i32) (result i32)
   (local $2 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -69930,11 +69930,11 @@
     i32.const 14768
     br $~lib/util/sort/COMPARATOR<i64>|inlined.0
    end
-   local.tee $1
+   local.tee $comparator
    i32.store $0
   end
-  local.get $0
-  local.get $1
+  local.get $this
+  local.get $comparator
   call $~lib/typedarray/Int64Array#sort
   local.set $2
   global.get $~lib/memory/__stack_pointer
@@ -69943,7 +69943,7 @@
   global.set $~lib/memory/__stack_pointer
   local.get $2
  )
- (func $~lib/typedarray/Uint64Array#sort@varargs (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/typedarray/Uint64Array#sort@varargs (param $this i32) (param $comparator i32) (result i32)
   (local $2 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -69970,11 +69970,11 @@
     i32.const 14832
     br $~lib/util/sort/COMPARATOR<u64>|inlined.0
    end
-   local.tee $1
+   local.tee $comparator
    i32.store $0
   end
-  local.get $0
-  local.get $1
+  local.get $this
+  local.get $comparator
   call $~lib/typedarray/Uint64Array#sort
   local.set $2
   global.get $~lib/memory/__stack_pointer
@@ -69983,7 +69983,7 @@
   global.set $~lib/memory/__stack_pointer
   local.get $2
  )
- (func $~lib/typedarray/Float32Array#sort@varargs (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/typedarray/Float32Array#sort@varargs (param $this i32) (param $comparator i32) (result i32)
   (local $2 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -70014,11 +70014,11 @@
     i32.const 14896
     br $~lib/util/sort/COMPARATOR<f32>|inlined.0
    end
-   local.tee $1
+   local.tee $comparator
    i32.store $0
   end
-  local.get $0
-  local.get $1
+  local.get $this
+  local.get $comparator
   call $~lib/typedarray/Float32Array#sort
   local.set $2
   global.get $~lib/memory/__stack_pointer

--- a/tests/compiler/super-inline.debug.wat
+++ b/tests/compiler/super-inline.debug.wat
@@ -2278,7 +2278,7 @@
   i32.add
   global.set $~lib/memory/__stack_pointer
  )
- (func $super-inline/Foo#constructor (param $0 i32) (result i32)
+ (func $super-inline/Foo#constructor (param $this i32) (result i32)
   (local $1 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -2288,17 +2288,17 @@
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   i32.store $0
-  local.get $0
+  local.get $this
   i32.eqz
   if
    global.get $~lib/memory/__stack_pointer
    i32.const 0
    i32.const 3
    call $~lib/rt/itcms/__new
-   local.tee $0
+   local.tee $this
    i32.store $0
   end
-  local.get $0
+  local.get $this
   local.set $1
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -2306,7 +2306,7 @@
   global.set $~lib/memory/__stack_pointer
   local.get $1
  )
- (func $super-inline/Bar#constructor (param $0 i32) (result i32)
+ (func $super-inline/Bar#constructor (param $this i32) (result i32)
   (local $1 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -2316,22 +2316,22 @@
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   i32.store $0
-  local.get $0
+  local.get $this
   i32.eqz
   if
    global.get $~lib/memory/__stack_pointer
    i32.const 0
    i32.const 4
    call $~lib/rt/itcms/__new
-   local.tee $0
+   local.tee $this
    i32.store $0
   end
   global.get $~lib/memory/__stack_pointer
-  local.get $0
+  local.get $this
   call $super-inline/Foo#constructor
-  local.tee $0
+  local.tee $this
   i32.store $0
-  local.get $0
+  local.get $this
   local.set $1
   global.get $~lib/memory/__stack_pointer
   i32.const 4

--- a/tests/compiler/templateliteral.debug.wat
+++ b/tests/compiler/templateliteral.debug.wat
@@ -4319,10 +4319,10 @@
   end
  )
  (func $templateliteral/test_string
-  (local $0 i32)
-  (local $1 i32)
-  (local $2 i32)
-  (local $3 i32)
+  (local $a i32)
+  (local $b i32)
+  (local $var$2 i32)
+  (local $var$3 i32)
   (local $4 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 24
@@ -4335,13 +4335,13 @@
   memory.fill $0
   global.get $~lib/memory/__stack_pointer
   i32.const 32
-  local.tee $0
+  local.tee $a
   i32.store $0
   global.get $~lib/memory/__stack_pointer
   i32.const 64
-  local.tee $1
+  local.tee $b
   i32.store $0 offset=4
-  local.get $0
+  local.get $a
   i32.const 32
   local.set $4
   global.get $~lib/memory/__stack_pointer
@@ -4358,8 +4358,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $0
-  local.get $1
+  local.get $a
+  local.get $b
   call $~lib/string/String#concat
   local.set $4
   global.get $~lib/memory/__stack_pointer
@@ -4382,10 +4382,10 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $0
-  local.set $2
-  local.get $1
-  local.set $3
+  local.get $a
+  local.set $var$2
+  local.get $b
+  local.set $var$3
   i32.const 720
   local.set $4
   global.get $~lib/memory/__stack_pointer
@@ -4393,7 +4393,7 @@
   i32.store $0 offset=16
   local.get $4
   i32.const 1
-  local.get $2
+  local.get $var$2
   call $~lib/staticarray/StaticArray<~lib/string/String>#__uset
   i32.const 720
   local.set $4
@@ -4402,7 +4402,7 @@
   i32.store $0 offset=16
   local.get $4
   i32.const 3
-  local.get $3
+  local.get $var$3
   call $~lib/staticarray/StaticArray<~lib/string/String>#__uset
   i32.const 720
   local.set $4
@@ -4444,10 +4444,10 @@
   global.set $~lib/memory/__stack_pointer
  )
  (func $templateliteral/test_integer
-  (local $0 i32)
-  (local $1 i32)
-  (local $2 i32)
-  (local $3 i32)
+  (local $a i32)
+  (local $b i32)
+  (local $var$2 i32)
+  (local $var$3 i32)
   (local $4 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 24
@@ -4459,10 +4459,10 @@
   i32.const 24
   memory.fill $0
   i32.const 1
-  local.set $0
+  local.set $a
   i32.const 2
-  local.set $1
-  local.get $0
+  local.set $b
+  local.get $a
   i32.const 10
   call $~lib/number/I32#toString
   local.set $4
@@ -4486,7 +4486,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $0
+  local.get $a
   i32.const 10
   call $~lib/number/I32#toString
   local.set $4
@@ -4494,7 +4494,7 @@
   local.get $4
   i32.store $0 offset=8
   local.get $4
-  local.get $1
+  local.get $b
   i32.const 10
   call $~lib/number/I32#toString
   local.set $4
@@ -4525,16 +4525,16 @@
    unreachable
   end
   global.get $~lib/memory/__stack_pointer
-  local.get $0
+  local.get $a
   i32.const 10
   call $~lib/number/I32#toString
-  local.tee $2
+  local.tee $var$2
   i32.store $0 offset=16
   global.get $~lib/memory/__stack_pointer
-  local.get $1
+  local.get $b
   i32.const 10
   call $~lib/number/I32#toString
-  local.tee $3
+  local.tee $var$3
   i32.store $0 offset=20
   i32.const 2656
   local.set $4
@@ -4543,7 +4543,7 @@
   i32.store $0 offset=8
   local.get $4
   i32.const 1
-  local.get $2
+  local.get $var$2
   call $~lib/staticarray/StaticArray<~lib/string/String>#__uset
   i32.const 2656
   local.set $4
@@ -4552,7 +4552,7 @@
   i32.store $0 offset=8
   local.get $4
   i32.const 3
-  local.get $3
+  local.get $var$3
   call $~lib/staticarray/StaticArray<~lib/string/String>#__uset
   i32.const 2656
   local.set $4
@@ -4594,10 +4594,10 @@
   global.set $~lib/memory/__stack_pointer
  )
  (func $templateliteral/test_float
-  (local $0 f64)
-  (local $1 f64)
-  (local $2 i32)
-  (local $3 i32)
+  (local $a f64)
+  (local $b f64)
+  (local $var$2 i32)
+  (local $var$3 i32)
   (local $4 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 24
@@ -4609,10 +4609,10 @@
   i32.const 24
   memory.fill $0
   f64.const 1
-  local.set $0
+  local.set $a
   f64.const 2
-  local.set $1
-  local.get $0
+  local.set $b
+  local.get $a
   i32.const 0
   call $~lib/number/F64#toString
   local.set $4
@@ -4636,7 +4636,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $0
+  local.get $a
   i32.const 0
   call $~lib/number/F64#toString
   local.set $4
@@ -4644,7 +4644,7 @@
   local.get $4
   i32.store $0 offset=8
   local.get $4
-  local.get $1
+  local.get $b
   i32.const 0
   call $~lib/number/F64#toString
   local.set $4
@@ -4675,16 +4675,16 @@
    unreachable
   end
   global.get $~lib/memory/__stack_pointer
-  local.get $0
+  local.get $a
   i32.const 0
   call $~lib/number/F64#toString
-  local.tee $2
+  local.tee $var$2
   i32.store $0 offset=16
   global.get $~lib/memory/__stack_pointer
-  local.get $1
+  local.get $b
   i32.const 0
   call $~lib/number/F64#toString
-  local.tee $3
+  local.tee $var$3
   i32.store $0 offset=20
   i32.const 3952
   local.set $4
@@ -4693,7 +4693,7 @@
   i32.store $0 offset=8
   local.get $4
   i32.const 1
-  local.get $2
+  local.get $var$2
   call $~lib/staticarray/StaticArray<~lib/string/String>#__uset
   i32.const 3952
   local.set $4
@@ -4702,7 +4702,7 @@
   i32.store $0 offset=8
   local.get $4
   i32.const 3
-  local.get $3
+  local.get $var$3
   call $~lib/staticarray/StaticArray<~lib/string/String>#__uset
   i32.const 3952
   local.set $4
@@ -4744,8 +4744,8 @@
   global.set $~lib/memory/__stack_pointer
  )
  (func $templateliteral/test_fast_paths_string
-  (local $0 i32)
-  (local $1 i32)
+  (local $a i32)
+  (local $b i32)
   (local $2 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 20
@@ -4757,12 +4757,12 @@
   i32.const 20
   memory.fill $0
   i32.const 2
-  local.set $0
+  local.set $a
   global.get $~lib/memory/__stack_pointer
   i32.const 64
-  local.tee $1
+  local.tee $b
   i32.store $0
-  local.get $0
+  local.get $a
   i32.const 10
   call $~lib/number/I32#toString
   local.set $2
@@ -4786,7 +4786,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $1
+  local.get $b
   i32.const 64
   local.set $2
   global.get $~lib/memory/__stack_pointer
@@ -4809,7 +4809,7 @@
   local.get $2
   i32.store $0 offset=12
   local.get $2
-  local.get $0
+  local.get $a
   i32.const 10
   call $~lib/number/I32#toString
   local.set $2
@@ -4845,7 +4845,7 @@
   local.get $2
   i32.store $0 offset=12
   local.get $2
-  local.get $1
+  local.get $b
   call $~lib/string/String#concat
   local.set $2
   global.get $~lib/memory/__stack_pointer
@@ -4868,7 +4868,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $0
+  local.get $a
   i32.const 10
   call $~lib/number/I32#toString
   local.set $2
@@ -4904,7 +4904,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $1
+  local.get $b
   i32.const 4176
   local.set $2
   global.get $~lib/memory/__stack_pointer
@@ -4933,7 +4933,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $0
+  local.get $a
   i32.const 10
   call $~lib/number/I32#toString
   local.set $2
@@ -4941,7 +4941,7 @@
   local.get $2
   i32.store $0 offset=12
   local.get $2
-  local.get $1
+  local.get $b
   call $~lib/string/String#concat
   local.set $2
   global.get $~lib/memory/__stack_pointer
@@ -4969,7 +4969,7 @@
   i32.add
   global.set $~lib/memory/__stack_pointer
  )
- (func $templateliteral/Ref#toString (param $0 i32) (result i32)
+ (func $templateliteral/Ref#toString (param $this i32) (result i32)
   (local $1 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 8
@@ -4985,7 +4985,7 @@
   local.get $1
   i32.store $0
   local.get $1
-  local.get $0
+  local.get $this
   i32.load $0
   i32.const 10
   call $~lib/number/I32#toString
@@ -5003,10 +5003,10 @@
   local.get $1
  )
  (func $templateliteral/test_ref
-  (local $0 i32)
-  (local $1 i32)
-  (local $2 i32)
-  (local $3 i32)
+  (local $a i32)
+  (local $b i32)
+  (local $var$2 i32)
+  (local $var$3 i32)
   (local $4 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 32
@@ -5021,15 +5021,15 @@
   i32.const 0
   i32.const 1
   call $templateliteral/Ref#constructor
-  local.tee $0
+  local.tee $a
   i32.store $0
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   i32.const 2
   call $templateliteral/Ref#constructor
-  local.tee $1
+  local.tee $b
   i32.store $0 offset=4
-  local.get $0
+  local.get $a
   call $templateliteral/Ref#toString
   local.set $4
   global.get $~lib/memory/__stack_pointer
@@ -5052,14 +5052,14 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $0
+  local.get $a
   call $templateliteral/Ref#toString
   local.set $4
   global.get $~lib/memory/__stack_pointer
   local.get $4
   i32.store $0 offset=16
   local.get $4
-  local.get $1
+  local.get $b
   call $templateliteral/Ref#toString
   local.set $4
   global.get $~lib/memory/__stack_pointer
@@ -5089,14 +5089,14 @@
    unreachable
   end
   global.get $~lib/memory/__stack_pointer
-  local.get $0
+  local.get $a
   call $templateliteral/Ref#toString
-  local.tee $2
+  local.tee $var$2
   i32.store $0 offset=24
   global.get $~lib/memory/__stack_pointer
-  local.get $1
+  local.get $b
   call $templateliteral/Ref#toString
-  local.tee $3
+  local.tee $var$3
   i32.store $0 offset=28
   i32.const 4416
   local.set $4
@@ -5105,7 +5105,7 @@
   i32.store $0 offset=16
   local.get $4
   i32.const 1
-  local.get $2
+  local.get $var$2
   call $~lib/staticarray/StaticArray<~lib/string/String>#__uset
   i32.const 4416
   local.set $4
@@ -5114,7 +5114,7 @@
   i32.store $0 offset=16
   local.get $4
   i32.const 3
-  local.get $3
+  local.get $var$3
   call $~lib/staticarray/StaticArray<~lib/string/String>#__uset
   i32.const 4416
   local.set $4
@@ -5155,10 +5155,10 @@
   i32.add
   global.set $~lib/memory/__stack_pointer
  )
- (func $templateliteral/RecursiveObject#toString (param $0 i32) (result i32)
-  (local $1 i32)
-  (local $2 i32)
-  (local $3 i32)
+ (func $templateliteral/RecursiveObject#toString (param $this i32) (result i32)
+  (local $var$1 i32)
+  (local $var$2 i32)
+  (local $var$3 i32)
   (local $4 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 20
@@ -5170,14 +5170,14 @@
   i32.const 20
   memory.fill $0
   global.get $~lib/memory/__stack_pointer
-  local.get $0
+  local.get $this
   i32.load $0 offset=4
-  local.tee $1
+  local.tee $var$1
   i32.store $0
-  local.get $1
+  local.get $var$1
   i32.eqz
   if
-   local.get $0
+   local.get $this
    i32.load $0
    local.set $4
    global.get $~lib/memory/__stack_pointer
@@ -5188,14 +5188,14 @@
    return
   end
   global.get $~lib/memory/__stack_pointer
-  local.get $0
+  local.get $this
   i32.load $0
-  local.tee $2
+  local.tee $var$2
   i32.store $0 offset=4
   global.get $~lib/memory/__stack_pointer
-  local.get $1
+  local.get $var$1
   call $templateliteral/RecursiveObject#toString
-  local.tee $3
+  local.tee $var$3
   i32.store $0 offset=8
   i32.const 4592
   local.set $4
@@ -5204,7 +5204,7 @@
   i32.store $0 offset=12
   local.get $4
   i32.const 0
-  local.get $2
+  local.get $var$2
   call $~lib/staticarray/StaticArray<~lib/string/String>#__uset
   i32.const 4592
   local.set $4
@@ -5213,7 +5213,7 @@
   i32.store $0 offset=12
   local.get $4
   i32.const 2
-  local.get $3
+  local.get $var$3
   call $~lib/staticarray/StaticArray<~lib/string/String>#__uset
   i32.const 4592
   local.set $4
@@ -5236,9 +5236,9 @@
   local.get $4
  )
  (func $templateliteral/test_recursive
-  (local $0 i32)
-  (local $1 i32)
-  (local $2 i32)
+  (local $c i32)
+  (local $b i32)
+  (local $a i32)
   (local $3 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 20
@@ -5259,7 +5259,7 @@
   local.get $3
   i32.const 0
   call $templateliteral/RecursiveObject#constructor
-  local.tee $0
+  local.tee $c
   i32.store $0 offset=4
   global.get $~lib/memory/__stack_pointer
   i32.const 0
@@ -5269,9 +5269,9 @@
   local.get $3
   i32.store $0
   local.get $3
-  local.get $0
+  local.get $c
   call $templateliteral/RecursiveObject#constructor
-  local.tee $1
+  local.tee $b
   i32.store $0 offset=8
   global.get $~lib/memory/__stack_pointer
   i32.const 0
@@ -5281,11 +5281,11 @@
   local.get $3
   i32.store $0
   local.get $3
-  local.get $1
+  local.get $b
   call $templateliteral/RecursiveObject#constructor
-  local.tee $2
+  local.tee $a
   i32.store $0 offset=12
-  local.get $2
+  local.get $a
   call $templateliteral/RecursiveObject#toString
   local.set $3
   global.get $~lib/memory/__stack_pointer
@@ -5313,11 +5313,11 @@
   i32.add
   global.set $~lib/memory/__stack_pointer
  )
- (func $~lib/string/String#concat (param $0 i32) (param $1 i32) (result i32)
-  (local $2 i32)
-  (local $3 i32)
-  (local $4 i32)
-  (local $5 i32)
+ (func $~lib/string/String#concat (param $this i32) (param $other i32) (result i32)
+  (local $thisSize i32)
+  (local $otherSize i32)
+  (local $outSize i32)
+  (local $out i32)
   (local $6 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -5327,21 +5327,21 @@
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   i32.store $0
-  local.get $0
+  local.get $this
   call $~lib/string/String#get:length
   i32.const 1
   i32.shl
-  local.set $2
-  local.get $1
+  local.set $thisSize
+  local.get $other
   call $~lib/string/String#get:length
   i32.const 1
   i32.shl
-  local.set $3
-  local.get $2
-  local.get $3
+  local.set $otherSize
+  local.get $thisSize
+  local.get $otherSize
   i32.add
-  local.set $4
-  local.get $4
+  local.set $outSize
+  local.get $outSize
   i32.const 0
   i32.eq
   if
@@ -5355,22 +5355,22 @@
    return
   end
   global.get $~lib/memory/__stack_pointer
-  local.get $4
+  local.get $outSize
   i32.const 1
   call $~lib/rt/itcms/__new
-  local.tee $5
+  local.tee $out
   i32.store $0
-  local.get $5
-  local.get $0
-  local.get $2
+  local.get $out
+  local.get $this
+  local.get $thisSize
   memory.copy $0 $0
-  local.get $5
-  local.get $2
+  local.get $out
+  local.get $thisSize
   i32.add
-  local.get $1
-  local.get $3
+  local.get $other
+  local.get $otherSize
   memory.copy $0 $0
-  local.get $5
+  local.get $out
   local.set $6
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -5378,16 +5378,16 @@
   global.set $~lib/memory/__stack_pointer
   local.get $6
  )
- (func $~lib/util/string/joinStringArray (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
-  (local $3 i32)
-  (local $4 i32)
-  (local $5 i32)
-  (local $6 i32)
-  (local $7 i32)
-  (local $8 i32)
-  (local $9 i32)
-  (local $10 i32)
-  (local $11 i32)
+ (func $~lib/util/string/joinStringArray (param $dataStart i32) (param $length i32) (param $separator i32) (result i32)
+  (local $lastIndex i32)
+  (local $var$4 i32)
+  (local $estLen i32)
+  (local $value i32)
+  (local $var$7 i32)
+  (local $offset i32)
+  (local $sepLen i32)
+  (local $result i32)
+  (local $var$11 i32)
   (local $12 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 12
@@ -5400,11 +5400,11 @@
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   i32.store $0 offset=8
-  local.get $1
+  local.get $length
   i32.const 1
   i32.sub
-  local.set $3
-  local.get $3
+  local.set $lastIndex
+  local.get $lastIndex
   i32.const 0
   i32.lt_s
   if
@@ -5417,17 +5417,17 @@
    local.get $12
    return
   end
-  local.get $3
+  local.get $lastIndex
   i32.eqz
   if
    global.get $~lib/memory/__stack_pointer
-   local.get $0
+   local.get $dataStart
    i32.load $0
-   local.tee $4
+   local.tee $var$4
    i32.store $0
-   local.get $4
+   local.get $var$4
    if (result i32)
-    local.get $4
+    local.get $var$4
    else
     i32.const 160
    end
@@ -5440,149 +5440,149 @@
    return
   end
   i32.const 0
-  local.set $5
+  local.set $estLen
   i32.const 0
-  local.set $4
+  local.set $var$4
   loop $for-loop|0
-   local.get $4
-   local.get $1
+   local.get $var$4
+   local.get $length
    i32.lt_s
-   local.set $7
-   local.get $7
+   local.set $var$7
+   local.get $var$7
    if
     global.get $~lib/memory/__stack_pointer
-    local.get $0
-    local.get $4
+    local.get $dataStart
+    local.get $var$4
     i32.const 2
     i32.shl
     i32.add
     i32.load $0
-    local.tee $6
+    local.tee $value
     i32.store $0 offset=4
-    local.get $6
+    local.get $value
     i32.const 0
     i32.ne
     if
-     local.get $5
-     local.get $6
+     local.get $estLen
+     local.get $value
      call $~lib/string/String#get:length
      i32.add
-     local.set $5
+     local.set $estLen
     end
-    local.get $4
+    local.get $var$4
     i32.const 1
     i32.add
-    local.set $4
+    local.set $var$4
     br $for-loop|0
    end
   end
   i32.const 0
-  local.set $8
-  local.get $2
+  local.set $offset
+  local.get $separator
   call $~lib/string/String#get:length
-  local.set $9
+  local.set $sepLen
   global.get $~lib/memory/__stack_pointer
-  local.get $5
-  local.get $9
-  local.get $3
+  local.get $estLen
+  local.get $sepLen
+  local.get $lastIndex
   i32.mul
   i32.add
   i32.const 1
   i32.shl
   i32.const 1
   call $~lib/rt/itcms/__new
-  local.tee $10
+  local.tee $result
   i32.store $0 offset=8
   i32.const 0
-  local.set $4
+  local.set $var$4
   loop $for-loop|1
-   local.get $4
-   local.get $3
+   local.get $var$4
+   local.get $lastIndex
    i32.lt_s
-   local.set $7
-   local.get $7
+   local.set $var$7
+   local.get $var$7
    if
     global.get $~lib/memory/__stack_pointer
-    local.get $0
-    local.get $4
+    local.get $dataStart
+    local.get $var$4
     i32.const 2
     i32.shl
     i32.add
     i32.load $0
-    local.tee $6
+    local.tee $value
     i32.store $0 offset=4
-    local.get $6
+    local.get $value
     i32.const 0
     i32.ne
     if
-     local.get $6
+     local.get $value
      call $~lib/string/String#get:length
-     local.set $11
-     local.get $10
-     local.get $8
+     local.set $var$11
+     local.get $result
+     local.get $offset
      i32.const 1
      i32.shl
      i32.add
-     local.get $6
-     local.get $11
+     local.get $value
+     local.get $var$11
      i32.const 1
      i32.shl
      memory.copy $0 $0
-     local.get $8
-     local.get $11
+     local.get $offset
+     local.get $var$11
      i32.add
-     local.set $8
+     local.set $offset
     end
-    local.get $9
+    local.get $sepLen
     if
-     local.get $10
-     local.get $8
+     local.get $result
+     local.get $offset
      i32.const 1
      i32.shl
      i32.add
-     local.get $2
-     local.get $9
+     local.get $separator
+     local.get $sepLen
      i32.const 1
      i32.shl
      memory.copy $0 $0
-     local.get $8
-     local.get $9
+     local.get $offset
+     local.get $sepLen
      i32.add
-     local.set $8
+     local.set $offset
     end
-    local.get $4
+    local.get $var$4
     i32.const 1
     i32.add
-    local.set $4
+    local.set $var$4
     br $for-loop|1
    end
   end
   global.get $~lib/memory/__stack_pointer
-  local.get $0
-  local.get $3
+  local.get $dataStart
+  local.get $lastIndex
   i32.const 2
   i32.shl
   i32.add
   i32.load $0
-  local.tee $6
+  local.tee $value
   i32.store $0 offset=4
-  local.get $6
+  local.get $value
   i32.const 0
   i32.ne
   if
-   local.get $10
-   local.get $8
+   local.get $result
+   local.get $offset
    i32.const 1
    i32.shl
    i32.add
-   local.get $6
-   local.get $6
+   local.get $value
+   local.get $value
    call $~lib/string/String#get:length
    i32.const 1
    i32.shl
    memory.copy $0 $0
   end
-  local.get $10
+  local.get $result
   local.set $12
   global.get $~lib/memory/__stack_pointer
   i32.const 12
@@ -5590,13 +5590,13 @@
   global.set $~lib/memory/__stack_pointer
   local.get $12
  )
- (func $~lib/util/number/itoa32 (param $0 i32) (param $1 i32) (result i32)
-  (local $2 i32)
-  (local $3 i32)
-  (local $4 i32)
-  (local $5 i32)
-  (local $6 i32)
-  (local $7 i32)
+ (func $~lib/util/number/itoa32 (param $value i32) (param $radix i32) (result i32)
+  (local $sign i32)
+  (local $out i32)
+  (local $var$4 i32)
+  (local $var$5 i32)
+  (local $var$6 i32)
+  (local $var$7 i32)
   (local $8 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -5606,13 +5606,13 @@
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   i32.store $0
-  local.get $1
+  local.get $radix
   i32.const 2
   i32.lt_s
   if (result i32)
    i32.const 1
   else
-   local.get $1
+   local.get $radix
    i32.const 36
    i32.gt_s
   end
@@ -5624,7 +5624,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $0
+  local.get $value
   i32.eqz
   if
    i32.const 1008
@@ -5636,128 +5636,128 @@
    local.get $8
    return
   end
-  local.get $0
+  local.get $value
   i32.const 31
   i32.shr_u
   i32.const 1
   i32.shl
-  local.set $2
-  local.get $2
+  local.set $sign
+  local.get $sign
   if
    i32.const 0
-   local.get $0
+   local.get $value
    i32.sub
-   local.set $0
+   local.set $value
   end
-  local.get $1
+  local.get $radix
   i32.const 10
   i32.eq
   if
-   local.get $0
+   local.get $value
    call $~lib/util/number/decimalCount32
-   local.set $4
+   local.set $var$4
    global.get $~lib/memory/__stack_pointer
-   local.get $4
+   local.get $var$4
    i32.const 1
    i32.shl
-   local.get $2
+   local.get $sign
    i32.add
    i32.const 1
    call $~lib/rt/itcms/__new
-   local.tee $3
+   local.tee $out
    i32.store $0
-   local.get $3
-   local.get $2
+   local.get $out
+   local.get $sign
    i32.add
-   local.set $7
-   local.get $0
-   local.set $6
-   local.get $4
-   local.set $5
+   local.set $var$7
+   local.get $value
+   local.set $var$6
+   local.get $var$4
+   local.set $var$5
    i32.const 0
    i32.const 1
    i32.ge_s
    drop
-   local.get $7
-   local.get $6
-   local.get $5
+   local.get $var$7
+   local.get $var$6
+   local.get $var$5
    call $~lib/util/number/utoa32_dec_lut
   else
-   local.get $1
+   local.get $radix
    i32.const 16
    i32.eq
    if
     i32.const 31
-    local.get $0
+    local.get $value
     i32.clz
     i32.sub
     i32.const 2
     i32.shr_s
     i32.const 1
     i32.add
-    local.set $4
+    local.set $var$4
     global.get $~lib/memory/__stack_pointer
-    local.get $4
+    local.get $var$4
     i32.const 1
     i32.shl
-    local.get $2
+    local.get $sign
     i32.add
     i32.const 1
     call $~lib/rt/itcms/__new
-    local.tee $3
+    local.tee $out
     i32.store $0
-    local.get $3
-    local.get $2
+    local.get $out
+    local.get $sign
     i32.add
-    local.set $7
-    local.get $0
-    local.set $6
-    local.get $4
-    local.set $5
+    local.set $var$7
+    local.get $value
+    local.set $var$6
+    local.get $var$4
+    local.set $var$5
     i32.const 0
     i32.const 1
     i32.ge_s
     drop
-    local.get $7
-    local.get $6
+    local.get $var$7
+    local.get $var$6
     i64.extend_i32_u
-    local.get $5
+    local.get $var$5
     call $~lib/util/number/utoa_hex_lut
    else
-    local.get $0
-    local.set $4
-    local.get $4
+    local.get $value
+    local.set $var$4
+    local.get $var$4
     i64.extend_i32_u
-    local.get $1
+    local.get $radix
     call $~lib/util/number/ulog_base
-    local.set $7
+    local.set $var$7
     global.get $~lib/memory/__stack_pointer
-    local.get $7
+    local.get $var$7
     i32.const 1
     i32.shl
-    local.get $2
+    local.get $sign
     i32.add
     i32.const 1
     call $~lib/rt/itcms/__new
-    local.tee $3
+    local.tee $out
     i32.store $0
-    local.get $3
-    local.get $2
+    local.get $out
+    local.get $sign
     i32.add
-    local.get $4
+    local.get $var$4
     i64.extend_i32_u
-    local.get $7
-    local.get $1
+    local.get $var$7
+    local.get $radix
     call $~lib/util/number/utoa64_any_core
    end
   end
-  local.get $2
+  local.get $sign
   if
-   local.get $3
+   local.get $out
    i32.const 45
    i32.store16 $0
   end
-  local.get $3
+  local.get $out
   local.set $8
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -5765,9 +5765,9 @@
   global.set $~lib/memory/__stack_pointer
   local.get $8
  )
- (func $~lib/util/number/dtoa (param $0 f64) (result i32)
-  (local $1 i32)
-  (local $2 i32)
+ (func $~lib/util/number/dtoa (param $value f64) (result i32)
+  (local $size i32)
+  (local $result i32)
   (local $3 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -5777,7 +5777,7 @@
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   i32.store $0
-  local.get $0
+  local.get $value
   f64.const 0
   f64.eq
   if
@@ -5790,15 +5790,15 @@
    local.get $3
    return
   end
-  local.get $0
-  local.get $0
+  local.get $value
+  local.get $value
   f64.sub
   f64.const 0
   f64.eq
   i32.eqz
   if
-   local.get $0
-   local.get $0
+   local.get $value
+   local.get $value
    f64.ne
    if
     i32.const 2784
@@ -5812,7 +5812,7 @@
    end
    i32.const 2816
    i32.const 2864
-   local.get $0
+   local.get $value
    f64.const 0
    f64.lt
    select
@@ -5825,22 +5825,22 @@
    return
   end
   i32.const 2896
-  local.get $0
+  local.get $value
   call $~lib/util/number/dtoa_core
   i32.const 1
   i32.shl
-  local.set $1
+  local.set $size
   global.get $~lib/memory/__stack_pointer
-  local.get $1
+  local.get $size
   i32.const 1
   call $~lib/rt/itcms/__new
-  local.tee $2
+  local.tee $result
   i32.store $0
-  local.get $2
+  local.get $result
   i32.const 2896
-  local.get $1
+  local.get $size
   memory.copy $0 $0
-  local.get $2
+  local.get $result
   local.set $3
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -5848,7 +5848,7 @@
   global.set $~lib/memory/__stack_pointer
   local.get $3
  )
- (func $templateliteral/Ref#constructor (param $0 i32) (param $1 i32) (result i32)
+ (func $templateliteral/Ref#constructor (param $this i32) (param $value i32) (result i32)
   (local $2 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -5858,20 +5858,20 @@
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   i32.store $0
-  local.get $0
+  local.get $this
   i32.eqz
   if
    global.get $~lib/memory/__stack_pointer
    i32.const 4
    i32.const 4
    call $~lib/rt/itcms/__new
-   local.tee $0
+   local.tee $this
    i32.store $0
   end
-  local.get $0
-  local.get $1
+  local.get $this
+  local.get $value
   call $templateliteral/Ref#set:value
-  local.get $0
+  local.get $this
   local.set $2
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -5879,7 +5879,7 @@
   global.set $~lib/memory/__stack_pointer
   local.get $2
  )
- (func $templateliteral/RecursiveObject#constructor (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $templateliteral/RecursiveObject#constructor (param $this i32) (param $key i32) (param $val i32) (result i32)
   (local $3 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -5889,23 +5889,23 @@
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   i32.store $0
-  local.get $0
+  local.get $this
   i32.eqz
   if
    global.get $~lib/memory/__stack_pointer
    i32.const 8
    i32.const 5
    call $~lib/rt/itcms/__new
-   local.tee $0
+   local.tee $this
    i32.store $0
   end
-  local.get $0
-  local.get $1
+  local.get $this
+  local.get $key
   call $templateliteral/RecursiveObject#set:key
-  local.get $0
-  local.get $2
+  local.get $this
+  local.get $val
   call $templateliteral/RecursiveObject#set:val
-  local.get $0
+  local.get $this
   local.set $3
   global.get $~lib/memory/__stack_pointer
   i32.const 4

--- a/tests/compiler/typeof.debug.wat
+++ b/tests/compiler/typeof.debug.wat
@@ -2985,7 +2985,7 @@
   i32.add
   global.set $~lib/memory/__stack_pointer
  )
- (func $typeof/SomeClass#constructor (param $0 i32) (result i32)
+ (func $typeof/SomeClass#constructor (param $this i32) (result i32)
   (local $1 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -2995,17 +2995,17 @@
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   i32.store $0
-  local.get $0
+  local.get $this
   i32.eqz
   if
    global.get $~lib/memory/__stack_pointer
    i32.const 0
    i32.const 4
    call $~lib/rt/itcms/__new
-   local.tee $0
+   local.tee $this
    i32.store $0
   end
-  local.get $0
+  local.get $this
   local.set $1
   global.get $~lib/memory/__stack_pointer
   i32.const 4

--- a/tests/compiler/while.debug.wat
+++ b/tests/compiler/while.debug.wat
@@ -3134,7 +3134,7 @@
    unreachable
   end
  )
- (func $while/Ref#constructor (param $0 i32) (result i32)
+ (func $while/Ref#constructor (param $this i32) (result i32)
   (local $1 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -3144,17 +3144,17 @@
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   i32.store $0
-  local.get $0
+  local.get $this
   i32.eqz
   if
    global.get $~lib/memory/__stack_pointer
    i32.const 0
    i32.const 3
    call $~lib/rt/itcms/__new
-   local.tee $0
+   local.tee $this
    i32.store $0
   end
-  local.get $0
+  local.get $this
   local.set $1
   global.get $~lib/memory/__stack_pointer
   i32.const 4


### PR DESCRIPTION
In shadowstack pass, if some function need to add temp local, It need to be removed and re-added. It will discard all debug info because debug info bind with functionref.

This PR aims at re-assign the debug info after shadowstack pass

- [x] I've read the contributing guidelines
- [x] I've added my name and email to the NOTICE file
