### PR TITLE
Use unique debug info per concrete function

### DIFF
--- a/src/compiler.ts
+++ b/src/compiler.ts
@@ -9870,8 +9870,10 @@ export class Compiler extends DiagnosticEmitter {
     let targetFunction = this.currentFlow.targetFunction;
     let source = range.source;
     if (source.debugInfoIndex < 0) source.debugInfoIndex = this.module.addDebugInfoFile(source.normalizedPath);
-    range.debugInfoRef = expr;
-    targetFunction.debugLocations.push(range);
+    // It's possible that an `expr` is seen multiple times, for example when
+    // first adding debug information for an inner expression and later on for
+    // an expression supposedly wrapping it, where the wrapping became a noop.
+    targetFunction.debugLocations.set(expr, range);
   }
 
   /** Checks whether a particular function signature is supported. */

--- a/src/diagnostics.ts
+++ b/src/diagnostics.ts
@@ -45,7 +45,6 @@ export const enum DiagnosticCategory {
 export class Range {
 
   source!: Source;
-  debugInfoRef: usize = 0;
 
   constructor(public start: i32, public end: i32) {}
 


### PR DESCRIPTION
A slightly simpler variant of #2688 using a `Map`, so debug info entries are automatically deduplicated.

fixes #2688, see also #2686

- [x] I've read the contributing guidelines
- [x] I've added my name and email to the NOTICE file
