### PR TITLE
Bindings: Expect memory growth when lowering references

### DIFF
--- a/tests/compiler/bindings/esm.debug.js
+++ b/tests/compiler/bindings/esm.debug.js
@@ -220,9 +220,9 @@ async function instantiate(module, imports = {}) {
     new Uint8Array(memory.buffer)[pointer + 40 >>> 0] = value.k ? 1 : 0;
     new Float32Array(memory.buffer)[pointer + 44 >>> 2] = value.l;
     new Float64Array(memory.buffer)[pointer + 48 >>> 3] = value.m;
-    new Uint32Array(memory.buffer)[pointer + 56 >>> 2] = __lowerString(value.n);
-    new Uint32Array(memory.buffer)[pointer + 60 >>> 2] = __lowerTypedArray(Uint8Array, 13, 0, value.o);
-    new Uint32Array(memory.buffer)[pointer + 64 >>> 2] = __lowerArray((pointer, value) => { new Uint32Array(memory.buffer)[pointer >>> 2] = __lowerString(value) || __notnull(); }, 14, 2, value.p);
+    __store_ref(pointer + 56, __lowerString(value.n));
+    __store_ref(pointer + 60, __lowerTypedArray(Uint8Array, 13, 0, value.o));
+    __store_ref(pointer + 64, __lowerArray((pointer, value) => { __store_ref(pointer, __lowerString(value) || __notnull()); }, 14, 2, value.p));
     exports.__unpin(pointer);
     return pointer;
   }
@@ -381,6 +381,9 @@ async function instantiate(module, imports = {}) {
   }
   function __notnull() {
     throw TypeError("value must not be null");
+  }
+  function __store_ref(pointer, value) {
+    new Uint32Array(memory.buffer)[pointer >>> 2] = value;
   }
   exports._start();
   return adaptedExports;

--- a/tests/compiler/bindings/esm.release.js
+++ b/tests/compiler/bindings/esm.release.js
@@ -220,9 +220,9 @@ async function instantiate(module, imports = {}) {
     new Uint8Array(memory.buffer)[pointer + 40 >>> 0] = value.k ? 1 : 0;
     new Float32Array(memory.buffer)[pointer + 44 >>> 2] = value.l;
     new Float64Array(memory.buffer)[pointer + 48 >>> 3] = value.m;
-    new Uint32Array(memory.buffer)[pointer + 56 >>> 2] = __lowerString(value.n);
-    new Uint32Array(memory.buffer)[pointer + 60 >>> 2] = __lowerTypedArray(Uint8Array, 13, 0, value.o);
-    new Uint32Array(memory.buffer)[pointer + 64 >>> 2] = __lowerArray((pointer, value) => { new Uint32Array(memory.buffer)[pointer >>> 2] = __lowerString(value) || __notnull(); }, 14, 2, value.p);
+    __store_ref(pointer + 56, __lowerString(value.n));
+    __store_ref(pointer + 60, __lowerTypedArray(Uint8Array, 13, 0, value.o));
+    __store_ref(pointer + 64, __lowerArray((pointer, value) => { __store_ref(pointer, __lowerString(value) || __notnull()); }, 14, 2, value.p));
     exports.__unpin(pointer);
     return pointer;
   }
@@ -381,6 +381,9 @@ async function instantiate(module, imports = {}) {
   }
   function __notnull() {
     throw TypeError("value must not be null");
+  }
+  function __store_ref(pointer, value) {
+    new Uint32Array(memory.buffer)[pointer >>> 2] = value;
   }
   exports._start();
   return adaptedExports;

--- a/tests/compiler/bindings/raw.debug.js
+++ b/tests/compiler/bindings/raw.debug.js
@@ -220,9 +220,9 @@ export async function instantiate(module, imports = {}) {
     new Uint8Array(memory.buffer)[pointer + 40 >>> 0] = value.k ? 1 : 0;
     new Float32Array(memory.buffer)[pointer + 44 >>> 2] = value.l;
     new Float64Array(memory.buffer)[pointer + 48 >>> 3] = value.m;
-    new Uint32Array(memory.buffer)[pointer + 56 >>> 2] = __lowerString(value.n);
-    new Uint32Array(memory.buffer)[pointer + 60 >>> 2] = __lowerTypedArray(Uint8Array, 13, 0, value.o);
-    new Uint32Array(memory.buffer)[pointer + 64 >>> 2] = __lowerArray((pointer, value) => { new Uint32Array(memory.buffer)[pointer >>> 2] = __lowerString(value) || __notnull(); }, 14, 2, value.p);
+    __store_ref(pointer + 56, __lowerString(value.n));
+    __store_ref(pointer + 60, __lowerTypedArray(Uint8Array, 13, 0, value.o));
+    __store_ref(pointer + 64, __lowerArray((pointer, value) => { __store_ref(pointer, __lowerString(value) || __notnull()); }, 14, 2, value.p));
     exports.__unpin(pointer);
     return pointer;
   }
@@ -381,6 +381,9 @@ export async function instantiate(module, imports = {}) {
   }
   function __notnull() {
     throw TypeError("value must not be null");
+  }
+  function __store_ref(pointer, value) {
+    new Uint32Array(memory.buffer)[pointer >>> 2] = value;
   }
   exports._start();
   return adaptedExports;

--- a/tests/compiler/bindings/raw.release.js
+++ b/tests/compiler/bindings/raw.release.js
@@ -220,9 +220,9 @@ export async function instantiate(module, imports = {}) {
     new Uint8Array(memory.buffer)[pointer + 40 >>> 0] = value.k ? 1 : 0;
     new Float32Array(memory.buffer)[pointer + 44 >>> 2] = value.l;
     new Float64Array(memory.buffer)[pointer + 48 >>> 3] = value.m;
-    new Uint32Array(memory.buffer)[pointer + 56 >>> 2] = __lowerString(value.n);
-    new Uint32Array(memory.buffer)[pointer + 60 >>> 2] = __lowerTypedArray(Uint8Array, 13, 0, value.o);
-    new Uint32Array(memory.buffer)[pointer + 64 >>> 2] = __lowerArray((pointer, value) => { new Uint32Array(memory.buffer)[pointer >>> 2] = __lowerString(value) || __notnull(); }, 14, 2, value.p);
+    __store_ref(pointer + 56, __lowerString(value.n));
+    __store_ref(pointer + 60, __lowerTypedArray(Uint8Array, 13, 0, value.o));
+    __store_ref(pointer + 64, __lowerArray((pointer, value) => { __store_ref(pointer, __lowerString(value) || __notnull()); }, 14, 2, value.p));
     exports.__unpin(pointer);
     return pointer;
   }
@@ -381,6 +381,9 @@ export async function instantiate(module, imports = {}) {
   }
   function __notnull() {
     throw TypeError("value must not be null");
+  }
+  function __store_ref(pointer, value) {
+    new Uint32Array(memory.buffer)[pointer >>> 2] = value;
   }
   exports._start();
   return adaptedExports;


### PR DESCRIPTION
Fixes #2553 by using a helper function when lowering (what's typically) another lowering to memory:

```ts
new Uint32Array(memory.buffer)[pointer >>> 2] = __lowerXY(...);
// ->
__store_ref(pointer, __lowerXY(...));
```

Changes evaluation order so the LHS view is not invalidated by memory growth in the RHS before the store is performed.

- [x] I've read the contributing guidelines
- [x] I've added my name and email to the NOTICE file
