### PR TITLE
Support string literal export names

### DIFF
--- a/src/ast.ts
+++ b/src/ast.ts
@@ -531,7 +531,7 @@ export abstract class Node {
 
   static createExportMember(
     localName: IdentifierExpression,
-    exportedName: IdentifierExpression | null,
+    exportedName: ExportName | null,
     range: Range
   ): ExportMember {
     if (!exportedName) exportedName = localName;
@@ -570,11 +570,10 @@ export abstract class Node {
   }
 
   static createImportDeclaration(
-    foreignName: IdentifierExpression,
-    name: IdentifierExpression | null,
+    foreignName: ExportName,
+    name: IdentifierExpression,
     range: Range
   ): ImportDeclaration {
-    if (!name) name = foreignName;
     return new ImportDeclaration(name, foreignName, range);
   }
 
@@ -1126,8 +1125,17 @@ export class CommentNode extends Node {
 /** Base class of all expression nodes. */
 export abstract class Expression extends Node { }
 
+/** Interface for nodes representing export names. */
+export interface ExportName {
+  /** Name of the exported member. */
+  readonly text: string;
+
+  /** Source range. */
+  range: Range;
+}
+
 /** Represents an identifier expression. */
-export class IdentifierExpression extends Expression {
+export class IdentifierExpression extends Expression implements ExportName {
   constructor(
     /** Textual name. */
     public text: string,
@@ -1480,7 +1488,7 @@ export class TernaryExpression extends Expression {
 }
 
 /** Represents a string literal expression. */
-export class StringLiteralExpression extends LiteralExpression {
+export class StringLiteralExpression extends LiteralExpression implements ExportName {
   constructor(
     /** String value without quotes. */
     public value: string,
@@ -1488,6 +1496,10 @@ export class StringLiteralExpression extends LiteralExpression {
     range: Range
   ) {
     super(LiteralKind.String, range);
+  }
+
+  get text(): string {
+    return this.value;
   }
 }
 
@@ -1928,8 +1940,8 @@ export class ExportMember extends Node {
   constructor(
     /** Local identifier. */
     public localName: IdentifierExpression,
-    /** Exported identifier. */
-    public exportedName: IdentifierExpression,
+    /** Exported name. */
+    public exportedName: ExportName,
     /** Source range. */
     range: Range
   ) {
@@ -2120,8 +2132,8 @@ export class ImportDeclaration extends DeclarationStatement {
   constructor(
     /** Simple name being declared. */
     name: IdentifierExpression,
-    /** Identifier being imported. */
-    public foreignName: IdentifierExpression,
+    /** Name being imported. */
+    public foreignName: ExportName,
     /** Source range. */
     range: Range
   ) {

--- a/src/extra/ast.ts
+++ b/src/extra/ast.ts
@@ -976,7 +976,7 @@ export class ASTBuilder {
     this.visitIdentifierExpression(node.localName);
     if (node.exportedName.text != node.localName.text) {
       this.sb.push(" as ");
-      this.visitIdentifierExpression(node.exportedName);
+      this.visitNode(<Node><Object>node.exportedName);
     }
   }
 
@@ -1227,7 +1227,7 @@ export class ASTBuilder {
   visitImportDeclaration(node: ImportDeclaration): void {
     let externalName = node.foreignName;
     let name = node.name;
-    this.visitIdentifierExpression(externalName);
+    this.visitNode(<Node><Object>externalName);
     if (externalName.text != name.text) {
       this.sb.push(" as ");
       this.visitIdentifierExpression(name);

--- a/src/program.ts
+++ b/src/program.ts
@@ -86,6 +86,7 @@ import {
   ArrowKind,
 
   Expression,
+  ExportName,
   IdentifierExpression,
   LiteralKind,
   StringLiteralExpression,
@@ -163,8 +164,8 @@ class QueuedImport {
     public localFile: File,
     /** Identifier within the local file. */
     public localIdentifier: IdentifierExpression,
-    /** Identifier within the other file. Is an `import *` if not set. */
-    public foreignIdentifier: IdentifierExpression | null,
+    /** Name within the other file. Is an `import *` if not set. */
+    public foreignName: ExportName | null,
     /** Path to the other file. */
     public foreignPath: string,
     /** Alternative path to the other file. */
@@ -177,8 +178,8 @@ class QueuedExport {
   constructor(
     /** Identifier within the local file. */
     public localIdentifier: IdentifierExpression,
-    /** Identifier within the other file. */
-    public foreignIdentifier: IdentifierExpression,
+    /** Name within the other file. */
+    public foreignName: ExportName,
     /** Path to the other file if a re-export. */
     public foreignPath: string | null,
     /** Alternative path to the other file if a re-export. */
@@ -1170,12 +1171,12 @@ export class Program extends DiagnosticEmitter {
       while (i < queuedImports.length) {
         let queuedImport = queuedImports[i];
         let localIdentifier = queuedImport.localIdentifier;
-        let foreignIdentifier = queuedImport.foreignIdentifier;
+        let foreignName = queuedImport.foreignName;
         // File must be found here, as it would otherwise already have been reported by the parser
         let foreignFile = assert(this.lookupForeignFile(queuedImport.foreignPath, queuedImport.foreignPathAlt));
-        if (foreignIdentifier) { // i.e. import { foo [as bar] } from "./baz"
+        if (foreignName) { // i.e. import { foo [as bar] } from "./baz"
           let element = this.lookupForeign(
-            foreignIdentifier.text,
+            foreignName.text,
             foreignFile,
             queuedExports
           );
@@ -1210,11 +1211,11 @@ export class Program extends DiagnosticEmitter {
         // report queued imports we were unable to resolve
         for (let j = 0, l = queuedImports.length; j < l; ++j) {
           let queuedImport = queuedImports[j];
-          let foreignIdentifier = queuedImport.foreignIdentifier;
-          if (foreignIdentifier) {
+          let foreignName = queuedImport.foreignName;
+          if (foreignName) {
             this.error(
               DiagnosticCode.Module_0_has_no_exported_member_1,
-              foreignIdentifier.range, queuedImport.foreignPath, foreignIdentifier.text
+              foreignName.range, queuedImport.foreignPath, foreignName.text
             );
           }
         }
@@ -1257,8 +1258,8 @@ export class Program extends DiagnosticEmitter {
             } else {
               this.error(
                 DiagnosticCode.Module_0_has_no_exported_member_1,
-                queuedExport.foreignIdentifier.range,
-                file.internalName, queuedExport.foreignIdentifier.text
+                queuedExport.foreignName.range,
+                file.internalName, queuedExport.foreignName.text
               );
             }
           }

--- a/tests/compiler/export.debug.wat
+++ b/tests/compiler/export.debug.wat
@@ -12,6 +12,7 @@
  (export "add" (func $export/add))
  (export "sub" (func $export/sub))
  (export "renamed_mul" (func $export/mul))
+ (export "\Not"A;Brand" (func $export/div))
  (export "a" (global $export/a))
  (export "b" (global $export/b))
  (export "renamed_c" (global $export/c))
@@ -32,6 +33,12 @@
   local.get $a
   local.get $b
   i32.mul
+  return
+ )
+ (func $export/div (param $a i32) (param $b i32) (result i32)
+  local.get $a
+  local.get $b
+  i32.div_s
   return
  )
 )

--- a/tests/compiler/export.release.wat
+++ b/tests/compiler/export.release.wat
@@ -7,6 +7,7 @@
  (export "add" (func $export/add))
  (export "sub" (func $export/sub))
  (export "renamed_mul" (func $export/mul))
+ (export "\Not"A;Brand" (func $export/div))
  (export "a" (global $export/a))
  (export "b" (global $export/b))
  (export "renamed_c" (global $export/c))
@@ -25,5 +26,10 @@
   local.get $0
   local.get $1
   i32.mul
+ )
+ (func $export/div (param $0 i32) (param $1 i32) (result i32)
+  local.get $0
+  local.get $1
+  i32.div_s
  )
 )

--- a/tests/compiler/export.ts
+++ b/tests/compiler/export.ts
@@ -14,6 +14,12 @@ function mul(a: i32, b: i32): i32 { // not exported as "mul"
 
 export { mul as renamed_mul };
 
+function div(a: i32, b: i32): i32 { // not exported as "div"
+  return a / b;
+}
+
+export { div as "\\Not\"A;Brand" };
+
 export const a: i32 = 1;
 
 const b: i32 = 2;

--- a/tests/compiler/exportstar.debug.wat
+++ b/tests/compiler/exportstar.debug.wat
@@ -12,6 +12,7 @@
  (export "add" (func $export/add))
  (export "sub" (func $export/sub))
  (export "renamed_mul" (func $export/mul))
+ (export "\Not"A;Brand" (func $export/div))
  (export "a" (global $export/a))
  (export "b" (global $export/b))
  (export "renamed_c" (global $export/c))
@@ -32,6 +33,12 @@
   local.get $a
   local.get $b
   i32.mul
+  return
+ )
+ (func $export/div (param $a i32) (param $b i32) (result i32)
+  local.get $a
+  local.get $b
+  i32.div_s
   return
  )
 )

--- a/tests/compiler/exportstar.release.wat
+++ b/tests/compiler/exportstar.release.wat
@@ -7,6 +7,7 @@
  (export "add" (func $export/add))
  (export "sub" (func $export/sub))
  (export "renamed_mul" (func $export/mul))
+ (export "\Not"A;Brand" (func $export/div))
  (export "a" (global $export/a))
  (export "b" (global $export/b))
  (export "renamed_c" (global $export/c))
@@ -25,5 +26,10 @@
   local.get $0
   local.get $1
   i32.mul
+ )
+ (func $export/div (param $0 i32) (param $1 i32) (result i32)
+  local.get $0
+  local.get $1
+  i32.div_s
  )
 )

--- a/tests/compiler/import.debug.wat
+++ b/tests/compiler/import.debug.wat
@@ -1,6 +1,6 @@
 (module
- (type $none_=>_none (func))
  (type $i32_i32_=>_i32 (func (param i32 i32) (result i32)))
+ (type $none_=>_none (func))
  (global $export/a i32 (i32.const 1))
  (global $export/b i32 (i32.const 2))
  (global $export/c i32 (i32.const 3))
@@ -30,6 +30,12 @@
   i32.mul
   return
  )
+ (func $export/div (param $a i32) (param $b i32) (result i32)
+  local.get $a
+  local.get $b
+  i32.div_s
+  return
+ )
  (func $export/ns.two
   nop
  )
@@ -47,6 +53,10 @@
   global.get $export/c
   global.get $export/a
   call $export/mul
+  i32.add
+  global.get $export/a
+  global.get $export/c
+  call $export/div
   i32.add
   drop
   call $export/ns.two

--- a/tests/compiler/import.ts
+++ b/tests/compiler/import.ts
@@ -2,13 +2,14 @@ import {
   add,
   sub as sub,
   renamed_mul as mul,
+  "\\Not\"A;Brand" as div,
   a,
   b as b,
   renamed_c as c,
   ns as renamed_ns
 } from "./export";
 
-add(a, b) + sub(b, c) + mul(c, a);
+add(a, b) + sub(b, c) + mul(c, a) + div(a, c);
 
 renamed_ns.two();
 

--- a/tests/tokenizer.js
+++ b/tests/tokenizer.js
@@ -7,22 +7,22 @@ const dirname = path.dirname(fileURLToPath(import.meta.url));
 
 const file = process.argv.length > 2 ? process.argv[2] : path.join(dirname, "..", "src", "tokenizer.ts");
 const text = fs.readFileSync(file).toString();
-const source = new Source(SourceKind.ENTRY, "tokenizer.ts", text);
+const source = new Source(SourceKind.Entry, "tokenizer.ts", text);
 const tn = new Tokenizer(source);
 
 do {
   const token = tn.next();
   const range = tn.range();
   process.stdout.write(Token[token] + " @ " + source.lineAt(range.start) + ":" + source.columnAt());
-  if (token == Token.IDENTIFIER) {
+  if (token == Token.Identifier) {
     process.stdout.write(" > " + tn.readIdentifier());
-  } else if (token == Token.INTEGERLITERAL) {
+  } else if (token == Token.IntegerLiteral) {
     process.stdout.write(" > " + tn.readInteger());
-  } else if (token == Token.FLOATLITERAL) {
+  } else if (token == Token.FloatLiteral) {
     process.stdout.write(" > " + tn.readFloat());
-  } else if (token == Token.STRINGLITERAL) {
+  } else if (token == Token.StringLiteral) {
     process.stdout.write(" > " + tn.readString());
-  } else if (token == Token.ENDOFFILE) {
+  } else if (token == Token.EndOfFile) {
     process.stdout.write("\n");
     break;
   } else {


### PR DESCRIPTION
<!--
 Thanks for submitting a pull request to AssemblyScript! Please take a moment to
 review the contributing guidelines linked below, and confirm with an [x] 🙂
-->

Changes proposed in this pull request:
⯈ Add support for `export {foo as "b a\r"}`
⯈ Add support for `import {"b a\r" as foo} from "baz";`

- [x] I've read the contributing guidelines
- [x] I've added my name and email to the NOTICE file
