### PR TITLE
Don't implicitly call exportStart function in generated host bindings

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -55,6 +55,7 @@ under the licensing terms detailed in LICENSE:
 * CountBleck <Mr.YouKnowWhoIAm@protonmail.com>
 * Abdul Rauf <abdulraufmujahid@gmail.com>
 * Bach Le <bach@bullno1.com>
+* Logan Davies <logan.davies181@gmail.com>
 
 Portions of this software are derived from third-party works licensed under
 the following terms:

--- a/src/bindings/js.ts
+++ b/src/bindings/js.ts
@@ -931,11 +931,6 @@ export class JSBuilder extends ExportsWalker {
     if (this.needsGetF32) sb.push(makeCheckedGetter("F32", "getFloat32"));
     if (this.needsGetF64) sb.push(makeCheckedGetter("F64", "getFloat64"));
 
-    let exportStart = options.exportStart;
-    if (exportStart) {
-      sb.push(`  exports.${exportStart}();\n`);
-    }
-
     if (hasAdaptedExports) {
       sb.push("  return adaptedExports;\n}\n");
     } else {

--- a/tests/compiler/bindings/noExportRuntime.debug.js
+++ b/tests/compiler/bindings/noExportRuntime.debug.js
@@ -141,7 +141,6 @@ async function instantiate(module, imports = {}) {
       return __dataview.getUint32(pointer, true);
     }
   }
-  exports._start();
   return adaptedExports;
 }
 export const {


### PR DESCRIPTION
<!--
 Thanks for submitting a pull request to AssemblyScript! Please take a moment to
 review the contributing guidelines linked below, and confirm with an [x] 🙂
-->

Hi there. Great project - imo it's what TS should have been :)

This PR removes the call to the target of --exportStart in the `instantiate` function from the generated JS host bindings. The current behavior causes issues for non-browser JS hosts as per the below.

I'm not sure how this affects browser-based users of --exportStart (nor what their use-case is for it) - but regardless, the current behaviour of the generated bindings does seem to be at odds with [the documentation](https://www.assemblyscript.org/compiler.html#compiler-options), which says that the function is not called implicitly, except that `instantiate` calls it anyway.


Consider this example from [the Nodejs wasi docs](https://nodejs.org/api/wasi.html), which I've modified to use generated host bindings:

```typescript
import { instantiate } from './build/release.js';

import { readFile } from 'node:fs/promises';
import { WASI } from 'wasi';
import { argv, env } from 'node:process';

const wasi = new WASI({
    args: argv,
    env,
});

const importObject = { wasi_snapshot_preview1: wasi.wasiImport };

const wasm = await WebAssembly.compile(await readFile(new URL('./build/release.wasm', import.meta.url)));

const instance = await instantiate(wasm, importObject); // error raised here

wasi.start({ exports: instance });
```

Nodejs exits with this error:
```
file:///some/path/build/release.js:11
        return __module0.fd_write(fd, iovs, iovs_len, nwritten);
                         ^

Error: wasi.start() has not been called
    at fd_write (file:///some/path/build/release.js:11:26)
    at wasm://wasm/bbc26f1e:wasm-function[12]:0xfcf
    at wasm://wasm/bbc26f1e:wasm-function[13]:0x1081
    at wasm://wasm/bbc26f1e:wasm-function[9]:0xa03
    at instantiate (file:///some/path/build/release.js:21:11)
    at async file:///some/path/index.js:16:18 {
  code: 'ERR_WASI_NOT_STARTED'
}

Node.js v19.2.0
```

Deno has a [nearly identical API](https://deno.land/std@0.170.0/wasi/snapshot_preview1.ts) and quietly exits instead of erroring like Node does

- [x] I've read the contributing guidelines
- [x] I've added my name and email to the NOTICE file
