### PR TITLE
fix: introduce resolver type before compiling a not eq expresssion

### DIFF
--- a/src/compiler.ts
+++ b/src/compiler.ts
@@ -3967,7 +3967,16 @@ export class Compiler extends DiagnosticEmitter {
       }
       case Token.Exclamation_Equals_Equals:
       case Token.Exclamation_Equals: {
-        leftExpr = this.compileExpression(left, contextualType);
+        let resolver = this.resolver;
+        let leftType = resolver.resolveExpression(left, this.currentFlow, Type.auto, ReportMode.Swallow);
+        if (leftType == this.options.usizeType || leftType == Type.auto || leftType == null) {
+          let rightType = this.resolver.resolveExpression(right, this.currentFlow, Type.auto, ReportMode.Swallow);
+          leftType = rightType;
+        }
+        if (leftType == null) {
+          leftType = Type.auto;
+        }
+        leftExpr = this.compileExpression(left, leftType);
         leftType = this.currentType;
 
         // check operator overload
@@ -3982,7 +3991,7 @@ export class Compiler extends DiagnosticEmitter {
 
         rightExpr = this.compileExpression(right, leftType);
         rightType = this.currentType;
-        commonType = Type.commonType(leftType, rightType, contextualType);
+        commonType = Type.commonType(leftType, rightType);
         if (!commonType) {
           this.error(
             DiagnosticCode.Operator_0_cannot_be_applied_to_types_1_and_2,

--- a/tests/compiler/builtins.debug.wat
+++ b/tests/compiler/builtins.debug.wat
@@ -3276,11 +3276,11 @@
   local.set $48
   i32.const 0
   local.set $49
-  i32.const 51
+  i32.const 52
   local.set $50
-  i32.const 52
+  i32.const 53
   local.set $51
-  i32.const 52
+  i32.const 53
   local.set $52
   i32.const 256
   local.set $63
@@ -3325,7 +3325,7 @@
    unreachable
   end
   local.get $50
-  i32.const 51
+  i32.const 52
   i32.eq
   i32.eqz
   if

--- a/tests/compiler/builtins.release.wat
+++ b/tests/compiler/builtins.release.wat
@@ -778,9 +778,9 @@
   i32.const 5
   f64.const 0
   f64.const 0
-  f64.const 51
   f64.const 52
-  f64.const 52
+  f64.const 53
+  f64.const 53
   call $~lib/builtins/trace
   global.get $~lib/memory/__stack_pointer
   local.tee $0

--- a/tests/compiler/field-initialization.debug.wat
+++ b/tests/compiler/field-initialization.debug.wat
@@ -4287,6 +4287,24 @@
    call $~lib/builtins/abort
    unreachable
   end
+  i32.const 0
+  local.get $3
+  local.set $34
+  global.get $~lib/memory/__stack_pointer
+  local.get $34
+  i32.store $0 offset=4
+  local.get $34
+  call $field-initialization/Nullable_Init#get:a
+  i32.ne
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 432
+   i32.const 33
+   i32.const 3
+   call $~lib/builtins/abort
+   unreachable
+  end
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   call $field-initialization/Nullable#constructor
@@ -4305,7 +4323,7 @@
   if
    i32.const 0
    i32.const 432
-   i32.const 40
+   i32.const 41
    i32.const 3
    call $~lib/builtins/abort
    unreachable
@@ -4328,7 +4346,7 @@
   if
    i32.const 0
    i32.const 432
-   i32.const 52
+   i32.const 53
    i32.const 3
    call $~lib/builtins/abort
    unreachable
@@ -4351,7 +4369,7 @@
   if
    i32.const 0
    i32.const 432
-   i32.const 62
+   i32.const 63
    i32.const 3
    call $~lib/builtins/abort
    unreachable
@@ -4374,7 +4392,7 @@
   if
    i32.const 0
    i32.const 432
-   i32.const 73
+   i32.const 74
    i32.const 3
    call $~lib/builtins/abort
    unreachable
@@ -4397,7 +4415,7 @@
   if
    i32.const 0
    i32.const 432
-   i32.const 83
+   i32.const 84
    i32.const 3
    call $~lib/builtins/abort
    unreachable
@@ -4420,7 +4438,7 @@
   if
    i32.const 0
    i32.const 432
-   i32.const 94
+   i32.const 95
    i32.const 3
    call $~lib/builtins/abort
    unreachable
@@ -4455,7 +4473,7 @@
   if
    i32.const 0
    i32.const 432
-   i32.const 104
+   i32.const 105
    i32.const 3
    call $~lib/builtins/abort
    unreachable
@@ -4478,7 +4496,7 @@
   if
    i32.const 0
    i32.const 432
-   i32.const 114
+   i32.const 115
    i32.const 3
    call $~lib/builtins/abort
    unreachable
@@ -4501,7 +4519,7 @@
   if
    i32.const 0
    i32.const 432
-   i32.const 124
+   i32.const 125
    i32.const 3
    call $~lib/builtins/abort
    unreachable
@@ -4524,7 +4542,7 @@
   if
    i32.const 0
    i32.const 432
-   i32.const 135
+   i32.const 136
    i32.const 3
    call $~lib/builtins/abort
    unreachable
@@ -4547,7 +4565,7 @@
   if
    i32.const 0
    i32.const 432
-   i32.const 147
+   i32.const 148
    i32.const 3
    call $~lib/builtins/abort
    unreachable
@@ -4570,7 +4588,7 @@
   if
    i32.const 0
    i32.const 432
-   i32.const 153
+   i32.const 154
    i32.const 3
    call $~lib/builtins/abort
    unreachable
@@ -4603,7 +4621,7 @@
   if
    i32.const 0
    i32.const 432
-   i32.const 164
+   i32.const 165
    i32.const 3
    call $~lib/builtins/abort
    unreachable
@@ -4626,7 +4644,7 @@
   if
    i32.const 0
    i32.const 432
-   i32.const 165
+   i32.const 166
    i32.const 3
    call $~lib/builtins/abort
    unreachable
@@ -4664,7 +4682,7 @@
   if
    i32.const 0
    i32.const 432
-   i32.const 167
+   i32.const 168
    i32.const 3
    call $~lib/builtins/abort
    unreachable
@@ -4687,7 +4705,7 @@
   if
    i32.const 0
    i32.const 432
-   i32.const 168
+   i32.const 169
    i32.const 3
    call $~lib/builtins/abort
    unreachable
@@ -4730,7 +4748,7 @@
   if
    i32.const 0
    i32.const 432
-   i32.const 170
+   i32.const 171
    i32.const 3
    call $~lib/builtins/abort
    unreachable
@@ -4758,7 +4776,7 @@
   if
    i32.const 0
    i32.const 432
-   i32.const 171
+   i32.const 172
    i32.const 3
    call $~lib/builtins/abort
    unreachable
@@ -4806,7 +4824,7 @@
   if
    i32.const 0
    i32.const 432
-   i32.const 173
+   i32.const 174
    i32.const 3
    call $~lib/builtins/abort
    unreachable
@@ -4834,7 +4852,7 @@
   if
    i32.const 0
    i32.const 432
-   i32.const 174
+   i32.const 175
    i32.const 3
    call $~lib/builtins/abort
    unreachable
@@ -4880,7 +4898,7 @@
   if
    i32.const 0
    i32.const 432
-   i32.const 182
+   i32.const 183
    i32.const 3
    call $~lib/builtins/abort
    unreachable
@@ -4903,7 +4921,7 @@
   if
    i32.const 0
    i32.const 432
-   i32.const 183
+   i32.const 184
    i32.const 3
    call $~lib/builtins/abort
    unreachable
@@ -4931,7 +4949,7 @@
   if
    i32.const 0
    i32.const 432
-   i32.const 184
+   i32.const 185
    i32.const 3
    call $~lib/builtins/abort
    unreachable
@@ -4992,7 +5010,7 @@
   if
    i32.const 0
    i32.const 432
-   i32.const 186
+   i32.const 187
    i32.const 3
    call $~lib/builtins/abort
    unreachable
@@ -5020,7 +5038,7 @@
   if
    i32.const 0
    i32.const 432
-   i32.const 187
+   i32.const 188
    i32.const 3
    call $~lib/builtins/abort
    unreachable
@@ -5048,7 +5066,7 @@
   if
    i32.const 0
    i32.const 432
-   i32.const 188
+   i32.const 189
    i32.const 3
    call $~lib/builtins/abort
    unreachable
@@ -5072,7 +5090,7 @@
   if
    i32.const 0
    i32.const 432
-   i32.const 205
+   i32.const 206
    i32.const 3
    call $~lib/builtins/abort
    unreachable
@@ -5121,7 +5139,7 @@
   if
    i32.const 0
    i32.const 432
-   i32.const 218
+   i32.const 219
    i32.const 3
    call $~lib/builtins/abort
    unreachable
@@ -5178,7 +5196,7 @@
   if
    i32.const 0
    i32.const 432
-   i32.const 230
+   i32.const 231
    i32.const 3
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/field-initialization.release.wat
+++ b/tests/compiler/field-initialization.release.wat
@@ -2233,6 +2233,20 @@
     unreachable
    end
    global.get $~lib/memory/__stack_pointer
+   local.get $1
+   i32.store $0 offset=4
+   local.get $1
+   i32.load $0
+   i32.eqz
+   if
+    i32.const 0
+    i32.const 1456
+    i32.const 33
+    i32.const 3
+    call $~lib/builtins/abort
+    unreachable
+   end
+   global.get $~lib/memory/__stack_pointer
    local.tee $0
    i32.const 8
    i32.sub
@@ -2281,7 +2295,7 @@
    if
     i32.const 0
     i32.const 1456
-    i32.const 40
+    i32.const 41
     i32.const 3
     call $~lib/builtins/abort
     unreachable
@@ -2327,7 +2341,7 @@
    if
     i32.const 0
     i32.const 1456
-    i32.const 52
+    i32.const 53
     i32.const 3
     call $~lib/builtins/abort
     unreachable
@@ -2375,7 +2389,7 @@
    if
     i32.const 0
     i32.const 1456
-    i32.const 62
+    i32.const 63
     i32.const 3
     call $~lib/builtins/abort
     unreachable
@@ -2429,7 +2443,7 @@
    if
     i32.const 0
     i32.const 1456
-    i32.const 73
+    i32.const 74
     i32.const 3
     call $~lib/builtins/abort
     unreachable
@@ -2489,7 +2503,7 @@
    if
     i32.const 0
     i32.const 1456
-    i32.const 83
+    i32.const 84
     i32.const 3
     call $~lib/builtins/abort
     unreachable
@@ -2555,7 +2569,7 @@
    if
     i32.const 0
     i32.const 1456
-    i32.const 94
+    i32.const 95
     i32.const 3
     call $~lib/builtins/abort
     unreachable
@@ -2623,7 +2637,7 @@
    if
     i32.const 0
     i32.const 1456
-    i32.const 104
+    i32.const 105
     i32.const 3
     call $~lib/builtins/abort
     unreachable
@@ -2668,7 +2682,7 @@
    if
     i32.const 0
     i32.const 1456
-    i32.const 114
+    i32.const 115
     i32.const 3
     call $~lib/builtins/abort
     unreachable
@@ -2728,7 +2742,7 @@
    if
     i32.const 0
     i32.const 1456
-    i32.const 124
+    i32.const 125
     i32.const 3
     call $~lib/builtins/abort
     unreachable
@@ -2794,7 +2808,7 @@
    if
     i32.const 0
     i32.const 1456
-    i32.const 135
+    i32.const 136
     i32.const 3
     call $~lib/builtins/abort
     unreachable
@@ -2843,7 +2857,7 @@
    if
     i32.const 0
     i32.const 1456
-    i32.const 147
+    i32.const 148
     i32.const 3
     call $~lib/builtins/abort
     unreachable
@@ -2892,7 +2906,7 @@
    if
     i32.const 0
     i32.const 1456
-    i32.const 153
+    i32.const 154
     i32.const 3
     call $~lib/builtins/abort
     unreachable
@@ -2920,7 +2934,7 @@
    if
     i32.const 0
     i32.const 1456
-    i32.const 164
+    i32.const 165
     i32.const 3
     call $~lib/builtins/abort
     unreachable
@@ -2941,7 +2955,7 @@
    if
     i32.const 0
     i32.const 1456
-    i32.const 165
+    i32.const 166
     i32.const 3
     call $~lib/builtins/abort
     unreachable
@@ -2974,7 +2988,7 @@
    if
     i32.const 0
     i32.const 1456
-    i32.const 167
+    i32.const 168
     i32.const 3
     call $~lib/builtins/abort
     unreachable
@@ -2995,7 +3009,7 @@
    if
     i32.const 0
     i32.const 1456
-    i32.const 168
+    i32.const 169
     i32.const 3
     call $~lib/builtins/abort
     unreachable
@@ -3032,7 +3046,7 @@
    if
     i32.const 0
     i32.const 1456
-    i32.const 170
+    i32.const 171
     i32.const 3
     call $~lib/builtins/abort
     unreachable
@@ -3056,7 +3070,7 @@
    if
     i32.const 0
     i32.const 1456
-    i32.const 171
+    i32.const 172
     i32.const 3
     call $~lib/builtins/abort
     unreachable
@@ -3098,7 +3112,7 @@
    if
     i32.const 0
     i32.const 1456
-    i32.const 173
+    i32.const 174
     i32.const 3
     call $~lib/builtins/abort
     unreachable
@@ -3122,7 +3136,7 @@
    if
     i32.const 0
     i32.const 1456
-    i32.const 174
+    i32.const 175
     i32.const 3
     call $~lib/builtins/abort
     unreachable
@@ -3161,7 +3175,7 @@
    if
     i32.const 0
     i32.const 1456
-    i32.const 182
+    i32.const 183
     i32.const 3
     call $~lib/builtins/abort
     unreachable
@@ -3182,7 +3196,7 @@
    if
     i32.const 0
     i32.const 1456
-    i32.const 183
+    i32.const 184
     i32.const 3
     call $~lib/builtins/abort
     unreachable
@@ -3206,7 +3220,7 @@
    if
     i32.const 0
     i32.const 1456
-    i32.const 184
+    i32.const 185
     i32.const 3
     call $~lib/builtins/abort
     unreachable
@@ -3260,7 +3274,7 @@
    if
     i32.const 0
     i32.const 1456
-    i32.const 186
+    i32.const 187
     i32.const 3
     call $~lib/builtins/abort
     unreachable
@@ -3284,7 +3298,7 @@
    if
     i32.const 0
     i32.const 1456
-    i32.const 187
+    i32.const 188
     i32.const 3
     call $~lib/builtins/abort
     unreachable
@@ -3308,7 +3322,7 @@
    if
     i32.const 0
     i32.const 1456
-    i32.const 188
+    i32.const 189
     i32.const 3
     call $~lib/builtins/abort
     unreachable
@@ -3374,7 +3388,7 @@
    if
     i32.const 0
     i32.const 1456
-    i32.const 205
+    i32.const 206
     i32.const 3
     call $~lib/builtins/abort
     unreachable
@@ -3415,7 +3429,7 @@
    if
     i32.const 0
     i32.const 1456
-    i32.const 218
+    i32.const 219
     i32.const 3
     call $~lib/builtins/abort
     unreachable
@@ -3462,7 +3476,7 @@
    if
     i32.const 0
     i32.const 1456
-    i32.const 230
+    i32.const 231
     i32.const 3
     call $~lib/builtins/abort
     unreachable

--- a/tests/compiler/field-initialization.ts
+++ b/tests/compiler/field-initialization.ts
@@ -30,6 +30,7 @@ class Nullable_Init {
 {
   let o = new Nullable_Init();
   assert(o.a != null);
+  assert(null != o.a);
 }
 
 class Nullable {


### PR DESCRIPTION
fix: #2662

The idea is compiler should infer the left type according to right type before compiling it.