### PR TITLE
Fix CI publishing

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -11,6 +11,7 @@ jobs:
     - uses: actions/checkout@v3
       with:
         ref: main
+        fetch-depth: 0
     - uses: dcodeIO/setup-node-nvm@master
       with:
         node-version: current


### PR DESCRIPTION
Follow-up to #2541. Recent versions of `actions/checkout` fetch with `depth=1`, then missing commit history and tags necessary for publishing.

- [x] I've read the contributing guidelines
- [x] I've added my name and email to the NOTICE file
