### PR TITLE
Handle all possible element kinds when walking exports

### DIFF
--- a/tests/compiler/bindings/esm.ts
+++ b/tests/compiler/bindings/esm.ts
@@ -169,3 +169,10 @@ immutableGlobalNested;
 declare function Date_getTimezoneOffset(): i32;
 
 Date_getTimezoneOffset();
+
+// Not yet instrumented element kinds:
+
+export class ExportedClass {}
+export interface ExportedInterface {}
+export type ExportedType = ExportedClass;
+export namespace ExportedNamespace {}


### PR DESCRIPTION
Fixes #2611 (I suppose), where it was discovered that some possible export kinds are not yet handled when walking exports during bindings generation, most notably exported interfaces.

- [x] I've read the contributing guidelines
- [x] I've added my name and email to the NOTICE file
