### PR TITLE
Do precise subtype tests in instanceof

### DIFF
--- a/src/bindings/js.ts
+++ b/src/bindings/js.ts
@@ -950,13 +950,13 @@ export class JSBuilder extends ExportsWalker {
     if (type.isInternalReference) {
       // Lift reference types
       const clazz = assert(type.getClassOrWrapper(this.program));
-      if (clazz.extends(this.program.arrayBufferInstance.prototype)) {
+      if (clazz.extendsPrototype(this.program.arrayBufferInstance.prototype)) {
         sb.push("__liftBuffer(");
         this.needsLiftBuffer = true;
-      } else if (clazz.extends(this.program.stringInstance.prototype)) {
+      } else if (clazz.extendsPrototype(this.program.stringInstance.prototype)) {
         sb.push("__liftString(");
         this.needsLiftString = true;
-      } else if (clazz.extends(this.program.arrayPrototype)) {
+      } else if (clazz.extendsPrototype(this.program.arrayPrototype)) {
         let valueType = clazz.getArrayValueType();
         sb.push("__liftArray(");
         this.makeLiftFromMemory(valueType, sb);
@@ -964,7 +964,7 @@ export class JSBuilder extends ExportsWalker {
         sb.push(valueType.alignLog2.toString());
         sb.push(", ");
         this.needsLiftArray = true;
-      } else if (clazz.extends(this.program.staticArrayPrototype)) {
+      } else if (clazz.extendsPrototype(this.program.staticArrayPrototype)) {
         let valueType = clazz.getArrayValueType();
         sb.push("__liftStaticArray(");
         this.makeLiftFromMemory(valueType, sb);
@@ -972,7 +972,7 @@ export class JSBuilder extends ExportsWalker {
         sb.push(valueType.alignLog2.toString());
         sb.push(", ");
         this.needsLiftStaticArray = true;
-      } else if (clazz.extends(this.program.arrayBufferViewInstance.prototype)) {
+      } else if (clazz.extendsPrototype(this.program.arrayBufferViewInstance.prototype)) {
         sb.push("__liftTypedArray(");
         if (clazz.name == "Uint64Array") {
           sb.push("BigUint64Array");
@@ -1021,13 +1021,13 @@ export class JSBuilder extends ExportsWalker {
     if (type.isInternalReference) {
       // Lower reference types
       const clazz = assert(type.getClassOrWrapper(this.program));
-      if (clazz.extends(this.program.arrayBufferInstance.prototype)) {
+      if (clazz.extendsPrototype(this.program.arrayBufferInstance.prototype)) {
         sb.push("__lowerBuffer(");
         this.needsLowerBuffer = true;
-      } else if (clazz.extends(this.program.stringInstance.prototype)) {
+      } else if (clazz.extendsPrototype(this.program.stringInstance.prototype)) {
         sb.push("__lowerString(");
         this.needsLowerString = true;
-      } else if (clazz.extends(this.program.arrayPrototype)) {
+      } else if (clazz.extendsPrototype(this.program.arrayPrototype)) {
         let valueType = clazz.getArrayValueType();
         sb.push("__lowerArray(");
         this.makeLowerToMemory(valueType, sb);
@@ -1037,7 +1037,7 @@ export class JSBuilder extends ExportsWalker {
         sb.push(clazz.getArrayValueType().alignLog2.toString());
         sb.push(", ");
         this.needsLowerArray = true;
-      } else if (clazz.extends(this.program.staticArrayPrototype)) {
+      } else if (clazz.extendsPrototype(this.program.staticArrayPrototype)) {
         let valueType = clazz.getArrayValueType();
         sb.push("__lowerStaticArray(");
         this.makeLowerToMemory(valueType, sb);
@@ -1047,7 +1047,7 @@ export class JSBuilder extends ExportsWalker {
         sb.push(valueType.alignLog2.toString());
         sb.push(", ");
         this.needsLowerStaticArray = true;
-      } else if (clazz.extends(this.program.arrayBufferViewInstance.prototype)) {
+      } else if (clazz.extendsPrototype(this.program.arrayBufferViewInstance.prototype)) {
         let valueType = clazz.getArrayValueType();
         sb.push("__lowerTypedArray(");
         if (valueType == Type.u64) {
@@ -1079,7 +1079,7 @@ export class JSBuilder extends ExportsWalker {
         this.needsLowerInternref = true;
       }
       sb.push(name);
-      if (clazz.extends(this.program.staticArrayPrototype)) {
+      if (clazz.extendsPrototype(this.program.staticArrayPrototype)) {
         // optional last argument for __lowerStaticArray
         let valueType = clazz.getArrayValueType();
         if (valueType.isNumericValue) {
@@ -1397,16 +1397,16 @@ export function liftRequiresExportRuntime(type: Type): bool {
   let program = clazz.program;
   // flat collections lift via memory copy
   if (
-    clazz.extends(program.arrayBufferInstance.prototype) ||
-    clazz.extends(program.stringInstance.prototype) ||
-    clazz.extends(program.arrayBufferViewInstance.prototype)
+    clazz.extendsPrototype(program.arrayBufferInstance.prototype) ||
+    clazz.extendsPrototype(program.stringInstance.prototype) ||
+    clazz.extendsPrototype(program.arrayBufferViewInstance.prototype)
   ) {
     return false;
   }
   // nested collections lift depending on element type
   if (
-    clazz.extends(program.arrayPrototype) ||
-    clazz.extends(program.staticArrayPrototype)
+    clazz.extendsPrototype(program.arrayPrototype) ||
+    clazz.extendsPrototype(program.staticArrayPrototype)
   ) {
     return liftRequiresExportRuntime(clazz.getArrayValueType());
   }
@@ -1428,11 +1428,11 @@ export function lowerRequiresExportRuntime(type: Type): bool {
   // lowers using __new
   let program = clazz.program;
   if (
-    clazz.extends(program.arrayBufferInstance.prototype) ||
-    clazz.extends(program.stringInstance.prototype) ||
-    clazz.extends(program.arrayBufferViewInstance.prototype) ||
-    clazz.extends(program.arrayPrototype) ||
-    clazz.extends(program.staticArrayPrototype)
+    clazz.extendsPrototype(program.arrayBufferInstance.prototype) ||
+    clazz.extendsPrototype(program.stringInstance.prototype) ||
+    clazz.extendsPrototype(program.arrayBufferViewInstance.prototype) ||
+    clazz.extendsPrototype(program.arrayPrototype) ||
+    clazz.extendsPrototype(program.staticArrayPrototype)
   ) {
     return true;
   }

--- a/src/bindings/tsd.ts
+++ b/src/bindings/tsd.ts
@@ -249,26 +249,26 @@ export class TSDBuilder extends ExportsWalker {
     if (type.isInternalReference) {
       const sb = new Array<string>();
       const clazz = assert(type.getClassOrWrapper(this.program));
-      if (clazz.extends(this.program.arrayBufferInstance.prototype)) {
+      if (clazz.extendsPrototype(this.program.arrayBufferInstance.prototype)) {
         sb.push("ArrayBuffer");
-      } else if (clazz.extends(this.program.stringInstance.prototype)) {
+      } else if (clazz.extendsPrototype(this.program.stringInstance.prototype)) {
         sb.push("string");
-      } else if (clazz.extends(this.program.arrayPrototype)) {
+      } else if (clazz.extendsPrototype(this.program.arrayPrototype)) {
         const valueType = clazz.getArrayValueType();
         sb.push("Array<");
         sb.push(this.toTypeScriptType(valueType, mode));
         sb.push(">");
-      } else if (clazz.extends(this.program.staticArrayPrototype)) {
+      } else if (clazz.extendsPrototype(this.program.staticArrayPrototype)) {
         const valueType = clazz.getArrayValueType();
         sb.push("ArrayLike<");
         sb.push(this.toTypeScriptType(valueType, mode));
         sb.push(">");
-      } else if (clazz.extends(this.program.arrayBufferViewInstance.prototype)) {
+      } else if (clazz.extendsPrototype(this.program.arrayBufferViewInstance.prototype)) {
         const valueType = clazz.getArrayValueType();
         if (valueType == Type.i8) {
           sb.push("Int8Array");
         } else if (valueType == Type.u8) {
-          if (clazz.extends(this.program.uint8ClampedArrayPrototype)) {
+          if (clazz.extendsPrototype(this.program.uint8ClampedArrayPrototype)) {
             sb.push("Uint8ClampedArray");
           } else {
             sb.push("Uint8Array");

--- a/src/builtins.ts
+++ b/src/builtins.ts
@@ -861,7 +861,7 @@ function builtin_isArray(ctx: BuiltinContext): ExpressionRef {
   let classReference = type.getClass();
   return reifyConstantType(ctx,
     module.i32(
-      classReference && classReference.extends(compiler.program.arrayPrototype)
+      classReference && classReference.extendsPrototype(compiler.program.arrayPrototype)
         ? 1
         : 0
     )
@@ -10420,26 +10420,26 @@ export function compileRTTI(compiler: Compiler): void {
     assert(instanceId == lastId++);
     let flags: TypeinfoFlags = 0;
     if (instance.isPointerfree) flags |= TypeinfoFlags.POINTERFREE;
-    if (instance != abvInstance && instance.extends(abvPrototype)) {
+    if (instance != abvInstance && instance.extendsPrototype(abvPrototype)) {
       let valueType = instance.getArrayValueType();
       flags |= TypeinfoFlags.ARRAYBUFFERVIEW;
       flags |= TypeinfoFlags.VALUE_ALIGN_0 * typeToRuntimeFlags(valueType);
-    } else if (instance.extends(arrayPrototype)) {
+    } else if (instance.extendsPrototype(arrayPrototype)) {
       let valueType = instance.getArrayValueType();
       flags |= TypeinfoFlags.ARRAY;
       flags |= TypeinfoFlags.VALUE_ALIGN_0 * typeToRuntimeFlags(valueType);
-    } else if (instance.extends(setPrototype)) {
+    } else if (instance.extendsPrototype(setPrototype)) {
       let typeArguments = assert(instance.getTypeArgumentsTo(setPrototype));
       assert(typeArguments.length == 1);
       flags |= TypeinfoFlags.SET;
       flags |= TypeinfoFlags.VALUE_ALIGN_0 * typeToRuntimeFlags(typeArguments[0]);
-    } else if (instance.extends(mapPrototype)) {
+    } else if (instance.extendsPrototype(mapPrototype)) {
       let typeArguments = assert(instance.getTypeArgumentsTo(mapPrototype));
       assert(typeArguments.length == 2);
       flags |= TypeinfoFlags.MAP;
       flags |= TypeinfoFlags.KEY_ALIGN_0   * typeToRuntimeFlags(typeArguments[0]);
       flags |= TypeinfoFlags.VALUE_ALIGN_0 * typeToRuntimeFlags(typeArguments[1]);
-    } else if (instance.extends(staticArrayPrototype)) {
+    } else if (instance.extendsPrototype(staticArrayPrototype)) {
       let valueType = instance.getArrayValueType();
       flags |= TypeinfoFlags.STATICARRAY;
       flags |= TypeinfoFlags.VALUE_ALIGN_0 * typeToRuntimeFlags(valueType);

--- a/src/compiler.ts
+++ b/src/compiler.ts
@@ -556,12 +556,18 @@ export class Compiler extends DiagnosticEmitter {
     for (let _keys = Map_keys(this.pendingInstanceOf), i = 0, k = _keys.length; i < k; ++i) {
       let elem = _keys[i];
       let name = assert(this.pendingInstanceOf.get(elem));
-      if (elem.kind == ElementKind.Class) {
-        this.finalizeInstanceOf(<Class>elem, name);
-      } else if (elem.kind == ElementKind.ClassPrototype) {
-        this.finalizeAnyInstanceOf(<ClassPrototype>elem, name);
-      } else {
-        assert(false);
+      switch (elem.kind) {
+        case ElementKind.Class:
+        case ElementKind.Interface: {
+          this.finalizeInstanceOf(<Class>elem, name);
+          break;
+        }
+        case ElementKind.ClassPrototype:
+        case ElementKind.InterfacePrototype: {
+          this.finalizeAnyInstanceOf(<ClassPrototype>elem, name);
+          break;
+        }
+        default: assert(false);
       }
     }
 

--- a/src/compiler.ts
+++ b/src/compiler.ts
@@ -6575,16 +6575,16 @@ export class Compiler extends DiagnosticEmitter {
         }
         let classInstance = assert(overrideInstance.getBoundClassOrInterface());
         builder.addCase(classInstance.id, stmts);
-        // Also alias each extendee inheriting this exact overload
-        let extendees = classInstance.extendees;
-        if (extendees) {
-          for (let _values = Set_values(extendees), i = 0, k = _values.length; i < k; ++i) {
-            let extendee = _values[i];
-            let instanceMembers = extendee.prototype.instanceMembers;
+        // Also alias each extender inheriting this exact overload
+        let extenders = classInstance.extenders;
+        if (extenders) {
+          for (let _values = Set_values(extenders), i = 0, k = _values.length; i < k; ++i) {
+            let extender = _values[i];
+            let instanceMembers = extender.prototype.instanceMembers;
             if (instanceMembers && instanceMembers.has(instance.declaration.name.text)) {
               continue; // skip those not inheriting
             }
-            builder.addCase(extendee.id, stmts);
+            builder.addCase(extender.id, stmts);
           }
         }
       }
@@ -6593,7 +6593,7 @@ export class Compiler extends DiagnosticEmitter {
     // Call the original function if no other id matches and the method is not
     // abstract or part of an interface. Note that doing so will not catch an
     // invalid id, but can reduce code size significantly since we also don't
-    // have to add branches for extendees inheriting the original function.
+    // have to add branches for extender inheriting the original function.
     let body: ExpressionRef;
     let instanceClass = instance.getBoundClassOrInterface();
     if (!instance.is(CommonFlags.Abstract) && !(instanceClass && instanceClass.kind == ElementKind.Interface)) {
@@ -7577,11 +7577,11 @@ export class Compiler extends DiagnosticEmitter {
     } else {
       allInstances = new Set();
       allInstances.add(instance);
-      let extendees = instance.extendees;
-      if (extendees) {
-        for (let _values = Set_values(extendees), i = 0, k = _values.length; i < k; ++i) {
-          let extendee = _values[i];
-          allInstances.add(extendee);
+      let extenders = instance.extenders;
+      if (extenders) {
+        for (let _values = Set_values(extenders), i = 0, k = _values.length; i < k; ++i) {
+          let extender = _values[i];
+          allInstances.add(extender);
         }
       }
     }
@@ -7724,11 +7724,11 @@ export class Compiler extends DiagnosticEmitter {
           }
         } else {
           allInstances.add(instance);
-          let extendees = instance.extendees;
-          if (extendees) {
-            for (let _values = Set_values(extendees), i = 0, k = _values.length; i < k; ++i) {
-              let extendee = _values[i];
-              allInstances.add(extendee);
+          let extenders = instance.extenders;
+          if (extenders) {
+            for (let _values = Set_values(extenders), i = 0, k = _values.length; i < k; ++i) {
+              let extender = _values[i];
+              allInstances.add(extender);
             }
           }
         }

--- a/src/compiler.ts
+++ b/src/compiler.ts
@@ -6593,7 +6593,7 @@ export class Compiler extends DiagnosticEmitter {
     // Call the original function if no other id matches and the method is not
     // abstract or part of an interface. Note that doing so will not catch an
     // invalid id, but can reduce code size significantly since we also don't
-    // have to add branches for extender inheriting the original function.
+    // have to add branches for extenders inheriting the original function.
     let body: ExpressionRef;
     let instanceClass = instance.getBoundClassOrInterface();
     if (!instance.is(CommonFlags.Abstract) && !(instanceClass && instanceClass.kind == ElementKind.Interface)) {

--- a/src/program.ts
+++ b/src/program.ts
@@ -4459,7 +4459,7 @@ export class Class extends TypedElement {
     } while (nextBase);
   }
 
-  /** Propagates an extendee to this class as its base classes. */
+  /** Propagates an extendee to this class and its base classes. */
   private propagateExtendeeUp(extendee: Class): void {
     let nextBase: Class | null = this;
     do {

--- a/src/program.ts
+++ b/src/program.ts
@@ -4466,7 +4466,8 @@ export class Class extends TypedElement {
               let thisExtendee = extendeesArray[i];
               baseInterfaceImplementers.add(thisExtendee);
             }
-            baseInterface = baseInterface.base;
+            baseInterface = <Interface>baseInterface.base;
+            assert(!baseInterface || baseInterface.isInterface);
           } while (baseInterface);
         }
       }
@@ -4817,13 +4818,14 @@ export class Class extends TypedElement {
   }
 
   /** Tests if this class directly or indirectly implements the given interface. */
-  implements(other: Interface): bool {
+  implements(other: Class): bool {
     let implementers = other.implementers;
     return implementers != null && implementers.has(this);
   }
 
   /** Tests if this interface has a direct or indirect implementer matching the given class. */
   hasImplementer(other: Class): bool {
+    assert(this.isInterface);
     return other.implements(this);
   }
 

--- a/src/program.ts
+++ b/src/program.ts
@@ -4783,9 +4783,10 @@ export class Class extends TypedElement {
   hasExtendee(other: Class): bool {
     let extendees = this.extendees;
     if (extendees) {
+      if (extendees.has(other)) return true;
       for (let _values = Set_values(extendees), i = 0, k = _values.length; i < k; ++i) {
         let extendee = _values[i];
-        if (extendee == other || extendee.hasExtendee(other)) return true;
+        if (/* extendee == other || */extendee.hasExtendee(other)) return true;
       }
     }
     return false;
@@ -4807,9 +4808,10 @@ export class Class extends TypedElement {
   implements(other: Class): bool {
     let interfaces = this.interfaces;
     if (interfaces) {
+      if (interfaces.has(other)) return true;
       for (let _values = Set_values(interfaces), i = 0, k = _values.length; i < k; ++i) {
         let iface = _values[i];
-        if (iface == other || iface.extends(other)) return true;
+        if (/* iface == other || */iface.extends(other)) return true;
       }
     }
     let base = this.base;
@@ -4820,9 +4822,10 @@ export class Class extends TypedElement {
   hasImplementer(other: Class): bool {
     let implementers = this.implementers;
     if (implementers) {
+      if (implementers.has(other)) return true;
       for (let _values = Set_values(implementers), i = 0, k = _values.length; i < k; ++i) {
         let implementer = _values[i];
-        if (implementer == other || implementer.extends(other)) return true;
+        if (/* implementer == other || */implementer.extends(other)) return true;
       }
     }
     return false;

--- a/src/program.ts
+++ b/src/program.ts
@@ -4442,7 +4442,8 @@ export class Class extends TypedElement {
     let extenders = this.extenders;
     if (extenders) {
       for (let _values = Set_values(extenders), i = 0, k = _values.length; i < k; ++i) {
-        base.propagateExtenderUp(_values[i]);
+        let extender = _values[i];
+        base.propagateExtenderUp(extender);
       }
     }
 
@@ -4452,7 +4453,8 @@ export class Class extends TypedElement {
       let baseInterfaces = nextBase.interfaces;
       if (baseInterfaces) {
         for (let _values = Set_values(baseInterfaces), i = 0, k = _values.length; i < k; ++i) {
-          this.propagateInterfaceDown(_values[i]);
+          let baseInterface = _values[i];
+          this.propagateInterfaceDown(baseInterface);
         }
       }
       nextBase = nextBase.base;
@@ -4461,17 +4463,22 @@ export class Class extends TypedElement {
 
   /** Propagates an extender to this class and its base classes. */
   private propagateExtenderUp(extender: Class): void {
+    // Start with this class, adding the extender to it. Repeat for the class's
+    // bases that are indirectly extended by the extender.
     let nextBase: Class | null = this;
     do {
-      let baseExtenders = nextBase.extenders;
-      if (!baseExtenders) nextBase.extenders = baseExtenders = new Set();
-      baseExtenders.add(extender);
+      let extenders = nextBase.extenders;
+      if (!extenders) nextBase.extenders = extenders = new Set();
+      extenders.add(extender);
       nextBase = nextBase.base;
     } while (nextBase);
   }
 
   /** Propagates an interface and its base interfaces to this class and its extenders. */
   private propagateInterfaceDown(iface: Interface): void {
+    // Start with the interface itself, adding this class and its extenders to
+    // its implementers. Repeat for the interface's bases that are indirectly
+    // implemented by means of being extended by the interface.
     let nextIface: Interface | null = iface;
     let extenders = this.extenders;
     do {
@@ -4493,6 +4500,8 @@ export class Class extends TypedElement {
     let interfaces = this.interfaces;
     if (!interfaces) this.interfaces = interfaces = new Set();
     interfaces.add(iface);
+
+    // This class and its extenders now implement the interface and its bases
     this.propagateInterfaceDown(iface);
   }
 
@@ -4800,7 +4809,7 @@ export class Class extends TypedElement {
   }
 
   /** Tests if this class directly or indirectly implements the given interface. */
-  implements(other: Class): bool {
+  implements(other: Interface): bool {
     return other.hasImplementer(this);
   }
 

--- a/src/program.ts
+++ b/src/program.ts
@@ -4182,7 +4182,7 @@ export class ClassPrototype extends DeclaredElement {
   /** Already resolved instances. */
   instances: Map<string,Class> | null = null;
   /** Classes extending this class. */
-  extendees: Set<ClassPrototype> = new Set();
+  extenders: Set<ClassPrototype> = new Set();
   /** Whether this class implicitly extends `Object`. */
   implicitlyExtendsObject: bool = false;
 
@@ -4319,7 +4319,7 @@ export class Class extends TypedElement {
   /** Wrapped type, if a wrapper for a basic type. */
   wrappedType: Type | null = null;
   /** Classes directly or indirectly extending this class, if any. */
-  extendees: Set<Class> | null = null;
+  extenders: Set<Class> | null = null;
   /** Classes directly or indirectly implementing this interface, if any. */
   implementers: Set<Class> | null = null;
   /** Whether the field initialization check has already been performed. */
@@ -4437,16 +4437,16 @@ export class Class extends TypedElement {
       }
     }
 
-    // This class and its extendees now extend each direct or indirect base class
-    base.propagateExtendeeUp(this);
-    let extendees = this.extendees;
-    if (extendees) {
-      for (let _values = Set_values(extendees), i = 0, k = _values.length; i < k; ++i) {
-        base.propagateExtendeeUp(_values[i]);
+    // This class and its extenders now extend each direct or indirect base class
+    base.propagateExtenderUp(this);
+    let extenders = this.extenders;
+    if (extenders) {
+      for (let _values = Set_values(extenders), i = 0, k = _values.length; i < k; ++i) {
+        base.propagateExtenderUp(_values[i]);
       }
     }
 
-    // Direct or indirect base interfaces are now implemented by this class and its extendees
+    // Direct or indirect base interfaces are now implemented by this class and its extenders
     let nextBase: Class | null = base;
     do {
       let baseInterfaces = nextBase.interfaces;
@@ -4459,29 +4459,29 @@ export class Class extends TypedElement {
     } while (nextBase);
   }
 
-  /** Propagates an extendee to this class and its base classes. */
-  private propagateExtendeeUp(extendee: Class): void {
+  /** Propagates an extender to this class and its base classes. */
+  private propagateExtenderUp(extender: Class): void {
     let nextBase: Class | null = this;
     do {
-      let extendees = nextBase.extendees;
-      if (!extendees) nextBase.extendees = extendees = new Set();
-      extendees.add(extendee);
+      let baseExtenders = nextBase.extenders;
+      if (!baseExtenders) nextBase.extenders = baseExtenders = new Set();
+      baseExtenders.add(extender);
       nextBase = nextBase.base;
     } while (nextBase);
   }
 
-  /** Propagates an interface and its base interfaces to this class and its extendees. */
+  /** Propagates an interface and its base interfaces to this class and its extenders. */
   private propagateInterfaceDown(iface: Interface): void {
     let nextIface: Interface | null = iface;
-    let extendees = this.extendees;
+    let extenders = this.extenders;
     do {
       let implementers = nextIface.implementers;
       if (!implementers) nextIface.implementers = implementers = new Set();
       implementers.add(this);
-      if (extendees) {
-        for (let _values = Set_values(extendees), i = 0, k = _values.length; i < k; ++i) {
-          let extendee = _values[i];
-          implementers.add(extendee);
+      if (extenders) {
+        for (let _values = Set_values(extenders), i = 0, k = _values.length; i < k; ++i) {
+          let extender = _values[i];
+          implementers.add(extender);
         }
       }
       nextIface = <Interface | null>nextIface.base;
@@ -4527,7 +4527,7 @@ export class Class extends TypedElement {
         return this.hasImplementerImplementing(<Interface>target);
       } else {
         // <TargetInterface>thisClass
-        return this.hasExtendeeImplementing(<Interface>target);
+        return this.hasExtenderImplementing(<Interface>target);
       }
     } else {
       if (this.isInterface) {
@@ -4535,7 +4535,7 @@ export class Class extends TypedElement {
         return this.hasImplementer(target);
       } else {
         // <TargetClass>thisClass
-        return this.hasExtendee(target);
+        return this.hasExtender(target);
       }
     }
   }
@@ -4778,22 +4778,22 @@ export class Class extends TypedElement {
 
   /** Tests if this class or interface extends the given class or interface. */
   extends(other: Class): bool {
-    let extendees = other.extendees;
-    return extendees != null && extendees.has(this);
+    let extenders = other.extenders;
+    return extenders != null && extenders.has(this);
   }
 
-  /** Tests if this class has a direct or indirect extendee matching the given class. */
-  hasExtendee(other: Class): bool {
+  /** Tests if this class has a direct or indirect extender matching the given class. */
+  hasExtender(other: Class): bool {
     return other.extends(this);
   }
 
-  /** Tests if this class has a direct or indirect extendee that implements the given interface. */
-  hasExtendeeImplementing(other: Interface): bool {
-    let extendees = this.extendees;
-    if (extendees) {
-      for (let _values = Set_values(extendees), i = 0, k = _values.length; i < k; ++i) {
-        let extendee = _values[i];
-        if (extendee.implements(other)) return true;
+  /** Tests if this class has a direct or indirect extender that implements the given interface. */
+  hasExtenderImplementing(other: Interface): bool {
+    let extenders = this.extenders;
+    if (extenders) {
+      for (let _values = Set_values(extenders), i = 0, k = _values.length; i < k; ++i) {
+        let extender = _values[i];
+        if (extender.implements(other)) return true;
       }
     }
     return false;

--- a/src/program.ts
+++ b/src/program.ts
@@ -4460,7 +4460,7 @@ export class Class extends TypedElement {
         return this == target || this.extends(target);
       } else {
         // targetInterface = thisClass
-        return this.implements(target);
+        return this.implements(<Interface>target);
       }
     } else {
       if (this.isInterface) {
@@ -4479,10 +4479,10 @@ export class Class extends TypedElement {
     if (target.isInterface) {
       if (this.isInterface) {
         // <TargetInterface>thisInterface
-        return this.hasImplementerImplementing(target);
+        return this.hasImplementerImplementing(<Interface>target);
       } else {
         // <TargetInterface>thisClass
-        return this.hasExtendeeImplementing(target);
+        return this.hasExtendeeImplementing(<Interface>target);
       }
     } else {
       if (this.isInterface) {
@@ -4793,7 +4793,7 @@ export class Class extends TypedElement {
   }
 
   /** Tests if this class has a direct or indirect extendee that implements the given interface. */
-  hasExtendeeImplementing(other: Class): bool {
+  hasExtendeeImplementing(other: Interface): bool {
     let extendees = this.extendees;
     if (extendees) {
       for (let _values = Set_values(extendees), i = 0, k = _values.length; i < k; ++i) {
@@ -4805,7 +4805,7 @@ export class Class extends TypedElement {
   }
 
   /** Tests if this class implements the given interface. */
-  implements(other: Class): bool {
+  implements(other: Interface): bool {
     let interfaces = this.interfaces;
     if (interfaces) {
       if (interfaces.has(other)) return true;
@@ -4832,7 +4832,7 @@ export class Class extends TypedElement {
   }
 
   /** Tests if this interface has an implementer implementing the given interface. */
-  hasImplementerImplementing(other: Class): bool {
+  hasImplementerImplementing(other: Interface): bool {
     let implementers = this.implementers;
     if (implementers) {
       for (let _values = Set_values(implementers), i = 0, k = _values.length; i < k; ++i) {

--- a/src/program.ts
+++ b/src/program.ts
@@ -4466,7 +4466,7 @@ export class Class extends TypedElement {
               let thisExtendee = extendeesArray[i];
               baseInterfaceImplementers.add(thisExtendee);
             }
-            baseInterface = <Interface>baseInterface.base;
+            baseInterface = <Interface | null>baseInterface.base;
             assert(!baseInterface || baseInterface.isInterface);
           } while (baseInterface);
         }

--- a/src/program.ts
+++ b/src/program.ts
@@ -4784,6 +4784,18 @@ export class Interface extends Class { // FIXME
       true
     );
   }
+
+  /** Tests if a value of this interface type is assignable to a target of the specified class type. */
+  override isAssignableTo(target: Class): boolean {
+    // Unlike classes, interfaces do not include `Object` in their inheritance
+    // graph, yet we know that an assignment would succeed because any class
+    // implementing an interface directly or indirectly extends `Object`.
+    if (target == this.program.objectInstance) {
+      assert(this.type.isManaged);
+      return true;
+    }
+    return super.isAssignableTo(target);
+  }
 }
 
 /** Registers a concrete element with a program. */

--- a/src/program.ts
+++ b/src/program.ts
@@ -4778,13 +4778,13 @@ export class Class extends TypedElement {
 
   /** Tests if this class or interface extends the given class or interface. */
   extends(other: Class): bool {
-    let extenders = other.extenders;
-    return extenders != null && extenders.has(this);
+    return other.hasExtender(this);
   }
 
   /** Tests if this class has a direct or indirect extender matching the given class. */
   hasExtender(other: Class): bool {
-    return other.extends(this);
+    let extenders = this.extenders;
+    return extenders != null && extenders.has(other);
   }
 
   /** Tests if this class has a direct or indirect extender that implements the given interface. */
@@ -4801,14 +4801,13 @@ export class Class extends TypedElement {
 
   /** Tests if this class directly or indirectly implements the given interface. */
   implements(other: Class): bool {
-    let implementers = other.implementers;
-    return implementers != null && implementers.has(this);
+    return other.hasImplementer(this);
   }
 
   /** Tests if this interface has a direct or indirect implementer matching the given class. */
   hasImplementer(other: Class): bool {
-    assert(this.isInterface);
-    return other.implements(this);
+    let implementers = this.implementers;
+    return implementers != null && implementers.has(other);
   }
 
   /** Tests if this interface has an implementer implementing the given interface. */

--- a/src/program.ts
+++ b/src/program.ts
@@ -4298,9 +4298,9 @@ export class Class extends TypedElement {
   prototype: ClassPrototype;
   /** Resolved type arguments. */
   typeArguments: Type[] | null;
-  /** Base class, if applicable. */
+  /** Base class, if any. */
   base: Class | null = null;
-  /** Implemented interfaces, if applicable. */
+  /** Directly implemented interfaces, if any. */
   interfaces: Set<Interface> | null = null;
   /** Contextual type arguments for fields and methods. */
   contextualTypeArguments: Map<string,Type> | null = null;
@@ -4318,9 +4318,9 @@ export class Class extends TypedElement {
   rttiFlags: u32 = 0;
   /** Wrapped type, if a wrapper for a basic type. */
   wrappedType: Type | null = null;
-  /** Classes directly extending this class. */
+  /** Classes directly extending this class, if any. */
   extendees: Set<Class> | null = null;
-  /** Classes implementing this interface. */
+  /** Classes directly implementing this interface, if any. */
   implementers: Set<Class> | null = null;
   /** Whether the field initialization check has already been performed. */
   didCheckFieldInitialization: bool = false;
@@ -4748,7 +4748,7 @@ export class Class extends TypedElement {
     return out;
   }
 
-  /** Gets all extendees and implementers of this class. */
+  /** Gets all extendees and implementers of this class or interface. */
   getAllExtendeesAndImplementers(out: Set<Class> = new Set()): Set<Class> {
     let extendees = this.extendees;
     if (extendees) {
@@ -4769,7 +4769,7 @@ export class Class extends TypedElement {
     return out;
   }
 
-  /** Tests if this class or interface extends the given classs or interface. */
+  /** Tests if this class or interface extends the given class or interface. */
   extends(other: Class): bool {
     let base = this.base;
     while (base) {
@@ -4781,15 +4781,7 @@ export class Class extends TypedElement {
 
   /** Tests if this class has a direct or indirect extendee matching the given class. */
   hasExtendee(other: Class): bool {
-    let extendees = this.extendees;
-    if (extendees) {
-      if (extendees.has(other)) return true;
-      for (let _values = Set_values(extendees), i = 0, k = _values.length; i < k; ++i) {
-        let extendee = _values[i];
-        if (/* extendee == other || */extendee.hasExtendee(other)) return true;
-      }
-    }
-    return false;
+    return other.extends(this);
   }
 
   /** Tests if this class has a direct or indirect extendee that implements the given interface. */
@@ -4804,7 +4796,7 @@ export class Class extends TypedElement {
     return false;
   }
 
-  /** Tests if this class implements the given interface. */
+  /** Tests if this class directly or indirectly implements the given interface. */
   implements(other: Interface): bool {
     let interfaces = this.interfaces;
     if (interfaces) {
@@ -4820,15 +4812,7 @@ export class Class extends TypedElement {
 
   /** Tests if this interface has a direct or indirect implementer matching the given class. */
   hasImplementer(other: Class): bool {
-    let implementers = this.implementers;
-    if (implementers) {
-      if (implementers.has(other)) return true;
-      for (let _values = Set_values(implementers), i = 0, k = _values.length; i < k; ++i) {
-        let implementer = _values[i];
-        if (/* implementer == other || */implementer.extends(other)) return true;
-      }
-    }
-    return false;
+    return other.implements(this);
   }
 
   /** Tests if this interface has an implementer implementing the given interface. */

--- a/src/types.ts
+++ b/src/types.ts
@@ -506,6 +506,14 @@ export class Type {
     return this.kind == target.kind;
   }
 
+  /** Tests if this type has a subtype assignable to the target type. */
+  hasSubtypeAssignableTo(target: Type): bool {
+    let thisClass = this.getClass();
+    let targetClass = target.getClass();
+    if (!thisClass || !targetClass) return false; // TODO: what about basic types?
+    return thisClass.hasSubclassAssignableTo(targetClass);
+  }
+
   /** Tests if a value of this type can be changed to the target type using `changetype`. */
   isChangeableTo(target: Type): bool {
     // special in that it allows integer references as well

--- a/tests/compiler/instanceof.debug.wat
+++ b/tests/compiler/instanceof.debug.wat
@@ -42,11 +42,12 @@
  (global $instanceof/nullAnimal (mut i32) (i32.const 0))
  (global $instanceof/nullCat (mut i32) (i32.const 0))
  (global $instanceof/nullBlackcat (mut i32) (i32.const 0))
- (global $instanceof/impl (mut i32) (i32.const 0))
+ (global $instanceof/a_i1 (mut i32) (i32.const 0))
+ (global $instanceof/b_i1_i2 (mut i32) (i32.const 0))
  (global $~lib/rt/__rtti_base i32 (i32.const 464))
- (global $~lib/memory/__data_end i32 (i32.const 532))
- (global $~lib/memory/__stack_pointer (mut i32) (i32.const 33300))
- (global $~lib/memory/__heap_base i32 (i32.const 33300))
+ (global $~lib/memory/__data_end i32 (i32.const 540))
+ (global $~lib/memory/__stack_pointer (mut i32) (i32.const 33308))
+ (global $~lib/memory/__heap_base i32 (i32.const 33308))
  (memory $0 1)
  (data (i32.const 12) "<\00\00\00\00\00\00\00\00\00\00\00\02\00\00\00(\00\00\00A\00l\00l\00o\00c\00a\00t\00i\00o\00n\00 \00t\00o\00o\00 \00l\00a\00r\00g\00e\00\00\00\00\00")
  (data (i32.const 76) "<\00\00\00\00\00\00\00\00\00\00\00\02\00\00\00 \00\00\00~\00l\00i\00b\00/\00r\00t\00/\00i\00t\00c\00m\00s\00.\00t\00s\00\00\00\00\00\00\00\00\00\00\00\00\00")
@@ -57,7 +58,7 @@
  (data (i32.const 320) "\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00")
  (data (i32.const 348) "<\00\00\00\00\00\00\00\00\00\00\00\02\00\00\00\1e\00\00\00~\00l\00i\00b\00/\00r\00t\00/\00t\00l\00s\00f\00.\00t\00s\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00")
  (data (i32.const 412) ",\00\00\00\00\00\00\00\00\00\00\00\02\00\00\00\1a\00\00\00i\00n\00s\00t\00a\00n\00c\00e\00o\00f\00.\00t\00s\00\00\00")
- (data (i32.const 464) "\10\00\00\00 \00\00\00 \00\00\00 \00\00\00\00\00\00\00 \00\00\00 \00\00\00 \00\00\00 \00\00\00 \00\00\00 \00\00\00 \00\00\00 \00\00\00 \00\00\00 \00\00\00 \00\00\00 \00\00\00")
+ (data (i32.const 464) "\12\00\00\00 \00\00\00 \00\00\00 \00\00\00\00\00\00\00 \00\00\00 \00\00\00 \00\00\00 \00\00\00 \00\00\00 \00\00\00 \00\00\00 \00\00\00 \00\00\00 \00\00\00 \00\00\00 \00\00\00 \00\00\00 \00\00\00")
  (table $0 1 1 funcref)
  (elem $0 (i32.const 1))
  (export "memory" (memory $0))
@@ -2302,14 +2303,16 @@
   (local $19 i32)
   (local $20 i32)
   (local $21 i32)
+  (local $22 i32)
+  (local $23 i32)
   global.get $~lib/memory/__stack_pointer
-  i32.const 88
+  i32.const 96
   i32.sub
   global.set $~lib/memory/__stack_pointer
   call $~stack_check
   global.get $~lib/memory/__stack_pointer
   i32.const 0
-  i32.const 88
+  i32.const 96
   memory.fill $0
   memory.size $0
   i32.const 16
@@ -3106,12 +3109,14 @@
    unreachable
   end
   i32.const 0
-  call $instanceof/ImplemensIFace#constructor
-  global.set $instanceof/impl
+  call $instanceof/A_I1#constructor
+  global.set $instanceof/a_i1
+  i32.const 1
+  drop
   i32.const 1
   drop
   global.get $~lib/memory/__stack_pointer
-  global.get $instanceof/impl
+  global.get $instanceof/a_i1
   local.tee $21
   i32.store $0 offset=84
   local.get $21
@@ -3120,19 +3125,75 @@
    i32.const 0
   else
    local.get $21
-   call $~instanceof|instanceof/IFace
+   call $~instanceof|instanceof/I1
   end
   i32.eqz
   if
    i32.const 0
    i32.const 432
-   i32.const 161
+   i32.const 165
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  i32.const 0
+  i32.eqz
+  drop
+  i32.const 0
+  call $instanceof/B_I1_I2#constructor
+  global.set $instanceof/b_i1_i2
+  i32.const 1
+  drop
+  i32.const 1
+  drop
+  i32.const 0
+  i32.eqz
+  drop
+  global.get $~lib/memory/__stack_pointer
+  global.get $instanceof/a_i1
+  local.tee $22
+  i32.store $0 offset=88
+  local.get $22
+  i32.eqz
+  if (result i32)
+   i32.const 0
+  else
+   local.get $22
+   call $~instanceof|instanceof/B_I1_I2
+  end
+  i32.eqz
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 432
+   i32.const 172
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   global.get $~lib/memory/__stack_pointer
-  i32.const 88
+  global.get $instanceof/b_i1_i2
+  local.tee $23
+  i32.store $0 offset=92
+  local.get $23
+  i32.eqz
+  if (result i32)
+   i32.const 0
+  else
+   local.get $23
+   call $~instanceof|instanceof/B_I1_I2
+  end
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 432
+   i32.const 173
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  global.get $~lib/memory/__stack_pointer
+  i32.const 96
   i32.add
   global.set $~lib/memory/__stack_pointer
  )
@@ -3229,7 +3290,7 @@
   end
   i32.const 1
  )
- (func $~instanceof|instanceof/IFace (type $i32_=>_i32) (param $0 i32) (result i32)
+ (func $~instanceof|instanceof/I1 (type $i32_=>_i32) (param $0 i32) (result i32)
   (local $1 i32)
   block $is_instance
    local.get $0
@@ -3243,6 +3304,27 @@
    br_if $is_instance
    local.get $1
    i32.const 14
+   i32.eq
+   br_if $is_instance
+   local.get $1
+   i32.const 17
+   i32.eq
+   br_if $is_instance
+   i32.const 0
+   return
+  end
+  i32.const 1
+ )
+ (func $~instanceof|instanceof/B_I1_I2 (type $i32_=>_i32) (param $0 i32) (result i32)
+  (local $1 i32)
+  block $is_instance
+   local.get $0
+   i32.const 8
+   i32.sub
+   i32.load $0
+   local.set $1
+   local.get $1
+   i32.const 17
    i32.eq
    br_if $is_instance
    i32.const 0
@@ -3350,7 +3432,14 @@
    local.get $0
    call $~lib/rt/itcms/__visit
   end
-  global.get $instanceof/impl
+  global.get $instanceof/a_i1
+  local.tee $1
+  if
+   local.get $1
+   local.get $0
+   call $~lib/rt/itcms/__visit
+  end
+  global.get $instanceof/b_i1_i2
   local.tee $1
   if
    local.get $1
@@ -3383,37 +3472,43 @@
  )
  (func $~lib/rt/__visit_members (type $i32_i32_=>_none) (param $0 i32) (param $1 i32)
   block $invalid
-   block $instanceof/IFace
-    block $instanceof/ImplemensIFace
-     block $instanceof/BlackCat
-      block $instanceof/Cat
-       block $instanceof/Animal
-        block $instanceof/SomethingElse<i32>
-         block $instanceof/Parent<f32>
-          block $instanceof/Child<f32>
-           block $instanceof/Parent<i32>
-            block $instanceof/Child<i32>
-             block $instanceof/B
-              block $instanceof/A
-               block $~lib/arraybuffer/ArrayBufferView
-                block $~lib/string/String
-                 block $~lib/arraybuffer/ArrayBuffer
-                  block $~lib/object/Object
-                   local.get $0
-                   i32.const 8
-                   i32.sub
-                   i32.load $0
-                   br_table $~lib/object/Object $~lib/arraybuffer/ArrayBuffer $~lib/string/String $~lib/arraybuffer/ArrayBufferView $instanceof/A $instanceof/B $instanceof/Child<i32> $instanceof/Parent<i32> $instanceof/Child<f32> $instanceof/Parent<f32> $instanceof/SomethingElse<i32> $instanceof/Animal $instanceof/Cat $instanceof/BlackCat $instanceof/ImplemensIFace $instanceof/IFace $invalid
+   block $instanceof/B_I1_I2
+    block $instanceof/I2
+     block $instanceof/I1
+      block $instanceof/A_I1
+       block $instanceof/BlackCat
+        block $instanceof/Cat
+         block $instanceof/Animal
+          block $instanceof/SomethingElse<i32>
+           block $instanceof/Parent<f32>
+            block $instanceof/Child<f32>
+             block $instanceof/Parent<i32>
+              block $instanceof/Child<i32>
+               block $instanceof/B
+                block $instanceof/A
+                 block $~lib/arraybuffer/ArrayBufferView
+                  block $~lib/string/String
+                   block $~lib/arraybuffer/ArrayBuffer
+                    block $~lib/object/Object
+                     local.get $0
+                     i32.const 8
+                     i32.sub
+                     i32.load $0
+                     br_table $~lib/object/Object $~lib/arraybuffer/ArrayBuffer $~lib/string/String $~lib/arraybuffer/ArrayBufferView $instanceof/A $instanceof/B $instanceof/Child<i32> $instanceof/Parent<i32> $instanceof/Child<f32> $instanceof/Parent<f32> $instanceof/SomethingElse<i32> $instanceof/Animal $instanceof/Cat $instanceof/BlackCat $instanceof/A_I1 $instanceof/I1 $instanceof/I2 $instanceof/B_I1_I2 $invalid
+                    end
+                    return
+                   end
+                   return
                   end
                   return
                  end
+                 local.get $0
+                 local.get $1
+                 call $~lib/arraybuffer/ArrayBufferView~visit
                  return
                 end
                 return
                end
-               local.get $0
-               local.get $1
-               call $~lib/arraybuffer/ArrayBufferView~visit
                return
               end
               return
@@ -3783,7 +3878,7 @@
   global.set $~lib/memory/__stack_pointer
   local.get $1
  )
- (func $instanceof/ImplemensIFace#constructor (type $i32_=>_i32) (param $this i32) (result i32)
+ (func $instanceof/A_I1#constructor (type $i32_=>_i32) (param $this i32) (result i32)
   (local $1 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -3799,6 +3894,39 @@
    global.get $~lib/memory/__stack_pointer
    i32.const 0
    i32.const 14
+   call $~lib/rt/itcms/__new
+   local.tee $this
+   i32.store $0
+  end
+  global.get $~lib/memory/__stack_pointer
+  local.get $this
+  call $~lib/object/Object#constructor
+  local.tee $this
+  i32.store $0
+  local.get $this
+  local.set $1
+  global.get $~lib/memory/__stack_pointer
+  i32.const 4
+  i32.add
+  global.set $~lib/memory/__stack_pointer
+  local.get $1
+ )
+ (func $instanceof/B_I1_I2#constructor (type $i32_=>_i32) (param $this i32) (result i32)
+  (local $1 i32)
+  global.get $~lib/memory/__stack_pointer
+  i32.const 4
+  i32.sub
+  global.set $~lib/memory/__stack_pointer
+  call $~stack_check
+  global.get $~lib/memory/__stack_pointer
+  i32.const 0
+  i32.store $0
+  local.get $this
+  i32.eqz
+  if
+   global.get $~lib/memory/__stack_pointer
+   i32.const 0
+   i32.const 17
    call $~lib/rt/itcms/__new
    local.tee $this
    i32.store $0

--- a/tests/compiler/instanceof.debug.wat
+++ b/tests/compiler/instanceof.debug.wat
@@ -42,10 +42,11 @@
  (global $instanceof/nullAnimal (mut i32) (i32.const 0))
  (global $instanceof/nullCat (mut i32) (i32.const 0))
  (global $instanceof/nullBlackcat (mut i32) (i32.const 0))
+ (global $instanceof/impl (mut i32) (i32.const 0))
  (global $~lib/rt/__rtti_base i32 (i32.const 464))
- (global $~lib/memory/__data_end i32 (i32.const 524))
- (global $~lib/memory/__stack_pointer (mut i32) (i32.const 33292))
- (global $~lib/memory/__heap_base i32 (i32.const 33292))
+ (global $~lib/memory/__data_end i32 (i32.const 532))
+ (global $~lib/memory/__stack_pointer (mut i32) (i32.const 33300))
+ (global $~lib/memory/__heap_base i32 (i32.const 33300))
  (memory $0 1)
  (data (i32.const 12) "<\00\00\00\00\00\00\00\00\00\00\00\02\00\00\00(\00\00\00A\00l\00l\00o\00c\00a\00t\00i\00o\00n\00 \00t\00o\00o\00 \00l\00a\00r\00g\00e\00\00\00\00\00")
  (data (i32.const 76) "<\00\00\00\00\00\00\00\00\00\00\00\02\00\00\00 \00\00\00~\00l\00i\00b\00/\00r\00t\00/\00i\00t\00c\00m\00s\00.\00t\00s\00\00\00\00\00\00\00\00\00\00\00\00\00")
@@ -56,7 +57,7 @@
  (data (i32.const 320) "\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00")
  (data (i32.const 348) "<\00\00\00\00\00\00\00\00\00\00\00\02\00\00\00\1e\00\00\00~\00l\00i\00b\00/\00r\00t\00/\00t\00l\00s\00f\00.\00t\00s\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00")
  (data (i32.const 412) ",\00\00\00\00\00\00\00\00\00\00\00\02\00\00\00\1a\00\00\00i\00n\00s\00t\00a\00n\00c\00e\00o\00f\00.\00t\00s\00\00\00")
- (data (i32.const 464) "\0e\00\00\00 \00\00\00 \00\00\00 \00\00\00\00\00\00\00 \00\00\00 \00\00\00 \00\00\00 \00\00\00 \00\00\00 \00\00\00 \00\00\00 \00\00\00 \00\00\00 \00\00\00")
+ (data (i32.const 464) "\10\00\00\00 \00\00\00 \00\00\00 \00\00\00\00\00\00\00 \00\00\00 \00\00\00 \00\00\00 \00\00\00 \00\00\00 \00\00\00 \00\00\00 \00\00\00 \00\00\00 \00\00\00 \00\00\00 \00\00\00")
  (table $0 1 1 funcref)
  (elem $0 (i32.const 1))
  (export "memory" (memory $0))
@@ -2300,14 +2301,15 @@
   (local $18 i32)
   (local $19 i32)
   (local $20 i32)
+  (local $21 i32)
   global.get $~lib/memory/__stack_pointer
-  i32.const 84
+  i32.const 88
   i32.sub
   global.set $~lib/memory/__stack_pointer
   call $~stack_check
   global.get $~lib/memory/__stack_pointer
   i32.const 0
-  i32.const 84
+  i32.const 88
   memory.fill $0
   memory.size $0
   i32.const 16
@@ -3103,8 +3105,34 @@
    call $~lib/builtins/abort
    unreachable
   end
+  i32.const 0
+  call $instanceof/ImplemensIFace#constructor
+  global.set $instanceof/impl
+  i32.const 1
+  drop
   global.get $~lib/memory/__stack_pointer
-  i32.const 84
+  global.get $instanceof/impl
+  local.tee $21
+  i32.store $0 offset=84
+  local.get $21
+  i32.eqz
+  if (result i32)
+   i32.const 0
+  else
+   local.get $21
+   call $~instanceof|instanceof/IFace
+  end
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 432
+   i32.const 161
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  global.get $~lib/memory/__stack_pointer
+  i32.const 88
   i32.add
   global.set $~lib/memory/__stack_pointer
  )
@@ -3194,6 +3222,27 @@
    local.set $1
    local.get $1
    i32.const 13
+   i32.eq
+   br_if $is_instance
+   i32.const 0
+   return
+  end
+  i32.const 1
+ )
+ (func $~instanceof|instanceof/IFace (type $i32_=>_i32) (param $0 i32) (result i32)
+  (local $1 i32)
+  block $is_instance
+   local.get $0
+   i32.const 8
+   i32.sub
+   i32.load $0
+   local.set $1
+   local.get $1
+   i32.const 15
+   i32.eq
+   br_if $is_instance
+   local.get $1
+   i32.const 14
    i32.eq
    br_if $is_instance
    i32.const 0
@@ -3301,6 +3350,13 @@
    local.get $0
    call $~lib/rt/itcms/__visit
   end
+  global.get $instanceof/impl
+  local.tee $1
+  if
+   local.get $1
+   local.get $0
+   call $~lib/rt/itcms/__visit
+  end
   i32.const 224
   local.get $0
   call $~lib/rt/itcms/__visit
@@ -3327,35 +3383,41 @@
  )
  (func $~lib/rt/__visit_members (type $i32_i32_=>_none) (param $0 i32) (param $1 i32)
   block $invalid
-   block $instanceof/BlackCat
-    block $instanceof/Cat
-     block $instanceof/Animal
-      block $instanceof/SomethingElse<i32>
-       block $instanceof/Parent<f32>
-        block $instanceof/Child<f32>
-         block $instanceof/Parent<i32>
-          block $instanceof/Child<i32>
-           block $instanceof/B
-            block $instanceof/A
-             block $~lib/arraybuffer/ArrayBufferView
-              block $~lib/string/String
-               block $~lib/arraybuffer/ArrayBuffer
-                block $~lib/object/Object
-                 local.get $0
-                 i32.const 8
-                 i32.sub
-                 i32.load $0
-                 br_table $~lib/object/Object $~lib/arraybuffer/ArrayBuffer $~lib/string/String $~lib/arraybuffer/ArrayBufferView $instanceof/A $instanceof/B $instanceof/Child<i32> $instanceof/Parent<i32> $instanceof/Child<f32> $instanceof/Parent<f32> $instanceof/SomethingElse<i32> $instanceof/Animal $instanceof/Cat $instanceof/BlackCat $invalid
+   block $instanceof/IFace
+    block $instanceof/ImplemensIFace
+     block $instanceof/BlackCat
+      block $instanceof/Cat
+       block $instanceof/Animal
+        block $instanceof/SomethingElse<i32>
+         block $instanceof/Parent<f32>
+          block $instanceof/Child<f32>
+           block $instanceof/Parent<i32>
+            block $instanceof/Child<i32>
+             block $instanceof/B
+              block $instanceof/A
+               block $~lib/arraybuffer/ArrayBufferView
+                block $~lib/string/String
+                 block $~lib/arraybuffer/ArrayBuffer
+                  block $~lib/object/Object
+                   local.get $0
+                   i32.const 8
+                   i32.sub
+                   i32.load $0
+                   br_table $~lib/object/Object $~lib/arraybuffer/ArrayBuffer $~lib/string/String $~lib/arraybuffer/ArrayBufferView $instanceof/A $instanceof/B $instanceof/Child<i32> $instanceof/Parent<i32> $instanceof/Child<f32> $instanceof/Parent<f32> $instanceof/SomethingElse<i32> $instanceof/Animal $instanceof/Cat $instanceof/BlackCat $instanceof/ImplemensIFace $instanceof/IFace $invalid
+                  end
+                  return
+                 end
+                 return
                 end
                 return
                end
+               local.get $0
+               local.get $1
+               call $~lib/arraybuffer/ArrayBufferView~visit
                return
               end
               return
              end
-             local.get $0
-             local.get $1
-             call $~lib/arraybuffer/ArrayBufferView~visit
              return
             end
             return
@@ -3388,8 +3450,8 @@
   global.get $~lib/memory/__data_end
   i32.lt_s
   if
-   i32.const 33312
-   i32.const 33360
+   i32.const 33328
+   i32.const 33376
    i32.const 1
    i32.const 1
    call $~lib/builtins/abort
@@ -3711,6 +3773,39 @@
   global.get $~lib/memory/__stack_pointer
   local.get $this
   call $instanceof/Cat#constructor
+  local.tee $this
+  i32.store $0
+  local.get $this
+  local.set $1
+  global.get $~lib/memory/__stack_pointer
+  i32.const 4
+  i32.add
+  global.set $~lib/memory/__stack_pointer
+  local.get $1
+ )
+ (func $instanceof/ImplemensIFace#constructor (type $i32_=>_i32) (param $this i32) (result i32)
+  (local $1 i32)
+  global.get $~lib/memory/__stack_pointer
+  i32.const 4
+  i32.sub
+  global.set $~lib/memory/__stack_pointer
+  call $~stack_check
+  global.get $~lib/memory/__stack_pointer
+  i32.const 0
+  i32.store $0
+  local.get $this
+  i32.eqz
+  if
+   global.get $~lib/memory/__stack_pointer
+   i32.const 0
+   i32.const 14
+   call $~lib/rt/itcms/__new
+   local.tee $this
+   i32.store $0
+  end
+  global.get $~lib/memory/__stack_pointer
+  local.get $this
+  call $~lib/object/Object#constructor
   local.tee $this
   i32.store $0
   local.get $this

--- a/tests/compiler/instanceof.debug.wat
+++ b/tests/compiler/instanceof.debug.wat
@@ -2280,922 +2280,126 @@
   i32.const 0
   return
  )
- (func $start:instanceof (type $none_=>_none)
-  (local $0 i32)
+ (func $instanceof/assertStaticTrue<instanceof/A_I1,~lib/object/Object> (type $i32_=>_none) (param $value i32)
+  i32.const 1
+  drop
+  return
+ )
+ (func $instanceof/assertStaticTrue<instanceof/A_I1,instanceof/I1> (type $i32_=>_none) (param $value i32)
+  i32.const 1
+  drop
+  return
+ )
+ (func $instanceof/assertStaticFalse<instanceof/A_I1,instanceof/I2> (type $i32_=>_none) (param $value i32)
+  i32.const 0
+  i32.eqz
+  drop
+  return
+ )
+ (func $instanceof/assertDynamicTrue<~lib/object/Object,instanceof/I1> (type $i32_=>_none) (param $value i32)
   (local $1 i32)
-  (local $2 i32)
-  (local $3 i32)
-  (local $4 i32)
-  (local $5 i32)
-  (local $6 i32)
-  (local $7 i32)
-  (local $8 i32)
-  (local $9 i32)
-  (local $10 i32)
-  (local $11 i32)
-  (local $12 i32)
-  (local $13 i32)
-  (local $14 i32)
-  (local $15 i32)
-  (local $16 i32)
-  (local $17 i32)
-  (local $18 i32)
-  (local $19 i32)
-  (local $20 i32)
-  (local $21 i32)
-  (local $22 i32)
-  (local $23 i32)
-  global.get $~lib/memory/__stack_pointer
-  i32.const 96
-  i32.sub
-  global.set $~lib/memory/__stack_pointer
-  call $~stack_check
-  global.get $~lib/memory/__stack_pointer
-  i32.const 0
-  i32.const 96
-  memory.fill $0
-  memory.size $0
-  i32.const 16
-  i32.shl
-  global.get $~lib/memory/__heap_base
-  i32.sub
-  i32.const 1
-  i32.shr_u
-  global.set $~lib/rt/itcms/threshold
-  i32.const 144
-  call $~lib/rt/itcms/initLazy
-  global.set $~lib/rt/itcms/pinSpace
-  i32.const 176
-  call $~lib/rt/itcms/initLazy
-  global.set $~lib/rt/itcms/toSpace
-  i32.const 320
-  call $~lib/rt/itcms/initLazy
-  global.set $~lib/rt/itcms/fromSpace
-  i32.const 0
-  call $instanceof/A#constructor
-  global.set $instanceof/a
-  i32.const 0
-  call $instanceof/B#constructor
-  global.set $instanceof/b
-  i32.const 1
-  drop
-  i32.const 1
-  drop
-  i32.const 0
-  i32.eqz
-  drop
-  i32.const 0
-  i32.eqz
-  drop
-  i32.const 0
-  i32.eqz
-  drop
-  i32.const 0
-  i32.eqz
-  drop
-  global.get $~lib/memory/__stack_pointer
-  global.get $instanceof/a
-  local.tee $0
-  i32.store $0
-  local.get $0
-  i32.eqz
-  if (result i32)
-   i32.const 0
-  else
-   local.get $0
-   call $~instanceof|instanceof/B
-  end
-  i32.eqz
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 432
-   i32.const 18
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  i32.const 1
-  drop
-  i32.const 0
-  i32.eqz
-  drop
-  i32.const 0
-  i32.eqz
-  drop
-  i32.const 0
-  i32.eqz
-  drop
-  i32.const 0
-  i32.eqz
-  drop
-  i32.const 0
-  i32.eqz
-  drop
-  i32.const 0
-  i32.eqz
-  drop
-  i32.const 1
-  drop
-  i32.const 0
-  i32.eqz
-  drop
-  i32.const 0
-  i32.eqz
-  drop
-  i32.const 0
-  i32.eqz
-  drop
-  i32.const 0
-  i32.eqz
-  drop
-  i32.const 0
-  i32.eqz
-  drop
-  i32.const 0
-  i32.eqz
-  drop
-  i32.const 1
-  drop
-  i32.const 0
-  i32.eqz
-  drop
-  i32.const 0
-  i32.eqz
-  drop
-  i32.const 0
-  i32.eqz
-  drop
-  i32.const 0
-  i32.eqz
-  drop
-  i32.const 0
-  i32.eqz
-  drop
-  i32.const 0
-  i32.eqz
-  drop
-  i32.const 1
-  drop
-  i32.const 0
-  i32.eqz
-  drop
-  i32.const 0
-  i32.eqz
-  drop
-  i32.const 0
-  i32.eqz
-  drop
-  i32.const 0
-  i32.eqz
-  drop
-  i32.const 0
-  i32.eqz
-  drop
-  i32.const 0
-  i32.eqz
-  drop
-  i32.const 1
-  drop
-  i32.const 0
-  call $instanceof/isI32<i32>
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 432
-   i32.const 62
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const 0
-  call $instanceof/isI32<f64>
-  i32.eqz
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 432
-   i32.const 63
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  i32.const 0
-  call $instanceof/isI32<u32>
-  i32.eqz
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 432
-   i32.const 64
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  i32.const 0
-  call $instanceof/isI32<u16>
-  i32.eqz
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 432
-   i32.const 65
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  global.get $instanceof/an
-  i32.const 0
-  i32.ne
-  i32.eqz
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 432
-   i32.const 68
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  i32.const 1
-  drop
-  i32.const 1
-  global.set $instanceof/an
-  global.get $instanceof/an
-  i32.const 0
-  i32.ne
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 432
-   i32.const 71
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  i32.const 1
-  drop
-  i32.const 0
-  call $instanceof/Child<i32>#constructor
-  global.set $instanceof/child
-  i32.const 1
-  drop
-  i32.const 1
-  drop
-  i32.const 0
-  i32.eqz
-  drop
-  i32.const 1
-  drop
-  i32.const 1
-  drop
-  i32.const 0
-  i32.eqz
-  drop
-  i32.const 0
-  i32.eqz
-  drop
-  i32.const 0
-  i32.eqz
-  drop
-  i32.const 0
-  call $instanceof/Child<f32>#constructor
-  global.set $instanceof/childAsParent
-  i32.const 1
-  drop
-  i32.const 1
-  drop
-  i32.const 0
-  i32.eqz
-  drop
-  global.get $~lib/memory/__stack_pointer
-  global.get $instanceof/childAsParent
+  (local $check i32)
+  local.get $value
   local.tee $1
-  i32.store $0 offset=4
-  local.get $1
   i32.eqz
   if (result i32)
    i32.const 0
   else
    local.get $1
-   call $~instanceof|instanceof/Child<f32>
-  end
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 432
-   i32.const 94
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  i32.const 0
-  i32.eqz
-  drop
-  global.get $~lib/memory/__stack_pointer
-  global.get $instanceof/childAsParent
-  local.tee $2
-  i32.store $0 offset=8
-  local.get $2
-  i32.eqz
-  if (result i32)
-   i32.const 0
-  else
-   local.get $2
-   call $~anyinstanceof|instanceof/Child
-  end
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 432
-   i32.const 96
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  i32.const 0
-  i32.eqz
-  drop
-  i32.const 0
-  i32.eqz
-  drop
-  i32.const 0
-  call $instanceof/Animal#constructor
-  global.set $instanceof/animal
-  i32.const 0
-  call $instanceof/Cat#constructor
-  global.set $instanceof/cat
-  i32.const 0
-  call $instanceof/BlackCat#constructor
-  global.set $instanceof/blackcat
-  i32.const 1
-  drop
-  global.get $~lib/memory/__stack_pointer
-  global.get $instanceof/animal
-  local.tee $3
-  i32.store $0 offset=12
-  local.get $3
-  i32.eqz
-  if (result i32)
-   i32.const 0
-  else
-   local.get $3
-   call $~instanceof|instanceof/Cat
-  end
-  i32.eqz
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 432
-   i32.const 111
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  global.get $~lib/memory/__stack_pointer
-  global.get $instanceof/animal
-  local.tee $4
-  i32.store $0 offset=16
-  local.get $4
-  i32.eqz
-  if (result i32)
-   i32.const 0
-  else
-   local.get $4
-   call $~instanceof|instanceof/BlackCat
-  end
-  i32.eqz
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 432
-   i32.const 112
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  i32.const 1
-  drop
-  global.get $~lib/memory/__stack_pointer
-  global.get $instanceof/cat
-  local.tee $5
-  i32.store $0 offset=20
-  local.get $5
-  i32.eqz
-  if (result i32)
-   i32.const 0
-  else
-   local.get $5
-   call $~instanceof|instanceof/Cat
-  end
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 432
-   i32.const 115
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  global.get $~lib/memory/__stack_pointer
-  global.get $instanceof/cat
-  local.tee $6
-  i32.store $0 offset=24
-  local.get $6
-  i32.eqz
-  if (result i32)
-   i32.const 0
-  else
-   local.get $6
-   call $~instanceof|instanceof/BlackCat
-  end
-  i32.eqz
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 432
-   i32.const 116
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  i32.const 1
-  drop
-  global.get $~lib/memory/__stack_pointer
-  global.get $instanceof/blackcat
-  local.tee $7
-  i32.store $0 offset=28
-  local.get $7
-  i32.eqz
-  if (result i32)
-   i32.const 0
-  else
-   local.get $7
-   call $~instanceof|instanceof/Cat
-  end
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 432
-   i32.const 119
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  global.get $~lib/memory/__stack_pointer
-  global.get $instanceof/blackcat
-  local.tee $8
-  i32.store $0 offset=32
-  local.get $8
-  i32.eqz
-  if (result i32)
-   i32.const 0
-  else
-   local.get $8
-   call $~instanceof|instanceof/BlackCat
-  end
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 432
-   i32.const 120
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  i32.const 0
-  call $instanceof/Animal#constructor
-  global.set $instanceof/nullableAnimal
-  i32.const 0
-  call $instanceof/Cat#constructor
-  global.set $instanceof/nullableCat
-  i32.const 0
-  call $instanceof/BlackCat#constructor
-  global.set $instanceof/nullableBlackcat
-  global.get $instanceof/nullableAnimal
-  i32.const 0
-  i32.ne
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 432
-   i32.const 126
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  global.get $~lib/memory/__stack_pointer
-  global.get $instanceof/nullableAnimal
-  local.tee $9
-  i32.store $0 offset=36
-  local.get $9
-  i32.eqz
-  if (result i32)
-   i32.const 0
-  else
-   local.get $9
-   call $~instanceof|instanceof/Cat
-  end
-  i32.eqz
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 432
-   i32.const 127
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  global.get $~lib/memory/__stack_pointer
-  global.get $instanceof/nullableAnimal
-  local.tee $10
-  i32.store $0 offset=40
-  local.get $10
-  i32.eqz
-  if (result i32)
-   i32.const 0
-  else
-   local.get $10
-   call $~instanceof|instanceof/BlackCat
-  end
-  i32.eqz
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 432
-   i32.const 128
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  global.get $instanceof/nullableCat
-  i32.const 0
-  i32.ne
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 432
-   i32.const 130
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  global.get $~lib/memory/__stack_pointer
-  global.get $instanceof/nullableCat
-  local.tee $11
-  i32.store $0 offset=44
-  local.get $11
-  i32.eqz
-  if (result i32)
-   i32.const 0
-  else
-   local.get $11
-   call $~instanceof|instanceof/Cat
-  end
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 432
-   i32.const 131
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  global.get $~lib/memory/__stack_pointer
-  global.get $instanceof/nullableCat
-  local.tee $12
-  i32.store $0 offset=48
-  local.get $12
-  i32.eqz
-  if (result i32)
-   i32.const 0
-  else
-   local.get $12
-   call $~instanceof|instanceof/BlackCat
-  end
-  i32.eqz
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 432
-   i32.const 132
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  global.get $instanceof/nullableBlackcat
-  i32.const 0
-  i32.ne
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 432
-   i32.const 134
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  global.get $~lib/memory/__stack_pointer
-  global.get $instanceof/nullableBlackcat
-  local.tee $13
-  i32.store $0 offset=52
-  local.get $13
-  i32.eqz
-  if (result i32)
-   i32.const 0
-  else
-   local.get $13
-   call $~instanceof|instanceof/Cat
-  end
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 432
-   i32.const 135
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  global.get $~lib/memory/__stack_pointer
-  global.get $instanceof/nullableBlackcat
-  local.tee $14
-  i32.store $0 offset=56
-  local.get $14
-  i32.eqz
-  if (result i32)
-   i32.const 0
-  else
-   local.get $14
-   call $~instanceof|instanceof/BlackCat
-  end
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 432
-   i32.const 136
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  global.get $instanceof/nullAnimal
-  i32.const 0
-  i32.ne
-  i32.eqz
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 432
-   i32.const 142
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  global.get $~lib/memory/__stack_pointer
-  global.get $instanceof/nullAnimal
-  local.tee $15
-  i32.store $0 offset=60
-  local.get $15
-  i32.eqz
-  if (result i32)
-   i32.const 0
-  else
-   local.get $15
-   call $~instanceof|instanceof/Cat
-  end
-  i32.eqz
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 432
-   i32.const 143
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  global.get $~lib/memory/__stack_pointer
-  global.get $instanceof/nullAnimal
-  local.tee $16
-  i32.store $0 offset=64
-  local.get $16
-  i32.eqz
-  if (result i32)
-   i32.const 0
-  else
-   local.get $16
-   call $~instanceof|instanceof/BlackCat
-  end
-  i32.eqz
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 432
-   i32.const 144
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  global.get $instanceof/nullCat
-  i32.const 0
-  i32.ne
-  i32.eqz
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 432
-   i32.const 146
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  global.get $~lib/memory/__stack_pointer
-  global.get $instanceof/nullCat
-  local.tee $17
-  i32.store $0 offset=68
-  local.get $17
-  i32.eqz
-  if (result i32)
-   i32.const 0
-  else
-   local.get $17
-   call $~instanceof|instanceof/Cat
-  end
-  i32.eqz
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 432
-   i32.const 147
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  global.get $~lib/memory/__stack_pointer
-  global.get $instanceof/nullCat
-  local.tee $18
-  i32.store $0 offset=72
-  local.get $18
-  i32.eqz
-  if (result i32)
-   i32.const 0
-  else
-   local.get $18
-   call $~instanceof|instanceof/BlackCat
-  end
-  i32.eqz
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 432
-   i32.const 148
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  global.get $instanceof/nullBlackcat
-  i32.const 0
-  i32.ne
-  i32.eqz
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 432
-   i32.const 150
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  global.get $~lib/memory/__stack_pointer
-  global.get $instanceof/nullBlackcat
-  local.tee $19
-  i32.store $0 offset=76
-  local.get $19
-  i32.eqz
-  if (result i32)
-   i32.const 0
-  else
-   local.get $19
-   call $~instanceof|instanceof/Cat
-  end
-  i32.eqz
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 432
-   i32.const 151
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  global.get $~lib/memory/__stack_pointer
-  global.get $instanceof/nullBlackcat
-  local.tee $20
-  i32.store $0 offset=80
-  local.get $20
-  i32.eqz
-  if (result i32)
-   i32.const 0
-  else
-   local.get $20
-   call $~instanceof|instanceof/BlackCat
-  end
-  i32.eqz
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 432
-   i32.const 152
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  i32.const 0
-  call $instanceof/A_I1#constructor
-  global.set $instanceof/a_i1
-  i32.const 1
-  drop
-  i32.const 1
-  drop
-  global.get $~lib/memory/__stack_pointer
-  global.get $instanceof/a_i1
-  local.tee $21
-  i32.store $0 offset=84
-  local.get $21
-  i32.eqz
-  if (result i32)
-   i32.const 0
-  else
-   local.get $21
    call $~instanceof|instanceof/I1
   end
   i32.eqz
   if
    i32.const 0
-   i32.const 432
-   i32.const 165
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
+   local.set $check
+   i32.const 0
+   i32.eqz
+   if
+    i32.const 0
+    i32.const 432
+    i32.const 12
+    i32.const 5
+    call $~lib/builtins/abort
+    unreachable
+   end
   end
+  i32.const 1
+  drop
+ )
+ (func $instanceof/assertStaticTrue<instanceof/B_I1_I2,instanceof/I1> (type $i32_=>_none) (param $value i32)
+  i32.const 1
+  drop
+  return
+ )
+ (func $instanceof/assertStaticTrue<instanceof/B_I1_I2,instanceof/I2> (type $i32_=>_none) (param $value i32)
+  i32.const 1
+  drop
+  return
+ )
+ (func $instanceof/assertStaticFalse<instanceof/A_I1,instanceof/B_I1_I2> (type $i32_=>_none) (param $value i32)
   i32.const 0
   i32.eqz
   drop
-  i32.const 0
-  call $instanceof/B_I1_I2#constructor
-  global.set $instanceof/b_i1_i2
-  i32.const 1
-  drop
-  i32.const 1
-  drop
-  i32.const 0
-  i32.eqz
-  drop
-  global.get $~lib/memory/__stack_pointer
-  global.get $instanceof/a_i1
-  local.tee $22
-  i32.store $0 offset=88
-  local.get $22
+  return
+ )
+ (func $instanceof/assertDynamicFalse<instanceof/I1,instanceof/B_I1_I2> (type $i32_=>_none) (param $value i32)
+  (local $1 i32)
+  (local $check i32)
+  local.get $value
+  local.tee $1
   i32.eqz
   if (result i32)
    i32.const 0
   else
-   local.get $22
+   local.get $1
    call $~instanceof|instanceof/B_I1_I2
   end
-  i32.eqz
-  i32.eqz
   if
    i32.const 0
-   i32.const 432
-   i32.const 172
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
+   local.set $check
+   i32.const 0
+   i32.eqz
+   if
+    i32.const 0
+    i32.const 432
+    i32.const 19
+    i32.const 5
+    call $~lib/builtins/abort
+    unreachable
+   end
   end
-  global.get $~lib/memory/__stack_pointer
-  global.get $instanceof/b_i1_i2
-  local.tee $23
-  i32.store $0 offset=92
-  local.get $23
+  i32.const 1
+  drop
+ )
+ (func $instanceof/assertDynamicTrue<instanceof/I1,instanceof/B_I1_I2> (type $i32_=>_none) (param $value i32)
+  (local $1 i32)
+  (local $check i32)
+  local.get $value
+  local.tee $1
   i32.eqz
   if (result i32)
    i32.const 0
   else
-   local.get $23
+   local.get $1
    call $~instanceof|instanceof/B_I1_I2
   end
   i32.eqz
   if
    i32.const 0
-   i32.const 432
-   i32.const 173
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
+   local.set $check
+   i32.const 0
+   i32.eqz
+   if
+    i32.const 0
+    i32.const 432
+    i32.const 12
+    i32.const 5
+    call $~lib/builtins/abort
+    unreachable
+   end
   end
-  global.get $~lib/memory/__stack_pointer
-  i32.const 96
-  i32.add
-  global.set $~lib/memory/__stack_pointer
+  i32.const 1
+  drop
  )
  (func $~instanceof|instanceof/B (type $i32_=>_i32) (param $0 i32) (result i32)
   (local $1 i32)
@@ -3552,6 +2756,906 @@
    call $~lib/builtins/abort
    unreachable
   end
+ )
+ (func $start:instanceof (type $none_=>_none)
+  (local $0 i32)
+  (local $1 i32)
+  (local $2 i32)
+  (local $3 i32)
+  (local $4 i32)
+  (local $5 i32)
+  (local $6 i32)
+  (local $7 i32)
+  (local $8 i32)
+  (local $9 i32)
+  (local $10 i32)
+  (local $11 i32)
+  (local $12 i32)
+  (local $13 i32)
+  (local $14 i32)
+  (local $15 i32)
+  (local $16 i32)
+  (local $17 i32)
+  (local $18 i32)
+  (local $19 i32)
+  (local $20 i32)
+  (local $21 i32)
+  global.get $~lib/memory/__stack_pointer
+  i32.const 88
+  i32.sub
+  global.set $~lib/memory/__stack_pointer
+  call $~stack_check
+  global.get $~lib/memory/__stack_pointer
+  i32.const 0
+  i32.const 88
+  memory.fill $0
+  memory.size $0
+  i32.const 16
+  i32.shl
+  global.get $~lib/memory/__heap_base
+  i32.sub
+  i32.const 1
+  i32.shr_u
+  global.set $~lib/rt/itcms/threshold
+  i32.const 144
+  call $~lib/rt/itcms/initLazy
+  global.set $~lib/rt/itcms/pinSpace
+  i32.const 176
+  call $~lib/rt/itcms/initLazy
+  global.set $~lib/rt/itcms/toSpace
+  i32.const 320
+  call $~lib/rt/itcms/initLazy
+  global.set $~lib/rt/itcms/fromSpace
+  i32.const 0
+  call $instanceof/A#constructor
+  global.set $instanceof/a
+  i32.const 0
+  call $instanceof/B#constructor
+  global.set $instanceof/b
+  i32.const 1
+  drop
+  i32.const 1
+  drop
+  i32.const 0
+  i32.eqz
+  drop
+  i32.const 0
+  i32.eqz
+  drop
+  i32.const 0
+  i32.eqz
+  drop
+  i32.const 0
+  i32.eqz
+  drop
+  global.get $~lib/memory/__stack_pointer
+  global.get $instanceof/a
+  local.tee $0
+  i32.store $0
+  local.get $0
+  i32.eqz
+  if (result i32)
+   i32.const 0
+  else
+   local.get $0
+   call $~instanceof|instanceof/B
+  end
+  i32.eqz
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 432
+   i32.const 41
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  i32.const 1
+  drop
+  i32.const 0
+  i32.eqz
+  drop
+  i32.const 0
+  i32.eqz
+  drop
+  i32.const 0
+  i32.eqz
+  drop
+  i32.const 0
+  i32.eqz
+  drop
+  i32.const 0
+  i32.eqz
+  drop
+  i32.const 0
+  i32.eqz
+  drop
+  i32.const 1
+  drop
+  i32.const 0
+  i32.eqz
+  drop
+  i32.const 0
+  i32.eqz
+  drop
+  i32.const 0
+  i32.eqz
+  drop
+  i32.const 0
+  i32.eqz
+  drop
+  i32.const 0
+  i32.eqz
+  drop
+  i32.const 0
+  i32.eqz
+  drop
+  i32.const 1
+  drop
+  i32.const 0
+  i32.eqz
+  drop
+  i32.const 0
+  i32.eqz
+  drop
+  i32.const 0
+  i32.eqz
+  drop
+  i32.const 0
+  i32.eqz
+  drop
+  i32.const 0
+  i32.eqz
+  drop
+  i32.const 0
+  i32.eqz
+  drop
+  i32.const 1
+  drop
+  i32.const 0
+  i32.eqz
+  drop
+  i32.const 0
+  i32.eqz
+  drop
+  i32.const 0
+  i32.eqz
+  drop
+  i32.const 0
+  i32.eqz
+  drop
+  i32.const 0
+  i32.eqz
+  drop
+  i32.const 0
+  i32.eqz
+  drop
+  i32.const 1
+  drop
+  i32.const 0
+  call $instanceof/isI32<i32>
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 432
+   i32.const 85
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const 0
+  call $instanceof/isI32<f64>
+  i32.eqz
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 432
+   i32.const 86
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  i32.const 0
+  call $instanceof/isI32<u32>
+  i32.eqz
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 432
+   i32.const 87
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  i32.const 0
+  call $instanceof/isI32<u16>
+  i32.eqz
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 432
+   i32.const 88
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  global.get $instanceof/an
+  i32.const 0
+  i32.ne
+  i32.eqz
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 432
+   i32.const 91
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  i32.const 1
+  drop
+  i32.const 1
+  global.set $instanceof/an
+  global.get $instanceof/an
+  i32.const 0
+  i32.ne
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 432
+   i32.const 94
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  i32.const 1
+  drop
+  i32.const 0
+  call $instanceof/Child<i32>#constructor
+  global.set $instanceof/child
+  i32.const 1
+  drop
+  i32.const 1
+  drop
+  i32.const 0
+  i32.eqz
+  drop
+  i32.const 1
+  drop
+  i32.const 1
+  drop
+  i32.const 0
+  i32.eqz
+  drop
+  i32.const 0
+  i32.eqz
+  drop
+  i32.const 0
+  i32.eqz
+  drop
+  i32.const 0
+  call $instanceof/Child<f32>#constructor
+  global.set $instanceof/childAsParent
+  i32.const 1
+  drop
+  i32.const 1
+  drop
+  i32.const 0
+  i32.eqz
+  drop
+  global.get $~lib/memory/__stack_pointer
+  global.get $instanceof/childAsParent
+  local.tee $1
+  i32.store $0 offset=4
+  local.get $1
+  i32.eqz
+  if (result i32)
+   i32.const 0
+  else
+   local.get $1
+   call $~instanceof|instanceof/Child<f32>
+  end
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 432
+   i32.const 117
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  i32.const 0
+  i32.eqz
+  drop
+  global.get $~lib/memory/__stack_pointer
+  global.get $instanceof/childAsParent
+  local.tee $2
+  i32.store $0 offset=8
+  local.get $2
+  i32.eqz
+  if (result i32)
+   i32.const 0
+  else
+   local.get $2
+   call $~anyinstanceof|instanceof/Child
+  end
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 432
+   i32.const 119
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  i32.const 0
+  i32.eqz
+  drop
+  i32.const 0
+  i32.eqz
+  drop
+  i32.const 0
+  call $instanceof/Animal#constructor
+  global.set $instanceof/animal
+  i32.const 0
+  call $instanceof/Cat#constructor
+  global.set $instanceof/cat
+  i32.const 0
+  call $instanceof/BlackCat#constructor
+  global.set $instanceof/blackcat
+  i32.const 1
+  drop
+  global.get $~lib/memory/__stack_pointer
+  global.get $instanceof/animal
+  local.tee $3
+  i32.store $0 offset=12
+  local.get $3
+  i32.eqz
+  if (result i32)
+   i32.const 0
+  else
+   local.get $3
+   call $~instanceof|instanceof/Cat
+  end
+  i32.eqz
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 432
+   i32.const 134
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  global.get $~lib/memory/__stack_pointer
+  global.get $instanceof/animal
+  local.tee $4
+  i32.store $0 offset=16
+  local.get $4
+  i32.eqz
+  if (result i32)
+   i32.const 0
+  else
+   local.get $4
+   call $~instanceof|instanceof/BlackCat
+  end
+  i32.eqz
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 432
+   i32.const 135
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  i32.const 1
+  drop
+  global.get $~lib/memory/__stack_pointer
+  global.get $instanceof/cat
+  local.tee $5
+  i32.store $0 offset=20
+  local.get $5
+  i32.eqz
+  if (result i32)
+   i32.const 0
+  else
+   local.get $5
+   call $~instanceof|instanceof/Cat
+  end
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 432
+   i32.const 138
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  global.get $~lib/memory/__stack_pointer
+  global.get $instanceof/cat
+  local.tee $6
+  i32.store $0 offset=24
+  local.get $6
+  i32.eqz
+  if (result i32)
+   i32.const 0
+  else
+   local.get $6
+   call $~instanceof|instanceof/BlackCat
+  end
+  i32.eqz
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 432
+   i32.const 139
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  i32.const 1
+  drop
+  global.get $~lib/memory/__stack_pointer
+  global.get $instanceof/blackcat
+  local.tee $7
+  i32.store $0 offset=28
+  local.get $7
+  i32.eqz
+  if (result i32)
+   i32.const 0
+  else
+   local.get $7
+   call $~instanceof|instanceof/Cat
+  end
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 432
+   i32.const 142
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  global.get $~lib/memory/__stack_pointer
+  global.get $instanceof/blackcat
+  local.tee $8
+  i32.store $0 offset=32
+  local.get $8
+  i32.eqz
+  if (result i32)
+   i32.const 0
+  else
+   local.get $8
+   call $~instanceof|instanceof/BlackCat
+  end
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 432
+   i32.const 143
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  i32.const 0
+  call $instanceof/Animal#constructor
+  global.set $instanceof/nullableAnimal
+  i32.const 0
+  call $instanceof/Cat#constructor
+  global.set $instanceof/nullableCat
+  i32.const 0
+  call $instanceof/BlackCat#constructor
+  global.set $instanceof/nullableBlackcat
+  global.get $instanceof/nullableAnimal
+  i32.const 0
+  i32.ne
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 432
+   i32.const 149
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  global.get $~lib/memory/__stack_pointer
+  global.get $instanceof/nullableAnimal
+  local.tee $9
+  i32.store $0 offset=36
+  local.get $9
+  i32.eqz
+  if (result i32)
+   i32.const 0
+  else
+   local.get $9
+   call $~instanceof|instanceof/Cat
+  end
+  i32.eqz
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 432
+   i32.const 150
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  global.get $~lib/memory/__stack_pointer
+  global.get $instanceof/nullableAnimal
+  local.tee $10
+  i32.store $0 offset=40
+  local.get $10
+  i32.eqz
+  if (result i32)
+   i32.const 0
+  else
+   local.get $10
+   call $~instanceof|instanceof/BlackCat
+  end
+  i32.eqz
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 432
+   i32.const 151
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  global.get $instanceof/nullableCat
+  i32.const 0
+  i32.ne
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 432
+   i32.const 153
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  global.get $~lib/memory/__stack_pointer
+  global.get $instanceof/nullableCat
+  local.tee $11
+  i32.store $0 offset=44
+  local.get $11
+  i32.eqz
+  if (result i32)
+   i32.const 0
+  else
+   local.get $11
+   call $~instanceof|instanceof/Cat
+  end
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 432
+   i32.const 154
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  global.get $~lib/memory/__stack_pointer
+  global.get $instanceof/nullableCat
+  local.tee $12
+  i32.store $0 offset=48
+  local.get $12
+  i32.eqz
+  if (result i32)
+   i32.const 0
+  else
+   local.get $12
+   call $~instanceof|instanceof/BlackCat
+  end
+  i32.eqz
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 432
+   i32.const 155
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  global.get $instanceof/nullableBlackcat
+  i32.const 0
+  i32.ne
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 432
+   i32.const 157
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  global.get $~lib/memory/__stack_pointer
+  global.get $instanceof/nullableBlackcat
+  local.tee $13
+  i32.store $0 offset=52
+  local.get $13
+  i32.eqz
+  if (result i32)
+   i32.const 0
+  else
+   local.get $13
+   call $~instanceof|instanceof/Cat
+  end
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 432
+   i32.const 158
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  global.get $~lib/memory/__stack_pointer
+  global.get $instanceof/nullableBlackcat
+  local.tee $14
+  i32.store $0 offset=56
+  local.get $14
+  i32.eqz
+  if (result i32)
+   i32.const 0
+  else
+   local.get $14
+   call $~instanceof|instanceof/BlackCat
+  end
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 432
+   i32.const 159
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  global.get $instanceof/nullAnimal
+  i32.const 0
+  i32.ne
+  i32.eqz
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 432
+   i32.const 165
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  global.get $~lib/memory/__stack_pointer
+  global.get $instanceof/nullAnimal
+  local.tee $15
+  i32.store $0 offset=60
+  local.get $15
+  i32.eqz
+  if (result i32)
+   i32.const 0
+  else
+   local.get $15
+   call $~instanceof|instanceof/Cat
+  end
+  i32.eqz
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 432
+   i32.const 166
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  global.get $~lib/memory/__stack_pointer
+  global.get $instanceof/nullAnimal
+  local.tee $16
+  i32.store $0 offset=64
+  local.get $16
+  i32.eqz
+  if (result i32)
+   i32.const 0
+  else
+   local.get $16
+   call $~instanceof|instanceof/BlackCat
+  end
+  i32.eqz
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 432
+   i32.const 167
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  global.get $instanceof/nullCat
+  i32.const 0
+  i32.ne
+  i32.eqz
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 432
+   i32.const 169
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  global.get $~lib/memory/__stack_pointer
+  global.get $instanceof/nullCat
+  local.tee $17
+  i32.store $0 offset=68
+  local.get $17
+  i32.eqz
+  if (result i32)
+   i32.const 0
+  else
+   local.get $17
+   call $~instanceof|instanceof/Cat
+  end
+  i32.eqz
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 432
+   i32.const 170
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  global.get $~lib/memory/__stack_pointer
+  global.get $instanceof/nullCat
+  local.tee $18
+  i32.store $0 offset=72
+  local.get $18
+  i32.eqz
+  if (result i32)
+   i32.const 0
+  else
+   local.get $18
+   call $~instanceof|instanceof/BlackCat
+  end
+  i32.eqz
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 432
+   i32.const 171
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  global.get $instanceof/nullBlackcat
+  i32.const 0
+  i32.ne
+  i32.eqz
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 432
+   i32.const 173
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  global.get $~lib/memory/__stack_pointer
+  global.get $instanceof/nullBlackcat
+  local.tee $19
+  i32.store $0 offset=76
+  local.get $19
+  i32.eqz
+  if (result i32)
+   i32.const 0
+  else
+   local.get $19
+   call $~instanceof|instanceof/Cat
+  end
+  i32.eqz
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 432
+   i32.const 174
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  global.get $~lib/memory/__stack_pointer
+  global.get $instanceof/nullBlackcat
+  local.tee $20
+  i32.store $0 offset=80
+  local.get $20
+  i32.eqz
+  if (result i32)
+   i32.const 0
+  else
+   local.get $20
+   call $~instanceof|instanceof/BlackCat
+  end
+  i32.eqz
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 432
+   i32.const 175
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  i32.const 0
+  call $instanceof/A_I1#constructor
+  global.set $instanceof/a_i1
+  global.get $instanceof/a_i1
+  local.set $21
+  global.get $~lib/memory/__stack_pointer
+  local.get $21
+  i32.store $0 offset=84
+  local.get $21
+  call $instanceof/assertStaticTrue<instanceof/A_I1,~lib/object/Object>
+  global.get $instanceof/a_i1
+  local.set $21
+  global.get $~lib/memory/__stack_pointer
+  local.get $21
+  i32.store $0 offset=84
+  local.get $21
+  call $instanceof/assertStaticTrue<instanceof/A_I1,instanceof/I1>
+  global.get $instanceof/a_i1
+  local.set $21
+  global.get $~lib/memory/__stack_pointer
+  local.get $21
+  i32.store $0 offset=84
+  local.get $21
+  call $instanceof/assertStaticFalse<instanceof/A_I1,instanceof/I2>
+  global.get $instanceof/a_i1
+  local.set $21
+  global.get $~lib/memory/__stack_pointer
+  local.get $21
+  i32.store $0 offset=84
+  local.get $21
+  call $instanceof/assertDynamicTrue<~lib/object/Object,instanceof/I1>
+  i32.const 0
+  call $instanceof/B_I1_I2#constructor
+  global.set $instanceof/b_i1_i2
+  global.get $instanceof/b_i1_i2
+  local.set $21
+  global.get $~lib/memory/__stack_pointer
+  local.get $21
+  i32.store $0 offset=84
+  local.get $21
+  call $instanceof/assertStaticTrue<instanceof/B_I1_I2,instanceof/I1>
+  global.get $instanceof/b_i1_i2
+  local.set $21
+  global.get $~lib/memory/__stack_pointer
+  local.get $21
+  i32.store $0 offset=84
+  local.get $21
+  call $instanceof/assertStaticTrue<instanceof/B_I1_I2,instanceof/I2>
+  global.get $instanceof/a_i1
+  local.set $21
+  global.get $~lib/memory/__stack_pointer
+  local.get $21
+  i32.store $0 offset=84
+  local.get $21
+  call $instanceof/assertStaticFalse<instanceof/A_I1,instanceof/B_I1_I2>
+  global.get $instanceof/a_i1
+  local.set $21
+  global.get $~lib/memory/__stack_pointer
+  local.get $21
+  i32.store $0 offset=84
+  local.get $21
+  call $instanceof/assertDynamicFalse<instanceof/I1,instanceof/B_I1_I2>
+  global.get $instanceof/b_i1_i2
+  local.set $21
+  global.get $~lib/memory/__stack_pointer
+  local.get $21
+  i32.store $0 offset=84
+  local.get $21
+  call $instanceof/assertDynamicTrue<instanceof/I1,instanceof/B_I1_I2>
+  global.get $~lib/memory/__stack_pointer
+  i32.const 88
+  i32.add
+  global.set $~lib/memory/__stack_pointer
  )
  (func $~lib/object/Object#constructor (type $i32_=>_i32) (param $this i32) (result i32)
   (local $1 i32)

--- a/tests/compiler/instanceof.debug.wat
+++ b/tests/compiler/instanceof.debug.wat
@@ -2503,10 +2503,6 @@
    i32.load $0
    local.set $1
    local.get $1
-   i32.const 15
-   i32.eq
-   br_if $is_instance
-   local.get $1
    i32.const 14
    i32.eq
    br_if $is_instance

--- a/tests/compiler/instanceof.debug.wat
+++ b/tests/compiler/instanceof.debug.wat
@@ -1,7 +1,7 @@
 (module
+ (type $i32_=>_none (func_subtype (param i32) func))
  (type $i32_=>_i32 (func_subtype (param i32) (result i32) func))
  (type $i32_i32_=>_none (func_subtype (param i32 i32) func))
- (type $i32_=>_none (func_subtype (param i32) func))
  (type $none_=>_none (func_subtype func))
  (type $i32_i32_=>_i32 (func_subtype (param i32 i32) (result i32) func))
  (type $i32_i32_i32_=>_none (func_subtype (param i32 i32 i32) func))
@@ -42,12 +42,14 @@
  (global $instanceof/nullAnimal (mut i32) (i32.const 0))
  (global $instanceof/nullCat (mut i32) (i32.const 0))
  (global $instanceof/nullBlackcat (mut i32) (i32.const 0))
- (global $instanceof/a_i1 (mut i32) (i32.const 0))
- (global $instanceof/b_i1_i2 (mut i32) (i32.const 0))
+ (global $instanceof/w (mut i32) (i32.const 0))
+ (global $instanceof/x (mut i32) (i32.const 0))
+ (global $instanceof/y (mut i32) (i32.const 0))
+ (global $instanceof/z (mut i32) (i32.const 0))
  (global $~lib/rt/__rtti_base i32 (i32.const 464))
- (global $~lib/memory/__data_end i32 (i32.const 540))
- (global $~lib/memory/__stack_pointer (mut i32) (i32.const 33308))
- (global $~lib/memory/__heap_base i32 (i32.const 33308))
+ (global $~lib/memory/__data_end i32 (i32.const 560))
+ (global $~lib/memory/__stack_pointer (mut i32) (i32.const 33328))
+ (global $~lib/memory/__heap_base i32 (i32.const 33328))
  (memory $0 1)
  (data (i32.const 12) "<\00\00\00\00\00\00\00\00\00\00\00\02\00\00\00(\00\00\00A\00l\00l\00o\00c\00a\00t\00i\00o\00n\00 \00t\00o\00o\00 \00l\00a\00r\00g\00e\00\00\00\00\00")
  (data (i32.const 76) "<\00\00\00\00\00\00\00\00\00\00\00\02\00\00\00 \00\00\00~\00l\00i\00b\00/\00r\00t\00/\00i\00t\00c\00m\00s\00.\00t\00s\00\00\00\00\00\00\00\00\00\00\00\00\00")
@@ -58,7 +60,7 @@
  (data (i32.const 320) "\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00")
  (data (i32.const 348) "<\00\00\00\00\00\00\00\00\00\00\00\02\00\00\00\1e\00\00\00~\00l\00i\00b\00/\00r\00t\00/\00t\00l\00s\00f\00.\00t\00s\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00")
  (data (i32.const 412) ",\00\00\00\00\00\00\00\00\00\00\00\02\00\00\00\1a\00\00\00i\00n\00s\00t\00a\00n\00c\00e\00o\00f\00.\00t\00s\00\00\00")
- (data (i32.const 464) "\12\00\00\00 \00\00\00 \00\00\00 \00\00\00\00\00\00\00 \00\00\00 \00\00\00 \00\00\00 \00\00\00 \00\00\00 \00\00\00 \00\00\00 \00\00\00 \00\00\00 \00\00\00 \00\00\00 \00\00\00 \00\00\00 \00\00\00")
+ (data (i32.const 464) "\17\00\00\00 \00\00\00 \00\00\00 \00\00\00\00\00\00\00 \00\00\00 \00\00\00 \00\00\00 \00\00\00 \00\00\00 \00\00\00 \00\00\00 \00\00\00 \00\00\00 \00\00\00 \00\00\00 \00\00\00 \00\00\00 \00\00\00 \00\00\00 \00\00\00 \00\00\00 \00\00\00 \00\00\00")
  (table $0 1 1 funcref)
  (elem $0 (i32.const 1))
  (export "memory" (memory $0))
@@ -2280,23 +2282,47 @@
   i32.const 0
   return
  )
- (func $instanceof/assertStaticTrue<instanceof/A_I1,~lib/object/Object> (type $i32_=>_none) (param $value i32)
+ (func $instanceof/assertStaticTrue<instanceof/W,~lib/object/Object> (type $i32_=>_none) (param $value i32)
   i32.const 1
   drop
   return
  )
- (func $instanceof/assertStaticTrue<instanceof/A_I1,instanceof/I1> (type $i32_=>_none) (param $value i32)
+ (func $instanceof/assertStaticTrue<instanceof/X,~lib/object/Object> (type $i32_=>_none) (param $value i32)
   i32.const 1
   drop
   return
  )
- (func $instanceof/assertStaticFalse<instanceof/A_I1,instanceof/I2> (type $i32_=>_none) (param $value i32)
-  i32.const 0
-  i32.eqz
+ (func $instanceof/assertStaticTrue<instanceof/Y,~lib/object/Object> (type $i32_=>_none) (param $value i32)
+  i32.const 1
   drop
   return
  )
- (func $instanceof/assertDynamicTrue<~lib/object/Object,instanceof/I1> (type $i32_=>_none) (param $value i32)
+ (func $instanceof/assertStaticTrue<instanceof/Z,~lib/object/Object> (type $i32_=>_none) (param $value i32)
+  i32.const 1
+  drop
+  return
+ )
+ (func $instanceof/assertStaticTrue<instanceof/IA,~lib/object/Object> (type $i32_=>_none) (param $value i32)
+  i32.const 1
+  drop
+  return
+ )
+ (func $instanceof/assertStaticTrue<instanceof/IB,~lib/object/Object> (type $i32_=>_none) (param $value i32)
+  i32.const 1
+  drop
+  return
+ )
+ (func $instanceof/assertStaticTrue<instanceof/IC,~lib/object/Object> (type $i32_=>_none) (param $value i32)
+  i32.const 1
+  drop
+  return
+ )
+ (func $instanceof/assertStaticTrue<instanceof/ID,~lib/object/Object> (type $i32_=>_none) (param $value i32)
+  i32.const 1
+  drop
+  return
+ )
+ (func $instanceof/assertDynamicTrue<~lib/object/Object,instanceof/W> (type $i32_=>_none) (param $value i32)
   (local $1 i32)
   (local $check i32)
   local.get $value
@@ -2306,7 +2332,7 @@
    i32.const 0
   else
    local.get $1
-   call $~instanceof|instanceof/I1
+   call $~instanceof|instanceof/W
   end
   i32.eqz
   if
@@ -2326,23 +2352,7 @@
   i32.const 1
   drop
  )
- (func $instanceof/assertStaticTrue<instanceof/B_I1_I2,instanceof/I1> (type $i32_=>_none) (param $value i32)
-  i32.const 1
-  drop
-  return
- )
- (func $instanceof/assertStaticTrue<instanceof/B_I1_I2,instanceof/I2> (type $i32_=>_none) (param $value i32)
-  i32.const 1
-  drop
-  return
- )
- (func $instanceof/assertStaticFalse<instanceof/A_I1,instanceof/B_I1_I2> (type $i32_=>_none) (param $value i32)
-  i32.const 0
-  i32.eqz
-  drop
-  return
- )
- (func $instanceof/assertDynamicFalse<instanceof/I1,instanceof/B_I1_I2> (type $i32_=>_none) (param $value i32)
+ (func $instanceof/assertDynamicTrue<~lib/object/Object,instanceof/X> (type $i32_=>_none) (param $value i32)
   (local $1 i32)
   (local $check i32)
   local.get $value
@@ -2352,7 +2362,263 @@
    i32.const 0
   else
    local.get $1
-   call $~instanceof|instanceof/B_I1_I2
+   call $~instanceof|instanceof/X
+  end
+  i32.eqz
+  if
+   i32.const 0
+   local.set $check
+   i32.const 0
+   i32.eqz
+   if
+    i32.const 0
+    i32.const 432
+    i32.const 12
+    i32.const 5
+    call $~lib/builtins/abort
+    unreachable
+   end
+  end
+  i32.const 1
+  drop
+ )
+ (func $instanceof/assertDynamicTrue<~lib/object/Object,instanceof/Y> (type $i32_=>_none) (param $value i32)
+  (local $1 i32)
+  (local $check i32)
+  local.get $value
+  local.tee $1
+  i32.eqz
+  if (result i32)
+   i32.const 0
+  else
+   local.get $1
+   call $~instanceof|instanceof/Y
+  end
+  i32.eqz
+  if
+   i32.const 0
+   local.set $check
+   i32.const 0
+   i32.eqz
+   if
+    i32.const 0
+    i32.const 432
+    i32.const 12
+    i32.const 5
+    call $~lib/builtins/abort
+    unreachable
+   end
+  end
+  i32.const 1
+  drop
+ )
+ (func $instanceof/assertDynamicTrue<~lib/object/Object,instanceof/Z> (type $i32_=>_none) (param $value i32)
+  (local $1 i32)
+  (local $check i32)
+  local.get $value
+  local.tee $1
+  i32.eqz
+  if (result i32)
+   i32.const 0
+  else
+   local.get $1
+   call $~instanceof|instanceof/Z
+  end
+  i32.eqz
+  if
+   i32.const 0
+   local.set $check
+   i32.const 0
+   i32.eqz
+   if
+    i32.const 0
+    i32.const 432
+    i32.const 12
+    i32.const 5
+    call $~lib/builtins/abort
+    unreachable
+   end
+  end
+  i32.const 1
+  drop
+ )
+ (func $instanceof/assertDynamicTrue<~lib/object/Object,instanceof/IA> (type $i32_=>_none) (param $value i32)
+  (local $1 i32)
+  (local $check i32)
+  local.get $value
+  local.tee $1
+  i32.eqz
+  if (result i32)
+   i32.const 0
+  else
+   local.get $1
+   call $~instanceof|instanceof/IA
+  end
+  i32.eqz
+  if
+   i32.const 0
+   local.set $check
+   i32.const 0
+   i32.eqz
+   if
+    i32.const 0
+    i32.const 432
+    i32.const 12
+    i32.const 5
+    call $~lib/builtins/abort
+    unreachable
+   end
+  end
+  i32.const 1
+  drop
+ )
+ (func $instanceof/assertDynamicTrue<~lib/object/Object,instanceof/IB> (type $i32_=>_none) (param $value i32)
+  (local $1 i32)
+  (local $check i32)
+  local.get $value
+  local.tee $1
+  i32.eqz
+  if (result i32)
+   i32.const 0
+  else
+   local.get $1
+   call $~instanceof|instanceof/IB
+  end
+  i32.eqz
+  if
+   i32.const 0
+   local.set $check
+   i32.const 0
+   i32.eqz
+   if
+    i32.const 0
+    i32.const 432
+    i32.const 12
+    i32.const 5
+    call $~lib/builtins/abort
+    unreachable
+   end
+  end
+  i32.const 1
+  drop
+ )
+ (func $instanceof/assertDynamicTrue<~lib/object/Object,instanceof/IC> (type $i32_=>_none) (param $value i32)
+  (local $1 i32)
+  (local $check i32)
+  local.get $value
+  local.tee $1
+  i32.eqz
+  if (result i32)
+   i32.const 0
+  else
+   local.get $1
+   call $~instanceof|instanceof/IC
+  end
+  i32.eqz
+  if
+   i32.const 0
+   local.set $check
+   i32.const 0
+   i32.eqz
+   if
+    i32.const 0
+    i32.const 432
+    i32.const 12
+    i32.const 5
+    call $~lib/builtins/abort
+    unreachable
+   end
+  end
+  i32.const 1
+  drop
+ )
+ (func $instanceof/assertDynamicTrue<~lib/object/Object,instanceof/ID> (type $i32_=>_none) (param $value i32)
+  (local $1 i32)
+  (local $check i32)
+  local.get $value
+  local.tee $1
+  i32.eqz
+  if (result i32)
+   i32.const 0
+  else
+   local.get $1
+   call $~instanceof|instanceof/ID
+  end
+  i32.eqz
+  if
+   i32.const 0
+   local.set $check
+   i32.const 0
+   i32.eqz
+   if
+    i32.const 0
+    i32.const 432
+    i32.const 12
+    i32.const 5
+    call $~lib/builtins/abort
+    unreachable
+   end
+  end
+  i32.const 1
+  drop
+ )
+ (func $instanceof/assertStaticTrue<instanceof/W,instanceof/W> (type $i32_=>_none) (param $value i32)
+  i32.const 1
+  drop
+  return
+ )
+ (func $instanceof/assertStaticFalse<instanceof/W,instanceof/X> (type $i32_=>_none) (param $value i32)
+  i32.const 0
+  i32.eqz
+  drop
+  return
+ )
+ (func $instanceof/assertStaticFalse<instanceof/W,instanceof/Y> (type $i32_=>_none) (param $value i32)
+  i32.const 0
+  i32.eqz
+  drop
+  return
+ )
+ (func $instanceof/assertStaticFalse<instanceof/W,instanceof/Z> (type $i32_=>_none) (param $value i32)
+  i32.const 0
+  i32.eqz
+  drop
+  return
+ )
+ (func $instanceof/assertStaticFalse<instanceof/X,instanceof/W> (type $i32_=>_none) (param $value i32)
+  i32.const 0
+  i32.eqz
+  drop
+  return
+ )
+ (func $instanceof/assertStaticFalse<instanceof/Y,instanceof/W> (type $i32_=>_none) (param $value i32)
+  i32.const 0
+  i32.eqz
+  drop
+  return
+ )
+ (func $instanceof/assertStaticFalse<instanceof/Z,instanceof/W> (type $i32_=>_none) (param $value i32)
+  i32.const 0
+  i32.eqz
+  drop
+  return
+ )
+ (func $instanceof/assertStaticTrue<instanceof/X,instanceof/X> (type $i32_=>_none) (param $value i32)
+  i32.const 1
+  drop
+  return
+ )
+ (func $instanceof/assertDynamicFalse<instanceof/X,instanceof/Y> (type $i32_=>_none) (param $value i32)
+  (local $1 i32)
+  (local $check i32)
+  local.get $value
+  local.tee $1
+  i32.eqz
+  if (result i32)
+   i32.const 0
+  else
+   local.get $1
+   call $~instanceof|instanceof/Y
   end
   if
    i32.const 0
@@ -2371,7 +2637,7 @@
   i32.const 1
   drop
  )
- (func $instanceof/assertDynamicTrue<instanceof/I1,instanceof/B_I1_I2> (type $i32_=>_none) (param $value i32)
+ (func $instanceof/assertDynamicFalse<instanceof/X,instanceof/Z> (type $i32_=>_none) (param $value i32)
   (local $1 i32)
   (local $check i32)
   local.get $value
@@ -2381,7 +2647,908 @@
    i32.const 0
   else
    local.get $1
-   call $~instanceof|instanceof/B_I1_I2
+   call $~instanceof|instanceof/Z
+  end
+  if
+   i32.const 0
+   local.set $check
+   i32.const 0
+   i32.eqz
+   if
+    i32.const 0
+    i32.const 432
+    i32.const 19
+    i32.const 5
+    call $~lib/builtins/abort
+    unreachable
+   end
+  end
+  i32.const 1
+  drop
+ )
+ (func $instanceof/assertDynamicTrue<instanceof/X,instanceof/Y> (type $i32_=>_none) (param $value i32)
+  (local $1 i32)
+  (local $check i32)
+  local.get $value
+  local.tee $1
+  i32.eqz
+  if (result i32)
+   i32.const 0
+  else
+   local.get $1
+   call $~instanceof|instanceof/Y
+  end
+  i32.eqz
+  if
+   i32.const 0
+   local.set $check
+   i32.const 0
+   i32.eqz
+   if
+    i32.const 0
+    i32.const 432
+    i32.const 12
+    i32.const 5
+    call $~lib/builtins/abort
+    unreachable
+   end
+  end
+  i32.const 1
+  drop
+ )
+ (func $instanceof/assertDynamicTrue<instanceof/X,instanceof/Z> (type $i32_=>_none) (param $value i32)
+  (local $1 i32)
+  (local $check i32)
+  local.get $value
+  local.tee $1
+  i32.eqz
+  if (result i32)
+   i32.const 0
+  else
+   local.get $1
+   call $~instanceof|instanceof/Z
+  end
+  i32.eqz
+  if
+   i32.const 0
+   local.set $check
+   i32.const 0
+   i32.eqz
+   if
+    i32.const 0
+    i32.const 432
+    i32.const 12
+    i32.const 5
+    call $~lib/builtins/abort
+    unreachable
+   end
+  end
+  i32.const 1
+  drop
+ )
+ (func $instanceof/assertStaticTrue<instanceof/Y,instanceof/X> (type $i32_=>_none) (param $value i32)
+  i32.const 1
+  drop
+  return
+ )
+ (func $instanceof/assertStaticTrue<instanceof/Y,instanceof/Y> (type $i32_=>_none) (param $value i32)
+  i32.const 1
+  drop
+  return
+ )
+ (func $instanceof/assertDynamicFalse<instanceof/Y,instanceof/Z> (type $i32_=>_none) (param $value i32)
+  (local $1 i32)
+  (local $check i32)
+  local.get $value
+  local.tee $1
+  i32.eqz
+  if (result i32)
+   i32.const 0
+  else
+   local.get $1
+   call $~instanceof|instanceof/Z
+  end
+  if
+   i32.const 0
+   local.set $check
+   i32.const 0
+   i32.eqz
+   if
+    i32.const 0
+    i32.const 432
+    i32.const 19
+    i32.const 5
+    call $~lib/builtins/abort
+    unreachable
+   end
+  end
+  i32.const 1
+  drop
+ )
+ (func $instanceof/assertDynamicTrue<instanceof/Y,instanceof/Z> (type $i32_=>_none) (param $value i32)
+  (local $1 i32)
+  (local $check i32)
+  local.get $value
+  local.tee $1
+  i32.eqz
+  if (result i32)
+   i32.const 0
+  else
+   local.get $1
+   call $~instanceof|instanceof/Z
+  end
+  i32.eqz
+  if
+   i32.const 0
+   local.set $check
+   i32.const 0
+   i32.eqz
+   if
+    i32.const 0
+    i32.const 432
+    i32.const 12
+    i32.const 5
+    call $~lib/builtins/abort
+    unreachable
+   end
+  end
+  i32.const 1
+  drop
+ )
+ (func $instanceof/assertStaticTrue<instanceof/Z,instanceof/X> (type $i32_=>_none) (param $value i32)
+  i32.const 1
+  drop
+  return
+ )
+ (func $instanceof/assertStaticTrue<instanceof/Z,instanceof/Y> (type $i32_=>_none) (param $value i32)
+  i32.const 1
+  drop
+  return
+ )
+ (func $instanceof/assertStaticTrue<instanceof/Z,instanceof/Z> (type $i32_=>_none) (param $value i32)
+  i32.const 1
+  drop
+  return
+ )
+ (func $instanceof/assertDynamicFalse<instanceof/IA,instanceof/IC> (type $i32_=>_none) (param $value i32)
+  (local $1 i32)
+  (local $check i32)
+  local.get $value
+  local.tee $1
+  i32.eqz
+  if (result i32)
+   i32.const 0
+  else
+   local.get $1
+   call $~instanceof|instanceof/IC
+  end
+  if
+   i32.const 0
+   local.set $check
+   i32.const 0
+   i32.eqz
+   if
+    i32.const 0
+    i32.const 432
+    i32.const 19
+    i32.const 5
+    call $~lib/builtins/abort
+    unreachable
+   end
+  end
+  i32.const 1
+  drop
+ )
+ (func $instanceof/assertDynamicFalse<instanceof/IB,instanceof/IC> (type $i32_=>_none) (param $value i32)
+  (local $1 i32)
+  (local $check i32)
+  local.get $value
+  local.tee $1
+  i32.eqz
+  if (result i32)
+   i32.const 0
+  else
+   local.get $1
+   call $~instanceof|instanceof/IC
+  end
+  if
+   i32.const 0
+   local.set $check
+   i32.const 0
+   i32.eqz
+   if
+    i32.const 0
+    i32.const 432
+    i32.const 19
+    i32.const 5
+    call $~lib/builtins/abort
+    unreachable
+   end
+  end
+  i32.const 1
+  drop
+ )
+ (func $instanceof/assertDynamicFalse<instanceof/IA,instanceof/ID> (type $i32_=>_none) (param $value i32)
+  (local $1 i32)
+  (local $check i32)
+  local.get $value
+  local.tee $1
+  i32.eqz
+  if (result i32)
+   i32.const 0
+  else
+   local.get $1
+   call $~instanceof|instanceof/ID
+  end
+  if
+   i32.const 0
+   local.set $check
+   i32.const 0
+   i32.eqz
+   if
+    i32.const 0
+    i32.const 432
+    i32.const 19
+    i32.const 5
+    call $~lib/builtins/abort
+    unreachable
+   end
+  end
+  i32.const 1
+  drop
+ )
+ (func $instanceof/assertDynamicFalse<instanceof/IB,instanceof/ID> (type $i32_=>_none) (param $value i32)
+  (local $1 i32)
+  (local $check i32)
+  local.get $value
+  local.tee $1
+  i32.eqz
+  if (result i32)
+   i32.const 0
+  else
+   local.get $1
+   call $~instanceof|instanceof/ID
+  end
+  if
+   i32.const 0
+   local.set $check
+   i32.const 0
+   i32.eqz
+   if
+    i32.const 0
+    i32.const 432
+    i32.const 19
+    i32.const 5
+    call $~lib/builtins/abort
+    unreachable
+   end
+  end
+  i32.const 1
+  drop
+ )
+ (func $instanceof/assertStaticFalse<instanceof/IA,instanceof/IE> (type $i32_=>_none) (param $value i32)
+  i32.const 0
+  i32.eqz
+  drop
+  return
+ )
+ (func $instanceof/assertStaticFalse<instanceof/IB,instanceof/IE> (type $i32_=>_none) (param $value i32)
+  i32.const 0
+  i32.eqz
+  drop
+  return
+ )
+ (func $instanceof/assertDynamicTrue<instanceof/IA,instanceof/IC> (type $i32_=>_none) (param $value i32)
+  (local $1 i32)
+  (local $check i32)
+  local.get $value
+  local.tee $1
+  i32.eqz
+  if (result i32)
+   i32.const 0
+  else
+   local.get $1
+   call $~instanceof|instanceof/IC
+  end
+  i32.eqz
+  if
+   i32.const 0
+   local.set $check
+   i32.const 0
+   i32.eqz
+   if
+    i32.const 0
+    i32.const 432
+    i32.const 12
+    i32.const 5
+    call $~lib/builtins/abort
+    unreachable
+   end
+  end
+  i32.const 1
+  drop
+ )
+ (func $instanceof/assertDynamicTrue<instanceof/IB,instanceof/IC> (type $i32_=>_none) (param $value i32)
+  (local $1 i32)
+  (local $check i32)
+  local.get $value
+  local.tee $1
+  i32.eqz
+  if (result i32)
+   i32.const 0
+  else
+   local.get $1
+   call $~instanceof|instanceof/IC
+  end
+  i32.eqz
+  if
+   i32.const 0
+   local.set $check
+   i32.const 0
+   i32.eqz
+   if
+    i32.const 0
+    i32.const 432
+    i32.const 12
+    i32.const 5
+    call $~lib/builtins/abort
+    unreachable
+   end
+  end
+  i32.const 1
+  drop
+ )
+ (func $instanceof/assertDynamicTrue<instanceof/IA,instanceof/ID> (type $i32_=>_none) (param $value i32)
+  (local $1 i32)
+  (local $check i32)
+  local.get $value
+  local.tee $1
+  i32.eqz
+  if (result i32)
+   i32.const 0
+  else
+   local.get $1
+   call $~instanceof|instanceof/ID
+  end
+  i32.eqz
+  if
+   i32.const 0
+   local.set $check
+   i32.const 0
+   i32.eqz
+   if
+    i32.const 0
+    i32.const 432
+    i32.const 12
+    i32.const 5
+    call $~lib/builtins/abort
+    unreachable
+   end
+  end
+  i32.const 1
+  drop
+ )
+ (func $instanceof/assertDynamicTrue<instanceof/IB,instanceof/ID> (type $i32_=>_none) (param $value i32)
+  (local $1 i32)
+  (local $check i32)
+  local.get $value
+  local.tee $1
+  i32.eqz
+  if (result i32)
+   i32.const 0
+  else
+   local.get $1
+   call $~instanceof|instanceof/ID
+  end
+  i32.eqz
+  if
+   i32.const 0
+   local.set $check
+   i32.const 0
+   i32.eqz
+   if
+    i32.const 0
+    i32.const 432
+    i32.const 12
+    i32.const 5
+    call $~lib/builtins/abort
+    unreachable
+   end
+  end
+  i32.const 1
+  drop
+ )
+ (func $instanceof/assertStaticTrue<instanceof/X,instanceof/IA> (type $i32_=>_none) (param $value i32)
+  i32.const 1
+  drop
+  return
+ )
+ (func $instanceof/assertStaticTrue<instanceof/X,instanceof/IB> (type $i32_=>_none) (param $value i32)
+  i32.const 1
+  drop
+  return
+ )
+ (func $instanceof/assertDynamicFalse<instanceof/X,instanceof/ID> (type $i32_=>_none) (param $value i32)
+  (local $1 i32)
+  (local $check i32)
+  local.get $value
+  local.tee $1
+  i32.eqz
+  if (result i32)
+   i32.const 0
+  else
+   local.get $1
+   call $~instanceof|instanceof/ID
+  end
+  if
+   i32.const 0
+   local.set $check
+   i32.const 0
+   i32.eqz
+   if
+    i32.const 0
+    i32.const 432
+    i32.const 19
+    i32.const 5
+    call $~lib/builtins/abort
+    unreachable
+   end
+  end
+  i32.const 1
+  drop
+ )
+ (func $instanceof/assertDynamicFalse<instanceof/X,instanceof/IC> (type $i32_=>_none) (param $value i32)
+  (local $1 i32)
+  (local $check i32)
+  local.get $value
+  local.tee $1
+  i32.eqz
+  if (result i32)
+   i32.const 0
+  else
+   local.get $1
+   call $~instanceof|instanceof/IC
+  end
+  if
+   i32.const 0
+   local.set $check
+   i32.const 0
+   i32.eqz
+   if
+    i32.const 0
+    i32.const 432
+    i32.const 19
+    i32.const 5
+    call $~lib/builtins/abort
+    unreachable
+   end
+  end
+  i32.const 1
+  drop
+ )
+ (func $instanceof/assertStaticFalse<instanceof/X,instanceof/IE> (type $i32_=>_none) (param $value i32)
+  i32.const 0
+  i32.eqz
+  drop
+  return
+ )
+ (func $instanceof/assertDynamicTrue<instanceof/X,instanceof/ID> (type $i32_=>_none) (param $value i32)
+  (local $1 i32)
+  (local $check i32)
+  local.get $value
+  local.tee $1
+  i32.eqz
+  if (result i32)
+   i32.const 0
+  else
+   local.get $1
+   call $~instanceof|instanceof/ID
+  end
+  i32.eqz
+  if
+   i32.const 0
+   local.set $check
+   i32.const 0
+   i32.eqz
+   if
+    i32.const 0
+    i32.const 432
+    i32.const 12
+    i32.const 5
+    call $~lib/builtins/abort
+    unreachable
+   end
+  end
+  i32.const 1
+  drop
+ )
+ (func $instanceof/assertDynamicTrue<instanceof/X,instanceof/IC> (type $i32_=>_none) (param $value i32)
+  (local $1 i32)
+  (local $check i32)
+  local.get $value
+  local.tee $1
+  i32.eqz
+  if (result i32)
+   i32.const 0
+  else
+   local.get $1
+   call $~instanceof|instanceof/IC
+  end
+  i32.eqz
+  if
+   i32.const 0
+   local.set $check
+   i32.const 0
+   i32.eqz
+   if
+    i32.const 0
+    i32.const 432
+    i32.const 12
+    i32.const 5
+    call $~lib/builtins/abort
+    unreachable
+   end
+  end
+  i32.const 1
+  drop
+ )
+ (func $instanceof/assertStaticTrue<instanceof/Y,instanceof/IA> (type $i32_=>_none) (param $value i32)
+  i32.const 1
+  drop
+  return
+ )
+ (func $instanceof/assertStaticTrue<instanceof/Y,instanceof/IB> (type $i32_=>_none) (param $value i32)
+  i32.const 1
+  drop
+  return
+ )
+ (func $instanceof/assertStaticTrue<instanceof/Y,instanceof/ID> (type $i32_=>_none) (param $value i32)
+  i32.const 1
+  drop
+  return
+ )
+ (func $instanceof/assertStaticTrue<instanceof/Y,instanceof/IC> (type $i32_=>_none) (param $value i32)
+  i32.const 1
+  drop
+  return
+ )
+ (func $instanceof/assertStaticFalse<instanceof/Y,instanceof/IE> (type $i32_=>_none) (param $value i32)
+  i32.const 0
+  i32.eqz
+  drop
+  return
+ )
+ (func $instanceof/assertStaticTrue<instanceof/Z,instanceof/IA> (type $i32_=>_none) (param $value i32)
+  i32.const 1
+  drop
+  return
+ )
+ (func $instanceof/assertStaticTrue<instanceof/Z,instanceof/IB> (type $i32_=>_none) (param $value i32)
+  i32.const 1
+  drop
+  return
+ )
+ (func $instanceof/assertStaticTrue<instanceof/Z,instanceof/ID> (type $i32_=>_none) (param $value i32)
+  i32.const 1
+  drop
+  return
+ )
+ (func $instanceof/assertStaticTrue<instanceof/Z,instanceof/IC> (type $i32_=>_none) (param $value i32)
+  i32.const 1
+  drop
+  return
+ )
+ (func $instanceof/assertStaticFalse<instanceof/Z,instanceof/IE> (type $i32_=>_none) (param $value i32)
+  i32.const 0
+  i32.eqz
+  drop
+  return
+ )
+ (func $instanceof/assertStaticFalse<instanceof/IA,instanceof/W> (type $i32_=>_none) (param $value i32)
+  i32.const 0
+  i32.eqz
+  drop
+  return
+ )
+ (func $instanceof/assertStaticFalse<instanceof/IB,instanceof/W> (type $i32_=>_none) (param $value i32)
+  i32.const 0
+  i32.eqz
+  drop
+  return
+ )
+ (func $instanceof/assertStaticFalse<instanceof/IC,instanceof/W> (type $i32_=>_none) (param $value i32)
+  i32.const 0
+  i32.eqz
+  drop
+  return
+ )
+ (func $instanceof/assertStaticFalse<instanceof/ID,instanceof/W> (type $i32_=>_none) (param $value i32)
+  i32.const 0
+  i32.eqz
+  drop
+  return
+ )
+ (func $instanceof/assertDynamicTrue<instanceof/IA,instanceof/X> (type $i32_=>_none) (param $value i32)
+  (local $1 i32)
+  (local $check i32)
+  local.get $value
+  local.tee $1
+  i32.eqz
+  if (result i32)
+   i32.const 0
+  else
+   local.get $1
+   call $~instanceof|instanceof/X
+  end
+  i32.eqz
+  if
+   i32.const 0
+   local.set $check
+   i32.const 0
+   i32.eqz
+   if
+    i32.const 0
+    i32.const 432
+    i32.const 12
+    i32.const 5
+    call $~lib/builtins/abort
+    unreachable
+   end
+  end
+  i32.const 1
+  drop
+ )
+ (func $instanceof/assertDynamicTrue<instanceof/IB,instanceof/X> (type $i32_=>_none) (param $value i32)
+  (local $1 i32)
+  (local $check i32)
+  local.get $value
+  local.tee $1
+  i32.eqz
+  if (result i32)
+   i32.const 0
+  else
+   local.get $1
+   call $~instanceof|instanceof/X
+  end
+  i32.eqz
+  if
+   i32.const 0
+   local.set $check
+   i32.const 0
+   i32.eqz
+   if
+    i32.const 0
+    i32.const 432
+    i32.const 12
+    i32.const 5
+    call $~lib/builtins/abort
+    unreachable
+   end
+  end
+  i32.const 1
+  drop
+ )
+ (func $instanceof/assertDynamicTrue<instanceof/IA,instanceof/Y> (type $i32_=>_none) (param $value i32)
+  (local $1 i32)
+  (local $check i32)
+  local.get $value
+  local.tee $1
+  i32.eqz
+  if (result i32)
+   i32.const 0
+  else
+   local.get $1
+   call $~instanceof|instanceof/Y
+  end
+  i32.eqz
+  if
+   i32.const 0
+   local.set $check
+   i32.const 0
+   i32.eqz
+   if
+    i32.const 0
+    i32.const 432
+    i32.const 12
+    i32.const 5
+    call $~lib/builtins/abort
+    unreachable
+   end
+  end
+  i32.const 1
+  drop
+ )
+ (func $instanceof/assertDynamicTrue<instanceof/IB,instanceof/Y> (type $i32_=>_none) (param $value i32)
+  (local $1 i32)
+  (local $check i32)
+  local.get $value
+  local.tee $1
+  i32.eqz
+  if (result i32)
+   i32.const 0
+  else
+   local.get $1
+   call $~instanceof|instanceof/Y
+  end
+  i32.eqz
+  if
+   i32.const 0
+   local.set $check
+   i32.const 0
+   i32.eqz
+   if
+    i32.const 0
+    i32.const 432
+    i32.const 12
+    i32.const 5
+    call $~lib/builtins/abort
+    unreachable
+   end
+  end
+  i32.const 1
+  drop
+ )
+ (func $instanceof/assertDynamicTrue<instanceof/IC,instanceof/Y> (type $i32_=>_none) (param $value i32)
+  (local $1 i32)
+  (local $check i32)
+  local.get $value
+  local.tee $1
+  i32.eqz
+  if (result i32)
+   i32.const 0
+  else
+   local.get $1
+   call $~instanceof|instanceof/Y
+  end
+  i32.eqz
+  if
+   i32.const 0
+   local.set $check
+   i32.const 0
+   i32.eqz
+   if
+    i32.const 0
+    i32.const 432
+    i32.const 12
+    i32.const 5
+    call $~lib/builtins/abort
+    unreachable
+   end
+  end
+  i32.const 1
+  drop
+ )
+ (func $instanceof/assertDynamicTrue<instanceof/ID,instanceof/Y> (type $i32_=>_none) (param $value i32)
+  (local $1 i32)
+  (local $check i32)
+  local.get $value
+  local.tee $1
+  i32.eqz
+  if (result i32)
+   i32.const 0
+  else
+   local.get $1
+   call $~instanceof|instanceof/Y
+  end
+  i32.eqz
+  if
+   i32.const 0
+   local.set $check
+   i32.const 0
+   i32.eqz
+   if
+    i32.const 0
+    i32.const 432
+    i32.const 12
+    i32.const 5
+    call $~lib/builtins/abort
+    unreachable
+   end
+  end
+  i32.const 1
+  drop
+ )
+ (func $instanceof/assertDynamicTrue<instanceof/IA,instanceof/Z> (type $i32_=>_none) (param $value i32)
+  (local $1 i32)
+  (local $check i32)
+  local.get $value
+  local.tee $1
+  i32.eqz
+  if (result i32)
+   i32.const 0
+  else
+   local.get $1
+   call $~instanceof|instanceof/Z
+  end
+  i32.eqz
+  if
+   i32.const 0
+   local.set $check
+   i32.const 0
+   i32.eqz
+   if
+    i32.const 0
+    i32.const 432
+    i32.const 12
+    i32.const 5
+    call $~lib/builtins/abort
+    unreachable
+   end
+  end
+  i32.const 1
+  drop
+ )
+ (func $instanceof/assertDynamicTrue<instanceof/IB,instanceof/Z> (type $i32_=>_none) (param $value i32)
+  (local $1 i32)
+  (local $check i32)
+  local.get $value
+  local.tee $1
+  i32.eqz
+  if (result i32)
+   i32.const 0
+  else
+   local.get $1
+   call $~instanceof|instanceof/Z
+  end
+  i32.eqz
+  if
+   i32.const 0
+   local.set $check
+   i32.const 0
+   i32.eqz
+   if
+    i32.const 0
+    i32.const 432
+    i32.const 12
+    i32.const 5
+    call $~lib/builtins/abort
+    unreachable
+   end
+  end
+  i32.const 1
+  drop
+ )
+ (func $instanceof/assertDynamicTrue<instanceof/IC,instanceof/Z> (type $i32_=>_none) (param $value i32)
+  (local $1 i32)
+  (local $check i32)
+  local.get $value
+  local.tee $1
+  i32.eqz
+  if (result i32)
+   i32.const 0
+  else
+   local.get $1
+   call $~instanceof|instanceof/Z
+  end
+  i32.eqz
+  if
+   i32.const 0
+   local.set $check
+   i32.const 0
+   i32.eqz
+   if
+    i32.const 0
+    i32.const 432
+    i32.const 12
+    i32.const 5
+    call $~lib/builtins/abort
+    unreachable
+   end
+  end
+  i32.const 1
+  drop
+ )
+ (func $instanceof/assertDynamicTrue<instanceof/ID,instanceof/Z> (type $i32_=>_none) (param $value i32)
+  (local $1 i32)
+  (local $check i32)
+  local.get $value
+  local.tee $1
+  i32.eqz
+  if (result i32)
+   i32.const 0
+  else
+   local.get $1
+   call $~instanceof|instanceof/Z
   end
   i32.eqz
   if
@@ -2494,7 +3661,7 @@
   end
   i32.const 1
  )
- (func $~instanceof|instanceof/I1 (type $i32_=>_i32) (param $0 i32) (result i32)
+ (func $~instanceof|instanceof/W (type $i32_=>_i32) (param $0 i32) (result i32)
   (local $1 i32)
   block $is_instance
    local.get $0
@@ -2506,16 +3673,12 @@
    i32.const 14
    i32.eq
    br_if $is_instance
-   local.get $1
-   i32.const 17
-   i32.eq
-   br_if $is_instance
    i32.const 0
    return
   end
   i32.const 1
  )
- (func $~instanceof|instanceof/B_I1_I2 (type $i32_=>_i32) (param $0 i32) (result i32)
+ (func $~instanceof|instanceof/X (type $i32_=>_i32) (param $0 i32) (result i32)
   (local $1 i32)
   block $is_instance
    local.get $0
@@ -2524,7 +3687,145 @@
    i32.load $0
    local.set $1
    local.get $1
-   i32.const 17
+   i32.const 15
+   i32.eq
+   br_if $is_instance
+   local.get $1
+   i32.const 18
+   i32.eq
+   br_if $is_instance
+   local.get $1
+   i32.const 21
+   i32.eq
+   br_if $is_instance
+   i32.const 0
+   return
+  end
+  i32.const 1
+ )
+ (func $~instanceof|instanceof/Y (type $i32_=>_i32) (param $0 i32) (result i32)
+  (local $1 i32)
+  block $is_instance
+   local.get $0
+   i32.const 8
+   i32.sub
+   i32.load $0
+   local.set $1
+   local.get $1
+   i32.const 18
+   i32.eq
+   br_if $is_instance
+   local.get $1
+   i32.const 21
+   i32.eq
+   br_if $is_instance
+   i32.const 0
+   return
+  end
+  i32.const 1
+ )
+ (func $~instanceof|instanceof/Z (type $i32_=>_i32) (param $0 i32) (result i32)
+  (local $1 i32)
+  block $is_instance
+   local.get $0
+   i32.const 8
+   i32.sub
+   i32.load $0
+   local.set $1
+   local.get $1
+   i32.const 21
+   i32.eq
+   br_if $is_instance
+   i32.const 0
+   return
+  end
+  i32.const 1
+ )
+ (func $~instanceof|instanceof/IA (type $i32_=>_i32) (param $0 i32) (result i32)
+  (local $1 i32)
+  block $is_instance
+   local.get $0
+   i32.const 8
+   i32.sub
+   i32.load $0
+   local.set $1
+   local.get $1
+   i32.const 15
+   i32.eq
+   br_if $is_instance
+   local.get $1
+   i32.const 18
+   i32.eq
+   br_if $is_instance
+   local.get $1
+   i32.const 21
+   i32.eq
+   br_if $is_instance
+   i32.const 0
+   return
+  end
+  i32.const 1
+ )
+ (func $~instanceof|instanceof/IB (type $i32_=>_i32) (param $0 i32) (result i32)
+  (local $1 i32)
+  block $is_instance
+   local.get $0
+   i32.const 8
+   i32.sub
+   i32.load $0
+   local.set $1
+   local.get $1
+   i32.const 15
+   i32.eq
+   br_if $is_instance
+   local.get $1
+   i32.const 18
+   i32.eq
+   br_if $is_instance
+   local.get $1
+   i32.const 21
+   i32.eq
+   br_if $is_instance
+   i32.const 0
+   return
+  end
+  i32.const 1
+ )
+ (func $~instanceof|instanceof/IC (type $i32_=>_i32) (param $0 i32) (result i32)
+  (local $1 i32)
+  block $is_instance
+   local.get $0
+   i32.const 8
+   i32.sub
+   i32.load $0
+   local.set $1
+   local.get $1
+   i32.const 18
+   i32.eq
+   br_if $is_instance
+   local.get $1
+   i32.const 21
+   i32.eq
+   br_if $is_instance
+   i32.const 0
+   return
+  end
+  i32.const 1
+ )
+ (func $~instanceof|instanceof/ID (type $i32_=>_i32) (param $0 i32) (result i32)
+  (local $1 i32)
+  block $is_instance
+   local.get $0
+   i32.const 8
+   i32.sub
+   i32.load $0
+   local.set $1
+   local.get $1
+   i32.const 18
+   i32.eq
+   br_if $is_instance
+   local.get $1
+   i32.const 21
    i32.eq
    br_if $is_instance
    i32.const 0
@@ -2632,14 +3933,28 @@
    local.get $0
    call $~lib/rt/itcms/__visit
   end
-  global.get $instanceof/a_i1
+  global.get $instanceof/w
   local.tee $1
   if
    local.get $1
    local.get $0
    call $~lib/rt/itcms/__visit
   end
-  global.get $instanceof/b_i1_i2
+  global.get $instanceof/x
+  local.tee $1
+  if
+   local.get $1
+   local.get $0
+   call $~lib/rt/itcms/__visit
+  end
+  global.get $instanceof/y
+  local.tee $1
+  if
+   local.get $1
+   local.get $0
+   call $~lib/rt/itcms/__visit
+  end
+  global.get $instanceof/z
   local.tee $1
   if
    local.get $1
@@ -2672,29 +3987,47 @@
  )
  (func $~lib/rt/__visit_members (type $i32_i32_=>_none) (param $0 i32) (param $1 i32)
   block $invalid
-   block $instanceof/B_I1_I2
-    block $instanceof/I2
-     block $instanceof/I1
-      block $instanceof/A_I1
-       block $instanceof/BlackCat
-        block $instanceof/Cat
-         block $instanceof/Animal
-          block $instanceof/SomethingElse<i32>
-           block $instanceof/Parent<f32>
-            block $instanceof/Child<f32>
-             block $instanceof/Parent<i32>
-              block $instanceof/Child<i32>
-               block $instanceof/B
-                block $instanceof/A
-                 block $~lib/arraybuffer/ArrayBufferView
-                  block $~lib/string/String
-                   block $~lib/arraybuffer/ArrayBuffer
-                    block $~lib/object/Object
-                     local.get $0
-                     i32.const 8
-                     i32.sub
-                     i32.load $0
-                     br_table $~lib/object/Object $~lib/arraybuffer/ArrayBuffer $~lib/string/String $~lib/arraybuffer/ArrayBufferView $instanceof/A $instanceof/B $instanceof/Child<i32> $instanceof/Parent<i32> $instanceof/Child<f32> $instanceof/Parent<f32> $instanceof/SomethingElse<i32> $instanceof/Animal $instanceof/Cat $instanceof/BlackCat $instanceof/A_I1 $instanceof/I1 $instanceof/I2 $instanceof/B_I1_I2 $invalid
+   block $instanceof/IE
+    block $instanceof/Z
+     block $instanceof/IC
+      block $instanceof/ID
+       block $instanceof/Y
+        block $instanceof/IA
+         block $instanceof/IB
+          block $instanceof/X
+           block $instanceof/W
+            block $instanceof/BlackCat
+             block $instanceof/Cat
+              block $instanceof/Animal
+               block $instanceof/SomethingElse<i32>
+                block $instanceof/Parent<f32>
+                 block $instanceof/Child<f32>
+                  block $instanceof/Parent<i32>
+                   block $instanceof/Child<i32>
+                    block $instanceof/B
+                     block $instanceof/A
+                      block $~lib/arraybuffer/ArrayBufferView
+                       block $~lib/string/String
+                        block $~lib/arraybuffer/ArrayBuffer
+                         block $~lib/object/Object
+                          local.get $0
+                          i32.const 8
+                          i32.sub
+                          i32.load $0
+                          br_table $~lib/object/Object $~lib/arraybuffer/ArrayBuffer $~lib/string/String $~lib/arraybuffer/ArrayBufferView $instanceof/A $instanceof/B $instanceof/Child<i32> $instanceof/Parent<i32> $instanceof/Child<f32> $instanceof/Parent<f32> $instanceof/SomethingElse<i32> $instanceof/Animal $instanceof/Cat $instanceof/BlackCat $instanceof/W $instanceof/X $instanceof/IB $instanceof/IA $instanceof/Y $instanceof/ID $instanceof/IC $instanceof/Z $instanceof/IE $invalid
+                         end
+                         return
+                        end
+                        return
+                       end
+                       return
+                      end
+                      local.get $0
+                      local.get $1
+                      call $~lib/arraybuffer/ArrayBufferView~visit
+                      return
+                     end
+                     return
                     end
                     return
                    end
@@ -2702,9 +4035,6 @@
                   end
                   return
                  end
-                 local.get $0
-                 local.get $1
-                 call $~lib/arraybuffer/ArrayBufferView~visit
                  return
                 end
                 return
@@ -2745,8 +4075,8 @@
   global.get $~lib/memory/__data_end
   i32.lt_s
   if
-   i32.const 33328
-   i32.const 33376
+   i32.const 33360
+   i32.const 33408
    i32.const 1
    i32.const 1
    call $~lib/builtins/abort
@@ -3580,74 +4910,941 @@
    unreachable
   end
   i32.const 0
-  call $instanceof/A_I1#constructor
-  global.set $instanceof/a_i1
-  global.get $instanceof/a_i1
-  local.set $21
-  global.get $~lib/memory/__stack_pointer
-  local.get $21
-  i32.store $0 offset=84
-  local.get $21
-  call $instanceof/assertStaticTrue<instanceof/A_I1,~lib/object/Object>
-  global.get $instanceof/a_i1
-  local.set $21
-  global.get $~lib/memory/__stack_pointer
-  local.get $21
-  i32.store $0 offset=84
-  local.get $21
-  call $instanceof/assertStaticTrue<instanceof/A_I1,instanceof/I1>
-  global.get $instanceof/a_i1
-  local.set $21
-  global.get $~lib/memory/__stack_pointer
-  local.get $21
-  i32.store $0 offset=84
-  local.get $21
-  call $instanceof/assertStaticFalse<instanceof/A_I1,instanceof/I2>
-  global.get $instanceof/a_i1
-  local.set $21
-  global.get $~lib/memory/__stack_pointer
-  local.get $21
-  i32.store $0 offset=84
-  local.get $21
-  call $instanceof/assertDynamicTrue<~lib/object/Object,instanceof/I1>
+  call $instanceof/W#constructor
+  global.set $instanceof/w
   i32.const 0
-  call $instanceof/B_I1_I2#constructor
-  global.set $instanceof/b_i1_i2
-  global.get $instanceof/b_i1_i2
+  call $instanceof/X#constructor
+  global.set $instanceof/x
+  i32.const 0
+  call $instanceof/Y#constructor
+  global.set $instanceof/y
+  i32.const 0
+  call $instanceof/Z#constructor
+  global.set $instanceof/z
+  global.get $instanceof/w
   local.set $21
   global.get $~lib/memory/__stack_pointer
   local.get $21
   i32.store $0 offset=84
   local.get $21
-  call $instanceof/assertStaticTrue<instanceof/B_I1_I2,instanceof/I1>
-  global.get $instanceof/b_i1_i2
+  call $instanceof/assertStaticTrue<instanceof/W,~lib/object/Object>
+  global.get $instanceof/x
   local.set $21
   global.get $~lib/memory/__stack_pointer
   local.get $21
   i32.store $0 offset=84
   local.get $21
-  call $instanceof/assertStaticTrue<instanceof/B_I1_I2,instanceof/I2>
-  global.get $instanceof/a_i1
+  call $instanceof/assertStaticTrue<instanceof/X,~lib/object/Object>
+  global.get $instanceof/y
   local.set $21
   global.get $~lib/memory/__stack_pointer
   local.get $21
   i32.store $0 offset=84
   local.get $21
-  call $instanceof/assertStaticFalse<instanceof/A_I1,instanceof/B_I1_I2>
-  global.get $instanceof/a_i1
+  call $instanceof/assertStaticTrue<instanceof/Y,~lib/object/Object>
+  global.get $instanceof/z
   local.set $21
   global.get $~lib/memory/__stack_pointer
   local.get $21
   i32.store $0 offset=84
   local.get $21
-  call $instanceof/assertDynamicFalse<instanceof/I1,instanceof/B_I1_I2>
-  global.get $instanceof/b_i1_i2
+  call $instanceof/assertStaticTrue<instanceof/Z,~lib/object/Object>
+  global.get $instanceof/x
   local.set $21
   global.get $~lib/memory/__stack_pointer
   local.get $21
   i32.store $0 offset=84
   local.get $21
-  call $instanceof/assertDynamicTrue<instanceof/I1,instanceof/B_I1_I2>
+  call $instanceof/assertStaticTrue<instanceof/IA,~lib/object/Object>
+  global.get $instanceof/x
+  local.set $21
+  global.get $~lib/memory/__stack_pointer
+  local.get $21
+  i32.store $0 offset=84
+  local.get $21
+  call $instanceof/assertStaticTrue<instanceof/IB,~lib/object/Object>
+  global.get $instanceof/y
+  local.set $21
+  global.get $~lib/memory/__stack_pointer
+  local.get $21
+  i32.store $0 offset=84
+  local.get $21
+  call $instanceof/assertStaticTrue<instanceof/IA,~lib/object/Object>
+  global.get $instanceof/y
+  local.set $21
+  global.get $~lib/memory/__stack_pointer
+  local.get $21
+  i32.store $0 offset=84
+  local.get $21
+  call $instanceof/assertStaticTrue<instanceof/IB,~lib/object/Object>
+  global.get $instanceof/y
+  local.set $21
+  global.get $~lib/memory/__stack_pointer
+  local.get $21
+  i32.store $0 offset=84
+  local.get $21
+  call $instanceof/assertStaticTrue<instanceof/IC,~lib/object/Object>
+  global.get $instanceof/y
+  local.set $21
+  global.get $~lib/memory/__stack_pointer
+  local.get $21
+  i32.store $0 offset=84
+  local.get $21
+  call $instanceof/assertStaticTrue<instanceof/ID,~lib/object/Object>
+  global.get $instanceof/z
+  local.set $21
+  global.get $~lib/memory/__stack_pointer
+  local.get $21
+  i32.store $0 offset=84
+  local.get $21
+  call $instanceof/assertStaticTrue<instanceof/IA,~lib/object/Object>
+  global.get $instanceof/z
+  local.set $21
+  global.get $~lib/memory/__stack_pointer
+  local.get $21
+  i32.store $0 offset=84
+  local.get $21
+  call $instanceof/assertStaticTrue<instanceof/IB,~lib/object/Object>
+  global.get $instanceof/z
+  local.set $21
+  global.get $~lib/memory/__stack_pointer
+  local.get $21
+  i32.store $0 offset=84
+  local.get $21
+  call $instanceof/assertStaticTrue<instanceof/IC,~lib/object/Object>
+  global.get $instanceof/z
+  local.set $21
+  global.get $~lib/memory/__stack_pointer
+  local.get $21
+  i32.store $0 offset=84
+  local.get $21
+  call $instanceof/assertStaticTrue<instanceof/ID,~lib/object/Object>
+  global.get $instanceof/w
+  local.set $21
+  global.get $~lib/memory/__stack_pointer
+  local.get $21
+  i32.store $0 offset=84
+  local.get $21
+  call $instanceof/assertDynamicTrue<~lib/object/Object,instanceof/W>
+  global.get $instanceof/x
+  local.set $21
+  global.get $~lib/memory/__stack_pointer
+  local.get $21
+  i32.store $0 offset=84
+  local.get $21
+  call $instanceof/assertDynamicTrue<~lib/object/Object,instanceof/X>
+  global.get $instanceof/y
+  local.set $21
+  global.get $~lib/memory/__stack_pointer
+  local.get $21
+  i32.store $0 offset=84
+  local.get $21
+  call $instanceof/assertDynamicTrue<~lib/object/Object,instanceof/X>
+  global.get $instanceof/z
+  local.set $21
+  global.get $~lib/memory/__stack_pointer
+  local.get $21
+  i32.store $0 offset=84
+  local.get $21
+  call $instanceof/assertDynamicTrue<~lib/object/Object,instanceof/X>
+  global.get $instanceof/y
+  local.set $21
+  global.get $~lib/memory/__stack_pointer
+  local.get $21
+  i32.store $0 offset=84
+  local.get $21
+  call $instanceof/assertDynamicTrue<~lib/object/Object,instanceof/Y>
+  global.get $instanceof/z
+  local.set $21
+  global.get $~lib/memory/__stack_pointer
+  local.get $21
+  i32.store $0 offset=84
+  local.get $21
+  call $instanceof/assertDynamicTrue<~lib/object/Object,instanceof/Y>
+  global.get $instanceof/z
+  local.set $21
+  global.get $~lib/memory/__stack_pointer
+  local.get $21
+  i32.store $0 offset=84
+  local.get $21
+  call $instanceof/assertDynamicTrue<~lib/object/Object,instanceof/Z>
+  global.get $instanceof/x
+  local.set $21
+  global.get $~lib/memory/__stack_pointer
+  local.get $21
+  i32.store $0 offset=84
+  local.get $21
+  call $instanceof/assertDynamicTrue<~lib/object/Object,instanceof/IA>
+  global.get $instanceof/x
+  local.set $21
+  global.get $~lib/memory/__stack_pointer
+  local.get $21
+  i32.store $0 offset=84
+  local.get $21
+  call $instanceof/assertDynamicTrue<~lib/object/Object,instanceof/IB>
+  global.get $instanceof/y
+  local.set $21
+  global.get $~lib/memory/__stack_pointer
+  local.get $21
+  i32.store $0 offset=84
+  local.get $21
+  call $instanceof/assertDynamicTrue<~lib/object/Object,instanceof/IA>
+  global.get $instanceof/y
+  local.set $21
+  global.get $~lib/memory/__stack_pointer
+  local.get $21
+  i32.store $0 offset=84
+  local.get $21
+  call $instanceof/assertDynamicTrue<~lib/object/Object,instanceof/IB>
+  global.get $instanceof/y
+  local.set $21
+  global.get $~lib/memory/__stack_pointer
+  local.get $21
+  i32.store $0 offset=84
+  local.get $21
+  call $instanceof/assertDynamicTrue<~lib/object/Object,instanceof/IC>
+  global.get $instanceof/y
+  local.set $21
+  global.get $~lib/memory/__stack_pointer
+  local.get $21
+  i32.store $0 offset=84
+  local.get $21
+  call $instanceof/assertDynamicTrue<~lib/object/Object,instanceof/ID>
+  global.get $instanceof/z
+  local.set $21
+  global.get $~lib/memory/__stack_pointer
+  local.get $21
+  i32.store $0 offset=84
+  local.get $21
+  call $instanceof/assertDynamicTrue<~lib/object/Object,instanceof/IA>
+  global.get $instanceof/z
+  local.set $21
+  global.get $~lib/memory/__stack_pointer
+  local.get $21
+  i32.store $0 offset=84
+  local.get $21
+  call $instanceof/assertDynamicTrue<~lib/object/Object,instanceof/IB>
+  global.get $instanceof/z
+  local.set $21
+  global.get $~lib/memory/__stack_pointer
+  local.get $21
+  i32.store $0 offset=84
+  local.get $21
+  call $instanceof/assertDynamicTrue<~lib/object/Object,instanceof/IC>
+  global.get $instanceof/z
+  local.set $21
+  global.get $~lib/memory/__stack_pointer
+  local.get $21
+  i32.store $0 offset=84
+  local.get $21
+  call $instanceof/assertDynamicTrue<~lib/object/Object,instanceof/ID>
+  global.get $instanceof/w
+  local.set $21
+  global.get $~lib/memory/__stack_pointer
+  local.get $21
+  i32.store $0 offset=84
+  local.get $21
+  call $instanceof/assertStaticTrue<instanceof/W,instanceof/W>
+  global.get $instanceof/w
+  local.set $21
+  global.get $~lib/memory/__stack_pointer
+  local.get $21
+  i32.store $0 offset=84
+  local.get $21
+  call $instanceof/assertStaticFalse<instanceof/W,instanceof/X>
+  global.get $instanceof/w
+  local.set $21
+  global.get $~lib/memory/__stack_pointer
+  local.get $21
+  i32.store $0 offset=84
+  local.get $21
+  call $instanceof/assertStaticFalse<instanceof/W,instanceof/Y>
+  global.get $instanceof/w
+  local.set $21
+  global.get $~lib/memory/__stack_pointer
+  local.get $21
+  i32.store $0 offset=84
+  local.get $21
+  call $instanceof/assertStaticFalse<instanceof/W,instanceof/Z>
+  global.get $instanceof/x
+  local.set $21
+  global.get $~lib/memory/__stack_pointer
+  local.get $21
+  i32.store $0 offset=84
+  local.get $21
+  call $instanceof/assertStaticFalse<instanceof/X,instanceof/W>
+  global.get $instanceof/y
+  local.set $21
+  global.get $~lib/memory/__stack_pointer
+  local.get $21
+  i32.store $0 offset=84
+  local.get $21
+  call $instanceof/assertStaticFalse<instanceof/Y,instanceof/W>
+  global.get $instanceof/z
+  local.set $21
+  global.get $~lib/memory/__stack_pointer
+  local.get $21
+  i32.store $0 offset=84
+  local.get $21
+  call $instanceof/assertStaticFalse<instanceof/Z,instanceof/W>
+  global.get $instanceof/x
+  local.set $21
+  global.get $~lib/memory/__stack_pointer
+  local.get $21
+  i32.store $0 offset=84
+  local.get $21
+  call $instanceof/assertStaticTrue<instanceof/X,instanceof/X>
+  global.get $instanceof/x
+  local.set $21
+  global.get $~lib/memory/__stack_pointer
+  local.get $21
+  i32.store $0 offset=84
+  local.get $21
+  call $instanceof/assertDynamicFalse<instanceof/X,instanceof/Y>
+  global.get $instanceof/x
+  local.set $21
+  global.get $~lib/memory/__stack_pointer
+  local.get $21
+  i32.store $0 offset=84
+  local.get $21
+  call $instanceof/assertDynamicFalse<instanceof/X,instanceof/Z>
+  global.get $instanceof/y
+  local.set $21
+  global.get $~lib/memory/__stack_pointer
+  local.get $21
+  i32.store $0 offset=84
+  local.get $21
+  call $instanceof/assertStaticTrue<instanceof/X,instanceof/X>
+  global.get $instanceof/y
+  local.set $21
+  global.get $~lib/memory/__stack_pointer
+  local.get $21
+  i32.store $0 offset=84
+  local.get $21
+  call $instanceof/assertDynamicTrue<instanceof/X,instanceof/Y>
+  global.get $instanceof/y
+  local.set $21
+  global.get $~lib/memory/__stack_pointer
+  local.get $21
+  i32.store $0 offset=84
+  local.get $21
+  call $instanceof/assertDynamicFalse<instanceof/X,instanceof/Z>
+  global.get $instanceof/z
+  local.set $21
+  global.get $~lib/memory/__stack_pointer
+  local.get $21
+  i32.store $0 offset=84
+  local.get $21
+  call $instanceof/assertStaticTrue<instanceof/X,instanceof/X>
+  global.get $instanceof/z
+  local.set $21
+  global.get $~lib/memory/__stack_pointer
+  local.get $21
+  i32.store $0 offset=84
+  local.get $21
+  call $instanceof/assertDynamicTrue<instanceof/X,instanceof/Y>
+  global.get $instanceof/z
+  local.set $21
+  global.get $~lib/memory/__stack_pointer
+  local.get $21
+  i32.store $0 offset=84
+  local.get $21
+  call $instanceof/assertDynamicTrue<instanceof/X,instanceof/Z>
+  global.get $instanceof/y
+  local.set $21
+  global.get $~lib/memory/__stack_pointer
+  local.get $21
+  i32.store $0 offset=84
+  local.get $21
+  call $instanceof/assertStaticTrue<instanceof/Y,instanceof/X>
+  global.get $instanceof/y
+  local.set $21
+  global.get $~lib/memory/__stack_pointer
+  local.get $21
+  i32.store $0 offset=84
+  local.get $21
+  call $instanceof/assertStaticTrue<instanceof/Y,instanceof/Y>
+  global.get $instanceof/y
+  local.set $21
+  global.get $~lib/memory/__stack_pointer
+  local.get $21
+  i32.store $0 offset=84
+  local.get $21
+  call $instanceof/assertDynamicFalse<instanceof/Y,instanceof/Z>
+  global.get $instanceof/z
+  local.set $21
+  global.get $~lib/memory/__stack_pointer
+  local.get $21
+  i32.store $0 offset=84
+  local.get $21
+  call $instanceof/assertStaticTrue<instanceof/Y,instanceof/X>
+  global.get $instanceof/z
+  local.set $21
+  global.get $~lib/memory/__stack_pointer
+  local.get $21
+  i32.store $0 offset=84
+  local.get $21
+  call $instanceof/assertStaticTrue<instanceof/Y,instanceof/Y>
+  global.get $instanceof/z
+  local.set $21
+  global.get $~lib/memory/__stack_pointer
+  local.get $21
+  i32.store $0 offset=84
+  local.get $21
+  call $instanceof/assertDynamicTrue<instanceof/Y,instanceof/Z>
+  global.get $instanceof/z
+  local.set $21
+  global.get $~lib/memory/__stack_pointer
+  local.get $21
+  i32.store $0 offset=84
+  local.get $21
+  call $instanceof/assertStaticTrue<instanceof/Z,instanceof/X>
+  global.get $instanceof/z
+  local.set $21
+  global.get $~lib/memory/__stack_pointer
+  local.get $21
+  i32.store $0 offset=84
+  local.get $21
+  call $instanceof/assertStaticTrue<instanceof/Z,instanceof/Y>
+  global.get $instanceof/z
+  local.set $21
+  global.get $~lib/memory/__stack_pointer
+  local.get $21
+  i32.store $0 offset=84
+  local.get $21
+  call $instanceof/assertStaticTrue<instanceof/Z,instanceof/Z>
+  global.get $instanceof/x
+  local.set $21
+  global.get $~lib/memory/__stack_pointer
+  local.get $21
+  i32.store $0 offset=84
+  local.get $21
+  call $instanceof/assertDynamicFalse<instanceof/IA,instanceof/IC>
+  global.get $instanceof/x
+  local.set $21
+  global.get $~lib/memory/__stack_pointer
+  local.get $21
+  i32.store $0 offset=84
+  local.get $21
+  call $instanceof/assertDynamicFalse<instanceof/IB,instanceof/IC>
+  global.get $instanceof/x
+  local.set $21
+  global.get $~lib/memory/__stack_pointer
+  local.get $21
+  i32.store $0 offset=84
+  local.get $21
+  call $instanceof/assertDynamicFalse<instanceof/IA,instanceof/ID>
+  global.get $instanceof/x
+  local.set $21
+  global.get $~lib/memory/__stack_pointer
+  local.get $21
+  i32.store $0 offset=84
+  local.get $21
+  call $instanceof/assertDynamicFalse<instanceof/IB,instanceof/ID>
+  global.get $instanceof/x
+  local.set $21
+  global.get $~lib/memory/__stack_pointer
+  local.get $21
+  i32.store $0 offset=84
+  local.get $21
+  call $instanceof/assertStaticFalse<instanceof/IA,instanceof/IE>
+  global.get $instanceof/x
+  local.set $21
+  global.get $~lib/memory/__stack_pointer
+  local.get $21
+  i32.store $0 offset=84
+  local.get $21
+  call $instanceof/assertStaticFalse<instanceof/IB,instanceof/IE>
+  global.get $instanceof/y
+  local.set $21
+  global.get $~lib/memory/__stack_pointer
+  local.get $21
+  i32.store $0 offset=84
+  local.get $21
+  call $instanceof/assertDynamicTrue<instanceof/IA,instanceof/IC>
+  global.get $instanceof/y
+  local.set $21
+  global.get $~lib/memory/__stack_pointer
+  local.get $21
+  i32.store $0 offset=84
+  local.get $21
+  call $instanceof/assertDynamicTrue<instanceof/IB,instanceof/IC>
+  global.get $instanceof/y
+  local.set $21
+  global.get $~lib/memory/__stack_pointer
+  local.get $21
+  i32.store $0 offset=84
+  local.get $21
+  call $instanceof/assertDynamicTrue<instanceof/IA,instanceof/ID>
+  global.get $instanceof/y
+  local.set $21
+  global.get $~lib/memory/__stack_pointer
+  local.get $21
+  i32.store $0 offset=84
+  local.get $21
+  call $instanceof/assertDynamicTrue<instanceof/IB,instanceof/ID>
+  global.get $instanceof/y
+  local.set $21
+  global.get $~lib/memory/__stack_pointer
+  local.get $21
+  i32.store $0 offset=84
+  local.get $21
+  call $instanceof/assertStaticFalse<instanceof/IA,instanceof/IE>
+  global.get $instanceof/y
+  local.set $21
+  global.get $~lib/memory/__stack_pointer
+  local.get $21
+  i32.store $0 offset=84
+  local.get $21
+  call $instanceof/assertStaticFalse<instanceof/IB,instanceof/IE>
+  global.get $instanceof/z
+  local.set $21
+  global.get $~lib/memory/__stack_pointer
+  local.get $21
+  i32.store $0 offset=84
+  local.get $21
+  call $instanceof/assertDynamicTrue<instanceof/IA,instanceof/IC>
+  global.get $instanceof/z
+  local.set $21
+  global.get $~lib/memory/__stack_pointer
+  local.get $21
+  i32.store $0 offset=84
+  local.get $21
+  call $instanceof/assertDynamicTrue<instanceof/IB,instanceof/IC>
+  global.get $instanceof/z
+  local.set $21
+  global.get $~lib/memory/__stack_pointer
+  local.get $21
+  i32.store $0 offset=84
+  local.get $21
+  call $instanceof/assertDynamicTrue<instanceof/IA,instanceof/ID>
+  global.get $instanceof/z
+  local.set $21
+  global.get $~lib/memory/__stack_pointer
+  local.get $21
+  i32.store $0 offset=84
+  local.get $21
+  call $instanceof/assertDynamicTrue<instanceof/IB,instanceof/ID>
+  global.get $instanceof/z
+  local.set $21
+  global.get $~lib/memory/__stack_pointer
+  local.get $21
+  i32.store $0 offset=84
+  local.get $21
+  call $instanceof/assertStaticFalse<instanceof/IA,instanceof/IE>
+  global.get $instanceof/z
+  local.set $21
+  global.get $~lib/memory/__stack_pointer
+  local.get $21
+  i32.store $0 offset=84
+  local.get $21
+  call $instanceof/assertStaticFalse<instanceof/IB,instanceof/IE>
+  global.get $instanceof/x
+  local.set $21
+  global.get $~lib/memory/__stack_pointer
+  local.get $21
+  i32.store $0 offset=84
+  local.get $21
+  call $instanceof/assertStaticTrue<instanceof/X,instanceof/IA>
+  global.get $instanceof/x
+  local.set $21
+  global.get $~lib/memory/__stack_pointer
+  local.get $21
+  i32.store $0 offset=84
+  local.get $21
+  call $instanceof/assertStaticTrue<instanceof/X,instanceof/IB>
+  global.get $instanceof/x
+  local.set $21
+  global.get $~lib/memory/__stack_pointer
+  local.get $21
+  i32.store $0 offset=84
+  local.get $21
+  call $instanceof/assertDynamicFalse<instanceof/X,instanceof/ID>
+  global.get $instanceof/x
+  local.set $21
+  global.get $~lib/memory/__stack_pointer
+  local.get $21
+  i32.store $0 offset=84
+  local.get $21
+  call $instanceof/assertDynamicFalse<instanceof/X,instanceof/IC>
+  global.get $instanceof/x
+  local.set $21
+  global.get $~lib/memory/__stack_pointer
+  local.get $21
+  i32.store $0 offset=84
+  local.get $21
+  call $instanceof/assertStaticFalse<instanceof/X,instanceof/IE>
+  global.get $instanceof/y
+  local.set $21
+  global.get $~lib/memory/__stack_pointer
+  local.get $21
+  i32.store $0 offset=84
+  local.get $21
+  call $instanceof/assertStaticTrue<instanceof/X,instanceof/IA>
+  global.get $instanceof/y
+  local.set $21
+  global.get $~lib/memory/__stack_pointer
+  local.get $21
+  i32.store $0 offset=84
+  local.get $21
+  call $instanceof/assertStaticTrue<instanceof/X,instanceof/IB>
+  global.get $instanceof/y
+  local.set $21
+  global.get $~lib/memory/__stack_pointer
+  local.get $21
+  i32.store $0 offset=84
+  local.get $21
+  call $instanceof/assertDynamicTrue<instanceof/X,instanceof/ID>
+  global.get $instanceof/y
+  local.set $21
+  global.get $~lib/memory/__stack_pointer
+  local.get $21
+  i32.store $0 offset=84
+  local.get $21
+  call $instanceof/assertDynamicTrue<instanceof/X,instanceof/IC>
+  global.get $instanceof/y
+  local.set $21
+  global.get $~lib/memory/__stack_pointer
+  local.get $21
+  i32.store $0 offset=84
+  local.get $21
+  call $instanceof/assertStaticFalse<instanceof/X,instanceof/IE>
+  global.get $instanceof/z
+  local.set $21
+  global.get $~lib/memory/__stack_pointer
+  local.get $21
+  i32.store $0 offset=84
+  local.get $21
+  call $instanceof/assertStaticTrue<instanceof/X,instanceof/IA>
+  global.get $instanceof/z
+  local.set $21
+  global.get $~lib/memory/__stack_pointer
+  local.get $21
+  i32.store $0 offset=84
+  local.get $21
+  call $instanceof/assertStaticTrue<instanceof/X,instanceof/IB>
+  global.get $instanceof/z
+  local.set $21
+  global.get $~lib/memory/__stack_pointer
+  local.get $21
+  i32.store $0 offset=84
+  local.get $21
+  call $instanceof/assertDynamicTrue<instanceof/X,instanceof/ID>
+  global.get $instanceof/z
+  local.set $21
+  global.get $~lib/memory/__stack_pointer
+  local.get $21
+  i32.store $0 offset=84
+  local.get $21
+  call $instanceof/assertDynamicTrue<instanceof/X,instanceof/IC>
+  global.get $instanceof/z
+  local.set $21
+  global.get $~lib/memory/__stack_pointer
+  local.get $21
+  i32.store $0 offset=84
+  local.get $21
+  call $instanceof/assertStaticFalse<instanceof/X,instanceof/IE>
+  global.get $instanceof/y
+  local.set $21
+  global.get $~lib/memory/__stack_pointer
+  local.get $21
+  i32.store $0 offset=84
+  local.get $21
+  call $instanceof/assertStaticTrue<instanceof/Y,instanceof/IA>
+  global.get $instanceof/y
+  local.set $21
+  global.get $~lib/memory/__stack_pointer
+  local.get $21
+  i32.store $0 offset=84
+  local.get $21
+  call $instanceof/assertStaticTrue<instanceof/Y,instanceof/IB>
+  global.get $instanceof/y
+  local.set $21
+  global.get $~lib/memory/__stack_pointer
+  local.get $21
+  i32.store $0 offset=84
+  local.get $21
+  call $instanceof/assertStaticTrue<instanceof/Y,instanceof/ID>
+  global.get $instanceof/y
+  local.set $21
+  global.get $~lib/memory/__stack_pointer
+  local.get $21
+  i32.store $0 offset=84
+  local.get $21
+  call $instanceof/assertStaticTrue<instanceof/Y,instanceof/IC>
+  global.get $instanceof/y
+  local.set $21
+  global.get $~lib/memory/__stack_pointer
+  local.get $21
+  i32.store $0 offset=84
+  local.get $21
+  call $instanceof/assertStaticFalse<instanceof/Y,instanceof/IE>
+  global.get $instanceof/z
+  local.set $21
+  global.get $~lib/memory/__stack_pointer
+  local.get $21
+  i32.store $0 offset=84
+  local.get $21
+  call $instanceof/assertStaticTrue<instanceof/Y,instanceof/IA>
+  global.get $instanceof/z
+  local.set $21
+  global.get $~lib/memory/__stack_pointer
+  local.get $21
+  i32.store $0 offset=84
+  local.get $21
+  call $instanceof/assertStaticTrue<instanceof/Y,instanceof/IB>
+  global.get $instanceof/z
+  local.set $21
+  global.get $~lib/memory/__stack_pointer
+  local.get $21
+  i32.store $0 offset=84
+  local.get $21
+  call $instanceof/assertStaticTrue<instanceof/Y,instanceof/ID>
+  global.get $instanceof/z
+  local.set $21
+  global.get $~lib/memory/__stack_pointer
+  local.get $21
+  i32.store $0 offset=84
+  local.get $21
+  call $instanceof/assertStaticTrue<instanceof/Y,instanceof/IC>
+  global.get $instanceof/z
+  local.set $21
+  global.get $~lib/memory/__stack_pointer
+  local.get $21
+  i32.store $0 offset=84
+  local.get $21
+  call $instanceof/assertStaticFalse<instanceof/Y,instanceof/IE>
+  global.get $instanceof/z
+  local.set $21
+  global.get $~lib/memory/__stack_pointer
+  local.get $21
+  i32.store $0 offset=84
+  local.get $21
+  call $instanceof/assertStaticTrue<instanceof/Z,instanceof/IA>
+  global.get $instanceof/z
+  local.set $21
+  global.get $~lib/memory/__stack_pointer
+  local.get $21
+  i32.store $0 offset=84
+  local.get $21
+  call $instanceof/assertStaticTrue<instanceof/Z,instanceof/IB>
+  global.get $instanceof/z
+  local.set $21
+  global.get $~lib/memory/__stack_pointer
+  local.get $21
+  i32.store $0 offset=84
+  local.get $21
+  call $instanceof/assertStaticTrue<instanceof/Z,instanceof/ID>
+  global.get $instanceof/z
+  local.set $21
+  global.get $~lib/memory/__stack_pointer
+  local.get $21
+  i32.store $0 offset=84
+  local.get $21
+  call $instanceof/assertStaticTrue<instanceof/Z,instanceof/IC>
+  global.get $instanceof/z
+  local.set $21
+  global.get $~lib/memory/__stack_pointer
+  local.get $21
+  i32.store $0 offset=84
+  local.get $21
+  call $instanceof/assertStaticFalse<instanceof/Z,instanceof/IE>
+  global.get $instanceof/x
+  local.set $21
+  global.get $~lib/memory/__stack_pointer
+  local.get $21
+  i32.store $0 offset=84
+  local.get $21
+  call $instanceof/assertStaticFalse<instanceof/IA,instanceof/W>
+  global.get $instanceof/x
+  local.set $21
+  global.get $~lib/memory/__stack_pointer
+  local.get $21
+  i32.store $0 offset=84
+  local.get $21
+  call $instanceof/assertStaticFalse<instanceof/IB,instanceof/W>
+  global.get $instanceof/y
+  local.set $21
+  global.get $~lib/memory/__stack_pointer
+  local.get $21
+  i32.store $0 offset=84
+  local.get $21
+  call $instanceof/assertStaticFalse<instanceof/IA,instanceof/W>
+  global.get $instanceof/y
+  local.set $21
+  global.get $~lib/memory/__stack_pointer
+  local.get $21
+  i32.store $0 offset=84
+  local.get $21
+  call $instanceof/assertStaticFalse<instanceof/IB,instanceof/W>
+  global.get $instanceof/y
+  local.set $21
+  global.get $~lib/memory/__stack_pointer
+  local.get $21
+  i32.store $0 offset=84
+  local.get $21
+  call $instanceof/assertStaticFalse<instanceof/IC,instanceof/W>
+  global.get $instanceof/y
+  local.set $21
+  global.get $~lib/memory/__stack_pointer
+  local.get $21
+  i32.store $0 offset=84
+  local.get $21
+  call $instanceof/assertStaticFalse<instanceof/ID,instanceof/W>
+  global.get $instanceof/z
+  local.set $21
+  global.get $~lib/memory/__stack_pointer
+  local.get $21
+  i32.store $0 offset=84
+  local.get $21
+  call $instanceof/assertStaticFalse<instanceof/IA,instanceof/W>
+  global.get $instanceof/z
+  local.set $21
+  global.get $~lib/memory/__stack_pointer
+  local.get $21
+  i32.store $0 offset=84
+  local.get $21
+  call $instanceof/assertStaticFalse<instanceof/IB,instanceof/W>
+  global.get $instanceof/z
+  local.set $21
+  global.get $~lib/memory/__stack_pointer
+  local.get $21
+  i32.store $0 offset=84
+  local.get $21
+  call $instanceof/assertStaticFalse<instanceof/IC,instanceof/W>
+  global.get $instanceof/z
+  local.set $21
+  global.get $~lib/memory/__stack_pointer
+  local.get $21
+  i32.store $0 offset=84
+  local.get $21
+  call $instanceof/assertStaticFalse<instanceof/ID,instanceof/W>
+  global.get $instanceof/x
+  local.set $21
+  global.get $~lib/memory/__stack_pointer
+  local.get $21
+  i32.store $0 offset=84
+  local.get $21
+  call $instanceof/assertDynamicTrue<instanceof/IA,instanceof/X>
+  global.get $instanceof/x
+  local.set $21
+  global.get $~lib/memory/__stack_pointer
+  local.get $21
+  i32.store $0 offset=84
+  local.get $21
+  call $instanceof/assertDynamicTrue<instanceof/IB,instanceof/X>
+  global.get $instanceof/y
+  local.set $21
+  global.get $~lib/memory/__stack_pointer
+  local.get $21
+  i32.store $0 offset=84
+  local.get $21
+  call $instanceof/assertDynamicTrue<instanceof/IA,instanceof/X>
+  global.get $instanceof/y
+  local.set $21
+  global.get $~lib/memory/__stack_pointer
+  local.get $21
+  i32.store $0 offset=84
+  local.get $21
+  call $instanceof/assertDynamicTrue<instanceof/IB,instanceof/X>
+  global.get $instanceof/z
+  local.set $21
+  global.get $~lib/memory/__stack_pointer
+  local.get $21
+  i32.store $0 offset=84
+  local.get $21
+  call $instanceof/assertDynamicTrue<instanceof/IA,instanceof/X>
+  global.get $instanceof/z
+  local.set $21
+  global.get $~lib/memory/__stack_pointer
+  local.get $21
+  i32.store $0 offset=84
+  local.get $21
+  call $instanceof/assertDynamicTrue<instanceof/IB,instanceof/X>
+  global.get $instanceof/y
+  local.set $21
+  global.get $~lib/memory/__stack_pointer
+  local.get $21
+  i32.store $0 offset=84
+  local.get $21
+  call $instanceof/assertDynamicTrue<instanceof/IA,instanceof/Y>
+  global.get $instanceof/y
+  local.set $21
+  global.get $~lib/memory/__stack_pointer
+  local.get $21
+  i32.store $0 offset=84
+  local.get $21
+  call $instanceof/assertDynamicTrue<instanceof/IB,instanceof/Y>
+  global.get $instanceof/y
+  local.set $21
+  global.get $~lib/memory/__stack_pointer
+  local.get $21
+  i32.store $0 offset=84
+  local.get $21
+  call $instanceof/assertDynamicTrue<instanceof/IC,instanceof/Y>
+  global.get $instanceof/y
+  local.set $21
+  global.get $~lib/memory/__stack_pointer
+  local.get $21
+  i32.store $0 offset=84
+  local.get $21
+  call $instanceof/assertDynamicTrue<instanceof/ID,instanceof/Y>
+  global.get $instanceof/z
+  local.set $21
+  global.get $~lib/memory/__stack_pointer
+  local.get $21
+  i32.store $0 offset=84
+  local.get $21
+  call $instanceof/assertDynamicTrue<instanceof/IA,instanceof/Y>
+  global.get $instanceof/z
+  local.set $21
+  global.get $~lib/memory/__stack_pointer
+  local.get $21
+  i32.store $0 offset=84
+  local.get $21
+  call $instanceof/assertDynamicTrue<instanceof/IB,instanceof/Y>
+  global.get $instanceof/z
+  local.set $21
+  global.get $~lib/memory/__stack_pointer
+  local.get $21
+  i32.store $0 offset=84
+  local.get $21
+  call $instanceof/assertDynamicTrue<instanceof/IC,instanceof/Y>
+  global.get $instanceof/z
+  local.set $21
+  global.get $~lib/memory/__stack_pointer
+  local.get $21
+  i32.store $0 offset=84
+  local.get $21
+  call $instanceof/assertDynamicTrue<instanceof/ID,instanceof/Y>
+  global.get $instanceof/z
+  local.set $21
+  global.get $~lib/memory/__stack_pointer
+  local.get $21
+  i32.store $0 offset=84
+  local.get $21
+  call $instanceof/assertDynamicTrue<instanceof/IA,instanceof/Z>
+  global.get $instanceof/z
+  local.set $21
+  global.get $~lib/memory/__stack_pointer
+  local.get $21
+  i32.store $0 offset=84
+  local.get $21
+  call $instanceof/assertDynamicTrue<instanceof/IB,instanceof/Z>
+  global.get $instanceof/z
+  local.set $21
+  global.get $~lib/memory/__stack_pointer
+  local.get $21
+  i32.store $0 offset=84
+  local.get $21
+  call $instanceof/assertDynamicTrue<instanceof/IC,instanceof/Z>
+  global.get $instanceof/z
+  local.set $21
+  global.get $~lib/memory/__stack_pointer
+  local.get $21
+  i32.store $0 offset=84
+  local.get $21
+  call $instanceof/assertDynamicTrue<instanceof/ID,instanceof/Z>
   global.get $~lib/memory/__stack_pointer
   i32.const 88
   i32.add
@@ -3978,7 +6175,7 @@
   global.set $~lib/memory/__stack_pointer
   local.get $1
  )
- (func $instanceof/A_I1#constructor (type $i32_=>_i32) (param $this i32) (result i32)
+ (func $instanceof/W#constructor (type $i32_=>_i32) (param $this i32) (result i32)
   (local $1 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -4011,7 +6208,7 @@
   global.set $~lib/memory/__stack_pointer
   local.get $1
  )
- (func $instanceof/B_I1_I2#constructor (type $i32_=>_i32) (param $this i32) (result i32)
+ (func $instanceof/X#constructor (type $i32_=>_i32) (param $this i32) (result i32)
   (local $1 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -4026,7 +6223,7 @@
   if
    global.get $~lib/memory/__stack_pointer
    i32.const 0
-   i32.const 17
+   i32.const 15
    call $~lib/rt/itcms/__new
    local.tee $this
    i32.store $0
@@ -4034,6 +6231,72 @@
   global.get $~lib/memory/__stack_pointer
   local.get $this
   call $~lib/object/Object#constructor
+  local.tee $this
+  i32.store $0
+  local.get $this
+  local.set $1
+  global.get $~lib/memory/__stack_pointer
+  i32.const 4
+  i32.add
+  global.set $~lib/memory/__stack_pointer
+  local.get $1
+ )
+ (func $instanceof/Y#constructor (type $i32_=>_i32) (param $this i32) (result i32)
+  (local $1 i32)
+  global.get $~lib/memory/__stack_pointer
+  i32.const 4
+  i32.sub
+  global.set $~lib/memory/__stack_pointer
+  call $~stack_check
+  global.get $~lib/memory/__stack_pointer
+  i32.const 0
+  i32.store $0
+  local.get $this
+  i32.eqz
+  if
+   global.get $~lib/memory/__stack_pointer
+   i32.const 0
+   i32.const 18
+   call $~lib/rt/itcms/__new
+   local.tee $this
+   i32.store $0
+  end
+  global.get $~lib/memory/__stack_pointer
+  local.get $this
+  call $instanceof/X#constructor
+  local.tee $this
+  i32.store $0
+  local.get $this
+  local.set $1
+  global.get $~lib/memory/__stack_pointer
+  i32.const 4
+  i32.add
+  global.set $~lib/memory/__stack_pointer
+  local.get $1
+ )
+ (func $instanceof/Z#constructor (type $i32_=>_i32) (param $this i32) (result i32)
+  (local $1 i32)
+  global.get $~lib/memory/__stack_pointer
+  i32.const 4
+  i32.sub
+  global.set $~lib/memory/__stack_pointer
+  call $~stack_check
+  global.get $~lib/memory/__stack_pointer
+  i32.const 0
+  i32.store $0
+  local.get $this
+  i32.eqz
+  if
+   global.get $~lib/memory/__stack_pointer
+   i32.const 0
+   i32.const 21
+   call $~lib/rt/itcms/__new
+   local.tee $this
+   i32.store $0
+  end
+  global.get $~lib/memory/__stack_pointer
+  local.get $this
+  call $instanceof/Y#constructor
   local.tee $this
   i32.store $0
   local.get $this

--- a/tests/compiler/instanceof.release.wat
+++ b/tests/compiler/instanceof.release.wat
@@ -2280,15 +2280,18 @@
     if (result i32)
      block $__inlined_func$~instanceof|instanceof/I1 (result i32)
       block $is_instance13
-       block $tablify|0
-        local.get $0
-        i32.const 8
-        i32.sub
-        i32.load $0
-        i32.const 14
-        i32.sub
-        br_table $is_instance13 $is_instance13 $tablify|0 $is_instance13 $tablify|0
-       end
+       local.get $0
+       i32.const 8
+       i32.sub
+       i32.load $0
+       local.tee $0
+       i32.const 14
+       i32.eq
+       br_if $is_instance13
+       local.get $0
+       i32.const 17
+       i32.eq
+       br_if $is_instance13
        i32.const 0
        br $__inlined_func$~instanceof|instanceof/I1
       end

--- a/tests/compiler/instanceof.release.wat
+++ b/tests/compiler/instanceof.release.wat
@@ -1449,867 +1449,6 @@
   memory.fill $0
   local.get $0
  )
- (func $start:instanceof (type $none_=>_none)
-  (local $0 i32)
-  (local $1 i32)
-  global.get $~lib/memory/__stack_pointer
-  i32.const 96
-  i32.sub
-  global.set $~lib/memory/__stack_pointer
-  block $folding-inner0
-   global.get $~lib/memory/__stack_pointer
-   i32.const 1564
-   i32.lt_s
-   br_if $folding-inner0
-   global.get $~lib/memory/__stack_pointer
-   i32.const 0
-   i32.const 96
-   memory.fill $0
-   memory.size $0
-   i32.const 16
-   i32.shl
-   i32.const 34332
-   i32.sub
-   i32.const 1
-   i32.shr_u
-   global.set $~lib/rt/itcms/threshold
-   i32.const 1172
-   i32.const 1168
-   i32.store $0
-   i32.const 1176
-   i32.const 1168
-   i32.store $0
-   i32.const 1168
-   global.set $~lib/rt/itcms/pinSpace
-   i32.const 1204
-   i32.const 1200
-   i32.store $0
-   i32.const 1208
-   i32.const 1200
-   i32.store $0
-   i32.const 1200
-   global.set $~lib/rt/itcms/toSpace
-   i32.const 1348
-   i32.const 1344
-   i32.store $0
-   i32.const 1352
-   i32.const 1344
-   i32.store $0
-   i32.const 1344
-   global.set $~lib/rt/itcms/fromSpace
-   i32.const 0
-   call $instanceof/A#constructor
-   global.set $instanceof/a
-   global.get $~lib/memory/__stack_pointer
-   i32.const 4
-   i32.sub
-   global.set $~lib/memory/__stack_pointer
-   global.get $~lib/memory/__stack_pointer
-   i32.const 1564
-   i32.lt_s
-   br_if $folding-inner0
-   global.get $~lib/memory/__stack_pointer
-   local.tee $0
-   i32.const 0
-   i32.store $0
-   local.get $0
-   i32.const 5
-   call $~lib/rt/itcms/__new
-   local.tee $0
-   i32.store $0
-   global.get $~lib/memory/__stack_pointer
-   local.get $0
-   call $instanceof/A#constructor
-   local.tee $0
-   i32.store $0
-   global.get $~lib/memory/__stack_pointer
-   i32.const 4
-   i32.add
-   global.set $~lib/memory/__stack_pointer
-   local.get $0
-   global.set $instanceof/b
-   global.get $~lib/memory/__stack_pointer
-   global.get $instanceof/a
-   local.tee $0
-   i32.store $0
-   local.get $0
-   if (result i32)
-    local.get $0
-    i32.const 8
-    i32.sub
-    i32.load $0
-    i32.const 5
-    i32.eq
-   else
-    i32.const 0
-   end
-   if
-    i32.const 0
-    i32.const 1456
-    i32.const 18
-    i32.const 1
-    call $~lib/builtins/abort
-    unreachable
-   end
-   global.get $instanceof/an
-   if
-    i32.const 0
-    i32.const 1456
-    i32.const 68
-    i32.const 1
-    call $~lib/builtins/abort
-    unreachable
-   end
-   i32.const 1
-   global.set $instanceof/an
-   global.get $~lib/memory/__stack_pointer
-   i32.const 4
-   i32.sub
-   global.set $~lib/memory/__stack_pointer
-   global.get $~lib/memory/__stack_pointer
-   i32.const 1564
-   i32.lt_s
-   br_if $folding-inner0
-   global.get $~lib/memory/__stack_pointer
-   local.tee $0
-   i32.const 0
-   i32.store $0
-   local.get $0
-   i32.const 6
-   call $~lib/rt/itcms/__new
-   local.tee $0
-   i32.store $0
-   global.get $~lib/memory/__stack_pointer
-   local.tee $1
-   i32.const 4
-   i32.sub
-   global.set $~lib/memory/__stack_pointer
-   global.get $~lib/memory/__stack_pointer
-   i32.const 1564
-   i32.lt_s
-   br_if $folding-inner0
-   global.get $~lib/memory/__stack_pointer
-   i32.const 0
-   i32.store $0
-   local.get $0
-   i32.eqz
-   if
-    global.get $~lib/memory/__stack_pointer
-    i32.const 7
-    call $~lib/rt/itcms/__new
-    local.tee $0
-    i32.store $0
-   end
-   global.get $~lib/memory/__stack_pointer
-   local.get $0
-   call $~lib/object/Object#constructor
-   local.tee $0
-   i32.store $0
-   global.get $~lib/memory/__stack_pointer
-   i32.const 4
-   i32.add
-   global.set $~lib/memory/__stack_pointer
-   local.get $1
-   local.get $0
-   i32.store $0
-   global.get $~lib/memory/__stack_pointer
-   i32.const 4
-   i32.add
-   global.set $~lib/memory/__stack_pointer
-   local.get $0
-   global.set $instanceof/child
-   global.get $~lib/memory/__stack_pointer
-   i32.const 4
-   i32.sub
-   global.set $~lib/memory/__stack_pointer
-   global.get $~lib/memory/__stack_pointer
-   i32.const 1564
-   i32.lt_s
-   br_if $folding-inner0
-   global.get $~lib/memory/__stack_pointer
-   local.tee $0
-   i32.const 0
-   i32.store $0
-   local.get $0
-   i32.const 8
-   call $~lib/rt/itcms/__new
-   local.tee $0
-   i32.store $0
-   global.get $~lib/memory/__stack_pointer
-   local.tee $1
-   i32.const 4
-   i32.sub
-   global.set $~lib/memory/__stack_pointer
-   global.get $~lib/memory/__stack_pointer
-   i32.const 1564
-   i32.lt_s
-   br_if $folding-inner0
-   global.get $~lib/memory/__stack_pointer
-   i32.const 0
-   i32.store $0
-   local.get $0
-   i32.eqz
-   if
-    global.get $~lib/memory/__stack_pointer
-    i32.const 9
-    call $~lib/rt/itcms/__new
-    local.tee $0
-    i32.store $0
-   end
-   global.get $~lib/memory/__stack_pointer
-   local.get $0
-   call $~lib/object/Object#constructor
-   local.tee $0
-   i32.store $0
-   global.get $~lib/memory/__stack_pointer
-   i32.const 4
-   i32.add
-   global.set $~lib/memory/__stack_pointer
-   local.get $1
-   local.get $0
-   i32.store $0
-   global.get $~lib/memory/__stack_pointer
-   i32.const 4
-   i32.add
-   global.set $~lib/memory/__stack_pointer
-   local.get $0
-   global.set $instanceof/childAsParent
-   global.get $~lib/memory/__stack_pointer
-   global.get $instanceof/childAsParent
-   local.tee $0
-   i32.store $0 offset=4
-   local.get $0
-   if (result i32)
-    local.get $0
-    i32.const 8
-    i32.sub
-    i32.load $0
-    i32.const 8
-    i32.eq
-   else
-    i32.const 0
-   end
-   i32.eqz
-   if
-    i32.const 0
-    i32.const 1456
-    i32.const 94
-    i32.const 1
-    call $~lib/builtins/abort
-    unreachable
-   end
-   global.get $~lib/memory/__stack_pointer
-   global.get $instanceof/childAsParent
-   local.tee $0
-   i32.store $0 offset=8
-   local.get $0
-   if (result i32)
-    block $__inlined_func$~anyinstanceof|instanceof/Child (result i32)
-     block $is_instance2
-      local.get $0
-      i32.const 8
-      i32.sub
-      i32.load $0
-      local.tee $0
-      i32.const 6
-      i32.eq
-      br_if $is_instance2
-      local.get $0
-      i32.const 8
-      i32.eq
-      br_if $is_instance2
-      i32.const 0
-      br $__inlined_func$~anyinstanceof|instanceof/Child
-     end
-     i32.const 1
-    end
-   else
-    i32.const 0
-   end
-   i32.eqz
-   if
-    i32.const 0
-    i32.const 1456
-    i32.const 96
-    i32.const 1
-    call $~lib/builtins/abort
-    unreachable
-   end
-   i32.const 0
-   call $instanceof/Animal#constructor
-   global.set $instanceof/animal
-   i32.const 0
-   call $instanceof/Cat#constructor
-   global.set $instanceof/cat
-   call $instanceof/BlackCat#constructor
-   global.set $instanceof/blackcat
-   global.get $~lib/memory/__stack_pointer
-   global.get $instanceof/animal
-   local.tee $0
-   i32.store $0 offset=12
-   local.get $0
-   if (result i32)
-    block $__inlined_func$~instanceof|instanceof/Cat (result i32)
-     block $is_instance3
-      local.get $0
-      i32.const 8
-      i32.sub
-      i32.load $0
-      local.tee $0
-      i32.const 12
-      i32.eq
-      br_if $is_instance3
-      local.get $0
-      i32.const 13
-      i32.eq
-      br_if $is_instance3
-      i32.const 0
-      br $__inlined_func$~instanceof|instanceof/Cat
-     end
-     i32.const 1
-    end
-   else
-    i32.const 0
-   end
-   if
-    i32.const 0
-    i32.const 1456
-    i32.const 111
-    i32.const 1
-    call $~lib/builtins/abort
-    unreachable
-   end
-   global.get $~lib/memory/__stack_pointer
-   global.get $instanceof/animal
-   local.tee $0
-   i32.store $0 offset=16
-   local.get $0
-   if (result i32)
-    local.get $0
-    i32.const 8
-    i32.sub
-    i32.load $0
-    i32.const 13
-    i32.eq
-   else
-    i32.const 0
-   end
-   if
-    i32.const 0
-    i32.const 1456
-    i32.const 112
-    i32.const 1
-    call $~lib/builtins/abort
-    unreachable
-   end
-   global.get $~lib/memory/__stack_pointer
-   global.get $instanceof/cat
-   local.tee $0
-   i32.store $0 offset=20
-   local.get $0
-   if (result i32)
-    block $__inlined_func$~instanceof|instanceof/Cat5 (result i32)
-     block $is_instance6
-      local.get $0
-      i32.const 8
-      i32.sub
-      i32.load $0
-      local.tee $0
-      i32.const 12
-      i32.eq
-      br_if $is_instance6
-      local.get $0
-      i32.const 13
-      i32.eq
-      br_if $is_instance6
-      i32.const 0
-      br $__inlined_func$~instanceof|instanceof/Cat5
-     end
-     i32.const 1
-    end
-   else
-    i32.const 0
-   end
-   i32.eqz
-   if
-    i32.const 0
-    i32.const 1456
-    i32.const 115
-    i32.const 1
-    call $~lib/builtins/abort
-    unreachable
-   end
-   global.get $~lib/memory/__stack_pointer
-   global.get $instanceof/cat
-   local.tee $0
-   i32.store $0 offset=24
-   local.get $0
-   if (result i32)
-    local.get $0
-    i32.const 8
-    i32.sub
-    i32.load $0
-    i32.const 13
-    i32.eq
-   else
-    i32.const 0
-   end
-   if
-    i32.const 0
-    i32.const 1456
-    i32.const 116
-    i32.const 1
-    call $~lib/builtins/abort
-    unreachable
-   end
-   global.get $~lib/memory/__stack_pointer
-   global.get $instanceof/blackcat
-   local.tee $0
-   i32.store $0 offset=28
-   local.get $0
-   if (result i32)
-    block $__inlined_func$~instanceof|instanceof/Cat9 (result i32)
-     block $is_instance10
-      local.get $0
-      i32.const 8
-      i32.sub
-      i32.load $0
-      local.tee $0
-      i32.const 12
-      i32.eq
-      br_if $is_instance10
-      local.get $0
-      i32.const 13
-      i32.eq
-      br_if $is_instance10
-      i32.const 0
-      br $__inlined_func$~instanceof|instanceof/Cat9
-     end
-     i32.const 1
-    end
-   else
-    i32.const 0
-   end
-   i32.eqz
-   if
-    i32.const 0
-    i32.const 1456
-    i32.const 119
-    i32.const 1
-    call $~lib/builtins/abort
-    unreachable
-   end
-   global.get $~lib/memory/__stack_pointer
-   global.get $instanceof/blackcat
-   local.tee $0
-   i32.store $0 offset=32
-   local.get $0
-   if (result i32)
-    local.get $0
-    i32.const 8
-    i32.sub
-    i32.load $0
-    i32.const 13
-    i32.eq
-   else
-    i32.const 0
-   end
-   i32.eqz
-   if
-    i32.const 0
-    i32.const 1456
-    i32.const 120
-    i32.const 1
-    call $~lib/builtins/abort
-    unreachable
-   end
-   i32.const 0
-   call $instanceof/Animal#constructor
-   global.set $instanceof/nullableAnimal
-   i32.const 0
-   call $instanceof/Cat#constructor
-   global.set $instanceof/nullableCat
-   call $instanceof/BlackCat#constructor
-   global.set $instanceof/nullableBlackcat
-   global.get $instanceof/nullableAnimal
-   i32.eqz
-   if
-    i32.const 0
-    i32.const 1456
-    i32.const 126
-    i32.const 1
-    call $~lib/builtins/abort
-    unreachable
-   end
-   global.get $~lib/memory/__stack_pointer
-   global.get $instanceof/nullableAnimal
-   local.tee $0
-   i32.store $0 offset=36
-   local.get $0
-   if (result i32)
-    block $__inlined_func$~instanceof|instanceof/Cat13 (result i32)
-     block $is_instance14
-      local.get $0
-      i32.const 8
-      i32.sub
-      i32.load $0
-      local.tee $0
-      i32.const 12
-      i32.eq
-      br_if $is_instance14
-      local.get $0
-      i32.const 13
-      i32.eq
-      br_if $is_instance14
-      i32.const 0
-      br $__inlined_func$~instanceof|instanceof/Cat13
-     end
-     i32.const 1
-    end
-   else
-    i32.const 0
-   end
-   if
-    i32.const 0
-    i32.const 1456
-    i32.const 127
-    i32.const 1
-    call $~lib/builtins/abort
-    unreachable
-   end
-   global.get $~lib/memory/__stack_pointer
-   global.get $instanceof/nullableAnimal
-   local.tee $0
-   i32.store $0 offset=40
-   local.get $0
-   if (result i32)
-    local.get $0
-    i32.const 8
-    i32.sub
-    i32.load $0
-    i32.const 13
-    i32.eq
-   else
-    i32.const 0
-   end
-   if
-    i32.const 0
-    i32.const 1456
-    i32.const 128
-    i32.const 1
-    call $~lib/builtins/abort
-    unreachable
-   end
-   global.get $instanceof/nullableCat
-   i32.eqz
-   if
-    i32.const 0
-    i32.const 1456
-    i32.const 130
-    i32.const 1
-    call $~lib/builtins/abort
-    unreachable
-   end
-   global.get $~lib/memory/__stack_pointer
-   global.get $instanceof/nullableCat
-   local.tee $0
-   i32.store $0 offset=44
-   local.get $0
-   if (result i32)
-    block $__inlined_func$~instanceof|instanceof/Cat17 (result i32)
-     block $is_instance18
-      local.get $0
-      i32.const 8
-      i32.sub
-      i32.load $0
-      local.tee $0
-      i32.const 12
-      i32.eq
-      br_if $is_instance18
-      local.get $0
-      i32.const 13
-      i32.eq
-      br_if $is_instance18
-      i32.const 0
-      br $__inlined_func$~instanceof|instanceof/Cat17
-     end
-     i32.const 1
-    end
-   else
-    i32.const 0
-   end
-   i32.eqz
-   if
-    i32.const 0
-    i32.const 1456
-    i32.const 131
-    i32.const 1
-    call $~lib/builtins/abort
-    unreachable
-   end
-   global.get $~lib/memory/__stack_pointer
-   global.get $instanceof/nullableCat
-   local.tee $0
-   i32.store $0 offset=48
-   local.get $0
-   if (result i32)
-    local.get $0
-    i32.const 8
-    i32.sub
-    i32.load $0
-    i32.const 13
-    i32.eq
-   else
-    i32.const 0
-   end
-   if
-    i32.const 0
-    i32.const 1456
-    i32.const 132
-    i32.const 1
-    call $~lib/builtins/abort
-    unreachable
-   end
-   global.get $instanceof/nullableBlackcat
-   i32.eqz
-   if
-    i32.const 0
-    i32.const 1456
-    i32.const 134
-    i32.const 1
-    call $~lib/builtins/abort
-    unreachable
-   end
-   global.get $~lib/memory/__stack_pointer
-   global.get $instanceof/nullableBlackcat
-   local.tee $0
-   i32.store $0 offset=52
-   local.get $0
-   if (result i32)
-    block $__inlined_func$~instanceof|instanceof/Cat21 (result i32)
-     block $is_instance22
-      local.get $0
-      i32.const 8
-      i32.sub
-      i32.load $0
-      local.tee $0
-      i32.const 12
-      i32.eq
-      br_if $is_instance22
-      local.get $0
-      i32.const 13
-      i32.eq
-      br_if $is_instance22
-      i32.const 0
-      br $__inlined_func$~instanceof|instanceof/Cat21
-     end
-     i32.const 1
-    end
-   else
-    i32.const 0
-   end
-   i32.eqz
-   if
-    i32.const 0
-    i32.const 1456
-    i32.const 135
-    i32.const 1
-    call $~lib/builtins/abort
-    unreachable
-   end
-   global.get $~lib/memory/__stack_pointer
-   global.get $instanceof/nullableBlackcat
-   local.tee $0
-   i32.store $0 offset=56
-   local.get $0
-   if (result i32)
-    local.get $0
-    i32.const 8
-    i32.sub
-    i32.load $0
-    i32.const 13
-    i32.eq
-   else
-    i32.const 0
-   end
-   i32.eqz
-   if
-    i32.const 0
-    i32.const 1456
-    i32.const 136
-    i32.const 1
-    call $~lib/builtins/abort
-    unreachable
-   end
-   global.get $~lib/memory/__stack_pointer
-   local.tee $0
-   i32.const 0
-   i32.store $0 offset=60
-   local.get $0
-   i32.const 0
-   i32.store $0 offset=64
-   local.get $0
-   i32.const 0
-   i32.store $0 offset=68
-   local.get $0
-   i32.const 0
-   i32.store $0 offset=72
-   local.get $0
-   i32.const 0
-   i32.store $0 offset=76
-   local.get $0
-   i32.const 0
-   i32.store $0 offset=80
-   local.get $0
-   i32.const 4
-   i32.sub
-   global.set $~lib/memory/__stack_pointer
-   global.get $~lib/memory/__stack_pointer
-   i32.const 1564
-   i32.lt_s
-   br_if $folding-inner0
-   global.get $~lib/memory/__stack_pointer
-   local.tee $0
-   i32.const 0
-   i32.store $0
-   local.get $0
-   i32.const 14
-   call $~lib/rt/itcms/__new
-   local.tee $0
-   i32.store $0
-   global.get $~lib/memory/__stack_pointer
-   local.get $0
-   call $~lib/object/Object#constructor
-   local.tee $0
-   i32.store $0
-   global.get $~lib/memory/__stack_pointer
-   i32.const 4
-   i32.add
-   global.set $~lib/memory/__stack_pointer
-   local.get $0
-   global.set $instanceof/a_i1
-   global.get $~lib/memory/__stack_pointer
-   global.get $instanceof/a_i1
-   local.tee $0
-   i32.store $0 offset=84
-   local.get $0
-   if (result i32)
-    block $__inlined_func$~instanceof|instanceof/I1 (result i32)
-     block $is_instance37
-      block $tablify|0
-       local.get $0
-       i32.const 8
-       i32.sub
-       i32.load $0
-       i32.const 14
-       i32.sub
-       br_table $is_instance37 $is_instance37 $tablify|0 $is_instance37 $tablify|0
-      end
-      i32.const 0
-      br $__inlined_func$~instanceof|instanceof/I1
-     end
-     i32.const 1
-    end
-   else
-    i32.const 0
-   end
-   i32.eqz
-   if
-    i32.const 0
-    i32.const 1456
-    i32.const 165
-    i32.const 1
-    call $~lib/builtins/abort
-    unreachable
-   end
-   global.get $~lib/memory/__stack_pointer
-   i32.const 4
-   i32.sub
-   global.set $~lib/memory/__stack_pointer
-   global.get $~lib/memory/__stack_pointer
-   i32.const 1564
-   i32.lt_s
-   br_if $folding-inner0
-   global.get $~lib/memory/__stack_pointer
-   local.tee $0
-   i32.const 0
-   i32.store $0
-   local.get $0
-   i32.const 17
-   call $~lib/rt/itcms/__new
-   local.tee $0
-   i32.store $0
-   global.get $~lib/memory/__stack_pointer
-   local.get $0
-   call $~lib/object/Object#constructor
-   local.tee $0
-   i32.store $0
-   global.get $~lib/memory/__stack_pointer
-   i32.const 4
-   i32.add
-   global.set $~lib/memory/__stack_pointer
-   local.get $0
-   global.set $instanceof/b_i1_i2
-   global.get $~lib/memory/__stack_pointer
-   global.get $instanceof/a_i1
-   local.tee $0
-   i32.store $0 offset=88
-   local.get $0
-   if (result i32)
-    local.get $0
-    i32.const 8
-    i32.sub
-    i32.load $0
-    i32.const 17
-    i32.eq
-   else
-    i32.const 0
-   end
-   if
-    i32.const 0
-    i32.const 1456
-    i32.const 172
-    i32.const 1
-    call $~lib/builtins/abort
-    unreachable
-   end
-   global.get $~lib/memory/__stack_pointer
-   global.get $instanceof/b_i1_i2
-   local.tee $0
-   i32.store $0 offset=92
-   local.get $0
-   if (result i32)
-    local.get $0
-    i32.const 8
-    i32.sub
-    i32.load $0
-    i32.const 17
-    i32.eq
-   else
-    i32.const 0
-   end
-   i32.eqz
-   if
-    i32.const 0
-    i32.const 1456
-    i32.const 173
-    i32.const 1
-    call $~lib/builtins/abort
-    unreachable
-   end
-   global.get $~lib/memory/__stack_pointer
-   i32.const 96
-   i32.add
-   global.set $~lib/memory/__stack_pointer
-   return
-  end
-  i32.const 34352
-  i32.const 34400
-  i32.const 1
-  i32.const 1
-  call $~lib/builtins/abort
-  unreachable
- )
  (func $~lib/rt/__visit_members (type $i32_=>_none) (param $0 i32)
   block $invalid
    block $instanceof/B_I1_I2
@@ -2383,6 +1522,880 @@
  )
  (func $~start (type $none_=>_none)
   call $start:instanceof
+ )
+ (func $start:instanceof (type $none_=>_none)
+  (local $0 i32)
+  (local $1 i32)
+  global.get $~lib/memory/__stack_pointer
+  i32.const 88
+  i32.sub
+  global.set $~lib/memory/__stack_pointer
+  block $folding-inner1
+   block $folding-inner0
+    global.get $~lib/memory/__stack_pointer
+    i32.const 1564
+    i32.lt_s
+    br_if $folding-inner0
+    global.get $~lib/memory/__stack_pointer
+    i32.const 0
+    i32.const 88
+    memory.fill $0
+    memory.size $0
+    i32.const 16
+    i32.shl
+    i32.const 34332
+    i32.sub
+    i32.const 1
+    i32.shr_u
+    global.set $~lib/rt/itcms/threshold
+    i32.const 1172
+    i32.const 1168
+    i32.store $0
+    i32.const 1176
+    i32.const 1168
+    i32.store $0
+    i32.const 1168
+    global.set $~lib/rt/itcms/pinSpace
+    i32.const 1204
+    i32.const 1200
+    i32.store $0
+    i32.const 1208
+    i32.const 1200
+    i32.store $0
+    i32.const 1200
+    global.set $~lib/rt/itcms/toSpace
+    i32.const 1348
+    i32.const 1344
+    i32.store $0
+    i32.const 1352
+    i32.const 1344
+    i32.store $0
+    i32.const 1344
+    global.set $~lib/rt/itcms/fromSpace
+    i32.const 0
+    call $instanceof/A#constructor
+    global.set $instanceof/a
+    global.get $~lib/memory/__stack_pointer
+    i32.const 4
+    i32.sub
+    global.set $~lib/memory/__stack_pointer
+    global.get $~lib/memory/__stack_pointer
+    i32.const 1564
+    i32.lt_s
+    br_if $folding-inner0
+    global.get $~lib/memory/__stack_pointer
+    local.tee $0
+    i32.const 0
+    i32.store $0
+    local.get $0
+    i32.const 5
+    call $~lib/rt/itcms/__new
+    local.tee $0
+    i32.store $0
+    global.get $~lib/memory/__stack_pointer
+    local.get $0
+    call $instanceof/A#constructor
+    local.tee $0
+    i32.store $0
+    global.get $~lib/memory/__stack_pointer
+    i32.const 4
+    i32.add
+    global.set $~lib/memory/__stack_pointer
+    local.get $0
+    global.set $instanceof/b
+    global.get $~lib/memory/__stack_pointer
+    global.get $instanceof/a
+    local.tee $0
+    i32.store $0
+    local.get $0
+    if (result i32)
+     local.get $0
+     i32.const 8
+     i32.sub
+     i32.load $0
+     i32.const 5
+     i32.eq
+    else
+     i32.const 0
+    end
+    if
+     i32.const 0
+     i32.const 1456
+     i32.const 41
+     i32.const 1
+     call $~lib/builtins/abort
+     unreachable
+    end
+    global.get $instanceof/an
+    if
+     i32.const 0
+     i32.const 1456
+     i32.const 91
+     i32.const 1
+     call $~lib/builtins/abort
+     unreachable
+    end
+    i32.const 1
+    global.set $instanceof/an
+    global.get $~lib/memory/__stack_pointer
+    i32.const 4
+    i32.sub
+    global.set $~lib/memory/__stack_pointer
+    global.get $~lib/memory/__stack_pointer
+    i32.const 1564
+    i32.lt_s
+    br_if $folding-inner0
+    global.get $~lib/memory/__stack_pointer
+    local.tee $0
+    i32.const 0
+    i32.store $0
+    local.get $0
+    i32.const 6
+    call $~lib/rt/itcms/__new
+    local.tee $0
+    i32.store $0
+    global.get $~lib/memory/__stack_pointer
+    local.tee $1
+    i32.const 4
+    i32.sub
+    global.set $~lib/memory/__stack_pointer
+    global.get $~lib/memory/__stack_pointer
+    i32.const 1564
+    i32.lt_s
+    br_if $folding-inner0
+    global.get $~lib/memory/__stack_pointer
+    i32.const 0
+    i32.store $0
+    local.get $0
+    i32.eqz
+    if
+     global.get $~lib/memory/__stack_pointer
+     i32.const 7
+     call $~lib/rt/itcms/__new
+     local.tee $0
+     i32.store $0
+    end
+    global.get $~lib/memory/__stack_pointer
+    local.get $0
+    call $~lib/object/Object#constructor
+    local.tee $0
+    i32.store $0
+    global.get $~lib/memory/__stack_pointer
+    i32.const 4
+    i32.add
+    global.set $~lib/memory/__stack_pointer
+    local.get $1
+    local.get $0
+    i32.store $0
+    global.get $~lib/memory/__stack_pointer
+    i32.const 4
+    i32.add
+    global.set $~lib/memory/__stack_pointer
+    local.get $0
+    global.set $instanceof/child
+    global.get $~lib/memory/__stack_pointer
+    i32.const 4
+    i32.sub
+    global.set $~lib/memory/__stack_pointer
+    global.get $~lib/memory/__stack_pointer
+    i32.const 1564
+    i32.lt_s
+    br_if $folding-inner0
+    global.get $~lib/memory/__stack_pointer
+    local.tee $0
+    i32.const 0
+    i32.store $0
+    local.get $0
+    i32.const 8
+    call $~lib/rt/itcms/__new
+    local.tee $0
+    i32.store $0
+    global.get $~lib/memory/__stack_pointer
+    local.tee $1
+    i32.const 4
+    i32.sub
+    global.set $~lib/memory/__stack_pointer
+    global.get $~lib/memory/__stack_pointer
+    i32.const 1564
+    i32.lt_s
+    br_if $folding-inner0
+    global.get $~lib/memory/__stack_pointer
+    i32.const 0
+    i32.store $0
+    local.get $0
+    i32.eqz
+    if
+     global.get $~lib/memory/__stack_pointer
+     i32.const 9
+     call $~lib/rt/itcms/__new
+     local.tee $0
+     i32.store $0
+    end
+    global.get $~lib/memory/__stack_pointer
+    local.get $0
+    call $~lib/object/Object#constructor
+    local.tee $0
+    i32.store $0
+    global.get $~lib/memory/__stack_pointer
+    i32.const 4
+    i32.add
+    global.set $~lib/memory/__stack_pointer
+    local.get $1
+    local.get $0
+    i32.store $0
+    global.get $~lib/memory/__stack_pointer
+    i32.const 4
+    i32.add
+    global.set $~lib/memory/__stack_pointer
+    local.get $0
+    global.set $instanceof/childAsParent
+    global.get $~lib/memory/__stack_pointer
+    global.get $instanceof/childAsParent
+    local.tee $0
+    i32.store $0 offset=4
+    local.get $0
+    if (result i32)
+     local.get $0
+     i32.const 8
+     i32.sub
+     i32.load $0
+     i32.const 8
+     i32.eq
+    else
+     i32.const 0
+    end
+    i32.eqz
+    if
+     i32.const 0
+     i32.const 1456
+     i32.const 117
+     i32.const 1
+     call $~lib/builtins/abort
+     unreachable
+    end
+    global.get $~lib/memory/__stack_pointer
+    global.get $instanceof/childAsParent
+    local.tee $0
+    i32.store $0 offset=8
+    local.get $0
+    if (result i32)
+     block $__inlined_func$~anyinstanceof|instanceof/Child (result i32)
+      block $is_instance2
+       local.get $0
+       i32.const 8
+       i32.sub
+       i32.load $0
+       local.tee $0
+       i32.const 6
+       i32.eq
+       br_if $is_instance2
+       local.get $0
+       i32.const 8
+       i32.eq
+       br_if $is_instance2
+       i32.const 0
+       br $__inlined_func$~anyinstanceof|instanceof/Child
+      end
+      i32.const 1
+     end
+    else
+     i32.const 0
+    end
+    i32.eqz
+    if
+     i32.const 0
+     i32.const 1456
+     i32.const 119
+     i32.const 1
+     call $~lib/builtins/abort
+     unreachable
+    end
+    i32.const 0
+    call $instanceof/Animal#constructor
+    global.set $instanceof/animal
+    i32.const 0
+    call $instanceof/Cat#constructor
+    global.set $instanceof/cat
+    call $instanceof/BlackCat#constructor
+    global.set $instanceof/blackcat
+    global.get $~lib/memory/__stack_pointer
+    global.get $instanceof/animal
+    local.tee $0
+    i32.store $0 offset=12
+    local.get $0
+    if (result i32)
+     block $__inlined_func$~instanceof|instanceof/Cat (result i32)
+      block $is_instance3
+       local.get $0
+       i32.const 8
+       i32.sub
+       i32.load $0
+       local.tee $0
+       i32.const 12
+       i32.eq
+       br_if $is_instance3
+       local.get $0
+       i32.const 13
+       i32.eq
+       br_if $is_instance3
+       i32.const 0
+       br $__inlined_func$~instanceof|instanceof/Cat
+      end
+      i32.const 1
+     end
+    else
+     i32.const 0
+    end
+    if
+     i32.const 0
+     i32.const 1456
+     i32.const 134
+     i32.const 1
+     call $~lib/builtins/abort
+     unreachable
+    end
+    global.get $~lib/memory/__stack_pointer
+    global.get $instanceof/animal
+    local.tee $0
+    i32.store $0 offset=16
+    local.get $0
+    if (result i32)
+     local.get $0
+     i32.const 8
+     i32.sub
+     i32.load $0
+     i32.const 13
+     i32.eq
+    else
+     i32.const 0
+    end
+    if
+     i32.const 0
+     i32.const 1456
+     i32.const 135
+     i32.const 1
+     call $~lib/builtins/abort
+     unreachable
+    end
+    global.get $~lib/memory/__stack_pointer
+    global.get $instanceof/cat
+    local.tee $0
+    i32.store $0 offset=20
+    local.get $0
+    if (result i32)
+     block $__inlined_func$~instanceof|instanceof/Cat5 (result i32)
+      block $is_instance6
+       local.get $0
+       i32.const 8
+       i32.sub
+       i32.load $0
+       local.tee $0
+       i32.const 12
+       i32.eq
+       br_if $is_instance6
+       local.get $0
+       i32.const 13
+       i32.eq
+       br_if $is_instance6
+       i32.const 0
+       br $__inlined_func$~instanceof|instanceof/Cat5
+      end
+      i32.const 1
+     end
+    else
+     i32.const 0
+    end
+    i32.eqz
+    if
+     i32.const 0
+     i32.const 1456
+     i32.const 138
+     i32.const 1
+     call $~lib/builtins/abort
+     unreachable
+    end
+    global.get $~lib/memory/__stack_pointer
+    global.get $instanceof/cat
+    local.tee $0
+    i32.store $0 offset=24
+    local.get $0
+    if (result i32)
+     local.get $0
+     i32.const 8
+     i32.sub
+     i32.load $0
+     i32.const 13
+     i32.eq
+    else
+     i32.const 0
+    end
+    if
+     i32.const 0
+     i32.const 1456
+     i32.const 139
+     i32.const 1
+     call $~lib/builtins/abort
+     unreachable
+    end
+    global.get $~lib/memory/__stack_pointer
+    global.get $instanceof/blackcat
+    local.tee $0
+    i32.store $0 offset=28
+    local.get $0
+    if (result i32)
+     block $__inlined_func$~instanceof|instanceof/Cat9 (result i32)
+      block $is_instance10
+       local.get $0
+       i32.const 8
+       i32.sub
+       i32.load $0
+       local.tee $0
+       i32.const 12
+       i32.eq
+       br_if $is_instance10
+       local.get $0
+       i32.const 13
+       i32.eq
+       br_if $is_instance10
+       i32.const 0
+       br $__inlined_func$~instanceof|instanceof/Cat9
+      end
+      i32.const 1
+     end
+    else
+     i32.const 0
+    end
+    i32.eqz
+    if
+     i32.const 0
+     i32.const 1456
+     i32.const 142
+     i32.const 1
+     call $~lib/builtins/abort
+     unreachable
+    end
+    global.get $~lib/memory/__stack_pointer
+    global.get $instanceof/blackcat
+    local.tee $0
+    i32.store $0 offset=32
+    local.get $0
+    if (result i32)
+     local.get $0
+     i32.const 8
+     i32.sub
+     i32.load $0
+     i32.const 13
+     i32.eq
+    else
+     i32.const 0
+    end
+    i32.eqz
+    if
+     i32.const 0
+     i32.const 1456
+     i32.const 143
+     i32.const 1
+     call $~lib/builtins/abort
+     unreachable
+    end
+    i32.const 0
+    call $instanceof/Animal#constructor
+    global.set $instanceof/nullableAnimal
+    i32.const 0
+    call $instanceof/Cat#constructor
+    global.set $instanceof/nullableCat
+    call $instanceof/BlackCat#constructor
+    global.set $instanceof/nullableBlackcat
+    global.get $instanceof/nullableAnimal
+    i32.eqz
+    if
+     i32.const 0
+     i32.const 1456
+     i32.const 149
+     i32.const 1
+     call $~lib/builtins/abort
+     unreachable
+    end
+    global.get $~lib/memory/__stack_pointer
+    global.get $instanceof/nullableAnimal
+    local.tee $0
+    i32.store $0 offset=36
+    local.get $0
+    if (result i32)
+     block $__inlined_func$~instanceof|instanceof/Cat13 (result i32)
+      block $is_instance14
+       local.get $0
+       i32.const 8
+       i32.sub
+       i32.load $0
+       local.tee $0
+       i32.const 12
+       i32.eq
+       br_if $is_instance14
+       local.get $0
+       i32.const 13
+       i32.eq
+       br_if $is_instance14
+       i32.const 0
+       br $__inlined_func$~instanceof|instanceof/Cat13
+      end
+      i32.const 1
+     end
+    else
+     i32.const 0
+    end
+    if
+     i32.const 0
+     i32.const 1456
+     i32.const 150
+     i32.const 1
+     call $~lib/builtins/abort
+     unreachable
+    end
+    global.get $~lib/memory/__stack_pointer
+    global.get $instanceof/nullableAnimal
+    local.tee $0
+    i32.store $0 offset=40
+    local.get $0
+    if (result i32)
+     local.get $0
+     i32.const 8
+     i32.sub
+     i32.load $0
+     i32.const 13
+     i32.eq
+    else
+     i32.const 0
+    end
+    if
+     i32.const 0
+     i32.const 1456
+     i32.const 151
+     i32.const 1
+     call $~lib/builtins/abort
+     unreachable
+    end
+    global.get $instanceof/nullableCat
+    i32.eqz
+    if
+     i32.const 0
+     i32.const 1456
+     i32.const 153
+     i32.const 1
+     call $~lib/builtins/abort
+     unreachable
+    end
+    global.get $~lib/memory/__stack_pointer
+    global.get $instanceof/nullableCat
+    local.tee $0
+    i32.store $0 offset=44
+    local.get $0
+    if (result i32)
+     block $__inlined_func$~instanceof|instanceof/Cat17 (result i32)
+      block $is_instance18
+       local.get $0
+       i32.const 8
+       i32.sub
+       i32.load $0
+       local.tee $0
+       i32.const 12
+       i32.eq
+       br_if $is_instance18
+       local.get $0
+       i32.const 13
+       i32.eq
+       br_if $is_instance18
+       i32.const 0
+       br $__inlined_func$~instanceof|instanceof/Cat17
+      end
+      i32.const 1
+     end
+    else
+     i32.const 0
+    end
+    i32.eqz
+    if
+     i32.const 0
+     i32.const 1456
+     i32.const 154
+     i32.const 1
+     call $~lib/builtins/abort
+     unreachable
+    end
+    global.get $~lib/memory/__stack_pointer
+    global.get $instanceof/nullableCat
+    local.tee $0
+    i32.store $0 offset=48
+    local.get $0
+    if (result i32)
+     local.get $0
+     i32.const 8
+     i32.sub
+     i32.load $0
+     i32.const 13
+     i32.eq
+    else
+     i32.const 0
+    end
+    if
+     i32.const 0
+     i32.const 1456
+     i32.const 155
+     i32.const 1
+     call $~lib/builtins/abort
+     unreachable
+    end
+    global.get $instanceof/nullableBlackcat
+    i32.eqz
+    if
+     i32.const 0
+     i32.const 1456
+     i32.const 157
+     i32.const 1
+     call $~lib/builtins/abort
+     unreachable
+    end
+    global.get $~lib/memory/__stack_pointer
+    global.get $instanceof/nullableBlackcat
+    local.tee $0
+    i32.store $0 offset=52
+    local.get $0
+    if (result i32)
+     block $__inlined_func$~instanceof|instanceof/Cat21 (result i32)
+      block $is_instance22
+       local.get $0
+       i32.const 8
+       i32.sub
+       i32.load $0
+       local.tee $0
+       i32.const 12
+       i32.eq
+       br_if $is_instance22
+       local.get $0
+       i32.const 13
+       i32.eq
+       br_if $is_instance22
+       i32.const 0
+       br $__inlined_func$~instanceof|instanceof/Cat21
+      end
+      i32.const 1
+     end
+    else
+     i32.const 0
+    end
+    i32.eqz
+    if
+     i32.const 0
+     i32.const 1456
+     i32.const 158
+     i32.const 1
+     call $~lib/builtins/abort
+     unreachable
+    end
+    global.get $~lib/memory/__stack_pointer
+    global.get $instanceof/nullableBlackcat
+    local.tee $0
+    i32.store $0 offset=56
+    local.get $0
+    if (result i32)
+     local.get $0
+     i32.const 8
+     i32.sub
+     i32.load $0
+     i32.const 13
+     i32.eq
+    else
+     i32.const 0
+    end
+    i32.eqz
+    if
+     i32.const 0
+     i32.const 1456
+     i32.const 159
+     i32.const 1
+     call $~lib/builtins/abort
+     unreachable
+    end
+    global.get $~lib/memory/__stack_pointer
+    local.tee $0
+    i32.const 0
+    i32.store $0 offset=60
+    local.get $0
+    i32.const 0
+    i32.store $0 offset=64
+    local.get $0
+    i32.const 0
+    i32.store $0 offset=68
+    local.get $0
+    i32.const 0
+    i32.store $0 offset=72
+    local.get $0
+    i32.const 0
+    i32.store $0 offset=76
+    local.get $0
+    i32.const 0
+    i32.store $0 offset=80
+    local.get $0
+    i32.const 4
+    i32.sub
+    global.set $~lib/memory/__stack_pointer
+    global.get $~lib/memory/__stack_pointer
+    i32.const 1564
+    i32.lt_s
+    br_if $folding-inner0
+    global.get $~lib/memory/__stack_pointer
+    local.tee $0
+    i32.const 0
+    i32.store $0
+    local.get $0
+    i32.const 14
+    call $~lib/rt/itcms/__new
+    local.tee $0
+    i32.store $0
+    global.get $~lib/memory/__stack_pointer
+    local.get $0
+    call $~lib/object/Object#constructor
+    local.tee $0
+    i32.store $0
+    global.get $~lib/memory/__stack_pointer
+    i32.const 4
+    i32.add
+    global.set $~lib/memory/__stack_pointer
+    local.get $0
+    global.set $instanceof/a_i1
+    global.get $~lib/memory/__stack_pointer
+    global.get $instanceof/a_i1
+    local.tee $0
+    i32.store $0 offset=84
+    global.get $~lib/memory/__stack_pointer
+    local.get $0
+    i32.store $0 offset=84
+    global.get $~lib/memory/__stack_pointer
+    local.get $0
+    i32.store $0 offset=84
+    global.get $~lib/memory/__stack_pointer
+    local.get $0
+    i32.store $0 offset=84
+    local.get $0
+    if (result i32)
+     block $__inlined_func$~instanceof|instanceof/I1 (result i32)
+      block $is_instance13
+       block $tablify|0
+        local.get $0
+        i32.const 8
+        i32.sub
+        i32.load $0
+        i32.const 14
+        i32.sub
+        br_table $is_instance13 $is_instance13 $tablify|0 $is_instance13 $tablify|0
+       end
+       i32.const 0
+       br $__inlined_func$~instanceof|instanceof/I1
+      end
+      i32.const 1
+     end
+    else
+     i32.const 0
+    end
+    i32.eqz
+    br_if $folding-inner1
+    global.get $~lib/memory/__stack_pointer
+    i32.const 4
+    i32.sub
+    global.set $~lib/memory/__stack_pointer
+    global.get $~lib/memory/__stack_pointer
+    i32.const 1564
+    i32.lt_s
+    br_if $folding-inner0
+    global.get $~lib/memory/__stack_pointer
+    local.tee $0
+    i32.const 0
+    i32.store $0
+    local.get $0
+    i32.const 17
+    call $~lib/rt/itcms/__new
+    local.tee $0
+    i32.store $0
+    global.get $~lib/memory/__stack_pointer
+    local.get $0
+    call $~lib/object/Object#constructor
+    local.tee $0
+    i32.store $0
+    global.get $~lib/memory/__stack_pointer
+    i32.const 4
+    i32.add
+    global.set $~lib/memory/__stack_pointer
+    local.get $0
+    global.set $instanceof/b_i1_i2
+    global.get $~lib/memory/__stack_pointer
+    global.get $instanceof/b_i1_i2
+    local.tee $0
+    i32.store $0 offset=84
+    global.get $~lib/memory/__stack_pointer
+    local.get $0
+    i32.store $0 offset=84
+    global.get $~lib/memory/__stack_pointer
+    global.get $instanceof/a_i1
+    local.tee $0
+    i32.store $0 offset=84
+    global.get $~lib/memory/__stack_pointer
+    local.get $0
+    i32.store $0 offset=84
+    local.get $0
+    if (result i32)
+     local.get $0
+     i32.const 8
+     i32.sub
+     i32.load $0
+     i32.const 17
+     i32.eq
+    else
+     i32.const 0
+    end
+    if
+     i32.const 0
+     i32.const 1456
+     i32.const 19
+     i32.const 5
+     call $~lib/builtins/abort
+     unreachable
+    end
+    global.get $~lib/memory/__stack_pointer
+    global.get $instanceof/b_i1_i2
+    local.tee $0
+    i32.store $0 offset=84
+    local.get $0
+    if (result i32)
+     local.get $0
+     i32.const 8
+     i32.sub
+     i32.load $0
+     i32.const 17
+     i32.eq
+    else
+     i32.const 0
+    end
+    i32.eqz
+    br_if $folding-inner1
+    global.get $~lib/memory/__stack_pointer
+    i32.const 88
+    i32.add
+    global.set $~lib/memory/__stack_pointer
+    return
+   end
+   i32.const 34352
+   i32.const 34400
+   i32.const 1
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  i32.const 0
+  i32.const 1456
+  i32.const 12
+  i32.const 5
+  call $~lib/builtins/abort
+  unreachable
  )
  (func $~lib/object/Object#constructor (type $i32_=>_i32) (param $0 i32) (result i32)
   global.get $~lib/memory/__stack_pointer

--- a/tests/compiler/instanceof.release.wat
+++ b/tests/compiler/instanceof.release.wat
@@ -28,7 +28,8 @@
  (global $instanceof/nullableAnimal (mut i32) (i32.const 0))
  (global $instanceof/nullableCat (mut i32) (i32.const 0))
  (global $instanceof/nullableBlackcat (mut i32) (i32.const 0))
- (global $~lib/memory/__stack_pointer (mut i32) (i32.const 34316))
+ (global $instanceof/impl (mut i32) (i32.const 0))
+ (global $~lib/memory/__stack_pointer (mut i32) (i32.const 34324))
  (memory $0 1)
  (data (i32.const 1036) "<")
  (data (i32.const 1048) "\02\00\00\00(\00\00\00A\00l\00l\00o\00c\00a\00t\00i\00o\00n\00 \00t\00o\00o\00 \00l\00a\00r\00g\00e")
@@ -42,7 +43,7 @@
  (data (i32.const 1384) "\02\00\00\00\1e\00\00\00~\00l\00i\00b\00/\00r\00t\00/\00t\00l\00s\00f\00.\00t\00s")
  (data (i32.const 1436) ",")
  (data (i32.const 1448) "\02\00\00\00\1a\00\00\00i\00n\00s\00t\00a\00n\00c\00e\00o\00f\00.\00t\00s")
- (data (i32.const 1488) "\0e\00\00\00 \00\00\00 \00\00\00 \00\00\00\00\00\00\00 \00\00\00 \00\00\00 \00\00\00 \00\00\00 \00\00\00 \00\00\00 \00\00\00 \00\00\00 \00\00\00 ")
+ (data (i32.const 1488) "\10\00\00\00 \00\00\00 \00\00\00 \00\00\00\00\00\00\00 \00\00\00 \00\00\00 \00\00\00 \00\00\00 \00\00\00 \00\00\00 \00\00\00 \00\00\00 \00\00\00 \00\00\00 \00\00\00 ")
  (export "memory" (memory $0))
  (start $~start)
  (func $~lib/rt/itcms/visitRoots (type $none_=>_none)
@@ -109,6 +110,12 @@
    call $byn-split-outlined-A$~lib/rt/itcms/__visit
   end
   global.get $instanceof/nullableBlackcat
+  local.tee $0
+  if
+   local.get $0
+   call $byn-split-outlined-A$~lib/rt/itcms/__visit
+  end
+  global.get $instanceof/impl
   local.tee $0
   if
    local.get $0
@@ -191,7 +198,7 @@
     i32.load $0 offset=8
     i32.eqz
     local.get $0
-    i32.const 34316
+    i32.const 34324
     i32.lt_u
     i32.and
     i32.eqz
@@ -819,10 +826,10 @@
   if
    unreachable
   end
-  i32.const 34320
+  i32.const 34336
   i32.const 0
   i32.store $0
-  i32.const 35888
+  i32.const 35904
   i32.const 0
   i32.store $0
   loop $for-loop|0
@@ -833,7 +840,7 @@
     local.get $0
     i32.const 2
     i32.shl
-    i32.const 34320
+    i32.const 34336
     i32.add
     i32.const 0
     i32.store $0 offset=4
@@ -851,7 +858,7 @@
       i32.add
       i32.const 2
       i32.shl
-      i32.const 34320
+      i32.const 34336
       i32.add
       i32.const 0
       i32.store $0 offset=96
@@ -869,13 +876,13 @@
     br $for-loop|0
    end
   end
-  i32.const 34320
-  i32.const 35892
+  i32.const 34336
+  i32.const 35908
   memory.size $0
   i32.const 16
   i32.shl
   call $~lib/rt/tlsf/addMemory
-  i32.const 34320
+  i32.const 34336
   global.set $~lib/rt/tlsf/ROOT
  )
  (func $~lib/rt/itcms/step (type $none_=>_i32) (result i32)
@@ -960,7 +967,7 @@
      local.set $0
      loop $while-continue|0
       local.get $0
-      i32.const 34316
+      i32.const 34324
       i32.lt_u
       if
        local.get $0
@@ -1060,7 +1067,7 @@
      unreachable
     end
     local.get $0
-    i32.const 34316
+    i32.const 34324
     i32.lt_u
     if
      local.get $0
@@ -1083,7 +1090,7 @@
      i32.const 4
      i32.add
      local.tee $0
-     i32.const 34316
+     i32.const 34324
      i32.ge_u
      if
       global.get $~lib/rt/tlsf/ROOT
@@ -1439,22 +1446,22 @@
   (local $0 i32)
   (local $1 i32)
   global.get $~lib/memory/__stack_pointer
-  i32.const 84
+  i32.const 88
   i32.sub
   global.set $~lib/memory/__stack_pointer
   block $folding-inner0
    global.get $~lib/memory/__stack_pointer
-   i32.const 1548
+   i32.const 1556
    i32.lt_s
    br_if $folding-inner0
    global.get $~lib/memory/__stack_pointer
    i32.const 0
-   i32.const 84
+   i32.const 88
    memory.fill $0
    memory.size $0
    i32.const 16
    i32.shl
-   i32.const 34316
+   i32.const 34324
    i32.sub
    i32.const 1
    i32.shr_u
@@ -1491,7 +1498,7 @@
    i32.sub
    global.set $~lib/memory/__stack_pointer
    global.get $~lib/memory/__stack_pointer
-   i32.const 1548
+   i32.const 1556
    i32.lt_s
    br_if $folding-inner0
    global.get $~lib/memory/__stack_pointer
@@ -1553,7 +1560,7 @@
    i32.sub
    global.set $~lib/memory/__stack_pointer
    global.get $~lib/memory/__stack_pointer
-   i32.const 1548
+   i32.const 1556
    i32.lt_s
    br_if $folding-inner0
    global.get $~lib/memory/__stack_pointer
@@ -1571,7 +1578,7 @@
    i32.sub
    global.set $~lib/memory/__stack_pointer
    global.get $~lib/memory/__stack_pointer
-   i32.const 1548
+   i32.const 1556
    i32.lt_s
    br_if $folding-inner0
    global.get $~lib/memory/__stack_pointer
@@ -1609,7 +1616,7 @@
    i32.sub
    global.set $~lib/memory/__stack_pointer
    global.get $~lib/memory/__stack_pointer
-   i32.const 1548
+   i32.const 1556
    i32.lt_s
    br_if $folding-inner0
    global.get $~lib/memory/__stack_pointer
@@ -1627,7 +1634,7 @@
    i32.sub
    global.set $~lib/memory/__stack_pointer
    global.get $~lib/memory/__stack_pointer
-   i32.const 1548
+   i32.const 1556
    i32.lt_s
    br_if $folding-inner0
    global.get $~lib/memory/__stack_pointer
@@ -2147,13 +2154,78 @@
    i32.const 0
    i32.store $0 offset=80
    local.get $0
-   i32.const 84
+   i32.const 4
+   i32.sub
+   global.set $~lib/memory/__stack_pointer
+   global.get $~lib/memory/__stack_pointer
+   i32.const 1556
+   i32.lt_s
+   br_if $folding-inner0
+   global.get $~lib/memory/__stack_pointer
+   local.tee $0
+   i32.const 0
+   i32.store $0
+   local.get $0
+   i32.const 14
+   call $~lib/rt/itcms/__new
+   local.tee $0
+   i32.store $0
+   global.get $~lib/memory/__stack_pointer
+   local.get $0
+   call $~lib/object/Object#constructor
+   local.tee $0
+   i32.store $0
+   global.get $~lib/memory/__stack_pointer
+   i32.const 4
+   i32.add
+   global.set $~lib/memory/__stack_pointer
+   local.get $0
+   global.set $instanceof/impl
+   global.get $~lib/memory/__stack_pointer
+   global.get $instanceof/impl
+   local.tee $0
+   i32.store $0 offset=84
+   local.get $0
+   if (result i32)
+    block $__inlined_func$~instanceof|instanceof/IFace (result i32)
+     block $is_instance37
+      local.get $0
+      i32.const 8
+      i32.sub
+      i32.load $0
+      local.tee $0
+      i32.const 15
+      i32.eq
+      br_if $is_instance37
+      local.get $0
+      i32.const 14
+      i32.eq
+      br_if $is_instance37
+      i32.const 0
+      br $__inlined_func$~instanceof|instanceof/IFace
+     end
+     i32.const 1
+    end
+   else
+    i32.const 0
+   end
+   i32.eqz
+   if
+    i32.const 0
+    i32.const 1456
+    i32.const 161
+    i32.const 1
+    call $~lib/builtins/abort
+    unreachable
+   end
+   global.get $~lib/memory/__stack_pointer
+   i32.const 88
    i32.add
    global.set $~lib/memory/__stack_pointer
    return
   end
-  i32.const 34336
-  i32.const 34384
+  i32.const 34352
+  i32.const 34400
   i32.const 1
   i32.const 1
   call $~lib/builtins/abort
@@ -2161,38 +2233,44 @@
  )
  (func $~lib/rt/__visit_members (type $i32_=>_none) (param $0 i32)
   block $invalid
-   block $instanceof/BlackCat
-    block $instanceof/Cat
-     block $instanceof/Animal
-      block $instanceof/SomethingElse<i32>
-       block $instanceof/Parent<f32>
-        block $instanceof/Child<f32>
-         block $instanceof/Parent<i32>
-          block $instanceof/Child<i32>
-           block $instanceof/B
-            block $instanceof/A
-             block $~lib/arraybuffer/ArrayBufferView
-              block $~lib/string/String
-               block $~lib/arraybuffer/ArrayBuffer
-                block $~lib/object/Object
-                 local.get $0
-                 i32.const 8
-                 i32.sub
-                 i32.load $0
-                 br_table $~lib/object/Object $~lib/arraybuffer/ArrayBuffer $~lib/string/String $~lib/arraybuffer/ArrayBufferView $instanceof/A $instanceof/B $instanceof/Child<i32> $instanceof/Parent<i32> $instanceof/Child<f32> $instanceof/Parent<f32> $instanceof/SomethingElse<i32> $instanceof/Animal $instanceof/Cat $instanceof/BlackCat $invalid
+   block $instanceof/IFace
+    block $instanceof/ImplemensIFace
+     block $instanceof/BlackCat
+      block $instanceof/Cat
+       block $instanceof/Animal
+        block $instanceof/SomethingElse<i32>
+         block $instanceof/Parent<f32>
+          block $instanceof/Child<f32>
+           block $instanceof/Parent<i32>
+            block $instanceof/Child<i32>
+             block $instanceof/B
+              block $instanceof/A
+               block $~lib/arraybuffer/ArrayBufferView
+                block $~lib/string/String
+                 block $~lib/arraybuffer/ArrayBuffer
+                  block $~lib/object/Object
+                   local.get $0
+                   i32.const 8
+                   i32.sub
+                   i32.load $0
+                   br_table $~lib/object/Object $~lib/arraybuffer/ArrayBuffer $~lib/string/String $~lib/arraybuffer/ArrayBufferView $instanceof/A $instanceof/B $instanceof/Child<i32> $instanceof/Parent<i32> $instanceof/Child<f32> $instanceof/Parent<f32> $instanceof/SomethingElse<i32> $instanceof/Animal $instanceof/Cat $instanceof/BlackCat $instanceof/ImplemensIFace $instanceof/IFace $invalid
+                  end
+                  return
+                 end
+                 return
                 end
                 return
+               end
+               local.get $0
+               i32.load $0
+               local.tee $0
+               if
+                local.get $0
+                call $byn-split-outlined-A$~lib/rt/itcms/__visit
                end
                return
               end
               return
-             end
-             local.get $0
-             i32.load $0
-             local.tee $0
-             if
-              local.get $0
-              call $byn-split-outlined-A$~lib/rt/itcms/__visit
              end
              return
             end
@@ -2227,11 +2305,11 @@
   i32.sub
   global.set $~lib/memory/__stack_pointer
   global.get $~lib/memory/__stack_pointer
-  i32.const 1548
+  i32.const 1556
   i32.lt_s
   if
-   i32.const 34336
-   i32.const 34384
+   i32.const 34352
+   i32.const 34400
    i32.const 1
    i32.const 1
    call $~lib/builtins/abort
@@ -2261,11 +2339,11 @@
   i32.sub
   global.set $~lib/memory/__stack_pointer
   global.get $~lib/memory/__stack_pointer
-  i32.const 1548
+  i32.const 1556
   i32.lt_s
   if
-   i32.const 34336
-   i32.const 34384
+   i32.const 34352
+   i32.const 34400
    i32.const 1
    i32.const 1
    call $~lib/builtins/abort
@@ -2300,11 +2378,11 @@
   i32.sub
   global.set $~lib/memory/__stack_pointer
   global.get $~lib/memory/__stack_pointer
-  i32.const 1548
+  i32.const 1556
   i32.lt_s
   if
-   i32.const 34336
-   i32.const 34384
+   i32.const 34352
+   i32.const 34400
    i32.const 1
    i32.const 1
    call $~lib/builtins/abort
@@ -2339,11 +2417,11 @@
   i32.sub
   global.set $~lib/memory/__stack_pointer
   global.get $~lib/memory/__stack_pointer
-  i32.const 1548
+  i32.const 1556
   i32.lt_s
   if
-   i32.const 34336
-   i32.const 34384
+   i32.const 34352
+   i32.const 34400
    i32.const 1
    i32.const 1
    call $~lib/builtins/abort
@@ -2379,11 +2457,11 @@
   i32.sub
   global.set $~lib/memory/__stack_pointer
   global.get $~lib/memory/__stack_pointer
-  i32.const 1548
+  i32.const 1556
   i32.lt_s
   if
-   i32.const 34336
-   i32.const 34384
+   i32.const 34352
+   i32.const 34400
    i32.const 1
    i32.const 1
    call $~lib/builtins/abort

--- a/tests/compiler/instanceof.release.wat
+++ b/tests/compiler/instanceof.release.wat
@@ -28,8 +28,9 @@
  (global $instanceof/nullableAnimal (mut i32) (i32.const 0))
  (global $instanceof/nullableCat (mut i32) (i32.const 0))
  (global $instanceof/nullableBlackcat (mut i32) (i32.const 0))
- (global $instanceof/impl (mut i32) (i32.const 0))
- (global $~lib/memory/__stack_pointer (mut i32) (i32.const 34324))
+ (global $instanceof/a_i1 (mut i32) (i32.const 0))
+ (global $instanceof/b_i1_i2 (mut i32) (i32.const 0))
+ (global $~lib/memory/__stack_pointer (mut i32) (i32.const 34332))
  (memory $0 1)
  (data (i32.const 1036) "<")
  (data (i32.const 1048) "\02\00\00\00(\00\00\00A\00l\00l\00o\00c\00a\00t\00i\00o\00n\00 \00t\00o\00o\00 \00l\00a\00r\00g\00e")
@@ -43,7 +44,7 @@
  (data (i32.const 1384) "\02\00\00\00\1e\00\00\00~\00l\00i\00b\00/\00r\00t\00/\00t\00l\00s\00f\00.\00t\00s")
  (data (i32.const 1436) ",")
  (data (i32.const 1448) "\02\00\00\00\1a\00\00\00i\00n\00s\00t\00a\00n\00c\00e\00o\00f\00.\00t\00s")
- (data (i32.const 1488) "\10\00\00\00 \00\00\00 \00\00\00 \00\00\00\00\00\00\00 \00\00\00 \00\00\00 \00\00\00 \00\00\00 \00\00\00 \00\00\00 \00\00\00 \00\00\00 \00\00\00 \00\00\00 \00\00\00 ")
+ (data (i32.const 1488) "\12\00\00\00 \00\00\00 \00\00\00 \00\00\00\00\00\00\00 \00\00\00 \00\00\00 \00\00\00 \00\00\00 \00\00\00 \00\00\00 \00\00\00 \00\00\00 \00\00\00 \00\00\00 \00\00\00 \00\00\00 \00\00\00 ")
  (export "memory" (memory $0))
  (start $~start)
  (func $~lib/rt/itcms/visitRoots (type $none_=>_none)
@@ -115,7 +116,13 @@
    local.get $0
    call $byn-split-outlined-A$~lib/rt/itcms/__visit
   end
-  global.get $instanceof/impl
+  global.get $instanceof/a_i1
+  local.tee $0
+  if
+   local.get $0
+   call $byn-split-outlined-A$~lib/rt/itcms/__visit
+  end
+  global.get $instanceof/b_i1_i2
   local.tee $0
   if
    local.get $0
@@ -198,7 +205,7 @@
     i32.load $0 offset=8
     i32.eqz
     local.get $0
-    i32.const 34324
+    i32.const 34332
     i32.lt_u
     i32.and
     i32.eqz
@@ -967,7 +974,7 @@
      local.set $0
      loop $while-continue|0
       local.get $0
-      i32.const 34324
+      i32.const 34332
       i32.lt_u
       if
        local.get $0
@@ -1067,7 +1074,7 @@
      unreachable
     end
     local.get $0
-    i32.const 34324
+    i32.const 34332
     i32.lt_u
     if
      local.get $0
@@ -1090,7 +1097,7 @@
      i32.const 4
      i32.add
      local.tee $0
-     i32.const 34324
+     i32.const 34332
      i32.ge_u
      if
       global.get $~lib/rt/tlsf/ROOT
@@ -1446,22 +1453,22 @@
   (local $0 i32)
   (local $1 i32)
   global.get $~lib/memory/__stack_pointer
-  i32.const 88
+  i32.const 96
   i32.sub
   global.set $~lib/memory/__stack_pointer
   block $folding-inner0
    global.get $~lib/memory/__stack_pointer
-   i32.const 1556
+   i32.const 1564
    i32.lt_s
    br_if $folding-inner0
    global.get $~lib/memory/__stack_pointer
    i32.const 0
-   i32.const 88
+   i32.const 96
    memory.fill $0
    memory.size $0
    i32.const 16
    i32.shl
-   i32.const 34324
+   i32.const 34332
    i32.sub
    i32.const 1
    i32.shr_u
@@ -1498,7 +1505,7 @@
    i32.sub
    global.set $~lib/memory/__stack_pointer
    global.get $~lib/memory/__stack_pointer
-   i32.const 1556
+   i32.const 1564
    i32.lt_s
    br_if $folding-inner0
    global.get $~lib/memory/__stack_pointer
@@ -1560,7 +1567,7 @@
    i32.sub
    global.set $~lib/memory/__stack_pointer
    global.get $~lib/memory/__stack_pointer
-   i32.const 1556
+   i32.const 1564
    i32.lt_s
    br_if $folding-inner0
    global.get $~lib/memory/__stack_pointer
@@ -1578,7 +1585,7 @@
    i32.sub
    global.set $~lib/memory/__stack_pointer
    global.get $~lib/memory/__stack_pointer
-   i32.const 1556
+   i32.const 1564
    i32.lt_s
    br_if $folding-inner0
    global.get $~lib/memory/__stack_pointer
@@ -1616,7 +1623,7 @@
    i32.sub
    global.set $~lib/memory/__stack_pointer
    global.get $~lib/memory/__stack_pointer
-   i32.const 1556
+   i32.const 1564
    i32.lt_s
    br_if $folding-inner0
    global.get $~lib/memory/__stack_pointer
@@ -1634,7 +1641,7 @@
    i32.sub
    global.set $~lib/memory/__stack_pointer
    global.get $~lib/memory/__stack_pointer
-   i32.const 1556
+   i32.const 1564
    i32.lt_s
    br_if $folding-inner0
    global.get $~lib/memory/__stack_pointer
@@ -2158,7 +2165,7 @@
    i32.sub
    global.set $~lib/memory/__stack_pointer
    global.get $~lib/memory/__stack_pointer
-   i32.const 1556
+   i32.const 1564
    i32.lt_s
    br_if $folding-inner0
    global.get $~lib/memory/__stack_pointer
@@ -2180,29 +2187,26 @@
    i32.add
    global.set $~lib/memory/__stack_pointer
    local.get $0
-   global.set $instanceof/impl
+   global.set $instanceof/a_i1
    global.get $~lib/memory/__stack_pointer
-   global.get $instanceof/impl
+   global.get $instanceof/a_i1
    local.tee $0
    i32.store $0 offset=84
    local.get $0
    if (result i32)
-    block $__inlined_func$~instanceof|instanceof/IFace (result i32)
+    block $__inlined_func$~instanceof|instanceof/I1 (result i32)
      block $is_instance37
-      local.get $0
-      i32.const 8
-      i32.sub
-      i32.load $0
-      local.tee $0
-      i32.const 15
-      i32.eq
-      br_if $is_instance37
-      local.get $0
-      i32.const 14
-      i32.eq
-      br_if $is_instance37
+      block $tablify|0
+       local.get $0
+       i32.const 8
+       i32.sub
+       i32.load $0
+       i32.const 14
+       i32.sub
+       br_table $is_instance37 $is_instance37 $tablify|0 $is_instance37 $tablify|0
+      end
       i32.const 0
-      br $__inlined_func$~instanceof|instanceof/IFace
+      br $__inlined_func$~instanceof|instanceof/I1
      end
      i32.const 1
     end
@@ -2213,13 +2217,88 @@
    if
     i32.const 0
     i32.const 1456
-    i32.const 161
+    i32.const 165
     i32.const 1
     call $~lib/builtins/abort
     unreachable
    end
    global.get $~lib/memory/__stack_pointer
-   i32.const 88
+   i32.const 4
+   i32.sub
+   global.set $~lib/memory/__stack_pointer
+   global.get $~lib/memory/__stack_pointer
+   i32.const 1564
+   i32.lt_s
+   br_if $folding-inner0
+   global.get $~lib/memory/__stack_pointer
+   local.tee $0
+   i32.const 0
+   i32.store $0
+   local.get $0
+   i32.const 17
+   call $~lib/rt/itcms/__new
+   local.tee $0
+   i32.store $0
+   global.get $~lib/memory/__stack_pointer
+   local.get $0
+   call $~lib/object/Object#constructor
+   local.tee $0
+   i32.store $0
+   global.get $~lib/memory/__stack_pointer
+   i32.const 4
+   i32.add
+   global.set $~lib/memory/__stack_pointer
+   local.get $0
+   global.set $instanceof/b_i1_i2
+   global.get $~lib/memory/__stack_pointer
+   global.get $instanceof/a_i1
+   local.tee $0
+   i32.store $0 offset=88
+   local.get $0
+   if (result i32)
+    local.get $0
+    i32.const 8
+    i32.sub
+    i32.load $0
+    i32.const 17
+    i32.eq
+   else
+    i32.const 0
+   end
+   if
+    i32.const 0
+    i32.const 1456
+    i32.const 172
+    i32.const 1
+    call $~lib/builtins/abort
+    unreachable
+   end
+   global.get $~lib/memory/__stack_pointer
+   global.get $instanceof/b_i1_i2
+   local.tee $0
+   i32.store $0 offset=92
+   local.get $0
+   if (result i32)
+    local.get $0
+    i32.const 8
+    i32.sub
+    i32.load $0
+    i32.const 17
+    i32.eq
+   else
+    i32.const 0
+   end
+   i32.eqz
+   if
+    i32.const 0
+    i32.const 1456
+    i32.const 173
+    i32.const 1
+    call $~lib/builtins/abort
+    unreachable
+   end
+   global.get $~lib/memory/__stack_pointer
+   i32.const 96
    i32.add
    global.set $~lib/memory/__stack_pointer
    return
@@ -2233,40 +2312,46 @@
  )
  (func $~lib/rt/__visit_members (type $i32_=>_none) (param $0 i32)
   block $invalid
-   block $instanceof/IFace
-    block $instanceof/ImplemensIFace
-     block $instanceof/BlackCat
-      block $instanceof/Cat
-       block $instanceof/Animal
-        block $instanceof/SomethingElse<i32>
-         block $instanceof/Parent<f32>
-          block $instanceof/Child<f32>
-           block $instanceof/Parent<i32>
-            block $instanceof/Child<i32>
-             block $instanceof/B
-              block $instanceof/A
-               block $~lib/arraybuffer/ArrayBufferView
-                block $~lib/string/String
-                 block $~lib/arraybuffer/ArrayBuffer
-                  block $~lib/object/Object
-                   local.get $0
-                   i32.const 8
-                   i32.sub
-                   i32.load $0
-                   br_table $~lib/object/Object $~lib/arraybuffer/ArrayBuffer $~lib/string/String $~lib/arraybuffer/ArrayBufferView $instanceof/A $instanceof/B $instanceof/Child<i32> $instanceof/Parent<i32> $instanceof/Child<f32> $instanceof/Parent<f32> $instanceof/SomethingElse<i32> $instanceof/Animal $instanceof/Cat $instanceof/BlackCat $instanceof/ImplemensIFace $instanceof/IFace $invalid
+   block $instanceof/B_I1_I2
+    block $instanceof/I2
+     block $instanceof/I1
+      block $instanceof/A_I1
+       block $instanceof/BlackCat
+        block $instanceof/Cat
+         block $instanceof/Animal
+          block $instanceof/SomethingElse<i32>
+           block $instanceof/Parent<f32>
+            block $instanceof/Child<f32>
+             block $instanceof/Parent<i32>
+              block $instanceof/Child<i32>
+               block $instanceof/B
+                block $instanceof/A
+                 block $~lib/arraybuffer/ArrayBufferView
+                  block $~lib/string/String
+                   block $~lib/arraybuffer/ArrayBuffer
+                    block $~lib/object/Object
+                     local.get $0
+                     i32.const 8
+                     i32.sub
+                     i32.load $0
+                     br_table $~lib/object/Object $~lib/arraybuffer/ArrayBuffer $~lib/string/String $~lib/arraybuffer/ArrayBufferView $instanceof/A $instanceof/B $instanceof/Child<i32> $instanceof/Parent<i32> $instanceof/Child<f32> $instanceof/Parent<f32> $instanceof/SomethingElse<i32> $instanceof/Animal $instanceof/Cat $instanceof/BlackCat $instanceof/A_I1 $instanceof/I1 $instanceof/I2 $instanceof/B_I1_I2 $invalid
+                    end
+                    return
+                   end
+                   return
                   end
                   return
+                 end
+                 local.get $0
+                 i32.load $0
+                 local.tee $0
+                 if
+                  local.get $0
+                  call $byn-split-outlined-A$~lib/rt/itcms/__visit
                  end
                  return
                 end
                 return
-               end
-               local.get $0
-               i32.load $0
-               local.tee $0
-               if
-                local.get $0
-                call $byn-split-outlined-A$~lib/rt/itcms/__visit
                end
                return
               end
@@ -2305,7 +2390,7 @@
   i32.sub
   global.set $~lib/memory/__stack_pointer
   global.get $~lib/memory/__stack_pointer
-  i32.const 1556
+  i32.const 1564
   i32.lt_s
   if
    i32.const 34352
@@ -2339,7 +2424,7 @@
   i32.sub
   global.set $~lib/memory/__stack_pointer
   global.get $~lib/memory/__stack_pointer
-  i32.const 1556
+  i32.const 1564
   i32.lt_s
   if
    i32.const 34352
@@ -2378,7 +2463,7 @@
   i32.sub
   global.set $~lib/memory/__stack_pointer
   global.get $~lib/memory/__stack_pointer
-  i32.const 1556
+  i32.const 1564
   i32.lt_s
   if
    i32.const 34352
@@ -2417,7 +2502,7 @@
   i32.sub
   global.set $~lib/memory/__stack_pointer
   global.get $~lib/memory/__stack_pointer
-  i32.const 1556
+  i32.const 1564
   i32.lt_s
   if
    i32.const 34352
@@ -2457,7 +2542,7 @@
   i32.sub
   global.set $~lib/memory/__stack_pointer
   global.get $~lib/memory/__stack_pointer
-  i32.const 1556
+  i32.const 1564
   i32.lt_s
   if
    i32.const 34352

--- a/tests/compiler/instanceof.release.wat
+++ b/tests/compiler/instanceof.release.wat
@@ -1,7 +1,7 @@
 (module
+ (type $i32_=>_none (func_subtype (param i32) func))
  (type $i32_=>_i32 (func_subtype (param i32) (result i32) func))
  (type $none_=>_none (func_subtype func))
- (type $i32_=>_none (func_subtype (param i32) func))
  (type $i32_i32_=>_none (func_subtype (param i32 i32) func))
  (type $none_=>_i32 (func_subtype (result i32) func))
  (type $i32_i32_i32_i32_=>_none (func_subtype (param i32 i32 i32 i32) func))
@@ -28,9 +28,11 @@
  (global $instanceof/nullableAnimal (mut i32) (i32.const 0))
  (global $instanceof/nullableCat (mut i32) (i32.const 0))
  (global $instanceof/nullableBlackcat (mut i32) (i32.const 0))
- (global $instanceof/a_i1 (mut i32) (i32.const 0))
- (global $instanceof/b_i1_i2 (mut i32) (i32.const 0))
- (global $~lib/memory/__stack_pointer (mut i32) (i32.const 34332))
+ (global $instanceof/w (mut i32) (i32.const 0))
+ (global $instanceof/x (mut i32) (i32.const 0))
+ (global $instanceof/y (mut i32) (i32.const 0))
+ (global $instanceof/z (mut i32) (i32.const 0))
+ (global $~lib/memory/__stack_pointer (mut i32) (i32.const 34352))
  (memory $0 1)
  (data (i32.const 1036) "<")
  (data (i32.const 1048) "\02\00\00\00(\00\00\00A\00l\00l\00o\00c\00a\00t\00i\00o\00n\00 \00t\00o\00o\00 \00l\00a\00r\00g\00e")
@@ -44,7 +46,7 @@
  (data (i32.const 1384) "\02\00\00\00\1e\00\00\00~\00l\00i\00b\00/\00r\00t\00/\00t\00l\00s\00f\00.\00t\00s")
  (data (i32.const 1436) ",")
  (data (i32.const 1448) "\02\00\00\00\1a\00\00\00i\00n\00s\00t\00a\00n\00c\00e\00o\00f\00.\00t\00s")
- (data (i32.const 1488) "\12\00\00\00 \00\00\00 \00\00\00 \00\00\00\00\00\00\00 \00\00\00 \00\00\00 \00\00\00 \00\00\00 \00\00\00 \00\00\00 \00\00\00 \00\00\00 \00\00\00 \00\00\00 \00\00\00 \00\00\00 \00\00\00 ")
+ (data (i32.const 1488) "\17\00\00\00 \00\00\00 \00\00\00 \00\00\00\00\00\00\00 \00\00\00 \00\00\00 \00\00\00 \00\00\00 \00\00\00 \00\00\00 \00\00\00 \00\00\00 \00\00\00 \00\00\00 \00\00\00 \00\00\00 \00\00\00 \00\00\00 \00\00\00 \00\00\00 \00\00\00 \00\00\00 ")
  (export "memory" (memory $0))
  (start $~start)
  (func $~lib/rt/itcms/visitRoots (type $none_=>_none)
@@ -116,13 +118,25 @@
    local.get $0
    call $byn-split-outlined-A$~lib/rt/itcms/__visit
   end
-  global.get $instanceof/a_i1
+  global.get $instanceof/w
   local.tee $0
   if
    local.get $0
    call $byn-split-outlined-A$~lib/rt/itcms/__visit
   end
-  global.get $instanceof/b_i1_i2
+  global.get $instanceof/x
+  local.tee $0
+  if
+   local.get $0
+   call $byn-split-outlined-A$~lib/rt/itcms/__visit
+  end
+  global.get $instanceof/y
+  local.tee $0
+  if
+   local.get $0
+   call $byn-split-outlined-A$~lib/rt/itcms/__visit
+  end
+  global.get $instanceof/z
   local.tee $0
   if
    local.get $0
@@ -205,7 +219,7 @@
     i32.load $0 offset=8
     i32.eqz
     local.get $0
-    i32.const 34332
+    i32.const 34352
     i32.lt_u
     i32.and
     i32.eqz
@@ -833,10 +847,10 @@
   if
    unreachable
   end
-  i32.const 34336
+  i32.const 34352
   i32.const 0
   i32.store $0
-  i32.const 35904
+  i32.const 35920
   i32.const 0
   i32.store $0
   loop $for-loop|0
@@ -847,7 +861,7 @@
     local.get $0
     i32.const 2
     i32.shl
-    i32.const 34336
+    i32.const 34352
     i32.add
     i32.const 0
     i32.store $0 offset=4
@@ -865,7 +879,7 @@
       i32.add
       i32.const 2
       i32.shl
-      i32.const 34336
+      i32.const 34352
       i32.add
       i32.const 0
       i32.store $0 offset=96
@@ -883,13 +897,13 @@
     br $for-loop|0
    end
   end
-  i32.const 34336
-  i32.const 35908
+  i32.const 34352
+  i32.const 35924
   memory.size $0
   i32.const 16
   i32.shl
   call $~lib/rt/tlsf/addMemory
-  i32.const 34336
+  i32.const 34352
   global.set $~lib/rt/tlsf/ROOT
  )
  (func $~lib/rt/itcms/step (type $none_=>_i32) (result i32)
@@ -974,7 +988,7 @@
      local.set $0
      loop $while-continue|0
       local.get $0
-      i32.const 34332
+      i32.const 34352
       i32.lt_u
       if
        local.get $0
@@ -1074,7 +1088,7 @@
      unreachable
     end
     local.get $0
-    i32.const 34332
+    i32.const 34352
     i32.lt_u
     if
      local.get $0
@@ -1097,7 +1111,7 @@
      i32.const 4
      i32.add
      local.tee $0
-     i32.const 34332
+     i32.const 34352
      i32.ge_u
      if
       global.get $~lib/rt/tlsf/ROOT
@@ -1449,44 +1463,203 @@
   memory.fill $0
   local.get $0
  )
+ (func $instanceof/assertDynamicTrue<~lib/object/Object,instanceof/X> (type $i32_=>_none) (param $0 i32)
+  local.get $0
+  if (result i32)
+   block $__inlined_func$~instanceof|instanceof/X (result i32)
+    block $is_instance
+     block $tablify|0
+      local.get $0
+      i32.const 8
+      i32.sub
+      i32.load $0
+      i32.const 15
+      i32.sub
+      br_table $is_instance $tablify|0 $tablify|0 $is_instance $tablify|0 $tablify|0 $is_instance $tablify|0
+     end
+     i32.const 0
+     br $__inlined_func$~instanceof|instanceof/X
+    end
+    i32.const 1
+   end
+  else
+   i32.const 0
+  end
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1456
+   i32.const 12
+   i32.const 5
+   call $~lib/builtins/abort
+   unreachable
+  end
+ )
+ (func $instanceof/assertDynamicTrue<~lib/object/Object,instanceof/Y> (type $i32_=>_none) (param $0 i32)
+  local.get $0
+  if (result i32)
+   block $__inlined_func$~instanceof|instanceof/Y (result i32)
+    block $is_instance
+     local.get $0
+     i32.const 8
+     i32.sub
+     i32.load $0
+     local.tee $0
+     i32.const 18
+     i32.eq
+     br_if $is_instance
+     local.get $0
+     i32.const 21
+     i32.eq
+     br_if $is_instance
+     i32.const 0
+     br $__inlined_func$~instanceof|instanceof/Y
+    end
+    i32.const 1
+   end
+  else
+   i32.const 0
+  end
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1456
+   i32.const 12
+   i32.const 5
+   call $~lib/builtins/abort
+   unreachable
+  end
+ )
+ (func $instanceof/assertDynamicTrue<~lib/object/Object,instanceof/Z> (type $i32_=>_none) (param $0 i32)
+  local.get $0
+  if (result i32)
+   local.get $0
+   i32.const 8
+   i32.sub
+   i32.load $0
+   i32.const 21
+   i32.eq
+  else
+   i32.const 0
+  end
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1456
+   i32.const 12
+   i32.const 5
+   call $~lib/builtins/abort
+   unreachable
+  end
+ )
+ (func $instanceof/assertDynamicFalse<instanceof/X,instanceof/Y> (type $i32_=>_none) (param $0 i32)
+  local.get $0
+  if (result i32)
+   block $__inlined_func$~instanceof|instanceof/Y (result i32)
+    block $is_instance
+     local.get $0
+     i32.const 8
+     i32.sub
+     i32.load $0
+     local.tee $0
+     i32.const 18
+     i32.eq
+     br_if $is_instance
+     local.get $0
+     i32.const 21
+     i32.eq
+     br_if $is_instance
+     i32.const 0
+     br $__inlined_func$~instanceof|instanceof/Y
+    end
+    i32.const 1
+   end
+  else
+   i32.const 0
+  end
+  if
+   i32.const 0
+   i32.const 1456
+   i32.const 19
+   i32.const 5
+   call $~lib/builtins/abort
+   unreachable
+  end
+ )
+ (func $instanceof/assertDynamicFalse<instanceof/X,instanceof/Z> (type $i32_=>_none) (param $0 i32)
+  local.get $0
+  if (result i32)
+   local.get $0
+   i32.const 8
+   i32.sub
+   i32.load $0
+   i32.const 21
+   i32.eq
+  else
+   i32.const 0
+  end
+  if
+   i32.const 0
+   i32.const 1456
+   i32.const 19
+   i32.const 5
+   call $~lib/builtins/abort
+   unreachable
+  end
+ )
  (func $~lib/rt/__visit_members (type $i32_=>_none) (param $0 i32)
   block $invalid
-   block $instanceof/B_I1_I2
-    block $instanceof/I2
-     block $instanceof/I1
-      block $instanceof/A_I1
-       block $instanceof/BlackCat
-        block $instanceof/Cat
-         block $instanceof/Animal
-          block $instanceof/SomethingElse<i32>
-           block $instanceof/Parent<f32>
-            block $instanceof/Child<f32>
-             block $instanceof/Parent<i32>
-              block $instanceof/Child<i32>
-               block $instanceof/B
-                block $instanceof/A
-                 block $~lib/arraybuffer/ArrayBufferView
-                  block $~lib/string/String
-                   block $~lib/arraybuffer/ArrayBuffer
-                    block $~lib/object/Object
-                     local.get $0
-                     i32.const 8
-                     i32.sub
-                     i32.load $0
-                     br_table $~lib/object/Object $~lib/arraybuffer/ArrayBuffer $~lib/string/String $~lib/arraybuffer/ArrayBufferView $instanceof/A $instanceof/B $instanceof/Child<i32> $instanceof/Parent<i32> $instanceof/Child<f32> $instanceof/Parent<f32> $instanceof/SomethingElse<i32> $instanceof/Animal $instanceof/Cat $instanceof/BlackCat $instanceof/A_I1 $instanceof/I1 $instanceof/I2 $instanceof/B_I1_I2 $invalid
+   block $instanceof/IE
+    block $instanceof/Z
+     block $instanceof/IC
+      block $instanceof/ID
+       block $instanceof/Y
+        block $instanceof/IA
+         block $instanceof/IB
+          block $instanceof/X
+           block $instanceof/W
+            block $instanceof/BlackCat
+             block $instanceof/Cat
+              block $instanceof/Animal
+               block $instanceof/SomethingElse<i32>
+                block $instanceof/Parent<f32>
+                 block $instanceof/Child<f32>
+                  block $instanceof/Parent<i32>
+                   block $instanceof/Child<i32>
+                    block $instanceof/B
+                     block $instanceof/A
+                      block $~lib/arraybuffer/ArrayBufferView
+                       block $~lib/string/String
+                        block $~lib/arraybuffer/ArrayBuffer
+                         block $~lib/object/Object
+                          local.get $0
+                          i32.const 8
+                          i32.sub
+                          i32.load $0
+                          br_table $~lib/object/Object $~lib/arraybuffer/ArrayBuffer $~lib/string/String $~lib/arraybuffer/ArrayBufferView $instanceof/A $instanceof/B $instanceof/Child<i32> $instanceof/Parent<i32> $instanceof/Child<f32> $instanceof/Parent<f32> $instanceof/SomethingElse<i32> $instanceof/Animal $instanceof/Cat $instanceof/BlackCat $instanceof/W $instanceof/X $instanceof/IB $instanceof/IA $instanceof/Y $instanceof/ID $instanceof/IC $instanceof/Z $instanceof/IE $invalid
+                         end
+                         return
+                        end
+                        return
+                       end
+                       return
+                      end
+                      local.get $0
+                      i32.load $0
+                      local.tee $0
+                      if
+                       local.get $0
+                       call $byn-split-outlined-A$~lib/rt/itcms/__visit
+                      end
+                      return
+                     end
+                     return
                     end
                     return
                    end
                    return
                   end
                   return
-                 end
-                 local.get $0
-                 i32.load $0
-                 local.tee $0
-                 if
-                  local.get $0
-                  call $byn-split-outlined-A$~lib/rt/itcms/__visit
                  end
                  return
                 end
@@ -1526,877 +1699,1389 @@
  (func $start:instanceof (type $none_=>_none)
   (local $0 i32)
   (local $1 i32)
+  (local $2 i32)
+  (local $3 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 88
   i32.sub
   global.set $~lib/memory/__stack_pointer
-  block $folding-inner1
-   block $folding-inner0
-    global.get $~lib/memory/__stack_pointer
-    i32.const 1564
-    i32.lt_s
-    br_if $folding-inner0
-    global.get $~lib/memory/__stack_pointer
-    i32.const 0
-    i32.const 88
-    memory.fill $0
-    memory.size $0
-    i32.const 16
-    i32.shl
-    i32.const 34332
-    i32.sub
-    i32.const 1
-    i32.shr_u
-    global.set $~lib/rt/itcms/threshold
-    i32.const 1172
-    i32.const 1168
-    i32.store $0
-    i32.const 1176
-    i32.const 1168
-    i32.store $0
-    i32.const 1168
-    global.set $~lib/rt/itcms/pinSpace
-    i32.const 1204
-    i32.const 1200
-    i32.store $0
-    i32.const 1208
-    i32.const 1200
-    i32.store $0
-    i32.const 1200
-    global.set $~lib/rt/itcms/toSpace
-    i32.const 1348
-    i32.const 1344
-    i32.store $0
-    i32.const 1352
-    i32.const 1344
-    i32.store $0
-    i32.const 1344
-    global.set $~lib/rt/itcms/fromSpace
-    i32.const 0
-    call $instanceof/A#constructor
-    global.set $instanceof/a
-    global.get $~lib/memory/__stack_pointer
-    i32.const 4
-    i32.sub
-    global.set $~lib/memory/__stack_pointer
-    global.get $~lib/memory/__stack_pointer
-    i32.const 1564
-    i32.lt_s
-    br_if $folding-inner0
-    global.get $~lib/memory/__stack_pointer
-    local.tee $0
-    i32.const 0
-    i32.store $0
-    local.get $0
-    i32.const 5
-    call $~lib/rt/itcms/__new
-    local.tee $0
-    i32.store $0
-    global.get $~lib/memory/__stack_pointer
-    local.get $0
-    call $instanceof/A#constructor
-    local.tee $0
-    i32.store $0
-    global.get $~lib/memory/__stack_pointer
-    i32.const 4
-    i32.add
-    global.set $~lib/memory/__stack_pointer
-    local.get $0
-    global.set $instanceof/b
-    global.get $~lib/memory/__stack_pointer
-    global.get $instanceof/a
-    local.tee $0
-    i32.store $0
-    local.get $0
-    if (result i32)
-     local.get $0
-     i32.const 8
-     i32.sub
-     i32.load $0
-     i32.const 5
-     i32.eq
-    else
-     i32.const 0
-    end
-    if
-     i32.const 0
-     i32.const 1456
-     i32.const 41
-     i32.const 1
-     call $~lib/builtins/abort
-     unreachable
-    end
-    global.get $instanceof/an
-    if
-     i32.const 0
-     i32.const 1456
-     i32.const 91
-     i32.const 1
-     call $~lib/builtins/abort
-     unreachable
-    end
-    i32.const 1
-    global.set $instanceof/an
-    global.get $~lib/memory/__stack_pointer
-    i32.const 4
-    i32.sub
-    global.set $~lib/memory/__stack_pointer
-    global.get $~lib/memory/__stack_pointer
-    i32.const 1564
-    i32.lt_s
-    br_if $folding-inner0
-    global.get $~lib/memory/__stack_pointer
-    local.tee $0
-    i32.const 0
-    i32.store $0
-    local.get $0
-    i32.const 6
-    call $~lib/rt/itcms/__new
-    local.tee $0
-    i32.store $0
-    global.get $~lib/memory/__stack_pointer
-    local.tee $1
-    i32.const 4
-    i32.sub
-    global.set $~lib/memory/__stack_pointer
-    global.get $~lib/memory/__stack_pointer
-    i32.const 1564
-    i32.lt_s
-    br_if $folding-inner0
-    global.get $~lib/memory/__stack_pointer
-    i32.const 0
-    i32.store $0
-    local.get $0
-    i32.eqz
-    if
-     global.get $~lib/memory/__stack_pointer
-     i32.const 7
-     call $~lib/rt/itcms/__new
-     local.tee $0
-     i32.store $0
-    end
-    global.get $~lib/memory/__stack_pointer
-    local.get $0
-    call $~lib/object/Object#constructor
-    local.tee $0
-    i32.store $0
-    global.get $~lib/memory/__stack_pointer
-    i32.const 4
-    i32.add
-    global.set $~lib/memory/__stack_pointer
-    local.get $1
-    local.get $0
-    i32.store $0
-    global.get $~lib/memory/__stack_pointer
-    i32.const 4
-    i32.add
-    global.set $~lib/memory/__stack_pointer
-    local.get $0
-    global.set $instanceof/child
-    global.get $~lib/memory/__stack_pointer
-    i32.const 4
-    i32.sub
-    global.set $~lib/memory/__stack_pointer
-    global.get $~lib/memory/__stack_pointer
-    i32.const 1564
-    i32.lt_s
-    br_if $folding-inner0
-    global.get $~lib/memory/__stack_pointer
-    local.tee $0
-    i32.const 0
-    i32.store $0
+  block $folding-inner0
+   global.get $~lib/memory/__stack_pointer
+   i32.const 1584
+   i32.lt_s
+   br_if $folding-inner0
+   global.get $~lib/memory/__stack_pointer
+   i32.const 0
+   i32.const 88
+   memory.fill $0
+   memory.size $0
+   i32.const 16
+   i32.shl
+   i32.const 34352
+   i32.sub
+   i32.const 1
+   i32.shr_u
+   global.set $~lib/rt/itcms/threshold
+   i32.const 1172
+   i32.const 1168
+   i32.store $0
+   i32.const 1176
+   i32.const 1168
+   i32.store $0
+   i32.const 1168
+   global.set $~lib/rt/itcms/pinSpace
+   i32.const 1204
+   i32.const 1200
+   i32.store $0
+   i32.const 1208
+   i32.const 1200
+   i32.store $0
+   i32.const 1200
+   global.set $~lib/rt/itcms/toSpace
+   i32.const 1348
+   i32.const 1344
+   i32.store $0
+   i32.const 1352
+   i32.const 1344
+   i32.store $0
+   i32.const 1344
+   global.set $~lib/rt/itcms/fromSpace
+   i32.const 0
+   call $instanceof/A#constructor
+   global.set $instanceof/a
+   global.get $~lib/memory/__stack_pointer
+   i32.const 4
+   i32.sub
+   global.set $~lib/memory/__stack_pointer
+   global.get $~lib/memory/__stack_pointer
+   i32.const 1584
+   i32.lt_s
+   br_if $folding-inner0
+   global.get $~lib/memory/__stack_pointer
+   local.tee $0
+   i32.const 0
+   i32.store $0
+   local.get $0
+   i32.const 5
+   call $~lib/rt/itcms/__new
+   local.tee $0
+   i32.store $0
+   global.get $~lib/memory/__stack_pointer
+   local.get $0
+   call $instanceof/A#constructor
+   local.tee $0
+   i32.store $0
+   global.get $~lib/memory/__stack_pointer
+   i32.const 4
+   i32.add
+   global.set $~lib/memory/__stack_pointer
+   local.get $0
+   global.set $instanceof/b
+   global.get $~lib/memory/__stack_pointer
+   global.get $instanceof/a
+   local.tee $0
+   i32.store $0
+   local.get $0
+   if (result i32)
     local.get $0
     i32.const 8
-    call $~lib/rt/itcms/__new
-    local.tee $0
-    i32.store $0
-    global.get $~lib/memory/__stack_pointer
-    local.tee $1
-    i32.const 4
     i32.sub
-    global.set $~lib/memory/__stack_pointer
-    global.get $~lib/memory/__stack_pointer
-    i32.const 1564
-    i32.lt_s
-    br_if $folding-inner0
-    global.get $~lib/memory/__stack_pointer
+    i32.load $0
+    i32.const 5
+    i32.eq
+   else
     i32.const 0
-    i32.store $0
-    local.get $0
-    i32.eqz
-    if
-     global.get $~lib/memory/__stack_pointer
-     i32.const 9
-     call $~lib/rt/itcms/__new
-     local.tee $0
-     i32.store $0
-    end
-    global.get $~lib/memory/__stack_pointer
-    local.get $0
-    call $~lib/object/Object#constructor
-    local.tee $0
-    i32.store $0
-    global.get $~lib/memory/__stack_pointer
-    i32.const 4
-    i32.add
-    global.set $~lib/memory/__stack_pointer
-    local.get $1
-    local.get $0
-    i32.store $0
-    global.get $~lib/memory/__stack_pointer
-    i32.const 4
-    i32.add
-    global.set $~lib/memory/__stack_pointer
-    local.get $0
-    global.set $instanceof/childAsParent
-    global.get $~lib/memory/__stack_pointer
-    global.get $instanceof/childAsParent
-    local.tee $0
-    i32.store $0 offset=4
-    local.get $0
-    if (result i32)
-     local.get $0
-     i32.const 8
-     i32.sub
-     i32.load $0
-     i32.const 8
-     i32.eq
-    else
-     i32.const 0
-    end
-    i32.eqz
-    if
-     i32.const 0
-     i32.const 1456
-     i32.const 117
-     i32.const 1
-     call $~lib/builtins/abort
-     unreachable
-    end
-    global.get $~lib/memory/__stack_pointer
-    global.get $instanceof/childAsParent
-    local.tee $0
-    i32.store $0 offset=8
-    local.get $0
-    if (result i32)
-     block $__inlined_func$~anyinstanceof|instanceof/Child (result i32)
-      block $is_instance2
-       local.get $0
-       i32.const 8
-       i32.sub
-       i32.load $0
-       local.tee $0
-       i32.const 6
-       i32.eq
-       br_if $is_instance2
-       local.get $0
-       i32.const 8
-       i32.eq
-       br_if $is_instance2
-       i32.const 0
-       br $__inlined_func$~anyinstanceof|instanceof/Child
-      end
-      i32.const 1
-     end
-    else
-     i32.const 0
-    end
-    i32.eqz
-    if
-     i32.const 0
-     i32.const 1456
-     i32.const 119
-     i32.const 1
-     call $~lib/builtins/abort
-     unreachable
-    end
-    i32.const 0
-    call $instanceof/Animal#constructor
-    global.set $instanceof/animal
-    i32.const 0
-    call $instanceof/Cat#constructor
-    global.set $instanceof/cat
-    call $instanceof/BlackCat#constructor
-    global.set $instanceof/blackcat
-    global.get $~lib/memory/__stack_pointer
-    global.get $instanceof/animal
-    local.tee $0
-    i32.store $0 offset=12
-    local.get $0
-    if (result i32)
-     block $__inlined_func$~instanceof|instanceof/Cat (result i32)
-      block $is_instance3
-       local.get $0
-       i32.const 8
-       i32.sub
-       i32.load $0
-       local.tee $0
-       i32.const 12
-       i32.eq
-       br_if $is_instance3
-       local.get $0
-       i32.const 13
-       i32.eq
-       br_if $is_instance3
-       i32.const 0
-       br $__inlined_func$~instanceof|instanceof/Cat
-      end
-      i32.const 1
-     end
-    else
-     i32.const 0
-    end
-    if
-     i32.const 0
-     i32.const 1456
-     i32.const 134
-     i32.const 1
-     call $~lib/builtins/abort
-     unreachable
-    end
-    global.get $~lib/memory/__stack_pointer
-    global.get $instanceof/animal
-    local.tee $0
-    i32.store $0 offset=16
-    local.get $0
-    if (result i32)
-     local.get $0
-     i32.const 8
-     i32.sub
-     i32.load $0
-     i32.const 13
-     i32.eq
-    else
-     i32.const 0
-    end
-    if
-     i32.const 0
-     i32.const 1456
-     i32.const 135
-     i32.const 1
-     call $~lib/builtins/abort
-     unreachable
-    end
-    global.get $~lib/memory/__stack_pointer
-    global.get $instanceof/cat
-    local.tee $0
-    i32.store $0 offset=20
-    local.get $0
-    if (result i32)
-     block $__inlined_func$~instanceof|instanceof/Cat5 (result i32)
-      block $is_instance6
-       local.get $0
-       i32.const 8
-       i32.sub
-       i32.load $0
-       local.tee $0
-       i32.const 12
-       i32.eq
-       br_if $is_instance6
-       local.get $0
-       i32.const 13
-       i32.eq
-       br_if $is_instance6
-       i32.const 0
-       br $__inlined_func$~instanceof|instanceof/Cat5
-      end
-      i32.const 1
-     end
-    else
-     i32.const 0
-    end
-    i32.eqz
-    if
-     i32.const 0
-     i32.const 1456
-     i32.const 138
-     i32.const 1
-     call $~lib/builtins/abort
-     unreachable
-    end
-    global.get $~lib/memory/__stack_pointer
-    global.get $instanceof/cat
-    local.tee $0
-    i32.store $0 offset=24
-    local.get $0
-    if (result i32)
-     local.get $0
-     i32.const 8
-     i32.sub
-     i32.load $0
-     i32.const 13
-     i32.eq
-    else
-     i32.const 0
-    end
-    if
-     i32.const 0
-     i32.const 1456
-     i32.const 139
-     i32.const 1
-     call $~lib/builtins/abort
-     unreachable
-    end
-    global.get $~lib/memory/__stack_pointer
-    global.get $instanceof/blackcat
-    local.tee $0
-    i32.store $0 offset=28
-    local.get $0
-    if (result i32)
-     block $__inlined_func$~instanceof|instanceof/Cat9 (result i32)
-      block $is_instance10
-       local.get $0
-       i32.const 8
-       i32.sub
-       i32.load $0
-       local.tee $0
-       i32.const 12
-       i32.eq
-       br_if $is_instance10
-       local.get $0
-       i32.const 13
-       i32.eq
-       br_if $is_instance10
-       i32.const 0
-       br $__inlined_func$~instanceof|instanceof/Cat9
-      end
-      i32.const 1
-     end
-    else
-     i32.const 0
-    end
-    i32.eqz
-    if
-     i32.const 0
-     i32.const 1456
-     i32.const 142
-     i32.const 1
-     call $~lib/builtins/abort
-     unreachable
-    end
-    global.get $~lib/memory/__stack_pointer
-    global.get $instanceof/blackcat
-    local.tee $0
-    i32.store $0 offset=32
-    local.get $0
-    if (result i32)
-     local.get $0
-     i32.const 8
-     i32.sub
-     i32.load $0
-     i32.const 13
-     i32.eq
-    else
-     i32.const 0
-    end
-    i32.eqz
-    if
-     i32.const 0
-     i32.const 1456
-     i32.const 143
-     i32.const 1
-     call $~lib/builtins/abort
-     unreachable
-    end
-    i32.const 0
-    call $instanceof/Animal#constructor
-    global.set $instanceof/nullableAnimal
-    i32.const 0
-    call $instanceof/Cat#constructor
-    global.set $instanceof/nullableCat
-    call $instanceof/BlackCat#constructor
-    global.set $instanceof/nullableBlackcat
-    global.get $instanceof/nullableAnimal
-    i32.eqz
-    if
-     i32.const 0
-     i32.const 1456
-     i32.const 149
-     i32.const 1
-     call $~lib/builtins/abort
-     unreachable
-    end
-    global.get $~lib/memory/__stack_pointer
-    global.get $instanceof/nullableAnimal
-    local.tee $0
-    i32.store $0 offset=36
-    local.get $0
-    if (result i32)
-     block $__inlined_func$~instanceof|instanceof/Cat13 (result i32)
-      block $is_instance14
-       local.get $0
-       i32.const 8
-       i32.sub
-       i32.load $0
-       local.tee $0
-       i32.const 12
-       i32.eq
-       br_if $is_instance14
-       local.get $0
-       i32.const 13
-       i32.eq
-       br_if $is_instance14
-       i32.const 0
-       br $__inlined_func$~instanceof|instanceof/Cat13
-      end
-      i32.const 1
-     end
-    else
-     i32.const 0
-    end
-    if
-     i32.const 0
-     i32.const 1456
-     i32.const 150
-     i32.const 1
-     call $~lib/builtins/abort
-     unreachable
-    end
-    global.get $~lib/memory/__stack_pointer
-    global.get $instanceof/nullableAnimal
-    local.tee $0
-    i32.store $0 offset=40
-    local.get $0
-    if (result i32)
-     local.get $0
-     i32.const 8
-     i32.sub
-     i32.load $0
-     i32.const 13
-     i32.eq
-    else
-     i32.const 0
-    end
-    if
-     i32.const 0
-     i32.const 1456
-     i32.const 151
-     i32.const 1
-     call $~lib/builtins/abort
-     unreachable
-    end
-    global.get $instanceof/nullableCat
-    i32.eqz
-    if
-     i32.const 0
-     i32.const 1456
-     i32.const 153
-     i32.const 1
-     call $~lib/builtins/abort
-     unreachable
-    end
-    global.get $~lib/memory/__stack_pointer
-    global.get $instanceof/nullableCat
-    local.tee $0
-    i32.store $0 offset=44
-    local.get $0
-    if (result i32)
-     block $__inlined_func$~instanceof|instanceof/Cat17 (result i32)
-      block $is_instance18
-       local.get $0
-       i32.const 8
-       i32.sub
-       i32.load $0
-       local.tee $0
-       i32.const 12
-       i32.eq
-       br_if $is_instance18
-       local.get $0
-       i32.const 13
-       i32.eq
-       br_if $is_instance18
-       i32.const 0
-       br $__inlined_func$~instanceof|instanceof/Cat17
-      end
-      i32.const 1
-     end
-    else
-     i32.const 0
-    end
-    i32.eqz
-    if
-     i32.const 0
-     i32.const 1456
-     i32.const 154
-     i32.const 1
-     call $~lib/builtins/abort
-     unreachable
-    end
-    global.get $~lib/memory/__stack_pointer
-    global.get $instanceof/nullableCat
-    local.tee $0
-    i32.store $0 offset=48
-    local.get $0
-    if (result i32)
-     local.get $0
-     i32.const 8
-     i32.sub
-     i32.load $0
-     i32.const 13
-     i32.eq
-    else
-     i32.const 0
-    end
-    if
-     i32.const 0
-     i32.const 1456
-     i32.const 155
-     i32.const 1
-     call $~lib/builtins/abort
-     unreachable
-    end
-    global.get $instanceof/nullableBlackcat
-    i32.eqz
-    if
-     i32.const 0
-     i32.const 1456
-     i32.const 157
-     i32.const 1
-     call $~lib/builtins/abort
-     unreachable
-    end
-    global.get $~lib/memory/__stack_pointer
-    global.get $instanceof/nullableBlackcat
-    local.tee $0
-    i32.store $0 offset=52
-    local.get $0
-    if (result i32)
-     block $__inlined_func$~instanceof|instanceof/Cat21 (result i32)
-      block $is_instance22
-       local.get $0
-       i32.const 8
-       i32.sub
-       i32.load $0
-       local.tee $0
-       i32.const 12
-       i32.eq
-       br_if $is_instance22
-       local.get $0
-       i32.const 13
-       i32.eq
-       br_if $is_instance22
-       i32.const 0
-       br $__inlined_func$~instanceof|instanceof/Cat21
-      end
-      i32.const 1
-     end
-    else
-     i32.const 0
-    end
-    i32.eqz
-    if
-     i32.const 0
-     i32.const 1456
-     i32.const 158
-     i32.const 1
-     call $~lib/builtins/abort
-     unreachable
-    end
-    global.get $~lib/memory/__stack_pointer
-    global.get $instanceof/nullableBlackcat
-    local.tee $0
-    i32.store $0 offset=56
-    local.get $0
-    if (result i32)
-     local.get $0
-     i32.const 8
-     i32.sub
-     i32.load $0
-     i32.const 13
-     i32.eq
-    else
-     i32.const 0
-    end
-    i32.eqz
-    if
-     i32.const 0
-     i32.const 1456
-     i32.const 159
-     i32.const 1
-     call $~lib/builtins/abort
-     unreachable
-    end
-    global.get $~lib/memory/__stack_pointer
-    local.tee $0
-    i32.const 0
-    i32.store $0 offset=60
-    local.get $0
-    i32.const 0
-    i32.store $0 offset=64
-    local.get $0
-    i32.const 0
-    i32.store $0 offset=68
-    local.get $0
-    i32.const 0
-    i32.store $0 offset=72
-    local.get $0
-    i32.const 0
-    i32.store $0 offset=76
-    local.get $0
-    i32.const 0
-    i32.store $0 offset=80
-    local.get $0
-    i32.const 4
-    i32.sub
-    global.set $~lib/memory/__stack_pointer
-    global.get $~lib/memory/__stack_pointer
-    i32.const 1564
-    i32.lt_s
-    br_if $folding-inner0
-    global.get $~lib/memory/__stack_pointer
-    local.tee $0
-    i32.const 0
-    i32.store $0
-    local.get $0
-    i32.const 14
-    call $~lib/rt/itcms/__new
-    local.tee $0
-    i32.store $0
-    global.get $~lib/memory/__stack_pointer
-    local.get $0
-    call $~lib/object/Object#constructor
-    local.tee $0
-    i32.store $0
-    global.get $~lib/memory/__stack_pointer
-    i32.const 4
-    i32.add
-    global.set $~lib/memory/__stack_pointer
-    local.get $0
-    global.set $instanceof/a_i1
-    global.get $~lib/memory/__stack_pointer
-    global.get $instanceof/a_i1
-    local.tee $0
-    i32.store $0 offset=84
-    global.get $~lib/memory/__stack_pointer
-    local.get $0
-    i32.store $0 offset=84
-    global.get $~lib/memory/__stack_pointer
-    local.get $0
-    i32.store $0 offset=84
-    global.get $~lib/memory/__stack_pointer
-    local.get $0
-    i32.store $0 offset=84
-    local.get $0
-    if (result i32)
-     block $__inlined_func$~instanceof|instanceof/I1 (result i32)
-      block $is_instance13
-       local.get $0
-       i32.const 8
-       i32.sub
-       i32.load $0
-       local.tee $0
-       i32.const 14
-       i32.eq
-       br_if $is_instance13
-       local.get $0
-       i32.const 17
-       i32.eq
-       br_if $is_instance13
-       i32.const 0
-       br $__inlined_func$~instanceof|instanceof/I1
-      end
-      i32.const 1
-     end
-    else
-     i32.const 0
-    end
-    i32.eqz
-    br_if $folding-inner1
-    global.get $~lib/memory/__stack_pointer
-    i32.const 4
-    i32.sub
-    global.set $~lib/memory/__stack_pointer
-    global.get $~lib/memory/__stack_pointer
-    i32.const 1564
-    i32.lt_s
-    br_if $folding-inner0
-    global.get $~lib/memory/__stack_pointer
-    local.tee $0
-    i32.const 0
-    i32.store $0
-    local.get $0
-    i32.const 17
-    call $~lib/rt/itcms/__new
-    local.tee $0
-    i32.store $0
-    global.get $~lib/memory/__stack_pointer
-    local.get $0
-    call $~lib/object/Object#constructor
-    local.tee $0
-    i32.store $0
-    global.get $~lib/memory/__stack_pointer
-    i32.const 4
-    i32.add
-    global.set $~lib/memory/__stack_pointer
-    local.get $0
-    global.set $instanceof/b_i1_i2
-    global.get $~lib/memory/__stack_pointer
-    global.get $instanceof/b_i1_i2
-    local.tee $0
-    i32.store $0 offset=84
-    global.get $~lib/memory/__stack_pointer
-    local.get $0
-    i32.store $0 offset=84
-    global.get $~lib/memory/__stack_pointer
-    global.get $instanceof/a_i1
-    local.tee $0
-    i32.store $0 offset=84
-    global.get $~lib/memory/__stack_pointer
-    local.get $0
-    i32.store $0 offset=84
-    local.get $0
-    if (result i32)
-     local.get $0
-     i32.const 8
-     i32.sub
-     i32.load $0
-     i32.const 17
-     i32.eq
-    else
-     i32.const 0
-    end
-    if
-     i32.const 0
-     i32.const 1456
-     i32.const 19
-     i32.const 5
-     call $~lib/builtins/abort
-     unreachable
-    end
-    global.get $~lib/memory/__stack_pointer
-    global.get $instanceof/b_i1_i2
-    local.tee $0
-    i32.store $0 offset=84
-    local.get $0
-    if (result i32)
-     local.get $0
-     i32.const 8
-     i32.sub
-     i32.load $0
-     i32.const 17
-     i32.eq
-    else
-     i32.const 0
-    end
-    i32.eqz
-    br_if $folding-inner1
-    global.get $~lib/memory/__stack_pointer
-    i32.const 88
-    i32.add
-    global.set $~lib/memory/__stack_pointer
-    return
    end
-   i32.const 34352
-   i32.const 34400
+   if
+    i32.const 0
+    i32.const 1456
+    i32.const 41
+    i32.const 1
+    call $~lib/builtins/abort
+    unreachable
+   end
+   global.get $instanceof/an
+   if
+    i32.const 0
+    i32.const 1456
+    i32.const 91
+    i32.const 1
+    call $~lib/builtins/abort
+    unreachable
+   end
    i32.const 1
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
+   global.set $instanceof/an
+   global.get $~lib/memory/__stack_pointer
+   i32.const 4
+   i32.sub
+   global.set $~lib/memory/__stack_pointer
+   global.get $~lib/memory/__stack_pointer
+   i32.const 1584
+   i32.lt_s
+   br_if $folding-inner0
+   global.get $~lib/memory/__stack_pointer
+   local.tee $0
+   i32.const 0
+   i32.store $0
+   local.get $0
+   i32.const 6
+   call $~lib/rt/itcms/__new
+   local.tee $0
+   i32.store $0
+   global.get $~lib/memory/__stack_pointer
+   local.tee $1
+   i32.const 4
+   i32.sub
+   global.set $~lib/memory/__stack_pointer
+   global.get $~lib/memory/__stack_pointer
+   i32.const 1584
+   i32.lt_s
+   br_if $folding-inner0
+   global.get $~lib/memory/__stack_pointer
+   i32.const 0
+   i32.store $0
+   local.get $0
+   i32.eqz
+   if
+    global.get $~lib/memory/__stack_pointer
+    i32.const 7
+    call $~lib/rt/itcms/__new
+    local.tee $0
+    i32.store $0
+   end
+   global.get $~lib/memory/__stack_pointer
+   local.get $0
+   call $~lib/object/Object#constructor
+   local.tee $0
+   i32.store $0
+   global.get $~lib/memory/__stack_pointer
+   i32.const 4
+   i32.add
+   global.set $~lib/memory/__stack_pointer
+   local.get $1
+   local.get $0
+   i32.store $0
+   global.get $~lib/memory/__stack_pointer
+   i32.const 4
+   i32.add
+   global.set $~lib/memory/__stack_pointer
+   local.get $0
+   global.set $instanceof/child
+   global.get $~lib/memory/__stack_pointer
+   i32.const 4
+   i32.sub
+   global.set $~lib/memory/__stack_pointer
+   global.get $~lib/memory/__stack_pointer
+   i32.const 1584
+   i32.lt_s
+   br_if $folding-inner0
+   global.get $~lib/memory/__stack_pointer
+   local.tee $0
+   i32.const 0
+   i32.store $0
+   local.get $0
+   i32.const 8
+   call $~lib/rt/itcms/__new
+   local.tee $0
+   i32.store $0
+   global.get $~lib/memory/__stack_pointer
+   local.tee $1
+   i32.const 4
+   i32.sub
+   global.set $~lib/memory/__stack_pointer
+   global.get $~lib/memory/__stack_pointer
+   i32.const 1584
+   i32.lt_s
+   br_if $folding-inner0
+   global.get $~lib/memory/__stack_pointer
+   i32.const 0
+   i32.store $0
+   local.get $0
+   i32.eqz
+   if
+    global.get $~lib/memory/__stack_pointer
+    i32.const 9
+    call $~lib/rt/itcms/__new
+    local.tee $0
+    i32.store $0
+   end
+   global.get $~lib/memory/__stack_pointer
+   local.get $0
+   call $~lib/object/Object#constructor
+   local.tee $0
+   i32.store $0
+   global.get $~lib/memory/__stack_pointer
+   i32.const 4
+   i32.add
+   global.set $~lib/memory/__stack_pointer
+   local.get $1
+   local.get $0
+   i32.store $0
+   global.get $~lib/memory/__stack_pointer
+   i32.const 4
+   i32.add
+   global.set $~lib/memory/__stack_pointer
+   local.get $0
+   global.set $instanceof/childAsParent
+   global.get $~lib/memory/__stack_pointer
+   global.get $instanceof/childAsParent
+   local.tee $0
+   i32.store $0 offset=4
+   local.get $0
+   if (result i32)
+    local.get $0
+    i32.const 8
+    i32.sub
+    i32.load $0
+    i32.const 8
+    i32.eq
+   else
+    i32.const 0
+   end
+   i32.eqz
+   if
+    i32.const 0
+    i32.const 1456
+    i32.const 117
+    i32.const 1
+    call $~lib/builtins/abort
+    unreachable
+   end
+   global.get $~lib/memory/__stack_pointer
+   global.get $instanceof/childAsParent
+   local.tee $0
+   i32.store $0 offset=8
+   local.get $0
+   if (result i32)
+    block $__inlined_func$~anyinstanceof|instanceof/Child (result i32)
+     block $is_instance2
+      local.get $0
+      i32.const 8
+      i32.sub
+      i32.load $0
+      local.tee $0
+      i32.const 6
+      i32.eq
+      br_if $is_instance2
+      local.get $0
+      i32.const 8
+      i32.eq
+      br_if $is_instance2
+      i32.const 0
+      br $__inlined_func$~anyinstanceof|instanceof/Child
+     end
+     i32.const 1
+    end
+   else
+    i32.const 0
+   end
+   i32.eqz
+   if
+    i32.const 0
+    i32.const 1456
+    i32.const 119
+    i32.const 1
+    call $~lib/builtins/abort
+    unreachable
+   end
+   i32.const 0
+   call $instanceof/Animal#constructor
+   global.set $instanceof/animal
+   i32.const 0
+   call $instanceof/Cat#constructor
+   global.set $instanceof/cat
+   call $instanceof/BlackCat#constructor
+   global.set $instanceof/blackcat
+   global.get $~lib/memory/__stack_pointer
+   global.get $instanceof/animal
+   local.tee $0
+   i32.store $0 offset=12
+   local.get $0
+   if (result i32)
+    block $__inlined_func$~instanceof|instanceof/Cat (result i32)
+     block $is_instance3
+      local.get $0
+      i32.const 8
+      i32.sub
+      i32.load $0
+      local.tee $0
+      i32.const 12
+      i32.eq
+      br_if $is_instance3
+      local.get $0
+      i32.const 13
+      i32.eq
+      br_if $is_instance3
+      i32.const 0
+      br $__inlined_func$~instanceof|instanceof/Cat
+     end
+     i32.const 1
+    end
+   else
+    i32.const 0
+   end
+   if
+    i32.const 0
+    i32.const 1456
+    i32.const 134
+    i32.const 1
+    call $~lib/builtins/abort
+    unreachable
+   end
+   global.get $~lib/memory/__stack_pointer
+   global.get $instanceof/animal
+   local.tee $0
+   i32.store $0 offset=16
+   local.get $0
+   if (result i32)
+    local.get $0
+    i32.const 8
+    i32.sub
+    i32.load $0
+    i32.const 13
+    i32.eq
+   else
+    i32.const 0
+   end
+   if
+    i32.const 0
+    i32.const 1456
+    i32.const 135
+    i32.const 1
+    call $~lib/builtins/abort
+    unreachable
+   end
+   global.get $~lib/memory/__stack_pointer
+   global.get $instanceof/cat
+   local.tee $0
+   i32.store $0 offset=20
+   local.get $0
+   if (result i32)
+    block $__inlined_func$~instanceof|instanceof/Cat5 (result i32)
+     block $is_instance6
+      local.get $0
+      i32.const 8
+      i32.sub
+      i32.load $0
+      local.tee $0
+      i32.const 12
+      i32.eq
+      br_if $is_instance6
+      local.get $0
+      i32.const 13
+      i32.eq
+      br_if $is_instance6
+      i32.const 0
+      br $__inlined_func$~instanceof|instanceof/Cat5
+     end
+     i32.const 1
+    end
+   else
+    i32.const 0
+   end
+   i32.eqz
+   if
+    i32.const 0
+    i32.const 1456
+    i32.const 138
+    i32.const 1
+    call $~lib/builtins/abort
+    unreachable
+   end
+   global.get $~lib/memory/__stack_pointer
+   global.get $instanceof/cat
+   local.tee $0
+   i32.store $0 offset=24
+   local.get $0
+   if (result i32)
+    local.get $0
+    i32.const 8
+    i32.sub
+    i32.load $0
+    i32.const 13
+    i32.eq
+   else
+    i32.const 0
+   end
+   if
+    i32.const 0
+    i32.const 1456
+    i32.const 139
+    i32.const 1
+    call $~lib/builtins/abort
+    unreachable
+   end
+   global.get $~lib/memory/__stack_pointer
+   global.get $instanceof/blackcat
+   local.tee $0
+   i32.store $0 offset=28
+   local.get $0
+   if (result i32)
+    block $__inlined_func$~instanceof|instanceof/Cat9 (result i32)
+     block $is_instance10
+      local.get $0
+      i32.const 8
+      i32.sub
+      i32.load $0
+      local.tee $0
+      i32.const 12
+      i32.eq
+      br_if $is_instance10
+      local.get $0
+      i32.const 13
+      i32.eq
+      br_if $is_instance10
+      i32.const 0
+      br $__inlined_func$~instanceof|instanceof/Cat9
+     end
+     i32.const 1
+    end
+   else
+    i32.const 0
+   end
+   i32.eqz
+   if
+    i32.const 0
+    i32.const 1456
+    i32.const 142
+    i32.const 1
+    call $~lib/builtins/abort
+    unreachable
+   end
+   global.get $~lib/memory/__stack_pointer
+   global.get $instanceof/blackcat
+   local.tee $0
+   i32.store $0 offset=32
+   local.get $0
+   if (result i32)
+    local.get $0
+    i32.const 8
+    i32.sub
+    i32.load $0
+    i32.const 13
+    i32.eq
+   else
+    i32.const 0
+   end
+   i32.eqz
+   if
+    i32.const 0
+    i32.const 1456
+    i32.const 143
+    i32.const 1
+    call $~lib/builtins/abort
+    unreachable
+   end
+   i32.const 0
+   call $instanceof/Animal#constructor
+   global.set $instanceof/nullableAnimal
+   i32.const 0
+   call $instanceof/Cat#constructor
+   global.set $instanceof/nullableCat
+   call $instanceof/BlackCat#constructor
+   global.set $instanceof/nullableBlackcat
+   global.get $instanceof/nullableAnimal
+   i32.eqz
+   if
+    i32.const 0
+    i32.const 1456
+    i32.const 149
+    i32.const 1
+    call $~lib/builtins/abort
+    unreachable
+   end
+   global.get $~lib/memory/__stack_pointer
+   global.get $instanceof/nullableAnimal
+   local.tee $0
+   i32.store $0 offset=36
+   local.get $0
+   if (result i32)
+    block $__inlined_func$~instanceof|instanceof/Cat13 (result i32)
+     block $is_instance14
+      local.get $0
+      i32.const 8
+      i32.sub
+      i32.load $0
+      local.tee $0
+      i32.const 12
+      i32.eq
+      br_if $is_instance14
+      local.get $0
+      i32.const 13
+      i32.eq
+      br_if $is_instance14
+      i32.const 0
+      br $__inlined_func$~instanceof|instanceof/Cat13
+     end
+     i32.const 1
+    end
+   else
+    i32.const 0
+   end
+   if
+    i32.const 0
+    i32.const 1456
+    i32.const 150
+    i32.const 1
+    call $~lib/builtins/abort
+    unreachable
+   end
+   global.get $~lib/memory/__stack_pointer
+   global.get $instanceof/nullableAnimal
+   local.tee $0
+   i32.store $0 offset=40
+   local.get $0
+   if (result i32)
+    local.get $0
+    i32.const 8
+    i32.sub
+    i32.load $0
+    i32.const 13
+    i32.eq
+   else
+    i32.const 0
+   end
+   if
+    i32.const 0
+    i32.const 1456
+    i32.const 151
+    i32.const 1
+    call $~lib/builtins/abort
+    unreachable
+   end
+   global.get $instanceof/nullableCat
+   i32.eqz
+   if
+    i32.const 0
+    i32.const 1456
+    i32.const 153
+    i32.const 1
+    call $~lib/builtins/abort
+    unreachable
+   end
+   global.get $~lib/memory/__stack_pointer
+   global.get $instanceof/nullableCat
+   local.tee $0
+   i32.store $0 offset=44
+   local.get $0
+   if (result i32)
+    block $__inlined_func$~instanceof|instanceof/Cat17 (result i32)
+     block $is_instance18
+      local.get $0
+      i32.const 8
+      i32.sub
+      i32.load $0
+      local.tee $0
+      i32.const 12
+      i32.eq
+      br_if $is_instance18
+      local.get $0
+      i32.const 13
+      i32.eq
+      br_if $is_instance18
+      i32.const 0
+      br $__inlined_func$~instanceof|instanceof/Cat17
+     end
+     i32.const 1
+    end
+   else
+    i32.const 0
+   end
+   i32.eqz
+   if
+    i32.const 0
+    i32.const 1456
+    i32.const 154
+    i32.const 1
+    call $~lib/builtins/abort
+    unreachable
+   end
+   global.get $~lib/memory/__stack_pointer
+   global.get $instanceof/nullableCat
+   local.tee $0
+   i32.store $0 offset=48
+   local.get $0
+   if (result i32)
+    local.get $0
+    i32.const 8
+    i32.sub
+    i32.load $0
+    i32.const 13
+    i32.eq
+   else
+    i32.const 0
+   end
+   if
+    i32.const 0
+    i32.const 1456
+    i32.const 155
+    i32.const 1
+    call $~lib/builtins/abort
+    unreachable
+   end
+   global.get $instanceof/nullableBlackcat
+   i32.eqz
+   if
+    i32.const 0
+    i32.const 1456
+    i32.const 157
+    i32.const 1
+    call $~lib/builtins/abort
+    unreachable
+   end
+   global.get $~lib/memory/__stack_pointer
+   global.get $instanceof/nullableBlackcat
+   local.tee $0
+   i32.store $0 offset=52
+   local.get $0
+   if (result i32)
+    block $__inlined_func$~instanceof|instanceof/Cat21 (result i32)
+     block $is_instance22
+      local.get $0
+      i32.const 8
+      i32.sub
+      i32.load $0
+      local.tee $0
+      i32.const 12
+      i32.eq
+      br_if $is_instance22
+      local.get $0
+      i32.const 13
+      i32.eq
+      br_if $is_instance22
+      i32.const 0
+      br $__inlined_func$~instanceof|instanceof/Cat21
+     end
+     i32.const 1
+    end
+   else
+    i32.const 0
+   end
+   i32.eqz
+   if
+    i32.const 0
+    i32.const 1456
+    i32.const 158
+    i32.const 1
+    call $~lib/builtins/abort
+    unreachable
+   end
+   global.get $~lib/memory/__stack_pointer
+   global.get $instanceof/nullableBlackcat
+   local.tee $0
+   i32.store $0 offset=56
+   local.get $0
+   if (result i32)
+    local.get $0
+    i32.const 8
+    i32.sub
+    i32.load $0
+    i32.const 13
+    i32.eq
+   else
+    i32.const 0
+   end
+   i32.eqz
+   if
+    i32.const 0
+    i32.const 1456
+    i32.const 159
+    i32.const 1
+    call $~lib/builtins/abort
+    unreachable
+   end
+   global.get $~lib/memory/__stack_pointer
+   local.tee $0
+   i32.const 0
+   i32.store $0 offset=60
+   local.get $0
+   i32.const 0
+   i32.store $0 offset=64
+   local.get $0
+   i32.const 0
+   i32.store $0 offset=68
+   local.get $0
+   i32.const 0
+   i32.store $0 offset=72
+   local.get $0
+   i32.const 0
+   i32.store $0 offset=76
+   local.get $0
+   i32.const 0
+   i32.store $0 offset=80
+   local.get $0
+   i32.const 4
+   i32.sub
+   global.set $~lib/memory/__stack_pointer
+   global.get $~lib/memory/__stack_pointer
+   i32.const 1584
+   i32.lt_s
+   br_if $folding-inner0
+   global.get $~lib/memory/__stack_pointer
+   local.tee $0
+   i32.const 0
+   i32.store $0
+   local.get $0
+   i32.const 14
+   call $~lib/rt/itcms/__new
+   local.tee $0
+   i32.store $0
+   global.get $~lib/memory/__stack_pointer
+   local.get $0
+   call $~lib/object/Object#constructor
+   local.tee $0
+   i32.store $0
+   global.get $~lib/memory/__stack_pointer
+   i32.const 4
+   i32.add
+   global.set $~lib/memory/__stack_pointer
+   local.get $0
+   global.set $instanceof/w
+   i32.const 0
+   call $instanceof/X#constructor
+   global.set $instanceof/x
+   i32.const 0
+   call $instanceof/Y#constructor
+   global.set $instanceof/y
+   global.get $~lib/memory/__stack_pointer
+   i32.const 4
+   i32.sub
+   global.set $~lib/memory/__stack_pointer
+   global.get $~lib/memory/__stack_pointer
+   i32.const 1584
+   i32.lt_s
+   br_if $folding-inner0
+   global.get $~lib/memory/__stack_pointer
+   local.tee $0
+   i32.const 0
+   i32.store $0
+   local.get $0
+   i32.const 21
+   call $~lib/rt/itcms/__new
+   local.tee $0
+   i32.store $0
+   global.get $~lib/memory/__stack_pointer
+   local.get $0
+   call $instanceof/Y#constructor
+   local.tee $0
+   i32.store $0
+   global.get $~lib/memory/__stack_pointer
+   i32.const 4
+   i32.add
+   global.set $~lib/memory/__stack_pointer
+   local.get $0
+   global.set $instanceof/z
+   global.get $~lib/memory/__stack_pointer
+   global.get $instanceof/w
+   local.tee $2
+   i32.store $0 offset=84
+   global.get $~lib/memory/__stack_pointer
+   global.get $instanceof/x
+   local.tee $3
+   i32.store $0 offset=84
+   global.get $~lib/memory/__stack_pointer
+   global.get $instanceof/y
+   local.tee $0
+   i32.store $0 offset=84
+   global.get $~lib/memory/__stack_pointer
+   global.get $instanceof/z
+   local.tee $1
+   i32.store $0 offset=84
+   global.get $~lib/memory/__stack_pointer
+   local.get $3
+   i32.store $0 offset=84
+   global.get $~lib/memory/__stack_pointer
+   local.get $3
+   i32.store $0 offset=84
+   global.get $~lib/memory/__stack_pointer
+   local.get $0
+   i32.store $0 offset=84
+   global.get $~lib/memory/__stack_pointer
+   local.get $0
+   i32.store $0 offset=84
+   global.get $~lib/memory/__stack_pointer
+   local.get $0
+   i32.store $0 offset=84
+   global.get $~lib/memory/__stack_pointer
+   local.get $0
+   i32.store $0 offset=84
+   global.get $~lib/memory/__stack_pointer
+   local.get $1
+   i32.store $0 offset=84
+   global.get $~lib/memory/__stack_pointer
+   local.get $1
+   i32.store $0 offset=84
+   global.get $~lib/memory/__stack_pointer
+   local.get $1
+   i32.store $0 offset=84
+   global.get $~lib/memory/__stack_pointer
+   local.get $1
+   i32.store $0 offset=84
+   global.get $~lib/memory/__stack_pointer
+   local.get $2
+   i32.store $0 offset=84
+   local.get $2
+   if (result i32)
+    local.get $2
+    i32.const 8
+    i32.sub
+    i32.load $0
+    i32.const 14
+    i32.eq
+   else
+    i32.const 0
+   end
+   i32.eqz
+   if
+    i32.const 0
+    i32.const 1456
+    i32.const 12
+    i32.const 5
+    call $~lib/builtins/abort
+    unreachable
+   end
+   global.get $~lib/memory/__stack_pointer
+   global.get $instanceof/x
+   local.tee $0
+   i32.store $0 offset=84
+   local.get $0
+   call $instanceof/assertDynamicTrue<~lib/object/Object,instanceof/X>
+   global.get $~lib/memory/__stack_pointer
+   global.get $instanceof/y
+   local.tee $0
+   i32.store $0 offset=84
+   local.get $0
+   call $instanceof/assertDynamicTrue<~lib/object/Object,instanceof/X>
+   global.get $~lib/memory/__stack_pointer
+   global.get $instanceof/z
+   local.tee $0
+   i32.store $0 offset=84
+   local.get $0
+   call $instanceof/assertDynamicTrue<~lib/object/Object,instanceof/X>
+   global.get $~lib/memory/__stack_pointer
+   global.get $instanceof/y
+   local.tee $0
+   i32.store $0 offset=84
+   local.get $0
+   call $instanceof/assertDynamicTrue<~lib/object/Object,instanceof/Y>
+   global.get $~lib/memory/__stack_pointer
+   global.get $instanceof/z
+   local.tee $0
+   i32.store $0 offset=84
+   local.get $0
+   call $instanceof/assertDynamicTrue<~lib/object/Object,instanceof/Y>
+   global.get $~lib/memory/__stack_pointer
+   global.get $instanceof/z
+   local.tee $0
+   i32.store $0 offset=84
+   local.get $0
+   call $instanceof/assertDynamicTrue<~lib/object/Object,instanceof/Z>
+   global.get $~lib/memory/__stack_pointer
+   global.get $instanceof/x
+   local.tee $0
+   i32.store $0 offset=84
+   local.get $0
+   call $instanceof/assertDynamicTrue<~lib/object/Object,instanceof/X>
+   global.get $~lib/memory/__stack_pointer
+   global.get $instanceof/x
+   local.tee $0
+   i32.store $0 offset=84
+   local.get $0
+   call $instanceof/assertDynamicTrue<~lib/object/Object,instanceof/X>
+   global.get $~lib/memory/__stack_pointer
+   global.get $instanceof/y
+   local.tee $0
+   i32.store $0 offset=84
+   local.get $0
+   call $instanceof/assertDynamicTrue<~lib/object/Object,instanceof/X>
+   global.get $~lib/memory/__stack_pointer
+   global.get $instanceof/y
+   local.tee $0
+   i32.store $0 offset=84
+   local.get $0
+   call $instanceof/assertDynamicTrue<~lib/object/Object,instanceof/X>
+   global.get $~lib/memory/__stack_pointer
+   global.get $instanceof/y
+   local.tee $0
+   i32.store $0 offset=84
+   local.get $0
+   call $instanceof/assertDynamicTrue<~lib/object/Object,instanceof/Y>
+   global.get $~lib/memory/__stack_pointer
+   global.get $instanceof/y
+   local.tee $0
+   i32.store $0 offset=84
+   local.get $0
+   call $instanceof/assertDynamicTrue<~lib/object/Object,instanceof/Y>
+   global.get $~lib/memory/__stack_pointer
+   global.get $instanceof/z
+   local.tee $0
+   i32.store $0 offset=84
+   local.get $0
+   call $instanceof/assertDynamicTrue<~lib/object/Object,instanceof/X>
+   global.get $~lib/memory/__stack_pointer
+   global.get $instanceof/z
+   local.tee $0
+   i32.store $0 offset=84
+   local.get $0
+   call $instanceof/assertDynamicTrue<~lib/object/Object,instanceof/X>
+   global.get $~lib/memory/__stack_pointer
+   global.get $instanceof/z
+   local.tee $0
+   i32.store $0 offset=84
+   local.get $0
+   call $instanceof/assertDynamicTrue<~lib/object/Object,instanceof/Y>
+   global.get $~lib/memory/__stack_pointer
+   global.get $instanceof/z
+   local.tee $0
+   i32.store $0 offset=84
+   local.get $0
+   call $instanceof/assertDynamicTrue<~lib/object/Object,instanceof/Y>
+   global.get $~lib/memory/__stack_pointer
+   global.get $instanceof/w
+   local.tee $0
+   i32.store $0 offset=84
+   global.get $~lib/memory/__stack_pointer
+   local.get $0
+   i32.store $0 offset=84
+   global.get $~lib/memory/__stack_pointer
+   local.get $0
+   i32.store $0 offset=84
+   global.get $~lib/memory/__stack_pointer
+   local.get $0
+   i32.store $0 offset=84
+   global.get $~lib/memory/__stack_pointer
+   global.get $instanceof/x
+   i32.store $0 offset=84
+   global.get $~lib/memory/__stack_pointer
+   global.get $instanceof/y
+   i32.store $0 offset=84
+   global.get $~lib/memory/__stack_pointer
+   global.get $instanceof/z
+   i32.store $0 offset=84
+   global.get $~lib/memory/__stack_pointer
+   global.get $instanceof/x
+   i32.store $0 offset=84
+   global.get $~lib/memory/__stack_pointer
+   global.get $instanceof/x
+   local.tee $0
+   i32.store $0 offset=84
+   local.get $0
+   call $instanceof/assertDynamicFalse<instanceof/X,instanceof/Y>
+   global.get $~lib/memory/__stack_pointer
+   global.get $instanceof/x
+   local.tee $0
+   i32.store $0 offset=84
+   local.get $0
+   call $instanceof/assertDynamicFalse<instanceof/X,instanceof/Z>
+   global.get $~lib/memory/__stack_pointer
+   global.get $instanceof/y
+   i32.store $0 offset=84
+   global.get $~lib/memory/__stack_pointer
+   global.get $instanceof/y
+   local.tee $0
+   i32.store $0 offset=84
+   local.get $0
+   call $instanceof/assertDynamicTrue<~lib/object/Object,instanceof/Y>
+   global.get $~lib/memory/__stack_pointer
+   global.get $instanceof/y
+   local.tee $0
+   i32.store $0 offset=84
+   local.get $0
+   call $instanceof/assertDynamicFalse<instanceof/X,instanceof/Z>
+   global.get $~lib/memory/__stack_pointer
+   global.get $instanceof/z
+   i32.store $0 offset=84
+   global.get $~lib/memory/__stack_pointer
+   global.get $instanceof/z
+   local.tee $0
+   i32.store $0 offset=84
+   local.get $0
+   call $instanceof/assertDynamicTrue<~lib/object/Object,instanceof/Y>
+   global.get $~lib/memory/__stack_pointer
+   global.get $instanceof/z
+   local.tee $0
+   i32.store $0 offset=84
+   local.get $0
+   call $instanceof/assertDynamicTrue<~lib/object/Object,instanceof/Z>
+   global.get $~lib/memory/__stack_pointer
+   global.get $instanceof/y
+   i32.store $0 offset=84
+   global.get $~lib/memory/__stack_pointer
+   global.get $instanceof/y
+   i32.store $0 offset=84
+   global.get $~lib/memory/__stack_pointer
+   global.get $instanceof/y
+   local.tee $0
+   i32.store $0 offset=84
+   local.get $0
+   call $instanceof/assertDynamicFalse<instanceof/X,instanceof/Z>
+   global.get $~lib/memory/__stack_pointer
+   global.get $instanceof/z
+   i32.store $0 offset=84
+   global.get $~lib/memory/__stack_pointer
+   global.get $instanceof/z
+   i32.store $0 offset=84
+   global.get $~lib/memory/__stack_pointer
+   global.get $instanceof/z
+   local.tee $0
+   i32.store $0 offset=84
+   local.get $0
+   call $instanceof/assertDynamicTrue<~lib/object/Object,instanceof/Z>
+   global.get $~lib/memory/__stack_pointer
+   global.get $instanceof/z
+   i32.store $0 offset=84
+   global.get $~lib/memory/__stack_pointer
+   global.get $instanceof/z
+   i32.store $0 offset=84
+   global.get $~lib/memory/__stack_pointer
+   global.get $instanceof/z
+   i32.store $0 offset=84
+   global.get $~lib/memory/__stack_pointer
+   global.get $instanceof/x
+   local.tee $0
+   i32.store $0 offset=84
+   local.get $0
+   call $instanceof/assertDynamicFalse<instanceof/X,instanceof/Y>
+   global.get $~lib/memory/__stack_pointer
+   global.get $instanceof/x
+   local.tee $0
+   i32.store $0 offset=84
+   local.get $0
+   call $instanceof/assertDynamicFalse<instanceof/X,instanceof/Y>
+   global.get $~lib/memory/__stack_pointer
+   global.get $instanceof/x
+   local.tee $0
+   i32.store $0 offset=84
+   local.get $0
+   call $instanceof/assertDynamicFalse<instanceof/X,instanceof/Y>
+   global.get $~lib/memory/__stack_pointer
+   global.get $instanceof/x
+   local.tee $0
+   i32.store $0 offset=84
+   local.get $0
+   call $instanceof/assertDynamicFalse<instanceof/X,instanceof/Y>
+   global.get $~lib/memory/__stack_pointer
+   global.get $instanceof/x
+   i32.store $0 offset=84
+   global.get $~lib/memory/__stack_pointer
+   global.get $instanceof/x
+   i32.store $0 offset=84
+   global.get $~lib/memory/__stack_pointer
+   global.get $instanceof/y
+   local.tee $0
+   i32.store $0 offset=84
+   local.get $0
+   call $instanceof/assertDynamicTrue<~lib/object/Object,instanceof/Y>
+   global.get $~lib/memory/__stack_pointer
+   global.get $instanceof/y
+   local.tee $0
+   i32.store $0 offset=84
+   local.get $0
+   call $instanceof/assertDynamicTrue<~lib/object/Object,instanceof/Y>
+   global.get $~lib/memory/__stack_pointer
+   global.get $instanceof/y
+   local.tee $0
+   i32.store $0 offset=84
+   local.get $0
+   call $instanceof/assertDynamicTrue<~lib/object/Object,instanceof/Y>
+   global.get $~lib/memory/__stack_pointer
+   global.get $instanceof/y
+   local.tee $0
+   i32.store $0 offset=84
+   local.get $0
+   call $instanceof/assertDynamicTrue<~lib/object/Object,instanceof/Y>
+   global.get $~lib/memory/__stack_pointer
+   global.get $instanceof/y
+   i32.store $0 offset=84
+   global.get $~lib/memory/__stack_pointer
+   global.get $instanceof/y
+   i32.store $0 offset=84
+   global.get $~lib/memory/__stack_pointer
+   global.get $instanceof/z
+   local.tee $0
+   i32.store $0 offset=84
+   local.get $0
+   call $instanceof/assertDynamicTrue<~lib/object/Object,instanceof/Y>
+   global.get $~lib/memory/__stack_pointer
+   global.get $instanceof/z
+   local.tee $0
+   i32.store $0 offset=84
+   local.get $0
+   call $instanceof/assertDynamicTrue<~lib/object/Object,instanceof/Y>
+   global.get $~lib/memory/__stack_pointer
+   global.get $instanceof/z
+   local.tee $0
+   i32.store $0 offset=84
+   local.get $0
+   call $instanceof/assertDynamicTrue<~lib/object/Object,instanceof/Y>
+   global.get $~lib/memory/__stack_pointer
+   global.get $instanceof/z
+   local.tee $0
+   i32.store $0 offset=84
+   local.get $0
+   call $instanceof/assertDynamicTrue<~lib/object/Object,instanceof/Y>
+   global.get $~lib/memory/__stack_pointer
+   global.get $instanceof/z
+   i32.store $0 offset=84
+   global.get $~lib/memory/__stack_pointer
+   global.get $instanceof/z
+   i32.store $0 offset=84
+   global.get $~lib/memory/__stack_pointer
+   global.get $instanceof/x
+   i32.store $0 offset=84
+   global.get $~lib/memory/__stack_pointer
+   global.get $instanceof/x
+   i32.store $0 offset=84
+   global.get $~lib/memory/__stack_pointer
+   global.get $instanceof/x
+   local.tee $0
+   i32.store $0 offset=84
+   local.get $0
+   call $instanceof/assertDynamicFalse<instanceof/X,instanceof/Y>
+   global.get $~lib/memory/__stack_pointer
+   global.get $instanceof/x
+   local.tee $0
+   i32.store $0 offset=84
+   local.get $0
+   call $instanceof/assertDynamicFalse<instanceof/X,instanceof/Y>
+   global.get $~lib/memory/__stack_pointer
+   global.get $instanceof/x
+   i32.store $0 offset=84
+   global.get $~lib/memory/__stack_pointer
+   global.get $instanceof/y
+   i32.store $0 offset=84
+   global.get $~lib/memory/__stack_pointer
+   global.get $instanceof/y
+   i32.store $0 offset=84
+   global.get $~lib/memory/__stack_pointer
+   global.get $instanceof/y
+   local.tee $0
+   i32.store $0 offset=84
+   local.get $0
+   call $instanceof/assertDynamicTrue<~lib/object/Object,instanceof/Y>
+   global.get $~lib/memory/__stack_pointer
+   global.get $instanceof/y
+   local.tee $0
+   i32.store $0 offset=84
+   local.get $0
+   call $instanceof/assertDynamicTrue<~lib/object/Object,instanceof/Y>
+   global.get $~lib/memory/__stack_pointer
+   global.get $instanceof/y
+   i32.store $0 offset=84
+   global.get $~lib/memory/__stack_pointer
+   global.get $instanceof/z
+   i32.store $0 offset=84
+   global.get $~lib/memory/__stack_pointer
+   global.get $instanceof/z
+   i32.store $0 offset=84
+   global.get $~lib/memory/__stack_pointer
+   global.get $instanceof/z
+   local.tee $0
+   i32.store $0 offset=84
+   local.get $0
+   call $instanceof/assertDynamicTrue<~lib/object/Object,instanceof/Y>
+   global.get $~lib/memory/__stack_pointer
+   global.get $instanceof/z
+   local.tee $0
+   i32.store $0 offset=84
+   local.get $0
+   call $instanceof/assertDynamicTrue<~lib/object/Object,instanceof/Y>
+   global.get $~lib/memory/__stack_pointer
+   global.get $instanceof/z
+   i32.store $0 offset=84
+   global.get $~lib/memory/__stack_pointer
+   global.get $instanceof/y
+   i32.store $0 offset=84
+   global.get $~lib/memory/__stack_pointer
+   global.get $instanceof/y
+   i32.store $0 offset=84
+   global.get $~lib/memory/__stack_pointer
+   global.get $instanceof/y
+   i32.store $0 offset=84
+   global.get $~lib/memory/__stack_pointer
+   global.get $instanceof/y
+   i32.store $0 offset=84
+   global.get $~lib/memory/__stack_pointer
+   global.get $instanceof/y
+   i32.store $0 offset=84
+   global.get $~lib/memory/__stack_pointer
+   global.get $instanceof/z
+   i32.store $0 offset=84
+   global.get $~lib/memory/__stack_pointer
+   global.get $instanceof/z
+   i32.store $0 offset=84
+   global.get $~lib/memory/__stack_pointer
+   global.get $instanceof/z
+   i32.store $0 offset=84
+   global.get $~lib/memory/__stack_pointer
+   global.get $instanceof/z
+   i32.store $0 offset=84
+   global.get $~lib/memory/__stack_pointer
+   global.get $instanceof/z
+   i32.store $0 offset=84
+   global.get $~lib/memory/__stack_pointer
+   global.get $instanceof/z
+   i32.store $0 offset=84
+   global.get $~lib/memory/__stack_pointer
+   global.get $instanceof/z
+   i32.store $0 offset=84
+   global.get $~lib/memory/__stack_pointer
+   global.get $instanceof/z
+   i32.store $0 offset=84
+   global.get $~lib/memory/__stack_pointer
+   global.get $instanceof/z
+   i32.store $0 offset=84
+   global.get $~lib/memory/__stack_pointer
+   global.get $instanceof/z
+   i32.store $0 offset=84
+   global.get $~lib/memory/__stack_pointer
+   global.get $instanceof/x
+   i32.store $0 offset=84
+   global.get $~lib/memory/__stack_pointer
+   global.get $instanceof/x
+   i32.store $0 offset=84
+   global.get $~lib/memory/__stack_pointer
+   global.get $instanceof/y
+   i32.store $0 offset=84
+   global.get $~lib/memory/__stack_pointer
+   global.get $instanceof/y
+   i32.store $0 offset=84
+   global.get $~lib/memory/__stack_pointer
+   global.get $instanceof/y
+   i32.store $0 offset=84
+   global.get $~lib/memory/__stack_pointer
+   global.get $instanceof/y
+   i32.store $0 offset=84
+   global.get $~lib/memory/__stack_pointer
+   global.get $instanceof/z
+   i32.store $0 offset=84
+   global.get $~lib/memory/__stack_pointer
+   global.get $instanceof/z
+   i32.store $0 offset=84
+   global.get $~lib/memory/__stack_pointer
+   global.get $instanceof/z
+   i32.store $0 offset=84
+   global.get $~lib/memory/__stack_pointer
+   global.get $instanceof/z
+   i32.store $0 offset=84
+   global.get $~lib/memory/__stack_pointer
+   global.get $instanceof/x
+   local.tee $0
+   i32.store $0 offset=84
+   local.get $0
+   call $instanceof/assertDynamicTrue<~lib/object/Object,instanceof/X>
+   global.get $~lib/memory/__stack_pointer
+   global.get $instanceof/x
+   local.tee $0
+   i32.store $0 offset=84
+   local.get $0
+   call $instanceof/assertDynamicTrue<~lib/object/Object,instanceof/X>
+   global.get $~lib/memory/__stack_pointer
+   global.get $instanceof/y
+   local.tee $0
+   i32.store $0 offset=84
+   local.get $0
+   call $instanceof/assertDynamicTrue<~lib/object/Object,instanceof/X>
+   global.get $~lib/memory/__stack_pointer
+   global.get $instanceof/y
+   local.tee $0
+   i32.store $0 offset=84
+   local.get $0
+   call $instanceof/assertDynamicTrue<~lib/object/Object,instanceof/X>
+   global.get $~lib/memory/__stack_pointer
+   global.get $instanceof/z
+   local.tee $0
+   i32.store $0 offset=84
+   local.get $0
+   call $instanceof/assertDynamicTrue<~lib/object/Object,instanceof/X>
+   global.get $~lib/memory/__stack_pointer
+   global.get $instanceof/z
+   local.tee $0
+   i32.store $0 offset=84
+   local.get $0
+   call $instanceof/assertDynamicTrue<~lib/object/Object,instanceof/X>
+   global.get $~lib/memory/__stack_pointer
+   global.get $instanceof/y
+   local.tee $0
+   i32.store $0 offset=84
+   local.get $0
+   call $instanceof/assertDynamicTrue<~lib/object/Object,instanceof/Y>
+   global.get $~lib/memory/__stack_pointer
+   global.get $instanceof/y
+   local.tee $0
+   i32.store $0 offset=84
+   local.get $0
+   call $instanceof/assertDynamicTrue<~lib/object/Object,instanceof/Y>
+   global.get $~lib/memory/__stack_pointer
+   global.get $instanceof/y
+   local.tee $0
+   i32.store $0 offset=84
+   local.get $0
+   call $instanceof/assertDynamicTrue<~lib/object/Object,instanceof/Y>
+   global.get $~lib/memory/__stack_pointer
+   global.get $instanceof/y
+   local.tee $0
+   i32.store $0 offset=84
+   local.get $0
+   call $instanceof/assertDynamicTrue<~lib/object/Object,instanceof/Y>
+   global.get $~lib/memory/__stack_pointer
+   global.get $instanceof/z
+   local.tee $0
+   i32.store $0 offset=84
+   local.get $0
+   call $instanceof/assertDynamicTrue<~lib/object/Object,instanceof/Y>
+   global.get $~lib/memory/__stack_pointer
+   global.get $instanceof/z
+   local.tee $0
+   i32.store $0 offset=84
+   local.get $0
+   call $instanceof/assertDynamicTrue<~lib/object/Object,instanceof/Y>
+   global.get $~lib/memory/__stack_pointer
+   global.get $instanceof/z
+   local.tee $0
+   i32.store $0 offset=84
+   local.get $0
+   call $instanceof/assertDynamicTrue<~lib/object/Object,instanceof/Y>
+   global.get $~lib/memory/__stack_pointer
+   global.get $instanceof/z
+   local.tee $0
+   i32.store $0 offset=84
+   local.get $0
+   call $instanceof/assertDynamicTrue<~lib/object/Object,instanceof/Y>
+   global.get $~lib/memory/__stack_pointer
+   global.get $instanceof/z
+   local.tee $0
+   i32.store $0 offset=84
+   local.get $0
+   call $instanceof/assertDynamicTrue<~lib/object/Object,instanceof/Z>
+   global.get $~lib/memory/__stack_pointer
+   global.get $instanceof/z
+   local.tee $0
+   i32.store $0 offset=84
+   local.get $0
+   call $instanceof/assertDynamicTrue<~lib/object/Object,instanceof/Z>
+   global.get $~lib/memory/__stack_pointer
+   global.get $instanceof/z
+   local.tee $0
+   i32.store $0 offset=84
+   local.get $0
+   call $instanceof/assertDynamicTrue<~lib/object/Object,instanceof/Z>
+   global.get $~lib/memory/__stack_pointer
+   global.get $instanceof/z
+   local.tee $0
+   i32.store $0 offset=84
+   local.get $0
+   call $instanceof/assertDynamicTrue<~lib/object/Object,instanceof/Z>
+   global.get $~lib/memory/__stack_pointer
+   i32.const 88
+   i32.add
+   global.set $~lib/memory/__stack_pointer
+   return
   end
-  i32.const 0
-  i32.const 1456
-  i32.const 12
-  i32.const 5
+  i32.const 34384
+  i32.const 34432
+  i32.const 1
+  i32.const 1
   call $~lib/builtins/abort
   unreachable
  )
@@ -2406,11 +3091,11 @@
   i32.sub
   global.set $~lib/memory/__stack_pointer
   global.get $~lib/memory/__stack_pointer
-  i32.const 1564
+  i32.const 1584
   i32.lt_s
   if
-   i32.const 34352
-   i32.const 34400
+   i32.const 34384
+   i32.const 34432
    i32.const 1
    i32.const 1
    call $~lib/builtins/abort
@@ -2440,11 +3125,11 @@
   i32.sub
   global.set $~lib/memory/__stack_pointer
   global.get $~lib/memory/__stack_pointer
-  i32.const 1564
+  i32.const 1584
   i32.lt_s
   if
-   i32.const 34352
-   i32.const 34400
+   i32.const 34384
+   i32.const 34432
    i32.const 1
    i32.const 1
    call $~lib/builtins/abort
@@ -2479,11 +3164,11 @@
   i32.sub
   global.set $~lib/memory/__stack_pointer
   global.get $~lib/memory/__stack_pointer
-  i32.const 1564
+  i32.const 1584
   i32.lt_s
   if
-   i32.const 34352
-   i32.const 34400
+   i32.const 34384
+   i32.const 34432
    i32.const 1
    i32.const 1
    call $~lib/builtins/abort
@@ -2518,11 +3203,11 @@
   i32.sub
   global.set $~lib/memory/__stack_pointer
   global.get $~lib/memory/__stack_pointer
-  i32.const 1564
+  i32.const 1584
   i32.lt_s
   if
-   i32.const 34352
-   i32.const 34400
+   i32.const 34384
+   i32.const 34432
    i32.const 1
    i32.const 1
    call $~lib/builtins/abort
@@ -2558,11 +3243,11 @@
   i32.sub
   global.set $~lib/memory/__stack_pointer
   global.get $~lib/memory/__stack_pointer
-  i32.const 1564
+  i32.const 1584
   i32.lt_s
   if
-   i32.const 34352
-   i32.const 34400
+   i32.const 34384
+   i32.const 34432
    i32.const 1
    i32.const 1
    call $~lib/builtins/abort
@@ -2580,6 +3265,84 @@
   global.get $~lib/memory/__stack_pointer
   local.get $0
   call $instanceof/Cat#constructor
+  local.tee $0
+  i32.store $0
+  global.get $~lib/memory/__stack_pointer
+  i32.const 4
+  i32.add
+  global.set $~lib/memory/__stack_pointer
+  local.get $0
+ )
+ (func $instanceof/X#constructor (type $i32_=>_i32) (param $0 i32) (result i32)
+  global.get $~lib/memory/__stack_pointer
+  i32.const 4
+  i32.sub
+  global.set $~lib/memory/__stack_pointer
+  global.get $~lib/memory/__stack_pointer
+  i32.const 1584
+  i32.lt_s
+  if
+   i32.const 34384
+   i32.const 34432
+   i32.const 1
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  global.get $~lib/memory/__stack_pointer
+  i32.const 0
+  i32.store $0
+  local.get $0
+  i32.eqz
+  if
+   global.get $~lib/memory/__stack_pointer
+   i32.const 15
+   call $~lib/rt/itcms/__new
+   local.tee $0
+   i32.store $0
+  end
+  global.get $~lib/memory/__stack_pointer
+  local.get $0
+  call $~lib/object/Object#constructor
+  local.tee $0
+  i32.store $0
+  global.get $~lib/memory/__stack_pointer
+  i32.const 4
+  i32.add
+  global.set $~lib/memory/__stack_pointer
+  local.get $0
+ )
+ (func $instanceof/Y#constructor (type $i32_=>_i32) (param $0 i32) (result i32)
+  global.get $~lib/memory/__stack_pointer
+  i32.const 4
+  i32.sub
+  global.set $~lib/memory/__stack_pointer
+  global.get $~lib/memory/__stack_pointer
+  i32.const 1584
+  i32.lt_s
+  if
+   i32.const 34384
+   i32.const 34432
+   i32.const 1
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  global.get $~lib/memory/__stack_pointer
+  i32.const 0
+  i32.store $0
+  local.get $0
+  i32.eqz
+  if
+   global.get $~lib/memory/__stack_pointer
+   i32.const 18
+   call $~lib/rt/itcms/__new
+   local.tee $0
+   i32.store $0
+  end
+  global.get $~lib/memory/__stack_pointer
+  local.get $0
+  call $instanceof/X#constructor
   local.tee $0
   i32.store $0
   global.get $~lib/memory/__stack_pointer

--- a/tests/compiler/instanceof.ts
+++ b/tests/compiler/instanceof.ts
@@ -176,21 +176,188 @@ assert(!(nullBlackcat instanceof BlackCat)); // dynamic false
 
 // Interfaces
 
-interface I1 {}
-interface I2 {}
-interface I3 extends I1 {}
-class A_I1 implements I1 {}
-class B_I1_I2 implements I1, I2 {}
+//  IA    W
+//   |
+//  IB    IC   IE
+//   |   /
+//   X  ID
+//   | /
+//   Y
+//   |
+//   Z
+class W {}
+interface IA {}
+interface IB extends IA {}
+class X implements IB {}
+interface IC {}
+interface ID extends IC {}
+class Y extends X implements ID {}
+class Z extends Y {}
+interface IE {}
 
-let a_i1 = new A_I1();
-assertStaticTrue<A_I1,Object>(a_i1);
-assertStaticTrue<A_I1,I1>(a_i1);
-assertStaticFalse<A_I1,I2>(a_i1);
-assertDynamicTrue<Object,I1>(a_i1);
+let w = new W();
+let x = new X();
+let y = new Y();
+let z = new Z();
 
-let b_i1_i2 = new B_I1_I2();
-assertStaticTrue<B_I1_I2,I1>(b_i1_i2);
-assertStaticTrue<B_I1_I2,I2>(b_i1_i2);
-assertStaticFalse<A_I1,B_I1_I2>(a_i1);
-assertDynamicFalse<I1,B_I1_I2>(a_i1);
-assertDynamicTrue<I1,B_I1_I2>(b_i1_i2);
+// <x> instanceof Object
+
+assertStaticTrue<W,Object>(w);
+assertStaticTrue<X,Object>(x);
+assertStaticTrue<Y,Object>(y);
+assertStaticTrue<Z,Object>(z);
+
+assertStaticTrue<IA,Object>(x);
+assertStaticTrue<IB,Object>(x);
+assertStaticTrue<IA,Object>(y);
+assertStaticTrue<IB,Object>(y);
+assertStaticTrue<IC,Object>(y);
+assertStaticTrue<ID,Object>(y);
+assertStaticTrue<IA,Object>(z);
+assertStaticTrue<IB,Object>(z);
+assertStaticTrue<IC,Object>(z);
+assertStaticTrue<ID,Object>(z);
+
+// Object instanceof <x>
+
+assertDynamicTrue<Object,W>(w);
+assertDynamicTrue<Object,X>(x);
+assertDynamicTrue<Object,X>(y);
+assertDynamicTrue<Object,X>(z);
+assertDynamicTrue<Object,Y>(y);
+assertDynamicTrue<Object,Y>(z);
+assertDynamicTrue<Object,Z>(z);
+
+assertDynamicTrue<Object,IA>(x);
+assertDynamicTrue<Object,IB>(x);
+assertDynamicTrue<Object,IA>(y);
+assertDynamicTrue<Object,IB>(y);
+assertDynamicTrue<Object,IC>(y);
+assertDynamicTrue<Object,ID>(y);
+assertDynamicTrue<Object,IA>(z);
+assertDynamicTrue<Object,IB>(z);
+assertDynamicTrue<Object,IC>(z);
+assertDynamicTrue<Object,ID>(z);
+
+// <class> instanceof <class>
+
+assertStaticTrue<W,W>(w);
+assertStaticFalse<W,X>(w);
+assertStaticFalse<W,Y>(w);
+assertStaticFalse<W,Z>(w);
+assertStaticFalse<X,W>(x);
+assertStaticFalse<Y,W>(y);
+assertStaticFalse<Z,W>(z);
+
+assertStaticTrue<X,X>(x);
+assertDynamicFalse<X,Y>(x);
+assertDynamicFalse<X,Z>(x);
+assertStaticTrue<X,X>(y);
+assertDynamicTrue<X,Y>(y);
+assertDynamicFalse<X,Z>(y);
+assertStaticTrue<X,X>(z);
+assertDynamicTrue<X,Y>(z);
+assertDynamicTrue<X,Z>(z);
+
+assertStaticTrue<Y,X>(y);
+assertStaticTrue<Y,Y>(y);
+assertDynamicFalse<Y,Z>(y);
+assertStaticTrue<Y,X>(z);
+assertStaticTrue<Y,Y>(z);
+assertDynamicTrue<Y,Z>(z);
+
+assertStaticTrue<Z,X>(z);
+assertStaticTrue<Z,Y>(z);
+assertStaticTrue<Z,Z>(z);
+
+// <interface> instanceof <interface>
+
+assertDynamicFalse<IA,IC>(x);
+assertDynamicFalse<IB,IC>(x);
+assertDynamicFalse<IA,ID>(x);
+assertDynamicFalse<IB,ID>(x);
+assertStaticFalse<IA,IE>(x);
+assertStaticFalse<IB,IE>(x);
+
+assertDynamicTrue<IA,IC>(y);
+assertDynamicTrue<IB,IC>(y);
+assertDynamicTrue<IA,ID>(y);
+assertDynamicTrue<IB,ID>(y);
+assertStaticFalse<IA,IE>(y);
+assertStaticFalse<IB,IE>(y);
+
+assertDynamicTrue<IA,IC>(z);
+assertDynamicTrue<IB,IC>(z);
+assertDynamicTrue<IA,ID>(z);
+assertDynamicTrue<IB,ID>(z);
+assertStaticFalse<IA,IE>(z);
+assertStaticFalse<IB,IE>(z);
+
+// <class> instanceof <interface>
+
+assertStaticTrue<X,IA>(x);
+assertStaticTrue<X,IB>(x);
+assertDynamicFalse<X,ID>(x);
+assertDynamicFalse<X,IC>(x);
+assertStaticFalse<X,IE>(x);
+assertStaticTrue<X,IA>(y);
+assertStaticTrue<X,IB>(y);
+assertDynamicTrue<X,ID>(y);
+assertDynamicTrue<X,IC>(y);
+assertStaticFalse<X,IE>(y);
+assertStaticTrue<X,IA>(z);
+assertStaticTrue<X,IB>(z);
+assertDynamicTrue<X,ID>(z);
+assertDynamicTrue<X,IC>(z);
+assertStaticFalse<X,IE>(z);
+
+assertStaticTrue<Y,IA>(y);
+assertStaticTrue<Y,IB>(y);
+assertStaticTrue<Y,ID>(y);
+assertStaticTrue<Y,IC>(y);
+assertStaticFalse<Y,IE>(y);
+assertStaticTrue<Y,IA>(z);
+assertStaticTrue<Y,IB>(z);
+assertStaticTrue<Y,ID>(z);
+assertStaticTrue<Y,IC>(z);
+assertStaticFalse<Y,IE>(z);
+
+assertStaticTrue<Z,IA>(z);
+assertStaticTrue<Z,IB>(z);
+assertStaticTrue<Z,ID>(z);
+assertStaticTrue<Z,IC>(z);
+assertStaticFalse<Z,IE>(z);
+
+// <interface> instanceof <class>
+
+assertStaticFalse<IA,W>(x);
+assertStaticFalse<IB,W>(x);
+assertStaticFalse<IA,W>(y);
+assertStaticFalse<IB,W>(y);
+assertStaticFalse<IC,W>(y);
+assertStaticFalse<ID,W>(y);
+assertStaticFalse<IA,W>(z);
+assertStaticFalse<IB,W>(z);
+assertStaticFalse<IC,W>(z);
+assertStaticFalse<ID,W>(z);
+
+assertDynamicTrue<IA,X>(x);
+assertDynamicTrue<IB,X>(x);
+assertDynamicTrue<IA,X>(y);
+assertDynamicTrue<IB,X>(y);
+assertDynamicTrue<IA,X>(z);
+assertDynamicTrue<IB,X>(z);
+
+assertDynamicTrue<IA,Y>(y);
+assertDynamicTrue<IB,Y>(y);
+assertDynamicTrue<IC,Y>(y);
+assertDynamicTrue<ID,Y>(y);
+assertDynamicTrue<IA,Y>(z);
+assertDynamicTrue<IB,Y>(z);
+assertDynamicTrue<IC,Y>(z);
+assertDynamicTrue<ID,Y>(z);
+
+assertDynamicTrue<IA,Z>(z);
+assertDynamicTrue<IB,Z>(z);
+assertDynamicTrue<IC,Z>(z);
+assertDynamicTrue<ID,Z>(z);

--- a/tests/compiler/instanceof.ts
+++ b/tests/compiler/instanceof.ts
@@ -1,3 +1,26 @@
+function assertStaticTrue<T,U>(value: T): void {
+  if (value instanceof U) return;
+  ERROR("should be statically true");
+}
+function assertStaticFalse<T,U>(value: T): void {
+  if (!(value instanceof U)) return;
+  ERROR("should be statically false");
+}
+function assertDynamicTrue<T,U>(value: T): void {
+  if (!(value instanceof U)) {
+    var check: i32 = 0;
+    assert(false);
+  }
+  assert(isDefined(check));
+}
+function assertDynamicFalse<T,U>(value: T): void {
+  if (value instanceof U) {
+    var check: i32 = 0;
+    assert(false);
+  }
+  assert(isDefined(check));
+}
+
 class A {}
 class B extends A {}
 
@@ -160,14 +183,14 @@ class A_I1 implements I1 {}
 class B_I1_I2 implements I1, I2 {}
 
 let a_i1 = new A_I1();
-assert(a_i1 instanceof Object);           // static true
-assert(a_i1 instanceof I1);               // static true
-assert(a_i1 as Object instanceof I1);     // dynamic true
-assert(!(a_i1 instanceof I2));            // static false
+assertStaticTrue<A_I1,Object>(a_i1);
+assertStaticTrue<A_I1,I1>(a_i1);
+assertStaticFalse<A_I1,I2>(a_i1);
+assertDynamicTrue<Object,I1>(a_i1);
 
 let b_i1_i2 = new B_I1_I2();
-assert(b_i1_i2 instanceof I1);            // static true
-assert(b_i1_i2 instanceof I2);            // static true
-assert(!(a_i1 instanceof B_I1_I2));       // dynamic false
-assert(!(a_i1 as I1 instanceof B_I1_I2)); // dynamic false
-assert(b_i1_i2 as I1 instanceof B_I1_I2); // dynamic true
+assertStaticTrue<B_I1_I2,I1>(b_i1_i2);
+assertStaticTrue<B_I1_I2,I2>(b_i1_i2);
+assertStaticFalse<A_I1,B_I1_I2>(a_i1);
+assertDynamicFalse<I1,B_I1_I2>(a_i1);
+assertDynamicTrue<I1,B_I1_I2>(b_i1_i2);

--- a/tests/compiler/instanceof.ts
+++ b/tests/compiler/instanceof.ts
@@ -151,11 +151,23 @@ assert(!(nullBlackcat instanceof Animal));   // static false
 assert(!(nullBlackcat instanceof Cat));      // dynamic false
 assert(!(nullBlackcat instanceof BlackCat)); // dynamic false
 
-// Interfaces participate and are Object instances
+// Interfaces
 
-interface IFace {}
-class ImplemensIFace implements IFace {}
+interface I1 {}
+interface I2 {}
+interface I3 extends I1 {}
+class A_I1 implements I1 {}
+class B_I1_I2 implements I1, I2 {}
 
-let impl = new ImplemensIFace();
-assert(impl instanceof IFace);           // static true
-assert(impl as Object instanceof IFace); // dynamic true
+let a_i1 = new A_I1();
+assert(a_i1 instanceof Object);           // static true
+assert(a_i1 instanceof I1);               // static true
+assert(a_i1 as Object instanceof I1);     // dynamic true
+assert(!(a_i1 instanceof I2));            // static false
+
+let b_i1_i2 = new B_I1_I2();
+assert(b_i1_i2 instanceof I1);            // static true
+assert(b_i1_i2 instanceof I2);            // static true
+assert(!(a_i1 instanceof B_I1_I2));       // dynamic false
+assert(!(a_i1 as I1 instanceof B_I1_I2)); // dynamic false
+assert(b_i1_i2 as I1 instanceof B_I1_I2); // dynamic true

--- a/tests/compiler/instanceof.ts
+++ b/tests/compiler/instanceof.ts
@@ -150,3 +150,12 @@ assert(!(nullCat instanceof BlackCat)); // dynamic false
 assert(!(nullBlackcat instanceof Animal));   // static false
 assert(!(nullBlackcat instanceof Cat));      // dynamic false
 assert(!(nullBlackcat instanceof BlackCat)); // dynamic false
+
+// Interfaces participate and are Object instances
+
+interface IFace {}
+class ImplemensIFace implements IFace {}
+
+let impl = new ImplemensIFace();
+assert(impl instanceof IFace);           // static true
+assert(impl as Object instanceof IFace); // dynamic true


### PR DESCRIPTION
Addresses #2577. One rather trivial part of the issue was that previously, since interfaces are not derived from `Object` but their implementing classes are, an `someInterface as Object instanceof SomeInterface` would fail. Another was that the check for when a cast may possibly succeed was overly simplistic, thus required more elaborate infrastructure.

The seemingly obvious alternative that doesn't work is to simply fall back to do dynamic checks if the relationship between the types is arbitrarily complicated (and hence possibly costly to compute), since that breaks assumptions about such checks being precomputable.

Making a draft for now while I untie the knot in my brain before figuring out how to best test the changes. Is perfectly possible that I missed something, hence I'd appreciate any amount of eyes on the new logic :)

- [x] I've read the contributing guidelines
- [x] I've added my name and email to the NOTICE file
