### PR TITLE
Detect recursive types early

### DIFF
--- a/src/ast.ts
+++ b/src/ast.ts
@@ -834,6 +834,9 @@ export abstract class TypeNode extends Node {
     super(kind, range);
   }
 
+  /** Whether this type node is currently in the process of being resolved. */
+  currentlyResolving: bool = false;
+
   /** Tests if this type has a generic component matching one of the given type parameters. */
   hasGenericComponent(typeParameterNodes: TypeParameterNode[]): bool {
     if (this.kind == NodeKind.NamedType) {

--- a/tests/compiler/typerecursion.json
+++ b/tests/compiler/typerecursion.json
@@ -1,0 +1,6 @@
+{
+  "stderr": [
+    "AS100: Not implemented: Recursive types",
+    "EOF"
+  ]
+}

--- a/tests/compiler/typerecursion.ts
+++ b/tests/compiler/typerecursion.ts
@@ -1,0 +1,6 @@
+type RecMethod = () => RecReturn;
+type RecReturn = RecMethod | null;
+
+const test: RecMethod = () => null;
+
+ERROR("EOF");

--- a/tests/parser/type.ts.fixture.ts
+++ b/tests/parser/type.ts.fixture.ts
@@ -5,11 +5,11 @@ export type T1 = int32_t;
 export type T2 = int32_t;
 export type T11 = T1 | null;
 export type T12 = T1 | null;
-// ERROR 2456: "Type alias 'T3' circularly references itself." in type.ts(11,23+4)
-// ERROR 100: "Not implemented: Recursion in type aliases" in type.ts(12,29+3)
-// ERROR 100: "Not implemented: Recursion in type aliases" in type.ts(13,24+2)
-// ERROR 100: "Not implemented: Recursion in type aliases" in type.ts(14,31+1)
-// ERROR 100: "Not implemented: Recursion in type aliases" in type.ts(15,26+1)
-// ERROR 100: "Not implemented: Recursion in type aliases" in type.ts(16,39+1)
-// ERROR 100: "Not implemented: Recursion in type aliases" in type.ts(17,32+1)
-// ERROR 100: "Not implemented: Recursion in type aliases" in type.ts(18,25+1)
+// ERROR 2456: "Type alias 'T3' circularly references itself." in type.ts(11,13+2)
+// ERROR 2456: "Type alias 'T4' circularly references itself." in type.ts(12,13+2)
+// ERROR 2456: "Type alias 'T5' circularly references itself." in type.ts(13,13+2)
+// ERROR 2456: "Type alias 'T6' circularly references itself." in type.ts(14,13+2)
+// ERROR 2456: "Type alias 'T7' circularly references itself." in type.ts(15,13+2)
+// ERROR 2456: "Type alias 'T8' circularly references itself." in type.ts(16,13+2)
+// ERROR 2456: "Type alias 'T9' circularly references itself." in type.ts(17,13+2)
+// ERROR 2456: "Type alias 'T10' circularly references itself." in type.ts(18,13+3)


### PR DESCRIPTION
Fixes #2633 by detecting recursive types, that are not supported yet. during resolve. Also touches detection of circular type aliases, which is related, simplifying the code a bit.

- [x] I've read the contributing guidelines
- [x] I've added my name and email to the NOTICE file
