### PR TITLE
Ensure call-less references to builtin functions in namespaces error

### DIFF
--- a/src/compiler.ts
+++ b/src/compiler.ts
@@ -9035,6 +9035,16 @@ export class Compiler extends DiagnosticEmitter {
       }
       case ElementKind.FunctionPrototype: {
         let functionPrototype = <FunctionPrototype>target;
+        let typeParameterNodes = functionPrototype.typeParameterNodes;
+
+        if (typeParameterNodes && typeParameterNodes.length != 0) {
+          this.error(
+            DiagnosticCode.Type_argument_expected,
+            expression.range
+          );
+          break; // also diagnose 'not a value at runtime'
+        }
+
         let functionInstance = this.resolver.resolveFunction(functionPrototype, null);
         if (!functionInstance) return module.unreachable();
         if (!this.compileFunction(functionInstance)) return module.unreachable();

--- a/src/compiler.ts
+++ b/src/compiler.ts
@@ -9049,6 +9049,15 @@ export class Compiler extends DiagnosticEmitter {
         if (!functionInstance) return module.unreachable();
         if (!this.compileFunction(functionInstance)) return module.unreachable();
         this.currentType = functionInstance.type;
+
+        if (functionInstance.hasDecorator(DecoratorFlags.Builtin)) {
+          this.error(
+            DiagnosticCode.Not_implemented_0,
+            expression.range, "First-class built-ins"
+          );
+          return module.unreachable();
+        }
+
         let offset = this.ensureRuntimeFunction(functionInstance);
         return this.options.isWasm64
           ? module.i64(i64_low(offset), i64_high(offset))

--- a/tests/compiler/issues/2737.json
+++ b/tests/compiler/issues/2737.json
@@ -1,0 +1,13 @@
+{
+  "stderr": [
+    "TS1140: Type argument expected.",
+    "foo.bar;",
+    "AS234: Expression does not compile to a value at runtime.",
+    "foo.bar;",
+    "TS1140: Type argument expected.",
+    "memory.data;",
+    "AS234: Expression does not compile to a value at runtime.",
+    "memory.data;",
+    "EOF"
+  ]
+}

--- a/tests/compiler/issues/2737.json
+++ b/tests/compiler/issues/2737.json
@@ -8,6 +8,8 @@
     "memory.data;",
     "AS234: Expression does not compile to a value at runtime.",
     "memory.data;",
+    "AS100: Not implemented: First-class built-ins",
+    "atomic.fence;",
     "EOF"
   ]
 }

--- a/tests/compiler/issues/2737.ts
+++ b/tests/compiler/issues/2737.ts
@@ -6,4 +6,7 @@ namespace foo {
 foo.bar;
 memory.data;
 
+// Should error from lacking first-class builtins:
+atomic.fence;
+
 ERROR("EOF");

--- a/tests/compiler/issues/2737.ts
+++ b/tests/compiler/issues/2737.ts
@@ -1,0 +1,9 @@
+namespace foo {
+    export function bar<T>(): void {}
+}
+
+// Should error from missing type arguments:
+foo.bar;
+memory.data;
+
+ERROR("EOF");


### PR DESCRIPTION
Changes proposed in this pull request:
⯈ Fix the long-standing bug where the compiler cries when referencing a generic namespaced function.
⯈ Error when builtin functions in namespaces are referenced without being called.

- [x] I've read the contributing guidelines
- [x] I've added my name and email to the NOTICE file
