### PR TITLE
use LinkedList solution for minimal runtime build

### DIFF
--- a/std/assembly/rt/index-minimal.ts
+++ b/std/assembly/rt/index-minimal.ts
@@ -1,2 +1,2 @@
-import "rt/tlsf";
+import "rt/lm";
 import "rt/tcms";

--- a/std/assembly/rt/lm.ts
+++ b/std/assembly/rt/lm.ts
@@ -1,0 +1,194 @@
+import { E_ALLOCATION_TOO_LARGE } from "../util/error";
+
+// This allocator is follow the algorithm from https://github.com/embeddedartistry/libmemory
+// FreeList is a linked list that manage all free blocks.
+
+// @ts-ignore: decorator
+@unmanaged class LinkedList {
+    prev: LinkedList;
+    next: LinkedList;
+}
+// @ts-ignore: decorator
+@inline export const BLOCK_MAXSIZE: usize = (1 << 30) - sizeof<LinkedList>();
+// @ts-ignore: decorator
+@inline const AL_BITS: u32 = 4; // 16 bytes to fit up to v128
+// @ts-ignore: decorator
+@inline const AL_SIZE: usize = 1 << <usize>AL_BITS;
+// @ts-ignore: decorator
+@inline const AL_MASK: usize = AL_SIZE - 1;
+// @ts-ignore: decorator
+@unmanaged class Block extends LinkedList {
+    size: usize;
+}
+// @ts-ignore: decorator
+@inline const BLOCK_SIZE: usize = offsetof<Block>();
+// @ts-ignore: decorator
+@inline const MIN_BLOCK_SIZE: usize = offsetof<usize>() + BLOCK_SIZE;
+const freeListPtr: usize = memory.data(sizeof<LinkedList>());
+// @ts-ignore: decorator
+@lazy var freelist: LinkedList;
+// @ts-ignore: decorator
+@inline function alignUp(num: usize): usize {
+    return ((num) + ((1 << alignof<usize>()) - 1)) & ~((1 << alignof<usize>()) - 1);
+}
+// @ts-ignore: decorator
+@inline function insertItem(newItem: LinkedList, preItem: LinkedList, nextItem: LinkedList): void {
+    nextItem.prev = newItem;
+    newItem.next = nextItem;
+    newItem.prev = preItem;
+    preItem.next = newItem;
+}
+
+// @ts-ignore: decorator
+@inline function dropItem(item: LinkedList): void {
+    let prev = item.prev;
+    let next = item.next;
+    if (prev && next) {
+        prev.next = next;
+        next.prev = prev;
+        item.prev = changetype<LinkedList>(0);
+        item.next = changetype<LinkedList>(0);
+    } else {
+        unreachable();
+    }
+}
+
+function growMemory(size: usize): void {
+    if (ASC_LOW_MEMORY_LIMIT) {
+        unreachable();
+    }
+    const pagesBefore = memory.size();
+    const pageBeforePtr = pagesBefore << 16;
+    const startPoint = (pageBeforePtr + <i32>BLOCK_SIZE);
+    const v128Alignment = <i32>(AL_SIZE - ((startPoint) & <i32>AL_MASK));
+    size += startPoint + v128Alignment;
+    const pagesNeeded = <i32>(((size + 0xffff) & ~0xffff) >>> 16);
+    const pagesWanted = pagesNeeded - pagesBefore; // double memory
+    if (memory.grow(pagesWanted) < 0) {
+        unreachable();
+    }
+    let block = changetype<Block>(pageBeforePtr + v128Alignment);
+    const pagesAfter = memory.size();
+    block.size = ((pagesAfter - pagesBefore) << 16) - <i32>BLOCK_SIZE - v128Alignment;
+    insertItem(changetype<LinkedList>(pageBeforePtr + v128Alignment), freelist.prev, freelist);
+}
+
+function initialize(): void {
+    freelist = changetype<LinkedList>(freeListPtr);
+    freelist.next = freelist;
+    freelist.prev = freelist;
+    const startPoint: usize = ((__heap_base + BLOCK_SIZE + AL_SIZE) & ~AL_MASK) - BLOCK_SIZE;
+    const pagesBefore = memory.size();
+    const pagesNeeded = <i32>((((startPoint + 1) + 0xffff) & ~0xffff) >>> 16);
+    if (pagesNeeded > pagesBefore && memory.grow(pagesNeeded - pagesBefore) < 0) unreachable();
+    let item: LinkedList = changetype<LinkedList>(startPoint);
+    insertItem(item, freelist, freelist);
+    let block: Block = changetype<Block>(startPoint);
+    block.size = (<usize>(memory.size() << 16)) - BLOCK_SIZE - startPoint;
+
+}
+
+// @ts-ignore: decorator
+@inline function searchBlockPtr(size: usize): usize {
+    let foundBlockPtr: usize = 0;
+    for (let item = changetype<LinkedList>(changetype<usize>(freelist.next));
+        changetype<usize>(item) != freeListPtr && item.next != null;
+        item = item.next) {
+        if (changetype<Block>(item).size > size) {
+            foundBlockPtr = changetype<usize>(item);
+        }
+    }
+    return foundBlockPtr;
+}
+
+function mergeBlock(prevPtr: usize, blockPtr: usize): bool {
+    let block = changetype<Block>(blockPtr);
+    if (prevPtr != freeListPtr && blockPtr != freeListPtr && prevPtr && blockPtr) {
+        let prevBlock = changetype<Block>(prevPtr);
+        const prevTailPtr = prevPtr + prevBlock.size + BLOCK_SIZE;
+        if (((blockPtr - prevTailPtr) < BLOCK_SIZE)) {
+            const tailPtr = changetype<usize>(block) + block.size + BLOCK_SIZE;
+            prevBlock.size += (tailPtr - prevTailPtr);
+            dropItem(changetype<LinkedList>(blockPtr));
+            return true;
+        }
+    }
+    return false;
+}
+
+// @ts-ignore: decorator
+@global @unsafe export function __alloc(size: usize): usize {
+    size = alignUp(size);
+    if (size > BLOCK_MAXSIZE) throw new Error(E_ALLOCATION_TOO_LARGE);
+    if (!freelist) initialize();
+    let foundBlockPtr: usize = searchBlockPtr(size);
+    if (!foundBlockPtr) { // found ptr
+        growMemory(size);
+        foundBlockPtr = searchBlockPtr(size)
+        if (!foundBlockPtr) {
+            unreachable(); // unreachable if cannot get block ptr after grow memory
+        }
+    }
+    let block = changetype<Block>(foundBlockPtr);
+    if (block.size - size > MIN_BLOCK_SIZE) { // divide linked list
+        let newBlockPtr = foundBlockPtr + size + BLOCK_SIZE;
+        const v128Alignment = AL_SIZE - ((newBlockPtr + BLOCK_SIZE) & AL_MASK); // align to 128 for new block
+        size += v128Alignment;
+        newBlockPtr += v128Alignment;
+        if (!((newBlockPtr + MIN_BLOCK_SIZE) > (foundBlockPtr + block.size))) { // aligned ptr out of the bound of block
+            let newBlock = changetype<Block>(newBlockPtr);
+            newBlock.size = block.size - size - BLOCK_SIZE;
+            block.size = size;
+            insertItem(changetype<LinkedList>(newBlock),
+                changetype<LinkedList>(block),
+                changetype<LinkedList>(changetype<usize>(block.next)));
+        }
+    }
+    dropItem(block);
+    return foundBlockPtr + BLOCK_SIZE;
+}
+
+// @ts-ignore: decorator
+@global @unsafe
+    export function __free(ptr: usize): void {
+    if (!ptr) unreachable(); // cannot be nullptr
+    const freeBlockPtr = ptr - BLOCK_SIZE;
+    let foundPos: bool = false;
+    for (let item = changetype<LinkedList>(changetype<usize>(freelist.next));
+        changetype<usize>(item) != freeListPtr && item.next != null;
+        item = item.next) {
+        if (changetype<usize>(item) > freeBlockPtr) {
+            insertItem(changetype<LinkedList>(freeBlockPtr), item.prev, item);
+            foundPos = true;
+            break;
+        }
+    }
+    if (!foundPos) { // add to tail
+        insertItem(changetype<LinkedList>(freeBlockPtr), freelist.prev, freelist);
+    }
+    let endPtr = freeListPtr;
+    for (let item = changetype<LinkedList>(changetype<usize>(freelist.next));
+        changetype<usize>(item) != freeListPtr && item.next != null;
+        item = item.next) {
+        const blockPtr = changetype<usize>(item);
+        const prevPtr = changetype<usize>(item.prev);
+        if (mergeBlock(prevPtr, blockPtr)) continue;
+        endPtr = blockPtr;
+    }
+    let endBlock = changetype<Block>(endPtr);
+    mergeBlock(endPtr, changetype<usize>(endBlock.next));
+}
+
+function moveBlock(block: Block, newSize: usize): usize {
+    const ptr = __alloc(newSize);
+    const prePtr = changetype<usize>(block) + BLOCK_SIZE;
+    memory.copy(ptr, prePtr, block.size);
+    if (prePtr > __heap_base) __free(prePtr);
+    return ptr;
+}
+
+// @ts-ignore: decorator
+@global @unsafe
+export function __realloc(ptr: usize, size: usize): usize {
+    return moveBlock(changetype<Block>(ptr - BLOCK_SIZE), size);
+}

--- a/std/assembly/rt/lm.ts
+++ b/std/assembly/rt/lm.ts
@@ -5,8 +5,8 @@ import { E_ALLOCATION_TOO_LARGE } from "../util/error";
 
 // @ts-ignore: decorator
 @unmanaged class LinkedList {
-    prev: LinkedList;
-    next: LinkedList;
+  prev: LinkedList;
+  next: LinkedList;
 }
 // @ts-ignore: decorator
 @inline export const BLOCK_MAXSIZE: usize = (1 << 30) - sizeof<LinkedList>();
@@ -18,7 +18,7 @@ import { E_ALLOCATION_TOO_LARGE } from "../util/error";
 @inline const AL_MASK: usize = AL_SIZE - 1;
 // @ts-ignore: decorator
 @unmanaged class Block extends LinkedList {
-    size: usize;
+  size: usize;
 }
 // @ts-ignore: decorator
 @inline const BLOCK_SIZE: usize = offsetof<Block>();
@@ -29,166 +29,166 @@ const freeListPtr: usize = memory.data(sizeof<LinkedList>());
 @lazy var freelist: LinkedList;
 // @ts-ignore: decorator
 @inline function alignUp(num: usize): usize {
-    return ((num) + ((1 << alignof<usize>()) - 1)) & ~((1 << alignof<usize>()) - 1);
+  return ((num) + ((1 << alignof<usize>()) - 1)) & ~((1 << alignof<usize>()) - 1);
 }
 // @ts-ignore: decorator
 @inline function insertItem(newItem: LinkedList, preItem: LinkedList, nextItem: LinkedList): void {
-    nextItem.prev = newItem;
-    newItem.next = nextItem;
-    newItem.prev = preItem;
-    preItem.next = newItem;
+  nextItem.prev = newItem;
+  newItem.next = nextItem;
+  newItem.prev = preItem;
+  preItem.next = newItem;
 }
 
 // @ts-ignore: decorator
 @inline function dropItem(item: LinkedList): void {
-    let prev = item.prev;
-    let next = item.next;
-    if (prev && next) {
-        prev.next = next;
-        next.prev = prev;
-        item.prev = changetype<LinkedList>(0);
-        item.next = changetype<LinkedList>(0);
-    } else {
-        unreachable();
-    }
+  let prev = item.prev;
+  let next = item.next;
+  if (prev && next) {
+    prev.next = next;
+    next.prev = prev;
+    item.prev = changetype<LinkedList>(0);
+    item.next = changetype<LinkedList>(0);
+  } else {
+    unreachable();
+  }
 }
 
 function growMemory(size: usize): void {
-    if (ASC_LOW_MEMORY_LIMIT) {
-        unreachable();
-    }
-    const pagesBefore = memory.size();
-    const pageBeforePtr = pagesBefore << 16;
-    const startPoint = (pageBeforePtr + <i32>BLOCK_SIZE);
-    const v128Alignment = <i32>(AL_SIZE - ((startPoint) & <i32>AL_MASK));
-    size += startPoint + v128Alignment;
-    const pagesNeeded = <i32>(((size + 0xffff) & ~0xffff) >>> 16);
-    const pagesWanted = pagesNeeded - pagesBefore; // double memory
-    if (memory.grow(pagesWanted) < 0) {
-        unreachable();
-    }
-    let block = changetype<Block>(pageBeforePtr + v128Alignment);
-    const pagesAfter = memory.size();
-    block.size = ((pagesAfter - pagesBefore) << 16) - <i32>BLOCK_SIZE - v128Alignment;
-    insertItem(changetype<LinkedList>(pageBeforePtr + v128Alignment), freelist.prev, freelist);
+  if (ASC_LOW_MEMORY_LIMIT) {
+    unreachable();
+  }
+  const pagesBefore = memory.size();
+  const pageBeforePtr = pagesBefore << 16;
+  const startPoint = (pageBeforePtr + <i32>BLOCK_SIZE);
+  const v128Alignment = <i32>(AL_SIZE - ((startPoint) & <i32>AL_MASK));
+  size += startPoint + v128Alignment;
+  const pagesNeeded = <i32>(((size + 0xffff) & ~0xffff) >>> 16);
+  const pagesWanted = pagesNeeded - pagesBefore; // double memory
+  if (memory.grow(pagesWanted) < 0) {
+    unreachable();
+  }
+  let block = changetype<Block>(pageBeforePtr + v128Alignment);
+  const pagesAfter = memory.size();
+  block.size = ((pagesAfter - pagesBefore) << 16) - <i32>BLOCK_SIZE - v128Alignment;
+  insertItem(changetype<LinkedList>(pageBeforePtr + v128Alignment), freelist.prev, freelist);
 }
 
 function initialize(): void {
-    freelist = changetype<LinkedList>(freeListPtr);
-    freelist.next = freelist;
-    freelist.prev = freelist;
-    const startPoint: usize = ((__heap_base + BLOCK_SIZE + AL_SIZE) & ~AL_MASK) - BLOCK_SIZE;
-    const pagesBefore = memory.size();
-    const pagesNeeded = <i32>((((startPoint + 1) + 0xffff) & ~0xffff) >>> 16);
-    if (pagesNeeded > pagesBefore && memory.grow(pagesNeeded - pagesBefore) < 0) unreachable();
-    let item: LinkedList = changetype<LinkedList>(startPoint);
-    insertItem(item, freelist, freelist);
-    let block: Block = changetype<Block>(startPoint);
-    block.size = (<usize>(memory.size() << 16)) - BLOCK_SIZE - startPoint;
+  freelist = changetype<LinkedList>(freeListPtr);
+  freelist.next = freelist;
+  freelist.prev = freelist;
+  const startPoint: usize = ((__heap_base + BLOCK_SIZE + AL_SIZE) & ~AL_MASK) - BLOCK_SIZE;
+  const pagesBefore = memory.size();
+  const pagesNeeded = <i32>((((startPoint + 1) + 0xffff) & ~0xffff) >>> 16);
+  if (pagesNeeded > pagesBefore && memory.grow(pagesNeeded - pagesBefore) < 0) unreachable();
+  let item: LinkedList = changetype<LinkedList>(startPoint);
+  insertItem(item, freelist, freelist);
+  let block: Block = changetype<Block>(startPoint);
+  block.size = (<usize>(memory.size() << 16)) - BLOCK_SIZE - startPoint;
 
 }
 
 // @ts-ignore: decorator
 @inline function searchBlockPtr(size: usize): usize {
-    let foundBlockPtr: usize = 0;
-    for (let item = changetype<LinkedList>(changetype<usize>(freelist.next));
-        changetype<usize>(item) != freeListPtr && item.next != null;
-        item = item.next) {
-        if (changetype<Block>(item).size > size) {
-            foundBlockPtr = changetype<usize>(item);
-        }
+  let foundBlockPtr: usize = 0;
+  for (let item = changetype<LinkedList>(changetype<usize>(freelist.next));
+    changetype<usize>(item) != freeListPtr && item.next != null;
+    item = item.next) {
+    if (changetype<Block>(item).size > size) {
+      foundBlockPtr = changetype<usize>(item);
     }
-    return foundBlockPtr;
+  }
+  return foundBlockPtr;
 }
 
 function mergeBlock(prevPtr: usize, blockPtr: usize): bool {
-    let block = changetype<Block>(blockPtr);
-    if (prevPtr != freeListPtr && blockPtr != freeListPtr && prevPtr && blockPtr) {
-        let prevBlock = changetype<Block>(prevPtr);
-        const prevTailPtr = prevPtr + prevBlock.size + BLOCK_SIZE;
-        if (((blockPtr - prevTailPtr) < BLOCK_SIZE)) {
-            const tailPtr = changetype<usize>(block) + block.size + BLOCK_SIZE;
-            prevBlock.size += (tailPtr - prevTailPtr);
-            dropItem(changetype<LinkedList>(blockPtr));
-            return true;
-        }
+  let block = changetype<Block>(blockPtr);
+  if (prevPtr != freeListPtr && blockPtr != freeListPtr && prevPtr && blockPtr) {
+    let prevBlock = changetype<Block>(prevPtr);
+    const prevTailPtr = prevPtr + prevBlock.size + BLOCK_SIZE;
+    if (((blockPtr - prevTailPtr) < BLOCK_SIZE)) {
+      const tailPtr = changetype<usize>(block) + block.size + BLOCK_SIZE;
+      prevBlock.size += (tailPtr - prevTailPtr);
+      dropItem(changetype<LinkedList>(blockPtr));
+      return true;
     }
-    return false;
+  }
+  return false;
 }
 
 // @ts-ignore: decorator
 @global @unsafe export function __alloc(size: usize): usize {
-    size = alignUp(size);
-    if (size > BLOCK_MAXSIZE) throw new Error(E_ALLOCATION_TOO_LARGE);
-    if (!freelist) initialize();
-    let foundBlockPtr: usize = searchBlockPtr(size);
-    if (!foundBlockPtr) { // found ptr
-        growMemory(size);
-        foundBlockPtr = searchBlockPtr(size)
-        if (!foundBlockPtr) {
-            unreachable(); // unreachable if cannot get block ptr after grow memory
-        }
+  size = alignUp(size);
+  if (size > BLOCK_MAXSIZE) throw new Error(E_ALLOCATION_TOO_LARGE);
+  if (!freelist) initialize();
+  let foundBlockPtr: usize = searchBlockPtr(size);
+  if (!foundBlockPtr) { // found ptr
+    growMemory(size);
+    foundBlockPtr = searchBlockPtr(size);
+    if (!foundBlockPtr) {
+      unreachable(); // unreachable if cannot get block ptr after grow memory
     }
-    let block = changetype<Block>(foundBlockPtr);
-    if (block.size - size > MIN_BLOCK_SIZE) { // divide linked list
-        let newBlockPtr = foundBlockPtr + size + BLOCK_SIZE;
-        const v128Alignment = AL_SIZE - ((newBlockPtr + BLOCK_SIZE) & AL_MASK); // align to 128 for new block
-        size += v128Alignment;
-        newBlockPtr += v128Alignment;
-        if (!((newBlockPtr + MIN_BLOCK_SIZE) > (foundBlockPtr + block.size))) { // aligned ptr out of the bound of block
-            let newBlock = changetype<Block>(newBlockPtr);
-            newBlock.size = block.size - size - BLOCK_SIZE;
-            block.size = size;
-            insertItem(changetype<LinkedList>(newBlock),
-                changetype<LinkedList>(block),
-                changetype<LinkedList>(changetype<usize>(block.next)));
-        }
+  }
+  let block = changetype<Block>(foundBlockPtr);
+  if (block.size - size > MIN_BLOCK_SIZE) { // divide linked list
+    let newBlockPtr = foundBlockPtr + size + BLOCK_SIZE;
+    const v128Alignment = AL_SIZE - ((newBlockPtr + BLOCK_SIZE) & AL_MASK); // align to 128 for new block
+    size += v128Alignment;
+    newBlockPtr += v128Alignment;
+    if (!((newBlockPtr + MIN_BLOCK_SIZE) > (foundBlockPtr + block.size))) { // aligned ptr out of the bound of block
+      let newBlock = changetype<Block>(newBlockPtr);
+      newBlock.size = block.size - size - BLOCK_SIZE;
+      block.size = size;
+      insertItem(changetype<LinkedList>(newBlock),
+        changetype<LinkedList>(block),
+        changetype<LinkedList>(changetype<usize>(block.next)));
     }
-    dropItem(block);
-    return foundBlockPtr + BLOCK_SIZE;
+  }
+  dropItem(block);
+  return foundBlockPtr + BLOCK_SIZE;
 }
 
 // @ts-ignore: decorator
 @global @unsafe
-    export function __free(ptr: usize): void {
-    if (!ptr) unreachable(); // cannot be nullptr
-    const freeBlockPtr = ptr - BLOCK_SIZE;
-    let foundPos: bool = false;
-    for (let item = changetype<LinkedList>(changetype<usize>(freelist.next));
-        changetype<usize>(item) != freeListPtr && item.next != null;
-        item = item.next) {
-        if (changetype<usize>(item) > freeBlockPtr) {
-            insertItem(changetype<LinkedList>(freeBlockPtr), item.prev, item);
-            foundPos = true;
-            break;
-        }
+export function __free(ptr: usize): void {
+  if (!ptr) unreachable(); // cannot be nullptr
+  const freeBlockPtr = ptr - BLOCK_SIZE;
+  let foundPos: bool = false;
+  for (let item = changetype<LinkedList>(changetype<usize>(freelist.next));
+    changetype<usize>(item) != freeListPtr && item.next != null;
+    item = item.next) {
+    if (changetype<usize>(item) > freeBlockPtr) {
+      insertItem(changetype<LinkedList>(freeBlockPtr), item.prev, item);
+      foundPos = true;
+      break;
     }
-    if (!foundPos) { // add to tail
-        insertItem(changetype<LinkedList>(freeBlockPtr), freelist.prev, freelist);
-    }
-    let endPtr = freeListPtr;
-    for (let item = changetype<LinkedList>(changetype<usize>(freelist.next));
-        changetype<usize>(item) != freeListPtr && item.next != null;
-        item = item.next) {
-        const blockPtr = changetype<usize>(item);
-        const prevPtr = changetype<usize>(item.prev);
-        if (mergeBlock(prevPtr, blockPtr)) continue;
-        endPtr = blockPtr;
-    }
-    let endBlock = changetype<Block>(endPtr);
-    mergeBlock(endPtr, changetype<usize>(endBlock.next));
+  }
+  if (!foundPos) { // add to tail
+    insertItem(changetype<LinkedList>(freeBlockPtr), freelist.prev, freelist);
+  }
+  let endPtr = freeListPtr;
+  for (let item = changetype<LinkedList>(changetype<usize>(freelist.next));
+    changetype<usize>(item) != freeListPtr && item.next != null;
+    item = item.next) {
+    const blockPtr = changetype<usize>(item);
+    const prevPtr = changetype<usize>(item.prev);
+    if (mergeBlock(prevPtr, blockPtr)) continue;
+    endPtr = blockPtr;
+  }
+  let endBlock = changetype<Block>(endPtr);
+  mergeBlock(endPtr, changetype<usize>(endBlock.next));
 }
 
 function moveBlock(block: Block, newSize: usize): usize {
-    const ptr = __alloc(newSize);
-    const prePtr = changetype<usize>(block) + BLOCK_SIZE;
-    memory.copy(ptr, prePtr, block.size);
-    if (prePtr > __heap_base) __free(prePtr);
-    return ptr;
+  const ptr = __alloc(newSize);
+  const prePtr = changetype<usize>(block) + BLOCK_SIZE;
+  memory.copy(ptr, prePtr, block.size);
+  if (prePtr > __heap_base) __free(prePtr);
+  return ptr;
 }
 
 // @ts-ignore: decorator
 @global @unsafe
 export function __realloc(ptr: usize, size: usize): usize {
-    return moveBlock(changetype<Block>(ptr - BLOCK_SIZE), size);
+  return moveBlock(changetype<Block>(ptr - BLOCK_SIZE), size);
 }

--- a/tests/compiler/rt/runtime-minimal-export.debug.wat
+++ b/tests/compiler/rt/runtime-minimal-export.debug.wat
@@ -272,7 +272,7 @@
    i32.const 48
    i32.const 176
    i32.const 122
-   i32.const 31
+   i32.const 29
    call $~lib/builtins/abort
    unreachable
   end

--- a/tests/compiler/rt/runtime-minimal-export.debug.wat
+++ b/tests/compiler/rt/runtime-minimal-export.debug.wat
@@ -4,11 +4,11 @@
  (type $i32_=>_none (func (param i32)))
  (type $none_=>_none (func))
  (type $i32_i32_=>_i32 (func (param i32 i32) (result i32)))
- (type $i32_i32_i32_=>_none (func (param i32 i32 i32)))
  (type $i32_i32_i32_i32_=>_none (func (param i32 i32 i32 i32)))
- (type $i32_i32_i32_=>_i32 (func (param i32 i32 i32) (result i32)))
+ (type $i32_i32_i32_=>_none (func (param i32 i32 i32)))
  (import "env" "abort" (func $~lib/builtins/abort (param i32 i32 i32 i32)))
- (global $~lib/rt/tlsf/ROOT (mut i32) (i32.const 0))
+ (global $~lib/rt/lm/freeListPtr i32 (i32.const 16))
+ (global $~lib/rt/lm/freelist (mut i32) (i32.const 0))
  (global $~lib/native/ASC_LOW_MEMORY_LIMIT i32 (i32.const 0))
  (global $~lib/rt/tcms/fromSpace (mut i32) (i32.const 0))
  (global $~lib/rt/tcms/white (mut i32) (i32.const 0))
@@ -18,9 +18,10 @@
  (global $~lib/rt/__rtti_base i32 (i32.const 432))
  (global $~lib/memory/__heap_base i32 (i32.const 460))
  (memory $0 1)
- (data (i32.const 12) "<\00\00\00\00\00\00\00\00\00\00\00\01\00\00\00(\00\00\00A\00l\00l\00o\00c\00a\00t\00i\00o\00n\00 \00t\00o\00o\00 \00l\00a\00r\00g\00e\00\00\00\00\00")
- (data (i32.const 76) "<\00\00\00\00\00\00\00\00\00\00\00\01\00\00\00\1e\00\00\00~\00l\00i\00b\00/\00r\00t\00/\00t\00c\00m\00s\00.\00t\00s\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00")
- (data (i32.const 140) "<\00\00\00\00\00\00\00\00\00\00\00\01\00\00\00\1e\00\00\00~\00l\00i\00b\00/\00r\00t\00/\00t\00l\00s\00f\00.\00t\00s\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00")
+ (data (i32.const 16) "\00\00\00\00")
+ (data (i32.const 28) "<\00\00\00\00\00\00\00\00\00\00\00\01\00\00\00(\00\00\00A\00l\00l\00o\00c\00a\00t\00i\00o\00n\00 \00t\00o\00o\00 \00l\00a\00r\00g\00e\00\00\00\00\00")
+ (data (i32.const 92) "<\00\00\00\00\00\00\00\00\00\00\00\01\00\00\00\1e\00\00\00~\00l\00i\00b\00/\00r\00t\00/\00t\00c\00m\00s\00.\00t\00s\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00")
+ (data (i32.const 156) ",\00\00\00\00\00\00\00\00\00\00\00\01\00\00\00\1a\00\00\00~\00l\00i\00b\00/\00r\00t\00/\00l\00m\00.\00t\00s\00\00\00")
  (data (i32.const 208) "\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00")
  (data (i32.const 236) "<\00\00\00\00\00\00\00\00\00\00\00\01\00\00\00*\00\00\00O\00b\00j\00e\00c\00t\00 \00a\00l\00r\00e\00a\00d\00y\00 \00p\00i\00n\00n\00e\00d\00\00\00")
  (data (i32.const 304) "\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00")
@@ -36,766 +37,53 @@
  (export "__rtti_base" (global $~lib/rt/__rtti_base))
  (export "memory" (memory $0))
  (start $~start)
- (func $~lib/rt/tlsf/Root#set:flMap (param $0 i32) (param $1 i32)
-  local.get $0
-  local.get $1
-  i32.store $0
- )
- (func $~lib/rt/common/BLOCK#set:mmInfo (param $0 i32) (param $1 i32)
-  local.get $0
-  local.get $1
-  i32.store $0
- )
- (func $~lib/rt/tlsf/Block#set:prev (param $0 i32) (param $1 i32)
+ (func $~lib/rt/lm/LinkedList#set:next (param $0 i32) (param $1 i32)
   local.get $0
   local.get $1
   i32.store $0 offset=4
  )
- (func $~lib/rt/tlsf/Block#set:next (param $0 i32) (param $1 i32)
+ (func $~lib/rt/lm/LinkedList#set:prev (param $0 i32) (param $1 i32)
+  local.get $0
+  local.get $1
+  i32.store $0
+ )
+ (func $~lib/rt/lm/Block#set:size (param $0 i32) (param $1 i32)
   local.get $0
   local.get $1
   i32.store $0 offset=8
  )
- (func $~lib/rt/tlsf/removeBlock (param $root i32) (param $block i32)
-  (local $blockInfo i32)
-  (local $size i32)
-  (local $fl i32)
-  (local $sl i32)
-  (local $var$6 i32)
-  (local $var$7 i32)
-  (local $prev i32)
-  (local $next i32)
-  (local $var$10 i32)
-  (local $var$11 i32)
-  local.get $block
-  i32.load $0
-  local.set $blockInfo
-  i32.const 1
-  drop
-  local.get $blockInfo
-  i32.const 1
-  i32.and
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 160
-   i32.const 268
-   i32.const 14
-   call $~lib/builtins/abort
-   unreachable
-  end
-  local.get $blockInfo
-  i32.const 3
-  i32.const -1
-  i32.xor
-  i32.and
-  local.set $size
-  i32.const 1
-  drop
-  local.get $size
-  i32.const 12
-  i32.ge_u
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 160
-   i32.const 270
-   i32.const 14
-   call $~lib/builtins/abort
-   unreachable
-  end
-  local.get $size
-  i32.const 256
-  i32.lt_u
-  if
-   i32.const 0
-   local.set $fl
-   local.get $size
-   i32.const 4
-   i32.shr_u
-   local.set $sl
-  else
-   local.get $size
-   local.tee $var$6
-   i32.const 1073741820
-   local.tee $var$7
-   local.get $var$6
-   local.get $var$7
-   i32.lt_u
-   select
-   local.set $var$6
-   i32.const 31
-   local.get $var$6
-   i32.clz
-   i32.sub
-   local.set $fl
-   local.get $var$6
-   local.get $fl
-   i32.const 4
-   i32.sub
-   i32.shr_u
-   i32.const 1
-   i32.const 4
-   i32.shl
-   i32.xor
-   local.set $sl
-   local.get $fl
-   i32.const 8
-   i32.const 1
-   i32.sub
-   i32.sub
-   local.set $fl
-  end
-  i32.const 1
-  drop
-  local.get $fl
-  i32.const 23
-  i32.lt_u
-  if (result i32)
-   local.get $sl
-   i32.const 16
-   i32.lt_u
-  else
-   i32.const 0
-  end
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 160
-   i32.const 284
-   i32.const 14
-   call $~lib/builtins/abort
-   unreachable
-  end
-  local.get $block
-  i32.load $0 offset=4
-  local.set $prev
-  local.get $block
-  i32.load $0 offset=8
-  local.set $next
-  local.get $prev
-  if
-   local.get $prev
-   local.get $next
-   call $~lib/rt/tlsf/Block#set:next
-  end
-  local.get $next
-  if
-   local.get $next
-   local.get $prev
-   call $~lib/rt/tlsf/Block#set:prev
-  end
-  local.get $block
-  local.get $root
-  local.set $var$10
-  local.get $fl
-  local.set $var$6
-  local.get $sl
-  local.set $var$7
-  local.get $var$10
-  local.get $var$6
-  i32.const 4
-  i32.shl
-  local.get $var$7
-  i32.add
-  i32.const 2
-  i32.shl
-  i32.add
-  i32.load $0 offset=96
-  i32.eq
-  if
-   local.get $root
-   local.set $var$11
-   local.get $fl
-   local.set $var$10
-   local.get $sl
-   local.set $var$6
-   local.get $next
-   local.set $var$7
-   local.get $var$11
-   local.get $var$10
-   i32.const 4
-   i32.shl
-   local.get $var$6
-   i32.add
-   i32.const 2
-   i32.shl
-   i32.add
-   local.get $var$7
-   i32.store $0 offset=96
-   local.get $next
-   i32.eqz
-   if
-    local.get $root
-    local.set $var$6
-    local.get $fl
-    local.set $var$7
-    local.get $var$6
-    local.get $var$7
-    i32.const 2
-    i32.shl
-    i32.add
-    i32.load $0 offset=4
-    local.set $var$6
-    local.get $root
-    local.set $var$7
-    local.get $fl
-    local.set $var$11
-    local.get $var$6
-    i32.const 1
-    local.get $sl
-    i32.shl
-    i32.const -1
-    i32.xor
-    i32.and
-    local.tee $var$6
-    local.set $var$10
-    local.get $var$7
-    local.get $var$11
-    i32.const 2
-    i32.shl
-    i32.add
-    local.get $var$10
-    i32.store $0 offset=4
-    local.get $var$6
-    i32.eqz
-    if
-     local.get $root
-     local.get $root
-     i32.load $0
-     i32.const 1
-     local.get $fl
-     i32.shl
-     i32.const -1
-     i32.xor
-     i32.and
-     call $~lib/rt/tlsf/Root#set:flMap
-    end
-   end
-  end
- )
- (func $~lib/rt/tlsf/insertBlock (param $root i32) (param $block i32)
-  (local $blockInfo i32)
-  (local $var$3 i32)
-  (local $right i32)
-  (local $rightInfo i32)
-  (local $var$6 i32)
-  (local $size i32)
-  (local $fl i32)
-  (local $sl i32)
-  (local $var$10 i32)
-  (local $head i32)
-  (local $var$12 i32)
-  (local $var$13 i32)
-  i32.const 1
-  drop
-  local.get $block
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 160
-   i32.const 201
-   i32.const 14
-   call $~lib/builtins/abort
-   unreachable
-  end
-  local.get $block
-  i32.load $0
-  local.set $blockInfo
-  i32.const 1
-  drop
-  local.get $blockInfo
-  i32.const 1
-  i32.and
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 160
-   i32.const 203
-   i32.const 14
-   call $~lib/builtins/abort
-   unreachable
-  end
-  local.get $block
-  local.set $var$3
-  local.get $var$3
-  i32.const 4
-  i32.add
-  local.get $var$3
-  i32.load $0
-  i32.const 3
-  i32.const -1
-  i32.xor
-  i32.and
-  i32.add
-  local.set $right
-  local.get $right
-  i32.load $0
-  local.set $rightInfo
-  local.get $rightInfo
-  i32.const 1
-  i32.and
-  if
-   local.get $root
-   local.get $right
-   call $~lib/rt/tlsf/removeBlock
-   local.get $block
-   local.get $blockInfo
-   i32.const 4
-   i32.add
-   local.get $rightInfo
-   i32.const 3
-   i32.const -1
-   i32.xor
-   i32.and
-   i32.add
-   local.tee $blockInfo
-   call $~lib/rt/common/BLOCK#set:mmInfo
-   local.get $block
-   local.set $var$3
-   local.get $var$3
-   i32.const 4
-   i32.add
-   local.get $var$3
-   i32.load $0
-   i32.const 3
-   i32.const -1
-   i32.xor
-   i32.and
-   i32.add
-   local.set $right
-   local.get $right
-   i32.load $0
-   local.set $rightInfo
-  end
-  local.get $blockInfo
-  i32.const 2
-  i32.and
-  if
-   local.get $block
-   local.set $var$3
-   local.get $var$3
-   i32.const 4
-   i32.sub
-   i32.load $0
-   local.set $var$3
-   local.get $var$3
-   i32.load $0
-   local.set $var$6
-   i32.const 1
-   drop
-   local.get $var$6
-   i32.const 1
-   i32.and
-   i32.eqz
-   if
-    i32.const 0
-    i32.const 160
-    i32.const 221
-    i32.const 16
-    call $~lib/builtins/abort
-    unreachable
-   end
-   local.get $root
-   local.get $var$3
-   call $~lib/rt/tlsf/removeBlock
-   local.get $var$3
-   local.set $block
-   local.get $block
-   local.get $var$6
-   i32.const 4
-   i32.add
-   local.get $blockInfo
-   i32.const 3
-   i32.const -1
-   i32.xor
-   i32.and
-   i32.add
-   local.tee $blockInfo
-   call $~lib/rt/common/BLOCK#set:mmInfo
-  end
-  local.get $right
-  local.get $rightInfo
-  i32.const 2
-  i32.or
-  call $~lib/rt/common/BLOCK#set:mmInfo
-  local.get $blockInfo
-  i32.const 3
-  i32.const -1
-  i32.xor
-  i32.and
-  local.set $size
-  i32.const 1
-  drop
-  local.get $size
-  i32.const 12
-  i32.ge_u
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 160
-   i32.const 233
-   i32.const 14
-   call $~lib/builtins/abort
-   unreachable
-  end
-  i32.const 1
-  drop
-  local.get $block
-  i32.const 4
-  i32.add
-  local.get $size
-  i32.add
-  local.get $right
-  i32.eq
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 160
-   i32.const 234
-   i32.const 14
-   call $~lib/builtins/abort
-   unreachable
-  end
-  local.get $right
-  i32.const 4
-  i32.sub
-  local.get $block
-  i32.store $0
-  local.get $size
-  i32.const 256
-  i32.lt_u
-  if
-   i32.const 0
-   local.set $fl
-   local.get $size
-   i32.const 4
-   i32.shr_u
-   local.set $sl
-  else
-   local.get $size
-   local.tee $var$3
-   i32.const 1073741820
-   local.tee $var$6
-   local.get $var$3
-   local.get $var$6
-   i32.lt_u
-   select
-   local.set $var$3
-   i32.const 31
-   local.get $var$3
-   i32.clz
-   i32.sub
-   local.set $fl
-   local.get $var$3
-   local.get $fl
-   i32.const 4
-   i32.sub
-   i32.shr_u
-   i32.const 1
-   i32.const 4
-   i32.shl
-   i32.xor
-   local.set $sl
-   local.get $fl
-   i32.const 8
-   i32.const 1
-   i32.sub
-   i32.sub
-   local.set $fl
-  end
-  i32.const 1
-  drop
-  local.get $fl
-  i32.const 23
-  i32.lt_u
-  if (result i32)
-   local.get $sl
-   i32.const 16
-   i32.lt_u
-  else
-   i32.const 0
-  end
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 160
-   i32.const 251
-   i32.const 14
-   call $~lib/builtins/abort
-   unreachable
-  end
-  local.get $root
-  local.set $var$10
-  local.get $fl
-  local.set $var$3
-  local.get $sl
-  local.set $var$6
-  local.get $var$10
-  local.get $var$3
-  i32.const 4
-  i32.shl
-  local.get $var$6
-  i32.add
-  i32.const 2
-  i32.shl
-  i32.add
-  i32.load $0 offset=96
-  local.set $head
-  local.get $block
-  i32.const 0
-  call $~lib/rt/tlsf/Block#set:prev
-  local.get $block
-  local.get $head
-  call $~lib/rt/tlsf/Block#set:next
-  local.get $head
-  if
-   local.get $head
-   local.get $block
-   call $~lib/rt/tlsf/Block#set:prev
-  end
-  local.get $root
-  local.set $var$12
-  local.get $fl
-  local.set $var$10
-  local.get $sl
-  local.set $var$3
-  local.get $block
-  local.set $var$6
-  local.get $var$12
-  local.get $var$10
-  i32.const 4
-  i32.shl
-  local.get $var$3
-  i32.add
-  i32.const 2
-  i32.shl
-  i32.add
-  local.get $var$6
-  i32.store $0 offset=96
-  local.get $root
-  local.get $root
-  i32.load $0
-  i32.const 1
-  local.get $fl
-  i32.shl
-  i32.or
-  call $~lib/rt/tlsf/Root#set:flMap
-  local.get $root
-  local.set $var$13
-  local.get $fl
-  local.set $var$12
-  local.get $root
-  local.set $var$3
-  local.get $fl
-  local.set $var$6
-  local.get $var$3
-  local.get $var$6
-  i32.const 2
-  i32.shl
-  i32.add
-  i32.load $0 offset=4
-  i32.const 1
-  local.get $sl
-  i32.shl
-  i32.or
-  local.set $var$10
-  local.get $var$13
-  local.get $var$12
-  i32.const 2
-  i32.shl
-  i32.add
-  local.get $var$10
-  i32.store $0 offset=4
- )
- (func $~lib/rt/tlsf/addMemory (param $root i32) (param $start i32) (param $end i32) (result i32)
-  (local $var$3 i32)
-  (local $tail i32)
-  (local $tailInfo i32)
-  (local $size i32)
-  (local $leftSize i32)
-  (local $left i32)
-  (local $var$9 i32)
-  i32.const 1
-  drop
-  local.get $start
-  local.get $end
-  i32.le_u
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 160
-   i32.const 377
-   i32.const 14
-   call $~lib/builtins/abort
-   unreachable
-  end
-  local.get $start
-  i32.const 4
-  i32.add
-  i32.const 15
-  i32.add
-  i32.const 15
-  i32.const -1
-  i32.xor
-  i32.and
-  i32.const 4
-  i32.sub
-  local.set $start
-  local.get $end
-  i32.const 15
-  i32.const -1
-  i32.xor
-  i32.and
-  local.set $end
-  local.get $root
-  local.set $var$3
-  local.get $var$3
-  i32.load $0 offset=1568
-  local.set $tail
-  i32.const 0
-  local.set $tailInfo
-  local.get $tail
-  if
-   i32.const 1
-   drop
-   local.get $start
-   local.get $tail
-   i32.const 4
-   i32.add
-   i32.ge_u
-   i32.eqz
-   if
-    i32.const 0
-    i32.const 160
-    i32.const 384
-    i32.const 16
-    call $~lib/builtins/abort
-    unreachable
-   end
-   local.get $start
-   i32.const 16
-   i32.sub
-   local.get $tail
-   i32.eq
-   if
-    local.get $start
-    i32.const 16
-    i32.sub
-    local.set $start
-    local.get $tail
-    i32.load $0
-    local.set $tailInfo
-   else
-    nop
-   end
-  else
-   i32.const 1
-   drop
-   local.get $start
-   local.get $root
-   i32.const 1572
-   i32.add
-   i32.ge_u
-   i32.eqz
-   if
-    i32.const 0
-    i32.const 160
-    i32.const 397
-    i32.const 5
-    call $~lib/builtins/abort
-    unreachable
-   end
-  end
-  local.get $end
-  local.get $start
-  i32.sub
-  local.set $size
-  local.get $size
-  i32.const 4
-  i32.const 12
-  i32.add
-  i32.const 4
-  i32.add
-  i32.lt_u
-  if
-   i32.const 0
-   return
-  end
-  local.get $size
-  i32.const 2
-  i32.const 4
-  i32.mul
-  i32.sub
-  local.set $leftSize
-  local.get $start
-  local.set $left
-  local.get $left
-  local.get $leftSize
-  i32.const 1
-  i32.or
-  local.get $tailInfo
-  i32.const 2
-  i32.and
-  i32.or
-  call $~lib/rt/common/BLOCK#set:mmInfo
-  local.get $left
-  i32.const 0
-  call $~lib/rt/tlsf/Block#set:prev
-  local.get $left
-  i32.const 0
-  call $~lib/rt/tlsf/Block#set:next
-  local.get $start
-  i32.const 4
-  i32.add
-  local.get $leftSize
-  i32.add
-  local.set $tail
-  local.get $tail
-  i32.const 0
-  i32.const 2
-  i32.or
-  call $~lib/rt/common/BLOCK#set:mmInfo
-  local.get $root
-  local.set $var$9
-  local.get $tail
-  local.set $var$3
-  local.get $var$9
-  local.get $var$3
-  i32.store $0 offset=1568
-  local.get $root
-  local.get $left
-  call $~lib/rt/tlsf/insertBlock
-  i32.const 1
- )
- (func $~lib/rt/tlsf/initialize
-  (local $rootOffset i32)
+ (func $~lib/rt/lm/initialize
+  (local $startPoint i32)
   (local $pagesBefore i32)
   (local $pagesNeeded i32)
-  (local $root i32)
+  (local $item i32)
   (local $var$4 i32)
   (local $var$5 i32)
-  (local $var$6 i32)
-  (local $var$7 i32)
-  (local $var$8 i32)
-  (local $var$9 i32)
-  (local $var$10 i32)
-  (local $var$11 i32)
-  (local $memStart i32)
-  i32.const 0
-  drop
+  (local $block i32)
+  global.get $~lib/rt/lm/freeListPtr
+  global.set $~lib/rt/lm/freelist
+  global.get $~lib/rt/lm/freelist
+  global.get $~lib/rt/lm/freelist
+  call $~lib/rt/lm/LinkedList#set:next
+  global.get $~lib/rt/lm/freelist
+  global.get $~lib/rt/lm/freelist
+  call $~lib/rt/lm/LinkedList#set:prev
   global.get $~lib/memory/__heap_base
-  i32.const 15
+  i32.const 12
+  i32.add
+  i32.const 16
   i32.add
   i32.const 15
   i32.const -1
   i32.xor
   i32.and
-  local.set $rootOffset
+  i32.const 12
+  i32.sub
+  local.set $startPoint
   memory.size $0
   local.set $pagesBefore
-  local.get $rootOffset
-  i32.const 1572
+  local.get $startPoint
+  i32.const 1
   i32.add
   i32.const 65535
   i32.add
@@ -822,360 +110,72 @@
   if
    unreachable
   end
-  local.get $rootOffset
-  local.set $root
-  local.get $root
-  i32.const 0
-  call $~lib/rt/tlsf/Root#set:flMap
-  local.get $root
+  local.get $startPoint
+  local.set $item
+  local.get $item
+  local.set $block
+  global.get $~lib/rt/lm/freelist
   local.set $var$5
-  i32.const 0
+  global.get $~lib/rt/lm/freelist
   local.set $var$4
-  local.get $var$5
   local.get $var$4
-  i32.store $0 offset=1568
-  i32.const 0
-  local.set $var$5
-  loop $for-loop|0
-   local.get $var$5
-   i32.const 23
-   i32.lt_u
-   local.set $var$4
-   local.get $var$4
-   if
-    local.get $root
-    local.set $var$8
-    local.get $var$5
-    local.set $var$7
-    i32.const 0
-    local.set $var$6
-    local.get $var$8
-    local.get $var$7
-    i32.const 2
-    i32.shl
-    i32.add
-    local.get $var$6
-    i32.store $0 offset=4
-    i32.const 0
-    local.set $var$8
-    loop $for-loop|1
-     local.get $var$8
-     i32.const 16
-     i32.lt_u
-     local.set $var$7
-     local.get $var$7
-     if
-      local.get $root
-      local.set $var$11
-      local.get $var$5
-      local.set $var$10
-      local.get $var$8
-      local.set $var$9
-      i32.const 0
-      local.set $var$6
-      local.get $var$11
-      local.get $var$10
-      i32.const 4
-      i32.shl
-      local.get $var$9
-      i32.add
-      i32.const 2
-      i32.shl
-      i32.add
-      local.get $var$6
-      i32.store $0 offset=96
-      local.get $var$8
-      i32.const 1
-      i32.add
-      local.set $var$8
-      br $for-loop|1
-     end
-    end
-    local.get $var$5
-    i32.const 1
-    i32.add
-    local.set $var$5
-    br $for-loop|0
-   end
-  end
-  local.get $rootOffset
-  i32.const 1572
-  i32.add
-  local.set $memStart
-  i32.const 0
-  drop
-  local.get $root
-  local.get $memStart
+  local.get $block
+  call $~lib/rt/lm/LinkedList#set:prev
+  local.get $block
+  local.get $var$4
+  call $~lib/rt/lm/LinkedList#set:next
+  local.get $block
+  local.get $var$5
+  call $~lib/rt/lm/LinkedList#set:prev
+  local.get $var$5
+  local.get $block
+  call $~lib/rt/lm/LinkedList#set:next
+  local.get $startPoint
+  local.set $block
+  local.get $block
   memory.size $0
   i32.const 16
   i32.shl
-  call $~lib/rt/tlsf/addMemory
-  drop
-  local.get $root
-  global.set $~lib/rt/tlsf/ROOT
- )
- (func $~lib/rt/tlsf/computeSize (param $size i32) (result i32)
-  local.get $size
   i32.const 12
-  i32.le_u
-  if (result i32)
-   i32.const 12
-  else
-   local.get $size
-   i32.const 4
-   i32.add
-   i32.const 15
-   i32.add
-   i32.const 15
-   i32.const -1
-   i32.xor
-   i32.and
-   i32.const 4
-   i32.sub
-  end
+  i32.sub
+  local.get $startPoint
+  i32.sub
+  call $~lib/rt/lm/Block#set:size
  )
- (func $~lib/rt/tlsf/prepareSize (param $size i32) (result i32)
-  local.get $size
-  i32.const 1073741820
-  i32.gt_u
-  if
-   i32.const 32
-   i32.const 160
-   i32.const 458
-   i32.const 29
-   call $~lib/builtins/abort
-   unreachable
-  end
-  local.get $size
-  call $~lib/rt/tlsf/computeSize
- )
- (func $~lib/rt/tlsf/searchBlock (param $root i32) (param $size i32) (result i32)
-  (local $fl i32)
-  (local $sl i32)
-  (local $var$4 i32)
-  (local $var$5 i32)
-  (local $slMap i32)
-  (local $head i32)
-  (local $var$8 i32)
-  (local $var$9 i32)
-  local.get $size
-  i32.const 256
-  i32.lt_u
-  if
-   i32.const 0
-   local.set $fl
-   local.get $size
-   i32.const 4
-   i32.shr_u
-   local.set $sl
-  else
-   local.get $size
-   i32.const 536870910
-   i32.lt_u
-   if (result i32)
-    local.get $size
-    i32.const 1
-    i32.const 27
-    local.get $size
-    i32.clz
-    i32.sub
-    i32.shl
-    i32.add
-    i32.const 1
-    i32.sub
-   else
-    local.get $size
-   end
-   local.set $var$4
-   i32.const 31
-   local.get $var$4
-   i32.clz
-   i32.sub
-   local.set $fl
-   local.get $var$4
-   local.get $fl
-   i32.const 4
-   i32.sub
-   i32.shr_u
-   i32.const 1
-   i32.const 4
-   i32.shl
-   i32.xor
-   local.set $sl
-   local.get $fl
-   i32.const 8
-   i32.const 1
-   i32.sub
-   i32.sub
-   local.set $fl
-  end
-  i32.const 1
-  drop
-  local.get $fl
-  i32.const 23
-  i32.lt_u
-  if (result i32)
-   local.get $sl
-   i32.const 16
-   i32.lt_u
-  else
-   i32.const 0
-  end
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 160
-   i32.const 330
-   i32.const 14
-   call $~lib/builtins/abort
-   unreachable
-  end
-  local.get $root
-  local.set $var$5
-  local.get $fl
-  local.set $var$4
-  local.get $var$5
-  local.get $var$4
-  i32.const 2
-  i32.shl
-  i32.add
-  i32.load $0 offset=4
-  i32.const 0
-  i32.const -1
-  i32.xor
-  local.get $sl
-  i32.shl
-  i32.and
-  local.set $slMap
-  i32.const 0
-  local.set $head
-  local.get $slMap
-  i32.eqz
-  if
-   local.get $root
-   i32.load $0
-   i32.const 0
-   i32.const -1
-   i32.xor
-   local.get $fl
-   i32.const 1
-   i32.add
-   i32.shl
-   i32.and
-   local.set $var$5
-   local.get $var$5
-   i32.eqz
-   if
-    i32.const 0
-    local.set $head
-   else
-    local.get $var$5
-    i32.ctz
-    local.set $fl
-    local.get $root
-    local.set $var$8
-    local.get $fl
-    local.set $var$4
-    local.get $var$8
-    local.get $var$4
-    i32.const 2
-    i32.shl
-    i32.add
-    i32.load $0 offset=4
-    local.set $slMap
-    i32.const 1
-    drop
-    local.get $slMap
-    i32.eqz
-    if
-     i32.const 0
-     i32.const 160
-     i32.const 343
-     i32.const 18
-     call $~lib/builtins/abort
-     unreachable
-    end
-    local.get $root
-    local.set $var$9
-    local.get $fl
-    local.set $var$8
-    local.get $slMap
-    i32.ctz
-    local.set $var$4
-    local.get $var$9
-    local.get $var$8
-    i32.const 4
-    i32.shl
-    local.get $var$4
-    i32.add
-    i32.const 2
-    i32.shl
-    i32.add
-    i32.load $0 offset=96
-    local.set $head
-   end
-  else
-   local.get $root
-   local.set $var$9
-   local.get $fl
-   local.set $var$8
-   local.get $slMap
-   i32.ctz
-   local.set $var$4
-   local.get $var$9
-   local.get $var$8
-   i32.const 4
-   i32.shl
-   local.get $var$4
-   i32.add
-   i32.const 2
-   i32.shl
-   i32.add
-   i32.load $0 offset=96
-   local.set $head
-  end
-  local.get $head
- )
- (func $~lib/rt/tlsf/growMemory (param $root i32) (param $size i32)
+ (func $~lib/rt/lm/growMemory (param $size i32)
   (local $pagesBefore i32)
-  (local $var$3 i32)
+  (local $pageBeforePtr i32)
+  (local $startPoint i32)
+  (local $v128Alignment i32)
   (local $pagesNeeded i32)
-  (local $var$5 i32)
   (local $pagesWanted i32)
+  (local $block i32)
   (local $pagesAfter i32)
+  (local $var$9 i32)
+  (local $var$10 i32)
+  (local $var$11 i32)
   i32.const 0
   drop
-  local.get $size
-  i32.const 536870910
-  i32.lt_u
-  if
-   local.get $size
-   i32.const 1
-   i32.const 27
-   local.get $size
-   i32.clz
-   i32.sub
-   i32.shl
-   i32.const 1
-   i32.sub
-   i32.add
-   local.set $size
-  end
   memory.size $0
   local.set $pagesBefore
-  local.get $size
-  i32.const 4
   local.get $pagesBefore
   i32.const 16
   i32.shl
-  i32.const 4
+  local.set $pageBeforePtr
+  local.get $pageBeforePtr
+  i32.const 12
+  i32.add
+  local.set $startPoint
+  i32.const 16
+  local.get $startPoint
+  i32.const 15
+  i32.and
   i32.sub
-  local.get $root
-  local.set $var$3
-  local.get $var$3
-  i32.load $0 offset=1568
-  i32.ne
-  i32.shl
+  local.set $v128Alignment
+  local.get $size
+  local.get $startPoint
+  local.get $v128Alignment
+  i32.add
   i32.add
   local.set $size
   local.get $size
@@ -1188,214 +188,293 @@
   i32.const 16
   i32.shr_u
   local.set $pagesNeeded
-  local.get $pagesBefore
-  local.tee $var$3
   local.get $pagesNeeded
-  local.tee $var$5
-  local.get $var$3
-  local.get $var$5
-  i32.gt_s
-  select
+  local.get $pagesBefore
+  i32.sub
   local.set $pagesWanted
   local.get $pagesWanted
   memory.grow $0
   i32.const 0
   i32.lt_s
   if
-   local.get $pagesNeeded
-   memory.grow $0
-   i32.const 0
-   i32.lt_s
-   if
-    unreachable
-   end
+   unreachable
   end
+  local.get $pageBeforePtr
+  local.get $v128Alignment
+  i32.add
+  local.set $block
   memory.size $0
   local.set $pagesAfter
-  local.get $root
-  local.get $pagesBefore
-  i32.const 16
-  i32.shl
-  local.get $pagesAfter
-  i32.const 16
-  i32.shl
-  call $~lib/rt/tlsf/addMemory
-  drop
- )
- (func $~lib/rt/tlsf/prepareBlock (param $root i32) (param $block i32) (param $size i32)
-  (local $blockInfo i32)
-  (local $remaining i32)
-  (local $var$5 i32)
   local.get $block
-  i32.load $0
-  local.set $blockInfo
-  i32.const 1
-  drop
-  local.get $size
-  i32.const 4
+  local.get $pagesAfter
+  local.get $pagesBefore
+  i32.sub
+  i32.const 16
+  i32.shl
+  i32.const 12
+  i32.sub
+  local.get $v128Alignment
+  i32.sub
+  call $~lib/rt/lm/Block#set:size
+  local.get $pageBeforePtr
+  local.get $v128Alignment
   i32.add
-  i32.const 15
-  i32.and
-  i32.eqz
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 160
-   i32.const 357
-   i32.const 14
-   call $~lib/builtins/abort
-   unreachable
-  end
-  local.get $blockInfo
-  i32.const 3
+  local.set $var$11
+  global.get $~lib/rt/lm/freelist
+  i32.load $0
+  local.set $var$10
+  global.get $~lib/rt/lm/freelist
+  local.set $var$9
+  local.get $var$9
+  local.get $var$11
+  call $~lib/rt/lm/LinkedList#set:prev
+  local.get $var$11
+  local.get $var$9
+  call $~lib/rt/lm/LinkedList#set:next
+  local.get $var$11
+  local.get $var$10
+  call $~lib/rt/lm/LinkedList#set:prev
+  local.get $var$10
+  local.get $var$11
+  call $~lib/rt/lm/LinkedList#set:next
+ )
+ (func $~lib/rt/lm/__alloc (param $size i32) (result i32)
+  (local $var$1 i32)
+  (local $var$2 i32)
+  (local $var$3 i32)
+  (local $var$4 i32)
+  (local $var$5 i32)
+  (local $var$6 i32)
+  (local $var$7 i32)
+  (local $var$8 i32)
+  local.get $size
+  local.set $var$1
+  local.get $var$1
+  i32.const 1
+  i32.const 2
+  i32.shl
+  i32.const 1
+  i32.sub
+  i32.add
+  i32.const 1
+  i32.const 2
+  i32.shl
+  i32.const 1
+  i32.sub
   i32.const -1
   i32.xor
   i32.and
+  local.set $size
   local.get $size
-  i32.sub
-  local.set $remaining
-  local.get $remaining
-  i32.const 4
-  i32.const 12
-  i32.add
-  i32.ge_u
+  i32.const 1073741820
+  i32.gt_u
   if
-   local.get $block
-   local.get $size
-   local.get $blockInfo
-   i32.const 2
-   i32.and
-   i32.or
-   call $~lib/rt/common/BLOCK#set:mmInfo
-   local.get $block
-   i32.const 4
-   i32.add
-   local.get $size
-   i32.add
-   local.set $var$5
-   local.get $var$5
-   local.get $remaining
-   i32.const 4
-   i32.sub
-   i32.const 1
-   i32.or
-   call $~lib/rt/common/BLOCK#set:mmInfo
-   local.get $root
-   local.get $var$5
-   call $~lib/rt/tlsf/insertBlock
-  else
-   local.get $block
-   local.get $blockInfo
-   i32.const 1
-   i32.const -1
-   i32.xor
-   i32.and
-   call $~lib/rt/common/BLOCK#set:mmInfo
-   local.get $block
-   local.set $var$5
-   local.get $var$5
-   i32.const 4
-   i32.add
-   local.get $var$5
-   i32.load $0
-   i32.const 3
-   i32.const -1
-   i32.xor
-   i32.and
-   i32.add
-   local.get $block
-   local.set $var$5
-   local.get $var$5
-   i32.const 4
-   i32.add
-   local.get $var$5
-   i32.load $0
-   i32.const 3
-   i32.const -1
-   i32.xor
-   i32.and
-   i32.add
-   i32.load $0
-   i32.const 2
-   i32.const -1
-   i32.xor
-   i32.and
-   call $~lib/rt/common/BLOCK#set:mmInfo
+   i32.const 48
+   i32.const 176
+   i32.const 122
+   i32.const 31
+   call $~lib/builtins/abort
+   unreachable
   end
- )
- (func $~lib/rt/tlsf/allocateBlock (param $root i32) (param $size i32) (result i32)
-  (local $payloadSize i32)
-  (local $block i32)
-  local.get $size
-  call $~lib/rt/tlsf/prepareSize
-  local.set $payloadSize
-  local.get $root
-  local.get $payloadSize
-  call $~lib/rt/tlsf/searchBlock
-  local.set $block
-  local.get $block
+  global.get $~lib/rt/lm/freelist
   i32.eqz
   if
-   local.get $root
-   local.get $payloadSize
-   call $~lib/rt/tlsf/growMemory
-   local.get $root
-   local.get $payloadSize
-   call $~lib/rt/tlsf/searchBlock
-   local.set $block
-   i32.const 1
-   drop
-   local.get $block
+   call $~lib/rt/lm/initialize
+  end
+  local.get $size
+  local.set $var$1
+  i32.const 0
+  local.set $var$2
+  global.get $~lib/rt/lm/freelist
+  i32.load $0 offset=4
+  local.set $var$3
+  loop $for-loop|0
+   local.get $var$3
+   global.get $~lib/rt/lm/freeListPtr
+   i32.ne
+   if (result i32)
+    local.get $var$3
+    i32.load $0 offset=4
+    i32.const 0
+    i32.ne
+   else
+    i32.const 0
+   end
+   local.set $var$4
+   local.get $var$4
+   if
+    local.get $var$3
+    i32.load $0 offset=8
+    local.get $var$1
+    i32.gt_u
+    if
+     local.get $var$3
+     local.set $var$2
+    end
+    local.get $var$3
+    i32.load $0 offset=4
+    local.set $var$3
+    br $for-loop|0
+   end
+  end
+  local.get $var$2
+  local.set $var$2
+  local.get $var$2
+  i32.eqz
+  if
+   local.get $size
+   call $~lib/rt/lm/growMemory
+   local.get $size
+   local.set $var$4
+   i32.const 0
+   local.set $var$1
+   global.get $~lib/rt/lm/freelist
+   i32.load $0 offset=4
+   local.set $var$3
+   loop $for-loop|1
+    local.get $var$3
+    global.get $~lib/rt/lm/freeListPtr
+    i32.ne
+    if (result i32)
+     local.get $var$3
+     i32.load $0 offset=4
+     i32.const 0
+     i32.ne
+    else
+     i32.const 0
+    end
+    local.set $var$5
+    local.get $var$5
+    if
+     local.get $var$3
+     i32.load $0 offset=8
+     local.get $var$4
+     i32.gt_u
+     if
+      local.get $var$3
+      local.set $var$1
+     end
+     local.get $var$3
+     i32.load $0 offset=4
+     local.set $var$3
+     br $for-loop|1
+    end
+   end
+   local.get $var$1
+   local.set $var$2
+   local.get $var$2
    i32.eqz
    if
-    i32.const 0
-    i32.const 160
-    i32.const 496
-    i32.const 16
-    call $~lib/builtins/abort
     unreachable
    end
   end
-  i32.const 1
-  drop
-  local.get $block
-  i32.load $0
-  i32.const 3
-  i32.const -1
-  i32.xor
-  i32.and
-  local.get $payloadSize
-  i32.ge_u
-  i32.eqz
+  local.get $var$2
+  local.set $var$1
+  local.get $var$1
+  i32.load $0 offset=8
+  local.get $size
+  i32.sub
+  i32.const 12
+  i32.gt_u
   if
+   local.get $var$2
+   local.get $size
+   i32.add
+   i32.const 12
+   i32.add
+   local.set $var$4
+   i32.const 16
+   local.get $var$4
+   i32.const 12
+   i32.add
+   i32.const 15
+   i32.and
+   i32.sub
+   local.set $var$3
+   local.get $size
+   local.get $var$3
+   i32.add
+   local.set $size
+   local.get $var$4
+   local.get $var$3
+   i32.add
+   local.set $var$4
+   local.get $var$4
+   i32.const 12
+   i32.add
+   local.get $var$2
+   local.get $var$1
+   i32.load $0 offset=8
+   i32.add
+   i32.gt_u
+   i32.eqz
+   if
+    local.get $var$4
+    local.set $var$5
+    local.get $var$5
+    local.get $var$1
+    i32.load $0 offset=8
+    local.get $size
+    i32.sub
+    i32.const 12
+    i32.sub
+    call $~lib/rt/lm/Block#set:size
+    local.get $var$1
+    local.get $size
+    call $~lib/rt/lm/Block#set:size
+    local.get $var$5
+    local.set $var$8
+    local.get $var$1
+    local.set $var$7
+    local.get $var$1
+    i32.load $0 offset=4
+    local.set $var$6
+    local.get $var$6
+    local.get $var$8
+    call $~lib/rt/lm/LinkedList#set:prev
+    local.get $var$8
+    local.get $var$6
+    call $~lib/rt/lm/LinkedList#set:next
+    local.get $var$8
+    local.get $var$7
+    call $~lib/rt/lm/LinkedList#set:prev
+    local.get $var$7
+    local.get $var$8
+    call $~lib/rt/lm/LinkedList#set:next
+   end
+  end
+  local.get $var$1
+  local.set $var$6
+  local.get $var$6
+  i32.load $0
+  local.set $var$3
+  local.get $var$6
+  i32.load $0 offset=4
+  local.set $var$4
+  local.get $var$3
+  if (result i32)
+   local.get $var$4
+  else
    i32.const 0
-   i32.const 160
-   i32.const 498
-   i32.const 14
-   call $~lib/builtins/abort
+  end
+  if
+   local.get $var$3
+   local.get $var$4
+   call $~lib/rt/lm/LinkedList#set:next
+   local.get $var$4
+   local.get $var$3
+   call $~lib/rt/lm/LinkedList#set:prev
+   local.get $var$6
+   i32.const 0
+   call $~lib/rt/lm/LinkedList#set:prev
+   local.get $var$6
+   i32.const 0
+   call $~lib/rt/lm/LinkedList#set:next
+  else
    unreachable
   end
-  local.get $root
-  local.get $block
-  call $~lib/rt/tlsf/removeBlock
-  local.get $root
-  local.get $block
-  local.get $payloadSize
-  call $~lib/rt/tlsf/prepareBlock
-  i32.const 0
-  drop
-  local.get $block
- )
- (func $~lib/rt/tlsf/__alloc (param $size i32) (result i32)
-  global.get $~lib/rt/tlsf/ROOT
-  i32.eqz
-  if
-   call $~lib/rt/tlsf/initialize
-  end
-  global.get $~lib/rt/tlsf/ROOT
-  local.get $size
-  call $~lib/rt/tlsf/allocateBlock
-  i32.const 4
+  local.get $var$2
+  i32.const 12
   i32.add
  )
  (func $~lib/rt/tcms/Object#set:rtId (param $0 i32) (param $1 i32)
@@ -1473,8 +552,8 @@
   i32.const 1073741804
   i32.gt_u
   if
-   i32.const 32
-   i32.const 96
+   i32.const 48
+   i32.const 112
    i32.const 125
    i32.const 30
    call $~lib/builtins/abort
@@ -1483,7 +562,7 @@
   i32.const 16
   local.get $size
   i32.add
-  call $~lib/rt/tlsf/__alloc
+  call $~lib/rt/lm/__alloc
   i32.const 4
   i32.sub
   local.set $obj
@@ -1546,7 +625,7 @@
    i32.eqz
    if
     i32.const 0
-    i32.const 96
+    i32.const 112
     i32.const 101
     i32.const 18
     call $~lib/builtins/abort
@@ -1563,7 +642,7 @@
   i32.eqz
   if
    i32.const 0
-   i32.const 96
+   i32.const 112
    i32.const 105
    i32.const 16
    call $~lib/builtins/abort
@@ -1590,7 +669,7 @@
    i32.eq
    if
     i32.const 256
-    i32.const 96
+    i32.const 112
     i32.const 181
     i32.const 7
     call $~lib/builtins/abort
@@ -1622,7 +701,7 @@
   i32.ne
   if
    i32.const 352
-   i32.const 96
+   i32.const 112
    i32.const 195
    i32.const 5
    call $~lib/builtins/abort
@@ -1635,72 +714,246 @@
   global.get $~lib/rt/tcms/white
   call $~lib/rt/tcms/Object#linkTo
  )
- (func $~lib/rt/tlsf/checkUsedBlock (param $ptr i32) (result i32)
-  (local $block i32)
-  local.get $ptr
-  i32.const 4
-  i32.sub
-  local.set $block
-  local.get $ptr
-  i32.const 0
+ (func $~lib/rt/lm/mergeBlock (param $prevPtr i32) (param $blockPtr i32) (result i32)
+  (local $var$2 i32)
+  (local $var$3 i32)
+  (local $var$4 i32)
+  (local $var$5 i32)
+  (local $var$6 i32)
+  (local $var$7 i32)
+  (local $var$8 i32)
+  local.get $blockPtr
+  local.set $var$2
+  local.get $prevPtr
+  global.get $~lib/rt/lm/freeListPtr
   i32.ne
   if (result i32)
-   local.get $ptr
-   i32.const 15
-   i32.and
-   i32.eqz
+   local.get $blockPtr
+   global.get $~lib/rt/lm/freeListPtr
+   i32.ne
   else
    i32.const 0
   end
   if (result i32)
-   local.get $block
-   i32.load $0
-   i32.const 1
-   i32.and
-   i32.eqz
+   local.get $prevPtr
   else
    i32.const 0
   end
+  if (result i32)
+   local.get $blockPtr
+  else
+   i32.const 0
+  end
+  if
+   local.get $prevPtr
+   local.set $var$3
+   local.get $prevPtr
+   local.get $var$3
+   i32.load $0 offset=8
+   i32.add
+   i32.const 12
+   i32.add
+   local.set $var$4
+   local.get $blockPtr
+   local.get $var$4
+   i32.sub
+   i32.const 12
+   i32.lt_u
+   if
+    local.get $var$2
+    local.get $var$2
+    i32.load $0 offset=8
+    i32.add
+    i32.const 12
+    i32.add
+    local.set $var$5
+    local.get $var$3
+    local.get $var$3
+    i32.load $0 offset=8
+    local.get $var$5
+    local.get $var$4
+    i32.sub
+    i32.add
+    call $~lib/rt/lm/Block#set:size
+    local.get $blockPtr
+    local.set $var$6
+    local.get $var$6
+    i32.load $0
+    local.set $var$7
+    local.get $var$6
+    i32.load $0 offset=4
+    local.set $var$8
+    local.get $var$7
+    if (result i32)
+     local.get $var$8
+    else
+     i32.const 0
+    end
+    if
+     local.get $var$7
+     local.get $var$8
+     call $~lib/rt/lm/LinkedList#set:next
+     local.get $var$8
+     local.get $var$7
+     call $~lib/rt/lm/LinkedList#set:prev
+     local.get $var$6
+     i32.const 0
+     call $~lib/rt/lm/LinkedList#set:prev
+     local.get $var$6
+     i32.const 0
+     call $~lib/rt/lm/LinkedList#set:next
+    else
+     unreachable
+    end
+    i32.const 1
+    return
+   end
+  end
+  i32.const 0
+ )
+ (func $~lib/rt/lm/__free (param $ptr i32)
+  (local $freeBlockPtr i32)
+  (local $foundPos i32)
+  (local $var$3 i32)
+  (local $var$4 i32)
+  (local $var$5 i32)
+  (local $endBlock i32)
+  (local $endPtr i32)
+  local.get $ptr
   i32.eqz
   if
-   i32.const 0
-   i32.const 160
-   i32.const 559
-   i32.const 3
-   call $~lib/builtins/abort
    unreachable
   end
-  local.get $block
- )
- (func $~lib/rt/tlsf/freeBlock (param $root i32) (param $block i32)
-  i32.const 0
-  drop
-  local.get $block
-  local.get $block
-  i32.load $0
-  i32.const 1
-  i32.or
-  call $~lib/rt/common/BLOCK#set:mmInfo
-  local.get $root
-  local.get $block
-  call $~lib/rt/tlsf/insertBlock
- )
- (func $~lib/rt/tlsf/__free (param $ptr i32)
   local.get $ptr
-  global.get $~lib/memory/__heap_base
-  i32.lt_u
-  if
-   return
+  i32.const 12
+  i32.sub
+  local.set $freeBlockPtr
+  i32.const 0
+  local.set $foundPos
+  global.get $~lib/rt/lm/freelist
+  i32.load $0 offset=4
+  local.set $var$3
+  block $for-break0
+   loop $for-loop|0
+    local.get $var$3
+    global.get $~lib/rt/lm/freeListPtr
+    i32.ne
+    if (result i32)
+     local.get $var$3
+     i32.load $0 offset=4
+     i32.const 0
+     i32.ne
+    else
+     i32.const 0
+    end
+    local.set $var$4
+    local.get $var$4
+    if
+     local.get $var$3
+     local.get $freeBlockPtr
+     i32.gt_u
+     if
+      local.get $freeBlockPtr
+      local.set $endPtr
+      local.get $var$3
+      i32.load $0
+      local.set $endBlock
+      local.get $var$3
+      local.set $var$5
+      local.get $var$5
+      local.get $endPtr
+      call $~lib/rt/lm/LinkedList#set:prev
+      local.get $endPtr
+      local.get $var$5
+      call $~lib/rt/lm/LinkedList#set:next
+      local.get $endPtr
+      local.get $endBlock
+      call $~lib/rt/lm/LinkedList#set:prev
+      local.get $endBlock
+      local.get $endPtr
+      call $~lib/rt/lm/LinkedList#set:next
+      i32.const 1
+      local.set $foundPos
+      br $for-break0
+     end
+     local.get $var$3
+     i32.load $0 offset=4
+     local.set $var$3
+     br $for-loop|0
+    end
+   end
   end
-  global.get $~lib/rt/tlsf/ROOT
+  local.get $foundPos
   i32.eqz
   if
-   call $~lib/rt/tlsf/initialize
+   local.get $freeBlockPtr
+   local.set $endPtr
+   global.get $~lib/rt/lm/freelist
+   i32.load $0
+   local.set $endBlock
+   global.get $~lib/rt/lm/freelist
+   local.set $var$5
+   local.get $var$5
+   local.get $endPtr
+   call $~lib/rt/lm/LinkedList#set:prev
+   local.get $endPtr
+   local.get $var$5
+   call $~lib/rt/lm/LinkedList#set:next
+   local.get $endPtr
+   local.get $endBlock
+   call $~lib/rt/lm/LinkedList#set:prev
+   local.get $endBlock
+   local.get $endPtr
+   call $~lib/rt/lm/LinkedList#set:next
   end
-  global.get $~lib/rt/tlsf/ROOT
-  local.get $ptr
-  call $~lib/rt/tlsf/checkUsedBlock
-  call $~lib/rt/tlsf/freeBlock
+  global.get $~lib/rt/lm/freeListPtr
+  local.set $endPtr
+  global.get $~lib/rt/lm/freelist
+  i32.load $0 offset=4
+  local.set $endBlock
+  loop $for-loop|1
+   local.get $endBlock
+   global.get $~lib/rt/lm/freeListPtr
+   i32.ne
+   if (result i32)
+    local.get $endBlock
+    i32.load $0 offset=4
+    i32.const 0
+    i32.ne
+   else
+    i32.const 0
+   end
+   local.set $var$5
+   local.get $var$5
+   if
+    block $for-continue|1
+     local.get $endBlock
+     local.set $var$3
+     local.get $endBlock
+     i32.load $0
+     local.set $var$4
+     local.get $var$4
+     local.get $var$3
+     call $~lib/rt/lm/mergeBlock
+     if
+      br $for-continue|1
+     end
+     local.get $var$3
+     local.set $endPtr
+    end
+    local.get $endBlock
+    i32.load $0 offset=4
+    local.set $endBlock
+    br $for-loop|1
+   end
+  end
+  local.get $endPtr
+  local.set $endBlock
+  local.get $endPtr
+  local.get $endBlock
+  i32.load $0 offset=4
+  call $~lib/rt/lm/mergeBlock
+  drop
  )
  (func $~lib/rt/tcms/__collect
   (local $pn i32)
@@ -1735,7 +988,7 @@
     i32.eqz
     if
      i32.const 0
-     i32.const 96
+     i32.const 112
      i32.const 213
      i32.const 16
      call $~lib/builtins/abort
@@ -1776,7 +1029,7 @@
     i32.eqz
     if
      i32.const 0
-     i32.const 96
+     i32.const 112
      i32.const 223
      i32.const 16
      call $~lib/builtins/abort
@@ -1814,7 +1067,7 @@
     i32.eqz
     if
      i32.const 0
-     i32.const 96
+     i32.const 112
      i32.const 232
      i32.const 16
      call $~lib/builtins/abort
@@ -1844,7 +1097,7 @@
      local.get $iter
      i32.const 4
      i32.add
-     call $~lib/rt/tlsf/__free
+     call $~lib/rt/lm/__free
     end
     local.get $newNext
     local.set $iter
@@ -1897,7 +1150,7 @@
  )
  (func $~lib/rt/__visit_globals (param $0 i32)
   (local $1 i32)
-  i32.const 32
+  i32.const 48
   local.get $0
   call $~lib/rt/tcms/__visit
   i32.const 256

--- a/tests/compiler/rt/runtime-minimal-export.release.wat
+++ b/tests/compiler/rt/runtime-minimal-export.release.wat
@@ -48,7 +48,7 @@
    i32.const 1056
    i32.const 1184
    i32.const 122
-   i32.const 31
+   i32.const 29
    call $~lib/builtins/abort
    unreachable
   end

--- a/tests/compiler/rt/runtime-minimal-export.release.wat
+++ b/tests/compiler/rt/runtime-minimal-export.release.wat
@@ -1,31 +1,29 @@
 (module
  (type $i32_=>_none (func (param i32)))
- (type $none_=>_none (func))
- (type $i32_i32_=>_none (func (param i32 i32)))
- (type $i32_i32_=>_i32 (func (param i32 i32) (result i32)))
- (type $i32_i32_i32_i32_=>_none (func (param i32 i32 i32 i32)))
- (type $i32_i32_i32_=>_none (func (param i32 i32 i32)))
  (type $i32_=>_i32 (func (param i32) (result i32)))
+ (type $none_=>_none (func))
+ (type $i32_i32_i32_i32_=>_none (func (param i32 i32 i32 i32)))
+ (type $i32_i32_=>_i32 (func (param i32 i32) (result i32)))
  (import "env" "abort" (func $~lib/builtins/abort (param i32 i32 i32 i32)))
- (global $~lib/rt/tlsf/ROOT (mut i32) (i32.const 0))
+ (global $~lib/rt/lm/freelist (mut i32) (i32.const 0))
  (global $~lib/rt/tcms/fromSpace (mut i32) (i32.const 0))
  (global $~lib/rt/tcms/white (mut i32) (i32.const 0))
  (global $~lib/rt/tcms/total (mut i32) (i32.const 0))
  (global $~lib/rt/tcms/pinSpace (mut i32) (i32.const 0))
  (global $~lib/rt/tcms/toSpace (mut i32) (i32.const 0))
- (global $~lib/rt/__rtti_base i32 (i32.const 1456))
+ (global $~lib/rt/__rtti_base i32 (i32.const 1440))
  (memory $0 1)
  (data (i32.const 1036) "<")
  (data (i32.const 1048) "\01\00\00\00(\00\00\00A\00l\00l\00o\00c\00a\00t\00i\00o\00n\00 \00t\00o\00o\00 \00l\00a\00r\00g\00e")
  (data (i32.const 1100) "<")
  (data (i32.const 1112) "\01\00\00\00\1e\00\00\00~\00l\00i\00b\00/\00r\00t\00/\00t\00c\00m\00s\00.\00t\00s")
- (data (i32.const 1164) "<")
- (data (i32.const 1176) "\01\00\00\00\1e\00\00\00~\00l\00i\00b\00/\00r\00t\00/\00t\00l\00s\00f\00.\00t\00s")
- (data (i32.const 1260) "<")
- (data (i32.const 1272) "\01\00\00\00*\00\00\00O\00b\00j\00e\00c\00t\00 \00a\00l\00r\00e\00a\00d\00y\00 \00p\00i\00n\00n\00e\00d")
- (data (i32.const 1356) "<")
- (data (i32.const 1368) "\01\00\00\00(\00\00\00O\00b\00j\00e\00c\00t\00 \00i\00s\00 \00n\00o\00t\00 \00p\00i\00n\00n\00e\00d")
- (data (i32.const 1456) "\03\00\00\00 \00\00\00\00\00\00\00 ")
+ (data (i32.const 1164) ",")
+ (data (i32.const 1176) "\01\00\00\00\1a\00\00\00~\00l\00i\00b\00/\00r\00t\00/\00l\00m\00.\00t\00s")
+ (data (i32.const 1244) "<")
+ (data (i32.const 1256) "\01\00\00\00*\00\00\00O\00b\00j\00e\00c\00t\00 \00a\00l\00r\00e\00a\00d\00y\00 \00p\00i\00n\00n\00e\00d")
+ (data (i32.const 1340) "<")
+ (data (i32.const 1352) "\01\00\00\00(\00\00\00O\00b\00j\00e\00c\00t\00 \00i\00s\00 \00n\00o\00t\00 \00p\00i\00n\00n\00e\00d")
+ (data (i32.const 1440) "\03\00\00\00 \00\00\00\00\00\00\00 ")
  (export "__new" (func $~lib/rt/tcms/__new))
  (export "__pin" (func $~lib/rt/tcms/__pin))
  (export "__unpin" (func $~lib/rt/tcms/__unpin))
@@ -33,728 +31,298 @@
  (export "__rtti_base" (global $~lib/rt/__rtti_base))
  (export "memory" (memory $0))
  (start $~start)
- (func $~lib/rt/tlsf/removeBlock (param $0 i32) (param $1 i32)
+ (func $~lib/rt/lm/__alloc (param $0 i32) (result i32)
+  (local $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
-  (local $5 i32)
-  local.get $1
-  i32.load $0
-  local.tee $2
-  i32.const 1
-  i32.and
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1184
-   i32.const 268
-   i32.const 14
-   call $~lib/builtins/abort
-   unreachable
-  end
-  local.get $2
+  local.get $0
+  i32.const 3
+  i32.add
   i32.const -4
   i32.and
   local.tee $2
-  i32.const 12
-  i32.lt_u
-  if
-   i32.const 0
-   i32.const 1184
-   i32.const 270
-   i32.const 14
-   call $~lib/builtins/abort
-   unreachable
-  end
-  local.get $2
-  i32.const 256
-  i32.lt_u
-  if (result i32)
-   local.get $2
-   i32.const 4
-   i32.shr_u
-  else
-   i32.const 31
-   i32.const 1073741820
-   local.get $2
-   local.get $2
-   i32.const 1073741820
-   i32.ge_u
-   select
-   local.tee $2
-   i32.clz
-   i32.sub
-   local.tee $4
-   i32.const 7
-   i32.sub
-   local.set $3
-   local.get $2
-   local.get $4
-   i32.const 4
-   i32.sub
-   i32.shr_u
-   i32.const 16
-   i32.xor
-  end
-  local.tee $2
-  i32.const 16
-  i32.lt_u
-  local.get $3
-  i32.const 23
-  i32.lt_u
-  i32.and
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1184
-   i32.const 284
-   i32.const 14
-   call $~lib/builtins/abort
-   unreachable
-  end
-  local.get $1
-  i32.load $0 offset=8
-  local.set $5
-  local.get $1
-  i32.load $0 offset=4
-  local.tee $4
-  if
-   local.get $4
-   local.get $5
-   i32.store $0 offset=8
-  end
-  local.get $5
-  if
-   local.get $5
-   local.get $4
-   i32.store $0 offset=4
-  end
-  local.get $1
-  local.get $0
-  local.get $3
-  i32.const 4
-  i32.shl
-  local.get $2
-  i32.add
-  i32.const 2
-  i32.shl
-  i32.add
-  i32.load $0 offset=96
-  i32.eq
-  if
-   local.get $0
-   local.get $3
-   i32.const 4
-   i32.shl
-   local.get $2
-   i32.add
-   i32.const 2
-   i32.shl
-   i32.add
-   local.get $5
-   i32.store $0 offset=96
-   local.get $5
-   i32.eqz
-   if
-    local.get $0
-    local.get $3
-    i32.const 2
-    i32.shl
-    i32.add
-    local.tee $1
-    i32.load $0 offset=4
-    i32.const -2
-    local.get $2
-    i32.rotl
-    i32.and
-    local.set $2
-    local.get $1
-    local.get $2
-    i32.store $0 offset=4
-    local.get $2
-    i32.eqz
-    if
-     local.get $0
-     local.get $0
-     i32.load $0
-     i32.const -2
-     local.get $3
-     i32.rotl
-     i32.and
-     i32.store $0
-    end
-   end
-  end
- )
- (func $~lib/rt/tlsf/insertBlock (param $0 i32) (param $1 i32)
-  (local $2 i32)
-  (local $3 i32)
-  (local $4 i32)
-  (local $5 i32)
-  (local $6 i32)
-  local.get $1
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1184
-   i32.const 201
-   i32.const 14
-   call $~lib/builtins/abort
-   unreachable
-  end
-  local.get $1
-  i32.load $0
-  local.tee $3
-  i32.const 1
-  i32.and
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1184
-   i32.const 203
-   i32.const 14
-   call $~lib/builtins/abort
-   unreachable
-  end
-  local.get $1
-  i32.const 4
-  i32.add
-  local.get $1
-  i32.load $0
-  i32.const -4
-  i32.and
-  i32.add
-  local.tee $4
-  i32.load $0
-  local.tee $2
-  i32.const 1
-  i32.and
-  if
-   local.get $0
-   local.get $4
-   call $~lib/rt/tlsf/removeBlock
-   local.get $1
-   local.get $3
-   i32.const 4
-   i32.add
-   local.get $2
-   i32.const -4
-   i32.and
-   i32.add
-   local.tee $3
-   i32.store $0
-   local.get $1
-   i32.const 4
-   i32.add
-   local.get $1
-   i32.load $0
-   i32.const -4
-   i32.and
-   i32.add
-   local.tee $4
-   i32.load $0
-   local.set $2
-  end
-  local.get $3
-  i32.const 2
-  i32.and
-  if
-   local.get $1
-   i32.const 4
-   i32.sub
-   i32.load $0
-   local.tee $1
-   i32.load $0
-   local.tee $6
-   i32.const 1
-   i32.and
-   i32.eqz
-   if
-    i32.const 0
-    i32.const 1184
-    i32.const 221
-    i32.const 16
-    call $~lib/builtins/abort
-    unreachable
-   end
-   local.get $0
-   local.get $1
-   call $~lib/rt/tlsf/removeBlock
-   local.get $1
-   local.get $6
-   i32.const 4
-   i32.add
-   local.get $3
-   i32.const -4
-   i32.and
-   i32.add
-   local.tee $3
-   i32.store $0
-  end
-  local.get $4
-  local.get $2
-  i32.const 2
-  i32.or
-  i32.store $0
-  local.get $3
-  i32.const -4
-  i32.and
-  local.tee $2
-  i32.const 12
-  i32.lt_u
-  if
-   i32.const 0
-   i32.const 1184
-   i32.const 233
-   i32.const 14
-   call $~lib/builtins/abort
-   unreachable
-  end
-  local.get $4
-  local.get $1
-  i32.const 4
-  i32.add
-  local.get $2
-  i32.add
-  i32.ne
-  if
-   i32.const 0
-   i32.const 1184
-   i32.const 234
-   i32.const 14
-   call $~lib/builtins/abort
-   unreachable
-  end
-  local.get $4
-  i32.const 4
-  i32.sub
-  local.get $1
-  i32.store $0
-  local.get $2
-  i32.const 256
-  i32.lt_u
-  if (result i32)
-   local.get $2
-   i32.const 4
-   i32.shr_u
-  else
-   i32.const 31
-   i32.const 1073741820
-   local.get $2
-   local.get $2
-   i32.const 1073741820
-   i32.ge_u
-   select
-   local.tee $2
-   i32.clz
-   i32.sub
-   local.tee $3
-   i32.const 7
-   i32.sub
-   local.set $5
-   local.get $2
-   local.get $3
-   i32.const 4
-   i32.sub
-   i32.shr_u
-   i32.const 16
-   i32.xor
-  end
-  local.tee $2
-  i32.const 16
-  i32.lt_u
-  local.get $5
-  i32.const 23
-  i32.lt_u
-  i32.and
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1184
-   i32.const 251
-   i32.const 14
-   call $~lib/builtins/abort
-   unreachable
-  end
-  local.get $0
-  local.get $5
-  i32.const 4
-  i32.shl
-  local.get $2
-  i32.add
-  i32.const 2
-  i32.shl
-  i32.add
-  i32.load $0 offset=96
-  local.set $3
-  local.get $1
-  i32.const 0
-  i32.store $0 offset=4
-  local.get $1
-  local.get $3
-  i32.store $0 offset=8
-  local.get $3
-  if
-   local.get $3
-   local.get $1
-   i32.store $0 offset=4
-  end
-  local.get $0
-  local.get $5
-  i32.const 4
-  i32.shl
-  local.get $2
-  i32.add
-  i32.const 2
-  i32.shl
-  i32.add
-  local.get $1
-  i32.store $0 offset=96
-  local.get $0
-  local.get $0
-  i32.load $0
-  i32.const 1
-  local.get $5
-  i32.shl
-  i32.or
-  i32.store $0
-  local.get $0
-  local.get $5
-  i32.const 2
-  i32.shl
-  i32.add
-  local.tee $0
-  local.get $0
-  i32.load $0 offset=4
-  i32.const 1
-  local.get $2
-  i32.shl
-  i32.or
-  i32.store $0 offset=4
- )
- (func $~lib/rt/tlsf/addMemory (param $0 i32) (param $1 i32) (param $2 i32)
-  (local $3 i32)
-  (local $4 i32)
-  local.get $1
-  local.get $2
+  i32.const 1073741820
   i32.gt_u
   if
-   i32.const 0
+   i32.const 1056
    i32.const 1184
-   i32.const 377
-   i32.const 14
+   i32.const 122
+   i32.const 31
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $1
-  i32.const 19
-  i32.add
-  i32.const -16
-  i32.and
-  i32.const 4
-  i32.sub
-  local.set $1
-  local.get $0
-  i32.load $0 offset=1568
-  local.tee $4
+  global.get $~lib/rt/lm/freelist
+  i32.eqz
   if
-   local.get $4
-   i32.const 4
-   i32.add
-   local.get $1
-   i32.gt_u
-   if
-    i32.const 0
-    i32.const 1184
-    i32.const 384
-    i32.const 16
-    call $~lib/builtins/abort
-    unreachable
-   end
-   local.get $1
-   i32.const 16
-   i32.sub
-   local.get $4
-   i32.eq
-   if
-    local.get $4
-    i32.load $0
-    local.set $3
-    local.get $1
-    i32.const 16
+   i32.const 1024
+   global.set $~lib/rt/lm/freelist
+   i32.const 1028
+   i32.const 1024
+   i32.store $0
+   i32.const 1024
+   i32.const 1024
+   i32.store $0
+   memory.size $0
+   local.tee $0
+   i32.const 0
+   i32.le_s
+   if (result i32)
+    i32.const 1
+    local.get $0
     i32.sub
-    local.set $1
-   end
-  else
-   local.get $0
-   i32.const 1572
-   i32.add
-   local.get $1
-   i32.gt_u
-   if
+    memory.grow $0
     i32.const 0
-    i32.const 1184
-    i32.const 397
-    i32.const 5
-    call $~lib/builtins/abort
+    i32.lt_s
+   else
+    i32.const 0
+   end
+   if
     unreachable
    end
+   global.get $~lib/rt/lm/freelist
+   local.tee $0
+   i32.const 1476
+   i32.store $0
+   i32.const 1480
+   local.get $0
+   i32.store $0
+   i32.const 1476
+   local.get $0
+   i32.store $0
+   local.get $0
+   i32.const 1476
+   i32.store $0 offset=4
+   i32.const 1484
+   memory.size $0
+   i32.const 16
+   i32.shl
+   i32.const 1488
+   i32.sub
+   i32.store $0
   end
-  local.get $2
-  i32.const -16
-  i32.and
-  local.get $1
-  i32.sub
-  local.tee $2
-  i32.const 20
-  i32.lt_u
+  i32.const 0
+  local.set $0
+  global.get $~lib/rt/lm/freelist
+  i32.load $0 offset=4
+  local.set $1
+  loop $for-loop|0
+   local.get $1
+   i32.const 1024
+   i32.ne
+   if (result i32)
+    local.get $1
+    i32.load $0 offset=4
+   else
+    i32.const 0
+   end
+   if
+    local.get $1
+    local.get $0
+    local.get $1
+    i32.load $0 offset=8
+    local.get $2
+    i32.gt_u
+    select
+    local.set $0
+    local.get $1
+    i32.load $0 offset=4
+    local.set $1
+    br $for-loop|0
+   end
+  end
+  local.get $0
+  i32.eqz
   if
-   return
-  end
-  local.get $1
-  local.get $3
-  i32.const 2
-  i32.and
-  local.get $2
-  i32.const 8
-  i32.sub
-  local.tee $2
-  i32.const 1
-  i32.or
-  i32.or
-  i32.store $0
-  local.get $1
-  i32.const 0
-  i32.store $0 offset=4
-  local.get $1
-  i32.const 0
-  i32.store $0 offset=8
-  local.get $1
-  i32.const 4
-  i32.add
-  local.get $2
-  i32.add
-  local.tee $2
-  i32.const 2
-  i32.store $0
-  local.get $0
-  local.get $2
-  i32.store $0 offset=1568
-  local.get $0
-  local.get $1
-  call $~lib/rt/tlsf/insertBlock
- )
- (func $~lib/rt/tlsf/initialize
-  (local $0 i32)
-  (local $1 i32)
-  memory.size $0
-  local.tee $1
-  i32.const 0
-  i32.le_s
-  if (result i32)
-   i32.const 1
+   local.get $2
+   i32.const 16
+   memory.size $0
+   local.tee $1
+   i32.const 16
+   i32.shl
+   local.tee $3
+   i32.const 12
+   i32.add
+   local.tee $4
+   i32.const 15
+   i32.and
+   i32.sub
+   local.tee $0
+   local.get $4
+   i32.add
+   i32.add
+   i32.const 65535
+   i32.add
+   i32.const -65536
+   i32.and
+   i32.const 16
+   i32.shr_u
    local.get $1
    i32.sub
    memory.grow $0
    i32.const 0
    i32.lt_s
-  else
-   i32.const 0
-  end
-  if
-   unreachable
-  end
-  i32.const 1488
-  i32.const 0
-  i32.store $0
-  i32.const 3056
-  i32.const 0
-  i32.store $0
-  loop $for-loop|0
-   local.get $0
-   i32.const 23
-   i32.lt_u
    if
-    local.get $0
-    i32.const 2
-    i32.shl
-    i32.const 1488
-    i32.add
-    i32.const 0
-    i32.store $0 offset=4
-    i32.const 0
-    local.set $1
-    loop $for-loop|1
+    unreachable
+   end
+   local.get $0
+   local.get $3
+   i32.add
+   local.tee $3
+   memory.size $0
+   local.get $1
+   i32.sub
+   i32.const 16
+   i32.shl
+   i32.const 12
+   i32.sub
+   local.get $0
+   i32.sub
+   i32.store $0 offset=8
+   global.get $~lib/rt/lm/freelist
+   local.tee $1
+   i32.load $0
+   local.set $0
+   local.get $1
+   local.get $3
+   i32.store $0
+   local.get $3
+   local.get $1
+   i32.store $0 offset=4
+   local.get $3
+   local.get $0
+   i32.store $0
+   local.get $0
+   local.get $3
+   i32.store $0 offset=4
+   i32.const 0
+   local.set $0
+   local.get $1
+   i32.load $0 offset=4
+   local.set $1
+   loop $for-loop|1
+    local.get $1
+    i32.const 1024
+    i32.ne
+    if (result i32)
      local.get $1
-     i32.const 16
-     i32.lt_u
-     if
-      local.get $0
-      i32.const 4
-      i32.shl
-      local.get $1
-      i32.add
-      i32.const 2
-      i32.shl
-      i32.const 1488
-      i32.add
-      i32.const 0
-      i32.store $0 offset=96
-      local.get $1
-      i32.const 1
-      i32.add
-      local.set $1
-      br $for-loop|1
-     end
+     i32.load $0 offset=4
+    else
+     i32.const 0
     end
-    local.get $0
-    i32.const 1
-    i32.add
-    local.set $0
-    br $for-loop|0
+    if
+     local.get $1
+     local.get $0
+     local.get $1
+     i32.load $0 offset=8
+     local.get $2
+     i32.gt_u
+     select
+     local.set $0
+     local.get $1
+     i32.load $0 offset=4
+     local.set $1
+     br $for-loop|1
+    end
+   end
+   local.get $0
+   i32.eqz
+   if
+    unreachable
    end
   end
-  i32.const 1488
-  i32.const 3060
-  memory.size $0
-  i32.const 16
-  i32.shl
-  call $~lib/rt/tlsf/addMemory
-  i32.const 1488
-  global.set $~lib/rt/tlsf/ROOT
- )
- (func $~lib/rt/tlsf/searchBlock (param $0 i32) (param $1 i32) (result i32)
-  (local $2 i32)
-  (local $3 i32)
-  local.get $1
-  i32.const 256
-  i32.lt_u
-  if (result i32)
-   local.get $1
-   i32.const 4
-   i32.shr_u
-  else
-   i32.const 31
-   local.get $1
-   i32.const 1
-   i32.const 27
-   local.get $1
-   i32.clz
-   i32.sub
-   i32.shl
+  local.get $0
+  i32.load $0 offset=8
+  local.get $2
+  i32.sub
+  i32.const 12
+  i32.gt_u
+  if
+   i32.const 16
+   local.get $0
+   local.get $2
    i32.add
-   i32.const 1
-   i32.sub
-   local.get $1
-   local.get $1
-   i32.const 536870910
-   i32.lt_u
-   select
+   i32.const 12
+   i32.add
    local.tee $1
-   i32.clz
+   i32.const 12
+   i32.add
+   i32.const 15
+   i32.and
    i32.sub
    local.tee $3
-   i32.const 7
-   i32.sub
+   local.get $2
+   i32.add
    local.set $2
    local.get $1
    local.get $3
-   i32.const 4
-   i32.sub
-   i32.shr_u
-   i32.const 16
-   i32.xor
+   i32.add
+   local.tee $1
+   i32.const 12
+   i32.add
+   local.get $0
+   local.get $0
+   i32.load $0 offset=8
+   i32.add
+   i32.le_u
+   if
+    local.get $1
+    local.get $0
+    i32.load $0 offset=8
+    local.get $2
+    i32.sub
+    i32.const 12
+    i32.sub
+    i32.store $0 offset=8
+    local.get $0
+    local.get $2
+    i32.store $0 offset=8
+    local.get $0
+    i32.load $0 offset=4
+    local.tee $2
+    local.get $1
+    i32.store $0
+    local.get $1
+    local.get $2
+    i32.store $0 offset=4
+    local.get $1
+    local.get $0
+    i32.store $0
+    local.get $0
+    local.get $1
+    i32.store $0 offset=4
+   end
   end
+  local.get $0
+  i32.load $0 offset=4
   local.tee $1
-  i32.const 16
-  i32.lt_u
-  local.get $2
-  i32.const 23
-  i32.lt_u
-  i32.and
-  i32.eqz
+  i32.const 0
+  local.get $0
+  i32.load $0
+  local.tee $2
+  select
   if
+   local.get $2
+   local.get $1
+   i32.store $0 offset=4
+   local.get $1
+   local.get $2
+   i32.store $0
+   local.get $0
    i32.const 0
-   i32.const 1184
-   i32.const 330
-   i32.const 14
-   call $~lib/builtins/abort
+   i32.store $0
+   local.get $0
+   i32.const 0
+   i32.store $0 offset=4
+  else
    unreachable
   end
   local.get $0
-  local.get $2
-  i32.const 2
-  i32.shl
+  i32.const 12
   i32.add
-  i32.load $0 offset=4
-  i32.const -1
-  local.get $1
-  i32.shl
-  i32.and
-  local.tee $1
-  if (result i32)
-   local.get $0
-   local.get $1
-   i32.ctz
-   local.get $2
-   i32.const 4
-   i32.shl
-   i32.add
-   i32.const 2
-   i32.shl
-   i32.add
-   i32.load $0 offset=96
-  else
-   local.get $0
-   i32.load $0
-   i32.const -1
-   local.get $2
-   i32.const 1
-   i32.add
-   i32.shl
-   i32.and
-   local.tee $1
-   if (result i32)
-    local.get $0
-    local.get $1
-    i32.ctz
-    local.tee $1
-    i32.const 2
-    i32.shl
-    i32.add
-    i32.load $0 offset=4
-    local.tee $2
-    i32.eqz
-    if
-     i32.const 0
-     i32.const 1184
-     i32.const 343
-     i32.const 18
-     call $~lib/builtins/abort
-     unreachable
-    end
-    local.get $0
-    local.get $2
-    i32.ctz
-    local.get $1
-    i32.const 4
-    i32.shl
-    i32.add
-    i32.const 2
-    i32.shl
-    i32.add
-    i32.load $0 offset=96
-   else
-    i32.const 0
-   end
-  end
  )
  (func $~lib/rt/tcms/__new (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
-  (local $3 i32)
-  (local $4 i32)
-  (local $5 i32)
-  (local $6 i32)
   local.get $0
   i32.const 1073741804
   i32.gt_u
@@ -766,204 +334,13 @@
    call $~lib/builtins/abort
    unreachable
   end
-  global.get $~lib/rt/tlsf/ROOT
-  i32.eqz
-  if
-   call $~lib/rt/tlsf/initialize
-  end
-  global.get $~lib/rt/tlsf/ROOT
-  local.set $4
   local.get $0
   i32.const 16
   i32.add
-  local.tee $2
-  i32.const 1073741820
-  i32.gt_u
-  if
-   i32.const 1056
-   i32.const 1184
-   i32.const 458
-   i32.const 29
-   call $~lib/builtins/abort
-   unreachable
-  end
-  local.get $4
-  i32.const 12
-  local.get $2
-  i32.const 19
-  i32.add
-  i32.const -16
-  i32.and
+  call $~lib/rt/lm/__alloc
   i32.const 4
   i32.sub
-  local.get $2
-  i32.const 12
-  i32.le_u
-  select
-  local.tee $5
-  call $~lib/rt/tlsf/searchBlock
   local.tee $2
-  i32.eqz
-  if
-   memory.size $0
-   local.tee $2
-   i32.const 4
-   local.get $4
-   i32.load $0 offset=1568
-   local.get $2
-   i32.const 16
-   i32.shl
-   i32.const 4
-   i32.sub
-   i32.ne
-   i32.shl
-   local.get $5
-   i32.const 1
-   i32.const 27
-   local.get $5
-   i32.clz
-   i32.sub
-   i32.shl
-   i32.const 1
-   i32.sub
-   i32.add
-   local.get $5
-   local.get $5
-   i32.const 536870910
-   i32.lt_u
-   select
-   i32.add
-   i32.const 65535
-   i32.add
-   i32.const -65536
-   i32.and
-   i32.const 16
-   i32.shr_u
-   local.tee $3
-   local.get $2
-   local.get $3
-   i32.gt_s
-   select
-   memory.grow $0
-   i32.const 0
-   i32.lt_s
-   if
-    local.get $3
-    memory.grow $0
-    i32.const 0
-    i32.lt_s
-    if
-     unreachable
-    end
-   end
-   local.get $4
-   local.get $2
-   i32.const 16
-   i32.shl
-   memory.size $0
-   i32.const 16
-   i32.shl
-   call $~lib/rt/tlsf/addMemory
-   local.get $4
-   local.get $5
-   call $~lib/rt/tlsf/searchBlock
-   local.tee $2
-   i32.eqz
-   if
-    i32.const 0
-    i32.const 1184
-    i32.const 496
-    i32.const 16
-    call $~lib/builtins/abort
-    unreachable
-   end
-  end
-  local.get $5
-  local.get $2
-  i32.load $0
-  i32.const -4
-  i32.and
-  i32.gt_u
-  if
-   i32.const 0
-   i32.const 1184
-   i32.const 498
-   i32.const 14
-   call $~lib/builtins/abort
-   unreachable
-  end
-  local.get $4
-  local.get $2
-  call $~lib/rt/tlsf/removeBlock
-  local.get $2
-  i32.load $0
-  local.set $3
-  local.get $5
-  i32.const 4
-  i32.add
-  i32.const 15
-  i32.and
-  if
-   i32.const 0
-   i32.const 1184
-   i32.const 357
-   i32.const 14
-   call $~lib/builtins/abort
-   unreachable
-  end
-  local.get $3
-  i32.const -4
-  i32.and
-  local.get $5
-  i32.sub
-  local.tee $6
-  i32.const 16
-  i32.ge_u
-  if
-   local.get $2
-   local.get $5
-   local.get $3
-   i32.const 2
-   i32.and
-   i32.or
-   i32.store $0
-   local.get $2
-   i32.const 4
-   i32.add
-   local.get $5
-   i32.add
-   local.tee $3
-   local.get $6
-   i32.const 4
-   i32.sub
-   i32.const 1
-   i32.or
-   i32.store $0
-   local.get $4
-   local.get $3
-   call $~lib/rt/tlsf/insertBlock
-  else
-   local.get $2
-   local.get $3
-   i32.const -2
-   i32.and
-   i32.store $0
-   local.get $2
-   i32.const 4
-   i32.add
-   local.get $2
-   i32.load $0
-   i32.const -4
-   i32.and
-   i32.add
-   local.tee $3
-   local.get $3
-   i32.load $0
-   i32.const -3
-   i32.and
-   i32.store $0
-  end
-  local.get $2
   local.get $1
   i32.store $0 offset=12
   local.get $2
@@ -1018,7 +395,7 @@
    i32.load $0 offset=8
    i32.eqz
    local.get $0
-   i32.const 1484
+   i32.const 1468
    i32.lt_u
    i32.and
    i32.eqz
@@ -1072,7 +449,7 @@
    i32.const 3
    i32.eq
    if
-    i32.const 1280
+    i32.const 1264
     i32.const 1120
     i32.const 181
     i32.const 7
@@ -1125,7 +502,7 @@
   i32.const 3
   i32.ne
   if
-   i32.const 1376
+   i32.const 1360
    i32.const 1120
    i32.const 195
    i32.const 5
@@ -1166,24 +543,25 @@
   (local $4 i32)
   (local $5 i32)
   (local $6 i32)
+  (local $7 i32)
   i32.const 1056
   call $byn-split-outlined-A$~lib/rt/tcms/__visit
-  i32.const 1280
+  i32.const 1264
   call $byn-split-outlined-A$~lib/rt/tcms/__visit
-  i32.const 1376
+  i32.const 1360
   call $byn-split-outlined-A$~lib/rt/tcms/__visit
   global.get $~lib/rt/tcms/pinSpace
-  local.tee $1
+  local.tee $0
   i32.load $0 offset=4
   i32.const -4
   i32.and
-  local.set $0
+  local.set $1
   loop $while-continue|0
    local.get $0
    local.get $1
    i32.ne
    if
-    local.get $0
+    local.get $1
     i32.load $0 offset=4
     i32.const 3
     i32.and
@@ -1197,34 +575,34 @@
      call $~lib/builtins/abort
      unreachable
     end
-    local.get $0
+    local.get $1
     i32.const 20
     i32.add
     call $~lib/rt/__visit_members
-    local.get $0
+    local.get $1
     i32.load $0 offset=4
     i32.const -4
     i32.and
-    local.set $0
+    local.set $1
     br $while-continue|0
    end
   end
   global.get $~lib/rt/tcms/white
   i32.eqz
-  local.set $3
+  local.set $5
   global.get $~lib/rt/tcms/toSpace
-  local.tee $2
+  local.tee $4
   i32.load $0 offset=4
   i32.const -4
   i32.and
-  local.set $0
+  local.set $1
   loop $while-continue|1
-   local.get $0
-   local.get $2
+   local.get $1
+   local.get $4
    i32.ne
    if
-    local.get $3
-    local.get $0
+    local.get $5
+    local.get $1
     i32.load $0 offset=4
     i32.const 3
     i32.and
@@ -1237,31 +615,31 @@
      call $~lib/builtins/abort
      unreachable
     end
-    local.get $0
+    local.get $1
     i32.const 20
     i32.add
     call $~lib/rt/__visit_members
-    local.get $0
+    local.get $1
     i32.load $0 offset=4
     i32.const -4
     i32.and
-    local.set $0
+    local.set $1
     br $while-continue|1
    end
   end
   global.get $~lib/rt/tcms/fromSpace
-  local.tee $5
+  local.tee $6
   i32.load $0 offset=4
   i32.const -4
   i32.and
-  local.set $0
+  local.set $1
   loop $while-continue|2
-   local.get $0
-   local.get $5
+   local.get $1
+   local.get $6
    i32.ne
    if
     global.get $~lib/rt/tcms/white
-    local.get $0
+    local.get $1
     i32.load $0 offset=4
     i32.const 3
     i32.and
@@ -1274,24 +652,24 @@
      call $~lib/builtins/abort
      unreachable
     end
-    local.get $0
+    local.get $1
     i32.load $0 offset=4
     i32.const -4
     i32.and
-    local.set $1
-    local.get $0
-    i32.const 1484
+    local.set $0
+    local.get $1
+    i32.const 1468
     i32.lt_u
     if
-     local.get $0
+     local.get $1
      i32.const 0
      i32.store $0 offset=4
-     local.get $0
+     local.get $1
      i32.const 0
      i32.store $0 offset=8
     else
      global.get $~lib/rt/tcms/total
-     local.get $0
+     local.get $1
      i32.load $0
      i32.const -4
      i32.and
@@ -1299,73 +677,267 @@
      i32.add
      i32.sub
      global.set $~lib/rt/tcms/total
-     local.get $0
+     local.get $1
      i32.const 4
      i32.add
-     local.tee $0
-     i32.const 1484
-     i32.ge_u
+     local.tee $1
+     i32.eqz
      if
-      global.get $~lib/rt/tlsf/ROOT
-      i32.eqz
-      if
-       call $~lib/rt/tlsf/initialize
-      end
-      global.get $~lib/rt/tlsf/ROOT
-      local.set $6
-      local.get $0
-      i32.const 4
-      i32.sub
-      local.set $4
-      local.get $0
-      i32.const 15
-      i32.and
-      i32.const 1
-      local.get $0
-      select
+      unreachable
+     end
+     local.get $1
+     i32.const 12
+     i32.sub
+     local.set $3
+     i32.const 0
+     local.set $7
+     global.get $~lib/rt/lm/freelist
+     i32.load $0 offset=4
+     local.set $1
+     loop $for-loop|0
+      local.get $1
+      i32.const 1024
+      i32.ne
       if (result i32)
-       i32.const 1
+       local.get $1
+       i32.load $0 offset=4
       else
-       local.get $4
-       i32.load $0
-       i32.const 1
-       i32.and
+       i32.const 0
       end
       if
-       i32.const 0
-       i32.const 1184
-       i32.const 559
-       i32.const 3
-       call $~lib/builtins/abort
-       unreachable
+       block $for-break0
+        local.get $1
+        local.get $3
+        i32.gt_u
+        if
+         local.get $1
+         i32.load $0
+         local.set $2
+         local.get $1
+         local.get $3
+         i32.store $0
+         local.get $3
+         local.get $1
+         i32.store $0 offset=4
+         local.get $3
+         local.get $2
+         i32.store $0
+         local.get $2
+         local.get $3
+         i32.store $0 offset=4
+         i32.const 1
+         local.set $7
+         br $for-break0
+        end
+        local.get $1
+        i32.load $0 offset=4
+        local.set $1
+        br $for-loop|0
+       end
       end
-      local.get $4
-      local.get $4
+     end
+     local.get $7
+     i32.eqz
+     if
+      global.get $~lib/rt/lm/freelist
+      local.tee $2
       i32.load $0
-      i32.const 1
-      i32.or
+      local.set $1
+      local.get $2
+      local.get $3
       i32.store $0
-      local.get $6
-      local.get $4
-      call $~lib/rt/tlsf/insertBlock
+      local.get $3
+      local.get $2
+      i32.store $0 offset=4
+      local.get $3
+      local.get $1
+      i32.store $0
+      local.get $1
+      local.get $3
+      i32.store $0 offset=4
+     end
+     i32.const 1024
+     local.set $1
+     global.get $~lib/rt/lm/freelist
+     i32.load $0 offset=4
+     local.set $7
+     loop $for-loop|1
+      local.get $7
+      i32.const 1024
+      i32.ne
+      if (result i32)
+       local.get $7
+       i32.load $0 offset=4
+      else
+       i32.const 0
+      end
+      if
+       local.get $1
+       local.get $7
+       block $__inlined_func$~lib/rt/lm/mergeBlock (result i32)
+        local.get $7
+        i32.const 0
+        local.get $7
+        i32.load $0
+        local.tee $2
+        i32.const 0
+        local.get $7
+        i32.const 1024
+        i32.ne
+        local.get $2
+        i32.const 1024
+        i32.ne
+        i32.and
+        select
+        select
+        if
+         local.get $7
+         local.get $2
+         local.get $2
+         i32.load $0 offset=8
+         i32.add
+         i32.const 12
+         i32.add
+         local.tee $1
+         i32.sub
+         i32.const 12
+         i32.lt_u
+         if
+          local.get $2
+          local.get $2
+          i32.load $0 offset=8
+          local.get $7
+          local.get $7
+          i32.load $0 offset=8
+          i32.add
+          i32.const 12
+          i32.add
+          local.get $1
+          i32.sub
+          i32.add
+          i32.store $0 offset=8
+          local.get $7
+          i32.load $0 offset=4
+          local.tee $2
+          i32.const 0
+          local.get $7
+          i32.load $0
+          local.tee $1
+          select
+          if
+           local.get $1
+           local.get $2
+           i32.store $0 offset=4
+           local.get $2
+           local.get $1
+           i32.store $0
+           local.get $7
+           i32.const 0
+           i32.store $0
+           local.get $7
+           i32.const 0
+           i32.store $0 offset=4
+          else
+           unreachable
+          end
+          i32.const 1
+          br $__inlined_func$~lib/rt/lm/mergeBlock
+         end
+        end
+        i32.const 0
+       end
+       select
+       local.set $1
+       local.get $7
+       i32.load $0 offset=4
+       local.set $7
+       br $for-loop|1
+      end
+     end
+     local.get $1
+     i32.load $0 offset=4
+     local.tee $3
+     i32.const 0
+     local.get $1
+     i32.const 0
+     local.get $3
+     i32.const 1024
+     i32.ne
+     local.get $1
+     i32.const 1024
+     i32.ne
+     i32.and
+     select
+     select
+     if
+      local.get $3
+      local.get $1
+      local.get $1
+      i32.load $0 offset=8
+      i32.add
+      i32.const 12
+      i32.add
+      local.tee $2
+      i32.sub
+      i32.const 12
+      i32.lt_u
+      if
+       local.get $1
+       local.get $1
+       i32.load $0 offset=8
+       local.get $3
+       local.get $3
+       i32.load $0 offset=8
+       i32.add
+       i32.const 12
+       i32.add
+       local.get $2
+       i32.sub
+       i32.add
+       i32.store $0 offset=8
+       local.get $3
+       i32.load $0 offset=4
+       local.tee $2
+       i32.const 0
+       local.get $3
+       i32.load $0
+       local.tee $1
+       select
+       if
+        local.get $1
+        local.get $2
+        i32.store $0 offset=4
+        local.get $2
+        local.get $1
+        i32.store $0
+        local.get $3
+        i32.const 0
+        i32.store $0
+        local.get $3
+        i32.const 0
+        i32.store $0 offset=4
+       else
+        unreachable
+       end
+      end
      end
     end
-    local.get $1
-    local.set $0
+    local.get $0
+    local.set $1
     br $while-continue|2
    end
   end
-  local.get $5
-  local.get $5
+  local.get $6
+  local.get $6
   i32.store $0 offset=4
-  local.get $5
-  local.get $5
+  local.get $6
+  local.get $6
   i32.store $0 offset=8
-  local.get $2
+  local.get $4
   global.set $~lib/rt/tcms/fromSpace
-  local.get $5
+  local.get $6
   global.set $~lib/rt/tcms/toSpace
-  local.get $3
+  local.get $5
   global.set $~lib/rt/tcms/white
  )
  (func $~lib/rt/__visit_members (param $0 i32)
@@ -1395,29 +967,29 @@
   unreachable
  )
  (func $~start
-  i32.const 1236
-  i32.const 1232
+  i32.const 1220
+  i32.const 1216
   i32.store $0
-  i32.const 1240
-  i32.const 1232
+  i32.const 1224
+  i32.const 1216
   i32.store $0
-  i32.const 1232
+  i32.const 1216
   global.set $~lib/rt/tcms/fromSpace
-  i32.const 1332
-  i32.const 1328
+  i32.const 1316
+  i32.const 1312
   i32.store $0
-  i32.const 1336
-  i32.const 1328
+  i32.const 1320
+  i32.const 1312
   i32.store $0
-  i32.const 1328
+  i32.const 1312
   global.set $~lib/rt/tcms/pinSpace
-  i32.const 1428
-  i32.const 1424
+  i32.const 1412
+  i32.const 1408
   i32.store $0
-  i32.const 1432
-  i32.const 1424
+  i32.const 1416
+  i32.const 1408
   i32.store $0
-  i32.const 1424
+  i32.const 1408
   global.set $~lib/rt/tcms/toSpace
  )
  (func $byn-split-outlined-A$~lib/rt/tcms/__visit (param $0 i32)

--- a/tests/compiler/rt/runtime-minimal.debug.wat
+++ b/tests/compiler/rt/runtime-minimal.debug.wat
@@ -1,5 +1,7 @@
 (module
- (memory $0 0)
+ (global $~lib/rt/lm/freeListPtr i32 (i32.const 16))
+ (memory $0 1)
+ (data (i32.const 16) "\00\00\00\00")
  (table $0 1 1 funcref)
  (elem $0 (i32.const 1))
  (export "memory" (memory $0))

--- a/tests/compiler/rt/runtime-minimal.release.wat
+++ b/tests/compiler/rt/runtime-minimal.release.wat
@@ -1,4 +1,4 @@
 (module
- (memory $0 0)
+ (memory $0 1)
  (export "memory" (memory $0))
 )


### PR DESCRIPTION
Hi Maintainer,
I prepared a lighter memory allocator for ASC, the algorithm is following [LibMemory](https://github.com/embeddedartistry/libmemory).
Comparing with current TLSF solution, it has below advantages:

1. It can use `page fault` ([Link](https://en.wikipedia.org/wiki/Page_fault)) feature of OS / Runtime. 
2. Linearly memory grow
3. Smaller size of target files (wasm, wast and map file)
4. Easier logic for `free`, which is an advantage when manage smaller amount of object at same time.
5. It is compatible to current GC solution (`mmInfo` not needed for LibMemory, but I did not remove it yet)

Disadvantages:

1. O(n) logic for alloc and free, according to my [simple bench](https://github.com/JesseCodeBones/WastDemo/tree/main/02assemblyscript/03malloc_bench), when managing about 100~200 objects at the same time, TLSF will be more efficient than LibMemory solution.

Bench Result:
![image](https://user-images.githubusercontent.com/56120624/194741881-e6020cce-5e8b-4708-aeb1-52e531dc259c.png)
![image](https://user-images.githubusercontent.com/56120624/194741960-c9918187-ad44-4ba1-80f7-655a223df1a2.png)

Target file size:
![image](https://user-images.githubusercontent.com/56120624/194742026-3dfbb454-bfc5-4b67-aeae-8174321ceb8e.png)


- [x] I've read the contributing guidelines
- [x] I've added my name and email to the NOTICE file
