### PR TITLE
fix: Improve date parsing (fractional seconds, UTC offsets)

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -56,6 +56,7 @@ under the licensing terms detailed in LICENSE:
 * Abdul Rauf <abdulraufmujahid@gmail.com>
 * Bach Le <bach@bullno1.com>
 * Xinquan Xu <xinquan0203@163.com>
+* Matt Johnson-Pint <mattjohnsonpint@gmail.com>
 
 Portions of this software are derived from third-party works licensed under
 the following terms:

--- a/std/assembly/date.ts
+++ b/std/assembly/date.ts
@@ -77,9 +77,7 @@ export class Date {
           let offsetHours = i32.parse(offsetParts[0]);
           let offsetMinutes = offsetParts.length >= 2 ? i32.parse(offsetParts[1]) : 0;
           offsetMs = (offsetHours * 60 + offsetMinutes) * MILLIS_PER_MINUTE;
-          if (c == 45) {
-            offsetMs = -offsetMs; // negative offset
-          }
+          if (c == 45) offsetMs = -offsetMs; // negative offset
           timeString = timeString.substring(0, i);
           break;
         }

--- a/std/assembly/date.ts
+++ b/std/assembly/date.ts
@@ -66,29 +66,29 @@ export class Date {
       let len = timeParts.length;
       if (len <= 1) throw new RangeError(E_INVALIDDATE);
 
-      hour = I32.parseInt(timeParts[0]);
-      min  = I32.parseInt(timeParts[1]);
+      hour = i32.parse(timeParts[0]);
+      min  = i32.parse(timeParts[1]);
       if (len >= 3) {
         let secAndMs = timeParts[2];
         let posDot = secAndMs.indexOf(".");
         if (~posDot) {
           // includes milliseconds
-          sec = I32.parseInt(secAndMs.substring(0, posDot));
-          ms  = I32.parseInt(secAndMs.substring(posDot + 1));
+          sec = i32.parse(secAndMs.substring(0, posDot));
+          ms  = i32.parse(secAndMs.substring(posDot + 1));
         } else {
-          sec = I32.parseInt(secAndMs);
+          sec = i32.parse(secAndMs);
         }
       }
     }
     // parse the YYYY-MM-DD component
     let parts = dateString.split("-");
-    let year = I32.parseInt(parts[0]);
+    let year = i32.parse(parts[0]);
     let month = 1, day = 1;
     let len = parts.length;
     if (len >= 2) {
-      month = I32.parseInt(parts[1]);
+      month = i32.parse(parts[1]);
       if (len >= 3) {
-        day = I32.parseInt(parts[2]);
+        day = i32.parse(parts[2]);
       }
     }
     return new Date(epochMillis(year, month, day, hour, min, sec, ms));

--- a/std/assembly/date.ts
+++ b/std/assembly/date.ts
@@ -73,10 +73,17 @@ export class Date {
           if (i == timeString.length - 1) {
             throw new RangeError(E_INVALIDDATE);
           }
-          let offsetParts = timeString.substring(i+1).split(":");
-          let offsetHours = i32.parse(offsetParts[0]);
-          let offsetMinutes = offsetParts.length >= 2 ? i32.parse(offsetParts[1]) : 0;
-          offsetMs = (offsetHours * 60 + offsetMinutes) * MILLIS_PER_MINUTE;
+
+          let posColon = timeString.indexOf(":", i + 1);
+          if (~posColon) {
+            let offsetHours = i32.parse(timeString.substring(i + 1, posColon));
+            let offsetMinutes = i32.parse(timeString.substring(posColon + 1));
+            offsetMs = (offsetHours * 60 + offsetMinutes) * MILLIS_PER_MINUTE;
+          } else {
+            let offsetHours = i32.parse(timeString.substring(i + 1));
+            offsetMs = offsetHours * MILLIS_PER_HOUR;
+          }    
+    
           if (c == 45) offsetMs = -offsetMs; // negative offset
           timeString = timeString.substring(0, i);
           break;

--- a/std/assembly/date.ts
+++ b/std/assembly/date.ts
@@ -76,7 +76,7 @@ export class Date {
           let offsetParts = timeString.substring(i+1).split(":");
           let offsetHours = i32.parse(offsetParts[0]);
           let offsetMinutes = offsetParts.length >= 2 ? i32.parse(offsetParts[1]) : 0;
-          offsetMs = (offsetHours * 60 + offsetMinutes) * 60000;
+          offsetMs = (offsetHours * 60 + offsetMinutes) * MILLIS_PER_MINUTE;
           if (c == 45) {
             offsetMs = -offsetMs; // negative offset
           }

--- a/tests/compiler/std/date.debug.wat
+++ b/tests/compiler/std/date.debug.wat
@@ -3495,77 +3495,6 @@
   i32.load
   return
  )
- (func $~lib/array/Array<~lib/string/String>#get:length_ (param $this i32) (result i32)
-  local.get $this
-  i32.load offset=12
- )
- (func $~lib/arraybuffer/ArrayBufferView#get:byteLength (param $this i32) (result i32)
-  local.get $this
-  i32.load offset=8
- )
- (func $~lib/arraybuffer/ArrayBufferView#get:buffer (param $this i32) (result i32)
-  local.get $this
-  i32.load
- )
- (func $~lib/rt/itcms/Object#get:rtSize (param $this i32) (result i32)
-  local.get $this
-  i32.load offset=16
- )
- (func $~lib/rt/itcms/__renew (param $oldPtr i32) (param $size i32) (result i32)
-  (local $oldObj i32)
-  (local $newPtr i32)
-  (local $4 i32)
-  (local $5 i32)
-  local.get $oldPtr
-  i32.const 20
-  i32.sub
-  local.set $oldObj
-  local.get $size
-  local.get $oldObj
-  call $~lib/rt/common/BLOCK#get:mmInfo
-  i32.const 3
-  i32.const -1
-  i32.xor
-  i32.and
-  i32.const 16
-  i32.sub
-  i32.le_u
-  if
-   local.get $oldObj
-   local.get $size
-   call $~lib/rt/itcms/Object#set:rtSize
-   local.get $oldPtr
-   return
-  end
-  local.get $size
-  local.get $oldObj
-  call $~lib/rt/itcms/Object#get:rtId
-  call $~lib/rt/itcms/__new
-  local.set $newPtr
-  local.get $newPtr
-  local.get $oldPtr
-  local.get $size
-  local.tee $4
-  local.get $oldObj
-  call $~lib/rt/itcms/Object#get:rtSize
-  local.tee $5
-  local.get $4
-  local.get $5
-  i32.lt_u
-  select
-  memory.copy
-  local.get $newPtr
-  return
- )
- (func $~lib/array/Array<~lib/string/String>#set:length_ (param $this i32) (param $length_ i32)
-  local.get $this
-  local.get $length_
-  i32.store offset=12
- )
- (func $~lib/array/Array<~lib/string/String>#get:dataStart (param $this i32) (result i32)
-  local.get $this
-  i32.load offset=4
- )
  (func $~lib/util/string/isSpace (param $c i32) (result i32)
   (local $1 i32)
   local.get $c
@@ -3652,6 +3581,77 @@
   end
   i32.const 0
   return
+ )
+ (func $~lib/array/Array<~lib/string/String>#get:length_ (param $this i32) (result i32)
+  local.get $this
+  i32.load offset=12
+ )
+ (func $~lib/arraybuffer/ArrayBufferView#get:byteLength (param $this i32) (result i32)
+  local.get $this
+  i32.load offset=8
+ )
+ (func $~lib/arraybuffer/ArrayBufferView#get:buffer (param $this i32) (result i32)
+  local.get $this
+  i32.load
+ )
+ (func $~lib/rt/itcms/Object#get:rtSize (param $this i32) (result i32)
+  local.get $this
+  i32.load offset=16
+ )
+ (func $~lib/rt/itcms/__renew (param $oldPtr i32) (param $size i32) (result i32)
+  (local $oldObj i32)
+  (local $newPtr i32)
+  (local $4 i32)
+  (local $5 i32)
+  local.get $oldPtr
+  i32.const 20
+  i32.sub
+  local.set $oldObj
+  local.get $size
+  local.get $oldObj
+  call $~lib/rt/common/BLOCK#get:mmInfo
+  i32.const 3
+  i32.const -1
+  i32.xor
+  i32.and
+  i32.const 16
+  i32.sub
+  i32.le_u
+  if
+   local.get $oldObj
+   local.get $size
+   call $~lib/rt/itcms/Object#set:rtSize
+   local.get $oldPtr
+   return
+  end
+  local.get $size
+  local.get $oldObj
+  call $~lib/rt/itcms/Object#get:rtId
+  call $~lib/rt/itcms/__new
+  local.set $newPtr
+  local.get $newPtr
+  local.get $oldPtr
+  local.get $size
+  local.tee $4
+  local.get $oldObj
+  call $~lib/rt/itcms/Object#get:rtSize
+  local.tee $5
+  local.get $4
+  local.get $5
+  i32.lt_u
+  select
+  memory.copy
+  local.get $newPtr
+  return
+ )
+ (func $~lib/array/Array<~lib/string/String>#set:length_ (param $this i32) (param $length_ i32)
+  local.get $this
+  local.get $length_
+  i32.store offset=12
+ )
+ (func $~lib/array/Array<~lib/string/String>#get:dataStart (param $this i32) (result i32)
+  local.get $this
+  i32.load offset=4
  )
  (func $~lib/rt/__visit_globals (param $0 i32)
   (local $1 i32)
@@ -3887,7 +3887,7 @@
   if
    i32.const 32
    i32.const 80
-   i32.const 124
+   i32.const 131
    i32.const 35
    call $~lib/builtins/abort
    unreachable
@@ -3941,7 +3941,7 @@
   if
    i32.const 32
    i32.const 80
-   i32.const 136
+   i32.const 143
    i32.const 28
    call $~lib/builtins/abort
    unreachable
@@ -6579,6 +6579,357 @@
   local.get $2
   return
  )
+ (func $~lib/util/string/strtol<i32> (param $str i32) (param $radix i32) (result i32)
+  (local $len i32)
+  (local $ptr i32)
+  (local $code i32)
+  (local $sign i32)
+  (local $6 i32)
+  (local $num i32)
+  (local $initial i32)
+  (local $9 i32)
+  (local $10 i32)
+  global.get $~lib/memory/__stack_pointer
+  i32.const 4
+  i32.sub
+  global.set $~lib/memory/__stack_pointer
+  call $~stack_check
+  global.get $~lib/memory/__stack_pointer
+  i32.const 0
+  i32.store
+  local.get $str
+  local.set $10
+  global.get $~lib/memory/__stack_pointer
+  local.get $10
+  i32.store
+  local.get $10
+  call $~lib/string/String#get:length
+  local.set $len
+  local.get $len
+  i32.eqz
+  if
+   i32.const 0
+   drop
+   i32.const 0
+   local.set $10
+   global.get $~lib/memory/__stack_pointer
+   i32.const 4
+   i32.add
+   global.set $~lib/memory/__stack_pointer
+   local.get $10
+   return
+  end
+  local.get $str
+  local.set $ptr
+  local.get $ptr
+  i32.load16_u
+  local.set $code
+  loop $while-continue|0
+   local.get $code
+   call $~lib/util/string/isSpace
+   if
+    local.get $ptr
+    i32.const 2
+    i32.add
+    local.tee $ptr
+    i32.load16_u
+    local.set $code
+    local.get $len
+    i32.const 1
+    i32.sub
+    local.set $len
+    br $while-continue|0
+   end
+  end
+  i32.const 1
+  local.set $sign
+  local.get $code
+  i32.const 45
+  i32.eq
+  if (result i32)
+   i32.const 1
+  else
+   local.get $code
+   i32.const 43
+   i32.eq
+  end
+  if
+   local.get $len
+   i32.const 1
+   i32.sub
+   local.tee $len
+   i32.eqz
+   if
+    i32.const 0
+    drop
+    i32.const 0
+    local.set $10
+    global.get $~lib/memory/__stack_pointer
+    i32.const 4
+    i32.add
+    global.set $~lib/memory/__stack_pointer
+    local.get $10
+    return
+   end
+   local.get $code
+   i32.const 45
+   i32.eq
+   if
+    i32.const -1
+    local.set $sign
+   end
+   local.get $ptr
+   i32.const 2
+   i32.add
+   local.tee $ptr
+   i32.load16_u
+   local.set $code
+  end
+  local.get $radix
+  if
+   local.get $radix
+   i32.const 2
+   i32.lt_s
+   if (result i32)
+    i32.const 1
+   else
+    local.get $radix
+    i32.const 36
+    i32.gt_s
+   end
+   if
+    i32.const 0
+    drop
+    i32.const 0
+    local.set $10
+    global.get $~lib/memory/__stack_pointer
+    i32.const 4
+    i32.add
+    global.set $~lib/memory/__stack_pointer
+    local.get $10
+    return
+   end
+   local.get $radix
+   i32.const 16
+   i32.eq
+   if
+    local.get $len
+    i32.const 2
+    i32.gt_s
+    if (result i32)
+     local.get $code
+     i32.const 48
+     i32.eq
+    else
+     i32.const 0
+    end
+    if (result i32)
+     local.get $ptr
+     i32.load16_u offset=2
+     i32.const 32
+     i32.or
+     i32.const 120
+     i32.eq
+    else
+     i32.const 0
+    end
+    if
+     local.get $ptr
+     i32.const 4
+     i32.add
+     local.set $ptr
+     local.get $len
+     i32.const 2
+     i32.sub
+     local.set $len
+    end
+   end
+  else
+   local.get $code
+   i32.const 48
+   i32.eq
+   if (result i32)
+    local.get $len
+    i32.const 2
+    i32.gt_s
+   else
+    i32.const 0
+   end
+   if
+    block $break|1
+     block $case2|1
+      block $case1|1
+       block $case0|1
+        local.get $ptr
+        i32.load16_u offset=2
+        i32.const 32
+        i32.or
+        local.set $6
+        local.get $6
+        i32.const 98
+        i32.eq
+        br_if $case0|1
+        local.get $6
+        i32.const 111
+        i32.eq
+        br_if $case1|1
+        local.get $6
+        i32.const 120
+        i32.eq
+        br_if $case2|1
+        br $break|1
+       end
+       local.get $ptr
+       i32.const 4
+       i32.add
+       local.set $ptr
+       local.get $len
+       i32.const 2
+       i32.sub
+       local.set $len
+       i32.const 2
+       local.set $radix
+       br $break|1
+      end
+      local.get $ptr
+      i32.const 4
+      i32.add
+      local.set $ptr
+      local.get $len
+      i32.const 2
+      i32.sub
+      local.set $len
+      i32.const 8
+      local.set $radix
+      br $break|1
+     end
+     local.get $ptr
+     i32.const 4
+     i32.add
+     local.set $ptr
+     local.get $len
+     i32.const 2
+     i32.sub
+     local.set $len
+     i32.const 16
+     local.set $radix
+     br $break|1
+    end
+   end
+   local.get $radix
+   i32.eqz
+   if
+    i32.const 10
+    local.set $radix
+   end
+  end
+  i32.const 0
+  local.set $num
+  local.get $len
+  i32.const 1
+  i32.sub
+  local.set $initial
+  block $while-break|2
+   loop $while-continue|2
+    local.get $len
+    local.tee $9
+    i32.const 1
+    i32.sub
+    local.set $len
+    local.get $9
+    if
+     local.get $ptr
+     i32.load16_u
+     local.set $code
+     local.get $code
+     i32.const 48
+     i32.sub
+     i32.const 10
+     i32.lt_u
+     if
+      local.get $code
+      i32.const 48
+      i32.sub
+      local.set $code
+     else
+      local.get $code
+      i32.const 65
+      i32.sub
+      i32.const 90
+      i32.const 65
+      i32.sub
+      i32.le_u
+      if
+       local.get $code
+       i32.const 65
+       i32.const 10
+       i32.sub
+       i32.sub
+       local.set $code
+      else
+       local.get $code
+       i32.const 97
+       i32.sub
+       i32.const 122
+       i32.const 97
+       i32.sub
+       i32.le_u
+       if
+        local.get $code
+        i32.const 97
+        i32.const 10
+        i32.sub
+        i32.sub
+        local.set $code
+       end
+      end
+     end
+     local.get $code
+     local.get $radix
+     i32.ge_u
+     if
+      local.get $initial
+      local.get $len
+      i32.eq
+      if
+       i32.const 0
+       drop
+       i32.const 0
+       local.set $10
+       global.get $~lib/memory/__stack_pointer
+       i32.const 4
+       i32.add
+       global.set $~lib/memory/__stack_pointer
+       local.get $10
+       return
+      end
+      br $while-break|2
+     end
+     local.get $num
+     local.get $radix
+     i32.mul
+     local.get $code
+     i32.add
+     local.set $num
+     local.get $ptr
+     i32.const 2
+     i32.add
+     local.set $ptr
+     br $while-continue|2
+    end
+   end
+  end
+  local.get $sign
+  local.get $num
+  i32.mul
+  local.set $10
+  global.get $~lib/memory/__stack_pointer
+  i32.const 4
+  i32.add
+  global.set $~lib/memory/__stack_pointer
+  local.get $10
+  return
+ )
  (func $~lib/array/ensureCapacity (param $array i32) (param $newSize i32) (param $alignLog2 i32) (param $canGrow i32)
   (local $oldCapacity i32)
   (local $oldData i32)
@@ -7306,6 +7657,31 @@
   global.set $~lib/memory/__stack_pointer
   local.get $3
  )
+ (func $~lib/array/Array<~lib/string/String>#get:length (param $this i32) (result i32)
+  (local $1 i32)
+  global.get $~lib/memory/__stack_pointer
+  i32.const 4
+  i32.sub
+  global.set $~lib/memory/__stack_pointer
+  call $~stack_check
+  global.get $~lib/memory/__stack_pointer
+  i32.const 0
+  i32.store
+  local.get $this
+  local.set $1
+  global.get $~lib/memory/__stack_pointer
+  local.get $1
+  i32.store
+  local.get $1
+  call $~lib/array/Array<~lib/string/String>#get:length_
+  local.set $1
+  global.get $~lib/memory/__stack_pointer
+  i32.const 4
+  i32.add
+  global.set $~lib/memory/__stack_pointer
+  local.get $1
+  return
+ )
  (func $~lib/array/Array<~lib/string/String>#__get (param $this i32) (param $index i32) (result i32)
   (local $value i32)
   (local $3 i32)
@@ -7371,382 +7747,6 @@
   i32.add
   global.set $~lib/memory/__stack_pointer
   local.get $3
-  return
- )
- (func $~lib/util/string/strtol<i32> (param $str i32) (param $radix i32) (result i32)
-  (local $len i32)
-  (local $ptr i32)
-  (local $code i32)
-  (local $sign i32)
-  (local $6 i32)
-  (local $num i32)
-  (local $initial i32)
-  (local $9 i32)
-  (local $10 i32)
-  global.get $~lib/memory/__stack_pointer
-  i32.const 4
-  i32.sub
-  global.set $~lib/memory/__stack_pointer
-  call $~stack_check
-  global.get $~lib/memory/__stack_pointer
-  i32.const 0
-  i32.store
-  local.get $str
-  local.set $10
-  global.get $~lib/memory/__stack_pointer
-  local.get $10
-  i32.store
-  local.get $10
-  call $~lib/string/String#get:length
-  local.set $len
-  local.get $len
-  i32.eqz
-  if
-   i32.const 0
-   drop
-   i32.const 0
-   local.set $10
-   global.get $~lib/memory/__stack_pointer
-   i32.const 4
-   i32.add
-   global.set $~lib/memory/__stack_pointer
-   local.get $10
-   return
-  end
-  local.get $str
-  local.set $ptr
-  local.get $ptr
-  i32.load16_u
-  local.set $code
-  loop $while-continue|0
-   local.get $code
-   call $~lib/util/string/isSpace
-   if
-    local.get $ptr
-    i32.const 2
-    i32.add
-    local.tee $ptr
-    i32.load16_u
-    local.set $code
-    local.get $len
-    i32.const 1
-    i32.sub
-    local.set $len
-    br $while-continue|0
-   end
-  end
-  i32.const 1
-  local.set $sign
-  local.get $code
-  i32.const 45
-  i32.eq
-  if (result i32)
-   i32.const 1
-  else
-   local.get $code
-   i32.const 43
-   i32.eq
-  end
-  if
-   local.get $len
-   i32.const 1
-   i32.sub
-   local.tee $len
-   i32.eqz
-   if
-    i32.const 0
-    drop
-    i32.const 0
-    local.set $10
-    global.get $~lib/memory/__stack_pointer
-    i32.const 4
-    i32.add
-    global.set $~lib/memory/__stack_pointer
-    local.get $10
-    return
-   end
-   local.get $code
-   i32.const 45
-   i32.eq
-   if
-    i32.const -1
-    local.set $sign
-   end
-   local.get $ptr
-   i32.const 2
-   i32.add
-   local.tee $ptr
-   i32.load16_u
-   local.set $code
-  end
-  local.get $radix
-  if
-   local.get $radix
-   i32.const 2
-   i32.lt_s
-   if (result i32)
-    i32.const 1
-   else
-    local.get $radix
-    i32.const 36
-    i32.gt_s
-   end
-   if
-    i32.const 0
-    drop
-    i32.const 0
-    local.set $10
-    global.get $~lib/memory/__stack_pointer
-    i32.const 4
-    i32.add
-    global.set $~lib/memory/__stack_pointer
-    local.get $10
-    return
-   end
-   local.get $radix
-   i32.const 16
-   i32.eq
-   if
-    local.get $len
-    i32.const 2
-    i32.gt_s
-    if (result i32)
-     local.get $code
-     i32.const 48
-     i32.eq
-    else
-     i32.const 0
-    end
-    if (result i32)
-     local.get $ptr
-     i32.load16_u offset=2
-     i32.const 32
-     i32.or
-     i32.const 120
-     i32.eq
-    else
-     i32.const 0
-    end
-    if
-     local.get $ptr
-     i32.const 4
-     i32.add
-     local.set $ptr
-     local.get $len
-     i32.const 2
-     i32.sub
-     local.set $len
-    end
-   end
-  else
-   local.get $code
-   i32.const 48
-   i32.eq
-   if (result i32)
-    local.get $len
-    i32.const 2
-    i32.gt_s
-   else
-    i32.const 0
-   end
-   if
-    block $break|1
-     block $case2|1
-      block $case1|1
-       block $case0|1
-        local.get $ptr
-        i32.load16_u offset=2
-        i32.const 32
-        i32.or
-        local.set $6
-        local.get $6
-        i32.const 98
-        i32.eq
-        br_if $case0|1
-        local.get $6
-        i32.const 111
-        i32.eq
-        br_if $case1|1
-        local.get $6
-        i32.const 120
-        i32.eq
-        br_if $case2|1
-        br $break|1
-       end
-       local.get $ptr
-       i32.const 4
-       i32.add
-       local.set $ptr
-       local.get $len
-       i32.const 2
-       i32.sub
-       local.set $len
-       i32.const 2
-       local.set $radix
-       br $break|1
-      end
-      local.get $ptr
-      i32.const 4
-      i32.add
-      local.set $ptr
-      local.get $len
-      i32.const 2
-      i32.sub
-      local.set $len
-      i32.const 8
-      local.set $radix
-      br $break|1
-     end
-     local.get $ptr
-     i32.const 4
-     i32.add
-     local.set $ptr
-     local.get $len
-     i32.const 2
-     i32.sub
-     local.set $len
-     i32.const 16
-     local.set $radix
-     br $break|1
-    end
-   end
-   local.get $radix
-   i32.eqz
-   if
-    i32.const 10
-    local.set $radix
-   end
-  end
-  i32.const 0
-  local.set $num
-  local.get $len
-  i32.const 1
-  i32.sub
-  local.set $initial
-  block $while-break|2
-   loop $while-continue|2
-    local.get $len
-    local.tee $9
-    i32.const 1
-    i32.sub
-    local.set $len
-    local.get $9
-    if
-     local.get $ptr
-     i32.load16_u
-     local.set $code
-     local.get $code
-     i32.const 48
-     i32.sub
-     i32.const 10
-     i32.lt_u
-     if
-      local.get $code
-      i32.const 48
-      i32.sub
-      local.set $code
-     else
-      local.get $code
-      i32.const 65
-      i32.sub
-      i32.const 90
-      i32.const 65
-      i32.sub
-      i32.le_u
-      if
-       local.get $code
-       i32.const 65
-       i32.const 10
-       i32.sub
-       i32.sub
-       local.set $code
-      else
-       local.get $code
-       i32.const 97
-       i32.sub
-       i32.const 122
-       i32.const 97
-       i32.sub
-       i32.le_u
-       if
-        local.get $code
-        i32.const 97
-        i32.const 10
-        i32.sub
-        i32.sub
-        local.set $code
-       end
-      end
-     end
-     local.get $code
-     local.get $radix
-     i32.ge_u
-     if
-      local.get $initial
-      local.get $len
-      i32.eq
-      if
-       i32.const 0
-       drop
-       i32.const 0
-       local.set $10
-       global.get $~lib/memory/__stack_pointer
-       i32.const 4
-       i32.add
-       global.set $~lib/memory/__stack_pointer
-       local.get $10
-       return
-      end
-      br $while-break|2
-     end
-     local.get $num
-     local.get $radix
-     i32.mul
-     local.get $code
-     i32.add
-     local.set $num
-     local.get $ptr
-     i32.const 2
-     i32.add
-     local.set $ptr
-     br $while-continue|2
-    end
-   end
-  end
-  local.get $sign
-  local.get $num
-  i32.mul
-  local.set $10
-  global.get $~lib/memory/__stack_pointer
-  i32.const 4
-  i32.add
-  global.set $~lib/memory/__stack_pointer
-  local.get $10
-  return
- )
- (func $~lib/array/Array<~lib/string/String>#get:length (param $this i32) (result i32)
-  (local $1 i32)
-  global.get $~lib/memory/__stack_pointer
-  i32.const 4
-  i32.sub
-  global.set $~lib/memory/__stack_pointer
-  call $~stack_check
-  global.get $~lib/memory/__stack_pointer
-  i32.const 0
-  i32.store
-  local.get $this
-  local.set $1
-  global.get $~lib/memory/__stack_pointer
-  local.get $1
-  i32.store
-  local.get $1
-  call $~lib/array/Array<~lib/string/String>#get:length_
-  local.set $1
-  global.get $~lib/memory/__stack_pointer
-  i32.const 4
-  i32.add
-  global.set $~lib/memory/__stack_pointer
-  local.get $1
   return
  )
  (func $~lib/string/String#substr (param $this i32) (param $start i32) (param $length i32) (result i32)
@@ -7990,39 +7990,42 @@
   (local $timeString i32)
   (local $i i32)
   (local $c i32)
-  (local $offsetParts i32)
+  (local $posColon i32)
   (local $value i32)
   (local $radix i32)
   (local $offsetHours i32)
   (local $value|15 i32)
   (local $radix|16 i32)
   (local $offsetMinutes i32)
+  (local $value|18 i32)
+  (local $radix|19 i32)
+  (local $offsetHours|20 i32)
   (local $timeParts i32)
   (local $len i32)
-  (local $value|20 i32)
-  (local $radix|21 i32)
-  (local $value|22 i32)
-  (local $radix|23 i32)
+  (local $value|23 i32)
+  (local $radix|24 i32)
+  (local $value|25 i32)
+  (local $radix|26 i32)
   (local $secAndFrac i32)
   (local $posDot i32)
-  (local $value|26 i32)
-  (local $radix|27 i32)
-  (local $value|28 i32)
-  (local $radix|29 i32)
-  (local $value|30 i32)
-  (local $radix|31 i32)
-  (local $parts i32)
+  (local $value|29 i32)
+  (local $radix|30 i32)
+  (local $value|31 i32)
+  (local $radix|32 i32)
   (local $value|33 i32)
   (local $radix|34 i32)
+  (local $parts i32)
+  (local $value|36 i32)
+  (local $radix|37 i32)
   (local $year i32)
   (local $month i32)
   (local $day i32)
-  (local $len|38 i32)
-  (local $value|39 i32)
-  (local $radix|40 i32)
-  (local $value|41 i32)
-  (local $radix|42 i32)
-  (local $43 i32)
+  (local $len|41 i32)
+  (local $value|42 i32)
+  (local $radix|43 i32)
+  (local $value|44 i32)
+  (local $radix|45 i32)
+  (local $46 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 76
   i32.sub
@@ -8033,11 +8036,11 @@
   i32.const 76
   memory.fill
   local.get $dateTimeString
-  local.set $43
+  local.set $46
   global.get $~lib/memory/__stack_pointer
-  local.get $43
+  local.get $46
   i32.store
-  local.get $43
+  local.get $46
   call $~lib/string/String#get:length
   i32.eqz
   if
@@ -8063,17 +8066,17 @@
   local.tee $dateString
   i32.store offset=4
   local.get $dateTimeString
-  local.set $43
+  local.set $46
   global.get $~lib/memory/__stack_pointer
-  local.get $43
+  local.get $46
   i32.store
-  local.get $43
+  local.get $46
   i32.const 2464
-  local.set $43
+  local.set $46
   global.get $~lib/memory/__stack_pointer
-  local.get $43
+  local.get $46
   i32.store offset=8
-  local.get $43
+  local.get $46
   i32.const 0
   call $~lib/string/String#indexOf
   local.set $posT
@@ -8083,11 +8086,11 @@
   if
    global.get $~lib/memory/__stack_pointer
    local.get $dateTimeString
-   local.set $43
+   local.set $46
    global.get $~lib/memory/__stack_pointer
-   local.get $43
+   local.get $46
    i32.store
-   local.get $43
+   local.get $46
    i32.const 0
    local.get $posT
    call $~lib/string/String#substring
@@ -8095,11 +8098,11 @@
    i32.store offset=4
    global.get $~lib/memory/__stack_pointer
    local.get $dateTimeString
-   local.set $43
+   local.set $46
    global.get $~lib/memory/__stack_pointer
-   local.get $43
+   local.get $46
    i32.store
-   local.get $43
+   local.get $46
    local.get $posT
    i32.const 1
    i32.add
@@ -8110,11 +8113,11 @@
    local.tee $timeString
    i32.store offset=12
    local.get $timeString
-   local.set $43
+   local.set $46
    global.get $~lib/memory/__stack_pointer
-   local.get $43
+   local.get $46
    i32.store
-   local.get $43
+   local.get $46
    call $~lib/string/String#get:length
    i32.const 1
    i32.sub
@@ -8126,11 +8129,11 @@
      i32.ge_s
      if
       local.get $timeString
-      local.set $43
+      local.set $46
       global.get $~lib/memory/__stack_pointer
-      local.get $43
+      local.get $46
       i32.store
-      local.get $43
+      local.get $46
       local.get $i
       call $~lib/string/String#charCodeAt
       local.set $c
@@ -8140,11 +8143,11 @@
       if
        global.get $~lib/memory/__stack_pointer
        local.get $timeString
-       local.set $43
+       local.set $46
        global.get $~lib/memory/__stack_pointer
-       local.get $43
+       local.get $46
        i32.store
-       local.get $43
+       local.get $46
        i32.const 0
        local.get $i
        call $~lib/string/String#substring
@@ -8165,11 +8168,11 @@
        if
         local.get $i
         local.get $timeString
-        local.set $43
+        local.set $46
         global.get $~lib/memory/__stack_pointer
-        local.get $43
+        local.get $46
         i32.store
-        local.get $43
+        local.get $46
         call $~lib/string/String#get:length
         i32.const 1
         i32.sub
@@ -8182,108 +8185,129 @@
          call $~lib/builtins/abort
          unreachable
         end
-        global.get $~lib/memory/__stack_pointer
         local.get $timeString
-        local.set $43
+        local.set $46
         global.get $~lib/memory/__stack_pointer
-        local.get $43
-        i32.store offset=16
-        local.get $43
+        local.get $46
+        i32.store
+        local.get $46
+        i32.const 2496
+        local.set $46
+        global.get $~lib/memory/__stack_pointer
+        local.get $46
+        i32.store offset=8
+        local.get $46
         local.get $i
         i32.const 1
         i32.add
-        i32.const 1
-        global.set $~argumentsLength
-        i32.const 0
-        call $~lib/string/String#substring@varargs
-        local.set $43
-        global.get $~lib/memory/__stack_pointer
-        local.get $43
-        i32.store
-        local.get $43
-        i32.const 2496
-        local.set $43
-        global.get $~lib/memory/__stack_pointer
-        local.get $43
-        i32.store offset=8
-        local.get $43
-        i32.const 1
-        global.set $~argumentsLength
-        i32.const 0
-        call $~lib/string/String#split@varargs
-        local.tee $offsetParts
-        i32.store offset=20
-        block $~lib/builtins/i32.parse|inlined.0 (result i32)
-         global.get $~lib/memory/__stack_pointer
-         local.get $offsetParts
-         local.set $43
-         global.get $~lib/memory/__stack_pointer
-         local.get $43
-         i32.store
-         local.get $43
-         i32.const 0
-         call $~lib/array/Array<~lib/string/String>#__get
-         local.tee $value
-         i32.store offset=24
-         i32.const 0
-         local.set $radix
-         local.get $value
-         local.set $43
-         global.get $~lib/memory/__stack_pointer
-         local.get $43
-         i32.store
-         local.get $43
-         local.get $radix
-         call $~lib/util/string/strtol<i32>
-         br $~lib/builtins/i32.parse|inlined.0
-        end
-        local.set $offsetHours
-        local.get $offsetParts
-        local.set $43
-        global.get $~lib/memory/__stack_pointer
-        local.get $43
-        i32.store
-        local.get $43
-        call $~lib/array/Array<~lib/string/String>#get:length
-        i32.const 2
-        i32.ge_s
-        if (result i32)
+        call $~lib/string/String#indexOf
+        local.set $posColon
+        local.get $posColon
+        i32.const -1
+        i32.xor
+        if
+         block $~lib/builtins/i32.parse|inlined.0 (result i32)
+          global.get $~lib/memory/__stack_pointer
+          local.get $timeString
+          local.set $46
+          global.get $~lib/memory/__stack_pointer
+          local.get $46
+          i32.store
+          local.get $46
+          local.get $i
+          i32.const 1
+          i32.add
+          local.get $posColon
+          call $~lib/string/String#substring
+          local.tee $value
+          i32.store offset=16
+          i32.const 0
+          local.set $radix
+          local.get $value
+          local.set $46
+          global.get $~lib/memory/__stack_pointer
+          local.get $46
+          i32.store
+          local.get $46
+          local.get $radix
+          call $~lib/util/string/strtol<i32>
+          br $~lib/builtins/i32.parse|inlined.0
+         end
+         local.set $offsetHours
          block $~lib/builtins/i32.parse|inlined.1 (result i32)
           global.get $~lib/memory/__stack_pointer
-          local.get $offsetParts
-          local.set $43
+          local.get $timeString
+          local.set $46
           global.get $~lib/memory/__stack_pointer
-          local.get $43
+          local.get $46
           i32.store
-          local.get $43
+          local.get $46
+          local.get $posColon
           i32.const 1
-          call $~lib/array/Array<~lib/string/String>#__get
+          i32.add
+          i32.const 1
+          global.set $~argumentsLength
+          i32.const 0
+          call $~lib/string/String#substring@varargs
           local.tee $value|15
-          i32.store offset=28
+          i32.store offset=20
           i32.const 0
           local.set $radix|16
           local.get $value|15
-          local.set $43
+          local.set $46
           global.get $~lib/memory/__stack_pointer
-          local.get $43
+          local.get $46
           i32.store
-          local.get $43
+          local.get $46
           local.get $radix|16
           call $~lib/util/string/strtol<i32>
           br $~lib/builtins/i32.parse|inlined.1
          end
+         local.set $offsetMinutes
+         local.get $offsetHours
+         i32.const 60
+         i32.mul
+         local.get $offsetMinutes
+         i32.add
+         i32.const 60000
+         i32.mul
+         local.set $offsetMs
         else
-         i32.const 0
+         block $~lib/builtins/i32.parse|inlined.2 (result i32)
+          global.get $~lib/memory/__stack_pointer
+          local.get $timeString
+          local.set $46
+          global.get $~lib/memory/__stack_pointer
+          local.get $46
+          i32.store
+          local.get $46
+          local.get $i
+          i32.const 1
+          i32.add
+          i32.const 1
+          global.set $~argumentsLength
+          i32.const 0
+          call $~lib/string/String#substring@varargs
+          local.tee $value|18
+          i32.store offset=24
+          i32.const 0
+          local.set $radix|19
+          local.get $value|18
+          local.set $46
+          global.get $~lib/memory/__stack_pointer
+          local.get $46
+          i32.store
+          local.get $46
+          local.get $radix|19
+          call $~lib/util/string/strtol<i32>
+          br $~lib/builtins/i32.parse|inlined.2
+         end
+         local.set $offsetHours|20
+         local.get $offsetHours|20
+         i32.const 3600000
+         i32.mul
+         local.set $offsetMs
         end
-        local.set $offsetMinutes
-        local.get $offsetHours
-        i32.const 60
-        i32.mul
-        local.get $offsetMinutes
-        i32.add
-        i32.const 60000
-        i32.mul
-        local.set $offsetMs
         local.get $c
         i32.const 45
         i32.eq
@@ -8295,11 +8319,11 @@
         end
         global.get $~lib/memory/__stack_pointer
         local.get $timeString
-        local.set $43
+        local.set $46
         global.get $~lib/memory/__stack_pointer
-        local.get $43
+        local.get $46
         i32.store
-        local.get $43
+        local.get $46
         i32.const 0
         local.get $i
         call $~lib/string/String#substring
@@ -8318,29 +8342,29 @@
    end
    global.get $~lib/memory/__stack_pointer
    local.get $timeString
-   local.set $43
+   local.set $46
    global.get $~lib/memory/__stack_pointer
-   local.get $43
+   local.get $46
    i32.store
-   local.get $43
+   local.get $46
    i32.const 2496
-   local.set $43
+   local.set $46
    global.get $~lib/memory/__stack_pointer
-   local.get $43
+   local.get $46
    i32.store offset=8
-   local.get $43
+   local.get $46
    i32.const 1
    global.set $~argumentsLength
    i32.const 0
    call $~lib/string/String#split@varargs
    local.tee $timeParts
-   i32.store offset=32
+   i32.store offset=28
    local.get $timeParts
-   local.set $43
+   local.set $46
    global.get $~lib/memory/__stack_pointer
-   local.get $43
+   local.get $46
    i32.store
-   local.get $43
+   local.get $46
    call $~lib/array/Array<~lib/string/String>#get:length
    local.set $len
    local.get $len
@@ -8349,59 +8373,59 @@
    if
     i32.const 32
     i32.const 80
-    i32.const 89
+    i32.const 96
     i32.const 21
     call $~lib/builtins/abort
     unreachable
    end
-   block $~lib/builtins/i32.parse|inlined.2 (result i32)
-    global.get $~lib/memory/__stack_pointer
-    local.get $timeParts
-    local.set $43
-    global.get $~lib/memory/__stack_pointer
-    local.get $43
-    i32.store
-    local.get $43
-    i32.const 0
-    call $~lib/array/Array<~lib/string/String>#__get
-    local.tee $value|20
-    i32.store offset=36
-    i32.const 0
-    local.set $radix|21
-    local.get $value|20
-    local.set $43
-    global.get $~lib/memory/__stack_pointer
-    local.get $43
-    i32.store
-    local.get $43
-    local.get $radix|21
-    call $~lib/util/string/strtol<i32>
-    br $~lib/builtins/i32.parse|inlined.2
-   end
-   local.set $hour
    block $~lib/builtins/i32.parse|inlined.3 (result i32)
     global.get $~lib/memory/__stack_pointer
     local.get $timeParts
-    local.set $43
+    local.set $46
     global.get $~lib/memory/__stack_pointer
-    local.get $43
+    local.get $46
     i32.store
-    local.get $43
-    i32.const 1
-    call $~lib/array/Array<~lib/string/String>#__get
-    local.tee $value|22
-    i32.store offset=40
+    local.get $46
     i32.const 0
-    local.set $radix|23
-    local.get $value|22
-    local.set $43
+    call $~lib/array/Array<~lib/string/String>#__get
+    local.tee $value|23
+    i32.store offset=32
+    i32.const 0
+    local.set $radix|24
+    local.get $value|23
+    local.set $46
     global.get $~lib/memory/__stack_pointer
-    local.get $43
+    local.get $46
     i32.store
-    local.get $43
-    local.get $radix|23
+    local.get $46
+    local.get $radix|24
     call $~lib/util/string/strtol<i32>
     br $~lib/builtins/i32.parse|inlined.3
+   end
+   local.set $hour
+   block $~lib/builtins/i32.parse|inlined.4 (result i32)
+    global.get $~lib/memory/__stack_pointer
+    local.get $timeParts
+    local.set $46
+    global.get $~lib/memory/__stack_pointer
+    local.get $46
+    i32.store
+    local.get $46
+    i32.const 1
+    call $~lib/array/Array<~lib/string/String>#__get
+    local.tee $value|25
+    i32.store offset=36
+    i32.const 0
+    local.set $radix|26
+    local.get $value|25
+    local.set $46
+    global.get $~lib/memory/__stack_pointer
+    local.get $46
+    i32.store
+    local.get $46
+    local.get $radix|26
+    call $~lib/util/string/strtol<i32>
+    br $~lib/builtins/i32.parse|inlined.4
    end
    local.set $min
    local.get $len
@@ -8410,27 +8434,27 @@
    if
     global.get $~lib/memory/__stack_pointer
     local.get $timeParts
-    local.set $43
+    local.set $46
     global.get $~lib/memory/__stack_pointer
-    local.get $43
+    local.get $46
     i32.store
-    local.get $43
+    local.get $46
     i32.const 2
     call $~lib/array/Array<~lib/string/String>#__get
     local.tee $secAndFrac
-    i32.store offset=44
+    i32.store offset=40
     local.get $secAndFrac
-    local.set $43
+    local.set $46
     global.get $~lib/memory/__stack_pointer
-    local.get $43
+    local.get $46
     i32.store
-    local.get $43
+    local.get $46
     i32.const 2528
-    local.set $43
+    local.set $46
     global.get $~lib/memory/__stack_pointer
-    local.get $43
+    local.get $46
     i32.store offset=8
-    local.get $43
+    local.get $46
     i32.const 0
     call $~lib/string/String#indexOf
     local.set $posDot
@@ -8438,90 +8462,90 @@
     i32.const -1
     i32.xor
     if
-     block $~lib/builtins/i32.parse|inlined.4 (result i32)
-      global.get $~lib/memory/__stack_pointer
-      local.get $secAndFrac
-      local.set $43
-      global.get $~lib/memory/__stack_pointer
-      local.get $43
-      i32.store
-      local.get $43
-      i32.const 0
-      local.get $posDot
-      call $~lib/string/String#substring
-      local.tee $value|26
-      i32.store offset=48
-      i32.const 0
-      local.set $radix|27
-      local.get $value|26
-      local.set $43
-      global.get $~lib/memory/__stack_pointer
-      local.get $43
-      i32.store
-      local.get $43
-      local.get $radix|27
-      call $~lib/util/string/strtol<i32>
-      br $~lib/builtins/i32.parse|inlined.4
-     end
-     local.set $sec
      block $~lib/builtins/i32.parse|inlined.5 (result i32)
       global.get $~lib/memory/__stack_pointer
       local.get $secAndFrac
-      local.set $43
+      local.set $46
       global.get $~lib/memory/__stack_pointer
-      local.get $43
-      i32.store offset=16
-      local.get $43
+      local.get $46
+      i32.store
+      local.get $46
+      i32.const 0
+      local.get $posDot
+      call $~lib/string/String#substring
+      local.tee $value|29
+      i32.store offset=44
+      i32.const 0
+      local.set $radix|30
+      local.get $value|29
+      local.set $46
+      global.get $~lib/memory/__stack_pointer
+      local.get $46
+      i32.store
+      local.get $46
+      local.get $radix|30
+      call $~lib/util/string/strtol<i32>
+      br $~lib/builtins/i32.parse|inlined.5
+     end
+     local.set $sec
+     block $~lib/builtins/i32.parse|inlined.6 (result i32)
+      global.get $~lib/memory/__stack_pointer
+      local.get $secAndFrac
+      local.set $46
+      global.get $~lib/memory/__stack_pointer
+      local.get $46
+      i32.store offset=48
+      local.get $46
       local.get $posDot
       i32.const 1
       i32.add
       i32.const 3
       call $~lib/string/String#substr
-      local.set $43
+      local.set $46
       global.get $~lib/memory/__stack_pointer
-      local.get $43
+      local.get $46
       i32.store
-      local.get $43
+      local.get $46
       i32.const 3
       i32.const 848
-      local.set $43
+      local.set $46
       global.get $~lib/memory/__stack_pointer
-      local.get $43
+      local.get $46
       i32.store offset=8
-      local.get $43
+      local.get $46
       call $~lib/string/String#padEnd
-      local.tee $value|28
+      local.tee $value|31
       i32.store offset=52
       i32.const 0
-      local.set $radix|29
-      local.get $value|28
-      local.set $43
+      local.set $radix|32
+      local.get $value|31
+      local.set $46
       global.get $~lib/memory/__stack_pointer
-      local.get $43
+      local.get $46
       i32.store
-      local.get $43
-      local.get $radix|29
+      local.get $46
+      local.get $radix|32
       call $~lib/util/string/strtol<i32>
-      br $~lib/builtins/i32.parse|inlined.5
+      br $~lib/builtins/i32.parse|inlined.6
      end
      local.set $ms
     else
-     block $~lib/builtins/i32.parse|inlined.6 (result i32)
+     block $~lib/builtins/i32.parse|inlined.7 (result i32)
       global.get $~lib/memory/__stack_pointer
       local.get $secAndFrac
-      local.tee $value|30
+      local.tee $value|33
       i32.store offset=56
       i32.const 0
-      local.set $radix|31
-      local.get $value|30
-      local.set $43
+      local.set $radix|34
+      local.get $value|33
+      local.set $46
       global.get $~lib/memory/__stack_pointer
-      local.get $43
+      local.get $46
       i32.store
-      local.get $43
-      local.get $radix|31
+      local.get $46
+      local.get $radix|34
       call $~lib/util/string/strtol<i32>
-      br $~lib/builtins/i32.parse|inlined.6
+      br $~lib/builtins/i32.parse|inlined.7
      end
      local.set $sec
     end
@@ -8529,46 +8553,46 @@
   end
   global.get $~lib/memory/__stack_pointer
   local.get $dateString
-  local.set $43
+  local.set $46
   global.get $~lib/memory/__stack_pointer
-  local.get $43
+  local.get $46
   i32.store
-  local.get $43
+  local.get $46
   i32.const 592
-  local.set $43
+  local.set $46
   global.get $~lib/memory/__stack_pointer
-  local.get $43
+  local.get $46
   i32.store offset=8
-  local.get $43
+  local.get $46
   i32.const 1
   global.set $~argumentsLength
   i32.const 0
   call $~lib/string/String#split@varargs
   local.tee $parts
   i32.store offset=60
-  block $~lib/builtins/i32.parse|inlined.7 (result i32)
+  block $~lib/builtins/i32.parse|inlined.8 (result i32)
    global.get $~lib/memory/__stack_pointer
    local.get $parts
-   local.set $43
+   local.set $46
    global.get $~lib/memory/__stack_pointer
-   local.get $43
+   local.get $46
    i32.store
-   local.get $43
+   local.get $46
    i32.const 0
    call $~lib/array/Array<~lib/string/String>#__get
-   local.tee $value|33
+   local.tee $value|36
    i32.store offset=64
    i32.const 0
-   local.set $radix|34
-   local.get $value|33
-   local.set $43
+   local.set $radix|37
+   local.get $value|36
+   local.set $46
    global.get $~lib/memory/__stack_pointer
-   local.get $43
+   local.get $46
    i32.store
-   local.get $43
-   local.get $radix|34
+   local.get $46
+   local.get $radix|37
    call $~lib/util/string/strtol<i32>
-   br $~lib/builtins/i32.parse|inlined.7
+   br $~lib/builtins/i32.parse|inlined.8
   end
   local.set $year
   i32.const 1
@@ -8576,69 +8600,69 @@
   i32.const 1
   local.set $day
   local.get $parts
-  local.set $43
+  local.set $46
   global.get $~lib/memory/__stack_pointer
-  local.get $43
+  local.get $46
   i32.store
-  local.get $43
+  local.get $46
   call $~lib/array/Array<~lib/string/String>#get:length
-  local.set $len|38
-  local.get $len|38
+  local.set $len|41
+  local.get $len|41
   i32.const 2
   i32.ge_s
   if
-   block $~lib/builtins/i32.parse|inlined.8 (result i32)
+   block $~lib/builtins/i32.parse|inlined.9 (result i32)
     global.get $~lib/memory/__stack_pointer
     local.get $parts
-    local.set $43
+    local.set $46
     global.get $~lib/memory/__stack_pointer
-    local.get $43
+    local.get $46
     i32.store
-    local.get $43
+    local.get $46
     i32.const 1
     call $~lib/array/Array<~lib/string/String>#__get
-    local.tee $value|39
+    local.tee $value|42
     i32.store offset=68
     i32.const 0
-    local.set $radix|40
-    local.get $value|39
-    local.set $43
+    local.set $radix|43
+    local.get $value|42
+    local.set $46
     global.get $~lib/memory/__stack_pointer
-    local.get $43
+    local.get $46
     i32.store
-    local.get $43
-    local.get $radix|40
+    local.get $46
+    local.get $radix|43
     call $~lib/util/string/strtol<i32>
-    br $~lib/builtins/i32.parse|inlined.8
+    br $~lib/builtins/i32.parse|inlined.9
    end
    local.set $month
-   local.get $len|38
+   local.get $len|41
    i32.const 3
    i32.ge_s
    if
-    block $~lib/builtins/i32.parse|inlined.9 (result i32)
+    block $~lib/builtins/i32.parse|inlined.10 (result i32)
      global.get $~lib/memory/__stack_pointer
      local.get $parts
-     local.set $43
+     local.set $46
      global.get $~lib/memory/__stack_pointer
-     local.get $43
+     local.get $46
      i32.store
-     local.get $43
+     local.get $46
      i32.const 2
      call $~lib/array/Array<~lib/string/String>#__get
-     local.tee $value|41
+     local.tee $value|44
      i32.store offset=72
      i32.const 0
-     local.set $radix|42
-     local.get $value|41
-     local.set $43
+     local.set $radix|45
+     local.get $value|44
+     local.set $46
      global.get $~lib/memory/__stack_pointer
-     local.get $43
+     local.get $46
      i32.store
-     local.get $43
-     local.get $radix|42
+     local.get $46
+     local.get $radix|45
      call $~lib/util/string/strtol<i32>
-     br $~lib/builtins/i32.parse|inlined.9
+     br $~lib/builtins/i32.parse|inlined.10
     end
     local.set $day
    end
@@ -8656,12 +8680,12 @@
   i64.extend_i32_s
   i64.sub
   call $~lib/date/Date#constructor
-  local.set $43
+  local.set $46
   global.get $~lib/memory/__stack_pointer
   i32.const 76
   i32.add
   global.set $~lib/memory/__stack_pointer
-  local.get $43
+  local.get $46
   return
  )
  (func $start:std/date

--- a/tests/compiler/std/date.debug.wat
+++ b/tests/compiler/std/date.debug.wat
@@ -3887,7 +3887,7 @@
   if
    i32.const 32
    i32.const 80
-   i32.const 126
+   i32.const 124
    i32.const 35
    call $~lib/builtins/abort
    unreachable
@@ -3941,7 +3941,7 @@
   if
    i32.const 32
    i32.const 80
-   i32.const 138
+   i32.const 136
    i32.const 28
    call $~lib/builtins/abort
    unreachable
@@ -8349,7 +8349,7 @@
    if
     i32.const 32
     i32.const 80
-    i32.const 91
+    i32.const 89
     i32.const 21
     call $~lib/builtins/abort
     unreachable

--- a/tests/compiler/std/date.debug.wat
+++ b/tests/compiler/std/date.debug.wat
@@ -43,10 +43,10 @@
  (global $~lib/native/ASC_SHRINK_LEVEL i32 (i32.const 0))
  (global $~lib/builtins/i32.MAX_VALUE i32 (i32.const 2147483647))
  (global $~lib/native/ASC_RUNTIME i32 (i32.const 2))
- (global $~lib/rt/__rtti_base i32 (i32.const 6768))
- (global $~lib/memory/__data_end i32 (i32.const 6804))
- (global $~lib/memory/__stack_pointer (mut i32) (i32.const 39572))
- (global $~lib/memory/__heap_base i32 (i32.const 39572))
+ (global $~lib/rt/__rtti_base i32 (i32.const 7408))
+ (global $~lib/memory/__data_end i32 (i32.const 7444))
+ (global $~lib/memory/__stack_pointer (mut i32) (i32.const 40212))
+ (global $~lib/memory/__heap_base i32 (i32.const 40212))
  (global $~started (mut i32) (i32.const 0))
  (memory $0 1)
  (data $0 (i32.const 12) ",\00\00\00\00\00\00\00\00\00\00\00\02\00\00\00\18\00\00\00I\00n\00v\00a\00l\00i\00d\00 \00D\00a\00t\00e\00\00\00\00\00")
@@ -149,16 +149,24 @@
  (data $97 (i32.const 6012) "<\00\00\00\00\00\00\00\00\00\00\00\02\00\00\00&\00\00\001\009\007\006\00-\000\002\00-\000\002\00T\001\002\00:\003\004\00:\005\006\00\00\00\00\00\00\00")
  (data $98 (i32.const 6076) "L\00\00\00\00\00\00\00\00\00\00\00\02\00\00\00.\00\00\001\009\007\006\00-\000\002\00-\000\002\00T\001\002\00:\003\004\00:\005\006\00.\004\005\006\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00")
  (data $99 (i32.const 6156) "L\00\00\00\00\00\00\00\00\00\00\00\02\00\00\000\00\00\001\009\007\006\00-\000\002\00-\000\002\00T\001\002\00:\003\004\00:\005\006\00.\004\005\006\00Z\00\00\00\00\00\00\00\00\00\00\00\00\00")
- (data $100 (i32.const 6236) "\1c\00\00\00\00\00\00\00\00\00\00\00\02\00\00\00\08\00\00\000\000\000\000\00\00\00\00\00")
- (data $101 (i32.const 6268) "\1c\00\00\00\00\00\00\00\00\00\00\00\02\00\00\00\08\00\00\000\000\000\001\00\00\00\00\00")
- (data $102 (i32.const 6300) "\1c\00\00\00\00\00\00\00\00\00\00\00\02\00\00\00\08\00\00\001\009\007\006\00\00\00\00\00")
- (data $103 (i32.const 6332) ",\00\00\00\00\00\00\00\00\00\00\00\02\00\00\00\0e\00\00\001\009\007\006\00-\000\002\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00")
- (data $104 (i32.const 6380) "<\00\00\00\00\00\00\00\00\00\00\00\02\00\00\00 \00\00\001\009\007\006\00-\000\002\00-\000\002\00T\001\002\00:\003\004\00\00\00\00\00\00\00\00\00\00\00\00\00")
- (data $105 (i32.const 6444) "L\00\00\00\00\00\00\00\00\00\00\00\02\00\00\006\00\00\00-\002\007\001\008\002\001\00-\000\004\00-\002\000\00T\000\000\00:\000\000\00:\000\000\00.\000\000\000\00Z\00\00\00\00\00\00\00")
- (data $106 (i32.const 6524) "L\00\00\00\00\00\00\00\00\00\00\00\02\00\00\006\00\00\00+\002\007\005\007\006\000\00-\000\009\00-\001\003\00T\000\000\00:\000\000\00:\000\000\00.\000\000\000\00Z\00\00\00\00\00\00\00")
- (data $107 (i32.const 6604) "L\00\00\00\00\00\00\00\00\00\00\00\02\00\00\006\00\00\00+\002\007\005\007\006\000\00-\000\009\00-\001\002\00T\002\003\00:\005\009\00:\005\009\00.\009\009\009\00Z\00\00\00\00\00\00\00")
- (data $108 (i32.const 6684) "L\00\00\00\00\00\00\00\00\00\00\00\02\00\00\006\00\00\00-\002\007\001\008\002\001\00-\000\004\00-\002\000\00T\000\000\00:\000\000\00:\000\000\00.\000\000\001\00Z\00\00\00\00\00\00\00")
- (data $109 (i32.const 6768) "\08\00\00\00 \00\00\00 \00\00\00 \00\00\00\00\00\00\00 \00\00\00\04A\00\00\02A\00\00\02\t\00\00")
+ (data $100 (i32.const 6236) "L\00\00\00\00\00\00\00\00\00\00\00\02\00\00\00:\00\00\001\009\007\006\00-\000\002\00-\000\002\00T\001\002\00:\003\004\00:\005\006\00.\004\005\006\00-\000\008\00:\000\000\00\00\00")
+ (data $101 (i32.const 6316) "L\00\00\00\00\00\00\00\00\00\00\00\02\00\00\00:\00\00\001\009\007\006\00-\000\002\00-\000\002\00T\001\002\00:\003\004\00:\005\006\00.\004\005\006\00+\000\005\00:\003\000\00\00\00")
+ (data $102 (i32.const 6396) "<\00\00\00\00\00\00\00\00\00\00\00\02\00\00\00,\00\00\001\009\007\006\00-\000\002\00-\000\002\00T\001\002\00:\003\004\00:\005\006\00.\004\005\00")
+ (data $103 (i32.const 6460) "L\00\00\00\00\00\00\00\00\00\00\00\02\00\00\00.\00\00\001\009\007\006\00-\000\002\00-\000\002\00T\001\002\00:\003\004\00:\005\006\00.\004\005\00Z\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00")
+ (data $104 (i32.const 6540) "L\00\00\00\00\00\00\00\00\00\00\00\02\00\00\008\00\00\001\009\007\006\00-\000\002\00-\000\002\00T\001\002\00:\003\004\00:\005\006\00.\004\005\00+\000\000\00:\000\000\00\00\00\00\00")
+ (data $105 (i32.const 6620) "L\00\00\00\00\00\00\00\00\00\00\00\02\00\00\004\00\00\001\009\007\006\00-\000\002\00-\000\002\00T\001\002\00:\003\004\00:\005\006\00.\004\005\006\007\008\009\00\00\00\00\00\00\00\00\00")
+ (data $106 (i32.const 6700) "L\00\00\00\00\00\00\00\00\00\00\00\02\00\00\006\00\00\001\009\007\006\00-\000\002\00-\000\002\00T\001\002\00:\003\004\00:\005\006\00.\004\005\006\007\008\009\00Z\00\00\00\00\00\00\00")
+ (data $107 (i32.const 6780) "\\\00\00\00\00\00\00\00\00\00\00\00\02\00\00\00@\00\00\001\009\007\006\00-\000\002\00-\000\002\00T\001\002\00:\003\004\00:\005\006\00.\004\005\006\007\008\009\00+\000\000\00:\000\000\00\00\00\00\00\00\00\00\00\00\00\00\00")
+ (data $108 (i32.const 6876) "\1c\00\00\00\00\00\00\00\00\00\00\00\02\00\00\00\08\00\00\000\000\000\000\00\00\00\00\00")
+ (data $109 (i32.const 6908) "\1c\00\00\00\00\00\00\00\00\00\00\00\02\00\00\00\08\00\00\000\000\000\001\00\00\00\00\00")
+ (data $110 (i32.const 6940) "\1c\00\00\00\00\00\00\00\00\00\00\00\02\00\00\00\08\00\00\001\009\007\006\00\00\00\00\00")
+ (data $111 (i32.const 6972) ",\00\00\00\00\00\00\00\00\00\00\00\02\00\00\00\0e\00\00\001\009\007\006\00-\000\002\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00")
+ (data $112 (i32.const 7020) "<\00\00\00\00\00\00\00\00\00\00\00\02\00\00\00 \00\00\001\009\007\006\00-\000\002\00-\000\002\00T\001\002\00:\003\004\00\00\00\00\00\00\00\00\00\00\00\00\00")
+ (data $113 (i32.const 7084) "L\00\00\00\00\00\00\00\00\00\00\00\02\00\00\006\00\00\00-\002\007\001\008\002\001\00-\000\004\00-\002\000\00T\000\000\00:\000\000\00:\000\000\00.\000\000\000\00Z\00\00\00\00\00\00\00")
+ (data $114 (i32.const 7164) "L\00\00\00\00\00\00\00\00\00\00\00\02\00\00\006\00\00\00+\002\007\005\007\006\000\00-\000\009\00-\001\003\00T\000\000\00:\000\000\00:\000\000\00.\000\000\000\00Z\00\00\00\00\00\00\00")
+ (data $115 (i32.const 7244) "L\00\00\00\00\00\00\00\00\00\00\00\02\00\00\006\00\00\00+\002\007\005\007\006\000\00-\000\009\00-\001\002\00T\002\003\00:\005\009\00:\005\009\00.\009\009\009\00Z\00\00\00\00\00\00\00")
+ (data $116 (i32.const 7324) "L\00\00\00\00\00\00\00\00\00\00\00\02\00\00\006\00\00\00-\002\007\001\008\002\001\00-\000\004\00-\002\000\00T\000\000\00:\000\000\00:\000\000\00.\000\000\001\00Z\00\00\00\00\00\00\00")
+ (data $117 (i32.const 7408) "\08\00\00\00 \00\00\00 \00\00\00 \00\00\00\00\00\00\00 \00\00\00\04A\00\00\02A\00\00\02\t\00\00")
  (table $0 1 1 funcref)
  (elem $0 (i32.const 1))
  (export "memory" (memory $0))
@@ -3814,8 +3822,8 @@
   global.get $~lib/memory/__data_end
   i32.lt_s
   if
-   i32.const 39600
-   i32.const 39648
+   i32.const 40240
+   i32.const 40288
    i32.const 1
    i32.const 1
    call $~lib/builtins/abort
@@ -3879,7 +3887,7 @@
   if
    i32.const 32
    i32.const 80
-   i32.const 100
+   i32.const 126
    i32.const 35
    call $~lib/builtins/abort
    unreachable
@@ -3933,7 +3941,7 @@
   if
    i32.const 32
    i32.const 80
-   i32.const 112
+   i32.const 138
    i32.const 28
    call $~lib/builtins/abort
    unreachable
@@ -6528,6 +6536,49 @@
   global.set $~lib/memory/__stack_pointer
   local.get $3
  )
+ (func $~lib/string/String#charCodeAt (param $this i32) (param $pos i32) (result i32)
+  (local $2 i32)
+  global.get $~lib/memory/__stack_pointer
+  i32.const 4
+  i32.sub
+  global.set $~lib/memory/__stack_pointer
+  call $~stack_check
+  global.get $~lib/memory/__stack_pointer
+  i32.const 0
+  i32.store
+  local.get $pos
+  local.get $this
+  local.set $2
+  global.get $~lib/memory/__stack_pointer
+  local.get $2
+  i32.store
+  local.get $2
+  call $~lib/string/String#get:length
+  i32.ge_u
+  if
+   i32.const -1
+   local.set $2
+   global.get $~lib/memory/__stack_pointer
+   i32.const 4
+   i32.add
+   global.set $~lib/memory/__stack_pointer
+   local.get $2
+   return
+  end
+  local.get $this
+  local.get $pos
+  i32.const 1
+  i32.shl
+  i32.add
+  i32.load16_u
+  local.set $2
+  global.get $~lib/memory/__stack_pointer
+  i32.const 4
+  i32.add
+  global.set $~lib/memory/__stack_pointer
+  local.get $2
+  return
+ )
  (func $~lib/array/ensureCapacity (param $array i32) (param $newSize i32) (param $alignLog2 i32) (param $canGrow i32)
   (local $oldCapacity i32)
   (local $oldData i32)
@@ -7255,31 +7306,6 @@
   global.set $~lib/memory/__stack_pointer
   local.get $3
  )
- (func $~lib/array/Array<~lib/string/String>#get:length (param $this i32) (result i32)
-  (local $1 i32)
-  global.get $~lib/memory/__stack_pointer
-  i32.const 4
-  i32.sub
-  global.set $~lib/memory/__stack_pointer
-  call $~stack_check
-  global.get $~lib/memory/__stack_pointer
-  i32.const 0
-  i32.store
-  local.get $this
-  local.set $1
-  global.get $~lib/memory/__stack_pointer
-  local.get $1
-  i32.store
-  local.get $1
-  call $~lib/array/Array<~lib/string/String>#get:length_
-  local.set $1
-  global.get $~lib/memory/__stack_pointer
-  i32.const 4
-  i32.add
-  global.set $~lib/memory/__stack_pointer
-  local.get $1
-  return
- )
  (func $~lib/array/Array<~lib/string/String>#__get (param $this i32) (param $index i32) (result i32)
   (local $value i32)
   (local $3 i32)
@@ -7698,8 +7724,8 @@
   local.get $10
   return
  )
- (func $~lib/number/I32.parseInt (param $value i32) (param $radix i32) (result i32)
-  (local $2 i32)
+ (func $~lib/array/Array<~lib/string/String>#get:length (param $this i32) (result i32)
+  (local $1 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 4
   i32.sub
@@ -7708,20 +7734,249 @@
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   i32.store
-  local.get $value
-  local.set $2
+  local.get $this
+  local.set $1
   global.get $~lib/memory/__stack_pointer
-  local.get $2
+  local.get $1
   i32.store
-  local.get $2
-  local.get $radix
-  call $~lib/util/string/strtol<i32>
-  local.set $2
+  local.get $1
+  call $~lib/array/Array<~lib/string/String>#get:length_
+  local.set $1
   global.get $~lib/memory/__stack_pointer
   i32.const 4
   i32.add
   global.set $~lib/memory/__stack_pointer
-  local.get $2
+  local.get $1
+  return
+ )
+ (func $~lib/string/String#substr (param $this i32) (param $start i32) (param $length i32) (result i32)
+  (local $intStart i32)
+  (local $end i32)
+  (local $len i32)
+  (local $6 i32)
+  (local $7 i32)
+  (local $8 i32)
+  (local $9 i32)
+  (local $10 i32)
+  (local $11 i32)
+  (local $size i32)
+  (local $out i32)
+  (local $14 i32)
+  global.get $~lib/memory/__stack_pointer
+  i32.const 8
+  i32.sub
+  global.set $~lib/memory/__stack_pointer
+  call $~stack_check
+  global.get $~lib/memory/__stack_pointer
+  i64.const 0
+  i64.store
+  local.get $start
+  local.set $intStart
+  local.get $length
+  local.set $end
+  local.get $this
+  local.set $14
+  global.get $~lib/memory/__stack_pointer
+  local.get $14
+  i32.store
+  local.get $14
+  call $~lib/string/String#get:length
+  local.set $len
+  local.get $intStart
+  i32.const 0
+  i32.lt_s
+  if
+   local.get $len
+   local.get $intStart
+   i32.add
+   local.tee $6
+   i32.const 0
+   local.tee $7
+   local.get $6
+   local.get $7
+   i32.gt_s
+   select
+   local.set $intStart
+  end
+  local.get $end
+  local.tee $8
+  i32.const 0
+  local.tee $9
+  local.get $8
+  local.get $9
+  i32.gt_s
+  select
+  local.tee $10
+  local.get $len
+  local.get $intStart
+  i32.sub
+  local.tee $11
+  local.get $10
+  local.get $11
+  i32.lt_s
+  select
+  i32.const 1
+  i32.shl
+  local.set $size
+  local.get $size
+  i32.const 0
+  i32.le_s
+  if
+   i32.const 2432
+   local.set $14
+   global.get $~lib/memory/__stack_pointer
+   i32.const 8
+   i32.add
+   global.set $~lib/memory/__stack_pointer
+   local.get $14
+   return
+  end
+  global.get $~lib/memory/__stack_pointer
+  local.get $size
+  i32.const 2
+  call $~lib/rt/itcms/__new
+  local.tee $out
+  i32.store offset=4
+  local.get $out
+  local.get $this
+  local.get $intStart
+  i32.const 1
+  i32.shl
+  i32.add
+  local.get $size
+  memory.copy
+  local.get $out
+  local.set $14
+  global.get $~lib/memory/__stack_pointer
+  i32.const 8
+  i32.add
+  global.set $~lib/memory/__stack_pointer
+  local.get $14
+  return
+ )
+ (func $~lib/string/String#padEnd (param $this i32) (param $length i32) (param $pad i32) (result i32)
+  (local $thisSize i32)
+  (local $targetSize i32)
+  (local $padSize i32)
+  (local $appendSize i32)
+  (local $out i32)
+  (local $repeatCount i32)
+  (local $restBase i32)
+  (local $restSize i32)
+  (local $11 i32)
+  global.get $~lib/memory/__stack_pointer
+  i32.const 8
+  i32.sub
+  global.set $~lib/memory/__stack_pointer
+  call $~stack_check
+  global.get $~lib/memory/__stack_pointer
+  i64.const 0
+  i64.store
+  local.get $this
+  local.set $11
+  global.get $~lib/memory/__stack_pointer
+  local.get $11
+  i32.store
+  local.get $11
+  call $~lib/string/String#get:length
+  i32.const 1
+  i32.shl
+  local.set $thisSize
+  local.get $length
+  i32.const 1
+  i32.shl
+  local.set $targetSize
+  local.get $pad
+  local.set $11
+  global.get $~lib/memory/__stack_pointer
+  local.get $11
+  i32.store
+  local.get $11
+  call $~lib/string/String#get:length
+  i32.const 1
+  i32.shl
+  local.set $padSize
+  local.get $targetSize
+  local.get $thisSize
+  i32.lt_u
+  if (result i32)
+   i32.const 1
+  else
+   local.get $padSize
+   i32.eqz
+  end
+  if
+   local.get $this
+   local.set $11
+   global.get $~lib/memory/__stack_pointer
+   i32.const 8
+   i32.add
+   global.set $~lib/memory/__stack_pointer
+   local.get $11
+   return
+  end
+  local.get $targetSize
+  local.get $thisSize
+  i32.sub
+  local.set $appendSize
+  global.get $~lib/memory/__stack_pointer
+  local.get $targetSize
+  i32.const 2
+  call $~lib/rt/itcms/__new
+  local.tee $out
+  i32.store offset=4
+  local.get $out
+  local.get $this
+  local.get $thisSize
+  memory.copy
+  local.get $appendSize
+  local.get $padSize
+  i32.gt_u
+  if
+   local.get $appendSize
+   i32.const 2
+   i32.sub
+   local.get $padSize
+   i32.div_u
+   local.set $repeatCount
+   local.get $repeatCount
+   local.get $padSize
+   i32.mul
+   local.set $restBase
+   local.get $appendSize
+   local.get $restBase
+   i32.sub
+   local.set $restSize
+   local.get $out
+   local.get $thisSize
+   i32.add
+   local.get $pad
+   local.get $padSize
+   local.get $repeatCount
+   call $~lib/memory/memory.repeat
+   local.get $out
+   local.get $thisSize
+   i32.add
+   local.get $restBase
+   i32.add
+   local.get $pad
+   local.get $restSize
+   memory.copy
+  else
+   local.get $out
+   local.get $thisSize
+   i32.add
+   local.get $pad
+   local.get $appendSize
+   memory.copy
+  end
+  local.get $out
+  local.set $11
+  global.get $~lib/memory/__stack_pointer
+  i32.const 8
+  i32.add
+  global.set $~lib/memory/__stack_pointer
+  local.get $11
   return
  )
  (func $~lib/date/Date.fromString (param $dateTimeString i32) (result i32)
@@ -7729,34 +7984,60 @@
   (local $min i32)
   (local $sec i32)
   (local $ms i32)
+  (local $offsetMs i32)
   (local $dateString i32)
   (local $posT i32)
   (local $timeString i32)
+  (local $i i32)
+  (local $c i32)
+  (local $offsetParts i32)
+  (local $value i32)
+  (local $radix i32)
+  (local $offsetHours i32)
+  (local $value|15 i32)
+  (local $radix|16 i32)
+  (local $offsetMinutes i32)
   (local $timeParts i32)
   (local $len i32)
-  (local $secAndMs i32)
+  (local $value|20 i32)
+  (local $radix|21 i32)
+  (local $value|22 i32)
+  (local $radix|23 i32)
+  (local $secAndFrac i32)
   (local $posDot i32)
+  (local $value|26 i32)
+  (local $radix|27 i32)
+  (local $value|28 i32)
+  (local $radix|29 i32)
+  (local $value|30 i32)
+  (local $radix|31 i32)
   (local $parts i32)
+  (local $value|33 i32)
+  (local $radix|34 i32)
   (local $year i32)
   (local $month i32)
   (local $day i32)
-  (local $len|16 i32)
-  (local $17 i32)
+  (local $len|38 i32)
+  (local $value|39 i32)
+  (local $radix|40 i32)
+  (local $value|41 i32)
+  (local $radix|42 i32)
+  (local $43 i32)
   global.get $~lib/memory/__stack_pointer
-  i32.const 28
+  i32.const 76
   i32.sub
   global.set $~lib/memory/__stack_pointer
   call $~stack_check
   global.get $~lib/memory/__stack_pointer
   i32.const 0
-  i32.const 28
+  i32.const 76
   memory.fill
   local.get $dateTimeString
-  local.set $17
+  local.set $43
   global.get $~lib/memory/__stack_pointer
-  local.get $17
+  local.get $43
   i32.store
-  local.get $17
+  local.get $43
   call $~lib/string/String#get:length
   i32.eqz
   if
@@ -7775,22 +8056,24 @@
   local.set $sec
   i32.const 0
   local.set $ms
+  i32.const 0
+  local.set $offsetMs
   global.get $~lib/memory/__stack_pointer
   local.get $dateTimeString
   local.tee $dateString
   i32.store offset=4
   local.get $dateTimeString
-  local.set $17
+  local.set $43
   global.get $~lib/memory/__stack_pointer
-  local.get $17
+  local.get $43
   i32.store
-  local.get $17
+  local.get $43
   i32.const 2464
-  local.set $17
+  local.set $43
   global.get $~lib/memory/__stack_pointer
-  local.get $17
+  local.get $43
   i32.store offset=8
-  local.get $17
+  local.get $43
   i32.const 0
   call $~lib/string/String#indexOf
   local.set $posT
@@ -7800,11 +8083,11 @@
   if
    global.get $~lib/memory/__stack_pointer
    local.get $dateTimeString
-   local.set $17
+   local.set $43
    global.get $~lib/memory/__stack_pointer
-   local.get $17
+   local.get $43
    i32.store
-   local.get $17
+   local.get $43
    i32.const 0
    local.get $posT
    call $~lib/string/String#substring
@@ -7812,11 +8095,11 @@
    i32.store offset=4
    global.get $~lib/memory/__stack_pointer
    local.get $dateTimeString
-   local.set $17
+   local.set $43
    global.get $~lib/memory/__stack_pointer
-   local.get $17
+   local.get $43
    i32.store
-   local.get $17
+   local.get $43
    local.get $posT
    i32.const 1
    i32.add
@@ -7826,31 +8109,238 @@
    call $~lib/string/String#substring@varargs
    local.tee $timeString
    i32.store offset=12
+   local.get $timeString
+   local.set $43
+   global.get $~lib/memory/__stack_pointer
+   local.get $43
+   i32.store
+   local.get $43
+   call $~lib/string/String#get:length
+   i32.const 1
+   i32.sub
+   local.set $i
+   block $for-break0
+    loop $for-loop|0
+     local.get $i
+     i32.const 0
+     i32.ge_s
+     if
+      local.get $timeString
+      local.set $43
+      global.get $~lib/memory/__stack_pointer
+      local.get $43
+      i32.store
+      local.get $43
+      local.get $i
+      call $~lib/string/String#charCodeAt
+      local.set $c
+      local.get $c
+      i32.const 90
+      i32.eq
+      if
+       global.get $~lib/memory/__stack_pointer
+       local.get $timeString
+       local.set $43
+       global.get $~lib/memory/__stack_pointer
+       local.get $43
+       i32.store
+       local.get $43
+       i32.const 0
+       local.get $i
+       call $~lib/string/String#substring
+       local.tee $timeString
+       i32.store offset=12
+       br $for-break0
+      else
+       local.get $c
+       i32.const 43
+       i32.eq
+       if (result i32)
+        i32.const 1
+       else
+        local.get $c
+        i32.const 45
+        i32.eq
+       end
+       if
+        local.get $i
+        local.get $timeString
+        local.set $43
+        global.get $~lib/memory/__stack_pointer
+        local.get $43
+        i32.store
+        local.get $43
+        call $~lib/string/String#get:length
+        i32.const 1
+        i32.sub
+        i32.eq
+        if
+         i32.const 32
+         i32.const 80
+         i32.const 74
+         i32.const 13
+         call $~lib/builtins/abort
+         unreachable
+        end
+        global.get $~lib/memory/__stack_pointer
+        local.get $timeString
+        local.set $43
+        global.get $~lib/memory/__stack_pointer
+        local.get $43
+        i32.store offset=16
+        local.get $43
+        local.get $i
+        i32.const 1
+        i32.add
+        i32.const 1
+        global.set $~argumentsLength
+        i32.const 0
+        call $~lib/string/String#substring@varargs
+        local.set $43
+        global.get $~lib/memory/__stack_pointer
+        local.get $43
+        i32.store
+        local.get $43
+        i32.const 2496
+        local.set $43
+        global.get $~lib/memory/__stack_pointer
+        local.get $43
+        i32.store offset=8
+        local.get $43
+        i32.const 1
+        global.set $~argumentsLength
+        i32.const 0
+        call $~lib/string/String#split@varargs
+        local.tee $offsetParts
+        i32.store offset=20
+        block $~lib/builtins/i32.parse|inlined.0 (result i32)
+         global.get $~lib/memory/__stack_pointer
+         local.get $offsetParts
+         local.set $43
+         global.get $~lib/memory/__stack_pointer
+         local.get $43
+         i32.store
+         local.get $43
+         i32.const 0
+         call $~lib/array/Array<~lib/string/String>#__get
+         local.tee $value
+         i32.store offset=24
+         i32.const 0
+         local.set $radix
+         local.get $value
+         local.set $43
+         global.get $~lib/memory/__stack_pointer
+         local.get $43
+         i32.store
+         local.get $43
+         local.get $radix
+         call $~lib/util/string/strtol<i32>
+         br $~lib/builtins/i32.parse|inlined.0
+        end
+        local.set $offsetHours
+        local.get $offsetParts
+        local.set $43
+        global.get $~lib/memory/__stack_pointer
+        local.get $43
+        i32.store
+        local.get $43
+        call $~lib/array/Array<~lib/string/String>#get:length
+        i32.const 2
+        i32.ge_s
+        if (result i32)
+         block $~lib/builtins/i32.parse|inlined.1 (result i32)
+          global.get $~lib/memory/__stack_pointer
+          local.get $offsetParts
+          local.set $43
+          global.get $~lib/memory/__stack_pointer
+          local.get $43
+          i32.store
+          local.get $43
+          i32.const 1
+          call $~lib/array/Array<~lib/string/String>#__get
+          local.tee $value|15
+          i32.store offset=28
+          i32.const 0
+          local.set $radix|16
+          local.get $value|15
+          local.set $43
+          global.get $~lib/memory/__stack_pointer
+          local.get $43
+          i32.store
+          local.get $43
+          local.get $radix|16
+          call $~lib/util/string/strtol<i32>
+          br $~lib/builtins/i32.parse|inlined.1
+         end
+        else
+         i32.const 0
+        end
+        local.set $offsetMinutes
+        local.get $offsetHours
+        i32.const 60
+        i32.mul
+        local.get $offsetMinutes
+        i32.add
+        i32.const 60000
+        i32.mul
+        local.set $offsetMs
+        local.get $c
+        i32.const 45
+        i32.eq
+        if
+         i32.const 0
+         local.get $offsetMs
+         i32.sub
+         local.set $offsetMs
+        end
+        global.get $~lib/memory/__stack_pointer
+        local.get $timeString
+        local.set $43
+        global.get $~lib/memory/__stack_pointer
+        local.get $43
+        i32.store
+        local.get $43
+        i32.const 0
+        local.get $i
+        call $~lib/string/String#substring
+        local.tee $timeString
+        i32.store offset=12
+        br $for-break0
+       end
+      end
+      local.get $i
+      i32.const 1
+      i32.sub
+      local.set $i
+      br $for-loop|0
+     end
+    end
+   end
    global.get $~lib/memory/__stack_pointer
    local.get $timeString
-   local.set $17
+   local.set $43
    global.get $~lib/memory/__stack_pointer
-   local.get $17
+   local.get $43
    i32.store
-   local.get $17
+   local.get $43
    i32.const 2496
-   local.set $17
+   local.set $43
    global.get $~lib/memory/__stack_pointer
-   local.get $17
+   local.get $43
    i32.store offset=8
-   local.get $17
+   local.get $43
    i32.const 1
    global.set $~argumentsLength
    i32.const 0
    call $~lib/string/String#split@varargs
    local.tee $timeParts
-   i32.store offset=16
+   i32.store offset=32
    local.get $timeParts
-   local.set $17
+   local.set $43
    global.get $~lib/memory/__stack_pointer
-   local.get $17
+   local.get $43
    i32.store
-   local.get $17
+   local.get $43
    call $~lib/array/Array<~lib/string/String>#get:length
    local.set $len
    local.get $len
@@ -7859,42 +8349,60 @@
    if
     i32.const 32
     i32.const 80
-    i32.const 67
+    i32.const 91
     i32.const 21
     call $~lib/builtins/abort
     unreachable
    end
-   local.get $timeParts
-   local.set $17
-   global.get $~lib/memory/__stack_pointer
-   local.get $17
-   i32.store offset=8
-   local.get $17
-   i32.const 0
-   call $~lib/array/Array<~lib/string/String>#__get
-   local.set $17
-   global.get $~lib/memory/__stack_pointer
-   local.get $17
-   i32.store
-   local.get $17
-   i32.const 0
-   call $~lib/number/I32.parseInt
+   block $~lib/builtins/i32.parse|inlined.2 (result i32)
+    global.get $~lib/memory/__stack_pointer
+    local.get $timeParts
+    local.set $43
+    global.get $~lib/memory/__stack_pointer
+    local.get $43
+    i32.store
+    local.get $43
+    i32.const 0
+    call $~lib/array/Array<~lib/string/String>#__get
+    local.tee $value|20
+    i32.store offset=36
+    i32.const 0
+    local.set $radix|21
+    local.get $value|20
+    local.set $43
+    global.get $~lib/memory/__stack_pointer
+    local.get $43
+    i32.store
+    local.get $43
+    local.get $radix|21
+    call $~lib/util/string/strtol<i32>
+    br $~lib/builtins/i32.parse|inlined.2
+   end
    local.set $hour
-   local.get $timeParts
-   local.set $17
-   global.get $~lib/memory/__stack_pointer
-   local.get $17
-   i32.store offset=8
-   local.get $17
-   i32.const 1
-   call $~lib/array/Array<~lib/string/String>#__get
-   local.set $17
-   global.get $~lib/memory/__stack_pointer
-   local.get $17
-   i32.store
-   local.get $17
-   i32.const 0
-   call $~lib/number/I32.parseInt
+   block $~lib/builtins/i32.parse|inlined.3 (result i32)
+    global.get $~lib/memory/__stack_pointer
+    local.get $timeParts
+    local.set $43
+    global.get $~lib/memory/__stack_pointer
+    local.get $43
+    i32.store
+    local.get $43
+    i32.const 1
+    call $~lib/array/Array<~lib/string/String>#__get
+    local.tee $value|22
+    i32.store offset=40
+    i32.const 0
+    local.set $radix|23
+    local.get $value|22
+    local.set $43
+    global.get $~lib/memory/__stack_pointer
+    local.get $43
+    i32.store
+    local.get $43
+    local.get $radix|23
+    call $~lib/util/string/strtol<i32>
+    br $~lib/builtins/i32.parse|inlined.3
+   end
    local.set $min
    local.get $len
    i32.const 3
@@ -7902,27 +8410,27 @@
    if
     global.get $~lib/memory/__stack_pointer
     local.get $timeParts
-    local.set $17
+    local.set $43
     global.get $~lib/memory/__stack_pointer
-    local.get $17
+    local.get $43
     i32.store
-    local.get $17
+    local.get $43
     i32.const 2
     call $~lib/array/Array<~lib/string/String>#__get
-    local.tee $secAndMs
-    i32.store offset=20
-    local.get $secAndMs
-    local.set $17
+    local.tee $secAndFrac
+    i32.store offset=44
+    local.get $secAndFrac
+    local.set $43
     global.get $~lib/memory/__stack_pointer
-    local.get $17
+    local.get $43
     i32.store
-    local.get $17
+    local.get $43
     i32.const 2528
-    local.set $17
+    local.set $43
     global.get $~lib/memory/__stack_pointer
-    local.get $17
+    local.get $43
     i32.store offset=8
-    local.get $17
+    local.get $43
     i32.const 0
     call $~lib/string/String#indexOf
     local.set $posDot
@@ -7930,143 +8438,208 @@
     i32.const -1
     i32.xor
     if
-     local.get $secAndMs
-     local.set $17
-     global.get $~lib/memory/__stack_pointer
-     local.get $17
-     i32.store offset=8
-     local.get $17
-     i32.const 0
-     local.get $posDot
-     call $~lib/string/String#substring
-     local.set $17
-     global.get $~lib/memory/__stack_pointer
-     local.get $17
-     i32.store
-     local.get $17
-     i32.const 0
-     call $~lib/number/I32.parseInt
+     block $~lib/builtins/i32.parse|inlined.4 (result i32)
+      global.get $~lib/memory/__stack_pointer
+      local.get $secAndFrac
+      local.set $43
+      global.get $~lib/memory/__stack_pointer
+      local.get $43
+      i32.store
+      local.get $43
+      i32.const 0
+      local.get $posDot
+      call $~lib/string/String#substring
+      local.tee $value|26
+      i32.store offset=48
+      i32.const 0
+      local.set $radix|27
+      local.get $value|26
+      local.set $43
+      global.get $~lib/memory/__stack_pointer
+      local.get $43
+      i32.store
+      local.get $43
+      local.get $radix|27
+      call $~lib/util/string/strtol<i32>
+      br $~lib/builtins/i32.parse|inlined.4
+     end
      local.set $sec
-     local.get $secAndMs
-     local.set $17
-     global.get $~lib/memory/__stack_pointer
-     local.get $17
-     i32.store offset=8
-     local.get $17
-     local.get $posDot
-     i32.const 1
-     i32.add
-     i32.const 1
-     global.set $~argumentsLength
-     i32.const 0
-     call $~lib/string/String#substring@varargs
-     local.set $17
-     global.get $~lib/memory/__stack_pointer
-     local.get $17
-     i32.store
-     local.get $17
-     i32.const 0
-     call $~lib/number/I32.parseInt
+     block $~lib/builtins/i32.parse|inlined.5 (result i32)
+      global.get $~lib/memory/__stack_pointer
+      local.get $secAndFrac
+      local.set $43
+      global.get $~lib/memory/__stack_pointer
+      local.get $43
+      i32.store offset=16
+      local.get $43
+      local.get $posDot
+      i32.const 1
+      i32.add
+      i32.const 3
+      call $~lib/string/String#substr
+      local.set $43
+      global.get $~lib/memory/__stack_pointer
+      local.get $43
+      i32.store
+      local.get $43
+      i32.const 3
+      i32.const 848
+      local.set $43
+      global.get $~lib/memory/__stack_pointer
+      local.get $43
+      i32.store offset=8
+      local.get $43
+      call $~lib/string/String#padEnd
+      local.tee $value|28
+      i32.store offset=52
+      i32.const 0
+      local.set $radix|29
+      local.get $value|28
+      local.set $43
+      global.get $~lib/memory/__stack_pointer
+      local.get $43
+      i32.store
+      local.get $43
+      local.get $radix|29
+      call $~lib/util/string/strtol<i32>
+      br $~lib/builtins/i32.parse|inlined.5
+     end
      local.set $ms
     else
-     local.get $secAndMs
-     local.set $17
-     global.get $~lib/memory/__stack_pointer
-     local.get $17
-     i32.store
-     local.get $17
-     i32.const 0
-     call $~lib/number/I32.parseInt
+     block $~lib/builtins/i32.parse|inlined.6 (result i32)
+      global.get $~lib/memory/__stack_pointer
+      local.get $secAndFrac
+      local.tee $value|30
+      i32.store offset=56
+      i32.const 0
+      local.set $radix|31
+      local.get $value|30
+      local.set $43
+      global.get $~lib/memory/__stack_pointer
+      local.get $43
+      i32.store
+      local.get $43
+      local.get $radix|31
+      call $~lib/util/string/strtol<i32>
+      br $~lib/builtins/i32.parse|inlined.6
+     end
      local.set $sec
     end
    end
   end
   global.get $~lib/memory/__stack_pointer
   local.get $dateString
-  local.set $17
+  local.set $43
   global.get $~lib/memory/__stack_pointer
-  local.get $17
+  local.get $43
   i32.store
-  local.get $17
+  local.get $43
   i32.const 592
-  local.set $17
+  local.set $43
   global.get $~lib/memory/__stack_pointer
-  local.get $17
+  local.get $43
   i32.store offset=8
-  local.get $17
+  local.get $43
   i32.const 1
   global.set $~argumentsLength
   i32.const 0
   call $~lib/string/String#split@varargs
   local.tee $parts
-  i32.store offset=24
-  local.get $parts
-  local.set $17
-  global.get $~lib/memory/__stack_pointer
-  local.get $17
-  i32.store offset=8
-  local.get $17
-  i32.const 0
-  call $~lib/array/Array<~lib/string/String>#__get
-  local.set $17
-  global.get $~lib/memory/__stack_pointer
-  local.get $17
-  i32.store
-  local.get $17
-  i32.const 0
-  call $~lib/number/I32.parseInt
+  i32.store offset=60
+  block $~lib/builtins/i32.parse|inlined.7 (result i32)
+   global.get $~lib/memory/__stack_pointer
+   local.get $parts
+   local.set $43
+   global.get $~lib/memory/__stack_pointer
+   local.get $43
+   i32.store
+   local.get $43
+   i32.const 0
+   call $~lib/array/Array<~lib/string/String>#__get
+   local.tee $value|33
+   i32.store offset=64
+   i32.const 0
+   local.set $radix|34
+   local.get $value|33
+   local.set $43
+   global.get $~lib/memory/__stack_pointer
+   local.get $43
+   i32.store
+   local.get $43
+   local.get $radix|34
+   call $~lib/util/string/strtol<i32>
+   br $~lib/builtins/i32.parse|inlined.7
+  end
   local.set $year
   i32.const 1
   local.set $month
   i32.const 1
   local.set $day
   local.get $parts
-  local.set $17
+  local.set $43
   global.get $~lib/memory/__stack_pointer
-  local.get $17
+  local.get $43
   i32.store
-  local.get $17
+  local.get $43
   call $~lib/array/Array<~lib/string/String>#get:length
-  local.set $len|16
-  local.get $len|16
+  local.set $len|38
+  local.get $len|38
   i32.const 2
   i32.ge_s
   if
-   local.get $parts
-   local.set $17
-   global.get $~lib/memory/__stack_pointer
-   local.get $17
-   i32.store offset=8
-   local.get $17
-   i32.const 1
-   call $~lib/array/Array<~lib/string/String>#__get
-   local.set $17
-   global.get $~lib/memory/__stack_pointer
-   local.get $17
-   i32.store
-   local.get $17
-   i32.const 0
-   call $~lib/number/I32.parseInt
+   block $~lib/builtins/i32.parse|inlined.8 (result i32)
+    global.get $~lib/memory/__stack_pointer
+    local.get $parts
+    local.set $43
+    global.get $~lib/memory/__stack_pointer
+    local.get $43
+    i32.store
+    local.get $43
+    i32.const 1
+    call $~lib/array/Array<~lib/string/String>#__get
+    local.tee $value|39
+    i32.store offset=68
+    i32.const 0
+    local.set $radix|40
+    local.get $value|39
+    local.set $43
+    global.get $~lib/memory/__stack_pointer
+    local.get $43
+    i32.store
+    local.get $43
+    local.get $radix|40
+    call $~lib/util/string/strtol<i32>
+    br $~lib/builtins/i32.parse|inlined.8
+   end
    local.set $month
-   local.get $len|16
+   local.get $len|38
    i32.const 3
    i32.ge_s
    if
-    local.get $parts
-    local.set $17
-    global.get $~lib/memory/__stack_pointer
-    local.get $17
-    i32.store offset=8
-    local.get $17
-    i32.const 2
-    call $~lib/array/Array<~lib/string/String>#__get
-    local.set $17
-    global.get $~lib/memory/__stack_pointer
-    local.get $17
-    i32.store
-    local.get $17
-    i32.const 0
-    call $~lib/number/I32.parseInt
+    block $~lib/builtins/i32.parse|inlined.9 (result i32)
+     global.get $~lib/memory/__stack_pointer
+     local.get $parts
+     local.set $43
+     global.get $~lib/memory/__stack_pointer
+     local.get $43
+     i32.store
+     local.get $43
+     i32.const 2
+     call $~lib/array/Array<~lib/string/String>#__get
+     local.tee $value|41
+     i32.store offset=72
+     i32.const 0
+     local.set $radix|42
+     local.get $value|41
+     local.set $43
+     global.get $~lib/memory/__stack_pointer
+     local.get $43
+     i32.store
+     local.get $43
+     local.get $radix|42
+     call $~lib/util/string/strtol<i32>
+     br $~lib/builtins/i32.parse|inlined.9
+    end
     local.set $day
    end
   end
@@ -8079,13 +8652,16 @@
   local.get $sec
   local.get $ms
   call $~lib/date/epochMillis
+  local.get $offsetMs
+  i64.extend_i32_s
+  i64.sub
   call $~lib/date/Date#constructor
-  local.set $17
+  local.set $43
   global.get $~lib/memory/__stack_pointer
-  i32.const 28
+  i32.const 76
   i32.add
   global.set $~lib/memory/__stack_pointer
-  local.get $17
+  local.get $43
   return
  )
  (func $start:std/date
@@ -8246,14 +8822,22 @@
   (local $154 i32)
   (local $155 i32)
   (local $156 i32)
+  (local $157 i32)
+  (local $158 i32)
+  (local $159 i32)
+  (local $160 i32)
+  (local $161 i32)
+  (local $162 i32)
+  (local $163 i32)
+  (local $164 i32)
   global.get $~lib/memory/__stack_pointer
-  i32.const 408
+  i32.const 440
   i32.sub
   global.set $~lib/memory/__stack_pointer
   call $~stack_check
   global.get $~lib/memory/__stack_pointer
   i32.const 0
-  i32.const 408
+  i32.const 440
   memory.fill
   block $~lib/date/Date.UTC|inlined.0 (result i64)
    i32.const 1970
@@ -8748,11 +9332,11 @@
    local.tee $58
    i32.store offset=4
    local.get $58
-   local.set $156
+   local.set $164
    global.get $~lib/memory/__stack_pointer
-   local.get $156
+   local.get $164
    i32.store offset=8
-   local.get $156
+   local.get $164
    call $~lib/date/Date#get:epochMillis
    br $~lib/date/Date#getTime|inlined.0
   end
@@ -8768,11 +9352,11 @@
    unreachable
   end
   local.get $57
-  local.set $156
+  local.set $164
   global.get $~lib/memory/__stack_pointer
-  local.get $156
+  local.get $164
   i32.store offset=8
-  local.get $156
+  local.get $164
   local.get $56
   i64.const 1
   i64.add
@@ -8784,11 +9368,11 @@
    local.tee $59
    i32.store offset=12
    local.get $59
-   local.set $156
+   local.set $164
    global.get $~lib/memory/__stack_pointer
-   local.get $156
+   local.get $164
    i32.store offset=8
-   local.get $156
+   local.get $164
    call $~lib/date/Date#get:epochMillis
    br $~lib/date/Date#getTime|inlined.1
   end
@@ -8817,11 +9401,11 @@
    local.tee $61
    i32.store offset=20
    local.get $61
-   local.set $156
+   local.set $164
    global.get $~lib/memory/__stack_pointer
-   local.get $156
+   local.get $164
    i32.store offset=8
-   local.get $156
+   local.get $164
    call $~lib/date/Date#get:year
    br $~lib/date/Date#getUTCFullYear|inlined.0
   end
@@ -8842,11 +9426,11 @@
    local.tee $62
    i32.store offset=24
    local.get $62
-   local.set $156
+   local.set $164
    global.get $~lib/memory/__stack_pointer
-   local.get $156
+   local.get $164
    i32.store offset=8
-   local.get $156
+   local.get $164
    call $~lib/date/Date#get:month
    i32.const 1
    i32.sub
@@ -8869,11 +9453,11 @@
    local.tee $63
    i32.store offset=28
    local.get $63
-   local.set $156
+   local.set $164
    global.get $~lib/memory/__stack_pointer
-   local.get $156
+   local.get $164
    i32.store offset=8
-   local.get $156
+   local.get $164
    call $~lib/date/Date#get:day
    br $~lib/date/Date#getUTCDate|inlined.0
   end
@@ -8889,11 +9473,11 @@
    unreachable
   end
   local.get $60
-  local.set $156
+  local.set $164
   global.get $~lib/memory/__stack_pointer
-  local.get $156
+  local.get $164
   i32.store offset=8
-  local.get $156
+  local.get $164
   call $~lib/date/Date#getUTCHours
   i32.const 22
   i32.eq
@@ -8907,11 +9491,11 @@
    unreachable
   end
   local.get $60
-  local.set $156
+  local.set $164
   global.get $~lib/memory/__stack_pointer
-  local.get $156
+  local.get $164
   i32.store offset=8
-  local.get $156
+  local.get $164
   call $~lib/date/Date#getUTCMinutes
   i32.const 9
   i32.eq
@@ -8925,11 +9509,11 @@
    unreachable
   end
   local.get $60
-  local.set $156
+  local.set $164
   global.get $~lib/memory/__stack_pointer
-  local.get $156
+  local.get $164
   i32.store offset=8
-  local.get $156
+  local.get $164
   call $~lib/date/Date#getUTCSeconds
   i32.const 43
   i32.eq
@@ -8943,11 +9527,11 @@
    unreachable
   end
   local.get $60
-  local.set $156
+  local.set $164
   global.get $~lib/memory/__stack_pointer
-  local.get $156
+  local.get $164
   i32.store offset=8
-  local.get $156
+  local.get $164
   call $~lib/date/Date#getUTCMilliseconds
   i32.const 706
   i32.eq
@@ -8972,11 +9556,11 @@
    local.tee $65
    i32.store offset=36
    local.get $65
-   local.set $156
+   local.set $164
    global.get $~lib/memory/__stack_pointer
-   local.get $156
+   local.get $164
    i32.store offset=8
-   local.get $156
+   local.get $164
    call $~lib/date/Date#get:year
    br $~lib/date/Date#getUTCFullYear|inlined.1
   end
@@ -8997,11 +9581,11 @@
    local.tee $66
    i32.store offset=40
    local.get $66
-   local.set $156
+   local.set $164
    global.get $~lib/memory/__stack_pointer
-   local.get $156
+   local.get $164
    i32.store offset=8
-   local.get $156
+   local.get $164
    call $~lib/date/Date#get:month
    i32.const 1
    i32.sub
@@ -9024,11 +9608,11 @@
    local.tee $67
    i32.store offset=44
    local.get $67
-   local.set $156
+   local.set $164
    global.get $~lib/memory/__stack_pointer
-   local.get $156
+   local.get $164
    i32.store offset=8
-   local.get $156
+   local.get $164
    call $~lib/date/Date#get:day
    br $~lib/date/Date#getUTCDate|inlined.1
   end
@@ -9044,11 +9628,11 @@
    unreachable
   end
   local.get $64
-  local.set $156
+  local.set $164
   global.get $~lib/memory/__stack_pointer
-  local.get $156
+  local.get $164
   i32.store offset=8
-  local.get $156
+  local.get $164
   call $~lib/date/Date#getUTCHours
   i32.const 1
   i32.eq
@@ -9062,11 +9646,11 @@
    unreachable
   end
   local.get $64
-  local.set $156
+  local.set $164
   global.get $~lib/memory/__stack_pointer
-  local.get $156
+  local.get $164
   i32.store offset=8
-  local.get $156
+  local.get $164
   call $~lib/date/Date#getUTCMinutes
   i32.const 3
   i32.eq
@@ -9080,11 +9664,11 @@
    unreachable
   end
   local.get $64
-  local.set $156
+  local.set $164
   global.get $~lib/memory/__stack_pointer
-  local.get $156
+  local.get $164
   i32.store offset=8
-  local.get $156
+  local.get $164
   call $~lib/date/Date#getUTCSeconds
   i32.const 11
   i32.eq
@@ -9098,11 +9682,11 @@
    unreachable
   end
   local.get $64
-  local.set $156
+  local.set $164
   global.get $~lib/memory/__stack_pointer
-  local.get $156
+  local.get $164
   i32.store offset=8
-  local.get $156
+  local.get $164
   call $~lib/date/Date#getUTCMilliseconds
   i32.const 274
   i32.eq
@@ -9122,11 +9706,11 @@
   local.tee $68
   i32.store offset=48
   local.get $68
-  local.set $156
+  local.set $164
   global.get $~lib/memory/__stack_pointer
-  local.get $156
+  local.get $164
   i32.store offset=8
-  local.get $156
+  local.get $164
   call $~lib/date/Date#getUTCMilliseconds
   i32.const 984
   i32.eq
@@ -9140,19 +9724,19 @@
    unreachable
   end
   local.get $68
-  local.set $156
+  local.set $164
   global.get $~lib/memory/__stack_pointer
-  local.get $156
+  local.get $164
   i32.store offset=8
-  local.get $156
+  local.get $164
   i32.const 12
   call $~lib/date/Date#setUTCMilliseconds
   local.get $68
-  local.set $156
+  local.set $164
   global.get $~lib/memory/__stack_pointer
-  local.get $156
+  local.get $164
   i32.store offset=8
-  local.get $156
+  local.get $164
   call $~lib/date/Date#getUTCMilliseconds
   i32.const 12
   i32.eq
@@ -9166,19 +9750,19 @@
    unreachable
   end
   local.get $68
-  local.set $156
+  local.set $164
   global.get $~lib/memory/__stack_pointer
-  local.get $156
+  local.get $164
   i32.store offset=8
-  local.get $156
+  local.get $164
   i32.const 568
   call $~lib/date/Date#setUTCMilliseconds
   local.get $68
-  local.set $156
+  local.set $164
   global.get $~lib/memory/__stack_pointer
-  local.get $156
+  local.get $164
   i32.store offset=8
-  local.get $156
+  local.get $164
   call $~lib/date/Date#getUTCMilliseconds
   i32.const 568
   i32.eq
@@ -9192,11 +9776,11 @@
    unreachable
   end
   local.get $68
-  local.set $156
+  local.set $164
   global.get $~lib/memory/__stack_pointer
-  local.get $156
+  local.get $164
   i32.store offset=8
-  local.get $156
+  local.get $164
   i32.const 0
   call $~lib/date/Date#setUTCMilliseconds
   block $~lib/date/Date#getTime|inlined.2 (result i64)
@@ -9205,11 +9789,11 @@
    local.tee $69
    i32.store offset=52
    local.get $69
-   local.set $156
+   local.set $164
    global.get $~lib/memory/__stack_pointer
-   local.get $156
+   local.get $164
    i32.store offset=8
-   local.get $156
+   local.get $164
    call $~lib/date/Date#get:epochMillis
    br $~lib/date/Date#getTime|inlined.2
   end
@@ -9225,11 +9809,11 @@
    unreachable
   end
   local.get $68
-  local.set $156
+  local.set $164
   global.get $~lib/memory/__stack_pointer
-  local.get $156
+  local.get $164
   i32.store offset=8
-  local.get $156
+  local.get $164
   i32.const 999
   call $~lib/date/Date#setUTCMilliseconds
   block $~lib/date/Date#getTime|inlined.3 (result i64)
@@ -9238,11 +9822,11 @@
    local.tee $70
    i32.store offset=56
    local.get $70
-   local.set $156
+   local.set $164
    global.get $~lib/memory/__stack_pointer
-   local.get $156
+   local.get $164
    i32.store offset=8
-   local.get $156
+   local.get $164
    call $~lib/date/Date#get:epochMillis
    br $~lib/date/Date#getTime|inlined.3
   end
@@ -9258,19 +9842,19 @@
    unreachable
   end
   local.get $68
-  local.set $156
+  local.set $164
   global.get $~lib/memory/__stack_pointer
-  local.get $156
+  local.get $164
   i32.store offset=8
-  local.get $156
+  local.get $164
   i32.const 2000
   call $~lib/date/Date#setUTCMilliseconds
   local.get $68
-  local.set $156
+  local.set $164
   global.get $~lib/memory/__stack_pointer
-  local.get $156
+  local.get $164
   i32.store offset=8
-  local.get $156
+  local.get $164
   call $~lib/date/Date#getUTCMilliseconds
   i32.const 0
   i32.eq
@@ -9289,11 +9873,11 @@
    local.tee $71
    i32.store offset=60
    local.get $71
-   local.set $156
+   local.set $164
    global.get $~lib/memory/__stack_pointer
-   local.get $156
+   local.get $164
    i32.store offset=8
-   local.get $156
+   local.get $164
    call $~lib/date/Date#get:epochMillis
    br $~lib/date/Date#getTime|inlined.4
   end
@@ -9309,19 +9893,19 @@
    unreachable
   end
   local.get $68
-  local.set $156
+  local.set $164
   global.get $~lib/memory/__stack_pointer
-  local.get $156
+  local.get $164
   i32.store offset=8
-  local.get $156
+  local.get $164
   i32.const -2000
   call $~lib/date/Date#setUTCMilliseconds
   local.get $68
-  local.set $156
+  local.set $164
   global.get $~lib/memory/__stack_pointer
-  local.get $156
+  local.get $164
   i32.store offset=8
-  local.get $156
+  local.get $164
   call $~lib/date/Date#getUTCMilliseconds
   i32.const 0
   i32.eq
@@ -9340,11 +9924,11 @@
    local.tee $72
    i32.store offset=64
    local.get $72
-   local.set $156
+   local.set $164
    global.get $~lib/memory/__stack_pointer
-   local.get $156
+   local.get $164
    i32.store offset=8
-   local.get $156
+   local.get $164
    call $~lib/date/Date#get:epochMillis
    br $~lib/date/Date#getTime|inlined.5
   end
@@ -9366,11 +9950,11 @@
   local.tee $73
   i32.store offset=68
   local.get $73
-  local.set $156
+  local.set $164
   global.get $~lib/memory/__stack_pointer
-  local.get $156
+  local.get $164
   i32.store offset=8
-  local.get $156
+  local.get $164
   call $~lib/date/Date#getUTCSeconds
   i32.const 31
   i32.eq
@@ -9384,19 +9968,19 @@
    unreachable
   end
   local.get $73
-  local.set $156
+  local.set $164
   global.get $~lib/memory/__stack_pointer
-  local.get $156
+  local.get $164
   i32.store offset=8
-  local.get $156
+  local.get $164
   i32.const 12
   call $~lib/date/Date#setUTCSeconds
   local.get $73
-  local.set $156
+  local.set $164
   global.get $~lib/memory/__stack_pointer
-  local.get $156
+  local.get $164
   i32.store offset=8
-  local.get $156
+  local.get $164
   call $~lib/date/Date#getUTCSeconds
   i32.const 12
   i32.eq
@@ -9410,19 +9994,19 @@
    unreachable
   end
   local.get $73
-  local.set $156
+  local.set $164
   global.get $~lib/memory/__stack_pointer
-  local.get $156
+  local.get $164
   i32.store offset=8
-  local.get $156
+  local.get $164
   i32.const 50
   call $~lib/date/Date#setUTCSeconds
   local.get $73
-  local.set $156
+  local.set $164
   global.get $~lib/memory/__stack_pointer
-  local.get $156
+  local.get $164
   i32.store offset=8
-  local.get $156
+  local.get $164
   call $~lib/date/Date#getUTCSeconds
   i32.const 50
   i32.eq
@@ -9436,11 +10020,11 @@
    unreachable
   end
   local.get $73
-  local.set $156
+  local.set $164
   global.get $~lib/memory/__stack_pointer
-  local.get $156
+  local.get $164
   i32.store offset=8
-  local.get $156
+  local.get $164
   i32.const 0
   call $~lib/date/Date#setUTCSeconds
   block $~lib/date/Date#getTime|inlined.6 (result i64)
@@ -9449,11 +10033,11 @@
    local.tee $74
    i32.store offset=72
    local.get $74
-   local.set $156
+   local.set $164
    global.get $~lib/memory/__stack_pointer
-   local.get $156
+   local.get $164
    i32.store offset=8
-   local.get $156
+   local.get $164
    call $~lib/date/Date#get:epochMillis
    br $~lib/date/Date#getTime|inlined.6
   end
@@ -9469,11 +10053,11 @@
    unreachable
   end
   local.get $73
-  local.set $156
+  local.set $164
   global.get $~lib/memory/__stack_pointer
-  local.get $156
+  local.get $164
   i32.store offset=8
-  local.get $156
+  local.get $164
   i32.const 59
   call $~lib/date/Date#setUTCSeconds
   block $~lib/date/Date#getTime|inlined.7 (result i64)
@@ -9482,11 +10066,11 @@
    local.tee $75
    i32.store offset=76
    local.get $75
-   local.set $156
+   local.set $164
    global.get $~lib/memory/__stack_pointer
-   local.get $156
+   local.get $164
    i32.store offset=8
-   local.get $156
+   local.get $164
    call $~lib/date/Date#get:epochMillis
    br $~lib/date/Date#getTime|inlined.7
   end
@@ -9508,11 +10092,11 @@
   local.tee $76
   i32.store offset=80
   local.get $76
-  local.set $156
+  local.set $164
   global.get $~lib/memory/__stack_pointer
-  local.get $156
+  local.get $164
   i32.store offset=8
-  local.get $156
+  local.get $164
   call $~lib/date/Date#getUTCMinutes
   i32.const 45
   i32.eq
@@ -9526,19 +10110,19 @@
    unreachable
   end
   local.get $76
-  local.set $156
+  local.set $164
   global.get $~lib/memory/__stack_pointer
-  local.get $156
+  local.get $164
   i32.store offset=8
-  local.get $156
+  local.get $164
   i32.const 12
   call $~lib/date/Date#setUTCMinutes
   local.get $76
-  local.set $156
+  local.set $164
   global.get $~lib/memory/__stack_pointer
-  local.get $156
+  local.get $164
   i32.store offset=8
-  local.get $156
+  local.get $164
   call $~lib/date/Date#getUTCMinutes
   i32.const 12
   i32.eq
@@ -9552,19 +10136,19 @@
    unreachable
   end
   local.get $76
-  local.set $156
+  local.set $164
   global.get $~lib/memory/__stack_pointer
-  local.get $156
+  local.get $164
   i32.store offset=8
-  local.get $156
+  local.get $164
   i32.const 50
   call $~lib/date/Date#setUTCMinutes
   local.get $76
-  local.set $156
+  local.set $164
   global.get $~lib/memory/__stack_pointer
-  local.get $156
+  local.get $164
   i32.store offset=8
-  local.get $156
+  local.get $164
   call $~lib/date/Date#getUTCMinutes
   i32.const 50
   i32.eq
@@ -9578,11 +10162,11 @@
    unreachable
   end
   local.get $76
-  local.set $156
+  local.set $164
   global.get $~lib/memory/__stack_pointer
-  local.get $156
+  local.get $164
   i32.store offset=8
-  local.get $156
+  local.get $164
   i32.const 0
   call $~lib/date/Date#setUTCMinutes
   block $~lib/date/Date#getTime|inlined.8 (result i64)
@@ -9591,11 +10175,11 @@
    local.tee $77
    i32.store offset=84
    local.get $77
-   local.set $156
+   local.set $164
    global.get $~lib/memory/__stack_pointer
-   local.get $156
+   local.get $164
    i32.store offset=8
-   local.get $156
+   local.get $164
    call $~lib/date/Date#get:epochMillis
    br $~lib/date/Date#getTime|inlined.8
   end
@@ -9611,11 +10195,11 @@
    unreachable
   end
   local.get $76
-  local.set $156
+  local.set $164
   global.get $~lib/memory/__stack_pointer
-  local.get $156
+  local.get $164
   i32.store offset=8
-  local.get $156
+  local.get $164
   i32.const 59
   call $~lib/date/Date#setUTCMinutes
   block $~lib/date/Date#getTime|inlined.9 (result i64)
@@ -9624,11 +10208,11 @@
    local.tee $78
    i32.store offset=88
    local.get $78
-   local.set $156
+   local.set $164
    global.get $~lib/memory/__stack_pointer
-   local.get $156
+   local.get $164
    i32.store offset=8
-   local.get $156
+   local.get $164
    call $~lib/date/Date#get:epochMillis
    br $~lib/date/Date#getTime|inlined.9
   end
@@ -9650,11 +10234,11 @@
   local.tee $79
   i32.store offset=92
   local.get $79
-  local.set $156
+  local.set $164
   global.get $~lib/memory/__stack_pointer
-  local.get $156
+  local.get $164
   i32.store offset=8
-  local.get $156
+  local.get $164
   call $~lib/date/Date#getUTCHours
   i32.const 17
   i32.eq
@@ -9668,19 +10252,19 @@
    unreachable
   end
   local.get $79
-  local.set $156
+  local.set $164
   global.get $~lib/memory/__stack_pointer
-  local.get $156
+  local.get $164
   i32.store offset=8
-  local.get $156
+  local.get $164
   i32.const 12
   call $~lib/date/Date#setUTCHours
   local.get $79
-  local.set $156
+  local.set $164
   global.get $~lib/memory/__stack_pointer
-  local.get $156
+  local.get $164
   i32.store offset=8
-  local.get $156
+  local.get $164
   call $~lib/date/Date#getUTCHours
   i32.const 12
   i32.eq
@@ -9694,19 +10278,19 @@
    unreachable
   end
   local.get $79
-  local.set $156
+  local.set $164
   global.get $~lib/memory/__stack_pointer
-  local.get $156
+  local.get $164
   i32.store offset=8
-  local.get $156
+  local.get $164
   i32.const 2
   call $~lib/date/Date#setUTCHours
   local.get $79
-  local.set $156
+  local.set $164
   global.get $~lib/memory/__stack_pointer
-  local.get $156
+  local.get $164
   i32.store offset=8
-  local.get $156
+  local.get $164
   call $~lib/date/Date#getUTCHours
   i32.const 2
   i32.eq
@@ -9720,11 +10304,11 @@
    unreachable
   end
   local.get $79
-  local.set $156
+  local.set $164
   global.get $~lib/memory/__stack_pointer
-  local.get $156
+  local.get $164
   i32.store offset=8
-  local.get $156
+  local.get $164
   i32.const 0
   call $~lib/date/Date#setUTCHours
   block $~lib/date/Date#getTime|inlined.10 (result i64)
@@ -9733,11 +10317,11 @@
    local.tee $80
    i32.store offset=96
    local.get $80
-   local.set $156
+   local.set $164
    global.get $~lib/memory/__stack_pointer
-   local.get $156
+   local.get $164
    i32.store offset=8
-   local.get $156
+   local.get $164
    call $~lib/date/Date#get:epochMillis
    br $~lib/date/Date#getTime|inlined.10
   end
@@ -9753,11 +10337,11 @@
    unreachable
   end
   local.get $79
-  local.set $156
+  local.set $164
   global.get $~lib/memory/__stack_pointer
-  local.get $156
+  local.get $164
   i32.store offset=8
-  local.get $156
+  local.get $164
   i32.const 23
   call $~lib/date/Date#setUTCHours
   block $~lib/date/Date#getTime|inlined.11 (result i64)
@@ -9766,11 +10350,11 @@
    local.tee $81
    i32.store offset=100
    local.get $81
-   local.set $156
+   local.set $164
    global.get $~lib/memory/__stack_pointer
-   local.get $156
+   local.get $164
    i32.store offset=8
-   local.get $156
+   local.get $164
    call $~lib/date/Date#get:epochMillis
    br $~lib/date/Date#getTime|inlined.11
   end
@@ -9797,11 +10381,11 @@
    local.tee $83
    i32.store offset=108
    local.get $83
-   local.set $156
+   local.set $164
    global.get $~lib/memory/__stack_pointer
-   local.get $156
+   local.get $164
    i32.store offset=8
-   local.get $156
+   local.get $164
    call $~lib/date/Date#get:year
    br $~lib/date/Date#getUTCFullYear|inlined.2
   end
@@ -9822,11 +10406,11 @@
    local.tee $84
    i32.store offset=112
    local.get $84
-   local.set $156
+   local.set $164
    global.get $~lib/memory/__stack_pointer
-   local.get $156
+   local.get $164
    i32.store offset=8
-   local.get $156
+   local.get $164
    call $~lib/date/Date#get:month
    i32.const 1
    i32.sub
@@ -9844,11 +10428,11 @@
    unreachable
   end
   local.get $82
-  local.set $156
+  local.set $164
   global.get $~lib/memory/__stack_pointer
-  local.get $156
+  local.get $164
   i32.store offset=8
-  local.get $156
+  local.get $164
   i32.const 12
   call $~lib/date/Date#setUTCDate
   block $~lib/date/Date#getUTCDate|inlined.2 (result i32)
@@ -9857,11 +10441,11 @@
    local.tee $85
    i32.store offset=116
    local.get $85
-   local.set $156
+   local.set $164
    global.get $~lib/memory/__stack_pointer
-   local.get $156
+   local.get $164
    i32.store offset=8
-   local.get $156
+   local.get $164
    call $~lib/date/Date#get:day
    br $~lib/date/Date#getUTCDate|inlined.2
   end
@@ -9877,11 +10461,11 @@
    unreachable
   end
   local.get $82
-  local.set $156
+  local.set $164
   global.get $~lib/memory/__stack_pointer
-  local.get $156
+  local.get $164
   i32.store offset=8
-  local.get $156
+  local.get $164
   i32.const 2
   call $~lib/date/Date#setUTCDate
   block $~lib/date/Date#getUTCDate|inlined.3 (result i32)
@@ -9890,11 +10474,11 @@
    local.tee $86
    i32.store offset=120
    local.get $86
-   local.set $156
+   local.set $164
    global.get $~lib/memory/__stack_pointer
-   local.get $156
+   local.get $164
    i32.store offset=8
-   local.get $156
+   local.get $164
    call $~lib/date/Date#get:day
    br $~lib/date/Date#getUTCDate|inlined.3
   end
@@ -9910,62 +10494,62 @@
    unreachable
   end
   local.get $82
-  local.set $156
+  local.set $164
   global.get $~lib/memory/__stack_pointer
-  local.get $156
+  local.get $164
   i32.store offset=8
-  local.get $156
+  local.get $164
   i32.const 1
   call $~lib/date/Date#setUTCDate
   local.get $82
-  local.set $156
+  local.set $164
   global.get $~lib/memory/__stack_pointer
-  local.get $156
+  local.get $164
   i32.store offset=8
-  local.get $156
+  local.get $164
   i32.const 30
   call $~lib/date/Date#setUTCDate
   local.get $82
-  local.set $156
+  local.set $164
   global.get $~lib/memory/__stack_pointer
-  local.get $156
+  local.get $164
   i32.store offset=8
-  local.get $156
+  local.get $164
   i32.const 0
   i32.const 1
   global.set $~argumentsLength
   i32.const 0
   call $~lib/date/Date#setUTCMonth@varargs
   local.get $82
-  local.set $156
+  local.set $164
   global.get $~lib/memory/__stack_pointer
-  local.get $156
+  local.get $164
   i32.store offset=8
-  local.get $156
+  local.get $164
   i32.const 1
   call $~lib/date/Date#setUTCDate
   local.get $82
-  local.set $156
+  local.set $164
   global.get $~lib/memory/__stack_pointer
-  local.get $156
+  local.get $164
   i32.store offset=8
-  local.get $156
+  local.get $164
   i32.const 31
   call $~lib/date/Date#setUTCDate
   local.get $82
-  local.set $156
+  local.set $164
   global.get $~lib/memory/__stack_pointer
-  local.get $156
+  local.get $164
   i32.store offset=8
-  local.get $156
+  local.get $164
   i32.const 2024
   call $~lib/date/Date#setUTCFullYear
   local.get $82
-  local.set $156
+  local.set $164
   global.get $~lib/memory/__stack_pointer
-  local.get $156
+  local.get $164
   i32.store offset=8
-  local.get $156
+  local.get $164
   i32.const 1
   i32.const 1
   global.set $~argumentsLength
@@ -9977,11 +10561,11 @@
    local.tee $87
    i32.store offset=124
    local.get $87
-   local.set $156
+   local.set $164
    global.get $~lib/memory/__stack_pointer
-   local.get $156
+   local.get $164
    i32.store offset=8
-   local.get $156
+   local.get $164
    call $~lib/date/Date#get:month
    i32.const 1
    i32.sub
@@ -9999,27 +10583,27 @@
    unreachable
   end
   local.get $82
-  local.set $156
+  local.set $164
   global.get $~lib/memory/__stack_pointer
-  local.get $156
+  local.get $164
   i32.store offset=8
-  local.get $156
+  local.get $164
   i32.const 1
   call $~lib/date/Date#setUTCDate
   local.get $82
-  local.set $156
+  local.set $164
   global.get $~lib/memory/__stack_pointer
-  local.get $156
+  local.get $164
   i32.store offset=8
-  local.get $156
+  local.get $164
   i32.const 29
   call $~lib/date/Date#setUTCDate
   local.get $82
-  local.set $156
+  local.set $164
   global.get $~lib/memory/__stack_pointer
-  local.get $156
+  local.get $164
   i32.store offset=8
-  local.get $156
+  local.get $164
   i32.const 1
   i32.const 1
   global.set $~argumentsLength
@@ -10031,11 +10615,11 @@
    local.tee $88
    i32.store offset=128
    local.get $88
-   local.set $156
+   local.set $164
    global.get $~lib/memory/__stack_pointer
-   local.get $156
+   local.get $164
    i32.store offset=8
-   local.get $156
+   local.get $164
    call $~lib/date/Date#get:epochMillis
    br $~lib/date/Date#getTime|inlined.12
   end
@@ -10056,11 +10640,11 @@
    local.tee $89
    i32.store offset=132
    local.get $89
-   local.set $156
+   local.set $164
    global.get $~lib/memory/__stack_pointer
-   local.get $156
+   local.get $164
    i32.store offset=8
-   local.get $156
+   local.get $164
    call $~lib/date/Date#get:month
    i32.const 1
    i32.sub
@@ -10083,11 +10667,11 @@
    local.tee $90
    i32.store offset=136
    local.get $90
-   local.set $156
+   local.set $164
    global.get $~lib/memory/__stack_pointer
-   local.get $156
+   local.get $164
    i32.store offset=8
-   local.get $156
+   local.get $164
    call $~lib/date/Date#get:day
    br $~lib/date/Date#getUTCDate|inlined.4
   end
@@ -10103,11 +10687,11 @@
    unreachable
   end
   local.get $82
-  local.set $156
+  local.set $164
   global.get $~lib/memory/__stack_pointer
-  local.get $156
+  local.get $164
   i32.store offset=8
-  local.get $156
+  local.get $164
   call $~lib/date/Date#getUTCMinutes
   i32.const 3
   i32.eq
@@ -10121,11 +10705,11 @@
    unreachable
   end
   local.get $82
-  local.set $156
+  local.set $164
   global.get $~lib/memory/__stack_pointer
-  local.get $156
+  local.get $164
   i32.store offset=8
-  local.get $156
+  local.get $164
   call $~lib/date/Date#getUTCSeconds
   i32.const 11
   i32.eq
@@ -10139,11 +10723,11 @@
    unreachable
   end
   local.get $82
-  local.set $156
+  local.set $164
   global.get $~lib/memory/__stack_pointer
-  local.get $156
+  local.get $164
   i32.store offset=8
-  local.get $156
+  local.get $164
   call $~lib/date/Date#getUTCMilliseconds
   i32.const 274
   i32.eq
@@ -10163,11 +10747,11 @@
   local.tee $82
   i32.store offset=104
   local.get $82
-  local.set $156
+  local.set $164
   global.get $~lib/memory/__stack_pointer
-  local.get $156
+  local.get $164
   i32.store offset=8
-  local.get $156
+  local.get $164
   i32.const 20
   call $~lib/date/Date#setUTCDate
   block $~lib/date/Date#getTime|inlined.13 (result i64)
@@ -10176,11 +10760,11 @@
    local.tee $91
    i32.store offset=140
    local.get $91
-   local.set $156
+   local.set $164
    global.get $~lib/memory/__stack_pointer
-   local.get $156
+   local.get $164
    i32.store offset=8
-   local.get $156
+   local.get $164
    call $~lib/date/Date#get:epochMillis
    br $~lib/date/Date#getTime|inlined.13
   end
@@ -10196,11 +10780,11 @@
    unreachable
   end
   local.get $82
-  local.set $156
+  local.set $164
   global.get $~lib/memory/__stack_pointer
-  local.get $156
+  local.get $164
   i32.store offset=8
-  local.get $156
+  local.get $164
   i32.const 1
   call $~lib/date/Date#setUTCDate
   block $~lib/date/Date#getTime|inlined.14 (result i64)
@@ -10209,11 +10793,11 @@
    local.tee $92
    i32.store offset=144
    local.get $92
-   local.set $156
+   local.set $164
    global.get $~lib/memory/__stack_pointer
-   local.get $156
+   local.get $164
    i32.store offset=8
-   local.get $156
+   local.get $164
    call $~lib/date/Date#get:epochMillis
    br $~lib/date/Date#getTime|inlined.14
   end
@@ -10229,11 +10813,11 @@
    unreachable
   end
   local.get $82
-  local.set $156
+  local.set $164
   global.get $~lib/memory/__stack_pointer
-  local.get $156
+  local.get $164
   i32.store offset=8
-  local.get $156
+  local.get $164
   i32.const 1000
   call $~lib/date/Date#setUTCMilliseconds
   block $~lib/date/Date#getTime|inlined.15 (result i64)
@@ -10242,11 +10826,11 @@
    local.tee $93
    i32.store offset=148
    local.get $93
-   local.set $156
+   local.set $164
    global.get $~lib/memory/__stack_pointer
-   local.get $156
+   local.get $164
    i32.store offset=8
-   local.get $156
+   local.get $164
    call $~lib/date/Date#get:epochMillis
    br $~lib/date/Date#getTime|inlined.15
   end
@@ -10262,11 +10846,11 @@
    unreachable
   end
   local.get $82
-  local.set $156
+  local.set $164
   global.get $~lib/memory/__stack_pointer
-  local.get $156
+  local.get $164
   i32.store offset=8
-  local.get $156
+  local.get $164
   i32.const 60
   i32.const 60
   i32.mul
@@ -10279,11 +10863,11 @@
    local.tee $94
    i32.store offset=152
    local.get $94
-   local.set $156
+   local.set $164
    global.get $~lib/memory/__stack_pointer
-   local.get $156
+   local.get $164
    i32.store offset=8
-   local.get $156
+   local.get $164
    call $~lib/date/Date#get:epochMillis
    br $~lib/date/Date#getTime|inlined.16
   end
@@ -10299,11 +10883,11 @@
    unreachable
   end
   local.get $82
-  local.set $156
+  local.set $164
   global.get $~lib/memory/__stack_pointer
-  local.get $156
+  local.get $164
   i32.store offset=8
-  local.get $156
+  local.get $164
   i32.const 60
   i32.const 60
   i32.mul
@@ -10318,11 +10902,11 @@
    local.tee $95
    i32.store offset=156
    local.get $95
-   local.set $156
+   local.set $164
    global.get $~lib/memory/__stack_pointer
-   local.get $156
+   local.get $164
    i32.store offset=8
-   local.get $156
+   local.get $164
    call $~lib/date/Date#get:epochMillis
    br $~lib/date/Date#getTime|inlined.17
   end
@@ -10338,11 +10922,11 @@
    unreachable
   end
   local.get $82
-  local.set $156
+  local.set $164
   global.get $~lib/memory/__stack_pointer
-  local.get $156
+  local.get $164
   i32.store offset=8
-  local.get $156
+  local.get $164
   i32.const 60
   i32.const 60
   i32.mul
@@ -10357,11 +10941,11 @@
    local.tee $96
    i32.store offset=160
    local.get $96
-   local.set $156
+   local.set $164
    global.get $~lib/memory/__stack_pointer
-   local.get $156
+   local.get $164
    i32.store offset=8
-   local.get $156
+   local.get $164
    call $~lib/date/Date#get:epochMillis
    br $~lib/date/Date#getTime|inlined.18
   end
@@ -10383,11 +10967,11 @@
   local.tee $82
   i32.store offset=104
   local.get $82
-  local.set $156
+  local.set $164
   global.get $~lib/memory/__stack_pointer
-  local.get $156
+  local.get $164
   i32.store offset=8
-  local.get $156
+  local.get $164
   i32.const -2208
   call $~lib/date/Date#setUTCDate
   block $~lib/date/Date#getTime|inlined.19 (result i64)
@@ -10396,11 +10980,11 @@
    local.tee $97
    i32.store offset=164
    local.get $97
-   local.set $156
+   local.set $164
    global.get $~lib/memory/__stack_pointer
-   local.get $156
+   local.get $164
    i32.store offset=8
-   local.get $156
+   local.get $164
    call $~lib/date/Date#get:epochMillis
    br $~lib/date/Date#getTime|inlined.19
   end
@@ -10422,11 +11006,11 @@
   local.tee $82
   i32.store offset=104
   local.get $82
-  local.set $156
+  local.set $164
   global.get $~lib/memory/__stack_pointer
-  local.get $156
+  local.get $164
   i32.store offset=8
-  local.get $156
+  local.get $164
   i32.const 2208
   call $~lib/date/Date#setUTCDate
   block $~lib/date/Date#getTime|inlined.20 (result i64)
@@ -10435,11 +11019,11 @@
    local.tee $98
    i32.store offset=168
    local.get $98
-   local.set $156
+   local.set $164
    global.get $~lib/memory/__stack_pointer
-   local.get $156
+   local.get $164
    i32.store offset=8
-   local.get $156
+   local.get $164
    call $~lib/date/Date#get:epochMillis
    br $~lib/date/Date#getTime|inlined.20
   end
@@ -10462,25 +11046,25 @@
    local.tee $99
    i32.store offset=172
    local.get $99
-   local.set $156
+   local.set $164
    global.get $~lib/memory/__stack_pointer
-   local.get $156
+   local.get $164
    i32.store offset=8
-   local.get $156
+   local.get $164
    call $~lib/date/Date#get:year
    local.get $99
-   local.set $156
+   local.set $164
    global.get $~lib/memory/__stack_pointer
-   local.get $156
+   local.get $164
    i32.store offset=8
-   local.get $156
+   local.get $164
    call $~lib/date/Date#get:month
    local.get $99
-   local.set $156
+   local.set $164
    global.get $~lib/memory/__stack_pointer
-   local.get $156
+   local.get $164
    i32.store offset=8
-   local.get $156
+   local.get $164
    call $~lib/date/Date#get:day
    call $~lib/date/dayOfWeek
    br $~lib/date/Date#getUTCDay|inlined.0
@@ -10506,25 +11090,25 @@
    local.tee $100
    i32.store offset=176
    local.get $100
-   local.set $156
+   local.set $164
    global.get $~lib/memory/__stack_pointer
-   local.get $156
+   local.get $164
    i32.store offset=8
-   local.get $156
+   local.get $164
    call $~lib/date/Date#get:year
    local.get $100
-   local.set $156
+   local.set $164
    global.get $~lib/memory/__stack_pointer
-   local.get $156
+   local.get $164
    i32.store offset=8
-   local.get $156
+   local.get $164
    call $~lib/date/Date#get:month
    local.get $100
-   local.set $156
+   local.set $164
    global.get $~lib/memory/__stack_pointer
-   local.get $156
+   local.get $164
    i32.store offset=8
-   local.get $156
+   local.get $164
    call $~lib/date/Date#get:day
    call $~lib/date/dayOfWeek
    br $~lib/date/Date#getUTCDay|inlined.1
@@ -10552,25 +11136,25 @@
    local.tee $101
    i32.store offset=180
    local.get $101
-   local.set $156
+   local.set $164
    global.get $~lib/memory/__stack_pointer
-   local.get $156
+   local.get $164
    i32.store offset=8
-   local.get $156
+   local.get $164
    call $~lib/date/Date#get:year
    local.get $101
-   local.set $156
+   local.set $164
    global.get $~lib/memory/__stack_pointer
-   local.get $156
+   local.get $164
    i32.store offset=8
-   local.get $156
+   local.get $164
    call $~lib/date/Date#get:month
    local.get $101
-   local.set $156
+   local.set $164
    global.get $~lib/memory/__stack_pointer
-   local.get $156
+   local.get $164
    i32.store offset=8
-   local.get $156
+   local.get $164
    call $~lib/date/Date#get:day
    call $~lib/date/dayOfWeek
    br $~lib/date/Date#getUTCDay|inlined.2
@@ -10596,25 +11180,25 @@
    local.tee $102
    i32.store offset=184
    local.get $102
-   local.set $156
+   local.set $164
    global.get $~lib/memory/__stack_pointer
-   local.get $156
+   local.get $164
    i32.store offset=8
-   local.get $156
+   local.get $164
    call $~lib/date/Date#get:year
    local.get $102
-   local.set $156
+   local.set $164
    global.get $~lib/memory/__stack_pointer
-   local.get $156
+   local.get $164
    i32.store offset=8
-   local.get $156
+   local.get $164
    call $~lib/date/Date#get:month
    local.get $102
-   local.set $156
+   local.set $164
    global.get $~lib/memory/__stack_pointer
-   local.get $156
+   local.get $164
    i32.store offset=8
-   local.get $156
+   local.get $164
    call $~lib/date/Date#get:day
    call $~lib/date/dayOfWeek
    br $~lib/date/Date#getUTCDay|inlined.3
@@ -10638,25 +11222,25 @@
    local.tee $103
    i32.store offset=188
    local.get $103
-   local.set $156
+   local.set $164
    global.get $~lib/memory/__stack_pointer
-   local.get $156
+   local.get $164
    i32.store offset=8
-   local.get $156
+   local.get $164
    call $~lib/date/Date#get:year
    local.get $103
-   local.set $156
+   local.set $164
    global.get $~lib/memory/__stack_pointer
-   local.get $156
+   local.get $164
    i32.store offset=8
-   local.get $156
+   local.get $164
    call $~lib/date/Date#get:month
    local.get $103
-   local.set $156
+   local.set $164
    global.get $~lib/memory/__stack_pointer
-   local.get $156
+   local.get $164
    i32.store offset=8
-   local.get $156
+   local.get $164
    call $~lib/date/Date#get:day
    call $~lib/date/dayOfWeek
    br $~lib/date/Date#getUTCDay|inlined.4
@@ -10682,25 +11266,25 @@
    local.tee $104
    i32.store offset=192
    local.get $104
-   local.set $156
+   local.set $164
    global.get $~lib/memory/__stack_pointer
-   local.get $156
+   local.get $164
    i32.store offset=8
-   local.get $156
+   local.get $164
    call $~lib/date/Date#get:year
    local.get $104
-   local.set $156
+   local.set $164
    global.get $~lib/memory/__stack_pointer
-   local.get $156
+   local.get $164
    i32.store offset=8
-   local.get $156
+   local.get $164
    call $~lib/date/Date#get:month
    local.get $104
-   local.set $156
+   local.set $164
    global.get $~lib/memory/__stack_pointer
-   local.get $156
+   local.get $164
    i32.store offset=8
-   local.get $156
+   local.get $164
    call $~lib/date/Date#get:day
    call $~lib/date/dayOfWeek
    br $~lib/date/Date#getUTCDay|inlined.5
@@ -10728,25 +11312,25 @@
    local.tee $105
    i32.store offset=196
    local.get $105
-   local.set $156
+   local.set $164
    global.get $~lib/memory/__stack_pointer
-   local.get $156
+   local.get $164
    i32.store offset=8
-   local.get $156
+   local.get $164
    call $~lib/date/Date#get:year
    local.get $105
-   local.set $156
+   local.set $164
    global.get $~lib/memory/__stack_pointer
-   local.get $156
+   local.get $164
    i32.store offset=8
-   local.get $156
+   local.get $164
    call $~lib/date/Date#get:month
    local.get $105
-   local.set $156
+   local.set $164
    global.get $~lib/memory/__stack_pointer
-   local.get $156
+   local.get $164
    i32.store offset=8
-   local.get $156
+   local.get $164
    call $~lib/date/Date#get:day
    call $~lib/date/dayOfWeek
    br $~lib/date/Date#getUTCDay|inlined.6
@@ -10772,25 +11356,25 @@
    local.tee $106
    i32.store offset=200
    local.get $106
-   local.set $156
+   local.set $164
    global.get $~lib/memory/__stack_pointer
-   local.get $156
+   local.get $164
    i32.store offset=8
-   local.get $156
+   local.get $164
    call $~lib/date/Date#get:year
    local.get $106
-   local.set $156
+   local.set $164
    global.get $~lib/memory/__stack_pointer
-   local.get $156
+   local.get $164
    i32.store offset=8
-   local.get $156
+   local.get $164
    call $~lib/date/Date#get:month
    local.get $106
-   local.set $156
+   local.set $164
    global.get $~lib/memory/__stack_pointer
-   local.get $156
+   local.get $164
    i32.store offset=8
-   local.get $156
+   local.get $164
    call $~lib/date/Date#get:day
    call $~lib/date/dayOfWeek
    br $~lib/date/Date#getUTCDay|inlined.7
@@ -10818,11 +11402,11 @@
    local.tee $108
    i32.store offset=208
    local.get $108
-   local.set $156
+   local.set $164
    global.get $~lib/memory/__stack_pointer
-   local.get $156
+   local.get $164
    i32.store offset=8
-   local.get $156
+   local.get $164
    call $~lib/date/Date#get:month
    i32.const 1
    i32.sub
@@ -10840,11 +11424,11 @@
    unreachable
   end
   local.get $107
-  local.set $156
+  local.set $164
   global.get $~lib/memory/__stack_pointer
-  local.get $156
+  local.get $164
   i32.store offset=8
-  local.get $156
+  local.get $164
   i32.const 10
   i32.const 1
   global.set $~argumentsLength
@@ -10856,11 +11440,11 @@
    local.tee $109
    i32.store offset=212
    local.get $109
-   local.set $156
+   local.set $164
    global.get $~lib/memory/__stack_pointer
-   local.get $156
+   local.get $164
    i32.store offset=8
-   local.get $156
+   local.get $164
    call $~lib/date/Date#get:month
    i32.const 1
    i32.sub
@@ -10878,11 +11462,11 @@
    unreachable
   end
   local.get $107
-  local.set $156
+  local.set $164
   global.get $~lib/memory/__stack_pointer
-  local.get $156
+  local.get $164
   i32.store offset=8
-  local.get $156
+  local.get $164
   i32.const 2
   i32.const 1
   global.set $~argumentsLength
@@ -10894,11 +11478,11 @@
    local.tee $110
    i32.store offset=216
    local.get $110
-   local.set $156
+   local.set $164
    global.get $~lib/memory/__stack_pointer
-   local.get $156
+   local.get $164
    i32.store offset=8
-   local.get $156
+   local.get $164
    call $~lib/date/Date#get:month
    i32.const 1
    i32.sub
@@ -10921,11 +11505,11 @@
    local.tee $111
    i32.store offset=220
    local.get $111
-   local.set $156
+   local.set $164
    global.get $~lib/memory/__stack_pointer
-   local.get $156
+   local.get $164
    i32.store offset=8
-   local.get $156
+   local.get $164
    call $~lib/date/Date#get:epochMillis
    br $~lib/date/Date#getTime|inlined.21
   end
@@ -10941,11 +11525,11 @@
    unreachable
   end
   local.get $107
-  local.set $156
+  local.set $164
   global.get $~lib/memory/__stack_pointer
-  local.get $156
+  local.get $164
   i32.store offset=8
-  local.get $156
+  local.get $164
   i32.const 0
   i32.const 1
   global.set $~argumentsLength
@@ -10957,11 +11541,11 @@
    local.tee $112
    i32.store offset=224
    local.get $112
-   local.set $156
+   local.set $164
    global.get $~lib/memory/__stack_pointer
-   local.get $156
+   local.get $164
    i32.store offset=8
-   local.get $156
+   local.get $164
    call $~lib/date/Date#get:epochMillis
    br $~lib/date/Date#getTime|inlined.22
   end
@@ -10977,11 +11561,11 @@
    unreachable
   end
   local.get $107
-  local.set $156
+  local.set $164
   global.get $~lib/memory/__stack_pointer
-  local.get $156
+  local.get $164
   i32.store offset=8
-  local.get $156
+  local.get $164
   i32.const 11
   i32.const 1
   global.set $~argumentsLength
@@ -10993,11 +11577,11 @@
    local.tee $113
    i32.store offset=228
    local.get $113
-   local.set $156
+   local.set $164
    global.get $~lib/memory/__stack_pointer
-   local.get $156
+   local.get $164
    i32.store offset=8
-   local.get $156
+   local.get $164
    call $~lib/date/Date#get:epochMillis
    br $~lib/date/Date#getTime|inlined.23
   end
@@ -11013,11 +11597,11 @@
    unreachable
   end
   local.get $107
-  local.set $156
+  local.set $164
   global.get $~lib/memory/__stack_pointer
-  local.get $156
+  local.get $164
   i32.store offset=8
-  local.get $156
+  local.get $164
   i32.const -1
   i32.const 1
   global.set $~argumentsLength
@@ -11029,11 +11613,11 @@
    local.tee $114
    i32.store offset=232
    local.get $114
-   local.set $156
+   local.set $164
    global.get $~lib/memory/__stack_pointer
-   local.get $156
+   local.get $164
    i32.store offset=8
-   local.get $156
+   local.get $164
    call $~lib/date/Date#get:month
    i32.const 1
    i32.sub
@@ -11056,11 +11640,11 @@
    local.tee $115
    i32.store offset=236
    local.get $115
-   local.set $156
+   local.set $164
    global.get $~lib/memory/__stack_pointer
-   local.get $156
+   local.get $164
    i32.store offset=8
-   local.get $156
+   local.get $164
    call $~lib/date/Date#get:epochMillis
    br $~lib/date/Date#getTime|inlined.24
   end
@@ -11076,11 +11660,11 @@
    unreachable
   end
   local.get $107
-  local.set $156
+  local.set $164
   global.get $~lib/memory/__stack_pointer
-  local.get $156
+  local.get $164
   i32.store offset=8
-  local.get $156
+  local.get $164
   i32.const 12
   i32.const 1
   global.set $~argumentsLength
@@ -11092,11 +11676,11 @@
    local.tee $116
    i32.store offset=240
    local.get $116
-   local.set $156
+   local.set $164
    global.get $~lib/memory/__stack_pointer
-   local.get $156
+   local.get $164
    i32.store offset=8
-   local.get $156
+   local.get $164
    call $~lib/date/Date#get:month
    i32.const 1
    i32.sub
@@ -11119,11 +11703,11 @@
    local.tee $117
    i32.store offset=244
    local.get $117
-   local.set $156
+   local.set $164
    global.get $~lib/memory/__stack_pointer
-   local.get $156
+   local.get $164
    i32.store offset=8
-   local.get $156
+   local.get $164
    call $~lib/date/Date#get:epochMillis
    br $~lib/date/Date#getTime|inlined.25
   end
@@ -11150,11 +11734,11 @@
    local.tee $119
    i32.store offset=252
    local.get $119
-   local.set $156
+   local.set $164
    global.get $~lib/memory/__stack_pointer
-   local.get $156
+   local.get $164
    i32.store offset=8
-   local.get $156
+   local.get $164
    call $~lib/date/Date#get:year
    br $~lib/date/Date#getUTCFullYear|inlined.3
   end
@@ -11170,11 +11754,11 @@
    unreachable
   end
   local.get $118
-  local.set $156
+  local.set $164
   global.get $~lib/memory/__stack_pointer
-  local.get $156
+  local.get $164
   i32.store offset=8
-  local.get $156
+  local.get $164
   i32.const 1976
   call $~lib/date/Date#setUTCFullYear
   block $~lib/date/Date#getUTCFullYear|inlined.4 (result i32)
@@ -11183,11 +11767,11 @@
    local.tee $120
    i32.store offset=256
    local.get $120
-   local.set $156
+   local.set $164
    global.get $~lib/memory/__stack_pointer
-   local.get $156
+   local.get $164
    i32.store offset=8
-   local.get $156
+   local.get $164
    call $~lib/date/Date#get:year
    br $~lib/date/Date#getUTCFullYear|inlined.4
   end
@@ -11203,11 +11787,11 @@
    unreachable
   end
   local.get $118
-  local.set $156
+  local.set $164
   global.get $~lib/memory/__stack_pointer
-  local.get $156
+  local.get $164
   i32.store offset=8
-  local.get $156
+  local.get $164
   i32.const 20212
   call $~lib/date/Date#setUTCFullYear
   block $~lib/date/Date#getUTCFullYear|inlined.5 (result i32)
@@ -11216,11 +11800,11 @@
    local.tee $121
    i32.store offset=260
    local.get $121
-   local.set $156
+   local.set $164
    global.get $~lib/memory/__stack_pointer
-   local.get $156
+   local.get $164
    i32.store offset=8
-   local.get $156
+   local.get $164
    call $~lib/date/Date#get:year
    br $~lib/date/Date#getUTCFullYear|inlined.5
   end
@@ -11236,11 +11820,11 @@
    unreachable
   end
   local.get $118
-  local.set $156
+  local.set $164
   global.get $~lib/memory/__stack_pointer
-  local.get $156
+  local.get $164
   i32.store offset=8
-  local.get $156
+  local.get $164
   i32.const 71
   call $~lib/date/Date#setUTCFullYear
   block $~lib/date/Date#getUTCFullYear|inlined.6 (result i32)
@@ -11249,11 +11833,11 @@
    local.tee $122
    i32.store offset=264
    local.get $122
-   local.set $156
+   local.set $164
    global.get $~lib/memory/__stack_pointer
-   local.get $156
+   local.get $164
    i32.store offset=8
-   local.get $156
+   local.get $164
    call $~lib/date/Date#get:year
    br $~lib/date/Date#getUTCFullYear|inlined.6
   end
@@ -11275,23 +11859,23 @@
   local.tee $123
   i32.store offset=268
   local.get $123
-  local.set $156
+  local.set $164
   global.get $~lib/memory/__stack_pointer
-  local.get $156
+  local.get $164
   i32.store offset=276
-  local.get $156
+  local.get $164
   call $~lib/date/Date#toISOString
-  local.set $156
+  local.set $164
   global.get $~lib/memory/__stack_pointer
-  local.get $156
+  local.get $164
   i32.store offset=8
-  local.get $156
+  local.get $164
   i32.const 2672
-  local.set $156
+  local.set $164
   global.get $~lib/memory/__stack_pointer
-  local.get $156
+  local.get $164
   i32.store offset=272
-  local.get $156
+  local.get $164
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -11311,23 +11895,23 @@
   local.tee $123
   i32.store offset=268
   local.get $123
-  local.set $156
+  local.set $164
   global.get $~lib/memory/__stack_pointer
-  local.get $156
+  local.get $164
   i32.store offset=276
-  local.get $156
+  local.get $164
   call $~lib/date/Date#toISOString
-  local.set $156
+  local.set $164
   global.get $~lib/memory/__stack_pointer
-  local.get $156
+  local.get $164
   i32.store offset=8
-  local.get $156
+  local.get $164
   i32.const 2752
-  local.set $156
+  local.set $164
   global.get $~lib/memory/__stack_pointer
-  local.get $156
+  local.get $164
   i32.store offset=272
-  local.get $156
+  local.get $164
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -11345,23 +11929,23 @@
   local.tee $123
   i32.store offset=268
   local.get $123
-  local.set $156
+  local.set $164
   global.get $~lib/memory/__stack_pointer
-  local.get $156
+  local.get $164
   i32.store offset=276
-  local.get $156
+  local.get $164
   call $~lib/date/Date#toISOString
-  local.set $156
+  local.set $164
   global.get $~lib/memory/__stack_pointer
-  local.get $156
+  local.get $164
   i32.store offset=8
-  local.get $156
+  local.get $164
   i32.const 2832
-  local.set $156
+  local.set $164
   global.get $~lib/memory/__stack_pointer
-  local.get $156
+  local.get $164
   i32.store offset=272
-  local.get $156
+  local.get $164
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -11379,23 +11963,23 @@
   local.tee $123
   i32.store offset=268
   local.get $123
-  local.set $156
+  local.set $164
   global.get $~lib/memory/__stack_pointer
-  local.get $156
+  local.get $164
   i32.store offset=276
-  local.get $156
+  local.get $164
   call $~lib/date/Date#toISOString
-  local.set $156
+  local.set $164
   global.get $~lib/memory/__stack_pointer
-  local.get $156
+  local.get $164
   i32.store offset=8
-  local.get $156
+  local.get $164
   i32.const 2912
-  local.set $156
+  local.set $164
   global.get $~lib/memory/__stack_pointer
-  local.get $156
+  local.get $164
   i32.store offset=272
-  local.get $156
+  local.get $164
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -11413,23 +11997,23 @@
   local.tee $123
   i32.store offset=268
   local.get $123
-  local.set $156
+  local.set $164
   global.get $~lib/memory/__stack_pointer
-  local.get $156
+  local.get $164
   i32.store offset=276
-  local.get $156
+  local.get $164
   call $~lib/date/Date#toISOString
-  local.set $156
+  local.set $164
   global.get $~lib/memory/__stack_pointer
-  local.get $156
+  local.get $164
   i32.store offset=8
-  local.get $156
+  local.get $164
   i32.const 2992
-  local.set $156
+  local.set $164
   global.get $~lib/memory/__stack_pointer
-  local.get $156
+  local.get $164
   i32.store offset=272
-  local.get $156
+  local.get $164
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -11447,23 +12031,23 @@
   local.tee $123
   i32.store offset=268
   local.get $123
-  local.set $156
+  local.set $164
   global.get $~lib/memory/__stack_pointer
-  local.get $156
+  local.get $164
   i32.store offset=276
-  local.get $156
+  local.get $164
   call $~lib/date/Date#toISOString
-  local.set $156
+  local.set $164
   global.get $~lib/memory/__stack_pointer
-  local.get $156
+  local.get $164
   i32.store offset=8
-  local.get $156
+  local.get $164
   i32.const 3072
-  local.set $156
+  local.set $164
   global.get $~lib/memory/__stack_pointer
-  local.get $156
+  local.get $164
   i32.store offset=272
-  local.get $156
+  local.get $164
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -11481,23 +12065,23 @@
   local.tee $123
   i32.store offset=268
   local.get $123
-  local.set $156
+  local.set $164
   global.get $~lib/memory/__stack_pointer
-  local.get $156
+  local.get $164
   i32.store offset=276
-  local.get $156
+  local.get $164
   call $~lib/date/Date#toISOString
-  local.set $156
+  local.set $164
   global.get $~lib/memory/__stack_pointer
-  local.get $156
+  local.get $164
   i32.store offset=8
-  local.get $156
+  local.get $164
   i32.const 3152
-  local.set $156
+  local.set $164
   global.get $~lib/memory/__stack_pointer
-  local.get $156
+  local.get $164
   i32.store offset=272
-  local.get $156
+  local.get $164
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -11515,23 +12099,23 @@
   local.tee $123
   i32.store offset=268
   local.get $123
-  local.set $156
+  local.set $164
   global.get $~lib/memory/__stack_pointer
-  local.get $156
+  local.get $164
   i32.store offset=276
-  local.get $156
+  local.get $164
   call $~lib/date/Date#toISOString
-  local.set $156
+  local.set $164
   global.get $~lib/memory/__stack_pointer
-  local.get $156
+  local.get $164
   i32.store offset=8
-  local.get $156
+  local.get $164
   i32.const 3232
-  local.set $156
+  local.set $164
   global.get $~lib/memory/__stack_pointer
-  local.get $156
+  local.get $164
   i32.store offset=272
-  local.get $156
+  local.get $164
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -11549,23 +12133,23 @@
   local.tee $123
   i32.store offset=268
   local.get $123
-  local.set $156
+  local.set $164
   global.get $~lib/memory/__stack_pointer
-  local.get $156
+  local.get $164
   i32.store offset=276
-  local.get $156
+  local.get $164
   call $~lib/date/Date#toISOString
-  local.set $156
+  local.set $164
   global.get $~lib/memory/__stack_pointer
-  local.get $156
+  local.get $164
   i32.store offset=8
-  local.get $156
+  local.get $164
   i32.const 3312
-  local.set $156
+  local.set $164
   global.get $~lib/memory/__stack_pointer
-  local.get $156
+  local.get $164
   i32.store offset=272
-  local.get $156
+  local.get $164
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -11583,23 +12167,23 @@
   local.tee $124
   i32.store offset=280
   local.get $124
-  local.set $156
+  local.set $164
   global.get $~lib/memory/__stack_pointer
-  local.get $156
+  local.get $164
   i32.store offset=276
-  local.get $156
+  local.get $164
   call $~lib/date/Date#toDateString
-  local.set $156
+  local.set $164
   global.get $~lib/memory/__stack_pointer
-  local.get $156
+  local.get $164
   i32.store offset=8
-  local.get $156
+  local.get $164
   i32.const 4240
-  local.set $156
+  local.set $164
   global.get $~lib/memory/__stack_pointer
-  local.get $156
+  local.get $164
   i32.store offset=272
-  local.get $156
+  local.get $164
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -11617,23 +12201,23 @@
   local.tee $124
   i32.store offset=280
   local.get $124
-  local.set $156
+  local.set $164
   global.get $~lib/memory/__stack_pointer
-  local.get $156
+  local.get $164
   i32.store offset=276
-  local.get $156
+  local.get $164
   call $~lib/date/Date#toDateString
-  local.set $156
+  local.set $164
   global.get $~lib/memory/__stack_pointer
-  local.get $156
+  local.get $164
   i32.store offset=8
-  local.get $156
+  local.get $164
   i32.const 4304
-  local.set $156
+  local.set $164
   global.get $~lib/memory/__stack_pointer
-  local.get $156
+  local.get $164
   i32.store offset=272
-  local.get $156
+  local.get $164
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -11651,23 +12235,23 @@
   local.tee $124
   i32.store offset=280
   local.get $124
-  local.set $156
+  local.set $164
   global.get $~lib/memory/__stack_pointer
-  local.get $156
+  local.get $164
   i32.store offset=276
-  local.get $156
+  local.get $164
   call $~lib/date/Date#toDateString
-  local.set $156
+  local.set $164
   global.get $~lib/memory/__stack_pointer
-  local.get $156
+  local.get $164
   i32.store offset=8
-  local.get $156
+  local.get $164
   i32.const 4368
-  local.set $156
+  local.set $164
   global.get $~lib/memory/__stack_pointer
-  local.get $156
+  local.get $164
   i32.store offset=272
-  local.get $156
+  local.get $164
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -11685,23 +12269,23 @@
   local.tee $125
   i32.store offset=284
   local.get $125
-  local.set $156
+  local.set $164
   global.get $~lib/memory/__stack_pointer
-  local.get $156
+  local.get $164
   i32.store offset=276
-  local.get $156
+  local.get $164
   call $~lib/date/Date#toTimeString
-  local.set $156
+  local.set $164
   global.get $~lib/memory/__stack_pointer
-  local.get $156
+  local.get $164
   i32.store offset=8
-  local.get $156
+  local.get $164
   i32.const 4480
-  local.set $156
+  local.set $164
   global.get $~lib/memory/__stack_pointer
-  local.get $156
+  local.get $164
   i32.store offset=272
-  local.get $156
+  local.get $164
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -11719,23 +12303,23 @@
   local.tee $125
   i32.store offset=284
   local.get $125
-  local.set $156
+  local.set $164
   global.get $~lib/memory/__stack_pointer
-  local.get $156
+  local.get $164
   i32.store offset=276
-  local.get $156
+  local.get $164
   call $~lib/date/Date#toTimeString
-  local.set $156
+  local.set $164
   global.get $~lib/memory/__stack_pointer
-  local.get $156
+  local.get $164
   i32.store offset=8
-  local.get $156
+  local.get $164
   i32.const 4528
-  local.set $156
+  local.set $164
   global.get $~lib/memory/__stack_pointer
-  local.get $156
+  local.get $164
   i32.store offset=272
-  local.get $156
+  local.get $164
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -11753,23 +12337,23 @@
   local.tee $126
   i32.store offset=288
   local.get $126
-  local.set $156
+  local.set $164
   global.get $~lib/memory/__stack_pointer
-  local.get $156
+  local.get $164
   i32.store offset=276
-  local.get $156
+  local.get $164
   call $~lib/date/Date#toUTCString
-  local.set $156
+  local.set $164
   global.get $~lib/memory/__stack_pointer
-  local.get $156
+  local.get $164
   i32.store offset=8
-  local.get $156
+  local.get $164
   i32.const 5424
-  local.set $156
+  local.set $164
   global.get $~lib/memory/__stack_pointer
-  local.get $156
+  local.get $164
   i32.store offset=272
-  local.get $156
+  local.get $164
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -11787,23 +12371,23 @@
   local.tee $126
   i32.store offset=288
   local.get $126
-  local.set $156
+  local.set $164
   global.get $~lib/memory/__stack_pointer
-  local.get $156
+  local.get $164
   i32.store offset=276
-  local.get $156
+  local.get $164
   call $~lib/date/Date#toUTCString
-  local.set $156
+  local.set $164
   global.get $~lib/memory/__stack_pointer
-  local.get $156
+  local.get $164
   i32.store offset=8
-  local.get $156
+  local.get $164
   i32.const 5504
-  local.set $156
+  local.set $164
   global.get $~lib/memory/__stack_pointer
-  local.get $156
+  local.get $164
   i32.store offset=272
-  local.get $156
+  local.get $164
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -11821,23 +12405,23 @@
   local.tee $126
   i32.store offset=288
   local.get $126
-  local.set $156
+  local.set $164
   global.get $~lib/memory/__stack_pointer
-  local.get $156
+  local.get $164
   i32.store offset=276
-  local.get $156
+  local.get $164
   call $~lib/date/Date#toUTCString
-  local.set $156
+  local.set $164
   global.get $~lib/memory/__stack_pointer
-  local.get $156
+  local.get $164
   i32.store offset=8
-  local.get $156
+  local.get $164
   i32.const 5584
-  local.set $156
+  local.set $164
   global.get $~lib/memory/__stack_pointer
-  local.get $156
+  local.get $164
   i32.store offset=272
-  local.get $156
+  local.get $164
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -11850,11 +12434,11 @@
   end
   global.get $~lib/memory/__stack_pointer
   i32.const 5664
-  local.set $156
+  local.set $164
   global.get $~lib/memory/__stack_pointer
-  local.get $156
+  local.get $164
   i32.store offset=8
-  local.get $156
+  local.get $164
   call $~lib/date/Date.fromString
   local.tee $127
   i32.store offset=292
@@ -11864,11 +12448,11 @@
    local.tee $128
    i32.store offset=296
    local.get $128
-   local.set $156
+   local.set $164
    global.get $~lib/memory/__stack_pointer
-   local.get $156
+   local.get $164
    i32.store offset=8
-   local.get $156
+   local.get $164
    call $~lib/date/Date#get:epochMillis
    br $~lib/date/Date#getTime|inlined.26
   end
@@ -11885,11 +12469,11 @@
   end
   global.get $~lib/memory/__stack_pointer
   i32.const 5936
-  local.set $156
+  local.set $164
   global.get $~lib/memory/__stack_pointer
-  local.get $156
+  local.get $164
   i32.store offset=8
-  local.get $156
+  local.get $164
   call $~lib/date/Date.fromString
   local.tee $127
   i32.store offset=292
@@ -11899,11 +12483,11 @@
    local.tee $129
    i32.store offset=300
    local.get $129
-   local.set $156
+   local.set $164
    global.get $~lib/memory/__stack_pointer
-   local.get $156
+   local.get $164
    i32.store offset=8
-   local.get $156
+   local.get $164
    call $~lib/date/Date#get:epochMillis
    br $~lib/date/Date#getTime|inlined.27
   end
@@ -11920,11 +12504,11 @@
   end
   global.get $~lib/memory/__stack_pointer
   i32.const 5984
-  local.set $156
+  local.set $164
   global.get $~lib/memory/__stack_pointer
-  local.get $156
+  local.get $164
   i32.store offset=8
-  local.get $156
+  local.get $164
   call $~lib/date/Date.fromString
   local.tee $127
   i32.store offset=292
@@ -11934,11 +12518,11 @@
    local.tee $130
    i32.store offset=304
    local.get $130
-   local.set $156
+   local.set $164
    global.get $~lib/memory/__stack_pointer
-   local.get $156
+   local.get $164
    i32.store offset=8
-   local.get $156
+   local.get $164
    call $~lib/date/Date#get:epochMillis
    br $~lib/date/Date#getTime|inlined.28
   end
@@ -11955,11 +12539,11 @@
   end
   global.get $~lib/memory/__stack_pointer
   i32.const 6032
-  local.set $156
+  local.set $164
   global.get $~lib/memory/__stack_pointer
-  local.get $156
+  local.get $164
   i32.store offset=8
-  local.get $156
+  local.get $164
   call $~lib/date/Date.fromString
   local.tee $127
   i32.store offset=292
@@ -11969,11 +12553,11 @@
    local.tee $131
    i32.store offset=308
    local.get $131
-   local.set $156
+   local.set $164
    global.get $~lib/memory/__stack_pointer
-   local.get $156
+   local.get $164
    i32.store offset=8
-   local.get $156
+   local.get $164
    call $~lib/date/Date#get:epochMillis
    br $~lib/date/Date#getTime|inlined.29
   end
@@ -11990,11 +12574,11 @@
   end
   global.get $~lib/memory/__stack_pointer
   i32.const 6096
-  local.set $156
+  local.set $164
   global.get $~lib/memory/__stack_pointer
-  local.get $156
+  local.get $164
   i32.store offset=8
-  local.get $156
+  local.get $164
   call $~lib/date/Date.fromString
   local.tee $127
   i32.store offset=292
@@ -12004,11 +12588,11 @@
    local.tee $132
    i32.store offset=312
    local.get $132
-   local.set $156
+   local.set $164
    global.get $~lib/memory/__stack_pointer
-   local.get $156
+   local.get $164
    i32.store offset=8
-   local.get $156
+   local.get $164
    call $~lib/date/Date#get:epochMillis
    br $~lib/date/Date#getTime|inlined.30
   end
@@ -12025,11 +12609,11 @@
   end
   global.get $~lib/memory/__stack_pointer
   i32.const 6176
-  local.set $156
+  local.set $164
   global.get $~lib/memory/__stack_pointer
-  local.get $156
+  local.get $164
   i32.store offset=8
-  local.get $156
+  local.get $164
   call $~lib/date/Date.fromString
   local.tee $127
   i32.store offset=292
@@ -12039,11 +12623,11 @@
    local.tee $133
    i32.store offset=316
    local.get $133
-   local.set $156
+   local.set $164
    global.get $~lib/memory/__stack_pointer
-   local.get $156
+   local.get $164
    i32.store offset=8
-   local.get $156
+   local.get $164
    call $~lib/date/Date#get:epochMillis
    br $~lib/date/Date#getTime|inlined.31
   end
@@ -12060,11 +12644,11 @@
   end
   global.get $~lib/memory/__stack_pointer
   i32.const 6256
-  local.set $156
+  local.set $164
   global.get $~lib/memory/__stack_pointer
-  local.get $156
+  local.get $164
   i32.store offset=8
-  local.get $156
+  local.get $164
   call $~lib/date/Date.fromString
   local.tee $127
   i32.store offset=292
@@ -12074,32 +12658,32 @@
    local.tee $134
    i32.store offset=320
    local.get $134
-   local.set $156
+   local.set $164
    global.get $~lib/memory/__stack_pointer
-   local.get $156
+   local.get $164
    i32.store offset=8
-   local.get $156
+   local.get $164
    call $~lib/date/Date#get:epochMillis
    br $~lib/date/Date#getTime|inlined.32
   end
-  i64.const -62167219200000
+  i64.const 192141296456
   i64.eq
   i32.eqz
   if
    i32.const 0
    i32.const 128
-   i32.const 310
+   i32.const 311
    i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
   global.get $~lib/memory/__stack_pointer
-  i32.const 6288
-  local.set $156
+  i32.const 6336
+  local.set $164
   global.get $~lib/memory/__stack_pointer
-  local.get $156
+  local.get $164
   i32.store offset=8
-  local.get $156
+  local.get $164
   call $~lib/date/Date.fromString
   local.tee $127
   i32.store offset=292
@@ -12109,32 +12693,32 @@
    local.tee $135
    i32.store offset=324
    local.get $135
-   local.set $156
+   local.set $164
    global.get $~lib/memory/__stack_pointer
-   local.get $156
+   local.get $164
    i32.store offset=8
-   local.get $156
+   local.get $164
    call $~lib/date/Date#get:epochMillis
    br $~lib/date/Date#getTime|inlined.33
   end
-  i64.const -62135596800000
+  i64.const 192092696456
   i64.eq
   i32.eqz
   if
    i32.const 0
    i32.const 128
-   i32.const 313
+   i32.const 315
    i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
   global.get $~lib/memory/__stack_pointer
-  i32.const 6320
-  local.set $156
+  i32.const 6416
+  local.set $164
   global.get $~lib/memory/__stack_pointer
-  local.get $156
+  local.get $164
   i32.store offset=8
-  local.get $156
+  local.get $164
   call $~lib/date/Date.fromString
   local.tee $127
   i32.store offset=292
@@ -12144,50 +12728,15 @@
    local.tee $136
    i32.store offset=328
    local.get $136
-   local.set $156
+   local.set $164
    global.get $~lib/memory/__stack_pointer
-   local.get $156
+   local.get $164
    i32.store offset=8
-   local.get $156
+   local.get $164
    call $~lib/date/Date#get:epochMillis
    br $~lib/date/Date#getTime|inlined.34
   end
-  i64.const 189302400000
-  i64.eq
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 128
-   i32.const 316
-   i32.const 3
-   call $~lib/builtins/abort
-   unreachable
-  end
-  global.get $~lib/memory/__stack_pointer
-  i32.const 6352
-  local.set $156
-  global.get $~lib/memory/__stack_pointer
-  local.get $156
-  i32.store offset=8
-  local.get $156
-  call $~lib/date/Date.fromString
-  local.tee $127
-  i32.store offset=292
-  block $~lib/date/Date#getTime|inlined.35 (result i64)
-   global.get $~lib/memory/__stack_pointer
-   local.get $127
-   local.tee $137
-   i32.store offset=332
-   local.get $137
-   local.set $156
-   global.get $~lib/memory/__stack_pointer
-   local.get $156
-   i32.store offset=8
-   local.get $156
-   call $~lib/date/Date#get:epochMillis
-   br $~lib/date/Date#getTime|inlined.35
-  end
-  i64.const 191980800000
+  i64.const 192112496450
   i64.eq
   i32.eqz
   if
@@ -12199,12 +12748,47 @@
    unreachable
   end
   global.get $~lib/memory/__stack_pointer
-  i32.const 5664
-  local.set $156
+  i32.const 6480
+  local.set $164
   global.get $~lib/memory/__stack_pointer
-  local.get $156
+  local.get $164
   i32.store offset=8
-  local.get $156
+  local.get $164
+  call $~lib/date/Date.fromString
+  local.tee $127
+  i32.store offset=292
+  block $~lib/date/Date#getTime|inlined.35 (result i64)
+   global.get $~lib/memory/__stack_pointer
+   local.get $127
+   local.tee $137
+   i32.store offset=332
+   local.get $137
+   local.set $164
+   global.get $~lib/memory/__stack_pointer
+   local.get $164
+   i32.store offset=8
+   local.get $164
+   call $~lib/date/Date#get:epochMillis
+   br $~lib/date/Date#getTime|inlined.35
+  end
+  i64.const 192112496450
+  i64.eq
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 128
+   i32.const 323
+   i32.const 3
+   call $~lib/builtins/abort
+   unreachable
+  end
+  global.get $~lib/memory/__stack_pointer
+  i32.const 6560
+  local.set $164
+  global.get $~lib/memory/__stack_pointer
+  local.get $164
+  i32.store offset=8
+  local.get $164
   call $~lib/date/Date.fromString
   local.tee $127
   i32.store offset=292
@@ -12214,32 +12798,32 @@
    local.tee $138
    i32.store offset=336
    local.get $138
-   local.set $156
+   local.set $164
    global.get $~lib/memory/__stack_pointer
-   local.get $156
+   local.get $164
    i32.store offset=8
-   local.get $156
+   local.get $164
    call $~lib/date/Date#get:epochMillis
    br $~lib/date/Date#getTime|inlined.36
   end
-  i64.const 192067200000
+  i64.const 192112496450
   i64.eq
   i32.eqz
   if
    i32.const 0
    i32.const 128
-   i32.const 322
+   i32.const 327
    i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
   global.get $~lib/memory/__stack_pointer
-  i32.const 6400
-  local.set $156
+  i32.const 6640
+  local.set $164
   global.get $~lib/memory/__stack_pointer
-  local.get $156
+  local.get $164
   i32.store offset=8
-  local.get $156
+  local.get $164
   call $~lib/date/Date.fromString
   local.tee $127
   i32.store offset=292
@@ -12249,32 +12833,32 @@
    local.tee $139
    i32.store offset=340
    local.get $139
-   local.set $156
+   local.set $164
    global.get $~lib/memory/__stack_pointer
-   local.get $156
+   local.get $164
    i32.store offset=8
-   local.get $156
+   local.get $164
    call $~lib/date/Date#get:epochMillis
    br $~lib/date/Date#getTime|inlined.37
   end
-  i64.const 192112440000
+  i64.const 192112496456
   i64.eq
   i32.eqz
   if
    i32.const 0
    i32.const 128
-   i32.const 325
+   i32.const 331
    i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
   global.get $~lib/memory/__stack_pointer
-  i32.const 6032
-  local.set $156
+  i32.const 6720
+  local.set $164
   global.get $~lib/memory/__stack_pointer
-  local.get $156
+  local.get $164
   i32.store offset=8
-  local.get $156
+  local.get $164
   call $~lib/date/Date.fromString
   local.tee $127
   i32.store offset=292
@@ -12284,13 +12868,293 @@
    local.tee $140
    i32.store offset=344
    local.get $140
-   local.set $156
+   local.set $164
    global.get $~lib/memory/__stack_pointer
-   local.get $156
+   local.get $164
    i32.store offset=8
-   local.get $156
+   local.get $164
    call $~lib/date/Date#get:epochMillis
    br $~lib/date/Date#getTime|inlined.38
+  end
+  i64.const 192112496456
+  i64.eq
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 128
+   i32.const 335
+   i32.const 3
+   call $~lib/builtins/abort
+   unreachable
+  end
+  global.get $~lib/memory/__stack_pointer
+  i32.const 6800
+  local.set $164
+  global.get $~lib/memory/__stack_pointer
+  local.get $164
+  i32.store offset=8
+  local.get $164
+  call $~lib/date/Date.fromString
+  local.tee $127
+  i32.store offset=292
+  block $~lib/date/Date#getTime|inlined.39 (result i64)
+   global.get $~lib/memory/__stack_pointer
+   local.get $127
+   local.tee $141
+   i32.store offset=348
+   local.get $141
+   local.set $164
+   global.get $~lib/memory/__stack_pointer
+   local.get $164
+   i32.store offset=8
+   local.get $164
+   call $~lib/date/Date#get:epochMillis
+   br $~lib/date/Date#getTime|inlined.39
+  end
+  i64.const 192112496456
+  i64.eq
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 128
+   i32.const 339
+   i32.const 3
+   call $~lib/builtins/abort
+   unreachable
+  end
+  global.get $~lib/memory/__stack_pointer
+  i32.const 6896
+  local.set $164
+  global.get $~lib/memory/__stack_pointer
+  local.get $164
+  i32.store offset=8
+  local.get $164
+  call $~lib/date/Date.fromString
+  local.tee $127
+  i32.store offset=292
+  block $~lib/date/Date#getTime|inlined.40 (result i64)
+   global.get $~lib/memory/__stack_pointer
+   local.get $127
+   local.tee $142
+   i32.store offset=352
+   local.get $142
+   local.set $164
+   global.get $~lib/memory/__stack_pointer
+   local.get $164
+   i32.store offset=8
+   local.get $164
+   call $~lib/date/Date#get:epochMillis
+   br $~lib/date/Date#getTime|inlined.40
+  end
+  i64.const -62167219200000
+  i64.eq
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 128
+   i32.const 342
+   i32.const 3
+   call $~lib/builtins/abort
+   unreachable
+  end
+  global.get $~lib/memory/__stack_pointer
+  i32.const 6928
+  local.set $164
+  global.get $~lib/memory/__stack_pointer
+  local.get $164
+  i32.store offset=8
+  local.get $164
+  call $~lib/date/Date.fromString
+  local.tee $127
+  i32.store offset=292
+  block $~lib/date/Date#getTime|inlined.41 (result i64)
+   global.get $~lib/memory/__stack_pointer
+   local.get $127
+   local.tee $143
+   i32.store offset=356
+   local.get $143
+   local.set $164
+   global.get $~lib/memory/__stack_pointer
+   local.get $164
+   i32.store offset=8
+   local.get $164
+   call $~lib/date/Date#get:epochMillis
+   br $~lib/date/Date#getTime|inlined.41
+  end
+  i64.const -62135596800000
+  i64.eq
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 128
+   i32.const 345
+   i32.const 3
+   call $~lib/builtins/abort
+   unreachable
+  end
+  global.get $~lib/memory/__stack_pointer
+  i32.const 6960
+  local.set $164
+  global.get $~lib/memory/__stack_pointer
+  local.get $164
+  i32.store offset=8
+  local.get $164
+  call $~lib/date/Date.fromString
+  local.tee $127
+  i32.store offset=292
+  block $~lib/date/Date#getTime|inlined.42 (result i64)
+   global.get $~lib/memory/__stack_pointer
+   local.get $127
+   local.tee $144
+   i32.store offset=360
+   local.get $144
+   local.set $164
+   global.get $~lib/memory/__stack_pointer
+   local.get $164
+   i32.store offset=8
+   local.get $164
+   call $~lib/date/Date#get:epochMillis
+   br $~lib/date/Date#getTime|inlined.42
+  end
+  i64.const 189302400000
+  i64.eq
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 128
+   i32.const 348
+   i32.const 3
+   call $~lib/builtins/abort
+   unreachable
+  end
+  global.get $~lib/memory/__stack_pointer
+  i32.const 6992
+  local.set $164
+  global.get $~lib/memory/__stack_pointer
+  local.get $164
+  i32.store offset=8
+  local.get $164
+  call $~lib/date/Date.fromString
+  local.tee $127
+  i32.store offset=292
+  block $~lib/date/Date#getTime|inlined.43 (result i64)
+   global.get $~lib/memory/__stack_pointer
+   local.get $127
+   local.tee $145
+   i32.store offset=364
+   local.get $145
+   local.set $164
+   global.get $~lib/memory/__stack_pointer
+   local.get $164
+   i32.store offset=8
+   local.get $164
+   call $~lib/date/Date#get:epochMillis
+   br $~lib/date/Date#getTime|inlined.43
+  end
+  i64.const 191980800000
+  i64.eq
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 128
+   i32.const 351
+   i32.const 3
+   call $~lib/builtins/abort
+   unreachable
+  end
+  global.get $~lib/memory/__stack_pointer
+  i32.const 5664
+  local.set $164
+  global.get $~lib/memory/__stack_pointer
+  local.get $164
+  i32.store offset=8
+  local.get $164
+  call $~lib/date/Date.fromString
+  local.tee $127
+  i32.store offset=292
+  block $~lib/date/Date#getTime|inlined.44 (result i64)
+   global.get $~lib/memory/__stack_pointer
+   local.get $127
+   local.tee $146
+   i32.store offset=368
+   local.get $146
+   local.set $164
+   global.get $~lib/memory/__stack_pointer
+   local.get $164
+   i32.store offset=8
+   local.get $164
+   call $~lib/date/Date#get:epochMillis
+   br $~lib/date/Date#getTime|inlined.44
+  end
+  i64.const 192067200000
+  i64.eq
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 128
+   i32.const 354
+   i32.const 3
+   call $~lib/builtins/abort
+   unreachable
+  end
+  global.get $~lib/memory/__stack_pointer
+  i32.const 7040
+  local.set $164
+  global.get $~lib/memory/__stack_pointer
+  local.get $164
+  i32.store offset=8
+  local.get $164
+  call $~lib/date/Date.fromString
+  local.tee $127
+  i32.store offset=292
+  block $~lib/date/Date#getTime|inlined.45 (result i64)
+   global.get $~lib/memory/__stack_pointer
+   local.get $127
+   local.tee $147
+   i32.store offset=372
+   local.get $147
+   local.set $164
+   global.get $~lib/memory/__stack_pointer
+   local.get $164
+   i32.store offset=8
+   local.get $164
+   call $~lib/date/Date#get:epochMillis
+   br $~lib/date/Date#getTime|inlined.45
+  end
+  i64.const 192112440000
+  i64.eq
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 128
+   i32.const 357
+   i32.const 3
+   call $~lib/builtins/abort
+   unreachable
+  end
+  global.get $~lib/memory/__stack_pointer
+  i32.const 6032
+  local.set $164
+  global.get $~lib/memory/__stack_pointer
+  local.get $164
+  i32.store offset=8
+  local.get $164
+  call $~lib/date/Date.fromString
+  local.tee $127
+  i32.store offset=292
+  block $~lib/date/Date#getTime|inlined.46 (result i64)
+   global.get $~lib/memory/__stack_pointer
+   local.get $127
+   local.tee $148
+   i32.store offset=376
+   local.get $148
+   local.set $164
+   global.get $~lib/memory/__stack_pointer
+   local.get $164
+   i32.store offset=8
+   local.get $164
+   call $~lib/date/Date#get:epochMillis
+   br $~lib/date/Date#getTime|inlined.46
   end
   i64.const 192112496000
   i64.eq
@@ -12298,7 +13162,7 @@
   if
    i32.const 0
    i32.const 128
-   i32.const 328
+   i32.const 360
    i32.const 3
    call $~lib/builtins/abort
    unreachable
@@ -12307,27 +13171,27 @@
   i32.const 0
   i64.const -8640000000000000
   call $~lib/date/Date#constructor
-  local.tee $141
-  i32.store offset=348
+  local.tee $149
+  i32.store offset=380
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   i64.const 8640000000000000
   call $~lib/date/Date#constructor
-  local.tee $142
-  i32.store offset=352
-  block $~lib/date/Date#getTime|inlined.39 (result i64)
+  local.tee $150
+  i32.store offset=384
+  block $~lib/date/Date#getTime|inlined.47 (result i64)
    global.get $~lib/memory/__stack_pointer
-   local.get $141
-   local.tee $143
-   i32.store offset=356
-   local.get $143
-   local.set $156
+   local.get $149
+   local.tee $151
+   i32.store offset=388
+   local.get $151
+   local.set $164
    global.get $~lib/memory/__stack_pointer
-   local.get $156
+   local.get $164
    i32.store offset=8
-   local.get $156
+   local.get $164
    call $~lib/date/Date#get:epochMillis
-   br $~lib/date/Date#getTime|inlined.39
+   br $~lib/date/Date#getTime|inlined.47
   end
   i64.const -8640000000000000
   i64.eq
@@ -12335,24 +13199,24 @@
   if
    i32.const 0
    i32.const 128
-   i32.const 346
+   i32.const 378
    i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
-  block $~lib/date/Date#getTime|inlined.40 (result i64)
+  block $~lib/date/Date#getTime|inlined.48 (result i64)
    global.get $~lib/memory/__stack_pointer
-   local.get $142
-   local.tee $144
-   i32.store offset=360
-   local.get $144
-   local.set $156
+   local.get $150
+   local.tee $152
+   i32.store offset=392
+   local.get $152
+   local.set $164
    global.get $~lib/memory/__stack_pointer
-   local.get $156
+   local.get $164
    i32.store offset=8
-   local.get $156
+   local.get $164
    call $~lib/date/Date#get:epochMillis
-   br $~lib/date/Date#getTime|inlined.40
+   br $~lib/date/Date#getTime|inlined.48
   end
   i64.const 8640000000000000
   i64.eq
@@ -12360,22 +13224,22 @@
   if
    i32.const 0
    i32.const 128
-   i32.const 347
+   i32.const 379
    i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
   block $~lib/date/Date#getUTCFullYear|inlined.7 (result i32)
    global.get $~lib/memory/__stack_pointer
-   local.get $141
-   local.tee $145
-   i32.store offset=364
-   local.get $145
-   local.set $156
+   local.get $149
+   local.tee $153
+   i32.store offset=396
+   local.get $153
+   local.set $164
    global.get $~lib/memory/__stack_pointer
-   local.get $156
+   local.get $164
    i32.store offset=8
-   local.get $156
+   local.get $164
    call $~lib/date/Date#get:year
    br $~lib/date/Date#getUTCFullYear|inlined.7
   end
@@ -12385,22 +13249,22 @@
   if
    i32.const 0
    i32.const 128
-   i32.const 349
+   i32.const 381
    i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
   block $~lib/date/Date#getUTCFullYear|inlined.8 (result i32)
    global.get $~lib/memory/__stack_pointer
-   local.get $142
-   local.tee $146
-   i32.store offset=368
-   local.get $146
-   local.set $156
+   local.get $150
+   local.tee $154
+   i32.store offset=400
+   local.get $154
+   local.set $164
    global.get $~lib/memory/__stack_pointer
-   local.get $156
+   local.get $164
    i32.store offset=8
-   local.get $156
+   local.get $164
    call $~lib/date/Date#get:year
    br $~lib/date/Date#getUTCFullYear|inlined.8
   end
@@ -12410,22 +13274,22 @@
   if
    i32.const 0
    i32.const 128
-   i32.const 350
+   i32.const 382
    i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
   block $~lib/date/Date#getUTCMonth|inlined.10 (result i32)
    global.get $~lib/memory/__stack_pointer
-   local.get $141
-   local.tee $147
-   i32.store offset=372
-   local.get $147
-   local.set $156
+   local.get $149
+   local.tee $155
+   i32.store offset=404
+   local.get $155
+   local.set $164
    global.get $~lib/memory/__stack_pointer
-   local.get $156
+   local.get $164
    i32.store offset=8
-   local.get $156
+   local.get $164
    call $~lib/date/Date#get:month
    i32.const 1
    i32.sub
@@ -12437,22 +13301,22 @@
   if
    i32.const 0
    i32.const 128
-   i32.const 352
+   i32.const 384
    i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
   block $~lib/date/Date#getUTCMonth|inlined.11 (result i32)
    global.get $~lib/memory/__stack_pointer
-   local.get $142
-   local.tee $148
-   i32.store offset=376
-   local.get $148
-   local.set $156
+   local.get $150
+   local.tee $156
+   i32.store offset=408
+   local.get $156
+   local.set $164
    global.get $~lib/memory/__stack_pointer
-   local.get $156
+   local.get $164
    i32.store offset=8
-   local.get $156
+   local.get $164
    call $~lib/date/Date#get:month
    i32.const 1
    i32.sub
@@ -12464,22 +13328,22 @@
   if
    i32.const 0
    i32.const 128
-   i32.const 353
+   i32.const 385
    i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
   block $~lib/date/Date#getUTCDate|inlined.5 (result i32)
    global.get $~lib/memory/__stack_pointer
-   local.get $141
-   local.tee $149
-   i32.store offset=380
    local.get $149
-   local.set $156
+   local.tee $157
+   i32.store offset=412
+   local.get $157
+   local.set $164
    global.get $~lib/memory/__stack_pointer
-   local.get $156
+   local.get $164
    i32.store offset=8
-   local.get $156
+   local.get $164
    call $~lib/date/Date#get:day
    br $~lib/date/Date#getUTCDate|inlined.5
   end
@@ -12489,22 +13353,22 @@
   if
    i32.const 0
    i32.const 128
-   i32.const 355
+   i32.const 387
    i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
   block $~lib/date/Date#getUTCDate|inlined.6 (result i32)
    global.get $~lib/memory/__stack_pointer
-   local.get $142
-   local.tee $150
-   i32.store offset=384
    local.get $150
-   local.set $156
+   local.tee $158
+   i32.store offset=416
+   local.get $158
+   local.set $164
    global.get $~lib/memory/__stack_pointer
-   local.get $156
+   local.get $164
    i32.store offset=8
-   local.get $156
+   local.get $164
    call $~lib/date/Date#get:day
    br $~lib/date/Date#getUTCDate|inlined.6
   end
@@ -12514,63 +13378,63 @@
   if
    i32.const 0
    i32.const 128
-   i32.const 356
+   i32.const 388
    i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $141
-  local.set $156
+  local.get $149
+  local.set $164
   global.get $~lib/memory/__stack_pointer
-  local.get $156
+  local.get $164
   i32.store offset=276
-  local.get $156
+  local.get $164
   call $~lib/date/Date#toISOString
-  local.set $156
+  local.set $164
   global.get $~lib/memory/__stack_pointer
-  local.get $156
+  local.get $164
   i32.store offset=8
-  local.get $156
-  i32.const 6464
-  local.set $156
+  local.get $164
+  i32.const 7104
+  local.set $164
   global.get $~lib/memory/__stack_pointer
-  local.get $156
+  local.get $164
   i32.store offset=272
-  local.get $156
+  local.get $164
   call $~lib/string/String.__eq
   i32.eqz
   if
    i32.const 0
    i32.const 128
-   i32.const 358
+   i32.const 390
    i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $142
-  local.set $156
+  local.get $150
+  local.set $164
   global.get $~lib/memory/__stack_pointer
-  local.get $156
+  local.get $164
   i32.store offset=276
-  local.get $156
+  local.get $164
   call $~lib/date/Date#toISOString
-  local.set $156
+  local.set $164
   global.get $~lib/memory/__stack_pointer
-  local.get $156
+  local.get $164
   i32.store offset=8
-  local.get $156
-  i32.const 6544
-  local.set $156
+  local.get $164
+  i32.const 7184
+  local.set $164
   global.get $~lib/memory/__stack_pointer
-  local.get $156
+  local.get $164
   i32.store offset=272
-  local.get $156
+  local.get $164
   call $~lib/string/String.__eq
   i32.eqz
   if
    i32.const 0
    i32.const 128
-   i32.const 359
+   i32.const 391
    i32.const 3
    call $~lib/builtins/abort
    unreachable
@@ -12581,27 +13445,27 @@
   i64.const 1
   i64.sub
   call $~lib/date/Date#constructor
-  local.tee $151
-  i32.store offset=388
+  local.tee $159
+  i32.store offset=420
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   i64.const -8640000000000000
   i64.const 1
   i64.add
   call $~lib/date/Date#constructor
-  local.tee $152
-  i32.store offset=392
+  local.tee $160
+  i32.store offset=424
   block $~lib/date/Date#getUTCFullYear|inlined.9 (result i32)
    global.get $~lib/memory/__stack_pointer
-   local.get $152
-   local.tee $153
-   i32.store offset=396
-   local.get $153
-   local.set $156
+   local.get $160
+   local.tee $161
+   i32.store offset=428
+   local.get $161
+   local.set $164
    global.get $~lib/memory/__stack_pointer
-   local.get $156
+   local.get $164
    i32.store offset=8
-   local.get $156
+   local.get $164
    call $~lib/date/Date#get:year
    br $~lib/date/Date#getUTCFullYear|inlined.9
   end
@@ -12611,22 +13475,22 @@
   if
    i32.const 0
    i32.const 128
-   i32.const 364
+   i32.const 396
    i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
   block $~lib/date/Date#getUTCMonth|inlined.12 (result i32)
    global.get $~lib/memory/__stack_pointer
-   local.get $152
-   local.tee $154
-   i32.store offset=400
-   local.get $154
-   local.set $156
+   local.get $160
+   local.tee $162
+   i32.store offset=432
+   local.get $162
+   local.set $164
    global.get $~lib/memory/__stack_pointer
-   local.get $156
+   local.get $164
    i32.store offset=8
-   local.get $156
+   local.get $164
    call $~lib/date/Date#get:month
    i32.const 1
    i32.sub
@@ -12638,22 +13502,22 @@
   if
    i32.const 0
    i32.const 128
-   i32.const 365
+   i32.const 397
    i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
   block $~lib/date/Date#getUTCDate|inlined.7 (result i32)
    global.get $~lib/memory/__stack_pointer
-   local.get $152
-   local.tee $155
-   i32.store offset=404
-   local.get $155
-   local.set $156
+   local.get $160
+   local.tee $163
+   i32.store offset=436
+   local.get $163
+   local.set $164
    global.get $~lib/memory/__stack_pointer
-   local.get $156
+   local.get $164
    i32.store offset=8
-   local.get $156
+   local.get $164
    call $~lib/date/Date#get:day
    br $~lib/date/Date#getUTCDate|inlined.7
   end
@@ -12663,17 +13527,17 @@
   if
    i32.const 0
    i32.const 128
-   i32.const 366
+   i32.const 398
    i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $152
-  local.set $156
+  local.get $160
+  local.set $164
   global.get $~lib/memory/__stack_pointer
-  local.get $156
+  local.get $164
   i32.store offset=8
-  local.get $156
+  local.get $164
   call $~lib/date/Date#getUTCHours
   i32.const 0
   i32.eq
@@ -12681,17 +13545,17 @@
   if
    i32.const 0
    i32.const 128
-   i32.const 367
+   i32.const 399
    i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $152
-  local.set $156
+  local.get $160
+  local.set $164
   global.get $~lib/memory/__stack_pointer
-  local.get $156
+  local.get $164
   i32.store offset=8
-  local.get $156
+  local.get $164
   call $~lib/date/Date#getUTCMinutes
   i32.const 0
   i32.eq
@@ -12699,17 +13563,17 @@
   if
    i32.const 0
    i32.const 128
-   i32.const 368
+   i32.const 400
    i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $152
-  local.set $156
+  local.get $160
+  local.set $164
   global.get $~lib/memory/__stack_pointer
-  local.get $156
+  local.get $164
   i32.store offset=8
-  local.get $156
+  local.get $164
   call $~lib/date/Date#getUTCSeconds
   i32.const 0
   i32.eq
@@ -12717,17 +13581,17 @@
   if
    i32.const 0
    i32.const 128
-   i32.const 369
+   i32.const 401
    i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $152
-  local.set $156
+  local.get $160
+  local.set $164
   global.get $~lib/memory/__stack_pointer
-  local.get $156
+  local.get $164
   i32.store offset=8
-  local.get $156
+  local.get $164
   call $~lib/date/Date#getUTCMilliseconds
   i32.const 1
   i32.eq
@@ -12735,69 +13599,69 @@
   if
    i32.const 0
    i32.const 128
-   i32.const 370
+   i32.const 402
    i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $151
-  local.set $156
+  local.get $159
+  local.set $164
   global.get $~lib/memory/__stack_pointer
-  local.get $156
+  local.get $164
   i32.store offset=276
-  local.get $156
+  local.get $164
   call $~lib/date/Date#toISOString
-  local.set $156
+  local.set $164
   global.get $~lib/memory/__stack_pointer
-  local.get $156
+  local.get $164
   i32.store offset=8
-  local.get $156
-  i32.const 6624
-  local.set $156
+  local.get $164
+  i32.const 7264
+  local.set $164
   global.get $~lib/memory/__stack_pointer
-  local.get $156
+  local.get $164
   i32.store offset=272
-  local.get $156
+  local.get $164
   call $~lib/string/String.__eq
   i32.eqz
   if
    i32.const 0
    i32.const 128
-   i32.const 372
+   i32.const 404
    i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $152
-  local.set $156
+  local.get $160
+  local.set $164
   global.get $~lib/memory/__stack_pointer
-  local.get $156
+  local.get $164
   i32.store offset=276
-  local.get $156
+  local.get $164
   call $~lib/date/Date#toISOString
-  local.set $156
+  local.set $164
   global.get $~lib/memory/__stack_pointer
-  local.get $156
+  local.get $164
   i32.store offset=8
-  local.get $156
-  i32.const 6704
-  local.set $156
+  local.get $164
+  i32.const 7344
+  local.set $164
   global.get $~lib/memory/__stack_pointer
-  local.get $156
+  local.get $164
   i32.store offset=272
-  local.get $156
+  local.get $164
   call $~lib/string/String.__eq
   i32.eqz
   if
    i32.const 0
    i32.const 128
-   i32.const 373
+   i32.const 405
    i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
   global.get $~lib/memory/__stack_pointer
-  i32.const 408
+  i32.const 440
   i32.add
   global.set $~lib/memory/__stack_pointer
  )

--- a/tests/compiler/std/date.release.wat
+++ b/tests/compiler/std/date.release.wat
@@ -2590,7 +2590,7 @@
   if
    i32.const 1056
    i32.const 1104
-   i32.const 124
+   i32.const 131
    i32.const 35
    call $~lib/builtins/abort
    unreachable
@@ -2650,7 +2650,7 @@
   if
    i32.const 1056
    i32.const 1104
-   i32.const 136
+   i32.const 143
    i32.const 28
    call $~lib/builtins/abort
    unreachable
@@ -5183,6 +5183,310 @@
   global.set $~lib/memory/__stack_pointer
   local.get $0
  )
+ (func $~lib/util/string/strtol<i32> (param $0 i32) (result i32)
+  (local $1 i32)
+  (local $2 i32)
+  (local $3 i32)
+  (local $4 i32)
+  (local $5 i32)
+  (local $6 i32)
+  (local $7 i32)
+  global.get $~lib/memory/__stack_pointer
+  i32.const 4
+  i32.sub
+  global.set $~lib/memory/__stack_pointer
+  global.get $~lib/memory/__stack_pointer
+  i32.const 8468
+  i32.lt_s
+  if
+   i32.const 41264
+   i32.const 41312
+   i32.const 1
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  global.get $~lib/memory/__stack_pointer
+  local.tee $1
+  i32.const 0
+  i32.store
+  local.get $1
+  local.get $0
+  i32.store
+  block $folding-inner0
+   local.get $0
+   i32.const 20
+   i32.sub
+   i32.load offset=16
+   i32.const 1
+   i32.shr_u
+   local.tee $1
+   i32.eqz
+   br_if $folding-inner0
+   local.get $0
+   local.tee $2
+   i32.load16_u
+   local.set $0
+   loop $while-continue|0
+    block $__inlined_func$~lib/util/string/isSpace$164 (result i32)
+     local.get $0
+     i32.const 128
+     i32.or
+     i32.const 160
+     i32.eq
+     local.get $0
+     i32.const 9
+     i32.sub
+     i32.const 4
+     i32.le_u
+     i32.or
+     local.get $0
+     i32.const 5760
+     i32.lt_u
+     br_if $__inlined_func$~lib/util/string/isSpace$164
+     drop
+     i32.const 1
+     local.get $0
+     i32.const -8192
+     i32.add
+     i32.const 10
+     i32.le_u
+     br_if $__inlined_func$~lib/util/string/isSpace$164
+     drop
+     block $break|0
+      block $case0|0
+       local.get $0
+       i32.const 5760
+       i32.eq
+       br_if $case0|0
+       local.get $0
+       i32.const 8232
+       i32.eq
+       br_if $case0|0
+       local.get $0
+       i32.const 8233
+       i32.eq
+       br_if $case0|0
+       local.get $0
+       i32.const 8239
+       i32.eq
+       br_if $case0|0
+       local.get $0
+       i32.const 8287
+       i32.eq
+       br_if $case0|0
+       local.get $0
+       i32.const 12288
+       i32.eq
+       br_if $case0|0
+       local.get $0
+       i32.const 65279
+       i32.eq
+       br_if $case0|0
+       br $break|0
+      end
+      i32.const 1
+      br $__inlined_func$~lib/util/string/isSpace$164
+     end
+     i32.const 0
+    end
+    if
+     local.get $2
+     i32.const 2
+     i32.add
+     local.tee $2
+     i32.load16_u
+     local.set $0
+     local.get $1
+     i32.const 1
+     i32.sub
+     local.set $1
+     br $while-continue|0
+    end
+   end
+   i32.const 1
+   local.set $4
+   local.get $0
+   i32.const 45
+   i32.eq
+   local.tee $6
+   local.get $0
+   i32.const 43
+   i32.eq
+   i32.or
+   if (result i32)
+    local.get $1
+    i32.const 1
+    i32.sub
+    local.tee $1
+    i32.eqz
+    br_if $folding-inner0
+    i32.const -1
+    i32.const 1
+    local.get $6
+    select
+    local.set $4
+    local.get $2
+    i32.const 2
+    i32.add
+    local.tee $2
+    i32.load16_u
+   else
+    local.get $0
+   end
+   i32.const 48
+   i32.eq
+   local.get $1
+   i32.const 2
+   i32.gt_s
+   i32.and
+   if
+    block $break|1
+     block $case2|1
+      block $case1|1
+       local.get $2
+       i32.load16_u offset=2
+       i32.const 32
+       i32.or
+       local.tee $0
+       i32.const 98
+       i32.ne
+       if
+        local.get $0
+        i32.const 111
+        i32.eq
+        br_if $case1|1
+        local.get $0
+        i32.const 120
+        i32.eq
+        br_if $case2|1
+        br $break|1
+       end
+       local.get $2
+       i32.const 4
+       i32.add
+       local.set $2
+       local.get $1
+       i32.const 2
+       i32.sub
+       local.set $1
+       i32.const 2
+       local.set $3
+       br $break|1
+      end
+      local.get $2
+      i32.const 4
+      i32.add
+      local.set $2
+      local.get $1
+      i32.const 2
+      i32.sub
+      local.set $1
+      i32.const 8
+      local.set $3
+      br $break|1
+     end
+     local.get $2
+     i32.const 4
+     i32.add
+     local.set $2
+     local.get $1
+     i32.const 2
+     i32.sub
+     local.set $1
+     i32.const 16
+     local.set $3
+    end
+   end
+   local.get $3
+   i32.const 10
+   local.get $3
+   select
+   local.set $6
+   local.get $1
+   i32.const 1
+   i32.sub
+   local.set $7
+   loop $while-continue|2
+    local.get $1
+    local.tee $0
+    i32.const 1
+    i32.sub
+    local.set $1
+    local.get $0
+    if
+     block $while-break|2
+      local.get $2
+      i32.load16_u
+      local.tee $3
+      i32.const 48
+      i32.sub
+      local.tee $0
+      i32.const 10
+      i32.ge_u
+      if
+       local.get $3
+       i32.const 65
+       i32.sub
+       i32.const 25
+       i32.le_u
+       if (result i32)
+        local.get $3
+        i32.const 55
+        i32.sub
+       else
+        local.get $3
+        i32.const 87
+        i32.sub
+        local.get $3
+        local.get $3
+        i32.const 97
+        i32.sub
+        i32.const 25
+        i32.le_u
+        select
+       end
+       local.set $0
+      end
+      local.get $0
+      local.get $6
+      i32.ge_u
+      if
+       local.get $1
+       local.get $7
+       i32.eq
+       br_if $folding-inner0
+       br $while-break|2
+      end
+      local.get $5
+      local.get $6
+      i32.mul
+      local.get $0
+      i32.add
+      local.set $5
+      local.get $2
+      i32.const 2
+      i32.add
+      local.set $2
+      br $while-continue|2
+     end
+    end
+   end
+   global.get $~lib/memory/__stack_pointer
+   i32.const 4
+   i32.add
+   global.set $~lib/memory/__stack_pointer
+   local.get $4
+   local.get $5
+   i32.mul
+   return
+  end
+  global.get $~lib/memory/__stack_pointer
+  i32.const 4
+  i32.add
+  global.set $~lib/memory/__stack_pointer
+  i32.const 0
+ )
  (func $~lib/array/ensureCapacity (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -5231,7 +5535,7 @@
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store
-   block $__inlined_func$~lib/rt/itcms/__renew$362
+   block $__inlined_func$~lib/rt/itcms/__renew$363
     i32.const 1073741820
     local.get $2
     i32.const 1
@@ -5274,7 +5578,7 @@
      i32.store offset=16
      local.get $2
      local.set $1
-     br $__inlined_func$~lib/rt/itcms/__renew$362
+     br $__inlined_func$~lib/rt/itcms/__renew$363
     end
     local.get $3
     local.get $4
@@ -5794,6 +6098,39 @@
   global.set $~lib/memory/__stack_pointer
   local.get $0
  )
+ (func $~lib/array/Array<~lib/string/String>#get:length (param $0 i32) (result i32)
+  (local $1 i32)
+  global.get $~lib/memory/__stack_pointer
+  i32.const 4
+  i32.sub
+  global.set $~lib/memory/__stack_pointer
+  global.get $~lib/memory/__stack_pointer
+  i32.const 8468
+  i32.lt_s
+  if
+   i32.const 41264
+   i32.const 41312
+   i32.const 1
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  global.get $~lib/memory/__stack_pointer
+  local.tee $1
+  i32.const 0
+  i32.store
+  local.get $1
+  local.get $0
+  i32.store
+  local.get $0
+  i32.load offset=12
+  local.set $0
+  local.get $1
+  i32.const 4
+  i32.add
+  global.set $~lib/memory/__stack_pointer
+  local.get $0
+ )
  (func $~lib/array/Array<~lib/string/String>#__get (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   global.get $~lib/memory/__stack_pointer
@@ -5856,343 +6193,6 @@
   end
   global.get $~lib/memory/__stack_pointer
   i32.const 8
-  i32.add
-  global.set $~lib/memory/__stack_pointer
-  local.get $0
- )
- (func $~lib/util/string/strtol<i32> (param $0 i32) (result i32)
-  (local $1 i32)
-  (local $2 i32)
-  (local $3 i32)
-  (local $4 i32)
-  (local $5 i32)
-  (local $6 i32)
-  (local $7 i32)
-  global.get $~lib/memory/__stack_pointer
-  i32.const 4
-  i32.sub
-  global.set $~lib/memory/__stack_pointer
-  global.get $~lib/memory/__stack_pointer
-  i32.const 8468
-  i32.lt_s
-  if
-   i32.const 41264
-   i32.const 41312
-   i32.const 1
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  global.get $~lib/memory/__stack_pointer
-  local.tee $1
-  i32.const 0
-  i32.store
-  local.get $1
-  local.get $0
-  i32.store
-  block $folding-inner0
-   local.get $0
-   i32.const 20
-   i32.sub
-   i32.load offset=16
-   i32.const 1
-   i32.shr_u
-   local.tee $1
-   i32.eqz
-   br_if $folding-inner0
-   local.get $0
-   local.tee $2
-   i32.load16_u
-   local.set $0
-   loop $while-continue|0
-    block $__inlined_func$~lib/util/string/isSpace$182 (result i32)
-     local.get $0
-     i32.const 128
-     i32.or
-     i32.const 160
-     i32.eq
-     local.get $0
-     i32.const 9
-     i32.sub
-     i32.const 4
-     i32.le_u
-     i32.or
-     local.get $0
-     i32.const 5760
-     i32.lt_u
-     br_if $__inlined_func$~lib/util/string/isSpace$182
-     drop
-     i32.const 1
-     local.get $0
-     i32.const -8192
-     i32.add
-     i32.const 10
-     i32.le_u
-     br_if $__inlined_func$~lib/util/string/isSpace$182
-     drop
-     block $break|0
-      block $case0|0
-       local.get $0
-       i32.const 5760
-       i32.eq
-       br_if $case0|0
-       local.get $0
-       i32.const 8232
-       i32.eq
-       br_if $case0|0
-       local.get $0
-       i32.const 8233
-       i32.eq
-       br_if $case0|0
-       local.get $0
-       i32.const 8239
-       i32.eq
-       br_if $case0|0
-       local.get $0
-       i32.const 8287
-       i32.eq
-       br_if $case0|0
-       local.get $0
-       i32.const 12288
-       i32.eq
-       br_if $case0|0
-       local.get $0
-       i32.const 65279
-       i32.eq
-       br_if $case0|0
-       br $break|0
-      end
-      i32.const 1
-      br $__inlined_func$~lib/util/string/isSpace$182
-     end
-     i32.const 0
-    end
-    if
-     local.get $2
-     i32.const 2
-     i32.add
-     local.tee $2
-     i32.load16_u
-     local.set $0
-     local.get $1
-     i32.const 1
-     i32.sub
-     local.set $1
-     br $while-continue|0
-    end
-   end
-   i32.const 1
-   local.set $4
-   local.get $0
-   i32.const 45
-   i32.eq
-   local.tee $6
-   local.get $0
-   i32.const 43
-   i32.eq
-   i32.or
-   if (result i32)
-    local.get $1
-    i32.const 1
-    i32.sub
-    local.tee $1
-    i32.eqz
-    br_if $folding-inner0
-    i32.const -1
-    i32.const 1
-    local.get $6
-    select
-    local.set $4
-    local.get $2
-    i32.const 2
-    i32.add
-    local.tee $2
-    i32.load16_u
-   else
-    local.get $0
-   end
-   i32.const 48
-   i32.eq
-   local.get $1
-   i32.const 2
-   i32.gt_s
-   i32.and
-   if
-    block $break|1
-     block $case2|1
-      block $case1|1
-       local.get $2
-       i32.load16_u offset=2
-       i32.const 32
-       i32.or
-       local.tee $0
-       i32.const 98
-       i32.ne
-       if
-        local.get $0
-        i32.const 111
-        i32.eq
-        br_if $case1|1
-        local.get $0
-        i32.const 120
-        i32.eq
-        br_if $case2|1
-        br $break|1
-       end
-       local.get $2
-       i32.const 4
-       i32.add
-       local.set $2
-       local.get $1
-       i32.const 2
-       i32.sub
-       local.set $1
-       i32.const 2
-       local.set $3
-       br $break|1
-      end
-      local.get $2
-      i32.const 4
-      i32.add
-      local.set $2
-      local.get $1
-      i32.const 2
-      i32.sub
-      local.set $1
-      i32.const 8
-      local.set $3
-      br $break|1
-     end
-     local.get $2
-     i32.const 4
-     i32.add
-     local.set $2
-     local.get $1
-     i32.const 2
-     i32.sub
-     local.set $1
-     i32.const 16
-     local.set $3
-    end
-   end
-   local.get $3
-   i32.const 10
-   local.get $3
-   select
-   local.set $6
-   local.get $1
-   i32.const 1
-   i32.sub
-   local.set $7
-   loop $while-continue|2
-    local.get $1
-    local.tee $0
-    i32.const 1
-    i32.sub
-    local.set $1
-    local.get $0
-    if
-     block $while-break|2
-      local.get $2
-      i32.load16_u
-      local.tee $3
-      i32.const 48
-      i32.sub
-      local.tee $0
-      i32.const 10
-      i32.ge_u
-      if
-       local.get $3
-       i32.const 65
-       i32.sub
-       i32.const 25
-       i32.le_u
-       if (result i32)
-        local.get $3
-        i32.const 55
-        i32.sub
-       else
-        local.get $3
-        i32.const 87
-        i32.sub
-        local.get $3
-        local.get $3
-        i32.const 97
-        i32.sub
-        i32.const 25
-        i32.le_u
-        select
-       end
-       local.set $0
-      end
-      local.get $0
-      local.get $6
-      i32.ge_u
-      if
-       local.get $1
-       local.get $7
-       i32.eq
-       br_if $folding-inner0
-       br $while-break|2
-      end
-      local.get $5
-      local.get $6
-      i32.mul
-      local.get $0
-      i32.add
-      local.set $5
-      local.get $2
-      i32.const 2
-      i32.add
-      local.set $2
-      br $while-continue|2
-     end
-    end
-   end
-   global.get $~lib/memory/__stack_pointer
-   i32.const 4
-   i32.add
-   global.set $~lib/memory/__stack_pointer
-   local.get $4
-   local.get $5
-   i32.mul
-   return
-  end
-  global.get $~lib/memory/__stack_pointer
-  i32.const 4
-  i32.add
-  global.set $~lib/memory/__stack_pointer
-  i32.const 0
- )
- (func $~lib/array/Array<~lib/string/String>#get:length (param $0 i32) (result i32)
-  (local $1 i32)
-  global.get $~lib/memory/__stack_pointer
-  i32.const 4
-  i32.sub
-  global.set $~lib/memory/__stack_pointer
-  global.get $~lib/memory/__stack_pointer
-  i32.const 8468
-  i32.lt_s
-  if
-   i32.const 41264
-   i32.const 41312
-   i32.const 1
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  global.get $~lib/memory/__stack_pointer
-  local.tee $1
-  i32.const 0
-  i32.store
-  local.get $1
-  local.get $0
-  i32.store
-  local.get $0
-  i32.load offset=12
-  local.set $0
-  local.get $1
-  i32.const 4
   i32.add
   global.set $~lib/memory/__stack_pointer
   local.get $0
@@ -6295,9 +6295,9 @@
     i32.shr_u
     i32.const 1
     i32.sub
-    local.set $5
+    local.set $3
     loop $for-loop|0
-     local.get $5
+     local.get $3
      i32.const 0
      i32.ge_s
      if
@@ -6321,7 +6321,7 @@
       local.get $0
       i32.store
       block $__inlined_func$~lib/string/String#charCodeAt$386
-       local.get $5
+       local.get $3
        local.get $0
        i32.const 20
        i32.sub
@@ -6339,7 +6339,7 @@
         br $__inlined_func$~lib/string/String#charCodeAt$386
        end
        local.get $0
-       local.get $5
+       local.get $3
        i32.const 1
        i32.shl
        i32.add
@@ -6366,7 +6366,7 @@
         global.get $~lib/memory/__stack_pointer
         local.get $0
         i32.store
-        local.get $5
+        local.get $3
         local.get $0
         i32.const 20
         i32.sub
@@ -6387,76 +6387,85 @@
         global.get $~lib/memory/__stack_pointer
         local.tee $4
         local.get $0
-        i32.store offset=16
-        i32.const 1
-        global.set $~argumentsLength
-        local.get $0
-        local.get $5
-        i32.const 1
-        i32.add
-        call $~lib/string/String#substring@varargs
-        local.set $7
-        global.get $~lib/memory/__stack_pointer
-        local.get $7
         i32.store
-        global.get $~lib/memory/__stack_pointer
+        local.get $4
         i32.const 3520
         i32.store offset=8
-        i32.const 1
-        global.set $~argumentsLength
-        local.get $4
-        local.get $7
+        i32.const 0
+        local.get $0
         i32.const 3520
-        call $~lib/string/String#split@varargs
+        local.get $3
+        i32.const 1
+        i32.add
         local.tee $4
-        i32.store offset=20
-        global.get $~lib/memory/__stack_pointer
-        local.get $4
-        i32.store
-        global.get $~lib/memory/__stack_pointer
-        local.get $4
-        i32.const 0
-        call $~lib/array/Array<~lib/string/String>#__get
+        call $~lib/string/String#indexOf
         local.tee $7
-        i32.store offset=24
-        global.get $~lib/memory/__stack_pointer
-        local.get $7
-        i32.store
-        local.get $7
-        call $~lib/util/string/strtol<i32>
-        local.set $7
-        global.get $~lib/memory/__stack_pointer
-        local.get $4
-        i32.store
-        i32.const 0
-        local.get $4
-        call $~lib/array/Array<~lib/string/String>#get:length
-        i32.const 2
-        i32.ge_s
+        i32.const -1
+        i32.xor
         if (result i32)
          global.get $~lib/memory/__stack_pointer
-         local.get $4
+         local.get $0
          i32.store
          global.get $~lib/memory/__stack_pointer
+         local.get $0
          local.get $4
-         i32.const 1
-         call $~lib/array/Array<~lib/string/String>#__get
+         local.get $7
+         call $~lib/string/String#substring
          local.tee $4
-         i32.store offset=28
+         i32.store offset=16
          global.get $~lib/memory/__stack_pointer
          local.get $4
          i32.store
          local.get $4
          call $~lib/util/string/strtol<i32>
+         local.set $4
+         global.get $~lib/memory/__stack_pointer
+         local.get $0
+         i32.store
+         i32.const 1
+         global.set $~argumentsLength
+         global.get $~lib/memory/__stack_pointer
+         local.get $0
+         local.get $7
+         i32.const 1
+         i32.add
+         call $~lib/string/String#substring@varargs
+         local.tee $7
+         i32.store offset=20
+         global.get $~lib/memory/__stack_pointer
+         local.get $7
+         i32.store
+         local.get $7
+         call $~lib/util/string/strtol<i32>
+         local.get $4
+         i32.const 60
+         i32.mul
+         i32.add
+         i32.const 60000
+         i32.mul
         else
-         i32.const 0
+         global.get $~lib/memory/__stack_pointer
+         local.tee $4
+         local.get $0
+         i32.store
+         i32.const 1
+         global.set $~argumentsLength
+         local.get $4
+         local.get $0
+         local.get $3
+         i32.const 1
+         i32.add
+         call $~lib/string/String#substring@varargs
+         local.tee $4
+         i32.store offset=24
+         global.get $~lib/memory/__stack_pointer
+         local.get $4
+         i32.store
+         local.get $4
+         call $~lib/util/string/strtol<i32>
+         i32.const 3600000
+         i32.mul
         end
-        local.get $7
-        i32.const 60
-        i32.mul
-        i32.add
-        i32.const 60000
-        i32.mul
         local.tee $4
         i32.sub
         local.get $4
@@ -6464,13 +6473,13 @@
         i32.const 45
         i32.eq
         select
-        local.set $7
+        local.set $4
         br $for-break0
        end
-       local.get $5
+       local.get $3
        i32.const 1
        i32.sub
-       local.set $5
+       local.set $3
        br $for-loop|0
       end
       global.get $~lib/memory/__stack_pointer
@@ -6480,7 +6489,7 @@
       local.get $2
       local.get $0
       i32.const 0
-      local.get $5
+      local.get $3
       call $~lib/string/String#substring
       local.tee $0
       i32.store offset=12
@@ -6500,7 +6509,7 @@
     i32.const 3520
     call $~lib/string/String#split@varargs
     local.tee $0
-    i32.store offset=32
+    i32.store offset=28
     global.get $~lib/memory/__stack_pointer
     local.get $0
     i32.store
@@ -6512,27 +6521,27 @@
     if
      i32.const 1056
      i32.const 1104
-     i32.const 89
+     i32.const 96
      i32.const 21
      call $~lib/builtins/abort
      unreachable
     end
     global.get $~lib/memory/__stack_pointer
-    local.tee $4
+    local.tee $3
     local.get $0
     i32.store
-    local.get $4
+    local.get $3
     local.get $0
     i32.const 0
     call $~lib/array/Array<~lib/string/String>#__get
-    local.tee $4
-    i32.store offset=36
+    local.tee $3
+    i32.store offset=32
     global.get $~lib/memory/__stack_pointer
-    local.get $4
+    local.get $3
     i32.store
-    local.get $4
+    local.get $3
     call $~lib/util/string/strtol<i32>
-    local.set $5
+    local.set $3
     global.get $~lib/memory/__stack_pointer
     local.get $0
     i32.store
@@ -6540,14 +6549,14 @@
     local.get $0
     i32.const 1
     call $~lib/array/Array<~lib/string/String>#__get
-    local.tee $4
-    i32.store offset=40
+    local.tee $7
+    i32.store offset=36
     global.get $~lib/memory/__stack_pointer
-    local.get $4
+    local.get $7
     i32.store
-    local.get $4
+    local.get $7
     call $~lib/util/string/strtol<i32>
-    local.set $4
+    local.set $7
     local.get $2
     i32.const 3
     i32.ge_s
@@ -6560,7 +6569,7 @@
      i32.const 2
      call $~lib/array/Array<~lib/string/String>#__get
      local.tee $2
-     i32.store offset=44
+     i32.store offset=40
      global.get $~lib/memory/__stack_pointer
      local.get $2
      i32.store
@@ -6584,7 +6593,7 @@
       local.get $0
       call $~lib/string/String#substring
       local.tee $6
-      i32.store offset=48
+      i32.store offset=44
       global.get $~lib/memory/__stack_pointer
       local.get $6
       i32.store
@@ -6592,11 +6601,11 @@
       call $~lib/util/string/strtol<i32>
       local.set $6
       global.get $~lib/memory/__stack_pointer
-      local.set $8
+      local.set $9
       block $__inlined_func$~lib/string/String#substr$387 (result i32)
        global.get $~lib/memory/__stack_pointer
        local.get $2
-       i32.store offset=16
+       i32.store offset=48
        local.get $0
        i32.const 1
        i32.add
@@ -6610,10 +6619,10 @@
        i32.lt_s
        br_if $folding-inner0
        global.get $~lib/memory/__stack_pointer
-       local.tee $9
+       local.tee $8
        i64.const 0
        i64.store
-       local.get $9
+       local.get $8
        local.get $2
        i32.store
        i32.const 3
@@ -6623,13 +6632,13 @@
        i32.load offset=16
        i32.const 1
        i32.shr_u
-       local.tee $9
+       local.tee $8
        local.get $0
        i32.const 0
        i32.lt_s
        if
         local.get $0
-        local.get $9
+        local.get $8
         i32.add
         local.tee $0
         i32.const 0
@@ -6641,14 +6650,14 @@
        end
        local.get $0
        i32.sub
-       local.tee $9
-       local.get $9
+       local.tee $8
+       local.get $8
        i32.const 3
        i32.gt_s
        select
        i32.const 1
        i32.shl
-       local.tee $9
+       local.tee $8
        i32.const 0
        i32.le_s
        if
@@ -6660,7 +6669,7 @@
         br $__inlined_func$~lib/string/String#substr$387
        end
        global.get $~lib/memory/__stack_pointer
-       local.get $9
+       local.get $8
        i32.const 2
        call $~lib/rt/itcms/__new
        local.tee $10
@@ -6671,7 +6680,7 @@
        i32.const 1
        i32.shl
        i32.add
-       local.get $9
+       local.get $8
        memory.copy
        global.get $~lib/memory/__stack_pointer
        i32.const 8
@@ -6717,7 +6726,7 @@
        i32.load
        i32.const -2
        i32.and
-       local.tee $11
+       local.tee $8
        i32.eqz
        local.get $10
        i32.const 6
@@ -6744,49 +6753,49 @@
        local.get $10
        i32.sub
        local.tee $0
-       local.get $11
+       local.get $8
        i32.gt_u
        if
         local.get $0
         local.get $0
         i32.const 2
         i32.sub
-        local.get $11
+        local.get $8
         i32.div_u
-        local.get $11
+        local.get $8
         i32.mul
-        local.tee $12
+        local.tee $0
         i32.sub
-        local.set $0
+        local.set $11
         local.get $2
         local.get $10
         i32.add
-        local.set $9
+        local.set $12
         loop $while-continue|0
-         local.get $3
-         local.get $12
-         i32.lt_u
+         local.get $0
+         local.get $5
+         i32.gt_u
          if
-          local.get $3
-          local.get $9
+          local.get $5
+          local.get $12
           i32.add
           i32.const 1872
-          local.get $11
+          local.get $8
           memory.copy
-          local.get $3
-          local.get $11
+          local.get $5
+          local.get $8
           i32.add
-          local.set $3
+          local.set $5
           br $while-continue|0
          end
         end
         local.get $2
         local.get $10
         i32.add
-        local.get $12
+        local.get $0
         i32.add
         i32.const 1872
-        local.get $0
+        local.get $11
         memory.copy
        else
         local.get $2
@@ -6803,7 +6812,7 @@
        local.get $2
        local.set $0
       end
-      local.get $8
+      local.get $9
       local.get $0
       i32.store offset=52
       global.get $~lib/memory/__stack_pointer
@@ -6811,7 +6820,7 @@
       i32.store
       local.get $0
       call $~lib/util/string/strtol<i32>
-      local.set $3
+      local.set $5
      else
       global.get $~lib/memory/__stack_pointer
       local.tee $0
@@ -6910,12 +6919,12 @@
    local.get $2
    local.get $1
    local.get $0
-   local.get $5
-   local.get $4
-   local.get $6
    local.get $3
-   call $~lib/date/epochMillis
    local.get $7
+   local.get $6
+   local.get $5
+   call $~lib/date/epochMillis
+   local.get $4
    i64.extend_i32_s
    i64.sub
    call $~lib/date/Date#constructor

--- a/tests/compiler/std/date.release.wat
+++ b/tests/compiler/std/date.release.wat
@@ -2590,7 +2590,7 @@
   if
    i32.const 1056
    i32.const 1104
-   i32.const 126
+   i32.const 124
    i32.const 35
    call $~lib/builtins/abort
    unreachable
@@ -2650,7 +2650,7 @@
   if
    i32.const 1056
    i32.const 1104
-   i32.const 138
+   i32.const 136
    i32.const 28
    call $~lib/builtins/abort
    unreachable
@@ -6512,7 +6512,7 @@
     if
      i32.const 1056
      i32.const 1104
-     i32.const 91
+     i32.const 89
      i32.const 21
      call $~lib/builtins/abort
      unreachable

--- a/tests/compiler/std/date.release.wat
+++ b/tests/compiler/std/date.release.wat
@@ -28,7 +28,7 @@
  (global $~lib/rt/itcms/fromSpace (mut i32) (i32.const 0))
  (global $~lib/rt/tlsf/ROOT (mut i32) (i32.const 0))
  (global $~argumentsLength (mut i32) (i32.const 0))
- (global $~lib/memory/__stack_pointer (mut i32) (i32.const 40596))
+ (global $~lib/memory/__stack_pointer (mut i32) (i32.const 41236))
  (global $~started (mut i32) (i32.const 0))
  (memory $0 1)
  (data $0 (i32.const 1036) ",")
@@ -220,25 +220,41 @@
  (data $98.1 (i32.const 7112) "\02\00\00\00.\00\00\001\009\007\006\00-\000\002\00-\000\002\00T\001\002\00:\003\004\00:\005\006\00.\004\005\006")
  (data $99 (i32.const 7180) "L")
  (data $99.1 (i32.const 7192) "\02\00\00\000\00\00\001\009\007\006\00-\000\002\00-\000\002\00T\001\002\00:\003\004\00:\005\006\00.\004\005\006\00Z")
- (data $100 (i32.const 7260) "\1c")
- (data $100.1 (i32.const 7272) "\02\00\00\00\08\00\00\000\000\000\000")
- (data $101 (i32.const 7292) "\1c")
- (data $101.1 (i32.const 7304) "\02\00\00\00\08\00\00\000\000\000\001")
- (data $102 (i32.const 7324) "\1c")
- (data $102.1 (i32.const 7336) "\02\00\00\00\08\00\00\001\009\007\006")
- (data $103 (i32.const 7356) ",")
- (data $103.1 (i32.const 7368) "\02\00\00\00\0e\00\00\001\009\007\006\00-\000\002")
- (data $104 (i32.const 7404) "<")
- (data $104.1 (i32.const 7416) "\02\00\00\00 \00\00\001\009\007\006\00-\000\002\00-\000\002\00T\001\002\00:\003\004")
- (data $105 (i32.const 7468) "L")
- (data $105.1 (i32.const 7480) "\02\00\00\006\00\00\00-\002\007\001\008\002\001\00-\000\004\00-\002\000\00T\000\000\00:\000\000\00:\000\000\00.\000\000\000\00Z")
- (data $106 (i32.const 7548) "L")
- (data $106.1 (i32.const 7560) "\02\00\00\006\00\00\00+\002\007\005\007\006\000\00-\000\009\00-\001\003\00T\000\000\00:\000\000\00:\000\000\00.\000\000\000\00Z")
- (data $107 (i32.const 7628) "L")
- (data $107.1 (i32.const 7640) "\02\00\00\006\00\00\00+\002\007\005\007\006\000\00-\000\009\00-\001\002\00T\002\003\00:\005\009\00:\005\009\00.\009\009\009\00Z")
- (data $108 (i32.const 7708) "L")
- (data $108.1 (i32.const 7720) "\02\00\00\006\00\00\00-\002\007\001\008\002\001\00-\000\004\00-\002\000\00T\000\000\00:\000\000\00:\000\000\00.\000\000\001\00Z")
- (data $109 (i32.const 7792) "\08\00\00\00 \00\00\00 \00\00\00 \00\00\00\00\00\00\00 \00\00\00\04A\00\00\02A\00\00\02\t")
+ (data $100 (i32.const 7260) "L")
+ (data $100.1 (i32.const 7272) "\02\00\00\00:\00\00\001\009\007\006\00-\000\002\00-\000\002\00T\001\002\00:\003\004\00:\005\006\00.\004\005\006\00-\000\008\00:\000\000")
+ (data $101 (i32.const 7340) "L")
+ (data $101.1 (i32.const 7352) "\02\00\00\00:\00\00\001\009\007\006\00-\000\002\00-\000\002\00T\001\002\00:\003\004\00:\005\006\00.\004\005\006\00+\000\005\00:\003\000")
+ (data $102 (i32.const 7420) "<")
+ (data $102.1 (i32.const 7432) "\02\00\00\00,\00\00\001\009\007\006\00-\000\002\00-\000\002\00T\001\002\00:\003\004\00:\005\006\00.\004\005")
+ (data $103 (i32.const 7484) "L")
+ (data $103.1 (i32.const 7496) "\02\00\00\00.\00\00\001\009\007\006\00-\000\002\00-\000\002\00T\001\002\00:\003\004\00:\005\006\00.\004\005\00Z")
+ (data $104 (i32.const 7564) "L")
+ (data $104.1 (i32.const 7576) "\02\00\00\008\00\00\001\009\007\006\00-\000\002\00-\000\002\00T\001\002\00:\003\004\00:\005\006\00.\004\005\00+\000\000\00:\000\000")
+ (data $105 (i32.const 7644) "L")
+ (data $105.1 (i32.const 7656) "\02\00\00\004\00\00\001\009\007\006\00-\000\002\00-\000\002\00T\001\002\00:\003\004\00:\005\006\00.\004\005\006\007\008\009")
+ (data $106 (i32.const 7724) "L")
+ (data $106.1 (i32.const 7736) "\02\00\00\006\00\00\001\009\007\006\00-\000\002\00-\000\002\00T\001\002\00:\003\004\00:\005\006\00.\004\005\006\007\008\009\00Z")
+ (data $107 (i32.const 7804) "\\")
+ (data $107.1 (i32.const 7816) "\02\00\00\00@\00\00\001\009\007\006\00-\000\002\00-\000\002\00T\001\002\00:\003\004\00:\005\006\00.\004\005\006\007\008\009\00+\000\000\00:\000\000")
+ (data $108 (i32.const 7900) "\1c")
+ (data $108.1 (i32.const 7912) "\02\00\00\00\08\00\00\000\000\000\000")
+ (data $109 (i32.const 7932) "\1c")
+ (data $109.1 (i32.const 7944) "\02\00\00\00\08\00\00\000\000\000\001")
+ (data $110 (i32.const 7964) "\1c")
+ (data $110.1 (i32.const 7976) "\02\00\00\00\08\00\00\001\009\007\006")
+ (data $111 (i32.const 7996) ",")
+ (data $111.1 (i32.const 8008) "\02\00\00\00\0e\00\00\001\009\007\006\00-\000\002")
+ (data $112 (i32.const 8044) "<")
+ (data $112.1 (i32.const 8056) "\02\00\00\00 \00\00\001\009\007\006\00-\000\002\00-\000\002\00T\001\002\00:\003\004")
+ (data $113 (i32.const 8108) "L")
+ (data $113.1 (i32.const 8120) "\02\00\00\006\00\00\00-\002\007\001\008\002\001\00-\000\004\00-\002\000\00T\000\000\00:\000\000\00:\000\000\00.\000\000\000\00Z")
+ (data $114 (i32.const 8188) "L")
+ (data $114.1 (i32.const 8200) "\02\00\00\006\00\00\00+\002\007\005\007\006\000\00-\000\009\00-\001\003\00T\000\000\00:\000\000\00:\000\000\00.\000\000\000\00Z")
+ (data $115 (i32.const 8268) "L")
+ (data $115.1 (i32.const 8280) "\02\00\00\006\00\00\00+\002\007\005\007\006\000\00-\000\009\00-\001\002\00T\002\003\00:\005\009\00:\005\009\00.\009\009\009\00Z")
+ (data $116 (i32.const 8348) "L")
+ (data $116.1 (i32.const 8360) "\02\00\00\006\00\00\00-\002\007\001\008\002\001\00-\000\004\00-\002\000\00T\000\000\00:\000\000\00:\000\000\00.\000\000\001\00Z")
+ (data $117 (i32.const 8432) "\08\00\00\00 \00\00\00 \00\00\00 \00\00\00\00\00\00\00 \00\00\00\04A\00\00\02A\00\00\02\t")
  (export "memory" (memory $0))
  (export "_start" (func $~start))
  (func $~lib/date/epochMillis (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (param $4 i32) (param $5 i32) (param $6 i32) (result i64)
@@ -488,7 +504,7 @@
    local.get $1
    global.set $~lib/rt/itcms/iter
   end
-  block $__inlined_func$~lib/rt/itcms/Object#unlink$359
+  block $__inlined_func$~lib/rt/itcms/Object#unlink$376
    local.get $0
    i32.load offset=4
    i32.const -4
@@ -500,7 +516,7 @@
     i32.load offset=8
     i32.eqz
     local.get $0
-    i32.const 40596
+    i32.const 41236
     i32.lt_u
     i32.and
     i32.eqz
@@ -512,7 +528,7 @@
      call $~lib/builtins/abort
      unreachable
     end
-    br $__inlined_func$~lib/rt/itcms/Object#unlink$359
+    br $__inlined_func$~lib/rt/itcms/Object#unlink$376
    end
    local.get $0
    i32.load offset=8
@@ -549,7 +565,7 @@
    i32.const 1
   else
    local.get $1
-   i32.const 7792
+   i32.const 8432
    i32.load
    i32.gt_u
    if
@@ -563,7 +579,7 @@
    local.get $1
    i32.const 2
    i32.shl
-   i32.const 7796
+   i32.const 8436
    i32.add
    i32.load
    i32.const 32
@@ -1147,10 +1163,10 @@
   if
    unreachable
   end
-  i32.const 40608
+  i32.const 41248
   i32.const 0
   i32.store
-  i32.const 42176
+  i32.const 42816
   i32.const 0
   i32.store
   loop $for-loop|0
@@ -1161,7 +1177,7 @@
     local.get $0
     i32.const 2
     i32.shl
-    i32.const 40608
+    i32.const 41248
     i32.add
     i32.const 0
     i32.store offset=4
@@ -1179,7 +1195,7 @@
       i32.add
       i32.const 2
       i32.shl
-      i32.const 40608
+      i32.const 41248
       i32.add
       i32.const 0
       i32.store offset=96
@@ -1197,14 +1213,14 @@
     br $for-loop|0
    end
   end
-  i32.const 40608
-  i32.const 42180
+  i32.const 41248
+  i32.const 42820
   memory.size
   i64.extend_i32_s
   i64.const 16
   i64.shl
   call $~lib/rt/tlsf/addMemory
-  i32.const 40608
+  i32.const 41248
   global.set $~lib/rt/tlsf/ROOT
  )
  (func $~lib/rt/itcms/step (result i32)
@@ -1289,7 +1305,7 @@
      local.set $0
      loop $while-continue|0
       local.get $0
-      i32.const 40596
+      i32.const 41236
       i32.lt_u
       if
        local.get $0
@@ -1385,7 +1401,7 @@
      unreachable
     end
     local.get $0
-    i32.const 40596
+    i32.const 41236
     i32.lt_u
     if
      local.get $0
@@ -1408,7 +1424,7 @@
      i32.const 4
      i32.add
      local.tee $0
-     i32.const 40596
+     i32.const 41236
      i32.ge_u
      if
       global.get $~lib/rt/tlsf/ROOT
@@ -2000,11 +2016,11 @@
   i32.sub
   global.set $~lib/memory/__stack_pointer
   global.get $~lib/memory/__stack_pointer
-  i32.const 7828
+  i32.const 8468
   i32.lt_s
   if
-   i32.const 40624
-   i32.const 40672
+   i32.const 41264
+   i32.const 41312
    i32.const 1
    i32.const 1
    call $~lib/builtins/abort
@@ -2425,7 +2441,7 @@
       i32.sub
       global.set $~lib/memory/__stack_pointer
       global.get $~lib/memory/__stack_pointer
-      i32.const 7828
+      i32.const 8468
       i32.lt_s
       br_if $folding-inner0
       global.get $~lib/memory/__stack_pointer
@@ -2474,7 +2490,7 @@
      i32.sub
      global.set $~lib/memory/__stack_pointer
      global.get $~lib/memory/__stack_pointer
-     i32.const 7828
+     i32.const 8468
      i32.lt_s
      br_if $folding-inner0
      global.get $~lib/memory/__stack_pointer
@@ -2484,8 +2500,8 @@
     end
     unreachable
    end
-   i32.const 40624
-   i32.const 40672
+   i32.const 41264
+   i32.const 41312
    i32.const 1
    i32.const 1
    call $~lib/builtins/abort
@@ -2519,11 +2535,11 @@
   i32.sub
   global.set $~lib/memory/__stack_pointer
   global.get $~lib/memory/__stack_pointer
-  i32.const 7828
+  i32.const 8468
   i32.lt_s
   if
-   i32.const 40624
-   i32.const 40672
+   i32.const 41264
+   i32.const 41312
    i32.const 1
    i32.const 1
    call $~lib/builtins/abort
@@ -2574,7 +2590,7 @@
   if
    i32.const 1056
    i32.const 1104
-   i32.const 100
+   i32.const 126
    i32.const 35
    call $~lib/builtins/abort
    unreachable
@@ -2611,11 +2627,11 @@
   i32.sub
   global.set $~lib/memory/__stack_pointer
   global.get $~lib/memory/__stack_pointer
-  i32.const 7828
+  i32.const 8468
   i32.lt_s
   if
-   i32.const 40624
-   i32.const 40672
+   i32.const 41264
+   i32.const 41312
    i32.const 1
    i32.const 1
    call $~lib/builtins/abort
@@ -2634,7 +2650,7 @@
   if
    i32.const 1056
    i32.const 1104
-   i32.const 112
+   i32.const 138
    i32.const 28
    call $~lib/builtins/abort
    unreachable
@@ -2678,11 +2694,11 @@
   i32.sub
   global.set $~lib/memory/__stack_pointer
   global.get $~lib/memory/__stack_pointer
-  i32.const 7828
+  i32.const 8468
   i32.lt_s
   if
-   i32.const 40624
-   i32.const 40672
+   i32.const 41264
+   i32.const 41312
    i32.const 1
    i32.const 1
    call $~lib/builtins/abort
@@ -2724,11 +2740,11 @@
   i32.sub
   global.set $~lib/memory/__stack_pointer
   global.get $~lib/memory/__stack_pointer
-  i32.const 7828
+  i32.const 8468
   i32.lt_s
   if
-   i32.const 40624
-   i32.const 40672
+   i32.const 41264
+   i32.const 41312
    i32.const 1
    i32.const 1
    call $~lib/builtins/abort
@@ -2770,11 +2786,11 @@
   i32.sub
   global.set $~lib/memory/__stack_pointer
   global.get $~lib/memory/__stack_pointer
-  i32.const 7828
+  i32.const 8468
   i32.lt_s
   if
-   i32.const 40624
-   i32.const 40672
+   i32.const 41264
+   i32.const 41312
    i32.const 1
    i32.const 1
    call $~lib/builtins/abort
@@ -2816,11 +2832,11 @@
   i32.sub
   global.set $~lib/memory/__stack_pointer
   global.get $~lib/memory/__stack_pointer
-  i32.const 7828
+  i32.const 8468
   i32.lt_s
   if
-   i32.const 40624
-   i32.const 40672
+   i32.const 41264
+   i32.const 41312
    i32.const 1
    i32.const 1
    call $~lib/builtins/abort
@@ -2860,11 +2876,11 @@
   i32.sub
   global.set $~lib/memory/__stack_pointer
   global.get $~lib/memory/__stack_pointer
-  i32.const 7828
+  i32.const 8468
   i32.lt_s
   if
-   i32.const 40624
-   i32.const 40672
+   i32.const 41264
+   i32.const 41312
    i32.const 1
    i32.const 1
    call $~lib/builtins/abort
@@ -2908,11 +2924,11 @@
   i32.sub
   global.set $~lib/memory/__stack_pointer
   global.get $~lib/memory/__stack_pointer
-  i32.const 7828
+  i32.const 8468
   i32.lt_s
   if
-   i32.const 40624
-   i32.const 40672
+   i32.const 41264
+   i32.const 41312
    i32.const 1
    i32.const 1
    call $~lib/builtins/abort
@@ -2958,11 +2974,11 @@
   i32.sub
   global.set $~lib/memory/__stack_pointer
   global.get $~lib/memory/__stack_pointer
-  i32.const 7828
+  i32.const 8468
   i32.lt_s
   if
-   i32.const 40624
-   i32.const 40672
+   i32.const 41264
+   i32.const 41312
    i32.const 1
    i32.const 1
    call $~lib/builtins/abort
@@ -3008,11 +3024,11 @@
   i32.sub
   global.set $~lib/memory/__stack_pointer
   global.get $~lib/memory/__stack_pointer
-  i32.const 7828
+  i32.const 8468
   i32.lt_s
   if
-   i32.const 40624
-   i32.const 40672
+   i32.const 41264
+   i32.const 41312
    i32.const 1
    i32.const 1
    call $~lib/builtins/abort
@@ -3059,11 +3075,11 @@
   i32.sub
   global.set $~lib/memory/__stack_pointer
   global.get $~lib/memory/__stack_pointer
-  i32.const 7828
+  i32.const 8468
   i32.lt_s
   if
-   i32.const 40624
-   i32.const 40672
+   i32.const 41264
+   i32.const 41312
    i32.const 1
    i32.const 1
    call $~lib/builtins/abort
@@ -3129,7 +3145,7 @@
   global.set $~lib/memory/__stack_pointer
   block $folding-inner0
    global.get $~lib/memory/__stack_pointer
-   i32.const 7828
+   i32.const 8468
    i32.lt_s
    br_if $folding-inner0
    global.get $~lib/memory/__stack_pointer
@@ -3161,7 +3177,7 @@
    i32.sub
    global.set $~lib/memory/__stack_pointer
    global.get $~lib/memory/__stack_pointer
-   i32.const 7828
+   i32.const 8468
    i32.lt_s
    br_if $folding-inner0
    global.get $~lib/memory/__stack_pointer
@@ -3211,8 +3227,8 @@
    global.set $~lib/memory/__stack_pointer
    return
   end
-  i32.const 40624
-  i32.const 40672
+  i32.const 41264
+  i32.const 41312
   i32.const 1
   i32.const 1
   call $~lib/builtins/abort
@@ -3227,11 +3243,11 @@
   i32.sub
   global.set $~lib/memory/__stack_pointer
   global.get $~lib/memory/__stack_pointer
-  i32.const 7828
+  i32.const 8468
   i32.lt_s
   if
-   i32.const 40624
-   i32.const 40672
+   i32.const 41264
+   i32.const 41312
    i32.const 1
    i32.const 1
    call $~lib/builtins/abort
@@ -3300,7 +3316,7 @@
   global.set $~lib/memory/__stack_pointer
   block $folding-inner0
    global.get $~lib/memory/__stack_pointer
-   i32.const 7828
+   i32.const 8468
    i32.lt_s
    br_if $folding-inner0
    global.get $~lib/memory/__stack_pointer
@@ -3320,7 +3336,7 @@
    i32.sub
    global.set $~lib/memory/__stack_pointer
    global.get $~lib/memory/__stack_pointer
-   i32.const 7828
+   i32.const 8468
    i32.lt_s
    br_if $folding-inner0
    global.get $~lib/memory/__stack_pointer
@@ -3340,7 +3356,7 @@
    local.get $5
    i32.const 1872
    i32.store
-   block $__inlined_func$~lib/string/String#padStart$367
+   block $__inlined_func$~lib/string/String#padStart$384
     i32.const 1868
     i32.load
     i32.const -2
@@ -3359,7 +3375,7 @@
      i32.const 8
      i32.add
      global.set $~lib/memory/__stack_pointer
-     br $__inlined_func$~lib/string/String#padStart$367
+     br $__inlined_func$~lib/string/String#padStart$384
     end
     global.get $~lib/memory/__stack_pointer
     local.get $6
@@ -3435,8 +3451,8 @@
    local.get $0
    return
   end
-  i32.const 40624
-  i32.const 40672
+  i32.const 41264
+  i32.const 41312
   i32.const 1
   i32.const 1
   call $~lib/builtins/abort
@@ -3454,11 +3470,11 @@
   i32.sub
   global.set $~lib/memory/__stack_pointer
   global.get $~lib/memory/__stack_pointer
-  i32.const 7828
+  i32.const 8468
   i32.lt_s
   if
-   i32.const 40624
-   i32.const 40672
+   i32.const 41264
+   i32.const 41312
    i32.const 1
    i32.const 1
    call $~lib/builtins/abort
@@ -3673,11 +3689,11 @@
   i32.sub
   global.set $~lib/memory/__stack_pointer
   global.get $~lib/memory/__stack_pointer
-  i32.const 7828
+  i32.const 8468
   i32.lt_s
   if
-   i32.const 40624
-   i32.const 40672
+   i32.const 41264
+   i32.const 41312
    i32.const 1
    i32.const 1
    call $~lib/builtins/abort
@@ -3724,7 +3740,7 @@
   global.set $~lib/memory/__stack_pointer
   block $folding-inner0
    global.get $~lib/memory/__stack_pointer
-   i32.const 7828
+   i32.const 8468
    i32.lt_s
    br_if $folding-inner0
    global.get $~lib/memory/__stack_pointer
@@ -3772,14 +3788,14 @@
     i32.sub
     global.set $~lib/memory/__stack_pointer
     global.get $~lib/memory/__stack_pointer
-    i32.const 7828
+    i32.const 8468
     i32.lt_s
     br_if $folding-inner0
     global.get $~lib/memory/__stack_pointer
     local.tee $1
     i64.const 0
     i64.store
-    block $__inlined_func$~lib/string/String#concat$368 (result i32)
+    block $__inlined_func$~lib/string/String#concat$385 (result i32)
      local.get $1
      local.get $3
      i32.store
@@ -3791,7 +3807,7 @@
      i32.sub
      global.set $~lib/memory/__stack_pointer
      global.get $~lib/memory/__stack_pointer
-     i32.const 7828
+     i32.const 8468
      i32.lt_s
      br_if $folding-inner0
      global.get $~lib/memory/__stack_pointer
@@ -3828,7 +3844,7 @@
       i32.add
       global.set $~lib/memory/__stack_pointer
       i32.const 3456
-      br $__inlined_func$~lib/string/String#concat$368
+      br $__inlined_func$~lib/string/String#concat$385
      end
      global.get $~lib/memory/__stack_pointer
      local.get $1
@@ -4055,8 +4071,8 @@
    local.get $0
    return
   end
-  i32.const 40624
-  i32.const 40672
+  i32.const 41264
+  i32.const 41312
   i32.const 1
   i32.const 1
   call $~lib/builtins/abort
@@ -4070,11 +4086,11 @@
   i32.sub
   global.set $~lib/memory/__stack_pointer
   global.get $~lib/memory/__stack_pointer
-  i32.const 7828
+  i32.const 8468
   i32.lt_s
   if
-   i32.const 40624
-   i32.const 40672
+   i32.const 41264
+   i32.const 41312
    i32.const 1
    i32.const 1
    call $~lib/builtins/abort
@@ -4164,11 +4180,11 @@
   i32.sub
   global.set $~lib/memory/__stack_pointer
   global.get $~lib/memory/__stack_pointer
-  i32.const 7828
+  i32.const 8468
   i32.lt_s
   if
-   i32.const 40624
-   i32.const 40672
+   i32.const 41264
+   i32.const 41312
    i32.const 1
    i32.const 1
    call $~lib/builtins/abort
@@ -4427,11 +4443,11 @@
   i32.sub
   global.set $~lib/memory/__stack_pointer
   global.get $~lib/memory/__stack_pointer
-  i32.const 7828
+  i32.const 8468
   i32.lt_s
   if
-   i32.const 40624
-   i32.const 40672
+   i32.const 41264
+   i32.const 41312
    i32.const 1
    i32.const 1
    call $~lib/builtins/abort
@@ -4549,11 +4565,11 @@
   i32.sub
   global.set $~lib/memory/__stack_pointer
   global.get $~lib/memory/__stack_pointer
-  i32.const 7828
+  i32.const 8468
   i32.lt_s
   if
-   i32.const 40624
-   i32.const 40672
+   i32.const 41264
+   i32.const 41312
    i32.const 1
    i32.const 1
    call $~lib/builtins/abort
@@ -4891,11 +4907,11 @@
   i32.sub
   global.set $~lib/memory/__stack_pointer
   global.get $~lib/memory/__stack_pointer
-  i32.const 7828
+  i32.const 8468
   i32.lt_s
   if
-   i32.const 40624
-   i32.const 40672
+   i32.const 41264
+   i32.const 41312
    i32.const 1
    i32.const 1
    call $~lib/builtins/abort
@@ -5009,11 +5025,11 @@
   i32.sub
   global.set $~lib/memory/__stack_pointer
   global.get $~lib/memory/__stack_pointer
-  i32.const 7828
+  i32.const 8468
   i32.lt_s
   if
-   i32.const 40624
-   i32.const 40672
+   i32.const 41264
+   i32.const 41312
    i32.const 1
    i32.const 1
    call $~lib/builtins/abort
@@ -5127,11 +5143,11 @@
   i32.sub
   global.set $~lib/memory/__stack_pointer
   global.get $~lib/memory/__stack_pointer
-  i32.const 7828
+  i32.const 8468
   i32.lt_s
   if
-   i32.const 40624
-   i32.const 40672
+   i32.const 41264
+   i32.const 41312
    i32.const 1
    i32.const 1
    call $~lib/builtins/abort
@@ -5176,11 +5192,11 @@
   i32.sub
   global.set $~lib/memory/__stack_pointer
   global.get $~lib/memory/__stack_pointer
-  i32.const 7828
+  i32.const 8468
   i32.lt_s
   if
-   i32.const 40624
-   i32.const 40672
+   i32.const 41264
+   i32.const 41312
    i32.const 1
    i32.const 1
    call $~lib/builtins/abort
@@ -5215,7 +5231,7 @@
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store
-   block $__inlined_func$~lib/rt/itcms/__renew$350
+   block $__inlined_func$~lib/rt/itcms/__renew$362
     i32.const 1073741820
     local.get $2
     i32.const 1
@@ -5258,7 +5274,7 @@
      i32.store offset=16
      local.get $2
      local.set $1
-     br $__inlined_func$~lib/rt/itcms/__renew$350
+     br $__inlined_func$~lib/rt/itcms/__renew$362
     end
     local.get $3
     local.get $4
@@ -5308,11 +5324,11 @@
   i32.sub
   global.set $~lib/memory/__stack_pointer
   global.get $~lib/memory/__stack_pointer
-  i32.const 7828
+  i32.const 8468
   i32.lt_s
   if
-   i32.const 40624
-   i32.const 40672
+   i32.const 41264
+   i32.const 41312
    i32.const 1
    i32.const 1
    call $~lib/builtins/abort
@@ -5377,7 +5393,7 @@
     block $folding-inner1
      block $folding-inner0
       global.get $~lib/memory/__stack_pointer
-      i32.const 7828
+      i32.const 8468
       i32.lt_s
       br_if $folding-inner0
       global.get $~lib/memory/__stack_pointer
@@ -5404,7 +5420,7 @@
        i32.sub
        global.set $~lib/memory/__stack_pointer
        global.get $~lib/memory/__stack_pointer
-       i32.const 7828
+       i32.const 8468
        i32.lt_s
        br_if $folding-inner0
        global.get $~lib/memory/__stack_pointer
@@ -5700,8 +5716,8 @@
       local.get $8
       return
      end
-     i32.const 40624
-     i32.const 40672
+     i32.const 41264
+     i32.const 41312
      i32.const 1
      i32.const 1
      call $~lib/builtins/abort
@@ -5732,11 +5748,11 @@
   i32.sub
   global.set $~lib/memory/__stack_pointer
   global.get $~lib/memory/__stack_pointer
-  i32.const 7828
+  i32.const 8468
   i32.lt_s
   if
-   i32.const 40624
-   i32.const 40672
+   i32.const 41264
+   i32.const 41312
    i32.const 1
    i32.const 1
    call $~lib/builtins/abort
@@ -5778,39 +5794,6 @@
   global.set $~lib/memory/__stack_pointer
   local.get $0
  )
- (func $~lib/array/Array<~lib/string/String>#get:length (param $0 i32) (result i32)
-  (local $1 i32)
-  global.get $~lib/memory/__stack_pointer
-  i32.const 4
-  i32.sub
-  global.set $~lib/memory/__stack_pointer
-  global.get $~lib/memory/__stack_pointer
-  i32.const 7828
-  i32.lt_s
-  if
-   i32.const 40624
-   i32.const 40672
-   i32.const 1
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  global.get $~lib/memory/__stack_pointer
-  local.tee $1
-  i32.const 0
-  i32.store
-  local.get $1
-  local.get $0
-  i32.store
-  local.get $0
-  i32.load offset=12
-  local.set $0
-  local.get $1
-  i32.const 4
-  i32.add
-  global.set $~lib/memory/__stack_pointer
-  local.get $0
- )
  (func $~lib/array/Array<~lib/string/String>#__get (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   global.get $~lib/memory/__stack_pointer
@@ -5818,11 +5801,11 @@
   i32.sub
   global.set $~lib/memory/__stack_pointer
   global.get $~lib/memory/__stack_pointer
-  i32.const 7828
+  i32.const 8468
   i32.lt_s
   if
-   i32.const 40624
-   i32.const 40672
+   i32.const 41264
+   i32.const 41312
    i32.const 1
    i32.const 1
    call $~lib/builtins/abort
@@ -5890,11 +5873,11 @@
   i32.sub
   global.set $~lib/memory/__stack_pointer
   global.get $~lib/memory/__stack_pointer
-  i32.const 7828
+  i32.const 8468
   i32.lt_s
   if
-   i32.const 40624
-   i32.const 40672
+   i32.const 41264
+   i32.const 41312
    i32.const 1
    i32.const 1
    call $~lib/builtins/abort
@@ -5922,7 +5905,7 @@
    i32.load16_u
    local.set $0
    loop $while-continue|0
-    block $__inlined_func$~lib/util/string/isSpace$183 (result i32)
+    block $__inlined_func$~lib/util/string/isSpace$182 (result i32)
      local.get $0
      i32.const 128
      i32.or
@@ -5937,7 +5920,7 @@
      local.get $0
      i32.const 5760
      i32.lt_u
-     br_if $__inlined_func$~lib/util/string/isSpace$183
+     br_if $__inlined_func$~lib/util/string/isSpace$182
      drop
      i32.const 1
      local.get $0
@@ -5945,7 +5928,7 @@
      i32.add
      i32.const 10
      i32.le_u
-     br_if $__inlined_func$~lib/util/string/isSpace$183
+     br_if $__inlined_func$~lib/util/string/isSpace$182
      drop
      block $break|0
       block $case0|0
@@ -5980,7 +5963,7 @@
        br $break|0
       end
       i32.const 1
-      br $__inlined_func$~lib/util/string/isSpace$183
+      br $__inlined_func$~lib/util/string/isSpace$182
      end
      i32.const 0
     end
@@ -6181,18 +6164,18 @@
   global.set $~lib/memory/__stack_pointer
   i32.const 0
  )
- (func $~lib/number/I32.parseInt (param $0 i32) (result i32)
+ (func $~lib/array/Array<~lib/string/String>#get:length (param $0 i32) (result i32)
   (local $1 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 4
   i32.sub
   global.set $~lib/memory/__stack_pointer
   global.get $~lib/memory/__stack_pointer
-  i32.const 7828
+  i32.const 8468
   i32.lt_s
   if
-   i32.const 40624
-   i32.const 40672
+   i32.const 41264
+   i32.const 41312
    i32.const 1
    i32.const 1
    call $~lib/builtins/abort
@@ -6206,9 +6189,9 @@
   local.get $0
   i32.store
   local.get $0
-  call $~lib/util/string/strtol<i32>
+  i32.load offset=12
   local.set $0
-  global.get $~lib/memory/__stack_pointer
+  local.get $1
   i32.const 4
   i32.add
   global.set $~lib/memory/__stack_pointer
@@ -6222,300 +6205,734 @@
   (local $5 i32)
   (local $6 i32)
   (local $7 i32)
+  (local $8 i32)
+  (local $9 i32)
+  (local $10 i32)
+  (local $11 i32)
+  (local $12 i32)
   global.get $~lib/memory/__stack_pointer
-  i32.const 28
+  i32.const 76
   i32.sub
   global.set $~lib/memory/__stack_pointer
-  global.get $~lib/memory/__stack_pointer
-  i32.const 7828
-  i32.lt_s
-  if
-   i32.const 40624
-   i32.const 40672
+  block $folding-inner0
+   global.get $~lib/memory/__stack_pointer
+   i32.const 8468
+   i32.lt_s
+   br_if $folding-inner0
+   global.get $~lib/memory/__stack_pointer
+   local.tee $1
+   i32.const 0
+   i32.const 76
+   memory.fill
+   local.get $1
+   local.get $0
+   i32.store
+   local.get $0
+   i32.const 20
+   i32.sub
+   i32.load offset=16
    i32.const 1
+   i32.shr_u
+   i32.eqz
+   if
+    i32.const 1056
+    i32.const 1104
+    i32.const 50
+    i32.const 33
+    call $~lib/builtins/abort
+    unreachable
+   end
+   global.get $~lib/memory/__stack_pointer
+   local.tee $1
+   local.get $0
+   i32.store offset=4
+   local.get $1
+   local.get $0
+   i32.store
+   local.get $1
+   i32.const 3488
+   i32.store offset=8
+   local.get $0
+   local.tee $1
+   i32.const 3488
+   i32.const 0
+   call $~lib/string/String#indexOf
+   local.tee $2
+   i32.const -1
+   i32.xor
+   if
+    global.get $~lib/memory/__stack_pointer
+    local.get $0
+    i32.store
+    global.get $~lib/memory/__stack_pointer
+    local.get $0
+    i32.const 0
+    local.get $2
+    call $~lib/string/String#substring
+    local.tee $1
+    i32.store offset=4
+    global.get $~lib/memory/__stack_pointer
+    local.get $0
+    i32.store
+    i32.const 1
+    global.set $~argumentsLength
+    global.get $~lib/memory/__stack_pointer
+    local.get $0
+    local.get $2
+    i32.const 1
+    i32.add
+    call $~lib/string/String#substring@varargs
+    local.tee $0
+    i32.store offset=12
+    global.get $~lib/memory/__stack_pointer
+    local.get $0
+    i32.store
+    local.get $0
+    i32.const 20
+    i32.sub
+    i32.load offset=16
+    i32.const 1
+    i32.shr_u
+    i32.const 1
+    i32.sub
+    local.set $5
+    loop $for-loop|0
+     local.get $5
+     i32.const 0
+     i32.ge_s
+     if
+      global.get $~lib/memory/__stack_pointer
+      local.tee $2
+      local.get $0
+      i32.store
+      local.get $2
+      i32.const 4
+      i32.sub
+      global.set $~lib/memory/__stack_pointer
+      global.get $~lib/memory/__stack_pointer
+      i32.const 8468
+      i32.lt_s
+      br_if $folding-inner0
+      global.get $~lib/memory/__stack_pointer
+      local.tee $2
+      i32.const 0
+      i32.store
+      local.get $2
+      local.get $0
+      i32.store
+      block $__inlined_func$~lib/string/String#charCodeAt$386
+       local.get $5
+       local.get $0
+       i32.const 20
+       i32.sub
+       i32.load offset=16
+       i32.const 1
+       i32.shr_u
+       i32.ge_u
+       if
+        local.get $2
+        i32.const 4
+        i32.add
+        global.set $~lib/memory/__stack_pointer
+        i32.const -1
+        local.set $2
+        br $__inlined_func$~lib/string/String#charCodeAt$386
+       end
+       local.get $0
+       local.get $5
+       i32.const 1
+       i32.shl
+       i32.add
+       i32.load16_u
+       local.set $2
+       global.get $~lib/memory/__stack_pointer
+       i32.const 4
+       i32.add
+       global.set $~lib/memory/__stack_pointer
+      end
+      block $for-break0
+       local.get $2
+       i32.const 90
+       i32.eq
+       br_if $for-break0
+       local.get $2
+       i32.const 45
+       i32.eq
+       local.get $2
+       i32.const 43
+       i32.eq
+       i32.or
+       if
+        global.get $~lib/memory/__stack_pointer
+        local.get $0
+        i32.store
+        local.get $5
+        local.get $0
+        i32.const 20
+        i32.sub
+        i32.load offset=16
+        i32.const 1
+        i32.shr_u
+        i32.const 1
+        i32.sub
+        i32.eq
+        if
+         i32.const 1056
+         i32.const 1104
+         i32.const 74
+         i32.const 13
+         call $~lib/builtins/abort
+         unreachable
+        end
+        global.get $~lib/memory/__stack_pointer
+        local.tee $4
+        local.get $0
+        i32.store offset=16
+        i32.const 1
+        global.set $~argumentsLength
+        local.get $0
+        local.get $5
+        i32.const 1
+        i32.add
+        call $~lib/string/String#substring@varargs
+        local.set $7
+        global.get $~lib/memory/__stack_pointer
+        local.get $7
+        i32.store
+        global.get $~lib/memory/__stack_pointer
+        i32.const 3520
+        i32.store offset=8
+        i32.const 1
+        global.set $~argumentsLength
+        local.get $4
+        local.get $7
+        i32.const 3520
+        call $~lib/string/String#split@varargs
+        local.tee $4
+        i32.store offset=20
+        global.get $~lib/memory/__stack_pointer
+        local.get $4
+        i32.store
+        global.get $~lib/memory/__stack_pointer
+        local.get $4
+        i32.const 0
+        call $~lib/array/Array<~lib/string/String>#__get
+        local.tee $7
+        i32.store offset=24
+        global.get $~lib/memory/__stack_pointer
+        local.get $7
+        i32.store
+        local.get $7
+        call $~lib/util/string/strtol<i32>
+        local.set $7
+        global.get $~lib/memory/__stack_pointer
+        local.get $4
+        i32.store
+        i32.const 0
+        local.get $4
+        call $~lib/array/Array<~lib/string/String>#get:length
+        i32.const 2
+        i32.ge_s
+        if (result i32)
+         global.get $~lib/memory/__stack_pointer
+         local.get $4
+         i32.store
+         global.get $~lib/memory/__stack_pointer
+         local.get $4
+         i32.const 1
+         call $~lib/array/Array<~lib/string/String>#__get
+         local.tee $4
+         i32.store offset=28
+         global.get $~lib/memory/__stack_pointer
+         local.get $4
+         i32.store
+         local.get $4
+         call $~lib/util/string/strtol<i32>
+        else
+         i32.const 0
+        end
+        local.get $7
+        i32.const 60
+        i32.mul
+        i32.add
+        i32.const 60000
+        i32.mul
+        local.tee $4
+        i32.sub
+        local.get $4
+        local.get $2
+        i32.const 45
+        i32.eq
+        select
+        local.set $7
+        br $for-break0
+       end
+       local.get $5
+       i32.const 1
+       i32.sub
+       local.set $5
+       br $for-loop|0
+      end
+      global.get $~lib/memory/__stack_pointer
+      local.tee $2
+      local.get $0
+      i32.store
+      local.get $2
+      local.get $0
+      i32.const 0
+      local.get $5
+      call $~lib/string/String#substring
+      local.tee $0
+      i32.store offset=12
+     end
+    end
+    global.get $~lib/memory/__stack_pointer
+    local.tee $2
+    local.get $0
+    i32.store
+    local.get $2
+    i32.const 3520
+    i32.store offset=8
+    i32.const 1
+    global.set $~argumentsLength
+    local.get $2
+    local.get $0
+    i32.const 3520
+    call $~lib/string/String#split@varargs
+    local.tee $0
+    i32.store offset=32
+    global.get $~lib/memory/__stack_pointer
+    local.get $0
+    i32.store
+    local.get $0
+    call $~lib/array/Array<~lib/string/String>#get:length
+    local.tee $2
+    i32.const 1
+    i32.le_s
+    if
+     i32.const 1056
+     i32.const 1104
+     i32.const 91
+     i32.const 21
+     call $~lib/builtins/abort
+     unreachable
+    end
+    global.get $~lib/memory/__stack_pointer
+    local.tee $4
+    local.get $0
+    i32.store
+    local.get $4
+    local.get $0
+    i32.const 0
+    call $~lib/array/Array<~lib/string/String>#__get
+    local.tee $4
+    i32.store offset=36
+    global.get $~lib/memory/__stack_pointer
+    local.get $4
+    i32.store
+    local.get $4
+    call $~lib/util/string/strtol<i32>
+    local.set $5
+    global.get $~lib/memory/__stack_pointer
+    local.get $0
+    i32.store
+    global.get $~lib/memory/__stack_pointer
+    local.get $0
+    i32.const 1
+    call $~lib/array/Array<~lib/string/String>#__get
+    local.tee $4
+    i32.store offset=40
+    global.get $~lib/memory/__stack_pointer
+    local.get $4
+    i32.store
+    local.get $4
+    call $~lib/util/string/strtol<i32>
+    local.set $4
+    local.get $2
+    i32.const 3
+    i32.ge_s
+    if
+     global.get $~lib/memory/__stack_pointer
+     local.get $0
+     i32.store
+     global.get $~lib/memory/__stack_pointer
+     local.get $0
+     i32.const 2
+     call $~lib/array/Array<~lib/string/String>#__get
+     local.tee $2
+     i32.store offset=44
+     global.get $~lib/memory/__stack_pointer
+     local.get $2
+     i32.store
+     global.get $~lib/memory/__stack_pointer
+     i32.const 3552
+     i32.store offset=8
+     local.get $2
+     i32.const 3552
+     i32.const 0
+     call $~lib/string/String#indexOf
+     local.tee $0
+     i32.const -1
+     i32.xor
+     if
+      global.get $~lib/memory/__stack_pointer
+      local.get $2
+      i32.store
+      global.get $~lib/memory/__stack_pointer
+      local.get $2
+      i32.const 0
+      local.get $0
+      call $~lib/string/String#substring
+      local.tee $6
+      i32.store offset=48
+      global.get $~lib/memory/__stack_pointer
+      local.get $6
+      i32.store
+      local.get $6
+      call $~lib/util/string/strtol<i32>
+      local.set $6
+      global.get $~lib/memory/__stack_pointer
+      local.set $8
+      block $__inlined_func$~lib/string/String#substr$387 (result i32)
+       global.get $~lib/memory/__stack_pointer
+       local.get $2
+       i32.store offset=16
+       local.get $0
+       i32.const 1
+       i32.add
+       local.set $0
+       global.get $~lib/memory/__stack_pointer
+       i32.const 8
+       i32.sub
+       global.set $~lib/memory/__stack_pointer
+       global.get $~lib/memory/__stack_pointer
+       i32.const 8468
+       i32.lt_s
+       br_if $folding-inner0
+       global.get $~lib/memory/__stack_pointer
+       local.tee $9
+       i64.const 0
+       i64.store
+       local.get $9
+       local.get $2
+       i32.store
+       i32.const 3
+       local.get $2
+       i32.const 20
+       i32.sub
+       i32.load offset=16
+       i32.const 1
+       i32.shr_u
+       local.tee $9
+       local.get $0
+       i32.const 0
+       i32.lt_s
+       if
+        local.get $0
+        local.get $9
+        i32.add
+        local.tee $0
+        i32.const 0
+        local.get $0
+        i32.const 0
+        i32.gt_s
+        select
+        local.set $0
+       end
+       local.get $0
+       i32.sub
+       local.tee $9
+       local.get $9
+       i32.const 3
+       i32.gt_s
+       select
+       i32.const 1
+       i32.shl
+       local.tee $9
+       i32.const 0
+       i32.le_s
+       if
+        global.get $~lib/memory/__stack_pointer
+        i32.const 8
+        i32.add
+        global.set $~lib/memory/__stack_pointer
+        i32.const 3456
+        br $__inlined_func$~lib/string/String#substr$387
+       end
+       global.get $~lib/memory/__stack_pointer
+       local.get $9
+       i32.const 2
+       call $~lib/rt/itcms/__new
+       local.tee $10
+       i32.store offset=4
+       local.get $10
+       local.get $2
+       local.get $0
+       i32.const 1
+       i32.shl
+       i32.add
+       local.get $9
+       memory.copy
+       global.get $~lib/memory/__stack_pointer
+       i32.const 8
+       i32.add
+       global.set $~lib/memory/__stack_pointer
+       local.get $10
+      end
+      local.set $0
+      global.get $~lib/memory/__stack_pointer
+      local.tee $2
+      local.get $0
+      i32.store
+      local.get $2
+      i32.const 1872
+      i32.store offset=8
+      local.get $2
+      i32.const 8
+      i32.sub
+      global.set $~lib/memory/__stack_pointer
+      global.get $~lib/memory/__stack_pointer
+      i32.const 8468
+      i32.lt_s
+      br_if $folding-inner0
+      global.get $~lib/memory/__stack_pointer
+      local.tee $2
+      i64.const 0
+      i64.store
+      local.get $2
+      local.get $0
+      i32.store
+      local.get $0
+      i32.const 20
+      i32.sub
+      i32.load offset=16
+      i32.const -2
+      i32.and
+      local.set $10
+      local.get $2
+      i32.const 1872
+      i32.store
+      block $__inlined_func$~lib/string/String#padEnd$388
+       i32.const 1868
+       i32.load
+       i32.const -2
+       i32.and
+       local.tee $11
+       i32.eqz
+       local.get $10
+       i32.const 6
+       i32.gt_u
+       i32.or
+       if
+        local.get $2
+        i32.const 8
+        i32.add
+        global.set $~lib/memory/__stack_pointer
+        br $__inlined_func$~lib/string/String#padEnd$388
+       end
+       global.get $~lib/memory/__stack_pointer
+       i32.const 6
+       i32.const 2
+       call $~lib/rt/itcms/__new
+       local.tee $2
+       i32.store offset=4
+       local.get $2
+       local.get $0
+       local.get $10
+       memory.copy
+       i32.const 6
+       local.get $10
+       i32.sub
+       local.tee $0
+       local.get $11
+       i32.gt_u
+       if
+        local.get $0
+        local.get $0
+        i32.const 2
+        i32.sub
+        local.get $11
+        i32.div_u
+        local.get $11
+        i32.mul
+        local.tee $12
+        i32.sub
+        local.set $0
+        local.get $2
+        local.get $10
+        i32.add
+        local.set $9
+        loop $while-continue|0
+         local.get $3
+         local.get $12
+         i32.lt_u
+         if
+          local.get $3
+          local.get $9
+          i32.add
+          i32.const 1872
+          local.get $11
+          memory.copy
+          local.get $3
+          local.get $11
+          i32.add
+          local.set $3
+          br $while-continue|0
+         end
+        end
+        local.get $2
+        local.get $10
+        i32.add
+        local.get $12
+        i32.add
+        i32.const 1872
+        local.get $0
+        memory.copy
+       else
+        local.get $2
+        local.get $10
+        i32.add
+        i32.const 1872
+        local.get $0
+        memory.copy
+       end
+       global.get $~lib/memory/__stack_pointer
+       i32.const 8
+       i32.add
+       global.set $~lib/memory/__stack_pointer
+       local.get $2
+       local.set $0
+      end
+      local.get $8
+      local.get $0
+      i32.store offset=52
+      global.get $~lib/memory/__stack_pointer
+      local.get $0
+      i32.store
+      local.get $0
+      call $~lib/util/string/strtol<i32>
+      local.set $3
+     else
+      global.get $~lib/memory/__stack_pointer
+      local.tee $0
+      local.get $2
+      i32.store offset=56
+      local.get $0
+      local.get $2
+      i32.store
+      local.get $2
+      call $~lib/util/string/strtol<i32>
+      local.set $6
+     end
+    end
+   end
+   global.get $~lib/memory/__stack_pointer
+   local.tee $0
+   local.get $1
+   i32.store
+   local.get $0
+   i32.const 1616
+   i32.store offset=8
    i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  global.get $~lib/memory/__stack_pointer
-  local.tee $1
-  i32.const 0
-  i32.const 28
-  memory.fill
-  local.get $1
-  local.get $0
-  i32.store
-  local.get $0
-  i32.const 20
-  i32.sub
-  i32.load offset=16
-  i32.const 1
-  i32.shr_u
-  i32.eqz
-  if
-   i32.const 1056
-   i32.const 1104
-   i32.const 50
-   i32.const 33
-   call $~lib/builtins/abort
-   unreachable
-  end
-  global.get $~lib/memory/__stack_pointer
-  local.tee $1
-  local.get $0
-  i32.store offset=4
-  local.get $1
-  local.get $0
-  i32.store
-  local.get $1
-  i32.const 3488
-  i32.store offset=8
-  local.get $0
-  local.tee $1
-  i32.const 3488
-  i32.const 0
-  call $~lib/string/String#indexOf
-  local.tee $6
-  i32.const -1
-  i32.xor
-  if
+   global.set $~argumentsLength
+   local.get $0
+   local.get $1
+   i32.const 1616
+   call $~lib/string/String#split@varargs
+   local.tee $0
+   i32.store offset=60
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.const 0
-   local.get $6
-   call $~lib/string/String#substring
+   call $~lib/array/Array<~lib/string/String>#__get
    local.tee $1
-   i32.store offset=4
+   i32.store offset=64
    global.get $~lib/memory/__stack_pointer
-   local.get $0
+   local.get $1
    i32.store
+   local.get $1
+   call $~lib/util/string/strtol<i32>
+   local.set $2
    i32.const 1
-   global.set $~argumentsLength
-   global.get $~lib/memory/__stack_pointer
-   local.get $0
-   local.get $6
-   i32.const 1
-   i32.add
-   call $~lib/string/String#substring@varargs
-   local.tee $0
-   i32.store offset=12
-   global.get $~lib/memory/__stack_pointer
-   local.get $0
-   i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 3520
-   i32.store offset=8
-   i32.const 1
-   global.set $~argumentsLength
-   global.get $~lib/memory/__stack_pointer
-   local.get $0
-   i32.const 3520
-   call $~lib/string/String#split@varargs
-   local.tee $0
-   i32.store offset=16
+   local.set $1
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store
    local.get $0
    call $~lib/array/Array<~lib/string/String>#get:length
-   local.tee $6
-   i32.const 1
-   i32.le_s
-   if
-    i32.const 1056
-    i32.const 1104
-    i32.const 67
-    i32.const 21
-    call $~lib/builtins/abort
-    unreachable
-   end
-   global.get $~lib/memory/__stack_pointer
-   local.get $0
-   i32.store offset=8
-   local.get $0
-   i32.const 0
-   call $~lib/array/Array<~lib/string/String>#__get
-   local.set $3
-   global.get $~lib/memory/__stack_pointer
-   local.get $3
-   i32.store
-   local.get $3
-   call $~lib/number/I32.parseInt
-   local.set $3
-   global.get $~lib/memory/__stack_pointer
-   local.get $0
-   i32.store offset=8
-   local.get $0
-   i32.const 1
-   call $~lib/array/Array<~lib/string/String>#__get
-   local.set $4
-   global.get $~lib/memory/__stack_pointer
-   local.get $4
-   i32.store
-   local.get $4
-   call $~lib/number/I32.parseInt
-   local.set $4
-   local.get $6
-   i32.const 3
-   i32.ge_s
-   if
-    global.get $~lib/memory/__stack_pointer
-    local.get $0
-    i32.store
-    global.get $~lib/memory/__stack_pointer
-    local.get $0
-    i32.const 2
-    call $~lib/array/Array<~lib/string/String>#__get
-    local.tee $0
-    i32.store offset=20
-    global.get $~lib/memory/__stack_pointer
-    local.get $0
-    i32.store
-    global.get $~lib/memory/__stack_pointer
-    i32.const 3552
-    i32.store offset=8
-    local.get $0
-    i32.const 3552
-    i32.const 0
-    call $~lib/string/String#indexOf
-    local.tee $6
-    i32.const -1
-    i32.xor
-    if
-     global.get $~lib/memory/__stack_pointer
-     local.get $0
-     i32.store offset=8
-     local.get $0
-     i32.const 0
-     local.get $6
-     call $~lib/string/String#substring
-     local.set $2
-     global.get $~lib/memory/__stack_pointer
-     local.get $2
-     i32.store
-     local.get $2
-     call $~lib/number/I32.parseInt
-     local.set $2
-     global.get $~lib/memory/__stack_pointer
-     local.get $0
-     i32.store offset=8
-     i32.const 1
-     global.set $~argumentsLength
-     local.get $0
-     local.get $6
-     i32.const 1
-     i32.add
-     call $~lib/string/String#substring@varargs
-     local.set $0
-     global.get $~lib/memory/__stack_pointer
-     local.get $0
-     i32.store
-     local.get $0
-     call $~lib/number/I32.parseInt
-     local.set $5
-    else
-     global.get $~lib/memory/__stack_pointer
-     local.get $0
-     i32.store
-     local.get $0
-     call $~lib/number/I32.parseInt
-     local.set $2
-    end
-   end
-  end
-  global.get $~lib/memory/__stack_pointer
-  local.tee $0
-  local.get $1
-  i32.store
-  local.get $0
-  i32.const 1616
-  i32.store offset=8
-  i32.const 1
-  global.set $~argumentsLength
-  local.get $0
-  local.get $1
-  i32.const 1616
-  call $~lib/string/String#split@varargs
-  local.tee $0
-  i32.store offset=24
-  global.get $~lib/memory/__stack_pointer
-  local.get $0
-  i32.store offset=8
-  local.get $0
-  i32.const 0
-  call $~lib/array/Array<~lib/string/String>#__get
-  local.set $1
-  global.get $~lib/memory/__stack_pointer
-  local.get $1
-  i32.store
-  local.get $1
-  call $~lib/number/I32.parseInt
-  local.set $7
-  i32.const 1
-  local.set $1
-  global.get $~lib/memory/__stack_pointer
-  local.get $0
-  i32.store
-  local.get $0
-  call $~lib/array/Array<~lib/string/String>#get:length
-  local.tee $6
-  i32.const 2
-  i32.ge_s
-  if (result i32)
-   global.get $~lib/memory/__stack_pointer
-   local.get $0
-   i32.store offset=8
-   local.get $0
-   i32.const 1
-   call $~lib/array/Array<~lib/string/String>#__get
-   local.set $1
-   global.get $~lib/memory/__stack_pointer
-   local.get $1
-   i32.store
-   local.get $1
-   call $~lib/number/I32.parseInt
-   local.set $1
-   local.get $6
-   i32.const 3
+   local.tee $8
+   i32.const 2
    i32.ge_s
    if (result i32)
     global.get $~lib/memory/__stack_pointer
     local.get $0
-    i32.store offset=8
-    local.get $0
-    i32.const 2
-    call $~lib/array/Array<~lib/string/String>#__get
-    local.set $0
+    i32.store
     global.get $~lib/memory/__stack_pointer
     local.get $0
+    i32.const 1
+    call $~lib/array/Array<~lib/string/String>#__get
+    local.tee $1
+    i32.store offset=68
+    global.get $~lib/memory/__stack_pointer
+    local.get $1
     i32.store
-    local.get $0
-    call $~lib/number/I32.parseInt
+    local.get $1
+    call $~lib/util/string/strtol<i32>
+    local.set $1
+    local.get $8
+    i32.const 3
+    i32.ge_s
+    if (result i32)
+     global.get $~lib/memory/__stack_pointer
+     local.get $0
+     i32.store
+     global.get $~lib/memory/__stack_pointer
+     local.get $0
+     i32.const 2
+     call $~lib/array/Array<~lib/string/String>#__get
+     local.tee $0
+     i32.store offset=72
+     global.get $~lib/memory/__stack_pointer
+     local.get $0
+     i32.store
+     local.get $0
+     call $~lib/util/string/strtol<i32>
+    else
+     i32.const 1
+    end
    else
     i32.const 1
    end
-  else
-   i32.const 1
+   local.set $0
+   local.get $2
+   local.get $1
+   local.get $0
+   local.get $5
+   local.get $4
+   local.get $6
+   local.get $3
+   call $~lib/date/epochMillis
+   local.get $7
+   i64.extend_i32_s
+   i64.sub
+   call $~lib/date/Date#constructor
+   local.set $0
+   global.get $~lib/memory/__stack_pointer
+   i32.const 76
+   i32.add
+   global.set $~lib/memory/__stack_pointer
+   local.get $0
+   return
   end
-  local.set $0
-  local.get $7
-  local.get $1
-  local.get $0
-  local.get $3
-  local.get $4
-  local.get $2
-  local.get $5
-  call $~lib/date/epochMillis
-  call $~lib/date/Date#constructor
-  local.set $0
-  global.get $~lib/memory/__stack_pointer
-  i32.const 28
-  i32.add
-  global.set $~lib/memory/__stack_pointer
-  local.get $0
+  i32.const 41264
+  i32.const 41312
+  i32.const 1
+  i32.const 1
+  call $~lib/builtins/abort
+  unreachable
  )
  (func $start:std/date
   (local $0 i32)
@@ -6523,15 +6940,15 @@
   (local $2 i32)
   (local $3 i32)
   global.get $~lib/memory/__stack_pointer
-  i32.const 408
+  i32.const 440
   i32.sub
   global.set $~lib/memory/__stack_pointer
   global.get $~lib/memory/__stack_pointer
-  i32.const 7828
+  i32.const 8468
   i32.lt_s
   if
-   i32.const 40624
-   i32.const 40672
+   i32.const 41264
+   i32.const 41312
    i32.const 1
    i32.const 1
    call $~lib/builtins/abort
@@ -6539,7 +6956,7 @@
   end
   global.get $~lib/memory/__stack_pointer
   i32.const 0
-  i32.const 408
+  i32.const 440
   memory.fill
   block $folding-inner0
    i32.const 1970
@@ -6734,7 +7151,7 @@
    memory.size
    i32.const 16
    i32.shl
-   i32.const 40596
+   i32.const 41236
    i32.sub
    i32.const 1
    i32.shr_u
@@ -9723,22 +10140,22 @@
    i32.store offset=8
    local.get $0
    i64.load offset=16
-   i64.const -62167219200000
+   i64.const 192141296456
    i64.ne
    if
     i32.const 0
     i32.const 1152
-    i32.const 310
+    i32.const 311
     i32.const 3
     call $~lib/builtins/abort
     unreachable
    end
    global.get $~lib/memory/__stack_pointer
    local.tee $0
-   i32.const 7312
+   i32.const 7360
    i32.store offset=8
    local.get $0
-   i32.const 7312
+   i32.const 7360
    call $~lib/date/Date.fromString
    local.tee $0
    i32.store offset=292
@@ -9750,22 +10167,22 @@
    i32.store offset=8
    local.get $0
    i64.load offset=16
-   i64.const -62135596800000
+   i64.const 192092696456
    i64.ne
    if
     i32.const 0
     i32.const 1152
-    i32.const 313
+    i32.const 315
     i32.const 3
     call $~lib/builtins/abort
     unreachable
    end
    global.get $~lib/memory/__stack_pointer
    local.tee $0
-   i32.const 7344
+   i32.const 7440
    i32.store offset=8
    local.get $0
-   i32.const 7344
+   i32.const 7440
    call $~lib/date/Date.fromString
    local.tee $0
    i32.store offset=292
@@ -9777,34 +10194,7 @@
    i32.store offset=8
    local.get $0
    i64.load offset=16
-   i64.const 189302400000
-   i64.ne
-   if
-    i32.const 0
-    i32.const 1152
-    i32.const 316
-    i32.const 3
-    call $~lib/builtins/abort
-    unreachable
-   end
-   global.get $~lib/memory/__stack_pointer
-   local.tee $0
-   i32.const 7376
-   i32.store offset=8
-   local.get $0
-   i32.const 7376
-   call $~lib/date/Date.fromString
-   local.tee $0
-   i32.store offset=292
-   global.get $~lib/memory/__stack_pointer
-   local.get $0
-   i32.store offset=332
-   global.get $~lib/memory/__stack_pointer
-   local.get $0
-   i32.store offset=8
-   local.get $0
-   i64.load offset=16
-   i64.const 191980800000
+   i64.const 192112496450
    i64.ne
    if
     i32.const 0
@@ -9816,10 +10206,37 @@
    end
    global.get $~lib/memory/__stack_pointer
    local.tee $0
-   i32.const 6688
+   i32.const 7504
    i32.store offset=8
    local.get $0
-   i32.const 6688
+   i32.const 7504
+   call $~lib/date/Date.fromString
+   local.tee $0
+   i32.store offset=292
+   global.get $~lib/memory/__stack_pointer
+   local.get $0
+   i32.store offset=332
+   global.get $~lib/memory/__stack_pointer
+   local.get $0
+   i32.store offset=8
+   local.get $0
+   i64.load offset=16
+   i64.const 192112496450
+   i64.ne
+   if
+    i32.const 0
+    i32.const 1152
+    i32.const 323
+    i32.const 3
+    call $~lib/builtins/abort
+    unreachable
+   end
+   global.get $~lib/memory/__stack_pointer
+   local.tee $0
+   i32.const 7584
+   i32.store offset=8
+   local.get $0
+   i32.const 7584
    call $~lib/date/Date.fromString
    local.tee $0
    i32.store offset=292
@@ -9831,22 +10248,22 @@
    i32.store offset=8
    local.get $0
    i64.load offset=16
-   i64.const 192067200000
+   i64.const 192112496450
    i64.ne
    if
     i32.const 0
     i32.const 1152
-    i32.const 322
+    i32.const 327
     i32.const 3
     call $~lib/builtins/abort
     unreachable
    end
    global.get $~lib/memory/__stack_pointer
    local.tee $0
-   i32.const 7424
+   i32.const 7664
    i32.store offset=8
    local.get $0
-   i32.const 7424
+   i32.const 7664
    call $~lib/date/Date.fromString
    local.tee $0
    i32.store offset=292
@@ -9858,12 +10275,228 @@
    i32.store offset=8
    local.get $0
    i64.load offset=16
+   i64.const 192112496456
+   i64.ne
+   if
+    i32.const 0
+    i32.const 1152
+    i32.const 331
+    i32.const 3
+    call $~lib/builtins/abort
+    unreachable
+   end
+   global.get $~lib/memory/__stack_pointer
+   local.tee $0
+   i32.const 7744
+   i32.store offset=8
+   local.get $0
+   i32.const 7744
+   call $~lib/date/Date.fromString
+   local.tee $0
+   i32.store offset=292
+   global.get $~lib/memory/__stack_pointer
+   local.get $0
+   i32.store offset=344
+   global.get $~lib/memory/__stack_pointer
+   local.get $0
+   i32.store offset=8
+   local.get $0
+   i64.load offset=16
+   i64.const 192112496456
+   i64.ne
+   if
+    i32.const 0
+    i32.const 1152
+    i32.const 335
+    i32.const 3
+    call $~lib/builtins/abort
+    unreachable
+   end
+   global.get $~lib/memory/__stack_pointer
+   local.tee $0
+   i32.const 7824
+   i32.store offset=8
+   local.get $0
+   i32.const 7824
+   call $~lib/date/Date.fromString
+   local.tee $0
+   i32.store offset=292
+   global.get $~lib/memory/__stack_pointer
+   local.get $0
+   i32.store offset=348
+   global.get $~lib/memory/__stack_pointer
+   local.get $0
+   i32.store offset=8
+   local.get $0
+   i64.load offset=16
+   i64.const 192112496456
+   i64.ne
+   if
+    i32.const 0
+    i32.const 1152
+    i32.const 339
+    i32.const 3
+    call $~lib/builtins/abort
+    unreachable
+   end
+   global.get $~lib/memory/__stack_pointer
+   local.tee $0
+   i32.const 7920
+   i32.store offset=8
+   local.get $0
+   i32.const 7920
+   call $~lib/date/Date.fromString
+   local.tee $0
+   i32.store offset=292
+   global.get $~lib/memory/__stack_pointer
+   local.get $0
+   i32.store offset=352
+   global.get $~lib/memory/__stack_pointer
+   local.get $0
+   i32.store offset=8
+   local.get $0
+   i64.load offset=16
+   i64.const -62167219200000
+   i64.ne
+   if
+    i32.const 0
+    i32.const 1152
+    i32.const 342
+    i32.const 3
+    call $~lib/builtins/abort
+    unreachable
+   end
+   global.get $~lib/memory/__stack_pointer
+   local.tee $0
+   i32.const 7952
+   i32.store offset=8
+   local.get $0
+   i32.const 7952
+   call $~lib/date/Date.fromString
+   local.tee $0
+   i32.store offset=292
+   global.get $~lib/memory/__stack_pointer
+   local.get $0
+   i32.store offset=356
+   global.get $~lib/memory/__stack_pointer
+   local.get $0
+   i32.store offset=8
+   local.get $0
+   i64.load offset=16
+   i64.const -62135596800000
+   i64.ne
+   if
+    i32.const 0
+    i32.const 1152
+    i32.const 345
+    i32.const 3
+    call $~lib/builtins/abort
+    unreachable
+   end
+   global.get $~lib/memory/__stack_pointer
+   local.tee $0
+   i32.const 7984
+   i32.store offset=8
+   local.get $0
+   i32.const 7984
+   call $~lib/date/Date.fromString
+   local.tee $0
+   i32.store offset=292
+   global.get $~lib/memory/__stack_pointer
+   local.get $0
+   i32.store offset=360
+   global.get $~lib/memory/__stack_pointer
+   local.get $0
+   i32.store offset=8
+   local.get $0
+   i64.load offset=16
+   i64.const 189302400000
+   i64.ne
+   if
+    i32.const 0
+    i32.const 1152
+    i32.const 348
+    i32.const 3
+    call $~lib/builtins/abort
+    unreachable
+   end
+   global.get $~lib/memory/__stack_pointer
+   local.tee $0
+   i32.const 8016
+   i32.store offset=8
+   local.get $0
+   i32.const 8016
+   call $~lib/date/Date.fromString
+   local.tee $0
+   i32.store offset=292
+   global.get $~lib/memory/__stack_pointer
+   local.get $0
+   i32.store offset=364
+   global.get $~lib/memory/__stack_pointer
+   local.get $0
+   i32.store offset=8
+   local.get $0
+   i64.load offset=16
+   i64.const 191980800000
+   i64.ne
+   if
+    i32.const 0
+    i32.const 1152
+    i32.const 351
+    i32.const 3
+    call $~lib/builtins/abort
+    unreachable
+   end
+   global.get $~lib/memory/__stack_pointer
+   local.tee $0
+   i32.const 6688
+   i32.store offset=8
+   local.get $0
+   i32.const 6688
+   call $~lib/date/Date.fromString
+   local.tee $0
+   i32.store offset=292
+   global.get $~lib/memory/__stack_pointer
+   local.get $0
+   i32.store offset=368
+   global.get $~lib/memory/__stack_pointer
+   local.get $0
+   i32.store offset=8
+   local.get $0
+   i64.load offset=16
+   i64.const 192067200000
+   i64.ne
+   if
+    i32.const 0
+    i32.const 1152
+    i32.const 354
+    i32.const 3
+    call $~lib/builtins/abort
+    unreachable
+   end
+   global.get $~lib/memory/__stack_pointer
+   local.tee $0
+   i32.const 8064
+   i32.store offset=8
+   local.get $0
+   i32.const 8064
+   call $~lib/date/Date.fromString
+   local.tee $0
+   i32.store offset=292
+   global.get $~lib/memory/__stack_pointer
+   local.get $0
+   i32.store offset=372
+   global.get $~lib/memory/__stack_pointer
+   local.get $0
+   i32.store offset=8
+   local.get $0
+   i64.load offset=16
    i64.const 192112440000
    i64.ne
    if
     i32.const 0
     i32.const 1152
-    i32.const 325
+    i32.const 357
     i32.const 3
     call $~lib/builtins/abort
     unreachable
@@ -9879,7 +10512,7 @@
    i32.store offset=292
    global.get $~lib/memory/__stack_pointer
    local.get $0
-   i32.store offset=344
+   i32.store offset=376
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store offset=8
@@ -9890,7 +10523,7 @@
    if
     i32.const 0
     i32.const 1152
-    i32.const 328
+    i32.const 360
     i32.const 3
     call $~lib/builtins/abort
     unreachable
@@ -9899,235 +10532,64 @@
    i64.const -8640000000000000
    call $~lib/date/Date#constructor
    local.tee $0
-   i32.store offset=348
+   i32.store offset=380
    global.get $~lib/memory/__stack_pointer
    i64.const 8640000000000000
    call $~lib/date/Date#constructor
    local.tee $2
-   i32.store offset=352
-   global.get $~lib/memory/__stack_pointer
-   local.get $0
-   i32.store offset=356
-   global.get $~lib/memory/__stack_pointer
-   local.get $0
-   i32.store offset=8
-   local.get $0
-   i64.load offset=16
-   i64.const -8640000000000000
-   i64.ne
-   if
-    i32.const 0
-    i32.const 1152
-    i32.const 346
-    i32.const 3
-    call $~lib/builtins/abort
-    unreachable
-   end
-   global.get $~lib/memory/__stack_pointer
-   local.tee $3
-   local.get $2
-   i32.store offset=360
-   local.get $3
-   local.get $2
-   i32.store offset=8
-   local.get $2
-   i64.load offset=16
-   i64.const 8640000000000000
-   i64.ne
-   if
-    i32.const 0
-    i32.const 1152
-    i32.const 347
-    i32.const 3
-    call $~lib/builtins/abort
-    unreachable
-   end
-   global.get $~lib/memory/__stack_pointer
-   local.tee $3
-   local.get $0
-   i32.store offset=364
-   local.get $3
-   local.get $0
-   i32.store offset=8
-   local.get $0
-   i32.load
-   i32.const -271821
-   i32.ne
-   if
-    i32.const 0
-    i32.const 1152
-    i32.const 349
-    i32.const 3
-    call $~lib/builtins/abort
-    unreachable
-   end
-   global.get $~lib/memory/__stack_pointer
-   local.tee $3
-   local.get $2
-   i32.store offset=368
-   local.get $3
-   local.get $2
-   i32.store offset=8
-   local.get $2
-   i32.load
-   i32.const 275760
-   i32.ne
-   if
-    i32.const 0
-    i32.const 1152
-    i32.const 350
-    i32.const 3
-    call $~lib/builtins/abort
-    unreachable
-   end
-   global.get $~lib/memory/__stack_pointer
-   local.tee $3
-   local.get $0
-   i32.store offset=372
-   local.get $3
-   local.get $0
-   i32.store offset=8
-   local.get $0
-   i32.load offset=4
-   i32.const 4
-   i32.ne
-   if
-    i32.const 0
-    i32.const 1152
-    i32.const 352
-    i32.const 3
-    call $~lib/builtins/abort
-    unreachable
-   end
-   global.get $~lib/memory/__stack_pointer
-   local.tee $3
-   local.get $2
-   i32.store offset=376
-   local.get $3
-   local.get $2
-   i32.store offset=8
-   local.get $2
-   i32.load offset=4
-   i32.const 9
-   i32.ne
-   if
-    i32.const 0
-    i32.const 1152
-    i32.const 353
-    i32.const 3
-    call $~lib/builtins/abort
-    unreachable
-   end
-   global.get $~lib/memory/__stack_pointer
-   local.tee $3
-   local.get $0
-   i32.store offset=380
-   local.get $3
-   local.get $0
-   i32.store offset=8
-   local.get $0
-   i32.load offset=8
-   i32.const 20
-   i32.ne
-   if
-    i32.const 0
-    i32.const 1152
-    i32.const 355
-    i32.const 3
-    call $~lib/builtins/abort
-    unreachable
-   end
-   global.get $~lib/memory/__stack_pointer
-   local.tee $3
-   local.get $2
    i32.store offset=384
-   local.get $3
-   local.get $2
-   i32.store offset=8
-   local.get $2
-   i32.load offset=8
-   i32.const 13
-   i32.ne
-   if
-    i32.const 0
-    i32.const 1152
-    i32.const 356
-    i32.const 3
-    call $~lib/builtins/abort
-    unreachable
-   end
    global.get $~lib/memory/__stack_pointer
    local.get $0
-   i32.store offset=276
-   local.get $0
-   call $~lib/date/Date#toISOString
-   local.set $0
-   global.get $~lib/memory/__stack_pointer
-   local.get $0
-   i32.store offset=8
-   global.get $~lib/memory/__stack_pointer
-   i32.const 7488
-   i32.store offset=272
-   local.get $0
-   i32.const 7488
-   call $~lib/string/String.__eq
-   i32.eqz
-   if
-    i32.const 0
-    i32.const 1152
-    i32.const 358
-    i32.const 3
-    call $~lib/builtins/abort
-    unreachable
-   end
-   global.get $~lib/memory/__stack_pointer
-   local.get $2
-   i32.store offset=276
-   local.get $2
-   call $~lib/date/Date#toISOString
-   local.set $0
-   global.get $~lib/memory/__stack_pointer
-   local.get $0
-   i32.store offset=8
-   global.get $~lib/memory/__stack_pointer
-   i32.const 7568
-   i32.store offset=272
-   local.get $0
-   i32.const 7568
-   call $~lib/string/String.__eq
-   i32.eqz
-   if
-    i32.const 0
-    i32.const 1152
-    i32.const 359
-    i32.const 3
-    call $~lib/builtins/abort
-    unreachable
-   end
-   global.get $~lib/memory/__stack_pointer
-   i64.const 8639999999999999
-   call $~lib/date/Date#constructor
-   local.tee $0
    i32.store offset=388
    global.get $~lib/memory/__stack_pointer
-   i64.const -8639999999999999
-   call $~lib/date/Date#constructor
-   local.tee $2
-   i32.store offset=392
+   local.get $0
+   i32.store offset=8
+   local.get $0
+   i64.load offset=16
+   i64.const -8640000000000000
+   i64.ne
+   if
+    i32.const 0
+    i32.const 1152
+    i32.const 378
+    i32.const 3
+    call $~lib/builtins/abort
+    unreachable
+   end
    global.get $~lib/memory/__stack_pointer
+   local.tee $3
    local.get $2
-   i32.store offset=396
-   global.get $~lib/memory/__stack_pointer
+   i32.store offset=392
+   local.get $3
    local.get $2
    i32.store offset=8
    local.get $2
+   i64.load offset=16
+   i64.const 8640000000000000
+   i64.ne
+   if
+    i32.const 0
+    i32.const 1152
+    i32.const 379
+    i32.const 3
+    call $~lib/builtins/abort
+    unreachable
+   end
+   global.get $~lib/memory/__stack_pointer
+   local.tee $3
+   local.get $0
+   i32.store offset=396
+   local.get $3
+   local.get $0
+   i32.store offset=8
+   local.get $0
    i32.load
    i32.const -271821
    i32.ne
    if
     i32.const 0
     i32.const 1152
-    i32.const 364
+    i32.const 381
     i32.const 3
     call $~lib/builtins/abort
     unreachable
@@ -10140,13 +10602,32 @@
    local.get $2
    i32.store offset=8
    local.get $2
+   i32.load
+   i32.const 275760
+   i32.ne
+   if
+    i32.const 0
+    i32.const 1152
+    i32.const 382
+    i32.const 3
+    call $~lib/builtins/abort
+    unreachable
+   end
+   global.get $~lib/memory/__stack_pointer
+   local.tee $3
+   local.get $0
+   i32.store offset=404
+   local.get $3
+   local.get $0
+   i32.store offset=8
+   local.get $0
    i32.load offset=4
    i32.const 4
    i32.ne
    if
     i32.const 0
     i32.const 1152
-    i32.const 365
+    i32.const 384
     i32.const 3
     call $~lib/builtins/abort
     unreachable
@@ -10154,7 +10635,159 @@
    global.get $~lib/memory/__stack_pointer
    local.tee $3
    local.get $2
-   i32.store offset=404
+   i32.store offset=408
+   local.get $3
+   local.get $2
+   i32.store offset=8
+   local.get $2
+   i32.load offset=4
+   i32.const 9
+   i32.ne
+   if
+    i32.const 0
+    i32.const 1152
+    i32.const 385
+    i32.const 3
+    call $~lib/builtins/abort
+    unreachable
+   end
+   global.get $~lib/memory/__stack_pointer
+   local.tee $3
+   local.get $0
+   i32.store offset=412
+   local.get $3
+   local.get $0
+   i32.store offset=8
+   local.get $0
+   i32.load offset=8
+   i32.const 20
+   i32.ne
+   if
+    i32.const 0
+    i32.const 1152
+    i32.const 387
+    i32.const 3
+    call $~lib/builtins/abort
+    unreachable
+   end
+   global.get $~lib/memory/__stack_pointer
+   local.tee $3
+   local.get $2
+   i32.store offset=416
+   local.get $3
+   local.get $2
+   i32.store offset=8
+   local.get $2
+   i32.load offset=8
+   i32.const 13
+   i32.ne
+   if
+    i32.const 0
+    i32.const 1152
+    i32.const 388
+    i32.const 3
+    call $~lib/builtins/abort
+    unreachable
+   end
+   global.get $~lib/memory/__stack_pointer
+   local.get $0
+   i32.store offset=276
+   local.get $0
+   call $~lib/date/Date#toISOString
+   local.set $0
+   global.get $~lib/memory/__stack_pointer
+   local.get $0
+   i32.store offset=8
+   global.get $~lib/memory/__stack_pointer
+   i32.const 8128
+   i32.store offset=272
+   local.get $0
+   i32.const 8128
+   call $~lib/string/String.__eq
+   i32.eqz
+   if
+    i32.const 0
+    i32.const 1152
+    i32.const 390
+    i32.const 3
+    call $~lib/builtins/abort
+    unreachable
+   end
+   global.get $~lib/memory/__stack_pointer
+   local.get $2
+   i32.store offset=276
+   local.get $2
+   call $~lib/date/Date#toISOString
+   local.set $0
+   global.get $~lib/memory/__stack_pointer
+   local.get $0
+   i32.store offset=8
+   global.get $~lib/memory/__stack_pointer
+   i32.const 8208
+   i32.store offset=272
+   local.get $0
+   i32.const 8208
+   call $~lib/string/String.__eq
+   i32.eqz
+   if
+    i32.const 0
+    i32.const 1152
+    i32.const 391
+    i32.const 3
+    call $~lib/builtins/abort
+    unreachable
+   end
+   global.get $~lib/memory/__stack_pointer
+   i64.const 8639999999999999
+   call $~lib/date/Date#constructor
+   local.tee $0
+   i32.store offset=420
+   global.get $~lib/memory/__stack_pointer
+   i64.const -8639999999999999
+   call $~lib/date/Date#constructor
+   local.tee $2
+   i32.store offset=424
+   global.get $~lib/memory/__stack_pointer
+   local.get $2
+   i32.store offset=428
+   global.get $~lib/memory/__stack_pointer
+   local.get $2
+   i32.store offset=8
+   local.get $2
+   i32.load
+   i32.const -271821
+   i32.ne
+   if
+    i32.const 0
+    i32.const 1152
+    i32.const 396
+    i32.const 3
+    call $~lib/builtins/abort
+    unreachable
+   end
+   global.get $~lib/memory/__stack_pointer
+   local.tee $3
+   local.get $2
+   i32.store offset=432
+   local.get $3
+   local.get $2
+   i32.store offset=8
+   local.get $2
+   i32.load offset=4
+   i32.const 4
+   i32.ne
+   if
+    i32.const 0
+    i32.const 1152
+    i32.const 397
+    i32.const 3
+    call $~lib/builtins/abort
+    unreachable
+   end
+   global.get $~lib/memory/__stack_pointer
+   local.tee $3
+   local.get $2
+   i32.store offset=436
    local.get $3
    local.get $2
    i32.store offset=8
@@ -10165,7 +10798,7 @@
    if
     i32.const 0
     i32.const 1152
-    i32.const 366
+    i32.const 398
     i32.const 3
     call $~lib/builtins/abort
     unreachable
@@ -10178,7 +10811,7 @@
    if
     i32.const 0
     i32.const 1152
-    i32.const 367
+    i32.const 399
     i32.const 3
     call $~lib/builtins/abort
     unreachable
@@ -10191,7 +10824,7 @@
    if
     i32.const 0
     i32.const 1152
-    i32.const 368
+    i32.const 400
     i32.const 3
     call $~lib/builtins/abort
     unreachable
@@ -10204,7 +10837,7 @@
    if
     i32.const 0
     i32.const 1152
-    i32.const 369
+    i32.const 401
     i32.const 3
     call $~lib/builtins/abort
     unreachable
@@ -10219,7 +10852,7 @@
    if
     i32.const 0
     i32.const 1152
-    i32.const 370
+    i32.const 402
     i32.const 3
     call $~lib/builtins/abort
     unreachable
@@ -10234,16 +10867,16 @@
    local.get $0
    i32.store offset=8
    global.get $~lib/memory/__stack_pointer
-   i32.const 7648
+   i32.const 8288
    i32.store offset=272
    local.get $0
-   i32.const 7648
+   i32.const 8288
    call $~lib/string/String.__eq
    i32.eqz
    if
     i32.const 0
     i32.const 1152
-    i32.const 372
+    i32.const 404
     i32.const 3
     call $~lib/builtins/abort
     unreachable
@@ -10258,22 +10891,22 @@
    local.get $0
    i32.store offset=8
    global.get $~lib/memory/__stack_pointer
-   i32.const 7728
+   i32.const 8368
    i32.store offset=272
    local.get $0
-   i32.const 7728
+   i32.const 8368
    call $~lib/string/String.__eq
    i32.eqz
    if
     i32.const 0
     i32.const 1152
-    i32.const 373
+    i32.const 405
     i32.const 3
     call $~lib/builtins/abort
     unreachable
    end
    global.get $~lib/memory/__stack_pointer
-   i32.const 408
+   i32.const 440
    i32.add
    global.set $~lib/memory/__stack_pointer
    return
@@ -10294,11 +10927,11 @@
   i32.sub
   global.set $~lib/memory/__stack_pointer
   global.get $~lib/memory/__stack_pointer
-  i32.const 7828
+  i32.const 8468
   i32.lt_s
   if
-   i32.const 40624
-   i32.const 40672
+   i32.const 41264
+   i32.const 41312
    i32.const 1
    i32.const 1
    call $~lib/builtins/abort

--- a/tests/compiler/std/date.ts
+++ b/tests/compiler/std/date.ts
@@ -295,15 +295,47 @@
   assert(date.getTime() == 11860387200000);
 
   // supports year / month / day / hour / minute / second
-  date = Date.fromString("1976-02-02T12:34:56"); // still use Z suffix
+  date = Date.fromString("1976-02-02T12:34:56");
   assert(date.getTime() == 192112496000);
 
   // supports milliseconds
-  date = Date.fromString("1976-02-02T12:34:56.456"); // still use Z suffix
+  date = Date.fromString("1976-02-02T12:34:56.456");
   assert(date.getTime() == 192112496456);
 
-  // supports 'Z' suffix
+  // supports 'Z' suffix (UTC)
   date = Date.fromString("1976-02-02T12:34:56.456Z");
+  assert(date.getTime() == 192112496456);
+
+  // supports negative offset from UTC
+  date = Date.fromString("1976-02-02T12:34:56.456-08:00");
+  assert(date.getTime() == 192141296456);
+
+  // supports positive offset from UTC
+  date = Date.fromString("1976-02-02T12:34:56.456+05:30");
+  assert(date.getTime() == 192092696456);
+
+  // allows fewer than 3 decimal places
+  date = Date.fromString("1976-02-02T12:34:56.45");
+  assert(date.getTime() == 192112496450);
+
+  // allows fewer than 3 decimal places (with Z)
+  date = Date.fromString("1976-02-02T12:34:56.45Z");
+  assert(date.getTime() == 192112496450);
+
+  // allows fewer than 3 decimal places (with offset)
+  date = Date.fromString("1976-02-02T12:34:56.45+00:00");
+  assert(date.getTime() == 192112496450);
+
+  // truncates more than 3 decimal places
+  date = Date.fromString("1976-02-02T12:34:56.456789");
+  assert(date.getTime() == 192112496456);
+
+  // truncates more than 3 decimal places (with Z)
+  date = Date.fromString("1976-02-02T12:34:56.456789Z");
+  assert(date.getTime() == 192112496456);
+
+  // truncates more than 3 decimal places (with offset)
+  date = Date.fromString("1976-02-02T12:34:56.456789+00:00");
   assert(date.getTime() == 192112496456);
 
   date = Date.fromString("0000");
@@ -321,10 +353,10 @@
   date = Date.fromString("1976-02-02");
   assert(date.getTime() == 192067200000);
 
-  date = Date.fromString("1976-02-02T12:34"); // still use Z suffix
+  date = Date.fromString("1976-02-02T12:34");
   assert(date.getTime() == 192112440000);
 
-  date = Date.fromString("1976-02-02T12:34:56"); // still use Z suffix
+  date = Date.fromString("1976-02-02T12:34:56");
   assert(date.getTime() == 192112496000);
 
   // date = Date.fromString('0Z');

--- a/tests/compiler/std/math.release.wat
+++ b/tests/compiler/std/math.release.wat
@@ -49911,7 +49911,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -nan:0x8000000000000
+  f64.const nan:0x8000000000000
   f64.const nan:0x8000000000000
   f64.const 0
   call $std/math/check<f64>
@@ -49955,7 +49955,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -nan:0x8000000000000
+  f64.const nan:0x8000000000000
   f64.const nan:0x8000000000000
   f64.const 0
   call $std/math/check<f64>
@@ -49977,7 +49977,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -nan:0x8000000000000
+  f64.const nan:0x8000000000000
   f64.const nan:0x8000000000000
   f64.const 0
   call $std/math/check<f64>
@@ -50043,7 +50043,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -nan:0x8000000000000
+  f64.const nan:0x8000000000000
   f64.const nan:0x8000000000000
   f64.const 0
   call $std/math/check<f64>
@@ -50109,7 +50109,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -nan:0x8000000000000
+  f64.const nan:0x8000000000000
   f64.const nan:0x8000000000000
   f64.const 0
   call $std/math/check<f64>
@@ -50175,7 +50175,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -nan:0x8000000000000
+  f64.const nan:0x8000000000000
   f64.const nan:0x8000000000000
   f64.const 0
   call $std/math/check<f64>
@@ -50263,7 +50263,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -nan:0x8000000000000
+  f64.const nan:0x8000000000000
   f64.const nan:0x8000000000000
   f64.const 0
   call $std/math/check<f64>
@@ -50373,7 +50373,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -nan:0x8000000000000
+  f64.const nan:0x8000000000000
   f64.const nan:0x8000000000000
   f64.const 0
   call $std/math/check<f64>
@@ -50527,7 +50527,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -nan:0x8000000000000
+  f64.const nan:0x8000000000000
   f64.const nan:0x8000000000000
   f64.const 0
   call $std/math/check<f64>
@@ -51759,7 +51759,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -nan:0x400000
+  f32.const nan:0x400000
   f32.const nan:0x400000
   f32.const 0
   call $std/math/check<f32>
@@ -51785,7 +51785,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -nan:0x400000
+  f32.const nan:0x400000
   f32.const nan:0x400000
   f32.const 0
   call $std/math/check<f32>
@@ -51798,7 +51798,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -nan:0x400000
+  f32.const nan:0x400000
   f32.const nan:0x400000
   f32.const 0
   call $std/math/check<f32>
@@ -51837,7 +51837,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -nan:0x400000
+  f32.const nan:0x400000
   f32.const nan:0x400000
   f32.const 0
   call $std/math/check<f32>
@@ -51876,7 +51876,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -nan:0x400000
+  f32.const nan:0x400000
   f32.const nan:0x400000
   f32.const 0
   call $std/math/check<f32>
@@ -51915,7 +51915,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -nan:0x400000
+  f32.const nan:0x400000
   f32.const nan:0x400000
   f32.const 0
   call $std/math/check<f32>
@@ -51967,7 +51967,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -nan:0x400000
+  f32.const nan:0x400000
   f32.const nan:0x400000
   f32.const 0
   call $std/math/check<f32>
@@ -52032,7 +52032,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -nan:0x400000
+  f32.const nan:0x400000
   f32.const nan:0x400000
   f32.const 0
   call $std/math/check<f32>
@@ -52058,7 +52058,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -nan:0x400000
+  f32.const nan:0x400000
   f32.const nan:0x400000
   f32.const 0
   call $std/math/check<f32>

--- a/tests/compiler/std/math.release.wat
+++ b/tests/compiler/std/math.release.wat
@@ -49911,7 +49911,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const nan:0x8000000000000
+  f64.const -nan:0x8000000000000
   f64.const nan:0x8000000000000
   f64.const 0
   call $std/math/check<f64>
@@ -49955,7 +49955,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const nan:0x8000000000000
+  f64.const -nan:0x8000000000000
   f64.const nan:0x8000000000000
   f64.const 0
   call $std/math/check<f64>
@@ -49977,7 +49977,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const nan:0x8000000000000
+  f64.const -nan:0x8000000000000
   f64.const nan:0x8000000000000
   f64.const 0
   call $std/math/check<f64>
@@ -50043,7 +50043,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const nan:0x8000000000000
+  f64.const -nan:0x8000000000000
   f64.const nan:0x8000000000000
   f64.const 0
   call $std/math/check<f64>
@@ -50109,7 +50109,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const nan:0x8000000000000
+  f64.const -nan:0x8000000000000
   f64.const nan:0x8000000000000
   f64.const 0
   call $std/math/check<f64>
@@ -50175,7 +50175,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const nan:0x8000000000000
+  f64.const -nan:0x8000000000000
   f64.const nan:0x8000000000000
   f64.const 0
   call $std/math/check<f64>
@@ -50263,7 +50263,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const nan:0x8000000000000
+  f64.const -nan:0x8000000000000
   f64.const nan:0x8000000000000
   f64.const 0
   call $std/math/check<f64>
@@ -50373,7 +50373,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const nan:0x8000000000000
+  f64.const -nan:0x8000000000000
   f64.const nan:0x8000000000000
   f64.const 0
   call $std/math/check<f64>
@@ -50527,7 +50527,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const nan:0x8000000000000
+  f64.const -nan:0x8000000000000
   f64.const nan:0x8000000000000
   f64.const 0
   call $std/math/check<f64>
@@ -51759,7 +51759,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const nan:0x400000
+  f32.const -nan:0x400000
   f32.const nan:0x400000
   f32.const 0
   call $std/math/check<f32>
@@ -51785,7 +51785,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const nan:0x400000
+  f32.const -nan:0x400000
   f32.const nan:0x400000
   f32.const 0
   call $std/math/check<f32>
@@ -51798,7 +51798,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const nan:0x400000
+  f32.const -nan:0x400000
   f32.const nan:0x400000
   f32.const 0
   call $std/math/check<f32>
@@ -51837,7 +51837,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const nan:0x400000
+  f32.const -nan:0x400000
   f32.const nan:0x400000
   f32.const 0
   call $std/math/check<f32>
@@ -51876,7 +51876,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const nan:0x400000
+  f32.const -nan:0x400000
   f32.const nan:0x400000
   f32.const 0
   call $std/math/check<f32>
@@ -51915,7 +51915,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const nan:0x400000
+  f32.const -nan:0x400000
   f32.const nan:0x400000
   f32.const 0
   call $std/math/check<f32>
@@ -51967,7 +51967,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const nan:0x400000
+  f32.const -nan:0x400000
   f32.const nan:0x400000
   f32.const 0
   call $std/math/check<f32>
@@ -52032,7 +52032,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const nan:0x400000
+  f32.const -nan:0x400000
   f32.const nan:0x400000
   f32.const 0
   call $std/math/check<f32>
@@ -52058,7 +52058,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const nan:0x400000
+  f32.const -nan:0x400000
   f32.const nan:0x400000
   f32.const 0
   call $std/math/check<f32>


### PR DESCRIPTION
The logic used by `Date.fromString` and `Date.parse` has a few issues:

- Incorrect handling of fractional seconds having more than 3 decimal places.  For example, `"2000-01-01T00:00:00.123456789Z"` was being treated as having 123456789 milliseconds, making the result wildly too large. Such values should be truncated to 3 decimal places before being interpreted as milliseconds.
- Incorrect handling of fractional seconds having _less_ than 3 decimal places.  For example `"2000-01-01T00:00:00.1"` was treated as having 1 millisecond, though it should be one tenth of a second (or 100 milliseconds).
- Ignoring any UTC offset (such as `+05:30` or `-08:00`), which is required by ISO 8601, RFC 3339, and the ECMAScript standard date format.

This PR addresses all three issues, and updates the existing `Date#fromString` test.

I also made two small unrelated changes:
- Replaced usages of `I32.parseInt` with `i32.parse` in `std/assembly/date.ts` to resolve deprecation warnings
- ~Regenerated the fixture for `std/math` test to resolve "fixture mismatch" error that was occurring on a clean clone of the repo before I made any changes.  (Not sure what update caused that, but compiler tests were failing.)~. (reverted this due to CI test failure.  See comments below.)

Thanks.

- [x] I've read the contributing guidelines
- [x] I've added my name and email to the NOTICE file
