### PR TITLE
Binaryen on transform

### DIFF
--- a/cli/index.d.ts
+++ b/cli/index.d.ts
@@ -240,13 +240,17 @@ export function createMemoryStream(fn?: (chunk: Uint8Array | string) => void): M
 /** Compatible TypeScript compiler options for syntax highlighting etc. */
 export const tscOptions: Record<string,unknown>;
 
-import { Program, Parser, Module } from "../src";
+import binaryen from "../lib/binaryen";
+import { Program, Parser } from "../src";
 
 /** Compiler transform base class. */
 export abstract class Transform {
 
   /** Program reference. */
   readonly program: Program;
+
+  /** Binaryen reference. */
+  readonly binaryen: typeof binaryen;
 
   /** Base directory. */
   readonly baseDir: string;
@@ -276,5 +280,5 @@ export abstract class Transform {
   afterInitialize?(program: Program): void | Promise<void>;
 
   /** Called when compilation is complete, before the module is being validated. */
-  afterCompile?(module: Module): void | Promise<void>;
+  afterCompile?(module: binaryen.Module): void | Promise<void>;
 }

--- a/cli/index.js
+++ b/cli/index.js
@@ -450,6 +450,7 @@ export async function main(argv, options) {
       if (typeof transform === "function") {
         Object.assign(transform.prototype, {
           program,
+          binaryen,
           baseDir,
           stdout,
           stderr,

--- a/scripts/build-dts.js
+++ b/scripts/build-dts.js
@@ -373,9 +373,13 @@ export function generateCli() {
     prefix,
     stdout,
     resolveModuleImport: ({ importedModuleId, currentModuleId }) => {
-      return currentModuleId == "cli/index" && importedModuleId == "../src"
-        ? prefix + "/src/index"
-        : null;
+      if (currentModuleId == "cli/index" && importedModuleId == "../src")
+        return prefix + "/src/index";
+
+      if (importedModuleId == "binaryen")
+        return "binaryen";
+
+      return null;
     },
   });
 


### PR DESCRIPTION
Fixes #2829

Changes proposed in this pull request:
⯈ Exposes the binaryen instance used by transforms as `Transform#binaryen`
⯈ Fixes the `.d.ts` type for `Transform#afterCompile`

- [x] I've read the contributing guidelines
- [x] I've added my name and email to the NOTICE file
