### PR TITLE
Use DataView in bindings generation

### DIFF
--- a/src/bindings/js.ts
+++ b/src/bindings/js.ts
@@ -131,7 +131,22 @@ export class JSBuilder extends ExportsWalker {
   private needsRetain: bool = false;
   private needsRelease: bool = false;
   private needsNotNull: bool = false;
-  private needsStoreRef: bool = false;
+  private needsSetU8: bool = false;
+  private needsSetU16: bool = false;
+  private needsSetU32: bool = false;
+  private needsSetU64: bool = false;
+  private needsSetF32: bool = false;
+  private needsSetF64: bool = false;
+  private needsGetI8: bool = false;
+  private needsGetU8: bool = false;
+  private needsGetI16: bool = false;
+  private needsGetU16: bool = false;
+  private needsGetI32: bool = false;
+  private needsGetU32: bool = false;
+  private needsGetI64: bool = false;
+  private needsGetU64: bool = false;
+  private needsGetF32: bool = false;
+  private needsGetF64: bool = false;
 
   private deferredLifts: Set<Element> = new Set();
   private deferredLowers: Set<Element> = new Set();
@@ -718,12 +733,12 @@ export class JSBuilder extends ExportsWalker {
     if (this.needsLiftArray) {
       let dataStartOffset = program.arrayBufferViewInstance.offsetof("dataStart");
       let lengthOffset = program.arrayBufferViewInstance.nextMemoryOffset;
+      this.needsGetU32 = true;
       sb.push(`  function __liftArray(liftElement, align, pointer) {
     if (!pointer) return null;
     const
-      memoryU32 = new Uint32Array(memory.buffer),
-      dataStart = memoryU32[pointer + ${dataStartOffset} >>> 2],
-      length = memoryU32[pointer + ${lengthOffset} >>> 2],
+      dataStart = __getU32(pointer + ${dataStartOffset}),
+      length = __dataview.getUint32(pointer + ${lengthOffset}, true),
       values = new Array(length);
     for (let i = 0; i < length; ++i) values[i] = liftElement(dataStart + (i << align >>> 0));
     return values;
@@ -738,17 +753,17 @@ export class JSBuilder extends ExportsWalker {
       let dataStartOffset = arrayBufferViewInstance.offsetof("dataStart");
       let byteLengthOffset = arrayBufferViewInstance.offsetof("byteLength");
       let lengthOffset = byteLengthOffset + 4;
+      this.needsSetU32 = true;
       sb.push(`  function __lowerArray(lowerElement, id, align, values) {
     if (values == null) return 0;
     const
       length = values.length,
       buffer = exports.__pin(exports.__new(length << align, ${arrayBufferId})) >>> 0,
-      header = exports.__pin(exports.__new(${arraySize}, id)) >>> 0,
-      memoryU32 = new Uint32Array(memory.buffer);
-    memoryU32[header + ${bufferOffset} >>> 2] = buffer;
-    memoryU32[header + ${dataStartOffset} >>> 2] = buffer;
-    memoryU32[header + ${byteLengthOffset} >>> 2] = length << align;
-    memoryU32[header + ${lengthOffset} >>> 2] = length;
+      header = exports.__pin(exports.__new(${arraySize}, id)) >>> 0;
+    __setU32(header + ${bufferOffset}, buffer);
+    __dataview.setUint32(header + ${dataStartOffset}, buffer, true);
+    __dataview.setUint32(header + ${byteLengthOffset}, length << align, true);
+    __dataview.setUint32(header + ${lengthOffset}, length, true);
     for (let i = 0; i < length; ++i) lowerElement(buffer + (i << align >>> 0), values[i]);
     exports.__unpin(buffer);
     exports.__unpin(header);
@@ -760,13 +775,13 @@ export class JSBuilder extends ExportsWalker {
       let arrayBufferViewInstance = program.arrayBufferViewInstance;
       let dataStartOffset = arrayBufferViewInstance.offsetof("dataStart");
       let byteLengthOffset = arrayBufferViewInstance.offsetof("byteLength");
+      this.needsGetU32 = true;
       sb.push(`  function __liftTypedArray(constructor, pointer) {
     if (!pointer) return null;
-    const memoryU32 = new Uint32Array(memory.buffer);
     return new constructor(
       memory.buffer,
-      memoryU32[pointer + ${dataStartOffset} >>> 2],
-      memoryU32[pointer + ${byteLengthOffset} >>> 2] / constructor.BYTES_PER_ELEMENT
+      __getU32(pointer + ${dataStartOffset}),
+      __dataview.getUint32(pointer + ${byteLengthOffset}, true) / constructor.BYTES_PER_ELEMENT
     ).slice();
   }
 `);
@@ -778,16 +793,16 @@ export class JSBuilder extends ExportsWalker {
       let bufferOffset = arrayBufferViewInstance.offsetof("buffer");
       let dataStartOffset = arrayBufferViewInstance.offsetof("dataStart");
       let byteLengthOffset = arrayBufferViewInstance.offsetof("byteLength");
+      this.needsSetU32 = true;
       sb.push(`  function __lowerTypedArray(constructor, id, align, values) {
     if (values == null) return 0;
     const
       length = values.length,
       buffer = exports.__pin(exports.__new(length << align, ${arrayBufferId})) >>> 0,
-      header = exports.__new(${size}, id) >>> 0,
-      memoryU32 = new Uint32Array(memory.buffer);
-    memoryU32[header + ${bufferOffset} >>> 2] = buffer;
-    memoryU32[header + ${dataStartOffset} >>> 2] = buffer;
-    memoryU32[header + ${byteLengthOffset} >>> 2] = length << align;
+      header = exports.__new(${size}, id) >>> 0;
+    __setU32(header + ${bufferOffset}, buffer);
+    __dataview.setUint32(header + ${dataStartOffset}, buffer, true);
+    __dataview.setUint32(header + ${byteLengthOffset}, length << align, true);
     new constructor(memory.buffer, buffer, length).set(values);
     exports.__unpin(buffer);
     return header;
@@ -797,10 +812,11 @@ export class JSBuilder extends ExportsWalker {
     if (this.needsLiftStaticArray) {
       let objectInstance = program.OBJECTInstance;
       let rtSizeOffset = objectInstance.offsetof("rtSize") - objectInstance.nextMemoryOffset;
+      this.needsGetU32 = true;
       sb.push(`  function __liftStaticArray(liftElement, align, pointer) {
     if (!pointer) return null;
     const
-      length = new Uint32Array(memory.buffer)[pointer - ${-rtSizeOffset} >>> 2] >>> align,
+      length = __getU32(pointer - ${-rtSizeOffset}) >>> align,
       values = new Array(length);
     for (let i = 0; i < length; ++i) values[i] = liftElement(pointer + (i << align >>> 0));
     return values;
@@ -878,12 +894,42 @@ export class JSBuilder extends ExportsWalker {
   }
 `);
     }
-    if (this.needsStoreRef) {
-      sb.push(`  function __store_ref(pointer, value) {
-    new Uint32Array(memory.buffer)[pointer >>> 2] = value;
-  }
-`);
+    if (
+      this.needsSetU8 ||
+      this.needsSetU16 ||
+      this.needsSetU32 ||
+      this.needsSetU64 ||
+      this.needsSetF32 ||
+      this.needsSetF64 ||
+      this.needsGetI8 ||
+      this.needsGetU8 ||
+      this.needsGetI16 ||
+      this.needsGetU16 ||
+      this.needsGetI32 ||
+      this.needsGetU32 ||
+      this.needsGetI64 ||
+      this.needsGetU64 ||
+      this.needsGetF32 ||
+      this.needsGetF64
+    ) {
+      sb.push("  let __dataview = new DataView(memory.buffer);\n");
     }
+    if (this.needsSetU8) sb.push(makeCheckedSetter("U8", "setUint8"));
+    if (this.needsSetU16) sb.push(makeCheckedSetter("U16", "setUint16"));
+    if (this.needsSetU32) sb.push(makeCheckedSetter("U32", "setUint32"));
+    if (this.needsSetU64) sb.push(makeCheckedSetter("U64", "setBigUint64"));
+    if (this.needsSetF32) sb.push(makeCheckedSetter("F32", "setFloat32"));
+    if (this.needsSetF64) sb.push(makeCheckedSetter("F64", "setFloat64"));
+    if (this.needsGetI8) sb.push(makeCheckedGetter("I8", "getInt8"));
+    if (this.needsGetU8) sb.push(makeCheckedGetter("U8", "getUint8"));
+    if (this.needsGetI16) sb.push(makeCheckedGetter("I16", "getInt16"));
+    if (this.needsGetU16) sb.push(makeCheckedGetter("U16", "getUint16"));
+    if (this.needsGetI32) sb.push(makeCheckedGetter("I32", "getInt32"));
+    if (this.needsGetU32) sb.push(makeCheckedGetter("U32", "getUint32"));
+    if (this.needsGetI64) sb.push(makeCheckedGetter("I64", "getBigInt64"));
+    if (this.needsGetU64) sb.push(makeCheckedGetter("U64", "getBigUint64"));
+    if (this.needsGetF32) sb.push(makeCheckedGetter("F32", "getFloat32"));
+    if (this.needsGetF64) sb.push(makeCheckedGetter("F64", "getFloat64"));
 
     let exportStart = options.exportStart;
     if (exportStart) {
@@ -971,8 +1017,8 @@ export class JSBuilder extends ExportsWalker {
     return moduleId;
   }
 
-  /** Lifts a WebAssembly value to a JavaScript value. */
-  makeLiftFromValue(name: string, type: Type, sb: string[] = this.sb): void {
+  /** Lifts a WebAssembly value to a JavaScript value, as an expression. */
+  makeLiftFromValue(valueExpr: string, type: Type, sb: string[] = this.sb): void {
     if (type.isInternalReference) {
       // Lift reference types
       const clazz = assert(type.getClassOrWrapper(this.program));
@@ -985,7 +1031,7 @@ export class JSBuilder extends ExportsWalker {
       } else if (clazz.extendsPrototype(this.program.arrayPrototype)) {
         let valueType = clazz.getArrayValueType();
         sb.push("__liftArray(");
-        this.makeLiftFromMemory(valueType, sb);
+        this.makeLiftFromMemoryFunc(valueType, sb);
         sb.push(", ");
         sb.push(valueType.alignLog2.toString());
         sb.push(", ");
@@ -993,7 +1039,7 @@ export class JSBuilder extends ExportsWalker {
       } else if (clazz.extendsPrototype(this.program.staticArrayPrototype)) {
         let valueType = clazz.getArrayValueType();
         sb.push("__liftStaticArray(");
-        this.makeLiftFromMemory(valueType, sb);
+        this.makeLiftFromMemoryFunc(valueType, sb);
         sb.push(", ");
         sb.push(valueType.alignLog2.toString());
         sb.push(", ");
@@ -1024,26 +1070,30 @@ export class JSBuilder extends ExportsWalker {
         sb.push("__liftInternref(");
         this.needsLiftInternref = true;
       }
-      sb.push(name);
-      if (!name.startsWith("new Uint32Array(")) {
+      sb.push(valueExpr);
+      if (!valueExpr.startsWith("__get")) {
         // no need to coerce when lifting with indirection
         sb.push(" >>> 0");
       }
       sb.push(")");
     } else {
-      // Lift basic plain types
-      if (type == Type.bool) {
-        sb.push(`${name} != 0`);
+      // Lift and coerce basic values (from a Wasm export)
+      if (type == Type.bool) { // i32 to boolean
+        sb.push(`${valueExpr} != 0`);
       } else if (type.isUnsignedIntegerValue && type.size >= 32) {
-        sb.push(type.size == 64 ? `BigInt.asUintN(64, ${name})` : `${name} >>> 0`);
+        if (type.size == 64) { // i64 to unsigned bigint
+          sb.push(`BigInt.asUintN(64, ${valueExpr})`);
+        } else { // i32 to unsigned
+          sb.push(`${valueExpr} >>> 0`);
+        }
       } else {
-        sb.push(name);
+        sb.push(valueExpr);
       }
     }
   }
 
-  /** Lowers a JavaScript value to a WebAssembly value. */
-  makeLowerToValue(name: string, type: Type, sb: string[] = this.sb): void {
+  /** Lowers a JavaScript value to a WebAssembly value, as an expression. */
+  makeLowerToValue(valueExpr: string, type: Type, sb: string[] = this.sb): void {
     if (type.isInternalReference) {
       // Lower reference types
       const clazz = assert(type.getClassOrWrapper(this.program));
@@ -1056,7 +1106,7 @@ export class JSBuilder extends ExportsWalker {
       } else if (clazz.extendsPrototype(this.program.arrayPrototype)) {
         let valueType = clazz.getArrayValueType();
         sb.push("__lowerArray(");
-        this.makeLowerToMemory(valueType, sb);
+        this.makeLowerToMemoryFunc(valueType, sb);
         sb.push(", ");
         sb.push(clazz.id.toString());
         sb.push(", ");
@@ -1066,7 +1116,7 @@ export class JSBuilder extends ExportsWalker {
       } else if (clazz.extendsPrototype(this.program.staticArrayPrototype)) {
         let valueType = clazz.getArrayValueType();
         sb.push("__lowerStaticArray(");
-        this.makeLowerToMemory(valueType, sb);
+        this.makeLowerToMemoryFunc(valueType, sb);
         sb.push(", ");
         sb.push(clazz.id.toString());
         sb.push(", ");
@@ -1104,7 +1154,7 @@ export class JSBuilder extends ExportsWalker {
         sb.push("__lowerInternref(");
         this.needsLowerInternref = true;
       }
-      sb.push(name);
+      sb.push(valueExpr);
       if (clazz.extendsPrototype(this.program.staticArrayPrototype)) {
         // optional last argument for __lowerStaticArray
         let valueType = clazz.getArrayValueType();
@@ -1143,7 +1193,7 @@ export class JSBuilder extends ExportsWalker {
       }
     } else {
       // Lower basic types
-      sb.push(name); // basic value
+      sb.push(valueExpr); // basic value
       if (type.isIntegerValue && type.size == 64) {
         sb.push(" || 0n");
       } else if (type == Type.bool) {
@@ -1153,108 +1203,144 @@ export class JSBuilder extends ExportsWalker {
     }
   }
 
-  /** Lifts a WebAssembly memory address to a JavaScript value. */
-  makeLiftFromMemory(valueType: Type, sb: string[] = this.sb, target: string | null = null): void {
-    if (!target) {
-      sb.push("pointer => ");
-      target = "pointer";
-    }
+  ensureLiftFromMemoryFn(valueType: Type): string {
     if (valueType.isInternalReference) {
-      let expr = new Array<string>();
-      expr.push("new Uint32Array(memory.buffer)[");
-      expr.push(target);
-      expr.push(" >>> 2]");
-      this.makeLiftFromValue(expr.join(""), valueType, sb);
-    } else {
-      if (valueType == Type.i8) {
-        sb.push("new Int8Array(memory.buffer)[");
-      } else if (valueType == Type.u8 || valueType == Type.bool) {
-        sb.push("new Uint8Array(memory.buffer)[");
-      } else if (valueType == Type.i16) {
-        sb.push("new Int16Array(memory.buffer)[");
-      } else if (valueType == Type.u16) {
-        sb.push("new Uint16Array(memory.buffer)[");
-      } else if (valueType == Type.i32 || valueType == Type.isize32) {
-        sb.push("new Int32Array(memory.buffer)[");
-      } else if (valueType == Type.u32 || valueType == Type.usize32) {
-        sb.push("new Uint32Array(memory.buffer)[");
-      } else if (valueType == Type.i64 || valueType == Type.isize64) {
-        sb.push("new BigInt64Array(memory.buffer)[");
-      } else if (valueType == Type.u64 || valueType == Type.usize64) {
-        sb.push("new BigUint64Array(memory.buffer)[");
-      } else if (valueType == Type.f32) {
-        sb.push("new Float32Array(memory.buffer)[");
-      } else if (valueType == Type.f64) {
-        sb.push("new Float64Array(memory.buffer)[");
+      if (this.program.options.isWasm64) {
+        this.needsGetU64 = true;
+        return "__getU64";
       } else {
-        sb.push("{ throw Error(\"unsupported type\"); }");
-        return;
+        this.needsGetU32 = true;
+        return "__getU32";
       }
-      sb.push(target);
-      sb.push(" >>> ");
-      sb.push(valueType.alignLog2.toString());
-      sb.push("]");
+    }
+    if (valueType == Type.i8) {
+      this.needsGetI8 = true;
+      return "__getI8";
+    }
+    if (valueType == Type.u8 || valueType == Type.bool) {
+      this.needsGetU8 = true;
+      return "__getU8";
+    }
+    if (valueType == Type.i16) {
+      this.needsGetI16 = true;
+      return "__getI16";
+    }
+    if (valueType == Type.u16) {
+      this.needsGetU16 = true;
+      return "__getU16";
+    }
+    if (valueType == Type.i32 || valueType == Type.isize32) {
+      this.needsGetI32 = true;
+      return "__getI32";
+    }
+    if (valueType == Type.u32 || valueType == Type.usize32) {
+      this.needsGetU32 = true;
+      return "__getU32";
+    }
+    if (valueType == Type.i64 || valueType == Type.isize64) {
+      this.needsGetI64 = true;
+      return "__getI64";
+    }
+    if (valueType == Type.u64 || valueType == Type.usize64) {
+      this.needsGetU64 = true;
+      return "__getU64";
+    }
+    if (valueType == Type.f32) {
+      this.needsGetF32 = true;
+      return "__getF32";
+    }
+    if (valueType == Type.f64) {
+      this.needsGetF64 = true;
+      return "__getF64";
+    }
+    return "(() => { throw Error(\"unsupported type\"); })";
+  }
+
+  /** Lifts a WebAssembly memory address to a JavaScript value, as a function. */
+  makeLiftFromMemoryFunc(valueType: Type, sb: string[] = this.sb): void {
+    let fn = this.ensureLiftFromMemoryFn(valueType);
+    sb.push("pointer => ");
+    this.makeLiftFromValue(`${fn}(pointer)`, valueType, sb);
+    // TODO: Can sometimes omit the arrow function
+  }
+
+  /** Lifts a WebAssembly memory address to a JavaScript value, as a call. */
+  makeLiftFromMemoryCall(valueType: Type, sb: string[] = this.sb, pointerExpr: string): void {
+    let fn = this.ensureLiftFromMemoryFn(valueType);
+    if (valueType.isInternalReference) {
+      this.makeLiftFromValue(`${fn}(${pointerExpr})`, valueType, sb);
+    } else {
+      sb.push(fn);
+      sb.push("(");
+      sb.push(pointerExpr);
+      sb.push(")");
       if (valueType == Type.bool) {
         sb.push(" != 0");
       }
+      // BigInt already lifts as either signed or unsigned
     }
   }
 
-  /** Lowers a JavaScript value to a WebAssembly memory address. */
-  makeLowerToMemory(valueType: Type, sb: string[] = this.sb, targetName: string | null = null, valueName: string | null = null): void {
-    let skipTail = true;
-    if (!targetName  || !valueName) {
-      sb.push("(pointer, value) => { ");
-      targetName = "pointer";
-      valueName = "value";
-      skipTail = false;
-    }
+  ensureLowerToMemoryFn(valueType: Type): string {
     if (valueType.isInternalReference) {
-      // The RHS is typically another lowering to memory, which may trigger
-      // memory growth. Use a helper closure to delay evaluation of `memory`.
-      this.needsStoreRef = true;
-      sb.push("__store_ref(");
-      sb.push(targetName);
-      sb.push(", ");
-      this.makeLowerToValue(valueName, valueType, sb);
-      sb.push(")");
-      if (!skipTail) sb.push("; }");
-      return;
-    }
-    if (valueType == Type.i8) {
-      sb.push("new Int8Array(memory.buffer)[");
-    } else if (valueType == Type.u8 || valueType == Type.bool) {
-      sb.push("new Uint8Array(memory.buffer)[");
-    } else if (valueType == Type.i16) {
-      sb.push("new Int16Array(memory.buffer)[");
-    } else if (valueType == Type.u16) {
-      sb.push("new Uint16Array(memory.buffer)[");
-    } else if (valueType == Type.i32 || valueType == Type.isize32) {
-      sb.push("new Int32Array(memory.buffer)[");
-    } else if (valueType == Type.u32 || valueType == Type.usize32) {
-      sb.push("new Uint32Array(memory.buffer)[");
-    } else if (valueType == Type.i64 || valueType == Type.isize64) {
-      sb.push("new BigInt64Array(memory.buffer)[");
-    } else if (valueType == Type.u64 || valueType == Type.usize64) {
-      sb.push("new BigUint64Array(memory.buffer)[");
-    } else if (valueType == Type.f32) {
-      sb.push("new Float32Array(memory.buffer)[");
-    } else if (valueType == Type.f64) {
-      sb.push("new Float64Array(memory.buffer)[");
-    } else {
-      if (skipTail) {
-        sb.push("(() => { throw Error(\"unsupported type\") })()");
+      if (this.program.options.isWasm64) {
+        this.needsSetU64 = true;
+        return "__setU64";
       } else {
-        sb.push("throw Error(\"unsupported type\"); }");
+        this.needsSetU32 = true;
+        return "__setU32";
       }
-      return;
     }
-    sb.push(targetName);
-    sb.push(" >>> ");
-    sb.push(valueType.alignLog2.toString());
-    sb.push("] = ");
-    this.makeLowerToValue(valueName, valueType, sb);
-    if (!skipTail) sb.push("; }");
+    if (valueType == Type.i8 || valueType == Type.u8 || valueType == Type.bool) {
+      this.needsSetU8 = true;
+      return "__setU8";
+    }
+    if (valueType == Type.i16 || valueType == Type.u16) {
+      this.needsSetU16 = true;
+      return "__setU16";
+    }
+    if (valueType == Type.i32 || valueType == Type.u32 || valueType == Type.isize32 || valueType == Type.usize32) {
+      this.needsSetU32 = true;
+      return "__setU32";
+    }
+    if (valueType == Type.i64 || valueType == Type.u64 || valueType == Type.isize64 || valueType == Type.usize64) {
+      this.needsSetU64 = true;
+      return "__setU64";
+    }
+    if (valueType == Type.f32) {
+      this.needsSetF32 = true;
+      return "__setF32";
+    }
+    if (valueType == Type.f64) {
+      this.needsSetF64 = true;
+      return "__setF64";
+    }
+    return "(() => { throw Error(\"unsupported type\") })";
+  }
+
+  /** Lowers a JavaScript value to a WebAssembly memory address, as a function. */
+  makeLowerToMemoryFunc(valueType: Type, sb: string[] = this.sb): void {
+    let fn = this.ensureLowerToMemoryFn(valueType);
+    if (valueType.isInternalReference) {
+      sb.push("(pointer, value) => { ");
+      sb.push(fn);
+      sb.push("(pointer, ");
+      this.makeLowerToValue("value", valueType, sb);
+      sb.push("); }");
+    } else {
+      sb.push(fn);
+    }
+  }
+
+  /** Lowers a JavaScript value to a WebAssembly memory address, as a call. */
+  makeLowerToMemoryCall(valueType: Type, sb: string[] = this.sb, pointerExpr: string = "pointer", valueExpr: string = "value"): void {
+    let fn = this.ensureLowerToMemoryFn(valueType);
+    sb.push(fn);
+    sb.push("(");
+    sb.push(pointerExpr);
+    sb.push(",");
+    this.makeLowerToValue(valueExpr, valueType, sb);
+    sb.push(")");
   }
 
   makeLiftRecord(clazz: Class): string {
@@ -1286,7 +1372,7 @@ export class JSBuilder extends ExportsWalker {
         indent(sb, this.indentLevel);
         sb.push(property.name);
         sb.push(": ");
-        this.makeLiftFromMemory(property.type, sb, "pointer + " + property.memoryOffset.toString());
+        this.makeLiftFromMemoryCall(property.type, sb, `pointer + ${property.memoryOffset}`);
         sb.push(",\n");
       }
     }
@@ -1328,7 +1414,7 @@ export class JSBuilder extends ExportsWalker {
         if (!property || !property.isField) continue;
         assert(property.memoryOffset >= 0);
         indent(sb, this.indentLevel);
-        this.makeLowerToMemory(property.type, sb, "pointer + " + property.memoryOffset.toString(), "value." + memberName);
+        this.makeLowerToMemoryCall(property.type, sb, `pointer + ${property.memoryOffset}`, `value.${memberName}`);
         sb.push(";\n");
       }
     }
@@ -1465,4 +1551,30 @@ export function lowerRequiresExportRuntime(type: Type): bool {
   // complex objects lower via internref by reference,
   // while plain objects lower using __new
   return isPlainObject(clazz);
+}
+
+/** Makes a checked setter function to memory for the given basic type. */
+function makeCheckedSetter(type: string, fn: string): string {
+  return `  function __set${type}(pointer, value) {
+    try {
+      __dataview.${fn}(pointer, value, true);
+    } catch {
+      __dataview = new DataView(memory.buffer);
+      __dataview.${fn}(pointer, value, true);
+    }
+  }
+`;
+}
+
+/** Makes a checked getter function from memory for the given basic type. */
+function makeCheckedGetter(type: string, fn: string): string {
+  return `  function __get${type}(pointer) {
+    try {
+      return __dataview.${fn}(pointer, true);
+    } catch {
+      __dataview = new DataView(memory.buffer);
+      return __dataview.${fn}(pointer, true);
+    }
+  }
+`;
 }

--- a/tests/compiler/bindings/esm.debug.d.ts
+++ b/tests/compiler/bindings/esm.debug.d.ts
@@ -119,12 +119,19 @@ export declare function staticarrayI64(a: ArrayLike<bigint>): ArrayLike<bigint>;
  */
 export declare function arrayFunction(a: Array<number>, b: Array<number>): Array<number>;
 /**
+ * bindings/esm/arrayOfStringsFunction
+ * @param a `~lib/array/Array<~lib/string/String>`
+ * @param b `~lib/array/Array<~lib/string/String>`
+ * @returns `~lib/array/Array<~lib/string/String>`
+ */
+export declare function arrayOfStringsFunction(a: Array<string>, b: Array<string>): Array<string>;
+/**
  * bindings/esm/objectFunction
  * @param a `bindings/esm/PlainObject`
  * @param b `bindings/esm/PlainObject`
  * @returns `bindings/esm/PlainObject`
  */
-export declare function objectFunction(a: __Record12<undefined>, b: __Record12<undefined>): __Record12<never>;
+export declare function objectFunction(a: __Record13<undefined>, b: __Record13<undefined>): __Record13<never>;
 /**
  * bindings/esm/newInternref
  * @returns `bindings/esm/NonPlainObject`
@@ -149,7 +156,7 @@ export declare const fn: {
   get value(): __Internref4
 };
 /** bindings/esm/PlainObject */
-declare interface __Record12<TOmittable> {
+declare interface __Record13<TOmittable> {
   /** @type `i8` */
   a: number | TOmittable;
   /** @type `i16` */

--- a/tests/compiler/bindings/esm.debug.js
+++ b/tests/compiler/bindings/esm.debug.js
@@ -137,40 +137,50 @@ async function instantiate(module, imports = {}) {
     },
     staticarrayFunction(a, b) {
       // bindings/esm/staticarrayFunction(~lib/staticarray/StaticArray<i32>, ~lib/staticarray/StaticArray<i32>) => ~lib/staticarray/StaticArray<i32>
-      a = __retain(__lowerStaticArray((pointer, value) => { new Int32Array(memory.buffer)[pointer >>> 2] = value; }, 8, 2, a, Int32Array) || __notnull());
-      b = __lowerStaticArray((pointer, value) => { new Int32Array(memory.buffer)[pointer >>> 2] = value; }, 8, 2, b, Int32Array) || __notnull();
+      a = __retain(__lowerStaticArray(__setU32, 8, 2, a, Int32Array) || __notnull());
+      b = __lowerStaticArray(__setU32, 8, 2, b, Int32Array) || __notnull();
       try {
-        return __liftStaticArray(pointer => new Int32Array(memory.buffer)[pointer >>> 2], 2, exports.staticarrayFunction(a, b) >>> 0);
+        return __liftStaticArray(pointer => __getI32(pointer), 2, exports.staticarrayFunction(a, b) >>> 0);
       } finally {
         __release(a);
       }
     },
     staticarrayU16(a) {
       // bindings/esm/staticarrayU16(~lib/staticarray/StaticArray<u16>) => ~lib/staticarray/StaticArray<u16>
-      a = __lowerStaticArray((pointer, value) => { new Uint16Array(memory.buffer)[pointer >>> 1] = value; }, 9, 1, a, Uint16Array) || __notnull();
-      return __liftStaticArray(pointer => new Uint16Array(memory.buffer)[pointer >>> 1], 1, exports.staticarrayU16(a) >>> 0);
+      a = __lowerStaticArray(__setU16, 9, 1, a, Uint16Array) || __notnull();
+      return __liftStaticArray(pointer => __getU16(pointer), 1, exports.staticarrayU16(a) >>> 0);
     },
     staticarrayI64(a) {
       // bindings/esm/staticarrayI64(~lib/staticarray/StaticArray<i64>) => ~lib/staticarray/StaticArray<i64>
-      a = __lowerStaticArray((pointer, value) => { new BigInt64Array(memory.buffer)[pointer >>> 3] = value || 0n; }, 10, 3, a, BigInt64Array) || __notnull();
-      return __liftStaticArray(pointer => new BigInt64Array(memory.buffer)[pointer >>> 3], 3, exports.staticarrayI64(a) >>> 0);
+      a = __lowerStaticArray(__setU64, 10, 3, a, BigInt64Array) || __notnull();
+      return __liftStaticArray(pointer => __getI64(pointer), 3, exports.staticarrayI64(a) >>> 0);
     },
     arrayFunction(a, b) {
       // bindings/esm/arrayFunction(~lib/array/Array<i32>, ~lib/array/Array<i32>) => ~lib/array/Array<i32>
-      a = __retain(__lowerArray((pointer, value) => { new Int32Array(memory.buffer)[pointer >>> 2] = value; }, 11, 2, a) || __notnull());
-      b = __lowerArray((pointer, value) => { new Int32Array(memory.buffer)[pointer >>> 2] = value; }, 11, 2, b) || __notnull();
+      a = __retain(__lowerArray(__setU32, 11, 2, a) || __notnull());
+      b = __lowerArray(__setU32, 11, 2, b) || __notnull();
       try {
-        return __liftArray(pointer => new Int32Array(memory.buffer)[pointer >>> 2], 2, exports.arrayFunction(a, b) >>> 0);
+        return __liftArray(pointer => __getI32(pointer), 2, exports.arrayFunction(a, b) >>> 0);
+      } finally {
+        __release(a);
+      }
+    },
+    arrayOfStringsFunction(a, b) {
+      // bindings/esm/arrayOfStringsFunction(~lib/array/Array<~lib/string/String>, ~lib/array/Array<~lib/string/String>) => ~lib/array/Array<~lib/string/String>
+      a = __retain(__lowerArray((pointer, value) => { __setU32(pointer, __lowerString(value) || __notnull()); }, 12, 2, a) || __notnull());
+      b = __lowerArray((pointer, value) => { __setU32(pointer, __lowerString(value) || __notnull()); }, 12, 2, b) || __notnull();
+      try {
+        return __liftArray(pointer => __liftString(__getU32(pointer)), 2, exports.arrayOfStringsFunction(a, b) >>> 0);
       } finally {
         __release(a);
       }
     },
     objectFunction(a, b) {
       // bindings/esm/objectFunction(bindings/esm/PlainObject, bindings/esm/PlainObject) => bindings/esm/PlainObject
-      a = __retain(__lowerRecord12(a) || __notnull());
-      b = __lowerRecord12(b) || __notnull();
+      a = __retain(__lowerRecord13(a) || __notnull());
+      b = __lowerRecord13(b) || __notnull();
       try {
-        return __liftRecord12(exports.objectFunction(a, b) >>> 0);
+        return __liftRecord13(exports.objectFunction(a, b) >>> 0);
       } finally {
         __release(a);
       }
@@ -202,51 +212,51 @@ async function instantiate(module, imports = {}) {
       }
     },
   }, exports);
-  function __lowerRecord12(value) {
+  function __lowerRecord13(value) {
     // bindings/esm/PlainObject
     // Hint: Opt-out from lowering as a record by providing an empty constructor
     if (value == null) return 0;
-    const pointer = exports.__pin(exports.__new(68, 12));
-    new Int8Array(memory.buffer)[pointer + 0 >>> 0] = value.a;
-    new Int16Array(memory.buffer)[pointer + 2 >>> 1] = value.b;
-    new Int32Array(memory.buffer)[pointer + 4 >>> 2] = value.c;
-    new BigInt64Array(memory.buffer)[pointer + 8 >>> 3] = value.d || 0n;
-    new Uint8Array(memory.buffer)[pointer + 16 >>> 0] = value.e;
-    new Uint16Array(memory.buffer)[pointer + 18 >>> 1] = value.f;
-    new Uint32Array(memory.buffer)[pointer + 20 >>> 2] = value.g;
-    new BigUint64Array(memory.buffer)[pointer + 24 >>> 3] = value.h || 0n;
-    new Int32Array(memory.buffer)[pointer + 32 >>> 2] = value.i;
-    new Uint32Array(memory.buffer)[pointer + 36 >>> 2] = value.j;
-    new Uint8Array(memory.buffer)[pointer + 40 >>> 0] = value.k ? 1 : 0;
-    new Float32Array(memory.buffer)[pointer + 44 >>> 2] = value.l;
-    new Float64Array(memory.buffer)[pointer + 48 >>> 3] = value.m;
-    __store_ref(pointer + 56, __lowerString(value.n));
-    __store_ref(pointer + 60, __lowerTypedArray(Uint8Array, 13, 0, value.o));
-    __store_ref(pointer + 64, __lowerArray((pointer, value) => { __store_ref(pointer, __lowerString(value) || __notnull()); }, 14, 2, value.p));
+    const pointer = exports.__pin(exports.__new(68, 13));
+    __setU8(pointer + 0,value.a);
+    __setU16(pointer + 2,value.b);
+    __setU32(pointer + 4,value.c);
+    __setU64(pointer + 8,value.d || 0n);
+    __setU8(pointer + 16,value.e);
+    __setU16(pointer + 18,value.f);
+    __setU32(pointer + 20,value.g);
+    __setU64(pointer + 24,value.h || 0n);
+    __setU32(pointer + 32,value.i);
+    __setU32(pointer + 36,value.j);
+    __setU8(pointer + 40,value.k ? 1 : 0);
+    __setF32(pointer + 44,value.l);
+    __setF64(pointer + 48,value.m);
+    __setU32(pointer + 56,__lowerString(value.n));
+    __setU32(pointer + 60,__lowerTypedArray(Uint8Array, 14, 0, value.o));
+    __setU32(pointer + 64,__lowerArray((pointer, value) => { __setU32(pointer, __lowerString(value) || __notnull()); }, 12, 2, value.p));
     exports.__unpin(pointer);
     return pointer;
   }
-  function __liftRecord12(pointer) {
+  function __liftRecord13(pointer) {
     // bindings/esm/PlainObject
     // Hint: Opt-out from lifting as a record by providing an empty constructor
     if (!pointer) return null;
     return {
-      a: new Int8Array(memory.buffer)[pointer + 0 >>> 0],
-      b: new Int16Array(memory.buffer)[pointer + 2 >>> 1],
-      c: new Int32Array(memory.buffer)[pointer + 4 >>> 2],
-      d: new BigInt64Array(memory.buffer)[pointer + 8 >>> 3],
-      e: new Uint8Array(memory.buffer)[pointer + 16 >>> 0],
-      f: new Uint16Array(memory.buffer)[pointer + 18 >>> 1],
-      g: new Uint32Array(memory.buffer)[pointer + 20 >>> 2],
-      h: new BigUint64Array(memory.buffer)[pointer + 24 >>> 3],
-      i: new Int32Array(memory.buffer)[pointer + 32 >>> 2],
-      j: new Uint32Array(memory.buffer)[pointer + 36 >>> 2],
-      k: new Uint8Array(memory.buffer)[pointer + 40 >>> 0] != 0,
-      l: new Float32Array(memory.buffer)[pointer + 44 >>> 2],
-      m: new Float64Array(memory.buffer)[pointer + 48 >>> 3],
-      n: __liftString(new Uint32Array(memory.buffer)[pointer + 56 >>> 2]),
-      o: __liftTypedArray(Uint8Array, new Uint32Array(memory.buffer)[pointer + 60 >>> 2]),
-      p: __liftArray(pointer => __liftString(new Uint32Array(memory.buffer)[pointer >>> 2]), 2, new Uint32Array(memory.buffer)[pointer + 64 >>> 2]),
+      a: __getI8(pointer + 0),
+      b: __getI16(pointer + 2),
+      c: __getI32(pointer + 4),
+      d: __getI64(pointer + 8),
+      e: __getU8(pointer + 16),
+      f: __getU16(pointer + 18),
+      g: __getU32(pointer + 20),
+      h: __getU64(pointer + 24),
+      i: __getI32(pointer + 32),
+      j: __getU32(pointer + 36),
+      k: __getU8(pointer + 40) != 0,
+      l: __getF32(pointer + 44),
+      m: __getF64(pointer + 48),
+      n: __liftString(__getU32(pointer + 56)),
+      o: __liftTypedArray(Uint8Array, __getU32(pointer + 60)),
+      p: __liftArray(pointer => __liftString(__getU32(pointer)), 2, __getU32(pointer + 64)),
     };
   }
   function __liftBuffer(pointer) {
@@ -282,9 +292,8 @@ async function instantiate(module, imports = {}) {
   function __liftArray(liftElement, align, pointer) {
     if (!pointer) return null;
     const
-      memoryU32 = new Uint32Array(memory.buffer),
-      dataStart = memoryU32[pointer + 4 >>> 2],
-      length = memoryU32[pointer + 12 >>> 2],
+      dataStart = __getU32(pointer + 4),
+      length = __dataview.getUint32(pointer + 12, true),
       values = new Array(length);
     for (let i = 0; i < length; ++i) values[i] = liftElement(dataStart + (i << align >>> 0));
     return values;
@@ -294,12 +303,11 @@ async function instantiate(module, imports = {}) {
     const
       length = values.length,
       buffer = exports.__pin(exports.__new(length << align, 1)) >>> 0,
-      header = exports.__pin(exports.__new(16, id)) >>> 0,
-      memoryU32 = new Uint32Array(memory.buffer);
-    memoryU32[header + 0 >>> 2] = buffer;
-    memoryU32[header + 4 >>> 2] = buffer;
-    memoryU32[header + 8 >>> 2] = length << align;
-    memoryU32[header + 12 >>> 2] = length;
+      header = exports.__pin(exports.__new(16, id)) >>> 0;
+    __setU32(header + 0, buffer);
+    __dataview.setUint32(header + 4, buffer, true);
+    __dataview.setUint32(header + 8, length << align, true);
+    __dataview.setUint32(header + 12, length, true);
     for (let i = 0; i < length; ++i) lowerElement(buffer + (i << align >>> 0), values[i]);
     exports.__unpin(buffer);
     exports.__unpin(header);
@@ -307,11 +315,10 @@ async function instantiate(module, imports = {}) {
   }
   function __liftTypedArray(constructor, pointer) {
     if (!pointer) return null;
-    const memoryU32 = new Uint32Array(memory.buffer);
     return new constructor(
       memory.buffer,
-      memoryU32[pointer + 4 >>> 2],
-      memoryU32[pointer + 8 >>> 2] / constructor.BYTES_PER_ELEMENT
+      __getU32(pointer + 4),
+      __dataview.getUint32(pointer + 8, true) / constructor.BYTES_PER_ELEMENT
     ).slice();
   }
   function __lowerTypedArray(constructor, id, align, values) {
@@ -319,11 +326,10 @@ async function instantiate(module, imports = {}) {
     const
       length = values.length,
       buffer = exports.__pin(exports.__new(length << align, 1)) >>> 0,
-      header = exports.__new(12, id) >>> 0,
-      memoryU32 = new Uint32Array(memory.buffer);
-    memoryU32[header + 0 >>> 2] = buffer;
-    memoryU32[header + 4 >>> 2] = buffer;
-    memoryU32[header + 8 >>> 2] = length << align;
+      header = exports.__new(12, id) >>> 0;
+    __setU32(header + 0, buffer);
+    __dataview.setUint32(header + 4, buffer, true);
+    __dataview.setUint32(header + 8, length << align, true);
     new constructor(memory.buffer, buffer, length).set(values);
     exports.__unpin(buffer);
     return header;
@@ -331,7 +337,7 @@ async function instantiate(module, imports = {}) {
   function __liftStaticArray(liftElement, align, pointer) {
     if (!pointer) return null;
     const
-      length = new Uint32Array(memory.buffer)[pointer - 4 >>> 2] >>> align,
+      length = __getU32(pointer - 4) >>> align,
       values = new Array(length);
     for (let i = 0; i < length; ++i) values[i] = liftElement(pointer + (i << align >>> 0));
     return values;
@@ -382,8 +388,134 @@ async function instantiate(module, imports = {}) {
   function __notnull() {
     throw TypeError("value must not be null");
   }
-  function __store_ref(pointer, value) {
-    new Uint32Array(memory.buffer)[pointer >>> 2] = value;
+  let __dataview = new DataView(memory.buffer);
+  function __setU8(pointer, value) {
+    try {
+      __dataview.setUint8(pointer, value, true);
+    } catch {
+      __dataview = new DataView(memory.buffer);
+      __dataview.setUint8(pointer, value, true);
+    }
+  }
+  function __setU16(pointer, value) {
+    try {
+      __dataview.setUint16(pointer, value, true);
+    } catch {
+      __dataview = new DataView(memory.buffer);
+      __dataview.setUint16(pointer, value, true);
+    }
+  }
+  function __setU32(pointer, value) {
+    try {
+      __dataview.setUint32(pointer, value, true);
+    } catch {
+      __dataview = new DataView(memory.buffer);
+      __dataview.setUint32(pointer, value, true);
+    }
+  }
+  function __setU64(pointer, value) {
+    try {
+      __dataview.setBigUint64(pointer, value, true);
+    } catch {
+      __dataview = new DataView(memory.buffer);
+      __dataview.setBigUint64(pointer, value, true);
+    }
+  }
+  function __setF32(pointer, value) {
+    try {
+      __dataview.setFloat32(pointer, value, true);
+    } catch {
+      __dataview = new DataView(memory.buffer);
+      __dataview.setFloat32(pointer, value, true);
+    }
+  }
+  function __setF64(pointer, value) {
+    try {
+      __dataview.setFloat64(pointer, value, true);
+    } catch {
+      __dataview = new DataView(memory.buffer);
+      __dataview.setFloat64(pointer, value, true);
+    }
+  }
+  function __getI8(pointer) {
+    try {
+      return __dataview.getInt8(pointer, true);
+    } catch {
+      __dataview = new DataView(memory.buffer);
+      return __dataview.getInt8(pointer, true);
+    }
+  }
+  function __getU8(pointer) {
+    try {
+      return __dataview.getUint8(pointer, true);
+    } catch {
+      __dataview = new DataView(memory.buffer);
+      return __dataview.getUint8(pointer, true);
+    }
+  }
+  function __getI16(pointer) {
+    try {
+      return __dataview.getInt16(pointer, true);
+    } catch {
+      __dataview = new DataView(memory.buffer);
+      return __dataview.getInt16(pointer, true);
+    }
+  }
+  function __getU16(pointer) {
+    try {
+      return __dataview.getUint16(pointer, true);
+    } catch {
+      __dataview = new DataView(memory.buffer);
+      return __dataview.getUint16(pointer, true);
+    }
+  }
+  function __getI32(pointer) {
+    try {
+      return __dataview.getInt32(pointer, true);
+    } catch {
+      __dataview = new DataView(memory.buffer);
+      return __dataview.getInt32(pointer, true);
+    }
+  }
+  function __getU32(pointer) {
+    try {
+      return __dataview.getUint32(pointer, true);
+    } catch {
+      __dataview = new DataView(memory.buffer);
+      return __dataview.getUint32(pointer, true);
+    }
+  }
+  function __getI64(pointer) {
+    try {
+      return __dataview.getBigInt64(pointer, true);
+    } catch {
+      __dataview = new DataView(memory.buffer);
+      return __dataview.getBigInt64(pointer, true);
+    }
+  }
+  function __getU64(pointer) {
+    try {
+      return __dataview.getBigUint64(pointer, true);
+    } catch {
+      __dataview = new DataView(memory.buffer);
+      return __dataview.getBigUint64(pointer, true);
+    }
+  }
+  function __getF32(pointer) {
+    try {
+      return __dataview.getFloat32(pointer, true);
+    } catch {
+      __dataview = new DataView(memory.buffer);
+      return __dataview.getFloat32(pointer, true);
+    }
+  }
+  function __getF64(pointer) {
+    try {
+      return __dataview.getFloat64(pointer, true);
+    } catch {
+      __dataview = new DataView(memory.buffer);
+      return __dataview.getFloat64(pointer, true);
+    }
   }
   exports._start();
   return adaptedExports;
@@ -408,6 +540,7 @@ export const {
   staticarrayU16,
   staticarrayI64,
   arrayFunction,
+  arrayOfStringsFunction,
   objectFunction,
   newInternref,
   internrefFunction,

--- a/tests/compiler/bindings/esm.debug.wat
+++ b/tests/compiler/bindings/esm.debug.wat
@@ -1,6 +1,6 @@
 (module
- (type $i32_=>_i32 (func_subtype (param i32) (result i32) func))
  (type $i32_i32_=>_none (func_subtype (param i32 i32) func))
+ (type $i32_=>_i32 (func_subtype (param i32) (result i32) func))
  (type $i32_i32_=>_i32 (func_subtype (param i32 i32) (result i32) func))
  (type $i32_=>_none (func_subtype (param i32) func))
  (type $none_=>_none (func_subtype func))
@@ -54,10 +54,10 @@
  (global $~lib/native/ASC_LOW_MEMORY_LIMIT i32 (i32.const 0))
  (global $~lib/native/ASC_RUNTIME i32 (i32.const 2))
  (global $~argumentsLength (mut i32) (i32.const 0))
- (global $~lib/rt/__rtti_base i32 (i32.const 1056))
- (global $~lib/memory/__data_end i32 (i32.const 1124))
- (global $~lib/memory/__stack_pointer (mut i32) (i32.const 33892))
- (global $~lib/memory/__heap_base i32 (i32.const 33892))
+ (global $~lib/rt/__rtti_base i32 (i32.const 1184))
+ (global $~lib/memory/__data_end i32 (i32.const 1252))
+ (global $~lib/memory/__stack_pointer (mut i32) (i32.const 34020))
+ (global $~lib/memory/__heap_base i32 (i32.const 34020))
  (global $~started (mut i32) (i32.const 0))
  (memory $0 1)
  (data (i32.const 12) "\1c\00\00\00\00\00\00\00\00\00\00\00\02\00\00\00\02\00\00\00a\00\00\00\00\00\00\00\00\00\00\00")
@@ -79,9 +79,10 @@
  (data (i32.const 748) "<\00\00\00\00\00\00\00\00\00\00\00\02\00\00\00$\00\00\00~\00l\00i\00b\00/\00t\00y\00p\00e\00d\00a\00r\00r\00a\00y\00.\00t\00s\00\00\00\00\00\00\00\00\00")
  (data (i32.const 812) "<\00\00\00\00\00\00\00\00\00\00\00\02\00\00\00&\00\00\00~\00l\00i\00b\00/\00s\00t\00a\00t\00i\00c\00a\00r\00r\00a\00y\00.\00t\00s\00\00\00\00\00\00\00")
  (data (i32.const 876) ",\00\00\00\00\00\00\00\00\00\00\00\02\00\00\00\1a\00\00\00~\00l\00i\00b\00/\00a\00r\00r\00a\00y\00.\00t\00s\00\00\00")
- (data (i32.const 924) "<\00\00\00\00\00\00\00\00\00\00\00\02\00\00\00*\00\00\00O\00b\00j\00e\00c\00t\00 \00a\00l\00r\00e\00a\00d\00y\00 \00p\00i\00n\00n\00e\00d\00\00\00")
- (data (i32.const 988) "<\00\00\00\00\00\00\00\00\00\00\00\02\00\00\00(\00\00\00O\00b\00j\00e\00c\00t\00 \00i\00s\00 \00n\00o\00t\00 \00p\00i\00n\00n\00e\00d\00\00\00\00\00")
- (data (i32.const 1056) "\10\00\00\00 \00\00\00 \00\00\00 \00\00\00\00\00\00\00\00\00\00\00\81\08\00\00\01\19\00\00\01\02\00\00$\t\00\00\a4\00\00\00$\n\00\00\02\t\00\00\00\00\00\00A\00\00\00\02A\00\00 \00\00\00")
+ (data (i32.const 924) "|\00\00\00\00\00\00\00\00\00\00\00\02\00\00\00^\00\00\00E\00l\00e\00m\00e\00n\00t\00 \00t\00y\00p\00e\00 \00m\00u\00s\00t\00 \00b\00e\00 \00n\00u\00l\00l\00a\00b\00l\00e\00 \00i\00f\00 \00a\00r\00r\00a\00y\00 \00i\00s\00 \00h\00o\00l\00e\00y\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00")
+ (data (i32.const 1052) "<\00\00\00\00\00\00\00\00\00\00\00\02\00\00\00*\00\00\00O\00b\00j\00e\00c\00t\00 \00a\00l\00r\00e\00a\00d\00y\00 \00p\00i\00n\00n\00e\00d\00\00\00")
+ (data (i32.const 1116) "<\00\00\00\00\00\00\00\00\00\00\00\02\00\00\00(\00\00\00O\00b\00j\00e\00c\00t\00 \00i\00s\00 \00n\00o\00t\00 \00p\00i\00n\00n\00e\00d\00\00\00\00\00")
+ (data (i32.const 1184) "\10\00\00\00 \00\00\00 \00\00\00 \00\00\00\00\00\00\00\00\00\00\00\81\08\00\00\01\19\00\00\01\02\00\00$\t\00\00\a4\00\00\00$\n\00\00\02\t\00\00\02A\00\00\00\00\00\00A\00\00\00 \00\00\00")
  (table $0 2 2 funcref)
  (elem $0 (i32.const 1) $start:bindings/esm~anonymous|0)
  (export "plainGlobal" (global $bindings/esm/plainGlobal))
@@ -116,6 +117,7 @@
  (export "staticarrayU16" (func $export:bindings/esm/staticarrayU16))
  (export "staticarrayI64" (func $export:bindings/esm/staticarrayI64))
  (export "arrayFunction" (func $export:bindings/esm/arrayFunction))
+ (export "arrayOfStringsFunction" (func $export:bindings/esm/arrayOfStringsFunction))
  (export "objectFunction" (func $export:bindings/esm/objectFunction))
  (export "internrefFunction" (func $export:bindings/esm/internrefFunction))
  (export "functionFunction" (func $export:bindings/esm/functionFunction))
@@ -2564,6 +2566,38 @@
   local.get $newPtr
   return
  )
+ (func $~lib/array/Array<~lib/string/String>#set:buffer (type $i32_i32_=>_none) (param $this i32) (param $buffer i32)
+  local.get $this
+  local.get $buffer
+  i32.store $0
+  local.get $this
+  local.get $buffer
+  i32.const 0
+  call $~lib/rt/itcms/__link
+ )
+ (func $~lib/array/Array<~lib/string/String>#set:dataStart (type $i32_i32_=>_none) (param $this i32) (param $dataStart i32)
+  local.get $this
+  local.get $dataStart
+  i32.store $0 offset=4
+ )
+ (func $~lib/array/Array<~lib/string/String>#set:byteLength (type $i32_i32_=>_none) (param $this i32) (param $byteLength i32)
+  local.get $this
+  local.get $byteLength
+  i32.store $0 offset=8
+ )
+ (func $~lib/array/Array<~lib/string/String>#set:length_ (type $i32_i32_=>_none) (param $this i32) (param $length_ i32)
+  local.get $this
+  local.get $length_
+  i32.store $0 offset=12
+ )
+ (func $~lib/array/Array<~lib/string/String>#get:length_ (type $i32_=>_i32) (param $this i32) (result i32)
+  local.get $this
+  i32.load $0 offset=12
+ )
+ (func $~lib/array/Array<~lib/string/String>#get:dataStart (type $i32_=>_i32) (param $this i32) (result i32)
+  local.get $this
+  i32.load $0 offset=4
+ )
  (func $bindings/esm/PlainObject#set:a (type $i32_i32_=>_none) (param $this i32) (param $a i32)
   local.get $this
   local.get $a
@@ -2690,7 +2724,7 @@
    i32.const 3
    i32.eq
    if
-    i32.const 944
+    i32.const 1072
     i32.const 400
     i32.const 338
     i32.const 7
@@ -2723,7 +2757,7 @@
   i32.const 3
   i32.ne
   if
-   i32.const 1008
+   i32.const 1136
    i32.const 400
    i32.const 352
    i32.const 5
@@ -2813,13 +2847,16 @@
   i32.const 224
   local.get $0
   call $~lib/rt/itcms/__visit
-  i32.const 336
-  local.get $0
-  call $~lib/rt/itcms/__visit
   i32.const 944
   local.get $0
   call $~lib/rt/itcms/__visit
-  i32.const 1008
+  i32.const 336
+  local.get $0
+  call $~lib/rt/itcms/__visit
+  i32.const 1072
+  local.get $0
+  call $~lib/rt/itcms/__visit
+  i32.const 1136
   local.get $0
   call $~lib/rt/itcms/__visit
  )
@@ -2879,6 +2916,18 @@
   local.get $1
   call $~lib/array/Array<i32>#__visit
  )
+ (func $~lib/array/Array<~lib/string/String>#get:buffer (type $i32_=>_i32) (param $this i32) (result i32)
+  local.get $this
+  i32.load $0
+ )
+ (func $~lib/array/Array<~lib/string/String>~visit (type $i32_i32_=>_none) (param $0 i32) (param $1 i32)
+  local.get $0
+  local.get $1
+  call $~lib/object/Object~visit
+  local.get $0
+  local.get $1
+  call $~lib/array/Array<~lib/string/String>#__visit
+ )
  (func $bindings/esm/PlainObject~visit (type $i32_i32_=>_none) (param $0 i32) (param $1 i32)
   (local $2 i32)
   local.get $0
@@ -2914,32 +2963,12 @@
   local.get $1
   call $~lib/arraybuffer/ArrayBufferView~visit
  )
- (func $~lib/array/Array<~lib/string/String>#get:dataStart (type $i32_=>_i32) (param $this i32) (result i32)
-  local.get $this
-  i32.load $0 offset=4
- )
- (func $~lib/array/Array<~lib/string/String>#get:length_ (type $i32_=>_i32) (param $this i32) (result i32)
-  local.get $this
-  i32.load $0 offset=12
- )
- (func $~lib/array/Array<~lib/string/String>#get:buffer (type $i32_=>_i32) (param $this i32) (result i32)
-  local.get $this
-  i32.load $0
- )
- (func $~lib/array/Array<~lib/string/String>~visit (type $i32_i32_=>_none) (param $0 i32) (param $1 i32)
-  local.get $0
-  local.get $1
-  call $~lib/object/Object~visit
-  local.get $0
-  local.get $1
-  call $~lib/array/Array<~lib/string/String>#__visit
- )
  (func $~lib/rt/__visit_members (type $i32_i32_=>_none) (param $0 i32) (param $1 i32)
   block $invalid
    block $bindings/esm/NonPlainObject
-    block $~lib/array/Array<~lib/string/String>
-     block $~lib/typedarray/Uint8Array
-      block $bindings/esm/PlainObject
+    block $~lib/typedarray/Uint8Array
+     block $bindings/esm/PlainObject
+      block $~lib/array/Array<~lib/string/String>
        block $~lib/array/Array<i32>
         block $~lib/staticarray/StaticArray<i64>
          block $~lib/staticarray/StaticArray<u16>
@@ -2956,7 +2985,7 @@
                    i32.const 8
                    i32.sub
                    i32.load $0
-                   br_table $~lib/object/Object $~lib/arraybuffer/ArrayBuffer $~lib/string/String $~lib/arraybuffer/ArrayBufferView $~lib/function/Function<%28%29=>void> $~lib/typedarray/Int16Array $~lib/typedarray/Float32Array $~lib/typedarray/Uint64Array $~lib/staticarray/StaticArray<i32> $~lib/staticarray/StaticArray<u16> $~lib/staticarray/StaticArray<i64> $~lib/array/Array<i32> $bindings/esm/PlainObject $~lib/typedarray/Uint8Array $~lib/array/Array<~lib/string/String> $bindings/esm/NonPlainObject $invalid
+                   br_table $~lib/object/Object $~lib/arraybuffer/ArrayBuffer $~lib/string/String $~lib/arraybuffer/ArrayBufferView $~lib/function/Function<%28%29=>void> $~lib/typedarray/Int16Array $~lib/typedarray/Float32Array $~lib/typedarray/Uint64Array $~lib/staticarray/StaticArray<i32> $~lib/staticarray/StaticArray<u16> $~lib/staticarray/StaticArray<i64> $~lib/array/Array<i32> $~lib/array/Array<~lib/string/String> $bindings/esm/PlainObject $~lib/typedarray/Uint8Array $bindings/esm/NonPlainObject $invalid
                   end
                   return
                  end
@@ -3002,17 +3031,17 @@
       end
       local.get $0
       local.get $1
-      call $bindings/esm/PlainObject~visit
+      call $~lib/array/Array<~lib/string/String>~visit
       return
      end
      local.get $0
      local.get $1
-     call $~lib/typedarray/Uint8Array~visit
+     call $bindings/esm/PlainObject~visit
      return
     end
     local.get $0
     local.get $1
-    call $~lib/array/Array<~lib/string/String>~visit
+    call $~lib/typedarray/Uint8Array~visit
     return
    end
    return
@@ -3054,8 +3083,8 @@
   global.get $~lib/memory/__data_end
   i32.lt_s
   if
-   i32.const 33920
-   i32.const 33968
+   i32.const 34048
+   i32.const 34096
    i32.const 1
    i32.const 1
    call $~lib/builtins/abort
@@ -4597,6 +4626,444 @@
   local.get $5
   return
  )
+ (func $~lib/array/Array<~lib/string/String>#constructor (type $i32_i32_=>_i32) (param $this i32) (param $length i32) (result i32)
+  (local $2 i32)
+  (local $3 i32)
+  (local $bufferSize i32)
+  (local $buffer i32)
+  (local $6 i32)
+  global.get $~lib/memory/__stack_pointer
+  i32.const 16
+  i32.sub
+  global.set $~lib/memory/__stack_pointer
+  call $~stack_check
+  global.get $~lib/memory/__stack_pointer
+  i64.const 0
+  i64.store $0
+  global.get $~lib/memory/__stack_pointer
+  i64.const 0
+  i64.store $0 offset=8
+  local.get $this
+  i32.eqz
+  if
+   global.get $~lib/memory/__stack_pointer
+   i32.const 16
+   i32.const 12
+   call $~lib/rt/itcms/__new
+   local.tee $this
+   i32.store $0
+  end
+  local.get $this
+  local.set $6
+  global.get $~lib/memory/__stack_pointer
+  local.get $6
+  i32.store $0 offset=4
+  local.get $6
+  i32.const 0
+  call $~lib/array/Array<~lib/string/String>#set:buffer
+  local.get $this
+  local.set $6
+  global.get $~lib/memory/__stack_pointer
+  local.get $6
+  i32.store $0 offset=4
+  local.get $6
+  i32.const 0
+  call $~lib/array/Array<~lib/string/String>#set:dataStart
+  local.get $this
+  local.set $6
+  global.get $~lib/memory/__stack_pointer
+  local.get $6
+  i32.store $0 offset=4
+  local.get $6
+  i32.const 0
+  call $~lib/array/Array<~lib/string/String>#set:byteLength
+  local.get $this
+  local.set $6
+  global.get $~lib/memory/__stack_pointer
+  local.get $6
+  i32.store $0 offset=4
+  local.get $6
+  i32.const 0
+  call $~lib/array/Array<~lib/string/String>#set:length_
+  local.get $length
+  i32.const 1073741820
+  i32.const 2
+  i32.shr_u
+  i32.gt_u
+  if
+   i32.const 224
+   i32.const 896
+   i32.const 70
+   i32.const 60
+   call $~lib/builtins/abort
+   unreachable
+  end
+  local.get $length
+  local.tee $2
+  i32.const 8
+  local.tee $3
+  local.get $2
+  local.get $3
+  i32.gt_u
+  select
+  i32.const 2
+  i32.shl
+  local.set $bufferSize
+  global.get $~lib/memory/__stack_pointer
+  local.get $bufferSize
+  i32.const 1
+  call $~lib/rt/itcms/__new
+  local.tee $buffer
+  i32.store $0 offset=8
+  i32.const 2
+  global.get $~lib/shared/runtime/Runtime.Incremental
+  i32.ne
+  drop
+  local.get $this
+  local.set $6
+  global.get $~lib/memory/__stack_pointer
+  local.get $6
+  i32.store $0 offset=4
+  local.get $6
+  local.get $buffer
+  local.set $6
+  global.get $~lib/memory/__stack_pointer
+  local.get $6
+  i32.store $0 offset=12
+  local.get $6
+  call $~lib/array/Array<~lib/string/String>#set:buffer
+  local.get $this
+  local.set $6
+  global.get $~lib/memory/__stack_pointer
+  local.get $6
+  i32.store $0 offset=4
+  local.get $6
+  local.get $buffer
+  call $~lib/array/Array<~lib/string/String>#set:dataStart
+  local.get $this
+  local.set $6
+  global.get $~lib/memory/__stack_pointer
+  local.get $6
+  i32.store $0 offset=4
+  local.get $6
+  local.get $bufferSize
+  call $~lib/array/Array<~lib/string/String>#set:byteLength
+  local.get $this
+  local.set $6
+  global.get $~lib/memory/__stack_pointer
+  local.get $6
+  i32.store $0 offset=4
+  local.get $6
+  local.get $length
+  call $~lib/array/Array<~lib/string/String>#set:length_
+  local.get $this
+  local.set $6
+  global.get $~lib/memory/__stack_pointer
+  i32.const 16
+  i32.add
+  global.set $~lib/memory/__stack_pointer
+  local.get $6
+ )
+ (func $~lib/array/Array<~lib/string/String>#get:length (type $i32_=>_i32) (param $this i32) (result i32)
+  (local $1 i32)
+  global.get $~lib/memory/__stack_pointer
+  i32.const 4
+  i32.sub
+  global.set $~lib/memory/__stack_pointer
+  call $~stack_check
+  global.get $~lib/memory/__stack_pointer
+  i32.const 0
+  i32.store $0
+  local.get $this
+  local.set $1
+  global.get $~lib/memory/__stack_pointer
+  local.get $1
+  i32.store $0
+  local.get $1
+  call $~lib/array/Array<~lib/string/String>#get:length_
+  local.set $1
+  global.get $~lib/memory/__stack_pointer
+  i32.const 4
+  i32.add
+  global.set $~lib/memory/__stack_pointer
+  local.get $1
+  return
+ )
+ (func $~lib/array/Array<~lib/string/String>#__get (type $i32_i32_=>_i32) (param $this i32) (param $index i32) (result i32)
+  (local $value i32)
+  (local $3 i32)
+  global.get $~lib/memory/__stack_pointer
+  i32.const 8
+  i32.sub
+  global.set $~lib/memory/__stack_pointer
+  call $~stack_check
+  global.get $~lib/memory/__stack_pointer
+  i64.const 0
+  i64.store $0
+  local.get $index
+  local.get $this
+  local.set $3
+  global.get $~lib/memory/__stack_pointer
+  local.get $3
+  i32.store $0
+  local.get $3
+  call $~lib/array/Array<~lib/string/String>#get:length_
+  i32.ge_u
+  if
+   i32.const 528
+   i32.const 896
+   i32.const 114
+   i32.const 42
+   call $~lib/builtins/abort
+   unreachable
+  end
+  global.get $~lib/memory/__stack_pointer
+  local.get $this
+  local.set $3
+  global.get $~lib/memory/__stack_pointer
+  local.get $3
+  i32.store $0
+  local.get $3
+  call $~lib/array/Array<~lib/string/String>#get:dataStart
+  local.get $index
+  i32.const 2
+  i32.shl
+  i32.add
+  i32.load $0
+  local.tee $value
+  i32.store $0 offset=4
+  i32.const 1
+  drop
+  i32.const 0
+  i32.eqz
+  drop
+  local.get $value
+  i32.eqz
+  if
+   i32.const 944
+   i32.const 896
+   i32.const 118
+   i32.const 40
+   call $~lib/builtins/abort
+   unreachable
+  end
+  local.get $value
+  local.set $3
+  global.get $~lib/memory/__stack_pointer
+  i32.const 8
+  i32.add
+  global.set $~lib/memory/__stack_pointer
+  local.get $3
+  return
+ )
+ (func $~lib/array/Array<~lib/string/String>#__set (type $i32_i32_i32_=>_none) (param $this i32) (param $index i32) (param $value i32)
+  (local $3 i32)
+  global.get $~lib/memory/__stack_pointer
+  i32.const 4
+  i32.sub
+  global.set $~lib/memory/__stack_pointer
+  call $~stack_check
+  global.get $~lib/memory/__stack_pointer
+  i32.const 0
+  i32.store $0
+  local.get $index
+  local.get $this
+  local.set $3
+  global.get $~lib/memory/__stack_pointer
+  local.get $3
+  i32.store $0
+  local.get $3
+  call $~lib/array/Array<~lib/string/String>#get:length_
+  i32.ge_u
+  if
+   local.get $index
+   i32.const 0
+   i32.lt_s
+   if
+    i32.const 528
+    i32.const 896
+    i32.const 130
+    i32.const 22
+    call $~lib/builtins/abort
+    unreachable
+   end
+   local.get $this
+   local.get $index
+   i32.const 1
+   i32.add
+   i32.const 2
+   i32.const 1
+   call $~lib/array/ensureCapacity
+   local.get $this
+   local.set $3
+   global.get $~lib/memory/__stack_pointer
+   local.get $3
+   i32.store $0
+   local.get $3
+   local.get $index
+   i32.const 1
+   i32.add
+   call $~lib/array/Array<~lib/string/String>#set:length_
+  end
+  local.get $this
+  local.set $3
+  global.get $~lib/memory/__stack_pointer
+  local.get $3
+  i32.store $0
+  local.get $3
+  call $~lib/array/Array<~lib/string/String>#get:dataStart
+  local.get $index
+  i32.const 2
+  i32.shl
+  i32.add
+  local.get $value
+  i32.store $0
+  i32.const 1
+  drop
+  local.get $this
+  local.get $value
+  i32.const 1
+  call $~lib/rt/itcms/__link
+  global.get $~lib/memory/__stack_pointer
+  i32.const 4
+  i32.add
+  global.set $~lib/memory/__stack_pointer
+ )
+ (func $bindings/esm/arrayOfStringsFunction (type $i32_i32_=>_i32) (param $a i32) (param $b i32) (result i32)
+  (local $c i32)
+  (local $i i32)
+  (local $i|4 i32)
+  (local $5 i32)
+  global.get $~lib/memory/__stack_pointer
+  i32.const 12
+  i32.sub
+  global.set $~lib/memory/__stack_pointer
+  call $~stack_check
+  global.get $~lib/memory/__stack_pointer
+  i64.const 0
+  i64.store $0
+  global.get $~lib/memory/__stack_pointer
+  i32.const 0
+  i32.store $0 offset=8
+  global.get $~lib/memory/__stack_pointer
+  i32.const 0
+  local.get $a
+  local.set $5
+  global.get $~lib/memory/__stack_pointer
+  local.get $5
+  i32.store $0
+  local.get $5
+  call $~lib/array/Array<~lib/string/String>#get:length
+  local.get $b
+  local.set $5
+  global.get $~lib/memory/__stack_pointer
+  local.get $5
+  i32.store $0
+  local.get $5
+  call $~lib/array/Array<~lib/string/String>#get:length
+  i32.add
+  call $~lib/array/Array<~lib/string/String>#constructor
+  local.tee $c
+  i32.store $0 offset=4
+  i32.const 0
+  local.set $i
+  loop $for-loop|0
+   local.get $i
+   local.get $a
+   local.set $5
+   global.get $~lib/memory/__stack_pointer
+   local.get $5
+   i32.store $0
+   local.get $5
+   call $~lib/array/Array<~lib/string/String>#get:length
+   i32.lt_s
+   if
+    local.get $c
+    local.set $5
+    global.get $~lib/memory/__stack_pointer
+    local.get $5
+    i32.store $0
+    local.get $5
+    local.get $i
+    local.get $a
+    local.set $5
+    global.get $~lib/memory/__stack_pointer
+    local.get $5
+    i32.store $0 offset=8
+    local.get $5
+    local.get $i
+    call $~lib/array/Array<~lib/string/String>#__get
+    local.set $5
+    global.get $~lib/memory/__stack_pointer
+    local.get $5
+    i32.store $0 offset=8
+    local.get $5
+    call $~lib/array/Array<~lib/string/String>#__set
+    local.get $i
+    i32.const 1
+    i32.add
+    local.set $i
+    br $for-loop|0
+   end
+  end
+  i32.const 0
+  local.set $i|4
+  loop $for-loop|1
+   local.get $i|4
+   local.get $b
+   local.set $5
+   global.get $~lib/memory/__stack_pointer
+   local.get $5
+   i32.store $0
+   local.get $5
+   call $~lib/array/Array<~lib/string/String>#get:length
+   i32.lt_s
+   if
+    local.get $c
+    local.set $5
+    global.get $~lib/memory/__stack_pointer
+    local.get $5
+    i32.store $0
+    local.get $5
+    local.get $a
+    local.set $5
+    global.get $~lib/memory/__stack_pointer
+    local.get $5
+    i32.store $0 offset=8
+    local.get $5
+    call $~lib/array/Array<~lib/string/String>#get:length
+    local.get $i|4
+    i32.add
+    local.get $b
+    local.set $5
+    global.get $~lib/memory/__stack_pointer
+    local.get $5
+    i32.store $0 offset=8
+    local.get $5
+    local.get $i|4
+    call $~lib/array/Array<~lib/string/String>#__get
+    local.set $5
+    global.get $~lib/memory/__stack_pointer
+    local.get $5
+    i32.store $0 offset=8
+    local.get $5
+    call $~lib/array/Array<~lib/string/String>#__set
+    local.get $i|4
+    i32.const 1
+    i32.add
+    local.set $i|4
+    br $for-loop|1
+   end
+  end
+  local.get $c
+  local.set $5
+  global.get $~lib/memory/__stack_pointer
+  i32.const 12
+  i32.add
+  global.set $~lib/memory/__stack_pointer
+  local.get $5
+  return
+ )
  (func $bindings/esm/PlainObject#constructor (type $i32_=>_i32) (param $this i32) (result i32)
   (local $1 i32)
   global.get $~lib/memory/__stack_pointer
@@ -4612,7 +5079,7 @@
   if
    global.get $~lib/memory/__stack_pointer
    i32.const 68
-   i32.const 12
+   i32.const 13
    call $~lib/rt/itcms/__new
    local.tee $this
    i32.store $0
@@ -5269,6 +5736,29 @@
   local.get $0
   local.get $1
   call $bindings/esm/arrayFunction
+  local.set $2
+  global.get $~lib/memory/__stack_pointer
+  i32.const 8
+  i32.add
+  global.set $~lib/memory/__stack_pointer
+  local.get $2
+ )
+ (func $export:bindings/esm/arrayOfStringsFunction (type $i32_i32_=>_i32) (param $0 i32) (param $1 i32) (result i32)
+  (local $2 i32)
+  global.get $~lib/memory/__stack_pointer
+  i32.const 8
+  i32.sub
+  global.set $~lib/memory/__stack_pointer
+  call $~stack_check
+  global.get $~lib/memory/__stack_pointer
+  local.get $0
+  i32.store $0
+  global.get $~lib/memory/__stack_pointer
+  local.get $1
+  i32.store $0 offset=4
+  local.get $0
+  local.get $1
+  call $bindings/esm/arrayOfStringsFunction
   local.set $2
   global.get $~lib/memory/__stack_pointer
   i32.const 8

--- a/tests/compiler/bindings/esm.js
+++ b/tests/compiler/bindings/esm.js
@@ -64,6 +64,8 @@ export async function postInstantiate(instance) {
 
   assert.deepStrictEqual(exports.arrayFunction([1, 2, 3], [4, 5, 6]), [1, 2, 3, 4, 5, 6]);
 
+  assert.deepStrictEqual(exports.arrayOfStringsFunction(["1", "2", "3"], ["4", "5", "6"]), ["1", "2", "3", "4", "5", "6"]);
+
   {
     let obj = exports.objectFunction({ a: 1, b: 2 }, { a: 3, b: 4 });
     assert.strictEqual(obj.a, 4);

--- a/tests/compiler/bindings/esm.release.d.ts
+++ b/tests/compiler/bindings/esm.release.d.ts
@@ -119,12 +119,19 @@ export declare function staticarrayI64(a: ArrayLike<bigint>): ArrayLike<bigint>;
  */
 export declare function arrayFunction(a: Array<number>, b: Array<number>): Array<number>;
 /**
+ * bindings/esm/arrayOfStringsFunction
+ * @param a `~lib/array/Array<~lib/string/String>`
+ * @param b `~lib/array/Array<~lib/string/String>`
+ * @returns `~lib/array/Array<~lib/string/String>`
+ */
+export declare function arrayOfStringsFunction(a: Array<string>, b: Array<string>): Array<string>;
+/**
  * bindings/esm/objectFunction
  * @param a `bindings/esm/PlainObject`
  * @param b `bindings/esm/PlainObject`
  * @returns `bindings/esm/PlainObject`
  */
-export declare function objectFunction(a: __Record12<undefined>, b: __Record12<undefined>): __Record12<never>;
+export declare function objectFunction(a: __Record13<undefined>, b: __Record13<undefined>): __Record13<never>;
 /**
  * bindings/esm/newInternref
  * @returns `bindings/esm/NonPlainObject`
@@ -149,7 +156,7 @@ export declare const fn: {
   get value(): __Internref4
 };
 /** bindings/esm/PlainObject */
-declare interface __Record12<TOmittable> {
+declare interface __Record13<TOmittable> {
   /** @type `i8` */
   a: number | TOmittable;
   /** @type `i16` */

--- a/tests/compiler/bindings/esm.release.js
+++ b/tests/compiler/bindings/esm.release.js
@@ -137,40 +137,50 @@ async function instantiate(module, imports = {}) {
     },
     staticarrayFunction(a, b) {
       // bindings/esm/staticarrayFunction(~lib/staticarray/StaticArray<i32>, ~lib/staticarray/StaticArray<i32>) => ~lib/staticarray/StaticArray<i32>
-      a = __retain(__lowerStaticArray((pointer, value) => { new Int32Array(memory.buffer)[pointer >>> 2] = value; }, 8, 2, a, Int32Array) || __notnull());
-      b = __lowerStaticArray((pointer, value) => { new Int32Array(memory.buffer)[pointer >>> 2] = value; }, 8, 2, b, Int32Array) || __notnull();
+      a = __retain(__lowerStaticArray(__setU32, 8, 2, a, Int32Array) || __notnull());
+      b = __lowerStaticArray(__setU32, 8, 2, b, Int32Array) || __notnull();
       try {
-        return __liftStaticArray(pointer => new Int32Array(memory.buffer)[pointer >>> 2], 2, exports.staticarrayFunction(a, b) >>> 0);
+        return __liftStaticArray(pointer => __getI32(pointer), 2, exports.staticarrayFunction(a, b) >>> 0);
       } finally {
         __release(a);
       }
     },
     staticarrayU16(a) {
       // bindings/esm/staticarrayU16(~lib/staticarray/StaticArray<u16>) => ~lib/staticarray/StaticArray<u16>
-      a = __lowerStaticArray((pointer, value) => { new Uint16Array(memory.buffer)[pointer >>> 1] = value; }, 9, 1, a, Uint16Array) || __notnull();
-      return __liftStaticArray(pointer => new Uint16Array(memory.buffer)[pointer >>> 1], 1, exports.staticarrayU16(a) >>> 0);
+      a = __lowerStaticArray(__setU16, 9, 1, a, Uint16Array) || __notnull();
+      return __liftStaticArray(pointer => __getU16(pointer), 1, exports.staticarrayU16(a) >>> 0);
     },
     staticarrayI64(a) {
       // bindings/esm/staticarrayI64(~lib/staticarray/StaticArray<i64>) => ~lib/staticarray/StaticArray<i64>
-      a = __lowerStaticArray((pointer, value) => { new BigInt64Array(memory.buffer)[pointer >>> 3] = value || 0n; }, 10, 3, a, BigInt64Array) || __notnull();
-      return __liftStaticArray(pointer => new BigInt64Array(memory.buffer)[pointer >>> 3], 3, exports.staticarrayI64(a) >>> 0);
+      a = __lowerStaticArray(__setU64, 10, 3, a, BigInt64Array) || __notnull();
+      return __liftStaticArray(pointer => __getI64(pointer), 3, exports.staticarrayI64(a) >>> 0);
     },
     arrayFunction(a, b) {
       // bindings/esm/arrayFunction(~lib/array/Array<i32>, ~lib/array/Array<i32>) => ~lib/array/Array<i32>
-      a = __retain(__lowerArray((pointer, value) => { new Int32Array(memory.buffer)[pointer >>> 2] = value; }, 11, 2, a) || __notnull());
-      b = __lowerArray((pointer, value) => { new Int32Array(memory.buffer)[pointer >>> 2] = value; }, 11, 2, b) || __notnull();
+      a = __retain(__lowerArray(__setU32, 11, 2, a) || __notnull());
+      b = __lowerArray(__setU32, 11, 2, b) || __notnull();
       try {
-        return __liftArray(pointer => new Int32Array(memory.buffer)[pointer >>> 2], 2, exports.arrayFunction(a, b) >>> 0);
+        return __liftArray(pointer => __getI32(pointer), 2, exports.arrayFunction(a, b) >>> 0);
+      } finally {
+        __release(a);
+      }
+    },
+    arrayOfStringsFunction(a, b) {
+      // bindings/esm/arrayOfStringsFunction(~lib/array/Array<~lib/string/String>, ~lib/array/Array<~lib/string/String>) => ~lib/array/Array<~lib/string/String>
+      a = __retain(__lowerArray((pointer, value) => { __setU32(pointer, __lowerString(value) || __notnull()); }, 12, 2, a) || __notnull());
+      b = __lowerArray((pointer, value) => { __setU32(pointer, __lowerString(value) || __notnull()); }, 12, 2, b) || __notnull();
+      try {
+        return __liftArray(pointer => __liftString(__getU32(pointer)), 2, exports.arrayOfStringsFunction(a, b) >>> 0);
       } finally {
         __release(a);
       }
     },
     objectFunction(a, b) {
       // bindings/esm/objectFunction(bindings/esm/PlainObject, bindings/esm/PlainObject) => bindings/esm/PlainObject
-      a = __retain(__lowerRecord12(a) || __notnull());
-      b = __lowerRecord12(b) || __notnull();
+      a = __retain(__lowerRecord13(a) || __notnull());
+      b = __lowerRecord13(b) || __notnull();
       try {
-        return __liftRecord12(exports.objectFunction(a, b) >>> 0);
+        return __liftRecord13(exports.objectFunction(a, b) >>> 0);
       } finally {
         __release(a);
       }
@@ -202,51 +212,51 @@ async function instantiate(module, imports = {}) {
       }
     },
   }, exports);
-  function __lowerRecord12(value) {
+  function __lowerRecord13(value) {
     // bindings/esm/PlainObject
     // Hint: Opt-out from lowering as a record by providing an empty constructor
     if (value == null) return 0;
-    const pointer = exports.__pin(exports.__new(68, 12));
-    new Int8Array(memory.buffer)[pointer + 0 >>> 0] = value.a;
-    new Int16Array(memory.buffer)[pointer + 2 >>> 1] = value.b;
-    new Int32Array(memory.buffer)[pointer + 4 >>> 2] = value.c;
-    new BigInt64Array(memory.buffer)[pointer + 8 >>> 3] = value.d || 0n;
-    new Uint8Array(memory.buffer)[pointer + 16 >>> 0] = value.e;
-    new Uint16Array(memory.buffer)[pointer + 18 >>> 1] = value.f;
-    new Uint32Array(memory.buffer)[pointer + 20 >>> 2] = value.g;
-    new BigUint64Array(memory.buffer)[pointer + 24 >>> 3] = value.h || 0n;
-    new Int32Array(memory.buffer)[pointer + 32 >>> 2] = value.i;
-    new Uint32Array(memory.buffer)[pointer + 36 >>> 2] = value.j;
-    new Uint8Array(memory.buffer)[pointer + 40 >>> 0] = value.k ? 1 : 0;
-    new Float32Array(memory.buffer)[pointer + 44 >>> 2] = value.l;
-    new Float64Array(memory.buffer)[pointer + 48 >>> 3] = value.m;
-    __store_ref(pointer + 56, __lowerString(value.n));
-    __store_ref(pointer + 60, __lowerTypedArray(Uint8Array, 13, 0, value.o));
-    __store_ref(pointer + 64, __lowerArray((pointer, value) => { __store_ref(pointer, __lowerString(value) || __notnull()); }, 14, 2, value.p));
+    const pointer = exports.__pin(exports.__new(68, 13));
+    __setU8(pointer + 0,value.a);
+    __setU16(pointer + 2,value.b);
+    __setU32(pointer + 4,value.c);
+    __setU64(pointer + 8,value.d || 0n);
+    __setU8(pointer + 16,value.e);
+    __setU16(pointer + 18,value.f);
+    __setU32(pointer + 20,value.g);
+    __setU64(pointer + 24,value.h || 0n);
+    __setU32(pointer + 32,value.i);
+    __setU32(pointer + 36,value.j);
+    __setU8(pointer + 40,value.k ? 1 : 0);
+    __setF32(pointer + 44,value.l);
+    __setF64(pointer + 48,value.m);
+    __setU32(pointer + 56,__lowerString(value.n));
+    __setU32(pointer + 60,__lowerTypedArray(Uint8Array, 14, 0, value.o));
+    __setU32(pointer + 64,__lowerArray((pointer, value) => { __setU32(pointer, __lowerString(value) || __notnull()); }, 12, 2, value.p));
     exports.__unpin(pointer);
     return pointer;
   }
-  function __liftRecord12(pointer) {
+  function __liftRecord13(pointer) {
     // bindings/esm/PlainObject
     // Hint: Opt-out from lifting as a record by providing an empty constructor
     if (!pointer) return null;
     return {
-      a: new Int8Array(memory.buffer)[pointer + 0 >>> 0],
-      b: new Int16Array(memory.buffer)[pointer + 2 >>> 1],
-      c: new Int32Array(memory.buffer)[pointer + 4 >>> 2],
-      d: new BigInt64Array(memory.buffer)[pointer + 8 >>> 3],
-      e: new Uint8Array(memory.buffer)[pointer + 16 >>> 0],
-      f: new Uint16Array(memory.buffer)[pointer + 18 >>> 1],
-      g: new Uint32Array(memory.buffer)[pointer + 20 >>> 2],
-      h: new BigUint64Array(memory.buffer)[pointer + 24 >>> 3],
-      i: new Int32Array(memory.buffer)[pointer + 32 >>> 2],
-      j: new Uint32Array(memory.buffer)[pointer + 36 >>> 2],
-      k: new Uint8Array(memory.buffer)[pointer + 40 >>> 0] != 0,
-      l: new Float32Array(memory.buffer)[pointer + 44 >>> 2],
-      m: new Float64Array(memory.buffer)[pointer + 48 >>> 3],
-      n: __liftString(new Uint32Array(memory.buffer)[pointer + 56 >>> 2]),
-      o: __liftTypedArray(Uint8Array, new Uint32Array(memory.buffer)[pointer + 60 >>> 2]),
-      p: __liftArray(pointer => __liftString(new Uint32Array(memory.buffer)[pointer >>> 2]), 2, new Uint32Array(memory.buffer)[pointer + 64 >>> 2]),
+      a: __getI8(pointer + 0),
+      b: __getI16(pointer + 2),
+      c: __getI32(pointer + 4),
+      d: __getI64(pointer + 8),
+      e: __getU8(pointer + 16),
+      f: __getU16(pointer + 18),
+      g: __getU32(pointer + 20),
+      h: __getU64(pointer + 24),
+      i: __getI32(pointer + 32),
+      j: __getU32(pointer + 36),
+      k: __getU8(pointer + 40) != 0,
+      l: __getF32(pointer + 44),
+      m: __getF64(pointer + 48),
+      n: __liftString(__getU32(pointer + 56)),
+      o: __liftTypedArray(Uint8Array, __getU32(pointer + 60)),
+      p: __liftArray(pointer => __liftString(__getU32(pointer)), 2, __getU32(pointer + 64)),
     };
   }
   function __liftBuffer(pointer) {
@@ -282,9 +292,8 @@ async function instantiate(module, imports = {}) {
   function __liftArray(liftElement, align, pointer) {
     if (!pointer) return null;
     const
-      memoryU32 = new Uint32Array(memory.buffer),
-      dataStart = memoryU32[pointer + 4 >>> 2],
-      length = memoryU32[pointer + 12 >>> 2],
+      dataStart = __getU32(pointer + 4),
+      length = __dataview.getUint32(pointer + 12, true),
       values = new Array(length);
     for (let i = 0; i < length; ++i) values[i] = liftElement(dataStart + (i << align >>> 0));
     return values;
@@ -294,12 +303,11 @@ async function instantiate(module, imports = {}) {
     const
       length = values.length,
       buffer = exports.__pin(exports.__new(length << align, 1)) >>> 0,
-      header = exports.__pin(exports.__new(16, id)) >>> 0,
-      memoryU32 = new Uint32Array(memory.buffer);
-    memoryU32[header + 0 >>> 2] = buffer;
-    memoryU32[header + 4 >>> 2] = buffer;
-    memoryU32[header + 8 >>> 2] = length << align;
-    memoryU32[header + 12 >>> 2] = length;
+      header = exports.__pin(exports.__new(16, id)) >>> 0;
+    __setU32(header + 0, buffer);
+    __dataview.setUint32(header + 4, buffer, true);
+    __dataview.setUint32(header + 8, length << align, true);
+    __dataview.setUint32(header + 12, length, true);
     for (let i = 0; i < length; ++i) lowerElement(buffer + (i << align >>> 0), values[i]);
     exports.__unpin(buffer);
     exports.__unpin(header);
@@ -307,11 +315,10 @@ async function instantiate(module, imports = {}) {
   }
   function __liftTypedArray(constructor, pointer) {
     if (!pointer) return null;
-    const memoryU32 = new Uint32Array(memory.buffer);
     return new constructor(
       memory.buffer,
-      memoryU32[pointer + 4 >>> 2],
-      memoryU32[pointer + 8 >>> 2] / constructor.BYTES_PER_ELEMENT
+      __getU32(pointer + 4),
+      __dataview.getUint32(pointer + 8, true) / constructor.BYTES_PER_ELEMENT
     ).slice();
   }
   function __lowerTypedArray(constructor, id, align, values) {
@@ -319,11 +326,10 @@ async function instantiate(module, imports = {}) {
     const
       length = values.length,
       buffer = exports.__pin(exports.__new(length << align, 1)) >>> 0,
-      header = exports.__new(12, id) >>> 0,
-      memoryU32 = new Uint32Array(memory.buffer);
-    memoryU32[header + 0 >>> 2] = buffer;
-    memoryU32[header + 4 >>> 2] = buffer;
-    memoryU32[header + 8 >>> 2] = length << align;
+      header = exports.__new(12, id) >>> 0;
+    __setU32(header + 0, buffer);
+    __dataview.setUint32(header + 4, buffer, true);
+    __dataview.setUint32(header + 8, length << align, true);
     new constructor(memory.buffer, buffer, length).set(values);
     exports.__unpin(buffer);
     return header;
@@ -331,7 +337,7 @@ async function instantiate(module, imports = {}) {
   function __liftStaticArray(liftElement, align, pointer) {
     if (!pointer) return null;
     const
-      length = new Uint32Array(memory.buffer)[pointer - 4 >>> 2] >>> align,
+      length = __getU32(pointer - 4) >>> align,
       values = new Array(length);
     for (let i = 0; i < length; ++i) values[i] = liftElement(pointer + (i << align >>> 0));
     return values;
@@ -382,8 +388,134 @@ async function instantiate(module, imports = {}) {
   function __notnull() {
     throw TypeError("value must not be null");
   }
-  function __store_ref(pointer, value) {
-    new Uint32Array(memory.buffer)[pointer >>> 2] = value;
+  let __dataview = new DataView(memory.buffer);
+  function __setU8(pointer, value) {
+    try {
+      __dataview.setUint8(pointer, value, true);
+    } catch {
+      __dataview = new DataView(memory.buffer);
+      __dataview.setUint8(pointer, value, true);
+    }
+  }
+  function __setU16(pointer, value) {
+    try {
+      __dataview.setUint16(pointer, value, true);
+    } catch {
+      __dataview = new DataView(memory.buffer);
+      __dataview.setUint16(pointer, value, true);
+    }
+  }
+  function __setU32(pointer, value) {
+    try {
+      __dataview.setUint32(pointer, value, true);
+    } catch {
+      __dataview = new DataView(memory.buffer);
+      __dataview.setUint32(pointer, value, true);
+    }
+  }
+  function __setU64(pointer, value) {
+    try {
+      __dataview.setBigUint64(pointer, value, true);
+    } catch {
+      __dataview = new DataView(memory.buffer);
+      __dataview.setBigUint64(pointer, value, true);
+    }
+  }
+  function __setF32(pointer, value) {
+    try {
+      __dataview.setFloat32(pointer, value, true);
+    } catch {
+      __dataview = new DataView(memory.buffer);
+      __dataview.setFloat32(pointer, value, true);
+    }
+  }
+  function __setF64(pointer, value) {
+    try {
+      __dataview.setFloat64(pointer, value, true);
+    } catch {
+      __dataview = new DataView(memory.buffer);
+      __dataview.setFloat64(pointer, value, true);
+    }
+  }
+  function __getI8(pointer) {
+    try {
+      return __dataview.getInt8(pointer, true);
+    } catch {
+      __dataview = new DataView(memory.buffer);
+      return __dataview.getInt8(pointer, true);
+    }
+  }
+  function __getU8(pointer) {
+    try {
+      return __dataview.getUint8(pointer, true);
+    } catch {
+      __dataview = new DataView(memory.buffer);
+      return __dataview.getUint8(pointer, true);
+    }
+  }
+  function __getI16(pointer) {
+    try {
+      return __dataview.getInt16(pointer, true);
+    } catch {
+      __dataview = new DataView(memory.buffer);
+      return __dataview.getInt16(pointer, true);
+    }
+  }
+  function __getU16(pointer) {
+    try {
+      return __dataview.getUint16(pointer, true);
+    } catch {
+      __dataview = new DataView(memory.buffer);
+      return __dataview.getUint16(pointer, true);
+    }
+  }
+  function __getI32(pointer) {
+    try {
+      return __dataview.getInt32(pointer, true);
+    } catch {
+      __dataview = new DataView(memory.buffer);
+      return __dataview.getInt32(pointer, true);
+    }
+  }
+  function __getU32(pointer) {
+    try {
+      return __dataview.getUint32(pointer, true);
+    } catch {
+      __dataview = new DataView(memory.buffer);
+      return __dataview.getUint32(pointer, true);
+    }
+  }
+  function __getI64(pointer) {
+    try {
+      return __dataview.getBigInt64(pointer, true);
+    } catch {
+      __dataview = new DataView(memory.buffer);
+      return __dataview.getBigInt64(pointer, true);
+    }
+  }
+  function __getU64(pointer) {
+    try {
+      return __dataview.getBigUint64(pointer, true);
+    } catch {
+      __dataview = new DataView(memory.buffer);
+      return __dataview.getBigUint64(pointer, true);
+    }
+  }
+  function __getF32(pointer) {
+    try {
+      return __dataview.getFloat32(pointer, true);
+    } catch {
+      __dataview = new DataView(memory.buffer);
+      return __dataview.getFloat32(pointer, true);
+    }
+  }
+  function __getF64(pointer) {
+    try {
+      return __dataview.getFloat64(pointer, true);
+    } catch {
+      __dataview = new DataView(memory.buffer);
+      return __dataview.getFloat64(pointer, true);
+    }
   }
   exports._start();
   return adaptedExports;
@@ -408,6 +540,7 @@ export const {
   staticarrayU16,
   staticarrayI64,
   arrayFunction,
+  arrayOfStringsFunction,
   objectFunction,
   newInternref,
   internrefFunction,

--- a/tests/compiler/bindings/esm.release.wat
+++ b/tests/compiler/bindings/esm.release.wat
@@ -1,11 +1,11 @@
 (module
  (type $i32_i32_=>_i32 (func_subtype (param i32 i32) (result i32) func))
  (type $i32_=>_none (func_subtype (param i32) func))
+ (type $i32_i32_i32_=>_none (func_subtype (param i32 i32 i32) func))
  (type $i32_=>_i32 (func_subtype (param i32) (result i32) func))
  (type $none_=>_i32 (func_subtype (result i32) func))
  (type $none_=>_none (func_subtype func))
  (type $i32_i32_=>_none (func_subtype (param i32 i32) func))
- (type $i32_i32_i32_=>_none (func_subtype (param i32 i32 i32) func))
  (type $i32_i32_f64_f64_f64_f64_f64_=>_none (func_subtype (param i32 i32 f64 f64 f64 f64 f64) func))
  (type $f64_=>_f64 (func_subtype (param f64) (result f64) func))
  (type $i64_i64_=>_i64 (func_subtype (param i64 i64) (result i64) func))
@@ -40,8 +40,8 @@
  (global $~lib/rt/itcms/fromSpace (mut i32) (i32.const 0))
  (global $~lib/rt/tlsf/ROOT (mut i32) (i32.const 0))
  (global $~argumentsLength (mut i32) (i32.const 0))
- (global $~lib/rt/__rtti_base i32 (i32.const 2080))
- (global $~lib/memory/__stack_pointer (mut i32) (i32.const 34916))
+ (global $~lib/rt/__rtti_base i32 (i32.const 2208))
+ (global $~lib/memory/__stack_pointer (mut i32) (i32.const 35044))
  (global $~started (mut i32) (i32.const 0))
  (memory $0 1)
  (data (i32.const 1036) "\1c")
@@ -76,12 +76,14 @@
  (data (i32.const 1848) "\02\00\00\00&\00\00\00~\00l\00i\00b\00/\00s\00t\00a\00t\00i\00c\00a\00r\00r\00a\00y\00.\00t\00s")
  (data (i32.const 1900) ",")
  (data (i32.const 1912) "\02\00\00\00\1a\00\00\00~\00l\00i\00b\00/\00a\00r\00r\00a\00y\00.\00t\00s")
- (data (i32.const 1948) "<")
- (data (i32.const 1960) "\02\00\00\00*\00\00\00O\00b\00j\00e\00c\00t\00 \00a\00l\00r\00e\00a\00d\00y\00 \00p\00i\00n\00n\00e\00d")
- (data (i32.const 2012) "<")
- (data (i32.const 2024) "\02\00\00\00(\00\00\00O\00b\00j\00e\00c\00t\00 \00i\00s\00 \00n\00o\00t\00 \00p\00i\00n\00n\00e\00d")
- (data (i32.const 2080) "\10\00\00\00 \00\00\00 \00\00\00 ")
- (data (i32.const 2104) "\81\08\00\00\01\19\00\00\01\02\00\00$\t\00\00\a4\00\00\00$\n\00\00\02\t\00\00\00\00\00\00A\00\00\00\02A\00\00 ")
+ (data (i32.const 1948) "|")
+ (data (i32.const 1960) "\02\00\00\00^\00\00\00E\00l\00e\00m\00e\00n\00t\00 \00t\00y\00p\00e\00 \00m\00u\00s\00t\00 \00b\00e\00 \00n\00u\00l\00l\00a\00b\00l\00e\00 \00i\00f\00 \00a\00r\00r\00a\00y\00 \00i\00s\00 \00h\00o\00l\00e\00y")
+ (data (i32.const 2076) "<")
+ (data (i32.const 2088) "\02\00\00\00*\00\00\00O\00b\00j\00e\00c\00t\00 \00a\00l\00r\00e\00a\00d\00y\00 \00p\00i\00n\00n\00e\00d")
+ (data (i32.const 2140) "<")
+ (data (i32.const 2152) "\02\00\00\00(\00\00\00O\00b\00j\00e\00c\00t\00 \00i\00s\00 \00n\00o\00t\00 \00p\00i\00n\00n\00e\00d")
+ (data (i32.const 2208) "\10\00\00\00 \00\00\00 \00\00\00 ")
+ (data (i32.const 2232) "\81\08\00\00\01\19\00\00\01\02\00\00$\t\00\00\a4\00\00\00$\n\00\00\02\t\00\00\02A\00\00\00\00\00\00A\00\00\00 ")
  (export "plainGlobal" (global $bindings/esm/plainGlobal))
  (export "plainMutableGlobal" (global $bindings/esm/plainMutableGlobal))
  (export "stringGlobal" (global $bindings/esm/stringGlobal))
@@ -114,6 +116,7 @@
  (export "staticarrayU16" (func $export:bindings/esm/staticarrayU16))
  (export "staticarrayI64" (func $export:bindings/esm/staticarrayU16))
  (export "arrayFunction" (func $export:bindings/esm/arrayFunction))
+ (export "arrayOfStringsFunction" (func $export:bindings/esm/arrayOfStringsFunction))
  (export "objectFunction" (func $export:bindings/esm/objectFunction))
  (export "internrefFunction" (func $export:bindings/esm/internrefFunction))
  (export "functionFunction" (func $export:bindings/esm/staticarrayU16))
@@ -148,11 +151,13 @@
   call $byn-split-outlined-A$~lib/rt/itcms/__visit
   i32.const 1248
   call $byn-split-outlined-A$~lib/rt/itcms/__visit
-  i32.const 1360
-  call $byn-split-outlined-A$~lib/rt/itcms/__visit
   i32.const 1968
   call $byn-split-outlined-A$~lib/rt/itcms/__visit
-  i32.const 2032
+  i32.const 1360
+  call $byn-split-outlined-A$~lib/rt/itcms/__visit
+  i32.const 2096
+  call $byn-split-outlined-A$~lib/rt/itcms/__visit
+  i32.const 2160
   call $byn-split-outlined-A$~lib/rt/itcms/__visit
   global.get $~lib/rt/itcms/pinSpace
   local.tee $1
@@ -205,7 +210,7 @@
    i32.load $0 offset=8
    i32.eqz
    local.get $0
-   i32.const 34916
+   i32.const 35044
    i32.lt_u
    i32.and
    i32.eqz
@@ -279,7 +284,7 @@
    i32.const 1
   else
    local.get $2
-   i32.const 2080
+   i32.const 2208
    i32.load $0
    i32.gt_u
    if
@@ -293,7 +298,7 @@
    local.get $2
    i32.const 2
    i32.shl
-   i32.const 2084
+   i32.const 2212
    i32.add
    i32.load $0
    i32.const 32
@@ -858,10 +863,10 @@
   if
    unreachable
   end
-  i32.const 34928
+  i32.const 35056
   i32.const 0
   i32.store $0
-  i32.const 36496
+  i32.const 36624
   i32.const 0
   i32.store $0
   loop $for-loop|0
@@ -872,7 +877,7 @@
     local.get $0
     i32.const 2
     i32.shl
-    i32.const 34928
+    i32.const 35056
     i32.add
     i32.const 0
     i32.store $0 offset=4
@@ -890,7 +895,7 @@
       i32.add
       i32.const 2
       i32.shl
-      i32.const 34928
+      i32.const 35056
       i32.add
       i32.const 0
       i32.store $0 offset=96
@@ -908,13 +913,13 @@
     br $for-loop|0
    end
   end
-  i32.const 34928
-  i32.const 36500
+  i32.const 35056
+  i32.const 36628
   memory.size $0
   i32.const 16
   i32.shl
   call $~lib/rt/tlsf/addMemory
-  i32.const 34928
+  i32.const 35056
   global.set $~lib/rt/tlsf/ROOT
  )
  (func $~lib/rt/itcms/step (type $none_=>_i32) (result i32)
@@ -999,7 +1004,7 @@
      local.set $0
      loop $while-continue|0
       local.get $0
-      i32.const 34916
+      i32.const 35044
       i32.lt_u
       if
        local.get $0
@@ -1099,7 +1104,7 @@
      unreachable
     end
     local.get $0
-    i32.const 34916
+    i32.const 35044
     i32.lt_u
     if
      local.get $0
@@ -1122,7 +1127,7 @@
      i32.const 4
      i32.add
      local.tee $0
-     i32.const 34916
+     i32.const 35044
      i32.ge_u
      if
       global.get $~lib/rt/tlsf/ROOT
@@ -1623,11 +1628,11 @@
   i32.sub
   global.set $~lib/memory/__stack_pointer
   global.get $~lib/memory/__stack_pointer
-  i32.const 2148
+  i32.const 2276
   i32.lt_s
   if
-   i32.const 34944
-   i32.const 34992
+   i32.const 35072
+   i32.const 35120
    i32.const 1
    i32.const 1
    call $~lib/builtins/abort
@@ -1665,7 +1670,7 @@
    i32.const 3
    i32.eq
    if
-    i32.const 1968
+    i32.const 2096
     i32.const 1424
     i32.const 338
     i32.const 7
@@ -1718,7 +1723,7 @@
   i32.const 3
   i32.ne
   if
-   i32.const 2032
+   i32.const 2160
    i32.const 1424
    i32.const 352
    i32.const 5
@@ -1803,8 +1808,8 @@
     block $folding-inner0
      block $invalid
       block $bindings/esm/NonPlainObject
-       block $~lib/array/Array<~lib/string/String>
-        block $bindings/esm/PlainObject
+       block $bindings/esm/PlainObject
+        block $~lib/array/Array<~lib/string/String>
          block $~lib/array/Array<i32>
           block $~lib/staticarray/StaticArray<i64>
            block $~lib/staticarray/StaticArray<u16>
@@ -1817,7 +1822,7 @@
                  i32.const 8
                  i32.sub
                  i32.load $0
-                 br_table $~lib/object/Object $~lib/arraybuffer/ArrayBuffer $~lib/string/String $folding-inner1 $~lib/function/Function<%28%29=>void> $folding-inner1 $folding-inner1 $folding-inner1 $~lib/staticarray/StaticArray<i32> $~lib/staticarray/StaticArray<u16> $~lib/staticarray/StaticArray<i64> $~lib/array/Array<i32> $bindings/esm/PlainObject $folding-inner1 $~lib/array/Array<~lib/string/String> $bindings/esm/NonPlainObject $invalid
+                 br_table $~lib/object/Object $~lib/arraybuffer/ArrayBuffer $~lib/string/String $folding-inner1 $~lib/function/Function<%28%29=>void> $folding-inner1 $folding-inner1 $folding-inner1 $~lib/staticarray/StaticArray<i32> $~lib/staticarray/StaticArray<u16> $~lib/staticarray/StaticArray<i64> $~lib/array/Array<i32> $~lib/array/Array<~lib/string/String> $bindings/esm/PlainObject $folding-inner1 $bindings/esm/NonPlainObject $invalid
                 end
                 return
                end
@@ -1830,7 +1835,7 @@
              i32.sub
              global.set $~lib/memory/__stack_pointer
              global.get $~lib/memory/__stack_pointer
-             i32.const 2148
+             i32.const 2276
              i32.lt_s
              br_if $folding-inner0
              global.get $~lib/memory/__stack_pointer
@@ -1864,7 +1869,7 @@
          i32.sub
          global.set $~lib/memory/__stack_pointer
          global.get $~lib/memory/__stack_pointer
-         i32.const 2148
+         i32.const 2276
          i32.lt_s
          br_if $folding-inner0
          global.get $~lib/memory/__stack_pointer
@@ -1872,84 +1877,84 @@
          i32.store $0
          br $folding-inner2
         end
-        local.get $0
-        i32.load $0 offset=56
-        local.tee $1
-        if
-         local.get $1
-         call $byn-split-outlined-A$~lib/rt/itcms/__visit
-        end
-        local.get $0
-        i32.load $0 offset=60
-        local.tee $1
-        if
-         local.get $1
-         call $byn-split-outlined-A$~lib/rt/itcms/__visit
-        end
-        local.get $0
-        i32.load $0 offset=64
-        local.tee $0
-        if
-         local.get $0
-         call $byn-split-outlined-A$~lib/rt/itcms/__visit
-        end
-        return
-       end
-       global.get $~lib/memory/__stack_pointer
-       i32.const 4
-       i32.sub
-       global.set $~lib/memory/__stack_pointer
-       global.get $~lib/memory/__stack_pointer
-       i32.const 2148
-       i32.lt_s
-       br_if $folding-inner0
-       global.get $~lib/memory/__stack_pointer
-       local.tee $2
-       i32.const 0
-       i32.store $0
-       local.get $2
-       local.get $0
-       i32.store $0
-       local.get $0
-       i32.load $0 offset=4
-       local.set $1
-       local.get $2
-       local.get $0
-       i32.store $0
-       local.get $1
-       local.get $0
-       i32.load $0 offset=12
-       i32.const 2
-       i32.shl
-       i32.add
-       local.set $2
-       loop $while-continue|0
-        local.get $1
+        global.get $~lib/memory/__stack_pointer
+        i32.const 4
+        i32.sub
+        global.set $~lib/memory/__stack_pointer
+        global.get $~lib/memory/__stack_pointer
+        i32.const 2276
+        i32.lt_s
+        br_if $folding-inner0
+        global.get $~lib/memory/__stack_pointer
+        local.tee $2
+        i32.const 0
+        i32.store $0
         local.get $2
-        i32.lt_u
-        if
+        local.get $0
+        i32.store $0
+        local.get $0
+        i32.load $0 offset=4
+        local.set $1
+        local.get $2
+        local.get $0
+        i32.store $0
+        local.get $1
+        local.get $0
+        i32.load $0 offset=12
+        i32.const 2
+        i32.shl
+        i32.add
+        local.set $2
+        loop $while-continue|0
          local.get $1
-         i32.load $0
-         local.tee $3
+         local.get $2
+         i32.lt_u
          if
-          local.get $3
-          call $byn-split-outlined-A$~lib/rt/itcms/__visit
+          local.get $1
+          i32.load $0
+          local.tee $3
+          if
+           local.get $3
+           call $byn-split-outlined-A$~lib/rt/itcms/__visit
+          end
+          local.get $1
+          i32.const 4
+          i32.add
+          local.set $1
+          br $while-continue|0
          end
-         local.get $1
-         i32.const 4
-         i32.add
-         local.set $1
-         br $while-continue|0
         end
+        br $folding-inner2
        end
-       br $folding-inner2
+       local.get $0
+       i32.load $0 offset=56
+       local.tee $1
+       if
+        local.get $1
+        call $byn-split-outlined-A$~lib/rt/itcms/__visit
+       end
+       local.get $0
+       i32.load $0 offset=60
+       local.tee $1
+       if
+        local.get $1
+        call $byn-split-outlined-A$~lib/rt/itcms/__visit
+       end
+       local.get $0
+       i32.load $0 offset=64
+       local.tee $0
+       if
+        local.get $0
+        call $byn-split-outlined-A$~lib/rt/itcms/__visit
+       end
+       return
       end
       return
      end
      unreachable
     end
-    i32.const 34944
-    i32.const 34992
+    i32.const 35072
+    i32.const 35120
     i32.const 1
     i32.const 1
     call $~lib/builtins/abort
@@ -1996,11 +2001,11 @@
   i32.sub
   global.set $~lib/memory/__stack_pointer
   global.get $~lib/memory/__stack_pointer
-  i32.const 2148
+  i32.const 2276
   i32.lt_s
   if
-   i32.const 34944
-   i32.const 34992
+   i32.const 35072
+   i32.const 35120
    i32.const 1
    i32.const 1
    call $~lib/builtins/abort
@@ -2038,7 +2043,7 @@
   memory.size $0
   i32.const 16
   i32.shl
-  i32.const 34916
+  i32.const 35044
   i32.sub
   i32.const 1
   i32.shr_u
@@ -2078,7 +2083,7 @@
   global.set $~lib/memory/__stack_pointer
   block $folding-inner0
    global.get $~lib/memory/__stack_pointer
-   i32.const 2148
+   i32.const 2276
    i32.lt_s
    br_if $folding-inner0
    global.get $~lib/memory/__stack_pointer
@@ -2096,7 +2101,7 @@
    i32.sub
    global.set $~lib/memory/__stack_pointer
    global.get $~lib/memory/__stack_pointer
-   i32.const 2148
+   i32.const 2276
    i32.lt_s
    br_if $folding-inner0
    global.get $~lib/memory/__stack_pointer
@@ -2114,7 +2119,7 @@
    i32.sub
    global.set $~lib/memory/__stack_pointer
    global.get $~lib/memory/__stack_pointer
-   i32.const 2148
+   i32.const 2276
    i32.lt_s
    br_if $folding-inner0
    global.get $~lib/memory/__stack_pointer
@@ -2187,8 +2192,8 @@
    local.get $2
    return
   end
-  i32.const 34944
-  i32.const 34992
+  i32.const 35072
+  i32.const 35120
   i32.const 1
   i32.const 1
   call $~lib/builtins/abort
@@ -2201,11 +2206,11 @@
   i32.sub
   global.set $~lib/memory/__stack_pointer
   global.get $~lib/memory/__stack_pointer
-  i32.const 2148
+  i32.const 2276
   i32.lt_s
   if
-   i32.const 34944
-   i32.const 34992
+   i32.const 35072
+   i32.const 35120
    i32.const 1
    i32.const 1
    call $~lib/builtins/abort
@@ -2236,11 +2241,11 @@
   i32.sub
   global.set $~lib/memory/__stack_pointer
   global.get $~lib/memory/__stack_pointer
-  i32.const 2148
+  i32.const 2276
   i32.lt_s
   if
-   i32.const 34944
-   i32.const 34992
+   i32.const 35072
+   i32.const 35120
    i32.const 1
    i32.const 1
    call $~lib/builtins/abort
@@ -2271,11 +2276,11 @@
   i32.sub
   global.set $~lib/memory/__stack_pointer
   global.get $~lib/memory/__stack_pointer
-  i32.const 2148
+  i32.const 2276
   i32.lt_s
   if
-   i32.const 34944
-   i32.const 34992
+   i32.const 35072
+   i32.const 35120
    i32.const 1
    i32.const 1
    call $~lib/builtins/abort
@@ -2334,7 +2339,7 @@
   global.set $~lib/memory/__stack_pointer
   block $folding-inner1
    global.get $~lib/memory/__stack_pointer
-   i32.const 2148
+   i32.const 2276
    i32.lt_s
    br_if $folding-inner1
    global.get $~lib/memory/__stack_pointer
@@ -2363,7 +2368,7 @@
    i32.sub
    global.set $~lib/memory/__stack_pointer
    global.get $~lib/memory/__stack_pointer
-   i32.const 2148
+   i32.const 2276
    i32.lt_s
    br_if $folding-inner1
    global.get $~lib/memory/__stack_pointer
@@ -2385,7 +2390,7 @@
    i32.sub
    global.set $~lib/memory/__stack_pointer
    global.get $~lib/memory/__stack_pointer
-   i32.const 2148
+   i32.const 2276
    i32.lt_s
    br_if $folding-inner1
    global.get $~lib/memory/__stack_pointer
@@ -2457,6 +2462,7 @@
    if
     local.get $2
     local.get $6
+    i32.const 0
     call $byn-split-outlined-A$~lib/rt/itcms/__link
    end
    global.get $~lib/memory/__stack_pointer
@@ -2507,7 +2513,7 @@
      i32.sub
      global.set $~lib/memory/__stack_pointer
      global.get $~lib/memory/__stack_pointer
-     i32.const 2148
+     i32.const 2276
      i32.lt_s
      br_if $folding-inner1
      global.get $~lib/memory/__stack_pointer
@@ -2590,7 +2596,7 @@
      i32.sub
      global.set $~lib/memory/__stack_pointer
      global.get $~lib/memory/__stack_pointer
-     i32.const 2148
+     i32.const 2276
      i32.lt_s
      br_if $folding-inner1
      global.get $~lib/memory/__stack_pointer
@@ -2649,8 +2655,8 @@
    local.get $2
    return
   end
-  i32.const 34944
-  i32.const 34992
+  i32.const 35072
+  i32.const 35120
   i32.const 1
   i32.const 1
   call $~lib/builtins/abort
@@ -2663,11 +2669,11 @@
   i32.sub
   global.set $~lib/memory/__stack_pointer
   global.get $~lib/memory/__stack_pointer
-  i32.const 2148
+  i32.const 2276
   i32.lt_s
   if
-   i32.const 34944
-   i32.const 34992
+   i32.const 35072
+   i32.const 35120
    i32.const 1
    i32.const 1
    call $~lib/builtins/abort
@@ -2716,11 +2722,11 @@
   i32.sub
   global.set $~lib/memory/__stack_pointer
   global.get $~lib/memory/__stack_pointer
-  i32.const 2148
+  i32.const 2276
   i32.lt_s
   if
-   i32.const 34944
-   i32.const 34992
+   i32.const 35072
+   i32.const 35120
    i32.const 1
    i32.const 1
    call $~lib/builtins/abort
@@ -2772,11 +2778,11 @@
   i32.sub
   global.set $~lib/memory/__stack_pointer
   global.get $~lib/memory/__stack_pointer
-  i32.const 2148
+  i32.const 2276
   i32.lt_s
   if
-   i32.const 34944
-   i32.const 34992
+   i32.const 35072
+   i32.const 35120
    i32.const 1
    i32.const 1
    call $~lib/builtins/abort
@@ -2805,11 +2811,11 @@
   i32.sub
   global.set $~lib/memory/__stack_pointer
   global.get $~lib/memory/__stack_pointer
-  i32.const 2148
+  i32.const 2276
   i32.lt_s
   if
-   i32.const 34944
-   i32.const 34992
+   i32.const 35072
+   i32.const 35120
    i32.const 1
    i32.const 1
    call $~lib/builtins/abort
@@ -2852,203 +2858,211 @@
   global.set $~lib/memory/__stack_pointer
   local.get $0
  )
- (func $~lib/array/Array<i32>#__set (type $i32_i32_i32_=>_none) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/array/ensureCapacity (type $i32_i32_=>_none) (param $0 i32) (param $1 i32)
+  (local $2 i32)
   (local $3 i32)
   (local $4 i32)
-  (local $5 i32)
-  (local $6 i32)
-  (local $7 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 4
   i32.sub
   global.set $~lib/memory/__stack_pointer
-  block $folding-inner0
-   global.get $~lib/memory/__stack_pointer
-   i32.const 2148
-   i32.lt_s
-   br_if $folding-inner0
-   global.get $~lib/memory/__stack_pointer
-   local.tee $3
-   i32.const 0
-   i32.store $0
-   local.get $3
-   local.get $0
-   i32.store $0
+  global.get $~lib/memory/__stack_pointer
+  i32.const 2276
+  i32.lt_s
+  if
+   i32.const 35072
+   i32.const 35120
+   i32.const 1
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  global.get $~lib/memory/__stack_pointer
+  local.tee $2
+  i32.const 0
+  i32.store $0
+  local.get $2
+  local.get $0
+  i32.store $0
+  local.get $1
+  local.get $0
+  i32.load $0 offset=8
+  local.tee $2
+  i32.const 2
+  i32.shr_u
+  i32.gt_u
+  if
    local.get $1
-   local.get $0
-   i32.load $0 offset=12
-   i32.ge_u
+   i32.const 268435455
+   i32.gt_u
    if
-    local.get $1
-    i32.const 0
-    i32.lt_s
-    if
-     i32.const 1552
-     i32.const 1920
-     i32.const 130
-     i32.const 22
-     call $~lib/builtins/abort
-     unreachable
-    end
-    local.get $1
-    i32.const 1
-    i32.add
-    local.tee $6
-    local.set $3
-    global.get $~lib/memory/__stack_pointer
-    i32.const 4
-    i32.sub
-    global.set $~lib/memory/__stack_pointer
-    global.get $~lib/memory/__stack_pointer
-    i32.const 2148
-    i32.lt_s
-    br_if $folding-inner0
-    global.get $~lib/memory/__stack_pointer
-    local.tee $4
-    i32.const 0
-    i32.store $0
-    local.get $4
-    local.get $0
-    i32.store $0
-    local.get $3
-    local.get $0
-    i32.load $0 offset=8
-    local.tee $4
-    i32.const 2
-    i32.shr_u
-    i32.gt_u
-    if
-     local.get $3
-     i32.const 268435455
-     i32.gt_u
-     if
-      i32.const 1248
-      i32.const 1920
-      i32.const 19
-      i32.const 48
-      call $~lib/builtins/abort
-      unreachable
-     end
-     global.get $~lib/memory/__stack_pointer
-     local.get $0
-     i32.store $0
-     block $__inlined_func$~lib/rt/itcms/__renew
-      i32.const 1073741820
-      local.get $4
-      i32.const 1
-      i32.shl
-      local.tee $4
-      local.get $4
-      i32.const 1073741820
-      i32.ge_u
-      select
-      local.tee $4
-      i32.const 8
-      local.get $3
-      local.get $3
-      i32.const 8
-      i32.le_u
-      select
-      i32.const 2
-      i32.shl
-      local.tee $3
-      local.get $3
-      local.get $4
-      i32.lt_u
-      select
-      local.tee $5
-      local.get $0
-      i32.load $0
-      local.tee $4
-      i32.const 20
-      i32.sub
-      local.tee $7
-      i32.load $0
-      i32.const -4
-      i32.and
-      i32.const 16
-      i32.sub
-      i32.le_u
-      if
-       local.get $7
-       local.get $5
-       i32.store $0 offset=16
-       local.get $4
-       local.set $3
-       br $__inlined_func$~lib/rt/itcms/__renew
-      end
-      local.get $5
-      local.get $7
-      i32.load $0 offset=12
-      call $~lib/rt/itcms/__new
-      local.tee $3
-      local.get $4
-      local.get $5
-      local.get $7
-      i32.load $0 offset=16
-      local.tee $7
-      local.get $5
-      local.get $7
-      i32.lt_u
-      select
-      memory.copy $0 $0
-     end
-     local.get $3
-     local.get $4
-     i32.ne
-     if
-      local.get $0
-      local.get $3
-      i32.store $0
-      local.get $0
-      local.get $3
-      i32.store $0 offset=4
-      local.get $3
-      if
-       local.get $0
-       local.get $3
-       call $byn-split-outlined-A$~lib/rt/itcms/__link
-      end
-     end
-     local.get $0
-     local.get $5
-     i32.store $0 offset=8
-    end
-    global.get $~lib/memory/__stack_pointer
-    i32.const 4
-    i32.add
-    global.set $~lib/memory/__stack_pointer
-    global.get $~lib/memory/__stack_pointer
-    local.get $0
-    i32.store $0
-    local.get $0
-    local.get $6
-    i32.store $0 offset=12
+    i32.const 1248
+    i32.const 1920
+    i32.const 19
+    i32.const 48
+    call $~lib/builtins/abort
+    unreachable
    end
    global.get $~lib/memory/__stack_pointer
-   local.tee $3
    local.get $0
    i32.store $0
-   local.get $0
-   i32.load $0 offset=4
+   block $__inlined_func$~lib/rt/itcms/__renew
+    i32.const 1073741820
+    local.get $2
+    i32.const 1
+    i32.shl
+    local.tee $2
+    local.get $2
+    i32.const 1073741820
+    i32.ge_u
+    select
+    local.tee $2
+    i32.const 8
+    local.get $1
+    local.get $1
+    i32.const 8
+    i32.le_u
+    select
+    i32.const 2
+    i32.shl
+    local.tee $1
+    local.get $1
+    local.get $2
+    i32.lt_u
+    select
+    local.tee $3
+    local.get $0
+    i32.load $0
+    local.tee $2
+    i32.const 20
+    i32.sub
+    local.tee $4
+    i32.load $0
+    i32.const -4
+    i32.and
+    i32.const 16
+    i32.sub
+    i32.le_u
+    if
+     local.get $4
+     local.get $3
+     i32.store $0 offset=16
+     local.get $2
+     local.set $1
+     br $__inlined_func$~lib/rt/itcms/__renew
+    end
+    local.get $3
+    local.get $4
+    i32.load $0 offset=12
+    call $~lib/rt/itcms/__new
+    local.tee $1
+    local.get $2
+    local.get $3
+    local.get $4
+    i32.load $0 offset=16
+    local.tee $4
+    local.get $3
+    local.get $4
+    i32.lt_u
+    select
+    memory.copy $0 $0
+   end
    local.get $1
-   i32.const 2
-   i32.shl
-   i32.add
    local.get $2
-   i32.store $0
+   i32.ne
+   if
+    local.get $0
+    local.get $1
+    i32.store $0
+    local.get $0
+    local.get $1
+    i32.store $0 offset=4
+    local.get $1
+    if
+     local.get $0
+     local.get $1
+     i32.const 0
+     call $byn-split-outlined-A$~lib/rt/itcms/__link
+    end
+   end
+   local.get $0
    local.get $3
-   i32.const 4
-   i32.add
-   global.set $~lib/memory/__stack_pointer
-   return
+   i32.store $0 offset=8
   end
-  i32.const 34944
-  i32.const 34992
-  i32.const 1
-  i32.const 1
-  call $~lib/builtins/abort
-  unreachable
+  global.get $~lib/memory/__stack_pointer
+  i32.const 4
+  i32.add
+  global.set $~lib/memory/__stack_pointer
+ )
+ (func $~lib/array/Array<i32>#__set (type $i32_i32_i32_=>_none) (param $0 i32) (param $1 i32) (param $2 i32)
+  (local $3 i32)
+  global.get $~lib/memory/__stack_pointer
+  i32.const 4
+  i32.sub
+  global.set $~lib/memory/__stack_pointer
+  global.get $~lib/memory/__stack_pointer
+  i32.const 2276
+  i32.lt_s
+  if
+   i32.const 35072
+   i32.const 35120
+   i32.const 1
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  global.get $~lib/memory/__stack_pointer
+  local.tee $3
+  i32.const 0
+  i32.store $0
+  local.get $3
+  local.get $0
+  i32.store $0
+  local.get $1
+  local.get $0
+  i32.load $0 offset=12
+  i32.ge_u
+  if
+   local.get $1
+   i32.const 0
+   i32.lt_s
+   if
+    i32.const 1552
+    i32.const 1920
+    i32.const 130
+    i32.const 22
+    call $~lib/builtins/abort
+    unreachable
+   end
+   local.get $0
+   local.get $1
+   i32.const 1
+   i32.add
+   local.tee $3
+   call $~lib/array/ensureCapacity
+   global.get $~lib/memory/__stack_pointer
+   local.get $0
+   i32.store $0
+   local.get $0
+   local.get $3
+   i32.store $0 offset=12
+  end
+  global.get $~lib/memory/__stack_pointer
+  local.tee $3
+  local.get $0
+  i32.store $0
+  local.get $0
+  i32.load $0 offset=4
+  local.get $1
+  i32.const 2
+  i32.shl
+  i32.add
+  local.get $2
+  i32.store $0
+  local.get $3
+  i32.const 4
+  i32.add
+  global.set $~lib/memory/__stack_pointer
  )
  (func $bindings/esm/arrayFunction (type $i32_i32_=>_i32) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
@@ -3064,7 +3078,7 @@
   global.set $~lib/memory/__stack_pointer
   block $folding-inner0
    global.get $~lib/memory/__stack_pointer
-   i32.const 2148
+   i32.const 2276
    i32.lt_s
    br_if $folding-inner0
    global.get $~lib/memory/__stack_pointer
@@ -3093,7 +3107,7 @@
    i32.sub
    global.set $~lib/memory/__stack_pointer
    global.get $~lib/memory/__stack_pointer
-   i32.const 2148
+   i32.const 2276
    i32.lt_s
    br_if $folding-inner0
    global.get $~lib/memory/__stack_pointer
@@ -3172,6 +3186,7 @@
    if
     local.get $5
     local.get $6
+    i32.const 0
     call $byn-split-outlined-A$~lib/rt/itcms/__link
    end
    global.get $~lib/memory/__stack_pointer
@@ -3275,8 +3290,393 @@
    local.get $5
    return
   end
-  i32.const 34944
-  i32.const 34992
+  i32.const 35072
+  i32.const 35120
+  i32.const 1
+  i32.const 1
+  call $~lib/builtins/abort
+  unreachable
+ )
+ (func $~lib/array/Array<~lib/string/String>#__get (type $i32_i32_=>_i32) (param $0 i32) (param $1 i32) (result i32)
+  (local $2 i32)
+  global.get $~lib/memory/__stack_pointer
+  i32.const 8
+  i32.sub
+  global.set $~lib/memory/__stack_pointer
+  global.get $~lib/memory/__stack_pointer
+  i32.const 2276
+  i32.lt_s
+  if
+   i32.const 35072
+   i32.const 35120
+   i32.const 1
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  global.get $~lib/memory/__stack_pointer
+  local.tee $2
+  i64.const 0
+  i64.store $0
+  local.get $2
+  local.get $0
+  i32.store $0
+  local.get $1
+  local.get $0
+  i32.load $0 offset=12
+  i32.ge_u
+  if
+   i32.const 1552
+   i32.const 1920
+   i32.const 114
+   i32.const 42
+   call $~lib/builtins/abort
+   unreachable
+  end
+  global.get $~lib/memory/__stack_pointer
+  local.tee $2
+  local.get $0
+  i32.store $0
+  local.get $2
+  local.get $0
+  i32.load $0 offset=4
+  local.get $1
+  i32.const 2
+  i32.shl
+  i32.add
+  i32.load $0
+  local.tee $0
+  i32.store $0 offset=4
+  local.get $0
+  i32.eqz
+  if
+   i32.const 1968
+   i32.const 1920
+   i32.const 118
+   i32.const 40
+   call $~lib/builtins/abort
+   unreachable
+  end
+  global.get $~lib/memory/__stack_pointer
+  i32.const 8
+  i32.add
+  global.set $~lib/memory/__stack_pointer
+  local.get $0
+ )
+ (func $~lib/array/Array<~lib/string/String>#__set (type $i32_i32_i32_=>_none) (param $0 i32) (param $1 i32) (param $2 i32)
+  (local $3 i32)
+  global.get $~lib/memory/__stack_pointer
+  i32.const 4
+  i32.sub
+  global.set $~lib/memory/__stack_pointer
+  global.get $~lib/memory/__stack_pointer
+  i32.const 2276
+  i32.lt_s
+  if
+   i32.const 35072
+   i32.const 35120
+   i32.const 1
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  global.get $~lib/memory/__stack_pointer
+  local.tee $3
+  i32.const 0
+  i32.store $0
+  local.get $3
+  local.get $0
+  i32.store $0
+  local.get $1
+  local.get $0
+  i32.load $0 offset=12
+  i32.ge_u
+  if
+   local.get $1
+   i32.const 0
+   i32.lt_s
+   if
+    i32.const 1552
+    i32.const 1920
+    i32.const 130
+    i32.const 22
+    call $~lib/builtins/abort
+    unreachable
+   end
+   local.get $0
+   local.get $1
+   i32.const 1
+   i32.add
+   local.tee $3
+   call $~lib/array/ensureCapacity
+   global.get $~lib/memory/__stack_pointer
+   local.get $0
+   i32.store $0
+   local.get $0
+   local.get $3
+   i32.store $0 offset=12
+  end
+  global.get $~lib/memory/__stack_pointer
+  local.get $0
+  i32.store $0
+  local.get $0
+  i32.load $0 offset=4
+  local.get $1
+  i32.const 2
+  i32.shl
+  i32.add
+  local.get $2
+  i32.store $0
+  local.get $2
+  if
+   local.get $0
+   local.get $2
+   i32.const 1
+   call $byn-split-outlined-A$~lib/rt/itcms/__link
+  end
+  global.get $~lib/memory/__stack_pointer
+  i32.const 4
+  i32.add
+  global.set $~lib/memory/__stack_pointer
+ )
+ (func $bindings/esm/arrayOfStringsFunction (type $i32_i32_=>_i32) (param $0 i32) (param $1 i32) (result i32)
+  (local $2 i32)
+  (local $3 i32)
+  (local $4 i32)
+  (local $5 i32)
+  (local $6 i32)
+  (local $7 i32)
+  (local $8 i32)
+  global.get $~lib/memory/__stack_pointer
+  i32.const 12
+  i32.sub
+  global.set $~lib/memory/__stack_pointer
+  block $folding-inner0
+   global.get $~lib/memory/__stack_pointer
+   i32.const 2276
+   i32.lt_s
+   br_if $folding-inner0
+   global.get $~lib/memory/__stack_pointer
+   local.tee $3
+   i64.const 0
+   i64.store $0
+   local.get $3
+   i32.const 0
+   i32.store $0 offset=8
+   local.get $3
+   local.get $0
+   i32.store $0
+   local.get $0
+   call $~lib/array/Array<i32>#get:length
+   local.set $4
+   global.get $~lib/memory/__stack_pointer
+   local.get $1
+   i32.store $0
+   local.get $1
+   call $~lib/array/Array<i32>#get:length
+   local.get $4
+   i32.add
+   local.set $4
+   global.get $~lib/memory/__stack_pointer
+   i32.const 16
+   i32.sub
+   global.set $~lib/memory/__stack_pointer
+   global.get $~lib/memory/__stack_pointer
+   i32.const 2276
+   i32.lt_s
+   br_if $folding-inner0
+   global.get $~lib/memory/__stack_pointer
+   local.tee $5
+   i64.const 0
+   i64.store $0
+   local.get $5
+   i64.const 0
+   i64.store $0 offset=8
+   local.get $5
+   i32.const 16
+   i32.const 12
+   call $~lib/rt/itcms/__new
+   local.tee $5
+   i32.store $0
+   global.get $~lib/memory/__stack_pointer
+   local.get $5
+   i32.store $0 offset=4
+   local.get $5
+   i32.const 0
+   i32.store $0
+   global.get $~lib/memory/__stack_pointer
+   local.tee $6
+   local.get $5
+   i32.store $0 offset=4
+   local.get $5
+   i32.const 0
+   i32.store $0 offset=4
+   local.get $6
+   local.get $5
+   i32.store $0 offset=4
+   local.get $5
+   i32.const 0
+   i32.store $0 offset=8
+   local.get $6
+   local.get $5
+   i32.store $0 offset=4
+   local.get $5
+   i32.const 0
+   i32.store $0 offset=12
+   local.get $4
+   i32.const 268435455
+   i32.gt_u
+   if
+    i32.const 1248
+    i32.const 1920
+    i32.const 70
+    i32.const 60
+    call $~lib/builtins/abort
+    unreachable
+   end
+   global.get $~lib/memory/__stack_pointer
+   i32.const 8
+   local.get $4
+   local.get $4
+   i32.const 8
+   i32.le_u
+   select
+   i32.const 2
+   i32.shl
+   local.tee $7
+   i32.const 1
+   call $~lib/rt/itcms/__new
+   local.tee $6
+   i32.store $0 offset=8
+   global.get $~lib/memory/__stack_pointer
+   local.get $5
+   i32.store $0 offset=4
+   global.get $~lib/memory/__stack_pointer
+   local.get $6
+   i32.store $0 offset=12
+   local.get $5
+   local.get $6
+   i32.store $0
+   local.get $6
+   if
+    local.get $5
+    local.get $6
+    i32.const 0
+    call $byn-split-outlined-A$~lib/rt/itcms/__link
+   end
+   global.get $~lib/memory/__stack_pointer
+   local.tee $8
+   local.get $5
+   i32.store $0 offset=4
+   local.get $5
+   local.get $6
+   i32.store $0 offset=4
+   local.get $8
+   local.get $5
+   i32.store $0 offset=4
+   local.get $5
+   local.get $7
+   i32.store $0 offset=8
+   local.get $8
+   local.get $5
+   i32.store $0 offset=4
+   local.get $5
+   local.get $4
+   i32.store $0 offset=12
+   local.get $8
+   i32.const 16
+   i32.add
+   global.set $~lib/memory/__stack_pointer
+   local.get $3
+   local.get $5
+   i32.store $0 offset=4
+   loop $for-loop|0
+    global.get $~lib/memory/__stack_pointer
+    local.get $0
+    i32.store $0
+    local.get $0
+    call $~lib/array/Array<i32>#get:length
+    local.get $2
+    i32.gt_s
+    if
+     global.get $~lib/memory/__stack_pointer
+     local.tee $3
+     local.get $5
+     i32.store $0
+     local.get $3
+     local.get $0
+     i32.store $0 offset=8
+     local.get $0
+     local.get $2
+     call $~lib/array/Array<~lib/string/String>#__get
+     local.set $3
+     global.get $~lib/memory/__stack_pointer
+     local.get $3
+     i32.store $0 offset=8
+     local.get $5
+     local.get $2
+     local.get $3
+     call $~lib/array/Array<~lib/string/String>#__set
+     local.get $2
+     i32.const 1
+     i32.add
+     local.set $2
+     br $for-loop|0
+    end
+   end
+   i32.const 0
+   local.set $2
+   loop $for-loop|1
+    global.get $~lib/memory/__stack_pointer
+    local.get $1
+    i32.store $0
+    local.get $1
+    call $~lib/array/Array<i32>#get:length
+    local.get $2
+    i32.gt_s
+    if
+     global.get $~lib/memory/__stack_pointer
+     local.tee $3
+     local.get $5
+     i32.store $0
+     local.get $3
+     local.get $0
+     i32.store $0 offset=8
+     local.get $0
+     call $~lib/array/Array<i32>#get:length
+     local.get $2
+     i32.add
+     local.set $3
+     global.get $~lib/memory/__stack_pointer
+     local.get $1
+     i32.store $0 offset=8
+     local.get $1
+     local.get $2
+     call $~lib/array/Array<~lib/string/String>#__get
+     local.set $4
+     global.get $~lib/memory/__stack_pointer
+     local.get $4
+     i32.store $0 offset=8
+     local.get $5
+     local.get $3
+     local.get $4
+     call $~lib/array/Array<~lib/string/String>#__set
+     local.get $2
+     i32.const 1
+     i32.add
+     local.set $2
+     br $for-loop|1
+    end
+   end
+   global.get $~lib/memory/__stack_pointer
+   i32.const 12
+   i32.add
+   global.set $~lib/memory/__stack_pointer
+   local.get $5
+   return
+  end
+  i32.const 35072
+  i32.const 35120
   i32.const 1
   i32.const 1
   call $~lib/builtins/abort
@@ -3293,7 +3693,7 @@
   global.set $~lib/memory/__stack_pointer
   block $folding-inner0
    global.get $~lib/memory/__stack_pointer
-   i32.const 2148
+   i32.const 2276
    i32.lt_s
    br_if $folding-inner0
    global.get $~lib/memory/__stack_pointer
@@ -3308,7 +3708,7 @@
    i32.sub
    global.set $~lib/memory/__stack_pointer
    global.get $~lib/memory/__stack_pointer
-   i32.const 2148
+   i32.const 2276
    i32.lt_s
    br_if $folding-inner0
    global.get $~lib/memory/__stack_pointer
@@ -3339,7 +3739,7 @@
    i32.sub
    global.set $~lib/memory/__stack_pointer
    global.get $~lib/memory/__stack_pointer
-   i32.const 2148
+   i32.const 2276
    i32.lt_s
    br_if $folding-inner0
    global.get $~lib/memory/__stack_pointer
@@ -3390,8 +3790,8 @@
    local.get $5
    return
   end
-  i32.const 34944
-  i32.const 34992
+  i32.const 35072
+  i32.const 35120
   i32.const 1
   i32.const 1
   call $~lib/builtins/abort
@@ -3404,11 +3804,11 @@
   i32.sub
   global.set $~lib/memory/__stack_pointer
   global.get $~lib/memory/__stack_pointer
-  i32.const 2148
+  i32.const 2276
   i32.lt_s
   if
-   i32.const 34944
-   i32.const 34992
+   i32.const 35072
+   i32.const 35120
    i32.const 1
    i32.const 1
    call $~lib/builtins/abort
@@ -3439,7 +3839,7 @@
   global.set $~lib/memory/__stack_pointer
   block $folding-inner0
    global.get $~lib/memory/__stack_pointer
-   i32.const 2148
+   i32.const 2276
    i32.lt_s
    br_if $folding-inner0
    global.get $~lib/memory/__stack_pointer
@@ -3454,7 +3854,7 @@
    i32.sub
    global.set $~lib/memory/__stack_pointer
    global.get $~lib/memory/__stack_pointer
-   i32.const 2148
+   i32.const 2276
    i32.lt_s
    br_if $folding-inner0
    global.get $~lib/memory/__stack_pointer
@@ -3502,8 +3902,8 @@
    local.get $0
    return
   end
-  i32.const 34944
-  i32.const 34992
+  i32.const 35072
+  i32.const 35120
   i32.const 1
   i32.const 1
   call $~lib/builtins/abort
@@ -3516,11 +3916,11 @@
   i32.sub
   global.set $~lib/memory/__stack_pointer
   global.get $~lib/memory/__stack_pointer
-  i32.const 2148
+  i32.const 2276
   i32.lt_s
   if
-   i32.const 34944
-   i32.const 34992
+   i32.const 35072
+   i32.const 35120
    i32.const 1
    i32.const 1
    call $~lib/builtins/abort
@@ -3554,7 +3954,7 @@
   global.set $~lib/memory/__stack_pointer
   block $folding-inner1
    global.get $~lib/memory/__stack_pointer
-   i32.const 2148
+   i32.const 2276
    i32.lt_s
    br_if $folding-inner1
    global.get $~lib/memory/__stack_pointer
@@ -3571,7 +3971,7 @@
     global.set $~lib/memory/__stack_pointer
     block $folding-inner0
      global.get $~lib/memory/__stack_pointer
-     i32.const 2148
+     i32.const 2276
      i32.lt_s
      br_if $folding-inner0
      global.get $~lib/memory/__stack_pointer
@@ -3608,7 +4008,7 @@
      i32.sub
      global.set $~lib/memory/__stack_pointer
      global.get $~lib/memory/__stack_pointer
-     i32.const 2148
+     i32.const 2276
      i32.lt_s
      br_if $folding-inner0
      global.get $~lib/memory/__stack_pointer
@@ -3737,8 +4137,8 @@
    local.get $0
    return
   end
-  i32.const 34944
-  i32.const 34992
+  i32.const 35072
+  i32.const 35120
   i32.const 1
   i32.const 1
   call $~lib/builtins/abort
@@ -3751,11 +4151,11 @@
   i32.sub
   global.set $~lib/memory/__stack_pointer
   global.get $~lib/memory/__stack_pointer
-  i32.const 2148
+  i32.const 2276
   i32.lt_s
   if
-   i32.const 34944
-   i32.const 34992
+   i32.const 35072
+   i32.const 35120
    i32.const 1
    i32.const 1
    call $~lib/builtins/abort
@@ -3778,11 +4178,11 @@
   i32.sub
   global.set $~lib/memory/__stack_pointer
   global.get $~lib/memory/__stack_pointer
-  i32.const 2148
+  i32.const 2276
   i32.lt_s
   if
-   i32.const 34944
-   i32.const 34992
+   i32.const 35072
+   i32.const 35120
    i32.const 1
    i32.const 1
    call $~lib/builtins/abort
@@ -3805,6 +4205,40 @@
   global.set $~lib/memory/__stack_pointer
   local.get $0
  )
+ (func $export:bindings/esm/arrayOfStringsFunction (type $i32_i32_=>_i32) (param $0 i32) (param $1 i32) (result i32)
+  (local $2 i32)
+  global.get $~lib/memory/__stack_pointer
+  i32.const 8
+  i32.sub
+  global.set $~lib/memory/__stack_pointer
+  global.get $~lib/memory/__stack_pointer
+  i32.const 2276
+  i32.lt_s
+  if
+   i32.const 35072
+   i32.const 35120
+   i32.const 1
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  global.get $~lib/memory/__stack_pointer
+  local.tee $2
+  local.get $0
+  i32.store $0
+  local.get $2
+  local.get $1
+  i32.store $0 offset=4
+  local.get $0
+  local.get $1
+  call $bindings/esm/arrayOfStringsFunction
+  local.set $0
+  global.get $~lib/memory/__stack_pointer
+  i32.const 8
+  i32.add
+  global.set $~lib/memory/__stack_pointer
+  local.get $0
+ )
  (func $export:bindings/esm/objectFunction (type $i32_i32_=>_i32) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
@@ -3815,7 +4249,7 @@
   global.set $~lib/memory/__stack_pointer
   block $folding-inner1
    global.get $~lib/memory/__stack_pointer
-   i32.const 2148
+   i32.const 2276
    i32.lt_s
    br_if $folding-inner1
    global.get $~lib/memory/__stack_pointer
@@ -3830,7 +4264,7 @@
    i32.sub
    global.set $~lib/memory/__stack_pointer
    global.get $~lib/memory/__stack_pointer
-   i32.const 2148
+   i32.const 2276
    i32.lt_s
    br_if $folding-inner1
    local.get $0
@@ -3850,7 +4284,7 @@
     global.set $~lib/memory/__stack_pointer
     block $folding-inner00
      global.get $~lib/memory/__stack_pointer
-     i32.const 2148
+     i32.const 2276
      i32.lt_s
      br_if $folding-inner00
      global.get $~lib/memory/__stack_pointer
@@ -3859,7 +4293,7 @@
      i64.store $0
      local.get $0
      i32.const 68
-     i32.const 12
+     i32.const 13
      call $~lib/rt/itcms/__new
      local.tee $0
      i32.store $0
@@ -3872,7 +4306,7 @@
      i32.sub
      global.set $~lib/memory/__stack_pointer
      global.get $~lib/memory/__stack_pointer
-     i32.const 2148
+     i32.const 2276
      i32.lt_s
      br_if $folding-inner00
      global.get $~lib/memory/__stack_pointer
@@ -4050,8 +4484,8 @@
    local.get $3
    return
   end
-  i32.const 34944
-  i32.const 34992
+  i32.const 35072
+  i32.const 35120
   i32.const 1
   i32.const 1
   call $~lib/builtins/abort
@@ -4064,11 +4498,11 @@
   i32.sub
   global.set $~lib/memory/__stack_pointer
   global.get $~lib/memory/__stack_pointer
-  i32.const 2148
+  i32.const 2276
   i32.lt_s
   if
-   i32.const 34944
-   i32.const 34992
+   i32.const 35072
+   i32.const 35120
    i32.const 1
    i32.const 1
    call $~lib/builtins/abort
@@ -4106,7 +4540,8 @@
    global.set $~lib/rt/itcms/visitCount
   end
  )
- (func $byn-split-outlined-A$~lib/rt/itcms/__link (type $i32_i32_=>_none) (param $0 i32) (param $1 i32)
+ (func $byn-split-outlined-A$~lib/rt/itcms/__link (type $i32_i32_i32_=>_none) (param $0 i32) (param $1 i32) (param $2 i32)
+  (local $3 i32)
   local.get $0
   i32.eqz
   if
@@ -4130,21 +4565,25 @@
    local.get $0
    i32.const 20
    i32.sub
+   local.tee $0
    i32.load $0 offset=4
    i32.const 3
    i32.and
-   local.tee $0
+   local.tee $3
    global.get $~lib/rt/itcms/white
    i32.eqz
    i32.eq
    if
+    local.get $0
     local.get $1
+    local.get $2
+    select
     call $~lib/rt/itcms/Object#makeGray
    else
     global.get $~lib/rt/itcms/state
     i32.const 1
     i32.eq
-    local.get $0
+    local.get $3
     i32.const 3
     i32.eq
     i32.and

--- a/tests/compiler/bindings/esm.ts
+++ b/tests/compiler/bindings/esm.ts
@@ -92,6 +92,17 @@ export function arrayFunction(a: Array<i32>, b: Array<i32>): Array<i32> {
   return c;
 }
 
+export function arrayOfStringsFunction(a: Array<string>, b: Array<string>): Array<string> {
+  var c = new Array<string>(a.length + b.length);
+  for (let i = 0; i < a.length; ++i) {
+    c[i] = a[i];
+  }
+  for (let i = 0; i < b.length; ++i) {
+    c[a.length + i] = b[i];
+  }
+  return c;
+}
+
 class PlainObject {
   a: i8;
   b: i16;

--- a/tests/compiler/bindings/raw.debug.d.ts
+++ b/tests/compiler/bindings/raw.debug.d.ts
@@ -120,12 +120,19 @@ declare namespace __AdaptedExports {
    */
   export function arrayFunction(a: Array<number>, b: Array<number>): Array<number>;
   /**
+   * bindings/esm/arrayOfStringsFunction
+   * @param a `~lib/array/Array<~lib/string/String>`
+   * @param b `~lib/array/Array<~lib/string/String>`
+   * @returns `~lib/array/Array<~lib/string/String>`
+   */
+  export function arrayOfStringsFunction(a: Array<string>, b: Array<string>): Array<string>;
+  /**
    * bindings/esm/objectFunction
    * @param a `bindings/esm/PlainObject`
    * @param b `bindings/esm/PlainObject`
    * @returns `bindings/esm/PlainObject`
    */
-  export function objectFunction(a: __Record12<undefined>, b: __Record12<undefined>): __Record12<never>;
+  export function objectFunction(a: __Record13<undefined>, b: __Record13<undefined>): __Record13<never>;
   /**
    * bindings/esm/newInternref
    * @returns `bindings/esm/NonPlainObject`
@@ -151,7 +158,7 @@ declare namespace __AdaptedExports {
   };
 }
 /** bindings/esm/PlainObject */
-declare interface __Record12<TOmittable> {
+declare interface __Record13<TOmittable> {
   /** @type `i8` */
   a: number | TOmittable;
   /** @type `i16` */

--- a/tests/compiler/bindings/raw.debug.js
+++ b/tests/compiler/bindings/raw.debug.js
@@ -137,40 +137,50 @@ export async function instantiate(module, imports = {}) {
     },
     staticarrayFunction(a, b) {
       // bindings/esm/staticarrayFunction(~lib/staticarray/StaticArray<i32>, ~lib/staticarray/StaticArray<i32>) => ~lib/staticarray/StaticArray<i32>
-      a = __retain(__lowerStaticArray((pointer, value) => { new Int32Array(memory.buffer)[pointer >>> 2] = value; }, 8, 2, a, Int32Array) || __notnull());
-      b = __lowerStaticArray((pointer, value) => { new Int32Array(memory.buffer)[pointer >>> 2] = value; }, 8, 2, b, Int32Array) || __notnull();
+      a = __retain(__lowerStaticArray(__setU32, 8, 2, a, Int32Array) || __notnull());
+      b = __lowerStaticArray(__setU32, 8, 2, b, Int32Array) || __notnull();
       try {
-        return __liftStaticArray(pointer => new Int32Array(memory.buffer)[pointer >>> 2], 2, exports.staticarrayFunction(a, b) >>> 0);
+        return __liftStaticArray(pointer => __getI32(pointer), 2, exports.staticarrayFunction(a, b) >>> 0);
       } finally {
         __release(a);
       }
     },
     staticarrayU16(a) {
       // bindings/esm/staticarrayU16(~lib/staticarray/StaticArray<u16>) => ~lib/staticarray/StaticArray<u16>
-      a = __lowerStaticArray((pointer, value) => { new Uint16Array(memory.buffer)[pointer >>> 1] = value; }, 9, 1, a, Uint16Array) || __notnull();
-      return __liftStaticArray(pointer => new Uint16Array(memory.buffer)[pointer >>> 1], 1, exports.staticarrayU16(a) >>> 0);
+      a = __lowerStaticArray(__setU16, 9, 1, a, Uint16Array) || __notnull();
+      return __liftStaticArray(pointer => __getU16(pointer), 1, exports.staticarrayU16(a) >>> 0);
     },
     staticarrayI64(a) {
       // bindings/esm/staticarrayI64(~lib/staticarray/StaticArray<i64>) => ~lib/staticarray/StaticArray<i64>
-      a = __lowerStaticArray((pointer, value) => { new BigInt64Array(memory.buffer)[pointer >>> 3] = value || 0n; }, 10, 3, a, BigInt64Array) || __notnull();
-      return __liftStaticArray(pointer => new BigInt64Array(memory.buffer)[pointer >>> 3], 3, exports.staticarrayI64(a) >>> 0);
+      a = __lowerStaticArray(__setU64, 10, 3, a, BigInt64Array) || __notnull();
+      return __liftStaticArray(pointer => __getI64(pointer), 3, exports.staticarrayI64(a) >>> 0);
     },
     arrayFunction(a, b) {
       // bindings/esm/arrayFunction(~lib/array/Array<i32>, ~lib/array/Array<i32>) => ~lib/array/Array<i32>
-      a = __retain(__lowerArray((pointer, value) => { new Int32Array(memory.buffer)[pointer >>> 2] = value; }, 11, 2, a) || __notnull());
-      b = __lowerArray((pointer, value) => { new Int32Array(memory.buffer)[pointer >>> 2] = value; }, 11, 2, b) || __notnull();
+      a = __retain(__lowerArray(__setU32, 11, 2, a) || __notnull());
+      b = __lowerArray(__setU32, 11, 2, b) || __notnull();
       try {
-        return __liftArray(pointer => new Int32Array(memory.buffer)[pointer >>> 2], 2, exports.arrayFunction(a, b) >>> 0);
+        return __liftArray(pointer => __getI32(pointer), 2, exports.arrayFunction(a, b) >>> 0);
+      } finally {
+        __release(a);
+      }
+    },
+    arrayOfStringsFunction(a, b) {
+      // bindings/esm/arrayOfStringsFunction(~lib/array/Array<~lib/string/String>, ~lib/array/Array<~lib/string/String>) => ~lib/array/Array<~lib/string/String>
+      a = __retain(__lowerArray((pointer, value) => { __setU32(pointer, __lowerString(value) || __notnull()); }, 12, 2, a) || __notnull());
+      b = __lowerArray((pointer, value) => { __setU32(pointer, __lowerString(value) || __notnull()); }, 12, 2, b) || __notnull();
+      try {
+        return __liftArray(pointer => __liftString(__getU32(pointer)), 2, exports.arrayOfStringsFunction(a, b) >>> 0);
       } finally {
         __release(a);
       }
     },
     objectFunction(a, b) {
       // bindings/esm/objectFunction(bindings/esm/PlainObject, bindings/esm/PlainObject) => bindings/esm/PlainObject
-      a = __retain(__lowerRecord12(a) || __notnull());
-      b = __lowerRecord12(b) || __notnull();
+      a = __retain(__lowerRecord13(a) || __notnull());
+      b = __lowerRecord13(b) || __notnull();
       try {
-        return __liftRecord12(exports.objectFunction(a, b) >>> 0);
+        return __liftRecord13(exports.objectFunction(a, b) >>> 0);
       } finally {
         __release(a);
       }
@@ -202,51 +212,51 @@ export async function instantiate(module, imports = {}) {
       }
     },
   }, exports);
-  function __lowerRecord12(value) {
+  function __lowerRecord13(value) {
     // bindings/esm/PlainObject
     // Hint: Opt-out from lowering as a record by providing an empty constructor
     if (value == null) return 0;
-    const pointer = exports.__pin(exports.__new(68, 12));
-    new Int8Array(memory.buffer)[pointer + 0 >>> 0] = value.a;
-    new Int16Array(memory.buffer)[pointer + 2 >>> 1] = value.b;
-    new Int32Array(memory.buffer)[pointer + 4 >>> 2] = value.c;
-    new BigInt64Array(memory.buffer)[pointer + 8 >>> 3] = value.d || 0n;
-    new Uint8Array(memory.buffer)[pointer + 16 >>> 0] = value.e;
-    new Uint16Array(memory.buffer)[pointer + 18 >>> 1] = value.f;
-    new Uint32Array(memory.buffer)[pointer + 20 >>> 2] = value.g;
-    new BigUint64Array(memory.buffer)[pointer + 24 >>> 3] = value.h || 0n;
-    new Int32Array(memory.buffer)[pointer + 32 >>> 2] = value.i;
-    new Uint32Array(memory.buffer)[pointer + 36 >>> 2] = value.j;
-    new Uint8Array(memory.buffer)[pointer + 40 >>> 0] = value.k ? 1 : 0;
-    new Float32Array(memory.buffer)[pointer + 44 >>> 2] = value.l;
-    new Float64Array(memory.buffer)[pointer + 48 >>> 3] = value.m;
-    __store_ref(pointer + 56, __lowerString(value.n));
-    __store_ref(pointer + 60, __lowerTypedArray(Uint8Array, 13, 0, value.o));
-    __store_ref(pointer + 64, __lowerArray((pointer, value) => { __store_ref(pointer, __lowerString(value) || __notnull()); }, 14, 2, value.p));
+    const pointer = exports.__pin(exports.__new(68, 13));
+    __setU8(pointer + 0,value.a);
+    __setU16(pointer + 2,value.b);
+    __setU32(pointer + 4,value.c);
+    __setU64(pointer + 8,value.d || 0n);
+    __setU8(pointer + 16,value.e);
+    __setU16(pointer + 18,value.f);
+    __setU32(pointer + 20,value.g);
+    __setU64(pointer + 24,value.h || 0n);
+    __setU32(pointer + 32,value.i);
+    __setU32(pointer + 36,value.j);
+    __setU8(pointer + 40,value.k ? 1 : 0);
+    __setF32(pointer + 44,value.l);
+    __setF64(pointer + 48,value.m);
+    __setU32(pointer + 56,__lowerString(value.n));
+    __setU32(pointer + 60,__lowerTypedArray(Uint8Array, 14, 0, value.o));
+    __setU32(pointer + 64,__lowerArray((pointer, value) => { __setU32(pointer, __lowerString(value) || __notnull()); }, 12, 2, value.p));
     exports.__unpin(pointer);
     return pointer;
   }
-  function __liftRecord12(pointer) {
+  function __liftRecord13(pointer) {
     // bindings/esm/PlainObject
     // Hint: Opt-out from lifting as a record by providing an empty constructor
     if (!pointer) return null;
     return {
-      a: new Int8Array(memory.buffer)[pointer + 0 >>> 0],
-      b: new Int16Array(memory.buffer)[pointer + 2 >>> 1],
-      c: new Int32Array(memory.buffer)[pointer + 4 >>> 2],
-      d: new BigInt64Array(memory.buffer)[pointer + 8 >>> 3],
-      e: new Uint8Array(memory.buffer)[pointer + 16 >>> 0],
-      f: new Uint16Array(memory.buffer)[pointer + 18 >>> 1],
-      g: new Uint32Array(memory.buffer)[pointer + 20 >>> 2],
-      h: new BigUint64Array(memory.buffer)[pointer + 24 >>> 3],
-      i: new Int32Array(memory.buffer)[pointer + 32 >>> 2],
-      j: new Uint32Array(memory.buffer)[pointer + 36 >>> 2],
-      k: new Uint8Array(memory.buffer)[pointer + 40 >>> 0] != 0,
-      l: new Float32Array(memory.buffer)[pointer + 44 >>> 2],
-      m: new Float64Array(memory.buffer)[pointer + 48 >>> 3],
-      n: __liftString(new Uint32Array(memory.buffer)[pointer + 56 >>> 2]),
-      o: __liftTypedArray(Uint8Array, new Uint32Array(memory.buffer)[pointer + 60 >>> 2]),
-      p: __liftArray(pointer => __liftString(new Uint32Array(memory.buffer)[pointer >>> 2]), 2, new Uint32Array(memory.buffer)[pointer + 64 >>> 2]),
+      a: __getI8(pointer + 0),
+      b: __getI16(pointer + 2),
+      c: __getI32(pointer + 4),
+      d: __getI64(pointer + 8),
+      e: __getU8(pointer + 16),
+      f: __getU16(pointer + 18),
+      g: __getU32(pointer + 20),
+      h: __getU64(pointer + 24),
+      i: __getI32(pointer + 32),
+      j: __getU32(pointer + 36),
+      k: __getU8(pointer + 40) != 0,
+      l: __getF32(pointer + 44),
+      m: __getF64(pointer + 48),
+      n: __liftString(__getU32(pointer + 56)),
+      o: __liftTypedArray(Uint8Array, __getU32(pointer + 60)),
+      p: __liftArray(pointer => __liftString(__getU32(pointer)), 2, __getU32(pointer + 64)),
     };
   }
   function __liftBuffer(pointer) {
@@ -282,9 +292,8 @@ export async function instantiate(module, imports = {}) {
   function __liftArray(liftElement, align, pointer) {
     if (!pointer) return null;
     const
-      memoryU32 = new Uint32Array(memory.buffer),
-      dataStart = memoryU32[pointer + 4 >>> 2],
-      length = memoryU32[pointer + 12 >>> 2],
+      dataStart = __getU32(pointer + 4),
+      length = __dataview.getUint32(pointer + 12, true),
       values = new Array(length);
     for (let i = 0; i < length; ++i) values[i] = liftElement(dataStart + (i << align >>> 0));
     return values;
@@ -294,12 +303,11 @@ export async function instantiate(module, imports = {}) {
     const
       length = values.length,
       buffer = exports.__pin(exports.__new(length << align, 1)) >>> 0,
-      header = exports.__pin(exports.__new(16, id)) >>> 0,
-      memoryU32 = new Uint32Array(memory.buffer);
-    memoryU32[header + 0 >>> 2] = buffer;
-    memoryU32[header + 4 >>> 2] = buffer;
-    memoryU32[header + 8 >>> 2] = length << align;
-    memoryU32[header + 12 >>> 2] = length;
+      header = exports.__pin(exports.__new(16, id)) >>> 0;
+    __setU32(header + 0, buffer);
+    __dataview.setUint32(header + 4, buffer, true);
+    __dataview.setUint32(header + 8, length << align, true);
+    __dataview.setUint32(header + 12, length, true);
     for (let i = 0; i < length; ++i) lowerElement(buffer + (i << align >>> 0), values[i]);
     exports.__unpin(buffer);
     exports.__unpin(header);
@@ -307,11 +315,10 @@ export async function instantiate(module, imports = {}) {
   }
   function __liftTypedArray(constructor, pointer) {
     if (!pointer) return null;
-    const memoryU32 = new Uint32Array(memory.buffer);
     return new constructor(
       memory.buffer,
-      memoryU32[pointer + 4 >>> 2],
-      memoryU32[pointer + 8 >>> 2] / constructor.BYTES_PER_ELEMENT
+      __getU32(pointer + 4),
+      __dataview.getUint32(pointer + 8, true) / constructor.BYTES_PER_ELEMENT
     ).slice();
   }
   function __lowerTypedArray(constructor, id, align, values) {
@@ -319,11 +326,10 @@ export async function instantiate(module, imports = {}) {
     const
       length = values.length,
       buffer = exports.__pin(exports.__new(length << align, 1)) >>> 0,
-      header = exports.__new(12, id) >>> 0,
-      memoryU32 = new Uint32Array(memory.buffer);
-    memoryU32[header + 0 >>> 2] = buffer;
-    memoryU32[header + 4 >>> 2] = buffer;
-    memoryU32[header + 8 >>> 2] = length << align;
+      header = exports.__new(12, id) >>> 0;
+    __setU32(header + 0, buffer);
+    __dataview.setUint32(header + 4, buffer, true);
+    __dataview.setUint32(header + 8, length << align, true);
     new constructor(memory.buffer, buffer, length).set(values);
     exports.__unpin(buffer);
     return header;
@@ -331,7 +337,7 @@ export async function instantiate(module, imports = {}) {
   function __liftStaticArray(liftElement, align, pointer) {
     if (!pointer) return null;
     const
-      length = new Uint32Array(memory.buffer)[pointer - 4 >>> 2] >>> align,
+      length = __getU32(pointer - 4) >>> align,
       values = new Array(length);
     for (let i = 0; i < length; ++i) values[i] = liftElement(pointer + (i << align >>> 0));
     return values;
@@ -382,8 +388,134 @@ export async function instantiate(module, imports = {}) {
   function __notnull() {
     throw TypeError("value must not be null");
   }
-  function __store_ref(pointer, value) {
-    new Uint32Array(memory.buffer)[pointer >>> 2] = value;
+  let __dataview = new DataView(memory.buffer);
+  function __setU8(pointer, value) {
+    try {
+      __dataview.setUint8(pointer, value, true);
+    } catch {
+      __dataview = new DataView(memory.buffer);
+      __dataview.setUint8(pointer, value, true);
+    }
+  }
+  function __setU16(pointer, value) {
+    try {
+      __dataview.setUint16(pointer, value, true);
+    } catch {
+      __dataview = new DataView(memory.buffer);
+      __dataview.setUint16(pointer, value, true);
+    }
+  }
+  function __setU32(pointer, value) {
+    try {
+      __dataview.setUint32(pointer, value, true);
+    } catch {
+      __dataview = new DataView(memory.buffer);
+      __dataview.setUint32(pointer, value, true);
+    }
+  }
+  function __setU64(pointer, value) {
+    try {
+      __dataview.setBigUint64(pointer, value, true);
+    } catch {
+      __dataview = new DataView(memory.buffer);
+      __dataview.setBigUint64(pointer, value, true);
+    }
+  }
+  function __setF32(pointer, value) {
+    try {
+      __dataview.setFloat32(pointer, value, true);
+    } catch {
+      __dataview = new DataView(memory.buffer);
+      __dataview.setFloat32(pointer, value, true);
+    }
+  }
+  function __setF64(pointer, value) {
+    try {
+      __dataview.setFloat64(pointer, value, true);
+    } catch {
+      __dataview = new DataView(memory.buffer);
+      __dataview.setFloat64(pointer, value, true);
+    }
+  }
+  function __getI8(pointer) {
+    try {
+      return __dataview.getInt8(pointer, true);
+    } catch {
+      __dataview = new DataView(memory.buffer);
+      return __dataview.getInt8(pointer, true);
+    }
+  }
+  function __getU8(pointer) {
+    try {
+      return __dataview.getUint8(pointer, true);
+    } catch {
+      __dataview = new DataView(memory.buffer);
+      return __dataview.getUint8(pointer, true);
+    }
+  }
+  function __getI16(pointer) {
+    try {
+      return __dataview.getInt16(pointer, true);
+    } catch {
+      __dataview = new DataView(memory.buffer);
+      return __dataview.getInt16(pointer, true);
+    }
+  }
+  function __getU16(pointer) {
+    try {
+      return __dataview.getUint16(pointer, true);
+    } catch {
+      __dataview = new DataView(memory.buffer);
+      return __dataview.getUint16(pointer, true);
+    }
+  }
+  function __getI32(pointer) {
+    try {
+      return __dataview.getInt32(pointer, true);
+    } catch {
+      __dataview = new DataView(memory.buffer);
+      return __dataview.getInt32(pointer, true);
+    }
+  }
+  function __getU32(pointer) {
+    try {
+      return __dataview.getUint32(pointer, true);
+    } catch {
+      __dataview = new DataView(memory.buffer);
+      return __dataview.getUint32(pointer, true);
+    }
+  }
+  function __getI64(pointer) {
+    try {
+      return __dataview.getBigInt64(pointer, true);
+    } catch {
+      __dataview = new DataView(memory.buffer);
+      return __dataview.getBigInt64(pointer, true);
+    }
+  }
+  function __getU64(pointer) {
+    try {
+      return __dataview.getBigUint64(pointer, true);
+    } catch {
+      __dataview = new DataView(memory.buffer);
+      return __dataview.getBigUint64(pointer, true);
+    }
+  }
+  function __getF32(pointer) {
+    try {
+      return __dataview.getFloat32(pointer, true);
+    } catch {
+      __dataview = new DataView(memory.buffer);
+      return __dataview.getFloat32(pointer, true);
+    }
+  }
+  function __getF64(pointer) {
+    try {
+      return __dataview.getFloat64(pointer, true);
+    } catch {
+      __dataview = new DataView(memory.buffer);
+      return __dataview.getFloat64(pointer, true);
+    }
   }
   exports._start();
   return adaptedExports;

--- a/tests/compiler/bindings/raw.debug.wat
+++ b/tests/compiler/bindings/raw.debug.wat
@@ -1,6 +1,6 @@
 (module
- (type $i32_=>_i32 (func_subtype (param i32) (result i32) func))
  (type $i32_i32_=>_none (func_subtype (param i32 i32) func))
+ (type $i32_=>_i32 (func_subtype (param i32) (result i32) func))
  (type $i32_i32_=>_i32 (func_subtype (param i32 i32) (result i32) func))
  (type $i32_=>_none (func_subtype (param i32) func))
  (type $none_=>_none (func_subtype func))
@@ -54,10 +54,10 @@
  (global $~lib/native/ASC_LOW_MEMORY_LIMIT i32 (i32.const 0))
  (global $~lib/native/ASC_RUNTIME i32 (i32.const 2))
  (global $~argumentsLength (mut i32) (i32.const 0))
- (global $~lib/rt/__rtti_base i32 (i32.const 1056))
- (global $~lib/memory/__data_end i32 (i32.const 1124))
- (global $~lib/memory/__stack_pointer (mut i32) (i32.const 33892))
- (global $~lib/memory/__heap_base i32 (i32.const 33892))
+ (global $~lib/rt/__rtti_base i32 (i32.const 1184))
+ (global $~lib/memory/__data_end i32 (i32.const 1252))
+ (global $~lib/memory/__stack_pointer (mut i32) (i32.const 34020))
+ (global $~lib/memory/__heap_base i32 (i32.const 34020))
  (global $~started (mut i32) (i32.const 0))
  (memory $0 1)
  (data (i32.const 12) "\1c\00\00\00\00\00\00\00\00\00\00\00\02\00\00\00\02\00\00\00a\00\00\00\00\00\00\00\00\00\00\00")
@@ -79,9 +79,10 @@
  (data (i32.const 748) "<\00\00\00\00\00\00\00\00\00\00\00\02\00\00\00$\00\00\00~\00l\00i\00b\00/\00t\00y\00p\00e\00d\00a\00r\00r\00a\00y\00.\00t\00s\00\00\00\00\00\00\00\00\00")
  (data (i32.const 812) "<\00\00\00\00\00\00\00\00\00\00\00\02\00\00\00&\00\00\00~\00l\00i\00b\00/\00s\00t\00a\00t\00i\00c\00a\00r\00r\00a\00y\00.\00t\00s\00\00\00\00\00\00\00")
  (data (i32.const 876) ",\00\00\00\00\00\00\00\00\00\00\00\02\00\00\00\1a\00\00\00~\00l\00i\00b\00/\00a\00r\00r\00a\00y\00.\00t\00s\00\00\00")
- (data (i32.const 924) "<\00\00\00\00\00\00\00\00\00\00\00\02\00\00\00*\00\00\00O\00b\00j\00e\00c\00t\00 \00a\00l\00r\00e\00a\00d\00y\00 \00p\00i\00n\00n\00e\00d\00\00\00")
- (data (i32.const 988) "<\00\00\00\00\00\00\00\00\00\00\00\02\00\00\00(\00\00\00O\00b\00j\00e\00c\00t\00 \00i\00s\00 \00n\00o\00t\00 \00p\00i\00n\00n\00e\00d\00\00\00\00\00")
- (data (i32.const 1056) "\10\00\00\00 \00\00\00 \00\00\00 \00\00\00\00\00\00\00\00\00\00\00\81\08\00\00\01\19\00\00\01\02\00\00$\t\00\00\a4\00\00\00$\n\00\00\02\t\00\00\00\00\00\00A\00\00\00\02A\00\00 \00\00\00")
+ (data (i32.const 924) "|\00\00\00\00\00\00\00\00\00\00\00\02\00\00\00^\00\00\00E\00l\00e\00m\00e\00n\00t\00 \00t\00y\00p\00e\00 \00m\00u\00s\00t\00 \00b\00e\00 \00n\00u\00l\00l\00a\00b\00l\00e\00 \00i\00f\00 \00a\00r\00r\00a\00y\00 \00i\00s\00 \00h\00o\00l\00e\00y\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00")
+ (data (i32.const 1052) "<\00\00\00\00\00\00\00\00\00\00\00\02\00\00\00*\00\00\00O\00b\00j\00e\00c\00t\00 \00a\00l\00r\00e\00a\00d\00y\00 \00p\00i\00n\00n\00e\00d\00\00\00")
+ (data (i32.const 1116) "<\00\00\00\00\00\00\00\00\00\00\00\02\00\00\00(\00\00\00O\00b\00j\00e\00c\00t\00 \00i\00s\00 \00n\00o\00t\00 \00p\00i\00n\00n\00e\00d\00\00\00\00\00")
+ (data (i32.const 1184) "\10\00\00\00 \00\00\00 \00\00\00 \00\00\00\00\00\00\00\00\00\00\00\81\08\00\00\01\19\00\00\01\02\00\00$\t\00\00\a4\00\00\00$\n\00\00\02\t\00\00\02A\00\00\00\00\00\00A\00\00\00 \00\00\00")
  (table $0 2 2 funcref)
  (elem $0 (i32.const 1) $start:bindings/esm~anonymous|0)
  (export "plainGlobal" (global $bindings/esm/plainGlobal))
@@ -116,6 +117,7 @@
  (export "staticarrayU16" (func $export:bindings/esm/staticarrayU16))
  (export "staticarrayI64" (func $export:bindings/esm/staticarrayI64))
  (export "arrayFunction" (func $export:bindings/esm/arrayFunction))
+ (export "arrayOfStringsFunction" (func $export:bindings/esm/arrayOfStringsFunction))
  (export "objectFunction" (func $export:bindings/esm/objectFunction))
  (export "internrefFunction" (func $export:bindings/esm/internrefFunction))
  (export "functionFunction" (func $export:bindings/esm/functionFunction))
@@ -2567,6 +2569,38 @@
   local.get $newPtr
   return
  )
+ (func $~lib/array/Array<~lib/string/String>#set:buffer (type $i32_i32_=>_none) (param $this i32) (param $buffer i32)
+  local.get $this
+  local.get $buffer
+  i32.store $0
+  local.get $this
+  local.get $buffer
+  i32.const 0
+  call $~lib/rt/itcms/__link
+ )
+ (func $~lib/array/Array<~lib/string/String>#set:dataStart (type $i32_i32_=>_none) (param $this i32) (param $dataStart i32)
+  local.get $this
+  local.get $dataStart
+  i32.store $0 offset=4
+ )
+ (func $~lib/array/Array<~lib/string/String>#set:byteLength (type $i32_i32_=>_none) (param $this i32) (param $byteLength i32)
+  local.get $this
+  local.get $byteLength
+  i32.store $0 offset=8
+ )
+ (func $~lib/array/Array<~lib/string/String>#set:length_ (type $i32_i32_=>_none) (param $this i32) (param $length_ i32)
+  local.get $this
+  local.get $length_
+  i32.store $0 offset=12
+ )
+ (func $~lib/array/Array<~lib/string/String>#get:length_ (type $i32_=>_i32) (param $this i32) (result i32)
+  local.get $this
+  i32.load $0 offset=12
+ )
+ (func $~lib/array/Array<~lib/string/String>#get:dataStart (type $i32_=>_i32) (param $this i32) (result i32)
+  local.get $this
+  i32.load $0 offset=4
+ )
  (func $bindings/esm/PlainObject#set:a (type $i32_i32_=>_none) (param $this i32) (param $a i32)
   local.get $this
   local.get $a
@@ -2693,7 +2727,7 @@
    i32.const 3
    i32.eq
    if
-    i32.const 944
+    i32.const 1072
     i32.const 400
     i32.const 338
     i32.const 7
@@ -2726,7 +2760,7 @@
   i32.const 3
   i32.ne
   if
-   i32.const 1008
+   i32.const 1136
    i32.const 400
    i32.const 352
    i32.const 5
@@ -2802,13 +2836,16 @@
   i32.const 224
   local.get $0
   call $~lib/rt/itcms/__visit
-  i32.const 336
-  local.get $0
-  call $~lib/rt/itcms/__visit
   i32.const 944
   local.get $0
   call $~lib/rt/itcms/__visit
-  i32.const 1008
+  i32.const 336
+  local.get $0
+  call $~lib/rt/itcms/__visit
+  i32.const 1072
+  local.get $0
+  call $~lib/rt/itcms/__visit
+  i32.const 1136
   local.get $0
   call $~lib/rt/itcms/__visit
   global.get $bindings/esm/stringGlobal
@@ -2882,6 +2919,18 @@
   local.get $1
   call $~lib/array/Array<i32>#__visit
  )
+ (func $~lib/array/Array<~lib/string/String>#get:buffer (type $i32_=>_i32) (param $this i32) (result i32)
+  local.get $this
+  i32.load $0
+ )
+ (func $~lib/array/Array<~lib/string/String>~visit (type $i32_i32_=>_none) (param $0 i32) (param $1 i32)
+  local.get $0
+  local.get $1
+  call $~lib/object/Object~visit
+  local.get $0
+  local.get $1
+  call $~lib/array/Array<~lib/string/String>#__visit
+ )
  (func $bindings/esm/PlainObject~visit (type $i32_i32_=>_none) (param $0 i32) (param $1 i32)
   (local $2 i32)
   local.get $0
@@ -2917,32 +2966,12 @@
   local.get $1
   call $~lib/arraybuffer/ArrayBufferView~visit
  )
- (func $~lib/array/Array<~lib/string/String>#get:dataStart (type $i32_=>_i32) (param $this i32) (result i32)
-  local.get $this
-  i32.load $0 offset=4
- )
- (func $~lib/array/Array<~lib/string/String>#get:length_ (type $i32_=>_i32) (param $this i32) (result i32)
-  local.get $this
-  i32.load $0 offset=12
- )
- (func $~lib/array/Array<~lib/string/String>#get:buffer (type $i32_=>_i32) (param $this i32) (result i32)
-  local.get $this
-  i32.load $0
- )
- (func $~lib/array/Array<~lib/string/String>~visit (type $i32_i32_=>_none) (param $0 i32) (param $1 i32)
-  local.get $0
-  local.get $1
-  call $~lib/object/Object~visit
-  local.get $0
-  local.get $1
-  call $~lib/array/Array<~lib/string/String>#__visit
- )
  (func $~lib/rt/__visit_members (type $i32_i32_=>_none) (param $0 i32) (param $1 i32)
   block $invalid
    block $bindings/esm/NonPlainObject
-    block $~lib/array/Array<~lib/string/String>
-     block $~lib/typedarray/Uint8Array
-      block $bindings/esm/PlainObject
+    block $~lib/typedarray/Uint8Array
+     block $bindings/esm/PlainObject
+      block $~lib/array/Array<~lib/string/String>
        block $~lib/array/Array<i32>
         block $~lib/staticarray/StaticArray<i64>
          block $~lib/staticarray/StaticArray<u16>
@@ -2959,7 +2988,7 @@
                    i32.const 8
                    i32.sub
                    i32.load $0
-                   br_table $~lib/object/Object $~lib/arraybuffer/ArrayBuffer $~lib/string/String $~lib/arraybuffer/ArrayBufferView $~lib/function/Function<%28%29=>void> $~lib/typedarray/Int16Array $~lib/typedarray/Float32Array $~lib/typedarray/Uint64Array $~lib/staticarray/StaticArray<i32> $~lib/staticarray/StaticArray<u16> $~lib/staticarray/StaticArray<i64> $~lib/array/Array<i32> $bindings/esm/PlainObject $~lib/typedarray/Uint8Array $~lib/array/Array<~lib/string/String> $bindings/esm/NonPlainObject $invalid
+                   br_table $~lib/object/Object $~lib/arraybuffer/ArrayBuffer $~lib/string/String $~lib/arraybuffer/ArrayBufferView $~lib/function/Function<%28%29=>void> $~lib/typedarray/Int16Array $~lib/typedarray/Float32Array $~lib/typedarray/Uint64Array $~lib/staticarray/StaticArray<i32> $~lib/staticarray/StaticArray<u16> $~lib/staticarray/StaticArray<i64> $~lib/array/Array<i32> $~lib/array/Array<~lib/string/String> $bindings/esm/PlainObject $~lib/typedarray/Uint8Array $bindings/esm/NonPlainObject $invalid
                   end
                   return
                  end
@@ -3005,17 +3034,17 @@
       end
       local.get $0
       local.get $1
-      call $bindings/esm/PlainObject~visit
+      call $~lib/array/Array<~lib/string/String>~visit
       return
      end
      local.get $0
      local.get $1
-     call $~lib/typedarray/Uint8Array~visit
+     call $bindings/esm/PlainObject~visit
      return
     end
     local.get $0
     local.get $1
-    call $~lib/array/Array<~lib/string/String>~visit
+    call $~lib/typedarray/Uint8Array~visit
     return
    end
    return
@@ -3057,8 +3086,8 @@
   global.get $~lib/memory/__data_end
   i32.lt_s
   if
-   i32.const 33920
-   i32.const 33968
+   i32.const 34048
+   i32.const 34096
    i32.const 1
    i32.const 1
    call $~lib/builtins/abort
@@ -4600,6 +4629,444 @@
   local.get $5
   return
  )
+ (func $~lib/array/Array<~lib/string/String>#constructor (type $i32_i32_=>_i32) (param $this i32) (param $length i32) (result i32)
+  (local $2 i32)
+  (local $3 i32)
+  (local $bufferSize i32)
+  (local $buffer i32)
+  (local $6 i32)
+  global.get $~lib/memory/__stack_pointer
+  i32.const 16
+  i32.sub
+  global.set $~lib/memory/__stack_pointer
+  call $~stack_check
+  global.get $~lib/memory/__stack_pointer
+  i64.const 0
+  i64.store $0
+  global.get $~lib/memory/__stack_pointer
+  i64.const 0
+  i64.store $0 offset=8
+  local.get $this
+  i32.eqz
+  if
+   global.get $~lib/memory/__stack_pointer
+   i32.const 16
+   i32.const 12
+   call $~lib/rt/itcms/__new
+   local.tee $this
+   i32.store $0
+  end
+  local.get $this
+  local.set $6
+  global.get $~lib/memory/__stack_pointer
+  local.get $6
+  i32.store $0 offset=4
+  local.get $6
+  i32.const 0
+  call $~lib/array/Array<~lib/string/String>#set:buffer
+  local.get $this
+  local.set $6
+  global.get $~lib/memory/__stack_pointer
+  local.get $6
+  i32.store $0 offset=4
+  local.get $6
+  i32.const 0
+  call $~lib/array/Array<~lib/string/String>#set:dataStart
+  local.get $this
+  local.set $6
+  global.get $~lib/memory/__stack_pointer
+  local.get $6
+  i32.store $0 offset=4
+  local.get $6
+  i32.const 0
+  call $~lib/array/Array<~lib/string/String>#set:byteLength
+  local.get $this
+  local.set $6
+  global.get $~lib/memory/__stack_pointer
+  local.get $6
+  i32.store $0 offset=4
+  local.get $6
+  i32.const 0
+  call $~lib/array/Array<~lib/string/String>#set:length_
+  local.get $length
+  i32.const 1073741820
+  i32.const 2
+  i32.shr_u
+  i32.gt_u
+  if
+   i32.const 224
+   i32.const 896
+   i32.const 70
+   i32.const 60
+   call $~lib/builtins/abort
+   unreachable
+  end
+  local.get $length
+  local.tee $2
+  i32.const 8
+  local.tee $3
+  local.get $2
+  local.get $3
+  i32.gt_u
+  select
+  i32.const 2
+  i32.shl
+  local.set $bufferSize
+  global.get $~lib/memory/__stack_pointer
+  local.get $bufferSize
+  i32.const 1
+  call $~lib/rt/itcms/__new
+  local.tee $buffer
+  i32.store $0 offset=8
+  i32.const 2
+  global.get $~lib/shared/runtime/Runtime.Incremental
+  i32.ne
+  drop
+  local.get $this
+  local.set $6
+  global.get $~lib/memory/__stack_pointer
+  local.get $6
+  i32.store $0 offset=4
+  local.get $6
+  local.get $buffer
+  local.set $6
+  global.get $~lib/memory/__stack_pointer
+  local.get $6
+  i32.store $0 offset=12
+  local.get $6
+  call $~lib/array/Array<~lib/string/String>#set:buffer
+  local.get $this
+  local.set $6
+  global.get $~lib/memory/__stack_pointer
+  local.get $6
+  i32.store $0 offset=4
+  local.get $6
+  local.get $buffer
+  call $~lib/array/Array<~lib/string/String>#set:dataStart
+  local.get $this
+  local.set $6
+  global.get $~lib/memory/__stack_pointer
+  local.get $6
+  i32.store $0 offset=4
+  local.get $6
+  local.get $bufferSize
+  call $~lib/array/Array<~lib/string/String>#set:byteLength
+  local.get $this
+  local.set $6
+  global.get $~lib/memory/__stack_pointer
+  local.get $6
+  i32.store $0 offset=4
+  local.get $6
+  local.get $length
+  call $~lib/array/Array<~lib/string/String>#set:length_
+  local.get $this
+  local.set $6
+  global.get $~lib/memory/__stack_pointer
+  i32.const 16
+  i32.add
+  global.set $~lib/memory/__stack_pointer
+  local.get $6
+ )
+ (func $~lib/array/Array<~lib/string/String>#get:length (type $i32_=>_i32) (param $this i32) (result i32)
+  (local $1 i32)
+  global.get $~lib/memory/__stack_pointer
+  i32.const 4
+  i32.sub
+  global.set $~lib/memory/__stack_pointer
+  call $~stack_check
+  global.get $~lib/memory/__stack_pointer
+  i32.const 0
+  i32.store $0
+  local.get $this
+  local.set $1
+  global.get $~lib/memory/__stack_pointer
+  local.get $1
+  i32.store $0
+  local.get $1
+  call $~lib/array/Array<~lib/string/String>#get:length_
+  local.set $1
+  global.get $~lib/memory/__stack_pointer
+  i32.const 4
+  i32.add
+  global.set $~lib/memory/__stack_pointer
+  local.get $1
+  return
+ )
+ (func $~lib/array/Array<~lib/string/String>#__get (type $i32_i32_=>_i32) (param $this i32) (param $index i32) (result i32)
+  (local $value i32)
+  (local $3 i32)
+  global.get $~lib/memory/__stack_pointer
+  i32.const 8
+  i32.sub
+  global.set $~lib/memory/__stack_pointer
+  call $~stack_check
+  global.get $~lib/memory/__stack_pointer
+  i64.const 0
+  i64.store $0
+  local.get $index
+  local.get $this
+  local.set $3
+  global.get $~lib/memory/__stack_pointer
+  local.get $3
+  i32.store $0
+  local.get $3
+  call $~lib/array/Array<~lib/string/String>#get:length_
+  i32.ge_u
+  if
+   i32.const 528
+   i32.const 896
+   i32.const 114
+   i32.const 42
+   call $~lib/builtins/abort
+   unreachable
+  end
+  global.get $~lib/memory/__stack_pointer
+  local.get $this
+  local.set $3
+  global.get $~lib/memory/__stack_pointer
+  local.get $3
+  i32.store $0
+  local.get $3
+  call $~lib/array/Array<~lib/string/String>#get:dataStart
+  local.get $index
+  i32.const 2
+  i32.shl
+  i32.add
+  i32.load $0
+  local.tee $value
+  i32.store $0 offset=4
+  i32.const 1
+  drop
+  i32.const 0
+  i32.eqz
+  drop
+  local.get $value
+  i32.eqz
+  if
+   i32.const 944
+   i32.const 896
+   i32.const 118
+   i32.const 40
+   call $~lib/builtins/abort
+   unreachable
+  end
+  local.get $value
+  local.set $3
+  global.get $~lib/memory/__stack_pointer
+  i32.const 8
+  i32.add
+  global.set $~lib/memory/__stack_pointer
+  local.get $3
+  return
+ )
+ (func $~lib/array/Array<~lib/string/String>#__set (type $i32_i32_i32_=>_none) (param $this i32) (param $index i32) (param $value i32)
+  (local $3 i32)
+  global.get $~lib/memory/__stack_pointer
+  i32.const 4
+  i32.sub
+  global.set $~lib/memory/__stack_pointer
+  call $~stack_check
+  global.get $~lib/memory/__stack_pointer
+  i32.const 0
+  i32.store $0
+  local.get $index
+  local.get $this
+  local.set $3
+  global.get $~lib/memory/__stack_pointer
+  local.get $3
+  i32.store $0
+  local.get $3
+  call $~lib/array/Array<~lib/string/String>#get:length_
+  i32.ge_u
+  if
+   local.get $index
+   i32.const 0
+   i32.lt_s
+   if
+    i32.const 528
+    i32.const 896
+    i32.const 130
+    i32.const 22
+    call $~lib/builtins/abort
+    unreachable
+   end
+   local.get $this
+   local.get $index
+   i32.const 1
+   i32.add
+   i32.const 2
+   i32.const 1
+   call $~lib/array/ensureCapacity
+   local.get $this
+   local.set $3
+   global.get $~lib/memory/__stack_pointer
+   local.get $3
+   i32.store $0
+   local.get $3
+   local.get $index
+   i32.const 1
+   i32.add
+   call $~lib/array/Array<~lib/string/String>#set:length_
+  end
+  local.get $this
+  local.set $3
+  global.get $~lib/memory/__stack_pointer
+  local.get $3
+  i32.store $0
+  local.get $3
+  call $~lib/array/Array<~lib/string/String>#get:dataStart
+  local.get $index
+  i32.const 2
+  i32.shl
+  i32.add
+  local.get $value
+  i32.store $0
+  i32.const 1
+  drop
+  local.get $this
+  local.get $value
+  i32.const 1
+  call $~lib/rt/itcms/__link
+  global.get $~lib/memory/__stack_pointer
+  i32.const 4
+  i32.add
+  global.set $~lib/memory/__stack_pointer
+ )
+ (func $bindings/esm/arrayOfStringsFunction (type $i32_i32_=>_i32) (param $a i32) (param $b i32) (result i32)
+  (local $c i32)
+  (local $i i32)
+  (local $i|4 i32)
+  (local $5 i32)
+  global.get $~lib/memory/__stack_pointer
+  i32.const 12
+  i32.sub
+  global.set $~lib/memory/__stack_pointer
+  call $~stack_check
+  global.get $~lib/memory/__stack_pointer
+  i64.const 0
+  i64.store $0
+  global.get $~lib/memory/__stack_pointer
+  i32.const 0
+  i32.store $0 offset=8
+  global.get $~lib/memory/__stack_pointer
+  i32.const 0
+  local.get $a
+  local.set $5
+  global.get $~lib/memory/__stack_pointer
+  local.get $5
+  i32.store $0
+  local.get $5
+  call $~lib/array/Array<~lib/string/String>#get:length
+  local.get $b
+  local.set $5
+  global.get $~lib/memory/__stack_pointer
+  local.get $5
+  i32.store $0
+  local.get $5
+  call $~lib/array/Array<~lib/string/String>#get:length
+  i32.add
+  call $~lib/array/Array<~lib/string/String>#constructor
+  local.tee $c
+  i32.store $0 offset=4
+  i32.const 0
+  local.set $i
+  loop $for-loop|0
+   local.get $i
+   local.get $a
+   local.set $5
+   global.get $~lib/memory/__stack_pointer
+   local.get $5
+   i32.store $0
+   local.get $5
+   call $~lib/array/Array<~lib/string/String>#get:length
+   i32.lt_s
+   if
+    local.get $c
+    local.set $5
+    global.get $~lib/memory/__stack_pointer
+    local.get $5
+    i32.store $0
+    local.get $5
+    local.get $i
+    local.get $a
+    local.set $5
+    global.get $~lib/memory/__stack_pointer
+    local.get $5
+    i32.store $0 offset=8
+    local.get $5
+    local.get $i
+    call $~lib/array/Array<~lib/string/String>#__get
+    local.set $5
+    global.get $~lib/memory/__stack_pointer
+    local.get $5
+    i32.store $0 offset=8
+    local.get $5
+    call $~lib/array/Array<~lib/string/String>#__set
+    local.get $i
+    i32.const 1
+    i32.add
+    local.set $i
+    br $for-loop|0
+   end
+  end
+  i32.const 0
+  local.set $i|4
+  loop $for-loop|1
+   local.get $i|4
+   local.get $b
+   local.set $5
+   global.get $~lib/memory/__stack_pointer
+   local.get $5
+   i32.store $0
+   local.get $5
+   call $~lib/array/Array<~lib/string/String>#get:length
+   i32.lt_s
+   if
+    local.get $c
+    local.set $5
+    global.get $~lib/memory/__stack_pointer
+    local.get $5
+    i32.store $0
+    local.get $5
+    local.get $a
+    local.set $5
+    global.get $~lib/memory/__stack_pointer
+    local.get $5
+    i32.store $0 offset=8
+    local.get $5
+    call $~lib/array/Array<~lib/string/String>#get:length
+    local.get $i|4
+    i32.add
+    local.get $b
+    local.set $5
+    global.get $~lib/memory/__stack_pointer
+    local.get $5
+    i32.store $0 offset=8
+    local.get $5
+    local.get $i|4
+    call $~lib/array/Array<~lib/string/String>#__get
+    local.set $5
+    global.get $~lib/memory/__stack_pointer
+    local.get $5
+    i32.store $0 offset=8
+    local.get $5
+    call $~lib/array/Array<~lib/string/String>#__set
+    local.get $i|4
+    i32.const 1
+    i32.add
+    local.set $i|4
+    br $for-loop|1
+   end
+  end
+  local.get $c
+  local.set $5
+  global.get $~lib/memory/__stack_pointer
+  i32.const 12
+  i32.add
+  global.set $~lib/memory/__stack_pointer
+  local.get $5
+  return
+ )
  (func $bindings/esm/PlainObject#constructor (type $i32_=>_i32) (param $this i32) (result i32)
   (local $1 i32)
   global.get $~lib/memory/__stack_pointer
@@ -4615,7 +5082,7 @@
   if
    global.get $~lib/memory/__stack_pointer
    i32.const 68
-   i32.const 12
+   i32.const 13
    call $~lib/rt/itcms/__new
    local.tee $this
    i32.store $0
@@ -5272,6 +5739,29 @@
   local.get $0
   local.get $1
   call $bindings/esm/arrayFunction
+  local.set $2
+  global.get $~lib/memory/__stack_pointer
+  i32.const 8
+  i32.add
+  global.set $~lib/memory/__stack_pointer
+  local.get $2
+ )
+ (func $export:bindings/esm/arrayOfStringsFunction (type $i32_i32_=>_i32) (param $0 i32) (param $1 i32) (result i32)
+  (local $2 i32)
+  global.get $~lib/memory/__stack_pointer
+  i32.const 8
+  i32.sub
+  global.set $~lib/memory/__stack_pointer
+  call $~stack_check
+  global.get $~lib/memory/__stack_pointer
+  local.get $0
+  i32.store $0
+  global.get $~lib/memory/__stack_pointer
+  local.get $1
+  i32.store $0 offset=4
+  local.get $0
+  local.get $1
+  call $bindings/esm/arrayOfStringsFunction
   local.set $2
   global.get $~lib/memory/__stack_pointer
   i32.const 8

--- a/tests/compiler/bindings/raw.release.d.ts
+++ b/tests/compiler/bindings/raw.release.d.ts
@@ -120,12 +120,19 @@ declare namespace __AdaptedExports {
    */
   export function arrayFunction(a: Array<number>, b: Array<number>): Array<number>;
   /**
+   * bindings/esm/arrayOfStringsFunction
+   * @param a `~lib/array/Array<~lib/string/String>`
+   * @param b `~lib/array/Array<~lib/string/String>`
+   * @returns `~lib/array/Array<~lib/string/String>`
+   */
+  export function arrayOfStringsFunction(a: Array<string>, b: Array<string>): Array<string>;
+  /**
    * bindings/esm/objectFunction
    * @param a `bindings/esm/PlainObject`
    * @param b `bindings/esm/PlainObject`
    * @returns `bindings/esm/PlainObject`
    */
-  export function objectFunction(a: __Record12<undefined>, b: __Record12<undefined>): __Record12<never>;
+  export function objectFunction(a: __Record13<undefined>, b: __Record13<undefined>): __Record13<never>;
   /**
    * bindings/esm/newInternref
    * @returns `bindings/esm/NonPlainObject`
@@ -151,7 +158,7 @@ declare namespace __AdaptedExports {
   };
 }
 /** bindings/esm/PlainObject */
-declare interface __Record12<TOmittable> {
+declare interface __Record13<TOmittable> {
   /** @type `i8` */
   a: number | TOmittable;
   /** @type `i16` */

--- a/tests/compiler/bindings/raw.release.js
+++ b/tests/compiler/bindings/raw.release.js
@@ -137,40 +137,50 @@ export async function instantiate(module, imports = {}) {
     },
     staticarrayFunction(a, b) {
       // bindings/esm/staticarrayFunction(~lib/staticarray/StaticArray<i32>, ~lib/staticarray/StaticArray<i32>) => ~lib/staticarray/StaticArray<i32>
-      a = __retain(__lowerStaticArray((pointer, value) => { new Int32Array(memory.buffer)[pointer >>> 2] = value; }, 8, 2, a, Int32Array) || __notnull());
-      b = __lowerStaticArray((pointer, value) => { new Int32Array(memory.buffer)[pointer >>> 2] = value; }, 8, 2, b, Int32Array) || __notnull();
+      a = __retain(__lowerStaticArray(__setU32, 8, 2, a, Int32Array) || __notnull());
+      b = __lowerStaticArray(__setU32, 8, 2, b, Int32Array) || __notnull();
       try {
-        return __liftStaticArray(pointer => new Int32Array(memory.buffer)[pointer >>> 2], 2, exports.staticarrayFunction(a, b) >>> 0);
+        return __liftStaticArray(pointer => __getI32(pointer), 2, exports.staticarrayFunction(a, b) >>> 0);
       } finally {
         __release(a);
       }
     },
     staticarrayU16(a) {
       // bindings/esm/staticarrayU16(~lib/staticarray/StaticArray<u16>) => ~lib/staticarray/StaticArray<u16>
-      a = __lowerStaticArray((pointer, value) => { new Uint16Array(memory.buffer)[pointer >>> 1] = value; }, 9, 1, a, Uint16Array) || __notnull();
-      return __liftStaticArray(pointer => new Uint16Array(memory.buffer)[pointer >>> 1], 1, exports.staticarrayU16(a) >>> 0);
+      a = __lowerStaticArray(__setU16, 9, 1, a, Uint16Array) || __notnull();
+      return __liftStaticArray(pointer => __getU16(pointer), 1, exports.staticarrayU16(a) >>> 0);
     },
     staticarrayI64(a) {
       // bindings/esm/staticarrayI64(~lib/staticarray/StaticArray<i64>) => ~lib/staticarray/StaticArray<i64>
-      a = __lowerStaticArray((pointer, value) => { new BigInt64Array(memory.buffer)[pointer >>> 3] = value || 0n; }, 10, 3, a, BigInt64Array) || __notnull();
-      return __liftStaticArray(pointer => new BigInt64Array(memory.buffer)[pointer >>> 3], 3, exports.staticarrayI64(a) >>> 0);
+      a = __lowerStaticArray(__setU64, 10, 3, a, BigInt64Array) || __notnull();
+      return __liftStaticArray(pointer => __getI64(pointer), 3, exports.staticarrayI64(a) >>> 0);
     },
     arrayFunction(a, b) {
       // bindings/esm/arrayFunction(~lib/array/Array<i32>, ~lib/array/Array<i32>) => ~lib/array/Array<i32>
-      a = __retain(__lowerArray((pointer, value) => { new Int32Array(memory.buffer)[pointer >>> 2] = value; }, 11, 2, a) || __notnull());
-      b = __lowerArray((pointer, value) => { new Int32Array(memory.buffer)[pointer >>> 2] = value; }, 11, 2, b) || __notnull();
+      a = __retain(__lowerArray(__setU32, 11, 2, a) || __notnull());
+      b = __lowerArray(__setU32, 11, 2, b) || __notnull();
       try {
-        return __liftArray(pointer => new Int32Array(memory.buffer)[pointer >>> 2], 2, exports.arrayFunction(a, b) >>> 0);
+        return __liftArray(pointer => __getI32(pointer), 2, exports.arrayFunction(a, b) >>> 0);
+      } finally {
+        __release(a);
+      }
+    },
+    arrayOfStringsFunction(a, b) {
+      // bindings/esm/arrayOfStringsFunction(~lib/array/Array<~lib/string/String>, ~lib/array/Array<~lib/string/String>) => ~lib/array/Array<~lib/string/String>
+      a = __retain(__lowerArray((pointer, value) => { __setU32(pointer, __lowerString(value) || __notnull()); }, 12, 2, a) || __notnull());
+      b = __lowerArray((pointer, value) => { __setU32(pointer, __lowerString(value) || __notnull()); }, 12, 2, b) || __notnull();
+      try {
+        return __liftArray(pointer => __liftString(__getU32(pointer)), 2, exports.arrayOfStringsFunction(a, b) >>> 0);
       } finally {
         __release(a);
       }
     },
     objectFunction(a, b) {
       // bindings/esm/objectFunction(bindings/esm/PlainObject, bindings/esm/PlainObject) => bindings/esm/PlainObject
-      a = __retain(__lowerRecord12(a) || __notnull());
-      b = __lowerRecord12(b) || __notnull();
+      a = __retain(__lowerRecord13(a) || __notnull());
+      b = __lowerRecord13(b) || __notnull();
       try {
-        return __liftRecord12(exports.objectFunction(a, b) >>> 0);
+        return __liftRecord13(exports.objectFunction(a, b) >>> 0);
       } finally {
         __release(a);
       }
@@ -202,51 +212,51 @@ export async function instantiate(module, imports = {}) {
       }
     },
   }, exports);
-  function __lowerRecord12(value) {
+  function __lowerRecord13(value) {
     // bindings/esm/PlainObject
     // Hint: Opt-out from lowering as a record by providing an empty constructor
     if (value == null) return 0;
-    const pointer = exports.__pin(exports.__new(68, 12));
-    new Int8Array(memory.buffer)[pointer + 0 >>> 0] = value.a;
-    new Int16Array(memory.buffer)[pointer + 2 >>> 1] = value.b;
-    new Int32Array(memory.buffer)[pointer + 4 >>> 2] = value.c;
-    new BigInt64Array(memory.buffer)[pointer + 8 >>> 3] = value.d || 0n;
-    new Uint8Array(memory.buffer)[pointer + 16 >>> 0] = value.e;
-    new Uint16Array(memory.buffer)[pointer + 18 >>> 1] = value.f;
-    new Uint32Array(memory.buffer)[pointer + 20 >>> 2] = value.g;
-    new BigUint64Array(memory.buffer)[pointer + 24 >>> 3] = value.h || 0n;
-    new Int32Array(memory.buffer)[pointer + 32 >>> 2] = value.i;
-    new Uint32Array(memory.buffer)[pointer + 36 >>> 2] = value.j;
-    new Uint8Array(memory.buffer)[pointer + 40 >>> 0] = value.k ? 1 : 0;
-    new Float32Array(memory.buffer)[pointer + 44 >>> 2] = value.l;
-    new Float64Array(memory.buffer)[pointer + 48 >>> 3] = value.m;
-    __store_ref(pointer + 56, __lowerString(value.n));
-    __store_ref(pointer + 60, __lowerTypedArray(Uint8Array, 13, 0, value.o));
-    __store_ref(pointer + 64, __lowerArray((pointer, value) => { __store_ref(pointer, __lowerString(value) || __notnull()); }, 14, 2, value.p));
+    const pointer = exports.__pin(exports.__new(68, 13));
+    __setU8(pointer + 0,value.a);
+    __setU16(pointer + 2,value.b);
+    __setU32(pointer + 4,value.c);
+    __setU64(pointer + 8,value.d || 0n);
+    __setU8(pointer + 16,value.e);
+    __setU16(pointer + 18,value.f);
+    __setU32(pointer + 20,value.g);
+    __setU64(pointer + 24,value.h || 0n);
+    __setU32(pointer + 32,value.i);
+    __setU32(pointer + 36,value.j);
+    __setU8(pointer + 40,value.k ? 1 : 0);
+    __setF32(pointer + 44,value.l);
+    __setF64(pointer + 48,value.m);
+    __setU32(pointer + 56,__lowerString(value.n));
+    __setU32(pointer + 60,__lowerTypedArray(Uint8Array, 14, 0, value.o));
+    __setU32(pointer + 64,__lowerArray((pointer, value) => { __setU32(pointer, __lowerString(value) || __notnull()); }, 12, 2, value.p));
     exports.__unpin(pointer);
     return pointer;
   }
-  function __liftRecord12(pointer) {
+  function __liftRecord13(pointer) {
     // bindings/esm/PlainObject
     // Hint: Opt-out from lifting as a record by providing an empty constructor
     if (!pointer) return null;
     return {
-      a: new Int8Array(memory.buffer)[pointer + 0 >>> 0],
-      b: new Int16Array(memory.buffer)[pointer + 2 >>> 1],
-      c: new Int32Array(memory.buffer)[pointer + 4 >>> 2],
-      d: new BigInt64Array(memory.buffer)[pointer + 8 >>> 3],
-      e: new Uint8Array(memory.buffer)[pointer + 16 >>> 0],
-      f: new Uint16Array(memory.buffer)[pointer + 18 >>> 1],
-      g: new Uint32Array(memory.buffer)[pointer + 20 >>> 2],
-      h: new BigUint64Array(memory.buffer)[pointer + 24 >>> 3],
-      i: new Int32Array(memory.buffer)[pointer + 32 >>> 2],
-      j: new Uint32Array(memory.buffer)[pointer + 36 >>> 2],
-      k: new Uint8Array(memory.buffer)[pointer + 40 >>> 0] != 0,
-      l: new Float32Array(memory.buffer)[pointer + 44 >>> 2],
-      m: new Float64Array(memory.buffer)[pointer + 48 >>> 3],
-      n: __liftString(new Uint32Array(memory.buffer)[pointer + 56 >>> 2]),
-      o: __liftTypedArray(Uint8Array, new Uint32Array(memory.buffer)[pointer + 60 >>> 2]),
-      p: __liftArray(pointer => __liftString(new Uint32Array(memory.buffer)[pointer >>> 2]), 2, new Uint32Array(memory.buffer)[pointer + 64 >>> 2]),
+      a: __getI8(pointer + 0),
+      b: __getI16(pointer + 2),
+      c: __getI32(pointer + 4),
+      d: __getI64(pointer + 8),
+      e: __getU8(pointer + 16),
+      f: __getU16(pointer + 18),
+      g: __getU32(pointer + 20),
+      h: __getU64(pointer + 24),
+      i: __getI32(pointer + 32),
+      j: __getU32(pointer + 36),
+      k: __getU8(pointer + 40) != 0,
+      l: __getF32(pointer + 44),
+      m: __getF64(pointer + 48),
+      n: __liftString(__getU32(pointer + 56)),
+      o: __liftTypedArray(Uint8Array, __getU32(pointer + 60)),
+      p: __liftArray(pointer => __liftString(__getU32(pointer)), 2, __getU32(pointer + 64)),
     };
   }
   function __liftBuffer(pointer) {
@@ -282,9 +292,8 @@ export async function instantiate(module, imports = {}) {
   function __liftArray(liftElement, align, pointer) {
     if (!pointer) return null;
     const
-      memoryU32 = new Uint32Array(memory.buffer),
-      dataStart = memoryU32[pointer + 4 >>> 2],
-      length = memoryU32[pointer + 12 >>> 2],
+      dataStart = __getU32(pointer + 4),
+      length = __dataview.getUint32(pointer + 12, true),
       values = new Array(length);
     for (let i = 0; i < length; ++i) values[i] = liftElement(dataStart + (i << align >>> 0));
     return values;
@@ -294,12 +303,11 @@ export async function instantiate(module, imports = {}) {
     const
       length = values.length,
       buffer = exports.__pin(exports.__new(length << align, 1)) >>> 0,
-      header = exports.__pin(exports.__new(16, id)) >>> 0,
-      memoryU32 = new Uint32Array(memory.buffer);
-    memoryU32[header + 0 >>> 2] = buffer;
-    memoryU32[header + 4 >>> 2] = buffer;
-    memoryU32[header + 8 >>> 2] = length << align;
-    memoryU32[header + 12 >>> 2] = length;
+      header = exports.__pin(exports.__new(16, id)) >>> 0;
+    __setU32(header + 0, buffer);
+    __dataview.setUint32(header + 4, buffer, true);
+    __dataview.setUint32(header + 8, length << align, true);
+    __dataview.setUint32(header + 12, length, true);
     for (let i = 0; i < length; ++i) lowerElement(buffer + (i << align >>> 0), values[i]);
     exports.__unpin(buffer);
     exports.__unpin(header);
@@ -307,11 +315,10 @@ export async function instantiate(module, imports = {}) {
   }
   function __liftTypedArray(constructor, pointer) {
     if (!pointer) return null;
-    const memoryU32 = new Uint32Array(memory.buffer);
     return new constructor(
       memory.buffer,
-      memoryU32[pointer + 4 >>> 2],
-      memoryU32[pointer + 8 >>> 2] / constructor.BYTES_PER_ELEMENT
+      __getU32(pointer + 4),
+      __dataview.getUint32(pointer + 8, true) / constructor.BYTES_PER_ELEMENT
     ).slice();
   }
   function __lowerTypedArray(constructor, id, align, values) {
@@ -319,11 +326,10 @@ export async function instantiate(module, imports = {}) {
     const
       length = values.length,
       buffer = exports.__pin(exports.__new(length << align, 1)) >>> 0,
-      header = exports.__new(12, id) >>> 0,
-      memoryU32 = new Uint32Array(memory.buffer);
-    memoryU32[header + 0 >>> 2] = buffer;
-    memoryU32[header + 4 >>> 2] = buffer;
-    memoryU32[header + 8 >>> 2] = length << align;
+      header = exports.__new(12, id) >>> 0;
+    __setU32(header + 0, buffer);
+    __dataview.setUint32(header + 4, buffer, true);
+    __dataview.setUint32(header + 8, length << align, true);
     new constructor(memory.buffer, buffer, length).set(values);
     exports.__unpin(buffer);
     return header;
@@ -331,7 +337,7 @@ export async function instantiate(module, imports = {}) {
   function __liftStaticArray(liftElement, align, pointer) {
     if (!pointer) return null;
     const
-      length = new Uint32Array(memory.buffer)[pointer - 4 >>> 2] >>> align,
+      length = __getU32(pointer - 4) >>> align,
       values = new Array(length);
     for (let i = 0; i < length; ++i) values[i] = liftElement(pointer + (i << align >>> 0));
     return values;
@@ -382,8 +388,134 @@ export async function instantiate(module, imports = {}) {
   function __notnull() {
     throw TypeError("value must not be null");
   }
-  function __store_ref(pointer, value) {
-    new Uint32Array(memory.buffer)[pointer >>> 2] = value;
+  let __dataview = new DataView(memory.buffer);
+  function __setU8(pointer, value) {
+    try {
+      __dataview.setUint8(pointer, value, true);
+    } catch {
+      __dataview = new DataView(memory.buffer);
+      __dataview.setUint8(pointer, value, true);
+    }
+  }
+  function __setU16(pointer, value) {
+    try {
+      __dataview.setUint16(pointer, value, true);
+    } catch {
+      __dataview = new DataView(memory.buffer);
+      __dataview.setUint16(pointer, value, true);
+    }
+  }
+  function __setU32(pointer, value) {
+    try {
+      __dataview.setUint32(pointer, value, true);
+    } catch {
+      __dataview = new DataView(memory.buffer);
+      __dataview.setUint32(pointer, value, true);
+    }
+  }
+  function __setU64(pointer, value) {
+    try {
+      __dataview.setBigUint64(pointer, value, true);
+    } catch {
+      __dataview = new DataView(memory.buffer);
+      __dataview.setBigUint64(pointer, value, true);
+    }
+  }
+  function __setF32(pointer, value) {
+    try {
+      __dataview.setFloat32(pointer, value, true);
+    } catch {
+      __dataview = new DataView(memory.buffer);
+      __dataview.setFloat32(pointer, value, true);
+    }
+  }
+  function __setF64(pointer, value) {
+    try {
+      __dataview.setFloat64(pointer, value, true);
+    } catch {
+      __dataview = new DataView(memory.buffer);
+      __dataview.setFloat64(pointer, value, true);
+    }
+  }
+  function __getI8(pointer) {
+    try {
+      return __dataview.getInt8(pointer, true);
+    } catch {
+      __dataview = new DataView(memory.buffer);
+      return __dataview.getInt8(pointer, true);
+    }
+  }
+  function __getU8(pointer) {
+    try {
+      return __dataview.getUint8(pointer, true);
+    } catch {
+      __dataview = new DataView(memory.buffer);
+      return __dataview.getUint8(pointer, true);
+    }
+  }
+  function __getI16(pointer) {
+    try {
+      return __dataview.getInt16(pointer, true);
+    } catch {
+      __dataview = new DataView(memory.buffer);
+      return __dataview.getInt16(pointer, true);
+    }
+  }
+  function __getU16(pointer) {
+    try {
+      return __dataview.getUint16(pointer, true);
+    } catch {
+      __dataview = new DataView(memory.buffer);
+      return __dataview.getUint16(pointer, true);
+    }
+  }
+  function __getI32(pointer) {
+    try {
+      return __dataview.getInt32(pointer, true);
+    } catch {
+      __dataview = new DataView(memory.buffer);
+      return __dataview.getInt32(pointer, true);
+    }
+  }
+  function __getU32(pointer) {
+    try {
+      return __dataview.getUint32(pointer, true);
+    } catch {
+      __dataview = new DataView(memory.buffer);
+      return __dataview.getUint32(pointer, true);
+    }
+  }
+  function __getI64(pointer) {
+    try {
+      return __dataview.getBigInt64(pointer, true);
+    } catch {
+      __dataview = new DataView(memory.buffer);
+      return __dataview.getBigInt64(pointer, true);
+    }
+  }
+  function __getU64(pointer) {
+    try {
+      return __dataview.getBigUint64(pointer, true);
+    } catch {
+      __dataview = new DataView(memory.buffer);
+      return __dataview.getBigUint64(pointer, true);
+    }
+  }
+  function __getF32(pointer) {
+    try {
+      return __dataview.getFloat32(pointer, true);
+    } catch {
+      __dataview = new DataView(memory.buffer);
+      return __dataview.getFloat32(pointer, true);
+    }
+  }
+  function __getF64(pointer) {
+    try {
+      return __dataview.getFloat64(pointer, true);
+    } catch {
+      __dataview = new DataView(memory.buffer);
+      return __dataview.getFloat64(pointer, true);
+    }
   }
   exports._start();
   return adaptedExports;

--- a/tests/compiler/bindings/raw.release.wat
+++ b/tests/compiler/bindings/raw.release.wat
@@ -1,11 +1,11 @@
 (module
  (type $i32_i32_=>_i32 (func_subtype (param i32 i32) (result i32) func))
  (type $i32_=>_none (func_subtype (param i32) func))
+ (type $i32_i32_i32_=>_none (func_subtype (param i32 i32 i32) func))
  (type $i32_=>_i32 (func_subtype (param i32) (result i32) func))
  (type $none_=>_i32 (func_subtype (result i32) func))
  (type $none_=>_none (func_subtype func))
  (type $i32_i32_=>_none (func_subtype (param i32 i32) func))
- (type $i32_i32_i32_=>_none (func_subtype (param i32 i32 i32) func))
  (type $i32_i32_f64_f64_f64_f64_f64_=>_none (func_subtype (param i32 i32 f64 f64 f64 f64 f64) func))
  (type $f64_=>_f64 (func_subtype (param f64) (result f64) func))
  (type $i64_i64_=>_i64 (func_subtype (param i64 i64) (result i64) func))
@@ -40,8 +40,8 @@
  (global $~lib/rt/itcms/fromSpace (mut i32) (i32.const 0))
  (global $~lib/rt/tlsf/ROOT (mut i32) (i32.const 0))
  (global $~argumentsLength (mut i32) (i32.const 0))
- (global $~lib/rt/__rtti_base i32 (i32.const 2080))
- (global $~lib/memory/__stack_pointer (mut i32) (i32.const 34916))
+ (global $~lib/rt/__rtti_base i32 (i32.const 2208))
+ (global $~lib/memory/__stack_pointer (mut i32) (i32.const 35044))
  (global $~started (mut i32) (i32.const 0))
  (memory $0 1)
  (data (i32.const 1036) "\1c")
@@ -76,12 +76,14 @@
  (data (i32.const 1848) "\02\00\00\00&\00\00\00~\00l\00i\00b\00/\00s\00t\00a\00t\00i\00c\00a\00r\00r\00a\00y\00.\00t\00s")
  (data (i32.const 1900) ",")
  (data (i32.const 1912) "\02\00\00\00\1a\00\00\00~\00l\00i\00b\00/\00a\00r\00r\00a\00y\00.\00t\00s")
- (data (i32.const 1948) "<")
- (data (i32.const 1960) "\02\00\00\00*\00\00\00O\00b\00j\00e\00c\00t\00 \00a\00l\00r\00e\00a\00d\00y\00 \00p\00i\00n\00n\00e\00d")
- (data (i32.const 2012) "<")
- (data (i32.const 2024) "\02\00\00\00(\00\00\00O\00b\00j\00e\00c\00t\00 \00i\00s\00 \00n\00o\00t\00 \00p\00i\00n\00n\00e\00d")
- (data (i32.const 2080) "\10\00\00\00 \00\00\00 \00\00\00 ")
- (data (i32.const 2104) "\81\08\00\00\01\19\00\00\01\02\00\00$\t\00\00\a4\00\00\00$\n\00\00\02\t\00\00\00\00\00\00A\00\00\00\02A\00\00 ")
+ (data (i32.const 1948) "|")
+ (data (i32.const 1960) "\02\00\00\00^\00\00\00E\00l\00e\00m\00e\00n\00t\00 \00t\00y\00p\00e\00 \00m\00u\00s\00t\00 \00b\00e\00 \00n\00u\00l\00l\00a\00b\00l\00e\00 \00i\00f\00 \00a\00r\00r\00a\00y\00 \00i\00s\00 \00h\00o\00l\00e\00y")
+ (data (i32.const 2076) "<")
+ (data (i32.const 2088) "\02\00\00\00*\00\00\00O\00b\00j\00e\00c\00t\00 \00a\00l\00r\00e\00a\00d\00y\00 \00p\00i\00n\00n\00e\00d")
+ (data (i32.const 2140) "<")
+ (data (i32.const 2152) "\02\00\00\00(\00\00\00O\00b\00j\00e\00c\00t\00 \00i\00s\00 \00n\00o\00t\00 \00p\00i\00n\00n\00e\00d")
+ (data (i32.const 2208) "\10\00\00\00 \00\00\00 \00\00\00 ")
+ (data (i32.const 2232) "\81\08\00\00\01\19\00\00\01\02\00\00$\t\00\00\a4\00\00\00$\n\00\00\02\t\00\00\02A\00\00\00\00\00\00A\00\00\00 ")
  (export "plainGlobal" (global $bindings/esm/plainGlobal))
  (export "plainMutableGlobal" (global $bindings/esm/plainMutableGlobal))
  (export "stringGlobal" (global $bindings/esm/stringGlobal))
@@ -114,6 +116,7 @@
  (export "staticarrayU16" (func $export:bindings/esm/staticarrayU16))
  (export "staticarrayI64" (func $export:bindings/esm/staticarrayU16))
  (export "arrayFunction" (func $export:bindings/esm/arrayFunction))
+ (export "arrayOfStringsFunction" (func $export:bindings/esm/arrayOfStringsFunction))
  (export "objectFunction" (func $export:bindings/esm/objectFunction))
  (export "internrefFunction" (func $export:bindings/esm/internrefFunction))
  (export "functionFunction" (func $export:bindings/esm/staticarrayU16))
@@ -140,11 +143,13 @@
   call $byn-split-outlined-A$~lib/rt/itcms/__visit
   i32.const 1248
   call $byn-split-outlined-A$~lib/rt/itcms/__visit
-  i32.const 1360
-  call $byn-split-outlined-A$~lib/rt/itcms/__visit
   i32.const 1968
   call $byn-split-outlined-A$~lib/rt/itcms/__visit
-  i32.const 2032
+  i32.const 1360
+  call $byn-split-outlined-A$~lib/rt/itcms/__visit
+  i32.const 2096
+  call $byn-split-outlined-A$~lib/rt/itcms/__visit
+  i32.const 2160
   call $byn-split-outlined-A$~lib/rt/itcms/__visit
   i32.const 1056
   call $byn-split-outlined-A$~lib/rt/itcms/__visit
@@ -205,7 +210,7 @@
    i32.load $0 offset=8
    i32.eqz
    local.get $0
-   i32.const 34916
+   i32.const 35044
    i32.lt_u
    i32.and
    i32.eqz
@@ -279,7 +284,7 @@
    i32.const 1
   else
    local.get $2
-   i32.const 2080
+   i32.const 2208
    i32.load $0
    i32.gt_u
    if
@@ -293,7 +298,7 @@
    local.get $2
    i32.const 2
    i32.shl
-   i32.const 2084
+   i32.const 2212
    i32.add
    i32.load $0
    i32.const 32
@@ -858,10 +863,10 @@
   if
    unreachable
   end
-  i32.const 34928
+  i32.const 35056
   i32.const 0
   i32.store $0
-  i32.const 36496
+  i32.const 36624
   i32.const 0
   i32.store $0
   loop $for-loop|0
@@ -872,7 +877,7 @@
     local.get $0
     i32.const 2
     i32.shl
-    i32.const 34928
+    i32.const 35056
     i32.add
     i32.const 0
     i32.store $0 offset=4
@@ -890,7 +895,7 @@
       i32.add
       i32.const 2
       i32.shl
-      i32.const 34928
+      i32.const 35056
       i32.add
       i32.const 0
       i32.store $0 offset=96
@@ -908,13 +913,13 @@
     br $for-loop|0
    end
   end
-  i32.const 34928
-  i32.const 36500
+  i32.const 35056
+  i32.const 36628
   memory.size $0
   i32.const 16
   i32.shl
   call $~lib/rt/tlsf/addMemory
-  i32.const 34928
+  i32.const 35056
   global.set $~lib/rt/tlsf/ROOT
  )
  (func $~lib/rt/itcms/step (type $none_=>_i32) (result i32)
@@ -999,7 +1004,7 @@
      local.set $0
      loop $while-continue|0
       local.get $0
-      i32.const 34916
+      i32.const 35044
       i32.lt_u
       if
        local.get $0
@@ -1099,7 +1104,7 @@
      unreachable
     end
     local.get $0
-    i32.const 34916
+    i32.const 35044
     i32.lt_u
     if
      local.get $0
@@ -1122,7 +1127,7 @@
      i32.const 4
      i32.add
      local.tee $0
-     i32.const 34916
+     i32.const 35044
      i32.ge_u
      if
       global.get $~lib/rt/tlsf/ROOT
@@ -1623,11 +1628,11 @@
   i32.sub
   global.set $~lib/memory/__stack_pointer
   global.get $~lib/memory/__stack_pointer
-  i32.const 2148
+  i32.const 2276
   i32.lt_s
   if
-   i32.const 34944
-   i32.const 34992
+   i32.const 35072
+   i32.const 35120
    i32.const 1
    i32.const 1
    call $~lib/builtins/abort
@@ -1665,7 +1670,7 @@
    i32.const 3
    i32.eq
    if
-    i32.const 1968
+    i32.const 2096
     i32.const 1424
     i32.const 338
     i32.const 7
@@ -1718,7 +1723,7 @@
   i32.const 3
   i32.ne
   if
-   i32.const 2032
+   i32.const 2160
    i32.const 1424
    i32.const 352
    i32.const 5
@@ -1803,8 +1808,8 @@
     block $folding-inner0
      block $invalid
       block $bindings/esm/NonPlainObject
-       block $~lib/array/Array<~lib/string/String>
-        block $bindings/esm/PlainObject
+       block $bindings/esm/PlainObject
+        block $~lib/array/Array<~lib/string/String>
          block $~lib/array/Array<i32>
           block $~lib/staticarray/StaticArray<i64>
            block $~lib/staticarray/StaticArray<u16>
@@ -1817,7 +1822,7 @@
                  i32.const 8
                  i32.sub
                  i32.load $0
-                 br_table $~lib/object/Object $~lib/arraybuffer/ArrayBuffer $~lib/string/String $folding-inner1 $~lib/function/Function<%28%29=>void> $folding-inner1 $folding-inner1 $folding-inner1 $~lib/staticarray/StaticArray<i32> $~lib/staticarray/StaticArray<u16> $~lib/staticarray/StaticArray<i64> $~lib/array/Array<i32> $bindings/esm/PlainObject $folding-inner1 $~lib/array/Array<~lib/string/String> $bindings/esm/NonPlainObject $invalid
+                 br_table $~lib/object/Object $~lib/arraybuffer/ArrayBuffer $~lib/string/String $folding-inner1 $~lib/function/Function<%28%29=>void> $folding-inner1 $folding-inner1 $folding-inner1 $~lib/staticarray/StaticArray<i32> $~lib/staticarray/StaticArray<u16> $~lib/staticarray/StaticArray<i64> $~lib/array/Array<i32> $~lib/array/Array<~lib/string/String> $bindings/esm/PlainObject $folding-inner1 $bindings/esm/NonPlainObject $invalid
                 end
                 return
                end
@@ -1830,7 +1835,7 @@
              i32.sub
              global.set $~lib/memory/__stack_pointer
              global.get $~lib/memory/__stack_pointer
-             i32.const 2148
+             i32.const 2276
              i32.lt_s
              br_if $folding-inner0
              global.get $~lib/memory/__stack_pointer
@@ -1864,7 +1869,7 @@
          i32.sub
          global.set $~lib/memory/__stack_pointer
          global.get $~lib/memory/__stack_pointer
-         i32.const 2148
+         i32.const 2276
          i32.lt_s
          br_if $folding-inner0
          global.get $~lib/memory/__stack_pointer
@@ -1872,84 +1877,84 @@
          i32.store $0
          br $folding-inner2
         end
-        local.get $0
-        i32.load $0 offset=56
-        local.tee $1
-        if
-         local.get $1
-         call $byn-split-outlined-A$~lib/rt/itcms/__visit
-        end
-        local.get $0
-        i32.load $0 offset=60
-        local.tee $1
-        if
-         local.get $1
-         call $byn-split-outlined-A$~lib/rt/itcms/__visit
-        end
-        local.get $0
-        i32.load $0 offset=64
-        local.tee $0
-        if
-         local.get $0
-         call $byn-split-outlined-A$~lib/rt/itcms/__visit
-        end
-        return
-       end
-       global.get $~lib/memory/__stack_pointer
-       i32.const 4
-       i32.sub
-       global.set $~lib/memory/__stack_pointer
-       global.get $~lib/memory/__stack_pointer
-       i32.const 2148
-       i32.lt_s
-       br_if $folding-inner0
-       global.get $~lib/memory/__stack_pointer
-       local.tee $2
-       i32.const 0
-       i32.store $0
-       local.get $2
-       local.get $0
-       i32.store $0
-       local.get $0
-       i32.load $0 offset=4
-       local.set $1
-       local.get $2
-       local.get $0
-       i32.store $0
-       local.get $1
-       local.get $0
-       i32.load $0 offset=12
-       i32.const 2
-       i32.shl
-       i32.add
-       local.set $2
-       loop $while-continue|0
-        local.get $1
+        global.get $~lib/memory/__stack_pointer
+        i32.const 4
+        i32.sub
+        global.set $~lib/memory/__stack_pointer
+        global.get $~lib/memory/__stack_pointer
+        i32.const 2276
+        i32.lt_s
+        br_if $folding-inner0
+        global.get $~lib/memory/__stack_pointer
+        local.tee $2
+        i32.const 0
+        i32.store $0
         local.get $2
-        i32.lt_u
-        if
+        local.get $0
+        i32.store $0
+        local.get $0
+        i32.load $0 offset=4
+        local.set $1
+        local.get $2
+        local.get $0
+        i32.store $0
+        local.get $1
+        local.get $0
+        i32.load $0 offset=12
+        i32.const 2
+        i32.shl
+        i32.add
+        local.set $2
+        loop $while-continue|0
          local.get $1
-         i32.load $0
-         local.tee $3
+         local.get $2
+         i32.lt_u
          if
-          local.get $3
-          call $byn-split-outlined-A$~lib/rt/itcms/__visit
+          local.get $1
+          i32.load $0
+          local.tee $3
+          if
+           local.get $3
+           call $byn-split-outlined-A$~lib/rt/itcms/__visit
+          end
+          local.get $1
+          i32.const 4
+          i32.add
+          local.set $1
+          br $while-continue|0
          end
-         local.get $1
-         i32.const 4
-         i32.add
-         local.set $1
-         br $while-continue|0
         end
+        br $folding-inner2
        end
-       br $folding-inner2
+       local.get $0
+       i32.load $0 offset=56
+       local.tee $1
+       if
+        local.get $1
+        call $byn-split-outlined-A$~lib/rt/itcms/__visit
+       end
+       local.get $0
+       i32.load $0 offset=60
+       local.tee $1
+       if
+        local.get $1
+        call $byn-split-outlined-A$~lib/rt/itcms/__visit
+       end
+       local.get $0
+       i32.load $0 offset=64
+       local.tee $0
+       if
+        local.get $0
+        call $byn-split-outlined-A$~lib/rt/itcms/__visit
+       end
+       return
       end
       return
      end
      unreachable
     end
-    i32.const 34944
-    i32.const 34992
+    i32.const 35072
+    i32.const 35120
     i32.const 1
     i32.const 1
     call $~lib/builtins/abort
@@ -1996,11 +2001,11 @@
   i32.sub
   global.set $~lib/memory/__stack_pointer
   global.get $~lib/memory/__stack_pointer
-  i32.const 2148
+  i32.const 2276
   i32.lt_s
   if
-   i32.const 34944
-   i32.const 34992
+   i32.const 35072
+   i32.const 35120
    i32.const 1
    i32.const 1
    call $~lib/builtins/abort
@@ -2038,7 +2043,7 @@
   memory.size $0
   i32.const 16
   i32.shl
-  i32.const 34916
+  i32.const 35044
   i32.sub
   i32.const 1
   i32.shr_u
@@ -2078,7 +2083,7 @@
   global.set $~lib/memory/__stack_pointer
   block $folding-inner0
    global.get $~lib/memory/__stack_pointer
-   i32.const 2148
+   i32.const 2276
    i32.lt_s
    br_if $folding-inner0
    global.get $~lib/memory/__stack_pointer
@@ -2096,7 +2101,7 @@
    i32.sub
    global.set $~lib/memory/__stack_pointer
    global.get $~lib/memory/__stack_pointer
-   i32.const 2148
+   i32.const 2276
    i32.lt_s
    br_if $folding-inner0
    global.get $~lib/memory/__stack_pointer
@@ -2114,7 +2119,7 @@
    i32.sub
    global.set $~lib/memory/__stack_pointer
    global.get $~lib/memory/__stack_pointer
-   i32.const 2148
+   i32.const 2276
    i32.lt_s
    br_if $folding-inner0
    global.get $~lib/memory/__stack_pointer
@@ -2187,8 +2192,8 @@
    local.get $2
    return
   end
-  i32.const 34944
-  i32.const 34992
+  i32.const 35072
+  i32.const 35120
   i32.const 1
   i32.const 1
   call $~lib/builtins/abort
@@ -2201,11 +2206,11 @@
   i32.sub
   global.set $~lib/memory/__stack_pointer
   global.get $~lib/memory/__stack_pointer
-  i32.const 2148
+  i32.const 2276
   i32.lt_s
   if
-   i32.const 34944
-   i32.const 34992
+   i32.const 35072
+   i32.const 35120
    i32.const 1
    i32.const 1
    call $~lib/builtins/abort
@@ -2236,11 +2241,11 @@
   i32.sub
   global.set $~lib/memory/__stack_pointer
   global.get $~lib/memory/__stack_pointer
-  i32.const 2148
+  i32.const 2276
   i32.lt_s
   if
-   i32.const 34944
-   i32.const 34992
+   i32.const 35072
+   i32.const 35120
    i32.const 1
    i32.const 1
    call $~lib/builtins/abort
@@ -2271,11 +2276,11 @@
   i32.sub
   global.set $~lib/memory/__stack_pointer
   global.get $~lib/memory/__stack_pointer
-  i32.const 2148
+  i32.const 2276
   i32.lt_s
   if
-   i32.const 34944
-   i32.const 34992
+   i32.const 35072
+   i32.const 35120
    i32.const 1
    i32.const 1
    call $~lib/builtins/abort
@@ -2334,7 +2339,7 @@
   global.set $~lib/memory/__stack_pointer
   block $folding-inner1
    global.get $~lib/memory/__stack_pointer
-   i32.const 2148
+   i32.const 2276
    i32.lt_s
    br_if $folding-inner1
    global.get $~lib/memory/__stack_pointer
@@ -2363,7 +2368,7 @@
    i32.sub
    global.set $~lib/memory/__stack_pointer
    global.get $~lib/memory/__stack_pointer
-   i32.const 2148
+   i32.const 2276
    i32.lt_s
    br_if $folding-inner1
    global.get $~lib/memory/__stack_pointer
@@ -2385,7 +2390,7 @@
    i32.sub
    global.set $~lib/memory/__stack_pointer
    global.get $~lib/memory/__stack_pointer
-   i32.const 2148
+   i32.const 2276
    i32.lt_s
    br_if $folding-inner1
    global.get $~lib/memory/__stack_pointer
@@ -2457,6 +2462,7 @@
    if
     local.get $2
     local.get $6
+    i32.const 0
     call $byn-split-outlined-A$~lib/rt/itcms/__link
    end
    global.get $~lib/memory/__stack_pointer
@@ -2507,7 +2513,7 @@
      i32.sub
      global.set $~lib/memory/__stack_pointer
      global.get $~lib/memory/__stack_pointer
-     i32.const 2148
+     i32.const 2276
      i32.lt_s
      br_if $folding-inner1
      global.get $~lib/memory/__stack_pointer
@@ -2590,7 +2596,7 @@
      i32.sub
      global.set $~lib/memory/__stack_pointer
      global.get $~lib/memory/__stack_pointer
-     i32.const 2148
+     i32.const 2276
      i32.lt_s
      br_if $folding-inner1
      global.get $~lib/memory/__stack_pointer
@@ -2649,8 +2655,8 @@
    local.get $2
    return
   end
-  i32.const 34944
-  i32.const 34992
+  i32.const 35072
+  i32.const 35120
   i32.const 1
   i32.const 1
   call $~lib/builtins/abort
@@ -2663,11 +2669,11 @@
   i32.sub
   global.set $~lib/memory/__stack_pointer
   global.get $~lib/memory/__stack_pointer
-  i32.const 2148
+  i32.const 2276
   i32.lt_s
   if
-   i32.const 34944
-   i32.const 34992
+   i32.const 35072
+   i32.const 35120
    i32.const 1
    i32.const 1
    call $~lib/builtins/abort
@@ -2716,11 +2722,11 @@
   i32.sub
   global.set $~lib/memory/__stack_pointer
   global.get $~lib/memory/__stack_pointer
-  i32.const 2148
+  i32.const 2276
   i32.lt_s
   if
-   i32.const 34944
-   i32.const 34992
+   i32.const 35072
+   i32.const 35120
    i32.const 1
    i32.const 1
    call $~lib/builtins/abort
@@ -2772,11 +2778,11 @@
   i32.sub
   global.set $~lib/memory/__stack_pointer
   global.get $~lib/memory/__stack_pointer
-  i32.const 2148
+  i32.const 2276
   i32.lt_s
   if
-   i32.const 34944
-   i32.const 34992
+   i32.const 35072
+   i32.const 35120
    i32.const 1
    i32.const 1
    call $~lib/builtins/abort
@@ -2805,11 +2811,11 @@
   i32.sub
   global.set $~lib/memory/__stack_pointer
   global.get $~lib/memory/__stack_pointer
-  i32.const 2148
+  i32.const 2276
   i32.lt_s
   if
-   i32.const 34944
-   i32.const 34992
+   i32.const 35072
+   i32.const 35120
    i32.const 1
    i32.const 1
    call $~lib/builtins/abort
@@ -2852,203 +2858,211 @@
   global.set $~lib/memory/__stack_pointer
   local.get $0
  )
- (func $~lib/array/Array<i32>#__set (type $i32_i32_i32_=>_none) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/array/ensureCapacity (type $i32_i32_=>_none) (param $0 i32) (param $1 i32)
+  (local $2 i32)
   (local $3 i32)
   (local $4 i32)
-  (local $5 i32)
-  (local $6 i32)
-  (local $7 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 4
   i32.sub
   global.set $~lib/memory/__stack_pointer
-  block $folding-inner0
-   global.get $~lib/memory/__stack_pointer
-   i32.const 2148
-   i32.lt_s
-   br_if $folding-inner0
-   global.get $~lib/memory/__stack_pointer
-   local.tee $3
-   i32.const 0
-   i32.store $0
-   local.get $3
-   local.get $0
-   i32.store $0
+  global.get $~lib/memory/__stack_pointer
+  i32.const 2276
+  i32.lt_s
+  if
+   i32.const 35072
+   i32.const 35120
+   i32.const 1
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  global.get $~lib/memory/__stack_pointer
+  local.tee $2
+  i32.const 0
+  i32.store $0
+  local.get $2
+  local.get $0
+  i32.store $0
+  local.get $1
+  local.get $0
+  i32.load $0 offset=8
+  local.tee $2
+  i32.const 2
+  i32.shr_u
+  i32.gt_u
+  if
    local.get $1
-   local.get $0
-   i32.load $0 offset=12
-   i32.ge_u
+   i32.const 268435455
+   i32.gt_u
    if
-    local.get $1
-    i32.const 0
-    i32.lt_s
-    if
-     i32.const 1552
-     i32.const 1920
-     i32.const 130
-     i32.const 22
-     call $~lib/builtins/abort
-     unreachable
-    end
-    local.get $1
-    i32.const 1
-    i32.add
-    local.tee $6
-    local.set $3
-    global.get $~lib/memory/__stack_pointer
-    i32.const 4
-    i32.sub
-    global.set $~lib/memory/__stack_pointer
-    global.get $~lib/memory/__stack_pointer
-    i32.const 2148
-    i32.lt_s
-    br_if $folding-inner0
-    global.get $~lib/memory/__stack_pointer
-    local.tee $4
-    i32.const 0
-    i32.store $0
-    local.get $4
-    local.get $0
-    i32.store $0
-    local.get $3
-    local.get $0
-    i32.load $0 offset=8
-    local.tee $4
-    i32.const 2
-    i32.shr_u
-    i32.gt_u
-    if
-     local.get $3
-     i32.const 268435455
-     i32.gt_u
-     if
-      i32.const 1248
-      i32.const 1920
-      i32.const 19
-      i32.const 48
-      call $~lib/builtins/abort
-      unreachable
-     end
-     global.get $~lib/memory/__stack_pointer
-     local.get $0
-     i32.store $0
-     block $__inlined_func$~lib/rt/itcms/__renew
-      i32.const 1073741820
-      local.get $4
-      i32.const 1
-      i32.shl
-      local.tee $4
-      local.get $4
-      i32.const 1073741820
-      i32.ge_u
-      select
-      local.tee $4
-      i32.const 8
-      local.get $3
-      local.get $3
-      i32.const 8
-      i32.le_u
-      select
-      i32.const 2
-      i32.shl
-      local.tee $3
-      local.get $3
-      local.get $4
-      i32.lt_u
-      select
-      local.tee $5
-      local.get $0
-      i32.load $0
-      local.tee $4
-      i32.const 20
-      i32.sub
-      local.tee $7
-      i32.load $0
-      i32.const -4
-      i32.and
-      i32.const 16
-      i32.sub
-      i32.le_u
-      if
-       local.get $7
-       local.get $5
-       i32.store $0 offset=16
-       local.get $4
-       local.set $3
-       br $__inlined_func$~lib/rt/itcms/__renew
-      end
-      local.get $5
-      local.get $7
-      i32.load $0 offset=12
-      call $~lib/rt/itcms/__new
-      local.tee $3
-      local.get $4
-      local.get $5
-      local.get $7
-      i32.load $0 offset=16
-      local.tee $7
-      local.get $5
-      local.get $7
-      i32.lt_u
-      select
-      memory.copy $0 $0
-     end
-     local.get $3
-     local.get $4
-     i32.ne
-     if
-      local.get $0
-      local.get $3
-      i32.store $0
-      local.get $0
-      local.get $3
-      i32.store $0 offset=4
-      local.get $3
-      if
-       local.get $0
-       local.get $3
-       call $byn-split-outlined-A$~lib/rt/itcms/__link
-      end
-     end
-     local.get $0
-     local.get $5
-     i32.store $0 offset=8
-    end
-    global.get $~lib/memory/__stack_pointer
-    i32.const 4
-    i32.add
-    global.set $~lib/memory/__stack_pointer
-    global.get $~lib/memory/__stack_pointer
-    local.get $0
-    i32.store $0
-    local.get $0
-    local.get $6
-    i32.store $0 offset=12
+    i32.const 1248
+    i32.const 1920
+    i32.const 19
+    i32.const 48
+    call $~lib/builtins/abort
+    unreachable
    end
    global.get $~lib/memory/__stack_pointer
-   local.tee $3
    local.get $0
    i32.store $0
-   local.get $0
-   i32.load $0 offset=4
+   block $__inlined_func$~lib/rt/itcms/__renew
+    i32.const 1073741820
+    local.get $2
+    i32.const 1
+    i32.shl
+    local.tee $2
+    local.get $2
+    i32.const 1073741820
+    i32.ge_u
+    select
+    local.tee $2
+    i32.const 8
+    local.get $1
+    local.get $1
+    i32.const 8
+    i32.le_u
+    select
+    i32.const 2
+    i32.shl
+    local.tee $1
+    local.get $1
+    local.get $2
+    i32.lt_u
+    select
+    local.tee $3
+    local.get $0
+    i32.load $0
+    local.tee $2
+    i32.const 20
+    i32.sub
+    local.tee $4
+    i32.load $0
+    i32.const -4
+    i32.and
+    i32.const 16
+    i32.sub
+    i32.le_u
+    if
+     local.get $4
+     local.get $3
+     i32.store $0 offset=16
+     local.get $2
+     local.set $1
+     br $__inlined_func$~lib/rt/itcms/__renew
+    end
+    local.get $3
+    local.get $4
+    i32.load $0 offset=12
+    call $~lib/rt/itcms/__new
+    local.tee $1
+    local.get $2
+    local.get $3
+    local.get $4
+    i32.load $0 offset=16
+    local.tee $4
+    local.get $3
+    local.get $4
+    i32.lt_u
+    select
+    memory.copy $0 $0
+   end
    local.get $1
-   i32.const 2
-   i32.shl
-   i32.add
    local.get $2
-   i32.store $0
+   i32.ne
+   if
+    local.get $0
+    local.get $1
+    i32.store $0
+    local.get $0
+    local.get $1
+    i32.store $0 offset=4
+    local.get $1
+    if
+     local.get $0
+     local.get $1
+     i32.const 0
+     call $byn-split-outlined-A$~lib/rt/itcms/__link
+    end
+   end
+   local.get $0
    local.get $3
-   i32.const 4
-   i32.add
-   global.set $~lib/memory/__stack_pointer
-   return
+   i32.store $0 offset=8
   end
-  i32.const 34944
-  i32.const 34992
-  i32.const 1
-  i32.const 1
-  call $~lib/builtins/abort
-  unreachable
+  global.get $~lib/memory/__stack_pointer
+  i32.const 4
+  i32.add
+  global.set $~lib/memory/__stack_pointer
+ )
+ (func $~lib/array/Array<i32>#__set (type $i32_i32_i32_=>_none) (param $0 i32) (param $1 i32) (param $2 i32)
+  (local $3 i32)
+  global.get $~lib/memory/__stack_pointer
+  i32.const 4
+  i32.sub
+  global.set $~lib/memory/__stack_pointer
+  global.get $~lib/memory/__stack_pointer
+  i32.const 2276
+  i32.lt_s
+  if
+   i32.const 35072
+   i32.const 35120
+   i32.const 1
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  global.get $~lib/memory/__stack_pointer
+  local.tee $3
+  i32.const 0
+  i32.store $0
+  local.get $3
+  local.get $0
+  i32.store $0
+  local.get $1
+  local.get $0
+  i32.load $0 offset=12
+  i32.ge_u
+  if
+   local.get $1
+   i32.const 0
+   i32.lt_s
+   if
+    i32.const 1552
+    i32.const 1920
+    i32.const 130
+    i32.const 22
+    call $~lib/builtins/abort
+    unreachable
+   end
+   local.get $0
+   local.get $1
+   i32.const 1
+   i32.add
+   local.tee $3
+   call $~lib/array/ensureCapacity
+   global.get $~lib/memory/__stack_pointer
+   local.get $0
+   i32.store $0
+   local.get $0
+   local.get $3
+   i32.store $0 offset=12
+  end
+  global.get $~lib/memory/__stack_pointer
+  local.tee $3
+  local.get $0
+  i32.store $0
+  local.get $0
+  i32.load $0 offset=4
+  local.get $1
+  i32.const 2
+  i32.shl
+  i32.add
+  local.get $2
+  i32.store $0
+  local.get $3
+  i32.const 4
+  i32.add
+  global.set $~lib/memory/__stack_pointer
  )
  (func $bindings/esm/arrayFunction (type $i32_i32_=>_i32) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
@@ -3064,7 +3078,7 @@
   global.set $~lib/memory/__stack_pointer
   block $folding-inner0
    global.get $~lib/memory/__stack_pointer
-   i32.const 2148
+   i32.const 2276
    i32.lt_s
    br_if $folding-inner0
    global.get $~lib/memory/__stack_pointer
@@ -3093,7 +3107,7 @@
    i32.sub
    global.set $~lib/memory/__stack_pointer
    global.get $~lib/memory/__stack_pointer
-   i32.const 2148
+   i32.const 2276
    i32.lt_s
    br_if $folding-inner0
    global.get $~lib/memory/__stack_pointer
@@ -3172,6 +3186,7 @@
    if
     local.get $5
     local.get $6
+    i32.const 0
     call $byn-split-outlined-A$~lib/rt/itcms/__link
    end
    global.get $~lib/memory/__stack_pointer
@@ -3275,8 +3290,393 @@
    local.get $5
    return
   end
-  i32.const 34944
-  i32.const 34992
+  i32.const 35072
+  i32.const 35120
+  i32.const 1
+  i32.const 1
+  call $~lib/builtins/abort
+  unreachable
+ )
+ (func $~lib/array/Array<~lib/string/String>#__get (type $i32_i32_=>_i32) (param $0 i32) (param $1 i32) (result i32)
+  (local $2 i32)
+  global.get $~lib/memory/__stack_pointer
+  i32.const 8
+  i32.sub
+  global.set $~lib/memory/__stack_pointer
+  global.get $~lib/memory/__stack_pointer
+  i32.const 2276
+  i32.lt_s
+  if
+   i32.const 35072
+   i32.const 35120
+   i32.const 1
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  global.get $~lib/memory/__stack_pointer
+  local.tee $2
+  i64.const 0
+  i64.store $0
+  local.get $2
+  local.get $0
+  i32.store $0
+  local.get $1
+  local.get $0
+  i32.load $0 offset=12
+  i32.ge_u
+  if
+   i32.const 1552
+   i32.const 1920
+   i32.const 114
+   i32.const 42
+   call $~lib/builtins/abort
+   unreachable
+  end
+  global.get $~lib/memory/__stack_pointer
+  local.tee $2
+  local.get $0
+  i32.store $0
+  local.get $2
+  local.get $0
+  i32.load $0 offset=4
+  local.get $1
+  i32.const 2
+  i32.shl
+  i32.add
+  i32.load $0
+  local.tee $0
+  i32.store $0 offset=4
+  local.get $0
+  i32.eqz
+  if
+   i32.const 1968
+   i32.const 1920
+   i32.const 118
+   i32.const 40
+   call $~lib/builtins/abort
+   unreachable
+  end
+  global.get $~lib/memory/__stack_pointer
+  i32.const 8
+  i32.add
+  global.set $~lib/memory/__stack_pointer
+  local.get $0
+ )
+ (func $~lib/array/Array<~lib/string/String>#__set (type $i32_i32_i32_=>_none) (param $0 i32) (param $1 i32) (param $2 i32)
+  (local $3 i32)
+  global.get $~lib/memory/__stack_pointer
+  i32.const 4
+  i32.sub
+  global.set $~lib/memory/__stack_pointer
+  global.get $~lib/memory/__stack_pointer
+  i32.const 2276
+  i32.lt_s
+  if
+   i32.const 35072
+   i32.const 35120
+   i32.const 1
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  global.get $~lib/memory/__stack_pointer
+  local.tee $3
+  i32.const 0
+  i32.store $0
+  local.get $3
+  local.get $0
+  i32.store $0
+  local.get $1
+  local.get $0
+  i32.load $0 offset=12
+  i32.ge_u
+  if
+   local.get $1
+   i32.const 0
+   i32.lt_s
+   if
+    i32.const 1552
+    i32.const 1920
+    i32.const 130
+    i32.const 22
+    call $~lib/builtins/abort
+    unreachable
+   end
+   local.get $0
+   local.get $1
+   i32.const 1
+   i32.add
+   local.tee $3
+   call $~lib/array/ensureCapacity
+   global.get $~lib/memory/__stack_pointer
+   local.get $0
+   i32.store $0
+   local.get $0
+   local.get $3
+   i32.store $0 offset=12
+  end
+  global.get $~lib/memory/__stack_pointer
+  local.get $0
+  i32.store $0
+  local.get $0
+  i32.load $0 offset=4
+  local.get $1
+  i32.const 2
+  i32.shl
+  i32.add
+  local.get $2
+  i32.store $0
+  local.get $2
+  if
+   local.get $0
+   local.get $2
+   i32.const 1
+   call $byn-split-outlined-A$~lib/rt/itcms/__link
+  end
+  global.get $~lib/memory/__stack_pointer
+  i32.const 4
+  i32.add
+  global.set $~lib/memory/__stack_pointer
+ )
+ (func $bindings/esm/arrayOfStringsFunction (type $i32_i32_=>_i32) (param $0 i32) (param $1 i32) (result i32)
+  (local $2 i32)
+  (local $3 i32)
+  (local $4 i32)
+  (local $5 i32)
+  (local $6 i32)
+  (local $7 i32)
+  (local $8 i32)
+  global.get $~lib/memory/__stack_pointer
+  i32.const 12
+  i32.sub
+  global.set $~lib/memory/__stack_pointer
+  block $folding-inner0
+   global.get $~lib/memory/__stack_pointer
+   i32.const 2276
+   i32.lt_s
+   br_if $folding-inner0
+   global.get $~lib/memory/__stack_pointer
+   local.tee $3
+   i64.const 0
+   i64.store $0
+   local.get $3
+   i32.const 0
+   i32.store $0 offset=8
+   local.get $3
+   local.get $0
+   i32.store $0
+   local.get $0
+   call $~lib/array/Array<i32>#get:length
+   local.set $4
+   global.get $~lib/memory/__stack_pointer
+   local.get $1
+   i32.store $0
+   local.get $1
+   call $~lib/array/Array<i32>#get:length
+   local.get $4
+   i32.add
+   local.set $4
+   global.get $~lib/memory/__stack_pointer
+   i32.const 16
+   i32.sub
+   global.set $~lib/memory/__stack_pointer
+   global.get $~lib/memory/__stack_pointer
+   i32.const 2276
+   i32.lt_s
+   br_if $folding-inner0
+   global.get $~lib/memory/__stack_pointer
+   local.tee $5
+   i64.const 0
+   i64.store $0
+   local.get $5
+   i64.const 0
+   i64.store $0 offset=8
+   local.get $5
+   i32.const 16
+   i32.const 12
+   call $~lib/rt/itcms/__new
+   local.tee $5
+   i32.store $0
+   global.get $~lib/memory/__stack_pointer
+   local.get $5
+   i32.store $0 offset=4
+   local.get $5
+   i32.const 0
+   i32.store $0
+   global.get $~lib/memory/__stack_pointer
+   local.tee $6
+   local.get $5
+   i32.store $0 offset=4
+   local.get $5
+   i32.const 0
+   i32.store $0 offset=4
+   local.get $6
+   local.get $5
+   i32.store $0 offset=4
+   local.get $5
+   i32.const 0
+   i32.store $0 offset=8
+   local.get $6
+   local.get $5
+   i32.store $0 offset=4
+   local.get $5
+   i32.const 0
+   i32.store $0 offset=12
+   local.get $4
+   i32.const 268435455
+   i32.gt_u
+   if
+    i32.const 1248
+    i32.const 1920
+    i32.const 70
+    i32.const 60
+    call $~lib/builtins/abort
+    unreachable
+   end
+   global.get $~lib/memory/__stack_pointer
+   i32.const 8
+   local.get $4
+   local.get $4
+   i32.const 8
+   i32.le_u
+   select
+   i32.const 2
+   i32.shl
+   local.tee $7
+   i32.const 1
+   call $~lib/rt/itcms/__new
+   local.tee $6
+   i32.store $0 offset=8
+   global.get $~lib/memory/__stack_pointer
+   local.get $5
+   i32.store $0 offset=4
+   global.get $~lib/memory/__stack_pointer
+   local.get $6
+   i32.store $0 offset=12
+   local.get $5
+   local.get $6
+   i32.store $0
+   local.get $6
+   if
+    local.get $5
+    local.get $6
+    i32.const 0
+    call $byn-split-outlined-A$~lib/rt/itcms/__link
+   end
+   global.get $~lib/memory/__stack_pointer
+   local.tee $8
+   local.get $5
+   i32.store $0 offset=4
+   local.get $5
+   local.get $6
+   i32.store $0 offset=4
+   local.get $8
+   local.get $5
+   i32.store $0 offset=4
+   local.get $5
+   local.get $7
+   i32.store $0 offset=8
+   local.get $8
+   local.get $5
+   i32.store $0 offset=4
+   local.get $5
+   local.get $4
+   i32.store $0 offset=12
+   local.get $8
+   i32.const 16
+   i32.add
+   global.set $~lib/memory/__stack_pointer
+   local.get $3
+   local.get $5
+   i32.store $0 offset=4
+   loop $for-loop|0
+    global.get $~lib/memory/__stack_pointer
+    local.get $0
+    i32.store $0
+    local.get $0
+    call $~lib/array/Array<i32>#get:length
+    local.get $2
+    i32.gt_s
+    if
+     global.get $~lib/memory/__stack_pointer
+     local.tee $3
+     local.get $5
+     i32.store $0
+     local.get $3
+     local.get $0
+     i32.store $0 offset=8
+     local.get $0
+     local.get $2
+     call $~lib/array/Array<~lib/string/String>#__get
+     local.set $3
+     global.get $~lib/memory/__stack_pointer
+     local.get $3
+     i32.store $0 offset=8
+     local.get $5
+     local.get $2
+     local.get $3
+     call $~lib/array/Array<~lib/string/String>#__set
+     local.get $2
+     i32.const 1
+     i32.add
+     local.set $2
+     br $for-loop|0
+    end
+   end
+   i32.const 0
+   local.set $2
+   loop $for-loop|1
+    global.get $~lib/memory/__stack_pointer
+    local.get $1
+    i32.store $0
+    local.get $1
+    call $~lib/array/Array<i32>#get:length
+    local.get $2
+    i32.gt_s
+    if
+     global.get $~lib/memory/__stack_pointer
+     local.tee $3
+     local.get $5
+     i32.store $0
+     local.get $3
+     local.get $0
+     i32.store $0 offset=8
+     local.get $0
+     call $~lib/array/Array<i32>#get:length
+     local.get $2
+     i32.add
+     local.set $3
+     global.get $~lib/memory/__stack_pointer
+     local.get $1
+     i32.store $0 offset=8
+     local.get $1
+     local.get $2
+     call $~lib/array/Array<~lib/string/String>#__get
+     local.set $4
+     global.get $~lib/memory/__stack_pointer
+     local.get $4
+     i32.store $0 offset=8
+     local.get $5
+     local.get $3
+     local.get $4
+     call $~lib/array/Array<~lib/string/String>#__set
+     local.get $2
+     i32.const 1
+     i32.add
+     local.set $2
+     br $for-loop|1
+    end
+   end
+   global.get $~lib/memory/__stack_pointer
+   i32.const 12
+   i32.add
+   global.set $~lib/memory/__stack_pointer
+   local.get $5
+   return
+  end
+  i32.const 35072
+  i32.const 35120
   i32.const 1
   i32.const 1
   call $~lib/builtins/abort
@@ -3293,7 +3693,7 @@
   global.set $~lib/memory/__stack_pointer
   block $folding-inner0
    global.get $~lib/memory/__stack_pointer
-   i32.const 2148
+   i32.const 2276
    i32.lt_s
    br_if $folding-inner0
    global.get $~lib/memory/__stack_pointer
@@ -3308,7 +3708,7 @@
    i32.sub
    global.set $~lib/memory/__stack_pointer
    global.get $~lib/memory/__stack_pointer
-   i32.const 2148
+   i32.const 2276
    i32.lt_s
    br_if $folding-inner0
    global.get $~lib/memory/__stack_pointer
@@ -3339,7 +3739,7 @@
    i32.sub
    global.set $~lib/memory/__stack_pointer
    global.get $~lib/memory/__stack_pointer
-   i32.const 2148
+   i32.const 2276
    i32.lt_s
    br_if $folding-inner0
    global.get $~lib/memory/__stack_pointer
@@ -3390,8 +3790,8 @@
    local.get $5
    return
   end
-  i32.const 34944
-  i32.const 34992
+  i32.const 35072
+  i32.const 35120
   i32.const 1
   i32.const 1
   call $~lib/builtins/abort
@@ -3404,11 +3804,11 @@
   i32.sub
   global.set $~lib/memory/__stack_pointer
   global.get $~lib/memory/__stack_pointer
-  i32.const 2148
+  i32.const 2276
   i32.lt_s
   if
-   i32.const 34944
-   i32.const 34992
+   i32.const 35072
+   i32.const 35120
    i32.const 1
    i32.const 1
    call $~lib/builtins/abort
@@ -3439,7 +3839,7 @@
   global.set $~lib/memory/__stack_pointer
   block $folding-inner0
    global.get $~lib/memory/__stack_pointer
-   i32.const 2148
+   i32.const 2276
    i32.lt_s
    br_if $folding-inner0
    global.get $~lib/memory/__stack_pointer
@@ -3454,7 +3854,7 @@
    i32.sub
    global.set $~lib/memory/__stack_pointer
    global.get $~lib/memory/__stack_pointer
-   i32.const 2148
+   i32.const 2276
    i32.lt_s
    br_if $folding-inner0
    global.get $~lib/memory/__stack_pointer
@@ -3502,8 +3902,8 @@
    local.get $0
    return
   end
-  i32.const 34944
-  i32.const 34992
+  i32.const 35072
+  i32.const 35120
   i32.const 1
   i32.const 1
   call $~lib/builtins/abort
@@ -3516,11 +3916,11 @@
   i32.sub
   global.set $~lib/memory/__stack_pointer
   global.get $~lib/memory/__stack_pointer
-  i32.const 2148
+  i32.const 2276
   i32.lt_s
   if
-   i32.const 34944
-   i32.const 34992
+   i32.const 35072
+   i32.const 35120
    i32.const 1
    i32.const 1
    call $~lib/builtins/abort
@@ -3554,7 +3954,7 @@
   global.set $~lib/memory/__stack_pointer
   block $folding-inner1
    global.get $~lib/memory/__stack_pointer
-   i32.const 2148
+   i32.const 2276
    i32.lt_s
    br_if $folding-inner1
    global.get $~lib/memory/__stack_pointer
@@ -3571,7 +3971,7 @@
     global.set $~lib/memory/__stack_pointer
     block $folding-inner0
      global.get $~lib/memory/__stack_pointer
-     i32.const 2148
+     i32.const 2276
      i32.lt_s
      br_if $folding-inner0
      global.get $~lib/memory/__stack_pointer
@@ -3608,7 +4008,7 @@
      i32.sub
      global.set $~lib/memory/__stack_pointer
      global.get $~lib/memory/__stack_pointer
-     i32.const 2148
+     i32.const 2276
      i32.lt_s
      br_if $folding-inner0
      global.get $~lib/memory/__stack_pointer
@@ -3737,8 +4137,8 @@
    local.get $0
    return
   end
-  i32.const 34944
-  i32.const 34992
+  i32.const 35072
+  i32.const 35120
   i32.const 1
   i32.const 1
   call $~lib/builtins/abort
@@ -3751,11 +4151,11 @@
   i32.sub
   global.set $~lib/memory/__stack_pointer
   global.get $~lib/memory/__stack_pointer
-  i32.const 2148
+  i32.const 2276
   i32.lt_s
   if
-   i32.const 34944
-   i32.const 34992
+   i32.const 35072
+   i32.const 35120
    i32.const 1
    i32.const 1
    call $~lib/builtins/abort
@@ -3778,11 +4178,11 @@
   i32.sub
   global.set $~lib/memory/__stack_pointer
   global.get $~lib/memory/__stack_pointer
-  i32.const 2148
+  i32.const 2276
   i32.lt_s
   if
-   i32.const 34944
-   i32.const 34992
+   i32.const 35072
+   i32.const 35120
    i32.const 1
    i32.const 1
    call $~lib/builtins/abort
@@ -3805,6 +4205,40 @@
   global.set $~lib/memory/__stack_pointer
   local.get $0
  )
+ (func $export:bindings/esm/arrayOfStringsFunction (type $i32_i32_=>_i32) (param $0 i32) (param $1 i32) (result i32)
+  (local $2 i32)
+  global.get $~lib/memory/__stack_pointer
+  i32.const 8
+  i32.sub
+  global.set $~lib/memory/__stack_pointer
+  global.get $~lib/memory/__stack_pointer
+  i32.const 2276
+  i32.lt_s
+  if
+   i32.const 35072
+   i32.const 35120
+   i32.const 1
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  global.get $~lib/memory/__stack_pointer
+  local.tee $2
+  local.get $0
+  i32.store $0
+  local.get $2
+  local.get $1
+  i32.store $0 offset=4
+  local.get $0
+  local.get $1
+  call $bindings/esm/arrayOfStringsFunction
+  local.set $0
+  global.get $~lib/memory/__stack_pointer
+  i32.const 8
+  i32.add
+  global.set $~lib/memory/__stack_pointer
+  local.get $0
+ )
  (func $export:bindings/esm/objectFunction (type $i32_i32_=>_i32) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
@@ -3815,7 +4249,7 @@
   global.set $~lib/memory/__stack_pointer
   block $folding-inner1
    global.get $~lib/memory/__stack_pointer
-   i32.const 2148
+   i32.const 2276
    i32.lt_s
    br_if $folding-inner1
    global.get $~lib/memory/__stack_pointer
@@ -3830,7 +4264,7 @@
    i32.sub
    global.set $~lib/memory/__stack_pointer
    global.get $~lib/memory/__stack_pointer
-   i32.const 2148
+   i32.const 2276
    i32.lt_s
    br_if $folding-inner1
    local.get $0
@@ -3850,7 +4284,7 @@
     global.set $~lib/memory/__stack_pointer
     block $folding-inner00
      global.get $~lib/memory/__stack_pointer
-     i32.const 2148
+     i32.const 2276
      i32.lt_s
      br_if $folding-inner00
      global.get $~lib/memory/__stack_pointer
@@ -3859,7 +4293,7 @@
      i64.store $0
      local.get $0
      i32.const 68
-     i32.const 12
+     i32.const 13
      call $~lib/rt/itcms/__new
      local.tee $0
      i32.store $0
@@ -3872,7 +4306,7 @@
      i32.sub
      global.set $~lib/memory/__stack_pointer
      global.get $~lib/memory/__stack_pointer
-     i32.const 2148
+     i32.const 2276
      i32.lt_s
      br_if $folding-inner00
      global.get $~lib/memory/__stack_pointer
@@ -4050,8 +4484,8 @@
    local.get $3
    return
   end
-  i32.const 34944
-  i32.const 34992
+  i32.const 35072
+  i32.const 35120
   i32.const 1
   i32.const 1
   call $~lib/builtins/abort
@@ -4064,11 +4498,11 @@
   i32.sub
   global.set $~lib/memory/__stack_pointer
   global.get $~lib/memory/__stack_pointer
-  i32.const 2148
+  i32.const 2276
   i32.lt_s
   if
-   i32.const 34944
-   i32.const 34992
+   i32.const 35072
+   i32.const 35120
    i32.const 1
    i32.const 1
    call $~lib/builtins/abort
@@ -4106,7 +4540,8 @@
    global.set $~lib/rt/itcms/visitCount
   end
  )
- (func $byn-split-outlined-A$~lib/rt/itcms/__link (type $i32_i32_=>_none) (param $0 i32) (param $1 i32)
+ (func $byn-split-outlined-A$~lib/rt/itcms/__link (type $i32_i32_i32_=>_none) (param $0 i32) (param $1 i32) (param $2 i32)
+  (local $3 i32)
   local.get $0
   i32.eqz
   if
@@ -4130,21 +4565,25 @@
    local.get $0
    i32.const 20
    i32.sub
+   local.tee $0
    i32.load $0 offset=4
    i32.const 3
    i32.and
-   local.tee $0
+   local.tee $3
    global.get $~lib/rt/itcms/white
    i32.eqz
    i32.eq
    if
+    local.get $0
     local.get $1
+    local.get $2
+    select
     call $~lib/rt/itcms/Object#makeGray
    else
     global.get $~lib/rt/itcms/state
     i32.const 1
     i32.eq
-    local.get $0
+    local.get $3
     i32.const 3
     i32.eq
     i32.and


### PR DESCRIPTION
Given the results of [this simple experiment](https://jsbench.me/uglc4wxdr2), instead of using short-lived views when accessing memory to work around a possibly detached buffer after a `memory.grow`, this PR changes memory accesses to utilize a cached `DataView` ([see also](https://v8.dev/blog/dataview)), where a try/catch can be and now is used to detect a detached buffer.

There is more that can be done here, like keeping track of where memory might actually grow, and if it's guaranteed to never grow in between two calls of the respective `__get/setXY` helpers access the `DataView` directly in subsequent calls. So far this is done where trivial, e.g. in some `__lift/lowerXY` helpers, but not yet in `__lift/lowerRecord` where it's a bit unclear whether the additional complexity would actually be worth it.

- [x] I've read the contributing guidelines
- [x] I've added my name and email to the NOTICE file
