### PR TITLE
feat: Provide an easily reusable Web SDK

### DIFF
--- a/scripts/build-web.js
+++ b/scripts/build-web.js
@@ -25,34 +25,18 @@ const importmap = {
 
 fs.writeFileSync(path.join(dirname, "..", "dist", "importmap.json"), `${JSON.stringify(importmap, null, 2)}
 `);
-fs.writeFileSync(path.join(dirname, "..", "dist", "importmap.js"), `var ASC_IMPORTMAP = ${JSON.stringify(importmap, null, 2)};
-`);
-fs.writeFileSync(path.join(dirname, "..", "dist", "web.html"), `<script async src="https://cdn.jsdelivr.net/npm/es-module-shims@1/dist/es-module-shims.js"></script>
-<script type="importmap">
-${JSON.stringify(importmap, null, 2)}
-</script>
-<script type="module">
-import asc from "assemblyscript/asc";
-
-const files = {
-  "index.ts": "export function add(a: i32, b: i32): i32 { return a + b; }"
-};
-
-const { error, stdout } = await asc.main([
-  "index.ts", "--textFile", "--optimize"
-], {
-  readFile(name, baseDir) {
-    if (Object.prototype.hasOwnProperty.call(files, name)) return files[name];
-    return null;
-  },
-  writeFile(name, data, baseDir) {
-  },
-  listFiles(dirname, baseDir) {
-    return [];
-  }
-});
-
-if (error) throw error;
-console.log(stdout.toString());
-</script>
+fs.writeFileSync(path.join(dirname, "..", "dist", "web.js"), `var ASSEMBLYSCRIPT_VERSION = ${JSON.stringify(mainVersion)};
+var ASSEMBLYSCRIPT_IMPORTMAP = ${JSON.stringify(importmap, null, 2)};
+if (!document.currentScript.src.includes("noinstall")) {
+  let elem = document.createElement("script");
+  elem.type = "importmap";
+  elem.text = JSON.stringify(ASSEMBLYSCRIPT_IMPORTMAP);
+  document.head.appendChild(elem);
+}
+if (!document.currentScript.src.includes("noshim")) {
+  let elem = document.createElement("script");
+  elem.async = true;
+  elem.src = "https://cdn.jsdelivr.net/npm/es-module-shims@1/dist/es-module-shims.wasm.min.js";
+  document.head.appendChild(elem);
+}
 `);


### PR DESCRIPTION
Using the AssemblyScript compiler on the Web currently requires multiple steps to make it work, which includes manually updating the import map on version bumps and optionally providing a shim for import maps. Instead of providing a workaround by exposing the import map in a script plus longish instructions, this PR changes the mechanism to a single script that sets everything up.

Usage is

```html
<script src="https://cdn.jsdelivr.net/npm/assemblyscript@latest/dist/web.js"></script>
<script type="module">
import asc from "assemblyscript/asc";
...
</script>
```

where `latest` can be any version since the change, and additional query parameters can be used to modify behavior:

* `web.js?noinstall` does not install the import map
* `web.js?noshim` does not install the import map shim
* Both can be combined with a `,`

Regardless of the parameters used, the following global variables are always available:

* `ASSEMBLYSCRIPT_VERSION` containing the current compiler version
* `ASSEMBLYSCRIPT_IMPORTMAP` containing the import map, which includes all relevant versions in the URLs

Removes the `web.html` and `importmap.js` artifacts, with `importmap.json` (for documentation) and `web.js` remaining. Reverts https://github.com/AssemblyScript/assemblyscript/commit/e1a5fce1b4cee28b40d8d52e31854a507b7c2d5a.

- [x] I've read the contributing guidelines
- [x] I've added my name and email to the NOTICE file