### PR TITLE
Fix SIMD Store Lane signatures

### DIFF
--- a/src/builtins.ts
+++ b/src/builtins.ts
@@ -4916,7 +4916,7 @@ function builtin_v128_load_lane(ctx: BuiltinFunctionContext): ExpressionRef {
 }
 builtinFunctions.set(BuiltinNames.v128_load_lane, builtin_v128_load_lane);
 
-// v128.store_lane<TFrom!>(ptr: usize, vec: v128, idx: u8, immOffset?: usize, immAlign?: usize) -> v128
+// v128.store_lane<TFrom!>(ptr: usize, vec: v128, idx: u8, immOffset?: usize, immAlign?: usize) -> void
 function builtin_v128_store_lane(ctx: BuiltinFunctionContext): ExpressionRef {
   let compiler = ctx.compiler;
   let module = compiler.module;
@@ -4958,7 +4958,7 @@ function builtin_v128_store_lane(ctx: BuiltinFunctionContext): ExpressionRef {
       }
     }
   }
-  compiler.currentType = Type.v128;
+  compiler.currentType = Type.void;
   if (type.isValue) {
     let maxIdx = (16 / assert(type.byteSize)) - 1;
     if (idx < 0 || idx > maxIdx) {

--- a/std/assembly/builtins.ts
+++ b/std/assembly/builtins.ts
@@ -1273,7 +1273,7 @@ export namespace v128 {
 
   // @ts-ignore: decorator
   @unsafe @builtin
-  export declare function store_lane<TFrom>(ptr: usize, vec: v128, idx: u8, immOffset?: usize, immAlign?: usize): v128;
+  export declare function store_lane<TFrom>(ptr: usize, vec: v128, idx: u8, immOffset?: usize, immAlign?: usize): void;
 
   // @ts-ignore: decorator
   @builtin
@@ -1345,19 +1345,19 @@ export namespace v128 {
 
   // @ts-ignore: decorator
   @unsafe @builtin
-  export declare function store8_lane(ptr: usize, vec: v128, idx: u8, immOffset?: u32, immAlign?: u32): v128;
+  export declare function store8_lane(ptr: usize, vec: v128, idx: u8, immOffset?: u32, immAlign?: u32): void;
 
   // @ts-ignore: decorator
   @unsafe @builtin
-  export declare function store16_lane(ptr: usize, vec: v128, idx: u8, immOffset?: u32, immAlign?: u32): v128;
+  export declare function store16_lane(ptr: usize, vec: v128, idx: u8, immOffset?: u32, immAlign?: u32): void;
 
   // @ts-ignore: decorator
   @unsafe @builtin
-  export declare function store32_lane(ptr: usize, vec: v128, idx: u8, immOffset?: u32, immAlign?: u32): v128;
+  export declare function store32_lane(ptr: usize, vec: v128, idx: u8, immOffset?: u32, immAlign?: u32): void;
 
   // @ts-ignore: decorator
   @unsafe @builtin
-  export declare function store64_lane(ptr: usize, vec: v128, idx: u8, immOffset?: u32, immAlign?: u32): v128;
+  export declare function store64_lane(ptr: usize, vec: v128, idx: u8, immOffset?: u32, immAlign?: u32): void;
 
   // @ts-ignore: decorator
   @unsafe @builtin

--- a/std/assembly/index.d.ts
+++ b/std/assembly/index.d.ts
@@ -808,7 +808,7 @@ declare namespace v128 {
   /** Loads a single lane from memory into the specified lane of the given vector. Other lanes are bypassed as is. */
   export function load_lane<T>(ptr: usize, vec: v128, idx: u8, immOffset?: usize, immAlign?: usize): v128;
   /** Stores the single lane at the specified index of the given vector to memory. */
-  export function store_lane<T>(ptr: usize, vec: v128, idx: u8, immOffset?: usize, immAlign?: usize): v128;
+  export function store_lane<T>(ptr: usize, vec: v128, idx: u8, immOffset?: usize, immAlign?: usize): void;
   /** Creates a vector with eight 16-bit integer lanes by loading and sign extending eight 8-bit integers. */
   export function load8x8_s(ptr: usize, immOffset?: u32, immAlign?: u32): v128;
   /** Creates a vector with eight 16-bit integer lanes by loading and zero extending eight 8-bit integers. */
@@ -844,13 +844,13 @@ declare namespace v128 {
   /** Loads a single 64-bit lane from memory into the specified lane of the given vector. Other lanes are bypassed as is. */
   export function load64_lane(ptr: usize, vec: v128, idx: u8, immOffset?: usize, immAlign?: usize): v128;
   /** Stores the 8-bit lane at the specified lane of the given vector to memory. */
-  export function store8_lane(ptr: usize, vec: v128, idx: u8, immOffset?: usize, immAlign?: usize): v128;
+  export function store8_lane(ptr: usize, vec: v128, idx: u8, immOffset?: usize, immAlign?: usize): void;
   /** Stores the 16-bit lane at the specified lane of the given vector to memory. */
-  export function store16_lane(ptr: usize, vec: v128, idx: u8, immOffset?: usize, immAlign?: usize): v128;
+  export function store16_lane(ptr: usize, vec: v128, idx: u8, immOffset?: usize, immAlign?: usize): void;
   /** Stores the 32-bit lane at the specified lane of the given vector to memory. */
-  export function store32_lane(ptr: usize, vec: v128, idx: u8, immOffset?: usize, immAlign?: usize): v128;
+  export function store32_lane(ptr: usize, vec: v128, idx: u8, immOffset?: usize, immAlign?: usize): void;
   /** Stores the 64-bit lane at the specified lane of the given vector to memory. */
-  export function store64_lane(ptr: usize, vec: v128, idx: u8, immOffset?: usize, immAlign?: usize): v128;
+  export function store64_lane(ptr: usize, vec: v128, idx: u8, immOffset?: usize, immAlign?: usize): void;
   /** Stores a vector to memory. */
   export function store(ptr: usize, value: v128, immOffset?: usize, immAlign?: usize): void;
   /** Adds each lane. */

--- a/tests/compiler/simd.debug.wat
+++ b/tests/compiler/simd.debug.wat
@@ -2387,8 +2387,10 @@
   (local $v|10 v128)
   (local $ptr|11 i32)
   (local $v|12 v128)
-  (local $v|13 v128)
+  (local $ptr|13 i32)
   (local $v|14 v128)
+  (local $v|15 v128)
+  (local $v|16 v128)
   v128.const i32x4 0x00000001 0x00000000 0x00000000 0x00000000
   v128.any_true
   i32.const 0
@@ -2889,10 +2891,97 @@
   end
   local.get $ptr|11
   call $~lib/rt/tlsf/__free
+  i32.const 16
+  call $~lib/rt/tlsf/__alloc
+  local.set $ptr|13
+  v128.const i32x4 0x0000002a 0x0000002b 0x0000002c 0x00000000
+  local.set $v|14
+  local.get $ptr|13
+  local.get $v|14
+  v128.store32_lane $0 0
+  local.get $ptr|13
+  i32.load $0
+  i32.const 42
+  i32.eq
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 528
+   i32.const 215
+   i32.const 5
+   call $~lib/builtins/abort
+   unreachable
+  end
+  local.get $ptr|13
+  local.get $v|14
+  v128.store8_lane $0 4
+  local.get $ptr|13
+  i32.load8_s $0
+  i32.const 43
+  i32.eq
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 528
+   i32.const 217
+   i32.const 5
+   call $~lib/builtins/abort
+   unreachable
+  end
+  local.get $ptr|13
+  local.get $v|14
+  v128.store16_lane $0 4
+  local.get $ptr|13
+  i32.load16_s $0
+  i32.const 44
+  i32.eq
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 528
+   i32.const 219
+   i32.const 5
+   call $~lib/builtins/abort
+   unreachable
+  end
+  local.get $ptr|13
+  local.get $v|14
+  v128.store32_lane $0 1
+  local.get $ptr|13
+  i32.load $0
+  i32.const 43
+  i32.eq
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 528
+   i32.const 221
+   i32.const 5
+   call $~lib/builtins/abort
+   unreachable
+  end
+  local.get $ptr|13
+  local.get $v|14
+  v128.store64_lane $0 offset=1 1
+  local.get $ptr|13
+  i64.load $0 offset=1
+  i64.const 44
+  i64.eq
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 528
+   i32.const 223
+   i32.const 5
+   call $~lib/builtins/abort
+   unreachable
+  end
+  local.get $ptr|13
+  call $~lib/rt/tlsf/__free
   v128.const i32x4 0x3f8ccccd 0xbe800000 0x428c051f 0x40800000
   f32x4.ceil
-  local.set $v|13
-  local.get $v|13
+  local.set $v|15
+  local.get $v|15
   v128.const i32x4 0x40000000 0x80000000 0x428e0000 0x40800000
   i8x16.eq
   i8x16.all_true
@@ -2902,15 +2991,15 @@
   if
    i32.const 0
    i32.const 528
-   i32.const 213
+   i32.const 228
    i32.const 5
    call $~lib/builtins/abort
    unreachable
   end
   v128.const i32x4 0x3f8ccccd 0xbe800000 0x428c051f 0x40800000
   f32x4.floor
-  local.set $v|14
-  local.get $v|14
+  local.set $v|16
+  local.get $v|16
   v128.const i32x4 0x3f800000 0xbf800000 0x428c0000 0x40800000
   i8x16.eq
   i8x16.all_true
@@ -2920,7 +3009,7 @@
   if
    i32.const 0
    i32.const 528
-   i32.const 217
+   i32.const 232
    i32.const 5
    call $~lib/builtins/abort
    unreachable
@@ -2994,7 +3083,7 @@
   if
    i32.const 0
    i32.const 528
-   i32.const 287
+   i32.const 302
    i32.const 3
    call $~lib/builtins/abort
    unreachable
@@ -3012,7 +3101,7 @@
   if
    i32.const 0
    i32.const 528
-   i32.const 289
+   i32.const 304
    i32.const 3
    call $~lib/builtins/abort
    unreachable
@@ -3031,7 +3120,7 @@
   if
    i32.const 0
    i32.const 528
-   i32.const 291
+   i32.const 306
    i32.const 3
    call $~lib/builtins/abort
    unreachable
@@ -3048,7 +3137,7 @@
   if
    i32.const 0
    i32.const 528
-   i32.const 292
+   i32.const 307
    i32.const 3
    call $~lib/builtins/abort
    unreachable
@@ -3109,7 +3198,7 @@
   if
    i32.const 0
    i32.const 528
-   i32.const 333
+   i32.const 348
    i32.const 3
    call $~lib/builtins/abort
    unreachable
@@ -3123,7 +3212,7 @@
   if
    i32.const 0
    i32.const 528
-   i32.const 338
+   i32.const 353
    i32.const 3
    call $~lib/builtins/abort
    unreachable
@@ -3137,7 +3226,7 @@
   if
    i32.const 0
    i32.const 528
-   i32.const 339
+   i32.const 354
    i32.const 3
    call $~lib/builtins/abort
    unreachable
@@ -3152,7 +3241,7 @@
   if
    i32.const 0
    i32.const 528
-   i32.const 340
+   i32.const 355
    i32.const 3
    call $~lib/builtins/abort
    unreachable
@@ -3169,7 +3258,7 @@
   if
    i32.const 0
    i32.const 528
-   i32.const 341
+   i32.const 356
    i32.const 3
    call $~lib/builtins/abort
    unreachable
@@ -3186,7 +3275,7 @@
   if
    i32.const 0
    i32.const 528
-   i32.const 346
+   i32.const 361
    i32.const 3
    call $~lib/builtins/abort
    unreachable
@@ -3310,7 +3399,7 @@
   if
    i32.const 0
    i32.const 528
-   i32.const 384
+   i32.const 399
    i32.const 3
    call $~lib/builtins/abort
    unreachable
@@ -3327,7 +3416,7 @@
   if
    i32.const 0
    i32.const 528
-   i32.const 385
+   i32.const 400
    i32.const 3
    call $~lib/builtins/abort
    unreachable
@@ -3344,7 +3433,7 @@
   if
    i32.const 0
    i32.const 528
-   i32.const 386
+   i32.const 401
    i32.const 3
    call $~lib/builtins/abort
    unreachable
@@ -3361,7 +3450,7 @@
   if
    i32.const 0
    i32.const 528
-   i32.const 387
+   i32.const 402
    i32.const 3
    call $~lib/builtins/abort
    unreachable
@@ -3378,7 +3467,7 @@
   if
    i32.const 0
    i32.const 528
-   i32.const 388
+   i32.const 403
    i32.const 3
    call $~lib/builtins/abort
    unreachable
@@ -3395,7 +3484,7 @@
   if
    i32.const 0
    i32.const 528
-   i32.const 389
+   i32.const 404
    i32.const 3
    call $~lib/builtins/abort
    unreachable
@@ -3412,7 +3501,7 @@
   if
    i32.const 0
    i32.const 528
-   i32.const 390
+   i32.const 405
    i32.const 3
    call $~lib/builtins/abort
    unreachable
@@ -3429,7 +3518,7 @@
   if
    i32.const 0
    i32.const 528
-   i32.const 391
+   i32.const 406
    i32.const 3
    call $~lib/builtins/abort
    unreachable
@@ -3446,7 +3535,7 @@
   if
    i32.const 0
    i32.const 528
-   i32.const 392
+   i32.const 407
    i32.const 3
    call $~lib/builtins/abort
    unreachable
@@ -3463,7 +3552,7 @@
   if
    i32.const 0
    i32.const 528
-   i32.const 393
+   i32.const 408
    i32.const 3
    call $~lib/builtins/abort
    unreachable
@@ -3508,7 +3597,7 @@
   if
    i32.const 0
    i32.const 528
-   i32.const 399
+   i32.const 414
    i32.const 5
    call $~lib/builtins/abort
    unreachable
@@ -3527,7 +3616,7 @@
   if
    i32.const 0
    i32.const 528
-   i32.const 405
+   i32.const 420
    i32.const 5
    call $~lib/builtins/abort
    unreachable
@@ -3543,7 +3632,7 @@
   if
    i32.const 0
    i32.const 528
-   i32.const 410
+   i32.const 425
    i32.const 5
    call $~lib/builtins/abort
    unreachable
@@ -3612,7 +3701,7 @@
   if
    i32.const 0
    i32.const 528
-   i32.const 465
+   i32.const 480
    i32.const 3
    call $~lib/builtins/abort
    unreachable
@@ -3630,7 +3719,7 @@
   if
    i32.const 0
    i32.const 528
-   i32.const 467
+   i32.const 482
    i32.const 3
    call $~lib/builtins/abort
    unreachable
@@ -3649,7 +3738,7 @@
   if
    i32.const 0
    i32.const 528
-   i32.const 469
+   i32.const 484
    i32.const 3
    call $~lib/builtins/abort
    unreachable
@@ -3666,7 +3755,7 @@
   if
    i32.const 0
    i32.const 528
-   i32.const 470
+   i32.const 485
    i32.const 3
    call $~lib/builtins/abort
    unreachable
@@ -3683,7 +3772,7 @@
   if
    i32.const 0
    i32.const 528
-   i32.const 471
+   i32.const 486
    i32.const 3
    call $~lib/builtins/abort
    unreachable
@@ -3744,7 +3833,7 @@
   if
    i32.const 0
    i32.const 528
-   i32.const 512
+   i32.const 527
    i32.const 3
    call $~lib/builtins/abort
    unreachable
@@ -3758,7 +3847,7 @@
   if
    i32.const 0
    i32.const 528
-   i32.const 517
+   i32.const 532
    i32.const 3
    call $~lib/builtins/abort
    unreachable
@@ -3772,7 +3861,7 @@
   if
    i32.const 0
    i32.const 528
-   i32.const 518
+   i32.const 533
    i32.const 3
    call $~lib/builtins/abort
    unreachable
@@ -3787,7 +3876,7 @@
   if
    i32.const 0
    i32.const 528
-   i32.const 519
+   i32.const 534
    i32.const 3
    call $~lib/builtins/abort
    unreachable
@@ -3804,7 +3893,7 @@
   if
    i32.const 0
    i32.const 528
-   i32.const 520
+   i32.const 535
    i32.const 3
    call $~lib/builtins/abort
    unreachable
@@ -3821,7 +3910,7 @@
   if
    i32.const 0
    i32.const 528
-   i32.const 525
+   i32.const 540
    i32.const 3
    call $~lib/builtins/abort
    unreachable
@@ -3945,7 +4034,7 @@
   if
    i32.const 0
    i32.const 528
-   i32.const 563
+   i32.const 578
    i32.const 3
    call $~lib/builtins/abort
    unreachable
@@ -3962,7 +4051,7 @@
   if
    i32.const 0
    i32.const 528
-   i32.const 564
+   i32.const 579
    i32.const 3
    call $~lib/builtins/abort
    unreachable
@@ -3979,7 +4068,7 @@
   if
    i32.const 0
    i32.const 528
-   i32.const 565
+   i32.const 580
    i32.const 3
    call $~lib/builtins/abort
    unreachable
@@ -3996,7 +4085,7 @@
   if
    i32.const 0
    i32.const 528
-   i32.const 566
+   i32.const 581
    i32.const 3
    call $~lib/builtins/abort
    unreachable
@@ -4013,7 +4102,7 @@
   if
    i32.const 0
    i32.const 528
-   i32.const 567
+   i32.const 582
    i32.const 3
    call $~lib/builtins/abort
    unreachable
@@ -4030,7 +4119,7 @@
   if
    i32.const 0
    i32.const 528
-   i32.const 568
+   i32.const 583
    i32.const 3
    call $~lib/builtins/abort
    unreachable
@@ -4047,7 +4136,7 @@
   if
    i32.const 0
    i32.const 528
-   i32.const 569
+   i32.const 584
    i32.const 3
    call $~lib/builtins/abort
    unreachable
@@ -4064,7 +4153,7 @@
   if
    i32.const 0
    i32.const 528
-   i32.const 570
+   i32.const 585
    i32.const 3
    call $~lib/builtins/abort
    unreachable
@@ -4081,7 +4170,7 @@
   if
    i32.const 0
    i32.const 528
-   i32.const 571
+   i32.const 586
    i32.const 3
    call $~lib/builtins/abort
    unreachable
@@ -4098,7 +4187,7 @@
   if
    i32.const 0
    i32.const 528
-   i32.const 572
+   i32.const 587
    i32.const 3
    call $~lib/builtins/abort
    unreachable
@@ -4189,7 +4278,7 @@
   if
    i32.const 0
    i32.const 528
-   i32.const 579
+   i32.const 594
    i32.const 3
    call $~lib/builtins/abort
    unreachable
@@ -4232,7 +4321,7 @@
   if
    i32.const 0
    i32.const 528
-   i32.const 594
+   i32.const 609
    i32.const 5
    call $~lib/builtins/abort
    unreachable
@@ -4248,7 +4337,7 @@
   if
    i32.const 0
    i32.const 528
-   i32.const 599
+   i32.const 614
    i32.const 5
    call $~lib/builtins/abort
    unreachable
@@ -4350,7 +4439,7 @@
   if
    i32.const 0
    i32.const 528
-   i32.const 667
+   i32.const 682
    i32.const 3
    call $~lib/builtins/abort
    unreachable
@@ -4368,7 +4457,7 @@
   if
    i32.const 0
    i32.const 528
-   i32.const 669
+   i32.const 684
    i32.const 3
    call $~lib/builtins/abort
    unreachable
@@ -4387,7 +4476,7 @@
   if
    i32.const 0
    i32.const 528
-   i32.const 671
+   i32.const 686
    i32.const 3
    call $~lib/builtins/abort
    unreachable
@@ -4404,7 +4493,7 @@
   if
    i32.const 0
    i32.const 528
-   i32.const 672
+   i32.const 687
    i32.const 3
    call $~lib/builtins/abort
    unreachable
@@ -4421,7 +4510,7 @@
   if
    i32.const 0
    i32.const 528
-   i32.const 673
+   i32.const 688
    i32.const 3
    call $~lib/builtins/abort
    unreachable
@@ -4482,7 +4571,7 @@
   if
    i32.const 0
    i32.const 528
-   i32.const 714
+   i32.const 729
    i32.const 3
    call $~lib/builtins/abort
    unreachable
@@ -4495,7 +4584,7 @@
   if
    i32.const 0
    i32.const 528
-   i32.const 719
+   i32.const 734
    i32.const 3
    call $~lib/builtins/abort
    unreachable
@@ -4508,7 +4597,7 @@
   if
    i32.const 0
    i32.const 528
-   i32.const 720
+   i32.const 735
    i32.const 3
    call $~lib/builtins/abort
    unreachable
@@ -4525,7 +4614,7 @@
   if
    i32.const 0
    i32.const 528
-   i32.const 721
+   i32.const 736
    i32.const 3
    call $~lib/builtins/abort
    unreachable
@@ -4542,7 +4631,7 @@
   if
    i32.const 0
    i32.const 528
-   i32.const 726
+   i32.const 741
    i32.const 3
    call $~lib/builtins/abort
    unreachable
@@ -4622,7 +4711,7 @@
   if
    i32.const 0
    i32.const 528
-   i32.const 740
+   i32.const 755
    i32.const 3
    call $~lib/builtins/abort
    unreachable
@@ -4639,7 +4728,7 @@
   if
    i32.const 0
    i32.const 528
-   i32.const 741
+   i32.const 756
    i32.const 3
    call $~lib/builtins/abort
    unreachable
@@ -4656,7 +4745,7 @@
   if
    i32.const 0
    i32.const 528
-   i32.const 742
+   i32.const 757
    i32.const 3
    call $~lib/builtins/abort
    unreachable
@@ -4673,7 +4762,7 @@
   if
    i32.const 0
    i32.const 528
-   i32.const 743
+   i32.const 758
    i32.const 3
    call $~lib/builtins/abort
    unreachable
@@ -4690,7 +4779,7 @@
   if
    i32.const 0
    i32.const 528
-   i32.const 744
+   i32.const 759
    i32.const 3
    call $~lib/builtins/abort
    unreachable
@@ -4707,7 +4796,7 @@
   if
    i32.const 0
    i32.const 528
-   i32.const 745
+   i32.const 760
    i32.const 3
    call $~lib/builtins/abort
    unreachable
@@ -4724,7 +4813,7 @@
   if
    i32.const 0
    i32.const 528
-   i32.const 746
+   i32.const 761
    i32.const 3
    call $~lib/builtins/abort
    unreachable
@@ -4741,7 +4830,7 @@
   if
    i32.const 0
    i32.const 528
-   i32.const 747
+   i32.const 762
    i32.const 3
    call $~lib/builtins/abort
    unreachable
@@ -4758,7 +4847,7 @@
   if
    i32.const 0
    i32.const 528
-   i32.const 748
+   i32.const 763
    i32.const 3
    call $~lib/builtins/abort
    unreachable
@@ -4775,7 +4864,7 @@
   if
    i32.const 0
    i32.const 528
-   i32.const 749
+   i32.const 764
    i32.const 3
    call $~lib/builtins/abort
    unreachable
@@ -4862,7 +4951,7 @@
   if
    i32.const 0
    i32.const 528
-   i32.const 764
+   i32.const 779
    i32.const 3
    call $~lib/builtins/abort
    unreachable
@@ -4893,7 +4982,7 @@
   if
    i32.const 0
    i32.const 528
-   i32.const 775
+   i32.const 790
    i32.const 5
    call $~lib/builtins/abort
    unreachable
@@ -4909,7 +4998,7 @@
   if
    i32.const 0
    i32.const 528
-   i32.const 780
+   i32.const 795
    i32.const 5
    call $~lib/builtins/abort
    unreachable
@@ -5009,7 +5098,7 @@
   if
    i32.const 0
    i32.const 528
-   i32.const 814
+   i32.const 829
    i32.const 3
    call $~lib/builtins/abort
    unreachable
@@ -5027,7 +5116,7 @@
   if
    i32.const 0
    i32.const 528
-   i32.const 816
+   i32.const 831
    i32.const 3
    call $~lib/builtins/abort
    unreachable
@@ -5046,7 +5135,7 @@
   if
    i32.const 0
    i32.const 528
-   i32.const 818
+   i32.const 833
    i32.const 3
    call $~lib/builtins/abort
    unreachable
@@ -5063,7 +5152,7 @@
   if
    i32.const 0
    i32.const 528
-   i32.const 819
+   i32.const 834
    i32.const 3
    call $~lib/builtins/abort
    unreachable
@@ -5080,7 +5169,7 @@
   if
    i32.const 0
    i32.const 528
-   i32.const 820
+   i32.const 835
    i32.const 3
    call $~lib/builtins/abort
    unreachable
@@ -5096,7 +5185,7 @@
   if
    i32.const 0
    i32.const 528
-   i32.const 821
+   i32.const 836
    i32.const 3
    call $~lib/builtins/abort
    unreachable
@@ -5109,7 +5198,7 @@
   if
    i32.const 0
    i32.const 528
-   i32.const 826
+   i32.const 841
    i32.const 3
    call $~lib/builtins/abort
    unreachable
@@ -5122,7 +5211,7 @@
   if
    i32.const 0
    i32.const 528
-   i32.const 827
+   i32.const 842
    i32.const 3
    call $~lib/builtins/abort
    unreachable
@@ -5139,7 +5228,7 @@
   if
    i32.const 0
    i32.const 528
-   i32.const 828
+   i32.const 843
    i32.const 3
    call $~lib/builtins/abort
    unreachable
@@ -5156,7 +5245,7 @@
   if
    i32.const 0
    i32.const 528
-   i32.const 833
+   i32.const 848
    i32.const 3
    call $~lib/builtins/abort
    unreachable
@@ -5229,7 +5318,7 @@
   if
    i32.const 0
    i32.const 528
-   i32.const 847
+   i32.const 862
    i32.const 5
    call $~lib/builtins/abort
    unreachable
@@ -5245,7 +5334,7 @@
   if
    i32.const 0
    i32.const 528
-   i32.const 852
+   i32.const 867
    i32.const 5
    call $~lib/builtins/abort
    unreachable
@@ -5626,7 +5715,7 @@
   if
    i32.const 0
    i32.const 528
-   i32.const 925
+   i32.const 940
    i32.const 3
    call $~lib/builtins/abort
    unreachable
@@ -5644,7 +5733,7 @@
   if
    i32.const 0
    i32.const 528
-   i32.const 927
+   i32.const 942
    i32.const 3
    call $~lib/builtins/abort
    unreachable
@@ -5663,7 +5752,7 @@
   if
    i32.const 0
    i32.const 528
-   i32.const 929
+   i32.const 944
    i32.const 3
    call $~lib/builtins/abort
    unreachable
@@ -5680,7 +5769,7 @@
   if
    i32.const 0
    i32.const 528
-   i32.const 930
+   i32.const 945
    i32.const 3
    call $~lib/builtins/abort
    unreachable
@@ -5697,7 +5786,7 @@
   if
    i32.const 0
    i32.const 528
-   i32.const 931
+   i32.const 946
    i32.const 3
    call $~lib/builtins/abort
    unreachable
@@ -5718,7 +5807,7 @@
   if
    i32.const 0
    i32.const 528
-   i32.const 933
+   i32.const 948
    i32.const 3
    call $~lib/builtins/abort
    unreachable
@@ -5735,7 +5824,7 @@
   if
    i32.const 0
    i32.const 528
-   i32.const 934
+   i32.const 949
    i32.const 3
    call $~lib/builtins/abort
    unreachable
@@ -5751,7 +5840,7 @@
   if
    i32.const 0
    i32.const 528
-   i32.const 935
+   i32.const 950
    i32.const 3
    call $~lib/builtins/abort
    unreachable
@@ -5764,7 +5853,7 @@
   if
    i32.const 0
    i32.const 528
-   i32.const 936
+   i32.const 951
    i32.const 3
    call $~lib/builtins/abort
    unreachable
@@ -5777,7 +5866,7 @@
   if
    i32.const 0
    i32.const 528
-   i32.const 937
+   i32.const 952
    i32.const 3
    call $~lib/builtins/abort
    unreachable
@@ -5794,7 +5883,7 @@
   if
    i32.const 0
    i32.const 528
-   i32.const 938
+   i32.const 953
    i32.const 3
    call $~lib/builtins/abort
    unreachable
@@ -5811,7 +5900,7 @@
   if
    i32.const 0
    i32.const 528
-   i32.const 943
+   i32.const 958
    i32.const 3
    call $~lib/builtins/abort
    unreachable
@@ -5842,7 +5931,7 @@
   if
    i32.const 0
    i32.const 528
-   i32.const 952
+   i32.const 967
    i32.const 3
    call $~lib/builtins/abort
    unreachable
@@ -5859,7 +5948,7 @@
   if
    i32.const 0
    i32.const 528
-   i32.const 953
+   i32.const 968
    i32.const 3
    call $~lib/builtins/abort
    unreachable
@@ -5876,7 +5965,7 @@
   if
    i32.const 0
    i32.const 528
-   i32.const 954
+   i32.const 969
    i32.const 3
    call $~lib/builtins/abort
    unreachable
@@ -5893,7 +5982,7 @@
   if
    i32.const 0
    i32.const 528
-   i32.const 955
+   i32.const 970
    i32.const 3
    call $~lib/builtins/abort
    unreachable
@@ -5910,7 +5999,7 @@
   if
    i32.const 0
    i32.const 528
-   i32.const 956
+   i32.const 971
    i32.const 3
    call $~lib/builtins/abort
    unreachable
@@ -5927,7 +6016,7 @@
   if
    i32.const 0
    i32.const 528
-   i32.const 957
+   i32.const 972
    i32.const 3
    call $~lib/builtins/abort
    unreachable
@@ -5944,7 +6033,7 @@
   if
    i32.const 0
    i32.const 528
-   i32.const 958
+   i32.const 973
    i32.const 3
    call $~lib/builtins/abort
    unreachable
@@ -5961,7 +6050,7 @@
   if
    i32.const 0
    i32.const 528
-   i32.const 959
+   i32.const 974
    i32.const 3
    call $~lib/builtins/abort
    unreachable
@@ -5977,7 +6066,7 @@
   if
    i32.const 0
    i32.const 528
-   i32.const 960
+   i32.const 975
    i32.const 3
    call $~lib/builtins/abort
    unreachable
@@ -6044,7 +6133,7 @@
   if
    i32.const 0
    i32.const 528
-   i32.const 987
+   i32.const 1002
    i32.const 5
    call $~lib/builtins/abort
    unreachable
@@ -6062,7 +6151,7 @@
   if
    i32.const 0
    i32.const 528
-   i32.const 991
+   i32.const 1006
    i32.const 5
    call $~lib/builtins/abort
    unreachable
@@ -6107,7 +6196,7 @@
   if
    i32.const 0
    i32.const 528
-   i32.const 1007
+   i32.const 1022
    i32.const 3
    call $~lib/builtins/abort
    unreachable
@@ -6125,7 +6214,7 @@
   if
    i32.const 0
    i32.const 528
-   i32.const 1009
+   i32.const 1024
    i32.const 3
    call $~lib/builtins/abort
    unreachable
@@ -6144,7 +6233,7 @@
   if
    i32.const 0
    i32.const 528
-   i32.const 1011
+   i32.const 1026
    i32.const 3
    call $~lib/builtins/abort
    unreachable
@@ -6161,7 +6250,7 @@
   if
    i32.const 0
    i32.const 528
-   i32.const 1012
+   i32.const 1027
    i32.const 3
    call $~lib/builtins/abort
    unreachable
@@ -6178,7 +6267,7 @@
   if
    i32.const 0
    i32.const 528
-   i32.const 1013
+   i32.const 1028
    i32.const 3
    call $~lib/builtins/abort
    unreachable
@@ -6199,7 +6288,7 @@
   if
    i32.const 0
    i32.const 528
-   i32.const 1015
+   i32.const 1030
    i32.const 3
    call $~lib/builtins/abort
    unreachable
@@ -6216,7 +6305,7 @@
   if
    i32.const 0
    i32.const 528
-   i32.const 1016
+   i32.const 1031
    i32.const 3
    call $~lib/builtins/abort
    unreachable
@@ -6232,7 +6321,7 @@
   if
    i32.const 0
    i32.const 528
-   i32.const 1017
+   i32.const 1032
    i32.const 3
    call $~lib/builtins/abort
    unreachable
@@ -6245,7 +6334,7 @@
   if
    i32.const 0
    i32.const 528
-   i32.const 1018
+   i32.const 1033
    i32.const 3
    call $~lib/builtins/abort
    unreachable
@@ -6258,7 +6347,7 @@
   if
    i32.const 0
    i32.const 528
-   i32.const 1019
+   i32.const 1034
    i32.const 3
    call $~lib/builtins/abort
    unreachable
@@ -6275,7 +6364,7 @@
   if
    i32.const 0
    i32.const 528
-   i32.const 1020
+   i32.const 1035
    i32.const 3
    call $~lib/builtins/abort
    unreachable
@@ -6292,7 +6381,7 @@
   if
    i32.const 0
    i32.const 528
-   i32.const 1025
+   i32.const 1040
    i32.const 3
    call $~lib/builtins/abort
    unreachable
@@ -6323,7 +6412,7 @@
   if
    i32.const 0
    i32.const 528
-   i32.const 1034
+   i32.const 1049
    i32.const 3
    call $~lib/builtins/abort
    unreachable
@@ -6340,7 +6429,7 @@
   if
    i32.const 0
    i32.const 528
-   i32.const 1035
+   i32.const 1050
    i32.const 3
    call $~lib/builtins/abort
    unreachable
@@ -6357,7 +6446,7 @@
   if
    i32.const 0
    i32.const 528
-   i32.const 1036
+   i32.const 1051
    i32.const 3
    call $~lib/builtins/abort
    unreachable
@@ -6374,7 +6463,7 @@
   if
    i32.const 0
    i32.const 528
-   i32.const 1037
+   i32.const 1052
    i32.const 3
    call $~lib/builtins/abort
    unreachable
@@ -6391,7 +6480,7 @@
   if
    i32.const 0
    i32.const 528
-   i32.const 1038
+   i32.const 1053
    i32.const 3
    call $~lib/builtins/abort
    unreachable
@@ -6408,7 +6497,7 @@
   if
    i32.const 0
    i32.const 528
-   i32.const 1039
+   i32.const 1054
    i32.const 3
    call $~lib/builtins/abort
    unreachable
@@ -6425,7 +6514,7 @@
   if
    i32.const 0
    i32.const 528
-   i32.const 1040
+   i32.const 1055
    i32.const 3
    call $~lib/builtins/abort
    unreachable
@@ -6442,7 +6531,7 @@
   if
    i32.const 0
    i32.const 528
-   i32.const 1041
+   i32.const 1056
    i32.const 3
    call $~lib/builtins/abort
    unreachable
@@ -6458,7 +6547,7 @@
   if
    i32.const 0
    i32.const 528
-   i32.const 1042
+   i32.const 1057
    i32.const 3
    call $~lib/builtins/abort
    unreachable
@@ -6511,7 +6600,7 @@
   if
    i32.const 0
    i32.const 528
-   i32.const 1061
+   i32.const 1076
    i32.const 5
    call $~lib/builtins/abort
    unreachable
@@ -6529,7 +6618,7 @@
   if
    i32.const 0
    i32.const 528
-   i32.const 1065
+   i32.const 1080
    i32.const 5
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/simd.release.wat
+++ b/tests/compiler/simd.release.wat
@@ -1847,6 +1847,93 @@
   end
   local.get $0
   call $~lib/rt/tlsf/__free
+  global.get $~lib/rt/tlsf/ROOT
+  i32.eqz
+  if
+   call $~lib/rt/tlsf/initialize
+  end
+  global.get $~lib/rt/tlsf/ROOT
+  i32.const 16
+  call $~lib/rt/tlsf/allocateBlock
+  i32.const 4
+  i32.add
+  local.tee $0
+  v128.const i32x4 0x0000002a 0x0000002b 0x0000002c 0x00000000
+  v128.store32_lane $0 0
+  local.get $0
+  i32.load $0
+  i32.const 42
+  i32.ne
+  if
+   i32.const 0
+   i32.const 1552
+   i32.const 215
+   i32.const 5
+   call $~lib/builtins/abort
+   unreachable
+  end
+  local.get $0
+  v128.const i32x4 0x0000002a 0x0000002b 0x0000002c 0x00000000
+  v128.store8_lane $0 4
+  local.get $0
+  i32.load8_s $0
+  i32.const 43
+  i32.ne
+  if
+   i32.const 0
+   i32.const 1552
+   i32.const 217
+   i32.const 5
+   call $~lib/builtins/abort
+   unreachable
+  end
+  local.get $0
+  v128.const i32x4 0x0000002a 0x0000002b 0x0000002c 0x00000000
+  v128.store16_lane $0 4
+  local.get $0
+  i32.load16_s $0
+  i32.const 44
+  i32.ne
+  if
+   i32.const 0
+   i32.const 1552
+   i32.const 219
+   i32.const 5
+   call $~lib/builtins/abort
+   unreachable
+  end
+  local.get $0
+  v128.const i32x4 0x0000002a 0x0000002b 0x0000002c 0x00000000
+  v128.store32_lane $0 1
+  local.get $0
+  i32.load $0
+  i32.const 43
+  i32.ne
+  if
+   i32.const 0
+   i32.const 1552
+   i32.const 221
+   i32.const 5
+   call $~lib/builtins/abort
+   unreachable
+  end
+  local.get $0
+  v128.const i32x4 0x0000002a 0x0000002b 0x0000002c 0x00000000
+  v128.store64_lane $0 offset=1 1
+  local.get $0
+  i64.load $0 offset=1
+  i64.const 44
+  i64.ne
+  if
+   i32.const 0
+   i32.const 1552
+   i32.const 223
+   i32.const 5
+   call $~lib/builtins/abort
+   unreachable
+  end
+  local.get $0
+  call $~lib/rt/tlsf/__free
  )
  (func $simd/reexport (param $0 v128) (result v128)
   local.get $0
@@ -2301,7 +2388,7 @@
    if
     i32.const 0
     i32.const 1552
-    i32.const 594
+    i32.const 609
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -2315,7 +2402,7 @@
    if
     i32.const 0
     i32.const 1552
-    i32.const 599
+    i32.const 614
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -2353,7 +2440,7 @@
    if
     i32.const 0
     i32.const 1552
-    i32.const 775
+    i32.const 790
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -2367,7 +2454,7 @@
    if
     i32.const 0
     i32.const 1552
-    i32.const 780
+    i32.const 795
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -2399,7 +2486,7 @@
    if
     i32.const 0
     i32.const 1552
-    i32.const 847
+    i32.const 862
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -2413,7 +2500,7 @@
    if
     i32.const 0
     i32.const 1552
-    i32.const 852
+    i32.const 867
     i32.const 5
     call $~lib/builtins/abort
     unreachable

--- a/tests/compiler/simd.ts
+++ b/tests/compiler/simd.ts
@@ -209,6 +209,21 @@ function test_v128(): void {
     __free(ptr);
   }
   {
+    let ptr = __alloc(16);
+    let v: v128 = v128(42, 0, 0, 0, 43, 0, 0, 0, 44, 0, 0, 0, 0, 0, 0, 0);
+    v128.store_lane<i32>(ptr, v, 0);
+    assert(load<i32>(ptr) == 42);
+    v128.store8_lane(ptr, v, 4);
+    assert(load<i8>(ptr) == 43);
+    v128.store16_lane(ptr, v, 4);
+    assert(load<i16>(ptr) == 44);
+    v128.store32_lane(ptr, v, 1);
+    assert(load<i32>(ptr) == 43);
+    v128.store64_lane(ptr, v, 1, 1);
+    assert(load<i64>(ptr, 1) == 44);
+    __free(ptr);
+  }
+  {
     let v: v128 = v128.ceil<f32>(f32x4(1.1, -0.25, 70.01, 4.0));
     assert(v == f32x4(2, -0.0, 71, 4));
   }


### PR DESCRIPTION
Fixes #2696 where it was discovered that SIMD store lane instructions used `v128` as the return type, but should use `void`.

- [x] I've read the contributing guidelines
- [x] I've added my name and email to the NOTICE file
