### PR TITLE
Push to the inline stack after compiling arguments

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -52,6 +52,7 @@ under the licensing terms detailed in LICENSE:
 * Ruixiang Chen <xiang19890319@gmail.com>
 * Daniel Salvadori <danaugrs@gmail.com>
 * Jairus Tanaka <jairus.v.tanaka@outlook.com>
+* CountBleck <Mr.YouKnowWhoIAm@protonmail.com>
 
 Portions of this software are derived from third-party works licensed under
 the following terms:

--- a/src/compiler.ts
+++ b/src/compiler.ts
@@ -6447,15 +6447,16 @@ export class Compiler extends DiagnosticEmitter {
           reportNode.range, instance.internalName
         );
       } else {
-        inlineStack.push(instance);
         let parameterTypes = signature.parameterTypes;
         assert(numArguments <= parameterTypes.length);
-        // compile argument expressions
+        // compile argument expressions *before* pushing to the inline stack
+        // otherwise, the arguments may not be inlined, e.g. `abc(abc(123))`
         let args = new Array<ExpressionRef>(numArguments);
         for (let i = 0; i < numArguments; ++i) {
           args[i] = this.compileExpression(argumentExpressions[i], parameterTypes[i], Constraints.CONV_IMPLICIT);
         }
         // make the inlined call
+        inlineStack.push(instance);
         let expr = this.makeCallInline(instance, args, thisArg, (constraints & Constraints.WILL_DROP) != 0);
         inlineStack.pop();
         return expr;

--- a/tests/compiler/inlining.debug.wat
+++ b/tests/compiler/inlining.debug.wat
@@ -153,6 +153,14 @@
   i32.const 1
   i32.eq
   drop
+  i32.const 1
+  local.set $var$2
+  local.get $var$2
+  local.set $var$2
+  local.get $var$2
+  i32.const 1
+  i32.eq
+  drop
   i32.const 2
   local.set $var$2
   local.get $var$2
@@ -203,7 +211,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 68
+   i32.const 69
    i32.const 3
    call $~lib/builtins/abort
    unreachable
@@ -235,7 +243,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 71
+   i32.const 72
    i32.const 3
    call $~lib/builtins/abort
    unreachable
@@ -2416,7 +2424,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 95
+   i32.const 96
    i32.const 3
    call $~lib/builtins/abort
    unreachable
@@ -2429,7 +2437,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 96
+   i32.const 97
    i32.const 3
    call $~lib/builtins/abort
    unreachable
@@ -2442,7 +2450,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 97
+   i32.const 98
    i32.const 3
    call $~lib/builtins/abort
    unreachable
@@ -2455,7 +2463,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 98
+   i32.const 99
    i32.const 3
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/inlining.release.wat
+++ b/tests/compiler/inlining.release.wat
@@ -1550,7 +1550,7 @@
    if
     i32.const 0
     i32.const 1056
-    i32.const 95
+    i32.const 96
     i32.const 3
     call $~lib/builtins/abort
     unreachable
@@ -1562,7 +1562,7 @@
    if
     i32.const 0
     i32.const 1056
-    i32.const 96
+    i32.const 97
     i32.const 3
     call $~lib/builtins/abort
     unreachable
@@ -1574,7 +1574,7 @@
    if
     i32.const 0
     i32.const 1056
-    i32.const 97
+    i32.const 98
     i32.const 3
     call $~lib/builtins/abort
     unreachable
@@ -1586,7 +1586,7 @@
    if
     i32.const 0
     i32.const 1056
-    i32.const 98
+    i32.const 99
     i32.const 3
     call $~lib/builtins/abort
     unreachable

--- a/tests/compiler/inlining.ts
+++ b/tests/compiler/inlining.ts
@@ -62,6 +62,7 @@ function test_funcs(): void {
   assert(func_ii(43) == 3);
   assert(func_ii_opt() == 0);
   assert(func_ii_opt(1) == 1);
+  assert(func_ii_opt(func_ii_opt(1)) == 1);
   assert(func_ii_loc(2) == 3);
   assert(func_ii_loc(3) == 4);
   func_iv(0);


### PR DESCRIPTION
This change allows calls like `a(a(a(1)))` to be @inlined properly.

<!--
 Thanks for submitting a pull request to AssemblyScript! Please take a moment to
 review the contributing guidelines linked below, and confirm with an [x] 🙂
-->

- [x] I've read the contributing guidelines
- [x] I've added my name and email to the NOTICE file
