### PR TITLE
fix: more information for runtime error

### DIFF
--- a/cli/index.js
+++ b/cli/index.js
@@ -639,7 +639,7 @@ export async function main(argv, options) {
     if (runtimeText == null) {
       runtimePath = runtimeName;
       runtimeText = await readFile(runtimePath + extension, baseDir);
-      if (runtimeText == null) return prepareResult(Error(`Runtime '${runtimeName}' not found.`));
+      if (runtimeText == null) return prepareResult(Error(`Runtime '${path.resolve(baseDir, runtimePath + extension)}' is not found.`));
     } else {
       runtimePath = `~lib/${runtimePath}`;
     }


### PR DESCRIPTION
Hi Maintainer,
I found customer runtime error log only contains the runtime path, actually the calculated path should contains the `baseDir` and `extension` information.
regards

- [x] I've read the contributing guidelines
- [x] I've added my name and email to the NOTICE file
