### PR TITLE
fix: incorrect filename of the test of tokenizer

### DIFF
--- a/tests/tokenizer.js
+++ b/tests/tokenizer.js
@@ -7,7 +7,7 @@ const dirname = path.dirname(fileURLToPath(import.meta.url));
 
 const file = process.argv.length > 2 ? process.argv[2] : path.join(dirname, "..", "src", "tokenizer.ts");
 const text = fs.readFileSync(file).toString();
-const source = new Source(SourceKind.ENTRY, "compiler.ts", text);
+const source = new Source(SourceKind.ENTRY, "tokenizer.ts", text);
 const tn = new Tokenizer(source);
 
 do {


### PR DESCRIPTION
very simple change that the tokenizer.js test file using incorrect file name.

- [x] I've read the contributing guidelines
- [x] I've added my name and email to the NOTICE file
