### PR TITLE
fix: add BLOCK_OVERHEAD before round size

### DIFF
--- a/std/assembly/rt/tlsf.ts
+++ b/std/assembly/rt/tlsf.ts
@@ -427,16 +427,16 @@ function growMemory(root: Root, size: usize): void {
     unreachable();
     return;
   }
-  // and additional BLOCK_OVERHEAD must be taken into account. If we are going
-  // to merge with the tail block, that's one time, otherwise it's two times.
-  let pagesBefore = memory.size();
-  size += BLOCK_OVERHEAD << usize((<usize>pagesBefore << 16) - BLOCK_OVERHEAD != changetype<usize>(GETTAIL(root)));
   // Here, both rounding performed in searchBlock ...
   const halfMaxSize = BLOCK_MAXSIZE >> 1;
   if (size < halfMaxSize) { // don't round last fl
     const invRound = (sizeof<usize>() * 8 - 1) - SL_BITS;
-    size += (1 << (invRound - clz<usize>(size))) - 1; // size should be larger than 15
+    size += (1 << (invRound - clz<usize>(size))) - 1;
   }
+  // and additional BLOCK_OVERHEAD must be taken into account. If we are going
+  // to merge with the tail block, that's one time, otherwise it's two times.
+  let pagesBefore = memory.size();
+  size += BLOCK_OVERHEAD << usize((<usize>pagesBefore << 16) - BLOCK_OVERHEAD != changetype<usize>(GETTAIL(root)));
   let pagesNeeded = <i32>(((size + 0xffff) & ~0xffff) >>> 16);
   let pagesWanted = max(pagesBefore, pagesNeeded); // double memory
   if (memory.grow(pagesWanted) < 0) {

--- a/std/assembly/rt/tlsf.ts
+++ b/std/assembly/rt/tlsf.ts
@@ -432,7 +432,7 @@ function growMemory(root: Root, size: usize): void {
     return;
   }
   // Here, both rounding performed in searchBlock ...
-  if (size > SB_SIZE) { // don't round last fl
+  if (size >= SB_SIZE) {
     size = roundSize(size);
   }
   // and additional BLOCK_OVERHEAD must be taken into account. If we are going

--- a/std/assembly/rt/tlsf.ts
+++ b/std/assembly/rt/tlsf.ts
@@ -427,16 +427,16 @@ function growMemory(root: Root, size: usize): void {
     unreachable();
     return;
   }
-  // Here, both rounding performed in searchBlock ...
-  const halfMaxSize = BLOCK_MAXSIZE >> 1;
-  if (size < halfMaxSize) { // don't round last fl
-    const invRound = (sizeof<usize>() * 8 - 1) - SL_BITS;
-    size += (1 << (invRound - clz<usize>(size))) - 1;
-  }
   // and additional BLOCK_OVERHEAD must be taken into account. If we are going
   // to merge with the tail block, that's one time, otherwise it's two times.
   let pagesBefore = memory.size();
   size += BLOCK_OVERHEAD << usize((<usize>pagesBefore << 16) - BLOCK_OVERHEAD != changetype<usize>(GETTAIL(root)));
+  // Here, both rounding performed in searchBlock ...
+  const halfMaxSize = BLOCK_MAXSIZE >> 1;
+  if (size < halfMaxSize) { // don't round last fl
+    const invRound = (sizeof<usize>() * 8 - 1) - SL_BITS;
+    size += (1 << (invRound - clz<usize>(size))) - 1; // size should be larger than 15
+  }
   let pagesNeeded = <i32>(((size + 0xffff) & ~0xffff) >>> 16);
   let pagesWanted = max(pagesBefore, pagesNeeded); // double memory
   if (memory.grow(pagesWanted) < 0) {

--- a/std/assembly/rt/tlsf.ts
+++ b/std/assembly/rt/tlsf.ts
@@ -307,6 +307,15 @@ function removeBlock(root: Root, block: Block): void {
   // must perform those updates.
 }
 
+function roundSize(size: usize): usize {
+  const halfMaxSize = BLOCK_MAXSIZE >> 1; // don't round last fl
+  const inv: usize = sizeof<usize>() * 8 - 1;
+  const invRound = inv - SL_BITS;
+  return size < halfMaxSize
+    ? size + (1 << (invRound - clz<usize>(size))) - 1
+    : size;
+}
+
 /** Searches for a free block of at least the specified size. */
 function searchBlock(root: Root, size: usize): Block | null {
   // size was already asserted by caller
@@ -317,13 +326,8 @@ function searchBlock(root: Root, size: usize): Block | null {
     fl = 0;
     sl = <u32>(size >> AL_BITS);
   } else {
-    const halfMaxSize = BLOCK_MAXSIZE >> 1; // don't round last fl
-    const inv: usize = sizeof<usize>() * 8 - 1;
-    const invRound = inv - SL_BITS;
-    let requestSize = size < halfMaxSize
-      ? size + (1 << (invRound - clz<usize>(size))) - 1
-      : size;
-    fl = inv - clz<usize>(requestSize);
+    const requestSize = roundSize(size);
+    fl = sizeof<usize>() * 8 - 1 - clz<usize>(requestSize);
     sl = <u32>((requestSize >> (fl - SL_BITS)) ^ (1 << SL_BITS));
     fl -= SB_BITS - 1;
   }
@@ -428,10 +432,8 @@ function growMemory(root: Root, size: usize): void {
     return;
   }
   // Here, both rounding performed in searchBlock ...
-  const halfMaxSize = BLOCK_MAXSIZE >> 1;
-  if (size < halfMaxSize) { // don't round last fl
-    const invRound = (sizeof<usize>() * 8 - 1) - SL_BITS;
-    size += (1 << (invRound - clz<usize>(size))) - 1;
+  if (size > SB_SIZE) { // don't round last fl
+    size = roundSize(size);
   }
   // and additional BLOCK_OVERHEAD must be taken into account. If we are going
   // to merge with the tail block, that's one time, otherwise it's two times.

--- a/tests/compiler/bindings/esm.debug.wat
+++ b/tests/compiler/bindings/esm.debug.wat
@@ -2026,22 +2026,6 @@
   (local $pagesAfter i32)
   i32.const 0
   drop
-  local.get $size
-  i32.const 536870910
-  i32.lt_u
-  if
-   local.get $size
-   i32.const 1
-   i32.const 27
-   local.get $size
-   i32.clz
-   i32.sub
-   i32.shl
-   i32.const 1
-   i32.sub
-   i32.add
-   local.set $size
-  end
   memory.size $0
   local.set $pagesBefore
   local.get $size
@@ -2062,6 +2046,22 @@
   i32.shl
   i32.add
   local.set $size
+  local.get $size
+  i32.const 536870910
+  i32.lt_u
+  if
+   local.get $size
+   i32.const 1
+   i32.const 27
+   local.get $size
+   i32.clz
+   i32.sub
+   i32.shl
+   i32.const 1
+   i32.sub
+   i32.add
+   local.set $size
+  end
   local.get $size
   i32.const 65535
   i32.add

--- a/tests/compiler/bindings/esm.release.wat
+++ b/tests/compiler/bindings/esm.release.wat
@@ -1386,7 +1386,7 @@
    call $~lib/rt/tlsf/initialize
   end
   global.get $~lib/rt/tlsf/ROOT
-  local.set $4
+  local.set $3
   local.get $0
   i32.const 16
   i32.add
@@ -1401,7 +1401,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $4
+  local.get $3
   i32.const 12
   local.get $2
   i32.const 19
@@ -1421,8 +1421,9 @@
   if
    memory.size $0
    local.tee $2
+   local.get $5
    i32.const 4
-   local.get $4
+   local.get $3
    i32.load $0 offset=1568
    local.get $2
    i32.const 16
@@ -1431,38 +1432,40 @@
    i32.sub
    i32.ne
    i32.shl
-   local.get $5
-   i32.const 1
-   i32.const 27
-   local.get $5
-   i32.clz
-   i32.sub
-   i32.shl
-   i32.const 1
-   i32.sub
    i32.add
-   local.get $5
-   local.get $5
+   local.tee $4
    i32.const 536870910
    i32.lt_u
-   select
-   i32.add
+   if (result i32)
+    local.get $4
+    i32.const 1
+    i32.const 27
+    local.get $4
+    i32.clz
+    i32.sub
+    i32.shl
+    i32.const 1
+    i32.sub
+    i32.add
+   else
+    local.get $4
+   end
    i32.const 65535
    i32.add
    i32.const -65536
    i32.and
    i32.const 16
    i32.shr_u
-   local.tee $3
+   local.tee $4
    local.get $2
-   local.get $3
+   local.get $4
    i32.gt_s
    select
    memory.grow $0
    i32.const 0
    i32.lt_s
    if
-    local.get $3
+    local.get $4
     memory.grow $0
     i32.const 0
     i32.lt_s
@@ -1470,7 +1473,7 @@
      unreachable
     end
    end
-   local.get $4
+   local.get $3
    local.get $2
    i32.const 16
    i32.shl
@@ -1479,7 +1482,7 @@
    i64.const 16
    i64.shl
    call $~lib/rt/tlsf/addMemory
-   local.get $4
+   local.get $3
    local.get $5
    call $~lib/rt/tlsf/searchBlock
    local.tee $2
@@ -1507,12 +1510,12 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $4
+  local.get $3
   local.get $2
   call $~lib/rt/tlsf/removeBlock
   local.get $2
   i32.load $0
-  local.set $3
+  local.set $4
   local.get $5
   i32.const 4
   i32.add
@@ -1526,7 +1529,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $3
+  local.get $4
   i32.const -4
   i32.and
   local.get $5
@@ -1537,7 +1540,7 @@
   if
    local.get $2
    local.get $5
-   local.get $3
+   local.get $4
    i32.const 2
    i32.and
    i32.or
@@ -1547,19 +1550,19 @@
    i32.add
    local.get $5
    i32.add
-   local.tee $3
+   local.tee $4
    local.get $6
    i32.const 4
    i32.sub
    i32.const 1
    i32.or
    i32.store $0
-   local.get $4
    local.get $3
+   local.get $4
    call $~lib/rt/tlsf/insertBlock
   else
    local.get $2
-   local.get $3
+   local.get $4
    i32.const -2
    i32.and
    i32.store $0

--- a/tests/compiler/bindings/noExportRuntime.debug.wat
+++ b/tests/compiler/bindings/noExportRuntime.debug.wat
@@ -1941,22 +1941,6 @@
   (local $pagesAfter i32)
   i32.const 0
   drop
-  local.get $size
-  i32.const 536870910
-  i32.lt_u
-  if
-   local.get $size
-   i32.const 1
-   i32.const 27
-   local.get $size
-   i32.clz
-   i32.sub
-   i32.shl
-   i32.const 1
-   i32.sub
-   i32.add
-   local.set $size
-  end
   memory.size $0
   local.set $pagesBefore
   local.get $size
@@ -1977,6 +1961,22 @@
   i32.shl
   i32.add
   local.set $size
+  local.get $size
+  i32.const 536870910
+  i32.lt_u
+  if
+   local.get $size
+   i32.const 1
+   i32.const 27
+   local.get $size
+   i32.clz
+   i32.sub
+   i32.shl
+   i32.const 1
+   i32.sub
+   i32.add
+   local.set $size
+  end
   local.get $size
   i32.const 65535
   i32.add

--- a/tests/compiler/bindings/noExportRuntime.debug.wat
+++ b/tests/compiler/bindings/noExportRuntime.debug.wat
@@ -1952,7 +1952,7 @@
   drop
   local.get $size
   i32.const 256
-  i32.gt_u
+  i32.ge_u
   if
    local.get $size
    call $~lib/rt/tlsf/roundSize

--- a/tests/compiler/bindings/noExportRuntime.debug.wat
+++ b/tests/compiler/bindings/noExportRuntime.debug.wat
@@ -1062,7 +1062,7 @@
   if
    i32.const 0
    i32.const 512
-   i32.const 378
+   i32.const 382
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1108,7 +1108,7 @@
    if
     i32.const 0
     i32.const 512
-    i32.const 385
+    i32.const 389
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1141,7 +1141,7 @@
    if
     i32.const 0
     i32.const 512
-    i32.const 398
+    i32.const 402
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1385,7 +1385,7 @@
   if
    i32.const 0
    i32.const 512
-   i32.const 560
+   i32.const 562
    i32.const 3
    call $~lib/builtins/abort
    unreachable
@@ -1714,13 +1714,33 @@
   if
    i32.const 176
    i32.const 512
-   i32.const 459
+   i32.const 461
    i32.const 29
    call $~lib/builtins/abort
    unreachable
   end
   local.get $size
   call $~lib/rt/tlsf/computeSize
+  return
+ )
+ (func $~lib/rt/tlsf/roundSize (param $size i32) (result i32)
+  local.get $size
+  i32.const 536870910
+  i32.lt_u
+  if (result i32)
+   local.get $size
+   i32.const 1
+   i32.const 27
+   local.get $size
+   i32.clz
+   i32.sub
+   i32.shl
+   i32.add
+   i32.const 1
+   i32.sub
+  else
+   local.get $size
+  end
   return
  )
  (func $~lib/rt/tlsf/searchBlock (param $root i32) (param $size i32) (result i32)
@@ -1752,24 +1772,13 @@
    local.set $sl
   else
    local.get $size
-   i32.const 536870910
-   i32.lt_u
-   if (result i32)
-    local.get $size
-    i32.const 1
-    i32.const 27
-    local.get $size
-    i32.clz
-    i32.sub
-    i32.shl
-    i32.add
-    i32.const 1
-    i32.sub
-   else
-    local.get $size
-   end
+   call $~lib/rt/tlsf/roundSize
    local.set $requestSize
-   i32.const 31
+   i32.const 4
+   i32.const 8
+   i32.mul
+   i32.const 1
+   i32.sub
    local.get $requestSize
    i32.clz
    i32.sub
@@ -1807,7 +1816,7 @@
   if
    i32.const 0
    i32.const 512
-   i32.const 330
+   i32.const 334
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1878,7 +1887,7 @@
     if
      i32.const 0
      i32.const 512
-     i32.const 343
+     i32.const 347
      i32.const 18
      call $~lib/builtins/abort
      unreachable
@@ -1941,6 +1950,14 @@
   (local $pagesAfter i32)
   i32.const 0
   drop
+  local.get $size
+  i32.const 256
+  i32.gt_u
+  if
+   local.get $size
+   call $~lib/rt/tlsf/roundSize
+   local.set $size
+  end
   memory.size $0
   local.set $pagesBefore
   local.get $size
@@ -1961,22 +1978,6 @@
   i32.shl
   i32.add
   local.set $size
-  local.get $size
-  i32.const 536870910
-  i32.lt_u
-  if
-   local.get $size
-   i32.const 1
-   i32.const 27
-   local.get $size
-   i32.clz
-   i32.sub
-   i32.shl
-   i32.const 1
-   i32.sub
-   i32.add
-   local.set $size
-  end
   local.get $size
   i32.const 65535
   i32.add
@@ -2043,7 +2044,7 @@
   if
    i32.const 0
    i32.const 512
-   i32.const 357
+   i32.const 361
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -2158,7 +2159,7 @@
    if
     i32.const 0
     i32.const 512
-    i32.const 497
+    i32.const 499
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -2178,7 +2179,7 @@
   if
    i32.const 0
    i32.const 512
-   i32.const 499
+   i32.const 501
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/bindings/noExportRuntime.release.wat
+++ b/tests/compiler/bindings/noExportRuntime.release.wat
@@ -1356,7 +1356,7 @@
    local.tee $2
    local.get $5
    i32.const 256
-   i32.gt_u
+   i32.ge_u
    if (result i32)
     local.get $5
     i32.const 1

--- a/tests/compiler/bindings/noExportRuntime.release.wat
+++ b/tests/compiler/bindings/noExportRuntime.release.wat
@@ -1319,7 +1319,7 @@
    call $~lib/rt/tlsf/initialize
   end
   global.get $~lib/rt/tlsf/ROOT
-  local.set $4
+  local.set $3
   local.get $0
   i32.const 16
   i32.add
@@ -1334,7 +1334,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $4
+  local.get $3
   i32.const 12
   local.get $2
   i32.const 19
@@ -1354,8 +1354,9 @@
   if
    memory.size $0
    local.tee $2
+   local.get $5
    i32.const 4
-   local.get $4
+   local.get $3
    i32.load $0 offset=1568
    local.get $2
    i32.const 16
@@ -1364,38 +1365,40 @@
    i32.sub
    i32.ne
    i32.shl
-   local.get $5
-   i32.const 1
-   i32.const 27
-   local.get $5
-   i32.clz
-   i32.sub
-   i32.shl
-   i32.const 1
-   i32.sub
    i32.add
-   local.get $5
-   local.get $5
+   local.tee $4
    i32.const 536870910
    i32.lt_u
-   select
-   i32.add
+   if (result i32)
+    local.get $4
+    i32.const 1
+    i32.const 27
+    local.get $4
+    i32.clz
+    i32.sub
+    i32.shl
+    i32.const 1
+    i32.sub
+    i32.add
+   else
+    local.get $4
+   end
    i32.const 65535
    i32.add
    i32.const -65536
    i32.and
    i32.const 16
    i32.shr_u
-   local.tee $3
+   local.tee $4
    local.get $2
-   local.get $3
+   local.get $4
    i32.gt_s
    select
    memory.grow $0
    i32.const 0
    i32.lt_s
    if
-    local.get $3
+    local.get $4
     memory.grow $0
     i32.const 0
     i32.lt_s
@@ -1403,7 +1406,7 @@
      unreachable
     end
    end
-   local.get $4
+   local.get $3
    local.get $2
    i32.const 16
    i32.shl
@@ -1412,7 +1415,7 @@
    i64.const 16
    i64.shl
    call $~lib/rt/tlsf/addMemory
-   local.get $4
+   local.get $3
    local.get $5
    call $~lib/rt/tlsf/searchBlock
    local.tee $2
@@ -1440,12 +1443,12 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $4
+  local.get $3
   local.get $2
   call $~lib/rt/tlsf/removeBlock
   local.get $2
   i32.load $0
-  local.set $3
+  local.set $4
   local.get $5
   i32.const 4
   i32.add
@@ -1459,7 +1462,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $3
+  local.get $4
   i32.const -4
   i32.and
   local.get $5
@@ -1470,7 +1473,7 @@
   if
    local.get $2
    local.get $5
-   local.get $3
+   local.get $4
    i32.const 2
    i32.and
    i32.or
@@ -1480,19 +1483,19 @@
    i32.add
    local.get $5
    i32.add
-   local.tee $3
+   local.tee $4
    local.get $6
    i32.const 4
    i32.sub
    i32.const 1
    i32.or
    i32.store $0
-   local.get $4
    local.get $3
+   local.get $4
    call $~lib/rt/tlsf/insertBlock
   else
    local.get $2
-   local.get $3
+   local.get $4
    i32.const -2
    i32.and
    i32.store $0

--- a/tests/compiler/bindings/noExportRuntime.release.wat
+++ b/tests/compiler/bindings/noExportRuntime.release.wat
@@ -674,7 +674,7 @@
   if
    i32.const 0
    i32.const 1536
-   i32.const 378
+   i32.const 382
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -699,7 +699,7 @@
    if
     i32.const 0
     i32.const 1536
-    i32.const 385
+    i32.const 389
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -727,7 +727,7 @@
    if
     i32.const 0
     i32.const 1536
-    i32.const 398
+    i32.const 402
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1094,7 +1094,7 @@
       if
        i32.const 0
        i32.const 1536
-       i32.const 560
+       i32.const 562
        i32.const 3
        call $~lib/builtins/abort
        unreachable
@@ -1178,7 +1178,7 @@
   if
    i32.const 0
    i32.const 1536
-   i32.const 330
+   i32.const 334
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1230,7 +1230,7 @@
     if
      i32.const 0
      i32.const 1536
-     i32.const 343
+     i32.const 347
      i32.const 18
      call $~lib/builtins/abort
      unreachable
@@ -1319,7 +1319,7 @@
    call $~lib/rt/tlsf/initialize
   end
   global.get $~lib/rt/tlsf/ROOT
-  local.set $3
+  local.set $4
   local.get $0
   i32.const 16
   i32.add
@@ -1329,12 +1329,12 @@
   if
    i32.const 1200
    i32.const 1536
-   i32.const 459
+   i32.const 461
    i32.const 29
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $3
+  local.get $4
   i32.const 12
   local.get $2
   i32.const 19
@@ -1355,8 +1355,29 @@
    memory.size $0
    local.tee $2
    local.get $5
+   i32.const 256
+   i32.gt_u
+   if (result i32)
+    local.get $5
+    i32.const 1
+    i32.const 27
+    local.get $5
+    i32.clz
+    i32.sub
+    i32.shl
+    i32.add
+    i32.const 1
+    i32.sub
+    local.get $5
+    local.get $5
+    i32.const 536870910
+    i32.lt_u
+    select
+   else
+    local.get $5
+   end
    i32.const 4
-   local.get $3
+   local.get $4
    i32.load $0 offset=1568
    local.get $2
    i32.const 16
@@ -1366,39 +1387,22 @@
    i32.ne
    i32.shl
    i32.add
-   local.tee $4
-   i32.const 536870910
-   i32.lt_u
-   if (result i32)
-    local.get $4
-    i32.const 1
-    i32.const 27
-    local.get $4
-    i32.clz
-    i32.sub
-    i32.shl
-    i32.const 1
-    i32.sub
-    i32.add
-   else
-    local.get $4
-   end
    i32.const 65535
    i32.add
    i32.const -65536
    i32.and
    i32.const 16
    i32.shr_u
-   local.tee $4
+   local.tee $3
    local.get $2
-   local.get $4
+   local.get $3
    i32.gt_s
    select
    memory.grow $0
    i32.const 0
    i32.lt_s
    if
-    local.get $4
+    local.get $3
     memory.grow $0
     i32.const 0
     i32.lt_s
@@ -1406,7 +1410,7 @@
      unreachable
     end
    end
-   local.get $3
+   local.get $4
    local.get $2
    i32.const 16
    i32.shl
@@ -1415,7 +1419,7 @@
    i64.const 16
    i64.shl
    call $~lib/rt/tlsf/addMemory
-   local.get $3
+   local.get $4
    local.get $5
    call $~lib/rt/tlsf/searchBlock
    local.tee $2
@@ -1423,7 +1427,7 @@
    if
     i32.const 0
     i32.const 1536
-    i32.const 497
+    i32.const 499
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1438,17 +1442,17 @@
   if
    i32.const 0
    i32.const 1536
-   i32.const 499
+   i32.const 501
    i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $3
+  local.get $4
   local.get $2
   call $~lib/rt/tlsf/removeBlock
   local.get $2
   i32.load $0
-  local.set $4
+  local.set $3
   local.get $5
   i32.const 4
   i32.add
@@ -1457,12 +1461,12 @@
   if
    i32.const 0
    i32.const 1536
-   i32.const 357
+   i32.const 361
    i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $4
+  local.get $3
   i32.const -4
   i32.and
   local.get $5
@@ -1473,7 +1477,7 @@
   if
    local.get $2
    local.get $5
-   local.get $4
+   local.get $3
    i32.const 2
    i32.and
    i32.or
@@ -1483,19 +1487,19 @@
    i32.add
    local.get $5
    i32.add
-   local.tee $4
+   local.tee $3
    local.get $6
    i32.const 4
    i32.sub
    i32.const 1
    i32.or
    i32.store $0
-   local.get $3
    local.get $4
+   local.get $3
    call $~lib/rt/tlsf/insertBlock
   else
    local.get $2
-   local.get $4
+   local.get $3
    i32.const -2
    i32.and
    i32.store $0

--- a/tests/compiler/bindings/raw.debug.wat
+++ b/tests/compiler/bindings/raw.debug.wat
@@ -2029,22 +2029,6 @@
   (local $pagesAfter i32)
   i32.const 0
   drop
-  local.get $size
-  i32.const 536870910
-  i32.lt_u
-  if
-   local.get $size
-   i32.const 1
-   i32.const 27
-   local.get $size
-   i32.clz
-   i32.sub
-   i32.shl
-   i32.const 1
-   i32.sub
-   i32.add
-   local.set $size
-  end
   memory.size $0
   local.set $pagesBefore
   local.get $size
@@ -2065,6 +2049,22 @@
   i32.shl
   i32.add
   local.set $size
+  local.get $size
+  i32.const 536870910
+  i32.lt_u
+  if
+   local.get $size
+   i32.const 1
+   i32.const 27
+   local.get $size
+   i32.clz
+   i32.sub
+   i32.shl
+   i32.const 1
+   i32.sub
+   i32.add
+   local.set $size
+  end
   local.get $size
   i32.const 65535
   i32.add

--- a/tests/compiler/bindings/raw.release.wat
+++ b/tests/compiler/bindings/raw.release.wat
@@ -1386,7 +1386,7 @@
    call $~lib/rt/tlsf/initialize
   end
   global.get $~lib/rt/tlsf/ROOT
-  local.set $4
+  local.set $3
   local.get $0
   i32.const 16
   i32.add
@@ -1401,7 +1401,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $4
+  local.get $3
   i32.const 12
   local.get $2
   i32.const 19
@@ -1421,8 +1421,9 @@
   if
    memory.size $0
    local.tee $2
+   local.get $5
    i32.const 4
-   local.get $4
+   local.get $3
    i32.load $0 offset=1568
    local.get $2
    i32.const 16
@@ -1431,38 +1432,40 @@
    i32.sub
    i32.ne
    i32.shl
-   local.get $5
-   i32.const 1
-   i32.const 27
-   local.get $5
-   i32.clz
-   i32.sub
-   i32.shl
-   i32.const 1
-   i32.sub
    i32.add
-   local.get $5
-   local.get $5
+   local.tee $4
    i32.const 536870910
    i32.lt_u
-   select
-   i32.add
+   if (result i32)
+    local.get $4
+    i32.const 1
+    i32.const 27
+    local.get $4
+    i32.clz
+    i32.sub
+    i32.shl
+    i32.const 1
+    i32.sub
+    i32.add
+   else
+    local.get $4
+   end
    i32.const 65535
    i32.add
    i32.const -65536
    i32.and
    i32.const 16
    i32.shr_u
-   local.tee $3
+   local.tee $4
    local.get $2
-   local.get $3
+   local.get $4
    i32.gt_s
    select
    memory.grow $0
    i32.const 0
    i32.lt_s
    if
-    local.get $3
+    local.get $4
     memory.grow $0
     i32.const 0
     i32.lt_s
@@ -1470,7 +1473,7 @@
      unreachable
     end
    end
-   local.get $4
+   local.get $3
    local.get $2
    i32.const 16
    i32.shl
@@ -1479,7 +1482,7 @@
    i64.const 16
    i64.shl
    call $~lib/rt/tlsf/addMemory
-   local.get $4
+   local.get $3
    local.get $5
    call $~lib/rt/tlsf/searchBlock
    local.tee $2
@@ -1507,12 +1510,12 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $4
+  local.get $3
   local.get $2
   call $~lib/rt/tlsf/removeBlock
   local.get $2
   i32.load $0
-  local.set $3
+  local.set $4
   local.get $5
   i32.const 4
   i32.add
@@ -1526,7 +1529,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $3
+  local.get $4
   i32.const -4
   i32.and
   local.get $5
@@ -1537,7 +1540,7 @@
   if
    local.get $2
    local.get $5
-   local.get $3
+   local.get $4
    i32.const 2
    i32.and
    i32.or
@@ -1547,19 +1550,19 @@
    i32.add
    local.get $5
    i32.add
-   local.tee $3
+   local.tee $4
    local.get $6
    i32.const 4
    i32.sub
    i32.const 1
    i32.or
    i32.store $0
-   local.get $4
    local.get $3
+   local.get $4
    call $~lib/rt/tlsf/insertBlock
   else
    local.get $2
-   local.get $3
+   local.get $4
    i32.const -2
    i32.and
    i32.store $0

--- a/tests/compiler/call-super.debug.wat
+++ b/tests/compiler/call-super.debug.wat
@@ -1927,7 +1927,7 @@
   drop
   local.get $size
   i32.const 256
-  i32.gt_u
+  i32.ge_u
   if
    local.get $size
    call $~lib/rt/tlsf/roundSize

--- a/tests/compiler/call-super.debug.wat
+++ b/tests/compiler/call-super.debug.wat
@@ -1916,22 +1916,6 @@
   (local $pagesAfter i32)
   i32.const 0
   drop
-  local.get $size
-  i32.const 536870910
-  i32.lt_u
-  if
-   local.get $size
-   i32.const 1
-   i32.const 27
-   local.get $size
-   i32.clz
-   i32.sub
-   i32.shl
-   i32.const 1
-   i32.sub
-   i32.add
-   local.set $size
-  end
   memory.size $0
   local.set $pagesBefore
   local.get $size
@@ -1952,6 +1936,22 @@
   i32.shl
   i32.add
   local.set $size
+  local.get $size
+  i32.const 536870910
+  i32.lt_u
+  if
+   local.get $size
+   i32.const 1
+   i32.const 27
+   local.get $size
+   i32.clz
+   i32.sub
+   i32.shl
+   i32.const 1
+   i32.sub
+   i32.add
+   local.set $size
+  end
   local.get $size
   i32.const 65535
   i32.add

--- a/tests/compiler/call-super.debug.wat
+++ b/tests/compiler/call-super.debug.wat
@@ -1037,7 +1037,7 @@
   if
    i32.const 0
    i32.const 416
-   i32.const 378
+   i32.const 382
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1083,7 +1083,7 @@
    if
     i32.const 0
     i32.const 416
-    i32.const 385
+    i32.const 389
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1116,7 +1116,7 @@
    if
     i32.const 0
     i32.const 416
-    i32.const 398
+    i32.const 402
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1360,7 +1360,7 @@
   if
    i32.const 0
    i32.const 416
-   i32.const 560
+   i32.const 562
    i32.const 3
    call $~lib/builtins/abort
    unreachable
@@ -1689,13 +1689,33 @@
   if
    i32.const 80
    i32.const 416
-   i32.const 459
+   i32.const 461
    i32.const 29
    call $~lib/builtins/abort
    unreachable
   end
   local.get $size
   call $~lib/rt/tlsf/computeSize
+  return
+ )
+ (func $~lib/rt/tlsf/roundSize (param $size i32) (result i32)
+  local.get $size
+  i32.const 536870910
+  i32.lt_u
+  if (result i32)
+   local.get $size
+   i32.const 1
+   i32.const 27
+   local.get $size
+   i32.clz
+   i32.sub
+   i32.shl
+   i32.add
+   i32.const 1
+   i32.sub
+  else
+   local.get $size
+  end
   return
  )
  (func $~lib/rt/tlsf/searchBlock (param $root i32) (param $size i32) (result i32)
@@ -1727,24 +1747,13 @@
    local.set $sl
   else
    local.get $size
-   i32.const 536870910
-   i32.lt_u
-   if (result i32)
-    local.get $size
-    i32.const 1
-    i32.const 27
-    local.get $size
-    i32.clz
-    i32.sub
-    i32.shl
-    i32.add
-    i32.const 1
-    i32.sub
-   else
-    local.get $size
-   end
+   call $~lib/rt/tlsf/roundSize
    local.set $requestSize
-   i32.const 31
+   i32.const 4
+   i32.const 8
+   i32.mul
+   i32.const 1
+   i32.sub
    local.get $requestSize
    i32.clz
    i32.sub
@@ -1782,7 +1791,7 @@
   if
    i32.const 0
    i32.const 416
-   i32.const 330
+   i32.const 334
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1853,7 +1862,7 @@
     if
      i32.const 0
      i32.const 416
-     i32.const 343
+     i32.const 347
      i32.const 18
      call $~lib/builtins/abort
      unreachable
@@ -1916,6 +1925,14 @@
   (local $pagesAfter i32)
   i32.const 0
   drop
+  local.get $size
+  i32.const 256
+  i32.gt_u
+  if
+   local.get $size
+   call $~lib/rt/tlsf/roundSize
+   local.set $size
+  end
   memory.size $0
   local.set $pagesBefore
   local.get $size
@@ -1936,22 +1953,6 @@
   i32.shl
   i32.add
   local.set $size
-  local.get $size
-  i32.const 536870910
-  i32.lt_u
-  if
-   local.get $size
-   i32.const 1
-   i32.const 27
-   local.get $size
-   i32.clz
-   i32.sub
-   i32.shl
-   i32.const 1
-   i32.sub
-   i32.add
-   local.set $size
-  end
   local.get $size
   i32.const 65535
   i32.add
@@ -2018,7 +2019,7 @@
   if
    i32.const 0
    i32.const 416
-   i32.const 357
+   i32.const 361
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -2133,7 +2134,7 @@
    if
     i32.const 0
     i32.const 416
-    i32.const 497
+    i32.const 499
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -2153,7 +2154,7 @@
   if
    i32.const 0
    i32.const 416
-   i32.const 499
+   i32.const 501
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/call-super.release.wat
+++ b/tests/compiler/call-super.release.wat
@@ -621,7 +621,7 @@
   if
    i32.const 0
    i32.const 1440
-   i32.const 378
+   i32.const 382
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -646,7 +646,7 @@
    if
     i32.const 0
     i32.const 1440
-    i32.const 385
+    i32.const 389
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -674,7 +674,7 @@
    if
     i32.const 0
     i32.const 1440
-    i32.const 398
+    i32.const 402
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1041,7 +1041,7 @@
       if
        i32.const 0
        i32.const 1440
-       i32.const 560
+       i32.const 562
        i32.const 3
        call $~lib/builtins/abort
        unreachable
@@ -1125,7 +1125,7 @@
   if
    i32.const 0
    i32.const 1440
-   i32.const 330
+   i32.const 334
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1177,7 +1177,7 @@
     if
      i32.const 0
      i32.const 1440
-     i32.const 343
+     i32.const 347
      i32.const 18
      call $~lib/builtins/abort
      unreachable
@@ -1266,7 +1266,7 @@
    call $~lib/rt/tlsf/initialize
   end
   global.get $~lib/rt/tlsf/ROOT
-  local.set $3
+  local.set $4
   local.get $0
   i32.const 16
   i32.add
@@ -1276,12 +1276,12 @@
   if
    i32.const 1104
    i32.const 1440
-   i32.const 459
+   i32.const 461
    i32.const 29
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $3
+  local.get $4
   i32.const 12
   local.get $2
   i32.const 19
@@ -1302,8 +1302,29 @@
    memory.size $0
    local.tee $2
    local.get $5
+   i32.const 256
+   i32.gt_u
+   if (result i32)
+    local.get $5
+    i32.const 1
+    i32.const 27
+    local.get $5
+    i32.clz
+    i32.sub
+    i32.shl
+    i32.add
+    i32.const 1
+    i32.sub
+    local.get $5
+    local.get $5
+    i32.const 536870910
+    i32.lt_u
+    select
+   else
+    local.get $5
+   end
    i32.const 4
-   local.get $3
+   local.get $4
    i32.load $0 offset=1568
    local.get $2
    i32.const 16
@@ -1313,39 +1334,22 @@
    i32.ne
    i32.shl
    i32.add
-   local.tee $4
-   i32.const 536870910
-   i32.lt_u
-   if (result i32)
-    local.get $4
-    i32.const 1
-    i32.const 27
-    local.get $4
-    i32.clz
-    i32.sub
-    i32.shl
-    i32.const 1
-    i32.sub
-    i32.add
-   else
-    local.get $4
-   end
    i32.const 65535
    i32.add
    i32.const -65536
    i32.and
    i32.const 16
    i32.shr_u
-   local.tee $4
+   local.tee $3
    local.get $2
-   local.get $4
+   local.get $3
    i32.gt_s
    select
    memory.grow $0
    i32.const 0
    i32.lt_s
    if
-    local.get $4
+    local.get $3
     memory.grow $0
     i32.const 0
     i32.lt_s
@@ -1353,7 +1357,7 @@
      unreachable
     end
    end
-   local.get $3
+   local.get $4
    local.get $2
    i32.const 16
    i32.shl
@@ -1362,7 +1366,7 @@
    i64.const 16
    i64.shl
    call $~lib/rt/tlsf/addMemory
-   local.get $3
+   local.get $4
    local.get $5
    call $~lib/rt/tlsf/searchBlock
    local.tee $2
@@ -1370,7 +1374,7 @@
    if
     i32.const 0
     i32.const 1440
-    i32.const 497
+    i32.const 499
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1385,17 +1389,17 @@
   if
    i32.const 0
    i32.const 1440
-   i32.const 499
+   i32.const 501
    i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $3
+  local.get $4
   local.get $2
   call $~lib/rt/tlsf/removeBlock
   local.get $2
   i32.load $0
-  local.set $4
+  local.set $3
   local.get $5
   i32.const 4
   i32.add
@@ -1404,12 +1408,12 @@
   if
    i32.const 0
    i32.const 1440
-   i32.const 357
+   i32.const 361
    i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $4
+  local.get $3
   i32.const -4
   i32.and
   local.get $5
@@ -1420,7 +1424,7 @@
   if
    local.get $2
    local.get $5
-   local.get $4
+   local.get $3
    i32.const 2
    i32.and
    i32.or
@@ -1430,19 +1434,19 @@
    i32.add
    local.get $5
    i32.add
-   local.tee $4
+   local.tee $3
    local.get $6
    i32.const 4
    i32.sub
    i32.const 1
    i32.or
    i32.store $0
-   local.get $3
    local.get $4
+   local.get $3
    call $~lib/rt/tlsf/insertBlock
   else
    local.get $2
-   local.get $4
+   local.get $3
    i32.const -2
    i32.and
    i32.store $0

--- a/tests/compiler/call-super.release.wat
+++ b/tests/compiler/call-super.release.wat
@@ -1303,7 +1303,7 @@
    local.tee $2
    local.get $5
    i32.const 256
-   i32.gt_u
+   i32.ge_u
    if (result i32)
     local.get $5
     i32.const 1

--- a/tests/compiler/call-super.release.wat
+++ b/tests/compiler/call-super.release.wat
@@ -1266,7 +1266,7 @@
    call $~lib/rt/tlsf/initialize
   end
   global.get $~lib/rt/tlsf/ROOT
-  local.set $4
+  local.set $3
   local.get $0
   i32.const 16
   i32.add
@@ -1281,7 +1281,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $4
+  local.get $3
   i32.const 12
   local.get $2
   i32.const 19
@@ -1301,8 +1301,9 @@
   if
    memory.size $0
    local.tee $2
+   local.get $5
    i32.const 4
-   local.get $4
+   local.get $3
    i32.load $0 offset=1568
    local.get $2
    i32.const 16
@@ -1311,38 +1312,40 @@
    i32.sub
    i32.ne
    i32.shl
-   local.get $5
-   i32.const 1
-   i32.const 27
-   local.get $5
-   i32.clz
-   i32.sub
-   i32.shl
-   i32.const 1
-   i32.sub
    i32.add
-   local.get $5
-   local.get $5
+   local.tee $4
    i32.const 536870910
    i32.lt_u
-   select
-   i32.add
+   if (result i32)
+    local.get $4
+    i32.const 1
+    i32.const 27
+    local.get $4
+    i32.clz
+    i32.sub
+    i32.shl
+    i32.const 1
+    i32.sub
+    i32.add
+   else
+    local.get $4
+   end
    i32.const 65535
    i32.add
    i32.const -65536
    i32.and
    i32.const 16
    i32.shr_u
-   local.tee $3
+   local.tee $4
    local.get $2
-   local.get $3
+   local.get $4
    i32.gt_s
    select
    memory.grow $0
    i32.const 0
    i32.lt_s
    if
-    local.get $3
+    local.get $4
     memory.grow $0
     i32.const 0
     i32.lt_s
@@ -1350,7 +1353,7 @@
      unreachable
     end
    end
-   local.get $4
+   local.get $3
    local.get $2
    i32.const 16
    i32.shl
@@ -1359,7 +1362,7 @@
    i64.const 16
    i64.shl
    call $~lib/rt/tlsf/addMemory
-   local.get $4
+   local.get $3
    local.get $5
    call $~lib/rt/tlsf/searchBlock
    local.tee $2
@@ -1387,12 +1390,12 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $4
+  local.get $3
   local.get $2
   call $~lib/rt/tlsf/removeBlock
   local.get $2
   i32.load $0
-  local.set $3
+  local.set $4
   local.get $5
   i32.const 4
   i32.add
@@ -1406,7 +1409,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $3
+  local.get $4
   i32.const -4
   i32.and
   local.get $5
@@ -1417,7 +1420,7 @@
   if
    local.get $2
    local.get $5
-   local.get $3
+   local.get $4
    i32.const 2
    i32.and
    i32.or
@@ -1427,19 +1430,19 @@
    i32.add
    local.get $5
    i32.add
-   local.tee $3
+   local.tee $4
    local.get $6
    i32.const 4
    i32.sub
    i32.const 1
    i32.or
    i32.store $0
-   local.get $4
    local.get $3
+   local.get $4
    call $~lib/rt/tlsf/insertBlock
   else
    local.get $2
-   local.get $3
+   local.get $4
    i32.const -2
    i32.and
    i32.store $0

--- a/tests/compiler/class-implements.debug.wat
+++ b/tests/compiler/class-implements.debug.wat
@@ -1040,7 +1040,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 378
+   i32.const 382
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1086,7 +1086,7 @@
    if
     i32.const 0
     i32.const 368
-    i32.const 385
+    i32.const 389
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1119,7 +1119,7 @@
    if
     i32.const 0
     i32.const 368
-    i32.const 398
+    i32.const 402
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1363,7 +1363,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 560
+   i32.const 562
    i32.const 3
    call $~lib/builtins/abort
    unreachable
@@ -1692,13 +1692,33 @@
   if
    i32.const 32
    i32.const 368
-   i32.const 459
+   i32.const 461
    i32.const 29
    call $~lib/builtins/abort
    unreachable
   end
   local.get $size
   call $~lib/rt/tlsf/computeSize
+  return
+ )
+ (func $~lib/rt/tlsf/roundSize (param $size i32) (result i32)
+  local.get $size
+  i32.const 536870910
+  i32.lt_u
+  if (result i32)
+   local.get $size
+   i32.const 1
+   i32.const 27
+   local.get $size
+   i32.clz
+   i32.sub
+   i32.shl
+   i32.add
+   i32.const 1
+   i32.sub
+  else
+   local.get $size
+  end
   return
  )
  (func $~lib/rt/tlsf/searchBlock (param $root i32) (param $size i32) (result i32)
@@ -1730,24 +1750,13 @@
    local.set $sl
   else
    local.get $size
-   i32.const 536870910
-   i32.lt_u
-   if (result i32)
-    local.get $size
-    i32.const 1
-    i32.const 27
-    local.get $size
-    i32.clz
-    i32.sub
-    i32.shl
-    i32.add
-    i32.const 1
-    i32.sub
-   else
-    local.get $size
-   end
+   call $~lib/rt/tlsf/roundSize
    local.set $requestSize
-   i32.const 31
+   i32.const 4
+   i32.const 8
+   i32.mul
+   i32.const 1
+   i32.sub
    local.get $requestSize
    i32.clz
    i32.sub
@@ -1785,7 +1794,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 330
+   i32.const 334
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1856,7 +1865,7 @@
     if
      i32.const 0
      i32.const 368
-     i32.const 343
+     i32.const 347
      i32.const 18
      call $~lib/builtins/abort
      unreachable
@@ -1919,6 +1928,14 @@
   (local $pagesAfter i32)
   i32.const 0
   drop
+  local.get $size
+  i32.const 256
+  i32.gt_u
+  if
+   local.get $size
+   call $~lib/rt/tlsf/roundSize
+   local.set $size
+  end
   memory.size $0
   local.set $pagesBefore
   local.get $size
@@ -1939,22 +1956,6 @@
   i32.shl
   i32.add
   local.set $size
-  local.get $size
-  i32.const 536870910
-  i32.lt_u
-  if
-   local.get $size
-   i32.const 1
-   i32.const 27
-   local.get $size
-   i32.clz
-   i32.sub
-   i32.shl
-   i32.const 1
-   i32.sub
-   i32.add
-   local.set $size
-  end
   local.get $size
   i32.const 65535
   i32.add
@@ -2021,7 +2022,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 357
+   i32.const 361
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -2136,7 +2137,7 @@
    if
     i32.const 0
     i32.const 368
-    i32.const 497
+    i32.const 499
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -2156,7 +2157,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 499
+   i32.const 501
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/class-implements.debug.wat
+++ b/tests/compiler/class-implements.debug.wat
@@ -1919,22 +1919,6 @@
   (local $pagesAfter i32)
   i32.const 0
   drop
-  local.get $size
-  i32.const 536870910
-  i32.lt_u
-  if
-   local.get $size
-   i32.const 1
-   i32.const 27
-   local.get $size
-   i32.clz
-   i32.sub
-   i32.shl
-   i32.const 1
-   i32.sub
-   i32.add
-   local.set $size
-  end
   memory.size $0
   local.set $pagesBefore
   local.get $size
@@ -1955,6 +1939,22 @@
   i32.shl
   i32.add
   local.set $size
+  local.get $size
+  i32.const 536870910
+  i32.lt_u
+  if
+   local.get $size
+   i32.const 1
+   i32.const 27
+   local.get $size
+   i32.clz
+   i32.sub
+   i32.shl
+   i32.const 1
+   i32.sub
+   i32.add
+   local.set $size
+  end
   local.get $size
   i32.const 65535
   i32.add

--- a/tests/compiler/class-implements.debug.wat
+++ b/tests/compiler/class-implements.debug.wat
@@ -1930,7 +1930,7 @@
   drop
   local.get $size
   i32.const 256
-  i32.gt_u
+  i32.ge_u
   if
    local.get $size
    call $~lib/rt/tlsf/roundSize

--- a/tests/compiler/class-implements.release.wat
+++ b/tests/compiler/class-implements.release.wat
@@ -1352,7 +1352,7 @@
    local.tee $2
    local.get $5
    i32.const 256
-   i32.gt_u
+   i32.ge_u
    if (result i32)
     local.get $5
     i32.const 1

--- a/tests/compiler/class-implements.release.wat
+++ b/tests/compiler/class-implements.release.wat
@@ -670,7 +670,7 @@
   if
    i32.const 0
    i32.const 1392
-   i32.const 378
+   i32.const 382
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -695,7 +695,7 @@
    if
     i32.const 0
     i32.const 1392
-    i32.const 385
+    i32.const 389
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -723,7 +723,7 @@
    if
     i32.const 0
     i32.const 1392
-    i32.const 398
+    i32.const 402
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1090,7 +1090,7 @@
       if
        i32.const 0
        i32.const 1392
-       i32.const 560
+       i32.const 562
        i32.const 3
        call $~lib/builtins/abort
        unreachable
@@ -1174,7 +1174,7 @@
   if
    i32.const 0
    i32.const 1392
-   i32.const 330
+   i32.const 334
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1226,7 +1226,7 @@
     if
      i32.const 0
      i32.const 1392
-     i32.const 343
+     i32.const 347
      i32.const 18
      call $~lib/builtins/abort
      unreachable
@@ -1315,7 +1315,7 @@
    call $~lib/rt/tlsf/initialize
   end
   global.get $~lib/rt/tlsf/ROOT
-  local.set $3
+  local.set $4
   local.get $0
   i32.const 16
   i32.add
@@ -1325,12 +1325,12 @@
   if
    i32.const 1056
    i32.const 1392
-   i32.const 459
+   i32.const 461
    i32.const 29
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $3
+  local.get $4
   i32.const 12
   local.get $2
   i32.const 19
@@ -1351,8 +1351,29 @@
    memory.size $0
    local.tee $2
    local.get $5
+   i32.const 256
+   i32.gt_u
+   if (result i32)
+    local.get $5
+    i32.const 1
+    i32.const 27
+    local.get $5
+    i32.clz
+    i32.sub
+    i32.shl
+    i32.add
+    i32.const 1
+    i32.sub
+    local.get $5
+    local.get $5
+    i32.const 536870910
+    i32.lt_u
+    select
+   else
+    local.get $5
+   end
    i32.const 4
-   local.get $3
+   local.get $4
    i32.load $0 offset=1568
    local.get $2
    i32.const 16
@@ -1362,39 +1383,22 @@
    i32.ne
    i32.shl
    i32.add
-   local.tee $4
-   i32.const 536870910
-   i32.lt_u
-   if (result i32)
-    local.get $4
-    i32.const 1
-    i32.const 27
-    local.get $4
-    i32.clz
-    i32.sub
-    i32.shl
-    i32.const 1
-    i32.sub
-    i32.add
-   else
-    local.get $4
-   end
    i32.const 65535
    i32.add
    i32.const -65536
    i32.and
    i32.const 16
    i32.shr_u
-   local.tee $4
+   local.tee $3
    local.get $2
-   local.get $4
+   local.get $3
    i32.gt_s
    select
    memory.grow $0
    i32.const 0
    i32.lt_s
    if
-    local.get $4
+    local.get $3
     memory.grow $0
     i32.const 0
     i32.lt_s
@@ -1402,7 +1406,7 @@
      unreachable
     end
    end
-   local.get $3
+   local.get $4
    local.get $2
    i32.const 16
    i32.shl
@@ -1411,7 +1415,7 @@
    i64.const 16
    i64.shl
    call $~lib/rt/tlsf/addMemory
-   local.get $3
+   local.get $4
    local.get $5
    call $~lib/rt/tlsf/searchBlock
    local.tee $2
@@ -1419,7 +1423,7 @@
    if
     i32.const 0
     i32.const 1392
-    i32.const 497
+    i32.const 499
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1434,17 +1438,17 @@
   if
    i32.const 0
    i32.const 1392
-   i32.const 499
+   i32.const 501
    i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $3
+  local.get $4
   local.get $2
   call $~lib/rt/tlsf/removeBlock
   local.get $2
   i32.load $0
-  local.set $4
+  local.set $3
   local.get $5
   i32.const 4
   i32.add
@@ -1453,12 +1457,12 @@
   if
    i32.const 0
    i32.const 1392
-   i32.const 357
+   i32.const 361
    i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $4
+  local.get $3
   i32.const -4
   i32.and
   local.get $5
@@ -1469,7 +1473,7 @@
   if
    local.get $2
    local.get $5
-   local.get $4
+   local.get $3
    i32.const 2
    i32.and
    i32.or
@@ -1479,19 +1483,19 @@
    i32.add
    local.get $5
    i32.add
-   local.tee $4
+   local.tee $3
    local.get $6
    i32.const 4
    i32.sub
    i32.const 1
    i32.or
    i32.store $0
-   local.get $3
    local.get $4
+   local.get $3
    call $~lib/rt/tlsf/insertBlock
   else
    local.get $2
-   local.get $4
+   local.get $3
    i32.const -2
    i32.and
    i32.store $0

--- a/tests/compiler/class-implements.release.wat
+++ b/tests/compiler/class-implements.release.wat
@@ -1315,7 +1315,7 @@
    call $~lib/rt/tlsf/initialize
   end
   global.get $~lib/rt/tlsf/ROOT
-  local.set $4
+  local.set $3
   local.get $0
   i32.const 16
   i32.add
@@ -1330,7 +1330,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $4
+  local.get $3
   i32.const 12
   local.get $2
   i32.const 19
@@ -1350,8 +1350,9 @@
   if
    memory.size $0
    local.tee $2
+   local.get $5
    i32.const 4
-   local.get $4
+   local.get $3
    i32.load $0 offset=1568
    local.get $2
    i32.const 16
@@ -1360,38 +1361,40 @@
    i32.sub
    i32.ne
    i32.shl
-   local.get $5
-   i32.const 1
-   i32.const 27
-   local.get $5
-   i32.clz
-   i32.sub
-   i32.shl
-   i32.const 1
-   i32.sub
    i32.add
-   local.get $5
-   local.get $5
+   local.tee $4
    i32.const 536870910
    i32.lt_u
-   select
-   i32.add
+   if (result i32)
+    local.get $4
+    i32.const 1
+    i32.const 27
+    local.get $4
+    i32.clz
+    i32.sub
+    i32.shl
+    i32.const 1
+    i32.sub
+    i32.add
+   else
+    local.get $4
+   end
    i32.const 65535
    i32.add
    i32.const -65536
    i32.and
    i32.const 16
    i32.shr_u
-   local.tee $3
+   local.tee $4
    local.get $2
-   local.get $3
+   local.get $4
    i32.gt_s
    select
    memory.grow $0
    i32.const 0
    i32.lt_s
    if
-    local.get $3
+    local.get $4
     memory.grow $0
     i32.const 0
     i32.lt_s
@@ -1399,7 +1402,7 @@
      unreachable
     end
    end
-   local.get $4
+   local.get $3
    local.get $2
    i32.const 16
    i32.shl
@@ -1408,7 +1411,7 @@
    i64.const 16
    i64.shl
    call $~lib/rt/tlsf/addMemory
-   local.get $4
+   local.get $3
    local.get $5
    call $~lib/rt/tlsf/searchBlock
    local.tee $2
@@ -1436,12 +1439,12 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $4
+  local.get $3
   local.get $2
   call $~lib/rt/tlsf/removeBlock
   local.get $2
   i32.load $0
-  local.set $3
+  local.set $4
   local.get $5
   i32.const 4
   i32.add
@@ -1455,7 +1458,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $3
+  local.get $4
   i32.const -4
   i32.and
   local.get $5
@@ -1466,7 +1469,7 @@
   if
    local.get $2
    local.get $5
-   local.get $3
+   local.get $4
    i32.const 2
    i32.and
    i32.or
@@ -1476,19 +1479,19 @@
    i32.add
    local.get $5
    i32.add
-   local.tee $3
+   local.tee $4
    local.get $6
    i32.const 4
    i32.sub
    i32.const 1
    i32.or
    i32.store $0
-   local.get $4
    local.get $3
+   local.get $4
    call $~lib/rt/tlsf/insertBlock
   else
    local.get $2
-   local.get $3
+   local.get $4
    i32.const -2
    i32.and
    i32.store $0

--- a/tests/compiler/class-overloading-cast.debug.wat
+++ b/tests/compiler/class-overloading-cast.debug.wat
@@ -1936,7 +1936,7 @@
   drop
   local.get $size
   i32.const 256
-  i32.gt_u
+  i32.ge_u
   if
    local.get $size
    call $~lib/rt/tlsf/roundSize

--- a/tests/compiler/class-overloading-cast.debug.wat
+++ b/tests/compiler/class-overloading-cast.debug.wat
@@ -1925,22 +1925,6 @@
   (local $pagesAfter i32)
   i32.const 0
   drop
-  local.get $size
-  i32.const 536870910
-  i32.lt_u
-  if
-   local.get $size
-   i32.const 1
-   i32.const 27
-   local.get $size
-   i32.clz
-   i32.sub
-   i32.shl
-   i32.const 1
-   i32.sub
-   i32.add
-   local.set $size
-  end
   memory.size $0
   local.set $pagesBefore
   local.get $size
@@ -1961,6 +1945,22 @@
   i32.shl
   i32.add
   local.set $size
+  local.get $size
+  i32.const 536870910
+  i32.lt_u
+  if
+   local.get $size
+   i32.const 1
+   i32.const 27
+   local.get $size
+   i32.clz
+   i32.sub
+   i32.shl
+   i32.const 1
+   i32.sub
+   i32.add
+   local.set $size
+  end
   local.get $size
   i32.const 65535
   i32.add

--- a/tests/compiler/class-overloading-cast.debug.wat
+++ b/tests/compiler/class-overloading-cast.debug.wat
@@ -1046,7 +1046,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 378
+   i32.const 382
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1092,7 +1092,7 @@
    if
     i32.const 0
     i32.const 368
-    i32.const 385
+    i32.const 389
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1125,7 +1125,7 @@
    if
     i32.const 0
     i32.const 368
-    i32.const 398
+    i32.const 402
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1369,7 +1369,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 560
+   i32.const 562
    i32.const 3
    call $~lib/builtins/abort
    unreachable
@@ -1698,13 +1698,33 @@
   if
    i32.const 32
    i32.const 368
-   i32.const 459
+   i32.const 461
    i32.const 29
    call $~lib/builtins/abort
    unreachable
   end
   local.get $size
   call $~lib/rt/tlsf/computeSize
+  return
+ )
+ (func $~lib/rt/tlsf/roundSize (param $size i32) (result i32)
+  local.get $size
+  i32.const 536870910
+  i32.lt_u
+  if (result i32)
+   local.get $size
+   i32.const 1
+   i32.const 27
+   local.get $size
+   i32.clz
+   i32.sub
+   i32.shl
+   i32.add
+   i32.const 1
+   i32.sub
+  else
+   local.get $size
+  end
   return
  )
  (func $~lib/rt/tlsf/searchBlock (param $root i32) (param $size i32) (result i32)
@@ -1736,24 +1756,13 @@
    local.set $sl
   else
    local.get $size
-   i32.const 536870910
-   i32.lt_u
-   if (result i32)
-    local.get $size
-    i32.const 1
-    i32.const 27
-    local.get $size
-    i32.clz
-    i32.sub
-    i32.shl
-    i32.add
-    i32.const 1
-    i32.sub
-   else
-    local.get $size
-   end
+   call $~lib/rt/tlsf/roundSize
    local.set $requestSize
-   i32.const 31
+   i32.const 4
+   i32.const 8
+   i32.mul
+   i32.const 1
+   i32.sub
    local.get $requestSize
    i32.clz
    i32.sub
@@ -1791,7 +1800,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 330
+   i32.const 334
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1862,7 +1871,7 @@
     if
      i32.const 0
      i32.const 368
-     i32.const 343
+     i32.const 347
      i32.const 18
      call $~lib/builtins/abort
      unreachable
@@ -1925,6 +1934,14 @@
   (local $pagesAfter i32)
   i32.const 0
   drop
+  local.get $size
+  i32.const 256
+  i32.gt_u
+  if
+   local.get $size
+   call $~lib/rt/tlsf/roundSize
+   local.set $size
+  end
   memory.size $0
   local.set $pagesBefore
   local.get $size
@@ -1945,22 +1962,6 @@
   i32.shl
   i32.add
   local.set $size
-  local.get $size
-  i32.const 536870910
-  i32.lt_u
-  if
-   local.get $size
-   i32.const 1
-   i32.const 27
-   local.get $size
-   i32.clz
-   i32.sub
-   i32.shl
-   i32.const 1
-   i32.sub
-   i32.add
-   local.set $size
-  end
   local.get $size
   i32.const 65535
   i32.add
@@ -2027,7 +2028,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 357
+   i32.const 361
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -2142,7 +2143,7 @@
    if
     i32.const 0
     i32.const 368
-    i32.const 497
+    i32.const 499
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -2162,7 +2163,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 499
+   i32.const 501
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/class-overloading-cast.release.wat
+++ b/tests/compiler/class-overloading-cast.release.wat
@@ -1229,6 +1229,8 @@
   if
    memory.size $0
    local.tee $1
+   i32.const 1
+   i32.const 27
    i32.const 4
    local.get $2
    i32.load $0 offset=1568
@@ -1239,7 +1241,22 @@
    i32.sub
    i32.ne
    i32.shl
-   i32.const 65563
+   i32.const 28
+   i32.add
+   local.tee $3
+   i32.clz
+   i32.sub
+   i32.shl
+   i32.const 1
+   i32.sub
+   local.get $3
+   i32.add
+   local.get $3
+   local.get $3
+   i32.const 536870910
+   i32.lt_u
+   select
+   i32.const 65535
    i32.add
    i32.const -65536
    i32.and

--- a/tests/compiler/class-overloading-cast.release.wat
+++ b/tests/compiler/class-overloading-cast.release.wat
@@ -658,7 +658,7 @@
   if
    i32.const 0
    i32.const 1392
-   i32.const 378
+   i32.const 382
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -683,7 +683,7 @@
    if
     i32.const 0
     i32.const 1392
-    i32.const 385
+    i32.const 389
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -711,7 +711,7 @@
    if
     i32.const 0
     i32.const 1392
-    i32.const 398
+    i32.const 402
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1078,7 +1078,7 @@
       if
        i32.const 0
        i32.const 1392
-       i32.const 560
+       i32.const 562
        i32.const 3
        call $~lib/builtins/abort
        unreachable
@@ -1145,7 +1145,7 @@
     if
      i32.const 0
      i32.const 1392
-     i32.const 343
+     i32.const 347
      i32.const 18
      call $~lib/builtins/abort
      unreachable
@@ -1229,8 +1229,6 @@
   if
    memory.size $0
    local.tee $1
-   i32.const 1
-   i32.const 27
    i32.const 4
    local.get $2
    i32.load $0 offset=1568
@@ -1241,22 +1239,7 @@
    i32.sub
    i32.ne
    i32.shl
-   i32.const 28
-   i32.add
-   local.tee $3
-   i32.clz
-   i32.sub
-   i32.shl
-   i32.const 1
-   i32.sub
-   local.get $3
-   i32.add
-   local.get $3
-   local.get $3
-   i32.const 536870910
-   i32.lt_u
-   select
-   i32.const 65535
+   i32.const 65563
    i32.add
    i32.const -65536
    i32.and
@@ -1295,7 +1278,7 @@
    if
     i32.const 0
     i32.const 1392
-    i32.const 497
+    i32.const 499
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1310,7 +1293,7 @@
   if
    i32.const 0
    i32.const 1392
-   i32.const 499
+   i32.const 501
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/class-overloading.debug.wat
+++ b/tests/compiler/class-overloading.debug.wat
@@ -1929,22 +1929,6 @@
   (local $pagesAfter i32)
   i32.const 0
   drop
-  local.get $size
-  i32.const 536870910
-  i32.lt_u
-  if
-   local.get $size
-   i32.const 1
-   i32.const 27
-   local.get $size
-   i32.clz
-   i32.sub
-   i32.shl
-   i32.const 1
-   i32.sub
-   i32.add
-   local.set $size
-  end
   memory.size $0
   local.set $pagesBefore
   local.get $size
@@ -1965,6 +1949,22 @@
   i32.shl
   i32.add
   local.set $size
+  local.get $size
+  i32.const 536870910
+  i32.lt_u
+  if
+   local.get $size
+   i32.const 1
+   i32.const 27
+   local.get $size
+   i32.clz
+   i32.sub
+   i32.shl
+   i32.const 1
+   i32.sub
+   i32.add
+   local.set $size
+  end
   local.get $size
   i32.const 65535
   i32.add

--- a/tests/compiler/class-overloading.debug.wat
+++ b/tests/compiler/class-overloading.debug.wat
@@ -1940,7 +1940,7 @@
   drop
   local.get $size
   i32.const 256
-  i32.gt_u
+  i32.ge_u
   if
    local.get $size
    call $~lib/rt/tlsf/roundSize

--- a/tests/compiler/class-overloading.debug.wat
+++ b/tests/compiler/class-overloading.debug.wat
@@ -1050,7 +1050,7 @@
   if
    i32.const 0
    i32.const 400
-   i32.const 378
+   i32.const 382
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1096,7 +1096,7 @@
    if
     i32.const 0
     i32.const 400
-    i32.const 385
+    i32.const 389
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1129,7 +1129,7 @@
    if
     i32.const 0
     i32.const 400
-    i32.const 398
+    i32.const 402
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1373,7 +1373,7 @@
   if
    i32.const 0
    i32.const 400
-   i32.const 560
+   i32.const 562
    i32.const 3
    call $~lib/builtins/abort
    unreachable
@@ -1702,13 +1702,33 @@
   if
    i32.const 64
    i32.const 400
-   i32.const 459
+   i32.const 461
    i32.const 29
    call $~lib/builtins/abort
    unreachable
   end
   local.get $size
   call $~lib/rt/tlsf/computeSize
+  return
+ )
+ (func $~lib/rt/tlsf/roundSize (param $size i32) (result i32)
+  local.get $size
+  i32.const 536870910
+  i32.lt_u
+  if (result i32)
+   local.get $size
+   i32.const 1
+   i32.const 27
+   local.get $size
+   i32.clz
+   i32.sub
+   i32.shl
+   i32.add
+   i32.const 1
+   i32.sub
+  else
+   local.get $size
+  end
   return
  )
  (func $~lib/rt/tlsf/searchBlock (param $root i32) (param $size i32) (result i32)
@@ -1740,24 +1760,13 @@
    local.set $sl
   else
    local.get $size
-   i32.const 536870910
-   i32.lt_u
-   if (result i32)
-    local.get $size
-    i32.const 1
-    i32.const 27
-    local.get $size
-    i32.clz
-    i32.sub
-    i32.shl
-    i32.add
-    i32.const 1
-    i32.sub
-   else
-    local.get $size
-   end
+   call $~lib/rt/tlsf/roundSize
    local.set $requestSize
-   i32.const 31
+   i32.const 4
+   i32.const 8
+   i32.mul
+   i32.const 1
+   i32.sub
    local.get $requestSize
    i32.clz
    i32.sub
@@ -1795,7 +1804,7 @@
   if
    i32.const 0
    i32.const 400
-   i32.const 330
+   i32.const 334
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1866,7 +1875,7 @@
     if
      i32.const 0
      i32.const 400
-     i32.const 343
+     i32.const 347
      i32.const 18
      call $~lib/builtins/abort
      unreachable
@@ -1929,6 +1938,14 @@
   (local $pagesAfter i32)
   i32.const 0
   drop
+  local.get $size
+  i32.const 256
+  i32.gt_u
+  if
+   local.get $size
+   call $~lib/rt/tlsf/roundSize
+   local.set $size
+  end
   memory.size $0
   local.set $pagesBefore
   local.get $size
@@ -1949,22 +1966,6 @@
   i32.shl
   i32.add
   local.set $size
-  local.get $size
-  i32.const 536870910
-  i32.lt_u
-  if
-   local.get $size
-   i32.const 1
-   i32.const 27
-   local.get $size
-   i32.clz
-   i32.sub
-   i32.shl
-   i32.const 1
-   i32.sub
-   i32.add
-   local.set $size
-  end
   local.get $size
   i32.const 65535
   i32.add
@@ -2031,7 +2032,7 @@
   if
    i32.const 0
    i32.const 400
-   i32.const 357
+   i32.const 361
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -2146,7 +2147,7 @@
    if
     i32.const 0
     i32.const 400
-    i32.const 497
+    i32.const 499
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -2166,7 +2167,7 @@
   if
    i32.const 0
    i32.const 400
-   i32.const 499
+   i32.const 501
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/class-overloading.release.wat
+++ b/tests/compiler/class-overloading.release.wat
@@ -680,7 +680,7 @@
   if
    i32.const 0
    i32.const 1424
-   i32.const 378
+   i32.const 382
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -705,7 +705,7 @@
    if
     i32.const 0
     i32.const 1424
-    i32.const 385
+    i32.const 389
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -733,7 +733,7 @@
    if
     i32.const 0
     i32.const 1424
-    i32.const 398
+    i32.const 402
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1100,7 +1100,7 @@
       if
        i32.const 0
        i32.const 1424
-       i32.const 560
+       i32.const 562
        i32.const 3
        call $~lib/builtins/abort
        unreachable
@@ -1167,7 +1167,7 @@
     if
      i32.const 0
      i32.const 1424
-     i32.const 343
+     i32.const 347
      i32.const 18
      call $~lib/builtins/abort
      unreachable
@@ -1251,8 +1251,6 @@
   if
    memory.size $0
    local.tee $1
-   i32.const 1
-   i32.const 27
    i32.const 4
    local.get $2
    i32.load $0 offset=1568
@@ -1263,22 +1261,7 @@
    i32.sub
    i32.ne
    i32.shl
-   i32.const 28
-   i32.add
-   local.tee $3
-   i32.clz
-   i32.sub
-   i32.shl
-   i32.const 1
-   i32.sub
-   local.get $3
-   i32.add
-   local.get $3
-   local.get $3
-   i32.const 536870910
-   i32.lt_u
-   select
-   i32.const 65535
+   i32.const 65563
    i32.add
    i32.const -65536
    i32.and
@@ -1317,7 +1300,7 @@
    if
     i32.const 0
     i32.const 1424
-    i32.const 497
+    i32.const 499
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1332,7 +1315,7 @@
   if
    i32.const 0
    i32.const 1424
-   i32.const 499
+   i32.const 501
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/class-overloading.release.wat
+++ b/tests/compiler/class-overloading.release.wat
@@ -1251,6 +1251,8 @@
   if
    memory.size $0
    local.tee $1
+   i32.const 1
+   i32.const 27
    i32.const 4
    local.get $2
    i32.load $0 offset=1568
@@ -1261,7 +1263,22 @@
    i32.sub
    i32.ne
    i32.shl
-   i32.const 65563
+   i32.const 28
+   i32.add
+   local.tee $3
+   i32.clz
+   i32.sub
+   i32.shl
+   i32.const 1
+   i32.sub
+   local.get $3
+   i32.add
+   local.get $3
+   local.get $3
+   i32.const 536870910
+   i32.lt_u
+   select
+   i32.const 65535
    i32.add
    i32.const -65536
    i32.and

--- a/tests/compiler/class.debug.wat
+++ b/tests/compiler/class.debug.wat
@@ -1997,22 +1997,6 @@
   (local $pagesAfter i32)
   i32.const 0
   drop
-  local.get $size
-  i32.const 536870910
-  i32.lt_u
-  if
-   local.get $size
-   i32.const 1
-   i32.const 27
-   local.get $size
-   i32.clz
-   i32.sub
-   i32.shl
-   i32.const 1
-   i32.sub
-   i32.add
-   local.set $size
-  end
   memory.size $0
   local.set $pagesBefore
   local.get $size
@@ -2033,6 +2017,22 @@
   i32.shl
   i32.add
   local.set $size
+  local.get $size
+  i32.const 536870910
+  i32.lt_u
+  if
+   local.get $size
+   i32.const 1
+   i32.const 27
+   local.get $size
+   i32.clz
+   i32.sub
+   i32.shl
+   i32.const 1
+   i32.sub
+   i32.add
+   local.set $size
+  end
   local.get $size
   i32.const 65535
   i32.add

--- a/tests/compiler/class.debug.wat
+++ b/tests/compiler/class.debug.wat
@@ -2008,7 +2008,7 @@
   drop
   local.get $size
   i32.const 256
-  i32.gt_u
+  i32.ge_u
   if
    local.get $size
    call $~lib/rt/tlsf/roundSize

--- a/tests/compiler/class.debug.wat
+++ b/tests/compiler/class.debug.wat
@@ -1118,7 +1118,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 378
+   i32.const 382
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1164,7 +1164,7 @@
    if
     i32.const 0
     i32.const 368
-    i32.const 385
+    i32.const 389
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1197,7 +1197,7 @@
    if
     i32.const 0
     i32.const 368
-    i32.const 398
+    i32.const 402
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1441,7 +1441,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 560
+   i32.const 562
    i32.const 3
    call $~lib/builtins/abort
    unreachable
@@ -1770,13 +1770,33 @@
   if
    i32.const 32
    i32.const 368
-   i32.const 459
+   i32.const 461
    i32.const 29
    call $~lib/builtins/abort
    unreachable
   end
   local.get $size
   call $~lib/rt/tlsf/computeSize
+  return
+ )
+ (func $~lib/rt/tlsf/roundSize (param $size i32) (result i32)
+  local.get $size
+  i32.const 536870910
+  i32.lt_u
+  if (result i32)
+   local.get $size
+   i32.const 1
+   i32.const 27
+   local.get $size
+   i32.clz
+   i32.sub
+   i32.shl
+   i32.add
+   i32.const 1
+   i32.sub
+  else
+   local.get $size
+  end
   return
  )
  (func $~lib/rt/tlsf/searchBlock (param $root i32) (param $size i32) (result i32)
@@ -1808,24 +1828,13 @@
    local.set $sl
   else
    local.get $size
-   i32.const 536870910
-   i32.lt_u
-   if (result i32)
-    local.get $size
-    i32.const 1
-    i32.const 27
-    local.get $size
-    i32.clz
-    i32.sub
-    i32.shl
-    i32.add
-    i32.const 1
-    i32.sub
-   else
-    local.get $size
-   end
+   call $~lib/rt/tlsf/roundSize
    local.set $requestSize
-   i32.const 31
+   i32.const 4
+   i32.const 8
+   i32.mul
+   i32.const 1
+   i32.sub
    local.get $requestSize
    i32.clz
    i32.sub
@@ -1863,7 +1872,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 330
+   i32.const 334
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1934,7 +1943,7 @@
     if
      i32.const 0
      i32.const 368
-     i32.const 343
+     i32.const 347
      i32.const 18
      call $~lib/builtins/abort
      unreachable
@@ -1997,6 +2006,14 @@
   (local $pagesAfter i32)
   i32.const 0
   drop
+  local.get $size
+  i32.const 256
+  i32.gt_u
+  if
+   local.get $size
+   call $~lib/rt/tlsf/roundSize
+   local.set $size
+  end
   memory.size $0
   local.set $pagesBefore
   local.get $size
@@ -2017,22 +2034,6 @@
   i32.shl
   i32.add
   local.set $size
-  local.get $size
-  i32.const 536870910
-  i32.lt_u
-  if
-   local.get $size
-   i32.const 1
-   i32.const 27
-   local.get $size
-   i32.clz
-   i32.sub
-   i32.shl
-   i32.const 1
-   i32.sub
-   i32.add
-   local.set $size
-  end
   local.get $size
   i32.const 65535
   i32.add
@@ -2099,7 +2100,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 357
+   i32.const 361
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -2214,7 +2215,7 @@
    if
     i32.const 0
     i32.const 368
-    i32.const 497
+    i32.const 499
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -2234,7 +2235,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 499
+   i32.const 501
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/class.release.wat
+++ b/tests/compiler/class.release.wat
@@ -1309,7 +1309,7 @@
    local.tee $2
    local.get $5
    i32.const 256
-   i32.gt_u
+   i32.ge_u
    if (result i32)
     local.get $5
     i32.const 1

--- a/tests/compiler/class.release.wat
+++ b/tests/compiler/class.release.wat
@@ -1272,7 +1272,7 @@
    call $~lib/rt/tlsf/initialize
   end
   global.get $~lib/rt/tlsf/ROOT
-  local.set $4
+  local.set $3
   local.get $0
   i32.const 16
   i32.add
@@ -1287,7 +1287,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $4
+  local.get $3
   i32.const 12
   local.get $2
   i32.const 19
@@ -1307,8 +1307,9 @@
   if
    memory.size $0
    local.tee $2
+   local.get $5
    i32.const 4
-   local.get $4
+   local.get $3
    i32.load $0 offset=1568
    local.get $2
    i32.const 16
@@ -1317,38 +1318,40 @@
    i32.sub
    i32.ne
    i32.shl
-   local.get $5
-   i32.const 1
-   i32.const 27
-   local.get $5
-   i32.clz
-   i32.sub
-   i32.shl
-   i32.const 1
-   i32.sub
    i32.add
-   local.get $5
-   local.get $5
+   local.tee $4
    i32.const 536870910
    i32.lt_u
-   select
-   i32.add
+   if (result i32)
+    local.get $4
+    i32.const 1
+    i32.const 27
+    local.get $4
+    i32.clz
+    i32.sub
+    i32.shl
+    i32.const 1
+    i32.sub
+    i32.add
+   else
+    local.get $4
+   end
    i32.const 65535
    i32.add
    i32.const -65536
    i32.and
    i32.const 16
    i32.shr_u
-   local.tee $3
+   local.tee $4
    local.get $2
-   local.get $3
+   local.get $4
    i32.gt_s
    select
    memory.grow $0
    i32.const 0
    i32.lt_s
    if
-    local.get $3
+    local.get $4
     memory.grow $0
     i32.const 0
     i32.lt_s
@@ -1356,7 +1359,7 @@
      unreachable
     end
    end
-   local.get $4
+   local.get $3
    local.get $2
    i32.const 16
    i32.shl
@@ -1365,7 +1368,7 @@
    i64.const 16
    i64.shl
    call $~lib/rt/tlsf/addMemory
-   local.get $4
+   local.get $3
    local.get $5
    call $~lib/rt/tlsf/searchBlock
    local.tee $2
@@ -1393,12 +1396,12 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $4
+  local.get $3
   local.get $2
   call $~lib/rt/tlsf/removeBlock
   local.get $2
   i32.load $0
-  local.set $3
+  local.set $4
   local.get $5
   i32.const 4
   i32.add
@@ -1412,7 +1415,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $3
+  local.get $4
   i32.const -4
   i32.and
   local.get $5
@@ -1423,7 +1426,7 @@
   if
    local.get $2
    local.get $5
-   local.get $3
+   local.get $4
    i32.const 2
    i32.and
    i32.or
@@ -1433,19 +1436,19 @@
    i32.add
    local.get $5
    i32.add
-   local.tee $3
+   local.tee $4
    local.get $6
    i32.const 4
    i32.sub
    i32.const 1
    i32.or
    i32.store $0
-   local.get $4
    local.get $3
+   local.get $4
    call $~lib/rt/tlsf/insertBlock
   else
    local.get $2
-   local.get $3
+   local.get $4
    i32.const -2
    i32.and
    i32.store $0

--- a/tests/compiler/class.release.wat
+++ b/tests/compiler/class.release.wat
@@ -627,7 +627,7 @@
   if
    i32.const 0
    i32.const 1392
-   i32.const 378
+   i32.const 382
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -652,7 +652,7 @@
    if
     i32.const 0
     i32.const 1392
-    i32.const 385
+    i32.const 389
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -680,7 +680,7 @@
    if
     i32.const 0
     i32.const 1392
-    i32.const 398
+    i32.const 402
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1047,7 +1047,7 @@
       if
        i32.const 0
        i32.const 1392
-       i32.const 560
+       i32.const 562
        i32.const 3
        call $~lib/builtins/abort
        unreachable
@@ -1131,7 +1131,7 @@
   if
    i32.const 0
    i32.const 1392
-   i32.const 330
+   i32.const 334
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1183,7 +1183,7 @@
     if
      i32.const 0
      i32.const 1392
-     i32.const 343
+     i32.const 347
      i32.const 18
      call $~lib/builtins/abort
      unreachable
@@ -1272,7 +1272,7 @@
    call $~lib/rt/tlsf/initialize
   end
   global.get $~lib/rt/tlsf/ROOT
-  local.set $3
+  local.set $4
   local.get $0
   i32.const 16
   i32.add
@@ -1282,12 +1282,12 @@
   if
    i32.const 1056
    i32.const 1392
-   i32.const 459
+   i32.const 461
    i32.const 29
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $3
+  local.get $4
   i32.const 12
   local.get $2
   i32.const 19
@@ -1308,8 +1308,29 @@
    memory.size $0
    local.tee $2
    local.get $5
+   i32.const 256
+   i32.gt_u
+   if (result i32)
+    local.get $5
+    i32.const 1
+    i32.const 27
+    local.get $5
+    i32.clz
+    i32.sub
+    i32.shl
+    i32.add
+    i32.const 1
+    i32.sub
+    local.get $5
+    local.get $5
+    i32.const 536870910
+    i32.lt_u
+    select
+   else
+    local.get $5
+   end
    i32.const 4
-   local.get $3
+   local.get $4
    i32.load $0 offset=1568
    local.get $2
    i32.const 16
@@ -1319,39 +1340,22 @@
    i32.ne
    i32.shl
    i32.add
-   local.tee $4
-   i32.const 536870910
-   i32.lt_u
-   if (result i32)
-    local.get $4
-    i32.const 1
-    i32.const 27
-    local.get $4
-    i32.clz
-    i32.sub
-    i32.shl
-    i32.const 1
-    i32.sub
-    i32.add
-   else
-    local.get $4
-   end
    i32.const 65535
    i32.add
    i32.const -65536
    i32.and
    i32.const 16
    i32.shr_u
-   local.tee $4
+   local.tee $3
    local.get $2
-   local.get $4
+   local.get $3
    i32.gt_s
    select
    memory.grow $0
    i32.const 0
    i32.lt_s
    if
-    local.get $4
+    local.get $3
     memory.grow $0
     i32.const 0
     i32.lt_s
@@ -1359,7 +1363,7 @@
      unreachable
     end
    end
-   local.get $3
+   local.get $4
    local.get $2
    i32.const 16
    i32.shl
@@ -1368,7 +1372,7 @@
    i64.const 16
    i64.shl
    call $~lib/rt/tlsf/addMemory
-   local.get $3
+   local.get $4
    local.get $5
    call $~lib/rt/tlsf/searchBlock
    local.tee $2
@@ -1376,7 +1380,7 @@
    if
     i32.const 0
     i32.const 1392
-    i32.const 497
+    i32.const 499
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1391,17 +1395,17 @@
   if
    i32.const 0
    i32.const 1392
-   i32.const 499
+   i32.const 501
    i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $3
+  local.get $4
   local.get $2
   call $~lib/rt/tlsf/removeBlock
   local.get $2
   i32.load $0
-  local.set $4
+  local.set $3
   local.get $5
   i32.const 4
   i32.add
@@ -1410,12 +1414,12 @@
   if
    i32.const 0
    i32.const 1392
-   i32.const 357
+   i32.const 361
    i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $4
+  local.get $3
   i32.const -4
   i32.and
   local.get $5
@@ -1426,7 +1430,7 @@
   if
    local.get $2
    local.get $5
-   local.get $4
+   local.get $3
    i32.const 2
    i32.and
    i32.or
@@ -1436,19 +1440,19 @@
    i32.add
    local.get $5
    i32.add
-   local.tee $4
+   local.tee $3
    local.get $6
    i32.const 4
    i32.sub
    i32.const 1
    i32.or
    i32.store $0
-   local.get $3
    local.get $4
+   local.get $3
    call $~lib/rt/tlsf/insertBlock
   else
    local.get $2
-   local.get $4
+   local.get $3
    i32.const -2
    i32.and
    i32.store $0

--- a/tests/compiler/constructor.debug.wat
+++ b/tests/compiler/constructor.debug.wat
@@ -1936,7 +1936,7 @@
   drop
   local.get $size
   i32.const 256
-  i32.gt_u
+  i32.ge_u
   if
    local.get $size
    call $~lib/rt/tlsf/roundSize

--- a/tests/compiler/constructor.debug.wat
+++ b/tests/compiler/constructor.debug.wat
@@ -1925,22 +1925,6 @@
   (local $pagesAfter i32)
   i32.const 0
   drop
-  local.get $size
-  i32.const 536870910
-  i32.lt_u
-  if
-   local.get $size
-   i32.const 1
-   i32.const 27
-   local.get $size
-   i32.clz
-   i32.sub
-   i32.shl
-   i32.const 1
-   i32.sub
-   i32.add
-   local.set $size
-  end
   memory.size $0
   local.set $pagesBefore
   local.get $size
@@ -1961,6 +1945,22 @@
   i32.shl
   i32.add
   local.set $size
+  local.get $size
+  i32.const 536870910
+  i32.lt_u
+  if
+   local.get $size
+   i32.const 1
+   i32.const 27
+   local.get $size
+   i32.clz
+   i32.sub
+   i32.shl
+   i32.const 1
+   i32.sub
+   i32.add
+   local.set $size
+  end
   local.get $size
   i32.const 65535
   i32.add

--- a/tests/compiler/constructor.debug.wat
+++ b/tests/compiler/constructor.debug.wat
@@ -1046,7 +1046,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 378
+   i32.const 382
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1092,7 +1092,7 @@
    if
     i32.const 0
     i32.const 368
-    i32.const 385
+    i32.const 389
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1125,7 +1125,7 @@
    if
     i32.const 0
     i32.const 368
-    i32.const 398
+    i32.const 402
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1369,7 +1369,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 560
+   i32.const 562
    i32.const 3
    call $~lib/builtins/abort
    unreachable
@@ -1698,13 +1698,33 @@
   if
    i32.const 32
    i32.const 368
-   i32.const 459
+   i32.const 461
    i32.const 29
    call $~lib/builtins/abort
    unreachable
   end
   local.get $size
   call $~lib/rt/tlsf/computeSize
+  return
+ )
+ (func $~lib/rt/tlsf/roundSize (param $size i32) (result i32)
+  local.get $size
+  i32.const 536870910
+  i32.lt_u
+  if (result i32)
+   local.get $size
+   i32.const 1
+   i32.const 27
+   local.get $size
+   i32.clz
+   i32.sub
+   i32.shl
+   i32.add
+   i32.const 1
+   i32.sub
+  else
+   local.get $size
+  end
   return
  )
  (func $~lib/rt/tlsf/searchBlock (param $root i32) (param $size i32) (result i32)
@@ -1736,24 +1756,13 @@
    local.set $sl
   else
    local.get $size
-   i32.const 536870910
-   i32.lt_u
-   if (result i32)
-    local.get $size
-    i32.const 1
-    i32.const 27
-    local.get $size
-    i32.clz
-    i32.sub
-    i32.shl
-    i32.add
-    i32.const 1
-    i32.sub
-   else
-    local.get $size
-   end
+   call $~lib/rt/tlsf/roundSize
    local.set $requestSize
-   i32.const 31
+   i32.const 4
+   i32.const 8
+   i32.mul
+   i32.const 1
+   i32.sub
    local.get $requestSize
    i32.clz
    i32.sub
@@ -1791,7 +1800,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 330
+   i32.const 334
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1862,7 +1871,7 @@
     if
      i32.const 0
      i32.const 368
-     i32.const 343
+     i32.const 347
      i32.const 18
      call $~lib/builtins/abort
      unreachable
@@ -1925,6 +1934,14 @@
   (local $pagesAfter i32)
   i32.const 0
   drop
+  local.get $size
+  i32.const 256
+  i32.gt_u
+  if
+   local.get $size
+   call $~lib/rt/tlsf/roundSize
+   local.set $size
+  end
   memory.size $0
   local.set $pagesBefore
   local.get $size
@@ -1945,22 +1962,6 @@
   i32.shl
   i32.add
   local.set $size
-  local.get $size
-  i32.const 536870910
-  i32.lt_u
-  if
-   local.get $size
-   i32.const 1
-   i32.const 27
-   local.get $size
-   i32.clz
-   i32.sub
-   i32.shl
-   i32.const 1
-   i32.sub
-   i32.add
-   local.set $size
-  end
   local.get $size
   i32.const 65535
   i32.add
@@ -2027,7 +2028,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 357
+   i32.const 361
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -2142,7 +2143,7 @@
    if
     i32.const 0
     i32.const 368
-    i32.const 497
+    i32.const 499
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -2162,7 +2163,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 499
+   i32.const 501
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/constructor.release.wat
+++ b/tests/compiler/constructor.release.wat
@@ -1329,7 +1329,7 @@
    call $~lib/rt/tlsf/initialize
   end
   global.get $~lib/rt/tlsf/ROOT
-  local.set $4
+  local.set $3
   local.get $0
   i32.const 16
   i32.add
@@ -1344,7 +1344,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $4
+  local.get $3
   i32.const 12
   local.get $2
   i32.const 19
@@ -1364,8 +1364,9 @@
   if
    memory.size $0
    local.tee $2
+   local.get $5
    i32.const 4
-   local.get $4
+   local.get $3
    i32.load $0 offset=1568
    local.get $2
    i32.const 16
@@ -1374,38 +1375,40 @@
    i32.sub
    i32.ne
    i32.shl
-   local.get $5
-   i32.const 1
-   i32.const 27
-   local.get $5
-   i32.clz
-   i32.sub
-   i32.shl
-   i32.const 1
-   i32.sub
    i32.add
-   local.get $5
-   local.get $5
+   local.tee $4
    i32.const 536870910
    i32.lt_u
-   select
-   i32.add
+   if (result i32)
+    local.get $4
+    i32.const 1
+    i32.const 27
+    local.get $4
+    i32.clz
+    i32.sub
+    i32.shl
+    i32.const 1
+    i32.sub
+    i32.add
+   else
+    local.get $4
+   end
    i32.const 65535
    i32.add
    i32.const -65536
    i32.and
    i32.const 16
    i32.shr_u
-   local.tee $3
+   local.tee $4
    local.get $2
-   local.get $3
+   local.get $4
    i32.gt_s
    select
    memory.grow $0
    i32.const 0
    i32.lt_s
    if
-    local.get $3
+    local.get $4
     memory.grow $0
     i32.const 0
     i32.lt_s
@@ -1413,7 +1416,7 @@
      unreachable
     end
    end
-   local.get $4
+   local.get $3
    local.get $2
    i32.const 16
    i32.shl
@@ -1422,7 +1425,7 @@
    i64.const 16
    i64.shl
    call $~lib/rt/tlsf/addMemory
-   local.get $4
+   local.get $3
    local.get $5
    call $~lib/rt/tlsf/searchBlock
    local.tee $2
@@ -1450,12 +1453,12 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $4
+  local.get $3
   local.get $2
   call $~lib/rt/tlsf/removeBlock
   local.get $2
   i32.load $0
-  local.set $3
+  local.set $4
   local.get $5
   i32.const 4
   i32.add
@@ -1469,7 +1472,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $3
+  local.get $4
   i32.const -4
   i32.and
   local.get $5
@@ -1480,7 +1483,7 @@
   if
    local.get $2
    local.get $5
-   local.get $3
+   local.get $4
    i32.const 2
    i32.and
    i32.or
@@ -1490,19 +1493,19 @@
    i32.add
    local.get $5
    i32.add
-   local.tee $3
+   local.tee $4
    local.get $6
    i32.const 4
    i32.sub
    i32.const 1
    i32.or
    i32.store $0
-   local.get $4
    local.get $3
+   local.get $4
    call $~lib/rt/tlsf/insertBlock
   else
    local.get $2
-   local.get $3
+   local.get $4
    i32.const -2
    i32.and
    i32.store $0

--- a/tests/compiler/constructor.release.wat
+++ b/tests/compiler/constructor.release.wat
@@ -1366,7 +1366,7 @@
    local.tee $2
    local.get $5
    i32.const 256
-   i32.gt_u
+   i32.ge_u
    if (result i32)
     local.get $5
     i32.const 1

--- a/tests/compiler/constructor.release.wat
+++ b/tests/compiler/constructor.release.wat
@@ -684,7 +684,7 @@
   if
    i32.const 0
    i32.const 1392
-   i32.const 378
+   i32.const 382
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -709,7 +709,7 @@
    if
     i32.const 0
     i32.const 1392
-    i32.const 385
+    i32.const 389
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -737,7 +737,7 @@
    if
     i32.const 0
     i32.const 1392
-    i32.const 398
+    i32.const 402
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1104,7 +1104,7 @@
       if
        i32.const 0
        i32.const 1392
-       i32.const 560
+       i32.const 562
        i32.const 3
        call $~lib/builtins/abort
        unreachable
@@ -1188,7 +1188,7 @@
   if
    i32.const 0
    i32.const 1392
-   i32.const 330
+   i32.const 334
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1240,7 +1240,7 @@
     if
      i32.const 0
      i32.const 1392
-     i32.const 343
+     i32.const 347
      i32.const 18
      call $~lib/builtins/abort
      unreachable
@@ -1329,7 +1329,7 @@
    call $~lib/rt/tlsf/initialize
   end
   global.get $~lib/rt/tlsf/ROOT
-  local.set $3
+  local.set $4
   local.get $0
   i32.const 16
   i32.add
@@ -1339,12 +1339,12 @@
   if
    i32.const 1056
    i32.const 1392
-   i32.const 459
+   i32.const 461
    i32.const 29
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $3
+  local.get $4
   i32.const 12
   local.get $2
   i32.const 19
@@ -1365,8 +1365,29 @@
    memory.size $0
    local.tee $2
    local.get $5
+   i32.const 256
+   i32.gt_u
+   if (result i32)
+    local.get $5
+    i32.const 1
+    i32.const 27
+    local.get $5
+    i32.clz
+    i32.sub
+    i32.shl
+    i32.add
+    i32.const 1
+    i32.sub
+    local.get $5
+    local.get $5
+    i32.const 536870910
+    i32.lt_u
+    select
+   else
+    local.get $5
+   end
    i32.const 4
-   local.get $3
+   local.get $4
    i32.load $0 offset=1568
    local.get $2
    i32.const 16
@@ -1376,39 +1397,22 @@
    i32.ne
    i32.shl
    i32.add
-   local.tee $4
-   i32.const 536870910
-   i32.lt_u
-   if (result i32)
-    local.get $4
-    i32.const 1
-    i32.const 27
-    local.get $4
-    i32.clz
-    i32.sub
-    i32.shl
-    i32.const 1
-    i32.sub
-    i32.add
-   else
-    local.get $4
-   end
    i32.const 65535
    i32.add
    i32.const -65536
    i32.and
    i32.const 16
    i32.shr_u
-   local.tee $4
+   local.tee $3
    local.get $2
-   local.get $4
+   local.get $3
    i32.gt_s
    select
    memory.grow $0
    i32.const 0
    i32.lt_s
    if
-    local.get $4
+    local.get $3
     memory.grow $0
     i32.const 0
     i32.lt_s
@@ -1416,7 +1420,7 @@
      unreachable
     end
    end
-   local.get $3
+   local.get $4
    local.get $2
    i32.const 16
    i32.shl
@@ -1425,7 +1429,7 @@
    i64.const 16
    i64.shl
    call $~lib/rt/tlsf/addMemory
-   local.get $3
+   local.get $4
    local.get $5
    call $~lib/rt/tlsf/searchBlock
    local.tee $2
@@ -1433,7 +1437,7 @@
    if
     i32.const 0
     i32.const 1392
-    i32.const 497
+    i32.const 499
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1448,17 +1452,17 @@
   if
    i32.const 0
    i32.const 1392
-   i32.const 499
+   i32.const 501
    i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $3
+  local.get $4
   local.get $2
   call $~lib/rt/tlsf/removeBlock
   local.get $2
   i32.load $0
-  local.set $4
+  local.set $3
   local.get $5
   i32.const 4
   i32.add
@@ -1467,12 +1471,12 @@
   if
    i32.const 0
    i32.const 1392
-   i32.const 357
+   i32.const 361
    i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $4
+  local.get $3
   i32.const -4
   i32.and
   local.get $5
@@ -1483,7 +1487,7 @@
   if
    local.get $2
    local.get $5
-   local.get $4
+   local.get $3
    i32.const 2
    i32.and
    i32.or
@@ -1493,19 +1497,19 @@
    i32.add
    local.get $5
    i32.add
-   local.tee $4
+   local.tee $3
    local.get $6
    i32.const 4
    i32.sub
    i32.const 1
    i32.or
    i32.store $0
-   local.get $3
    local.get $4
+   local.get $3
    call $~lib/rt/tlsf/insertBlock
   else
    local.get $2
-   local.get $4
+   local.get $3
    i32.const -2
    i32.and
    i32.store $0

--- a/tests/compiler/do.debug.wat
+++ b/tests/compiler/do.debug.wat
@@ -2331,7 +2331,7 @@
   drop
   local.get $size
   i32.const 256
-  i32.gt_u
+  i32.ge_u
   if
    local.get $size
    call $~lib/rt/tlsf/roundSize

--- a/tests/compiler/do.debug.wat
+++ b/tests/compiler/do.debug.wat
@@ -1441,7 +1441,7 @@
   if
    i32.const 0
    i32.const 400
-   i32.const 378
+   i32.const 382
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1487,7 +1487,7 @@
    if
     i32.const 0
     i32.const 400
-    i32.const 385
+    i32.const 389
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1520,7 +1520,7 @@
    if
     i32.const 0
     i32.const 400
-    i32.const 398
+    i32.const 402
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1764,7 +1764,7 @@
   if
    i32.const 0
    i32.const 400
-   i32.const 560
+   i32.const 562
    i32.const 3
    call $~lib/builtins/abort
    unreachable
@@ -2093,13 +2093,33 @@
   if
    i32.const 64
    i32.const 400
-   i32.const 459
+   i32.const 461
    i32.const 29
    call $~lib/builtins/abort
    unreachable
   end
   local.get $size
   call $~lib/rt/tlsf/computeSize
+  return
+ )
+ (func $~lib/rt/tlsf/roundSize (param $size i32) (result i32)
+  local.get $size
+  i32.const 536870910
+  i32.lt_u
+  if (result i32)
+   local.get $size
+   i32.const 1
+   i32.const 27
+   local.get $size
+   i32.clz
+   i32.sub
+   i32.shl
+   i32.add
+   i32.const 1
+   i32.sub
+  else
+   local.get $size
+  end
   return
  )
  (func $~lib/rt/tlsf/searchBlock (param $root i32) (param $size i32) (result i32)
@@ -2131,24 +2151,13 @@
    local.set $sl
   else
    local.get $size
-   i32.const 536870910
-   i32.lt_u
-   if (result i32)
-    local.get $size
-    i32.const 1
-    i32.const 27
-    local.get $size
-    i32.clz
-    i32.sub
-    i32.shl
-    i32.add
-    i32.const 1
-    i32.sub
-   else
-    local.get $size
-   end
+   call $~lib/rt/tlsf/roundSize
    local.set $requestSize
-   i32.const 31
+   i32.const 4
+   i32.const 8
+   i32.mul
+   i32.const 1
+   i32.sub
    local.get $requestSize
    i32.clz
    i32.sub
@@ -2186,7 +2195,7 @@
   if
    i32.const 0
    i32.const 400
-   i32.const 330
+   i32.const 334
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -2257,7 +2266,7 @@
     if
      i32.const 0
      i32.const 400
-     i32.const 343
+     i32.const 347
      i32.const 18
      call $~lib/builtins/abort
      unreachable
@@ -2320,6 +2329,14 @@
   (local $pagesAfter i32)
   i32.const 0
   drop
+  local.get $size
+  i32.const 256
+  i32.gt_u
+  if
+   local.get $size
+   call $~lib/rt/tlsf/roundSize
+   local.set $size
+  end
   memory.size $0
   local.set $pagesBefore
   local.get $size
@@ -2340,22 +2357,6 @@
   i32.shl
   i32.add
   local.set $size
-  local.get $size
-  i32.const 536870910
-  i32.lt_u
-  if
-   local.get $size
-   i32.const 1
-   i32.const 27
-   local.get $size
-   i32.clz
-   i32.sub
-   i32.shl
-   i32.const 1
-   i32.sub
-   i32.add
-   local.set $size
-  end
   local.get $size
   i32.const 65535
   i32.add
@@ -2422,7 +2423,7 @@
   if
    i32.const 0
    i32.const 400
-   i32.const 357
+   i32.const 361
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -2537,7 +2538,7 @@
    if
     i32.const 0
     i32.const 400
-    i32.const 497
+    i32.const 499
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -2557,7 +2558,7 @@
   if
    i32.const 0
    i32.const 400
-   i32.const 499
+   i32.const 501
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/do.debug.wat
+++ b/tests/compiler/do.debug.wat
@@ -2320,22 +2320,6 @@
   (local $pagesAfter i32)
   i32.const 0
   drop
-  local.get $size
-  i32.const 536870910
-  i32.lt_u
-  if
-   local.get $size
-   i32.const 1
-   i32.const 27
-   local.get $size
-   i32.clz
-   i32.sub
-   i32.shl
-   i32.const 1
-   i32.sub
-   i32.add
-   local.set $size
-  end
   memory.size $0
   local.set $pagesBefore
   local.get $size
@@ -2356,6 +2340,22 @@
   i32.shl
   i32.add
   local.set $size
+  local.get $size
+  i32.const 536870910
+  i32.lt_u
+  if
+   local.get $size
+   i32.const 1
+   i32.const 27
+   local.get $size
+   i32.clz
+   i32.sub
+   i32.shl
+   i32.const 1
+   i32.sub
+   i32.add
+   local.set $size
+  end
   local.get $size
   i32.const 65535
   i32.add

--- a/tests/compiler/do.release.wat
+++ b/tests/compiler/do.release.wat
@@ -1191,6 +1191,8 @@
   if
    memory.size $0
    local.tee $1
+   i32.const 1
+   i32.const 27
    i32.const 4
    local.get $2
    i32.load $0 offset=1568
@@ -1201,7 +1203,22 @@
    i32.sub
    i32.ne
    i32.shl
-   i32.const 65563
+   i32.const 28
+   i32.add
+   local.tee $3
+   i32.clz
+   i32.sub
+   i32.shl
+   i32.const 1
+   i32.sub
+   local.get $3
+   i32.add
+   local.get $3
+   local.get $3
+   i32.const 536870910
+   i32.lt_u
+   select
+   i32.const 65535
    i32.add
    i32.const -65536
    i32.and

--- a/tests/compiler/do.release.wat
+++ b/tests/compiler/do.release.wat
@@ -620,7 +620,7 @@
   if
    i32.const 0
    i32.const 1424
-   i32.const 378
+   i32.const 382
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -645,7 +645,7 @@
    if
     i32.const 0
     i32.const 1424
-    i32.const 385
+    i32.const 389
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -673,7 +673,7 @@
    if
     i32.const 0
     i32.const 1424
-    i32.const 398
+    i32.const 402
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1040,7 +1040,7 @@
       if
        i32.const 0
        i32.const 1424
-       i32.const 560
+       i32.const 562
        i32.const 3
        call $~lib/builtins/abort
        unreachable
@@ -1107,7 +1107,7 @@
     if
      i32.const 0
      i32.const 1424
-     i32.const 343
+     i32.const 347
      i32.const 18
      call $~lib/builtins/abort
      unreachable
@@ -1191,8 +1191,6 @@
   if
    memory.size $0
    local.tee $1
-   i32.const 1
-   i32.const 27
    i32.const 4
    local.get $2
    i32.load $0 offset=1568
@@ -1203,22 +1201,7 @@
    i32.sub
    i32.ne
    i32.shl
-   i32.const 28
-   i32.add
-   local.tee $3
-   i32.clz
-   i32.sub
-   i32.shl
-   i32.const 1
-   i32.sub
-   local.get $3
-   i32.add
-   local.get $3
-   local.get $3
-   i32.const 536870910
-   i32.lt_u
-   select
-   i32.const 65535
+   i32.const 65563
    i32.add
    i32.const -65536
    i32.and
@@ -1257,7 +1240,7 @@
    if
     i32.const 0
     i32.const 1424
-    i32.const 497
+    i32.const 499
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1272,7 +1255,7 @@
   if
    i32.const 0
    i32.const 1424
-   i32.const 499
+   i32.const 501
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/duplicate-fields.debug.wat
+++ b/tests/compiler/duplicate-fields.debug.wat
@@ -1040,7 +1040,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 378
+   i32.const 382
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1086,7 +1086,7 @@
    if
     i32.const 0
     i32.const 368
-    i32.const 385
+    i32.const 389
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1119,7 +1119,7 @@
    if
     i32.const 0
     i32.const 368
-    i32.const 398
+    i32.const 402
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1363,7 +1363,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 560
+   i32.const 562
    i32.const 3
    call $~lib/builtins/abort
    unreachable
@@ -1692,13 +1692,33 @@
   if
    i32.const 32
    i32.const 368
-   i32.const 459
+   i32.const 461
    i32.const 29
    call $~lib/builtins/abort
    unreachable
   end
   local.get $size
   call $~lib/rt/tlsf/computeSize
+  return
+ )
+ (func $~lib/rt/tlsf/roundSize (param $size i32) (result i32)
+  local.get $size
+  i32.const 536870910
+  i32.lt_u
+  if (result i32)
+   local.get $size
+   i32.const 1
+   i32.const 27
+   local.get $size
+   i32.clz
+   i32.sub
+   i32.shl
+   i32.add
+   i32.const 1
+   i32.sub
+  else
+   local.get $size
+  end
   return
  )
  (func $~lib/rt/tlsf/searchBlock (param $root i32) (param $size i32) (result i32)
@@ -1730,24 +1750,13 @@
    local.set $sl
   else
    local.get $size
-   i32.const 536870910
-   i32.lt_u
-   if (result i32)
-    local.get $size
-    i32.const 1
-    i32.const 27
-    local.get $size
-    i32.clz
-    i32.sub
-    i32.shl
-    i32.add
-    i32.const 1
-    i32.sub
-   else
-    local.get $size
-   end
+   call $~lib/rt/tlsf/roundSize
    local.set $requestSize
-   i32.const 31
+   i32.const 4
+   i32.const 8
+   i32.mul
+   i32.const 1
+   i32.sub
    local.get $requestSize
    i32.clz
    i32.sub
@@ -1785,7 +1794,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 330
+   i32.const 334
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1856,7 +1865,7 @@
     if
      i32.const 0
      i32.const 368
-     i32.const 343
+     i32.const 347
      i32.const 18
      call $~lib/builtins/abort
      unreachable
@@ -1919,6 +1928,14 @@
   (local $pagesAfter i32)
   i32.const 0
   drop
+  local.get $size
+  i32.const 256
+  i32.gt_u
+  if
+   local.get $size
+   call $~lib/rt/tlsf/roundSize
+   local.set $size
+  end
   memory.size $0
   local.set $pagesBefore
   local.get $size
@@ -1939,22 +1956,6 @@
   i32.shl
   i32.add
   local.set $size
-  local.get $size
-  i32.const 536870910
-  i32.lt_u
-  if
-   local.get $size
-   i32.const 1
-   i32.const 27
-   local.get $size
-   i32.clz
-   i32.sub
-   i32.shl
-   i32.const 1
-   i32.sub
-   i32.add
-   local.set $size
-  end
   local.get $size
   i32.const 65535
   i32.add
@@ -2021,7 +2022,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 357
+   i32.const 361
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -2136,7 +2137,7 @@
    if
     i32.const 0
     i32.const 368
-    i32.const 497
+    i32.const 499
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -2156,7 +2157,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 499
+   i32.const 501
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/duplicate-fields.debug.wat
+++ b/tests/compiler/duplicate-fields.debug.wat
@@ -1919,22 +1919,6 @@
   (local $pagesAfter i32)
   i32.const 0
   drop
-  local.get $size
-  i32.const 536870910
-  i32.lt_u
-  if
-   local.get $size
-   i32.const 1
-   i32.const 27
-   local.get $size
-   i32.clz
-   i32.sub
-   i32.shl
-   i32.const 1
-   i32.sub
-   i32.add
-   local.set $size
-  end
   memory.size $0
   local.set $pagesBefore
   local.get $size
@@ -1955,6 +1939,22 @@
   i32.shl
   i32.add
   local.set $size
+  local.get $size
+  i32.const 536870910
+  i32.lt_u
+  if
+   local.get $size
+   i32.const 1
+   i32.const 27
+   local.get $size
+   i32.clz
+   i32.sub
+   i32.shl
+   i32.const 1
+   i32.sub
+   i32.add
+   local.set $size
+  end
   local.get $size
   i32.const 65535
   i32.add

--- a/tests/compiler/duplicate-fields.debug.wat
+++ b/tests/compiler/duplicate-fields.debug.wat
@@ -1930,7 +1930,7 @@
   drop
   local.get $size
   i32.const 256
-  i32.gt_u
+  i32.ge_u
   if
    local.get $size
    call $~lib/rt/tlsf/roundSize

--- a/tests/compiler/duplicate-fields.release.wat
+++ b/tests/compiler/duplicate-fields.release.wat
@@ -1279,7 +1279,7 @@
    call $~lib/rt/tlsf/initialize
   end
   global.get $~lib/rt/tlsf/ROOT
-  local.set $4
+  local.set $3
   local.get $0
   i32.const 16
   i32.add
@@ -1294,7 +1294,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $4
+  local.get $3
   i32.const 12
   local.get $2
   i32.const 19
@@ -1314,8 +1314,9 @@
   if
    memory.size $0
    local.tee $2
+   local.get $5
    i32.const 4
-   local.get $4
+   local.get $3
    i32.load $0 offset=1568
    local.get $2
    i32.const 16
@@ -1324,38 +1325,40 @@
    i32.sub
    i32.ne
    i32.shl
-   local.get $5
-   i32.const 1
-   i32.const 27
-   local.get $5
-   i32.clz
-   i32.sub
-   i32.shl
-   i32.const 1
-   i32.sub
    i32.add
-   local.get $5
-   local.get $5
+   local.tee $4
    i32.const 536870910
    i32.lt_u
-   select
-   i32.add
+   if (result i32)
+    local.get $4
+    i32.const 1
+    i32.const 27
+    local.get $4
+    i32.clz
+    i32.sub
+    i32.shl
+    i32.const 1
+    i32.sub
+    i32.add
+   else
+    local.get $4
+   end
    i32.const 65535
    i32.add
    i32.const -65536
    i32.and
    i32.const 16
    i32.shr_u
-   local.tee $3
+   local.tee $4
    local.get $2
-   local.get $3
+   local.get $4
    i32.gt_s
    select
    memory.grow $0
    i32.const 0
    i32.lt_s
    if
-    local.get $3
+    local.get $4
     memory.grow $0
     i32.const 0
     i32.lt_s
@@ -1363,7 +1366,7 @@
      unreachable
     end
    end
-   local.get $4
+   local.get $3
    local.get $2
    i32.const 16
    i32.shl
@@ -1372,7 +1375,7 @@
    i64.const 16
    i64.shl
    call $~lib/rt/tlsf/addMemory
-   local.get $4
+   local.get $3
    local.get $5
    call $~lib/rt/tlsf/searchBlock
    local.tee $2
@@ -1400,12 +1403,12 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $4
+  local.get $3
   local.get $2
   call $~lib/rt/tlsf/removeBlock
   local.get $2
   i32.load $0
-  local.set $3
+  local.set $4
   local.get $5
   i32.const 4
   i32.add
@@ -1419,7 +1422,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $3
+  local.get $4
   i32.const -4
   i32.and
   local.get $5
@@ -1430,7 +1433,7 @@
   if
    local.get $2
    local.get $5
-   local.get $3
+   local.get $4
    i32.const 2
    i32.and
    i32.or
@@ -1440,19 +1443,19 @@
    i32.add
    local.get $5
    i32.add
-   local.tee $3
+   local.tee $4
    local.get $6
    i32.const 4
    i32.sub
    i32.const 1
    i32.or
    i32.store $0
-   local.get $4
    local.get $3
+   local.get $4
    call $~lib/rt/tlsf/insertBlock
   else
    local.get $2
-   local.get $3
+   local.get $4
    i32.const -2
    i32.and
    i32.store $0

--- a/tests/compiler/duplicate-fields.release.wat
+++ b/tests/compiler/duplicate-fields.release.wat
@@ -634,7 +634,7 @@
   if
    i32.const 0
    i32.const 1392
-   i32.const 378
+   i32.const 382
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -659,7 +659,7 @@
    if
     i32.const 0
     i32.const 1392
-    i32.const 385
+    i32.const 389
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -687,7 +687,7 @@
    if
     i32.const 0
     i32.const 1392
-    i32.const 398
+    i32.const 402
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1054,7 +1054,7 @@
       if
        i32.const 0
        i32.const 1392
-       i32.const 560
+       i32.const 562
        i32.const 3
        call $~lib/builtins/abort
        unreachable
@@ -1138,7 +1138,7 @@
   if
    i32.const 0
    i32.const 1392
-   i32.const 330
+   i32.const 334
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1190,7 +1190,7 @@
     if
      i32.const 0
      i32.const 1392
-     i32.const 343
+     i32.const 347
      i32.const 18
      call $~lib/builtins/abort
      unreachable
@@ -1279,7 +1279,7 @@
    call $~lib/rt/tlsf/initialize
   end
   global.get $~lib/rt/tlsf/ROOT
-  local.set $3
+  local.set $4
   local.get $0
   i32.const 16
   i32.add
@@ -1289,12 +1289,12 @@
   if
    i32.const 1056
    i32.const 1392
-   i32.const 459
+   i32.const 461
    i32.const 29
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $3
+  local.get $4
   i32.const 12
   local.get $2
   i32.const 19
@@ -1315,8 +1315,29 @@
    memory.size $0
    local.tee $2
    local.get $5
+   i32.const 256
+   i32.gt_u
+   if (result i32)
+    local.get $5
+    i32.const 1
+    i32.const 27
+    local.get $5
+    i32.clz
+    i32.sub
+    i32.shl
+    i32.add
+    i32.const 1
+    i32.sub
+    local.get $5
+    local.get $5
+    i32.const 536870910
+    i32.lt_u
+    select
+   else
+    local.get $5
+   end
    i32.const 4
-   local.get $3
+   local.get $4
    i32.load $0 offset=1568
    local.get $2
    i32.const 16
@@ -1326,39 +1347,22 @@
    i32.ne
    i32.shl
    i32.add
-   local.tee $4
-   i32.const 536870910
-   i32.lt_u
-   if (result i32)
-    local.get $4
-    i32.const 1
-    i32.const 27
-    local.get $4
-    i32.clz
-    i32.sub
-    i32.shl
-    i32.const 1
-    i32.sub
-    i32.add
-   else
-    local.get $4
-   end
    i32.const 65535
    i32.add
    i32.const -65536
    i32.and
    i32.const 16
    i32.shr_u
-   local.tee $4
+   local.tee $3
    local.get $2
-   local.get $4
+   local.get $3
    i32.gt_s
    select
    memory.grow $0
    i32.const 0
    i32.lt_s
    if
-    local.get $4
+    local.get $3
     memory.grow $0
     i32.const 0
     i32.lt_s
@@ -1366,7 +1370,7 @@
      unreachable
     end
    end
-   local.get $3
+   local.get $4
    local.get $2
    i32.const 16
    i32.shl
@@ -1375,7 +1379,7 @@
    i64.const 16
    i64.shl
    call $~lib/rt/tlsf/addMemory
-   local.get $3
+   local.get $4
    local.get $5
    call $~lib/rt/tlsf/searchBlock
    local.tee $2
@@ -1383,7 +1387,7 @@
    if
     i32.const 0
     i32.const 1392
-    i32.const 497
+    i32.const 499
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1398,17 +1402,17 @@
   if
    i32.const 0
    i32.const 1392
-   i32.const 499
+   i32.const 501
    i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $3
+  local.get $4
   local.get $2
   call $~lib/rt/tlsf/removeBlock
   local.get $2
   i32.load $0
-  local.set $4
+  local.set $3
   local.get $5
   i32.const 4
   i32.add
@@ -1417,12 +1421,12 @@
   if
    i32.const 0
    i32.const 1392
-   i32.const 357
+   i32.const 361
    i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $4
+  local.get $3
   i32.const -4
   i32.and
   local.get $5
@@ -1433,7 +1437,7 @@
   if
    local.get $2
    local.get $5
-   local.get $4
+   local.get $3
    i32.const 2
    i32.and
    i32.or
@@ -1443,19 +1447,19 @@
    i32.add
    local.get $5
    i32.add
-   local.tee $4
+   local.tee $3
    local.get $6
    i32.const 4
    i32.sub
    i32.const 1
    i32.or
    i32.store $0
-   local.get $3
    local.get $4
+   local.get $3
    call $~lib/rt/tlsf/insertBlock
   else
    local.get $2
-   local.get $4
+   local.get $3
    i32.const -2
    i32.and
    i32.store $0

--- a/tests/compiler/duplicate-fields.release.wat
+++ b/tests/compiler/duplicate-fields.release.wat
@@ -1316,7 +1316,7 @@
    local.tee $2
    local.get $5
    i32.const 256
-   i32.gt_u
+   i32.ge_u
    if (result i32)
     local.get $5
     i32.const 1

--- a/tests/compiler/empty-exportruntime.debug.wat
+++ b/tests/compiler/empty-exportruntime.debug.wat
@@ -1039,7 +1039,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 378
+   i32.const 382
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1085,7 +1085,7 @@
    if
     i32.const 0
     i32.const 368
-    i32.const 385
+    i32.const 389
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1118,7 +1118,7 @@
    if
     i32.const 0
     i32.const 368
-    i32.const 398
+    i32.const 402
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1362,7 +1362,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 560
+   i32.const 562
    i32.const 3
    call $~lib/builtins/abort
    unreachable
@@ -1691,13 +1691,33 @@
   if
    i32.const 32
    i32.const 368
-   i32.const 459
+   i32.const 461
    i32.const 29
    call $~lib/builtins/abort
    unreachable
   end
   local.get $size
   call $~lib/rt/tlsf/computeSize
+  return
+ )
+ (func $~lib/rt/tlsf/roundSize (param $size i32) (result i32)
+  local.get $size
+  i32.const 536870910
+  i32.lt_u
+  if (result i32)
+   local.get $size
+   i32.const 1
+   i32.const 27
+   local.get $size
+   i32.clz
+   i32.sub
+   i32.shl
+   i32.add
+   i32.const 1
+   i32.sub
+  else
+   local.get $size
+  end
   return
  )
  (func $~lib/rt/tlsf/searchBlock (param $root i32) (param $size i32) (result i32)
@@ -1729,24 +1749,13 @@
    local.set $sl
   else
    local.get $size
-   i32.const 536870910
-   i32.lt_u
-   if (result i32)
-    local.get $size
-    i32.const 1
-    i32.const 27
-    local.get $size
-    i32.clz
-    i32.sub
-    i32.shl
-    i32.add
-    i32.const 1
-    i32.sub
-   else
-    local.get $size
-   end
+   call $~lib/rt/tlsf/roundSize
    local.set $requestSize
-   i32.const 31
+   i32.const 4
+   i32.const 8
+   i32.mul
+   i32.const 1
+   i32.sub
    local.get $requestSize
    i32.clz
    i32.sub
@@ -1784,7 +1793,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 330
+   i32.const 334
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1855,7 +1864,7 @@
     if
      i32.const 0
      i32.const 368
-     i32.const 343
+     i32.const 347
      i32.const 18
      call $~lib/builtins/abort
      unreachable
@@ -1918,6 +1927,14 @@
   (local $pagesAfter i32)
   i32.const 0
   drop
+  local.get $size
+  i32.const 256
+  i32.gt_u
+  if
+   local.get $size
+   call $~lib/rt/tlsf/roundSize
+   local.set $size
+  end
   memory.size $0
   local.set $pagesBefore
   local.get $size
@@ -1938,22 +1955,6 @@
   i32.shl
   i32.add
   local.set $size
-  local.get $size
-  i32.const 536870910
-  i32.lt_u
-  if
-   local.get $size
-   i32.const 1
-   i32.const 27
-   local.get $size
-   i32.clz
-   i32.sub
-   i32.shl
-   i32.const 1
-   i32.sub
-   i32.add
-   local.set $size
-  end
   local.get $size
   i32.const 65535
   i32.add
@@ -2020,7 +2021,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 357
+   i32.const 361
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -2135,7 +2136,7 @@
    if
     i32.const 0
     i32.const 368
-    i32.const 497
+    i32.const 499
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -2155,7 +2156,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 499
+   i32.const 501
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/empty-exportruntime.debug.wat
+++ b/tests/compiler/empty-exportruntime.debug.wat
@@ -1918,22 +1918,6 @@
   (local $pagesAfter i32)
   i32.const 0
   drop
-  local.get $size
-  i32.const 536870910
-  i32.lt_u
-  if
-   local.get $size
-   i32.const 1
-   i32.const 27
-   local.get $size
-   i32.clz
-   i32.sub
-   i32.shl
-   i32.const 1
-   i32.sub
-   i32.add
-   local.set $size
-  end
   memory.size $0
   local.set $pagesBefore
   local.get $size
@@ -1954,6 +1938,22 @@
   i32.shl
   i32.add
   local.set $size
+  local.get $size
+  i32.const 536870910
+  i32.lt_u
+  if
+   local.get $size
+   i32.const 1
+   i32.const 27
+   local.get $size
+   i32.clz
+   i32.sub
+   i32.shl
+   i32.const 1
+   i32.sub
+   i32.add
+   local.set $size
+  end
   local.get $size
   i32.const 65535
   i32.add

--- a/tests/compiler/empty-exportruntime.debug.wat
+++ b/tests/compiler/empty-exportruntime.debug.wat
@@ -1929,7 +1929,7 @@
   drop
   local.get $size
   i32.const 256
-  i32.gt_u
+  i32.ge_u
   if
    local.get $size
    call $~lib/rt/tlsf/roundSize

--- a/tests/compiler/empty-exportruntime.release.wat
+++ b/tests/compiler/empty-exportruntime.release.wat
@@ -635,7 +635,7 @@
   if
    i32.const 0
    i32.const 1392
-   i32.const 378
+   i32.const 382
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -660,7 +660,7 @@
    if
     i32.const 0
     i32.const 1392
-    i32.const 385
+    i32.const 389
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -688,7 +688,7 @@
    if
     i32.const 0
     i32.const 1392
-    i32.const 398
+    i32.const 402
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1055,7 +1055,7 @@
       if
        i32.const 0
        i32.const 1392
-       i32.const 560
+       i32.const 562
        i32.const 3
        call $~lib/builtins/abort
        unreachable
@@ -1139,7 +1139,7 @@
   if
    i32.const 0
    i32.const 1392
-   i32.const 330
+   i32.const 334
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1191,7 +1191,7 @@
     if
      i32.const 0
      i32.const 1392
-     i32.const 343
+     i32.const 347
      i32.const 18
      call $~lib/builtins/abort
      unreachable
@@ -1280,7 +1280,7 @@
    call $~lib/rt/tlsf/initialize
   end
   global.get $~lib/rt/tlsf/ROOT
-  local.set $3
+  local.set $4
   local.get $0
   i32.const 16
   i32.add
@@ -1290,12 +1290,12 @@
   if
    i32.const 1056
    i32.const 1392
-   i32.const 459
+   i32.const 461
    i32.const 29
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $3
+  local.get $4
   i32.const 12
   local.get $2
   i32.const 19
@@ -1316,8 +1316,29 @@
    memory.size $0
    local.tee $2
    local.get $5
+   i32.const 256
+   i32.gt_u
+   if (result i32)
+    local.get $5
+    i32.const 1
+    i32.const 27
+    local.get $5
+    i32.clz
+    i32.sub
+    i32.shl
+    i32.add
+    i32.const 1
+    i32.sub
+    local.get $5
+    local.get $5
+    i32.const 536870910
+    i32.lt_u
+    select
+   else
+    local.get $5
+   end
    i32.const 4
-   local.get $3
+   local.get $4
    i32.load $0 offset=1568
    local.get $2
    i32.const 16
@@ -1327,39 +1348,22 @@
    i32.ne
    i32.shl
    i32.add
-   local.tee $4
-   i32.const 536870910
-   i32.lt_u
-   if (result i32)
-    local.get $4
-    i32.const 1
-    i32.const 27
-    local.get $4
-    i32.clz
-    i32.sub
-    i32.shl
-    i32.const 1
-    i32.sub
-    i32.add
-   else
-    local.get $4
-   end
    i32.const 65535
    i32.add
    i32.const -65536
    i32.and
    i32.const 16
    i32.shr_u
-   local.tee $4
+   local.tee $3
    local.get $2
-   local.get $4
+   local.get $3
    i32.gt_s
    select
    memory.grow $0
    i32.const 0
    i32.lt_s
    if
-    local.get $4
+    local.get $3
     memory.grow $0
     i32.const 0
     i32.lt_s
@@ -1367,7 +1371,7 @@
      unreachable
     end
    end
-   local.get $3
+   local.get $4
    local.get $2
    i32.const 16
    i32.shl
@@ -1376,7 +1380,7 @@
    i64.const 16
    i64.shl
    call $~lib/rt/tlsf/addMemory
-   local.get $3
+   local.get $4
    local.get $5
    call $~lib/rt/tlsf/searchBlock
    local.tee $2
@@ -1384,7 +1388,7 @@
    if
     i32.const 0
     i32.const 1392
-    i32.const 497
+    i32.const 499
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1399,17 +1403,17 @@
   if
    i32.const 0
    i32.const 1392
-   i32.const 499
+   i32.const 501
    i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $3
+  local.get $4
   local.get $2
   call $~lib/rt/tlsf/removeBlock
   local.get $2
   i32.load $0
-  local.set $4
+  local.set $3
   local.get $5
   i32.const 4
   i32.add
@@ -1418,12 +1422,12 @@
   if
    i32.const 0
    i32.const 1392
-   i32.const 357
+   i32.const 361
    i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $4
+  local.get $3
   i32.const -4
   i32.and
   local.get $5
@@ -1434,7 +1438,7 @@
   if
    local.get $2
    local.get $5
-   local.get $4
+   local.get $3
    i32.const 2
    i32.and
    i32.or
@@ -1444,19 +1448,19 @@
    i32.add
    local.get $5
    i32.add
-   local.tee $4
+   local.tee $3
    local.get $6
    i32.const 4
    i32.sub
    i32.const 1
    i32.or
    i32.store $0
-   local.get $3
    local.get $4
+   local.get $3
    call $~lib/rt/tlsf/insertBlock
   else
    local.get $2
-   local.get $4
+   local.get $3
    i32.const -2
    i32.and
    i32.store $0

--- a/tests/compiler/empty-exportruntime.release.wat
+++ b/tests/compiler/empty-exportruntime.release.wat
@@ -1317,7 +1317,7 @@
    local.tee $2
    local.get $5
    i32.const 256
-   i32.gt_u
+   i32.ge_u
    if (result i32)
     local.get $5
     i32.const 1

--- a/tests/compiler/empty-exportruntime.release.wat
+++ b/tests/compiler/empty-exportruntime.release.wat
@@ -1280,7 +1280,7 @@
    call $~lib/rt/tlsf/initialize
   end
   global.get $~lib/rt/tlsf/ROOT
-  local.set $4
+  local.set $3
   local.get $0
   i32.const 16
   i32.add
@@ -1295,7 +1295,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $4
+  local.get $3
   i32.const 12
   local.get $2
   i32.const 19
@@ -1315,8 +1315,9 @@
   if
    memory.size $0
    local.tee $2
+   local.get $5
    i32.const 4
-   local.get $4
+   local.get $3
    i32.load $0 offset=1568
    local.get $2
    i32.const 16
@@ -1325,38 +1326,40 @@
    i32.sub
    i32.ne
    i32.shl
-   local.get $5
-   i32.const 1
-   i32.const 27
-   local.get $5
-   i32.clz
-   i32.sub
-   i32.shl
-   i32.const 1
-   i32.sub
    i32.add
-   local.get $5
-   local.get $5
+   local.tee $4
    i32.const 536870910
    i32.lt_u
-   select
-   i32.add
+   if (result i32)
+    local.get $4
+    i32.const 1
+    i32.const 27
+    local.get $4
+    i32.clz
+    i32.sub
+    i32.shl
+    i32.const 1
+    i32.sub
+    i32.add
+   else
+    local.get $4
+   end
    i32.const 65535
    i32.add
    i32.const -65536
    i32.and
    i32.const 16
    i32.shr_u
-   local.tee $3
+   local.tee $4
    local.get $2
-   local.get $3
+   local.get $4
    i32.gt_s
    select
    memory.grow $0
    i32.const 0
    i32.lt_s
    if
-    local.get $3
+    local.get $4
     memory.grow $0
     i32.const 0
     i32.lt_s
@@ -1364,7 +1367,7 @@
      unreachable
     end
    end
-   local.get $4
+   local.get $3
    local.get $2
    i32.const 16
    i32.shl
@@ -1373,7 +1376,7 @@
    i64.const 16
    i64.shl
    call $~lib/rt/tlsf/addMemory
-   local.get $4
+   local.get $3
    local.get $5
    call $~lib/rt/tlsf/searchBlock
    local.tee $2
@@ -1401,12 +1404,12 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $4
+  local.get $3
   local.get $2
   call $~lib/rt/tlsf/removeBlock
   local.get $2
   i32.load $0
-  local.set $3
+  local.set $4
   local.get $5
   i32.const 4
   i32.add
@@ -1420,7 +1423,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $3
+  local.get $4
   i32.const -4
   i32.and
   local.get $5
@@ -1431,7 +1434,7 @@
   if
    local.get $2
    local.get $5
-   local.get $3
+   local.get $4
    i32.const 2
    i32.and
    i32.or
@@ -1441,19 +1444,19 @@
    i32.add
    local.get $5
    i32.add
-   local.tee $3
+   local.tee $4
    local.get $6
    i32.const 4
    i32.sub
    i32.const 1
    i32.or
    i32.store $0
-   local.get $4
    local.get $3
+   local.get $4
    call $~lib/rt/tlsf/insertBlock
   else
    local.get $2
-   local.get $3
+   local.get $4
    i32.const -2
    i32.and
    i32.store $0

--- a/tests/compiler/empty-new.debug.wat
+++ b/tests/compiler/empty-new.debug.wat
@@ -1,6 +1,6 @@
 (module
- (type $i32_i32_=>_none (func (param i32 i32)))
  (type $i32_=>_i32 (func (param i32) (result i32)))
+ (type $i32_i32_=>_none (func (param i32 i32)))
  (type $i32_=>_none (func (param i32)))
  (type $none_=>_none (func))
  (type $i32_i32_=>_i32 (func (param i32 i32) (result i32)))
@@ -1032,7 +1032,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 378
+   i32.const 382
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1078,7 +1078,7 @@
    if
     i32.const 0
     i32.const 368
-    i32.const 385
+    i32.const 389
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1111,7 +1111,7 @@
    if
     i32.const 0
     i32.const 368
-    i32.const 398
+    i32.const 402
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1355,7 +1355,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 560
+   i32.const 562
    i32.const 3
    call $~lib/builtins/abort
    unreachable
@@ -1684,13 +1684,33 @@
   if
    i32.const 32
    i32.const 368
-   i32.const 459
+   i32.const 461
    i32.const 29
    call $~lib/builtins/abort
    unreachable
   end
   local.get $size
   call $~lib/rt/tlsf/computeSize
+  return
+ )
+ (func $~lib/rt/tlsf/roundSize (param $size i32) (result i32)
+  local.get $size
+  i32.const 536870910
+  i32.lt_u
+  if (result i32)
+   local.get $size
+   i32.const 1
+   i32.const 27
+   local.get $size
+   i32.clz
+   i32.sub
+   i32.shl
+   i32.add
+   i32.const 1
+   i32.sub
+  else
+   local.get $size
+  end
   return
  )
  (func $~lib/rt/tlsf/searchBlock (param $root i32) (param $size i32) (result i32)
@@ -1722,24 +1742,13 @@
    local.set $sl
   else
    local.get $size
-   i32.const 536870910
-   i32.lt_u
-   if (result i32)
-    local.get $size
-    i32.const 1
-    i32.const 27
-    local.get $size
-    i32.clz
-    i32.sub
-    i32.shl
-    i32.add
-    i32.const 1
-    i32.sub
-   else
-    local.get $size
-   end
+   call $~lib/rt/tlsf/roundSize
    local.set $requestSize
-   i32.const 31
+   i32.const 4
+   i32.const 8
+   i32.mul
+   i32.const 1
+   i32.sub
    local.get $requestSize
    i32.clz
    i32.sub
@@ -1777,7 +1786,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 330
+   i32.const 334
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1848,7 +1857,7 @@
     if
      i32.const 0
      i32.const 368
-     i32.const 343
+     i32.const 347
      i32.const 18
      call $~lib/builtins/abort
      unreachable
@@ -1911,6 +1920,14 @@
   (local $pagesAfter i32)
   i32.const 0
   drop
+  local.get $size
+  i32.const 256
+  i32.gt_u
+  if
+   local.get $size
+   call $~lib/rt/tlsf/roundSize
+   local.set $size
+  end
   memory.size $0
   local.set $pagesBefore
   local.get $size
@@ -1931,22 +1948,6 @@
   i32.shl
   i32.add
   local.set $size
-  local.get $size
-  i32.const 536870910
-  i32.lt_u
-  if
-   local.get $size
-   i32.const 1
-   i32.const 27
-   local.get $size
-   i32.clz
-   i32.sub
-   i32.shl
-   i32.const 1
-   i32.sub
-   i32.add
-   local.set $size
-  end
   local.get $size
   i32.const 65535
   i32.add
@@ -2013,7 +2014,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 357
+   i32.const 361
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -2128,7 +2129,7 @@
    if
     i32.const 0
     i32.const 368
-    i32.const 497
+    i32.const 499
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -2148,7 +2149,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 499
+   i32.const 501
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/empty-new.debug.wat
+++ b/tests/compiler/empty-new.debug.wat
@@ -1911,22 +1911,6 @@
   (local $pagesAfter i32)
   i32.const 0
   drop
-  local.get $size
-  i32.const 536870910
-  i32.lt_u
-  if
-   local.get $size
-   i32.const 1
-   i32.const 27
-   local.get $size
-   i32.clz
-   i32.sub
-   i32.shl
-   i32.const 1
-   i32.sub
-   i32.add
-   local.set $size
-  end
   memory.size $0
   local.set $pagesBefore
   local.get $size
@@ -1947,6 +1931,22 @@
   i32.shl
   i32.add
   local.set $size
+  local.get $size
+  i32.const 536870910
+  i32.lt_u
+  if
+   local.get $size
+   i32.const 1
+   i32.const 27
+   local.get $size
+   i32.clz
+   i32.sub
+   i32.shl
+   i32.const 1
+   i32.sub
+   i32.add
+   local.set $size
+  end
   local.get $size
   i32.const 65535
   i32.add

--- a/tests/compiler/empty-new.debug.wat
+++ b/tests/compiler/empty-new.debug.wat
@@ -1922,7 +1922,7 @@
   drop
   local.get $size
   i32.const 256
-  i32.gt_u
+  i32.ge_u
   if
    local.get $size
    call $~lib/rt/tlsf/roundSize

--- a/tests/compiler/empty-new.release.wat
+++ b/tests/compiler/empty-new.release.wat
@@ -617,7 +617,7 @@
   if
    i32.const 0
    i32.const 1392
-   i32.const 378
+   i32.const 382
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -642,7 +642,7 @@
    if
     i32.const 0
     i32.const 1392
-    i32.const 385
+    i32.const 389
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -670,7 +670,7 @@
    if
     i32.const 0
     i32.const 1392
-    i32.const 398
+    i32.const 402
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1037,7 +1037,7 @@
       if
        i32.const 0
        i32.const 1392
-       i32.const 560
+       i32.const 562
        i32.const 3
        call $~lib/builtins/abort
        unreachable
@@ -1104,7 +1104,7 @@
     if
      i32.const 0
      i32.const 1392
-     i32.const 343
+     i32.const 347
      i32.const 18
      call $~lib/builtins/abort
      unreachable
@@ -1188,8 +1188,6 @@
   if
    memory.size $0
    local.tee $0
-   i32.const 1
-   i32.const 27
    i32.const 4
    local.get $1
    i32.load $0 offset=1568
@@ -1200,22 +1198,7 @@
    i32.sub
    i32.ne
    i32.shl
-   i32.const 28
-   i32.add
-   local.tee $2
-   i32.clz
-   i32.sub
-   i32.shl
-   i32.const 1
-   i32.sub
-   local.get $2
-   i32.add
-   local.get $2
-   local.get $2
-   i32.const 536870910
-   i32.lt_u
-   select
-   i32.const 65535
+   i32.const 65563
    i32.add
    i32.const -65536
    i32.and
@@ -1254,7 +1237,7 @@
    if
     i32.const 0
     i32.const 1392
-    i32.const 497
+    i32.const 499
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1269,7 +1252,7 @@
   if
    i32.const 0
    i32.const 1392
-   i32.const 499
+   i32.const 501
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/empty-new.release.wat
+++ b/tests/compiler/empty-new.release.wat
@@ -1188,6 +1188,8 @@
   if
    memory.size $0
    local.tee $0
+   i32.const 1
+   i32.const 27
    i32.const 4
    local.get $1
    i32.load $0 offset=1568
@@ -1198,7 +1200,22 @@
    i32.sub
    i32.ne
    i32.shl
-   i32.const 65563
+   i32.const 28
+   i32.add
+   local.tee $2
+   i32.clz
+   i32.sub
+   i32.shl
+   i32.const 1
+   i32.sub
+   local.get $2
+   i32.add
+   local.get $2
+   local.get $2
+   i32.const 536870910
+   i32.lt_u
+   select
+   i32.const 65535
    i32.add
    i32.const -65536
    i32.and

--- a/tests/compiler/exportstar-rereexport.debug.wat
+++ b/tests/compiler/exportstar-rereexport.debug.wat
@@ -1951,22 +1951,6 @@
   (local $pagesAfter i32)
   i32.const 0
   drop
-  local.get $size
-  i32.const 536870910
-  i32.lt_u
-  if
-   local.get $size
-   i32.const 1
-   i32.const 27
-   local.get $size
-   i32.clz
-   i32.sub
-   i32.shl
-   i32.const 1
-   i32.sub
-   i32.add
-   local.set $size
-  end
   memory.size $0
   local.set $pagesBefore
   local.get $size
@@ -1987,6 +1971,22 @@
   i32.shl
   i32.add
   local.set $size
+  local.get $size
+  i32.const 536870910
+  i32.lt_u
+  if
+   local.get $size
+   i32.const 1
+   i32.const 27
+   local.get $size
+   i32.clz
+   i32.sub
+   i32.shl
+   i32.const 1
+   i32.sub
+   i32.add
+   local.set $size
+  end
   local.get $size
   i32.const 65535
   i32.add

--- a/tests/compiler/exportstar-rereexport.debug.wat
+++ b/tests/compiler/exportstar-rereexport.debug.wat
@@ -1962,7 +1962,7 @@
   drop
   local.get $size
   i32.const 256
-  i32.gt_u
+  i32.ge_u
   if
    local.get $size
    call $~lib/rt/tlsf/roundSize

--- a/tests/compiler/exportstar-rereexport.debug.wat
+++ b/tests/compiler/exportstar-rereexport.debug.wat
@@ -1072,7 +1072,7 @@
   if
    i32.const 0
    i32.const 416
-   i32.const 378
+   i32.const 382
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1118,7 +1118,7 @@
    if
     i32.const 0
     i32.const 416
-    i32.const 385
+    i32.const 389
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1151,7 +1151,7 @@
    if
     i32.const 0
     i32.const 416
-    i32.const 398
+    i32.const 402
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1395,7 +1395,7 @@
   if
    i32.const 0
    i32.const 416
-   i32.const 560
+   i32.const 562
    i32.const 3
    call $~lib/builtins/abort
    unreachable
@@ -1724,13 +1724,33 @@
   if
    i32.const 80
    i32.const 416
-   i32.const 459
+   i32.const 461
    i32.const 29
    call $~lib/builtins/abort
    unreachable
   end
   local.get $size
   call $~lib/rt/tlsf/computeSize
+  return
+ )
+ (func $~lib/rt/tlsf/roundSize (param $size i32) (result i32)
+  local.get $size
+  i32.const 536870910
+  i32.lt_u
+  if (result i32)
+   local.get $size
+   i32.const 1
+   i32.const 27
+   local.get $size
+   i32.clz
+   i32.sub
+   i32.shl
+   i32.add
+   i32.const 1
+   i32.sub
+  else
+   local.get $size
+  end
   return
  )
  (func $~lib/rt/tlsf/searchBlock (param $root i32) (param $size i32) (result i32)
@@ -1762,24 +1782,13 @@
    local.set $sl
   else
    local.get $size
-   i32.const 536870910
-   i32.lt_u
-   if (result i32)
-    local.get $size
-    i32.const 1
-    i32.const 27
-    local.get $size
-    i32.clz
-    i32.sub
-    i32.shl
-    i32.add
-    i32.const 1
-    i32.sub
-   else
-    local.get $size
-   end
+   call $~lib/rt/tlsf/roundSize
    local.set $requestSize
-   i32.const 31
+   i32.const 4
+   i32.const 8
+   i32.mul
+   i32.const 1
+   i32.sub
    local.get $requestSize
    i32.clz
    i32.sub
@@ -1817,7 +1826,7 @@
   if
    i32.const 0
    i32.const 416
-   i32.const 330
+   i32.const 334
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1888,7 +1897,7 @@
     if
      i32.const 0
      i32.const 416
-     i32.const 343
+     i32.const 347
      i32.const 18
      call $~lib/builtins/abort
      unreachable
@@ -1951,6 +1960,14 @@
   (local $pagesAfter i32)
   i32.const 0
   drop
+  local.get $size
+  i32.const 256
+  i32.gt_u
+  if
+   local.get $size
+   call $~lib/rt/tlsf/roundSize
+   local.set $size
+  end
   memory.size $0
   local.set $pagesBefore
   local.get $size
@@ -1971,22 +1988,6 @@
   i32.shl
   i32.add
   local.set $size
-  local.get $size
-  i32.const 536870910
-  i32.lt_u
-  if
-   local.get $size
-   i32.const 1
-   i32.const 27
-   local.get $size
-   i32.clz
-   i32.sub
-   i32.shl
-   i32.const 1
-   i32.sub
-   i32.add
-   local.set $size
-  end
   local.get $size
   i32.const 65535
   i32.add
@@ -2053,7 +2054,7 @@
   if
    i32.const 0
    i32.const 416
-   i32.const 357
+   i32.const 361
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -2168,7 +2169,7 @@
    if
     i32.const 0
     i32.const 416
-    i32.const 497
+    i32.const 499
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -2188,7 +2189,7 @@
   if
    i32.const 0
    i32.const 416
-   i32.const 499
+   i32.const 501
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/exportstar-rereexport.release.wat
+++ b/tests/compiler/exportstar-rereexport.release.wat
@@ -1222,6 +1222,8 @@
   if
    memory.size $0
    local.tee $0
+   i32.const 1
+   i32.const 27
    i32.const 4
    local.get $1
    i32.load $0 offset=1568
@@ -1232,7 +1234,22 @@
    i32.sub
    i32.ne
    i32.shl
-   i32.const 65563
+   i32.const 28
+   i32.add
+   local.tee $2
+   i32.clz
+   i32.sub
+   i32.shl
+   i32.const 1
+   i32.sub
+   local.get $2
+   i32.add
+   local.get $2
+   local.get $2
+   i32.const 536870910
+   i32.lt_u
+   select
+   i32.const 65535
    i32.add
    i32.const -65536
    i32.and

--- a/tests/compiler/exportstar-rereexport.release.wat
+++ b/tests/compiler/exportstar-rereexport.release.wat
@@ -651,7 +651,7 @@
   if
    i32.const 0
    i32.const 1440
-   i32.const 378
+   i32.const 382
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -676,7 +676,7 @@
    if
     i32.const 0
     i32.const 1440
-    i32.const 385
+    i32.const 389
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -704,7 +704,7 @@
    if
     i32.const 0
     i32.const 1440
-    i32.const 398
+    i32.const 402
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1071,7 +1071,7 @@
       if
        i32.const 0
        i32.const 1440
-       i32.const 560
+       i32.const 562
        i32.const 3
        call $~lib/builtins/abort
        unreachable
@@ -1138,7 +1138,7 @@
     if
      i32.const 0
      i32.const 1440
-     i32.const 343
+     i32.const 347
      i32.const 18
      call $~lib/builtins/abort
      unreachable
@@ -1222,8 +1222,6 @@
   if
    memory.size $0
    local.tee $0
-   i32.const 1
-   i32.const 27
    i32.const 4
    local.get $1
    i32.load $0 offset=1568
@@ -1234,22 +1232,7 @@
    i32.sub
    i32.ne
    i32.shl
-   i32.const 28
-   i32.add
-   local.tee $2
-   i32.clz
-   i32.sub
-   i32.shl
-   i32.const 1
-   i32.sub
-   local.get $2
-   i32.add
-   local.get $2
-   local.get $2
-   i32.const 536870910
-   i32.lt_u
-   select
-   i32.const 65535
+   i32.const 65563
    i32.add
    i32.const -65536
    i32.and
@@ -1288,7 +1271,7 @@
    if
     i32.const 0
     i32.const 1440
-    i32.const 497
+    i32.const 499
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1303,7 +1286,7 @@
   if
    i32.const 0
    i32.const 1440
-   i32.const 499
+   i32.const 501
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/extends-baseaggregate.debug.wat
+++ b/tests/compiler/extends-baseaggregate.debug.wat
@@ -1932,7 +1932,7 @@
   drop
   local.get $size
   i32.const 256
-  i32.gt_u
+  i32.ge_u
   if
    local.get $size
    call $~lib/rt/tlsf/roundSize

--- a/tests/compiler/extends-baseaggregate.debug.wat
+++ b/tests/compiler/extends-baseaggregate.debug.wat
@@ -1921,22 +1921,6 @@
   (local $pagesAfter i32)
   i32.const 0
   drop
-  local.get $size
-  i32.const 536870910
-  i32.lt_u
-  if
-   local.get $size
-   i32.const 1
-   i32.const 27
-   local.get $size
-   i32.clz
-   i32.sub
-   i32.shl
-   i32.const 1
-   i32.sub
-   i32.add
-   local.set $size
-  end
   memory.size $0
   local.set $pagesBefore
   local.get $size
@@ -1957,6 +1941,22 @@
   i32.shl
   i32.add
   local.set $size
+  local.get $size
+  i32.const 536870910
+  i32.lt_u
+  if
+   local.get $size
+   i32.const 1
+   i32.const 27
+   local.get $size
+   i32.clz
+   i32.sub
+   i32.shl
+   i32.const 1
+   i32.sub
+   i32.add
+   local.set $size
+  end
   local.get $size
   i32.const 65535
   i32.add

--- a/tests/compiler/extends-baseaggregate.debug.wat
+++ b/tests/compiler/extends-baseaggregate.debug.wat
@@ -1042,7 +1042,7 @@
   if
    i32.const 0
    i32.const 528
-   i32.const 378
+   i32.const 382
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1088,7 +1088,7 @@
    if
     i32.const 0
     i32.const 528
-    i32.const 385
+    i32.const 389
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1121,7 +1121,7 @@
    if
     i32.const 0
     i32.const 528
-    i32.const 398
+    i32.const 402
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1365,7 +1365,7 @@
   if
    i32.const 0
    i32.const 528
-   i32.const 560
+   i32.const 562
    i32.const 3
    call $~lib/builtins/abort
    unreachable
@@ -1694,13 +1694,33 @@
   if
    i32.const 192
    i32.const 528
-   i32.const 459
+   i32.const 461
    i32.const 29
    call $~lib/builtins/abort
    unreachable
   end
   local.get $size
   call $~lib/rt/tlsf/computeSize
+  return
+ )
+ (func $~lib/rt/tlsf/roundSize (param $size i32) (result i32)
+  local.get $size
+  i32.const 536870910
+  i32.lt_u
+  if (result i32)
+   local.get $size
+   i32.const 1
+   i32.const 27
+   local.get $size
+   i32.clz
+   i32.sub
+   i32.shl
+   i32.add
+   i32.const 1
+   i32.sub
+  else
+   local.get $size
+  end
   return
  )
  (func $~lib/rt/tlsf/searchBlock (param $root i32) (param $size i32) (result i32)
@@ -1732,24 +1752,13 @@
    local.set $sl
   else
    local.get $size
-   i32.const 536870910
-   i32.lt_u
-   if (result i32)
-    local.get $size
-    i32.const 1
-    i32.const 27
-    local.get $size
-    i32.clz
-    i32.sub
-    i32.shl
-    i32.add
-    i32.const 1
-    i32.sub
-   else
-    local.get $size
-   end
+   call $~lib/rt/tlsf/roundSize
    local.set $requestSize
-   i32.const 31
+   i32.const 4
+   i32.const 8
+   i32.mul
+   i32.const 1
+   i32.sub
    local.get $requestSize
    i32.clz
    i32.sub
@@ -1787,7 +1796,7 @@
   if
    i32.const 0
    i32.const 528
-   i32.const 330
+   i32.const 334
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1858,7 +1867,7 @@
     if
      i32.const 0
      i32.const 528
-     i32.const 343
+     i32.const 347
      i32.const 18
      call $~lib/builtins/abort
      unreachable
@@ -1921,6 +1930,14 @@
   (local $pagesAfter i32)
   i32.const 0
   drop
+  local.get $size
+  i32.const 256
+  i32.gt_u
+  if
+   local.get $size
+   call $~lib/rt/tlsf/roundSize
+   local.set $size
+  end
   memory.size $0
   local.set $pagesBefore
   local.get $size
@@ -1941,22 +1958,6 @@
   i32.shl
   i32.add
   local.set $size
-  local.get $size
-  i32.const 536870910
-  i32.lt_u
-  if
-   local.get $size
-   i32.const 1
-   i32.const 27
-   local.get $size
-   i32.clz
-   i32.sub
-   i32.shl
-   i32.const 1
-   i32.sub
-   i32.add
-   local.set $size
-  end
   local.get $size
   i32.const 65535
   i32.add
@@ -2023,7 +2024,7 @@
   if
    i32.const 0
    i32.const 528
-   i32.const 357
+   i32.const 361
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -2138,7 +2139,7 @@
    if
     i32.const 0
     i32.const 528
-    i32.const 497
+    i32.const 499
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -2158,7 +2159,7 @@
   if
    i32.const 0
    i32.const 528
-   i32.const 499
+   i32.const 501
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/extends-baseaggregate.release.wat
+++ b/tests/compiler/extends-baseaggregate.release.wat
@@ -637,7 +637,7 @@
   if
    i32.const 0
    i32.const 1552
-   i32.const 378
+   i32.const 382
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -662,7 +662,7 @@
    if
     i32.const 0
     i32.const 1552
-    i32.const 385
+    i32.const 389
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -690,7 +690,7 @@
    if
     i32.const 0
     i32.const 1552
-    i32.const 398
+    i32.const 402
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1057,7 +1057,7 @@
       if
        i32.const 0
        i32.const 1552
-       i32.const 560
+       i32.const 562
        i32.const 3
        call $~lib/builtins/abort
        unreachable
@@ -1141,7 +1141,7 @@
   if
    i32.const 0
    i32.const 1552
-   i32.const 330
+   i32.const 334
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1193,7 +1193,7 @@
     if
      i32.const 0
      i32.const 1552
-     i32.const 343
+     i32.const 347
      i32.const 18
      call $~lib/builtins/abort
      unreachable
@@ -1282,7 +1282,7 @@
    call $~lib/rt/tlsf/initialize
   end
   global.get $~lib/rt/tlsf/ROOT
-  local.set $3
+  local.set $4
   local.get $0
   i32.const 16
   i32.add
@@ -1292,12 +1292,12 @@
   if
    i32.const 1216
    i32.const 1552
-   i32.const 459
+   i32.const 461
    i32.const 29
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $3
+  local.get $4
   i32.const 12
   local.get $2
   i32.const 19
@@ -1318,8 +1318,29 @@
    memory.size $0
    local.tee $2
    local.get $5
+   i32.const 256
+   i32.gt_u
+   if (result i32)
+    local.get $5
+    i32.const 1
+    i32.const 27
+    local.get $5
+    i32.clz
+    i32.sub
+    i32.shl
+    i32.add
+    i32.const 1
+    i32.sub
+    local.get $5
+    local.get $5
+    i32.const 536870910
+    i32.lt_u
+    select
+   else
+    local.get $5
+   end
    i32.const 4
-   local.get $3
+   local.get $4
    i32.load $0 offset=1568
    local.get $2
    i32.const 16
@@ -1329,39 +1350,22 @@
    i32.ne
    i32.shl
    i32.add
-   local.tee $4
-   i32.const 536870910
-   i32.lt_u
-   if (result i32)
-    local.get $4
-    i32.const 1
-    i32.const 27
-    local.get $4
-    i32.clz
-    i32.sub
-    i32.shl
-    i32.const 1
-    i32.sub
-    i32.add
-   else
-    local.get $4
-   end
    i32.const 65535
    i32.add
    i32.const -65536
    i32.and
    i32.const 16
    i32.shr_u
-   local.tee $4
+   local.tee $3
    local.get $2
-   local.get $4
+   local.get $3
    i32.gt_s
    select
    memory.grow $0
    i32.const 0
    i32.lt_s
    if
-    local.get $4
+    local.get $3
     memory.grow $0
     i32.const 0
     i32.lt_s
@@ -1369,7 +1373,7 @@
      unreachable
     end
    end
-   local.get $3
+   local.get $4
    local.get $2
    i32.const 16
    i32.shl
@@ -1378,7 +1382,7 @@
    i64.const 16
    i64.shl
    call $~lib/rt/tlsf/addMemory
-   local.get $3
+   local.get $4
    local.get $5
    call $~lib/rt/tlsf/searchBlock
    local.tee $2
@@ -1386,7 +1390,7 @@
    if
     i32.const 0
     i32.const 1552
-    i32.const 497
+    i32.const 499
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1401,17 +1405,17 @@
   if
    i32.const 0
    i32.const 1552
-   i32.const 499
+   i32.const 501
    i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $3
+  local.get $4
   local.get $2
   call $~lib/rt/tlsf/removeBlock
   local.get $2
   i32.load $0
-  local.set $4
+  local.set $3
   local.get $5
   i32.const 4
   i32.add
@@ -1420,12 +1424,12 @@
   if
    i32.const 0
    i32.const 1552
-   i32.const 357
+   i32.const 361
    i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $4
+  local.get $3
   i32.const -4
   i32.and
   local.get $5
@@ -1436,7 +1440,7 @@
   if
    local.get $2
    local.get $5
-   local.get $4
+   local.get $3
    i32.const 2
    i32.and
    i32.or
@@ -1446,19 +1450,19 @@
    i32.add
    local.get $5
    i32.add
-   local.tee $4
+   local.tee $3
    local.get $6
    i32.const 4
    i32.sub
    i32.const 1
    i32.or
    i32.store $0
-   local.get $3
    local.get $4
+   local.get $3
    call $~lib/rt/tlsf/insertBlock
   else
    local.get $2
-   local.get $4
+   local.get $3
    i32.const -2
    i32.and
    i32.store $0

--- a/tests/compiler/extends-baseaggregate.release.wat
+++ b/tests/compiler/extends-baseaggregate.release.wat
@@ -1319,7 +1319,7 @@
    local.tee $2
    local.get $5
    i32.const 256
-   i32.gt_u
+   i32.ge_u
    if (result i32)
     local.get $5
     i32.const 1

--- a/tests/compiler/extends-baseaggregate.release.wat
+++ b/tests/compiler/extends-baseaggregate.release.wat
@@ -1282,7 +1282,7 @@
    call $~lib/rt/tlsf/initialize
   end
   global.get $~lib/rt/tlsf/ROOT
-  local.set $4
+  local.set $3
   local.get $0
   i32.const 16
   i32.add
@@ -1297,7 +1297,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $4
+  local.get $3
   i32.const 12
   local.get $2
   i32.const 19
@@ -1317,8 +1317,9 @@
   if
    memory.size $0
    local.tee $2
+   local.get $5
    i32.const 4
-   local.get $4
+   local.get $3
    i32.load $0 offset=1568
    local.get $2
    i32.const 16
@@ -1327,38 +1328,40 @@
    i32.sub
    i32.ne
    i32.shl
-   local.get $5
-   i32.const 1
-   i32.const 27
-   local.get $5
-   i32.clz
-   i32.sub
-   i32.shl
-   i32.const 1
-   i32.sub
    i32.add
-   local.get $5
-   local.get $5
+   local.tee $4
    i32.const 536870910
    i32.lt_u
-   select
-   i32.add
+   if (result i32)
+    local.get $4
+    i32.const 1
+    i32.const 27
+    local.get $4
+    i32.clz
+    i32.sub
+    i32.shl
+    i32.const 1
+    i32.sub
+    i32.add
+   else
+    local.get $4
+   end
    i32.const 65535
    i32.add
    i32.const -65536
    i32.and
    i32.const 16
    i32.shr_u
-   local.tee $3
+   local.tee $4
    local.get $2
-   local.get $3
+   local.get $4
    i32.gt_s
    select
    memory.grow $0
    i32.const 0
    i32.lt_s
    if
-    local.get $3
+    local.get $4
     memory.grow $0
     i32.const 0
     i32.lt_s
@@ -1366,7 +1369,7 @@
      unreachable
     end
    end
-   local.get $4
+   local.get $3
    local.get $2
    i32.const 16
    i32.shl
@@ -1375,7 +1378,7 @@
    i64.const 16
    i64.shl
    call $~lib/rt/tlsf/addMemory
-   local.get $4
+   local.get $3
    local.get $5
    call $~lib/rt/tlsf/searchBlock
    local.tee $2
@@ -1403,12 +1406,12 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $4
+  local.get $3
   local.get $2
   call $~lib/rt/tlsf/removeBlock
   local.get $2
   i32.load $0
-  local.set $3
+  local.set $4
   local.get $5
   i32.const 4
   i32.add
@@ -1422,7 +1425,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $3
+  local.get $4
   i32.const -4
   i32.and
   local.get $5
@@ -1433,7 +1436,7 @@
   if
    local.get $2
    local.get $5
-   local.get $3
+   local.get $4
    i32.const 2
    i32.and
    i32.or
@@ -1443,19 +1446,19 @@
    i32.add
    local.get $5
    i32.add
-   local.tee $3
+   local.tee $4
    local.get $6
    i32.const 4
    i32.sub
    i32.const 1
    i32.or
    i32.store $0
-   local.get $4
    local.get $3
+   local.get $4
    call $~lib/rt/tlsf/insertBlock
   else
    local.get $2
-   local.get $3
+   local.get $4
    i32.const -2
    i32.and
    i32.store $0

--- a/tests/compiler/extends-recursive.debug.wat
+++ b/tests/compiler/extends-recursive.debug.wat
@@ -1,6 +1,6 @@
 (module
- (type $i32_i32_=>_none (func (param i32 i32)))
  (type $i32_=>_i32 (func (param i32) (result i32)))
+ (type $i32_i32_=>_none (func (param i32 i32)))
  (type $i32_=>_none (func (param i32)))
  (type $none_=>_none (func))
  (type $i32_i32_i32_=>_none (func (param i32 i32 i32)))
@@ -1032,7 +1032,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 378
+   i32.const 382
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1078,7 +1078,7 @@
    if
     i32.const 0
     i32.const 368
-    i32.const 385
+    i32.const 389
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1111,7 +1111,7 @@
    if
     i32.const 0
     i32.const 368
-    i32.const 398
+    i32.const 402
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1355,7 +1355,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 560
+   i32.const 562
    i32.const 3
    call $~lib/builtins/abort
    unreachable
@@ -1684,13 +1684,33 @@
   if
    i32.const 32
    i32.const 368
-   i32.const 459
+   i32.const 461
    i32.const 29
    call $~lib/builtins/abort
    unreachable
   end
   local.get $size
   call $~lib/rt/tlsf/computeSize
+  return
+ )
+ (func $~lib/rt/tlsf/roundSize (param $size i32) (result i32)
+  local.get $size
+  i32.const 536870910
+  i32.lt_u
+  if (result i32)
+   local.get $size
+   i32.const 1
+   i32.const 27
+   local.get $size
+   i32.clz
+   i32.sub
+   i32.shl
+   i32.add
+   i32.const 1
+   i32.sub
+  else
+   local.get $size
+  end
   return
  )
  (func $~lib/rt/tlsf/searchBlock (param $root i32) (param $size i32) (result i32)
@@ -1722,24 +1742,13 @@
    local.set $sl
   else
    local.get $size
-   i32.const 536870910
-   i32.lt_u
-   if (result i32)
-    local.get $size
-    i32.const 1
-    i32.const 27
-    local.get $size
-    i32.clz
-    i32.sub
-    i32.shl
-    i32.add
-    i32.const 1
-    i32.sub
-   else
-    local.get $size
-   end
+   call $~lib/rt/tlsf/roundSize
    local.set $requestSize
-   i32.const 31
+   i32.const 4
+   i32.const 8
+   i32.mul
+   i32.const 1
+   i32.sub
    local.get $requestSize
    i32.clz
    i32.sub
@@ -1777,7 +1786,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 330
+   i32.const 334
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1848,7 +1857,7 @@
     if
      i32.const 0
      i32.const 368
-     i32.const 343
+     i32.const 347
      i32.const 18
      call $~lib/builtins/abort
      unreachable
@@ -1911,6 +1920,14 @@
   (local $pagesAfter i32)
   i32.const 0
   drop
+  local.get $size
+  i32.const 256
+  i32.gt_u
+  if
+   local.get $size
+   call $~lib/rt/tlsf/roundSize
+   local.set $size
+  end
   memory.size $0
   local.set $pagesBefore
   local.get $size
@@ -1931,22 +1948,6 @@
   i32.shl
   i32.add
   local.set $size
-  local.get $size
-  i32.const 536870910
-  i32.lt_u
-  if
-   local.get $size
-   i32.const 1
-   i32.const 27
-   local.get $size
-   i32.clz
-   i32.sub
-   i32.shl
-   i32.const 1
-   i32.sub
-   i32.add
-   local.set $size
-  end
   local.get $size
   i32.const 65535
   i32.add
@@ -2013,7 +2014,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 357
+   i32.const 361
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -2128,7 +2129,7 @@
    if
     i32.const 0
     i32.const 368
-    i32.const 497
+    i32.const 499
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -2148,7 +2149,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 499
+   i32.const 501
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/extends-recursive.debug.wat
+++ b/tests/compiler/extends-recursive.debug.wat
@@ -1911,22 +1911,6 @@
   (local $pagesAfter i32)
   i32.const 0
   drop
-  local.get $size
-  i32.const 536870910
-  i32.lt_u
-  if
-   local.get $size
-   i32.const 1
-   i32.const 27
-   local.get $size
-   i32.clz
-   i32.sub
-   i32.shl
-   i32.const 1
-   i32.sub
-   i32.add
-   local.set $size
-  end
   memory.size $0
   local.set $pagesBefore
   local.get $size
@@ -1947,6 +1931,22 @@
   i32.shl
   i32.add
   local.set $size
+  local.get $size
+  i32.const 536870910
+  i32.lt_u
+  if
+   local.get $size
+   i32.const 1
+   i32.const 27
+   local.get $size
+   i32.clz
+   i32.sub
+   i32.shl
+   i32.const 1
+   i32.sub
+   i32.add
+   local.set $size
+  end
   local.get $size
   i32.const 65535
   i32.add

--- a/tests/compiler/extends-recursive.debug.wat
+++ b/tests/compiler/extends-recursive.debug.wat
@@ -1922,7 +1922,7 @@
   drop
   local.get $size
   i32.const 256
-  i32.gt_u
+  i32.ge_u
   if
    local.get $size
    call $~lib/rt/tlsf/roundSize

--- a/tests/compiler/extends-recursive.release.wat
+++ b/tests/compiler/extends-recursive.release.wat
@@ -1300,7 +1300,7 @@
    local.tee $2
    local.get $5
    i32.const 256
-   i32.gt_u
+   i32.ge_u
    if (result i32)
     local.get $5
     i32.const 1

--- a/tests/compiler/extends-recursive.release.wat
+++ b/tests/compiler/extends-recursive.release.wat
@@ -618,7 +618,7 @@
   if
    i32.const 0
    i32.const 1392
-   i32.const 378
+   i32.const 382
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -643,7 +643,7 @@
    if
     i32.const 0
     i32.const 1392
-    i32.const 385
+    i32.const 389
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -671,7 +671,7 @@
    if
     i32.const 0
     i32.const 1392
-    i32.const 398
+    i32.const 402
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1038,7 +1038,7 @@
       if
        i32.const 0
        i32.const 1392
-       i32.const 560
+       i32.const 562
        i32.const 3
        call $~lib/builtins/abort
        unreachable
@@ -1122,7 +1122,7 @@
   if
    i32.const 0
    i32.const 1392
-   i32.const 330
+   i32.const 334
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1174,7 +1174,7 @@
     if
      i32.const 0
      i32.const 1392
-     i32.const 343
+     i32.const 347
      i32.const 18
      call $~lib/builtins/abort
      unreachable
@@ -1263,7 +1263,7 @@
    call $~lib/rt/tlsf/initialize
   end
   global.get $~lib/rt/tlsf/ROOT
-  local.set $3
+  local.set $4
   local.get $0
   i32.const 16
   i32.add
@@ -1273,12 +1273,12 @@
   if
    i32.const 1056
    i32.const 1392
-   i32.const 459
+   i32.const 461
    i32.const 29
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $3
+  local.get $4
   i32.const 12
   local.get $2
   i32.const 19
@@ -1299,8 +1299,29 @@
    memory.size $0
    local.tee $2
    local.get $5
+   i32.const 256
+   i32.gt_u
+   if (result i32)
+    local.get $5
+    i32.const 1
+    i32.const 27
+    local.get $5
+    i32.clz
+    i32.sub
+    i32.shl
+    i32.add
+    i32.const 1
+    i32.sub
+    local.get $5
+    local.get $5
+    i32.const 536870910
+    i32.lt_u
+    select
+   else
+    local.get $5
+   end
    i32.const 4
-   local.get $3
+   local.get $4
    i32.load $0 offset=1568
    local.get $2
    i32.const 16
@@ -1310,39 +1331,22 @@
    i32.ne
    i32.shl
    i32.add
-   local.tee $4
-   i32.const 536870910
-   i32.lt_u
-   if (result i32)
-    local.get $4
-    i32.const 1
-    i32.const 27
-    local.get $4
-    i32.clz
-    i32.sub
-    i32.shl
-    i32.const 1
-    i32.sub
-    i32.add
-   else
-    local.get $4
-   end
    i32.const 65535
    i32.add
    i32.const -65536
    i32.and
    i32.const 16
    i32.shr_u
-   local.tee $4
+   local.tee $3
    local.get $2
-   local.get $4
+   local.get $3
    i32.gt_s
    select
    memory.grow $0
    i32.const 0
    i32.lt_s
    if
-    local.get $4
+    local.get $3
     memory.grow $0
     i32.const 0
     i32.lt_s
@@ -1350,7 +1354,7 @@
      unreachable
     end
    end
-   local.get $3
+   local.get $4
    local.get $2
    i32.const 16
    i32.shl
@@ -1359,7 +1363,7 @@
    i64.const 16
    i64.shl
    call $~lib/rt/tlsf/addMemory
-   local.get $3
+   local.get $4
    local.get $5
    call $~lib/rt/tlsf/searchBlock
    local.tee $2
@@ -1367,7 +1371,7 @@
    if
     i32.const 0
     i32.const 1392
-    i32.const 497
+    i32.const 499
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1382,17 +1386,17 @@
   if
    i32.const 0
    i32.const 1392
-   i32.const 499
+   i32.const 501
    i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $3
+  local.get $4
   local.get $2
   call $~lib/rt/tlsf/removeBlock
   local.get $2
   i32.load $0
-  local.set $4
+  local.set $3
   local.get $5
   i32.const 4
   i32.add
@@ -1401,12 +1405,12 @@
   if
    i32.const 0
    i32.const 1392
-   i32.const 357
+   i32.const 361
    i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $4
+  local.get $3
   i32.const -4
   i32.and
   local.get $5
@@ -1417,7 +1421,7 @@
   if
    local.get $2
    local.get $5
-   local.get $4
+   local.get $3
    i32.const 2
    i32.and
    i32.or
@@ -1427,19 +1431,19 @@
    i32.add
    local.get $5
    i32.add
-   local.tee $4
+   local.tee $3
    local.get $6
    i32.const 4
    i32.sub
    i32.const 1
    i32.or
    i32.store $0
-   local.get $3
    local.get $4
+   local.get $3
    call $~lib/rt/tlsf/insertBlock
   else
    local.get $2
-   local.get $4
+   local.get $3
    i32.const -2
    i32.and
    i32.store $0

--- a/tests/compiler/extends-recursive.release.wat
+++ b/tests/compiler/extends-recursive.release.wat
@@ -1263,7 +1263,7 @@
    call $~lib/rt/tlsf/initialize
   end
   global.get $~lib/rt/tlsf/ROOT
-  local.set $4
+  local.set $3
   local.get $0
   i32.const 16
   i32.add
@@ -1278,7 +1278,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $4
+  local.get $3
   i32.const 12
   local.get $2
   i32.const 19
@@ -1298,8 +1298,9 @@
   if
    memory.size $0
    local.tee $2
+   local.get $5
    i32.const 4
-   local.get $4
+   local.get $3
    i32.load $0 offset=1568
    local.get $2
    i32.const 16
@@ -1308,38 +1309,40 @@
    i32.sub
    i32.ne
    i32.shl
-   local.get $5
-   i32.const 1
-   i32.const 27
-   local.get $5
-   i32.clz
-   i32.sub
-   i32.shl
-   i32.const 1
-   i32.sub
    i32.add
-   local.get $5
-   local.get $5
+   local.tee $4
    i32.const 536870910
    i32.lt_u
-   select
-   i32.add
+   if (result i32)
+    local.get $4
+    i32.const 1
+    i32.const 27
+    local.get $4
+    i32.clz
+    i32.sub
+    i32.shl
+    i32.const 1
+    i32.sub
+    i32.add
+   else
+    local.get $4
+   end
    i32.const 65535
    i32.add
    i32.const -65536
    i32.and
    i32.const 16
    i32.shr_u
-   local.tee $3
+   local.tee $4
    local.get $2
-   local.get $3
+   local.get $4
    i32.gt_s
    select
    memory.grow $0
    i32.const 0
    i32.lt_s
    if
-    local.get $3
+    local.get $4
     memory.grow $0
     i32.const 0
     i32.lt_s
@@ -1347,7 +1350,7 @@
      unreachable
     end
    end
-   local.get $4
+   local.get $3
    local.get $2
    i32.const 16
    i32.shl
@@ -1356,7 +1359,7 @@
    i64.const 16
    i64.shl
    call $~lib/rt/tlsf/addMemory
-   local.get $4
+   local.get $3
    local.get $5
    call $~lib/rt/tlsf/searchBlock
    local.tee $2
@@ -1384,12 +1387,12 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $4
+  local.get $3
   local.get $2
   call $~lib/rt/tlsf/removeBlock
   local.get $2
   i32.load $0
-  local.set $3
+  local.set $4
   local.get $5
   i32.const 4
   i32.add
@@ -1403,7 +1406,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $3
+  local.get $4
   i32.const -4
   i32.and
   local.get $5
@@ -1414,7 +1417,7 @@
   if
    local.get $2
    local.get $5
-   local.get $3
+   local.get $4
    i32.const 2
    i32.and
    i32.or
@@ -1424,19 +1427,19 @@
    i32.add
    local.get $5
    i32.add
-   local.tee $3
+   local.tee $4
    local.get $6
    i32.const 4
    i32.sub
    i32.const 1
    i32.or
    i32.store $0
-   local.get $4
    local.get $3
+   local.get $4
    call $~lib/rt/tlsf/insertBlock
   else
    local.get $2
-   local.get $3
+   local.get $4
    i32.const -2
    i32.and
    i32.store $0

--- a/tests/compiler/field-initialization.debug.wat
+++ b/tests/compiler/field-initialization.debug.wat
@@ -1043,7 +1043,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 378
+   i32.const 382
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1089,7 +1089,7 @@
    if
     i32.const 0
     i32.const 368
-    i32.const 385
+    i32.const 389
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1122,7 +1122,7 @@
    if
     i32.const 0
     i32.const 368
-    i32.const 398
+    i32.const 402
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1366,7 +1366,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 560
+   i32.const 562
    i32.const 3
    call $~lib/builtins/abort
    unreachable
@@ -1695,13 +1695,33 @@
   if
    i32.const 32
    i32.const 368
-   i32.const 459
+   i32.const 461
    i32.const 29
    call $~lib/builtins/abort
    unreachable
   end
   local.get $size
   call $~lib/rt/tlsf/computeSize
+  return
+ )
+ (func $~lib/rt/tlsf/roundSize (param $size i32) (result i32)
+  local.get $size
+  i32.const 536870910
+  i32.lt_u
+  if (result i32)
+   local.get $size
+   i32.const 1
+   i32.const 27
+   local.get $size
+   i32.clz
+   i32.sub
+   i32.shl
+   i32.add
+   i32.const 1
+   i32.sub
+  else
+   local.get $size
+  end
   return
  )
  (func $~lib/rt/tlsf/searchBlock (param $root i32) (param $size i32) (result i32)
@@ -1733,24 +1753,13 @@
    local.set $sl
   else
    local.get $size
-   i32.const 536870910
-   i32.lt_u
-   if (result i32)
-    local.get $size
-    i32.const 1
-    i32.const 27
-    local.get $size
-    i32.clz
-    i32.sub
-    i32.shl
-    i32.add
-    i32.const 1
-    i32.sub
-   else
-    local.get $size
-   end
+   call $~lib/rt/tlsf/roundSize
    local.set $requestSize
-   i32.const 31
+   i32.const 4
+   i32.const 8
+   i32.mul
+   i32.const 1
+   i32.sub
    local.get $requestSize
    i32.clz
    i32.sub
@@ -1788,7 +1797,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 330
+   i32.const 334
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1859,7 +1868,7 @@
     if
      i32.const 0
      i32.const 368
-     i32.const 343
+     i32.const 347
      i32.const 18
      call $~lib/builtins/abort
      unreachable
@@ -1922,6 +1931,14 @@
   (local $pagesAfter i32)
   i32.const 0
   drop
+  local.get $size
+  i32.const 256
+  i32.gt_u
+  if
+   local.get $size
+   call $~lib/rt/tlsf/roundSize
+   local.set $size
+  end
   memory.size $0
   local.set $pagesBefore
   local.get $size
@@ -1942,22 +1959,6 @@
   i32.shl
   i32.add
   local.set $size
-  local.get $size
-  i32.const 536870910
-  i32.lt_u
-  if
-   local.get $size
-   i32.const 1
-   i32.const 27
-   local.get $size
-   i32.clz
-   i32.sub
-   i32.shl
-   i32.const 1
-   i32.sub
-   i32.add
-   local.set $size
-  end
   local.get $size
   i32.const 65535
   i32.add
@@ -2024,7 +2025,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 357
+   i32.const 361
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -2139,7 +2140,7 @@
    if
     i32.const 0
     i32.const 368
-    i32.const 497
+    i32.const 499
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -2159,7 +2160,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 499
+   i32.const 501
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/field-initialization.debug.wat
+++ b/tests/compiler/field-initialization.debug.wat
@@ -1922,22 +1922,6 @@
   (local $pagesAfter i32)
   i32.const 0
   drop
-  local.get $size
-  i32.const 536870910
-  i32.lt_u
-  if
-   local.get $size
-   i32.const 1
-   i32.const 27
-   local.get $size
-   i32.clz
-   i32.sub
-   i32.shl
-   i32.const 1
-   i32.sub
-   i32.add
-   local.set $size
-  end
   memory.size $0
   local.set $pagesBefore
   local.get $size
@@ -1958,6 +1942,22 @@
   i32.shl
   i32.add
   local.set $size
+  local.get $size
+  i32.const 536870910
+  i32.lt_u
+  if
+   local.get $size
+   i32.const 1
+   i32.const 27
+   local.get $size
+   i32.clz
+   i32.sub
+   i32.shl
+   i32.const 1
+   i32.sub
+   i32.add
+   local.set $size
+  end
   local.get $size
   i32.const 65535
   i32.add

--- a/tests/compiler/field-initialization.debug.wat
+++ b/tests/compiler/field-initialization.debug.wat
@@ -1933,7 +1933,7 @@
   drop
   local.get $size
   i32.const 256
-  i32.gt_u
+  i32.ge_u
   if
    local.get $size
    call $~lib/rt/tlsf/roundSize

--- a/tests/compiler/field-initialization.release.wat
+++ b/tests/compiler/field-initialization.release.wat
@@ -1320,7 +1320,7 @@
    local.tee $2
    local.get $5
    i32.const 256
-   i32.gt_u
+   i32.ge_u
    if (result i32)
     local.get $5
     i32.const 1

--- a/tests/compiler/field-initialization.release.wat
+++ b/tests/compiler/field-initialization.release.wat
@@ -1283,7 +1283,7 @@
    call $~lib/rt/tlsf/initialize
   end
   global.get $~lib/rt/tlsf/ROOT
-  local.set $4
+  local.set $3
   local.get $0
   i32.const 16
   i32.add
@@ -1298,7 +1298,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $4
+  local.get $3
   i32.const 12
   local.get $2
   i32.const 19
@@ -1318,8 +1318,9 @@
   if
    memory.size $0
    local.tee $2
+   local.get $5
    i32.const 4
-   local.get $4
+   local.get $3
    i32.load $0 offset=1568
    local.get $2
    i32.const 16
@@ -1328,38 +1329,40 @@
    i32.sub
    i32.ne
    i32.shl
-   local.get $5
-   i32.const 1
-   i32.const 27
-   local.get $5
-   i32.clz
-   i32.sub
-   i32.shl
-   i32.const 1
-   i32.sub
    i32.add
-   local.get $5
-   local.get $5
+   local.tee $4
    i32.const 536870910
    i32.lt_u
-   select
-   i32.add
+   if (result i32)
+    local.get $4
+    i32.const 1
+    i32.const 27
+    local.get $4
+    i32.clz
+    i32.sub
+    i32.shl
+    i32.const 1
+    i32.sub
+    i32.add
+   else
+    local.get $4
+   end
    i32.const 65535
    i32.add
    i32.const -65536
    i32.and
    i32.const 16
    i32.shr_u
-   local.tee $3
+   local.tee $4
    local.get $2
-   local.get $3
+   local.get $4
    i32.gt_s
    select
    memory.grow $0
    i32.const 0
    i32.lt_s
    if
-    local.get $3
+    local.get $4
     memory.grow $0
     i32.const 0
     i32.lt_s
@@ -1367,7 +1370,7 @@
      unreachable
     end
    end
-   local.get $4
+   local.get $3
    local.get $2
    i32.const 16
    i32.shl
@@ -1376,7 +1379,7 @@
    i64.const 16
    i64.shl
    call $~lib/rt/tlsf/addMemory
-   local.get $4
+   local.get $3
    local.get $5
    call $~lib/rt/tlsf/searchBlock
    local.tee $2
@@ -1404,12 +1407,12 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $4
+  local.get $3
   local.get $2
   call $~lib/rt/tlsf/removeBlock
   local.get $2
   i32.load $0
-  local.set $3
+  local.set $4
   local.get $5
   i32.const 4
   i32.add
@@ -1423,7 +1426,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $3
+  local.get $4
   i32.const -4
   i32.and
   local.get $5
@@ -1434,7 +1437,7 @@
   if
    local.get $2
    local.get $5
-   local.get $3
+   local.get $4
    i32.const 2
    i32.and
    i32.or
@@ -1444,19 +1447,19 @@
    i32.add
    local.get $5
    i32.add
-   local.tee $3
+   local.tee $4
    local.get $6
    i32.const 4
    i32.sub
    i32.const 1
    i32.or
    i32.store $0
-   local.get $4
    local.get $3
+   local.get $4
    call $~lib/rt/tlsf/insertBlock
   else
    local.get $2
-   local.get $3
+   local.get $4
    i32.const -2
    i32.and
    i32.store $0

--- a/tests/compiler/field-initialization.release.wat
+++ b/tests/compiler/field-initialization.release.wat
@@ -638,7 +638,7 @@
   if
    i32.const 0
    i32.const 1392
-   i32.const 378
+   i32.const 382
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -663,7 +663,7 @@
    if
     i32.const 0
     i32.const 1392
-    i32.const 385
+    i32.const 389
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -691,7 +691,7 @@
    if
     i32.const 0
     i32.const 1392
-    i32.const 398
+    i32.const 402
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1058,7 +1058,7 @@
       if
        i32.const 0
        i32.const 1392
-       i32.const 560
+       i32.const 562
        i32.const 3
        call $~lib/builtins/abort
        unreachable
@@ -1142,7 +1142,7 @@
   if
    i32.const 0
    i32.const 1392
-   i32.const 330
+   i32.const 334
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1194,7 +1194,7 @@
     if
      i32.const 0
      i32.const 1392
-     i32.const 343
+     i32.const 347
      i32.const 18
      call $~lib/builtins/abort
      unreachable
@@ -1283,7 +1283,7 @@
    call $~lib/rt/tlsf/initialize
   end
   global.get $~lib/rt/tlsf/ROOT
-  local.set $3
+  local.set $4
   local.get $0
   i32.const 16
   i32.add
@@ -1293,12 +1293,12 @@
   if
    i32.const 1056
    i32.const 1392
-   i32.const 459
+   i32.const 461
    i32.const 29
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $3
+  local.get $4
   i32.const 12
   local.get $2
   i32.const 19
@@ -1319,8 +1319,29 @@
    memory.size $0
    local.tee $2
    local.get $5
+   i32.const 256
+   i32.gt_u
+   if (result i32)
+    local.get $5
+    i32.const 1
+    i32.const 27
+    local.get $5
+    i32.clz
+    i32.sub
+    i32.shl
+    i32.add
+    i32.const 1
+    i32.sub
+    local.get $5
+    local.get $5
+    i32.const 536870910
+    i32.lt_u
+    select
+   else
+    local.get $5
+   end
    i32.const 4
-   local.get $3
+   local.get $4
    i32.load $0 offset=1568
    local.get $2
    i32.const 16
@@ -1330,39 +1351,22 @@
    i32.ne
    i32.shl
    i32.add
-   local.tee $4
-   i32.const 536870910
-   i32.lt_u
-   if (result i32)
-    local.get $4
-    i32.const 1
-    i32.const 27
-    local.get $4
-    i32.clz
-    i32.sub
-    i32.shl
-    i32.const 1
-    i32.sub
-    i32.add
-   else
-    local.get $4
-   end
    i32.const 65535
    i32.add
    i32.const -65536
    i32.and
    i32.const 16
    i32.shr_u
-   local.tee $4
+   local.tee $3
    local.get $2
-   local.get $4
+   local.get $3
    i32.gt_s
    select
    memory.grow $0
    i32.const 0
    i32.lt_s
    if
-    local.get $4
+    local.get $3
     memory.grow $0
     i32.const 0
     i32.lt_s
@@ -1370,7 +1374,7 @@
      unreachable
     end
    end
-   local.get $3
+   local.get $4
    local.get $2
    i32.const 16
    i32.shl
@@ -1379,7 +1383,7 @@
    i64.const 16
    i64.shl
    call $~lib/rt/tlsf/addMemory
-   local.get $3
+   local.get $4
    local.get $5
    call $~lib/rt/tlsf/searchBlock
    local.tee $2
@@ -1387,7 +1391,7 @@
    if
     i32.const 0
     i32.const 1392
-    i32.const 497
+    i32.const 499
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1402,17 +1406,17 @@
   if
    i32.const 0
    i32.const 1392
-   i32.const 499
+   i32.const 501
    i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $3
+  local.get $4
   local.get $2
   call $~lib/rt/tlsf/removeBlock
   local.get $2
   i32.load $0
-  local.set $4
+  local.set $3
   local.get $5
   i32.const 4
   i32.add
@@ -1421,12 +1425,12 @@
   if
    i32.const 0
    i32.const 1392
-   i32.const 357
+   i32.const 361
    i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $4
+  local.get $3
   i32.const -4
   i32.and
   local.get $5
@@ -1437,7 +1441,7 @@
   if
    local.get $2
    local.get $5
-   local.get $4
+   local.get $3
    i32.const 2
    i32.and
    i32.or
@@ -1447,19 +1451,19 @@
    i32.add
    local.get $5
    i32.add
-   local.tee $4
+   local.tee $3
    local.get $6
    i32.const 4
    i32.sub
    i32.const 1
    i32.or
    i32.store $0
-   local.get $3
    local.get $4
+   local.get $3
    call $~lib/rt/tlsf/insertBlock
   else
    local.get $2
-   local.get $4
+   local.get $3
    i32.const -2
    i32.and
    i32.store $0

--- a/tests/compiler/field.debug.wat
+++ b/tests/compiler/field.debug.wat
@@ -1,6 +1,6 @@
 (module
- (type $i32_i32_=>_none (func (param i32 i32)))
  (type $i32_=>_i32 (func (param i32) (result i32)))
+ (type $i32_i32_=>_none (func (param i32 i32)))
  (type $i32_=>_none (func (param i32)))
  (type $none_=>_none (func))
  (type $i32_i32_i32_=>_none (func (param i32 i32 i32)))
@@ -1035,7 +1035,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 378
+   i32.const 382
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1081,7 +1081,7 @@
    if
     i32.const 0
     i32.const 368
-    i32.const 385
+    i32.const 389
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1114,7 +1114,7 @@
    if
     i32.const 0
     i32.const 368
-    i32.const 398
+    i32.const 402
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1358,7 +1358,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 560
+   i32.const 562
    i32.const 3
    call $~lib/builtins/abort
    unreachable
@@ -1687,13 +1687,33 @@
   if
    i32.const 32
    i32.const 368
-   i32.const 459
+   i32.const 461
    i32.const 29
    call $~lib/builtins/abort
    unreachable
   end
   local.get $size
   call $~lib/rt/tlsf/computeSize
+  return
+ )
+ (func $~lib/rt/tlsf/roundSize (param $size i32) (result i32)
+  local.get $size
+  i32.const 536870910
+  i32.lt_u
+  if (result i32)
+   local.get $size
+   i32.const 1
+   i32.const 27
+   local.get $size
+   i32.clz
+   i32.sub
+   i32.shl
+   i32.add
+   i32.const 1
+   i32.sub
+  else
+   local.get $size
+  end
   return
  )
  (func $~lib/rt/tlsf/searchBlock (param $root i32) (param $size i32) (result i32)
@@ -1725,24 +1745,13 @@
    local.set $sl
   else
    local.get $size
-   i32.const 536870910
-   i32.lt_u
-   if (result i32)
-    local.get $size
-    i32.const 1
-    i32.const 27
-    local.get $size
-    i32.clz
-    i32.sub
-    i32.shl
-    i32.add
-    i32.const 1
-    i32.sub
-   else
-    local.get $size
-   end
+   call $~lib/rt/tlsf/roundSize
    local.set $requestSize
-   i32.const 31
+   i32.const 4
+   i32.const 8
+   i32.mul
+   i32.const 1
+   i32.sub
    local.get $requestSize
    i32.clz
    i32.sub
@@ -1780,7 +1789,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 330
+   i32.const 334
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1851,7 +1860,7 @@
     if
      i32.const 0
      i32.const 368
-     i32.const 343
+     i32.const 347
      i32.const 18
      call $~lib/builtins/abort
      unreachable
@@ -1914,6 +1923,14 @@
   (local $pagesAfter i32)
   i32.const 0
   drop
+  local.get $size
+  i32.const 256
+  i32.gt_u
+  if
+   local.get $size
+   call $~lib/rt/tlsf/roundSize
+   local.set $size
+  end
   memory.size $0
   local.set $pagesBefore
   local.get $size
@@ -1934,22 +1951,6 @@
   i32.shl
   i32.add
   local.set $size
-  local.get $size
-  i32.const 536870910
-  i32.lt_u
-  if
-   local.get $size
-   i32.const 1
-   i32.const 27
-   local.get $size
-   i32.clz
-   i32.sub
-   i32.shl
-   i32.const 1
-   i32.sub
-   i32.add
-   local.set $size
-  end
   local.get $size
   i32.const 65535
   i32.add
@@ -2016,7 +2017,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 357
+   i32.const 361
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -2131,7 +2132,7 @@
    if
     i32.const 0
     i32.const 368
-    i32.const 497
+    i32.const 499
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -2151,7 +2152,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 499
+   i32.const 501
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/field.debug.wat
+++ b/tests/compiler/field.debug.wat
@@ -1914,22 +1914,6 @@
   (local $pagesAfter i32)
   i32.const 0
   drop
-  local.get $size
-  i32.const 536870910
-  i32.lt_u
-  if
-   local.get $size
-   i32.const 1
-   i32.const 27
-   local.get $size
-   i32.clz
-   i32.sub
-   i32.shl
-   i32.const 1
-   i32.sub
-   i32.add
-   local.set $size
-  end
   memory.size $0
   local.set $pagesBefore
   local.get $size
@@ -1950,6 +1934,22 @@
   i32.shl
   i32.add
   local.set $size
+  local.get $size
+  i32.const 536870910
+  i32.lt_u
+  if
+   local.get $size
+   i32.const 1
+   i32.const 27
+   local.get $size
+   i32.clz
+   i32.sub
+   i32.shl
+   i32.const 1
+   i32.sub
+   i32.add
+   local.set $size
+  end
   local.get $size
   i32.const 65535
   i32.add

--- a/tests/compiler/field.debug.wat
+++ b/tests/compiler/field.debug.wat
@@ -1925,7 +1925,7 @@
   drop
   local.get $size
   i32.const 256
-  i32.gt_u
+  i32.ge_u
   if
    local.get $size
    call $~lib/rt/tlsf/roundSize

--- a/tests/compiler/field.release.wat
+++ b/tests/compiler/field.release.wat
@@ -621,7 +621,7 @@
   if
    i32.const 0
    i32.const 1392
-   i32.const 378
+   i32.const 382
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -646,7 +646,7 @@
    if
     i32.const 0
     i32.const 1392
-    i32.const 385
+    i32.const 389
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -674,7 +674,7 @@
    if
     i32.const 0
     i32.const 1392
-    i32.const 398
+    i32.const 402
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1041,7 +1041,7 @@
       if
        i32.const 0
        i32.const 1392
-       i32.const 560
+       i32.const 562
        i32.const 3
        call $~lib/builtins/abort
        unreachable
@@ -1125,7 +1125,7 @@
   if
    i32.const 0
    i32.const 1392
-   i32.const 330
+   i32.const 334
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1177,7 +1177,7 @@
     if
      i32.const 0
      i32.const 1392
-     i32.const 343
+     i32.const 347
      i32.const 18
      call $~lib/builtins/abort
      unreachable
@@ -1266,7 +1266,7 @@
    call $~lib/rt/tlsf/initialize
   end
   global.get $~lib/rt/tlsf/ROOT
-  local.set $3
+  local.set $4
   local.get $0
   i32.const 16
   i32.add
@@ -1276,12 +1276,12 @@
   if
    i32.const 1056
    i32.const 1392
-   i32.const 459
+   i32.const 461
    i32.const 29
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $3
+  local.get $4
   i32.const 12
   local.get $2
   i32.const 19
@@ -1302,8 +1302,29 @@
    memory.size $0
    local.tee $2
    local.get $5
+   i32.const 256
+   i32.gt_u
+   if (result i32)
+    local.get $5
+    i32.const 1
+    i32.const 27
+    local.get $5
+    i32.clz
+    i32.sub
+    i32.shl
+    i32.add
+    i32.const 1
+    i32.sub
+    local.get $5
+    local.get $5
+    i32.const 536870910
+    i32.lt_u
+    select
+   else
+    local.get $5
+   end
    i32.const 4
-   local.get $3
+   local.get $4
    i32.load $0 offset=1568
    local.get $2
    i32.const 16
@@ -1313,39 +1334,22 @@
    i32.ne
    i32.shl
    i32.add
-   local.tee $4
-   i32.const 536870910
-   i32.lt_u
-   if (result i32)
-    local.get $4
-    i32.const 1
-    i32.const 27
-    local.get $4
-    i32.clz
-    i32.sub
-    i32.shl
-    i32.const 1
-    i32.sub
-    i32.add
-   else
-    local.get $4
-   end
    i32.const 65535
    i32.add
    i32.const -65536
    i32.and
    i32.const 16
    i32.shr_u
-   local.tee $4
+   local.tee $3
    local.get $2
-   local.get $4
+   local.get $3
    i32.gt_s
    select
    memory.grow $0
    i32.const 0
    i32.lt_s
    if
-    local.get $4
+    local.get $3
     memory.grow $0
     i32.const 0
     i32.lt_s
@@ -1353,7 +1357,7 @@
      unreachable
     end
    end
-   local.get $3
+   local.get $4
    local.get $2
    i32.const 16
    i32.shl
@@ -1362,7 +1366,7 @@
    i64.const 16
    i64.shl
    call $~lib/rt/tlsf/addMemory
-   local.get $3
+   local.get $4
    local.get $5
    call $~lib/rt/tlsf/searchBlock
    local.tee $2
@@ -1370,7 +1374,7 @@
    if
     i32.const 0
     i32.const 1392
-    i32.const 497
+    i32.const 499
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1385,17 +1389,17 @@
   if
    i32.const 0
    i32.const 1392
-   i32.const 499
+   i32.const 501
    i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $3
+  local.get $4
   local.get $2
   call $~lib/rt/tlsf/removeBlock
   local.get $2
   i32.load $0
-  local.set $4
+  local.set $3
   local.get $5
   i32.const 4
   i32.add
@@ -1404,12 +1408,12 @@
   if
    i32.const 0
    i32.const 1392
-   i32.const 357
+   i32.const 361
    i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $4
+  local.get $3
   i32.const -4
   i32.and
   local.get $5
@@ -1420,7 +1424,7 @@
   if
    local.get $2
    local.get $5
-   local.get $4
+   local.get $3
    i32.const 2
    i32.and
    i32.or
@@ -1430,19 +1434,19 @@
    i32.add
    local.get $5
    i32.add
-   local.tee $4
+   local.tee $3
    local.get $6
    i32.const 4
    i32.sub
    i32.const 1
    i32.or
    i32.store $0
-   local.get $3
    local.get $4
+   local.get $3
    call $~lib/rt/tlsf/insertBlock
   else
    local.get $2
-   local.get $4
+   local.get $3
    i32.const -2
    i32.and
    i32.store $0

--- a/tests/compiler/field.release.wat
+++ b/tests/compiler/field.release.wat
@@ -1303,7 +1303,7 @@
    local.tee $2
    local.get $5
    i32.const 256
-   i32.gt_u
+   i32.ge_u
    if (result i32)
     local.get $5
     i32.const 1

--- a/tests/compiler/field.release.wat
+++ b/tests/compiler/field.release.wat
@@ -1266,7 +1266,7 @@
    call $~lib/rt/tlsf/initialize
   end
   global.get $~lib/rt/tlsf/ROOT
-  local.set $4
+  local.set $3
   local.get $0
   i32.const 16
   i32.add
@@ -1281,7 +1281,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $4
+  local.get $3
   i32.const 12
   local.get $2
   i32.const 19
@@ -1301,8 +1301,9 @@
   if
    memory.size $0
    local.tee $2
+   local.get $5
    i32.const 4
-   local.get $4
+   local.get $3
    i32.load $0 offset=1568
    local.get $2
    i32.const 16
@@ -1311,38 +1312,40 @@
    i32.sub
    i32.ne
    i32.shl
-   local.get $5
-   i32.const 1
-   i32.const 27
-   local.get $5
-   i32.clz
-   i32.sub
-   i32.shl
-   i32.const 1
-   i32.sub
    i32.add
-   local.get $5
-   local.get $5
+   local.tee $4
    i32.const 536870910
    i32.lt_u
-   select
-   i32.add
+   if (result i32)
+    local.get $4
+    i32.const 1
+    i32.const 27
+    local.get $4
+    i32.clz
+    i32.sub
+    i32.shl
+    i32.const 1
+    i32.sub
+    i32.add
+   else
+    local.get $4
+   end
    i32.const 65535
    i32.add
    i32.const -65536
    i32.and
    i32.const 16
    i32.shr_u
-   local.tee $3
+   local.tee $4
    local.get $2
-   local.get $3
+   local.get $4
    i32.gt_s
    select
    memory.grow $0
    i32.const 0
    i32.lt_s
    if
-    local.get $3
+    local.get $4
     memory.grow $0
     i32.const 0
     i32.lt_s
@@ -1350,7 +1353,7 @@
      unreachable
     end
    end
-   local.get $4
+   local.get $3
    local.get $2
    i32.const 16
    i32.shl
@@ -1359,7 +1362,7 @@
    i64.const 16
    i64.shl
    call $~lib/rt/tlsf/addMemory
-   local.get $4
+   local.get $3
    local.get $5
    call $~lib/rt/tlsf/searchBlock
    local.tee $2
@@ -1387,12 +1390,12 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $4
+  local.get $3
   local.get $2
   call $~lib/rt/tlsf/removeBlock
   local.get $2
   i32.load $0
-  local.set $3
+  local.set $4
   local.get $5
   i32.const 4
   i32.add
@@ -1406,7 +1409,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $3
+  local.get $4
   i32.const -4
   i32.and
   local.get $5
@@ -1417,7 +1420,7 @@
   if
    local.get $2
    local.get $5
-   local.get $3
+   local.get $4
    i32.const 2
    i32.and
    i32.or
@@ -1427,19 +1430,19 @@
    i32.add
    local.get $5
    i32.add
-   local.tee $3
+   local.tee $4
    local.get $6
    i32.const 4
    i32.sub
    i32.const 1
    i32.or
    i32.store $0
-   local.get $4
    local.get $3
+   local.get $4
    call $~lib/rt/tlsf/insertBlock
   else
    local.get $2
-   local.get $3
+   local.get $4
    i32.const -2
    i32.and
    i32.store $0

--- a/tests/compiler/for.debug.wat
+++ b/tests/compiler/for.debug.wat
@@ -1422,7 +1422,7 @@
   if
    i32.const 0
    i32.const 400
-   i32.const 378
+   i32.const 382
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1468,7 +1468,7 @@
    if
     i32.const 0
     i32.const 400
-    i32.const 385
+    i32.const 389
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1501,7 +1501,7 @@
    if
     i32.const 0
     i32.const 400
-    i32.const 398
+    i32.const 402
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1745,7 +1745,7 @@
   if
    i32.const 0
    i32.const 400
-   i32.const 560
+   i32.const 562
    i32.const 3
    call $~lib/builtins/abort
    unreachable
@@ -2074,13 +2074,33 @@
   if
    i32.const 64
    i32.const 400
-   i32.const 459
+   i32.const 461
    i32.const 29
    call $~lib/builtins/abort
    unreachable
   end
   local.get $size
   call $~lib/rt/tlsf/computeSize
+  return
+ )
+ (func $~lib/rt/tlsf/roundSize (param $size i32) (result i32)
+  local.get $size
+  i32.const 536870910
+  i32.lt_u
+  if (result i32)
+   local.get $size
+   i32.const 1
+   i32.const 27
+   local.get $size
+   i32.clz
+   i32.sub
+   i32.shl
+   i32.add
+   i32.const 1
+   i32.sub
+  else
+   local.get $size
+  end
   return
  )
  (func $~lib/rt/tlsf/searchBlock (param $root i32) (param $size i32) (result i32)
@@ -2112,24 +2132,13 @@
    local.set $sl
   else
    local.get $size
-   i32.const 536870910
-   i32.lt_u
-   if (result i32)
-    local.get $size
-    i32.const 1
-    i32.const 27
-    local.get $size
-    i32.clz
-    i32.sub
-    i32.shl
-    i32.add
-    i32.const 1
-    i32.sub
-   else
-    local.get $size
-   end
+   call $~lib/rt/tlsf/roundSize
    local.set $requestSize
-   i32.const 31
+   i32.const 4
+   i32.const 8
+   i32.mul
+   i32.const 1
+   i32.sub
    local.get $requestSize
    i32.clz
    i32.sub
@@ -2167,7 +2176,7 @@
   if
    i32.const 0
    i32.const 400
-   i32.const 330
+   i32.const 334
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -2238,7 +2247,7 @@
     if
      i32.const 0
      i32.const 400
-     i32.const 343
+     i32.const 347
      i32.const 18
      call $~lib/builtins/abort
      unreachable
@@ -2301,6 +2310,14 @@
   (local $pagesAfter i32)
   i32.const 0
   drop
+  local.get $size
+  i32.const 256
+  i32.gt_u
+  if
+   local.get $size
+   call $~lib/rt/tlsf/roundSize
+   local.set $size
+  end
   memory.size $0
   local.set $pagesBefore
   local.get $size
@@ -2321,22 +2338,6 @@
   i32.shl
   i32.add
   local.set $size
-  local.get $size
-  i32.const 536870910
-  i32.lt_u
-  if
-   local.get $size
-   i32.const 1
-   i32.const 27
-   local.get $size
-   i32.clz
-   i32.sub
-   i32.shl
-   i32.const 1
-   i32.sub
-   i32.add
-   local.set $size
-  end
   local.get $size
   i32.const 65535
   i32.add
@@ -2403,7 +2404,7 @@
   if
    i32.const 0
    i32.const 400
-   i32.const 357
+   i32.const 361
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -2518,7 +2519,7 @@
    if
     i32.const 0
     i32.const 400
-    i32.const 497
+    i32.const 499
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -2538,7 +2539,7 @@
   if
    i32.const 0
    i32.const 400
-   i32.const 499
+   i32.const 501
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/for.debug.wat
+++ b/tests/compiler/for.debug.wat
@@ -2301,22 +2301,6 @@
   (local $pagesAfter i32)
   i32.const 0
   drop
-  local.get $size
-  i32.const 536870910
-  i32.lt_u
-  if
-   local.get $size
-   i32.const 1
-   i32.const 27
-   local.get $size
-   i32.clz
-   i32.sub
-   i32.shl
-   i32.const 1
-   i32.sub
-   i32.add
-   local.set $size
-  end
   memory.size $0
   local.set $pagesBefore
   local.get $size
@@ -2337,6 +2321,22 @@
   i32.shl
   i32.add
   local.set $size
+  local.get $size
+  i32.const 536870910
+  i32.lt_u
+  if
+   local.get $size
+   i32.const 1
+   i32.const 27
+   local.get $size
+   i32.clz
+   i32.sub
+   i32.shl
+   i32.const 1
+   i32.sub
+   i32.add
+   local.set $size
+  end
   local.get $size
   i32.const 65535
   i32.add

--- a/tests/compiler/for.debug.wat
+++ b/tests/compiler/for.debug.wat
@@ -2312,7 +2312,7 @@
   drop
   local.get $size
   i32.const 256
-  i32.gt_u
+  i32.ge_u
   if
    local.get $size
    call $~lib/rt/tlsf/roundSize

--- a/tests/compiler/for.release.wat
+++ b/tests/compiler/for.release.wat
@@ -1191,6 +1191,8 @@
   if
    memory.size $0
    local.tee $1
+   i32.const 1
+   i32.const 27
    i32.const 4
    local.get $2
    i32.load $0 offset=1568
@@ -1201,7 +1203,22 @@
    i32.sub
    i32.ne
    i32.shl
-   i32.const 65563
+   i32.const 28
+   i32.add
+   local.tee $3
+   i32.clz
+   i32.sub
+   i32.shl
+   i32.const 1
+   i32.sub
+   local.get $3
+   i32.add
+   local.get $3
+   local.get $3
+   i32.const 536870910
+   i32.lt_u
+   select
+   i32.const 65535
    i32.add
    i32.const -65536
    i32.and

--- a/tests/compiler/for.release.wat
+++ b/tests/compiler/for.release.wat
@@ -620,7 +620,7 @@
   if
    i32.const 0
    i32.const 1424
-   i32.const 378
+   i32.const 382
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -645,7 +645,7 @@
    if
     i32.const 0
     i32.const 1424
-    i32.const 385
+    i32.const 389
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -673,7 +673,7 @@
    if
     i32.const 0
     i32.const 1424
-    i32.const 398
+    i32.const 402
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1040,7 +1040,7 @@
       if
        i32.const 0
        i32.const 1424
-       i32.const 560
+       i32.const 562
        i32.const 3
        call $~lib/builtins/abort
        unreachable
@@ -1107,7 +1107,7 @@
     if
      i32.const 0
      i32.const 1424
-     i32.const 343
+     i32.const 347
      i32.const 18
      call $~lib/builtins/abort
      unreachable
@@ -1191,8 +1191,6 @@
   if
    memory.size $0
    local.tee $1
-   i32.const 1
-   i32.const 27
    i32.const 4
    local.get $2
    i32.load $0 offset=1568
@@ -1203,22 +1201,7 @@
    i32.sub
    i32.ne
    i32.shl
-   i32.const 28
-   i32.add
-   local.tee $3
-   i32.clz
-   i32.sub
-   i32.shl
-   i32.const 1
-   i32.sub
-   local.get $3
-   i32.add
-   local.get $3
-   local.get $3
-   i32.const 536870910
-   i32.lt_u
-   select
-   i32.const 65535
+   i32.const 65563
    i32.add
    i32.const -65536
    i32.and
@@ -1257,7 +1240,7 @@
    if
     i32.const 0
     i32.const 1424
-    i32.const 497
+    i32.const 499
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1272,7 +1255,7 @@
   if
    i32.const 0
    i32.const 1424
-   i32.const 499
+   i32.const 501
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/function-call.debug.wat
+++ b/tests/compiler/function-call.debug.wat
@@ -1961,7 +1961,7 @@
   drop
   local.get $size
   i32.const 256
-  i32.gt_u
+  i32.ge_u
   if
    local.get $size
    call $~lib/rt/tlsf/roundSize

--- a/tests/compiler/function-call.debug.wat
+++ b/tests/compiler/function-call.debug.wat
@@ -1950,22 +1950,6 @@
   (local $pagesAfter i32)
   i32.const 0
   drop
-  local.get $size
-  i32.const 536870910
-  i32.lt_u
-  if
-   local.get $size
-   i32.const 1
-   i32.const 27
-   local.get $size
-   i32.clz
-   i32.sub
-   i32.shl
-   i32.const 1
-   i32.sub
-   i32.add
-   local.set $size
-  end
   memory.size $0
   local.set $pagesBefore
   local.get $size
@@ -1986,6 +1970,22 @@
   i32.shl
   i32.add
   local.set $size
+  local.get $size
+  i32.const 536870910
+  i32.lt_u
+  if
+   local.get $size
+   i32.const 1
+   i32.const 27
+   local.get $size
+   i32.clz
+   i32.sub
+   i32.shl
+   i32.const 1
+   i32.sub
+   i32.add
+   local.set $size
+  end
   local.get $size
   i32.const 65535
   i32.add

--- a/tests/compiler/function-call.debug.wat
+++ b/tests/compiler/function-call.debug.wat
@@ -1071,7 +1071,7 @@
   if
    i32.const 0
    i32.const 592
-   i32.const 378
+   i32.const 382
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1117,7 +1117,7 @@
    if
     i32.const 0
     i32.const 592
-    i32.const 385
+    i32.const 389
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1150,7 +1150,7 @@
    if
     i32.const 0
     i32.const 592
-    i32.const 398
+    i32.const 402
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1394,7 +1394,7 @@
   if
    i32.const 0
    i32.const 592
-   i32.const 560
+   i32.const 562
    i32.const 3
    call $~lib/builtins/abort
    unreachable
@@ -1723,13 +1723,33 @@
   if
    i32.const 256
    i32.const 592
-   i32.const 459
+   i32.const 461
    i32.const 29
    call $~lib/builtins/abort
    unreachable
   end
   local.get $size
   call $~lib/rt/tlsf/computeSize
+  return
+ )
+ (func $~lib/rt/tlsf/roundSize (param $size i32) (result i32)
+  local.get $size
+  i32.const 536870910
+  i32.lt_u
+  if (result i32)
+   local.get $size
+   i32.const 1
+   i32.const 27
+   local.get $size
+   i32.clz
+   i32.sub
+   i32.shl
+   i32.add
+   i32.const 1
+   i32.sub
+  else
+   local.get $size
+  end
   return
  )
  (func $~lib/rt/tlsf/searchBlock (param $root i32) (param $size i32) (result i32)
@@ -1761,24 +1781,13 @@
    local.set $sl
   else
    local.get $size
-   i32.const 536870910
-   i32.lt_u
-   if (result i32)
-    local.get $size
-    i32.const 1
-    i32.const 27
-    local.get $size
-    i32.clz
-    i32.sub
-    i32.shl
-    i32.add
-    i32.const 1
-    i32.sub
-   else
-    local.get $size
-   end
+   call $~lib/rt/tlsf/roundSize
    local.set $requestSize
-   i32.const 31
+   i32.const 4
+   i32.const 8
+   i32.mul
+   i32.const 1
+   i32.sub
    local.get $requestSize
    i32.clz
    i32.sub
@@ -1816,7 +1825,7 @@
   if
    i32.const 0
    i32.const 592
-   i32.const 330
+   i32.const 334
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1887,7 +1896,7 @@
     if
      i32.const 0
      i32.const 592
-     i32.const 343
+     i32.const 347
      i32.const 18
      call $~lib/builtins/abort
      unreachable
@@ -1950,6 +1959,14 @@
   (local $pagesAfter i32)
   i32.const 0
   drop
+  local.get $size
+  i32.const 256
+  i32.gt_u
+  if
+   local.get $size
+   call $~lib/rt/tlsf/roundSize
+   local.set $size
+  end
   memory.size $0
   local.set $pagesBefore
   local.get $size
@@ -1970,22 +1987,6 @@
   i32.shl
   i32.add
   local.set $size
-  local.get $size
-  i32.const 536870910
-  i32.lt_u
-  if
-   local.get $size
-   i32.const 1
-   i32.const 27
-   local.get $size
-   i32.clz
-   i32.sub
-   i32.shl
-   i32.const 1
-   i32.sub
-   i32.add
-   local.set $size
-  end
   local.get $size
   i32.const 65535
   i32.add
@@ -2052,7 +2053,7 @@
   if
    i32.const 0
    i32.const 592
-   i32.const 357
+   i32.const 361
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -2167,7 +2168,7 @@
    if
     i32.const 0
     i32.const 592
-    i32.const 497
+    i32.const 499
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -2187,7 +2188,7 @@
   if
    i32.const 0
    i32.const 592
-   i32.const 499
+   i32.const 501
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/function-call.release.wat
+++ b/tests/compiler/function-call.release.wat
@@ -1230,6 +1230,8 @@
   if
    memory.size $0
    local.tee $1
+   i32.const 1
+   i32.const 27
    i32.const 4
    local.get $2
    i32.load $0 offset=1568
@@ -1240,7 +1242,22 @@
    i32.sub
    i32.ne
    i32.shl
-   i32.const 65563
+   i32.const 28
+   i32.add
+   local.tee $3
+   i32.clz
+   i32.sub
+   i32.shl
+   i32.const 1
+   i32.sub
+   local.get $3
+   i32.add
+   local.get $3
+   local.get $3
+   i32.const 536870910
+   i32.lt_u
+   select
+   i32.const 65535
    i32.add
    i32.const -65536
    i32.and

--- a/tests/compiler/function-call.release.wat
+++ b/tests/compiler/function-call.release.wat
@@ -659,7 +659,7 @@
   if
    i32.const 0
    i32.const 1616
-   i32.const 378
+   i32.const 382
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -684,7 +684,7 @@
    if
     i32.const 0
     i32.const 1616
-    i32.const 385
+    i32.const 389
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -712,7 +712,7 @@
    if
     i32.const 0
     i32.const 1616
-    i32.const 398
+    i32.const 402
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1079,7 +1079,7 @@
       if
        i32.const 0
        i32.const 1616
-       i32.const 560
+       i32.const 562
        i32.const 3
        call $~lib/builtins/abort
        unreachable
@@ -1146,7 +1146,7 @@
     if
      i32.const 0
      i32.const 1616
-     i32.const 343
+     i32.const 347
      i32.const 18
      call $~lib/builtins/abort
      unreachable
@@ -1230,8 +1230,6 @@
   if
    memory.size $0
    local.tee $1
-   i32.const 1
-   i32.const 27
    i32.const 4
    local.get $2
    i32.load $0 offset=1568
@@ -1242,22 +1240,7 @@
    i32.sub
    i32.ne
    i32.shl
-   i32.const 28
-   i32.add
-   local.tee $3
-   i32.clz
-   i32.sub
-   i32.shl
-   i32.const 1
-   i32.sub
-   local.get $3
-   i32.add
-   local.get $3
-   local.get $3
-   i32.const 536870910
-   i32.lt_u
-   select
-   i32.const 65535
+   i32.const 65563
    i32.add
    i32.const -65536
    i32.and
@@ -1296,7 +1279,7 @@
    if
     i32.const 0
     i32.const 1616
-    i32.const 497
+    i32.const 499
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1311,7 +1294,7 @@
   if
    i32.const 0
    i32.const 1616
-   i32.const 499
+   i32.const 501
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/function-expression.debug.wat
+++ b/tests/compiler/function-expression.debug.wat
@@ -1228,7 +1228,7 @@
   if
    i32.const 0
    i32.const 912
-   i32.const 378
+   i32.const 382
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1274,7 +1274,7 @@
    if
     i32.const 0
     i32.const 912
-    i32.const 385
+    i32.const 389
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1307,7 +1307,7 @@
    if
     i32.const 0
     i32.const 912
-    i32.const 398
+    i32.const 402
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1551,7 +1551,7 @@
   if
    i32.const 0
    i32.const 912
-   i32.const 560
+   i32.const 562
    i32.const 3
    call $~lib/builtins/abort
    unreachable
@@ -1880,13 +1880,33 @@
   if
    i32.const 576
    i32.const 912
-   i32.const 459
+   i32.const 461
    i32.const 29
    call $~lib/builtins/abort
    unreachable
   end
   local.get $size
   call $~lib/rt/tlsf/computeSize
+  return
+ )
+ (func $~lib/rt/tlsf/roundSize (param $size i32) (result i32)
+  local.get $size
+  i32.const 536870910
+  i32.lt_u
+  if (result i32)
+   local.get $size
+   i32.const 1
+   i32.const 27
+   local.get $size
+   i32.clz
+   i32.sub
+   i32.shl
+   i32.add
+   i32.const 1
+   i32.sub
+  else
+   local.get $size
+  end
   return
  )
  (func $~lib/rt/tlsf/searchBlock (param $root i32) (param $size i32) (result i32)
@@ -1918,24 +1938,13 @@
    local.set $sl
   else
    local.get $size
-   i32.const 536870910
-   i32.lt_u
-   if (result i32)
-    local.get $size
-    i32.const 1
-    i32.const 27
-    local.get $size
-    i32.clz
-    i32.sub
-    i32.shl
-    i32.add
-    i32.const 1
-    i32.sub
-   else
-    local.get $size
-   end
+   call $~lib/rt/tlsf/roundSize
    local.set $requestSize
-   i32.const 31
+   i32.const 4
+   i32.const 8
+   i32.mul
+   i32.const 1
+   i32.sub
    local.get $requestSize
    i32.clz
    i32.sub
@@ -1973,7 +1982,7 @@
   if
    i32.const 0
    i32.const 912
-   i32.const 330
+   i32.const 334
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -2044,7 +2053,7 @@
     if
      i32.const 0
      i32.const 912
-     i32.const 343
+     i32.const 347
      i32.const 18
      call $~lib/builtins/abort
      unreachable
@@ -2107,6 +2116,14 @@
   (local $pagesAfter i32)
   i32.const 0
   drop
+  local.get $size
+  i32.const 256
+  i32.gt_u
+  if
+   local.get $size
+   call $~lib/rt/tlsf/roundSize
+   local.set $size
+  end
   memory.size $0
   local.set $pagesBefore
   local.get $size
@@ -2127,22 +2144,6 @@
   i32.shl
   i32.add
   local.set $size
-  local.get $size
-  i32.const 536870910
-  i32.lt_u
-  if
-   local.get $size
-   i32.const 1
-   i32.const 27
-   local.get $size
-   i32.clz
-   i32.sub
-   i32.shl
-   i32.const 1
-   i32.sub
-   i32.add
-   local.set $size
-  end
   local.get $size
   i32.const 65535
   i32.add
@@ -2209,7 +2210,7 @@
   if
    i32.const 0
    i32.const 912
-   i32.const 357
+   i32.const 361
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -2324,7 +2325,7 @@
    if
     i32.const 0
     i32.const 912
-    i32.const 497
+    i32.const 499
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -2344,7 +2345,7 @@
   if
    i32.const 0
    i32.const 912
-   i32.const 499
+   i32.const 501
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/function-expression.debug.wat
+++ b/tests/compiler/function-expression.debug.wat
@@ -2118,7 +2118,7 @@
   drop
   local.get $size
   i32.const 256
-  i32.gt_u
+  i32.ge_u
   if
    local.get $size
    call $~lib/rt/tlsf/roundSize

--- a/tests/compiler/function-expression.debug.wat
+++ b/tests/compiler/function-expression.debug.wat
@@ -2107,22 +2107,6 @@
   (local $pagesAfter i32)
   i32.const 0
   drop
-  local.get $size
-  i32.const 536870910
-  i32.lt_u
-  if
-   local.get $size
-   i32.const 1
-   i32.const 27
-   local.get $size
-   i32.clz
-   i32.sub
-   i32.shl
-   i32.const 1
-   i32.sub
-   i32.add
-   local.set $size
-  end
   memory.size $0
   local.set $pagesBefore
   local.get $size
@@ -2143,6 +2127,22 @@
   i32.shl
   i32.add
   local.set $size
+  local.get $size
+  i32.const 536870910
+  i32.lt_u
+  if
+   local.get $size
+   i32.const 1
+   i32.const 27
+   local.get $size
+   i32.clz
+   i32.sub
+   i32.shl
+   i32.const 1
+   i32.sub
+   i32.add
+   local.set $size
+  end
   local.get $size
   i32.const 65535
   i32.add

--- a/tests/compiler/function-expression.release.wat
+++ b/tests/compiler/function-expression.release.wat
@@ -685,7 +685,7 @@
   if
    i32.const 0
    i32.const 1936
-   i32.const 378
+   i32.const 382
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -710,7 +710,7 @@
    if
     i32.const 0
     i32.const 1936
-    i32.const 385
+    i32.const 389
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -738,7 +738,7 @@
    if
     i32.const 0
     i32.const 1936
-    i32.const 398
+    i32.const 402
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1105,7 +1105,7 @@
       if
        i32.const 0
        i32.const 1936
-       i32.const 560
+       i32.const 562
        i32.const 3
        call $~lib/builtins/abort
        unreachable
@@ -1172,7 +1172,7 @@
     if
      i32.const 0
      i32.const 1936
-     i32.const 343
+     i32.const 347
      i32.const 18
      call $~lib/builtins/abort
      unreachable
@@ -1256,8 +1256,6 @@
   if
    memory.size $0
    local.tee $0
-   i32.const 1
-   i32.const 27
    i32.const 4
    local.get $1
    i32.load $0 offset=1568
@@ -1268,22 +1266,7 @@
    i32.sub
    i32.ne
    i32.shl
-   i32.const 28
-   i32.add
-   local.tee $2
-   i32.clz
-   i32.sub
-   i32.shl
-   i32.const 1
-   i32.sub
-   local.get $2
-   i32.add
-   local.get $2
-   local.get $2
-   i32.const 536870910
-   i32.lt_u
-   select
-   i32.const 65535
+   i32.const 65563
    i32.add
    i32.const -65536
    i32.and
@@ -1322,7 +1305,7 @@
    if
     i32.const 0
     i32.const 1936
-    i32.const 497
+    i32.const 499
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1337,7 +1320,7 @@
   if
    i32.const 0
    i32.const 1936
-   i32.const 499
+   i32.const 501
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/function-expression.release.wat
+++ b/tests/compiler/function-expression.release.wat
@@ -1256,6 +1256,8 @@
   if
    memory.size $0
    local.tee $0
+   i32.const 1
+   i32.const 27
    i32.const 4
    local.get $1
    i32.load $0 offset=1568
@@ -1266,7 +1268,22 @@
    i32.sub
    i32.ne
    i32.shl
-   i32.const 65563
+   i32.const 28
+   i32.add
+   local.tee $2
+   i32.clz
+   i32.sub
+   i32.shl
+   i32.const 1
+   i32.sub
+   local.get $2
+   i32.add
+   local.get $2
+   local.get $2
+   i32.const 536870910
+   i32.lt_u
+   select
+   i32.const 65535
    i32.add
    i32.const -65536
    i32.and

--- a/tests/compiler/getter-call.debug.wat
+++ b/tests/compiler/getter-call.debug.wat
@@ -1914,22 +1914,6 @@
   (local $pagesAfter i32)
   i32.const 0
   drop
-  local.get $size
-  i32.const 536870910
-  i32.lt_u
-  if
-   local.get $size
-   i32.const 1
-   i32.const 27
-   local.get $size
-   i32.clz
-   i32.sub
-   i32.shl
-   i32.const 1
-   i32.sub
-   i32.add
-   local.set $size
-  end
   memory.size $0
   local.set $pagesBefore
   local.get $size
@@ -1950,6 +1934,22 @@
   i32.shl
   i32.add
   local.set $size
+  local.get $size
+  i32.const 536870910
+  i32.lt_u
+  if
+   local.get $size
+   i32.const 1
+   i32.const 27
+   local.get $size
+   i32.clz
+   i32.sub
+   i32.shl
+   i32.const 1
+   i32.sub
+   i32.add
+   local.set $size
+  end
   local.get $size
   i32.const 65535
   i32.add

--- a/tests/compiler/getter-call.debug.wat
+++ b/tests/compiler/getter-call.debug.wat
@@ -1035,7 +1035,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 378
+   i32.const 382
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1081,7 +1081,7 @@
    if
     i32.const 0
     i32.const 368
-    i32.const 385
+    i32.const 389
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1114,7 +1114,7 @@
    if
     i32.const 0
     i32.const 368
-    i32.const 398
+    i32.const 402
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1358,7 +1358,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 560
+   i32.const 562
    i32.const 3
    call $~lib/builtins/abort
    unreachable
@@ -1687,13 +1687,33 @@
   if
    i32.const 32
    i32.const 368
-   i32.const 459
+   i32.const 461
    i32.const 29
    call $~lib/builtins/abort
    unreachable
   end
   local.get $size
   call $~lib/rt/tlsf/computeSize
+  return
+ )
+ (func $~lib/rt/tlsf/roundSize (param $size i32) (result i32)
+  local.get $size
+  i32.const 536870910
+  i32.lt_u
+  if (result i32)
+   local.get $size
+   i32.const 1
+   i32.const 27
+   local.get $size
+   i32.clz
+   i32.sub
+   i32.shl
+   i32.add
+   i32.const 1
+   i32.sub
+  else
+   local.get $size
+  end
   return
  )
  (func $~lib/rt/tlsf/searchBlock (param $root i32) (param $size i32) (result i32)
@@ -1725,24 +1745,13 @@
    local.set $sl
   else
    local.get $size
-   i32.const 536870910
-   i32.lt_u
-   if (result i32)
-    local.get $size
-    i32.const 1
-    i32.const 27
-    local.get $size
-    i32.clz
-    i32.sub
-    i32.shl
-    i32.add
-    i32.const 1
-    i32.sub
-   else
-    local.get $size
-   end
+   call $~lib/rt/tlsf/roundSize
    local.set $requestSize
-   i32.const 31
+   i32.const 4
+   i32.const 8
+   i32.mul
+   i32.const 1
+   i32.sub
    local.get $requestSize
    i32.clz
    i32.sub
@@ -1780,7 +1789,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 330
+   i32.const 334
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1851,7 +1860,7 @@
     if
      i32.const 0
      i32.const 368
-     i32.const 343
+     i32.const 347
      i32.const 18
      call $~lib/builtins/abort
      unreachable
@@ -1914,6 +1923,14 @@
   (local $pagesAfter i32)
   i32.const 0
   drop
+  local.get $size
+  i32.const 256
+  i32.gt_u
+  if
+   local.get $size
+   call $~lib/rt/tlsf/roundSize
+   local.set $size
+  end
   memory.size $0
   local.set $pagesBefore
   local.get $size
@@ -1934,22 +1951,6 @@
   i32.shl
   i32.add
   local.set $size
-  local.get $size
-  i32.const 536870910
-  i32.lt_u
-  if
-   local.get $size
-   i32.const 1
-   i32.const 27
-   local.get $size
-   i32.clz
-   i32.sub
-   i32.shl
-   i32.const 1
-   i32.sub
-   i32.add
-   local.set $size
-  end
   local.get $size
   i32.const 65535
   i32.add
@@ -2016,7 +2017,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 357
+   i32.const 361
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -2131,7 +2132,7 @@
    if
     i32.const 0
     i32.const 368
-    i32.const 497
+    i32.const 499
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -2151,7 +2152,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 499
+   i32.const 501
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/getter-call.debug.wat
+++ b/tests/compiler/getter-call.debug.wat
@@ -1925,7 +1925,7 @@
   drop
   local.get $size
   i32.const 256
-  i32.gt_u
+  i32.ge_u
   if
    local.get $size
    call $~lib/rt/tlsf/roundSize

--- a/tests/compiler/getter-call.release.wat
+++ b/tests/compiler/getter-call.release.wat
@@ -1194,6 +1194,8 @@
   if
    memory.size $0
    local.tee $1
+   i32.const 1
+   i32.const 27
    i32.const 4
    local.get $2
    i32.load $0 offset=1568
@@ -1204,7 +1206,22 @@
    i32.sub
    i32.ne
    i32.shl
-   i32.const 65563
+   i32.const 28
+   i32.add
+   local.tee $3
+   i32.clz
+   i32.sub
+   i32.shl
+   i32.const 1
+   i32.sub
+   local.get $3
+   i32.add
+   local.get $3
+   local.get $3
+   i32.const 536870910
+   i32.lt_u
+   select
+   i32.const 65535
    i32.add
    i32.const -65536
    i32.and

--- a/tests/compiler/getter-call.release.wat
+++ b/tests/compiler/getter-call.release.wat
@@ -623,7 +623,7 @@
   if
    i32.const 0
    i32.const 1392
-   i32.const 378
+   i32.const 382
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -648,7 +648,7 @@
    if
     i32.const 0
     i32.const 1392
-    i32.const 385
+    i32.const 389
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -676,7 +676,7 @@
    if
     i32.const 0
     i32.const 1392
-    i32.const 398
+    i32.const 402
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1043,7 +1043,7 @@
       if
        i32.const 0
        i32.const 1392
-       i32.const 560
+       i32.const 562
        i32.const 3
        call $~lib/builtins/abort
        unreachable
@@ -1110,7 +1110,7 @@
     if
      i32.const 0
      i32.const 1392
-     i32.const 343
+     i32.const 347
      i32.const 18
      call $~lib/builtins/abort
      unreachable
@@ -1194,8 +1194,6 @@
   if
    memory.size $0
    local.tee $1
-   i32.const 1
-   i32.const 27
    i32.const 4
    local.get $2
    i32.load $0 offset=1568
@@ -1206,22 +1204,7 @@
    i32.sub
    i32.ne
    i32.shl
-   i32.const 28
-   i32.add
-   local.tee $3
-   i32.clz
-   i32.sub
-   i32.shl
-   i32.const 1
-   i32.sub
-   local.get $3
-   i32.add
-   local.get $3
-   local.get $3
-   i32.const 536870910
-   i32.lt_u
-   select
-   i32.const 65535
+   i32.const 65563
    i32.add
    i32.const -65536
    i32.and
@@ -1260,7 +1243,7 @@
    if
     i32.const 0
     i32.const 1392
-    i32.const 497
+    i32.const 499
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1275,7 +1258,7 @@
   if
    i32.const 0
    i32.const 1392
-   i32.const 499
+   i32.const 501
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/heap.debug.wat
+++ b/tests/compiler/heap.debug.wat
@@ -1240,7 +1240,7 @@
   drop
   local.get $size
   i32.const 256
-  i32.gt_u
+  i32.ge_u
   if
    local.get $size
    call $~lib/rt/tlsf/roundSize

--- a/tests/compiler/heap.debug.wat
+++ b/tests/compiler/heap.debug.wat
@@ -1229,22 +1229,6 @@
   (local $pagesAfter i32)
   i32.const 0
   drop
-  local.get $size
-  i32.const 536870910
-  i32.lt_u
-  if
-   local.get $size
-   i32.const 1
-   i32.const 27
-   local.get $size
-   i32.clz
-   i32.sub
-   i32.shl
-   i32.const 1
-   i32.sub
-   i32.add
-   local.set $size
-  end
   memory.size $0
   local.set $pagesBefore
   local.get $size
@@ -1265,6 +1249,22 @@
   i32.shl
   i32.add
   local.set $size
+  local.get $size
+  i32.const 536870910
+  i32.lt_u
+  if
+   local.get $size
+   i32.const 1
+   i32.const 27
+   local.get $size
+   i32.clz
+   i32.sub
+   i32.shl
+   i32.const 1
+   i32.sub
+   i32.add
+   local.set $size
+  end
   local.get $size
   i32.const 65535
   i32.add

--- a/tests/compiler/heap.debug.wat
+++ b/tests/compiler/heap.debug.wat
@@ -681,7 +681,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 378
+   i32.const 382
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -727,7 +727,7 @@
    if
     i32.const 0
     i32.const 32
-    i32.const 385
+    i32.const 389
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -760,7 +760,7 @@
    if
     i32.const 0
     i32.const 32
-    i32.const 398
+    i32.const 402
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1002,13 +1002,33 @@
   if
    i32.const 96
    i32.const 32
-   i32.const 459
+   i32.const 461
    i32.const 29
    call $~lib/builtins/abort
    unreachable
   end
   local.get $size
   call $~lib/rt/tlsf/computeSize
+  return
+ )
+ (func $~lib/rt/tlsf/roundSize (param $size i32) (result i32)
+  local.get $size
+  i32.const 536870910
+  i32.lt_u
+  if (result i32)
+   local.get $size
+   i32.const 1
+   i32.const 27
+   local.get $size
+   i32.clz
+   i32.sub
+   i32.shl
+   i32.add
+   i32.const 1
+   i32.sub
+  else
+   local.get $size
+  end
   return
  )
  (func $~lib/rt/tlsf/searchBlock (param $root i32) (param $size i32) (result i32)
@@ -1040,24 +1060,13 @@
    local.set $sl
   else
    local.get $size
-   i32.const 536870910
-   i32.lt_u
-   if (result i32)
-    local.get $size
-    i32.const 1
-    i32.const 27
-    local.get $size
-    i32.clz
-    i32.sub
-    i32.shl
-    i32.add
-    i32.const 1
-    i32.sub
-   else
-    local.get $size
-   end
+   call $~lib/rt/tlsf/roundSize
    local.set $requestSize
-   i32.const 31
+   i32.const 4
+   i32.const 8
+   i32.mul
+   i32.const 1
+   i32.sub
    local.get $requestSize
    i32.clz
    i32.sub
@@ -1095,7 +1104,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 330
+   i32.const 334
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1166,7 +1175,7 @@
     if
      i32.const 0
      i32.const 32
-     i32.const 343
+     i32.const 347
      i32.const 18
      call $~lib/builtins/abort
      unreachable
@@ -1229,6 +1238,14 @@
   (local $pagesAfter i32)
   i32.const 0
   drop
+  local.get $size
+  i32.const 256
+  i32.gt_u
+  if
+   local.get $size
+   call $~lib/rt/tlsf/roundSize
+   local.set $size
+  end
   memory.size $0
   local.set $pagesBefore
   local.get $size
@@ -1249,22 +1266,6 @@
   i32.shl
   i32.add
   local.set $size
-  local.get $size
-  i32.const 536870910
-  i32.lt_u
-  if
-   local.get $size
-   i32.const 1
-   i32.const 27
-   local.get $size
-   i32.clz
-   i32.sub
-   i32.shl
-   i32.const 1
-   i32.sub
-   i32.add
-   local.set $size
-  end
   local.get $size
   i32.const 65535
   i32.add
@@ -1331,7 +1332,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 357
+   i32.const 361
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1446,7 +1447,7 @@
    if
     i32.const 0
     i32.const 32
-    i32.const 497
+    i32.const 499
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1466,7 +1467,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 499
+   i32.const 501
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1531,7 +1532,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 560
+   i32.const 562
    i32.const 3
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/heap.release.wat
+++ b/tests/compiler/heap.release.wat
@@ -847,7 +847,7 @@
    local.tee $3
    local.get $2
    i32.const 256
-   i32.gt_u
+   i32.ge_u
    if (result i32)
     local.get $2
     i32.const 1

--- a/tests/compiler/heap.release.wat
+++ b/tests/compiler/heap.release.wat
@@ -425,7 +425,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 378
+   i32.const 382
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -450,7 +450,7 @@
    if
     i32.const 0
     i32.const 1056
-    i32.const 385
+    i32.const 389
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -478,7 +478,7 @@
    if
     i32.const 0
     i32.const 1056
-    i32.const 398
+    i32.const 402
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -616,7 +616,7 @@
   if
    i32.const 1120
    i32.const 1056
-   i32.const 459
+   i32.const 461
    i32.const 29
    call $~lib/builtins/abort
    unreachable
@@ -687,7 +687,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 330
+   i32.const 334
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -739,7 +739,7 @@
     if
      i32.const 0
      i32.const 1056
-     i32.const 343
+     i32.const 347
      i32.const 18
      call $~lib/builtins/abort
      unreachable
@@ -774,7 +774,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 357
+   i32.const 361
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -844,12 +844,33 @@
   i32.eqz
   if
    memory.size $0
-   local.tee $1
+   local.tee $3
    local.get $2
+   i32.const 256
+   i32.gt_u
+   if (result i32)
+    local.get $2
+    i32.const 1
+    i32.const 27
+    local.get $2
+    i32.clz
+    i32.sub
+    i32.shl
+    i32.add
+    i32.const 1
+    i32.sub
+    local.get $2
+    local.get $2
+    i32.const 536870910
+    i32.lt_u
+    select
+   else
+    local.get $2
+   end
    i32.const 4
    local.get $0
    i32.load $0 offset=1568
-   local.get $1
+   local.get $3
    i32.const 16
    i32.shl
    i32.const 4
@@ -857,39 +878,22 @@
    i32.ne
    i32.shl
    i32.add
-   local.tee $3
-   i32.const 536870910
-   i32.lt_u
-   if (result i32)
-    local.get $3
-    i32.const 1
-    i32.const 27
-    local.get $3
-    i32.clz
-    i32.sub
-    i32.shl
-    i32.const 1
-    i32.sub
-    i32.add
-   else
-    local.get $3
-   end
    i32.const 65535
    i32.add
    i32.const -65536
    i32.and
    i32.const 16
    i32.shr_u
-   local.tee $3
+   local.tee $1
    local.get $1
    local.get $3
-   i32.gt_s
+   i32.lt_s
    select
    memory.grow $0
    i32.const 0
    i32.lt_s
    if
-    local.get $3
+    local.get $1
     memory.grow $0
     i32.const 0
     i32.lt_s
@@ -898,7 +902,7 @@
     end
    end
    local.get $0
-   local.get $1
+   local.get $3
    i32.const 16
    i32.shl
    memory.size $0
@@ -914,7 +918,7 @@
    if
     i32.const 0
     i32.const 1056
-    i32.const 497
+    i32.const 499
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -929,7 +933,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 499
+   i32.const 501
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -966,7 +970,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 560
+   i32.const 562
    i32.const 3
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/heap.release.wat
+++ b/tests/compiler/heap.release.wat
@@ -844,49 +844,52 @@
   i32.eqz
   if
    memory.size $0
-   local.tee $3
+   local.tee $1
+   local.get $2
    i32.const 4
    local.get $0
    i32.load $0 offset=1568
-   local.get $3
+   local.get $1
    i32.const 16
    i32.shl
    i32.const 4
    i32.sub
    i32.ne
    i32.shl
-   local.get $2
-   i32.const 1
-   i32.const 27
-   local.get $2
-   i32.clz
-   i32.sub
-   i32.shl
-   i32.const 1
-   i32.sub
    i32.add
-   local.get $2
-   local.get $2
+   local.tee $3
    i32.const 536870910
    i32.lt_u
-   select
-   i32.add
+   if (result i32)
+    local.get $3
+    i32.const 1
+    i32.const 27
+    local.get $3
+    i32.clz
+    i32.sub
+    i32.shl
+    i32.const 1
+    i32.sub
+    i32.add
+   else
+    local.get $3
+   end
    i32.const 65535
    i32.add
    i32.const -65536
    i32.and
    i32.const 16
    i32.shr_u
-   local.tee $1
+   local.tee $3
    local.get $1
    local.get $3
-   i32.lt_s
+   i32.gt_s
    select
    memory.grow $0
    i32.const 0
    i32.lt_s
    if
-    local.get $1
+    local.get $3
     memory.grow $0
     i32.const 0
     i32.lt_s
@@ -895,7 +898,7 @@
     end
    end
    local.get $0
-   local.get $3
+   local.get $1
    i32.const 16
    i32.shl
    memory.size $0

--- a/tests/compiler/infer-array.debug.wat
+++ b/tests/compiler/infer-array.debug.wat
@@ -1054,7 +1054,7 @@
   if
    i32.const 0
    i32.const 400
-   i32.const 378
+   i32.const 382
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1100,7 +1100,7 @@
    if
     i32.const 0
     i32.const 400
-    i32.const 385
+    i32.const 389
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1133,7 +1133,7 @@
    if
     i32.const 0
     i32.const 400
-    i32.const 398
+    i32.const 402
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1377,7 +1377,7 @@
   if
    i32.const 0
    i32.const 400
-   i32.const 560
+   i32.const 562
    i32.const 3
    call $~lib/builtins/abort
    unreachable
@@ -1706,13 +1706,33 @@
   if
    i32.const 64
    i32.const 400
-   i32.const 459
+   i32.const 461
    i32.const 29
    call $~lib/builtins/abort
    unreachable
   end
   local.get $size
   call $~lib/rt/tlsf/computeSize
+  return
+ )
+ (func $~lib/rt/tlsf/roundSize (param $size i32) (result i32)
+  local.get $size
+  i32.const 536870910
+  i32.lt_u
+  if (result i32)
+   local.get $size
+   i32.const 1
+   i32.const 27
+   local.get $size
+   i32.clz
+   i32.sub
+   i32.shl
+   i32.add
+   i32.const 1
+   i32.sub
+  else
+   local.get $size
+  end
   return
  )
  (func $~lib/rt/tlsf/searchBlock (param $root i32) (param $size i32) (result i32)
@@ -1744,24 +1764,13 @@
    local.set $sl
   else
    local.get $size
-   i32.const 536870910
-   i32.lt_u
-   if (result i32)
-    local.get $size
-    i32.const 1
-    i32.const 27
-    local.get $size
-    i32.clz
-    i32.sub
-    i32.shl
-    i32.add
-    i32.const 1
-    i32.sub
-   else
-    local.get $size
-   end
+   call $~lib/rt/tlsf/roundSize
    local.set $requestSize
-   i32.const 31
+   i32.const 4
+   i32.const 8
+   i32.mul
+   i32.const 1
+   i32.sub
    local.get $requestSize
    i32.clz
    i32.sub
@@ -1799,7 +1808,7 @@
   if
    i32.const 0
    i32.const 400
-   i32.const 330
+   i32.const 334
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1870,7 +1879,7 @@
     if
      i32.const 0
      i32.const 400
-     i32.const 343
+     i32.const 347
      i32.const 18
      call $~lib/builtins/abort
      unreachable
@@ -1933,6 +1942,14 @@
   (local $pagesAfter i32)
   i32.const 0
   drop
+  local.get $size
+  i32.const 256
+  i32.gt_u
+  if
+   local.get $size
+   call $~lib/rt/tlsf/roundSize
+   local.set $size
+  end
   memory.size $0
   local.set $pagesBefore
   local.get $size
@@ -1953,22 +1970,6 @@
   i32.shl
   i32.add
   local.set $size
-  local.get $size
-  i32.const 536870910
-  i32.lt_u
-  if
-   local.get $size
-   i32.const 1
-   i32.const 27
-   local.get $size
-   i32.clz
-   i32.sub
-   i32.shl
-   i32.const 1
-   i32.sub
-   i32.add
-   local.set $size
-  end
   local.get $size
   i32.const 65535
   i32.add
@@ -2035,7 +2036,7 @@
   if
    i32.const 0
    i32.const 400
-   i32.const 357
+   i32.const 361
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -2150,7 +2151,7 @@
    if
     i32.const 0
     i32.const 400
-    i32.const 497
+    i32.const 499
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -2170,7 +2171,7 @@
   if
    i32.const 0
    i32.const 400
-   i32.const 499
+   i32.const 501
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/infer-array.debug.wat
+++ b/tests/compiler/infer-array.debug.wat
@@ -1933,22 +1933,6 @@
   (local $pagesAfter i32)
   i32.const 0
   drop
-  local.get $size
-  i32.const 536870910
-  i32.lt_u
-  if
-   local.get $size
-   i32.const 1
-   i32.const 27
-   local.get $size
-   i32.clz
-   i32.sub
-   i32.shl
-   i32.const 1
-   i32.sub
-   i32.add
-   local.set $size
-  end
   memory.size $0
   local.set $pagesBefore
   local.get $size
@@ -1969,6 +1953,22 @@
   i32.shl
   i32.add
   local.set $size
+  local.get $size
+  i32.const 536870910
+  i32.lt_u
+  if
+   local.get $size
+   i32.const 1
+   i32.const 27
+   local.get $size
+   i32.clz
+   i32.sub
+   i32.shl
+   i32.const 1
+   i32.sub
+   i32.add
+   local.set $size
+  end
   local.get $size
   i32.const 65535
   i32.add

--- a/tests/compiler/infer-array.debug.wat
+++ b/tests/compiler/infer-array.debug.wat
@@ -1944,7 +1944,7 @@
   drop
   local.get $size
   i32.const 256
-  i32.gt_u
+  i32.ge_u
   if
    local.get $size
    call $~lib/rt/tlsf/roundSize

--- a/tests/compiler/infer-array.release.wat
+++ b/tests/compiler/infer-array.release.wat
@@ -1342,7 +1342,7 @@
    local.tee $2
    local.get $5
    i32.const 256
-   i32.gt_u
+   i32.ge_u
    if (result i32)
     local.get $5
     i32.const 1

--- a/tests/compiler/infer-array.release.wat
+++ b/tests/compiler/infer-array.release.wat
@@ -660,7 +660,7 @@
   if
    i32.const 0
    i32.const 1424
-   i32.const 378
+   i32.const 382
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -685,7 +685,7 @@
    if
     i32.const 0
     i32.const 1424
-    i32.const 385
+    i32.const 389
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -713,7 +713,7 @@
    if
     i32.const 0
     i32.const 1424
-    i32.const 398
+    i32.const 402
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1080,7 +1080,7 @@
       if
        i32.const 0
        i32.const 1424
-       i32.const 560
+       i32.const 562
        i32.const 3
        call $~lib/builtins/abort
        unreachable
@@ -1164,7 +1164,7 @@
   if
    i32.const 0
    i32.const 1424
-   i32.const 330
+   i32.const 334
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1216,7 +1216,7 @@
     if
      i32.const 0
      i32.const 1424
-     i32.const 343
+     i32.const 347
      i32.const 18
      call $~lib/builtins/abort
      unreachable
@@ -1305,7 +1305,7 @@
    call $~lib/rt/tlsf/initialize
   end
   global.get $~lib/rt/tlsf/ROOT
-  local.set $3
+  local.set $4
   local.get $0
   i32.const 16
   i32.add
@@ -1315,12 +1315,12 @@
   if
    i32.const 1088
    i32.const 1424
-   i32.const 459
+   i32.const 461
    i32.const 29
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $3
+  local.get $4
   i32.const 12
   local.get $2
   i32.const 19
@@ -1341,8 +1341,29 @@
    memory.size $0
    local.tee $2
    local.get $5
+   i32.const 256
+   i32.gt_u
+   if (result i32)
+    local.get $5
+    i32.const 1
+    i32.const 27
+    local.get $5
+    i32.clz
+    i32.sub
+    i32.shl
+    i32.add
+    i32.const 1
+    i32.sub
+    local.get $5
+    local.get $5
+    i32.const 536870910
+    i32.lt_u
+    select
+   else
+    local.get $5
+   end
    i32.const 4
-   local.get $3
+   local.get $4
    i32.load $0 offset=1568
    local.get $2
    i32.const 16
@@ -1352,39 +1373,22 @@
    i32.ne
    i32.shl
    i32.add
-   local.tee $4
-   i32.const 536870910
-   i32.lt_u
-   if (result i32)
-    local.get $4
-    i32.const 1
-    i32.const 27
-    local.get $4
-    i32.clz
-    i32.sub
-    i32.shl
-    i32.const 1
-    i32.sub
-    i32.add
-   else
-    local.get $4
-   end
    i32.const 65535
    i32.add
    i32.const -65536
    i32.and
    i32.const 16
    i32.shr_u
-   local.tee $4
+   local.tee $3
    local.get $2
-   local.get $4
+   local.get $3
    i32.gt_s
    select
    memory.grow $0
    i32.const 0
    i32.lt_s
    if
-    local.get $4
+    local.get $3
     memory.grow $0
     i32.const 0
     i32.lt_s
@@ -1392,7 +1396,7 @@
      unreachable
     end
    end
-   local.get $3
+   local.get $4
    local.get $2
    i32.const 16
    i32.shl
@@ -1401,7 +1405,7 @@
    i64.const 16
    i64.shl
    call $~lib/rt/tlsf/addMemory
-   local.get $3
+   local.get $4
    local.get $5
    call $~lib/rt/tlsf/searchBlock
    local.tee $2
@@ -1409,7 +1413,7 @@
    if
     i32.const 0
     i32.const 1424
-    i32.const 497
+    i32.const 499
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1424,17 +1428,17 @@
   if
    i32.const 0
    i32.const 1424
-   i32.const 499
+   i32.const 501
    i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $3
+  local.get $4
   local.get $2
   call $~lib/rt/tlsf/removeBlock
   local.get $2
   i32.load $0
-  local.set $4
+  local.set $3
   local.get $5
   i32.const 4
   i32.add
@@ -1443,12 +1447,12 @@
   if
    i32.const 0
    i32.const 1424
-   i32.const 357
+   i32.const 361
    i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $4
+  local.get $3
   i32.const -4
   i32.and
   local.get $5
@@ -1459,7 +1463,7 @@
   if
    local.get $2
    local.get $5
-   local.get $4
+   local.get $3
    i32.const 2
    i32.and
    i32.or
@@ -1469,19 +1473,19 @@
    i32.add
    local.get $5
    i32.add
-   local.tee $4
+   local.tee $3
    local.get $6
    i32.const 4
    i32.sub
    i32.const 1
    i32.or
    i32.store $0
-   local.get $3
    local.get $4
+   local.get $3
    call $~lib/rt/tlsf/insertBlock
   else
    local.get $2
-   local.get $4
+   local.get $3
    i32.const -2
    i32.and
    i32.store $0

--- a/tests/compiler/infer-array.release.wat
+++ b/tests/compiler/infer-array.release.wat
@@ -1305,7 +1305,7 @@
    call $~lib/rt/tlsf/initialize
   end
   global.get $~lib/rt/tlsf/ROOT
-  local.set $4
+  local.set $3
   local.get $0
   i32.const 16
   i32.add
@@ -1320,7 +1320,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $4
+  local.get $3
   i32.const 12
   local.get $2
   i32.const 19
@@ -1340,8 +1340,9 @@
   if
    memory.size $0
    local.tee $2
+   local.get $5
    i32.const 4
-   local.get $4
+   local.get $3
    i32.load $0 offset=1568
    local.get $2
    i32.const 16
@@ -1350,38 +1351,40 @@
    i32.sub
    i32.ne
    i32.shl
-   local.get $5
-   i32.const 1
-   i32.const 27
-   local.get $5
-   i32.clz
-   i32.sub
-   i32.shl
-   i32.const 1
-   i32.sub
    i32.add
-   local.get $5
-   local.get $5
+   local.tee $4
    i32.const 536870910
    i32.lt_u
-   select
-   i32.add
+   if (result i32)
+    local.get $4
+    i32.const 1
+    i32.const 27
+    local.get $4
+    i32.clz
+    i32.sub
+    i32.shl
+    i32.const 1
+    i32.sub
+    i32.add
+   else
+    local.get $4
+   end
    i32.const 65535
    i32.add
    i32.const -65536
    i32.and
    i32.const 16
    i32.shr_u
-   local.tee $3
+   local.tee $4
    local.get $2
-   local.get $3
+   local.get $4
    i32.gt_s
    select
    memory.grow $0
    i32.const 0
    i32.lt_s
    if
-    local.get $3
+    local.get $4
     memory.grow $0
     i32.const 0
     i32.lt_s
@@ -1389,7 +1392,7 @@
      unreachable
     end
    end
-   local.get $4
+   local.get $3
    local.get $2
    i32.const 16
    i32.shl
@@ -1398,7 +1401,7 @@
    i64.const 16
    i64.shl
    call $~lib/rt/tlsf/addMemory
-   local.get $4
+   local.get $3
    local.get $5
    call $~lib/rt/tlsf/searchBlock
    local.tee $2
@@ -1426,12 +1429,12 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $4
+  local.get $3
   local.get $2
   call $~lib/rt/tlsf/removeBlock
   local.get $2
   i32.load $0
-  local.set $3
+  local.set $4
   local.get $5
   i32.const 4
   i32.add
@@ -1445,7 +1448,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $3
+  local.get $4
   i32.const -4
   i32.and
   local.get $5
@@ -1456,7 +1459,7 @@
   if
    local.get $2
    local.get $5
-   local.get $3
+   local.get $4
    i32.const 2
    i32.and
    i32.or
@@ -1466,19 +1469,19 @@
    i32.add
    local.get $5
    i32.add
-   local.tee $3
+   local.tee $4
    local.get $6
    i32.const 4
    i32.sub
    i32.const 1
    i32.or
    i32.store $0
-   local.get $4
    local.get $3
+   local.get $4
    call $~lib/rt/tlsf/insertBlock
   else
    local.get $2
-   local.get $3
+   local.get $4
    i32.const -2
    i32.and
    i32.store $0

--- a/tests/compiler/infer-generic.debug.wat
+++ b/tests/compiler/infer-generic.debug.wat
@@ -1081,7 +1081,7 @@
   if
    i32.const 0
    i32.const 544
-   i32.const 378
+   i32.const 382
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1127,7 +1127,7 @@
    if
     i32.const 0
     i32.const 544
-    i32.const 385
+    i32.const 389
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1160,7 +1160,7 @@
    if
     i32.const 0
     i32.const 544
-    i32.const 398
+    i32.const 402
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1404,7 +1404,7 @@
   if
    i32.const 0
    i32.const 544
-   i32.const 560
+   i32.const 562
    i32.const 3
    call $~lib/builtins/abort
    unreachable
@@ -1733,13 +1733,33 @@
   if
    i32.const 208
    i32.const 544
-   i32.const 459
+   i32.const 461
    i32.const 29
    call $~lib/builtins/abort
    unreachable
   end
   local.get $size
   call $~lib/rt/tlsf/computeSize
+  return
+ )
+ (func $~lib/rt/tlsf/roundSize (param $size i32) (result i32)
+  local.get $size
+  i32.const 536870910
+  i32.lt_u
+  if (result i32)
+   local.get $size
+   i32.const 1
+   i32.const 27
+   local.get $size
+   i32.clz
+   i32.sub
+   i32.shl
+   i32.add
+   i32.const 1
+   i32.sub
+  else
+   local.get $size
+  end
   return
  )
  (func $~lib/rt/tlsf/searchBlock (param $root i32) (param $size i32) (result i32)
@@ -1771,24 +1791,13 @@
    local.set $sl
   else
    local.get $size
-   i32.const 536870910
-   i32.lt_u
-   if (result i32)
-    local.get $size
-    i32.const 1
-    i32.const 27
-    local.get $size
-    i32.clz
-    i32.sub
-    i32.shl
-    i32.add
-    i32.const 1
-    i32.sub
-   else
-    local.get $size
-   end
+   call $~lib/rt/tlsf/roundSize
    local.set $requestSize
-   i32.const 31
+   i32.const 4
+   i32.const 8
+   i32.mul
+   i32.const 1
+   i32.sub
    local.get $requestSize
    i32.clz
    i32.sub
@@ -1826,7 +1835,7 @@
   if
    i32.const 0
    i32.const 544
-   i32.const 330
+   i32.const 334
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1897,7 +1906,7 @@
     if
      i32.const 0
      i32.const 544
-     i32.const 343
+     i32.const 347
      i32.const 18
      call $~lib/builtins/abort
      unreachable
@@ -1960,6 +1969,14 @@
   (local $pagesAfter i32)
   i32.const 0
   drop
+  local.get $size
+  i32.const 256
+  i32.gt_u
+  if
+   local.get $size
+   call $~lib/rt/tlsf/roundSize
+   local.set $size
+  end
   memory.size $0
   local.set $pagesBefore
   local.get $size
@@ -1980,22 +1997,6 @@
   i32.shl
   i32.add
   local.set $size
-  local.get $size
-  i32.const 536870910
-  i32.lt_u
-  if
-   local.get $size
-   i32.const 1
-   i32.const 27
-   local.get $size
-   i32.clz
-   i32.sub
-   i32.shl
-   i32.const 1
-   i32.sub
-   i32.add
-   local.set $size
-  end
   local.get $size
   i32.const 65535
   i32.add
@@ -2062,7 +2063,7 @@
   if
    i32.const 0
    i32.const 544
-   i32.const 357
+   i32.const 361
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -2177,7 +2178,7 @@
    if
     i32.const 0
     i32.const 544
-    i32.const 497
+    i32.const 499
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -2197,7 +2198,7 @@
   if
    i32.const 0
    i32.const 544
-   i32.const 499
+   i32.const 501
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/infer-generic.debug.wat
+++ b/tests/compiler/infer-generic.debug.wat
@@ -1971,7 +1971,7 @@
   drop
   local.get $size
   i32.const 256
-  i32.gt_u
+  i32.ge_u
   if
    local.get $size
    call $~lib/rt/tlsf/roundSize

--- a/tests/compiler/infer-generic.debug.wat
+++ b/tests/compiler/infer-generic.debug.wat
@@ -1960,22 +1960,6 @@
   (local $pagesAfter i32)
   i32.const 0
   drop
-  local.get $size
-  i32.const 536870910
-  i32.lt_u
-  if
-   local.get $size
-   i32.const 1
-   i32.const 27
-   local.get $size
-   i32.clz
-   i32.sub
-   i32.shl
-   i32.const 1
-   i32.sub
-   i32.add
-   local.set $size
-  end
   memory.size $0
   local.set $pagesBefore
   local.get $size
@@ -1996,6 +1980,22 @@
   i32.shl
   i32.add
   local.set $size
+  local.get $size
+  i32.const 536870910
+  i32.lt_u
+  if
+   local.get $size
+   i32.const 1
+   i32.const 27
+   local.get $size
+   i32.clz
+   i32.sub
+   i32.shl
+   i32.const 1
+   i32.sub
+   i32.add
+   local.set $size
+  end
   local.get $size
   i32.const 65535
   i32.add

--- a/tests/compiler/infer-generic.release.wat
+++ b/tests/compiler/infer-generic.release.wat
@@ -1292,7 +1292,7 @@
    call $~lib/rt/tlsf/initialize
   end
   global.get $~lib/rt/tlsf/ROOT
-  local.set $4
+  local.set $3
   local.get $0
   i32.const 16
   i32.add
@@ -1307,7 +1307,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $4
+  local.get $3
   i32.const 12
   local.get $2
   i32.const 19
@@ -1327,8 +1327,9 @@
   if
    memory.size $0
    local.tee $2
+   local.get $5
    i32.const 4
-   local.get $4
+   local.get $3
    i32.load $0 offset=1568
    local.get $2
    i32.const 16
@@ -1337,38 +1338,40 @@
    i32.sub
    i32.ne
    i32.shl
-   local.get $5
-   i32.const 1
-   i32.const 27
-   local.get $5
-   i32.clz
-   i32.sub
-   i32.shl
-   i32.const 1
-   i32.sub
    i32.add
-   local.get $5
-   local.get $5
+   local.tee $4
    i32.const 536870910
    i32.lt_u
-   select
-   i32.add
+   if (result i32)
+    local.get $4
+    i32.const 1
+    i32.const 27
+    local.get $4
+    i32.clz
+    i32.sub
+    i32.shl
+    i32.const 1
+    i32.sub
+    i32.add
+   else
+    local.get $4
+   end
    i32.const 65535
    i32.add
    i32.const -65536
    i32.and
    i32.const 16
    i32.shr_u
-   local.tee $3
+   local.tee $4
    local.get $2
-   local.get $3
+   local.get $4
    i32.gt_s
    select
    memory.grow $0
    i32.const 0
    i32.lt_s
    if
-    local.get $3
+    local.get $4
     memory.grow $0
     i32.const 0
     i32.lt_s
@@ -1376,7 +1379,7 @@
      unreachable
     end
    end
-   local.get $4
+   local.get $3
    local.get $2
    i32.const 16
    i32.shl
@@ -1385,7 +1388,7 @@
    i64.const 16
    i64.shl
    call $~lib/rt/tlsf/addMemory
-   local.get $4
+   local.get $3
    local.get $5
    call $~lib/rt/tlsf/searchBlock
    local.tee $2
@@ -1413,12 +1416,12 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $4
+  local.get $3
   local.get $2
   call $~lib/rt/tlsf/removeBlock
   local.get $2
   i32.load $0
-  local.set $3
+  local.set $4
   local.get $5
   i32.const 4
   i32.add
@@ -1432,7 +1435,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $3
+  local.get $4
   i32.const -4
   i32.and
   local.get $5
@@ -1443,7 +1446,7 @@
   if
    local.get $2
    local.get $5
-   local.get $3
+   local.get $4
    i32.const 2
    i32.and
    i32.or
@@ -1453,19 +1456,19 @@
    i32.add
    local.get $5
    i32.add
-   local.tee $3
+   local.tee $4
    local.get $6
    i32.const 4
    i32.sub
    i32.const 1
    i32.or
    i32.store $0
-   local.get $4
    local.get $3
+   local.get $4
    call $~lib/rt/tlsf/insertBlock
   else
    local.get $2
-   local.get $3
+   local.get $4
    i32.const -2
    i32.and
    i32.store $0

--- a/tests/compiler/infer-generic.release.wat
+++ b/tests/compiler/infer-generic.release.wat
@@ -647,7 +647,7 @@
   if
    i32.const 0
    i32.const 1568
-   i32.const 378
+   i32.const 382
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -672,7 +672,7 @@
    if
     i32.const 0
     i32.const 1568
-    i32.const 385
+    i32.const 389
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -700,7 +700,7 @@
    if
     i32.const 0
     i32.const 1568
-    i32.const 398
+    i32.const 402
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1067,7 +1067,7 @@
       if
        i32.const 0
        i32.const 1568
-       i32.const 560
+       i32.const 562
        i32.const 3
        call $~lib/builtins/abort
        unreachable
@@ -1151,7 +1151,7 @@
   if
    i32.const 0
    i32.const 1568
-   i32.const 330
+   i32.const 334
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1203,7 +1203,7 @@
     if
      i32.const 0
      i32.const 1568
-     i32.const 343
+     i32.const 347
      i32.const 18
      call $~lib/builtins/abort
      unreachable
@@ -1292,7 +1292,7 @@
    call $~lib/rt/tlsf/initialize
   end
   global.get $~lib/rt/tlsf/ROOT
-  local.set $3
+  local.set $4
   local.get $0
   i32.const 16
   i32.add
@@ -1302,12 +1302,12 @@
   if
    i32.const 1232
    i32.const 1568
-   i32.const 459
+   i32.const 461
    i32.const 29
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $3
+  local.get $4
   i32.const 12
   local.get $2
   i32.const 19
@@ -1328,8 +1328,29 @@
    memory.size $0
    local.tee $2
    local.get $5
+   i32.const 256
+   i32.gt_u
+   if (result i32)
+    local.get $5
+    i32.const 1
+    i32.const 27
+    local.get $5
+    i32.clz
+    i32.sub
+    i32.shl
+    i32.add
+    i32.const 1
+    i32.sub
+    local.get $5
+    local.get $5
+    i32.const 536870910
+    i32.lt_u
+    select
+   else
+    local.get $5
+   end
    i32.const 4
-   local.get $3
+   local.get $4
    i32.load $0 offset=1568
    local.get $2
    i32.const 16
@@ -1339,39 +1360,22 @@
    i32.ne
    i32.shl
    i32.add
-   local.tee $4
-   i32.const 536870910
-   i32.lt_u
-   if (result i32)
-    local.get $4
-    i32.const 1
-    i32.const 27
-    local.get $4
-    i32.clz
-    i32.sub
-    i32.shl
-    i32.const 1
-    i32.sub
-    i32.add
-   else
-    local.get $4
-   end
    i32.const 65535
    i32.add
    i32.const -65536
    i32.and
    i32.const 16
    i32.shr_u
-   local.tee $4
+   local.tee $3
    local.get $2
-   local.get $4
+   local.get $3
    i32.gt_s
    select
    memory.grow $0
    i32.const 0
    i32.lt_s
    if
-    local.get $4
+    local.get $3
     memory.grow $0
     i32.const 0
     i32.lt_s
@@ -1379,7 +1383,7 @@
      unreachable
     end
    end
-   local.get $3
+   local.get $4
    local.get $2
    i32.const 16
    i32.shl
@@ -1388,7 +1392,7 @@
    i64.const 16
    i64.shl
    call $~lib/rt/tlsf/addMemory
-   local.get $3
+   local.get $4
    local.get $5
    call $~lib/rt/tlsf/searchBlock
    local.tee $2
@@ -1396,7 +1400,7 @@
    if
     i32.const 0
     i32.const 1568
-    i32.const 497
+    i32.const 499
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1411,17 +1415,17 @@
   if
    i32.const 0
    i32.const 1568
-   i32.const 499
+   i32.const 501
    i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $3
+  local.get $4
   local.get $2
   call $~lib/rt/tlsf/removeBlock
   local.get $2
   i32.load $0
-  local.set $4
+  local.set $3
   local.get $5
   i32.const 4
   i32.add
@@ -1430,12 +1434,12 @@
   if
    i32.const 0
    i32.const 1568
-   i32.const 357
+   i32.const 361
    i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $4
+  local.get $3
   i32.const -4
   i32.and
   local.get $5
@@ -1446,7 +1450,7 @@
   if
    local.get $2
    local.get $5
-   local.get $4
+   local.get $3
    i32.const 2
    i32.and
    i32.or
@@ -1456,19 +1460,19 @@
    i32.add
    local.get $5
    i32.add
-   local.tee $4
+   local.tee $3
    local.get $6
    i32.const 4
    i32.sub
    i32.const 1
    i32.or
    i32.store $0
-   local.get $3
    local.get $4
+   local.get $3
    call $~lib/rt/tlsf/insertBlock
   else
    local.get $2
-   local.get $4
+   local.get $3
    i32.const -2
    i32.and
    i32.store $0

--- a/tests/compiler/infer-generic.release.wat
+++ b/tests/compiler/infer-generic.release.wat
@@ -1329,7 +1329,7 @@
    local.tee $2
    local.get $5
    i32.const 256
-   i32.gt_u
+   i32.ge_u
    if (result i32)
     local.get $5
     i32.const 1

--- a/tests/compiler/inlining.debug.wat
+++ b/tests/compiler/inlining.debug.wat
@@ -1300,7 +1300,7 @@
   if
    i32.const 0
    i32.const 448
-   i32.const 378
+   i32.const 382
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1346,7 +1346,7 @@
    if
     i32.const 0
     i32.const 448
-    i32.const 385
+    i32.const 389
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1379,7 +1379,7 @@
    if
     i32.const 0
     i32.const 448
-    i32.const 398
+    i32.const 402
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1623,7 +1623,7 @@
   if
    i32.const 0
    i32.const 448
-   i32.const 560
+   i32.const 562
    i32.const 3
    call $~lib/builtins/abort
    unreachable
@@ -1952,13 +1952,33 @@
   if
    i32.const 112
    i32.const 448
-   i32.const 459
+   i32.const 461
    i32.const 29
    call $~lib/builtins/abort
    unreachable
   end
   local.get $size
   call $~lib/rt/tlsf/computeSize
+  return
+ )
+ (func $~lib/rt/tlsf/roundSize (param $size i32) (result i32)
+  local.get $size
+  i32.const 536870910
+  i32.lt_u
+  if (result i32)
+   local.get $size
+   i32.const 1
+   i32.const 27
+   local.get $size
+   i32.clz
+   i32.sub
+   i32.shl
+   i32.add
+   i32.const 1
+   i32.sub
+  else
+   local.get $size
+  end
   return
  )
  (func $~lib/rt/tlsf/searchBlock (param $root i32) (param $size i32) (result i32)
@@ -1990,24 +2010,13 @@
    local.set $sl
   else
    local.get $size
-   i32.const 536870910
-   i32.lt_u
-   if (result i32)
-    local.get $size
-    i32.const 1
-    i32.const 27
-    local.get $size
-    i32.clz
-    i32.sub
-    i32.shl
-    i32.add
-    i32.const 1
-    i32.sub
-   else
-    local.get $size
-   end
+   call $~lib/rt/tlsf/roundSize
    local.set $requestSize
-   i32.const 31
+   i32.const 4
+   i32.const 8
+   i32.mul
+   i32.const 1
+   i32.sub
    local.get $requestSize
    i32.clz
    i32.sub
@@ -2045,7 +2054,7 @@
   if
    i32.const 0
    i32.const 448
-   i32.const 330
+   i32.const 334
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -2116,7 +2125,7 @@
     if
      i32.const 0
      i32.const 448
-     i32.const 343
+     i32.const 347
      i32.const 18
      call $~lib/builtins/abort
      unreachable
@@ -2179,6 +2188,14 @@
   (local $pagesAfter i32)
   i32.const 0
   drop
+  local.get $size
+  i32.const 256
+  i32.gt_u
+  if
+   local.get $size
+   call $~lib/rt/tlsf/roundSize
+   local.set $size
+  end
   memory.size $0
   local.set $pagesBefore
   local.get $size
@@ -2199,22 +2216,6 @@
   i32.shl
   i32.add
   local.set $size
-  local.get $size
-  i32.const 536870910
-  i32.lt_u
-  if
-   local.get $size
-   i32.const 1
-   i32.const 27
-   local.get $size
-   i32.clz
-   i32.sub
-   i32.shl
-   i32.const 1
-   i32.sub
-   i32.add
-   local.set $size
-  end
   local.get $size
   i32.const 65535
   i32.add
@@ -2281,7 +2282,7 @@
   if
    i32.const 0
    i32.const 448
-   i32.const 357
+   i32.const 361
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -2396,7 +2397,7 @@
    if
     i32.const 0
     i32.const 448
-    i32.const 497
+    i32.const 499
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -2416,7 +2417,7 @@
   if
    i32.const 0
    i32.const 448
-   i32.const 499
+   i32.const 501
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/inlining.debug.wat
+++ b/tests/compiler/inlining.debug.wat
@@ -2179,22 +2179,6 @@
   (local $pagesAfter i32)
   i32.const 0
   drop
-  local.get $size
-  i32.const 536870910
-  i32.lt_u
-  if
-   local.get $size
-   i32.const 1
-   i32.const 27
-   local.get $size
-   i32.clz
-   i32.sub
-   i32.shl
-   i32.const 1
-   i32.sub
-   i32.add
-   local.set $size
-  end
   memory.size $0
   local.set $pagesBefore
   local.get $size
@@ -2215,6 +2199,22 @@
   i32.shl
   i32.add
   local.set $size
+  local.get $size
+  i32.const 536870910
+  i32.lt_u
+  if
+   local.get $size
+   i32.const 1
+   i32.const 27
+   local.get $size
+   i32.clz
+   i32.sub
+   i32.shl
+   i32.const 1
+   i32.sub
+   i32.add
+   local.set $size
+  end
   local.get $size
   i32.const 65535
   i32.add

--- a/tests/compiler/inlining.debug.wat
+++ b/tests/compiler/inlining.debug.wat
@@ -2190,7 +2190,7 @@
   drop
   local.get $size
   i32.const 256
-  i32.gt_u
+  i32.ge_u
   if
    local.get $size
    call $~lib/rt/tlsf/roundSize

--- a/tests/compiler/inlining.release.wat
+++ b/tests/compiler/inlining.release.wat
@@ -1278,7 +1278,7 @@
    call $~lib/rt/tlsf/initialize
   end
   global.get $~lib/rt/tlsf/ROOT
-  local.set $4
+  local.set $3
   local.get $0
   i32.const 16
   i32.add
@@ -1293,7 +1293,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $4
+  local.get $3
   i32.const 12
   local.get $2
   i32.const 19
@@ -1313,8 +1313,9 @@
   if
    memory.size $0
    local.tee $2
+   local.get $5
    i32.const 4
-   local.get $4
+   local.get $3
    i32.load $0 offset=1568
    local.get $2
    i32.const 16
@@ -1323,38 +1324,40 @@
    i32.sub
    i32.ne
    i32.shl
-   local.get $5
-   i32.const 1
-   i32.const 27
-   local.get $5
-   i32.clz
-   i32.sub
-   i32.shl
-   i32.const 1
-   i32.sub
    i32.add
-   local.get $5
-   local.get $5
+   local.tee $4
    i32.const 536870910
    i32.lt_u
-   select
-   i32.add
+   if (result i32)
+    local.get $4
+    i32.const 1
+    i32.const 27
+    local.get $4
+    i32.clz
+    i32.sub
+    i32.shl
+    i32.const 1
+    i32.sub
+    i32.add
+   else
+    local.get $4
+   end
    i32.const 65535
    i32.add
    i32.const -65536
    i32.and
    i32.const 16
    i32.shr_u
-   local.tee $3
+   local.tee $4
    local.get $2
-   local.get $3
+   local.get $4
    i32.gt_s
    select
    memory.grow $0
    i32.const 0
    i32.lt_s
    if
-    local.get $3
+    local.get $4
     memory.grow $0
     i32.const 0
     i32.lt_s
@@ -1362,7 +1365,7 @@
      unreachable
     end
    end
-   local.get $4
+   local.get $3
    local.get $2
    i32.const 16
    i32.shl
@@ -1371,7 +1374,7 @@
    i64.const 16
    i64.shl
    call $~lib/rt/tlsf/addMemory
-   local.get $4
+   local.get $3
    local.get $5
    call $~lib/rt/tlsf/searchBlock
    local.tee $2
@@ -1399,12 +1402,12 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $4
+  local.get $3
   local.get $2
   call $~lib/rt/tlsf/removeBlock
   local.get $2
   i32.load $0
-  local.set $3
+  local.set $4
   local.get $5
   i32.const 4
   i32.add
@@ -1418,7 +1421,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $3
+  local.get $4
   i32.const -4
   i32.and
   local.get $5
@@ -1429,7 +1432,7 @@
   if
    local.get $2
    local.get $5
-   local.get $3
+   local.get $4
    i32.const 2
    i32.and
    i32.or
@@ -1439,19 +1442,19 @@
    i32.add
    local.get $5
    i32.add
-   local.tee $3
+   local.tee $4
    local.get $6
    i32.const 4
    i32.sub
    i32.const 1
    i32.or
    i32.store $0
-   local.get $4
    local.get $3
+   local.get $4
    call $~lib/rt/tlsf/insertBlock
   else
    local.get $2
-   local.get $3
+   local.get $4
    i32.const -2
    i32.and
    i32.store $0

--- a/tests/compiler/inlining.release.wat
+++ b/tests/compiler/inlining.release.wat
@@ -1315,7 +1315,7 @@
    local.tee $2
    local.get $5
    i32.const 256
-   i32.gt_u
+   i32.ge_u
    if (result i32)
     local.get $5
     i32.const 1

--- a/tests/compiler/inlining.release.wat
+++ b/tests/compiler/inlining.release.wat
@@ -633,7 +633,7 @@
   if
    i32.const 0
    i32.const 1472
-   i32.const 378
+   i32.const 382
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -658,7 +658,7 @@
    if
     i32.const 0
     i32.const 1472
-    i32.const 385
+    i32.const 389
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -686,7 +686,7 @@
    if
     i32.const 0
     i32.const 1472
-    i32.const 398
+    i32.const 402
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1053,7 +1053,7 @@
       if
        i32.const 0
        i32.const 1472
-       i32.const 560
+       i32.const 562
        i32.const 3
        call $~lib/builtins/abort
        unreachable
@@ -1137,7 +1137,7 @@
   if
    i32.const 0
    i32.const 1472
-   i32.const 330
+   i32.const 334
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1189,7 +1189,7 @@
     if
      i32.const 0
      i32.const 1472
-     i32.const 343
+     i32.const 347
      i32.const 18
      call $~lib/builtins/abort
      unreachable
@@ -1278,7 +1278,7 @@
    call $~lib/rt/tlsf/initialize
   end
   global.get $~lib/rt/tlsf/ROOT
-  local.set $3
+  local.set $4
   local.get $0
   i32.const 16
   i32.add
@@ -1288,12 +1288,12 @@
   if
    i32.const 1136
    i32.const 1472
-   i32.const 459
+   i32.const 461
    i32.const 29
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $3
+  local.get $4
   i32.const 12
   local.get $2
   i32.const 19
@@ -1314,8 +1314,29 @@
    memory.size $0
    local.tee $2
    local.get $5
+   i32.const 256
+   i32.gt_u
+   if (result i32)
+    local.get $5
+    i32.const 1
+    i32.const 27
+    local.get $5
+    i32.clz
+    i32.sub
+    i32.shl
+    i32.add
+    i32.const 1
+    i32.sub
+    local.get $5
+    local.get $5
+    i32.const 536870910
+    i32.lt_u
+    select
+   else
+    local.get $5
+   end
    i32.const 4
-   local.get $3
+   local.get $4
    i32.load $0 offset=1568
    local.get $2
    i32.const 16
@@ -1325,39 +1346,22 @@
    i32.ne
    i32.shl
    i32.add
-   local.tee $4
-   i32.const 536870910
-   i32.lt_u
-   if (result i32)
-    local.get $4
-    i32.const 1
-    i32.const 27
-    local.get $4
-    i32.clz
-    i32.sub
-    i32.shl
-    i32.const 1
-    i32.sub
-    i32.add
-   else
-    local.get $4
-   end
    i32.const 65535
    i32.add
    i32.const -65536
    i32.and
    i32.const 16
    i32.shr_u
-   local.tee $4
+   local.tee $3
    local.get $2
-   local.get $4
+   local.get $3
    i32.gt_s
    select
    memory.grow $0
    i32.const 0
    i32.lt_s
    if
-    local.get $4
+    local.get $3
     memory.grow $0
     i32.const 0
     i32.lt_s
@@ -1365,7 +1369,7 @@
      unreachable
     end
    end
-   local.get $3
+   local.get $4
    local.get $2
    i32.const 16
    i32.shl
@@ -1374,7 +1378,7 @@
    i64.const 16
    i64.shl
    call $~lib/rt/tlsf/addMemory
-   local.get $3
+   local.get $4
    local.get $5
    call $~lib/rt/tlsf/searchBlock
    local.tee $2
@@ -1382,7 +1386,7 @@
    if
     i32.const 0
     i32.const 1472
-    i32.const 497
+    i32.const 499
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1397,17 +1401,17 @@
   if
    i32.const 0
    i32.const 1472
-   i32.const 499
+   i32.const 501
    i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $3
+  local.get $4
   local.get $2
   call $~lib/rt/tlsf/removeBlock
   local.get $2
   i32.load $0
-  local.set $4
+  local.set $3
   local.get $5
   i32.const 4
   i32.add
@@ -1416,12 +1420,12 @@
   if
    i32.const 0
    i32.const 1472
-   i32.const 357
+   i32.const 361
    i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $4
+  local.get $3
   i32.const -4
   i32.and
   local.get $5
@@ -1432,7 +1436,7 @@
   if
    local.get $2
    local.get $5
-   local.get $4
+   local.get $3
    i32.const 2
    i32.and
    i32.or
@@ -1442,19 +1446,19 @@
    i32.add
    local.get $5
    i32.add
-   local.tee $4
+   local.tee $3
    local.get $6
    i32.const 4
    i32.sub
    i32.const 1
    i32.or
    i32.store $0
-   local.get $3
    local.get $4
+   local.get $3
    call $~lib/rt/tlsf/insertBlock
   else
    local.get $2
-   local.get $4
+   local.get $3
    i32.const -2
    i32.and
    i32.store $0

--- a/tests/compiler/instanceof.debug.wat
+++ b/tests/compiler/instanceof.debug.wat
@@ -1935,22 +1935,6 @@
   (local $pagesAfter i32)
   i32.const 0
   drop
-  local.get $size
-  i32.const 536870910
-  i32.lt_u
-  if
-   local.get $size
-   i32.const 1
-   i32.const 27
-   local.get $size
-   i32.clz
-   i32.sub
-   i32.shl
-   i32.const 1
-   i32.sub
-   i32.add
-   local.set $size
-  end
   memory.size $0
   local.set $pagesBefore
   local.get $size
@@ -1971,6 +1955,22 @@
   i32.shl
   i32.add
   local.set $size
+  local.get $size
+  i32.const 536870910
+  i32.lt_u
+  if
+   local.get $size
+   i32.const 1
+   i32.const 27
+   local.get $size
+   i32.clz
+   i32.sub
+   i32.shl
+   i32.const 1
+   i32.sub
+   i32.add
+   local.set $size
+  end
   local.get $size
   i32.const 65535
   i32.add

--- a/tests/compiler/instanceof.debug.wat
+++ b/tests/compiler/instanceof.debug.wat
@@ -1056,7 +1056,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 378
+   i32.const 382
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1102,7 +1102,7 @@
    if
     i32.const 0
     i32.const 368
-    i32.const 385
+    i32.const 389
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1135,7 +1135,7 @@
    if
     i32.const 0
     i32.const 368
-    i32.const 398
+    i32.const 402
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1379,7 +1379,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 560
+   i32.const 562
    i32.const 3
    call $~lib/builtins/abort
    unreachable
@@ -1708,13 +1708,33 @@
   if
    i32.const 32
    i32.const 368
-   i32.const 459
+   i32.const 461
    i32.const 29
    call $~lib/builtins/abort
    unreachable
   end
   local.get $size
   call $~lib/rt/tlsf/computeSize
+  return
+ )
+ (func $~lib/rt/tlsf/roundSize (param $size i32) (result i32)
+  local.get $size
+  i32.const 536870910
+  i32.lt_u
+  if (result i32)
+   local.get $size
+   i32.const 1
+   i32.const 27
+   local.get $size
+   i32.clz
+   i32.sub
+   i32.shl
+   i32.add
+   i32.const 1
+   i32.sub
+  else
+   local.get $size
+  end
   return
  )
  (func $~lib/rt/tlsf/searchBlock (param $root i32) (param $size i32) (result i32)
@@ -1746,24 +1766,13 @@
    local.set $sl
   else
    local.get $size
-   i32.const 536870910
-   i32.lt_u
-   if (result i32)
-    local.get $size
-    i32.const 1
-    i32.const 27
-    local.get $size
-    i32.clz
-    i32.sub
-    i32.shl
-    i32.add
-    i32.const 1
-    i32.sub
-   else
-    local.get $size
-   end
+   call $~lib/rt/tlsf/roundSize
    local.set $requestSize
-   i32.const 31
+   i32.const 4
+   i32.const 8
+   i32.mul
+   i32.const 1
+   i32.sub
    local.get $requestSize
    i32.clz
    i32.sub
@@ -1801,7 +1810,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 330
+   i32.const 334
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1872,7 +1881,7 @@
     if
      i32.const 0
      i32.const 368
-     i32.const 343
+     i32.const 347
      i32.const 18
      call $~lib/builtins/abort
      unreachable
@@ -1935,6 +1944,14 @@
   (local $pagesAfter i32)
   i32.const 0
   drop
+  local.get $size
+  i32.const 256
+  i32.gt_u
+  if
+   local.get $size
+   call $~lib/rt/tlsf/roundSize
+   local.set $size
+  end
   memory.size $0
   local.set $pagesBefore
   local.get $size
@@ -1955,22 +1972,6 @@
   i32.shl
   i32.add
   local.set $size
-  local.get $size
-  i32.const 536870910
-  i32.lt_u
-  if
-   local.get $size
-   i32.const 1
-   i32.const 27
-   local.get $size
-   i32.clz
-   i32.sub
-   i32.shl
-   i32.const 1
-   i32.sub
-   i32.add
-   local.set $size
-  end
   local.get $size
   i32.const 65535
   i32.add
@@ -2037,7 +2038,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 357
+   i32.const 361
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -2152,7 +2153,7 @@
    if
     i32.const 0
     i32.const 368
-    i32.const 497
+    i32.const 499
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -2172,7 +2173,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 499
+   i32.const 501
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/instanceof.debug.wat
+++ b/tests/compiler/instanceof.debug.wat
@@ -1946,7 +1946,7 @@
   drop
   local.get $size
   i32.const 256
-  i32.gt_u
+  i32.ge_u
   if
    local.get $size
    call $~lib/rt/tlsf/roundSize

--- a/tests/compiler/instanceof.release.wat
+++ b/tests/compiler/instanceof.release.wat
@@ -1296,6 +1296,8 @@
   if
    memory.size $0
    local.tee $1
+   i32.const 1
+   i32.const 27
    i32.const 4
    local.get $2
    i32.load $0 offset=1568
@@ -1306,7 +1308,22 @@
    i32.sub
    i32.ne
    i32.shl
-   i32.const 65563
+   i32.const 28
+   i32.add
+   local.tee $3
+   i32.clz
+   i32.sub
+   i32.shl
+   i32.const 1
+   i32.sub
+   local.get $3
+   i32.add
+   local.get $3
+   local.get $3
+   i32.const 536870910
+   i32.lt_u
+   select
+   i32.const 65535
    i32.add
    i32.const -65536
    i32.and

--- a/tests/compiler/instanceof.release.wat
+++ b/tests/compiler/instanceof.release.wat
@@ -725,7 +725,7 @@
   if
    i32.const 0
    i32.const 1392
-   i32.const 378
+   i32.const 382
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -750,7 +750,7 @@
    if
     i32.const 0
     i32.const 1392
-    i32.const 385
+    i32.const 389
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -778,7 +778,7 @@
    if
     i32.const 0
     i32.const 1392
-    i32.const 398
+    i32.const 402
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1145,7 +1145,7 @@
       if
        i32.const 0
        i32.const 1392
-       i32.const 560
+       i32.const 562
        i32.const 3
        call $~lib/builtins/abort
        unreachable
@@ -1212,7 +1212,7 @@
     if
      i32.const 0
      i32.const 1392
-     i32.const 343
+     i32.const 347
      i32.const 18
      call $~lib/builtins/abort
      unreachable
@@ -1296,8 +1296,6 @@
   if
    memory.size $0
    local.tee $1
-   i32.const 1
-   i32.const 27
    i32.const 4
    local.get $2
    i32.load $0 offset=1568
@@ -1308,22 +1306,7 @@
    i32.sub
    i32.ne
    i32.shl
-   i32.const 28
-   i32.add
-   local.tee $3
-   i32.clz
-   i32.sub
-   i32.shl
-   i32.const 1
-   i32.sub
-   local.get $3
-   i32.add
-   local.get $3
-   local.get $3
-   i32.const 536870910
-   i32.lt_u
-   select
-   i32.const 65535
+   i32.const 65563
    i32.add
    i32.const -65536
    i32.and
@@ -1362,7 +1345,7 @@
    if
     i32.const 0
     i32.const 1392
-    i32.const 497
+    i32.const 499
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1377,7 +1360,7 @@
   if
    i32.const 0
    i32.const 1392
-   i32.const 499
+   i32.const 501
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/issues/1095.debug.wat
+++ b/tests/compiler/issues/1095.debug.wat
@@ -1914,22 +1914,6 @@
   (local $pagesAfter i32)
   i32.const 0
   drop
-  local.get $size
-  i32.const 536870910
-  i32.lt_u
-  if
-   local.get $size
-   i32.const 1
-   i32.const 27
-   local.get $size
-   i32.clz
-   i32.sub
-   i32.shl
-   i32.const 1
-   i32.sub
-   i32.add
-   local.set $size
-  end
   memory.size $0
   local.set $pagesBefore
   local.get $size
@@ -1950,6 +1934,22 @@
   i32.shl
   i32.add
   local.set $size
+  local.get $size
+  i32.const 536870910
+  i32.lt_u
+  if
+   local.get $size
+   i32.const 1
+   i32.const 27
+   local.get $size
+   i32.clz
+   i32.sub
+   i32.shl
+   i32.const 1
+   i32.sub
+   i32.add
+   local.set $size
+  end
   local.get $size
   i32.const 65535
   i32.add

--- a/tests/compiler/issues/1095.debug.wat
+++ b/tests/compiler/issues/1095.debug.wat
@@ -1035,7 +1035,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 378
+   i32.const 382
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1081,7 +1081,7 @@
    if
     i32.const 0
     i32.const 368
-    i32.const 385
+    i32.const 389
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1114,7 +1114,7 @@
    if
     i32.const 0
     i32.const 368
-    i32.const 398
+    i32.const 402
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1358,7 +1358,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 560
+   i32.const 562
    i32.const 3
    call $~lib/builtins/abort
    unreachable
@@ -1687,13 +1687,33 @@
   if
    i32.const 32
    i32.const 368
-   i32.const 459
+   i32.const 461
    i32.const 29
    call $~lib/builtins/abort
    unreachable
   end
   local.get $size
   call $~lib/rt/tlsf/computeSize
+  return
+ )
+ (func $~lib/rt/tlsf/roundSize (param $size i32) (result i32)
+  local.get $size
+  i32.const 536870910
+  i32.lt_u
+  if (result i32)
+   local.get $size
+   i32.const 1
+   i32.const 27
+   local.get $size
+   i32.clz
+   i32.sub
+   i32.shl
+   i32.add
+   i32.const 1
+   i32.sub
+  else
+   local.get $size
+  end
   return
  )
  (func $~lib/rt/tlsf/searchBlock (param $root i32) (param $size i32) (result i32)
@@ -1725,24 +1745,13 @@
    local.set $sl
   else
    local.get $size
-   i32.const 536870910
-   i32.lt_u
-   if (result i32)
-    local.get $size
-    i32.const 1
-    i32.const 27
-    local.get $size
-    i32.clz
-    i32.sub
-    i32.shl
-    i32.add
-    i32.const 1
-    i32.sub
-   else
-    local.get $size
-   end
+   call $~lib/rt/tlsf/roundSize
    local.set $requestSize
-   i32.const 31
+   i32.const 4
+   i32.const 8
+   i32.mul
+   i32.const 1
+   i32.sub
    local.get $requestSize
    i32.clz
    i32.sub
@@ -1780,7 +1789,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 330
+   i32.const 334
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1851,7 +1860,7 @@
     if
      i32.const 0
      i32.const 368
-     i32.const 343
+     i32.const 347
      i32.const 18
      call $~lib/builtins/abort
      unreachable
@@ -1914,6 +1923,14 @@
   (local $pagesAfter i32)
   i32.const 0
   drop
+  local.get $size
+  i32.const 256
+  i32.gt_u
+  if
+   local.get $size
+   call $~lib/rt/tlsf/roundSize
+   local.set $size
+  end
   memory.size $0
   local.set $pagesBefore
   local.get $size
@@ -1934,22 +1951,6 @@
   i32.shl
   i32.add
   local.set $size
-  local.get $size
-  i32.const 536870910
-  i32.lt_u
-  if
-   local.get $size
-   i32.const 1
-   i32.const 27
-   local.get $size
-   i32.clz
-   i32.sub
-   i32.shl
-   i32.const 1
-   i32.sub
-   i32.add
-   local.set $size
-  end
   local.get $size
   i32.const 65535
   i32.add
@@ -2016,7 +2017,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 357
+   i32.const 361
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -2131,7 +2132,7 @@
    if
     i32.const 0
     i32.const 368
-    i32.const 497
+    i32.const 499
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -2151,7 +2152,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 499
+   i32.const 501
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/issues/1095.debug.wat
+++ b/tests/compiler/issues/1095.debug.wat
@@ -1925,7 +1925,7 @@
   drop
   local.get $size
   i32.const 256
-  i32.gt_u
+  i32.ge_u
   if
    local.get $size
    call $~lib/rt/tlsf/roundSize

--- a/tests/compiler/issues/1095.release.wat
+++ b/tests/compiler/issues/1095.release.wat
@@ -1306,7 +1306,7 @@
    local.tee $2
    local.get $5
    i32.const 256
-   i32.gt_u
+   i32.ge_u
    if (result i32)
     local.get $5
     i32.const 1

--- a/tests/compiler/issues/1095.release.wat
+++ b/tests/compiler/issues/1095.release.wat
@@ -624,7 +624,7 @@
   if
    i32.const 0
    i32.const 1392
-   i32.const 378
+   i32.const 382
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -649,7 +649,7 @@
    if
     i32.const 0
     i32.const 1392
-    i32.const 385
+    i32.const 389
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -677,7 +677,7 @@
    if
     i32.const 0
     i32.const 1392
-    i32.const 398
+    i32.const 402
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1044,7 +1044,7 @@
       if
        i32.const 0
        i32.const 1392
-       i32.const 560
+       i32.const 562
        i32.const 3
        call $~lib/builtins/abort
        unreachable
@@ -1128,7 +1128,7 @@
   if
    i32.const 0
    i32.const 1392
-   i32.const 330
+   i32.const 334
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1180,7 +1180,7 @@
     if
      i32.const 0
      i32.const 1392
-     i32.const 343
+     i32.const 347
      i32.const 18
      call $~lib/builtins/abort
      unreachable
@@ -1269,7 +1269,7 @@
    call $~lib/rt/tlsf/initialize
   end
   global.get $~lib/rt/tlsf/ROOT
-  local.set $3
+  local.set $4
   local.get $0
   i32.const 16
   i32.add
@@ -1279,12 +1279,12 @@
   if
    i32.const 1056
    i32.const 1392
-   i32.const 459
+   i32.const 461
    i32.const 29
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $3
+  local.get $4
   i32.const 12
   local.get $2
   i32.const 19
@@ -1305,8 +1305,29 @@
    memory.size $0
    local.tee $2
    local.get $5
+   i32.const 256
+   i32.gt_u
+   if (result i32)
+    local.get $5
+    i32.const 1
+    i32.const 27
+    local.get $5
+    i32.clz
+    i32.sub
+    i32.shl
+    i32.add
+    i32.const 1
+    i32.sub
+    local.get $5
+    local.get $5
+    i32.const 536870910
+    i32.lt_u
+    select
+   else
+    local.get $5
+   end
    i32.const 4
-   local.get $3
+   local.get $4
    i32.load $0 offset=1568
    local.get $2
    i32.const 16
@@ -1316,39 +1337,22 @@
    i32.ne
    i32.shl
    i32.add
-   local.tee $4
-   i32.const 536870910
-   i32.lt_u
-   if (result i32)
-    local.get $4
-    i32.const 1
-    i32.const 27
-    local.get $4
-    i32.clz
-    i32.sub
-    i32.shl
-    i32.const 1
-    i32.sub
-    i32.add
-   else
-    local.get $4
-   end
    i32.const 65535
    i32.add
    i32.const -65536
    i32.and
    i32.const 16
    i32.shr_u
-   local.tee $4
+   local.tee $3
    local.get $2
-   local.get $4
+   local.get $3
    i32.gt_s
    select
    memory.grow $0
    i32.const 0
    i32.lt_s
    if
-    local.get $4
+    local.get $3
     memory.grow $0
     i32.const 0
     i32.lt_s
@@ -1356,7 +1360,7 @@
      unreachable
     end
    end
-   local.get $3
+   local.get $4
    local.get $2
    i32.const 16
    i32.shl
@@ -1365,7 +1369,7 @@
    i64.const 16
    i64.shl
    call $~lib/rt/tlsf/addMemory
-   local.get $3
+   local.get $4
    local.get $5
    call $~lib/rt/tlsf/searchBlock
    local.tee $2
@@ -1373,7 +1377,7 @@
    if
     i32.const 0
     i32.const 1392
-    i32.const 497
+    i32.const 499
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1388,17 +1392,17 @@
   if
    i32.const 0
    i32.const 1392
-   i32.const 499
+   i32.const 501
    i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $3
+  local.get $4
   local.get $2
   call $~lib/rt/tlsf/removeBlock
   local.get $2
   i32.load $0
-  local.set $4
+  local.set $3
   local.get $5
   i32.const 4
   i32.add
@@ -1407,12 +1411,12 @@
   if
    i32.const 0
    i32.const 1392
-   i32.const 357
+   i32.const 361
    i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $4
+  local.get $3
   i32.const -4
   i32.and
   local.get $5
@@ -1423,7 +1427,7 @@
   if
    local.get $2
    local.get $5
-   local.get $4
+   local.get $3
    i32.const 2
    i32.and
    i32.or
@@ -1433,19 +1437,19 @@
    i32.add
    local.get $5
    i32.add
-   local.tee $4
+   local.tee $3
    local.get $6
    i32.const 4
    i32.sub
    i32.const 1
    i32.or
    i32.store $0
-   local.get $3
    local.get $4
+   local.get $3
    call $~lib/rt/tlsf/insertBlock
   else
    local.get $2
-   local.get $4
+   local.get $3
    i32.const -2
    i32.and
    i32.store $0

--- a/tests/compiler/issues/1095.release.wat
+++ b/tests/compiler/issues/1095.release.wat
@@ -1269,7 +1269,7 @@
    call $~lib/rt/tlsf/initialize
   end
   global.get $~lib/rt/tlsf/ROOT
-  local.set $4
+  local.set $3
   local.get $0
   i32.const 16
   i32.add
@@ -1284,7 +1284,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $4
+  local.get $3
   i32.const 12
   local.get $2
   i32.const 19
@@ -1304,8 +1304,9 @@
   if
    memory.size $0
    local.tee $2
+   local.get $5
    i32.const 4
-   local.get $4
+   local.get $3
    i32.load $0 offset=1568
    local.get $2
    i32.const 16
@@ -1314,38 +1315,40 @@
    i32.sub
    i32.ne
    i32.shl
-   local.get $5
-   i32.const 1
-   i32.const 27
-   local.get $5
-   i32.clz
-   i32.sub
-   i32.shl
-   i32.const 1
-   i32.sub
    i32.add
-   local.get $5
-   local.get $5
+   local.tee $4
    i32.const 536870910
    i32.lt_u
-   select
-   i32.add
+   if (result i32)
+    local.get $4
+    i32.const 1
+    i32.const 27
+    local.get $4
+    i32.clz
+    i32.sub
+    i32.shl
+    i32.const 1
+    i32.sub
+    i32.add
+   else
+    local.get $4
+   end
    i32.const 65535
    i32.add
    i32.const -65536
    i32.and
    i32.const 16
    i32.shr_u
-   local.tee $3
+   local.tee $4
    local.get $2
-   local.get $3
+   local.get $4
    i32.gt_s
    select
    memory.grow $0
    i32.const 0
    i32.lt_s
    if
-    local.get $3
+    local.get $4
     memory.grow $0
     i32.const 0
     i32.lt_s
@@ -1353,7 +1356,7 @@
      unreachable
     end
    end
-   local.get $4
+   local.get $3
    local.get $2
    i32.const 16
    i32.shl
@@ -1362,7 +1365,7 @@
    i64.const 16
    i64.shl
    call $~lib/rt/tlsf/addMemory
-   local.get $4
+   local.get $3
    local.get $5
    call $~lib/rt/tlsf/searchBlock
    local.tee $2
@@ -1390,12 +1393,12 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $4
+  local.get $3
   local.get $2
   call $~lib/rt/tlsf/removeBlock
   local.get $2
   i32.load $0
-  local.set $3
+  local.set $4
   local.get $5
   i32.const 4
   i32.add
@@ -1409,7 +1412,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $3
+  local.get $4
   i32.const -4
   i32.and
   local.get $5
@@ -1420,7 +1423,7 @@
   if
    local.get $2
    local.get $5
-   local.get $3
+   local.get $4
    i32.const 2
    i32.and
    i32.or
@@ -1430,19 +1433,19 @@
    i32.add
    local.get $5
    i32.add
-   local.tee $3
+   local.tee $4
    local.get $6
    i32.const 4
    i32.sub
    i32.const 1
    i32.or
    i32.store $0
-   local.get $4
    local.get $3
+   local.get $4
    call $~lib/rt/tlsf/insertBlock
   else
    local.get $2
-   local.get $3
+   local.get $4
    i32.const -2
    i32.and
    i32.store $0

--- a/tests/compiler/issues/1225.debug.wat
+++ b/tests/compiler/issues/1225.debug.wat
@@ -1929,22 +1929,6 @@
   (local $pagesAfter i32)
   i32.const 0
   drop
-  local.get $size
-  i32.const 536870910
-  i32.lt_u
-  if
-   local.get $size
-   i32.const 1
-   i32.const 27
-   local.get $size
-   i32.clz
-   i32.sub
-   i32.shl
-   i32.const 1
-   i32.sub
-   i32.add
-   local.set $size
-  end
   memory.size $0
   local.set $pagesBefore
   local.get $size
@@ -1965,6 +1949,22 @@
   i32.shl
   i32.add
   local.set $size
+  local.get $size
+  i32.const 536870910
+  i32.lt_u
+  if
+   local.get $size
+   i32.const 1
+   i32.const 27
+   local.get $size
+   i32.clz
+   i32.sub
+   i32.shl
+   i32.const 1
+   i32.sub
+   i32.add
+   local.set $size
+  end
   local.get $size
   i32.const 65535
   i32.add

--- a/tests/compiler/issues/1225.debug.wat
+++ b/tests/compiler/issues/1225.debug.wat
@@ -1940,7 +1940,7 @@
   drop
   local.get $size
   i32.const 256
-  i32.gt_u
+  i32.ge_u
   if
    local.get $size
    call $~lib/rt/tlsf/roundSize

--- a/tests/compiler/issues/1225.debug.wat
+++ b/tests/compiler/issues/1225.debug.wat
@@ -1050,7 +1050,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 378
+   i32.const 382
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1096,7 +1096,7 @@
    if
     i32.const 0
     i32.const 368
-    i32.const 385
+    i32.const 389
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1129,7 +1129,7 @@
    if
     i32.const 0
     i32.const 368
-    i32.const 398
+    i32.const 402
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1373,7 +1373,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 560
+   i32.const 562
    i32.const 3
    call $~lib/builtins/abort
    unreachable
@@ -1702,13 +1702,33 @@
   if
    i32.const 32
    i32.const 368
-   i32.const 459
+   i32.const 461
    i32.const 29
    call $~lib/builtins/abort
    unreachable
   end
   local.get $size
   call $~lib/rt/tlsf/computeSize
+  return
+ )
+ (func $~lib/rt/tlsf/roundSize (param $size i32) (result i32)
+  local.get $size
+  i32.const 536870910
+  i32.lt_u
+  if (result i32)
+   local.get $size
+   i32.const 1
+   i32.const 27
+   local.get $size
+   i32.clz
+   i32.sub
+   i32.shl
+   i32.add
+   i32.const 1
+   i32.sub
+  else
+   local.get $size
+  end
   return
  )
  (func $~lib/rt/tlsf/searchBlock (param $root i32) (param $size i32) (result i32)
@@ -1740,24 +1760,13 @@
    local.set $sl
   else
    local.get $size
-   i32.const 536870910
-   i32.lt_u
-   if (result i32)
-    local.get $size
-    i32.const 1
-    i32.const 27
-    local.get $size
-    i32.clz
-    i32.sub
-    i32.shl
-    i32.add
-    i32.const 1
-    i32.sub
-   else
-    local.get $size
-   end
+   call $~lib/rt/tlsf/roundSize
    local.set $requestSize
-   i32.const 31
+   i32.const 4
+   i32.const 8
+   i32.mul
+   i32.const 1
+   i32.sub
    local.get $requestSize
    i32.clz
    i32.sub
@@ -1795,7 +1804,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 330
+   i32.const 334
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1866,7 +1875,7 @@
     if
      i32.const 0
      i32.const 368
-     i32.const 343
+     i32.const 347
      i32.const 18
      call $~lib/builtins/abort
      unreachable
@@ -1929,6 +1938,14 @@
   (local $pagesAfter i32)
   i32.const 0
   drop
+  local.get $size
+  i32.const 256
+  i32.gt_u
+  if
+   local.get $size
+   call $~lib/rt/tlsf/roundSize
+   local.set $size
+  end
   memory.size $0
   local.set $pagesBefore
   local.get $size
@@ -1949,22 +1966,6 @@
   i32.shl
   i32.add
   local.set $size
-  local.get $size
-  i32.const 536870910
-  i32.lt_u
-  if
-   local.get $size
-   i32.const 1
-   i32.const 27
-   local.get $size
-   i32.clz
-   i32.sub
-   i32.shl
-   i32.const 1
-   i32.sub
-   i32.add
-   local.set $size
-  end
   local.get $size
   i32.const 65535
   i32.add
@@ -2031,7 +2032,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 357
+   i32.const 361
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -2146,7 +2147,7 @@
    if
     i32.const 0
     i32.const 368
-    i32.const 497
+    i32.const 499
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -2166,7 +2167,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 499
+   i32.const 501
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/issues/1225.release.wat
+++ b/tests/compiler/issues/1225.release.wat
@@ -1200,6 +1200,8 @@
   if
    memory.size $0
    local.tee $0
+   i32.const 1
+   i32.const 27
    i32.const 4
    local.get $1
    i32.load $0 offset=1568
@@ -1210,7 +1212,22 @@
    i32.sub
    i32.ne
    i32.shl
-   i32.const 65563
+   i32.const 28
+   i32.add
+   local.tee $2
+   i32.clz
+   i32.sub
+   i32.shl
+   i32.const 1
+   i32.sub
+   local.get $2
+   i32.add
+   local.get $2
+   local.get $2
+   i32.const 536870910
+   i32.lt_u
+   select
+   i32.const 65535
    i32.add
    i32.const -65536
    i32.and

--- a/tests/compiler/issues/1225.release.wat
+++ b/tests/compiler/issues/1225.release.wat
@@ -629,7 +629,7 @@
   if
    i32.const 0
    i32.const 1392
-   i32.const 378
+   i32.const 382
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -654,7 +654,7 @@
    if
     i32.const 0
     i32.const 1392
-    i32.const 385
+    i32.const 389
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -682,7 +682,7 @@
    if
     i32.const 0
     i32.const 1392
-    i32.const 398
+    i32.const 402
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1049,7 +1049,7 @@
       if
        i32.const 0
        i32.const 1392
-       i32.const 560
+       i32.const 562
        i32.const 3
        call $~lib/builtins/abort
        unreachable
@@ -1116,7 +1116,7 @@
     if
      i32.const 0
      i32.const 1392
-     i32.const 343
+     i32.const 347
      i32.const 18
      call $~lib/builtins/abort
      unreachable
@@ -1200,8 +1200,6 @@
   if
    memory.size $0
    local.tee $0
-   i32.const 1
-   i32.const 27
    i32.const 4
    local.get $1
    i32.load $0 offset=1568
@@ -1212,22 +1210,7 @@
    i32.sub
    i32.ne
    i32.shl
-   i32.const 28
-   i32.add
-   local.tee $2
-   i32.clz
-   i32.sub
-   i32.shl
-   i32.const 1
-   i32.sub
-   local.get $2
-   i32.add
-   local.get $2
-   local.get $2
-   i32.const 536870910
-   i32.lt_u
-   select
-   i32.const 65535
+   i32.const 65563
    i32.add
    i32.const -65536
    i32.and
@@ -1266,7 +1249,7 @@
    if
     i32.const 0
     i32.const 1392
-    i32.const 497
+    i32.const 499
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1281,7 +1264,7 @@
   if
    i32.const 0
    i32.const 1392
-   i32.const 499
+   i32.const 501
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/issues/1699.debug.wat
+++ b/tests/compiler/issues/1699.debug.wat
@@ -1927,7 +1927,7 @@
   drop
   local.get $size
   i32.const 256
-  i32.gt_u
+  i32.ge_u
   if
    local.get $size
    call $~lib/rt/tlsf/roundSize

--- a/tests/compiler/issues/1699.debug.wat
+++ b/tests/compiler/issues/1699.debug.wat
@@ -1916,22 +1916,6 @@
   (local $pagesAfter i32)
   i32.const 0
   drop
-  local.get $size
-  i32.const 536870910
-  i32.lt_u
-  if
-   local.get $size
-   i32.const 1
-   i32.const 27
-   local.get $size
-   i32.clz
-   i32.sub
-   i32.shl
-   i32.const 1
-   i32.sub
-   i32.add
-   local.set $size
-  end
   memory.size $0
   local.set $pagesBefore
   local.get $size
@@ -1952,6 +1936,22 @@
   i32.shl
   i32.add
   local.set $size
+  local.get $size
+  i32.const 536870910
+  i32.lt_u
+  if
+   local.get $size
+   i32.const 1
+   i32.const 27
+   local.get $size
+   i32.clz
+   i32.sub
+   i32.shl
+   i32.const 1
+   i32.sub
+   i32.add
+   local.set $size
+  end
   local.get $size
   i32.const 65535
   i32.add

--- a/tests/compiler/issues/1699.debug.wat
+++ b/tests/compiler/issues/1699.debug.wat
@@ -1037,7 +1037,7 @@
   if
    i32.const 0
    i32.const 464
-   i32.const 378
+   i32.const 382
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1083,7 +1083,7 @@
    if
     i32.const 0
     i32.const 464
-    i32.const 385
+    i32.const 389
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1116,7 +1116,7 @@
    if
     i32.const 0
     i32.const 464
-    i32.const 398
+    i32.const 402
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1360,7 +1360,7 @@
   if
    i32.const 0
    i32.const 464
-   i32.const 560
+   i32.const 562
    i32.const 3
    call $~lib/builtins/abort
    unreachable
@@ -1689,13 +1689,33 @@
   if
    i32.const 128
    i32.const 464
-   i32.const 459
+   i32.const 461
    i32.const 29
    call $~lib/builtins/abort
    unreachable
   end
   local.get $size
   call $~lib/rt/tlsf/computeSize
+  return
+ )
+ (func $~lib/rt/tlsf/roundSize (param $size i32) (result i32)
+  local.get $size
+  i32.const 536870910
+  i32.lt_u
+  if (result i32)
+   local.get $size
+   i32.const 1
+   i32.const 27
+   local.get $size
+   i32.clz
+   i32.sub
+   i32.shl
+   i32.add
+   i32.const 1
+   i32.sub
+  else
+   local.get $size
+  end
   return
  )
  (func $~lib/rt/tlsf/searchBlock (param $root i32) (param $size i32) (result i32)
@@ -1727,24 +1747,13 @@
    local.set $sl
   else
    local.get $size
-   i32.const 536870910
-   i32.lt_u
-   if (result i32)
-    local.get $size
-    i32.const 1
-    i32.const 27
-    local.get $size
-    i32.clz
-    i32.sub
-    i32.shl
-    i32.add
-    i32.const 1
-    i32.sub
-   else
-    local.get $size
-   end
+   call $~lib/rt/tlsf/roundSize
    local.set $requestSize
-   i32.const 31
+   i32.const 4
+   i32.const 8
+   i32.mul
+   i32.const 1
+   i32.sub
    local.get $requestSize
    i32.clz
    i32.sub
@@ -1782,7 +1791,7 @@
   if
    i32.const 0
    i32.const 464
-   i32.const 330
+   i32.const 334
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1853,7 +1862,7 @@
     if
      i32.const 0
      i32.const 464
-     i32.const 343
+     i32.const 347
      i32.const 18
      call $~lib/builtins/abort
      unreachable
@@ -1916,6 +1925,14 @@
   (local $pagesAfter i32)
   i32.const 0
   drop
+  local.get $size
+  i32.const 256
+  i32.gt_u
+  if
+   local.get $size
+   call $~lib/rt/tlsf/roundSize
+   local.set $size
+  end
   memory.size $0
   local.set $pagesBefore
   local.get $size
@@ -1936,22 +1953,6 @@
   i32.shl
   i32.add
   local.set $size
-  local.get $size
-  i32.const 536870910
-  i32.lt_u
-  if
-   local.get $size
-   i32.const 1
-   i32.const 27
-   local.get $size
-   i32.clz
-   i32.sub
-   i32.shl
-   i32.const 1
-   i32.sub
-   i32.add
-   local.set $size
-  end
   local.get $size
   i32.const 65535
   i32.add
@@ -2018,7 +2019,7 @@
   if
    i32.const 0
    i32.const 464
-   i32.const 357
+   i32.const 361
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -2133,7 +2134,7 @@
    if
     i32.const 0
     i32.const 464
-    i32.const 497
+    i32.const 499
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -2153,7 +2154,7 @@
   if
    i32.const 0
    i32.const 464
-   i32.const 499
+   i32.const 501
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/issues/1699.release.wat
+++ b/tests/compiler/issues/1699.release.wat
@@ -1313,7 +1313,7 @@
    local.tee $2
    local.get $5
    i32.const 256
-   i32.gt_u
+   i32.ge_u
    if (result i32)
     local.get $5
     i32.const 1

--- a/tests/compiler/issues/1699.release.wat
+++ b/tests/compiler/issues/1699.release.wat
@@ -631,7 +631,7 @@
   if
    i32.const 0
    i32.const 1488
-   i32.const 378
+   i32.const 382
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -656,7 +656,7 @@
    if
     i32.const 0
     i32.const 1488
-    i32.const 385
+    i32.const 389
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -684,7 +684,7 @@
    if
     i32.const 0
     i32.const 1488
-    i32.const 398
+    i32.const 402
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1051,7 +1051,7 @@
       if
        i32.const 0
        i32.const 1488
-       i32.const 560
+       i32.const 562
        i32.const 3
        call $~lib/builtins/abort
        unreachable
@@ -1135,7 +1135,7 @@
   if
    i32.const 0
    i32.const 1488
-   i32.const 330
+   i32.const 334
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1187,7 +1187,7 @@
     if
      i32.const 0
      i32.const 1488
-     i32.const 343
+     i32.const 347
      i32.const 18
      call $~lib/builtins/abort
      unreachable
@@ -1276,7 +1276,7 @@
    call $~lib/rt/tlsf/initialize
   end
   global.get $~lib/rt/tlsf/ROOT
-  local.set $3
+  local.set $4
   local.get $0
   i32.const 16
   i32.add
@@ -1286,12 +1286,12 @@
   if
    i32.const 1152
    i32.const 1488
-   i32.const 459
+   i32.const 461
    i32.const 29
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $3
+  local.get $4
   i32.const 12
   local.get $2
   i32.const 19
@@ -1312,8 +1312,29 @@
    memory.size $0
    local.tee $2
    local.get $5
+   i32.const 256
+   i32.gt_u
+   if (result i32)
+    local.get $5
+    i32.const 1
+    i32.const 27
+    local.get $5
+    i32.clz
+    i32.sub
+    i32.shl
+    i32.add
+    i32.const 1
+    i32.sub
+    local.get $5
+    local.get $5
+    i32.const 536870910
+    i32.lt_u
+    select
+   else
+    local.get $5
+   end
    i32.const 4
-   local.get $3
+   local.get $4
    i32.load $0 offset=1568
    local.get $2
    i32.const 16
@@ -1323,39 +1344,22 @@
    i32.ne
    i32.shl
    i32.add
-   local.tee $4
-   i32.const 536870910
-   i32.lt_u
-   if (result i32)
-    local.get $4
-    i32.const 1
-    i32.const 27
-    local.get $4
-    i32.clz
-    i32.sub
-    i32.shl
-    i32.const 1
-    i32.sub
-    i32.add
-   else
-    local.get $4
-   end
    i32.const 65535
    i32.add
    i32.const -65536
    i32.and
    i32.const 16
    i32.shr_u
-   local.tee $4
+   local.tee $3
    local.get $2
-   local.get $4
+   local.get $3
    i32.gt_s
    select
    memory.grow $0
    i32.const 0
    i32.lt_s
    if
-    local.get $4
+    local.get $3
     memory.grow $0
     i32.const 0
     i32.lt_s
@@ -1363,7 +1367,7 @@
      unreachable
     end
    end
-   local.get $3
+   local.get $4
    local.get $2
    i32.const 16
    i32.shl
@@ -1372,7 +1376,7 @@
    i64.const 16
    i64.shl
    call $~lib/rt/tlsf/addMemory
-   local.get $3
+   local.get $4
    local.get $5
    call $~lib/rt/tlsf/searchBlock
    local.tee $2
@@ -1380,7 +1384,7 @@
    if
     i32.const 0
     i32.const 1488
-    i32.const 497
+    i32.const 499
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1395,17 +1399,17 @@
   if
    i32.const 0
    i32.const 1488
-   i32.const 499
+   i32.const 501
    i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $3
+  local.get $4
   local.get $2
   call $~lib/rt/tlsf/removeBlock
   local.get $2
   i32.load $0
-  local.set $4
+  local.set $3
   local.get $5
   i32.const 4
   i32.add
@@ -1414,12 +1418,12 @@
   if
    i32.const 0
    i32.const 1488
-   i32.const 357
+   i32.const 361
    i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $4
+  local.get $3
   i32.const -4
   i32.and
   local.get $5
@@ -1430,7 +1434,7 @@
   if
    local.get $2
    local.get $5
-   local.get $4
+   local.get $3
    i32.const 2
    i32.and
    i32.or
@@ -1440,19 +1444,19 @@
    i32.add
    local.get $5
    i32.add
-   local.tee $4
+   local.tee $3
    local.get $6
    i32.const 4
    i32.sub
    i32.const 1
    i32.or
    i32.store $0
-   local.get $3
    local.get $4
+   local.get $3
    call $~lib/rt/tlsf/insertBlock
   else
    local.get $2
-   local.get $4
+   local.get $3
    i32.const -2
    i32.and
    i32.store $0

--- a/tests/compiler/issues/1699.release.wat
+++ b/tests/compiler/issues/1699.release.wat
@@ -1276,7 +1276,7 @@
    call $~lib/rt/tlsf/initialize
   end
   global.get $~lib/rt/tlsf/ROOT
-  local.set $4
+  local.set $3
   local.get $0
   i32.const 16
   i32.add
@@ -1291,7 +1291,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $4
+  local.get $3
   i32.const 12
   local.get $2
   i32.const 19
@@ -1311,8 +1311,9 @@
   if
    memory.size $0
    local.tee $2
+   local.get $5
    i32.const 4
-   local.get $4
+   local.get $3
    i32.load $0 offset=1568
    local.get $2
    i32.const 16
@@ -1321,38 +1322,40 @@
    i32.sub
    i32.ne
    i32.shl
-   local.get $5
-   i32.const 1
-   i32.const 27
-   local.get $5
-   i32.clz
-   i32.sub
-   i32.shl
-   i32.const 1
-   i32.sub
    i32.add
-   local.get $5
-   local.get $5
+   local.tee $4
    i32.const 536870910
    i32.lt_u
-   select
-   i32.add
+   if (result i32)
+    local.get $4
+    i32.const 1
+    i32.const 27
+    local.get $4
+    i32.clz
+    i32.sub
+    i32.shl
+    i32.const 1
+    i32.sub
+    i32.add
+   else
+    local.get $4
+   end
    i32.const 65535
    i32.add
    i32.const -65536
    i32.and
    i32.const 16
    i32.shr_u
-   local.tee $3
+   local.tee $4
    local.get $2
-   local.get $3
+   local.get $4
    i32.gt_s
    select
    memory.grow $0
    i32.const 0
    i32.lt_s
    if
-    local.get $3
+    local.get $4
     memory.grow $0
     i32.const 0
     i32.lt_s
@@ -1360,7 +1363,7 @@
      unreachable
     end
    end
-   local.get $4
+   local.get $3
    local.get $2
    i32.const 16
    i32.shl
@@ -1369,7 +1372,7 @@
    i64.const 16
    i64.shl
    call $~lib/rt/tlsf/addMemory
-   local.get $4
+   local.get $3
    local.get $5
    call $~lib/rt/tlsf/searchBlock
    local.tee $2
@@ -1397,12 +1400,12 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $4
+  local.get $3
   local.get $2
   call $~lib/rt/tlsf/removeBlock
   local.get $2
   i32.load $0
-  local.set $3
+  local.set $4
   local.get $5
   i32.const 4
   i32.add
@@ -1416,7 +1419,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $3
+  local.get $4
   i32.const -4
   i32.and
   local.get $5
@@ -1427,7 +1430,7 @@
   if
    local.get $2
    local.get $5
-   local.get $3
+   local.get $4
    i32.const 2
    i32.and
    i32.or
@@ -1437,19 +1440,19 @@
    i32.add
    local.get $5
    i32.add
-   local.tee $3
+   local.tee $4
    local.get $6
    i32.const 4
    i32.sub
    i32.const 1
    i32.or
    i32.store $0
-   local.get $4
    local.get $3
+   local.get $4
    call $~lib/rt/tlsf/insertBlock
   else
    local.get $2
-   local.get $3
+   local.get $4
    i32.const -2
    i32.and
    i32.store $0

--- a/tests/compiler/issues/2166.debug.wat
+++ b/tests/compiler/issues/2166.debug.wat
@@ -1039,7 +1039,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 378
+   i32.const 382
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1085,7 +1085,7 @@
    if
     i32.const 0
     i32.const 368
-    i32.const 385
+    i32.const 389
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1118,7 +1118,7 @@
    if
     i32.const 0
     i32.const 368
-    i32.const 398
+    i32.const 402
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1362,7 +1362,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 560
+   i32.const 562
    i32.const 3
    call $~lib/builtins/abort
    unreachable
@@ -1691,13 +1691,33 @@
   if
    i32.const 32
    i32.const 368
-   i32.const 459
+   i32.const 461
    i32.const 29
    call $~lib/builtins/abort
    unreachable
   end
   local.get $size
   call $~lib/rt/tlsf/computeSize
+  return
+ )
+ (func $~lib/rt/tlsf/roundSize (param $size i32) (result i32)
+  local.get $size
+  i32.const 536870910
+  i32.lt_u
+  if (result i32)
+   local.get $size
+   i32.const 1
+   i32.const 27
+   local.get $size
+   i32.clz
+   i32.sub
+   i32.shl
+   i32.add
+   i32.const 1
+   i32.sub
+  else
+   local.get $size
+  end
   return
  )
  (func $~lib/rt/tlsf/searchBlock (param $root i32) (param $size i32) (result i32)
@@ -1729,24 +1749,13 @@
    local.set $sl
   else
    local.get $size
-   i32.const 536870910
-   i32.lt_u
-   if (result i32)
-    local.get $size
-    i32.const 1
-    i32.const 27
-    local.get $size
-    i32.clz
-    i32.sub
-    i32.shl
-    i32.add
-    i32.const 1
-    i32.sub
-   else
-    local.get $size
-   end
+   call $~lib/rt/tlsf/roundSize
    local.set $requestSize
-   i32.const 31
+   i32.const 4
+   i32.const 8
+   i32.mul
+   i32.const 1
+   i32.sub
    local.get $requestSize
    i32.clz
    i32.sub
@@ -1784,7 +1793,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 330
+   i32.const 334
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1855,7 +1864,7 @@
     if
      i32.const 0
      i32.const 368
-     i32.const 343
+     i32.const 347
      i32.const 18
      call $~lib/builtins/abort
      unreachable
@@ -1918,6 +1927,14 @@
   (local $pagesAfter i32)
   i32.const 0
   drop
+  local.get $size
+  i32.const 256
+  i32.gt_u
+  if
+   local.get $size
+   call $~lib/rt/tlsf/roundSize
+   local.set $size
+  end
   memory.size $0
   local.set $pagesBefore
   local.get $size
@@ -1938,22 +1955,6 @@
   i32.shl
   i32.add
   local.set $size
-  local.get $size
-  i32.const 536870910
-  i32.lt_u
-  if
-   local.get $size
-   i32.const 1
-   i32.const 27
-   local.get $size
-   i32.clz
-   i32.sub
-   i32.shl
-   i32.const 1
-   i32.sub
-   i32.add
-   local.set $size
-  end
   local.get $size
   i32.const 65535
   i32.add
@@ -2020,7 +2021,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 357
+   i32.const 361
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -2135,7 +2136,7 @@
    if
     i32.const 0
     i32.const 368
-    i32.const 497
+    i32.const 499
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -2155,7 +2156,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 499
+   i32.const 501
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/issues/2166.debug.wat
+++ b/tests/compiler/issues/2166.debug.wat
@@ -1918,22 +1918,6 @@
   (local $pagesAfter i32)
   i32.const 0
   drop
-  local.get $size
-  i32.const 536870910
-  i32.lt_u
-  if
-   local.get $size
-   i32.const 1
-   i32.const 27
-   local.get $size
-   i32.clz
-   i32.sub
-   i32.shl
-   i32.const 1
-   i32.sub
-   i32.add
-   local.set $size
-  end
   memory.size $0
   local.set $pagesBefore
   local.get $size
@@ -1954,6 +1938,22 @@
   i32.shl
   i32.add
   local.set $size
+  local.get $size
+  i32.const 536870910
+  i32.lt_u
+  if
+   local.get $size
+   i32.const 1
+   i32.const 27
+   local.get $size
+   i32.clz
+   i32.sub
+   i32.shl
+   i32.const 1
+   i32.sub
+   i32.add
+   local.set $size
+  end
   local.get $size
   i32.const 65535
   i32.add

--- a/tests/compiler/issues/2166.debug.wat
+++ b/tests/compiler/issues/2166.debug.wat
@@ -1929,7 +1929,7 @@
   drop
   local.get $size
   i32.const 256
-  i32.gt_u
+  i32.ge_u
   if
    local.get $size
    call $~lib/rt/tlsf/roundSize

--- a/tests/compiler/issues/2166.release.wat
+++ b/tests/compiler/issues/2166.release.wat
@@ -629,7 +629,7 @@
   if
    i32.const 0
    i32.const 1392
-   i32.const 378
+   i32.const 382
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -654,7 +654,7 @@
    if
     i32.const 0
     i32.const 1392
-    i32.const 385
+    i32.const 389
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -682,7 +682,7 @@
    if
     i32.const 0
     i32.const 1392
-    i32.const 398
+    i32.const 402
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1049,7 +1049,7 @@
       if
        i32.const 0
        i32.const 1392
-       i32.const 560
+       i32.const 562
        i32.const 3
        call $~lib/builtins/abort
        unreachable
@@ -1116,7 +1116,7 @@
     if
      i32.const 0
      i32.const 1392
-     i32.const 343
+     i32.const 347
      i32.const 18
      call $~lib/builtins/abort
      unreachable
@@ -1200,8 +1200,6 @@
   if
    memory.size $0
    local.tee $1
-   i32.const 1
-   i32.const 27
    i32.const 4
    local.get $2
    i32.load $0 offset=1568
@@ -1212,22 +1210,7 @@
    i32.sub
    i32.ne
    i32.shl
-   i32.const 28
-   i32.add
-   local.tee $3
-   i32.clz
-   i32.sub
-   i32.shl
-   i32.const 1
-   i32.sub
-   local.get $3
-   i32.add
-   local.get $3
-   local.get $3
-   i32.const 536870910
-   i32.lt_u
-   select
-   i32.const 65535
+   i32.const 65563
    i32.add
    i32.const -65536
    i32.and
@@ -1266,7 +1249,7 @@
    if
     i32.const 0
     i32.const 1392
-    i32.const 497
+    i32.const 499
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1281,7 +1264,7 @@
   if
    i32.const 0
    i32.const 1392
-   i32.const 499
+   i32.const 501
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/issues/2166.release.wat
+++ b/tests/compiler/issues/2166.release.wat
@@ -1200,6 +1200,8 @@
   if
    memory.size $0
    local.tee $1
+   i32.const 1
+   i32.const 27
    i32.const 4
    local.get $2
    i32.load $0 offset=1568
@@ -1210,7 +1212,22 @@
    i32.sub
    i32.ne
    i32.shl
-   i32.const 65563
+   i32.const 28
+   i32.add
+   local.tee $3
+   i32.clz
+   i32.sub
+   i32.shl
+   i32.const 1
+   i32.sub
+   local.get $3
+   i32.add
+   local.get $3
+   local.get $3
+   i32.const 536870910
+   i32.lt_u
+   select
+   i32.const 65535
    i32.add
    i32.const -65536
    i32.and

--- a/tests/compiler/issues/2322/index.debug.wat
+++ b/tests/compiler/issues/2322/index.debug.wat
@@ -1912,22 +1912,6 @@
   (local $pagesAfter i32)
   i32.const 0
   drop
-  local.get $size
-  i32.const 536870910
-  i32.lt_u
-  if
-   local.get $size
-   i32.const 1
-   i32.const 27
-   local.get $size
-   i32.clz
-   i32.sub
-   i32.shl
-   i32.const 1
-   i32.sub
-   i32.add
-   local.set $size
-  end
   memory.size $0
   local.set $pagesBefore
   local.get $size
@@ -1948,6 +1932,22 @@
   i32.shl
   i32.add
   local.set $size
+  local.get $size
+  i32.const 536870910
+  i32.lt_u
+  if
+   local.get $size
+   i32.const 1
+   i32.const 27
+   local.get $size
+   i32.clz
+   i32.sub
+   i32.shl
+   i32.const 1
+   i32.sub
+   i32.add
+   local.set $size
+  end
   local.get $size
   i32.const 65535
   i32.add

--- a/tests/compiler/issues/2322/index.debug.wat
+++ b/tests/compiler/issues/2322/index.debug.wat
@@ -1033,7 +1033,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 378
+   i32.const 382
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1079,7 +1079,7 @@
    if
     i32.const 0
     i32.const 368
-    i32.const 385
+    i32.const 389
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1112,7 +1112,7 @@
    if
     i32.const 0
     i32.const 368
-    i32.const 398
+    i32.const 402
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1356,7 +1356,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 560
+   i32.const 562
    i32.const 3
    call $~lib/builtins/abort
    unreachable
@@ -1685,13 +1685,33 @@
   if
    i32.const 32
    i32.const 368
-   i32.const 459
+   i32.const 461
    i32.const 29
    call $~lib/builtins/abort
    unreachable
   end
   local.get $size
   call $~lib/rt/tlsf/computeSize
+  return
+ )
+ (func $~lib/rt/tlsf/roundSize (param $size i32) (result i32)
+  local.get $size
+  i32.const 536870910
+  i32.lt_u
+  if (result i32)
+   local.get $size
+   i32.const 1
+   i32.const 27
+   local.get $size
+   i32.clz
+   i32.sub
+   i32.shl
+   i32.add
+   i32.const 1
+   i32.sub
+  else
+   local.get $size
+  end
   return
  )
  (func $~lib/rt/tlsf/searchBlock (param $root i32) (param $size i32) (result i32)
@@ -1723,24 +1743,13 @@
    local.set $sl
   else
    local.get $size
-   i32.const 536870910
-   i32.lt_u
-   if (result i32)
-    local.get $size
-    i32.const 1
-    i32.const 27
-    local.get $size
-    i32.clz
-    i32.sub
-    i32.shl
-    i32.add
-    i32.const 1
-    i32.sub
-   else
-    local.get $size
-   end
+   call $~lib/rt/tlsf/roundSize
    local.set $requestSize
-   i32.const 31
+   i32.const 4
+   i32.const 8
+   i32.mul
+   i32.const 1
+   i32.sub
    local.get $requestSize
    i32.clz
    i32.sub
@@ -1778,7 +1787,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 330
+   i32.const 334
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1849,7 +1858,7 @@
     if
      i32.const 0
      i32.const 368
-     i32.const 343
+     i32.const 347
      i32.const 18
      call $~lib/builtins/abort
      unreachable
@@ -1912,6 +1921,14 @@
   (local $pagesAfter i32)
   i32.const 0
   drop
+  local.get $size
+  i32.const 256
+  i32.gt_u
+  if
+   local.get $size
+   call $~lib/rt/tlsf/roundSize
+   local.set $size
+  end
   memory.size $0
   local.set $pagesBefore
   local.get $size
@@ -1932,22 +1949,6 @@
   i32.shl
   i32.add
   local.set $size
-  local.get $size
-  i32.const 536870910
-  i32.lt_u
-  if
-   local.get $size
-   i32.const 1
-   i32.const 27
-   local.get $size
-   i32.clz
-   i32.sub
-   i32.shl
-   i32.const 1
-   i32.sub
-   i32.add
-   local.set $size
-  end
   local.get $size
   i32.const 65535
   i32.add
@@ -2014,7 +2015,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 357
+   i32.const 361
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -2129,7 +2130,7 @@
    if
     i32.const 0
     i32.const 368
-    i32.const 497
+    i32.const 499
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -2149,7 +2150,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 499
+   i32.const 501
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/issues/2322/index.debug.wat
+++ b/tests/compiler/issues/2322/index.debug.wat
@@ -1923,7 +1923,7 @@
   drop
   local.get $size
   i32.const 256
-  i32.gt_u
+  i32.ge_u
   if
    local.get $size
    call $~lib/rt/tlsf/roundSize

--- a/tests/compiler/issues/2322/index.release.wat
+++ b/tests/compiler/issues/2322/index.release.wat
@@ -619,7 +619,7 @@
   if
    i32.const 0
    i32.const 1392
-   i32.const 378
+   i32.const 382
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -644,7 +644,7 @@
    if
     i32.const 0
     i32.const 1392
-    i32.const 385
+    i32.const 389
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -672,7 +672,7 @@
    if
     i32.const 0
     i32.const 1392
-    i32.const 398
+    i32.const 402
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1039,7 +1039,7 @@
       if
        i32.const 0
        i32.const 1392
-       i32.const 560
+       i32.const 562
        i32.const 3
        call $~lib/builtins/abort
        unreachable
@@ -1123,7 +1123,7 @@
   if
    i32.const 0
    i32.const 1392
-   i32.const 330
+   i32.const 334
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1175,7 +1175,7 @@
     if
      i32.const 0
      i32.const 1392
-     i32.const 343
+     i32.const 347
      i32.const 18
      call $~lib/builtins/abort
      unreachable
@@ -1264,7 +1264,7 @@
    call $~lib/rt/tlsf/initialize
   end
   global.get $~lib/rt/tlsf/ROOT
-  local.set $3
+  local.set $4
   local.get $0
   i32.const 16
   i32.add
@@ -1274,12 +1274,12 @@
   if
    i32.const 1056
    i32.const 1392
-   i32.const 459
+   i32.const 461
    i32.const 29
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $3
+  local.get $4
   i32.const 12
   local.get $2
   i32.const 19
@@ -1300,8 +1300,29 @@
    memory.size $0
    local.tee $2
    local.get $5
+   i32.const 256
+   i32.gt_u
+   if (result i32)
+    local.get $5
+    i32.const 1
+    i32.const 27
+    local.get $5
+    i32.clz
+    i32.sub
+    i32.shl
+    i32.add
+    i32.const 1
+    i32.sub
+    local.get $5
+    local.get $5
+    i32.const 536870910
+    i32.lt_u
+    select
+   else
+    local.get $5
+   end
    i32.const 4
-   local.get $3
+   local.get $4
    i32.load $0 offset=1568
    local.get $2
    i32.const 16
@@ -1311,39 +1332,22 @@
    i32.ne
    i32.shl
    i32.add
-   local.tee $4
-   i32.const 536870910
-   i32.lt_u
-   if (result i32)
-    local.get $4
-    i32.const 1
-    i32.const 27
-    local.get $4
-    i32.clz
-    i32.sub
-    i32.shl
-    i32.const 1
-    i32.sub
-    i32.add
-   else
-    local.get $4
-   end
    i32.const 65535
    i32.add
    i32.const -65536
    i32.and
    i32.const 16
    i32.shr_u
-   local.tee $4
+   local.tee $3
    local.get $2
-   local.get $4
+   local.get $3
    i32.gt_s
    select
    memory.grow $0
    i32.const 0
    i32.lt_s
    if
-    local.get $4
+    local.get $3
     memory.grow $0
     i32.const 0
     i32.lt_s
@@ -1351,7 +1355,7 @@
      unreachable
     end
    end
-   local.get $3
+   local.get $4
    local.get $2
    i32.const 16
    i32.shl
@@ -1360,7 +1364,7 @@
    i64.const 16
    i64.shl
    call $~lib/rt/tlsf/addMemory
-   local.get $3
+   local.get $4
    local.get $5
    call $~lib/rt/tlsf/searchBlock
    local.tee $2
@@ -1368,7 +1372,7 @@
    if
     i32.const 0
     i32.const 1392
-    i32.const 497
+    i32.const 499
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1383,17 +1387,17 @@
   if
    i32.const 0
    i32.const 1392
-   i32.const 499
+   i32.const 501
    i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $3
+  local.get $4
   local.get $2
   call $~lib/rt/tlsf/removeBlock
   local.get $2
   i32.load $0
-  local.set $4
+  local.set $3
   local.get $5
   i32.const 4
   i32.add
@@ -1402,12 +1406,12 @@
   if
    i32.const 0
    i32.const 1392
-   i32.const 357
+   i32.const 361
    i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $4
+  local.get $3
   i32.const -4
   i32.and
   local.get $5
@@ -1418,7 +1422,7 @@
   if
    local.get $2
    local.get $5
-   local.get $4
+   local.get $3
    i32.const 2
    i32.and
    i32.or
@@ -1428,19 +1432,19 @@
    i32.add
    local.get $5
    i32.add
-   local.tee $4
+   local.tee $3
    local.get $6
    i32.const 4
    i32.sub
    i32.const 1
    i32.or
    i32.store $0
-   local.get $3
    local.get $4
+   local.get $3
    call $~lib/rt/tlsf/insertBlock
   else
    local.get $2
-   local.get $4
+   local.get $3
    i32.const -2
    i32.and
    i32.store $0

--- a/tests/compiler/issues/2322/index.release.wat
+++ b/tests/compiler/issues/2322/index.release.wat
@@ -1301,7 +1301,7 @@
    local.tee $2
    local.get $5
    i32.const 256
-   i32.gt_u
+   i32.ge_u
    if (result i32)
     local.get $5
     i32.const 1

--- a/tests/compiler/issues/2322/index.release.wat
+++ b/tests/compiler/issues/2322/index.release.wat
@@ -1264,7 +1264,7 @@
    call $~lib/rt/tlsf/initialize
   end
   global.get $~lib/rt/tlsf/ROOT
-  local.set $4
+  local.set $3
   local.get $0
   i32.const 16
   i32.add
@@ -1279,7 +1279,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $4
+  local.get $3
   i32.const 12
   local.get $2
   i32.const 19
@@ -1299,8 +1299,9 @@
   if
    memory.size $0
    local.tee $2
+   local.get $5
    i32.const 4
-   local.get $4
+   local.get $3
    i32.load $0 offset=1568
    local.get $2
    i32.const 16
@@ -1309,38 +1310,40 @@
    i32.sub
    i32.ne
    i32.shl
-   local.get $5
-   i32.const 1
-   i32.const 27
-   local.get $5
-   i32.clz
-   i32.sub
-   i32.shl
-   i32.const 1
-   i32.sub
    i32.add
-   local.get $5
-   local.get $5
+   local.tee $4
    i32.const 536870910
    i32.lt_u
-   select
-   i32.add
+   if (result i32)
+    local.get $4
+    i32.const 1
+    i32.const 27
+    local.get $4
+    i32.clz
+    i32.sub
+    i32.shl
+    i32.const 1
+    i32.sub
+    i32.add
+   else
+    local.get $4
+   end
    i32.const 65535
    i32.add
    i32.const -65536
    i32.and
    i32.const 16
    i32.shr_u
-   local.tee $3
+   local.tee $4
    local.get $2
-   local.get $3
+   local.get $4
    i32.gt_s
    select
    memory.grow $0
    i32.const 0
    i32.lt_s
    if
-    local.get $3
+    local.get $4
     memory.grow $0
     i32.const 0
     i32.lt_s
@@ -1348,7 +1351,7 @@
      unreachable
     end
    end
-   local.get $4
+   local.get $3
    local.get $2
    i32.const 16
    i32.shl
@@ -1357,7 +1360,7 @@
    i64.const 16
    i64.shl
    call $~lib/rt/tlsf/addMemory
-   local.get $4
+   local.get $3
    local.get $5
    call $~lib/rt/tlsf/searchBlock
    local.tee $2
@@ -1385,12 +1388,12 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $4
+  local.get $3
   local.get $2
   call $~lib/rt/tlsf/removeBlock
   local.get $2
   i32.load $0
-  local.set $3
+  local.set $4
   local.get $5
   i32.const 4
   i32.add
@@ -1404,7 +1407,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $3
+  local.get $4
   i32.const -4
   i32.and
   local.get $5
@@ -1415,7 +1418,7 @@
   if
    local.get $2
    local.get $5
-   local.get $3
+   local.get $4
    i32.const 2
    i32.and
    i32.or
@@ -1425,19 +1428,19 @@
    i32.add
    local.get $5
    i32.add
-   local.tee $3
+   local.tee $4
    local.get $6
    i32.const 4
    i32.sub
    i32.const 1
    i32.or
    i32.store $0
-   local.get $4
    local.get $3
+   local.get $4
    call $~lib/rt/tlsf/insertBlock
   else
    local.get $2
-   local.get $3
+   local.get $4
    i32.const -2
    i32.and
    i32.store $0

--- a/tests/compiler/issues/2622.debug.wat
+++ b/tests/compiler/issues/2622.debug.wat
@@ -1036,7 +1036,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 378
+   i32.const 382
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1082,7 +1082,7 @@
    if
     i32.const 0
     i32.const 368
-    i32.const 385
+    i32.const 389
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1115,7 +1115,7 @@
    if
     i32.const 0
     i32.const 368
-    i32.const 398
+    i32.const 402
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1359,7 +1359,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 560
+   i32.const 562
    i32.const 3
    call $~lib/builtins/abort
    unreachable
@@ -1688,13 +1688,33 @@
   if
    i32.const 32
    i32.const 368
-   i32.const 459
+   i32.const 461
    i32.const 29
    call $~lib/builtins/abort
    unreachable
   end
   local.get $size
   call $~lib/rt/tlsf/computeSize
+  return
+ )
+ (func $~lib/rt/tlsf/roundSize (param $size i32) (result i32)
+  local.get $size
+  i32.const 536870910
+  i32.lt_u
+  if (result i32)
+   local.get $size
+   i32.const 1
+   i32.const 27
+   local.get $size
+   i32.clz
+   i32.sub
+   i32.shl
+   i32.add
+   i32.const 1
+   i32.sub
+  else
+   local.get $size
+  end
   return
  )
  (func $~lib/rt/tlsf/searchBlock (param $root i32) (param $size i32) (result i32)
@@ -1726,24 +1746,13 @@
    local.set $sl
   else
    local.get $size
-   i32.const 536870910
-   i32.lt_u
-   if (result i32)
-    local.get $size
-    i32.const 1
-    i32.const 27
-    local.get $size
-    i32.clz
-    i32.sub
-    i32.shl
-    i32.add
-    i32.const 1
-    i32.sub
-   else
-    local.get $size
-   end
+   call $~lib/rt/tlsf/roundSize
    local.set $requestSize
-   i32.const 31
+   i32.const 4
+   i32.const 8
+   i32.mul
+   i32.const 1
+   i32.sub
    local.get $requestSize
    i32.clz
    i32.sub
@@ -1781,7 +1790,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 330
+   i32.const 334
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1852,7 +1861,7 @@
     if
      i32.const 0
      i32.const 368
-     i32.const 343
+     i32.const 347
      i32.const 18
      call $~lib/builtins/abort
      unreachable
@@ -1915,6 +1924,14 @@
   (local $pagesAfter i32)
   i32.const 0
   drop
+  local.get $size
+  i32.const 256
+  i32.gt_u
+  if
+   local.get $size
+   call $~lib/rt/tlsf/roundSize
+   local.set $size
+  end
   memory.size $0
   local.set $pagesBefore
   local.get $size
@@ -1935,22 +1952,6 @@
   i32.shl
   i32.add
   local.set $size
-  local.get $size
-  i32.const 536870910
-  i32.lt_u
-  if
-   local.get $size
-   i32.const 1
-   i32.const 27
-   local.get $size
-   i32.clz
-   i32.sub
-   i32.shl
-   i32.const 1
-   i32.sub
-   i32.add
-   local.set $size
-  end
   local.get $size
   i32.const 65535
   i32.add
@@ -2017,7 +2018,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 357
+   i32.const 361
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -2132,7 +2133,7 @@
    if
     i32.const 0
     i32.const 368
-    i32.const 497
+    i32.const 499
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -2152,7 +2153,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 499
+   i32.const 501
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/issues/2622.debug.wat
+++ b/tests/compiler/issues/2622.debug.wat
@@ -1926,7 +1926,7 @@
   drop
   local.get $size
   i32.const 256
-  i32.gt_u
+  i32.ge_u
   if
    local.get $size
    call $~lib/rt/tlsf/roundSize

--- a/tests/compiler/issues/2622.debug.wat
+++ b/tests/compiler/issues/2622.debug.wat
@@ -1915,22 +1915,6 @@
   (local $pagesAfter i32)
   i32.const 0
   drop
-  local.get $size
-  i32.const 536870910
-  i32.lt_u
-  if
-   local.get $size
-   i32.const 1
-   i32.const 27
-   local.get $size
-   i32.clz
-   i32.sub
-   i32.shl
-   i32.const 1
-   i32.sub
-   i32.add
-   local.set $size
-  end
   memory.size $0
   local.set $pagesBefore
   local.get $size
@@ -1951,6 +1935,22 @@
   i32.shl
   i32.add
   local.set $size
+  local.get $size
+  i32.const 536870910
+  i32.lt_u
+  if
+   local.get $size
+   i32.const 1
+   i32.const 27
+   local.get $size
+   i32.clz
+   i32.sub
+   i32.shl
+   i32.const 1
+   i32.sub
+   i32.add
+   local.set $size
+  end
   local.get $size
   i32.const 65535
   i32.add

--- a/tests/compiler/issues/2622.release.wat
+++ b/tests/compiler/issues/2622.release.wat
@@ -1229,6 +1229,8 @@
   if
    memory.size $0
    local.tee $1
+   i32.const 1
+   i32.const 27
    i32.const 4
    local.get $2
    i32.load $0 offset=1568
@@ -1239,7 +1241,22 @@
    i32.sub
    i32.ne
    i32.shl
-   i32.const 65563
+   i32.const 28
+   i32.add
+   local.tee $3
+   i32.clz
+   i32.sub
+   i32.shl
+   i32.const 1
+   i32.sub
+   local.get $3
+   i32.add
+   local.get $3
+   local.get $3
+   i32.const 536870910
+   i32.lt_u
+   select
+   i32.const 65535
    i32.add
    i32.const -65536
    i32.and

--- a/tests/compiler/issues/2622.release.wat
+++ b/tests/compiler/issues/2622.release.wat
@@ -658,7 +658,7 @@
   if
    i32.const 0
    i32.const 1392
-   i32.const 378
+   i32.const 382
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -683,7 +683,7 @@
    if
     i32.const 0
     i32.const 1392
-    i32.const 385
+    i32.const 389
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -711,7 +711,7 @@
    if
     i32.const 0
     i32.const 1392
-    i32.const 398
+    i32.const 402
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1078,7 +1078,7 @@
       if
        i32.const 0
        i32.const 1392
-       i32.const 560
+       i32.const 562
        i32.const 3
        call $~lib/builtins/abort
        unreachable
@@ -1145,7 +1145,7 @@
     if
      i32.const 0
      i32.const 1392
-     i32.const 343
+     i32.const 347
      i32.const 18
      call $~lib/builtins/abort
      unreachable
@@ -1229,8 +1229,6 @@
   if
    memory.size $0
    local.tee $1
-   i32.const 1
-   i32.const 27
    i32.const 4
    local.get $2
    i32.load $0 offset=1568
@@ -1241,22 +1239,7 @@
    i32.sub
    i32.ne
    i32.shl
-   i32.const 28
-   i32.add
-   local.tee $3
-   i32.clz
-   i32.sub
-   i32.shl
-   i32.const 1
-   i32.sub
-   local.get $3
-   i32.add
-   local.get $3
-   local.get $3
-   i32.const 536870910
-   i32.lt_u
-   select
-   i32.const 65535
+   i32.const 65563
    i32.add
    i32.const -65536
    i32.and
@@ -1295,7 +1278,7 @@
    if
     i32.const 0
     i32.const 1392
-    i32.const 497
+    i32.const 499
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1310,7 +1293,7 @@
   if
    i32.const 0
    i32.const 1392
-   i32.const 499
+   i32.const 501
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/logical.debug.wat
+++ b/tests/compiler/logical.debug.wat
@@ -1941,22 +1941,6 @@
   (local $pagesAfter i32)
   i32.const 0
   drop
-  local.get $size
-  i32.const 536870910
-  i32.lt_u
-  if
-   local.get $size
-   i32.const 1
-   i32.const 27
-   local.get $size
-   i32.clz
-   i32.sub
-   i32.shl
-   i32.const 1
-   i32.sub
-   i32.add
-   local.set $size
-  end
   memory.size $0
   local.set $pagesBefore
   local.get $size
@@ -1977,6 +1961,22 @@
   i32.shl
   i32.add
   local.set $size
+  local.get $size
+  i32.const 536870910
+  i32.lt_u
+  if
+   local.get $size
+   i32.const 1
+   i32.const 27
+   local.get $size
+   i32.clz
+   i32.sub
+   i32.shl
+   i32.const 1
+   i32.sub
+   i32.add
+   local.set $size
+  end
   local.get $size
   i32.const 65535
   i32.add

--- a/tests/compiler/logical.debug.wat
+++ b/tests/compiler/logical.debug.wat
@@ -1952,7 +1952,7 @@
   drop
   local.get $size
   i32.const 256
-  i32.gt_u
+  i32.ge_u
   if
    local.get $size
    call $~lib/rt/tlsf/roundSize

--- a/tests/compiler/logical.debug.wat
+++ b/tests/compiler/logical.debug.wat
@@ -1062,7 +1062,7 @@
   if
    i32.const 0
    i32.const 416
-   i32.const 378
+   i32.const 382
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1108,7 +1108,7 @@
    if
     i32.const 0
     i32.const 416
-    i32.const 385
+    i32.const 389
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1141,7 +1141,7 @@
    if
     i32.const 0
     i32.const 416
-    i32.const 398
+    i32.const 402
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1385,7 +1385,7 @@
   if
    i32.const 0
    i32.const 416
-   i32.const 560
+   i32.const 562
    i32.const 3
    call $~lib/builtins/abort
    unreachable
@@ -1714,13 +1714,33 @@
   if
    i32.const 80
    i32.const 416
-   i32.const 459
+   i32.const 461
    i32.const 29
    call $~lib/builtins/abort
    unreachable
   end
   local.get $size
   call $~lib/rt/tlsf/computeSize
+  return
+ )
+ (func $~lib/rt/tlsf/roundSize (param $size i32) (result i32)
+  local.get $size
+  i32.const 536870910
+  i32.lt_u
+  if (result i32)
+   local.get $size
+   i32.const 1
+   i32.const 27
+   local.get $size
+   i32.clz
+   i32.sub
+   i32.shl
+   i32.add
+   i32.const 1
+   i32.sub
+  else
+   local.get $size
+  end
   return
  )
  (func $~lib/rt/tlsf/searchBlock (param $root i32) (param $size i32) (result i32)
@@ -1752,24 +1772,13 @@
    local.set $sl
   else
    local.get $size
-   i32.const 536870910
-   i32.lt_u
-   if (result i32)
-    local.get $size
-    i32.const 1
-    i32.const 27
-    local.get $size
-    i32.clz
-    i32.sub
-    i32.shl
-    i32.add
-    i32.const 1
-    i32.sub
-   else
-    local.get $size
-   end
+   call $~lib/rt/tlsf/roundSize
    local.set $requestSize
-   i32.const 31
+   i32.const 4
+   i32.const 8
+   i32.mul
+   i32.const 1
+   i32.sub
    local.get $requestSize
    i32.clz
    i32.sub
@@ -1807,7 +1816,7 @@
   if
    i32.const 0
    i32.const 416
-   i32.const 330
+   i32.const 334
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1878,7 +1887,7 @@
     if
      i32.const 0
      i32.const 416
-     i32.const 343
+     i32.const 347
      i32.const 18
      call $~lib/builtins/abort
      unreachable
@@ -1941,6 +1950,14 @@
   (local $pagesAfter i32)
   i32.const 0
   drop
+  local.get $size
+  i32.const 256
+  i32.gt_u
+  if
+   local.get $size
+   call $~lib/rt/tlsf/roundSize
+   local.set $size
+  end
   memory.size $0
   local.set $pagesBefore
   local.get $size
@@ -1961,22 +1978,6 @@
   i32.shl
   i32.add
   local.set $size
-  local.get $size
-  i32.const 536870910
-  i32.lt_u
-  if
-   local.get $size
-   i32.const 1
-   i32.const 27
-   local.get $size
-   i32.clz
-   i32.sub
-   i32.shl
-   i32.const 1
-   i32.sub
-   i32.add
-   local.set $size
-  end
   local.get $size
   i32.const 65535
   i32.add
@@ -2043,7 +2044,7 @@
   if
    i32.const 0
    i32.const 416
-   i32.const 357
+   i32.const 361
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -2158,7 +2159,7 @@
    if
     i32.const 0
     i32.const 416
-    i32.const 497
+    i32.const 499
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -2178,7 +2179,7 @@
   if
    i32.const 0
    i32.const 416
-   i32.const 499
+   i32.const 501
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/logical.release.wat
+++ b/tests/compiler/logical.release.wat
@@ -634,7 +634,7 @@
   if
    i32.const 0
    i32.const 1440
-   i32.const 378
+   i32.const 382
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -659,7 +659,7 @@
    if
     i32.const 0
     i32.const 1440
-    i32.const 385
+    i32.const 389
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -687,7 +687,7 @@
    if
     i32.const 0
     i32.const 1440
-    i32.const 398
+    i32.const 402
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1054,7 +1054,7 @@
       if
        i32.const 0
        i32.const 1440
-       i32.const 560
+       i32.const 562
        i32.const 3
        call $~lib/builtins/abort
        unreachable
@@ -1121,7 +1121,7 @@
     if
      i32.const 0
      i32.const 1440
-     i32.const 343
+     i32.const 347
      i32.const 18
      call $~lib/builtins/abort
      unreachable
@@ -1205,8 +1205,6 @@
   if
    memory.size $0
    local.tee $1
-   i32.const 1
-   i32.const 27
    i32.const 4
    local.get $2
    i32.load $0 offset=1568
@@ -1217,22 +1215,7 @@
    i32.sub
    i32.ne
    i32.shl
-   i32.const 28
-   i32.add
-   local.tee $3
-   i32.clz
-   i32.sub
-   i32.shl
-   i32.const 1
-   i32.sub
-   local.get $3
-   i32.add
-   local.get $3
-   local.get $3
-   i32.const 536870910
-   i32.lt_u
-   select
-   i32.const 65535
+   i32.const 65563
    i32.add
    i32.const -65536
    i32.and
@@ -1271,7 +1254,7 @@
    if
     i32.const 0
     i32.const 1440
-    i32.const 497
+    i32.const 499
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1286,7 +1269,7 @@
   if
    i32.const 0
    i32.const 1440
-   i32.const 499
+   i32.const 501
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/logical.release.wat
+++ b/tests/compiler/logical.release.wat
@@ -1205,6 +1205,8 @@
   if
    memory.size $0
    local.tee $1
+   i32.const 1
+   i32.const 27
    i32.const 4
    local.get $2
    i32.load $0 offset=1568
@@ -1215,7 +1217,22 @@
    i32.sub
    i32.ne
    i32.shl
-   i32.const 65563
+   i32.const 28
+   i32.add
+   local.tee $3
+   i32.clz
+   i32.sub
+   i32.shl
+   i32.const 1
+   i32.sub
+   local.get $3
+   i32.add
+   local.get $3
+   local.get $3
+   i32.const 536870910
+   i32.lt_u
+   select
+   i32.const 65535
    i32.add
    i32.const -65536
    i32.and

--- a/tests/compiler/managed-cast.debug.wat
+++ b/tests/compiler/managed-cast.debug.wat
@@ -1914,22 +1914,6 @@
   (local $pagesAfter i32)
   i32.const 0
   drop
-  local.get $size
-  i32.const 536870910
-  i32.lt_u
-  if
-   local.get $size
-   i32.const 1
-   i32.const 27
-   local.get $size
-   i32.clz
-   i32.sub
-   i32.shl
-   i32.const 1
-   i32.sub
-   i32.add
-   local.set $size
-  end
   memory.size $0
   local.set $pagesBefore
   local.get $size
@@ -1950,6 +1934,22 @@
   i32.shl
   i32.add
   local.set $size
+  local.get $size
+  i32.const 536870910
+  i32.lt_u
+  if
+   local.get $size
+   i32.const 1
+   i32.const 27
+   local.get $size
+   i32.clz
+   i32.sub
+   i32.shl
+   i32.const 1
+   i32.sub
+   i32.add
+   local.set $size
+  end
   local.get $size
   i32.const 65535
   i32.add

--- a/tests/compiler/managed-cast.debug.wat
+++ b/tests/compiler/managed-cast.debug.wat
@@ -1035,7 +1035,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 378
+   i32.const 382
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1081,7 +1081,7 @@
    if
     i32.const 0
     i32.const 368
-    i32.const 385
+    i32.const 389
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1114,7 +1114,7 @@
    if
     i32.const 0
     i32.const 368
-    i32.const 398
+    i32.const 402
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1358,7 +1358,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 560
+   i32.const 562
    i32.const 3
    call $~lib/builtins/abort
    unreachable
@@ -1687,13 +1687,33 @@
   if
    i32.const 32
    i32.const 368
-   i32.const 459
+   i32.const 461
    i32.const 29
    call $~lib/builtins/abort
    unreachable
   end
   local.get $size
   call $~lib/rt/tlsf/computeSize
+  return
+ )
+ (func $~lib/rt/tlsf/roundSize (param $size i32) (result i32)
+  local.get $size
+  i32.const 536870910
+  i32.lt_u
+  if (result i32)
+   local.get $size
+   i32.const 1
+   i32.const 27
+   local.get $size
+   i32.clz
+   i32.sub
+   i32.shl
+   i32.add
+   i32.const 1
+   i32.sub
+  else
+   local.get $size
+  end
   return
  )
  (func $~lib/rt/tlsf/searchBlock (param $root i32) (param $size i32) (result i32)
@@ -1725,24 +1745,13 @@
    local.set $sl
   else
    local.get $size
-   i32.const 536870910
-   i32.lt_u
-   if (result i32)
-    local.get $size
-    i32.const 1
-    i32.const 27
-    local.get $size
-    i32.clz
-    i32.sub
-    i32.shl
-    i32.add
-    i32.const 1
-    i32.sub
-   else
-    local.get $size
-   end
+   call $~lib/rt/tlsf/roundSize
    local.set $requestSize
-   i32.const 31
+   i32.const 4
+   i32.const 8
+   i32.mul
+   i32.const 1
+   i32.sub
    local.get $requestSize
    i32.clz
    i32.sub
@@ -1780,7 +1789,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 330
+   i32.const 334
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1851,7 +1860,7 @@
     if
      i32.const 0
      i32.const 368
-     i32.const 343
+     i32.const 347
      i32.const 18
      call $~lib/builtins/abort
      unreachable
@@ -1914,6 +1923,14 @@
   (local $pagesAfter i32)
   i32.const 0
   drop
+  local.get $size
+  i32.const 256
+  i32.gt_u
+  if
+   local.get $size
+   call $~lib/rt/tlsf/roundSize
+   local.set $size
+  end
   memory.size $0
   local.set $pagesBefore
   local.get $size
@@ -1934,22 +1951,6 @@
   i32.shl
   i32.add
   local.set $size
-  local.get $size
-  i32.const 536870910
-  i32.lt_u
-  if
-   local.get $size
-   i32.const 1
-   i32.const 27
-   local.get $size
-   i32.clz
-   i32.sub
-   i32.shl
-   i32.const 1
-   i32.sub
-   i32.add
-   local.set $size
-  end
   local.get $size
   i32.const 65535
   i32.add
@@ -2016,7 +2017,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 357
+   i32.const 361
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -2131,7 +2132,7 @@
    if
     i32.const 0
     i32.const 368
-    i32.const 497
+    i32.const 499
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -2151,7 +2152,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 499
+   i32.const 501
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/managed-cast.debug.wat
+++ b/tests/compiler/managed-cast.debug.wat
@@ -1925,7 +1925,7 @@
   drop
   local.get $size
   i32.const 256
-  i32.gt_u
+  i32.ge_u
   if
    local.get $size
    call $~lib/rt/tlsf/roundSize

--- a/tests/compiler/managed-cast.release.wat
+++ b/tests/compiler/managed-cast.release.wat
@@ -624,7 +624,7 @@
   if
    i32.const 0
    i32.const 1392
-   i32.const 378
+   i32.const 382
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -649,7 +649,7 @@
    if
     i32.const 0
     i32.const 1392
-    i32.const 385
+    i32.const 389
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -677,7 +677,7 @@
    if
     i32.const 0
     i32.const 1392
-    i32.const 398
+    i32.const 402
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1044,7 +1044,7 @@
       if
        i32.const 0
        i32.const 1392
-       i32.const 560
+       i32.const 562
        i32.const 3
        call $~lib/builtins/abort
        unreachable
@@ -1111,7 +1111,7 @@
     if
      i32.const 0
      i32.const 1392
-     i32.const 343
+     i32.const 347
      i32.const 18
      call $~lib/builtins/abort
      unreachable
@@ -1195,8 +1195,6 @@
   if
    memory.size $0
    local.tee $1
-   i32.const 1
-   i32.const 27
    i32.const 4
    local.get $2
    i32.load $0 offset=1568
@@ -1207,22 +1205,7 @@
    i32.sub
    i32.ne
    i32.shl
-   i32.const 28
-   i32.add
-   local.tee $3
-   i32.clz
-   i32.sub
-   i32.shl
-   i32.const 1
-   i32.sub
-   local.get $3
-   i32.add
-   local.get $3
-   local.get $3
-   i32.const 536870910
-   i32.lt_u
-   select
-   i32.const 65535
+   i32.const 65563
    i32.add
    i32.const -65536
    i32.and
@@ -1261,7 +1244,7 @@
    if
     i32.const 0
     i32.const 1392
-    i32.const 497
+    i32.const 499
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1276,7 +1259,7 @@
   if
    i32.const 0
    i32.const 1392
-   i32.const 499
+   i32.const 501
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/managed-cast.release.wat
+++ b/tests/compiler/managed-cast.release.wat
@@ -1195,6 +1195,8 @@
   if
    memory.size $0
    local.tee $1
+   i32.const 1
+   i32.const 27
    i32.const 4
    local.get $2
    i32.load $0 offset=1568
@@ -1205,7 +1207,22 @@
    i32.sub
    i32.ne
    i32.shl
-   i32.const 65563
+   i32.const 28
+   i32.add
+   local.tee $3
+   i32.clz
+   i32.sub
+   i32.shl
+   i32.const 1
+   i32.sub
+   local.get $3
+   i32.add
+   local.get $3
+   local.get $3
+   i32.const 536870910
+   i32.lt_u
+   select
+   i32.const 65535
    i32.add
    i32.const -65536
    i32.and

--- a/tests/compiler/new.debug.wat
+++ b/tests/compiler/new.debug.wat
@@ -1917,22 +1917,6 @@
   (local $pagesAfter i32)
   i32.const 0
   drop
-  local.get $size
-  i32.const 536870910
-  i32.lt_u
-  if
-   local.get $size
-   i32.const 1
-   i32.const 27
-   local.get $size
-   i32.clz
-   i32.sub
-   i32.shl
-   i32.const 1
-   i32.sub
-   i32.add
-   local.set $size
-  end
   memory.size $0
   local.set $pagesBefore
   local.get $size
@@ -1953,6 +1937,22 @@
   i32.shl
   i32.add
   local.set $size
+  local.get $size
+  i32.const 536870910
+  i32.lt_u
+  if
+   local.get $size
+   i32.const 1
+   i32.const 27
+   local.get $size
+   i32.clz
+   i32.sub
+   i32.shl
+   i32.const 1
+   i32.sub
+   i32.add
+   local.set $size
+  end
   local.get $size
   i32.const 65535
   i32.add

--- a/tests/compiler/new.debug.wat
+++ b/tests/compiler/new.debug.wat
@@ -1928,7 +1928,7 @@
   drop
   local.get $size
   i32.const 256
-  i32.gt_u
+  i32.ge_u
   if
    local.get $size
    call $~lib/rt/tlsf/roundSize

--- a/tests/compiler/new.debug.wat
+++ b/tests/compiler/new.debug.wat
@@ -1038,7 +1038,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 378
+   i32.const 382
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1084,7 +1084,7 @@
    if
     i32.const 0
     i32.const 368
-    i32.const 385
+    i32.const 389
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1117,7 +1117,7 @@
    if
     i32.const 0
     i32.const 368
-    i32.const 398
+    i32.const 402
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1361,7 +1361,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 560
+   i32.const 562
    i32.const 3
    call $~lib/builtins/abort
    unreachable
@@ -1690,13 +1690,33 @@
   if
    i32.const 32
    i32.const 368
-   i32.const 459
+   i32.const 461
    i32.const 29
    call $~lib/builtins/abort
    unreachable
   end
   local.get $size
   call $~lib/rt/tlsf/computeSize
+  return
+ )
+ (func $~lib/rt/tlsf/roundSize (param $size i32) (result i32)
+  local.get $size
+  i32.const 536870910
+  i32.lt_u
+  if (result i32)
+   local.get $size
+   i32.const 1
+   i32.const 27
+   local.get $size
+   i32.clz
+   i32.sub
+   i32.shl
+   i32.add
+   i32.const 1
+   i32.sub
+  else
+   local.get $size
+  end
   return
  )
  (func $~lib/rt/tlsf/searchBlock (param $root i32) (param $size i32) (result i32)
@@ -1728,24 +1748,13 @@
    local.set $sl
   else
    local.get $size
-   i32.const 536870910
-   i32.lt_u
-   if (result i32)
-    local.get $size
-    i32.const 1
-    i32.const 27
-    local.get $size
-    i32.clz
-    i32.sub
-    i32.shl
-    i32.add
-    i32.const 1
-    i32.sub
-   else
-    local.get $size
-   end
+   call $~lib/rt/tlsf/roundSize
    local.set $requestSize
-   i32.const 31
+   i32.const 4
+   i32.const 8
+   i32.mul
+   i32.const 1
+   i32.sub
    local.get $requestSize
    i32.clz
    i32.sub
@@ -1783,7 +1792,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 330
+   i32.const 334
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1854,7 +1863,7 @@
     if
      i32.const 0
      i32.const 368
-     i32.const 343
+     i32.const 347
      i32.const 18
      call $~lib/builtins/abort
      unreachable
@@ -1917,6 +1926,14 @@
   (local $pagesAfter i32)
   i32.const 0
   drop
+  local.get $size
+  i32.const 256
+  i32.gt_u
+  if
+   local.get $size
+   call $~lib/rt/tlsf/roundSize
+   local.set $size
+  end
   memory.size $0
   local.set $pagesBefore
   local.get $size
@@ -1937,22 +1954,6 @@
   i32.shl
   i32.add
   local.set $size
-  local.get $size
-  i32.const 536870910
-  i32.lt_u
-  if
-   local.get $size
-   i32.const 1
-   i32.const 27
-   local.get $size
-   i32.clz
-   i32.sub
-   i32.shl
-   i32.const 1
-   i32.sub
-   i32.add
-   local.set $size
-  end
   local.get $size
   i32.const 65535
   i32.add
@@ -2019,7 +2020,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 357
+   i32.const 361
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -2134,7 +2135,7 @@
    if
     i32.const 0
     i32.const 368
-    i32.const 497
+    i32.const 499
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -2154,7 +2155,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 499
+   i32.const 501
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/new.release.wat
+++ b/tests/compiler/new.release.wat
@@ -1231,6 +1231,8 @@
   if
    memory.size $0
    local.tee $1
+   i32.const 1
+   i32.const 27
    i32.const 4
    local.get $2
    i32.load $0 offset=1568
@@ -1241,7 +1243,22 @@
    i32.sub
    i32.ne
    i32.shl
-   i32.const 65563
+   i32.const 28
+   i32.add
+   local.tee $3
+   i32.clz
+   i32.sub
+   i32.shl
+   i32.const 1
+   i32.sub
+   local.get $3
+   i32.add
+   local.get $3
+   local.get $3
+   i32.const 536870910
+   i32.lt_u
+   select
+   i32.const 65535
    i32.add
    i32.const -65536
    i32.and

--- a/tests/compiler/new.release.wat
+++ b/tests/compiler/new.release.wat
@@ -660,7 +660,7 @@
   if
    i32.const 0
    i32.const 1392
-   i32.const 378
+   i32.const 382
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -685,7 +685,7 @@
    if
     i32.const 0
     i32.const 1392
-    i32.const 385
+    i32.const 389
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -713,7 +713,7 @@
    if
     i32.const 0
     i32.const 1392
-    i32.const 398
+    i32.const 402
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1080,7 +1080,7 @@
       if
        i32.const 0
        i32.const 1392
-       i32.const 560
+       i32.const 562
        i32.const 3
        call $~lib/builtins/abort
        unreachable
@@ -1147,7 +1147,7 @@
     if
      i32.const 0
      i32.const 1392
-     i32.const 343
+     i32.const 347
      i32.const 18
      call $~lib/builtins/abort
      unreachable
@@ -1231,8 +1231,6 @@
   if
    memory.size $0
    local.tee $1
-   i32.const 1
-   i32.const 27
    i32.const 4
    local.get $2
    i32.load $0 offset=1568
@@ -1243,22 +1241,7 @@
    i32.sub
    i32.ne
    i32.shl
-   i32.const 28
-   i32.add
-   local.tee $3
-   i32.clz
-   i32.sub
-   i32.shl
-   i32.const 1
-   i32.sub
-   local.get $3
-   i32.add
-   local.get $3
-   local.get $3
-   i32.const 536870910
-   i32.lt_u
-   select
-   i32.const 65535
+   i32.const 65563
    i32.add
    i32.const -65536
    i32.and
@@ -1297,7 +1280,7 @@
    if
     i32.const 0
     i32.const 1392
-    i32.const 497
+    i32.const 499
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1312,7 +1295,7 @@
   if
    i32.const 0
    i32.const 1392
-   i32.const 499
+   i32.const 501
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/object-literal.debug.wat
+++ b/tests/compiler/object-literal.debug.wat
@@ -2009,22 +2009,6 @@
   (local $pagesAfter i32)
   i32.const 0
   drop
-  local.get $size
-  i32.const 536870910
-  i32.lt_u
-  if
-   local.get $size
-   i32.const 1
-   i32.const 27
-   local.get $size
-   i32.clz
-   i32.sub
-   i32.shl
-   i32.const 1
-   i32.sub
-   i32.add
-   local.set $size
-  end
   memory.size $0
   local.set $pagesBefore
   local.get $size
@@ -2045,6 +2029,22 @@
   i32.shl
   i32.add
   local.set $size
+  local.get $size
+  i32.const 536870910
+  i32.lt_u
+  if
+   local.get $size
+   i32.const 1
+   i32.const 27
+   local.get $size
+   i32.clz
+   i32.sub
+   i32.shl
+   i32.const 1
+   i32.sub
+   i32.add
+   local.set $size
+  end
   local.get $size
   i32.const 65535
   i32.add

--- a/tests/compiler/object-literal.debug.wat
+++ b/tests/compiler/object-literal.debug.wat
@@ -1130,7 +1130,7 @@
   if
    i32.const 0
    i32.const 416
-   i32.const 378
+   i32.const 382
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1176,7 +1176,7 @@
    if
     i32.const 0
     i32.const 416
-    i32.const 385
+    i32.const 389
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1209,7 +1209,7 @@
    if
     i32.const 0
     i32.const 416
-    i32.const 398
+    i32.const 402
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1453,7 +1453,7 @@
   if
    i32.const 0
    i32.const 416
-   i32.const 560
+   i32.const 562
    i32.const 3
    call $~lib/builtins/abort
    unreachable
@@ -1782,13 +1782,33 @@
   if
    i32.const 288
    i32.const 416
-   i32.const 459
+   i32.const 461
    i32.const 29
    call $~lib/builtins/abort
    unreachable
   end
   local.get $size
   call $~lib/rt/tlsf/computeSize
+  return
+ )
+ (func $~lib/rt/tlsf/roundSize (param $size i32) (result i32)
+  local.get $size
+  i32.const 536870910
+  i32.lt_u
+  if (result i32)
+   local.get $size
+   i32.const 1
+   i32.const 27
+   local.get $size
+   i32.clz
+   i32.sub
+   i32.shl
+   i32.add
+   i32.const 1
+   i32.sub
+  else
+   local.get $size
+  end
   return
  )
  (func $~lib/rt/tlsf/searchBlock (param $root i32) (param $size i32) (result i32)
@@ -1820,24 +1840,13 @@
    local.set $sl
   else
    local.get $size
-   i32.const 536870910
-   i32.lt_u
-   if (result i32)
-    local.get $size
-    i32.const 1
-    i32.const 27
-    local.get $size
-    i32.clz
-    i32.sub
-    i32.shl
-    i32.add
-    i32.const 1
-    i32.sub
-   else
-    local.get $size
-   end
+   call $~lib/rt/tlsf/roundSize
    local.set $requestSize
-   i32.const 31
+   i32.const 4
+   i32.const 8
+   i32.mul
+   i32.const 1
+   i32.sub
    local.get $requestSize
    i32.clz
    i32.sub
@@ -1875,7 +1884,7 @@
   if
    i32.const 0
    i32.const 416
-   i32.const 330
+   i32.const 334
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1946,7 +1955,7 @@
     if
      i32.const 0
      i32.const 416
-     i32.const 343
+     i32.const 347
      i32.const 18
      call $~lib/builtins/abort
      unreachable
@@ -2009,6 +2018,14 @@
   (local $pagesAfter i32)
   i32.const 0
   drop
+  local.get $size
+  i32.const 256
+  i32.gt_u
+  if
+   local.get $size
+   call $~lib/rt/tlsf/roundSize
+   local.set $size
+  end
   memory.size $0
   local.set $pagesBefore
   local.get $size
@@ -2029,22 +2046,6 @@
   i32.shl
   i32.add
   local.set $size
-  local.get $size
-  i32.const 536870910
-  i32.lt_u
-  if
-   local.get $size
-   i32.const 1
-   i32.const 27
-   local.get $size
-   i32.clz
-   i32.sub
-   i32.shl
-   i32.const 1
-   i32.sub
-   i32.add
-   local.set $size
-  end
   local.get $size
   i32.const 65535
   i32.add
@@ -2111,7 +2112,7 @@
   if
    i32.const 0
    i32.const 416
-   i32.const 357
+   i32.const 361
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -2226,7 +2227,7 @@
    if
     i32.const 0
     i32.const 416
-    i32.const 497
+    i32.const 499
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -2246,7 +2247,7 @@
   if
    i32.const 0
    i32.const 416
-   i32.const 499
+   i32.const 501
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/object-literal.debug.wat
+++ b/tests/compiler/object-literal.debug.wat
@@ -2020,7 +2020,7 @@
   drop
   local.get $size
   i32.const 256
-  i32.gt_u
+  i32.ge_u
   if
    local.get $size
    call $~lib/rt/tlsf/roundSize

--- a/tests/compiler/object-literal.release.wat
+++ b/tests/compiler/object-literal.release.wat
@@ -1252,6 +1252,7 @@
   if
    memory.size $0
    local.tee $1
+   local.get $3
    i32.const 4
    local.get $0
    i32.load $0 offset=1568
@@ -1262,22 +1263,24 @@
    i32.sub
    i32.ne
    i32.shl
-   local.get $3
-   i32.const 1
-   i32.const 27
-   local.get $3
-   i32.clz
-   i32.sub
-   i32.shl
-   i32.const 1
-   i32.sub
    i32.add
-   local.get $3
-   local.get $3
+   local.tee $2
    i32.const 536870910
    i32.lt_u
-   select
-   i32.add
+   if (result i32)
+    local.get $2
+    i32.const 1
+    i32.const 27
+    local.get $2
+    i32.clz
+    i32.sub
+    i32.shl
+    i32.const 1
+    i32.sub
+    i32.add
+   else
+    local.get $2
+   end
    i32.const 65535
    i32.add
    i32.const -65536
@@ -1343,7 +1346,7 @@
   call $~lib/rt/tlsf/removeBlock
   local.get $1
   i32.load $0
-  local.set $4
+  local.set $2
   local.get $3
   i32.const 4
   i32.add
@@ -1357,18 +1360,18 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $4
+  local.get $2
   i32.const -4
   i32.and
   local.get $3
   i32.sub
-  local.tee $2
+  local.tee $4
   i32.const 16
   i32.ge_u
   if
    local.get $1
    local.get $3
-   local.get $4
+   local.get $2
    i32.const 2
    i32.and
    i32.or
@@ -1378,19 +1381,19 @@
    i32.add
    local.get $3
    i32.add
-   local.tee $3
-   local.get $2
+   local.tee $2
+   local.get $4
    i32.const 4
    i32.sub
    i32.const 1
    i32.or
    i32.store $0
    local.get $0
-   local.get $3
+   local.get $2
    call $~lib/rt/tlsf/insertBlock
   else
    local.get $1
-   local.get $4
+   local.get $2
    i32.const -2
    i32.and
    i32.store $0

--- a/tests/compiler/object-literal.release.wat
+++ b/tests/compiler/object-literal.release.wat
@@ -634,7 +634,7 @@
   if
    i32.const 0
    i32.const 1440
-   i32.const 378
+   i32.const 382
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -659,7 +659,7 @@
    if
     i32.const 0
     i32.const 1440
-    i32.const 385
+    i32.const 389
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -687,7 +687,7 @@
    if
     i32.const 0
     i32.const 1440
-    i32.const 398
+    i32.const 402
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -855,7 +855,7 @@
   if
    i32.const 0
    i32.const 1440
-   i32.const 560
+   i32.const 562
    i32.const 3
    call $~lib/builtins/abort
    unreachable
@@ -1144,7 +1144,7 @@
   if
    i32.const 0
    i32.const 1440
-   i32.const 330
+   i32.const 334
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1196,7 +1196,7 @@
     if
      i32.const 0
      i32.const 1440
-     i32.const 343
+     i32.const 347
      i32.const 18
      call $~lib/builtins/abort
      unreachable
@@ -1227,7 +1227,7 @@
   if
    i32.const 1312
    i32.const 1440
-   i32.const 459
+   i32.const 461
    i32.const 29
    call $~lib/builtins/abort
    unreachable
@@ -1253,6 +1253,27 @@
    memory.size $0
    local.tee $1
    local.get $3
+   i32.const 256
+   i32.gt_u
+   if (result i32)
+    local.get $3
+    i32.const 1
+    i32.const 27
+    local.get $3
+    i32.clz
+    i32.sub
+    i32.shl
+    i32.add
+    i32.const 1
+    i32.sub
+    local.get $3
+    local.get $3
+    i32.const 536870910
+    i32.lt_u
+    select
+   else
+    local.get $3
+   end
    i32.const 4
    local.get $0
    i32.load $0 offset=1568
@@ -1264,23 +1285,6 @@
    i32.ne
    i32.shl
    i32.add
-   local.tee $2
-   i32.const 536870910
-   i32.lt_u
-   if (result i32)
-    local.get $2
-    i32.const 1
-    i32.const 27
-    local.get $2
-    i32.clz
-    i32.sub
-    i32.shl
-    i32.const 1
-    i32.sub
-    i32.add
-   else
-    local.get $2
-   end
    i32.const 65535
    i32.add
    i32.const -65536
@@ -1321,7 +1325,7 @@
    if
     i32.const 0
     i32.const 1440
-    i32.const 497
+    i32.const 499
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1336,7 +1340,7 @@
   if
    i32.const 0
    i32.const 1440
-   i32.const 499
+   i32.const 501
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1346,7 +1350,7 @@
   call $~lib/rt/tlsf/removeBlock
   local.get $1
   i32.load $0
-  local.set $2
+  local.set $4
   local.get $3
   i32.const 4
   i32.add
@@ -1355,23 +1359,23 @@
   if
    i32.const 0
    i32.const 1440
-   i32.const 357
+   i32.const 361
    i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $2
+  local.get $4
   i32.const -4
   i32.and
   local.get $3
   i32.sub
-  local.tee $4
+  local.tee $2
   i32.const 16
   i32.ge_u
   if
    local.get $1
    local.get $3
-   local.get $2
+   local.get $4
    i32.const 2
    i32.and
    i32.or
@@ -1381,19 +1385,19 @@
    i32.add
    local.get $3
    i32.add
-   local.tee $2
-   local.get $4
+   local.tee $3
+   local.get $2
    i32.const 4
    i32.sub
    i32.const 1
    i32.or
    i32.store $0
    local.get $0
-   local.get $2
+   local.get $3
    call $~lib/rt/tlsf/insertBlock
   else
    local.get $1
-   local.get $2
+   local.get $4
    i32.const -2
    i32.and
    i32.store $0

--- a/tests/compiler/object-literal.release.wat
+++ b/tests/compiler/object-literal.release.wat
@@ -1254,7 +1254,7 @@
    local.tee $1
    local.get $3
    i32.const 256
-   i32.gt_u
+   i32.ge_u
    if (result i32)
     local.get $3
     i32.const 1

--- a/tests/compiler/optional-typeparameters.debug.wat
+++ b/tests/compiler/optional-typeparameters.debug.wat
@@ -1936,7 +1936,7 @@
   drop
   local.get $size
   i32.const 256
-  i32.gt_u
+  i32.ge_u
   if
    local.get $size
    call $~lib/rt/tlsf/roundSize

--- a/tests/compiler/optional-typeparameters.debug.wat
+++ b/tests/compiler/optional-typeparameters.debug.wat
@@ -1925,22 +1925,6 @@
   (local $pagesAfter i32)
   i32.const 0
   drop
-  local.get $size
-  i32.const 536870910
-  i32.lt_u
-  if
-   local.get $size
-   i32.const 1
-   i32.const 27
-   local.get $size
-   i32.clz
-   i32.sub
-   i32.shl
-   i32.const 1
-   i32.sub
-   i32.add
-   local.set $size
-  end
   memory.size $0
   local.set $pagesBefore
   local.get $size
@@ -1961,6 +1945,22 @@
   i32.shl
   i32.add
   local.set $size
+  local.get $size
+  i32.const 536870910
+  i32.lt_u
+  if
+   local.get $size
+   i32.const 1
+   i32.const 27
+   local.get $size
+   i32.clz
+   i32.sub
+   i32.shl
+   i32.const 1
+   i32.sub
+   i32.add
+   local.set $size
+  end
   local.get $size
   i32.const 65535
   i32.add

--- a/tests/compiler/optional-typeparameters.debug.wat
+++ b/tests/compiler/optional-typeparameters.debug.wat
@@ -1046,7 +1046,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 378
+   i32.const 382
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1092,7 +1092,7 @@
    if
     i32.const 0
     i32.const 368
-    i32.const 385
+    i32.const 389
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1125,7 +1125,7 @@
    if
     i32.const 0
     i32.const 368
-    i32.const 398
+    i32.const 402
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1369,7 +1369,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 560
+   i32.const 562
    i32.const 3
    call $~lib/builtins/abort
    unreachable
@@ -1698,13 +1698,33 @@
   if
    i32.const 32
    i32.const 368
-   i32.const 459
+   i32.const 461
    i32.const 29
    call $~lib/builtins/abort
    unreachable
   end
   local.get $size
   call $~lib/rt/tlsf/computeSize
+  return
+ )
+ (func $~lib/rt/tlsf/roundSize (param $size i32) (result i32)
+  local.get $size
+  i32.const 536870910
+  i32.lt_u
+  if (result i32)
+   local.get $size
+   i32.const 1
+   i32.const 27
+   local.get $size
+   i32.clz
+   i32.sub
+   i32.shl
+   i32.add
+   i32.const 1
+   i32.sub
+  else
+   local.get $size
+  end
   return
  )
  (func $~lib/rt/tlsf/searchBlock (param $root i32) (param $size i32) (result i32)
@@ -1736,24 +1756,13 @@
    local.set $sl
   else
    local.get $size
-   i32.const 536870910
-   i32.lt_u
-   if (result i32)
-    local.get $size
-    i32.const 1
-    i32.const 27
-    local.get $size
-    i32.clz
-    i32.sub
-    i32.shl
-    i32.add
-    i32.const 1
-    i32.sub
-   else
-    local.get $size
-   end
+   call $~lib/rt/tlsf/roundSize
    local.set $requestSize
-   i32.const 31
+   i32.const 4
+   i32.const 8
+   i32.mul
+   i32.const 1
+   i32.sub
    local.get $requestSize
    i32.clz
    i32.sub
@@ -1791,7 +1800,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 330
+   i32.const 334
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1862,7 +1871,7 @@
     if
      i32.const 0
      i32.const 368
-     i32.const 343
+     i32.const 347
      i32.const 18
      call $~lib/builtins/abort
      unreachable
@@ -1925,6 +1934,14 @@
   (local $pagesAfter i32)
   i32.const 0
   drop
+  local.get $size
+  i32.const 256
+  i32.gt_u
+  if
+   local.get $size
+   call $~lib/rt/tlsf/roundSize
+   local.set $size
+  end
   memory.size $0
   local.set $pagesBefore
   local.get $size
@@ -1945,22 +1962,6 @@
   i32.shl
   i32.add
   local.set $size
-  local.get $size
-  i32.const 536870910
-  i32.lt_u
-  if
-   local.get $size
-   i32.const 1
-   i32.const 27
-   local.get $size
-   i32.clz
-   i32.sub
-   i32.shl
-   i32.const 1
-   i32.sub
-   i32.add
-   local.set $size
-  end
   local.get $size
   i32.const 65535
   i32.add
@@ -2027,7 +2028,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 357
+   i32.const 361
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -2142,7 +2143,7 @@
    if
     i32.const 0
     i32.const 368
-    i32.const 497
+    i32.const 499
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -2162,7 +2163,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 499
+   i32.const 501
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/optional-typeparameters.release.wat
+++ b/tests/compiler/optional-typeparameters.release.wat
@@ -1217,6 +1217,8 @@
   if
    memory.size $0
    local.tee $1
+   i32.const 1
+   i32.const 27
    i32.const 4
    local.get $2
    i32.load $0 offset=1568
@@ -1227,7 +1229,22 @@
    i32.sub
    i32.ne
    i32.shl
-   i32.const 65563
+   i32.const 28
+   i32.add
+   local.tee $3
+   i32.clz
+   i32.sub
+   i32.shl
+   i32.const 1
+   i32.sub
+   local.get $3
+   i32.add
+   local.get $3
+   local.get $3
+   i32.const 536870910
+   i32.lt_u
+   select
+   i32.const 65535
    i32.add
    i32.const -65536
    i32.and

--- a/tests/compiler/optional-typeparameters.release.wat
+++ b/tests/compiler/optional-typeparameters.release.wat
@@ -646,7 +646,7 @@
   if
    i32.const 0
    i32.const 1392
-   i32.const 378
+   i32.const 382
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -671,7 +671,7 @@
    if
     i32.const 0
     i32.const 1392
-    i32.const 385
+    i32.const 389
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -699,7 +699,7 @@
    if
     i32.const 0
     i32.const 1392
-    i32.const 398
+    i32.const 402
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1066,7 +1066,7 @@
       if
        i32.const 0
        i32.const 1392
-       i32.const 560
+       i32.const 562
        i32.const 3
        call $~lib/builtins/abort
        unreachable
@@ -1133,7 +1133,7 @@
     if
      i32.const 0
      i32.const 1392
-     i32.const 343
+     i32.const 347
      i32.const 18
      call $~lib/builtins/abort
      unreachable
@@ -1217,8 +1217,6 @@
   if
    memory.size $0
    local.tee $1
-   i32.const 1
-   i32.const 27
    i32.const 4
    local.get $2
    i32.load $0 offset=1568
@@ -1229,22 +1227,7 @@
    i32.sub
    i32.ne
    i32.shl
-   i32.const 28
-   i32.add
-   local.tee $3
-   i32.clz
-   i32.sub
-   i32.shl
-   i32.const 1
-   i32.sub
-   local.get $3
-   i32.add
-   local.get $3
-   local.get $3
-   i32.const 536870910
-   i32.lt_u
-   select
-   i32.const 65535
+   i32.const 65563
    i32.add
    i32.const -65536
    i32.and
@@ -1283,7 +1266,7 @@
    if
     i32.const 0
     i32.const 1392
-    i32.const 497
+    i32.const 499
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1298,7 +1281,7 @@
   if
    i32.const 0
    i32.const 1392
-   i32.const 499
+   i32.const 501
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/reexport.debug.wat
+++ b/tests/compiler/reexport.debug.wat
@@ -1079,7 +1079,7 @@
   if
    i32.const 0
    i32.const 416
-   i32.const 378
+   i32.const 382
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1125,7 +1125,7 @@
    if
     i32.const 0
     i32.const 416
-    i32.const 385
+    i32.const 389
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1158,7 +1158,7 @@
    if
     i32.const 0
     i32.const 416
-    i32.const 398
+    i32.const 402
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1402,7 +1402,7 @@
   if
    i32.const 0
    i32.const 416
-   i32.const 560
+   i32.const 562
    i32.const 3
    call $~lib/builtins/abort
    unreachable
@@ -1731,13 +1731,33 @@
   if
    i32.const 80
    i32.const 416
-   i32.const 459
+   i32.const 461
    i32.const 29
    call $~lib/builtins/abort
    unreachable
   end
   local.get $size
   call $~lib/rt/tlsf/computeSize
+  return
+ )
+ (func $~lib/rt/tlsf/roundSize (param $size i32) (result i32)
+  local.get $size
+  i32.const 536870910
+  i32.lt_u
+  if (result i32)
+   local.get $size
+   i32.const 1
+   i32.const 27
+   local.get $size
+   i32.clz
+   i32.sub
+   i32.shl
+   i32.add
+   i32.const 1
+   i32.sub
+  else
+   local.get $size
+  end
   return
  )
  (func $~lib/rt/tlsf/searchBlock (param $root i32) (param $size i32) (result i32)
@@ -1769,24 +1789,13 @@
    local.set $sl
   else
    local.get $size
-   i32.const 536870910
-   i32.lt_u
-   if (result i32)
-    local.get $size
-    i32.const 1
-    i32.const 27
-    local.get $size
-    i32.clz
-    i32.sub
-    i32.shl
-    i32.add
-    i32.const 1
-    i32.sub
-   else
-    local.get $size
-   end
+   call $~lib/rt/tlsf/roundSize
    local.set $requestSize
-   i32.const 31
+   i32.const 4
+   i32.const 8
+   i32.mul
+   i32.const 1
+   i32.sub
    local.get $requestSize
    i32.clz
    i32.sub
@@ -1824,7 +1833,7 @@
   if
    i32.const 0
    i32.const 416
-   i32.const 330
+   i32.const 334
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1895,7 +1904,7 @@
     if
      i32.const 0
      i32.const 416
-     i32.const 343
+     i32.const 347
      i32.const 18
      call $~lib/builtins/abort
      unreachable
@@ -1958,6 +1967,14 @@
   (local $pagesAfter i32)
   i32.const 0
   drop
+  local.get $size
+  i32.const 256
+  i32.gt_u
+  if
+   local.get $size
+   call $~lib/rt/tlsf/roundSize
+   local.set $size
+  end
   memory.size $0
   local.set $pagesBefore
   local.get $size
@@ -1978,22 +1995,6 @@
   i32.shl
   i32.add
   local.set $size
-  local.get $size
-  i32.const 536870910
-  i32.lt_u
-  if
-   local.get $size
-   i32.const 1
-   i32.const 27
-   local.get $size
-   i32.clz
-   i32.sub
-   i32.shl
-   i32.const 1
-   i32.sub
-   i32.add
-   local.set $size
-  end
   local.get $size
   i32.const 65535
   i32.add
@@ -2060,7 +2061,7 @@
   if
    i32.const 0
    i32.const 416
-   i32.const 357
+   i32.const 361
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -2175,7 +2176,7 @@
    if
     i32.const 0
     i32.const 416
-    i32.const 497
+    i32.const 499
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -2195,7 +2196,7 @@
   if
    i32.const 0
    i32.const 416
-   i32.const 499
+   i32.const 501
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/reexport.debug.wat
+++ b/tests/compiler/reexport.debug.wat
@@ -1969,7 +1969,7 @@
   drop
   local.get $size
   i32.const 256
-  i32.gt_u
+  i32.ge_u
   if
    local.get $size
    call $~lib/rt/tlsf/roundSize

--- a/tests/compiler/reexport.debug.wat
+++ b/tests/compiler/reexport.debug.wat
@@ -1958,22 +1958,6 @@
   (local $pagesAfter i32)
   i32.const 0
   drop
-  local.get $size
-  i32.const 536870910
-  i32.lt_u
-  if
-   local.get $size
-   i32.const 1
-   i32.const 27
-   local.get $size
-   i32.clz
-   i32.sub
-   i32.shl
-   i32.const 1
-   i32.sub
-   i32.add
-   local.set $size
-  end
   memory.size $0
   local.set $pagesBefore
   local.get $size
@@ -1994,6 +1978,22 @@
   i32.shl
   i32.add
   local.set $size
+  local.get $size
+  i32.const 536870910
+  i32.lt_u
+  if
+   local.get $size
+   i32.const 1
+   i32.const 27
+   local.get $size
+   i32.clz
+   i32.sub
+   i32.shl
+   i32.const 1
+   i32.sub
+   i32.add
+   local.set $size
+  end
   local.get $size
   i32.const 65535
   i32.add

--- a/tests/compiler/reexport.release.wat
+++ b/tests/compiler/reexport.release.wat
@@ -653,7 +653,7 @@
   if
    i32.const 0
    i32.const 1440
-   i32.const 378
+   i32.const 382
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -678,7 +678,7 @@
    if
     i32.const 0
     i32.const 1440
-    i32.const 385
+    i32.const 389
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -706,7 +706,7 @@
    if
     i32.const 0
     i32.const 1440
-    i32.const 398
+    i32.const 402
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1073,7 +1073,7 @@
       if
        i32.const 0
        i32.const 1440
-       i32.const 560
+       i32.const 562
        i32.const 3
        call $~lib/builtins/abort
        unreachable
@@ -1140,7 +1140,7 @@
     if
      i32.const 0
      i32.const 1440
-     i32.const 343
+     i32.const 347
      i32.const 18
      call $~lib/builtins/abort
      unreachable
@@ -1224,8 +1224,6 @@
   if
    memory.size $0
    local.tee $0
-   i32.const 1
-   i32.const 27
    i32.const 4
    local.get $1
    i32.load $0 offset=1568
@@ -1236,22 +1234,7 @@
    i32.sub
    i32.ne
    i32.shl
-   i32.const 28
-   i32.add
-   local.tee $2
-   i32.clz
-   i32.sub
-   i32.shl
-   i32.const 1
-   i32.sub
-   local.get $2
-   i32.add
-   local.get $2
-   local.get $2
-   i32.const 536870910
-   i32.lt_u
-   select
-   i32.const 65535
+   i32.const 65563
    i32.add
    i32.const -65536
    i32.and
@@ -1290,7 +1273,7 @@
    if
     i32.const 0
     i32.const 1440
-    i32.const 497
+    i32.const 499
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1305,7 +1288,7 @@
   if
    i32.const 0
    i32.const 1440
-   i32.const 499
+   i32.const 501
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/reexport.release.wat
+++ b/tests/compiler/reexport.release.wat
@@ -1224,6 +1224,8 @@
   if
    memory.size $0
    local.tee $0
+   i32.const 1
+   i32.const 27
    i32.const 4
    local.get $1
    i32.load $0 offset=1568
@@ -1234,7 +1236,22 @@
    i32.sub
    i32.ne
    i32.shl
-   i32.const 65563
+   i32.const 28
+   i32.add
+   local.tee $2
+   i32.clz
+   i32.sub
+   i32.shl
+   i32.const 1
+   i32.sub
+   local.get $2
+   i32.add
+   local.get $2
+   local.get $2
+   i32.const 536870910
+   i32.lt_u
+   select
+   i32.const 65535
    i32.add
    i32.const -65536
    i32.and

--- a/tests/compiler/rereexport.debug.wat
+++ b/tests/compiler/rereexport.debug.wat
@@ -1951,22 +1951,6 @@
   (local $pagesAfter i32)
   i32.const 0
   drop
-  local.get $size
-  i32.const 536870910
-  i32.lt_u
-  if
-   local.get $size
-   i32.const 1
-   i32.const 27
-   local.get $size
-   i32.clz
-   i32.sub
-   i32.shl
-   i32.const 1
-   i32.sub
-   i32.add
-   local.set $size
-  end
   memory.size $0
   local.set $pagesBefore
   local.get $size
@@ -1987,6 +1971,22 @@
   i32.shl
   i32.add
   local.set $size
+  local.get $size
+  i32.const 536870910
+  i32.lt_u
+  if
+   local.get $size
+   i32.const 1
+   i32.const 27
+   local.get $size
+   i32.clz
+   i32.sub
+   i32.shl
+   i32.const 1
+   i32.sub
+   i32.add
+   local.set $size
+  end
   local.get $size
   i32.const 65535
   i32.add

--- a/tests/compiler/rereexport.debug.wat
+++ b/tests/compiler/rereexport.debug.wat
@@ -1962,7 +1962,7 @@
   drop
   local.get $size
   i32.const 256
-  i32.gt_u
+  i32.ge_u
   if
    local.get $size
    call $~lib/rt/tlsf/roundSize

--- a/tests/compiler/rereexport.debug.wat
+++ b/tests/compiler/rereexport.debug.wat
@@ -1072,7 +1072,7 @@
   if
    i32.const 0
    i32.const 416
-   i32.const 378
+   i32.const 382
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1118,7 +1118,7 @@
    if
     i32.const 0
     i32.const 416
-    i32.const 385
+    i32.const 389
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1151,7 +1151,7 @@
    if
     i32.const 0
     i32.const 416
-    i32.const 398
+    i32.const 402
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1395,7 +1395,7 @@
   if
    i32.const 0
    i32.const 416
-   i32.const 560
+   i32.const 562
    i32.const 3
    call $~lib/builtins/abort
    unreachable
@@ -1724,13 +1724,33 @@
   if
    i32.const 80
    i32.const 416
-   i32.const 459
+   i32.const 461
    i32.const 29
    call $~lib/builtins/abort
    unreachable
   end
   local.get $size
   call $~lib/rt/tlsf/computeSize
+  return
+ )
+ (func $~lib/rt/tlsf/roundSize (param $size i32) (result i32)
+  local.get $size
+  i32.const 536870910
+  i32.lt_u
+  if (result i32)
+   local.get $size
+   i32.const 1
+   i32.const 27
+   local.get $size
+   i32.clz
+   i32.sub
+   i32.shl
+   i32.add
+   i32.const 1
+   i32.sub
+  else
+   local.get $size
+  end
   return
  )
  (func $~lib/rt/tlsf/searchBlock (param $root i32) (param $size i32) (result i32)
@@ -1762,24 +1782,13 @@
    local.set $sl
   else
    local.get $size
-   i32.const 536870910
-   i32.lt_u
-   if (result i32)
-    local.get $size
-    i32.const 1
-    i32.const 27
-    local.get $size
-    i32.clz
-    i32.sub
-    i32.shl
-    i32.add
-    i32.const 1
-    i32.sub
-   else
-    local.get $size
-   end
+   call $~lib/rt/tlsf/roundSize
    local.set $requestSize
-   i32.const 31
+   i32.const 4
+   i32.const 8
+   i32.mul
+   i32.const 1
+   i32.sub
    local.get $requestSize
    i32.clz
    i32.sub
@@ -1817,7 +1826,7 @@
   if
    i32.const 0
    i32.const 416
-   i32.const 330
+   i32.const 334
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1888,7 +1897,7 @@
     if
      i32.const 0
      i32.const 416
-     i32.const 343
+     i32.const 347
      i32.const 18
      call $~lib/builtins/abort
      unreachable
@@ -1951,6 +1960,14 @@
   (local $pagesAfter i32)
   i32.const 0
   drop
+  local.get $size
+  i32.const 256
+  i32.gt_u
+  if
+   local.get $size
+   call $~lib/rt/tlsf/roundSize
+   local.set $size
+  end
   memory.size $0
   local.set $pagesBefore
   local.get $size
@@ -1971,22 +1988,6 @@
   i32.shl
   i32.add
   local.set $size
-  local.get $size
-  i32.const 536870910
-  i32.lt_u
-  if
-   local.get $size
-   i32.const 1
-   i32.const 27
-   local.get $size
-   i32.clz
-   i32.sub
-   i32.shl
-   i32.const 1
-   i32.sub
-   i32.add
-   local.set $size
-  end
   local.get $size
   i32.const 65535
   i32.add
@@ -2053,7 +2054,7 @@
   if
    i32.const 0
    i32.const 416
-   i32.const 357
+   i32.const 361
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -2168,7 +2169,7 @@
    if
     i32.const 0
     i32.const 416
-    i32.const 497
+    i32.const 499
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -2188,7 +2189,7 @@
   if
    i32.const 0
    i32.const 416
-   i32.const 499
+   i32.const 501
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/rereexport.release.wat
+++ b/tests/compiler/rereexport.release.wat
@@ -1222,6 +1222,8 @@
   if
    memory.size $0
    local.tee $0
+   i32.const 1
+   i32.const 27
    i32.const 4
    local.get $1
    i32.load $0 offset=1568
@@ -1232,7 +1234,22 @@
    i32.sub
    i32.ne
    i32.shl
-   i32.const 65563
+   i32.const 28
+   i32.add
+   local.tee $2
+   i32.clz
+   i32.sub
+   i32.shl
+   i32.const 1
+   i32.sub
+   local.get $2
+   i32.add
+   local.get $2
+   local.get $2
+   i32.const 536870910
+   i32.lt_u
+   select
+   i32.const 65535
    i32.add
    i32.const -65536
    i32.and

--- a/tests/compiler/rereexport.release.wat
+++ b/tests/compiler/rereexport.release.wat
@@ -651,7 +651,7 @@
   if
    i32.const 0
    i32.const 1440
-   i32.const 378
+   i32.const 382
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -676,7 +676,7 @@
    if
     i32.const 0
     i32.const 1440
-    i32.const 385
+    i32.const 389
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -704,7 +704,7 @@
    if
     i32.const 0
     i32.const 1440
-    i32.const 398
+    i32.const 402
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1071,7 +1071,7 @@
       if
        i32.const 0
        i32.const 1440
-       i32.const 560
+       i32.const 562
        i32.const 3
        call $~lib/builtins/abort
        unreachable
@@ -1138,7 +1138,7 @@
     if
      i32.const 0
      i32.const 1440
-     i32.const 343
+     i32.const 347
      i32.const 18
      call $~lib/builtins/abort
      unreachable
@@ -1222,8 +1222,6 @@
   if
    memory.size $0
    local.tee $0
-   i32.const 1
-   i32.const 27
    i32.const 4
    local.get $1
    i32.load $0 offset=1568
@@ -1234,22 +1232,7 @@
    i32.sub
    i32.ne
    i32.shl
-   i32.const 28
-   i32.add
-   local.tee $2
-   i32.clz
-   i32.sub
-   i32.shl
-   i32.const 1
-   i32.sub
-   local.get $2
-   i32.add
-   local.get $2
-   local.get $2
-   i32.const 536870910
-   i32.lt_u
-   select
-   i32.const 65535
+   i32.const 65563
    i32.add
    i32.const -65536
    i32.and
@@ -1288,7 +1271,7 @@
    if
     i32.const 0
     i32.const 1440
-    i32.const 497
+    i32.const 499
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1303,7 +1286,7 @@
   if
    i32.const 0
    i32.const 1440
-   i32.const 499
+   i32.const 501
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/resolve-access.debug.wat
+++ b/tests/compiler/resolve-access.debug.wat
@@ -1054,7 +1054,7 @@
   if
    i32.const 0
    i32.const 400
-   i32.const 378
+   i32.const 382
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1100,7 +1100,7 @@
    if
     i32.const 0
     i32.const 400
-    i32.const 385
+    i32.const 389
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1133,7 +1133,7 @@
    if
     i32.const 0
     i32.const 400
-    i32.const 398
+    i32.const 402
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1377,7 +1377,7 @@
   if
    i32.const 0
    i32.const 400
-   i32.const 560
+   i32.const 562
    i32.const 3
    call $~lib/builtins/abort
    unreachable
@@ -1706,13 +1706,33 @@
   if
    i32.const 64
    i32.const 400
-   i32.const 459
+   i32.const 461
    i32.const 29
    call $~lib/builtins/abort
    unreachable
   end
   local.get $size
   call $~lib/rt/tlsf/computeSize
+  return
+ )
+ (func $~lib/rt/tlsf/roundSize (param $size i32) (result i32)
+  local.get $size
+  i32.const 536870910
+  i32.lt_u
+  if (result i32)
+   local.get $size
+   i32.const 1
+   i32.const 27
+   local.get $size
+   i32.clz
+   i32.sub
+   i32.shl
+   i32.add
+   i32.const 1
+   i32.sub
+  else
+   local.get $size
+  end
   return
  )
  (func $~lib/rt/tlsf/searchBlock (param $root i32) (param $size i32) (result i32)
@@ -1744,24 +1764,13 @@
    local.set $sl
   else
    local.get $size
-   i32.const 536870910
-   i32.lt_u
-   if (result i32)
-    local.get $size
-    i32.const 1
-    i32.const 27
-    local.get $size
-    i32.clz
-    i32.sub
-    i32.shl
-    i32.add
-    i32.const 1
-    i32.sub
-   else
-    local.get $size
-   end
+   call $~lib/rt/tlsf/roundSize
    local.set $requestSize
-   i32.const 31
+   i32.const 4
+   i32.const 8
+   i32.mul
+   i32.const 1
+   i32.sub
    local.get $requestSize
    i32.clz
    i32.sub
@@ -1799,7 +1808,7 @@
   if
    i32.const 0
    i32.const 400
-   i32.const 330
+   i32.const 334
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1870,7 +1879,7 @@
     if
      i32.const 0
      i32.const 400
-     i32.const 343
+     i32.const 347
      i32.const 18
      call $~lib/builtins/abort
      unreachable
@@ -1933,6 +1942,14 @@
   (local $pagesAfter i32)
   i32.const 0
   drop
+  local.get $size
+  i32.const 256
+  i32.gt_u
+  if
+   local.get $size
+   call $~lib/rt/tlsf/roundSize
+   local.set $size
+  end
   memory.size $0
   local.set $pagesBefore
   local.get $size
@@ -1953,22 +1970,6 @@
   i32.shl
   i32.add
   local.set $size
-  local.get $size
-  i32.const 536870910
-  i32.lt_u
-  if
-   local.get $size
-   i32.const 1
-   i32.const 27
-   local.get $size
-   i32.clz
-   i32.sub
-   i32.shl
-   i32.const 1
-   i32.sub
-   i32.add
-   local.set $size
-  end
   local.get $size
   i32.const 65535
   i32.add
@@ -2035,7 +2036,7 @@
   if
    i32.const 0
    i32.const 400
-   i32.const 357
+   i32.const 361
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -2150,7 +2151,7 @@
    if
     i32.const 0
     i32.const 400
-    i32.const 497
+    i32.const 499
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -2170,7 +2171,7 @@
   if
    i32.const 0
    i32.const 400
-   i32.const 499
+   i32.const 501
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/resolve-access.debug.wat
+++ b/tests/compiler/resolve-access.debug.wat
@@ -1933,22 +1933,6 @@
   (local $pagesAfter i32)
   i32.const 0
   drop
-  local.get $size
-  i32.const 536870910
-  i32.lt_u
-  if
-   local.get $size
-   i32.const 1
-   i32.const 27
-   local.get $size
-   i32.clz
-   i32.sub
-   i32.shl
-   i32.const 1
-   i32.sub
-   i32.add
-   local.set $size
-  end
   memory.size $0
   local.set $pagesBefore
   local.get $size
@@ -1969,6 +1953,22 @@
   i32.shl
   i32.add
   local.set $size
+  local.get $size
+  i32.const 536870910
+  i32.lt_u
+  if
+   local.get $size
+   i32.const 1
+   i32.const 27
+   local.get $size
+   i32.clz
+   i32.sub
+   i32.shl
+   i32.const 1
+   i32.sub
+   i32.add
+   local.set $size
+  end
   local.get $size
   i32.const 65535
   i32.add

--- a/tests/compiler/resolve-access.debug.wat
+++ b/tests/compiler/resolve-access.debug.wat
@@ -1944,7 +1944,7 @@
   drop
   local.get $size
   i32.const 256
-  i32.gt_u
+  i32.ge_u
   if
    local.get $size
    call $~lib/rt/tlsf/roundSize

--- a/tests/compiler/resolve-access.release.wat
+++ b/tests/compiler/resolve-access.release.wat
@@ -1324,7 +1324,7 @@
    local.tee $2
    local.get $5
    i32.const 256
-   i32.gt_u
+   i32.ge_u
    if (result i32)
     local.get $5
     i32.const 1

--- a/tests/compiler/resolve-access.release.wat
+++ b/tests/compiler/resolve-access.release.wat
@@ -642,7 +642,7 @@
   if
    i32.const 0
    i32.const 1424
-   i32.const 378
+   i32.const 382
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -667,7 +667,7 @@
    if
     i32.const 0
     i32.const 1424
-    i32.const 385
+    i32.const 389
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -695,7 +695,7 @@
    if
     i32.const 0
     i32.const 1424
-    i32.const 398
+    i32.const 402
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1062,7 +1062,7 @@
       if
        i32.const 0
        i32.const 1424
-       i32.const 560
+       i32.const 562
        i32.const 3
        call $~lib/builtins/abort
        unreachable
@@ -1146,7 +1146,7 @@
   if
    i32.const 0
    i32.const 1424
-   i32.const 330
+   i32.const 334
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1198,7 +1198,7 @@
     if
      i32.const 0
      i32.const 1424
-     i32.const 343
+     i32.const 347
      i32.const 18
      call $~lib/builtins/abort
      unreachable
@@ -1287,7 +1287,7 @@
    call $~lib/rt/tlsf/initialize
   end
   global.get $~lib/rt/tlsf/ROOT
-  local.set $3
+  local.set $4
   local.get $0
   i32.const 16
   i32.add
@@ -1297,12 +1297,12 @@
   if
    i32.const 1088
    i32.const 1424
-   i32.const 459
+   i32.const 461
    i32.const 29
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $3
+  local.get $4
   i32.const 12
   local.get $2
   i32.const 19
@@ -1323,8 +1323,29 @@
    memory.size $0
    local.tee $2
    local.get $5
+   i32.const 256
+   i32.gt_u
+   if (result i32)
+    local.get $5
+    i32.const 1
+    i32.const 27
+    local.get $5
+    i32.clz
+    i32.sub
+    i32.shl
+    i32.add
+    i32.const 1
+    i32.sub
+    local.get $5
+    local.get $5
+    i32.const 536870910
+    i32.lt_u
+    select
+   else
+    local.get $5
+   end
    i32.const 4
-   local.get $3
+   local.get $4
    i32.load $0 offset=1568
    local.get $2
    i32.const 16
@@ -1334,39 +1355,22 @@
    i32.ne
    i32.shl
    i32.add
-   local.tee $4
-   i32.const 536870910
-   i32.lt_u
-   if (result i32)
-    local.get $4
-    i32.const 1
-    i32.const 27
-    local.get $4
-    i32.clz
-    i32.sub
-    i32.shl
-    i32.const 1
-    i32.sub
-    i32.add
-   else
-    local.get $4
-   end
    i32.const 65535
    i32.add
    i32.const -65536
    i32.and
    i32.const 16
    i32.shr_u
-   local.tee $4
+   local.tee $3
    local.get $2
-   local.get $4
+   local.get $3
    i32.gt_s
    select
    memory.grow $0
    i32.const 0
    i32.lt_s
    if
-    local.get $4
+    local.get $3
     memory.grow $0
     i32.const 0
     i32.lt_s
@@ -1374,7 +1378,7 @@
      unreachable
     end
    end
-   local.get $3
+   local.get $4
    local.get $2
    i32.const 16
    i32.shl
@@ -1383,7 +1387,7 @@
    i64.const 16
    i64.shl
    call $~lib/rt/tlsf/addMemory
-   local.get $3
+   local.get $4
    local.get $5
    call $~lib/rt/tlsf/searchBlock
    local.tee $2
@@ -1391,7 +1395,7 @@
    if
     i32.const 0
     i32.const 1424
-    i32.const 497
+    i32.const 499
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1406,17 +1410,17 @@
   if
    i32.const 0
    i32.const 1424
-   i32.const 499
+   i32.const 501
    i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $3
+  local.get $4
   local.get $2
   call $~lib/rt/tlsf/removeBlock
   local.get $2
   i32.load $0
-  local.set $4
+  local.set $3
   local.get $5
   i32.const 4
   i32.add
@@ -1425,12 +1429,12 @@
   if
    i32.const 0
    i32.const 1424
-   i32.const 357
+   i32.const 361
    i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $4
+  local.get $3
   i32.const -4
   i32.and
   local.get $5
@@ -1441,7 +1445,7 @@
   if
    local.get $2
    local.get $5
-   local.get $4
+   local.get $3
    i32.const 2
    i32.and
    i32.or
@@ -1451,19 +1455,19 @@
    i32.add
    local.get $5
    i32.add
-   local.tee $4
+   local.tee $3
    local.get $6
    i32.const 4
    i32.sub
    i32.const 1
    i32.or
    i32.store $0
-   local.get $3
    local.get $4
+   local.get $3
    call $~lib/rt/tlsf/insertBlock
   else
    local.get $2
-   local.get $4
+   local.get $3
    i32.const -2
    i32.and
    i32.store $0

--- a/tests/compiler/resolve-access.release.wat
+++ b/tests/compiler/resolve-access.release.wat
@@ -1287,7 +1287,7 @@
    call $~lib/rt/tlsf/initialize
   end
   global.get $~lib/rt/tlsf/ROOT
-  local.set $4
+  local.set $3
   local.get $0
   i32.const 16
   i32.add
@@ -1302,7 +1302,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $4
+  local.get $3
   i32.const 12
   local.get $2
   i32.const 19
@@ -1322,8 +1322,9 @@
   if
    memory.size $0
    local.tee $2
+   local.get $5
    i32.const 4
-   local.get $4
+   local.get $3
    i32.load $0 offset=1568
    local.get $2
    i32.const 16
@@ -1332,38 +1333,40 @@
    i32.sub
    i32.ne
    i32.shl
-   local.get $5
-   i32.const 1
-   i32.const 27
-   local.get $5
-   i32.clz
-   i32.sub
-   i32.shl
-   i32.const 1
-   i32.sub
    i32.add
-   local.get $5
-   local.get $5
+   local.tee $4
    i32.const 536870910
    i32.lt_u
-   select
-   i32.add
+   if (result i32)
+    local.get $4
+    i32.const 1
+    i32.const 27
+    local.get $4
+    i32.clz
+    i32.sub
+    i32.shl
+    i32.const 1
+    i32.sub
+    i32.add
+   else
+    local.get $4
+   end
    i32.const 65535
    i32.add
    i32.const -65536
    i32.and
    i32.const 16
    i32.shr_u
-   local.tee $3
+   local.tee $4
    local.get $2
-   local.get $3
+   local.get $4
    i32.gt_s
    select
    memory.grow $0
    i32.const 0
    i32.lt_s
    if
-    local.get $3
+    local.get $4
     memory.grow $0
     i32.const 0
     i32.lt_s
@@ -1371,7 +1374,7 @@
      unreachable
     end
    end
-   local.get $4
+   local.get $3
    local.get $2
    i32.const 16
    i32.shl
@@ -1380,7 +1383,7 @@
    i64.const 16
    i64.shl
    call $~lib/rt/tlsf/addMemory
-   local.get $4
+   local.get $3
    local.get $5
    call $~lib/rt/tlsf/searchBlock
    local.tee $2
@@ -1408,12 +1411,12 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $4
+  local.get $3
   local.get $2
   call $~lib/rt/tlsf/removeBlock
   local.get $2
   i32.load $0
-  local.set $3
+  local.set $4
   local.get $5
   i32.const 4
   i32.add
@@ -1427,7 +1430,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $3
+  local.get $4
   i32.const -4
   i32.and
   local.get $5
@@ -1438,7 +1441,7 @@
   if
    local.get $2
    local.get $5
-   local.get $3
+   local.get $4
    i32.const 2
    i32.and
    i32.or
@@ -1448,19 +1451,19 @@
    i32.add
    local.get $5
    i32.add
-   local.tee $3
+   local.tee $4
    local.get $6
    i32.const 4
    i32.sub
    i32.const 1
    i32.or
    i32.store $0
-   local.get $4
    local.get $3
+   local.get $4
    call $~lib/rt/tlsf/insertBlock
   else
    local.get $2
-   local.get $3
+   local.get $4
    i32.const -2
    i32.and
    i32.store $0

--- a/tests/compiler/resolve-binary.debug.wat
+++ b/tests/compiler/resolve-binary.debug.wat
@@ -2164,7 +2164,7 @@
   drop
   local.get $size
   i32.const 256
-  i32.gt_u
+  i32.ge_u
   if
    local.get $size
    call $~lib/rt/tlsf/roundSize

--- a/tests/compiler/resolve-binary.debug.wat
+++ b/tests/compiler/resolve-binary.debug.wat
@@ -2153,22 +2153,6 @@
   (local $pagesAfter i32)
   i32.const 0
   drop
-  local.get $size
-  i32.const 536870910
-  i32.lt_u
-  if
-   local.get $size
-   i32.const 1
-   i32.const 27
-   local.get $size
-   i32.clz
-   i32.sub
-   i32.shl
-   i32.const 1
-   i32.sub
-   i32.add
-   local.set $size
-  end
   memory.size $0
   local.set $pagesBefore
   local.get $size
@@ -2189,6 +2173,22 @@
   i32.shl
   i32.add
   local.set $size
+  local.get $size
+  i32.const 536870910
+  i32.lt_u
+  if
+   local.get $size
+   i32.const 1
+   i32.const 27
+   local.get $size
+   i32.clz
+   i32.sub
+   i32.shl
+   i32.const 1
+   i32.sub
+   i32.add
+   local.set $size
+  end
   local.get $size
   i32.const 65535
   i32.add

--- a/tests/compiler/resolve-binary.debug.wat
+++ b/tests/compiler/resolve-binary.debug.wat
@@ -1274,7 +1274,7 @@
   if
    i32.const 0
    i32.const 720
-   i32.const 378
+   i32.const 382
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1320,7 +1320,7 @@
    if
     i32.const 0
     i32.const 720
-    i32.const 385
+    i32.const 389
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1353,7 +1353,7 @@
    if
     i32.const 0
     i32.const 720
-    i32.const 398
+    i32.const 402
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1597,7 +1597,7 @@
   if
    i32.const 0
    i32.const 720
-   i32.const 560
+   i32.const 562
    i32.const 3
    call $~lib/builtins/abort
    unreachable
@@ -1926,13 +1926,33 @@
   if
    i32.const 384
    i32.const 720
-   i32.const 459
+   i32.const 461
    i32.const 29
    call $~lib/builtins/abort
    unreachable
   end
   local.get $size
   call $~lib/rt/tlsf/computeSize
+  return
+ )
+ (func $~lib/rt/tlsf/roundSize (param $size i32) (result i32)
+  local.get $size
+  i32.const 536870910
+  i32.lt_u
+  if (result i32)
+   local.get $size
+   i32.const 1
+   i32.const 27
+   local.get $size
+   i32.clz
+   i32.sub
+   i32.shl
+   i32.add
+   i32.const 1
+   i32.sub
+  else
+   local.get $size
+  end
   return
  )
  (func $~lib/rt/tlsf/searchBlock (param $root i32) (param $size i32) (result i32)
@@ -1964,24 +1984,13 @@
    local.set $sl
   else
    local.get $size
-   i32.const 536870910
-   i32.lt_u
-   if (result i32)
-    local.get $size
-    i32.const 1
-    i32.const 27
-    local.get $size
-    i32.clz
-    i32.sub
-    i32.shl
-    i32.add
-    i32.const 1
-    i32.sub
-   else
-    local.get $size
-   end
+   call $~lib/rt/tlsf/roundSize
    local.set $requestSize
-   i32.const 31
+   i32.const 4
+   i32.const 8
+   i32.mul
+   i32.const 1
+   i32.sub
    local.get $requestSize
    i32.clz
    i32.sub
@@ -2019,7 +2028,7 @@
   if
    i32.const 0
    i32.const 720
-   i32.const 330
+   i32.const 334
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -2090,7 +2099,7 @@
     if
      i32.const 0
      i32.const 720
-     i32.const 343
+     i32.const 347
      i32.const 18
      call $~lib/builtins/abort
      unreachable
@@ -2153,6 +2162,14 @@
   (local $pagesAfter i32)
   i32.const 0
   drop
+  local.get $size
+  i32.const 256
+  i32.gt_u
+  if
+   local.get $size
+   call $~lib/rt/tlsf/roundSize
+   local.set $size
+  end
   memory.size $0
   local.set $pagesBefore
   local.get $size
@@ -2173,22 +2190,6 @@
   i32.shl
   i32.add
   local.set $size
-  local.get $size
-  i32.const 536870910
-  i32.lt_u
-  if
-   local.get $size
-   i32.const 1
-   i32.const 27
-   local.get $size
-   i32.clz
-   i32.sub
-   i32.shl
-   i32.const 1
-   i32.sub
-   i32.add
-   local.set $size
-  end
   local.get $size
   i32.const 65535
   i32.add
@@ -2255,7 +2256,7 @@
   if
    i32.const 0
    i32.const 720
-   i32.const 357
+   i32.const 361
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -2370,7 +2371,7 @@
    if
     i32.const 0
     i32.const 720
-    i32.const 497
+    i32.const 499
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -2390,7 +2391,7 @@
   if
    i32.const 0
    i32.const 720
-   i32.const 499
+   i32.const 501
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/resolve-binary.release.wat
+++ b/tests/compiler/resolve-binary.release.wat
@@ -851,7 +851,7 @@
   if
    i32.const 0
    i32.const 1744
-   i32.const 378
+   i32.const 382
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -876,7 +876,7 @@
    if
     i32.const 0
     i32.const 1744
-    i32.const 385
+    i32.const 389
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -904,7 +904,7 @@
    if
     i32.const 0
     i32.const 1744
-    i32.const 398
+    i32.const 402
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1271,7 +1271,7 @@
       if
        i32.const 0
        i32.const 1744
-       i32.const 560
+       i32.const 562
        i32.const 3
        call $~lib/builtins/abort
        unreachable
@@ -1355,7 +1355,7 @@
   if
    i32.const 0
    i32.const 1744
-   i32.const 330
+   i32.const 334
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1407,7 +1407,7 @@
     if
      i32.const 0
      i32.const 1744
-     i32.const 343
+     i32.const 347
      i32.const 18
      call $~lib/builtins/abort
      unreachable
@@ -1496,7 +1496,7 @@
    call $~lib/rt/tlsf/initialize
   end
   global.get $~lib/rt/tlsf/ROOT
-  local.set $3
+  local.set $4
   local.get $0
   i32.const 16
   i32.add
@@ -1506,12 +1506,12 @@
   if
    i32.const 1408
    i32.const 1744
-   i32.const 459
+   i32.const 461
    i32.const 29
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $3
+  local.get $4
   i32.const 12
   local.get $2
   i32.const 19
@@ -1532,8 +1532,29 @@
    memory.size $0
    local.tee $2
    local.get $5
+   i32.const 256
+   i32.gt_u
+   if (result i32)
+    local.get $5
+    i32.const 1
+    i32.const 27
+    local.get $5
+    i32.clz
+    i32.sub
+    i32.shl
+    i32.add
+    i32.const 1
+    i32.sub
+    local.get $5
+    local.get $5
+    i32.const 536870910
+    i32.lt_u
+    select
+   else
+    local.get $5
+   end
    i32.const 4
-   local.get $3
+   local.get $4
    i32.load $0 offset=1568
    local.get $2
    i32.const 16
@@ -1543,39 +1564,22 @@
    i32.ne
    i32.shl
    i32.add
-   local.tee $4
-   i32.const 536870910
-   i32.lt_u
-   if (result i32)
-    local.get $4
-    i32.const 1
-    i32.const 27
-    local.get $4
-    i32.clz
-    i32.sub
-    i32.shl
-    i32.const 1
-    i32.sub
-    i32.add
-   else
-    local.get $4
-   end
    i32.const 65535
    i32.add
    i32.const -65536
    i32.and
    i32.const 16
    i32.shr_u
-   local.tee $4
+   local.tee $3
    local.get $2
-   local.get $4
+   local.get $3
    i32.gt_s
    select
    memory.grow $0
    i32.const 0
    i32.lt_s
    if
-    local.get $4
+    local.get $3
     memory.grow $0
     i32.const 0
     i32.lt_s
@@ -1583,7 +1587,7 @@
      unreachable
     end
    end
-   local.get $3
+   local.get $4
    local.get $2
    i32.const 16
    i32.shl
@@ -1592,7 +1596,7 @@
    i64.const 16
    i64.shl
    call $~lib/rt/tlsf/addMemory
-   local.get $3
+   local.get $4
    local.get $5
    call $~lib/rt/tlsf/searchBlock
    local.tee $2
@@ -1600,7 +1604,7 @@
    if
     i32.const 0
     i32.const 1744
-    i32.const 497
+    i32.const 499
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1615,17 +1619,17 @@
   if
    i32.const 0
    i32.const 1744
-   i32.const 499
+   i32.const 501
    i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $3
+  local.get $4
   local.get $2
   call $~lib/rt/tlsf/removeBlock
   local.get $2
   i32.load $0
-  local.set $4
+  local.set $3
   local.get $5
   i32.const 4
   i32.add
@@ -1634,12 +1638,12 @@
   if
    i32.const 0
    i32.const 1744
-   i32.const 357
+   i32.const 361
    i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $4
+  local.get $3
   i32.const -4
   i32.and
   local.get $5
@@ -1650,7 +1654,7 @@
   if
    local.get $2
    local.get $5
-   local.get $4
+   local.get $3
    i32.const 2
    i32.and
    i32.or
@@ -1660,19 +1664,19 @@
    i32.add
    local.get $5
    i32.add
-   local.tee $4
+   local.tee $3
    local.get $6
    i32.const 4
    i32.sub
    i32.const 1
    i32.or
    i32.store $0
-   local.get $3
    local.get $4
+   local.get $3
    call $~lib/rt/tlsf/insertBlock
   else
    local.get $2
-   local.get $4
+   local.get $3
    i32.const -2
    i32.and
    i32.store $0

--- a/tests/compiler/resolve-binary.release.wat
+++ b/tests/compiler/resolve-binary.release.wat
@@ -1496,7 +1496,7 @@
    call $~lib/rt/tlsf/initialize
   end
   global.get $~lib/rt/tlsf/ROOT
-  local.set $4
+  local.set $3
   local.get $0
   i32.const 16
   i32.add
@@ -1511,7 +1511,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $4
+  local.get $3
   i32.const 12
   local.get $2
   i32.const 19
@@ -1531,8 +1531,9 @@
   if
    memory.size $0
    local.tee $2
+   local.get $5
    i32.const 4
-   local.get $4
+   local.get $3
    i32.load $0 offset=1568
    local.get $2
    i32.const 16
@@ -1541,38 +1542,40 @@
    i32.sub
    i32.ne
    i32.shl
-   local.get $5
-   i32.const 1
-   i32.const 27
-   local.get $5
-   i32.clz
-   i32.sub
-   i32.shl
-   i32.const 1
-   i32.sub
    i32.add
-   local.get $5
-   local.get $5
+   local.tee $4
    i32.const 536870910
    i32.lt_u
-   select
-   i32.add
+   if (result i32)
+    local.get $4
+    i32.const 1
+    i32.const 27
+    local.get $4
+    i32.clz
+    i32.sub
+    i32.shl
+    i32.const 1
+    i32.sub
+    i32.add
+   else
+    local.get $4
+   end
    i32.const 65535
    i32.add
    i32.const -65536
    i32.and
    i32.const 16
    i32.shr_u
-   local.tee $3
+   local.tee $4
    local.get $2
-   local.get $3
+   local.get $4
    i32.gt_s
    select
    memory.grow $0
    i32.const 0
    i32.lt_s
    if
-    local.get $3
+    local.get $4
     memory.grow $0
     i32.const 0
     i32.lt_s
@@ -1580,7 +1583,7 @@
      unreachable
     end
    end
-   local.get $4
+   local.get $3
    local.get $2
    i32.const 16
    i32.shl
@@ -1589,7 +1592,7 @@
    i64.const 16
    i64.shl
    call $~lib/rt/tlsf/addMemory
-   local.get $4
+   local.get $3
    local.get $5
    call $~lib/rt/tlsf/searchBlock
    local.tee $2
@@ -1617,12 +1620,12 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $4
+  local.get $3
   local.get $2
   call $~lib/rt/tlsf/removeBlock
   local.get $2
   i32.load $0
-  local.set $3
+  local.set $4
   local.get $5
   i32.const 4
   i32.add
@@ -1636,7 +1639,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $3
+  local.get $4
   i32.const -4
   i32.and
   local.get $5
@@ -1647,7 +1650,7 @@
   if
    local.get $2
    local.get $5
-   local.get $3
+   local.get $4
    i32.const 2
    i32.and
    i32.or
@@ -1657,19 +1660,19 @@
    i32.add
    local.get $5
    i32.add
-   local.tee $3
+   local.tee $4
    local.get $6
    i32.const 4
    i32.sub
    i32.const 1
    i32.or
    i32.store $0
-   local.get $4
    local.get $3
+   local.get $4
    call $~lib/rt/tlsf/insertBlock
   else
    local.get $2
-   local.get $3
+   local.get $4
    i32.const -2
    i32.and
    i32.store $0

--- a/tests/compiler/resolve-binary.release.wat
+++ b/tests/compiler/resolve-binary.release.wat
@@ -1533,7 +1533,7 @@
    local.tee $2
    local.get $5
    i32.const 256
-   i32.gt_u
+   i32.ge_u
    if (result i32)
     local.get $5
     i32.const 1

--- a/tests/compiler/resolve-elementaccess.debug.wat
+++ b/tests/compiler/resolve-elementaccess.debug.wat
@@ -1077,7 +1077,7 @@
   if
    i32.const 0
    i32.const 480
-   i32.const 378
+   i32.const 382
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1123,7 +1123,7 @@
    if
     i32.const 0
     i32.const 480
-    i32.const 385
+    i32.const 389
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1156,7 +1156,7 @@
    if
     i32.const 0
     i32.const 480
-    i32.const 398
+    i32.const 402
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1400,7 +1400,7 @@
   if
    i32.const 0
    i32.const 480
-   i32.const 560
+   i32.const 562
    i32.const 3
    call $~lib/builtins/abort
    unreachable
@@ -1729,13 +1729,33 @@
   if
    i32.const 144
    i32.const 480
-   i32.const 459
+   i32.const 461
    i32.const 29
    call $~lib/builtins/abort
    unreachable
   end
   local.get $size
   call $~lib/rt/tlsf/computeSize
+  return
+ )
+ (func $~lib/rt/tlsf/roundSize (param $size i32) (result i32)
+  local.get $size
+  i32.const 536870910
+  i32.lt_u
+  if (result i32)
+   local.get $size
+   i32.const 1
+   i32.const 27
+   local.get $size
+   i32.clz
+   i32.sub
+   i32.shl
+   i32.add
+   i32.const 1
+   i32.sub
+  else
+   local.get $size
+  end
   return
  )
  (func $~lib/rt/tlsf/searchBlock (param $root i32) (param $size i32) (result i32)
@@ -1767,24 +1787,13 @@
    local.set $sl
   else
    local.get $size
-   i32.const 536870910
-   i32.lt_u
-   if (result i32)
-    local.get $size
-    i32.const 1
-    i32.const 27
-    local.get $size
-    i32.clz
-    i32.sub
-    i32.shl
-    i32.add
-    i32.const 1
-    i32.sub
-   else
-    local.get $size
-   end
+   call $~lib/rt/tlsf/roundSize
    local.set $requestSize
-   i32.const 31
+   i32.const 4
+   i32.const 8
+   i32.mul
+   i32.const 1
+   i32.sub
    local.get $requestSize
    i32.clz
    i32.sub
@@ -1822,7 +1831,7 @@
   if
    i32.const 0
    i32.const 480
-   i32.const 330
+   i32.const 334
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1893,7 +1902,7 @@
     if
      i32.const 0
      i32.const 480
-     i32.const 343
+     i32.const 347
      i32.const 18
      call $~lib/builtins/abort
      unreachable
@@ -1956,6 +1965,14 @@
   (local $pagesAfter i32)
   i32.const 0
   drop
+  local.get $size
+  i32.const 256
+  i32.gt_u
+  if
+   local.get $size
+   call $~lib/rt/tlsf/roundSize
+   local.set $size
+  end
   memory.size $0
   local.set $pagesBefore
   local.get $size
@@ -1976,22 +1993,6 @@
   i32.shl
   i32.add
   local.set $size
-  local.get $size
-  i32.const 536870910
-  i32.lt_u
-  if
-   local.get $size
-   i32.const 1
-   i32.const 27
-   local.get $size
-   i32.clz
-   i32.sub
-   i32.shl
-   i32.const 1
-   i32.sub
-   i32.add
-   local.set $size
-  end
   local.get $size
   i32.const 65535
   i32.add
@@ -2058,7 +2059,7 @@
   if
    i32.const 0
    i32.const 480
-   i32.const 357
+   i32.const 361
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -2173,7 +2174,7 @@
    if
     i32.const 0
     i32.const 480
-    i32.const 497
+    i32.const 499
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -2193,7 +2194,7 @@
   if
    i32.const 0
    i32.const 480
-   i32.const 499
+   i32.const 501
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/resolve-elementaccess.debug.wat
+++ b/tests/compiler/resolve-elementaccess.debug.wat
@@ -1967,7 +1967,7 @@
   drop
   local.get $size
   i32.const 256
-  i32.gt_u
+  i32.ge_u
   if
    local.get $size
    call $~lib/rt/tlsf/roundSize

--- a/tests/compiler/resolve-elementaccess.debug.wat
+++ b/tests/compiler/resolve-elementaccess.debug.wat
@@ -1956,22 +1956,6 @@
   (local $pagesAfter i32)
   i32.const 0
   drop
-  local.get $size
-  i32.const 536870910
-  i32.lt_u
-  if
-   local.get $size
-   i32.const 1
-   i32.const 27
-   local.get $size
-   i32.clz
-   i32.sub
-   i32.shl
-   i32.const 1
-   i32.sub
-   i32.add
-   local.set $size
-  end
   memory.size $0
   local.set $pagesBefore
   local.get $size
@@ -1992,6 +1976,22 @@
   i32.shl
   i32.add
   local.set $size
+  local.get $size
+  i32.const 536870910
+  i32.lt_u
+  if
+   local.get $size
+   i32.const 1
+   i32.const 27
+   local.get $size
+   i32.clz
+   i32.sub
+   i32.shl
+   i32.const 1
+   i32.sub
+   i32.add
+   local.set $size
+  end
   local.get $size
   i32.const 65535
   i32.add

--- a/tests/compiler/resolve-elementaccess.release.wat
+++ b/tests/compiler/resolve-elementaccess.release.wat
@@ -1376,7 +1376,7 @@
    local.tee $2
    local.get $5
    i32.const 256
-   i32.gt_u
+   i32.ge_u
    if (result i32)
     local.get $5
     i32.const 1

--- a/tests/compiler/resolve-elementaccess.release.wat
+++ b/tests/compiler/resolve-elementaccess.release.wat
@@ -694,7 +694,7 @@
   if
    i32.const 0
    i32.const 1504
-   i32.const 378
+   i32.const 382
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -719,7 +719,7 @@
    if
     i32.const 0
     i32.const 1504
-    i32.const 385
+    i32.const 389
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -747,7 +747,7 @@
    if
     i32.const 0
     i32.const 1504
-    i32.const 398
+    i32.const 402
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1114,7 +1114,7 @@
       if
        i32.const 0
        i32.const 1504
-       i32.const 560
+       i32.const 562
        i32.const 3
        call $~lib/builtins/abort
        unreachable
@@ -1198,7 +1198,7 @@
   if
    i32.const 0
    i32.const 1504
-   i32.const 330
+   i32.const 334
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1250,7 +1250,7 @@
     if
      i32.const 0
      i32.const 1504
-     i32.const 343
+     i32.const 347
      i32.const 18
      call $~lib/builtins/abort
      unreachable
@@ -1339,7 +1339,7 @@
    call $~lib/rt/tlsf/initialize
   end
   global.get $~lib/rt/tlsf/ROOT
-  local.set $3
+  local.set $4
   local.get $0
   i32.const 16
   i32.add
@@ -1349,12 +1349,12 @@
   if
    i32.const 1168
    i32.const 1504
-   i32.const 459
+   i32.const 461
    i32.const 29
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $3
+  local.get $4
   i32.const 12
   local.get $2
   i32.const 19
@@ -1375,8 +1375,29 @@
    memory.size $0
    local.tee $2
    local.get $5
+   i32.const 256
+   i32.gt_u
+   if (result i32)
+    local.get $5
+    i32.const 1
+    i32.const 27
+    local.get $5
+    i32.clz
+    i32.sub
+    i32.shl
+    i32.add
+    i32.const 1
+    i32.sub
+    local.get $5
+    local.get $5
+    i32.const 536870910
+    i32.lt_u
+    select
+   else
+    local.get $5
+   end
    i32.const 4
-   local.get $3
+   local.get $4
    i32.load $0 offset=1568
    local.get $2
    i32.const 16
@@ -1386,39 +1407,22 @@
    i32.ne
    i32.shl
    i32.add
-   local.tee $4
-   i32.const 536870910
-   i32.lt_u
-   if (result i32)
-    local.get $4
-    i32.const 1
-    i32.const 27
-    local.get $4
-    i32.clz
-    i32.sub
-    i32.shl
-    i32.const 1
-    i32.sub
-    i32.add
-   else
-    local.get $4
-   end
    i32.const 65535
    i32.add
    i32.const -65536
    i32.and
    i32.const 16
    i32.shr_u
-   local.tee $4
+   local.tee $3
    local.get $2
-   local.get $4
+   local.get $3
    i32.gt_s
    select
    memory.grow $0
    i32.const 0
    i32.lt_s
    if
-    local.get $4
+    local.get $3
     memory.grow $0
     i32.const 0
     i32.lt_s
@@ -1426,7 +1430,7 @@
      unreachable
     end
    end
-   local.get $3
+   local.get $4
    local.get $2
    i32.const 16
    i32.shl
@@ -1435,7 +1439,7 @@
    i64.const 16
    i64.shl
    call $~lib/rt/tlsf/addMemory
-   local.get $3
+   local.get $4
    local.get $5
    call $~lib/rt/tlsf/searchBlock
    local.tee $2
@@ -1443,7 +1447,7 @@
    if
     i32.const 0
     i32.const 1504
-    i32.const 497
+    i32.const 499
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1458,17 +1462,17 @@
   if
    i32.const 0
    i32.const 1504
-   i32.const 499
+   i32.const 501
    i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $3
+  local.get $4
   local.get $2
   call $~lib/rt/tlsf/removeBlock
   local.get $2
   i32.load $0
-  local.set $4
+  local.set $3
   local.get $5
   i32.const 4
   i32.add
@@ -1477,12 +1481,12 @@
   if
    i32.const 0
    i32.const 1504
-   i32.const 357
+   i32.const 361
    i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $4
+  local.get $3
   i32.const -4
   i32.and
   local.get $5
@@ -1493,7 +1497,7 @@
   if
    local.get $2
    local.get $5
-   local.get $4
+   local.get $3
    i32.const 2
    i32.and
    i32.or
@@ -1503,19 +1507,19 @@
    i32.add
    local.get $5
    i32.add
-   local.tee $4
+   local.tee $3
    local.get $6
    i32.const 4
    i32.sub
    i32.const 1
    i32.or
    i32.store $0
-   local.get $3
    local.get $4
+   local.get $3
    call $~lib/rt/tlsf/insertBlock
   else
    local.get $2
-   local.get $4
+   local.get $3
    i32.const -2
    i32.and
    i32.store $0

--- a/tests/compiler/resolve-elementaccess.release.wat
+++ b/tests/compiler/resolve-elementaccess.release.wat
@@ -1339,7 +1339,7 @@
    call $~lib/rt/tlsf/initialize
   end
   global.get $~lib/rt/tlsf/ROOT
-  local.set $4
+  local.set $3
   local.get $0
   i32.const 16
   i32.add
@@ -1354,7 +1354,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $4
+  local.get $3
   i32.const 12
   local.get $2
   i32.const 19
@@ -1374,8 +1374,9 @@
   if
    memory.size $0
    local.tee $2
+   local.get $5
    i32.const 4
-   local.get $4
+   local.get $3
    i32.load $0 offset=1568
    local.get $2
    i32.const 16
@@ -1384,38 +1385,40 @@
    i32.sub
    i32.ne
    i32.shl
-   local.get $5
-   i32.const 1
-   i32.const 27
-   local.get $5
-   i32.clz
-   i32.sub
-   i32.shl
-   i32.const 1
-   i32.sub
    i32.add
-   local.get $5
-   local.get $5
+   local.tee $4
    i32.const 536870910
    i32.lt_u
-   select
-   i32.add
+   if (result i32)
+    local.get $4
+    i32.const 1
+    i32.const 27
+    local.get $4
+    i32.clz
+    i32.sub
+    i32.shl
+    i32.const 1
+    i32.sub
+    i32.add
+   else
+    local.get $4
+   end
    i32.const 65535
    i32.add
    i32.const -65536
    i32.and
    i32.const 16
    i32.shr_u
-   local.tee $3
+   local.tee $4
    local.get $2
-   local.get $3
+   local.get $4
    i32.gt_s
    select
    memory.grow $0
    i32.const 0
    i32.lt_s
    if
-    local.get $3
+    local.get $4
     memory.grow $0
     i32.const 0
     i32.lt_s
@@ -1423,7 +1426,7 @@
      unreachable
     end
    end
-   local.get $4
+   local.get $3
    local.get $2
    i32.const 16
    i32.shl
@@ -1432,7 +1435,7 @@
    i64.const 16
    i64.shl
    call $~lib/rt/tlsf/addMemory
-   local.get $4
+   local.get $3
    local.get $5
    call $~lib/rt/tlsf/searchBlock
    local.tee $2
@@ -1460,12 +1463,12 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $4
+  local.get $3
   local.get $2
   call $~lib/rt/tlsf/removeBlock
   local.get $2
   i32.load $0
-  local.set $3
+  local.set $4
   local.get $5
   i32.const 4
   i32.add
@@ -1479,7 +1482,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $3
+  local.get $4
   i32.const -4
   i32.and
   local.get $5
@@ -1490,7 +1493,7 @@
   if
    local.get $2
    local.get $5
-   local.get $3
+   local.get $4
    i32.const 2
    i32.and
    i32.or
@@ -1500,19 +1503,19 @@
    i32.add
    local.get $5
    i32.add
-   local.tee $3
+   local.tee $4
    local.get $6
    i32.const 4
    i32.sub
    i32.const 1
    i32.or
    i32.store $0
-   local.get $4
    local.get $3
+   local.get $4
    call $~lib/rt/tlsf/insertBlock
   else
    local.get $2
-   local.get $3
+   local.get $4
    i32.const -2
    i32.and
    i32.store $0

--- a/tests/compiler/resolve-function-expression.debug.wat
+++ b/tests/compiler/resolve-function-expression.debug.wat
@@ -2010,7 +2010,7 @@
   drop
   local.get $size
   i32.const 256
-  i32.gt_u
+  i32.ge_u
   if
    local.get $size
    call $~lib/rt/tlsf/roundSize

--- a/tests/compiler/resolve-function-expression.debug.wat
+++ b/tests/compiler/resolve-function-expression.debug.wat
@@ -1120,7 +1120,7 @@
   if
    i32.const 0
    i32.const 768
-   i32.const 378
+   i32.const 382
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1166,7 +1166,7 @@
    if
     i32.const 0
     i32.const 768
-    i32.const 385
+    i32.const 389
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1199,7 +1199,7 @@
    if
     i32.const 0
     i32.const 768
-    i32.const 398
+    i32.const 402
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1443,7 +1443,7 @@
   if
    i32.const 0
    i32.const 768
-   i32.const 560
+   i32.const 562
    i32.const 3
    call $~lib/builtins/abort
    unreachable
@@ -1772,13 +1772,33 @@
   if
    i32.const 432
    i32.const 768
-   i32.const 459
+   i32.const 461
    i32.const 29
    call $~lib/builtins/abort
    unreachable
   end
   local.get $size
   call $~lib/rt/tlsf/computeSize
+  return
+ )
+ (func $~lib/rt/tlsf/roundSize (param $size i32) (result i32)
+  local.get $size
+  i32.const 536870910
+  i32.lt_u
+  if (result i32)
+   local.get $size
+   i32.const 1
+   i32.const 27
+   local.get $size
+   i32.clz
+   i32.sub
+   i32.shl
+   i32.add
+   i32.const 1
+   i32.sub
+  else
+   local.get $size
+  end
   return
  )
  (func $~lib/rt/tlsf/searchBlock (param $root i32) (param $size i32) (result i32)
@@ -1810,24 +1830,13 @@
    local.set $sl
   else
    local.get $size
-   i32.const 536870910
-   i32.lt_u
-   if (result i32)
-    local.get $size
-    i32.const 1
-    i32.const 27
-    local.get $size
-    i32.clz
-    i32.sub
-    i32.shl
-    i32.add
-    i32.const 1
-    i32.sub
-   else
-    local.get $size
-   end
+   call $~lib/rt/tlsf/roundSize
    local.set $requestSize
-   i32.const 31
+   i32.const 4
+   i32.const 8
+   i32.mul
+   i32.const 1
+   i32.sub
    local.get $requestSize
    i32.clz
    i32.sub
@@ -1865,7 +1874,7 @@
   if
    i32.const 0
    i32.const 768
-   i32.const 330
+   i32.const 334
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1936,7 +1945,7 @@
     if
      i32.const 0
      i32.const 768
-     i32.const 343
+     i32.const 347
      i32.const 18
      call $~lib/builtins/abort
      unreachable
@@ -1999,6 +2008,14 @@
   (local $pagesAfter i32)
   i32.const 0
   drop
+  local.get $size
+  i32.const 256
+  i32.gt_u
+  if
+   local.get $size
+   call $~lib/rt/tlsf/roundSize
+   local.set $size
+  end
   memory.size $0
   local.set $pagesBefore
   local.get $size
@@ -2019,22 +2036,6 @@
   i32.shl
   i32.add
   local.set $size
-  local.get $size
-  i32.const 536870910
-  i32.lt_u
-  if
-   local.get $size
-   i32.const 1
-   i32.const 27
-   local.get $size
-   i32.clz
-   i32.sub
-   i32.shl
-   i32.const 1
-   i32.sub
-   i32.add
-   local.set $size
-  end
   local.get $size
   i32.const 65535
   i32.add
@@ -2101,7 +2102,7 @@
   if
    i32.const 0
    i32.const 768
-   i32.const 357
+   i32.const 361
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -2216,7 +2217,7 @@
    if
     i32.const 0
     i32.const 768
-    i32.const 497
+    i32.const 499
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -2236,7 +2237,7 @@
   if
    i32.const 0
    i32.const 768
-   i32.const 499
+   i32.const 501
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/resolve-function-expression.debug.wat
+++ b/tests/compiler/resolve-function-expression.debug.wat
@@ -1999,22 +1999,6 @@
   (local $pagesAfter i32)
   i32.const 0
   drop
-  local.get $size
-  i32.const 536870910
-  i32.lt_u
-  if
-   local.get $size
-   i32.const 1
-   i32.const 27
-   local.get $size
-   i32.clz
-   i32.sub
-   i32.shl
-   i32.const 1
-   i32.sub
-   i32.add
-   local.set $size
-  end
   memory.size $0
   local.set $pagesBefore
   local.get $size
@@ -2035,6 +2019,22 @@
   i32.shl
   i32.add
   local.set $size
+  local.get $size
+  i32.const 536870910
+  i32.lt_u
+  if
+   local.get $size
+   i32.const 1
+   i32.const 27
+   local.get $size
+   i32.clz
+   i32.sub
+   i32.shl
+   i32.const 1
+   i32.sub
+   i32.add
+   local.set $size
+  end
   local.get $size
   i32.const 65535
   i32.add

--- a/tests/compiler/resolve-function-expression.release.wat
+++ b/tests/compiler/resolve-function-expression.release.wat
@@ -1441,7 +1441,7 @@
     local.tee $2
     local.get $8
     i32.const 256
-    i32.gt_u
+    i32.ge_u
     if (result i32)
      local.get $8
      i32.const 1

--- a/tests/compiler/resolve-function-expression.release.wat
+++ b/tests/compiler/resolve-function-expression.release.wat
@@ -1275,11 +1275,11 @@
     i32.add
     global.set $~lib/memory/__stack_pointer
     i32.const 1424
-    local.set $1
+    local.set $2
     br $__inlined_func$~lib/util/number/itoa32
    end
    global.get $~lib/memory/__stack_pointer
-   local.set $5
+   local.set $4
    i32.const 0
    local.get $0
    i32.sub
@@ -1337,12 +1337,12 @@
      i32.add
     end
    end
-   local.tee $2
+   local.tee $1
    i32.const 1
    i32.shl
    local.get $3
    i32.add
-   local.tee $6
+   local.tee $7
    i32.const 1073741804
    i32.ge_u
    if
@@ -1359,12 +1359,12 @@
    if
     block $__inlined_func$~lib/rt/itcms/interrupt
      i32.const 2048
-     local.set $1
+     local.set $2
      loop $do-loop|0
-      local.get $1
+      local.get $2
       call $~lib/rt/itcms/step
       i32.sub
-      local.set $1
+      local.set $2
       global.get $~lib/rt/itcms/state
       i32.eqz
       if
@@ -1380,20 +1380,20 @@
        global.set $~lib/rt/itcms/threshold
        br $__inlined_func$~lib/rt/itcms/interrupt
       end
-      local.get $1
+      local.get $2
       i32.const 0
       i32.gt_s
       br_if $do-loop|0
      end
      global.get $~lib/rt/itcms/total
-     local.tee $1
+     local.tee $2
      global.get $~lib/rt/itcms/threshold
      i32.sub
      i32.const 1024
      i32.lt_u
      i32.const 10
      i32.shl
-     local.get $1
+     local.get $2
      i32.add
      global.set $~lib/rt/itcms/threshold
     end
@@ -1404,11 +1404,11 @@
     call $~lib/rt/tlsf/initialize
    end
    global.get $~lib/rt/tlsf/ROOT
-   local.set $7
-   local.get $6
+   local.set $5
+   local.get $7
    i32.const 16
    i32.add
-   local.tee $1
+   local.tee $2
    i32.const 1073741820
    i32.gt_u
    if
@@ -1419,68 +1419,71 @@
     call $~lib/builtins/abort
     unreachable
    end
-   local.get $7
+   local.get $5
    i32.const 12
-   local.get $1
+   local.get $2
    i32.const 19
    i32.add
    i32.const -16
    i32.and
    i32.const 4
    i32.sub
-   local.get $1
+   local.get $2
    i32.const 12
    i32.le_u
    select
    local.tee $8
    call $~lib/rt/tlsf/searchBlock
-   local.tee $1
+   local.tee $2
    i32.eqz
    if
     memory.size $0
-    local.tee $1
+    local.tee $2
+    local.get $8
     i32.const 4
-    local.get $7
+    local.get $5
     i32.load $0 offset=1568
-    local.get $1
+    local.get $2
     i32.const 16
     i32.shl
     i32.const 4
     i32.sub
     i32.ne
     i32.shl
-    local.get $8
-    i32.const 1
-    i32.const 27
-    local.get $8
-    i32.clz
-    i32.sub
-    i32.shl
-    i32.const 1
-    i32.sub
     i32.add
-    local.get $8
-    local.get $8
+    local.tee $6
     i32.const 536870910
     i32.lt_u
-    select
-    i32.add
+    if (result i32)
+     local.get $6
+     i32.const 1
+     i32.const 27
+     local.get $6
+     i32.clz
+     i32.sub
+     i32.shl
+     i32.const 1
+     i32.sub
+     i32.add
+    else
+     local.get $6
+    end
     i32.const 65535
     i32.add
     i32.const -65536
     i32.and
     i32.const 16
     i32.shr_u
-    local.tee $4
-    local.get $1
-    local.get $4
+    local.tee $6
+    local.get $2
+    local.get $6
     i32.gt_s
     select
     memory.grow $0
     i32.const 0
     i32.lt_s
     if
-     local.get $4
+     local.get $6
      memory.grow $0
      i32.const 0
      i32.lt_s
@@ -1488,8 +1491,8 @@
       unreachable
      end
     end
-    local.get $7
-    local.get $1
+    local.get $5
+    local.get $2
     i32.const 16
     i32.shl
     memory.size $0
@@ -1497,10 +1500,10 @@
     i64.const 16
     i64.shl
     call $~lib/rt/tlsf/addMemory
-    local.get $7
+    local.get $5
     local.get $8
     call $~lib/rt/tlsf/searchBlock
-    local.tee $1
+    local.tee $2
     i32.eqz
     if
      i32.const 0
@@ -1512,7 +1515,7 @@
     end
    end
    local.get $8
-   local.get $1
+   local.get $2
    i32.load $0
    i32.const -4
    i32.and
@@ -1525,12 +1528,12 @@
     call $~lib/builtins/abort
     unreachable
    end
-   local.get $7
-   local.get $1
+   local.get $5
+   local.get $2
    call $~lib/rt/tlsf/removeBlock
-   local.get $1
+   local.get $2
    i32.load $0
-   local.set $4
+   local.set $6
    local.get $8
    i32.const 4
    i32.add
@@ -1544,7 +1547,7 @@
     call $~lib/builtins/abort
     unreachable
    end
-   local.get $4
+   local.get $6
    i32.const -4
    i32.and
    local.get $8
@@ -1553,80 +1556,80 @@
    i32.const 16
    i32.ge_u
    if
-    local.get $1
+    local.get $2
     local.get $8
-    local.get $4
+    local.get $6
     i32.const 2
     i32.and
     i32.or
     i32.store $0
-    local.get $1
+    local.get $2
     i32.const 4
     i32.add
     local.get $8
     i32.add
-    local.tee $4
+    local.tee $6
     local.get $9
     i32.const 4
     i32.sub
     i32.const 1
     i32.or
     i32.store $0
-    local.get $7
-    local.get $4
+    local.get $5
+    local.get $6
     call $~lib/rt/tlsf/insertBlock
    else
-    local.get $1
-    local.get $4
+    local.get $2
+    local.get $6
     i32.const -2
     i32.and
     i32.store $0
-    local.get $1
+    local.get $2
     i32.const 4
     i32.add
-    local.get $1
+    local.get $2
     i32.load $0
     i32.const -4
     i32.and
     i32.add
-    local.tee $4
-    local.get $4
+    local.tee $5
+    local.get $5
     i32.load $0
     i32.const -3
     i32.and
     i32.store $0
    end
-   local.get $1
+   local.get $2
    i32.const 2
    i32.store $0 offset=12
-   local.get $1
-   local.get $6
+   local.get $2
+   local.get $7
    i32.store $0 offset=16
    global.get $~lib/rt/itcms/fromSpace
-   local.tee $4
+   local.tee $5
    i32.load $0 offset=8
-   local.set $7
-   local.get $1
-   local.get $4
+   local.set $6
+   local.get $2
+   local.get $5
    global.get $~lib/rt/itcms/white
    i32.or
    i32.store $0 offset=4
-   local.get $1
-   local.get $7
+   local.get $2
+   local.get $6
    i32.store $0 offset=8
-   local.get $7
-   local.get $1
-   local.get $7
+   local.get $6
+   local.get $2
+   local.get $6
    i32.load $0 offset=4
    i32.const 3
    i32.and
    i32.or
    i32.store $0 offset=4
-   local.get $4
-   local.get $1
+   local.get $5
+   local.get $2
    i32.store $0 offset=8
    global.get $~lib/rt/itcms/total
-   local.get $1
+   local.get $2
    i32.load $0
    i32.const -4
    i32.and
@@ -1634,17 +1637,17 @@
    i32.add
    i32.add
    global.set $~lib/rt/itcms/total
-   local.get $1
+   local.get $2
    i32.const 20
    i32.add
-   local.tee $1
+   local.tee $2
    i32.const 0
-   local.get $6
+   local.get $7
    memory.fill $0
-   local.get $5
-   local.get $1
+   local.get $4
+   local.get $2
    i32.store $0
-   local.get $1
+   local.get $2
    local.get $3
    i32.add
    local.set $4
@@ -1662,10 +1665,10 @@
      i32.div_u
      local.set $0
      local.get $4
-     local.get $2
+     local.get $1
      i32.const 4
      i32.sub
-     local.tee $2
+     local.tee $1
      i32.const 1
      i32.shl
      i32.add
@@ -1697,10 +1700,10 @@
    i32.ge_u
    if
     local.get $4
-    local.get $2
+    local.get $1
     i32.const 2
     i32.sub
-    local.tee $2
+    local.tee $1
     i32.const 1
     i32.shl
     i32.add
@@ -1723,7 +1726,7 @@
    i32.ge_u
    if
     local.get $4
-    local.get $2
+    local.get $1
     i32.const 2
     i32.sub
     i32.const 1
@@ -1738,7 +1741,7 @@
     i32.store $0
    else
     local.get $4
-    local.get $2
+    local.get $1
     i32.const 1
     i32.sub
     i32.const 1
@@ -1751,7 +1754,7 @@
    end
    local.get $3
    if
-    local.get $1
+    local.get $2
     i32.const 45
     i32.store16 $0
    end
@@ -1760,7 +1763,7 @@
    i32.add
    global.set $~lib/memory/__stack_pointer
   end
-  local.get $1
+  local.get $2
  )
  (func $~lib/rt/__visit_members (param $0 i32)
   (local $1 i32)

--- a/tests/compiler/resolve-function-expression.release.wat
+++ b/tests/compiler/resolve-function-expression.release.wat
@@ -661,7 +661,7 @@
   if
    i32.const 0
    i32.const 1792
-   i32.const 378
+   i32.const 382
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -686,7 +686,7 @@
    if
     i32.const 0
     i32.const 1792
-    i32.const 385
+    i32.const 389
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -714,7 +714,7 @@
    if
     i32.const 0
     i32.const 1792
-    i32.const 398
+    i32.const 402
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1081,7 +1081,7 @@
       if
        i32.const 0
        i32.const 1792
-       i32.const 560
+       i32.const 562
        i32.const 3
        call $~lib/builtins/abort
        unreachable
@@ -1165,7 +1165,7 @@
   if
    i32.const 0
    i32.const 1792
-   i32.const 330
+   i32.const 334
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1217,7 +1217,7 @@
     if
      i32.const 0
      i32.const 1792
-     i32.const 343
+     i32.const 347
      i32.const 18
      call $~lib/builtins/abort
      unreachable
@@ -1342,7 +1342,7 @@
    i32.shl
    local.get $3
    i32.add
-   local.tee $7
+   local.tee $6
    i32.const 1073741804
    i32.ge_u
    if
@@ -1404,8 +1404,8 @@
     call $~lib/rt/tlsf/initialize
    end
    global.get $~lib/rt/tlsf/ROOT
-   local.set $5
-   local.get $7
+   local.set $7
+   local.get $6
    i32.const 16
    i32.add
    local.tee $2
@@ -1414,12 +1414,12 @@
    if
     i32.const 1456
     i32.const 1792
-    i32.const 459
+    i32.const 461
     i32.const 29
     call $~lib/builtins/abort
     unreachable
    end
-   local.get $5
+   local.get $7
    i32.const 12
    local.get $2
    i32.const 19
@@ -1440,8 +1440,29 @@
     memory.size $0
     local.tee $2
     local.get $8
+    i32.const 256
+    i32.gt_u
+    if (result i32)
+     local.get $8
+     i32.const 1
+     i32.const 27
+     local.get $8
+     i32.clz
+     i32.sub
+     i32.shl
+     i32.add
+     i32.const 1
+     i32.sub
+     local.get $8
+     local.get $8
+     i32.const 536870910
+     i32.lt_u
+     select
+    else
+     local.get $8
+    end
     i32.const 4
-    local.get $5
+    local.get $7
     i32.load $0 offset=1568
     local.get $2
     i32.const 16
@@ -1451,39 +1472,22 @@
     i32.ne
     i32.shl
     i32.add
-    local.tee $6
-    i32.const 536870910
-    i32.lt_u
-    if (result i32)
-     local.get $6
-     i32.const 1
-     i32.const 27
-     local.get $6
-     i32.clz
-     i32.sub
-     i32.shl
-     i32.const 1
-     i32.sub
-     i32.add
-    else
-     local.get $6
-    end
     i32.const 65535
     i32.add
     i32.const -65536
     i32.and
     i32.const 16
     i32.shr_u
-    local.tee $6
+    local.tee $5
     local.get $2
-    local.get $6
+    local.get $5
     i32.gt_s
     select
     memory.grow $0
     i32.const 0
     i32.lt_s
     if
-     local.get $6
+     local.get $5
      memory.grow $0
      i32.const 0
      i32.lt_s
@@ -1491,7 +1495,7 @@
       unreachable
      end
     end
-    local.get $5
+    local.get $7
     local.get $2
     i32.const 16
     i32.shl
@@ -1500,7 +1504,7 @@
     i64.const 16
     i64.shl
     call $~lib/rt/tlsf/addMemory
-    local.get $5
+    local.get $7
     local.get $8
     call $~lib/rt/tlsf/searchBlock
     local.tee $2
@@ -1508,7 +1512,7 @@
     if
      i32.const 0
      i32.const 1792
-     i32.const 497
+     i32.const 499
      i32.const 16
      call $~lib/builtins/abort
      unreachable
@@ -1523,17 +1527,17 @@
    if
     i32.const 0
     i32.const 1792
-    i32.const 499
+    i32.const 501
     i32.const 14
     call $~lib/builtins/abort
     unreachable
    end
-   local.get $5
+   local.get $7
    local.get $2
    call $~lib/rt/tlsf/removeBlock
    local.get $2
    i32.load $0
-   local.set $6
+   local.set $9
    local.get $8
    i32.const 4
    i32.add
@@ -1542,23 +1546,23 @@
    if
     i32.const 0
     i32.const 1792
-    i32.const 357
+    i32.const 361
     i32.const 14
     call $~lib/builtins/abort
     unreachable
    end
-   local.get $6
+   local.get $9
    i32.const -4
    i32.and
    local.get $8
    i32.sub
-   local.tee $9
+   local.tee $5
    i32.const 16
    i32.ge_u
    if
     local.get $2
     local.get $8
-    local.get $6
+    local.get $9
     i32.const 2
     i32.and
     i32.or
@@ -1568,19 +1572,19 @@
     i32.add
     local.get $8
     i32.add
-    local.tee $6
-    local.get $9
+    local.tee $8
+    local.get $5
     i32.const 4
     i32.sub
     i32.const 1
     i32.or
     i32.store $0
-    local.get $5
-    local.get $6
+    local.get $7
+    local.get $8
     call $~lib/rt/tlsf/insertBlock
    else
     local.get $2
-    local.get $6
+    local.get $9
     i32.const -2
     i32.and
     i32.store $0
@@ -1603,23 +1607,23 @@
    i32.const 2
    i32.store $0 offset=12
    local.get $2
-   local.get $7
+   local.get $6
    i32.store $0 offset=16
    global.get $~lib/rt/itcms/fromSpace
    local.tee $5
    i32.load $0 offset=8
-   local.set $6
+   local.set $7
    local.get $2
    local.get $5
    global.get $~lib/rt/itcms/white
    i32.or
    i32.store $0 offset=4
    local.get $2
-   local.get $6
+   local.get $7
    i32.store $0 offset=8
-   local.get $6
+   local.get $7
    local.get $2
-   local.get $6
+   local.get $7
    i32.load $0 offset=4
    i32.const 3
    i32.and
@@ -1642,7 +1646,7 @@
    i32.add
    local.tee $2
    i32.const 0
-   local.get $7
+   local.get $6
    memory.fill $0
    local.get $4
    local.get $2

--- a/tests/compiler/resolve-new.debug.wat
+++ b/tests/compiler/resolve-new.debug.wat
@@ -1912,22 +1912,6 @@
   (local $pagesAfter i32)
   i32.const 0
   drop
-  local.get $size
-  i32.const 536870910
-  i32.lt_u
-  if
-   local.get $size
-   i32.const 1
-   i32.const 27
-   local.get $size
-   i32.clz
-   i32.sub
-   i32.shl
-   i32.const 1
-   i32.sub
-   i32.add
-   local.set $size
-  end
   memory.size $0
   local.set $pagesBefore
   local.get $size
@@ -1948,6 +1932,22 @@
   i32.shl
   i32.add
   local.set $size
+  local.get $size
+  i32.const 536870910
+  i32.lt_u
+  if
+   local.get $size
+   i32.const 1
+   i32.const 27
+   local.get $size
+   i32.clz
+   i32.sub
+   i32.shl
+   i32.const 1
+   i32.sub
+   i32.add
+   local.set $size
+  end
   local.get $size
   i32.const 65535
   i32.add

--- a/tests/compiler/resolve-new.debug.wat
+++ b/tests/compiler/resolve-new.debug.wat
@@ -1033,7 +1033,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 378
+   i32.const 382
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1079,7 +1079,7 @@
    if
     i32.const 0
     i32.const 368
-    i32.const 385
+    i32.const 389
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1112,7 +1112,7 @@
    if
     i32.const 0
     i32.const 368
-    i32.const 398
+    i32.const 402
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1356,7 +1356,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 560
+   i32.const 562
    i32.const 3
    call $~lib/builtins/abort
    unreachable
@@ -1685,13 +1685,33 @@
   if
    i32.const 32
    i32.const 368
-   i32.const 459
+   i32.const 461
    i32.const 29
    call $~lib/builtins/abort
    unreachable
   end
   local.get $size
   call $~lib/rt/tlsf/computeSize
+  return
+ )
+ (func $~lib/rt/tlsf/roundSize (param $size i32) (result i32)
+  local.get $size
+  i32.const 536870910
+  i32.lt_u
+  if (result i32)
+   local.get $size
+   i32.const 1
+   i32.const 27
+   local.get $size
+   i32.clz
+   i32.sub
+   i32.shl
+   i32.add
+   i32.const 1
+   i32.sub
+  else
+   local.get $size
+  end
   return
  )
  (func $~lib/rt/tlsf/searchBlock (param $root i32) (param $size i32) (result i32)
@@ -1723,24 +1743,13 @@
    local.set $sl
   else
    local.get $size
-   i32.const 536870910
-   i32.lt_u
-   if (result i32)
-    local.get $size
-    i32.const 1
-    i32.const 27
-    local.get $size
-    i32.clz
-    i32.sub
-    i32.shl
-    i32.add
-    i32.const 1
-    i32.sub
-   else
-    local.get $size
-   end
+   call $~lib/rt/tlsf/roundSize
    local.set $requestSize
-   i32.const 31
+   i32.const 4
+   i32.const 8
+   i32.mul
+   i32.const 1
+   i32.sub
    local.get $requestSize
    i32.clz
    i32.sub
@@ -1778,7 +1787,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 330
+   i32.const 334
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1849,7 +1858,7 @@
     if
      i32.const 0
      i32.const 368
-     i32.const 343
+     i32.const 347
      i32.const 18
      call $~lib/builtins/abort
      unreachable
@@ -1912,6 +1921,14 @@
   (local $pagesAfter i32)
   i32.const 0
   drop
+  local.get $size
+  i32.const 256
+  i32.gt_u
+  if
+   local.get $size
+   call $~lib/rt/tlsf/roundSize
+   local.set $size
+  end
   memory.size $0
   local.set $pagesBefore
   local.get $size
@@ -1932,22 +1949,6 @@
   i32.shl
   i32.add
   local.set $size
-  local.get $size
-  i32.const 536870910
-  i32.lt_u
-  if
-   local.get $size
-   i32.const 1
-   i32.const 27
-   local.get $size
-   i32.clz
-   i32.sub
-   i32.shl
-   i32.const 1
-   i32.sub
-   i32.add
-   local.set $size
-  end
   local.get $size
   i32.const 65535
   i32.add
@@ -2014,7 +2015,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 357
+   i32.const 361
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -2129,7 +2130,7 @@
    if
     i32.const 0
     i32.const 368
-    i32.const 497
+    i32.const 499
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -2149,7 +2150,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 499
+   i32.const 501
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/resolve-new.debug.wat
+++ b/tests/compiler/resolve-new.debug.wat
@@ -1923,7 +1923,7 @@
   drop
   local.get $size
   i32.const 256
-  i32.gt_u
+  i32.ge_u
   if
    local.get $size
    call $~lib/rt/tlsf/roundSize

--- a/tests/compiler/resolve-new.release.wat
+++ b/tests/compiler/resolve-new.release.wat
@@ -625,7 +625,7 @@
   if
    i32.const 0
    i32.const 1392
-   i32.const 378
+   i32.const 382
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -650,7 +650,7 @@
    if
     i32.const 0
     i32.const 1392
-    i32.const 385
+    i32.const 389
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -678,7 +678,7 @@
    if
     i32.const 0
     i32.const 1392
-    i32.const 398
+    i32.const 402
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1045,7 +1045,7 @@
       if
        i32.const 0
        i32.const 1392
-       i32.const 560
+       i32.const 562
        i32.const 3
        call $~lib/builtins/abort
        unreachable
@@ -1112,7 +1112,7 @@
     if
      i32.const 0
      i32.const 1392
-     i32.const 343
+     i32.const 347
      i32.const 18
      call $~lib/builtins/abort
      unreachable
@@ -1196,8 +1196,6 @@
   if
    memory.size $0
    local.tee $1
-   i32.const 1
-   i32.const 27
    i32.const 4
    local.get $2
    i32.load $0 offset=1568
@@ -1208,22 +1206,7 @@
    i32.sub
    i32.ne
    i32.shl
-   i32.const 28
-   i32.add
-   local.tee $3
-   i32.clz
-   i32.sub
-   i32.shl
-   i32.const 1
-   i32.sub
-   local.get $3
-   i32.add
-   local.get $3
-   local.get $3
-   i32.const 536870910
-   i32.lt_u
-   select
-   i32.const 65535
+   i32.const 65563
    i32.add
    i32.const -65536
    i32.and
@@ -1262,7 +1245,7 @@
    if
     i32.const 0
     i32.const 1392
-    i32.const 497
+    i32.const 499
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1277,7 +1260,7 @@
   if
    i32.const 0
    i32.const 1392
-   i32.const 499
+   i32.const 501
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/resolve-new.release.wat
+++ b/tests/compiler/resolve-new.release.wat
@@ -1196,6 +1196,8 @@
   if
    memory.size $0
    local.tee $1
+   i32.const 1
+   i32.const 27
    i32.const 4
    local.get $2
    i32.load $0 offset=1568
@@ -1206,7 +1208,22 @@
    i32.sub
    i32.ne
    i32.shl
-   i32.const 65563
+   i32.const 28
+   i32.add
+   local.tee $3
+   i32.clz
+   i32.sub
+   i32.shl
+   i32.const 1
+   i32.sub
+   local.get $3
+   i32.add
+   local.get $3
+   local.get $3
+   i32.const 536870910
+   i32.lt_u
+   select
+   i32.const 65535
    i32.add
    i32.const -65536
    i32.and

--- a/tests/compiler/resolve-propertyaccess.debug.wat
+++ b/tests/compiler/resolve-propertyaccess.debug.wat
@@ -1120,7 +1120,7 @@
   if
    i32.const 0
    i32.const 592
-   i32.const 378
+   i32.const 382
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1166,7 +1166,7 @@
    if
     i32.const 0
     i32.const 592
-    i32.const 385
+    i32.const 389
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1199,7 +1199,7 @@
    if
     i32.const 0
     i32.const 592
-    i32.const 398
+    i32.const 402
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1443,7 +1443,7 @@
   if
    i32.const 0
    i32.const 592
-   i32.const 560
+   i32.const 562
    i32.const 3
    call $~lib/builtins/abort
    unreachable
@@ -1772,13 +1772,33 @@
   if
    i32.const 256
    i32.const 592
-   i32.const 459
+   i32.const 461
    i32.const 29
    call $~lib/builtins/abort
    unreachable
   end
   local.get $size
   call $~lib/rt/tlsf/computeSize
+  return
+ )
+ (func $~lib/rt/tlsf/roundSize (param $size i32) (result i32)
+  local.get $size
+  i32.const 536870910
+  i32.lt_u
+  if (result i32)
+   local.get $size
+   i32.const 1
+   i32.const 27
+   local.get $size
+   i32.clz
+   i32.sub
+   i32.shl
+   i32.add
+   i32.const 1
+   i32.sub
+  else
+   local.get $size
+  end
   return
  )
  (func $~lib/rt/tlsf/searchBlock (param $root i32) (param $size i32) (result i32)
@@ -1810,24 +1830,13 @@
    local.set $sl
   else
    local.get $size
-   i32.const 536870910
-   i32.lt_u
-   if (result i32)
-    local.get $size
-    i32.const 1
-    i32.const 27
-    local.get $size
-    i32.clz
-    i32.sub
-    i32.shl
-    i32.add
-    i32.const 1
-    i32.sub
-   else
-    local.get $size
-   end
+   call $~lib/rt/tlsf/roundSize
    local.set $requestSize
-   i32.const 31
+   i32.const 4
+   i32.const 8
+   i32.mul
+   i32.const 1
+   i32.sub
    local.get $requestSize
    i32.clz
    i32.sub
@@ -1865,7 +1874,7 @@
   if
    i32.const 0
    i32.const 592
-   i32.const 330
+   i32.const 334
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1936,7 +1945,7 @@
     if
      i32.const 0
      i32.const 592
-     i32.const 343
+     i32.const 347
      i32.const 18
      call $~lib/builtins/abort
      unreachable
@@ -1999,6 +2008,14 @@
   (local $pagesAfter i32)
   i32.const 0
   drop
+  local.get $size
+  i32.const 256
+  i32.gt_u
+  if
+   local.get $size
+   call $~lib/rt/tlsf/roundSize
+   local.set $size
+  end
   memory.size $0
   local.set $pagesBefore
   local.get $size
@@ -2019,22 +2036,6 @@
   i32.shl
   i32.add
   local.set $size
-  local.get $size
-  i32.const 536870910
-  i32.lt_u
-  if
-   local.get $size
-   i32.const 1
-   i32.const 27
-   local.get $size
-   i32.clz
-   i32.sub
-   i32.shl
-   i32.const 1
-   i32.sub
-   i32.add
-   local.set $size
-  end
   local.get $size
   i32.const 65535
   i32.add
@@ -2101,7 +2102,7 @@
   if
    i32.const 0
    i32.const 592
-   i32.const 357
+   i32.const 361
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -2216,7 +2217,7 @@
    if
     i32.const 0
     i32.const 592
-    i32.const 497
+    i32.const 499
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -2236,7 +2237,7 @@
   if
    i32.const 0
    i32.const 592
-   i32.const 499
+   i32.const 501
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/resolve-propertyaccess.debug.wat
+++ b/tests/compiler/resolve-propertyaccess.debug.wat
@@ -2010,7 +2010,7 @@
   drop
   local.get $size
   i32.const 256
-  i32.gt_u
+  i32.ge_u
   if
    local.get $size
    call $~lib/rt/tlsf/roundSize

--- a/tests/compiler/resolve-propertyaccess.debug.wat
+++ b/tests/compiler/resolve-propertyaccess.debug.wat
@@ -1999,22 +1999,6 @@
   (local $pagesAfter i32)
   i32.const 0
   drop
-  local.get $size
-  i32.const 536870910
-  i32.lt_u
-  if
-   local.get $size
-   i32.const 1
-   i32.const 27
-   local.get $size
-   i32.clz
-   i32.sub
-   i32.shl
-   i32.const 1
-   i32.sub
-   i32.add
-   local.set $size
-  end
   memory.size $0
   local.set $pagesBefore
   local.get $size
@@ -2035,6 +2019,22 @@
   i32.shl
   i32.add
   local.set $size
+  local.get $size
+  i32.const 536870910
+  i32.lt_u
+  if
+   local.get $size
+   i32.const 1
+   i32.const 27
+   local.get $size
+   i32.clz
+   i32.sub
+   i32.shl
+   i32.const 1
+   i32.sub
+   i32.add
+   local.set $size
+  end
   local.get $size
   i32.const 65535
   i32.add

--- a/tests/compiler/resolve-propertyaccess.release.wat
+++ b/tests/compiler/resolve-propertyaccess.release.wat
@@ -1342,7 +1342,7 @@
    local.tee $2
    local.get $5
    i32.const 256
-   i32.gt_u
+   i32.ge_u
    if (result i32)
     local.get $5
     i32.const 1

--- a/tests/compiler/resolve-propertyaccess.release.wat
+++ b/tests/compiler/resolve-propertyaccess.release.wat
@@ -660,7 +660,7 @@
   if
    i32.const 0
    i32.const 1616
-   i32.const 378
+   i32.const 382
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -685,7 +685,7 @@
    if
     i32.const 0
     i32.const 1616
-    i32.const 385
+    i32.const 389
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -713,7 +713,7 @@
    if
     i32.const 0
     i32.const 1616
-    i32.const 398
+    i32.const 402
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1080,7 +1080,7 @@
       if
        i32.const 0
        i32.const 1616
-       i32.const 560
+       i32.const 562
        i32.const 3
        call $~lib/builtins/abort
        unreachable
@@ -1164,7 +1164,7 @@
   if
    i32.const 0
    i32.const 1616
-   i32.const 330
+   i32.const 334
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1216,7 +1216,7 @@
     if
      i32.const 0
      i32.const 1616
-     i32.const 343
+     i32.const 347
      i32.const 18
      call $~lib/builtins/abort
      unreachable
@@ -1305,7 +1305,7 @@
    call $~lib/rt/tlsf/initialize
   end
   global.get $~lib/rt/tlsf/ROOT
-  local.set $3
+  local.set $4
   local.get $0
   i32.const 16
   i32.add
@@ -1315,12 +1315,12 @@
   if
    i32.const 1280
    i32.const 1616
-   i32.const 459
+   i32.const 461
    i32.const 29
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $3
+  local.get $4
   i32.const 12
   local.get $2
   i32.const 19
@@ -1341,8 +1341,29 @@
    memory.size $0
    local.tee $2
    local.get $5
+   i32.const 256
+   i32.gt_u
+   if (result i32)
+    local.get $5
+    i32.const 1
+    i32.const 27
+    local.get $5
+    i32.clz
+    i32.sub
+    i32.shl
+    i32.add
+    i32.const 1
+    i32.sub
+    local.get $5
+    local.get $5
+    i32.const 536870910
+    i32.lt_u
+    select
+   else
+    local.get $5
+   end
    i32.const 4
-   local.get $3
+   local.get $4
    i32.load $0 offset=1568
    local.get $2
    i32.const 16
@@ -1352,39 +1373,22 @@
    i32.ne
    i32.shl
    i32.add
-   local.tee $4
-   i32.const 536870910
-   i32.lt_u
-   if (result i32)
-    local.get $4
-    i32.const 1
-    i32.const 27
-    local.get $4
-    i32.clz
-    i32.sub
-    i32.shl
-    i32.const 1
-    i32.sub
-    i32.add
-   else
-    local.get $4
-   end
    i32.const 65535
    i32.add
    i32.const -65536
    i32.and
    i32.const 16
    i32.shr_u
-   local.tee $4
+   local.tee $3
    local.get $2
-   local.get $4
+   local.get $3
    i32.gt_s
    select
    memory.grow $0
    i32.const 0
    i32.lt_s
    if
-    local.get $4
+    local.get $3
     memory.grow $0
     i32.const 0
     i32.lt_s
@@ -1392,7 +1396,7 @@
      unreachable
     end
    end
-   local.get $3
+   local.get $4
    local.get $2
    i32.const 16
    i32.shl
@@ -1401,7 +1405,7 @@
    i64.const 16
    i64.shl
    call $~lib/rt/tlsf/addMemory
-   local.get $3
+   local.get $4
    local.get $5
    call $~lib/rt/tlsf/searchBlock
    local.tee $2
@@ -1409,7 +1413,7 @@
    if
     i32.const 0
     i32.const 1616
-    i32.const 497
+    i32.const 499
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1424,17 +1428,17 @@
   if
    i32.const 0
    i32.const 1616
-   i32.const 499
+   i32.const 501
    i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $3
+  local.get $4
   local.get $2
   call $~lib/rt/tlsf/removeBlock
   local.get $2
   i32.load $0
-  local.set $4
+  local.set $3
   local.get $5
   i32.const 4
   i32.add
@@ -1443,12 +1447,12 @@
   if
    i32.const 0
    i32.const 1616
-   i32.const 357
+   i32.const 361
    i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $4
+  local.get $3
   i32.const -4
   i32.and
   local.get $5
@@ -1459,7 +1463,7 @@
   if
    local.get $2
    local.get $5
-   local.get $4
+   local.get $3
    i32.const 2
    i32.and
    i32.or
@@ -1469,19 +1473,19 @@
    i32.add
    local.get $5
    i32.add
-   local.tee $4
+   local.tee $3
    local.get $6
    i32.const 4
    i32.sub
    i32.const 1
    i32.or
    i32.store $0
-   local.get $3
    local.get $4
+   local.get $3
    call $~lib/rt/tlsf/insertBlock
   else
    local.get $2
-   local.get $4
+   local.get $3
    i32.const -2
    i32.and
    i32.store $0

--- a/tests/compiler/resolve-propertyaccess.release.wat
+++ b/tests/compiler/resolve-propertyaccess.release.wat
@@ -1305,7 +1305,7 @@
    call $~lib/rt/tlsf/initialize
   end
   global.get $~lib/rt/tlsf/ROOT
-  local.set $4
+  local.set $3
   local.get $0
   i32.const 16
   i32.add
@@ -1320,7 +1320,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $4
+  local.get $3
   i32.const 12
   local.get $2
   i32.const 19
@@ -1340,8 +1340,9 @@
   if
    memory.size $0
    local.tee $2
+   local.get $5
    i32.const 4
-   local.get $4
+   local.get $3
    i32.load $0 offset=1568
    local.get $2
    i32.const 16
@@ -1350,38 +1351,40 @@
    i32.sub
    i32.ne
    i32.shl
-   local.get $5
-   i32.const 1
-   i32.const 27
-   local.get $5
-   i32.clz
-   i32.sub
-   i32.shl
-   i32.const 1
-   i32.sub
    i32.add
-   local.get $5
-   local.get $5
+   local.tee $4
    i32.const 536870910
    i32.lt_u
-   select
-   i32.add
+   if (result i32)
+    local.get $4
+    i32.const 1
+    i32.const 27
+    local.get $4
+    i32.clz
+    i32.sub
+    i32.shl
+    i32.const 1
+    i32.sub
+    i32.add
+   else
+    local.get $4
+   end
    i32.const 65535
    i32.add
    i32.const -65536
    i32.and
    i32.const 16
    i32.shr_u
-   local.tee $3
+   local.tee $4
    local.get $2
-   local.get $3
+   local.get $4
    i32.gt_s
    select
    memory.grow $0
    i32.const 0
    i32.lt_s
    if
-    local.get $3
+    local.get $4
     memory.grow $0
     i32.const 0
     i32.lt_s
@@ -1389,7 +1392,7 @@
      unreachable
     end
    end
-   local.get $4
+   local.get $3
    local.get $2
    i32.const 16
    i32.shl
@@ -1398,7 +1401,7 @@
    i64.const 16
    i64.shl
    call $~lib/rt/tlsf/addMemory
-   local.get $4
+   local.get $3
    local.get $5
    call $~lib/rt/tlsf/searchBlock
    local.tee $2
@@ -1426,12 +1429,12 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $4
+  local.get $3
   local.get $2
   call $~lib/rt/tlsf/removeBlock
   local.get $2
   i32.load $0
-  local.set $3
+  local.set $4
   local.get $5
   i32.const 4
   i32.add
@@ -1445,7 +1448,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $3
+  local.get $4
   i32.const -4
   i32.and
   local.get $5
@@ -1456,7 +1459,7 @@
   if
    local.get $2
    local.get $5
-   local.get $3
+   local.get $4
    i32.const 2
    i32.and
    i32.or
@@ -1466,19 +1469,19 @@
    i32.add
    local.get $5
    i32.add
-   local.tee $3
+   local.tee $4
    local.get $6
    i32.const 4
    i32.sub
    i32.const 1
    i32.or
    i32.store $0
-   local.get $4
    local.get $3
+   local.get $4
    call $~lib/rt/tlsf/insertBlock
   else
    local.get $2
-   local.get $3
+   local.get $4
    i32.const -2
    i32.and
    i32.store $0

--- a/tests/compiler/resolve-ternary.debug.wat
+++ b/tests/compiler/resolve-ternary.debug.wat
@@ -1128,7 +1128,7 @@
   if
    i32.const 0
    i32.const 592
-   i32.const 378
+   i32.const 382
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1174,7 +1174,7 @@
    if
     i32.const 0
     i32.const 592
-    i32.const 385
+    i32.const 389
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1207,7 +1207,7 @@
    if
     i32.const 0
     i32.const 592
-    i32.const 398
+    i32.const 402
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1451,7 +1451,7 @@
   if
    i32.const 0
    i32.const 592
-   i32.const 560
+   i32.const 562
    i32.const 3
    call $~lib/builtins/abort
    unreachable
@@ -1780,13 +1780,33 @@
   if
    i32.const 256
    i32.const 592
-   i32.const 459
+   i32.const 461
    i32.const 29
    call $~lib/builtins/abort
    unreachable
   end
   local.get $size
   call $~lib/rt/tlsf/computeSize
+  return
+ )
+ (func $~lib/rt/tlsf/roundSize (param $size i32) (result i32)
+  local.get $size
+  i32.const 536870910
+  i32.lt_u
+  if (result i32)
+   local.get $size
+   i32.const 1
+   i32.const 27
+   local.get $size
+   i32.clz
+   i32.sub
+   i32.shl
+   i32.add
+   i32.const 1
+   i32.sub
+  else
+   local.get $size
+  end
   return
  )
  (func $~lib/rt/tlsf/searchBlock (param $root i32) (param $size i32) (result i32)
@@ -1818,24 +1838,13 @@
    local.set $sl
   else
    local.get $size
-   i32.const 536870910
-   i32.lt_u
-   if (result i32)
-    local.get $size
-    i32.const 1
-    i32.const 27
-    local.get $size
-    i32.clz
-    i32.sub
-    i32.shl
-    i32.add
-    i32.const 1
-    i32.sub
-   else
-    local.get $size
-   end
+   call $~lib/rt/tlsf/roundSize
    local.set $requestSize
-   i32.const 31
+   i32.const 4
+   i32.const 8
+   i32.mul
+   i32.const 1
+   i32.sub
    local.get $requestSize
    i32.clz
    i32.sub
@@ -1873,7 +1882,7 @@
   if
    i32.const 0
    i32.const 592
-   i32.const 330
+   i32.const 334
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1944,7 +1953,7 @@
     if
      i32.const 0
      i32.const 592
-     i32.const 343
+     i32.const 347
      i32.const 18
      call $~lib/builtins/abort
      unreachable
@@ -2007,6 +2016,14 @@
   (local $pagesAfter i32)
   i32.const 0
   drop
+  local.get $size
+  i32.const 256
+  i32.gt_u
+  if
+   local.get $size
+   call $~lib/rt/tlsf/roundSize
+   local.set $size
+  end
   memory.size $0
   local.set $pagesBefore
   local.get $size
@@ -2027,22 +2044,6 @@
   i32.shl
   i32.add
   local.set $size
-  local.get $size
-  i32.const 536870910
-  i32.lt_u
-  if
-   local.get $size
-   i32.const 1
-   i32.const 27
-   local.get $size
-   i32.clz
-   i32.sub
-   i32.shl
-   i32.const 1
-   i32.sub
-   i32.add
-   local.set $size
-  end
   local.get $size
   i32.const 65535
   i32.add
@@ -2109,7 +2110,7 @@
   if
    i32.const 0
    i32.const 592
-   i32.const 357
+   i32.const 361
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -2224,7 +2225,7 @@
    if
     i32.const 0
     i32.const 592
-    i32.const 497
+    i32.const 499
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -2244,7 +2245,7 @@
   if
    i32.const 0
    i32.const 592
-   i32.const 499
+   i32.const 501
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/resolve-ternary.debug.wat
+++ b/tests/compiler/resolve-ternary.debug.wat
@@ -2018,7 +2018,7 @@
   drop
   local.get $size
   i32.const 256
-  i32.gt_u
+  i32.ge_u
   if
    local.get $size
    call $~lib/rt/tlsf/roundSize

--- a/tests/compiler/resolve-ternary.debug.wat
+++ b/tests/compiler/resolve-ternary.debug.wat
@@ -2007,22 +2007,6 @@
   (local $pagesAfter i32)
   i32.const 0
   drop
-  local.get $size
-  i32.const 536870910
-  i32.lt_u
-  if
-   local.get $size
-   i32.const 1
-   i32.const 27
-   local.get $size
-   i32.clz
-   i32.sub
-   i32.shl
-   i32.const 1
-   i32.sub
-   i32.add
-   local.set $size
-  end
   memory.size $0
   local.set $pagesBefore
   local.get $size
@@ -2043,6 +2027,22 @@
   i32.shl
   i32.add
   local.set $size
+  local.get $size
+  i32.const 536870910
+  i32.lt_u
+  if
+   local.get $size
+   i32.const 1
+   i32.const 27
+   local.get $size
+   i32.clz
+   i32.sub
+   i32.shl
+   i32.const 1
+   i32.sub
+   i32.add
+   local.set $size
+  end
   local.get $size
   i32.const 65535
   i32.add

--- a/tests/compiler/resolve-ternary.release.wat
+++ b/tests/compiler/resolve-ternary.release.wat
@@ -1348,7 +1348,7 @@
    local.tee $1
    local.get $4
    i32.const 256
-   i32.gt_u
+   i32.ge_u
    if (result i32)
     local.get $4
     i32.const 1

--- a/tests/compiler/resolve-ternary.release.wat
+++ b/tests/compiler/resolve-ternary.release.wat
@@ -666,7 +666,7 @@
   if
    i32.const 0
    i32.const 1616
-   i32.const 378
+   i32.const 382
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -691,7 +691,7 @@
    if
     i32.const 0
     i32.const 1616
-    i32.const 385
+    i32.const 389
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -719,7 +719,7 @@
    if
     i32.const 0
     i32.const 1616
-    i32.const 398
+    i32.const 402
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1086,7 +1086,7 @@
       if
        i32.const 0
        i32.const 1616
-       i32.const 560
+       i32.const 562
        i32.const 3
        call $~lib/builtins/abort
        unreachable
@@ -1170,7 +1170,7 @@
   if
    i32.const 0
    i32.const 1616
-   i32.const 330
+   i32.const 334
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1222,7 +1222,7 @@
     if
      i32.const 0
      i32.const 1616
-     i32.const 343
+     i32.const 347
      i32.const 18
      call $~lib/builtins/abort
      unreachable
@@ -1311,7 +1311,7 @@
    call $~lib/rt/tlsf/initialize
   end
   global.get $~lib/rt/tlsf/ROOT
-  local.set $2
+  local.set $3
   local.get $0
   i32.const 16
   i32.add
@@ -1321,12 +1321,12 @@
   if
    i32.const 1280
    i32.const 1616
-   i32.const 459
+   i32.const 461
    i32.const 29
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $2
+  local.get $3
   i32.const 12
   local.get $1
   i32.const 19
@@ -1347,8 +1347,29 @@
    memory.size $0
    local.tee $1
    local.get $4
+   i32.const 256
+   i32.gt_u
+   if (result i32)
+    local.get $4
+    i32.const 1
+    i32.const 27
+    local.get $4
+    i32.clz
+    i32.sub
+    i32.shl
+    i32.add
+    i32.const 1
+    i32.sub
+    local.get $4
+    local.get $4
+    i32.const 536870910
+    i32.lt_u
+    select
+   else
+    local.get $4
+   end
    i32.const 4
-   local.get $2
+   local.get $3
    i32.load $0 offset=1568
    local.get $1
    i32.const 16
@@ -1358,39 +1379,22 @@
    i32.ne
    i32.shl
    i32.add
-   local.tee $3
-   i32.const 536870910
-   i32.lt_u
-   if (result i32)
-    local.get $3
-    i32.const 1
-    i32.const 27
-    local.get $3
-    i32.clz
-    i32.sub
-    i32.shl
-    i32.const 1
-    i32.sub
-    i32.add
-   else
-    local.get $3
-   end
    i32.const 65535
    i32.add
    i32.const -65536
    i32.and
    i32.const 16
    i32.shr_u
-   local.tee $3
+   local.tee $2
    local.get $1
-   local.get $3
+   local.get $2
    i32.gt_s
    select
    memory.grow $0
    i32.const 0
    i32.lt_s
    if
-    local.get $3
+    local.get $2
     memory.grow $0
     i32.const 0
     i32.lt_s
@@ -1398,7 +1402,7 @@
      unreachable
     end
    end
-   local.get $2
+   local.get $3
    local.get $1
    i32.const 16
    i32.shl
@@ -1407,7 +1411,7 @@
    i64.const 16
    i64.shl
    call $~lib/rt/tlsf/addMemory
-   local.get $2
+   local.get $3
    local.get $4
    call $~lib/rt/tlsf/searchBlock
    local.tee $1
@@ -1415,7 +1419,7 @@
    if
     i32.const 0
     i32.const 1616
-    i32.const 497
+    i32.const 499
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1430,17 +1434,17 @@
   if
    i32.const 0
    i32.const 1616
-   i32.const 499
+   i32.const 501
    i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $2
+  local.get $3
   local.get $1
   call $~lib/rt/tlsf/removeBlock
   local.get $1
   i32.load $0
-  local.set $3
+  local.set $2
   local.get $4
   i32.const 4
   i32.add
@@ -1449,12 +1453,12 @@
   if
    i32.const 0
    i32.const 1616
-   i32.const 357
+   i32.const 361
    i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $3
+  local.get $2
   i32.const -4
   i32.and
   local.get $4
@@ -1465,7 +1469,7 @@
   if
    local.get $1
    local.get $4
-   local.get $3
+   local.get $2
    i32.const 2
    i32.and
    i32.or
@@ -1475,19 +1479,19 @@
    i32.add
    local.get $4
    i32.add
-   local.tee $3
+   local.tee $2
    local.get $5
    i32.const 4
    i32.sub
    i32.const 1
    i32.or
    i32.store $0
-   local.get $2
    local.get $3
+   local.get $2
    call $~lib/rt/tlsf/insertBlock
   else
    local.get $1
-   local.get $3
+   local.get $2
    i32.const -2
    i32.and
    i32.store $0

--- a/tests/compiler/resolve-ternary.release.wat
+++ b/tests/compiler/resolve-ternary.release.wat
@@ -1311,7 +1311,7 @@
    call $~lib/rt/tlsf/initialize
   end
   global.get $~lib/rt/tlsf/ROOT
-  local.set $3
+  local.set $2
   local.get $0
   i32.const 16
   i32.add
@@ -1326,7 +1326,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $3
+  local.get $2
   i32.const 12
   local.get $1
   i32.const 19
@@ -1346,8 +1346,9 @@
   if
    memory.size $0
    local.tee $1
+   local.get $4
    i32.const 4
-   local.get $3
+   local.get $2
    i32.load $0 offset=1568
    local.get $1
    i32.const 16
@@ -1356,38 +1357,40 @@
    i32.sub
    i32.ne
    i32.shl
-   local.get $4
-   i32.const 1
-   i32.const 27
-   local.get $4
-   i32.clz
-   i32.sub
-   i32.shl
-   i32.const 1
-   i32.sub
    i32.add
-   local.get $4
-   local.get $4
+   local.tee $3
    i32.const 536870910
    i32.lt_u
-   select
-   i32.add
+   if (result i32)
+    local.get $3
+    i32.const 1
+    i32.const 27
+    local.get $3
+    i32.clz
+    i32.sub
+    i32.shl
+    i32.const 1
+    i32.sub
+    i32.add
+   else
+    local.get $3
+   end
    i32.const 65535
    i32.add
    i32.const -65536
    i32.and
    i32.const 16
    i32.shr_u
-   local.tee $2
+   local.tee $3
    local.get $1
-   local.get $2
+   local.get $3
    i32.gt_s
    select
    memory.grow $0
    i32.const 0
    i32.lt_s
    if
-    local.get $2
+    local.get $3
     memory.grow $0
     i32.const 0
     i32.lt_s
@@ -1395,7 +1398,7 @@
      unreachable
     end
    end
-   local.get $3
+   local.get $2
    local.get $1
    i32.const 16
    i32.shl
@@ -1404,7 +1407,7 @@
    i64.const 16
    i64.shl
    call $~lib/rt/tlsf/addMemory
-   local.get $3
+   local.get $2
    local.get $4
    call $~lib/rt/tlsf/searchBlock
    local.tee $1
@@ -1432,12 +1435,12 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $3
+  local.get $2
   local.get $1
   call $~lib/rt/tlsf/removeBlock
   local.get $1
   i32.load $0
-  local.set $2
+  local.set $3
   local.get $4
   i32.const 4
   i32.add
@@ -1451,7 +1454,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $2
+  local.get $3
   i32.const -4
   i32.and
   local.get $4
@@ -1462,7 +1465,7 @@
   if
    local.get $1
    local.get $4
-   local.get $2
+   local.get $3
    i32.const 2
    i32.and
    i32.or
@@ -1472,19 +1475,19 @@
    i32.add
    local.get $4
    i32.add
-   local.tee $2
+   local.tee $3
    local.get $5
    i32.const 4
    i32.sub
    i32.const 1
    i32.or
    i32.store $0
-   local.get $3
    local.get $2
+   local.get $3
    call $~lib/rt/tlsf/insertBlock
   else
    local.get $1
-   local.get $2
+   local.get $3
    i32.const -2
    i32.and
    i32.store $0

--- a/tests/compiler/resolve-unary.debug.wat
+++ b/tests/compiler/resolve-unary.debug.wat
@@ -1120,7 +1120,7 @@
   if
    i32.const 0
    i32.const 592
-   i32.const 378
+   i32.const 382
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1166,7 +1166,7 @@
    if
     i32.const 0
     i32.const 592
-    i32.const 385
+    i32.const 389
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1199,7 +1199,7 @@
    if
     i32.const 0
     i32.const 592
-    i32.const 398
+    i32.const 402
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1443,7 +1443,7 @@
   if
    i32.const 0
    i32.const 592
-   i32.const 560
+   i32.const 562
    i32.const 3
    call $~lib/builtins/abort
    unreachable
@@ -1772,13 +1772,33 @@
   if
    i32.const 256
    i32.const 592
-   i32.const 459
+   i32.const 461
    i32.const 29
    call $~lib/builtins/abort
    unreachable
   end
   local.get $size
   call $~lib/rt/tlsf/computeSize
+  return
+ )
+ (func $~lib/rt/tlsf/roundSize (param $size i32) (result i32)
+  local.get $size
+  i32.const 536870910
+  i32.lt_u
+  if (result i32)
+   local.get $size
+   i32.const 1
+   i32.const 27
+   local.get $size
+   i32.clz
+   i32.sub
+   i32.shl
+   i32.add
+   i32.const 1
+   i32.sub
+  else
+   local.get $size
+  end
   return
  )
  (func $~lib/rt/tlsf/searchBlock (param $root i32) (param $size i32) (result i32)
@@ -1810,24 +1830,13 @@
    local.set $sl
   else
    local.get $size
-   i32.const 536870910
-   i32.lt_u
-   if (result i32)
-    local.get $size
-    i32.const 1
-    i32.const 27
-    local.get $size
-    i32.clz
-    i32.sub
-    i32.shl
-    i32.add
-    i32.const 1
-    i32.sub
-   else
-    local.get $size
-   end
+   call $~lib/rt/tlsf/roundSize
    local.set $requestSize
-   i32.const 31
+   i32.const 4
+   i32.const 8
+   i32.mul
+   i32.const 1
+   i32.sub
    local.get $requestSize
    i32.clz
    i32.sub
@@ -1865,7 +1874,7 @@
   if
    i32.const 0
    i32.const 592
-   i32.const 330
+   i32.const 334
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1936,7 +1945,7 @@
     if
      i32.const 0
      i32.const 592
-     i32.const 343
+     i32.const 347
      i32.const 18
      call $~lib/builtins/abort
      unreachable
@@ -1999,6 +2008,14 @@
   (local $pagesAfter i32)
   i32.const 0
   drop
+  local.get $size
+  i32.const 256
+  i32.gt_u
+  if
+   local.get $size
+   call $~lib/rt/tlsf/roundSize
+   local.set $size
+  end
   memory.size $0
   local.set $pagesBefore
   local.get $size
@@ -2019,22 +2036,6 @@
   i32.shl
   i32.add
   local.set $size
-  local.get $size
-  i32.const 536870910
-  i32.lt_u
-  if
-   local.get $size
-   i32.const 1
-   i32.const 27
-   local.get $size
-   i32.clz
-   i32.sub
-   i32.shl
-   i32.const 1
-   i32.sub
-   i32.add
-   local.set $size
-  end
   local.get $size
   i32.const 65535
   i32.add
@@ -2101,7 +2102,7 @@
   if
    i32.const 0
    i32.const 592
-   i32.const 357
+   i32.const 361
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -2216,7 +2217,7 @@
    if
     i32.const 0
     i32.const 592
-    i32.const 497
+    i32.const 499
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -2236,7 +2237,7 @@
   if
    i32.const 0
    i32.const 592
-   i32.const 499
+   i32.const 501
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/resolve-unary.debug.wat
+++ b/tests/compiler/resolve-unary.debug.wat
@@ -2010,7 +2010,7 @@
   drop
   local.get $size
   i32.const 256
-  i32.gt_u
+  i32.ge_u
   if
    local.get $size
    call $~lib/rt/tlsf/roundSize

--- a/tests/compiler/resolve-unary.debug.wat
+++ b/tests/compiler/resolve-unary.debug.wat
@@ -1999,22 +1999,6 @@
   (local $pagesAfter i32)
   i32.const 0
   drop
-  local.get $size
-  i32.const 536870910
-  i32.lt_u
-  if
-   local.get $size
-   i32.const 1
-   i32.const 27
-   local.get $size
-   i32.clz
-   i32.sub
-   i32.shl
-   i32.const 1
-   i32.sub
-   i32.add
-   local.set $size
-  end
   memory.size $0
   local.set $pagesBefore
   local.get $size
@@ -2035,6 +2019,22 @@
   i32.shl
   i32.add
   local.set $size
+  local.get $size
+  i32.const 536870910
+  i32.lt_u
+  if
+   local.get $size
+   i32.const 1
+   i32.const 27
+   local.get $size
+   i32.clz
+   i32.sub
+   i32.shl
+   i32.const 1
+   i32.sub
+   i32.add
+   local.set $size
+  end
   local.get $size
   i32.const 65535
   i32.add

--- a/tests/compiler/resolve-unary.release.wat
+++ b/tests/compiler/resolve-unary.release.wat
@@ -1368,7 +1368,7 @@
    local.tee $2
    local.get $5
    i32.const 256
-   i32.gt_u
+   i32.ge_u
    if (result i32)
     local.get $5
     i32.const 1

--- a/tests/compiler/resolve-unary.release.wat
+++ b/tests/compiler/resolve-unary.release.wat
@@ -686,7 +686,7 @@
   if
    i32.const 0
    i32.const 1616
-   i32.const 378
+   i32.const 382
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -711,7 +711,7 @@
    if
     i32.const 0
     i32.const 1616
-    i32.const 385
+    i32.const 389
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -739,7 +739,7 @@
    if
     i32.const 0
     i32.const 1616
-    i32.const 398
+    i32.const 402
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1106,7 +1106,7 @@
       if
        i32.const 0
        i32.const 1616
-       i32.const 560
+       i32.const 562
        i32.const 3
        call $~lib/builtins/abort
        unreachable
@@ -1190,7 +1190,7 @@
   if
    i32.const 0
    i32.const 1616
-   i32.const 330
+   i32.const 334
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1242,7 +1242,7 @@
     if
      i32.const 0
      i32.const 1616
-     i32.const 343
+     i32.const 347
      i32.const 18
      call $~lib/builtins/abort
      unreachable
@@ -1331,7 +1331,7 @@
    call $~lib/rt/tlsf/initialize
   end
   global.get $~lib/rt/tlsf/ROOT
-  local.set $3
+  local.set $4
   local.get $0
   i32.const 16
   i32.add
@@ -1341,12 +1341,12 @@
   if
    i32.const 1280
    i32.const 1616
-   i32.const 459
+   i32.const 461
    i32.const 29
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $3
+  local.get $4
   i32.const 12
   local.get $2
   i32.const 19
@@ -1367,8 +1367,29 @@
    memory.size $0
    local.tee $2
    local.get $5
+   i32.const 256
+   i32.gt_u
+   if (result i32)
+    local.get $5
+    i32.const 1
+    i32.const 27
+    local.get $5
+    i32.clz
+    i32.sub
+    i32.shl
+    i32.add
+    i32.const 1
+    i32.sub
+    local.get $5
+    local.get $5
+    i32.const 536870910
+    i32.lt_u
+    select
+   else
+    local.get $5
+   end
    i32.const 4
-   local.get $3
+   local.get $4
    i32.load $0 offset=1568
    local.get $2
    i32.const 16
@@ -1378,39 +1399,22 @@
    i32.ne
    i32.shl
    i32.add
-   local.tee $4
-   i32.const 536870910
-   i32.lt_u
-   if (result i32)
-    local.get $4
-    i32.const 1
-    i32.const 27
-    local.get $4
-    i32.clz
-    i32.sub
-    i32.shl
-    i32.const 1
-    i32.sub
-    i32.add
-   else
-    local.get $4
-   end
    i32.const 65535
    i32.add
    i32.const -65536
    i32.and
    i32.const 16
    i32.shr_u
-   local.tee $4
+   local.tee $3
    local.get $2
-   local.get $4
+   local.get $3
    i32.gt_s
    select
    memory.grow $0
    i32.const 0
    i32.lt_s
    if
-    local.get $4
+    local.get $3
     memory.grow $0
     i32.const 0
     i32.lt_s
@@ -1418,7 +1422,7 @@
      unreachable
     end
    end
-   local.get $3
+   local.get $4
    local.get $2
    i32.const 16
    i32.shl
@@ -1427,7 +1431,7 @@
    i64.const 16
    i64.shl
    call $~lib/rt/tlsf/addMemory
-   local.get $3
+   local.get $4
    local.get $5
    call $~lib/rt/tlsf/searchBlock
    local.tee $2
@@ -1435,7 +1439,7 @@
    if
     i32.const 0
     i32.const 1616
-    i32.const 497
+    i32.const 499
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1450,17 +1454,17 @@
   if
    i32.const 0
    i32.const 1616
-   i32.const 499
+   i32.const 501
    i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $3
+  local.get $4
   local.get $2
   call $~lib/rt/tlsf/removeBlock
   local.get $2
   i32.load $0
-  local.set $4
+  local.set $3
   local.get $5
   i32.const 4
   i32.add
@@ -1469,12 +1473,12 @@
   if
    i32.const 0
    i32.const 1616
-   i32.const 357
+   i32.const 361
    i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $4
+  local.get $3
   i32.const -4
   i32.and
   local.get $5
@@ -1485,7 +1489,7 @@
   if
    local.get $2
    local.get $5
-   local.get $4
+   local.get $3
    i32.const 2
    i32.and
    i32.or
@@ -1495,19 +1499,19 @@
    i32.add
    local.get $5
    i32.add
-   local.tee $4
+   local.tee $3
    local.get $6
    i32.const 4
    i32.sub
    i32.const 1
    i32.or
    i32.store $0
-   local.get $3
    local.get $4
+   local.get $3
    call $~lib/rt/tlsf/insertBlock
   else
    local.get $2
-   local.get $4
+   local.get $3
    i32.const -2
    i32.and
    i32.store $0

--- a/tests/compiler/resolve-unary.release.wat
+++ b/tests/compiler/resolve-unary.release.wat
@@ -1331,7 +1331,7 @@
    call $~lib/rt/tlsf/initialize
   end
   global.get $~lib/rt/tlsf/ROOT
-  local.set $4
+  local.set $3
   local.get $0
   i32.const 16
   i32.add
@@ -1346,7 +1346,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $4
+  local.get $3
   i32.const 12
   local.get $2
   i32.const 19
@@ -1366,8 +1366,9 @@
   if
    memory.size $0
    local.tee $2
+   local.get $5
    i32.const 4
-   local.get $4
+   local.get $3
    i32.load $0 offset=1568
    local.get $2
    i32.const 16
@@ -1376,38 +1377,40 @@
    i32.sub
    i32.ne
    i32.shl
-   local.get $5
-   i32.const 1
-   i32.const 27
-   local.get $5
-   i32.clz
-   i32.sub
-   i32.shl
-   i32.const 1
-   i32.sub
    i32.add
-   local.get $5
-   local.get $5
+   local.tee $4
    i32.const 536870910
    i32.lt_u
-   select
-   i32.add
+   if (result i32)
+    local.get $4
+    i32.const 1
+    i32.const 27
+    local.get $4
+    i32.clz
+    i32.sub
+    i32.shl
+    i32.const 1
+    i32.sub
+    i32.add
+   else
+    local.get $4
+   end
    i32.const 65535
    i32.add
    i32.const -65536
    i32.and
    i32.const 16
    i32.shr_u
-   local.tee $3
+   local.tee $4
    local.get $2
-   local.get $3
+   local.get $4
    i32.gt_s
    select
    memory.grow $0
    i32.const 0
    i32.lt_s
    if
-    local.get $3
+    local.get $4
     memory.grow $0
     i32.const 0
     i32.lt_s
@@ -1415,7 +1418,7 @@
      unreachable
     end
    end
-   local.get $4
+   local.get $3
    local.get $2
    i32.const 16
    i32.shl
@@ -1424,7 +1427,7 @@
    i64.const 16
    i64.shl
    call $~lib/rt/tlsf/addMemory
-   local.get $4
+   local.get $3
    local.get $5
    call $~lib/rt/tlsf/searchBlock
    local.tee $2
@@ -1452,12 +1455,12 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $4
+  local.get $3
   local.get $2
   call $~lib/rt/tlsf/removeBlock
   local.get $2
   i32.load $0
-  local.set $3
+  local.set $4
   local.get $5
   i32.const 4
   i32.add
@@ -1471,7 +1474,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $3
+  local.get $4
   i32.const -4
   i32.and
   local.get $5
@@ -1482,7 +1485,7 @@
   if
    local.get $2
    local.get $5
-   local.get $3
+   local.get $4
    i32.const 2
    i32.and
    i32.or
@@ -1492,19 +1495,19 @@
    i32.add
    local.get $5
    i32.add
-   local.tee $3
+   local.tee $4
    local.get $6
    i32.const 4
    i32.sub
    i32.const 1
    i32.or
    i32.store $0
-   local.get $4
    local.get $3
+   local.get $4
    call $~lib/rt/tlsf/insertBlock
   else
    local.get $2
-   local.get $3
+   local.get $4
    i32.const -2
    i32.and
    i32.store $0

--- a/tests/compiler/return-unreachable.debug.wat
+++ b/tests/compiler/return-unreachable.debug.wat
@@ -1926,7 +1926,7 @@
   drop
   local.get $size
   i32.const 256
-  i32.gt_u
+  i32.ge_u
   if
    local.get $size
    call $~lib/rt/tlsf/roundSize

--- a/tests/compiler/return-unreachable.debug.wat
+++ b/tests/compiler/return-unreachable.debug.wat
@@ -1036,7 +1036,7 @@
   if
    i32.const 0
    i32.const 464
-   i32.const 378
+   i32.const 382
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1082,7 +1082,7 @@
    if
     i32.const 0
     i32.const 464
-    i32.const 385
+    i32.const 389
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1115,7 +1115,7 @@
    if
     i32.const 0
     i32.const 464
-    i32.const 398
+    i32.const 402
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1359,7 +1359,7 @@
   if
    i32.const 0
    i32.const 464
-   i32.const 560
+   i32.const 562
    i32.const 3
    call $~lib/builtins/abort
    unreachable
@@ -1688,13 +1688,33 @@
   if
    i32.const 128
    i32.const 464
-   i32.const 459
+   i32.const 461
    i32.const 29
    call $~lib/builtins/abort
    unreachable
   end
   local.get $size
   call $~lib/rt/tlsf/computeSize
+  return
+ )
+ (func $~lib/rt/tlsf/roundSize (param $size i32) (result i32)
+  local.get $size
+  i32.const 536870910
+  i32.lt_u
+  if (result i32)
+   local.get $size
+   i32.const 1
+   i32.const 27
+   local.get $size
+   i32.clz
+   i32.sub
+   i32.shl
+   i32.add
+   i32.const 1
+   i32.sub
+  else
+   local.get $size
+  end
   return
  )
  (func $~lib/rt/tlsf/searchBlock (param $root i32) (param $size i32) (result i32)
@@ -1726,24 +1746,13 @@
    local.set $sl
   else
    local.get $size
-   i32.const 536870910
-   i32.lt_u
-   if (result i32)
-    local.get $size
-    i32.const 1
-    i32.const 27
-    local.get $size
-    i32.clz
-    i32.sub
-    i32.shl
-    i32.add
-    i32.const 1
-    i32.sub
-   else
-    local.get $size
-   end
+   call $~lib/rt/tlsf/roundSize
    local.set $requestSize
-   i32.const 31
+   i32.const 4
+   i32.const 8
+   i32.mul
+   i32.const 1
+   i32.sub
    local.get $requestSize
    i32.clz
    i32.sub
@@ -1781,7 +1790,7 @@
   if
    i32.const 0
    i32.const 464
-   i32.const 330
+   i32.const 334
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1852,7 +1861,7 @@
     if
      i32.const 0
      i32.const 464
-     i32.const 343
+     i32.const 347
      i32.const 18
      call $~lib/builtins/abort
      unreachable
@@ -1915,6 +1924,14 @@
   (local $pagesAfter i32)
   i32.const 0
   drop
+  local.get $size
+  i32.const 256
+  i32.gt_u
+  if
+   local.get $size
+   call $~lib/rt/tlsf/roundSize
+   local.set $size
+  end
   memory.size $0
   local.set $pagesBefore
   local.get $size
@@ -1935,22 +1952,6 @@
   i32.shl
   i32.add
   local.set $size
-  local.get $size
-  i32.const 536870910
-  i32.lt_u
-  if
-   local.get $size
-   i32.const 1
-   i32.const 27
-   local.get $size
-   i32.clz
-   i32.sub
-   i32.shl
-   i32.const 1
-   i32.sub
-   i32.add
-   local.set $size
-  end
   local.get $size
   i32.const 65535
   i32.add
@@ -2017,7 +2018,7 @@
   if
    i32.const 0
    i32.const 464
-   i32.const 357
+   i32.const 361
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -2132,7 +2133,7 @@
    if
     i32.const 0
     i32.const 464
-    i32.const 497
+    i32.const 499
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -2152,7 +2153,7 @@
   if
    i32.const 0
    i32.const 464
-   i32.const 499
+   i32.const 501
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/return-unreachable.debug.wat
+++ b/tests/compiler/return-unreachable.debug.wat
@@ -1915,22 +1915,6 @@
   (local $pagesAfter i32)
   i32.const 0
   drop
-  local.get $size
-  i32.const 536870910
-  i32.lt_u
-  if
-   local.get $size
-   i32.const 1
-   i32.const 27
-   local.get $size
-   i32.clz
-   i32.sub
-   i32.shl
-   i32.const 1
-   i32.sub
-   i32.add
-   local.set $size
-  end
   memory.size $0
   local.set $pagesBefore
   local.get $size
@@ -1951,6 +1935,22 @@
   i32.shl
   i32.add
   local.set $size
+  local.get $size
+  i32.const 536870910
+  i32.lt_u
+  if
+   local.get $size
+   i32.const 1
+   i32.const 27
+   local.get $size
+   i32.clz
+   i32.sub
+   i32.shl
+   i32.const 1
+   i32.sub
+   i32.add
+   local.set $size
+  end
   local.get $size
   i32.const 65535
   i32.add

--- a/tests/compiler/return-unreachable.release.wat
+++ b/tests/compiler/return-unreachable.release.wat
@@ -626,7 +626,7 @@
   if
    i32.const 0
    i32.const 1488
-   i32.const 378
+   i32.const 382
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -651,7 +651,7 @@
    if
     i32.const 0
     i32.const 1488
-    i32.const 385
+    i32.const 389
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -679,7 +679,7 @@
    if
     i32.const 0
     i32.const 1488
-    i32.const 398
+    i32.const 402
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1046,7 +1046,7 @@
       if
        i32.const 0
        i32.const 1488
-       i32.const 560
+       i32.const 562
        i32.const 3
        call $~lib/builtins/abort
        unreachable
@@ -1130,7 +1130,7 @@
   if
    i32.const 0
    i32.const 1488
-   i32.const 330
+   i32.const 334
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1182,7 +1182,7 @@
     if
      i32.const 0
      i32.const 1488
-     i32.const 343
+     i32.const 347
      i32.const 18
      call $~lib/builtins/abort
      unreachable
@@ -1271,7 +1271,7 @@
    call $~lib/rt/tlsf/initialize
   end
   global.get $~lib/rt/tlsf/ROOT
-  local.set $3
+  local.set $4
   local.get $0
   i32.const 16
   i32.add
@@ -1281,12 +1281,12 @@
   if
    i32.const 1152
    i32.const 1488
-   i32.const 459
+   i32.const 461
    i32.const 29
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $3
+  local.get $4
   i32.const 12
   local.get $2
   i32.const 19
@@ -1307,8 +1307,29 @@
    memory.size $0
    local.tee $2
    local.get $5
+   i32.const 256
+   i32.gt_u
+   if (result i32)
+    local.get $5
+    i32.const 1
+    i32.const 27
+    local.get $5
+    i32.clz
+    i32.sub
+    i32.shl
+    i32.add
+    i32.const 1
+    i32.sub
+    local.get $5
+    local.get $5
+    i32.const 536870910
+    i32.lt_u
+    select
+   else
+    local.get $5
+   end
    i32.const 4
-   local.get $3
+   local.get $4
    i32.load $0 offset=1568
    local.get $2
    i32.const 16
@@ -1318,39 +1339,22 @@
    i32.ne
    i32.shl
    i32.add
-   local.tee $4
-   i32.const 536870910
-   i32.lt_u
-   if (result i32)
-    local.get $4
-    i32.const 1
-    i32.const 27
-    local.get $4
-    i32.clz
-    i32.sub
-    i32.shl
-    i32.const 1
-    i32.sub
-    i32.add
-   else
-    local.get $4
-   end
    i32.const 65535
    i32.add
    i32.const -65536
    i32.and
    i32.const 16
    i32.shr_u
-   local.tee $4
+   local.tee $3
    local.get $2
-   local.get $4
+   local.get $3
    i32.gt_s
    select
    memory.grow $0
    i32.const 0
    i32.lt_s
    if
-    local.get $4
+    local.get $3
     memory.grow $0
     i32.const 0
     i32.lt_s
@@ -1358,7 +1362,7 @@
      unreachable
     end
    end
-   local.get $3
+   local.get $4
    local.get $2
    i32.const 16
    i32.shl
@@ -1367,7 +1371,7 @@
    i64.const 16
    i64.shl
    call $~lib/rt/tlsf/addMemory
-   local.get $3
+   local.get $4
    local.get $5
    call $~lib/rt/tlsf/searchBlock
    local.tee $2
@@ -1375,7 +1379,7 @@
    if
     i32.const 0
     i32.const 1488
-    i32.const 497
+    i32.const 499
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1390,17 +1394,17 @@
   if
    i32.const 0
    i32.const 1488
-   i32.const 499
+   i32.const 501
    i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $3
+  local.get $4
   local.get $2
   call $~lib/rt/tlsf/removeBlock
   local.get $2
   i32.load $0
-  local.set $4
+  local.set $3
   local.get $5
   i32.const 4
   i32.add
@@ -1409,12 +1413,12 @@
   if
    i32.const 0
    i32.const 1488
-   i32.const 357
+   i32.const 361
    i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $4
+  local.get $3
   i32.const -4
   i32.and
   local.get $5
@@ -1425,7 +1429,7 @@
   if
    local.get $2
    local.get $5
-   local.get $4
+   local.get $3
    i32.const 2
    i32.and
    i32.or
@@ -1435,19 +1439,19 @@
    i32.add
    local.get $5
    i32.add
-   local.tee $4
+   local.tee $3
    local.get $6
    i32.const 4
    i32.sub
    i32.const 1
    i32.or
    i32.store $0
-   local.get $3
    local.get $4
+   local.get $3
    call $~lib/rt/tlsf/insertBlock
   else
    local.get $2
-   local.get $4
+   local.get $3
    i32.const -2
    i32.and
    i32.store $0

--- a/tests/compiler/return-unreachable.release.wat
+++ b/tests/compiler/return-unreachable.release.wat
@@ -1308,7 +1308,7 @@
    local.tee $2
    local.get $5
    i32.const 256
-   i32.gt_u
+   i32.ge_u
    if (result i32)
     local.get $5
     i32.const 1

--- a/tests/compiler/return-unreachable.release.wat
+++ b/tests/compiler/return-unreachable.release.wat
@@ -1271,7 +1271,7 @@
    call $~lib/rt/tlsf/initialize
   end
   global.get $~lib/rt/tlsf/ROOT
-  local.set $4
+  local.set $3
   local.get $0
   i32.const 16
   i32.add
@@ -1286,7 +1286,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $4
+  local.get $3
   i32.const 12
   local.get $2
   i32.const 19
@@ -1306,8 +1306,9 @@
   if
    memory.size $0
    local.tee $2
+   local.get $5
    i32.const 4
-   local.get $4
+   local.get $3
    i32.load $0 offset=1568
    local.get $2
    i32.const 16
@@ -1316,38 +1317,40 @@
    i32.sub
    i32.ne
    i32.shl
-   local.get $5
-   i32.const 1
-   i32.const 27
-   local.get $5
-   i32.clz
-   i32.sub
-   i32.shl
-   i32.const 1
-   i32.sub
    i32.add
-   local.get $5
-   local.get $5
+   local.tee $4
    i32.const 536870910
    i32.lt_u
-   select
-   i32.add
+   if (result i32)
+    local.get $4
+    i32.const 1
+    i32.const 27
+    local.get $4
+    i32.clz
+    i32.sub
+    i32.shl
+    i32.const 1
+    i32.sub
+    i32.add
+   else
+    local.get $4
+   end
    i32.const 65535
    i32.add
    i32.const -65536
    i32.and
    i32.const 16
    i32.shr_u
-   local.tee $3
+   local.tee $4
    local.get $2
-   local.get $3
+   local.get $4
    i32.gt_s
    select
    memory.grow $0
    i32.const 0
    i32.lt_s
    if
-    local.get $3
+    local.get $4
     memory.grow $0
     i32.const 0
     i32.lt_s
@@ -1355,7 +1358,7 @@
      unreachable
     end
    end
-   local.get $4
+   local.get $3
    local.get $2
    i32.const 16
    i32.shl
@@ -1364,7 +1367,7 @@
    i64.const 16
    i64.shl
    call $~lib/rt/tlsf/addMemory
-   local.get $4
+   local.get $3
    local.get $5
    call $~lib/rt/tlsf/searchBlock
    local.tee $2
@@ -1392,12 +1395,12 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $4
+  local.get $3
   local.get $2
   call $~lib/rt/tlsf/removeBlock
   local.get $2
   i32.load $0
-  local.set $3
+  local.set $4
   local.get $5
   i32.const 4
   i32.add
@@ -1411,7 +1414,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $3
+  local.get $4
   i32.const -4
   i32.and
   local.get $5
@@ -1422,7 +1425,7 @@
   if
    local.get $2
    local.get $5
-   local.get $3
+   local.get $4
    i32.const 2
    i32.and
    i32.or
@@ -1432,19 +1435,19 @@
    i32.add
    local.get $5
    i32.add
-   local.tee $3
+   local.tee $4
    local.get $6
    i32.const 4
    i32.sub
    i32.const 1
    i32.or
    i32.store $0
-   local.get $4
    local.get $3
+   local.get $4
    call $~lib/rt/tlsf/insertBlock
   else
    local.get $2
-   local.get $3
+   local.get $4
    i32.const -2
    i32.and
    i32.store $0

--- a/tests/compiler/rt/alloc-large-memory.debug.wat
+++ b/tests/compiler/rt/alloc-large-memory.debug.wat
@@ -1237,7 +1237,7 @@
   drop
   local.get $size
   i32.const 256
-  i32.gt_u
+  i32.ge_u
   if
    local.get $size
    call $~lib/rt/tlsf/roundSize

--- a/tests/compiler/rt/alloc-large-memory.debug.wat
+++ b/tests/compiler/rt/alloc-large-memory.debug.wat
@@ -678,7 +678,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 378
+   i32.const 382
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -724,7 +724,7 @@
    if
     i32.const 0
     i32.const 32
-    i32.const 385
+    i32.const 389
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -757,7 +757,7 @@
    if
     i32.const 0
     i32.const 32
-    i32.const 398
+    i32.const 402
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -999,13 +999,33 @@
   if
    i32.const 96
    i32.const 32
-   i32.const 459
+   i32.const 461
    i32.const 29
    call $~lib/builtins/abort
    unreachable
   end
   local.get $size
   call $~lib/rt/tlsf/computeSize
+  return
+ )
+ (func $~lib/rt/tlsf/roundSize (param $size i32) (result i32)
+  local.get $size
+  i32.const 536870910
+  i32.lt_u
+  if (result i32)
+   local.get $size
+   i32.const 1
+   i32.const 27
+   local.get $size
+   i32.clz
+   i32.sub
+   i32.shl
+   i32.add
+   i32.const 1
+   i32.sub
+  else
+   local.get $size
+  end
   return
  )
  (func $~lib/rt/tlsf/searchBlock (param $root i32) (param $size i32) (result i32)
@@ -1037,24 +1057,13 @@
    local.set $sl
   else
    local.get $size
-   i32.const 536870910
-   i32.lt_u
-   if (result i32)
-    local.get $size
-    i32.const 1
-    i32.const 27
-    local.get $size
-    i32.clz
-    i32.sub
-    i32.shl
-    i32.add
-    i32.const 1
-    i32.sub
-   else
-    local.get $size
-   end
+   call $~lib/rt/tlsf/roundSize
    local.set $requestSize
-   i32.const 31
+   i32.const 4
+   i32.const 8
+   i32.mul
+   i32.const 1
+   i32.sub
    local.get $requestSize
    i32.clz
    i32.sub
@@ -1092,7 +1101,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 330
+   i32.const 334
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1163,7 +1172,7 @@
     if
      i32.const 0
      i32.const 32
-     i32.const 343
+     i32.const 347
      i32.const 18
      call $~lib/builtins/abort
      unreachable
@@ -1227,19 +1236,11 @@
   i32.const 0
   drop
   local.get $size
-  i32.const 536870910
-  i32.lt_u
+  i32.const 256
+  i32.gt_u
   if
    local.get $size
-   i32.const 1
-   i32.const 27
-   local.get $size
-   i32.clz
-   i32.sub
-   i32.shl
-   i32.const 1
-   i32.sub
-   i32.add
+   call $~lib/rt/tlsf/roundSize
    local.set $size
   end
   memory.size $0
@@ -1328,7 +1329,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 357
+   i32.const 361
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1443,7 +1444,7 @@
    if
     i32.const 0
     i32.const 32
-    i32.const 497
+    i32.const 499
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1463,7 +1464,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 499
+   i32.const 501
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/rt/alloc-large-memory.release.wat
+++ b/tests/compiler/rt/alloc-large-memory.release.wat
@@ -423,7 +423,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 378
+   i32.const 382
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -448,7 +448,7 @@
    if
     i32.const 0
     i32.const 1056
-    i32.const 385
+    i32.const 389
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -476,7 +476,7 @@
    if
     i32.const 0
     i32.const 1056
-    i32.const 398
+    i32.const 402
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -580,7 +580,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 330
+   i32.const 334
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -632,7 +632,7 @@
     if
      i32.const 0
      i32.const 1056
-     i32.const 343
+     i32.const 347
      i32.const 18
      call $~lib/builtins/abort
      unreachable
@@ -746,7 +746,7 @@
   if
    i32.const 1120
    i32.const 1056
-   i32.const 459
+   i32.const 461
    i32.const 29
    call $~lib/builtins/abort
    unreachable
@@ -771,6 +771,28 @@
   if
    memory.size $0
    local.tee $1
+   local.get $0
+   i32.const 256
+   i32.gt_u
+   if (result i32)
+    local.get $0
+    i32.const 1
+    i32.const 27
+    local.get $0
+    i32.clz
+    i32.sub
+    i32.shl
+    i32.add
+    i32.const 1
+    i32.sub
+    local.get $0
+    local.get $0
+    i32.const 536870910
+    i32.lt_u
+    select
+   else
+    local.get $0
+   end
    i32.const 4
    local.get $3
    i32.load $0 offset=1568
@@ -781,21 +803,6 @@
    i32.sub
    i32.ne
    i32.shl
-   local.get $0
-   i32.const 1
-   i32.const 27
-   local.get $0
-   i32.clz
-   i32.sub
-   i32.shl
-   i32.const 1
-   i32.sub
-   i32.add
-   local.get $0
-   local.get $0
-   i32.const 536870910
-   i32.lt_u
-   select
    i32.add
    i32.const 65535
    i32.add
@@ -837,7 +844,7 @@
    if
     i32.const 0
     i32.const 1056
-    i32.const 497
+    i32.const 499
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -852,7 +859,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 499
+   i32.const 501
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -871,7 +878,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 357
+   i32.const 361
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/rt/alloc-large-memory.release.wat
+++ b/tests/compiler/rt/alloc-large-memory.release.wat
@@ -773,7 +773,7 @@
    local.tee $1
    local.get $0
    i32.const 256
-   i32.gt_u
+   i32.ge_u
    if (result i32)
     local.get $0
     i32.const 1

--- a/tests/compiler/rt/finalize.debug.wat
+++ b/tests/compiler/rt/finalize.debug.wat
@@ -1935,22 +1935,6 @@
   (local $pagesAfter i32)
   i32.const 0
   drop
-  local.get $size
-  i32.const 536870910
-  i32.lt_u
-  if
-   local.get $size
-   i32.const 1
-   i32.const 27
-   local.get $size
-   i32.clz
-   i32.sub
-   i32.shl
-   i32.const 1
-   i32.sub
-   i32.add
-   local.set $size
-  end
   memory.size $0
   local.set $pagesBefore
   local.get $size
@@ -1971,6 +1955,22 @@
   i32.shl
   i32.add
   local.set $size
+  local.get $size
+  i32.const 536870910
+  i32.lt_u
+  if
+   local.get $size
+   i32.const 1
+   i32.const 27
+   local.get $size
+   i32.clz
+   i32.sub
+   i32.shl
+   i32.const 1
+   i32.sub
+   i32.add
+   local.set $size
+  end
   local.get $size
   i32.const 65535
   i32.add

--- a/tests/compiler/rt/finalize.debug.wat
+++ b/tests/compiler/rt/finalize.debug.wat
@@ -1052,7 +1052,7 @@
   if
    i32.const 0
    i32.const 416
-   i32.const 378
+   i32.const 382
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1098,7 +1098,7 @@
    if
     i32.const 0
     i32.const 416
-    i32.const 385
+    i32.const 389
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1131,7 +1131,7 @@
    if
     i32.const 0
     i32.const 416
-    i32.const 398
+    i32.const 402
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1375,7 +1375,7 @@
   if
    i32.const 0
    i32.const 416
-   i32.const 560
+   i32.const 562
    i32.const 3
    call $~lib/builtins/abort
    unreachable
@@ -1708,13 +1708,33 @@
   if
    i32.const 32
    i32.const 416
-   i32.const 459
+   i32.const 461
    i32.const 29
    call $~lib/builtins/abort
    unreachable
   end
   local.get $size
   call $~lib/rt/tlsf/computeSize
+  return
+ )
+ (func $~lib/rt/tlsf/roundSize (param $size i32) (result i32)
+  local.get $size
+  i32.const 536870910
+  i32.lt_u
+  if (result i32)
+   local.get $size
+   i32.const 1
+   i32.const 27
+   local.get $size
+   i32.clz
+   i32.sub
+   i32.shl
+   i32.add
+   i32.const 1
+   i32.sub
+  else
+   local.get $size
+  end
   return
  )
  (func $~lib/rt/tlsf/searchBlock (param $root i32) (param $size i32) (result i32)
@@ -1746,24 +1766,13 @@
    local.set $sl
   else
    local.get $size
-   i32.const 536870910
-   i32.lt_u
-   if (result i32)
-    local.get $size
-    i32.const 1
-    i32.const 27
-    local.get $size
-    i32.clz
-    i32.sub
-    i32.shl
-    i32.add
-    i32.const 1
-    i32.sub
-   else
-    local.get $size
-   end
+   call $~lib/rt/tlsf/roundSize
    local.set $requestSize
-   i32.const 31
+   i32.const 4
+   i32.const 8
+   i32.mul
+   i32.const 1
+   i32.sub
    local.get $requestSize
    i32.clz
    i32.sub
@@ -1801,7 +1810,7 @@
   if
    i32.const 0
    i32.const 416
-   i32.const 330
+   i32.const 334
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1872,7 +1881,7 @@
     if
      i32.const 0
      i32.const 416
-     i32.const 343
+     i32.const 347
      i32.const 18
      call $~lib/builtins/abort
      unreachable
@@ -1935,6 +1944,14 @@
   (local $pagesAfter i32)
   i32.const 0
   drop
+  local.get $size
+  i32.const 256
+  i32.gt_u
+  if
+   local.get $size
+   call $~lib/rt/tlsf/roundSize
+   local.set $size
+  end
   memory.size $0
   local.set $pagesBefore
   local.get $size
@@ -1955,22 +1972,6 @@
   i32.shl
   i32.add
   local.set $size
-  local.get $size
-  i32.const 536870910
-  i32.lt_u
-  if
-   local.get $size
-   i32.const 1
-   i32.const 27
-   local.get $size
-   i32.clz
-   i32.sub
-   i32.shl
-   i32.const 1
-   i32.sub
-   i32.add
-   local.set $size
-  end
   local.get $size
   i32.const 65535
   i32.add
@@ -2037,7 +2038,7 @@
   if
    i32.const 0
    i32.const 416
-   i32.const 357
+   i32.const 361
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -2152,7 +2153,7 @@
    if
     i32.const 0
     i32.const 416
-    i32.const 497
+    i32.const 499
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -2172,7 +2173,7 @@
   if
    i32.const 0
    i32.const 416
-   i32.const 499
+   i32.const 501
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/rt/finalize.debug.wat
+++ b/tests/compiler/rt/finalize.debug.wat
@@ -1946,7 +1946,7 @@
   drop
   local.get $size
   i32.const 256
-  i32.gt_u
+  i32.ge_u
   if
    local.get $size
    call $~lib/rt/tlsf/roundSize

--- a/tests/compiler/rt/finalize.release.wat
+++ b/tests/compiler/rt/finalize.release.wat
@@ -623,7 +623,7 @@
   if
    i32.const 0
    i32.const 1440
-   i32.const 378
+   i32.const 382
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -648,7 +648,7 @@
    if
     i32.const 0
     i32.const 1440
-    i32.const 385
+    i32.const 389
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -676,7 +676,7 @@
    if
     i32.const 0
     i32.const 1440
-    i32.const 398
+    i32.const 402
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1058,7 +1058,7 @@
       if
        i32.const 0
        i32.const 1440
-       i32.const 560
+       i32.const 562
        i32.const 3
        call $~lib/builtins/abort
        unreachable
@@ -1125,7 +1125,7 @@
     if
      i32.const 0
      i32.const 1440
-     i32.const 343
+     i32.const 347
      i32.const 18
      call $~lib/builtins/abort
      unreachable
@@ -1209,8 +1209,6 @@
   if
    memory.size $0
    local.tee $1
-   i32.const 1
-   i32.const 27
    i32.const 4
    local.get $2
    i32.load $0 offset=1568
@@ -1221,22 +1219,7 @@
    i32.sub
    i32.ne
    i32.shl
-   i32.const 28
-   i32.add
-   local.tee $3
-   i32.clz
-   i32.sub
-   i32.shl
-   i32.const 1
-   i32.sub
-   local.get $3
-   i32.add
-   local.get $3
-   local.get $3
-   i32.const 536870910
-   i32.lt_u
-   select
-   i32.const 65535
+   i32.const 65563
    i32.add
    i32.const -65536
    i32.and
@@ -1275,7 +1258,7 @@
    if
     i32.const 0
     i32.const 1440
-    i32.const 497
+    i32.const 499
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1290,7 +1273,7 @@
   if
    i32.const 0
    i32.const 1440
-   i32.const 499
+   i32.const 501
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/rt/finalize.release.wat
+++ b/tests/compiler/rt/finalize.release.wat
@@ -1209,6 +1209,8 @@
   if
    memory.size $0
    local.tee $1
+   i32.const 1
+   i32.const 27
    i32.const 4
    local.get $2
    i32.load $0 offset=1568
@@ -1219,7 +1221,22 @@
    i32.sub
    i32.ne
    i32.shl
-   i32.const 65563
+   i32.const 28
+   i32.add
+   local.tee $3
+   i32.clz
+   i32.sub
+   i32.shl
+   i32.const 1
+   i32.sub
+   local.get $3
+   i32.add
+   local.get $3
+   local.get $3
+   i32.const 536870910
+   i32.lt_u
+   select
+   i32.const 65535
    i32.add
    i32.const -65536
    i32.and

--- a/tests/compiler/rt/runtime-incremental-export.debug.wat
+++ b/tests/compiler/rt/runtime-incremental-export.debug.wat
@@ -1039,7 +1039,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 378
+   i32.const 382
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1085,7 +1085,7 @@
    if
     i32.const 0
     i32.const 368
-    i32.const 385
+    i32.const 389
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1118,7 +1118,7 @@
    if
     i32.const 0
     i32.const 368
-    i32.const 398
+    i32.const 402
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1362,7 +1362,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 560
+   i32.const 562
    i32.const 3
    call $~lib/builtins/abort
    unreachable
@@ -1691,13 +1691,33 @@
   if
    i32.const 32
    i32.const 368
-   i32.const 459
+   i32.const 461
    i32.const 29
    call $~lib/builtins/abort
    unreachable
   end
   local.get $size
   call $~lib/rt/tlsf/computeSize
+  return
+ )
+ (func $~lib/rt/tlsf/roundSize (param $size i32) (result i32)
+  local.get $size
+  i32.const 536870910
+  i32.lt_u
+  if (result i32)
+   local.get $size
+   i32.const 1
+   i32.const 27
+   local.get $size
+   i32.clz
+   i32.sub
+   i32.shl
+   i32.add
+   i32.const 1
+   i32.sub
+  else
+   local.get $size
+  end
   return
  )
  (func $~lib/rt/tlsf/searchBlock (param $root i32) (param $size i32) (result i32)
@@ -1729,24 +1749,13 @@
    local.set $sl
   else
    local.get $size
-   i32.const 536870910
-   i32.lt_u
-   if (result i32)
-    local.get $size
-    i32.const 1
-    i32.const 27
-    local.get $size
-    i32.clz
-    i32.sub
-    i32.shl
-    i32.add
-    i32.const 1
-    i32.sub
-   else
-    local.get $size
-   end
+   call $~lib/rt/tlsf/roundSize
    local.set $requestSize
-   i32.const 31
+   i32.const 4
+   i32.const 8
+   i32.mul
+   i32.const 1
+   i32.sub
    local.get $requestSize
    i32.clz
    i32.sub
@@ -1784,7 +1793,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 330
+   i32.const 334
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1855,7 +1864,7 @@
     if
      i32.const 0
      i32.const 368
-     i32.const 343
+     i32.const 347
      i32.const 18
      call $~lib/builtins/abort
      unreachable
@@ -1918,6 +1927,14 @@
   (local $pagesAfter i32)
   i32.const 0
   drop
+  local.get $size
+  i32.const 256
+  i32.gt_u
+  if
+   local.get $size
+   call $~lib/rt/tlsf/roundSize
+   local.set $size
+  end
   memory.size $0
   local.set $pagesBefore
   local.get $size
@@ -1938,22 +1955,6 @@
   i32.shl
   i32.add
   local.set $size
-  local.get $size
-  i32.const 536870910
-  i32.lt_u
-  if
-   local.get $size
-   i32.const 1
-   i32.const 27
-   local.get $size
-   i32.clz
-   i32.sub
-   i32.shl
-   i32.const 1
-   i32.sub
-   i32.add
-   local.set $size
-  end
   local.get $size
   i32.const 65535
   i32.add
@@ -2020,7 +2021,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 357
+   i32.const 361
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -2135,7 +2136,7 @@
    if
     i32.const 0
     i32.const 368
-    i32.const 497
+    i32.const 499
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -2155,7 +2156,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 499
+   i32.const 501
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/rt/runtime-incremental-export.debug.wat
+++ b/tests/compiler/rt/runtime-incremental-export.debug.wat
@@ -1918,22 +1918,6 @@
   (local $pagesAfter i32)
   i32.const 0
   drop
-  local.get $size
-  i32.const 536870910
-  i32.lt_u
-  if
-   local.get $size
-   i32.const 1
-   i32.const 27
-   local.get $size
-   i32.clz
-   i32.sub
-   i32.shl
-   i32.const 1
-   i32.sub
-   i32.add
-   local.set $size
-  end
   memory.size $0
   local.set $pagesBefore
   local.get $size
@@ -1954,6 +1938,22 @@
   i32.shl
   i32.add
   local.set $size
+  local.get $size
+  i32.const 536870910
+  i32.lt_u
+  if
+   local.get $size
+   i32.const 1
+   i32.const 27
+   local.get $size
+   i32.clz
+   i32.sub
+   i32.shl
+   i32.const 1
+   i32.sub
+   i32.add
+   local.set $size
+  end
   local.get $size
   i32.const 65535
   i32.add

--- a/tests/compiler/rt/runtime-incremental-export.debug.wat
+++ b/tests/compiler/rt/runtime-incremental-export.debug.wat
@@ -1929,7 +1929,7 @@
   drop
   local.get $size
   i32.const 256
-  i32.gt_u
+  i32.ge_u
   if
    local.get $size
    call $~lib/rt/tlsf/roundSize

--- a/tests/compiler/rt/runtime-incremental-export.release.wat
+++ b/tests/compiler/rt/runtime-incremental-export.release.wat
@@ -635,7 +635,7 @@
   if
    i32.const 0
    i32.const 1392
-   i32.const 378
+   i32.const 382
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -660,7 +660,7 @@
    if
     i32.const 0
     i32.const 1392
-    i32.const 385
+    i32.const 389
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -688,7 +688,7 @@
    if
     i32.const 0
     i32.const 1392
-    i32.const 398
+    i32.const 402
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1055,7 +1055,7 @@
       if
        i32.const 0
        i32.const 1392
-       i32.const 560
+       i32.const 562
        i32.const 3
        call $~lib/builtins/abort
        unreachable
@@ -1139,7 +1139,7 @@
   if
    i32.const 0
    i32.const 1392
-   i32.const 330
+   i32.const 334
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1191,7 +1191,7 @@
     if
      i32.const 0
      i32.const 1392
-     i32.const 343
+     i32.const 347
      i32.const 18
      call $~lib/builtins/abort
      unreachable
@@ -1280,7 +1280,7 @@
    call $~lib/rt/tlsf/initialize
   end
   global.get $~lib/rt/tlsf/ROOT
-  local.set $3
+  local.set $4
   local.get $0
   i32.const 16
   i32.add
@@ -1290,12 +1290,12 @@
   if
    i32.const 1056
    i32.const 1392
-   i32.const 459
+   i32.const 461
    i32.const 29
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $3
+  local.get $4
   i32.const 12
   local.get $2
   i32.const 19
@@ -1316,8 +1316,29 @@
    memory.size $0
    local.tee $2
    local.get $5
+   i32.const 256
+   i32.gt_u
+   if (result i32)
+    local.get $5
+    i32.const 1
+    i32.const 27
+    local.get $5
+    i32.clz
+    i32.sub
+    i32.shl
+    i32.add
+    i32.const 1
+    i32.sub
+    local.get $5
+    local.get $5
+    i32.const 536870910
+    i32.lt_u
+    select
+   else
+    local.get $5
+   end
    i32.const 4
-   local.get $3
+   local.get $4
    i32.load $0 offset=1568
    local.get $2
    i32.const 16
@@ -1327,39 +1348,22 @@
    i32.ne
    i32.shl
    i32.add
-   local.tee $4
-   i32.const 536870910
-   i32.lt_u
-   if (result i32)
-    local.get $4
-    i32.const 1
-    i32.const 27
-    local.get $4
-    i32.clz
-    i32.sub
-    i32.shl
-    i32.const 1
-    i32.sub
-    i32.add
-   else
-    local.get $4
-   end
    i32.const 65535
    i32.add
    i32.const -65536
    i32.and
    i32.const 16
    i32.shr_u
-   local.tee $4
+   local.tee $3
    local.get $2
-   local.get $4
+   local.get $3
    i32.gt_s
    select
    memory.grow $0
    i32.const 0
    i32.lt_s
    if
-    local.get $4
+    local.get $3
     memory.grow $0
     i32.const 0
     i32.lt_s
@@ -1367,7 +1371,7 @@
      unreachable
     end
    end
-   local.get $3
+   local.get $4
    local.get $2
    i32.const 16
    i32.shl
@@ -1376,7 +1380,7 @@
    i64.const 16
    i64.shl
    call $~lib/rt/tlsf/addMemory
-   local.get $3
+   local.get $4
    local.get $5
    call $~lib/rt/tlsf/searchBlock
    local.tee $2
@@ -1384,7 +1388,7 @@
    if
     i32.const 0
     i32.const 1392
-    i32.const 497
+    i32.const 499
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1399,17 +1403,17 @@
   if
    i32.const 0
    i32.const 1392
-   i32.const 499
+   i32.const 501
    i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $3
+  local.get $4
   local.get $2
   call $~lib/rt/tlsf/removeBlock
   local.get $2
   i32.load $0
-  local.set $4
+  local.set $3
   local.get $5
   i32.const 4
   i32.add
@@ -1418,12 +1422,12 @@
   if
    i32.const 0
    i32.const 1392
-   i32.const 357
+   i32.const 361
    i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $4
+  local.get $3
   i32.const -4
   i32.and
   local.get $5
@@ -1434,7 +1438,7 @@
   if
    local.get $2
    local.get $5
-   local.get $4
+   local.get $3
    i32.const 2
    i32.and
    i32.or
@@ -1444,19 +1448,19 @@
    i32.add
    local.get $5
    i32.add
-   local.tee $4
+   local.tee $3
    local.get $6
    i32.const 4
    i32.sub
    i32.const 1
    i32.or
    i32.store $0
-   local.get $3
    local.get $4
+   local.get $3
    call $~lib/rt/tlsf/insertBlock
   else
    local.get $2
-   local.get $4
+   local.get $3
    i32.const -2
    i32.and
    i32.store $0

--- a/tests/compiler/rt/runtime-incremental-export.release.wat
+++ b/tests/compiler/rt/runtime-incremental-export.release.wat
@@ -1317,7 +1317,7 @@
    local.tee $2
    local.get $5
    i32.const 256
-   i32.gt_u
+   i32.ge_u
    if (result i32)
     local.get $5
     i32.const 1

--- a/tests/compiler/rt/runtime-incremental-export.release.wat
+++ b/tests/compiler/rt/runtime-incremental-export.release.wat
@@ -1280,7 +1280,7 @@
    call $~lib/rt/tlsf/initialize
   end
   global.get $~lib/rt/tlsf/ROOT
-  local.set $4
+  local.set $3
   local.get $0
   i32.const 16
   i32.add
@@ -1295,7 +1295,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $4
+  local.get $3
   i32.const 12
   local.get $2
   i32.const 19
@@ -1315,8 +1315,9 @@
   if
    memory.size $0
    local.tee $2
+   local.get $5
    i32.const 4
-   local.get $4
+   local.get $3
    i32.load $0 offset=1568
    local.get $2
    i32.const 16
@@ -1325,38 +1326,40 @@
    i32.sub
    i32.ne
    i32.shl
-   local.get $5
-   i32.const 1
-   i32.const 27
-   local.get $5
-   i32.clz
-   i32.sub
-   i32.shl
-   i32.const 1
-   i32.sub
    i32.add
-   local.get $5
-   local.get $5
+   local.tee $4
    i32.const 536870910
    i32.lt_u
-   select
-   i32.add
+   if (result i32)
+    local.get $4
+    i32.const 1
+    i32.const 27
+    local.get $4
+    i32.clz
+    i32.sub
+    i32.shl
+    i32.const 1
+    i32.sub
+    i32.add
+   else
+    local.get $4
+   end
    i32.const 65535
    i32.add
    i32.const -65536
    i32.and
    i32.const 16
    i32.shr_u
-   local.tee $3
+   local.tee $4
    local.get $2
-   local.get $3
+   local.get $4
    i32.gt_s
    select
    memory.grow $0
    i32.const 0
    i32.lt_s
    if
-    local.get $3
+    local.get $4
     memory.grow $0
     i32.const 0
     i32.lt_s
@@ -1364,7 +1367,7 @@
      unreachable
     end
    end
-   local.get $4
+   local.get $3
    local.get $2
    i32.const 16
    i32.shl
@@ -1373,7 +1376,7 @@
    i64.const 16
    i64.shl
    call $~lib/rt/tlsf/addMemory
-   local.get $4
+   local.get $3
    local.get $5
    call $~lib/rt/tlsf/searchBlock
    local.tee $2
@@ -1401,12 +1404,12 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $4
+  local.get $3
   local.get $2
   call $~lib/rt/tlsf/removeBlock
   local.get $2
   i32.load $0
-  local.set $3
+  local.set $4
   local.get $5
   i32.const 4
   i32.add
@@ -1420,7 +1423,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $3
+  local.get $4
   i32.const -4
   i32.and
   local.get $5
@@ -1431,7 +1434,7 @@
   if
    local.get $2
    local.get $5
-   local.get $3
+   local.get $4
    i32.const 2
    i32.and
    i32.or
@@ -1441,19 +1444,19 @@
    i32.add
    local.get $5
    i32.add
-   local.tee $3
+   local.tee $4
    local.get $6
    i32.const 4
    i32.sub
    i32.const 1
    i32.or
    i32.store $0
-   local.get $4
    local.get $3
+   local.get $4
    call $~lib/rt/tlsf/insertBlock
   else
    local.get $2
-   local.get $3
+   local.get $4
    i32.const -2
    i32.and
    i32.store $0

--- a/tests/compiler/rt/runtime-minimal-export.debug.wat
+++ b/tests/compiler/rt/runtime-minimal-export.debug.wat
@@ -1254,7 +1254,7 @@
   drop
   local.get $size
   i32.const 256
-  i32.gt_u
+  i32.ge_u
   if
    local.get $size
    call $~lib/rt/tlsf/roundSize

--- a/tests/compiler/rt/runtime-minimal-export.debug.wat
+++ b/tests/compiler/rt/runtime-minimal-export.debug.wat
@@ -695,7 +695,7 @@
   if
    i32.const 0
    i32.const 160
-   i32.const 378
+   i32.const 382
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -741,7 +741,7 @@
    if
     i32.const 0
     i32.const 160
-    i32.const 385
+    i32.const 389
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -774,7 +774,7 @@
    if
     i32.const 0
     i32.const 160
-    i32.const 398
+    i32.const 402
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1016,13 +1016,33 @@
   if
    i32.const 32
    i32.const 160
-   i32.const 459
+   i32.const 461
    i32.const 29
    call $~lib/builtins/abort
    unreachable
   end
   local.get $size
   call $~lib/rt/tlsf/computeSize
+  return
+ )
+ (func $~lib/rt/tlsf/roundSize (param $size i32) (result i32)
+  local.get $size
+  i32.const 536870910
+  i32.lt_u
+  if (result i32)
+   local.get $size
+   i32.const 1
+   i32.const 27
+   local.get $size
+   i32.clz
+   i32.sub
+   i32.shl
+   i32.add
+   i32.const 1
+   i32.sub
+  else
+   local.get $size
+  end
   return
  )
  (func $~lib/rt/tlsf/searchBlock (param $root i32) (param $size i32) (result i32)
@@ -1054,24 +1074,13 @@
    local.set $sl
   else
    local.get $size
-   i32.const 536870910
-   i32.lt_u
-   if (result i32)
-    local.get $size
-    i32.const 1
-    i32.const 27
-    local.get $size
-    i32.clz
-    i32.sub
-    i32.shl
-    i32.add
-    i32.const 1
-    i32.sub
-   else
-    local.get $size
-   end
+   call $~lib/rt/tlsf/roundSize
    local.set $requestSize
-   i32.const 31
+   i32.const 4
+   i32.const 8
+   i32.mul
+   i32.const 1
+   i32.sub
    local.get $requestSize
    i32.clz
    i32.sub
@@ -1109,7 +1118,7 @@
   if
    i32.const 0
    i32.const 160
-   i32.const 330
+   i32.const 334
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1180,7 +1189,7 @@
     if
      i32.const 0
      i32.const 160
-     i32.const 343
+     i32.const 347
      i32.const 18
      call $~lib/builtins/abort
      unreachable
@@ -1243,6 +1252,14 @@
   (local $pagesAfter i32)
   i32.const 0
   drop
+  local.get $size
+  i32.const 256
+  i32.gt_u
+  if
+   local.get $size
+   call $~lib/rt/tlsf/roundSize
+   local.set $size
+  end
   memory.size $0
   local.set $pagesBefore
   local.get $size
@@ -1263,22 +1280,6 @@
   i32.shl
   i32.add
   local.set $size
-  local.get $size
-  i32.const 536870910
-  i32.lt_u
-  if
-   local.get $size
-   i32.const 1
-   i32.const 27
-   local.get $size
-   i32.clz
-   i32.sub
-   i32.shl
-   i32.const 1
-   i32.sub
-   i32.add
-   local.set $size
-  end
   local.get $size
   i32.const 65535
   i32.add
@@ -1345,7 +1346,7 @@
   if
    i32.const 0
    i32.const 160
-   i32.const 357
+   i32.const 361
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1460,7 +1461,7 @@
    if
     i32.const 0
     i32.const 160
-    i32.const 497
+    i32.const 499
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1480,7 +1481,7 @@
   if
    i32.const 0
    i32.const 160
-   i32.const 499
+   i32.const 501
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1791,7 +1792,7 @@
   if
    i32.const 0
    i32.const 160
-   i32.const 560
+   i32.const 562
    i32.const 3
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/rt/runtime-minimal-export.debug.wat
+++ b/tests/compiler/rt/runtime-minimal-export.debug.wat
@@ -1243,22 +1243,6 @@
   (local $pagesAfter i32)
   i32.const 0
   drop
-  local.get $size
-  i32.const 536870910
-  i32.lt_u
-  if
-   local.get $size
-   i32.const 1
-   i32.const 27
-   local.get $size
-   i32.clz
-   i32.sub
-   i32.shl
-   i32.const 1
-   i32.sub
-   i32.add
-   local.set $size
-  end
   memory.size $0
   local.set $pagesBefore
   local.get $size
@@ -1279,6 +1263,22 @@
   i32.shl
   i32.add
   local.set $size
+  local.get $size
+  i32.const 536870910
+  i32.lt_u
+  if
+   local.get $size
+   i32.const 1
+   i32.const 27
+   local.get $size
+   i32.clz
+   i32.sub
+   i32.shl
+   i32.const 1
+   i32.sub
+   i32.add
+   local.set $size
+  end
   local.get $size
   i32.const 65535
   i32.add

--- a/tests/compiler/rt/runtime-minimal-export.release.wat
+++ b/tests/compiler/rt/runtime-minimal-export.release.wat
@@ -775,7 +775,7 @@
    call $~lib/rt/tlsf/initialize
   end
   global.get $~lib/rt/tlsf/ROOT
-  local.set $4
+  local.set $3
   local.get $0
   i32.const 16
   i32.add
@@ -790,7 +790,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $4
+  local.get $3
   i32.const 12
   local.get $2
   i32.const 19
@@ -810,8 +810,9 @@
   if
    memory.size $0
    local.tee $2
+   local.get $5
    i32.const 4
-   local.get $4
+   local.get $3
    i32.load $0 offset=1568
    local.get $2
    i32.const 16
@@ -820,38 +821,40 @@
    i32.sub
    i32.ne
    i32.shl
-   local.get $5
-   i32.const 1
-   i32.const 27
-   local.get $5
-   i32.clz
-   i32.sub
-   i32.shl
-   i32.const 1
-   i32.sub
    i32.add
-   local.get $5
-   local.get $5
+   local.tee $4
    i32.const 536870910
    i32.lt_u
-   select
-   i32.add
+   if (result i32)
+    local.get $4
+    i32.const 1
+    i32.const 27
+    local.get $4
+    i32.clz
+    i32.sub
+    i32.shl
+    i32.const 1
+    i32.sub
+    i32.add
+   else
+    local.get $4
+   end
    i32.const 65535
    i32.add
    i32.const -65536
    i32.and
    i32.const 16
    i32.shr_u
-   local.tee $3
+   local.tee $4
    local.get $2
-   local.get $3
+   local.get $4
    i32.gt_s
    select
    memory.grow $0
    i32.const 0
    i32.lt_s
    if
-    local.get $3
+    local.get $4
     memory.grow $0
     i32.const 0
     i32.lt_s
@@ -859,7 +862,7 @@
      unreachable
     end
    end
-   local.get $4
+   local.get $3
    local.get $2
    i32.const 16
    i32.shl
@@ -868,7 +871,7 @@
    i64.const 16
    i64.shl
    call $~lib/rt/tlsf/addMemory
-   local.get $4
+   local.get $3
    local.get $5
    call $~lib/rt/tlsf/searchBlock
    local.tee $2
@@ -896,12 +899,12 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $4
+  local.get $3
   local.get $2
   call $~lib/rt/tlsf/removeBlock
   local.get $2
   i32.load $0
-  local.set $3
+  local.set $4
   local.get $5
   i32.const 4
   i32.add
@@ -915,7 +918,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $3
+  local.get $4
   i32.const -4
   i32.and
   local.get $5
@@ -926,7 +929,7 @@
   if
    local.get $2
    local.get $5
-   local.get $3
+   local.get $4
    i32.const 2
    i32.and
    i32.or
@@ -936,19 +939,19 @@
    i32.add
    local.get $5
    i32.add
-   local.tee $3
+   local.tee $4
    local.get $6
    i32.const 4
    i32.sub
    i32.const 1
    i32.or
    i32.store $0
-   local.get $4
    local.get $3
+   local.get $4
    call $~lib/rt/tlsf/insertBlock
   else
    local.get $2
-   local.get $3
+   local.get $4
    i32.const -2
    i32.and
    i32.store $0

--- a/tests/compiler/rt/runtime-minimal-export.release.wat
+++ b/tests/compiler/rt/runtime-minimal-export.release.wat
@@ -442,7 +442,7 @@
   if
    i32.const 0
    i32.const 1184
-   i32.const 378
+   i32.const 382
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -467,7 +467,7 @@
    if
     i32.const 0
     i32.const 1184
-    i32.const 385
+    i32.const 389
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -495,7 +495,7 @@
    if
     i32.const 0
     i32.const 1184
-    i32.const 398
+    i32.const 402
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -679,7 +679,7 @@
   if
    i32.const 0
    i32.const 1184
-   i32.const 330
+   i32.const 334
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -731,7 +731,7 @@
     if
      i32.const 0
      i32.const 1184
-     i32.const 343
+     i32.const 347
      i32.const 18
      call $~lib/builtins/abort
      unreachable
@@ -775,7 +775,7 @@
    call $~lib/rt/tlsf/initialize
   end
   global.get $~lib/rt/tlsf/ROOT
-  local.set $3
+  local.set $4
   local.get $0
   i32.const 16
   i32.add
@@ -785,12 +785,12 @@
   if
    i32.const 1056
    i32.const 1184
-   i32.const 459
+   i32.const 461
    i32.const 29
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $3
+  local.get $4
   i32.const 12
   local.get $2
   i32.const 19
@@ -811,8 +811,29 @@
    memory.size $0
    local.tee $2
    local.get $5
+   i32.const 256
+   i32.gt_u
+   if (result i32)
+    local.get $5
+    i32.const 1
+    i32.const 27
+    local.get $5
+    i32.clz
+    i32.sub
+    i32.shl
+    i32.add
+    i32.const 1
+    i32.sub
+    local.get $5
+    local.get $5
+    i32.const 536870910
+    i32.lt_u
+    select
+   else
+    local.get $5
+   end
    i32.const 4
-   local.get $3
+   local.get $4
    i32.load $0 offset=1568
    local.get $2
    i32.const 16
@@ -822,39 +843,22 @@
    i32.ne
    i32.shl
    i32.add
-   local.tee $4
-   i32.const 536870910
-   i32.lt_u
-   if (result i32)
-    local.get $4
-    i32.const 1
-    i32.const 27
-    local.get $4
-    i32.clz
-    i32.sub
-    i32.shl
-    i32.const 1
-    i32.sub
-    i32.add
-   else
-    local.get $4
-   end
    i32.const 65535
    i32.add
    i32.const -65536
    i32.and
    i32.const 16
    i32.shr_u
-   local.tee $4
+   local.tee $3
    local.get $2
-   local.get $4
+   local.get $3
    i32.gt_s
    select
    memory.grow $0
    i32.const 0
    i32.lt_s
    if
-    local.get $4
+    local.get $3
     memory.grow $0
     i32.const 0
     i32.lt_s
@@ -862,7 +866,7 @@
      unreachable
     end
    end
-   local.get $3
+   local.get $4
    local.get $2
    i32.const 16
    i32.shl
@@ -871,7 +875,7 @@
    i64.const 16
    i64.shl
    call $~lib/rt/tlsf/addMemory
-   local.get $3
+   local.get $4
    local.get $5
    call $~lib/rt/tlsf/searchBlock
    local.tee $2
@@ -879,7 +883,7 @@
    if
     i32.const 0
     i32.const 1184
-    i32.const 497
+    i32.const 499
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -894,17 +898,17 @@
   if
    i32.const 0
    i32.const 1184
-   i32.const 499
+   i32.const 501
    i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $3
+  local.get $4
   local.get $2
   call $~lib/rt/tlsf/removeBlock
   local.get $2
   i32.load $0
-  local.set $4
+  local.set $3
   local.get $5
   i32.const 4
   i32.add
@@ -913,12 +917,12 @@
   if
    i32.const 0
    i32.const 1184
-   i32.const 357
+   i32.const 361
    i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $4
+  local.get $3
   i32.const -4
   i32.and
   local.get $5
@@ -929,7 +933,7 @@
   if
    local.get $2
    local.get $5
-   local.get $4
+   local.get $3
    i32.const 2
    i32.and
    i32.or
@@ -939,19 +943,19 @@
    i32.add
    local.get $5
    i32.add
-   local.tee $4
+   local.tee $3
    local.get $6
    i32.const 4
    i32.sub
    i32.const 1
    i32.or
    i32.store $0
-   local.get $3
    local.get $4
+   local.get $3
    call $~lib/rt/tlsf/insertBlock
   else
    local.get $2
-   local.get $4
+   local.get $3
    i32.const -2
    i32.and
    i32.store $0
@@ -1341,7 +1345,7 @@
       if
        i32.const 0
        i32.const 1184
-       i32.const 560
+       i32.const 562
        i32.const 3
        call $~lib/builtins/abort
        unreachable

--- a/tests/compiler/rt/runtime-minimal-export.release.wat
+++ b/tests/compiler/rt/runtime-minimal-export.release.wat
@@ -812,7 +812,7 @@
    local.tee $2
    local.get $5
    i32.const 256
-   i32.gt_u
+   i32.ge_u
    if (result i32)
     local.get $5
     i32.const 1

--- a/tests/compiler/simd.debug.wat
+++ b/tests/compiler/simd.debug.wat
@@ -1951,22 +1951,6 @@
   (local $pagesAfter i32)
   i32.const 0
   drop
-  local.get $size
-  i32.const 536870910
-  i32.lt_u
-  if
-   local.get $size
-   i32.const 1
-   i32.const 27
-   local.get $size
-   i32.clz
-   i32.sub
-   i32.shl
-   i32.const 1
-   i32.sub
-   i32.add
-   local.set $size
-  end
   memory.size $0
   local.set $pagesBefore
   local.get $size
@@ -1987,6 +1971,22 @@
   i32.shl
   i32.add
   local.set $size
+  local.get $size
+  i32.const 536870910
+  i32.lt_u
+  if
+   local.get $size
+   i32.const 1
+   i32.const 27
+   local.get $size
+   i32.clz
+   i32.sub
+   i32.shl
+   i32.const 1
+   i32.sub
+   i32.add
+   local.set $size
+  end
   local.get $size
   i32.const 65535
   i32.add

--- a/tests/compiler/simd.debug.wat
+++ b/tests/compiler/simd.debug.wat
@@ -1,6 +1,6 @@
 (module
- (type $i32_i32_=>_none (func (param i32 i32)))
  (type $i32_=>_i32 (func (param i32) (result i32)))
+ (type $i32_i32_=>_none (func (param i32 i32)))
  (type $none_=>_none (func))
  (type $i32_=>_none (func (param i32)))
  (type $i32_i32_i32_=>_none (func (param i32 i32 i32)))
@@ -1072,7 +1072,7 @@
   if
    i32.const 0
    i32.const 416
-   i32.const 378
+   i32.const 382
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1118,7 +1118,7 @@
    if
     i32.const 0
     i32.const 416
-    i32.const 385
+    i32.const 389
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1151,7 +1151,7 @@
    if
     i32.const 0
     i32.const 416
-    i32.const 398
+    i32.const 402
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1395,7 +1395,7 @@
   if
    i32.const 0
    i32.const 416
-   i32.const 560
+   i32.const 562
    i32.const 3
    call $~lib/builtins/abort
    unreachable
@@ -1724,13 +1724,33 @@
   if
    i32.const 80
    i32.const 416
-   i32.const 459
+   i32.const 461
    i32.const 29
    call $~lib/builtins/abort
    unreachable
   end
   local.get $size
   call $~lib/rt/tlsf/computeSize
+  return
+ )
+ (func $~lib/rt/tlsf/roundSize (param $size i32) (result i32)
+  local.get $size
+  i32.const 536870910
+  i32.lt_u
+  if (result i32)
+   local.get $size
+   i32.const 1
+   i32.const 27
+   local.get $size
+   i32.clz
+   i32.sub
+   i32.shl
+   i32.add
+   i32.const 1
+   i32.sub
+  else
+   local.get $size
+  end
   return
  )
  (func $~lib/rt/tlsf/searchBlock (param $root i32) (param $size i32) (result i32)
@@ -1762,24 +1782,13 @@
    local.set $sl
   else
    local.get $size
-   i32.const 536870910
-   i32.lt_u
-   if (result i32)
-    local.get $size
-    i32.const 1
-    i32.const 27
-    local.get $size
-    i32.clz
-    i32.sub
-    i32.shl
-    i32.add
-    i32.const 1
-    i32.sub
-   else
-    local.get $size
-   end
+   call $~lib/rt/tlsf/roundSize
    local.set $requestSize
-   i32.const 31
+   i32.const 4
+   i32.const 8
+   i32.mul
+   i32.const 1
+   i32.sub
    local.get $requestSize
    i32.clz
    i32.sub
@@ -1817,7 +1826,7 @@
   if
    i32.const 0
    i32.const 416
-   i32.const 330
+   i32.const 334
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1888,7 +1897,7 @@
     if
      i32.const 0
      i32.const 416
-     i32.const 343
+     i32.const 347
      i32.const 18
      call $~lib/builtins/abort
      unreachable
@@ -1951,6 +1960,14 @@
   (local $pagesAfter i32)
   i32.const 0
   drop
+  local.get $size
+  i32.const 256
+  i32.gt_u
+  if
+   local.get $size
+   call $~lib/rt/tlsf/roundSize
+   local.set $size
+  end
   memory.size $0
   local.set $pagesBefore
   local.get $size
@@ -1971,22 +1988,6 @@
   i32.shl
   i32.add
   local.set $size
-  local.get $size
-  i32.const 536870910
-  i32.lt_u
-  if
-   local.get $size
-   i32.const 1
-   i32.const 27
-   local.get $size
-   i32.clz
-   i32.sub
-   i32.shl
-   i32.const 1
-   i32.sub
-   i32.add
-   local.set $size
-  end
   local.get $size
   i32.const 65535
   i32.add
@@ -2053,7 +2054,7 @@
   if
    i32.const 0
    i32.const 416
-   i32.const 357
+   i32.const 361
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -2168,7 +2169,7 @@
    if
     i32.const 0
     i32.const 416
-    i32.const 497
+    i32.const 499
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -2188,7 +2189,7 @@
   if
    i32.const 0
    i32.const 416
-   i32.const 499
+   i32.const 501
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/simd.debug.wat
+++ b/tests/compiler/simd.debug.wat
@@ -1962,7 +1962,7 @@
   drop
   local.get $size
   i32.const 256
-  i32.gt_u
+  i32.ge_u
   if
    local.get $size
    call $~lib/rt/tlsf/roundSize

--- a/tests/compiler/simd.release.wat
+++ b/tests/compiler/simd.release.wat
@@ -651,7 +651,7 @@
   if
    i32.const 0
    i32.const 1440
-   i32.const 378
+   i32.const 382
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -676,7 +676,7 @@
    if
     i32.const 0
     i32.const 1440
-    i32.const 385
+    i32.const 389
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -704,7 +704,7 @@
    if
     i32.const 0
     i32.const 1440
-    i32.const 398
+    i32.const 402
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -872,7 +872,7 @@
   if
    i32.const 0
    i32.const 1440
-   i32.const 560
+   i32.const 562
    i32.const 3
    call $~lib/builtins/abort
    unreachable
@@ -1161,7 +1161,7 @@
   if
    i32.const 0
    i32.const 1440
-   i32.const 330
+   i32.const 334
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1213,7 +1213,7 @@
     if
      i32.const 0
      i32.const 1440
-     i32.const 343
+     i32.const 347
      i32.const 18
      call $~lib/builtins/abort
      unreachable
@@ -1244,7 +1244,7 @@
   if
    i32.const 1104
    i32.const 1440
-   i32.const 459
+   i32.const 461
    i32.const 29
    call $~lib/builtins/abort
    unreachable
@@ -1270,6 +1270,27 @@
    memory.size $0
    local.tee $1
    local.get $3
+   i32.const 256
+   i32.gt_u
+   if (result i32)
+    local.get $3
+    i32.const 1
+    i32.const 27
+    local.get $3
+    i32.clz
+    i32.sub
+    i32.shl
+    i32.add
+    i32.const 1
+    i32.sub
+    local.get $3
+    local.get $3
+    i32.const 536870910
+    i32.lt_u
+    select
+   else
+    local.get $3
+   end
    i32.const 4
    local.get $0
    i32.load $0 offset=1568
@@ -1281,23 +1302,6 @@
    i32.ne
    i32.shl
    i32.add
-   local.tee $2
-   i32.const 536870910
-   i32.lt_u
-   if (result i32)
-    local.get $2
-    i32.const 1
-    i32.const 27
-    local.get $2
-    i32.clz
-    i32.sub
-    i32.shl
-    i32.const 1
-    i32.sub
-    i32.add
-   else
-    local.get $2
-   end
    i32.const 65535
    i32.add
    i32.const -65536
@@ -1338,7 +1342,7 @@
    if
     i32.const 0
     i32.const 1440
-    i32.const 497
+    i32.const 499
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1353,7 +1357,7 @@
   if
    i32.const 0
    i32.const 1440
-   i32.const 499
+   i32.const 501
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1363,7 +1367,7 @@
   call $~lib/rt/tlsf/removeBlock
   local.get $1
   i32.load $0
-  local.set $2
+  local.set $4
   local.get $3
   i32.const 4
   i32.add
@@ -1372,23 +1376,23 @@
   if
    i32.const 0
    i32.const 1440
-   i32.const 357
+   i32.const 361
    i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $2
+  local.get $4
   i32.const -4
   i32.and
   local.get $3
   i32.sub
-  local.tee $4
+  local.tee $2
   i32.const 16
   i32.ge_u
   if
    local.get $1
    local.get $3
-   local.get $2
+   local.get $4
    i32.const 2
    i32.and
    i32.or
@@ -1398,19 +1402,19 @@
    i32.add
    local.get $3
    i32.add
-   local.tee $2
-   local.get $4
+   local.tee $3
+   local.get $2
    i32.const 4
    i32.sub
    i32.const 1
    i32.or
    i32.store $0
    local.get $0
-   local.get $2
+   local.get $3
    call $~lib/rt/tlsf/insertBlock
   else
    local.get $1
-   local.get $2
+   local.get $4
    i32.const -2
    i32.and
    i32.store $0

--- a/tests/compiler/simd.release.wat
+++ b/tests/compiler/simd.release.wat
@@ -1271,7 +1271,7 @@
    local.tee $1
    local.get $3
    i32.const 256
-   i32.gt_u
+   i32.ge_u
    if (result i32)
     local.get $3
     i32.const 1

--- a/tests/compiler/simd.release.wat
+++ b/tests/compiler/simd.release.wat
@@ -1269,6 +1269,7 @@
   if
    memory.size $0
    local.tee $1
+   local.get $3
    i32.const 4
    local.get $0
    i32.load $0 offset=1568
@@ -1279,22 +1280,24 @@
    i32.sub
    i32.ne
    i32.shl
-   local.get $3
-   i32.const 1
-   i32.const 27
-   local.get $3
-   i32.clz
-   i32.sub
-   i32.shl
-   i32.const 1
-   i32.sub
    i32.add
-   local.get $3
-   local.get $3
+   local.tee $2
    i32.const 536870910
    i32.lt_u
-   select
-   i32.add
+   if (result i32)
+    local.get $2
+    i32.const 1
+    i32.const 27
+    local.get $2
+    i32.clz
+    i32.sub
+    i32.shl
+    i32.const 1
+    i32.sub
+    i32.add
+   else
+    local.get $2
+   end
    i32.const 65535
    i32.add
    i32.const -65536
@@ -1360,7 +1363,7 @@
   call $~lib/rt/tlsf/removeBlock
   local.get $1
   i32.load $0
-  local.set $4
+  local.set $2
   local.get $3
   i32.const 4
   i32.add
@@ -1374,18 +1377,18 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $4
+  local.get $2
   i32.const -4
   i32.and
   local.get $3
   i32.sub
-  local.tee $2
+  local.tee $4
   i32.const 16
   i32.ge_u
   if
    local.get $1
    local.get $3
-   local.get $4
+   local.get $2
    i32.const 2
    i32.and
    i32.or
@@ -1395,19 +1398,19 @@
    i32.add
    local.get $3
    i32.add
-   local.tee $3
-   local.get $2
+   local.tee $2
+   local.get $4
    i32.const 4
    i32.sub
    i32.const 1
    i32.or
    i32.store $0
    local.get $0
-   local.get $3
+   local.get $2
    call $~lib/rt/tlsf/insertBlock
   else
    local.get $1
-   local.get $4
+   local.get $2
    i32.const -2
    i32.and
    i32.store $0

--- a/tests/compiler/std/array-literal.debug.wat
+++ b/tests/compiler/std/array-literal.debug.wat
@@ -1947,22 +1947,6 @@
   (local $pagesAfter i32)
   i32.const 0
   drop
-  local.get $size
-  i32.const 536870910
-  i32.lt_u
-  if
-   local.get $size
-   i32.const 1
-   i32.const 27
-   local.get $size
-   i32.clz
-   i32.sub
-   i32.shl
-   i32.const 1
-   i32.sub
-   i32.add
-   local.set $size
-  end
   memory.size $0
   local.set $pagesBefore
   local.get $size
@@ -1983,6 +1967,22 @@
   i32.shl
   i32.add
   local.set $size
+  local.get $size
+  i32.const 536870910
+  i32.lt_u
+  if
+   local.get $size
+   i32.const 1
+   i32.const 27
+   local.get $size
+   i32.clz
+   i32.sub
+   i32.shl
+   i32.const 1
+   i32.sub
+   i32.add
+   local.set $size
+  end
   local.get $size
   i32.const 65535
   i32.add

--- a/tests/compiler/std/array-literal.debug.wat
+++ b/tests/compiler/std/array-literal.debug.wat
@@ -1958,7 +1958,7 @@
   drop
   local.get $size
   i32.const 256
-  i32.gt_u
+  i32.ge_u
   if
    local.get $size
    call $~lib/rt/tlsf/roundSize

--- a/tests/compiler/std/array-literal.debug.wat
+++ b/tests/compiler/std/array-literal.debug.wat
@@ -1068,7 +1068,7 @@
   if
    i32.const 0
    i32.const 720
-   i32.const 378
+   i32.const 382
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1114,7 +1114,7 @@
    if
     i32.const 0
     i32.const 720
-    i32.const 385
+    i32.const 389
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1147,7 +1147,7 @@
    if
     i32.const 0
     i32.const 720
-    i32.const 398
+    i32.const 402
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1391,7 +1391,7 @@
   if
    i32.const 0
    i32.const 720
-   i32.const 560
+   i32.const 562
    i32.const 3
    call $~lib/builtins/abort
    unreachable
@@ -1720,13 +1720,33 @@
   if
    i32.const 448
    i32.const 720
-   i32.const 459
+   i32.const 461
    i32.const 29
    call $~lib/builtins/abort
    unreachable
   end
   local.get $size
   call $~lib/rt/tlsf/computeSize
+  return
+ )
+ (func $~lib/rt/tlsf/roundSize (param $size i32) (result i32)
+  local.get $size
+  i32.const 536870910
+  i32.lt_u
+  if (result i32)
+   local.get $size
+   i32.const 1
+   i32.const 27
+   local.get $size
+   i32.clz
+   i32.sub
+   i32.shl
+   i32.add
+   i32.const 1
+   i32.sub
+  else
+   local.get $size
+  end
   return
  )
  (func $~lib/rt/tlsf/searchBlock (param $root i32) (param $size i32) (result i32)
@@ -1758,24 +1778,13 @@
    local.set $sl
   else
    local.get $size
-   i32.const 536870910
-   i32.lt_u
-   if (result i32)
-    local.get $size
-    i32.const 1
-    i32.const 27
-    local.get $size
-    i32.clz
-    i32.sub
-    i32.shl
-    i32.add
-    i32.const 1
-    i32.sub
-   else
-    local.get $size
-   end
+   call $~lib/rt/tlsf/roundSize
    local.set $requestSize
-   i32.const 31
+   i32.const 4
+   i32.const 8
+   i32.mul
+   i32.const 1
+   i32.sub
    local.get $requestSize
    i32.clz
    i32.sub
@@ -1813,7 +1822,7 @@
   if
    i32.const 0
    i32.const 720
-   i32.const 330
+   i32.const 334
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1884,7 +1893,7 @@
     if
      i32.const 0
      i32.const 720
-     i32.const 343
+     i32.const 347
      i32.const 18
      call $~lib/builtins/abort
      unreachable
@@ -1947,6 +1956,14 @@
   (local $pagesAfter i32)
   i32.const 0
   drop
+  local.get $size
+  i32.const 256
+  i32.gt_u
+  if
+   local.get $size
+   call $~lib/rt/tlsf/roundSize
+   local.set $size
+  end
   memory.size $0
   local.set $pagesBefore
   local.get $size
@@ -1967,22 +1984,6 @@
   i32.shl
   i32.add
   local.set $size
-  local.get $size
-  i32.const 536870910
-  i32.lt_u
-  if
-   local.get $size
-   i32.const 1
-   i32.const 27
-   local.get $size
-   i32.clz
-   i32.sub
-   i32.shl
-   i32.const 1
-   i32.sub
-   i32.add
-   local.set $size
-  end
   local.get $size
   i32.const 65535
   i32.add
@@ -2049,7 +2050,7 @@
   if
    i32.const 0
    i32.const 720
-   i32.const 357
+   i32.const 361
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -2164,7 +2165,7 @@
    if
     i32.const 0
     i32.const 720
-    i32.const 497
+    i32.const 499
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -2184,7 +2185,7 @@
   if
    i32.const 0
    i32.const 720
-   i32.const 499
+   i32.const 501
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/std/array-literal.release.wat
+++ b/tests/compiler/std/array-literal.release.wat
@@ -1326,7 +1326,7 @@
    call $~lib/rt/tlsf/initialize
   end
   global.get $~lib/rt/tlsf/ROOT
-  local.set $4
+  local.set $3
   local.get $0
   i32.const 16
   i32.add
@@ -1341,7 +1341,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $4
+  local.get $3
   i32.const 12
   local.get $2
   i32.const 19
@@ -1361,8 +1361,9 @@
   if
    memory.size $0
    local.tee $2
+   local.get $5
    i32.const 4
-   local.get $4
+   local.get $3
    i32.load $0 offset=1568
    local.get $2
    i32.const 16
@@ -1371,38 +1372,40 @@
    i32.sub
    i32.ne
    i32.shl
-   local.get $5
-   i32.const 1
-   i32.const 27
-   local.get $5
-   i32.clz
-   i32.sub
-   i32.shl
-   i32.const 1
-   i32.sub
    i32.add
-   local.get $5
-   local.get $5
+   local.tee $4
    i32.const 536870910
    i32.lt_u
-   select
-   i32.add
+   if (result i32)
+    local.get $4
+    i32.const 1
+    i32.const 27
+    local.get $4
+    i32.clz
+    i32.sub
+    i32.shl
+    i32.const 1
+    i32.sub
+    i32.add
+   else
+    local.get $4
+   end
    i32.const 65535
    i32.add
    i32.const -65536
    i32.and
    i32.const 16
    i32.shr_u
-   local.tee $3
+   local.tee $4
    local.get $2
-   local.get $3
+   local.get $4
    i32.gt_s
    select
    memory.grow $0
    i32.const 0
    i32.lt_s
    if
-    local.get $3
+    local.get $4
     memory.grow $0
     i32.const 0
     i32.lt_s
@@ -1410,7 +1413,7 @@
      unreachable
     end
    end
-   local.get $4
+   local.get $3
    local.get $2
    i32.const 16
    i32.shl
@@ -1419,7 +1422,7 @@
    i64.const 16
    i64.shl
    call $~lib/rt/tlsf/addMemory
-   local.get $4
+   local.get $3
    local.get $5
    call $~lib/rt/tlsf/searchBlock
    local.tee $2
@@ -1447,12 +1450,12 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $4
+  local.get $3
   local.get $2
   call $~lib/rt/tlsf/removeBlock
   local.get $2
   i32.load $0
-  local.set $3
+  local.set $4
   local.get $5
   i32.const 4
   i32.add
@@ -1466,7 +1469,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $3
+  local.get $4
   i32.const -4
   i32.and
   local.get $5
@@ -1477,7 +1480,7 @@
   if
    local.get $2
    local.get $5
-   local.get $3
+   local.get $4
    i32.const 2
    i32.and
    i32.or
@@ -1487,19 +1490,19 @@
    i32.add
    local.get $5
    i32.add
-   local.tee $3
+   local.tee $4
    local.get $6
    i32.const 4
    i32.sub
    i32.const 1
    i32.or
    i32.store $0
-   local.get $4
    local.get $3
+   local.get $4
    call $~lib/rt/tlsf/insertBlock
   else
    local.get $2
-   local.get $3
+   local.get $4
    i32.const -2
    i32.and
    i32.store $0

--- a/tests/compiler/std/array-literal.release.wat
+++ b/tests/compiler/std/array-literal.release.wat
@@ -681,7 +681,7 @@
   if
    i32.const 0
    i32.const 1744
-   i32.const 378
+   i32.const 382
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -706,7 +706,7 @@
    if
     i32.const 0
     i32.const 1744
-    i32.const 385
+    i32.const 389
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -734,7 +734,7 @@
    if
     i32.const 0
     i32.const 1744
-    i32.const 398
+    i32.const 402
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1101,7 +1101,7 @@
       if
        i32.const 0
        i32.const 1744
-       i32.const 560
+       i32.const 562
        i32.const 3
        call $~lib/builtins/abort
        unreachable
@@ -1185,7 +1185,7 @@
   if
    i32.const 0
    i32.const 1744
-   i32.const 330
+   i32.const 334
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1237,7 +1237,7 @@
     if
      i32.const 0
      i32.const 1744
-     i32.const 343
+     i32.const 347
      i32.const 18
      call $~lib/builtins/abort
      unreachable
@@ -1326,7 +1326,7 @@
    call $~lib/rt/tlsf/initialize
   end
   global.get $~lib/rt/tlsf/ROOT
-  local.set $3
+  local.set $4
   local.get $0
   i32.const 16
   i32.add
@@ -1336,12 +1336,12 @@
   if
    i32.const 1472
    i32.const 1744
-   i32.const 459
+   i32.const 461
    i32.const 29
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $3
+  local.get $4
   i32.const 12
   local.get $2
   i32.const 19
@@ -1362,8 +1362,29 @@
    memory.size $0
    local.tee $2
    local.get $5
+   i32.const 256
+   i32.gt_u
+   if (result i32)
+    local.get $5
+    i32.const 1
+    i32.const 27
+    local.get $5
+    i32.clz
+    i32.sub
+    i32.shl
+    i32.add
+    i32.const 1
+    i32.sub
+    local.get $5
+    local.get $5
+    i32.const 536870910
+    i32.lt_u
+    select
+   else
+    local.get $5
+   end
    i32.const 4
-   local.get $3
+   local.get $4
    i32.load $0 offset=1568
    local.get $2
    i32.const 16
@@ -1373,39 +1394,22 @@
    i32.ne
    i32.shl
    i32.add
-   local.tee $4
-   i32.const 536870910
-   i32.lt_u
-   if (result i32)
-    local.get $4
-    i32.const 1
-    i32.const 27
-    local.get $4
-    i32.clz
-    i32.sub
-    i32.shl
-    i32.const 1
-    i32.sub
-    i32.add
-   else
-    local.get $4
-   end
    i32.const 65535
    i32.add
    i32.const -65536
    i32.and
    i32.const 16
    i32.shr_u
-   local.tee $4
+   local.tee $3
    local.get $2
-   local.get $4
+   local.get $3
    i32.gt_s
    select
    memory.grow $0
    i32.const 0
    i32.lt_s
    if
-    local.get $4
+    local.get $3
     memory.grow $0
     i32.const 0
     i32.lt_s
@@ -1413,7 +1417,7 @@
      unreachable
     end
    end
-   local.get $3
+   local.get $4
    local.get $2
    i32.const 16
    i32.shl
@@ -1422,7 +1426,7 @@
    i64.const 16
    i64.shl
    call $~lib/rt/tlsf/addMemory
-   local.get $3
+   local.get $4
    local.get $5
    call $~lib/rt/tlsf/searchBlock
    local.tee $2
@@ -1430,7 +1434,7 @@
    if
     i32.const 0
     i32.const 1744
-    i32.const 497
+    i32.const 499
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1445,17 +1449,17 @@
   if
    i32.const 0
    i32.const 1744
-   i32.const 499
+   i32.const 501
    i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $3
+  local.get $4
   local.get $2
   call $~lib/rt/tlsf/removeBlock
   local.get $2
   i32.load $0
-  local.set $4
+  local.set $3
   local.get $5
   i32.const 4
   i32.add
@@ -1464,12 +1468,12 @@
   if
    i32.const 0
    i32.const 1744
-   i32.const 357
+   i32.const 361
    i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $4
+  local.get $3
   i32.const -4
   i32.and
   local.get $5
@@ -1480,7 +1484,7 @@
   if
    local.get $2
    local.get $5
-   local.get $4
+   local.get $3
    i32.const 2
    i32.and
    i32.or
@@ -1490,19 +1494,19 @@
    i32.add
    local.get $5
    i32.add
-   local.tee $4
+   local.tee $3
    local.get $6
    i32.const 4
    i32.sub
    i32.const 1
    i32.or
    i32.store $0
-   local.get $3
    local.get $4
+   local.get $3
    call $~lib/rt/tlsf/insertBlock
   else
    local.get $2
-   local.get $4
+   local.get $3
    i32.const -2
    i32.and
    i32.store $0

--- a/tests/compiler/std/array-literal.release.wat
+++ b/tests/compiler/std/array-literal.release.wat
@@ -1363,7 +1363,7 @@
    local.tee $2
    local.get $5
    i32.const 256
-   i32.gt_u
+   i32.ge_u
    if (result i32)
     local.get $5
     i32.const 1

--- a/tests/compiler/std/array.debug.wat
+++ b/tests/compiler/std/array.debug.wat
@@ -2256,22 +2256,6 @@
   (local $pagesAfter i32)
   i32.const 0
   drop
-  local.get $size
-  i32.const 536870910
-  i32.lt_u
-  if
-   local.get $size
-   i32.const 1
-   i32.const 27
-   local.get $size
-   i32.clz
-   i32.sub
-   i32.shl
-   i32.const 1
-   i32.sub
-   i32.add
-   local.set $size
-  end
   memory.size $0
   local.set $pagesBefore
   local.get $size
@@ -2292,6 +2276,22 @@
   i32.shl
   i32.add
   local.set $size
+  local.get $size
+  i32.const 536870910
+  i32.lt_u
+  if
+   local.get $size
+   i32.const 1
+   i32.const 27
+   local.get $size
+   i32.clz
+   i32.sub
+   i32.shl
+   i32.const 1
+   i32.sub
+   i32.add
+   local.set $size
+  end
   local.get $size
   i32.const 65535
   i32.add

--- a/tests/compiler/std/array.debug.wat
+++ b/tests/compiler/std/array.debug.wat
@@ -2267,7 +2267,7 @@
   drop
   local.get $size
   i32.const 256
-  i32.gt_u
+  i32.ge_u
   if
    local.get $size
    call $~lib/rt/tlsf/roundSize

--- a/tests/compiler/std/array.debug.wat
+++ b/tests/compiler/std/array.debug.wat
@@ -1377,7 +1377,7 @@
   if
    i32.const 0
    i32.const 464
-   i32.const 378
+   i32.const 382
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1423,7 +1423,7 @@
    if
     i32.const 0
     i32.const 464
-    i32.const 385
+    i32.const 389
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1456,7 +1456,7 @@
    if
     i32.const 0
     i32.const 464
-    i32.const 398
+    i32.const 402
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1700,7 +1700,7 @@
   if
    i32.const 0
    i32.const 464
-   i32.const 560
+   i32.const 562
    i32.const 3
    call $~lib/builtins/abort
    unreachable
@@ -2029,13 +2029,33 @@
   if
    i32.const 128
    i32.const 464
-   i32.const 459
+   i32.const 461
    i32.const 29
    call $~lib/builtins/abort
    unreachable
   end
   local.get $size
   call $~lib/rt/tlsf/computeSize
+  return
+ )
+ (func $~lib/rt/tlsf/roundSize (param $size i32) (result i32)
+  local.get $size
+  i32.const 536870910
+  i32.lt_u
+  if (result i32)
+   local.get $size
+   i32.const 1
+   i32.const 27
+   local.get $size
+   i32.clz
+   i32.sub
+   i32.shl
+   i32.add
+   i32.const 1
+   i32.sub
+  else
+   local.get $size
+  end
   return
  )
  (func $~lib/rt/tlsf/searchBlock (param $root i32) (param $size i32) (result i32)
@@ -2067,24 +2087,13 @@
    local.set $sl
   else
    local.get $size
-   i32.const 536870910
-   i32.lt_u
-   if (result i32)
-    local.get $size
-    i32.const 1
-    i32.const 27
-    local.get $size
-    i32.clz
-    i32.sub
-    i32.shl
-    i32.add
-    i32.const 1
-    i32.sub
-   else
-    local.get $size
-   end
+   call $~lib/rt/tlsf/roundSize
    local.set $requestSize
-   i32.const 31
+   i32.const 4
+   i32.const 8
+   i32.mul
+   i32.const 1
+   i32.sub
    local.get $requestSize
    i32.clz
    i32.sub
@@ -2122,7 +2131,7 @@
   if
    i32.const 0
    i32.const 464
-   i32.const 330
+   i32.const 334
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -2193,7 +2202,7 @@
     if
      i32.const 0
      i32.const 464
-     i32.const 343
+     i32.const 347
      i32.const 18
      call $~lib/builtins/abort
      unreachable
@@ -2256,6 +2265,14 @@
   (local $pagesAfter i32)
   i32.const 0
   drop
+  local.get $size
+  i32.const 256
+  i32.gt_u
+  if
+   local.get $size
+   call $~lib/rt/tlsf/roundSize
+   local.set $size
+  end
   memory.size $0
   local.set $pagesBefore
   local.get $size
@@ -2276,22 +2293,6 @@
   i32.shl
   i32.add
   local.set $size
-  local.get $size
-  i32.const 536870910
-  i32.lt_u
-  if
-   local.get $size
-   i32.const 1
-   i32.const 27
-   local.get $size
-   i32.clz
-   i32.sub
-   i32.shl
-   i32.const 1
-   i32.sub
-   i32.add
-   local.set $size
-  end
   local.get $size
   i32.const 65535
   i32.add
@@ -2358,7 +2359,7 @@
   if
    i32.const 0
    i32.const 464
-   i32.const 357
+   i32.const 361
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -2473,7 +2474,7 @@
    if
     i32.const 0
     i32.const 464
-    i32.const 497
+    i32.const 499
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -2493,7 +2494,7 @@
   if
    i32.const 0
    i32.const 464
-   i32.const 499
+   i32.const 501
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/std/array.release.wat
+++ b/tests/compiler/std/array.release.wat
@@ -1276,7 +1276,7 @@
   if
    i32.const 0
    i32.const 1488
-   i32.const 378
+   i32.const 382
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1301,7 +1301,7 @@
    if
     i32.const 0
     i32.const 1488
-    i32.const 385
+    i32.const 389
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1329,7 +1329,7 @@
    if
     i32.const 0
     i32.const 1488
-    i32.const 398
+    i32.const 402
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1497,7 +1497,7 @@
   if
    i32.const 0
    i32.const 1488
-   i32.const 560
+   i32.const 562
    i32.const 3
    call $~lib/builtins/abort
    unreachable
@@ -1786,7 +1786,7 @@
   if
    i32.const 0
    i32.const 1488
-   i32.const 330
+   i32.const 334
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1838,7 +1838,7 @@
     if
      i32.const 0
      i32.const 1488
-     i32.const 343
+     i32.const 347
      i32.const 18
      call $~lib/builtins/abort
      unreachable
@@ -1869,7 +1869,7 @@
   if
    i32.const 1152
    i32.const 1488
-   i32.const 459
+   i32.const 461
    i32.const 29
    call $~lib/builtins/abort
    unreachable
@@ -1895,6 +1895,27 @@
    memory.size $0
    local.tee $1
    local.get $3
+   i32.const 256
+   i32.gt_u
+   if (result i32)
+    local.get $3
+    i32.const 1
+    i32.const 27
+    local.get $3
+    i32.clz
+    i32.sub
+    i32.shl
+    i32.add
+    i32.const 1
+    i32.sub
+    local.get $3
+    local.get $3
+    i32.const 536870910
+    i32.lt_u
+    select
+   else
+    local.get $3
+   end
    i32.const 4
    local.get $0
    i32.load $0 offset=1568
@@ -1906,23 +1927,6 @@
    i32.ne
    i32.shl
    i32.add
-   local.tee $2
-   i32.const 536870910
-   i32.lt_u
-   if (result i32)
-    local.get $2
-    i32.const 1
-    i32.const 27
-    local.get $2
-    i32.clz
-    i32.sub
-    i32.shl
-    i32.const 1
-    i32.sub
-    i32.add
-   else
-    local.get $2
-   end
    i32.const 65535
    i32.add
    i32.const -65536
@@ -1963,7 +1967,7 @@
    if
     i32.const 0
     i32.const 1488
-    i32.const 497
+    i32.const 499
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1978,7 +1982,7 @@
   if
    i32.const 0
    i32.const 1488
-   i32.const 499
+   i32.const 501
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1988,7 +1992,7 @@
   call $~lib/rt/tlsf/removeBlock
   local.get $1
   i32.load $0
-  local.set $2
+  local.set $4
   local.get $3
   i32.const 4
   i32.add
@@ -1997,23 +2001,23 @@
   if
    i32.const 0
    i32.const 1488
-   i32.const 357
+   i32.const 361
    i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $2
+  local.get $4
   i32.const -4
   i32.and
   local.get $3
   i32.sub
-  local.tee $4
+  local.tee $2
   i32.const 16
   i32.ge_u
   if
    local.get $1
    local.get $3
-   local.get $2
+   local.get $4
    i32.const 2
    i32.and
    i32.or
@@ -2023,19 +2027,19 @@
    i32.add
    local.get $3
    i32.add
-   local.tee $2
-   local.get $4
+   local.tee $3
+   local.get $2
    i32.const 4
    i32.sub
    i32.const 1
    i32.or
    i32.store $0
    local.get $0
-   local.get $2
+   local.get $3
    call $~lib/rt/tlsf/insertBlock
   else
    local.get $1
-   local.get $2
+   local.get $4
    i32.const -2
    i32.and
    i32.store $0

--- a/tests/compiler/std/array.release.wat
+++ b/tests/compiler/std/array.release.wat
@@ -1894,6 +1894,7 @@
   if
    memory.size $0
    local.tee $1
+   local.get $3
    i32.const 4
    local.get $0
    i32.load $0 offset=1568
@@ -1904,22 +1905,24 @@
    i32.sub
    i32.ne
    i32.shl
-   local.get $3
-   i32.const 1
-   i32.const 27
-   local.get $3
-   i32.clz
-   i32.sub
-   i32.shl
-   i32.const 1
-   i32.sub
    i32.add
-   local.get $3
-   local.get $3
+   local.tee $2
    i32.const 536870910
    i32.lt_u
-   select
-   i32.add
+   if (result i32)
+    local.get $2
+    i32.const 1
+    i32.const 27
+    local.get $2
+    i32.clz
+    i32.sub
+    i32.shl
+    i32.const 1
+    i32.sub
+    i32.add
+   else
+    local.get $2
+   end
    i32.const 65535
    i32.add
    i32.const -65536
@@ -1985,7 +1988,7 @@
   call $~lib/rt/tlsf/removeBlock
   local.get $1
   i32.load $0
-  local.set $4
+  local.set $2
   local.get $3
   i32.const 4
   i32.add
@@ -1999,18 +2002,18 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $4
+  local.get $2
   i32.const -4
   i32.and
   local.get $3
   i32.sub
-  local.tee $2
+  local.tee $4
   i32.const 16
   i32.ge_u
   if
    local.get $1
    local.get $3
-   local.get $4
+   local.get $2
    i32.const 2
    i32.and
    i32.or
@@ -2020,19 +2023,19 @@
    i32.add
    local.get $3
    i32.add
-   local.tee $3
-   local.get $2
+   local.tee $2
+   local.get $4
    i32.const 4
    i32.sub
    i32.const 1
    i32.or
    i32.store $0
    local.get $0
-   local.get $3
+   local.get $2
    call $~lib/rt/tlsf/insertBlock
   else
    local.get $1
-   local.get $4
+   local.get $2
    i32.const -2
    i32.and
    i32.store $0

--- a/tests/compiler/std/array.release.wat
+++ b/tests/compiler/std/array.release.wat
@@ -1896,7 +1896,7 @@
    local.tee $1
    local.get $3
    i32.const 256
-   i32.gt_u
+   i32.ge_u
    if (result i32)
     local.get $3
     i32.const 1

--- a/tests/compiler/std/arraybuffer.debug.wat
+++ b/tests/compiler/std/arraybuffer.debug.wat
@@ -1931,7 +1931,7 @@
   drop
   local.get $size
   i32.const 256
-  i32.gt_u
+  i32.ge_u
   if
    local.get $size
    call $~lib/rt/tlsf/roundSize

--- a/tests/compiler/std/arraybuffer.debug.wat
+++ b/tests/compiler/std/arraybuffer.debug.wat
@@ -1041,7 +1041,7 @@
   if
    i32.const 0
    i32.const 480
-   i32.const 378
+   i32.const 382
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1087,7 +1087,7 @@
    if
     i32.const 0
     i32.const 480
-    i32.const 385
+    i32.const 389
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1120,7 +1120,7 @@
    if
     i32.const 0
     i32.const 480
-    i32.const 398
+    i32.const 402
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1364,7 +1364,7 @@
   if
    i32.const 0
    i32.const 480
-   i32.const 560
+   i32.const 562
    i32.const 3
    call $~lib/builtins/abort
    unreachable
@@ -1693,13 +1693,33 @@
   if
    i32.const 144
    i32.const 480
-   i32.const 459
+   i32.const 461
    i32.const 29
    call $~lib/builtins/abort
    unreachable
   end
   local.get $size
   call $~lib/rt/tlsf/computeSize
+  return
+ )
+ (func $~lib/rt/tlsf/roundSize (param $size i32) (result i32)
+  local.get $size
+  i32.const 536870910
+  i32.lt_u
+  if (result i32)
+   local.get $size
+   i32.const 1
+   i32.const 27
+   local.get $size
+   i32.clz
+   i32.sub
+   i32.shl
+   i32.add
+   i32.const 1
+   i32.sub
+  else
+   local.get $size
+  end
   return
  )
  (func $~lib/rt/tlsf/searchBlock (param $root i32) (param $size i32) (result i32)
@@ -1731,24 +1751,13 @@
    local.set $sl
   else
    local.get $size
-   i32.const 536870910
-   i32.lt_u
-   if (result i32)
-    local.get $size
-    i32.const 1
-    i32.const 27
-    local.get $size
-    i32.clz
-    i32.sub
-    i32.shl
-    i32.add
-    i32.const 1
-    i32.sub
-   else
-    local.get $size
-   end
+   call $~lib/rt/tlsf/roundSize
    local.set $requestSize
-   i32.const 31
+   i32.const 4
+   i32.const 8
+   i32.mul
+   i32.const 1
+   i32.sub
    local.get $requestSize
    i32.clz
    i32.sub
@@ -1786,7 +1795,7 @@
   if
    i32.const 0
    i32.const 480
-   i32.const 330
+   i32.const 334
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1857,7 +1866,7 @@
     if
      i32.const 0
      i32.const 480
-     i32.const 343
+     i32.const 347
      i32.const 18
      call $~lib/builtins/abort
      unreachable
@@ -1920,6 +1929,14 @@
   (local $pagesAfter i32)
   i32.const 0
   drop
+  local.get $size
+  i32.const 256
+  i32.gt_u
+  if
+   local.get $size
+   call $~lib/rt/tlsf/roundSize
+   local.set $size
+  end
   memory.size $0
   local.set $pagesBefore
   local.get $size
@@ -1940,22 +1957,6 @@
   i32.shl
   i32.add
   local.set $size
-  local.get $size
-  i32.const 536870910
-  i32.lt_u
-  if
-   local.get $size
-   i32.const 1
-   i32.const 27
-   local.get $size
-   i32.clz
-   i32.sub
-   i32.shl
-   i32.const 1
-   i32.sub
-   i32.add
-   local.set $size
-  end
   local.get $size
   i32.const 65535
   i32.add
@@ -2022,7 +2023,7 @@
   if
    i32.const 0
    i32.const 480
-   i32.const 357
+   i32.const 361
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -2137,7 +2138,7 @@
    if
     i32.const 0
     i32.const 480
-    i32.const 497
+    i32.const 499
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -2157,7 +2158,7 @@
   if
    i32.const 0
    i32.const 480
-   i32.const 499
+   i32.const 501
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/std/arraybuffer.debug.wat
+++ b/tests/compiler/std/arraybuffer.debug.wat
@@ -1920,22 +1920,6 @@
   (local $pagesAfter i32)
   i32.const 0
   drop
-  local.get $size
-  i32.const 536870910
-  i32.lt_u
-  if
-   local.get $size
-   i32.const 1
-   i32.const 27
-   local.get $size
-   i32.clz
-   i32.sub
-   i32.shl
-   i32.const 1
-   i32.sub
-   i32.add
-   local.set $size
-  end
   memory.size $0
   local.set $pagesBefore
   local.get $size
@@ -1956,6 +1940,22 @@
   i32.shl
   i32.add
   local.set $size
+  local.get $size
+  i32.const 536870910
+  i32.lt_u
+  if
+   local.get $size
+   i32.const 1
+   i32.const 27
+   local.get $size
+   i32.clz
+   i32.sub
+   i32.shl
+   i32.const 1
+   i32.sub
+   i32.add
+   local.set $size
+  end
   local.get $size
   i32.const 65535
   i32.add

--- a/tests/compiler/std/arraybuffer.release.wat
+++ b/tests/compiler/std/arraybuffer.release.wat
@@ -1277,7 +1277,7 @@
    call $~lib/rt/tlsf/initialize
   end
   global.get $~lib/rt/tlsf/ROOT
-  local.set $4
+  local.set $3
   local.get $0
   i32.const 16
   i32.add
@@ -1292,7 +1292,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $4
+  local.get $3
   i32.const 12
   local.get $2
   i32.const 19
@@ -1312,8 +1312,9 @@
   if
    memory.size $0
    local.tee $2
+   local.get $5
    i32.const 4
-   local.get $4
+   local.get $3
    i32.load $0 offset=1568
    local.get $2
    i32.const 16
@@ -1322,38 +1323,40 @@
    i32.sub
    i32.ne
    i32.shl
-   local.get $5
-   i32.const 1
-   i32.const 27
-   local.get $5
-   i32.clz
-   i32.sub
-   i32.shl
-   i32.const 1
-   i32.sub
    i32.add
-   local.get $5
-   local.get $5
+   local.tee $4
    i32.const 536870910
    i32.lt_u
-   select
-   i32.add
+   if (result i32)
+    local.get $4
+    i32.const 1
+    i32.const 27
+    local.get $4
+    i32.clz
+    i32.sub
+    i32.shl
+    i32.const 1
+    i32.sub
+    i32.add
+   else
+    local.get $4
+   end
    i32.const 65535
    i32.add
    i32.const -65536
    i32.and
    i32.const 16
    i32.shr_u
-   local.tee $3
+   local.tee $4
    local.get $2
-   local.get $3
+   local.get $4
    i32.gt_s
    select
    memory.grow $0
    i32.const 0
    i32.lt_s
    if
-    local.get $3
+    local.get $4
     memory.grow $0
     i32.const 0
     i32.lt_s
@@ -1361,7 +1364,7 @@
      unreachable
     end
    end
-   local.get $4
+   local.get $3
    local.get $2
    i32.const 16
    i32.shl
@@ -1370,7 +1373,7 @@
    i64.const 16
    i64.shl
    call $~lib/rt/tlsf/addMemory
-   local.get $4
+   local.get $3
    local.get $5
    call $~lib/rt/tlsf/searchBlock
    local.tee $2
@@ -1398,12 +1401,12 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $4
+  local.get $3
   local.get $2
   call $~lib/rt/tlsf/removeBlock
   local.get $2
   i32.load $0
-  local.set $3
+  local.set $4
   local.get $5
   i32.const 4
   i32.add
@@ -1417,7 +1420,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $3
+  local.get $4
   i32.const -4
   i32.and
   local.get $5
@@ -1428,7 +1431,7 @@
   if
    local.get $2
    local.get $5
-   local.get $3
+   local.get $4
    i32.const 2
    i32.and
    i32.or
@@ -1438,19 +1441,19 @@
    i32.add
    local.get $5
    i32.add
-   local.tee $3
+   local.tee $4
    local.get $6
    i32.const 4
    i32.sub
    i32.const 1
    i32.or
    i32.store $0
-   local.get $4
    local.get $3
+   local.get $4
    call $~lib/rt/tlsf/insertBlock
   else
    local.get $2
-   local.get $3
+   local.get $4
    i32.const -2
    i32.and
    i32.store $0

--- a/tests/compiler/std/arraybuffer.release.wat
+++ b/tests/compiler/std/arraybuffer.release.wat
@@ -632,7 +632,7 @@
   if
    i32.const 0
    i32.const 1504
-   i32.const 378
+   i32.const 382
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -657,7 +657,7 @@
    if
     i32.const 0
     i32.const 1504
-    i32.const 385
+    i32.const 389
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -685,7 +685,7 @@
    if
     i32.const 0
     i32.const 1504
-    i32.const 398
+    i32.const 402
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1052,7 +1052,7 @@
       if
        i32.const 0
        i32.const 1504
-       i32.const 560
+       i32.const 562
        i32.const 3
        call $~lib/builtins/abort
        unreachable
@@ -1136,7 +1136,7 @@
   if
    i32.const 0
    i32.const 1504
-   i32.const 330
+   i32.const 334
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1188,7 +1188,7 @@
     if
      i32.const 0
      i32.const 1504
-     i32.const 343
+     i32.const 347
      i32.const 18
      call $~lib/builtins/abort
      unreachable
@@ -1277,7 +1277,7 @@
    call $~lib/rt/tlsf/initialize
   end
   global.get $~lib/rt/tlsf/ROOT
-  local.set $3
+  local.set $4
   local.get $0
   i32.const 16
   i32.add
@@ -1287,12 +1287,12 @@
   if
    i32.const 1168
    i32.const 1504
-   i32.const 459
+   i32.const 461
    i32.const 29
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $3
+  local.get $4
   i32.const 12
   local.get $2
   i32.const 19
@@ -1313,8 +1313,29 @@
    memory.size $0
    local.tee $2
    local.get $5
+   i32.const 256
+   i32.gt_u
+   if (result i32)
+    local.get $5
+    i32.const 1
+    i32.const 27
+    local.get $5
+    i32.clz
+    i32.sub
+    i32.shl
+    i32.add
+    i32.const 1
+    i32.sub
+    local.get $5
+    local.get $5
+    i32.const 536870910
+    i32.lt_u
+    select
+   else
+    local.get $5
+   end
    i32.const 4
-   local.get $3
+   local.get $4
    i32.load $0 offset=1568
    local.get $2
    i32.const 16
@@ -1324,39 +1345,22 @@
    i32.ne
    i32.shl
    i32.add
-   local.tee $4
-   i32.const 536870910
-   i32.lt_u
-   if (result i32)
-    local.get $4
-    i32.const 1
-    i32.const 27
-    local.get $4
-    i32.clz
-    i32.sub
-    i32.shl
-    i32.const 1
-    i32.sub
-    i32.add
-   else
-    local.get $4
-   end
    i32.const 65535
    i32.add
    i32.const -65536
    i32.and
    i32.const 16
    i32.shr_u
-   local.tee $4
+   local.tee $3
    local.get $2
-   local.get $4
+   local.get $3
    i32.gt_s
    select
    memory.grow $0
    i32.const 0
    i32.lt_s
    if
-    local.get $4
+    local.get $3
     memory.grow $0
     i32.const 0
     i32.lt_s
@@ -1364,7 +1368,7 @@
      unreachable
     end
    end
-   local.get $3
+   local.get $4
    local.get $2
    i32.const 16
    i32.shl
@@ -1373,7 +1377,7 @@
    i64.const 16
    i64.shl
    call $~lib/rt/tlsf/addMemory
-   local.get $3
+   local.get $4
    local.get $5
    call $~lib/rt/tlsf/searchBlock
    local.tee $2
@@ -1381,7 +1385,7 @@
    if
     i32.const 0
     i32.const 1504
-    i32.const 497
+    i32.const 499
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1396,17 +1400,17 @@
   if
    i32.const 0
    i32.const 1504
-   i32.const 499
+   i32.const 501
    i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $3
+  local.get $4
   local.get $2
   call $~lib/rt/tlsf/removeBlock
   local.get $2
   i32.load $0
-  local.set $4
+  local.set $3
   local.get $5
   i32.const 4
   i32.add
@@ -1415,12 +1419,12 @@
   if
    i32.const 0
    i32.const 1504
-   i32.const 357
+   i32.const 361
    i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $4
+  local.get $3
   i32.const -4
   i32.and
   local.get $5
@@ -1431,7 +1435,7 @@
   if
    local.get $2
    local.get $5
-   local.get $4
+   local.get $3
    i32.const 2
    i32.and
    i32.or
@@ -1441,19 +1445,19 @@
    i32.add
    local.get $5
    i32.add
-   local.tee $4
+   local.tee $3
    local.get $6
    i32.const 4
    i32.sub
    i32.const 1
    i32.or
    i32.store $0
-   local.get $3
    local.get $4
+   local.get $3
    call $~lib/rt/tlsf/insertBlock
   else
    local.get $2
-   local.get $4
+   local.get $3
    i32.const -2
    i32.and
    i32.store $0

--- a/tests/compiler/std/arraybuffer.release.wat
+++ b/tests/compiler/std/arraybuffer.release.wat
@@ -1314,7 +1314,7 @@
    local.tee $2
    local.get $5
    i32.const 256
-   i32.gt_u
+   i32.ge_u
    if (result i32)
     local.get $5
     i32.const 1

--- a/tests/compiler/std/dataview.debug.wat
+++ b/tests/compiler/std/dataview.debug.wat
@@ -1047,7 +1047,7 @@
   if
    i32.const 0
    i32.const 480
-   i32.const 378
+   i32.const 382
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1093,7 +1093,7 @@
    if
     i32.const 0
     i32.const 480
-    i32.const 385
+    i32.const 389
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1126,7 +1126,7 @@
    if
     i32.const 0
     i32.const 480
-    i32.const 398
+    i32.const 402
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1370,7 +1370,7 @@
   if
    i32.const 0
    i32.const 480
-   i32.const 560
+   i32.const 562
    i32.const 3
    call $~lib/builtins/abort
    unreachable
@@ -1699,13 +1699,33 @@
   if
    i32.const 144
    i32.const 480
-   i32.const 459
+   i32.const 461
    i32.const 29
    call $~lib/builtins/abort
    unreachable
   end
   local.get $size
   call $~lib/rt/tlsf/computeSize
+  return
+ )
+ (func $~lib/rt/tlsf/roundSize (param $size i32) (result i32)
+  local.get $size
+  i32.const 536870910
+  i32.lt_u
+  if (result i32)
+   local.get $size
+   i32.const 1
+   i32.const 27
+   local.get $size
+   i32.clz
+   i32.sub
+   i32.shl
+   i32.add
+   i32.const 1
+   i32.sub
+  else
+   local.get $size
+  end
   return
  )
  (func $~lib/rt/tlsf/searchBlock (param $root i32) (param $size i32) (result i32)
@@ -1737,24 +1757,13 @@
    local.set $sl
   else
    local.get $size
-   i32.const 536870910
-   i32.lt_u
-   if (result i32)
-    local.get $size
-    i32.const 1
-    i32.const 27
-    local.get $size
-    i32.clz
-    i32.sub
-    i32.shl
-    i32.add
-    i32.const 1
-    i32.sub
-   else
-    local.get $size
-   end
+   call $~lib/rt/tlsf/roundSize
    local.set $requestSize
-   i32.const 31
+   i32.const 4
+   i32.const 8
+   i32.mul
+   i32.const 1
+   i32.sub
    local.get $requestSize
    i32.clz
    i32.sub
@@ -1792,7 +1801,7 @@
   if
    i32.const 0
    i32.const 480
-   i32.const 330
+   i32.const 334
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1863,7 +1872,7 @@
     if
      i32.const 0
      i32.const 480
-     i32.const 343
+     i32.const 347
      i32.const 18
      call $~lib/builtins/abort
      unreachable
@@ -1926,6 +1935,14 @@
   (local $pagesAfter i32)
   i32.const 0
   drop
+  local.get $size
+  i32.const 256
+  i32.gt_u
+  if
+   local.get $size
+   call $~lib/rt/tlsf/roundSize
+   local.set $size
+  end
   memory.size $0
   local.set $pagesBefore
   local.get $size
@@ -1946,22 +1963,6 @@
   i32.shl
   i32.add
   local.set $size
-  local.get $size
-  i32.const 536870910
-  i32.lt_u
-  if
-   local.get $size
-   i32.const 1
-   i32.const 27
-   local.get $size
-   i32.clz
-   i32.sub
-   i32.shl
-   i32.const 1
-   i32.sub
-   i32.add
-   local.set $size
-  end
   local.get $size
   i32.const 65535
   i32.add
@@ -2028,7 +2029,7 @@
   if
    i32.const 0
    i32.const 480
-   i32.const 357
+   i32.const 361
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -2143,7 +2144,7 @@
    if
     i32.const 0
     i32.const 480
-    i32.const 497
+    i32.const 499
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -2163,7 +2164,7 @@
   if
    i32.const 0
    i32.const 480
-   i32.const 499
+   i32.const 501
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/std/dataview.debug.wat
+++ b/tests/compiler/std/dataview.debug.wat
@@ -1926,22 +1926,6 @@
   (local $pagesAfter i32)
   i32.const 0
   drop
-  local.get $size
-  i32.const 536870910
-  i32.lt_u
-  if
-   local.get $size
-   i32.const 1
-   i32.const 27
-   local.get $size
-   i32.clz
-   i32.sub
-   i32.shl
-   i32.const 1
-   i32.sub
-   i32.add
-   local.set $size
-  end
   memory.size $0
   local.set $pagesBefore
   local.get $size
@@ -1962,6 +1946,22 @@
   i32.shl
   i32.add
   local.set $size
+  local.get $size
+  i32.const 536870910
+  i32.lt_u
+  if
+   local.get $size
+   i32.const 1
+   i32.const 27
+   local.get $size
+   i32.clz
+   i32.sub
+   i32.shl
+   i32.const 1
+   i32.sub
+   i32.add
+   local.set $size
+  end
   local.get $size
   i32.const 65535
   i32.add

--- a/tests/compiler/std/dataview.debug.wat
+++ b/tests/compiler/std/dataview.debug.wat
@@ -1937,7 +1937,7 @@
   drop
   local.get $size
   i32.const 256
-  i32.gt_u
+  i32.ge_u
   if
    local.get $size
    call $~lib/rt/tlsf/roundSize

--- a/tests/compiler/std/dataview.release.wat
+++ b/tests/compiler/std/dataview.release.wat
@@ -1285,7 +1285,7 @@
    call $~lib/rt/tlsf/initialize
   end
   global.get $~lib/rt/tlsf/ROOT
-  local.set $4
+  local.set $3
   local.get $0
   i32.const 16
   i32.add
@@ -1300,7 +1300,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $4
+  local.get $3
   i32.const 12
   local.get $2
   i32.const 19
@@ -1320,8 +1320,9 @@
   if
    memory.size $0
    local.tee $2
+   local.get $5
    i32.const 4
-   local.get $4
+   local.get $3
    i32.load $0 offset=1568
    local.get $2
    i32.const 16
@@ -1330,38 +1331,40 @@
    i32.sub
    i32.ne
    i32.shl
-   local.get $5
-   i32.const 1
-   i32.const 27
-   local.get $5
-   i32.clz
-   i32.sub
-   i32.shl
-   i32.const 1
-   i32.sub
    i32.add
-   local.get $5
-   local.get $5
+   local.tee $4
    i32.const 536870910
    i32.lt_u
-   select
-   i32.add
+   if (result i32)
+    local.get $4
+    i32.const 1
+    i32.const 27
+    local.get $4
+    i32.clz
+    i32.sub
+    i32.shl
+    i32.const 1
+    i32.sub
+    i32.add
+   else
+    local.get $4
+   end
    i32.const 65535
    i32.add
    i32.const -65536
    i32.and
    i32.const 16
    i32.shr_u
-   local.tee $3
+   local.tee $4
    local.get $2
-   local.get $3
+   local.get $4
    i32.gt_s
    select
    memory.grow $0
    i32.const 0
    i32.lt_s
    if
-    local.get $3
+    local.get $4
     memory.grow $0
     i32.const 0
     i32.lt_s
@@ -1369,7 +1372,7 @@
      unreachable
     end
    end
-   local.get $4
+   local.get $3
    local.get $2
    i32.const 16
    i32.shl
@@ -1378,7 +1381,7 @@
    i64.const 16
    i64.shl
    call $~lib/rt/tlsf/addMemory
-   local.get $4
+   local.get $3
    local.get $5
    call $~lib/rt/tlsf/searchBlock
    local.tee $2
@@ -1406,12 +1409,12 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $4
+  local.get $3
   local.get $2
   call $~lib/rt/tlsf/removeBlock
   local.get $2
   i32.load $0
-  local.set $3
+  local.set $4
   local.get $5
   i32.const 4
   i32.add
@@ -1425,7 +1428,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $3
+  local.get $4
   i32.const -4
   i32.and
   local.get $5
@@ -1436,7 +1439,7 @@
   if
    local.get $2
    local.get $5
-   local.get $3
+   local.get $4
    i32.const 2
    i32.and
    i32.or
@@ -1446,19 +1449,19 @@
    i32.add
    local.get $5
    i32.add
-   local.tee $3
+   local.tee $4
    local.get $6
    i32.const 4
    i32.sub
    i32.const 1
    i32.or
    i32.store $0
-   local.get $4
    local.get $3
+   local.get $4
    call $~lib/rt/tlsf/insertBlock
   else
    local.get $2
-   local.get $3
+   local.get $4
    i32.const -2
    i32.and
    i32.store $0

--- a/tests/compiler/std/dataview.release.wat
+++ b/tests/compiler/std/dataview.release.wat
@@ -640,7 +640,7 @@
   if
    i32.const 0
    i32.const 1504
-   i32.const 378
+   i32.const 382
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -665,7 +665,7 @@
    if
     i32.const 0
     i32.const 1504
-    i32.const 385
+    i32.const 389
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -693,7 +693,7 @@
    if
     i32.const 0
     i32.const 1504
-    i32.const 398
+    i32.const 402
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1060,7 +1060,7 @@
       if
        i32.const 0
        i32.const 1504
-       i32.const 560
+       i32.const 562
        i32.const 3
        call $~lib/builtins/abort
        unreachable
@@ -1144,7 +1144,7 @@
   if
    i32.const 0
    i32.const 1504
-   i32.const 330
+   i32.const 334
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1196,7 +1196,7 @@
     if
      i32.const 0
      i32.const 1504
-     i32.const 343
+     i32.const 347
      i32.const 18
      call $~lib/builtins/abort
      unreachable
@@ -1285,7 +1285,7 @@
    call $~lib/rt/tlsf/initialize
   end
   global.get $~lib/rt/tlsf/ROOT
-  local.set $3
+  local.set $4
   local.get $0
   i32.const 16
   i32.add
@@ -1295,12 +1295,12 @@
   if
    i32.const 1168
    i32.const 1504
-   i32.const 459
+   i32.const 461
    i32.const 29
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $3
+  local.get $4
   i32.const 12
   local.get $2
   i32.const 19
@@ -1321,8 +1321,29 @@
    memory.size $0
    local.tee $2
    local.get $5
+   i32.const 256
+   i32.gt_u
+   if (result i32)
+    local.get $5
+    i32.const 1
+    i32.const 27
+    local.get $5
+    i32.clz
+    i32.sub
+    i32.shl
+    i32.add
+    i32.const 1
+    i32.sub
+    local.get $5
+    local.get $5
+    i32.const 536870910
+    i32.lt_u
+    select
+   else
+    local.get $5
+   end
    i32.const 4
-   local.get $3
+   local.get $4
    i32.load $0 offset=1568
    local.get $2
    i32.const 16
@@ -1332,39 +1353,22 @@
    i32.ne
    i32.shl
    i32.add
-   local.tee $4
-   i32.const 536870910
-   i32.lt_u
-   if (result i32)
-    local.get $4
-    i32.const 1
-    i32.const 27
-    local.get $4
-    i32.clz
-    i32.sub
-    i32.shl
-    i32.const 1
-    i32.sub
-    i32.add
-   else
-    local.get $4
-   end
    i32.const 65535
    i32.add
    i32.const -65536
    i32.and
    i32.const 16
    i32.shr_u
-   local.tee $4
+   local.tee $3
    local.get $2
-   local.get $4
+   local.get $3
    i32.gt_s
    select
    memory.grow $0
    i32.const 0
    i32.lt_s
    if
-    local.get $4
+    local.get $3
     memory.grow $0
     i32.const 0
     i32.lt_s
@@ -1372,7 +1376,7 @@
      unreachable
     end
    end
-   local.get $3
+   local.get $4
    local.get $2
    i32.const 16
    i32.shl
@@ -1381,7 +1385,7 @@
    i64.const 16
    i64.shl
    call $~lib/rt/tlsf/addMemory
-   local.get $3
+   local.get $4
    local.get $5
    call $~lib/rt/tlsf/searchBlock
    local.tee $2
@@ -1389,7 +1393,7 @@
    if
     i32.const 0
     i32.const 1504
-    i32.const 497
+    i32.const 499
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1404,17 +1408,17 @@
   if
    i32.const 0
    i32.const 1504
-   i32.const 499
+   i32.const 501
    i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $3
+  local.get $4
   local.get $2
   call $~lib/rt/tlsf/removeBlock
   local.get $2
   i32.load $0
-  local.set $4
+  local.set $3
   local.get $5
   i32.const 4
   i32.add
@@ -1423,12 +1427,12 @@
   if
    i32.const 0
    i32.const 1504
-   i32.const 357
+   i32.const 361
    i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $4
+  local.get $3
   i32.const -4
   i32.and
   local.get $5
@@ -1439,7 +1443,7 @@
   if
    local.get $2
    local.get $5
-   local.get $4
+   local.get $3
    i32.const 2
    i32.and
    i32.or
@@ -1449,19 +1453,19 @@
    i32.add
    local.get $5
    i32.add
-   local.tee $4
+   local.tee $3
    local.get $6
    i32.const 4
    i32.sub
    i32.const 1
    i32.or
    i32.store $0
-   local.get $3
    local.get $4
+   local.get $3
    call $~lib/rt/tlsf/insertBlock
   else
    local.get $2
-   local.get $4
+   local.get $3
    i32.const -2
    i32.and
    i32.store $0

--- a/tests/compiler/std/dataview.release.wat
+++ b/tests/compiler/std/dataview.release.wat
@@ -1322,7 +1322,7 @@
    local.tee $2
    local.get $5
    i32.const 256
-   i32.gt_u
+   i32.ge_u
    if (result i32)
     local.get $5
     i32.const 1

--- a/tests/compiler/std/date.debug.wat
+++ b/tests/compiler/std/date.debug.wat
@@ -1425,7 +1425,7 @@
   if
    i32.const 0
    i32.const 512
-   i32.const 378
+   i32.const 382
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1471,7 +1471,7 @@
    if
     i32.const 0
     i32.const 512
-    i32.const 385
+    i32.const 389
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1504,7 +1504,7 @@
    if
     i32.const 0
     i32.const 512
-    i32.const 398
+    i32.const 402
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1748,7 +1748,7 @@
   if
    i32.const 0
    i32.const 512
-   i32.const 560
+   i32.const 562
    i32.const 3
    call $~lib/builtins/abort
    unreachable
@@ -2077,13 +2077,33 @@
   if
    i32.const 176
    i32.const 512
-   i32.const 459
+   i32.const 461
    i32.const 29
    call $~lib/builtins/abort
    unreachable
   end
   local.get $size
   call $~lib/rt/tlsf/computeSize
+  return
+ )
+ (func $~lib/rt/tlsf/roundSize (param $size i32) (result i32)
+  local.get $size
+  i32.const 536870910
+  i32.lt_u
+  if (result i32)
+   local.get $size
+   i32.const 1
+   i32.const 27
+   local.get $size
+   i32.clz
+   i32.sub
+   i32.shl
+   i32.add
+   i32.const 1
+   i32.sub
+  else
+   local.get $size
+  end
   return
  )
  (func $~lib/rt/tlsf/searchBlock (param $root i32) (param $size i32) (result i32)
@@ -2115,24 +2135,13 @@
    local.set $sl
   else
    local.get $size
-   i32.const 536870910
-   i32.lt_u
-   if (result i32)
-    local.get $size
-    i32.const 1
-    i32.const 27
-    local.get $size
-    i32.clz
-    i32.sub
-    i32.shl
-    i32.add
-    i32.const 1
-    i32.sub
-   else
-    local.get $size
-   end
+   call $~lib/rt/tlsf/roundSize
    local.set $requestSize
-   i32.const 31
+   i32.const 4
+   i32.const 8
+   i32.mul
+   i32.const 1
+   i32.sub
    local.get $requestSize
    i32.clz
    i32.sub
@@ -2170,7 +2179,7 @@
   if
    i32.const 0
    i32.const 512
-   i32.const 330
+   i32.const 334
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -2241,7 +2250,7 @@
     if
      i32.const 0
      i32.const 512
-     i32.const 343
+     i32.const 347
      i32.const 18
      call $~lib/builtins/abort
      unreachable
@@ -2304,6 +2313,14 @@
   (local $pagesAfter i32)
   i32.const 0
   drop
+  local.get $size
+  i32.const 256
+  i32.gt_u
+  if
+   local.get $size
+   call $~lib/rt/tlsf/roundSize
+   local.set $size
+  end
   memory.size $0
   local.set $pagesBefore
   local.get $size
@@ -2324,22 +2341,6 @@
   i32.shl
   i32.add
   local.set $size
-  local.get $size
-  i32.const 536870910
-  i32.lt_u
-  if
-   local.get $size
-   i32.const 1
-   i32.const 27
-   local.get $size
-   i32.clz
-   i32.sub
-   i32.shl
-   i32.const 1
-   i32.sub
-   i32.add
-   local.set $size
-  end
   local.get $size
   i32.const 65535
   i32.add
@@ -2406,7 +2407,7 @@
   if
    i32.const 0
    i32.const 512
-   i32.const 357
+   i32.const 361
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -2521,7 +2522,7 @@
    if
     i32.const 0
     i32.const 512
-    i32.const 497
+    i32.const 499
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -2541,7 +2542,7 @@
   if
    i32.const 0
    i32.const 512
-   i32.const 499
+   i32.const 501
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/std/date.debug.wat
+++ b/tests/compiler/std/date.debug.wat
@@ -2315,7 +2315,7 @@
   drop
   local.get $size
   i32.const 256
-  i32.gt_u
+  i32.ge_u
   if
    local.get $size
    call $~lib/rt/tlsf/roundSize

--- a/tests/compiler/std/date.debug.wat
+++ b/tests/compiler/std/date.debug.wat
@@ -2304,22 +2304,6 @@
   (local $pagesAfter i32)
   i32.const 0
   drop
-  local.get $size
-  i32.const 536870910
-  i32.lt_u
-  if
-   local.get $size
-   i32.const 1
-   i32.const 27
-   local.get $size
-   i32.clz
-   i32.sub
-   i32.shl
-   i32.const 1
-   i32.sub
-   i32.add
-   local.set $size
-  end
   memory.size $0
   local.set $pagesBefore
   local.get $size
@@ -2340,6 +2324,22 @@
   i32.shl
   i32.add
   local.set $size
+  local.get $size
+  i32.const 536870910
+  i32.lt_u
+  if
+   local.get $size
+   i32.const 1
+   i32.const 27
+   local.get $size
+   i32.clz
+   i32.sub
+   i32.shl
+   i32.const 1
+   i32.sub
+   i32.add
+   local.set $size
+  end
   local.get $size
   i32.const 65535
   i32.add

--- a/tests/compiler/std/date.release.wat
+++ b/tests/compiler/std/date.release.wat
@@ -1006,7 +1006,7 @@
   if
    i32.const 0
    i32.const 1536
-   i32.const 378
+   i32.const 382
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1031,7 +1031,7 @@
    if
     i32.const 0
     i32.const 1536
-    i32.const 385
+    i32.const 389
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1059,7 +1059,7 @@
    if
     i32.const 0
     i32.const 1536
-    i32.const 398
+    i32.const 402
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1426,7 +1426,7 @@
       if
        i32.const 0
        i32.const 1536
-       i32.const 560
+       i32.const 562
        i32.const 3
        call $~lib/builtins/abort
        unreachable
@@ -1510,7 +1510,7 @@
   if
    i32.const 0
    i32.const 1536
-   i32.const 330
+   i32.const 334
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1562,7 +1562,7 @@
     if
      i32.const 0
      i32.const 1536
-     i32.const 343
+     i32.const 347
      i32.const 18
      call $~lib/builtins/abort
      unreachable
@@ -1651,7 +1651,7 @@
    call $~lib/rt/tlsf/initialize
   end
   global.get $~lib/rt/tlsf/ROOT
-  local.set $3
+  local.set $4
   local.get $0
   i32.const 16
   i32.add
@@ -1661,12 +1661,12 @@
   if
    i32.const 1200
    i32.const 1536
-   i32.const 459
+   i32.const 461
    i32.const 29
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $3
+  local.get $4
   i32.const 12
   local.get $2
   i32.const 19
@@ -1687,8 +1687,29 @@
    memory.size $0
    local.tee $2
    local.get $5
+   i32.const 256
+   i32.gt_u
+   if (result i32)
+    local.get $5
+    i32.const 1
+    i32.const 27
+    local.get $5
+    i32.clz
+    i32.sub
+    i32.shl
+    i32.add
+    i32.const 1
+    i32.sub
+    local.get $5
+    local.get $5
+    i32.const 536870910
+    i32.lt_u
+    select
+   else
+    local.get $5
+   end
    i32.const 4
-   local.get $3
+   local.get $4
    i32.load $0 offset=1568
    local.get $2
    i32.const 16
@@ -1698,39 +1719,22 @@
    i32.ne
    i32.shl
    i32.add
-   local.tee $4
-   i32.const 536870910
-   i32.lt_u
-   if (result i32)
-    local.get $4
-    i32.const 1
-    i32.const 27
-    local.get $4
-    i32.clz
-    i32.sub
-    i32.shl
-    i32.const 1
-    i32.sub
-    i32.add
-   else
-    local.get $4
-   end
    i32.const 65535
    i32.add
    i32.const -65536
    i32.and
    i32.const 16
    i32.shr_u
-   local.tee $4
+   local.tee $3
    local.get $2
-   local.get $4
+   local.get $3
    i32.gt_s
    select
    memory.grow $0
    i32.const 0
    i32.lt_s
    if
-    local.get $4
+    local.get $3
     memory.grow $0
     i32.const 0
     i32.lt_s
@@ -1738,7 +1742,7 @@
      unreachable
     end
    end
-   local.get $3
+   local.get $4
    local.get $2
    i32.const 16
    i32.shl
@@ -1747,7 +1751,7 @@
    i64.const 16
    i64.shl
    call $~lib/rt/tlsf/addMemory
-   local.get $3
+   local.get $4
    local.get $5
    call $~lib/rt/tlsf/searchBlock
    local.tee $2
@@ -1755,7 +1759,7 @@
    if
     i32.const 0
     i32.const 1536
-    i32.const 497
+    i32.const 499
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1770,17 +1774,17 @@
   if
    i32.const 0
    i32.const 1536
-   i32.const 499
+   i32.const 501
    i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $3
+  local.get $4
   local.get $2
   call $~lib/rt/tlsf/removeBlock
   local.get $2
   i32.load $0
-  local.set $4
+  local.set $3
   local.get $5
   i32.const 4
   i32.add
@@ -1789,12 +1793,12 @@
   if
    i32.const 0
    i32.const 1536
-   i32.const 357
+   i32.const 361
    i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $4
+  local.get $3
   i32.const -4
   i32.and
   local.get $5
@@ -1805,7 +1809,7 @@
   if
    local.get $2
    local.get $5
-   local.get $4
+   local.get $3
    i32.const 2
    i32.and
    i32.or
@@ -1815,19 +1819,19 @@
    i32.add
    local.get $5
    i32.add
-   local.tee $4
+   local.tee $3
    local.get $6
    i32.const 4
    i32.sub
    i32.const 1
    i32.or
    i32.store $0
-   local.get $3
    local.get $4
+   local.get $3
    call $~lib/rt/tlsf/insertBlock
   else
    local.get $2
-   local.get $4
+   local.get $3
    i32.const -2
    i32.and
    i32.store $0

--- a/tests/compiler/std/date.release.wat
+++ b/tests/compiler/std/date.release.wat
@@ -1688,7 +1688,7 @@
    local.tee $2
    local.get $5
    i32.const 256
-   i32.gt_u
+   i32.ge_u
    if (result i32)
     local.get $5
     i32.const 1

--- a/tests/compiler/std/date.release.wat
+++ b/tests/compiler/std/date.release.wat
@@ -1651,7 +1651,7 @@
    call $~lib/rt/tlsf/initialize
   end
   global.get $~lib/rt/tlsf/ROOT
-  local.set $4
+  local.set $3
   local.get $0
   i32.const 16
   i32.add
@@ -1666,7 +1666,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $4
+  local.get $3
   i32.const 12
   local.get $2
   i32.const 19
@@ -1686,8 +1686,9 @@
   if
    memory.size $0
    local.tee $2
+   local.get $5
    i32.const 4
-   local.get $4
+   local.get $3
    i32.load $0 offset=1568
    local.get $2
    i32.const 16
@@ -1696,38 +1697,40 @@
    i32.sub
    i32.ne
    i32.shl
-   local.get $5
-   i32.const 1
-   i32.const 27
-   local.get $5
-   i32.clz
-   i32.sub
-   i32.shl
-   i32.const 1
-   i32.sub
    i32.add
-   local.get $5
-   local.get $5
+   local.tee $4
    i32.const 536870910
    i32.lt_u
-   select
-   i32.add
+   if (result i32)
+    local.get $4
+    i32.const 1
+    i32.const 27
+    local.get $4
+    i32.clz
+    i32.sub
+    i32.shl
+    i32.const 1
+    i32.sub
+    i32.add
+   else
+    local.get $4
+   end
    i32.const 65535
    i32.add
    i32.const -65536
    i32.and
    i32.const 16
    i32.shr_u
-   local.tee $3
+   local.tee $4
    local.get $2
-   local.get $3
+   local.get $4
    i32.gt_s
    select
    memory.grow $0
    i32.const 0
    i32.lt_s
    if
-    local.get $3
+    local.get $4
     memory.grow $0
     i32.const 0
     i32.lt_s
@@ -1735,7 +1738,7 @@
      unreachable
     end
    end
-   local.get $4
+   local.get $3
    local.get $2
    i32.const 16
    i32.shl
@@ -1744,7 +1747,7 @@
    i64.const 16
    i64.shl
    call $~lib/rt/tlsf/addMemory
-   local.get $4
+   local.get $3
    local.get $5
    call $~lib/rt/tlsf/searchBlock
    local.tee $2
@@ -1772,12 +1775,12 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $4
+  local.get $3
   local.get $2
   call $~lib/rt/tlsf/removeBlock
   local.get $2
   i32.load $0
-  local.set $3
+  local.set $4
   local.get $5
   i32.const 4
   i32.add
@@ -1791,7 +1794,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $3
+  local.get $4
   i32.const -4
   i32.and
   local.get $5
@@ -1802,7 +1805,7 @@
   if
    local.get $2
    local.get $5
-   local.get $3
+   local.get $4
    i32.const 2
    i32.and
    i32.or
@@ -1812,19 +1815,19 @@
    i32.add
    local.get $5
    i32.add
-   local.tee $3
+   local.tee $4
    local.get $6
    i32.const 4
    i32.sub
    i32.const 1
    i32.or
    i32.store $0
-   local.get $4
    local.get $3
+   local.get $4
    call $~lib/rt/tlsf/insertBlock
   else
    local.get $2
-   local.get $3
+   local.get $4
    i32.const -2
    i32.and
    i32.store $0

--- a/tests/compiler/std/map.debug.wat
+++ b/tests/compiler/std/map.debug.wat
@@ -1943,22 +1943,6 @@
   (local $pagesAfter i32)
   i32.const 0
   drop
-  local.get $size
-  i32.const 536870910
-  i32.lt_u
-  if
-   local.get $size
-   i32.const 1
-   i32.const 27
-   local.get $size
-   i32.clz
-   i32.sub
-   i32.shl
-   i32.const 1
-   i32.sub
-   i32.add
-   local.set $size
-  end
   memory.size $0
   local.set $pagesBefore
   local.get $size
@@ -1979,6 +1963,22 @@
   i32.shl
   i32.add
   local.set $size
+  local.get $size
+  i32.const 536870910
+  i32.lt_u
+  if
+   local.get $size
+   i32.const 1
+   i32.const 27
+   local.get $size
+   i32.clz
+   i32.sub
+   i32.shl
+   i32.const 1
+   i32.sub
+   i32.add
+   local.set $size
+  end
   local.get $size
   i32.const 65535
   i32.add

--- a/tests/compiler/std/map.debug.wat
+++ b/tests/compiler/std/map.debug.wat
@@ -1064,7 +1064,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 378
+   i32.const 382
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1110,7 +1110,7 @@
    if
     i32.const 0
     i32.const 368
-    i32.const 385
+    i32.const 389
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1143,7 +1143,7 @@
    if
     i32.const 0
     i32.const 368
-    i32.const 398
+    i32.const 402
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1387,7 +1387,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 560
+   i32.const 562
    i32.const 3
    call $~lib/builtins/abort
    unreachable
@@ -1716,13 +1716,33 @@
   if
    i32.const 32
    i32.const 368
-   i32.const 459
+   i32.const 461
    i32.const 29
    call $~lib/builtins/abort
    unreachable
   end
   local.get $size
   call $~lib/rt/tlsf/computeSize
+  return
+ )
+ (func $~lib/rt/tlsf/roundSize (param $size i32) (result i32)
+  local.get $size
+  i32.const 536870910
+  i32.lt_u
+  if (result i32)
+   local.get $size
+   i32.const 1
+   i32.const 27
+   local.get $size
+   i32.clz
+   i32.sub
+   i32.shl
+   i32.add
+   i32.const 1
+   i32.sub
+  else
+   local.get $size
+  end
   return
  )
  (func $~lib/rt/tlsf/searchBlock (param $root i32) (param $size i32) (result i32)
@@ -1754,24 +1774,13 @@
    local.set $sl
   else
    local.get $size
-   i32.const 536870910
-   i32.lt_u
-   if (result i32)
-    local.get $size
-    i32.const 1
-    i32.const 27
-    local.get $size
-    i32.clz
-    i32.sub
-    i32.shl
-    i32.add
-    i32.const 1
-    i32.sub
-   else
-    local.get $size
-   end
+   call $~lib/rt/tlsf/roundSize
    local.set $requestSize
-   i32.const 31
+   i32.const 4
+   i32.const 8
+   i32.mul
+   i32.const 1
+   i32.sub
    local.get $requestSize
    i32.clz
    i32.sub
@@ -1809,7 +1818,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 330
+   i32.const 334
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1880,7 +1889,7 @@
     if
      i32.const 0
      i32.const 368
-     i32.const 343
+     i32.const 347
      i32.const 18
      call $~lib/builtins/abort
      unreachable
@@ -1943,6 +1952,14 @@
   (local $pagesAfter i32)
   i32.const 0
   drop
+  local.get $size
+  i32.const 256
+  i32.gt_u
+  if
+   local.get $size
+   call $~lib/rt/tlsf/roundSize
+   local.set $size
+  end
   memory.size $0
   local.set $pagesBefore
   local.get $size
@@ -1963,22 +1980,6 @@
   i32.shl
   i32.add
   local.set $size
-  local.get $size
-  i32.const 536870910
-  i32.lt_u
-  if
-   local.get $size
-   i32.const 1
-   i32.const 27
-   local.get $size
-   i32.clz
-   i32.sub
-   i32.shl
-   i32.const 1
-   i32.sub
-   i32.add
-   local.set $size
-  end
   local.get $size
   i32.const 65535
   i32.add
@@ -2045,7 +2046,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 357
+   i32.const 361
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -2160,7 +2161,7 @@
    if
     i32.const 0
     i32.const 368
-    i32.const 497
+    i32.const 499
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -2180,7 +2181,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 499
+   i32.const 501
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/std/map.debug.wat
+++ b/tests/compiler/std/map.debug.wat
@@ -1954,7 +1954,7 @@
   drop
   local.get $size
   i32.const 256
-  i32.gt_u
+  i32.ge_u
   if
    local.get $size
    call $~lib/rt/tlsf/roundSize

--- a/tests/compiler/std/map.release.wat
+++ b/tests/compiler/std/map.release.wat
@@ -1297,7 +1297,7 @@
    call $~lib/rt/tlsf/initialize
   end
   global.get $~lib/rt/tlsf/ROOT
-  local.set $4
+  local.set $3
   local.get $0
   i32.const 16
   i32.add
@@ -1312,7 +1312,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $4
+  local.get $3
   i32.const 12
   local.get $2
   i32.const 19
@@ -1332,8 +1332,9 @@
   if
    memory.size $0
    local.tee $2
+   local.get $5
    i32.const 4
-   local.get $4
+   local.get $3
    i32.load $0 offset=1568
    local.get $2
    i32.const 16
@@ -1342,38 +1343,40 @@
    i32.sub
    i32.ne
    i32.shl
-   local.get $5
-   i32.const 1
-   i32.const 27
-   local.get $5
-   i32.clz
-   i32.sub
-   i32.shl
-   i32.const 1
-   i32.sub
    i32.add
-   local.get $5
-   local.get $5
+   local.tee $4
    i32.const 536870910
    i32.lt_u
-   select
-   i32.add
+   if (result i32)
+    local.get $4
+    i32.const 1
+    i32.const 27
+    local.get $4
+    i32.clz
+    i32.sub
+    i32.shl
+    i32.const 1
+    i32.sub
+    i32.add
+   else
+    local.get $4
+   end
    i32.const 65535
    i32.add
    i32.const -65536
    i32.and
    i32.const 16
    i32.shr_u
-   local.tee $3
+   local.tee $4
    local.get $2
-   local.get $3
+   local.get $4
    i32.gt_s
    select
    memory.grow $0
    i32.const 0
    i32.lt_s
    if
-    local.get $3
+    local.get $4
     memory.grow $0
     i32.const 0
     i32.lt_s
@@ -1381,7 +1384,7 @@
      unreachable
     end
    end
-   local.get $4
+   local.get $3
    local.get $2
    i32.const 16
    i32.shl
@@ -1390,7 +1393,7 @@
    i64.const 16
    i64.shl
    call $~lib/rt/tlsf/addMemory
-   local.get $4
+   local.get $3
    local.get $5
    call $~lib/rt/tlsf/searchBlock
    local.tee $2
@@ -1418,12 +1421,12 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $4
+  local.get $3
   local.get $2
   call $~lib/rt/tlsf/removeBlock
   local.get $2
   i32.load $0
-  local.set $3
+  local.set $4
   local.get $5
   i32.const 4
   i32.add
@@ -1437,7 +1440,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $3
+  local.get $4
   i32.const -4
   i32.and
   local.get $5
@@ -1448,7 +1451,7 @@
   if
    local.get $2
    local.get $5
-   local.get $3
+   local.get $4
    i32.const 2
    i32.and
    i32.or
@@ -1458,19 +1461,19 @@
    i32.add
    local.get $5
    i32.add
-   local.tee $3
+   local.tee $4
    local.get $6
    i32.const 4
    i32.sub
    i32.const 1
    i32.or
    i32.store $0
-   local.get $4
    local.get $3
+   local.get $4
    call $~lib/rt/tlsf/insertBlock
   else
    local.get $2
-   local.get $3
+   local.get $4
    i32.const -2
    i32.and
    i32.store $0

--- a/tests/compiler/std/map.release.wat
+++ b/tests/compiler/std/map.release.wat
@@ -652,7 +652,7 @@
   if
    i32.const 0
    i32.const 1392
-   i32.const 378
+   i32.const 382
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -677,7 +677,7 @@
    if
     i32.const 0
     i32.const 1392
-    i32.const 385
+    i32.const 389
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -705,7 +705,7 @@
    if
     i32.const 0
     i32.const 1392
-    i32.const 398
+    i32.const 402
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1072,7 +1072,7 @@
       if
        i32.const 0
        i32.const 1392
-       i32.const 560
+       i32.const 562
        i32.const 3
        call $~lib/builtins/abort
        unreachable
@@ -1156,7 +1156,7 @@
   if
    i32.const 0
    i32.const 1392
-   i32.const 330
+   i32.const 334
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1208,7 +1208,7 @@
     if
      i32.const 0
      i32.const 1392
-     i32.const 343
+     i32.const 347
      i32.const 18
      call $~lib/builtins/abort
      unreachable
@@ -1297,7 +1297,7 @@
    call $~lib/rt/tlsf/initialize
   end
   global.get $~lib/rt/tlsf/ROOT
-  local.set $3
+  local.set $4
   local.get $0
   i32.const 16
   i32.add
@@ -1307,12 +1307,12 @@
   if
    i32.const 1056
    i32.const 1392
-   i32.const 459
+   i32.const 461
    i32.const 29
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $3
+  local.get $4
   i32.const 12
   local.get $2
   i32.const 19
@@ -1333,8 +1333,29 @@
    memory.size $0
    local.tee $2
    local.get $5
+   i32.const 256
+   i32.gt_u
+   if (result i32)
+    local.get $5
+    i32.const 1
+    i32.const 27
+    local.get $5
+    i32.clz
+    i32.sub
+    i32.shl
+    i32.add
+    i32.const 1
+    i32.sub
+    local.get $5
+    local.get $5
+    i32.const 536870910
+    i32.lt_u
+    select
+   else
+    local.get $5
+   end
    i32.const 4
-   local.get $3
+   local.get $4
    i32.load $0 offset=1568
    local.get $2
    i32.const 16
@@ -1344,39 +1365,22 @@
    i32.ne
    i32.shl
    i32.add
-   local.tee $4
-   i32.const 536870910
-   i32.lt_u
-   if (result i32)
-    local.get $4
-    i32.const 1
-    i32.const 27
-    local.get $4
-    i32.clz
-    i32.sub
-    i32.shl
-    i32.const 1
-    i32.sub
-    i32.add
-   else
-    local.get $4
-   end
    i32.const 65535
    i32.add
    i32.const -65536
    i32.and
    i32.const 16
    i32.shr_u
-   local.tee $4
+   local.tee $3
    local.get $2
-   local.get $4
+   local.get $3
    i32.gt_s
    select
    memory.grow $0
    i32.const 0
    i32.lt_s
    if
-    local.get $4
+    local.get $3
     memory.grow $0
     i32.const 0
     i32.lt_s
@@ -1384,7 +1388,7 @@
      unreachable
     end
    end
-   local.get $3
+   local.get $4
    local.get $2
    i32.const 16
    i32.shl
@@ -1393,7 +1397,7 @@
    i64.const 16
    i64.shl
    call $~lib/rt/tlsf/addMemory
-   local.get $3
+   local.get $4
    local.get $5
    call $~lib/rt/tlsf/searchBlock
    local.tee $2
@@ -1401,7 +1405,7 @@
    if
     i32.const 0
     i32.const 1392
-    i32.const 497
+    i32.const 499
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1416,17 +1420,17 @@
   if
    i32.const 0
    i32.const 1392
-   i32.const 499
+   i32.const 501
    i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $3
+  local.get $4
   local.get $2
   call $~lib/rt/tlsf/removeBlock
   local.get $2
   i32.load $0
-  local.set $4
+  local.set $3
   local.get $5
   i32.const 4
   i32.add
@@ -1435,12 +1439,12 @@
   if
    i32.const 0
    i32.const 1392
-   i32.const 357
+   i32.const 361
    i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $4
+  local.get $3
   i32.const -4
   i32.and
   local.get $5
@@ -1451,7 +1455,7 @@
   if
    local.get $2
    local.get $5
-   local.get $4
+   local.get $3
    i32.const 2
    i32.and
    i32.or
@@ -1461,19 +1465,19 @@
    i32.add
    local.get $5
    i32.add
-   local.tee $4
+   local.tee $3
    local.get $6
    i32.const 4
    i32.sub
    i32.const 1
    i32.or
    i32.store $0
-   local.get $3
    local.get $4
+   local.get $3
    call $~lib/rt/tlsf/insertBlock
   else
    local.get $2
-   local.get $4
+   local.get $3
    i32.const -2
    i32.and
    i32.store $0

--- a/tests/compiler/std/map.release.wat
+++ b/tests/compiler/std/map.release.wat
@@ -1334,7 +1334,7 @@
    local.tee $2
    local.get $5
    i32.const 256
-   i32.gt_u
+   i32.ge_u
    if (result i32)
     local.get $5
     i32.const 1

--- a/tests/compiler/std/new.debug.wat
+++ b/tests/compiler/std/new.debug.wat
@@ -1929,22 +1929,6 @@
   (local $pagesAfter i32)
   i32.const 0
   drop
-  local.get $size
-  i32.const 536870910
-  i32.lt_u
-  if
-   local.get $size
-   i32.const 1
-   i32.const 27
-   local.get $size
-   i32.clz
-   i32.sub
-   i32.shl
-   i32.const 1
-   i32.sub
-   i32.add
-   local.set $size
-  end
   memory.size $0
   local.set $pagesBefore
   local.get $size
@@ -1965,6 +1949,22 @@
   i32.shl
   i32.add
   local.set $size
+  local.get $size
+  i32.const 536870910
+  i32.lt_u
+  if
+   local.get $size
+   i32.const 1
+   i32.const 27
+   local.get $size
+   i32.clz
+   i32.sub
+   i32.shl
+   i32.const 1
+   i32.sub
+   i32.add
+   local.set $size
+  end
   local.get $size
   i32.const 65535
   i32.add

--- a/tests/compiler/std/new.debug.wat
+++ b/tests/compiler/std/new.debug.wat
@@ -1940,7 +1940,7 @@
   drop
   local.get $size
   i32.const 256
-  i32.gt_u
+  i32.ge_u
   if
    local.get $size
    call $~lib/rt/tlsf/roundSize

--- a/tests/compiler/std/new.debug.wat
+++ b/tests/compiler/std/new.debug.wat
@@ -1050,7 +1050,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 378
+   i32.const 382
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1096,7 +1096,7 @@
    if
     i32.const 0
     i32.const 368
-    i32.const 385
+    i32.const 389
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1129,7 +1129,7 @@
    if
     i32.const 0
     i32.const 368
-    i32.const 398
+    i32.const 402
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1373,7 +1373,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 560
+   i32.const 562
    i32.const 3
    call $~lib/builtins/abort
    unreachable
@@ -1702,13 +1702,33 @@
   if
    i32.const 32
    i32.const 368
-   i32.const 459
+   i32.const 461
    i32.const 29
    call $~lib/builtins/abort
    unreachable
   end
   local.get $size
   call $~lib/rt/tlsf/computeSize
+  return
+ )
+ (func $~lib/rt/tlsf/roundSize (param $size i32) (result i32)
+  local.get $size
+  i32.const 536870910
+  i32.lt_u
+  if (result i32)
+   local.get $size
+   i32.const 1
+   i32.const 27
+   local.get $size
+   i32.clz
+   i32.sub
+   i32.shl
+   i32.add
+   i32.const 1
+   i32.sub
+  else
+   local.get $size
+  end
   return
  )
  (func $~lib/rt/tlsf/searchBlock (param $root i32) (param $size i32) (result i32)
@@ -1740,24 +1760,13 @@
    local.set $sl
   else
    local.get $size
-   i32.const 536870910
-   i32.lt_u
-   if (result i32)
-    local.get $size
-    i32.const 1
-    i32.const 27
-    local.get $size
-    i32.clz
-    i32.sub
-    i32.shl
-    i32.add
-    i32.const 1
-    i32.sub
-   else
-    local.get $size
-   end
+   call $~lib/rt/tlsf/roundSize
    local.set $requestSize
-   i32.const 31
+   i32.const 4
+   i32.const 8
+   i32.mul
+   i32.const 1
+   i32.sub
    local.get $requestSize
    i32.clz
    i32.sub
@@ -1795,7 +1804,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 330
+   i32.const 334
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1866,7 +1875,7 @@
     if
      i32.const 0
      i32.const 368
-     i32.const 343
+     i32.const 347
      i32.const 18
      call $~lib/builtins/abort
      unreachable
@@ -1929,6 +1938,14 @@
   (local $pagesAfter i32)
   i32.const 0
   drop
+  local.get $size
+  i32.const 256
+  i32.gt_u
+  if
+   local.get $size
+   call $~lib/rt/tlsf/roundSize
+   local.set $size
+  end
   memory.size $0
   local.set $pagesBefore
   local.get $size
@@ -1949,22 +1966,6 @@
   i32.shl
   i32.add
   local.set $size
-  local.get $size
-  i32.const 536870910
-  i32.lt_u
-  if
-   local.get $size
-   i32.const 1
-   i32.const 27
-   local.get $size
-   i32.clz
-   i32.sub
-   i32.shl
-   i32.const 1
-   i32.sub
-   i32.add
-   local.set $size
-  end
   local.get $size
   i32.const 65535
   i32.add
@@ -2031,7 +2032,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 357
+   i32.const 361
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -2146,7 +2147,7 @@
    if
     i32.const 0
     i32.const 368
-    i32.const 497
+    i32.const 499
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -2166,7 +2167,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 499
+   i32.const 501
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/std/new.release.wat
+++ b/tests/compiler/std/new.release.wat
@@ -1196,6 +1196,8 @@
   if
    memory.size $0
    local.tee $0
+   i32.const 1
+   i32.const 27
    i32.const 4
    local.get $1
    i32.load $0 offset=1568
@@ -1206,7 +1208,22 @@
    i32.sub
    i32.ne
    i32.shl
-   i32.const 65563
+   i32.const 28
+   i32.add
+   local.tee $2
+   i32.clz
+   i32.sub
+   i32.shl
+   i32.const 1
+   i32.sub
+   local.get $2
+   i32.add
+   local.get $2
+   local.get $2
+   i32.const 536870910
+   i32.lt_u
+   select
+   i32.const 65535
    i32.add
    i32.const -65536
    i32.and

--- a/tests/compiler/std/new.release.wat
+++ b/tests/compiler/std/new.release.wat
@@ -625,7 +625,7 @@
   if
    i32.const 0
    i32.const 1392
-   i32.const 378
+   i32.const 382
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -650,7 +650,7 @@
    if
     i32.const 0
     i32.const 1392
-    i32.const 385
+    i32.const 389
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -678,7 +678,7 @@
    if
     i32.const 0
     i32.const 1392
-    i32.const 398
+    i32.const 402
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1045,7 +1045,7 @@
       if
        i32.const 0
        i32.const 1392
-       i32.const 560
+       i32.const 562
        i32.const 3
        call $~lib/builtins/abort
        unreachable
@@ -1112,7 +1112,7 @@
     if
      i32.const 0
      i32.const 1392
-     i32.const 343
+     i32.const 347
      i32.const 18
      call $~lib/builtins/abort
      unreachable
@@ -1196,8 +1196,6 @@
   if
    memory.size $0
    local.tee $0
-   i32.const 1
-   i32.const 27
    i32.const 4
    local.get $1
    i32.load $0 offset=1568
@@ -1208,22 +1206,7 @@
    i32.sub
    i32.ne
    i32.shl
-   i32.const 28
-   i32.add
-   local.tee $2
-   i32.clz
-   i32.sub
-   i32.shl
-   i32.const 1
-   i32.sub
-   local.get $2
-   i32.add
-   local.get $2
-   local.get $2
-   i32.const 536870910
-   i32.lt_u
-   select
-   i32.const 65535
+   i32.const 65563
    i32.add
    i32.const -65536
    i32.and
@@ -1262,7 +1245,7 @@
    if
     i32.const 0
     i32.const 1392
-    i32.const 497
+    i32.const 499
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1277,7 +1260,7 @@
   if
    i32.const 0
    i32.const 1392
-   i32.const 499
+   i32.const 501
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/std/operator-overloading.debug.wat
+++ b/tests/compiler/std/operator-overloading.debug.wat
@@ -1985,22 +1985,6 @@
   (local $pagesAfter i32)
   i32.const 0
   drop
-  local.get $size
-  i32.const 536870910
-  i32.lt_u
-  if
-   local.get $size
-   i32.const 1
-   i32.const 27
-   local.get $size
-   i32.clz
-   i32.sub
-   i32.shl
-   i32.const 1
-   i32.sub
-   i32.add
-   local.set $size
-  end
   memory.size $0
   local.set $pagesBefore
   local.get $size
@@ -2021,6 +2005,22 @@
   i32.shl
   i32.add
   local.set $size
+  local.get $size
+  i32.const 536870910
+  i32.lt_u
+  if
+   local.get $size
+   i32.const 1
+   i32.const 27
+   local.get $size
+   i32.clz
+   i32.sub
+   i32.shl
+   i32.const 1
+   i32.sub
+   i32.add
+   local.set $size
+  end
   local.get $size
   i32.const 65535
   i32.add

--- a/tests/compiler/std/operator-overloading.debug.wat
+++ b/tests/compiler/std/operator-overloading.debug.wat
@@ -1106,7 +1106,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 378
+   i32.const 382
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1152,7 +1152,7 @@
    if
     i32.const 0
     i32.const 368
-    i32.const 385
+    i32.const 389
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1185,7 +1185,7 @@
    if
     i32.const 0
     i32.const 368
-    i32.const 398
+    i32.const 402
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1429,7 +1429,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 560
+   i32.const 562
    i32.const 3
    call $~lib/builtins/abort
    unreachable
@@ -1758,13 +1758,33 @@
   if
    i32.const 32
    i32.const 368
-   i32.const 459
+   i32.const 461
    i32.const 29
    call $~lib/builtins/abort
    unreachable
   end
   local.get $size
   call $~lib/rt/tlsf/computeSize
+  return
+ )
+ (func $~lib/rt/tlsf/roundSize (param $size i32) (result i32)
+  local.get $size
+  i32.const 536870910
+  i32.lt_u
+  if (result i32)
+   local.get $size
+   i32.const 1
+   i32.const 27
+   local.get $size
+   i32.clz
+   i32.sub
+   i32.shl
+   i32.add
+   i32.const 1
+   i32.sub
+  else
+   local.get $size
+  end
   return
  )
  (func $~lib/rt/tlsf/searchBlock (param $root i32) (param $size i32) (result i32)
@@ -1796,24 +1816,13 @@
    local.set $sl
   else
    local.get $size
-   i32.const 536870910
-   i32.lt_u
-   if (result i32)
-    local.get $size
-    i32.const 1
-    i32.const 27
-    local.get $size
-    i32.clz
-    i32.sub
-    i32.shl
-    i32.add
-    i32.const 1
-    i32.sub
-   else
-    local.get $size
-   end
+   call $~lib/rt/tlsf/roundSize
    local.set $requestSize
-   i32.const 31
+   i32.const 4
+   i32.const 8
+   i32.mul
+   i32.const 1
+   i32.sub
    local.get $requestSize
    i32.clz
    i32.sub
@@ -1851,7 +1860,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 330
+   i32.const 334
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1922,7 +1931,7 @@
     if
      i32.const 0
      i32.const 368
-     i32.const 343
+     i32.const 347
      i32.const 18
      call $~lib/builtins/abort
      unreachable
@@ -1985,6 +1994,14 @@
   (local $pagesAfter i32)
   i32.const 0
   drop
+  local.get $size
+  i32.const 256
+  i32.gt_u
+  if
+   local.get $size
+   call $~lib/rt/tlsf/roundSize
+   local.set $size
+  end
   memory.size $0
   local.set $pagesBefore
   local.get $size
@@ -2005,22 +2022,6 @@
   i32.shl
   i32.add
   local.set $size
-  local.get $size
-  i32.const 536870910
-  i32.lt_u
-  if
-   local.get $size
-   i32.const 1
-   i32.const 27
-   local.get $size
-   i32.clz
-   i32.sub
-   i32.shl
-   i32.const 1
-   i32.sub
-   i32.add
-   local.set $size
-  end
   local.get $size
   i32.const 65535
   i32.add
@@ -2087,7 +2088,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 357
+   i32.const 361
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -2202,7 +2203,7 @@
    if
     i32.const 0
     i32.const 368
-    i32.const 497
+    i32.const 499
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -2222,7 +2223,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 499
+   i32.const 501
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/std/operator-overloading.debug.wat
+++ b/tests/compiler/std/operator-overloading.debug.wat
@@ -1996,7 +1996,7 @@
   drop
   local.get $size
   i32.const 256
-  i32.gt_u
+  i32.ge_u
   if
    local.get $size
    call $~lib/rt/tlsf/roundSize

--- a/tests/compiler/std/operator-overloading.release.wat
+++ b/tests/compiler/std/operator-overloading.release.wat
@@ -558,7 +558,7 @@
   if
    i32.const 0
    i32.const 1392
-   i32.const 378
+   i32.const 382
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -583,7 +583,7 @@
    if
     i32.const 0
     i32.const 1392
-    i32.const 385
+    i32.const 389
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -611,7 +611,7 @@
    if
     i32.const 0
     i32.const 1392
-    i32.const 398
+    i32.const 402
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -978,7 +978,7 @@
       if
        i32.const 0
        i32.const 1392
-       i32.const 560
+       i32.const 562
        i32.const 3
        call $~lib/builtins/abort
        unreachable
@@ -1045,7 +1045,7 @@
     if
      i32.const 0
      i32.const 1392
-     i32.const 343
+     i32.const 347
      i32.const 18
      call $~lib/builtins/abort
      unreachable
@@ -1129,8 +1129,6 @@
   if
    memory.size $0
    local.tee $1
-   i32.const 1
-   i32.const 27
    i32.const 4
    local.get $2
    i32.load $0 offset=1568
@@ -1141,22 +1139,7 @@
    i32.sub
    i32.ne
    i32.shl
-   i32.const 28
-   i32.add
-   local.tee $3
-   i32.clz
-   i32.sub
-   i32.shl
-   i32.const 1
-   i32.sub
-   local.get $3
-   i32.add
-   local.get $3
-   local.get $3
-   i32.const 536870910
-   i32.lt_u
-   select
-   i32.const 65535
+   i32.const 65563
    i32.add
    i32.const -65536
    i32.and
@@ -1195,7 +1178,7 @@
    if
     i32.const 0
     i32.const 1392
-    i32.const 497
+    i32.const 499
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1210,7 +1193,7 @@
   if
    i32.const 0
    i32.const 1392
-   i32.const 499
+   i32.const 501
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/std/operator-overloading.release.wat
+++ b/tests/compiler/std/operator-overloading.release.wat
@@ -1129,6 +1129,8 @@
   if
    memory.size $0
    local.tee $1
+   i32.const 1
+   i32.const 27
    i32.const 4
    local.get $2
    i32.load $0 offset=1568
@@ -1139,7 +1141,22 @@
    i32.sub
    i32.ne
    i32.shl
-   i32.const 65563
+   i32.const 28
+   i32.add
+   local.tee $3
+   i32.clz
+   i32.sub
+   i32.shl
+   i32.const 1
+   i32.sub
+   local.get $3
+   i32.add
+   local.get $3
+   local.get $3
+   i32.const 536870910
+   i32.lt_u
+   select
+   i32.const 65535
    i32.add
    i32.const -65536
    i32.and

--- a/tests/compiler/std/set.debug.wat
+++ b/tests/compiler/std/set.debug.wat
@@ -1938,22 +1938,6 @@
   (local $pagesAfter i32)
   i32.const 0
   drop
-  local.get $size
-  i32.const 536870910
-  i32.lt_u
-  if
-   local.get $size
-   i32.const 1
-   i32.const 27
-   local.get $size
-   i32.clz
-   i32.sub
-   i32.shl
-   i32.const 1
-   i32.sub
-   i32.add
-   local.set $size
-  end
   memory.size $0
   local.set $pagesBefore
   local.get $size
@@ -1974,6 +1958,22 @@
   i32.shl
   i32.add
   local.set $size
+  local.get $size
+  i32.const 536870910
+  i32.lt_u
+  if
+   local.get $size
+   i32.const 1
+   i32.const 27
+   local.get $size
+   i32.clz
+   i32.sub
+   i32.shl
+   i32.const 1
+   i32.sub
+   i32.add
+   local.set $size
+  end
   local.get $size
   i32.const 65535
   i32.add

--- a/tests/compiler/std/set.debug.wat
+++ b/tests/compiler/std/set.debug.wat
@@ -1949,7 +1949,7 @@
   drop
   local.get $size
   i32.const 256
-  i32.gt_u
+  i32.ge_u
   if
    local.get $size
    call $~lib/rt/tlsf/roundSize

--- a/tests/compiler/std/set.debug.wat
+++ b/tests/compiler/std/set.debug.wat
@@ -1059,7 +1059,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 378
+   i32.const 382
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1105,7 +1105,7 @@
    if
     i32.const 0
     i32.const 368
-    i32.const 385
+    i32.const 389
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1138,7 +1138,7 @@
    if
     i32.const 0
     i32.const 368
-    i32.const 398
+    i32.const 402
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1382,7 +1382,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 560
+   i32.const 562
    i32.const 3
    call $~lib/builtins/abort
    unreachable
@@ -1711,13 +1711,33 @@
   if
    i32.const 32
    i32.const 368
-   i32.const 459
+   i32.const 461
    i32.const 29
    call $~lib/builtins/abort
    unreachable
   end
   local.get $size
   call $~lib/rt/tlsf/computeSize
+  return
+ )
+ (func $~lib/rt/tlsf/roundSize (param $size i32) (result i32)
+  local.get $size
+  i32.const 536870910
+  i32.lt_u
+  if (result i32)
+   local.get $size
+   i32.const 1
+   i32.const 27
+   local.get $size
+   i32.clz
+   i32.sub
+   i32.shl
+   i32.add
+   i32.const 1
+   i32.sub
+  else
+   local.get $size
+  end
   return
  )
  (func $~lib/rt/tlsf/searchBlock (param $root i32) (param $size i32) (result i32)
@@ -1749,24 +1769,13 @@
    local.set $sl
   else
    local.get $size
-   i32.const 536870910
-   i32.lt_u
-   if (result i32)
-    local.get $size
-    i32.const 1
-    i32.const 27
-    local.get $size
-    i32.clz
-    i32.sub
-    i32.shl
-    i32.add
-    i32.const 1
-    i32.sub
-   else
-    local.get $size
-   end
+   call $~lib/rt/tlsf/roundSize
    local.set $requestSize
-   i32.const 31
+   i32.const 4
+   i32.const 8
+   i32.mul
+   i32.const 1
+   i32.sub
    local.get $requestSize
    i32.clz
    i32.sub
@@ -1804,7 +1813,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 330
+   i32.const 334
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1875,7 +1884,7 @@
     if
      i32.const 0
      i32.const 368
-     i32.const 343
+     i32.const 347
      i32.const 18
      call $~lib/builtins/abort
      unreachable
@@ -1938,6 +1947,14 @@
   (local $pagesAfter i32)
   i32.const 0
   drop
+  local.get $size
+  i32.const 256
+  i32.gt_u
+  if
+   local.get $size
+   call $~lib/rt/tlsf/roundSize
+   local.set $size
+  end
   memory.size $0
   local.set $pagesBefore
   local.get $size
@@ -1958,22 +1975,6 @@
   i32.shl
   i32.add
   local.set $size
-  local.get $size
-  i32.const 536870910
-  i32.lt_u
-  if
-   local.get $size
-   i32.const 1
-   i32.const 27
-   local.get $size
-   i32.clz
-   i32.sub
-   i32.shl
-   i32.const 1
-   i32.sub
-   i32.add
-   local.set $size
-  end
   local.get $size
   i32.const 65535
   i32.add
@@ -2040,7 +2041,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 357
+   i32.const 361
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -2155,7 +2156,7 @@
    if
     i32.const 0
     i32.const 368
-    i32.const 497
+    i32.const 499
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -2175,7 +2176,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 499
+   i32.const 501
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/std/set.release.wat
+++ b/tests/compiler/std/set.release.wat
@@ -1288,7 +1288,7 @@
    call $~lib/rt/tlsf/initialize
   end
   global.get $~lib/rt/tlsf/ROOT
-  local.set $4
+  local.set $3
   local.get $0
   i32.const 16
   i32.add
@@ -1303,7 +1303,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $4
+  local.get $3
   i32.const 12
   local.get $2
   i32.const 19
@@ -1323,8 +1323,9 @@
   if
    memory.size $0
    local.tee $2
+   local.get $5
    i32.const 4
-   local.get $4
+   local.get $3
    i32.load $0 offset=1568
    local.get $2
    i32.const 16
@@ -1333,38 +1334,40 @@
    i32.sub
    i32.ne
    i32.shl
-   local.get $5
-   i32.const 1
-   i32.const 27
-   local.get $5
-   i32.clz
-   i32.sub
-   i32.shl
-   i32.const 1
-   i32.sub
    i32.add
-   local.get $5
-   local.get $5
+   local.tee $4
    i32.const 536870910
    i32.lt_u
-   select
-   i32.add
+   if (result i32)
+    local.get $4
+    i32.const 1
+    i32.const 27
+    local.get $4
+    i32.clz
+    i32.sub
+    i32.shl
+    i32.const 1
+    i32.sub
+    i32.add
+   else
+    local.get $4
+   end
    i32.const 65535
    i32.add
    i32.const -65536
    i32.and
    i32.const 16
    i32.shr_u
-   local.tee $3
+   local.tee $4
    local.get $2
-   local.get $3
+   local.get $4
    i32.gt_s
    select
    memory.grow $0
    i32.const 0
    i32.lt_s
    if
-    local.get $3
+    local.get $4
     memory.grow $0
     i32.const 0
     i32.lt_s
@@ -1372,7 +1375,7 @@
      unreachable
     end
    end
-   local.get $4
+   local.get $3
    local.get $2
    i32.const 16
    i32.shl
@@ -1381,7 +1384,7 @@
    i64.const 16
    i64.shl
    call $~lib/rt/tlsf/addMemory
-   local.get $4
+   local.get $3
    local.get $5
    call $~lib/rt/tlsf/searchBlock
    local.tee $2
@@ -1409,12 +1412,12 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $4
+  local.get $3
   local.get $2
   call $~lib/rt/tlsf/removeBlock
   local.get $2
   i32.load $0
-  local.set $3
+  local.set $4
   local.get $5
   i32.const 4
   i32.add
@@ -1428,7 +1431,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $3
+  local.get $4
   i32.const -4
   i32.and
   local.get $5
@@ -1439,7 +1442,7 @@
   if
    local.get $2
    local.get $5
-   local.get $3
+   local.get $4
    i32.const 2
    i32.and
    i32.or
@@ -1449,19 +1452,19 @@
    i32.add
    local.get $5
    i32.add
-   local.tee $3
+   local.tee $4
    local.get $6
    i32.const 4
    i32.sub
    i32.const 1
    i32.or
    i32.store $0
-   local.get $4
    local.get $3
+   local.get $4
    call $~lib/rt/tlsf/insertBlock
   else
    local.get $2
-   local.get $3
+   local.get $4
    i32.const -2
    i32.and
    i32.store $0

--- a/tests/compiler/std/set.release.wat
+++ b/tests/compiler/std/set.release.wat
@@ -643,7 +643,7 @@
   if
    i32.const 0
    i32.const 1392
-   i32.const 378
+   i32.const 382
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -668,7 +668,7 @@
    if
     i32.const 0
     i32.const 1392
-    i32.const 385
+    i32.const 389
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -696,7 +696,7 @@
    if
     i32.const 0
     i32.const 1392
-    i32.const 398
+    i32.const 402
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1063,7 +1063,7 @@
       if
        i32.const 0
        i32.const 1392
-       i32.const 560
+       i32.const 562
        i32.const 3
        call $~lib/builtins/abort
        unreachable
@@ -1147,7 +1147,7 @@
   if
    i32.const 0
    i32.const 1392
-   i32.const 330
+   i32.const 334
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1199,7 +1199,7 @@
     if
      i32.const 0
      i32.const 1392
-     i32.const 343
+     i32.const 347
      i32.const 18
      call $~lib/builtins/abort
      unreachable
@@ -1288,7 +1288,7 @@
    call $~lib/rt/tlsf/initialize
   end
   global.get $~lib/rt/tlsf/ROOT
-  local.set $3
+  local.set $4
   local.get $0
   i32.const 16
   i32.add
@@ -1298,12 +1298,12 @@
   if
    i32.const 1056
    i32.const 1392
-   i32.const 459
+   i32.const 461
    i32.const 29
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $3
+  local.get $4
   i32.const 12
   local.get $2
   i32.const 19
@@ -1324,8 +1324,29 @@
    memory.size $0
    local.tee $2
    local.get $5
+   i32.const 256
+   i32.gt_u
+   if (result i32)
+    local.get $5
+    i32.const 1
+    i32.const 27
+    local.get $5
+    i32.clz
+    i32.sub
+    i32.shl
+    i32.add
+    i32.const 1
+    i32.sub
+    local.get $5
+    local.get $5
+    i32.const 536870910
+    i32.lt_u
+    select
+   else
+    local.get $5
+   end
    i32.const 4
-   local.get $3
+   local.get $4
    i32.load $0 offset=1568
    local.get $2
    i32.const 16
@@ -1335,39 +1356,22 @@
    i32.ne
    i32.shl
    i32.add
-   local.tee $4
-   i32.const 536870910
-   i32.lt_u
-   if (result i32)
-    local.get $4
-    i32.const 1
-    i32.const 27
-    local.get $4
-    i32.clz
-    i32.sub
-    i32.shl
-    i32.const 1
-    i32.sub
-    i32.add
-   else
-    local.get $4
-   end
    i32.const 65535
    i32.add
    i32.const -65536
    i32.and
    i32.const 16
    i32.shr_u
-   local.tee $4
+   local.tee $3
    local.get $2
-   local.get $4
+   local.get $3
    i32.gt_s
    select
    memory.grow $0
    i32.const 0
    i32.lt_s
    if
-    local.get $4
+    local.get $3
     memory.grow $0
     i32.const 0
     i32.lt_s
@@ -1375,7 +1379,7 @@
      unreachable
     end
    end
-   local.get $3
+   local.get $4
    local.get $2
    i32.const 16
    i32.shl
@@ -1384,7 +1388,7 @@
    i64.const 16
    i64.shl
    call $~lib/rt/tlsf/addMemory
-   local.get $3
+   local.get $4
    local.get $5
    call $~lib/rt/tlsf/searchBlock
    local.tee $2
@@ -1392,7 +1396,7 @@
    if
     i32.const 0
     i32.const 1392
-    i32.const 497
+    i32.const 499
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1407,17 +1411,17 @@
   if
    i32.const 0
    i32.const 1392
-   i32.const 499
+   i32.const 501
    i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $3
+  local.get $4
   local.get $2
   call $~lib/rt/tlsf/removeBlock
   local.get $2
   i32.load $0
-  local.set $4
+  local.set $3
   local.get $5
   i32.const 4
   i32.add
@@ -1426,12 +1430,12 @@
   if
    i32.const 0
    i32.const 1392
-   i32.const 357
+   i32.const 361
    i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $4
+  local.get $3
   i32.const -4
   i32.and
   local.get $5
@@ -1442,7 +1446,7 @@
   if
    local.get $2
    local.get $5
-   local.get $4
+   local.get $3
    i32.const 2
    i32.and
    i32.or
@@ -1452,19 +1456,19 @@
    i32.add
    local.get $5
    i32.add
-   local.tee $4
+   local.tee $3
    local.get $6
    i32.const 4
    i32.sub
    i32.const 1
    i32.or
    i32.store $0
-   local.get $3
    local.get $4
+   local.get $3
    call $~lib/rt/tlsf/insertBlock
   else
    local.get $2
-   local.get $4
+   local.get $3
    i32.const -2
    i32.and
    i32.store $0

--- a/tests/compiler/std/set.release.wat
+++ b/tests/compiler/std/set.release.wat
@@ -1325,7 +1325,7 @@
    local.tee $2
    local.get $5
    i32.const 256
-   i32.gt_u
+   i32.ge_u
    if (result i32)
     local.get $5
     i32.const 1

--- a/tests/compiler/std/static-array.debug.wat
+++ b/tests/compiler/std/static-array.debug.wat
@@ -1965,7 +1965,7 @@
   drop
   local.get $size
   i32.const 256
-  i32.gt_u
+  i32.ge_u
   if
    local.get $size
    call $~lib/rt/tlsf/roundSize

--- a/tests/compiler/std/static-array.debug.wat
+++ b/tests/compiler/std/static-array.debug.wat
@@ -1954,22 +1954,6 @@
   (local $pagesAfter i32)
   i32.const 0
   drop
-  local.get $size
-  i32.const 536870910
-  i32.lt_u
-  if
-   local.get $size
-   i32.const 1
-   i32.const 27
-   local.get $size
-   i32.clz
-   i32.sub
-   i32.shl
-   i32.const 1
-   i32.sub
-   i32.add
-   local.set $size
-  end
   memory.size $0
   local.set $pagesBefore
   local.get $size
@@ -1990,6 +1974,22 @@
   i32.shl
   i32.add
   local.set $size
+  local.get $size
+  i32.const 536870910
+  i32.lt_u
+  if
+   local.get $size
+   i32.const 1
+   i32.const 27
+   local.get $size
+   i32.clz
+   i32.sub
+   i32.shl
+   i32.const 1
+   i32.sub
+   i32.add
+   local.set $size
+  end
   local.get $size
   i32.const 65535
   i32.add

--- a/tests/compiler/std/static-array.debug.wat
+++ b/tests/compiler/std/static-array.debug.wat
@@ -1075,7 +1075,7 @@
   if
    i32.const 0
    i32.const 880
-   i32.const 378
+   i32.const 382
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1121,7 +1121,7 @@
    if
     i32.const 0
     i32.const 880
-    i32.const 385
+    i32.const 389
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1154,7 +1154,7 @@
    if
     i32.const 0
     i32.const 880
-    i32.const 398
+    i32.const 402
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1398,7 +1398,7 @@
   if
    i32.const 0
    i32.const 880
-   i32.const 560
+   i32.const 562
    i32.const 3
    call $~lib/builtins/abort
    unreachable
@@ -1727,13 +1727,33 @@
   if
    i32.const 608
    i32.const 880
-   i32.const 459
+   i32.const 461
    i32.const 29
    call $~lib/builtins/abort
    unreachable
   end
   local.get $size
   call $~lib/rt/tlsf/computeSize
+  return
+ )
+ (func $~lib/rt/tlsf/roundSize (param $size i32) (result i32)
+  local.get $size
+  i32.const 536870910
+  i32.lt_u
+  if (result i32)
+   local.get $size
+   i32.const 1
+   i32.const 27
+   local.get $size
+   i32.clz
+   i32.sub
+   i32.shl
+   i32.add
+   i32.const 1
+   i32.sub
+  else
+   local.get $size
+  end
   return
  )
  (func $~lib/rt/tlsf/searchBlock (param $root i32) (param $size i32) (result i32)
@@ -1765,24 +1785,13 @@
    local.set $sl
   else
    local.get $size
-   i32.const 536870910
-   i32.lt_u
-   if (result i32)
-    local.get $size
-    i32.const 1
-    i32.const 27
-    local.get $size
-    i32.clz
-    i32.sub
-    i32.shl
-    i32.add
-    i32.const 1
-    i32.sub
-   else
-    local.get $size
-   end
+   call $~lib/rt/tlsf/roundSize
    local.set $requestSize
-   i32.const 31
+   i32.const 4
+   i32.const 8
+   i32.mul
+   i32.const 1
+   i32.sub
    local.get $requestSize
    i32.clz
    i32.sub
@@ -1820,7 +1829,7 @@
   if
    i32.const 0
    i32.const 880
-   i32.const 330
+   i32.const 334
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1891,7 +1900,7 @@
     if
      i32.const 0
      i32.const 880
-     i32.const 343
+     i32.const 347
      i32.const 18
      call $~lib/builtins/abort
      unreachable
@@ -1954,6 +1963,14 @@
   (local $pagesAfter i32)
   i32.const 0
   drop
+  local.get $size
+  i32.const 256
+  i32.gt_u
+  if
+   local.get $size
+   call $~lib/rt/tlsf/roundSize
+   local.set $size
+  end
   memory.size $0
   local.set $pagesBefore
   local.get $size
@@ -1974,22 +1991,6 @@
   i32.shl
   i32.add
   local.set $size
-  local.get $size
-  i32.const 536870910
-  i32.lt_u
-  if
-   local.get $size
-   i32.const 1
-   i32.const 27
-   local.get $size
-   i32.clz
-   i32.sub
-   i32.shl
-   i32.const 1
-   i32.sub
-   i32.add
-   local.set $size
-  end
   local.get $size
   i32.const 65535
   i32.add
@@ -2056,7 +2057,7 @@
   if
    i32.const 0
    i32.const 880
-   i32.const 357
+   i32.const 361
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -2171,7 +2172,7 @@
    if
     i32.const 0
     i32.const 880
-    i32.const 497
+    i32.const 499
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -2191,7 +2192,7 @@
   if
    i32.const 0
    i32.const 880
-   i32.const 499
+   i32.const 501
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/std/static-array.release.wat
+++ b/tests/compiler/std/static-array.release.wat
@@ -1465,7 +1465,7 @@
     local.tee $2
     i32.const 20
     i32.sub
-    local.tee $6
+    local.tee $4
     i32.load $0
     i32.const -4
     i32.and
@@ -1473,14 +1473,14 @@
     i32.sub
     i32.le_u
     if
-     local.get $6
+     local.get $4
      local.get $3
      i32.store $0 offset=16
      local.get $2
      local.set $1
      br $__inlined_func$~lib/rt/itcms/__renew
     end
-    local.get $6
+    local.get $4
     i32.load $0 offset=12
     local.set $7
     local.get $3
@@ -1545,7 +1545,7 @@
      call $~lib/rt/tlsf/initialize
     end
     global.get $~lib/rt/tlsf/ROOT
-    local.set $4
+    local.set $5
     local.get $3
     i32.const 16
     i32.add
@@ -1560,7 +1560,7 @@
      call $~lib/builtins/abort
      unreachable
     end
-    local.get $4
+    local.get $5
     i32.const 12
     local.get $1
     i32.const 19
@@ -1580,8 +1580,9 @@
     if
      memory.size $0
      local.tee $1
+     local.get $8
      i32.const 4
-     local.get $4
+     local.get $5
      i32.load $0 offset=1568
      local.get $1
      i32.const 16
@@ -1590,38 +1591,40 @@
      i32.sub
      i32.ne
      i32.shl
-     local.get $8
-     i32.const 1
-     i32.const 27
-     local.get $8
-     i32.clz
-     i32.sub
-     i32.shl
-     i32.const 1
-     i32.sub
      i32.add
-     local.get $8
-     local.get $8
+     local.tee $6
      i32.const 536870910
      i32.lt_u
-     select
-     i32.add
+     if (result i32)
+      local.get $6
+      i32.const 1
+      i32.const 27
+      local.get $6
+      i32.clz
+      i32.sub
+      i32.shl
+      i32.const 1
+      i32.sub
+      i32.add
+     else
+      local.get $6
+     end
      i32.const 65535
      i32.add
      i32.const -65536
      i32.and
      i32.const 16
      i32.shr_u
-     local.tee $5
+     local.tee $6
      local.get $1
-     local.get $5
+     local.get $6
      i32.gt_s
      select
      memory.grow $0
      i32.const 0
      i32.lt_s
      if
-      local.get $5
+      local.get $6
       memory.grow $0
       i32.const 0
       i32.lt_s
@@ -1629,7 +1632,7 @@
        unreachable
       end
      end
-     local.get $4
+     local.get $5
      local.get $1
      i32.const 16
      i32.shl
@@ -1638,7 +1641,7 @@
      i64.const 16
      i64.shl
      call $~lib/rt/tlsf/addMemory
-     local.get $4
+     local.get $5
      local.get $8
      call $~lib/rt/tlsf/searchBlock
      local.tee $1
@@ -1666,12 +1669,12 @@
      call $~lib/builtins/abort
      unreachable
     end
-    local.get $4
+    local.get $5
     local.get $1
     call $~lib/rt/tlsf/removeBlock
     local.get $1
     i32.load $0
-    local.set $5
+    local.set $6
     local.get $8
     i32.const 4
     i32.add
@@ -1685,7 +1688,7 @@
      call $~lib/builtins/abort
      unreachable
     end
-    local.get $5
+    local.get $6
     i32.const -4
     i32.and
     local.get $8
@@ -1696,7 +1699,7 @@
     if
      local.get $1
      local.get $8
-     local.get $5
+     local.get $6
      i32.const 2
      i32.and
      i32.or
@@ -1706,19 +1709,19 @@
      i32.add
      local.get $8
      i32.add
-     local.tee $5
+     local.tee $6
      local.get $9
      i32.const 4
      i32.sub
      i32.const 1
      i32.or
      i32.store $0
-     local.get $4
      local.get $5
+     local.get $6
      call $~lib/rt/tlsf/insertBlock
     else
      local.get $1
-     local.get $5
+     local.get $6
      i32.const -2
      i32.and
      i32.store $0
@@ -1730,8 +1733,8 @@
      i32.const -4
      i32.and
      i32.add
-     local.tee $4
-     local.get $4
+     local.tee $5
+     local.get $5
      i32.load $0
      i32.const -3
      i32.and
@@ -1744,26 +1747,26 @@
     local.get $3
     i32.store $0 offset=16
     global.get $~lib/rt/itcms/fromSpace
-    local.tee $4
+    local.tee $5
     i32.load $0 offset=8
-    local.set $5
+    local.set $6
     local.get $1
-    local.get $4
+    local.get $5
     global.get $~lib/rt/itcms/white
     i32.or
     i32.store $0 offset=4
     local.get $1
-    local.get $5
+    local.get $6
     i32.store $0 offset=8
-    local.get $5
+    local.get $6
     local.get $1
-    local.get $5
+    local.get $6
     i32.load $0 offset=4
     i32.const 3
     i32.and
     i32.or
     i32.store $0 offset=4
-    local.get $4
+    local.get $5
     local.get $1
     i32.store $0 offset=8
     global.get $~lib/rt/itcms/total
@@ -1785,7 +1788,7 @@
     local.get $1
     local.get $2
     local.get $3
-    local.get $6
+    local.get $4
     i32.load $0 offset=16
     local.tee $4
     local.get $3

--- a/tests/compiler/std/static-array.release.wat
+++ b/tests/compiler/std/static-array.release.wat
@@ -655,7 +655,7 @@
   if
    i32.const 0
    i32.const 1904
-   i32.const 378
+   i32.const 382
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -680,7 +680,7 @@
    if
     i32.const 0
     i32.const 1904
-    i32.const 385
+    i32.const 389
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -708,7 +708,7 @@
    if
     i32.const 0
     i32.const 1904
-    i32.const 398
+    i32.const 402
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1075,7 +1075,7 @@
       if
        i32.const 0
        i32.const 1904
-       i32.const 560
+       i32.const 562
        i32.const 3
        call $~lib/builtins/abort
        unreachable
@@ -1159,7 +1159,7 @@
   if
    i32.const 0
    i32.const 1904
-   i32.const 330
+   i32.const 334
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1211,7 +1211,7 @@
     if
      i32.const 0
      i32.const 1904
-     i32.const 343
+     i32.const 347
      i32.const 18
      call $~lib/builtins/abort
      unreachable
@@ -1465,7 +1465,7 @@
     local.tee $2
     i32.const 20
     i32.sub
-    local.tee $4
+    local.tee $6
     i32.load $0
     i32.const -4
     i32.and
@@ -1473,14 +1473,14 @@
     i32.sub
     i32.le_u
     if
-     local.get $4
+     local.get $6
      local.get $3
      i32.store $0 offset=16
      local.get $2
      local.set $1
      br $__inlined_func$~lib/rt/itcms/__renew
     end
-    local.get $4
+    local.get $6
     i32.load $0 offset=12
     local.set $7
     local.get $3
@@ -1545,7 +1545,7 @@
      call $~lib/rt/tlsf/initialize
     end
     global.get $~lib/rt/tlsf/ROOT
-    local.set $5
+    local.set $4
     local.get $3
     i32.const 16
     i32.add
@@ -1555,12 +1555,12 @@
     if
      i32.const 1632
      i32.const 1904
-     i32.const 459
+     i32.const 461
      i32.const 29
      call $~lib/builtins/abort
      unreachable
     end
-    local.get $5
+    local.get $4
     i32.const 12
     local.get $1
     i32.const 19
@@ -1581,8 +1581,29 @@
      memory.size $0
      local.tee $1
      local.get $8
+     i32.const 256
+     i32.gt_u
+     if (result i32)
+      local.get $8
+      i32.const 1
+      i32.const 27
+      local.get $8
+      i32.clz
+      i32.sub
+      i32.shl
+      i32.add
+      i32.const 1
+      i32.sub
+      local.get $8
+      local.get $8
+      i32.const 536870910
+      i32.lt_u
+      select
+     else
+      local.get $8
+     end
      i32.const 4
-     local.get $5
+     local.get $4
      i32.load $0 offset=1568
      local.get $1
      i32.const 16
@@ -1592,39 +1613,22 @@
      i32.ne
      i32.shl
      i32.add
-     local.tee $6
-     i32.const 536870910
-     i32.lt_u
-     if (result i32)
-      local.get $6
-      i32.const 1
-      i32.const 27
-      local.get $6
-      i32.clz
-      i32.sub
-      i32.shl
-      i32.const 1
-      i32.sub
-      i32.add
-     else
-      local.get $6
-     end
      i32.const 65535
      i32.add
      i32.const -65536
      i32.and
      i32.const 16
      i32.shr_u
-     local.tee $6
+     local.tee $5
      local.get $1
-     local.get $6
+     local.get $5
      i32.gt_s
      select
      memory.grow $0
      i32.const 0
      i32.lt_s
      if
-      local.get $6
+      local.get $5
       memory.grow $0
       i32.const 0
       i32.lt_s
@@ -1632,7 +1636,7 @@
        unreachable
       end
      end
-     local.get $5
+     local.get $4
      local.get $1
      i32.const 16
      i32.shl
@@ -1641,7 +1645,7 @@
      i64.const 16
      i64.shl
      call $~lib/rt/tlsf/addMemory
-     local.get $5
+     local.get $4
      local.get $8
      call $~lib/rt/tlsf/searchBlock
      local.tee $1
@@ -1649,7 +1653,7 @@
      if
       i32.const 0
       i32.const 1904
-      i32.const 497
+      i32.const 499
       i32.const 16
       call $~lib/builtins/abort
       unreachable
@@ -1664,17 +1668,17 @@
     if
      i32.const 0
      i32.const 1904
-     i32.const 499
+     i32.const 501
      i32.const 14
      call $~lib/builtins/abort
      unreachable
     end
-    local.get $5
+    local.get $4
     local.get $1
     call $~lib/rt/tlsf/removeBlock
     local.get $1
     i32.load $0
-    local.set $6
+    local.set $5
     local.get $8
     i32.const 4
     i32.add
@@ -1683,12 +1687,12 @@
     if
      i32.const 0
      i32.const 1904
-     i32.const 357
+     i32.const 361
      i32.const 14
      call $~lib/builtins/abort
      unreachable
     end
-    local.get $6
+    local.get $5
     i32.const -4
     i32.and
     local.get $8
@@ -1699,7 +1703,7 @@
     if
      local.get $1
      local.get $8
-     local.get $6
+     local.get $5
      i32.const 2
      i32.and
      i32.or
@@ -1709,19 +1713,19 @@
      i32.add
      local.get $8
      i32.add
-     local.tee $6
+     local.tee $5
      local.get $9
      i32.const 4
      i32.sub
      i32.const 1
      i32.or
      i32.store $0
+     local.get $4
      local.get $5
-     local.get $6
      call $~lib/rt/tlsf/insertBlock
     else
      local.get $1
-     local.get $6
+     local.get $5
      i32.const -2
      i32.and
      i32.store $0
@@ -1733,8 +1737,8 @@
      i32.const -4
      i32.and
      i32.add
-     local.tee $5
-     local.get $5
+     local.tee $4
+     local.get $4
      i32.load $0
      i32.const -3
      i32.and
@@ -1747,26 +1751,26 @@
     local.get $3
     i32.store $0 offset=16
     global.get $~lib/rt/itcms/fromSpace
-    local.tee $5
+    local.tee $4
     i32.load $0 offset=8
-    local.set $6
+    local.set $5
     local.get $1
-    local.get $5
+    local.get $4
     global.get $~lib/rt/itcms/white
     i32.or
     i32.store $0 offset=4
     local.get $1
-    local.get $6
+    local.get $5
     i32.store $0 offset=8
-    local.get $6
+    local.get $5
     local.get $1
-    local.get $6
+    local.get $5
     i32.load $0 offset=4
     i32.const 3
     i32.and
     i32.or
     i32.store $0 offset=4
-    local.get $5
+    local.get $4
     local.get $1
     i32.store $0 offset=8
     global.get $~lib/rt/itcms/total
@@ -1788,7 +1792,7 @@
     local.get $1
     local.get $2
     local.get $3
-    local.get $4
+    local.get $6
     i32.load $0 offset=16
     local.tee $4
     local.get $3

--- a/tests/compiler/std/static-array.release.wat
+++ b/tests/compiler/std/static-array.release.wat
@@ -1582,7 +1582,7 @@
      local.tee $1
      local.get $8
      i32.const 256
-     i32.gt_u
+     i32.ge_u
      if (result i32)
       local.get $8
       i32.const 1

--- a/tests/compiler/std/staticarray.debug.wat
+++ b/tests/compiler/std/staticarray.debug.wat
@@ -2015,22 +2015,6 @@
   (local $pagesAfter i32)
   i32.const 0
   drop
-  local.get $size
-  i32.const 536870910
-  i32.lt_u
-  if
-   local.get $size
-   i32.const 1
-   i32.const 27
-   local.get $size
-   i32.clz
-   i32.sub
-   i32.shl
-   i32.const 1
-   i32.sub
-   i32.add
-   local.set $size
-  end
   memory.size $0
   local.set $pagesBefore
   local.get $size
@@ -2051,6 +2035,22 @@
   i32.shl
   i32.add
   local.set $size
+  local.get $size
+  i32.const 536870910
+  i32.lt_u
+  if
+   local.get $size
+   i32.const 1
+   i32.const 27
+   local.get $size
+   i32.clz
+   i32.sub
+   i32.shl
+   i32.const 1
+   i32.sub
+   i32.add
+   local.set $size
+  end
   local.get $size
   i32.const 65535
   i32.add

--- a/tests/compiler/std/staticarray.debug.wat
+++ b/tests/compiler/std/staticarray.debug.wat
@@ -1136,7 +1136,7 @@
   if
    i32.const 0
    i32.const 592
-   i32.const 378
+   i32.const 382
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1182,7 +1182,7 @@
    if
     i32.const 0
     i32.const 592
-    i32.const 385
+    i32.const 389
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1215,7 +1215,7 @@
    if
     i32.const 0
     i32.const 592
-    i32.const 398
+    i32.const 402
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1459,7 +1459,7 @@
   if
    i32.const 0
    i32.const 592
-   i32.const 560
+   i32.const 562
    i32.const 3
    call $~lib/builtins/abort
    unreachable
@@ -1788,13 +1788,33 @@
   if
    i32.const 320
    i32.const 592
-   i32.const 459
+   i32.const 461
    i32.const 29
    call $~lib/builtins/abort
    unreachable
   end
   local.get $size
   call $~lib/rt/tlsf/computeSize
+  return
+ )
+ (func $~lib/rt/tlsf/roundSize (param $size i32) (result i32)
+  local.get $size
+  i32.const 536870910
+  i32.lt_u
+  if (result i32)
+   local.get $size
+   i32.const 1
+   i32.const 27
+   local.get $size
+   i32.clz
+   i32.sub
+   i32.shl
+   i32.add
+   i32.const 1
+   i32.sub
+  else
+   local.get $size
+  end
   return
  )
  (func $~lib/rt/tlsf/searchBlock (param $root i32) (param $size i32) (result i32)
@@ -1826,24 +1846,13 @@
    local.set $sl
   else
    local.get $size
-   i32.const 536870910
-   i32.lt_u
-   if (result i32)
-    local.get $size
-    i32.const 1
-    i32.const 27
-    local.get $size
-    i32.clz
-    i32.sub
-    i32.shl
-    i32.add
-    i32.const 1
-    i32.sub
-   else
-    local.get $size
-   end
+   call $~lib/rt/tlsf/roundSize
    local.set $requestSize
-   i32.const 31
+   i32.const 4
+   i32.const 8
+   i32.mul
+   i32.const 1
+   i32.sub
    local.get $requestSize
    i32.clz
    i32.sub
@@ -1881,7 +1890,7 @@
   if
    i32.const 0
    i32.const 592
-   i32.const 330
+   i32.const 334
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1952,7 +1961,7 @@
     if
      i32.const 0
      i32.const 592
-     i32.const 343
+     i32.const 347
      i32.const 18
      call $~lib/builtins/abort
      unreachable
@@ -2015,6 +2024,14 @@
   (local $pagesAfter i32)
   i32.const 0
   drop
+  local.get $size
+  i32.const 256
+  i32.gt_u
+  if
+   local.get $size
+   call $~lib/rt/tlsf/roundSize
+   local.set $size
+  end
   memory.size $0
   local.set $pagesBefore
   local.get $size
@@ -2035,22 +2052,6 @@
   i32.shl
   i32.add
   local.set $size
-  local.get $size
-  i32.const 536870910
-  i32.lt_u
-  if
-   local.get $size
-   i32.const 1
-   i32.const 27
-   local.get $size
-   i32.clz
-   i32.sub
-   i32.shl
-   i32.const 1
-   i32.sub
-   i32.add
-   local.set $size
-  end
   local.get $size
   i32.const 65535
   i32.add
@@ -2117,7 +2118,7 @@
   if
    i32.const 0
    i32.const 592
-   i32.const 357
+   i32.const 361
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -2232,7 +2233,7 @@
    if
     i32.const 0
     i32.const 592
-    i32.const 497
+    i32.const 499
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -2252,7 +2253,7 @@
   if
    i32.const 0
    i32.const 592
-   i32.const 499
+   i32.const 501
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/std/staticarray.debug.wat
+++ b/tests/compiler/std/staticarray.debug.wat
@@ -2026,7 +2026,7 @@
   drop
   local.get $size
   i32.const 256
-  i32.gt_u
+  i32.ge_u
   if
    local.get $size
    call $~lib/rt/tlsf/roundSize

--- a/tests/compiler/std/staticarray.release.wat
+++ b/tests/compiler/std/staticarray.release.wat
@@ -769,7 +769,7 @@
   if
    i32.const 0
    i32.const 1616
-   i32.const 378
+   i32.const 382
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -794,7 +794,7 @@
    if
     i32.const 0
     i32.const 1616
-    i32.const 385
+    i32.const 389
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -822,7 +822,7 @@
    if
     i32.const 0
     i32.const 1616
-    i32.const 398
+    i32.const 402
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -990,7 +990,7 @@
   if
    i32.const 0
    i32.const 1616
-   i32.const 560
+   i32.const 562
    i32.const 3
    call $~lib/builtins/abort
    unreachable
@@ -1279,7 +1279,7 @@
   if
    i32.const 0
    i32.const 1616
-   i32.const 330
+   i32.const 334
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1331,7 +1331,7 @@
     if
      i32.const 0
      i32.const 1616
-     i32.const 343
+     i32.const 347
      i32.const 18
      call $~lib/builtins/abort
      unreachable
@@ -1362,7 +1362,7 @@
   if
    i32.const 1344
    i32.const 1616
-   i32.const 459
+   i32.const 461
    i32.const 29
    call $~lib/builtins/abort
    unreachable
@@ -1388,6 +1388,27 @@
    memory.size $0
    local.tee $1
    local.get $3
+   i32.const 256
+   i32.gt_u
+   if (result i32)
+    local.get $3
+    i32.const 1
+    i32.const 27
+    local.get $3
+    i32.clz
+    i32.sub
+    i32.shl
+    i32.add
+    i32.const 1
+    i32.sub
+    local.get $3
+    local.get $3
+    i32.const 536870910
+    i32.lt_u
+    select
+   else
+    local.get $3
+   end
    i32.const 4
    local.get $0
    i32.load $0 offset=1568
@@ -1399,23 +1420,6 @@
    i32.ne
    i32.shl
    i32.add
-   local.tee $2
-   i32.const 536870910
-   i32.lt_u
-   if (result i32)
-    local.get $2
-    i32.const 1
-    i32.const 27
-    local.get $2
-    i32.clz
-    i32.sub
-    i32.shl
-    i32.const 1
-    i32.sub
-    i32.add
-   else
-    local.get $2
-   end
    i32.const 65535
    i32.add
    i32.const -65536
@@ -1456,7 +1460,7 @@
    if
     i32.const 0
     i32.const 1616
-    i32.const 497
+    i32.const 499
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1471,7 +1475,7 @@
   if
    i32.const 0
    i32.const 1616
-   i32.const 499
+   i32.const 501
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1481,7 +1485,7 @@
   call $~lib/rt/tlsf/removeBlock
   local.get $1
   i32.load $0
-  local.set $2
+  local.set $4
   local.get $3
   i32.const 4
   i32.add
@@ -1490,23 +1494,23 @@
   if
    i32.const 0
    i32.const 1616
-   i32.const 357
+   i32.const 361
    i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $2
+  local.get $4
   i32.const -4
   i32.and
   local.get $3
   i32.sub
-  local.tee $4
+  local.tee $2
   i32.const 16
   i32.ge_u
   if
    local.get $1
    local.get $3
-   local.get $2
+   local.get $4
    i32.const 2
    i32.and
    i32.or
@@ -1516,19 +1520,19 @@
    i32.add
    local.get $3
    i32.add
-   local.tee $2
-   local.get $4
+   local.tee $3
+   local.get $2
    i32.const 4
    i32.sub
    i32.const 1
    i32.or
    i32.store $0
    local.get $0
-   local.get $2
+   local.get $3
    call $~lib/rt/tlsf/insertBlock
   else
    local.get $1
-   local.get $2
+   local.get $4
    i32.const -2
    i32.and
    i32.store $0

--- a/tests/compiler/std/staticarray.release.wat
+++ b/tests/compiler/std/staticarray.release.wat
@@ -1387,6 +1387,7 @@
   if
    memory.size $0
    local.tee $1
+   local.get $3
    i32.const 4
    local.get $0
    i32.load $0 offset=1568
@@ -1397,22 +1398,24 @@
    i32.sub
    i32.ne
    i32.shl
-   local.get $3
-   i32.const 1
-   i32.const 27
-   local.get $3
-   i32.clz
-   i32.sub
-   i32.shl
-   i32.const 1
-   i32.sub
    i32.add
-   local.get $3
-   local.get $3
+   local.tee $2
    i32.const 536870910
    i32.lt_u
-   select
-   i32.add
+   if (result i32)
+    local.get $2
+    i32.const 1
+    i32.const 27
+    local.get $2
+    i32.clz
+    i32.sub
+    i32.shl
+    i32.const 1
+    i32.sub
+    i32.add
+   else
+    local.get $2
+   end
    i32.const 65535
    i32.add
    i32.const -65536
@@ -1478,7 +1481,7 @@
   call $~lib/rt/tlsf/removeBlock
   local.get $1
   i32.load $0
-  local.set $4
+  local.set $2
   local.get $3
   i32.const 4
   i32.add
@@ -1492,18 +1495,18 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $4
+  local.get $2
   i32.const -4
   i32.and
   local.get $3
   i32.sub
-  local.tee $2
+  local.tee $4
   i32.const 16
   i32.ge_u
   if
    local.get $1
    local.get $3
-   local.get $4
+   local.get $2
    i32.const 2
    i32.and
    i32.or
@@ -1513,19 +1516,19 @@
    i32.add
    local.get $3
    i32.add
-   local.tee $3
-   local.get $2
+   local.tee $2
+   local.get $4
    i32.const 4
    i32.sub
    i32.const 1
    i32.or
    i32.store $0
    local.get $0
-   local.get $3
+   local.get $2
    call $~lib/rt/tlsf/insertBlock
   else
    local.get $1
-   local.get $4
+   local.get $2
    i32.const -2
    i32.and
    i32.store $0

--- a/tests/compiler/std/staticarray.release.wat
+++ b/tests/compiler/std/staticarray.release.wat
@@ -1389,7 +1389,7 @@
    local.tee $1
    local.get $3
    i32.const 256
-   i32.gt_u
+   i32.ge_u
    if (result i32)
     local.get $3
     i32.const 1

--- a/tests/compiler/std/string-casemapping.debug.wat
+++ b/tests/compiler/std/string-casemapping.debug.wat
@@ -2117,7 +2117,7 @@
   drop
   local.get $size
   i32.const 256
-  i32.gt_u
+  i32.ge_u
   if
    local.get $size
    call $~lib/rt/tlsf/roundSize

--- a/tests/compiler/std/string-casemapping.debug.wat
+++ b/tests/compiler/std/string-casemapping.debug.wat
@@ -2106,22 +2106,6 @@
   (local $pagesAfter i32)
   i32.const 0
   drop
-  local.get $size
-  i32.const 536870910
-  i32.lt_u
-  if
-   local.get $size
-   i32.const 1
-   i32.const 27
-   local.get $size
-   i32.clz
-   i32.sub
-   i32.shl
-   i32.const 1
-   i32.sub
-   i32.add
-   local.set $size
-  end
   memory.size $0
   local.set $pagesBefore
   local.get $size
@@ -2142,6 +2126,22 @@
   i32.shl
   i32.add
   local.set $size
+  local.get $size
+  i32.const 536870910
+  i32.lt_u
+  if
+   local.get $size
+   i32.const 1
+   i32.const 27
+   local.get $size
+   i32.clz
+   i32.sub
+   i32.shl
+   i32.const 1
+   i32.sub
+   i32.add
+   local.set $size
+  end
   local.get $size
   i32.const 65535
   i32.add

--- a/tests/compiler/std/string-casemapping.debug.wat
+++ b/tests/compiler/std/string-casemapping.debug.wat
@@ -1227,7 +1227,7 @@
   if
    i32.const 0
    i32.const 400
-   i32.const 378
+   i32.const 382
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1273,7 +1273,7 @@
    if
     i32.const 0
     i32.const 400
-    i32.const 385
+    i32.const 389
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1306,7 +1306,7 @@
    if
     i32.const 0
     i32.const 400
-    i32.const 398
+    i32.const 402
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1550,7 +1550,7 @@
   if
    i32.const 0
    i32.const 400
-   i32.const 560
+   i32.const 562
    i32.const 3
    call $~lib/builtins/abort
    unreachable
@@ -1879,13 +1879,33 @@
   if
    i32.const 64
    i32.const 400
-   i32.const 459
+   i32.const 461
    i32.const 29
    call $~lib/builtins/abort
    unreachable
   end
   local.get $size
   call $~lib/rt/tlsf/computeSize
+  return
+ )
+ (func $~lib/rt/tlsf/roundSize (param $size i32) (result i32)
+  local.get $size
+  i32.const 536870910
+  i32.lt_u
+  if (result i32)
+   local.get $size
+   i32.const 1
+   i32.const 27
+   local.get $size
+   i32.clz
+   i32.sub
+   i32.shl
+   i32.add
+   i32.const 1
+   i32.sub
+  else
+   local.get $size
+  end
   return
  )
  (func $~lib/rt/tlsf/searchBlock (param $root i32) (param $size i32) (result i32)
@@ -1917,24 +1937,13 @@
    local.set $sl
   else
    local.get $size
-   i32.const 536870910
-   i32.lt_u
-   if (result i32)
-    local.get $size
-    i32.const 1
-    i32.const 27
-    local.get $size
-    i32.clz
-    i32.sub
-    i32.shl
-    i32.add
-    i32.const 1
-    i32.sub
-   else
-    local.get $size
-   end
+   call $~lib/rt/tlsf/roundSize
    local.set $requestSize
-   i32.const 31
+   i32.const 4
+   i32.const 8
+   i32.mul
+   i32.const 1
+   i32.sub
    local.get $requestSize
    i32.clz
    i32.sub
@@ -1972,7 +1981,7 @@
   if
    i32.const 0
    i32.const 400
-   i32.const 330
+   i32.const 334
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -2043,7 +2052,7 @@
     if
      i32.const 0
      i32.const 400
-     i32.const 343
+     i32.const 347
      i32.const 18
      call $~lib/builtins/abort
      unreachable
@@ -2106,6 +2115,14 @@
   (local $pagesAfter i32)
   i32.const 0
   drop
+  local.get $size
+  i32.const 256
+  i32.gt_u
+  if
+   local.get $size
+   call $~lib/rt/tlsf/roundSize
+   local.set $size
+  end
   memory.size $0
   local.set $pagesBefore
   local.get $size
@@ -2126,22 +2143,6 @@
   i32.shl
   i32.add
   local.set $size
-  local.get $size
-  i32.const 536870910
-  i32.lt_u
-  if
-   local.get $size
-   i32.const 1
-   i32.const 27
-   local.get $size
-   i32.clz
-   i32.sub
-   i32.shl
-   i32.const 1
-   i32.sub
-   i32.add
-   local.set $size
-  end
   local.get $size
   i32.const 65535
   i32.add
@@ -2208,7 +2209,7 @@
   if
    i32.const 0
    i32.const 400
-   i32.const 357
+   i32.const 361
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -2323,7 +2324,7 @@
    if
     i32.const 0
     i32.const 400
-    i32.const 497
+    i32.const 499
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -2343,7 +2344,7 @@
   if
    i32.const 0
    i32.const 400
-   i32.const 499
+   i32.const 501
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/std/string-casemapping.release.wat
+++ b/tests/compiler/std/string-casemapping.release.wat
@@ -1074,7 +1074,7 @@
   if
    i32.const 0
    i32.const 1424
-   i32.const 378
+   i32.const 382
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1099,7 +1099,7 @@
    if
     i32.const 0
     i32.const 1424
-    i32.const 385
+    i32.const 389
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1127,7 +1127,7 @@
    if
     i32.const 0
     i32.const 1424
-    i32.const 398
+    i32.const 402
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1494,7 +1494,7 @@
       if
        i32.const 0
        i32.const 1424
-       i32.const 560
+       i32.const 562
        i32.const 3
        call $~lib/builtins/abort
        unreachable
@@ -1578,7 +1578,7 @@
   if
    i32.const 0
    i32.const 1424
-   i32.const 330
+   i32.const 334
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1630,7 +1630,7 @@
     if
      i32.const 0
      i32.const 1424
-     i32.const 343
+     i32.const 347
      i32.const 18
      call $~lib/builtins/abort
      unreachable
@@ -1719,7 +1719,7 @@
    call $~lib/rt/tlsf/initialize
   end
   global.get $~lib/rt/tlsf/ROOT
-  local.set $3
+  local.set $4
   local.get $0
   i32.const 16
   i32.add
@@ -1729,12 +1729,12 @@
   if
    i32.const 1088
    i32.const 1424
-   i32.const 459
+   i32.const 461
    i32.const 29
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $3
+  local.get $4
   i32.const 12
   local.get $2
   i32.const 19
@@ -1755,8 +1755,29 @@
    memory.size $0
    local.tee $2
    local.get $5
+   i32.const 256
+   i32.gt_u
+   if (result i32)
+    local.get $5
+    i32.const 1
+    i32.const 27
+    local.get $5
+    i32.clz
+    i32.sub
+    i32.shl
+    i32.add
+    i32.const 1
+    i32.sub
+    local.get $5
+    local.get $5
+    i32.const 536870910
+    i32.lt_u
+    select
+   else
+    local.get $5
+   end
    i32.const 4
-   local.get $3
+   local.get $4
    i32.load $0 offset=1568
    local.get $2
    i32.const 16
@@ -1766,39 +1787,22 @@
    i32.ne
    i32.shl
    i32.add
-   local.tee $4
-   i32.const 536870910
-   i32.lt_u
-   if (result i32)
-    local.get $4
-    i32.const 1
-    i32.const 27
-    local.get $4
-    i32.clz
-    i32.sub
-    i32.shl
-    i32.const 1
-    i32.sub
-    i32.add
-   else
-    local.get $4
-   end
    i32.const 65535
    i32.add
    i32.const -65536
    i32.and
    i32.const 16
    i32.shr_u
-   local.tee $4
+   local.tee $3
    local.get $2
-   local.get $4
+   local.get $3
    i32.gt_s
    select
    memory.grow $0
    i32.const 0
    i32.lt_s
    if
-    local.get $4
+    local.get $3
     memory.grow $0
     i32.const 0
     i32.lt_s
@@ -1806,7 +1810,7 @@
      unreachable
     end
    end
-   local.get $3
+   local.get $4
    local.get $2
    i32.const 16
    i32.shl
@@ -1815,7 +1819,7 @@
    i64.const 16
    i64.shl
    call $~lib/rt/tlsf/addMemory
-   local.get $3
+   local.get $4
    local.get $5
    call $~lib/rt/tlsf/searchBlock
    local.tee $2
@@ -1823,7 +1827,7 @@
    if
     i32.const 0
     i32.const 1424
-    i32.const 497
+    i32.const 499
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1838,17 +1842,17 @@
   if
    i32.const 0
    i32.const 1424
-   i32.const 499
+   i32.const 501
    i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $3
+  local.get $4
   local.get $2
   call $~lib/rt/tlsf/removeBlock
   local.get $2
   i32.load $0
-  local.set $4
+  local.set $3
   local.get $5
   i32.const 4
   i32.add
@@ -1857,12 +1861,12 @@
   if
    i32.const 0
    i32.const 1424
-   i32.const 357
+   i32.const 361
    i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $4
+  local.get $3
   i32.const -4
   i32.and
   local.get $5
@@ -1873,7 +1877,7 @@
   if
    local.get $2
    local.get $5
-   local.get $4
+   local.get $3
    i32.const 2
    i32.and
    i32.or
@@ -1883,19 +1887,19 @@
    i32.add
    local.get $5
    i32.add
-   local.tee $4
+   local.tee $3
    local.get $6
    i32.const 4
    i32.sub
    i32.const 1
    i32.or
    i32.store $0
-   local.get $3
    local.get $4
+   local.get $3
    call $~lib/rt/tlsf/insertBlock
   else
    local.get $2
-   local.get $4
+   local.get $3
    i32.const -2
    i32.and
    i32.store $0

--- a/tests/compiler/std/string-casemapping.release.wat
+++ b/tests/compiler/std/string-casemapping.release.wat
@@ -1756,7 +1756,7 @@
    local.tee $2
    local.get $5
    i32.const 256
-   i32.gt_u
+   i32.ge_u
    if (result i32)
     local.get $5
     i32.const 1

--- a/tests/compiler/std/string-casemapping.release.wat
+++ b/tests/compiler/std/string-casemapping.release.wat
@@ -1719,7 +1719,7 @@
    call $~lib/rt/tlsf/initialize
   end
   global.get $~lib/rt/tlsf/ROOT
-  local.set $4
+  local.set $3
   local.get $0
   i32.const 16
   i32.add
@@ -1734,7 +1734,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $4
+  local.get $3
   i32.const 12
   local.get $2
   i32.const 19
@@ -1754,8 +1754,9 @@
   if
    memory.size $0
    local.tee $2
+   local.get $5
    i32.const 4
-   local.get $4
+   local.get $3
    i32.load $0 offset=1568
    local.get $2
    i32.const 16
@@ -1764,38 +1765,40 @@
    i32.sub
    i32.ne
    i32.shl
-   local.get $5
-   i32.const 1
-   i32.const 27
-   local.get $5
-   i32.clz
-   i32.sub
-   i32.shl
-   i32.const 1
-   i32.sub
    i32.add
-   local.get $5
-   local.get $5
+   local.tee $4
    i32.const 536870910
    i32.lt_u
-   select
-   i32.add
+   if (result i32)
+    local.get $4
+    i32.const 1
+    i32.const 27
+    local.get $4
+    i32.clz
+    i32.sub
+    i32.shl
+    i32.const 1
+    i32.sub
+    i32.add
+   else
+    local.get $4
+   end
    i32.const 65535
    i32.add
    i32.const -65536
    i32.and
    i32.const 16
    i32.shr_u
-   local.tee $3
+   local.tee $4
    local.get $2
-   local.get $3
+   local.get $4
    i32.gt_s
    select
    memory.grow $0
    i32.const 0
    i32.lt_s
    if
-    local.get $3
+    local.get $4
     memory.grow $0
     i32.const 0
     i32.lt_s
@@ -1803,7 +1806,7 @@
      unreachable
     end
    end
-   local.get $4
+   local.get $3
    local.get $2
    i32.const 16
    i32.shl
@@ -1812,7 +1815,7 @@
    i64.const 16
    i64.shl
    call $~lib/rt/tlsf/addMemory
-   local.get $4
+   local.get $3
    local.get $5
    call $~lib/rt/tlsf/searchBlock
    local.tee $2
@@ -1840,12 +1843,12 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $4
+  local.get $3
   local.get $2
   call $~lib/rt/tlsf/removeBlock
   local.get $2
   i32.load $0
-  local.set $3
+  local.set $4
   local.get $5
   i32.const 4
   i32.add
@@ -1859,7 +1862,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $3
+  local.get $4
   i32.const -4
   i32.and
   local.get $5
@@ -1870,7 +1873,7 @@
   if
    local.get $2
    local.get $5
-   local.get $3
+   local.get $4
    i32.const 2
    i32.and
    i32.or
@@ -1880,19 +1883,19 @@
    i32.add
    local.get $5
    i32.add
-   local.tee $3
+   local.tee $4
    local.get $6
    i32.const 4
    i32.sub
    i32.const 1
    i32.or
    i32.store $0
-   local.get $4
    local.get $3
+   local.get $4
    call $~lib/rt/tlsf/insertBlock
   else
    local.get $2
-   local.get $3
+   local.get $4
    i32.const -2
    i32.and
    i32.store $0

--- a/tests/compiler/std/string-encoding.debug.wat
+++ b/tests/compiler/std/string-encoding.debug.wat
@@ -1945,22 +1945,6 @@
   (local $pagesAfter i32)
   i32.const 0
   drop
-  local.get $size
-  i32.const 536870910
-  i32.lt_u
-  if
-   local.get $size
-   i32.const 1
-   i32.const 27
-   local.get $size
-   i32.clz
-   i32.sub
-   i32.shl
-   i32.const 1
-   i32.sub
-   i32.add
-   local.set $size
-  end
   memory.size $0
   local.set $pagesBefore
   local.get $size
@@ -1981,6 +1965,22 @@
   i32.shl
   i32.add
   local.set $size
+  local.get $size
+  i32.const 536870910
+  i32.lt_u
+  if
+   local.get $size
+   i32.const 1
+   i32.const 27
+   local.get $size
+   i32.clz
+   i32.sub
+   i32.shl
+   i32.const 1
+   i32.sub
+   i32.add
+   local.set $size
+  end
   local.get $size
   i32.const 65535
   i32.add

--- a/tests/compiler/std/string-encoding.debug.wat
+++ b/tests/compiler/std/string-encoding.debug.wat
@@ -1956,7 +1956,7 @@
   drop
   local.get $size
   i32.const 256
-  i32.gt_u
+  i32.ge_u
   if
    local.get $size
    call $~lib/rt/tlsf/roundSize

--- a/tests/compiler/std/string-encoding.debug.wat
+++ b/tests/compiler/std/string-encoding.debug.wat
@@ -1066,7 +1066,7 @@
   if
    i32.const 0
    i32.const 464
-   i32.const 378
+   i32.const 382
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1112,7 +1112,7 @@
    if
     i32.const 0
     i32.const 464
-    i32.const 385
+    i32.const 389
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1145,7 +1145,7 @@
    if
     i32.const 0
     i32.const 464
-    i32.const 398
+    i32.const 402
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1389,7 +1389,7 @@
   if
    i32.const 0
    i32.const 464
-   i32.const 560
+   i32.const 562
    i32.const 3
    call $~lib/builtins/abort
    unreachable
@@ -1718,13 +1718,33 @@
   if
    i32.const 128
    i32.const 464
-   i32.const 459
+   i32.const 461
    i32.const 29
    call $~lib/builtins/abort
    unreachable
   end
   local.get $size
   call $~lib/rt/tlsf/computeSize
+  return
+ )
+ (func $~lib/rt/tlsf/roundSize (param $size i32) (result i32)
+  local.get $size
+  i32.const 536870910
+  i32.lt_u
+  if (result i32)
+   local.get $size
+   i32.const 1
+   i32.const 27
+   local.get $size
+   i32.clz
+   i32.sub
+   i32.shl
+   i32.add
+   i32.const 1
+   i32.sub
+  else
+   local.get $size
+  end
   return
  )
  (func $~lib/rt/tlsf/searchBlock (param $root i32) (param $size i32) (result i32)
@@ -1756,24 +1776,13 @@
    local.set $sl
   else
    local.get $size
-   i32.const 536870910
-   i32.lt_u
-   if (result i32)
-    local.get $size
-    i32.const 1
-    i32.const 27
-    local.get $size
-    i32.clz
-    i32.sub
-    i32.shl
-    i32.add
-    i32.const 1
-    i32.sub
-   else
-    local.get $size
-   end
+   call $~lib/rt/tlsf/roundSize
    local.set $requestSize
-   i32.const 31
+   i32.const 4
+   i32.const 8
+   i32.mul
+   i32.const 1
+   i32.sub
    local.get $requestSize
    i32.clz
    i32.sub
@@ -1811,7 +1820,7 @@
   if
    i32.const 0
    i32.const 464
-   i32.const 330
+   i32.const 334
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1882,7 +1891,7 @@
     if
      i32.const 0
      i32.const 464
-     i32.const 343
+     i32.const 347
      i32.const 18
      call $~lib/builtins/abort
      unreachable
@@ -1945,6 +1954,14 @@
   (local $pagesAfter i32)
   i32.const 0
   drop
+  local.get $size
+  i32.const 256
+  i32.gt_u
+  if
+   local.get $size
+   call $~lib/rt/tlsf/roundSize
+   local.set $size
+  end
   memory.size $0
   local.set $pagesBefore
   local.get $size
@@ -1965,22 +1982,6 @@
   i32.shl
   i32.add
   local.set $size
-  local.get $size
-  i32.const 536870910
-  i32.lt_u
-  if
-   local.get $size
-   i32.const 1
-   i32.const 27
-   local.get $size
-   i32.clz
-   i32.sub
-   i32.shl
-   i32.const 1
-   i32.sub
-   i32.add
-   local.set $size
-  end
   local.get $size
   i32.const 65535
   i32.add
@@ -2047,7 +2048,7 @@
   if
    i32.const 0
    i32.const 464
-   i32.const 357
+   i32.const 361
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -2162,7 +2163,7 @@
    if
     i32.const 0
     i32.const 464
-    i32.const 497
+    i32.const 499
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -2182,7 +2183,7 @@
   if
    i32.const 0
    i32.const 464
-   i32.const 499
+   i32.const 501
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/std/string-encoding.release.wat
+++ b/tests/compiler/std/string-encoding.release.wat
@@ -1306,7 +1306,7 @@
    call $~lib/rt/tlsf/initialize
   end
   global.get $~lib/rt/tlsf/ROOT
-  local.set $4
+  local.set $3
   local.get $0
   i32.const 16
   i32.add
@@ -1321,7 +1321,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $4
+  local.get $3
   i32.const 12
   local.get $2
   i32.const 19
@@ -1341,8 +1341,9 @@
   if
    memory.size $0
    local.tee $2
+   local.get $5
    i32.const 4
-   local.get $4
+   local.get $3
    i32.load $0 offset=1568
    local.get $2
    i32.const 16
@@ -1351,38 +1352,40 @@
    i32.sub
    i32.ne
    i32.shl
-   local.get $5
-   i32.const 1
-   i32.const 27
-   local.get $5
-   i32.clz
-   i32.sub
-   i32.shl
-   i32.const 1
-   i32.sub
    i32.add
-   local.get $5
-   local.get $5
+   local.tee $4
    i32.const 536870910
    i32.lt_u
-   select
-   i32.add
+   if (result i32)
+    local.get $4
+    i32.const 1
+    i32.const 27
+    local.get $4
+    i32.clz
+    i32.sub
+    i32.shl
+    i32.const 1
+    i32.sub
+    i32.add
+   else
+    local.get $4
+   end
    i32.const 65535
    i32.add
    i32.const -65536
    i32.and
    i32.const 16
    i32.shr_u
-   local.tee $3
+   local.tee $4
    local.get $2
-   local.get $3
+   local.get $4
    i32.gt_s
    select
    memory.grow $0
    i32.const 0
    i32.lt_s
    if
-    local.get $3
+    local.get $4
     memory.grow $0
     i32.const 0
     i32.lt_s
@@ -1390,7 +1393,7 @@
      unreachable
     end
    end
-   local.get $4
+   local.get $3
    local.get $2
    i32.const 16
    i32.shl
@@ -1399,7 +1402,7 @@
    i64.const 16
    i64.shl
    call $~lib/rt/tlsf/addMemory
-   local.get $4
+   local.get $3
    local.get $5
    call $~lib/rt/tlsf/searchBlock
    local.tee $2
@@ -1427,12 +1430,12 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $4
+  local.get $3
   local.get $2
   call $~lib/rt/tlsf/removeBlock
   local.get $2
   i32.load $0
-  local.set $3
+  local.set $4
   local.get $5
   i32.const 4
   i32.add
@@ -1446,7 +1449,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $3
+  local.get $4
   i32.const -4
   i32.and
   local.get $5
@@ -1457,7 +1460,7 @@
   if
    local.get $2
    local.get $5
-   local.get $3
+   local.get $4
    i32.const 2
    i32.and
    i32.or
@@ -1467,19 +1470,19 @@
    i32.add
    local.get $5
    i32.add
-   local.tee $3
+   local.tee $4
    local.get $6
    i32.const 4
    i32.sub
    i32.const 1
    i32.or
    i32.store $0
-   local.get $4
    local.get $3
+   local.get $4
    call $~lib/rt/tlsf/insertBlock
   else
    local.get $2
-   local.get $3
+   local.get $4
    i32.const -2
    i32.and
    i32.store $0

--- a/tests/compiler/std/string-encoding.release.wat
+++ b/tests/compiler/std/string-encoding.release.wat
@@ -1343,7 +1343,7 @@
    local.tee $2
    local.get $5
    i32.const 256
-   i32.gt_u
+   i32.ge_u
    if (result i32)
     local.get $5
     i32.const 1

--- a/tests/compiler/std/string-encoding.release.wat
+++ b/tests/compiler/std/string-encoding.release.wat
@@ -661,7 +661,7 @@
   if
    i32.const 0
    i32.const 1488
-   i32.const 378
+   i32.const 382
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -686,7 +686,7 @@
    if
     i32.const 0
     i32.const 1488
-    i32.const 385
+    i32.const 389
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -714,7 +714,7 @@
    if
     i32.const 0
     i32.const 1488
-    i32.const 398
+    i32.const 402
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1081,7 +1081,7 @@
       if
        i32.const 0
        i32.const 1488
-       i32.const 560
+       i32.const 562
        i32.const 3
        call $~lib/builtins/abort
        unreachable
@@ -1165,7 +1165,7 @@
   if
    i32.const 0
    i32.const 1488
-   i32.const 330
+   i32.const 334
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1217,7 +1217,7 @@
     if
      i32.const 0
      i32.const 1488
-     i32.const 343
+     i32.const 347
      i32.const 18
      call $~lib/builtins/abort
      unreachable
@@ -1306,7 +1306,7 @@
    call $~lib/rt/tlsf/initialize
   end
   global.get $~lib/rt/tlsf/ROOT
-  local.set $3
+  local.set $4
   local.get $0
   i32.const 16
   i32.add
@@ -1316,12 +1316,12 @@
   if
    i32.const 1152
    i32.const 1488
-   i32.const 459
+   i32.const 461
    i32.const 29
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $3
+  local.get $4
   i32.const 12
   local.get $2
   i32.const 19
@@ -1342,8 +1342,29 @@
    memory.size $0
    local.tee $2
    local.get $5
+   i32.const 256
+   i32.gt_u
+   if (result i32)
+    local.get $5
+    i32.const 1
+    i32.const 27
+    local.get $5
+    i32.clz
+    i32.sub
+    i32.shl
+    i32.add
+    i32.const 1
+    i32.sub
+    local.get $5
+    local.get $5
+    i32.const 536870910
+    i32.lt_u
+    select
+   else
+    local.get $5
+   end
    i32.const 4
-   local.get $3
+   local.get $4
    i32.load $0 offset=1568
    local.get $2
    i32.const 16
@@ -1353,39 +1374,22 @@
    i32.ne
    i32.shl
    i32.add
-   local.tee $4
-   i32.const 536870910
-   i32.lt_u
-   if (result i32)
-    local.get $4
-    i32.const 1
-    i32.const 27
-    local.get $4
-    i32.clz
-    i32.sub
-    i32.shl
-    i32.const 1
-    i32.sub
-    i32.add
-   else
-    local.get $4
-   end
    i32.const 65535
    i32.add
    i32.const -65536
    i32.and
    i32.const 16
    i32.shr_u
-   local.tee $4
+   local.tee $3
    local.get $2
-   local.get $4
+   local.get $3
    i32.gt_s
    select
    memory.grow $0
    i32.const 0
    i32.lt_s
    if
-    local.get $4
+    local.get $3
     memory.grow $0
     i32.const 0
     i32.lt_s
@@ -1393,7 +1397,7 @@
      unreachable
     end
    end
-   local.get $3
+   local.get $4
    local.get $2
    i32.const 16
    i32.shl
@@ -1402,7 +1406,7 @@
    i64.const 16
    i64.shl
    call $~lib/rt/tlsf/addMemory
-   local.get $3
+   local.get $4
    local.get $5
    call $~lib/rt/tlsf/searchBlock
    local.tee $2
@@ -1410,7 +1414,7 @@
    if
     i32.const 0
     i32.const 1488
-    i32.const 497
+    i32.const 499
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1425,17 +1429,17 @@
   if
    i32.const 0
    i32.const 1488
-   i32.const 499
+   i32.const 501
    i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $3
+  local.get $4
   local.get $2
   call $~lib/rt/tlsf/removeBlock
   local.get $2
   i32.load $0
-  local.set $4
+  local.set $3
   local.get $5
   i32.const 4
   i32.add
@@ -1444,12 +1448,12 @@
   if
    i32.const 0
    i32.const 1488
-   i32.const 357
+   i32.const 361
    i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $4
+  local.get $3
   i32.const -4
   i32.and
   local.get $5
@@ -1460,7 +1464,7 @@
   if
    local.get $2
    local.get $5
-   local.get $4
+   local.get $3
    i32.const 2
    i32.and
    i32.or
@@ -1470,19 +1474,19 @@
    i32.add
    local.get $5
    i32.add
-   local.tee $4
+   local.tee $3
    local.get $6
    i32.const 4
    i32.sub
    i32.const 1
    i32.or
    i32.store $0
-   local.get $3
    local.get $4
+   local.get $3
    call $~lib/rt/tlsf/insertBlock
   else
    local.get $2
-   local.get $4
+   local.get $3
    i32.const -2
    i32.and
    i32.store $0

--- a/tests/compiler/std/string.debug.wat
+++ b/tests/compiler/std/string.debug.wat
@@ -1657,7 +1657,7 @@
   if
    i32.const 0
    i32.const 624
-   i32.const 378
+   i32.const 382
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1703,7 +1703,7 @@
    if
     i32.const 0
     i32.const 624
-    i32.const 385
+    i32.const 389
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1736,7 +1736,7 @@
    if
     i32.const 0
     i32.const 624
-    i32.const 398
+    i32.const 402
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1980,7 +1980,7 @@
   if
    i32.const 0
    i32.const 624
-   i32.const 560
+   i32.const 562
    i32.const 3
    call $~lib/builtins/abort
    unreachable
@@ -2309,13 +2309,33 @@
   if
    i32.const 352
    i32.const 624
-   i32.const 459
+   i32.const 461
    i32.const 29
    call $~lib/builtins/abort
    unreachable
   end
   local.get $size
   call $~lib/rt/tlsf/computeSize
+  return
+ )
+ (func $~lib/rt/tlsf/roundSize (param $size i32) (result i32)
+  local.get $size
+  i32.const 536870910
+  i32.lt_u
+  if (result i32)
+   local.get $size
+   i32.const 1
+   i32.const 27
+   local.get $size
+   i32.clz
+   i32.sub
+   i32.shl
+   i32.add
+   i32.const 1
+   i32.sub
+  else
+   local.get $size
+  end
   return
  )
  (func $~lib/rt/tlsf/searchBlock (param $root i32) (param $size i32) (result i32)
@@ -2347,24 +2367,13 @@
    local.set $sl
   else
    local.get $size
-   i32.const 536870910
-   i32.lt_u
-   if (result i32)
-    local.get $size
-    i32.const 1
-    i32.const 27
-    local.get $size
-    i32.clz
-    i32.sub
-    i32.shl
-    i32.add
-    i32.const 1
-    i32.sub
-   else
-    local.get $size
-   end
+   call $~lib/rt/tlsf/roundSize
    local.set $requestSize
-   i32.const 31
+   i32.const 4
+   i32.const 8
+   i32.mul
+   i32.const 1
+   i32.sub
    local.get $requestSize
    i32.clz
    i32.sub
@@ -2402,7 +2411,7 @@
   if
    i32.const 0
    i32.const 624
-   i32.const 330
+   i32.const 334
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -2473,7 +2482,7 @@
     if
      i32.const 0
      i32.const 624
-     i32.const 343
+     i32.const 347
      i32.const 18
      call $~lib/builtins/abort
      unreachable
@@ -2536,6 +2545,14 @@
   (local $pagesAfter i32)
   i32.const 0
   drop
+  local.get $size
+  i32.const 256
+  i32.gt_u
+  if
+   local.get $size
+   call $~lib/rt/tlsf/roundSize
+   local.set $size
+  end
   memory.size $0
   local.set $pagesBefore
   local.get $size
@@ -2556,22 +2573,6 @@
   i32.shl
   i32.add
   local.set $size
-  local.get $size
-  i32.const 536870910
-  i32.lt_u
-  if
-   local.get $size
-   i32.const 1
-   i32.const 27
-   local.get $size
-   i32.clz
-   i32.sub
-   i32.shl
-   i32.const 1
-   i32.sub
-   i32.add
-   local.set $size
-  end
   local.get $size
   i32.const 65535
   i32.add
@@ -2638,7 +2639,7 @@
   if
    i32.const 0
    i32.const 624
-   i32.const 357
+   i32.const 361
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -2753,7 +2754,7 @@
    if
     i32.const 0
     i32.const 624
-    i32.const 497
+    i32.const 499
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -2773,7 +2774,7 @@
   if
    i32.const 0
    i32.const 624
-   i32.const 499
+   i32.const 501
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/std/string.debug.wat
+++ b/tests/compiler/std/string.debug.wat
@@ -2536,22 +2536,6 @@
   (local $pagesAfter i32)
   i32.const 0
   drop
-  local.get $size
-  i32.const 536870910
-  i32.lt_u
-  if
-   local.get $size
-   i32.const 1
-   i32.const 27
-   local.get $size
-   i32.clz
-   i32.sub
-   i32.shl
-   i32.const 1
-   i32.sub
-   i32.add
-   local.set $size
-  end
   memory.size $0
   local.set $pagesBefore
   local.get $size
@@ -2572,6 +2556,22 @@
   i32.shl
   i32.add
   local.set $size
+  local.get $size
+  i32.const 536870910
+  i32.lt_u
+  if
+   local.get $size
+   i32.const 1
+   i32.const 27
+   local.get $size
+   i32.clz
+   i32.sub
+   i32.shl
+   i32.const 1
+   i32.sub
+   i32.add
+   local.set $size
+  end
   local.get $size
   i32.const 65535
   i32.add

--- a/tests/compiler/std/string.debug.wat
+++ b/tests/compiler/std/string.debug.wat
@@ -2547,7 +2547,7 @@
   drop
   local.get $size
   i32.const 256
-  i32.gt_u
+  i32.ge_u
   if
    local.get $size
    call $~lib/rt/tlsf/roundSize

--- a/tests/compiler/std/string.release.wat
+++ b/tests/compiler/std/string.release.wat
@@ -1653,7 +1653,7 @@
   if
    i32.const 0
    i32.const 1648
-   i32.const 378
+   i32.const 382
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1678,7 +1678,7 @@
    if
     i32.const 0
     i32.const 1648
-    i32.const 385
+    i32.const 389
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1706,7 +1706,7 @@
    if
     i32.const 0
     i32.const 1648
-    i32.const 398
+    i32.const 402
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -2073,7 +2073,7 @@
       if
        i32.const 0
        i32.const 1648
-       i32.const 560
+       i32.const 562
        i32.const 3
        call $~lib/builtins/abort
        unreachable
@@ -2157,7 +2157,7 @@
   if
    i32.const 0
    i32.const 1648
-   i32.const 330
+   i32.const 334
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -2209,7 +2209,7 @@
     if
      i32.const 0
      i32.const 1648
-     i32.const 343
+     i32.const 347
      i32.const 18
      call $~lib/builtins/abort
      unreachable
@@ -2298,7 +2298,7 @@
    call $~lib/rt/tlsf/initialize
   end
   global.get $~lib/rt/tlsf/ROOT
-  local.set $3
+  local.set $4
   local.get $0
   i32.const 16
   i32.add
@@ -2308,12 +2308,12 @@
   if
    i32.const 1376
    i32.const 1648
-   i32.const 459
+   i32.const 461
    i32.const 29
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $3
+  local.get $4
   i32.const 12
   local.get $2
   i32.const 19
@@ -2334,8 +2334,29 @@
    memory.size $0
    local.tee $2
    local.get $5
+   i32.const 256
+   i32.gt_u
+   if (result i32)
+    local.get $5
+    i32.const 1
+    i32.const 27
+    local.get $5
+    i32.clz
+    i32.sub
+    i32.shl
+    i32.add
+    i32.const 1
+    i32.sub
+    local.get $5
+    local.get $5
+    i32.const 536870910
+    i32.lt_u
+    select
+   else
+    local.get $5
+   end
    i32.const 4
-   local.get $3
+   local.get $4
    i32.load $0 offset=1568
    local.get $2
    i32.const 16
@@ -2345,39 +2366,22 @@
    i32.ne
    i32.shl
    i32.add
-   local.tee $4
-   i32.const 536870910
-   i32.lt_u
-   if (result i32)
-    local.get $4
-    i32.const 1
-    i32.const 27
-    local.get $4
-    i32.clz
-    i32.sub
-    i32.shl
-    i32.const 1
-    i32.sub
-    i32.add
-   else
-    local.get $4
-   end
    i32.const 65535
    i32.add
    i32.const -65536
    i32.and
    i32.const 16
    i32.shr_u
-   local.tee $4
+   local.tee $3
    local.get $2
-   local.get $4
+   local.get $3
    i32.gt_s
    select
    memory.grow $0
    i32.const 0
    i32.lt_s
    if
-    local.get $4
+    local.get $3
     memory.grow $0
     i32.const 0
     i32.lt_s
@@ -2385,7 +2389,7 @@
      unreachable
     end
    end
-   local.get $3
+   local.get $4
    local.get $2
    i32.const 16
    i32.shl
@@ -2394,7 +2398,7 @@
    i64.const 16
    i64.shl
    call $~lib/rt/tlsf/addMemory
-   local.get $3
+   local.get $4
    local.get $5
    call $~lib/rt/tlsf/searchBlock
    local.tee $2
@@ -2402,7 +2406,7 @@
    if
     i32.const 0
     i32.const 1648
-    i32.const 497
+    i32.const 499
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -2417,17 +2421,17 @@
   if
    i32.const 0
    i32.const 1648
-   i32.const 499
+   i32.const 501
    i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $3
+  local.get $4
   local.get $2
   call $~lib/rt/tlsf/removeBlock
   local.get $2
   i32.load $0
-  local.set $4
+  local.set $3
   local.get $5
   i32.const 4
   i32.add
@@ -2436,12 +2440,12 @@
   if
    i32.const 0
    i32.const 1648
-   i32.const 357
+   i32.const 361
    i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $4
+  local.get $3
   i32.const -4
   i32.and
   local.get $5
@@ -2452,7 +2456,7 @@
   if
    local.get $2
    local.get $5
-   local.get $4
+   local.get $3
    i32.const 2
    i32.and
    i32.or
@@ -2462,19 +2466,19 @@
    i32.add
    local.get $5
    i32.add
-   local.tee $4
+   local.tee $3
    local.get $6
    i32.const 4
    i32.sub
    i32.const 1
    i32.or
    i32.store $0
-   local.get $3
    local.get $4
+   local.get $3
    call $~lib/rt/tlsf/insertBlock
   else
    local.get $2
-   local.get $4
+   local.get $3
    i32.const -2
    i32.and
    i32.store $0

--- a/tests/compiler/std/string.release.wat
+++ b/tests/compiler/std/string.release.wat
@@ -2335,7 +2335,7 @@
    local.tee $2
    local.get $5
    i32.const 256
-   i32.gt_u
+   i32.ge_u
    if (result i32)
     local.get $5
     i32.const 1

--- a/tests/compiler/std/string.release.wat
+++ b/tests/compiler/std/string.release.wat
@@ -2298,7 +2298,7 @@
    call $~lib/rt/tlsf/initialize
   end
   global.get $~lib/rt/tlsf/ROOT
-  local.set $4
+  local.set $3
   local.get $0
   i32.const 16
   i32.add
@@ -2313,7 +2313,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $4
+  local.get $3
   i32.const 12
   local.get $2
   i32.const 19
@@ -2333,8 +2333,9 @@
   if
    memory.size $0
    local.tee $2
+   local.get $5
    i32.const 4
-   local.get $4
+   local.get $3
    i32.load $0 offset=1568
    local.get $2
    i32.const 16
@@ -2343,38 +2344,40 @@
    i32.sub
    i32.ne
    i32.shl
-   local.get $5
-   i32.const 1
-   i32.const 27
-   local.get $5
-   i32.clz
-   i32.sub
-   i32.shl
-   i32.const 1
-   i32.sub
    i32.add
-   local.get $5
-   local.get $5
+   local.tee $4
    i32.const 536870910
    i32.lt_u
-   select
-   i32.add
+   if (result i32)
+    local.get $4
+    i32.const 1
+    i32.const 27
+    local.get $4
+    i32.clz
+    i32.sub
+    i32.shl
+    i32.const 1
+    i32.sub
+    i32.add
+   else
+    local.get $4
+   end
    i32.const 65535
    i32.add
    i32.const -65536
    i32.and
    i32.const 16
    i32.shr_u
-   local.tee $3
+   local.tee $4
    local.get $2
-   local.get $3
+   local.get $4
    i32.gt_s
    select
    memory.grow $0
    i32.const 0
    i32.lt_s
    if
-    local.get $3
+    local.get $4
     memory.grow $0
     i32.const 0
     i32.lt_s
@@ -2382,7 +2385,7 @@
      unreachable
     end
    end
-   local.get $4
+   local.get $3
    local.get $2
    i32.const 16
    i32.shl
@@ -2391,7 +2394,7 @@
    i64.const 16
    i64.shl
    call $~lib/rt/tlsf/addMemory
-   local.get $4
+   local.get $3
    local.get $5
    call $~lib/rt/tlsf/searchBlock
    local.tee $2
@@ -2419,12 +2422,12 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $4
+  local.get $3
   local.get $2
   call $~lib/rt/tlsf/removeBlock
   local.get $2
   i32.load $0
-  local.set $3
+  local.set $4
   local.get $5
   i32.const 4
   i32.add
@@ -2438,7 +2441,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $3
+  local.get $4
   i32.const -4
   i32.and
   local.get $5
@@ -2449,7 +2452,7 @@
   if
    local.get $2
    local.get $5
-   local.get $3
+   local.get $4
    i32.const 2
    i32.and
    i32.or
@@ -2459,19 +2462,19 @@
    i32.add
    local.get $5
    i32.add
-   local.tee $3
+   local.tee $4
    local.get $6
    i32.const 4
    i32.sub
    i32.const 1
    i32.or
    i32.store $0
-   local.get $4
    local.get $3
+   local.get $4
    call $~lib/rt/tlsf/insertBlock
   else
    local.get $2
-   local.get $3
+   local.get $4
    i32.const -2
    i32.and
    i32.store $0

--- a/tests/compiler/std/symbol.debug.wat
+++ b/tests/compiler/std/symbol.debug.wat
@@ -1095,7 +1095,7 @@
   if
    i32.const 0
    i32.const 448
-   i32.const 378
+   i32.const 382
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1141,7 +1141,7 @@
    if
     i32.const 0
     i32.const 448
-    i32.const 385
+    i32.const 389
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1174,7 +1174,7 @@
    if
     i32.const 0
     i32.const 448
-    i32.const 398
+    i32.const 402
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1418,7 +1418,7 @@
   if
    i32.const 0
    i32.const 448
-   i32.const 560
+   i32.const 562
    i32.const 3
    call $~lib/builtins/abort
    unreachable
@@ -1747,13 +1747,33 @@
   if
    i32.const 112
    i32.const 448
-   i32.const 459
+   i32.const 461
    i32.const 29
    call $~lib/builtins/abort
    unreachable
   end
   local.get $size
   call $~lib/rt/tlsf/computeSize
+  return
+ )
+ (func $~lib/rt/tlsf/roundSize (param $size i32) (result i32)
+  local.get $size
+  i32.const 536870910
+  i32.lt_u
+  if (result i32)
+   local.get $size
+   i32.const 1
+   i32.const 27
+   local.get $size
+   i32.clz
+   i32.sub
+   i32.shl
+   i32.add
+   i32.const 1
+   i32.sub
+  else
+   local.get $size
+  end
   return
  )
  (func $~lib/rt/tlsf/searchBlock (param $root i32) (param $size i32) (result i32)
@@ -1785,24 +1805,13 @@
    local.set $sl
   else
    local.get $size
-   i32.const 536870910
-   i32.lt_u
-   if (result i32)
-    local.get $size
-    i32.const 1
-    i32.const 27
-    local.get $size
-    i32.clz
-    i32.sub
-    i32.shl
-    i32.add
-    i32.const 1
-    i32.sub
-   else
-    local.get $size
-   end
+   call $~lib/rt/tlsf/roundSize
    local.set $requestSize
-   i32.const 31
+   i32.const 4
+   i32.const 8
+   i32.mul
+   i32.const 1
+   i32.sub
    local.get $requestSize
    i32.clz
    i32.sub
@@ -1840,7 +1849,7 @@
   if
    i32.const 0
    i32.const 448
-   i32.const 330
+   i32.const 334
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1911,7 +1920,7 @@
     if
      i32.const 0
      i32.const 448
-     i32.const 343
+     i32.const 347
      i32.const 18
      call $~lib/builtins/abort
      unreachable
@@ -1974,6 +1983,14 @@
   (local $pagesAfter i32)
   i32.const 0
   drop
+  local.get $size
+  i32.const 256
+  i32.gt_u
+  if
+   local.get $size
+   call $~lib/rt/tlsf/roundSize
+   local.set $size
+  end
   memory.size $0
   local.set $pagesBefore
   local.get $size
@@ -1994,22 +2011,6 @@
   i32.shl
   i32.add
   local.set $size
-  local.get $size
-  i32.const 536870910
-  i32.lt_u
-  if
-   local.get $size
-   i32.const 1
-   i32.const 27
-   local.get $size
-   i32.clz
-   i32.sub
-   i32.shl
-   i32.const 1
-   i32.sub
-   i32.add
-   local.set $size
-  end
   local.get $size
   i32.const 65535
   i32.add
@@ -2076,7 +2077,7 @@
   if
    i32.const 0
    i32.const 448
-   i32.const 357
+   i32.const 361
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -2191,7 +2192,7 @@
    if
     i32.const 0
     i32.const 448
-    i32.const 497
+    i32.const 499
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -2211,7 +2212,7 @@
   if
    i32.const 0
    i32.const 448
-   i32.const 499
+   i32.const 501
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/std/symbol.debug.wat
+++ b/tests/compiler/std/symbol.debug.wat
@@ -1974,22 +1974,6 @@
   (local $pagesAfter i32)
   i32.const 0
   drop
-  local.get $size
-  i32.const 536870910
-  i32.lt_u
-  if
-   local.get $size
-   i32.const 1
-   i32.const 27
-   local.get $size
-   i32.clz
-   i32.sub
-   i32.shl
-   i32.const 1
-   i32.sub
-   i32.add
-   local.set $size
-  end
   memory.size $0
   local.set $pagesBefore
   local.get $size
@@ -2010,6 +1994,22 @@
   i32.shl
   i32.add
   local.set $size
+  local.get $size
+  i32.const 536870910
+  i32.lt_u
+  if
+   local.get $size
+   i32.const 1
+   i32.const 27
+   local.get $size
+   i32.clz
+   i32.sub
+   i32.shl
+   i32.const 1
+   i32.sub
+   i32.add
+   local.set $size
+  end
   local.get $size
   i32.const 65535
   i32.add

--- a/tests/compiler/std/symbol.debug.wat
+++ b/tests/compiler/std/symbol.debug.wat
@@ -1985,7 +1985,7 @@
   drop
   local.get $size
   i32.const 256
-  i32.gt_u
+  i32.ge_u
   if
    local.get $size
    call $~lib/rt/tlsf/roundSize

--- a/tests/compiler/std/symbol.release.wat
+++ b/tests/compiler/std/symbol.release.wat
@@ -1369,7 +1369,7 @@
    call $~lib/rt/tlsf/initialize
   end
   global.get $~lib/rt/tlsf/ROOT
-  local.set $4
+  local.set $3
   local.get $0
   i32.const 16
   i32.add
@@ -1384,7 +1384,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $4
+  local.get $3
   i32.const 12
   local.get $2
   i32.const 19
@@ -1404,8 +1404,9 @@
   if
    memory.size $0
    local.tee $2
+   local.get $5
    i32.const 4
-   local.get $4
+   local.get $3
    i32.load $0 offset=1568
    local.get $2
    i32.const 16
@@ -1414,38 +1415,40 @@
    i32.sub
    i32.ne
    i32.shl
-   local.get $5
-   i32.const 1
-   i32.const 27
-   local.get $5
-   i32.clz
-   i32.sub
-   i32.shl
-   i32.const 1
-   i32.sub
    i32.add
-   local.get $5
-   local.get $5
+   local.tee $4
    i32.const 536870910
    i32.lt_u
-   select
-   i32.add
+   if (result i32)
+    local.get $4
+    i32.const 1
+    i32.const 27
+    local.get $4
+    i32.clz
+    i32.sub
+    i32.shl
+    i32.const 1
+    i32.sub
+    i32.add
+   else
+    local.get $4
+   end
    i32.const 65535
    i32.add
    i32.const -65536
    i32.and
    i32.const 16
    i32.shr_u
-   local.tee $3
+   local.tee $4
    local.get $2
-   local.get $3
+   local.get $4
    i32.gt_s
    select
    memory.grow $0
    i32.const 0
    i32.lt_s
    if
-    local.get $3
+    local.get $4
     memory.grow $0
     i32.const 0
     i32.lt_s
@@ -1453,7 +1456,7 @@
      unreachable
     end
    end
-   local.get $4
+   local.get $3
    local.get $2
    i32.const 16
    i32.shl
@@ -1462,7 +1465,7 @@
    i64.const 16
    i64.shl
    call $~lib/rt/tlsf/addMemory
-   local.get $4
+   local.get $3
    local.get $5
    call $~lib/rt/tlsf/searchBlock
    local.tee $2
@@ -1490,12 +1493,12 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $4
+  local.get $3
   local.get $2
   call $~lib/rt/tlsf/removeBlock
   local.get $2
   i32.load $0
-  local.set $3
+  local.set $4
   local.get $5
   i32.const 4
   i32.add
@@ -1509,7 +1512,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $3
+  local.get $4
   i32.const -4
   i32.and
   local.get $5
@@ -1520,7 +1523,7 @@
   if
    local.get $2
    local.get $5
-   local.get $3
+   local.get $4
    i32.const 2
    i32.and
    i32.or
@@ -1530,19 +1533,19 @@
    i32.add
    local.get $5
    i32.add
-   local.tee $3
+   local.tee $4
    local.get $6
    i32.const 4
    i32.sub
    i32.const 1
    i32.or
    i32.store $0
-   local.get $4
    local.get $3
+   local.get $4
    call $~lib/rt/tlsf/insertBlock
   else
    local.get $2
-   local.get $3
+   local.get $4
    i32.const -2
    i32.and
    i32.store $0

--- a/tests/compiler/std/symbol.release.wat
+++ b/tests/compiler/std/symbol.release.wat
@@ -1406,7 +1406,7 @@
    local.tee $2
    local.get $5
    i32.const 256
-   i32.gt_u
+   i32.ge_u
    if (result i32)
     local.get $5
     i32.const 1

--- a/tests/compiler/std/symbol.release.wat
+++ b/tests/compiler/std/symbol.release.wat
@@ -724,7 +724,7 @@
   if
    i32.const 0
    i32.const 1472
-   i32.const 378
+   i32.const 382
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -749,7 +749,7 @@
    if
     i32.const 0
     i32.const 1472
-    i32.const 385
+    i32.const 389
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -777,7 +777,7 @@
    if
     i32.const 0
     i32.const 1472
-    i32.const 398
+    i32.const 402
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1144,7 +1144,7 @@
       if
        i32.const 0
        i32.const 1472
-       i32.const 560
+       i32.const 562
        i32.const 3
        call $~lib/builtins/abort
        unreachable
@@ -1228,7 +1228,7 @@
   if
    i32.const 0
    i32.const 1472
-   i32.const 330
+   i32.const 334
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1280,7 +1280,7 @@
     if
      i32.const 0
      i32.const 1472
-     i32.const 343
+     i32.const 347
      i32.const 18
      call $~lib/builtins/abort
      unreachable
@@ -1369,7 +1369,7 @@
    call $~lib/rt/tlsf/initialize
   end
   global.get $~lib/rt/tlsf/ROOT
-  local.set $3
+  local.set $4
   local.get $0
   i32.const 16
   i32.add
@@ -1379,12 +1379,12 @@
   if
    i32.const 1136
    i32.const 1472
-   i32.const 459
+   i32.const 461
    i32.const 29
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $3
+  local.get $4
   i32.const 12
   local.get $2
   i32.const 19
@@ -1405,8 +1405,29 @@
    memory.size $0
    local.tee $2
    local.get $5
+   i32.const 256
+   i32.gt_u
+   if (result i32)
+    local.get $5
+    i32.const 1
+    i32.const 27
+    local.get $5
+    i32.clz
+    i32.sub
+    i32.shl
+    i32.add
+    i32.const 1
+    i32.sub
+    local.get $5
+    local.get $5
+    i32.const 536870910
+    i32.lt_u
+    select
+   else
+    local.get $5
+   end
    i32.const 4
-   local.get $3
+   local.get $4
    i32.load $0 offset=1568
    local.get $2
    i32.const 16
@@ -1416,39 +1437,22 @@
    i32.ne
    i32.shl
    i32.add
-   local.tee $4
-   i32.const 536870910
-   i32.lt_u
-   if (result i32)
-    local.get $4
-    i32.const 1
-    i32.const 27
-    local.get $4
-    i32.clz
-    i32.sub
-    i32.shl
-    i32.const 1
-    i32.sub
-    i32.add
-   else
-    local.get $4
-   end
    i32.const 65535
    i32.add
    i32.const -65536
    i32.and
    i32.const 16
    i32.shr_u
-   local.tee $4
+   local.tee $3
    local.get $2
-   local.get $4
+   local.get $3
    i32.gt_s
    select
    memory.grow $0
    i32.const 0
    i32.lt_s
    if
-    local.get $4
+    local.get $3
     memory.grow $0
     i32.const 0
     i32.lt_s
@@ -1456,7 +1460,7 @@
      unreachable
     end
    end
-   local.get $3
+   local.get $4
    local.get $2
    i32.const 16
    i32.shl
@@ -1465,7 +1469,7 @@
    i64.const 16
    i64.shl
    call $~lib/rt/tlsf/addMemory
-   local.get $3
+   local.get $4
    local.get $5
    call $~lib/rt/tlsf/searchBlock
    local.tee $2
@@ -1473,7 +1477,7 @@
    if
     i32.const 0
     i32.const 1472
-    i32.const 497
+    i32.const 499
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1488,17 +1492,17 @@
   if
    i32.const 0
    i32.const 1472
-   i32.const 499
+   i32.const 501
    i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $3
+  local.get $4
   local.get $2
   call $~lib/rt/tlsf/removeBlock
   local.get $2
   i32.load $0
-  local.set $4
+  local.set $3
   local.get $5
   i32.const 4
   i32.add
@@ -1507,12 +1511,12 @@
   if
    i32.const 0
    i32.const 1472
-   i32.const 357
+   i32.const 361
    i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $4
+  local.get $3
   i32.const -4
   i32.and
   local.get $5
@@ -1523,7 +1527,7 @@
   if
    local.get $2
    local.get $5
-   local.get $4
+   local.get $3
    i32.const 2
    i32.and
    i32.or
@@ -1533,19 +1537,19 @@
    i32.add
    local.get $5
    i32.add
-   local.tee $4
+   local.tee $3
    local.get $6
    i32.const 4
    i32.sub
    i32.const 1
    i32.or
    i32.store $0
-   local.get $3
    local.get $4
+   local.get $3
    call $~lib/rt/tlsf/insertBlock
   else
    local.get $2
-   local.get $4
+   local.get $3
    i32.const -2
    i32.and
    i32.store $0

--- a/tests/compiler/std/typedarray.debug.wat
+++ b/tests/compiler/std/typedarray.debug.wat
@@ -2294,7 +2294,7 @@
   drop
   local.get $size
   i32.const 256
-  i32.gt_u
+  i32.ge_u
   if
    local.get $size
    call $~lib/rt/tlsf/roundSize

--- a/tests/compiler/std/typedarray.debug.wat
+++ b/tests/compiler/std/typedarray.debug.wat
@@ -1404,7 +1404,7 @@
   if
    i32.const 0
    i32.const 480
-   i32.const 378
+   i32.const 382
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1450,7 +1450,7 @@
    if
     i32.const 0
     i32.const 480
-    i32.const 385
+    i32.const 389
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1483,7 +1483,7 @@
    if
     i32.const 0
     i32.const 480
-    i32.const 398
+    i32.const 402
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1727,7 +1727,7 @@
   if
    i32.const 0
    i32.const 480
-   i32.const 560
+   i32.const 562
    i32.const 3
    call $~lib/builtins/abort
    unreachable
@@ -2056,13 +2056,33 @@
   if
    i32.const 144
    i32.const 480
-   i32.const 459
+   i32.const 461
    i32.const 29
    call $~lib/builtins/abort
    unreachable
   end
   local.get $size
   call $~lib/rt/tlsf/computeSize
+  return
+ )
+ (func $~lib/rt/tlsf/roundSize (param $size i32) (result i32)
+  local.get $size
+  i32.const 536870910
+  i32.lt_u
+  if (result i32)
+   local.get $size
+   i32.const 1
+   i32.const 27
+   local.get $size
+   i32.clz
+   i32.sub
+   i32.shl
+   i32.add
+   i32.const 1
+   i32.sub
+  else
+   local.get $size
+  end
   return
  )
  (func $~lib/rt/tlsf/searchBlock (param $root i32) (param $size i32) (result i32)
@@ -2094,24 +2114,13 @@
    local.set $sl
   else
    local.get $size
-   i32.const 536870910
-   i32.lt_u
-   if (result i32)
-    local.get $size
-    i32.const 1
-    i32.const 27
-    local.get $size
-    i32.clz
-    i32.sub
-    i32.shl
-    i32.add
-    i32.const 1
-    i32.sub
-   else
-    local.get $size
-   end
+   call $~lib/rt/tlsf/roundSize
    local.set $requestSize
-   i32.const 31
+   i32.const 4
+   i32.const 8
+   i32.mul
+   i32.const 1
+   i32.sub
    local.get $requestSize
    i32.clz
    i32.sub
@@ -2149,7 +2158,7 @@
   if
    i32.const 0
    i32.const 480
-   i32.const 330
+   i32.const 334
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -2220,7 +2229,7 @@
     if
      i32.const 0
      i32.const 480
-     i32.const 343
+     i32.const 347
      i32.const 18
      call $~lib/builtins/abort
      unreachable
@@ -2283,6 +2292,14 @@
   (local $pagesAfter i32)
   i32.const 0
   drop
+  local.get $size
+  i32.const 256
+  i32.gt_u
+  if
+   local.get $size
+   call $~lib/rt/tlsf/roundSize
+   local.set $size
+  end
   memory.size $0
   local.set $pagesBefore
   local.get $size
@@ -2303,22 +2320,6 @@
   i32.shl
   i32.add
   local.set $size
-  local.get $size
-  i32.const 536870910
-  i32.lt_u
-  if
-   local.get $size
-   i32.const 1
-   i32.const 27
-   local.get $size
-   i32.clz
-   i32.sub
-   i32.shl
-   i32.const 1
-   i32.sub
-   i32.add
-   local.set $size
-  end
   local.get $size
   i32.const 65535
   i32.add
@@ -2385,7 +2386,7 @@
   if
    i32.const 0
    i32.const 480
-   i32.const 357
+   i32.const 361
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -2500,7 +2501,7 @@
    if
     i32.const 0
     i32.const 480
-    i32.const 497
+    i32.const 499
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -2520,7 +2521,7 @@
   if
    i32.const 0
    i32.const 480
-   i32.const 499
+   i32.const 501
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/std/typedarray.debug.wat
+++ b/tests/compiler/std/typedarray.debug.wat
@@ -2283,22 +2283,6 @@
   (local $pagesAfter i32)
   i32.const 0
   drop
-  local.get $size
-  i32.const 536870910
-  i32.lt_u
-  if
-   local.get $size
-   i32.const 1
-   i32.const 27
-   local.get $size
-   i32.clz
-   i32.sub
-   i32.shl
-   i32.const 1
-   i32.sub
-   i32.add
-   local.set $size
-  end
   memory.size $0
   local.set $pagesBefore
   local.get $size
@@ -2319,6 +2303,22 @@
   i32.shl
   i32.add
   local.set $size
+  local.get $size
+  i32.const 536870910
+  i32.lt_u
+  if
+   local.get $size
+   i32.const 1
+   i32.const 27
+   local.get $size
+   i32.clz
+   i32.sub
+   i32.shl
+   i32.const 1
+   i32.sub
+   i32.add
+   local.set $size
+  end
   local.get $size
   i32.const 65535
   i32.add

--- a/tests/compiler/std/typedarray.release.wat
+++ b/tests/compiler/std/typedarray.release.wat
@@ -1903,6 +1903,7 @@
   if
    memory.size $0
    local.tee $1
+   local.get $3
    i32.const 4
    local.get $0
    i32.load $0 offset=1568
@@ -1913,22 +1914,24 @@
    i32.sub
    i32.ne
    i32.shl
-   local.get $3
-   i32.const 1
-   i32.const 27
-   local.get $3
-   i32.clz
-   i32.sub
-   i32.shl
-   i32.const 1
-   i32.sub
    i32.add
-   local.get $3
-   local.get $3
+   local.tee $2
    i32.const 536870910
    i32.lt_u
-   select
-   i32.add
+   if (result i32)
+    local.get $2
+    i32.const 1
+    i32.const 27
+    local.get $2
+    i32.clz
+    i32.sub
+    i32.shl
+    i32.const 1
+    i32.sub
+    i32.add
+   else
+    local.get $2
+   end
    i32.const 65535
    i32.add
    i32.const -65536
@@ -1994,7 +1997,7 @@
   call $~lib/rt/tlsf/removeBlock
   local.get $1
   i32.load $0
-  local.set $4
+  local.set $2
   local.get $3
   i32.const 4
   i32.add
@@ -2008,18 +2011,18 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $4
+  local.get $2
   i32.const -4
   i32.and
   local.get $3
   i32.sub
-  local.tee $2
+  local.tee $4
   i32.const 16
   i32.ge_u
   if
    local.get $1
    local.get $3
-   local.get $4
+   local.get $2
    i32.const 2
    i32.and
    i32.or
@@ -2029,19 +2032,19 @@
    i32.add
    local.get $3
    i32.add
-   local.tee $3
-   local.get $2
+   local.tee $2
+   local.get $4
    i32.const 4
    i32.sub
    i32.const 1
    i32.or
    i32.store $0
    local.get $0
-   local.get $3
+   local.get $2
    call $~lib/rt/tlsf/insertBlock
   else
    local.get $1
-   local.get $4
+   local.get $2
    i32.const -2
    i32.and
    i32.store $0

--- a/tests/compiler/std/typedarray.release.wat
+++ b/tests/compiler/std/typedarray.release.wat
@@ -1285,7 +1285,7 @@
   if
    i32.const 0
    i32.const 1504
-   i32.const 378
+   i32.const 382
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1310,7 +1310,7 @@
    if
     i32.const 0
     i32.const 1504
-    i32.const 385
+    i32.const 389
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1338,7 +1338,7 @@
    if
     i32.const 0
     i32.const 1504
-    i32.const 398
+    i32.const 402
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1506,7 +1506,7 @@
   if
    i32.const 0
    i32.const 1504
-   i32.const 560
+   i32.const 562
    i32.const 3
    call $~lib/builtins/abort
    unreachable
@@ -1795,7 +1795,7 @@
   if
    i32.const 0
    i32.const 1504
-   i32.const 330
+   i32.const 334
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1847,7 +1847,7 @@
     if
      i32.const 0
      i32.const 1504
-     i32.const 343
+     i32.const 347
      i32.const 18
      call $~lib/builtins/abort
      unreachable
@@ -1878,7 +1878,7 @@
   if
    i32.const 1168
    i32.const 1504
-   i32.const 459
+   i32.const 461
    i32.const 29
    call $~lib/builtins/abort
    unreachable
@@ -1904,6 +1904,27 @@
    memory.size $0
    local.tee $1
    local.get $3
+   i32.const 256
+   i32.gt_u
+   if (result i32)
+    local.get $3
+    i32.const 1
+    i32.const 27
+    local.get $3
+    i32.clz
+    i32.sub
+    i32.shl
+    i32.add
+    i32.const 1
+    i32.sub
+    local.get $3
+    local.get $3
+    i32.const 536870910
+    i32.lt_u
+    select
+   else
+    local.get $3
+   end
    i32.const 4
    local.get $0
    i32.load $0 offset=1568
@@ -1915,23 +1936,6 @@
    i32.ne
    i32.shl
    i32.add
-   local.tee $2
-   i32.const 536870910
-   i32.lt_u
-   if (result i32)
-    local.get $2
-    i32.const 1
-    i32.const 27
-    local.get $2
-    i32.clz
-    i32.sub
-    i32.shl
-    i32.const 1
-    i32.sub
-    i32.add
-   else
-    local.get $2
-   end
    i32.const 65535
    i32.add
    i32.const -65536
@@ -1972,7 +1976,7 @@
    if
     i32.const 0
     i32.const 1504
-    i32.const 497
+    i32.const 499
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1987,7 +1991,7 @@
   if
    i32.const 0
    i32.const 1504
-   i32.const 499
+   i32.const 501
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1997,7 +2001,7 @@
   call $~lib/rt/tlsf/removeBlock
   local.get $1
   i32.load $0
-  local.set $2
+  local.set $4
   local.get $3
   i32.const 4
   i32.add
@@ -2006,23 +2010,23 @@
   if
    i32.const 0
    i32.const 1504
-   i32.const 357
+   i32.const 361
    i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $2
+  local.get $4
   i32.const -4
   i32.and
   local.get $3
   i32.sub
-  local.tee $4
+  local.tee $2
   i32.const 16
   i32.ge_u
   if
    local.get $1
    local.get $3
-   local.get $2
+   local.get $4
    i32.const 2
    i32.and
    i32.or
@@ -2032,19 +2036,19 @@
    i32.add
    local.get $3
    i32.add
-   local.tee $2
-   local.get $4
+   local.tee $3
+   local.get $2
    i32.const 4
    i32.sub
    i32.const 1
    i32.or
    i32.store $0
    local.get $0
-   local.get $2
+   local.get $3
    call $~lib/rt/tlsf/insertBlock
   else
    local.get $1
-   local.get $2
+   local.get $4
    i32.const -2
    i32.and
    i32.store $0

--- a/tests/compiler/std/typedarray.release.wat
+++ b/tests/compiler/std/typedarray.release.wat
@@ -1905,7 +1905,7 @@
    local.tee $1
    local.get $3
    i32.const 256
-   i32.gt_u
+   i32.ge_u
    if (result i32)
     local.get $3
     i32.const 1

--- a/tests/compiler/std/uri.debug.wat
+++ b/tests/compiler/std/uri.debug.wat
@@ -1109,7 +1109,7 @@
   if
    i32.const 0
    i32.const 496
-   i32.const 378
+   i32.const 382
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1155,7 +1155,7 @@
    if
     i32.const 0
     i32.const 496
-    i32.const 385
+    i32.const 389
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1188,7 +1188,7 @@
    if
     i32.const 0
     i32.const 496
-    i32.const 398
+    i32.const 402
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1432,7 +1432,7 @@
   if
    i32.const 0
    i32.const 496
-   i32.const 560
+   i32.const 562
    i32.const 3
    call $~lib/builtins/abort
    unreachable
@@ -1761,13 +1761,33 @@
   if
    i32.const 160
    i32.const 496
-   i32.const 459
+   i32.const 461
    i32.const 29
    call $~lib/builtins/abort
    unreachable
   end
   local.get $size
   call $~lib/rt/tlsf/computeSize
+  return
+ )
+ (func $~lib/rt/tlsf/roundSize (param $size i32) (result i32)
+  local.get $size
+  i32.const 536870910
+  i32.lt_u
+  if (result i32)
+   local.get $size
+   i32.const 1
+   i32.const 27
+   local.get $size
+   i32.clz
+   i32.sub
+   i32.shl
+   i32.add
+   i32.const 1
+   i32.sub
+  else
+   local.get $size
+  end
   return
  )
  (func $~lib/rt/tlsf/searchBlock (param $root i32) (param $size i32) (result i32)
@@ -1799,24 +1819,13 @@
    local.set $sl
   else
    local.get $size
-   i32.const 536870910
-   i32.lt_u
-   if (result i32)
-    local.get $size
-    i32.const 1
-    i32.const 27
-    local.get $size
-    i32.clz
-    i32.sub
-    i32.shl
-    i32.add
-    i32.const 1
-    i32.sub
-   else
-    local.get $size
-   end
+   call $~lib/rt/tlsf/roundSize
    local.set $requestSize
-   i32.const 31
+   i32.const 4
+   i32.const 8
+   i32.mul
+   i32.const 1
+   i32.sub
    local.get $requestSize
    i32.clz
    i32.sub
@@ -1854,7 +1863,7 @@
   if
    i32.const 0
    i32.const 496
-   i32.const 330
+   i32.const 334
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1925,7 +1934,7 @@
     if
      i32.const 0
      i32.const 496
-     i32.const 343
+     i32.const 347
      i32.const 18
      call $~lib/builtins/abort
      unreachable
@@ -1988,6 +1997,14 @@
   (local $pagesAfter i32)
   i32.const 0
   drop
+  local.get $size
+  i32.const 256
+  i32.gt_u
+  if
+   local.get $size
+   call $~lib/rt/tlsf/roundSize
+   local.set $size
+  end
   memory.size $0
   local.set $pagesBefore
   local.get $size
@@ -2008,22 +2025,6 @@
   i32.shl
   i32.add
   local.set $size
-  local.get $size
-  i32.const 536870910
-  i32.lt_u
-  if
-   local.get $size
-   i32.const 1
-   i32.const 27
-   local.get $size
-   i32.clz
-   i32.sub
-   i32.shl
-   i32.const 1
-   i32.sub
-   i32.add
-   local.set $size
-  end
   local.get $size
   i32.const 65535
   i32.add
@@ -2090,7 +2091,7 @@
   if
    i32.const 0
    i32.const 496
-   i32.const 357
+   i32.const 361
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -2205,7 +2206,7 @@
    if
     i32.const 0
     i32.const 496
-    i32.const 497
+    i32.const 499
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -2225,7 +2226,7 @@
   if
    i32.const 0
    i32.const 496
-   i32.const 499
+   i32.const 501
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/std/uri.debug.wat
+++ b/tests/compiler/std/uri.debug.wat
@@ -1988,22 +1988,6 @@
   (local $pagesAfter i32)
   i32.const 0
   drop
-  local.get $size
-  i32.const 536870910
-  i32.lt_u
-  if
-   local.get $size
-   i32.const 1
-   i32.const 27
-   local.get $size
-   i32.clz
-   i32.sub
-   i32.shl
-   i32.const 1
-   i32.sub
-   i32.add
-   local.set $size
-  end
   memory.size $0
   local.set $pagesBefore
   local.get $size
@@ -2024,6 +2008,22 @@
   i32.shl
   i32.add
   local.set $size
+  local.get $size
+  i32.const 536870910
+  i32.lt_u
+  if
+   local.get $size
+   i32.const 1
+   i32.const 27
+   local.get $size
+   i32.clz
+   i32.sub
+   i32.shl
+   i32.const 1
+   i32.sub
+   i32.add
+   local.set $size
+  end
   local.get $size
   i32.const 65535
   i32.add

--- a/tests/compiler/std/uri.debug.wat
+++ b/tests/compiler/std/uri.debug.wat
@@ -1999,7 +1999,7 @@
   drop
   local.get $size
   i32.const 256
-  i32.gt_u
+  i32.ge_u
   if
    local.get $size
    call $~lib/rt/tlsf/roundSize

--- a/tests/compiler/std/uri.release.wat
+++ b/tests/compiler/std/uri.release.wat
@@ -741,7 +741,7 @@
   if
    i32.const 0
    i32.const 1520
-   i32.const 378
+   i32.const 382
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -766,7 +766,7 @@
    if
     i32.const 0
     i32.const 1520
-    i32.const 385
+    i32.const 389
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -794,7 +794,7 @@
    if
     i32.const 0
     i32.const 1520
-    i32.const 398
+    i32.const 402
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1161,7 +1161,7 @@
       if
        i32.const 0
        i32.const 1520
-       i32.const 560
+       i32.const 562
        i32.const 3
        call $~lib/builtins/abort
        unreachable
@@ -1245,7 +1245,7 @@
   if
    i32.const 0
    i32.const 1520
-   i32.const 330
+   i32.const 334
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1297,7 +1297,7 @@
     if
      i32.const 0
      i32.const 1520
-     i32.const 343
+     i32.const 347
      i32.const 18
      call $~lib/builtins/abort
      unreachable
@@ -1386,7 +1386,7 @@
    call $~lib/rt/tlsf/initialize
   end
   global.get $~lib/rt/tlsf/ROOT
-  local.set $3
+  local.set $4
   local.get $0
   i32.const 16
   i32.add
@@ -1396,12 +1396,12 @@
   if
    i32.const 1184
    i32.const 1520
-   i32.const 459
+   i32.const 461
    i32.const 29
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $3
+  local.get $4
   i32.const 12
   local.get $2
   i32.const 19
@@ -1422,8 +1422,29 @@
    memory.size $0
    local.tee $2
    local.get $5
+   i32.const 256
+   i32.gt_u
+   if (result i32)
+    local.get $5
+    i32.const 1
+    i32.const 27
+    local.get $5
+    i32.clz
+    i32.sub
+    i32.shl
+    i32.add
+    i32.const 1
+    i32.sub
+    local.get $5
+    local.get $5
+    i32.const 536870910
+    i32.lt_u
+    select
+   else
+    local.get $5
+   end
    i32.const 4
-   local.get $3
+   local.get $4
    i32.load $0 offset=1568
    local.get $2
    i32.const 16
@@ -1433,39 +1454,22 @@
    i32.ne
    i32.shl
    i32.add
-   local.tee $4
-   i32.const 536870910
-   i32.lt_u
-   if (result i32)
-    local.get $4
-    i32.const 1
-    i32.const 27
-    local.get $4
-    i32.clz
-    i32.sub
-    i32.shl
-    i32.const 1
-    i32.sub
-    i32.add
-   else
-    local.get $4
-   end
    i32.const 65535
    i32.add
    i32.const -65536
    i32.and
    i32.const 16
    i32.shr_u
-   local.tee $4
+   local.tee $3
    local.get $2
-   local.get $4
+   local.get $3
    i32.gt_s
    select
    memory.grow $0
    i32.const 0
    i32.lt_s
    if
-    local.get $4
+    local.get $3
     memory.grow $0
     i32.const 0
     i32.lt_s
@@ -1473,7 +1477,7 @@
      unreachable
     end
    end
-   local.get $3
+   local.get $4
    local.get $2
    i32.const 16
    i32.shl
@@ -1482,7 +1486,7 @@
    i64.const 16
    i64.shl
    call $~lib/rt/tlsf/addMemory
-   local.get $3
+   local.get $4
    local.get $5
    call $~lib/rt/tlsf/searchBlock
    local.tee $2
@@ -1490,7 +1494,7 @@
    if
     i32.const 0
     i32.const 1520
-    i32.const 497
+    i32.const 499
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1505,17 +1509,17 @@
   if
    i32.const 0
    i32.const 1520
-   i32.const 499
+   i32.const 501
    i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $3
+  local.get $4
   local.get $2
   call $~lib/rt/tlsf/removeBlock
   local.get $2
   i32.load $0
-  local.set $4
+  local.set $3
   local.get $5
   i32.const 4
   i32.add
@@ -1524,12 +1528,12 @@
   if
    i32.const 0
    i32.const 1520
-   i32.const 357
+   i32.const 361
    i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $4
+  local.get $3
   i32.const -4
   i32.and
   local.get $5
@@ -1540,7 +1544,7 @@
   if
    local.get $2
    local.get $5
-   local.get $4
+   local.get $3
    i32.const 2
    i32.and
    i32.or
@@ -1550,19 +1554,19 @@
    i32.add
    local.get $5
    i32.add
-   local.tee $4
+   local.tee $3
    local.get $6
    i32.const 4
    i32.sub
    i32.const 1
    i32.or
    i32.store $0
-   local.get $3
    local.get $4
+   local.get $3
    call $~lib/rt/tlsf/insertBlock
   else
    local.get $2
-   local.get $4
+   local.get $3
    i32.const -2
    i32.and
    i32.store $0

--- a/tests/compiler/std/uri.release.wat
+++ b/tests/compiler/std/uri.release.wat
@@ -1423,7 +1423,7 @@
    local.tee $2
    local.get $5
    i32.const 256
-   i32.gt_u
+   i32.ge_u
    if (result i32)
     local.get $5
     i32.const 1

--- a/tests/compiler/std/uri.release.wat
+++ b/tests/compiler/std/uri.release.wat
@@ -1386,7 +1386,7 @@
    call $~lib/rt/tlsf/initialize
   end
   global.get $~lib/rt/tlsf/ROOT
-  local.set $4
+  local.set $3
   local.get $0
   i32.const 16
   i32.add
@@ -1401,7 +1401,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $4
+  local.get $3
   i32.const 12
   local.get $2
   i32.const 19
@@ -1421,8 +1421,9 @@
   if
    memory.size $0
    local.tee $2
+   local.get $5
    i32.const 4
-   local.get $4
+   local.get $3
    i32.load $0 offset=1568
    local.get $2
    i32.const 16
@@ -1431,38 +1432,40 @@
    i32.sub
    i32.ne
    i32.shl
-   local.get $5
-   i32.const 1
-   i32.const 27
-   local.get $5
-   i32.clz
-   i32.sub
-   i32.shl
-   i32.const 1
-   i32.sub
    i32.add
-   local.get $5
-   local.get $5
+   local.tee $4
    i32.const 536870910
    i32.lt_u
-   select
-   i32.add
+   if (result i32)
+    local.get $4
+    i32.const 1
+    i32.const 27
+    local.get $4
+    i32.clz
+    i32.sub
+    i32.shl
+    i32.const 1
+    i32.sub
+    i32.add
+   else
+    local.get $4
+   end
    i32.const 65535
    i32.add
    i32.const -65536
    i32.and
    i32.const 16
    i32.shr_u
-   local.tee $3
+   local.tee $4
    local.get $2
-   local.get $3
+   local.get $4
    i32.gt_s
    select
    memory.grow $0
    i32.const 0
    i32.lt_s
    if
-    local.get $3
+    local.get $4
     memory.grow $0
     i32.const 0
     i32.lt_s
@@ -1470,7 +1473,7 @@
      unreachable
     end
    end
-   local.get $4
+   local.get $3
    local.get $2
    i32.const 16
    i32.shl
@@ -1479,7 +1482,7 @@
    i64.const 16
    i64.shl
    call $~lib/rt/tlsf/addMemory
-   local.get $4
+   local.get $3
    local.get $5
    call $~lib/rt/tlsf/searchBlock
    local.tee $2
@@ -1507,12 +1510,12 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $4
+  local.get $3
   local.get $2
   call $~lib/rt/tlsf/removeBlock
   local.get $2
   i32.load $0
-  local.set $3
+  local.set $4
   local.get $5
   i32.const 4
   i32.add
@@ -1526,7 +1529,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $3
+  local.get $4
   i32.const -4
   i32.and
   local.get $5
@@ -1537,7 +1540,7 @@
   if
    local.get $2
    local.get $5
-   local.get $3
+   local.get $4
    i32.const 2
    i32.and
    i32.or
@@ -1547,19 +1550,19 @@
    i32.add
    local.get $5
    i32.add
-   local.tee $3
+   local.tee $4
    local.get $6
    i32.const 4
    i32.sub
    i32.const 1
    i32.or
    i32.store $0
-   local.get $4
    local.get $3
+   local.get $4
    call $~lib/rt/tlsf/insertBlock
   else
    local.get $2
-   local.get $3
+   local.get $4
    i32.const -2
    i32.and
    i32.store $0

--- a/tests/compiler/super-inline.debug.wat
+++ b/tests/compiler/super-inline.debug.wat
@@ -1034,7 +1034,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 378
+   i32.const 382
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1080,7 +1080,7 @@
    if
     i32.const 0
     i32.const 368
-    i32.const 385
+    i32.const 389
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1113,7 +1113,7 @@
    if
     i32.const 0
     i32.const 368
-    i32.const 398
+    i32.const 402
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1357,7 +1357,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 560
+   i32.const 562
    i32.const 3
    call $~lib/builtins/abort
    unreachable
@@ -1686,13 +1686,33 @@
   if
    i32.const 32
    i32.const 368
-   i32.const 459
+   i32.const 461
    i32.const 29
    call $~lib/builtins/abort
    unreachable
   end
   local.get $size
   call $~lib/rt/tlsf/computeSize
+  return
+ )
+ (func $~lib/rt/tlsf/roundSize (param $size i32) (result i32)
+  local.get $size
+  i32.const 536870910
+  i32.lt_u
+  if (result i32)
+   local.get $size
+   i32.const 1
+   i32.const 27
+   local.get $size
+   i32.clz
+   i32.sub
+   i32.shl
+   i32.add
+   i32.const 1
+   i32.sub
+  else
+   local.get $size
+  end
   return
  )
  (func $~lib/rt/tlsf/searchBlock (param $root i32) (param $size i32) (result i32)
@@ -1724,24 +1744,13 @@
    local.set $sl
   else
    local.get $size
-   i32.const 536870910
-   i32.lt_u
-   if (result i32)
-    local.get $size
-    i32.const 1
-    i32.const 27
-    local.get $size
-    i32.clz
-    i32.sub
-    i32.shl
-    i32.add
-    i32.const 1
-    i32.sub
-   else
-    local.get $size
-   end
+   call $~lib/rt/tlsf/roundSize
    local.set $requestSize
-   i32.const 31
+   i32.const 4
+   i32.const 8
+   i32.mul
+   i32.const 1
+   i32.sub
    local.get $requestSize
    i32.clz
    i32.sub
@@ -1779,7 +1788,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 330
+   i32.const 334
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1850,7 +1859,7 @@
     if
      i32.const 0
      i32.const 368
-     i32.const 343
+     i32.const 347
      i32.const 18
      call $~lib/builtins/abort
      unreachable
@@ -1913,6 +1922,14 @@
   (local $pagesAfter i32)
   i32.const 0
   drop
+  local.get $size
+  i32.const 256
+  i32.gt_u
+  if
+   local.get $size
+   call $~lib/rt/tlsf/roundSize
+   local.set $size
+  end
   memory.size $0
   local.set $pagesBefore
   local.get $size
@@ -1933,22 +1950,6 @@
   i32.shl
   i32.add
   local.set $size
-  local.get $size
-  i32.const 536870910
-  i32.lt_u
-  if
-   local.get $size
-   i32.const 1
-   i32.const 27
-   local.get $size
-   i32.clz
-   i32.sub
-   i32.shl
-   i32.const 1
-   i32.sub
-   i32.add
-   local.set $size
-  end
   local.get $size
   i32.const 65535
   i32.add
@@ -2015,7 +2016,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 357
+   i32.const 361
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -2130,7 +2131,7 @@
    if
     i32.const 0
     i32.const 368
-    i32.const 497
+    i32.const 499
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -2150,7 +2151,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 499
+   i32.const 501
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/super-inline.debug.wat
+++ b/tests/compiler/super-inline.debug.wat
@@ -1913,22 +1913,6 @@
   (local $pagesAfter i32)
   i32.const 0
   drop
-  local.get $size
-  i32.const 536870910
-  i32.lt_u
-  if
-   local.get $size
-   i32.const 1
-   i32.const 27
-   local.get $size
-   i32.clz
-   i32.sub
-   i32.shl
-   i32.const 1
-   i32.sub
-   i32.add
-   local.set $size
-  end
   memory.size $0
   local.set $pagesBefore
   local.get $size
@@ -1949,6 +1933,22 @@
   i32.shl
   i32.add
   local.set $size
+  local.get $size
+  i32.const 536870910
+  i32.lt_u
+  if
+   local.get $size
+   i32.const 1
+   i32.const 27
+   local.get $size
+   i32.clz
+   i32.sub
+   i32.shl
+   i32.const 1
+   i32.sub
+   i32.add
+   local.set $size
+  end
   local.get $size
   i32.const 65535
   i32.add

--- a/tests/compiler/super-inline.debug.wat
+++ b/tests/compiler/super-inline.debug.wat
@@ -1924,7 +1924,7 @@
   drop
   local.get $size
   i32.const 256
-  i32.gt_u
+  i32.ge_u
   if
    local.get $size
    call $~lib/rt/tlsf/roundSize

--- a/tests/compiler/super-inline.release.wat
+++ b/tests/compiler/super-inline.release.wat
@@ -632,7 +632,7 @@
   if
    i32.const 0
    i32.const 1392
-   i32.const 378
+   i32.const 382
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -657,7 +657,7 @@
    if
     i32.const 0
     i32.const 1392
-    i32.const 385
+    i32.const 389
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -685,7 +685,7 @@
    if
     i32.const 0
     i32.const 1392
-    i32.const 398
+    i32.const 402
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1052,7 +1052,7 @@
       if
        i32.const 0
        i32.const 1392
-       i32.const 560
+       i32.const 562
        i32.const 3
        call $~lib/builtins/abort
        unreachable
@@ -1119,7 +1119,7 @@
     if
      i32.const 0
      i32.const 1392
-     i32.const 343
+     i32.const 347
      i32.const 18
      call $~lib/builtins/abort
      unreachable
@@ -1203,8 +1203,6 @@
   if
    memory.size $0
    local.tee $1
-   i32.const 1
-   i32.const 27
    i32.const 4
    local.get $2
    i32.load $0 offset=1568
@@ -1215,22 +1213,7 @@
    i32.sub
    i32.ne
    i32.shl
-   i32.const 28
-   i32.add
-   local.tee $3
-   i32.clz
-   i32.sub
-   i32.shl
-   i32.const 1
-   i32.sub
-   local.get $3
-   i32.add
-   local.get $3
-   local.get $3
-   i32.const 536870910
-   i32.lt_u
-   select
-   i32.const 65535
+   i32.const 65563
    i32.add
    i32.const -65536
    i32.and
@@ -1269,7 +1252,7 @@
    if
     i32.const 0
     i32.const 1392
-    i32.const 497
+    i32.const 499
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1284,7 +1267,7 @@
   if
    i32.const 0
    i32.const 1392
-   i32.const 499
+   i32.const 501
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/super-inline.release.wat
+++ b/tests/compiler/super-inline.release.wat
@@ -1203,6 +1203,8 @@
   if
    memory.size $0
    local.tee $1
+   i32.const 1
+   i32.const 27
    i32.const 4
    local.get $2
    i32.load $0 offset=1568
@@ -1213,7 +1215,22 @@
    i32.sub
    i32.ne
    i32.shl
-   i32.const 65563
+   i32.const 28
+   i32.add
+   local.tee $3
+   i32.clz
+   i32.sub
+   i32.shl
+   i32.const 1
+   i32.sub
+   local.get $3
+   i32.add
+   local.get $3
+   local.get $3
+   i32.const 536870910
+   i32.lt_u
+   select
+   i32.const 65535
    i32.add
    i32.const -65536
    i32.and

--- a/tests/compiler/templateliteral.debug.wat
+++ b/tests/compiler/templateliteral.debug.wat
@@ -1215,7 +1215,7 @@
   if
    i32.const 0
    i32.const 528
-   i32.const 378
+   i32.const 382
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1261,7 +1261,7 @@
    if
     i32.const 0
     i32.const 528
-    i32.const 385
+    i32.const 389
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1294,7 +1294,7 @@
    if
     i32.const 0
     i32.const 528
-    i32.const 398
+    i32.const 402
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1538,7 +1538,7 @@
   if
    i32.const 0
    i32.const 528
-   i32.const 560
+   i32.const 562
    i32.const 3
    call $~lib/builtins/abort
    unreachable
@@ -1867,13 +1867,33 @@
   if
    i32.const 192
    i32.const 528
-   i32.const 459
+   i32.const 461
    i32.const 29
    call $~lib/builtins/abort
    unreachable
   end
   local.get $size
   call $~lib/rt/tlsf/computeSize
+  return
+ )
+ (func $~lib/rt/tlsf/roundSize (param $size i32) (result i32)
+  local.get $size
+  i32.const 536870910
+  i32.lt_u
+  if (result i32)
+   local.get $size
+   i32.const 1
+   i32.const 27
+   local.get $size
+   i32.clz
+   i32.sub
+   i32.shl
+   i32.add
+   i32.const 1
+   i32.sub
+  else
+   local.get $size
+  end
   return
  )
  (func $~lib/rt/tlsf/searchBlock (param $root i32) (param $size i32) (result i32)
@@ -1905,24 +1925,13 @@
    local.set $sl
   else
    local.get $size
-   i32.const 536870910
-   i32.lt_u
-   if (result i32)
-    local.get $size
-    i32.const 1
-    i32.const 27
-    local.get $size
-    i32.clz
-    i32.sub
-    i32.shl
-    i32.add
-    i32.const 1
-    i32.sub
-   else
-    local.get $size
-   end
+   call $~lib/rt/tlsf/roundSize
    local.set $requestSize
-   i32.const 31
+   i32.const 4
+   i32.const 8
+   i32.mul
+   i32.const 1
+   i32.sub
    local.get $requestSize
    i32.clz
    i32.sub
@@ -1960,7 +1969,7 @@
   if
    i32.const 0
    i32.const 528
-   i32.const 330
+   i32.const 334
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -2031,7 +2040,7 @@
     if
      i32.const 0
      i32.const 528
-     i32.const 343
+     i32.const 347
      i32.const 18
      call $~lib/builtins/abort
      unreachable
@@ -2094,6 +2103,14 @@
   (local $pagesAfter i32)
   i32.const 0
   drop
+  local.get $size
+  i32.const 256
+  i32.gt_u
+  if
+   local.get $size
+   call $~lib/rt/tlsf/roundSize
+   local.set $size
+  end
   memory.size $0
   local.set $pagesBefore
   local.get $size
@@ -2114,22 +2131,6 @@
   i32.shl
   i32.add
   local.set $size
-  local.get $size
-  i32.const 536870910
-  i32.lt_u
-  if
-   local.get $size
-   i32.const 1
-   i32.const 27
-   local.get $size
-   i32.clz
-   i32.sub
-   i32.shl
-   i32.const 1
-   i32.sub
-   i32.add
-   local.set $size
-  end
   local.get $size
   i32.const 65535
   i32.add
@@ -2196,7 +2197,7 @@
   if
    i32.const 0
    i32.const 528
-   i32.const 357
+   i32.const 361
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -2311,7 +2312,7 @@
    if
     i32.const 0
     i32.const 528
-    i32.const 497
+    i32.const 499
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -2331,7 +2332,7 @@
   if
    i32.const 0
    i32.const 528
-   i32.const 499
+   i32.const 501
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/templateliteral.debug.wat
+++ b/tests/compiler/templateliteral.debug.wat
@@ -2105,7 +2105,7 @@
   drop
   local.get $size
   i32.const 256
-  i32.gt_u
+  i32.ge_u
   if
    local.get $size
    call $~lib/rt/tlsf/roundSize

--- a/tests/compiler/templateliteral.debug.wat
+++ b/tests/compiler/templateliteral.debug.wat
@@ -2094,22 +2094,6 @@
   (local $pagesAfter i32)
   i32.const 0
   drop
-  local.get $size
-  i32.const 536870910
-  i32.lt_u
-  if
-   local.get $size
-   i32.const 1
-   i32.const 27
-   local.get $size
-   i32.clz
-   i32.sub
-   i32.shl
-   i32.const 1
-   i32.sub
-   i32.add
-   local.set $size
-  end
   memory.size $0
   local.set $pagesBefore
   local.get $size
@@ -2130,6 +2114,22 @@
   i32.shl
   i32.add
   local.set $size
+  local.get $size
+  i32.const 536870910
+  i32.lt_u
+  if
+   local.get $size
+   i32.const 1
+   i32.const 27
+   local.get $size
+   i32.clz
+   i32.sub
+   i32.shl
+   i32.const 1
+   i32.sub
+   i32.add
+   local.set $size
+  end
   local.get $size
   i32.const 65535
   i32.add

--- a/tests/compiler/templateliteral.release.wat
+++ b/tests/compiler/templateliteral.release.wat
@@ -721,7 +721,7 @@
   if
    i32.const 0
    i32.const 1552
-   i32.const 378
+   i32.const 382
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -746,7 +746,7 @@
    if
     i32.const 0
     i32.const 1552
-    i32.const 385
+    i32.const 389
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -774,7 +774,7 @@
    if
     i32.const 0
     i32.const 1552
-    i32.const 398
+    i32.const 402
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1141,7 +1141,7 @@
       if
        i32.const 0
        i32.const 1552
-       i32.const 560
+       i32.const 562
        i32.const 3
        call $~lib/builtins/abort
        unreachable
@@ -1225,7 +1225,7 @@
   if
    i32.const 0
    i32.const 1552
-   i32.const 330
+   i32.const 334
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1277,7 +1277,7 @@
     if
      i32.const 0
      i32.const 1552
-     i32.const 343
+     i32.const 347
      i32.const 18
      call $~lib/builtins/abort
      unreachable
@@ -1366,7 +1366,7 @@
    call $~lib/rt/tlsf/initialize
   end
   global.get $~lib/rt/tlsf/ROOT
-  local.set $3
+  local.set $4
   local.get $0
   i32.const 16
   i32.add
@@ -1376,12 +1376,12 @@
   if
    i32.const 1216
    i32.const 1552
-   i32.const 459
+   i32.const 461
    i32.const 29
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $3
+  local.get $4
   i32.const 12
   local.get $2
   i32.const 19
@@ -1402,8 +1402,29 @@
    memory.size $0
    local.tee $2
    local.get $5
+   i32.const 256
+   i32.gt_u
+   if (result i32)
+    local.get $5
+    i32.const 1
+    i32.const 27
+    local.get $5
+    i32.clz
+    i32.sub
+    i32.shl
+    i32.add
+    i32.const 1
+    i32.sub
+    local.get $5
+    local.get $5
+    i32.const 536870910
+    i32.lt_u
+    select
+   else
+    local.get $5
+   end
    i32.const 4
-   local.get $3
+   local.get $4
    i32.load $0 offset=1568
    local.get $2
    i32.const 16
@@ -1413,39 +1434,22 @@
    i32.ne
    i32.shl
    i32.add
-   local.tee $4
-   i32.const 536870910
-   i32.lt_u
-   if (result i32)
-    local.get $4
-    i32.const 1
-    i32.const 27
-    local.get $4
-    i32.clz
-    i32.sub
-    i32.shl
-    i32.const 1
-    i32.sub
-    i32.add
-   else
-    local.get $4
-   end
    i32.const 65535
    i32.add
    i32.const -65536
    i32.and
    i32.const 16
    i32.shr_u
-   local.tee $4
+   local.tee $3
    local.get $2
-   local.get $4
+   local.get $3
    i32.gt_s
    select
    memory.grow $0
    i32.const 0
    i32.lt_s
    if
-    local.get $4
+    local.get $3
     memory.grow $0
     i32.const 0
     i32.lt_s
@@ -1453,7 +1457,7 @@
      unreachable
     end
    end
-   local.get $3
+   local.get $4
    local.get $2
    i32.const 16
    i32.shl
@@ -1462,7 +1466,7 @@
    i64.const 16
    i64.shl
    call $~lib/rt/tlsf/addMemory
-   local.get $3
+   local.get $4
    local.get $5
    call $~lib/rt/tlsf/searchBlock
    local.tee $2
@@ -1470,7 +1474,7 @@
    if
     i32.const 0
     i32.const 1552
-    i32.const 497
+    i32.const 499
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1485,17 +1489,17 @@
   if
    i32.const 0
    i32.const 1552
-   i32.const 499
+   i32.const 501
    i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $3
+  local.get $4
   local.get $2
   call $~lib/rt/tlsf/removeBlock
   local.get $2
   i32.load $0
-  local.set $4
+  local.set $3
   local.get $5
   i32.const 4
   i32.add
@@ -1504,12 +1508,12 @@
   if
    i32.const 0
    i32.const 1552
-   i32.const 357
+   i32.const 361
    i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $4
+  local.get $3
   i32.const -4
   i32.and
   local.get $5
@@ -1520,7 +1524,7 @@
   if
    local.get $2
    local.get $5
-   local.get $4
+   local.get $3
    i32.const 2
    i32.and
    i32.or
@@ -1530,19 +1534,19 @@
    i32.add
    local.get $5
    i32.add
-   local.tee $4
+   local.tee $3
    local.get $6
    i32.const 4
    i32.sub
    i32.const 1
    i32.or
    i32.store $0
-   local.get $3
    local.get $4
+   local.get $3
    call $~lib/rt/tlsf/insertBlock
   else
    local.get $2
-   local.get $4
+   local.get $3
    i32.const -2
    i32.and
    i32.store $0

--- a/tests/compiler/templateliteral.release.wat
+++ b/tests/compiler/templateliteral.release.wat
@@ -1366,7 +1366,7 @@
    call $~lib/rt/tlsf/initialize
   end
   global.get $~lib/rt/tlsf/ROOT
-  local.set $4
+  local.set $3
   local.get $0
   i32.const 16
   i32.add
@@ -1381,7 +1381,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $4
+  local.get $3
   i32.const 12
   local.get $2
   i32.const 19
@@ -1401,8 +1401,9 @@
   if
    memory.size $0
    local.tee $2
+   local.get $5
    i32.const 4
-   local.get $4
+   local.get $3
    i32.load $0 offset=1568
    local.get $2
    i32.const 16
@@ -1411,38 +1412,40 @@
    i32.sub
    i32.ne
    i32.shl
-   local.get $5
-   i32.const 1
-   i32.const 27
-   local.get $5
-   i32.clz
-   i32.sub
-   i32.shl
-   i32.const 1
-   i32.sub
    i32.add
-   local.get $5
-   local.get $5
+   local.tee $4
    i32.const 536870910
    i32.lt_u
-   select
-   i32.add
+   if (result i32)
+    local.get $4
+    i32.const 1
+    i32.const 27
+    local.get $4
+    i32.clz
+    i32.sub
+    i32.shl
+    i32.const 1
+    i32.sub
+    i32.add
+   else
+    local.get $4
+   end
    i32.const 65535
    i32.add
    i32.const -65536
    i32.and
    i32.const 16
    i32.shr_u
-   local.tee $3
+   local.tee $4
    local.get $2
-   local.get $3
+   local.get $4
    i32.gt_s
    select
    memory.grow $0
    i32.const 0
    i32.lt_s
    if
-    local.get $3
+    local.get $4
     memory.grow $0
     i32.const 0
     i32.lt_s
@@ -1450,7 +1453,7 @@
      unreachable
     end
    end
-   local.get $4
+   local.get $3
    local.get $2
    i32.const 16
    i32.shl
@@ -1459,7 +1462,7 @@
    i64.const 16
    i64.shl
    call $~lib/rt/tlsf/addMemory
-   local.get $4
+   local.get $3
    local.get $5
    call $~lib/rt/tlsf/searchBlock
    local.tee $2
@@ -1487,12 +1490,12 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $4
+  local.get $3
   local.get $2
   call $~lib/rt/tlsf/removeBlock
   local.get $2
   i32.load $0
-  local.set $3
+  local.set $4
   local.get $5
   i32.const 4
   i32.add
@@ -1506,7 +1509,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $3
+  local.get $4
   i32.const -4
   i32.and
   local.get $5
@@ -1517,7 +1520,7 @@
   if
    local.get $2
    local.get $5
-   local.get $3
+   local.get $4
    i32.const 2
    i32.and
    i32.or
@@ -1527,19 +1530,19 @@
    i32.add
    local.get $5
    i32.add
-   local.tee $3
+   local.tee $4
    local.get $6
    i32.const 4
    i32.sub
    i32.const 1
    i32.or
    i32.store $0
-   local.get $4
    local.get $3
+   local.get $4
    call $~lib/rt/tlsf/insertBlock
   else
    local.get $2
-   local.get $3
+   local.get $4
    i32.const -2
    i32.and
    i32.store $0

--- a/tests/compiler/templateliteral.release.wat
+++ b/tests/compiler/templateliteral.release.wat
@@ -1403,7 +1403,7 @@
    local.tee $2
    local.get $5
    i32.const 256
-   i32.gt_u
+   i32.ge_u
    if (result i32)
     local.get $5
     i32.const 1

--- a/tests/compiler/throw.debug.wat
+++ b/tests/compiler/throw.debug.wat
@@ -1146,7 +1146,7 @@
   if
    i32.const 0
    i32.const 608
-   i32.const 378
+   i32.const 382
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1192,7 +1192,7 @@
    if
     i32.const 0
     i32.const 608
-    i32.const 385
+    i32.const 389
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1225,7 +1225,7 @@
    if
     i32.const 0
     i32.const 608
-    i32.const 398
+    i32.const 402
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1469,7 +1469,7 @@
   if
    i32.const 0
    i32.const 608
-   i32.const 560
+   i32.const 562
    i32.const 3
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/throw.release.wat
+++ b/tests/compiler/throw.release.wat
@@ -921,7 +921,7 @@
        if
         i32.const 0
         i32.const 1632
-        i32.const 378
+        i32.const 382
         i32.const 14
         call $~lib/builtins/abort
         unreachable
@@ -940,7 +940,7 @@
         if
          i32.const 0
          i32.const 1632
-         i32.const 385
+         i32.const 389
          i32.const 16
          call $~lib/builtins/abort
          unreachable
@@ -1028,7 +1028,7 @@
       if
        i32.const 0
        i32.const 1632
-       i32.const 560
+       i32.const 562
        i32.const 3
        call $~lib/builtins/abort
        unreachable

--- a/tests/compiler/typeof.debug.wat
+++ b/tests/compiler/typeof.debug.wat
@@ -1173,7 +1173,7 @@
   if
    i32.const 0
    i32.const 672
-   i32.const 378
+   i32.const 382
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1219,7 +1219,7 @@
    if
     i32.const 0
     i32.const 672
-    i32.const 385
+    i32.const 389
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1252,7 +1252,7 @@
    if
     i32.const 0
     i32.const 672
-    i32.const 398
+    i32.const 402
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1496,7 +1496,7 @@
   if
    i32.const 0
    i32.const 672
-   i32.const 560
+   i32.const 562
    i32.const 3
    call $~lib/builtins/abort
    unreachable
@@ -1825,13 +1825,33 @@
   if
    i32.const 336
    i32.const 672
-   i32.const 459
+   i32.const 461
    i32.const 29
    call $~lib/builtins/abort
    unreachable
   end
   local.get $size
   call $~lib/rt/tlsf/computeSize
+  return
+ )
+ (func $~lib/rt/tlsf/roundSize (param $size i32) (result i32)
+  local.get $size
+  i32.const 536870910
+  i32.lt_u
+  if (result i32)
+   local.get $size
+   i32.const 1
+   i32.const 27
+   local.get $size
+   i32.clz
+   i32.sub
+   i32.shl
+   i32.add
+   i32.const 1
+   i32.sub
+  else
+   local.get $size
+  end
   return
  )
  (func $~lib/rt/tlsf/searchBlock (param $root i32) (param $size i32) (result i32)
@@ -1863,24 +1883,13 @@
    local.set $sl
   else
    local.get $size
-   i32.const 536870910
-   i32.lt_u
-   if (result i32)
-    local.get $size
-    i32.const 1
-    i32.const 27
-    local.get $size
-    i32.clz
-    i32.sub
-    i32.shl
-    i32.add
-    i32.const 1
-    i32.sub
-   else
-    local.get $size
-   end
+   call $~lib/rt/tlsf/roundSize
    local.set $requestSize
-   i32.const 31
+   i32.const 4
+   i32.const 8
+   i32.mul
+   i32.const 1
+   i32.sub
    local.get $requestSize
    i32.clz
    i32.sub
@@ -1918,7 +1927,7 @@
   if
    i32.const 0
    i32.const 672
-   i32.const 330
+   i32.const 334
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1989,7 +1998,7 @@
     if
      i32.const 0
      i32.const 672
-     i32.const 343
+     i32.const 347
      i32.const 18
      call $~lib/builtins/abort
      unreachable
@@ -2052,6 +2061,14 @@
   (local $pagesAfter i32)
   i32.const 0
   drop
+  local.get $size
+  i32.const 256
+  i32.gt_u
+  if
+   local.get $size
+   call $~lib/rt/tlsf/roundSize
+   local.set $size
+  end
   memory.size $0
   local.set $pagesBefore
   local.get $size
@@ -2072,22 +2089,6 @@
   i32.shl
   i32.add
   local.set $size
-  local.get $size
-  i32.const 536870910
-  i32.lt_u
-  if
-   local.get $size
-   i32.const 1
-   i32.const 27
-   local.get $size
-   i32.clz
-   i32.sub
-   i32.shl
-   i32.const 1
-   i32.sub
-   i32.add
-   local.set $size
-  end
   local.get $size
   i32.const 65535
   i32.add
@@ -2154,7 +2155,7 @@
   if
    i32.const 0
    i32.const 672
-   i32.const 357
+   i32.const 361
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -2269,7 +2270,7 @@
    if
     i32.const 0
     i32.const 672
-    i32.const 497
+    i32.const 499
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -2289,7 +2290,7 @@
   if
    i32.const 0
    i32.const 672
-   i32.const 499
+   i32.const 501
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/typeof.debug.wat
+++ b/tests/compiler/typeof.debug.wat
@@ -2052,22 +2052,6 @@
   (local $pagesAfter i32)
   i32.const 0
   drop
-  local.get $size
-  i32.const 536870910
-  i32.lt_u
-  if
-   local.get $size
-   i32.const 1
-   i32.const 27
-   local.get $size
-   i32.clz
-   i32.sub
-   i32.shl
-   i32.const 1
-   i32.sub
-   i32.add
-   local.set $size
-  end
   memory.size $0
   local.set $pagesBefore
   local.get $size
@@ -2088,6 +2072,22 @@
   i32.shl
   i32.add
   local.set $size
+  local.get $size
+  i32.const 536870910
+  i32.lt_u
+  if
+   local.get $size
+   i32.const 1
+   i32.const 27
+   local.get $size
+   i32.clz
+   i32.sub
+   i32.shl
+   i32.const 1
+   i32.sub
+   i32.add
+   local.set $size
+  end
   local.get $size
   i32.const 65535
   i32.add

--- a/tests/compiler/typeof.debug.wat
+++ b/tests/compiler/typeof.debug.wat
@@ -2063,7 +2063,7 @@
   drop
   local.get $size
   i32.const 256
-  i32.gt_u
+  i32.ge_u
   if
    local.get $size
    call $~lib/rt/tlsf/roundSize

--- a/tests/compiler/typeof.release.wat
+++ b/tests/compiler/typeof.release.wat
@@ -648,7 +648,7 @@
   if
    i32.const 0
    i32.const 1696
-   i32.const 378
+   i32.const 382
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -673,7 +673,7 @@
    if
     i32.const 0
     i32.const 1696
-    i32.const 385
+    i32.const 389
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -701,7 +701,7 @@
    if
     i32.const 0
     i32.const 1696
-    i32.const 398
+    i32.const 402
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1068,7 +1068,7 @@
       if
        i32.const 0
        i32.const 1696
-       i32.const 560
+       i32.const 562
        i32.const 3
        call $~lib/builtins/abort
        unreachable
@@ -1135,7 +1135,7 @@
     if
      i32.const 0
      i32.const 1696
-     i32.const 343
+     i32.const 347
      i32.const 18
      call $~lib/builtins/abort
      unreachable
@@ -1219,8 +1219,6 @@
   if
    memory.size $0
    local.tee $1
-   i32.const 1
-   i32.const 27
    i32.const 4
    local.get $2
    i32.load $0 offset=1568
@@ -1231,22 +1229,7 @@
    i32.sub
    i32.ne
    i32.shl
-   i32.const 28
-   i32.add
-   local.tee $3
-   i32.clz
-   i32.sub
-   i32.shl
-   i32.const 1
-   i32.sub
-   local.get $3
-   i32.add
-   local.get $3
-   local.get $3
-   i32.const 536870910
-   i32.lt_u
-   select
-   i32.const 65535
+   i32.const 65563
    i32.add
    i32.const -65536
    i32.and
@@ -1285,7 +1268,7 @@
    if
     i32.const 0
     i32.const 1696
-    i32.const 497
+    i32.const 499
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1300,7 +1283,7 @@
   if
    i32.const 0
    i32.const 1696
-   i32.const 499
+   i32.const 501
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/typeof.release.wat
+++ b/tests/compiler/typeof.release.wat
@@ -1219,6 +1219,8 @@
   if
    memory.size $0
    local.tee $1
+   i32.const 1
+   i32.const 27
    i32.const 4
    local.get $2
    i32.load $0 offset=1568
@@ -1229,7 +1231,22 @@
    i32.sub
    i32.ne
    i32.shl
-   i32.const 65563
+   i32.const 28
+   i32.add
+   local.tee $3
+   i32.clz
+   i32.sub
+   i32.shl
+   i32.const 1
+   i32.sub
+   local.get $3
+   i32.add
+   local.get $3
+   local.get $3
+   i32.const 536870910
+   i32.lt_u
+   select
+   i32.const 65535
    i32.add
    i32.const -65536
    i32.and

--- a/tests/compiler/while.debug.wat
+++ b/tests/compiler/while.debug.wat
@@ -2335,22 +2335,6 @@
   (local $pagesAfter i32)
   i32.const 0
   drop
-  local.get $size
-  i32.const 536870910
-  i32.lt_u
-  if
-   local.get $size
-   i32.const 1
-   i32.const 27
-   local.get $size
-   i32.clz
-   i32.sub
-   i32.shl
-   i32.const 1
-   i32.sub
-   i32.add
-   local.set $size
-  end
   memory.size $0
   local.set $pagesBefore
   local.get $size
@@ -2371,6 +2355,22 @@
   i32.shl
   i32.add
   local.set $size
+  local.get $size
+  i32.const 536870910
+  i32.lt_u
+  if
+   local.get $size
+   i32.const 1
+   i32.const 27
+   local.get $size
+   i32.clz
+   i32.sub
+   i32.shl
+   i32.const 1
+   i32.sub
+   i32.add
+   local.set $size
+  end
   local.get $size
   i32.const 65535
   i32.add

--- a/tests/compiler/while.debug.wat
+++ b/tests/compiler/while.debug.wat
@@ -2346,7 +2346,7 @@
   drop
   local.get $size
   i32.const 256
-  i32.gt_u
+  i32.ge_u
   if
    local.get $size
    call $~lib/rt/tlsf/roundSize

--- a/tests/compiler/while.debug.wat
+++ b/tests/compiler/while.debug.wat
@@ -1,6 +1,6 @@
 (module
- (type $none_=>_none (func))
  (type $i32_=>_i32 (func (param i32) (result i32)))
+ (type $none_=>_none (func))
  (type $i32_i32_=>_none (func (param i32 i32)))
  (type $i32_=>_none (func (param i32)))
  (type $none_=>_i32 (func (result i32)))
@@ -1456,7 +1456,7 @@
   if
    i32.const 0
    i32.const 416
-   i32.const 378
+   i32.const 382
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1502,7 +1502,7 @@
    if
     i32.const 0
     i32.const 416
-    i32.const 385
+    i32.const 389
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1535,7 +1535,7 @@
    if
     i32.const 0
     i32.const 416
-    i32.const 398
+    i32.const 402
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1779,7 +1779,7 @@
   if
    i32.const 0
    i32.const 416
-   i32.const 560
+   i32.const 562
    i32.const 3
    call $~lib/builtins/abort
    unreachable
@@ -2108,13 +2108,33 @@
   if
    i32.const 80
    i32.const 416
-   i32.const 459
+   i32.const 461
    i32.const 29
    call $~lib/builtins/abort
    unreachable
   end
   local.get $size
   call $~lib/rt/tlsf/computeSize
+  return
+ )
+ (func $~lib/rt/tlsf/roundSize (param $size i32) (result i32)
+  local.get $size
+  i32.const 536870910
+  i32.lt_u
+  if (result i32)
+   local.get $size
+   i32.const 1
+   i32.const 27
+   local.get $size
+   i32.clz
+   i32.sub
+   i32.shl
+   i32.add
+   i32.const 1
+   i32.sub
+  else
+   local.get $size
+  end
   return
  )
  (func $~lib/rt/tlsf/searchBlock (param $root i32) (param $size i32) (result i32)
@@ -2146,24 +2166,13 @@
    local.set $sl
   else
    local.get $size
-   i32.const 536870910
-   i32.lt_u
-   if (result i32)
-    local.get $size
-    i32.const 1
-    i32.const 27
-    local.get $size
-    i32.clz
-    i32.sub
-    i32.shl
-    i32.add
-    i32.const 1
-    i32.sub
-   else
-    local.get $size
-   end
+   call $~lib/rt/tlsf/roundSize
    local.set $requestSize
-   i32.const 31
+   i32.const 4
+   i32.const 8
+   i32.mul
+   i32.const 1
+   i32.sub
    local.get $requestSize
    i32.clz
    i32.sub
@@ -2201,7 +2210,7 @@
   if
    i32.const 0
    i32.const 416
-   i32.const 330
+   i32.const 334
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -2272,7 +2281,7 @@
     if
      i32.const 0
      i32.const 416
-     i32.const 343
+     i32.const 347
      i32.const 18
      call $~lib/builtins/abort
      unreachable
@@ -2335,6 +2344,14 @@
   (local $pagesAfter i32)
   i32.const 0
   drop
+  local.get $size
+  i32.const 256
+  i32.gt_u
+  if
+   local.get $size
+   call $~lib/rt/tlsf/roundSize
+   local.set $size
+  end
   memory.size $0
   local.set $pagesBefore
   local.get $size
@@ -2355,22 +2372,6 @@
   i32.shl
   i32.add
   local.set $size
-  local.get $size
-  i32.const 536870910
-  i32.lt_u
-  if
-   local.get $size
-   i32.const 1
-   i32.const 27
-   local.get $size
-   i32.clz
-   i32.sub
-   i32.shl
-   i32.const 1
-   i32.sub
-   i32.add
-   local.set $size
-  end
   local.get $size
   i32.const 65535
   i32.add
@@ -2437,7 +2438,7 @@
   if
    i32.const 0
    i32.const 416
-   i32.const 357
+   i32.const 361
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -2552,7 +2553,7 @@
    if
     i32.const 0
     i32.const 416
-    i32.const 497
+    i32.const 499
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -2572,7 +2573,7 @@
   if
    i32.const 0
    i32.const 416
-   i32.const 499
+   i32.const 501
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/while.release.wat
+++ b/tests/compiler/while.release.wat
@@ -1191,6 +1191,8 @@
   if
    memory.size $0
    local.tee $1
+   i32.const 1
+   i32.const 27
    i32.const 4
    local.get $2
    i32.load $0 offset=1568
@@ -1201,7 +1203,22 @@
    i32.sub
    i32.ne
    i32.shl
-   i32.const 65563
+   i32.const 28
+   i32.add
+   local.tee $3
+   i32.clz
+   i32.sub
+   i32.shl
+   i32.const 1
+   i32.sub
+   local.get $3
+   i32.add
+   local.get $3
+   local.get $3
+   i32.const 536870910
+   i32.lt_u
+   select
+   i32.const 65535
    i32.add
    i32.const -65536
    i32.and

--- a/tests/compiler/while.release.wat
+++ b/tests/compiler/while.release.wat
@@ -620,7 +620,7 @@
   if
    i32.const 0
    i32.const 1440
-   i32.const 378
+   i32.const 382
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -645,7 +645,7 @@
    if
     i32.const 0
     i32.const 1440
-    i32.const 385
+    i32.const 389
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -673,7 +673,7 @@
    if
     i32.const 0
     i32.const 1440
-    i32.const 398
+    i32.const 402
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1040,7 +1040,7 @@
       if
        i32.const 0
        i32.const 1440
-       i32.const 560
+       i32.const 562
        i32.const 3
        call $~lib/builtins/abort
        unreachable
@@ -1107,7 +1107,7 @@
     if
      i32.const 0
      i32.const 1440
-     i32.const 343
+     i32.const 347
      i32.const 18
      call $~lib/builtins/abort
      unreachable
@@ -1191,8 +1191,6 @@
   if
    memory.size $0
    local.tee $1
-   i32.const 1
-   i32.const 27
    i32.const 4
    local.get $2
    i32.load $0 offset=1568
@@ -1203,22 +1201,7 @@
    i32.sub
    i32.ne
    i32.shl
-   i32.const 28
-   i32.add
-   local.tee $3
-   i32.clz
-   i32.sub
-   i32.shl
-   i32.const 1
-   i32.sub
-   local.get $3
-   i32.add
-   local.get $3
-   local.get $3
-   i32.const 536870910
-   i32.lt_u
-   select
-   i32.const 65535
+   i32.const 65563
    i32.add
    i32.const -65536
    i32.and
@@ -1257,7 +1240,7 @@
    if
     i32.const 0
     i32.const 1440
-    i32.const 497
+    i32.const 499
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1272,7 +1255,7 @@
   if
    i32.const 0
    i32.const 1440
-   i32.const 499
+   i32.const 501
    i32.const 14
    call $~lib/builtins/abort
    unreachable


### PR DESCRIPTION
When calling `heap.alloc(1)`, It will alloc a block size = `BLOCK_MINSIZE` (12bytes)
And then 
invRound = 27
clz<usize>(size) = 28
(1 << (invRound - clz<usize>(size))) - 1 = 2147483647

Runtime will grow lots of memory.