### PR TITLE
Fix the bindings for performance.now() and document.*

### DIFF
--- a/src/bindings/js.ts
+++ b/src/bindings/js.ts
@@ -285,7 +285,7 @@ export class JSBuilder extends ExportsWalker {
       sb.push(escapeString(name, CharCode.DoubleQuote));
       sb.push("\"");
     }
-    if (isPlainFunction(signature, Mode.Import) && !code) {
+    if (isPlainFunction(signature, Mode.Import) && !code && isIdentifier(name)) {
       sb.push(": (\n");
       indent(sb, this.indentLevel + 1);
       sb.push("// ");


### PR DESCRIPTION
`performance.now()` and co. need to be called with the proper this value.

<!--
 Thanks for submitting a pull request to AssemblyScript! Please take a moment to
 review the contributing guidelines linked below, and confirm with an [x] 🙂
-->

Changes proposed in this pull request:
⯈ Ensure `performance.now()` is called properly.
⯈ Ensure `document.*` is called properly.

- [x] I've read the contributing guidelines
- [x] I've added my name and email to the NOTICE file
