### PR TITLE
fix: use correct valueType for compileAssignment[NFC]

### DIFF
--- a/src/compiler.ts
+++ b/src/compiler.ts
@@ -5703,10 +5703,12 @@ export class Compiler extends DiagnosticEmitter {
     assert(targetType != Type.void);
     let valueExpr = this.compileExpression(valueExpression, targetType);
     let valueType = this.currentType;
+    if (targetType.isNullableReference && this.currentFlow.isNonnull(valueExpr, valueType)) targetType = targetType.nonNullableType;
+    valueExpr = this.convertExpression(valueExpr, valueType, targetType, false, valueExpression);
     return this.makeAssignment(
       target,
-      this.convertExpression(valueExpr, valueType, targetType, false, valueExpression),
-      valueType,
+      valueExpr,
+      targetType,
       valueExpression,
       thisExpression,
       elementExpression,


### PR DESCRIPTION
In `makeAssignment`, `valueType` doesn't match the type of `valueExpr`.
But there are no actual influence for current generated wasm.
