### PR TITLE
Remove unchecked indexed set on normal arrays

### DIFF
--- a/std/assembly/array.ts
+++ b/std/assembly/array.ts
@@ -131,10 +131,6 @@ export class Array<T> {
       ensureCapacity(changetype<usize>(this), index + 1, alignof<T>());
       this.length_ = index + 1;
     }
-    this.__uset(index, value);
-  }
-
-  @unsafe @operator("{}=") private __uset(index: i32, value: T): void {
     store<T>(this.dataStart + (<usize>index << alignof<T>()), value);
     if (isManaged<T>()) {
       __link(changetype<usize>(this), changetype<usize>(value), true);

--- a/tests/compiler/bindings/esm.debug.wat
+++ b/tests/compiler/bindings/esm.debug.wat
@@ -2840,18 +2840,6 @@
    i32.store $0 offset=8
   end
  )
- (func $~lib/array/Array<i32>#__uset (type $i32_i32_i32_=>_none) (param $this i32) (param $index i32) (param $value i32)
-  local.get $this
-  call $~lib/array/Array<i32>#get:dataStart
-  local.get $index
-  i32.const 2
-  i32.shl
-  i32.add
-  local.get $value
-  i32.store $0
-  i32.const 0
-  drop
- )
  (func $~lib/array/Array<i32>#__set (type $i32_i32_i32_=>_none) (param $this i32) (param $index i32) (param $value i32)
   local.get $index
   local.get $this
@@ -2883,9 +2871,15 @@
    call $~lib/array/Array<i32>#set:length_
   end
   local.get $this
+  call $~lib/array/Array<i32>#get:dataStart
   local.get $index
+  i32.const 2
+  i32.shl
+  i32.add
   local.get $value
-  call $~lib/array/Array<i32>#__uset
+  i32.store $0
+  i32.const 0
+  drop
  )
  (func $bindings/esm/PlainObject#set:a (type $i32_i32_=>_none) (param $this i32) (param $a i32)
   local.get $this

--- a/tests/compiler/bindings/raw.debug.wat
+++ b/tests/compiler/bindings/raw.debug.wat
@@ -2843,18 +2843,6 @@
    i32.store $0 offset=8
   end
  )
- (func $~lib/array/Array<i32>#__uset (type $i32_i32_i32_=>_none) (param $this i32) (param $index i32) (param $value i32)
-  local.get $this
-  call $~lib/array/Array<i32>#get:dataStart
-  local.get $index
-  i32.const 2
-  i32.shl
-  i32.add
-  local.get $value
-  i32.store $0
-  i32.const 0
-  drop
- )
  (func $~lib/array/Array<i32>#__set (type $i32_i32_i32_=>_none) (param $this i32) (param $index i32) (param $value i32)
   local.get $index
   local.get $this
@@ -2886,9 +2874,15 @@
    call $~lib/array/Array<i32>#set:length_
   end
   local.get $this
+  call $~lib/array/Array<i32>#get:dataStart
   local.get $index
+  i32.const 2
+  i32.shl
+  i32.add
   local.get $value
-  call $~lib/array/Array<i32>#__uset
+  i32.store $0
+  i32.const 0
+  drop
  )
  (func $bindings/esm/PlainObject#set:a (type $i32_i32_=>_none) (param $this i32) (param $a i32)
   local.get $this

--- a/tests/compiler/infer-array.debug.wat
+++ b/tests/compiler/infer-array.debug.wat
@@ -5,8 +5,8 @@
  (type $i32_=>_none (func_subtype (param i32) func))
  (type $i32_i32_i32_=>_none (func_subtype (param i32 i32 i32) func))
  (type $none_=>_none (func_subtype func))
- (type $i32_i32_i32_=>_i32 (func_subtype (param i32 i32 i32) (result i32) func))
  (type $i32_i32_i32_i32_=>_none (func_subtype (param i32 i32 i32 i32) func))
+ (type $i32_i32_i32_=>_i32 (func_subtype (param i32 i32 i32) (result i32) func))
  (type $none_=>_i32 (func_subtype (result i32) func))
  (type $i32_i32_=>_f64 (func_subtype (param i32 i32) (result f64) func))
  (type $i32_i32_=>_f32 (func_subtype (param i32 i32) (result f32) func))
@@ -26,10 +26,11 @@
  (global $~lib/rt/itcms/fromSpace (mut i32) (i32.const 0))
  (global $~lib/rt/tlsf/ROOT (mut i32) (i32.const 0))
  (global $~lib/native/ASC_LOW_MEMORY_LIMIT i32 (i32.const 0))
- (global $~lib/rt/__rtti_base i32 (i32.const 1088))
- (global $~lib/memory/__data_end i32 (i32.const 1144))
- (global $~lib/memory/__stack_pointer (mut i32) (i32.const 33912))
- (global $~lib/memory/__heap_base i32 (i32.const 33912))
+ (global $~lib/native/ASC_RUNTIME i32 (i32.const 2))
+ (global $~lib/rt/__rtti_base i32 (i32.const 1136))
+ (global $~lib/memory/__data_end i32 (i32.const 1192))
+ (global $~lib/memory/__stack_pointer (mut i32) (i32.const 33960))
+ (global $~lib/memory/__heap_base i32 (i32.const 33960))
  (memory $0 1)
  (data (i32.const 12) "\1c\00\00\00\00\00\00\00\00\00\00\00\01\00\00\00\0c\00\00\00\01\00\00\00\02\00\00\00\03\00\00\00")
  (data (i32.const 44) "<\00\00\00\00\00\00\00\00\00\00\00\02\00\00\00(\00\00\00A\00l\00l\00o\00c\00a\00t\00i\00o\00n\00 \00t\00o\00o\00 \00l\00a\00r\00g\00e\00\00\00\00\00")
@@ -46,16 +47,17 @@
  (data (i32.const 588) "\1c\00\00\00\00\00\00\00\00\00\00\00\01\00\00\00\08\00\00\00\01\00\00\00\ff\ff\ff\ff\00\00\00\00")
  (data (i32.const 620) ",\00\00\00\00\00\00\00\00\00\00\00\01\00\00\00\18\00\00\00\00\00\00\00\00\00\f0?\00\00\00\00\00\00\00@\00\00\00\00\00\00\08@\00\00\00\00")
  (data (i32.const 668) "\1c\00\00\00\00\00\00\00\00\00\00\00\01\00\00\00\0c\00\00\00\00\00\80?\00\00\00@\00\00@@")
- (data (i32.const 700) "\1c\00\00\00\00\00\00\00\00\00\00\00\02\00\00\00\02\00\00\00a\00\00\00\00\00\00\00\00\00\00\00")
- (data (i32.const 732) "\1c\00\00\00\00\00\00\00\00\00\00\00\01\00\00\00\08\00\00\00\00\00\00\00\d0\02\00\00\00\00\00\00")
- (data (i32.const 764) "\1c\00\00\00\00\00\00\00\00\00\00\00\01\00\00\00\04\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00")
- (data (i32.const 796) "\1c\00\00\00\00\00\00\00\00\00\00\00\01\00\00\00\08\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00")
- (data (i32.const 828) "\1c\00\00\00\00\00\00\00\00\00\00\00\01\00\00\00\08\00\00\00\01\00\00\00\00\00\00\00\00\00\00\00")
- (data (i32.const 860) "\1c\00\00\00\00\00\00\00\00\00\00\00\01\00\00\00\08\00\00\00\00\00\00\00\01\00\00\00\00\00\00\00")
- (data (i32.const 892) "\1c\00\00\00\00\00\00\00\00\00\00\00\01\00\00\00\04\00\00\00\01\00\00\00\00\00\00\00\00\00\00\00")
- (data (i32.const 924) "\1c\00\00\00\00\00\00\00\00\00\00\00\01\00\00\00\04\00\00\00\02\00\00\00\00\00\00\00\00\00\00\00")
- (data (i32.const 956) "|\00\00\00\00\00\00\00\00\00\00\00\02\00\00\00^\00\00\00E\00l\00e\00m\00e\00n\00t\00 \00t\00y\00p\00e\00 \00m\00u\00s\00t\00 \00b\00e\00 \00n\00u\00l\00l\00a\00b\00l\00e\00 \00i\00f\00 \00a\00r\00r\00a\00y\00 \00i\00s\00 \00h\00o\00l\00e\00y\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00")
- (data (i32.const 1088) "\r\00\00\00 \00\00\00 \00\00\00 \00\00\00\00\00\00\00\02\t\00\00\02\1a\00\00\02\01\00\00\02\19\00\00 \00\00\00\02a\00\00\02a\00\00\02\01\00\00\02A\00\00")
+ (data (i32.const 700) ",\00\00\00\00\00\00\00\00\00\00\00\02\00\00\00\1c\00\00\00I\00n\00v\00a\00l\00i\00d\00 \00l\00e\00n\00g\00t\00h\00")
+ (data (i32.const 748) "\1c\00\00\00\00\00\00\00\00\00\00\00\02\00\00\00\02\00\00\00a\00\00\00\00\00\00\00\00\00\00\00")
+ (data (i32.const 780) "\1c\00\00\00\00\00\00\00\00\00\00\00\01\00\00\00\08\00\00\00\00\00\00\00\00\03\00\00\00\00\00\00")
+ (data (i32.const 812) "\1c\00\00\00\00\00\00\00\00\00\00\00\01\00\00\00\04\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00")
+ (data (i32.const 844) "\1c\00\00\00\00\00\00\00\00\00\00\00\01\00\00\00\08\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00")
+ (data (i32.const 876) "\1c\00\00\00\00\00\00\00\00\00\00\00\01\00\00\00\08\00\00\00\01\00\00\00\00\00\00\00\00\00\00\00")
+ (data (i32.const 908) "\1c\00\00\00\00\00\00\00\00\00\00\00\01\00\00\00\08\00\00\00\00\00\00\00\01\00\00\00\00\00\00\00")
+ (data (i32.const 940) "\1c\00\00\00\00\00\00\00\00\00\00\00\01\00\00\00\04\00\00\00\01\00\00\00\00\00\00\00\00\00\00\00")
+ (data (i32.const 972) "\1c\00\00\00\00\00\00\00\00\00\00\00\01\00\00\00\04\00\00\00\02\00\00\00\00\00\00\00\00\00\00\00")
+ (data (i32.const 1004) "|\00\00\00\00\00\00\00\00\00\00\00\02\00\00\00^\00\00\00E\00l\00e\00m\00e\00n\00t\00 \00t\00y\00p\00e\00 \00m\00u\00s\00t\00 \00b\00e\00 \00n\00u\00l\00l\00a\00b\00l\00e\00 \00i\00f\00 \00a\00r\00r\00a\00y\00 \00i\00s\00 \00h\00o\00l\00e\00y\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00")
+ (data (i32.const 1136) "\r\00\00\00 \00\00\00 \00\00\00 \00\00\00\00\00\00\00\02\t\00\00\02\1a\00\00\02\01\00\00\02\19\00\00 \00\00\00\02a\00\00\02a\00\00\02\01\00\00\02A\00\00")
  (table $0 1 1 funcref)
  (elem $0 (i32.const 1))
  (export "memory" (memory $0))
@@ -2477,11 +2479,203 @@
   local.get $value
   return
  )
+ (func $~lib/array/Array<infer-array/Ref|null>#get:length_ (type $i32_=>_i32) (param $this i32) (result i32)
+  local.get $this
+  i32.load $0 offset=12
+ )
+ (func $~lib/arraybuffer/ArrayBufferView#get:byteLength (type $i32_=>_i32) (param $this i32) (result i32)
+  local.get $this
+  i32.load $0 offset=8
+ )
+ (func $~lib/arraybuffer/ArrayBufferView#get:buffer (type $i32_=>_i32) (param $this i32) (result i32)
+  local.get $this
+  i32.load $0
+ )
+ (func $~lib/rt/itcms/Object#get:rtSize (type $i32_=>_i32) (param $this i32) (result i32)
+  local.get $this
+  i32.load $0 offset=16
+ )
+ (func $~lib/rt/itcms/__renew (type $i32_i32_=>_i32) (param $oldPtr i32) (param $size i32) (result i32)
+  (local $oldObj i32)
+  (local $newPtr i32)
+  (local $4 i32)
+  (local $5 i32)
+  local.get $oldPtr
+  i32.const 20
+  i32.sub
+  local.set $oldObj
+  local.get $size
+  local.get $oldObj
+  call $~lib/rt/common/BLOCK#get:mmInfo
+  i32.const 3
+  i32.const -1
+  i32.xor
+  i32.and
+  i32.const 16
+  i32.sub
+  i32.le_u
+  if
+   local.get $oldObj
+   local.get $size
+   call $~lib/rt/itcms/Object#set:rtSize
+   local.get $oldPtr
+   return
+  end
+  local.get $size
+  local.get $oldObj
+  call $~lib/rt/itcms/Object#get:rtId
+  call $~lib/rt/itcms/__new
+  local.set $newPtr
+  local.get $newPtr
+  local.get $oldPtr
+  local.get $size
+  local.tee $4
+  local.get $oldObj
+  call $~lib/rt/itcms/Object#get:rtSize
+  local.tee $5
+  local.get $4
+  local.get $5
+  i32.lt_u
+  select
+  memory.copy $0 $0
+  local.get $newPtr
+  return
+ )
+ (func $~lib/array/ensureCapacity (type $i32_i32_i32_i32_=>_none) (param $array i32) (param $newSize i32) (param $alignLog2 i32) (param $canGrow i32)
+  (local $oldCapacity i32)
+  (local $oldData i32)
+  (local $6 i32)
+  (local $7 i32)
+  (local $newCapacity i32)
+  (local $9 i32)
+  (local $10 i32)
+  (local $11 i32)
+  (local $12 i32)
+  (local $newData i32)
+  local.get $array
+  call $~lib/arraybuffer/ArrayBufferView#get:byteLength
+  local.set $oldCapacity
+  local.get $newSize
+  local.get $oldCapacity
+  local.get $alignLog2
+  i32.shr_u
+  i32.gt_u
+  if
+   local.get $newSize
+   i32.const 1073741820
+   local.get $alignLog2
+   i32.shr_u
+   i32.gt_u
+   if
+    i32.const 720
+    i32.const 464
+    i32.const 19
+    i32.const 48
+    call $~lib/builtins/abort
+    unreachable
+   end
+   local.get $array
+   call $~lib/arraybuffer/ArrayBufferView#get:buffer
+   local.set $oldData
+   local.get $newSize
+   local.tee $6
+   i32.const 8
+   local.tee $7
+   local.get $6
+   local.get $7
+   i32.gt_u
+   select
+   local.get $alignLog2
+   i32.shl
+   local.set $newCapacity
+   local.get $canGrow
+   if
+    local.get $oldCapacity
+    i32.const 1
+    i32.shl
+    local.tee $9
+    i32.const 1073741820
+    local.tee $10
+    local.get $9
+    local.get $10
+    i32.lt_u
+    select
+    local.tee $11
+    local.get $newCapacity
+    local.tee $12
+    local.get $11
+    local.get $12
+    i32.gt_u
+    select
+    local.set $newCapacity
+   end
+   local.get $oldData
+   local.get $newCapacity
+   call $~lib/rt/itcms/__renew
+   local.set $newData
+   i32.const 2
+   global.get $~lib/shared/runtime/Runtime.Incremental
+   i32.ne
+   drop
+   local.get $newData
+   local.get $oldData
+   i32.ne
+   if
+    local.get $array
+    local.get $newData
+    i32.store $0
+    local.get $array
+    local.get $newData
+    i32.store $0 offset=4
+    local.get $array
+    local.get $newData
+    i32.const 0
+    call $~lib/rt/itcms/__link
+   end
+   local.get $array
+   local.get $newCapacity
+   i32.store $0 offset=8
+  end
+ )
+ (func $~lib/array/Array<infer-array/Ref|null>#set:length_ (type $i32_i32_=>_none) (param $this i32) (param $length_ i32)
+  local.get $this
+  local.get $length_
+  i32.store $0 offset=12
+ )
  (func $~lib/array/Array<infer-array/Ref|null>#get:dataStart (type $i32_=>_i32) (param $this i32) (result i32)
   local.get $this
   i32.load $0 offset=4
  )
- (func $~lib/array/Array<infer-array/Ref|null>#__uset (type $i32_i32_i32_=>_none) (param $this i32) (param $index i32) (param $value i32)
+ (func $~lib/array/Array<infer-array/Ref|null>#__set (type $i32_i32_i32_=>_none) (param $this i32) (param $index i32) (param $value i32)
+  local.get $index
+  local.get $this
+  call $~lib/array/Array<infer-array/Ref|null>#get:length_
+  i32.ge_u
+  if
+   local.get $index
+   i32.const 0
+   i32.lt_s
+   if
+    i32.const 256
+    i32.const 464
+    i32.const 130
+    i32.const 22
+    call $~lib/builtins/abort
+    unreachable
+   end
+   local.get $this
+   local.get $index
+   i32.const 1
+   i32.add
+   i32.const 2
+   i32.const 1
+   call $~lib/array/ensureCapacity
+   local.get $this
+   local.get $index
+   i32.const 1
+   i32.add
+   call $~lib/array/Array<infer-array/Ref|null>#set:length_
+  end
   local.get $this
   call $~lib/array/Array<infer-array/Ref|null>#get:dataStart
   local.get $index
@@ -2496,10 +2690,6 @@
   local.get $value
   i32.const 1
   call $~lib/rt/itcms/__link
- )
- (func $~lib/array/Array<infer-array/Ref|null>#get:length_ (type $i32_=>_i32) (param $this i32) (result i32)
-  local.get $this
-  i32.load $0 offset=12
  )
  (func $~lib/array/Array<~lib/string/String|null>#get:length_ (type $i32_=>_i32) (param $this i32) (result i32)
   local.get $this
@@ -2544,11 +2734,49 @@
   local.get $value
   return
  )
+ (func $~lib/array/Array<~lib/array/Array<i32>>#get:length_ (type $i32_=>_i32) (param $this i32) (result i32)
+  local.get $this
+  i32.load $0 offset=12
+ )
+ (func $~lib/array/Array<~lib/array/Array<i32>>#set:length_ (type $i32_i32_=>_none) (param $this i32) (param $length_ i32)
+  local.get $this
+  local.get $length_
+  i32.store $0 offset=12
+ )
  (func $~lib/array/Array<~lib/array/Array<i32>>#get:dataStart (type $i32_=>_i32) (param $this i32) (result i32)
   local.get $this
   i32.load $0 offset=4
  )
- (func $~lib/array/Array<~lib/array/Array<i32>>#__uset (type $i32_i32_i32_=>_none) (param $this i32) (param $index i32) (param $value i32)
+ (func $~lib/array/Array<~lib/array/Array<i32>>#__set (type $i32_i32_i32_=>_none) (param $this i32) (param $index i32) (param $value i32)
+  local.get $index
+  local.get $this
+  call $~lib/array/Array<~lib/array/Array<i32>>#get:length_
+  i32.ge_u
+  if
+   local.get $index
+   i32.const 0
+   i32.lt_s
+   if
+    i32.const 256
+    i32.const 464
+    i32.const 130
+    i32.const 22
+    call $~lib/builtins/abort
+    unreachable
+   end
+   local.get $this
+   local.get $index
+   i32.const 1
+   i32.add
+   i32.const 2
+   i32.const 1
+   call $~lib/array/ensureCapacity
+   local.get $this
+   local.get $index
+   i32.const 1
+   i32.add
+   call $~lib/array/Array<~lib/array/Array<i32>>#set:length_
+  end
   local.get $this
   call $~lib/array/Array<~lib/array/Array<i32>>#get:dataStart
   local.get $index
@@ -2563,10 +2791,6 @@
   local.get $value
   i32.const 1
   call $~lib/rt/itcms/__link
- )
- (func $~lib/array/Array<~lib/array/Array<i32>>#get:length_ (type $i32_=>_i32) (param $this i32) (result i32)
-  local.get $this
-  i32.load $0 offset=12
  )
  (func $start:infer-array (type $none_=>_none)
   (local $0 i32)
@@ -2831,11 +3055,11 @@
   local.get $18
   i32.const 0
   local.get $a
-  call $~lib/array/Array<infer-array/Ref|null>#__uset
+  call $~lib/array/Array<infer-array/Ref|null>#__set
   local.get $18
   i32.const 1
   local.get $b
-  call $~lib/array/Array<infer-array/Ref|null>#__uset
+  call $~lib/array/Array<infer-array/Ref|null>#__set
   local.get $18
   local.tee $arr|20
   i32.store $0 offset=36
@@ -2880,11 +3104,11 @@
   local.get $23
   i32.const 0
   local.get $a|21
-  call $~lib/array/Array<infer-array/Ref|null>#__uset
+  call $~lib/array/Array<infer-array/Ref|null>#__set
   local.get $23
   i32.const 1
   local.get $b|22
-  call $~lib/array/Array<infer-array/Ref|null>#__uset
+  call $~lib/array/Array<infer-array/Ref|null>#__set
   local.get $23
   local.tee $arr|25
   i32.store $0 offset=56
@@ -2924,11 +3148,11 @@
   local.get $27
   i32.const 0
   local.get $a|26
-  call $~lib/array/Array<infer-array/Ref|null>#__uset
+  call $~lib/array/Array<infer-array/Ref|null>#__set
   local.get $27
   i32.const 1
   i32.const 0
-  call $~lib/array/Array<infer-array/Ref|null>#__uset
+  call $~lib/array/Array<infer-array/Ref|null>#__set
   local.get $27
   local.tee $arr|29
   i32.store $0 offset=72
@@ -2950,7 +3174,7 @@
   i32.const 2
   i32.const 2
   i32.const 10
-  i32.const 752
+  i32.const 800
   call $~lib/rt/__newArray
   local.tee $arr|32
   i32.store $0 offset=76
@@ -2972,7 +3196,7 @@
   i32.const 1
   i32.const 2
   i32.const 11
-  i32.const 784
+  i32.const 832
   call $~lib/rt/__newArray
   local.tee $arr1
   i32.store $0 offset=80
@@ -3009,7 +3233,7 @@
   i32.const 2
   i32.const 2
   i32.const 11
-  i32.const 816
+  i32.const 864
   call $~lib/rt/__newArray
   local.tee $arr2
   i32.store $0 offset=84
@@ -3046,7 +3270,7 @@
   i32.const 2
   i32.const 2
   i32.const 4
-  i32.const 848
+  i32.const 896
   call $~lib/rt/__newArray
   local.tee $arr1|41
   i32.store $0 offset=88
@@ -3083,7 +3307,7 @@
   i32.const 2
   i32.const 2
   i32.const 4
-  i32.const 880
+  i32.const 928
   call $~lib/rt/__newArray
   local.tee $arr2|44
   i32.store $0 offset=92
@@ -3135,17 +3359,17 @@
   i32.const 1
   i32.const 2
   i32.const 4
-  i32.const 912
+  i32.const 960
   call $~lib/rt/__newArray
-  call $~lib/array/Array<~lib/array/Array<i32>>#__uset
+  call $~lib/array/Array<~lib/array/Array<i32>>#__set
   local.get $45
   i32.const 1
   i32.const 1
   i32.const 2
   i32.const 4
-  i32.const 944
+  i32.const 992
   call $~lib/rt/__newArray
-  call $~lib/array/Array<~lib/array/Array<i32>>#__uset
+  call $~lib/array/Array<~lib/array/Array<i32>>#__set
   local.get $45
   local.tee $arr|51
   i32.store $0 offset=104
@@ -3176,7 +3400,10 @@
   i32.const 256
   local.get $0
   call $~lib/rt/itcms/__visit
-  i32.const 976
+  i32.const 720
+  local.get $0
+  call $~lib/rt/itcms/__visit
+  i32.const 1024
   local.get $0
   call $~lib/rt/itcms/__visit
   i32.const 64
@@ -3546,8 +3773,8 @@
   global.get $~lib/memory/__data_end
   i32.lt_s
   if
-   i32.const 33936
    i32.const 33984
+   i32.const 34032
    i32.const 1
    i32.const 1
    call $~lib/builtins/abort
@@ -3803,7 +4030,7 @@
   local.get $value
   i32.eqz
   if
-   i32.const 976
+   i32.const 1024
    i32.const 464
    i32.const 118
    i32.const 40

--- a/tests/compiler/infer-array.release.wat
+++ b/tests/compiler/infer-array.release.wat
@@ -18,7 +18,7 @@
  (global $~lib/rt/itcms/white (mut i32) (i32.const 0))
  (global $~lib/rt/itcms/fromSpace (mut i32) (i32.const 0))
  (global $~lib/rt/tlsf/ROOT (mut i32) (i32.const 0))
- (global $~lib/memory/__stack_pointer (mut i32) (i32.const 34936))
+ (global $~lib/memory/__stack_pointer (mut i32) (i32.const 34984))
  (memory $0 1)
  (data (i32.const 1036) "\1c")
  (data (i32.const 1048) "\01\00\00\00\0c\00\00\00\01\00\00\00\02\00\00\00\03")
@@ -46,25 +46,27 @@
  (data (i32.const 1670) "\f0?\00\00\00\00\00\00\00@\00\00\00\00\00\00\08@")
  (data (i32.const 1692) "\1c")
  (data (i32.const 1704) "\01\00\00\00\0c\00\00\00\00\00\80?\00\00\00@\00\00@@")
- (data (i32.const 1724) "\1c")
- (data (i32.const 1736) "\02\00\00\00\02\00\00\00a")
- (data (i32.const 1756) "\1c")
- (data (i32.const 1768) "\01\00\00\00\08\00\00\00\00\00\00\00\d0\06")
- (data (i32.const 1788) "\1c")
- (data (i32.const 1800) "\01\00\00\00\04")
- (data (i32.const 1820) "\1c")
- (data (i32.const 1832) "\01\00\00\00\08")
- (data (i32.const 1852) "\1c")
- (data (i32.const 1864) "\01\00\00\00\08\00\00\00\01")
- (data (i32.const 1884) "\1c")
- (data (i32.const 1896) "\01\00\00\00\08\00\00\00\00\00\00\00\01")
- (data (i32.const 1916) "\1c")
- (data (i32.const 1928) "\01\00\00\00\04\00\00\00\01")
- (data (i32.const 1948) "\1c")
- (data (i32.const 1960) "\01\00\00\00\04\00\00\00\02")
- (data (i32.const 1980) "|")
- (data (i32.const 1992) "\02\00\00\00^\00\00\00E\00l\00e\00m\00e\00n\00t\00 \00t\00y\00p\00e\00 \00m\00u\00s\00t\00 \00b\00e\00 \00n\00u\00l\00l\00a\00b\00l\00e\00 \00i\00f\00 \00a\00r\00r\00a\00y\00 \00i\00s\00 \00h\00o\00l\00e\00y")
- (data (i32.const 2112) "\r\00\00\00 \00\00\00 \00\00\00 \00\00\00\00\00\00\00\02\t\00\00\02\1a\00\00\02\01\00\00\02\19\00\00 \00\00\00\02a\00\00\02a\00\00\02\01\00\00\02A")
+ (data (i32.const 1724) ",")
+ (data (i32.const 1736) "\02\00\00\00\1c\00\00\00I\00n\00v\00a\00l\00i\00d\00 \00l\00e\00n\00g\00t\00h")
+ (data (i32.const 1772) "\1c")
+ (data (i32.const 1784) "\02\00\00\00\02\00\00\00a")
+ (data (i32.const 1804) "\1c")
+ (data (i32.const 1816) "\01\00\00\00\08\00\00\00\00\00\00\00\00\07")
+ (data (i32.const 1836) "\1c")
+ (data (i32.const 1848) "\01\00\00\00\04")
+ (data (i32.const 1868) "\1c")
+ (data (i32.const 1880) "\01\00\00\00\08")
+ (data (i32.const 1900) "\1c")
+ (data (i32.const 1912) "\01\00\00\00\08\00\00\00\01")
+ (data (i32.const 1932) "\1c")
+ (data (i32.const 1944) "\01\00\00\00\08\00\00\00\00\00\00\00\01")
+ (data (i32.const 1964) "\1c")
+ (data (i32.const 1976) "\01\00\00\00\04\00\00\00\01")
+ (data (i32.const 1996) "\1c")
+ (data (i32.const 2008) "\01\00\00\00\04\00\00\00\02")
+ (data (i32.const 2028) "|")
+ (data (i32.const 2040) "\02\00\00\00^\00\00\00E\00l\00e\00m\00e\00n\00t\00 \00t\00y\00p\00e\00 \00m\00u\00s\00t\00 \00b\00e\00 \00n\00u\00l\00l\00a\00b\00l\00e\00 \00i\00f\00 \00a\00r\00r\00a\00y\00 \00i\00s\00 \00h\00o\00l\00e\00y")
+ (data (i32.const 2160) "\r\00\00\00 \00\00\00 \00\00\00 \00\00\00\00\00\00\00\02\t\00\00\02\1a\00\00\02\01\00\00\02\19\00\00 \00\00\00\02a\00\00\02a\00\00\02\01\00\00\02A")
  (export "memory" (memory $0))
  (start $~start)
  (func $~lib/rt/itcms/visitRoots (type $none_=>_none)
@@ -72,7 +74,9 @@
   (local $1 i32)
   i32.const 1280
   call $byn-split-outlined-A$~lib/rt/itcms/__visit
-  i32.const 2000
+  i32.const 1744
+  call $byn-split-outlined-A$~lib/rt/itcms/__visit
+  i32.const 2048
   call $byn-split-outlined-A$~lib/rt/itcms/__visit
   i32.const 1088
   call $byn-split-outlined-A$~lib/rt/itcms/__visit
@@ -149,7 +153,7 @@
     i32.load $0 offset=8
     i32.eqz
     local.get $0
-    i32.const 34936
+    i32.const 34984
     i32.lt_u
     i32.and
     i32.eqz
@@ -198,7 +202,7 @@
    i32.const 1
   else
    local.get $1
-   i32.const 2112
+   i32.const 2160
    i32.load $0
    i32.gt_u
    if
@@ -212,7 +216,7 @@
    local.get $1
    i32.const 2
    i32.shl
-   i32.const 2116
+   i32.const 2164
    i32.add
    i32.load $0
    i32.const 32
@@ -777,10 +781,10 @@
   if
    unreachable
   end
-  i32.const 34944
+  i32.const 34992
   i32.const 0
   i32.store $0
-  i32.const 36512
+  i32.const 36560
   i32.const 0
   i32.store $0
   loop $for-loop|0
@@ -791,7 +795,7 @@
     local.get $0
     i32.const 2
     i32.shl
-    i32.const 34944
+    i32.const 34992
     i32.add
     i32.const 0
     i32.store $0 offset=4
@@ -809,7 +813,7 @@
       i32.add
       i32.const 2
       i32.shl
-      i32.const 34944
+      i32.const 34992
       i32.add
       i32.const 0
       i32.store $0 offset=96
@@ -827,13 +831,13 @@
     br $for-loop|0
    end
   end
-  i32.const 34944
-  i32.const 36516
+  i32.const 34992
+  i32.const 36564
   memory.size $0
   i32.const 16
   i32.shl
   call $~lib/rt/tlsf/addMemory
-  i32.const 34944
+  i32.const 34992
   global.set $~lib/rt/tlsf/ROOT
  )
  (func $~lib/rt/itcms/step (type $none_=>_i32) (result i32)
@@ -918,7 +922,7 @@
      local.set $0
      loop $while-continue|0
       local.get $0
-      i32.const 34936
+      i32.const 34984
       i32.lt_u
       if
        local.get $0
@@ -1018,7 +1022,7 @@
      unreachable
     end
     local.get $0
-    i32.const 34936
+    i32.const 34984
     i32.lt_u
     if
      local.get $0
@@ -1041,7 +1045,7 @@
      i32.const 4
      i32.add
      local.tee $0
-     i32.const 34936
+     i32.const 34984
      i32.ge_u
      if
       global.get $~lib/rt/tlsf/ROOT
@@ -1612,7 +1616,138 @@
   f32.load $0
   drop
  )
- (func $~lib/array/Array<infer-array/Ref|null>#__uset (type $i32_i32_i32_=>_none) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/array/Array<infer-array/Ref|null>#__set (type $i32_i32_i32_=>_none) (param $0 i32) (param $1 i32) (param $2 i32)
+  (local $3 i32)
+  (local $4 i32)
+  (local $5 i32)
+  (local $6 i32)
+  local.get $1
+  local.get $0
+  i32.load $0 offset=12
+  i32.ge_u
+  if
+   local.get $1
+   i32.const 0
+   i32.lt_s
+   if
+    i32.const 1280
+    i32.const 1488
+    i32.const 130
+    i32.const 22
+    call $~lib/builtins/abort
+    unreachable
+   end
+   local.get $1
+   i32.const 1
+   i32.add
+   local.tee $5
+   local.get $0
+   i32.load $0 offset=8
+   local.tee $3
+   i32.const 2
+   i32.shr_u
+   i32.gt_u
+   if
+    local.get $5
+    i32.const 268435455
+    i32.gt_u
+    if
+     i32.const 1744
+     i32.const 1488
+     i32.const 19
+     i32.const 48
+     call $~lib/builtins/abort
+     unreachable
+    end
+    block $__inlined_func$~lib/rt/itcms/__renew
+     i32.const 1073741820
+     local.get $3
+     i32.const 1
+     i32.shl
+     local.tee $3
+     local.get $3
+     i32.const 1073741820
+     i32.ge_u
+     select
+     local.tee $4
+     i32.const 8
+     local.get $5
+     local.get $5
+     i32.const 8
+     i32.le_u
+     select
+     i32.const 2
+     i32.shl
+     local.tee $3
+     local.get $3
+     local.get $4
+     i32.lt_u
+     select
+     local.tee $6
+     local.get $0
+     i32.load $0
+     local.tee $3
+     i32.const 20
+     i32.sub
+     local.tee $5
+     i32.load $0
+     i32.const -4
+     i32.and
+     i32.const 16
+     i32.sub
+     i32.le_u
+     if
+      local.get $5
+      local.get $6
+      i32.store $0 offset=16
+      local.get $3
+      local.set $4
+      br $__inlined_func$~lib/rt/itcms/__renew
+     end
+     local.get $6
+     local.get $5
+     i32.load $0 offset=12
+     call $~lib/rt/itcms/__new
+     local.tee $4
+     local.get $3
+     local.get $6
+     local.get $5
+     i32.load $0 offset=16
+     local.tee $5
+     local.get $5
+     local.get $6
+     i32.gt_u
+     select
+     memory.copy $0 $0
+    end
+    local.get $3
+    local.get $4
+    i32.ne
+    if
+     local.get $0
+     local.get $4
+     i32.store $0
+     local.get $0
+     local.get $4
+     i32.store $0 offset=4
+     local.get $4
+     if
+      local.get $0
+      local.get $4
+      i32.const 0
+      call $byn-split-outlined-A$~lib/rt/itcms/__link
+     end
+    end
+    local.get $0
+    local.get $6
+    i32.store $0 offset=8
+   end
+   local.get $0
+   local.get $1
+   i32.const 1
+   i32.add
+   i32.store $0 offset=12
+  end
   local.get $0
   i32.load $0 offset=4
   local.get $1
@@ -1640,7 +1775,7 @@
   global.set $~lib/memory/__stack_pointer
   block $folding-inner0
    global.get $~lib/memory/__stack_pointer
-   i32.const 2168
+   i32.const 2216
    i32.lt_s
    br_if $folding-inner0
    global.get $~lib/memory/__stack_pointer
@@ -1651,7 +1786,7 @@
    memory.size $0
    i32.const 16
    i32.shl
-   i32.const 34936
+   i32.const 34984
    i32.sub
    i32.const 1
    i32.shr_u
@@ -1780,11 +1915,11 @@
    local.get $3
    i32.const 0
    local.get $0
-   call $~lib/array/Array<infer-array/Ref|null>#__uset
+   call $~lib/array/Array<infer-array/Ref|null>#__set
    local.get $3
    i32.const 1
    local.get $1
-   call $~lib/array/Array<infer-array/Ref|null>#__uset
+   call $~lib/array/Array<infer-array/Ref|null>#__set
    local.get $2
    local.get $3
    i32.store $0 offset=36
@@ -1816,11 +1951,11 @@
    local.get $3
    i32.const 0
    local.get $0
-   call $~lib/array/Array<infer-array/Ref|null>#__uset
+   call $~lib/array/Array<infer-array/Ref|null>#__set
    local.get $3
    i32.const 1
    local.get $1
-   call $~lib/array/Array<infer-array/Ref|null>#__uset
+   call $~lib/array/Array<infer-array/Ref|null>#__set
    local.get $2
    local.get $3
    i32.store $0 offset=56
@@ -1848,11 +1983,11 @@
    local.get $2
    i32.const 0
    local.get $0
-   call $~lib/array/Array<infer-array/Ref|null>#__uset
+   call $~lib/array/Array<infer-array/Ref|null>#__set
    local.get $2
    i32.const 1
    i32.const 0
-   call $~lib/array/Array<infer-array/Ref|null>#__uset
+   call $~lib/array/Array<infer-array/Ref|null>#__set
    local.get $1
    local.get $2
    i32.store $0 offset=72
@@ -1863,7 +1998,7 @@
    i32.const 2
    i32.const 2
    i32.const 10
-   i32.const 1776
+   i32.const 1824
    call $~lib/rt/__newArray
    local.tee $0
    i32.store $0 offset=76
@@ -1874,7 +2009,7 @@
    i32.const 1
    i32.const 2
    i32.const 11
-   i32.const 1808
+   i32.const 1856
    call $~lib/rt/__newArray
    local.tee $0
    i32.store $0 offset=80
@@ -1890,7 +2025,7 @@
    i32.const 2
    i32.const 2
    i32.const 11
-   i32.const 1840
+   i32.const 1888
    call $~lib/rt/__newArray
    local.tee $0
    i32.store $0 offset=84
@@ -1906,7 +2041,7 @@
    i32.const 2
    i32.const 2
    i32.const 4
-   i32.const 1872
+   i32.const 1920
    call $~lib/rt/__newArray
    local.tee $0
    i32.store $0 offset=88
@@ -1918,7 +2053,7 @@
    i32.const 2
    i32.const 2
    i32.const 4
-   i32.const 1904
+   i32.const 1952
    call $~lib/rt/__newArray
    local.tee $0
    i32.store $0 offset=92
@@ -1945,17 +2080,17 @@
    i32.const 1
    i32.const 2
    i32.const 4
-   i32.const 1936
+   i32.const 1984
    call $~lib/rt/__newArray
-   call $~lib/array/Array<infer-array/Ref|null>#__uset
+   call $~lib/array/Array<infer-array/Ref|null>#__set
    local.get $1
    i32.const 1
    i32.const 1
    i32.const 2
    i32.const 4
-   i32.const 1968
+   i32.const 2016
    call $~lib/rt/__newArray
-   call $~lib/array/Array<infer-array/Ref|null>#__uset
+   call $~lib/array/Array<infer-array/Ref|null>#__set
    local.get $0
    local.get $1
    i32.store $0 offset=104
@@ -1964,7 +2099,7 @@
    i32.sub
    global.set $~lib/memory/__stack_pointer
    global.get $~lib/memory/__stack_pointer
-   i32.const 2168
+   i32.const 2216
    i32.lt_s
    br_if $folding-inner0
    global.get $~lib/memory/__stack_pointer
@@ -1990,7 +2125,7 @@
    local.get $0
    i32.eqz
    if
-    i32.const 2000
+    i32.const 2048
     i32.const 1488
     i32.const 118
     i32.const 40
@@ -2007,8 +2142,8 @@
    global.set $~lib/memory/__stack_pointer
    return
   end
-  i32.const 34960
   i32.const 35008
+  i32.const 35056
   i32.const 1
   i32.const 1
   call $~lib/builtins/abort
@@ -2097,11 +2232,11 @@
   i32.sub
   global.set $~lib/memory/__stack_pointer
   global.get $~lib/memory/__stack_pointer
-  i32.const 2168
+  i32.const 2216
   i32.lt_s
   if
-   i32.const 34960
    i32.const 35008
+   i32.const 35056
    i32.const 1
    i32.const 1
    call $~lib/builtins/abort
@@ -2165,7 +2300,7 @@
   global.set $~lib/memory/__stack_pointer
   block $folding-inner0
    global.get $~lib/memory/__stack_pointer
-   i32.const 2168
+   i32.const 2216
    i32.lt_s
    br_if $folding-inner0
    global.get $~lib/memory/__stack_pointer
@@ -2184,7 +2319,7 @@
    i32.sub
    global.set $~lib/memory/__stack_pointer
    global.get $~lib/memory/__stack_pointer
-   i32.const 2168
+   i32.const 2216
    i32.lt_s
    br_if $folding-inner0
    global.get $~lib/memory/__stack_pointer
@@ -2214,8 +2349,8 @@
    local.get $0
    return
   end
-  i32.const 34960
   i32.const 35008
+  i32.const 35056
   i32.const 1
   i32.const 1
   call $~lib/builtins/abort
@@ -2228,11 +2363,11 @@
   i32.sub
   global.set $~lib/memory/__stack_pointer
   global.get $~lib/memory/__stack_pointer
-  i32.const 2168
+  i32.const 2216
   i32.lt_s
   if
-   i32.const 34960
    i32.const 35008
+   i32.const 35056
    i32.const 1
    i32.const 1
    call $~lib/builtins/abort

--- a/tests/compiler/issues/1699.debug.wat
+++ b/tests/compiler/issues/1699.debug.wat
@@ -2498,22 +2498,6 @@
   local.get $this
   i32.load $0 offset=4
  )
- (func $~lib/array/Array<issues/1699/MultiAssignmentTest>#__uset (type $i32_i32_i32_=>_none) (param $this i32) (param $index i32) (param $value i32)
-  local.get $this
-  call $~lib/array/Array<issues/1699/MultiAssignmentTest>#get:dataStart
-  local.get $index
-  i32.const 2
-  i32.shl
-  i32.add
-  local.get $value
-  i32.store $0
-  i32.const 1
-  drop
-  local.get $this
-  local.get $value
-  i32.const 1
-  call $~lib/rt/itcms/__link
- )
  (func $~lib/array/Array<issues/1699/MultiAssignmentTest>#__set (type $i32_i32_i32_=>_none) (param $this i32) (param $index i32) (param $value i32)
   local.get $index
   local.get $this
@@ -2545,9 +2529,19 @@
    call $~lib/array/Array<issues/1699/MultiAssignmentTest>#set:length_
   end
   local.get $this
+  call $~lib/array/Array<issues/1699/MultiAssignmentTest>#get:dataStart
   local.get $index
+  i32.const 2
+  i32.shl
+  i32.add
   local.get $value
-  call $~lib/array/Array<issues/1699/MultiAssignmentTest>#__uset
+  i32.store $0
+  i32.const 1
+  drop
+  local.get $this
+  local.get $value
+  i32.const 1
+  call $~lib/rt/itcms/__link
  )
  (func $~lib/array/Array<issues/1699/MultiAssignmentTest>#get:length (type $i32_=>_i32) (param $this i32) (result i32)
   local.get $this

--- a/tests/compiler/std/array-literal.debug.wat
+++ b/tests/compiler/std/array-literal.debug.wat
@@ -3,10 +3,10 @@
  (type $i32_i32_=>_none (func_subtype (param i32 i32) func))
  (type $i32_=>_none (func_subtype (param i32) func))
  (type $i32_i32_i32_=>_none (func_subtype (param i32 i32 i32) func))
- (type $none_=>_none (func_subtype func))
  (type $i32_i32_=>_i32 (func_subtype (param i32 i32) (result i32) func))
- (type $i32_i32_i32_=>_i32 (func_subtype (param i32 i32 i32) (result i32) func))
+ (type $none_=>_none (func_subtype func))
  (type $i32_i32_i32_i32_=>_none (func_subtype (param i32 i32 i32 i32) func))
+ (type $i32_i32_i32_=>_i32 (func_subtype (param i32 i32 i32) (result i32) func))
  (type $none_=>_i32 (func_subtype (result i32) func))
  (type $i32_i32_i32_i32_=>_i32 (func_subtype (param i32 i32 i32 i32) (result i32) func))
  (import "env" "abort" (func $~lib/builtins/abort (param i32 i32 i32 i32)))
@@ -28,14 +28,15 @@
  (global $~lib/rt/itcms/fromSpace (mut i32) (i32.const 0))
  (global $~lib/rt/tlsf/ROOT (mut i32) (i32.const 0))
  (global $~lib/native/ASC_LOW_MEMORY_LIMIT i32 (i32.const 0))
+ (global $~lib/native/ASC_RUNTIME i32 (i32.const 2))
  (global $std/array-literal/dynamicArrayI8 (mut i32) (i32.const 0))
  (global $std/array-literal/dynamicArrayI32 (mut i32) (i32.const 0))
  (global $std/array-literal/dynamicArrayRef (mut i32) (i32.const 0))
  (global $std/array-literal/dynamicArrayRefWithCtor (mut i32) (i32.const 0))
- (global $~lib/rt/__rtti_base i32 (i32.const 768))
- (global $~lib/memory/__data_end i32 (i32.const 812))
- (global $~lib/memory/__stack_pointer (mut i32) (i32.const 33580))
- (global $~lib/memory/__heap_base i32 (i32.const 33580))
+ (global $~lib/rt/__rtti_base i32 (i32.const 816))
+ (global $~lib/memory/__data_end i32 (i32.const 860))
+ (global $~lib/memory/__stack_pointer (mut i32) (i32.const 33628))
+ (global $~lib/memory/__heap_base i32 (i32.const 33628))
  (memory $0 1)
  (data (i32.const 12) "\1c\00\00\00\00\00\00\00\00\00\00\00\01\00\00\00\03\00\00\00\00\01\02\00\00\00\00\00\00\00\00\00")
  (data (i32.const 44) ",\00\00\00\00\00\00\00\00\00\00\00\04\00\00\00\10\00\00\00 \00\00\00 \00\00\00\03\00\00\00\03\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00")
@@ -53,7 +54,8 @@
  (data (i32.const 620) ",\00\00\00\00\00\00\00\00\00\00\00\02\00\00\00\14\00\00\00~\00l\00i\00b\00/\00r\00t\00.\00t\00s\00\00\00\00\00\00\00\00\00")
  (data (i32.const 672) "\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00")
  (data (i32.const 700) "<\00\00\00\00\00\00\00\00\00\00\00\02\00\00\00\1e\00\00\00~\00l\00i\00b\00/\00r\00t\00/\00t\00l\00s\00f\00.\00t\00s\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00")
- (data (i32.const 768) "\n\00\00\00 \00\00\00 \00\00\00 \00\00\00\00\00\00\00B\08\00\00\02\t\00\00 \00\00\00\02A\00\00 \00\00\00\02A\00\00")
+ (data (i32.const 764) ",\00\00\00\00\00\00\00\00\00\00\00\02\00\00\00\1c\00\00\00I\00n\00v\00a\00l\00i\00d\00 \00l\00e\00n\00g\00t\00h\00")
+ (data (i32.const 816) "\n\00\00\00 \00\00\00 \00\00\00 \00\00\00\00\00\00\00B\08\00\00\02\t\00\00 \00\00\00\02A\00\00 \00\00\00\02A\00\00")
  (table $0 1 1 funcref)
  (elem $0 (i32.const 1))
  (export "memory" (memory $0))
@@ -2415,7 +2417,195 @@
    end
   end
  )
- (func $~lib/array/Array<i8>#__uset (type $i32_i32_i32_=>_none) (param $this i32) (param $index i32) (param $value i32)
+ (func $~lib/arraybuffer/ArrayBufferView#get:byteLength (type $i32_=>_i32) (param $this i32) (result i32)
+  local.get $this
+  i32.load $0 offset=8
+ )
+ (func $~lib/arraybuffer/ArrayBufferView#get:buffer (type $i32_=>_i32) (param $this i32) (result i32)
+  local.get $this
+  i32.load $0
+ )
+ (func $~lib/rt/itcms/Object#get:rtSize (type $i32_=>_i32) (param $this i32) (result i32)
+  local.get $this
+  i32.load $0 offset=16
+ )
+ (func $~lib/rt/itcms/__renew (type $i32_i32_=>_i32) (param $oldPtr i32) (param $size i32) (result i32)
+  (local $oldObj i32)
+  (local $newPtr i32)
+  (local $4 i32)
+  (local $5 i32)
+  local.get $oldPtr
+  i32.const 20
+  i32.sub
+  local.set $oldObj
+  local.get $size
+  local.get $oldObj
+  call $~lib/rt/common/BLOCK#get:mmInfo
+  i32.const 3
+  i32.const -1
+  i32.xor
+  i32.and
+  i32.const 16
+  i32.sub
+  i32.le_u
+  if
+   local.get $oldObj
+   local.get $size
+   call $~lib/rt/itcms/Object#set:rtSize
+   local.get $oldPtr
+   return
+  end
+  local.get $size
+  local.get $oldObj
+  call $~lib/rt/itcms/Object#get:rtId
+  call $~lib/rt/itcms/__new
+  local.set $newPtr
+  local.get $newPtr
+  local.get $oldPtr
+  local.get $size
+  local.tee $4
+  local.get $oldObj
+  call $~lib/rt/itcms/Object#get:rtSize
+  local.tee $5
+  local.get $4
+  local.get $5
+  i32.lt_u
+  select
+  memory.copy $0 $0
+  local.get $newPtr
+  return
+ )
+ (func $~lib/array/ensureCapacity (type $i32_i32_i32_i32_=>_none) (param $array i32) (param $newSize i32) (param $alignLog2 i32) (param $canGrow i32)
+  (local $oldCapacity i32)
+  (local $oldData i32)
+  (local $6 i32)
+  (local $7 i32)
+  (local $newCapacity i32)
+  (local $9 i32)
+  (local $10 i32)
+  (local $11 i32)
+  (local $12 i32)
+  (local $newData i32)
+  local.get $array
+  call $~lib/arraybuffer/ArrayBufferView#get:byteLength
+  local.set $oldCapacity
+  local.get $newSize
+  local.get $oldCapacity
+  local.get $alignLog2
+  i32.shr_u
+  i32.gt_u
+  if
+   local.get $newSize
+   i32.const 1073741820
+   local.get $alignLog2
+   i32.shr_u
+   i32.gt_u
+   if
+    i32.const 784
+    i32.const 240
+    i32.const 19
+    i32.const 48
+    call $~lib/builtins/abort
+    unreachable
+   end
+   local.get $array
+   call $~lib/arraybuffer/ArrayBufferView#get:buffer
+   local.set $oldData
+   local.get $newSize
+   local.tee $6
+   i32.const 8
+   local.tee $7
+   local.get $6
+   local.get $7
+   i32.gt_u
+   select
+   local.get $alignLog2
+   i32.shl
+   local.set $newCapacity
+   local.get $canGrow
+   if
+    local.get $oldCapacity
+    i32.const 1
+    i32.shl
+    local.tee $9
+    i32.const 1073741820
+    local.tee $10
+    local.get $9
+    local.get $10
+    i32.lt_u
+    select
+    local.tee $11
+    local.get $newCapacity
+    local.tee $12
+    local.get $11
+    local.get $12
+    i32.gt_u
+    select
+    local.set $newCapacity
+   end
+   local.get $oldData
+   local.get $newCapacity
+   call $~lib/rt/itcms/__renew
+   local.set $newData
+   i32.const 2
+   global.get $~lib/shared/runtime/Runtime.Incremental
+   i32.ne
+   drop
+   local.get $newData
+   local.get $oldData
+   i32.ne
+   if
+    local.get $array
+    local.get $newData
+    i32.store $0
+    local.get $array
+    local.get $newData
+    i32.store $0 offset=4
+    local.get $array
+    local.get $newData
+    i32.const 0
+    call $~lib/rt/itcms/__link
+   end
+   local.get $array
+   local.get $newCapacity
+   i32.store $0 offset=8
+  end
+ )
+ (func $~lib/array/Array<i8>#set:length_ (type $i32_i32_=>_none) (param $this i32) (param $length_ i32)
+  local.get $this
+  local.get $length_
+  i32.store $0 offset=12
+ )
+ (func $~lib/array/Array<i8>#__set (type $i32_i32_i32_=>_none) (param $this i32) (param $index i32) (param $value i32)
+  local.get $index
+  local.get $this
+  call $~lib/array/Array<i8>#get:length_
+  i32.ge_u
+  if
+   local.get $index
+   i32.const 0
+   i32.lt_s
+   if
+    i32.const 176
+    i32.const 240
+    i32.const 130
+    i32.const 22
+    call $~lib/builtins/abort
+    unreachable
+   end
+   local.get $this
+   local.get $index
+   i32.const 1
+   i32.add
+   i32.const 0
+   i32.const 1
+   call $~lib/array/ensureCapacity
+   local.get $this
+   local.get $index
+   i32.const 1
+   i32.add
+   call $~lib/array/Array<i8>#set:length_
+  end
   local.get $this
   call $~lib/array/Array<i8>#get:dataStart
   local.get $index
@@ -2427,7 +2617,41 @@
   i32.const 0
   drop
  )
- (func $~lib/array/Array<i32>#__uset (type $i32_i32_i32_=>_none) (param $this i32) (param $index i32) (param $value i32)
+ (func $~lib/array/Array<i32>#set:length_ (type $i32_i32_=>_none) (param $this i32) (param $length_ i32)
+  local.get $this
+  local.get $length_
+  i32.store $0 offset=12
+ )
+ (func $~lib/array/Array<i32>#__set (type $i32_i32_i32_=>_none) (param $this i32) (param $index i32) (param $value i32)
+  local.get $index
+  local.get $this
+  call $~lib/array/Array<i32>#get:length_
+  i32.ge_u
+  if
+   local.get $index
+   i32.const 0
+   i32.lt_s
+   if
+    i32.const 176
+    i32.const 240
+    i32.const 130
+    i32.const 22
+    call $~lib/builtins/abort
+    unreachable
+   end
+   local.get $this
+   local.get $index
+   i32.const 1
+   i32.add
+   i32.const 2
+   i32.const 1
+   call $~lib/array/ensureCapacity
+   local.get $this
+   local.get $index
+   i32.const 1
+   i32.add
+   call $~lib/array/Array<i32>#set:length_
+  end
   local.get $this
   call $~lib/array/Array<i32>#get:dataStart
   local.get $index
@@ -2439,11 +2663,49 @@
   i32.const 0
   drop
  )
+ (func $~lib/array/Array<std/array-literal/Ref>#get:length_ (type $i32_=>_i32) (param $this i32) (result i32)
+  local.get $this
+  i32.load $0 offset=12
+ )
+ (func $~lib/array/Array<std/array-literal/Ref>#set:length_ (type $i32_i32_=>_none) (param $this i32) (param $length_ i32)
+  local.get $this
+  local.get $length_
+  i32.store $0 offset=12
+ )
  (func $~lib/array/Array<std/array-literal/Ref>#get:dataStart (type $i32_=>_i32) (param $this i32) (result i32)
   local.get $this
   i32.load $0 offset=4
  )
- (func $~lib/array/Array<std/array-literal/Ref>#__uset (type $i32_i32_i32_=>_none) (param $this i32) (param $index i32) (param $value i32)
+ (func $~lib/array/Array<std/array-literal/Ref>#__set (type $i32_i32_i32_=>_none) (param $this i32) (param $index i32) (param $value i32)
+  local.get $index
+  local.get $this
+  call $~lib/array/Array<std/array-literal/Ref>#get:length_
+  i32.ge_u
+  if
+   local.get $index
+   i32.const 0
+   i32.lt_s
+   if
+    i32.const 176
+    i32.const 240
+    i32.const 130
+    i32.const 22
+    call $~lib/builtins/abort
+    unreachable
+   end
+   local.get $this
+   local.get $index
+   i32.const 1
+   i32.add
+   i32.const 2
+   i32.const 1
+   call $~lib/array/ensureCapacity
+   local.get $this
+   local.get $index
+   i32.const 1
+   i32.add
+   call $~lib/array/Array<std/array-literal/Ref>#set:length_
+  end
   local.get $this
   call $~lib/array/Array<std/array-literal/Ref>#get:dataStart
   local.get $index
@@ -2459,20 +2721,54 @@
   i32.const 1
   call $~lib/rt/itcms/__link
  )
- (func $~lib/array/Array<std/array-literal/Ref>#get:length_ (type $i32_=>_i32) (param $this i32) (result i32)
-  local.get $this
-  i32.load $0 offset=12
- )
  (func $~lib/array/Array<std/array-literal/Ref>#get:length (type $i32_=>_i32) (param $this i32) (result i32)
   local.get $this
   call $~lib/array/Array<std/array-literal/Ref>#get:length_
   return
  )
+ (func $~lib/array/Array<std/array-literal/RefWithCtor>#get:length_ (type $i32_=>_i32) (param $this i32) (result i32)
+  local.get $this
+  i32.load $0 offset=12
+ )
+ (func $~lib/array/Array<std/array-literal/RefWithCtor>#set:length_ (type $i32_i32_=>_none) (param $this i32) (param $length_ i32)
+  local.get $this
+  local.get $length_
+  i32.store $0 offset=12
+ )
  (func $~lib/array/Array<std/array-literal/RefWithCtor>#get:dataStart (type $i32_=>_i32) (param $this i32) (result i32)
   local.get $this
   i32.load $0 offset=4
  )
- (func $~lib/array/Array<std/array-literal/RefWithCtor>#__uset (type $i32_i32_i32_=>_none) (param $this i32) (param $index i32) (param $value i32)
+ (func $~lib/array/Array<std/array-literal/RefWithCtor>#__set (type $i32_i32_i32_=>_none) (param $this i32) (param $index i32) (param $value i32)
+  local.get $index
+  local.get $this
+  call $~lib/array/Array<std/array-literal/RefWithCtor>#get:length_
+  i32.ge_u
+  if
+   local.get $index
+   i32.const 0
+   i32.lt_s
+   if
+    i32.const 176
+    i32.const 240
+    i32.const 130
+    i32.const 22
+    call $~lib/builtins/abort
+    unreachable
+   end
+   local.get $this
+   local.get $index
+   i32.const 1
+   i32.add
+   i32.const 2
+   i32.const 1
+   call $~lib/array/ensureCapacity
+   local.get $this
+   local.get $index
+   i32.const 1
+   i32.add
+   call $~lib/array/Array<std/array-literal/RefWithCtor>#set:length_
+  end
   local.get $this
   call $~lib/array/Array<std/array-literal/RefWithCtor>#get:dataStart
   local.get $index
@@ -2487,10 +2783,6 @@
   local.get $value
   i32.const 1
   call $~lib/rt/itcms/__link
- )
- (func $~lib/array/Array<std/array-literal/RefWithCtor>#get:length_ (type $i32_=>_i32) (param $this i32) (result i32)
-  local.get $this
-  i32.load $0 offset=12
  )
  (func $~lib/array/Array<std/array-literal/RefWithCtor>#get:length (type $i32_=>_i32) (param $this i32) (result i32)
   local.get $this
@@ -2598,6 +2890,9 @@
    call $~lib/rt/itcms/__visit
   end
   i32.const 176
+  local.get $0
+  call $~lib/rt/itcms/__visit
+  i32.const 784
   local.get $0
   call $~lib/rt/itcms/__visit
   i32.const 448
@@ -2832,8 +3127,8 @@
   global.get $~lib/memory/__data_end
   i32.lt_s
   if
-   i32.const 33600
    i32.const 33648
+   i32.const 33696
    i32.const 1
    i32.const 1
    call $~lib/builtins/abort
@@ -3068,7 +3363,7 @@
   local.get $6
   i32.const 0
   global.get $std/array-literal/i
-  call $~lib/array/Array<i8>#__uset
+  call $~lib/array/Array<i8>#__set
   local.get $6
   i32.const 1
   global.get $std/array-literal/i
@@ -3076,7 +3371,7 @@
   i32.add
   global.set $std/array-literal/i
   global.get $std/array-literal/i
-  call $~lib/array/Array<i8>#__uset
+  call $~lib/array/Array<i8>#__set
   local.get $6
   i32.const 2
   global.get $std/array-literal/i
@@ -3084,7 +3379,7 @@
   i32.add
   global.set $std/array-literal/i
   global.get $std/array-literal/i
-  call $~lib/array/Array<i8>#__uset
+  call $~lib/array/Array<i8>#__set
   local.get $6
   global.set $std/array-literal/dynamicArrayI8
   global.get $std/array-literal/dynamicArrayI8
@@ -3180,7 +3475,7 @@
   local.get $8
   i32.const 0
   global.get $std/array-literal/i
-  call $~lib/array/Array<i32>#__uset
+  call $~lib/array/Array<i32>#__set
   local.get $8
   i32.const 1
   global.get $std/array-literal/i
@@ -3188,7 +3483,7 @@
   i32.add
   global.set $std/array-literal/i
   global.get $std/array-literal/i
-  call $~lib/array/Array<i32>#__uset
+  call $~lib/array/Array<i32>#__set
   local.get $8
   i32.const 2
   global.get $std/array-literal/i
@@ -3196,7 +3491,7 @@
   i32.add
   global.set $std/array-literal/i
   global.get $std/array-literal/i
-  call $~lib/array/Array<i32>#__uset
+  call $~lib/array/Array<i32>#__set
   local.get $8
   global.set $std/array-literal/dynamicArrayI32
   global.get $std/array-literal/dynamicArrayI32
@@ -3291,17 +3586,17 @@
   i32.const 0
   i32.const 0
   call $std/array-literal/Ref#constructor
-  call $~lib/array/Array<std/array-literal/Ref>#__uset
+  call $~lib/array/Array<std/array-literal/Ref>#__set
   local.get $10
   i32.const 1
   i32.const 0
   call $std/array-literal/Ref#constructor
-  call $~lib/array/Array<std/array-literal/Ref>#__uset
+  call $~lib/array/Array<std/array-literal/Ref>#__set
   local.get $10
   i32.const 2
   i32.const 0
   call $std/array-literal/Ref#constructor
-  call $~lib/array/Array<std/array-literal/Ref>#__uset
+  call $~lib/array/Array<std/array-literal/Ref>#__set
   local.get $10
   global.set $std/array-literal/dynamicArrayRef
   global.get $std/array-literal/dynamicArrayRef
@@ -3339,17 +3634,17 @@
   i32.const 0
   i32.const 0
   call $std/array-literal/RefWithCtor#constructor
-  call $~lib/array/Array<std/array-literal/RefWithCtor>#__uset
+  call $~lib/array/Array<std/array-literal/RefWithCtor>#__set
   local.get $12
   i32.const 1
   i32.const 0
   call $std/array-literal/RefWithCtor#constructor
-  call $~lib/array/Array<std/array-literal/RefWithCtor>#__uset
+  call $~lib/array/Array<std/array-literal/RefWithCtor>#__set
   local.get $12
   i32.const 2
   i32.const 0
   call $std/array-literal/RefWithCtor#constructor
-  call $~lib/array/Array<std/array-literal/RefWithCtor>#__uset
+  call $~lib/array/Array<std/array-literal/RefWithCtor>#__set
   local.get $12
   global.set $std/array-literal/dynamicArrayRefWithCtor
   global.get $std/array-literal/dynamicArrayRefWithCtor
@@ -3397,7 +3692,7 @@
   i32.const 0
   i32.const 0
   call $std/array-literal/Ref#constructor
-  call $~lib/array/Array<std/array-literal/Ref>#__uset
+  call $~lib/array/Array<std/array-literal/Ref>#__set
   local.get $14
   local.set $16
   global.get $~lib/memory/__stack_pointer

--- a/tests/compiler/std/array-literal.release.wat
+++ b/tests/compiler/std/array-literal.release.wat
@@ -1,8 +1,8 @@
 (module
+ (type $i32_i32_i32_=>_none (func_subtype (param i32 i32 i32) func))
  (type $i32_i32_=>_i32 (func_subtype (param i32 i32) (result i32) func))
  (type $none_=>_none (func_subtype func))
  (type $i32_=>_none (func_subtype (param i32) func))
- (type $i32_i32_i32_=>_none (func_subtype (param i32 i32 i32) func))
  (type $none_=>_i32 (func_subtype (result i32) func))
  (type $i32_i32_=>_none (func_subtype (param i32 i32) func))
  (type $i32_i32_i32_i32_=>_none (func_subtype (param i32 i32 i32 i32) func))
@@ -24,7 +24,7 @@
  (global $std/array-literal/dynamicArrayI32 (mut i32) (i32.const 0))
  (global $std/array-literal/dynamicArrayRef (mut i32) (i32.const 0))
  (global $std/array-literal/dynamicArrayRefWithCtor (mut i32) (i32.const 0))
- (global $~lib/memory/__stack_pointer (mut i32) (i32.const 34604))
+ (global $~lib/memory/__stack_pointer (mut i32) (i32.const 34652))
  (memory $0 1)
  (data (i32.const 1036) "\1c")
  (data (i32.const 1048) "\01\00\00\00\03\00\00\00\00\01\02")
@@ -52,7 +52,9 @@
  (data (i32.const 1656) "\02\00\00\00\14\00\00\00~\00l\00i\00b\00/\00r\00t\00.\00t\00s")
  (data (i32.const 1724) "<")
  (data (i32.const 1736) "\02\00\00\00\1e\00\00\00~\00l\00i\00b\00/\00r\00t\00/\00t\00l\00s\00f\00.\00t\00s")
- (data (i32.const 1792) "\n\00\00\00 \00\00\00 \00\00\00 \00\00\00\00\00\00\00B\08\00\00\02\t\00\00 \00\00\00\02A\00\00 \00\00\00\02A")
+ (data (i32.const 1788) ",")
+ (data (i32.const 1800) "\02\00\00\00\1c\00\00\00I\00n\00v\00a\00l\00i\00d\00 \00l\00e\00n\00g\00t\00h")
+ (data (i32.const 1840) "\n\00\00\00 \00\00\00 \00\00\00 \00\00\00\00\00\00\00B\08\00\00\02\t\00\00 \00\00\00\02A\00\00 \00\00\00\02A")
  (export "memory" (memory $0))
  (start $~start)
  (func $~lib/array/Array<i8>#__get (type $i32_i32_=>_i32) (param $0 i32) (param $1 i32) (result i32)
@@ -134,6 +136,8 @@
   end
   i32.const 1200
   call $byn-split-outlined-A$~lib/rt/itcms/__visit
+  i32.const 1808
+  call $byn-split-outlined-A$~lib/rt/itcms/__visit
   i32.const 1472
   call $byn-split-outlined-A$~lib/rt/itcms/__visit
   global.get $~lib/rt/itcms/pinSpace
@@ -209,7 +213,7 @@
     i32.load $0 offset=8
     i32.eqz
     local.get $0
-    i32.const 34604
+    i32.const 34652
     i32.lt_u
     i32.and
     i32.eqz
@@ -258,7 +262,7 @@
    i32.const 1
   else
    local.get $1
-   i32.const 1792
+   i32.const 1840
    i32.load $0
    i32.gt_u
    if
@@ -272,7 +276,7 @@
    local.get $1
    i32.const 2
    i32.shl
-   i32.const 1796
+   i32.const 1844
    i32.add
    i32.load $0
    i32.const 32
@@ -837,10 +841,10 @@
   if
    unreachable
   end
-  i32.const 34608
+  i32.const 34656
   i32.const 0
   i32.store $0
-  i32.const 36176
+  i32.const 36224
   i32.const 0
   i32.store $0
   loop $for-loop|0
@@ -851,7 +855,7 @@
     local.get $0
     i32.const 2
     i32.shl
-    i32.const 34608
+    i32.const 34656
     i32.add
     i32.const 0
     i32.store $0 offset=4
@@ -869,7 +873,7 @@
       i32.add
       i32.const 2
       i32.shl
-      i32.const 34608
+      i32.const 34656
       i32.add
       i32.const 0
       i32.store $0 offset=96
@@ -887,13 +891,13 @@
     br $for-loop|0
    end
   end
-  i32.const 34608
-  i32.const 36180
+  i32.const 34656
+  i32.const 36228
   memory.size $0
   i32.const 16
   i32.shl
   call $~lib/rt/tlsf/addMemory
-  i32.const 34608
+  i32.const 34656
   global.set $~lib/rt/tlsf/ROOT
  )
  (func $~lib/rt/itcms/step (type $none_=>_i32) (result i32)
@@ -978,7 +982,7 @@
      local.set $0
      loop $while-continue|0
       local.get $0
-      i32.const 34604
+      i32.const 34652
       i32.lt_u
       if
        local.get $0
@@ -1078,7 +1082,7 @@
      unreachable
     end
     local.get $0
-    i32.const 34604
+    i32.const 34652
     i32.lt_u
     if
      local.get $0
@@ -1101,7 +1105,7 @@
      i32.const 4
      i32.add
      local.tee $0
-     i32.const 34604
+     i32.const 34652
      i32.ge_u
      if
       global.get $~lib/rt/tlsf/ROOT
@@ -1595,7 +1599,217 @@
   memory.fill $0
   local.get $1
  )
- (func $~lib/array/Array<std/array-literal/Ref>#__uset (type $i32_i32_i32_=>_none) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/array/ensureCapacity (type $i32_i32_i32_=>_none) (param $0 i32) (param $1 i32) (param $2 i32)
+  (local $3 i32)
+  (local $4 i32)
+  local.get $1
+  local.get $0
+  i32.load $0 offset=8
+  local.tee $3
+  local.get $2
+  i32.shr_u
+  i32.gt_u
+  if
+   local.get $1
+   i32.const 1073741820
+   local.get $2
+   i32.shr_u
+   i32.gt_u
+   if
+    i32.const 1808
+    i32.const 1264
+    i32.const 19
+    i32.const 48
+    call $~lib/builtins/abort
+    unreachable
+   end
+   block $__inlined_func$~lib/rt/itcms/__renew
+    i32.const 1073741820
+    local.get $3
+    i32.const 1
+    i32.shl
+    local.tee $3
+    local.get $3
+    i32.const 1073741820
+    i32.ge_u
+    select
+    local.tee $3
+    i32.const 8
+    local.get $1
+    local.get $1
+    i32.const 8
+    i32.le_u
+    select
+    local.get $2
+    i32.shl
+    local.tee $1
+    local.get $1
+    local.get $3
+    i32.lt_u
+    select
+    local.tee $3
+    local.get $0
+    i32.load $0
+    local.tee $2
+    i32.const 20
+    i32.sub
+    local.tee $4
+    i32.load $0
+    i32.const -4
+    i32.and
+    i32.const 16
+    i32.sub
+    i32.le_u
+    if
+     local.get $4
+     local.get $3
+     i32.store $0 offset=16
+     local.get $2
+     local.set $1
+     br $__inlined_func$~lib/rt/itcms/__renew
+    end
+    local.get $3
+    local.get $4
+    i32.load $0 offset=12
+    call $~lib/rt/itcms/__new
+    local.tee $1
+    local.get $2
+    local.get $3
+    local.get $4
+    i32.load $0 offset=16
+    local.tee $4
+    local.get $3
+    local.get $4
+    i32.lt_u
+    select
+    memory.copy $0 $0
+   end
+   local.get $1
+   local.get $2
+   i32.ne
+   if
+    local.get $0
+    local.get $1
+    i32.store $0
+    local.get $0
+    local.get $1
+    i32.store $0 offset=4
+    local.get $1
+    if
+     local.get $0
+     local.get $1
+     i32.const 0
+     call $byn-split-outlined-A$~lib/rt/itcms/__link
+    end
+   end
+   local.get $0
+   local.get $3
+   i32.store $0 offset=8
+  end
+ )
+ (func $~lib/array/Array<i8>#__set (type $i32_i32_i32_=>_none) (param $0 i32) (param $1 i32) (param $2 i32)
+  (local $3 i32)
+  local.get $1
+  local.get $0
+  i32.load $0 offset=12
+  i32.ge_u
+  if
+   local.get $1
+   i32.const 0
+   i32.lt_s
+   if
+    i32.const 1200
+    i32.const 1264
+    i32.const 130
+    i32.const 22
+    call $~lib/builtins/abort
+    unreachable
+   end
+   local.get $0
+   local.get $1
+   i32.const 1
+   i32.add
+   local.tee $3
+   i32.const 0
+   call $~lib/array/ensureCapacity
+   local.get $0
+   local.get $3
+   i32.store $0 offset=12
+  end
+  local.get $0
+  i32.load $0 offset=4
+  local.get $1
+  i32.add
+  local.get $2
+  i32.store8 $0
+ )
+ (func $~lib/array/Array<i32>#__set (type $i32_i32_i32_=>_none) (param $0 i32) (param $1 i32) (param $2 i32)
+  (local $3 i32)
+  local.get $1
+  local.get $0
+  i32.load $0 offset=12
+  i32.ge_u
+  if
+   local.get $1
+   i32.const 0
+   i32.lt_s
+   if
+    i32.const 1200
+    i32.const 1264
+    i32.const 130
+    i32.const 22
+    call $~lib/builtins/abort
+    unreachable
+   end
+   local.get $0
+   local.get $1
+   i32.const 1
+   i32.add
+   local.tee $3
+   i32.const 2
+   call $~lib/array/ensureCapacity
+   local.get $0
+   local.get $3
+   i32.store $0 offset=12
+  end
+  local.get $0
+  i32.load $0 offset=4
+  local.get $1
+  i32.const 2
+  i32.shl
+  i32.add
+  local.get $2
+  i32.store $0
+ )
+ (func $~lib/array/Array<std/array-literal/Ref>#__set (type $i32_i32_i32_=>_none) (param $0 i32) (param $1 i32) (param $2 i32)
+  (local $3 i32)
+  local.get $1
+  local.get $0
+  i32.load $0 offset=12
+  i32.ge_u
+  if
+   local.get $1
+   i32.const 0
+   i32.lt_s
+   if
+    i32.const 1200
+    i32.const 1264
+    i32.const 130
+    i32.const 22
+    call $~lib/builtins/abort
+    unreachable
+   end
+   local.get $0
+   local.get $1
+   i32.const 1
+   i32.add
+   local.tee $3
+   i32.const 2
+   call $~lib/array/ensureCapacity
+   local.get $0
+   local.get $3
+   i32.store $0 offset=12
+  end
   local.get $0
   i32.load $0 offset=4
   local.get $1
@@ -1701,17 +1915,16 @@
  )
  (func $start:std/array-literal (type $none_=>_none)
   (local $0 i32)
-  (local $1 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 44
   i32.sub
   global.set $~lib/memory/__stack_pointer
   global.get $~lib/memory/__stack_pointer
-  i32.const 1836
+  i32.const 1884
   i32.lt_s
   if
-   i32.const 34624
    i32.const 34672
+   i32.const 34720
    i32.const 1
    i32.const 1
    call $~lib/builtins/abort
@@ -1861,7 +2074,7 @@
   memory.size $0
   i32.const 16
   i32.shl
-  i32.const 34604
+  i32.const 34652
   i32.sub
   i32.const 1
   i32.shr_u
@@ -1902,26 +2115,25 @@
   i32.load $0 offset=4
   i32.store $0 offset=8
   local.get $0
-  i32.load $0 offset=4
+  i32.const 0
   global.get $std/array-literal/i
-  local.tee $1
-  i32.store8 $0
-  local.get $1
-  i32.const 1
-  i32.add
-  global.set $std/array-literal/i
-  local.get $0
-  i32.load $0 offset=4
-  global.get $std/array-literal/i
-  i32.store8 $0 offset=1
+  call $~lib/array/Array<i8>#__set
   global.get $std/array-literal/i
   i32.const 1
   i32.add
   global.set $std/array-literal/i
   local.get $0
-  i32.load $0 offset=4
+  i32.const 1
   global.get $std/array-literal/i
-  i32.store8 $0 offset=2
+  call $~lib/array/Array<i8>#__set
+  global.get $std/array-literal/i
+  i32.const 1
+  i32.add
+  global.set $std/array-literal/i
+  local.get $0
+  i32.const 2
+  global.get $std/array-literal/i
+  call $~lib/array/Array<i8>#__set
   local.get $0
   global.set $std/array-literal/dynamicArrayI8
   global.get $~lib/memory/__stack_pointer
@@ -2003,26 +2215,25 @@
   i32.load $0 offset=4
   i32.store $0 offset=16
   local.get $0
-  i32.load $0 offset=4
+  i32.const 0
   global.get $std/array-literal/i
-  local.tee $1
-  i32.store $0
-  local.get $1
-  i32.const 1
-  i32.add
-  global.set $std/array-literal/i
-  local.get $0
-  i32.load $0 offset=4
-  global.get $std/array-literal/i
-  i32.store $0 offset=4
+  call $~lib/array/Array<i32>#__set
   global.get $std/array-literal/i
   i32.const 1
   i32.add
   global.set $std/array-literal/i
   local.get $0
-  i32.load $0 offset=4
+  i32.const 1
   global.get $std/array-literal/i
-  i32.store $0 offset=8
+  call $~lib/array/Array<i32>#__set
+  global.get $std/array-literal/i
+  i32.const 1
+  i32.add
+  global.set $std/array-literal/i
+  local.get $0
+  i32.const 2
+  global.get $std/array-literal/i
+  call $~lib/array/Array<i32>#__set
   local.get $0
   global.set $std/array-literal/dynamicArrayI32
   global.get $~lib/memory/__stack_pointer
@@ -2104,15 +2315,15 @@
   local.get $0
   i32.const 0
   call $std/array-literal/Ref#constructor
-  call $~lib/array/Array<std/array-literal/Ref>#__uset
+  call $~lib/array/Array<std/array-literal/Ref>#__set
   local.get $0
   i32.const 1
   call $std/array-literal/Ref#constructor
-  call $~lib/array/Array<std/array-literal/Ref>#__uset
+  call $~lib/array/Array<std/array-literal/Ref>#__set
   local.get $0
   i32.const 2
   call $std/array-literal/Ref#constructor
-  call $~lib/array/Array<std/array-literal/Ref>#__uset
+  call $~lib/array/Array<std/array-literal/Ref>#__set
   local.get $0
   global.set $std/array-literal/dynamicArrayRef
   global.get $~lib/memory/__stack_pointer
@@ -2145,15 +2356,15 @@
   local.get $0
   i32.const 0
   call $std/array-literal/RefWithCtor#constructor
-  call $~lib/array/Array<std/array-literal/Ref>#__uset
+  call $~lib/array/Array<std/array-literal/Ref>#__set
   local.get $0
   i32.const 1
   call $std/array-literal/RefWithCtor#constructor
-  call $~lib/array/Array<std/array-literal/Ref>#__uset
+  call $~lib/array/Array<std/array-literal/Ref>#__set
   local.get $0
   i32.const 2
   call $std/array-literal/RefWithCtor#constructor
-  call $~lib/array/Array<std/array-literal/Ref>#__uset
+  call $~lib/array/Array<std/array-literal/Ref>#__set
   local.get $0
   global.set $std/array-literal/dynamicArrayRefWithCtor
   global.get $~lib/memory/__stack_pointer
@@ -2196,11 +2407,11 @@
   local.get $0
   i32.const 0
   call $std/array-literal/Ref#constructor
-  call $~lib/array/Array<std/array-literal/Ref>#__uset
+  call $~lib/array/Array<std/array-literal/Ref>#__set
   global.get $~lib/memory/__stack_pointer
   local.get $0
   i32.store $0
-  i32.const 34604
+  i32.const 34652
   global.set $~lib/memory/__stack_pointer
   global.get $~lib/rt/itcms/state
   i32.const 0
@@ -2247,11 +2458,11 @@
   i32.sub
   global.set $~lib/memory/__stack_pointer
   global.get $~lib/memory/__stack_pointer
-  i32.const 1836
+  i32.const 1884
   i32.lt_s
   if
-   i32.const 34624
    i32.const 34672
+   i32.const 34720
    i32.const 1
    i32.const 1
    call $~lib/builtins/abort
@@ -2307,7 +2518,7 @@
   global.set $~lib/memory/__stack_pointer
   block $folding-inner0
    global.get $~lib/memory/__stack_pointer
-   i32.const 1836
+   i32.const 1884
    i32.lt_s
    br_if $folding-inner0
    global.get $~lib/memory/__stack_pointer
@@ -2326,7 +2537,7 @@
    i32.sub
    global.set $~lib/memory/__stack_pointer
    global.get $~lib/memory/__stack_pointer
-   i32.const 1836
+   i32.const 1884
    i32.lt_s
    br_if $folding-inner0
    global.get $~lib/memory/__stack_pointer
@@ -2356,8 +2567,8 @@
    local.get $0
    return
   end
-  i32.const 34624
   i32.const 34672
+  i32.const 34720
   i32.const 1
   i32.const 1
   call $~lib/builtins/abort
@@ -2370,11 +2581,11 @@
   i32.sub
   global.set $~lib/memory/__stack_pointer
   global.get $~lib/memory/__stack_pointer
-  i32.const 1836
+  i32.const 1884
   i32.lt_s
   if
-   i32.const 34624
    i32.const 34672
+   i32.const 34720
    i32.const 1
    i32.const 1
    call $~lib/builtins/abort

--- a/tests/compiler/std/array.debug.wat
+++ b/tests/compiler/std/array.debug.wat
@@ -3,8 +3,8 @@
  (type $i32_=>_i32 (func_subtype (param i32) (result i32) func))
  (type $i32_i32_=>_none (func_subtype (param i32 i32) func))
  (type $i32_i32_i32_=>_i32 (func_subtype (param i32 i32 i32) (result i32) func))
- (type $i32_i32_i32_=>_none (func_subtype (param i32 i32 i32) func))
  (type $i32_i32_i32_i32_=>_i32 (func_subtype (param i32 i32 i32 i32) (result i32) func))
+ (type $i32_i32_i32_=>_none (func_subtype (param i32 i32 i32) func))
  (type $i32_i32_i32_i32_i32_=>_none (func_subtype (param i32 i32 i32 i32 i32) func))
  (type $f32_f32_=>_i32 (func_subtype (param f32 f32) (result i32) func))
  (type $f64_f64_=>_i32 (func_subtype (param f64 f64) (result i32) func))
@@ -3794,7 +3794,7 @@
   if
    i32.const 1616
    i32.const 80
-   i32.const 275
+   i32.const 271
    i32.const 18
    call $~lib/builtins/abort
    unreachable
@@ -3816,11 +3816,49 @@
   local.get $val
   return
  )
+ (func $~lib/array/Array<std/array/Ref>#get:length_ (type $i32_=>_i32) (param $this i32) (result i32)
+  local.get $this
+  i32.load $0 offset=12
+ )
+ (func $~lib/array/Array<std/array/Ref>#set:length_ (type $i32_i32_=>_none) (param $this i32) (param $length_ i32)
+  local.get $this
+  local.get $length_
+  i32.store $0 offset=12
+ )
  (func $~lib/array/Array<std/array/Ref>#get:dataStart (type $i32_=>_i32) (param $this i32) (result i32)
   local.get $this
   i32.load $0 offset=4
  )
- (func $~lib/array/Array<std/array/Ref>#__uset (type $i32_i32_i32_=>_none) (param $this i32) (param $index i32) (param $value i32)
+ (func $~lib/array/Array<std/array/Ref>#__set (type $i32_i32_i32_=>_none) (param $this i32) (param $index i32) (param $value i32)
+  local.get $index
+  local.get $this
+  call $~lib/array/Array<std/array/Ref>#get:length_
+  i32.ge_u
+  if
+   local.get $index
+   i32.const 0
+   i32.lt_s
+   if
+    i32.const 320
+    i32.const 80
+    i32.const 130
+    i32.const 22
+    call $~lib/builtins/abort
+    unreachable
+   end
+   local.get $this
+   local.get $index
+   i32.const 1
+   i32.add
+   i32.const 2
+   i32.const 1
+   call $~lib/array/ensureCapacity
+   local.get $this
+   local.get $index
+   i32.const 1
+   i32.add
+   call $~lib/array/Array<std/array/Ref>#set:length_
+  end
   local.get $this
   call $~lib/array/Array<std/array/Ref>#get:dataStart
   local.get $index
@@ -3836,11 +3874,6 @@
   i32.const 1
   call $~lib/rt/itcms/__link
  )
- (func $~lib/array/Array<std/array/Ref>#set:length_ (type $i32_i32_=>_none) (param $this i32) (param $length_ i32)
-  local.get $this
-  local.get $length_
-  i32.store $0 offset=12
- )
  (func $~lib/array/Array<std/array/Ref>#set:length (type $i32_i32_=>_none) (param $this i32) (param $newLength i32)
   local.get $this
   local.get $newLength
@@ -3850,10 +3883,6 @@
   local.get $this
   local.get $newLength
   call $~lib/array/Array<std/array/Ref>#set:length_
- )
- (func $~lib/array/Array<std/array/Ref>#get:length_ (type $i32_=>_i32) (param $this i32) (result i32)
-  local.get $this
-  i32.load $0 offset=12
  )
  (func $~lib/array/Array<std/array/Ref>#get:length (type $i32_=>_i32) (param $this i32) (result i32)
   local.get $this
@@ -3881,7 +3910,7 @@
   if
    i32.const 320
    i32.const 80
-   i32.const 147
+   i32.const 143
    i32.const 33
    call $~lib/builtins/abort
    unreachable
@@ -4167,7 +4196,7 @@
   if
    i32.const 1616
    i32.const 80
-   i32.const 334
+   i32.const 330
    i32.const 18
    call $~lib/builtins/abort
    unreachable
@@ -5144,11 +5173,49 @@
   local.get $this
   i32.load $0
  )
+ (func $~lib/array/Array<std/array/Ref|null>#get:length_ (type $i32_=>_i32) (param $this i32) (result i32)
+  local.get $this
+  i32.load $0 offset=12
+ )
+ (func $~lib/array/Array<std/array/Ref|null>#set:length_ (type $i32_i32_=>_none) (param $this i32) (param $length_ i32)
+  local.get $this
+  local.get $length_
+  i32.store $0 offset=12
+ )
  (func $~lib/array/Array<std/array/Ref|null>#get:dataStart (type $i32_=>_i32) (param $this i32) (result i32)
   local.get $this
   i32.load $0 offset=4
  )
- (func $~lib/array/Array<std/array/Ref|null>#__uset (type $i32_i32_i32_=>_none) (param $this i32) (param $index i32) (param $value i32)
+ (func $~lib/array/Array<std/array/Ref|null>#__set (type $i32_i32_i32_=>_none) (param $this i32) (param $index i32) (param $value i32)
+  local.get $index
+  local.get $this
+  call $~lib/array/Array<std/array/Ref|null>#get:length_
+  i32.ge_u
+  if
+   local.get $index
+   i32.const 0
+   i32.lt_s
+   if
+    i32.const 320
+    i32.const 80
+    i32.const 130
+    i32.const 22
+    call $~lib/builtins/abort
+    unreachable
+   end
+   local.get $this
+   local.get $index
+   i32.const 1
+   i32.add
+   i32.const 2
+   i32.const 1
+   call $~lib/array/ensureCapacity
+   local.get $this
+   local.get $index
+   i32.const 1
+   i32.add
+   call $~lib/array/Array<std/array/Ref|null>#set:length_
+  end
   local.get $this
   call $~lib/array/Array<std/array/Ref|null>#get:dataStart
   local.get $index
@@ -5164,31 +5231,10 @@
   i32.const 1
   call $~lib/rt/itcms/__link
  )
- (func $~lib/array/Array<std/array/Ref|null>#get:length_ (type $i32_=>_i32) (param $this i32) (result i32)
-  local.get $this
-  i32.load $0 offset=12
- )
- (func $~lib/array/Array<std/array/Ref|null>#set:length_ (type $i32_i32_=>_none) (param $this i32) (param $length_ i32)
-  local.get $this
-  local.get $length_
-  i32.store $0 offset=12
- )
  (func $~lib/array/Array<std/array/Ref|null>#get:length (type $i32_=>_i32) (param $this i32) (result i32)
   local.get $this
   call $~lib/array/Array<std/array/Ref|null>#get:length_
   return
- )
- (func $~lib/array/Array<i32>#__uset (type $i32_i32_i32_=>_none) (param $this i32) (param $index i32) (param $value i32)
-  local.get $this
-  call $~lib/array/Array<i32>#get:dataStart
-  local.get $index
-  i32.const 2
-  i32.shl
-  i32.add
-  local.get $value
-  i32.store $0
-  i32.const 0
-  drop
  )
  (func $~lib/array/Array<i32>#__set (type $i32_i32_i32_=>_none) (param $this i32) (param $index i32) (param $value i32)
   local.get $index
@@ -5221,9 +5267,15 @@
    call $~lib/array/Array<i32>#set:length_
   end
   local.get $this
+  call $~lib/array/Array<i32>#get:dataStart
   local.get $index
+  i32.const 2
+  i32.shl
+  i32.add
   local.get $value
-  call $~lib/array/Array<i32>#__uset
+  i32.store $0
+  i32.const 0
+  drop
  )
  (func $start:std/array~anonymous|0 (type $i32_i32_i32_=>_i32) (param $value i32) (param $$1 i32) (param $$2 i32) (result i32)
   local.get $value
@@ -6626,11 +6678,49 @@
   local.get $width
   i32.store $0 offset=4
  )
+ (func $~lib/array/Array<std/array/Dim>#get:length_ (type $i32_=>_i32) (param $this i32) (result i32)
+  local.get $this
+  i32.load $0 offset=12
+ )
+ (func $~lib/array/Array<std/array/Dim>#set:length_ (type $i32_i32_=>_none) (param $this i32) (param $length_ i32)
+  local.get $this
+  local.get $length_
+  i32.store $0 offset=12
+ )
  (func $~lib/array/Array<std/array/Dim>#get:dataStart (type $i32_=>_i32) (param $this i32) (result i32)
   local.get $this
   i32.load $0 offset=4
  )
- (func $~lib/array/Array<std/array/Dim>#__uset (type $i32_i32_i32_=>_none) (param $this i32) (param $index i32) (param $value i32)
+ (func $~lib/array/Array<std/array/Dim>#__set (type $i32_i32_i32_=>_none) (param $this i32) (param $index i32) (param $value i32)
+  local.get $index
+  local.get $this
+  call $~lib/array/Array<std/array/Dim>#get:length_
+  i32.ge_u
+  if
+   local.get $index
+   i32.const 0
+   i32.lt_s
+   if
+    i32.const 320
+    i32.const 80
+    i32.const 130
+    i32.const 22
+    call $~lib/builtins/abort
+    unreachable
+   end
+   local.get $this
+   local.get $index
+   i32.const 1
+   i32.add
+   i32.const 2
+   i32.const 1
+   call $~lib/array/ensureCapacity
+   local.get $this
+   local.get $index
+   i32.const 1
+   i32.add
+   call $~lib/array/Array<std/array/Dim>#set:length_
+  end
   local.get $this
   call $~lib/array/Array<std/array/Dim>#get:dataStart
   local.get $index
@@ -10617,10 +10707,6 @@
   i32.const 1
   return
  )
- (func $~lib/array/Array<std/array/Dim>#get:length_ (type $i32_=>_i32) (param $this i32) (result i32)
-  local.get $this
-  i32.load $0 offset=12
- )
  (func $~lib/array/Array<std/array/Dim>#slice@varargs (type $i32_i32_i32_=>_i32) (param $this i32) (param $start i32) (param $end i32) (result i32)
   block $2of2
    block $1of2
@@ -11532,22 +11618,6 @@
   local.get $this
   i32.load $0 offset=4
  )
- (func $~lib/array/Array<~lib/array/Array<i32>>#__uset (type $i32_i32_i32_=>_none) (param $this i32) (param $index i32) (param $value i32)
-  local.get $this
-  call $~lib/array/Array<~lib/array/Array<i32>>#get:dataStart
-  local.get $index
-  i32.const 2
-  i32.shl
-  i32.add
-  local.get $value
-  i32.store $0
-  i32.const 1
-  drop
-  local.get $this
-  local.get $value
-  i32.const 1
-  call $~lib/rt/itcms/__link
- )
  (func $~lib/array/Array<~lib/array/Array<i32>>#__set (type $i32_i32_i32_=>_none) (param $this i32) (param $index i32) (param $value i32)
   local.get $index
   local.get $this
@@ -11579,9 +11649,19 @@
    call $~lib/array/Array<~lib/array/Array<i32>>#set:length_
   end
   local.get $this
+  call $~lib/array/Array<~lib/array/Array<i32>>#get:dataStart
   local.get $index
+  i32.const 2
+  i32.shl
+  i32.add
   local.get $value
-  call $~lib/array/Array<~lib/array/Array<i32>>#__uset
+  i32.store $0
+  i32.const 1
+  drop
+  local.get $this
+  local.get $value
+  i32.const 1
+  call $~lib/rt/itcms/__link
  )
  (func $start:std/array~anonymous|52 (type $i32_i32_=>_i32) (param $a i32) (param $b i32) (result i32)
   local.get $a
@@ -12452,22 +12532,6 @@
   local.get $this
   i32.load $0 offset=4
  )
- (func $~lib/array/Array<std/array/Proxy<i32>>#__uset (type $i32_i32_i32_=>_none) (param $this i32) (param $index i32) (param $value i32)
-  local.get $this
-  call $~lib/array/Array<std/array/Proxy<i32>>#get:dataStart
-  local.get $index
-  i32.const 2
-  i32.shl
-  i32.add
-  local.get $value
-  i32.store $0
-  i32.const 1
-  drop
-  local.get $this
-  local.get $value
-  i32.const 1
-  call $~lib/rt/itcms/__link
- )
  (func $~lib/array/Array<std/array/Proxy<i32>>#__set (type $i32_i32_i32_=>_none) (param $this i32) (param $index i32) (param $value i32)
   local.get $index
   local.get $this
@@ -12499,9 +12563,19 @@
    call $~lib/array/Array<std/array/Proxy<i32>>#set:length_
   end
   local.get $this
+  call $~lib/array/Array<std/array/Proxy<i32>>#get:dataStart
   local.get $index
+  i32.const 2
+  i32.shl
+  i32.add
   local.get $value
-  call $~lib/array/Array<std/array/Proxy<i32>>#__uset
+  i32.store $0
+  i32.const 1
+  drop
+  local.get $this
+  local.get $value
+  i32.const 1
+  call $~lib/rt/itcms/__link
  )
  (func $std/array/Proxy<i32>#get:x (type $i32_=>_i32) (param $this i32) (result i32)
   local.get $this
@@ -14483,22 +14557,6 @@
   local.get $this
   i32.load $0 offset=12
  )
- (func $~lib/array/Array<~lib/string/String>#__uset (type $i32_i32_i32_=>_none) (param $this i32) (param $index i32) (param $value i32)
-  local.get $this
-  call $~lib/array/Array<~lib/string/String>#get:dataStart
-  local.get $index
-  i32.const 2
-  i32.shl
-  i32.add
-  local.get $value
-  i32.store $0
-  i32.const 1
-  drop
-  local.get $this
-  local.get $value
-  i32.const 1
-  call $~lib/rt/itcms/__link
- )
  (func $~lib/array/Array<~lib/string/String>#__set (type $i32_i32_i32_=>_none) (param $this i32) (param $index i32) (param $value i32)
   local.get $index
   local.get $this
@@ -14530,9 +14588,19 @@
    call $~lib/array/Array<~lib/string/String>#set:length_
   end
   local.get $this
+  call $~lib/array/Array<~lib/string/String>#get:dataStart
   local.get $index
+  i32.const 2
+  i32.shl
+  i32.add
   local.get $value
-  call $~lib/array/Array<~lib/string/String>#__uset
+  i32.store $0
+  i32.const 1
+  drop
+  local.get $this
+  local.get $value
+  i32.const 1
+  call $~lib/rt/itcms/__link
  )
  (func $~lib/util/sort/insertionSort<~lib/string/String> (type $i32_i32_i32_i32_i32_=>_none) (param $ptr i32) (param $left i32) (param $right i32) (param $presorted i32) (param $comparator i32)
   (local $range i32)
@@ -18105,11 +18173,49 @@
   call $~lib/util/string/joinReferenceArray<~lib/array/Array<i32>>
   return
  )
+ (func $~lib/array/Array<~lib/array/Array<u8>>#get:length_ (type $i32_=>_i32) (param $this i32) (result i32)
+  local.get $this
+  i32.load $0 offset=12
+ )
+ (func $~lib/array/Array<~lib/array/Array<u8>>#set:length_ (type $i32_i32_=>_none) (param $this i32) (param $length_ i32)
+  local.get $this
+  local.get $length_
+  i32.store $0 offset=12
+ )
  (func $~lib/array/Array<~lib/array/Array<u8>>#get:dataStart (type $i32_=>_i32) (param $this i32) (result i32)
   local.get $this
   i32.load $0 offset=4
  )
- (func $~lib/array/Array<~lib/array/Array<u8>>#__uset (type $i32_i32_i32_=>_none) (param $this i32) (param $index i32) (param $value i32)
+ (func $~lib/array/Array<~lib/array/Array<u8>>#__set (type $i32_i32_i32_=>_none) (param $this i32) (param $index i32) (param $value i32)
+  local.get $index
+  local.get $this
+  call $~lib/array/Array<~lib/array/Array<u8>>#get:length_
+  i32.ge_u
+  if
+   local.get $index
+   i32.const 0
+   i32.lt_s
+   if
+    i32.const 320
+    i32.const 80
+    i32.const 130
+    i32.const 22
+    call $~lib/builtins/abort
+    unreachable
+   end
+   local.get $this
+   local.get $index
+   i32.const 1
+   i32.add
+   i32.const 2
+   i32.const 1
+   call $~lib/array/ensureCapacity
+   local.get $this
+   local.get $index
+   i32.const 1
+   i32.add
+   call $~lib/array/Array<~lib/array/Array<u8>>#set:length_
+  end
   local.get $this
   call $~lib/array/Array<~lib/array/Array<u8>>#get:dataStart
   local.get $index
@@ -18124,10 +18230,6 @@
   local.get $value
   i32.const 1
   call $~lib/rt/itcms/__link
- )
- (func $~lib/array/Array<~lib/array/Array<u8>>#get:length_ (type $i32_=>_i32) (param $this i32) (result i32)
-  local.get $this
-  i32.load $0 offset=12
  )
  (func $~lib/util/number/itoa_buffered<u8> (type $i32_i32_=>_i32) (param $buffer i32) (param $value i32) (result i32)
   (local $sign i32)
@@ -18249,33 +18351,51 @@
   call $~lib/util/string/joinReferenceArray<~lib/array/Array<u8>>
   return
  )
+ (func $~lib/array/Array<~lib/array/Array<u32>>#get:length_ (type $i32_=>_i32) (param $this i32) (result i32)
+  local.get $this
+  i32.load $0 offset=12
+ )
+ (func $~lib/array/Array<~lib/array/Array<u32>>#set:length_ (type $i32_i32_=>_none) (param $this i32) (param $length_ i32)
+  local.get $this
+  local.get $length_
+  i32.store $0 offset=12
+ )
  (func $~lib/array/Array<~lib/array/Array<u32>>#get:dataStart (type $i32_=>_i32) (param $this i32) (result i32)
   local.get $this
   i32.load $0 offset=4
  )
- (func $~lib/array/Array<~lib/array/Array<u32>>#__uset (type $i32_i32_i32_=>_none) (param $this i32) (param $index i32) (param $value i32)
+ (func $~lib/array/Array<~lib/array/Array<u32>>#__set (type $i32_i32_i32_=>_none) (param $this i32) (param $index i32) (param $value i32)
+  local.get $index
+  local.get $this
+  call $~lib/array/Array<~lib/array/Array<u32>>#get:length_
+  i32.ge_u
+  if
+   local.get $index
+   i32.const 0
+   i32.lt_s
+   if
+    i32.const 320
+    i32.const 80
+    i32.const 130
+    i32.const 22
+    call $~lib/builtins/abort
+    unreachable
+   end
+   local.get $this
+   local.get $index
+   i32.const 1
+   i32.add
+   i32.const 2
+   i32.const 1
+   call $~lib/array/ensureCapacity
+   local.get $this
+   local.get $index
+   i32.const 1
+   i32.add
+   call $~lib/array/Array<~lib/array/Array<u32>>#set:length_
+  end
   local.get $this
   call $~lib/array/Array<~lib/array/Array<u32>>#get:dataStart
-  local.get $index
-  i32.const 2
-  i32.shl
-  i32.add
-  local.get $value
-  i32.store $0
-  i32.const 1
-  drop
-  local.get $this
-  local.get $value
-  i32.const 1
-  call $~lib/rt/itcms/__link
- )
- (func $~lib/array/Array<~lib/array/Array<~lib/array/Array<u32>>>#get:dataStart (type $i32_=>_i32) (param $this i32) (result i32)
-  local.get $this
-  i32.load $0 offset=4
- )
- (func $~lib/array/Array<~lib/array/Array<~lib/array/Array<u32>>>#__uset (type $i32_i32_i32_=>_none) (param $this i32) (param $index i32) (param $value i32)
-  local.get $this
-  call $~lib/array/Array<~lib/array/Array<~lib/array/Array<u32>>>#get:dataStart
   local.get $index
   i32.const 2
   i32.shl
@@ -18293,9 +18413,59 @@
   local.get $this
   i32.load $0 offset=12
  )
- (func $~lib/array/Array<~lib/array/Array<u32>>#get:length_ (type $i32_=>_i32) (param $this i32) (result i32)
+ (func $~lib/array/Array<~lib/array/Array<~lib/array/Array<u32>>>#set:length_ (type $i32_i32_=>_none) (param $this i32) (param $length_ i32)
   local.get $this
-  i32.load $0 offset=12
+  local.get $length_
+  i32.store $0 offset=12
+ )
+ (func $~lib/array/Array<~lib/array/Array<~lib/array/Array<u32>>>#get:dataStart (type $i32_=>_i32) (param $this i32) (result i32)
+  local.get $this
+  i32.load $0 offset=4
+ )
+ (func $~lib/array/Array<~lib/array/Array<~lib/array/Array<u32>>>#__set (type $i32_i32_i32_=>_none) (param $this i32) (param $index i32) (param $value i32)
+  local.get $index
+  local.get $this
+  call $~lib/array/Array<~lib/array/Array<~lib/array/Array<u32>>>#get:length_
+  i32.ge_u
+  if
+   local.get $index
+   i32.const 0
+   i32.lt_s
+   if
+    i32.const 320
+    i32.const 80
+    i32.const 130
+    i32.const 22
+    call $~lib/builtins/abort
+    unreachable
+   end
+   local.get $this
+   local.get $index
+   i32.const 1
+   i32.add
+   i32.const 2
+   i32.const 1
+   call $~lib/array/ensureCapacity
+   local.get $this
+   local.get $index
+   i32.const 1
+   i32.add
+   call $~lib/array/Array<~lib/array/Array<~lib/array/Array<u32>>>#set:length_
+  end
+  local.get $this
+  call $~lib/array/Array<~lib/array/Array<~lib/array/Array<u32>>>#get:dataStart
+  local.get $index
+  i32.const 2
+  i32.shl
+  i32.add
+  local.get $value
+  i32.store $0
+  i32.const 1
+  drop
+  local.get $this
+  local.get $value
+  i32.const 1
+  call $~lib/rt/itcms/__link
  )
  (func $~lib/array/Array<~lib/array/Array<u32>>#join (type $i32_i32_=>_i32) (param $this i32) (param $separator i32) (result i32)
   (local $ptr i32)
@@ -18355,11 +18525,49 @@
   call $~lib/util/string/joinReferenceArray<~lib/array/Array<~lib/array/Array<u32>>>
   return
  )
+ (func $~lib/array/Array<~lib/array/Array<~lib/string/String|null>>#get:length_ (type $i32_=>_i32) (param $this i32) (result i32)
+  local.get $this
+  i32.load $0 offset=12
+ )
+ (func $~lib/array/Array<~lib/array/Array<~lib/string/String|null>>#set:length_ (type $i32_i32_=>_none) (param $this i32) (param $length_ i32)
+  local.get $this
+  local.get $length_
+  i32.store $0 offset=12
+ )
  (func $~lib/array/Array<~lib/array/Array<~lib/string/String|null>>#get:dataStart (type $i32_=>_i32) (param $this i32) (result i32)
   local.get $this
   i32.load $0 offset=4
  )
- (func $~lib/array/Array<~lib/array/Array<~lib/string/String|null>>#__uset (type $i32_i32_i32_=>_none) (param $this i32) (param $index i32) (param $value i32)
+ (func $~lib/array/Array<~lib/array/Array<~lib/string/String|null>>#__set (type $i32_i32_i32_=>_none) (param $this i32) (param $index i32) (param $value i32)
+  local.get $index
+  local.get $this
+  call $~lib/array/Array<~lib/array/Array<~lib/string/String|null>>#get:length_
+  i32.ge_u
+  if
+   local.get $index
+   i32.const 0
+   i32.lt_s
+   if
+    i32.const 320
+    i32.const 80
+    i32.const 130
+    i32.const 22
+    call $~lib/builtins/abort
+    unreachable
+   end
+   local.get $this
+   local.get $index
+   i32.const 1
+   i32.add
+   i32.const 2
+   i32.const 1
+   call $~lib/array/ensureCapacity
+   local.get $this
+   local.get $index
+   i32.const 1
+   i32.add
+   call $~lib/array/Array<~lib/array/Array<~lib/string/String|null>>#set:length_
+  end
   local.get $this
   call $~lib/array/Array<~lib/array/Array<~lib/string/String|null>>#get:dataStart
   local.get $index
@@ -18374,10 +18582,6 @@
   local.get $value
   i32.const 1
   call $~lib/rt/itcms/__link
- )
- (func $~lib/array/Array<~lib/array/Array<~lib/string/String|null>>#get:length_ (type $i32_=>_i32) (param $this i32) (result i32)
-  local.get $this
-  i32.load $0 offset=12
  )
  (func $start:std/array~anonymous|54 (type $i32_i32_i32_=>_i32) (param $nestedArray i32) (param $$1 i32) (param $$2 i32) (result i32)
   local.get $nestedArray
@@ -24859,13 +25063,13 @@
   i32.const 0
   i32.const 0
   call $std/array/Ref#constructor
-  call $~lib/array/Array<std/array/Ref>#__uset
+  call $~lib/array/Array<std/array/Ref>#__set
   local.get $48
   i32.const 1
   i32.const 0
   i32.const 0
   call $std/array/Ref#constructor
-  call $~lib/array/Array<std/array/Ref>#__uset
+  call $~lib/array/Array<std/array/Ref>#__set
   local.get $48
   local.tee $50
   i32.store $0 offset=28
@@ -28578,31 +28782,31 @@
   i32.const 0
   i32.const 1
   call $std/array/Ref#constructor
-  call $~lib/array/Array<std/array/Ref>#__uset
+  call $~lib/array/Array<std/array/Ref>#__set
   local.get $257
   i32.const 1
   i32.const 0
   i32.const 2
   call $std/array/Ref#constructor
-  call $~lib/array/Array<std/array/Ref>#__uset
+  call $~lib/array/Array<std/array/Ref>#__set
   local.get $257
   i32.const 2
   i32.const 0
   i32.const 3
   call $std/array/Ref#constructor
-  call $~lib/array/Array<std/array/Ref>#__uset
+  call $~lib/array/Array<std/array/Ref>#__set
   local.get $257
   i32.const 3
   i32.const 0
   i32.const 4
   call $std/array/Ref#constructor
-  call $~lib/array/Array<std/array/Ref>#__uset
+  call $~lib/array/Array<std/array/Ref>#__set
   local.get $257
   i32.const 4
   i32.const 0
   i32.const 5
   call $std/array/Ref#constructor
-  call $~lib/array/Array<std/array/Ref>#__uset
+  call $~lib/array/Array<std/array/Ref>#__set
   local.get $257
   local.tee $255
   i32.store $0 offset=92
@@ -28758,17 +28962,17 @@
   i32.const 0
   i32.const 1
   call $std/array/Ref#constructor
-  call $~lib/array/Array<std/array/Ref|null>#__uset
+  call $~lib/array/Array<std/array/Ref|null>#__set
   local.get $259
   i32.const 1
   i32.const 0
-  call $~lib/array/Array<std/array/Ref|null>#__uset
+  call $~lib/array/Array<std/array/Ref|null>#__set
   local.get $259
   i32.const 2
   i32.const 0
   i32.const 2
   call $std/array/Ref#constructor
-  call $~lib/array/Array<std/array/Ref|null>#__uset
+  call $~lib/array/Array<std/array/Ref|null>#__set
   local.get $259
   local.tee $261
   i32.store $0 offset=116
@@ -31014,7 +31218,7 @@
   i32.const 80
   call $std/array/Dim#set:width
   local.get $278
-  call $~lib/array/Array<std/array/Dim>#__uset
+  call $~lib/array/Array<std/array/Dim>#__set
   local.get $276
   i32.const 1
   global.get $~lib/memory/__stack_pointer
@@ -31029,7 +31233,7 @@
   i32.const 90
   call $std/array/Dim#set:width
   local.get $279
-  call $~lib/array/Array<std/array/Dim>#__uset
+  call $~lib/array/Array<std/array/Dim>#__set
   local.get $276
   i32.const 2
   global.get $~lib/memory/__stack_pointer
@@ -31044,7 +31248,7 @@
   i32.const 95
   call $std/array/Dim#set:width
   local.get $280
-  call $~lib/array/Array<std/array/Dim>#__uset
+  call $~lib/array/Array<std/array/Dim>#__set
   local.get $276
   i32.const 3
   global.get $~lib/memory/__stack_pointer
@@ -31059,7 +31263,7 @@
   i32.const 100
   call $std/array/Dim#set:width
   local.get $281
-  call $~lib/array/Array<std/array/Dim>#__uset
+  call $~lib/array/Array<std/array/Dim>#__set
   local.get $276
   i32.const 4
   global.get $~lib/memory/__stack_pointer
@@ -31074,7 +31278,7 @@
   i32.const 110
   call $std/array/Dim#set:width
   local.get $282
-  call $~lib/array/Array<std/array/Dim>#__uset
+  call $~lib/array/Array<std/array/Dim>#__set
   local.get $276
   i32.const 5
   global.get $~lib/memory/__stack_pointer
@@ -31089,7 +31293,7 @@
   i32.const 115
   call $std/array/Dim#set:width
   local.get $283
-  call $~lib/array/Array<std/array/Dim>#__uset
+  call $~lib/array/Array<std/array/Dim>#__set
   local.get $276
   i32.const 6
   global.get $~lib/memory/__stack_pointer
@@ -31104,7 +31308,7 @@
   i32.const 120
   call $std/array/Dim#set:width
   local.get $284
-  call $~lib/array/Array<std/array/Dim>#__uset
+  call $~lib/array/Array<std/array/Dim>#__set
   local.get $276
   i32.const 7
   global.get $~lib/memory/__stack_pointer
@@ -31119,7 +31323,7 @@
   i32.const 125
   call $std/array/Dim#set:width
   local.get $285
-  call $~lib/array/Array<std/array/Dim>#__uset
+  call $~lib/array/Array<std/array/Dim>#__set
   local.get $276
   i32.const 8
   global.get $~lib/memory/__stack_pointer
@@ -31134,7 +31338,7 @@
   i32.const 130
   call $std/array/Dim#set:width
   local.get $286
-  call $~lib/array/Array<std/array/Dim>#__uset
+  call $~lib/array/Array<std/array/Dim>#__set
   local.get $276
   i32.const 9
   global.get $~lib/memory/__stack_pointer
@@ -31149,7 +31353,7 @@
   i32.const 135
   call $std/array/Dim#set:width
   local.get $287
-  call $~lib/array/Array<std/array/Dim>#__uset
+  call $~lib/array/Array<std/array/Dim>#__set
   local.get $276
   i32.const 10
   global.get $~lib/memory/__stack_pointer
@@ -31164,7 +31368,7 @@
   i32.const 140
   call $std/array/Dim#set:width
   local.get $288
-  call $~lib/array/Array<std/array/Dim>#__uset
+  call $~lib/array/Array<std/array/Dim>#__set
   local.get $276
   i32.const 11
   global.get $~lib/memory/__stack_pointer
@@ -31179,7 +31383,7 @@
   i32.const 140
   call $std/array/Dim#set:width
   local.get $289
-  call $~lib/array/Array<std/array/Dim>#__uset
+  call $~lib/array/Array<std/array/Dim>#__set
   local.get $276
   global.set $std/array/inputStabArr
   global.get $~lib/memory/__stack_pointer
@@ -31209,7 +31413,7 @@
   i32.const 95
   call $std/array/Dim#set:width
   local.get $292
-  call $~lib/array/Array<std/array/Dim>#__uset
+  call $~lib/array/Array<std/array/Dim>#__set
   local.get $290
   i32.const 1
   global.get $~lib/memory/__stack_pointer
@@ -31224,7 +31428,7 @@
   i32.const 125
   call $std/array/Dim#set:width
   local.get $293
-  call $~lib/array/Array<std/array/Dim>#__uset
+  call $~lib/array/Array<std/array/Dim>#__set
   local.get $290
   i32.const 2
   global.get $~lib/memory/__stack_pointer
@@ -31239,7 +31443,7 @@
   i32.const 130
   call $std/array/Dim#set:width
   local.get $294
-  call $~lib/array/Array<std/array/Dim>#__uset
+  call $~lib/array/Array<std/array/Dim>#__set
   local.get $290
   i32.const 3
   global.get $~lib/memory/__stack_pointer
@@ -31254,7 +31458,7 @@
   i32.const 140
   call $std/array/Dim#set:width
   local.get $295
-  call $~lib/array/Array<std/array/Dim>#__uset
+  call $~lib/array/Array<std/array/Dim>#__set
   local.get $290
   i32.const 4
   global.get $~lib/memory/__stack_pointer
@@ -31269,7 +31473,7 @@
   i32.const 140
   call $std/array/Dim#set:width
   local.get $296
-  call $~lib/array/Array<std/array/Dim>#__uset
+  call $~lib/array/Array<std/array/Dim>#__set
   local.get $290
   i32.const 5
   global.get $~lib/memory/__stack_pointer
@@ -31284,7 +31488,7 @@
   i32.const 110
   call $std/array/Dim#set:width
   local.get $297
-  call $~lib/array/Array<std/array/Dim>#__uset
+  call $~lib/array/Array<std/array/Dim>#__set
   local.get $290
   i32.const 6
   global.get $~lib/memory/__stack_pointer
@@ -31299,7 +31503,7 @@
   i32.const 90
   call $std/array/Dim#set:width
   local.get $298
-  call $~lib/array/Array<std/array/Dim>#__uset
+  call $~lib/array/Array<std/array/Dim>#__set
   local.get $290
   i32.const 7
   global.get $~lib/memory/__stack_pointer
@@ -31314,7 +31518,7 @@
   i32.const 80
   call $std/array/Dim#set:width
   local.get $299
-  call $~lib/array/Array<std/array/Dim>#__uset
+  call $~lib/array/Array<std/array/Dim>#__set
   local.get $290
   i32.const 8
   global.get $~lib/memory/__stack_pointer
@@ -31329,7 +31533,7 @@
   i32.const 100
   call $std/array/Dim#set:width
   local.get $300
-  call $~lib/array/Array<std/array/Dim>#__uset
+  call $~lib/array/Array<std/array/Dim>#__set
   local.get $290
   i32.const 9
   global.get $~lib/memory/__stack_pointer
@@ -31344,7 +31548,7 @@
   i32.const 120
   call $std/array/Dim#set:width
   local.get $301
-  call $~lib/array/Array<std/array/Dim>#__uset
+  call $~lib/array/Array<std/array/Dim>#__set
   local.get $290
   i32.const 10
   global.get $~lib/memory/__stack_pointer
@@ -31359,7 +31563,7 @@
   i32.const 135
   call $std/array/Dim#set:width
   local.get $302
-  call $~lib/array/Array<std/array/Dim>#__uset
+  call $~lib/array/Array<std/array/Dim>#__set
   local.get $290
   i32.const 11
   global.get $~lib/memory/__stack_pointer
@@ -31374,7 +31578,7 @@
   i32.const 115
   call $std/array/Dim#set:width
   local.get $303
-  call $~lib/array/Array<std/array/Dim>#__uset
+  call $~lib/array/Array<std/array/Dim>#__set
   local.get $290
   global.set $std/array/outputStabArr
   global.get $~lib/memory/__stack_pointer
@@ -32109,17 +32313,17 @@
   i32.const 0
   i32.const 0
   call $std/array/Ref#constructor
-  call $~lib/array/Array<std/array/Ref|null>#__uset
+  call $~lib/array/Array<std/array/Ref|null>#__set
   local.get $376
   i32.const 1
   i32.const 0
-  call $~lib/array/Array<std/array/Ref|null>#__uset
+  call $~lib/array/Array<std/array/Ref|null>#__set
   local.get $376
   i32.const 2
   i32.const 0
   i32.const 0
   call $std/array/Ref#constructor
-  call $~lib/array/Array<std/array/Ref|null>#__uset
+  call $~lib/array/Array<std/array/Ref|null>#__set
   local.get $376
   local.tee $378
   i32.store $0 offset=364
@@ -32171,13 +32375,13 @@
   i32.const 0
   i32.const 0
   call $std/array/Ref#constructor
-  call $~lib/array/Array<std/array/Ref>#__uset
+  call $~lib/array/Array<std/array/Ref>#__set
   local.get $379
   i32.const 1
   i32.const 0
   i32.const 0
   call $std/array/Ref#constructor
-  call $~lib/array/Array<std/array/Ref>#__uset
+  call $~lib/array/Array<std/array/Ref>#__set
   local.get $379
   local.tee $381
   i32.store $0 offset=376
@@ -32642,7 +32846,7 @@
   i32.const 4
   i32.const 14080
   call $~lib/rt/__newArray
-  call $~lib/array/Array<~lib/array/Array<i32>>#__uset
+  call $~lib/array/Array<~lib/array/Array<i32>>#__set
   local.get $413
   i32.const 1
   i32.const 2
@@ -32650,7 +32854,7 @@
   i32.const 4
   i32.const 14112
   call $~lib/rt/__newArray
-  call $~lib/array/Array<~lib/array/Array<i32>>#__uset
+  call $~lib/array/Array<~lib/array/Array<i32>>#__set
   local.get $413
   local.tee $419
   i32.store $0 offset=408
@@ -32698,7 +32902,7 @@
   i32.const 7
   i32.const 14192
   call $~lib/rt/__newArray
-  call $~lib/array/Array<~lib/array/Array<u8>>#__uset
+  call $~lib/array/Array<~lib/array/Array<u8>>#__set
   local.get $420
   i32.const 1
   i32.const 2
@@ -32706,7 +32910,7 @@
   i32.const 7
   i32.const 14224
   call $~lib/rt/__newArray
-  call $~lib/array/Array<~lib/array/Array<u8>>#__uset
+  call $~lib/array/Array<~lib/array/Array<u8>>#__set
   local.get $420
   local.tee $426
   i32.store $0 offset=420
@@ -32769,9 +32973,9 @@
   i32.const 8
   i32.const 14256
   call $~lib/rt/__newArray
-  call $~lib/array/Array<~lib/array/Array<u32>>#__uset
+  call $~lib/array/Array<~lib/array/Array<u32>>#__set
   local.get $429
-  call $~lib/array/Array<~lib/array/Array<~lib/array/Array<u32>>>#__uset
+  call $~lib/array/Array<~lib/array/Array<~lib/array/Array<u32>>>#__set
   local.get $427
   local.tee $433
   i32.store $0 offset=440
@@ -32819,7 +33023,7 @@
   i32.const 4
   i32.const 14288
   call $~lib/rt/__newArray
-  call $~lib/array/Array<~lib/array/Array<i32>>#__uset
+  call $~lib/array/Array<~lib/array/Array<i32>>#__set
   local.get $434
   i32.const 1
   i32.const 3
@@ -32827,7 +33031,7 @@
   i32.const 4
   i32.const 14320
   call $~lib/rt/__newArray
-  call $~lib/array/Array<~lib/array/Array<i32>>#__uset
+  call $~lib/array/Array<~lib/array/Array<i32>>#__set
   local.get $434
   i32.const 2
   i32.const 3
@@ -32835,7 +33039,7 @@
   i32.const 4
   i32.const 14352
   call $~lib/rt/__newArray
-  call $~lib/array/Array<~lib/array/Array<i32>>#__uset
+  call $~lib/array/Array<~lib/array/Array<i32>>#__set
   local.get $434
   i32.const 3
   i32.const 3
@@ -32843,7 +33047,7 @@
   i32.const 4
   i32.const 14384
   call $~lib/rt/__newArray
-  call $~lib/array/Array<~lib/array/Array<i32>>#__uset
+  call $~lib/array/Array<~lib/array/Array<i32>>#__set
   local.get $434
   local.tee $444
   i32.store $0 offset=452
@@ -32914,7 +33118,7 @@
   i32.const 34
   i32.const 14448
   call $~lib/rt/__newArray
-  call $~lib/array/Array<~lib/array/Array<~lib/string/String|null>>#__uset
+  call $~lib/array/Array<~lib/array/Array<~lib/string/String|null>>#__set
   local.get $447
   i32.const 1
   i32.const 3
@@ -32922,7 +33126,7 @@
   i32.const 34
   i32.const 14544
   call $~lib/rt/__newArray
-  call $~lib/array/Array<~lib/array/Array<~lib/string/String|null>>#__uset
+  call $~lib/array/Array<~lib/array/Array<~lib/string/String|null>>#__set
   local.get $447
   i32.const 2
   i32.const 3
@@ -32930,7 +33134,7 @@
   i32.const 34
   i32.const 14672
   call $~lib/rt/__newArray
-  call $~lib/array/Array<~lib/array/Array<~lib/string/String|null>>#__uset
+  call $~lib/array/Array<~lib/array/Array<~lib/string/String|null>>#__set
   local.get $447
   i32.const 3
   i32.const 1
@@ -32938,7 +33142,7 @@
   i32.const 34
   i32.const 14736
   call $~lib/rt/__newArray
-  call $~lib/array/Array<~lib/array/Array<~lib/string/String|null>>#__uset
+  call $~lib/array/Array<~lib/array/Array<~lib/string/String|null>>#__set
   local.get $447
   local.tee $457
   i32.store $0 offset=468
@@ -33030,7 +33234,7 @@
   i32.const 4
   i32.const 14832
   call $~lib/rt/__newArray
-  call $~lib/array/Array<~lib/array/Array<i32>>#__uset
+  call $~lib/array/Array<~lib/array/Array<i32>>#__set
   local.get $463
   i32.const 1
   i32.const 0
@@ -33038,7 +33242,7 @@
   i32.const 4
   i32.const 14864
   call $~lib/rt/__newArray
-  call $~lib/array/Array<~lib/array/Array<i32>>#__uset
+  call $~lib/array/Array<~lib/array/Array<i32>>#__set
   local.get $463
   local.tee $469
   i32.store $0 offset=488
@@ -33082,7 +33286,7 @@
   i32.const 4
   i32.const 14896
   call $~lib/rt/__newArray
-  call $~lib/array/Array<~lib/array/Array<i32>>#__uset
+  call $~lib/array/Array<~lib/array/Array<i32>>#__set
   local.get $470
   i32.const 1
   i32.const 1
@@ -33090,7 +33294,7 @@
   i32.const 4
   i32.const 14928
   call $~lib/rt/__newArray
-  call $~lib/array/Array<~lib/array/Array<i32>>#__uset
+  call $~lib/array/Array<~lib/array/Array<i32>>#__set
   local.get $470
   local.tee $476
   i32.store $0 offset=500
@@ -33538,7 +33742,7 @@
   if
    i32.const 32
    i32.const 80
-   i32.const 228
+   i32.const 224
    i32.const 60
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/std/array.release.wat
+++ b/tests/compiler/std/array.release.wat
@@ -2784,7 +2784,7 @@
   if
    i32.const 2640
    i32.const 1104
-   i32.const 275
+   i32.const 271
    i32.const 18
    call $~lib/builtins/abort
    unreachable
@@ -2805,7 +2805,35 @@
   i32.store $0 offset=12
   local.get $2
  )
- (func $~lib/array/Array<std/array/Ref>#__uset (type $i32_i32_i32_=>_none) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/array/Array<std/array/Ref>#__set (type $i32_i32_i32_=>_none) (param $0 i32) (param $1 i32) (param $2 i32)
+  (local $3 i32)
+  local.get $1
+  local.get $0
+  i32.load $0 offset=12
+  i32.ge_u
+  if
+   local.get $1
+   i32.const 0
+   i32.lt_s
+   if
+    i32.const 1344
+    i32.const 1104
+    i32.const 130
+    i32.const 22
+    call $~lib/builtins/abort
+    unreachable
+   end
+   local.get $0
+   local.get $1
+   i32.const 1
+   i32.add
+   local.tee $3
+   i32.const 1
+   call $~lib/array/ensureCapacity
+   local.get $0
+   local.get $3
+   i32.store $0 offset=12
+  end
   local.get $0
   i32.load $0 offset=4
   local.get $1
@@ -2840,7 +2868,7 @@
   if
    i32.const 1344
    i32.const 1104
-   i32.const 147
+   i32.const 143
    i32.const 33
    call $~lib/builtins/abort
    unreachable
@@ -8069,40 +8097,6 @@
   local.get $0
   i32.sub
  )
- (func $~lib/array/Array<~lib/array/Array<i32>>#__set (type $i32_i32_i32_=>_none) (param $0 i32) (param $1 i32) (param $2 i32)
-  (local $3 i32)
-  local.get $1
-  local.get $0
-  i32.load $0 offset=12
-  i32.ge_u
-  if
-   local.get $1
-   i32.const 0
-   i32.lt_s
-   if
-    i32.const 1344
-    i32.const 1104
-    i32.const 130
-    i32.const 22
-    call $~lib/builtins/abort
-    unreachable
-   end
-   local.get $0
-   local.get $1
-   i32.const 1
-   i32.add
-   local.tee $3
-   i32.const 1
-   call $~lib/array/ensureCapacity
-   local.get $0
-   local.get $3
-   i32.store $0 offset=12
-  end
-  local.get $0
-  local.get $1
-  local.get $2
-  call $~lib/array/Array<std/array/Ref>#__uset
- )
  (func $start:std/array~anonymous|52 (type $i32_i32_=>_i32) (param $0 i32) (param $1 i32) (result i32)
   local.get $0
   i32.const 0
@@ -12388,7 +12382,7 @@
      local.get $7
      local.get $2
      local.get $0
-     call $~lib/array/Array<~lib/array/Array<i32>>#__set
+     call $~lib/array/Array<std/array/Ref>#__set
      local.get $2
      i32.const 1
      i32.add
@@ -14245,12 +14239,12 @@
    i32.const 0
    i32.const 0
    call $std/array/Ref#constructor
-   call $~lib/array/Array<std/array/Ref>#__uset
+   call $~lib/array/Array<std/array/Ref>#__set
    local.get $1
    i32.const 1
    i32.const 0
    call $std/array/Ref#constructor
-   call $~lib/array/Array<std/array/Ref>#__uset
+   call $~lib/array/Array<std/array/Ref>#__set
    local.get $0
    local.get $1
    i32.store $0 offset=28
@@ -15363,7 +15357,7 @@
    if
     i32.const 2640
     i32.const 1104
-    i32.const 334
+    i32.const 330
     i32.const 18
     call $~lib/builtins/abort
     unreachable
@@ -19056,27 +19050,27 @@
    i32.const 0
    i32.const 1
    call $std/array/Ref#constructor
-   call $~lib/array/Array<std/array/Ref>#__uset
+   call $~lib/array/Array<std/array/Ref>#__set
    local.get $1
    i32.const 1
    i32.const 2
    call $std/array/Ref#constructor
-   call $~lib/array/Array<std/array/Ref>#__uset
+   call $~lib/array/Array<std/array/Ref>#__set
    local.get $1
    i32.const 2
    i32.const 3
    call $std/array/Ref#constructor
-   call $~lib/array/Array<std/array/Ref>#__uset
+   call $~lib/array/Array<std/array/Ref>#__set
    local.get $1
    i32.const 3
    i32.const 4
    call $std/array/Ref#constructor
-   call $~lib/array/Array<std/array/Ref>#__uset
+   call $~lib/array/Array<std/array/Ref>#__set
    local.get $1
    i32.const 4
    i32.const 5
    call $std/array/Ref#constructor
-   call $~lib/array/Array<std/array/Ref>#__uset
+   call $~lib/array/Array<std/array/Ref>#__set
    local.get $0
    local.get $1
    i32.store $0 offset=92
@@ -19222,16 +19216,16 @@
    i32.const 0
    i32.const 1
    call $std/array/Ref#constructor
-   call $~lib/array/Array<std/array/Ref>#__uset
+   call $~lib/array/Array<std/array/Ref>#__set
    local.get $1
    i32.const 1
    i32.const 0
-   call $~lib/array/Array<std/array/Ref>#__uset
+   call $~lib/array/Array<std/array/Ref>#__set
    local.get $1
    i32.const 2
    i32.const 2
    call $std/array/Ref#constructor
-   call $~lib/array/Array<std/array/Ref>#__uset
+   call $~lib/array/Array<std/array/Ref>#__set
    local.get $0
    local.get $1
    i32.store $0 offset=116
@@ -22954,7 +22948,7 @@
    local.get $0
    i32.const 0
    local.get $1
-   call $~lib/array/Array<std/array/Ref>#__uset
+   call $~lib/array/Array<std/array/Ref>#__set
    global.get $~lib/memory/__stack_pointer
    call $std/array/Dim#constructor
    local.tee $1
@@ -22968,7 +22962,7 @@
    local.get $0
    i32.const 1
    local.get $1
-   call $~lib/array/Array<std/array/Ref>#__uset
+   call $~lib/array/Array<std/array/Ref>#__set
    global.get $~lib/memory/__stack_pointer
    call $std/array/Dim#constructor
    local.tee $1
@@ -22982,7 +22976,7 @@
    local.get $0
    i32.const 2
    local.get $1
-   call $~lib/array/Array<std/array/Ref>#__uset
+   call $~lib/array/Array<std/array/Ref>#__set
    global.get $~lib/memory/__stack_pointer
    call $std/array/Dim#constructor
    local.tee $1
@@ -22996,7 +22990,7 @@
    local.get $0
    i32.const 3
    local.get $1
-   call $~lib/array/Array<std/array/Ref>#__uset
+   call $~lib/array/Array<std/array/Ref>#__set
    global.get $~lib/memory/__stack_pointer
    call $std/array/Dim#constructor
    local.tee $1
@@ -23010,7 +23004,7 @@
    local.get $0
    i32.const 4
    local.get $1
-   call $~lib/array/Array<std/array/Ref>#__uset
+   call $~lib/array/Array<std/array/Ref>#__set
    global.get $~lib/memory/__stack_pointer
    call $std/array/Dim#constructor
    local.tee $1
@@ -23024,7 +23018,7 @@
    local.get $0
    i32.const 5
    local.get $1
-   call $~lib/array/Array<std/array/Ref>#__uset
+   call $~lib/array/Array<std/array/Ref>#__set
    global.get $~lib/memory/__stack_pointer
    call $std/array/Dim#constructor
    local.tee $1
@@ -23038,7 +23032,7 @@
    local.get $0
    i32.const 6
    local.get $1
-   call $~lib/array/Array<std/array/Ref>#__uset
+   call $~lib/array/Array<std/array/Ref>#__set
    global.get $~lib/memory/__stack_pointer
    call $std/array/Dim#constructor
    local.tee $1
@@ -23052,7 +23046,7 @@
    local.get $0
    i32.const 7
    local.get $1
-   call $~lib/array/Array<std/array/Ref>#__uset
+   call $~lib/array/Array<std/array/Ref>#__set
    global.get $~lib/memory/__stack_pointer
    call $std/array/Dim#constructor
    local.tee $1
@@ -23066,7 +23060,7 @@
    local.get $0
    i32.const 8
    local.get $1
-   call $~lib/array/Array<std/array/Ref>#__uset
+   call $~lib/array/Array<std/array/Ref>#__set
    global.get $~lib/memory/__stack_pointer
    call $std/array/Dim#constructor
    local.tee $1
@@ -23080,7 +23074,7 @@
    local.get $0
    i32.const 9
    local.get $1
-   call $~lib/array/Array<std/array/Ref>#__uset
+   call $~lib/array/Array<std/array/Ref>#__set
    global.get $~lib/memory/__stack_pointer
    call $std/array/Dim#constructor
    local.tee $1
@@ -23094,7 +23088,7 @@
    local.get $0
    i32.const 10
    local.get $1
-   call $~lib/array/Array<std/array/Ref>#__uset
+   call $~lib/array/Array<std/array/Ref>#__set
    global.get $~lib/memory/__stack_pointer
    call $std/array/Dim#constructor
    local.tee $1
@@ -23108,7 +23102,7 @@
    local.get $0
    i32.const 11
    local.get $1
-   call $~lib/array/Array<std/array/Ref>#__uset
+   call $~lib/array/Array<std/array/Ref>#__set
    local.get $0
    global.set $std/array/inputStabArr
    global.get $~lib/memory/__stack_pointer
@@ -23136,7 +23130,7 @@
    local.get $0
    i32.const 0
    local.get $1
-   call $~lib/array/Array<std/array/Ref>#__uset
+   call $~lib/array/Array<std/array/Ref>#__set
    global.get $~lib/memory/__stack_pointer
    call $std/array/Dim#constructor
    local.tee $1
@@ -23150,7 +23144,7 @@
    local.get $0
    i32.const 1
    local.get $1
-   call $~lib/array/Array<std/array/Ref>#__uset
+   call $~lib/array/Array<std/array/Ref>#__set
    global.get $~lib/memory/__stack_pointer
    call $std/array/Dim#constructor
    local.tee $1
@@ -23164,7 +23158,7 @@
    local.get $0
    i32.const 2
    local.get $1
-   call $~lib/array/Array<std/array/Ref>#__uset
+   call $~lib/array/Array<std/array/Ref>#__set
    global.get $~lib/memory/__stack_pointer
    call $std/array/Dim#constructor
    local.tee $1
@@ -23178,7 +23172,7 @@
    local.get $0
    i32.const 3
    local.get $1
-   call $~lib/array/Array<std/array/Ref>#__uset
+   call $~lib/array/Array<std/array/Ref>#__set
    global.get $~lib/memory/__stack_pointer
    call $std/array/Dim#constructor
    local.tee $1
@@ -23192,7 +23186,7 @@
    local.get $0
    i32.const 4
    local.get $1
-   call $~lib/array/Array<std/array/Ref>#__uset
+   call $~lib/array/Array<std/array/Ref>#__set
    global.get $~lib/memory/__stack_pointer
    call $std/array/Dim#constructor
    local.tee $1
@@ -23206,7 +23200,7 @@
    local.get $0
    i32.const 5
    local.get $1
-   call $~lib/array/Array<std/array/Ref>#__uset
+   call $~lib/array/Array<std/array/Ref>#__set
    global.get $~lib/memory/__stack_pointer
    call $std/array/Dim#constructor
    local.tee $1
@@ -23220,7 +23214,7 @@
    local.get $0
    i32.const 6
    local.get $1
-   call $~lib/array/Array<std/array/Ref>#__uset
+   call $~lib/array/Array<std/array/Ref>#__set
    global.get $~lib/memory/__stack_pointer
    call $std/array/Dim#constructor
    local.tee $1
@@ -23234,7 +23228,7 @@
    local.get $0
    i32.const 7
    local.get $1
-   call $~lib/array/Array<std/array/Ref>#__uset
+   call $~lib/array/Array<std/array/Ref>#__set
    global.get $~lib/memory/__stack_pointer
    call $std/array/Dim#constructor
    local.tee $1
@@ -23248,7 +23242,7 @@
    local.get $0
    i32.const 8
    local.get $1
-   call $~lib/array/Array<std/array/Ref>#__uset
+   call $~lib/array/Array<std/array/Ref>#__set
    global.get $~lib/memory/__stack_pointer
    call $std/array/Dim#constructor
    local.tee $1
@@ -23262,7 +23256,7 @@
    local.get $0
    i32.const 9
    local.get $1
-   call $~lib/array/Array<std/array/Ref>#__uset
+   call $~lib/array/Array<std/array/Ref>#__set
    global.get $~lib/memory/__stack_pointer
    call $std/array/Dim#constructor
    local.tee $1
@@ -23276,7 +23270,7 @@
    local.get $0
    i32.const 10
    local.get $1
-   call $~lib/array/Array<std/array/Ref>#__uset
+   call $~lib/array/Array<std/array/Ref>#__set
    global.get $~lib/memory/__stack_pointer
    call $std/array/Dim#constructor
    local.tee $1
@@ -23290,7 +23284,7 @@
    local.get $0
    i32.const 11
    local.get $1
-   call $~lib/array/Array<std/array/Ref>#__uset
+   call $~lib/array/Array<std/array/Ref>#__set
    local.get $0
    global.set $std/array/outputStabArr
    global.get $~lib/memory/__stack_pointer
@@ -24156,7 +24150,7 @@
      local.get $2
      local.get $0
      local.get $6
-     call $~lib/array/Array<~lib/array/Array<i32>>#__set
+     call $~lib/array/Array<std/array/Ref>#__set
      local.get $0
      i32.const 1
      i32.add
@@ -24293,7 +24287,7 @@
      local.get $6
      local.get $0
      local.get $2
-     call $~lib/array/Array<~lib/array/Array<i32>>#__set
+     call $~lib/array/Array<std/array/Ref>#__set
      local.get $0
      i32.const 1
      i32.add
@@ -24990,16 +24984,16 @@
    i32.const 0
    i32.const 0
    call $std/array/Ref#constructor
-   call $~lib/array/Array<std/array/Ref>#__uset
+   call $~lib/array/Array<std/array/Ref>#__set
    local.get $1
    i32.const 1
    i32.const 0
-   call $~lib/array/Array<std/array/Ref>#__uset
+   call $~lib/array/Array<std/array/Ref>#__set
    local.get $1
    i32.const 2
    i32.const 0
    call $std/array/Ref#constructor
-   call $~lib/array/Array<std/array/Ref>#__uset
+   call $~lib/array/Array<std/array/Ref>#__set
    local.get $0
    local.get $1
    i32.store $0 offset=364
@@ -25044,12 +25038,12 @@
    i32.const 0
    i32.const 0
    call $std/array/Ref#constructor
-   call $~lib/array/Array<std/array/Ref>#__uset
+   call $~lib/array/Array<std/array/Ref>#__set
    local.get $1
    i32.const 1
    i32.const 0
    call $std/array/Ref#constructor
-   call $~lib/array/Array<std/array/Ref>#__uset
+   call $~lib/array/Array<std/array/Ref>#__set
    local.get $0
    local.get $1
    i32.store $0 offset=376
@@ -26177,7 +26171,7 @@
    i32.const 4
    i32.const 15104
    call $~lib/rt/__newArray
-   call $~lib/array/Array<std/array/Ref>#__uset
+   call $~lib/array/Array<std/array/Ref>#__set
    local.get $1
    i32.const 1
    i32.const 2
@@ -26185,7 +26179,7 @@
    i32.const 4
    i32.const 15136
    call $~lib/rt/__newArray
-   call $~lib/array/Array<std/array/Ref>#__uset
+   call $~lib/array/Array<std/array/Ref>#__set
    local.get $0
    local.get $1
    i32.store $0 offset=408
@@ -26395,7 +26389,7 @@
    i32.const 7
    i32.const 15216
    call $~lib/rt/__newArray
-   call $~lib/array/Array<std/array/Ref>#__uset
+   call $~lib/array/Array<std/array/Ref>#__set
    local.get $1
    i32.const 1
    i32.const 2
@@ -26403,7 +26397,7 @@
    i32.const 7
    i32.const 15248
    call $~lib/rt/__newArray
-   call $~lib/array/Array<std/array/Ref>#__uset
+   call $~lib/array/Array<std/array/Ref>#__set
    local.get $0
    local.get $1
    i32.store $0 offset=420
@@ -26625,11 +26619,11 @@
    i32.const 8
    i32.const 15280
    call $~lib/rt/__newArray
-   call $~lib/array/Array<std/array/Ref>#__uset
+   call $~lib/array/Array<std/array/Ref>#__set
    local.get $1
    i32.const 0
    local.get $2
-   call $~lib/array/Array<std/array/Ref>#__uset
+   call $~lib/array/Array<std/array/Ref>#__set
    local.get $0
    local.get $1
    i32.store $0 offset=440
@@ -26839,7 +26833,7 @@
    i32.const 4
    i32.const 15312
    call $~lib/rt/__newArray
-   call $~lib/array/Array<std/array/Ref>#__uset
+   call $~lib/array/Array<std/array/Ref>#__set
    local.get $1
    i32.const 1
    i32.const 3
@@ -26847,7 +26841,7 @@
    i32.const 4
    i32.const 15344
    call $~lib/rt/__newArray
-   call $~lib/array/Array<std/array/Ref>#__uset
+   call $~lib/array/Array<std/array/Ref>#__set
    local.get $1
    i32.const 2
    i32.const 3
@@ -26855,7 +26849,7 @@
    i32.const 4
    i32.const 15376
    call $~lib/rt/__newArray
-   call $~lib/array/Array<std/array/Ref>#__uset
+   call $~lib/array/Array<std/array/Ref>#__set
    local.get $1
    i32.const 3
    i32.const 3
@@ -26863,7 +26857,7 @@
    i32.const 4
    i32.const 15408
    call $~lib/rt/__newArray
-   call $~lib/array/Array<std/array/Ref>#__uset
+   call $~lib/array/Array<std/array/Ref>#__set
    local.get $0
    local.get $1
    i32.store $0 offset=452
@@ -26931,7 +26925,7 @@
    i32.const 34
    i32.const 15472
    call $~lib/rt/__newArray
-   call $~lib/array/Array<std/array/Ref>#__uset
+   call $~lib/array/Array<std/array/Ref>#__set
    local.get $1
    i32.const 1
    i32.const 3
@@ -26939,7 +26933,7 @@
    i32.const 34
    i32.const 15568
    call $~lib/rt/__newArray
-   call $~lib/array/Array<std/array/Ref>#__uset
+   call $~lib/array/Array<std/array/Ref>#__set
    local.get $1
    i32.const 2
    i32.const 3
@@ -26947,7 +26941,7 @@
    i32.const 34
    i32.const 15696
    call $~lib/rt/__newArray
-   call $~lib/array/Array<std/array/Ref>#__uset
+   call $~lib/array/Array<std/array/Ref>#__set
    local.get $1
    i32.const 3
    i32.const 1
@@ -26955,7 +26949,7 @@
    i32.const 34
    i32.const 15760
    call $~lib/rt/__newArray
-   call $~lib/array/Array<std/array/Ref>#__uset
+   call $~lib/array/Array<std/array/Ref>#__set
    local.get $0
    local.get $1
    i32.store $0 offset=468
@@ -27199,7 +27193,7 @@
    i32.const 4
    i32.const 15856
    call $~lib/rt/__newArray
-   call $~lib/array/Array<std/array/Ref>#__uset
+   call $~lib/array/Array<std/array/Ref>#__set
    local.get $1
    i32.const 1
    i32.const 0
@@ -27207,7 +27201,7 @@
    i32.const 4
    i32.const 15888
    call $~lib/rt/__newArray
-   call $~lib/array/Array<std/array/Ref>#__uset
+   call $~lib/array/Array<std/array/Ref>#__set
    local.get $0
    local.get $1
    i32.store $0 offset=488
@@ -27247,7 +27241,7 @@
    i32.const 4
    i32.const 15920
    call $~lib/rt/__newArray
-   call $~lib/array/Array<std/array/Ref>#__uset
+   call $~lib/array/Array<std/array/Ref>#__set
    local.get $1
    i32.const 1
    i32.const 1
@@ -27255,7 +27249,7 @@
    i32.const 4
    i32.const 15952
    call $~lib/rt/__newArray
-   call $~lib/array/Array<std/array/Ref>#__uset
+   call $~lib/array/Array<std/array/Ref>#__set
    local.get $0
    local.get $1
    i32.store $0 offset=500
@@ -27747,7 +27741,7 @@
   if
    i32.const 1056
    i32.const 1104
-   i32.const 228
+   i32.const 224
    i32.const 60
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/std/date.debug.wat
+++ b/tests/compiler/std/date.debug.wat
@@ -140,8 +140,8 @@
  (data (i32.const 5484) "L\00\00\00\00\00\00\00\00\00\00\00\02\00\00\00:\00\00\00M\00o\00n\00,\00 \000\003\00 \00F\00e\00b\00 \002\000\002\000\00 \001\004\00:\005\003\00:\003\003\00 \00G\00M\00T\00\00\00")
  (data (i32.const 5564) "L\00\00\00\00\00\00\00\00\00\00\00\02\00\00\00<\00\00\00T\00h\00u\00,\00 \000\001\00 \00J\00u\00l\00 \00-\000\000\000\001\00 \000\000\00:\000\000\00:\000\000\00 \00G\00M\00T\00")
  (data (i32.const 5644) ",\00\00\00\00\00\00\00\00\00\00\00\02\00\00\00\14\00\00\001\009\007\006\00-\000\002\00-\000\002\00\00\00\00\00\00\00\00\00")
- (data (i32.const 5692) ",\00\00\00\00\00\00\00\00\00\00\00\02\00\00\00\1c\00\00\00I\00n\00v\00a\00l\00i\00d\00 \00l\00e\00n\00g\00t\00h\00")
- (data (i32.const 5740) ",\00\00\00\00\00\00\00\00\00\00\00\02\00\00\00\1a\00\00\00~\00l\00i\00b\00/\00a\00r\00r\00a\00y\00.\00t\00s\00\00\00")
+ (data (i32.const 5692) ",\00\00\00\00\00\00\00\00\00\00\00\02\00\00\00\1a\00\00\00~\00l\00i\00b\00/\00a\00r\00r\00a\00y\00.\00t\00s\00\00\00")
+ (data (i32.const 5740) ",\00\00\00\00\00\00\00\00\00\00\00\02\00\00\00\1c\00\00\00I\00n\00v\00a\00l\00i\00d\00 \00l\00e\00n\00g\00t\00h\00")
  (data (i32.const 5788) "|\00\00\00\00\00\00\00\00\00\00\00\02\00\00\00^\00\00\00E\00l\00e\00m\00e\00n\00t\00 \00t\00y\00p\00e\00 \00m\00u\00s\00t\00 \00b\00e\00 \00n\00u\00l\00l\00a\00b\00l\00e\00 \00i\00f\00 \00a\00r\00r\00a\00y\00 \00i\00s\00 \00h\00o\00l\00e\00y\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00")
  (data (i32.const 5916) ",\00\00\00\00\00\00\00\00\00\00\00\02\00\00\00\10\00\00\001\009\007\006\00-\002\00-\002\00\00\00\00\00\00\00\00\00\00\00\00\00")
  (data (i32.const 5964) ",\00\00\00\00\00\00\00\00\00\00\00\02\00\00\00\14\00\00\002\003\004\005\00-\001\001\00-\000\004\00\00\00\00\00\00\00\00\00")
@@ -3933,26 +3933,6 @@
   local.get $end
   call $~lib/string/String#substring
  )
- (func $~lib/array/Array<~lib/string/String>#get:dataStart (type $i32_=>_i32) (param $this i32) (result i32)
-  local.get $this
-  i32.load $0 offset=4
- )
- (func $~lib/array/Array<~lib/string/String>#__uset (type $i32_i32_i32_=>_none) (param $this i32) (param $index i32) (param $value i32)
-  local.get $this
-  call $~lib/array/Array<~lib/string/String>#get:dataStart
-  local.get $index
-  i32.const 2
-  i32.shl
-  i32.add
-  local.get $value
-  i32.store $0
-  i32.const 1
-  drop
-  local.get $this
-  local.get $value
-  i32.const 1
-  call $~lib/rt/itcms/__link
- )
  (func $~lib/array/Array<~lib/string/String>#get:length_ (type $i32_=>_i32) (param $this i32) (result i32)
   local.get $this
   i32.load $0 offset=12
@@ -4041,8 +4021,8 @@
    i32.shr_u
    i32.gt_u
    if
-    i32.const 5712
     i32.const 5760
+    i32.const 5712
     i32.const 19
     i32.const 48
     call $~lib/builtins/abort
@@ -4115,6 +4095,55 @@
   local.get $this
   local.get $length_
   i32.store $0 offset=12
+ )
+ (func $~lib/array/Array<~lib/string/String>#get:dataStart (type $i32_=>_i32) (param $this i32) (result i32)
+  local.get $this
+  i32.load $0 offset=4
+ )
+ (func $~lib/array/Array<~lib/string/String>#__set (type $i32_i32_i32_=>_none) (param $this i32) (param $index i32) (param $value i32)
+  local.get $index
+  local.get $this
+  call $~lib/array/Array<~lib/string/String>#get:length_
+  i32.ge_u
+  if
+   local.get $index
+   i32.const 0
+   i32.lt_s
+   if
+    i32.const 368
+    i32.const 5712
+    i32.const 130
+    i32.const 22
+    call $~lib/builtins/abort
+    unreachable
+   end
+   local.get $this
+   local.get $index
+   i32.const 1
+   i32.add
+   i32.const 2
+   i32.const 1
+   call $~lib/array/ensureCapacity
+   local.get $this
+   local.get $index
+   i32.const 1
+   i32.add
+   call $~lib/array/Array<~lib/string/String>#set:length_
+  end
+  local.get $this
+  call $~lib/array/Array<~lib/string/String>#get:dataStart
+  local.get $index
+  i32.const 2
+  i32.shl
+  i32.add
+  local.get $value
+  i32.store $0
+  i32.const 1
+  drop
+  local.get $this
+  local.get $value
+  i32.const 1
+  call $~lib/rt/itcms/__link
  )
  (func $~lib/array/Array<~lib/string/String>#push (type $i32_i32_=>_i32) (param $this i32) (param $value i32) (result i32)
   (local $oldLen i32)
@@ -4582,7 +4611,7 @@
   i32.const 368
   local.get $0
   call $~lib/rt/itcms/__visit
-  i32.const 5712
+  i32.const 5760
   local.get $0
   call $~lib/rt/itcms/__visit
   i32.const 5808
@@ -5632,7 +5661,7 @@
    local.get $3
    i32.const 0
    local.get $this
-   call $~lib/array/Array<~lib/string/String>#__uset
+   call $~lib/array/Array<~lib/string/String>#__set
    local.get $3
    local.set $22
    global.get $~lib/memory/__stack_pointer
@@ -10634,7 +10663,7 @@
   i32.ge_u
   if
    i32.const 368
-   i32.const 5760
+   i32.const 5712
    i32.const 114
    i32.const 42
    call $~lib/builtins/abort
@@ -10659,7 +10688,7 @@
   i32.eqz
   if
    i32.const 5808
-   i32.const 5760
+   i32.const 5712
    i32.const 118
    i32.const 40
    call $~lib/builtins/abort

--- a/tests/compiler/std/date.release.wat
+++ b/tests/compiler/std/date.release.wat
@@ -204,9 +204,9 @@
  (data (i32.const 6668) ",")
  (data (i32.const 6680) "\02\00\00\00\14\00\00\001\009\007\006\00-\000\002\00-\000\002")
  (data (i32.const 6716) ",")
- (data (i32.const 6728) "\02\00\00\00\1c\00\00\00I\00n\00v\00a\00l\00i\00d\00 \00l\00e\00n\00g\00t\00h")
+ (data (i32.const 6728) "\02\00\00\00\1a\00\00\00~\00l\00i\00b\00/\00a\00r\00r\00a\00y\00.\00t\00s")
  (data (i32.const 6764) ",")
- (data (i32.const 6776) "\02\00\00\00\1a\00\00\00~\00l\00i\00b\00/\00a\00r\00r\00a\00y\00.\00t\00s")
+ (data (i32.const 6776) "\02\00\00\00\1c\00\00\00I\00n\00v\00a\00l\00i\00d\00 \00l\00e\00n\00g\00t\00h")
  (data (i32.const 6812) "|")
  (data (i32.const 6824) "\02\00\00\00^\00\00\00E\00l\00e\00m\00e\00n\00t\00 \00t\00y\00p\00e\00 \00m\00u\00s\00t\00 \00b\00e\00 \00n\00u\00l\00l\00a\00b\00l\00e\00 \00i\00f\00 \00a\00r\00r\00a\00y\00 \00i\00s\00 \00h\00o\00l\00e\00y")
  (data (i32.const 6940) ",")
@@ -414,7 +414,7 @@
   (local $1 i32)
   i32.const 1392
   call $byn-split-outlined-A$~lib/rt/itcms/__visit
-  i32.const 6736
+  i32.const 6784
   call $byn-split-outlined-A$~lib/rt/itcms/__visit
   i32.const 6832
   call $byn-split-outlined-A$~lib/rt/itcms/__visit
@@ -2840,71 +2840,60 @@
   local.get $2
   call $~lib/string/String#substring
  )
- (func $~lib/array/Array<~lib/string/String>#push (type $i32_i32_=>_none) (param $0 i32) (param $1 i32)
+ (func $~lib/array/ensureCapacity (type $i32_i32_=>_none) (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
-  (local $5 i32)
-  (local $6 i32)
-  (local $7 i32)
-  (local $8 i32)
-  local.get $0
-  i32.load $0 offset=12
-  local.tee $5
-  i32.const 1
-  i32.add
-  local.tee $7
+  local.get $1
   local.get $0
   i32.load $0 offset=8
-  local.tee $3
+  local.tee $2
   i32.const 2
   i32.shr_u
   i32.gt_u
   if
-   local.get $7
+   local.get $1
    i32.const 268435455
    i32.gt_u
    if
-    i32.const 6736
     i32.const 6784
+    i32.const 6736
     i32.const 19
     i32.const 48
     call $~lib/builtins/abort
     unreachable
    end
-   local.get $0
-   i32.load $0
-   local.tee $2
-   local.set $4
    block $__inlined_func$~lib/rt/itcms/__renew
     i32.const 1073741820
-    local.get $3
+    local.get $2
     i32.const 1
     i32.shl
-    local.tee $3
-    local.get $3
+    local.tee $2
+    local.get $2
     i32.const 1073741820
     i32.ge_u
     select
-    local.tee $3
+    local.tee $2
     i32.const 8
-    local.get $7
-    local.get $7
+    local.get $1
+    local.get $1
     i32.const 8
     i32.le_u
     select
     i32.const 2
     i32.shl
-    local.tee $6
-    local.get $3
-    local.get $6
-    i32.gt_u
-    select
-    local.tee $8
+    local.tee $1
+    local.get $1
     local.get $2
+    i32.lt_u
+    select
+    local.tee $3
+    local.get $0
+    i32.load $0
+    local.tee $2
     i32.const 20
     i32.sub
-    local.tee $6
+    local.tee $4
     i32.load $0
     i32.const -4
     i32.and
@@ -2912,54 +2901,66 @@
     i32.sub
     i32.le_u
     if
-     local.get $6
-     local.get $8
+     local.get $4
+     local.get $3
      i32.store $0 offset=16
+     local.get $2
+     local.set $1
      br $__inlined_func$~lib/rt/itcms/__renew
     end
-    local.get $8
-    local.get $6
+    local.get $3
+    local.get $4
     i32.load $0 offset=12
     call $~lib/rt/itcms/__new
-    local.tee $3
+    local.tee $1
     local.get $2
-    local.get $8
-    local.get $6
+    local.get $3
+    local.get $4
     i32.load $0 offset=16
-    local.tee $2
-    local.get $2
-    local.get $8
-    i32.gt_u
+    local.tee $4
+    local.get $3
+    local.get $4
+    i32.lt_u
     select
     memory.copy $0 $0
-    local.get $3
-    local.set $2
    end
+   local.get $1
    local.get $2
-   local.get $4
    i32.ne
    if
     local.get $0
-    local.get $2
+    local.get $1
     i32.store $0
     local.get $0
-    local.get $2
+    local.get $1
     i32.store $0 offset=4
-    local.get $2
+    local.get $1
     if
      local.get $0
-     local.get $2
+     local.get $1
      i32.const 0
      call $byn-split-outlined-A$~lib/rt/itcms/__link
     end
    end
    local.get $0
-   local.get $8
+   local.get $3
    i32.store $0 offset=8
   end
+ )
+ (func $~lib/array/Array<~lib/string/String>#push (type $i32_i32_=>_none) (param $0 i32) (param $1 i32)
+  (local $2 i32)
+  (local $3 i32)
+  local.get $0
+  local.get $0
+  i32.load $0 offset=12
+  local.tee $2
+  i32.const 1
+  i32.add
+  local.tee $3
+  call $~lib/array/ensureCapacity
   local.get $0
   i32.load $0 offset=4
-  local.get $5
+  local.get $2
   i32.const 2
   i32.shl
   i32.add
@@ -2973,7 +2974,7 @@
    call $byn-split-outlined-A$~lib/rt/itcms/__link
   end
   local.get $0
-  local.get $7
+  local.get $3
   i32.store $0 offset=12
  )
  (func $~lib/string/String#split@varargs (type $i32_i32_=>_i32) (param $0 i32) (param $1 i32) (result i32)
@@ -4478,19 +4479,30 @@
       global.get $~lib/memory/__stack_pointer
       i32.const 1
       call $~lib/rt/__newArray
-      local.tee $3
+      local.tee $2
       i32.store $0
       global.get $~lib/memory/__stack_pointer
-      local.get $3
+      local.get $2
       i32.load $0 offset=4
       i32.store $0 offset=4
-      local.get $3
+      local.get $2
+      i32.load $0 offset=12
+      i32.eqz
+      if
+       local.get $2
+       i32.const 1
+       call $~lib/array/ensureCapacity
+       local.get $2
+       i32.const 1
+       i32.store $0 offset=12
+      end
+      local.get $2
       i32.load $0 offset=4
       local.get $0
       i32.store $0
       local.get $0
       if
-       local.get $3
+       local.get $2
        local.get $0
        i32.const 1
        call $byn-split-outlined-A$~lib/rt/itcms/__link
@@ -4503,59 +4515,57 @@
      i32.load $0 offset=16
      i32.const 1
      i32.shr_u
-     local.set $5
+     local.set $7
      i32.const 2147483647
      local.get $2
      local.get $2
      i32.const 0
      i32.lt_s
      select
-     local.set $2
+     local.set $9
      local.get $1
      i32.const 20
      i32.sub
      i32.load $0 offset=16
      i32.const 1
      i32.shr_u
-     local.tee $8
+     local.tee $4
      if
-      local.get $5
+      local.get $7
       i32.eqz
       if
        global.get $~lib/memory/__stack_pointer
        i32.const 1
        call $~lib/rt/__newArray
-       local.tee $3
+       local.tee $2
        i32.store $0 offset=16
-       local.get $3
+       local.get $2
        i32.load $0 offset=4
        i32.const 3456
        i32.store $0
        br $folding-inner1
       end
      else
-      local.get $5
+      local.get $7
       i32.eqz
       br_if $folding-inner0
       global.get $~lib/memory/__stack_pointer
-      local.get $5
-      local.get $2
-      local.get $2
-      local.get $5
-      i32.gt_s
+      local.get $7
+      local.get $9
+      local.get $7
+      local.get $9
+      i32.lt_s
       select
       local.tee $1
       call $~lib/rt/__newArray
-      local.tee $3
+      local.tee $2
       i32.store $0 offset=8
-      local.get $3
+      local.get $2
       i32.load $0 offset=4
       local.set $4
-      i32.const 0
-      local.set $2
       loop $for-loop|0
        local.get $1
-       local.get $2
+       local.get $3
        i32.gt_s
        if
         global.get $~lib/memory/__stack_pointer
@@ -4566,14 +4576,14 @@
         i32.store $0 offset=12
         local.get $5
         local.get $0
-        local.get $2
+        local.get $3
         i32.const 1
         i32.shl
         i32.add
         i32.load16_u $0
         i32.store16 $0
         local.get $4
-        local.get $2
+        local.get $3
         i32.const 2
         i32.shl
         i32.add
@@ -4581,15 +4591,15 @@
         i32.store $0
         local.get $5
         if
-         local.get $3
+         local.get $2
          local.get $5
          i32.const 1
          call $byn-split-outlined-A$~lib/rt/itcms/__link
         end
-        local.get $2
+        local.get $3
         i32.const 1
         i32.add
-        local.set $2
+        local.set $3
         br $for-loop|0
        end
       end
@@ -4598,61 +4608,60 @@
      global.get $~lib/memory/__stack_pointer
      i32.const 0
      call $~lib/rt/__newArray
-     local.tee $6
+     local.tee $8
      i32.store $0 offset=20
      loop $while-continue|1
       local.get $0
       local.get $1
       local.get $3
       call $~lib/string/String#indexOf
-      local.tee $9
+      local.tee $10
       i32.const -1
       i32.xor
       if
-       local.get $9
+       local.get $10
        local.get $3
        i32.sub
-       local.tee $7
+       local.tee $2
        i32.const 0
        i32.gt_s
        if
         global.get $~lib/memory/__stack_pointer
-        local.get $7
+        local.get $2
         i32.const 1
         i32.shl
-        local.tee $10
+        local.tee $5
         i32.const 2
         call $~lib/rt/itcms/__new
-        local.tee $7
+        local.tee $2
         i32.store $0 offset=24
-        local.get $7
+        local.get $2
         local.get $0
         local.get $3
         i32.const 1
         i32.shl
         i32.add
-        local.get $10
+        local.get $5
         memory.copy $0 $0
-        local.get $6
-        local.get $7
-        call $~lib/array/Array<~lib/string/String>#push
        else
+        i32.const 3456
+        local.set $2
         global.get $~lib/memory/__stack_pointer
         i32.const 3456
         i32.store $0 offset=28
-        local.get $6
-        i32.const 3456
-        call $~lib/array/Array<~lib/string/String>#push
        end
-       local.get $4
+       local.get $8
+       local.get $2
+       call $~lib/array/Array<~lib/string/String>#push
+       local.get $6
        i32.const 1
        i32.add
-       local.tee $4
-       local.get $2
+       local.tee $6
+       local.get $9
        i32.eq
        br_if $folding-inner2
-       local.get $8
-       local.get $9
+       local.get $4
+       local.get $10
        i32.add
        local.set $3
        br $while-continue|1
@@ -4661,12 +4670,12 @@
      local.get $3
      i32.eqz
      if
-      local.get $6
+      local.get $8
       local.get $0
       call $~lib/array/Array<~lib/string/String>#push
       br $folding-inner2
      end
-     local.get $5
+     local.get $7
      local.get $3
      i32.sub
      local.tee $1
@@ -4690,14 +4699,14 @@
       i32.add
       local.get $1
       memory.copy $0 $0
-      local.get $6
+      local.get $8
       local.get $2
       call $~lib/array/Array<~lib/string/String>#push
      else
       global.get $~lib/memory/__stack_pointer
       i32.const 3456
       i32.store $0 offset=28
-      local.get $6
+      local.get $8
       i32.const 3456
       call $~lib/array/Array<~lib/string/String>#push
      end
@@ -4705,25 +4714,25 @@
      i32.const 36
      i32.add
      global.set $~lib/memory/__stack_pointer
-     local.get $6
+     local.get $8
      return
     end
     i32.const 0
     call $~lib/rt/__newArray
-    local.set $3
+    local.set $2
    end
    global.get $~lib/memory/__stack_pointer
    i32.const 36
    i32.add
    global.set $~lib/memory/__stack_pointer
-   local.get $3
+   local.get $2
    return
   end
   global.get $~lib/memory/__stack_pointer
   i32.const 36
   i32.add
   global.set $~lib/memory/__stack_pointer
-  local.get $6
+  local.get $8
  )
  (func $~lib/date/Date.fromString (type $i32_=>_i32) (param $0 i32) (result i32)
   (local $1 i32)
@@ -8536,7 +8545,7 @@
   i32.ge_u
   if
    i32.const 1392
-   i32.const 6784
+   i32.const 6736
    i32.const 114
    i32.const 42
    call $~lib/builtins/abort
@@ -8556,7 +8565,7 @@
   i32.eqz
   if
    i32.const 6832
-   i32.const 6784
+   i32.const 6736
    i32.const 118
    i32.const 40
    call $~lib/builtins/abort

--- a/tests/compiler/std/map.debug.wat
+++ b/tests/compiler/std/map.debug.wat
@@ -2749,21 +2749,9 @@
   local.get $length_
   i32.store $0 offset=12
  )
- (func $~lib/array/Array<i8>#get:dataStart (type $i32_=>_i32) (param $this i32) (result i32)
+ (func $~lib/array/Array<i8>#get:length_ (type $i32_=>_i32) (param $this i32) (result i32)
   local.get $this
-  i32.load $0 offset=4
- )
- (func $~lib/array/Array<i8>#__uset (type $i32_i32_i32_=>_none) (param $this i32) (param $index i32) (param $value i32)
-  local.get $this
-  call $~lib/array/Array<i8>#get:dataStart
-  local.get $index
-  i32.const 0
-  i32.shl
-  i32.add
-  local.get $value
-  i32.store8 $0
-  i32.const 0
-  drop
+  i32.load $0 offset=12
  )
  (func $~lib/arraybuffer/ArrayBufferView#get:byteLength (type $i32_=>_i32) (param $this i32) (result i32)
   local.get $this
@@ -2919,6 +2907,51 @@
    i32.store $0 offset=8
   end
  )
+ (func $~lib/array/Array<i8>#get:dataStart (type $i32_=>_i32) (param $this i32) (result i32)
+  local.get $this
+  i32.load $0 offset=4
+ )
+ (func $~lib/array/Array<i8>#__set (type $i32_i32_i32_=>_none) (param $this i32) (param $index i32) (param $value i32)
+  local.get $index
+  local.get $this
+  call $~lib/array/Array<i8>#get:length_
+  i32.ge_u
+  if
+   local.get $index
+   i32.const 0
+   i32.lt_s
+   if
+    i32.const 224
+    i32.const 704
+    i32.const 130
+    i32.const 22
+    call $~lib/builtins/abort
+    unreachable
+   end
+   local.get $this
+   local.get $index
+   i32.const 1
+   i32.add
+   i32.const 0
+   i32.const 1
+   call $~lib/array/ensureCapacity
+   local.get $this
+   local.get $index
+   i32.const 1
+   i32.add
+   call $~lib/array/Array<i8>#set:length_
+  end
+  local.get $this
+  call $~lib/array/Array<i8>#get:dataStart
+  local.get $index
+  i32.const 0
+  i32.shl
+  i32.add
+  local.get $value
+  i32.store8 $0
+  i32.const 0
+  drop
+ )
  (func $~lib/array/Array<i8>#set:length (type $i32_i32_=>_none) (param $this i32) (param $newLength i32)
   local.get $this
   local.get $newLength
@@ -2953,11 +2986,44 @@
   local.get $length_
   i32.store $0 offset=12
  )
+ (func $~lib/array/Array<i32>#get:length_ (type $i32_=>_i32) (param $this i32) (result i32)
+  local.get $this
+  i32.load $0 offset=12
+ )
  (func $~lib/array/Array<i32>#get:dataStart (type $i32_=>_i32) (param $this i32) (result i32)
   local.get $this
   i32.load $0 offset=4
  )
- (func $~lib/array/Array<i32>#__uset (type $i32_i32_i32_=>_none) (param $this i32) (param $index i32) (param $value i32)
+ (func $~lib/array/Array<i32>#__set (type $i32_i32_i32_=>_none) (param $this i32) (param $index i32) (param $value i32)
+  local.get $index
+  local.get $this
+  call $~lib/array/Array<i32>#get:length_
+  i32.ge_u
+  if
+   local.get $index
+   i32.const 0
+   i32.lt_s
+   if
+    i32.const 224
+    i32.const 704
+    i32.const 130
+    i32.const 22
+    call $~lib/builtins/abort
+    unreachable
+   end
+   local.get $this
+   local.get $index
+   i32.const 1
+   i32.add
+   i32.const 2
+   i32.const 1
+   call $~lib/array/ensureCapacity
+   local.get $this
+   local.get $index
+   i32.const 1
+   i32.add
+   call $~lib/array/Array<i32>#set:length_
+  end
   local.get $this
   call $~lib/array/Array<i32>#get:dataStart
   local.get $index
@@ -3055,10 +3121,6 @@
   local.get $entriesCount
   i32.store $0 offset=20
  )
- (func $~lib/array/Array<i8>#get:length_ (type $i32_=>_i32) (param $this i32) (result i32)
-  local.get $this
-  i32.load $0 offset=12
- )
  (func $~lib/array/Array<i8>#get:length (type $i32_=>_i32) (param $this i32) (result i32)
   local.get $this
   call $~lib/array/Array<i8>#get:length_
@@ -3090,10 +3152,6 @@
   drop
   local.get $value
   return
- )
- (func $~lib/array/Array<i32>#get:length_ (type $i32_=>_i32) (param $this i32) (result i32)
-  local.get $this
-  i32.load $0 offset=12
  )
  (func $~lib/array/Array<i32>#__get (type $i32_i32_=>_i32) (param $this i32) (param $index i32) (result i32)
   (local $value i32)
@@ -4650,11 +4708,44 @@
   local.get $length_
   i32.store $0 offset=12
  )
+ (func $~lib/array/Array<u8>#get:length_ (type $i32_=>_i32) (param $this i32) (result i32)
+  local.get $this
+  i32.load $0 offset=12
+ )
  (func $~lib/array/Array<u8>#get:dataStart (type $i32_=>_i32) (param $this i32) (result i32)
   local.get $this
   i32.load $0 offset=4
  )
- (func $~lib/array/Array<u8>#__uset (type $i32_i32_i32_=>_none) (param $this i32) (param $index i32) (param $value i32)
+ (func $~lib/array/Array<u8>#__set (type $i32_i32_i32_=>_none) (param $this i32) (param $index i32) (param $value i32)
+  local.get $index
+  local.get $this
+  call $~lib/array/Array<u8>#get:length_
+  i32.ge_u
+  if
+   local.get $index
+   i32.const 0
+   i32.lt_s
+   if
+    i32.const 224
+    i32.const 704
+    i32.const 130
+    i32.const 22
+    call $~lib/builtins/abort
+    unreachable
+   end
+   local.get $this
+   local.get $index
+   i32.const 1
+   i32.add
+   i32.const 0
+   i32.const 1
+   call $~lib/array/ensureCapacity
+   local.get $this
+   local.get $index
+   i32.const 1
+   i32.add
+   call $~lib/array/Array<u8>#set:length_
+  end
   local.get $this
   call $~lib/array/Array<u8>#get:dataStart
   local.get $index
@@ -4713,10 +4804,6 @@
   local.get $this
   local.get $entriesCount
   i32.store $0 offset=20
- )
- (func $~lib/array/Array<u8>#get:length_ (type $i32_=>_i32) (param $this i32) (result i32)
-  local.get $this
-  i32.load $0 offset=12
  )
  (func $~lib/array/Array<u8>#get:length (type $i32_=>_i32) (param $this i32) (result i32)
   local.get $this
@@ -5958,11 +6045,44 @@
   local.get $length_
   i32.store $0 offset=12
  )
+ (func $~lib/array/Array<i16>#get:length_ (type $i32_=>_i32) (param $this i32) (result i32)
+  local.get $this
+  i32.load $0 offset=12
+ )
  (func $~lib/array/Array<i16>#get:dataStart (type $i32_=>_i32) (param $this i32) (result i32)
   local.get $this
   i32.load $0 offset=4
  )
- (func $~lib/array/Array<i16>#__uset (type $i32_i32_i32_=>_none) (param $this i32) (param $index i32) (param $value i32)
+ (func $~lib/array/Array<i16>#__set (type $i32_i32_i32_=>_none) (param $this i32) (param $index i32) (param $value i32)
+  local.get $index
+  local.get $this
+  call $~lib/array/Array<i16>#get:length_
+  i32.ge_u
+  if
+   local.get $index
+   i32.const 0
+   i32.lt_s
+   if
+    i32.const 224
+    i32.const 704
+    i32.const 130
+    i32.const 22
+    call $~lib/builtins/abort
+    unreachable
+   end
+   local.get $this
+   local.get $index
+   i32.const 1
+   i32.add
+   i32.const 1
+   i32.const 1
+   call $~lib/array/ensureCapacity
+   local.get $this
+   local.get $index
+   i32.const 1
+   i32.add
+   call $~lib/array/Array<i16>#set:length_
+  end
   local.get $this
   call $~lib/array/Array<i16>#get:dataStart
   local.get $index
@@ -6021,10 +6141,6 @@
   local.get $this
   local.get $entriesCount
   i32.store $0 offset=20
- )
- (func $~lib/array/Array<i16>#get:length_ (type $i32_=>_i32) (param $this i32) (result i32)
-  local.get $this
-  i32.load $0 offset=12
  )
  (func $~lib/array/Array<i16>#get:length (type $i32_=>_i32) (param $this i32) (result i32)
   local.get $this
@@ -7267,11 +7383,44 @@
   local.get $length_
   i32.store $0 offset=12
  )
+ (func $~lib/array/Array<u16>#get:length_ (type $i32_=>_i32) (param $this i32) (result i32)
+  local.get $this
+  i32.load $0 offset=12
+ )
  (func $~lib/array/Array<u16>#get:dataStart (type $i32_=>_i32) (param $this i32) (result i32)
   local.get $this
   i32.load $0 offset=4
  )
- (func $~lib/array/Array<u16>#__uset (type $i32_i32_i32_=>_none) (param $this i32) (param $index i32) (param $value i32)
+ (func $~lib/array/Array<u16>#__set (type $i32_i32_i32_=>_none) (param $this i32) (param $index i32) (param $value i32)
+  local.get $index
+  local.get $this
+  call $~lib/array/Array<u16>#get:length_
+  i32.ge_u
+  if
+   local.get $index
+   i32.const 0
+   i32.lt_s
+   if
+    i32.const 224
+    i32.const 704
+    i32.const 130
+    i32.const 22
+    call $~lib/builtins/abort
+    unreachable
+   end
+   local.get $this
+   local.get $index
+   i32.const 1
+   i32.add
+   i32.const 1
+   i32.const 1
+   call $~lib/array/ensureCapacity
+   local.get $this
+   local.get $index
+   i32.const 1
+   i32.add
+   call $~lib/array/Array<u16>#set:length_
+  end
   local.get $this
   call $~lib/array/Array<u16>#get:dataStart
   local.get $index
@@ -7330,10 +7479,6 @@
   local.get $this
   local.get $entriesCount
   i32.store $0 offset=20
- )
- (func $~lib/array/Array<u16>#get:length_ (type $i32_=>_i32) (param $this i32) (result i32)
-  local.get $this
-  i32.load $0 offset=12
  )
  (func $~lib/array/Array<u16>#get:length (type $i32_=>_i32) (param $this i32) (result i32)
   local.get $this
@@ -9146,11 +9291,44 @@
   local.get $length_
   i32.store $0 offset=12
  )
+ (func $~lib/array/Array<u32>#get:length_ (type $i32_=>_i32) (param $this i32) (result i32)
+  local.get $this
+  i32.load $0 offset=12
+ )
  (func $~lib/array/Array<u32>#get:dataStart (type $i32_=>_i32) (param $this i32) (result i32)
   local.get $this
   i32.load $0 offset=4
  )
- (func $~lib/array/Array<u32>#__uset (type $i32_i32_i32_=>_none) (param $this i32) (param $index i32) (param $value i32)
+ (func $~lib/array/Array<u32>#__set (type $i32_i32_i32_=>_none) (param $this i32) (param $index i32) (param $value i32)
+  local.get $index
+  local.get $this
+  call $~lib/array/Array<u32>#get:length_
+  i32.ge_u
+  if
+   local.get $index
+   i32.const 0
+   i32.lt_s
+   if
+    i32.const 224
+    i32.const 704
+    i32.const 130
+    i32.const 22
+    call $~lib/builtins/abort
+    unreachable
+   end
+   local.get $this
+   local.get $index
+   i32.const 1
+   i32.add
+   i32.const 2
+   i32.const 1
+   call $~lib/array/ensureCapacity
+   local.get $this
+   local.get $index
+   i32.const 1
+   i32.add
+   call $~lib/array/Array<u32>#set:length_
+  end
   local.get $this
   call $~lib/array/Array<u32>#get:dataStart
   local.get $index
@@ -9209,10 +9387,6 @@
   local.get $this
   local.get $entriesCount
   i32.store $0 offset=20
- )
- (func $~lib/array/Array<u32>#get:length_ (type $i32_=>_i32) (param $this i32) (result i32)
-  local.get $this
-  i32.load $0 offset=12
  )
  (func $~lib/array/Array<u32>#get:length (type $i32_=>_i32) (param $this i32) (result i32)
   local.get $this
@@ -10464,11 +10638,44 @@
   local.get $length_
   i32.store $0 offset=12
  )
+ (func $~lib/array/Array<i64>#get:length_ (type $i32_=>_i32) (param $this i32) (result i32)
+  local.get $this
+  i32.load $0 offset=12
+ )
  (func $~lib/array/Array<i64>#get:dataStart (type $i32_=>_i32) (param $this i32) (result i32)
   local.get $this
   i32.load $0 offset=4
  )
- (func $~lib/array/Array<i64>#__uset (type $i32_i32_i64_=>_none) (param $this i32) (param $index i32) (param $value i64)
+ (func $~lib/array/Array<i64>#__set (type $i32_i32_i64_=>_none) (param $this i32) (param $index i32) (param $value i64)
+  local.get $index
+  local.get $this
+  call $~lib/array/Array<i64>#get:length_
+  i32.ge_u
+  if
+   local.get $index
+   i32.const 0
+   i32.lt_s
+   if
+    i32.const 224
+    i32.const 704
+    i32.const 130
+    i32.const 22
+    call $~lib/builtins/abort
+    unreachable
+   end
+   local.get $this
+   local.get $index
+   i32.const 1
+   i32.add
+   i32.const 3
+   i32.const 1
+   call $~lib/array/ensureCapacity
+   local.get $this
+   local.get $index
+   i32.const 1
+   i32.add
+   call $~lib/array/Array<i64>#set:length_
+  end
   local.get $this
   call $~lib/array/Array<i64>#get:dataStart
   local.get $index
@@ -10527,10 +10734,6 @@
   local.get $this
   local.get $entriesCount
   i32.store $0 offset=20
- )
- (func $~lib/array/Array<i64>#get:length_ (type $i32_=>_i32) (param $this i32) (result i32)
-  local.get $this
-  i32.load $0 offset=12
  )
  (func $~lib/array/Array<i64>#get:length (type $i32_=>_i32) (param $this i32) (result i32)
   local.get $this
@@ -11790,11 +11993,44 @@
   local.get $length_
   i32.store $0 offset=12
  )
+ (func $~lib/array/Array<u64>#get:length_ (type $i32_=>_i32) (param $this i32) (result i32)
+  local.get $this
+  i32.load $0 offset=12
+ )
  (func $~lib/array/Array<u64>#get:dataStart (type $i32_=>_i32) (param $this i32) (result i32)
   local.get $this
   i32.load $0 offset=4
  )
- (func $~lib/array/Array<u64>#__uset (type $i32_i32_i64_=>_none) (param $this i32) (param $index i32) (param $value i64)
+ (func $~lib/array/Array<u64>#__set (type $i32_i32_i64_=>_none) (param $this i32) (param $index i32) (param $value i64)
+  local.get $index
+  local.get $this
+  call $~lib/array/Array<u64>#get:length_
+  i32.ge_u
+  if
+   local.get $index
+   i32.const 0
+   i32.lt_s
+   if
+    i32.const 224
+    i32.const 704
+    i32.const 130
+    i32.const 22
+    call $~lib/builtins/abort
+    unreachable
+   end
+   local.get $this
+   local.get $index
+   i32.const 1
+   i32.add
+   i32.const 3
+   i32.const 1
+   call $~lib/array/ensureCapacity
+   local.get $this
+   local.get $index
+   i32.const 1
+   i32.add
+   call $~lib/array/Array<u64>#set:length_
+  end
   local.get $this
   call $~lib/array/Array<u64>#get:dataStart
   local.get $index
@@ -11853,10 +12089,6 @@
   local.get $this
   local.get $entriesCount
   i32.store $0 offset=20
- )
- (func $~lib/array/Array<u64>#get:length_ (type $i32_=>_i32) (param $this i32) (result i32)
-  local.get $this
-  i32.load $0 offset=12
  )
  (func $~lib/array/Array<u64>#get:length (type $i32_=>_i32) (param $this i32) (result i32)
   local.get $this
@@ -13100,11 +13332,44 @@
   local.get $length_
   i32.store $0 offset=12
  )
+ (func $~lib/array/Array<f32>#get:length_ (type $i32_=>_i32) (param $this i32) (result i32)
+  local.get $this
+  i32.load $0 offset=12
+ )
  (func $~lib/array/Array<f32>#get:dataStart (type $i32_=>_i32) (param $this i32) (result i32)
   local.get $this
   i32.load $0 offset=4
  )
- (func $~lib/array/Array<f32>#__uset (type $i32_i32_f32_=>_none) (param $this i32) (param $index i32) (param $value f32)
+ (func $~lib/array/Array<f32>#__set (type $i32_i32_f32_=>_none) (param $this i32) (param $index i32) (param $value f32)
+  local.get $index
+  local.get $this
+  call $~lib/array/Array<f32>#get:length_
+  i32.ge_u
+  if
+   local.get $index
+   i32.const 0
+   i32.lt_s
+   if
+    i32.const 224
+    i32.const 704
+    i32.const 130
+    i32.const 22
+    call $~lib/builtins/abort
+    unreachable
+   end
+   local.get $this
+   local.get $index
+   i32.const 1
+   i32.add
+   i32.const 2
+   i32.const 1
+   call $~lib/array/ensureCapacity
+   local.get $this
+   local.get $index
+   i32.const 1
+   i32.add
+   call $~lib/array/Array<f32>#set:length_
+  end
   local.get $this
   call $~lib/array/Array<f32>#get:dataStart
   local.get $index
@@ -13163,10 +13428,6 @@
   local.get $this
   local.get $entriesCount
   i32.store $0 offset=20
- )
- (func $~lib/array/Array<f32>#get:length_ (type $i32_=>_i32) (param $this i32) (result i32)
-  local.get $this
-  i32.load $0 offset=12
  )
  (func $~lib/array/Array<f32>#get:length (type $i32_=>_i32) (param $this i32) (result i32)
   local.get $this
@@ -14427,11 +14688,44 @@
   local.get $length_
   i32.store $0 offset=12
  )
+ (func $~lib/array/Array<f64>#get:length_ (type $i32_=>_i32) (param $this i32) (result i32)
+  local.get $this
+  i32.load $0 offset=12
+ )
  (func $~lib/array/Array<f64>#get:dataStart (type $i32_=>_i32) (param $this i32) (result i32)
   local.get $this
   i32.load $0 offset=4
  )
- (func $~lib/array/Array<f64>#__uset (type $i32_i32_f64_=>_none) (param $this i32) (param $index i32) (param $value f64)
+ (func $~lib/array/Array<f64>#__set (type $i32_i32_f64_=>_none) (param $this i32) (param $index i32) (param $value f64)
+  local.get $index
+  local.get $this
+  call $~lib/array/Array<f64>#get:length_
+  i32.ge_u
+  if
+   local.get $index
+   i32.const 0
+   i32.lt_s
+   if
+    i32.const 224
+    i32.const 704
+    i32.const 130
+    i32.const 22
+    call $~lib/builtins/abort
+    unreachable
+   end
+   local.get $this
+   local.get $index
+   i32.const 1
+   i32.add
+   i32.const 3
+   i32.const 1
+   call $~lib/array/ensureCapacity
+   local.get $this
+   local.get $index
+   i32.const 1
+   i32.add
+   call $~lib/array/Array<f64>#set:length_
+  end
   local.get $this
   call $~lib/array/Array<f64>#get:dataStart
   local.get $index
@@ -14490,10 +14784,6 @@
   local.get $this
   local.get $entriesCount
   i32.store $0 offset=20
- )
- (func $~lib/array/Array<f64>#get:length_ (type $i32_=>_i32) (param $this i32) (result i32)
-  local.get $this
-  i32.load $0 offset=12
  )
  (func $~lib/array/Array<f64>#get:length (type $i32_=>_i32) (param $this i32) (result i32)
   local.get $this
@@ -18471,7 +18761,7 @@
      local.get $7
      local.get $entry
      call $~lib/map/MapEntry<i8,i32>#get:key
-     call $~lib/array/Array<i8>#__uset
+     call $~lib/array/Array<i8>#__set
     end
     local.get $i
     i32.const 1
@@ -18644,7 +18934,7 @@
      local.get $7
      local.get $entry
      call $~lib/map/MapEntry<i8,i32>#get:value
-     call $~lib/array/Array<i32>#__uset
+     call $~lib/array/Array<i32>#__set
     end
     local.get $i
     i32.const 1
@@ -19189,7 +19479,7 @@
      local.get $7
      local.get $entry
      call $~lib/map/MapEntry<u8,i32>#get:key
-     call $~lib/array/Array<u8>#__uset
+     call $~lib/array/Array<u8>#__set
     end
     local.get $i
     i32.const 1
@@ -19272,7 +19562,7 @@
      local.get $7
      local.get $entry
      call $~lib/map/MapEntry<u8,i32>#get:value
-     call $~lib/array/Array<i32>#__uset
+     call $~lib/array/Array<i32>#__set
     end
     local.get $i
     i32.const 1
@@ -19693,7 +19983,7 @@
      local.get $7
      local.get $entry
      call $~lib/map/MapEntry<i16,i32>#get:key
-     call $~lib/array/Array<i16>#__uset
+     call $~lib/array/Array<i16>#__set
     end
     local.get $i
     i32.const 1
@@ -19776,7 +20066,7 @@
      local.get $7
      local.get $entry
      call $~lib/map/MapEntry<i16,i32>#get:value
-     call $~lib/array/Array<i32>#__uset
+     call $~lib/array/Array<i32>#__set
     end
     local.get $i
     i32.const 1
@@ -20197,7 +20487,7 @@
      local.get $7
      local.get $entry
      call $~lib/map/MapEntry<u16,i32>#get:key
-     call $~lib/array/Array<u16>#__uset
+     call $~lib/array/Array<u16>#__set
     end
     local.get $i
     i32.const 1
@@ -20280,7 +20570,7 @@
      local.get $7
      local.get $entry
      call $~lib/map/MapEntry<u16,i32>#get:value
-     call $~lib/array/Array<i32>#__uset
+     call $~lib/array/Array<i32>#__set
     end
     local.get $i
     i32.const 1
@@ -20487,7 +20777,7 @@
      local.get $7
      local.get $entry
      call $~lib/map/MapEntry<i32,i32>#get:key
-     call $~lib/array/Array<i32>#__uset
+     call $~lib/array/Array<i32>#__set
     end
     local.get $i
     i32.const 1
@@ -20570,7 +20860,7 @@
      local.get $7
      local.get $entry
      call $~lib/map/MapEntry<i32,i32>#get:value
-     call $~lib/array/Array<i32>#__uset
+     call $~lib/array/Array<i32>#__set
     end
     local.get $i
     i32.const 1
@@ -20867,7 +21157,7 @@
      local.get $7
      local.get $entry
      call $~lib/map/MapEntry<u32,i32>#get:key
-     call $~lib/array/Array<u32>#__uset
+     call $~lib/array/Array<u32>#__set
     end
     local.get $i
     i32.const 1
@@ -20950,7 +21240,7 @@
      local.get $7
      local.get $entry
      call $~lib/map/MapEntry<u32,i32>#get:value
-     call $~lib/array/Array<i32>#__uset
+     call $~lib/array/Array<i32>#__set
     end
     local.get $i
     i32.const 1
@@ -21371,7 +21661,7 @@
      local.get $7
      local.get $entry
      call $~lib/map/MapEntry<i64,i32>#get:key
-     call $~lib/array/Array<i64>#__uset
+     call $~lib/array/Array<i64>#__set
     end
     local.get $i
     i32.const 1
@@ -21454,7 +21744,7 @@
      local.get $7
      local.get $entry
      call $~lib/map/MapEntry<i64,i32>#get:value
-     call $~lib/array/Array<i32>#__uset
+     call $~lib/array/Array<i32>#__set
     end
     local.get $i
     i32.const 1
@@ -21875,7 +22165,7 @@
      local.get $7
      local.get $entry
      call $~lib/map/MapEntry<u64,i32>#get:key
-     call $~lib/array/Array<u64>#__uset
+     call $~lib/array/Array<u64>#__set
     end
     local.get $i
     i32.const 1
@@ -21958,7 +22248,7 @@
      local.get $7
      local.get $entry
      call $~lib/map/MapEntry<u64,i32>#get:value
-     call $~lib/array/Array<i32>#__uset
+     call $~lib/array/Array<i32>#__set
     end
     local.get $i
     i32.const 1
@@ -22379,7 +22669,7 @@
      local.get $7
      local.get $entry
      call $~lib/map/MapEntry<f32,i32>#get:key
-     call $~lib/array/Array<f32>#__uset
+     call $~lib/array/Array<f32>#__set
     end
     local.get $i
     i32.const 1
@@ -22462,7 +22752,7 @@
      local.get $7
      local.get $entry
      call $~lib/map/MapEntry<f32,i32>#get:value
-     call $~lib/array/Array<i32>#__uset
+     call $~lib/array/Array<i32>#__set
     end
     local.get $i
     i32.const 1
@@ -22883,7 +23173,7 @@
      local.get $7
      local.get $entry
      call $~lib/map/MapEntry<f64,i32>#get:key
-     call $~lib/array/Array<f64>#__uset
+     call $~lib/array/Array<f64>#__set
     end
     local.get $i
     i32.const 1
@@ -22966,7 +23256,7 @@
      local.get $7
      local.get $entry
      call $~lib/map/MapEntry<f64,i32>#get:value
-     call $~lib/array/Array<i32>#__uset
+     call $~lib/array/Array<i32>#__set
     end
     local.get $i
     i32.const 1

--- a/tests/compiler/std/map.release.wat
+++ b/tests/compiler/std/map.release.wat
@@ -1,15 +1,16 @@
 (module
  (type $i32_i32_=>_none (func_subtype (param i32 i32) func))
  (type $none_=>_none (func_subtype func))
- (type $i32_i32_=>_i32 (func_subtype (param i32 i32) (result i32) func))
  (type $i32_i32_i32_=>_none (func_subtype (param i32 i32 i32) func))
+ (type $i32_i32_=>_i32 (func_subtype (param i32 i32) (result i32) func))
  (type $i32_=>_none (func_subtype (param i32) func))
  (type $i32_=>_i32 (func_subtype (param i32) (result i32) func))
+ (type $i32_i32_i32_i32_=>_none (func_subtype (param i32 i32 i32 i32) func))
  (type $none_=>_i32 (func_subtype (result i32) func))
  (type $i32_i64_=>_i32 (func_subtype (param i32 i64) (result i32) func))
  (type $i32_i64_=>_none (func_subtype (param i32 i64) func))
  (type $i32_i64_i32_=>_none (func_subtype (param i32 i64 i32) func))
- (type $i32_i32_i32_i32_=>_none (func_subtype (param i32 i32 i32 i32) func))
+ (type $i32_i32_i64_=>_none (func_subtype (param i32 i32 i64) func))
  (type $i32_f32_=>_i32 (func_subtype (param i32 f32) (result i32) func))
  (type $i32_f32_=>_none (func_subtype (param i32 f32) func))
  (type $i32_f64_=>_i32 (func_subtype (param i32 f64) (result i32) func))
@@ -1775,12 +1776,13 @@
   local.get $0
   i32.load $0 offset=4
  )
- (func $~lib/array/ensureCapacity (type $i32_i32_i32_=>_none) (param $0 i32) (param $1 i32) (param $2 i32)
-  (local $3 i32)
+ (func $~lib/array/ensureCapacity (type $i32_i32_i32_i32_=>_none) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32)
   (local $4 i32)
+  (local $5 i32)
   local.get $1
   local.get $0
   i32.load $0 offset=8
+  local.tee $5
   local.get $2
   i32.shr_u
   i32.gt_u
@@ -1798,73 +1800,170 @@
     call $~lib/builtins/abort
     unreachable
    end
-   block $__inlined_func$~lib/rt/itcms/__renew
-    i32.const 8
-    local.get $1
-    local.get $1
-    i32.const 8
-    i32.le_u
-    select
-    local.get $2
+   local.get $0
+   i32.load $0
+   local.set $4
+   i32.const 8
+   local.get $1
+   local.get $1
+   i32.const 8
+   i32.le_u
+   select
+   local.get $2
+   i32.shl
+   local.set $1
+   local.get $3
+   if
+    i32.const 1073741820
+    local.get $5
+    i32.const 1
     i32.shl
-    local.tee $3
-    local.get $0
-    i32.load $0
     local.tee $2
+    local.get $2
+    i32.const 1073741820
+    i32.ge_u
+    select
+    local.tee $2
+    local.get $1
+    local.get $1
+    local.get $2
+    i32.lt_u
+    select
+    local.set $1
+   end
+   block $__inlined_func$~lib/rt/itcms/__renew
+    local.get $4
     i32.const 20
     i32.sub
-    local.tee $4
+    local.tee $3
     i32.load $0
     i32.const -4
     i32.and
     i32.const 16
     i32.sub
-    i32.le_u
+    local.get $1
+    i32.ge_u
     if
-     local.get $4
      local.get $3
+     local.get $1
      i32.store $0 offset=16
-     local.get $2
-     local.set $1
+     local.get $4
+     local.set $2
      br $__inlined_func$~lib/rt/itcms/__renew
     end
+    local.get $1
     local.get $3
-    local.get $4
     i32.load $0 offset=12
     call $~lib/rt/itcms/__new
-    local.tee $1
-    local.get $2
-    local.get $3
+    local.tee $2
     local.get $4
+    local.get $1
+    local.get $3
     i32.load $0 offset=16
-    local.tee $4
+    local.tee $3
+    local.get $1
     local.get $3
-    local.get $4
     i32.lt_u
     select
     memory.copy $0 $0
    end
-   local.get $1
    local.get $2
+   local.get $4
    i32.ne
    if
     local.get $0
-    local.get $1
+    local.get $2
     i32.store $0
     local.get $0
-    local.get $1
+    local.get $2
     i32.store $0 offset=4
-    local.get $1
+    local.get $2
     if
      local.get $0
-     local.get $1
+     local.get $2
      call $byn-split-outlined-A$~lib/rt/itcms/__link
     end
    end
    local.get $0
-   local.get $3
+   local.get $1
    i32.store $0 offset=8
   end
+ )
+ (func $~lib/array/Array<i8>#__set (type $i32_i32_i32_=>_none) (param $0 i32) (param $1 i32) (param $2 i32)
+  (local $3 i32)
+  local.get $1
+  local.get $0
+  i32.load $0 offset=12
+  i32.ge_u
+  if
+   local.get $1
+   i32.const 0
+   i32.lt_s
+   if
+    i32.const 1248
+    i32.const 1728
+    i32.const 130
+    i32.const 22
+    call $~lib/builtins/abort
+    unreachable
+   end
+   local.get $0
+   local.get $1
+   i32.const 1
+   i32.add
+   local.tee $3
+   i32.const 0
+   i32.const 1
+   call $~lib/array/ensureCapacity
+   local.get $0
+   local.get $3
+   i32.store $0 offset=12
+  end
+  local.get $0
+  i32.load $0 offset=4
+  local.get $1
+  i32.add
+  local.get $2
+  i32.store8 $0
+ )
+ (func $~lib/array/Array<i32>#__set (type $i32_i32_i32_=>_none) (param $0 i32) (param $1 i32) (param $2 i32)
+  (local $3 i32)
+  local.get $1
+  local.get $0
+  i32.load $0 offset=12
+  i32.ge_u
+  if
+   local.get $1
+   i32.const 0
+   i32.lt_s
+   if
+    i32.const 1248
+    i32.const 1728
+    i32.const 130
+    i32.const 22
+    call $~lib/builtins/abort
+    unreachable
+   end
+   local.get $0
+   local.get $1
+   i32.const 1
+   i32.add
+   local.tee $3
+   i32.const 2
+   i32.const 1
+   call $~lib/array/ensureCapacity
+   local.get $0
+   local.get $3
+   i32.store $0 offset=12
+  end
+  local.get $0
+  i32.load $0 offset=4
+  local.get $1
+  i32.const 2
+  i32.shl
+  i32.add
+  local.get $2
+  i32.store $0
  )
  (func $~lib/array/Array<i32>#__get (type $i32_i32_=>_i32) (param $0 i32) (param $1 i32) (result i32)
   local.get $1
@@ -2814,13 +2913,11 @@
      i32.and
      i32.eqz
      if
-      local.get $0
       local.get $2
-      i32.load $0 offset=4
-      i32.add
+      local.get $0
       local.get $6
       i32.load8_s $0
-      i32.store8 $0
+      call $~lib/array/Array<i8>#__set
       local.get $0
       i32.const 1
       i32.add
@@ -2835,6 +2932,7 @@
    end
    local.get $2
    local.get $0
+   i32.const 0
    i32.const 0
    call $~lib/array/ensureCapacity
    local.get $2
@@ -4983,13 +5081,11 @@
      i32.and
      i32.eqz
      if
-      local.get $0
       local.get $2
-      i32.load $0 offset=4
-      i32.add
+      local.get $0
       local.get $6
       i32.load8_u $0
-      i32.store8 $0
+      call $~lib/array/Array<i8>#__set
       local.get $0
       i32.const 1
       i32.add
@@ -5004,6 +5100,7 @@
    end
    local.get $2
    local.get $0
+   i32.const 0
    i32.const 0
    call $~lib/array/ensureCapacity
    local.get $2
@@ -6385,6 +6482,45 @@
   local.get $0
   i32.load $0 offset=4
  )
+ (func $~lib/array/Array<i16>#__set (type $i32_i32_i32_=>_none) (param $0 i32) (param $1 i32) (param $2 i32)
+  (local $3 i32)
+  local.get $1
+  local.get $0
+  i32.load $0 offset=12
+  i32.ge_u
+  if
+   local.get $1
+   i32.const 0
+   i32.lt_s
+   if
+    i32.const 1248
+    i32.const 1728
+    i32.const 130
+    i32.const 22
+    call $~lib/builtins/abort
+    unreachable
+   end
+   local.get $0
+   local.get $1
+   i32.const 1
+   i32.add
+   local.tee $3
+   i32.const 1
+   i32.const 1
+   call $~lib/array/ensureCapacity
+   local.get $0
+   local.get $3
+   i32.store $0 offset=12
+  end
+  local.get $0
+  i32.load $0 offset=4
+  local.get $1
+  i32.const 1
+  i32.shl
+  i32.add
+  local.get $2
+  i32.store16 $0
+ )
  (func $~lib/map/Map<i16,i32>#delete (type $i32_i32_=>_none) (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -7149,14 +7285,10 @@
      i32.eqz
      if
       local.get $2
-      i32.load $0 offset=4
       local.get $0
-      i32.const 1
-      i32.shl
-      i32.add
       local.get $6
       i32.load16_s $0
-      i32.store16 $0
+      call $~lib/array/Array<i16>#__set
       local.get $0
       i32.const 1
       i32.add
@@ -7172,6 +7304,7 @@
    local.get $2
    local.get $0
    i32.const 1
+   i32.const 0
    call $~lib/array/ensureCapacity
    local.get $2
    local.get $0
@@ -9324,14 +9457,10 @@
      i32.eqz
      if
       local.get $2
-      i32.load $0 offset=4
       local.get $0
-      i32.const 1
-      i32.shl
-      i32.add
       local.get $6
       i32.load16_u $0
-      i32.store16 $0
+      call $~lib/array/Array<i16>#__set
       local.get $0
       i32.const 1
       i32.add
@@ -9347,6 +9476,7 @@
    local.get $2
    local.get $0
    i32.const 1
+   i32.const 0
    call $~lib/array/ensureCapacity
    local.get $2
    local.get $0
@@ -11163,14 +11293,10 @@
      i32.eqz
      if
       local.get $6
-      i32.load $0 offset=4
       local.get $0
-      i32.const 2
-      i32.shl
-      i32.add
       local.get $7
       i32.load $0
-      i32.store $0
+      call $~lib/array/Array<i32>#__set
       local.get $0
       i32.const 1
       i32.add
@@ -11186,6 +11312,7 @@
    local.get $6
    local.get $0
    i32.const 2
+   i32.const 0
    call $~lib/array/ensureCapacity
    local.get $6
    local.get $0
@@ -12900,14 +13027,10 @@
      i32.eqz
      if
       local.get $2
-      i32.load $0 offset=4
       local.get $0
-      i32.const 2
-      i32.shl
-      i32.add
       local.get $6
       i32.load $0
-      i32.store $0
+      call $~lib/array/Array<i32>#__set
       local.get $0
       i32.const 1
       i32.add
@@ -12923,6 +13046,7 @@
    local.get $2
    local.get $0
    i32.const 2
+   i32.const 0
    call $~lib/array/ensureCapacity
    local.get $2
    local.get $0
@@ -14302,6 +14426,45 @@
   local.get $0
   i32.load $0 offset=8
  )
+ (func $~lib/array/Array<i64>#__set (type $i32_i32_i64_=>_none) (param $0 i32) (param $1 i32) (param $2 i64)
+  (local $3 i32)
+  local.get $1
+  local.get $0
+  i32.load $0 offset=12
+  i32.ge_u
+  if
+   local.get $1
+   i32.const 0
+   i32.lt_s
+   if
+    i32.const 1248
+    i32.const 1728
+    i32.const 130
+    i32.const 22
+    call $~lib/builtins/abort
+    unreachable
+   end
+   local.get $0
+   local.get $1
+   i32.const 1
+   i32.add
+   local.tee $3
+   i32.const 3
+   i32.const 1
+   call $~lib/array/ensureCapacity
+   local.get $0
+   local.get $3
+   i32.store $0 offset=12
+  end
+  local.get $0
+  i32.load $0 offset=4
+  local.get $1
+  i32.const 3
+  i32.shl
+  i32.add
+  local.get $2
+  i64.store $0
+ )
  (func $~lib/map/Map<i64,i32>#delete (type $i32_i64_=>_none) (param $0 i32) (param $1 i64)
   (local $2 i32)
   (local $3 i32)
@@ -15116,14 +15279,10 @@
      i32.eqz
      if
       local.get $2
-      i32.load $0 offset=4
       local.get $0
-      i32.const 3
-      i32.shl
-      i32.add
       local.get $1
       i64.load $0
-      i64.store $0
+      call $~lib/array/Array<i64>#__set
       local.get $0
       i32.const 1
       i32.add
@@ -15139,6 +15298,7 @@
    local.get $2
    local.get $0
    i32.const 3
+   i32.const 0
    call $~lib/array/ensureCapacity
    local.get $2
    local.get $0
@@ -15308,8 +15468,8 @@
      i32.add
      i32.load $0
      local.set $0
-     block $__inlined_func$~lib/map/Map<i64,i32>#find38
-      loop $while-continue|042
+     block $__inlined_func$~lib/map/Map<i64,i32>#find37
+      loop $while-continue|041
        local.get $0
        if
         local.get $0
@@ -15325,12 +15485,12 @@
          i64.load $0
          i64.eq
         end
-        br_if $__inlined_func$~lib/map/Map<i64,i32>#find38
+        br_if $__inlined_func$~lib/map/Map<i64,i32>#find37
         local.get $1
         i32.const -2
         i32.and
         local.set $0
-        br $while-continue|042
+        br $while-continue|041
        end
       end
       i32.const 0
@@ -15400,8 +15560,8 @@
      i32.add
      i32.load $0
      local.set $0
-     block $__inlined_func$~lib/map/Map<i64,i32>#find45
-      loop $while-continue|049
+     block $__inlined_func$~lib/map/Map<i64,i32>#find44
+      loop $while-continue|048
        local.get $0
        if
         local.get $0
@@ -15417,12 +15577,12 @@
          i64.load $0
          i64.eq
         end
-        br_if $__inlined_func$~lib/map/Map<i64,i32>#find45
+        br_if $__inlined_func$~lib/map/Map<i64,i32>#find44
         local.get $1
         i32.const -2
         i32.and
         local.set $0
-        br $while-continue|049
+        br $while-continue|048
        end
       end
       i32.const 0
@@ -15501,7 +15661,7 @@
      i32.load $0
      local.set $0
      block $__inlined_func$~lib/map/Map<i64,i64>#find
-      loop $while-continue|056
+      loop $while-continue|055
        local.get $0
        if
         local.get $0
@@ -15522,7 +15682,7 @@
         i32.const -2
         i32.and
         local.set $0
-        br $while-continue|056
+        br $while-continue|055
        end
       end
       i32.const 0
@@ -15869,8 +16029,8 @@
      i32.add
      i32.load $0
      local.set $0
-     block $__inlined_func$~lib/map/Map<i64,i32>#find77
-      loop $while-continue|081
+     block $__inlined_func$~lib/map/Map<i64,i32>#find76
+      loop $while-continue|080
        local.get $0
        if
         local.get $0
@@ -15886,12 +16046,12 @@
          i64.load $0
          i64.eq
         end
-        br_if $__inlined_func$~lib/map/Map<i64,i32>#find77
+        br_if $__inlined_func$~lib/map/Map<i64,i32>#find76
         local.get $1
         i32.const -2
         i32.and
         local.set $0
-        br $while-continue|081
+        br $while-continue|080
        end
       end
       i32.const 0
@@ -15976,8 +16136,8 @@
      i32.add
      i32.load $0
      local.set $0
-     block $__inlined_func$~lib/map/Map<i64,i32>#find84
-      loop $while-continue|088
+     block $__inlined_func$~lib/map/Map<i64,i32>#find83
+      loop $while-continue|087
        local.get $0
        if
         local.get $0
@@ -15993,12 +16153,12 @@
          i64.load $0
          i64.eq
         end
-        br_if $__inlined_func$~lib/map/Map<i64,i32>#find84
+        br_if $__inlined_func$~lib/map/Map<i64,i32>#find83
         local.get $1
         i32.const -2
         i32.and
         local.set $0
-        br $while-continue|088
+        br $while-continue|087
        end
       end
       i32.const 0
@@ -16089,8 +16249,8 @@
      i32.add
      i32.load $0
      local.set $0
-     block $__inlined_func$~lib/map/Map<i64,i32>#find93
-      loop $while-continue|097
+     block $__inlined_func$~lib/map/Map<i64,i32>#find92
+      loop $while-continue|096
        local.get $0
        if
         local.get $0
@@ -16106,12 +16266,12 @@
          i64.load $0
          i64.eq
         end
-        br_if $__inlined_func$~lib/map/Map<i64,i32>#find93
+        br_if $__inlined_func$~lib/map/Map<i64,i32>#find92
         local.get $1
         i32.const -2
         i32.and
         local.set $0
-        br $while-continue|097
+        br $while-continue|096
        end
       end
       i32.const 0
@@ -16183,8 +16343,8 @@
      i32.add
      i32.load $0
      local.set $0
-     block $__inlined_func$~lib/map/Map<i64,i32>#find100
-      loop $while-continue|0104
+     block $__inlined_func$~lib/map/Map<i64,i32>#find99
+      loop $while-continue|0103
        local.get $0
        if
         local.get $0
@@ -16200,12 +16360,12 @@
          i64.load $0
          i64.eq
         end
-        br_if $__inlined_func$~lib/map/Map<i64,i32>#find100
+        br_if $__inlined_func$~lib/map/Map<i64,i32>#find99
         local.get $1
         i32.const -2
         i32.and
         local.set $0
-        br $while-continue|0104
+        br $while-continue|0103
        end
       end
       i32.const 0
@@ -16274,8 +16434,8 @@
      i32.add
      i32.load $0
      local.set $0
-     block $__inlined_func$~lib/map/Map<i64,i32>#find107
-      loop $while-continue|0111
+     block $__inlined_func$~lib/map/Map<i64,i32>#find106
+      loop $while-continue|0110
        local.get $0
        if
         local.get $0
@@ -16291,12 +16451,12 @@
          i64.load $0
          i64.eq
         end
-        br_if $__inlined_func$~lib/map/Map<i64,i32>#find107
+        br_if $__inlined_func$~lib/map/Map<i64,i32>#find106
         local.get $1
         i32.const -2
         i32.and
         local.set $0
-        br $while-continue|0111
+        br $while-continue|0110
        end
       end
       i32.const 0
@@ -17441,14 +17601,10 @@
      i32.eqz
      if
       local.get $2
-      i32.load $0 offset=4
       local.get $0
-      i32.const 3
-      i32.shl
-      i32.add
       local.get $1
       i64.load $0
-      i64.store $0
+      call $~lib/array/Array<i64>#__set
       local.get $0
       i32.const 1
       i32.add
@@ -17464,6 +17620,7 @@
    local.get $2
    local.get $0
    i32.const 3
+   i32.const 0
    call $~lib/array/ensureCapacity
    local.get $2
    local.get $0
@@ -17633,8 +17790,8 @@
      i32.add
      i32.load $0
      local.set $0
-     block $__inlined_func$~lib/map/Map<u64,i32>#find38
-      loop $while-continue|042
+     block $__inlined_func$~lib/map/Map<u64,i32>#find37
+      loop $while-continue|041
        local.get $0
        if
         local.get $0
@@ -17650,12 +17807,12 @@
          i64.load $0
          i64.eq
         end
-        br_if $__inlined_func$~lib/map/Map<u64,i32>#find38
+        br_if $__inlined_func$~lib/map/Map<u64,i32>#find37
         local.get $1
         i32.const -2
         i32.and
         local.set $0
-        br $while-continue|042
+        br $while-continue|041
        end
       end
       i32.const 0
@@ -17725,8 +17882,8 @@
      i32.add
      i32.load $0
      local.set $0
-     block $__inlined_func$~lib/map/Map<u64,i32>#find45
-      loop $while-continue|049
+     block $__inlined_func$~lib/map/Map<u64,i32>#find44
+      loop $while-continue|048
        local.get $0
        if
         local.get $0
@@ -17742,12 +17899,12 @@
          i64.load $0
          i64.eq
         end
-        br_if $__inlined_func$~lib/map/Map<u64,i32>#find45
+        br_if $__inlined_func$~lib/map/Map<u64,i32>#find44
         local.get $1
         i32.const -2
         i32.and
         local.set $0
-        br $while-continue|049
+        br $while-continue|048
        end
       end
       i32.const 0
@@ -17826,7 +17983,7 @@
      i32.load $0
      local.set $0
      block $__inlined_func$~lib/map/Map<u64,u64>#find
-      loop $while-continue|056
+      loop $while-continue|055
        local.get $0
        if
         local.get $0
@@ -17847,7 +18004,7 @@
         i32.const -2
         i32.and
         local.set $0
-        br $while-continue|056
+        br $while-continue|055
        end
       end
       i32.const 0
@@ -18194,8 +18351,8 @@
      i32.add
      i32.load $0
      local.set $0
-     block $__inlined_func$~lib/map/Map<u64,i32>#find77
-      loop $while-continue|081
+     block $__inlined_func$~lib/map/Map<u64,i32>#find76
+      loop $while-continue|080
        local.get $0
        if
         local.get $0
@@ -18211,12 +18368,12 @@
          i64.load $0
          i64.eq
         end
-        br_if $__inlined_func$~lib/map/Map<u64,i32>#find77
+        br_if $__inlined_func$~lib/map/Map<u64,i32>#find76
         local.get $1
         i32.const -2
         i32.and
         local.set $0
-        br $while-continue|081
+        br $while-continue|080
        end
       end
       i32.const 0
@@ -18301,8 +18458,8 @@
      i32.add
      i32.load $0
      local.set $0
-     block $__inlined_func$~lib/map/Map<u64,i32>#find84
-      loop $while-continue|088
+     block $__inlined_func$~lib/map/Map<u64,i32>#find83
+      loop $while-continue|087
        local.get $0
        if
         local.get $0
@@ -18318,12 +18475,12 @@
          i64.load $0
          i64.eq
         end
-        br_if $__inlined_func$~lib/map/Map<u64,i32>#find84
+        br_if $__inlined_func$~lib/map/Map<u64,i32>#find83
         local.get $1
         i32.const -2
         i32.and
         local.set $0
-        br $while-continue|088
+        br $while-continue|087
        end
       end
       i32.const 0
@@ -18414,8 +18571,8 @@
      i32.add
      i32.load $0
      local.set $0
-     block $__inlined_func$~lib/map/Map<u64,i32>#find93
-      loop $while-continue|097
+     block $__inlined_func$~lib/map/Map<u64,i32>#find92
+      loop $while-continue|096
        local.get $0
        if
         local.get $0
@@ -18431,12 +18588,12 @@
          i64.load $0
          i64.eq
         end
-        br_if $__inlined_func$~lib/map/Map<u64,i32>#find93
+        br_if $__inlined_func$~lib/map/Map<u64,i32>#find92
         local.get $1
         i32.const -2
         i32.and
         local.set $0
-        br $while-continue|097
+        br $while-continue|096
        end
       end
       i32.const 0
@@ -18508,8 +18665,8 @@
      i32.add
      i32.load $0
      local.set $0
-     block $__inlined_func$~lib/map/Map<u64,i32>#find100
-      loop $while-continue|0104
+     block $__inlined_func$~lib/map/Map<u64,i32>#find99
+      loop $while-continue|0103
        local.get $0
        if
         local.get $0
@@ -18525,12 +18682,12 @@
          i64.load $0
          i64.eq
         end
-        br_if $__inlined_func$~lib/map/Map<u64,i32>#find100
+        br_if $__inlined_func$~lib/map/Map<u64,i32>#find99
         local.get $1
         i32.const -2
         i32.and
         local.set $0
-        br $while-continue|0104
+        br $while-continue|0103
        end
       end
       i32.const 0
@@ -18599,8 +18756,8 @@
      i32.add
      i32.load $0
      local.set $0
-     block $__inlined_func$~lib/map/Map<u64,i32>#find107
-      loop $while-continue|0111
+     block $__inlined_func$~lib/map/Map<u64,i32>#find106
+      loop $while-continue|0110
        local.get $0
        if
         local.get $0
@@ -18616,12 +18773,12 @@
          i64.load $0
          i64.eq
         end
-        br_if $__inlined_func$~lib/map/Map<u64,i32>#find107
+        br_if $__inlined_func$~lib/map/Map<u64,i32>#find106
         local.get $1
         i32.const -2
         i32.and
         local.set $0
-        br $while-continue|0111
+        br $while-continue|0110
        end
       end
       i32.const 0
@@ -19056,19 +19213,19 @@
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
-  (local $3 i32)
-  (local $4 f32)
+  (local $3 f32)
+  (local $4 i32)
   (local $5 i32)
   (local $6 i32)
   (local $7 i32)
-  (local $8 f32)
+  (local $8 i32)
   (local $9 i32)
   (local $10 i32)
   (local $11 i32)
   (local $12 i32)
   (local $13 i32)
   (local $14 i32)
-  (local $15 i32)
+  (local $15 f32)
   (local $16 i32)
   (local $17 i32)
   global.get $~lib/memory/__stack_pointer
@@ -19094,55 +19251,55 @@
    i32.lt_s
    br_if $folding-inner1
    global.get $~lib/memory/__stack_pointer
-   local.tee $0
+   local.tee $4
    i64.const 0
    i64.store $0
-   local.get $0
+   local.get $4
    i32.const 24
    i32.const 27
    call $~lib/rt/itcms/__new
-   local.tee $11
+   local.tee $10
    i32.store $0
    i32.const 16
    call $~lib/arraybuffer/ArrayBuffer#constructor
-   local.set $0
+   local.set $4
    global.get $~lib/memory/__stack_pointer
-   local.get $0
+   local.get $4
    i32.store $0 offset=4
-   local.get $11
-   local.get $0
+   local.get $10
+   local.get $4
    i32.store $0
-   local.get $0
+   local.get $4
    if
-    local.get $11
-    local.get $0
+    local.get $10
+    local.get $4
     call $byn-split-outlined-A$~lib/rt/itcms/__link
    end
-   local.get $11
+   local.get $10
    i32.const 3
    i32.store $0 offset=4
    i32.const 48
    call $~lib/arraybuffer/ArrayBuffer#constructor
-   local.set $0
+   local.set $4
    global.get $~lib/memory/__stack_pointer
-   local.get $0
+   local.get $4
    i32.store $0 offset=4
-   local.get $11
-   local.get $0
+   local.get $10
+   local.get $4
    i32.store $0 offset=8
-   local.get $0
+   local.get $4
    if
-    local.get $11
-    local.get $0
+    local.get $10
+    local.get $4
     call $byn-split-outlined-A$~lib/rt/itcms/__link
    end
-   local.get $11
+   local.get $10
    i32.const 4
    i32.store $0 offset=12
-   local.get $11
+   local.get $10
    i32.const 0
    i32.store $0 offset=16
-   local.get $11
+   local.get $10
    i32.const 0
    i32.store $0 offset=20
    global.get $~lib/memory/__stack_pointer
@@ -19150,18 +19307,18 @@
    i32.add
    global.set $~lib/memory/__stack_pointer
    local.get $2
-   local.get $11
+   local.get $10
    i32.store $0
    loop $for-loop|0
-    local.get $4
+    local.get $3
     f32.const 100
     f32.lt
     if
-     local.get $11
+     local.get $10
      i32.load $0
-     local.get $11
+     local.get $10
      i32.load $0 offset=4
-     local.get $4
+     local.get $3
      i32.reinterpret_f32
      i32.const -1028477379
      i32.mul
@@ -19171,22 +19328,22 @@
      i32.rotl
      i32.const 668265263
      i32.mul
-     local.tee $0
-     local.get $0
+     local.tee $2
+     local.get $2
      i32.const 15
      i32.shr_u
      i32.xor
      i32.const -2048144777
      i32.mul
-     local.tee $0
-     local.get $0
+     local.tee $2
+     local.get $2
      i32.const 13
      i32.shr_u
      i32.xor
      i32.const -1028477379
      i32.mul
-     local.tee $0
-     local.get $0
+     local.tee $2
+     local.get $2
      i32.const 16
      i32.shr_u
      i32.xor
@@ -19195,36 +19352,36 @@
      i32.shl
      i32.add
      i32.load $0
-     local.set $0
+     local.set $2
      block $__inlined_func$~lib/map/Map<f32,i32>#find
       loop $while-continue|0
-       local.get $0
+       local.get $2
        if
-        local.get $0
+        local.get $2
         i32.load $0 offset=8
-        local.tee $2
+        local.tee $4
         i32.const 1
         i32.and
         if (result i32)
          i32.const 0
         else
-         local.get $0
+         local.get $2
          f32.load $0
-         local.get $4
+         local.get $3
          f32.eq
         end
         br_if $__inlined_func$~lib/map/Map<f32,i32>#find
-        local.get $2
+        local.get $4
         i32.const -2
         i32.and
-        local.set $0
+        local.set $2
         br $while-continue|0
        end
       end
       i32.const 0
-      local.set $0
+      local.set $2
      end
-     local.get $0
+     local.get $2
      if
       i32.const 0
       i32.const 1568
@@ -19233,18 +19390,18 @@
       call $~lib/builtins/abort
       unreachable
      end
-     local.get $11
-     local.get $4
-     local.get $4
+     local.get $10
+     local.get $3
+     local.get $3
      i32.trunc_sat_f32_s
      i32.const 10
      i32.add
      call $~lib/map/Map<f32,i32>#set
-     local.get $11
+     local.get $10
      i32.load $0
-     local.get $11
+     local.get $10
      i32.load $0 offset=4
-     local.get $4
+     local.get $3
      i32.reinterpret_f32
      i32.const -1028477379
      i32.mul
@@ -19254,22 +19411,22 @@
      i32.rotl
      i32.const 668265263
      i32.mul
-     local.tee $0
-     local.get $0
+     local.tee $2
+     local.get $2
      i32.const 15
      i32.shr_u
      i32.xor
      i32.const -2048144777
      i32.mul
-     local.tee $0
-     local.get $0
+     local.tee $2
+     local.get $2
      i32.const 13
      i32.shr_u
      i32.xor
      i32.const -1028477379
      i32.mul
-     local.tee $0
-     local.get $0
+     local.tee $2
+     local.get $2
      i32.const 16
      i32.shr_u
      i32.xor
@@ -19278,36 +19435,36 @@
      i32.shl
      i32.add
      i32.load $0
-     local.set $0
+     local.set $2
      block $__inlined_func$~lib/map/Map<f32,i32>#find1
       loop $while-continue|02
-       local.get $0
+       local.get $2
        if
-        local.get $0
+        local.get $2
         i32.load $0 offset=8
-        local.tee $2
+        local.tee $4
         i32.const 1
         i32.and
         if (result i32)
          i32.const 0
         else
-         local.get $0
+         local.get $2
          f32.load $0
-         local.get $4
+         local.get $3
          f32.eq
         end
         br_if $__inlined_func$~lib/map/Map<f32,i32>#find1
-        local.get $2
+        local.get $4
         i32.const -2
         i32.and
-        local.set $0
+        local.set $2
         br $while-continue|02
        end
       end
       i32.const 0
-      local.set $0
+      local.set $2
      end
-     local.get $0
+     local.get $2
      i32.eqz
      if
       i32.const 0
@@ -19317,10 +19474,10 @@
       call $~lib/builtins/abort
       unreachable
      end
-     local.get $11
-     local.get $4
+     local.get $10
+     local.get $3
      call $~lib/map/Map<f32,i32>#get
-     local.get $4
+     local.get $3
      i32.trunc_sat_f32_s
      i32.const 10
      i32.add
@@ -19333,14 +19490,14 @@
       call $~lib/builtins/abort
       unreachable
      end
-     local.get $4
+     local.get $3
      f32.const 1
      f32.add
-     local.set $4
+     local.set $3
      br $for-loop|0
     end
    end
-   local.get $11
+   local.get $10
    i32.load $0 offset=20
    i32.const 100
    i32.ne
@@ -19353,17 +19510,17 @@
     unreachable
    end
    f32.const 0
-   local.set $4
+   local.set $3
    loop $for-loop|1
-    local.get $4
+    local.get $3
     f32.const 100
     f32.lt
     if
-     local.get $11
+     local.get $10
      i32.load $0
-     local.get $11
+     local.get $10
      i32.load $0 offset=4
-     local.get $4
+     local.get $3
      i32.reinterpret_f32
      i32.const -1028477379
      i32.mul
@@ -19373,22 +19530,22 @@
      i32.rotl
      i32.const 668265263
      i32.mul
-     local.tee $0
-     local.get $0
+     local.tee $2
+     local.get $2
      i32.const 15
      i32.shr_u
      i32.xor
      i32.const -2048144777
      i32.mul
-     local.tee $0
-     local.get $0
+     local.tee $2
+     local.get $2
      i32.const 13
      i32.shr_u
      i32.xor
      i32.const -1028477379
      i32.mul
-     local.tee $0
-     local.get $0
+     local.tee $2
+     local.get $2
      i32.const 16
      i32.shr_u
      i32.xor
@@ -19397,36 +19554,36 @@
      i32.shl
      i32.add
      i32.load $0
-     local.set $0
+     local.set $2
      block $__inlined_func$~lib/map/Map<f32,i32>#find4
       loop $while-continue|05
-       local.get $0
+       local.get $2
        if
-        local.get $0
+        local.get $2
         i32.load $0 offset=8
-        local.tee $2
+        local.tee $4
         i32.const 1
         i32.and
         if (result i32)
          i32.const 0
         else
-         local.get $0
+         local.get $2
          f32.load $0
-         local.get $4
+         local.get $3
          f32.eq
         end
         br_if $__inlined_func$~lib/map/Map<f32,i32>#find4
-        local.get $2
+        local.get $4
         i32.const -2
         i32.and
-        local.set $0
+        local.set $2
         br $while-continue|05
        end
       end
       i32.const 0
-      local.set $0
+      local.set $2
      end
-     local.get $0
+     local.get $2
      i32.eqz
      if
       i32.const 0
@@ -19436,10 +19593,10 @@
       call $~lib/builtins/abort
       unreachable
      end
-     local.get $11
-     local.get $4
+     local.get $10
+     local.get $3
      call $~lib/map/Map<f32,i32>#get
-     local.get $4
+     local.get $3
      i32.trunc_sat_f32_s
      i32.const 10
      i32.add
@@ -19452,18 +19609,422 @@
       call $~lib/builtins/abort
       unreachable
      end
-     local.get $11
-     local.get $4
-     local.get $4
+     local.get $10
+     local.get $3
+     local.get $3
      i32.trunc_sat_f32_s
      i32.const 20
      i32.add
      call $~lib/map/Map<f32,i32>#set
-     local.get $11
+     local.get $10
      i32.load $0
+     local.get $10
+     i32.load $0 offset=4
+     local.get $3
+     i32.reinterpret_f32
+     i32.const -1028477379
+     i32.mul
+     i32.const 374761397
+     i32.add
+     i32.const 17
+     i32.rotl
+     i32.const 668265263
+     i32.mul
+     local.tee $2
+     local.get $2
+     i32.const 15
+     i32.shr_u
+     i32.xor
+     i32.const -2048144777
+     i32.mul
+     local.tee $2
+     local.get $2
+     i32.const 13
+     i32.shr_u
+     i32.xor
+     i32.const -1028477379
+     i32.mul
+     local.tee $2
+     local.get $2
+     i32.const 16
+     i32.shr_u
+     i32.xor
+     i32.and
+     i32.const 2
+     i32.shl
+     i32.add
+     i32.load $0
+     local.set $2
+     block $__inlined_func$~lib/map/Map<f32,i32>#find7
+      loop $while-continue|08
+       local.get $2
+       if
+        local.get $2
+        i32.load $0 offset=8
+        local.tee $4
+        i32.const 1
+        i32.and
+        if (result i32)
+         i32.const 0
+        else
+         local.get $2
+         f32.load $0
+         local.get $3
+         f32.eq
+        end
+        br_if $__inlined_func$~lib/map/Map<f32,i32>#find7
+        local.get $4
+        i32.const -2
+        i32.and
+        local.set $2
+        br $while-continue|08
+       end
+      end
+      i32.const 0
+      local.set $2
+     end
+     local.get $2
+     i32.eqz
+     if
+      i32.const 0
+      i32.const 1568
+      i32.const 18
+      i32.const 5
+      call $~lib/builtins/abort
+      unreachable
+     end
+     local.get $10
+     local.get $3
+     call $~lib/map/Map<f32,i32>#get
+     local.get $3
+     i32.trunc_sat_f32_s
+     i32.const 20
+     i32.add
+     i32.ne
+     if
+      i32.const 0
+      i32.const 1568
+      i32.const 19
+      i32.const 5
+      call $~lib/builtins/abort
+      unreachable
+     end
+     local.get $3
+     f32.const 1
+     f32.add
+     local.set $3
+     br $for-loop|1
+    end
+   end
+   local.get $10
+   i32.load $0 offset=20
+   i32.const 100
+   i32.ne
+   if
+    i32.const 0
+    i32.const 1568
+    i32.const 21
+    i32.const 3
+    call $~lib/builtins/abort
+    unreachable
+   end
+   global.get $~lib/memory/__stack_pointer
+   local.tee $4
+   i32.const 4
+   i32.sub
+   global.set $~lib/memory/__stack_pointer
+   global.get $~lib/memory/__stack_pointer
+   i32.const 1896
+   i32.lt_s
+   br_if $folding-inner1
+   global.get $~lib/memory/__stack_pointer
+   local.tee $2
+   i32.const 0
+   i32.store $0
+   local.get $10
+   i32.load $0 offset=8
+   local.set $5
+   local.get $10
+   i32.load $0 offset=16
+   local.set $6
+   local.get $2
+   i32.const 8
+   i32.sub
+   global.set $~lib/memory/__stack_pointer
+   global.get $~lib/memory/__stack_pointer
+   i32.const 1896
+   i32.lt_s
+   br_if $folding-inner1
+   global.get $~lib/memory/__stack_pointer
+   local.tee $7
+   i64.const 0
+   i64.store $0
+   local.get $7
+   i32.const 16
+   i32.const 28
+   call $~lib/rt/itcms/__new
+   local.tee $11
+   i32.store $0
+   local.get $11
+   i32.const 0
+   i32.store $0
+   local.get $11
+   i32.const 0
+   i32.store $0 offset=4
+   local.get $11
+   i32.const 0
+   i32.store $0 offset=8
+   local.get $11
+   i32.const 0
+   i32.store $0 offset=12
+   local.get $6
+   i32.const 268435455
+   i32.gt_u
+   if
+    i32.const 1456
+    i32.const 1728
+    i32.const 70
+    i32.const 60
+    call $~lib/builtins/abort
+    unreachable
+   end
+   global.get $~lib/memory/__stack_pointer
+   i32.const 8
+   local.get $6
+   local.get $6
+   i32.const 8
+   i32.le_u
+   select
+   i32.const 2
+   i32.shl
+   local.tee $7
+   i32.const 1
+   call $~lib/rt/itcms/__new
+   local.tee $8
+   i32.store $0 offset=4
+   local.get $11
+   local.get $8
+   i32.store $0
+   local.get $8
+   if
+    local.get $11
+    local.get $8
+    call $byn-split-outlined-A$~lib/rt/itcms/__link
+   end
+   local.get $11
+   local.get $8
+   i32.store $0 offset=4
+   local.get $11
+   local.get $7
+   i32.store $0 offset=8
+   local.get $11
+   local.get $6
+   i32.store $0 offset=12
+   global.get $~lib/memory/__stack_pointer
+   i32.const 8
+   i32.add
+   global.set $~lib/memory/__stack_pointer
+   local.get $2
+   local.get $11
+   i32.store $0
+   loop $for-loop|00
+    local.get $0
+    local.get $6
+    i32.lt_s
+    if
+     local.get $5
+     local.get $0
+     i32.const 12
+     i32.mul
+     i32.add
+     local.tee $2
+     i32.load $0 offset=8
+     i32.const 1
+     i32.and
+     i32.eqz
+     if
+      local.get $2
+      f32.load $0
+      local.set $3
+      local.get $1
+      local.tee $2
+      i32.const 1
+      i32.add
+      local.set $1
+      local.get $2
+      local.get $11
+      i32.load $0 offset=12
+      i32.ge_u
+      if
+       local.get $2
+       i32.const 0
+       i32.lt_s
+       if
+        i32.const 1248
+        i32.const 1728
+        i32.const 130
+        i32.const 22
+        call $~lib/builtins/abort
+        unreachable
+       end
+       local.get $11
+       local.get $2
+       i32.const 1
+       i32.add
+       local.tee $7
+       i32.const 2
+       i32.const 1
+       call $~lib/array/ensureCapacity
+       local.get $11
+       local.get $7
+       i32.store $0 offset=12
+      end
+      local.get $11
+      i32.load $0 offset=4
+      local.get $2
+      i32.const 2
+      i32.shl
+      i32.add
+      local.get $3
+      f32.store $0
+     end
+     local.get $0
+     i32.const 1
+     i32.add
+     local.set $0
+     br $for-loop|00
+    end
+   end
+   local.get $11
+   local.get $1
+   i32.const 2
+   i32.const 0
+   call $~lib/array/ensureCapacity
+   local.get $11
+   local.get $1
+   i32.store $0 offset=12
+   global.get $~lib/memory/__stack_pointer
+   i32.const 4
+   i32.add
+   global.set $~lib/memory/__stack_pointer
+   local.get $4
+   local.get $11
+   i32.store $0 offset=4
+   global.get $~lib/memory/__stack_pointer
+   local.get $10
+   call $~lib/map/Map<i8,i32>#values
+   local.tee $12
+   i32.store $0 offset=8
+   global.get $~lib/memory/__stack_pointer
+   local.set $0
+   global.get $~lib/memory/__stack_pointer
+   i32.const 8
+   i32.sub
+   global.set $~lib/memory/__stack_pointer
+   global.get $~lib/memory/__stack_pointer
+   i32.const 1896
+   i32.lt_s
+   br_if $folding-inner1
+   global.get $~lib/memory/__stack_pointer
+   local.tee $1
+   i64.const 0
+   i64.store $0
+   local.get $1
+   i32.const 24
+   i32.const 29
+   call $~lib/rt/itcms/__new
+   local.tee $7
+   i32.store $0
+   i32.const 16
+   call $~lib/arraybuffer/ArrayBuffer#constructor
+   local.set $1
+   global.get $~lib/memory/__stack_pointer
+   local.get $1
+   i32.store $0 offset=4
+   local.get $7
+   local.get $1
+   i32.store $0
+   local.get $1
+   if
+    local.get $7
+    local.get $1
+    call $byn-split-outlined-A$~lib/rt/itcms/__link
+   end
+   local.get $7
+   i32.const 3
+   i32.store $0 offset=4
+   i32.const 48
+   call $~lib/arraybuffer/ArrayBuffer#constructor
+   local.set $1
+   global.get $~lib/memory/__stack_pointer
+   local.get $1
+   i32.store $0 offset=4
+   local.get $7
+   local.get $1
+   i32.store $0 offset=8
+   local.get $1
+   if
+    local.get $7
+    local.get $1
+    call $byn-split-outlined-A$~lib/rt/itcms/__link
+   end
+   local.get $7
+   i32.const 4
+   i32.store $0 offset=12
+   local.get $7
+   i32.const 0
+   i32.store $0 offset=16
+   local.get $7
+   i32.const 0
+   i32.store $0 offset=20
+   global.get $~lib/memory/__stack_pointer
+   i32.const 8
+   i32.add
+   global.set $~lib/memory/__stack_pointer
+   local.get $0
+   local.get $7
+   i32.store $0 offset=12
+   global.get $~lib/memory/__stack_pointer
+   call $~lib/map/Map<i32,i32>#constructor
+   local.tee $13
+   i32.store $0 offset=16
+   i32.const 0
+   local.set $1
+   loop $for-loop|2
+    local.get $1
+    local.get $11
+    i32.load $0 offset=12
+    i32.lt_s
+    if
+     local.get $1
+     local.get $11
+     i32.load $0 offset=12
+     i32.ge_u
+     if
+      i32.const 1248
+      i32.const 1728
+      i32.const 114
+      i32.const 42
+      call $~lib/builtins/abort
+      unreachable
+     end
      local.get $11
      i32.load $0 offset=4
-     local.get $4
+     local.get $1
+     i32.const 2
+     i32.shl
+     i32.add
+     f32.load $0
+     local.set $3
+     local.get $12
+     local.get $1
+     call $~lib/array/Array<i32>#__get
+     local.set $14
+     local.get $10
+     i32.load $0
+     local.get $10
+     i32.load $0 offset=4
+     local.get $3
      i32.reinterpret_f32
      i32.const -1028477379
      i32.mul
@@ -19498,8 +20059,8 @@
      i32.add
      i32.load $0
      local.set $0
-     block $__inlined_func$~lib/map/Map<f32,i32>#find7
-      loop $while-continue|08
+     block $__inlined_func$~lib/map/Map<f32,i32>#find14
+      loop $while-continue|015
        local.get $0
        if
         local.get $0
@@ -19512,15 +20073,15 @@
         else
          local.get $0
          f32.load $0
-         local.get $4
+         local.get $3
          f32.eq
         end
-        br_if $__inlined_func$~lib/map/Map<f32,i32>#find7
+        br_if $__inlined_func$~lib/map/Map<f32,i32>#find14
         local.get $2
         i32.const -2
         i32.and
         local.set $0
-        br $while-continue|08
+        br $while-continue|015
        end
       end
       i32.const 0
@@ -19531,390 +20092,20 @@
      if
       i32.const 0
       i32.const 1568
-      i32.const 18
-      i32.const 5
-      call $~lib/builtins/abort
-      unreachable
-     end
-     local.get $11
-     local.get $4
-     call $~lib/map/Map<f32,i32>#get
-     local.get $4
-     i32.trunc_sat_f32_s
-     i32.const 20
-     i32.add
-     i32.ne
-     if
-      i32.const 0
-      i32.const 1568
-      i32.const 19
-      i32.const 5
-      call $~lib/builtins/abort
-      unreachable
-     end
-     local.get $4
-     f32.const 1
-     f32.add
-     local.set $4
-     br $for-loop|1
-    end
-   end
-   local.get $11
-   i32.load $0 offset=20
-   i32.const 100
-   i32.ne
-   if
-    i32.const 0
-    i32.const 1568
-    i32.const 21
-    i32.const 3
-    call $~lib/builtins/abort
-    unreachable
-   end
-   global.get $~lib/memory/__stack_pointer
-   local.tee $9
-   i32.const 4
-   i32.sub
-   global.set $~lib/memory/__stack_pointer
-   global.get $~lib/memory/__stack_pointer
-   i32.const 1896
-   i32.lt_s
-   br_if $folding-inner1
-   global.get $~lib/memory/__stack_pointer
-   local.tee $7
-   i32.const 0
-   i32.store $0
-   local.get $11
-   i32.load $0 offset=8
-   local.set $6
-   local.get $11
-   i32.load $0 offset=16
-   local.set $5
-   local.get $7
-   i32.const 8
-   i32.sub
-   global.set $~lib/memory/__stack_pointer
-   global.get $~lib/memory/__stack_pointer
-   i32.const 1896
-   i32.lt_s
-   br_if $folding-inner1
-   global.get $~lib/memory/__stack_pointer
-   local.tee $0
-   i64.const 0
-   i64.store $0
-   local.get $0
-   i32.const 16
-   i32.const 28
-   call $~lib/rt/itcms/__new
-   local.tee $2
-   i32.store $0
-   local.get $2
-   i32.const 0
-   i32.store $0
-   local.get $2
-   i32.const 0
-   i32.store $0 offset=4
-   local.get $2
-   i32.const 0
-   i32.store $0 offset=8
-   local.get $2
-   i32.const 0
-   i32.store $0 offset=12
-   local.get $5
-   i32.const 268435455
-   i32.gt_u
-   if
-    i32.const 1456
-    i32.const 1728
-    i32.const 70
-    i32.const 60
-    call $~lib/builtins/abort
-    unreachable
-   end
-   global.get $~lib/memory/__stack_pointer
-   i32.const 8
-   local.get $5
-   local.get $5
-   i32.const 8
-   i32.le_u
-   select
-   i32.const 2
-   i32.shl
-   local.tee $3
-   i32.const 1
-   call $~lib/rt/itcms/__new
-   local.tee $0
-   i32.store $0 offset=4
-   local.get $2
-   local.get $0
-   i32.store $0
-   local.get $0
-   if
-    local.get $2
-    local.get $0
-    call $byn-split-outlined-A$~lib/rt/itcms/__link
-   end
-   local.get $2
-   local.get $0
-   i32.store $0 offset=4
-   local.get $2
-   local.get $3
-   i32.store $0 offset=8
-   local.get $2
-   local.get $5
-   i32.store $0 offset=12
-   global.get $~lib/memory/__stack_pointer
-   i32.const 8
-   i32.add
-   global.set $~lib/memory/__stack_pointer
-   local.get $7
-   local.get $2
-   i32.store $0
-   loop $for-loop|00
-    local.get $5
-    local.get $10
-    i32.gt_s
-    if
-     local.get $6
-     local.get $10
-     i32.const 12
-     i32.mul
-     i32.add
-     local.tee $0
-     i32.load $0 offset=8
-     i32.const 1
-     i32.and
-     i32.eqz
-     if
-      local.get $2
-      i32.load $0 offset=4
-      local.get $1
-      i32.const 2
-      i32.shl
-      i32.add
-      local.get $0
-      f32.load $0
-      f32.store $0
-      local.get $1
-      i32.const 1
-      i32.add
-      local.set $1
-     end
-     local.get $10
-     i32.const 1
-     i32.add
-     local.set $10
-     br $for-loop|00
-    end
-   end
-   local.get $2
-   local.get $1
-   i32.const 2
-   call $~lib/array/ensureCapacity
-   local.get $2
-   local.get $1
-   i32.store $0 offset=12
-   global.get $~lib/memory/__stack_pointer
-   i32.const 4
-   i32.add
-   global.set $~lib/memory/__stack_pointer
-   local.get $9
-   local.get $2
-   i32.store $0 offset=4
-   global.get $~lib/memory/__stack_pointer
-   local.get $11
-   call $~lib/map/Map<i8,i32>#values
-   local.tee $10
-   i32.store $0 offset=8
-   global.get $~lib/memory/__stack_pointer
-   local.set $1
-   global.get $~lib/memory/__stack_pointer
-   i32.const 8
-   i32.sub
-   global.set $~lib/memory/__stack_pointer
-   global.get $~lib/memory/__stack_pointer
-   i32.const 1896
-   i32.lt_s
-   br_if $folding-inner1
-   global.get $~lib/memory/__stack_pointer
-   local.tee $0
-   i64.const 0
-   i64.store $0
-   local.get $0
-   i32.const 24
-   i32.const 29
-   call $~lib/rt/itcms/__new
-   local.tee $14
-   i32.store $0
-   i32.const 16
-   call $~lib/arraybuffer/ArrayBuffer#constructor
-   local.set $0
-   global.get $~lib/memory/__stack_pointer
-   local.get $0
-   i32.store $0 offset=4
-   local.get $14
-   local.get $0
-   i32.store $0
-   local.get $0
-   if
-    local.get $14
-    local.get $0
-    call $byn-split-outlined-A$~lib/rt/itcms/__link
-   end
-   local.get $14
-   i32.const 3
-   i32.store $0 offset=4
-   i32.const 48
-   call $~lib/arraybuffer/ArrayBuffer#constructor
-   local.set $0
-   global.get $~lib/memory/__stack_pointer
-   local.get $0
-   i32.store $0 offset=4
-   local.get $14
-   local.get $0
-   i32.store $0 offset=8
-   local.get $0
-   if
-    local.get $14
-    local.get $0
-    call $byn-split-outlined-A$~lib/rt/itcms/__link
-   end
-   local.get $14
-   i32.const 4
-   i32.store $0 offset=12
-   local.get $14
-   i32.const 0
-   i32.store $0 offset=16
-   local.get $14
-   i32.const 0
-   i32.store $0 offset=20
-   global.get $~lib/memory/__stack_pointer
-   i32.const 8
-   i32.add
-   global.set $~lib/memory/__stack_pointer
-   local.get $1
-   local.get $14
-   i32.store $0 offset=12
-   global.get $~lib/memory/__stack_pointer
-   call $~lib/map/Map<i32,i32>#constructor
-   local.tee $9
-   i32.store $0 offset=16
-   loop $for-loop|2
-    local.get $16
-    local.get $2
-    i32.load $0 offset=12
-    i32.lt_s
-    if
-     local.get $16
-     local.get $2
-     i32.load $0 offset=12
-     i32.ge_u
-     if
-      i32.const 1248
-      i32.const 1728
-      i32.const 114
-      i32.const 42
-      call $~lib/builtins/abort
-      unreachable
-     end
-     local.get $2
-     i32.load $0 offset=4
-     local.get $16
-     i32.const 2
-     i32.shl
-     i32.add
-     f32.load $0
-     local.set $8
-     local.get $10
-     local.get $16
-     call $~lib/array/Array<i32>#__get
-     local.set $7
-     local.get $11
-     i32.load $0
-     local.get $11
-     i32.load $0 offset=4
-     local.get $8
-     i32.reinterpret_f32
-     i32.const -1028477379
-     i32.mul
-     i32.const 374761397
-     i32.add
-     i32.const 17
-     i32.rotl
-     i32.const 668265263
-     i32.mul
-     local.tee $0
-     local.get $0
-     i32.const 15
-     i32.shr_u
-     i32.xor
-     i32.const -2048144777
-     i32.mul
-     local.tee $0
-     local.get $0
-     i32.const 13
-     i32.shr_u
-     i32.xor
-     i32.const -1028477379
-     i32.mul
-     local.tee $0
-     local.get $0
-     i32.const 16
-     i32.shr_u
-     i32.xor
-     i32.and
-     i32.const 2
-     i32.shl
-     i32.add
-     i32.load $0
-     local.set $1
-     block $__inlined_func$~lib/map/Map<f32,i32>#find14
-      loop $while-continue|015
-       local.get $1
-       if
-        local.get $1
-        i32.load $0 offset=8
-        local.tee $0
-        i32.const 1
-        i32.and
-        if (result i32)
-         i32.const 0
-        else
-         local.get $1
-         f32.load $0
-         local.get $8
-         f32.eq
-        end
-        br_if $__inlined_func$~lib/map/Map<f32,i32>#find14
-        local.get $0
-        i32.const -2
-        i32.and
-        local.set $1
-        br $while-continue|015
-       end
-      end
-      i32.const 0
-      local.set $1
-     end
-     local.get $1
-     i32.eqz
-     if
-      i32.const 0
-      i32.const 1568
       i32.const 31
       i32.const 5
       call $~lib/builtins/abort
       unreachable
      end
-     local.get $11
+     local.get $10
      i32.load $0
-     local.get $11
+     local.get $10
      i32.load $0 offset=4
-     local.get $7
+     local.get $14
      i32.const 20
      i32.sub
      f32.convert_i32_s
-     local.tee $4
+     local.tee $15
      i32.reinterpret_f32
      i32.const -1028477379
      i32.mul
@@ -19948,36 +20139,36 @@
      i32.shl
      i32.add
      i32.load $0
-     local.set $1
+     local.set $0
      block $__inlined_func$~lib/map/Map<f32,i32>#find17
       loop $while-continue|018
-       local.get $1
+       local.get $0
        if
-        local.get $1
+        local.get $0
         i32.load $0 offset=8
-        local.tee $0
+        local.tee $2
         i32.const 1
         i32.and
         if (result i32)
          i32.const 0
         else
-         local.get $1
+         local.get $0
          f32.load $0
-         local.get $4
+         local.get $15
          f32.eq
         end
         br_if $__inlined_func$~lib/map/Map<f32,i32>#find17
-        local.get $0
+        local.get $2
         i32.const -2
         i32.and
-        local.set $1
+        local.set $0
         br $while-continue|018
        end
       end
       i32.const 0
-      local.set $1
+      local.set $0
      end
-     local.get $1
+     local.get $0
      i32.eqz
      if
       i32.const 0
@@ -19998,9 +20189,9 @@
      global.get $~lib/memory/__stack_pointer
      i32.const 0
      i32.store $0
-     local.get $14
+     local.get $7
      i32.load $0
-     local.get $8
+     local.get $3
      i32.reinterpret_f32
      i32.const -1028477379
      i32.mul
@@ -20029,58 +20220,58 @@
      i32.shr_u
      local.get $0
      i32.xor
-     local.tee $6
-     local.get $14
+     local.tee $16
+     local.get $7
      i32.load $0 offset=4
      i32.and
      i32.const 2
      i32.shl
      i32.add
      i32.load $0
-     local.set $1
+     local.set $0
      block $__inlined_func$~lib/map/Map<f32,i32>#find19
       loop $while-continue|020
-       local.get $1
+       local.get $0
        if
-        local.get $1
+        local.get $0
         i32.load $0 offset=8
-        local.tee $0
+        local.tee $2
         i32.const 1
         i32.and
         if (result i32)
          i32.const 0
         else
-         local.get $8
-         local.get $1
+         local.get $3
+         local.get $0
          f32.load $0
          f32.eq
         end
         br_if $__inlined_func$~lib/map/Map<f32,i32>#find19
-        local.get $0
+        local.get $2
         i32.const -2
         i32.and
-        local.set $1
+        local.set $0
         br $while-continue|020
        end
       end
       i32.const 0
-      local.set $1
+      local.set $0
      end
-     local.get $1
+     local.get $0
      if
-      local.get $1
-      local.get $8
+      local.get $0
+      local.get $3
       f32.store $0 offset=4
      else
-      local.get $14
+      local.get $7
       i32.load $0 offset=16
-      local.get $14
+      local.get $7
       i32.load $0 offset=12
       i32.eq
       if
-       local.get $14
+       local.get $7
        i32.load $0 offset=20
-       local.get $14
+       local.get $7
        i32.load $0 offset=12
        i32.const 3
        i32.mul
@@ -20088,17 +20279,17 @@
        i32.div_s
        i32.lt_s
        if (result i32)
-        local.get $14
+        local.get $7
         i32.load $0 offset=4
        else
-        local.get $14
+        local.get $7
         i32.load $0 offset=4
         i32.const 1
         i32.shl
         i32.const 1
         i32.or
        end
-       local.set $13
+       local.set $8
        global.get $~lib/memory/__stack_pointer
        i32.const 8
        i32.sub
@@ -20112,14 +20303,14 @@
        i64.const 0
        i64.store $0
        local.get $0
-       local.get $13
+       local.get $8
        i32.const 1
        i32.add
        local.tee $0
        i32.const 2
        i32.shl
        call $~lib/arraybuffer/ArrayBuffer#constructor
-       local.tee $12
+       local.tee $9
        i32.store $0
        global.get $~lib/memory/__stack_pointer
        local.get $0
@@ -20131,43 +20322,43 @@
        i32.const 12
        i32.mul
        call $~lib/arraybuffer/ArrayBuffer#constructor
-       local.tee $1
+       local.tee $2
        i32.store $0 offset=4
-       local.get $14
+       local.get $7
        i32.load $0 offset=8
-       local.tee $17
-       local.get $14
+       local.tee $4
+       local.get $7
        i32.load $0 offset=16
        i32.const 12
        i32.mul
        i32.add
-       local.set $15
-       local.get $1
+       local.set $6
+       local.get $2
        local.set $0
        loop $while-continue|00
-        local.get $15
-        local.get $17
+        local.get $4
+        local.get $6
         i32.ne
         if
-         local.get $17
+         local.get $4
          i32.load $0 offset=8
          i32.const 1
          i32.and
          i32.eqz
          if
           local.get $0
-          local.get $17
+          local.get $4
           f32.load $0
-          local.tee $4
+          local.tee $15
           f32.store $0
           local.get $0
-          local.get $17
+          local.get $4
           f32.load $0 offset=4
           f32.store $0 offset=4
           local.get $0
-          local.get $12
-          local.get $13
-          local.get $4
+          local.get $9
+          local.get $8
+          local.get $15
           i32.reinterpret_f32
           i32.const -1028477379
           i32.mul
@@ -20177,33 +20368,33 @@
           i32.rotl
           i32.const 668265263
           i32.mul
-          local.tee $3
+          local.tee $17
           i32.const 15
           i32.shr_u
-          local.get $3
+          local.get $17
           i32.xor
           i32.const -2048144777
           i32.mul
-          local.tee $3
+          local.tee $17
           i32.const 13
           i32.shr_u
-          local.get $3
+          local.get $17
           i32.xor
           i32.const -1028477379
           i32.mul
-          local.tee $3
+          local.tee $17
           i32.const 16
           i32.shr_u
-          local.get $3
+          local.get $17
           i32.xor
           i32.and
           i32.const 2
           i32.shl
           i32.add
-          local.tee $3
+          local.tee $17
           i32.load $0
           i32.store $0 offset=8
-          local.get $3
+          local.get $17
           local.get $0
           i32.store $0
           local.get $0
@@ -20211,39 +20402,39 @@
           i32.add
           local.set $0
          end
-         local.get $17
+         local.get $4
          i32.const 12
          i32.add
-         local.set $17
+         local.set $4
          br $while-continue|00
         end
        end
-       local.get $14
-       local.get $12
+       local.get $7
+       local.get $9
        i32.store $0
-       local.get $12
+       local.get $9
        if
-        local.get $14
-        local.get $12
+        local.get $7
+        local.get $9
         call $byn-split-outlined-A$~lib/rt/itcms/__link
        end
-       local.get $14
-       local.get $13
+       local.get $7
+       local.get $8
        i32.store $0 offset=4
-       local.get $14
-       local.get $1
+       local.get $7
+       local.get $2
        i32.store $0 offset=8
-       local.get $1
+       local.get $2
        if
-        local.get $14
-        local.get $1
+        local.get $7
+        local.get $2
         call $byn-split-outlined-A$~lib/rt/itcms/__link
        end
-       local.get $14
+       local.get $7
        local.get $5
        i32.store $0 offset=12
-       local.get $14
-       local.get $14
+       local.get $7
+       local.get $7
        i32.load $0 offset=20
        i32.store $0 offset=16
        global.get $~lib/memory/__stack_pointer
@@ -20252,70 +20443,70 @@
        global.set $~lib/memory/__stack_pointer
       end
       global.get $~lib/memory/__stack_pointer
-      local.get $14
+      local.get $7
       i32.load $0 offset=8
-      local.tee $1
-      i32.store $0
-      local.get $14
-      local.get $14
-      i32.load $0 offset=16
       local.tee $0
+      i32.store $0
+      local.get $7
+      local.get $7
+      i32.load $0 offset=16
+      local.tee $2
       i32.const 1
       i32.add
       i32.store $0 offset=16
-      local.get $1
       local.get $0
+      local.get $2
       i32.const 12
       i32.mul
       i32.add
-      local.tee $1
-      local.get $8
+      local.tee $0
+      local.get $3
       f32.store $0
-      local.get $1
-      local.get $8
+      local.get $0
+      local.get $3
       f32.store $0 offset=4
-      local.get $14
-      local.get $14
+      local.get $7
+      local.get $7
       i32.load $0 offset=20
       i32.const 1
       i32.add
       i32.store $0 offset=20
-      local.get $1
-      local.get $14
+      local.get $0
+      local.get $7
       i32.load $0
-      local.get $6
-      local.get $14
+      local.get $16
+      local.get $7
       i32.load $0 offset=4
       i32.and
       i32.const 2
       i32.shl
       i32.add
-      local.tee $0
+      local.tee $2
       i32.load $0
       i32.store $0 offset=8
+      local.get $2
       local.get $0
-      local.get $1
       i32.store $0
      end
      global.get $~lib/memory/__stack_pointer
      i32.const 4
      i32.add
      global.set $~lib/memory/__stack_pointer
-     local.get $9
-     local.get $7
+     local.get $13
+     local.get $14
      i32.const 20
      i32.sub
      local.tee $0
      local.get $0
      call $~lib/map/Map<i32,i32>#set
-     local.get $16
+     local.get $1
      i32.const 1
      i32.add
-     local.set $16
+     local.set $1
      br $for-loop|2
     end
    end
-   local.get $14
+   local.get $7
    i32.load $0 offset=20
    i32.const 100
    i32.ne
@@ -20327,7 +20518,7 @@
     call $~lib/builtins/abort
     unreachable
    end
-   local.get $9
+   local.get $13
    i32.load $0 offset=20
    i32.const 100
    i32.ne
@@ -20340,17 +20531,17 @@
     unreachable
    end
    f32.const 0
-   local.set $4
+   local.set $3
    loop $for-loop|3
-    local.get $4
+    local.get $3
     f32.const 50
     f32.lt
     if
-     local.get $11
+     local.get $10
      i32.load $0
-     local.get $11
+     local.get $10
      i32.load $0 offset=4
-     local.get $4
+     local.get $3
      i32.reinterpret_f32
      i32.const -1028477379
      i32.mul
@@ -20384,36 +20575,36 @@
      i32.shl
      i32.add
      i32.load $0
-     local.set $0
+     local.set $2
      block $__inlined_func$~lib/map/Map<f32,i32>#find24
       loop $while-continue|025
-       local.get $0
+       local.get $2
        if
-        local.get $0
+        local.get $2
         i32.load $0 offset=8
-        local.tee $1
+        local.tee $0
         i32.const 1
         i32.and
         if (result i32)
          i32.const 0
         else
-         local.get $0
+         local.get $2
          f32.load $0
-         local.get $4
+         local.get $3
          f32.eq
         end
         br_if $__inlined_func$~lib/map/Map<f32,i32>#find24
-        local.get $1
+        local.get $0
         i32.const -2
         i32.and
-        local.set $0
+        local.set $2
         br $while-continue|025
        end
       end
       i32.const 0
-      local.set $0
+      local.set $2
      end
-     local.get $0
+     local.get $2
      i32.eqz
      if
       i32.const 0
@@ -20423,10 +20614,10 @@
       call $~lib/builtins/abort
       unreachable
      end
-     local.get $11
-     local.get $4
+     local.get $10
+     local.get $3
      call $~lib/map/Map<f32,i32>#get
-     local.get $4
+     local.get $3
      i32.trunc_sat_f32_s
      i32.const 20
      i32.add
@@ -20439,14 +20630,14 @@
       call $~lib/builtins/abort
       unreachable
      end
-     local.get $11
-     local.get $4
+     local.get $10
+     local.get $3
      call $~lib/map/Map<f32,i32>#delete
-     local.get $11
+     local.get $10
      i32.load $0
-     local.get $11
+     local.get $10
      i32.load $0 offset=4
-     local.get $4
+     local.get $3
      i32.reinterpret_f32
      i32.const -1028477379
      i32.mul
@@ -20480,36 +20671,36 @@
      i32.shl
      i32.add
      i32.load $0
-     local.set $0
+     local.set $2
      block $__inlined_func$~lib/map/Map<f32,i32>#find27
       loop $while-continue|028
-       local.get $0
+       local.get $2
        if
-        local.get $0
+        local.get $2
         i32.load $0 offset=8
-        local.tee $1
+        local.tee $0
         i32.const 1
         i32.and
         if (result i32)
          i32.const 0
         else
-         local.get $0
+         local.get $2
          f32.load $0
-         local.get $4
+         local.get $3
          f32.eq
         end
         br_if $__inlined_func$~lib/map/Map<f32,i32>#find27
-        local.get $1
+        local.get $0
         i32.const -2
         i32.and
-        local.set $0
+        local.set $2
         br $while-continue|028
        end
       end
       i32.const 0
-      local.set $0
+      local.set $2
      end
-     local.get $0
+     local.get $2
      if
       i32.const 0
       i32.const 1568
@@ -20518,14 +20709,14 @@
       call $~lib/builtins/abort
       unreachable
      end
-     local.get $4
+     local.get $3
      f32.const 1
      f32.add
-     local.set $4
+     local.set $3
      br $for-loop|3
     end
    end
-   local.get $11
+   local.get $10
    i32.load $0 offset=20
    i32.const 50
    i32.ne
@@ -20538,17 +20729,17 @@
     unreachable
    end
    f32.const 0
-   local.set $4
+   local.set $3
    loop $for-loop|4
-    local.get $4
+    local.get $3
     f32.const 50
     f32.lt
     if
-     local.get $11
+     local.get $10
      i32.load $0
-     local.get $11
+     local.get $10
      i32.load $0 offset=4
-     local.get $4
+     local.get $3
      i32.reinterpret_f32
      i32.const -1028477379
      i32.mul
@@ -20582,36 +20773,36 @@
      i32.shl
      i32.add
      i32.load $0
-     local.set $0
+     local.set $2
      block $__inlined_func$~lib/map/Map<f32,i32>#find30
       loop $while-continue|031
-       local.get $0
+       local.get $2
        if
-        local.get $0
+        local.get $2
         i32.load $0 offset=8
-        local.tee $1
+        local.tee $0
         i32.const 1
         i32.and
         if (result i32)
          i32.const 0
         else
-         local.get $0
+         local.get $2
          f32.load $0
-         local.get $4
+         local.get $3
          f32.eq
         end
         br_if $__inlined_func$~lib/map/Map<f32,i32>#find30
-        local.get $1
+        local.get $0
         i32.const -2
         i32.and
-        local.set $0
+        local.set $2
         br $while-continue|031
        end
       end
       i32.const 0
-      local.set $0
+      local.set $2
      end
-     local.get $0
+     local.get $2
      if
       i32.const 0
       i32.const 1568
@@ -20620,18 +20811,18 @@
       call $~lib/builtins/abort
       unreachable
      end
-     local.get $11
-     local.get $4
-     local.get $4
+     local.get $10
+     local.get $3
+     local.get $3
      i32.trunc_sat_f32_s
      i32.const 10
      i32.add
      call $~lib/map/Map<f32,i32>#set
-     local.get $11
+     local.get $10
      i32.load $0
-     local.get $11
+     local.get $10
      i32.load $0 offset=4
-     local.get $4
+     local.get $3
      i32.reinterpret_f32
      i32.const -1028477379
      i32.mul
@@ -20665,36 +20856,36 @@
      i32.shl
      i32.add
      i32.load $0
-     local.set $0
+     local.set $2
      block $__inlined_func$~lib/map/Map<f32,i32>#find33
       loop $while-continue|034
-       local.get $0
+       local.get $2
        if
-        local.get $0
+        local.get $2
         i32.load $0 offset=8
-        local.tee $1
+        local.tee $0
         i32.const 1
         i32.and
         if (result i32)
          i32.const 0
         else
-         local.get $0
+         local.get $2
          f32.load $0
-         local.get $4
+         local.get $3
          f32.eq
         end
         br_if $__inlined_func$~lib/map/Map<f32,i32>#find33
-        local.get $1
+        local.get $0
         i32.const -2
         i32.and
-        local.set $0
+        local.set $2
         br $while-continue|034
        end
       end
       i32.const 0
-      local.set $0
+      local.set $2
      end
-     local.get $0
+     local.get $2
      i32.eqz
      if
       i32.const 0
@@ -20704,14 +20895,14 @@
       call $~lib/builtins/abort
       unreachable
      end
-     local.get $11
-     local.get $4
+     local.get $10
+     local.get $3
      call $~lib/map/Map<f32,i32>#delete
-     local.get $11
+     local.get $10
      i32.load $0
-     local.get $11
+     local.get $10
      i32.load $0 offset=4
-     local.get $4
+     local.get $3
      i32.reinterpret_f32
      i32.const -1028477379
      i32.mul
@@ -20745,36 +20936,36 @@
      i32.shl
      i32.add
      i32.load $0
-     local.set $0
+     local.set $2
      block $__inlined_func$~lib/map/Map<f32,i32>#find36
       loop $while-continue|037
-       local.get $0
+       local.get $2
        if
-        local.get $0
+        local.get $2
         i32.load $0 offset=8
-        local.tee $1
+        local.tee $0
         i32.const 1
         i32.and
         if (result i32)
          i32.const 0
         else
-         local.get $0
+         local.get $2
          f32.load $0
-         local.get $4
+         local.get $3
          f32.eq
         end
         br_if $__inlined_func$~lib/map/Map<f32,i32>#find36
-        local.get $1
+        local.get $0
         i32.const -2
         i32.and
-        local.set $0
+        local.set $2
         br $while-continue|037
        end
       end
       i32.const 0
-      local.set $0
+      local.set $2
      end
-     local.get $0
+     local.get $2
      if
       i32.const 0
       i32.const 1568
@@ -20783,14 +20974,14 @@
       call $~lib/builtins/abort
       unreachable
      end
-     local.get $4
+     local.get $3
      f32.const 1
      f32.add
-     local.set $4
+     local.set $3
      br $for-loop|4
     end
    end
-   local.get $11
+   local.get $10
    i32.load $0 offset=20
    i32.const 50
    i32.ne
@@ -20802,9 +20993,9 @@
     call $~lib/builtins/abort
     unreachable
    end
-   local.get $11
+   local.get $10
    call $~lib/map/Map<i8,i32>#clear
-   local.get $11
+   local.get $10
    i32.load $0 offset=20
    if
     i32.const 0
@@ -21245,12 +21436,12 @@
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
-  (local $3 i64)
-  (local $4 i32)
-  (local $5 f64)
+  (local $3 f64)
+  (local $4 i64)
+  (local $5 i32)
   (local $6 i32)
   (local $7 i32)
-  (local $8 f64)
+  (local $8 i32)
   (local $9 i32)
   (local $10 i32)
   (local $11 i32)
@@ -21258,7 +21449,7 @@
   (local $13 i32)
   (local $14 i32)
   (local $15 i32)
-  (local $16 i32)
+  (local $16 f64)
   (local $17 i32)
   (local $18 i32)
   global.get $~lib/memory/__stack_pointer
@@ -21271,11 +21462,11 @@
    i32.lt_s
    br_if $folding-inner1
    global.get $~lib/memory/__stack_pointer
-   local.tee $1
+   local.tee $2
    i32.const 0
    i32.const 20
    memory.fill $0
-   local.get $1
+   local.get $2
    i32.const 8
    i32.sub
    global.set $~lib/memory/__stack_pointer
@@ -21284,10 +21475,10 @@
    i32.lt_s
    br_if $folding-inner1
    global.get $~lib/memory/__stack_pointer
-   local.tee $0
+   local.tee $5
    i64.const 0
    i64.store $0
-   local.get $0
+   local.get $5
    i32.const 24
    i32.const 30
    call $~lib/rt/itcms/__new
@@ -21295,17 +21486,17 @@
    i32.store $0
    i32.const 16
    call $~lib/arraybuffer/ArrayBuffer#constructor
-   local.set $0
+   local.set $5
    global.get $~lib/memory/__stack_pointer
-   local.get $0
+   local.get $5
    i32.store $0 offset=4
    local.get $11
-   local.get $0
+   local.get $5
    i32.store $0
-   local.get $0
+   local.get $5
    if
     local.get $11
-    local.get $0
+    local.get $5
     call $byn-split-outlined-A$~lib/rt/itcms/__link
    end
    local.get $11
@@ -21313,17 +21504,17 @@
    i32.store $0 offset=4
    i32.const 64
    call $~lib/arraybuffer/ArrayBuffer#constructor
-   local.set $0
+   local.set $5
    global.get $~lib/memory/__stack_pointer
-   local.get $0
+   local.get $5
    i32.store $0 offset=4
    local.get $11
-   local.get $0
+   local.get $5
    i32.store $0 offset=8
-   local.get $0
+   local.get $5
    if
     local.get $11
-    local.get $0
+    local.get $5
     call $byn-split-outlined-A$~lib/rt/itcms/__link
    end
    local.get $11
@@ -21339,11 +21530,11 @@
    i32.const 8
    i32.add
    global.set $~lib/memory/__stack_pointer
-   local.get $1
+   local.get $2
    local.get $11
    i32.store $0
    loop $for-loop|0
-    local.get $5
+    local.get $3
     f64.const 100
     f64.lt
     if
@@ -21351,9 +21542,9 @@
      i32.load $0
      local.get $11
      i32.load $0 offset=4
-     local.get $5
+     local.get $3
      i64.reinterpret_f64
-     local.tee $3
+     local.tee $4
      i32.wrap_i64
      i32.const -1028477379
      i32.mul
@@ -21363,7 +21554,7 @@
      i32.rotl
      i32.const 668265263
      i32.mul
-     local.get $3
+     local.get $4
      i64.const 32
      i64.shr_u
      i32.wrap_i64
@@ -21374,22 +21565,22 @@
      i32.rotl
      i32.const 668265263
      i32.mul
-     local.tee $0
-     local.get $0
+     local.tee $2
+     local.get $2
      i32.const 15
      i32.shr_u
      i32.xor
      i32.const -2048144777
      i32.mul
-     local.tee $0
-     local.get $0
+     local.tee $2
+     local.get $2
      i32.const 13
      i32.shr_u
      i32.xor
      i32.const -1028477379
      i32.mul
-     local.tee $0
-     local.get $0
+     local.tee $2
+     local.get $2
      i32.const 16
      i32.shr_u
      i32.xor
@@ -21398,36 +21589,36 @@
      i32.shl
      i32.add
      i32.load $0
-     local.set $0
+     local.set $2
      block $__inlined_func$~lib/map/Map<f64,i32>#find
       loop $while-continue|0
-       local.get $0
+       local.get $2
        if
-        local.get $0
+        local.get $2
         i32.load $0 offset=12
-        local.tee $1
+        local.tee $5
         i32.const 1
         i32.and
         if (result i32)
          i32.const 0
         else
-         local.get $5
-         local.get $0
+         local.get $3
+         local.get $2
          f64.load $0
          f64.eq
         end
         br_if $__inlined_func$~lib/map/Map<f64,i32>#find
-        local.get $1
+        local.get $5
         i32.const -2
         i32.and
-        local.set $0
+        local.set $2
         br $while-continue|0
        end
       end
       i32.const 0
-      local.set $0
+      local.set $2
      end
-     local.get $0
+     local.get $2
      if
       i32.const 0
       i32.const 1568
@@ -21437,8 +21628,8 @@
       unreachable
      end
      local.get $11
-     local.get $5
-     local.get $5
+     local.get $3
+     local.get $3
      i32.trunc_sat_f64_s
      i32.const 10
      i32.add
@@ -21447,9 +21638,9 @@
      i32.load $0
      local.get $11
      i32.load $0 offset=4
-     local.get $5
+     local.get $3
      i64.reinterpret_f64
-     local.tee $3
+     local.tee $4
      i32.wrap_i64
      i32.const -1028477379
      i32.mul
@@ -21459,7 +21650,7 @@
      i32.rotl
      i32.const 668265263
      i32.mul
-     local.get $3
+     local.get $4
      i64.const 32
      i64.shr_u
      i32.wrap_i64
@@ -21470,22 +21661,22 @@
      i32.rotl
      i32.const 668265263
      i32.mul
-     local.tee $0
-     local.get $0
+     local.tee $2
+     local.get $2
      i32.const 15
      i32.shr_u
      i32.xor
      i32.const -2048144777
      i32.mul
-     local.tee $0
-     local.get $0
+     local.tee $2
+     local.get $2
      i32.const 13
      i32.shr_u
      i32.xor
      i32.const -1028477379
      i32.mul
-     local.tee $0
-     local.get $0
+     local.tee $2
+     local.get $2
      i32.const 16
      i32.shr_u
      i32.xor
@@ -21494,36 +21685,36 @@
      i32.shl
      i32.add
      i32.load $0
-     local.set $0
+     local.set $2
      block $__inlined_func$~lib/map/Map<f64,i32>#find1
       loop $while-continue|05
-       local.get $0
+       local.get $2
        if
-        local.get $0
+        local.get $2
         i32.load $0 offset=12
-        local.tee $1
+        local.tee $5
         i32.const 1
         i32.and
         if (result i32)
          i32.const 0
         else
-         local.get $5
-         local.get $0
+         local.get $3
+         local.get $2
          f64.load $0
          f64.eq
         end
         br_if $__inlined_func$~lib/map/Map<f64,i32>#find1
-        local.get $1
+        local.get $5
         i32.const -2
         i32.and
-        local.set $0
+        local.set $2
         br $while-continue|05
        end
       end
       i32.const 0
-      local.set $0
+      local.set $2
      end
-     local.get $0
+     local.get $2
      i32.eqz
      if
       i32.const 0
@@ -21534,9 +21725,9 @@
       unreachable
      end
      local.get $11
-     local.get $5
+     local.get $3
      call $~lib/map/Map<f64,i32>#get
-     local.get $5
+     local.get $3
      i32.trunc_sat_f64_s
      i32.const 10
      i32.add
@@ -21549,10 +21740,10 @@
       call $~lib/builtins/abort
       unreachable
      end
-     local.get $5
+     local.get $3
      f64.const 1
      f64.add
-     local.set $5
+     local.set $3
      br $for-loop|0
     end
    end
@@ -21569,9 +21760,9 @@
     unreachable
    end
    f64.const 0
-   local.set $5
+   local.set $3
    loop $for-loop|1
-    local.get $5
+    local.get $3
     f64.const 100
     f64.lt
     if
@@ -21579,9 +21770,9 @@
      i32.load $0
      local.get $11
      i32.load $0 offset=4
-     local.get $5
+     local.get $3
      i64.reinterpret_f64
-     local.tee $3
+     local.tee $4
      i32.wrap_i64
      i32.const -1028477379
      i32.mul
@@ -21591,7 +21782,7 @@
      i32.rotl
      i32.const 668265263
      i32.mul
-     local.get $3
+     local.get $4
      i64.const 32
      i64.shr_u
      i32.wrap_i64
@@ -21602,22 +21793,22 @@
      i32.rotl
      i32.const 668265263
      i32.mul
-     local.tee $0
-     local.get $0
+     local.tee $2
+     local.get $2
      i32.const 15
      i32.shr_u
      i32.xor
      i32.const -2048144777
      i32.mul
-     local.tee $0
-     local.get $0
+     local.tee $2
+     local.get $2
      i32.const 13
      i32.shr_u
      i32.xor
      i32.const -1028477379
      i32.mul
-     local.tee $0
-     local.get $0
+     local.tee $2
+     local.get $2
      i32.const 16
      i32.shr_u
      i32.xor
@@ -21626,36 +21817,36 @@
      i32.shl
      i32.add
      i32.load $0
-     local.set $0
+     local.set $2
      block $__inlined_func$~lib/map/Map<f64,i32>#find8
       loop $while-continue|012
-       local.get $0
+       local.get $2
        if
-        local.get $0
+        local.get $2
         i32.load $0 offset=12
-        local.tee $1
+        local.tee $5
         i32.const 1
         i32.and
         if (result i32)
          i32.const 0
         else
-         local.get $5
-         local.get $0
+         local.get $3
+         local.get $2
          f64.load $0
          f64.eq
         end
         br_if $__inlined_func$~lib/map/Map<f64,i32>#find8
-        local.get $1
+        local.get $5
         i32.const -2
         i32.and
-        local.set $0
+        local.set $2
         br $while-continue|012
        end
       end
       i32.const 0
-      local.set $0
+      local.set $2
      end
-     local.get $0
+     local.get $2
      i32.eqz
      if
       i32.const 0
@@ -21666,9 +21857,9 @@
       unreachable
      end
      local.get $11
-     local.get $5
+     local.get $3
      call $~lib/map/Map<f64,i32>#get
-     local.get $5
+     local.get $3
      i32.trunc_sat_f64_s
      i32.const 10
      i32.add
@@ -21682,8 +21873,8 @@
       unreachable
      end
      local.get $11
-     local.get $5
-     local.get $5
+     local.get $3
+     local.get $3
      i32.trunc_sat_f64_s
      i32.const 20
      i32.add
@@ -21692,9 +21883,9 @@
      i32.load $0
      local.get $11
      i32.load $0 offset=4
-     local.get $5
+     local.get $3
      i64.reinterpret_f64
-     local.tee $3
+     local.tee $4
      i32.wrap_i64
      i32.const -1028477379
      i32.mul
@@ -21704,7 +21895,7 @@
      i32.rotl
      i32.const 668265263
      i32.mul
-     local.get $3
+     local.get $4
      i64.const 32
      i64.shr_u
      i32.wrap_i64
@@ -21715,22 +21906,22 @@
      i32.rotl
      i32.const 668265263
      i32.mul
-     local.tee $0
-     local.get $0
+     local.tee $2
+     local.get $2
      i32.const 15
      i32.shr_u
      i32.xor
      i32.const -2048144777
      i32.mul
-     local.tee $0
-     local.get $0
+     local.tee $2
+     local.get $2
      i32.const 13
      i32.shr_u
      i32.xor
      i32.const -1028477379
      i32.mul
-     local.tee $0
-     local.get $0
+     local.tee $2
+     local.get $2
      i32.const 16
      i32.shr_u
      i32.xor
@@ -21739,36 +21930,36 @@
      i32.shl
      i32.add
      i32.load $0
-     local.set $0
+     local.set $2
      block $__inlined_func$~lib/map/Map<f64,i32>#find15
       loop $while-continue|019
-       local.get $0
+       local.get $2
        if
-        local.get $0
+        local.get $2
         i32.load $0 offset=12
-        local.tee $1
+        local.tee $5
         i32.const 1
         i32.and
         if (result i32)
          i32.const 0
         else
-         local.get $5
-         local.get $0
+         local.get $3
+         local.get $2
          f64.load $0
          f64.eq
         end
         br_if $__inlined_func$~lib/map/Map<f64,i32>#find15
-        local.get $1
+        local.get $5
         i32.const -2
         i32.and
-        local.set $0
+        local.set $2
         br $while-continue|019
        end
       end
       i32.const 0
-      local.set $0
+      local.set $2
      end
-     local.get $0
+     local.get $2
      i32.eqz
      if
       i32.const 0
@@ -21779,9 +21970,9 @@
       unreachable
      end
      local.get $11
-     local.get $5
+     local.get $3
      call $~lib/map/Map<f64,i32>#get
-     local.get $5
+     local.get $3
      i32.trunc_sat_f64_s
      i32.const 20
      i32.add
@@ -21794,10 +21985,10 @@
       call $~lib/builtins/abort
       unreachable
      end
-     local.get $5
+     local.get $3
      f64.const 1
      f64.add
-     local.set $5
+     local.set $3
      br $for-loop|1
     end
    end
@@ -21814,7 +22005,7 @@
     unreachable
    end
    global.get $~lib/memory/__stack_pointer
-   local.tee $9
+   local.tee $5
    i32.const 4
    i32.sub
    global.set $~lib/memory/__stack_pointer
@@ -21823,7 +22014,7 @@
    i32.lt_s
    br_if $folding-inner1
    global.get $~lib/memory/__stack_pointer
-   local.tee $7
+   local.tee $2
    i32.const 0
    i32.store $0
    local.get $11
@@ -21831,8 +22022,8 @@
    local.set $6
    local.get $11
    i32.load $0 offset=16
-   local.set $4
-   local.get $7
+   local.set $7
+   local.get $2
    i32.const 8
    i32.sub
    global.set $~lib/memory/__stack_pointer
@@ -21841,28 +22032,28 @@
    i32.lt_s
    br_if $folding-inner1
    global.get $~lib/memory/__stack_pointer
-   local.tee $0
+   local.tee $8
    i64.const 0
    i64.store $0
-   local.get $0
+   local.get $8
    i32.const 16
    i32.const 31
    call $~lib/rt/itcms/__new
-   local.tee $2
+   local.tee $12
    i32.store $0
-   local.get $2
+   local.get $12
    i32.const 0
    i32.store $0
-   local.get $2
+   local.get $12
    i32.const 0
    i32.store $0 offset=4
-   local.get $2
+   local.get $12
    i32.const 0
    i32.store $0 offset=8
-   local.get $2
+   local.get $12
    i32.const 0
    i32.store $0 offset=12
-   local.get $4
+   local.get $7
    i32.const 134217727
    i32.gt_u
    if
@@ -21875,103 +22066,133 @@
    end
    global.get $~lib/memory/__stack_pointer
    i32.const 8
-   local.get $4
-   local.get $4
+   local.get $7
+   local.get $7
    i32.const 8
    i32.le_u
    select
    i32.const 3
    i32.shl
-   local.tee $1
+   local.tee $8
    i32.const 1
    call $~lib/rt/itcms/__new
-   local.tee $0
+   local.tee $9
    i32.store $0 offset=4
-   local.get $2
-   local.get $0
+   local.get $12
+   local.get $9
    i32.store $0
-   local.get $0
+   local.get $9
    if
-    local.get $2
-    local.get $0
+    local.get $12
+    local.get $9
     call $byn-split-outlined-A$~lib/rt/itcms/__link
    end
-   local.get $2
-   local.get $0
+   local.get $12
+   local.get $9
    i32.store $0 offset=4
-   local.get $2
-   local.get $1
+   local.get $12
+   local.get $8
    i32.store $0 offset=8
-   local.get $2
-   local.get $4
+   local.get $12
+   local.get $7
    i32.store $0 offset=12
    global.get $~lib/memory/__stack_pointer
    i32.const 8
    i32.add
    global.set $~lib/memory/__stack_pointer
-   local.get $7
    local.get $2
+   local.get $12
    i32.store $0
-   i32.const 0
-   local.set $0
    loop $for-loop|03
-    local.get $4
-    local.get $10
-    i32.gt_s
+    local.get $0
+    local.get $7
+    i32.lt_s
     if
      local.get $6
-     local.get $10
+     local.get $0
      i32.const 4
      i32.shl
      i32.add
-     local.tee $1
+     local.tee $2
      i32.load $0 offset=12
      i32.const 1
      i32.and
      i32.eqz
      if
       local.get $2
+      f64.load $0
+      local.set $3
+      local.get $1
+      local.tee $2
+      i32.const 1
+      i32.add
+      local.set $1
+      local.get $2
+      local.get $12
+      i32.load $0 offset=12
+      i32.ge_u
+      if
+       local.get $2
+       i32.const 0
+       i32.lt_s
+       if
+        i32.const 1248
+        i32.const 1728
+        i32.const 130
+        i32.const 22
+        call $~lib/builtins/abort
+        unreachable
+       end
+       local.get $12
+       local.get $2
+       i32.const 1
+       i32.add
+       local.tee $8
+       i32.const 3
+       i32.const 1
+       call $~lib/array/ensureCapacity
+       local.get $12
+       local.get $8
+       i32.store $0 offset=12
+      end
+      local.get $12
       i32.load $0 offset=4
-      local.get $0
+      local.get $2
       i32.const 3
       i32.shl
       i32.add
-      local.get $1
-      f64.load $0
+      local.get $3
       f64.store $0
-      local.get $0
-      i32.const 1
-      i32.add
-      local.set $0
      end
-     local.get $10
+     local.get $0
      i32.const 1
      i32.add
-     local.set $10
+     local.set $0
      br $for-loop|03
     end
    end
-   local.get $2
-   local.get $0
+   local.get $12
+   local.get $1
    i32.const 3
+   i32.const 0
    call $~lib/array/ensureCapacity
-   local.get $2
-   local.get $0
+   local.get $12
+   local.get $1
    i32.store $0 offset=12
    global.get $~lib/memory/__stack_pointer
    i32.const 4
    i32.add
    global.set $~lib/memory/__stack_pointer
-   local.get $9
-   local.get $2
+   local.get $5
+   local.get $12
    i32.store $0 offset=4
    global.get $~lib/memory/__stack_pointer
    local.get $11
    call $~lib/map/Map<i64,i32>#values
-   local.tee $10
+   local.tee $13
    i32.store $0 offset=8
    global.get $~lib/memory/__stack_pointer
-   local.set $1
+   local.set $0
    global.get $~lib/memory/__stack_pointer
    i32.const 8
    i32.sub
@@ -21981,76 +22202,78 @@
    i32.lt_s
    br_if $folding-inner1
    global.get $~lib/memory/__stack_pointer
-   local.tee $0
+   local.tee $1
    i64.const 0
    i64.store $0
-   local.get $0
+   local.get $1
    i32.const 24
    i32.const 32
    call $~lib/rt/itcms/__new
-   local.tee $14
+   local.tee $8
    i32.store $0
    i32.const 16
    call $~lib/arraybuffer/ArrayBuffer#constructor
-   local.set $0
+   local.set $1
    global.get $~lib/memory/__stack_pointer
-   local.get $0
+   local.get $1
    i32.store $0 offset=4
-   local.get $14
-   local.get $0
+   local.get $8
+   local.get $1
    i32.store $0
-   local.get $0
+   local.get $1
    if
-    local.get $14
-    local.get $0
+    local.get $8
+    local.get $1
     call $byn-split-outlined-A$~lib/rt/itcms/__link
    end
-   local.get $14
+   local.get $8
    i32.const 3
    i32.store $0 offset=4
    i32.const 96
    call $~lib/arraybuffer/ArrayBuffer#constructor
-   local.set $0
+   local.set $1
    global.get $~lib/memory/__stack_pointer
-   local.get $0
+   local.get $1
    i32.store $0 offset=4
-   local.get $14
-   local.get $0
+   local.get $8
+   local.get $1
    i32.store $0 offset=8
-   local.get $0
+   local.get $1
    if
-    local.get $14
-    local.get $0
+    local.get $8
+    local.get $1
     call $byn-split-outlined-A$~lib/rt/itcms/__link
    end
-   local.get $14
+   local.get $8
    i32.const 4
    i32.store $0 offset=12
-   local.get $14
+   local.get $8
    i32.const 0
    i32.store $0 offset=16
-   local.get $14
+   local.get $8
    i32.const 0
    i32.store $0 offset=20
    global.get $~lib/memory/__stack_pointer
    i32.const 8
    i32.add
    global.set $~lib/memory/__stack_pointer
-   local.get $1
-   local.get $14
+   local.get $0
+   local.get $8
    i32.store $0 offset=12
    global.get $~lib/memory/__stack_pointer
    call $~lib/map/Map<i32,i32>#constructor
-   local.tee $9
+   local.tee $14
    i32.store $0 offset=16
+   i32.const 0
+   local.set $1
    loop $for-loop|2
-    local.get $17
-    local.get $2
+    local.get $1
+    local.get $12
     i32.load $0 offset=12
     i32.lt_s
     if
-     local.get $17
-     local.get $2
+     local.get $1
+     local.get $12
      i32.load $0 offset=12
      i32.ge_u
      if
@@ -22061,25 +22284,25 @@
       call $~lib/builtins/abort
       unreachable
      end
-     local.get $2
+     local.get $12
      i32.load $0 offset=4
-     local.get $17
+     local.get $1
      i32.const 3
      i32.shl
      i32.add
      f64.load $0
-     local.set $8
-     local.get $10
-     local.get $17
+     local.set $3
+     local.get $13
+     local.get $1
      call $~lib/array/Array<i32>#__get
-     local.set $7
+     local.set $15
      local.get $11
      i32.load $0
      local.get $11
      i32.load $0 offset=4
-     local.get $8
+     local.get $3
      i64.reinterpret_f64
-     local.tee $3
+     local.tee $4
      i32.wrap_i64
      i32.const -1028477379
      i32.mul
@@ -22089,7 +22312,7 @@
      i32.rotl
      i32.const 668265263
      i32.mul
-     local.get $3
+     local.get $4
      i64.const 32
      i64.shr_u
      i32.wrap_i64
@@ -22125,29 +22348,29 @@
      i32.add
      i32.load $0
      local.set $0
-     block $__inlined_func$~lib/map/Map<f64,i32>#find38
-      loop $while-continue|042
+     block $__inlined_func$~lib/map/Map<f64,i32>#find40
+      loop $while-continue|044
        local.get $0
        if
         local.get $0
         i32.load $0 offset=12
-        local.tee $1
+        local.tee $2
         i32.const 1
         i32.and
         if (result i32)
          i32.const 0
         else
-         local.get $8
+         local.get $3
          local.get $0
          f64.load $0
          f64.eq
         end
-        br_if $__inlined_func$~lib/map/Map<f64,i32>#find38
-        local.get $1
+        br_if $__inlined_func$~lib/map/Map<f64,i32>#find40
+        local.get $2
         i32.const -2
         i32.and
         local.set $0
-        br $while-continue|042
+        br $while-continue|044
        end
       end
       i32.const 0
@@ -22167,13 +22390,13 @@
      i32.load $0
      local.get $11
      i32.load $0 offset=4
-     local.get $7
+     local.get $15
      i32.const 20
      i32.sub
      f64.convert_i32_s
-     local.tee $5
+     local.tee $16
      i64.reinterpret_f64
-     local.tee $3
+     local.tee $4
      i32.wrap_i64
      i32.const -1028477379
      i32.mul
@@ -22183,7 +22406,7 @@
      i32.rotl
      i32.const 668265263
      i32.mul
-     local.get $3
+     local.get $4
      i64.const 32
      i64.shr_u
      i32.wrap_i64
@@ -22219,29 +22442,29 @@
      i32.add
      i32.load $0
      local.set $0
-     block $__inlined_func$~lib/map/Map<f64,i32>#find45
-      loop $while-continue|049
+     block $__inlined_func$~lib/map/Map<f64,i32>#find47
+      loop $while-continue|051
        local.get $0
        if
         local.get $0
         i32.load $0 offset=12
-        local.tee $1
+        local.tee $2
         i32.const 1
         i32.and
         if (result i32)
          i32.const 0
         else
-         local.get $5
+         local.get $16
          local.get $0
          f64.load $0
          f64.eq
         end
-        br_if $__inlined_func$~lib/map/Map<f64,i32>#find45
-        local.get $1
+        br_if $__inlined_func$~lib/map/Map<f64,i32>#find47
+        local.get $2
         i32.const -2
         i32.and
         local.set $0
-        br $while-continue|049
+        br $while-continue|051
        end
       end
       i32.const 0
@@ -22268,11 +22491,11 @@
      global.get $~lib/memory/__stack_pointer
      i32.const 0
      i32.store $0
-     local.get $14
-     i32.load $0
      local.get $8
+     i32.load $0
+     local.get $3
      i64.reinterpret_f64
-     local.tee $3
+     local.tee $4
      i32.wrap_i64
      i32.const -1028477379
      i32.mul
@@ -22282,7 +22505,7 @@
      i32.rotl
      i32.const 668265263
      i32.mul
-     local.get $3
+     local.get $4
      i64.const 32
      i64.shr_u
      i32.wrap_i64
@@ -22312,8 +22535,8 @@
      i32.const 16
      i32.shr_u
      i32.xor
-     local.tee $6
-     local.get $14
+     local.tee $17
+     local.get $8
      i32.load $0 offset=4
      i32.and
      i32.const 2
@@ -22322,28 +22545,28 @@
      i32.load $0
      local.set $0
      block $__inlined_func$~lib/map/Map<f64,f64>#find
-      loop $while-continue|056
+      loop $while-continue|058
        local.get $0
        if
         local.get $0
         i32.load $0 offset=16
-        local.tee $1
+        local.tee $2
         i32.const 1
         i32.and
         if (result i32)
          i32.const 0
         else
-         local.get $8
+         local.get $3
          local.get $0
          f64.load $0
          f64.eq
         end
         br_if $__inlined_func$~lib/map/Map<f64,f64>#find
-        local.get $1
+        local.get $2
         i32.const -2
         i32.and
         local.set $0
-        br $while-continue|056
+        br $while-continue|058
        end
       end
       i32.const 0
@@ -22352,18 +22575,18 @@
      local.get $0
      if
       local.get $0
-      local.get $8
+      local.get $3
       f64.store $0 offset=8
      else
-      local.get $14
+      local.get $8
       i32.load $0 offset=16
-      local.get $14
+      local.get $8
       i32.load $0 offset=12
       i32.eq
       if
-       local.get $14
+       local.get $8
        i32.load $0 offset=20
-       local.get $14
+       local.get $8
        i32.load $0 offset=12
        i32.const 3
        i32.mul
@@ -22371,17 +22594,17 @@
        i32.div_s
        i32.lt_s
        if (result i32)
-        local.get $14
+        local.get $8
         i32.load $0 offset=4
        else
-        local.get $14
+        local.get $8
         i32.load $0 offset=4
         i32.const 1
         i32.shl
         i32.const 1
         i32.or
        end
-       local.set $13
+       local.set $9
        global.get $~lib/memory/__stack_pointer
        i32.const 8
        i32.sub
@@ -22395,14 +22618,14 @@
        i64.const 0
        i64.store $0
        local.get $0
-       local.get $13
+       local.get $9
        i32.const 1
        i32.add
        local.tee $0
        i32.const 2
        i32.shl
        call $~lib/arraybuffer/ArrayBuffer#constructor
-       local.tee $12
+       local.tee $10
        i32.store $0
        global.get $~lib/memory/__stack_pointer
        local.get $0
@@ -22410,49 +22633,49 @@
        i32.shl
        i32.const 3
        i32.div_s
-       local.tee $16
+       local.tee $6
        i32.const 24
        i32.mul
        call $~lib/arraybuffer/ArrayBuffer#constructor
-       local.tee $1
+       local.tee $2
        i32.store $0 offset=4
-       local.get $14
+       local.get $8
        i32.load $0 offset=8
-       local.tee $18
-       local.get $14
+       local.tee $5
+       local.get $8
        i32.load $0 offset=16
        i32.const 24
        i32.mul
        i32.add
-       local.set $15
-       local.get $1
+       local.set $7
+       local.get $2
        local.set $0
        loop $while-continue|00
-        local.get $15
-        local.get $18
+        local.get $5
+        local.get $7
         i32.ne
         if
-         local.get $18
+         local.get $5
          i32.load $0 offset=16
          i32.const 1
          i32.and
          i32.eqz
          if
           local.get $0
-          local.get $18
+          local.get $5
           f64.load $0
-          local.tee $5
+          local.tee $16
           f64.store $0
           local.get $0
-          local.get $18
+          local.get $5
           f64.load $0 offset=8
           f64.store $0 offset=8
           local.get $0
-          local.get $12
-          local.get $13
-          local.get $5
+          local.get $10
+          local.get $9
+          local.get $16
           i64.reinterpret_f64
-          local.tee $3
+          local.tee $4
           i32.wrap_i64
           i32.const -1028477379
           i32.mul
@@ -22462,7 +22685,7 @@
           i32.rotl
           i32.const 668265263
           i32.mul
-          local.get $3
+          local.get $4
           i64.const 32
           i64.shr_u
           i32.wrap_i64
@@ -22473,22 +22696,22 @@
           i32.rotl
           i32.const 668265263
           i32.mul
-          local.tee $4
-          local.get $4
+          local.tee $18
+          local.get $18
           i32.const 15
           i32.shr_u
           i32.xor
           i32.const -2048144777
           i32.mul
-          local.tee $4
-          local.get $4
+          local.tee $18
+          local.get $18
           i32.const 13
           i32.shr_u
           i32.xor
           i32.const -1028477379
           i32.mul
-          local.tee $4
-          local.get $4
+          local.tee $18
+          local.get $18
           i32.const 16
           i32.shr_u
           i32.xor
@@ -22496,10 +22719,10 @@
           i32.const 2
           i32.shl
           i32.add
-          local.tee $4
+          local.tee $18
           i32.load $0
           i32.store $0 offset=16
-          local.get $4
+          local.get $18
           local.get $0
           i32.store $0
           local.get $0
@@ -22507,39 +22730,39 @@
           i32.add
           local.set $0
          end
-         local.get $18
+         local.get $5
          i32.const 24
          i32.add
-         local.set $18
+         local.set $5
          br $while-continue|00
         end
        end
-       local.get $14
-       local.get $12
+       local.get $8
+       local.get $10
        i32.store $0
-       local.get $12
+       local.get $10
        if
-        local.get $14
-        local.get $12
+        local.get $8
+        local.get $10
         call $byn-split-outlined-A$~lib/rt/itcms/__link
        end
-       local.get $14
-       local.get $13
+       local.get $8
+       local.get $9
        i32.store $0 offset=4
-       local.get $14
-       local.get $1
+       local.get $8
+       local.get $2
        i32.store $0 offset=8
-       local.get $1
+       local.get $2
        if
-        local.get $14
-        local.get $1
+        local.get $8
+        local.get $2
         call $byn-split-outlined-A$~lib/rt/itcms/__link
        end
-       local.get $14
-       local.get $16
+       local.get $8
+       local.get $6
        i32.store $0 offset=12
-       local.get $14
-       local.get $14
+       local.get $8
+       local.get $8
        i32.load $0 offset=20
        i32.store $0 offset=16
        global.get $~lib/memory/__stack_pointer
@@ -22548,70 +22771,70 @@
        global.set $~lib/memory/__stack_pointer
       end
       global.get $~lib/memory/__stack_pointer
-      local.get $14
+      local.get $8
       i32.load $0 offset=8
-      local.tee $1
-      i32.store $0
-      local.get $14
-      local.get $14
-      i32.load $0 offset=16
       local.tee $0
+      i32.store $0
+      local.get $8
+      local.get $8
+      i32.load $0 offset=16
+      local.tee $2
       i32.const 1
       i32.add
       i32.store $0 offset=16
-      local.get $1
       local.get $0
+      local.get $2
       i32.const 24
       i32.mul
       i32.add
-      local.tee $1
-      local.get $8
+      local.tee $0
+      local.get $3
       f64.store $0
-      local.get $1
-      local.get $8
+      local.get $0
+      local.get $3
       f64.store $0 offset=8
-      local.get $14
-      local.get $14
+      local.get $8
+      local.get $8
       i32.load $0 offset=20
       i32.const 1
       i32.add
       i32.store $0 offset=20
-      local.get $1
-      local.get $14
+      local.get $0
+      local.get $8
       i32.load $0
-      local.get $6
-      local.get $14
+      local.get $17
+      local.get $8
       i32.load $0 offset=4
       i32.and
       i32.const 2
       i32.shl
       i32.add
-      local.tee $0
+      local.tee $2
       i32.load $0
       i32.store $0 offset=16
+      local.get $2
       local.get $0
-      local.get $1
       i32.store $0
      end
      global.get $~lib/memory/__stack_pointer
      i32.const 4
      i32.add
      global.set $~lib/memory/__stack_pointer
-     local.get $9
-     local.get $7
+     local.get $14
+     local.get $15
      i32.const 20
      i32.sub
      local.tee $0
      local.get $0
      call $~lib/map/Map<i32,i32>#set
-     local.get $17
+     local.get $1
      i32.const 1
      i32.add
-     local.set $17
+     local.set $1
      br $for-loop|2
     end
    end
-   local.get $14
+   local.get $8
    i32.load $0 offset=20
    i32.const 100
    i32.ne
@@ -22623,7 +22846,7 @@
     call $~lib/builtins/abort
     unreachable
    end
-   local.get $9
+   local.get $14
    i32.load $0 offset=20
    i32.const 100
    i32.ne
@@ -22636,9 +22859,9 @@
     unreachable
    end
    f64.const 0
-   local.set $5
+   local.set $3
    loop $for-loop|3
-    local.get $5
+    local.get $3
     f64.const 50
     f64.lt
     if
@@ -22646,9 +22869,9 @@
      i32.load $0
      local.get $11
      i32.load $0 offset=4
-     local.get $5
+     local.get $3
      i64.reinterpret_f64
-     local.tee $3
+     local.tee $4
      i32.wrap_i64
      i32.const -1028477379
      i32.mul
@@ -22658,7 +22881,7 @@
      i32.rotl
      i32.const 668265263
      i32.mul
-     local.get $3
+     local.get $4
      i64.const 32
      i64.shr_u
      i32.wrap_i64
@@ -22693,36 +22916,36 @@
      i32.shl
      i32.add
      i32.load $0
-     local.set $0
-     block $__inlined_func$~lib/map/Map<f64,i32>#find77
-      loop $while-continue|081
-       local.get $0
+     local.set $2
+     block $__inlined_func$~lib/map/Map<f64,i32>#find79
+      loop $while-continue|083
+       local.get $2
        if
-        local.get $0
+        local.get $2
         i32.load $0 offset=12
-        local.tee $1
+        local.tee $0
         i32.const 1
         i32.and
         if (result i32)
          i32.const 0
         else
-         local.get $5
-         local.get $0
+         local.get $3
+         local.get $2
          f64.load $0
          f64.eq
         end
-        br_if $__inlined_func$~lib/map/Map<f64,i32>#find77
-        local.get $1
+        br_if $__inlined_func$~lib/map/Map<f64,i32>#find79
+        local.get $0
         i32.const -2
         i32.and
-        local.set $0
-        br $while-continue|081
+        local.set $2
+        br $while-continue|083
        end
       end
       i32.const 0
-      local.set $0
+      local.set $2
      end
-     local.get $0
+     local.get $2
      i32.eqz
      if
       i32.const 0
@@ -22733,9 +22956,9 @@
       unreachable
      end
      local.get $11
-     local.get $5
+     local.get $3
      call $~lib/map/Map<f64,i32>#get
-     local.get $5
+     local.get $3
      i32.trunc_sat_f64_s
      i32.const 20
      i32.add
@@ -22749,15 +22972,15 @@
       unreachable
      end
      local.get $11
-     local.get $5
+     local.get $3
      call $~lib/map/Map<f64,i32>#delete
      local.get $11
      i32.load $0
      local.get $11
      i32.load $0 offset=4
-     local.get $5
+     local.get $3
      i64.reinterpret_f64
-     local.tee $3
+     local.tee $4
      i32.wrap_i64
      i32.const -1028477379
      i32.mul
@@ -22767,7 +22990,7 @@
      i32.rotl
      i32.const 668265263
      i32.mul
-     local.get $3
+     local.get $4
      i64.const 32
      i64.shr_u
      i32.wrap_i64
@@ -22802,36 +23025,36 @@
      i32.shl
      i32.add
      i32.load $0
-     local.set $0
-     block $__inlined_func$~lib/map/Map<f64,i32>#find84
-      loop $while-continue|088
-       local.get $0
+     local.set $2
+     block $__inlined_func$~lib/map/Map<f64,i32>#find86
+      loop $while-continue|090
+       local.get $2
        if
-        local.get $0
+        local.get $2
         i32.load $0 offset=12
-        local.tee $1
+        local.tee $0
         i32.const 1
         i32.and
         if (result i32)
          i32.const 0
         else
-         local.get $5
-         local.get $0
+         local.get $3
+         local.get $2
          f64.load $0
          f64.eq
         end
-        br_if $__inlined_func$~lib/map/Map<f64,i32>#find84
-        local.get $1
+        br_if $__inlined_func$~lib/map/Map<f64,i32>#find86
+        local.get $0
         i32.const -2
         i32.and
-        local.set $0
-        br $while-continue|088
+        local.set $2
+        br $while-continue|090
        end
       end
       i32.const 0
-      local.set $0
+      local.set $2
      end
-     local.get $0
+     local.get $2
      if
       i32.const 0
       i32.const 1568
@@ -22840,10 +23063,10 @@
       call $~lib/builtins/abort
       unreachable
      end
-     local.get $5
+     local.get $3
      f64.const 1
      f64.add
-     local.set $5
+     local.set $3
      br $for-loop|3
     end
    end
@@ -22860,9 +23083,9 @@
     unreachable
    end
    f64.const 0
-   local.set $5
+   local.set $3
    loop $for-loop|4
-    local.get $5
+    local.get $3
     f64.const 50
     f64.lt
     if
@@ -22870,9 +23093,9 @@
      i32.load $0
      local.get $11
      i32.load $0 offset=4
-     local.get $5
+     local.get $3
      i64.reinterpret_f64
-     local.tee $3
+     local.tee $4
      i32.wrap_i64
      i32.const -1028477379
      i32.mul
@@ -22882,7 +23105,7 @@
      i32.rotl
      i32.const 668265263
      i32.mul
-     local.get $3
+     local.get $4
      i64.const 32
      i64.shr_u
      i32.wrap_i64
@@ -22917,36 +23140,36 @@
      i32.shl
      i32.add
      i32.load $0
-     local.set $0
-     block $__inlined_func$~lib/map/Map<f64,i32>#find93
-      loop $while-continue|097
-       local.get $0
+     local.set $2
+     block $__inlined_func$~lib/map/Map<f64,i32>#find95
+      loop $while-continue|099
+       local.get $2
        if
-        local.get $0
+        local.get $2
         i32.load $0 offset=12
-        local.tee $1
+        local.tee $0
         i32.const 1
         i32.and
         if (result i32)
          i32.const 0
         else
-         local.get $5
-         local.get $0
+         local.get $3
+         local.get $2
          f64.load $0
          f64.eq
         end
-        br_if $__inlined_func$~lib/map/Map<f64,i32>#find93
-        local.get $1
+        br_if $__inlined_func$~lib/map/Map<f64,i32>#find95
+        local.get $0
         i32.const -2
         i32.and
-        local.set $0
-        br $while-continue|097
+        local.set $2
+        br $while-continue|099
        end
       end
       i32.const 0
-      local.set $0
+      local.set $2
      end
-     local.get $0
+     local.get $2
      if
       i32.const 0
       i32.const 1568
@@ -22956,8 +23179,8 @@
       unreachable
      end
      local.get $11
-     local.get $5
-     local.get $5
+     local.get $3
+     local.get $3
      i32.trunc_sat_f64_s
      i32.const 10
      i32.add
@@ -22966,9 +23189,9 @@
      i32.load $0
      local.get $11
      i32.load $0 offset=4
-     local.get $5
+     local.get $3
      i64.reinterpret_f64
-     local.tee $3
+     local.tee $4
      i32.wrap_i64
      i32.const -1028477379
      i32.mul
@@ -22978,7 +23201,7 @@
      i32.rotl
      i32.const 668265263
      i32.mul
-     local.get $3
+     local.get $4
      i64.const 32
      i64.shr_u
      i32.wrap_i64
@@ -23013,36 +23236,36 @@
      i32.shl
      i32.add
      i32.load $0
-     local.set $0
-     block $__inlined_func$~lib/map/Map<f64,i32>#find100
-      loop $while-continue|0104
-       local.get $0
+     local.set $2
+     block $__inlined_func$~lib/map/Map<f64,i32>#find102
+      loop $while-continue|0106
+       local.get $2
        if
-        local.get $0
+        local.get $2
         i32.load $0 offset=12
-        local.tee $1
+        local.tee $0
         i32.const 1
         i32.and
         if (result i32)
          i32.const 0
         else
-         local.get $5
-         local.get $0
+         local.get $3
+         local.get $2
          f64.load $0
          f64.eq
         end
-        br_if $__inlined_func$~lib/map/Map<f64,i32>#find100
-        local.get $1
+        br_if $__inlined_func$~lib/map/Map<f64,i32>#find102
+        local.get $0
         i32.const -2
         i32.and
-        local.set $0
-        br $while-continue|0104
+        local.set $2
+        br $while-continue|0106
        end
       end
       i32.const 0
-      local.set $0
+      local.set $2
      end
-     local.get $0
+     local.get $2
      i32.eqz
      if
       i32.const 0
@@ -23053,15 +23276,15 @@
       unreachable
      end
      local.get $11
-     local.get $5
+     local.get $3
      call $~lib/map/Map<f64,i32>#delete
      local.get $11
      i32.load $0
      local.get $11
      i32.load $0 offset=4
-     local.get $5
+     local.get $3
      i64.reinterpret_f64
-     local.tee $3
+     local.tee $4
      i32.wrap_i64
      i32.const -1028477379
      i32.mul
@@ -23071,7 +23294,7 @@
      i32.rotl
      i32.const 668265263
      i32.mul
-     local.get $3
+     local.get $4
      i64.const 32
      i64.shr_u
      i32.wrap_i64
@@ -23106,36 +23329,36 @@
      i32.shl
      i32.add
      i32.load $0
-     local.set $0
-     block $__inlined_func$~lib/map/Map<f64,i32>#find107
-      loop $while-continue|0111
-       local.get $0
+     local.set $2
+     block $__inlined_func$~lib/map/Map<f64,i32>#find109
+      loop $while-continue|0113
+       local.get $2
        if
-        local.get $0
+        local.get $2
         i32.load $0 offset=12
-        local.tee $1
+        local.tee $0
         i32.const 1
         i32.and
         if (result i32)
          i32.const 0
         else
-         local.get $5
-         local.get $0
+         local.get $3
+         local.get $2
          f64.load $0
          f64.eq
         end
-        br_if $__inlined_func$~lib/map/Map<f64,i32>#find107
-        local.get $1
+        br_if $__inlined_func$~lib/map/Map<f64,i32>#find109
+        local.get $0
         i32.const -2
         i32.and
-        local.set $0
-        br $while-continue|0111
+        local.set $2
+        br $while-continue|0113
        end
       end
       i32.const 0
-      local.set $0
+      local.set $2
      end
-     local.get $0
+     local.get $2
      if
       i32.const 0
       i32.const 1568
@@ -23144,10 +23367,10 @@
       call $~lib/builtins/abort
       unreachable
      end
-     local.get $5
+     local.get $3
      f64.const 1
      f64.add
-     local.set $5
+     local.set $3
      br $for-loop|4
     end
    end
@@ -23895,14 +24118,10 @@
     i32.eqz
     if
      local.get $4
-     i32.load $0 offset=4
      local.get $0
-     i32.const 2
-     i32.shl
-     i32.add
      local.get $3
      i32.load $0 offset=4
-     i32.store $0
+     call $~lib/array/Array<i32>#__set
      local.get $0
      i32.const 1
      i32.add
@@ -23918,6 +24137,7 @@
   local.get $4
   local.get $0
   i32.const 2
+  i32.const 0
   call $~lib/array/ensureCapacity
   local.get $4
   local.get $0
@@ -25055,14 +25275,10 @@
     i32.eqz
     if
      local.get $4
-     i32.load $0 offset=4
      local.get $0
-     i32.const 2
-     i32.shl
-     i32.add
      local.get $3
      i32.load $0 offset=8
-     i32.store $0
+     call $~lib/array/Array<i32>#__set
      local.get $0
      i32.const 1
      i32.add
@@ -25078,6 +25294,7 @@
   local.get $4
   local.get $0
   i32.const 2
+  i32.const 0
   call $~lib/array/ensureCapacity
   local.get $4
   local.get $0

--- a/tests/compiler/std/set.debug.wat
+++ b/tests/compiler/std/set.debug.wat
@@ -2803,21 +2803,9 @@
   local.get $length_
   i32.store $0 offset=12
  )
- (func $~lib/array/Array<i8>#get:dataStart (type $i32_=>_i32) (param $this i32) (result i32)
+ (func $~lib/array/Array<i8>#get:length_ (type $i32_=>_i32) (param $this i32) (result i32)
   local.get $this
-  i32.load $0 offset=4
- )
- (func $~lib/array/Array<i8>#__uset (type $i32_i32_i32_=>_none) (param $this i32) (param $index i32) (param $value i32)
-  local.get $this
-  call $~lib/array/Array<i8>#get:dataStart
-  local.get $index
-  i32.const 0
-  i32.shl
-  i32.add
-  local.get $value
-  i32.store8 $0
-  i32.const 0
-  drop
+  i32.load $0 offset=12
  )
  (func $~lib/arraybuffer/ArrayBufferView#get:byteLength (type $i32_=>_i32) (param $this i32) (result i32)
   local.get $this
@@ -2973,6 +2961,51 @@
    i32.store $0 offset=8
   end
  )
+ (func $~lib/array/Array<i8>#get:dataStart (type $i32_=>_i32) (param $this i32) (result i32)
+  local.get $this
+  i32.load $0 offset=4
+ )
+ (func $~lib/array/Array<i8>#__set (type $i32_i32_i32_=>_none) (param $this i32) (param $index i32) (param $value i32)
+  local.get $index
+  local.get $this
+  call $~lib/array/Array<i8>#get:length_
+  i32.ge_u
+  if
+   local.get $index
+   i32.const 0
+   i32.lt_s
+   if
+    i32.const 224
+    i32.const 592
+    i32.const 130
+    i32.const 22
+    call $~lib/builtins/abort
+    unreachable
+   end
+   local.get $this
+   local.get $index
+   i32.const 1
+   i32.add
+   i32.const 0
+   i32.const 1
+   call $~lib/array/ensureCapacity
+   local.get $this
+   local.get $index
+   i32.const 1
+   i32.add
+   call $~lib/array/Array<i8>#set:length_
+  end
+  local.get $this
+  call $~lib/array/Array<i8>#get:dataStart
+  local.get $index
+  i32.const 0
+  i32.shl
+  i32.add
+  local.get $value
+  i32.store8 $0
+  i32.const 0
+  drop
+ )
  (func $~lib/array/Array<i8>#set:length (type $i32_i32_=>_none) (param $this i32) (param $newLength i32)
   local.get $this
   local.get $newLength
@@ -2982,10 +3015,6 @@
   local.get $this
   local.get $newLength
   call $~lib/array/Array<i8>#set:length_
- )
- (func $~lib/array/Array<i8>#get:length_ (type $i32_=>_i32) (param $this i32) (result i32)
-  local.get $this
-  i32.load $0 offset=12
  )
  (func $~lib/array/Array<i8>#get:length (type $i32_=>_i32) (param $this i32) (result i32)
   local.get $this
@@ -3909,11 +3938,44 @@
   local.get $length_
   i32.store $0 offset=12
  )
+ (func $~lib/array/Array<u8>#get:length_ (type $i32_=>_i32) (param $this i32) (result i32)
+  local.get $this
+  i32.load $0 offset=12
+ )
  (func $~lib/array/Array<u8>#get:dataStart (type $i32_=>_i32) (param $this i32) (result i32)
   local.get $this
   i32.load $0 offset=4
  )
- (func $~lib/array/Array<u8>#__uset (type $i32_i32_i32_=>_none) (param $this i32) (param $index i32) (param $value i32)
+ (func $~lib/array/Array<u8>#__set (type $i32_i32_i32_=>_none) (param $this i32) (param $index i32) (param $value i32)
+  local.get $index
+  local.get $this
+  call $~lib/array/Array<u8>#get:length_
+  i32.ge_u
+  if
+   local.get $index
+   i32.const 0
+   i32.lt_s
+   if
+    i32.const 224
+    i32.const 592
+    i32.const 130
+    i32.const 22
+    call $~lib/builtins/abort
+    unreachable
+   end
+   local.get $this
+   local.get $index
+   i32.const 1
+   i32.add
+   i32.const 0
+   i32.const 1
+   call $~lib/array/ensureCapacity
+   local.get $this
+   local.get $index
+   i32.const 1
+   i32.add
+   call $~lib/array/Array<u8>#set:length_
+  end
   local.get $this
   call $~lib/array/Array<u8>#get:dataStart
   local.get $index
@@ -3934,10 +3996,6 @@
   local.get $this
   local.get $newLength
   call $~lib/array/Array<u8>#set:length_
- )
- (func $~lib/array/Array<u8>#get:length_ (type $i32_=>_i32) (param $this i32) (result i32)
-  local.get $this
-  i32.load $0 offset=12
  )
  (func $~lib/array/Array<u8>#get:length (type $i32_=>_i32) (param $this i32) (result i32)
   local.get $this
@@ -4858,11 +4916,44 @@
   local.get $length_
   i32.store $0 offset=12
  )
+ (func $~lib/array/Array<i16>#get:length_ (type $i32_=>_i32) (param $this i32) (result i32)
+  local.get $this
+  i32.load $0 offset=12
+ )
  (func $~lib/array/Array<i16>#get:dataStart (type $i32_=>_i32) (param $this i32) (result i32)
   local.get $this
   i32.load $0 offset=4
  )
- (func $~lib/array/Array<i16>#__uset (type $i32_i32_i32_=>_none) (param $this i32) (param $index i32) (param $value i32)
+ (func $~lib/array/Array<i16>#__set (type $i32_i32_i32_=>_none) (param $this i32) (param $index i32) (param $value i32)
+  local.get $index
+  local.get $this
+  call $~lib/array/Array<i16>#get:length_
+  i32.ge_u
+  if
+   local.get $index
+   i32.const 0
+   i32.lt_s
+   if
+    i32.const 224
+    i32.const 592
+    i32.const 130
+    i32.const 22
+    call $~lib/builtins/abort
+    unreachable
+   end
+   local.get $this
+   local.get $index
+   i32.const 1
+   i32.add
+   i32.const 1
+   i32.const 1
+   call $~lib/array/ensureCapacity
+   local.get $this
+   local.get $index
+   i32.const 1
+   i32.add
+   call $~lib/array/Array<i16>#set:length_
+  end
   local.get $this
   call $~lib/array/Array<i16>#get:dataStart
   local.get $index
@@ -4883,10 +4974,6 @@
   local.get $this
   local.get $newLength
   call $~lib/array/Array<i16>#set:length_
- )
- (func $~lib/array/Array<i16>#get:length_ (type $i32_=>_i32) (param $this i32) (result i32)
-  local.get $this
-  i32.load $0 offset=12
  )
  (func $~lib/array/Array<i16>#get:length (type $i32_=>_i32) (param $this i32) (result i32)
   local.get $this
@@ -5810,11 +5897,44 @@
   local.get $length_
   i32.store $0 offset=12
  )
+ (func $~lib/array/Array<u16>#get:length_ (type $i32_=>_i32) (param $this i32) (result i32)
+  local.get $this
+  i32.load $0 offset=12
+ )
  (func $~lib/array/Array<u16>#get:dataStart (type $i32_=>_i32) (param $this i32) (result i32)
   local.get $this
   i32.load $0 offset=4
  )
- (func $~lib/array/Array<u16>#__uset (type $i32_i32_i32_=>_none) (param $this i32) (param $index i32) (param $value i32)
+ (func $~lib/array/Array<u16>#__set (type $i32_i32_i32_=>_none) (param $this i32) (param $index i32) (param $value i32)
+  local.get $index
+  local.get $this
+  call $~lib/array/Array<u16>#get:length_
+  i32.ge_u
+  if
+   local.get $index
+   i32.const 0
+   i32.lt_s
+   if
+    i32.const 224
+    i32.const 592
+    i32.const 130
+    i32.const 22
+    call $~lib/builtins/abort
+    unreachable
+   end
+   local.get $this
+   local.get $index
+   i32.const 1
+   i32.add
+   i32.const 1
+   i32.const 1
+   call $~lib/array/ensureCapacity
+   local.get $this
+   local.get $index
+   i32.const 1
+   i32.add
+   call $~lib/array/Array<u16>#set:length_
+  end
   local.get $this
   call $~lib/array/Array<u16>#get:dataStart
   local.get $index
@@ -5835,10 +5955,6 @@
   local.get $this
   local.get $newLength
   call $~lib/array/Array<u16>#set:length_
- )
- (func $~lib/array/Array<u16>#get:length_ (type $i32_=>_i32) (param $this i32) (result i32)
-  local.get $this
-  i32.load $0 offset=12
  )
  (func $~lib/array/Array<u16>#get:length (type $i32_=>_i32) (param $this i32) (result i32)
   local.get $this
@@ -6756,11 +6872,44 @@
   local.get $length_
   i32.store $0 offset=12
  )
+ (func $~lib/array/Array<i32>#get:length_ (type $i32_=>_i32) (param $this i32) (result i32)
+  local.get $this
+  i32.load $0 offset=12
+ )
  (func $~lib/array/Array<i32>#get:dataStart (type $i32_=>_i32) (param $this i32) (result i32)
   local.get $this
   i32.load $0 offset=4
  )
- (func $~lib/array/Array<i32>#__uset (type $i32_i32_i32_=>_none) (param $this i32) (param $index i32) (param $value i32)
+ (func $~lib/array/Array<i32>#__set (type $i32_i32_i32_=>_none) (param $this i32) (param $index i32) (param $value i32)
+  local.get $index
+  local.get $this
+  call $~lib/array/Array<i32>#get:length_
+  i32.ge_u
+  if
+   local.get $index
+   i32.const 0
+   i32.lt_s
+   if
+    i32.const 224
+    i32.const 592
+    i32.const 130
+    i32.const 22
+    call $~lib/builtins/abort
+    unreachable
+   end
+   local.get $this
+   local.get $index
+   i32.const 1
+   i32.add
+   i32.const 2
+   i32.const 1
+   call $~lib/array/ensureCapacity
+   local.get $this
+   local.get $index
+   i32.const 1
+   i32.add
+   call $~lib/array/Array<i32>#set:length_
+  end
   local.get $this
   call $~lib/array/Array<i32>#get:dataStart
   local.get $index
@@ -6781,10 +6930,6 @@
   local.get $this
   local.get $newLength
   call $~lib/array/Array<i32>#set:length_
- )
- (func $~lib/array/Array<i32>#get:length_ (type $i32_=>_i32) (param $this i32) (result i32)
-  local.get $this
-  i32.load $0 offset=12
  )
  (func $~lib/array/Array<i32>#get:length (type $i32_=>_i32) (param $this i32) (result i32)
   local.get $this
@@ -7702,11 +7847,44 @@
   local.get $length_
   i32.store $0 offset=12
  )
+ (func $~lib/array/Array<u32>#get:length_ (type $i32_=>_i32) (param $this i32) (result i32)
+  local.get $this
+  i32.load $0 offset=12
+ )
  (func $~lib/array/Array<u32>#get:dataStart (type $i32_=>_i32) (param $this i32) (result i32)
   local.get $this
   i32.load $0 offset=4
  )
- (func $~lib/array/Array<u32>#__uset (type $i32_i32_i32_=>_none) (param $this i32) (param $index i32) (param $value i32)
+ (func $~lib/array/Array<u32>#__set (type $i32_i32_i32_=>_none) (param $this i32) (param $index i32) (param $value i32)
+  local.get $index
+  local.get $this
+  call $~lib/array/Array<u32>#get:length_
+  i32.ge_u
+  if
+   local.get $index
+   i32.const 0
+   i32.lt_s
+   if
+    i32.const 224
+    i32.const 592
+    i32.const 130
+    i32.const 22
+    call $~lib/builtins/abort
+    unreachable
+   end
+   local.get $this
+   local.get $index
+   i32.const 1
+   i32.add
+   i32.const 2
+   i32.const 1
+   call $~lib/array/ensureCapacity
+   local.get $this
+   local.get $index
+   i32.const 1
+   i32.add
+   call $~lib/array/Array<u32>#set:length_
+  end
   local.get $this
   call $~lib/array/Array<u32>#get:dataStart
   local.get $index
@@ -7727,10 +7905,6 @@
   local.get $this
   local.get $newLength
   call $~lib/array/Array<u32>#set:length_
- )
- (func $~lib/array/Array<u32>#get:length_ (type $i32_=>_i32) (param $this i32) (result i32)
-  local.get $this
-  i32.load $0 offset=12
  )
  (func $~lib/array/Array<u32>#get:length (type $i32_=>_i32) (param $this i32) (result i32)
   local.get $this
@@ -8665,11 +8839,44 @@
   local.get $length_
   i32.store $0 offset=12
  )
+ (func $~lib/array/Array<i64>#get:length_ (type $i32_=>_i32) (param $this i32) (result i32)
+  local.get $this
+  i32.load $0 offset=12
+ )
  (func $~lib/array/Array<i64>#get:dataStart (type $i32_=>_i32) (param $this i32) (result i32)
   local.get $this
   i32.load $0 offset=4
  )
- (func $~lib/array/Array<i64>#__uset (type $i32_i32_i64_=>_none) (param $this i32) (param $index i32) (param $value i64)
+ (func $~lib/array/Array<i64>#__set (type $i32_i32_i64_=>_none) (param $this i32) (param $index i32) (param $value i64)
+  local.get $index
+  local.get $this
+  call $~lib/array/Array<i64>#get:length_
+  i32.ge_u
+  if
+   local.get $index
+   i32.const 0
+   i32.lt_s
+   if
+    i32.const 224
+    i32.const 592
+    i32.const 130
+    i32.const 22
+    call $~lib/builtins/abort
+    unreachable
+   end
+   local.get $this
+   local.get $index
+   i32.const 1
+   i32.add
+   i32.const 3
+   i32.const 1
+   call $~lib/array/ensureCapacity
+   local.get $this
+   local.get $index
+   i32.const 1
+   i32.add
+   call $~lib/array/Array<i64>#set:length_
+  end
   local.get $this
   call $~lib/array/Array<i64>#get:dataStart
   local.get $index
@@ -8690,10 +8897,6 @@
   local.get $this
   local.get $newLength
   call $~lib/array/Array<i64>#set:length_
- )
- (func $~lib/array/Array<i64>#get:length_ (type $i32_=>_i32) (param $this i32) (result i32)
-  local.get $this
-  i32.load $0 offset=12
  )
  (func $~lib/array/Array<i64>#get:length (type $i32_=>_i32) (param $this i32) (result i32)
   local.get $this
@@ -9628,11 +9831,44 @@
   local.get $length_
   i32.store $0 offset=12
  )
+ (func $~lib/array/Array<u64>#get:length_ (type $i32_=>_i32) (param $this i32) (result i32)
+  local.get $this
+  i32.load $0 offset=12
+ )
  (func $~lib/array/Array<u64>#get:dataStart (type $i32_=>_i32) (param $this i32) (result i32)
   local.get $this
   i32.load $0 offset=4
  )
- (func $~lib/array/Array<u64>#__uset (type $i32_i32_i64_=>_none) (param $this i32) (param $index i32) (param $value i64)
+ (func $~lib/array/Array<u64>#__set (type $i32_i32_i64_=>_none) (param $this i32) (param $index i32) (param $value i64)
+  local.get $index
+  local.get $this
+  call $~lib/array/Array<u64>#get:length_
+  i32.ge_u
+  if
+   local.get $index
+   i32.const 0
+   i32.lt_s
+   if
+    i32.const 224
+    i32.const 592
+    i32.const 130
+    i32.const 22
+    call $~lib/builtins/abort
+    unreachable
+   end
+   local.get $this
+   local.get $index
+   i32.const 1
+   i32.add
+   i32.const 3
+   i32.const 1
+   call $~lib/array/ensureCapacity
+   local.get $this
+   local.get $index
+   i32.const 1
+   i32.add
+   call $~lib/array/Array<u64>#set:length_
+  end
   local.get $this
   call $~lib/array/Array<u64>#get:dataStart
   local.get $index
@@ -9653,10 +9889,6 @@
   local.get $this
   local.get $newLength
   call $~lib/array/Array<u64>#set:length_
- )
- (func $~lib/array/Array<u64>#get:length_ (type $i32_=>_i32) (param $this i32) (result i32)
-  local.get $this
-  i32.load $0 offset=12
  )
  (func $~lib/array/Array<u64>#get:length (type $i32_=>_i32) (param $this i32) (result i32)
   local.get $this
@@ -10575,11 +10807,44 @@
   local.get $length_
   i32.store $0 offset=12
  )
+ (func $~lib/array/Array<f32>#get:length_ (type $i32_=>_i32) (param $this i32) (result i32)
+  local.get $this
+  i32.load $0 offset=12
+ )
  (func $~lib/array/Array<f32>#get:dataStart (type $i32_=>_i32) (param $this i32) (result i32)
   local.get $this
   i32.load $0 offset=4
  )
- (func $~lib/array/Array<f32>#__uset (type $i32_i32_f32_=>_none) (param $this i32) (param $index i32) (param $value f32)
+ (func $~lib/array/Array<f32>#__set (type $i32_i32_f32_=>_none) (param $this i32) (param $index i32) (param $value f32)
+  local.get $index
+  local.get $this
+  call $~lib/array/Array<f32>#get:length_
+  i32.ge_u
+  if
+   local.get $index
+   i32.const 0
+   i32.lt_s
+   if
+    i32.const 224
+    i32.const 592
+    i32.const 130
+    i32.const 22
+    call $~lib/builtins/abort
+    unreachable
+   end
+   local.get $this
+   local.get $index
+   i32.const 1
+   i32.add
+   i32.const 2
+   i32.const 1
+   call $~lib/array/ensureCapacity
+   local.get $this
+   local.get $index
+   i32.const 1
+   i32.add
+   call $~lib/array/Array<f32>#set:length_
+  end
   local.get $this
   call $~lib/array/Array<f32>#get:dataStart
   local.get $index
@@ -10600,10 +10865,6 @@
   local.get $this
   local.get $newLength
   call $~lib/array/Array<f32>#set:length_
- )
- (func $~lib/array/Array<f32>#get:length_ (type $i32_=>_i32) (param $this i32) (result i32)
-  local.get $this
-  i32.load $0 offset=12
  )
  (func $~lib/array/Array<f32>#get:length (type $i32_=>_i32) (param $this i32) (result i32)
   local.get $this
@@ -11539,11 +11800,44 @@
   local.get $length_
   i32.store $0 offset=12
  )
+ (func $~lib/array/Array<f64>#get:length_ (type $i32_=>_i32) (param $this i32) (result i32)
+  local.get $this
+  i32.load $0 offset=12
+ )
  (func $~lib/array/Array<f64>#get:dataStart (type $i32_=>_i32) (param $this i32) (result i32)
   local.get $this
   i32.load $0 offset=4
  )
- (func $~lib/array/Array<f64>#__uset (type $i32_i32_f64_=>_none) (param $this i32) (param $index i32) (param $value f64)
+ (func $~lib/array/Array<f64>#__set (type $i32_i32_f64_=>_none) (param $this i32) (param $index i32) (param $value f64)
+  local.get $index
+  local.get $this
+  call $~lib/array/Array<f64>#get:length_
+  i32.ge_u
+  if
+   local.get $index
+   i32.const 0
+   i32.lt_s
+   if
+    i32.const 224
+    i32.const 592
+    i32.const 130
+    i32.const 22
+    call $~lib/builtins/abort
+    unreachable
+   end
+   local.get $this
+   local.get $index
+   i32.const 1
+   i32.add
+   i32.const 3
+   i32.const 1
+   call $~lib/array/ensureCapacity
+   local.get $this
+   local.get $index
+   i32.const 1
+   i32.add
+   call $~lib/array/Array<f64>#set:length_
+  end
   local.get $this
   call $~lib/array/Array<f64>#get:dataStart
   local.get $index
@@ -11564,10 +11858,6 @@
   local.get $this
   local.get $newLength
   call $~lib/array/Array<f64>#set:length_
- )
- (func $~lib/array/Array<f64>#get:length_ (type $i32_=>_i32) (param $this i32) (result i32)
-  local.get $this
-  i32.load $0 offset=12
  )
  (func $~lib/array/Array<f64>#get:length (type $i32_=>_i32) (param $this i32) (result i32)
   local.get $this
@@ -14152,7 +14442,7 @@
      local.get $7
      local.get $entry
      call $~lib/set/SetEntry<i8>#get:key
-     call $~lib/array/Array<i8>#__uset
+     call $~lib/array/Array<i8>#__set
     end
     local.get $i
     i32.const 1
@@ -14325,7 +14615,7 @@
      local.get $7
      local.get $entry
      call $~lib/set/SetEntry<u8>#get:key
-     call $~lib/array/Array<u8>#__uset
+     call $~lib/array/Array<u8>#__set
     end
     local.get $i
     i32.const 1
@@ -14498,7 +14788,7 @@
      local.get $7
      local.get $entry
      call $~lib/set/SetEntry<i16>#get:key
-     call $~lib/array/Array<i16>#__uset
+     call $~lib/array/Array<i16>#__set
     end
     local.get $i
     i32.const 1
@@ -14671,7 +14961,7 @@
      local.get $7
      local.get $entry
      call $~lib/set/SetEntry<u16>#get:key
-     call $~lib/array/Array<u16>#__uset
+     call $~lib/array/Array<u16>#__set
     end
     local.get $i
     i32.const 1
@@ -14844,7 +15134,7 @@
      local.get $7
      local.get $entry
      call $~lib/set/SetEntry<i32>#get:key
-     call $~lib/array/Array<i32>#__uset
+     call $~lib/array/Array<i32>#__set
     end
     local.get $i
     i32.const 1
@@ -15017,7 +15307,7 @@
      local.get $7
      local.get $entry
      call $~lib/set/SetEntry<u32>#get:key
-     call $~lib/array/Array<u32>#__uset
+     call $~lib/array/Array<u32>#__set
     end
     local.get $i
     i32.const 1
@@ -15190,7 +15480,7 @@
      local.get $7
      local.get $entry
      call $~lib/set/SetEntry<i64>#get:key
-     call $~lib/array/Array<i64>#__uset
+     call $~lib/array/Array<i64>#__set
     end
     local.get $i
     i32.const 1
@@ -15363,7 +15653,7 @@
      local.get $7
      local.get $entry
      call $~lib/set/SetEntry<u64>#get:key
-     call $~lib/array/Array<u64>#__uset
+     call $~lib/array/Array<u64>#__set
     end
     local.get $i
     i32.const 1
@@ -15536,7 +15826,7 @@
      local.get $7
      local.get $entry
      call $~lib/set/SetEntry<f32>#get:key
-     call $~lib/array/Array<f32>#__uset
+     call $~lib/array/Array<f32>#__set
     end
     local.get $i
     i32.const 1
@@ -15709,7 +15999,7 @@
      local.get $7
      local.get $entry
      call $~lib/set/SetEntry<f64>#get:key
-     call $~lib/array/Array<f64>#__uset
+     call $~lib/array/Array<f64>#__set
     end
     local.get $i
     i32.const 1

--- a/tests/compiler/std/set.release.wat
+++ b/tests/compiler/std/set.release.wat
@@ -4,12 +4,13 @@
  (type $none_=>_i32 (func_subtype (result i32) func))
  (type $i32_i32_=>_i32 (func_subtype (param i32 i32) (result i32) func))
  (type $i32_=>_none (func_subtype (param i32) func))
- (type $i32_i64_=>_none (func_subtype (param i32 i64) func))
  (type $i32_i32_i32_=>_none (func_subtype (param i32 i32 i32) func))
+ (type $i32_i64_=>_none (func_subtype (param i32 i64) func))
+ (type $i32_i32_i32_i32_=>_none (func_subtype (param i32 i32 i32 i32) func))
  (type $i32_i32_=>_i64 (func_subtype (param i32 i32) (result i64) func))
  (type $i32_f32_=>_none (func_subtype (param i32 f32) func))
  (type $i32_f64_=>_none (func_subtype (param i32 f64) func))
- (type $i32_i32_i32_i32_=>_none (func_subtype (param i32 i32 i32 i32) func))
+ (type $i32_i32_i64_=>_none (func_subtype (param i32 i32 i64) func))
  (type $i32_i32_=>_f32 (func_subtype (param i32 i32) (result f32) func))
  (type $i32_i32_=>_f64 (func_subtype (param i32 i32) (result f64) func))
  (type $i32_=>_i32 (func_subtype (param i32) (result i32) func))
@@ -1827,12 +1828,13 @@
    i32.store $0
   end
  )
- (func $~lib/array/ensureCapacity (type $i32_i32_i32_=>_none) (param $0 i32) (param $1 i32) (param $2 i32)
-  (local $3 i32)
+ (func $~lib/array/ensureCapacity (type $i32_i32_i32_i32_=>_none) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32)
   (local $4 i32)
+  (local $5 i32)
   local.get $1
   local.get $0
   i32.load $0 offset=8
+  local.tee $5
   local.get $2
   i32.shr_u
   i32.gt_u
@@ -1850,73 +1852,131 @@
     call $~lib/builtins/abort
     unreachable
    end
-   block $__inlined_func$~lib/rt/itcms/__renew
-    i32.const 8
-    local.get $1
-    local.get $1
-    i32.const 8
-    i32.le_u
-    select
-    local.get $2
+   local.get $0
+   i32.load $0
+   local.set $4
+   i32.const 8
+   local.get $1
+   local.get $1
+   i32.const 8
+   i32.le_u
+   select
+   local.get $2
+   i32.shl
+   local.set $1
+   local.get $3
+   if
+    i32.const 1073741820
+    local.get $5
+    i32.const 1
     i32.shl
-    local.tee $3
-    local.get $0
-    i32.load $0
     local.tee $2
+    local.get $2
+    i32.const 1073741820
+    i32.ge_u
+    select
+    local.tee $2
+    local.get $1
+    local.get $1
+    local.get $2
+    i32.lt_u
+    select
+    local.set $1
+   end
+   block $__inlined_func$~lib/rt/itcms/__renew
+    local.get $4
     i32.const 20
     i32.sub
-    local.tee $4
+    local.tee $3
     i32.load $0
     i32.const -4
     i32.and
     i32.const 16
     i32.sub
-    i32.le_u
+    local.get $1
+    i32.ge_u
     if
-     local.get $4
      local.get $3
+     local.get $1
      i32.store $0 offset=16
-     local.get $2
-     local.set $1
+     local.get $4
+     local.set $2
      br $__inlined_func$~lib/rt/itcms/__renew
     end
+    local.get $1
     local.get $3
-    local.get $4
     i32.load $0 offset=12
     call $~lib/rt/itcms/__new
-    local.tee $1
-    local.get $2
-    local.get $3
+    local.tee $2
     local.get $4
+    local.get $1
+    local.get $3
     i32.load $0 offset=16
-    local.tee $4
+    local.tee $3
+    local.get $1
     local.get $3
-    local.get $4
     i32.lt_u
     select
     memory.copy $0 $0
    end
-   local.get $1
    local.get $2
+   local.get $4
    i32.ne
    if
     local.get $0
-    local.get $1
+    local.get $2
     i32.store $0
     local.get $0
-    local.get $1
+    local.get $2
     i32.store $0 offset=4
-    local.get $1
+    local.get $2
     if
      local.get $0
-     local.get $1
+     local.get $2
      call $byn-split-outlined-A$~lib/rt/itcms/__link
     end
    end
    local.get $0
-   local.get $3
+   local.get $1
    i32.store $0 offset=8
   end
+ )
+ (func $~lib/array/Array<i8>#__set (type $i32_i32_i32_=>_none) (param $0 i32) (param $1 i32) (param $2 i32)
+  (local $3 i32)
+  local.get $1
+  local.get $0
+  i32.load $0 offset=12
+  i32.ge_u
+  if
+   local.get $1
+   i32.const 0
+   i32.lt_s
+   if
+    i32.const 1248
+    i32.const 1616
+    i32.const 130
+    i32.const 22
+    call $~lib/builtins/abort
+    unreachable
+   end
+   local.get $0
+   local.get $1
+   i32.const 1
+   i32.add
+   local.tee $3
+   i32.const 0
+   i32.const 1
+   call $~lib/array/ensureCapacity
+   local.get $0
+   local.get $3
+   i32.store $0 offset=12
+  end
+  local.get $0
+  i32.load $0 offset=4
+  local.get $1
+  i32.add
+  local.get $2
+  i32.store8 $0
  )
  (func $~lib/array/Array<i8>#__get (type $i32_i32_=>_i32) (param $0 i32) (param $1 i32) (result i32)
   local.get $1
@@ -2578,13 +2638,11 @@
      i32.and
      i32.eqz
      if
-      local.get $0
       local.get $7
-      i32.load $0 offset=4
-      i32.add
+      local.get $0
       local.get $4
       i32.load8_s $0
-      i32.store8 $0
+      call $~lib/array/Array<i8>#__set
       local.get $0
       i32.const 1
       i32.add
@@ -2599,6 +2657,7 @@
    end
    local.get $7
    local.get $0
+   i32.const 0
    i32.const 0
    call $~lib/array/ensureCapacity
    local.get $7
@@ -4186,13 +4245,11 @@
      i32.and
      i32.eqz
      if
-      local.get $0
       local.get $7
-      i32.load $0 offset=4
-      i32.add
+      local.get $0
       local.get $4
       i32.load8_u $0
-      i32.store8 $0
+      call $~lib/array/Array<i8>#__set
       local.get $0
       i32.const 1
       i32.add
@@ -4207,6 +4264,7 @@
    end
    local.get $7
    local.get $0
+   i32.const 0
    i32.const 0
    call $~lib/array/ensureCapacity
    local.get $7
@@ -5135,6 +5193,45 @@
    i32.store $0
   end
  )
+ (func $~lib/array/Array<i16>#__set (type $i32_i32_i32_=>_none) (param $0 i32) (param $1 i32) (param $2 i32)
+  (local $3 i32)
+  local.get $1
+  local.get $0
+  i32.load $0 offset=12
+  i32.ge_u
+  if
+   local.get $1
+   i32.const 0
+   i32.lt_s
+   if
+    i32.const 1248
+    i32.const 1616
+    i32.const 130
+    i32.const 22
+    call $~lib/builtins/abort
+    unreachable
+   end
+   local.get $0
+   local.get $1
+   i32.const 1
+   i32.add
+   local.tee $3
+   i32.const 1
+   i32.const 1
+   call $~lib/array/ensureCapacity
+   local.get $0
+   local.get $3
+   i32.store $0 offset=12
+  end
+  local.get $0
+  i32.load $0 offset=4
+  local.get $1
+  i32.const 1
+  i32.shl
+  i32.add
+  local.get $2
+  i32.store16 $0
+ )
  (func $~lib/array/Array<i16>#__get (type $i32_i32_=>_i32) (param $0 i32) (param $1 i32) (result i32)
   local.get $1
   local.get $0
@@ -5800,14 +5897,10 @@
      i32.eqz
      if
       local.get $7
-      i32.load $0 offset=4
       local.get $0
-      i32.const 1
-      i32.shl
-      i32.add
       local.get $4
       i32.load16_s $0
-      i32.store16 $0
+      call $~lib/array/Array<i16>#__set
       local.get $0
       i32.const 1
       i32.add
@@ -5823,6 +5916,7 @@
    local.get $7
    local.get $0
    i32.const 1
+   i32.const 0
    call $~lib/array/ensureCapacity
    local.get $7
    local.get $0
@@ -7414,14 +7508,10 @@
      i32.eqz
      if
       local.get $7
-      i32.load $0 offset=4
       local.get $0
-      i32.const 1
-      i32.shl
-      i32.add
       local.get $4
       i32.load16_u $0
-      i32.store16 $0
+      call $~lib/array/Array<i16>#__set
       local.get $0
       i32.const 1
       i32.add
@@ -7437,6 +7527,7 @@
    local.get $7
    local.get $0
    i32.const 1
+   i32.const 0
    call $~lib/array/ensureCapacity
    local.get $7
    local.get $0
@@ -8360,6 +8451,45 @@
    i32.store $0
   end
  )
+ (func $~lib/array/Array<i32>#__set (type $i32_i32_i32_=>_none) (param $0 i32) (param $1 i32) (param $2 i32)
+  (local $3 i32)
+  local.get $1
+  local.get $0
+  i32.load $0 offset=12
+  i32.ge_u
+  if
+   local.get $1
+   i32.const 0
+   i32.lt_s
+   if
+    i32.const 1248
+    i32.const 1616
+    i32.const 130
+    i32.const 22
+    call $~lib/builtins/abort
+    unreachable
+   end
+   local.get $0
+   local.get $1
+   i32.const 1
+   i32.add
+   local.tee $3
+   i32.const 2
+   i32.const 1
+   call $~lib/array/ensureCapacity
+   local.get $0
+   local.get $3
+   i32.store $0 offset=12
+  end
+  local.get $0
+  i32.load $0 offset=4
+  local.get $1
+  i32.const 2
+  i32.shl
+  i32.add
+  local.get $2
+  i32.store $0
+ )
  (func $~lib/array/Array<i32>#__get (type $i32_i32_=>_i32) (param $0 i32) (param $1 i32) (result i32)
   local.get $1
   local.get $0
@@ -9010,14 +9140,10 @@
      i32.eqz
      if
       local.get $7
-      i32.load $0 offset=4
       local.get $0
-      i32.const 2
-      i32.shl
-      i32.add
       local.get $4
       i32.load $0
-      i32.store $0
+      call $~lib/array/Array<i32>#__set
       local.get $0
       i32.const 1
       i32.add
@@ -9033,6 +9159,7 @@
    local.get $7
    local.get $0
    i32.const 2
+   i32.const 0
    call $~lib/array/ensureCapacity
    local.get $7
    local.get $0
@@ -10582,14 +10709,10 @@
      i32.eqz
      if
       local.get $7
-      i32.load $0 offset=4
       local.get $0
-      i32.const 2
-      i32.shl
-      i32.add
       local.get $4
       i32.load $0
-      i32.store $0
+      call $~lib/array/Array<i32>#__set
       local.get $0
       i32.const 1
       i32.add
@@ -10605,6 +10728,7 @@
    local.get $7
    local.get $0
    i32.const 2
+   i32.const 0
    call $~lib/array/ensureCapacity
    local.get $7
    local.get $0
@@ -11528,6 +11652,45 @@
    i32.store $0
   end
  )
+ (func $~lib/array/Array<i64>#__set (type $i32_i32_i64_=>_none) (param $0 i32) (param $1 i32) (param $2 i64)
+  (local $3 i32)
+  local.get $1
+  local.get $0
+  i32.load $0 offset=12
+  i32.ge_u
+  if
+   local.get $1
+   i32.const 0
+   i32.lt_s
+   if
+    i32.const 1248
+    i32.const 1616
+    i32.const 130
+    i32.const 22
+    call $~lib/builtins/abort
+    unreachable
+   end
+   local.get $0
+   local.get $1
+   i32.const 1
+   i32.add
+   local.tee $3
+   i32.const 3
+   i32.const 1
+   call $~lib/array/ensureCapacity
+   local.get $0
+   local.get $3
+   i32.store $0 offset=12
+  end
+  local.get $0
+  i32.load $0 offset=4
+  local.get $1
+  i32.const 3
+  i32.shl
+  i32.add
+  local.get $2
+  i64.store $0
+ )
  (func $~lib/array/Array<i64>#__get (type $i32_i32_=>_i64) (param $0 i32) (param $1 i32) (result i64)
   local.get $1
   local.get $0
@@ -12238,14 +12401,10 @@
      i32.eqz
      if
       local.get $8
-      i32.load $0 offset=4
       local.get $0
-      i32.const 3
-      i32.shl
-      i32.add
       local.get $6
       i64.load $0
-      i64.store $0
+      call $~lib/array/Array<i64>#__set
       local.get $0
       i32.const 1
       i32.add
@@ -12261,6 +12420,7 @@
    local.get $8
    local.get $0
    i32.const 3
+   i32.const 0
    call $~lib/array/ensureCapacity
    local.get $8
    local.get $0
@@ -12338,8 +12498,8 @@
      i32.add
      i32.load $0
      local.set $2
-     block $__inlined_func$~lib/set/Set<i64>#find29
-      loop $while-continue|033
+     block $__inlined_func$~lib/set/Set<i64>#find28
+      loop $while-continue|032
        local.get $2
        if
         local.get $2
@@ -12355,12 +12515,12 @@
          i64.load $0
          i64.eq
         end
-        br_if $__inlined_func$~lib/set/Set<i64>#find29
+        br_if $__inlined_func$~lib/set/Set<i64>#find28
         local.get $5
         i32.const -2
         i32.and
         local.set $2
-        br $while-continue|033
+        br $while-continue|032
        end
       end
       i32.const 0
@@ -12458,8 +12618,8 @@
      i32.add
      i32.load $0
      local.set $0
-     block $__inlined_func$~lib/set/Set<i64>#find40
-      loop $while-continue|044
+     block $__inlined_func$~lib/set/Set<i64>#find39
+      loop $while-continue|043
        local.get $0
        if
         local.get $0
@@ -12475,12 +12635,12 @@
          i64.load $0
          i64.eq
         end
-        br_if $__inlined_func$~lib/set/Set<i64>#find40
+        br_if $__inlined_func$~lib/set/Set<i64>#find39
         local.get $2
         i32.const -2
         i32.and
         local.set $0
-        br $while-continue|044
+        br $while-continue|043
        end
       end
       i32.const 0
@@ -12549,8 +12709,8 @@
      i32.add
      i32.load $0
      local.set $0
-     block $__inlined_func$~lib/set/Set<i64>#find47
-      loop $while-continue|051
+     block $__inlined_func$~lib/set/Set<i64>#find46
+      loop $while-continue|050
        local.get $0
        if
         local.get $0
@@ -12566,12 +12726,12 @@
          i64.load $0
          i64.eq
         end
-        br_if $__inlined_func$~lib/set/Set<i64>#find47
+        br_if $__inlined_func$~lib/set/Set<i64>#find46
         local.get $2
         i32.const -2
         i32.and
         local.set $0
-        br $while-continue|051
+        br $while-continue|050
        end
       end
       i32.const 0
@@ -12662,8 +12822,8 @@
      i32.add
      i32.load $0
      local.set $0
-     block $__inlined_func$~lib/set/Set<i64>#find56
-      loop $while-continue|060
+     block $__inlined_func$~lib/set/Set<i64>#find55
+      loop $while-continue|059
        local.get $0
        if
         local.get $0
@@ -12679,12 +12839,12 @@
          i64.load $0
          i64.eq
         end
-        br_if $__inlined_func$~lib/set/Set<i64>#find56
+        br_if $__inlined_func$~lib/set/Set<i64>#find55
         local.get $2
         i32.const -2
         i32.and
         local.set $0
-        br $while-continue|060
+        br $while-continue|059
        end
       end
       i32.const 0
@@ -12752,8 +12912,8 @@
      i32.add
      i32.load $0
      local.set $0
-     block $__inlined_func$~lib/set/Set<i64>#find63
-      loop $while-continue|067
+     block $__inlined_func$~lib/set/Set<i64>#find62
+      loop $while-continue|066
        local.get $0
        if
         local.get $0
@@ -12769,12 +12929,12 @@
          i64.load $0
          i64.eq
         end
-        br_if $__inlined_func$~lib/set/Set<i64>#find63
+        br_if $__inlined_func$~lib/set/Set<i64>#find62
         local.get $2
         i32.const -2
         i32.and
         local.set $0
-        br $while-continue|067
+        br $while-continue|066
        end
       end
       i32.const 0
@@ -12843,8 +13003,8 @@
      i32.add
      i32.load $0
      local.set $0
-     block $__inlined_func$~lib/set/Set<i64>#find70
-      loop $while-continue|074
+     block $__inlined_func$~lib/set/Set<i64>#find69
+      loop $while-continue|073
        local.get $0
        if
         local.get $0
@@ -12860,12 +13020,12 @@
          i64.load $0
          i64.eq
         end
-        br_if $__inlined_func$~lib/set/Set<i64>#find70
+        br_if $__inlined_func$~lib/set/Set<i64>#find69
         local.get $2
         i32.const -2
         i32.and
         local.set $0
-        br $while-continue|074
+        br $while-continue|073
        end
       end
       i32.const 0
@@ -13966,14 +14126,10 @@
      i32.eqz
      if
       local.get $8
-      i32.load $0 offset=4
       local.get $0
-      i32.const 3
-      i32.shl
-      i32.add
       local.get $6
       i64.load $0
-      i64.store $0
+      call $~lib/array/Array<i64>#__set
       local.get $0
       i32.const 1
       i32.add
@@ -13989,6 +14145,7 @@
    local.get $8
    local.get $0
    i32.const 3
+   i32.const 0
    call $~lib/array/ensureCapacity
    local.get $8
    local.get $0
@@ -14066,8 +14223,8 @@
      i32.add
      i32.load $0
      local.set $2
-     block $__inlined_func$~lib/set/Set<u64>#find29
-      loop $while-continue|033
+     block $__inlined_func$~lib/set/Set<u64>#find28
+      loop $while-continue|032
        local.get $2
        if
         local.get $2
@@ -14083,12 +14240,12 @@
          i64.load $0
          i64.eq
         end
-        br_if $__inlined_func$~lib/set/Set<u64>#find29
+        br_if $__inlined_func$~lib/set/Set<u64>#find28
         local.get $5
         i32.const -2
         i32.and
         local.set $2
-        br $while-continue|033
+        br $while-continue|032
        end
       end
       i32.const 0
@@ -14186,8 +14343,8 @@
      i32.add
      i32.load $0
      local.set $0
-     block $__inlined_func$~lib/set/Set<u64>#find40
-      loop $while-continue|044
+     block $__inlined_func$~lib/set/Set<u64>#find39
+      loop $while-continue|043
        local.get $0
        if
         local.get $0
@@ -14203,12 +14360,12 @@
          i64.load $0
          i64.eq
         end
-        br_if $__inlined_func$~lib/set/Set<u64>#find40
+        br_if $__inlined_func$~lib/set/Set<u64>#find39
         local.get $2
         i32.const -2
         i32.and
         local.set $0
-        br $while-continue|044
+        br $while-continue|043
        end
       end
       i32.const 0
@@ -14277,8 +14434,8 @@
      i32.add
      i32.load $0
      local.set $0
-     block $__inlined_func$~lib/set/Set<u64>#find47
-      loop $while-continue|051
+     block $__inlined_func$~lib/set/Set<u64>#find46
+      loop $while-continue|050
        local.get $0
        if
         local.get $0
@@ -14294,12 +14451,12 @@
          i64.load $0
          i64.eq
         end
-        br_if $__inlined_func$~lib/set/Set<u64>#find47
+        br_if $__inlined_func$~lib/set/Set<u64>#find46
         local.get $2
         i32.const -2
         i32.and
         local.set $0
-        br $while-continue|051
+        br $while-continue|050
        end
       end
       i32.const 0
@@ -14390,8 +14547,8 @@
      i32.add
      i32.load $0
      local.set $0
-     block $__inlined_func$~lib/set/Set<u64>#find56
-      loop $while-continue|060
+     block $__inlined_func$~lib/set/Set<u64>#find55
+      loop $while-continue|059
        local.get $0
        if
         local.get $0
@@ -14407,12 +14564,12 @@
          i64.load $0
          i64.eq
         end
-        br_if $__inlined_func$~lib/set/Set<u64>#find56
+        br_if $__inlined_func$~lib/set/Set<u64>#find55
         local.get $2
         i32.const -2
         i32.and
         local.set $0
-        br $while-continue|060
+        br $while-continue|059
        end
       end
       i32.const 0
@@ -14480,8 +14637,8 @@
      i32.add
      i32.load $0
      local.set $0
-     block $__inlined_func$~lib/set/Set<u64>#find63
-      loop $while-continue|067
+     block $__inlined_func$~lib/set/Set<u64>#find62
+      loop $while-continue|066
        local.get $0
        if
         local.get $0
@@ -14497,12 +14654,12 @@
          i64.load $0
          i64.eq
         end
-        br_if $__inlined_func$~lib/set/Set<u64>#find63
+        br_if $__inlined_func$~lib/set/Set<u64>#find62
         local.get $2
         i32.const -2
         i32.and
         local.set $0
-        br $while-continue|067
+        br $while-continue|066
        end
       end
       i32.const 0
@@ -14571,8 +14728,8 @@
      i32.add
      i32.load $0
      local.set $0
-     block $__inlined_func$~lib/set/Set<u64>#find70
-      loop $while-continue|074
+     block $__inlined_func$~lib/set/Set<u64>#find69
+      loop $while-continue|073
        local.get $0
        if
         local.get $0
@@ -14588,12 +14745,12 @@
          i64.load $0
          i64.eq
         end
-        br_if $__inlined_func$~lib/set/Set<u64>#find70
+        br_if $__inlined_func$~lib/set/Set<u64>#find69
         local.get $2
         i32.const -2
         i32.and
         local.set $0
-        br $while-continue|074
+        br $while-continue|073
        end
       end
       i32.const 0
@@ -15117,6 +15274,7 @@
   (local $8 i32)
   (local $9 i32)
   (local $10 i32)
+  (local $11 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 12
   i32.sub
@@ -15127,24 +15285,24 @@
    i32.lt_s
    br_if $folding-inner0
    global.get $~lib/memory/__stack_pointer
-   local.tee $1
+   local.tee $0
    i64.const 0
    i64.store $0
-   local.get $1
+   local.get $0
    i32.const 0
    i32.store $0 offset=8
-   local.get $1
+   local.get $0
    call $~lib/set/Set<f32>#constructor
-   local.tee $3
+   local.tee $11
    i32.store $0
    loop $for-loop|0
     local.get $2
     f32.const 100
     f32.lt
     if
-     local.get $3
+     local.get $11
      i32.load $0
-     local.get $3
+     local.get $11
      i32.load $0 offset=4
      local.get $2
      i32.reinterpret_f32
@@ -15156,22 +15314,22 @@
      i32.rotl
      i32.const 668265263
      i32.mul
-     local.tee $1
-     local.get $1
+     local.tee $0
+     local.get $0
      i32.const 15
      i32.shr_u
      i32.xor
      i32.const -2048144777
      i32.mul
-     local.tee $1
-     local.get $1
+     local.tee $0
+     local.get $0
      i32.const 13
      i32.shr_u
      i32.xor
      i32.const -1028477379
      i32.mul
-     local.tee $1
-     local.get $1
+     local.tee $0
+     local.get $0
      i32.const 16
      i32.shr_u
      i32.xor
@@ -15180,36 +15338,36 @@
      i32.shl
      i32.add
      i32.load $0
-     local.set $1
+     local.set $3
      block $__inlined_func$~lib/set/Set<f32>#find
       loop $while-continue|0
-       local.get $1
+       local.get $3
        if
-        local.get $1
+        local.get $3
         i32.load $0 offset=4
-        local.tee $5
+        local.tee $0
         i32.const 1
         i32.and
         if (result i32)
          i32.const 0
         else
-         local.get $1
+         local.get $3
          f32.load $0
          local.get $2
          f32.eq
         end
         br_if $__inlined_func$~lib/set/Set<f32>#find
-        local.get $5
+        local.get $0
         i32.const -2
         i32.and
-        local.set $1
+        local.set $3
         br $while-continue|0
        end
       end
       i32.const 0
-      local.set $1
+      local.set $3
      end
-     local.get $1
+     local.get $3
      if
       i32.const 0
       i32.const 1568
@@ -15218,12 +15376,12 @@
       call $~lib/builtins/abort
       unreachable
      end
-     local.get $3
+     local.get $11
      local.get $2
      call $~lib/set/Set<f32>#add
-     local.get $3
+     local.get $11
      i32.load $0
-     local.get $3
+     local.get $11
      i32.load $0 offset=4
      local.get $2
      i32.reinterpret_f32
@@ -15235,22 +15393,22 @@
      i32.rotl
      i32.const 668265263
      i32.mul
-     local.tee $1
-     local.get $1
+     local.tee $0
+     local.get $0
      i32.const 15
      i32.shr_u
      i32.xor
      i32.const -2048144777
      i32.mul
-     local.tee $1
-     local.get $1
+     local.tee $0
+     local.get $0
      i32.const 13
      i32.shr_u
      i32.xor
      i32.const -1028477379
      i32.mul
-     local.tee $1
-     local.get $1
+     local.tee $0
+     local.get $0
      i32.const 16
      i32.shr_u
      i32.xor
@@ -15259,36 +15417,36 @@
      i32.shl
      i32.add
      i32.load $0
-     local.set $1
+     local.set $3
      block $__inlined_func$~lib/set/Set<f32>#find1
       loop $while-continue|02
-       local.get $1
+       local.get $3
        if
-        local.get $1
+        local.get $3
         i32.load $0 offset=4
-        local.tee $5
+        local.tee $0
         i32.const 1
         i32.and
         if (result i32)
          i32.const 0
         else
-         local.get $1
+         local.get $3
          f32.load $0
          local.get $2
          f32.eq
         end
         br_if $__inlined_func$~lib/set/Set<f32>#find1
-        local.get $5
+        local.get $0
         i32.const -2
         i32.and
-        local.set $1
+        local.set $3
         br $while-continue|02
        end
       end
       i32.const 0
-      local.set $1
+      local.set $3
      end
-     local.get $1
+     local.get $3
      i32.eqz
      if
       i32.const 0
@@ -15305,7 +15463,7 @@
      br $for-loop|0
     end
    end
-   local.get $3
+   local.get $11
    i32.load $0 offset=20
    i32.const 100
    i32.ne
@@ -15324,9 +15482,9 @@
     f32.const 100
     f32.lt
     if
-     local.get $3
+     local.get $11
      i32.load $0
-     local.get $3
+     local.get $11
      i32.load $0 offset=4
      local.get $2
      i32.reinterpret_f32
@@ -15338,22 +15496,22 @@
      i32.rotl
      i32.const 668265263
      i32.mul
-     local.tee $1
-     local.get $1
+     local.tee $0
+     local.get $0
      i32.const 15
      i32.shr_u
      i32.xor
      i32.const -2048144777
      i32.mul
-     local.tee $1
-     local.get $1
+     local.tee $0
+     local.get $0
      i32.const 13
      i32.shr_u
      i32.xor
      i32.const -1028477379
      i32.mul
-     local.tee $1
-     local.get $1
+     local.tee $0
+     local.get $0
      i32.const 16
      i32.shr_u
      i32.xor
@@ -15362,36 +15520,36 @@
      i32.shl
      i32.add
      i32.load $0
-     local.set $1
+     local.set $3
      block $__inlined_func$~lib/set/Set<f32>#find4
       loop $while-continue|05
-       local.get $1
+       local.get $3
        if
-        local.get $1
+        local.get $3
         i32.load $0 offset=4
-        local.tee $5
+        local.tee $0
         i32.const 1
         i32.and
         if (result i32)
          i32.const 0
         else
-         local.get $1
+         local.get $3
          f32.load $0
          local.get $2
          f32.eq
         end
         br_if $__inlined_func$~lib/set/Set<f32>#find4
-        local.get $5
+        local.get $0
         i32.const -2
         i32.and
-        local.set $1
+        local.set $3
         br $while-continue|05
        end
       end
       i32.const 0
-      local.set $1
+      local.set $3
      end
-     local.get $1
+     local.get $3
      i32.eqz
      if
       i32.const 0
@@ -15401,12 +15559,12 @@
       call $~lib/builtins/abort
       unreachable
      end
-     local.get $3
+     local.get $11
      local.get $2
      call $~lib/set/Set<f32>#add
-     local.get $3
+     local.get $11
      i32.load $0
-     local.get $3
+     local.get $11
      i32.load $0 offset=4
      local.get $2
      i32.reinterpret_f32
@@ -15418,22 +15576,22 @@
      i32.rotl
      i32.const 668265263
      i32.mul
-     local.tee $1
-     local.get $1
+     local.tee $0
+     local.get $0
      i32.const 15
      i32.shr_u
      i32.xor
      i32.const -2048144777
      i32.mul
-     local.tee $1
-     local.get $1
+     local.tee $0
+     local.get $0
      i32.const 13
      i32.shr_u
      i32.xor
      i32.const -1028477379
      i32.mul
-     local.tee $1
-     local.get $1
+     local.tee $0
+     local.get $0
      i32.const 16
      i32.shr_u
      i32.xor
@@ -15442,36 +15600,36 @@
      i32.shl
      i32.add
      i32.load $0
-     local.set $1
+     local.set $3
      block $__inlined_func$~lib/set/Set<f32>#find7
       loop $while-continue|08
-       local.get $1
+       local.get $3
        if
-        local.get $1
+        local.get $3
         i32.load $0 offset=4
-        local.tee $5
+        local.tee $0
         i32.const 1
         i32.and
         if (result i32)
          i32.const 0
         else
-         local.get $1
+         local.get $3
          f32.load $0
          local.get $2
          f32.eq
         end
         br_if $__inlined_func$~lib/set/Set<f32>#find7
-        local.get $5
+        local.get $0
         i32.const -2
         i32.and
-        local.set $1
+        local.set $3
         br $while-continue|08
        end
       end
       i32.const 0
-      local.set $1
+      local.set $3
      end
-     local.get $1
+     local.get $3
      i32.eqz
      if
       i32.const 0
@@ -15488,7 +15646,7 @@
      br $for-loop|1
     end
    end
-   local.get $3
+   local.get $11
    i32.load $0 offset=20
    i32.const 100
    i32.ne
@@ -15510,16 +15668,16 @@
    i32.lt_s
    br_if $folding-inner0
    global.get $~lib/memory/__stack_pointer
-   local.tee $9
+   local.tee $3
    i32.const 0
    i32.store $0
-   local.get $3
+   local.get $11
    i32.load $0 offset=8
-   local.set $1
-   local.get $3
+   local.set $4
+   local.get $11
    i32.load $0 offset=16
-   local.set $5
-   local.get $9
+   local.set $7
+   local.get $3
    i32.const 8
    i32.sub
    global.set $~lib/memory/__stack_pointer
@@ -15528,28 +15686,28 @@
    i32.lt_s
    br_if $folding-inner0
    global.get $~lib/memory/__stack_pointer
-   local.tee $6
+   local.tee $0
    i64.const 0
    i64.store $0
-   local.get $6
+   local.get $0
    i32.const 16
    i32.const 21
    call $~lib/rt/itcms/__new
-   local.tee $10
+   local.tee $6
    i32.store $0
-   local.get $10
+   local.get $6
    i32.const 0
    i32.store $0
-   local.get $10
+   local.get $6
    i32.const 0
    i32.store $0 offset=4
-   local.get $10
+   local.get $6
    i32.const 0
    i32.store $0 offset=8
-   local.get $10
+   local.get $6
    i32.const 0
    i32.store $0 offset=12
-   local.get $5
+   local.get $7
    i32.const 268435455
    i32.gt_u
    if
@@ -15562,108 +15720,138 @@
    end
    global.get $~lib/memory/__stack_pointer
    i32.const 8
-   local.get $5
-   local.get $5
+   local.get $7
+   local.get $7
    i32.const 8
    i32.le_u
    select
    i32.const 2
    i32.shl
-   local.tee $6
+   local.tee $0
    i32.const 1
    call $~lib/rt/itcms/__new
-   local.tee $7
+   local.tee $5
    i32.store $0 offset=4
-   local.get $10
-   local.get $7
+   local.get $6
+   local.get $5
    i32.store $0
-   local.get $7
+   local.get $5
    if
-    local.get $10
-    local.get $7
+    local.get $6
+    local.get $5
     call $byn-split-outlined-A$~lib/rt/itcms/__link
    end
-   local.get $10
-   local.get $7
-   i32.store $0 offset=4
-   local.get $10
    local.get $6
-   i32.store $0 offset=8
-   local.get $10
    local.get $5
+   i32.store $0 offset=4
+   local.get $6
+   local.get $0
+   i32.store $0 offset=8
+   local.get $6
+   local.get $7
    i32.store $0 offset=12
    global.get $~lib/memory/__stack_pointer
    i32.const 8
    i32.add
    global.set $~lib/memory/__stack_pointer
-   local.get $9
-   local.get $10
+   local.get $3
+   local.get $6
    i32.store $0
    loop $for-loop|00
-    local.get $4
-    local.get $5
-    i32.lt_s
+    local.get $7
+    local.get $9
+    i32.gt_s
     if
-     local.get $1
      local.get $4
+     local.get $9
      i32.const 3
      i32.shl
      i32.add
-     local.tee $6
+     local.tee $0
      i32.load $0 offset=4
      i32.const 1
      i32.and
      i32.eqz
      if
-      local.get $10
+      local.get $0
+      f32.load $0
+      local.set $2
+      local.get $1
+      local.tee $0
+      i32.const 1
+      i32.add
+      local.set $1
+      local.get $0
+      local.get $6
+      i32.load $0 offset=12
+      i32.ge_u
+      if
+       local.get $0
+       i32.const 0
+       i32.lt_s
+       if
+        i32.const 1248
+        i32.const 1616
+        i32.const 130
+        i32.const 22
+        call $~lib/builtins/abort
+        unreachable
+       end
+       local.get $6
+       local.get $0
+       i32.const 1
+       i32.add
+       local.tee $3
+       i32.const 2
+       i32.const 1
+       call $~lib/array/ensureCapacity
+       local.get $6
+       local.get $3
+       i32.store $0 offset=12
+      end
+      local.get $6
       i32.load $0 offset=4
       local.get $0
       i32.const 2
       i32.shl
       i32.add
-      local.get $6
-      f32.load $0
+      local.get $2
       f32.store $0
-      local.get $0
-      i32.const 1
-      i32.add
-      local.set $0
      end
-     local.get $4
+     local.get $9
      i32.const 1
      i32.add
-     local.set $4
+     local.set $9
      br $for-loop|00
     end
    end
-   local.get $10
-   local.get $0
+   local.get $6
+   local.get $1
    i32.const 2
+   i32.const 0
    call $~lib/array/ensureCapacity
-   local.get $10
-   local.get $0
+   local.get $6
+   local.get $1
    i32.store $0 offset=12
    global.get $~lib/memory/__stack_pointer
    i32.const 4
    i32.add
    global.set $~lib/memory/__stack_pointer
    local.get $8
-   local.get $10
+   local.get $6
    i32.store $0 offset=4
    global.get $~lib/memory/__stack_pointer
    call $~lib/set/Set<f32>#constructor
-   local.tee $4
+   local.tee $3
    i32.store $0 offset=8
-   i32.const 0
-   local.set $0
    loop $for-loop|2
-    local.get $0
     local.get $10
+    local.get $6
     i32.load $0 offset=12
     i32.lt_s
     if
+     local.get $6
      local.get $10
-     local.get $0
      call $~lib/array/Array<f32>#__get
      local.tee $2
      i32.reinterpret_f32
@@ -15675,29 +15863,29 @@
      i32.rotl
      i32.const 668265263
      i32.mul
-     local.tee $1
-     local.get $1
+     local.tee $0
+     local.get $0
      i32.const 15
      i32.shr_u
      i32.xor
      i32.const -2048144777
      i32.mul
-     local.tee $1
-     local.get $1
+     local.tee $0
+     local.get $0
      i32.const 13
      i32.shr_u
      i32.xor
      i32.const -1028477379
      i32.mul
-     local.set $1
-     local.get $3
+     local.set $0
+     local.get $11
      i32.load $0
-     local.get $3
+     local.get $11
      i32.load $0 offset=4
-     local.get $1
+     local.get $0
      i32.const 16
      i32.shr_u
-     local.get $1
+     local.get $0
      i32.xor
      i32.and
      i32.const 2
@@ -15711,7 +15899,7 @@
        if
         local.get $1
         i32.load $0 offset=4
-        local.tee $5
+        local.tee $0
         i32.const 1
         i32.and
         if (result i32)
@@ -15723,7 +15911,7 @@
          f32.eq
         end
         br_if $__inlined_func$~lib/set/Set<f32>#find11
-        local.get $5
+        local.get $0
         i32.const -2
         i32.and
         local.set $1
@@ -15743,21 +15931,21 @@
       call $~lib/builtins/abort
       unreachable
      end
-     local.get $4
+     local.get $3
+     local.get $6
      local.get $10
-     local.get $0
      call $~lib/array/Array<f32>#__get
      call $~lib/set/Set<f32>#add
-     local.get $0
+     local.get $10
      i32.const 1
      i32.add
-     local.set $0
+     local.set $10
      br $for-loop|2
     end
    end
-   local.get $4
-   i32.load $0 offset=20
    local.get $3
+   i32.load $0 offset=20
+   local.get $11
    i32.load $0 offset=20
    i32.ne
    if
@@ -15775,9 +15963,9 @@
     f32.const 50
     f32.lt
     if
-     local.get $3
+     local.get $11
      i32.load $0
-     local.get $3
+     local.get $11
      i32.load $0 offset=4
      local.get $2
      i32.reinterpret_f32
@@ -15813,12 +16001,12 @@
      i32.shl
      i32.add
      i32.load $0
-     local.set $1
+     local.set $3
      block $__inlined_func$~lib/set/Set<f32>#find14
       loop $while-continue|015
-       local.get $1
+       local.get $3
        if
-        local.get $1
+        local.get $3
         i32.load $0 offset=4
         local.tee $0
         i32.const 1
@@ -15826,7 +16014,7 @@
         if (result i32)
          i32.const 0
         else
-         local.get $1
+         local.get $3
          f32.load $0
          local.get $2
          f32.eq
@@ -15835,14 +16023,14 @@
         local.get $0
         i32.const -2
         i32.and
-        local.set $1
+        local.set $3
         br $while-continue|015
        end
       end
       i32.const 0
-      local.set $1
+      local.set $3
      end
-     local.get $1
+     local.get $3
      i32.eqz
      if
       i32.const 0
@@ -15852,12 +16040,12 @@
       call $~lib/builtins/abort
       unreachable
      end
-     local.get $3
+     local.get $11
      local.get $2
      call $~lib/set/Set<f32>#delete
-     local.get $3
+     local.get $11
      i32.load $0
-     local.get $3
+     local.get $11
      i32.load $0 offset=4
      local.get $2
      i32.reinterpret_f32
@@ -15893,12 +16081,12 @@
      i32.shl
      i32.add
      i32.load $0
-     local.set $1
+     local.set $3
      block $__inlined_func$~lib/set/Set<f32>#find17
       loop $while-continue|018
-       local.get $1
+       local.get $3
        if
-        local.get $1
+        local.get $3
         i32.load $0 offset=4
         local.tee $0
         i32.const 1
@@ -15906,7 +16094,7 @@
         if (result i32)
          i32.const 0
         else
-         local.get $1
+         local.get $3
          f32.load $0
          local.get $2
          f32.eq
@@ -15915,14 +16103,14 @@
         local.get $0
         i32.const -2
         i32.and
-        local.set $1
+        local.set $3
         br $while-continue|018
        end
       end
       i32.const 0
-      local.set $1
+      local.set $3
      end
-     local.get $1
+     local.get $3
      if
       i32.const 0
       i32.const 1568
@@ -15938,7 +16126,7 @@
      br $for-loop|3
     end
    end
-   local.get $3
+   local.get $11
    i32.load $0 offset=20
    i32.const 50
    i32.ne
@@ -15957,9 +16145,9 @@
     f32.const 50
     f32.lt
     if
-     local.get $3
+     local.get $11
      i32.load $0
-     local.get $3
+     local.get $11
      i32.load $0 offset=4
      local.get $2
      i32.reinterpret_f32
@@ -15995,12 +16183,12 @@
      i32.shl
      i32.add
      i32.load $0
-     local.set $1
+     local.set $3
      block $__inlined_func$~lib/set/Set<f32>#find20
       loop $while-continue|021
-       local.get $1
+       local.get $3
        if
-        local.get $1
+        local.get $3
         i32.load $0 offset=4
         local.tee $0
         i32.const 1
@@ -16008,7 +16196,7 @@
         if (result i32)
          i32.const 0
         else
-         local.get $1
+         local.get $3
          f32.load $0
          local.get $2
          f32.eq
@@ -16017,14 +16205,14 @@
         local.get $0
         i32.const -2
         i32.and
-        local.set $1
+        local.set $3
         br $while-continue|021
        end
       end
       i32.const 0
-      local.set $1
+      local.set $3
      end
-     local.get $1
+     local.get $3
      if
       i32.const 0
       i32.const 1568
@@ -16033,12 +16221,12 @@
       call $~lib/builtins/abort
       unreachable
      end
-     local.get $3
+     local.get $11
      local.get $2
      call $~lib/set/Set<f32>#add
-     local.get $3
+     local.get $11
      i32.load $0
-     local.get $3
+     local.get $11
      i32.load $0 offset=4
      local.get $2
      i32.reinterpret_f32
@@ -16074,12 +16262,12 @@
      i32.shl
      i32.add
      i32.load $0
-     local.set $1
+     local.set $3
      block $__inlined_func$~lib/set/Set<f32>#find23
       loop $while-continue|024
-       local.get $1
+       local.get $3
        if
-        local.get $1
+        local.get $3
         i32.load $0 offset=4
         local.tee $0
         i32.const 1
@@ -16087,7 +16275,7 @@
         if (result i32)
          i32.const 0
         else
-         local.get $1
+         local.get $3
          f32.load $0
          local.get $2
          f32.eq
@@ -16096,14 +16284,14 @@
         local.get $0
         i32.const -2
         i32.and
-        local.set $1
+        local.set $3
         br $while-continue|024
        end
       end
       i32.const 0
-      local.set $1
+      local.set $3
      end
-     local.get $1
+     local.get $3
      i32.eqz
      if
       i32.const 0
@@ -16113,12 +16301,12 @@
       call $~lib/builtins/abort
       unreachable
      end
-     local.get $3
+     local.get $11
      local.get $2
      call $~lib/set/Set<f32>#delete
-     local.get $3
+     local.get $11
      i32.load $0
-     local.get $3
+     local.get $11
      i32.load $0 offset=4
      local.get $2
      i32.reinterpret_f32
@@ -16154,12 +16342,12 @@
      i32.shl
      i32.add
      i32.load $0
-     local.set $1
+     local.set $3
      block $__inlined_func$~lib/set/Set<f32>#find26
       loop $while-continue|027
-       local.get $1
+       local.get $3
        if
-        local.get $1
+        local.get $3
         i32.load $0 offset=4
         local.tee $0
         i32.const 1
@@ -16167,7 +16355,7 @@
         if (result i32)
          i32.const 0
         else
-         local.get $1
+         local.get $3
          f32.load $0
          local.get $2
          f32.eq
@@ -16176,14 +16364,14 @@
         local.get $0
         i32.const -2
         i32.and
-        local.set $1
+        local.set $3
         br $while-continue|027
        end
       end
       i32.const 0
-      local.set $1
+      local.set $3
      end
-     local.get $1
+     local.get $3
      if
       i32.const 0
       i32.const 1568
@@ -16199,7 +16387,7 @@
      br $for-loop|4
     end
    end
-   local.get $3
+   local.get $11
    i32.load $0 offset=20
    i32.const 50
    i32.ne
@@ -16211,9 +16399,9 @@
     call $~lib/builtins/abort
     unreachable
    end
-   local.get $3
+   local.get $11
    call $~lib/set/Set<i8>#clear
-   local.get $3
+   local.get $11
    i32.load $0 offset=20
    if
     i32.const 0
@@ -16733,16 +16921,17 @@
  )
  (func $std/set/testNumeric<f64> (type $none_=>_none)
   (local $0 i32)
-  (local $1 f64)
-  (local $2 i32)
-  (local $3 i32)
-  (local $4 i64)
+  (local $1 i32)
+  (local $2 i64)
+  (local $3 f64)
+  (local $4 i32)
   (local $5 i32)
   (local $6 i32)
   (local $7 i32)
   (local $8 i32)
   (local $9 i32)
   (local $10 i32)
+  (local $11 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 12
   i32.sub
@@ -16761,20 +16950,20 @@
    i32.store $0 offset=8
    local.get $0
    call $~lib/set/Set<f64>#constructor
-   local.tee $3
+   local.tee $11
    i32.store $0
    loop $for-loop|0
-    local.get $1
+    local.get $3
     f64.const 100
     f64.lt
     if
-     local.get $3
+     local.get $11
      i32.load $0
-     local.get $3
+     local.get $11
      i32.load $0 offset=4
-     local.get $1
+     local.get $3
      i64.reinterpret_f64
-     local.tee $4
+     local.tee $2
      i32.wrap_i64
      i32.const -1028477379
      i32.mul
@@ -16784,7 +16973,7 @@
      i32.rotl
      i32.const 668265263
      i32.mul
-     local.get $4
+     local.get $2
      i64.const 32
      i64.shr_u
      i32.wrap_i64
@@ -16819,36 +17008,36 @@
      i32.shl
      i32.add
      i32.load $0
-     local.set $0
+     local.set $5
      block $__inlined_func$~lib/set/Set<f64>#find
       loop $while-continue|0
-       local.get $0
+       local.get $5
        if
-        local.get $0
+        local.get $5
         i32.load $0 offset=8
-        local.tee $5
+        local.tee $0
         i32.const 1
         i32.and
         if (result i32)
          i32.const 0
         else
-         local.get $1
-         local.get $0
+         local.get $3
+         local.get $5
          f64.load $0
          f64.eq
         end
         br_if $__inlined_func$~lib/set/Set<f64>#find
-        local.get $5
+        local.get $0
         i32.const -2
         i32.and
-        local.set $0
+        local.set $5
         br $while-continue|0
        end
       end
       i32.const 0
-      local.set $0
+      local.set $5
      end
-     local.get $0
+     local.get $5
      if
       i32.const 0
       i32.const 1568
@@ -16857,16 +17046,16 @@
       call $~lib/builtins/abort
       unreachable
      end
+     local.get $11
      local.get $3
-     local.get $1
      call $~lib/set/Set<f64>#add
-     local.get $3
+     local.get $11
      i32.load $0
-     local.get $3
+     local.get $11
      i32.load $0 offset=4
-     local.get $1
+     local.get $3
      i64.reinterpret_f64
-     local.tee $4
+     local.tee $2
      i32.wrap_i64
      i32.const -1028477379
      i32.mul
@@ -16876,7 +17065,7 @@
      i32.rotl
      i32.const 668265263
      i32.mul
-     local.get $4
+     local.get $2
      i64.const 32
      i64.shr_u
      i32.wrap_i64
@@ -16911,36 +17100,36 @@
      i32.shl
      i32.add
      i32.load $0
-     local.set $0
+     local.set $5
      block $__inlined_func$~lib/set/Set<f64>#find0
       loop $while-continue|04
-       local.get $0
+       local.get $5
        if
-        local.get $0
+        local.get $5
         i32.load $0 offset=8
-        local.tee $5
+        local.tee $0
         i32.const 1
         i32.and
         if (result i32)
          i32.const 0
         else
-         local.get $1
-         local.get $0
+         local.get $3
+         local.get $5
          f64.load $0
          f64.eq
         end
         br_if $__inlined_func$~lib/set/Set<f64>#find0
-        local.get $5
+        local.get $0
         i32.const -2
         i32.and
-        local.set $0
+        local.set $5
         br $while-continue|04
        end
       end
       i32.const 0
-      local.set $0
+      local.set $5
      end
-     local.get $0
+     local.get $5
      i32.eqz
      if
       i32.const 0
@@ -16950,14 +17139,14 @@
       call $~lib/builtins/abort
       unreachable
      end
-     local.get $1
+     local.get $3
      f64.const 1
      f64.add
-     local.set $1
+     local.set $3
      br $for-loop|0
     end
    end
-   local.get $3
+   local.get $11
    i32.load $0 offset=20
    i32.const 100
    i32.ne
@@ -16970,19 +17159,19 @@
     unreachable
    end
    f64.const 50
-   local.set $1
+   local.set $3
    loop $for-loop|1
-    local.get $1
+    local.get $3
     f64.const 100
     f64.lt
     if
-     local.get $3
+     local.get $11
      i32.load $0
-     local.get $3
+     local.get $11
      i32.load $0 offset=4
-     local.get $1
+     local.get $3
      i64.reinterpret_f64
-     local.tee $4
+     local.tee $2
      i32.wrap_i64
      i32.const -1028477379
      i32.mul
@@ -16992,7 +17181,7 @@
      i32.rotl
      i32.const 668265263
      i32.mul
-     local.get $4
+     local.get $2
      i64.const 32
      i64.shr_u
      i32.wrap_i64
@@ -17027,36 +17216,36 @@
      i32.shl
      i32.add
      i32.load $0
-     local.set $0
+     local.set $5
      block $__inlined_func$~lib/set/Set<f64>#find7
       loop $while-continue|011
-       local.get $0
+       local.get $5
        if
-        local.get $0
+        local.get $5
         i32.load $0 offset=8
-        local.tee $5
+        local.tee $0
         i32.const 1
         i32.and
         if (result i32)
          i32.const 0
         else
-         local.get $1
-         local.get $0
+         local.get $3
+         local.get $5
          f64.load $0
          f64.eq
         end
         br_if $__inlined_func$~lib/set/Set<f64>#find7
-        local.get $5
+        local.get $0
         i32.const -2
         i32.and
-        local.set $0
+        local.set $5
         br $while-continue|011
        end
       end
       i32.const 0
-      local.set $0
+      local.set $5
      end
-     local.get $0
+     local.get $5
      i32.eqz
      if
       i32.const 0
@@ -17066,16 +17255,16 @@
       call $~lib/builtins/abort
       unreachable
      end
+     local.get $11
      local.get $3
-     local.get $1
      call $~lib/set/Set<f64>#add
-     local.get $3
+     local.get $11
      i32.load $0
-     local.get $3
+     local.get $11
      i32.load $0 offset=4
-     local.get $1
+     local.get $3
      i64.reinterpret_f64
-     local.tee $4
+     local.tee $2
      i32.wrap_i64
      i32.const -1028477379
      i32.mul
@@ -17085,7 +17274,7 @@
      i32.rotl
      i32.const 668265263
      i32.mul
-     local.get $4
+     local.get $2
      i64.const 32
      i64.shr_u
      i32.wrap_i64
@@ -17120,36 +17309,36 @@
      i32.shl
      i32.add
      i32.load $0
-     local.set $0
+     local.set $5
      block $__inlined_func$~lib/set/Set<f64>#find14
       loop $while-continue|018
-       local.get $0
+       local.get $5
        if
-        local.get $0
+        local.get $5
         i32.load $0 offset=8
-        local.tee $5
+        local.tee $0
         i32.const 1
         i32.and
         if (result i32)
          i32.const 0
         else
-         local.get $1
-         local.get $0
+         local.get $3
+         local.get $5
          f64.load $0
          f64.eq
         end
         br_if $__inlined_func$~lib/set/Set<f64>#find14
-        local.get $5
+        local.get $0
         i32.const -2
         i32.and
-        local.set $0
+        local.set $5
         br $while-continue|018
        end
       end
       i32.const 0
-      local.set $0
+      local.set $5
      end
-     local.get $0
+     local.get $5
      i32.eqz
      if
       i32.const 0
@@ -17159,14 +17348,14 @@
       call $~lib/builtins/abort
       unreachable
      end
-     local.get $1
+     local.get $3
      f64.const 1
      f64.add
-     local.set $1
+     local.set $3
      br $for-loop|1
     end
    end
-   local.get $3
+   local.get $11
    i32.load $0 offset=20
    i32.const 100
    i32.ne
@@ -17179,7 +17368,7 @@
     unreachable
    end
    global.get $~lib/memory/__stack_pointer
-   local.tee $6
+   local.tee $9
    i32.const 4
    i32.sub
    global.set $~lib/memory/__stack_pointer
@@ -17188,16 +17377,16 @@
    i32.lt_s
    br_if $folding-inner0
    global.get $~lib/memory/__stack_pointer
-   local.tee $7
+   local.tee $4
    i32.const 0
    i32.store $0
-   local.get $3
+   local.get $11
    i32.load $0 offset=8
-   local.set $8
-   local.get $3
-   i32.load $0 offset=16
    local.set $5
-   local.get $7
+   local.get $11
+   i32.load $0 offset=16
+   local.set $8
+   local.get $4
    i32.const 8
    i32.sub
    global.set $~lib/memory/__stack_pointer
@@ -17213,21 +17402,21 @@
    i32.const 16
    i32.const 23
    call $~lib/rt/itcms/__new
-   local.tee $9
+   local.tee $7
    i32.store $0
-   local.get $9
+   local.get $7
    i32.const 0
    i32.store $0
-   local.get $9
+   local.get $7
    i32.const 0
    i32.store $0 offset=4
-   local.get $9
+   local.get $7
    i32.const 0
    i32.store $0 offset=8
-   local.get $9
+   local.get $7
    i32.const 0
    i32.store $0 offset=12
-   local.get $5
+   local.get $8
    i32.const 134217727
    i32.gt_u
    if
@@ -17240,114 +17429,144 @@
    end
    global.get $~lib/memory/__stack_pointer
    i32.const 8
-   local.get $5
-   local.get $5
+   local.get $8
+   local.get $8
    i32.const 8
    i32.le_u
    select
    i32.const 3
    i32.shl
-   local.tee $10
+   local.tee $0
    i32.const 1
    call $~lib/rt/itcms/__new
-   local.tee $0
+   local.tee $6
    i32.store $0 offset=4
-   local.get $9
-   local.get $0
+   local.get $7
+   local.get $6
    i32.store $0
-   local.get $0
+   local.get $6
    if
-    local.get $9
-    local.get $0
+    local.get $7
+    local.get $6
     call $byn-split-outlined-A$~lib/rt/itcms/__link
    end
-   local.get $9
-   local.get $0
+   local.get $7
+   local.get $6
    i32.store $0 offset=4
-   local.get $9
-   local.get $10
+   local.get $7
+   local.get $0
    i32.store $0 offset=8
-   local.get $9
-   local.get $5
+   local.get $7
+   local.get $8
    i32.store $0 offset=12
    global.get $~lib/memory/__stack_pointer
    i32.const 8
    i32.add
    global.set $~lib/memory/__stack_pointer
+   local.get $4
    local.get $7
-   local.get $9
    i32.store $0
-   i32.const 0
-   local.set $0
    loop $for-loop|03
-    local.get $2
-    local.get $5
-    i32.lt_s
+    local.get $8
+    local.get $10
+    i32.gt_s
     if
-     local.get $8
-     local.get $2
+     local.get $5
+     local.get $10
      i32.const 4
      i32.shl
      i32.add
-     local.tee $7
+     local.tee $0
      i32.load $0 offset=8
      i32.const 1
      i32.and
      i32.eqz
      if
-      local.get $9
+      local.get $0
+      f64.load $0
+      local.set $3
+      local.get $1
+      local.tee $0
+      i32.const 1
+      i32.add
+      local.set $1
+      local.get $0
+      local.get $7
+      i32.load $0 offset=12
+      i32.ge_u
+      if
+       local.get $0
+       i32.const 0
+       i32.lt_s
+       if
+        i32.const 1248
+        i32.const 1616
+        i32.const 130
+        i32.const 22
+        call $~lib/builtins/abort
+        unreachable
+       end
+       local.get $7
+       local.get $0
+       i32.const 1
+       i32.add
+       local.tee $4
+       i32.const 3
+       i32.const 1
+       call $~lib/array/ensureCapacity
+       local.get $7
+       local.get $4
+       i32.store $0 offset=12
+      end
+      local.get $7
       i32.load $0 offset=4
       local.get $0
       i32.const 3
       i32.shl
       i32.add
-      local.get $7
-      f64.load $0
+      local.get $3
       f64.store $0
-      local.get $0
-      i32.const 1
-      i32.add
-      local.set $0
      end
-     local.get $2
+     local.get $10
      i32.const 1
      i32.add
-     local.set $2
+     local.set $10
      br $for-loop|03
     end
    end
-   local.get $9
-   local.get $0
+   local.get $7
+   local.get $1
    i32.const 3
+   i32.const 0
    call $~lib/array/ensureCapacity
-   local.get $9
-   local.get $0
+   local.get $7
+   local.get $1
    i32.store $0 offset=12
    global.get $~lib/memory/__stack_pointer
    i32.const 4
    i32.add
    global.set $~lib/memory/__stack_pointer
-   local.get $6
    local.get $9
+   local.get $7
    i32.store $0 offset=4
    global.get $~lib/memory/__stack_pointer
    call $~lib/set/Set<f64>#constructor
-   local.tee $5
+   local.tee $4
    i32.store $0 offset=8
    i32.const 0
-   local.set $0
+   local.set $5
    loop $for-loop|2
-    local.get $0
-    local.get $9
+    local.get $5
+    local.get $7
     i32.load $0 offset=12
     i32.lt_s
     if
-     local.get $9
-     local.get $0
+     local.get $7
+     local.get $5
      call $~lib/array/Array<f64>#__get
-     local.tee $1
+     local.tee $3
      i64.reinterpret_f64
-     local.tee $4
+     local.tee $2
      i32.wrap_i64
      i32.const -1028477379
      i32.mul
@@ -17357,7 +17576,7 @@
      i32.rotl
      i32.const 668265263
      i32.mul
-     local.get $4
+     local.get $2
      i64.const 32
      i64.shr_u
      i32.wrap_i64
@@ -17368,65 +17587,65 @@
      i32.rotl
      i32.const 668265263
      i32.mul
-     local.tee $2
-     local.get $2
+     local.tee $0
+     local.get $0
      i32.const 15
      i32.shr_u
      i32.xor
      i32.const -2048144777
      i32.mul
-     local.tee $2
-     local.get $2
+     local.tee $0
+     local.get $0
      i32.const 13
      i32.shr_u
      i32.xor
      i32.const -1028477379
      i32.mul
-     local.set $2
-     local.get $3
+     local.set $0
+     local.get $11
      i32.load $0
-     local.get $3
+     local.get $11
      i32.load $0 offset=4
-     local.get $2
+     local.get $0
      i32.const 16
      i32.shr_u
-     local.get $2
+     local.get $0
      i32.xor
      i32.and
      i32.const 2
      i32.shl
      i32.add
      i32.load $0
-     local.set $2
-     block $__inlined_func$~lib/set/Set<f64>#find29
-      loop $while-continue|033
-       local.get $2
+     local.set $1
+     block $__inlined_func$~lib/set/Set<f64>#find31
+      loop $while-continue|035
+       local.get $1
        if
-        local.get $2
+        local.get $1
         i32.load $0 offset=8
-        local.tee $6
+        local.tee $0
         i32.const 1
         i32.and
         if (result i32)
          i32.const 0
         else
+         local.get $3
          local.get $1
-         local.get $2
          f64.load $0
          f64.eq
         end
-        br_if $__inlined_func$~lib/set/Set<f64>#find29
-        local.get $6
+        br_if $__inlined_func$~lib/set/Set<f64>#find31
+        local.get $0
         i32.const -2
         i32.and
-        local.set $2
-        br $while-continue|033
+        local.set $1
+        br $while-continue|035
        end
       end
       i32.const 0
-      local.set $2
+      local.set $1
      end
-     local.get $2
+     local.get $1
      i32.eqz
      if
       i32.const 0
@@ -17436,21 +17655,21 @@
       call $~lib/builtins/abort
       unreachable
      end
+     local.get $4
+     local.get $7
      local.get $5
-     local.get $9
-     local.get $0
      call $~lib/array/Array<f64>#__get
      call $~lib/set/Set<f64>#add
-     local.get $0
+     local.get $5
      i32.const 1
      i32.add
-     local.set $0
+     local.set $5
      br $for-loop|2
     end
    end
-   local.get $5
+   local.get $4
    i32.load $0 offset=20
-   local.get $3
+   local.get $11
    i32.load $0 offset=20
    i32.ne
    if
@@ -17462,19 +17681,19 @@
     unreachable
    end
    f64.const 0
-   local.set $1
+   local.set $3
    loop $for-loop|3
-    local.get $1
+    local.get $3
     f64.const 50
     f64.lt
     if
-     local.get $3
+     local.get $11
      i32.load $0
-     local.get $3
+     local.get $11
      i32.load $0 offset=4
-     local.get $1
+     local.get $3
      i64.reinterpret_f64
-     local.tee $4
+     local.tee $2
      i32.wrap_i64
      i32.const -1028477379
      i32.mul
@@ -17484,7 +17703,7 @@
      i32.rotl
      i32.const 668265263
      i32.mul
-     local.get $4
+     local.get $2
      i64.const 32
      i64.shr_u
      i32.wrap_i64
@@ -17519,36 +17738,36 @@
      i32.shl
      i32.add
      i32.load $0
-     local.set $0
-     block $__inlined_func$~lib/set/Set<f64>#find40
-      loop $while-continue|044
-       local.get $0
+     local.set $5
+     block $__inlined_func$~lib/set/Set<f64>#find42
+      loop $while-continue|046
+       local.get $5
        if
-        local.get $0
+        local.get $5
         i32.load $0 offset=8
-        local.tee $2
+        local.tee $0
         i32.const 1
         i32.and
         if (result i32)
          i32.const 0
         else
-         local.get $1
-         local.get $0
+         local.get $3
+         local.get $5
          f64.load $0
          f64.eq
         end
-        br_if $__inlined_func$~lib/set/Set<f64>#find40
-        local.get $2
+        br_if $__inlined_func$~lib/set/Set<f64>#find42
+        local.get $0
         i32.const -2
         i32.and
-        local.set $0
-        br $while-continue|044
+        local.set $5
+        br $while-continue|046
        end
       end
       i32.const 0
-      local.set $0
+      local.set $5
      end
-     local.get $0
+     local.get $5
      i32.eqz
      if
       i32.const 0
@@ -17558,16 +17777,16 @@
       call $~lib/builtins/abort
       unreachable
      end
+     local.get $11
      local.get $3
-     local.get $1
      call $~lib/set/Set<f64>#delete
-     local.get $3
+     local.get $11
      i32.load $0
-     local.get $3
+     local.get $11
      i32.load $0 offset=4
-     local.get $1
+     local.get $3
      i64.reinterpret_f64
-     local.tee $4
+     local.tee $2
      i32.wrap_i64
      i32.const -1028477379
      i32.mul
@@ -17577,7 +17796,7 @@
      i32.rotl
      i32.const 668265263
      i32.mul
-     local.get $4
+     local.get $2
      i64.const 32
      i64.shr_u
      i32.wrap_i64
@@ -17612,36 +17831,36 @@
      i32.shl
      i32.add
      i32.load $0
-     local.set $0
-     block $__inlined_func$~lib/set/Set<f64>#find47
-      loop $while-continue|051
-       local.get $0
+     local.set $5
+     block $__inlined_func$~lib/set/Set<f64>#find49
+      loop $while-continue|053
+       local.get $5
        if
-        local.get $0
+        local.get $5
         i32.load $0 offset=8
-        local.tee $2
+        local.tee $0
         i32.const 1
         i32.and
         if (result i32)
          i32.const 0
         else
-         local.get $1
-         local.get $0
+         local.get $3
+         local.get $5
          f64.load $0
          f64.eq
         end
-        br_if $__inlined_func$~lib/set/Set<f64>#find47
-        local.get $2
+        br_if $__inlined_func$~lib/set/Set<f64>#find49
+        local.get $0
         i32.const -2
         i32.and
-        local.set $0
-        br $while-continue|051
+        local.set $5
+        br $while-continue|053
        end
       end
       i32.const 0
-      local.set $0
+      local.set $5
      end
-     local.get $0
+     local.get $5
      if
       i32.const 0
       i32.const 1568
@@ -17650,14 +17869,14 @@
       call $~lib/builtins/abort
       unreachable
      end
-     local.get $1
+     local.get $3
      f64.const 1
      f64.add
-     local.set $1
+     local.set $3
      br $for-loop|3
     end
    end
-   local.get $3
+   local.get $11
    i32.load $0 offset=20
    i32.const 50
    i32.ne
@@ -17670,19 +17889,19 @@
     unreachable
    end
    f64.const 0
-   local.set $1
+   local.set $3
    loop $for-loop|4
-    local.get $1
+    local.get $3
     f64.const 50
     f64.lt
     if
-     local.get $3
+     local.get $11
      i32.load $0
-     local.get $3
+     local.get $11
      i32.load $0 offset=4
-     local.get $1
+     local.get $3
      i64.reinterpret_f64
-     local.tee $4
+     local.tee $2
      i32.wrap_i64
      i32.const -1028477379
      i32.mul
@@ -17692,7 +17911,7 @@
      i32.rotl
      i32.const 668265263
      i32.mul
-     local.get $4
+     local.get $2
      i64.const 32
      i64.shr_u
      i32.wrap_i64
@@ -17727,36 +17946,36 @@
      i32.shl
      i32.add
      i32.load $0
-     local.set $0
-     block $__inlined_func$~lib/set/Set<f64>#find56
-      loop $while-continue|060
-       local.get $0
+     local.set $5
+     block $__inlined_func$~lib/set/Set<f64>#find58
+      loop $while-continue|062
+       local.get $5
        if
-        local.get $0
+        local.get $5
         i32.load $0 offset=8
-        local.tee $2
+        local.tee $0
         i32.const 1
         i32.and
         if (result i32)
          i32.const 0
         else
-         local.get $1
-         local.get $0
+         local.get $3
+         local.get $5
          f64.load $0
          f64.eq
         end
-        br_if $__inlined_func$~lib/set/Set<f64>#find56
-        local.get $2
+        br_if $__inlined_func$~lib/set/Set<f64>#find58
+        local.get $0
         i32.const -2
         i32.and
-        local.set $0
-        br $while-continue|060
+        local.set $5
+        br $while-continue|062
        end
       end
       i32.const 0
-      local.set $0
+      local.set $5
      end
-     local.get $0
+     local.get $5
      if
       i32.const 0
       i32.const 1568
@@ -17765,16 +17984,16 @@
       call $~lib/builtins/abort
       unreachable
      end
+     local.get $11
      local.get $3
-     local.get $1
      call $~lib/set/Set<f64>#add
-     local.get $3
+     local.get $11
      i32.load $0
-     local.get $3
+     local.get $11
      i32.load $0 offset=4
-     local.get $1
+     local.get $3
      i64.reinterpret_f64
-     local.tee $4
+     local.tee $2
      i32.wrap_i64
      i32.const -1028477379
      i32.mul
@@ -17784,7 +18003,7 @@
      i32.rotl
      i32.const 668265263
      i32.mul
-     local.get $4
+     local.get $2
      i64.const 32
      i64.shr_u
      i32.wrap_i64
@@ -17819,36 +18038,36 @@
      i32.shl
      i32.add
      i32.load $0
-     local.set $0
-     block $__inlined_func$~lib/set/Set<f64>#find63
-      loop $while-continue|067
-       local.get $0
+     local.set $5
+     block $__inlined_func$~lib/set/Set<f64>#find65
+      loop $while-continue|069
+       local.get $5
        if
-        local.get $0
+        local.get $5
         i32.load $0 offset=8
-        local.tee $2
+        local.tee $0
         i32.const 1
         i32.and
         if (result i32)
          i32.const 0
         else
-         local.get $1
-         local.get $0
+         local.get $3
+         local.get $5
          f64.load $0
          f64.eq
         end
-        br_if $__inlined_func$~lib/set/Set<f64>#find63
-        local.get $2
+        br_if $__inlined_func$~lib/set/Set<f64>#find65
+        local.get $0
         i32.const -2
         i32.and
-        local.set $0
-        br $while-continue|067
+        local.set $5
+        br $while-continue|069
        end
       end
       i32.const 0
-      local.set $0
+      local.set $5
      end
-     local.get $0
+     local.get $5
      i32.eqz
      if
       i32.const 0
@@ -17858,16 +18077,16 @@
       call $~lib/builtins/abort
       unreachable
      end
+     local.get $11
      local.get $3
-     local.get $1
      call $~lib/set/Set<f64>#delete
-     local.get $3
+     local.get $11
      i32.load $0
-     local.get $3
+     local.get $11
      i32.load $0 offset=4
-     local.get $1
+     local.get $3
      i64.reinterpret_f64
-     local.tee $4
+     local.tee $2
      i32.wrap_i64
      i32.const -1028477379
      i32.mul
@@ -17877,7 +18096,7 @@
      i32.rotl
      i32.const 668265263
      i32.mul
-     local.get $4
+     local.get $2
      i64.const 32
      i64.shr_u
      i32.wrap_i64
@@ -17912,36 +18131,36 @@
      i32.shl
      i32.add
      i32.load $0
-     local.set $0
-     block $__inlined_func$~lib/set/Set<f64>#find70
-      loop $while-continue|074
-       local.get $0
+     local.set $5
+     block $__inlined_func$~lib/set/Set<f64>#find72
+      loop $while-continue|076
+       local.get $5
        if
-        local.get $0
+        local.get $5
         i32.load $0 offset=8
-        local.tee $2
+        local.tee $0
         i32.const 1
         i32.and
         if (result i32)
          i32.const 0
         else
-         local.get $1
-         local.get $0
+         local.get $3
+         local.get $5
          f64.load $0
          f64.eq
         end
-        br_if $__inlined_func$~lib/set/Set<f64>#find70
-        local.get $2
+        br_if $__inlined_func$~lib/set/Set<f64>#find72
+        local.get $0
         i32.const -2
         i32.and
-        local.set $0
-        br $while-continue|074
+        local.set $5
+        br $while-continue|076
        end
       end
       i32.const 0
-      local.set $0
+      local.set $5
      end
-     local.get $0
+     local.get $5
      if
       i32.const 0
       i32.const 1568
@@ -17950,14 +18169,14 @@
       call $~lib/builtins/abort
       unreachable
      end
-     local.get $1
+     local.get $3
      f64.const 1
      f64.add
-     local.set $1
+     local.set $3
      br $for-loop|4
     end
    end
-   local.get $3
+   local.get $11
    i32.load $0 offset=20
    i32.const 50
    i32.ne
@@ -17969,9 +18188,9 @@
     call $~lib/builtins/abort
     unreachable
    end
-   local.get $3
+   local.get $11
    call $~lib/set/Set<i64>#clear
-   local.get $3
+   local.get $11
    i32.load $0 offset=20
    if
     i32.const 0

--- a/tests/compiler/std/static-array.debug.wat
+++ b/tests/compiler/std/static-array.debug.wat
@@ -3,17 +3,17 @@
  (type $i32_i32_=>_none (func_subtype (param i32 i32) func))
  (type $i32_=>_none (func_subtype (param i32) func))
  (type $i32_i32_=>_i32 (func_subtype (param i32 i32) (result i32) func))
- (type $i32_i32_i32_=>_none (func_subtype (param i32 i32 i32) func))
  (type $none_=>_none (func_subtype func))
+ (type $i32_i32_i32_=>_none (func_subtype (param i32 i32 i32) func))
  (type $i32_i32_i32_i32_=>_none (func_subtype (param i32 i32 i32 i32) func))
- (type $i32_i32_i64_=>_none (func_subtype (param i32 i32 i64) func))
- (type $i32_i32_f32_=>_none (func_subtype (param i32 i32 f32) func))
- (type $i32_i32_f64_=>_none (func_subtype (param i32 i32 f64) func))
  (type $i32_i32_i32_=>_i32 (func_subtype (param i32 i32 i32) (result i32) func))
  (type $none_=>_i32 (func_subtype (result i32) func))
  (type $i32_i32_=>_i64 (func_subtype (param i32 i32) (result i64) func))
+ (type $i32_i32_i64_=>_none (func_subtype (param i32 i32 i64) func))
  (type $i32_i32_=>_f32 (func_subtype (param i32 i32) (result f32) func))
+ (type $i32_i32_f32_=>_none (func_subtype (param i32 i32 f32) func))
  (type $i32_i32_=>_f64 (func_subtype (param i32 i32) (result f64) func))
+ (type $i32_i32_f64_=>_none (func_subtype (param i32 i32 f64) func))
  (import "env" "abort" (func $~lib/builtins/abort (param i32 i32 i32 i32)))
  (global $std/static-array/i i32 (i32.const 64))
  (global $std/static-array/I i32 (i32.const 160))
@@ -2523,18 +2523,6 @@
   local.get $length_
   i32.store $0 offset=12
  )
- (func $~lib/array/Array<i32>#__uset (type $i32_i32_i32_=>_none) (param $this i32) (param $index i32) (param $value i32)
-  local.get $this
-  call $~lib/array/Array<i32>#get:dataStart
-  local.get $index
-  i32.const 2
-  i32.shl
-  i32.add
-  local.get $value
-  i32.store $0
-  i32.const 0
-  drop
- )
  (func $~lib/array/Array<i32>#__set (type $i32_i32_i32_=>_none) (param $this i32) (param $index i32) (param $value i32)
   local.get $index
   local.get $this
@@ -2566,9 +2554,15 @@
    call $~lib/array/Array<i32>#set:length_
   end
   local.get $this
+  call $~lib/array/Array<i32>#get:dataStart
   local.get $index
+  i32.const 2
+  i32.shl
+  i32.add
   local.get $value
-  call $~lib/array/Array<i32>#__uset
+  i32.store $0
+  i32.const 0
+  drop
  )
  (func $~lib/array/Array<i64>#get:length_ (type $i32_=>_i32) (param $this i32) (result i32)
   local.get $this
@@ -2615,18 +2609,6 @@
   local.get $length_
   i32.store $0 offset=12
  )
- (func $~lib/array/Array<i64>#__uset (type $i32_i32_i64_=>_none) (param $this i32) (param $index i32) (param $value i64)
-  local.get $this
-  call $~lib/array/Array<i64>#get:dataStart
-  local.get $index
-  i32.const 3
-  i32.shl
-  i32.add
-  local.get $value
-  i64.store $0
-  i32.const 0
-  drop
- )
  (func $~lib/array/Array<i64>#__set (type $i32_i32_i64_=>_none) (param $this i32) (param $index i32) (param $value i64)
   local.get $index
   local.get $this
@@ -2658,9 +2640,15 @@
    call $~lib/array/Array<i64>#set:length_
   end
   local.get $this
+  call $~lib/array/Array<i64>#get:dataStart
   local.get $index
+  i32.const 3
+  i32.shl
+  i32.add
   local.get $value
-  call $~lib/array/Array<i64>#__uset
+  i64.store $0
+  i32.const 0
+  drop
  )
  (func $~lib/array/Array<f32>#get:length_ (type $i32_=>_i32) (param $this i32) (result i32)
   local.get $this
@@ -2707,18 +2695,6 @@
   local.get $length_
   i32.store $0 offset=12
  )
- (func $~lib/array/Array<f32>#__uset (type $i32_i32_f32_=>_none) (param $this i32) (param $index i32) (param $value f32)
-  local.get $this
-  call $~lib/array/Array<f32>#get:dataStart
-  local.get $index
-  i32.const 2
-  i32.shl
-  i32.add
-  local.get $value
-  f32.store $0
-  i32.const 0
-  drop
- )
  (func $~lib/array/Array<f32>#__set (type $i32_i32_f32_=>_none) (param $this i32) (param $index i32) (param $value f32)
   local.get $index
   local.get $this
@@ -2750,9 +2726,15 @@
    call $~lib/array/Array<f32>#set:length_
   end
   local.get $this
+  call $~lib/array/Array<f32>#get:dataStart
   local.get $index
+  i32.const 2
+  i32.shl
+  i32.add
   local.get $value
-  call $~lib/array/Array<f32>#__uset
+  f32.store $0
+  i32.const 0
+  drop
  )
  (func $~lib/array/Array<f64>#get:length_ (type $i32_=>_i32) (param $this i32) (result i32)
   local.get $this
@@ -2799,18 +2781,6 @@
   local.get $length_
   i32.store $0 offset=12
  )
- (func $~lib/array/Array<f64>#__uset (type $i32_i32_f64_=>_none) (param $this i32) (param $index i32) (param $value f64)
-  local.get $this
-  call $~lib/array/Array<f64>#get:dataStart
-  local.get $index
-  i32.const 3
-  i32.shl
-  i32.add
-  local.get $value
-  f64.store $0
-  i32.const 0
-  drop
- )
  (func $~lib/array/Array<f64>#__set (type $i32_i32_f64_=>_none) (param $this i32) (param $index i32) (param $value f64)
   local.get $index
   local.get $this
@@ -2842,9 +2812,15 @@
    call $~lib/array/Array<f64>#set:length_
   end
   local.get $this
+  call $~lib/array/Array<f64>#get:dataStart
   local.get $index
+  i32.const 3
+  i32.shl
+  i32.add
   local.get $value
-  call $~lib/array/Array<f64>#__uset
+  f64.store $0
+  i32.const 0
+  drop
  )
  (func $~lib/rt/__visit_globals (type $i32_=>_none) (param $0 i32)
   (local $1 i32)

--- a/tests/compiler/std/string.debug.wat
+++ b/tests/compiler/std/string.debug.wat
@@ -6194,26 +6194,6 @@
   local.get $end
   call $~lib/string/String#substring
  )
- (func $~lib/array/Array<~lib/string/String>#get:dataStart (type $i32_=>_i32) (param $this i32) (result i32)
-  local.get $this
-  i32.load $0 offset=4
- )
- (func $~lib/array/Array<~lib/string/String>#__uset (type $i32_i32_i32_=>_none) (param $this i32) (param $index i32) (param $value i32)
-  local.get $this
-  call $~lib/array/Array<~lib/string/String>#get:dataStart
-  local.get $index
-  i32.const 2
-  i32.shl
-  i32.add
-  local.get $value
-  i32.store $0
-  i32.const 1
-  drop
-  local.get $this
-  local.get $value
-  i32.const 1
-  call $~lib/rt/itcms/__link
- )
  (func $~lib/array/Array<~lib/string/String>#get:length_ (type $i32_=>_i32) (param $this i32) (result i32)
   local.get $this
   i32.load $0 offset=12
@@ -6326,6 +6306,55 @@
   local.get $this
   local.get $length_
   i32.store $0 offset=12
+ )
+ (func $~lib/array/Array<~lib/string/String>#get:dataStart (type $i32_=>_i32) (param $this i32) (result i32)
+  local.get $this
+  i32.load $0 offset=4
+ )
+ (func $~lib/array/Array<~lib/string/String>#__set (type $i32_i32_i32_=>_none) (param $this i32) (param $index i32) (param $value i32)
+  local.get $index
+  local.get $this
+  call $~lib/array/Array<~lib/string/String>#get:length_
+  i32.ge_u
+  if
+   local.get $index
+   i32.const 0
+   i32.lt_s
+   if
+    i32.const 240
+    i32.const 14640
+    i32.const 130
+    i32.const 22
+    call $~lib/builtins/abort
+    unreachable
+   end
+   local.get $this
+   local.get $index
+   i32.const 1
+   i32.add
+   i32.const 2
+   i32.const 1
+   call $~lib/array/ensureCapacity
+   local.get $this
+   local.get $index
+   i32.const 1
+   i32.add
+   call $~lib/array/Array<~lib/string/String>#set:length_
+  end
+  local.get $this
+  call $~lib/array/Array<~lib/string/String>#get:dataStart
+  local.get $index
+  i32.const 2
+  i32.shl
+  i32.add
+  local.get $value
+  i32.store $0
+  i32.const 1
+  drop
+  local.get $this
+  local.get $value
+  i32.const 1
+  call $~lib/rt/itcms/__link
  )
  (func $~lib/array/Array<~lib/string/String>#push (type $i32_i32_=>_i32) (param $this i32) (param $value i32) (result i32)
   (local $oldLen i32)
@@ -8588,7 +8617,7 @@
    local.get $3
    i32.const 0
    local.get $this
-   call $~lib/array/Array<~lib/string/String>#__uset
+   call $~lib/array/Array<~lib/string/String>#__set
    local.get $3
    local.set $22
    global.get $~lib/memory/__stack_pointer

--- a/tests/compiler/std/string.release.wat
+++ b/tests/compiler/std/string.release.wat
@@ -3,8 +3,8 @@
  (type $i32_i32_i32_=>_i32 (func_subtype (param i32 i32 i32) (result i32) func))
  (type $i32_=>_i32 (func_subtype (param i32) (result i32) func))
  (type $none_=>_none (func_subtype func))
- (type $i32_=>_none (func_subtype (param i32) func))
  (type $i32_i32_=>_none (func_subtype (param i32 i32) func))
+ (type $i32_=>_none (func_subtype (param i32) func))
  (type $i32_i32_i32_=>_none (func_subtype (param i32 i32 i32) func))
  (type $none_=>_i32 (func_subtype (result i32) func))
  (type $f64_=>_i32 (func_subtype (param f64) (result i32) func))
@@ -5177,26 +5177,18 @@
   local.get $2
   call $~lib/string/String#substring
  )
- (func $~lib/array/Array<~lib/string/String>#push (type $i32_i32_=>_none) (param $0 i32) (param $1 i32)
+ (func $~lib/array/ensureCapacity (type $i32_i32_=>_none) (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
-  (local $4 i32)
-  (local $5 i32)
-  (local $6 i32)
-  local.get $0
-  i32.load $0 offset=12
-  local.tee $3
-  i32.const 1
-  i32.add
-  local.tee $2
+  local.get $1
   local.get $0
   i32.load $0 offset=8
-  local.tee $5
+  local.tee $3
   i32.const 2
   i32.shr_u
   i32.gt_u
   if
-   local.get $2
+   local.get $1
    i32.const 268435455
    i32.gt_u
    if
@@ -5209,57 +5201,69 @@
    end
    local.get $0
    i32.load $0
-   local.tee $4
+   local.tee $2
    i32.const 1073741820
-   local.get $5
+   local.get $3
    i32.const 1
    i32.shl
-   local.tee $5
-   local.get $5
+   local.tee $3
+   local.get $3
    i32.const 1073741820
    i32.ge_u
    select
-   local.tee $5
+   local.tee $3
    i32.const 8
-   local.get $2
-   local.get $2
+   local.get $1
+   local.get $1
    i32.const 8
    i32.le_u
    select
    i32.const 2
    i32.shl
-   local.tee $6
-   local.get $5
-   local.get $6
-   i32.gt_u
+   local.tee $1
+   local.get $1
+   local.get $3
+   i32.lt_u
    select
-   local.tee $5
+   local.tee $1
    call $~lib/rt/itcms/__renew
-   local.tee $6
-   local.get $4
+   local.tee $3
+   local.get $2
    i32.ne
    if
     local.get $0
-    local.get $6
+    local.get $3
     i32.store $0
     local.get $0
-    local.get $6
+    local.get $3
     i32.store $0 offset=4
-    local.get $6
+    local.get $3
     if
      local.get $0
-     local.get $6
+     local.get $3
      i32.const 0
      call $byn-split-outlined-A$~lib/rt/itcms/__link
     end
    end
    local.get $0
-   local.get $5
+   local.get $1
    i32.store $0 offset=8
   end
+ )
+ (func $~lib/array/Array<~lib/string/String>#push (type $i32_i32_=>_none) (param $0 i32) (param $1 i32)
+  (local $2 i32)
+  (local $3 i32)
+  local.get $0
+  local.get $0
+  i32.load $0 offset=12
+  local.tee $2
+  i32.const 1
+  i32.add
+  local.tee $3
+  call $~lib/array/ensureCapacity
   local.get $0
   i32.load $0 offset=4
-  local.get $3
+  local.get $2
   i32.const 2
   i32.shl
   i32.add
@@ -5273,7 +5277,7 @@
    call $byn-split-outlined-A$~lib/rt/itcms/__link
   end
   local.get $0
-  local.get $2
+  local.get $3
   i32.store $0 offset=12
  )
  (func $~lib/string/String#split@varargs (type $i32_i32_=>_i32) (param $0 i32) (param $1 i32) (result i32)
@@ -6718,19 +6722,30 @@
       i32.const 5
       i32.const 0
       call $~lib/rt/__newArray
-      local.tee $3
+      local.tee $2
       i32.store $0
       global.get $~lib/memory/__stack_pointer
-      local.get $3
+      local.get $2
       i32.load $0 offset=4
       i32.store $0 offset=4
-      local.get $3
+      local.get $2
+      i32.load $0 offset=12
+      i32.eqz
+      if
+       local.get $2
+       i32.const 1
+       call $~lib/array/ensureCapacity
+       local.get $2
+       i32.const 1
+       i32.store $0 offset=12
+      end
+      local.get $2
       i32.load $0 offset=4
       local.get $0
       i32.store $0
       local.get $0
       if
-       local.get $3
+       local.get $2
        local.get $0
        i32.const 1
        call $byn-split-outlined-A$~lib/rt/itcms/__link
@@ -6743,23 +6758,23 @@
      i32.load $0 offset=16
      i32.const 1
      i32.shr_u
-     local.set $5
+     local.set $7
      i32.const 2147483647
      local.get $2
      local.get $2
      i32.const 0
      i32.lt_s
      select
-     local.set $2
+     local.set $9
      local.get $1
      i32.const 20
      i32.sub
      i32.load $0 offset=16
      i32.const 1
      i32.shr_u
-     local.tee $8
+     local.tee $4
      if
-      local.get $5
+      local.get $7
       i32.eqz
       if
        global.get $~lib/memory/__stack_pointer
@@ -6767,39 +6782,37 @@
        i32.const 5
        i32.const 0
        call $~lib/rt/__newArray
-       local.tee $3
+       local.tee $2
        i32.store $0 offset=16
-       local.get $3
+       local.get $2
        i32.load $0 offset=4
        i32.const 1712
        i32.store $0
        br $folding-inner1
       end
      else
-      local.get $5
+      local.get $7
       i32.eqz
       br_if $folding-inner0
       global.get $~lib/memory/__stack_pointer
-      local.get $5
-      local.get $2
-      local.get $2
-      local.get $5
-      i32.gt_s
+      local.get $7
+      local.get $9
+      local.get $7
+      local.get $9
+      i32.lt_s
       select
       local.tee $1
       i32.const 5
       i32.const 0
       call $~lib/rt/__newArray
-      local.tee $3
+      local.tee $2
       i32.store $0 offset=8
-      local.get $3
+      local.get $2
       i32.load $0 offset=4
       local.set $4
-      i32.const 0
-      local.set $2
       loop $for-loop|0
        local.get $1
-       local.get $2
+       local.get $3
        i32.gt_s
        if
         global.get $~lib/memory/__stack_pointer
@@ -6810,14 +6823,14 @@
         i32.store $0 offset=12
         local.get $5
         local.get $0
-        local.get $2
+        local.get $3
         i32.const 1
         i32.shl
         i32.add
         i32.load16_u $0
         i32.store16 $0
         local.get $4
-        local.get $2
+        local.get $3
         i32.const 2
         i32.shl
         i32.add
@@ -6825,15 +6838,15 @@
         i32.store $0
         local.get $5
         if
-         local.get $3
+         local.get $2
          local.get $5
          i32.const 1
          call $byn-split-outlined-A$~lib/rt/itcms/__link
         end
-        local.get $2
+        local.get $3
         i32.const 1
         i32.add
-        local.set $2
+        local.set $3
         br $for-loop|0
        end
       end
@@ -6844,61 +6857,60 @@
      i32.const 5
      i32.const 0
      call $~lib/rt/__newArray
-     local.tee $6
+     local.tee $8
      i32.store $0 offset=20
      loop $while-continue|1
       local.get $0
       local.get $1
       local.get $3
       call $~lib/string/String#indexOf
-      local.tee $9
+      local.tee $10
       i32.const -1
       i32.xor
       if
-       local.get $9
+       local.get $10
        local.get $3
        i32.sub
-       local.tee $7
+       local.tee $2
        i32.const 0
        i32.gt_s
        if
         global.get $~lib/memory/__stack_pointer
-        local.get $7
+        local.get $2
         i32.const 1
         i32.shl
-        local.tee $10
+        local.tee $5
         i32.const 2
         call $~lib/rt/itcms/__new
-        local.tee $7
+        local.tee $2
         i32.store $0 offset=24
-        local.get $7
+        local.get $2
         local.get $0
         local.get $3
         i32.const 1
         i32.shl
         i32.add
-        local.get $10
+        local.get $5
         memory.copy $0 $0
-        local.get $6
-        local.get $7
-        call $~lib/array/Array<~lib/string/String>#push
        else
+        i32.const 1712
+        local.set $2
         global.get $~lib/memory/__stack_pointer
         i32.const 1712
         i32.store $0 offset=28
-        local.get $6
-        i32.const 1712
-        call $~lib/array/Array<~lib/string/String>#push
        end
-       local.get $4
+       local.get $8
+       local.get $2
+       call $~lib/array/Array<~lib/string/String>#push
+       local.get $6
        i32.const 1
        i32.add
-       local.tee $4
-       local.get $2
+       local.tee $6
+       local.get $9
        i32.eq
        br_if $folding-inner2
-       local.get $8
-       local.get $9
+       local.get $4
+       local.get $10
        i32.add
        local.set $3
        br $while-continue|1
@@ -6907,12 +6919,12 @@
      local.get $3
      i32.eqz
      if
-      local.get $6
+      local.get $8
       local.get $0
       call $~lib/array/Array<~lib/string/String>#push
       br $folding-inner2
      end
-     local.get $5
+     local.get $7
      local.get $3
      i32.sub
      local.tee $1
@@ -6936,14 +6948,14 @@
       i32.add
       local.get $1
       memory.copy $0 $0
-      local.get $6
+      local.get $8
       local.get $2
       call $~lib/array/Array<~lib/string/String>#push
      else
       global.get $~lib/memory/__stack_pointer
       i32.const 1712
       i32.store $0 offset=28
-      local.get $6
+      local.get $8
       i32.const 1712
       call $~lib/array/Array<~lib/string/String>#push
      end
@@ -6951,27 +6963,27 @@
      i32.const 36
      i32.add
      global.set $~lib/memory/__stack_pointer
-     local.get $6
+     local.get $8
      return
     end
     i32.const 0
     i32.const 5
     i32.const 0
     call $~lib/rt/__newArray
-    local.set $3
+    local.set $2
    end
    global.get $~lib/memory/__stack_pointer
    i32.const 36
    i32.add
    global.set $~lib/memory/__stack_pointer
-   local.get $3
+   local.get $2
    return
   end
   global.get $~lib/memory/__stack_pointer
   i32.const 36
   i32.add
   global.set $~lib/memory/__stack_pointer
-  local.get $6
+  local.get $8
  )
  (func $start:std/string (type $none_=>_none)
   (local $0 i32)


### PR DESCRIPTION
Turned up in #2575, where if `--uncheckedBehavior always` is given, an `array[index] = ...`, when setting an `index >= length`, does not ensure that the array has enough capacity. Code might however expect that this basic contract holds regardless. Hence this PR removes unchecked indexed set on normal arrays. Does not change fixed sized arrays, where there is no such side-effect to retain.

- [x] I've read the contributing guidelines
- [x] I've added my name and email to the NOTICE file