### PR TITLE
Ensure function locals are not in closures

### DIFF
--- a/src/compiler.ts
+++ b/src/compiler.ts
@@ -6106,6 +6106,15 @@ export class Compiler extends DiagnosticEmitter {
         let local = <Local>target;
         signature = local.type.signatureReference;
         if (signature) {
+          if (local.parent != flow.parentFunction) {
+            // TODO: closures
+            this.error(
+              DiagnosticCode.Not_implemented_0,
+              expression.range,
+              "Closures"
+            );
+            return module.unreachable();
+          }
           if (local.is(CommonFlags.INLINED)) {
             let inlinedValue = local.constantIntegerValue;
             if (this.options.isWasm64) {

--- a/tests/compiler/closure.json
+++ b/tests/compiler/closure.json
@@ -8,6 +8,8 @@
     "$local0; // closure 2",
     "AS100: Not implemented: Closures",
     "$local0; // closure 3",
+    "AS100: Not implemented: Closures",
+    "$local0(123); // closure 4",
     "EOF"
   ]
 }

--- a/tests/compiler/closure.ts
+++ b/tests/compiler/closure.ts
@@ -21,4 +21,11 @@ function testLet(): (value: i32) => i32 {
 }
 testLet();
 
+function testFuncParam($local0: (x: i32) => void): () => void {
+  return () => {
+    $local0(123); // closure 4
+  };
+}
+testFuncParam((x: i32) => {});
+
 ERROR("EOF");


### PR DESCRIPTION
While closures are detected for regular local variables, they are not detected for functions. This commit ensures functions are detected as well.

- [x] I've read the contributing guidelines
- [x] I've added my name and email to the NOTICE file
