### PR TITLE
fix: use `typeof self === object && self.constructor` to identifier execution environment

### DIFF
--- a/src/bindings/js.ts
+++ b/src/bindings/js.ts
@@ -976,8 +976,8 @@ export class JSBuilder extends ExportsWalker {
       }
       sb.push(`} = await (async url => instantiate(
   await (async () => {
-    try { return await globalThis.WebAssembly.compileStreaming(globalThis.fetch(url)); }
-    catch { return globalThis.WebAssembly.compile(await (await import("node:fs/promises")).readFile(url)); }
+    if (typeof self === "object" && self.constructor) { return await globalThis.WebAssembly.compileStreaming(globalThis.fetch(url)); }
+    else { return globalThis.WebAssembly.compile(await (await import("node:fs/promises")).readFile(url)); }
   })(), {
 `);
       let needsMaybeDefault = false;

--- a/src/bindings/js.ts
+++ b/src/bindings/js.ts
@@ -976,8 +976,9 @@ export class JSBuilder extends ExportsWalker {
       }
       sb.push(`} = await (async url => instantiate(
   await (async () => {
-    if (typeof self === "object" && self.constructor) { return await globalThis.WebAssembly.compileStreaming(globalThis.fetch(url)); }
-    else { return globalThis.WebAssembly.compile(await (await import("node:fs/promises")).readFile(url)); }
+    const isNodeOrBun = typeof process != "undefined" && process.versions != null && (process.versions.node != null || process.versions.bun != null);
+    if (isNodeOrBun) { return globalThis.WebAssembly.compile(await (await import("node:fs/promises")).readFile(url)); }
+    else { return await globalThis.WebAssembly.compileStreaming(globalThis.fetch(url)); }
   })(), {
 `);
       let needsMaybeDefault = false;

--- a/tests/compiler/bindings/esm.debug.js
+++ b/tests/compiler/bindings/esm.debug.js
@@ -553,8 +553,9 @@ export const {
   fn,
 } = await (async url => instantiate(
   await (async () => {
-    if (typeof self === "object" && self.constructor) { return await globalThis.WebAssembly.compileStreaming(globalThis.fetch(url)); }
-    else { return globalThis.WebAssembly.compile(await (await import("node:fs/promises")).readFile(url)); }
+    const isNodeOrBun = typeof process != "undefined" && process.versions != null && (process.versions.node != null || process.versions.bun != null);
+    if (isNodeOrBun) { return globalThis.WebAssembly.compile(await (await import("node:fs/promises")).readFile(url)); }
+    else { return await globalThis.WebAssembly.compileStreaming(globalThis.fetch(url)); }
   })(), {
   }
 ))(new URL("esm.debug.wasm", import.meta.url));

--- a/tests/compiler/bindings/esm.debug.js
+++ b/tests/compiler/bindings/esm.debug.js
@@ -553,8 +553,8 @@ export const {
   fn,
 } = await (async url => instantiate(
   await (async () => {
-    try { return await globalThis.WebAssembly.compileStreaming(globalThis.fetch(url)); }
-    catch { return globalThis.WebAssembly.compile(await (await import("node:fs/promises")).readFile(url)); }
+    if (typeof self === "object" && self.constructor) { return await globalThis.WebAssembly.compileStreaming(globalThis.fetch(url)); }
+    else { return globalThis.WebAssembly.compile(await (await import("node:fs/promises")).readFile(url)); }
   })(), {
   }
 ))(new URL("esm.debug.wasm", import.meta.url));

--- a/tests/compiler/bindings/esm.release.js
+++ b/tests/compiler/bindings/esm.release.js
@@ -553,8 +553,8 @@ export const {
   fn,
 } = await (async url => instantiate(
   await (async () => {
-    try { return await globalThis.WebAssembly.compileStreaming(globalThis.fetch(url)); }
-    catch { return globalThis.WebAssembly.compile(await (await import("node:fs/promises")).readFile(url)); }
+    if (typeof self === "object" && self.constructor) { return await globalThis.WebAssembly.compileStreaming(globalThis.fetch(url)); }
+    else { return globalThis.WebAssembly.compile(await (await import("node:fs/promises")).readFile(url)); }
   })(), {
   }
 ))(new URL("esm.release.wasm", import.meta.url));

--- a/tests/compiler/bindings/esm.release.js
+++ b/tests/compiler/bindings/esm.release.js
@@ -553,8 +553,9 @@ export const {
   fn,
 } = await (async url => instantiate(
   await (async () => {
-    if (typeof self === "object" && self.constructor) { return await globalThis.WebAssembly.compileStreaming(globalThis.fetch(url)); }
-    else { return globalThis.WebAssembly.compile(await (await import("node:fs/promises")).readFile(url)); }
+    const isNodeOrBun = typeof process != "undefined" && process.versions != null && (process.versions.node != null || process.versions.bun != null);
+    if (isNodeOrBun) { return globalThis.WebAssembly.compile(await (await import("node:fs/promises")).readFile(url)); }
+    else { return await globalThis.WebAssembly.compileStreaming(globalThis.fetch(url)); }
   })(), {
   }
 ))(new URL("esm.release.wasm", import.meta.url));

--- a/tests/compiler/bindings/noExportRuntime.debug.js
+++ b/tests/compiler/bindings/noExportRuntime.debug.js
@@ -162,8 +162,8 @@ export const {
   takesFunction,
 } = await (async url => instantiate(
   await (async () => {
-    try { return await globalThis.WebAssembly.compileStreaming(globalThis.fetch(url)); }
-    catch { return globalThis.WebAssembly.compile(await (await import("node:fs/promises")).readFile(url)); }
+    if (typeof self === "object" && self.constructor) { return await globalThis.WebAssembly.compileStreaming(globalThis.fetch(url)); }
+    else { return globalThis.WebAssembly.compile(await (await import("node:fs/promises")).readFile(url)); }
   })(), {
   }
 ))(new URL("noExportRuntime.debug.wasm", import.meta.url));

--- a/tests/compiler/bindings/noExportRuntime.debug.js
+++ b/tests/compiler/bindings/noExportRuntime.debug.js
@@ -162,8 +162,9 @@ export const {
   takesFunction,
 } = await (async url => instantiate(
   await (async () => {
-    if (typeof self === "object" && self.constructor) { return await globalThis.WebAssembly.compileStreaming(globalThis.fetch(url)); }
-    else { return globalThis.WebAssembly.compile(await (await import("node:fs/promises")).readFile(url)); }
+    const isNodeOrBun = typeof process != "undefined" && process.versions != null && (process.versions.node != null || process.versions.bun != null);
+    if (isNodeOrBun) { return globalThis.WebAssembly.compile(await (await import("node:fs/promises")).readFile(url)); }
+    else { return await globalThis.WebAssembly.compileStreaming(globalThis.fetch(url)); }
   })(), {
   }
 ))(new URL("noExportRuntime.debug.wasm", import.meta.url));

--- a/tests/compiler/bindings/noExportRuntime.release.js
+++ b/tests/compiler/bindings/noExportRuntime.release.js
@@ -162,8 +162,8 @@ export const {
   takesFunction,
 } = await (async url => instantiate(
   await (async () => {
-    try { return await globalThis.WebAssembly.compileStreaming(globalThis.fetch(url)); }
-    catch { return globalThis.WebAssembly.compile(await (await import("node:fs/promises")).readFile(url)); }
+    if (typeof self === "object" && self.constructor) { return await globalThis.WebAssembly.compileStreaming(globalThis.fetch(url)); }
+    else { return globalThis.WebAssembly.compile(await (await import("node:fs/promises")).readFile(url)); }
   })(), {
   }
 ))(new URL("noExportRuntime.release.wasm", import.meta.url));

--- a/tests/compiler/bindings/noExportRuntime.release.js
+++ b/tests/compiler/bindings/noExportRuntime.release.js
@@ -162,8 +162,9 @@ export const {
   takesFunction,
 } = await (async url => instantiate(
   await (async () => {
-    if (typeof self === "object" && self.constructor) { return await globalThis.WebAssembly.compileStreaming(globalThis.fetch(url)); }
-    else { return globalThis.WebAssembly.compile(await (await import("node:fs/promises")).readFile(url)); }
+    const isNodeOrBun = typeof process != "undefined" && process.versions != null && (process.versions.node != null || process.versions.bun != null);
+    if (isNodeOrBun) { return globalThis.WebAssembly.compile(await (await import("node:fs/promises")).readFile(url)); }
+    else { return await globalThis.WebAssembly.compileStreaming(globalThis.fetch(url)); }
   })(), {
   }
 ))(new URL("noExportRuntime.release.wasm", import.meta.url));


### PR DESCRIPTION
Use a better way to identifier exection environemt becasue `try` and `catch` will cause misleaded error message
