### PR TITLE
Integrate Rtrace with ESM bindings

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,6 +59,12 @@
     },
     "./*": "./*"
   },
+  "imports": {
+    "#rtrace": {
+      "import": "./lib/rtrace/index.js",
+      "types": "./lib/rtrace/index.d.ts"
+    }
+  },
   "bin": {
     "asc": "./bin/asc.js",
     "asinit": "./bin/asinit.js"

--- a/src/bindings/js.ts
+++ b/src/bindings/js.ts
@@ -92,6 +92,18 @@ import {
 //   callee expects a properly coerced integer value, leading to more `>>> 0`
 //   coercions than necessary when the import is actually another Wasm module.
 
+/** Maps special imports to their actual modules. */
+function importToModule(moduleName: string): string {
+  // Map rtrace via `imports` in package.json
+  if (moduleName == "rtrace") return "#rtrace";
+  return moduleName;
+}
+
+/** Determines whether a module's imports should be instrumented. */
+function shouldInstrument(moduleName: string): bool {
+  return moduleName != "rtrace";
+}
+
 /** A JavaScript bindings builder. */
 export class JSBuilder extends ExportsWalker {
 
@@ -515,6 +527,12 @@ export class JSBuilder extends ExportsWalker {
         sb.push(escapeString(moduleName, CharCode.DoubleQuote));
         sb.push("\"");
       }
+      if (!shouldInstrument(moduleName)) {
+        sb.push(": __module");
+        sb.push(moduleId.toString());
+        sb.push(",\n");
+        continue;
+      }
       let resetPos = sb.length;
       sb.push(": Object.assign(Object.create(");
       if (moduleName == "env") {
@@ -580,6 +598,14 @@ export class JSBuilder extends ExportsWalker {
         map.push("  const env = imports.env;\n");
       } else {
         let moduleId = <i32>mappings.get(moduleName);
+        if (moduleName == "rtrace") {
+          // Rtrace is special in that it needs to be installed on the imports
+          // object. Use sensible defaults and substitute the original import.
+          map.push("  ((rtrace) => {\n");
+          map.push("    delete imports.rtrace;\n");
+          map.push("    new rtrace.Rtrace({ getMemory() { return memory; }, onerror() { console.log(`RTRACE: ${err.stack}`); } }).install(imports);\n");
+          map.push("  })(imports.rtrace);\n");
+        }
         map.push("  const __module");
         map.push(moduleId.toString());
         map.push(" = imports");
@@ -914,7 +940,7 @@ export class JSBuilder extends ExportsWalker {
           importExpr.push("import * as __import");
           importExpr.push(moduleId.toString());
           importExpr.push(" from \"");
-          importExpr.push(escapeString(moduleName, CharCode.DoubleQuote));
+          importExpr.push(escapeString(importToModule(moduleName), CharCode.DoubleQuote));
           importExpr.push("\";\n");
           needsMaybeDefault = true;
         }

--- a/src/bindings/js.ts
+++ b/src/bindings/js.ts
@@ -603,7 +603,7 @@ export class JSBuilder extends ExportsWalker {
           // object. Use sensible defaults and substitute the original import.
           map.push("  ((rtrace) => {\n");
           map.push("    delete imports.rtrace;\n");
-          map.push("    new rtrace.Rtrace({ getMemory() { return memory; }, onerror() { console.log(`RTRACE: ${err.stack}`); } }).install(imports);\n");
+          map.push("    new rtrace.Rtrace({ getMemory() { return memory; }, onerror(err) { console.log(`RTRACE: ${err.stack}`); } }).install(imports);\n");
           map.push("  })(imports.rtrace);\n");
         }
         map.push("  const __module");


### PR DESCRIPTION
The Rtrace utility to inspect the inner workings of the runtime must be installed on the respective imports objects, which did not work as-is with ESM bindings

Hence, add a special case to ESM bindings generation to install Rtrace when used, exclude its imports from instrumentation, and import it with a private package specifier so it can be mapped via `imports` in package.json. Also unbreaks `bootstrap:rtraced` in so far as that it executes.

- [x] I've read the contributing guidelines
- [x] I've added my name and email to the NOTICE file
