### PR TITLE
fix: asinit support --noColors opinion

### DIFF
--- a/bin/asinit.js
+++ b/bin/asinit.js
@@ -55,10 +55,19 @@ const asinitOptions = {
     ],
     "type": "b",
     "alias": "y"
-  }
+  },
+  "noColors": {
+    "description": "Disables terminal colors.",
+    "type": "b",
+    "default": false
+  },
 };
 
 const cliOptions = optionsUtil.parse(process.argv.slice(2), asinitOptions);
+
+if (cliOptions.options.noColors) {
+  stdoutColors.enabled = false;
+}
 
 if (cliOptions.options.help || cliOptions.arguments.length === 0) printHelp();
 


### PR DESCRIPTION
Detection terminal background technically is possible, but I don't want to introduce deps to resolve UI/UX issue.
like `asc` did, this PR provides `--noColors` opinion in `asinit` to disable colorful output .

Fixes #2816.
