### PR TITLE
Move module creation to program

### DIFF
--- a/src/compiler.ts
+++ b/src/compiler.ts
@@ -388,12 +388,12 @@ export class Compiler extends DiagnosticEmitter {
 
   /** Program reference. */
   program: Program;
-  /** Resolver reference. */
-  get resolver(): Resolver { return this.program.resolver; }
+  /** Module instance being compiled. */
+  get module(): Module { return this.program.module; }
   /** Provided options. */
   get options(): Options { return this.program.options; }
-  /** Module instance being compiled. */
-  module: Module;
+  /** Resolver reference. */
+  get resolver(): Resolver { return this.program.resolver; }
 
   /** Current control flow. */
   currentFlow: Flow;
@@ -443,9 +443,8 @@ export class Compiler extends DiagnosticEmitter {
   constructor(program: Program) {
     super(program.diagnostics);
     this.program = program;
+    let module = program.module;
     let options = program.options;
-    let module = Module.create(options.stackSize > 0, options.sizeTypeRef);
-    this.module = module;
     if (options.memoryBase) {
       this.memoryOffset = i64_new(options.memoryBase);
       module.setLowMemoryUnused(false);

--- a/src/program.ts
+++ b/src/program.ts
@@ -432,6 +432,7 @@ export class Program extends DiagnosticEmitter {
     super(diagnostics);
     let nativeSource = new Source(SourceKind.LibraryEntry, LIBRARY_PREFIX + "native.ts", "[native code]");
     this.nativeSource = nativeSource;
+    this.module = Module.create(options.stackSize > 0, options.sizeTypeRef);
     this.parser = new Parser(this.diagnostics, this.sources);
     this.resolver = new Resolver(this);
     let nativeFile = new File(this, nativeSource);
@@ -439,6 +440,8 @@ export class Program extends DiagnosticEmitter {
     this.filesByName.set(nativeFile.internalName, nativeFile);
   }
 
+  /** Module instance. */
+  module: Module;
   /** Parser instance. */
   parser: Parser;
   /** Resolver instance. */


### PR DESCRIPTION
Moves creation of the module to the program, which is the common link between all of parser, resolver, compiler *and* module. With the change, it for example becomes possible to assign names of program elements when building compound types for classes and signatures, where previously there was a missing reference to the module (type => program !=> module) the names are supposed to be added to.

- [x] I've read the contributing guidelines
- [x] I've added my name and email to the NOTICE file
