### PR TITLE
Use constructor signature for class decorators

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -54,6 +54,7 @@ under the licensing terms detailed in LICENSE:
 * Jairus Tanaka <jairus.v.tanaka@outlook.com>
 * CountBleck <Mr.YouKnowWhoIAm@protonmail.com>
 * Abdul Rauf <abdulraufmujahid@gmail.com>
+* Bach Le <bach@bullno1.com>
 
 Portions of this software are derived from third-party works licensed under
 the following terms:

--- a/std/assembly/index.d.ts
+++ b/std/assembly/index.d.ts
@@ -2281,6 +2281,10 @@ interface TypedPropertyDescriptor<T> {
   set?(value: T): void;
 }
 
+type Constructor =
+  (new (...args: any[]) => unknown)
+  | (abstract new (...args: any[]) => unknown);
+
 /** Annotates a method as a binary operator overload for the specified `token`. */
 declare function operator(token:
   "[]" | "[]=" | "{}" | "{}=" | "==" | "!=" | ">" | "<" | "<=" | ">=" |
@@ -2319,10 +2323,10 @@ declare namespace operator {
 declare function global(...args: any[]): any;
 
 /** Annotates a class as being unmanaged with limited capabilities. */
-declare function unmanaged(constructor: Function): void;
+declare function unmanaged(constructor: Constructor): void;
 
 /** Annotates a class as being final / non-derivable. */
-declare function final(constructor: Function): void;
+declare function final(constructor: Constructor): void;
 
 /** Annotates a method, function or constant global as always inlined. */
 declare function inline(...args: any[]): any;


### PR DESCRIPTION
Use constructor signature for `@unmanaged` and `@final` instead of `Function`.
This removes the need to use `// @ts-ignore: decorator` to suppress error from tsserver (used for code completion) while using the `assembly.json` config.

`Function` in `assembly` is different from `portable` so a class type signature inferred by Typescript is not assignable to `Function`.

- [x] I've read the contributing guidelines
- [x] I've added my name and email to the NOTICE file
