### PR TITLE
Allow manually triggered publishes

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,5 +1,8 @@
 name: Publish
 on:
+  # Note that the main branch will be used regardless of the branch chosen
+  # in the web interface.
+  workflow_dispatch:
   schedule:
   - cron: '0 0 * * *'
 jobs:


### PR DESCRIPTION
Changes proposed in this pull request:
⯈ Allow the main branch to be published manually via the Actions tab

- [x] I've read the contributing guidelines
- [x] I've added my name and email to the NOTICE file
