### PR TITLE
fix: pre-analysis extendType before infer generic

### DIFF
--- a/src/resolver.ts
+++ b/src/resolver.ts
@@ -739,21 +739,30 @@ export class Resolver extends DiagnosticEmitter {
         let type = Type.auto;
         let extendType = typeParameterNodes[i].extendsType;
         if (extendType) {
-          let parent = prototype.parent;
-          let defaultTypeContextualTypeArguments: Map<string, Type> | null = null;
-          if (parent.kind == ElementKind.Class) {
-            defaultTypeContextualTypeArguments = (<Class>parent).contextualTypeArguments;
-          } else if (parent.kind == ElementKind.Function) {
-            defaultTypeContextualTypeArguments = (<Function>parent).contextualTypeArguments;
-          }
-          let resolvedExtendType = this.resolveType(
-            extendType,
-            prototype,
-            defaultTypeContextualTypeArguments,
-            reportMode
-          );
-          if (resolvedExtendType && resolvedExtendType.isReference) {
-            type = resolvedExtendType;
+          const extendTypeName = extendType.name.identifier.text;
+          if (
+            !extendTypeName.startsWith("ArrayLike") &&
+            extendTypeName != "number"
+          ) {
+            let parent = prototype.parent;
+            let extendTypeContextualTypeArguments: Map<string, Type> | null =
+              null;
+            if (parent.kind == ElementKind.Class) {
+              extendTypeContextualTypeArguments = (<Class>parent)
+                .contextualTypeArguments;
+            } else if (parent.kind == ElementKind.Function) {
+              extendTypeContextualTypeArguments = (<Function>parent)
+                .contextualTypeArguments;
+            }
+            let resolvedExtendType = this.resolveType(
+              extendType,
+              prototype,
+              extendTypeContextualTypeArguments,
+              reportMode
+            );
+            if (resolvedExtendType && resolvedExtendType.isReference) {
+              type = resolvedExtendType;
+            }
           }
         }
         contextualTypeArguments.set(name, type);

--- a/tests/compiler/infer-generic.debug.wat
+++ b/tests/compiler/infer-generic.debug.wat
@@ -4,13 +4,14 @@
  (type $i32_=>_none (func (param i32)))
  (type $none_=>_none (func))
  (type $i32_i32_=>_i32 (func (param i32 i32) (result i32)))
- (type $i32_f32_i32_i32_=>_i32 (func (param i32 f32 i32 i32) (result i32)))
  (type $i32_i32_i32_=>_none (func (param i32 i32 i32)))
  (type $i32_i32_i32_=>_i32 (func (param i32 i32 i32) (result i32)))
+ (type $i32_f32_i32_i32_=>_i32 (func (param i32 f32 i32 i32) (result i32)))
  (type $f32_=>_f32 (func (param f32) (result f32)))
  (type $f64_f64_=>_i32 (func (param f64 f64) (result i32)))
  (type $i32_i32_i32_i32_=>_none (func (param i32 i32 i32 i32)))
  (type $none_=>_i32 (func (result i32)))
+ (type $i32_i32_i32_i32_=>_i32 (func (param i32 i32 i32 i32) (result i32)))
  (import "env" "abort" (func $~lib/builtins/abort (param i32 i32 i32 i32)))
  (global $infer-generic/arr i32 (i32.const 128))
  (global $~lib/shared/runtime/Runtime.Stub i32 (i32.const 0))
@@ -28,10 +29,11 @@
  (global $~lib/rt/itcms/fromSpace (mut i32) (i32.const 0))
  (global $~lib/rt/tlsf/ROOT (mut i32) (i32.const 0))
  (global $~lib/native/ASC_LOW_MEMORY_LIMIT i32 (i32.const 0))
- (global $~lib/rt/__rtti_base i32 (i32.const 592))
- (global $~lib/memory/__data_end i32 (i32.const 636))
- (global $~lib/memory/__stack_pointer (mut i32) (i32.const 33404))
- (global $~lib/memory/__heap_base i32 (i32.const 33404))
+ (global $infer-generic/r (mut i32) (i32.const 0))
+ (global $~lib/rt/__rtti_base i32 (i32.const 624))
+ (global $~lib/memory/__data_end i32 (i32.const 680))
+ (global $~lib/memory/__stack_pointer (mut i32) (i32.const 33448))
+ (global $~lib/memory/__heap_base i32 (i32.const 33448))
  (memory $0 1)
  (data (i32.const 12) "<\00\00\00\00\00\00\00\00\00\00\00\02\00\00\00 \00\00\00i\00n\00f\00e\00r\00-\00g\00e\00n\00e\00r\00i\00c\00.\00t\00s\00\00\00\00\00\00\00\00\00\00\00\00\00")
  (data (i32.const 76) "\1c\00\00\00\00\00\00\00\00\00\00\00\01\00\00\00\0c\00\00\00\00\00\80?\00\00\00@\00\00@@")
@@ -45,7 +47,8 @@
  (data (i32.const 444) ",\00\00\00\00\00\00\00\00\00\00\00\02\00\00\00\14\00\00\00~\00l\00i\00b\00/\00r\00t\00.\00t\00s\00\00\00\00\00\00\00\00\00")
  (data (i32.const 496) "\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00")
  (data (i32.const 524) "<\00\00\00\00\00\00\00\00\00\00\00\02\00\00\00\1e\00\00\00~\00l\00i\00b\00/\00r\00t\00/\00t\00l\00s\00f\00.\00t\00s\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00")
- (data (i32.const 592) "\n\00\00\00 \00\00\00 \00\00\00 \00\00\00\00\00\00\00\02\19\00\00\00\00\00\00 \00\00\00\00\00\00\00\00\00\00\00\00\00\00\00")
+ (data (i32.const 588) "\1c\00\00\00\00\00\00\00\00\00\00\00\01\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00")
+ (data (i32.const 624) "\r\00\00\00 \00\00\00 \00\00\00 \00\00\00\00\00\00\00\02\19\00\00\00\00\00\00 \00\00\00 \00\00\00\02A\00\00\02\t\00\00\00\00\00\00\00\00\00\00\00\00\00\00")
  (table $0 2 2 funcref)
  (elem $0 (i32.const 1) $start:infer-generic~anonymous|0)
  (export "test1" (func $infer-generic/test1))
@@ -2286,6 +2289,94 @@
   local.get $a
   return
  )
+ (func $~lib/rt/__newBuffer (param $size i32) (param $id i32) (param $data i32) (result i32)
+  (local $buffer i32)
+  local.get $size
+  local.get $id
+  call $~lib/rt/itcms/__new
+  local.set $buffer
+  local.get $data
+  if
+   local.get $buffer
+   local.get $data
+   local.get $size
+   memory.copy $0 $0
+  end
+  local.get $buffer
+  return
+ )
+ (func $~lib/rt/itcms/__link (param $parentPtr i32) (param $childPtr i32) (param $expectMultiple i32)
+  (local $child i32)
+  (local $parent i32)
+  (local $parentColor i32)
+  local.get $childPtr
+  i32.eqz
+  if
+   return
+  end
+  i32.const 1
+  drop
+  local.get $parentPtr
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 272
+   i32.const 295
+   i32.const 14
+   call $~lib/builtins/abort
+   unreachable
+  end
+  local.get $childPtr
+  i32.const 20
+  i32.sub
+  local.set $child
+  local.get $child
+  call $~lib/rt/itcms/Object#get:color
+  global.get $~lib/rt/itcms/white
+  i32.eq
+  if
+   local.get $parentPtr
+   i32.const 20
+   i32.sub
+   local.set $parent
+   local.get $parent
+   call $~lib/rt/itcms/Object#get:color
+   local.set $parentColor
+   local.get $parentColor
+   global.get $~lib/rt/itcms/white
+   i32.eqz
+   i32.eq
+   if
+    local.get $expectMultiple
+    if
+     local.get $parent
+     call $~lib/rt/itcms/Object#makeGray
+    else
+     local.get $child
+     call $~lib/rt/itcms/Object#makeGray
+    end
+   else
+    local.get $parentColor
+    i32.const 3
+    i32.eq
+    if (result i32)
+     global.get $~lib/rt/itcms/state
+     i32.const 1
+     i32.eq
+    else
+     i32.const 0
+    end
+    if
+     local.get $child
+     call $~lib/rt/itcms/Object#makeGray
+    end
+   end
+  end
+ )
+ (func $infer-generic/InferByExtendType<~lib/string/String>#foo<~lib/array/Array<~lib/string/String>> (param $this i32) (param $a i32) (result i32)
+  local.get $a
+  return
+ )
  (func $infer-generic/inferPlain<f32> (param $arr f32) (result f32)
   local.get $arr
   return
@@ -2318,6 +2409,13 @@
  (func $~lib/rt/__visit_globals (param $0 i32)
   (local $1 i32)
   global.get $infer-generic/arr
+  local.tee $1
+  if
+   local.get $1
+   local.get $0
+   call $~lib/rt/itcms/__visit
+  end
+  global.get $infer-generic/r
   local.tee $1
   if
    local.get $1
@@ -2372,6 +2470,38 @@
   local.get $1
   call $~lib/function/Function<%28bool%2Cf32%2Ci32%2C~lib/array/Array<f32>%29=>bool>#__visit
  )
+ (func $~lib/array/Array<~lib/string/String>#get:dataStart (param $this i32) (result i32)
+  local.get $this
+  i32.load $0 offset=4
+ )
+ (func $~lib/array/Array<~lib/string/String>#get:length_ (param $this i32) (result i32)
+  local.get $this
+  i32.load $0 offset=12
+ )
+ (func $~lib/array/Array<~lib/string/String>#get:buffer (param $this i32) (result i32)
+  local.get $this
+  i32.load $0
+ )
+ (func $~lib/array/Array<~lib/string/String>~visit (param $0 i32) (param $1 i32)
+  local.get $0
+  local.get $1
+  call $~lib/object/Object~visit
+  local.get $0
+  local.get $1
+  call $~lib/array/Array<~lib/string/String>#__visit
+ )
+ (func $~lib/array/Array<i32>#get:buffer (param $this i32) (result i32)
+  local.get $this
+  i32.load $0
+ )
+ (func $~lib/array/Array<i32>~visit (param $0 i32) (param $1 i32)
+  local.get $0
+  local.get $1
+  call $~lib/object/Object~visit
+  local.get $0
+  local.get $1
+  call $~lib/array/Array<i32>#__visit
+ )
  (func $~lib/function/Function<%28%29=>f64>#get:_env (param $this i32) (result i32)
   local.get $this
   i32.load $0 offset=4
@@ -2413,40 +2543,55 @@
    block $~lib/function/Function<%28f32%2Ci32%29=>f64>
     block $~lib/function/Function<%28f32%29=>f64>
      block $~lib/function/Function<%28%29=>f64>
-      block $infer-generic/Ref
-       block $~lib/function/Function<%28bool%2Cf32%2Ci32%2C~lib/array/Array<f32>%29=>bool>
-        block $~lib/array/Array<f32>
-         block $~lib/arraybuffer/ArrayBufferView
-          block $~lib/string/String
-           block $~lib/arraybuffer/ArrayBuffer
-            block $~lib/object/Object
-             local.get $0
-             i32.const 8
-             i32.sub
-             i32.load $0
-             br_table $~lib/object/Object $~lib/arraybuffer/ArrayBuffer $~lib/string/String $~lib/arraybuffer/ArrayBufferView $~lib/array/Array<f32> $~lib/function/Function<%28bool%2Cf32%2Ci32%2C~lib/array/Array<f32>%29=>bool> $infer-generic/Ref $~lib/function/Function<%28%29=>f64> $~lib/function/Function<%28f32%29=>f64> $~lib/function/Function<%28f32%2Ci32%29=>f64> $invalid
+      block $~lib/array/Array<i32>
+       block $~lib/array/Array<~lib/string/String>
+        block $infer-generic/InferByExtendType<~lib/string/String>
+         block $infer-generic/Ref
+          block $~lib/function/Function<%28bool%2Cf32%2Ci32%2C~lib/array/Array<f32>%29=>bool>
+           block $~lib/array/Array<f32>
+            block $~lib/arraybuffer/ArrayBufferView
+             block $~lib/string/String
+              block $~lib/arraybuffer/ArrayBuffer
+               block $~lib/object/Object
+                local.get $0
+                i32.const 8
+                i32.sub
+                i32.load $0
+                br_table $~lib/object/Object $~lib/arraybuffer/ArrayBuffer $~lib/string/String $~lib/arraybuffer/ArrayBufferView $~lib/array/Array<f32> $~lib/function/Function<%28bool%2Cf32%2Ci32%2C~lib/array/Array<f32>%29=>bool> $infer-generic/Ref $infer-generic/InferByExtendType<~lib/string/String> $~lib/array/Array<~lib/string/String> $~lib/array/Array<i32> $~lib/function/Function<%28%29=>f64> $~lib/function/Function<%28f32%29=>f64> $~lib/function/Function<%28f32%2Ci32%29=>f64> $invalid
+               end
+               return
+              end
+              return
+             end
+             return
             end
+            local.get $0
+            local.get $1
+            call $~lib/arraybuffer/ArrayBufferView~visit
             return
            end
+           local.get $0
+           local.get $1
+           call $~lib/array/Array<f32>~visit
            return
           end
+          local.get $0
+          local.get $1
+          call $~lib/function/Function<%28bool%2Cf32%2Ci32%2C~lib/array/Array<f32>%29=>bool>~visit
           return
          end
-         local.get $0
-         local.get $1
-         call $~lib/arraybuffer/ArrayBufferView~visit
          return
         end
-        local.get $0
-        local.get $1
-        call $~lib/array/Array<f32>~visit
         return
        end
        local.get $0
        local.get $1
-       call $~lib/function/Function<%28bool%2Cf32%2Ci32%2C~lib/array/Array<f32>%29=>bool>~visit
+       call $~lib/array/Array<~lib/string/String>~visit
        return
       end
+      local.get $0
+      local.get $1
+      call $~lib/array/Array<i32>~visit
       return
      end
      local.get $0
@@ -2474,8 +2619,8 @@
   global.get $~lib/memory/__data_end
   i32.lt_s
   if
-   i32.const 33424
    i32.const 33472
+   i32.const 33520
    i32.const 1
    i32.const 1
    call $~lib/builtins/abort
@@ -2618,11 +2763,51 @@
   global.set $~lib/memory/__stack_pointer
   local.get $1
  )
+ (func $infer-generic/InferByExtendType<~lib/string/String>#constructor (param $this i32) (result i32)
+  (local $1 i32)
+  global.get $~lib/memory/__stack_pointer
+  i32.const 8
+  i32.sub
+  global.set $~lib/memory/__stack_pointer
+  call $~stack_check
+  global.get $~lib/memory/__stack_pointer
+  i64.const 0
+  i64.store $0
+  local.get $this
+  i32.eqz
+  if
+   global.get $~lib/memory/__stack_pointer
+   i32.const 0
+   i32.const 7
+   call $~lib/rt/itcms/__new
+   local.tee $this
+   i32.store $0
+  end
+  global.get $~lib/memory/__stack_pointer
+  local.get $this
+  local.set $1
+  global.get $~lib/memory/__stack_pointer
+  local.get $1
+  i32.store $0 offset=4
+  local.get $1
+  call $~lib/object/Object#constructor
+  local.tee $this
+  i32.store $0
+  local.get $this
+  local.set $1
+  global.get $~lib/memory/__stack_pointer
+  i32.const 8
+  i32.add
+  global.set $~lib/memory/__stack_pointer
+  local.get $1
+ )
  (func $start:infer-generic
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
+  (local $4 i32)
+  (local $5 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 12
   i32.sub
@@ -2647,17 +2832,17 @@
    unreachable
   end
   global.get $infer-generic/arr
-  local.set $3
+  local.set $5
   global.get $~lib/memory/__stack_pointer
-  local.get $3
+  local.get $5
   i32.store $0
-  local.get $3
+  local.get $5
   i32.const 176
-  local.set $3
+  local.set $5
   global.get $~lib/memory/__stack_pointer
-  local.get $3
+  local.get $5
   i32.store $0 offset=4
-  local.get $3
+  local.get $5
   i32.const 0
   call $~lib/array/Array<f32>#reduce<bool>
   drop
@@ -2697,19 +2882,19 @@
   local.tee $2
   i32.store $0 offset=8
   local.get $2
-  local.set $3
+  local.set $5
   global.get $~lib/memory/__stack_pointer
-  local.get $3
+  local.get $5
   i32.store $0 offset=4
-  local.get $3
+  local.get $5
   i32.const 2
   call $infer-generic/Ref#set:x
   local.get $2
-  local.set $3
+  local.set $5
   global.get $~lib/memory/__stack_pointer
-  local.get $3
+  local.get $5
   i32.store $0
-  local.get $3
+  local.get $5
   call $infer-generic/inferDefault<infer-generic/Ref>
   drop
   i32.const 1
@@ -2722,6 +2907,27 @@
    call $~lib/builtins/abort
    unreachable
   end
+  i32.const 0
+  call $infer-generic/InferByExtendType<~lib/string/String>#constructor
+  local.set $5
+  global.get $~lib/memory/__stack_pointer
+  local.get $5
+  i32.store $0
+  local.get $5
+  i32.const 0
+  i32.const 2
+  i32.const 8
+  i32.const 608
+  call $~lib/rt/__newArray
+  local.set $5
+  global.get $~lib/memory/__stack_pointer
+  local.get $5
+  i32.store $0 offset=4
+  local.get $5
+  call $infer-generic/InferByExtendType<~lib/string/String>#foo<~lib/array/Array<~lib/string/String>>
+  global.set $infer-generic/r
+  i32.const 1
+  drop
   global.get $~lib/memory/__stack_pointer
   i32.const 12
   i32.add
@@ -2916,6 +3122,102 @@
   i32.add
   global.set $~lib/memory/__stack_pointer
  )
+ (func $~lib/array/Array<~lib/string/String>#__visit (param $this i32) (param $cookie i32)
+  (local $cur i32)
+  (local $end i32)
+  (local $val i32)
+  (local $5 i32)
+  global.get $~lib/memory/__stack_pointer
+  i32.const 4
+  i32.sub
+  global.set $~lib/memory/__stack_pointer
+  call $~stack_check
+  global.get $~lib/memory/__stack_pointer
+  i32.const 0
+  i32.store $0
+  i32.const 1
+  drop
+  local.get $this
+  local.set $5
+  global.get $~lib/memory/__stack_pointer
+  local.get $5
+  i32.store $0
+  local.get $5
+  call $~lib/array/Array<~lib/string/String>#get:dataStart
+  local.set $cur
+  local.get $cur
+  local.get $this
+  local.set $5
+  global.get $~lib/memory/__stack_pointer
+  local.get $5
+  i32.store $0
+  local.get $5
+  call $~lib/array/Array<~lib/string/String>#get:length_
+  i32.const 2
+  i32.shl
+  i32.add
+  local.set $end
+  loop $while-continue|0
+   local.get $cur
+   local.get $end
+   i32.lt_u
+   if
+    local.get $cur
+    i32.load $0
+    local.set $val
+    local.get $val
+    if
+     local.get $val
+     local.get $cookie
+     call $~lib/rt/itcms/__visit
+    end
+    local.get $cur
+    i32.const 4
+    i32.add
+    local.set $cur
+    br $while-continue|0
+   end
+  end
+  local.get $this
+  local.set $5
+  global.get $~lib/memory/__stack_pointer
+  local.get $5
+  i32.store $0
+  local.get $5
+  call $~lib/array/Array<~lib/string/String>#get:buffer
+  local.get $cookie
+  call $~lib/rt/itcms/__visit
+  global.get $~lib/memory/__stack_pointer
+  i32.const 4
+  i32.add
+  global.set $~lib/memory/__stack_pointer
+ )
+ (func $~lib/array/Array<i32>#__visit (param $this i32) (param $cookie i32)
+  (local $2 i32)
+  global.get $~lib/memory/__stack_pointer
+  i32.const 4
+  i32.sub
+  global.set $~lib/memory/__stack_pointer
+  call $~stack_check
+  global.get $~lib/memory/__stack_pointer
+  i32.const 0
+  i32.store $0
+  i32.const 0
+  drop
+  local.get $this
+  local.set $2
+  global.get $~lib/memory/__stack_pointer
+  local.get $2
+  i32.store $0
+  local.get $2
+  call $~lib/array/Array<i32>#get:buffer
+  local.get $cookie
+  call $~lib/rt/itcms/__visit
+  global.get $~lib/memory/__stack_pointer
+  i32.const 4
+  i32.add
+  global.set $~lib/memory/__stack_pointer
+ )
  (func $~lib/function/Function<%28%29=>f64>#__visit (param $this i32) (param $cookie i32)
   (local $2 i32)
   global.get $~lib/memory/__stack_pointer
@@ -3015,6 +3317,59 @@
   i32.add
   global.set $~lib/memory/__stack_pointer
   local.get $1
+ )
+ (func $~lib/rt/__newArray (param $length i32) (param $alignLog2 i32) (param $id i32) (param $data i32) (result i32)
+  (local $bufferSize i32)
+  (local $buffer i32)
+  (local $array i32)
+  (local $7 i32)
+  global.get $~lib/memory/__stack_pointer
+  i32.const 4
+  i32.sub
+  global.set $~lib/memory/__stack_pointer
+  call $~stack_check
+  global.get $~lib/memory/__stack_pointer
+  i32.const 0
+  i32.store $0
+  local.get $length
+  local.get $alignLog2
+  i32.shl
+  local.set $bufferSize
+  global.get $~lib/memory/__stack_pointer
+  local.get $bufferSize
+  i32.const 1
+  local.get $data
+  call $~lib/rt/__newBuffer
+  local.tee $buffer
+  i32.store $0
+  i32.const 16
+  local.get $id
+  call $~lib/rt/itcms/__new
+  local.set $array
+  local.get $array
+  local.get $buffer
+  i32.store $0
+  local.get $array
+  local.get $buffer
+  i32.const 0
+  call $~lib/rt/itcms/__link
+  local.get $array
+  local.get $buffer
+  i32.store $0 offset=4
+  local.get $array
+  local.get $bufferSize
+  i32.store $0 offset=8
+  local.get $array
+  local.get $length
+  i32.store $0 offset=12
+  local.get $array
+  local.set $7
+  global.get $~lib/memory/__stack_pointer
+  i32.const 4
+  i32.add
+  global.set $~lib/memory/__stack_pointer
+  local.get $7
+  return
  )
  (func $export:infer-generic/test2 (param $0 i32) (result i32)
   (local $1 i32)

--- a/tests/compiler/infer-generic.release.wat
+++ b/tests/compiler/infer-generic.release.wat
@@ -4,11 +4,11 @@
  (type $i32_f32_i32_i32_=>_i32 (func (param i32 f32 i32 i32) (result i32)))
  (type $i32_i32_=>_none (func (param i32 i32)))
  (type $i32_i32_=>_i32 (func (param i32 i32) (result i32)))
+ (type $i32_=>_i32 (func (param i32) (result i32)))
  (type $i32_i32_i32_i32_=>_none (func (param i32 i32 i32 i32)))
  (type $i32_i32_i32_=>_none (func (param i32 i32 i32)))
  (type $none_=>_i32 (func (result i32)))
  (type $f32_=>_f32 (func (param f32) (result f32)))
- (type $i32_=>_i32 (func (param i32) (result i32)))
  (import "env" "abort" (func $~lib/builtins/abort (param i32 i32 i32 i32)))
  (global $~lib/rt/itcms/total (mut i32) (i32.const 0))
  (global $~lib/rt/itcms/threshold (mut i32) (i32.const 0))
@@ -20,7 +20,8 @@
  (global $~lib/rt/itcms/white (mut i32) (i32.const 0))
  (global $~lib/rt/itcms/fromSpace (mut i32) (i32.const 0))
  (global $~lib/rt/tlsf/ROOT (mut i32) (i32.const 0))
- (global $~lib/memory/__stack_pointer (mut i32) (i32.const 34428))
+ (global $infer-generic/r (mut i32) (i32.const 0))
+ (global $~lib/memory/__stack_pointer (mut i32) (i32.const 34472))
  (memory $0 1)
  (data (i32.const 1036) "<")
  (data (i32.const 1048) "\02\00\00\00 \00\00\00i\00n\00f\00e\00r\00-\00g\00e\00n\00e\00r\00i\00c\00.\00t\00s")
@@ -40,7 +41,9 @@
  (data (i32.const 1480) "\02\00\00\00\14\00\00\00~\00l\00i\00b\00/\00r\00t\00.\00t\00s")
  (data (i32.const 1548) "<")
  (data (i32.const 1560) "\02\00\00\00\1e\00\00\00~\00l\00i\00b\00/\00r\00t\00/\00t\00l\00s\00f\00.\00t\00s")
- (data (i32.const 1616) "\n\00\00\00 \00\00\00 \00\00\00 \00\00\00\00\00\00\00\02\19\00\00\00\00\00\00 ")
+ (data (i32.const 1612) "\1c")
+ (data (i32.const 1624) "\01")
+ (data (i32.const 1648) "\r\00\00\00 \00\00\00 \00\00\00 \00\00\00\00\00\00\00\02\19\00\00\00\00\00\00 \00\00\00 \00\00\00\02A\00\00\02\t")
  (table $0 2 2 funcref)
  (elem $0 (i32.const 1) $start:infer-generic~anonymous|0)
  (export "test1" (func $infer-generic/test1))
@@ -64,6 +67,12 @@
   (local $1 i32)
   i32.const 1152
   call $byn-split-outlined-A$~lib/rt/itcms/__visit
+  global.get $infer-generic/r
+  local.tee $0
+  if
+   local.get $0
+   call $byn-split-outlined-A$~lib/rt/itcms/__visit
+  end
   i32.const 1424
   call $byn-split-outlined-A$~lib/rt/itcms/__visit
   i32.const 1232
@@ -141,7 +150,7 @@
     i32.load $0 offset=8
     i32.eqz
     local.get $0
-    i32.const 34428
+    i32.const 34472
     i32.lt_u
     i32.and
     i32.eqz
@@ -190,7 +199,7 @@
    i32.const 1
   else
    local.get $1
-   i32.const 1616
+   i32.const 1648
    i32.load $0
    i32.gt_u
    if
@@ -204,7 +213,7 @@
    local.get $1
    i32.const 2
    i32.shl
-   i32.const 1620
+   i32.const 1652
    i32.add
    i32.load $0
    i32.const 32
@@ -769,10 +778,10 @@
   if
    unreachable
   end
-  i32.const 34432
+  i32.const 34480
   i32.const 0
   i32.store $0
-  i32.const 36000
+  i32.const 36048
   i32.const 0
   i32.store $0
   loop $for-loop|0
@@ -783,7 +792,7 @@
     local.get $0
     i32.const 2
     i32.shl
-    i32.const 34432
+    i32.const 34480
     i32.add
     i32.const 0
     i32.store $0 offset=4
@@ -801,7 +810,7 @@
       i32.add
       i32.const 2
       i32.shl
-      i32.const 34432
+      i32.const 34480
       i32.add
       i32.const 0
       i32.store $0 offset=96
@@ -819,13 +828,13 @@
     br $for-loop|0
    end
   end
-  i32.const 34432
-  i32.const 36004
+  i32.const 34480
+  i32.const 36052
   memory.size $0
   i32.const 16
   i32.shl
   call $~lib/rt/tlsf/addMemory
-  i32.const 34432
+  i32.const 34480
   global.set $~lib/rt/tlsf/ROOT
  )
  (func $~lib/rt/itcms/step (result i32)
@@ -910,7 +919,7 @@
      local.set $0
      loop $while-continue|0
       local.get $0
-      i32.const 34428
+      i32.const 34472
       i32.lt_u
       if
        local.get $0
@@ -1010,7 +1019,7 @@
      unreachable
     end
     local.get $0
-    i32.const 34428
+    i32.const 34472
     i32.lt_u
     if
      local.get $0
@@ -1033,7 +1042,7 @@
      i32.const 4
      i32.add
      local.tee $0
-     i32.const 34428
+     i32.const 34472
      i32.ge_u
      if
       global.get $~lib/rt/tlsf/ROOT
@@ -1530,35 +1539,84 @@
  (func $infer-generic/test1 (param $0 f32) (result f32)
   local.get $0
  )
+ (func $~lib/array/Array<f32>~visit (param $0 i32)
+  (local $1 i32)
+  global.get $~lib/memory/__stack_pointer
+  i32.const 4
+  i32.sub
+  global.set $~lib/memory/__stack_pointer
+  global.get $~lib/memory/__stack_pointer
+  i32.const 1704
+  i32.lt_s
+  if
+   i32.const 34496
+   i32.const 34544
+   i32.const 1
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  global.get $~lib/memory/__stack_pointer
+  local.tee $1
+  i32.const 0
+  i32.store $0
+  local.get $1
+  local.get $0
+  i32.store $0
+  local.get $0
+  i32.load $0
+  local.tee $0
+  if
+   local.get $0
+   call $byn-split-outlined-A$~lib/rt/itcms/__visit
+  end
+  global.get $~lib/memory/__stack_pointer
+  i32.const 4
+  i32.add
+  global.set $~lib/memory/__stack_pointer
+ )
  (func $~lib/rt/__visit_members (param $0 i32)
   (local $1 i32)
+  (local $2 i32)
+  (local $3 i32)
   block $folding-inner1
    block $folding-inner0
     block $invalid
-     block $infer-generic/Ref
-      block $~lib/array/Array<f32>
-       block $~lib/arraybuffer/ArrayBufferView
-        block $~lib/string/String
-         block $~lib/arraybuffer/ArrayBuffer
-          block $~lib/object/Object
+     block $~lib/array/Array<i32>
+      block $~lib/array/Array<~lib/string/String>
+       block $infer-generic/InferByExtendType<~lib/string/String>
+        block $infer-generic/Ref
+         block $~lib/array/Array<f32>
+          block $~lib/arraybuffer/ArrayBufferView
+           block $~lib/string/String
+            block $~lib/arraybuffer/ArrayBuffer
+             block $~lib/object/Object
+              local.get $0
+              i32.const 8
+              i32.sub
+              i32.load $0
+              br_table $~lib/object/Object $~lib/arraybuffer/ArrayBuffer $~lib/string/String $~lib/arraybuffer/ArrayBufferView $~lib/array/Array<f32> $folding-inner0 $infer-generic/Ref $infer-generic/InferByExtendType<~lib/string/String> $~lib/array/Array<~lib/string/String> $~lib/array/Array<i32> $folding-inner0 $folding-inner0 $folding-inner0 $invalid
+             end
+             return
+            end
+            return
+           end
+           return
+          end
+          local.get $0
+          i32.load $0
+          local.tee $0
+          if
            local.get $0
-           i32.const 8
-           i32.sub
-           i32.load $0
-           br_table $~lib/object/Object $~lib/arraybuffer/ArrayBuffer $~lib/string/String $~lib/arraybuffer/ArrayBufferView $~lib/array/Array<f32> $folding-inner0 $infer-generic/Ref $folding-inner0 $folding-inner0 $folding-inner0 $invalid
+           call $byn-split-outlined-A$~lib/rt/itcms/__visit
           end
           return
          end
+         local.get $0
+         call $~lib/array/Array<f32>~visit
          return
         end
         return
-       end
-       local.get $0
-       i32.load $0
-       local.tee $0
-       if
-        local.get $0
-        call $byn-split-outlined-A$~lib/rt/itcms/__visit
        end
        return
       end
@@ -1567,14 +1625,49 @@
       i32.sub
       global.set $~lib/memory/__stack_pointer
       global.get $~lib/memory/__stack_pointer
-      i32.const 1660
+      i32.const 1704
       i32.lt_s
       br_if $folding-inner1
       global.get $~lib/memory/__stack_pointer
-      local.tee $1
+      local.tee $2
       i32.const 0
       i32.store $0
+      local.get $2
+      local.get $0
+      i32.store $0
+      local.get $0
+      i32.load $0 offset=4
+      local.set $1
+      local.get $2
+      local.get $0
+      i32.store $0
       local.get $1
+      local.get $0
+      i32.load $0 offset=12
+      i32.const 2
+      i32.shl
+      i32.add
+      local.set $2
+      loop $while-continue|0
+       local.get $1
+       local.get $2
+       i32.lt_u
+       if
+        local.get $1
+        i32.load $0
+        local.tee $3
+        if
+         local.get $3
+         call $byn-split-outlined-A$~lib/rt/itcms/__visit
+        end
+        local.get $1
+        i32.const 4
+        i32.add
+        local.set $1
+        br $while-continue|0
+       end
+      end
+      global.get $~lib/memory/__stack_pointer
       local.get $0
       i32.store $0
       local.get $0
@@ -1590,6 +1683,8 @@
       global.set $~lib/memory/__stack_pointer
       return
      end
+     local.get $0
+     call $~lib/array/Array<f32>~visit
      return
     end
     unreachable
@@ -1599,7 +1694,7 @@
    i32.sub
    global.set $~lib/memory/__stack_pointer
    global.get $~lib/memory/__stack_pointer
-   i32.const 1660
+   i32.const 1704
    i32.lt_s
    br_if $folding-inner1
    global.get $~lib/memory/__stack_pointer
@@ -1622,8 +1717,8 @@
    global.set $~lib/memory/__stack_pointer
    return
   end
-  i32.const 34448
   i32.const 34496
+  i32.const 34544
   i32.const 1
   i32.const 1
   call $~lib/builtins/abort
@@ -1641,7 +1736,7 @@
   global.set $~lib/memory/__stack_pointer
   block $folding-inner0
    global.get $~lib/memory/__stack_pointer
-   i32.const 1660
+   i32.const 1704
    i32.lt_s
    br_if $folding-inner0
    global.get $~lib/memory/__stack_pointer
@@ -1662,7 +1757,7 @@
    i32.sub
    global.set $~lib/memory/__stack_pointer
    global.get $~lib/memory/__stack_pointer
-   i32.const 1660
+   i32.const 1704
    i32.lt_s
    br_if $folding-inner0
    global.get $~lib/memory/__stack_pointer
@@ -1730,7 +1825,7 @@
    memory.size $0
    i32.const 16
    i32.shl
-   i32.const 34428
+   i32.const 34472
    i32.sub
    i32.const 1
    i32.shr_u
@@ -1760,13 +1855,62 @@
    i32.const 1520
    global.set $~lib/rt/itcms/fromSpace
    global.get $~lib/memory/__stack_pointer
-   local.set $1
+   local.set $0
    global.get $~lib/memory/__stack_pointer
    i32.const 8
    i32.sub
    global.set $~lib/memory/__stack_pointer
    global.get $~lib/memory/__stack_pointer
-   i32.const 1660
+   i32.const 1704
+   i32.lt_s
+   br_if $folding-inner0
+   global.get $~lib/memory/__stack_pointer
+   local.tee $1
+   i64.const 0
+   i64.store $0
+   local.get $1
+   i32.const 4
+   i32.const 6
+   call $~lib/rt/itcms/__new
+   local.tee $1
+   i32.store $0
+   global.get $~lib/memory/__stack_pointer
+   local.tee $3
+   local.get $1
+   i32.store $0 offset=4
+   local.get $3
+   local.get $1
+   call $~lib/object/Object#constructor
+   local.tee $1
+   i32.store $0
+   global.get $~lib/memory/__stack_pointer
+   local.get $1
+   i32.store $0 offset=4
+   local.get $1
+   i32.const 0
+   i32.store $0
+   global.get $~lib/memory/__stack_pointer
+   i32.const 8
+   i32.add
+   global.set $~lib/memory/__stack_pointer
+   local.get $0
+   local.get $1
+   i32.store $0 offset=8
+   global.get $~lib/memory/__stack_pointer
+   local.get $1
+   i32.store $0 offset=4
+   local.get $1
+   i32.const 2
+   i32.store $0
+   global.get $~lib/memory/__stack_pointer
+   local.get $1
+   i32.store $0
+   global.get $~lib/memory/__stack_pointer
+   i32.const 8
+   i32.sub
+   global.set $~lib/memory/__stack_pointer
+   global.get $~lib/memory/__stack_pointer
+   i32.const 1704
    i32.lt_s
    br_if $folding-inner0
    global.get $~lib/memory/__stack_pointer
@@ -1774,77 +1918,170 @@
    i64.const 0
    i64.store $0
    local.get $0
-   i32.const 4
-   i32.const 6
+   i32.const 0
+   i32.const 7
    call $~lib/rt/itcms/__new
    local.tee $0
    i32.store $0
    global.get $~lib/memory/__stack_pointer
-   local.tee $3
+   local.tee $1
    local.get $0
    i32.store $0 offset=4
-   local.get $3
-   i32.const 4
-   i32.sub
-   global.set $~lib/memory/__stack_pointer
-   global.get $~lib/memory/__stack_pointer
-   i32.const 1660
-   i32.lt_s
-   br_if $folding-inner0
-   global.get $~lib/memory/__stack_pointer
-   i32.const 0
-   i32.store $0
+   local.get $1
    local.get $0
-   i32.eqz
-   if
-    global.get $~lib/memory/__stack_pointer
-    i32.const 0
-    i32.const 0
-    call $~lib/rt/itcms/__new
-    local.tee $0
-    i32.store $0
-   end
-   global.get $~lib/memory/__stack_pointer
-   i32.const 4
-   i32.add
-   global.set $~lib/memory/__stack_pointer
-   local.get $3
-   local.get $0
-   i32.store $0
-   global.get $~lib/memory/__stack_pointer
-   local.get $0
-   i32.store $0 offset=4
-   local.get $0
-   i32.const 0
+   call $~lib/object/Object#constructor
+   local.tee $0
    i32.store $0
    global.get $~lib/memory/__stack_pointer
    i32.const 8
    i32.add
    global.set $~lib/memory/__stack_pointer
-   local.get $1
+   global.get $~lib/memory/__stack_pointer
    local.get $0
+   i32.store $0
+   global.get $~lib/memory/__stack_pointer
+   i32.const 4
+   i32.sub
+   global.set $~lib/memory/__stack_pointer
+   global.get $~lib/memory/__stack_pointer
+   i32.const 1704
+   i32.lt_s
+   br_if $folding-inner0
+   global.get $~lib/memory/__stack_pointer
+   local.tee $0
+   i32.const 0
+   i32.store $0
+   i32.const 0
+   i32.const 1
+   call $~lib/rt/itcms/__new
+   local.tee $1
+   i32.const 1632
+   i32.const 0
+   memory.copy $0 $0
+   local.get $0
+   local.get $1
+   i32.store $0
+   i32.const 16
+   i32.const 8
+   call $~lib/rt/itcms/__new
+   local.tee $0
+   local.get $1
+   i32.store $0
+   local.get $1
+   if
+    local.get $0
+    i32.eqz
+    if
+     i32.const 0
+     i32.const 1296
+     i32.const 295
+     i32.const 14
+     call $~lib/builtins/abort
+     unreachable
+    end
+    global.get $~lib/rt/itcms/white
+    local.get $1
+    i32.const 20
+    i32.sub
+    local.tee $3
+    i32.load $0 offset=4
+    i32.const 3
+    i32.and
+    i32.eq
+    if
+     local.get $0
+     i32.const 20
+     i32.sub
+     i32.load $0 offset=4
+     i32.const 3
+     i32.and
+     local.tee $4
+     global.get $~lib/rt/itcms/white
+     i32.eqz
+     i32.eq
+     if
+      local.get $3
+      call $~lib/rt/itcms/Object#makeGray
+     else
+      global.get $~lib/rt/itcms/state
+      i32.const 1
+      i32.eq
+      local.get $4
+      i32.const 3
+      i32.eq
+      i32.and
+      if
+       local.get $3
+       call $~lib/rt/itcms/Object#makeGray
+      end
+     end
+    end
+   end
+   local.get $0
+   local.get $1
+   i32.store $0 offset=4
+   local.get $0
+   i32.const 0
    i32.store $0 offset=8
+   local.get $0
+   i32.const 0
+   i32.store $0 offset=12
+   global.get $~lib/memory/__stack_pointer
+   i32.const 4
+   i32.add
+   global.set $~lib/memory/__stack_pointer
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store $0 offset=4
    local.get $0
-   i32.const 2
-   i32.store $0
-   global.get $~lib/memory/__stack_pointer
-   local.get $0
-   i32.store $0
+   global.set $infer-generic/r
    global.get $~lib/memory/__stack_pointer
    i32.const 12
    i32.add
    global.set $~lib/memory/__stack_pointer
    return
   end
-  i32.const 34448
   i32.const 34496
+  i32.const 34544
   i32.const 1
   i32.const 1
   call $~lib/builtins/abort
   unreachable
+ )
+ (func $~lib/object/Object#constructor (param $0 i32) (result i32)
+  global.get $~lib/memory/__stack_pointer
+  i32.const 4
+  i32.sub
+  global.set $~lib/memory/__stack_pointer
+  global.get $~lib/memory/__stack_pointer
+  i32.const 1704
+  i32.lt_s
+  if
+   i32.const 34496
+   i32.const 34544
+   i32.const 1
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  global.get $~lib/memory/__stack_pointer
+  i32.const 0
+  i32.store $0
+  local.get $0
+  i32.eqz
+  if
+   global.get $~lib/memory/__stack_pointer
+   i32.const 0
+   i32.const 0
+   call $~lib/rt/itcms/__new
+   local.tee $0
+   i32.store $0
+  end
+  global.get $~lib/memory/__stack_pointer
+  i32.const 4
+  i32.add
+  global.set $~lib/memory/__stack_pointer
+  local.get $0
  )
  (func $export:infer-generic/test2 (param $0 i32) (result i32)
   (local $1 i32)
@@ -1854,7 +2091,7 @@
   global.set $~lib/memory/__stack_pointer
   block $folding-inner0
    global.get $~lib/memory/__stack_pointer
-   i32.const 1660
+   i32.const 1704
    i32.lt_s
    br_if $folding-inner0
    global.get $~lib/memory/__stack_pointer
@@ -1866,7 +2103,7 @@
    i32.sub
    global.set $~lib/memory/__stack_pointer
    global.get $~lib/memory/__stack_pointer
-   i32.const 1660
+   i32.const 1704
    i32.lt_s
    br_if $folding-inner0
    global.get $~lib/memory/__stack_pointer
@@ -1887,8 +2124,8 @@
    local.get $0
    return
   end
-  i32.const 34448
   i32.const 34496
+  i32.const 34544
   i32.const 1
   i32.const 1
   call $~lib/builtins/abort
@@ -1902,7 +2139,7 @@
   global.set $~lib/memory/__stack_pointer
   block $folding-inner0
    global.get $~lib/memory/__stack_pointer
-   i32.const 1660
+   i32.const 1704
    i32.lt_s
    br_if $folding-inner0
    global.get $~lib/memory/__stack_pointer
@@ -1914,7 +2151,7 @@
    i32.sub
    global.set $~lib/memory/__stack_pointer
    global.get $~lib/memory/__stack_pointer
-   i32.const 1660
+   i32.const 1704
    i32.lt_s
    br_if $folding-inner0
    global.get $~lib/memory/__stack_pointer
@@ -1951,8 +2188,8 @@
    global.set $~lib/memory/__stack_pointer
    return
   end
-  i32.const 34448
   i32.const 34496
+  i32.const 34544
   i32.const 1
   i32.const 1
   call $~lib/builtins/abort

--- a/tests/compiler/infer-generic.ts
+++ b/tests/compiler/infer-generic.ts
@@ -74,3 +74,11 @@ assert(inferDefault({ x: 2 }) instanceof Ref);
 export function inferAssert(v: Ref | null): void {
   assert(v).x;
 }
+
+class InferByExtendType<T> {
+  foo<U extends Array<T> = Array<T>>(a: U): U {
+    return a;
+  }
+}
+const r = new InferByExtendType<string>().foo([]); // `r` should infer as Array<string> but it deduced as `Array<usize>` instead
+assert(r instanceof Array<string>);


### PR DESCRIPTION
fix #2405 

concept of this PR is when inferring generic, use `extendType` as default type. And then use this default type to resolver argument type and get `targetType`. And then use `targetType` as `ctxType` to resolve argument expression.

For most of `resolveExpression`, `ctxType` do not have any effect, but for expression like `[]`, `ctxType` is effective