### PR TITLE
fix: Fix accuratePow64 util when base is a negative

### DIFF
--- a/src/util/math.ts
+++ b/src/util/math.ts
@@ -14,7 +14,12 @@ export function accuratePow64(x: f64, y: f64): f64 {
     // This speculative optimization leads to loose precisions like 10 ** 208 != 1e208
     // or/and 10 ** -5 != 1e-5 anymore. For avoid this behaviour we are forcing exponent
     // to fractional form and compensate this afterwards.
-    if (isFinite(y) && Math.abs(y) >= 2 && Math.trunc(y) == y) {
+    if (
+      isFinite(y) &&
+      !isPowerOf2(x) &&
+      Math.abs(y) >= 2 &&
+      Math.trunc(y) == y
+    ) {
       if (x < 0) return (y % 2 ? -1 : 1) * accuratePow64(-x, y);
       if (y < 0) {
         return Math.pow(x, y + 0.5) / Math.pow(x, 0.5);

--- a/src/util/math.ts
+++ b/src/util/math.ts
@@ -15,6 +15,7 @@ export function accuratePow64(x: f64, y: f64): f64 {
     // or/and 10 ** -5 != 1e-5 anymore. For avoid this behaviour we are forcing exponent
     // to fractional form and compensate this afterwards.
     if (isFinite(y) && Math.abs(y) >= 2 && Math.trunc(y) == y) {
+      if (x < 0) return -accuratePow64(-x, y);
       if (y < 0) {
         return Math.pow(x, y + 0.5) / Math.pow(x, 0.5);
       } else {

--- a/src/util/math.ts
+++ b/src/util/math.ts
@@ -15,7 +15,7 @@ export function accuratePow64(x: f64, y: f64): f64 {
     // or/and 10 ** -5 != 1e-5 anymore. For avoid this behaviour we are forcing exponent
     // to fractional form and compensate this afterwards.
     if (isFinite(y) && Math.abs(y) >= 2 && Math.trunc(y) == y) {
-      if (x < 0) return -accuratePow64(-x, y);
+      if (x < 0) return (y % 2 ? -1 : 1) * accuratePow64(-x, y);
       if (y < 0) {
         return Math.pow(x, y + 0.5) / Math.pow(x, 0.5);
       } else {

--- a/src/util/math.ts
+++ b/src/util/math.ts
@@ -15,8 +15,9 @@ export function accuratePow64(x: f64, y: f64): f64 {
     // or/and 10 ** -5 != 1e-5 anymore. For avoid this behaviour we are forcing exponent
     // to fractional form and compensate this afterwards.
     if (
-      isFinite(y) &&
+      x != 0 &&
       !isPowerOf2(x) &&
+      isFinite(y) &&
       Math.abs(y) >= 2 &&
       Math.trunc(y) == y
     ) {


### PR DESCRIPTION
Before:

```ts
accuratePow64(-10, -5) 
// > NaN
```

After:
```ts
accuratePow64(-10, -5) 
// > -0.00001
```

- [x] I've read the contributing guidelines
- [x] I've added my name and email to the NOTICE file
