### PR TITLE
fix: update this and return type in child class constructor #2574

### DIFF
--- a/src/compiler.ts
+++ b/src/compiler.ts
@@ -8693,7 +8693,14 @@ export class Compiler extends DiagnosticEmitter {
             (<FunctionDeclaration>baseCtor.declaration).clone()
           ),
           null,
-          baseCtor.signature,
+          Signature.create(
+            this.program,
+            baseCtor.signature.parameterTypes,
+            classInstance.type,
+            classInstance.type,
+            baseCtor.signature.requiredParameters,
+            baseCtor.signature.hasRest
+          ),
           contextualTypeArguments
         );
 

--- a/tests/compiler/constructor.debug.wat
+++ b/tests/compiler/constructor.debug.wat
@@ -36,9 +36,9 @@
  (global $constructor/ctorConditionallyReturnsThis (mut i32) (i32.const 0))
  (global $constructor/ctorFieldInitOrder (mut i32) (i32.const 0))
  (global $~lib/rt/__rtti_base i32 (i32.const 464))
- (global $~lib/memory/__data_end i32 (i32.const 528))
- (global $~lib/memory/__stack_pointer (mut i32) (i32.const 33296))
- (global $~lib/memory/__heap_base i32 (i32.const 33296))
+ (global $~lib/memory/__data_end i32 (i32.const 532))
+ (global $~lib/memory/__stack_pointer (mut i32) (i32.const 33300))
+ (global $~lib/memory/__heap_base i32 (i32.const 33300))
  (memory $0 1)
  (data (i32.const 12) "<\00\00\00\00\00\00\00\00\00\00\00\02\00\00\00(\00\00\00A\00l\00l\00o\00c\00a\00t\00i\00o\00n\00 \00t\00o\00o\00 \00l\00a\00r\00g\00e\00\00\00\00\00")
  (data (i32.const 76) "<\00\00\00\00\00\00\00\00\00\00\00\02\00\00\00 \00\00\00~\00l\00i\00b\00/\00r\00t\00/\00i\00t\00c\00m\00s\00.\00t\00s\00\00\00\00\00\00\00\00\00\00\00\00\00")
@@ -49,7 +49,7 @@
  (data (i32.const 320) "\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00")
  (data (i32.const 348) "<\00\00\00\00\00\00\00\00\00\00\00\02\00\00\00\1e\00\00\00~\00l\00i\00b\00/\00r\00t\00/\00t\00l\00s\00f\00.\00t\00s\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00")
  (data (i32.const 412) ",\00\00\00\00\00\00\00\00\00\00\00\02\00\00\00\1c\00\00\00c\00o\00n\00s\00t\00r\00u\00c\00t\00o\00r\00.\00t\00s\00")
- (data (i32.const 464) "\0f\00\00\00 \00\00\00 \00\00\00 \00\00\00\00\00\00\00 \00\00\00 \00\00\00 \00\00\00 \00\00\00 \00\00\00 \00\00\00 \00\00\00 \00\00\00 \00\00\00 \00\00\00 \00\00\00")
+ (data (i32.const 464) "\10\00\00\00 \00\00\00 \00\00\00 \00\00\00\00\00\00\00 \00\00\00 \00\00\00 \00\00\00 \00\00\00 \00\00\00 \00\00\00 \00\00\00 \00\00\00 \00\00\00 \00\00\00 \00\00\00 \00\00\00")
  (table $0 1 1 funcref)
  (elem $0 (i32.const 1))
  (export "memory" (memory $0))
@@ -2276,6 +2276,24 @@
   i32.const 0
   return
  )
+ (func $constructor/CtorFieldInitWithoutConstrucotr#set:a (param $this i32) (param $a i32)
+  local.get $this
+  local.get $a
+  i32.store $0
+ )
+ (func $constructor/CtorFieldInitWithoutConstrucotr#get:a (param $this i32) (result i32)
+  local.get $this
+  i32.load $0
+ )
+ (func $constructor/CtorFieldInitWithoutConstrucotr#set:b (param $this i32) (param $b i32)
+  local.get $this
+  local.get $b
+  i32.store $0 offset=4
+ )
+ (func $constructor/CtorFieldInitWithoutConstrucotr#get:b (param $this i32) (result i32)
+  local.get $this
+  i32.load $0 offset=4
+ )
  (func $constructor/CtorFieldInitOrder#get:a (param $this i32) (result i32)
   local.get $this
   i32.load $0 offset=4
@@ -2409,35 +2427,38 @@
  (func $~lib/rt/__visit_members (param $0 i32) (param $1 i32)
   block $invalid
    block $constructor/CtorFieldInitOrder
-    block $constructor/CtorConditionallyReturnsThis
-     block $constructor/CtorConditionallyReturns
-      block $constructor/CtorReturns
-       block $constructor/JustFieldNoInit
-        block $constructor/JustFieldInit
-         block $constructor/None
-          block $constructor/EmptyCtorWithFieldAccess
-           block $constructor/EmptyCtorWithFieldNoInit
-            block $constructor/EmptyCtorWithFieldInit
-             block $constructor/EmptyCtor
-              block $~lib/arraybuffer/ArrayBufferView
-               block $~lib/string/String
-                block $~lib/arraybuffer/ArrayBuffer
-                 block $~lib/object/Object
-                  local.get $0
-                  i32.const 8
-                  i32.sub
-                  i32.load $0
-                  br_table $~lib/object/Object $~lib/arraybuffer/ArrayBuffer $~lib/string/String $~lib/arraybuffer/ArrayBufferView $constructor/EmptyCtor $constructor/EmptyCtorWithFieldInit $constructor/EmptyCtorWithFieldNoInit $constructor/EmptyCtorWithFieldAccess $constructor/None $constructor/JustFieldInit $constructor/JustFieldNoInit $constructor/CtorReturns $constructor/CtorConditionallyReturns $constructor/CtorConditionallyReturnsThis $constructor/CtorFieldInitOrder $invalid
+    block $constructor/CtorFieldInitWithoutConstrucotr
+     block $constructor/CtorConditionallyReturnsThis
+      block $constructor/CtorConditionallyReturns
+       block $constructor/CtorReturns
+        block $constructor/JustFieldNoInit
+         block $constructor/JustFieldInit
+          block $constructor/None
+           block $constructor/EmptyCtorWithFieldAccess
+            block $constructor/EmptyCtorWithFieldNoInit
+             block $constructor/EmptyCtorWithFieldInit
+              block $constructor/EmptyCtor
+               block $~lib/arraybuffer/ArrayBufferView
+                block $~lib/string/String
+                 block $~lib/arraybuffer/ArrayBuffer
+                  block $~lib/object/Object
+                   local.get $0
+                   i32.const 8
+                   i32.sub
+                   i32.load $0
+                   br_table $~lib/object/Object $~lib/arraybuffer/ArrayBuffer $~lib/string/String $~lib/arraybuffer/ArrayBufferView $constructor/EmptyCtor $constructor/EmptyCtorWithFieldInit $constructor/EmptyCtorWithFieldNoInit $constructor/EmptyCtorWithFieldAccess $constructor/None $constructor/JustFieldInit $constructor/JustFieldNoInit $constructor/CtorReturns $constructor/CtorConditionallyReturns $constructor/CtorConditionallyReturnsThis $constructor/CtorFieldInitWithoutConstrucotr $constructor/CtorFieldInitOrder $invalid
+                  end
+                  return
                  end
                  return
                 end
                 return
                end
+               local.get $0
+               local.get $1
+               call $~lib/arraybuffer/ArrayBufferView~visit
                return
               end
-              local.get $0
-              local.get $1
-              call $~lib/arraybuffer/ArrayBufferView~visit
               return
              end
              return
@@ -2726,6 +2747,69 @@
   global.set $~lib/memory/__stack_pointer
   local.get $1
  )
+ (func $constructor/CtorFieldInitWithoutConstrucotr#constructor (param $this i32) (result i32)
+  (local $1 i32)
+  global.get $~lib/memory/__stack_pointer
+  i32.const 12
+  i32.sub
+  global.set $~lib/memory/__stack_pointer
+  call $~stack_check
+  global.get $~lib/memory/__stack_pointer
+  i64.const 0
+  i64.store $0
+  global.get $~lib/memory/__stack_pointer
+  i32.const 0
+  i32.store $0 offset=8
+  local.get $this
+  i32.eqz
+  if
+   global.get $~lib/memory/__stack_pointer
+   i32.const 8
+   i32.const 14
+   call $~lib/rt/itcms/__new
+   local.tee $this
+   i32.store $0
+  end
+  global.get $~lib/memory/__stack_pointer
+  local.get $this
+  local.set $1
+  global.get $~lib/memory/__stack_pointer
+  local.get $1
+  i32.store $0 offset=4
+  local.get $1
+  call $~lib/object/Object#constructor
+  local.tee $this
+  i32.store $0
+  local.get $this
+  local.set $1
+  global.get $~lib/memory/__stack_pointer
+  local.get $1
+  i32.store $0 offset=4
+  local.get $1
+  i32.const 10
+  call $constructor/CtorFieldInitWithoutConstrucotr#set:a
+  local.get $this
+  local.set $1
+  global.get $~lib/memory/__stack_pointer
+  local.get $1
+  i32.store $0 offset=4
+  local.get $1
+  local.get $this
+  local.set $1
+  global.get $~lib/memory/__stack_pointer
+  local.get $1
+  i32.store $0 offset=8
+  local.get $1
+  call $constructor/CtorFieldInitWithoutConstrucotr#get:a
+  call $constructor/CtorFieldInitWithoutConstrucotr#set:b
+  local.get $this
+  local.set $1
+  global.get $~lib/memory/__stack_pointer
+  i32.const 12
+  i32.add
+  global.set $~lib/memory/__stack_pointer
+  local.get $1
+ )
  (func $constructor/CtorFieldInitOrder#constructor (param $this i32) (param $a i32) (param $b i32) (result i32)
   (local $3 i32)
   global.get $~lib/memory/__stack_pointer
@@ -2744,7 +2828,7 @@
   if
    global.get $~lib/memory/__stack_pointer
    i32.const 12
-   i32.const 14
+   i32.const 15
    call $~lib/rt/itcms/__new
    local.tee $this
    i32.store $0
@@ -2794,7 +2878,7 @@
   if
    i32.const 0
    i32.const 432
-   i32.const 93
+   i32.const 101
    i32.const 5
    call $~lib/builtins/abort
    unreachable
@@ -2812,7 +2896,7 @@
   if
    i32.const 0
    i32.const 432
-   i32.const 94
+   i32.const 102
    i32.const 5
    call $~lib/builtins/abort
    unreachable
@@ -2824,7 +2908,7 @@
   if
    i32.const 0
    i32.const 432
-   i32.const 95
+   i32.const 103
    i32.const 5
    call $~lib/builtins/abort
    unreachable
@@ -2842,7 +2926,7 @@
   if
    i32.const 0
    i32.const 432
-   i32.const 96
+   i32.const 104
    i32.const 5
    call $~lib/builtins/abort
    unreachable
@@ -2860,7 +2944,7 @@
   if
    i32.const 0
    i32.const 432
-   i32.const 97
+   i32.const 105
    i32.const 5
    call $~lib/builtins/abort
    unreachable
@@ -2931,6 +3015,44 @@
   call $constructor/CtorConditionallyReturnsThis#constructor
   global.set $constructor/ctorConditionallyReturnsThis
   i32.const 0
+  call $constructor/CtorFieldInitWithoutConstrucotr#constructor
+  local.set $0
+  global.get $~lib/memory/__stack_pointer
+  local.get $0
+  i32.store $0
+  local.get $0
+  call $constructor/CtorFieldInitWithoutConstrucotr#get:a
+  i32.const 10
+  i32.eq
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 432
+   i32.const 94
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  i32.const 0
+  call $constructor/CtorFieldInitWithoutConstrucotr#constructor
+  local.set $0
+  global.get $~lib/memory/__stack_pointer
+  local.get $0
+  i32.store $0
+  local.get $0
+  call $constructor/CtorFieldInitWithoutConstrucotr#get:b
+  i32.const 10
+  i32.eq
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 432
+   i32.const 95
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  i32.const 0
   i32.const 1
   i32.const 2
   call $constructor/CtorFieldInitOrder#constructor
@@ -2948,7 +3070,7 @@
   if
    i32.const 0
    i32.const 432
-   i32.const 102
+   i32.const 110
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -2966,7 +3088,7 @@
   if
    i32.const 0
    i32.const 432
-   i32.const 103
+   i32.const 111
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -2984,7 +3106,7 @@
   if
    i32.const 0
    i32.const 432
-   i32.const 104
+   i32.const 112
    i32.const 1
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/constructor.debug.wat
+++ b/tests/compiler/constructor.debug.wat
@@ -2276,21 +2276,21 @@
   i32.const 0
   return
  )
- (func $constructor/CtorFieldInitWithoutConstrucotr#set:a (param $this i32) (param $a i32)
+ (func $constructor/CtorFieldInitWithoutConstructor#set:a (param $this i32) (param $a i32)
   local.get $this
   local.get $a
   i32.store $0
  )
- (func $constructor/CtorFieldInitWithoutConstrucotr#get:a (param $this i32) (result i32)
+ (func $constructor/CtorFieldInitWithoutConstructor#get:a (param $this i32) (result i32)
   local.get $this
   i32.load $0
  )
- (func $constructor/CtorFieldInitWithoutConstrucotr#set:b (param $this i32) (param $b i32)
+ (func $constructor/CtorFieldInitWithoutConstructor#set:b (param $this i32) (param $b i32)
   local.get $this
   local.get $b
   i32.store $0 offset=4
  )
- (func $constructor/CtorFieldInitWithoutConstrucotr#get:b (param $this i32) (result i32)
+ (func $constructor/CtorFieldInitWithoutConstructor#get:b (param $this i32) (result i32)
   local.get $this
   i32.load $0 offset=4
  )
@@ -2427,7 +2427,7 @@
  (func $~lib/rt/__visit_members (param $0 i32) (param $1 i32)
   block $invalid
    block $constructor/CtorFieldInitOrder
-    block $constructor/CtorFieldInitWithoutConstrucotr
+    block $constructor/CtorFieldInitWithoutConstructor
      block $constructor/CtorConditionallyReturnsThis
       block $constructor/CtorConditionallyReturns
        block $constructor/CtorReturns
@@ -2446,7 +2446,7 @@
                    i32.const 8
                    i32.sub
                    i32.load $0
-                   br_table $~lib/object/Object $~lib/arraybuffer/ArrayBuffer $~lib/string/String $~lib/arraybuffer/ArrayBufferView $constructor/EmptyCtor $constructor/EmptyCtorWithFieldInit $constructor/EmptyCtorWithFieldNoInit $constructor/EmptyCtorWithFieldAccess $constructor/None $constructor/JustFieldInit $constructor/JustFieldNoInit $constructor/CtorReturns $constructor/CtorConditionallyReturns $constructor/CtorConditionallyReturnsThis $constructor/CtorFieldInitWithoutConstrucotr $constructor/CtorFieldInitOrder $invalid
+                   br_table $~lib/object/Object $~lib/arraybuffer/ArrayBuffer $~lib/string/String $~lib/arraybuffer/ArrayBufferView $constructor/EmptyCtor $constructor/EmptyCtorWithFieldInit $constructor/EmptyCtorWithFieldNoInit $constructor/EmptyCtorWithFieldAccess $constructor/None $constructor/JustFieldInit $constructor/JustFieldNoInit $constructor/CtorReturns $constructor/CtorConditionallyReturns $constructor/CtorConditionallyReturnsThis $constructor/CtorFieldInitWithoutConstructor $constructor/CtorFieldInitOrder $invalid
                   end
                   return
                  end
@@ -2747,7 +2747,7 @@
   global.set $~lib/memory/__stack_pointer
   local.get $1
  )
- (func $constructor/CtorFieldInitWithoutConstrucotr#constructor (param $this i32) (result i32)
+ (func $constructor/CtorFieldInitWithoutConstructor#constructor (param $this i32) (result i32)
   (local $1 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 12
@@ -2787,7 +2787,7 @@
   i32.store $0 offset=4
   local.get $1
   i32.const 10
-  call $constructor/CtorFieldInitWithoutConstrucotr#set:a
+  call $constructor/CtorFieldInitWithoutConstructor#set:a
   local.get $this
   local.set $1
   global.get $~lib/memory/__stack_pointer
@@ -2800,8 +2800,8 @@
   local.get $1
   i32.store $0 offset=8
   local.get $1
-  call $constructor/CtorFieldInitWithoutConstrucotr#get:a
-  call $constructor/CtorFieldInitWithoutConstrucotr#set:b
+  call $constructor/CtorFieldInitWithoutConstructor#get:a
+  call $constructor/CtorFieldInitWithoutConstructor#set:b
   local.get $this
   local.set $1
   global.get $~lib/memory/__stack_pointer
@@ -3015,13 +3015,13 @@
   call $constructor/CtorConditionallyReturnsThis#constructor
   global.set $constructor/ctorConditionallyReturnsThis
   i32.const 0
-  call $constructor/CtorFieldInitWithoutConstrucotr#constructor
+  call $constructor/CtorFieldInitWithoutConstructor#constructor
   local.set $0
   global.get $~lib/memory/__stack_pointer
   local.get $0
   i32.store $0
   local.get $0
-  call $constructor/CtorFieldInitWithoutConstrucotr#get:a
+  call $constructor/CtorFieldInitWithoutConstructor#get:a
   i32.const 10
   i32.eq
   i32.eqz
@@ -3034,13 +3034,13 @@
    unreachable
   end
   i32.const 0
-  call $constructor/CtorFieldInitWithoutConstrucotr#constructor
+  call $constructor/CtorFieldInitWithoutConstructor#constructor
   local.set $0
   global.get $~lib/memory/__stack_pointer
   local.get $0
   i32.store $0
   local.get $0
-  call $constructor/CtorFieldInitWithoutConstrucotr#get:b
+  call $constructor/CtorFieldInitWithoutConstructor#get:b
   i32.const 10
   i32.eq
   i32.eqz

--- a/tests/compiler/constructor.release.wat
+++ b/tests/compiler/constructor.release.wat
@@ -2,10 +2,10 @@
  (type $none_=>_none (func))
  (type $i32_=>_none (func (param i32)))
  (type $i32_i32_=>_none (func (param i32 i32)))
+ (type $none_=>_i32 (func (result i32)))
  (type $i32_i32_=>_i32 (func (param i32 i32) (result i32)))
  (type $i32_i32_i32_i32_=>_none (func (param i32 i32 i32 i32)))
  (type $i32_i32_i32_=>_none (func (param i32 i32 i32)))
- (type $none_=>_i32 (func (result i32)))
  (type $i32_=>_i32 (func (param i32) (result i32)))
  (import "env" "abort" (func $~lib/builtins/abort (param i32 i32 i32 i32)))
  (global $~lib/rt/itcms/total (mut i32) (i32.const 0))
@@ -27,7 +27,7 @@
  (global $constructor/justFieldNoInit (mut i32) (i32.const 0))
  (global $constructor/ctorConditionallyReturnsThis (mut i32) (i32.const 0))
  (global $constructor/ctorFieldInitOrder (mut i32) (i32.const 0))
- (global $~lib/memory/__stack_pointer (mut i32) (i32.const 34320))
+ (global $~lib/memory/__stack_pointer (mut i32) (i32.const 34324))
  (memory $0 1)
  (data (i32.const 1036) "<")
  (data (i32.const 1048) "\02\00\00\00(\00\00\00A\00l\00l\00o\00c\00a\00t\00i\00o\00n\00 \00t\00o\00o\00 \00l\00a\00r\00g\00e")
@@ -41,7 +41,7 @@
  (data (i32.const 1384) "\02\00\00\00\1e\00\00\00~\00l\00i\00b\00/\00r\00t\00/\00t\00l\00s\00f\00.\00t\00s")
  (data (i32.const 1436) ",")
  (data (i32.const 1448) "\02\00\00\00\1c\00\00\00c\00o\00n\00s\00t\00r\00u\00c\00t\00o\00r\00.\00t\00s")
- (data (i32.const 1488) "\0f\00\00\00 \00\00\00 \00\00\00 \00\00\00\00\00\00\00 \00\00\00 \00\00\00 \00\00\00 \00\00\00 \00\00\00 \00\00\00 \00\00\00 \00\00\00 \00\00\00 \00\00\00 ")
+ (data (i32.const 1488) "\10\00\00\00 \00\00\00 \00\00\00 \00\00\00\00\00\00\00 \00\00\00 \00\00\00 \00\00\00 \00\00\00 \00\00\00 \00\00\00 \00\00\00 \00\00\00 \00\00\00 \00\00\00 \00\00\00 ")
  (export "memory" (memory $0))
  (start $~start)
  (func $~lib/rt/itcms/visitRoots
@@ -178,7 +178,7 @@
     i32.load $0 offset=8
     i32.eqz
     local.get $0
-    i32.const 34320
+    i32.const 34324
     i32.lt_u
     i32.and
     i32.eqz
@@ -806,10 +806,10 @@
   if
    unreachable
   end
-  i32.const 34320
+  i32.const 34336
   i32.const 0
   i32.store $0
-  i32.const 35888
+  i32.const 35904
   i32.const 0
   i32.store $0
   loop $for-loop|0
@@ -820,7 +820,7 @@
     local.get $0
     i32.const 2
     i32.shl
-    i32.const 34320
+    i32.const 34336
     i32.add
     i32.const 0
     i32.store $0 offset=4
@@ -838,7 +838,7 @@
       i32.add
       i32.const 2
       i32.shl
-      i32.const 34320
+      i32.const 34336
       i32.add
       i32.const 0
       i32.store $0 offset=96
@@ -856,13 +856,13 @@
     br $for-loop|0
    end
   end
-  i32.const 34320
-  i32.const 35892
+  i32.const 34336
+  i32.const 35908
   memory.size $0
   i32.const 16
   i32.shl
   call $~lib/rt/tlsf/addMemory
-  i32.const 34320
+  i32.const 34336
   global.set $~lib/rt/tlsf/ROOT
  )
  (func $~lib/rt/itcms/step (result i32)
@@ -947,7 +947,7 @@
      local.set $0
      loop $while-continue|0
       local.get $0
-      i32.const 34320
+      i32.const 34324
       i32.lt_u
       if
        local.get $0
@@ -1047,7 +1047,7 @@
      unreachable
     end
     local.get $0
-    i32.const 34320
+    i32.const 34324
     i32.lt_u
     if
      local.get $0
@@ -1070,7 +1070,7 @@
      i32.const 4
      i32.add
      local.tee $0
-     i32.const 34320
+     i32.const 34324
      i32.ge_u
      if
       global.get $~lib/rt/tlsf/ROOT
@@ -1567,38 +1567,41 @@
  (func $~lib/rt/__visit_members (param $0 i32)
   block $invalid
    block $constructor/CtorFieldInitOrder
-    block $constructor/CtorConditionallyReturnsThis
-     block $constructor/CtorConditionallyReturns
-      block $constructor/CtorReturns
-       block $constructor/JustFieldNoInit
-        block $constructor/JustFieldInit
-         block $constructor/None
-          block $constructor/EmptyCtorWithFieldAccess
-           block $constructor/EmptyCtorWithFieldNoInit
-            block $constructor/EmptyCtorWithFieldInit
-             block $constructor/EmptyCtor
-              block $~lib/arraybuffer/ArrayBufferView
-               block $~lib/string/String
-                block $~lib/arraybuffer/ArrayBuffer
-                 block $~lib/object/Object
-                  local.get $0
-                  i32.const 8
-                  i32.sub
-                  i32.load $0
-                  br_table $~lib/object/Object $~lib/arraybuffer/ArrayBuffer $~lib/string/String $~lib/arraybuffer/ArrayBufferView $constructor/EmptyCtor $constructor/EmptyCtorWithFieldInit $constructor/EmptyCtorWithFieldNoInit $constructor/EmptyCtorWithFieldAccess $constructor/None $constructor/JustFieldInit $constructor/JustFieldNoInit $constructor/CtorReturns $constructor/CtorConditionallyReturns $constructor/CtorConditionallyReturnsThis $constructor/CtorFieldInitOrder $invalid
+    block $constructor/CtorFieldInitWithoutConstrucotr
+     block $constructor/CtorConditionallyReturnsThis
+      block $constructor/CtorConditionallyReturns
+       block $constructor/CtorReturns
+        block $constructor/JustFieldNoInit
+         block $constructor/JustFieldInit
+          block $constructor/None
+           block $constructor/EmptyCtorWithFieldAccess
+            block $constructor/EmptyCtorWithFieldNoInit
+             block $constructor/EmptyCtorWithFieldInit
+              block $constructor/EmptyCtor
+               block $~lib/arraybuffer/ArrayBufferView
+                block $~lib/string/String
+                 block $~lib/arraybuffer/ArrayBuffer
+                  block $~lib/object/Object
+                   local.get $0
+                   i32.const 8
+                   i32.sub
+                   i32.load $0
+                   br_table $~lib/object/Object $~lib/arraybuffer/ArrayBuffer $~lib/string/String $~lib/arraybuffer/ArrayBufferView $constructor/EmptyCtor $constructor/EmptyCtorWithFieldInit $constructor/EmptyCtorWithFieldNoInit $constructor/EmptyCtorWithFieldAccess $constructor/None $constructor/JustFieldInit $constructor/JustFieldNoInit $constructor/CtorReturns $constructor/CtorConditionallyReturns $constructor/CtorConditionallyReturnsThis $constructor/CtorFieldInitWithoutConstrucotr $constructor/CtorFieldInitOrder $invalid
+                  end
+                  return
                  end
                  return
                 end
                 return
                end
-               return
-              end
-              local.get $0
-              i32.load $0
-              local.tee $0
-              if
                local.get $0
-               call $byn-split-outlined-A$~lib/rt/itcms/__visit
+               i32.load $0
+               local.tee $0
+               if
+                local.get $0
+                call $byn-split-outlined-A$~lib/rt/itcms/__visit
+               end
+               return
               end
               return
              end
@@ -1636,7 +1639,7 @@
   global.set $~lib/memory/__stack_pointer
   block $folding-inner1
    global.get $~lib/memory/__stack_pointer
-   i32.const 1552
+   i32.const 1556
    i32.lt_s
    br_if $folding-inner1
    global.get $~lib/memory/__stack_pointer
@@ -1646,7 +1649,7 @@
    memory.size $0
    i32.const 16
    i32.shl
-   i32.const 34320
+   i32.const 34324
    i32.sub
    i32.const 1
    i32.shr_u
@@ -1680,7 +1683,7 @@
    i32.sub
    global.set $~lib/memory/__stack_pointer
    global.get $~lib/memory/__stack_pointer
-   i32.const 1552
+   i32.const 1556
    i32.lt_s
    br_if $folding-inner1
    global.get $~lib/memory/__stack_pointer
@@ -1704,7 +1707,7 @@
    i32.sub
    global.set $~lib/memory/__stack_pointer
    global.get $~lib/memory/__stack_pointer
-   i32.const 1552
+   i32.const 1556
    i32.lt_s
    br_if $folding-inner1
    global.get $~lib/memory/__stack_pointer
@@ -1735,7 +1738,7 @@
    i32.sub
    global.set $~lib/memory/__stack_pointer
    global.get $~lib/memory/__stack_pointer
-   i32.const 1552
+   i32.const 1556
    i32.lt_s
    br_if $folding-inner1
    global.get $~lib/memory/__stack_pointer
@@ -1766,7 +1769,7 @@
    i32.sub
    global.set $~lib/memory/__stack_pointer
    global.get $~lib/memory/__stack_pointer
-   i32.const 1552
+   i32.const 1556
    i32.lt_s
    br_if $folding-inner1
    global.get $~lib/memory/__stack_pointer
@@ -1803,7 +1806,7 @@
    i32.sub
    global.set $~lib/memory/__stack_pointer
    global.get $~lib/memory/__stack_pointer
-   i32.const 1552
+   i32.const 1556
    i32.lt_s
    br_if $folding-inner1
    global.get $~lib/memory/__stack_pointer
@@ -1836,7 +1839,7 @@
    i32.sub
    global.set $~lib/memory/__stack_pointer
    global.get $~lib/memory/__stack_pointer
-   i32.const 1552
+   i32.const 1556
    i32.lt_s
    br_if $folding-inner1
    global.get $~lib/memory/__stack_pointer
@@ -1875,7 +1878,7 @@
    i32.sub
    global.set $~lib/memory/__stack_pointer
    global.get $~lib/memory/__stack_pointer
-   i32.const 1552
+   i32.const 1556
    i32.lt_s
    br_if $folding-inner1
    global.get $~lib/memory/__stack_pointer
@@ -1914,7 +1917,7 @@
    i32.sub
    global.set $~lib/memory/__stack_pointer
    global.get $~lib/memory/__stack_pointer
-   i32.const 1552
+   i32.const 1556
    i32.lt_s
    br_if $folding-inner1
    global.get $~lib/memory/__stack_pointer
@@ -1935,7 +1938,7 @@
    i32.sub
    global.set $~lib/memory/__stack_pointer
    global.get $~lib/memory/__stack_pointer
-   i32.const 1552
+   i32.const 1556
    i32.lt_s
    br_if $folding-inner1
    global.get $~lib/memory/__stack_pointer
@@ -1954,12 +1957,46 @@
    global.set $~lib/memory/__stack_pointer
    local.get $0
    global.set $constructor/ctorConditionallyReturnsThis
+   call $constructor/CtorFieldInitWithoutConstrucotr#constructor
+   local.set $0
+   global.get $~lib/memory/__stack_pointer
+   local.get $0
+   i32.store $0
+   local.get $0
+   i32.load $0
+   i32.const 10
+   i32.ne
+   if
+    i32.const 0
+    i32.const 1456
+    i32.const 94
+    i32.const 1
+    call $~lib/builtins/abort
+    unreachable
+   end
+   call $constructor/CtorFieldInitWithoutConstrucotr#constructor
+   local.set $0
+   global.get $~lib/memory/__stack_pointer
+   local.get $0
+   i32.store $0
+   local.get $0
+   i32.load $0 offset=4
+   i32.const 10
+   i32.ne
+   if
+    i32.const 0
+    i32.const 1456
+    i32.const 95
+    i32.const 1
+    call $~lib/builtins/abort
+    unreachable
+   end
    global.get $~lib/memory/__stack_pointer
    i32.const 12
    i32.sub
    global.set $~lib/memory/__stack_pointer
    global.get $~lib/memory/__stack_pointer
-   i32.const 1552
+   i32.const 1556
    i32.lt_s
    br_if $folding-inner1
    global.get $~lib/memory/__stack_pointer
@@ -1971,7 +2008,7 @@
    i32.store $0 offset=8
    local.get $0
    i32.const 12
-   i32.const 14
+   i32.const 15
    call $~lib/rt/itcms/__new
    local.tee $1
    i32.store $0
@@ -2016,7 +2053,7 @@
    if
     i32.const 0
     i32.const 1456
-    i32.const 94
+    i32.const 102
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -2031,7 +2068,7 @@
    if
     i32.const 0
     i32.const 1456
-    i32.const 96
+    i32.const 104
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -2046,7 +2083,7 @@
    if
     i32.const 0
     i32.const 1456
-    i32.const 97
+    i32.const 105
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -2068,7 +2105,7 @@
    if
     i32.const 0
     i32.const 1456
-    i32.const 102
+    i32.const 110
     i32.const 1
     call $~lib/builtins/abort
     unreachable
@@ -2084,7 +2121,7 @@
    if
     i32.const 0
     i32.const 1456
-    i32.const 103
+    i32.const 111
     i32.const 1
     call $~lib/builtins/abort
     unreachable
@@ -2100,7 +2137,7 @@
    if
     i32.const 0
     i32.const 1456
-    i32.const 104
+    i32.const 112
     i32.const 1
     call $~lib/builtins/abort
     unreachable
@@ -2118,13 +2155,75 @@
   call $~lib/builtins/abort
   unreachable
  )
+ (func $constructor/CtorFieldInitWithoutConstrucotr#constructor (result i32)
+  (local $0 i32)
+  (local $1 i32)
+  global.get $~lib/memory/__stack_pointer
+  i32.const 12
+  i32.sub
+  global.set $~lib/memory/__stack_pointer
+  global.get $~lib/memory/__stack_pointer
+  i32.const 1556
+  i32.lt_s
+  if
+   i32.const 34352
+   i32.const 34400
+   i32.const 1
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  global.get $~lib/memory/__stack_pointer
+  local.tee $0
+  i64.const 0
+  i64.store $0
+  local.get $0
+  i32.const 0
+  i32.store $0 offset=8
+  local.get $0
+  i32.const 8
+  i32.const 14
+  call $~lib/rt/itcms/__new
+  local.tee $0
+  i32.store $0
+  global.get $~lib/memory/__stack_pointer
+  local.tee $1
+  local.get $0
+  i32.store $0 offset=4
+  local.get $1
+  local.get $0
+  call $~lib/object/Object#constructor
+  local.tee $0
+  i32.store $0
+  global.get $~lib/memory/__stack_pointer
+  local.get $0
+  i32.store $0 offset=4
+  local.get $0
+  i32.const 10
+  i32.store $0
+  global.get $~lib/memory/__stack_pointer
+  local.get $0
+  i32.store $0 offset=4
+  global.get $~lib/memory/__stack_pointer
+  local.get $0
+  i32.store $0 offset=8
+  local.get $0
+  local.get $0
+  i32.load $0
+  i32.store $0 offset=4
+  global.get $~lib/memory/__stack_pointer
+  i32.const 12
+  i32.add
+  global.set $~lib/memory/__stack_pointer
+  local.get $0
+ )
  (func $~lib/object/Object#constructor (param $0 i32) (result i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 4
   i32.sub
   global.set $~lib/memory/__stack_pointer
   global.get $~lib/memory/__stack_pointer
-  i32.const 1552
+  i32.const 1556
   i32.lt_s
   if
    i32.const 34352

--- a/tests/compiler/constructor.release.wat
+++ b/tests/compiler/constructor.release.wat
@@ -1567,7 +1567,7 @@
  (func $~lib/rt/__visit_members (param $0 i32)
   block $invalid
    block $constructor/CtorFieldInitOrder
-    block $constructor/CtorFieldInitWithoutConstrucotr
+    block $constructor/CtorFieldInitWithoutConstructor
      block $constructor/CtorConditionallyReturnsThis
       block $constructor/CtorConditionallyReturns
        block $constructor/CtorReturns
@@ -1586,7 +1586,7 @@
                    i32.const 8
                    i32.sub
                    i32.load $0
-                   br_table $~lib/object/Object $~lib/arraybuffer/ArrayBuffer $~lib/string/String $~lib/arraybuffer/ArrayBufferView $constructor/EmptyCtor $constructor/EmptyCtorWithFieldInit $constructor/EmptyCtorWithFieldNoInit $constructor/EmptyCtorWithFieldAccess $constructor/None $constructor/JustFieldInit $constructor/JustFieldNoInit $constructor/CtorReturns $constructor/CtorConditionallyReturns $constructor/CtorConditionallyReturnsThis $constructor/CtorFieldInitWithoutConstrucotr $constructor/CtorFieldInitOrder $invalid
+                   br_table $~lib/object/Object $~lib/arraybuffer/ArrayBuffer $~lib/string/String $~lib/arraybuffer/ArrayBufferView $constructor/EmptyCtor $constructor/EmptyCtorWithFieldInit $constructor/EmptyCtorWithFieldNoInit $constructor/EmptyCtorWithFieldAccess $constructor/None $constructor/JustFieldInit $constructor/JustFieldNoInit $constructor/CtorReturns $constructor/CtorConditionallyReturns $constructor/CtorConditionallyReturnsThis $constructor/CtorFieldInitWithoutConstructor $constructor/CtorFieldInitOrder $invalid
                   end
                   return
                  end
@@ -1957,7 +1957,7 @@
    global.set $~lib/memory/__stack_pointer
    local.get $0
    global.set $constructor/ctorConditionallyReturnsThis
-   call $constructor/CtorFieldInitWithoutConstrucotr#constructor
+   call $constructor/CtorFieldInitWithoutConstructor#constructor
    local.set $0
    global.get $~lib/memory/__stack_pointer
    local.get $0
@@ -1974,7 +1974,7 @@
     call $~lib/builtins/abort
     unreachable
    end
-   call $constructor/CtorFieldInitWithoutConstrucotr#constructor
+   call $constructor/CtorFieldInitWithoutConstructor#constructor
    local.set $0
    global.get $~lib/memory/__stack_pointer
    local.get $0
@@ -2155,7 +2155,7 @@
   call $~lib/builtins/abort
   unreachable
  )
- (func $constructor/CtorFieldInitWithoutConstrucotr#constructor (result i32)
+ (func $constructor/CtorFieldInitWithoutConstructor#constructor (result i32)
   (local $0 i32)
   (local $1 i32)
   global.get $~lib/memory/__stack_pointer

--- a/tests/compiler/constructor.ts
+++ b/tests/compiler/constructor.ts
@@ -87,6 +87,14 @@ class CtorConditionallyReturnsThis {
 
 var ctorConditionallyReturnsThis = new CtorConditionallyReturnsThis();
 
+class CtorFieldInitWithoutConstrucotr {
+  a: i32 = 10;
+  b: i32 = this.a;
+}
+assert(new CtorFieldInitWithoutConstrucotr().a == 10);
+assert(new CtorFieldInitWithoutConstrucotr().b == 10);
+
+
 class CtorFieldInitOrder {
   c: i32 = this.a + this.b;
   constructor(public a: i32, public b: i32 = 2) {

--- a/tests/compiler/constructor.ts
+++ b/tests/compiler/constructor.ts
@@ -87,12 +87,12 @@ class CtorConditionallyReturnsThis {
 
 var ctorConditionallyReturnsThis = new CtorConditionallyReturnsThis();
 
-class CtorFieldInitWithoutConstrucotr {
+class CtorFieldInitWithoutConstructor {
   a: i32 = 10;
   b: i32 = this.a;
 }
-assert(new CtorFieldInitWithoutConstrucotr().a == 10);
-assert(new CtorFieldInitWithoutConstrucotr().b == 10);
+assert(new CtorFieldInitWithoutConstructor().a == 10);
+assert(new CtorFieldInitWithoutConstructor().b == 10);
 
 
 class CtorFieldInitOrder {


### PR DESCRIPTION
When use parent constructor as child default constructor, function signature should update `thisType` and `returnType` instead of directly using parent constructor
