### PR TITLE
fix: handle nest `tostack` in shadowstack pass

### DIFF
--- a/tests/compiler/resolve-unary.debug.wat
+++ b/tests/compiler/resolve-unary.debug.wat
@@ -3753,10 +3753,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  global.get $~lib/memory/__stack_pointer
   global.get $resolve-unary/bar
-  local.tee $6
-  i32.store
+  local.set $6
   global.get $~lib/memory/__stack_pointer
   local.get $6
   i32.store offset=12
@@ -3789,10 +3787,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  global.get $~lib/memory/__stack_pointer
   global.get $resolve-unary/bar
-  local.tee $6
-  i32.store
+  local.set $6
   global.get $~lib/memory/__stack_pointer
   local.get $6
   i32.store offset=12

--- a/tests/compiler/resolve-unary.release.wat
+++ b/tests/compiler/resolve-unary.release.wat
@@ -2626,10 +2626,6 @@
    global.get $~lib/memory/__stack_pointer
    local.tee $0
    global.get $resolve-unary/bar
-   local.tee $1
-   i32.store
-   local.get $0
-   local.get $1
    i32.store offset=12
    local.get $0
    i32.const 3680
@@ -2655,10 +2651,6 @@
    global.get $~lib/memory/__stack_pointer
    local.tee $0
    global.get $resolve-unary/bar
-   local.tee $1
-   i32.store
-   local.get $0
-   local.get $1
    i32.store offset=12
    local.get $0
    i32.const 3712


### PR DESCRIPTION
match `tostack(tostack(expr))` pattern in shadowstack pass.