### PR TITLE
Expose import maps when generating web template

### DIFF
--- a/scripts/build-web.js
+++ b/scripts/build-web.js
@@ -14,7 +14,7 @@ const longVersion = pkg.dependencies.long.version;
 const distUrl = mainVersion === "0.0.0" ? `./` : `https://cdn.jsdelivr.net/npm/assemblyscript@${mainVersion}/dist/`;
 const binaryenUrl = `https://cdn.jsdelivr.net/npm/binaryen@${binaryenVersion}/index.js`;
 const longUrl = `https://cdn.jsdelivr.net/npm/long@${longVersion}/index.js`;
-const imports = {
+const importmap = {
   "imports": {
     "assemblyscript": `${distUrl}assemblyscript.js`,
     "assemblyscript/asc": `${distUrl}asc.js`,
@@ -23,14 +23,14 @@ const imports = {
   }
 };
 
-fs.writeFileSync(path.join(dirname, "..", "dist", "web.json"), `${JSON.stringify(imports, null, 2)}
+fs.writeFileSync(path.join(dirname, "..", "dist", "importmap.json"), `${JSON.stringify(importmap, null, 2)}
 `);
-fs.writeFileSync(path.join(dirname, "..", "dist", "web.js"), `export const importMap = ${JSON.stringify(imports, null, 2)}
-export default importMap;
+fs.writeFileSync(path.join(dirname, "..", "dist", "importmap.js"), `export const importmap = ${JSON.stringify(importmap, null, 2)}
+export default importmap;
 `);
 fs.writeFileSync(path.join(dirname, "..", "dist", "web.html"), `<script async src="https://cdn.jsdelivr.net/npm/es-module-shims@1/dist/es-module-shims.js"></script>
 <script type="importmap">
-${JSON.stringify(imports, null, 2)}
+${JSON.stringify(importmap, null, 2)}
 </script>
 <script type="module">
 import asc from "assemblyscript/asc";

--- a/scripts/build-web.js
+++ b/scripts/build-web.js
@@ -11,20 +11,26 @@ const mainVersion = pkg.version;
 const binaryenVersion = pkg.dependencies.binaryen.version;
 const longVersion = pkg.dependencies.long.version;
 
-const distUrl = mainVersion === "0.0.0" ? `../dist/` : `https://cdn.jsdelivr.net/npm/assemblyscript@${mainVersion}/dist/`;
+const distUrl = mainVersion === "0.0.0" ? `./` : `https://cdn.jsdelivr.net/npm/assemblyscript@${mainVersion}/dist/`;
 const binaryenUrl = `https://cdn.jsdelivr.net/npm/binaryen@${binaryenVersion}/index.js`;
 const longUrl = `https://cdn.jsdelivr.net/npm/long@${longVersion}/index.js`;
-
-fs.writeFileSync(path.join(dirname, "..", "dist", "web.html"), `<script async src="https://cdn.jsdelivr.net/npm/es-module-shims@1.3.2/dist/es-module-shims.js"></script>
-<script type="importmap">
-{
+const imports = {
   "imports": {
-    "binaryen": ${JSON.stringify(binaryenUrl)},
-    "long": ${JSON.stringify(longUrl)},
-    "assemblyscript": ${JSON.stringify(distUrl + "assemblyscript.js")},
-    "assemblyscript/asc": ${JSON.stringify(distUrl + "asc.js")}
+    "assemblyscript": `${distUrl}assemblyscript.js`,
+    "assemblyscript/asc": `${distUrl}asc.js`,
+    "binaryen": binaryenUrl,
+    "long": longUrl
   }
-}
+};
+
+fs.writeFileSync(path.join(dirname, "..", "dist", "web.json"), `${JSON.stringify(imports, null, 2)}
+`);
+fs.writeFileSync(path.join(dirname, "..", "dist", "web.js"), `export const importMap = ${JSON.stringify(imports, null, 2)}
+export default importMap;
+`);
+fs.writeFileSync(path.join(dirname, "..", "dist", "web.html"), `<script async src="https://cdn.jsdelivr.net/npm/es-module-shims@1/dist/es-module-shims.js"></script>
+<script type="importmap">
+${JSON.stringify(imports, null, 2)}
 </script>
 <script type="module">
 import asc from "assemblyscript/asc";


### PR DESCRIPTION
Generates two additional files as part of the web template: `importmap.json` containing the import map, and `importmap.js` exporting the import map. Should help to automate setting up the compiler without manually editing versions, as we currently do on the website.

- [x] I've read the contributing guidelines
- [x] I've added my name and email to the NOTICE file
