### PR TITLE
fix: addDebugInfo before convertExpression

### DIFF
--- a/src/compiler.ts
+++ b/src/compiler.ts
@@ -3449,22 +3449,28 @@ export class Compiler extends DiagnosticEmitter {
         expr = this.module.unreachable();
       }
     }
-    // debug location is added here so the caller doesn't have to. means: compilation of an expression
-    // must go through this function, with the respective per-kind functions not being used directly.
-    if (this.options.sourceMap) this.addDebugLocation(expr, expression.range);
     // ensure conversion and wrapping in case the respective function doesn't on its own
     let currentType = this.currentType;
     let wrap = (constraints & Constraints.MustWrap) != 0;
     if (currentType != contextualType.nonNullableType) { // allow assigning non-nullable to nullable
       if (constraints & Constraints.ConvExplicit) {
+        // emit debug location for inner expression before conversion
+        if (this.options.sourceMap) this.addDebugLocation(expr, expression.range);
         expr = this.convertExpression(expr, currentType, contextualType, true, expression);
         this.currentType = currentType = contextualType;
       } else if (constraints & Constraints.ConvImplicit) {
+        if (this.options.sourceMap) this.addDebugLocation(expr, expression.range);
         expr = this.convertExpression(expr, currentType, contextualType, false, expression);
         this.currentType = currentType = contextualType;
       }
     }
-    if (wrap) expr = this.ensureSmallIntegerWrap(expr, currentType);
+    if (wrap) {
+      if (this.options.sourceMap) this.addDebugLocation(expr, expression.range);
+      expr = this.ensureSmallIntegerWrap(expr, currentType);
+    }
+    // debug location is added here so the caller doesn't have to. means: compilation of an expression
+    // must go through this function, with the respective per-kind functions not being used directly.
+    if (this.options.sourceMap) this.addDebugLocation(expr, expression.range);
     return expr;
   }
 

--- a/src/compiler.ts
+++ b/src/compiler.ts
@@ -3449,6 +3449,9 @@ export class Compiler extends DiagnosticEmitter {
         expr = this.module.unreachable();
       }
     }
+    // debug location is added here so the caller doesn't have to. means: compilation of an expression
+    // must go through this function, with the respective per-kind functions not being used directly.
+    if (this.options.sourceMap) this.addDebugLocation(expr, expression.range);
     // ensure conversion and wrapping in case the respective function doesn't on its own
     let currentType = this.currentType;
     let wrap = (constraints & Constraints.MustWrap) != 0;
@@ -3462,9 +3465,6 @@ export class Compiler extends DiagnosticEmitter {
       }
     }
     if (wrap) expr = this.ensureSmallIntegerWrap(expr, currentType);
-    // debug location is added here so the caller doesn't have to. means: compilation of an expression
-    // must go through this function, with the respective per-kind functions not being used directly.
-    if (this.options.sourceMap) this.addDebugLocation(expr, expression.range);
     return expr;
   }
 


### PR DESCRIPTION
<!--
 Thanks for submitting a pull request to AssemblyScript! Please take a moment to
 review the contributing guidelines linked below, and confirm with an [x] 🙂
-->
Fixes #2833  .

add debugLocation before convertExpression.
For code snippet: 
```typescript
function add(a: i32, b: i32): i32 {
  return a + b;
}

add(1, 2);
```

Before this PR, we emit: 
```typescript
addDebugLocation(drop, line = 5, column = 2);       // In there, we should emit `call` instruction
addDebugLocation(drop, line = 5, column = 2); 
```

With this PR, we emit:
```typescript
addDebugLocation(call, line = 5, column = 2);      
addDebugLocation(drop, line = 5, column = 2); 
```
- [x] I've read the contributing guidelines
- [x] I've added my name and email to the NOTICE file
