### PR TITLE
Simplify compileCallExpression

### DIFF
--- a/src/compiler.ts
+++ b/src/compiler.ts
@@ -6025,7 +6025,7 @@ export class Compiler extends DiagnosticEmitter {
 
     // handle indirect call
     let functionArg = this.compileExpression(expression.expression, Type.auto);
-    let signature = this.currentType.signatureReference;
+    let signature = this.currentType.getSignature();
     if (signature) {
       return this.compileCallIndirect(
         signature,

--- a/src/diagnosticMessages.json
+++ b/src/diagnosticMessages.json
@@ -199,6 +199,7 @@
   "File '{0}' not found.": 6054,
   "Numeric separators are not allowed here.": 6188,
   "Multiple consecutive numeric separators are not permitted.": 6189,
+  "This expression is not callable because it is a 'get' accessor. Did you mean to use it without '()'?": 6234,
   "'super' must be called before accessing 'this' in the constructor of a derived class.": 17009,
   "'super' must be called before accessing a property of 'super' in the constructor of a derived class.": 17011
 }

--- a/src/resolver.ts
+++ b/src/resolver.ts
@@ -2441,9 +2441,13 @@ export class Resolver extends DiagnosticEmitter {
         ) {
           return this.resolveExpression(node.args[0], ctxFlow, ctxType, reportMode);
         }
-        let instance = this.maybeInferCall(node, functionPrototype, ctxFlow, reportMode);
-        if (!instance) return null;
-        return instance.signature.returnType;
+        let functionInstance = this.maybeInferCall(node, functionPrototype, ctxFlow, reportMode);
+        if (!functionInstance) return null;
+        target = functionInstance;
+        // fall-through
+      }
+      case ElementKind.Function: {
+        return (<Function>target).signature.returnType;
       }
       case ElementKind.PropertyPrototype: {
         let propertyInstance = this.resolveProperty(<PropertyPrototype>target, reportMode);

--- a/src/resolver.ts
+++ b/src/resolver.ts
@@ -2455,25 +2455,18 @@ export class Resolver extends DiagnosticEmitter {
         target = propertyInstance;
         // fall-through
       }
-      case ElementKind.Global:
-      case ElementKind.Local:
-      case ElementKind.Property: {
-        let varType = (<VariableLikeElement>target).type;
-        let varElement = this.getElementOfType(varType);
-        if (!varElement || varElement.kind != ElementKind.Class) {
-          break;
-        }
-        target = varElement;
+      default: {
+        if (!isTypedElement(target.kind)) break;
+        let targetElement = this.getElementOfType((<TypedElement>target).type);
+        if (!targetElement || targetElement.kind != ElementKind.Class) break;
+        target = targetElement;
         // fall-through
       }
       case ElementKind.Class: {
         let typeArguments = (<Class>target).getTypeArgumentsTo(this.program.functionPrototype);
-        if (typeArguments && typeArguments.length > 0) {
-          let ftype = typeArguments[0];
-          let signatureReference = assert(ftype.signatureReference);
-          return signatureReference.returnType;
-        }
-        break;
+        if (!(typeArguments && typeArguments.length)) break;
+        let signature = assert(typeArguments[0].getSignature());
+        return signature.returnType;
       }
     }
     if (reportMode == ReportMode.Report) {

--- a/tests/compiler/assert-nonnull.debug.wat
+++ b/tests/compiler/assert-nonnull.debug.wat
@@ -69,23 +69,27 @@
   i32.load $0 offset=4
  )
  (func $assert-nonnull/testFn (type $i32_=>_i32) (param $fn i32) (result i32)
+  (local $1 i32)
   i32.const 0
   global.set $~argumentsLength
   local.get $fn
+  local.tee $1
+  if (result i32)
+   local.get $1
+  else
+   i32.const 32
+   i32.const 96
+   i32.const 35
+   i32.const 10
+   call $~lib/builtins/abort
+   unreachable
+  end
   i32.load $0
   call_indirect $0 (type $none_=>_i32)
  )
  (func $assert-nonnull/Foo#get:baz (type $i32_=>_i32) (param $this i32) (result i32)
   local.get $this
   i32.load $0 offset=4
- )
- (func $assert-nonnull/testObjFn (type $i32_=>_i32) (param $foo i32) (result i32)
-  i32.const 0
-  global.set $~argumentsLength
-  local.get $foo
-  call $assert-nonnull/Foo#get:baz
-  i32.load $0
-  call_indirect $0 (type $none_=>_i32)
  )
  (func $~stack_check (type $none_=>_none)
   global.get $~lib/memory/__stack_pointer
@@ -538,6 +542,7 @@
  (func $assert-nonnull/testRet (type $i32_=>_i32) (param $fn i32) (result i32)
   (local $1 i32)
   (local $2 i32)
+  (local $3 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 4
   i32.sub
@@ -550,11 +555,7 @@
   i32.const 0
   global.set $~argumentsLength
   local.get $fn
-  i32.load $0
-  call_indirect $0 (type $none_=>_i32)
   local.tee $1
-  i32.store $0
-  local.get $1
   if (result i32)
    local.get $1
   else
@@ -565,14 +566,29 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.set $2
+  i32.load $0
+  call_indirect $0 (type $none_=>_i32)
+  local.tee $2
+  i32.store $0
+  local.get $2
+  if (result i32)
+   local.get $2
+  else
+   i32.const 32
+   i32.const 96
+   i32.const 44
+   i32.const 10
+   call $~lib/builtins/abort
+   unreachable
+  end
+  local.set $3
   global.get $~lib/memory/__stack_pointer
   i32.const 4
   i32.add
   global.set $~lib/memory/__stack_pointer
-  local.get $2
+  local.get $3
  )
- (func $assert-nonnull/testObjRet (type $i32_=>_i32) (param $foo i32) (result i32)
+ (func $assert-nonnull/testObjFn (type $i32_=>_i32) (param $foo i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   global.get $~lib/memory/__stack_pointer
@@ -583,13 +599,51 @@
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   i32.store $0
+  i32.const 0
+  global.set $~argumentsLength
+  global.get $~lib/memory/__stack_pointer
+  local.get $foo
+  call $assert-nonnull/Foo#get:baz
+  local.tee $1
+  i32.store $0
+  local.get $1
+  if (result i32)
+   local.get $1
+  else
+   i32.const 32
+   i32.const 96
+   i32.const 48
+   i32.const 10
+   call $~lib/builtins/abort
+   unreachable
+  end
+  i32.load $0
+  call_indirect $0 (type $none_=>_i32)
+  local.set $2
+  global.get $~lib/memory/__stack_pointer
+  i32.const 4
+  i32.add
+  global.set $~lib/memory/__stack_pointer
+  local.get $2
+ )
+ (func $assert-nonnull/testObjRet (type $i32_=>_i32) (param $foo i32) (result i32)
+  (local $1 i32)
+  (local $2 i32)
+  (local $3 i32)
+  global.get $~lib/memory/__stack_pointer
+  i32.const 8
+  i32.sub
+  global.set $~lib/memory/__stack_pointer
+  call $~stack_check
+  global.get $~lib/memory/__stack_pointer
+  i64.const 0
+  i64.store $0
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   global.set $~argumentsLength
+  global.get $~lib/memory/__stack_pointer
   local.get $foo
   call $assert-nonnull/Foo#get:baz
-  i32.load $0
-  call_indirect $0 (type $none_=>_i32)
   local.tee $1
   i32.store $0
   local.get $1
@@ -603,12 +657,27 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.set $2
+  i32.load $0
+  call_indirect $0 (type $none_=>_i32)
+  local.tee $2
+  i32.store $0 offset=4
+  local.get $2
+  if (result i32)
+   local.get $2
+  else
+   i32.const 32
+   i32.const 96
+   i32.const 52
+   i32.const 10
+   call $~lib/builtins/abort
+   unreachable
+  end
+  local.set $3
   global.get $~lib/memory/__stack_pointer
-  i32.const 4
+  i32.const 8
   i32.add
   global.set $~lib/memory/__stack_pointer
-  local.get $2
+  local.get $3
  )
  (func $export:assert-nonnull/testVar (type $i32_=>_i32) (param $0 i32) (result i32)
   (local $1 i32)

--- a/tests/compiler/assert-nonnull.release.wat
+++ b/tests/compiler/assert-nonnull.release.wat
@@ -571,6 +571,16 @@
   local.get $0
   i32.store $0
   local.get $0
+  i32.eqz
+  if
+   i32.const 1056
+   i32.const 1120
+   i32.const 35
+   i32.const 10
+   call $~lib/builtins/abort
+   unreachable
+  end
+  local.get $0
   i32.load $0
   call_indirect $0 (type $none_=>_i32)
   drop
@@ -635,48 +645,36 @@
   i32.const 4
   i32.sub
   global.set $~lib/memory/__stack_pointer
-  block $folding-inner0
-   global.get $~lib/memory/__stack_pointer
-   i32.const 1404
-   i32.lt_s
-   br_if $folding-inner0
-   global.get $~lib/memory/__stack_pointer
-   local.tee $1
-   local.get $0
-   i32.store $0
-   local.get $1
-   i32.const 4
-   i32.sub
-   global.set $~lib/memory/__stack_pointer
-   global.get $~lib/memory/__stack_pointer
-   i32.const 1404
-   i32.lt_s
-   br_if $folding-inner0
-   global.get $~lib/memory/__stack_pointer
-   i32.const 0
-   i32.store $0
-   local.get $0
-   i32.load $0
-   call_indirect $0 (type $none_=>_i32)
-   drop
-   unreachable
-  end
-  i32.const 34192
-  i32.const 34240
-  i32.const 1
-  i32.const 1
-  call $~lib/builtins/abort
-  unreachable
- )
- (func $export:assert-nonnull/testObjFn (type $i32_=>_i32) (param $0 i32) (result i32)
-  global.get $~lib/memory/__stack_pointer
-  i32.const 4
-  i32.sub
-  global.set $~lib/memory/__stack_pointer
-  global.get $~lib/memory/__stack_pointer
-  i32.const 1404
-  i32.lt_s
-  if
+  block $folding-inner1
+   block $folding-inner0
+    global.get $~lib/memory/__stack_pointer
+    i32.const 1404
+    i32.lt_s
+    br_if $folding-inner0
+    global.get $~lib/memory/__stack_pointer
+    local.tee $1
+    local.get $0
+    i32.store $0
+    local.get $1
+    i32.const 4
+    i32.sub
+    global.set $~lib/memory/__stack_pointer
+    global.get $~lib/memory/__stack_pointer
+    i32.const 1404
+    i32.lt_s
+    br_if $folding-inner0
+    global.get $~lib/memory/__stack_pointer
+    i32.const 0
+    i32.store $0
+    local.get $0
+    i32.eqz
+    br_if $folding-inner1
+    local.get $0
+    i32.load $0
+    call_indirect $0 (type $none_=>_i32)
+    drop
+    unreachable
+   end
    i32.const 34192
    i32.const 34240
    i32.const 1
@@ -684,17 +682,14 @@
    call $~lib/builtins/abort
    unreachable
   end
-  global.get $~lib/memory/__stack_pointer
-  local.get $0
-  i32.store $0
-  local.get $0
-  i32.load $0 offset=4
-  i32.load $0
-  call_indirect $0 (type $none_=>_i32)
-  drop
+  i32.const 1056
+  i32.const 1120
+  i32.const 44
+  i32.const 10
+  call $~lib/builtins/abort
   unreachable
  )
- (func $export:assert-nonnull/testObjRet (type $i32_=>_i32) (param $0 i32) (result i32)
+ (func $export:assert-nonnull/testObjFn (type $i32_=>_i32) (param $0 i32) (result i32)
   (local $1 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -718,10 +713,25 @@
    i32.lt_s
    br_if $folding-inner0
    global.get $~lib/memory/__stack_pointer
+   local.tee $1
    i32.const 0
    i32.store $0
+   local.get $1
    local.get $0
    i32.load $0 offset=4
+   local.tee $0
+   i32.store $0
+   local.get $0
+   i32.eqz
+   if
+    i32.const 1056
+    i32.const 1120
+    i32.const 48
+    i32.const 10
+    call $~lib/builtins/abort
+    unreachable
+   end
+   local.get $0
    i32.load $0
    call_indirect $0 (type $none_=>_i32)
    drop
@@ -731,6 +741,62 @@
   i32.const 34240
   i32.const 1
   i32.const 1
+  call $~lib/builtins/abort
+  unreachable
+ )
+ (func $export:assert-nonnull/testObjRet (type $i32_=>_i32) (param $0 i32) (result i32)
+  (local $1 i32)
+  global.get $~lib/memory/__stack_pointer
+  i32.const 4
+  i32.sub
+  global.set $~lib/memory/__stack_pointer
+  block $folding-inner1
+   block $folding-inner0
+    global.get $~lib/memory/__stack_pointer
+    i32.const 1404
+    i32.lt_s
+    br_if $folding-inner0
+    global.get $~lib/memory/__stack_pointer
+    local.tee $1
+    local.get $0
+    i32.store $0
+    local.get $1
+    i32.const 8
+    i32.sub
+    global.set $~lib/memory/__stack_pointer
+    global.get $~lib/memory/__stack_pointer
+    i32.const 1404
+    i32.lt_s
+    br_if $folding-inner0
+    global.get $~lib/memory/__stack_pointer
+    local.tee $1
+    i64.const 0
+    i64.store $0
+    local.get $1
+    local.get $0
+    i32.load $0 offset=4
+    local.tee $0
+    i32.store $0
+    local.get $0
+    i32.eqz
+    br_if $folding-inner1
+    local.get $0
+    i32.load $0
+    call_indirect $0 (type $none_=>_i32)
+    drop
+    unreachable
+   end
+   i32.const 34192
+   i32.const 34240
+   i32.const 1
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  i32.const 1056
+  i32.const 1120
+  i32.const 52
+  i32.const 10
   call $~lib/builtins/abort
   unreachable
  )

--- a/tests/compiler/std/array-access.debug.wat
+++ b/tests/compiler/std/array-access.debug.wat
@@ -10,6 +10,7 @@
  (global $~lib/shared/runtime/Runtime.Minimal i32 (i32.const 1))
  (global $~lib/shared/runtime/Runtime.Incremental i32 (i32.const 2))
  (global $~lib/native/ASC_SHRINK_LEVEL i32 (i32.const 0))
+ (global $~argumentsLength (mut i32) (i32.const 0))
  (global $~lib/memory/__data_end i32 (i32.const 284))
  (global $~lib/memory/__stack_pointer (mut i32) (i32.const 33052))
  (global $~lib/memory/__heap_base i32 (i32.const 33052))
@@ -26,6 +27,7 @@
  (export "stringArrayMethodCall" (func $export:std/array-access/stringArrayMethodCall))
  (export "stringArrayArrayPropertyAccess" (func $export:std/array-access/stringArrayArrayPropertyAccess))
  (export "stringArrayArrayMethodCall" (func $export:std/array-access/stringArrayArrayMethodCall))
+ (export "functionArrayElementCall" (func $export:std/array-access/functionArrayElementCall))
  (func $~lib/array/Array<~lib/array/Array<i32>>#get:length_ (type $i32_=>_i32) (param $this i32) (result i32)
   local.get $this
   i32.load $0 offset=12
@@ -248,6 +250,24 @@
  (func $~lib/array/Array<~lib/array/Array<~lib/string/String>>#get:dataStart (type $i32_=>_i32) (param $this i32) (result i32)
   local.get $this
   i32.load $0 offset=4
+ )
+ (func $~lib/array/Array<%28i32%29=>i32>#get:length_ (type $i32_=>_i32) (param $this i32) (result i32)
+  local.get $this
+  i32.load $0 offset=12
+ )
+ (func $~lib/array/Array<%28i32%29=>i32>#get:dataStart (type $i32_=>_i32) (param $this i32) (result i32)
+  local.get $this
+  i32.load $0 offset=4
+ )
+ (func $std/array-access/functionArrayElementCall (type $i32_=>_i32) (param $a i32) (result i32)
+  i32.const 123
+  i32.const 1
+  global.set $~argumentsLength
+  local.get $a
+  i32.const 0
+  call $~lib/array/Array<%28i32%29=>i32>#__get
+  i32.load $0
+  call_indirect $0 (type $i32_=>_i32)
  )
  (func $~stack_check (type $none_=>_none)
   global.get $~lib/memory/__stack_pointer
@@ -592,6 +612,62 @@
   global.set $~lib/memory/__stack_pointer
   local.get $3
  )
+ (func $~lib/array/Array<%28i32%29=>i32>#__get (type $i32_i32_=>_i32) (param $this i32) (param $index i32) (result i32)
+  (local $value i32)
+  (local $3 i32)
+  global.get $~lib/memory/__stack_pointer
+  i32.const 4
+  i32.sub
+  global.set $~lib/memory/__stack_pointer
+  call $~stack_check
+  global.get $~lib/memory/__stack_pointer
+  i32.const 0
+  i32.store $0
+  local.get $index
+  local.get $this
+  call $~lib/array/Array<%28i32%29=>i32>#get:length_
+  i32.ge_u
+  if
+   i32.const 32
+   i32.const 96
+   i32.const 114
+   i32.const 42
+   call $~lib/builtins/abort
+   unreachable
+  end
+  global.get $~lib/memory/__stack_pointer
+  local.get $this
+  call $~lib/array/Array<%28i32%29=>i32>#get:dataStart
+  local.get $index
+  i32.const 2
+  i32.shl
+  i32.add
+  i32.load $0
+  local.tee $value
+  i32.store $0
+  i32.const 1
+  drop
+  i32.const 0
+  i32.eqz
+  drop
+  local.get $value
+  i32.eqz
+  if
+   i32.const 144
+   i32.const 96
+   i32.const 118
+   i32.const 40
+   call $~lib/builtins/abort
+   unreachable
+  end
+  local.get $value
+  local.set $3
+  global.get $~lib/memory/__stack_pointer
+  i32.const 4
+  i32.add
+  global.set $~lib/memory/__stack_pointer
+  local.get $3
+ )
  (func $export:std/array-access/i32ArrayArrayElementAccess (type $i32_=>_i32) (param $0 i32) (result i32)
   (local $1 i32)
   global.get $~lib/memory/__stack_pointer
@@ -680,6 +756,25 @@
   i32.store $0
   local.get $0
   call $std/array-access/stringArrayArrayMethodCall
+  local.set $1
+  global.get $~lib/memory/__stack_pointer
+  i32.const 4
+  i32.add
+  global.set $~lib/memory/__stack_pointer
+  local.get $1
+ )
+ (func $export:std/array-access/functionArrayElementCall (type $i32_=>_i32) (param $0 i32) (result i32)
+  (local $1 i32)
+  global.get $~lib/memory/__stack_pointer
+  i32.const 4
+  i32.sub
+  global.set $~lib/memory/__stack_pointer
+  call $~stack_check
+  global.get $~lib/memory/__stack_pointer
+  local.get $0
+  i32.store $0
+  local.get $0
+  call $std/array-access/functionArrayElementCall
   local.set $1
   global.get $~lib/memory/__stack_pointer
   i32.const 4

--- a/tests/compiler/std/array-access.release.wat
+++ b/tests/compiler/std/array-access.release.wat
@@ -13,12 +13,14 @@
  (data (i32.const 1160) "\01\00\00\00^\00\00\00E\00l\00e\00m\00e\00n\00t\00 \00t\00y\00p\00e\00 \00m\00u\00s\00t\00 \00b\00e\00 \00n\00u\00l\00l\00a\00b\00l\00e\00 \00i\00f\00 \00a\00r\00r\00a\00y\00 \00i\00s\00 \00h\00o\00l\00e\00y")
  (data (i32.const 1276) "\1c")
  (data (i32.const 1288) "\01")
+ (table $0 1 1 funcref)
  (export "memory" (memory $0))
  (export "i32ArrayArrayElementAccess" (func $export:std/array-access/i32ArrayArrayElementAccess))
  (export "stringArrayPropertyAccess" (func $export:std/array-access/stringArrayPropertyAccess))
  (export "stringArrayMethodCall" (func $export:std/array-access/stringArrayMethodCall))
  (export "stringArrayArrayPropertyAccess" (func $export:std/array-access/stringArrayArrayPropertyAccess))
  (export "stringArrayArrayMethodCall" (func $export:std/array-access/stringArrayArrayMethodCall))
+ (export "functionArrayElementCall" (func $export:std/array-access/functionArrayElementCall))
  (func $~lib/string/String#startsWith (type $i32_=>_i32) (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
@@ -487,6 +489,34 @@
   i32.const 1
   i32.const 1
   call $~lib/builtins/abort
+  unreachable
+ )
+ (func $export:std/array-access/functionArrayElementCall (type $i32_=>_i32) (param $0 i32) (result i32)
+  global.get $~lib/memory/__stack_pointer
+  i32.const 4
+  i32.sub
+  global.set $~lib/memory/__stack_pointer
+  global.get $~lib/memory/__stack_pointer
+  i32.const 1308
+  i32.lt_s
+  if
+   i32.const 34096
+   i32.const 34144
+   i32.const 1
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  global.get $~lib/memory/__stack_pointer
+  local.get $0
+  i32.store $0
+  i32.const 123
+  local.get $0
+  i32.const 0
+  call $~lib/array/Array<~lib/array/Array<i32>>#__get
+  i32.load $0
+  call_indirect $0 (type $i32_=>_i32)
+  drop
   unreachable
  )
 )

--- a/tests/compiler/std/array-access.ts
+++ b/tests/compiler/std/array-access.ts
@@ -17,3 +17,9 @@ export function stringArrayArrayPropertyAccess(a: string[][]): i32 {
 export function stringArrayArrayMethodCall(a: string[][]): i32 {
   return a[0][1].startsWith("");
 }
+
+// FIXME: Parenthesizing signature types is not supported
+type T = (x: i32) => i32
+export function functionArrayElementCall(a: T[]): i32 {
+  return a[0](123);
+}


### PR DESCRIPTION
An alternative to #2530 that instead simplifies the logic in `compileCallExpression`: Any call that is not a direct call compiles the target expression for use as the function argument of an indirect call.

cc @CountBleck 

Fixes #2530, fixes #2525 

- [x] I've read the contributing guidelines
- [x] I've added my name and email to the NOTICE file
