### PR TITLE
fix: `instanceof` in override function compile as unreachable

### DIFF
--- a/src/compiler.ts
+++ b/src/compiler.ts
@@ -559,25 +559,6 @@ export class Compiler extends DiagnosticEmitter {
       }
     } while (lazyFunctions.size);
 
-    // compile pending instanceof helpers
-    for (let _keys = Map_keys(this.pendingInstanceOf), i = 0, k = _keys.length; i < k; ++i) {
-      let elem = _keys[i];
-      let name = assert(this.pendingInstanceOf.get(elem));
-      switch (elem.kind) {
-        case ElementKind.Class:
-        case ElementKind.Interface: {
-          this.finalizeInstanceOf(<Class>elem, name);
-          break;
-        }
-        case ElementKind.ClassPrototype:
-        case ElementKind.InterfacePrototype: {
-          this.finalizeAnyInstanceOf(<ClassPrototype>elem, name);
-          break;
-        }
-        default: assert(false);
-      }
-    }
-
     // set up override stubs
     let functionTable = this.functionTable;
     let overrideStubs = this.overrideStubs;
@@ -609,6 +590,25 @@ export class Compiler extends DiagnosticEmitter {
     overrideStubsSeen.clear();
     for (let _values = Set_values(overrideStubs), i = 0, k = _values.length; i < k; ++i) {
       this.finalizeOverrideStub(_values[i]);
+    }
+
+    // compile pending instanceof helpers
+    for (let _keys = Map_keys(this.pendingInstanceOf), i = 0, k = _keys.length; i < k; ++i) {
+      let elem = _keys[i];
+      let name = assert(this.pendingInstanceOf.get(elem));
+      switch (elem.kind) {
+        case ElementKind.Class:
+        case ElementKind.Interface: {
+          this.finalizeInstanceOf(<Class>elem, name);
+          break;
+        }
+        case ElementKind.ClassPrototype:
+        case ElementKind.InterfacePrototype: {
+          this.finalizeAnyInstanceOf(<ClassPrototype>elem, name);
+          break;
+        }
+        default: assert(false);
+      }
     }
 
     // finalize runtime features

--- a/tests/compiler/instanceof.debug.wat
+++ b/tests/compiler/instanceof.debug.wat
@@ -4111,6 +4111,58 @@
   i32.add
   global.set $~lib/memory/__stack_pointer
  )
+ (func $instanceof/C#checkInstanceof (param $this i32)
+  (local $1 i32)
+  global.get $~lib/memory/__stack_pointer
+  i32.const 4
+  i32.sub
+  global.set $~lib/memory/__stack_pointer
+  call $~stack_check
+  global.get $~lib/memory/__stack_pointer
+  i32.const 0
+  i32.store $0
+  global.get $~lib/memory/__stack_pointer
+  global.get $instanceof/a
+  local.tee $1
+  i32.store $0
+  local.get $1
+  i32.eqz
+  if (result i32)
+   i32.const 0
+  else
+   local.get $1
+   call $~instanceof|instanceof/C
+  end
+  if
+   nop
+  end
+  global.get $~lib/memory/__stack_pointer
+  i32.const 4
+  i32.add
+  global.set $~lib/memory/__stack_pointer
+ )
+ (func $instanceof/A#checkInstanceof@override (param $0 i32)
+  (local $1 i32)
+  block $default
+   block $case0
+    local.get $0
+    i32.const 8
+    i32.sub
+    i32.load $0
+    local.set $1
+    local.get $1
+    i32.const 6
+    i32.eq
+    br_if $case0
+    br $default
+   end
+   local.get $0
+   call $instanceof/C#checkInstanceof
+   return
+  end
+  local.get $0
+  call $instanceof/A#checkInstanceof
+ )
  (func $~instanceof|instanceof/B (param $0 i32) (result i32)
   (local $1 i32)
   block $is_instance
@@ -4377,59 +4429,21 @@
   i32.const 1
  )
  (func $~instanceof|instanceof/C (param $0 i32) (result i32)
-  unreachable
- )
- (func $instanceof/C#checkInstanceof (param $this i32)
   (local $1 i32)
-  global.get $~lib/memory/__stack_pointer
-  i32.const 4
-  i32.sub
-  global.set $~lib/memory/__stack_pointer
-  call $~stack_check
-  global.get $~lib/memory/__stack_pointer
-  i32.const 0
-  i32.store $0
-  global.get $~lib/memory/__stack_pointer
-  global.get $instanceof/a
-  local.tee $1
-  i32.store $0
-  local.get $1
-  i32.eqz
-  if (result i32)
-   i32.const 0
-  else
-   local.get $1
-   call $~instanceof|instanceof/C
-  end
-  if
-   nop
-  end
-  global.get $~lib/memory/__stack_pointer
-  i32.const 4
-  i32.add
-  global.set $~lib/memory/__stack_pointer
- )
- (func $instanceof/A#checkInstanceof@override (param $0 i32)
-  (local $1 i32)
-  block $default
-   block $case0
-    local.get $0
-    i32.const 8
-    i32.sub
-    i32.load $0
-    local.set $1
-    local.get $1
-    i32.const 6
-    i32.eq
-    br_if $case0
-    br $default
-   end
+  block $is_instance
    local.get $0
-   call $instanceof/C#checkInstanceof
+   i32.const 8
+   i32.sub
+   i32.load $0
+   local.set $1
+   local.get $1
+   i32.const 6
+   i32.eq
+   br_if $is_instance
+   i32.const 0
    return
   end
-  local.get $0
-  call $instanceof/A#checkInstanceof
+  i32.const 1
  )
  (func $~lib/rt/__visit_globals (param $0 i32)
   (local $1 i32)

--- a/tests/compiler/instanceof.debug.wat
+++ b/tests/compiler/instanceof.debug.wat
@@ -47,9 +47,9 @@
  (global $instanceof/y (mut i32) (i32.const 0))
  (global $instanceof/z (mut i32) (i32.const 0))
  (global $~lib/rt/__rtti_base i32 (i32.const 464))
- (global $~lib/memory/__data_end i32 (i32.const 560))
- (global $~lib/memory/__stack_pointer (mut i32) (i32.const 33328))
- (global $~lib/memory/__heap_base i32 (i32.const 33328))
+ (global $~lib/memory/__data_end i32 (i32.const 564))
+ (global $~lib/memory/__stack_pointer (mut i32) (i32.const 33332))
+ (global $~lib/memory/__heap_base i32 (i32.const 33332))
  (memory $0 1)
  (data (i32.const 12) "<\00\00\00\00\00\00\00\00\00\00\00\02\00\00\00(\00\00\00A\00l\00l\00o\00c\00a\00t\00i\00o\00n\00 \00t\00o\00o\00 \00l\00a\00r\00g\00e\00\00\00\00\00")
  (data (i32.const 76) "<\00\00\00\00\00\00\00\00\00\00\00\02\00\00\00 \00\00\00~\00l\00i\00b\00/\00r\00t\00/\00i\00t\00c\00m\00s\00.\00t\00s\00\00\00\00\00\00\00\00\00\00\00\00\00")
@@ -60,7 +60,7 @@
  (data (i32.const 320) "\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00")
  (data (i32.const 348) "<\00\00\00\00\00\00\00\00\00\00\00\02\00\00\00\1e\00\00\00~\00l\00i\00b\00/\00r\00t\00/\00t\00l\00s\00f\00.\00t\00s\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00")
  (data (i32.const 412) ",\00\00\00\00\00\00\00\00\00\00\00\02\00\00\00\1a\00\00\00i\00n\00s\00t\00a\00n\00c\00e\00o\00f\00.\00t\00s\00\00\00")
- (data (i32.const 464) "\17\00\00\00 \00\00\00 \00\00\00 \00\00\00\00\00\00\00 \00\00\00 \00\00\00 \00\00\00 \00\00\00 \00\00\00 \00\00\00 \00\00\00 \00\00\00 \00\00\00 \00\00\00 \00\00\00 \00\00\00 \00\00\00 \00\00\00 \00\00\00 \00\00\00 \00\00\00 \00\00\00 \00\00\00")
+ (data (i32.const 464) "\18\00\00\00 \00\00\00 \00\00\00 \00\00\00\00\00\00\00 \00\00\00 \00\00\00 \00\00\00 \00\00\00 \00\00\00 \00\00\00 \00\00\00 \00\00\00 \00\00\00 \00\00\00 \00\00\00 \00\00\00 \00\00\00 \00\00\00 \00\00\00 \00\00\00 \00\00\00 \00\00\00 \00\00\00 \00\00\00")
  (table $0 1 1 funcref)
  (elem $0 (i32.const 1))
  (export "memory" (memory $0))
@@ -2258,6 +2258,9 @@
   local.get $ptr
   return
  )
+ (func $instanceof/A#checkInstanceof (param $this i32)
+  nop
+ )
  (func $instanceof/isI32<i32> (param $v i32) (result i32)
   i32.const 1
   drop
@@ -4134,7 +4137,7 @@
    i32.load $0
    local.set $1
    local.get $1
-   i32.const 8
+   i32.const 9
    i32.eq
    br_if $is_instance
    i32.const 0
@@ -4151,11 +4154,11 @@
    i32.load $0
    local.set $1
    local.get $1
-   i32.const 6
+   i32.const 7
    i32.eq
    br_if $is_instance
    local.get $1
-   i32.const 8
+   i32.const 9
    i32.eq
    br_if $is_instance
    i32.const 0
@@ -4172,11 +4175,11 @@
    i32.load $0
    local.set $1
    local.get $1
-   i32.const 12
+   i32.const 13
    i32.eq
    br_if $is_instance
    local.get $1
-   i32.const 13
+   i32.const 14
    i32.eq
    br_if $is_instance
    i32.const 0
@@ -4193,7 +4196,7 @@
    i32.load $0
    local.set $1
    local.get $1
-   i32.const 13
+   i32.const 14
    i32.eq
    br_if $is_instance
    i32.const 0
@@ -4210,7 +4213,7 @@
    i32.load $0
    local.set $1
    local.get $1
-   i32.const 14
+   i32.const 15
    i32.eq
    br_if $is_instance
    i32.const 0
@@ -4227,15 +4230,15 @@
    i32.load $0
    local.set $1
    local.get $1
-   i32.const 15
+   i32.const 16
    i32.eq
    br_if $is_instance
    local.get $1
-   i32.const 18
+   i32.const 19
    i32.eq
    br_if $is_instance
    local.get $1
-   i32.const 21
+   i32.const 22
    i32.eq
    br_if $is_instance
    i32.const 0
@@ -4252,11 +4255,11 @@
    i32.load $0
    local.set $1
    local.get $1
-   i32.const 18
+   i32.const 19
    i32.eq
    br_if $is_instance
    local.get $1
-   i32.const 21
+   i32.const 22
    i32.eq
    br_if $is_instance
    i32.const 0
@@ -4273,7 +4276,7 @@
    i32.load $0
    local.set $1
    local.get $1
-   i32.const 21
+   i32.const 22
    i32.eq
    br_if $is_instance
    i32.const 0
@@ -4290,15 +4293,15 @@
    i32.load $0
    local.set $1
    local.get $1
-   i32.const 15
+   i32.const 16
    i32.eq
    br_if $is_instance
    local.get $1
-   i32.const 18
+   i32.const 19
    i32.eq
    br_if $is_instance
    local.get $1
-   i32.const 21
+   i32.const 22
    i32.eq
    br_if $is_instance
    i32.const 0
@@ -4315,15 +4318,15 @@
    i32.load $0
    local.set $1
    local.get $1
-   i32.const 15
+   i32.const 16
    i32.eq
    br_if $is_instance
    local.get $1
-   i32.const 18
+   i32.const 19
    i32.eq
    br_if $is_instance
    local.get $1
-   i32.const 21
+   i32.const 22
    i32.eq
    br_if $is_instance
    i32.const 0
@@ -4340,11 +4343,11 @@
    i32.load $0
    local.set $1
    local.get $1
-   i32.const 18
+   i32.const 19
    i32.eq
    br_if $is_instance
    local.get $1
-   i32.const 21
+   i32.const 22
    i32.eq
    br_if $is_instance
    i32.const 0
@@ -4361,17 +4364,72 @@
    i32.load $0
    local.set $1
    local.get $1
-   i32.const 18
+   i32.const 19
    i32.eq
    br_if $is_instance
    local.get $1
-   i32.const 21
+   i32.const 22
    i32.eq
    br_if $is_instance
    i32.const 0
    return
   end
   i32.const 1
+ )
+ (func $~instanceof|instanceof/C (param $0 i32) (result i32)
+  unreachable
+ )
+ (func $instanceof/C#checkInstanceof (param $this i32)
+  (local $1 i32)
+  global.get $~lib/memory/__stack_pointer
+  i32.const 4
+  i32.sub
+  global.set $~lib/memory/__stack_pointer
+  call $~stack_check
+  global.get $~lib/memory/__stack_pointer
+  i32.const 0
+  i32.store $0
+  global.get $~lib/memory/__stack_pointer
+  global.get $instanceof/a
+  local.tee $1
+  i32.store $0
+  local.get $1
+  i32.eqz
+  if (result i32)
+   i32.const 0
+  else
+   local.get $1
+   call $~instanceof|instanceof/C
+  end
+  if
+   nop
+  end
+  global.get $~lib/memory/__stack_pointer
+  i32.const 4
+  i32.add
+  global.set $~lib/memory/__stack_pointer
+ )
+ (func $instanceof/A#checkInstanceof@override (param $0 i32)
+  (local $1 i32)
+  block $default
+   block $case0
+    local.get $0
+    i32.const 8
+    i32.sub
+    i32.load $0
+    local.set $1
+    local.get $1
+    i32.const 6
+    i32.eq
+    br_if $case0
+    br $default
+   end
+   local.get $0
+   call $instanceof/C#checkInstanceof
+   return
+  end
+  local.get $0
+  call $instanceof/A#checkInstanceof
  )
  (func $~lib/rt/__visit_globals (param $0 i32)
   (local $1 i32)
@@ -4544,27 +4602,30 @@
                  block $instanceof/Child<f32>
                   block $instanceof/Parent<i32>
                    block $instanceof/Child<i32>
-                    block $instanceof/B
-                     block $instanceof/A
-                      block $~lib/arraybuffer/ArrayBufferView
-                       block $~lib/string/String
-                        block $~lib/arraybuffer/ArrayBuffer
-                         block $~lib/object/Object
-                          local.get $0
-                          i32.const 8
-                          i32.sub
-                          i32.load $0
-                          br_table $~lib/object/Object $~lib/arraybuffer/ArrayBuffer $~lib/string/String $~lib/arraybuffer/ArrayBufferView $instanceof/A $instanceof/B $instanceof/Child<i32> $instanceof/Parent<i32> $instanceof/Child<f32> $instanceof/Parent<f32> $instanceof/SomethingElse<i32> $instanceof/Animal $instanceof/Cat $instanceof/BlackCat $instanceof/W $instanceof/X $instanceof/IB $instanceof/IA $instanceof/Y $instanceof/ID $instanceof/IC $instanceof/Z $instanceof/IE $invalid
+                    block $instanceof/C
+                     block $instanceof/B
+                      block $instanceof/A
+                       block $~lib/arraybuffer/ArrayBufferView
+                        block $~lib/string/String
+                         block $~lib/arraybuffer/ArrayBuffer
+                          block $~lib/object/Object
+                           local.get $0
+                           i32.const 8
+                           i32.sub
+                           i32.load $0
+                           br_table $~lib/object/Object $~lib/arraybuffer/ArrayBuffer $~lib/string/String $~lib/arraybuffer/ArrayBufferView $instanceof/A $instanceof/B $instanceof/C $instanceof/Child<i32> $instanceof/Parent<i32> $instanceof/Child<f32> $instanceof/Parent<f32> $instanceof/SomethingElse<i32> $instanceof/Animal $instanceof/Cat $instanceof/BlackCat $instanceof/W $instanceof/X $instanceof/IB $instanceof/IA $instanceof/Y $instanceof/ID $instanceof/IC $instanceof/Z $instanceof/IE $invalid
+                          end
+                          return
                          end
                          return
                         end
                         return
                        end
+                       local.get $0
+                       local.get $1
+                       call $~lib/arraybuffer/ArrayBufferView~visit
                        return
                       end
-                      local.get $0
-                      local.get $1
-                      call $~lib/arraybuffer/ArrayBufferView~visit
                       return
                      end
                      return
@@ -4699,6 +4760,44 @@
   global.set $~lib/memory/__stack_pointer
   local.get $1
  )
+ (func $instanceof/C#constructor (param $this i32) (result i32)
+  (local $1 i32)
+  global.get $~lib/memory/__stack_pointer
+  i32.const 8
+  i32.sub
+  global.set $~lib/memory/__stack_pointer
+  call $~stack_check
+  global.get $~lib/memory/__stack_pointer
+  i64.const 0
+  i64.store $0
+  local.get $this
+  i32.eqz
+  if
+   global.get $~lib/memory/__stack_pointer
+   i32.const 0
+   i32.const 6
+   call $~lib/rt/itcms/__new
+   local.tee $this
+   i32.store $0
+  end
+  global.get $~lib/memory/__stack_pointer
+  local.get $this
+  local.set $1
+  global.get $~lib/memory/__stack_pointer
+  local.get $1
+  i32.store $0 offset=4
+  local.get $1
+  call $instanceof/A#constructor
+  local.tee $this
+  i32.store $0
+  local.get $this
+  local.set $1
+  global.get $~lib/memory/__stack_pointer
+  i32.const 8
+  i32.add
+  global.set $~lib/memory/__stack_pointer
+  local.get $1
+ )
  (func $instanceof/Parent<i32>#constructor (param $this i32) (result i32)
   (local $1 i32)
   global.get $~lib/memory/__stack_pointer
@@ -4714,7 +4813,7 @@
   if
    global.get $~lib/memory/__stack_pointer
    i32.const 0
-   i32.const 7
+   i32.const 8
    call $~lib/rt/itcms/__new
    local.tee $this
    i32.store $0
@@ -4752,7 +4851,7 @@
   if
    global.get $~lib/memory/__stack_pointer
    i32.const 0
-   i32.const 6
+   i32.const 7
    call $~lib/rt/itcms/__new
    local.tee $this
    i32.store $0
@@ -4790,7 +4889,7 @@
   if
    global.get $~lib/memory/__stack_pointer
    i32.const 0
-   i32.const 9
+   i32.const 10
    call $~lib/rt/itcms/__new
    local.tee $this
    i32.store $0
@@ -4828,7 +4927,7 @@
   if
    global.get $~lib/memory/__stack_pointer
    i32.const 0
-   i32.const 8
+   i32.const 9
    call $~lib/rt/itcms/__new
    local.tee $this
    i32.store $0
@@ -4866,7 +4965,7 @@
   if
    global.get $~lib/memory/__stack_pointer
    i32.const 0
-   i32.const 11
+   i32.const 12
    call $~lib/rt/itcms/__new
    local.tee $this
    i32.store $0
@@ -4904,7 +5003,7 @@
   if
    global.get $~lib/memory/__stack_pointer
    i32.const 0
-   i32.const 12
+   i32.const 13
    call $~lib/rt/itcms/__new
    local.tee $this
    i32.store $0
@@ -4942,7 +5041,7 @@
   if
    global.get $~lib/memory/__stack_pointer
    i32.const 0
-   i32.const 13
+   i32.const 14
    call $~lib/rt/itcms/__new
    local.tee $this
    i32.store $0
@@ -4980,7 +5079,7 @@
   if
    global.get $~lib/memory/__stack_pointer
    i32.const 0
-   i32.const 14
+   i32.const 15
    call $~lib/rt/itcms/__new
    local.tee $this
    i32.store $0
@@ -5018,7 +5117,7 @@
   if
    global.get $~lib/memory/__stack_pointer
    i32.const 0
-   i32.const 15
+   i32.const 16
    call $~lib/rt/itcms/__new
    local.tee $this
    i32.store $0
@@ -5056,7 +5155,7 @@
   if
    global.get $~lib/memory/__stack_pointer
    i32.const 0
-   i32.const 18
+   i32.const 19
    call $~lib/rt/itcms/__new
    local.tee $this
    i32.store $0
@@ -5094,7 +5193,7 @@
   if
    global.get $~lib/memory/__stack_pointer
    i32.const 0
-   i32.const 21
+   i32.const 22
    call $~lib/rt/itcms/__new
    local.tee $this
    i32.store $0
@@ -5172,6 +5271,14 @@
   i32.const 0
   call $instanceof/B#constructor
   global.set $instanceof/b
+  i32.const 0
+  call $instanceof/C#constructor
+  local.set $21
+  global.get $~lib/memory/__stack_pointer
+  local.get $21
+  i32.store $0
+  local.get $21
+  call $instanceof/A#checkInstanceof@override
   i32.const 1
   drop
   i32.const 1
@@ -5191,7 +5298,7 @@
   global.get $~lib/memory/__stack_pointer
   global.get $instanceof/a
   local.tee $0
-  i32.store $0
+  i32.store $0 offset=4
   local.get $0
   i32.eqz
   if (result i32)
@@ -5205,7 +5312,7 @@
   if
    i32.const 0
    i32.const 432
-   i32.const 41
+   i32.const 50
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -5298,7 +5405,7 @@
   if
    i32.const 0
    i32.const 432
-   i32.const 85
+   i32.const 94
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -5310,7 +5417,7 @@
   if
    i32.const 0
    i32.const 432
-   i32.const 86
+   i32.const 95
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -5322,7 +5429,7 @@
   if
    i32.const 0
    i32.const 432
-   i32.const 87
+   i32.const 96
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -5334,7 +5441,7 @@
   if
    i32.const 0
    i32.const 432
-   i32.const 88
+   i32.const 97
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -5347,7 +5454,7 @@
   if
    i32.const 0
    i32.const 432
-   i32.const 91
+   i32.const 100
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -5363,7 +5470,7 @@
   if
    i32.const 0
    i32.const 432
-   i32.const 94
+   i32.const 103
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -5406,7 +5513,7 @@
   global.get $~lib/memory/__stack_pointer
   global.get $instanceof/childAsParent
   local.tee $1
-  i32.store $0 offset=4
+  i32.store $0 offset=8
   local.get $1
   i32.eqz
   if (result i32)
@@ -5419,7 +5526,7 @@
   if
    i32.const 0
    i32.const 432
-   i32.const 117
+   i32.const 126
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -5430,7 +5537,7 @@
   global.get $~lib/memory/__stack_pointer
   global.get $instanceof/childAsParent
   local.tee $2
-  i32.store $0 offset=8
+  i32.store $0 offset=12
   local.get $2
   i32.eqz
   if (result i32)
@@ -5443,7 +5550,7 @@
   if
    i32.const 0
    i32.const 432
-   i32.const 119
+   i32.const 128
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -5468,7 +5575,7 @@
   global.get $~lib/memory/__stack_pointer
   global.get $instanceof/animal
   local.tee $3
-  i32.store $0 offset=12
+  i32.store $0 offset=16
   local.get $3
   i32.eqz
   if (result i32)
@@ -5482,7 +5589,7 @@
   if
    i32.const 0
    i32.const 432
-   i32.const 134
+   i32.const 143
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -5490,7 +5597,7 @@
   global.get $~lib/memory/__stack_pointer
   global.get $instanceof/animal
   local.tee $4
-  i32.store $0 offset=16
+  i32.store $0 offset=20
   local.get $4
   i32.eqz
   if (result i32)
@@ -5504,7 +5611,7 @@
   if
    i32.const 0
    i32.const 432
-   i32.const 135
+   i32.const 144
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -5514,7 +5621,7 @@
   global.get $~lib/memory/__stack_pointer
   global.get $instanceof/cat
   local.tee $5
-  i32.store $0 offset=20
+  i32.store $0 offset=24
   local.get $5
   i32.eqz
   if (result i32)
@@ -5527,7 +5634,7 @@
   if
    i32.const 0
    i32.const 432
-   i32.const 138
+   i32.const 147
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -5535,7 +5642,7 @@
   global.get $~lib/memory/__stack_pointer
   global.get $instanceof/cat
   local.tee $6
-  i32.store $0 offset=24
+  i32.store $0 offset=28
   local.get $6
   i32.eqz
   if (result i32)
@@ -5549,7 +5656,7 @@
   if
    i32.const 0
    i32.const 432
-   i32.const 139
+   i32.const 148
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -5559,7 +5666,7 @@
   global.get $~lib/memory/__stack_pointer
   global.get $instanceof/blackcat
   local.tee $7
-  i32.store $0 offset=28
+  i32.store $0 offset=32
   local.get $7
   i32.eqz
   if (result i32)
@@ -5572,7 +5679,7 @@
   if
    i32.const 0
    i32.const 432
-   i32.const 142
+   i32.const 151
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -5580,7 +5687,7 @@
   global.get $~lib/memory/__stack_pointer
   global.get $instanceof/blackcat
   local.tee $8
-  i32.store $0 offset=32
+  i32.store $0 offset=36
   local.get $8
   i32.eqz
   if (result i32)
@@ -5593,7 +5700,7 @@
   if
    i32.const 0
    i32.const 432
-   i32.const 143
+   i32.const 152
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -5614,7 +5721,7 @@
   if
    i32.const 0
    i32.const 432
-   i32.const 149
+   i32.const 158
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -5622,7 +5729,7 @@
   global.get $~lib/memory/__stack_pointer
   global.get $instanceof/nullableAnimal
   local.tee $9
-  i32.store $0 offset=36
+  i32.store $0 offset=40
   local.get $9
   i32.eqz
   if (result i32)
@@ -5636,7 +5743,7 @@
   if
    i32.const 0
    i32.const 432
-   i32.const 150
+   i32.const 159
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -5644,7 +5751,7 @@
   global.get $~lib/memory/__stack_pointer
   global.get $instanceof/nullableAnimal
   local.tee $10
-  i32.store $0 offset=40
+  i32.store $0 offset=44
   local.get $10
   i32.eqz
   if (result i32)
@@ -5658,7 +5765,7 @@
   if
    i32.const 0
    i32.const 432
-   i32.const 151
+   i32.const 160
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -5670,7 +5777,7 @@
   if
    i32.const 0
    i32.const 432
-   i32.const 153
+   i32.const 162
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -5678,7 +5785,7 @@
   global.get $~lib/memory/__stack_pointer
   global.get $instanceof/nullableCat
   local.tee $11
-  i32.store $0 offset=44
+  i32.store $0 offset=48
   local.get $11
   i32.eqz
   if (result i32)
@@ -5691,7 +5798,7 @@
   if
    i32.const 0
    i32.const 432
-   i32.const 154
+   i32.const 163
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -5699,7 +5806,7 @@
   global.get $~lib/memory/__stack_pointer
   global.get $instanceof/nullableCat
   local.tee $12
-  i32.store $0 offset=48
+  i32.store $0 offset=52
   local.get $12
   i32.eqz
   if (result i32)
@@ -5713,7 +5820,7 @@
   if
    i32.const 0
    i32.const 432
-   i32.const 155
+   i32.const 164
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -5725,7 +5832,7 @@
   if
    i32.const 0
    i32.const 432
-   i32.const 157
+   i32.const 166
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -5733,7 +5840,7 @@
   global.get $~lib/memory/__stack_pointer
   global.get $instanceof/nullableBlackcat
   local.tee $13
-  i32.store $0 offset=52
+  i32.store $0 offset=56
   local.get $13
   i32.eqz
   if (result i32)
@@ -5746,7 +5853,7 @@
   if
    i32.const 0
    i32.const 432
-   i32.const 158
+   i32.const 167
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -5754,7 +5861,7 @@
   global.get $~lib/memory/__stack_pointer
   global.get $instanceof/nullableBlackcat
   local.tee $14
-  i32.store $0 offset=56
+  i32.store $0 offset=60
   local.get $14
   i32.eqz
   if (result i32)
@@ -5767,7 +5874,7 @@
   if
    i32.const 0
    i32.const 432
-   i32.const 159
+   i32.const 168
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -5780,7 +5887,7 @@
   if
    i32.const 0
    i32.const 432
-   i32.const 165
+   i32.const 174
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -5788,7 +5895,7 @@
   global.get $~lib/memory/__stack_pointer
   global.get $instanceof/nullAnimal
   local.tee $15
-  i32.store $0 offset=60
+  i32.store $0 offset=64
   local.get $15
   i32.eqz
   if (result i32)
@@ -5802,7 +5909,7 @@
   if
    i32.const 0
    i32.const 432
-   i32.const 166
+   i32.const 175
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -5810,7 +5917,7 @@
   global.get $~lib/memory/__stack_pointer
   global.get $instanceof/nullAnimal
   local.tee $16
-  i32.store $0 offset=64
+  i32.store $0 offset=68
   local.get $16
   i32.eqz
   if (result i32)
@@ -5824,7 +5931,7 @@
   if
    i32.const 0
    i32.const 432
-   i32.const 167
+   i32.const 176
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -5837,7 +5944,7 @@
   if
    i32.const 0
    i32.const 432
-   i32.const 169
+   i32.const 178
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -5845,7 +5952,7 @@
   global.get $~lib/memory/__stack_pointer
   global.get $instanceof/nullCat
   local.tee $17
-  i32.store $0 offset=68
+  i32.store $0 offset=72
   local.get $17
   i32.eqz
   if (result i32)
@@ -5859,7 +5966,7 @@
   if
    i32.const 0
    i32.const 432
-   i32.const 170
+   i32.const 179
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -5867,7 +5974,7 @@
   global.get $~lib/memory/__stack_pointer
   global.get $instanceof/nullCat
   local.tee $18
-  i32.store $0 offset=72
+  i32.store $0 offset=76
   local.get $18
   i32.eqz
   if (result i32)
@@ -5881,7 +5988,7 @@
   if
    i32.const 0
    i32.const 432
-   i32.const 171
+   i32.const 180
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -5894,7 +6001,7 @@
   if
    i32.const 0
    i32.const 432
-   i32.const 173
+   i32.const 182
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -5902,7 +6009,7 @@
   global.get $~lib/memory/__stack_pointer
   global.get $instanceof/nullBlackcat
   local.tee $19
-  i32.store $0 offset=76
+  i32.store $0 offset=80
   local.get $19
   i32.eqz
   if (result i32)
@@ -5916,7 +6023,7 @@
   if
    i32.const 0
    i32.const 432
-   i32.const 174
+   i32.const 183
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -5924,7 +6031,7 @@
   global.get $~lib/memory/__stack_pointer
   global.get $instanceof/nullBlackcat
   local.tee $20
-  i32.store $0 offset=80
+  i32.store $0 offset=84
   local.get $20
   i32.eqz
   if (result i32)
@@ -5938,7 +6045,7 @@
   if
    i32.const 0
    i32.const 432
-   i32.const 175
+   i32.const 184
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -5959,924 +6066,924 @@
   local.set $21
   global.get $~lib/memory/__stack_pointer
   local.get $21
-  i32.store $0 offset=84
+  i32.store $0
   local.get $21
   call $instanceof/assertStaticTrue<instanceof/W,~lib/object/Object>
   global.get $instanceof/x
   local.set $21
   global.get $~lib/memory/__stack_pointer
   local.get $21
-  i32.store $0 offset=84
+  i32.store $0
   local.get $21
   call $instanceof/assertStaticTrue<instanceof/X,~lib/object/Object>
   global.get $instanceof/y
   local.set $21
   global.get $~lib/memory/__stack_pointer
   local.get $21
-  i32.store $0 offset=84
+  i32.store $0
   local.get $21
   call $instanceof/assertStaticTrue<instanceof/Y,~lib/object/Object>
   global.get $instanceof/z
   local.set $21
   global.get $~lib/memory/__stack_pointer
   local.get $21
-  i32.store $0 offset=84
+  i32.store $0
   local.get $21
   call $instanceof/assertStaticTrue<instanceof/Z,~lib/object/Object>
   global.get $instanceof/x
   local.set $21
   global.get $~lib/memory/__stack_pointer
   local.get $21
-  i32.store $0 offset=84
+  i32.store $0
   local.get $21
   call $instanceof/assertStaticTrue<instanceof/IA,~lib/object/Object>
   global.get $instanceof/x
   local.set $21
   global.get $~lib/memory/__stack_pointer
   local.get $21
-  i32.store $0 offset=84
+  i32.store $0
   local.get $21
   call $instanceof/assertStaticTrue<instanceof/IB,~lib/object/Object>
   global.get $instanceof/y
   local.set $21
   global.get $~lib/memory/__stack_pointer
   local.get $21
-  i32.store $0 offset=84
+  i32.store $0
   local.get $21
   call $instanceof/assertStaticTrue<instanceof/IA,~lib/object/Object>
   global.get $instanceof/y
   local.set $21
   global.get $~lib/memory/__stack_pointer
   local.get $21
-  i32.store $0 offset=84
+  i32.store $0
   local.get $21
   call $instanceof/assertStaticTrue<instanceof/IB,~lib/object/Object>
   global.get $instanceof/y
   local.set $21
   global.get $~lib/memory/__stack_pointer
   local.get $21
-  i32.store $0 offset=84
+  i32.store $0
   local.get $21
   call $instanceof/assertStaticTrue<instanceof/IC,~lib/object/Object>
   global.get $instanceof/y
   local.set $21
   global.get $~lib/memory/__stack_pointer
   local.get $21
-  i32.store $0 offset=84
+  i32.store $0
   local.get $21
   call $instanceof/assertStaticTrue<instanceof/ID,~lib/object/Object>
   global.get $instanceof/z
   local.set $21
   global.get $~lib/memory/__stack_pointer
   local.get $21
-  i32.store $0 offset=84
+  i32.store $0
   local.get $21
   call $instanceof/assertStaticTrue<instanceof/IA,~lib/object/Object>
   global.get $instanceof/z
   local.set $21
   global.get $~lib/memory/__stack_pointer
   local.get $21
-  i32.store $0 offset=84
+  i32.store $0
   local.get $21
   call $instanceof/assertStaticTrue<instanceof/IB,~lib/object/Object>
   global.get $instanceof/z
   local.set $21
   global.get $~lib/memory/__stack_pointer
   local.get $21
-  i32.store $0 offset=84
+  i32.store $0
   local.get $21
   call $instanceof/assertStaticTrue<instanceof/IC,~lib/object/Object>
   global.get $instanceof/z
   local.set $21
   global.get $~lib/memory/__stack_pointer
   local.get $21
-  i32.store $0 offset=84
+  i32.store $0
   local.get $21
   call $instanceof/assertStaticTrue<instanceof/ID,~lib/object/Object>
   global.get $instanceof/w
   local.set $21
   global.get $~lib/memory/__stack_pointer
   local.get $21
-  i32.store $0 offset=84
+  i32.store $0
   local.get $21
   call $instanceof/assertDynamicTrue<~lib/object/Object,instanceof/W>
   global.get $instanceof/x
   local.set $21
   global.get $~lib/memory/__stack_pointer
   local.get $21
-  i32.store $0 offset=84
+  i32.store $0
   local.get $21
   call $instanceof/assertDynamicTrue<~lib/object/Object,instanceof/X>
   global.get $instanceof/y
   local.set $21
   global.get $~lib/memory/__stack_pointer
   local.get $21
-  i32.store $0 offset=84
+  i32.store $0
   local.get $21
   call $instanceof/assertDynamicTrue<~lib/object/Object,instanceof/X>
   global.get $instanceof/z
   local.set $21
   global.get $~lib/memory/__stack_pointer
   local.get $21
-  i32.store $0 offset=84
+  i32.store $0
   local.get $21
   call $instanceof/assertDynamicTrue<~lib/object/Object,instanceof/X>
   global.get $instanceof/y
   local.set $21
   global.get $~lib/memory/__stack_pointer
   local.get $21
-  i32.store $0 offset=84
+  i32.store $0
   local.get $21
   call $instanceof/assertDynamicTrue<~lib/object/Object,instanceof/Y>
   global.get $instanceof/z
   local.set $21
   global.get $~lib/memory/__stack_pointer
   local.get $21
-  i32.store $0 offset=84
+  i32.store $0
   local.get $21
   call $instanceof/assertDynamicTrue<~lib/object/Object,instanceof/Y>
   global.get $instanceof/z
   local.set $21
   global.get $~lib/memory/__stack_pointer
   local.get $21
-  i32.store $0 offset=84
+  i32.store $0
   local.get $21
   call $instanceof/assertDynamicTrue<~lib/object/Object,instanceof/Z>
   global.get $instanceof/x
   local.set $21
   global.get $~lib/memory/__stack_pointer
   local.get $21
-  i32.store $0 offset=84
+  i32.store $0
   local.get $21
   call $instanceof/assertDynamicTrue<~lib/object/Object,instanceof/IA>
   global.get $instanceof/x
   local.set $21
   global.get $~lib/memory/__stack_pointer
   local.get $21
-  i32.store $0 offset=84
+  i32.store $0
   local.get $21
   call $instanceof/assertDynamicTrue<~lib/object/Object,instanceof/IB>
   global.get $instanceof/y
   local.set $21
   global.get $~lib/memory/__stack_pointer
   local.get $21
-  i32.store $0 offset=84
+  i32.store $0
   local.get $21
   call $instanceof/assertDynamicTrue<~lib/object/Object,instanceof/IA>
   global.get $instanceof/y
   local.set $21
   global.get $~lib/memory/__stack_pointer
   local.get $21
-  i32.store $0 offset=84
+  i32.store $0
   local.get $21
   call $instanceof/assertDynamicTrue<~lib/object/Object,instanceof/IB>
   global.get $instanceof/y
   local.set $21
   global.get $~lib/memory/__stack_pointer
   local.get $21
-  i32.store $0 offset=84
+  i32.store $0
   local.get $21
   call $instanceof/assertDynamicTrue<~lib/object/Object,instanceof/IC>
   global.get $instanceof/y
   local.set $21
   global.get $~lib/memory/__stack_pointer
   local.get $21
-  i32.store $0 offset=84
+  i32.store $0
   local.get $21
   call $instanceof/assertDynamicTrue<~lib/object/Object,instanceof/ID>
   global.get $instanceof/z
   local.set $21
   global.get $~lib/memory/__stack_pointer
   local.get $21
-  i32.store $0 offset=84
+  i32.store $0
   local.get $21
   call $instanceof/assertDynamicTrue<~lib/object/Object,instanceof/IA>
   global.get $instanceof/z
   local.set $21
   global.get $~lib/memory/__stack_pointer
   local.get $21
-  i32.store $0 offset=84
+  i32.store $0
   local.get $21
   call $instanceof/assertDynamicTrue<~lib/object/Object,instanceof/IB>
   global.get $instanceof/z
   local.set $21
   global.get $~lib/memory/__stack_pointer
   local.get $21
-  i32.store $0 offset=84
+  i32.store $0
   local.get $21
   call $instanceof/assertDynamicTrue<~lib/object/Object,instanceof/IC>
   global.get $instanceof/z
   local.set $21
   global.get $~lib/memory/__stack_pointer
   local.get $21
-  i32.store $0 offset=84
+  i32.store $0
   local.get $21
   call $instanceof/assertDynamicTrue<~lib/object/Object,instanceof/ID>
   global.get $instanceof/w
   local.set $21
   global.get $~lib/memory/__stack_pointer
   local.get $21
-  i32.store $0 offset=84
+  i32.store $0
   local.get $21
   call $instanceof/assertStaticTrue<instanceof/W,instanceof/W>
   global.get $instanceof/w
   local.set $21
   global.get $~lib/memory/__stack_pointer
   local.get $21
-  i32.store $0 offset=84
+  i32.store $0
   local.get $21
   call $instanceof/assertStaticFalse<instanceof/W,instanceof/X>
   global.get $instanceof/w
   local.set $21
   global.get $~lib/memory/__stack_pointer
   local.get $21
-  i32.store $0 offset=84
+  i32.store $0
   local.get $21
   call $instanceof/assertStaticFalse<instanceof/W,instanceof/Y>
   global.get $instanceof/w
   local.set $21
   global.get $~lib/memory/__stack_pointer
   local.get $21
-  i32.store $0 offset=84
+  i32.store $0
   local.get $21
   call $instanceof/assertStaticFalse<instanceof/W,instanceof/Z>
   global.get $instanceof/x
   local.set $21
   global.get $~lib/memory/__stack_pointer
   local.get $21
-  i32.store $0 offset=84
+  i32.store $0
   local.get $21
   call $instanceof/assertStaticFalse<instanceof/X,instanceof/W>
   global.get $instanceof/y
   local.set $21
   global.get $~lib/memory/__stack_pointer
   local.get $21
-  i32.store $0 offset=84
+  i32.store $0
   local.get $21
   call $instanceof/assertStaticFalse<instanceof/Y,instanceof/W>
   global.get $instanceof/z
   local.set $21
   global.get $~lib/memory/__stack_pointer
   local.get $21
-  i32.store $0 offset=84
+  i32.store $0
   local.get $21
   call $instanceof/assertStaticFalse<instanceof/Z,instanceof/W>
   global.get $instanceof/x
   local.set $21
   global.get $~lib/memory/__stack_pointer
   local.get $21
-  i32.store $0 offset=84
+  i32.store $0
   local.get $21
   call $instanceof/assertStaticTrue<instanceof/X,instanceof/X>
   global.get $instanceof/x
   local.set $21
   global.get $~lib/memory/__stack_pointer
   local.get $21
-  i32.store $0 offset=84
+  i32.store $0
   local.get $21
   call $instanceof/assertDynamicFalse<instanceof/X,instanceof/Y>
   global.get $instanceof/x
   local.set $21
   global.get $~lib/memory/__stack_pointer
   local.get $21
-  i32.store $0 offset=84
+  i32.store $0
   local.get $21
   call $instanceof/assertDynamicFalse<instanceof/X,instanceof/Z>
   global.get $instanceof/y
   local.set $21
   global.get $~lib/memory/__stack_pointer
   local.get $21
-  i32.store $0 offset=84
+  i32.store $0
   local.get $21
   call $instanceof/assertStaticTrue<instanceof/X,instanceof/X>
   global.get $instanceof/y
   local.set $21
   global.get $~lib/memory/__stack_pointer
   local.get $21
-  i32.store $0 offset=84
+  i32.store $0
   local.get $21
   call $instanceof/assertDynamicTrue<instanceof/X,instanceof/Y>
   global.get $instanceof/y
   local.set $21
   global.get $~lib/memory/__stack_pointer
   local.get $21
-  i32.store $0 offset=84
+  i32.store $0
   local.get $21
   call $instanceof/assertDynamicFalse<instanceof/X,instanceof/Z>
   global.get $instanceof/z
   local.set $21
   global.get $~lib/memory/__stack_pointer
   local.get $21
-  i32.store $0 offset=84
+  i32.store $0
   local.get $21
   call $instanceof/assertStaticTrue<instanceof/X,instanceof/X>
   global.get $instanceof/z
   local.set $21
   global.get $~lib/memory/__stack_pointer
   local.get $21
-  i32.store $0 offset=84
+  i32.store $0
   local.get $21
   call $instanceof/assertDynamicTrue<instanceof/X,instanceof/Y>
   global.get $instanceof/z
   local.set $21
   global.get $~lib/memory/__stack_pointer
   local.get $21
-  i32.store $0 offset=84
+  i32.store $0
   local.get $21
   call $instanceof/assertDynamicTrue<instanceof/X,instanceof/Z>
   global.get $instanceof/y
   local.set $21
   global.get $~lib/memory/__stack_pointer
   local.get $21
-  i32.store $0 offset=84
+  i32.store $0
   local.get $21
   call $instanceof/assertStaticTrue<instanceof/Y,instanceof/X>
   global.get $instanceof/y
   local.set $21
   global.get $~lib/memory/__stack_pointer
   local.get $21
-  i32.store $0 offset=84
+  i32.store $0
   local.get $21
   call $instanceof/assertStaticTrue<instanceof/Y,instanceof/Y>
   global.get $instanceof/y
   local.set $21
   global.get $~lib/memory/__stack_pointer
   local.get $21
-  i32.store $0 offset=84
+  i32.store $0
   local.get $21
   call $instanceof/assertDynamicFalse<instanceof/Y,instanceof/Z>
   global.get $instanceof/z
   local.set $21
   global.get $~lib/memory/__stack_pointer
   local.get $21
-  i32.store $0 offset=84
+  i32.store $0
   local.get $21
   call $instanceof/assertStaticTrue<instanceof/Y,instanceof/X>
   global.get $instanceof/z
   local.set $21
   global.get $~lib/memory/__stack_pointer
   local.get $21
-  i32.store $0 offset=84
+  i32.store $0
   local.get $21
   call $instanceof/assertStaticTrue<instanceof/Y,instanceof/Y>
   global.get $instanceof/z
   local.set $21
   global.get $~lib/memory/__stack_pointer
   local.get $21
-  i32.store $0 offset=84
+  i32.store $0
   local.get $21
   call $instanceof/assertDynamicTrue<instanceof/Y,instanceof/Z>
   global.get $instanceof/z
   local.set $21
   global.get $~lib/memory/__stack_pointer
   local.get $21
-  i32.store $0 offset=84
+  i32.store $0
   local.get $21
   call $instanceof/assertStaticTrue<instanceof/Z,instanceof/X>
   global.get $instanceof/z
   local.set $21
   global.get $~lib/memory/__stack_pointer
   local.get $21
-  i32.store $0 offset=84
+  i32.store $0
   local.get $21
   call $instanceof/assertStaticTrue<instanceof/Z,instanceof/Y>
   global.get $instanceof/z
   local.set $21
   global.get $~lib/memory/__stack_pointer
   local.get $21
-  i32.store $0 offset=84
+  i32.store $0
   local.get $21
   call $instanceof/assertStaticTrue<instanceof/Z,instanceof/Z>
   global.get $instanceof/x
   local.set $21
   global.get $~lib/memory/__stack_pointer
   local.get $21
-  i32.store $0 offset=84
+  i32.store $0
   local.get $21
   call $instanceof/assertDynamicFalse<instanceof/IA,instanceof/IC>
   global.get $instanceof/x
   local.set $21
   global.get $~lib/memory/__stack_pointer
   local.get $21
-  i32.store $0 offset=84
+  i32.store $0
   local.get $21
   call $instanceof/assertDynamicFalse<instanceof/IB,instanceof/IC>
   global.get $instanceof/x
   local.set $21
   global.get $~lib/memory/__stack_pointer
   local.get $21
-  i32.store $0 offset=84
+  i32.store $0
   local.get $21
   call $instanceof/assertDynamicFalse<instanceof/IA,instanceof/ID>
   global.get $instanceof/x
   local.set $21
   global.get $~lib/memory/__stack_pointer
   local.get $21
-  i32.store $0 offset=84
+  i32.store $0
   local.get $21
   call $instanceof/assertDynamicFalse<instanceof/IB,instanceof/ID>
   global.get $instanceof/x
   local.set $21
   global.get $~lib/memory/__stack_pointer
   local.get $21
-  i32.store $0 offset=84
+  i32.store $0
   local.get $21
   call $instanceof/assertStaticFalse<instanceof/IA,instanceof/IE>
   global.get $instanceof/x
   local.set $21
   global.get $~lib/memory/__stack_pointer
   local.get $21
-  i32.store $0 offset=84
+  i32.store $0
   local.get $21
   call $instanceof/assertStaticFalse<instanceof/IB,instanceof/IE>
   global.get $instanceof/y
   local.set $21
   global.get $~lib/memory/__stack_pointer
   local.get $21
-  i32.store $0 offset=84
+  i32.store $0
   local.get $21
   call $instanceof/assertDynamicTrue<instanceof/IA,instanceof/IC>
   global.get $instanceof/y
   local.set $21
   global.get $~lib/memory/__stack_pointer
   local.get $21
-  i32.store $0 offset=84
+  i32.store $0
   local.get $21
   call $instanceof/assertDynamicTrue<instanceof/IB,instanceof/IC>
   global.get $instanceof/y
   local.set $21
   global.get $~lib/memory/__stack_pointer
   local.get $21
-  i32.store $0 offset=84
+  i32.store $0
   local.get $21
   call $instanceof/assertDynamicTrue<instanceof/IA,instanceof/ID>
   global.get $instanceof/y
   local.set $21
   global.get $~lib/memory/__stack_pointer
   local.get $21
-  i32.store $0 offset=84
+  i32.store $0
   local.get $21
   call $instanceof/assertDynamicTrue<instanceof/IB,instanceof/ID>
   global.get $instanceof/y
   local.set $21
   global.get $~lib/memory/__stack_pointer
   local.get $21
-  i32.store $0 offset=84
+  i32.store $0
   local.get $21
   call $instanceof/assertStaticFalse<instanceof/IA,instanceof/IE>
   global.get $instanceof/y
   local.set $21
   global.get $~lib/memory/__stack_pointer
   local.get $21
-  i32.store $0 offset=84
+  i32.store $0
   local.get $21
   call $instanceof/assertStaticFalse<instanceof/IB,instanceof/IE>
   global.get $instanceof/z
   local.set $21
   global.get $~lib/memory/__stack_pointer
   local.get $21
-  i32.store $0 offset=84
+  i32.store $0
   local.get $21
   call $instanceof/assertDynamicTrue<instanceof/IA,instanceof/IC>
   global.get $instanceof/z
   local.set $21
   global.get $~lib/memory/__stack_pointer
   local.get $21
-  i32.store $0 offset=84
+  i32.store $0
   local.get $21
   call $instanceof/assertDynamicTrue<instanceof/IB,instanceof/IC>
   global.get $instanceof/z
   local.set $21
   global.get $~lib/memory/__stack_pointer
   local.get $21
-  i32.store $0 offset=84
+  i32.store $0
   local.get $21
   call $instanceof/assertDynamicTrue<instanceof/IA,instanceof/ID>
   global.get $instanceof/z
   local.set $21
   global.get $~lib/memory/__stack_pointer
   local.get $21
-  i32.store $0 offset=84
+  i32.store $0
   local.get $21
   call $instanceof/assertDynamicTrue<instanceof/IB,instanceof/ID>
   global.get $instanceof/z
   local.set $21
   global.get $~lib/memory/__stack_pointer
   local.get $21
-  i32.store $0 offset=84
+  i32.store $0
   local.get $21
   call $instanceof/assertStaticFalse<instanceof/IA,instanceof/IE>
   global.get $instanceof/z
   local.set $21
   global.get $~lib/memory/__stack_pointer
   local.get $21
-  i32.store $0 offset=84
+  i32.store $0
   local.get $21
   call $instanceof/assertStaticFalse<instanceof/IB,instanceof/IE>
   global.get $instanceof/x
   local.set $21
   global.get $~lib/memory/__stack_pointer
   local.get $21
-  i32.store $0 offset=84
+  i32.store $0
   local.get $21
   call $instanceof/assertStaticTrue<instanceof/X,instanceof/IA>
   global.get $instanceof/x
   local.set $21
   global.get $~lib/memory/__stack_pointer
   local.get $21
-  i32.store $0 offset=84
+  i32.store $0
   local.get $21
   call $instanceof/assertStaticTrue<instanceof/X,instanceof/IB>
   global.get $instanceof/x
   local.set $21
   global.get $~lib/memory/__stack_pointer
   local.get $21
-  i32.store $0 offset=84
+  i32.store $0
   local.get $21
   call $instanceof/assertDynamicFalse<instanceof/X,instanceof/ID>
   global.get $instanceof/x
   local.set $21
   global.get $~lib/memory/__stack_pointer
   local.get $21
-  i32.store $0 offset=84
+  i32.store $0
   local.get $21
   call $instanceof/assertDynamicFalse<instanceof/X,instanceof/IC>
   global.get $instanceof/x
   local.set $21
   global.get $~lib/memory/__stack_pointer
   local.get $21
-  i32.store $0 offset=84
+  i32.store $0
   local.get $21
   call $instanceof/assertStaticFalse<instanceof/X,instanceof/IE>
   global.get $instanceof/y
   local.set $21
   global.get $~lib/memory/__stack_pointer
   local.get $21
-  i32.store $0 offset=84
+  i32.store $0
   local.get $21
   call $instanceof/assertStaticTrue<instanceof/X,instanceof/IA>
   global.get $instanceof/y
   local.set $21
   global.get $~lib/memory/__stack_pointer
   local.get $21
-  i32.store $0 offset=84
+  i32.store $0
   local.get $21
   call $instanceof/assertStaticTrue<instanceof/X,instanceof/IB>
   global.get $instanceof/y
   local.set $21
   global.get $~lib/memory/__stack_pointer
   local.get $21
-  i32.store $0 offset=84
+  i32.store $0
   local.get $21
   call $instanceof/assertDynamicTrue<instanceof/X,instanceof/ID>
   global.get $instanceof/y
   local.set $21
   global.get $~lib/memory/__stack_pointer
   local.get $21
-  i32.store $0 offset=84
+  i32.store $0
   local.get $21
   call $instanceof/assertDynamicTrue<instanceof/X,instanceof/IC>
   global.get $instanceof/y
   local.set $21
   global.get $~lib/memory/__stack_pointer
   local.get $21
-  i32.store $0 offset=84
+  i32.store $0
   local.get $21
   call $instanceof/assertStaticFalse<instanceof/X,instanceof/IE>
   global.get $instanceof/z
   local.set $21
   global.get $~lib/memory/__stack_pointer
   local.get $21
-  i32.store $0 offset=84
+  i32.store $0
   local.get $21
   call $instanceof/assertStaticTrue<instanceof/X,instanceof/IA>
   global.get $instanceof/z
   local.set $21
   global.get $~lib/memory/__stack_pointer
   local.get $21
-  i32.store $0 offset=84
+  i32.store $0
   local.get $21
   call $instanceof/assertStaticTrue<instanceof/X,instanceof/IB>
   global.get $instanceof/z
   local.set $21
   global.get $~lib/memory/__stack_pointer
   local.get $21
-  i32.store $0 offset=84
+  i32.store $0
   local.get $21
   call $instanceof/assertDynamicTrue<instanceof/X,instanceof/ID>
   global.get $instanceof/z
   local.set $21
   global.get $~lib/memory/__stack_pointer
   local.get $21
-  i32.store $0 offset=84
+  i32.store $0
   local.get $21
   call $instanceof/assertDynamicTrue<instanceof/X,instanceof/IC>
   global.get $instanceof/z
   local.set $21
   global.get $~lib/memory/__stack_pointer
   local.get $21
-  i32.store $0 offset=84
+  i32.store $0
   local.get $21
   call $instanceof/assertStaticFalse<instanceof/X,instanceof/IE>
   global.get $instanceof/y
   local.set $21
   global.get $~lib/memory/__stack_pointer
   local.get $21
-  i32.store $0 offset=84
+  i32.store $0
   local.get $21
   call $instanceof/assertStaticTrue<instanceof/Y,instanceof/IA>
   global.get $instanceof/y
   local.set $21
   global.get $~lib/memory/__stack_pointer
   local.get $21
-  i32.store $0 offset=84
+  i32.store $0
   local.get $21
   call $instanceof/assertStaticTrue<instanceof/Y,instanceof/IB>
   global.get $instanceof/y
   local.set $21
   global.get $~lib/memory/__stack_pointer
   local.get $21
-  i32.store $0 offset=84
+  i32.store $0
   local.get $21
   call $instanceof/assertStaticTrue<instanceof/Y,instanceof/ID>
   global.get $instanceof/y
   local.set $21
   global.get $~lib/memory/__stack_pointer
   local.get $21
-  i32.store $0 offset=84
+  i32.store $0
   local.get $21
   call $instanceof/assertStaticTrue<instanceof/Y,instanceof/IC>
   global.get $instanceof/y
   local.set $21
   global.get $~lib/memory/__stack_pointer
   local.get $21
-  i32.store $0 offset=84
+  i32.store $0
   local.get $21
   call $instanceof/assertStaticFalse<instanceof/Y,instanceof/IE>
   global.get $instanceof/z
   local.set $21
   global.get $~lib/memory/__stack_pointer
   local.get $21
-  i32.store $0 offset=84
+  i32.store $0
   local.get $21
   call $instanceof/assertStaticTrue<instanceof/Y,instanceof/IA>
   global.get $instanceof/z
   local.set $21
   global.get $~lib/memory/__stack_pointer
   local.get $21
-  i32.store $0 offset=84
+  i32.store $0
   local.get $21
   call $instanceof/assertStaticTrue<instanceof/Y,instanceof/IB>
   global.get $instanceof/z
   local.set $21
   global.get $~lib/memory/__stack_pointer
   local.get $21
-  i32.store $0 offset=84
+  i32.store $0
   local.get $21
   call $instanceof/assertStaticTrue<instanceof/Y,instanceof/ID>
   global.get $instanceof/z
   local.set $21
   global.get $~lib/memory/__stack_pointer
   local.get $21
-  i32.store $0 offset=84
+  i32.store $0
   local.get $21
   call $instanceof/assertStaticTrue<instanceof/Y,instanceof/IC>
   global.get $instanceof/z
   local.set $21
   global.get $~lib/memory/__stack_pointer
   local.get $21
-  i32.store $0 offset=84
+  i32.store $0
   local.get $21
   call $instanceof/assertStaticFalse<instanceof/Y,instanceof/IE>
   global.get $instanceof/z
   local.set $21
   global.get $~lib/memory/__stack_pointer
   local.get $21
-  i32.store $0 offset=84
+  i32.store $0
   local.get $21
   call $instanceof/assertStaticTrue<instanceof/Z,instanceof/IA>
   global.get $instanceof/z
   local.set $21
   global.get $~lib/memory/__stack_pointer
   local.get $21
-  i32.store $0 offset=84
+  i32.store $0
   local.get $21
   call $instanceof/assertStaticTrue<instanceof/Z,instanceof/IB>
   global.get $instanceof/z
   local.set $21
   global.get $~lib/memory/__stack_pointer
   local.get $21
-  i32.store $0 offset=84
+  i32.store $0
   local.get $21
   call $instanceof/assertStaticTrue<instanceof/Z,instanceof/ID>
   global.get $instanceof/z
   local.set $21
   global.get $~lib/memory/__stack_pointer
   local.get $21
-  i32.store $0 offset=84
+  i32.store $0
   local.get $21
   call $instanceof/assertStaticTrue<instanceof/Z,instanceof/IC>
   global.get $instanceof/z
   local.set $21
   global.get $~lib/memory/__stack_pointer
   local.get $21
-  i32.store $0 offset=84
+  i32.store $0
   local.get $21
   call $instanceof/assertStaticFalse<instanceof/Z,instanceof/IE>
   global.get $instanceof/x
   local.set $21
   global.get $~lib/memory/__stack_pointer
   local.get $21
-  i32.store $0 offset=84
+  i32.store $0
   local.get $21
   call $instanceof/assertStaticFalse<instanceof/IA,instanceof/W>
   global.get $instanceof/x
   local.set $21
   global.get $~lib/memory/__stack_pointer
   local.get $21
-  i32.store $0 offset=84
+  i32.store $0
   local.get $21
   call $instanceof/assertStaticFalse<instanceof/IB,instanceof/W>
   global.get $instanceof/y
   local.set $21
   global.get $~lib/memory/__stack_pointer
   local.get $21
-  i32.store $0 offset=84
+  i32.store $0
   local.get $21
   call $instanceof/assertStaticFalse<instanceof/IA,instanceof/W>
   global.get $instanceof/y
   local.set $21
   global.get $~lib/memory/__stack_pointer
   local.get $21
-  i32.store $0 offset=84
+  i32.store $0
   local.get $21
   call $instanceof/assertStaticFalse<instanceof/IB,instanceof/W>
   global.get $instanceof/y
   local.set $21
   global.get $~lib/memory/__stack_pointer
   local.get $21
-  i32.store $0 offset=84
+  i32.store $0
   local.get $21
   call $instanceof/assertStaticFalse<instanceof/IC,instanceof/W>
   global.get $instanceof/y
   local.set $21
   global.get $~lib/memory/__stack_pointer
   local.get $21
-  i32.store $0 offset=84
+  i32.store $0
   local.get $21
   call $instanceof/assertStaticFalse<instanceof/ID,instanceof/W>
   global.get $instanceof/z
   local.set $21
   global.get $~lib/memory/__stack_pointer
   local.get $21
-  i32.store $0 offset=84
+  i32.store $0
   local.get $21
   call $instanceof/assertStaticFalse<instanceof/IA,instanceof/W>
   global.get $instanceof/z
   local.set $21
   global.get $~lib/memory/__stack_pointer
   local.get $21
-  i32.store $0 offset=84
+  i32.store $0
   local.get $21
   call $instanceof/assertStaticFalse<instanceof/IB,instanceof/W>
   global.get $instanceof/z
   local.set $21
   global.get $~lib/memory/__stack_pointer
   local.get $21
-  i32.store $0 offset=84
+  i32.store $0
   local.get $21
   call $instanceof/assertStaticFalse<instanceof/IC,instanceof/W>
   global.get $instanceof/z
   local.set $21
   global.get $~lib/memory/__stack_pointer
   local.get $21
-  i32.store $0 offset=84
+  i32.store $0
   local.get $21
   call $instanceof/assertStaticFalse<instanceof/ID,instanceof/W>
   global.get $instanceof/x
   local.set $21
   global.get $~lib/memory/__stack_pointer
   local.get $21
-  i32.store $0 offset=84
+  i32.store $0
   local.get $21
   call $instanceof/assertDynamicTrue<instanceof/IA,instanceof/X>
   global.get $instanceof/x
   local.set $21
   global.get $~lib/memory/__stack_pointer
   local.get $21
-  i32.store $0 offset=84
+  i32.store $0
   local.get $21
   call $instanceof/assertDynamicTrue<instanceof/IB,instanceof/X>
   global.get $instanceof/y
   local.set $21
   global.get $~lib/memory/__stack_pointer
   local.get $21
-  i32.store $0 offset=84
+  i32.store $0
   local.get $21
   call $instanceof/assertDynamicTrue<instanceof/IA,instanceof/X>
   global.get $instanceof/y
   local.set $21
   global.get $~lib/memory/__stack_pointer
   local.get $21
-  i32.store $0 offset=84
+  i32.store $0
   local.get $21
   call $instanceof/assertDynamicTrue<instanceof/IB,instanceof/X>
   global.get $instanceof/z
   local.set $21
   global.get $~lib/memory/__stack_pointer
   local.get $21
-  i32.store $0 offset=84
+  i32.store $0
   local.get $21
   call $instanceof/assertDynamicTrue<instanceof/IA,instanceof/X>
   global.get $instanceof/z
   local.set $21
   global.get $~lib/memory/__stack_pointer
   local.get $21
-  i32.store $0 offset=84
+  i32.store $0
   local.get $21
   call $instanceof/assertDynamicTrue<instanceof/IB,instanceof/X>
   global.get $instanceof/y
   local.set $21
   global.get $~lib/memory/__stack_pointer
   local.get $21
-  i32.store $0 offset=84
+  i32.store $0
   local.get $21
   call $instanceof/assertDynamicTrue<instanceof/IA,instanceof/Y>
   global.get $instanceof/y
   local.set $21
   global.get $~lib/memory/__stack_pointer
   local.get $21
-  i32.store $0 offset=84
+  i32.store $0
   local.get $21
   call $instanceof/assertDynamicTrue<instanceof/IB,instanceof/Y>
   global.get $instanceof/y
   local.set $21
   global.get $~lib/memory/__stack_pointer
   local.get $21
-  i32.store $0 offset=84
+  i32.store $0
   local.get $21
   call $instanceof/assertDynamicTrue<instanceof/IC,instanceof/Y>
   global.get $instanceof/y
   local.set $21
   global.get $~lib/memory/__stack_pointer
   local.get $21
-  i32.store $0 offset=84
+  i32.store $0
   local.get $21
   call $instanceof/assertDynamicTrue<instanceof/ID,instanceof/Y>
   global.get $instanceof/z
   local.set $21
   global.get $~lib/memory/__stack_pointer
   local.get $21
-  i32.store $0 offset=84
+  i32.store $0
   local.get $21
   call $instanceof/assertDynamicTrue<instanceof/IA,instanceof/Y>
   global.get $instanceof/z
   local.set $21
   global.get $~lib/memory/__stack_pointer
   local.get $21
-  i32.store $0 offset=84
+  i32.store $0
   local.get $21
   call $instanceof/assertDynamicTrue<instanceof/IB,instanceof/Y>
   global.get $instanceof/z
   local.set $21
   global.get $~lib/memory/__stack_pointer
   local.get $21
-  i32.store $0 offset=84
+  i32.store $0
   local.get $21
   call $instanceof/assertDynamicTrue<instanceof/IC,instanceof/Y>
   global.get $instanceof/z
   local.set $21
   global.get $~lib/memory/__stack_pointer
   local.get $21
-  i32.store $0 offset=84
+  i32.store $0
   local.get $21
   call $instanceof/assertDynamicTrue<instanceof/ID,instanceof/Y>
   global.get $instanceof/z
   local.set $21
   global.get $~lib/memory/__stack_pointer
   local.get $21
-  i32.store $0 offset=84
+  i32.store $0
   local.get $21
   call $instanceof/assertDynamicTrue<instanceof/IA,instanceof/Z>
   global.get $instanceof/z
   local.set $21
   global.get $~lib/memory/__stack_pointer
   local.get $21
-  i32.store $0 offset=84
+  i32.store $0
   local.get $21
   call $instanceof/assertDynamicTrue<instanceof/IB,instanceof/Z>
   global.get $instanceof/z
   local.set $21
   global.get $~lib/memory/__stack_pointer
   local.get $21
-  i32.store $0 offset=84
+  i32.store $0
   local.get $21
   call $instanceof/assertDynamicTrue<instanceof/IC,instanceof/Z>
   global.get $instanceof/z
   local.set $21
   global.get $~lib/memory/__stack_pointer
   local.get $21
-  i32.store $0 offset=84
+  i32.store $0
   local.get $21
   call $instanceof/assertDynamicTrue<instanceof/ID,instanceof/Z>
   global.get $~lib/memory/__stack_pointer

--- a/tests/compiler/instanceof.release.wat
+++ b/tests/compiler/instanceof.release.wat
@@ -32,7 +32,7 @@
  (global $instanceof/x (mut i32) (i32.const 0))
  (global $instanceof/y (mut i32) (i32.const 0))
  (global $instanceof/z (mut i32) (i32.const 0))
- (global $~lib/memory/__stack_pointer (mut i32) (i32.const 34352))
+ (global $~lib/memory/__stack_pointer (mut i32) (i32.const 34356))
  (memory $0 1)
  (data (i32.const 1036) "<")
  (data (i32.const 1048) "\02\00\00\00(\00\00\00A\00l\00l\00o\00c\00a\00t\00i\00o\00n\00 \00t\00o\00o\00 \00l\00a\00r\00g\00e")
@@ -46,7 +46,7 @@
  (data (i32.const 1384) "\02\00\00\00\1e\00\00\00~\00l\00i\00b\00/\00r\00t\00/\00t\00l\00s\00f\00.\00t\00s")
  (data (i32.const 1436) ",")
  (data (i32.const 1448) "\02\00\00\00\1a\00\00\00i\00n\00s\00t\00a\00n\00c\00e\00o\00f\00.\00t\00s")
- (data (i32.const 1488) "\17\00\00\00 \00\00\00 \00\00\00 \00\00\00\00\00\00\00 \00\00\00 \00\00\00 \00\00\00 \00\00\00 \00\00\00 \00\00\00 \00\00\00 \00\00\00 \00\00\00 \00\00\00 \00\00\00 \00\00\00 \00\00\00 \00\00\00 \00\00\00 \00\00\00 \00\00\00 \00\00\00 ")
+ (data (i32.const 1488) "\18\00\00\00 \00\00\00 \00\00\00 \00\00\00\00\00\00\00 \00\00\00 \00\00\00 \00\00\00 \00\00\00 \00\00\00 \00\00\00 \00\00\00 \00\00\00 \00\00\00 \00\00\00 \00\00\00 \00\00\00 \00\00\00 \00\00\00 \00\00\00 \00\00\00 \00\00\00 \00\00\00 \00\00\00 ")
  (export "memory" (memory $0))
  (start $~start)
  (func $~lib/rt/itcms/visitRoots
@@ -219,7 +219,7 @@
     i32.load $0 offset=8
     i32.eqz
     local.get $0
-    i32.const 34352
+    i32.const 34356
     i32.lt_u
     i32.and
     i32.eqz
@@ -847,10 +847,10 @@
   if
    unreachable
   end
-  i32.const 34352
+  i32.const 34368
   i32.const 0
   i32.store $0
-  i32.const 35920
+  i32.const 35936
   i32.const 0
   i32.store $0
   loop $for-loop|0
@@ -861,7 +861,7 @@
     local.get $0
     i32.const 2
     i32.shl
-    i32.const 34352
+    i32.const 34368
     i32.add
     i32.const 0
     i32.store $0 offset=4
@@ -879,7 +879,7 @@
       i32.add
       i32.const 2
       i32.shl
-      i32.const 34352
+      i32.const 34368
       i32.add
       i32.const 0
       i32.store $0 offset=96
@@ -897,13 +897,13 @@
     br $for-loop|0
    end
   end
-  i32.const 34352
-  i32.const 35924
+  i32.const 34368
+  i32.const 35940
   memory.size $0
   i32.const 16
   i32.shl
   call $~lib/rt/tlsf/addMemory
-  i32.const 34352
+  i32.const 34368
   global.set $~lib/rt/tlsf/ROOT
  )
  (func $~lib/rt/itcms/step (result i32)
@@ -988,7 +988,7 @@
      local.set $0
      loop $while-continue|0
       local.get $0
-      i32.const 34352
+      i32.const 34356
       i32.lt_u
       if
        local.get $0
@@ -1088,7 +1088,7 @@
      unreachable
     end
     local.get $0
-    i32.const 34352
+    i32.const 34356
     i32.lt_u
     if
      local.get $0
@@ -1111,7 +1111,7 @@
      i32.const 4
      i32.add
      local.tee $0
-     i32.const 34352
+     i32.const 34356
      i32.ge_u
      if
       global.get $~lib/rt/tlsf/ROOT
@@ -1470,7 +1470,7 @@
   i32.sub
   global.set $~lib/memory/__stack_pointer
   global.get $~lib/memory/__stack_pointer
-  i32.const 1584
+  i32.const 1588
   i32.lt_s
   if
    i32.const 34384
@@ -1496,7 +1496,7 @@
       i32.const 8
       i32.sub
       i32.load $0
-      i32.const 15
+      i32.const 16
       i32.sub
       br_table $is_instance $tablify|0 $tablify|0 $is_instance $tablify|0 $tablify|0 $is_instance $tablify|0
      end
@@ -1529,7 +1529,7 @@
   i32.sub
   global.set $~lib/memory/__stack_pointer
   global.get $~lib/memory/__stack_pointer
-  i32.const 1584
+  i32.const 1588
   i32.lt_s
   if
    i32.const 34384
@@ -1555,11 +1555,11 @@
      i32.sub
      i32.load $0
      local.tee $0
-     i32.const 18
+     i32.const 19
      i32.eq
      br_if $is_instance
      local.get $0
-     i32.const 21
+     i32.const 22
      i32.eq
      br_if $is_instance
      i32.const 0
@@ -1591,7 +1591,7 @@
   i32.sub
   global.set $~lib/memory/__stack_pointer
   global.get $~lib/memory/__stack_pointer
-  i32.const 1584
+  i32.const 1588
   i32.lt_s
   if
    i32.const 34384
@@ -1614,7 +1614,7 @@
    i32.const 8
    i32.sub
    i32.load $0
-   i32.const 21
+   i32.const 22
    i32.eq
   else
    i32.const 0
@@ -1640,7 +1640,7 @@
   i32.sub
   global.set $~lib/memory/__stack_pointer
   global.get $~lib/memory/__stack_pointer
-  i32.const 1584
+  i32.const 1588
   i32.lt_s
   if
    i32.const 34384
@@ -1666,11 +1666,11 @@
      i32.sub
      i32.load $0
      local.tee $0
-     i32.const 18
+     i32.const 19
      i32.eq
      br_if $is_instance
      local.get $0
-     i32.const 21
+     i32.const 22
      i32.eq
      br_if $is_instance
      i32.const 0
@@ -1701,7 +1701,7 @@
   i32.sub
   global.set $~lib/memory/__stack_pointer
   global.get $~lib/memory/__stack_pointer
-  i32.const 1584
+  i32.const 1588
   i32.lt_s
   if
    i32.const 34384
@@ -1724,7 +1724,7 @@
    i32.const 8
    i32.sub
    i32.load $0
-   i32.const 21
+   i32.const 22
    i32.eq
   else
    i32.const 0
@@ -1761,30 +1761,33 @@
                  block $instanceof/Child<f32>
                   block $instanceof/Parent<i32>
                    block $instanceof/Child<i32>
-                    block $instanceof/B
-                     block $instanceof/A
-                      block $~lib/arraybuffer/ArrayBufferView
-                       block $~lib/string/String
-                        block $~lib/arraybuffer/ArrayBuffer
-                         block $~lib/object/Object
-                          local.get $0
-                          i32.const 8
-                          i32.sub
-                          i32.load $0
-                          br_table $~lib/object/Object $~lib/arraybuffer/ArrayBuffer $~lib/string/String $~lib/arraybuffer/ArrayBufferView $instanceof/A $instanceof/B $instanceof/Child<i32> $instanceof/Parent<i32> $instanceof/Child<f32> $instanceof/Parent<f32> $instanceof/SomethingElse<i32> $instanceof/Animal $instanceof/Cat $instanceof/BlackCat $instanceof/W $instanceof/X $instanceof/IB $instanceof/IA $instanceof/Y $instanceof/ID $instanceof/IC $instanceof/Z $instanceof/IE $invalid
+                    block $instanceof/C
+                     block $instanceof/B
+                      block $instanceof/A
+                       block $~lib/arraybuffer/ArrayBufferView
+                        block $~lib/string/String
+                         block $~lib/arraybuffer/ArrayBuffer
+                          block $~lib/object/Object
+                           local.get $0
+                           i32.const 8
+                           i32.sub
+                           i32.load $0
+                           br_table $~lib/object/Object $~lib/arraybuffer/ArrayBuffer $~lib/string/String $~lib/arraybuffer/ArrayBufferView $instanceof/A $instanceof/B $instanceof/C $instanceof/Child<i32> $instanceof/Parent<i32> $instanceof/Child<f32> $instanceof/Parent<f32> $instanceof/SomethingElse<i32> $instanceof/Animal $instanceof/Cat $instanceof/BlackCat $instanceof/W $instanceof/X $instanceof/IB $instanceof/IA $instanceof/Y $instanceof/ID $instanceof/IC $instanceof/Z $instanceof/IE $invalid
+                          end
+                          return
                          end
                          return
                         end
                         return
                        end
-                       return
-                      end
-                      local.get $0
-                      i32.load $0
-                      local.tee $0
-                      if
                        local.get $0
-                       call $byn-split-outlined-A$~lib/rt/itcms/__visit
+                       i32.load $0
+                       local.tee $0
+                       if
+                        local.get $0
+                        call $byn-split-outlined-A$~lib/rt/itcms/__visit
+                       end
+                       return
                       end
                       return
                      end
@@ -1838,7 +1841,7 @@
   i32.sub
   global.set $~lib/memory/__stack_pointer
   global.get $~lib/memory/__stack_pointer
-  i32.const 1584
+  i32.const 1588
   i32.lt_s
   if
    i32.const 34384
@@ -1882,51 +1885,7 @@
   i32.sub
   global.set $~lib/memory/__stack_pointer
   global.get $~lib/memory/__stack_pointer
-  i32.const 1584
-  i32.lt_s
-  if
-   i32.const 34384
-   i32.const 34432
-   i32.const 1
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  global.get $~lib/memory/__stack_pointer
-  i64.const 0
-  i64.store $0
-  local.get $0
-  i32.eqz
-  if
-   global.get $~lib/memory/__stack_pointer
-   i32.const 11
-   call $~lib/rt/itcms/__new
-   local.tee $0
-   i32.store $0
-  end
-  global.get $~lib/memory/__stack_pointer
-  local.tee $1
-  local.get $0
-  i32.store $0 offset=4
-  local.get $1
-  local.get $0
-  call $~lib/object/Object#constructor
-  local.tee $0
-  i32.store $0
-  global.get $~lib/memory/__stack_pointer
-  i32.const 8
-  i32.add
-  global.set $~lib/memory/__stack_pointer
-  local.get $0
- )
- (func $instanceof/Cat#constructor (param $0 i32) (result i32)
-  (local $1 i32)
-  global.get $~lib/memory/__stack_pointer
-  i32.const 8
-  i32.sub
-  global.set $~lib/memory/__stack_pointer
-  global.get $~lib/memory/__stack_pointer
-  i32.const 1584
+  i32.const 1588
   i32.lt_s
   if
    i32.const 34384
@@ -1954,6 +1913,50 @@
   i32.store $0 offset=4
   local.get $1
   local.get $0
+  call $~lib/object/Object#constructor
+  local.tee $0
+  i32.store $0
+  global.get $~lib/memory/__stack_pointer
+  i32.const 8
+  i32.add
+  global.set $~lib/memory/__stack_pointer
+  local.get $0
+ )
+ (func $instanceof/Cat#constructor (param $0 i32) (result i32)
+  (local $1 i32)
+  global.get $~lib/memory/__stack_pointer
+  i32.const 8
+  i32.sub
+  global.set $~lib/memory/__stack_pointer
+  global.get $~lib/memory/__stack_pointer
+  i32.const 1588
+  i32.lt_s
+  if
+   i32.const 34384
+   i32.const 34432
+   i32.const 1
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  global.get $~lib/memory/__stack_pointer
+  i64.const 0
+  i64.store $0
+  local.get $0
+  i32.eqz
+  if
+   global.get $~lib/memory/__stack_pointer
+   i32.const 13
+   call $~lib/rt/itcms/__new
+   local.tee $0
+   i32.store $0
+  end
+  global.get $~lib/memory/__stack_pointer
+  local.tee $1
+  local.get $0
+  i32.store $0 offset=4
+  local.get $1
+  local.get $0
   call $instanceof/Animal#constructor
   local.tee $0
   i32.store $0
@@ -1971,7 +1974,7 @@
   i32.sub
   global.set $~lib/memory/__stack_pointer
   global.get $~lib/memory/__stack_pointer
-  i32.const 1584
+  i32.const 1588
   i32.lt_s
   if
    i32.const 34384
@@ -1986,7 +1989,7 @@
   i64.const 0
   i64.store $0
   local.get $0
-  i32.const 13
+  i32.const 14
   call $~lib/rt/itcms/__new
   local.tee $0
   i32.store $0
@@ -2012,7 +2015,7 @@
   i32.sub
   global.set $~lib/memory/__stack_pointer
   global.get $~lib/memory/__stack_pointer
-  i32.const 1584
+  i32.const 1588
   i32.lt_s
   if
    i32.const 34384
@@ -2029,7 +2032,7 @@
   i32.eqz
   if
    global.get $~lib/memory/__stack_pointer
-   i32.const 15
+   i32.const 16
    call $~lib/rt/itcms/__new
    local.tee $0
    i32.store $0
@@ -2056,7 +2059,7 @@
   i32.sub
   global.set $~lib/memory/__stack_pointer
   global.get $~lib/memory/__stack_pointer
-  i32.const 1584
+  i32.const 1588
   i32.lt_s
   if
    i32.const 34384
@@ -2073,7 +2076,7 @@
   i32.eqz
   if
    global.get $~lib/memory/__stack_pointer
-   i32.const 18
+   i32.const 19
    call $~lib/rt/itcms/__new
    local.tee $0
    i32.store $0
@@ -2104,7 +2107,7 @@
   global.set $~lib/memory/__stack_pointer
   block $folding-inner0
    global.get $~lib/memory/__stack_pointer
-   i32.const 1584
+   i32.const 1588
    i32.lt_s
    br_if $folding-inner0
    global.get $~lib/memory/__stack_pointer
@@ -2114,7 +2117,7 @@
    memory.size $0
    i32.const 16
    i32.shl
-   i32.const 34352
+   i32.const 34356
    i32.sub
    i32.const 1
    i32.shr_u
@@ -2151,7 +2154,7 @@
    i32.sub
    global.set $~lib/memory/__stack_pointer
    global.get $~lib/memory/__stack_pointer
-   i32.const 1584
+   i32.const 1588
    i32.lt_s
    br_if $folding-inner0
    global.get $~lib/memory/__stack_pointer
@@ -2179,45 +2182,11 @@
    local.get $0
    global.set $instanceof/b
    global.get $~lib/memory/__stack_pointer
-   global.get $instanceof/a
-   local.tee $0
-   i32.store $0
-   local.get $0
-   if (result i32)
-    local.get $0
-    i32.const 8
-    i32.sub
-    i32.load $0
-    i32.const 5
-    i32.eq
-   else
-    i32.const 0
-   end
-   if
-    i32.const 0
-    i32.const 1456
-    i32.const 41
-    i32.const 1
-    call $~lib/builtins/abort
-    unreachable
-   end
-   global.get $instanceof/an
-   if
-    i32.const 0
-    i32.const 1456
-    i32.const 91
-    i32.const 1
-    call $~lib/builtins/abort
-    unreachable
-   end
-   i32.const 1
-   global.set $instanceof/an
-   global.get $~lib/memory/__stack_pointer
    i32.const 8
    i32.sub
    global.set $~lib/memory/__stack_pointer
    global.get $~lib/memory/__stack_pointer
-   i32.const 1584
+   i32.const 1588
    i32.lt_s
    br_if $folding-inner0
    global.get $~lib/memory/__stack_pointer
@@ -2234,11 +2203,110 @@
    local.get $0
    i32.store $0 offset=4
    local.get $1
+   local.get $0
+   call $instanceof/A#constructor
+   local.tee $0
+   i32.store $0
+   global.get $~lib/memory/__stack_pointer
+   i32.const 8
+   i32.add
+   global.set $~lib/memory/__stack_pointer
+   global.get $~lib/memory/__stack_pointer
+   local.get $0
+   i32.store $0
+   local.get $0
+   i32.const 8
+   i32.sub
+   i32.load $0
+   i32.const 6
+   i32.eq
+   if
+    global.get $~lib/memory/__stack_pointer
+    i32.const 4
+    i32.sub
+    global.set $~lib/memory/__stack_pointer
+    global.get $~lib/memory/__stack_pointer
+    i32.const 1588
+    i32.lt_s
+    br_if $folding-inner0
+    global.get $~lib/memory/__stack_pointer
+    local.tee $0
+    i32.const 0
+    i32.store $0
+    local.get $0
+    global.get $instanceof/a
+    local.tee $0
+    i32.store $0
+    local.get $0
+    if
+     unreachable
+    end
+    global.get $~lib/memory/__stack_pointer
+    i32.const 4
+    i32.add
+    global.set $~lib/memory/__stack_pointer
+   end
+   global.get $~lib/memory/__stack_pointer
+   global.get $instanceof/a
+   local.tee $0
+   i32.store $0 offset=4
+   local.get $0
+   if (result i32)
+    local.get $0
+    i32.const 8
+    i32.sub
+    i32.load $0
+    i32.const 5
+    i32.eq
+   else
+    i32.const 0
+   end
+   if
+    i32.const 0
+    i32.const 1456
+    i32.const 50
+    i32.const 1
+    call $~lib/builtins/abort
+    unreachable
+   end
+   global.get $instanceof/an
+   if
+    i32.const 0
+    i32.const 1456
+    i32.const 100
+    i32.const 1
+    call $~lib/builtins/abort
+    unreachable
+   end
+   i32.const 1
+   global.set $instanceof/an
+   global.get $~lib/memory/__stack_pointer
    i32.const 8
    i32.sub
    global.set $~lib/memory/__stack_pointer
    global.get $~lib/memory/__stack_pointer
-   i32.const 1584
+   i32.const 1588
+   i32.lt_s
+   br_if $folding-inner0
+   global.get $~lib/memory/__stack_pointer
+   local.tee $0
+   i64.const 0
+   i64.store $0
+   local.get $0
+   i32.const 7
+   call $~lib/rt/itcms/__new
+   local.tee $0
+   i32.store $0
+   global.get $~lib/memory/__stack_pointer
+   local.tee $1
+   local.get $0
+   i32.store $0 offset=4
+   local.get $1
+   i32.const 8
+   i32.sub
+   global.set $~lib/memory/__stack_pointer
+   global.get $~lib/memory/__stack_pointer
+   i32.const 1588
    i32.lt_s
    br_if $folding-inner0
    global.get $~lib/memory/__stack_pointer
@@ -2248,7 +2316,7 @@
    i32.eqz
    if
     global.get $~lib/memory/__stack_pointer
-    i32.const 7
+    i32.const 8
     call $~lib/rt/itcms/__new
     local.tee $0
     i32.store $0
@@ -2280,7 +2348,7 @@
    i32.sub
    global.set $~lib/memory/__stack_pointer
    global.get $~lib/memory/__stack_pointer
-   i32.const 1584
+   i32.const 1588
    i32.lt_s
    br_if $folding-inner0
    global.get $~lib/memory/__stack_pointer
@@ -2288,7 +2356,7 @@
    i64.const 0
    i64.store $0
    local.get $0
-   i32.const 8
+   i32.const 9
    call $~lib/rt/itcms/__new
    local.tee $0
    i32.store $0
@@ -2301,7 +2369,7 @@
    i32.sub
    global.set $~lib/memory/__stack_pointer
    global.get $~lib/memory/__stack_pointer
-   i32.const 1584
+   i32.const 1588
    i32.lt_s
    br_if $folding-inner0
    global.get $~lib/memory/__stack_pointer
@@ -2311,7 +2379,7 @@
    i32.eqz
    if
     global.get $~lib/memory/__stack_pointer
-    i32.const 9
+    i32.const 10
     call $~lib/rt/itcms/__new
     local.tee $0
     i32.store $0
@@ -2341,14 +2409,14 @@
    global.get $~lib/memory/__stack_pointer
    global.get $instanceof/childAsParent
    local.tee $0
-   i32.store $0 offset=4
+   i32.store $0 offset=8
    local.get $0
    if (result i32)
     local.get $0
     i32.const 8
     i32.sub
     i32.load $0
-    i32.const 8
+    i32.const 9
     i32.eq
    else
     i32.const 0
@@ -2357,7 +2425,7 @@
    if
     i32.const 0
     i32.const 1456
-    i32.const 117
+    i32.const 126
     i32.const 1
     call $~lib/builtins/abort
     unreachable
@@ -2365,7 +2433,7 @@
    global.get $~lib/memory/__stack_pointer
    global.get $instanceof/childAsParent
    local.tee $0
-   i32.store $0 offset=8
+   i32.store $0 offset=12
    local.get $0
    if (result i32)
     block $__inlined_func$~anyinstanceof|instanceof/Child (result i32)
@@ -2375,11 +2443,11 @@
       i32.sub
       i32.load $0
       local.tee $0
-      i32.const 6
+      i32.const 7
       i32.eq
       br_if $is_instance2
       local.get $0
-      i32.const 8
+      i32.const 9
       i32.eq
       br_if $is_instance2
       i32.const 0
@@ -2394,7 +2462,7 @@
    if
     i32.const 0
     i32.const 1456
-    i32.const 119
+    i32.const 128
     i32.const 1
     call $~lib/builtins/abort
     unreachable
@@ -2410,7 +2478,7 @@
    global.get $~lib/memory/__stack_pointer
    global.get $instanceof/animal
    local.tee $0
-   i32.store $0 offset=12
+   i32.store $0 offset=16
    local.get $0
    if (result i32)
     block $__inlined_func$~instanceof|instanceof/Cat (result i32)
@@ -2420,11 +2488,11 @@
       i32.sub
       i32.load $0
       local.tee $0
-      i32.const 12
+      i32.const 13
       i32.eq
       br_if $is_instance3
       local.get $0
-      i32.const 13
+      i32.const 14
       i32.eq
       br_if $is_instance3
       i32.const 0
@@ -2438,7 +2506,7 @@
    if
     i32.const 0
     i32.const 1456
-    i32.const 134
+    i32.const 143
     i32.const 1
     call $~lib/builtins/abort
     unreachable
@@ -2446,14 +2514,14 @@
    global.get $~lib/memory/__stack_pointer
    global.get $instanceof/animal
    local.tee $0
-   i32.store $0 offset=16
+   i32.store $0 offset=20
    local.get $0
    if (result i32)
     local.get $0
     i32.const 8
     i32.sub
     i32.load $0
-    i32.const 13
+    i32.const 14
     i32.eq
    else
     i32.const 0
@@ -2461,7 +2529,7 @@
    if
     i32.const 0
     i32.const 1456
-    i32.const 135
+    i32.const 144
     i32.const 1
     call $~lib/builtins/abort
     unreachable
@@ -2469,7 +2537,7 @@
    global.get $~lib/memory/__stack_pointer
    global.get $instanceof/cat
    local.tee $0
-   i32.store $0 offset=20
+   i32.store $0 offset=24
    local.get $0
    if (result i32)
     block $__inlined_func$~instanceof|instanceof/Cat5 (result i32)
@@ -2479,11 +2547,11 @@
       i32.sub
       i32.load $0
       local.tee $0
-      i32.const 12
+      i32.const 13
       i32.eq
       br_if $is_instance6
       local.get $0
-      i32.const 13
+      i32.const 14
       i32.eq
       br_if $is_instance6
       i32.const 0
@@ -2498,7 +2566,7 @@
    if
     i32.const 0
     i32.const 1456
-    i32.const 138
+    i32.const 147
     i32.const 1
     call $~lib/builtins/abort
     unreachable
@@ -2506,14 +2574,14 @@
    global.get $~lib/memory/__stack_pointer
    global.get $instanceof/cat
    local.tee $0
-   i32.store $0 offset=24
+   i32.store $0 offset=28
    local.get $0
    if (result i32)
     local.get $0
     i32.const 8
     i32.sub
     i32.load $0
-    i32.const 13
+    i32.const 14
     i32.eq
    else
     i32.const 0
@@ -2521,7 +2589,7 @@
    if
     i32.const 0
     i32.const 1456
-    i32.const 139
+    i32.const 148
     i32.const 1
     call $~lib/builtins/abort
     unreachable
@@ -2529,7 +2597,7 @@
    global.get $~lib/memory/__stack_pointer
    global.get $instanceof/blackcat
    local.tee $0
-   i32.store $0 offset=28
+   i32.store $0 offset=32
    local.get $0
    if (result i32)
     block $__inlined_func$~instanceof|instanceof/Cat9 (result i32)
@@ -2539,11 +2607,11 @@
       i32.sub
       i32.load $0
       local.tee $0
-      i32.const 12
+      i32.const 13
       i32.eq
       br_if $is_instance10
       local.get $0
-      i32.const 13
+      i32.const 14
       i32.eq
       br_if $is_instance10
       i32.const 0
@@ -2558,7 +2626,7 @@
    if
     i32.const 0
     i32.const 1456
-    i32.const 142
+    i32.const 151
     i32.const 1
     call $~lib/builtins/abort
     unreachable
@@ -2566,14 +2634,14 @@
    global.get $~lib/memory/__stack_pointer
    global.get $instanceof/blackcat
    local.tee $0
-   i32.store $0 offset=32
+   i32.store $0 offset=36
    local.get $0
    if (result i32)
     local.get $0
     i32.const 8
     i32.sub
     i32.load $0
-    i32.const 13
+    i32.const 14
     i32.eq
    else
     i32.const 0
@@ -2582,7 +2650,7 @@
    if
     i32.const 0
     i32.const 1456
-    i32.const 143
+    i32.const 152
     i32.const 1
     call $~lib/builtins/abort
     unreachable
@@ -2600,7 +2668,7 @@
    if
     i32.const 0
     i32.const 1456
-    i32.const 149
+    i32.const 158
     i32.const 1
     call $~lib/builtins/abort
     unreachable
@@ -2608,7 +2676,7 @@
    global.get $~lib/memory/__stack_pointer
    global.get $instanceof/nullableAnimal
    local.tee $0
-   i32.store $0 offset=36
+   i32.store $0 offset=40
    local.get $0
    if (result i32)
     block $__inlined_func$~instanceof|instanceof/Cat13 (result i32)
@@ -2618,11 +2686,11 @@
       i32.sub
       i32.load $0
       local.tee $0
-      i32.const 12
+      i32.const 13
       i32.eq
       br_if $is_instance14
       local.get $0
-      i32.const 13
+      i32.const 14
       i32.eq
       br_if $is_instance14
       i32.const 0
@@ -2636,7 +2704,7 @@
    if
     i32.const 0
     i32.const 1456
-    i32.const 150
+    i32.const 159
     i32.const 1
     call $~lib/builtins/abort
     unreachable
@@ -2644,14 +2712,14 @@
    global.get $~lib/memory/__stack_pointer
    global.get $instanceof/nullableAnimal
    local.tee $0
-   i32.store $0 offset=40
+   i32.store $0 offset=44
    local.get $0
    if (result i32)
     local.get $0
     i32.const 8
     i32.sub
     i32.load $0
-    i32.const 13
+    i32.const 14
     i32.eq
    else
     i32.const 0
@@ -2659,7 +2727,7 @@
    if
     i32.const 0
     i32.const 1456
-    i32.const 151
+    i32.const 160
     i32.const 1
     call $~lib/builtins/abort
     unreachable
@@ -2669,7 +2737,7 @@
    if
     i32.const 0
     i32.const 1456
-    i32.const 153
+    i32.const 162
     i32.const 1
     call $~lib/builtins/abort
     unreachable
@@ -2677,7 +2745,7 @@
    global.get $~lib/memory/__stack_pointer
    global.get $instanceof/nullableCat
    local.tee $0
-   i32.store $0 offset=44
+   i32.store $0 offset=48
    local.get $0
    if (result i32)
     block $__inlined_func$~instanceof|instanceof/Cat17 (result i32)
@@ -2687,11 +2755,11 @@
       i32.sub
       i32.load $0
       local.tee $0
-      i32.const 12
+      i32.const 13
       i32.eq
       br_if $is_instance18
       local.get $0
-      i32.const 13
+      i32.const 14
       i32.eq
       br_if $is_instance18
       i32.const 0
@@ -2706,7 +2774,7 @@
    if
     i32.const 0
     i32.const 1456
-    i32.const 154
+    i32.const 163
     i32.const 1
     call $~lib/builtins/abort
     unreachable
@@ -2714,14 +2782,14 @@
    global.get $~lib/memory/__stack_pointer
    global.get $instanceof/nullableCat
    local.tee $0
-   i32.store $0 offset=48
+   i32.store $0 offset=52
    local.get $0
    if (result i32)
     local.get $0
     i32.const 8
     i32.sub
     i32.load $0
-    i32.const 13
+    i32.const 14
     i32.eq
    else
     i32.const 0
@@ -2729,7 +2797,7 @@
    if
     i32.const 0
     i32.const 1456
-    i32.const 155
+    i32.const 164
     i32.const 1
     call $~lib/builtins/abort
     unreachable
@@ -2739,7 +2807,7 @@
    if
     i32.const 0
     i32.const 1456
-    i32.const 157
+    i32.const 166
     i32.const 1
     call $~lib/builtins/abort
     unreachable
@@ -2747,7 +2815,7 @@
    global.get $~lib/memory/__stack_pointer
    global.get $instanceof/nullableBlackcat
    local.tee $0
-   i32.store $0 offset=52
+   i32.store $0 offset=56
    local.get $0
    if (result i32)
     block $__inlined_func$~instanceof|instanceof/Cat21 (result i32)
@@ -2757,11 +2825,11 @@
       i32.sub
       i32.load $0
       local.tee $0
-      i32.const 12
+      i32.const 13
       i32.eq
       br_if $is_instance22
       local.get $0
-      i32.const 13
+      i32.const 14
       i32.eq
       br_if $is_instance22
       i32.const 0
@@ -2776,7 +2844,7 @@
    if
     i32.const 0
     i32.const 1456
-    i32.const 158
+    i32.const 167
     i32.const 1
     call $~lib/builtins/abort
     unreachable
@@ -2784,14 +2852,14 @@
    global.get $~lib/memory/__stack_pointer
    global.get $instanceof/nullableBlackcat
    local.tee $0
-   i32.store $0 offset=56
+   i32.store $0 offset=60
    local.get $0
    if (result i32)
     local.get $0
     i32.const 8
     i32.sub
     i32.load $0
-    i32.const 13
+    i32.const 14
     i32.eq
    else
     i32.const 0
@@ -2800,16 +2868,13 @@
    if
     i32.const 0
     i32.const 1456
-    i32.const 159
+    i32.const 168
     i32.const 1
     call $~lib/builtins/abort
     unreachable
    end
    global.get $~lib/memory/__stack_pointer
    local.tee $0
-   i32.const 0
-   i32.store $0 offset=60
-   local.get $0
    i32.const 0
    i32.store $0 offset=64
    local.get $0
@@ -2825,11 +2890,14 @@
    i32.const 0
    i32.store $0 offset=80
    local.get $0
+   i32.const 0
+   i32.store $0 offset=84
+   local.get $0
    i32.const 8
    i32.sub
    global.set $~lib/memory/__stack_pointer
    global.get $~lib/memory/__stack_pointer
-   i32.const 1584
+   i32.const 1588
    i32.lt_s
    br_if $folding-inner0
    global.get $~lib/memory/__stack_pointer
@@ -2837,7 +2905,7 @@
    i64.const 0
    i64.store $0
    local.get $0
-   i32.const 14
+   i32.const 15
    call $~lib/rt/itcms/__new
    local.tee $0
    i32.store $0
@@ -2867,7 +2935,7 @@
    i32.sub
    global.set $~lib/memory/__stack_pointer
    global.get $~lib/memory/__stack_pointer
-   i32.const 1584
+   i32.const 1588
    i32.lt_s
    br_if $folding-inner0
    global.get $~lib/memory/__stack_pointer
@@ -2875,7 +2943,7 @@
    i64.const 0
    i64.store $0
    local.get $0
-   i32.const 21
+   i32.const 22
    call $~lib/rt/itcms/__new
    local.tee $0
    i32.store $0
@@ -2897,58 +2965,58 @@
    global.get $~lib/memory/__stack_pointer
    global.get $instanceof/w
    local.tee $1
-   i32.store $0 offset=84
+   i32.store $0
    global.get $~lib/memory/__stack_pointer
    global.get $instanceof/x
    local.tee $2
-   i32.store $0 offset=84
+   i32.store $0
    global.get $~lib/memory/__stack_pointer
    global.get $instanceof/y
    local.tee $3
-   i32.store $0 offset=84
+   i32.store $0
    global.get $~lib/memory/__stack_pointer
    global.get $instanceof/z
    local.tee $0
-   i32.store $0 offset=84
+   i32.store $0
    global.get $~lib/memory/__stack_pointer
    local.get $2
-   i32.store $0 offset=84
+   i32.store $0
    global.get $~lib/memory/__stack_pointer
    local.get $2
-   i32.store $0 offset=84
+   i32.store $0
    global.get $~lib/memory/__stack_pointer
    local.get $3
-   i32.store $0 offset=84
+   i32.store $0
    global.get $~lib/memory/__stack_pointer
    local.get $3
-   i32.store $0 offset=84
+   i32.store $0
    global.get $~lib/memory/__stack_pointer
    local.get $3
-   i32.store $0 offset=84
+   i32.store $0
    global.get $~lib/memory/__stack_pointer
    local.get $3
-   i32.store $0 offset=84
+   i32.store $0
    global.get $~lib/memory/__stack_pointer
    local.get $0
-   i32.store $0 offset=84
+   i32.store $0
    global.get $~lib/memory/__stack_pointer
    local.get $0
-   i32.store $0 offset=84
+   i32.store $0
    global.get $~lib/memory/__stack_pointer
    local.get $0
-   i32.store $0 offset=84
+   i32.store $0
    global.get $~lib/memory/__stack_pointer
    local.get $0
-   i32.store $0 offset=84
+   i32.store $0
    global.get $~lib/memory/__stack_pointer
    local.get $1
-   i32.store $0 offset=84
+   i32.store $0
    global.get $~lib/memory/__stack_pointer
    i32.const 4
    i32.sub
    global.set $~lib/memory/__stack_pointer
    global.get $~lib/memory/__stack_pointer
-   i32.const 1584
+   i32.const 1588
    i32.lt_s
    br_if $folding-inner0
    global.get $~lib/memory/__stack_pointer
@@ -2964,7 +3032,7 @@
     i32.const 8
     i32.sub
     i32.load $0
-    i32.const 14
+    i32.const 15
     i32.eq
    else
     i32.const 0
@@ -2985,533 +3053,533 @@
    global.get $~lib/memory/__stack_pointer
    global.get $instanceof/x
    local.tee $0
-   i32.store $0 offset=84
+   i32.store $0
    local.get $0
    call $instanceof/assertDynamicTrue<~lib/object/Object,instanceof/X>
    global.get $~lib/memory/__stack_pointer
    global.get $instanceof/y
    local.tee $0
-   i32.store $0 offset=84
+   i32.store $0
    local.get $0
    call $instanceof/assertDynamicTrue<~lib/object/Object,instanceof/X>
    global.get $~lib/memory/__stack_pointer
    global.get $instanceof/z
    local.tee $0
-   i32.store $0 offset=84
+   i32.store $0
    local.get $0
    call $instanceof/assertDynamicTrue<~lib/object/Object,instanceof/X>
    global.get $~lib/memory/__stack_pointer
    global.get $instanceof/y
    local.tee $0
-   i32.store $0 offset=84
+   i32.store $0
    local.get $0
    call $instanceof/assertDynamicTrue<~lib/object/Object,instanceof/Y>
    global.get $~lib/memory/__stack_pointer
    global.get $instanceof/z
    local.tee $0
-   i32.store $0 offset=84
+   i32.store $0
    local.get $0
    call $instanceof/assertDynamicTrue<~lib/object/Object,instanceof/Y>
    global.get $~lib/memory/__stack_pointer
    global.get $instanceof/z
    local.tee $0
-   i32.store $0 offset=84
+   i32.store $0
    local.get $0
    call $instanceof/assertDynamicTrue<~lib/object/Object,instanceof/Z>
    global.get $~lib/memory/__stack_pointer
    global.get $instanceof/x
    local.tee $0
-   i32.store $0 offset=84
+   i32.store $0
    local.get $0
    call $instanceof/assertDynamicTrue<~lib/object/Object,instanceof/X>
    global.get $~lib/memory/__stack_pointer
    global.get $instanceof/x
    local.tee $0
-   i32.store $0 offset=84
+   i32.store $0
    local.get $0
    call $instanceof/assertDynamicTrue<~lib/object/Object,instanceof/X>
    global.get $~lib/memory/__stack_pointer
    global.get $instanceof/y
    local.tee $0
-   i32.store $0 offset=84
+   i32.store $0
    local.get $0
    call $instanceof/assertDynamicTrue<~lib/object/Object,instanceof/X>
    global.get $~lib/memory/__stack_pointer
    global.get $instanceof/y
    local.tee $0
-   i32.store $0 offset=84
+   i32.store $0
    local.get $0
    call $instanceof/assertDynamicTrue<~lib/object/Object,instanceof/X>
    global.get $~lib/memory/__stack_pointer
    global.get $instanceof/y
    local.tee $0
-   i32.store $0 offset=84
+   i32.store $0
    local.get $0
    call $instanceof/assertDynamicTrue<~lib/object/Object,instanceof/Y>
    global.get $~lib/memory/__stack_pointer
    global.get $instanceof/y
    local.tee $0
-   i32.store $0 offset=84
+   i32.store $0
    local.get $0
    call $instanceof/assertDynamicTrue<~lib/object/Object,instanceof/Y>
    global.get $~lib/memory/__stack_pointer
    global.get $instanceof/z
    local.tee $0
-   i32.store $0 offset=84
+   i32.store $0
    local.get $0
    call $instanceof/assertDynamicTrue<~lib/object/Object,instanceof/X>
    global.get $~lib/memory/__stack_pointer
    global.get $instanceof/z
    local.tee $0
-   i32.store $0 offset=84
+   i32.store $0
    local.get $0
    call $instanceof/assertDynamicTrue<~lib/object/Object,instanceof/X>
    global.get $~lib/memory/__stack_pointer
    global.get $instanceof/z
    local.tee $0
-   i32.store $0 offset=84
+   i32.store $0
    local.get $0
    call $instanceof/assertDynamicTrue<~lib/object/Object,instanceof/Y>
    global.get $~lib/memory/__stack_pointer
    global.get $instanceof/z
    local.tee $0
-   i32.store $0 offset=84
+   i32.store $0
    local.get $0
    call $instanceof/assertDynamicTrue<~lib/object/Object,instanceof/Y>
    global.get $~lib/memory/__stack_pointer
    global.get $instanceof/w
    local.tee $0
-   i32.store $0 offset=84
+   i32.store $0
    global.get $~lib/memory/__stack_pointer
    local.get $0
-   i32.store $0 offset=84
+   i32.store $0
    global.get $~lib/memory/__stack_pointer
    local.get $0
-   i32.store $0 offset=84
+   i32.store $0
    global.get $~lib/memory/__stack_pointer
    local.get $0
-   i32.store $0 offset=84
+   i32.store $0
    global.get $~lib/memory/__stack_pointer
    global.get $instanceof/x
-   i32.store $0 offset=84
+   i32.store $0
    global.get $~lib/memory/__stack_pointer
    global.get $instanceof/y
-   i32.store $0 offset=84
+   i32.store $0
    global.get $~lib/memory/__stack_pointer
    global.get $instanceof/z
-   i32.store $0 offset=84
+   i32.store $0
    global.get $~lib/memory/__stack_pointer
    global.get $instanceof/x
-   i32.store $0 offset=84
+   i32.store $0
    global.get $~lib/memory/__stack_pointer
    global.get $instanceof/x
    local.tee $0
-   i32.store $0 offset=84
+   i32.store $0
    local.get $0
    call $instanceof/assertDynamicFalse<instanceof/X,instanceof/Y>
    global.get $~lib/memory/__stack_pointer
    global.get $instanceof/x
    local.tee $0
-   i32.store $0 offset=84
+   i32.store $0
    local.get $0
    call $instanceof/assertDynamicFalse<instanceof/X,instanceof/Z>
    global.get $~lib/memory/__stack_pointer
    global.get $instanceof/y
-   i32.store $0 offset=84
+   i32.store $0
    global.get $~lib/memory/__stack_pointer
    global.get $instanceof/y
    local.tee $0
-   i32.store $0 offset=84
+   i32.store $0
    local.get $0
    call $instanceof/assertDynamicTrue<~lib/object/Object,instanceof/Y>
    global.get $~lib/memory/__stack_pointer
    global.get $instanceof/y
    local.tee $0
-   i32.store $0 offset=84
+   i32.store $0
    local.get $0
    call $instanceof/assertDynamicFalse<instanceof/X,instanceof/Z>
    global.get $~lib/memory/__stack_pointer
    global.get $instanceof/z
-   i32.store $0 offset=84
+   i32.store $0
    global.get $~lib/memory/__stack_pointer
    global.get $instanceof/z
    local.tee $0
-   i32.store $0 offset=84
+   i32.store $0
    local.get $0
    call $instanceof/assertDynamicTrue<~lib/object/Object,instanceof/Y>
    global.get $~lib/memory/__stack_pointer
    global.get $instanceof/z
    local.tee $0
-   i32.store $0 offset=84
+   i32.store $0
    local.get $0
    call $instanceof/assertDynamicTrue<~lib/object/Object,instanceof/Z>
    global.get $~lib/memory/__stack_pointer
    global.get $instanceof/y
-   i32.store $0 offset=84
+   i32.store $0
    global.get $~lib/memory/__stack_pointer
    global.get $instanceof/y
-   i32.store $0 offset=84
+   i32.store $0
    global.get $~lib/memory/__stack_pointer
    global.get $instanceof/y
    local.tee $0
-   i32.store $0 offset=84
+   i32.store $0
    local.get $0
    call $instanceof/assertDynamicFalse<instanceof/X,instanceof/Z>
    global.get $~lib/memory/__stack_pointer
    global.get $instanceof/z
-   i32.store $0 offset=84
+   i32.store $0
    global.get $~lib/memory/__stack_pointer
    global.get $instanceof/z
-   i32.store $0 offset=84
+   i32.store $0
    global.get $~lib/memory/__stack_pointer
    global.get $instanceof/z
    local.tee $0
-   i32.store $0 offset=84
+   i32.store $0
    local.get $0
    call $instanceof/assertDynamicTrue<~lib/object/Object,instanceof/Z>
    global.get $~lib/memory/__stack_pointer
    global.get $instanceof/z
-   i32.store $0 offset=84
+   i32.store $0
    global.get $~lib/memory/__stack_pointer
    global.get $instanceof/z
-   i32.store $0 offset=84
+   i32.store $0
    global.get $~lib/memory/__stack_pointer
    global.get $instanceof/z
-   i32.store $0 offset=84
+   i32.store $0
    global.get $~lib/memory/__stack_pointer
    global.get $instanceof/x
    local.tee $0
-   i32.store $0 offset=84
+   i32.store $0
    local.get $0
    call $instanceof/assertDynamicFalse<instanceof/X,instanceof/Y>
    global.get $~lib/memory/__stack_pointer
    global.get $instanceof/x
    local.tee $0
-   i32.store $0 offset=84
+   i32.store $0
    local.get $0
    call $instanceof/assertDynamicFalse<instanceof/X,instanceof/Y>
    global.get $~lib/memory/__stack_pointer
    global.get $instanceof/x
    local.tee $0
-   i32.store $0 offset=84
+   i32.store $0
    local.get $0
    call $instanceof/assertDynamicFalse<instanceof/X,instanceof/Y>
    global.get $~lib/memory/__stack_pointer
    global.get $instanceof/x
    local.tee $0
-   i32.store $0 offset=84
+   i32.store $0
    local.get $0
    call $instanceof/assertDynamicFalse<instanceof/X,instanceof/Y>
    global.get $~lib/memory/__stack_pointer
    global.get $instanceof/x
-   i32.store $0 offset=84
+   i32.store $0
    global.get $~lib/memory/__stack_pointer
    global.get $instanceof/x
-   i32.store $0 offset=84
+   i32.store $0
    global.get $~lib/memory/__stack_pointer
    global.get $instanceof/y
    local.tee $0
-   i32.store $0 offset=84
-   local.get $0
-   call $instanceof/assertDynamicTrue<~lib/object/Object,instanceof/Y>
-   global.get $~lib/memory/__stack_pointer
-   global.get $instanceof/y
-   local.tee $0
-   i32.store $0 offset=84
+   i32.store $0
    local.get $0
    call $instanceof/assertDynamicTrue<~lib/object/Object,instanceof/Y>
    global.get $~lib/memory/__stack_pointer
    global.get $instanceof/y
    local.tee $0
-   i32.store $0 offset=84
+   i32.store $0
    local.get $0
    call $instanceof/assertDynamicTrue<~lib/object/Object,instanceof/Y>
    global.get $~lib/memory/__stack_pointer
    global.get $instanceof/y
    local.tee $0
-   i32.store $0 offset=84
+   i32.store $0
    local.get $0
    call $instanceof/assertDynamicTrue<~lib/object/Object,instanceof/Y>
    global.get $~lib/memory/__stack_pointer
    global.get $instanceof/y
-   i32.store $0 offset=84
+   local.tee $0
+   i32.store $0
+   local.get $0
+   call $instanceof/assertDynamicTrue<~lib/object/Object,instanceof/Y>
    global.get $~lib/memory/__stack_pointer
    global.get $instanceof/y
-   i32.store $0 offset=84
+   i32.store $0
+   global.get $~lib/memory/__stack_pointer
+   global.get $instanceof/y
+   i32.store $0
    global.get $~lib/memory/__stack_pointer
    global.get $instanceof/z
    local.tee $0
-   i32.store $0 offset=84
+   i32.store $0
    local.get $0
    call $instanceof/assertDynamicTrue<~lib/object/Object,instanceof/Y>
    global.get $~lib/memory/__stack_pointer
    global.get $instanceof/z
    local.tee $0
-   i32.store $0 offset=84
+   i32.store $0
    local.get $0
    call $instanceof/assertDynamicTrue<~lib/object/Object,instanceof/Y>
    global.get $~lib/memory/__stack_pointer
    global.get $instanceof/z
    local.tee $0
-   i32.store $0 offset=84
+   i32.store $0
    local.get $0
    call $instanceof/assertDynamicTrue<~lib/object/Object,instanceof/Y>
    global.get $~lib/memory/__stack_pointer
    global.get $instanceof/z
    local.tee $0
-   i32.store $0 offset=84
+   i32.store $0
    local.get $0
    call $instanceof/assertDynamicTrue<~lib/object/Object,instanceof/Y>
    global.get $~lib/memory/__stack_pointer
    global.get $instanceof/z
-   i32.store $0 offset=84
+   i32.store $0
    global.get $~lib/memory/__stack_pointer
    global.get $instanceof/z
-   i32.store $0 offset=84
+   i32.store $0
    global.get $~lib/memory/__stack_pointer
    global.get $instanceof/x
-   i32.store $0 offset=84
+   i32.store $0
    global.get $~lib/memory/__stack_pointer
    global.get $instanceof/x
-   i32.store $0 offset=84
+   i32.store $0
    global.get $~lib/memory/__stack_pointer
    global.get $instanceof/x
    local.tee $0
-   i32.store $0 offset=84
+   i32.store $0
    local.get $0
    call $instanceof/assertDynamicFalse<instanceof/X,instanceof/Y>
    global.get $~lib/memory/__stack_pointer
    global.get $instanceof/x
    local.tee $0
-   i32.store $0 offset=84
+   i32.store $0
    local.get $0
    call $instanceof/assertDynamicFalse<instanceof/X,instanceof/Y>
    global.get $~lib/memory/__stack_pointer
    global.get $instanceof/x
-   i32.store $0 offset=84
+   i32.store $0
    global.get $~lib/memory/__stack_pointer
    global.get $instanceof/y
-   i32.store $0 offset=84
+   i32.store $0
    global.get $~lib/memory/__stack_pointer
    global.get $instanceof/y
-   i32.store $0 offset=84
+   i32.store $0
    global.get $~lib/memory/__stack_pointer
    global.get $instanceof/y
    local.tee $0
-   i32.store $0 offset=84
+   i32.store $0
    local.get $0
    call $instanceof/assertDynamicTrue<~lib/object/Object,instanceof/Y>
    global.get $~lib/memory/__stack_pointer
    global.get $instanceof/y
    local.tee $0
-   i32.store $0 offset=84
+   i32.store $0
    local.get $0
    call $instanceof/assertDynamicTrue<~lib/object/Object,instanceof/Y>
    global.get $~lib/memory/__stack_pointer
    global.get $instanceof/y
-   i32.store $0 offset=84
+   i32.store $0
    global.get $~lib/memory/__stack_pointer
    global.get $instanceof/z
-   i32.store $0 offset=84
+   i32.store $0
    global.get $~lib/memory/__stack_pointer
    global.get $instanceof/z
-   i32.store $0 offset=84
+   i32.store $0
    global.get $~lib/memory/__stack_pointer
    global.get $instanceof/z
    local.tee $0
-   i32.store $0 offset=84
+   i32.store $0
    local.get $0
    call $instanceof/assertDynamicTrue<~lib/object/Object,instanceof/Y>
    global.get $~lib/memory/__stack_pointer
    global.get $instanceof/z
    local.tee $0
-   i32.store $0 offset=84
+   i32.store $0
    local.get $0
    call $instanceof/assertDynamicTrue<~lib/object/Object,instanceof/Y>
    global.get $~lib/memory/__stack_pointer
    global.get $instanceof/z
-   i32.store $0 offset=84
+   i32.store $0
    global.get $~lib/memory/__stack_pointer
    global.get $instanceof/y
-   i32.store $0 offset=84
+   i32.store $0
    global.get $~lib/memory/__stack_pointer
    global.get $instanceof/y
-   i32.store $0 offset=84
+   i32.store $0
    global.get $~lib/memory/__stack_pointer
    global.get $instanceof/y
-   i32.store $0 offset=84
+   i32.store $0
    global.get $~lib/memory/__stack_pointer
    global.get $instanceof/y
-   i32.store $0 offset=84
+   i32.store $0
    global.get $~lib/memory/__stack_pointer
    global.get $instanceof/y
-   i32.store $0 offset=84
+   i32.store $0
    global.get $~lib/memory/__stack_pointer
    global.get $instanceof/z
-   i32.store $0 offset=84
+   i32.store $0
    global.get $~lib/memory/__stack_pointer
    global.get $instanceof/z
-   i32.store $0 offset=84
+   i32.store $0
    global.get $~lib/memory/__stack_pointer
    global.get $instanceof/z
-   i32.store $0 offset=84
+   i32.store $0
    global.get $~lib/memory/__stack_pointer
    global.get $instanceof/z
-   i32.store $0 offset=84
+   i32.store $0
    global.get $~lib/memory/__stack_pointer
    global.get $instanceof/z
-   i32.store $0 offset=84
+   i32.store $0
    global.get $~lib/memory/__stack_pointer
    global.get $instanceof/z
-   i32.store $0 offset=84
+   i32.store $0
    global.get $~lib/memory/__stack_pointer
    global.get $instanceof/z
-   i32.store $0 offset=84
+   i32.store $0
    global.get $~lib/memory/__stack_pointer
    global.get $instanceof/z
-   i32.store $0 offset=84
+   i32.store $0
    global.get $~lib/memory/__stack_pointer
    global.get $instanceof/z
-   i32.store $0 offset=84
+   i32.store $0
    global.get $~lib/memory/__stack_pointer
    global.get $instanceof/z
-   i32.store $0 offset=84
+   i32.store $0
    global.get $~lib/memory/__stack_pointer
    global.get $instanceof/x
-   i32.store $0 offset=84
+   i32.store $0
    global.get $~lib/memory/__stack_pointer
    global.get $instanceof/x
-   i32.store $0 offset=84
+   i32.store $0
    global.get $~lib/memory/__stack_pointer
    global.get $instanceof/y
-   i32.store $0 offset=84
+   i32.store $0
    global.get $~lib/memory/__stack_pointer
    global.get $instanceof/y
-   i32.store $0 offset=84
+   i32.store $0
    global.get $~lib/memory/__stack_pointer
    global.get $instanceof/y
-   i32.store $0 offset=84
+   i32.store $0
    global.get $~lib/memory/__stack_pointer
    global.get $instanceof/y
-   i32.store $0 offset=84
+   i32.store $0
    global.get $~lib/memory/__stack_pointer
    global.get $instanceof/z
-   i32.store $0 offset=84
+   i32.store $0
    global.get $~lib/memory/__stack_pointer
    global.get $instanceof/z
-   i32.store $0 offset=84
+   i32.store $0
    global.get $~lib/memory/__stack_pointer
    global.get $instanceof/z
-   i32.store $0 offset=84
+   i32.store $0
    global.get $~lib/memory/__stack_pointer
    global.get $instanceof/z
-   i32.store $0 offset=84
-   global.get $~lib/memory/__stack_pointer
-   global.get $instanceof/x
-   local.tee $0
-   i32.store $0 offset=84
-   local.get $0
-   call $instanceof/assertDynamicTrue<~lib/object/Object,instanceof/X>
+   i32.store $0
    global.get $~lib/memory/__stack_pointer
    global.get $instanceof/x
    local.tee $0
-   i32.store $0 offset=84
+   i32.store $0
+   local.get $0
+   call $instanceof/assertDynamicTrue<~lib/object/Object,instanceof/X>
+   global.get $~lib/memory/__stack_pointer
+   global.get $instanceof/x
+   local.tee $0
+   i32.store $0
    local.get $0
    call $instanceof/assertDynamicTrue<~lib/object/Object,instanceof/X>
    global.get $~lib/memory/__stack_pointer
    global.get $instanceof/y
    local.tee $0
-   i32.store $0 offset=84
+   i32.store $0
    local.get $0
    call $instanceof/assertDynamicTrue<~lib/object/Object,instanceof/X>
    global.get $~lib/memory/__stack_pointer
    global.get $instanceof/y
    local.tee $0
-   i32.store $0 offset=84
+   i32.store $0
    local.get $0
    call $instanceof/assertDynamicTrue<~lib/object/Object,instanceof/X>
    global.get $~lib/memory/__stack_pointer
    global.get $instanceof/z
    local.tee $0
-   i32.store $0 offset=84
+   i32.store $0
    local.get $0
    call $instanceof/assertDynamicTrue<~lib/object/Object,instanceof/X>
    global.get $~lib/memory/__stack_pointer
    global.get $instanceof/z
    local.tee $0
-   i32.store $0 offset=84
+   i32.store $0
    local.get $0
    call $instanceof/assertDynamicTrue<~lib/object/Object,instanceof/X>
    global.get $~lib/memory/__stack_pointer
    global.get $instanceof/y
    local.tee $0
-   i32.store $0 offset=84
+   i32.store $0
    local.get $0
    call $instanceof/assertDynamicTrue<~lib/object/Object,instanceof/Y>
    global.get $~lib/memory/__stack_pointer
    global.get $instanceof/y
    local.tee $0
-   i32.store $0 offset=84
+   i32.store $0
    local.get $0
    call $instanceof/assertDynamicTrue<~lib/object/Object,instanceof/Y>
    global.get $~lib/memory/__stack_pointer
    global.get $instanceof/y
    local.tee $0
-   i32.store $0 offset=84
+   i32.store $0
    local.get $0
    call $instanceof/assertDynamicTrue<~lib/object/Object,instanceof/Y>
    global.get $~lib/memory/__stack_pointer
    global.get $instanceof/y
    local.tee $0
-   i32.store $0 offset=84
+   i32.store $0
    local.get $0
    call $instanceof/assertDynamicTrue<~lib/object/Object,instanceof/Y>
    global.get $~lib/memory/__stack_pointer
    global.get $instanceof/z
    local.tee $0
-   i32.store $0 offset=84
+   i32.store $0
    local.get $0
    call $instanceof/assertDynamicTrue<~lib/object/Object,instanceof/Y>
    global.get $~lib/memory/__stack_pointer
    global.get $instanceof/z
    local.tee $0
-   i32.store $0 offset=84
+   i32.store $0
    local.get $0
    call $instanceof/assertDynamicTrue<~lib/object/Object,instanceof/Y>
    global.get $~lib/memory/__stack_pointer
    global.get $instanceof/z
    local.tee $0
-   i32.store $0 offset=84
+   i32.store $0
    local.get $0
    call $instanceof/assertDynamicTrue<~lib/object/Object,instanceof/Y>
    global.get $~lib/memory/__stack_pointer
    global.get $instanceof/z
    local.tee $0
-   i32.store $0 offset=84
+   i32.store $0
    local.get $0
    call $instanceof/assertDynamicTrue<~lib/object/Object,instanceof/Y>
    global.get $~lib/memory/__stack_pointer
    global.get $instanceof/z
    local.tee $0
-   i32.store $0 offset=84
-   local.get $0
-   call $instanceof/assertDynamicTrue<~lib/object/Object,instanceof/Z>
-   global.get $~lib/memory/__stack_pointer
-   global.get $instanceof/z
-   local.tee $0
-   i32.store $0 offset=84
+   i32.store $0
    local.get $0
    call $instanceof/assertDynamicTrue<~lib/object/Object,instanceof/Z>
    global.get $~lib/memory/__stack_pointer
    global.get $instanceof/z
    local.tee $0
-   i32.store $0 offset=84
+   i32.store $0
    local.get $0
    call $instanceof/assertDynamicTrue<~lib/object/Object,instanceof/Z>
    global.get $~lib/memory/__stack_pointer
    global.get $instanceof/z
    local.tee $0
-   i32.store $0 offset=84
+   i32.store $0
+   local.get $0
+   call $instanceof/assertDynamicTrue<~lib/object/Object,instanceof/Z>
+   global.get $~lib/memory/__stack_pointer
+   global.get $instanceof/z
+   local.tee $0
+   i32.store $0
    local.get $0
    call $instanceof/assertDynamicTrue<~lib/object/Object,instanceof/Z>
    global.get $~lib/memory/__stack_pointer
@@ -3533,7 +3601,7 @@
   i32.sub
   global.set $~lib/memory/__stack_pointer
   global.get $~lib/memory/__stack_pointer
-  i32.const 1584
+  i32.const 1588
   i32.lt_s
   if
    i32.const 34384

--- a/tests/compiler/instanceof.release.wat
+++ b/tests/compiler/instanceof.release.wat
@@ -2239,7 +2239,11 @@
     i32.store $0
     local.get $0
     if
-     unreachable
+     local.get $0
+     i32.const 8
+     i32.sub
+     i32.load $0
+     drop
     end
     global.get $~lib/memory/__stack_pointer
     i32.const 4

--- a/tests/compiler/instanceof.ts
+++ b/tests/compiler/instanceof.ts
@@ -21,11 +21,20 @@ function assertDynamicFalse<T,U>(value: T): void {
   assert(isDefined(check));
 }
 
-class A {}
+class A {
+  checkInstanceof(): void {}
+}
 class B extends A {}
 
 var a: A = new A();
+class C extends A {
+  checkInstanceof(): void {
+    if (a instanceof C) {
+    }
+  }
+}
 var b: B = new B();
+(new C() as A).checkInstanceof();
 var i: i32;
 var I: i64;
 var f: f32;


### PR DESCRIPTION
fix: #2660

switch the order of `compile pending instanceof helpers` and `set up override stubs`