### PR TITLE
Check that builtins are implemented

### DIFF
--- a/src/builtins.ts
+++ b/src/builtins.ts
@@ -42,7 +42,8 @@ import {
   CallExpression,
   NodeKind,
   LiteralExpression,
-  ArrayLiteralExpression
+  ArrayLiteralExpression,
+  IdentifierExpression
 } from "./ast";
 
 import {
@@ -83,7 +84,8 @@ import {
   Global,
   DecoratorFlags,
   Class,
-  PropertyPrototype
+  PropertyPrototype,
+  VariableLikeElement
 } from "./program";
 
 import {
@@ -363,8 +365,8 @@ export namespace BuiltinNames {
   export const i64_atomic_rmw16_cmpxchg_u = "~lib/builtins/i64.atomic.rmw16.cmpxchg_u";
   export const i64_atomic_rmw32_cmpxchg_u = "~lib/builtins/i64.atomic.rmw32.cmpxchg_u";
   export const i64_atomic_rmw_cmpxchg = "~lib/builtins/i64.atomic.rmw.cmpxchg";
-  export const i32_wait = "~lib/builtins/i32.wait";
-  export const i64_wait = "~lib/builtins/i64.wait";
+  export const memory_atomic_wait32 = "~lib/memory/memory.atomic.wait32";
+  export const memory_atomic_wait64 = "~lib/memory/memory.atomic.wait64";
 
   export const v128_splat = "~lib/builtins/v128.splat";
   export const v128_extract_lane = "~lib/builtins/v128.extract_lane";
@@ -696,6 +698,8 @@ export namespace BuiltinNames {
   export const tostack = "~lib/rt/__tostack";
 
   // std/number.ts
+  export const NaN = "~lib/number/NaN";
+  export const Infinity = "~lib/number/Infinity";
   export const isNaN = "~lib/number/isNaN";
   export const isFinite = "~lib/number/isFinite";
 
@@ -706,6 +710,7 @@ export namespace BuiltinNames {
 
   // std/function.ts
   export const Function = "~lib/function/Function";
+  export const Function_call = "~lib/function/Function#call";
 
   // std/memory.ts
   export const memory_size = "~lib/memory/memory.size";
@@ -737,8 +742,22 @@ export namespace BuiltinNames {
   export const Object = "~lib/object/Object";
 }
 
-/** Builtin compilation context. */
-export class BuiltinContext {
+/** Builtin variable compilation context. */
+export class BuiltinVariableContext {
+  constructor(
+    /** Compiler reference. */
+    public compiler: Compiler,
+    /** Variable being accessed. */
+    public element: VariableLikeElement,
+    /** Contextual type. */
+    public contextualType: Type = element.type,
+    /** Respective report expression. */
+    public reportNode: IdentifierExpression = element.identifierNode
+  ) {}
+}
+
+/** Builtin function compilation context. */
+export class BuiltinFunctionContext {
   constructor(
     /** Compiler reference. */
     public compiler: Compiler,
@@ -759,16 +778,17 @@ export class BuiltinContext {
   ) {}
 }
 
-/** Global builtins map. */
-export const builtins = new Map<string,(ctx: BuiltinContext) => ExpressionRef>();
+/** Builtin functions map. */
+export const builtinFunctions = new Map<string, (ctx: BuiltinFunctionContext) => ExpressionRef>();
 
-/** Function builtins map. */
-export const function_builtins = new Map<string,(ctx: BuiltinContext) => ExpressionRef>();
+/** Builtin variables map. */
+export const builtinVariables_onCompile = new Map<string, (ctx: BuiltinVariableContext) => void>();
+export const builtinVariables_onAccess = new Map<string, (ctx: BuiltinVariableContext) => ExpressionRef>();
 
 // === Static type evaluation =================================================================
 
 // isBoolean<T!>() / isBoolean<T?>(value: T) -> bool
-function builtin_isBoolean(ctx: BuiltinContext): ExpressionRef {
+function builtin_isBoolean(ctx: BuiltinFunctionContext): ExpressionRef {
   let compiler = ctx.compiler;
   let module = compiler.module;
   let type = checkConstantType(ctx);
@@ -776,10 +796,10 @@ function builtin_isBoolean(ctx: BuiltinContext): ExpressionRef {
   if (!type) return module.unreachable();
   return reifyConstantType(ctx, module.i32(type.isBooleanValue ? 1 : 0));
 }
-builtins.set(BuiltinNames.isBoolean, builtin_isBoolean);
+builtinFunctions.set(BuiltinNames.isBoolean, builtin_isBoolean);
 
 // isInteger<T!>() / isInteger<T?>(value: T) -> bool
-function builtin_isInteger(ctx: BuiltinContext): ExpressionRef {
+function builtin_isInteger(ctx: BuiltinFunctionContext): ExpressionRef {
   let compiler = ctx.compiler;
   let module = compiler.module;
   let type = checkConstantType(ctx);
@@ -787,10 +807,10 @@ function builtin_isInteger(ctx: BuiltinContext): ExpressionRef {
   if (!type) return module.unreachable();
   return reifyConstantType(ctx, module.i32(type.isIntegerValue ? 1 : 0));
 }
-builtins.set(BuiltinNames.isInteger, builtin_isInteger);
+builtinFunctions.set(BuiltinNames.isInteger, builtin_isInteger);
 
 // isSigned<T!>() / isSigned<T?>(value: T) -> bool
-function builtin_isSigned(ctx: BuiltinContext): ExpressionRef {
+function builtin_isSigned(ctx: BuiltinFunctionContext): ExpressionRef {
   let compiler = ctx.compiler;
   let module = compiler.module;
   let type = checkConstantType(ctx);
@@ -798,10 +818,10 @@ function builtin_isSigned(ctx: BuiltinContext): ExpressionRef {
   if (!type) return module.unreachable();
   return reifyConstantType(ctx, module.i32(type.isSignedIntegerValue ? 1 : 0));
 }
-builtins.set(BuiltinNames.isSigned, builtin_isSigned);
+builtinFunctions.set(BuiltinNames.isSigned, builtin_isSigned);
 
 // isFloat<T!>() / isFloat<T?>(value: T) -> bool
-function builtin_isFloat(ctx: BuiltinContext): ExpressionRef {
+function builtin_isFloat(ctx: BuiltinFunctionContext): ExpressionRef {
   let compiler = ctx.compiler;
   let module = compiler.module;
   let type = checkConstantType(ctx);
@@ -809,10 +829,10 @@ function builtin_isFloat(ctx: BuiltinContext): ExpressionRef {
   if (!type) return module.unreachable();
   return reifyConstantType(ctx, module.i32(type.isFloatValue ? 1 : 0));
 }
-builtins.set(BuiltinNames.isFloat, builtin_isFloat);
+builtinFunctions.set(BuiltinNames.isFloat, builtin_isFloat);
 
 // isVector<T!>() / isVector<T?>(value: T) -> bool
-function builtin_isVector(ctx: BuiltinContext): ExpressionRef {
+function builtin_isVector(ctx: BuiltinFunctionContext): ExpressionRef {
   let compiler = ctx.compiler;
   let module = compiler.module;
   let type = checkConstantType(ctx);
@@ -820,10 +840,10 @@ function builtin_isVector(ctx: BuiltinContext): ExpressionRef {
   if (!type) return module.unreachable();
   return reifyConstantType(ctx, module.i32(type.isVectorValue ? 1 : 0));
 }
-builtins.set(BuiltinNames.isVector, builtin_isVector);
+builtinFunctions.set(BuiltinNames.isVector, builtin_isVector);
 
 // isReference<T!>() / isReference<T?>(value: T) -> bool
-function builtin_isReference(ctx: BuiltinContext): ExpressionRef {
+function builtin_isReference(ctx: BuiltinFunctionContext): ExpressionRef {
   let compiler = ctx.compiler;
   let module = compiler.module;
   let type = checkConstantType(ctx);
@@ -831,10 +851,10 @@ function builtin_isReference(ctx: BuiltinContext): ExpressionRef {
   if (!type) return module.unreachable();
   return reifyConstantType(ctx, module.i32(type.isReference ? 1 : 0));
 }
-builtins.set(BuiltinNames.isReference, builtin_isReference);
+builtinFunctions.set(BuiltinNames.isReference, builtin_isReference);
 
 // isString<T!>() / isString<T?>(value: T) -> bool
-function builtin_isString(ctx: BuiltinContext): ExpressionRef {
+function builtin_isString(ctx: BuiltinFunctionContext): ExpressionRef {
   let compiler = ctx.compiler;
   let module = compiler.module;
   let type = checkConstantType(ctx);
@@ -849,10 +869,10 @@ function builtin_isString(ctx: BuiltinContext): ExpressionRef {
     )
   );
 }
-builtins.set(BuiltinNames.isString, builtin_isString);
+builtinFunctions.set(BuiltinNames.isString, builtin_isString);
 
 // isArray<T!>() / isArray<T?>(value: T) -> bool
-function builtin_isArray(ctx: BuiltinContext): ExpressionRef {
+function builtin_isArray(ctx: BuiltinFunctionContext): ExpressionRef {
   let compiler = ctx.compiler;
   let module = compiler.module;
   let type = checkConstantType(ctx);
@@ -867,10 +887,10 @@ function builtin_isArray(ctx: BuiltinContext): ExpressionRef {
     )
   );
 }
-builtins.set(BuiltinNames.isArray, builtin_isArray);
+builtinFunctions.set(BuiltinNames.isArray, builtin_isArray);
 
 // isArrayLike<T!>() / isArrayLike<T?>(value: T) -> bool
-function builtin_isArrayLike(ctx: BuiltinContext): ExpressionRef {
+function builtin_isArrayLike(ctx: BuiltinFunctionContext): ExpressionRef {
   let compiler = ctx.compiler;
   let module = compiler.module;
   let type = checkConstantType(ctx);
@@ -885,10 +905,10 @@ function builtin_isArrayLike(ctx: BuiltinContext): ExpressionRef {
     )
   );
 }
-builtins.set(BuiltinNames.isArrayLike, builtin_isArrayLike);
+builtinFunctions.set(BuiltinNames.isArrayLike, builtin_isArrayLike);
 
 // isFunction<T!> / isFunction<T?>(value: T) -> bool
-function builtin_isFunction(ctx: BuiltinContext): ExpressionRef {
+function builtin_isFunction(ctx: BuiltinFunctionContext): ExpressionRef {
   let compiler = ctx.compiler;
   let module = compiler.module;
   let type = checkConstantType(ctx);
@@ -896,10 +916,10 @@ function builtin_isFunction(ctx: BuiltinContext): ExpressionRef {
   if (!type) return module.unreachable();
   return reifyConstantType(ctx, module.i32(type.isFunction ? 1 : 0));
 }
-builtins.set(BuiltinNames.isFunction, builtin_isFunction);
+builtinFunctions.set(BuiltinNames.isFunction, builtin_isFunction);
 
 // isNullable<T!> / isNullable<T?>(value: T) -> bool
-function builtin_isNullable(ctx: BuiltinContext): ExpressionRef {
+function builtin_isNullable(ctx: BuiltinFunctionContext): ExpressionRef {
   let compiler = ctx.compiler;
   let module = compiler.module;
   let type = checkConstantType(ctx);
@@ -907,10 +927,10 @@ function builtin_isNullable(ctx: BuiltinContext): ExpressionRef {
   if (!type) return module.unreachable();
   return reifyConstantType(ctx, module.i32(type.isNullableReference ? 1 : 0));
 }
-builtins.set(BuiltinNames.isNullable, builtin_isNullable);
+builtinFunctions.set(BuiltinNames.isNullable, builtin_isNullable);
 
 // isDefined(expression) -> bool
-function builtin_isDefined(ctx: BuiltinContext): ExpressionRef {
+function builtin_isDefined(ctx: BuiltinFunctionContext): ExpressionRef {
   // Note that `isDefined` neither compiles nor evaluates the given expression
   // but exclusively performs a check whether it can be compiled in theory.
   // This is not exactly unsafe due to only seemingly having side effects which
@@ -930,10 +950,10 @@ function builtin_isDefined(ctx: BuiltinContext): ExpressionRef {
   );
   return module.i32(element ? 1 : 0);
 }
-builtins.set(BuiltinNames.isDefined, builtin_isDefined);
+builtinFunctions.set(BuiltinNames.isDefined, builtin_isDefined);
 
 // isConstant(expression) -> bool
-function builtin_isConstant(ctx: BuiltinContext): ExpressionRef {
+function builtin_isConstant(ctx: BuiltinFunctionContext): ExpressionRef {
   let compiler = ctx.compiler;
   let module = compiler.module;
   compiler.currentType = Type.bool;
@@ -951,10 +971,10 @@ function builtin_isConstant(ctx: BuiltinContext): ExpressionRef {
     module.i32(0)
   ], getExpressionType(expr));
 }
-builtins.set(BuiltinNames.isConstant, builtin_isConstant);
+builtinFunctions.set(BuiltinNames.isConstant, builtin_isConstant);
 
 // isManaged<T!>() -> bool
-function builtin_isManaged(ctx: BuiltinContext): ExpressionRef {
+function builtin_isManaged(ctx: BuiltinFunctionContext): ExpressionRef {
   let compiler = ctx.compiler;
   let module = compiler.module;
   let type = checkConstantType(ctx);
@@ -962,10 +982,10 @@ function builtin_isManaged(ctx: BuiltinContext): ExpressionRef {
   if (!type) return module.unreachable();
   return reifyConstantType(ctx, module.i32(type.isManaged ? 1 : 0));
 }
-builtins.set(BuiltinNames.isManaged, builtin_isManaged);
+builtinFunctions.set(BuiltinNames.isManaged, builtin_isManaged);
 
 // isVoid<T!>() -> bool
-function builtin_isVoid(ctx: BuiltinContext): ExpressionRef {
+function builtin_isVoid(ctx: BuiltinFunctionContext): ExpressionRef {
   let compiler = ctx.compiler;
   let module = compiler.module;
   let type = checkConstantType(ctx);
@@ -973,10 +993,10 @@ function builtin_isVoid(ctx: BuiltinContext): ExpressionRef {
   if (!type) return module.unreachable();
   return reifyConstantType(ctx, module.i32(type.kind == TypeKind.Void ? 1 : 0));
 }
-builtins.set(BuiltinNames.isVoid, builtin_isVoid);
+builtinFunctions.set(BuiltinNames.isVoid, builtin_isVoid);
 
 // lengthof<T!>() -> i32
-function builtin_lengthof(ctx: BuiltinContext): ExpressionRef {
+function builtin_lengthof(ctx: BuiltinFunctionContext): ExpressionRef {
   let compiler = ctx.compiler;
   let module = compiler.module;
   let type = checkConstantType(ctx);
@@ -992,10 +1012,10 @@ function builtin_lengthof(ctx: BuiltinContext): ExpressionRef {
   }
   return reifyConstantType(ctx, module.i32(signatureReference.parameterTypes.length));
 }
-builtins.set(BuiltinNames.lengthof, builtin_lengthof);
+builtinFunctions.set(BuiltinNames.lengthof, builtin_lengthof);
 
 // sizeof<T!>() -> usize*
-function builtin_sizeof(ctx: BuiltinContext): ExpressionRef {
+function builtin_sizeof(ctx: BuiltinFunctionContext): ExpressionRef {
   let compiler = ctx.compiler;
   let module = compiler.module;
   compiler.currentType = compiler.options.usizeType;
@@ -1014,10 +1034,10 @@ function builtin_sizeof(ctx: BuiltinContext): ExpressionRef {
   }
   return contextualUsize(compiler, i64_new(byteSize), ctx.contextualType);
 }
-builtins.set(BuiltinNames.sizeof, builtin_sizeof);
+builtinFunctions.set(BuiltinNames.sizeof, builtin_sizeof);
 
 // alignof<T!>() -> usize*
-function builtin_alignof(ctx: BuiltinContext): ExpressionRef {
+function builtin_alignof(ctx: BuiltinFunctionContext): ExpressionRef {
   let compiler = ctx.compiler;
   let module = compiler.module;
   compiler.currentType = compiler.options.usizeType;
@@ -1036,10 +1056,10 @@ function builtin_alignof(ctx: BuiltinContext): ExpressionRef {
   }
   return contextualUsize(compiler, i64_new(ctz<i32>(byteSize)), ctx.contextualType);
 }
-builtins.set(BuiltinNames.alignof, builtin_alignof);
+builtinFunctions.set(BuiltinNames.alignof, builtin_alignof);
 
 // offsetof<T!>(fieldName?: string) -> usize*
-function builtin_offsetof(ctx: BuiltinContext): ExpressionRef {
+function builtin_offsetof(ctx: BuiltinFunctionContext): ExpressionRef {
   let compiler = ctx.compiler;
   let module = compiler.module;
   compiler.currentType = compiler.options.usizeType;
@@ -1093,10 +1113,10 @@ function builtin_offsetof(ctx: BuiltinContext): ExpressionRef {
   }
   return contextualUsize(compiler, i64_new(classReference.nextMemoryOffset), contextualType);
 }
-builtins.set(BuiltinNames.offsetof, builtin_offsetof);
+builtinFunctions.set(BuiltinNames.offsetof, builtin_offsetof);
 
 // nameof<T> -> string
-function builtin_nameof(ctx: BuiltinContext): ExpressionRef {
+function builtin_nameof(ctx: BuiltinFunctionContext): ExpressionRef {
   let compiler = ctx.compiler;
   let module = compiler.module;
   let resultType = checkConstantType(ctx);
@@ -1118,10 +1138,10 @@ function builtin_nameof(ctx: BuiltinContext): ExpressionRef {
   }
   return reifyConstantType(ctx, compiler.ensureStaticString(value));
 }
-builtins.set(BuiltinNames.nameof, builtin_nameof);
+builtinFunctions.set(BuiltinNames.nameof, builtin_nameof);
 
 // idof<T> -> u32
-function builtin_idof(ctx: BuiltinContext): ExpressionRef {
+function builtin_idof(ctx: BuiltinFunctionContext): ExpressionRef {
   let compiler = ctx.compiler;
   let module = compiler.module;
   let type = checkConstantType(ctx);
@@ -1141,10 +1161,10 @@ function builtin_idof(ctx: BuiltinContext): ExpressionRef {
   );
   return module.unreachable();
 }
-builtins.set(BuiltinNames.idof, builtin_idof);
+builtinFunctions.set(BuiltinNames.idof, builtin_idof);
 
 // bswap<T?>(value: T) -> T
-function builtin_bswap(ctx: BuiltinContext): ExpressionRef {
+function builtin_bswap(ctx: BuiltinFunctionContext): ExpressionRef {
   let compiler = ctx.compiler;
   let module = compiler.module;
   if (
@@ -1316,12 +1336,58 @@ function builtin_bswap(ctx: BuiltinContext): ExpressionRef {
   );
   return module.unreachable();
 }
-builtins.set(BuiltinNames.bswap, builtin_bswap);
+builtinFunctions.set(BuiltinNames.bswap, builtin_bswap);
 
 // === Math ===================================================================================
 
+// NaN
+function builtin_NaN_compile(ctx: BuiltinVariableContext): void {
+  let element = ctx.element;
+  if (element.is(CommonFlags.ModuleExport)) {
+    let module = ctx.compiler.module;
+    module.addGlobal(element.internalName, TypeRef.F64, false, module.f64(NaN));
+  }
+}
+builtinVariables_onCompile.set(BuiltinNames.NaN, builtin_NaN_compile);
+
+// NaN -> f32 | f64
+function builtin_NaN_access(ctx: BuiltinVariableContext): ExpressionRef {
+  let compiler = ctx.compiler;
+  let module = compiler.module;
+  if (ctx.contextualType == Type.f32) {
+    compiler.currentType = Type.f32;
+    return module.f32(<f32>NaN);
+  }
+  compiler.currentType = Type.f64;
+  return module.f64(NaN);
+}
+builtinVariables_onAccess.set(BuiltinNames.NaN, builtin_NaN_access);
+
+// Infinity
+function builtin_Infinity_compile(ctx: BuiltinVariableContext): void {
+  let element = ctx.element;
+  if (element.is(CommonFlags.ModuleExport)) {
+    let module = ctx.compiler.module;
+    module.addGlobal(element.internalName, TypeRef.F64, false, module.f64(Infinity));
+  }
+}
+builtinVariables_onCompile.set(BuiltinNames.Infinity, builtin_Infinity_compile);
+
+// Infinity -> f32 | f64
+function builtin_Infinity_access(ctx: BuiltinVariableContext): ExpressionRef {
+  let compiler = ctx.compiler;
+  let module = compiler.module;
+  if (ctx.contextualType == Type.f32) {
+    compiler.currentType = Type.f32;
+    return module.f32(<f32>Infinity);
+  }
+  compiler.currentType = Type.f64;
+  return module.f64(Infinity);
+}
+builtinVariables_onAccess.set(BuiltinNames.Infinity, builtin_Infinity_access);
+
 // clz<T?>(value: T) -> T
-function builtin_clz(ctx: BuiltinContext): ExpressionRef {
+function builtin_clz(ctx: BuiltinFunctionContext): ExpressionRef {
   let compiler = ctx.compiler;
   let module = compiler.module;
   if (
@@ -1354,10 +1420,10 @@ function builtin_clz(ctx: BuiltinContext): ExpressionRef {
   );
   return module.unreachable();
 }
-builtins.set(BuiltinNames.clz, builtin_clz);
+builtinFunctions.set(BuiltinNames.clz, builtin_clz);
 
 // ctz<T?>(value: T) -> T
-function builtin_ctz(ctx: BuiltinContext): ExpressionRef {
+function builtin_ctz(ctx: BuiltinFunctionContext): ExpressionRef {
   let compiler = ctx.compiler;
   let module = compiler.module;
   if (
@@ -1391,10 +1457,10 @@ function builtin_ctz(ctx: BuiltinContext): ExpressionRef {
   );
   return module.unreachable();
 }
-builtins.set(BuiltinNames.ctz, builtin_ctz);
+builtinFunctions.set(BuiltinNames.ctz, builtin_ctz);
 
 // popcnt<T?>(value: T) -> T
-function builtin_popcnt(ctx: BuiltinContext): ExpressionRef {
+function builtin_popcnt(ctx: BuiltinFunctionContext): ExpressionRef {
   let compiler = ctx.compiler;
   let module = compiler.module;
   if (
@@ -1428,10 +1494,10 @@ function builtin_popcnt(ctx: BuiltinContext): ExpressionRef {
   );
   return module.unreachable();
 }
-builtins.set(BuiltinNames.popcnt, builtin_popcnt);
+builtinFunctions.set(BuiltinNames.popcnt, builtin_popcnt);
 
 // rotl<T?>(value: T, shift: T) -> T
-function builtin_rotl(ctx: BuiltinContext): ExpressionRef {
+function builtin_rotl(ctx: BuiltinFunctionContext): ExpressionRef {
   let compiler = ctx.compiler;
   let module = compiler.module;
   if (
@@ -1500,10 +1566,10 @@ function builtin_rotl(ctx: BuiltinContext): ExpressionRef {
   );
   return module.unreachable();
 }
-builtins.set(BuiltinNames.rotl, builtin_rotl);
+builtinFunctions.set(BuiltinNames.rotl, builtin_rotl);
 
 // rotr<T?>(value: T, shift: T) -> T
-function builtin_rotr(ctx: BuiltinContext): ExpressionRef {
+function builtin_rotr(ctx: BuiltinFunctionContext): ExpressionRef {
   let compiler = ctx.compiler;
   let module = compiler.module;
   if (
@@ -1572,10 +1638,10 @@ function builtin_rotr(ctx: BuiltinContext): ExpressionRef {
   );
   return module.unreachable();
 }
-builtins.set(BuiltinNames.rotr, builtin_rotr);
+builtinFunctions.set(BuiltinNames.rotr, builtin_rotr);
 
 // abs<T?>(value: T) -> T
-function builtin_abs(ctx: BuiltinContext): ExpressionRef {
+function builtin_abs(ctx: BuiltinFunctionContext): ExpressionRef {
   let compiler = ctx.compiler;
   let module = compiler.module;
   if (
@@ -1677,10 +1743,10 @@ function builtin_abs(ctx: BuiltinContext): ExpressionRef {
   );
   return module.unreachable();
 }
-builtins.set(BuiltinNames.abs, builtin_abs);
+builtinFunctions.set(BuiltinNames.abs, builtin_abs);
 
 // max<T?>(left: T, right: T) -> T
-function builtin_max(ctx: BuiltinContext): ExpressionRef {
+function builtin_max(ctx: BuiltinFunctionContext): ExpressionRef {
   let compiler = ctx.compiler;
   let module = compiler.module;
   if (
@@ -1745,10 +1811,10 @@ function builtin_max(ctx: BuiltinContext): ExpressionRef {
   );
   return module.unreachable();
 }
-builtins.set(BuiltinNames.max, builtin_max);
+builtinFunctions.set(BuiltinNames.max, builtin_max);
 
 // min<T?>(left: T, right: T) -> T
-function builtin_min(ctx: BuiltinContext): ExpressionRef {
+function builtin_min(ctx: BuiltinFunctionContext): ExpressionRef {
   let compiler = ctx.compiler;
   let module = compiler.module;
   if (
@@ -1813,10 +1879,10 @@ function builtin_min(ctx: BuiltinContext): ExpressionRef {
   );
   return module.unreachable();
 }
-builtins.set(BuiltinNames.min, builtin_min);
+builtinFunctions.set(BuiltinNames.min, builtin_min);
 
 // ceil<T?>(value: T) -> T
-function builtin_ceil(ctx: BuiltinContext): ExpressionRef {
+function builtin_ceil(ctx: BuiltinFunctionContext): ExpressionRef {
   let compiler = ctx.compiler;
   let module = compiler.module;
   if (
@@ -1852,10 +1918,10 @@ function builtin_ceil(ctx: BuiltinContext): ExpressionRef {
   );
   return module.unreachable();
 }
-builtins.set(BuiltinNames.ceil, builtin_ceil);
+builtinFunctions.set(BuiltinNames.ceil, builtin_ceil);
 
 // floor<T?>(value: T) -> T
-function builtin_floor(ctx: BuiltinContext): ExpressionRef {
+function builtin_floor(ctx: BuiltinFunctionContext): ExpressionRef {
   let compiler = ctx.compiler;
   let module = compiler.module;
   if (
@@ -1891,10 +1957,10 @@ function builtin_floor(ctx: BuiltinContext): ExpressionRef {
   );
   return module.unreachable();
 }
-builtins.set(BuiltinNames.floor, builtin_floor);
+builtinFunctions.set(BuiltinNames.floor, builtin_floor);
 
 // copysign<T?>(left: T, right: T) -> T
-function builtin_copysign(ctx: BuiltinContext): ExpressionRef {
+function builtin_copysign(ctx: BuiltinFunctionContext): ExpressionRef {
   let compiler = ctx.compiler;
   let module = compiler.module;
   if (
@@ -1921,10 +1987,10 @@ function builtin_copysign(ctx: BuiltinContext): ExpressionRef {
   );
   return module.unreachable();
 }
-builtins.set(BuiltinNames.copysign, builtin_copysign);
+builtinFunctions.set(BuiltinNames.copysign, builtin_copysign);
 
 // nearest<T?>(value: T) -> T
-function builtin_nearest(ctx: BuiltinContext): ExpressionRef {
+function builtin_nearest(ctx: BuiltinFunctionContext): ExpressionRef {
   let compiler = ctx.compiler;
   let module = compiler.module;
   if (
@@ -1960,10 +2026,10 @@ function builtin_nearest(ctx: BuiltinContext): ExpressionRef {
   );
   return module.unreachable();
 }
-builtins.set(BuiltinNames.nearest, builtin_nearest);
+builtinFunctions.set(BuiltinNames.nearest, builtin_nearest);
 
 // reinterpret<T!>(value: *) -> T
-function builtin_reinterpret(ctx: BuiltinContext): ExpressionRef {
+function builtin_reinterpret(ctx: BuiltinFunctionContext): ExpressionRef {
   let compiler = ctx.compiler;
   let module = compiler.module;
   if (
@@ -2020,10 +2086,10 @@ function builtin_reinterpret(ctx: BuiltinContext): ExpressionRef {
   );
   return module.unreachable();
 }
-builtins.set(BuiltinNames.reinterpret, builtin_reinterpret);
+builtinFunctions.set(BuiltinNames.reinterpret, builtin_reinterpret);
 
 // sqrt<T?>(value: T) -> T
-function builtin_sqrt(ctx: BuiltinContext): ExpressionRef {
+function builtin_sqrt(ctx: BuiltinFunctionContext): ExpressionRef {
   let compiler = ctx.compiler;
   let module = compiler.module;
   if (
@@ -2049,10 +2115,10 @@ function builtin_sqrt(ctx: BuiltinContext): ExpressionRef {
   );
   return module.unreachable();
 }
-builtins.set(BuiltinNames.sqrt, builtin_sqrt);
+builtinFunctions.set(BuiltinNames.sqrt, builtin_sqrt);
 
 // trunc<T?>(value: T) -> T
-function builtin_trunc(ctx: BuiltinContext): ExpressionRef {
+function builtin_trunc(ctx: BuiltinFunctionContext): ExpressionRef {
   let compiler = ctx.compiler;
   let module = compiler.module;
   if (
@@ -2088,10 +2154,10 @@ function builtin_trunc(ctx: BuiltinContext): ExpressionRef {
   );
   return module.unreachable();
 }
-builtins.set(BuiltinNames.trunc, builtin_trunc);
+builtinFunctions.set(BuiltinNames.trunc, builtin_trunc);
 
 // isNaN<T?>(value: T) -> bool
-function builtin_isNaN(ctx: BuiltinContext): ExpressionRef {
+function builtin_isNaN(ctx: BuiltinFunctionContext): ExpressionRef {
   let compiler = ctx.compiler;
   let module = compiler.module;
   if (
@@ -2162,10 +2228,10 @@ function builtin_isNaN(ctx: BuiltinContext): ExpressionRef {
   );
   return module.unreachable();
 }
-builtins.set(BuiltinNames.isNaN, builtin_isNaN);
+builtinFunctions.set(BuiltinNames.isNaN, builtin_isNaN);
 
 // isFinite<T?>(value: T) -> bool
-function builtin_isFinite(ctx: BuiltinContext): ExpressionRef {
+function builtin_isFinite(ctx: BuiltinFunctionContext): ExpressionRef {
   let compiler = ctx.compiler;
   let module = compiler.module;
   if (
@@ -2248,12 +2314,104 @@ function builtin_isFinite(ctx: BuiltinContext): ExpressionRef {
   );
   return module.unreachable();
 }
-builtins.set(BuiltinNames.isFinite, builtin_isFinite);
+builtinFunctions.set(BuiltinNames.isFinite, builtin_isFinite);
 
 // === Memory access ==========================================================================
 
+// __heap_base
+function builtin_heap_base_compile(ctx: BuiltinVariableContext): void {
+  let compiler = ctx.compiler;
+  let module = compiler.module;
+  let element = ctx.element;
+  let type = element.type;
+  compiler.runtimeFeatures |= RuntimeFeatures.Heap;
+  module.addGlobal(element.internalName, type.toRef(), true, compiler.makeZero(type)); // dummy
+}
+builtinVariables_onCompile.set(BuiltinNames.heap_base, builtin_heap_base_compile);
+
+// __heap_base -> usize
+function builtin_heap_base_access(ctx: BuiltinVariableContext): ExpressionRef {
+  let compiler = ctx.compiler;
+  let module = compiler.module;
+  let element = ctx.element;
+  let type = element.type;
+  compiler.runtimeFeatures |= RuntimeFeatures.Heap;
+  compiler.currentType = type;
+  return module.global_get(element.internalName, type.toRef());
+}
+builtinVariables_onAccess.set(BuiltinNames.heap_base, builtin_heap_base_access);
+
+// __data_end
+function builtin_data_end_compile(ctx: BuiltinVariableContext): void {
+  let compiler = ctx.compiler;
+  let module = compiler.module;
+  let element = ctx.element;
+  let type = element.type;
+  compiler.runtimeFeatures |= RuntimeFeatures.Data;
+  module.addGlobal(element.internalName, type.toRef(), true, compiler.makeZero(type)); // dummy
+}
+builtinVariables_onCompile.set(BuiltinNames.data_end, builtin_data_end_compile);
+
+// __data_end -> usize
+function builtin_data_end_access(ctx: BuiltinVariableContext): ExpressionRef {
+  let compiler = ctx.compiler;
+  let module = compiler.module;
+  let element = ctx.element;
+  let type = element.type;
+  compiler.runtimeFeatures |= RuntimeFeatures.Data;
+  compiler.currentType = type;
+  return module.global_get(element.internalName, type.toRef());
+}
+builtinVariables_onAccess.set(BuiltinNames.data_end, builtin_data_end_access);
+
+// __stack_pointer
+function builtin_stack_pointer_compile(ctx: BuiltinVariableContext): void {
+  let compiler = ctx.compiler;
+  let module = compiler.module;
+  let element = ctx.element;
+  let type = element.type;
+  compiler.runtimeFeatures |= RuntimeFeatures.Stack;
+  module.addGlobal(element.internalName, type.toRef(), true, compiler.makeZero(type)); // dummy
+}
+builtinVariables_onCompile.set(BuiltinNames.stack_pointer, builtin_stack_pointer_compile);
+
+// __stack_pointer -> usize
+function builtin_stack_pointer_access(ctx: BuiltinVariableContext): ExpressionRef {
+  let compiler = ctx.compiler;
+  let module = compiler.module;
+  let element = ctx.element;
+  let type = element.type;
+  compiler.runtimeFeatures |= RuntimeFeatures.Stack;
+  compiler.currentType = type;
+  return module.global_get(element.internalName, type.toRef());
+}
+builtinVariables_onAccess.set(BuiltinNames.stack_pointer, builtin_stack_pointer_access);
+
+// __rtti_base
+function builtin_rtti_base_compile(ctx: BuiltinVariableContext): void {
+  let compiler = ctx.compiler;
+  let module = compiler.module;
+  let element = ctx.element;
+  let type = element.type;
+  compiler.runtimeFeatures |= RuntimeFeatures.Rtti;
+  module.addGlobal(element.internalName, type.toRef(), true, compiler.makeZero(type)); // dummy
+}
+builtinVariables_onCompile.set(BuiltinNames.rtti_base, builtin_rtti_base_compile);
+
+// __rtti_base -> usize
+function builtin_rtti_base_access(ctx: BuiltinVariableContext): ExpressionRef {
+  let compiler = ctx.compiler;
+  let module = compiler.module;
+  let element = ctx.element;
+  let type = element.type;
+  compiler.runtimeFeatures |= RuntimeFeatures.Rtti;
+  compiler.currentType = type;
+  return module.global_get(element.internalName, type.toRef());
+}
+builtinVariables_onAccess.set(BuiltinNames.rtti_base, builtin_rtti_base_access);
+
 // load<T!>(offset: usize, immOffset?: usize, immAlign?: usize) -> T*
-function builtin_load(ctx: BuiltinContext): ExpressionRef {
+function builtin_load(ctx: BuiltinFunctionContext): ExpressionRef {
   let compiler = ctx.compiler;
   let module = compiler.module;
   if (
@@ -2309,10 +2467,10 @@ function builtin_load(ctx: BuiltinContext): ExpressionRef {
     immAlign
   );
 }
-builtins.set(BuiltinNames.load, builtin_load);
+builtinFunctions.set(BuiltinNames.load, builtin_load);
 
 // store<T!>(ptr: usize, value: T*, immOffset?: usize, immAlign?: usize) -> void
-function builtin_store(ctx: BuiltinContext): ExpressionRef {
+function builtin_store(ctx: BuiltinFunctionContext): ExpressionRef {
   let compiler = ctx.compiler;
   let module = compiler.module;
   compiler.currentType = Type.void;
@@ -2377,10 +2535,10 @@ function builtin_store(ctx: BuiltinContext): ExpressionRef {
   compiler.currentType = Type.void;
   return module.store(type.byteSize, arg0, arg1, inType.toRef(), immOffset, immAlign);
 }
-builtins.set(BuiltinNames.store, builtin_store);
+builtinFunctions.set(BuiltinNames.store, builtin_store);
 
 // rem<T?>(left: T, right: T) -> T
-function builtin_rem(ctx: BuiltinContext): ExpressionRef {
+function builtin_rem(ctx: BuiltinFunctionContext): ExpressionRef {
   let compiler = ctx.compiler;
   let module = compiler.module;
   if (checkTypeOptional(ctx, true) | checkArgsRequired(ctx, 2)) {
@@ -2431,10 +2589,10 @@ function builtin_rem(ctx: BuiltinContext): ExpressionRef {
   );
   return module.unreachable();
 }
-builtins.set(BuiltinNames.rem, builtin_rem);
+builtinFunctions.set(BuiltinNames.rem, builtin_rem);
 
 // add<T?>(left: T, right: T) -> T
-function builtin_add(ctx: BuiltinContext): ExpressionRef {
+function builtin_add(ctx: BuiltinFunctionContext): ExpressionRef {
   let compiler = ctx.compiler;
   let module = compiler.module;
   if (checkTypeOptional(ctx, true) | checkArgsRequired(ctx, 2)) {
@@ -2485,10 +2643,10 @@ function builtin_add(ctx: BuiltinContext): ExpressionRef {
   );
   return module.unreachable();
 }
-builtins.set(BuiltinNames.add, builtin_add);
+builtinFunctions.set(BuiltinNames.add, builtin_add);
 
 // sub<T?>(left: T, right: T) -> T
-function builtin_sub(ctx: BuiltinContext): ExpressionRef {
+function builtin_sub(ctx: BuiltinFunctionContext): ExpressionRef {
   let compiler = ctx.compiler;
   let module = compiler.module;
   if (checkTypeOptional(ctx, true) | checkArgsRequired(ctx, 2)) {
@@ -2539,10 +2697,10 @@ function builtin_sub(ctx: BuiltinContext): ExpressionRef {
   );
   return module.unreachable();
 }
-builtins.set(BuiltinNames.sub, builtin_sub);
+builtinFunctions.set(BuiltinNames.sub, builtin_sub);
 
 // mul<T?>(left: T, right: T) -> T
-function builtin_mul(ctx: BuiltinContext): ExpressionRef {
+function builtin_mul(ctx: BuiltinFunctionContext): ExpressionRef {
   let compiler = ctx.compiler;
   let module = compiler.module;
   if (checkTypeOptional(ctx, true) | checkArgsRequired(ctx, 2)) {
@@ -2593,10 +2751,10 @@ function builtin_mul(ctx: BuiltinContext): ExpressionRef {
   );
   return module.unreachable();
 }
-builtins.set(BuiltinNames.mul, builtin_mul);
+builtinFunctions.set(BuiltinNames.mul, builtin_mul);
 
 // div<T?>(left: T, right: T) -> T
-function builtin_div(ctx: BuiltinContext): ExpressionRef {
+function builtin_div(ctx: BuiltinFunctionContext): ExpressionRef {
   let compiler = ctx.compiler;
   let module = compiler.module;
   if (checkTypeOptional(ctx, true) | checkArgsRequired(ctx, 2)) {
@@ -2647,10 +2805,10 @@ function builtin_div(ctx: BuiltinContext): ExpressionRef {
   );
   return module.unreachable();
 }
-builtins.set(BuiltinNames.div, builtin_div);
+builtinFunctions.set(BuiltinNames.div, builtin_div);
 
 // eq<T?>(left: T, right: T) -> i32
-function builtin_eq(ctx: BuiltinContext): ExpressionRef {
+function builtin_eq(ctx: BuiltinFunctionContext): ExpressionRef {
   let compiler = ctx.compiler;
   let module = compiler.module;
   if (checkTypeOptional(ctx, true) | checkArgsRequired(ctx, 2)) {
@@ -2702,10 +2860,10 @@ function builtin_eq(ctx: BuiltinContext): ExpressionRef {
   );
   return module.unreachable();
 }
-builtins.set(BuiltinNames.eq, builtin_eq);
+builtinFunctions.set(BuiltinNames.eq, builtin_eq);
 
 // ne<T?>(left: T, right: T) -> i32
-function builtin_ne(ctx: BuiltinContext): ExpressionRef {
+function builtin_ne(ctx: BuiltinFunctionContext): ExpressionRef {
   let compiler = ctx.compiler;
   let module = compiler.module;
   if (checkTypeOptional(ctx, true) | checkArgsRequired(ctx, 2)) {
@@ -2757,12 +2915,12 @@ function builtin_ne(ctx: BuiltinContext): ExpressionRef {
   );
   return module.unreachable();
 }
-builtins.set(BuiltinNames.ne, builtin_ne);
+builtinFunctions.set(BuiltinNames.ne, builtin_ne);
 
 // === Atomics ================================================================================
 
 // atomic.load<T!>(offset: usize, immOffset?: usize) -> T*
-function builtin_atomic_load(ctx: BuiltinContext): ExpressionRef {
+function builtin_atomic_load(ctx: BuiltinFunctionContext): ExpressionRef {
   let compiler = ctx.compiler;
   let module = compiler.module;
   if (
@@ -2801,10 +2959,10 @@ function builtin_atomic_load(ctx: BuiltinContext): ExpressionRef {
     immOffset
   );
 }
-builtins.set(BuiltinNames.atomic_load, builtin_atomic_load);
+builtinFunctions.set(BuiltinNames.atomic_load, builtin_atomic_load);
 
 // atomic.store<T!>(offset: usize, value: T*, immOffset?: usize) -> void
-function builtin_atomic_store(ctx: BuiltinContext): ExpressionRef {
+function builtin_atomic_store(ctx: BuiltinFunctionContext): ExpressionRef {
   let compiler = ctx.compiler;
   let module = compiler.module;
   if (
@@ -2858,10 +3016,10 @@ function builtin_atomic_store(ctx: BuiltinContext): ExpressionRef {
   compiler.currentType = Type.void;
   return module.atomic_store(type.byteSize, arg0, arg1, inType.toRef(), immOffset);
 }
-builtins.set(BuiltinNames.atomic_store, builtin_atomic_store);
+builtinFunctions.set(BuiltinNames.atomic_store, builtin_atomic_store);
 
 // any_atomic_binary<T!>(ptr, value: T, immOffset?: usize) -> T
-function builtin_atomic_binary(ctx: BuiltinContext, op: AtomicRMWOp, opName: string): ExpressionRef {
+function builtin_atomic_binary(ctx: BuiltinFunctionContext, op: AtomicRMWOp, opName: string): ExpressionRef {
   let compiler = ctx.compiler;
   let module = compiler.module;
   if (
@@ -2918,43 +3076,43 @@ function builtin_atomic_binary(ctx: BuiltinContext, op: AtomicRMWOp, opName: str
 }
 
 // atomic.add<T!>(ptr, value: T, immOffset?: usize) -> T
-function builtin_atomic_add(ctx: BuiltinContext): ExpressionRef {
+function builtin_atomic_add(ctx: BuiltinFunctionContext): ExpressionRef {
   return builtin_atomic_binary(ctx, AtomicRMWOp.Add, "atomic.add");
 }
-builtins.set(BuiltinNames.atomic_add, builtin_atomic_add);
+builtinFunctions.set(BuiltinNames.atomic_add, builtin_atomic_add);
 
 // atomic.sub<T!>(ptr, value: T, immOffset?: usize) -> T
-function builtin_atomic_sub(ctx: BuiltinContext): ExpressionRef {
+function builtin_atomic_sub(ctx: BuiltinFunctionContext): ExpressionRef {
   return builtin_atomic_binary(ctx, AtomicRMWOp.Sub, "atomic.sub");
 }
-builtins.set(BuiltinNames.atomic_sub, builtin_atomic_sub);
+builtinFunctions.set(BuiltinNames.atomic_sub, builtin_atomic_sub);
 
 // atomic.and<T!>(ptr, value: T, immOffset?: usize) -> T
-function builtin_atomic_and(ctx: BuiltinContext): ExpressionRef {
+function builtin_atomic_and(ctx: BuiltinFunctionContext): ExpressionRef {
   return builtin_atomic_binary(ctx, AtomicRMWOp.And, "atomic.and");
 }
-builtins.set(BuiltinNames.atomic_and, builtin_atomic_and);
+builtinFunctions.set(BuiltinNames.atomic_and, builtin_atomic_and);
 
 // atomic.or<T!>(ptr, value: T, immOffset?: usize) -> T
-function builtin_atomic_or(ctx: BuiltinContext): ExpressionRef {
+function builtin_atomic_or(ctx: BuiltinFunctionContext): ExpressionRef {
   return builtin_atomic_binary(ctx, AtomicRMWOp.Or, "atomic.or");
 }
-builtins.set(BuiltinNames.atomic_or, builtin_atomic_or);
+builtinFunctions.set(BuiltinNames.atomic_or, builtin_atomic_or);
 
 // atomic.xor<T!>(ptr, value: T, immOffset?: usize) -> T
-function builtin_atomic_xor(ctx: BuiltinContext): ExpressionRef {
+function builtin_atomic_xor(ctx: BuiltinFunctionContext): ExpressionRef {
   return builtin_atomic_binary(ctx, AtomicRMWOp.Xor, "atomic.xor");
 }
-builtins.set(BuiltinNames.atomic_xor, builtin_atomic_xor);
+builtinFunctions.set(BuiltinNames.atomic_xor, builtin_atomic_xor);
 
 // atomic.xchg<T!>(ptr, value: T, immOffset?: usize) -> T
-function builtin_atomic_xchg(ctx: BuiltinContext): ExpressionRef {
+function builtin_atomic_xchg(ctx: BuiltinFunctionContext): ExpressionRef {
   return builtin_atomic_binary(ctx, AtomicRMWOp.Xchg, "atomic.xchg");
 }
-builtins.set(BuiltinNames.atomic_xchg, builtin_atomic_xchg);
+builtinFunctions.set(BuiltinNames.atomic_xchg, builtin_atomic_xchg);
 
 // atomic.cmpxchg<T!>(ptr: usize, expected: T, replacement: T, off?: usize) -> T
-function builtin_atomic_cmpxchg(ctx: BuiltinContext): ExpressionRef {
+function builtin_atomic_cmpxchg(ctx: BuiltinFunctionContext): ExpressionRef {
   let compiler = ctx.compiler;
   let module = compiler.module;
   if (
@@ -3014,10 +3172,10 @@ function builtin_atomic_cmpxchg(ctx: BuiltinContext): ExpressionRef {
   compiler.currentType = inType;
   return module.atomic_cmpxchg(type.byteSize, immOffset, arg0, arg1, arg2, inType.toRef());
 }
-builtins.set(BuiltinNames.atomic_cmpxchg, builtin_atomic_cmpxchg);
+builtinFunctions.set(BuiltinNames.atomic_cmpxchg, builtin_atomic_cmpxchg);
 
 // atomic.wait<T!>(ptr: usize, expected: T, timeout?: i64) -> i32
-function builtin_atomic_wait(ctx: BuiltinContext): ExpressionRef {
+function builtin_atomic_wait(ctx: BuiltinFunctionContext): ExpressionRef {
   let compiler = ctx.compiler;
   let module = compiler.module;
   if (
@@ -3051,10 +3209,10 @@ function builtin_atomic_wait(ctx: BuiltinContext): ExpressionRef {
   );
   return module.unreachable();
 }
-builtins.set(BuiltinNames.atomic_wait, builtin_atomic_wait);
+builtinFunctions.set(BuiltinNames.atomic_wait, builtin_atomic_wait);
 
 // atomic.notify(ptr: usize, count?: i32) -> i32
-function builtin_atomic_notify(ctx: BuiltinContext): ExpressionRef {
+function builtin_atomic_notify(ctx: BuiltinFunctionContext): ExpressionRef {
   let compiler = ctx.compiler;
   let module = compiler.module;
   if (
@@ -3073,10 +3231,10 @@ function builtin_atomic_notify(ctx: BuiltinContext): ExpressionRef {
   compiler.currentType = Type.i32;
   return module.atomic_notify(arg0, arg1);
 }
-builtins.set(BuiltinNames.atomic_notify, builtin_atomic_notify);
+builtinFunctions.set(BuiltinNames.atomic_notify, builtin_atomic_notify);
 
 // atomic.fence() -> void
-function builtin_atomic_fence(ctx: BuiltinContext): ExpressionRef {
+function builtin_atomic_fence(ctx: BuiltinFunctionContext): ExpressionRef {
   let compiler = ctx.compiler;
   let module = compiler.module;
   compiler.currentType = Type.void;
@@ -3087,12 +3245,12 @@ function builtin_atomic_fence(ctx: BuiltinContext): ExpressionRef {
   ) return module.unreachable();
   return module.atomic_fence();
 }
-builtins.set(BuiltinNames.atomic_fence, builtin_atomic_fence);
+builtinFunctions.set(BuiltinNames.atomic_fence, builtin_atomic_fence);
 
 // === Control flow ===========================================================================
 
 // select<T?>(ifTrue: T, ifFalse: T, condition: bool) -> T
-function builtin_select(ctx: BuiltinContext): ExpressionRef {
+function builtin_select(ctx: BuiltinFunctionContext): ExpressionRef {
   let compiler = ctx.compiler;
   let module = compiler.module;
   if (
@@ -3121,20 +3279,20 @@ function builtin_select(ctx: BuiltinContext): ExpressionRef {
   compiler.currentType = type;
   return module.select(arg0, arg1, arg2, type.toRef());
 }
-builtins.set(BuiltinNames.select, builtin_select);
+builtinFunctions.set(BuiltinNames.select, builtin_select);
 
 // unreachable() -> *
-function builtin_unreachable(ctx: BuiltinContext): ExpressionRef {
+function builtin_unreachable(ctx: BuiltinFunctionContext): ExpressionRef {
   checkTypeAbsent(ctx);
   checkArgsRequired(ctx, 0);
   return ctx.compiler.module.unreachable();
 }
-builtins.set(BuiltinNames.unreachable, builtin_unreachable);
+builtinFunctions.set(BuiltinNames.unreachable, builtin_unreachable);
 
 // === Memory =================================================================================
 
 // memory.size() -> i32
-function builtin_memory_size(ctx: BuiltinContext): ExpressionRef {
+function builtin_memory_size(ctx: BuiltinFunctionContext): ExpressionRef {
   let compiler = ctx.compiler;
   let module = compiler.module;
   compiler.currentType = Type.i32;
@@ -3144,10 +3302,10 @@ function builtin_memory_size(ctx: BuiltinContext): ExpressionRef {
   ) return module.unreachable();
   return module.memory_size();
 }
-builtins.set(BuiltinNames.memory_size, builtin_memory_size);
+builtinFunctions.set(BuiltinNames.memory_size, builtin_memory_size);
 
 // memory.grow(pages: i32) -> i32
-function builtin_memory_grow(ctx: BuiltinContext): ExpressionRef {
+function builtin_memory_grow(ctx: BuiltinFunctionContext): ExpressionRef {
   let compiler = ctx.compiler;
   let module = compiler.module;
   compiler.currentType = Type.i32;
@@ -3157,10 +3315,10 @@ function builtin_memory_grow(ctx: BuiltinContext): ExpressionRef {
   ) return module.unreachable();
   return module.memory_grow(compiler.compileExpression(ctx.operands[0], Type.i32, Constraints.ConvImplicit));
 }
-builtins.set(BuiltinNames.memory_grow, builtin_memory_grow);
+builtinFunctions.set(BuiltinNames.memory_grow, builtin_memory_grow);
 
 // memory.copy(dest: usize, src: usize: n: usize) -> void
-function builtin_memory_copy(ctx: BuiltinContext): ExpressionRef {
+function builtin_memory_copy(ctx: BuiltinFunctionContext): ExpressionRef {
   let compiler = ctx.compiler;
   let module = compiler.module;
   compiler.currentType = Type.void;
@@ -3183,10 +3341,10 @@ function builtin_memory_copy(ctx: BuiltinContext): ExpressionRef {
   compiler.currentType = Type.void;
   return module.memory_copy(arg0, arg1, arg2);
 }
-builtins.set(BuiltinNames.memory_copy, builtin_memory_copy);
+builtinFunctions.set(BuiltinNames.memory_copy, builtin_memory_copy);
 
 // memory.fill(dest: usize, value: u8, n: usize) -> void
-function builtin_memory_fill(ctx: BuiltinContext): ExpressionRef {
+function builtin_memory_fill(ctx: BuiltinFunctionContext): ExpressionRef {
   let compiler = ctx.compiler;
   let module = compiler.module;
   compiler.currentType = Type.void;
@@ -3209,11 +3367,11 @@ function builtin_memory_fill(ctx: BuiltinContext): ExpressionRef {
   compiler.currentType = Type.void;
   return module.memory_fill(arg0, arg1, arg2);
 }
-builtins.set(BuiltinNames.memory_fill, builtin_memory_fill);
+builtinFunctions.set(BuiltinNames.memory_fill, builtin_memory_fill);
 
 // memory.data(size[, align]) -> usize
 // memory.data<T>(values[, align]) -> usize
-function builtin_memory_data(ctx: BuiltinContext): ExpressionRef {
+function builtin_memory_data(ctx: BuiltinFunctionContext): ExpressionRef {
   let compiler = ctx.compiler;
   let module = compiler.module;
   compiler.currentType = Type.i32;
@@ -3322,11 +3480,11 @@ function builtin_memory_data(ctx: BuiltinContext): ExpressionRef {
     return module.i64(i64_low(offset), i64_high(offset));
   }
 }
-builtins.set(BuiltinNames.memory_data, builtin_memory_data);
+builtinFunctions.set(BuiltinNames.memory_data, builtin_memory_data);
 
 // === GC =====================================================================================
 
-function builtin_i31_new(ctx: BuiltinContext): ExpressionRef {
+function builtin_i31_new(ctx: BuiltinFunctionContext): ExpressionRef {
   let compiler = ctx.compiler;
   let module = compiler.module;
   if (
@@ -3338,9 +3496,9 @@ function builtin_i31_new(ctx: BuiltinContext): ExpressionRef {
   compiler.currentType = Type.i31ref;
   return module.i31_new(arg0);
 }
-builtins.set(BuiltinNames.i31_new, builtin_i31_new);
+builtinFunctions.set(BuiltinNames.i31_new, builtin_i31_new);
 
-function builtin_i31_get(ctx: BuiltinContext): ExpressionRef {
+function builtin_i31_get(ctx: BuiltinFunctionContext): ExpressionRef {
   let compiler = ctx.compiler;
   let module = compiler.module;
   if (
@@ -3357,12 +3515,12 @@ function builtin_i31_get(ctx: BuiltinContext): ExpressionRef {
     return module.i31_get(arg0, true);
   }
 }
-builtins.set(BuiltinNames.i31_get, builtin_i31_get);
+builtinFunctions.set(BuiltinNames.i31_get, builtin_i31_get);
 
 // === Helpers ================================================================================
 
 // changetype<T!>(value: *) -> T
-function builtin_changetype(ctx: BuiltinContext): ExpressionRef {
+function builtin_changetype(ctx: BuiltinFunctionContext): ExpressionRef {
   let compiler = ctx.compiler;
   let module = compiler.module;
   if (
@@ -3384,10 +3542,10 @@ function builtin_changetype(ctx: BuiltinContext): ExpressionRef {
   }
   return arg0;
 }
-builtins.set(BuiltinNames.changetype, builtin_changetype);
+builtinFunctions.set(BuiltinNames.changetype, builtin_changetype);
 
 // assert<T?>(isTrueish: T, message?: string) -> T{!= null}
-function builtin_assert(ctx: BuiltinContext): ExpressionRef {
+function builtin_assert(ctx: BuiltinFunctionContext): ExpressionRef {
   let compiler = ctx.compiler;
   let module = compiler.module;
   let typeArguments = ctx.typeArguments;
@@ -3576,10 +3734,10 @@ function builtin_assert(ctx: BuiltinContext): ExpressionRef {
   );
   return abort;
 }
-builtins.set(BuiltinNames.assert, builtin_assert);
+builtinFunctions.set(BuiltinNames.assert, builtin_assert);
 
 // unchecked(expr: *) -> *
-function builtin_unchecked(ctx: BuiltinContext): ExpressionRef {
+function builtin_unchecked(ctx: BuiltinFunctionContext): ExpressionRef {
   let compiler = ctx.compiler;
   let module = compiler.module;
   if (
@@ -3596,10 +3754,10 @@ function builtin_unchecked(ctx: BuiltinContext): ExpressionRef {
   if (!alreadyUnchecked) flow.unset(FlowFlags.UncheckedContext);
   return expr;
 }
-builtins.set(BuiltinNames.unchecked, builtin_unchecked);
+builtinFunctions.set(BuiltinNames.unchecked, builtin_unchecked);
 
 // call_indirect<T?>(index: u32, ...args: *[]) -> T
-function builtin_call_indirect(ctx: BuiltinContext): ExpressionRef {
+function builtin_call_indirect(ctx: BuiltinFunctionContext): ExpressionRef {
   let compiler = ctx.compiler;
   let module = compiler.module;
   if (
@@ -3626,10 +3784,10 @@ function builtin_call_indirect(ctx: BuiltinContext): ExpressionRef {
   compiler.currentType = returnType;
   return module.call_indirect(null /* TODO */, indexArg, operandExprs, createType(paramTypeRefs), returnType.toRef());
 }
-builtins.set(BuiltinNames.call_indirect, builtin_call_indirect);
+builtinFunctions.set(BuiltinNames.call_indirect, builtin_call_indirect);
 
 // instantiate<T!>(...args: *[]) -> T
-function builtin_instantiate(ctx: BuiltinContext): ExpressionRef {
+function builtin_instantiate(ctx: BuiltinFunctionContext): ExpressionRef {
   let compiler = ctx.compiler;
   let module = compiler.module;
   if (
@@ -3651,11 +3809,11 @@ function builtin_instantiate(ctx: BuiltinContext): ExpressionRef {
   compiler.checkFieldInitialization(classInstance, ctx.reportNode);
   return compiler.compileInstantiate(ctor, operands, Constraints.None, ctx.reportNode);
 }
-builtins.set(BuiltinNames.instantiate, builtin_instantiate);
+builtinFunctions.set(BuiltinNames.instantiate, builtin_instantiate);
 
 // === User-defined diagnostics ===============================================================
 
-function builtin_diagnostic(ctx: BuiltinContext, category: DiagnosticCategory): ExpressionRef {
+function builtin_diagnostic(ctx: BuiltinFunctionContext, category: DiagnosticCategory): ExpressionRef {
   let compiler = ctx.compiler;
   let module = compiler.module;
   checkTypeAbsent(ctx);
@@ -3676,27 +3834,27 @@ function builtin_diagnostic(ctx: BuiltinContext, category: DiagnosticCategory): 
 }
 
 // ERROR(message?)
-function builtin_error(ctx: BuiltinContext): ExpressionRef {
+function builtin_error(ctx: BuiltinFunctionContext): ExpressionRef {
   return builtin_diagnostic(ctx, DiagnosticCategory.Error);
 }
-builtins.set(BuiltinNames.ERROR, builtin_error);
+builtinFunctions.set(BuiltinNames.ERROR, builtin_error);
 
 // WARNING(message?)
-function builtin_warning(ctx: BuiltinContext): ExpressionRef {
+function builtin_warning(ctx: BuiltinFunctionContext): ExpressionRef {
   return builtin_diagnostic(ctx, DiagnosticCategory.Warning);
 }
-builtins.set(BuiltinNames.WARNING, builtin_warning);
+builtinFunctions.set(BuiltinNames.WARNING, builtin_warning);
 
 // INFO(message?)
-function builtin_info(ctx: BuiltinContext): ExpressionRef {
+function builtin_info(ctx: BuiltinFunctionContext): ExpressionRef {
   return builtin_diagnostic(ctx, DiagnosticCategory.Info);
 }
-builtins.set(BuiltinNames.INFO, builtin_info);
+builtinFunctions.set(BuiltinNames.INFO, builtin_info);
 
 // === Function builtins ======================================================================
 
 // Function<T>#call(thisArg: thisof<T> | null, ...args: *[]) -> returnof<T>
-function builtin_function_call(ctx: BuiltinContext): ExpressionRef {
+function builtin_function_call(ctx: BuiltinFunctionContext): ExpressionRef {
   let compiler = ctx.compiler;
   let parent = ctx.prototype.parent;
   assert(parent.kind == ElementKind.Class);
@@ -3729,10 +3887,10 @@ function builtin_function_call(ctx: BuiltinContext): ExpressionRef {
   }
   return compiler.compileCallIndirect(signature, functionArg, ctx.operands, ctx.reportNode, thisArg, ctx.contextualType == Type.void);
 }
-function_builtins.set("call", builtin_function_call);
+builtinFunctions.set(BuiltinNames.Function_call, builtin_function_call);
 
 // String.raw(parts: TemplateStringsArray, ...values: unknown[]): string
-function builtin_string_raw(ctx: BuiltinContext): ExpressionRef {
+function builtin_string_raw(ctx: BuiltinFunctionContext): ExpressionRef {
   let compiler = ctx.compiler;
   let module = compiler.module;
   compiler.currentType = ctx.compiler.program.stringInstance.type;
@@ -3742,11 +3900,11 @@ function builtin_string_raw(ctx: BuiltinContext): ExpressionRef {
   );
   return module.unreachable();
 }
-builtins.set(BuiltinNames.String_raw, builtin_string_raw);
+builtinFunctions.set(BuiltinNames.String_raw, builtin_string_raw);
 
 // === Portable type conversions ==============================================================
 
-function builtin_conversion(ctx: BuiltinContext, toType: Type): ExpressionRef {
+function builtin_conversion(ctx: BuiltinFunctionContext, toType: Type): ExpressionRef {
   let compiler = ctx.compiler;
   if (
     checkTypeAbsent(ctx) |
@@ -3759,93 +3917,93 @@ function builtin_conversion(ctx: BuiltinContext, toType: Type): ExpressionRef {
 }
 
 // i8(*) -> i8
-function builtin_i8(ctx: BuiltinContext): ExpressionRef {
+function builtin_i8(ctx: BuiltinFunctionContext): ExpressionRef {
   return builtin_conversion(ctx, Type.i8);
 }
-builtins.set(BuiltinNames.i8, builtin_i8);
+builtinFunctions.set(BuiltinNames.i8, builtin_i8);
 
 // i16(*) -> i16
-function builtin_i16(ctx: BuiltinContext): ExpressionRef {
+function builtin_i16(ctx: BuiltinFunctionContext): ExpressionRef {
   return builtin_conversion(ctx, Type.i16);
 }
-builtins.set(BuiltinNames.i16, builtin_i16);
+builtinFunctions.set(BuiltinNames.i16, builtin_i16);
 
 // i32(*) -> i32
-function builtin_i32(ctx: BuiltinContext): ExpressionRef {
+function builtin_i32(ctx: BuiltinFunctionContext): ExpressionRef {
   return builtin_conversion(ctx, Type.i32);
 }
-builtins.set(BuiltinNames.i32, builtin_i32);
+builtinFunctions.set(BuiltinNames.i32, builtin_i32);
 
 // i64(*) -> i64
-function builtin_i64(ctx: BuiltinContext): ExpressionRef {
+function builtin_i64(ctx: BuiltinFunctionContext): ExpressionRef {
   return builtin_conversion(ctx, Type.i64);
 }
-builtins.set(BuiltinNames.i64, builtin_i64);
+builtinFunctions.set(BuiltinNames.i64, builtin_i64);
 
 // isize(*) -> isize
-function builtin_isize(ctx: BuiltinContext): ExpressionRef {
+function builtin_isize(ctx: BuiltinFunctionContext): ExpressionRef {
   return builtin_conversion(ctx, ctx.compiler.options.isizeType);
 }
-builtins.set(BuiltinNames.isize, builtin_isize);
+builtinFunctions.set(BuiltinNames.isize, builtin_isize);
 
 // u8(*) -> u8
-function builtin_u8(ctx: BuiltinContext): ExpressionRef {
+function builtin_u8(ctx: BuiltinFunctionContext): ExpressionRef {
   return builtin_conversion(ctx, Type.u8);
 }
-builtins.set(BuiltinNames.u8, builtin_u8);
+builtinFunctions.set(BuiltinNames.u8, builtin_u8);
 
 // u16(*) -> u16
-function builtin_u16(ctx: BuiltinContext): ExpressionRef {
+function builtin_u16(ctx: BuiltinFunctionContext): ExpressionRef {
   return builtin_conversion(ctx, Type.u16);
 }
-builtins.set(BuiltinNames.u16, builtin_u16);
+builtinFunctions.set(BuiltinNames.u16, builtin_u16);
 
 // u32(*) -> u32
-function builtin_u32(ctx: BuiltinContext): ExpressionRef {
+function builtin_u32(ctx: BuiltinFunctionContext): ExpressionRef {
   return builtin_conversion(ctx, Type.u32);
 }
-builtins.set(BuiltinNames.u32, builtin_u32);
+builtinFunctions.set(BuiltinNames.u32, builtin_u32);
 
 // u64(*) -> u64
-function builtin_u64(ctx: BuiltinContext): ExpressionRef {
+function builtin_u64(ctx: BuiltinFunctionContext): ExpressionRef {
   return builtin_conversion(ctx, Type.u64);
 }
-builtins.set(BuiltinNames.u64, builtin_u64);
+builtinFunctions.set(BuiltinNames.u64, builtin_u64);
 
 // usize(*) -> usize
-function builtin_usize(ctx: BuiltinContext): ExpressionRef {
+function builtin_usize(ctx: BuiltinFunctionContext): ExpressionRef {
   return builtin_conversion(ctx, ctx.compiler.options.usizeType);
 }
-builtins.set(BuiltinNames.usize, builtin_usize);
+builtinFunctions.set(BuiltinNames.usize, builtin_usize);
 
 // bool(*) -> bool
-function builtin_bool(ctx: BuiltinContext): ExpressionRef {
+function builtin_bool(ctx: BuiltinFunctionContext): ExpressionRef {
   return builtin_conversion(ctx, Type.bool);
 }
-builtins.set(BuiltinNames.bool, builtin_bool);
+builtinFunctions.set(BuiltinNames.bool, builtin_bool);
 
 // f32(*) -> f32
-function builtin_f32(ctx: BuiltinContext): ExpressionRef {
+function builtin_f32(ctx: BuiltinFunctionContext): ExpressionRef {
   return builtin_conversion(ctx, Type.f32);
 }
-builtins.set(BuiltinNames.f32, builtin_f32);
+builtinFunctions.set(BuiltinNames.f32, builtin_f32);
 
 // f64(*) -> f64
-function builtin_f64(ctx: BuiltinContext): ExpressionRef {
+function builtin_f64(ctx: BuiltinFunctionContext): ExpressionRef {
   return builtin_conversion(ctx, Type.f64);
 }
-builtins.set(BuiltinNames.f64, builtin_f64);
+builtinFunctions.set(BuiltinNames.f64, builtin_f64);
 
 // TODO: alias for now, splat input integer perhaps?
-function builtin_v128(ctx: BuiltinContext): ExpressionRef {
+function builtin_v128(ctx: BuiltinFunctionContext): ExpressionRef {
   return builtin_i8x16(ctx);
 }
-builtins.set(BuiltinNames.v128, builtin_v128);
+builtinFunctions.set(BuiltinNames.v128, builtin_v128);
 
 // === SIMD ===================================================================================
 
 // i8x16(...values: i8[16]) -> v128
-function builtin_i8x16(ctx: BuiltinContext): ExpressionRef {
+function builtin_i8x16(ctx: BuiltinFunctionContext): ExpressionRef {
   let compiler = ctx.compiler;
   let module = compiler.module;
   if (
@@ -3892,10 +4050,10 @@ function builtin_i8x16(ctx: BuiltinContext): ExpressionRef {
     return vec;
   }
 }
-builtins.set(BuiltinNames.i8x16, builtin_i8x16);
+builtinFunctions.set(BuiltinNames.i8x16, builtin_i8x16);
 
 // i16x8(...values: i16[8]) -> v128
-function builtin_i16x8(ctx: BuiltinContext): ExpressionRef {
+function builtin_i16x8(ctx: BuiltinFunctionContext): ExpressionRef {
   let compiler = ctx.compiler;
   let module = compiler.module;
   if (
@@ -3942,10 +4100,10 @@ function builtin_i16x8(ctx: BuiltinContext): ExpressionRef {
     return vec;
   }
 }
-builtins.set(BuiltinNames.i16x8, builtin_i16x8);
+builtinFunctions.set(BuiltinNames.i16x8, builtin_i16x8);
 
 // i32x4(...values: i32[4]) -> v128
-function builtin_i32x4(ctx: BuiltinContext): ExpressionRef {
+function builtin_i32x4(ctx: BuiltinFunctionContext): ExpressionRef {
   let compiler = ctx.compiler;
   let module = compiler.module;
   if (
@@ -3992,10 +4150,10 @@ function builtin_i32x4(ctx: BuiltinContext): ExpressionRef {
     return vec;
   }
 }
-builtins.set(BuiltinNames.i32x4, builtin_i32x4);
+builtinFunctions.set(BuiltinNames.i32x4, builtin_i32x4);
 
 // i64x2(...values: i64[2]) -> v128
-function builtin_i64x2(ctx: BuiltinContext): ExpressionRef {
+function builtin_i64x2(ctx: BuiltinFunctionContext): ExpressionRef {
   let compiler = ctx.compiler;
   let module = compiler.module;
   if (
@@ -4044,10 +4202,10 @@ function builtin_i64x2(ctx: BuiltinContext): ExpressionRef {
     return vec;
   }
 }
-builtins.set(BuiltinNames.i64x2, builtin_i64x2);
+builtinFunctions.set(BuiltinNames.i64x2, builtin_i64x2);
 
 // f32x4(...values: f32[4]) -> v128
-function builtin_f32x4(ctx: BuiltinContext): ExpressionRef {
+function builtin_f32x4(ctx: BuiltinFunctionContext): ExpressionRef {
   let compiler = ctx.compiler;
   let module = compiler.module;
   if (
@@ -4094,10 +4252,10 @@ function builtin_f32x4(ctx: BuiltinContext): ExpressionRef {
     return vec;
   }
 }
-builtins.set(BuiltinNames.f32x4, builtin_f32x4);
+builtinFunctions.set(BuiltinNames.f32x4, builtin_f32x4);
 
 // f64x2(...values: f64[2]) -> v128
-function builtin_f64x2(ctx: BuiltinContext): ExpressionRef {
+function builtin_f64x2(ctx: BuiltinFunctionContext): ExpressionRef {
   let compiler = ctx.compiler;
   let module = compiler.module;
   if (
@@ -4144,10 +4302,10 @@ function builtin_f64x2(ctx: BuiltinContext): ExpressionRef {
     return vec;
   }
 }
-builtins.set(BuiltinNames.f64x2, builtin_f64x2);
+builtinFunctions.set(BuiltinNames.f64x2, builtin_f64x2);
 
 // v128.splat<T!>(x: T) -> v128
-function builtin_v128_splat(ctx: BuiltinContext): ExpressionRef {
+function builtin_v128_splat(ctx: BuiltinFunctionContext): ExpressionRef {
   let compiler = ctx.compiler;
   let module = compiler.module;
   if (
@@ -4192,10 +4350,10 @@ function builtin_v128_splat(ctx: BuiltinContext): ExpressionRef {
   );
   return module.unreachable();
 }
-builtins.set(BuiltinNames.v128_splat, builtin_v128_splat);
+builtinFunctions.set(BuiltinNames.v128_splat, builtin_v128_splat);
 
 // v128.extract_lane<T!>(x: v128, idx: u8) -> T
-function builtin_v128_extract_lane(ctx: BuiltinContext): ExpressionRef {
+function builtin_v128_extract_lane(ctx: BuiltinFunctionContext): ExpressionRef {
   let compiler = ctx.compiler;
   let module = compiler.module;
   if (
@@ -4256,10 +4414,10 @@ function builtin_v128_extract_lane(ctx: BuiltinContext): ExpressionRef {
   );
   return module.unreachable();
 }
-builtins.set(BuiltinNames.v128_extract_lane, builtin_v128_extract_lane);
+builtinFunctions.set(BuiltinNames.v128_extract_lane, builtin_v128_extract_lane);
 
 // v128.replace_lane<T!>(x: v128, idx: u8, value: T) -> v128
-function builtin_v128_replace_lane(ctx: BuiltinContext): ExpressionRef {
+function builtin_v128_replace_lane(ctx: BuiltinFunctionContext): ExpressionRef {
   let compiler = ctx.compiler;
   let module = compiler.module;
   if (
@@ -4324,10 +4482,10 @@ function builtin_v128_replace_lane(ctx: BuiltinContext): ExpressionRef {
   );
   return module.unreachable();
 }
-builtins.set(BuiltinNames.v128_replace_lane, builtin_v128_replace_lane);
+builtinFunctions.set(BuiltinNames.v128_replace_lane, builtin_v128_replace_lane);
 
 // v128.shuffle<T!>(a: v128, b: v128, ...lanes: u8[]) -> v128
-function builtin_v128_shuffle(ctx: BuiltinContext): ExpressionRef {
+function builtin_v128_shuffle(ctx: BuiltinFunctionContext): ExpressionRef {
   let compiler = ctx.compiler;
   let module = compiler.module;
   if (
@@ -4436,10 +4594,10 @@ function builtin_v128_shuffle(ctx: BuiltinContext): ExpressionRef {
   compiler.currentType = Type.v128;
   return module.unreachable();
 }
-builtins.set(BuiltinNames.v128_shuffle, builtin_v128_shuffle);
+builtinFunctions.set(BuiltinNames.v128_shuffle, builtin_v128_shuffle);
 
 // v128.swizzle(a: v128, b: v128) -> v128
-function builtin_v128_swizzle(ctx: BuiltinContext): ExpressionRef {
+function builtin_v128_swizzle(ctx: BuiltinFunctionContext): ExpressionRef {
   let compiler = ctx.compiler;
   let module = compiler.module;
   if (
@@ -4455,10 +4613,10 @@ function builtin_v128_swizzle(ctx: BuiltinContext): ExpressionRef {
   let arg1 = compiler.compileExpression(operands[1], Type.v128, Constraints.ConvImplicit);
   return module.binary(BinaryOp.SwizzleI8x16, arg0, arg1);
 }
-builtins.set(BuiltinNames.v128_swizzle, builtin_v128_swizzle);
+builtinFunctions.set(BuiltinNames.v128_swizzle, builtin_v128_swizzle);
 
 // v128.load_splat<T!>(ptr: usize, immOffset?: usize, immAlign?: usize) -> v128
-function builtin_v128_load_splat(ctx: BuiltinContext): ExpressionRef {
+function builtin_v128_load_splat(ctx: BuiltinFunctionContext): ExpressionRef {
   let compiler = ctx.compiler;
   let module = compiler.module;
   if (
@@ -4523,10 +4681,10 @@ function builtin_v128_load_splat(ctx: BuiltinContext): ExpressionRef {
   );
   return module.unreachable();
 }
-builtins.set(BuiltinNames.v128_load_splat, builtin_v128_load_splat);
+builtinFunctions.set(BuiltinNames.v128_load_splat, builtin_v128_load_splat);
 
 // v128.load_ext<TFrom!>(ptr: usize, immOffset?: usize, immAlign?: usize) -> v128
-function builtin_v128_load_ext(ctx: BuiltinContext): ExpressionRef {
+function builtin_v128_load_ext(ctx: BuiltinFunctionContext): ExpressionRef {
   let compiler = ctx.compiler;
   let module = compiler.module;
   if (
@@ -4580,10 +4738,10 @@ function builtin_v128_load_ext(ctx: BuiltinContext): ExpressionRef {
   );
   return module.unreachable();
 }
-builtins.set(BuiltinNames.v128_load_ext, builtin_v128_load_ext);
+builtinFunctions.set(BuiltinNames.v128_load_ext, builtin_v128_load_ext);
 
 // v128.load_zero<TFrom!>(ptr: usize, immOffset?: usize, immAlign?: usize) -> v128
-function builtin_v128_load_zero(ctx: BuiltinContext): ExpressionRef {
+function builtin_v128_load_zero(ctx: BuiltinFunctionContext): ExpressionRef {
   let compiler = ctx.compiler;
   let module = compiler.module;
   if (
@@ -4640,10 +4798,10 @@ function builtin_v128_load_zero(ctx: BuiltinContext): ExpressionRef {
   );
   return module.unreachable();
 }
-builtins.set(BuiltinNames.v128_load_zero, builtin_v128_load_zero);
+builtinFunctions.set(BuiltinNames.v128_load_zero, builtin_v128_load_zero);
 
 // v128.load_lane<TFrom!>(ptr: usize, vec: v128, idx: u8, immOffset?: usize, immAlign?: usize) -> v128
-function builtin_v128_load_lane(ctx: BuiltinContext): ExpressionRef {
+function builtin_v128_load_lane(ctx: BuiltinFunctionContext): ExpressionRef {
   let compiler = ctx.compiler;
   let module = compiler.module;
   if (
@@ -4726,10 +4884,10 @@ function builtin_v128_load_lane(ctx: BuiltinContext): ExpressionRef {
   );
   return module.unreachable();
 }
-builtins.set(BuiltinNames.v128_load_lane, builtin_v128_load_lane);
+builtinFunctions.set(BuiltinNames.v128_load_lane, builtin_v128_load_lane);
 
 // v128.store_lane<TFrom!>(ptr: usize, vec: v128, idx: u8, immOffset?: usize, immAlign?: usize) -> v128
-function builtin_v128_store_lane(ctx: BuiltinContext): ExpressionRef {
+function builtin_v128_store_lane(ctx: BuiltinFunctionContext): ExpressionRef {
   let compiler = ctx.compiler;
   let module = compiler.module;
   if (
@@ -4812,10 +4970,10 @@ function builtin_v128_store_lane(ctx: BuiltinContext): ExpressionRef {
   );
   return module.unreachable();
 }
-builtins.set(BuiltinNames.v128_store_lane, builtin_v128_store_lane);
+builtinFunctions.set(BuiltinNames.v128_store_lane, builtin_v128_store_lane);
 
 // v128.add<T!>(a: v128, b: v128) -> v128
-function builtin_v128_add(ctx: BuiltinContext): ExpressionRef {
+function builtin_v128_add(ctx: BuiltinFunctionContext): ExpressionRef {
   let compiler = ctx.compiler;
   let module = compiler.module;
   if (
@@ -4860,10 +5018,10 @@ function builtin_v128_add(ctx: BuiltinContext): ExpressionRef {
   );
   return module.unreachable();
 }
-builtins.set(BuiltinNames.v128_add, builtin_v128_add);
+builtinFunctions.set(BuiltinNames.v128_add, builtin_v128_add);
 
 // v128.sub<T!>(a: v128, b: v128) -> v128
-function builtin_v128_sub(ctx: BuiltinContext): ExpressionRef {
+function builtin_v128_sub(ctx: BuiltinFunctionContext): ExpressionRef {
   let compiler = ctx.compiler;
   let module = compiler.module;
   if (
@@ -4908,10 +5066,10 @@ function builtin_v128_sub(ctx: BuiltinContext): ExpressionRef {
   );
   return module.unreachable();
 }
-builtins.set(BuiltinNames.v128_sub, builtin_v128_sub);
+builtinFunctions.set(BuiltinNames.v128_sub, builtin_v128_sub);
 
 // v128.mul<T!>(a: v128, b: v128) -> v128
-function builtin_v128_mul(ctx: BuiltinContext): ExpressionRef {
+function builtin_v128_mul(ctx: BuiltinFunctionContext): ExpressionRef {
   let compiler = ctx.compiler;
   let module = compiler.module;
   if (
@@ -4947,10 +5105,10 @@ function builtin_v128_mul(ctx: BuiltinContext): ExpressionRef {
   );
   return module.unreachable();
 }
-builtins.set(BuiltinNames.v128_mul, builtin_v128_mul);
+builtinFunctions.set(BuiltinNames.v128_mul, builtin_v128_mul);
 
 // v128.div<T!>(a: v128, b: v128) -> v128
-function builtin_v128_div(ctx: BuiltinContext): ExpressionRef {
+function builtin_v128_div(ctx: BuiltinFunctionContext): ExpressionRef {
   let compiler = ctx.compiler;
   let module = compiler.module;
   if (
@@ -4978,10 +5136,10 @@ function builtin_v128_div(ctx: BuiltinContext): ExpressionRef {
   );
   return module.unreachable();
 }
-builtins.set(BuiltinNames.v128_div, builtin_v128_div);
+builtinFunctions.set(BuiltinNames.v128_div, builtin_v128_div);
 
 // v128.add_sat<T!>(a: v128, b: v128) -> v128
-function builtin_v128_add_sat(ctx: BuiltinContext): ExpressionRef {
+function builtin_v128_add_sat(ctx: BuiltinFunctionContext): ExpressionRef {
   let compiler = ctx.compiler;
   let module = compiler.module;
   if (
@@ -5011,10 +5169,10 @@ function builtin_v128_add_sat(ctx: BuiltinContext): ExpressionRef {
   );
   return module.unreachable();
 }
-builtins.set(BuiltinNames.v128_add_sat, builtin_v128_add_sat);
+builtinFunctions.set(BuiltinNames.v128_add_sat, builtin_v128_add_sat);
 
 // v128.sub_sat<T!>(a: v128, b: v128) -> v128
-function builtin_v128_sub_sat(ctx: BuiltinContext): ExpressionRef {
+function builtin_v128_sub_sat(ctx: BuiltinFunctionContext): ExpressionRef {
   let compiler = ctx.compiler;
   let module = compiler.module;
   if (
@@ -5044,10 +5202,10 @@ function builtin_v128_sub_sat(ctx: BuiltinContext): ExpressionRef {
   );
   return module.unreachable();
 }
-builtins.set(BuiltinNames.v128_sub_sat, builtin_v128_sub_sat);
+builtinFunctions.set(BuiltinNames.v128_sub_sat, builtin_v128_sub_sat);
 
 // v128.min<T!>(a: v128, b: v128) -> v128
-function builtin_v128_min(ctx: BuiltinContext): ExpressionRef {
+function builtin_v128_min(ctx: BuiltinFunctionContext): ExpressionRef {
   let compiler = ctx.compiler;
   let module = compiler.module;
   if (
@@ -5089,10 +5247,10 @@ function builtin_v128_min(ctx: BuiltinContext): ExpressionRef {
   );
   return module.unreachable();
 }
-builtins.set(BuiltinNames.v128_min, builtin_v128_min);
+builtinFunctions.set(BuiltinNames.v128_min, builtin_v128_min);
 
 // v128.max<T!>(a: v128, b: v128) -> v128
-function builtin_v128_max(ctx: BuiltinContext): ExpressionRef {
+function builtin_v128_max(ctx: BuiltinFunctionContext): ExpressionRef {
   let compiler = ctx.compiler;
   let module = compiler.module;
   if (
@@ -5134,10 +5292,10 @@ function builtin_v128_max(ctx: BuiltinContext): ExpressionRef {
   );
   return module.unreachable();
 }
-builtins.set(BuiltinNames.v128_max, builtin_v128_max);
+builtinFunctions.set(BuiltinNames.v128_max, builtin_v128_max);
 
 // v128.pmin<T!>(a: v128, b: v128) -> v128
-function builtin_v128_pmin(ctx: BuiltinContext): ExpressionRef {
+function builtin_v128_pmin(ctx: BuiltinFunctionContext): ExpressionRef {
   let compiler = ctx.compiler;
   let module = compiler.module;
   if (
@@ -5165,10 +5323,10 @@ function builtin_v128_pmin(ctx: BuiltinContext): ExpressionRef {
   );
   return module.unreachable();
 }
-builtins.set(BuiltinNames.v128_pmin, builtin_v128_pmin);
+builtinFunctions.set(BuiltinNames.v128_pmin, builtin_v128_pmin);
 
 // v128.pmax<T!>(a: v128, b: v128) -> v128
-function builtin_v128_pmax(ctx: BuiltinContext): ExpressionRef {
+function builtin_v128_pmax(ctx: BuiltinFunctionContext): ExpressionRef {
   let compiler = ctx.compiler;
   let module = compiler.module;
   if (
@@ -5196,10 +5354,10 @@ function builtin_v128_pmax(ctx: BuiltinContext): ExpressionRef {
   );
   return module.unreachable();
 }
-builtins.set(BuiltinNames.v128_pmax, builtin_v128_pmax);
+builtinFunctions.set(BuiltinNames.v128_pmax, builtin_v128_pmax);
 
 // v128.dot<T!>(a: v128, b: v128) -> v128
-function builtin_v128_dot(ctx: BuiltinContext): ExpressionRef {
+function builtin_v128_dot(ctx: BuiltinFunctionContext): ExpressionRef {
   let compiler = ctx.compiler;
   let module = compiler.module;
   if (
@@ -5226,10 +5384,10 @@ function builtin_v128_dot(ctx: BuiltinContext): ExpressionRef {
   );
   return module.unreachable();
 }
-builtins.set(BuiltinNames.v128_dot, builtin_v128_dot);
+builtinFunctions.set(BuiltinNames.v128_dot, builtin_v128_dot);
 
 // v128.avgr<T!>(a: v128, b: v128) -> v128
-function builtin_v128_avgr(ctx: BuiltinContext): ExpressionRef {
+function builtin_v128_avgr(ctx: BuiltinFunctionContext): ExpressionRef {
   let compiler = ctx.compiler;
   let module = compiler.module;
   if (
@@ -5257,10 +5415,10 @@ function builtin_v128_avgr(ctx: BuiltinContext): ExpressionRef {
   );
   return module.unreachable();
 }
-builtins.set(BuiltinNames.v128_avgr, builtin_v128_avgr);
+builtinFunctions.set(BuiltinNames.v128_avgr, builtin_v128_avgr);
 
 // v128.eq<T!>(a: v128, b: v128) -> v128
-function builtin_v128_eq(ctx: BuiltinContext): ExpressionRef {
+function builtin_v128_eq(ctx: BuiltinFunctionContext): ExpressionRef {
   let compiler = ctx.compiler;
   let module = compiler.module;
   if (
@@ -5298,10 +5456,10 @@ function builtin_v128_eq(ctx: BuiltinContext): ExpressionRef {
   );
   return module.unreachable();
 }
-builtins.set(BuiltinNames.v128_eq, builtin_v128_eq);
+builtinFunctions.set(BuiltinNames.v128_eq, builtin_v128_eq);
 
 // v128.ne<T!>(a: v128, b: v128) -> v128
-function builtin_v128_ne(ctx: BuiltinContext): ExpressionRef {
+function builtin_v128_ne(ctx: BuiltinFunctionContext): ExpressionRef {
   let compiler = ctx.compiler;
   let module = compiler.module;
   if (
@@ -5339,10 +5497,10 @@ function builtin_v128_ne(ctx: BuiltinContext): ExpressionRef {
   );
   return module.unreachable();
 }
-builtins.set(BuiltinNames.v128_ne, builtin_v128_ne);
+builtinFunctions.set(BuiltinNames.v128_ne, builtin_v128_ne);
 
 // v128.lt<T!>(a: v128, b: v128) -> v128
-function builtin_v128_lt(ctx: BuiltinContext): ExpressionRef {
+function builtin_v128_lt(ctx: BuiltinFunctionContext): ExpressionRef {
   let compiler = ctx.compiler;
   let module = compiler.module;
   if (
@@ -5383,10 +5541,10 @@ function builtin_v128_lt(ctx: BuiltinContext): ExpressionRef {
   );
   return module.unreachable();
 }
-builtins.set(BuiltinNames.v128_lt, builtin_v128_lt);
+builtinFunctions.set(BuiltinNames.v128_lt, builtin_v128_lt);
 
 // v128.le<T!>(a: v128, b: v128) -> v128
-function builtin_v128_le(ctx: BuiltinContext): ExpressionRef {
+function builtin_v128_le(ctx: BuiltinFunctionContext): ExpressionRef {
   let compiler = ctx.compiler;
   let module = compiler.module;
   if (
@@ -5427,10 +5585,10 @@ function builtin_v128_le(ctx: BuiltinContext): ExpressionRef {
   );
   return module.unreachable();
 }
-builtins.set(BuiltinNames.v128_le, builtin_v128_le);
+builtinFunctions.set(BuiltinNames.v128_le, builtin_v128_le);
 
 // v128.gt<T!>(a: v128, b: v128) -> v128
-function builtin_v128_gt(ctx: BuiltinContext): ExpressionRef {
+function builtin_v128_gt(ctx: BuiltinFunctionContext): ExpressionRef {
   let compiler = ctx.compiler;
   let module = compiler.module;
   if (
@@ -5471,10 +5629,10 @@ function builtin_v128_gt(ctx: BuiltinContext): ExpressionRef {
   );
   return module.unreachable();
 }
-builtins.set(BuiltinNames.v128_gt, builtin_v128_gt);
+builtinFunctions.set(BuiltinNames.v128_gt, builtin_v128_gt);
 
 // v128.ge<T!>(a: v128, b: v128) -> v128
-function builtin_v128_ge(ctx: BuiltinContext): ExpressionRef {
+function builtin_v128_ge(ctx: BuiltinFunctionContext): ExpressionRef {
   let compiler = ctx.compiler;
   let module = compiler.module;
   if (
@@ -5515,10 +5673,10 @@ function builtin_v128_ge(ctx: BuiltinContext): ExpressionRef {
   );
   return module.unreachable();
 }
-builtins.set(BuiltinNames.v128_ge, builtin_v128_ge);
+builtinFunctions.set(BuiltinNames.v128_ge, builtin_v128_ge);
 
 // v128.narrow<T!>(a: v128, b: v128) -> v128
-function builtin_v128_narrow(ctx: BuiltinContext): ExpressionRef {
+function builtin_v128_narrow(ctx: BuiltinFunctionContext): ExpressionRef {
   let compiler = ctx.compiler;
   let module = compiler.module;
   if (
@@ -5548,10 +5706,10 @@ function builtin_v128_narrow(ctx: BuiltinContext): ExpressionRef {
   );
   return module.unreachable();
 }
-builtins.set(BuiltinNames.v128_narrow, builtin_v128_narrow);
+builtinFunctions.set(BuiltinNames.v128_narrow, builtin_v128_narrow);
 
 // v128.neg<T!>(a: v128) -> v128
-function builtin_v128_neg(ctx: BuiltinContext): ExpressionRef {
+function builtin_v128_neg(ctx: BuiltinFunctionContext): ExpressionRef {
   let compiler = ctx.compiler;
   let module = compiler.module;
   if (
@@ -5595,10 +5753,10 @@ function builtin_v128_neg(ctx: BuiltinContext): ExpressionRef {
   );
   return module.unreachable();
 }
-builtins.set(BuiltinNames.v128_neg, builtin_v128_neg);
+builtinFunctions.set(BuiltinNames.v128_neg, builtin_v128_neg);
 
 // v128.abs<T!>(a: v128) -> v128
-function builtin_v128_abs(ctx: BuiltinContext): ExpressionRef {
+function builtin_v128_abs(ctx: BuiltinFunctionContext): ExpressionRef {
   let compiler = ctx.compiler;
   let module = compiler.module;
   if (
@@ -5635,10 +5793,10 @@ function builtin_v128_abs(ctx: BuiltinContext): ExpressionRef {
   );
   return module.unreachable();
 }
-builtins.set(BuiltinNames.v128_abs, builtin_v128_abs);
+builtinFunctions.set(BuiltinNames.v128_abs, builtin_v128_abs);
 
 // v128.sqrt<T!>(a: v128) -> v128
-function builtin_v128_sqrt(ctx: BuiltinContext): ExpressionRef {
+function builtin_v128_sqrt(ctx: BuiltinFunctionContext): ExpressionRef {
   let compiler = ctx.compiler;
   let module = compiler.module;
   if (
@@ -5665,10 +5823,10 @@ function builtin_v128_sqrt(ctx: BuiltinContext): ExpressionRef {
   );
   return module.unreachable();
 }
-builtins.set(BuiltinNames.v128_sqrt, builtin_v128_sqrt);
+builtinFunctions.set(BuiltinNames.v128_sqrt, builtin_v128_sqrt);
 
 // v128.ceil<T!>(a: v128) -> v128
-function builtin_v128_ceil(ctx: BuiltinContext): ExpressionRef {
+function builtin_v128_ceil(ctx: BuiltinFunctionContext): ExpressionRef {
   let compiler = ctx.compiler;
   let module = compiler.module;
   if (
@@ -5695,10 +5853,10 @@ function builtin_v128_ceil(ctx: BuiltinContext): ExpressionRef {
   );
   return module.unreachable();
 }
-builtins.set(BuiltinNames.v128_ceil, builtin_v128_ceil);
+builtinFunctions.set(BuiltinNames.v128_ceil, builtin_v128_ceil);
 
 // v128.floor<T!>(a: v128) -> v128
-function builtin_v128_floor(ctx: BuiltinContext): ExpressionRef {
+function builtin_v128_floor(ctx: BuiltinFunctionContext): ExpressionRef {
   let compiler = ctx.compiler;
   let module = compiler.module;
   if (
@@ -5725,10 +5883,10 @@ function builtin_v128_floor(ctx: BuiltinContext): ExpressionRef {
   );
   return module.unreachable();
 }
-builtins.set(BuiltinNames.v128_floor, builtin_v128_floor);
+builtinFunctions.set(BuiltinNames.v128_floor, builtin_v128_floor);
 
 // v128.trunc<T!>(a: v128) -> v128
-function builtin_v128_trunc(ctx: BuiltinContext): ExpressionRef {
+function builtin_v128_trunc(ctx: BuiltinFunctionContext): ExpressionRef {
   let compiler = ctx.compiler;
   let module = compiler.module;
   if (
@@ -5755,10 +5913,10 @@ function builtin_v128_trunc(ctx: BuiltinContext): ExpressionRef {
   );
   return module.unreachable();
 }
-builtins.set(BuiltinNames.v128_trunc, builtin_v128_trunc);
+builtinFunctions.set(BuiltinNames.v128_trunc, builtin_v128_trunc);
 
 // v128.nearest<T!>(a: v128) -> v128
-function builtin_v128_nearest(ctx: BuiltinContext): ExpressionRef {
+function builtin_v128_nearest(ctx: BuiltinFunctionContext): ExpressionRef {
   let compiler = ctx.compiler;
   let module = compiler.module;
   if (
@@ -5785,10 +5943,10 @@ function builtin_v128_nearest(ctx: BuiltinContext): ExpressionRef {
   );
   return module.unreachable();
 }
-builtins.set(BuiltinNames.v128_nearest, builtin_v128_nearest);
+builtinFunctions.set(BuiltinNames.v128_nearest, builtin_v128_nearest);
 
 // v128.convert<T!>(a: v128) -> v128
-function builtin_v128_convert(ctx: BuiltinContext): ExpressionRef {
+function builtin_v128_convert(ctx: BuiltinFunctionContext): ExpressionRef {
   let compiler = ctx.compiler;
   let module = compiler.module;
   if (
@@ -5823,10 +5981,10 @@ function builtin_v128_convert(ctx: BuiltinContext): ExpressionRef {
   );
   return module.unreachable();
 }
-builtins.set(BuiltinNames.v128_convert, builtin_v128_convert);
+builtinFunctions.set(BuiltinNames.v128_convert, builtin_v128_convert);
 
 // v128.convert_low<T!>(a: v128) -> v128
-function builtin_v128_convert_low(ctx: BuiltinContext): ExpressionRef {
+function builtin_v128_convert_low(ctx: BuiltinFunctionContext): ExpressionRef {
   let compiler = ctx.compiler;
   let module = compiler.module;
   if (
@@ -5861,10 +6019,10 @@ function builtin_v128_convert_low(ctx: BuiltinContext): ExpressionRef {
   );
   return module.unreachable();
 }
-builtins.set(BuiltinNames.v128_convert_low, builtin_v128_convert_low);
+builtinFunctions.set(BuiltinNames.v128_convert_low, builtin_v128_convert_low);
 
 // v128.trunc_sat<T!>(a: v128) -> v128
-function builtin_v128_trunc_sat(ctx: BuiltinContext): ExpressionRef {
+function builtin_v128_trunc_sat(ctx: BuiltinFunctionContext): ExpressionRef {
   let compiler = ctx.compiler;
   let module = compiler.module;
   if (
@@ -5899,10 +6057,10 @@ function builtin_v128_trunc_sat(ctx: BuiltinContext): ExpressionRef {
   );
   return module.unreachable();
 }
-builtins.set(BuiltinNames.v128_trunc_sat, builtin_v128_trunc_sat);
+builtinFunctions.set(BuiltinNames.v128_trunc_sat, builtin_v128_trunc_sat);
 
 // v128.trunc_sat_zero<T!>(a: v128) -> v128
-function builtin_v128_trunc_sat_zero(ctx: BuiltinContext): ExpressionRef {
+function builtin_v128_trunc_sat_zero(ctx: BuiltinFunctionContext): ExpressionRef {
   let compiler = ctx.compiler;
   let module = compiler.module;
   if (
@@ -5937,10 +6095,10 @@ function builtin_v128_trunc_sat_zero(ctx: BuiltinContext): ExpressionRef {
   );
   return module.unreachable();
 }
-builtins.set(BuiltinNames.v128_trunc_sat_zero, builtin_v128_trunc_sat_zero);
+builtinFunctions.set(BuiltinNames.v128_trunc_sat_zero, builtin_v128_trunc_sat_zero);
 
 // v128.extend_low<T!>(a: v128) -> v128
-function builtin_v128_extend_low(ctx: BuiltinContext): ExpressionRef {
+function builtin_v128_extend_low(ctx: BuiltinFunctionContext): ExpressionRef {
   let compiler = ctx.compiler;
   let module = compiler.module;
   if (
@@ -5979,10 +6137,10 @@ function builtin_v128_extend_low(ctx: BuiltinContext): ExpressionRef {
   );
   return module.unreachable();
 }
-builtins.set(BuiltinNames.v128_extend_low, builtin_v128_extend_low);
+builtinFunctions.set(BuiltinNames.v128_extend_low, builtin_v128_extend_low);
 
 // v128.extend_high<T!>(a: v128) -> v128
-function builtin_v128_extend_high(ctx: BuiltinContext): ExpressionRef {
+function builtin_v128_extend_high(ctx: BuiltinFunctionContext): ExpressionRef {
   let compiler = ctx.compiler;
   let module = compiler.module;
   if (
@@ -6021,10 +6179,10 @@ function builtin_v128_extend_high(ctx: BuiltinContext): ExpressionRef {
   );
   return module.unreachable();
 }
-builtins.set(BuiltinNames.v128_extend_high, builtin_v128_extend_high);
+builtinFunctions.set(BuiltinNames.v128_extend_high, builtin_v128_extend_high);
 
 // v128.shl<T!>(a: v128, b: i32) -> v128
-function builtin_v128_shl(ctx: BuiltinContext): ExpressionRef {
+function builtin_v128_shl(ctx: BuiltinFunctionContext): ExpressionRef {
   let compiler = ctx.compiler;
   let module = compiler.module;
   if (
@@ -6067,10 +6225,10 @@ function builtin_v128_shl(ctx: BuiltinContext): ExpressionRef {
   );
   return module.unreachable();
 }
-builtins.set(BuiltinNames.v128_shl, builtin_v128_shl);
+builtinFunctions.set(BuiltinNames.v128_shl, builtin_v128_shl);
 
 // v128.shr<T!>(a: v128, b: i32) -> v128
-function builtin_v128_shr(ctx: BuiltinContext): ExpressionRef {
+function builtin_v128_shr(ctx: BuiltinFunctionContext): ExpressionRef {
   let compiler = ctx.compiler;
   let module = compiler.module;
   if (
@@ -6120,9 +6278,9 @@ function builtin_v128_shr(ctx: BuiltinContext): ExpressionRef {
   );
   return module.unreachable();
 }
-builtins.set(BuiltinNames.v128_shr, builtin_v128_shr);
+builtinFunctions.set(BuiltinNames.v128_shr, builtin_v128_shr);
 
-function builtin_v128_bitwise_binary(ctx: BuiltinContext, op: BinaryOp): ExpressionRef {
+function builtin_v128_bitwise_binary(ctx: BuiltinFunctionContext, op: BinaryOp): ExpressionRef {
   let compiler = ctx.compiler;
   let module = compiler.module;
   if (
@@ -6140,30 +6298,30 @@ function builtin_v128_bitwise_binary(ctx: BuiltinContext, op: BinaryOp): Express
 }
 
 // v128.and(a: v128, b: v128) -> v128
-function builtin_v128_and(ctx: BuiltinContext): ExpressionRef {
+function builtin_v128_and(ctx: BuiltinFunctionContext): ExpressionRef {
   return builtin_v128_bitwise_binary(ctx, BinaryOp.AndV128);
 }
-builtins.set(BuiltinNames.v128_and, builtin_v128_and);
+builtinFunctions.set(BuiltinNames.v128_and, builtin_v128_and);
 
 // v128.or(a: v128, b: v128) -> v128
-function builtin_v128_or(ctx: BuiltinContext): ExpressionRef {
+function builtin_v128_or(ctx: BuiltinFunctionContext): ExpressionRef {
   return builtin_v128_bitwise_binary(ctx, BinaryOp.OrV128);
 }
-builtins.set(BuiltinNames.v128_or, builtin_v128_or);
+builtinFunctions.set(BuiltinNames.v128_or, builtin_v128_or);
 
 // v128.xor(a: v128, b: v128) -> v128
-function builtin_v128_xor(ctx: BuiltinContext): ExpressionRef {
+function builtin_v128_xor(ctx: BuiltinFunctionContext): ExpressionRef {
   return builtin_v128_bitwise_binary(ctx, BinaryOp.XorV128);
 }
-builtins.set(BuiltinNames.v128_xor, builtin_v128_xor);
+builtinFunctions.set(BuiltinNames.v128_xor, builtin_v128_xor);
 
 // v128.andnot(a: v128, b: v128) -> v128
-function builtin_v128_andnot(ctx: BuiltinContext): ExpressionRef {
+function builtin_v128_andnot(ctx: BuiltinFunctionContext): ExpressionRef {
   return builtin_v128_bitwise_binary(ctx, BinaryOp.AndnotV128);
 }
-builtins.set(BuiltinNames.v128_andnot, builtin_v128_andnot);
+builtinFunctions.set(BuiltinNames.v128_andnot, builtin_v128_andnot);
 
-function builtin_v128_bitwise_unary(ctx: BuiltinContext, op: UnaryOp): ExpressionRef {
+function builtin_v128_bitwise_unary(ctx: BuiltinFunctionContext, op: UnaryOp): ExpressionRef {
   let compiler = ctx.compiler;
   let module = compiler.module;
   if (
@@ -6180,12 +6338,12 @@ function builtin_v128_bitwise_unary(ctx: BuiltinContext, op: UnaryOp): Expressio
 }
 
 // v128.not(a: v128) -> v128
-function builtin_v128_not(ctx: BuiltinContext): ExpressionRef {
+function builtin_v128_not(ctx: BuiltinFunctionContext): ExpressionRef {
   return builtin_v128_bitwise_unary(ctx, UnaryOp.NotV128);
 }
-builtins.set(BuiltinNames.v128_not, builtin_v128_not);
+builtinFunctions.set(BuiltinNames.v128_not, builtin_v128_not);
 
-function builtin_v128_bitwise_ternary(ctx: BuiltinContext, op: SIMDTernaryOp): ExpressionRef {
+function builtin_v128_bitwise_ternary(ctx: BuiltinFunctionContext, op: SIMDTernaryOp): ExpressionRef {
   let compiler = ctx.compiler;
   let module = compiler.module;
   if (
@@ -6204,13 +6362,13 @@ function builtin_v128_bitwise_ternary(ctx: BuiltinContext, op: SIMDTernaryOp): E
 }
 
 // v128.bitselect(v1: v128, v2: v128, c: v128) -> v128
-function builtin_v128_bitselect(ctx: BuiltinContext): ExpressionRef {
+function builtin_v128_bitselect(ctx: BuiltinFunctionContext): ExpressionRef {
   return builtin_v128_bitwise_ternary(ctx, SIMDTernaryOp.Bitselect);
 }
-builtins.set(BuiltinNames.v128_bitselect, builtin_v128_bitselect);
+builtinFunctions.set(BuiltinNames.v128_bitselect, builtin_v128_bitselect);
 
 // v128.any_true(a: v128) -> bool
-function builtin_v128_any_true(ctx: BuiltinContext): ExpressionRef {
+function builtin_v128_any_true(ctx: BuiltinFunctionContext): ExpressionRef {
   let compiler = ctx.compiler;
   let module = compiler.module;
   if (
@@ -6226,10 +6384,10 @@ function builtin_v128_any_true(ctx: BuiltinContext): ExpressionRef {
   compiler.currentType = Type.bool;
   return module.unary(UnaryOp.AnyTrueV128, arg0);
 }
-builtins.set(BuiltinNames.v128_any_true, builtin_v128_any_true);
+builtinFunctions.set(BuiltinNames.v128_any_true, builtin_v128_any_true);
 
 // v128.all_true<T!>(a: v128) -> bool
-function builtin_v128_all_true(ctx: BuiltinContext): ExpressionRef {
+function builtin_v128_all_true(ctx: BuiltinFunctionContext): ExpressionRef {
   let compiler = ctx.compiler;
   let module = compiler.module;
   if (
@@ -6271,10 +6429,10 @@ function builtin_v128_all_true(ctx: BuiltinContext): ExpressionRef {
   );
   return module.unreachable();
 }
-builtins.set(BuiltinNames.v128_all_true, builtin_v128_all_true);
+builtinFunctions.set(BuiltinNames.v128_all_true, builtin_v128_all_true);
 
 // v128.bitmask<T!>(a: v128) -> i32
-function builtin_v128_bitmask(ctx: BuiltinContext): ExpressionRef {
+function builtin_v128_bitmask(ctx: BuiltinFunctionContext): ExpressionRef {
   let compiler = ctx.compiler;
   let module = compiler.module;
   if (
@@ -6316,10 +6474,10 @@ function builtin_v128_bitmask(ctx: BuiltinContext): ExpressionRef {
   );
   return module.unreachable();
 }
-builtins.set(BuiltinNames.v128_bitmask, builtin_v128_bitmask);
+builtinFunctions.set(BuiltinNames.v128_bitmask, builtin_v128_bitmask);
 
 // v128.popcnt<T!>(a: v128) -> v128
-function builtin_v128_popcnt(ctx: BuiltinContext): ExpressionRef {
+function builtin_v128_popcnt(ctx: BuiltinFunctionContext): ExpressionRef {
   let compiler = ctx.compiler;
   let module = compiler.module;
   if (
@@ -6346,10 +6504,10 @@ function builtin_v128_popcnt(ctx: BuiltinContext): ExpressionRef {
   );
   return module.unreachable();
 }
-builtins.set(BuiltinNames.v128_popcnt, builtin_v128_popcnt);
+builtinFunctions.set(BuiltinNames.v128_popcnt, builtin_v128_popcnt);
 
 // v128.extadd_pairwise<T!>(a: v128) -> v128
-function builtin_v128_extadd_pairwise(ctx: BuiltinContext): ExpressionRef {
+function builtin_v128_extadd_pairwise(ctx: BuiltinFunctionContext): ExpressionRef {
   let compiler = ctx.compiler;
   let module = compiler.module;
   if (
@@ -6378,10 +6536,10 @@ function builtin_v128_extadd_pairwise(ctx: BuiltinContext): ExpressionRef {
   );
   return module.unreachable();
 }
-builtins.set(BuiltinNames.v128_extadd_pairwise, builtin_v128_extadd_pairwise);
+builtinFunctions.set(BuiltinNames.v128_extadd_pairwise, builtin_v128_extadd_pairwise);
 
 // v128.demote_zero<T?>(a: v128) -> v128
-function builtin_v128_demote_zero(ctx: BuiltinContext): ExpressionRef {
+function builtin_v128_demote_zero(ctx: BuiltinFunctionContext): ExpressionRef {
   let compiler = ctx.compiler;
   let module = compiler.module;
   if (
@@ -6408,10 +6566,10 @@ function builtin_v128_demote_zero(ctx: BuiltinContext): ExpressionRef {
   );
   return module.unreachable();
 }
-builtins.set(BuiltinNames.v128_demote_zero, builtin_v128_demote_zero);
+builtinFunctions.set(BuiltinNames.v128_demote_zero, builtin_v128_demote_zero);
 
 // v128.promote_low<T?>(a: v128) -> v128
-function builtin_v128_promote_low(ctx: BuiltinContext): ExpressionRef {
+function builtin_v128_promote_low(ctx: BuiltinFunctionContext): ExpressionRef {
   let compiler = ctx.compiler;
   let module = compiler.module;
   if (
@@ -6438,10 +6596,10 @@ function builtin_v128_promote_low(ctx: BuiltinContext): ExpressionRef {
   );
   return module.unreachable();
 }
-builtins.set(BuiltinNames.v128_promote_low, builtin_v128_promote_low);
+builtinFunctions.set(BuiltinNames.v128_promote_low, builtin_v128_promote_low);
 
 // v128.q15mulr_sat<T!>(a: v128, b: v128) -> v128
-function builtin_v128_q15mulr_sat(ctx: BuiltinContext): ExpressionRef {
+function builtin_v128_q15mulr_sat(ctx: BuiltinFunctionContext): ExpressionRef {
   let compiler = ctx.compiler;
   let module = compiler.module;
   if (
@@ -6468,10 +6626,10 @@ function builtin_v128_q15mulr_sat(ctx: BuiltinContext): ExpressionRef {
   );
   return module.unreachable();
 }
-builtins.set(BuiltinNames.v128_q15mulr_sat, builtin_v128_q15mulr_sat);
+builtinFunctions.set(BuiltinNames.v128_q15mulr_sat, builtin_v128_q15mulr_sat);
 
 // v128.extmul_low<T!>(a: v128, b: v128) -> v128
-function builtin_v128_extmul_low(ctx: BuiltinContext): ExpressionRef {
+function builtin_v128_extmul_low(ctx: BuiltinFunctionContext): ExpressionRef {
   let compiler = ctx.compiler;
   let module = compiler.module;
   if (
@@ -6503,10 +6661,10 @@ function builtin_v128_extmul_low(ctx: BuiltinContext): ExpressionRef {
   );
   return module.unreachable();
 }
-builtins.set(BuiltinNames.v128_extmul_low, builtin_v128_extmul_low);
+builtinFunctions.set(BuiltinNames.v128_extmul_low, builtin_v128_extmul_low);
 
 // v128.extmul_high<T!>(a: v128, b: v128) -> v128
-function builtin_v128_extmul_high(ctx: BuiltinContext): ExpressionRef {
+function builtin_v128_extmul_high(ctx: BuiltinFunctionContext): ExpressionRef {
   let compiler = ctx.compiler;
   let module = compiler.module;
   if (
@@ -6538,12 +6696,12 @@ function builtin_v128_extmul_high(ctx: BuiltinContext): ExpressionRef {
   );
   return module.unreachable();
 }
-builtins.set(BuiltinNames.v128_extmul_high, builtin_v128_extmul_high);
+builtinFunctions.set(BuiltinNames.v128_extmul_high, builtin_v128_extmul_high);
 
 // === Internal runtime =======================================================================
 
 // __visit_globals(cookie: u32) -> void
-function builtin_visit_globals(ctx: BuiltinContext): ExpressionRef {
+function builtin_visit_globals(ctx: BuiltinFunctionContext): ExpressionRef {
   let compiler = ctx.compiler;
   let module = compiler.module;
   if (
@@ -6559,10 +6717,10 @@ function builtin_visit_globals(ctx: BuiltinContext): ExpressionRef {
   compiler.currentType = Type.void;
   return module.call(BuiltinNames.visit_globals, [ arg0 ], TypeRef.None);
 }
-builtins.set(BuiltinNames.visit_globals, builtin_visit_globals);
+builtinFunctions.set(BuiltinNames.visit_globals, builtin_visit_globals);
 
 // __visit_members(ref: usize, cookie: u32) -> void
-function builtin_visit_members(ctx: BuiltinContext): ExpressionRef {
+function builtin_visit_members(ctx: BuiltinFunctionContext): ExpressionRef {
   let compiler = ctx.compiler;
   let module = compiler.module;
   if (
@@ -6579,7 +6737,7 @@ function builtin_visit_members(ctx: BuiltinContext): ExpressionRef {
   compiler.currentType = Type.void;
   return module.call(BuiltinNames.visit_members, [ arg0, arg1 ], TypeRef.None);
 }
-builtins.set(BuiltinNames.visit_members, builtin_visit_members);
+builtinFunctions.set(BuiltinNames.visit_members, builtin_visit_members);
 
 // === Inline assembler =======================================================================
 
@@ -6589,3555 +6747,3555 @@ builtins.set(BuiltinNames.visit_members, builtin_visit_members);
 //   eq, eqz, ne, lt_s, lt_u, le_s, le_u, gt_s, gt_u, ge_s, ge_u
 
 // i32.clz -> clz<i32>
-function builtin_i32_clz(ctx: BuiltinContext): ExpressionRef {
+function builtin_i32_clz(ctx: BuiltinFunctionContext): ExpressionRef {
   checkTypeAbsent(ctx);
   ctx.typeArguments = [ Type.i32 ];
   ctx.contextualType = Type.i32;
   return builtin_clz(ctx);
 }
-builtins.set(BuiltinNames.i32_clz, builtin_i32_clz);
+builtinFunctions.set(BuiltinNames.i32_clz, builtin_i32_clz);
 
 // i64.clz -> clz<i64>
-function builtin_i64_clz(ctx: BuiltinContext): ExpressionRef {
+function builtin_i64_clz(ctx: BuiltinFunctionContext): ExpressionRef {
   checkTypeAbsent(ctx);
   ctx.typeArguments = [ Type.i64 ];
   ctx.contextualType = Type.i64;
   return builtin_clz(ctx);
 }
-builtins.set(BuiltinNames.i64_clz, builtin_i64_clz);
+builtinFunctions.set(BuiltinNames.i64_clz, builtin_i64_clz);
 
 // i32.ctz -> ctz<i32>
-function builtin_i32_ctz(ctx: BuiltinContext): ExpressionRef {
+function builtin_i32_ctz(ctx: BuiltinFunctionContext): ExpressionRef {
   checkTypeAbsent(ctx);
   ctx.typeArguments = [ Type.i32 ];
   ctx.contextualType = Type.i32;
   return builtin_ctz(ctx);
 }
-builtins.set(BuiltinNames.i32_ctz, builtin_i32_ctz);
+builtinFunctions.set(BuiltinNames.i32_ctz, builtin_i32_ctz);
 
 // i64.ctz -> ctz<i64>
-function builtin_i64_ctz(ctx: BuiltinContext): ExpressionRef {
+function builtin_i64_ctz(ctx: BuiltinFunctionContext): ExpressionRef {
   checkTypeAbsent(ctx);
   ctx.typeArguments = [ Type.i64 ];
   ctx.contextualType = Type.i64;
   return builtin_ctz(ctx);
 }
-builtins.set(BuiltinNames.i64_ctz, builtin_i64_ctz);
+builtinFunctions.set(BuiltinNames.i64_ctz, builtin_i64_ctz);
 
 // i32.popcnt -> popcnt<i32>
-function builtin_i32_popcnt(ctx: BuiltinContext): ExpressionRef {
+function builtin_i32_popcnt(ctx: BuiltinFunctionContext): ExpressionRef {
   checkTypeAbsent(ctx);
   ctx.typeArguments = [ Type.i32 ];
   ctx.contextualType = Type.i32;
   return builtin_popcnt(ctx);
 }
-builtins.set(BuiltinNames.i32_popcnt, builtin_i32_popcnt);
+builtinFunctions.set(BuiltinNames.i32_popcnt, builtin_i32_popcnt);
 
 // i64.popcnt -> popcnt<i64>
-function builtin_i64_popcnt(ctx: BuiltinContext): ExpressionRef {
+function builtin_i64_popcnt(ctx: BuiltinFunctionContext): ExpressionRef {
   checkTypeAbsent(ctx);
   ctx.typeArguments = [ Type.i64 ];
   ctx.contextualType = Type.i64;
   return builtin_popcnt(ctx);
 }
-builtins.set(BuiltinNames.i64_popcnt, builtin_i64_popcnt);
+builtinFunctions.set(BuiltinNames.i64_popcnt, builtin_i64_popcnt);
 
 // i32.rotl -> rotl<i32>
-function builtin_i32_rotl(ctx: BuiltinContext): ExpressionRef {
+function builtin_i32_rotl(ctx: BuiltinFunctionContext): ExpressionRef {
   checkTypeAbsent(ctx);
   ctx.typeArguments = [ Type.i32 ];
   ctx.contextualType = Type.i32;
   return builtin_rotl(ctx);
 }
-builtins.set(BuiltinNames.i32_rotl, builtin_i32_rotl);
+builtinFunctions.set(BuiltinNames.i32_rotl, builtin_i32_rotl);
 
 // i64.rotl -> rotl<i64>
-function builtin_i64_rotl(ctx: BuiltinContext): ExpressionRef {
+function builtin_i64_rotl(ctx: BuiltinFunctionContext): ExpressionRef {
   checkTypeAbsent(ctx);
   ctx.typeArguments = [ Type.i64 ];
   ctx.contextualType = Type.i64;
   return builtin_rotl(ctx);
 }
-builtins.set(BuiltinNames.i64_rotl, builtin_i64_rotl);
+builtinFunctions.set(BuiltinNames.i64_rotl, builtin_i64_rotl);
 
 // i32.rotr -> rotr<i32>
-function builtin_i32_rotr(ctx: BuiltinContext): ExpressionRef {
+function builtin_i32_rotr(ctx: BuiltinFunctionContext): ExpressionRef {
   checkTypeAbsent(ctx);
   ctx.typeArguments = [ Type.i32 ];
   ctx.contextualType = Type.i32;
   return builtin_rotr(ctx);
 }
-builtins.set(BuiltinNames.i32_rotr, builtin_i32_rotr);
+builtinFunctions.set(BuiltinNames.i32_rotr, builtin_i32_rotr);
 
 // i64.rotr -> rotr<i64>
-function builtin_i64_rotr(ctx: BuiltinContext): ExpressionRef {
+function builtin_i64_rotr(ctx: BuiltinFunctionContext): ExpressionRef {
   checkTypeAbsent(ctx);
   ctx.typeArguments = [ Type.i64 ];
   ctx.contextualType = Type.i64;
   return builtin_rotr(ctx);
 }
-builtins.set(BuiltinNames.i64_rotr, builtin_i64_rotr);
+builtinFunctions.set(BuiltinNames.i64_rotr, builtin_i64_rotr);
 
 // f32.abs -> abs<f32>
-function builtin_f32_abs(ctx: BuiltinContext): ExpressionRef {
+function builtin_f32_abs(ctx: BuiltinFunctionContext): ExpressionRef {
   checkTypeAbsent(ctx);
   ctx.typeArguments = [ Type.f32 ];
   ctx.contextualType = Type.f32;
   return builtin_abs(ctx);
 }
-builtins.set(BuiltinNames.f32_abs, builtin_f32_abs);
+builtinFunctions.set(BuiltinNames.f32_abs, builtin_f32_abs);
 
 // f64.abs -> abs<f64>
-function builtin_f64_abs(ctx: BuiltinContext): ExpressionRef {
+function builtin_f64_abs(ctx: BuiltinFunctionContext): ExpressionRef {
   checkTypeAbsent(ctx);
   ctx.typeArguments = [ Type.f64 ];
   ctx.contextualType = Type.f64;
   return builtin_abs(ctx);
 }
-builtins.set(BuiltinNames.f64_abs, builtin_f64_abs);
+builtinFunctions.set(BuiltinNames.f64_abs, builtin_f64_abs);
 
 // f32.max -> max<f32>
-function builtin_f32_max(ctx: BuiltinContext): ExpressionRef {
+function builtin_f32_max(ctx: BuiltinFunctionContext): ExpressionRef {
   checkTypeAbsent(ctx);
   ctx.typeArguments = [ Type.f32 ];
   ctx.contextualType = Type.f32;
   return builtin_max(ctx);
 }
-builtins.set(BuiltinNames.f32_max, builtin_f32_max);
+builtinFunctions.set(BuiltinNames.f32_max, builtin_f32_max);
 
 // f64.max -> max<f64>
-function builtin_f64_max(ctx: BuiltinContext): ExpressionRef {
+function builtin_f64_max(ctx: BuiltinFunctionContext): ExpressionRef {
   checkTypeAbsent(ctx);
   ctx.typeArguments = [ Type.f64 ];
   ctx.contextualType = Type.f64;
   return builtin_max(ctx);
 }
-builtins.set(BuiltinNames.f64_max, builtin_f64_max);
+builtinFunctions.set(BuiltinNames.f64_max, builtin_f64_max);
 
 // f32.min -> min<f32>
-function builtin_f32_min(ctx: BuiltinContext): ExpressionRef {
+function builtin_f32_min(ctx: BuiltinFunctionContext): ExpressionRef {
   checkTypeAbsent(ctx);
   ctx.typeArguments = [ Type.f32 ];
   ctx.contextualType = Type.f32;
   return builtin_min(ctx);
 }
-builtins.set(BuiltinNames.f32_min, builtin_f32_min);
+builtinFunctions.set(BuiltinNames.f32_min, builtin_f32_min);
 
 // f64.min -> min<f64>
-function builtin_f64_min(ctx: BuiltinContext): ExpressionRef {
+function builtin_f64_min(ctx: BuiltinFunctionContext): ExpressionRef {
   checkTypeAbsent(ctx);
   ctx.typeArguments = [ Type.f64 ];
   ctx.contextualType = Type.f64;
   return builtin_min(ctx);
 }
-builtins.set(BuiltinNames.f64_min, builtin_f64_min);
+builtinFunctions.set(BuiltinNames.f64_min, builtin_f64_min);
 
 // f32.ceil -> ceil<f32>
-function builtin_f32_ceil(ctx: BuiltinContext): ExpressionRef {
+function builtin_f32_ceil(ctx: BuiltinFunctionContext): ExpressionRef {
   checkTypeAbsent(ctx);
   ctx.typeArguments = [ Type.f32 ];
   ctx.contextualType = Type.f32;
   return builtin_ceil(ctx);
 }
-builtins.set(BuiltinNames.f32_ceil, builtin_f32_ceil);
+builtinFunctions.set(BuiltinNames.f32_ceil, builtin_f32_ceil);
 
 // f64.ceil -> ceil<f64>
-function builtin_f64_ceil(ctx: BuiltinContext): ExpressionRef {
+function builtin_f64_ceil(ctx: BuiltinFunctionContext): ExpressionRef {
   checkTypeAbsent(ctx);
   ctx.typeArguments = [ Type.f64 ];
   ctx.contextualType = Type.f64;
   return builtin_ceil(ctx);
 }
-builtins.set(BuiltinNames.f64_ceil, builtin_f64_ceil);
+builtinFunctions.set(BuiltinNames.f64_ceil, builtin_f64_ceil);
 
 // f32.floor -> floor<f32>
-function builtin_f32_floor(ctx: BuiltinContext): ExpressionRef {
+function builtin_f32_floor(ctx: BuiltinFunctionContext): ExpressionRef {
   checkTypeAbsent(ctx);
   ctx.typeArguments = [ Type.f32 ];
   ctx.contextualType = Type.f32;
   return builtin_floor(ctx);
 }
-builtins.set(BuiltinNames.f32_floor, builtin_f32_floor);
+builtinFunctions.set(BuiltinNames.f32_floor, builtin_f32_floor);
 
 // f64.floor -> floor<f64>
-function builtin_f64_floor(ctx: BuiltinContext): ExpressionRef {
+function builtin_f64_floor(ctx: BuiltinFunctionContext): ExpressionRef {
   checkTypeAbsent(ctx);
   ctx.typeArguments = [ Type.f64 ];
   ctx.contextualType = Type.f64;
   return builtin_floor(ctx);
 }
-builtins.set(BuiltinNames.f64_floor, builtin_f64_floor);
+builtinFunctions.set(BuiltinNames.f64_floor, builtin_f64_floor);
 
 // f32.copysign -> copysign<f32>
-function builtin_f32_copysign(ctx: BuiltinContext): ExpressionRef {
+function builtin_f32_copysign(ctx: BuiltinFunctionContext): ExpressionRef {
   checkTypeAbsent(ctx);
   ctx.typeArguments = [ Type.f32 ];
   ctx.contextualType = Type.f32;
   return builtin_copysign(ctx);
 }
-builtins.set(BuiltinNames.f32_copysign, builtin_f32_copysign);
+builtinFunctions.set(BuiltinNames.f32_copysign, builtin_f32_copysign);
 
 // f64.copysign -> copysign<f64>
-function builtin_f64_copysign(ctx: BuiltinContext): ExpressionRef {
+function builtin_f64_copysign(ctx: BuiltinFunctionContext): ExpressionRef {
   checkTypeAbsent(ctx);
   ctx.typeArguments = [ Type.f64 ];
   ctx.contextualType = Type.f64;
   return builtin_copysign(ctx);
 }
-builtins.set(BuiltinNames.f64_copysign, builtin_f64_copysign);
+builtinFunctions.set(BuiltinNames.f64_copysign, builtin_f64_copysign);
 
 // f32.nearest -> nearest<f32>
-function builtin_f32_nearest(ctx: BuiltinContext): ExpressionRef {
+function builtin_f32_nearest(ctx: BuiltinFunctionContext): ExpressionRef {
   checkTypeAbsent(ctx);
   ctx.typeArguments = [ Type.f32 ];
   ctx.contextualType = Type.f32;
   return builtin_nearest(ctx);
 }
-builtins.set(BuiltinNames.f32_nearest, builtin_f32_nearest);
+builtinFunctions.set(BuiltinNames.f32_nearest, builtin_f32_nearest);
 
 // f64.nearest -> nearest<f64>
-function builtin_f64_nearest(ctx: BuiltinContext): ExpressionRef {
+function builtin_f64_nearest(ctx: BuiltinFunctionContext): ExpressionRef {
   checkTypeAbsent(ctx);
   ctx.typeArguments = [ Type.f64 ];
   ctx.contextualType = Type.f64;
   return builtin_nearest(ctx);
 }
-builtins.set(BuiltinNames.f64_nearest, builtin_f64_nearest);
+builtinFunctions.set(BuiltinNames.f64_nearest, builtin_f64_nearest);
 
 // i32.reinterpret_f32 -> reinterpret<i32>
-function builtin_i32_reinterpret_f32(ctx: BuiltinContext): ExpressionRef {
+function builtin_i32_reinterpret_f32(ctx: BuiltinFunctionContext): ExpressionRef {
   checkTypeAbsent(ctx);
   ctx.typeArguments = [ Type.i32 ];
   ctx.contextualType = Type.f32;
   return builtin_reinterpret(ctx);
 }
-builtins.set(BuiltinNames.i32_reinterpret_f32, builtin_i32_reinterpret_f32);
+builtinFunctions.set(BuiltinNames.i32_reinterpret_f32, builtin_i32_reinterpret_f32);
 
 // i64.reinterpret_f64 -> reinterpret<i64>
-function builtin_i64_reinterpret_f64(ctx: BuiltinContext): ExpressionRef {
+function builtin_i64_reinterpret_f64(ctx: BuiltinFunctionContext): ExpressionRef {
   checkTypeAbsent(ctx);
   ctx.typeArguments = [ Type.i64 ];
   ctx.contextualType = Type.f64;
   return builtin_reinterpret(ctx);
 }
-builtins.set(BuiltinNames.i64_reinterpret_f64, builtin_i64_reinterpret_f64);
+builtinFunctions.set(BuiltinNames.i64_reinterpret_f64, builtin_i64_reinterpret_f64);
 
 // f32.reinterpret_i32 -> reinterpret<f32>
-function builtin_f32_reinterpret_i32(ctx: BuiltinContext): ExpressionRef {
+function builtin_f32_reinterpret_i32(ctx: BuiltinFunctionContext): ExpressionRef {
   checkTypeAbsent(ctx);
   ctx.typeArguments = [ Type.f32 ];
   ctx.contextualType = Type.i32;
   return builtin_reinterpret(ctx);
 }
-builtins.set(BuiltinNames.f32_reinterpret_i32, builtin_f32_reinterpret_i32);
+builtinFunctions.set(BuiltinNames.f32_reinterpret_i32, builtin_f32_reinterpret_i32);
 
 // f64.reinterpret_i64 -> reinterpret<f64>
-function builtin_f64_reinterpret_i64(ctx: BuiltinContext): ExpressionRef {
+function builtin_f64_reinterpret_i64(ctx: BuiltinFunctionContext): ExpressionRef {
   checkTypeAbsent(ctx);
   ctx.typeArguments = [ Type.f64 ];
   ctx.contextualType = Type.i64;
   return builtin_reinterpret(ctx);
 }
-builtins.set(BuiltinNames.f64_reinterpret_i64, builtin_f64_reinterpret_i64);
+builtinFunctions.set(BuiltinNames.f64_reinterpret_i64, builtin_f64_reinterpret_i64);
 
 // f32.sqrt -> sqrt<f32>
-function builtin_f32_sqrt(ctx: BuiltinContext): ExpressionRef {
+function builtin_f32_sqrt(ctx: BuiltinFunctionContext): ExpressionRef {
   checkTypeAbsent(ctx);
   ctx.typeArguments = [ Type.f32 ];
   ctx.contextualType = Type.f32;
   return builtin_sqrt(ctx);
 }
-builtins.set(BuiltinNames.f32_sqrt, builtin_f32_sqrt);
+builtinFunctions.set(BuiltinNames.f32_sqrt, builtin_f32_sqrt);
 
 // f64.sqrt -> sqrt<f64>
-function builtin_f64_sqrt(ctx: BuiltinContext): ExpressionRef {
+function builtin_f64_sqrt(ctx: BuiltinFunctionContext): ExpressionRef {
   checkTypeAbsent(ctx);
   ctx.typeArguments = [ Type.f64 ];
   ctx.contextualType = Type.f64;
   return builtin_sqrt(ctx);
 }
-builtins.set(BuiltinNames.f64_sqrt, builtin_f64_sqrt);
+builtinFunctions.set(BuiltinNames.f64_sqrt, builtin_f64_sqrt);
 
 // f32.trunc -> trunc<f32>
-function builtin_f32_trunc(ctx: BuiltinContext): ExpressionRef {
+function builtin_f32_trunc(ctx: BuiltinFunctionContext): ExpressionRef {
   checkTypeAbsent(ctx);
   ctx.typeArguments = [ Type.f32 ];
   ctx.contextualType = Type.f32;
   return builtin_trunc(ctx);
 }
-builtins.set(BuiltinNames.f32_trunc, builtin_f32_trunc);
+builtinFunctions.set(BuiltinNames.f32_trunc, builtin_f32_trunc);
 
 // f64.trunc -> trunc<f64>
-function builtin_f64_trunc(ctx: BuiltinContext): ExpressionRef {
+function builtin_f64_trunc(ctx: BuiltinFunctionContext): ExpressionRef {
   checkTypeAbsent(ctx);
   ctx.typeArguments = [ Type.f64 ];
   ctx.contextualType = Type.f64;
   return builtin_trunc(ctx);
 }
-builtins.set(BuiltinNames.f64_trunc, builtin_f64_trunc);
+builtinFunctions.set(BuiltinNames.f64_trunc, builtin_f64_trunc);
 
 // i32.rem_s -> rem<i32>
-function builtin_i32_rem_s(ctx: BuiltinContext): ExpressionRef {
+function builtin_i32_rem_s(ctx: BuiltinFunctionContext): ExpressionRef {
   checkTypeAbsent(ctx);
   ctx.typeArguments = [ Type.i32 ];
   ctx.contextualType = Type.i32;
   return builtin_rem(ctx);
 }
-builtins.set(BuiltinNames.i32_rem_s, builtin_i32_rem_s);
+builtinFunctions.set(BuiltinNames.i32_rem_s, builtin_i32_rem_s);
 
 // i32.rem_u -> rem<u32>
-function builtin_i32_rem_u(ctx: BuiltinContext): ExpressionRef {
+function builtin_i32_rem_u(ctx: BuiltinFunctionContext): ExpressionRef {
   checkTypeAbsent(ctx);
   ctx.typeArguments = [ Type.u32 ];
   ctx.contextualType = Type.u32;
   return builtin_rem(ctx);
 }
-builtins.set(BuiltinNames.i32_rem_u, builtin_i32_rem_u);
+builtinFunctions.set(BuiltinNames.i32_rem_u, builtin_i32_rem_u);
 
 // i64.rem_s -> rem<i64>
-function builtin_i64_rem_s(ctx: BuiltinContext): ExpressionRef {
+function builtin_i64_rem_s(ctx: BuiltinFunctionContext): ExpressionRef {
   checkTypeAbsent(ctx);
   ctx.typeArguments = [ Type.i64 ];
   ctx.contextualType = Type.i64;
   return builtin_rem(ctx);
 }
-builtins.set(BuiltinNames.i64_rem_s, builtin_i64_rem_s);
+builtinFunctions.set(BuiltinNames.i64_rem_s, builtin_i64_rem_s);
 
 // i64.rem_u -> rem<u64>
-function builtin_i64_rem_u(ctx: BuiltinContext): ExpressionRef {
+function builtin_i64_rem_u(ctx: BuiltinFunctionContext): ExpressionRef {
   checkTypeAbsent(ctx);
   ctx.typeArguments = [ Type.u64 ];
   ctx.contextualType = Type.u64;
   return builtin_rem(ctx);
 }
-builtins.set(BuiltinNames.i64_rem_u, builtin_i64_rem_u);
+builtinFunctions.set(BuiltinNames.i64_rem_u, builtin_i64_rem_u);
 
 // i32.add -> add<i32>
-function builtin_i32_add(ctx: BuiltinContext): ExpressionRef {
+function builtin_i32_add(ctx: BuiltinFunctionContext): ExpressionRef {
   checkTypeAbsent(ctx);
   ctx.typeArguments = [ Type.i32 ];
   ctx.contextualType = Type.i32;
   return builtin_add(ctx);
 }
-builtins.set(BuiltinNames.i32_add, builtin_i32_add);
+builtinFunctions.set(BuiltinNames.i32_add, builtin_i32_add);
 
 // i64.add -> add<i64>
-function builtin_i64_add(ctx: BuiltinContext): ExpressionRef {
+function builtin_i64_add(ctx: BuiltinFunctionContext): ExpressionRef {
   checkTypeAbsent(ctx);
   ctx.typeArguments = [ Type.i64 ];
   ctx.contextualType = Type.i64;
   return builtin_add(ctx);
 }
-builtins.set(BuiltinNames.i64_add, builtin_i64_add);
+builtinFunctions.set(BuiltinNames.i64_add, builtin_i64_add);
 
 // f32.add -> add<f32>
-function builtin_f32_add(ctx: BuiltinContext): ExpressionRef {
+function builtin_f32_add(ctx: BuiltinFunctionContext): ExpressionRef {
   checkTypeAbsent(ctx);
   ctx.typeArguments = [ Type.f32 ];
   ctx.contextualType = Type.f32;
   return builtin_add(ctx);
 }
-builtins.set(BuiltinNames.f32_add, builtin_f32_add);
+builtinFunctions.set(BuiltinNames.f32_add, builtin_f32_add);
 
 // f64.add -> add<f64>
-function builtin_f64_add(ctx: BuiltinContext): ExpressionRef {
+function builtin_f64_add(ctx: BuiltinFunctionContext): ExpressionRef {
   checkTypeAbsent(ctx);
   ctx.typeArguments = [ Type.f64 ];
   ctx.contextualType = Type.f64;
   return builtin_add(ctx);
 }
-builtins.set(BuiltinNames.f64_add, builtin_f64_add);
+builtinFunctions.set(BuiltinNames.f64_add, builtin_f64_add);
 
 // i32.sub -> sub<i32>
-function builtin_i32_sub(ctx: BuiltinContext): ExpressionRef {
+function builtin_i32_sub(ctx: BuiltinFunctionContext): ExpressionRef {
   checkTypeAbsent(ctx);
   ctx.typeArguments = [ Type.i32 ];
   ctx.contextualType = Type.i32;
   return builtin_sub(ctx);
 }
-builtins.set(BuiltinNames.i32_sub, builtin_i32_sub);
+builtinFunctions.set(BuiltinNames.i32_sub, builtin_i32_sub);
 
 // i64.sub -> sub<i64>
-function builtin_i64_sub(ctx: BuiltinContext): ExpressionRef {
+function builtin_i64_sub(ctx: BuiltinFunctionContext): ExpressionRef {
   checkTypeAbsent(ctx);
   ctx.typeArguments = [ Type.i64 ];
   ctx.contextualType = Type.i64;
   return builtin_sub(ctx);
 }
-builtins.set(BuiltinNames.i64_sub, builtin_i64_sub);
+builtinFunctions.set(BuiltinNames.i64_sub, builtin_i64_sub);
 
 // f32.sub -> sub<f32>
-function builtin_f32_sub(ctx: BuiltinContext): ExpressionRef {
+function builtin_f32_sub(ctx: BuiltinFunctionContext): ExpressionRef {
   checkTypeAbsent(ctx);
   ctx.typeArguments = [ Type.f32 ];
   ctx.contextualType = Type.f32;
   return builtin_sub(ctx);
 }
-builtins.set(BuiltinNames.f32_sub, builtin_f32_sub);
+builtinFunctions.set(BuiltinNames.f32_sub, builtin_f32_sub);
 
 // f64.sub -> sub<f64>
-function builtin_f64_sub(ctx: BuiltinContext): ExpressionRef {
+function builtin_f64_sub(ctx: BuiltinFunctionContext): ExpressionRef {
   checkTypeAbsent(ctx);
   ctx.typeArguments = [ Type.f64 ];
   ctx.contextualType = Type.f64;
   return builtin_sub(ctx);
 }
-builtins.set(BuiltinNames.f64_sub, builtin_f64_sub);
+builtinFunctions.set(BuiltinNames.f64_sub, builtin_f64_sub);
 
 // i32.mul -> mul<i32>
-function builtin_i32_mul(ctx: BuiltinContext): ExpressionRef {
+function builtin_i32_mul(ctx: BuiltinFunctionContext): ExpressionRef {
   checkTypeAbsent(ctx);
   ctx.typeArguments = [ Type.i32 ];
   ctx.contextualType = Type.i32;
   return builtin_mul(ctx);
 }
-builtins.set(BuiltinNames.i32_mul, builtin_i32_mul);
+builtinFunctions.set(BuiltinNames.i32_mul, builtin_i32_mul);
 
 // i64.mul -> mul<i64>
-function builtin_i64_mul(ctx: BuiltinContext): ExpressionRef {
+function builtin_i64_mul(ctx: BuiltinFunctionContext): ExpressionRef {
   checkTypeAbsent(ctx);
   ctx.typeArguments = [ Type.i64 ];
   ctx.contextualType = Type.i64;
   return builtin_mul(ctx);
 }
-builtins.set(BuiltinNames.i64_mul, builtin_i64_mul);
+builtinFunctions.set(BuiltinNames.i64_mul, builtin_i64_mul);
 
 // f32.mul -> mul<f32>
-function builtin_f32_mul(ctx: BuiltinContext): ExpressionRef {
+function builtin_f32_mul(ctx: BuiltinFunctionContext): ExpressionRef {
   checkTypeAbsent(ctx);
   ctx.typeArguments = [ Type.f32 ];
   ctx.contextualType = Type.f32;
   return builtin_mul(ctx);
 }
-builtins.set(BuiltinNames.f32_mul, builtin_f32_mul);
+builtinFunctions.set(BuiltinNames.f32_mul, builtin_f32_mul);
 
 // f64.mul -> mul<f64>
-function builtin_f64_mul(ctx: BuiltinContext): ExpressionRef {
+function builtin_f64_mul(ctx: BuiltinFunctionContext): ExpressionRef {
   checkTypeAbsent(ctx);
   ctx.typeArguments = [ Type.f64 ];
   ctx.contextualType = Type.f64;
   return builtin_mul(ctx);
 }
-builtins.set(BuiltinNames.f64_mul, builtin_f64_mul);
+builtinFunctions.set(BuiltinNames.f64_mul, builtin_f64_mul);
 
 // i32.div_s -> div<i32>
-function builtin_i32_div_s(ctx: BuiltinContext): ExpressionRef {
+function builtin_i32_div_s(ctx: BuiltinFunctionContext): ExpressionRef {
   checkTypeAbsent(ctx);
   ctx.typeArguments = [ Type.i32 ];
   ctx.contextualType = Type.i32;
   return builtin_div(ctx);
 }
-builtins.set(BuiltinNames.i32_div_s, builtin_i32_div_s);
+builtinFunctions.set(BuiltinNames.i32_div_s, builtin_i32_div_s);
 
 // i32.div_u -> div<u32>
-function builtin_i32_div_u(ctx: BuiltinContext): ExpressionRef {
+function builtin_i32_div_u(ctx: BuiltinFunctionContext): ExpressionRef {
   checkTypeAbsent(ctx);
   ctx.typeArguments = [ Type.u32 ];
   ctx.contextualType = Type.u32;
   return builtin_div(ctx);
 }
-builtins.set(BuiltinNames.i32_div_u, builtin_i32_div_u);
+builtinFunctions.set(BuiltinNames.i32_div_u, builtin_i32_div_u);
 
 // i64.div_s -> div_s<i64>
-function builtin_i64_div_s(ctx: BuiltinContext): ExpressionRef {
+function builtin_i64_div_s(ctx: BuiltinFunctionContext): ExpressionRef {
   checkTypeAbsent(ctx);
   ctx.typeArguments = [ Type.i64 ];
   ctx.contextualType = Type.i64;
   return builtin_div(ctx);
 }
-builtins.set(BuiltinNames.i64_div_s, builtin_i64_div_s);
+builtinFunctions.set(BuiltinNames.i64_div_s, builtin_i64_div_s);
 
 // i64.div_u -> div_u<u64>
-function builtin_i64_div_u(ctx: BuiltinContext): ExpressionRef {
+function builtin_i64_div_u(ctx: BuiltinFunctionContext): ExpressionRef {
   checkTypeAbsent(ctx);
   ctx.typeArguments = [ Type.u64 ];
   ctx.contextualType = Type.u64;
   return builtin_div(ctx);
 }
-builtins.set(BuiltinNames.i64_div_u, builtin_i64_div_u);
+builtinFunctions.set(BuiltinNames.i64_div_u, builtin_i64_div_u);
 
 // f32.div -> div<f32>
-function builtin_f32_div(ctx: BuiltinContext): ExpressionRef {
+function builtin_f32_div(ctx: BuiltinFunctionContext): ExpressionRef {
   checkTypeAbsent(ctx);
   ctx.typeArguments = [ Type.f32 ];
   ctx.contextualType = Type.f32;
   return builtin_div(ctx);
 }
-builtins.set(BuiltinNames.f32_div, builtin_f32_div);
+builtinFunctions.set(BuiltinNames.f32_div, builtin_f32_div);
 
 // f64.div -> div<f64>
-function builtin_f64_div(ctx: BuiltinContext): ExpressionRef {
+function builtin_f64_div(ctx: BuiltinFunctionContext): ExpressionRef {
   checkTypeAbsent(ctx);
   ctx.typeArguments = [ Type.f64 ];
   ctx.contextualType = Type.f64;
   return builtin_div(ctx);
 }
-builtins.set(BuiltinNames.f64_div, builtin_f64_div);
+builtinFunctions.set(BuiltinNames.f64_div, builtin_f64_div);
 
 // i32.eq -> eq<i32>
-function builtin_i32_eq(ctx: BuiltinContext): ExpressionRef {
+function builtin_i32_eq(ctx: BuiltinFunctionContext): ExpressionRef {
   checkTypeAbsent(ctx);
   ctx.typeArguments = [ Type.i32 ];
   ctx.contextualType = Type.i32;
   return builtin_eq(ctx);
 }
-builtins.set(BuiltinNames.i32_eq, builtin_i32_eq);
+builtinFunctions.set(BuiltinNames.i32_eq, builtin_i32_eq);
 
 // i64.eq -> eq<i64>
-function builtin_i64_eq(ctx: BuiltinContext): ExpressionRef {
+function builtin_i64_eq(ctx: BuiltinFunctionContext): ExpressionRef {
   checkTypeAbsent(ctx);
   ctx.typeArguments = [ Type.i64 ];
   ctx.contextualType = Type.i32;
   return builtin_eq(ctx);
 }
-builtins.set(BuiltinNames.i64_eq, builtin_i64_eq);
+builtinFunctions.set(BuiltinNames.i64_eq, builtin_i64_eq);
 
 // f32.eq -> eq<f32>
-function builtin_f32_eq(ctx: BuiltinContext): ExpressionRef {
+function builtin_f32_eq(ctx: BuiltinFunctionContext): ExpressionRef {
   checkTypeAbsent(ctx);
   ctx.typeArguments = [ Type.f32 ];
   ctx.contextualType = Type.i32;
   return builtin_eq(ctx);
 }
-builtins.set(BuiltinNames.f32_eq, builtin_f32_eq);
+builtinFunctions.set(BuiltinNames.f32_eq, builtin_f32_eq);
 
 // f64.eq -> eq<f64>
-function builtin_f64_eq(ctx: BuiltinContext): ExpressionRef {
+function builtin_f64_eq(ctx: BuiltinFunctionContext): ExpressionRef {
   checkTypeAbsent(ctx);
   ctx.typeArguments = [ Type.f64 ];
   ctx.contextualType = Type.i32;
   return builtin_eq(ctx);
 }
-builtins.set(BuiltinNames.f64_eq, builtin_f64_eq);
+builtinFunctions.set(BuiltinNames.f64_eq, builtin_f64_eq);
 
 // i32.ne -> ne<i32>
-function builtin_i32_ne(ctx: BuiltinContext): ExpressionRef {
+function builtin_i32_ne(ctx: BuiltinFunctionContext): ExpressionRef {
   checkTypeAbsent(ctx);
   ctx.typeArguments = [ Type.i32 ];
   ctx.contextualType = Type.i32;
   return builtin_ne(ctx);
 }
-builtins.set(BuiltinNames.i32_ne, builtin_i32_ne);
+builtinFunctions.set(BuiltinNames.i32_ne, builtin_i32_ne);
 
 // i64.ne -> ne<i64>
-function builtin_i64_ne(ctx: BuiltinContext): ExpressionRef {
+function builtin_i64_ne(ctx: BuiltinFunctionContext): ExpressionRef {
   checkTypeAbsent(ctx);
   ctx.typeArguments = [ Type.i64 ];
   ctx.contextualType = Type.i32;
   return builtin_ne(ctx);
 }
-builtins.set(BuiltinNames.i64_ne, builtin_i64_ne);
+builtinFunctions.set(BuiltinNames.i64_ne, builtin_i64_ne);
 
 // f32.ne -> ne<f32>
-function builtin_f32_ne(ctx: BuiltinContext): ExpressionRef {
+function builtin_f32_ne(ctx: BuiltinFunctionContext): ExpressionRef {
   checkTypeAbsent(ctx);
   ctx.typeArguments = [ Type.f32 ];
   ctx.contextualType = Type.i32;
   return builtin_ne(ctx);
 }
-builtins.set(BuiltinNames.f32_ne, builtin_f32_ne);
+builtinFunctions.set(BuiltinNames.f32_ne, builtin_f32_ne);
 
 // f64.ne-> ne<f64>
-function builtin_f64_ne(ctx: BuiltinContext): ExpressionRef {
+function builtin_f64_ne(ctx: BuiltinFunctionContext): ExpressionRef {
   checkTypeAbsent(ctx);
   ctx.typeArguments = [ Type.f64 ];
   ctx.contextualType = Type.i32;
   return builtin_ne(ctx);
 }
-builtins.set(BuiltinNames.f64_ne, builtin_f64_ne);
+builtinFunctions.set(BuiltinNames.f64_ne, builtin_f64_ne);
 
 // i32.load8_s -> <i32>load<i8>
-function builtin_i32_load8_s(ctx: BuiltinContext): ExpressionRef {
+function builtin_i32_load8_s(ctx: BuiltinFunctionContext): ExpressionRef {
   checkTypeAbsent(ctx);
   ctx.typeArguments = [ Type.i8 ];
   ctx.contextualType = Type.i32;
   return builtin_load(ctx);
 }
-builtins.set(BuiltinNames.i32_load8_s, builtin_i32_load8_s);
+builtinFunctions.set(BuiltinNames.i32_load8_s, builtin_i32_load8_s);
 
 // i32.load8_u -> <i32>load<u8>
-function builtin_i32_load8_u(ctx: BuiltinContext): ExpressionRef {
+function builtin_i32_load8_u(ctx: BuiltinFunctionContext): ExpressionRef {
   checkTypeAbsent(ctx);
   ctx.typeArguments = [ Type.u8 ];
   ctx.contextualType = Type.i32;
   return builtin_load(ctx);
 }
-builtins.set(BuiltinNames.i32_load8_u, builtin_i32_load8_u);
+builtinFunctions.set(BuiltinNames.i32_load8_u, builtin_i32_load8_u);
 
 // i32.load16_s -> <i32>load<i16>
-function builtin_i32_load16_s(ctx: BuiltinContext): ExpressionRef {
+function builtin_i32_load16_s(ctx: BuiltinFunctionContext): ExpressionRef {
   checkTypeAbsent(ctx);
   ctx.typeArguments = [ Type.i16 ];
   ctx.contextualType = Type.i32;
   return builtin_load(ctx);
 }
-builtins.set(BuiltinNames.i32_load16_s, builtin_i32_load16_s);
+builtinFunctions.set(BuiltinNames.i32_load16_s, builtin_i32_load16_s);
 
 // i32.load16_u -> <i32>load<u16>
-function builtin_i32_load16_u(ctx: BuiltinContext): ExpressionRef {
+function builtin_i32_load16_u(ctx: BuiltinFunctionContext): ExpressionRef {
   checkTypeAbsent(ctx);
   ctx.typeArguments = [ Type.u16 ];
   ctx.contextualType = Type.i32;
   return builtin_load(ctx);
 }
-builtins.set(BuiltinNames.i32_load16_u, builtin_i32_load16_u);
+builtinFunctions.set(BuiltinNames.i32_load16_u, builtin_i32_load16_u);
 
 // i32.load -> <i32>load<i32>
-function builtin_i32_load(ctx: BuiltinContext): ExpressionRef {
+function builtin_i32_load(ctx: BuiltinFunctionContext): ExpressionRef {
   checkTypeAbsent(ctx);
   ctx.typeArguments = [ Type.i32 ];
   ctx.contextualType = Type.i32;
   return builtin_load(ctx);
 }
-builtins.set(BuiltinNames.i32_load, builtin_i32_load);
+builtinFunctions.set(BuiltinNames.i32_load, builtin_i32_load);
 
 // i64.load8_s -> <i64>load<i8>
-function builtin_i64_load8_s(ctx: BuiltinContext): ExpressionRef {
+function builtin_i64_load8_s(ctx: BuiltinFunctionContext): ExpressionRef {
   checkTypeAbsent(ctx);
   ctx.typeArguments = [ Type.i8 ];
   ctx.contextualType = Type.i64;
   return builtin_load(ctx);
 }
-builtins.set(BuiltinNames.i64_load8_s, builtin_i64_load8_s);
+builtinFunctions.set(BuiltinNames.i64_load8_s, builtin_i64_load8_s);
 
 // i64.load8_u -> <i64>load<u8>
-function builtin_i64_load8_u(ctx: BuiltinContext): ExpressionRef {
+function builtin_i64_load8_u(ctx: BuiltinFunctionContext): ExpressionRef {
   checkTypeAbsent(ctx);
   ctx.typeArguments = [ Type.u8 ];
   ctx.contextualType = Type.i64;
   return builtin_load(ctx);
 }
-builtins.set(BuiltinNames.i64_load8_u, builtin_i64_load8_u);
+builtinFunctions.set(BuiltinNames.i64_load8_u, builtin_i64_load8_u);
 
 // i64.load16_s -> <i64>load<i16>
-function builtin_i64_load16_s(ctx: BuiltinContext): ExpressionRef {
+function builtin_i64_load16_s(ctx: BuiltinFunctionContext): ExpressionRef {
   checkTypeAbsent(ctx);
   ctx.typeArguments = [ Type.i16 ];
   ctx.contextualType = Type.i64;
   return builtin_load(ctx);
 }
-builtins.set(BuiltinNames.i64_load16_s, builtin_i64_load16_s);
+builtinFunctions.set(BuiltinNames.i64_load16_s, builtin_i64_load16_s);
 
 // i64.load16_u -> <i64>load<u16>
-function builtin_i64_load16_u(ctx: BuiltinContext): ExpressionRef {
+function builtin_i64_load16_u(ctx: BuiltinFunctionContext): ExpressionRef {
   checkTypeAbsent(ctx);
   ctx.typeArguments = [ Type.u16 ];
   ctx.contextualType = Type.i64;
   return builtin_load(ctx);
 }
-builtins.set(BuiltinNames.i64_load16_u, builtin_i64_load16_u);
+builtinFunctions.set(BuiltinNames.i64_load16_u, builtin_i64_load16_u);
 
 // i64.load32_s -> <i64>load<i32>
-function builtin_i64_load32_s(ctx: BuiltinContext): ExpressionRef {
+function builtin_i64_load32_s(ctx: BuiltinFunctionContext): ExpressionRef {
   checkTypeAbsent(ctx);
   ctx.typeArguments = [ Type.i32 ];
   ctx.contextualType = Type.i64;
   return builtin_load(ctx);
 }
-builtins.set(BuiltinNames.i64_load32_s, builtin_i64_load32_s);
+builtinFunctions.set(BuiltinNames.i64_load32_s, builtin_i64_load32_s);
 
 // i64.load32_u -> <i64>load<u32>
-function builtin_i64_load32_u(ctx: BuiltinContext): ExpressionRef {
+function builtin_i64_load32_u(ctx: BuiltinFunctionContext): ExpressionRef {
   checkTypeAbsent(ctx);
   ctx.typeArguments = [ Type.u32 ];
   ctx.contextualType = Type.i64;
   return builtin_load(ctx);
 }
-builtins.set(BuiltinNames.i64_load32_u, builtin_i64_load32_u);
+builtinFunctions.set(BuiltinNames.i64_load32_u, builtin_i64_load32_u);
 
 // i64.load -> <i64>load<i64>
-function builtin_i64_load(ctx: BuiltinContext): ExpressionRef {
+function builtin_i64_load(ctx: BuiltinFunctionContext): ExpressionRef {
   checkTypeAbsent(ctx);
   ctx.typeArguments = [ Type.i64 ];
   ctx.contextualType = Type.i64;
   return builtin_load(ctx);
 }
-builtins.set(BuiltinNames.i64_load, builtin_i64_load);
+builtinFunctions.set(BuiltinNames.i64_load, builtin_i64_load);
 
 // f32.load -> <f32>load<f32>
-function builtin_f32_load(ctx: BuiltinContext): ExpressionRef {
+function builtin_f32_load(ctx: BuiltinFunctionContext): ExpressionRef {
   checkTypeAbsent(ctx);
   ctx.typeArguments = [ Type.f32 ];
   ctx.contextualType = Type.f32;
   return builtin_load(ctx);
 }
-builtins.set(BuiltinNames.f32_load, builtin_f32_load);
+builtinFunctions.set(BuiltinNames.f32_load, builtin_f32_load);
 
 // f64.load -> <f64>load<f64>
-function builtin_f64_load(ctx: BuiltinContext): ExpressionRef {
+function builtin_f64_load(ctx: BuiltinFunctionContext): ExpressionRef {
   checkTypeAbsent(ctx);
   ctx.typeArguments = [ Type.f64 ];
   ctx.contextualType = Type.f64;
   return builtin_load(ctx);
 }
-builtins.set(BuiltinNames.f64_load, builtin_f64_load);
+builtinFunctions.set(BuiltinNames.f64_load, builtin_f64_load);
 
 // i32.store8 -> store<i8 from i32>
-function builtin_i32_store8(ctx: BuiltinContext): ExpressionRef {
+function builtin_i32_store8(ctx: BuiltinFunctionContext): ExpressionRef {
   checkTypeAbsent(ctx);
   ctx.typeArguments = [ Type.i8 ];
   ctx.contextualType = Type.i32;
   ctx.contextIsExact = true;
   return builtin_store(ctx);
 }
-builtins.set(BuiltinNames.i32_store8, builtin_i32_store8);
+builtinFunctions.set(BuiltinNames.i32_store8, builtin_i32_store8);
 
 // i32.store16 -> store<i16 from i32>
-function builtin_i32_store16(ctx: BuiltinContext): ExpressionRef {
+function builtin_i32_store16(ctx: BuiltinFunctionContext): ExpressionRef {
   checkTypeAbsent(ctx);
   ctx.typeArguments = [ Type.i16 ];
   ctx.contextualType = Type.i32;
   ctx.contextIsExact = true;
   return builtin_store(ctx);
 }
-builtins.set(BuiltinNames.i32_store16, builtin_i32_store16);
+builtinFunctions.set(BuiltinNames.i32_store16, builtin_i32_store16);
 
 // i32.store -> store<i32 from i32>
-function builtin_i32_store(ctx: BuiltinContext): ExpressionRef {
+function builtin_i32_store(ctx: BuiltinFunctionContext): ExpressionRef {
   checkTypeAbsent(ctx);
   ctx.typeArguments = [ Type.i32 ];
   ctx.contextualType = Type.i32;
   ctx.contextIsExact = true;
   return builtin_store(ctx);
 }
-builtins.set(BuiltinNames.i32_store, builtin_i32_store);
+builtinFunctions.set(BuiltinNames.i32_store, builtin_i32_store);
 
 // i64.store8 -> store<i8 from i64>
-function builtin_i64_store8(ctx: BuiltinContext): ExpressionRef {
+function builtin_i64_store8(ctx: BuiltinFunctionContext): ExpressionRef {
   checkTypeAbsent(ctx);
   ctx.typeArguments = [ Type.i8 ];
   ctx.contextualType = Type.i64;
   ctx.contextIsExact = true;
   return builtin_store(ctx);
 }
-builtins.set(BuiltinNames.i64_store8, builtin_i64_store8);
+builtinFunctions.set(BuiltinNames.i64_store8, builtin_i64_store8);
 
 // i64.store16 -> store<i16 from i64>
-function builtin_i64_store16(ctx: BuiltinContext): ExpressionRef {
+function builtin_i64_store16(ctx: BuiltinFunctionContext): ExpressionRef {
   checkTypeAbsent(ctx);
   ctx.typeArguments = [ Type.i16 ];
   ctx.contextualType = Type.i64;
   ctx.contextIsExact = true;
   return builtin_store(ctx);
 }
-builtins.set(BuiltinNames.i64_store16, builtin_i64_store16);
+builtinFunctions.set(BuiltinNames.i64_store16, builtin_i64_store16);
 
 // i64.store32 -> store<i32 from i64>
-function builtin_i64_store32(ctx: BuiltinContext): ExpressionRef {
+function builtin_i64_store32(ctx: BuiltinFunctionContext): ExpressionRef {
   checkTypeAbsent(ctx);
   ctx.typeArguments = [ Type.i32 ];
   ctx.contextualType = Type.i64;
   ctx.contextIsExact = true;
   return builtin_store(ctx);
 }
-builtins.set(BuiltinNames.i64_store32, builtin_i64_store32);
+builtinFunctions.set(BuiltinNames.i64_store32, builtin_i64_store32);
 
 // i64.store -> store<i64 from i64>
-function builtin_i64_store(ctx: BuiltinContext): ExpressionRef {
+function builtin_i64_store(ctx: BuiltinFunctionContext): ExpressionRef {
   checkTypeAbsent(ctx);
   ctx.typeArguments = [ Type.i64 ];
   ctx.contextualType = Type.i64;
   ctx.contextIsExact = true;
   return builtin_store(ctx);
 }
-builtins.set(BuiltinNames.i64_store, builtin_i64_store);
+builtinFunctions.set(BuiltinNames.i64_store, builtin_i64_store);
 
 // f32.store -> store<f32 from f64>
-function builtin_f32_store(ctx: BuiltinContext): ExpressionRef {
+function builtin_f32_store(ctx: BuiltinFunctionContext): ExpressionRef {
   checkTypeAbsent(ctx);
   ctx.typeArguments = [ Type.f32 ];
   ctx.contextualType = Type.f32;
   ctx.contextIsExact = true;
   return builtin_store(ctx);
 }
-builtins.set(BuiltinNames.f32_store, builtin_f32_store);
+builtinFunctions.set(BuiltinNames.f32_store, builtin_f32_store);
 
 // f64.store -> store<f64 from f64>
-function builtin_f64_store(ctx: BuiltinContext): ExpressionRef {
+function builtin_f64_store(ctx: BuiltinFunctionContext): ExpressionRef {
   checkTypeAbsent(ctx);
   ctx.typeArguments = [ Type.f64 ];
   ctx.contextualType = Type.f64;
   ctx.contextIsExact = true;
   return builtin_store(ctx);
 }
-builtins.set(BuiltinNames.f64_store, builtin_f64_store);
+builtinFunctions.set(BuiltinNames.f64_store, builtin_f64_store);
 
 // i32.atomic.load8_u -> <i32>atomic.load<u8>
-function builtin_i32_atomic_load8_u(ctx: BuiltinContext): ExpressionRef {
+function builtin_i32_atomic_load8_u(ctx: BuiltinFunctionContext): ExpressionRef {
   checkTypeAbsent(ctx);
   ctx.typeArguments = [ Type.u8 ];
   ctx.contextualType = Type.i32;
   return builtin_atomic_load(ctx);
 }
-builtins.set(BuiltinNames.i32_atomic_load8_u, builtin_i32_atomic_load8_u);
+builtinFunctions.set(BuiltinNames.i32_atomic_load8_u, builtin_i32_atomic_load8_u);
 
 // i32.atomic.load16_u -> <i32>atomic.load<u16>
-function builtin_i32_atomic_load16_u(ctx: BuiltinContext): ExpressionRef {
+function builtin_i32_atomic_load16_u(ctx: BuiltinFunctionContext): ExpressionRef {
   checkTypeAbsent(ctx);
   ctx.typeArguments = [ Type.u16 ];
   ctx.contextualType = Type.i32;
   return builtin_atomic_load(ctx);
 }
-builtins.set(BuiltinNames.i32_atomic_load16_u, builtin_i32_atomic_load16_u);
+builtinFunctions.set(BuiltinNames.i32_atomic_load16_u, builtin_i32_atomic_load16_u);
 
 // i32.atomic.load -> <i32>atomic.load<i32>
-function builtin_i32_atomic_load(ctx: BuiltinContext): ExpressionRef {
+function builtin_i32_atomic_load(ctx: BuiltinFunctionContext): ExpressionRef {
   checkTypeAbsent(ctx);
   ctx.typeArguments = [ Type.i32 ];
   ctx.contextualType = Type.i32;
   return builtin_atomic_load(ctx);
 }
-builtins.set(BuiltinNames.i32_atomic_load, builtin_i32_atomic_load);
+builtinFunctions.set(BuiltinNames.i32_atomic_load, builtin_i32_atomic_load);
 
 // i64.atomic.load8_u -> <i64>atomic.load<u8>
-function builtin_i64_atomic_load8_u(ctx: BuiltinContext): ExpressionRef {
+function builtin_i64_atomic_load8_u(ctx: BuiltinFunctionContext): ExpressionRef {
   checkTypeAbsent(ctx);
   ctx.typeArguments = [ Type.u8 ];
   ctx.contextualType = Type.i64;
   return builtin_atomic_load(ctx);
 }
-builtins.set(BuiltinNames.i64_atomic_load8_u, builtin_i64_atomic_load8_u);
+builtinFunctions.set(BuiltinNames.i64_atomic_load8_u, builtin_i64_atomic_load8_u);
 
 // i64.atomic.load16_u -> <i64>atomic.load<u16>
-function builtin_i64_atomic_load16_u(ctx: BuiltinContext): ExpressionRef {
+function builtin_i64_atomic_load16_u(ctx: BuiltinFunctionContext): ExpressionRef {
   checkTypeAbsent(ctx);
   ctx.typeArguments = [ Type.u16 ];
   ctx.contextualType = Type.i64;
   return builtin_atomic_load(ctx);
 }
-builtins.set(BuiltinNames.i64_atomic_load16_u, builtin_i64_atomic_load16_u);
+builtinFunctions.set(BuiltinNames.i64_atomic_load16_u, builtin_i64_atomic_load16_u);
 
 // i64.atomic.load32_u -> <i64>atomic.load<u32>
-function builtin_i64_atomic_load32_u(ctx: BuiltinContext): ExpressionRef {
+function builtin_i64_atomic_load32_u(ctx: BuiltinFunctionContext): ExpressionRef {
   checkTypeAbsent(ctx);
   ctx.typeArguments = [ Type.u32 ];
   ctx.contextualType = Type.i64;
   return builtin_atomic_load(ctx);
 }
-builtins.set(BuiltinNames.i64_atomic_load32_u, builtin_i64_atomic_load32_u);
+builtinFunctions.set(BuiltinNames.i64_atomic_load32_u, builtin_i64_atomic_load32_u);
 
 // i64.atomic.load -> <i64>atomic.load<i64>
-function builtin_i64_atomic_load(ctx: BuiltinContext): ExpressionRef {
+function builtin_i64_atomic_load(ctx: BuiltinFunctionContext): ExpressionRef {
   checkTypeAbsent(ctx);
   ctx.typeArguments = [ Type.i64 ];
   ctx.contextualType = Type.i64;
   return builtin_atomic_load(ctx);
 }
-builtins.set(BuiltinNames.i64_atomic_load, builtin_i64_atomic_load);
+builtinFunctions.set(BuiltinNames.i64_atomic_load, builtin_i64_atomic_load);
 
 // i32.atomic.store8 -> atomic.store<i8 from i32>
-function builtin_i32_atomic_store8(ctx: BuiltinContext): ExpressionRef {
+function builtin_i32_atomic_store8(ctx: BuiltinFunctionContext): ExpressionRef {
   checkTypeAbsent(ctx);
   ctx.typeArguments = [ Type.i8 ];
   ctx.contextualType = Type.i32;
   ctx.contextIsExact = true;
   return builtin_atomic_store(ctx);
 }
-builtins.set(BuiltinNames.i32_atomic_store8, builtin_i32_atomic_store8);
+builtinFunctions.set(BuiltinNames.i32_atomic_store8, builtin_i32_atomic_store8);
 
 // i32.atomic.store16 -> atomic.store<i16 from i32>
-function builtin_i32_atomic_store16(ctx: BuiltinContext): ExpressionRef {
+function builtin_i32_atomic_store16(ctx: BuiltinFunctionContext): ExpressionRef {
   checkTypeAbsent(ctx);
   ctx.typeArguments = [ Type.i16 ];
   ctx.contextualType = Type.i32;
   ctx.contextIsExact = true;
   return builtin_atomic_store(ctx);
 }
-builtins.set(BuiltinNames.i32_atomic_store16, builtin_i32_atomic_store16);
+builtinFunctions.set(BuiltinNames.i32_atomic_store16, builtin_i32_atomic_store16);
 
 // i32.atomic.store -> atomic.store<i32 from i32>
-function builtin_i32_atomic_store(ctx: BuiltinContext): ExpressionRef {
+function builtin_i32_atomic_store(ctx: BuiltinFunctionContext): ExpressionRef {
   checkTypeAbsent(ctx);
   ctx.typeArguments = [ Type.i32 ];
   ctx.contextualType = Type.i32;
   ctx.contextIsExact = true;
   return builtin_atomic_store(ctx);
 }
-builtins.set(BuiltinNames.i32_atomic_store, builtin_i32_atomic_store);
+builtinFunctions.set(BuiltinNames.i32_atomic_store, builtin_i32_atomic_store);
 
 // i64.atomic.store8 -> atomic.store<i8 from i64>
-function builtin_i64_atomic_store8(ctx: BuiltinContext): ExpressionRef {
+function builtin_i64_atomic_store8(ctx: BuiltinFunctionContext): ExpressionRef {
   checkTypeAbsent(ctx);
   ctx.typeArguments = [ Type.i8 ];
   ctx.contextualType = Type.i64;
   ctx.contextIsExact = true;
   return builtin_atomic_store(ctx);
 }
-builtins.set(BuiltinNames.i64_atomic_store8, builtin_i64_atomic_store8);
+builtinFunctions.set(BuiltinNames.i64_atomic_store8, builtin_i64_atomic_store8);
 
 // i64.atomic.store16 -> atomic.store<i16 from i64>
-function builtin_i64_atomic_store16(ctx: BuiltinContext): ExpressionRef {
+function builtin_i64_atomic_store16(ctx: BuiltinFunctionContext): ExpressionRef {
   checkTypeAbsent(ctx);
   ctx.typeArguments = [ Type.u16 ];
   ctx.contextualType = Type.i64;
   ctx.contextIsExact = true;
   return builtin_atomic_store(ctx);
 }
-builtins.set(BuiltinNames.i64_atomic_store16, builtin_i64_atomic_store16);
+builtinFunctions.set(BuiltinNames.i64_atomic_store16, builtin_i64_atomic_store16);
 
 // i64.atomic.store32 -> atomic.store<i32 from i64>
-function builtin_i64_atomic_store32(ctx: BuiltinContext): ExpressionRef {
+function builtin_i64_atomic_store32(ctx: BuiltinFunctionContext): ExpressionRef {
   checkTypeAbsent(ctx);
   ctx.typeArguments = [ Type.i32 ];
   ctx.contextualType = Type.i64;
   ctx.contextIsExact = true;
   return builtin_atomic_store(ctx);
 }
-builtins.set(BuiltinNames.i64_atomic_store32, builtin_i64_atomic_store32);
+builtinFunctions.set(BuiltinNames.i64_atomic_store32, builtin_i64_atomic_store32);
 
 // i64.atomic.store -> atomic.store<i64 from i64>
-function builtin_i64_atomic_store(ctx: BuiltinContext): ExpressionRef {
+function builtin_i64_atomic_store(ctx: BuiltinFunctionContext): ExpressionRef {
   checkTypeAbsent(ctx);
   ctx.typeArguments = [ Type.i64 ];
   ctx.contextualType = Type.i64;
   ctx.contextIsExact = true;
   return builtin_atomic_store(ctx);
 }
-builtins.set(BuiltinNames.i64_atomic_store, builtin_i64_atomic_store);
+builtinFunctions.set(BuiltinNames.i64_atomic_store, builtin_i64_atomic_store);
 
 // i32.atomic.rmw8.add_u -> <i32>atomic.add<u8 from i32>
-function builtin_i32_atomic_rmw8_add_u(ctx: BuiltinContext): ExpressionRef {
+function builtin_i32_atomic_rmw8_add_u(ctx: BuiltinFunctionContext): ExpressionRef {
   checkTypeAbsent(ctx);
   ctx.typeArguments = [ Type.u8 ];
   ctx.contextualType = Type.i32;
   ctx.contextIsExact = true;
   return builtin_atomic_add(ctx);
 }
-builtins.set(BuiltinNames.i32_atomic_rmw8_add_u, builtin_i32_atomic_rmw8_add_u);
+builtinFunctions.set(BuiltinNames.i32_atomic_rmw8_add_u, builtin_i32_atomic_rmw8_add_u);
 
 // i32.atomic.rmw16.add_u -> <i32>atomic.add<u16 from i32>
-function builtin_i32_atomic_rmw16_add_u(ctx: BuiltinContext): ExpressionRef {
+function builtin_i32_atomic_rmw16_add_u(ctx: BuiltinFunctionContext): ExpressionRef {
   checkTypeAbsent(ctx);
   ctx.typeArguments = [ Type.u16 ];
   ctx.contextualType = Type.i32;
   ctx.contextIsExact = true;
   return builtin_atomic_add(ctx);
 }
-builtins.set(BuiltinNames.i32_atomic_rmw16_add_u, builtin_i32_atomic_rmw16_add_u);
+builtinFunctions.set(BuiltinNames.i32_atomic_rmw16_add_u, builtin_i32_atomic_rmw16_add_u);
 
 // i32.atomic.rmw.add -> <i32>atomic.add<i32 from i32>
-function builtin_i32_atomic_rmw_add(ctx: BuiltinContext): ExpressionRef {
+function builtin_i32_atomic_rmw_add(ctx: BuiltinFunctionContext): ExpressionRef {
   checkTypeAbsent(ctx);
   ctx.typeArguments = [ Type.i32 ];
   ctx.contextualType = Type.i32;
   ctx.contextIsExact = true;
   return builtin_atomic_add(ctx);
 }
-builtins.set(BuiltinNames.i32_atomic_rmw_add, builtin_i32_atomic_rmw_add);
+builtinFunctions.set(BuiltinNames.i32_atomic_rmw_add, builtin_i32_atomic_rmw_add);
 
 // i64.atomic.rmw8.add_u -> <i64>atomic.add<u8 from i64>
-function builtin_i64_atomic_rmw8_add_u(ctx: BuiltinContext): ExpressionRef {
+function builtin_i64_atomic_rmw8_add_u(ctx: BuiltinFunctionContext): ExpressionRef {
   checkTypeAbsent(ctx);
   ctx.typeArguments = [ Type.u8 ];
   ctx.contextualType = Type.i64;
   ctx.contextIsExact = true;
   return builtin_atomic_add(ctx);
 }
-builtins.set(BuiltinNames.i64_atomic_rmw8_add_u, builtin_i64_atomic_rmw8_add_u);
+builtinFunctions.set(BuiltinNames.i64_atomic_rmw8_add_u, builtin_i64_atomic_rmw8_add_u);
 
 // i64.atomic.rmw16.add_u -> <i64>atomic.add<u16 from i64>
-function builtin_i64_atomic_rmw16_add_u(ctx: BuiltinContext): ExpressionRef {
+function builtin_i64_atomic_rmw16_add_u(ctx: BuiltinFunctionContext): ExpressionRef {
   checkTypeAbsent(ctx);
   ctx.typeArguments = [ Type.u16 ];
   ctx.contextualType = Type.i64;
   ctx.contextIsExact = true;
   return builtin_atomic_add(ctx);
 }
-builtins.set(BuiltinNames.i64_atomic_rmw16_add_u, builtin_i64_atomic_rmw16_add_u);
+builtinFunctions.set(BuiltinNames.i64_atomic_rmw16_add_u, builtin_i64_atomic_rmw16_add_u);
 
 // i64.atomic.rmw32.add_u -> <i64>atomic.add<u32 from i64>
-function builtin_i64_atomic_rmw32_add_u(ctx: BuiltinContext): ExpressionRef {
+function builtin_i64_atomic_rmw32_add_u(ctx: BuiltinFunctionContext): ExpressionRef {
   checkTypeAbsent(ctx);
   ctx.typeArguments = [ Type.u32 ];
   ctx.contextualType = Type.i64;
   ctx.contextIsExact = true;
   return builtin_atomic_add(ctx);
 }
-builtins.set(BuiltinNames.i64_atomic_rmw32_add_u, builtin_i64_atomic_rmw32_add_u);
+builtinFunctions.set(BuiltinNames.i64_atomic_rmw32_add_u, builtin_i64_atomic_rmw32_add_u);
 
 // i64.atomic.rmw.add -> <i64>atomic.add<i64 from i64>
-function builtin_i64_atomic_rmw_add(ctx: BuiltinContext): ExpressionRef {
+function builtin_i64_atomic_rmw_add(ctx: BuiltinFunctionContext): ExpressionRef {
   checkTypeAbsent(ctx);
   ctx.typeArguments = [ Type.i64 ];
   ctx.contextualType = Type.i64;
   ctx.contextIsExact = true;
   return builtin_atomic_add(ctx);
 }
-builtins.set(BuiltinNames.i64_atomic_rmw_add, builtin_i64_atomic_rmw_add);
+builtinFunctions.set(BuiltinNames.i64_atomic_rmw_add, builtin_i64_atomic_rmw_add);
 
 // i32.atomic.rmw8.sub_u -> <i32>atomic.sub<u8 from i32>
-function builtin_i32_atomic_rmw8_sub_u(ctx: BuiltinContext): ExpressionRef {
+function builtin_i32_atomic_rmw8_sub_u(ctx: BuiltinFunctionContext): ExpressionRef {
   checkTypeAbsent(ctx);
   ctx.typeArguments = [ Type.u8 ];
   ctx.contextualType = Type.i32;
   ctx.contextIsExact = true;
   return builtin_atomic_sub(ctx);
 }
-builtins.set(BuiltinNames.i32_atomic_rmw8_sub_u, builtin_i32_atomic_rmw8_sub_u);
+builtinFunctions.set(BuiltinNames.i32_atomic_rmw8_sub_u, builtin_i32_atomic_rmw8_sub_u);
 
 // i32.atomic.rmw16.sub_u -> <i32>atomic.sub<u16 from i32>
-function builtin_i32_atomic_rmw16_sub_u(ctx: BuiltinContext): ExpressionRef {
+function builtin_i32_atomic_rmw16_sub_u(ctx: BuiltinFunctionContext): ExpressionRef {
   checkTypeAbsent(ctx);
   ctx.typeArguments = [ Type.u16 ];
   ctx.contextualType = Type.i32;
   ctx.contextIsExact = true;
   return builtin_atomic_sub(ctx);
 }
-builtins.set(BuiltinNames.i32_atomic_rmw16_sub_u, builtin_i32_atomic_rmw16_sub_u);
+builtinFunctions.set(BuiltinNames.i32_atomic_rmw16_sub_u, builtin_i32_atomic_rmw16_sub_u);
 
 // i32.atomic.rmw.sub -> <i32>atomic.sub<i32 from i32>
-function builtin_i32_atomic_rmw_sub(ctx: BuiltinContext): ExpressionRef {
+function builtin_i32_atomic_rmw_sub(ctx: BuiltinFunctionContext): ExpressionRef {
   checkTypeAbsent(ctx);
   ctx.typeArguments = [ Type.i32 ];
   ctx.contextualType = Type.i32;
   ctx.contextIsExact = true;
   return builtin_atomic_sub(ctx);
 }
-builtins.set(BuiltinNames.i32_atomic_rmw_sub, builtin_i32_atomic_rmw_sub);
+builtinFunctions.set(BuiltinNames.i32_atomic_rmw_sub, builtin_i32_atomic_rmw_sub);
 
 // i64.atomic.rmw8.sub_u -> <i64>atomic.sub<u8 from i64>
-function builtin_i64_atomic_rmw8_sub_u(ctx: BuiltinContext): ExpressionRef {
+function builtin_i64_atomic_rmw8_sub_u(ctx: BuiltinFunctionContext): ExpressionRef {
   checkTypeAbsent(ctx);
   ctx.typeArguments = [ Type.u8 ];
   ctx.contextualType = Type.i64;
   ctx.contextIsExact = true;
   return builtin_atomic_sub(ctx);
 }
-builtins.set(BuiltinNames.i64_atomic_rmw8_sub_u, builtin_i64_atomic_rmw8_sub_u);
+builtinFunctions.set(BuiltinNames.i64_atomic_rmw8_sub_u, builtin_i64_atomic_rmw8_sub_u);
 
 // i64.atomic.rmw16.sub_u -> <i64>atomic.sub<u16 from i64>
-function builtin_i64_atomic_rmw16_sub_u(ctx: BuiltinContext): ExpressionRef {
+function builtin_i64_atomic_rmw16_sub_u(ctx: BuiltinFunctionContext): ExpressionRef {
   checkTypeAbsent(ctx);
   ctx.typeArguments = [ Type.u16 ];
   ctx.contextualType = Type.i64;
   ctx.contextIsExact = true;
   return builtin_atomic_sub(ctx);
 }
-builtins.set(BuiltinNames.i64_atomic_rmw16_sub_u, builtin_i64_atomic_rmw16_sub_u);
+builtinFunctions.set(BuiltinNames.i64_atomic_rmw16_sub_u, builtin_i64_atomic_rmw16_sub_u);
 
 // i64.atomic.rmw32.sub_u -> <i64>atomic.sub<u32 from i64>
-function builtin_i64_atomic_rmw32_sub_u(ctx: BuiltinContext): ExpressionRef {
+function builtin_i64_atomic_rmw32_sub_u(ctx: BuiltinFunctionContext): ExpressionRef {
   checkTypeAbsent(ctx);
   ctx.typeArguments = [ Type.u32 ];
   ctx.contextualType = Type.i64;
   ctx.contextIsExact = true;
   return builtin_atomic_sub(ctx);
 }
-builtins.set(BuiltinNames.i64_atomic_rmw32_sub_u, builtin_i64_atomic_rmw32_sub_u);
+builtinFunctions.set(BuiltinNames.i64_atomic_rmw32_sub_u, builtin_i64_atomic_rmw32_sub_u);
 
 // i64.atomic.rmw.sub -> <i64>atomic.sub<i64 from i64>
-function builtin_i64_atomic_rmw_sub(ctx: BuiltinContext): ExpressionRef {
+function builtin_i64_atomic_rmw_sub(ctx: BuiltinFunctionContext): ExpressionRef {
   checkTypeAbsent(ctx);
   ctx.typeArguments = [ Type.i64 ];
   ctx.contextualType = Type.i64;
   ctx.contextIsExact = true;
   return builtin_atomic_sub(ctx);
 }
-builtins.set(BuiltinNames.i64_atomic_rmw_sub, builtin_i64_atomic_rmw_sub);
+builtinFunctions.set(BuiltinNames.i64_atomic_rmw_sub, builtin_i64_atomic_rmw_sub);
 
 // i32.atomic.rmw8.and_u -> <i32>atomic.and<u8 from i32>
-function builtin_i32_atomic_rmw8_and_u(ctx: BuiltinContext): ExpressionRef {
+function builtin_i32_atomic_rmw8_and_u(ctx: BuiltinFunctionContext): ExpressionRef {
   checkTypeAbsent(ctx);
   ctx.typeArguments = [ Type.u8 ];
   ctx.contextualType = Type.i32;
   ctx.contextIsExact = true;
   return builtin_atomic_and(ctx);
 }
-builtins.set(BuiltinNames.i32_atomic_rmw8_and_u, builtin_i32_atomic_rmw8_and_u);
+builtinFunctions.set(BuiltinNames.i32_atomic_rmw8_and_u, builtin_i32_atomic_rmw8_and_u);
 
 // i32.atomic.rmw16.and_u -> <i32>atomic.and<u16 from i32>
-function builtin_i32_atomic_rmw16_and_u(ctx: BuiltinContext): ExpressionRef {
+function builtin_i32_atomic_rmw16_and_u(ctx: BuiltinFunctionContext): ExpressionRef {
   checkTypeAbsent(ctx);
   ctx.typeArguments = [ Type.u16 ];
   ctx.contextualType = Type.i32;
   ctx.contextIsExact = true;
   return builtin_atomic_and(ctx);
 }
-builtins.set(BuiltinNames.i32_atomic_rmw16_and_u, builtin_i32_atomic_rmw16_and_u);
+builtinFunctions.set(BuiltinNames.i32_atomic_rmw16_and_u, builtin_i32_atomic_rmw16_and_u);
 
 // i32.atomic.rmw.and -> <i32>atomic.and<i32 from i32>
-function builtin_i32_atomic_rmw_and(ctx: BuiltinContext): ExpressionRef {
+function builtin_i32_atomic_rmw_and(ctx: BuiltinFunctionContext): ExpressionRef {
   checkTypeAbsent(ctx);
   ctx.typeArguments = [ Type.i32 ];
   ctx.contextualType = Type.i32;
   ctx.contextIsExact = true;
   return builtin_atomic_and(ctx);
 }
-builtins.set(BuiltinNames.i32_atomic_rmw_and, builtin_i32_atomic_rmw_and);
+builtinFunctions.set(BuiltinNames.i32_atomic_rmw_and, builtin_i32_atomic_rmw_and);
 
 // i64.atomic.rmw8.and_u -> <i64>atomic.and<u8 from i64>
-function builtin_i64_atomic_rmw8_and_u(ctx: BuiltinContext): ExpressionRef {
+function builtin_i64_atomic_rmw8_and_u(ctx: BuiltinFunctionContext): ExpressionRef {
   checkTypeAbsent(ctx);
   ctx.typeArguments = [ Type.u8 ];
   ctx.contextualType = Type.i64;
   ctx.contextIsExact = true;
   return builtin_atomic_and(ctx);
 }
-builtins.set(BuiltinNames.i64_atomic_rmw8_and_u, builtin_i64_atomic_rmw8_and_u);
+builtinFunctions.set(BuiltinNames.i64_atomic_rmw8_and_u, builtin_i64_atomic_rmw8_and_u);
 
 // i64.atomic.rmw16.and_u -> <i64>atomic.and<u16 from i64>
-function builtin_i64_atomic_rmw16_and_u(ctx: BuiltinContext): ExpressionRef {
+function builtin_i64_atomic_rmw16_and_u(ctx: BuiltinFunctionContext): ExpressionRef {
   checkTypeAbsent(ctx);
   ctx.typeArguments = [ Type.u16 ];
   ctx.contextualType = Type.i64;
   ctx.contextIsExact = true;
   return builtin_atomic_and(ctx);
 }
-builtins.set(BuiltinNames.i64_atomic_rmw16_and_u, builtin_i64_atomic_rmw16_and_u);
+builtinFunctions.set(BuiltinNames.i64_atomic_rmw16_and_u, builtin_i64_atomic_rmw16_and_u);
 
 // i64.atomic.rmw32.and_u -> <i64>atomic.and<u32 from i64>
-function builtin_i64_atomic_rmw32_and_u(ctx: BuiltinContext): ExpressionRef {
+function builtin_i64_atomic_rmw32_and_u(ctx: BuiltinFunctionContext): ExpressionRef {
   checkTypeAbsent(ctx);
   ctx.typeArguments = [ Type.u32 ];
   ctx.contextualType = Type.i64;
   ctx.contextIsExact = true;
   return builtin_atomic_and(ctx);
 }
-builtins.set(BuiltinNames.i64_atomic_rmw32_and_u, builtin_i64_atomic_rmw32_and_u);
+builtinFunctions.set(BuiltinNames.i64_atomic_rmw32_and_u, builtin_i64_atomic_rmw32_and_u);
 
 // i64.atomic.rmw.and -> <i64>atomic.and<i64 from i64>
-function builtin_i64_atomic_rmw_and(ctx: BuiltinContext): ExpressionRef {
+function builtin_i64_atomic_rmw_and(ctx: BuiltinFunctionContext): ExpressionRef {
   checkTypeAbsent(ctx);
   ctx.typeArguments = [ Type.i64 ];
   ctx.contextualType = Type.i64;
   ctx.contextIsExact = true;
   return builtin_atomic_and(ctx);
 }
-builtins.set(BuiltinNames.i64_atomic_rmw_and, builtin_i64_atomic_rmw_and);
+builtinFunctions.set(BuiltinNames.i64_atomic_rmw_and, builtin_i64_atomic_rmw_and);
 
 // i32.atomic.rmw8.or_u -> <i32>atomic.or<u8 from i32>
-function builtin_i32_atomic_rmw8_or_u(ctx: BuiltinContext): ExpressionRef {
+function builtin_i32_atomic_rmw8_or_u(ctx: BuiltinFunctionContext): ExpressionRef {
   checkTypeAbsent(ctx);
   ctx.typeArguments = [ Type.u8 ];
   ctx.contextualType = Type.i32;
   ctx.contextIsExact = true;
   return builtin_atomic_or(ctx);
 }
-builtins.set(BuiltinNames.i32_atomic_rmw8_or_u, builtin_i32_atomic_rmw8_or_u);
+builtinFunctions.set(BuiltinNames.i32_atomic_rmw8_or_u, builtin_i32_atomic_rmw8_or_u);
 
 // i32.atomic.rmw16.or_u -> <i32atomic.or<u16 from i32>
-function builtin_i32_atomic_rmw16_or_u(ctx: BuiltinContext): ExpressionRef {
+function builtin_i32_atomic_rmw16_or_u(ctx: BuiltinFunctionContext): ExpressionRef {
   checkTypeAbsent(ctx);
   ctx.typeArguments = [ Type.u16 ];
   ctx.contextualType = Type.i32;
   ctx.contextIsExact = true;
   return builtin_atomic_or(ctx);
 }
-builtins.set(BuiltinNames.i32_atomic_rmw16_or_u, builtin_i32_atomic_rmw16_or_u);
+builtinFunctions.set(BuiltinNames.i32_atomic_rmw16_or_u, builtin_i32_atomic_rmw16_or_u);
 
 // i32.atomic.rmw.or -> <i32>atomic.or<i32 from i32>
-function builtin_i32_atomic_rmw_or(ctx: BuiltinContext): ExpressionRef {
+function builtin_i32_atomic_rmw_or(ctx: BuiltinFunctionContext): ExpressionRef {
   checkTypeAbsent(ctx);
   ctx.typeArguments = [ Type.i32 ];
   ctx.contextualType = Type.i32;
   ctx.contextIsExact = true;
   return builtin_atomic_or(ctx);
 }
-builtins.set(BuiltinNames.i32_atomic_rmw_or, builtin_i32_atomic_rmw_or);
+builtinFunctions.set(BuiltinNames.i32_atomic_rmw_or, builtin_i32_atomic_rmw_or);
 
 // i64.atomic.rmw8.or_u -> <i64>atomic.or<u8 from i64>
-function builtin_i64_atomic_rmw8_or_u(ctx: BuiltinContext): ExpressionRef {
+function builtin_i64_atomic_rmw8_or_u(ctx: BuiltinFunctionContext): ExpressionRef {
   checkTypeAbsent(ctx);
   ctx.typeArguments = [ Type.u8 ];
   ctx.contextualType = Type.i64;
   ctx.contextIsExact = true;
   return builtin_atomic_or(ctx);
 }
-builtins.set(BuiltinNames.i64_atomic_rmw8_or_u, builtin_i64_atomic_rmw8_or_u);
+builtinFunctions.set(BuiltinNames.i64_atomic_rmw8_or_u, builtin_i64_atomic_rmw8_or_u);
 
 // i64.atomic.rmw16.or_u -> <i64>atomic.or<u16 from i64>
-function builtin_i64_atomic_rmw16_or_u(ctx: BuiltinContext): ExpressionRef {
+function builtin_i64_atomic_rmw16_or_u(ctx: BuiltinFunctionContext): ExpressionRef {
   checkTypeAbsent(ctx);
   ctx.typeArguments = [ Type.u16 ];
   ctx.contextualType = Type.i64;
   ctx.contextIsExact = true;
   return builtin_atomic_or(ctx);
 }
-builtins.set(BuiltinNames.i64_atomic_rmw16_or_u, builtin_i64_atomic_rmw16_or_u);
+builtinFunctions.set(BuiltinNames.i64_atomic_rmw16_or_u, builtin_i64_atomic_rmw16_or_u);
 
 // i64.atomic.rmw32.or_u -> <i64>atomic.or<u32 from i64>
-function builtin_i64_atomic_rmw32_or_u(ctx: BuiltinContext): ExpressionRef {
+function builtin_i64_atomic_rmw32_or_u(ctx: BuiltinFunctionContext): ExpressionRef {
   checkTypeAbsent(ctx);
   ctx.typeArguments = [ Type.u32 ];
   ctx.contextualType = Type.i64;
   ctx.contextIsExact = true;
   return builtin_atomic_or(ctx);
 }
-builtins.set(BuiltinNames.i64_atomic_rmw32_or_u, builtin_i64_atomic_rmw32_or_u);
+builtinFunctions.set(BuiltinNames.i64_atomic_rmw32_or_u, builtin_i64_atomic_rmw32_or_u);
 
 // i64.atomic.rmw.or -> <i64>atomic.or<i64 from i64>
-function builtin_i64_atomic_rmw_or(ctx: BuiltinContext): ExpressionRef {
+function builtin_i64_atomic_rmw_or(ctx: BuiltinFunctionContext): ExpressionRef {
   checkTypeAbsent(ctx);
   ctx.typeArguments = [ Type.i64 ];
   ctx.contextualType = Type.i64;
   ctx.contextIsExact = true;
   return builtin_atomic_or(ctx);
 }
-builtins.set(BuiltinNames.i64_atomic_rmw_or, builtin_i64_atomic_rmw_or);
+builtinFunctions.set(BuiltinNames.i64_atomic_rmw_or, builtin_i64_atomic_rmw_or);
 
 // i32.atomic.rmw8.xor_u -> <i32>atomic.xor<u8 from i32>
-function builtin_i32_atomic_rmw8_xor_u(ctx: BuiltinContext): ExpressionRef {
+function builtin_i32_atomic_rmw8_xor_u(ctx: BuiltinFunctionContext): ExpressionRef {
   checkTypeAbsent(ctx);
   ctx.typeArguments = [ Type.u8 ];
   ctx.contextualType = Type.i32;
   ctx.contextIsExact = true;
   return builtin_atomic_xor(ctx);
 }
-builtins.set(BuiltinNames.i32_atomic_rmw8_xor_u, builtin_i32_atomic_rmw8_xor_u);
+builtinFunctions.set(BuiltinNames.i32_atomic_rmw8_xor_u, builtin_i32_atomic_rmw8_xor_u);
 
 // i32.atomic.rmw16.xor_u -> <i32>atomic.xor<u16 from i32>
-function builtin_i32_atomic_rmw16_xor_u(ctx: BuiltinContext): ExpressionRef {
+function builtin_i32_atomic_rmw16_xor_u(ctx: BuiltinFunctionContext): ExpressionRef {
   checkTypeAbsent(ctx);
   ctx.typeArguments = [ Type.u16 ];
   ctx.contextualType = Type.i32;
   ctx.contextIsExact = true;
   return builtin_atomic_xor(ctx);
 }
-builtins.set(BuiltinNames.i32_atomic_rmw16_xor_u, builtin_i32_atomic_rmw16_xor_u);
+builtinFunctions.set(BuiltinNames.i32_atomic_rmw16_xor_u, builtin_i32_atomic_rmw16_xor_u);
 
 // i32.atomic.rmw.xor -> <i32>atomic.xor<i32 from i32>
-function builtin_i32_atomic_rmw_xor(ctx: BuiltinContext): ExpressionRef {
+function builtin_i32_atomic_rmw_xor(ctx: BuiltinFunctionContext): ExpressionRef {
   checkTypeAbsent(ctx);
   ctx.typeArguments = [ Type.i32 ];
   ctx.contextualType = Type.i32;
   ctx.contextIsExact = true;
   return builtin_atomic_xor(ctx);
 }
-builtins.set(BuiltinNames.i32_atomic_rmw_xor, builtin_i32_atomic_rmw_xor);
+builtinFunctions.set(BuiltinNames.i32_atomic_rmw_xor, builtin_i32_atomic_rmw_xor);
 
 // i64.atomic.rmw8.xor_u -> <i64>atomic.xor<u8 from i64>
-function builtin_i64_atomic_rmw8_xor_u(ctx: BuiltinContext): ExpressionRef {
+function builtin_i64_atomic_rmw8_xor_u(ctx: BuiltinFunctionContext): ExpressionRef {
   checkTypeAbsent(ctx);
   ctx.typeArguments = [ Type.u8 ];
   ctx.contextualType = Type.i64;
   ctx.contextIsExact = true;
   return builtin_atomic_xor(ctx);
 }
-builtins.set(BuiltinNames.i64_atomic_rmw8_xor_u, builtin_i64_atomic_rmw8_xor_u);
+builtinFunctions.set(BuiltinNames.i64_atomic_rmw8_xor_u, builtin_i64_atomic_rmw8_xor_u);
 
 // i64.atomic.rmw16.xor_u -> <i64>atomic.xor<u16 from i64>
-function builtin_i64_atomic_rmw16_xor_u(ctx: BuiltinContext): ExpressionRef {
+function builtin_i64_atomic_rmw16_xor_u(ctx: BuiltinFunctionContext): ExpressionRef {
   checkTypeAbsent(ctx);
   ctx.typeArguments = [ Type.u16 ];
   ctx.contextualType = Type.i64;
   ctx.contextIsExact = true;
   return builtin_atomic_xor(ctx);
 }
-builtins.set(BuiltinNames.i64_atomic_rmw16_xor_u, builtin_i64_atomic_rmw16_xor_u);
+builtinFunctions.set(BuiltinNames.i64_atomic_rmw16_xor_u, builtin_i64_atomic_rmw16_xor_u);
 
 // i64.atomic.rmw32.xor_u -> <i64>atomic.xor<u32 from i64>
-function builtin_i64_atomic_rmw32_xor_u(ctx: BuiltinContext): ExpressionRef {
+function builtin_i64_atomic_rmw32_xor_u(ctx: BuiltinFunctionContext): ExpressionRef {
   checkTypeAbsent(ctx);
   ctx.typeArguments = [ Type.u32 ];
   ctx.contextualType = Type.i64;
   ctx.contextIsExact = true;
   return builtin_atomic_xor(ctx);
 }
-builtins.set(BuiltinNames.i64_atomic_rmw32_xor_u, builtin_i64_atomic_rmw32_xor_u);
+builtinFunctions.set(BuiltinNames.i64_atomic_rmw32_xor_u, builtin_i64_atomic_rmw32_xor_u);
 
 // i64.atomic.rmw.xor -> <i64>atomic.xor<i64 from i64>
-function builtin_i64_atomic_rmw_xor(ctx: BuiltinContext): ExpressionRef {
+function builtin_i64_atomic_rmw_xor(ctx: BuiltinFunctionContext): ExpressionRef {
   checkTypeAbsent(ctx);
   ctx.typeArguments = [ Type.i64 ];
   ctx.contextualType = Type.i64;
   ctx.contextIsExact = true;
   return builtin_atomic_xor(ctx);
 }
-builtins.set(BuiltinNames.i64_atomic_rmw_xor, builtin_i64_atomic_rmw_xor);
+builtinFunctions.set(BuiltinNames.i64_atomic_rmw_xor, builtin_i64_atomic_rmw_xor);
 
 // i32.atomic.rmw8.xchg_u -> <i32>atomic.xchg<u8 from i32>
-function builtin_i32_atomic_rmw8_xchg_u(ctx: BuiltinContext): ExpressionRef {
+function builtin_i32_atomic_rmw8_xchg_u(ctx: BuiltinFunctionContext): ExpressionRef {
   checkTypeAbsent(ctx);
   ctx.typeArguments = [ Type.u8 ];
   ctx.contextualType = Type.i32;
   ctx.contextIsExact = true;
   return builtin_atomic_xchg(ctx);
 }
-builtins.set(BuiltinNames.i32_atomic_rmw8_xchg_u, builtin_i32_atomic_rmw8_xchg_u);
+builtinFunctions.set(BuiltinNames.i32_atomic_rmw8_xchg_u, builtin_i32_atomic_rmw8_xchg_u);
 
 // i32.atomic.rmw16.xchg_u -> <i32>atomic.xchg<u16 from i32>
-function builtin_i32_atomic_rmw16_xchg_u(ctx: BuiltinContext): ExpressionRef {
+function builtin_i32_atomic_rmw16_xchg_u(ctx: BuiltinFunctionContext): ExpressionRef {
   checkTypeAbsent(ctx);
   ctx.typeArguments = [ Type.u16 ];
   ctx.contextualType = Type.i32;
   ctx.contextIsExact = true;
   return builtin_atomic_xchg(ctx);
 }
-builtins.set(BuiltinNames.i32_atomic_rmw16_xchg_u, builtin_i32_atomic_rmw16_xchg_u);
+builtinFunctions.set(BuiltinNames.i32_atomic_rmw16_xchg_u, builtin_i32_atomic_rmw16_xchg_u);
 
 // i32.atomic.rmw.xchg -> <i32>atomic.xchg<i32 from i32>
-function builtin_i32_atomic_rmw_xchg(ctx: BuiltinContext): ExpressionRef {
+function builtin_i32_atomic_rmw_xchg(ctx: BuiltinFunctionContext): ExpressionRef {
   checkTypeAbsent(ctx);
   ctx.typeArguments = [ Type.i32 ];
   ctx.contextualType = Type.i32;
   ctx.contextIsExact = true;
   return builtin_atomic_xchg(ctx);
 }
-builtins.set(BuiltinNames.i32_atomic_rmw_xchg, builtin_i32_atomic_rmw_xchg);
+builtinFunctions.set(BuiltinNames.i32_atomic_rmw_xchg, builtin_i32_atomic_rmw_xchg);
 
 // i64.atomic.rmw8.xchg_u -> <i64>atomic.xchg<u8 from i64>
-function builtin_i64_atomic_rmw8_xchg_u(ctx: BuiltinContext): ExpressionRef {
+function builtin_i64_atomic_rmw8_xchg_u(ctx: BuiltinFunctionContext): ExpressionRef {
   checkTypeAbsent(ctx);
   ctx.typeArguments = [ Type.u8 ];
   ctx.contextualType = Type.i64;
   ctx.contextIsExact = true;
   return builtin_atomic_xchg(ctx);
 }
-builtins.set(BuiltinNames.i64_atomic_rmw8_xchg_u, builtin_i64_atomic_rmw8_xchg_u);
+builtinFunctions.set(BuiltinNames.i64_atomic_rmw8_xchg_u, builtin_i64_atomic_rmw8_xchg_u);
 
 // i64.atomic.rmw16.xchg_u -> <i64>atomic.xchg<u16 from i64>
-function builtin_i64_atomic_rmw16_xchg_u(ctx: BuiltinContext): ExpressionRef {
+function builtin_i64_atomic_rmw16_xchg_u(ctx: BuiltinFunctionContext): ExpressionRef {
   checkTypeAbsent(ctx);
   ctx.typeArguments = [ Type.u16 ];
   ctx.contextualType = Type.i64;
   ctx.contextIsExact = true;
   return builtin_atomic_xchg(ctx);
 }
-builtins.set(BuiltinNames.i64_atomic_rmw16_xchg_u, builtin_i64_atomic_rmw16_xchg_u);
+builtinFunctions.set(BuiltinNames.i64_atomic_rmw16_xchg_u, builtin_i64_atomic_rmw16_xchg_u);
 
 // i64.atomic.rmw32.xchg_u -> <i64>atomic.xchg<u32 from i64>
-function builtin_i64_atomic_rmw32_xchg_u(ctx: BuiltinContext): ExpressionRef {
+function builtin_i64_atomic_rmw32_xchg_u(ctx: BuiltinFunctionContext): ExpressionRef {
   checkTypeAbsent(ctx);
   ctx.typeArguments = [ Type.u32 ];
   ctx.contextualType = Type.i64;
   ctx.contextIsExact = true;
   return builtin_atomic_xchg(ctx);
 }
-builtins.set(BuiltinNames.i64_atomic_rmw32_xchg_u, builtin_i64_atomic_rmw32_xchg_u);
+builtinFunctions.set(BuiltinNames.i64_atomic_rmw32_xchg_u, builtin_i64_atomic_rmw32_xchg_u);
 
 // i64.atomic.rmw.xchg -> <i64>atomic.xchg<i64 from i64>
-function builtin_i64_atomic_rmw_xchg(ctx: BuiltinContext): ExpressionRef {
+function builtin_i64_atomic_rmw_xchg(ctx: BuiltinFunctionContext): ExpressionRef {
   checkTypeAbsent(ctx);
   ctx.typeArguments = [ Type.i64 ];
   ctx.contextualType = Type.i64;
   ctx.contextIsExact = true;
   return builtin_atomic_xchg(ctx);
 }
-builtins.set(BuiltinNames.i64_atomic_rmw_xchg, builtin_i64_atomic_rmw_xchg);
+builtinFunctions.set(BuiltinNames.i64_atomic_rmw_xchg, builtin_i64_atomic_rmw_xchg);
 
 // i32.atomic.rmw8.cmpxchg_u -> <i32>atomic.cmpxchg<u8 from i32>
-function builtin_i32_atomic_rmw8_cmpxchg_u(ctx: BuiltinContext): ExpressionRef {
+function builtin_i32_atomic_rmw8_cmpxchg_u(ctx: BuiltinFunctionContext): ExpressionRef {
   checkTypeAbsent(ctx);
   ctx.typeArguments = [ Type.u8 ];
   ctx.contextualType = Type.i32;
   ctx.contextIsExact = true;
   return builtin_atomic_cmpxchg(ctx);
 }
-builtins.set(BuiltinNames.i32_atomic_rmw8_cmpxchg_u, builtin_i32_atomic_rmw8_cmpxchg_u);
+builtinFunctions.set(BuiltinNames.i32_atomic_rmw8_cmpxchg_u, builtin_i32_atomic_rmw8_cmpxchg_u);
 
 // i32.atomic.rmw16.cmpxchg_u -> <i32>atomic.cmpxchg<u16 from i32>
-function builtin_i32_atomic_rmw16_cmpxchg_u(ctx: BuiltinContext): ExpressionRef {
+function builtin_i32_atomic_rmw16_cmpxchg_u(ctx: BuiltinFunctionContext): ExpressionRef {
   checkTypeAbsent(ctx);
   ctx.typeArguments = [ Type.u16 ];
   ctx.contextualType = Type.i32;
   ctx.contextIsExact = true;
   return builtin_atomic_cmpxchg(ctx);
 }
-builtins.set(BuiltinNames.i32_atomic_rmw16_cmpxchg_u, builtin_i32_atomic_rmw16_cmpxchg_u);
+builtinFunctions.set(BuiltinNames.i32_atomic_rmw16_cmpxchg_u, builtin_i32_atomic_rmw16_cmpxchg_u);
 
 // i32.atomic.rmw.cmpxchg -> <i32>atomic.cmpxchg<i32 from i32>
-function builtin_i32_atomic_rmw_cmpxchg(ctx: BuiltinContext): ExpressionRef {
+function builtin_i32_atomic_rmw_cmpxchg(ctx: BuiltinFunctionContext): ExpressionRef {
   checkTypeAbsent(ctx);
   ctx.typeArguments = [ Type.i32 ];
   ctx.contextualType = Type.i32;
   ctx.contextIsExact = true;
   return builtin_atomic_cmpxchg(ctx);
 }
-builtins.set(BuiltinNames.i32_atomic_rmw_cmpxchg, builtin_i32_atomic_rmw_cmpxchg);
+builtinFunctions.set(BuiltinNames.i32_atomic_rmw_cmpxchg, builtin_i32_atomic_rmw_cmpxchg);
 
 // i64.atomic.rmw8.cmpxchg_u -> <i64>atomic.cmpxchg<u8 from i64>
-function builtin_i64_atomic_rmw8_cmpxchg_u(ctx: BuiltinContext): ExpressionRef {
+function builtin_i64_atomic_rmw8_cmpxchg_u(ctx: BuiltinFunctionContext): ExpressionRef {
   checkTypeAbsent(ctx);
   ctx.typeArguments = [ Type.u8 ];
   ctx.contextualType = Type.i64;
   ctx.contextIsExact = true;
   return builtin_atomic_cmpxchg(ctx);
 }
-builtins.set(BuiltinNames.i64_atomic_rmw8_cmpxchg_u, builtin_i64_atomic_rmw8_cmpxchg_u);
+builtinFunctions.set(BuiltinNames.i64_atomic_rmw8_cmpxchg_u, builtin_i64_atomic_rmw8_cmpxchg_u);
 
 // i64.atomic.rmw16.cmpxchg_u -> <i64>atomic.cmpxchg<u16 from i64>
-function builtin_i64_atomic_rmw16_cmpxchg_u(ctx: BuiltinContext): ExpressionRef {
+function builtin_i64_atomic_rmw16_cmpxchg_u(ctx: BuiltinFunctionContext): ExpressionRef {
   checkTypeAbsent(ctx);
   ctx.typeArguments = [ Type.u16 ];
   ctx.contextualType = Type.i64;
   ctx.contextIsExact = true;
   return builtin_atomic_cmpxchg(ctx);
 }
-builtins.set(BuiltinNames.i64_atomic_rmw16_cmpxchg_u, builtin_i64_atomic_rmw16_cmpxchg_u);
+builtinFunctions.set(BuiltinNames.i64_atomic_rmw16_cmpxchg_u, builtin_i64_atomic_rmw16_cmpxchg_u);
 
 // i64.atomic.rmw32.cmpxchg_u -> <i64>atomic.cmpxchg<u32 from i64>
-function builtin_i64_atomic_rmw32_cmpxchg_u(ctx: BuiltinContext): ExpressionRef {
+function builtin_i64_atomic_rmw32_cmpxchg_u(ctx: BuiltinFunctionContext): ExpressionRef {
   checkTypeAbsent(ctx);
   ctx.typeArguments = [ Type.u32 ];
   ctx.contextualType = Type.i64;
   ctx.contextIsExact = true;
   return builtin_atomic_cmpxchg(ctx);
 }
-builtins.set(BuiltinNames.i64_atomic_rmw32_cmpxchg_u, builtin_i64_atomic_rmw32_cmpxchg_u);
+builtinFunctions.set(BuiltinNames.i64_atomic_rmw32_cmpxchg_u, builtin_i64_atomic_rmw32_cmpxchg_u);
 
 // i64.atomic.rmw.cmpxchg -> <i64>atomic.cmpxchg<i64 from i64>
-function builtin_i64_atomic_rmw_cmpxchg(ctx: BuiltinContext): ExpressionRef {
+function builtin_i64_atomic_rmw_cmpxchg(ctx: BuiltinFunctionContext): ExpressionRef {
   checkTypeAbsent(ctx);
   ctx.typeArguments = [ Type.i64 ];
   ctx.contextualType = Type.i64;
   ctx.contextIsExact = true;
   return builtin_atomic_cmpxchg(ctx);
 }
-builtins.set(BuiltinNames.i64_atomic_rmw_cmpxchg, builtin_i64_atomic_rmw_cmpxchg);
+builtinFunctions.set(BuiltinNames.i64_atomic_rmw_cmpxchg, builtin_i64_atomic_rmw_cmpxchg);
 
-// i32.wait -> atomic.wait<i32>
-function builtin_i32_wait(ctx: BuiltinContext): ExpressionRef {
+// memory.atomic.wait32 -> atomic.wait<i32>
+function builtin_memory_atomic_wait32(ctx: BuiltinFunctionContext): ExpressionRef {
   checkTypeAbsent(ctx);
   ctx.typeArguments = [ Type.i32 ];
   return builtin_atomic_wait(ctx);
 }
-builtins.set(BuiltinNames.i32_wait, builtin_i32_wait);
+builtinFunctions.set(BuiltinNames.memory_atomic_wait32, builtin_memory_atomic_wait32);
 
-// i64.wait -> atomic.wait<i64>
-function builtin_i64_wait(ctx: BuiltinContext): ExpressionRef {
+// memory.atomic.wait64 -> atomic.wait<i64>
+function builtin_memory_atomic_wait64(ctx: BuiltinFunctionContext): ExpressionRef {
   checkTypeAbsent(ctx);
   ctx.typeArguments = [ Type.i64 ];
   ctx.contextualType = Type.i32;
   return builtin_atomic_wait(ctx);
 }
-builtins.set(BuiltinNames.i64_wait, builtin_i64_wait);
+builtinFunctions.set(BuiltinNames.memory_atomic_wait64, builtin_memory_atomic_wait64);
 
 // v128.load -> load<v128>
-function builtin_v128_load(ctx: BuiltinContext): ExpressionRef {
+function builtin_v128_load(ctx: BuiltinFunctionContext): ExpressionRef {
   checkTypeAbsent(ctx);
   ctx.typeArguments = [ Type.v128 ];
   ctx.contextualType = Type.v128;
   return builtin_load(ctx);
 }
-builtins.set(BuiltinNames.v128_load, builtin_v128_load);
+builtinFunctions.set(BuiltinNames.v128_load, builtin_v128_load);
 
 // v128.load8x8_s -> v128.load_ext<i8>
-function builtin_v128_load8x8_s(ctx: BuiltinContext): ExpressionRef {
+function builtin_v128_load8x8_s(ctx: BuiltinFunctionContext): ExpressionRef {
   checkTypeAbsent(ctx);
   ctx.typeArguments = [ Type.i8 ];
   ctx.contextualType = Type.v128;
   return builtin_v128_load_ext(ctx);
 }
-builtins.set(BuiltinNames.v128_load8x8_s, builtin_v128_load8x8_s);
+builtinFunctions.set(BuiltinNames.v128_load8x8_s, builtin_v128_load8x8_s);
 
 // v128.load8x8_u -> v128.load_ext<u8>
-function builtin_v128_load8x8_u(ctx: BuiltinContext): ExpressionRef {
+function builtin_v128_load8x8_u(ctx: BuiltinFunctionContext): ExpressionRef {
   checkTypeAbsent(ctx);
   ctx.typeArguments = [ Type.u8 ];
   ctx.contextualType = Type.v128;
   return builtin_v128_load_ext(ctx);
 }
-builtins.set(BuiltinNames.v128_load8x8_u, builtin_v128_load8x8_u);
+builtinFunctions.set(BuiltinNames.v128_load8x8_u, builtin_v128_load8x8_u);
 
 // v128.load16x4_s -> v128.load_ext<i16>
-function builtin_v128_load16x4_s(ctx: BuiltinContext): ExpressionRef {
+function builtin_v128_load16x4_s(ctx: BuiltinFunctionContext): ExpressionRef {
   checkTypeAbsent(ctx);
   ctx.typeArguments = [ Type.i16 ];
   ctx.contextualType = Type.v128;
   return builtin_v128_load_ext(ctx);
 }
-builtins.set(BuiltinNames.v128_load16x4_s, builtin_v128_load16x4_s);
+builtinFunctions.set(BuiltinNames.v128_load16x4_s, builtin_v128_load16x4_s);
 
 // v128.load16x4_u -> v128.load_ext<u16>
-function builtin_v128_load16x4_u(ctx: BuiltinContext): ExpressionRef {
+function builtin_v128_load16x4_u(ctx: BuiltinFunctionContext): ExpressionRef {
   checkTypeAbsent(ctx);
   ctx.typeArguments = [ Type.u16 ];
   ctx.contextualType = Type.v128;
   return builtin_v128_load_ext(ctx);
 }
-builtins.set(BuiltinNames.v128_load16x4_u, builtin_v128_load16x4_u);
+builtinFunctions.set(BuiltinNames.v128_load16x4_u, builtin_v128_load16x4_u);
 
 // v128.load32x2_s -> v128.load_ext<i32>
-function builtin_v128_load32x2_s(ctx: BuiltinContext): ExpressionRef {
+function builtin_v128_load32x2_s(ctx: BuiltinFunctionContext): ExpressionRef {
   checkTypeAbsent(ctx);
   ctx.typeArguments = [ Type.i32 ];
   ctx.contextualType = Type.v128;
   return builtin_v128_load_ext(ctx);
 }
-builtins.set(BuiltinNames.v128_load32x2_s, builtin_v128_load32x2_s);
+builtinFunctions.set(BuiltinNames.v128_load32x2_s, builtin_v128_load32x2_s);
 
 // v128.load32x2_u -> v128.load_ext<u32>
-function builtin_v128_load32x2_u(ctx: BuiltinContext): ExpressionRef {
+function builtin_v128_load32x2_u(ctx: BuiltinFunctionContext): ExpressionRef {
   checkTypeAbsent(ctx);
   ctx.typeArguments = [ Type.u32 ];
   ctx.contextualType = Type.v128;
   return builtin_v128_load_ext(ctx);
 }
-builtins.set(BuiltinNames.v128_load32x2_u, builtin_v128_load32x2_u);
+builtinFunctions.set(BuiltinNames.v128_load32x2_u, builtin_v128_load32x2_u);
 
 // v128.load8_splat -> v128.load_splat<u8>
-function builtin_v128_load8_splat(ctx: BuiltinContext): ExpressionRef {
+function builtin_v128_load8_splat(ctx: BuiltinFunctionContext): ExpressionRef {
   checkTypeAbsent(ctx);
   ctx.typeArguments = [ Type.u8 ];
   ctx.contextualType = Type.v128;
   return builtin_v128_load_splat(ctx);
 }
-builtins.set(BuiltinNames.v128_load8_splat, builtin_v128_load8_splat);
+builtinFunctions.set(BuiltinNames.v128_load8_splat, builtin_v128_load8_splat);
 
 // v128.load16_splat -> v128.load_splat<u16>
-function builtin_v128_load16_splat(ctx: BuiltinContext): ExpressionRef {
+function builtin_v128_load16_splat(ctx: BuiltinFunctionContext): ExpressionRef {
   checkTypeAbsent(ctx);
   ctx.typeArguments = [ Type.u16 ];
   ctx.contextualType = Type.v128;
   return builtin_v128_load_splat(ctx);
 }
-builtins.set(BuiltinNames.v128_load16_splat, builtin_v128_load16_splat);
+builtinFunctions.set(BuiltinNames.v128_load16_splat, builtin_v128_load16_splat);
 
 // v128.load32_splat -> v128.load_splat<u32>
-function builtin_v128_load32_splat(ctx: BuiltinContext): ExpressionRef {
+function builtin_v128_load32_splat(ctx: BuiltinFunctionContext): ExpressionRef {
   checkTypeAbsent(ctx);
   ctx.typeArguments = [ Type.u32 ];
   ctx.contextualType = Type.v128;
   return builtin_v128_load_splat(ctx);
 }
-builtins.set(BuiltinNames.v128_load32_splat, builtin_v128_load32_splat);
+builtinFunctions.set(BuiltinNames.v128_load32_splat, builtin_v128_load32_splat);
 
 // v128.load64_splat -> v128.load_splat<u64>
-function builtin_v128_load64_splat(ctx: BuiltinContext): ExpressionRef {
+function builtin_v128_load64_splat(ctx: BuiltinFunctionContext): ExpressionRef {
   checkTypeAbsent(ctx);
   ctx.typeArguments = [ Type.u64 ];
   ctx.contextualType = Type.v128;
   return builtin_v128_load_splat(ctx);
 }
-builtins.set(BuiltinNames.v128_load64_splat, builtin_v128_load64_splat);
+builtinFunctions.set(BuiltinNames.v128_load64_splat, builtin_v128_load64_splat);
 
 // v128.load32_zero -> v128.load_zero<u32>
-function builtin_v128_load32_zero(ctx: BuiltinContext): ExpressionRef {
+function builtin_v128_load32_zero(ctx: BuiltinFunctionContext): ExpressionRef {
   checkTypeAbsent(ctx);
   ctx.typeArguments = [ Type.u32 ];
   ctx.contextualType = Type.v128;
   return builtin_v128_load_zero(ctx);
 }
-builtins.set(BuiltinNames.v128_load32_zero, builtin_v128_load32_zero);
+builtinFunctions.set(BuiltinNames.v128_load32_zero, builtin_v128_load32_zero);
 
 // v128.load64_zero -> v128.load_zero<u64>
-function builtin_v128_load64_zero(ctx: BuiltinContext): ExpressionRef {
+function builtin_v128_load64_zero(ctx: BuiltinFunctionContext): ExpressionRef {
   checkTypeAbsent(ctx);
   ctx.typeArguments = [ Type.u64 ];
   ctx.contextualType = Type.v128;
   return builtin_v128_load_zero(ctx);
 }
-builtins.set(BuiltinNames.v128_load64_zero, builtin_v128_load64_zero);
+builtinFunctions.set(BuiltinNames.v128_load64_zero, builtin_v128_load64_zero);
 
 // v128.load8_lane -> v128.load_lane<u8>
-function builtin_v128_load8_lane(ctx: BuiltinContext): ExpressionRef {
+function builtin_v128_load8_lane(ctx: BuiltinFunctionContext): ExpressionRef {
   checkTypeAbsent(ctx);
   ctx.typeArguments = [ Type.u8 ];
   ctx.contextualType = Type.v128;
   return builtin_v128_load_lane(ctx);
 }
-builtins.set(BuiltinNames.v128_load8_lane, builtin_v128_load8_lane);
+builtinFunctions.set(BuiltinNames.v128_load8_lane, builtin_v128_load8_lane);
 
 // v128.load16_lane -> v128.load_lane<u16>
-function builtin_v128_load16_lane(ctx: BuiltinContext): ExpressionRef {
+function builtin_v128_load16_lane(ctx: BuiltinFunctionContext): ExpressionRef {
   checkTypeAbsent(ctx);
   ctx.typeArguments = [ Type.u16 ];
   ctx.contextualType = Type.v128;
   return builtin_v128_load_lane(ctx);
 }
-builtins.set(BuiltinNames.v128_load16_lane, builtin_v128_load16_lane);
+builtinFunctions.set(BuiltinNames.v128_load16_lane, builtin_v128_load16_lane);
 
 // v128.load32_lane -> v128.load_lane<u32>
-function builtin_v128_load32_lane(ctx: BuiltinContext): ExpressionRef {
+function builtin_v128_load32_lane(ctx: BuiltinFunctionContext): ExpressionRef {
   checkTypeAbsent(ctx);
   ctx.typeArguments = [ Type.u32 ];
   ctx.contextualType = Type.v128;
   return builtin_v128_load_lane(ctx);
 }
-builtins.set(BuiltinNames.v128_load32_lane, builtin_v128_load32_lane);
+builtinFunctions.set(BuiltinNames.v128_load32_lane, builtin_v128_load32_lane);
 
 // v128.load64_lane -> v128.load_lane<u64>
-function builtin_v128_load64_lane(ctx: BuiltinContext): ExpressionRef {
+function builtin_v128_load64_lane(ctx: BuiltinFunctionContext): ExpressionRef {
   checkTypeAbsent(ctx);
   ctx.typeArguments = [ Type.u64 ];
   ctx.contextualType = Type.v128;
   return builtin_v128_load_lane(ctx);
 }
-builtins.set(BuiltinNames.v128_load64_lane, builtin_v128_load64_lane);
+builtinFunctions.set(BuiltinNames.v128_load64_lane, builtin_v128_load64_lane);
 
 // v128.store8_lane -> v128.store_lane<u8>
-function builtin_v128_store8_lane(ctx: BuiltinContext): ExpressionRef {
+function builtin_v128_store8_lane(ctx: BuiltinFunctionContext): ExpressionRef {
   checkTypeAbsent(ctx);
   ctx.typeArguments = [ Type.u8 ];
   ctx.contextualType = Type.v128;
   return builtin_v128_store_lane(ctx);
 }
-builtins.set(BuiltinNames.v128_store8_lane, builtin_v128_store8_lane);
+builtinFunctions.set(BuiltinNames.v128_store8_lane, builtin_v128_store8_lane);
 
 // v128.store16_lane -> v128.store_lane<u16>
-function builtin_v128_store16_lane(ctx: BuiltinContext): ExpressionRef {
+function builtin_v128_store16_lane(ctx: BuiltinFunctionContext): ExpressionRef {
   checkTypeAbsent(ctx);
   ctx.typeArguments = [ Type.u16 ];
   ctx.contextualType = Type.v128;
   return builtin_v128_store_lane(ctx);
 }
-builtins.set(BuiltinNames.v128_store16_lane, builtin_v128_store16_lane);
+builtinFunctions.set(BuiltinNames.v128_store16_lane, builtin_v128_store16_lane);
 
 // v128.store32_lane -> v128.store_lane<u32>
-function builtin_v128_store32_lane(ctx: BuiltinContext): ExpressionRef {
+function builtin_v128_store32_lane(ctx: BuiltinFunctionContext): ExpressionRef {
   checkTypeAbsent(ctx);
   ctx.typeArguments = [ Type.u32 ];
   ctx.contextualType = Type.v128;
   return builtin_v128_store_lane(ctx);
 }
-builtins.set(BuiltinNames.v128_store32_lane, builtin_v128_store32_lane);
+builtinFunctions.set(BuiltinNames.v128_store32_lane, builtin_v128_store32_lane);
 
 // v128.store64_lane -> v128.store_lane<u64>
-function builtin_v128_store64_lane(ctx: BuiltinContext): ExpressionRef {
+function builtin_v128_store64_lane(ctx: BuiltinFunctionContext): ExpressionRef {
   checkTypeAbsent(ctx);
   ctx.typeArguments = [ Type.u64 ];
   ctx.contextualType = Type.v128;
   return builtin_v128_store_lane(ctx);
 }
-builtins.set(BuiltinNames.v128_store64_lane, builtin_v128_store64_lane);
+builtinFunctions.set(BuiltinNames.v128_store64_lane, builtin_v128_store64_lane);
 
 // v128.store -> store<v128 from v128>
-function builtin_v128_store(ctx: BuiltinContext): ExpressionRef {
+function builtin_v128_store(ctx: BuiltinFunctionContext): ExpressionRef {
   checkTypeAbsent(ctx);
   ctx.typeArguments = [ Type.v128 ];
   ctx.contextualType = Type.v128;
   ctx.contextIsExact = true;
   return builtin_store(ctx);
 }
-builtins.set(BuiltinNames.v128_store, builtin_v128_store);
+builtinFunctions.set(BuiltinNames.v128_store, builtin_v128_store);
 
 // i8x16_splat -> v128.splat<i8>
-function builtin_i8x16_splat(ctx: BuiltinContext): ExpressionRef {
+function builtin_i8x16_splat(ctx: BuiltinFunctionContext): ExpressionRef {
   checkTypeAbsent(ctx);
   ctx.typeArguments = [ Type.i8 ];
   ctx.contextualType = Type.v128;
   return builtin_v128_splat(ctx);
 }
-builtins.set(BuiltinNames.i8x16_splat, builtin_i8x16_splat);
+builtinFunctions.set(BuiltinNames.i8x16_splat, builtin_i8x16_splat);
 
 // i8x16.extract_lane_s -> <i32>v128.extract_lane<i8>
-function builtin_i8x16_extract_lane_s(ctx: BuiltinContext): ExpressionRef {
+function builtin_i8x16_extract_lane_s(ctx: BuiltinFunctionContext): ExpressionRef {
   checkTypeAbsent(ctx);
   ctx.typeArguments = [ Type.i8 ];
   ctx.contextualType = Type.i32;
   return builtin_v128_extract_lane(ctx);
 }
-builtins.set(BuiltinNames.i8x16_extract_lane_s, builtin_i8x16_extract_lane_s);
+builtinFunctions.set(BuiltinNames.i8x16_extract_lane_s, builtin_i8x16_extract_lane_s);
 
 // i8x16.extract_lane_u -> <i32>v128.extract_lane<u8>
-function builtin_i8x16_extract_lane_u(ctx: BuiltinContext): ExpressionRef {
+function builtin_i8x16_extract_lane_u(ctx: BuiltinFunctionContext): ExpressionRef {
   checkTypeAbsent(ctx);
   ctx.typeArguments = [ Type.u8 ];
   ctx.contextualType = Type.i32;
   return builtin_v128_extract_lane(ctx);
 }
-builtins.set(BuiltinNames.i8x16_extract_lane_u, builtin_i8x16_extract_lane_u);
+builtinFunctions.set(BuiltinNames.i8x16_extract_lane_u, builtin_i8x16_extract_lane_u);
 
 // i8x16.replace_lane -> v128.replace_lane<i8>
-function builtin_i8x16_replace_lane(ctx: BuiltinContext): ExpressionRef {
+function builtin_i8x16_replace_lane(ctx: BuiltinFunctionContext): ExpressionRef {
   checkTypeAbsent(ctx);
   ctx.typeArguments = [ Type.i8 ];
   ctx.contextualType = Type.v128;
   return builtin_v128_replace_lane(ctx);
 }
-builtins.set(BuiltinNames.i8x16_replace_lane, builtin_i8x16_replace_lane);
+builtinFunctions.set(BuiltinNames.i8x16_replace_lane, builtin_i8x16_replace_lane);
 
 // i8x16.add -> v128.add<i8>
-function builtin_i8x16_add(ctx: BuiltinContext): ExpressionRef {
+function builtin_i8x16_add(ctx: BuiltinFunctionContext): ExpressionRef {
   checkTypeAbsent(ctx);
   ctx.typeArguments = [ Type.i8 ];
   ctx.contextualType = Type.v128;
   return builtin_v128_add(ctx);
 }
-builtins.set(BuiltinNames.i8x16_add, builtin_i8x16_add);
+builtinFunctions.set(BuiltinNames.i8x16_add, builtin_i8x16_add);
 
 // i8x16.sub -> v128.sub<i8>
-function builtin_i8x16_sub(ctx: BuiltinContext): ExpressionRef {
+function builtin_i8x16_sub(ctx: BuiltinFunctionContext): ExpressionRef {
   checkTypeAbsent(ctx);
   ctx.typeArguments = [ Type.i8 ];
   ctx.contextualType = Type.v128;
   return builtin_v128_sub(ctx);
 }
-builtins.set(BuiltinNames.i8x16_sub, builtin_i8x16_sub);
+builtinFunctions.set(BuiltinNames.i8x16_sub, builtin_i8x16_sub);
 
 // i8x16.min_s -> v128.min<i8>
-function builtin_i8x16_min_s(ctx: BuiltinContext): ExpressionRef {
+function builtin_i8x16_min_s(ctx: BuiltinFunctionContext): ExpressionRef {
   checkTypeAbsent(ctx);
   ctx.typeArguments = [ Type.i8 ];
   ctx.contextualType = Type.v128;
   return builtin_v128_min(ctx);
 }
-builtins.set(BuiltinNames.i8x16_min_s, builtin_i8x16_min_s);
+builtinFunctions.set(BuiltinNames.i8x16_min_s, builtin_i8x16_min_s);
 
 // i8x16.min_u -> v128.min<u8>
-function builtin_i8x16_min_u(ctx: BuiltinContext): ExpressionRef {
+function builtin_i8x16_min_u(ctx: BuiltinFunctionContext): ExpressionRef {
   checkTypeAbsent(ctx);
   ctx.typeArguments = [ Type.u8 ];
   ctx.contextualType = Type.v128;
   return builtin_v128_min(ctx);
 }
-builtins.set(BuiltinNames.i8x16_min_u, builtin_i8x16_min_u);
+builtinFunctions.set(BuiltinNames.i8x16_min_u, builtin_i8x16_min_u);
 
 // i8x16.max_s -> v128.max<i8>
-function builtin_i8x16_max_s(ctx: BuiltinContext): ExpressionRef {
+function builtin_i8x16_max_s(ctx: BuiltinFunctionContext): ExpressionRef {
   checkTypeAbsent(ctx);
   ctx.typeArguments = [ Type.i8 ];
   ctx.contextualType = Type.v128;
   return builtin_v128_max(ctx);
 }
-builtins.set(BuiltinNames.i8x16_max_s, builtin_i8x16_max_s);
+builtinFunctions.set(BuiltinNames.i8x16_max_s, builtin_i8x16_max_s);
 
 // i8x16.max_u -> v128.max<u8>
-function builtin_i8x16_max_u(ctx: BuiltinContext): ExpressionRef {
+function builtin_i8x16_max_u(ctx: BuiltinFunctionContext): ExpressionRef {
   checkTypeAbsent(ctx);
   ctx.typeArguments = [ Type.u8 ];
   ctx.contextualType = Type.v128;
   return builtin_v128_max(ctx);
 }
-builtins.set(BuiltinNames.i8x16_max_u, builtin_i8x16_max_u);
+builtinFunctions.set(BuiltinNames.i8x16_max_u, builtin_i8x16_max_u);
 
 // i8x16.avgr_u -> v128.avgr<u8>
-function builtin_i8x16_avgr_u(ctx: BuiltinContext): ExpressionRef {
+function builtin_i8x16_avgr_u(ctx: BuiltinFunctionContext): ExpressionRef {
   checkTypeAbsent(ctx);
   ctx.typeArguments = [ Type.u8 ];
   ctx.contextualType = Type.v128;
   return builtin_v128_avgr(ctx);
 }
-builtins.set(BuiltinNames.i8x16_avgr_u, builtin_i8x16_avgr_u);
+builtinFunctions.set(BuiltinNames.i8x16_avgr_u, builtin_i8x16_avgr_u);
 
 // i8x16.abs -> v128.abs<i8>
-function builtin_i8x16_abs(ctx: BuiltinContext): ExpressionRef {
+function builtin_i8x16_abs(ctx: BuiltinFunctionContext): ExpressionRef {
   checkTypeAbsent(ctx);
   ctx.typeArguments = [ Type.i8 ];
   ctx.contextualType = Type.v128;
   return builtin_v128_abs(ctx);
 }
-builtins.set(BuiltinNames.i8x16_abs, builtin_i8x16_abs);
+builtinFunctions.set(BuiltinNames.i8x16_abs, builtin_i8x16_abs);
 
 // i8x16.neg -> v128.neg<i8>
-function builtin_i8x16_neg(ctx: BuiltinContext): ExpressionRef {
+function builtin_i8x16_neg(ctx: BuiltinFunctionContext): ExpressionRef {
   checkTypeAbsent(ctx);
   ctx.typeArguments = [ Type.i8 ];
   ctx.contextualType = Type.v128;
   return builtin_v128_neg(ctx);
 }
-builtins.set(BuiltinNames.i8x16_neg, builtin_i8x16_neg);
+builtinFunctions.set(BuiltinNames.i8x16_neg, builtin_i8x16_neg);
 
 // i8x16.add_sat_s -> v128.add_sat<i8>
-function builtin_i8x16_add_sat_s(ctx: BuiltinContext): ExpressionRef {
+function builtin_i8x16_add_sat_s(ctx: BuiltinFunctionContext): ExpressionRef {
   checkTypeAbsent(ctx);
   ctx.typeArguments = [ Type.i8 ];
   ctx.contextualType = Type.v128;
   return builtin_v128_add_sat(ctx);
 }
-builtins.set(BuiltinNames.i8x16_add_sat_s, builtin_i8x16_add_sat_s);
+builtinFunctions.set(BuiltinNames.i8x16_add_sat_s, builtin_i8x16_add_sat_s);
 
 // i8x16.add_sat_u -> v128.add_sat<u8>
-function builtin_i8x16_add_sat_u(ctx: BuiltinContext): ExpressionRef {
+function builtin_i8x16_add_sat_u(ctx: BuiltinFunctionContext): ExpressionRef {
   checkTypeAbsent(ctx);
   ctx.typeArguments = [ Type.u8 ];
   ctx.contextualType = Type.v128;
   return builtin_v128_add_sat(ctx);
 }
-builtins.set(BuiltinNames.i8x16_add_sat_u, builtin_i8x16_add_sat_u);
+builtinFunctions.set(BuiltinNames.i8x16_add_sat_u, builtin_i8x16_add_sat_u);
 
 // i8x16.sub_sat_s -> v128.sub_sat<i8>
-function builtin_i8x16_sub_sat_s(ctx: BuiltinContext): ExpressionRef {
+function builtin_i8x16_sub_sat_s(ctx: BuiltinFunctionContext): ExpressionRef {
   checkTypeAbsent(ctx);
   ctx.typeArguments = [ Type.i8 ];
   ctx.contextualType = Type.v128;
   return builtin_v128_sub_sat(ctx);
 }
-builtins.set(BuiltinNames.i8x16_sub_sat_s, builtin_i8x16_sub_sat_s);
+builtinFunctions.set(BuiltinNames.i8x16_sub_sat_s, builtin_i8x16_sub_sat_s);
 
 // i8x16.sub_sat_u -> v128.sub_sat<u8>
-function builtin_i8x16_sub_sat_u(ctx: BuiltinContext): ExpressionRef {
+function builtin_i8x16_sub_sat_u(ctx: BuiltinFunctionContext): ExpressionRef {
   checkTypeAbsent(ctx);
   ctx.typeArguments = [ Type.u8 ];
   ctx.contextualType = Type.v128;
   return builtin_v128_sub_sat(ctx);
 }
-builtins.set(BuiltinNames.i8x16_sub_sat_u, builtin_i8x16_sub_sat_u);
+builtinFunctions.set(BuiltinNames.i8x16_sub_sat_u, builtin_i8x16_sub_sat_u);
 
 // i8x16.shl -> v128.shl<i8>
-function builtin_i8x16_shl(ctx: BuiltinContext): ExpressionRef {
+function builtin_i8x16_shl(ctx: BuiltinFunctionContext): ExpressionRef {
   checkTypeAbsent(ctx);
   ctx.typeArguments = [ Type.i8 ];
   ctx.contextualType = Type.v128;
   return builtin_v128_shl(ctx);
 }
-builtins.set(BuiltinNames.i8x16_shl, builtin_i8x16_shl);
+builtinFunctions.set(BuiltinNames.i8x16_shl, builtin_i8x16_shl);
 
 // i8x16.shr_s -> v128.shr<i8>
-function builtin_i8x16_shr_s(ctx: BuiltinContext): ExpressionRef {
+function builtin_i8x16_shr_s(ctx: BuiltinFunctionContext): ExpressionRef {
   checkTypeAbsent(ctx);
   ctx.typeArguments = [ Type.i8 ];
   ctx.contextualType = Type.v128;
   return builtin_v128_shr(ctx);
 }
-builtins.set(BuiltinNames.i8x16_shr_s, builtin_i8x16_shr_s);
+builtinFunctions.set(BuiltinNames.i8x16_shr_s, builtin_i8x16_shr_s);
 
 // i8x16.shr_u -> v128.shr<u8>
-function builtin_i8x16_shr_u(ctx: BuiltinContext): ExpressionRef {
+function builtin_i8x16_shr_u(ctx: BuiltinFunctionContext): ExpressionRef {
   checkTypeAbsent(ctx);
   ctx.typeArguments = [ Type.u8 ];
   ctx.contextualType = Type.v128;
   return builtin_v128_shr(ctx);
 }
-builtins.set(BuiltinNames.i8x16_shr_u, builtin_i8x16_shr_u);
+builtinFunctions.set(BuiltinNames.i8x16_shr_u, builtin_i8x16_shr_u);
 
 // i8x16.all_true -> v128.all_true<i8>
-function builtin_i8x16_all_true(ctx: BuiltinContext): ExpressionRef {
+function builtin_i8x16_all_true(ctx: BuiltinFunctionContext): ExpressionRef {
   checkTypeAbsent(ctx);
   ctx.typeArguments = [ Type.i8 ];
   ctx.contextualType = Type.i32;
   return builtin_v128_all_true(ctx);
 }
-builtins.set(BuiltinNames.i8x16_all_true, builtin_i8x16_all_true);
+builtinFunctions.set(BuiltinNames.i8x16_all_true, builtin_i8x16_all_true);
 
 // i8x16.bitmask -> v128.bitmask<i8>
-function builtin_i8x16_bitmask(ctx: BuiltinContext): ExpressionRef {
+function builtin_i8x16_bitmask(ctx: BuiltinFunctionContext): ExpressionRef {
   checkTypeAbsent(ctx);
   ctx.typeArguments = [ Type.i8 ];
   ctx.contextualType = Type.i32;
   return builtin_v128_bitmask(ctx);
 }
-builtins.set(BuiltinNames.i8x16_bitmask, builtin_i8x16_bitmask);
+builtinFunctions.set(BuiltinNames.i8x16_bitmask, builtin_i8x16_bitmask);
 
 // i8x16.popcnt -> v128.popcnt<i8>
-function builtin_i8x16_popcnt(ctx: BuiltinContext): ExpressionRef {
+function builtin_i8x16_popcnt(ctx: BuiltinFunctionContext): ExpressionRef {
   checkTypeAbsent(ctx);
   ctx.typeArguments = [ Type.i8 ];
   ctx.contextualType = Type.v128;
   return builtin_v128_popcnt(ctx);
 }
-builtins.set(BuiltinNames.i8x16_popcnt, builtin_i8x16_popcnt);
+builtinFunctions.set(BuiltinNames.i8x16_popcnt, builtin_i8x16_popcnt);
 
 // i8x16.eq -> v128.eq<i8>
-function builtin_i8x16_eq(ctx: BuiltinContext): ExpressionRef {
+function builtin_i8x16_eq(ctx: BuiltinFunctionContext): ExpressionRef {
   checkTypeAbsent(ctx);
   ctx.typeArguments = [ Type.i8 ];
   ctx.contextualType = Type.v128;
   return builtin_v128_eq(ctx);
 }
-builtins.set(BuiltinNames.i8x16_eq, builtin_i8x16_eq);
+builtinFunctions.set(BuiltinNames.i8x16_eq, builtin_i8x16_eq);
 
 // i8x16.ne -> v128.ne<i8>
-function builtin_i8x16_ne(ctx: BuiltinContext): ExpressionRef {
+function builtin_i8x16_ne(ctx: BuiltinFunctionContext): ExpressionRef {
   checkTypeAbsent(ctx);
   ctx.typeArguments = [ Type.i8 ];
   ctx.contextualType = Type.v128;
   return builtin_v128_ne(ctx);
 }
-builtins.set(BuiltinNames.i8x16_ne, builtin_i8x16_ne);
+builtinFunctions.set(BuiltinNames.i8x16_ne, builtin_i8x16_ne);
 
 // i8x16.lt_s -> v128.lt<i8>
-function builtin_i8x16_lt_s(ctx: BuiltinContext): ExpressionRef {
+function builtin_i8x16_lt_s(ctx: BuiltinFunctionContext): ExpressionRef {
   checkTypeAbsent(ctx);
   ctx.typeArguments = [ Type.i8 ];
   ctx.contextualType = Type.v128;
   return builtin_v128_lt(ctx);
 }
-builtins.set(BuiltinNames.i8x16_lt_s, builtin_i8x16_lt_s);
+builtinFunctions.set(BuiltinNames.i8x16_lt_s, builtin_i8x16_lt_s);
 
 // i8x16.lt_u -> v128.lt<u8>
-function builtin_i8x16_lt_u(ctx: BuiltinContext): ExpressionRef {
+function builtin_i8x16_lt_u(ctx: BuiltinFunctionContext): ExpressionRef {
   checkTypeAbsent(ctx);
   ctx.typeArguments = [ Type.u8 ];
   ctx.contextualType = Type.v128;
   return builtin_v128_lt(ctx);
 }
-builtins.set(BuiltinNames.i8x16_lt_u, builtin_i8x16_lt_u);
+builtinFunctions.set(BuiltinNames.i8x16_lt_u, builtin_i8x16_lt_u);
 
 // i8x16.le_s -> v128.le<i8>
-function builtin_i8x16_le_s(ctx: BuiltinContext): ExpressionRef {
+function builtin_i8x16_le_s(ctx: BuiltinFunctionContext): ExpressionRef {
   checkTypeAbsent(ctx);
   ctx.typeArguments = [ Type.i8 ];
   ctx.contextualType = Type.v128;
   return builtin_v128_le(ctx);
 }
-builtins.set(BuiltinNames.i8x16_le_s, builtin_i8x16_le_s);
+builtinFunctions.set(BuiltinNames.i8x16_le_s, builtin_i8x16_le_s);
 
 // i8x16.le_u -> v128.le<u8>
-function builtin_i8x16_le_u(ctx: BuiltinContext): ExpressionRef {
+function builtin_i8x16_le_u(ctx: BuiltinFunctionContext): ExpressionRef {
   checkTypeAbsent(ctx);
   ctx.typeArguments = [ Type.u8 ];
   ctx.contextualType = Type.v128;
   return builtin_v128_le(ctx);
 }
-builtins.set(BuiltinNames.i8x16_le_u, builtin_i8x16_le_u);
+builtinFunctions.set(BuiltinNames.i8x16_le_u, builtin_i8x16_le_u);
 
 // i8x16.gt_s -> v128.gt<i8>
-function builtin_i8x16_gt_s(ctx: BuiltinContext): ExpressionRef {
+function builtin_i8x16_gt_s(ctx: BuiltinFunctionContext): ExpressionRef {
   checkTypeAbsent(ctx);
   ctx.typeArguments = [ Type.i8 ];
   ctx.contextualType = Type.v128;
   return builtin_v128_gt(ctx);
 }
-builtins.set(BuiltinNames.i8x16_gt_s, builtin_i8x16_gt_s);
+builtinFunctions.set(BuiltinNames.i8x16_gt_s, builtin_i8x16_gt_s);
 
 // i8x16.gt_u -> v128.gt<u8>
-function builtin_i8x16_gt_u(ctx: BuiltinContext): ExpressionRef {
+function builtin_i8x16_gt_u(ctx: BuiltinFunctionContext): ExpressionRef {
   checkTypeAbsent(ctx);
   ctx.typeArguments = [ Type.u8 ];
   ctx.contextualType = Type.v128;
   return builtin_v128_gt(ctx);
 }
-builtins.set(BuiltinNames.i8x16_gt_u, builtin_i8x16_gt_u);
+builtinFunctions.set(BuiltinNames.i8x16_gt_u, builtin_i8x16_gt_u);
 
 // i8x16.ge_s -> v128.ge<i8>
-function builtin_i8x16_ge_s(ctx: BuiltinContext): ExpressionRef {
+function builtin_i8x16_ge_s(ctx: BuiltinFunctionContext): ExpressionRef {
   checkTypeAbsent(ctx);
   ctx.typeArguments = [ Type.i8 ];
   ctx.contextualType = Type.v128;
   return builtin_v128_ge(ctx);
 }
-builtins.set(BuiltinNames.i8x16_ge_s, builtin_i8x16_ge_s);
+builtinFunctions.set(BuiltinNames.i8x16_ge_s, builtin_i8x16_ge_s);
 
 // i8x16.ge_u -> v128.ge<u8>
-function builtin_i8x16_ge_u(ctx: BuiltinContext): ExpressionRef {
+function builtin_i8x16_ge_u(ctx: BuiltinFunctionContext): ExpressionRef {
   checkTypeAbsent(ctx);
   ctx.typeArguments = [ Type.u8 ];
   ctx.contextualType = Type.v128;
   return builtin_v128_ge(ctx);
 }
-builtins.set(BuiltinNames.i8x16_ge_u, builtin_i8x16_ge_u);
+builtinFunctions.set(BuiltinNames.i8x16_ge_u, builtin_i8x16_ge_u);
 
 // i8x16.narrow_i16x8_s -> v128.narrow<i16>
-function builtin_i8x16_narrow_i16x8_s(ctx: BuiltinContext): ExpressionRef {
+function builtin_i8x16_narrow_i16x8_s(ctx: BuiltinFunctionContext): ExpressionRef {
   checkTypeAbsent(ctx);
   ctx.typeArguments = [ Type.i16 ];
   ctx.contextualType = Type.v128;
   return builtin_v128_narrow(ctx);
 }
-builtins.set(BuiltinNames.i8x16_narrow_i16x8_s, builtin_i8x16_narrow_i16x8_s);
+builtinFunctions.set(BuiltinNames.i8x16_narrow_i16x8_s, builtin_i8x16_narrow_i16x8_s);
 
 // i8x16.narrow_i16x8_u -> v128.narrow<u16>
-function builtin_i8x16_narrow_i16x8_u(ctx: BuiltinContext): ExpressionRef {
+function builtin_i8x16_narrow_i16x8_u(ctx: BuiltinFunctionContext): ExpressionRef {
   checkTypeAbsent(ctx);
   ctx.typeArguments = [ Type.u16 ];
   ctx.contextualType = Type.v128;
   return builtin_v128_narrow(ctx);
 }
-builtins.set(BuiltinNames.i8x16_narrow_i16x8_u, builtin_i8x16_narrow_i16x8_u);
+builtinFunctions.set(BuiltinNames.i8x16_narrow_i16x8_u, builtin_i8x16_narrow_i16x8_u);
 
 // i8x16.shuffle -> v128.shuffle<i8>
-function builtin_i8x16_shuffle(ctx: BuiltinContext): ExpressionRef {
+function builtin_i8x16_shuffle(ctx: BuiltinFunctionContext): ExpressionRef {
   checkTypeAbsent(ctx);
   ctx.typeArguments = [ Type.i8 ];
   ctx.contextualType = Type.v128;
   return builtin_v128_shuffle(ctx);
 }
-builtins.set(BuiltinNames.i8x16_shuffle, builtin_i8x16_shuffle);
+builtinFunctions.set(BuiltinNames.i8x16_shuffle, builtin_i8x16_shuffle);
 
 // i8x16.swizzle -> v128.swizzle
-function builtin_i8x16_swizzle(ctx: BuiltinContext): ExpressionRef {
+function builtin_i8x16_swizzle(ctx: BuiltinFunctionContext): ExpressionRef {
   ctx.typeArguments = null;
   ctx.contextualType = Type.v128;
   return builtin_v128_swizzle(ctx);
 }
-builtins.set(BuiltinNames.i8x16_swizzle, builtin_i8x16_swizzle);
+builtinFunctions.set(BuiltinNames.i8x16_swizzle, builtin_i8x16_swizzle);
 
 // i16x8.splat -> v128.splat<i16>
-function builtin_i16x8_splat(ctx: BuiltinContext): ExpressionRef {
+function builtin_i16x8_splat(ctx: BuiltinFunctionContext): ExpressionRef {
   checkTypeAbsent(ctx);
   ctx.typeArguments = [ Type.i16 ];
   ctx.contextualType = Type.v128;
   return builtin_v128_splat(ctx);
 }
-builtins.set(BuiltinNames.i16x8_splat, builtin_i16x8_splat);
+builtinFunctions.set(BuiltinNames.i16x8_splat, builtin_i16x8_splat);
 
 // i16x8.extract_lane_s -> v128.extract_lane<i16>
-function builtin_i16x8_extract_lane_s(ctx: BuiltinContext): ExpressionRef {
+function builtin_i16x8_extract_lane_s(ctx: BuiltinFunctionContext): ExpressionRef {
   checkTypeAbsent(ctx);
   ctx.typeArguments = [ Type.i16 ];
   ctx.contextualType = Type.i32;
   return builtin_v128_extract_lane(ctx);
 }
-builtins.set(BuiltinNames.i16x8_extract_lane_s, builtin_i16x8_extract_lane_s);
+builtinFunctions.set(BuiltinNames.i16x8_extract_lane_s, builtin_i16x8_extract_lane_s);
 
 // i16x8..extract_lane_u -> v128.extract_lane<u16>
-function builtin_i16x8_extract_lane_u(ctx: BuiltinContext): ExpressionRef {
+function builtin_i16x8_extract_lane_u(ctx: BuiltinFunctionContext): ExpressionRef {
   checkTypeAbsent(ctx);
   ctx.typeArguments = [ Type.u16 ];
   ctx.contextualType = Type.i32;
   return builtin_v128_extract_lane(ctx);
 }
-builtins.set(BuiltinNames.i16x8_extract_lane_u, builtin_i16x8_extract_lane_u);
+builtinFunctions.set(BuiltinNames.i16x8_extract_lane_u, builtin_i16x8_extract_lane_u);
 
 // i16x8.replace_lane -> v128.replace_lane<i16>
-function builtin_i16x8_replace_lane(ctx: BuiltinContext): ExpressionRef {
+function builtin_i16x8_replace_lane(ctx: BuiltinFunctionContext): ExpressionRef {
   checkTypeAbsent(ctx);
   ctx.typeArguments = [ Type.i16 ];
   ctx.contextualType = Type.v128;
   return builtin_v128_replace_lane(ctx);
 }
-builtins.set(BuiltinNames.i16x8_replace_lane, builtin_i16x8_replace_lane);
+builtinFunctions.set(BuiltinNames.i16x8_replace_lane, builtin_i16x8_replace_lane);
 
 // i16x8.add -> v128.add<i16>
-function builtin_i16x8_add(ctx: BuiltinContext): ExpressionRef {
+function builtin_i16x8_add(ctx: BuiltinFunctionContext): ExpressionRef {
   checkTypeAbsent(ctx);
   ctx.typeArguments = [ Type.i16 ];
   ctx.contextualType = Type.v128;
   return builtin_v128_add(ctx);
 }
-builtins.set(BuiltinNames.i16x8_add, builtin_i16x8_add);
+builtinFunctions.set(BuiltinNames.i16x8_add, builtin_i16x8_add);
 
 // i16x8.sub -> v128.sub<i16>
-function builtin_i16x8_sub(ctx: BuiltinContext): ExpressionRef {
+function builtin_i16x8_sub(ctx: BuiltinFunctionContext): ExpressionRef {
   checkTypeAbsent(ctx);
   ctx.typeArguments = [ Type.i16 ];
   ctx.contextualType = Type.v128;
   return builtin_v128_sub(ctx);
 }
-builtins.set(BuiltinNames.i16x8_sub, builtin_i16x8_sub);
+builtinFunctions.set(BuiltinNames.i16x8_sub, builtin_i16x8_sub);
 
 // i16x8.mul -> v128.mul<i16>
-function builtin_i16x8_mul(ctx: BuiltinContext): ExpressionRef {
+function builtin_i16x8_mul(ctx: BuiltinFunctionContext): ExpressionRef {
   checkTypeAbsent(ctx);
   ctx.typeArguments = [ Type.i16 ];
   ctx.contextualType = Type.v128;
   return builtin_v128_mul(ctx);
 }
-builtins.set(BuiltinNames.i16x8_mul, builtin_i16x8_mul);
+builtinFunctions.set(BuiltinNames.i16x8_mul, builtin_i16x8_mul);
 
 // i16x8.min_s -> v128.min<i16>
-function builtin_i16x8_min_s(ctx: BuiltinContext): ExpressionRef {
+function builtin_i16x8_min_s(ctx: BuiltinFunctionContext): ExpressionRef {
   checkTypeAbsent(ctx);
   ctx.typeArguments = [ Type.i16 ];
   ctx.contextualType = Type.v128;
   return builtin_v128_min(ctx);
 }
-builtins.set(BuiltinNames.i16x8_min_s, builtin_i16x8_min_s);
+builtinFunctions.set(BuiltinNames.i16x8_min_s, builtin_i16x8_min_s);
 
 // i16x8.min_u -> v128.min<u16>
-function builtin_i16x8_min_u(ctx: BuiltinContext): ExpressionRef {
+function builtin_i16x8_min_u(ctx: BuiltinFunctionContext): ExpressionRef {
   checkTypeAbsent(ctx);
   ctx.typeArguments = [ Type.u16 ];
   ctx.contextualType = Type.v128;
   return builtin_v128_min(ctx);
 }
-builtins.set(BuiltinNames.i16x8_min_u, builtin_i16x8_min_u);
+builtinFunctions.set(BuiltinNames.i16x8_min_u, builtin_i16x8_min_u);
 
 // i16x8.max_s -> v128.max<i16>
-function builtin_i16x8_max_s(ctx: BuiltinContext): ExpressionRef {
+function builtin_i16x8_max_s(ctx: BuiltinFunctionContext): ExpressionRef {
   checkTypeAbsent(ctx);
   ctx.typeArguments = [ Type.i16 ];
   ctx.contextualType = Type.v128;
   return builtin_v128_max(ctx);
 }
-builtins.set(BuiltinNames.i16x8_max_s, builtin_i16x8_max_s);
+builtinFunctions.set(BuiltinNames.i16x8_max_s, builtin_i16x8_max_s);
 
 // i16x8.max_u -> v128.max<u16>
-function builtin_i16x8_max_u(ctx: BuiltinContext): ExpressionRef {
+function builtin_i16x8_max_u(ctx: BuiltinFunctionContext): ExpressionRef {
   checkTypeAbsent(ctx);
   ctx.typeArguments = [ Type.u16 ];
   ctx.contextualType = Type.v128;
   return builtin_v128_max(ctx);
 }
-builtins.set(BuiltinNames.i16x8_max_u, builtin_i16x8_max_u);
+builtinFunctions.set(BuiltinNames.i16x8_max_u, builtin_i16x8_max_u);
 
 // i16x8.avgr_u -> v128.avgr<u16>
-function builtin_i16x8_avgr_u(ctx: BuiltinContext): ExpressionRef {
+function builtin_i16x8_avgr_u(ctx: BuiltinFunctionContext): ExpressionRef {
   checkTypeAbsent(ctx);
   ctx.typeArguments = [ Type.u16 ];
   ctx.contextualType = Type.v128;
   return builtin_v128_avgr(ctx);
 }
-builtins.set(BuiltinNames.i16x8_avgr_u, builtin_i16x8_avgr_u);
+builtinFunctions.set(BuiltinNames.i16x8_avgr_u, builtin_i16x8_avgr_u);
 
 // i16x8.abs -> v128.abs<i16>
-function builtin_i16x8_abs(ctx: BuiltinContext): ExpressionRef {
+function builtin_i16x8_abs(ctx: BuiltinFunctionContext): ExpressionRef {
   checkTypeAbsent(ctx);
   ctx.typeArguments = [ Type.i16 ];
   ctx.contextualType = Type.v128;
   return builtin_v128_abs(ctx);
 }
-builtins.set(BuiltinNames.i16x8_abs, builtin_i16x8_abs);
+builtinFunctions.set(BuiltinNames.i16x8_abs, builtin_i16x8_abs);
 
 // i16x8.neg -> v128.neg<i16>
-function builtin_i16x8_neg(ctx: BuiltinContext): ExpressionRef {
+function builtin_i16x8_neg(ctx: BuiltinFunctionContext): ExpressionRef {
   checkTypeAbsent(ctx);
   ctx.typeArguments = [ Type.i16 ];
   ctx.contextualType = Type.v128;
   return builtin_v128_neg(ctx);
 }
-builtins.set(BuiltinNames.i16x8_neg, builtin_i16x8_neg);
+builtinFunctions.set(BuiltinNames.i16x8_neg, builtin_i16x8_neg);
 
 // i16x8.add_sat_s -> v128.add_sat<i16>
-function builtin_i16x8_add_sat_s(ctx: BuiltinContext): ExpressionRef {
+function builtin_i16x8_add_sat_s(ctx: BuiltinFunctionContext): ExpressionRef {
   checkTypeAbsent(ctx);
   ctx.typeArguments = [ Type.i16 ];
   ctx.contextualType = Type.v128;
   return builtin_v128_add_sat(ctx);
 }
-builtins.set(BuiltinNames.i16x8_add_sat_s, builtin_i16x8_add_sat_s);
+builtinFunctions.set(BuiltinNames.i16x8_add_sat_s, builtin_i16x8_add_sat_s);
 
 // i16x8.add_sat_u -> v128.add_sat<u16>
-function builtin_i16x8_add_sat_u(ctx: BuiltinContext): ExpressionRef {
+function builtin_i16x8_add_sat_u(ctx: BuiltinFunctionContext): ExpressionRef {
   checkTypeAbsent(ctx);
   ctx.typeArguments = [ Type.u16 ];
   ctx.contextualType = Type.v128;
   return builtin_v128_add_sat(ctx);
 }
-builtins.set(BuiltinNames.i16x8_add_sat_u, builtin_i16x8_add_sat_u);
+builtinFunctions.set(BuiltinNames.i16x8_add_sat_u, builtin_i16x8_add_sat_u);
 
 // i16x8.sub_sat_s -> v128.sub_sat<i16>
-function builtin_i16x8_sub_sat_s(ctx: BuiltinContext): ExpressionRef {
+function builtin_i16x8_sub_sat_s(ctx: BuiltinFunctionContext): ExpressionRef {
   checkTypeAbsent(ctx);
   ctx.typeArguments = [ Type.i16 ];
   ctx.contextualType = Type.v128;
   return builtin_v128_sub_sat(ctx);
 }
-builtins.set(BuiltinNames.i16x8_sub_sat_s, builtin_i16x8_sub_sat_s);
+builtinFunctions.set(BuiltinNames.i16x8_sub_sat_s, builtin_i16x8_sub_sat_s);
 
 // i16x8.sub_sat_u -> v128.sub_sat<u16>
-function builtin_i16x8_sub_sat_u(ctx: BuiltinContext): ExpressionRef {
+function builtin_i16x8_sub_sat_u(ctx: BuiltinFunctionContext): ExpressionRef {
   checkTypeAbsent(ctx);
   ctx.typeArguments = [ Type.u16 ];
   ctx.contextualType = Type.v128;
   return builtin_v128_sub_sat(ctx);
 }
-builtins.set(BuiltinNames.i16x8_sub_sat_u, builtin_i16x8_sub_sat_u);
+builtinFunctions.set(BuiltinNames.i16x8_sub_sat_u, builtin_i16x8_sub_sat_u);
 
 // i16x8.shl -> v128.shl<i16>
-function builtin_i16x8_shl(ctx: BuiltinContext): ExpressionRef {
+function builtin_i16x8_shl(ctx: BuiltinFunctionContext): ExpressionRef {
   checkTypeAbsent(ctx);
   ctx.typeArguments = [ Type.i16 ];
   ctx.contextualType = Type.v128;
   return builtin_v128_shl(ctx);
 }
-builtins.set(BuiltinNames.i16x8_shl, builtin_i16x8_shl);
+builtinFunctions.set(BuiltinNames.i16x8_shl, builtin_i16x8_shl);
 
 // i16x8.shr_s -> v128.shr<i16>
-function builtin_i16x8_shr_s(ctx: BuiltinContext): ExpressionRef {
+function builtin_i16x8_shr_s(ctx: BuiltinFunctionContext): ExpressionRef {
   checkTypeAbsent(ctx);
   ctx.typeArguments = [ Type.i16 ];
   ctx.contextualType = Type.v128;
   return builtin_v128_shr(ctx);
 }
-builtins.set(BuiltinNames.i16x8_shr_s, builtin_i16x8_shr_s);
+builtinFunctions.set(BuiltinNames.i16x8_shr_s, builtin_i16x8_shr_s);
 
 // i16x8.shr_u -> v128.shr<u16>
-function builtin_i16x8_shr_u(ctx: BuiltinContext): ExpressionRef {
+function builtin_i16x8_shr_u(ctx: BuiltinFunctionContext): ExpressionRef {
   checkTypeAbsent(ctx);
   ctx.typeArguments = [ Type.u16 ];
   ctx.contextualType = Type.v128;
   return builtin_v128_shr(ctx);
 }
-builtins.set(BuiltinNames.i16x8_shr_u, builtin_i16x8_shr_u);
+builtinFunctions.set(BuiltinNames.i16x8_shr_u, builtin_i16x8_shr_u);
 
 // i16x8.all_true -> v128.all_true<i16>
-function builtin_i16x8_all_true(ctx: BuiltinContext): ExpressionRef {
+function builtin_i16x8_all_true(ctx: BuiltinFunctionContext): ExpressionRef {
   checkTypeAbsent(ctx);
   ctx.typeArguments = [ Type.i16 ];
   ctx.contextualType = Type.i32;
   return builtin_v128_all_true(ctx);
 }
-builtins.set(BuiltinNames.i16x8_all_true, builtin_i16x8_all_true);
+builtinFunctions.set(BuiltinNames.i16x8_all_true, builtin_i16x8_all_true);
 
 // i16x8.bitmask -> v128.bitmask<i16>
-function builtin_i16x8_bitmask(ctx: BuiltinContext): ExpressionRef {
+function builtin_i16x8_bitmask(ctx: BuiltinFunctionContext): ExpressionRef {
   checkTypeAbsent(ctx);
   ctx.typeArguments = [ Type.i16 ];
   ctx.contextualType = Type.i32;
   return builtin_v128_bitmask(ctx);
 }
-builtins.set(BuiltinNames.i16x8_bitmask, builtin_i16x8_bitmask);
+builtinFunctions.set(BuiltinNames.i16x8_bitmask, builtin_i16x8_bitmask);
 
 // i16x8.eq -> v128.eq<i16>
-function builtin_i16x8_eq(ctx: BuiltinContext): ExpressionRef {
+function builtin_i16x8_eq(ctx: BuiltinFunctionContext): ExpressionRef {
   checkTypeAbsent(ctx);
   ctx.typeArguments = [ Type.i16 ];
   ctx.contextualType = Type.v128;
   return builtin_v128_eq(ctx);
 }
-builtins.set(BuiltinNames.i16x8_eq, builtin_i16x8_eq);
+builtinFunctions.set(BuiltinNames.i16x8_eq, builtin_i16x8_eq);
 
 // i16x8.ne -> v128.ne<i16>
-function builtin_i16x8_ne(ctx: BuiltinContext): ExpressionRef {
+function builtin_i16x8_ne(ctx: BuiltinFunctionContext): ExpressionRef {
   checkTypeAbsent(ctx);
   ctx.typeArguments = [ Type.i16 ];
   ctx.contextualType = Type.v128;
   return builtin_v128_ne(ctx);
 }
-builtins.set(BuiltinNames.i16x8_ne, builtin_i16x8_ne);
+builtinFunctions.set(BuiltinNames.i16x8_ne, builtin_i16x8_ne);
 
 // i16x8.lt_s -> v128.lt<i16>
-function builtin_i16x8_lt_s(ctx: BuiltinContext): ExpressionRef {
+function builtin_i16x8_lt_s(ctx: BuiltinFunctionContext): ExpressionRef {
   checkTypeAbsent(ctx);
   ctx.typeArguments = [ Type.i16 ];
   ctx.contextualType = Type.v128;
   return builtin_v128_lt(ctx);
 }
-builtins.set(BuiltinNames.i16x8_lt_s, builtin_i16x8_lt_s);
+builtinFunctions.set(BuiltinNames.i16x8_lt_s, builtin_i16x8_lt_s);
 
 // i16x8.lt_u -> v128.lt<u16>
-function builtin_i16x8_lt_u(ctx: BuiltinContext): ExpressionRef {
+function builtin_i16x8_lt_u(ctx: BuiltinFunctionContext): ExpressionRef {
   checkTypeAbsent(ctx);
   ctx.typeArguments = [ Type.u16 ];
   ctx.contextualType = Type.v128;
   return builtin_v128_lt(ctx);
 }
-builtins.set(BuiltinNames.i16x8_lt_u, builtin_i16x8_lt_u);
+builtinFunctions.set(BuiltinNames.i16x8_lt_u, builtin_i16x8_lt_u);
 
 // i16x8.le_s -> v128.le<i16>
-function builtin_i16x8_le_s(ctx: BuiltinContext): ExpressionRef {
+function builtin_i16x8_le_s(ctx: BuiltinFunctionContext): ExpressionRef {
   checkTypeAbsent(ctx);
   ctx.typeArguments = [ Type.i16 ];
   ctx.contextualType = Type.v128;
   return builtin_v128_le(ctx);
 }
-builtins.set(BuiltinNames.i16x8_le_s, builtin_i16x8_le_s);
+builtinFunctions.set(BuiltinNames.i16x8_le_s, builtin_i16x8_le_s);
 
 // i16x8.le_u -> v128.le<u16>
-function builtin_i16x8_le_u(ctx: BuiltinContext): ExpressionRef {
+function builtin_i16x8_le_u(ctx: BuiltinFunctionContext): ExpressionRef {
   checkTypeAbsent(ctx);
   ctx.typeArguments = [ Type.u16 ];
   ctx.contextualType = Type.v128;
   return builtin_v128_le(ctx);
 }
-builtins.set(BuiltinNames.i16x8_le_u, builtin_i16x8_le_u);
+builtinFunctions.set(BuiltinNames.i16x8_le_u, builtin_i16x8_le_u);
 
 // i16x8.gt_s -> v128.gt<i16>
-function builtin_i16x8_gt_s(ctx: BuiltinContext): ExpressionRef {
+function builtin_i16x8_gt_s(ctx: BuiltinFunctionContext): ExpressionRef {
   checkTypeAbsent(ctx);
   ctx.typeArguments = [ Type.i16 ];
   ctx.contextualType = Type.v128;
   return builtin_v128_gt(ctx);
 }
-builtins.set(BuiltinNames.i16x8_gt_s, builtin_i16x8_gt_s);
+builtinFunctions.set(BuiltinNames.i16x8_gt_s, builtin_i16x8_gt_s);
 
 // i16x8.gt_u -> v128.gt<u16>
-function builtin_i16x8_gt_u(ctx: BuiltinContext): ExpressionRef {
+function builtin_i16x8_gt_u(ctx: BuiltinFunctionContext): ExpressionRef {
   checkTypeAbsent(ctx);
   ctx.typeArguments = [ Type.u16 ];
   ctx.contextualType = Type.v128;
   return builtin_v128_gt(ctx);
 }
-builtins.set(BuiltinNames.i16x8_gt_u, builtin_i16x8_gt_u);
+builtinFunctions.set(BuiltinNames.i16x8_gt_u, builtin_i16x8_gt_u);
 
 // i16x8.ge_s -> v128.ge<i16>
-function builtin_i16x8_ge_s(ctx: BuiltinContext): ExpressionRef {
+function builtin_i16x8_ge_s(ctx: BuiltinFunctionContext): ExpressionRef {
   checkTypeAbsent(ctx);
   ctx.typeArguments = [ Type.i16 ];
   ctx.contextualType = Type.v128;
   return builtin_v128_ge(ctx);
 }
-builtins.set(BuiltinNames.i16x8_ge_s, builtin_i16x8_ge_s);
+builtinFunctions.set(BuiltinNames.i16x8_ge_s, builtin_i16x8_ge_s);
 
 // i16x8.ge_u -> v128.ge<u16>
-function builtin_i16x8_ge_u(ctx: BuiltinContext): ExpressionRef {
+function builtin_i16x8_ge_u(ctx: BuiltinFunctionContext): ExpressionRef {
   checkTypeAbsent(ctx);
   ctx.typeArguments = [ Type.u16 ];
   ctx.contextualType = Type.v128;
   return builtin_v128_ge(ctx);
 }
-builtins.set(BuiltinNames.i16x8_ge_u, builtin_i16x8_ge_u);
+builtinFunctions.set(BuiltinNames.i16x8_ge_u, builtin_i16x8_ge_u);
 
 // i16x8.narrow_i32x4_s -> v128.narrow<i32>
-function builtin_i16x8_narrow_i32x4_s(ctx: BuiltinContext): ExpressionRef {
+function builtin_i16x8_narrow_i32x4_s(ctx: BuiltinFunctionContext): ExpressionRef {
   checkTypeAbsent(ctx);
   ctx.typeArguments = [ Type.i32 ];
   ctx.contextualType = Type.v128;
   return builtin_v128_narrow(ctx);
 }
-builtins.set(BuiltinNames.i16x8_narrow_i32x4_s, builtin_i16x8_narrow_i32x4_s);
+builtinFunctions.set(BuiltinNames.i16x8_narrow_i32x4_s, builtin_i16x8_narrow_i32x4_s);
 
 // i16x8.narrow_i32x4_u -> v128.narrow<u32>
-function builtin_i16x8_narrow_i32x4_u(ctx: BuiltinContext): ExpressionRef {
+function builtin_i16x8_narrow_i32x4_u(ctx: BuiltinFunctionContext): ExpressionRef {
   checkTypeAbsent(ctx);
   ctx.typeArguments = [ Type.u32 ];
   ctx.contextualType = Type.v128;
   return builtin_v128_narrow(ctx);
 }
-builtins.set(BuiltinNames.i16x8_narrow_i32x4_u, builtin_i16x8_narrow_i32x4_u);
+builtinFunctions.set(BuiltinNames.i16x8_narrow_i32x4_u, builtin_i16x8_narrow_i32x4_u);
 
 // i16x8.extend_low_i8x16_s -> v128.extend_low<i8>
-function builtin_i16x8_extend_low_i8x16_s(ctx: BuiltinContext): ExpressionRef {
+function builtin_i16x8_extend_low_i8x16_s(ctx: BuiltinFunctionContext): ExpressionRef {
   checkTypeAbsent(ctx);
   ctx.typeArguments = [ Type.i8 ];
   ctx.contextualType = Type.v128;
   return builtin_v128_extend_low(ctx);
 }
-builtins.set(BuiltinNames.i16x8_extend_low_i8x16_s, builtin_i16x8_extend_low_i8x16_s);
+builtinFunctions.set(BuiltinNames.i16x8_extend_low_i8x16_s, builtin_i16x8_extend_low_i8x16_s);
 
 // i16x8.extend_low_i8x16_u -> v128.extend_low<u8>
-function builtin_i16x8_extend_low_i8x16_u(ctx: BuiltinContext): ExpressionRef {
+function builtin_i16x8_extend_low_i8x16_u(ctx: BuiltinFunctionContext): ExpressionRef {
   checkTypeAbsent(ctx);
   ctx.typeArguments = [ Type.u8 ];
   ctx.contextualType = Type.v128;
   return builtin_v128_extend_low(ctx);
 }
-builtins.set(BuiltinNames.i16x8_extend_low_i8x16_u, builtin_i16x8_extend_low_i8x16_u);
+builtinFunctions.set(BuiltinNames.i16x8_extend_low_i8x16_u, builtin_i16x8_extend_low_i8x16_u);
 
 // i16x8.extend_high_i8x16_s -> v128.extend_high<i8>
-function builtin_i16x8_extend_high_i8x16_s(ctx: BuiltinContext): ExpressionRef {
+function builtin_i16x8_extend_high_i8x16_s(ctx: BuiltinFunctionContext): ExpressionRef {
   checkTypeAbsent(ctx);
   ctx.typeArguments = [ Type.i8 ];
   ctx.contextualType = Type.v128;
   return builtin_v128_extend_high(ctx);
 }
-builtins.set(BuiltinNames.i16x8_extend_high_i8x16_s, builtin_i16x8_extend_high_i8x16_s);
+builtinFunctions.set(BuiltinNames.i16x8_extend_high_i8x16_s, builtin_i16x8_extend_high_i8x16_s);
 
 // i16x8.extend_high_i8x16_u -> v128.extend_high<u8>
-function builtin_i16x8_extend_high_i8x16_u(ctx: BuiltinContext): ExpressionRef {
+function builtin_i16x8_extend_high_i8x16_u(ctx: BuiltinFunctionContext): ExpressionRef {
   checkTypeAbsent(ctx);
   ctx.typeArguments = [ Type.u8 ];
   ctx.contextualType = Type.v128;
   return builtin_v128_extend_high(ctx);
 }
-builtins.set(BuiltinNames.i16x8_extend_high_i8x16_u, builtin_i16x8_extend_high_i8x16_u);
+builtinFunctions.set(BuiltinNames.i16x8_extend_high_i8x16_u, builtin_i16x8_extend_high_i8x16_u);
 
 // i16x8.extadd_pairwise_i8x16_s -> v128.extadd_pairwise<i8>
-function builtin_i16x8_extadd_pairwise_i8x16_s(ctx: BuiltinContext): ExpressionRef {
+function builtin_i16x8_extadd_pairwise_i8x16_s(ctx: BuiltinFunctionContext): ExpressionRef {
   checkTypeAbsent(ctx);
   ctx.typeArguments = [ Type.i8 ];
   ctx.contextualType = Type.v128;
   return builtin_v128_extadd_pairwise(ctx);
 }
-builtins.set(BuiltinNames.i16x8_extadd_pairwise_i8x16_s, builtin_i16x8_extadd_pairwise_i8x16_s);
+builtinFunctions.set(BuiltinNames.i16x8_extadd_pairwise_i8x16_s, builtin_i16x8_extadd_pairwise_i8x16_s);
 
 // i16x8.extadd_pairwise_i8x16_u -> v128.extadd_pairwise<u8>
-function builtin_i16x8_extadd_pairwise_i8x16_u(ctx: BuiltinContext): ExpressionRef {
+function builtin_i16x8_extadd_pairwise_i8x16_u(ctx: BuiltinFunctionContext): ExpressionRef {
   checkTypeAbsent(ctx);
   ctx.typeArguments = [ Type.u8 ];
   ctx.contextualType = Type.v128;
   return builtin_v128_extadd_pairwise(ctx);
 }
-builtins.set(BuiltinNames.i16x8_extadd_pairwise_i8x16_u, builtin_i16x8_extadd_pairwise_i8x16_u);
+builtinFunctions.set(BuiltinNames.i16x8_extadd_pairwise_i8x16_u, builtin_i16x8_extadd_pairwise_i8x16_u);
 
 // i16x8.q15mulr_sat_s -> v128.q15mulr_sat<i16>
-function builtin_i16x8_q15mulr_sat_s(ctx: BuiltinContext): ExpressionRef {
+function builtin_i16x8_q15mulr_sat_s(ctx: BuiltinFunctionContext): ExpressionRef {
   checkTypeAbsent(ctx);
   ctx.typeArguments = [ Type.i16 ];
   ctx.contextualType = Type.v128;
   return builtin_v128_q15mulr_sat(ctx);
 }
-builtins.set(BuiltinNames.i16x8_q15mulr_sat_s, builtin_i16x8_q15mulr_sat_s);
+builtinFunctions.set(BuiltinNames.i16x8_q15mulr_sat_s, builtin_i16x8_q15mulr_sat_s);
 
 // i16x8.extmul_low_i8x16_s -> v128.extmul_low<i16>
-function builtin_i16x8_extmul_low_i8x16_s(ctx: BuiltinContext): ExpressionRef {
+function builtin_i16x8_extmul_low_i8x16_s(ctx: BuiltinFunctionContext): ExpressionRef {
   checkTypeAbsent(ctx);
   ctx.typeArguments = [ Type.i8 ];
   ctx.contextualType = Type.v128;
   return builtin_v128_extmul_low(ctx);
 }
-builtins.set(BuiltinNames.i16x8_extmul_low_i8x16_s, builtin_i16x8_extmul_low_i8x16_s);
+builtinFunctions.set(BuiltinNames.i16x8_extmul_low_i8x16_s, builtin_i16x8_extmul_low_i8x16_s);
 
 // i16x8.extmul_low_i8x16_u -> v128.extmul_low<u16>
-function builtin_i16x8_extmul_low_i8x16_u(ctx: BuiltinContext): ExpressionRef {
+function builtin_i16x8_extmul_low_i8x16_u(ctx: BuiltinFunctionContext): ExpressionRef {
   checkTypeAbsent(ctx);
   ctx.typeArguments = [ Type.u8 ];
   ctx.contextualType = Type.v128;
   return builtin_v128_extmul_low(ctx);
 }
-builtins.set(BuiltinNames.i16x8_extmul_low_i8x16_u, builtin_i16x8_extmul_low_i8x16_u);
+builtinFunctions.set(BuiltinNames.i16x8_extmul_low_i8x16_u, builtin_i16x8_extmul_low_i8x16_u);
 
 // i16x8.extmul_high_i8x16_s -> v128.extmul_high<i16>
-function builtin_i16x8_extmul_high_i8x16_s(ctx: BuiltinContext): ExpressionRef {
+function builtin_i16x8_extmul_high_i8x16_s(ctx: BuiltinFunctionContext): ExpressionRef {
   checkTypeAbsent(ctx);
   ctx.typeArguments = [ Type.i8 ];
   ctx.contextualType = Type.v128;
   return builtin_v128_extmul_high(ctx);
 }
-builtins.set(BuiltinNames.i16x8_extmul_high_i8x16_s, builtin_i16x8_extmul_high_i8x16_s);
+builtinFunctions.set(BuiltinNames.i16x8_extmul_high_i8x16_s, builtin_i16x8_extmul_high_i8x16_s);
 
 // i16x8.extmul_high_i8x16_u -> v128.extmul_high<u16>
-function builtin_i16x8_extmul_high_i8x16_u(ctx: BuiltinContext): ExpressionRef {
+function builtin_i16x8_extmul_high_i8x16_u(ctx: BuiltinFunctionContext): ExpressionRef {
   checkTypeAbsent(ctx);
   ctx.typeArguments = [ Type.u8 ];
   ctx.contextualType = Type.v128;
   return builtin_v128_extmul_high(ctx);
 }
-builtins.set(BuiltinNames.i16x8_extmul_high_i8x16_u, builtin_i16x8_extmul_high_i8x16_u);
+builtinFunctions.set(BuiltinNames.i16x8_extmul_high_i8x16_u, builtin_i16x8_extmul_high_i8x16_u);
 
 // i16x8.shuffle -> v128.shuffle<i16>
-function builtin_i16x8_shuffle(ctx: BuiltinContext): ExpressionRef {
+function builtin_i16x8_shuffle(ctx: BuiltinFunctionContext): ExpressionRef {
   checkTypeAbsent(ctx);
   ctx.typeArguments = [ Type.i16 ];
   ctx.contextualType = Type.v128;
   return builtin_v128_shuffle(ctx);
 }
-builtins.set(BuiltinNames.i16x8_shuffle, builtin_i16x8_shuffle);
+builtinFunctions.set(BuiltinNames.i16x8_shuffle, builtin_i16x8_shuffle);
 
 // i16x8.swizzle -> v128.swizzle
-function builtin_i16x8_swizzle(ctx: BuiltinContext): ExpressionRef {
+function builtin_i16x8_swizzle(ctx: BuiltinFunctionContext): ExpressionRef {
   ctx.typeArguments = null;
   ctx.contextualType = Type.v128;
   return builtin_v128_swizzle(ctx);
 }
-builtins.set(BuiltinNames.i16x8_swizzle, builtin_i16x8_swizzle);
+builtinFunctions.set(BuiltinNames.i16x8_swizzle, builtin_i16x8_swizzle);
 
 // i32x4.splat -> v128.splat<i32>
-function builtin_i32x4_splat(ctx: BuiltinContext): ExpressionRef {
+function builtin_i32x4_splat(ctx: BuiltinFunctionContext): ExpressionRef {
   checkTypeAbsent(ctx);
   ctx.typeArguments = [ Type.i32 ];
   ctx.contextualType = Type.v128;
   return builtin_v128_splat(ctx);
 }
-builtins.set(BuiltinNames.i32x4_splat, builtin_i32x4_splat);
+builtinFunctions.set(BuiltinNames.i32x4_splat, builtin_i32x4_splat);
 
 // i32x4.extract_lane -> <i32>v128.extract_lane<i32>
-function builtin_i32x4_extract_lane(ctx: BuiltinContext): ExpressionRef {
+function builtin_i32x4_extract_lane(ctx: BuiltinFunctionContext): ExpressionRef {
   checkTypeAbsent(ctx);
   ctx.typeArguments = [ Type.i32 ];
   ctx.contextualType = Type.i32;
   return builtin_v128_extract_lane(ctx);
 }
-builtins.set(BuiltinNames.i32x4_extract_lane, builtin_i32x4_extract_lane);
+builtinFunctions.set(BuiltinNames.i32x4_extract_lane, builtin_i32x4_extract_lane);
 
 // i32x4.replace_lane -> v128.replace_lane<i32>
-function builtin_i32x4_replace_lane(ctx: BuiltinContext): ExpressionRef {
+function builtin_i32x4_replace_lane(ctx: BuiltinFunctionContext): ExpressionRef {
   checkTypeAbsent(ctx);
   ctx.typeArguments = [ Type.i32 ];
   ctx.contextualType = Type.v128;
   return builtin_v128_replace_lane(ctx);
 }
-builtins.set(BuiltinNames.i32x4_replace_lane, builtin_i32x4_replace_lane);
+builtinFunctions.set(BuiltinNames.i32x4_replace_lane, builtin_i32x4_replace_lane);
 
 // i32x4.add -> v128.add<i32>
-function builtin_i32x4_add(ctx: BuiltinContext): ExpressionRef {
+function builtin_i32x4_add(ctx: BuiltinFunctionContext): ExpressionRef {
   checkTypeAbsent(ctx);
   ctx.typeArguments = [ Type.i32 ];
   ctx.contextualType = Type.v128;
   return builtin_v128_add(ctx);
 }
-builtins.set(BuiltinNames.i32x4_add, builtin_i32x4_add);
+builtinFunctions.set(BuiltinNames.i32x4_add, builtin_i32x4_add);
 
 // i32x4.sub -> v128.sub<i32>
-function builtin_i32x4_sub(ctx: BuiltinContext): ExpressionRef {
+function builtin_i32x4_sub(ctx: BuiltinFunctionContext): ExpressionRef {
   checkTypeAbsent(ctx);
   ctx.typeArguments = [ Type.i32 ];
   ctx.contextualType = Type.v128;
   return builtin_v128_sub(ctx);
 }
-builtins.set(BuiltinNames.i32x4_sub, builtin_i32x4_sub);
+builtinFunctions.set(BuiltinNames.i32x4_sub, builtin_i32x4_sub);
 
 // i32x4.mul -> v128.mul<i32>
-function builtin_i32x4_mul(ctx: BuiltinContext): ExpressionRef {
+function builtin_i32x4_mul(ctx: BuiltinFunctionContext): ExpressionRef {
   checkTypeAbsent(ctx);
   ctx.typeArguments = [ Type.i32 ];
   ctx.contextualType = Type.v128;
   return builtin_v128_mul(ctx);
 }
-builtins.set(BuiltinNames.i32x4_mul, builtin_i32x4_mul);
+builtinFunctions.set(BuiltinNames.i32x4_mul, builtin_i32x4_mul);
 
 // i32x4.min_s -> v128.min<i32>
-function builtin_i32x4_min_s(ctx: BuiltinContext): ExpressionRef {
+function builtin_i32x4_min_s(ctx: BuiltinFunctionContext): ExpressionRef {
   checkTypeAbsent(ctx);
   ctx.typeArguments = [ Type.i32 ];
   ctx.contextualType = Type.v128;
   return builtin_v128_min(ctx);
 }
-builtins.set(BuiltinNames.i32x4_min_s, builtin_i32x4_min_s);
+builtinFunctions.set(BuiltinNames.i32x4_min_s, builtin_i32x4_min_s);
 
 // i32x4.min_u -> v128.min<u32>
-function builtin_i32x4_min_u(ctx: BuiltinContext): ExpressionRef {
+function builtin_i32x4_min_u(ctx: BuiltinFunctionContext): ExpressionRef {
   checkTypeAbsent(ctx);
   ctx.typeArguments = [ Type.u32 ];
   ctx.contextualType = Type.v128;
   return builtin_v128_min(ctx);
 }
-builtins.set(BuiltinNames.i32x4_min_u, builtin_i32x4_min_u);
+builtinFunctions.set(BuiltinNames.i32x4_min_u, builtin_i32x4_min_u);
 
 // i32x4.max_s -> v128.max<i32>
-function builtin_i32x4_max_s(ctx: BuiltinContext): ExpressionRef {
+function builtin_i32x4_max_s(ctx: BuiltinFunctionContext): ExpressionRef {
   checkTypeAbsent(ctx);
   ctx.typeArguments = [ Type.i32 ];
   ctx.contextualType = Type.v128;
   return builtin_v128_max(ctx);
 }
-builtins.set(BuiltinNames.i32x4_max_s, builtin_i32x4_max_s);
+builtinFunctions.set(BuiltinNames.i32x4_max_s, builtin_i32x4_max_s);
 
 // i32x4.max_u -> v128.max<u32>
-function builtin_i32x4_max_u(ctx: BuiltinContext): ExpressionRef {
+function builtin_i32x4_max_u(ctx: BuiltinFunctionContext): ExpressionRef {
   checkTypeAbsent(ctx);
   ctx.typeArguments = [ Type.u32 ];
   ctx.contextualType = Type.v128;
   return builtin_v128_max(ctx);
 }
-builtins.set(BuiltinNames.i32x4_max_u, builtin_i32x4_max_u);
+builtinFunctions.set(BuiltinNames.i32x4_max_u, builtin_i32x4_max_u);
 
 // i32x4.dot_i16x8_s -> v128.dot<i16>
-function builtin_i32x4_dot_i16x8_s(ctx: BuiltinContext): ExpressionRef {
+function builtin_i32x4_dot_i16x8_s(ctx: BuiltinFunctionContext): ExpressionRef {
   checkTypeAbsent(ctx);
   ctx.typeArguments = [ Type.i16 ];
   ctx.contextualType = Type.v128;
   return builtin_v128_dot(ctx);
 }
-builtins.set(BuiltinNames.i32x4_dot_i16x8_s, builtin_i32x4_dot_i16x8_s);
+builtinFunctions.set(BuiltinNames.i32x4_dot_i16x8_s, builtin_i32x4_dot_i16x8_s);
 
 // i32x4.abs -> v128.abs<i32>
-function builtin_i32x4_abs(ctx: BuiltinContext): ExpressionRef {
+function builtin_i32x4_abs(ctx: BuiltinFunctionContext): ExpressionRef {
   checkTypeAbsent(ctx);
   ctx.typeArguments = [ Type.i32 ];
   ctx.contextualType = Type.v128;
   return builtin_v128_abs(ctx);
 }
-builtins.set(BuiltinNames.i32x4_abs, builtin_i32x4_abs);
+builtinFunctions.set(BuiltinNames.i32x4_abs, builtin_i32x4_abs);
 
 // i32x4.neg -> v128.neg<i32>
-function builtin_i32x4_neg(ctx: BuiltinContext): ExpressionRef {
+function builtin_i32x4_neg(ctx: BuiltinFunctionContext): ExpressionRef {
   checkTypeAbsent(ctx);
   ctx.typeArguments = [ Type.i32 ];
   ctx.contextualType = Type.v128;
   return builtin_v128_neg(ctx);
 }
-builtins.set(BuiltinNames.i32x4_neg, builtin_i32x4_neg);
+builtinFunctions.set(BuiltinNames.i32x4_neg, builtin_i32x4_neg);
 
 // i32x4.shl -> v128.shl<i32>
-function builtin_i32x4_shl(ctx: BuiltinContext): ExpressionRef {
+function builtin_i32x4_shl(ctx: BuiltinFunctionContext): ExpressionRef {
   checkTypeAbsent(ctx);
   ctx.typeArguments = [ Type.i32 ];
   ctx.contextualType = Type.v128;
   return builtin_v128_shl(ctx);
 }
-builtins.set(BuiltinNames.i32x4_shl, builtin_i32x4_shl);
+builtinFunctions.set(BuiltinNames.i32x4_shl, builtin_i32x4_shl);
 
 // i32x4.shr_s -> v128.shr<i32>
-function builtin_i32x4_shr_s(ctx: BuiltinContext): ExpressionRef {
+function builtin_i32x4_shr_s(ctx: BuiltinFunctionContext): ExpressionRef {
   checkTypeAbsent(ctx);
   ctx.typeArguments = [ Type.i32 ];
   ctx.contextualType = Type.v128;
   return builtin_v128_shr(ctx);
 }
-builtins.set(BuiltinNames.i32x4_shr_s, builtin_i32x4_shr_s);
+builtinFunctions.set(BuiltinNames.i32x4_shr_s, builtin_i32x4_shr_s);
 
 // i32x4.shr_u -> v128.shr<u32>
-function builtin_i32x4_shr_u(ctx: BuiltinContext): ExpressionRef {
+function builtin_i32x4_shr_u(ctx: BuiltinFunctionContext): ExpressionRef {
   checkTypeAbsent(ctx);
   ctx.typeArguments = [ Type.u32 ];
   ctx.contextualType = Type.v128;
   return builtin_v128_shr(ctx);
 }
-builtins.set(BuiltinNames.i32x4_shr_u, builtin_i32x4_shr_u);
+builtinFunctions.set(BuiltinNames.i32x4_shr_u, builtin_i32x4_shr_u);
 
 // i32x4.all_true -> v128.all_true<i32>
-function builtin_i32x4_all_true(ctx: BuiltinContext): ExpressionRef {
+function builtin_i32x4_all_true(ctx: BuiltinFunctionContext): ExpressionRef {
   checkTypeAbsent(ctx);
   ctx.typeArguments = [ Type.i32 ];
   ctx.contextualType = Type.i32;
   return builtin_v128_all_true(ctx);
 }
-builtins.set(BuiltinNames.i32x4_all_true, builtin_i32x4_all_true);
+builtinFunctions.set(BuiltinNames.i32x4_all_true, builtin_i32x4_all_true);
 
 // i32x4.bitmask -> v128.bitmask<i32>
-function builtin_i32x4_bitmask(ctx: BuiltinContext): ExpressionRef {
+function builtin_i32x4_bitmask(ctx: BuiltinFunctionContext): ExpressionRef {
   checkTypeAbsent(ctx);
   ctx.typeArguments = [ Type.i32 ];
   ctx.contextualType = Type.i32;
   return builtin_v128_bitmask(ctx);
 }
-builtins.set(BuiltinNames.i32x4_bitmask, builtin_i32x4_bitmask);
+builtinFunctions.set(BuiltinNames.i32x4_bitmask, builtin_i32x4_bitmask);
 
 // i32x4.eq -> v128.eq<i32>
-function builtin_i32x4_eq(ctx: BuiltinContext): ExpressionRef {
+function builtin_i32x4_eq(ctx: BuiltinFunctionContext): ExpressionRef {
   checkTypeAbsent(ctx);
   ctx.typeArguments = [ Type.i32 ];
   ctx.contextualType = Type.v128;
   return builtin_v128_eq(ctx);
 }
-builtins.set(BuiltinNames.i32x4_eq, builtin_i32x4_eq);
+builtinFunctions.set(BuiltinNames.i32x4_eq, builtin_i32x4_eq);
 
 // i32x4.ne -> v128.ne<i32>
-function builtin_i32x4_ne(ctx: BuiltinContext): ExpressionRef {
+function builtin_i32x4_ne(ctx: BuiltinFunctionContext): ExpressionRef {
   checkTypeAbsent(ctx);
   ctx.typeArguments = [ Type.i32 ];
   ctx.contextualType = Type.v128;
   return builtin_v128_ne(ctx);
 }
-builtins.set(BuiltinNames.i32x4_ne, builtin_i32x4_ne);
+builtinFunctions.set(BuiltinNames.i32x4_ne, builtin_i32x4_ne);
 
 // i32x4.lt_s -> v128.lt<i32>
-function builtin_i32x4_lt_s(ctx: BuiltinContext): ExpressionRef {
+function builtin_i32x4_lt_s(ctx: BuiltinFunctionContext): ExpressionRef {
   checkTypeAbsent(ctx);
   ctx.typeArguments = [ Type.i32 ];
   ctx.contextualType = Type.v128;
   return builtin_v128_lt(ctx);
 }
-builtins.set(BuiltinNames.i32x4_lt_s, builtin_i32x4_lt_s);
+builtinFunctions.set(BuiltinNames.i32x4_lt_s, builtin_i32x4_lt_s);
 
 // i32x4.lt_u -> v128.lt<u32>
-function builtin_i32x4_lt_u(ctx: BuiltinContext): ExpressionRef {
+function builtin_i32x4_lt_u(ctx: BuiltinFunctionContext): ExpressionRef {
   checkTypeAbsent(ctx);
   ctx.typeArguments = [ Type.u32 ];
   ctx.contextualType = Type.v128;
   return builtin_v128_lt(ctx);
 }
-builtins.set(BuiltinNames.i32x4_lt_u, builtin_i32x4_lt_u);
+builtinFunctions.set(BuiltinNames.i32x4_lt_u, builtin_i32x4_lt_u);
 
 // i32x4.le_s -> v128.le<i32>
-function builtin_i32x4_le_s(ctx: BuiltinContext): ExpressionRef {
+function builtin_i32x4_le_s(ctx: BuiltinFunctionContext): ExpressionRef {
   checkTypeAbsent(ctx);
   ctx.typeArguments = [ Type.i32 ];
   ctx.contextualType = Type.v128;
   return builtin_v128_le(ctx);
 }
-builtins.set(BuiltinNames.i32x4_le_s, builtin_i32x4_le_s);
+builtinFunctions.set(BuiltinNames.i32x4_le_s, builtin_i32x4_le_s);
 
 // i32x4.le_u -> v128.le<u32>
-function builtin_i32x4_le_u(ctx: BuiltinContext): ExpressionRef {
+function builtin_i32x4_le_u(ctx: BuiltinFunctionContext): ExpressionRef {
   checkTypeAbsent(ctx);
   ctx.typeArguments = [ Type.u32 ];
   ctx.contextualType = Type.v128;
   return builtin_v128_le(ctx);
 }
-builtins.set(BuiltinNames.i32x4_le_u, builtin_i32x4_le_u);
+builtinFunctions.set(BuiltinNames.i32x4_le_u, builtin_i32x4_le_u);
 
 // i32x4.gt_s -> v128.gt<i32>
-function builtin_i32x4_gt_s(ctx: BuiltinContext): ExpressionRef {
+function builtin_i32x4_gt_s(ctx: BuiltinFunctionContext): ExpressionRef {
   checkTypeAbsent(ctx);
   ctx.typeArguments = [ Type.i32 ];
   ctx.contextualType = Type.v128;
   return builtin_v128_gt(ctx);
 }
-builtins.set(BuiltinNames.i32x4_gt_s, builtin_i32x4_gt_s);
+builtinFunctions.set(BuiltinNames.i32x4_gt_s, builtin_i32x4_gt_s);
 
 // i32x4.gt_u -> v128.gt<u32>
-function builtin_i32x4_gt_u(ctx: BuiltinContext): ExpressionRef {
+function builtin_i32x4_gt_u(ctx: BuiltinFunctionContext): ExpressionRef {
   checkTypeAbsent(ctx);
   ctx.typeArguments = [ Type.u32 ];
   ctx.contextualType = Type.v128;
   return builtin_v128_gt(ctx);
 }
-builtins.set(BuiltinNames.i32x4_gt_u, builtin_i32x4_gt_u);
+builtinFunctions.set(BuiltinNames.i32x4_gt_u, builtin_i32x4_gt_u);
 
 // i32x4.ge_s -> v128.ge<i32>
-function builtin_i32x4_ge_s(ctx: BuiltinContext): ExpressionRef {
+function builtin_i32x4_ge_s(ctx: BuiltinFunctionContext): ExpressionRef {
   checkTypeAbsent(ctx);
   ctx.typeArguments = [ Type.i32 ];
   ctx.contextualType = Type.v128;
   return builtin_v128_ge(ctx);
 }
-builtins.set(BuiltinNames.i32x4_ge_s, builtin_i32x4_ge_s);
+builtinFunctions.set(BuiltinNames.i32x4_ge_s, builtin_i32x4_ge_s);
 
 // i32x4.ge_u -> v128.ge<u32>
-function builtin_i32x4_ge_u(ctx: BuiltinContext): ExpressionRef {
+function builtin_i32x4_ge_u(ctx: BuiltinFunctionContext): ExpressionRef {
   checkTypeAbsent(ctx);
   ctx.typeArguments = [ Type.u32 ];
   ctx.contextualType = Type.v128;
   return builtin_v128_ge(ctx);
 }
-builtins.set(BuiltinNames.i32x4_ge_u, builtin_i32x4_ge_u);
+builtinFunctions.set(BuiltinNames.i32x4_ge_u, builtin_i32x4_ge_u);
 
 // i32x4.trunc_sat_f32x4_s -> v128.trunc_sat<i32>
-function builtin_i32x4_trunc_sat_f32x4_s(ctx: BuiltinContext): ExpressionRef {
+function builtin_i32x4_trunc_sat_f32x4_s(ctx: BuiltinFunctionContext): ExpressionRef {
   checkTypeAbsent(ctx);
   ctx.typeArguments = [ Type.i32 ];
   ctx.contextualType = Type.v128;
   return builtin_v128_trunc_sat(ctx);
 }
-builtins.set(BuiltinNames.i32x4_trunc_sat_f32x4_s, builtin_i32x4_trunc_sat_f32x4_s);
+builtinFunctions.set(BuiltinNames.i32x4_trunc_sat_f32x4_s, builtin_i32x4_trunc_sat_f32x4_s);
 
 // i32x4.trunc_sat_f32x4_u -> v128.trunc_sat<u32>
-function builtin_i32x4_trunc_sat_f32x4_u(ctx: BuiltinContext): ExpressionRef {
+function builtin_i32x4_trunc_sat_f32x4_u(ctx: BuiltinFunctionContext): ExpressionRef {
   checkTypeAbsent(ctx);
   ctx.typeArguments = [ Type.u32 ];
   ctx.contextualType = Type.v128;
   return builtin_v128_trunc_sat(ctx);
 }
-builtins.set(BuiltinNames.i32x4_trunc_sat_f32x4_u, builtin_i32x4_trunc_sat_f32x4_u);
+builtinFunctions.set(BuiltinNames.i32x4_trunc_sat_f32x4_u, builtin_i32x4_trunc_sat_f32x4_u);
 
 // i32x4.trunc_sat_f64x2_s_zero -> v128.trunc_sat_zero<i32>
-function builtin_i32x4_trunc_sat_f64x2_s_zero(ctx: BuiltinContext): ExpressionRef {
+function builtin_i32x4_trunc_sat_f64x2_s_zero(ctx: BuiltinFunctionContext): ExpressionRef {
   checkTypeAbsent(ctx);
   ctx.typeArguments = [ Type.i32 ];
   ctx.contextualType = Type.v128;
   return builtin_v128_trunc_sat_zero(ctx);
 }
-builtins.set(BuiltinNames.i32x4_trunc_sat_f64x2_s_zero, builtin_i32x4_trunc_sat_f64x2_s_zero);
+builtinFunctions.set(BuiltinNames.i32x4_trunc_sat_f64x2_s_zero, builtin_i32x4_trunc_sat_f64x2_s_zero);
 
 // i32x4.trunc_sat_f64x2_u_zero -> v128.trunc_sat_zero<u32>
-function builtin_i32x4_trunc_sat_f64x2_u_zero(ctx: BuiltinContext): ExpressionRef {
+function builtin_i32x4_trunc_sat_f64x2_u_zero(ctx: BuiltinFunctionContext): ExpressionRef {
   checkTypeAbsent(ctx);
   ctx.typeArguments = [ Type.u32 ];
   ctx.contextualType = Type.v128;
   return builtin_v128_trunc_sat_zero(ctx);
 }
-builtins.set(BuiltinNames.i32x4_trunc_sat_f64x2_u_zero, builtin_i32x4_trunc_sat_f64x2_u_zero);
+builtinFunctions.set(BuiltinNames.i32x4_trunc_sat_f64x2_u_zero, builtin_i32x4_trunc_sat_f64x2_u_zero);
 
 // i32x4.extend_low_i16x8_s -> // v128.extend_low<i16>
-function builtin_i32x4_extend_low_i16x8_s(ctx: BuiltinContext): ExpressionRef {
+function builtin_i32x4_extend_low_i16x8_s(ctx: BuiltinFunctionContext): ExpressionRef {
   checkTypeAbsent(ctx);
   ctx.typeArguments = [ Type.i16 ];
   ctx.contextualType = Type.v128;
   return builtin_v128_extend_low(ctx);
 }
-builtins.set(BuiltinNames.i32x4_extend_low_i16x8_s, builtin_i32x4_extend_low_i16x8_s);
+builtinFunctions.set(BuiltinNames.i32x4_extend_low_i16x8_s, builtin_i32x4_extend_low_i16x8_s);
 
 // i32x4.extend_low_i16x8_u -> v128.extend_low<u16>
-function builtin_i32x4_extend_low_i16x8_u(ctx: BuiltinContext): ExpressionRef {
+function builtin_i32x4_extend_low_i16x8_u(ctx: BuiltinFunctionContext): ExpressionRef {
   checkTypeAbsent(ctx);
   ctx.typeArguments = [ Type.u16 ];
   ctx.contextualType = Type.v128;
   return builtin_v128_extend_low(ctx);
 }
-builtins.set(BuiltinNames.i32x4_extend_low_i16x8_u, builtin_i32x4_extend_low_i16x8_u);
+builtinFunctions.set(BuiltinNames.i32x4_extend_low_i16x8_u, builtin_i32x4_extend_low_i16x8_u);
 
 // i32x4.extend_high_i16x8_s -> v128.extend_high<i16>
-function builtin_i32x4_extend_high_i16x8_s(ctx: BuiltinContext): ExpressionRef {
+function builtin_i32x4_extend_high_i16x8_s(ctx: BuiltinFunctionContext): ExpressionRef {
   checkTypeAbsent(ctx);
   ctx.typeArguments = [ Type.i16 ];
   ctx.contextualType = Type.v128;
   return builtin_v128_extend_high(ctx);
 }
-builtins.set(BuiltinNames.i32x4_extend_high_i16x8_s, builtin_i32x4_extend_high_i16x8_s);
+builtinFunctions.set(BuiltinNames.i32x4_extend_high_i16x8_s, builtin_i32x4_extend_high_i16x8_s);
 
 // i32x4.extend_high_i16x8_u -> v128.extend_high<u16>
-function builtin_i32x4_extend_high_i16x8_u(ctx: BuiltinContext): ExpressionRef {
+function builtin_i32x4_extend_high_i16x8_u(ctx: BuiltinFunctionContext): ExpressionRef {
   checkTypeAbsent(ctx);
   ctx.typeArguments = [ Type.u16 ];
   ctx.contextualType = Type.v128;
   return builtin_v128_extend_high(ctx);
 }
-builtins.set(BuiltinNames.i32x4_extend_high_i16x8_u, builtin_i32x4_extend_high_i16x8_u);
+builtinFunctions.set(BuiltinNames.i32x4_extend_high_i16x8_u, builtin_i32x4_extend_high_i16x8_u);
 
 // i32x4.extadd_pairwise_i16x8_s -> v128.extadd_pairwise<i16>
-function builtin_i32x4_extadd_pairwise_i16x8_s(ctx: BuiltinContext): ExpressionRef {
+function builtin_i32x4_extadd_pairwise_i16x8_s(ctx: BuiltinFunctionContext): ExpressionRef {
   checkTypeAbsent(ctx);
   ctx.typeArguments = [ Type.i16 ];
   ctx.contextualType = Type.v128;
   return builtin_v128_extadd_pairwise(ctx);
 }
-builtins.set(BuiltinNames.i32x4_extadd_pairwise_i16x8_s, builtin_i32x4_extadd_pairwise_i16x8_s);
+builtinFunctions.set(BuiltinNames.i32x4_extadd_pairwise_i16x8_s, builtin_i32x4_extadd_pairwise_i16x8_s);
 
 // i32x4.extadd_pairwise_i16x8_u -> v128.extadd_pairwise<u16>
-function builtin_i32x4_extadd_pairwise_i16x8_u(ctx: BuiltinContext): ExpressionRef {
+function builtin_i32x4_extadd_pairwise_i16x8_u(ctx: BuiltinFunctionContext): ExpressionRef {
   checkTypeAbsent(ctx);
   ctx.typeArguments = [ Type.u16 ];
   ctx.contextualType = Type.v128;
   return builtin_v128_extadd_pairwise(ctx);
 }
-builtins.set(BuiltinNames.i32x4_extadd_pairwise_i16x8_u, builtin_i32x4_extadd_pairwise_i16x8_u);
+builtinFunctions.set(BuiltinNames.i32x4_extadd_pairwise_i16x8_u, builtin_i32x4_extadd_pairwise_i16x8_u);
 
 // i32x4.extmul_low_i16x8_s -> v128.extmul_low<i16>
-function builtin_i32x4_extmul_low_i16x8_s(ctx: BuiltinContext): ExpressionRef {
+function builtin_i32x4_extmul_low_i16x8_s(ctx: BuiltinFunctionContext): ExpressionRef {
   checkTypeAbsent(ctx);
   ctx.typeArguments = [ Type.i16 ];
   ctx.contextualType = Type.v128;
   return builtin_v128_extmul_low(ctx);
 }
-builtins.set(BuiltinNames.i32x4_extmul_low_i16x8_s, builtin_i32x4_extmul_low_i16x8_s);
+builtinFunctions.set(BuiltinNames.i32x4_extmul_low_i16x8_s, builtin_i32x4_extmul_low_i16x8_s);
 
 // i32x4.extmul_low_i16x8_u -> v128.extmul_low<u16>
-function builtin_i32x4_extmul_low_i16x8_u(ctx: BuiltinContext): ExpressionRef {
+function builtin_i32x4_extmul_low_i16x8_u(ctx: BuiltinFunctionContext): ExpressionRef {
   checkTypeAbsent(ctx);
   ctx.typeArguments = [ Type.u16 ];
   ctx.contextualType = Type.v128;
   return builtin_v128_extmul_low(ctx);
 }
-builtins.set(BuiltinNames.i32x4_extmul_low_i16x8_u, builtin_i32x4_extmul_low_i16x8_u);
+builtinFunctions.set(BuiltinNames.i32x4_extmul_low_i16x8_u, builtin_i32x4_extmul_low_i16x8_u);
 
 // i32x4.extmul_high_i16x8_s -> v128.extmul_high<i16>
-function builtin_i32x4_extmul_high_i16x8_s(ctx: BuiltinContext): ExpressionRef {
+function builtin_i32x4_extmul_high_i16x8_s(ctx: BuiltinFunctionContext): ExpressionRef {
   checkTypeAbsent(ctx);
   ctx.typeArguments = [ Type.i16 ];
   ctx.contextualType = Type.v128;
   return builtin_v128_extmul_high(ctx);
 }
-builtins.set(BuiltinNames.i32x4_extmul_high_i16x8_s, builtin_i32x4_extmul_high_i16x8_s);
+builtinFunctions.set(BuiltinNames.i32x4_extmul_high_i16x8_s, builtin_i32x4_extmul_high_i16x8_s);
 
 // i32x4.extmul_high_i16x8_u -> v128.extmul_high<u16>
-function builtin_i32x4_extmul_high_i16x8_u(ctx: BuiltinContext): ExpressionRef {
+function builtin_i32x4_extmul_high_i16x8_u(ctx: BuiltinFunctionContext): ExpressionRef {
   checkTypeAbsent(ctx);
   ctx.typeArguments = [ Type.u16 ];
   ctx.contextualType = Type.v128;
   return builtin_v128_extmul_high(ctx);
 }
-builtins.set(BuiltinNames.i32x4_extmul_high_i16x8_u, builtin_i32x4_extmul_high_i16x8_u);
+builtinFunctions.set(BuiltinNames.i32x4_extmul_high_i16x8_u, builtin_i32x4_extmul_high_i16x8_u);
 
 // i32x4.shuffle -> v128.shuffle<i32>
-function builtin_i32x4_shuffle(ctx: BuiltinContext): ExpressionRef {
+function builtin_i32x4_shuffle(ctx: BuiltinFunctionContext): ExpressionRef {
   checkTypeAbsent(ctx);
   ctx.typeArguments = [ Type.i32 ];
   ctx.contextualType = Type.v128;
   return builtin_v128_shuffle(ctx);
 }
-builtins.set(BuiltinNames.i32x4_shuffle, builtin_i32x4_shuffle);
+builtinFunctions.set(BuiltinNames.i32x4_shuffle, builtin_i32x4_shuffle);
 
 // i32x4.swizzle -> v128.swizzle
-function builtin_i32x4_swizzle(ctx: BuiltinContext): ExpressionRef {
+function builtin_i32x4_swizzle(ctx: BuiltinFunctionContext): ExpressionRef {
   ctx.typeArguments = null;
   ctx.contextualType = Type.v128;
   return builtin_v128_swizzle(ctx);
 }
-builtins.set(BuiltinNames.i32x4_swizzle, builtin_i32x4_swizzle);
+builtinFunctions.set(BuiltinNames.i32x4_swizzle, builtin_i32x4_swizzle);
 
 // i64x2.splat -> v128.splat<i64>
-function builtin_i64x2_splat(ctx: BuiltinContext): ExpressionRef {
+function builtin_i64x2_splat(ctx: BuiltinFunctionContext): ExpressionRef {
   checkTypeAbsent(ctx);
   ctx.typeArguments = [ Type.i64 ];
   ctx.contextualType = Type.v128;
   return builtin_v128_splat(ctx);
 }
-builtins.set(BuiltinNames.i64x2_splat, builtin_i64x2_splat);
+builtinFunctions.set(BuiltinNames.i64x2_splat, builtin_i64x2_splat);
 
 // i64x2.extract_lane -> <i64>v128.extract_lane<i64>
-function builtin_i64x2_extract_lane(ctx: BuiltinContext): ExpressionRef {
+function builtin_i64x2_extract_lane(ctx: BuiltinFunctionContext): ExpressionRef {
   checkTypeAbsent(ctx);
   ctx.typeArguments = [ Type.i64 ];
   ctx.contextualType = Type.i64;
   return builtin_v128_extract_lane(ctx);
 }
-builtins.set(BuiltinNames.i64x2_extract_lane, builtin_i64x2_extract_lane);
+builtinFunctions.set(BuiltinNames.i64x2_extract_lane, builtin_i64x2_extract_lane);
 
 // i64x2.replace_lane -> v128.replace_lane<i64>
-function builtin_i64x2_replace_lane(ctx: BuiltinContext): ExpressionRef {
+function builtin_i64x2_replace_lane(ctx: BuiltinFunctionContext): ExpressionRef {
   checkTypeAbsent(ctx);
   ctx.typeArguments = [ Type.i64 ];
   ctx.contextualType = Type.v128;
   return builtin_v128_replace_lane(ctx);
 }
-builtins.set(BuiltinNames.i64x2_replace_lane, builtin_i64x2_replace_lane);
+builtinFunctions.set(BuiltinNames.i64x2_replace_lane, builtin_i64x2_replace_lane);
 
 // i64x2.add -> v128.add<i64>
-function builtin_i64x2_add(ctx: BuiltinContext): ExpressionRef {
+function builtin_i64x2_add(ctx: BuiltinFunctionContext): ExpressionRef {
   checkTypeAbsent(ctx);
   ctx.typeArguments = [ Type.i64 ];
   ctx.contextualType = Type.v128;
   return builtin_v128_add(ctx);
 }
-builtins.set(BuiltinNames.i64x2_add, builtin_i64x2_add);
+builtinFunctions.set(BuiltinNames.i64x2_add, builtin_i64x2_add);
 
 // i64x2.sub -> v128.sub<i64>
-function builtin_i64x2_sub(ctx: BuiltinContext): ExpressionRef {
+function builtin_i64x2_sub(ctx: BuiltinFunctionContext): ExpressionRef {
   checkTypeAbsent(ctx);
   ctx.typeArguments = [ Type.i64 ];
   ctx.contextualType = Type.v128;
   return builtin_v128_sub(ctx);
 }
-builtins.set(BuiltinNames.i64x2_sub, builtin_i64x2_sub);
+builtinFunctions.set(BuiltinNames.i64x2_sub, builtin_i64x2_sub);
 
 // i64x2.mul -> v128.mul<i64>
-function builtin_i64x2_mul(ctx: BuiltinContext): ExpressionRef {
+function builtin_i64x2_mul(ctx: BuiltinFunctionContext): ExpressionRef {
   checkTypeAbsent(ctx);
   ctx.typeArguments = [ Type.i64 ];
   ctx.contextualType = Type.v128;
   return builtin_v128_mul(ctx);
 }
-builtins.set(BuiltinNames.i64x2_mul, builtin_i64x2_mul);
+builtinFunctions.set(BuiltinNames.i64x2_mul, builtin_i64x2_mul);
 
 // i64x2.abs -> v128.abs<i64>
-function builtin_i64x2_abs(ctx: BuiltinContext): ExpressionRef {
+function builtin_i64x2_abs(ctx: BuiltinFunctionContext): ExpressionRef {
   checkTypeAbsent(ctx);
   ctx.typeArguments = [ Type.i64 ];
   ctx.contextualType = Type.v128;
   return builtin_v128_abs(ctx);
 }
-builtins.set(BuiltinNames.i64x2_abs, builtin_i64x2_abs);
+builtinFunctions.set(BuiltinNames.i64x2_abs, builtin_i64x2_abs);
 
 // i64x2.neg -> v128.neg<i64>
-function builtin_i64x2_neg(ctx: BuiltinContext): ExpressionRef {
+function builtin_i64x2_neg(ctx: BuiltinFunctionContext): ExpressionRef {
   checkTypeAbsent(ctx);
   ctx.typeArguments = [ Type.i64 ];
   ctx.contextualType = Type.v128;
   return builtin_v128_neg(ctx);
 }
-builtins.set(BuiltinNames.i64x2_neg, builtin_i64x2_neg);
+builtinFunctions.set(BuiltinNames.i64x2_neg, builtin_i64x2_neg);
 
 // i64x2.shl -> v128.shl<i64>
-function builtin_i64x2_shl(ctx: BuiltinContext): ExpressionRef {
+function builtin_i64x2_shl(ctx: BuiltinFunctionContext): ExpressionRef {
   checkTypeAbsent(ctx);
   ctx.typeArguments = [ Type.i64 ];
   ctx.contextualType = Type.v128;
   return builtin_v128_shl(ctx);
 }
-builtins.set(BuiltinNames.i64x2_shl, builtin_i64x2_shl);
+builtinFunctions.set(BuiltinNames.i64x2_shl, builtin_i64x2_shl);
 
 // i64x2.shr_s -> v128.shr<i64>
-function builtin_i64x2_shr_s(ctx: BuiltinContext): ExpressionRef {
+function builtin_i64x2_shr_s(ctx: BuiltinFunctionContext): ExpressionRef {
   checkTypeAbsent(ctx);
   ctx.typeArguments = [ Type.i64 ];
   ctx.contextualType = Type.v128;
   return builtin_v128_shr(ctx);
 }
-builtins.set(BuiltinNames.i64x2_shr_s, builtin_i64x2_shr_s);
+builtinFunctions.set(BuiltinNames.i64x2_shr_s, builtin_i64x2_shr_s);
 
 // i64x2.shr_u -> v128.shr<u64>
-function builtin_i64x2_shr_u(ctx: BuiltinContext): ExpressionRef {
+function builtin_i64x2_shr_u(ctx: BuiltinFunctionContext): ExpressionRef {
   checkTypeAbsent(ctx);
   ctx.typeArguments = [ Type.u64 ];
   ctx.contextualType = Type.v128;
   return builtin_v128_shr(ctx);
 }
-builtins.set(BuiltinNames.i64x2_shr_u, builtin_i64x2_shr_u);
+builtinFunctions.set(BuiltinNames.i64x2_shr_u, builtin_i64x2_shr_u);
 
 // i64x2.all_true -> v128.all_true<i64>
-function builtin_i64x2_all_true(ctx: BuiltinContext): ExpressionRef {
+function builtin_i64x2_all_true(ctx: BuiltinFunctionContext): ExpressionRef {
   checkTypeAbsent(ctx);
   ctx.typeArguments = [ Type.i64 ];
   ctx.contextualType = Type.i32;
   return builtin_v128_all_true(ctx);
 }
-builtins.set(BuiltinNames.i64x2_all_true, builtin_i64x2_all_true);
+builtinFunctions.set(BuiltinNames.i64x2_all_true, builtin_i64x2_all_true);
 
 // i64x2.bitmask -> v128.bitmask<i64>
-function builtin_i64x2_bitmask(ctx: BuiltinContext): ExpressionRef {
+function builtin_i64x2_bitmask(ctx: BuiltinFunctionContext): ExpressionRef {
   checkTypeAbsent(ctx);
   ctx.typeArguments = [ Type.i64 ];
   ctx.contextualType = Type.i32;
   return builtin_v128_bitmask(ctx);
 }
-builtins.set(BuiltinNames.i64x2_bitmask, builtin_i64x2_bitmask);
+builtinFunctions.set(BuiltinNames.i64x2_bitmask, builtin_i64x2_bitmask);
 
 // i64x2.eq -> v128.eq<i64>
-function builtin_i64x2_eq(ctx: BuiltinContext): ExpressionRef {
+function builtin_i64x2_eq(ctx: BuiltinFunctionContext): ExpressionRef {
   checkTypeAbsent(ctx);
   ctx.typeArguments = [ Type.i64 ];
   ctx.contextualType = Type.v128;
   return builtin_v128_eq(ctx);
 }
-builtins.set(BuiltinNames.i64x2_eq, builtin_i64x2_eq);
+builtinFunctions.set(BuiltinNames.i64x2_eq, builtin_i64x2_eq);
 
 // i64x2.ne -> v128.ne<i64>
-function builtin_i64x2_ne(ctx: BuiltinContext): ExpressionRef {
+function builtin_i64x2_ne(ctx: BuiltinFunctionContext): ExpressionRef {
   checkTypeAbsent(ctx);
   ctx.typeArguments = [ Type.i64 ];
   ctx.contextualType = Type.v128;
   return builtin_v128_ne(ctx);
 }
-builtins.set(BuiltinNames.i64x2_ne, builtin_i64x2_ne);
+builtinFunctions.set(BuiltinNames.i64x2_ne, builtin_i64x2_ne);
 
 // i64x2.lt_s -> v128.lt<i64>
-function builtin_i64x2_lt_s(ctx: BuiltinContext): ExpressionRef {
+function builtin_i64x2_lt_s(ctx: BuiltinFunctionContext): ExpressionRef {
   checkTypeAbsent(ctx);
   ctx.typeArguments = [ Type.i64 ];
   ctx.contextualType = Type.v128;
   return builtin_v128_lt(ctx);
 }
-builtins.set(BuiltinNames.i64x2_lt_s, builtin_i64x2_lt_s);
+builtinFunctions.set(BuiltinNames.i64x2_lt_s, builtin_i64x2_lt_s);
 
 // i64x2.le_s -> v128.le<i64>
-function builtin_i64x2_le_s(ctx: BuiltinContext): ExpressionRef {
+function builtin_i64x2_le_s(ctx: BuiltinFunctionContext): ExpressionRef {
   checkTypeAbsent(ctx);
   ctx.typeArguments = [ Type.i64 ];
   ctx.contextualType = Type.v128;
   return builtin_v128_le(ctx);
 }
-builtins.set(BuiltinNames.i64x2_le_s, builtin_i64x2_le_s);
+builtinFunctions.set(BuiltinNames.i64x2_le_s, builtin_i64x2_le_s);
 
 // i64x2.gt_s -> v128.gt<i64>
-function builtin_i64x2_gt_s(ctx: BuiltinContext): ExpressionRef {
+function builtin_i64x2_gt_s(ctx: BuiltinFunctionContext): ExpressionRef {
   checkTypeAbsent(ctx);
   ctx.typeArguments = [ Type.i64 ];
   ctx.contextualType = Type.v128;
   return builtin_v128_gt(ctx);
 }
-builtins.set(BuiltinNames.i64x2_gt_s, builtin_i64x2_gt_s);
+builtinFunctions.set(BuiltinNames.i64x2_gt_s, builtin_i64x2_gt_s);
 
 // i64x2.ge_s -> v128.ge<i64>
-function builtin_i64x2_ge_s(ctx: BuiltinContext): ExpressionRef {
+function builtin_i64x2_ge_s(ctx: BuiltinFunctionContext): ExpressionRef {
   checkTypeAbsent(ctx);
   ctx.typeArguments = [ Type.i64 ];
   ctx.contextualType = Type.v128;
   return builtin_v128_ge(ctx);
 }
-builtins.set(BuiltinNames.i64x2_ge_s, builtin_i64x2_ge_s);
+builtinFunctions.set(BuiltinNames.i64x2_ge_s, builtin_i64x2_ge_s);
 
 // i64x2.extend_low_i32x4_s -> // v128.extend_low<i32>
-function builtin_i64x2_extend_low_i32x4_s(ctx: BuiltinContext): ExpressionRef {
+function builtin_i64x2_extend_low_i32x4_s(ctx: BuiltinFunctionContext): ExpressionRef {
   checkTypeAbsent(ctx);
   ctx.typeArguments = [ Type.i32 ];
   ctx.contextualType = Type.v128;
   return builtin_v128_extend_low(ctx);
 }
-builtins.set(BuiltinNames.i64x2_extend_low_i32x4_s, builtin_i64x2_extend_low_i32x4_s);
+builtinFunctions.set(BuiltinNames.i64x2_extend_low_i32x4_s, builtin_i64x2_extend_low_i32x4_s);
 
 // i64x2.extend_low_i32x4_u -> v128.extend_low<u32>
-function builtin_i64x2_extend_low_i32x4_u(ctx: BuiltinContext): ExpressionRef {
+function builtin_i64x2_extend_low_i32x4_u(ctx: BuiltinFunctionContext): ExpressionRef {
   checkTypeAbsent(ctx);
   ctx.typeArguments = [ Type.u32 ];
   ctx.contextualType = Type.v128;
   return builtin_v128_extend_low(ctx);
 }
-builtins.set(BuiltinNames.i64x2_extend_low_i32x4_u, builtin_i64x2_extend_low_i32x4_u);
+builtinFunctions.set(BuiltinNames.i64x2_extend_low_i32x4_u, builtin_i64x2_extend_low_i32x4_u);
 
 // i64x2.extend_high_i32x4_s -> v128.extend_high<i32>
-function builtin_i64x2_extend_high_i32x4_s(ctx: BuiltinContext): ExpressionRef {
+function builtin_i64x2_extend_high_i32x4_s(ctx: BuiltinFunctionContext): ExpressionRef {
   checkTypeAbsent(ctx);
   ctx.typeArguments = [ Type.i32 ];
   ctx.contextualType = Type.v128;
   return builtin_v128_extend_high(ctx);
 }
-builtins.set(BuiltinNames.i64x2_extend_high_i32x4_s, builtin_i64x2_extend_high_i32x4_s);
+builtinFunctions.set(BuiltinNames.i64x2_extend_high_i32x4_s, builtin_i64x2_extend_high_i32x4_s);
 
 // i64x2.extend_high_i32x4_u -> v128.extend_high<u32>
-function builtin_i64x2_extend_high_i32x4_u(ctx: BuiltinContext): ExpressionRef {
+function builtin_i64x2_extend_high_i32x4_u(ctx: BuiltinFunctionContext): ExpressionRef {
   checkTypeAbsent(ctx);
   ctx.typeArguments = [ Type.u32 ];
   ctx.contextualType = Type.v128;
   return builtin_v128_extend_high(ctx);
 }
-builtins.set(BuiltinNames.i64x2_extend_high_i32x4_u, builtin_i64x2_extend_high_i32x4_u);
+builtinFunctions.set(BuiltinNames.i64x2_extend_high_i32x4_u, builtin_i64x2_extend_high_i32x4_u);
 
 // i64x2.extmul_low_i32x4_s -> v128.extmul_low<i32>
-function builtin_i64x2_extmul_low_i32x4_s(ctx: BuiltinContext): ExpressionRef {
+function builtin_i64x2_extmul_low_i32x4_s(ctx: BuiltinFunctionContext): ExpressionRef {
   checkTypeAbsent(ctx);
   ctx.typeArguments = [ Type.i32 ];
   ctx.contextualType = Type.v128;
   return builtin_v128_extmul_low(ctx);
 }
-builtins.set(BuiltinNames.i64x2_extmul_low_i32x4_s, builtin_i64x2_extmul_low_i32x4_s);
+builtinFunctions.set(BuiltinNames.i64x2_extmul_low_i32x4_s, builtin_i64x2_extmul_low_i32x4_s);
 
 // i64x2.extmul_low_i32x4_u -> v128.extmul_low<u32>
-function builtin_i64x2_extmul_low_i32x4_u(ctx: BuiltinContext): ExpressionRef {
+function builtin_i64x2_extmul_low_i32x4_u(ctx: BuiltinFunctionContext): ExpressionRef {
   checkTypeAbsent(ctx);
   ctx.typeArguments = [ Type.u32 ];
   ctx.contextualType = Type.v128;
   return builtin_v128_extmul_low(ctx);
 }
-builtins.set(BuiltinNames.i64x2_extmul_low_i32x4_u, builtin_i64x2_extmul_low_i32x4_u);
+builtinFunctions.set(BuiltinNames.i64x2_extmul_low_i32x4_u, builtin_i64x2_extmul_low_i32x4_u);
 
 // i64x2.extmul_high_i32x4_s -> v128.extmul_high<i32>
-function builtin_i64x2_extmul_high_i32x4_s(ctx: BuiltinContext): ExpressionRef {
+function builtin_i64x2_extmul_high_i32x4_s(ctx: BuiltinFunctionContext): ExpressionRef {
   checkTypeAbsent(ctx);
   ctx.typeArguments = [ Type.i32 ];
   ctx.contextualType = Type.v128;
   return builtin_v128_extmul_high(ctx);
 }
-builtins.set(BuiltinNames.i64x2_extmul_high_i32x4_s, builtin_i64x2_extmul_high_i32x4_s);
+builtinFunctions.set(BuiltinNames.i64x2_extmul_high_i32x4_s, builtin_i64x2_extmul_high_i32x4_s);
 
 // i64x2.extmul_high_i32x4_u -> v128.extmul_high<u32>
-function builtin_i64x2_extmul_high_i32x4_u(ctx: BuiltinContext): ExpressionRef {
+function builtin_i64x2_extmul_high_i32x4_u(ctx: BuiltinFunctionContext): ExpressionRef {
   checkTypeAbsent(ctx);
   ctx.typeArguments = [ Type.u32 ];
   ctx.contextualType = Type.v128;
   return builtin_v128_extmul_high(ctx);
 }
-builtins.set(BuiltinNames.i64x2_extmul_high_i32x4_u, builtin_i64x2_extmul_high_i32x4_u);
+builtinFunctions.set(BuiltinNames.i64x2_extmul_high_i32x4_u, builtin_i64x2_extmul_high_i32x4_u);
 
 // i64x2.shuffle -> v128.shuffle<i64>
-function builtin_i64x2_shuffle(ctx: BuiltinContext): ExpressionRef {
+function builtin_i64x2_shuffle(ctx: BuiltinFunctionContext): ExpressionRef {
   checkTypeAbsent(ctx);
   ctx.typeArguments = [ Type.i64 ];
   ctx.contextualType = Type.v128;
   return builtin_v128_shuffle(ctx);
 }
-builtins.set(BuiltinNames.i64x2_shuffle, builtin_i64x2_shuffle);
+builtinFunctions.set(BuiltinNames.i64x2_shuffle, builtin_i64x2_shuffle);
 
 // i64x2.swizzle -> v128.swizzle
-function builtin_i64x2_swizzle(ctx: BuiltinContext): ExpressionRef {
+function builtin_i64x2_swizzle(ctx: BuiltinFunctionContext): ExpressionRef {
   ctx.typeArguments = null;
   ctx.contextualType = Type.v128;
   return builtin_v128_swizzle(ctx);
 }
-builtins.set(BuiltinNames.i64x2_swizzle, builtin_i64x2_swizzle);
+builtinFunctions.set(BuiltinNames.i64x2_swizzle, builtin_i64x2_swizzle);
 
 // f32x4.splat -> v128.splat<f32>
-function builtin_f32x4_splat(ctx: BuiltinContext): ExpressionRef {
+function builtin_f32x4_splat(ctx: BuiltinFunctionContext): ExpressionRef {
   checkTypeAbsent(ctx);
   ctx.typeArguments = [ Type.f32 ];
   ctx.contextualType = Type.v128;
   return builtin_v128_splat(ctx);
 }
-builtins.set(BuiltinNames.f32x4_splat, builtin_f32x4_splat);
+builtinFunctions.set(BuiltinNames.f32x4_splat, builtin_f32x4_splat);
 
 // f32x4.extract_lane -> <f32>v128.extract_lane<f32>
-function builtin_f32x4_extract_lane(ctx: BuiltinContext): ExpressionRef {
+function builtin_f32x4_extract_lane(ctx: BuiltinFunctionContext): ExpressionRef {
   checkTypeAbsent(ctx);
   ctx.typeArguments = [ Type.f32 ];
   ctx.contextualType = Type.f32;
   return builtin_v128_extract_lane(ctx);
 }
-builtins.set(BuiltinNames.f32x4_extract_lane, builtin_f32x4_extract_lane);
+builtinFunctions.set(BuiltinNames.f32x4_extract_lane, builtin_f32x4_extract_lane);
 
 // f32x4.replace_lane -> v128.replace_lane<f32>
-function builtin_f32x4_replace_lane(ctx: BuiltinContext): ExpressionRef {
+function builtin_f32x4_replace_lane(ctx: BuiltinFunctionContext): ExpressionRef {
   checkTypeAbsent(ctx);
   ctx.typeArguments = [ Type.f32 ];
   ctx.contextualType = Type.v128;
   return builtin_v128_replace_lane(ctx);
 }
-builtins.set(BuiltinNames.f32x4_replace_lane, builtin_f32x4_replace_lane);
+builtinFunctions.set(BuiltinNames.f32x4_replace_lane, builtin_f32x4_replace_lane);
 
 // f32x4.add -> v128.add<f32>
-function builtin_f32x4_add(ctx: BuiltinContext): ExpressionRef {
+function builtin_f32x4_add(ctx: BuiltinFunctionContext): ExpressionRef {
   checkTypeAbsent(ctx);
   ctx.typeArguments = [ Type.f32 ];
   ctx.contextualType = Type.v128;
   return builtin_v128_add(ctx);
 }
-builtins.set(BuiltinNames.f32x4_add, builtin_f32x4_add);
+builtinFunctions.set(BuiltinNames.f32x4_add, builtin_f32x4_add);
 
 // f32x4.sub -> v128.sub<f32>
-function builtin_f32x4_sub(ctx: BuiltinContext): ExpressionRef {
+function builtin_f32x4_sub(ctx: BuiltinFunctionContext): ExpressionRef {
   checkTypeAbsent(ctx);
   ctx.typeArguments = [ Type.f32 ];
   ctx.contextualType = Type.v128;
   return builtin_v128_sub(ctx);
 }
-builtins.set(BuiltinNames.f32x4_sub, builtin_f32x4_sub);
+builtinFunctions.set(BuiltinNames.f32x4_sub, builtin_f32x4_sub);
 
 // f32x4.mul -> v128.mul<f32>
-function builtin_f32x4_mul(ctx: BuiltinContext): ExpressionRef {
+function builtin_f32x4_mul(ctx: BuiltinFunctionContext): ExpressionRef {
   checkTypeAbsent(ctx);
   ctx.typeArguments = [ Type.f32 ];
   ctx.contextualType = Type.v128;
   return builtin_v128_mul(ctx);
 }
-builtins.set(BuiltinNames.f32x4_mul, builtin_f32x4_mul);
+builtinFunctions.set(BuiltinNames.f32x4_mul, builtin_f32x4_mul);
 
 // f32x4.div -> v128.div<f32>
-function builtin_f32x4_div(ctx: BuiltinContext): ExpressionRef {
+function builtin_f32x4_div(ctx: BuiltinFunctionContext): ExpressionRef {
   checkTypeAbsent(ctx);
   ctx.typeArguments = [ Type.f32 ];
   ctx.contextualType = Type.v128;
   return builtin_v128_div(ctx);
 }
-builtins.set(BuiltinNames.f32x4_div, builtin_f32x4_div);
+builtinFunctions.set(BuiltinNames.f32x4_div, builtin_f32x4_div);
 
 // f32x4.neg -> v128.neg<f32>
-function builtin_f32x4_neg(ctx: BuiltinContext): ExpressionRef {
+function builtin_f32x4_neg(ctx: BuiltinFunctionContext): ExpressionRef {
   checkTypeAbsent(ctx);
   ctx.typeArguments = [ Type.f32 ];
   ctx.contextualType = Type.v128;
   return builtin_v128_neg(ctx);
 }
-builtins.set(BuiltinNames.f32x4_neg, builtin_f32x4_neg);
+builtinFunctions.set(BuiltinNames.f32x4_neg, builtin_f32x4_neg);
 
 // f32x4.min -> v128.min<f32>
-function builtin_f32x4_min(ctx: BuiltinContext): ExpressionRef {
+function builtin_f32x4_min(ctx: BuiltinFunctionContext): ExpressionRef {
   checkTypeAbsent(ctx);
   ctx.typeArguments = [ Type.f32 ];
   ctx.contextualType = Type.v128;
   return builtin_v128_min(ctx);
 }
-builtins.set(BuiltinNames.f32x4_min, builtin_f32x4_min);
+builtinFunctions.set(BuiltinNames.f32x4_min, builtin_f32x4_min);
 
 // f32x4.max -> v128.max<f32>
-function builtin_f32x4_max(ctx: BuiltinContext): ExpressionRef {
+function builtin_f32x4_max(ctx: BuiltinFunctionContext): ExpressionRef {
   checkTypeAbsent(ctx);
   ctx.typeArguments = [ Type.f32 ];
   ctx.contextualType = Type.v128;
   return builtin_v128_max(ctx);
 }
-builtins.set(BuiltinNames.f32x4_max, builtin_f32x4_max);
+builtinFunctions.set(BuiltinNames.f32x4_max, builtin_f32x4_max);
 
 // f32x4.pmin -> v128.pmin<f32>
-function builtin_f32x4_pmin(ctx: BuiltinContext): ExpressionRef {
+function builtin_f32x4_pmin(ctx: BuiltinFunctionContext): ExpressionRef {
   checkTypeAbsent(ctx);
   ctx.typeArguments = [ Type.f32 ];
   ctx.contextualType = Type.v128;
   return builtin_v128_pmin(ctx);
 }
-builtins.set(BuiltinNames.f32x4_pmin, builtin_f32x4_pmin);
+builtinFunctions.set(BuiltinNames.f32x4_pmin, builtin_f32x4_pmin);
 
 // f32x4.pmax -> v128.pmax<f32>
-function builtin_f32x4_pmax(ctx: BuiltinContext): ExpressionRef {
+function builtin_f32x4_pmax(ctx: BuiltinFunctionContext): ExpressionRef {
   checkTypeAbsent(ctx);
   ctx.typeArguments = [ Type.f32 ];
   ctx.contextualType = Type.v128;
   return builtin_v128_pmax(ctx);
 }
-builtins.set(BuiltinNames.f32x4_pmax, builtin_f32x4_pmax);
+builtinFunctions.set(BuiltinNames.f32x4_pmax, builtin_f32x4_pmax);
 
 // f32x4.abs -> v128.abs<f32>
-function builtin_f32x4_abs(ctx: BuiltinContext): ExpressionRef {
+function builtin_f32x4_abs(ctx: BuiltinFunctionContext): ExpressionRef {
   checkTypeAbsent(ctx);
   ctx.typeArguments = [ Type.f32 ];
   ctx.contextualType = Type.v128;
   return builtin_v128_abs(ctx);
 }
-builtins.set(BuiltinNames.f32x4_abs, builtin_f32x4_abs);
+builtinFunctions.set(BuiltinNames.f32x4_abs, builtin_f32x4_abs);
 
 // f32x4.sqrt -> v128.sqrt<f32>
-function builtin_f32x4_sqrt(ctx: BuiltinContext): ExpressionRef {
+function builtin_f32x4_sqrt(ctx: BuiltinFunctionContext): ExpressionRef {
   checkTypeAbsent(ctx);
   ctx.typeArguments = [ Type.f32 ];
   ctx.contextualType = Type.v128;
   return builtin_v128_sqrt(ctx);
 }
-builtins.set(BuiltinNames.f32x4_sqrt, builtin_f32x4_sqrt);
+builtinFunctions.set(BuiltinNames.f32x4_sqrt, builtin_f32x4_sqrt);
 
 // f32x4.ceil -> v128.ceil<f32>
-function builtin_f32x4_ceil(ctx: BuiltinContext): ExpressionRef {
+function builtin_f32x4_ceil(ctx: BuiltinFunctionContext): ExpressionRef {
   checkTypeAbsent(ctx);
   ctx.typeArguments = [ Type.f32 ];
   ctx.contextualType = Type.v128;
   return builtin_v128_ceil(ctx);
 }
-builtins.set(BuiltinNames.f32x4_ceil, builtin_f32x4_ceil);
+builtinFunctions.set(BuiltinNames.f32x4_ceil, builtin_f32x4_ceil);
 
 // f32x4.floor -> v128.floor<f32>
-function builtin_f32x4_floor(ctx: BuiltinContext): ExpressionRef {
+function builtin_f32x4_floor(ctx: BuiltinFunctionContext): ExpressionRef {
   checkTypeAbsent(ctx);
   ctx.typeArguments = [ Type.f32 ];
   ctx.contextualType = Type.v128;
   return builtin_v128_floor(ctx);
 }
-builtins.set(BuiltinNames.f32x4_floor, builtin_f32x4_floor);
+builtinFunctions.set(BuiltinNames.f32x4_floor, builtin_f32x4_floor);
 
 // f32x4.trunc -> v128.trunc<f32>
-function builtin_f32x4_trunc(ctx: BuiltinContext): ExpressionRef {
+function builtin_f32x4_trunc(ctx: BuiltinFunctionContext): ExpressionRef {
   checkTypeAbsent(ctx);
   ctx.typeArguments = [ Type.f32 ];
   ctx.contextualType = Type.v128;
   return builtin_v128_trunc(ctx);
 }
-builtins.set(BuiltinNames.f32x4_trunc, builtin_f32x4_trunc);
+builtinFunctions.set(BuiltinNames.f32x4_trunc, builtin_f32x4_trunc);
 
 // f32x4.nearest -> v128.nearest<f32>
-function builtin_f32x4_nearest(ctx: BuiltinContext): ExpressionRef {
+function builtin_f32x4_nearest(ctx: BuiltinFunctionContext): ExpressionRef {
   checkTypeAbsent(ctx);
   ctx.typeArguments = [ Type.f32 ];
   ctx.contextualType = Type.v128;
   return builtin_v128_nearest(ctx);
 }
-builtins.set(BuiltinNames.f32x4_nearest, builtin_f32x4_nearest);
+builtinFunctions.set(BuiltinNames.f32x4_nearest, builtin_f32x4_nearest);
 
 // f32x4.eq -> v128.eq<f32>
-function builtin_f32x4_eq(ctx: BuiltinContext): ExpressionRef {
+function builtin_f32x4_eq(ctx: BuiltinFunctionContext): ExpressionRef {
   checkTypeAbsent(ctx);
   ctx.typeArguments = [ Type.f32 ];
   ctx.contextualType = Type.v128;
   return builtin_v128_eq(ctx);
 }
-builtins.set(BuiltinNames.f32x4_eq, builtin_f32x4_eq);
+builtinFunctions.set(BuiltinNames.f32x4_eq, builtin_f32x4_eq);
 
 // f32x4.ne -> v128.ne<f32>
-function builtin_f32x4_ne(ctx: BuiltinContext): ExpressionRef {
+function builtin_f32x4_ne(ctx: BuiltinFunctionContext): ExpressionRef {
   checkTypeAbsent(ctx);
   ctx.typeArguments = [ Type.f32 ];
   ctx.contextualType = Type.v128;
   return builtin_v128_ne(ctx);
 }
-builtins.set(BuiltinNames.f32x4_ne, builtin_f32x4_ne);
+builtinFunctions.set(BuiltinNames.f32x4_ne, builtin_f32x4_ne);
 
 // f32x4.lt -> v128.lt<f32>
-function builtin_f32x4_lt(ctx: BuiltinContext): ExpressionRef {
+function builtin_f32x4_lt(ctx: BuiltinFunctionContext): ExpressionRef {
   checkTypeAbsent(ctx);
   ctx.typeArguments = [ Type.f32 ];
   ctx.contextualType = Type.v128;
   return builtin_v128_lt(ctx);
 }
-builtins.set(BuiltinNames.f32x4_lt, builtin_f32x4_lt);
+builtinFunctions.set(BuiltinNames.f32x4_lt, builtin_f32x4_lt);
 
 // f32x4.le -> v128.le<f32>
-function builtin_f32x4_le(ctx: BuiltinContext): ExpressionRef {
+function builtin_f32x4_le(ctx: BuiltinFunctionContext): ExpressionRef {
   checkTypeAbsent(ctx);
   ctx.typeArguments = [ Type.f32 ];
   ctx.contextualType = Type.v128;
   return builtin_v128_le(ctx);
 }
-builtins.set(BuiltinNames.f32x4_le, builtin_f32x4_le);
+builtinFunctions.set(BuiltinNames.f32x4_le, builtin_f32x4_le);
 
 // f32x4.gt -> v128.gt<f32>
-function builtin_f32x4_gt(ctx: BuiltinContext): ExpressionRef {
+function builtin_f32x4_gt(ctx: BuiltinFunctionContext): ExpressionRef {
   checkTypeAbsent(ctx);
   ctx.typeArguments = [ Type.f32 ];
   ctx.contextualType = Type.v128;
   return builtin_v128_gt(ctx);
 }
-builtins.set(BuiltinNames.f32x4_gt, builtin_f32x4_gt);
+builtinFunctions.set(BuiltinNames.f32x4_gt, builtin_f32x4_gt);
 
 // f32x4.ge -> v128.ge<f32>
-function builtin_f32x4_ge(ctx: BuiltinContext): ExpressionRef {
+function builtin_f32x4_ge(ctx: BuiltinFunctionContext): ExpressionRef {
   checkTypeAbsent(ctx);
   ctx.typeArguments = [ Type.f32 ];
   ctx.contextualType = Type.v128;
   return builtin_v128_ge(ctx);
 }
-builtins.set(BuiltinNames.f32x4_ge, builtin_f32x4_ge);
+builtinFunctions.set(BuiltinNames.f32x4_ge, builtin_f32x4_ge);
 
 // f32x4.convert_i32x4_s -> v128.convert<i32>
-function builtin_f32x4_convert_i32x4_s(ctx: BuiltinContext): ExpressionRef {
+function builtin_f32x4_convert_i32x4_s(ctx: BuiltinFunctionContext): ExpressionRef {
   checkTypeAbsent(ctx);
   ctx.typeArguments = [ Type.i32 ];
   ctx.contextualType = Type.v128;
   return builtin_v128_convert(ctx);
 }
-builtins.set(BuiltinNames.f32x4_convert_i32x4_s, builtin_f32x4_convert_i32x4_s);
+builtinFunctions.set(BuiltinNames.f32x4_convert_i32x4_s, builtin_f32x4_convert_i32x4_s);
 
 // f32x4.convert_i32x4_u -> v128.convert<u32>
-function builtin_f32x4_convert_i32x4_u(ctx: BuiltinContext): ExpressionRef {
+function builtin_f32x4_convert_i32x4_u(ctx: BuiltinFunctionContext): ExpressionRef {
   checkTypeAbsent(ctx);
   ctx.typeArguments = [ Type.u32 ];
   ctx.contextualType = Type.v128;
   return builtin_v128_convert(ctx);
 }
-builtins.set(BuiltinNames.f32x4_convert_i32x4_u, builtin_f32x4_convert_i32x4_u);
+builtinFunctions.set(BuiltinNames.f32x4_convert_i32x4_u, builtin_f32x4_convert_i32x4_u);
 
 // f32x4.demote_f64x2_zero -> v128.demote_zero<f64>
-function builtin_f32x4_demote_f64x2_zero(ctx: BuiltinContext): ExpressionRef {
+function builtin_f32x4_demote_f64x2_zero(ctx: BuiltinFunctionContext): ExpressionRef {
   checkTypeAbsent(ctx);
   ctx.typeArguments = [ Type.f64 ];
   ctx.contextualType = Type.v128;
   return builtin_v128_demote_zero(ctx);
 }
-builtins.set(BuiltinNames.f32x4_demote_f64x2_zero, builtin_f32x4_demote_f64x2_zero);
+builtinFunctions.set(BuiltinNames.f32x4_demote_f64x2_zero, builtin_f32x4_demote_f64x2_zero);
 
 // f32x4.shuffle -> v128.shuffle<f32>
-function builtin_f32x4_shuffle(ctx: BuiltinContext): ExpressionRef {
+function builtin_f32x4_shuffle(ctx: BuiltinFunctionContext): ExpressionRef {
   checkTypeAbsent(ctx);
   ctx.typeArguments = [ Type.f32 ];
   ctx.contextualType = Type.v128;
   return builtin_v128_shuffle(ctx);
 }
-builtins.set(BuiltinNames.f32x4_shuffle, builtin_f32x4_shuffle);
+builtinFunctions.set(BuiltinNames.f32x4_shuffle, builtin_f32x4_shuffle);
 
 // f32x4.swizzle -> v128.swizzle
-function builtin_f32x4_swizzle(ctx: BuiltinContext): ExpressionRef {
+function builtin_f32x4_swizzle(ctx: BuiltinFunctionContext): ExpressionRef {
   ctx.typeArguments = null;
   ctx.contextualType = Type.v128;
   return builtin_v128_swizzle(ctx);
 }
-builtins.set(BuiltinNames.f32x4_swizzle, builtin_f32x4_swizzle);
+builtinFunctions.set(BuiltinNames.f32x4_swizzle, builtin_f32x4_swizzle);
 
 // f64x2.splat -> v128.splat<f64>
-function builtin_f64x2_splat(ctx: BuiltinContext): ExpressionRef {
+function builtin_f64x2_splat(ctx: BuiltinFunctionContext): ExpressionRef {
   checkTypeAbsent(ctx);
   ctx.typeArguments = [ Type.f64 ];
   ctx.contextualType = Type.v128;
   return builtin_v128_splat(ctx);
 }
-builtins.set(BuiltinNames.f64x2_splat, builtin_f64x2_splat);
+builtinFunctions.set(BuiltinNames.f64x2_splat, builtin_f64x2_splat);
 
 // f64x2.extract_lane -> <f64>v128.extract_lane<f64>
-function builtin_f64x2_extract_lane(ctx: BuiltinContext): ExpressionRef {
+function builtin_f64x2_extract_lane(ctx: BuiltinFunctionContext): ExpressionRef {
   checkTypeAbsent(ctx);
   ctx.typeArguments = [ Type.f64 ];
   ctx.contextualType = Type.f64;
   return builtin_v128_extract_lane(ctx);
 }
-builtins.set(BuiltinNames.f64x2_extract_lane, builtin_f64x2_extract_lane);
+builtinFunctions.set(BuiltinNames.f64x2_extract_lane, builtin_f64x2_extract_lane);
 
 // f64x2.replace_lane -> v128.replace_lane
-function builtin_f64x2_replace_lane(ctx: BuiltinContext): ExpressionRef {
+function builtin_f64x2_replace_lane(ctx: BuiltinFunctionContext): ExpressionRef {
   checkTypeAbsent(ctx);
   ctx.typeArguments = [ Type.f64 ];
   ctx.contextualType = Type.v128;
   return builtin_v128_replace_lane(ctx);
 }
-builtins.set(BuiltinNames.f64x2_replace_lane, builtin_f64x2_replace_lane);
+builtinFunctions.set(BuiltinNames.f64x2_replace_lane, builtin_f64x2_replace_lane);
 
 // f64x2.add -> v128.add<f64>
-function builtin_f64x2_add(ctx: BuiltinContext): ExpressionRef {
+function builtin_f64x2_add(ctx: BuiltinFunctionContext): ExpressionRef {
   checkTypeAbsent(ctx);
   ctx.typeArguments = [ Type.f64 ];
   ctx.contextualType = Type.v128;
   return builtin_v128_add(ctx);
 }
-builtins.set(BuiltinNames.f64x2_add, builtin_f64x2_add);
+builtinFunctions.set(BuiltinNames.f64x2_add, builtin_f64x2_add);
 
 // f64x2.sub -> v128.sub<f64>
-function builtin_f64x2_sub(ctx: BuiltinContext): ExpressionRef {
+function builtin_f64x2_sub(ctx: BuiltinFunctionContext): ExpressionRef {
   checkTypeAbsent(ctx);
   ctx.typeArguments = [ Type.f64 ];
   ctx.contextualType = Type.v128;
   return builtin_v128_sub(ctx);
 }
-builtins.set(BuiltinNames.f64x2_sub, builtin_f64x2_sub);
+builtinFunctions.set(BuiltinNames.f64x2_sub, builtin_f64x2_sub);
 
 // f64x2.mul -> v128.mul<f64>
-function builtin_f64x2_mul(ctx: BuiltinContext): ExpressionRef {
+function builtin_f64x2_mul(ctx: BuiltinFunctionContext): ExpressionRef {
   checkTypeAbsent(ctx);
   ctx.typeArguments = [ Type.f64 ];
   ctx.contextualType = Type.v128;
   return builtin_v128_mul(ctx);
 }
-builtins.set(BuiltinNames.f64x2_mul, builtin_f64x2_mul);
+builtinFunctions.set(BuiltinNames.f64x2_mul, builtin_f64x2_mul);
 
 // f64x2.div -> v128.div<f64>
-function builtin_f64x2_div(ctx: BuiltinContext): ExpressionRef {
+function builtin_f64x2_div(ctx: BuiltinFunctionContext): ExpressionRef {
   checkTypeAbsent(ctx);
   ctx.typeArguments = [ Type.f64 ];
   ctx.contextualType = Type.v128;
   return builtin_v128_div(ctx);
 }
-builtins.set(BuiltinNames.f64x2_div, builtin_f64x2_div);
+builtinFunctions.set(BuiltinNames.f64x2_div, builtin_f64x2_div);
 
 // f64x2.neg -> v128.neg<f64>
-function builtin_f64x2_neg(ctx: BuiltinContext): ExpressionRef {
+function builtin_f64x2_neg(ctx: BuiltinFunctionContext): ExpressionRef {
   checkTypeAbsent(ctx);
   ctx.typeArguments = [ Type.f64 ];
   ctx.contextualType = Type.v128;
   return builtin_v128_neg(ctx);
 }
-builtins.set(BuiltinNames.f64x2_neg, builtin_f64x2_neg);
+builtinFunctions.set(BuiltinNames.f64x2_neg, builtin_f64x2_neg);
 
 // f64x2.min -> v128.min<f64>
-function builtin_f64x2_min(ctx: BuiltinContext): ExpressionRef {
+function builtin_f64x2_min(ctx: BuiltinFunctionContext): ExpressionRef {
   checkTypeAbsent(ctx);
   ctx.typeArguments = [ Type.f64 ];
   ctx.contextualType = Type.v128;
   return builtin_v128_min(ctx);
 }
-builtins.set(BuiltinNames.f64x2_min, builtin_f64x2_min);
+builtinFunctions.set(BuiltinNames.f64x2_min, builtin_f64x2_min);
 
 // f64x2.max -> v128.max<f64>
-function builtin_f64x2_max(ctx: BuiltinContext): ExpressionRef {
+function builtin_f64x2_max(ctx: BuiltinFunctionContext): ExpressionRef {
   checkTypeAbsent(ctx);
   ctx.typeArguments = [ Type.f64 ];
   ctx.contextualType = Type.v128;
   return builtin_v128_max(ctx);
 }
-builtins.set(BuiltinNames.f64x2_max, builtin_f64x2_max);
+builtinFunctions.set(BuiltinNames.f64x2_max, builtin_f64x2_max);
 
 // f64x2.pmin -> v128.pmin<f64>
-function builtin_f64x2_pmin(ctx: BuiltinContext): ExpressionRef {
+function builtin_f64x2_pmin(ctx: BuiltinFunctionContext): ExpressionRef {
   checkTypeAbsent(ctx);
   ctx.typeArguments = [ Type.f64 ];
   ctx.contextualType = Type.v128;
   return builtin_v128_pmin(ctx);
 }
-builtins.set(BuiltinNames.f64x2_pmin, builtin_f64x2_pmin);
+builtinFunctions.set(BuiltinNames.f64x2_pmin, builtin_f64x2_pmin);
 
 // f64x2.pmax -> v128.pmax<f64>
-function builtin_f64x2_pmax(ctx: BuiltinContext): ExpressionRef {
+function builtin_f64x2_pmax(ctx: BuiltinFunctionContext): ExpressionRef {
   checkTypeAbsent(ctx);
   ctx.typeArguments = [ Type.f64 ];
   ctx.contextualType = Type.v128;
   return builtin_v128_pmax(ctx);
 }
-builtins.set(BuiltinNames.f64x2_pmax, builtin_f64x2_pmax);
+builtinFunctions.set(BuiltinNames.f64x2_pmax, builtin_f64x2_pmax);
 
 // f64x2.abs -> v128.abs<f64>
-function builtin_f64x2_abs(ctx: BuiltinContext): ExpressionRef {
+function builtin_f64x2_abs(ctx: BuiltinFunctionContext): ExpressionRef {
   checkTypeAbsent(ctx);
   ctx.typeArguments = [ Type.f64 ];
   ctx.contextualType = Type.v128;
   return builtin_v128_abs(ctx);
 }
-builtins.set(BuiltinNames.f64x2_abs, builtin_f64x2_abs);
+builtinFunctions.set(BuiltinNames.f64x2_abs, builtin_f64x2_abs);
 
 // f64x2.sqrt -> v128.sqrt<f64>
-function builtin_f64x2_sqrt(ctx: BuiltinContext): ExpressionRef {
+function builtin_f64x2_sqrt(ctx: BuiltinFunctionContext): ExpressionRef {
   checkTypeAbsent(ctx);
   ctx.typeArguments = [ Type.f64 ];
   ctx.contextualType = Type.v128;
   return builtin_v128_sqrt(ctx);
 }
-builtins.set(BuiltinNames.f64x2_sqrt, builtin_f64x2_sqrt);
+builtinFunctions.set(BuiltinNames.f64x2_sqrt, builtin_f64x2_sqrt);
 
 // f64x2.ceil -> v128.ceil<f64>
-function builtin_f64x2_ceil(ctx: BuiltinContext): ExpressionRef {
+function builtin_f64x2_ceil(ctx: BuiltinFunctionContext): ExpressionRef {
   checkTypeAbsent(ctx);
   ctx.typeArguments = [ Type.f64 ];
   ctx.contextualType = Type.v128;
   return builtin_v128_ceil(ctx);
 }
-builtins.set(BuiltinNames.f64x2_ceil, builtin_f64x2_ceil);
+builtinFunctions.set(BuiltinNames.f64x2_ceil, builtin_f64x2_ceil);
 
 // f64x2.floor -> v128.floor<f64>
-function builtin_f64x2_floor(ctx: BuiltinContext): ExpressionRef {
+function builtin_f64x2_floor(ctx: BuiltinFunctionContext): ExpressionRef {
   checkTypeAbsent(ctx);
   ctx.typeArguments = [ Type.f64 ];
   ctx.contextualType = Type.v128;
   return builtin_v128_floor(ctx);
 }
-builtins.set(BuiltinNames.f64x2_floor, builtin_f64x2_floor);
+builtinFunctions.set(BuiltinNames.f64x2_floor, builtin_f64x2_floor);
 
 // f64x2.trunc -> v128.trunc<f64>
-function builtin_f64x2_trunc(ctx: BuiltinContext): ExpressionRef {
+function builtin_f64x2_trunc(ctx: BuiltinFunctionContext): ExpressionRef {
   checkTypeAbsent(ctx);
   ctx.typeArguments = [ Type.f64 ];
   ctx.contextualType = Type.v128;
   return builtin_v128_trunc(ctx);
 }
-builtins.set(BuiltinNames.f64x2_trunc, builtin_f64x2_trunc);
+builtinFunctions.set(BuiltinNames.f64x2_trunc, builtin_f64x2_trunc);
 
 // f64x2.nearest -> v128.nearest<f64>
-function builtin_f64x2_nearest(ctx: BuiltinContext): ExpressionRef {
+function builtin_f64x2_nearest(ctx: BuiltinFunctionContext): ExpressionRef {
   checkTypeAbsent(ctx);
   ctx.typeArguments = [ Type.f64 ];
   ctx.contextualType = Type.v128;
   return builtin_v128_nearest(ctx);
 }
-builtins.set(BuiltinNames.f64x2_nearest, builtin_f64x2_nearest);
+builtinFunctions.set(BuiltinNames.f64x2_nearest, builtin_f64x2_nearest);
 
 // f64x2.eq -> v128.eq<f64>
-function builtin_f64x2_eq(ctx: BuiltinContext): ExpressionRef {
+function builtin_f64x2_eq(ctx: BuiltinFunctionContext): ExpressionRef {
   checkTypeAbsent(ctx);
   ctx.typeArguments = [ Type.f64 ];
   ctx.contextualType = Type.v128;
   return builtin_v128_eq(ctx);
 }
-builtins.set(BuiltinNames.f64x2_eq, builtin_f64x2_eq);
+builtinFunctions.set(BuiltinNames.f64x2_eq, builtin_f64x2_eq);
 
 // f64x2.ne -> v128.ne<f64>
-function builtin_f64x2_ne(ctx: BuiltinContext): ExpressionRef {
+function builtin_f64x2_ne(ctx: BuiltinFunctionContext): ExpressionRef {
   checkTypeAbsent(ctx);
   ctx.typeArguments = [ Type.f64 ];
   ctx.contextualType = Type.v128;
   return builtin_v128_ne(ctx);
 }
-builtins.set(BuiltinNames.f64x2_ne, builtin_f64x2_ne);
+builtinFunctions.set(BuiltinNames.f64x2_ne, builtin_f64x2_ne);
 
 // f64x2.lt -> v128.lt<f64>
-function builtin_f64x2_lt(ctx: BuiltinContext): ExpressionRef {
+function builtin_f64x2_lt(ctx: BuiltinFunctionContext): ExpressionRef {
   checkTypeAbsent(ctx);
   ctx.typeArguments = [ Type.f64 ];
   ctx.contextualType = Type.v128;
   return builtin_v128_lt(ctx);
 }
-builtins.set(BuiltinNames.f64x2_lt, builtin_f64x2_lt);
+builtinFunctions.set(BuiltinNames.f64x2_lt, builtin_f64x2_lt);
 
 // f64x2.le -> v128.le<f64>
-function builtin_f64x2_le(ctx: BuiltinContext): ExpressionRef {
+function builtin_f64x2_le(ctx: BuiltinFunctionContext): ExpressionRef {
   checkTypeAbsent(ctx);
   ctx.typeArguments = [ Type.f64 ];
   ctx.contextualType = Type.v128;
   return builtin_v128_le(ctx);
 }
-builtins.set(BuiltinNames.f64x2_le, builtin_f64x2_le);
+builtinFunctions.set(BuiltinNames.f64x2_le, builtin_f64x2_le);
 
 // f64x2.gt -> v128.gt<f64>
-function builtin_f64x2_gt(ctx: BuiltinContext): ExpressionRef {
+function builtin_f64x2_gt(ctx: BuiltinFunctionContext): ExpressionRef {
   checkTypeAbsent(ctx);
   ctx.typeArguments = [ Type.f64 ];
   ctx.contextualType = Type.v128;
   return builtin_v128_gt(ctx);
 }
-builtins.set(BuiltinNames.f64x2_gt, builtin_f64x2_gt);
+builtinFunctions.set(BuiltinNames.f64x2_gt, builtin_f64x2_gt);
 
 // f64x2.ge -> v128.ge<f64>
-function builtin_f64x2_ge(ctx: BuiltinContext): ExpressionRef {
+function builtin_f64x2_ge(ctx: BuiltinFunctionContext): ExpressionRef {
   checkTypeAbsent(ctx);
   ctx.typeArguments = [ Type.f64 ];
   ctx.contextualType = Type.v128;
   return builtin_v128_ge(ctx);
 }
-builtins.set(BuiltinNames.f64x2_ge, builtin_f64x2_ge);
+builtinFunctions.set(BuiltinNames.f64x2_ge, builtin_f64x2_ge);
 
 // f64x2.convert_low_i32x4_s -> v128.convert_low<i32>
-function builtin_f64x2_convert_low_i32x4_s(ctx: BuiltinContext): ExpressionRef {
+function builtin_f64x2_convert_low_i32x4_s(ctx: BuiltinFunctionContext): ExpressionRef {
   checkTypeAbsent(ctx);
   ctx.typeArguments = [ Type.i32 ];
   ctx.contextualType = Type.v128;
   return builtin_v128_convert_low(ctx);
 }
-builtins.set(BuiltinNames.f64x2_convert_low_i32x4_s, builtin_f64x2_convert_low_i32x4_s);
+builtinFunctions.set(BuiltinNames.f64x2_convert_low_i32x4_s, builtin_f64x2_convert_low_i32x4_s);
 
 // f64x2.convert_low_i32x4_u -> v128.convert_low<u32>
-function builtin_f64x2_convert_low_i32x4_u(ctx: BuiltinContext): ExpressionRef {
+function builtin_f64x2_convert_low_i32x4_u(ctx: BuiltinFunctionContext): ExpressionRef {
   checkTypeAbsent(ctx);
   ctx.typeArguments = [ Type.u32 ];
   ctx.contextualType = Type.v128;
   return builtin_v128_convert_low(ctx);
 }
-builtins.set(BuiltinNames.f64x2_convert_low_i32x4_u, builtin_f64x2_convert_low_i32x4_u);
+builtinFunctions.set(BuiltinNames.f64x2_convert_low_i32x4_u, builtin_f64x2_convert_low_i32x4_u);
 
 // f64x2.promote_low_f32x4 -> v128.promote_low<f32>
-function builtin_f64x4_promote_low_f32x4(ctx: BuiltinContext): ExpressionRef {
+function builtin_f64x4_promote_low_f32x4(ctx: BuiltinFunctionContext): ExpressionRef {
   checkTypeAbsent(ctx);
   ctx.typeArguments = [ Type.f32 ];
   ctx.contextualType = Type.v128;
   return builtin_v128_promote_low(ctx);
 }
-builtins.set(BuiltinNames.f64x2_promote_low_f32x4, builtin_f64x4_promote_low_f32x4);
+builtinFunctions.set(BuiltinNames.f64x2_promote_low_f32x4, builtin_f64x4_promote_low_f32x4);
 
 // f64x2.shuffle -> v128.shuffle<f32>
-function builtin_f64x2_shuffle(ctx: BuiltinContext): ExpressionRef {
+function builtin_f64x2_shuffle(ctx: BuiltinFunctionContext): ExpressionRef {
   checkTypeAbsent(ctx);
   ctx.typeArguments = [ Type.f64 ];
   ctx.contextualType = Type.v128;
   return builtin_v128_shuffle(ctx);
 }
-builtins.set(BuiltinNames.f64x2_shuffle, builtin_f64x2_shuffle);
+builtinFunctions.set(BuiltinNames.f64x2_shuffle, builtin_f64x2_shuffle);
 
 // f64x2.swizzle -> v128.swizzle
-function builtin_f64x2_swizzle(ctx: BuiltinContext): ExpressionRef {
+function builtin_f64x2_swizzle(ctx: BuiltinFunctionContext): ExpressionRef {
   ctx.typeArguments = null;
   ctx.contextualType = Type.v128;
   return builtin_v128_swizzle(ctx);
 }
-builtins.set(BuiltinNames.f64x2_swizzle, builtin_f64x2_swizzle);
+builtinFunctions.set(BuiltinNames.f64x2_swizzle, builtin_f64x2_swizzle);
 
 // === Internal helpers =======================================================================
 
@@ -10465,7 +10623,7 @@ export function compileRTTI(compiler: Compiler): void {
 let checkConstantType_expr: ExpressionRef = 0;
 
 /** Checks the constant type of a type argument *or* expression. */
-function checkConstantType(ctx: BuiltinContext): Type | null {
+function checkConstantType(ctx: BuiltinFunctionContext): Type | null {
   let compiler = ctx.compiler;
   let operands = ctx.operands;
   let typeArguments = ctx.typeArguments;
@@ -10509,7 +10667,7 @@ function checkConstantType(ctx: BuiltinContext): Type | null {
 }
 
 /** Reifies a constant type check potentially involving an expression. */
-function reifyConstantType(ctx: BuiltinContext, expr: ExpressionRef): ExpressionRef {
+function reifyConstantType(ctx: BuiltinFunctionContext, expr: ExpressionRef): ExpressionRef {
   let module = ctx.compiler.module;
   if (checkConstantType_expr && mustPreserveSideEffects(checkConstantType_expr, module.ref)) {
     expr = module.block(null, [
@@ -10575,7 +10733,7 @@ function evaluateImmediateAlign(expression: Expression, naturalAlign: i32, compi
 }
 
 /** Checks that the specified feature is enabled. */
-function checkFeatureEnabled(ctx: BuiltinContext, feature: Feature): i32 {
+function checkFeatureEnabled(ctx: BuiltinFunctionContext, feature: Feature): i32 {
   let compiler = ctx.compiler;
   if (!compiler.options.hasFeature(feature)) {
     compiler.error(
@@ -10588,7 +10746,7 @@ function checkFeatureEnabled(ctx: BuiltinContext, feature: Feature): i32 {
 }
 
 /** Checks a call with a single required type argument. Returns `1` on error. */
-function checkTypeRequired(ctx: BuiltinContext, setCurrentTypeOnError: bool = false): i32 {
+function checkTypeRequired(ctx: BuiltinFunctionContext, setCurrentTypeOnError: bool = false): i32 {
   let compiler = ctx.compiler;
   let typeArguments = ctx.typeArguments;
   if (typeArguments) {
@@ -10610,7 +10768,7 @@ function checkTypeRequired(ctx: BuiltinContext, setCurrentTypeOnError: bool = fa
 }
 
 /** Checks a call with a single optional type argument. Returns `1` on error. */
-function checkTypeOptional(ctx: BuiltinContext, setCurrentTypeOnError: bool = false): i32 {
+function checkTypeOptional(ctx: BuiltinFunctionContext, setCurrentTypeOnError: bool = false): i32 {
   let typeArguments = ctx.typeArguments;
   if (typeArguments) {
     let compiler = ctx.compiler;
@@ -10628,7 +10786,7 @@ function checkTypeOptional(ctx: BuiltinContext, setCurrentTypeOnError: bool = fa
 }
 
 /** Checks a call that is not generic. Returns `1` on error. */
-function checkTypeAbsent(ctx: BuiltinContext): i32 {
+function checkTypeAbsent(ctx: BuiltinFunctionContext): i32 {
   let typeArguments = ctx.typeArguments;
   if (typeArguments) {
     let prototype = ctx.prototype;
@@ -10642,7 +10800,7 @@ function checkTypeAbsent(ctx: BuiltinContext): i32 {
 }
 
 /** Checks a call that requires a fixed number of arguments. Returns `1` on error. */
-function checkArgsRequired(ctx: BuiltinContext, expected: i32): i32 {
+function checkArgsRequired(ctx: BuiltinFunctionContext, expected: i32): i32 {
   let operands = ctx.operands;
   if (operands.length != expected) {
     ctx.compiler.error(
@@ -10655,7 +10813,7 @@ function checkArgsRequired(ctx: BuiltinContext, expected: i32): i32 {
 }
 
 /** Checks a call that requires a variable number of arguments. Returns `1` on error. */
-function checkArgsOptional(ctx: BuiltinContext, expectedMinimum: i32, expectedMaximum: i32): i32 {
+function checkArgsOptional(ctx: BuiltinFunctionContext, expectedMinimum: i32, expectedMaximum: i32): i32 {
   let operands = ctx.operands;
   let numOperands = operands.length;
   if (numOperands < expectedMinimum) {

--- a/src/compiler.ts
+++ b/src/compiler.ts
@@ -1168,7 +1168,7 @@ export class Compiler extends DiagnosticEmitter {
     // Handle builtins like '__heap_base' that need to be resolved but are added explicitly
     if (global.hasDecorator(DecoratorFlags.Builtin)) {
       let internalName = global.internalName;
-      if (builtinVariables_onCompile.has(internalName)) {
+      if (builtinVariables_onCompile.has(internalName)) { // optional
         let fn = assert(builtinVariables_onCompile.get(internalName));
         fn(new BuiltinVariableContext(this, global));
       }
@@ -6117,7 +6117,6 @@ export class Compiler extends DiagnosticEmitter {
       expression,
       false
     );
-    // handle builtins
     let internalName: string;
     if (prototype.is(CommonFlags.Instance)) {
       // omit generic name components, e.g. in `Function<...>#call`
@@ -6126,12 +6125,9 @@ export class Compiler extends DiagnosticEmitter {
     } else {
       internalName = prototype.internalName;
     }
-    if (builtinFunctions.has(internalName)) {
-      let fn = assert(builtinFunctions.get(internalName));
-      return fn(ctx);
-    }
-    assert(false, "missing builtin " + internalName);
-    return this.module.unreachable();
+    assert(builtinFunctions.has(internalName)); // checked earlier
+    let fn = assert(builtinFunctions.get(internalName));
+    return fn(ctx);
   }
 
   /**
@@ -7431,23 +7427,14 @@ export class Compiler extends DiagnosticEmitter {
   ): ExpressionRef {
     if (element.hasDecorator(DecoratorFlags.Unsafe)) this.checkUnsafe(expression, element.identifierNode);
     let internalName = element.internalName;
-    if (builtinVariables_onAccess.has(internalName)) {
-      let fn = assert(builtinVariables_onAccess.get(internalName));
-      return fn(new BuiltinVariableContext(
-        this,
-        element,
-        contextualType,
-        expression
-      ));
-    }
-    this.errorRelated(
-      DiagnosticCode.Not_implemented_0,
-      expression.range,
-      element.identifierNode.range,
-      `Builtin '${internalName}'`
-    );
-    this.currentType = element.type;
-    return this.module.unreachable();
+    assert(builtinVariables_onAccess.has(internalName)); // checked earlier
+    let fn = assert(builtinVariables_onAccess.get(internalName));
+    return fn(new BuiltinVariableContext(
+      this,
+      element,
+      contextualType,
+      expression
+    ));
   }
 
   private compileInstanceOfExpression(

--- a/src/compiler.ts
+++ b/src/compiler.ts
@@ -9,10 +9,10 @@ import {
   BuiltinVariableContext,
   builtinFunctions,
   builtinVariables_onAccess,
+  builtinVariables_onCompile,
   compileVisitGlobals,
   compileVisitMembers,
-  compileRTTI,
-  builtinVariables_onCompile
+  compileRTTI
 } from "./builtins";
 
 import {

--- a/src/compiler.ts
+++ b/src/compiler.ts
@@ -5,12 +5,14 @@
 
 import {
   BuiltinNames,
-  BuiltinContext,
-  builtins,
-  function_builtins,
+  BuiltinFunctionContext,
+  BuiltinVariableContext,
+  builtinFunctions,
+  builtinVariables_onAccess,
   compileVisitGlobals,
   compileVisitMembers,
-  compileRTTI
+  compileRTTI,
+  builtinVariables_onCompile
 } from "./builtins";
 
 import {
@@ -508,17 +510,6 @@ export class Compiler extends DiagnosticEmitter {
     assert(startFunctionInstance.internalName == BuiltinNames.start);
     let startFunctionBody = this.currentBody;
     assert(startFunctionBody.length == 0);
-
-    // add mutable data, heap and rtti offset dummies
-    if (options.isWasm64) {
-      module.addGlobal(BuiltinNames.data_end,  TypeRef.I64, true, module.i64(0));
-      module.addGlobal(BuiltinNames.heap_base, TypeRef.I64, true, module.i64(0));
-      module.addGlobal(BuiltinNames.rtti_base, TypeRef.I64, true, module.i64(0));
-    } else {
-      module.addGlobal(BuiltinNames.data_end,  TypeRef.I32, true, module.i32(0));
-      module.addGlobal(BuiltinNames.heap_base, TypeRef.I32, true, module.i32(0));
-      module.addGlobal(BuiltinNames.rtti_base, TypeRef.I32, true, module.i32(0));
-    }
 
     // compile entry file(s) while traversing reachable elements
     let files = program.filesByName;
@@ -1174,13 +1165,13 @@ export class Compiler extends DiagnosticEmitter {
       }
     }
 
-    // Handle ambient builtins like '__heap_base' that need to be resolved but are added explicitly
-    if (global.is(CommonFlags.Ambient) && global.hasDecorator(DecoratorFlags.Builtin)) {
+    // Handle builtins like '__heap_base' that need to be resolved but are added explicitly
+    if (global.hasDecorator(DecoratorFlags.Builtin)) {
       let internalName = global.internalName;
-      if (internalName == BuiltinNames.data_end) this.runtimeFeatures |= RuntimeFeatures.Data;
-      else if (internalName == BuiltinNames.stack_pointer) this.runtimeFeatures |= RuntimeFeatures.Stack;
-      else if (internalName == BuiltinNames.heap_base) this.runtimeFeatures |= RuntimeFeatures.Heap;
-      else if (internalName == BuiltinNames.rtti_base) this.runtimeFeatures |= RuntimeFeatures.Rtti;
+      if (builtinVariables_onCompile.has(internalName)) {
+        let fn = assert(builtinVariables_onCompile.get(internalName));
+        fn(new BuiltinVariableContext(this, global));
+      }
       pendingElements.delete(global);
       return true;
     }
@@ -6114,7 +6105,7 @@ export class Compiler extends DiagnosticEmitter {
       );
     }
     let callee = expression.expression;
-    let ctx = new BuiltinContext(
+    let ctx = new BuiltinFunctionContext(
       this,
       prototype,
       typeArguments,
@@ -6126,25 +6117,20 @@ export class Compiler extends DiagnosticEmitter {
       expression,
       false
     );
-    // global builtins
-    let internalName = prototype.internalName;
-    if (builtins.has(internalName)) {
-      let fn = assert(builtins.get(internalName));
+    // handle builtins
+    let internalName: string;
+    if (prototype.is(CommonFlags.Instance)) {
+      // omit generic name components, e.g. in `Function<...>#call`
+      let parent = assert(prototype.getBoundClassOrInterface());
+      internalName = `${parent.prototype.internalName}#${prototype.name}`;
+    } else {
+      internalName = prototype.internalName;
+    }
+    if (builtinFunctions.has(internalName)) {
+      let fn = assert(builtinFunctions.get(internalName));
       return fn(ctx);
     }
-    // class builtins
-    let parent = prototype.parent;
-    if (parent.kind == ElementKind.Class) {
-      let classPrototype = (<Class>parent).prototype;
-      if (classPrototype == this.program.functionPrototype) {
-        let methodName = prototype.name;
-        if (function_builtins.has(methodName)) {
-          let fn = assert(function_builtins.get(methodName));
-          return fn(ctx);
-        }
-      }
-    }
-    assert(false);
+    assert(false, "missing builtin " + internalName);
     return this.module.unreachable();
   }
 
@@ -7361,6 +7347,9 @@ export class Compiler extends DiagnosticEmitter {
           return module.unreachable();
         }
         assert(globalType != Type.void);
+        if (global.hasDecorator(DecoratorFlags.Builtin)) {
+          return this.compileIdentifierExpressionBuiltin(global, expression, contextualType);
+        }
         if (global.is(CommonFlags.Inlined)) {
           return this.compileInlineConstant(global, contextualType, constraints);
         }
@@ -7433,6 +7422,32 @@ export class Compiler extends DiagnosticEmitter {
       expression.range
     );
     return module.unreachable();
+  }
+
+  private compileIdentifierExpressionBuiltin(
+    element: VariableLikeElement,
+    expression: IdentifierExpression,
+    contextualType: Type
+  ): ExpressionRef {
+    if (element.hasDecorator(DecoratorFlags.Unsafe)) this.checkUnsafe(expression, element.identifierNode);
+    let internalName = element.internalName;
+    if (builtinVariables_onAccess.has(internalName)) {
+      let fn = assert(builtinVariables_onAccess.get(internalName));
+      return fn(new BuiltinVariableContext(
+        this,
+        element,
+        contextualType,
+        expression
+      ));
+    }
+    this.errorRelated(
+      DiagnosticCode.Not_implemented_0,
+      expression.range,
+      element.identifierNode.range,
+      `Builtin '${internalName}'`
+    );
+    this.currentType = element.type;
+    return this.module.unreachable();
   }
 
   private compileInstanceOfExpression(

--- a/src/module.ts
+++ b/src/module.ts
@@ -2092,9 +2092,11 @@ export class Module {
 
   removeGlobal(
     name: string
-  ): void {
+  ): bool {
     let cStr = this.allocStringCached(name);
+    if (!binaryen._BinaryenGetGlobal(this.ref, cStr)) return false;
     binaryen._BinaryenRemoveGlobal(this.ref, cStr);
+    return true;
   }
 
   // tags

--- a/src/program.ts
+++ b/src/program.ts
@@ -147,8 +147,8 @@ import {
 } from "./parser";
 
 import {
-  builtinFunctions,
   BuiltinNames,
+  builtinFunctions,
   builtinVariables_onAccess
 } from "./builtins";
 

--- a/src/program.ts
+++ b/src/program.ts
@@ -2821,7 +2821,7 @@ export class Program extends DiagnosticEmitter {
       if (element.hasDecorator(DecoratorFlags.Builtin) && !builtinVariables_onAccess.has(element.internalName)) {
         this.error(
           DiagnosticCode.Not_implemented_0,
-          declaration.name.range, `Builtin '${element.internalName}'`
+          declaration.range, `Builtin '${element.internalName}'`
         );
       }
       if (!parent.add(name, element)) continue; // reports

--- a/src/program.ts
+++ b/src/program.ts
@@ -147,7 +147,9 @@ import {
 } from "./parser";
 
 import {
-  BuiltinNames
+  builtinFunctions,
+  BuiltinNames,
+  builtinVariables_onAccess
 } from "./builtins";
 
 // Memory manager constants
@@ -474,8 +476,6 @@ export class Program extends DiagnosticEmitter {
   managedClasses: Map<i32,Class> = new Map();
   /** A set of unique function signatures contained in the program, by id. */
   uniqueSignatures: Map<string, Signature> = new Map<string, Signature>();
-  /** Module exports. */
-  moduleExports: Map<string,Element> = new Map();
   /** Module imports. */
   moduleImports: Map<string,Map<string,Element>> = new Map();
 
@@ -1915,16 +1915,7 @@ export class Program extends DiagnosticEmitter {
         let kind = DecoratorKind.fromNode(decorator.name);
         let flag = DecoratorFlags.fromKind(kind);
         if (flag) {
-          if (flag == DecoratorFlags.Builtin) {
-            if (!(acceptedFlags & flag) && !decorator.range.source.isLibrary) {
-              this.error(
-                DiagnosticCode.Decorator_0_is_not_valid_here,
-                decorator.range, decorator.name.range.toString()
-              );
-            } else {
-              flags |= flag;
-            }
-          } else if (!(acceptedFlags & flag)) {
+          if (!(acceptedFlags & flag)) {
             this.error(
               DiagnosticCode.Decorator_0_is_not_valid_here,
               decorator.range, decorator.name.range.toString()
@@ -2154,12 +2145,21 @@ export class Program extends DiagnosticEmitter {
     if (parent.is(CommonFlags.Ambient)) {
       acceptedFlags |= DecoratorFlags.External;
     }
+    if (declaration.range.source.isLibrary) {
+      acceptedFlags |= DecoratorFlags.Builtin;
+    }
     let element = new FunctionPrototype(
       name,
       parent,
       declaration,
       this.checkDecorators(declaration.decorators, acceptedFlags)
     );
+    if (element.hasDecorator(DecoratorFlags.Builtin) && !builtinFunctions.has(element.internalName)) {
+      this.error(
+        DiagnosticCode.Not_implemented_0,
+        declaration.range, `Builtin '${element.internalName}'`
+      );
+    }
     if (isStatic) { // global function
       assert(declaration.name.kind != NodeKind.Constructor);
       if (!parent.add(name, element)) return null;
@@ -2579,7 +2579,7 @@ export class Program extends DiagnosticEmitter {
     parent: Element
   ): FunctionPrototype | null {
     let name = declaration.name.text;
-    let validDecorators = DecoratorFlags.Unsafe | DecoratorFlags.Builtin;
+    let validDecorators = DecoratorFlags.Unsafe;
     if (declaration.is(CommonFlags.Ambient)) {
       validDecorators |= DecoratorFlags.External | DecoratorFlags.ExternalJs;
     } else {
@@ -2593,12 +2593,21 @@ export class Program extends DiagnosticEmitter {
         validDecorators |= DecoratorFlags.Global;
       }
     }
+    if (declaration.range.source.isLibrary) {
+      validDecorators |= DecoratorFlags.Builtin;
+    }
     let element = new FunctionPrototype(
       name,
       parent,
       declaration,
       this.checkDecorators(declaration.decorators, validDecorators)
     );
+    if (element.hasDecorator(DecoratorFlags.Builtin) && !builtinFunctions.has(element.internalName)) {
+      this.error(
+        DiagnosticCode.Not_implemented_0,
+        declaration.range, `Builtin '${element.internalName}'`
+      );
+    }
     if (!parent.add(name, element)) return null;
     return element;
   }
@@ -2800,12 +2809,21 @@ export class Program extends DiagnosticEmitter {
       if (declaration.is(CommonFlags.Const)) {
         acceptedFlags |= DecoratorFlags.Inline;
       }
+      if (declaration.range.source.isLibrary) {
+        acceptedFlags |= DecoratorFlags.Builtin;
+      }
       let element = new Global(
         name,
         parent,
         this.checkDecorators(declaration.decorators, acceptedFlags),
         declaration
       );
+      if (element.hasDecorator(DecoratorFlags.Builtin) && !builtinVariables_onAccess.has(element.internalName)) {
+        this.error(
+          DiagnosticCode.Not_implemented_0,
+          declaration.name.range, `Builtin '${element.internalName}'`
+        );
+      }
       if (!parent.add(name, element)) continue; // reports
     }
   }

--- a/std/assembly/builtins.ts
+++ b/std/assembly/builtins.ts
@@ -452,10 +452,6 @@ export namespace i32 {
     @unsafe @builtin
     export declare function store(ptr: usize, value: i32, immOffset?: usize): void;
 
-    // @ts-ignore: decorator
-    @builtin
-    export declare function wait(ptr: usize, expected: i32, timeout: i64): AtomicWaitResult;
-
     export namespace rmw8 {
 
       // @ts-ignore: decorator
@@ -708,10 +704,6 @@ export namespace i64 {
     // @ts-ignore: decorator
     @unsafe @builtin
     export declare function store(ptr: usize, value: i64, immOffset?: usize): void;
-
-    // @ts-ignore: decorator
-    @builtin
-    export declare function wait(ptr: usize, expected: i64, timeout: i64): AtomicWaitResult;
 
     export namespace rmw8 {
 

--- a/std/assembly/index.d.ts
+++ b/std/assembly/index.d.ts
@@ -387,8 +387,6 @@ declare namespace i32 {
     export function store16(ptr: usize, value: i32, immOffset?: usize): void;
     /** Atomically stores a 32-bit integer value to memory. */
     export function store(ptr: usize, value: i32, immOffset?: usize): void;
-    /** Performs a wait operation on a 32-bit integer value in memory suspending this agent if the condition is met. */
-    export function wait(ptr: usize, expected: i32, timeout?: i64): AtomicWaitResult;
     /** Atomic 32-bit integer read-modify-write operations on 8-bit values. */
     export namespace rmw8 {
       /** Atomically adds an 8-bit unsigned integer value in memory. */
@@ -522,8 +520,6 @@ declare namespace i64 {
     export function store32(ptr: usize, value: i64, immOffset?: usize): void;
     /** Atomically stores a 64-bit integer value to memory. */
     export function store(ptr: usize, value: i64, immOffset?: usize): void;
-    /** Performs a wait operation on a 64-bit integer value in memory suspending this agent if the condition is met. */
-    export function wait(ptr: usize, expected: i64, timeout?: i64): AtomicWaitResult;
     /** Atomic 64-bit integer read-modify-write operations on 8-bit values. */
     export namespace rmw8 {
       /** Atomically adds an 8-bit unsigned integer value in memory. */
@@ -1530,6 +1526,13 @@ declare namespace memory {
   export function data(size: i32, align?: i32): usize;
   /** Gets a pointer to a pre-initialized static chunk of memory. Alignment defaults to the size of `T`. Arguments must be compile-time constants. */
   export function data<T>(values: T[], align?: i32): usize;
+
+  export namespace atomic {
+    /** Performs a wait operation on a 32-bit integer value in memory suspending this agent if the condition is met. */
+    export function wait32(ptr: usize, expected: i32, timeout?: i64): AtomicWaitResult;
+    /** Performs a wait operation on a 64-bit integer value in memory suspending this agent if the condition is met. */
+    export function wait64(ptr: usize, expected: i64, timeout?: i64): AtomicWaitResult;
+  }
 }
 
 /** Heap memory interface. */

--- a/std/assembly/memory.ts
+++ b/std/assembly/memory.ts
@@ -28,6 +28,17 @@ export namespace memory {
     memmove(dst, src, n); // fallback if "bulk-memory" isn't enabled
   }
 
+  export namespace atomic {
+
+    // @ts-ignore: decorator
+    @unsafe @builtin
+    export declare function wait32(ptr: usize, expected: i32, timeout: i64): AtomicWaitResult;
+
+    // @ts-ignore: decorator
+    @unsafe @builtin
+    export declare function wait64(ptr: usize, expected: i64, timeout: i64): AtomicWaitResult;
+  }
+
   /** Initializes a memory segment. */
   // @ts-ignore: decorator
   @unsafe

--- a/std/assembly/number.ts
+++ b/std/assembly/number.ts
@@ -3,11 +3,11 @@ import { strtol, strtod } from "./util/string";
 
 // @ts-ignore: decorator
 @builtin @inline
-export const NaN: f64 = 0 / 0;
+export const NaN: f64 = 0 / 0; // context-aware
 
 // @ts-ignore: decorator
 @builtin @inline
-export const Infinity: f64 = 1 / 0;
+export const Infinity: f64 = 1 / 0; // context-aware
 
 // @ts-ignore: decorator
 @builtin


### PR DESCRIPTION
Addresses https://github.com/AssemblyScript/assemblyscript/pull/2632#pullrequestreview-1267379884 by only allowing `@builtin` decorators if there actually is such a builtin, effectively preventing that the decorator is used otherwise. Also refactors builtins into functions and variables, where the latter use two hooks now: One when compiled and one when accessed. Previously, variables were handled explicitly, whereas now these can be registered. The change also uncovered an issue with the `memory.atomic.waitXY` instructions that weren't correctly registering, which now is fixed.

- [x] I've read the contributing guidelines
- [x] I've added my name and email to the NOTICE file
