### PR TITLE
Diagnose not yet implemented 'in' operator

### DIFF
--- a/src/compiler.ts
+++ b/src/compiler.ts
@@ -4662,6 +4662,14 @@ export class Compiler extends DiagnosticEmitter {
         }
         break;
       }
+      case Token.In: {
+        this.error(
+          DiagnosticCode.Not_implemented_0,
+          expression.range, "'in' operator"
+        );
+        this.currentType = Type.bool;
+        return module.unreachable();
+      }
       default: {
         assert(false);
         expr = this.module.unreachable();

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -4311,7 +4311,8 @@ export class Parser extends DiagnosticEmitter {
         case Token.Bar:
         case Token.Caret:
         case Token.Ampersand_Ampersand:
-        case Token.Bar_Bar: {
+        case Token.Bar_Bar:
+        case Token.In: {
           let next = this.parseExpression(tn, nextPrecedence + 1);
           if (!next) return null;
           expr = Node.createBinaryExpression(token, expr, next, tn.range(startPos, tn.pos));

--- a/src/resolver.ts
+++ b/src/resolver.ts
@@ -2054,6 +2054,12 @@ export class Resolver extends DiagnosticEmitter {
         return Type.bool;
       }
 
+      // in operator
+
+      case Token.In: {
+        return Type.bool;
+      }
+
       // arithmetics: result is common type of LHS and RHS, preferring overloads
 
       case Token.Plus:

--- a/tests/compiler/in.json
+++ b/tests/compiler/in.json
@@ -1,0 +1,6 @@
+{
+  "stderr": [
+    "AS100: Not implemented: 'in' operator", "\"log\" in console",
+    "EOF"
+  ]
+}

--- a/tests/compiler/in.ts
+++ b/tests/compiler/in.ts
@@ -1,0 +1,3 @@
+"log" in console;
+
+ERROR("EOF");


### PR DESCRIPTION
Addresses (only) the assertion seen in #2628, where parsing an unsupported complex type ends up interpreting the input as a yet unsupported `in` operator. Adds the `in` operator as a case of `BinaryExpression` for now that is then diagnosed as AS100 Not implemented.

- [x] I've read the contributing guidelines
- [x] I've added my name and email to the NOTICE file
