### PR TITLE
feat: `lowMemoryLimit` can accept more than 1 page value

### DIFF
--- a/cli/options.json
+++ b/cli/options.json
@@ -260,7 +260,7 @@
   },
   "lowMemoryLimit": {
     "category": "Features",
-    "description": "Enforces very low (<64k) memory constraints.",
+    "description": "Enforces memory constraints, memory usage will not exceed the given value.",
     "default": 0,
     "type": "i"
   },

--- a/src/compiler.ts
+++ b/src/compiler.ts
@@ -275,7 +275,7 @@ export class Options {
   noUnsafe: bool = false;
   /** If true, enables pedantic diagnostics. */
   pedantic: bool = false;
-  /** Indicates a very low (<64k) memory limit. */
+  /** Indicates a memory limit. */
   lowMemoryLimit: u32 = 0;
   /** If true, exports the runtime helpers. */
   exportRuntime: bool = false;

--- a/std/assembly/rt/tlsf.ts
+++ b/std/assembly/rt/tlsf.ts
@@ -381,8 +381,9 @@ function addMemory(root: Root, start: usize, endU64: u64): bool {
   let end = <usize>endU64;
   if (ASC_LOW_MEMORY_LIMIT) {
     end = <u64>ASC_LOW_MEMORY_LIMIT;
+    if (start > ASC_LOW_MEMORY_LIMIT) unreachable();
   }
-  if (<u64>start > endU64) unreachable();
+  if (DEBUG) assert(<u64>start <= endU64); // must be valid
   start = ((start + BLOCK_OVERHEAD + AL_MASK) & ~AL_MASK) - BLOCK_OVERHEAD;
   end &= ~AL_MASK;
 

--- a/std/assembly/rt/tlsf.ts
+++ b/std/assembly/rt/tlsf.ts
@@ -379,6 +379,9 @@ function prepareBlock(root: Root, block: Block, size: usize): void {
 /** Adds more memory to the pool. */
 function addMemory(root: Root, start: usize, endU64: u64): bool {
   let end = <usize>endU64;
+  if (ASC_LOW_MEMORY_LIMIT) {
+    end = <u64>ASC_LOW_MEMORY_LIMIT;
+  }
   if (DEBUG) assert(<u64>start <= endU64); // must be valid
   start = ((start + BLOCK_OVERHEAD + AL_MASK) & ~AL_MASK) - BLOCK_OVERHEAD;
   end &= ~AL_MASK;
@@ -427,10 +430,6 @@ function addMemory(root: Root, start: usize, endU64: u64): bool {
 
 /** Grows memory to fit at least another block of the specified size. */
 function growMemory(root: Root, size: usize): void {
-  if (ASC_LOW_MEMORY_LIMIT) {
-    unreachable();
-    return;
-  }
   // Here, both rounding performed in searchBlock ...
   if (size >= SB_SIZE) {
     size = roundSize(size);
@@ -479,13 +478,7 @@ function initialize(): void {
     }
   }
   let memStart = rootOffset + ROOT_SIZE;
-  if (ASC_LOW_MEMORY_LIMIT) {
-    const memEnd = <u64>ASC_LOW_MEMORY_LIMIT & ~AL_MASK;
-    if (memStart <= memEnd) addMemory(root, memStart, memEnd);
-    else unreachable(); // low memory limit already exceeded
-  } else {
-    addMemory(root, memStart, <u64>memory.size() << 16);
-  }
+  addMemory(root, memStart, <u64>memory.size() << 16);
   ROOT = root;
 }
 

--- a/std/assembly/rt/tlsf.ts
+++ b/std/assembly/rt/tlsf.ts
@@ -382,7 +382,7 @@ function addMemory(root: Root, start: usize, endU64: u64): bool {
   if (ASC_LOW_MEMORY_LIMIT) {
     end = <u64>ASC_LOW_MEMORY_LIMIT;
   }
-  if (DEBUG) assert(<u64>start <= endU64); // must be valid
+  if (<u64>start > endU64) unreachable();
   start = ((start + BLOCK_OVERHEAD + AL_MASK) & ~AL_MASK) - BLOCK_OVERHEAD;
   end &= ~AL_MASK;
 

--- a/tests/compiler/assignment-chain.debug.wat
+++ b/tests/compiler/assignment-chain.debug.wat
@@ -1031,6 +1031,8 @@
   local.get $endU64
   i32.wrap_i64
   local.set $end
+  i32.const 0
+  drop
   i32.const 1
   drop
   local.get $start
@@ -1041,7 +1043,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 382
+   i32.const 385
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1087,7 +1089,7 @@
    if
     i32.const 0
     i32.const 368
-    i32.const 389
+    i32.const 392
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1119,7 +1121,7 @@
    if
     i32.const 0
     i32.const 368
-    i32.const 402
+    i32.const 405
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1320,8 +1322,6 @@
   i32.const 1572
   i32.add
   local.set $memStart
-  i32.const 0
-  drop
   local.get $root
   local.get $memStart
   memory.size
@@ -1363,7 +1363,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 562
+   i32.const 555
    i32.const 3
    call $~lib/builtins/abort
    unreachable
@@ -1692,7 +1692,7 @@
   if
    i32.const 32
    i32.const 368
-   i32.const 461
+   i32.const 460
    i32.const 29
    call $~lib/builtins/abort
    unreachable
@@ -1926,8 +1926,6 @@
   (local $6 i32)
   (local $pagesWanted i32)
   (local $pagesAfter i32)
-  i32.const 0
-  drop
   local.get $size
   i32.const 256
   i32.ge_u
@@ -2137,7 +2135,7 @@
    if
     i32.const 0
     i32.const 368
-    i32.const 499
+    i32.const 492
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -2157,7 +2155,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 501
+   i32.const 494
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/assignment-chain.debug.wat
+++ b/tests/compiler/assignment-chain.debug.wat
@@ -1033,19 +1033,11 @@
   local.set $end
   i32.const 0
   drop
-  i32.const 1
-  drop
   local.get $start
   i64.extend_i32_u
   local.get $endU64
-  i64.le_u
-  i32.eqz
+  i64.gt_u
   if
-   i32.const 0
-   i32.const 368
-   i32.const 385
-   i32.const 14
-   call $~lib/builtins/abort
    unreachable
   end
   local.get $start

--- a/tests/compiler/assignment-chain.debug.wat
+++ b/tests/compiler/assignment-chain.debug.wat
@@ -1033,11 +1033,19 @@
   local.set $end
   i32.const 0
   drop
+  i32.const 1
+  drop
   local.get $start
   i64.extend_i32_u
   local.get $endU64
-  i64.gt_u
+  i64.le_u
+  i32.eqz
   if
+   i32.const 0
+   i32.const 368
+   i32.const 386
+   i32.const 14
+   call $~lib/builtins/abort
    unreachable
   end
   local.get $start
@@ -1081,7 +1089,7 @@
    if
     i32.const 0
     i32.const 368
-    i32.const 392
+    i32.const 393
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1113,7 +1121,7 @@
    if
     i32.const 0
     i32.const 368
-    i32.const 405
+    i32.const 406
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1355,7 +1363,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 555
+   i32.const 556
    i32.const 3
    call $~lib/builtins/abort
    unreachable
@@ -1684,7 +1692,7 @@
   if
    i32.const 32
    i32.const 368
-   i32.const 460
+   i32.const 461
    i32.const 29
    call $~lib/builtins/abort
    unreachable
@@ -2127,7 +2135,7 @@
    if
     i32.const 0
     i32.const 368
-    i32.const 492
+    i32.const 493
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -2147,7 +2155,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 494
+   i32.const 495
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/assignment-chain.release.wat
+++ b/tests/compiler/assignment-chain.release.wat
@@ -632,16 +632,11 @@
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
-  local.get $2
   local.get $1
   i64.extend_i32_u
-  i64.lt_u
+  local.get $2
+  i64.gt_u
   if
-   i32.const 0
-   i32.const 1392
-   i32.const 385
-   i32.const 14
-   call $~lib/builtins/abort
    unreachable
   end
   local.get $1

--- a/tests/compiler/assignment-chain.release.wat
+++ b/tests/compiler/assignment-chain.release.wat
@@ -639,7 +639,7 @@
   if
    i32.const 0
    i32.const 1392
-   i32.const 382
+   i32.const 385
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -664,7 +664,7 @@
    if
     i32.const 0
     i32.const 1392
-    i32.const 389
+    i32.const 392
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -691,7 +691,7 @@
    if
     i32.const 0
     i32.const 1392
-    i32.const 402
+    i32.const 405
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1054,7 +1054,7 @@
       if
        i32.const 0
        i32.const 1392
-       i32.const 562
+       i32.const 555
        i32.const 3
        call $~lib/builtins/abort
        unreachable
@@ -1289,7 +1289,7 @@
   if
    i32.const 1056
    i32.const 1392
-   i32.const 461
+   i32.const 460
    i32.const 29
    call $~lib/builtins/abort
    unreachable
@@ -1391,7 +1391,7 @@
    if
     i32.const 0
     i32.const 1392
-    i32.const 499
+    i32.const 492
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1406,7 +1406,7 @@
   if
    i32.const 0
    i32.const 1392
-   i32.const 501
+   i32.const 494
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/assignment-chain.release.wat
+++ b/tests/compiler/assignment-chain.release.wat
@@ -632,11 +632,16 @@
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
+  local.get $2
   local.get $1
   i64.extend_i32_u
-  local.get $2
-  i64.gt_u
+  i64.lt_u
   if
+   i32.const 0
+   i32.const 1392
+   i32.const 386
+   i32.const 14
+   call $~lib/builtins/abort
    unreachable
   end
   local.get $1
@@ -659,7 +664,7 @@
    if
     i32.const 0
     i32.const 1392
-    i32.const 392
+    i32.const 393
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -686,7 +691,7 @@
    if
     i32.const 0
     i32.const 1392
-    i32.const 405
+    i32.const 406
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1049,7 +1054,7 @@
       if
        i32.const 0
        i32.const 1392
-       i32.const 555
+       i32.const 556
        i32.const 3
        call $~lib/builtins/abort
        unreachable
@@ -1284,7 +1289,7 @@
   if
    i32.const 1056
    i32.const 1392
-   i32.const 460
+   i32.const 461
    i32.const 29
    call $~lib/builtins/abort
    unreachable
@@ -1386,7 +1391,7 @@
    if
     i32.const 0
     i32.const 1392
-    i32.const 492
+    i32.const 493
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1401,7 +1406,7 @@
   if
    i32.const 0
    i32.const 1392
-   i32.const 494
+   i32.const 495
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/bindings/esm.debug.wat
+++ b/tests/compiler/bindings/esm.debug.wat
@@ -1138,11 +1138,19 @@
   local.set $end
   i32.const 0
   drop
+  i32.const 1
+  drop
   local.get $start
   i64.extend_i32_u
   local.get $endU64
-  i64.gt_u
+  i64.le_u
+  i32.eqz
   if
+   i32.const 0
+   i32.const 672
+   i32.const 386
+   i32.const 14
+   call $~lib/builtins/abort
    unreachable
   end
   local.get $start
@@ -1186,7 +1194,7 @@
    if
     i32.const 0
     i32.const 672
-    i32.const 392
+    i32.const 393
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1218,7 +1226,7 @@
    if
     i32.const 0
     i32.const 672
-    i32.const 405
+    i32.const 406
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1460,7 +1468,7 @@
   if
    i32.const 0
    i32.const 672
-   i32.const 555
+   i32.const 556
    i32.const 3
    call $~lib/builtins/abort
    unreachable
@@ -1789,7 +1797,7 @@
   if
    i32.const 336
    i32.const 672
-   i32.const 460
+   i32.const 461
    i32.const 29
    call $~lib/builtins/abort
    unreachable
@@ -2232,7 +2240,7 @@
    if
     i32.const 0
     i32.const 672
-    i32.const 492
+    i32.const 493
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -2252,7 +2260,7 @@
   if
    i32.const 0
    i32.const 672
-   i32.const 494
+   i32.const 495
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/bindings/esm.debug.wat
+++ b/tests/compiler/bindings/esm.debug.wat
@@ -1138,19 +1138,11 @@
   local.set $end
   i32.const 0
   drop
-  i32.const 1
-  drop
   local.get $start
   i64.extend_i32_u
   local.get $endU64
-  i64.le_u
-  i32.eqz
+  i64.gt_u
   if
-   i32.const 0
-   i32.const 672
-   i32.const 385
-   i32.const 14
-   call $~lib/builtins/abort
    unreachable
   end
   local.get $start

--- a/tests/compiler/bindings/esm.debug.wat
+++ b/tests/compiler/bindings/esm.debug.wat
@@ -1136,6 +1136,8 @@
   local.get $endU64
   i32.wrap_i64
   local.set $end
+  i32.const 0
+  drop
   i32.const 1
   drop
   local.get $start
@@ -1146,7 +1148,7 @@
   if
    i32.const 0
    i32.const 672
-   i32.const 382
+   i32.const 385
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1192,7 +1194,7 @@
    if
     i32.const 0
     i32.const 672
-    i32.const 389
+    i32.const 392
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1224,7 +1226,7 @@
    if
     i32.const 0
     i32.const 672
-    i32.const 402
+    i32.const 405
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1425,8 +1427,6 @@
   i32.const 1572
   i32.add
   local.set $memStart
-  i32.const 0
-  drop
   local.get $root
   local.get $memStart
   memory.size
@@ -1468,7 +1468,7 @@
   if
    i32.const 0
    i32.const 672
-   i32.const 562
+   i32.const 555
    i32.const 3
    call $~lib/builtins/abort
    unreachable
@@ -1797,7 +1797,7 @@
   if
    i32.const 336
    i32.const 672
-   i32.const 461
+   i32.const 460
    i32.const 29
    call $~lib/builtins/abort
    unreachable
@@ -2031,8 +2031,6 @@
   (local $6 i32)
   (local $pagesWanted i32)
   (local $pagesAfter i32)
-  i32.const 0
-  drop
   local.get $size
   i32.const 256
   i32.ge_u
@@ -2242,7 +2240,7 @@
    if
     i32.const 0
     i32.const 672
-    i32.const 499
+    i32.const 492
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -2262,7 +2260,7 @@
   if
    i32.const 0
    i32.const 672
-   i32.const 501
+   i32.const 494
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/bindings/esm.release.wat
+++ b/tests/compiler/bindings/esm.release.wat
@@ -752,16 +752,11 @@
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
-  local.get $2
   local.get $1
   i64.extend_i32_u
-  i64.lt_u
+  local.get $2
+  i64.gt_u
   if
-   i32.const 0
-   i32.const 1696
-   i32.const 385
-   i32.const 14
-   call $~lib/builtins/abort
    unreachable
   end
   local.get $1

--- a/tests/compiler/bindings/esm.release.wat
+++ b/tests/compiler/bindings/esm.release.wat
@@ -759,7 +759,7 @@
   if
    i32.const 0
    i32.const 1696
-   i32.const 382
+   i32.const 385
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -784,7 +784,7 @@
    if
     i32.const 0
     i32.const 1696
-    i32.const 389
+    i32.const 392
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -811,7 +811,7 @@
    if
     i32.const 0
     i32.const 1696
-    i32.const 402
+    i32.const 405
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1174,7 +1174,7 @@
       if
        i32.const 0
        i32.const 1696
-       i32.const 562
+       i32.const 555
        i32.const 3
        call $~lib/builtins/abort
        unreachable
@@ -1409,7 +1409,7 @@
   if
    i32.const 1360
    i32.const 1696
-   i32.const 461
+   i32.const 460
    i32.const 29
    call $~lib/builtins/abort
    unreachable
@@ -1511,7 +1511,7 @@
    if
     i32.const 0
     i32.const 1696
-    i32.const 499
+    i32.const 492
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1526,7 +1526,7 @@
   if
    i32.const 0
    i32.const 1696
-   i32.const 501
+   i32.const 494
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/bindings/esm.release.wat
+++ b/tests/compiler/bindings/esm.release.wat
@@ -752,11 +752,16 @@
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
+  local.get $2
   local.get $1
   i64.extend_i32_u
-  local.get $2
-  i64.gt_u
+  i64.lt_u
   if
+   i32.const 0
+   i32.const 1696
+   i32.const 386
+   i32.const 14
+   call $~lib/builtins/abort
    unreachable
   end
   local.get $1
@@ -779,7 +784,7 @@
    if
     i32.const 0
     i32.const 1696
-    i32.const 392
+    i32.const 393
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -806,7 +811,7 @@
    if
     i32.const 0
     i32.const 1696
-    i32.const 405
+    i32.const 406
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1169,7 +1174,7 @@
       if
        i32.const 0
        i32.const 1696
-       i32.const 555
+       i32.const 556
        i32.const 3
        call $~lib/builtins/abort
        unreachable
@@ -1404,7 +1409,7 @@
   if
    i32.const 1360
    i32.const 1696
-   i32.const 460
+   i32.const 461
    i32.const 29
    call $~lib/builtins/abort
    unreachable
@@ -1506,7 +1511,7 @@
    if
     i32.const 0
     i32.const 1696
-    i32.const 492
+    i32.const 493
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1521,7 +1526,7 @@
   if
    i32.const 0
    i32.const 1696
-   i32.const 494
+   i32.const 495
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/bindings/noExportRuntime.debug.wat
+++ b/tests/compiler/bindings/noExportRuntime.debug.wat
@@ -1052,6 +1052,8 @@
   local.get $endU64
   i32.wrap_i64
   local.set $end
+  i32.const 0
+  drop
   i32.const 1
   drop
   local.get $start
@@ -1062,7 +1064,7 @@
   if
    i32.const 0
    i32.const 512
-   i32.const 382
+   i32.const 385
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1108,7 +1110,7 @@
    if
     i32.const 0
     i32.const 512
-    i32.const 389
+    i32.const 392
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1140,7 +1142,7 @@
    if
     i32.const 0
     i32.const 512
-    i32.const 402
+    i32.const 405
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1341,8 +1343,6 @@
   i32.const 1572
   i32.add
   local.set $memStart
-  i32.const 0
-  drop
   local.get $root
   local.get $memStart
   memory.size
@@ -1384,7 +1384,7 @@
   if
    i32.const 0
    i32.const 512
-   i32.const 562
+   i32.const 555
    i32.const 3
    call $~lib/builtins/abort
    unreachable
@@ -1713,7 +1713,7 @@
   if
    i32.const 176
    i32.const 512
-   i32.const 461
+   i32.const 460
    i32.const 29
    call $~lib/builtins/abort
    unreachable
@@ -1947,8 +1947,6 @@
   (local $6 i32)
   (local $pagesWanted i32)
   (local $pagesAfter i32)
-  i32.const 0
-  drop
   local.get $size
   i32.const 256
   i32.ge_u
@@ -2158,7 +2156,7 @@
    if
     i32.const 0
     i32.const 512
-    i32.const 499
+    i32.const 492
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -2178,7 +2176,7 @@
   if
    i32.const 0
    i32.const 512
-   i32.const 501
+   i32.const 494
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/bindings/noExportRuntime.debug.wat
+++ b/tests/compiler/bindings/noExportRuntime.debug.wat
@@ -1054,11 +1054,19 @@
   local.set $end
   i32.const 0
   drop
+  i32.const 1
+  drop
   local.get $start
   i64.extend_i32_u
   local.get $endU64
-  i64.gt_u
+  i64.le_u
+  i32.eqz
   if
+   i32.const 0
+   i32.const 512
+   i32.const 386
+   i32.const 14
+   call $~lib/builtins/abort
    unreachable
   end
   local.get $start
@@ -1102,7 +1110,7 @@
    if
     i32.const 0
     i32.const 512
-    i32.const 392
+    i32.const 393
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1134,7 +1142,7 @@
    if
     i32.const 0
     i32.const 512
-    i32.const 405
+    i32.const 406
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1376,7 +1384,7 @@
   if
    i32.const 0
    i32.const 512
-   i32.const 555
+   i32.const 556
    i32.const 3
    call $~lib/builtins/abort
    unreachable
@@ -1705,7 +1713,7 @@
   if
    i32.const 176
    i32.const 512
-   i32.const 460
+   i32.const 461
    i32.const 29
    call $~lib/builtins/abort
    unreachable
@@ -2148,7 +2156,7 @@
    if
     i32.const 0
     i32.const 512
-    i32.const 492
+    i32.const 493
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -2168,7 +2176,7 @@
   if
    i32.const 0
    i32.const 512
-   i32.const 494
+   i32.const 495
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/bindings/noExportRuntime.debug.wat
+++ b/tests/compiler/bindings/noExportRuntime.debug.wat
@@ -1054,19 +1054,11 @@
   local.set $end
   i32.const 0
   drop
-  i32.const 1
-  drop
   local.get $start
   i64.extend_i32_u
   local.get $endU64
-  i64.le_u
-  i32.eqz
+  i64.gt_u
   if
-   i32.const 0
-   i32.const 512
-   i32.const 385
-   i32.const 14
-   call $~lib/builtins/abort
    unreachable
   end
   local.get $start

--- a/tests/compiler/bindings/noExportRuntime.release.wat
+++ b/tests/compiler/bindings/noExportRuntime.release.wat
@@ -685,16 +685,11 @@
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
-  local.get $2
   local.get $1
   i64.extend_i32_u
-  i64.lt_u
+  local.get $2
+  i64.gt_u
   if
-   i32.const 0
-   i32.const 1536
-   i32.const 385
-   i32.const 14
-   call $~lib/builtins/abort
    unreachable
   end
   local.get $1

--- a/tests/compiler/bindings/noExportRuntime.release.wat
+++ b/tests/compiler/bindings/noExportRuntime.release.wat
@@ -692,7 +692,7 @@
   if
    i32.const 0
    i32.const 1536
-   i32.const 382
+   i32.const 385
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -717,7 +717,7 @@
    if
     i32.const 0
     i32.const 1536
-    i32.const 389
+    i32.const 392
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -744,7 +744,7 @@
    if
     i32.const 0
     i32.const 1536
-    i32.const 402
+    i32.const 405
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1107,7 +1107,7 @@
       if
        i32.const 0
        i32.const 1536
-       i32.const 562
+       i32.const 555
        i32.const 3
        call $~lib/builtins/abort
        unreachable
@@ -1342,7 +1342,7 @@
   if
    i32.const 1200
    i32.const 1536
-   i32.const 461
+   i32.const 460
    i32.const 29
    call $~lib/builtins/abort
    unreachable
@@ -1444,7 +1444,7 @@
    if
     i32.const 0
     i32.const 1536
-    i32.const 499
+    i32.const 492
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1459,7 +1459,7 @@
   if
    i32.const 0
    i32.const 1536
-   i32.const 501
+   i32.const 494
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/bindings/noExportRuntime.release.wat
+++ b/tests/compiler/bindings/noExportRuntime.release.wat
@@ -685,11 +685,16 @@
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
+  local.get $2
   local.get $1
   i64.extend_i32_u
-  local.get $2
-  i64.gt_u
+  i64.lt_u
   if
+   i32.const 0
+   i32.const 1536
+   i32.const 386
+   i32.const 14
+   call $~lib/builtins/abort
    unreachable
   end
   local.get $1
@@ -712,7 +717,7 @@
    if
     i32.const 0
     i32.const 1536
-    i32.const 392
+    i32.const 393
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -739,7 +744,7 @@
    if
     i32.const 0
     i32.const 1536
-    i32.const 405
+    i32.const 406
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1102,7 +1107,7 @@
       if
        i32.const 0
        i32.const 1536
-       i32.const 555
+       i32.const 556
        i32.const 3
        call $~lib/builtins/abort
        unreachable
@@ -1337,7 +1342,7 @@
   if
    i32.const 1200
    i32.const 1536
-   i32.const 460
+   i32.const 461
    i32.const 29
    call $~lib/builtins/abort
    unreachable
@@ -1439,7 +1444,7 @@
    if
     i32.const 0
     i32.const 1536
-    i32.const 492
+    i32.const 493
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1454,7 +1459,7 @@
   if
    i32.const 0
    i32.const 1536
-   i32.const 494
+   i32.const 495
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/bindings/raw.debug.wat
+++ b/tests/compiler/bindings/raw.debug.wat
@@ -1139,6 +1139,8 @@
   local.get $endU64
   i32.wrap_i64
   local.set $end
+  i32.const 0
+  drop
   i32.const 1
   drop
   local.get $start
@@ -1149,7 +1151,7 @@
   if
    i32.const 0
    i32.const 672
-   i32.const 382
+   i32.const 385
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1195,7 +1197,7 @@
    if
     i32.const 0
     i32.const 672
-    i32.const 389
+    i32.const 392
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1227,7 +1229,7 @@
    if
     i32.const 0
     i32.const 672
-    i32.const 402
+    i32.const 405
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1428,8 +1430,6 @@
   i32.const 1572
   i32.add
   local.set $memStart
-  i32.const 0
-  drop
   local.get $root
   local.get $memStart
   memory.size
@@ -1471,7 +1471,7 @@
   if
    i32.const 0
    i32.const 672
-   i32.const 562
+   i32.const 555
    i32.const 3
    call $~lib/builtins/abort
    unreachable
@@ -1800,7 +1800,7 @@
   if
    i32.const 336
    i32.const 672
-   i32.const 461
+   i32.const 460
    i32.const 29
    call $~lib/builtins/abort
    unreachable
@@ -2034,8 +2034,6 @@
   (local $6 i32)
   (local $pagesWanted i32)
   (local $pagesAfter i32)
-  i32.const 0
-  drop
   local.get $size
   i32.const 256
   i32.ge_u
@@ -2245,7 +2243,7 @@
    if
     i32.const 0
     i32.const 672
-    i32.const 499
+    i32.const 492
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -2265,7 +2263,7 @@
   if
    i32.const 0
    i32.const 672
-   i32.const 501
+   i32.const 494
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/bindings/raw.debug.wat
+++ b/tests/compiler/bindings/raw.debug.wat
@@ -1141,11 +1141,19 @@
   local.set $end
   i32.const 0
   drop
+  i32.const 1
+  drop
   local.get $start
   i64.extend_i32_u
   local.get $endU64
-  i64.gt_u
+  i64.le_u
+  i32.eqz
   if
+   i32.const 0
+   i32.const 672
+   i32.const 386
+   i32.const 14
+   call $~lib/builtins/abort
    unreachable
   end
   local.get $start
@@ -1189,7 +1197,7 @@
    if
     i32.const 0
     i32.const 672
-    i32.const 392
+    i32.const 393
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1221,7 +1229,7 @@
    if
     i32.const 0
     i32.const 672
-    i32.const 405
+    i32.const 406
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1463,7 +1471,7 @@
   if
    i32.const 0
    i32.const 672
-   i32.const 555
+   i32.const 556
    i32.const 3
    call $~lib/builtins/abort
    unreachable
@@ -1792,7 +1800,7 @@
   if
    i32.const 336
    i32.const 672
-   i32.const 460
+   i32.const 461
    i32.const 29
    call $~lib/builtins/abort
    unreachable
@@ -2235,7 +2243,7 @@
    if
     i32.const 0
     i32.const 672
-    i32.const 492
+    i32.const 493
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -2255,7 +2263,7 @@
   if
    i32.const 0
    i32.const 672
-   i32.const 494
+   i32.const 495
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/bindings/raw.debug.wat
+++ b/tests/compiler/bindings/raw.debug.wat
@@ -1141,19 +1141,11 @@
   local.set $end
   i32.const 0
   drop
-  i32.const 1
-  drop
   local.get $start
   i64.extend_i32_u
   local.get $endU64
-  i64.le_u
-  i32.eqz
+  i64.gt_u
   if
-   i32.const 0
-   i32.const 672
-   i32.const 385
-   i32.const 14
-   call $~lib/builtins/abort
    unreachable
   end
   local.get $start

--- a/tests/compiler/bindings/raw.release.wat
+++ b/tests/compiler/bindings/raw.release.wat
@@ -752,16 +752,11 @@
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
-  local.get $2
   local.get $1
   i64.extend_i32_u
-  i64.lt_u
+  local.get $2
+  i64.gt_u
   if
-   i32.const 0
-   i32.const 1696
-   i32.const 385
-   i32.const 14
-   call $~lib/builtins/abort
    unreachable
   end
   local.get $1

--- a/tests/compiler/bindings/raw.release.wat
+++ b/tests/compiler/bindings/raw.release.wat
@@ -759,7 +759,7 @@
   if
    i32.const 0
    i32.const 1696
-   i32.const 382
+   i32.const 385
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -784,7 +784,7 @@
    if
     i32.const 0
     i32.const 1696
-    i32.const 389
+    i32.const 392
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -811,7 +811,7 @@
    if
     i32.const 0
     i32.const 1696
-    i32.const 402
+    i32.const 405
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1174,7 +1174,7 @@
       if
        i32.const 0
        i32.const 1696
-       i32.const 562
+       i32.const 555
        i32.const 3
        call $~lib/builtins/abort
        unreachable
@@ -1409,7 +1409,7 @@
   if
    i32.const 1360
    i32.const 1696
-   i32.const 461
+   i32.const 460
    i32.const 29
    call $~lib/builtins/abort
    unreachable
@@ -1511,7 +1511,7 @@
    if
     i32.const 0
     i32.const 1696
-    i32.const 499
+    i32.const 492
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1526,7 +1526,7 @@
   if
    i32.const 0
    i32.const 1696
-   i32.const 501
+   i32.const 494
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/bindings/raw.release.wat
+++ b/tests/compiler/bindings/raw.release.wat
@@ -752,11 +752,16 @@
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
+  local.get $2
   local.get $1
   i64.extend_i32_u
-  local.get $2
-  i64.gt_u
+  i64.lt_u
   if
+   i32.const 0
+   i32.const 1696
+   i32.const 386
+   i32.const 14
+   call $~lib/builtins/abort
    unreachable
   end
   local.get $1
@@ -779,7 +784,7 @@
    if
     i32.const 0
     i32.const 1696
-    i32.const 392
+    i32.const 393
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -806,7 +811,7 @@
    if
     i32.const 0
     i32.const 1696
-    i32.const 405
+    i32.const 406
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1169,7 +1174,7 @@
       if
        i32.const 0
        i32.const 1696
-       i32.const 555
+       i32.const 556
        i32.const 3
        call $~lib/builtins/abort
        unreachable
@@ -1404,7 +1409,7 @@
   if
    i32.const 1360
    i32.const 1696
-   i32.const 460
+   i32.const 461
    i32.const 29
    call $~lib/builtins/abort
    unreachable
@@ -1506,7 +1511,7 @@
    if
     i32.const 0
     i32.const 1696
-    i32.const 492
+    i32.const 493
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1521,7 +1526,7 @@
   if
    i32.const 0
    i32.const 1696
-   i32.const 494
+   i32.const 495
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/call-super.debug.wat
+++ b/tests/compiler/call-super.debug.wat
@@ -1027,6 +1027,8 @@
   local.get $endU64
   i32.wrap_i64
   local.set $end
+  i32.const 0
+  drop
   i32.const 1
   drop
   local.get $start
@@ -1037,7 +1039,7 @@
   if
    i32.const 0
    i32.const 416
-   i32.const 382
+   i32.const 385
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1083,7 +1085,7 @@
    if
     i32.const 0
     i32.const 416
-    i32.const 389
+    i32.const 392
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1115,7 +1117,7 @@
    if
     i32.const 0
     i32.const 416
-    i32.const 402
+    i32.const 405
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1316,8 +1318,6 @@
   i32.const 1572
   i32.add
   local.set $memStart
-  i32.const 0
-  drop
   local.get $root
   local.get $memStart
   memory.size
@@ -1359,7 +1359,7 @@
   if
    i32.const 0
    i32.const 416
-   i32.const 562
+   i32.const 555
    i32.const 3
    call $~lib/builtins/abort
    unreachable
@@ -1688,7 +1688,7 @@
   if
    i32.const 80
    i32.const 416
-   i32.const 461
+   i32.const 460
    i32.const 29
    call $~lib/builtins/abort
    unreachable
@@ -1922,8 +1922,6 @@
   (local $6 i32)
   (local $pagesWanted i32)
   (local $pagesAfter i32)
-  i32.const 0
-  drop
   local.get $size
   i32.const 256
   i32.ge_u
@@ -2133,7 +2131,7 @@
    if
     i32.const 0
     i32.const 416
-    i32.const 499
+    i32.const 492
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -2153,7 +2151,7 @@
   if
    i32.const 0
    i32.const 416
-   i32.const 501
+   i32.const 494
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/call-super.debug.wat
+++ b/tests/compiler/call-super.debug.wat
@@ -1029,11 +1029,19 @@
   local.set $end
   i32.const 0
   drop
+  i32.const 1
+  drop
   local.get $start
   i64.extend_i32_u
   local.get $endU64
-  i64.gt_u
+  i64.le_u
+  i32.eqz
   if
+   i32.const 0
+   i32.const 416
+   i32.const 386
+   i32.const 14
+   call $~lib/builtins/abort
    unreachable
   end
   local.get $start
@@ -1077,7 +1085,7 @@
    if
     i32.const 0
     i32.const 416
-    i32.const 392
+    i32.const 393
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1109,7 +1117,7 @@
    if
     i32.const 0
     i32.const 416
-    i32.const 405
+    i32.const 406
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1351,7 +1359,7 @@
   if
    i32.const 0
    i32.const 416
-   i32.const 555
+   i32.const 556
    i32.const 3
    call $~lib/builtins/abort
    unreachable
@@ -1680,7 +1688,7 @@
   if
    i32.const 80
    i32.const 416
-   i32.const 460
+   i32.const 461
    i32.const 29
    call $~lib/builtins/abort
    unreachable
@@ -2123,7 +2131,7 @@
    if
     i32.const 0
     i32.const 416
-    i32.const 492
+    i32.const 493
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -2143,7 +2151,7 @@
   if
    i32.const 0
    i32.const 416
-   i32.const 494
+   i32.const 495
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/call-super.debug.wat
+++ b/tests/compiler/call-super.debug.wat
@@ -1029,19 +1029,11 @@
   local.set $end
   i32.const 0
   drop
-  i32.const 1
-  drop
   local.get $start
   i64.extend_i32_u
   local.get $endU64
-  i64.le_u
-  i32.eqz
+  i64.gt_u
   if
-   i32.const 0
-   i32.const 416
-   i32.const 385
-   i32.const 14
-   call $~lib/builtins/abort
    unreachable
   end
   local.get $start

--- a/tests/compiler/call-super.release.wat
+++ b/tests/compiler/call-super.release.wat
@@ -635,7 +635,7 @@
   if
    i32.const 0
    i32.const 1440
-   i32.const 382
+   i32.const 385
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -660,7 +660,7 @@
    if
     i32.const 0
     i32.const 1440
-    i32.const 389
+    i32.const 392
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -687,7 +687,7 @@
    if
     i32.const 0
     i32.const 1440
-    i32.const 402
+    i32.const 405
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1050,7 +1050,7 @@
       if
        i32.const 0
        i32.const 1440
-       i32.const 562
+       i32.const 555
        i32.const 3
        call $~lib/builtins/abort
        unreachable
@@ -1285,7 +1285,7 @@
   if
    i32.const 1104
    i32.const 1440
-   i32.const 461
+   i32.const 460
    i32.const 29
    call $~lib/builtins/abort
    unreachable
@@ -1387,7 +1387,7 @@
    if
     i32.const 0
     i32.const 1440
-    i32.const 499
+    i32.const 492
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1402,7 +1402,7 @@
   if
    i32.const 0
    i32.const 1440
-   i32.const 501
+   i32.const 494
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/call-super.release.wat
+++ b/tests/compiler/call-super.release.wat
@@ -628,11 +628,16 @@
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
+  local.get $2
   local.get $1
   i64.extend_i32_u
-  local.get $2
-  i64.gt_u
+  i64.lt_u
   if
+   i32.const 0
+   i32.const 1440
+   i32.const 386
+   i32.const 14
+   call $~lib/builtins/abort
    unreachable
   end
   local.get $1
@@ -655,7 +660,7 @@
    if
     i32.const 0
     i32.const 1440
-    i32.const 392
+    i32.const 393
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -682,7 +687,7 @@
    if
     i32.const 0
     i32.const 1440
-    i32.const 405
+    i32.const 406
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1045,7 +1050,7 @@
       if
        i32.const 0
        i32.const 1440
-       i32.const 555
+       i32.const 556
        i32.const 3
        call $~lib/builtins/abort
        unreachable
@@ -1280,7 +1285,7 @@
   if
    i32.const 1104
    i32.const 1440
-   i32.const 460
+   i32.const 461
    i32.const 29
    call $~lib/builtins/abort
    unreachable
@@ -1382,7 +1387,7 @@
    if
     i32.const 0
     i32.const 1440
-    i32.const 492
+    i32.const 493
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1397,7 +1402,7 @@
   if
    i32.const 0
    i32.const 1440
-   i32.const 494
+   i32.const 495
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/call-super.release.wat
+++ b/tests/compiler/call-super.release.wat
@@ -628,16 +628,11 @@
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
-  local.get $2
   local.get $1
   i64.extend_i32_u
-  i64.lt_u
+  local.get $2
+  i64.gt_u
   if
-   i32.const 0
-   i32.const 1440
-   i32.const 385
-   i32.const 14
-   call $~lib/builtins/abort
    unreachable
   end
   local.get $1

--- a/tests/compiler/class-implements.debug.wat
+++ b/tests/compiler/class-implements.debug.wat
@@ -1032,19 +1032,11 @@
   local.set $end
   i32.const 0
   drop
-  i32.const 1
-  drop
   local.get $start
   i64.extend_i32_u
   local.get $endU64
-  i64.le_u
-  i32.eqz
+  i64.gt_u
   if
-   i32.const 0
-   i32.const 368
-   i32.const 385
-   i32.const 14
-   call $~lib/builtins/abort
    unreachable
   end
   local.get $start

--- a/tests/compiler/class-implements.debug.wat
+++ b/tests/compiler/class-implements.debug.wat
@@ -1030,6 +1030,8 @@
   local.get $endU64
   i32.wrap_i64
   local.set $end
+  i32.const 0
+  drop
   i32.const 1
   drop
   local.get $start
@@ -1040,7 +1042,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 382
+   i32.const 385
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1086,7 +1088,7 @@
    if
     i32.const 0
     i32.const 368
-    i32.const 389
+    i32.const 392
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1118,7 +1120,7 @@
    if
     i32.const 0
     i32.const 368
-    i32.const 402
+    i32.const 405
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1319,8 +1321,6 @@
   i32.const 1572
   i32.add
   local.set $memStart
-  i32.const 0
-  drop
   local.get $root
   local.get $memStart
   memory.size
@@ -1362,7 +1362,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 562
+   i32.const 555
    i32.const 3
    call $~lib/builtins/abort
    unreachable
@@ -1691,7 +1691,7 @@
   if
    i32.const 32
    i32.const 368
-   i32.const 461
+   i32.const 460
    i32.const 29
    call $~lib/builtins/abort
    unreachable
@@ -1925,8 +1925,6 @@
   (local $6 i32)
   (local $pagesWanted i32)
   (local $pagesAfter i32)
-  i32.const 0
-  drop
   local.get $size
   i32.const 256
   i32.ge_u
@@ -2136,7 +2134,7 @@
    if
     i32.const 0
     i32.const 368
-    i32.const 499
+    i32.const 492
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -2156,7 +2154,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 501
+   i32.const 494
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/class-implements.debug.wat
+++ b/tests/compiler/class-implements.debug.wat
@@ -1032,11 +1032,19 @@
   local.set $end
   i32.const 0
   drop
+  i32.const 1
+  drop
   local.get $start
   i64.extend_i32_u
   local.get $endU64
-  i64.gt_u
+  i64.le_u
+  i32.eqz
   if
+   i32.const 0
+   i32.const 368
+   i32.const 386
+   i32.const 14
+   call $~lib/builtins/abort
    unreachable
   end
   local.get $start
@@ -1080,7 +1088,7 @@
    if
     i32.const 0
     i32.const 368
-    i32.const 392
+    i32.const 393
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1112,7 +1120,7 @@
    if
     i32.const 0
     i32.const 368
-    i32.const 405
+    i32.const 406
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1354,7 +1362,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 555
+   i32.const 556
    i32.const 3
    call $~lib/builtins/abort
    unreachable
@@ -1683,7 +1691,7 @@
   if
    i32.const 32
    i32.const 368
-   i32.const 460
+   i32.const 461
    i32.const 29
    call $~lib/builtins/abort
    unreachable
@@ -2126,7 +2134,7 @@
    if
     i32.const 0
     i32.const 368
-    i32.const 492
+    i32.const 493
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -2146,7 +2154,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 494
+   i32.const 495
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/class-implements.release.wat
+++ b/tests/compiler/class-implements.release.wat
@@ -677,11 +677,16 @@
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
+  local.get $2
   local.get $1
   i64.extend_i32_u
-  local.get $2
-  i64.gt_u
+  i64.lt_u
   if
+   i32.const 0
+   i32.const 1392
+   i32.const 386
+   i32.const 14
+   call $~lib/builtins/abort
    unreachable
   end
   local.get $1
@@ -704,7 +709,7 @@
    if
     i32.const 0
     i32.const 1392
-    i32.const 392
+    i32.const 393
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -731,7 +736,7 @@
    if
     i32.const 0
     i32.const 1392
-    i32.const 405
+    i32.const 406
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1094,7 +1099,7 @@
       if
        i32.const 0
        i32.const 1392
-       i32.const 555
+       i32.const 556
        i32.const 3
        call $~lib/builtins/abort
        unreachable
@@ -1329,7 +1334,7 @@
   if
    i32.const 1056
    i32.const 1392
-   i32.const 460
+   i32.const 461
    i32.const 29
    call $~lib/builtins/abort
    unreachable
@@ -1431,7 +1436,7 @@
    if
     i32.const 0
     i32.const 1392
-    i32.const 492
+    i32.const 493
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1446,7 +1451,7 @@
   if
    i32.const 0
    i32.const 1392
-   i32.const 494
+   i32.const 495
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/class-implements.release.wat
+++ b/tests/compiler/class-implements.release.wat
@@ -677,16 +677,11 @@
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
-  local.get $2
   local.get $1
   i64.extend_i32_u
-  i64.lt_u
+  local.get $2
+  i64.gt_u
   if
-   i32.const 0
-   i32.const 1392
-   i32.const 385
-   i32.const 14
-   call $~lib/builtins/abort
    unreachable
   end
   local.get $1

--- a/tests/compiler/class-implements.release.wat
+++ b/tests/compiler/class-implements.release.wat
@@ -684,7 +684,7 @@
   if
    i32.const 0
    i32.const 1392
-   i32.const 382
+   i32.const 385
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -709,7 +709,7 @@
    if
     i32.const 0
     i32.const 1392
-    i32.const 389
+    i32.const 392
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -736,7 +736,7 @@
    if
     i32.const 0
     i32.const 1392
-    i32.const 402
+    i32.const 405
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1099,7 +1099,7 @@
       if
        i32.const 0
        i32.const 1392
-       i32.const 562
+       i32.const 555
        i32.const 3
        call $~lib/builtins/abort
        unreachable
@@ -1334,7 +1334,7 @@
   if
    i32.const 1056
    i32.const 1392
-   i32.const 461
+   i32.const 460
    i32.const 29
    call $~lib/builtins/abort
    unreachable
@@ -1436,7 +1436,7 @@
    if
     i32.const 0
     i32.const 1392
-    i32.const 499
+    i32.const 492
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1451,7 +1451,7 @@
   if
    i32.const 0
    i32.const 1392
-   i32.const 501
+   i32.const 494
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/class-overloading-cast.debug.wat
+++ b/tests/compiler/class-overloading-cast.debug.wat
@@ -1038,19 +1038,11 @@
   local.set $end
   i32.const 0
   drop
-  i32.const 1
-  drop
   local.get $start
   i64.extend_i32_u
   local.get $endU64
-  i64.le_u
-  i32.eqz
+  i64.gt_u
   if
-   i32.const 0
-   i32.const 368
-   i32.const 385
-   i32.const 14
-   call $~lib/builtins/abort
    unreachable
   end
   local.get $start

--- a/tests/compiler/class-overloading-cast.debug.wat
+++ b/tests/compiler/class-overloading-cast.debug.wat
@@ -1038,11 +1038,19 @@
   local.set $end
   i32.const 0
   drop
+  i32.const 1
+  drop
   local.get $start
   i64.extend_i32_u
   local.get $endU64
-  i64.gt_u
+  i64.le_u
+  i32.eqz
   if
+   i32.const 0
+   i32.const 368
+   i32.const 386
+   i32.const 14
+   call $~lib/builtins/abort
    unreachable
   end
   local.get $start
@@ -1086,7 +1094,7 @@
    if
     i32.const 0
     i32.const 368
-    i32.const 392
+    i32.const 393
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1118,7 +1126,7 @@
    if
     i32.const 0
     i32.const 368
-    i32.const 405
+    i32.const 406
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1360,7 +1368,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 555
+   i32.const 556
    i32.const 3
    call $~lib/builtins/abort
    unreachable
@@ -1689,7 +1697,7 @@
   if
    i32.const 32
    i32.const 368
-   i32.const 460
+   i32.const 461
    i32.const 29
    call $~lib/builtins/abort
    unreachable
@@ -2132,7 +2140,7 @@
    if
     i32.const 0
     i32.const 368
-    i32.const 492
+    i32.const 493
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -2152,7 +2160,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 494
+   i32.const 495
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/class-overloading-cast.debug.wat
+++ b/tests/compiler/class-overloading-cast.debug.wat
@@ -1036,6 +1036,8 @@
   local.get $endU64
   i32.wrap_i64
   local.set $end
+  i32.const 0
+  drop
   i32.const 1
   drop
   local.get $start
@@ -1046,7 +1048,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 382
+   i32.const 385
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1092,7 +1094,7 @@
    if
     i32.const 0
     i32.const 368
-    i32.const 389
+    i32.const 392
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1124,7 +1126,7 @@
    if
     i32.const 0
     i32.const 368
-    i32.const 402
+    i32.const 405
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1325,8 +1327,6 @@
   i32.const 1572
   i32.add
   local.set $memStart
-  i32.const 0
-  drop
   local.get $root
   local.get $memStart
   memory.size
@@ -1368,7 +1368,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 562
+   i32.const 555
    i32.const 3
    call $~lib/builtins/abort
    unreachable
@@ -1697,7 +1697,7 @@
   if
    i32.const 32
    i32.const 368
-   i32.const 461
+   i32.const 460
    i32.const 29
    call $~lib/builtins/abort
    unreachable
@@ -1931,8 +1931,6 @@
   (local $6 i32)
   (local $pagesWanted i32)
   (local $pagesAfter i32)
-  i32.const 0
-  drop
   local.get $size
   i32.const 256
   i32.ge_u
@@ -2142,7 +2140,7 @@
    if
     i32.const 0
     i32.const 368
-    i32.const 499
+    i32.const 492
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -2162,7 +2160,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 501
+   i32.const 494
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/class-overloading-cast.release.wat
+++ b/tests/compiler/class-overloading-cast.release.wat
@@ -672,7 +672,7 @@
   if
    i32.const 0
    i32.const 1392
-   i32.const 382
+   i32.const 385
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -697,7 +697,7 @@
    if
     i32.const 0
     i32.const 1392
-    i32.const 389
+    i32.const 392
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -724,7 +724,7 @@
    if
     i32.const 0
     i32.const 1392
-    i32.const 402
+    i32.const 405
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1087,7 +1087,7 @@
       if
        i32.const 0
        i32.const 1392
-       i32.const 562
+       i32.const 555
        i32.const 3
        call $~lib/builtins/abort
        unreachable
@@ -1285,7 +1285,7 @@
    if
     i32.const 0
     i32.const 1392
-    i32.const 499
+    i32.const 492
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1300,7 +1300,7 @@
   if
    i32.const 0
    i32.const 1392
-   i32.const 501
+   i32.const 494
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/class-overloading-cast.release.wat
+++ b/tests/compiler/class-overloading-cast.release.wat
@@ -665,11 +665,16 @@
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
+  local.get $2
   local.get $1
   i64.extend_i32_u
-  local.get $2
-  i64.gt_u
+  i64.lt_u
   if
+   i32.const 0
+   i32.const 1392
+   i32.const 386
+   i32.const 14
+   call $~lib/builtins/abort
    unreachable
   end
   local.get $1
@@ -692,7 +697,7 @@
    if
     i32.const 0
     i32.const 1392
-    i32.const 392
+    i32.const 393
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -719,7 +724,7 @@
    if
     i32.const 0
     i32.const 1392
-    i32.const 405
+    i32.const 406
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1082,7 +1087,7 @@
       if
        i32.const 0
        i32.const 1392
-       i32.const 555
+       i32.const 556
        i32.const 3
        call $~lib/builtins/abort
        unreachable
@@ -1280,7 +1285,7 @@
    if
     i32.const 0
     i32.const 1392
-    i32.const 492
+    i32.const 493
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1295,7 +1300,7 @@
   if
    i32.const 0
    i32.const 1392
-   i32.const 494
+   i32.const 495
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/class-overloading-cast.release.wat
+++ b/tests/compiler/class-overloading-cast.release.wat
@@ -665,16 +665,11 @@
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
-  local.get $2
   local.get $1
   i64.extend_i32_u
-  i64.lt_u
+  local.get $2
+  i64.gt_u
   if
-   i32.const 0
-   i32.const 1392
-   i32.const 385
-   i32.const 14
-   call $~lib/builtins/abort
    unreachable
   end
   local.get $1

--- a/tests/compiler/class-overloading.debug.wat
+++ b/tests/compiler/class-overloading.debug.wat
@@ -1040,6 +1040,8 @@
   local.get $endU64
   i32.wrap_i64
   local.set $end
+  i32.const 0
+  drop
   i32.const 1
   drop
   local.get $start
@@ -1050,7 +1052,7 @@
   if
    i32.const 0
    i32.const 400
-   i32.const 382
+   i32.const 385
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1096,7 +1098,7 @@
    if
     i32.const 0
     i32.const 400
-    i32.const 389
+    i32.const 392
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1128,7 +1130,7 @@
    if
     i32.const 0
     i32.const 400
-    i32.const 402
+    i32.const 405
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1329,8 +1331,6 @@
   i32.const 1572
   i32.add
   local.set $memStart
-  i32.const 0
-  drop
   local.get $root
   local.get $memStart
   memory.size
@@ -1372,7 +1372,7 @@
   if
    i32.const 0
    i32.const 400
-   i32.const 562
+   i32.const 555
    i32.const 3
    call $~lib/builtins/abort
    unreachable
@@ -1701,7 +1701,7 @@
   if
    i32.const 64
    i32.const 400
-   i32.const 461
+   i32.const 460
    i32.const 29
    call $~lib/builtins/abort
    unreachable
@@ -1935,8 +1935,6 @@
   (local $6 i32)
   (local $pagesWanted i32)
   (local $pagesAfter i32)
-  i32.const 0
-  drop
   local.get $size
   i32.const 256
   i32.ge_u
@@ -2146,7 +2144,7 @@
    if
     i32.const 0
     i32.const 400
-    i32.const 499
+    i32.const 492
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -2166,7 +2164,7 @@
   if
    i32.const 0
    i32.const 400
-   i32.const 501
+   i32.const 494
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/class-overloading.debug.wat
+++ b/tests/compiler/class-overloading.debug.wat
@@ -1042,11 +1042,19 @@
   local.set $end
   i32.const 0
   drop
+  i32.const 1
+  drop
   local.get $start
   i64.extend_i32_u
   local.get $endU64
-  i64.gt_u
+  i64.le_u
+  i32.eqz
   if
+   i32.const 0
+   i32.const 400
+   i32.const 386
+   i32.const 14
+   call $~lib/builtins/abort
    unreachable
   end
   local.get $start
@@ -1090,7 +1098,7 @@
    if
     i32.const 0
     i32.const 400
-    i32.const 392
+    i32.const 393
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1122,7 +1130,7 @@
    if
     i32.const 0
     i32.const 400
-    i32.const 405
+    i32.const 406
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1364,7 +1372,7 @@
   if
    i32.const 0
    i32.const 400
-   i32.const 555
+   i32.const 556
    i32.const 3
    call $~lib/builtins/abort
    unreachable
@@ -1693,7 +1701,7 @@
   if
    i32.const 64
    i32.const 400
-   i32.const 460
+   i32.const 461
    i32.const 29
    call $~lib/builtins/abort
    unreachable
@@ -2136,7 +2144,7 @@
    if
     i32.const 0
     i32.const 400
-    i32.const 492
+    i32.const 493
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -2156,7 +2164,7 @@
   if
    i32.const 0
    i32.const 400
-   i32.const 494
+   i32.const 495
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/class-overloading.debug.wat
+++ b/tests/compiler/class-overloading.debug.wat
@@ -1042,19 +1042,11 @@
   local.set $end
   i32.const 0
   drop
-  i32.const 1
-  drop
   local.get $start
   i64.extend_i32_u
   local.get $endU64
-  i64.le_u
-  i32.eqz
+  i64.gt_u
   if
-   i32.const 0
-   i32.const 400
-   i32.const 385
-   i32.const 14
-   call $~lib/builtins/abort
    unreachable
   end
   local.get $start

--- a/tests/compiler/class-overloading.release.wat
+++ b/tests/compiler/class-overloading.release.wat
@@ -687,11 +687,16 @@
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
+  local.get $2
   local.get $1
   i64.extend_i32_u
-  local.get $2
-  i64.gt_u
+  i64.lt_u
   if
+   i32.const 0
+   i32.const 1424
+   i32.const 386
+   i32.const 14
+   call $~lib/builtins/abort
    unreachable
   end
   local.get $1
@@ -714,7 +719,7 @@
    if
     i32.const 0
     i32.const 1424
-    i32.const 392
+    i32.const 393
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -741,7 +746,7 @@
    if
     i32.const 0
     i32.const 1424
-    i32.const 405
+    i32.const 406
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1104,7 +1109,7 @@
       if
        i32.const 0
        i32.const 1424
-       i32.const 555
+       i32.const 556
        i32.const 3
        call $~lib/builtins/abort
        unreachable
@@ -1302,7 +1307,7 @@
    if
     i32.const 0
     i32.const 1424
-    i32.const 492
+    i32.const 493
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1317,7 +1322,7 @@
   if
    i32.const 0
    i32.const 1424
-   i32.const 494
+   i32.const 495
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/class-overloading.release.wat
+++ b/tests/compiler/class-overloading.release.wat
@@ -687,16 +687,11 @@
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
-  local.get $2
   local.get $1
   i64.extend_i32_u
-  i64.lt_u
+  local.get $2
+  i64.gt_u
   if
-   i32.const 0
-   i32.const 1424
-   i32.const 385
-   i32.const 14
-   call $~lib/builtins/abort
    unreachable
   end
   local.get $1

--- a/tests/compiler/class-overloading.release.wat
+++ b/tests/compiler/class-overloading.release.wat
@@ -694,7 +694,7 @@
   if
    i32.const 0
    i32.const 1424
-   i32.const 382
+   i32.const 385
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -719,7 +719,7 @@
    if
     i32.const 0
     i32.const 1424
-    i32.const 389
+    i32.const 392
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -746,7 +746,7 @@
    if
     i32.const 0
     i32.const 1424
-    i32.const 402
+    i32.const 405
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1109,7 +1109,7 @@
       if
        i32.const 0
        i32.const 1424
-       i32.const 562
+       i32.const 555
        i32.const 3
        call $~lib/builtins/abort
        unreachable
@@ -1307,7 +1307,7 @@
    if
     i32.const 0
     i32.const 1424
-    i32.const 499
+    i32.const 492
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1322,7 +1322,7 @@
   if
    i32.const 0
    i32.const 1424
-   i32.const 501
+   i32.const 494
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/class-override.debug.wat
+++ b/tests/compiler/class-override.debug.wat
@@ -1027,19 +1027,11 @@
   local.set $end
   i32.const 0
   drop
-  i32.const 1
-  drop
   local.get $start
   i64.extend_i32_u
   local.get $endU64
-  i64.le_u
-  i32.eqz
+  i64.gt_u
   if
-   i32.const 0
-   i32.const 368
-   i32.const 385
-   i32.const 14
-   call $~lib/builtins/abort
    unreachable
   end
   local.get $start

--- a/tests/compiler/class-override.debug.wat
+++ b/tests/compiler/class-override.debug.wat
@@ -1027,11 +1027,19 @@
   local.set $end
   i32.const 0
   drop
+  i32.const 1
+  drop
   local.get $start
   i64.extend_i32_u
   local.get $endU64
-  i64.gt_u
+  i64.le_u
+  i32.eqz
   if
+   i32.const 0
+   i32.const 368
+   i32.const 386
+   i32.const 14
+   call $~lib/builtins/abort
    unreachable
   end
   local.get $start
@@ -1075,7 +1083,7 @@
    if
     i32.const 0
     i32.const 368
-    i32.const 392
+    i32.const 393
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1107,7 +1115,7 @@
    if
     i32.const 0
     i32.const 368
-    i32.const 405
+    i32.const 406
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1349,7 +1357,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 555
+   i32.const 556
    i32.const 3
    call $~lib/builtins/abort
    unreachable
@@ -1678,7 +1686,7 @@
   if
    i32.const 32
    i32.const 368
-   i32.const 460
+   i32.const 461
    i32.const 29
    call $~lib/builtins/abort
    unreachable
@@ -2121,7 +2129,7 @@
    if
     i32.const 0
     i32.const 368
-    i32.const 492
+    i32.const 493
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -2141,7 +2149,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 494
+   i32.const 495
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/class-override.debug.wat
+++ b/tests/compiler/class-override.debug.wat
@@ -1025,6 +1025,8 @@
   local.get $endU64
   i32.wrap_i64
   local.set $end
+  i32.const 0
+  drop
   i32.const 1
   drop
   local.get $start
@@ -1035,7 +1037,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 382
+   i32.const 385
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1081,7 +1083,7 @@
    if
     i32.const 0
     i32.const 368
-    i32.const 389
+    i32.const 392
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1113,7 +1115,7 @@
    if
     i32.const 0
     i32.const 368
-    i32.const 402
+    i32.const 405
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1314,8 +1316,6 @@
   i32.const 1572
   i32.add
   local.set $memStart
-  i32.const 0
-  drop
   local.get $root
   local.get $memStart
   memory.size
@@ -1357,7 +1357,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 562
+   i32.const 555
    i32.const 3
    call $~lib/builtins/abort
    unreachable
@@ -1686,7 +1686,7 @@
   if
    i32.const 32
    i32.const 368
-   i32.const 461
+   i32.const 460
    i32.const 29
    call $~lib/builtins/abort
    unreachable
@@ -1920,8 +1920,6 @@
   (local $6 i32)
   (local $pagesWanted i32)
   (local $pagesAfter i32)
-  i32.const 0
-  drop
   local.get $size
   i32.const 256
   i32.ge_u
@@ -2131,7 +2129,7 @@
    if
     i32.const 0
     i32.const 368
-    i32.const 499
+    i32.const 492
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -2151,7 +2149,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 501
+   i32.const 494
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/class-override.release.wat
+++ b/tests/compiler/class-override.release.wat
@@ -636,16 +636,11 @@
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
-  local.get $2
   local.get $1
   i64.extend_i32_u
-  i64.lt_u
+  local.get $2
+  i64.gt_u
   if
-   i32.const 0
-   i32.const 1392
-   i32.const 385
-   i32.const 14
-   call $~lib/builtins/abort
    unreachable
   end
   local.get $1

--- a/tests/compiler/class-override.release.wat
+++ b/tests/compiler/class-override.release.wat
@@ -643,7 +643,7 @@
   if
    i32.const 0
    i32.const 1392
-   i32.const 382
+   i32.const 385
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -668,7 +668,7 @@
    if
     i32.const 0
     i32.const 1392
-    i32.const 389
+    i32.const 392
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -695,7 +695,7 @@
    if
     i32.const 0
     i32.const 1392
-    i32.const 402
+    i32.const 405
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1058,7 +1058,7 @@
       if
        i32.const 0
        i32.const 1392
-       i32.const 562
+       i32.const 555
        i32.const 3
        call $~lib/builtins/abort
        unreachable
@@ -1256,7 +1256,7 @@
    if
     i32.const 0
     i32.const 1392
-    i32.const 499
+    i32.const 492
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1271,7 +1271,7 @@
   if
    i32.const 0
    i32.const 1392
-   i32.const 501
+   i32.const 494
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/class-override.release.wat
+++ b/tests/compiler/class-override.release.wat
@@ -636,11 +636,16 @@
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
+  local.get $2
   local.get $1
   i64.extend_i32_u
-  local.get $2
-  i64.gt_u
+  i64.lt_u
   if
+   i32.const 0
+   i32.const 1392
+   i32.const 386
+   i32.const 14
+   call $~lib/builtins/abort
    unreachable
   end
   local.get $1
@@ -663,7 +668,7 @@
    if
     i32.const 0
     i32.const 1392
-    i32.const 392
+    i32.const 393
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -690,7 +695,7 @@
    if
     i32.const 0
     i32.const 1392
-    i32.const 405
+    i32.const 406
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1053,7 +1058,7 @@
       if
        i32.const 0
        i32.const 1392
-       i32.const 555
+       i32.const 556
        i32.const 3
        call $~lib/builtins/abort
        unreachable
@@ -1251,7 +1256,7 @@
    if
     i32.const 0
     i32.const 1392
-    i32.const 492
+    i32.const 493
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1266,7 +1271,7 @@
   if
    i32.const 0
    i32.const 1392
-   i32.const 494
+   i32.const 495
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/class.debug.wat
+++ b/tests/compiler/class.debug.wat
@@ -1110,19 +1110,11 @@
   local.set $end
   i32.const 0
   drop
-  i32.const 1
-  drop
   local.get $start
   i64.extend_i32_u
   local.get $endU64
-  i64.le_u
-  i32.eqz
+  i64.gt_u
   if
-   i32.const 0
-   i32.const 368
-   i32.const 385
-   i32.const 14
-   call $~lib/builtins/abort
    unreachable
   end
   local.get $start

--- a/tests/compiler/class.debug.wat
+++ b/tests/compiler/class.debug.wat
@@ -1110,11 +1110,19 @@
   local.set $end
   i32.const 0
   drop
+  i32.const 1
+  drop
   local.get $start
   i64.extend_i32_u
   local.get $endU64
-  i64.gt_u
+  i64.le_u
+  i32.eqz
   if
+   i32.const 0
+   i32.const 368
+   i32.const 386
+   i32.const 14
+   call $~lib/builtins/abort
    unreachable
   end
   local.get $start
@@ -1158,7 +1166,7 @@
    if
     i32.const 0
     i32.const 368
-    i32.const 392
+    i32.const 393
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1190,7 +1198,7 @@
    if
     i32.const 0
     i32.const 368
-    i32.const 405
+    i32.const 406
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1432,7 +1440,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 555
+   i32.const 556
    i32.const 3
    call $~lib/builtins/abort
    unreachable
@@ -1761,7 +1769,7 @@
   if
    i32.const 32
    i32.const 368
-   i32.const 460
+   i32.const 461
    i32.const 29
    call $~lib/builtins/abort
    unreachable
@@ -2204,7 +2212,7 @@
    if
     i32.const 0
     i32.const 368
-    i32.const 492
+    i32.const 493
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -2224,7 +2232,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 494
+   i32.const 495
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/class.debug.wat
+++ b/tests/compiler/class.debug.wat
@@ -1108,6 +1108,8 @@
   local.get $endU64
   i32.wrap_i64
   local.set $end
+  i32.const 0
+  drop
   i32.const 1
   drop
   local.get $start
@@ -1118,7 +1120,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 382
+   i32.const 385
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1164,7 +1166,7 @@
    if
     i32.const 0
     i32.const 368
-    i32.const 389
+    i32.const 392
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1196,7 +1198,7 @@
    if
     i32.const 0
     i32.const 368
-    i32.const 402
+    i32.const 405
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1397,8 +1399,6 @@
   i32.const 1572
   i32.add
   local.set $memStart
-  i32.const 0
-  drop
   local.get $root
   local.get $memStart
   memory.size
@@ -1440,7 +1440,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 562
+   i32.const 555
    i32.const 3
    call $~lib/builtins/abort
    unreachable
@@ -1769,7 +1769,7 @@
   if
    i32.const 32
    i32.const 368
-   i32.const 461
+   i32.const 460
    i32.const 29
    call $~lib/builtins/abort
    unreachable
@@ -2003,8 +2003,6 @@
   (local $6 i32)
   (local $pagesWanted i32)
   (local $pagesAfter i32)
-  i32.const 0
-  drop
   local.get $size
   i32.const 256
   i32.ge_u
@@ -2214,7 +2212,7 @@
    if
     i32.const 0
     i32.const 368
-    i32.const 499
+    i32.const 492
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -2234,7 +2232,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 501
+   i32.const 494
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/class.release.wat
+++ b/tests/compiler/class.release.wat
@@ -638,11 +638,16 @@
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
+  local.get $2
   local.get $1
   i64.extend_i32_u
-  local.get $2
-  i64.gt_u
+  i64.lt_u
   if
+   i32.const 0
+   i32.const 1392
+   i32.const 386
+   i32.const 14
+   call $~lib/builtins/abort
    unreachable
   end
   local.get $1
@@ -665,7 +670,7 @@
    if
     i32.const 0
     i32.const 1392
-    i32.const 392
+    i32.const 393
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -692,7 +697,7 @@
    if
     i32.const 0
     i32.const 1392
-    i32.const 405
+    i32.const 406
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1055,7 +1060,7 @@
       if
        i32.const 0
        i32.const 1392
-       i32.const 555
+       i32.const 556
        i32.const 3
        call $~lib/builtins/abort
        unreachable
@@ -1290,7 +1295,7 @@
   if
    i32.const 1056
    i32.const 1392
-   i32.const 460
+   i32.const 461
    i32.const 29
    call $~lib/builtins/abort
    unreachable
@@ -1392,7 +1397,7 @@
    if
     i32.const 0
     i32.const 1392
-    i32.const 492
+    i32.const 493
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1407,7 +1412,7 @@
   if
    i32.const 0
    i32.const 1392
-   i32.const 494
+   i32.const 495
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/class.release.wat
+++ b/tests/compiler/class.release.wat
@@ -638,16 +638,11 @@
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
-  local.get $2
   local.get $1
   i64.extend_i32_u
-  i64.lt_u
+  local.get $2
+  i64.gt_u
   if
-   i32.const 0
-   i32.const 1392
-   i32.const 385
-   i32.const 14
-   call $~lib/builtins/abort
    unreachable
   end
   local.get $1

--- a/tests/compiler/class.release.wat
+++ b/tests/compiler/class.release.wat
@@ -645,7 +645,7 @@
   if
    i32.const 0
    i32.const 1392
-   i32.const 382
+   i32.const 385
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -670,7 +670,7 @@
    if
     i32.const 0
     i32.const 1392
-    i32.const 389
+    i32.const 392
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -697,7 +697,7 @@
    if
     i32.const 0
     i32.const 1392
-    i32.const 402
+    i32.const 405
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1060,7 +1060,7 @@
       if
        i32.const 0
        i32.const 1392
-       i32.const 562
+       i32.const 555
        i32.const 3
        call $~lib/builtins/abort
        unreachable
@@ -1295,7 +1295,7 @@
   if
    i32.const 1056
    i32.const 1392
-   i32.const 461
+   i32.const 460
    i32.const 29
    call $~lib/builtins/abort
    unreachable
@@ -1397,7 +1397,7 @@
    if
     i32.const 0
     i32.const 1392
-    i32.const 499
+    i32.const 492
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1412,7 +1412,7 @@
   if
    i32.const 0
    i32.const 1392
-   i32.const 501
+   i32.const 494
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/constructor.debug.wat
+++ b/tests/compiler/constructor.debug.wat
@@ -1038,19 +1038,11 @@
   local.set $end
   i32.const 0
   drop
-  i32.const 1
-  drop
   local.get $start
   i64.extend_i32_u
   local.get $endU64
-  i64.le_u
-  i32.eqz
+  i64.gt_u
   if
-   i32.const 0
-   i32.const 368
-   i32.const 385
-   i32.const 14
-   call $~lib/builtins/abort
    unreachable
   end
   local.get $start

--- a/tests/compiler/constructor.debug.wat
+++ b/tests/compiler/constructor.debug.wat
@@ -1038,11 +1038,19 @@
   local.set $end
   i32.const 0
   drop
+  i32.const 1
+  drop
   local.get $start
   i64.extend_i32_u
   local.get $endU64
-  i64.gt_u
+  i64.le_u
+  i32.eqz
   if
+   i32.const 0
+   i32.const 368
+   i32.const 386
+   i32.const 14
+   call $~lib/builtins/abort
    unreachable
   end
   local.get $start
@@ -1086,7 +1094,7 @@
    if
     i32.const 0
     i32.const 368
-    i32.const 392
+    i32.const 393
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1118,7 +1126,7 @@
    if
     i32.const 0
     i32.const 368
-    i32.const 405
+    i32.const 406
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1360,7 +1368,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 555
+   i32.const 556
    i32.const 3
    call $~lib/builtins/abort
    unreachable
@@ -1689,7 +1697,7 @@
   if
    i32.const 32
    i32.const 368
-   i32.const 460
+   i32.const 461
    i32.const 29
    call $~lib/builtins/abort
    unreachable
@@ -2132,7 +2140,7 @@
    if
     i32.const 0
     i32.const 368
-    i32.const 492
+    i32.const 493
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -2152,7 +2160,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 494
+   i32.const 495
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/constructor.debug.wat
+++ b/tests/compiler/constructor.debug.wat
@@ -1036,6 +1036,8 @@
   local.get $endU64
   i32.wrap_i64
   local.set $end
+  i32.const 0
+  drop
   i32.const 1
   drop
   local.get $start
@@ -1046,7 +1048,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 382
+   i32.const 385
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1092,7 +1094,7 @@
    if
     i32.const 0
     i32.const 368
-    i32.const 389
+    i32.const 392
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1124,7 +1126,7 @@
    if
     i32.const 0
     i32.const 368
-    i32.const 402
+    i32.const 405
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1325,8 +1327,6 @@
   i32.const 1572
   i32.add
   local.set $memStart
-  i32.const 0
-  drop
   local.get $root
   local.get $memStart
   memory.size
@@ -1368,7 +1368,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 562
+   i32.const 555
    i32.const 3
    call $~lib/builtins/abort
    unreachable
@@ -1697,7 +1697,7 @@
   if
    i32.const 32
    i32.const 368
-   i32.const 461
+   i32.const 460
    i32.const 29
    call $~lib/builtins/abort
    unreachable
@@ -1931,8 +1931,6 @@
   (local $6 i32)
   (local $pagesWanted i32)
   (local $pagesAfter i32)
-  i32.const 0
-  drop
   local.get $size
   i32.const 256
   i32.ge_u
@@ -2142,7 +2140,7 @@
    if
     i32.const 0
     i32.const 368
-    i32.const 499
+    i32.const 492
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -2162,7 +2160,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 501
+   i32.const 494
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/constructor.release.wat
+++ b/tests/compiler/constructor.release.wat
@@ -698,7 +698,7 @@
   if
    i32.const 0
    i32.const 1392
-   i32.const 382
+   i32.const 385
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -723,7 +723,7 @@
    if
     i32.const 0
     i32.const 1392
-    i32.const 389
+    i32.const 392
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -750,7 +750,7 @@
    if
     i32.const 0
     i32.const 1392
-    i32.const 402
+    i32.const 405
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1113,7 +1113,7 @@
       if
        i32.const 0
        i32.const 1392
-       i32.const 562
+       i32.const 555
        i32.const 3
        call $~lib/builtins/abort
        unreachable
@@ -1348,7 +1348,7 @@
   if
    i32.const 1056
    i32.const 1392
-   i32.const 461
+   i32.const 460
    i32.const 29
    call $~lib/builtins/abort
    unreachable
@@ -1450,7 +1450,7 @@
    if
     i32.const 0
     i32.const 1392
-    i32.const 499
+    i32.const 492
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1465,7 +1465,7 @@
   if
    i32.const 0
    i32.const 1392
-   i32.const 501
+   i32.const 494
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/constructor.release.wat
+++ b/tests/compiler/constructor.release.wat
@@ -691,11 +691,16 @@
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
+  local.get $2
   local.get $1
   i64.extend_i32_u
-  local.get $2
-  i64.gt_u
+  i64.lt_u
   if
+   i32.const 0
+   i32.const 1392
+   i32.const 386
+   i32.const 14
+   call $~lib/builtins/abort
    unreachable
   end
   local.get $1
@@ -718,7 +723,7 @@
    if
     i32.const 0
     i32.const 1392
-    i32.const 392
+    i32.const 393
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -745,7 +750,7 @@
    if
     i32.const 0
     i32.const 1392
-    i32.const 405
+    i32.const 406
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1108,7 +1113,7 @@
       if
        i32.const 0
        i32.const 1392
-       i32.const 555
+       i32.const 556
        i32.const 3
        call $~lib/builtins/abort
        unreachable
@@ -1343,7 +1348,7 @@
   if
    i32.const 1056
    i32.const 1392
-   i32.const 460
+   i32.const 461
    i32.const 29
    call $~lib/builtins/abort
    unreachable
@@ -1445,7 +1450,7 @@
    if
     i32.const 0
     i32.const 1392
-    i32.const 492
+    i32.const 493
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1460,7 +1465,7 @@
   if
    i32.const 0
    i32.const 1392
-   i32.const 494
+   i32.const 495
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/constructor.release.wat
+++ b/tests/compiler/constructor.release.wat
@@ -691,16 +691,11 @@
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
-  local.get $2
   local.get $1
   i64.extend_i32_u
-  i64.lt_u
+  local.get $2
+  i64.gt_u
   if
-   i32.const 0
-   i32.const 1392
-   i32.const 385
-   i32.const 14
-   call $~lib/builtins/abort
    unreachable
   end
   local.get $1

--- a/tests/compiler/do.debug.wat
+++ b/tests/compiler/do.debug.wat
@@ -1432,19 +1432,11 @@
   local.set $end
   i32.const 0
   drop
-  i32.const 1
-  drop
   local.get $start
   i64.extend_i32_u
   local.get $endU64
-  i64.le_u
-  i32.eqz
+  i64.gt_u
   if
-   i32.const 0
-   i32.const 400
-   i32.const 385
-   i32.const 14
-   call $~lib/builtins/abort
    unreachable
   end
   local.get $start

--- a/tests/compiler/do.debug.wat
+++ b/tests/compiler/do.debug.wat
@@ -1432,11 +1432,19 @@
   local.set $end
   i32.const 0
   drop
+  i32.const 1
+  drop
   local.get $start
   i64.extend_i32_u
   local.get $endU64
-  i64.gt_u
+  i64.le_u
+  i32.eqz
   if
+   i32.const 0
+   i32.const 400
+   i32.const 386
+   i32.const 14
+   call $~lib/builtins/abort
    unreachable
   end
   local.get $start
@@ -1480,7 +1488,7 @@
    if
     i32.const 0
     i32.const 400
-    i32.const 392
+    i32.const 393
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1512,7 +1520,7 @@
    if
     i32.const 0
     i32.const 400
-    i32.const 405
+    i32.const 406
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1754,7 +1762,7 @@
   if
    i32.const 0
    i32.const 400
-   i32.const 555
+   i32.const 556
    i32.const 3
    call $~lib/builtins/abort
    unreachable
@@ -2083,7 +2091,7 @@
   if
    i32.const 64
    i32.const 400
-   i32.const 460
+   i32.const 461
    i32.const 29
    call $~lib/builtins/abort
    unreachable
@@ -2526,7 +2534,7 @@
    if
     i32.const 0
     i32.const 400
-    i32.const 492
+    i32.const 493
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -2546,7 +2554,7 @@
   if
    i32.const 0
    i32.const 400
-   i32.const 494
+   i32.const 495
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/do.debug.wat
+++ b/tests/compiler/do.debug.wat
@@ -1430,6 +1430,8 @@
   local.get $endU64
   i32.wrap_i64
   local.set $end
+  i32.const 0
+  drop
   i32.const 1
   drop
   local.get $start
@@ -1440,7 +1442,7 @@
   if
    i32.const 0
    i32.const 400
-   i32.const 382
+   i32.const 385
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1486,7 +1488,7 @@
    if
     i32.const 0
     i32.const 400
-    i32.const 389
+    i32.const 392
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1518,7 +1520,7 @@
    if
     i32.const 0
     i32.const 400
-    i32.const 402
+    i32.const 405
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1719,8 +1721,6 @@
   i32.const 1572
   i32.add
   local.set $memStart
-  i32.const 0
-  drop
   local.get $root
   local.get $memStart
   memory.size
@@ -1762,7 +1762,7 @@
   if
    i32.const 0
    i32.const 400
-   i32.const 562
+   i32.const 555
    i32.const 3
    call $~lib/builtins/abort
    unreachable
@@ -2091,7 +2091,7 @@
   if
    i32.const 64
    i32.const 400
-   i32.const 461
+   i32.const 460
    i32.const 29
    call $~lib/builtins/abort
    unreachable
@@ -2325,8 +2325,6 @@
   (local $6 i32)
   (local $pagesWanted i32)
   (local $pagesAfter i32)
-  i32.const 0
-  drop
   local.get $size
   i32.const 256
   i32.ge_u
@@ -2536,7 +2534,7 @@
    if
     i32.const 0
     i32.const 400
-    i32.const 499
+    i32.const 492
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -2556,7 +2554,7 @@
   if
    i32.const 0
    i32.const 400
-   i32.const 501
+   i32.const 494
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/do.release.wat
+++ b/tests/compiler/do.release.wat
@@ -627,11 +627,16 @@
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
+  local.get $2
   local.get $1
   i64.extend_i32_u
-  local.get $2
-  i64.gt_u
+  i64.lt_u
   if
+   i32.const 0
+   i32.const 1424
+   i32.const 386
+   i32.const 14
+   call $~lib/builtins/abort
    unreachable
   end
   local.get $1
@@ -654,7 +659,7 @@
    if
     i32.const 0
     i32.const 1424
-    i32.const 392
+    i32.const 393
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -681,7 +686,7 @@
    if
     i32.const 0
     i32.const 1424
-    i32.const 405
+    i32.const 406
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1044,7 +1049,7 @@
       if
        i32.const 0
        i32.const 1424
-       i32.const 555
+       i32.const 556
        i32.const 3
        call $~lib/builtins/abort
        unreachable
@@ -1242,7 +1247,7 @@
    if
     i32.const 0
     i32.const 1424
-    i32.const 492
+    i32.const 493
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1257,7 +1262,7 @@
   if
    i32.const 0
    i32.const 1424
-   i32.const 494
+   i32.const 495
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/do.release.wat
+++ b/tests/compiler/do.release.wat
@@ -634,7 +634,7 @@
   if
    i32.const 0
    i32.const 1424
-   i32.const 382
+   i32.const 385
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -659,7 +659,7 @@
    if
     i32.const 0
     i32.const 1424
-    i32.const 389
+    i32.const 392
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -686,7 +686,7 @@
    if
     i32.const 0
     i32.const 1424
-    i32.const 402
+    i32.const 405
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1049,7 +1049,7 @@
       if
        i32.const 0
        i32.const 1424
-       i32.const 562
+       i32.const 555
        i32.const 3
        call $~lib/builtins/abort
        unreachable
@@ -1247,7 +1247,7 @@
    if
     i32.const 0
     i32.const 1424
-    i32.const 499
+    i32.const 492
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1262,7 +1262,7 @@
   if
    i32.const 0
    i32.const 1424
-   i32.const 501
+   i32.const 494
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/do.release.wat
+++ b/tests/compiler/do.release.wat
@@ -627,16 +627,11 @@
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
-  local.get $2
   local.get $1
   i64.extend_i32_u
-  i64.lt_u
+  local.get $2
+  i64.gt_u
   if
-   i32.const 0
-   i32.const 1424
-   i32.const 385
-   i32.const 14
-   call $~lib/builtins/abort
    unreachable
   end
   local.get $1

--- a/tests/compiler/duplicate-fields.debug.wat
+++ b/tests/compiler/duplicate-fields.debug.wat
@@ -1032,19 +1032,11 @@
   local.set $end
   i32.const 0
   drop
-  i32.const 1
-  drop
   local.get $start
   i64.extend_i32_u
   local.get $endU64
-  i64.le_u
-  i32.eqz
+  i64.gt_u
   if
-   i32.const 0
-   i32.const 368
-   i32.const 385
-   i32.const 14
-   call $~lib/builtins/abort
    unreachable
   end
   local.get $start

--- a/tests/compiler/duplicate-fields.debug.wat
+++ b/tests/compiler/duplicate-fields.debug.wat
@@ -1030,6 +1030,8 @@
   local.get $endU64
   i32.wrap_i64
   local.set $end
+  i32.const 0
+  drop
   i32.const 1
   drop
   local.get $start
@@ -1040,7 +1042,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 382
+   i32.const 385
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1086,7 +1088,7 @@
    if
     i32.const 0
     i32.const 368
-    i32.const 389
+    i32.const 392
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1118,7 +1120,7 @@
    if
     i32.const 0
     i32.const 368
-    i32.const 402
+    i32.const 405
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1319,8 +1321,6 @@
   i32.const 1572
   i32.add
   local.set $memStart
-  i32.const 0
-  drop
   local.get $root
   local.get $memStart
   memory.size
@@ -1362,7 +1362,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 562
+   i32.const 555
    i32.const 3
    call $~lib/builtins/abort
    unreachable
@@ -1691,7 +1691,7 @@
   if
    i32.const 32
    i32.const 368
-   i32.const 461
+   i32.const 460
    i32.const 29
    call $~lib/builtins/abort
    unreachable
@@ -1925,8 +1925,6 @@
   (local $6 i32)
   (local $pagesWanted i32)
   (local $pagesAfter i32)
-  i32.const 0
-  drop
   local.get $size
   i32.const 256
   i32.ge_u
@@ -2136,7 +2134,7 @@
    if
     i32.const 0
     i32.const 368
-    i32.const 499
+    i32.const 492
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -2156,7 +2154,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 501
+   i32.const 494
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/duplicate-fields.debug.wat
+++ b/tests/compiler/duplicate-fields.debug.wat
@@ -1032,11 +1032,19 @@
   local.set $end
   i32.const 0
   drop
+  i32.const 1
+  drop
   local.get $start
   i64.extend_i32_u
   local.get $endU64
-  i64.gt_u
+  i64.le_u
+  i32.eqz
   if
+   i32.const 0
+   i32.const 368
+   i32.const 386
+   i32.const 14
+   call $~lib/builtins/abort
    unreachable
   end
   local.get $start
@@ -1080,7 +1088,7 @@
    if
     i32.const 0
     i32.const 368
-    i32.const 392
+    i32.const 393
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1112,7 +1120,7 @@
    if
     i32.const 0
     i32.const 368
-    i32.const 405
+    i32.const 406
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1354,7 +1362,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 555
+   i32.const 556
    i32.const 3
    call $~lib/builtins/abort
    unreachable
@@ -1683,7 +1691,7 @@
   if
    i32.const 32
    i32.const 368
-   i32.const 460
+   i32.const 461
    i32.const 29
    call $~lib/builtins/abort
    unreachable
@@ -2126,7 +2134,7 @@
    if
     i32.const 0
     i32.const 368
-    i32.const 492
+    i32.const 493
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -2146,7 +2154,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 494
+   i32.const 495
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/duplicate-fields.release.wat
+++ b/tests/compiler/duplicate-fields.release.wat
@@ -652,7 +652,7 @@
   if
    i32.const 0
    i32.const 1392
-   i32.const 382
+   i32.const 385
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -677,7 +677,7 @@
    if
     i32.const 0
     i32.const 1392
-    i32.const 389
+    i32.const 392
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -704,7 +704,7 @@
    if
     i32.const 0
     i32.const 1392
-    i32.const 402
+    i32.const 405
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1067,7 +1067,7 @@
       if
        i32.const 0
        i32.const 1392
-       i32.const 562
+       i32.const 555
        i32.const 3
        call $~lib/builtins/abort
        unreachable
@@ -1302,7 +1302,7 @@
   if
    i32.const 1056
    i32.const 1392
-   i32.const 461
+   i32.const 460
    i32.const 29
    call $~lib/builtins/abort
    unreachable
@@ -1404,7 +1404,7 @@
    if
     i32.const 0
     i32.const 1392
-    i32.const 499
+    i32.const 492
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1419,7 +1419,7 @@
   if
    i32.const 0
    i32.const 1392
-   i32.const 501
+   i32.const 494
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/duplicate-fields.release.wat
+++ b/tests/compiler/duplicate-fields.release.wat
@@ -645,16 +645,11 @@
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
-  local.get $2
   local.get $1
   i64.extend_i32_u
-  i64.lt_u
+  local.get $2
+  i64.gt_u
   if
-   i32.const 0
-   i32.const 1392
-   i32.const 385
-   i32.const 14
-   call $~lib/builtins/abort
    unreachable
   end
   local.get $1

--- a/tests/compiler/duplicate-fields.release.wat
+++ b/tests/compiler/duplicate-fields.release.wat
@@ -645,11 +645,16 @@
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
+  local.get $2
   local.get $1
   i64.extend_i32_u
-  local.get $2
-  i64.gt_u
+  i64.lt_u
   if
+   i32.const 0
+   i32.const 1392
+   i32.const 386
+   i32.const 14
+   call $~lib/builtins/abort
    unreachable
   end
   local.get $1
@@ -672,7 +677,7 @@
    if
     i32.const 0
     i32.const 1392
-    i32.const 392
+    i32.const 393
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -699,7 +704,7 @@
    if
     i32.const 0
     i32.const 1392
-    i32.const 405
+    i32.const 406
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1062,7 +1067,7 @@
       if
        i32.const 0
        i32.const 1392
-       i32.const 555
+       i32.const 556
        i32.const 3
        call $~lib/builtins/abort
        unreachable
@@ -1297,7 +1302,7 @@
   if
    i32.const 1056
    i32.const 1392
-   i32.const 460
+   i32.const 461
    i32.const 29
    call $~lib/builtins/abort
    unreachable
@@ -1399,7 +1404,7 @@
    if
     i32.const 0
     i32.const 1392
-    i32.const 492
+    i32.const 493
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1414,7 +1419,7 @@
   if
    i32.const 0
    i32.const 1392
-   i32.const 494
+   i32.const 495
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/empty-exportruntime.debug.wat
+++ b/tests/compiler/empty-exportruntime.debug.wat
@@ -1031,11 +1031,19 @@
   local.set $end
   i32.const 0
   drop
+  i32.const 1
+  drop
   local.get $start
   i64.extend_i32_u
   local.get $endU64
-  i64.gt_u
+  i64.le_u
+  i32.eqz
   if
+   i32.const 0
+   i32.const 368
+   i32.const 386
+   i32.const 14
+   call $~lib/builtins/abort
    unreachable
   end
   local.get $start
@@ -1079,7 +1087,7 @@
    if
     i32.const 0
     i32.const 368
-    i32.const 392
+    i32.const 393
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1111,7 +1119,7 @@
    if
     i32.const 0
     i32.const 368
-    i32.const 405
+    i32.const 406
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1353,7 +1361,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 555
+   i32.const 556
    i32.const 3
    call $~lib/builtins/abort
    unreachable
@@ -1682,7 +1690,7 @@
   if
    i32.const 32
    i32.const 368
-   i32.const 460
+   i32.const 461
    i32.const 29
    call $~lib/builtins/abort
    unreachable
@@ -2125,7 +2133,7 @@
    if
     i32.const 0
     i32.const 368
-    i32.const 492
+    i32.const 493
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -2145,7 +2153,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 494
+   i32.const 495
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/empty-exportruntime.debug.wat
+++ b/tests/compiler/empty-exportruntime.debug.wat
@@ -1031,19 +1031,11 @@
   local.set $end
   i32.const 0
   drop
-  i32.const 1
-  drop
   local.get $start
   i64.extend_i32_u
   local.get $endU64
-  i64.le_u
-  i32.eqz
+  i64.gt_u
   if
-   i32.const 0
-   i32.const 368
-   i32.const 385
-   i32.const 14
-   call $~lib/builtins/abort
    unreachable
   end
   local.get $start

--- a/tests/compiler/empty-exportruntime.debug.wat
+++ b/tests/compiler/empty-exportruntime.debug.wat
@@ -1029,6 +1029,8 @@
   local.get $endU64
   i32.wrap_i64
   local.set $end
+  i32.const 0
+  drop
   i32.const 1
   drop
   local.get $start
@@ -1039,7 +1041,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 382
+   i32.const 385
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1085,7 +1087,7 @@
    if
     i32.const 0
     i32.const 368
-    i32.const 389
+    i32.const 392
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1117,7 +1119,7 @@
    if
     i32.const 0
     i32.const 368
-    i32.const 402
+    i32.const 405
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1318,8 +1320,6 @@
   i32.const 1572
   i32.add
   local.set $memStart
-  i32.const 0
-  drop
   local.get $root
   local.get $memStart
   memory.size
@@ -1361,7 +1361,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 562
+   i32.const 555
    i32.const 3
    call $~lib/builtins/abort
    unreachable
@@ -1690,7 +1690,7 @@
   if
    i32.const 32
    i32.const 368
-   i32.const 461
+   i32.const 460
    i32.const 29
    call $~lib/builtins/abort
    unreachable
@@ -1924,8 +1924,6 @@
   (local $6 i32)
   (local $pagesWanted i32)
   (local $pagesAfter i32)
-  i32.const 0
-  drop
   local.get $size
   i32.const 256
   i32.ge_u
@@ -2135,7 +2133,7 @@
    if
     i32.const 0
     i32.const 368
-    i32.const 499
+    i32.const 492
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -2155,7 +2153,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 501
+   i32.const 494
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/empty-exportruntime.release.wat
+++ b/tests/compiler/empty-exportruntime.release.wat
@@ -646,16 +646,11 @@
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
-  local.get $2
   local.get $1
   i64.extend_i32_u
-  i64.lt_u
+  local.get $2
+  i64.gt_u
   if
-   i32.const 0
-   i32.const 1392
-   i32.const 385
-   i32.const 14
-   call $~lib/builtins/abort
    unreachable
   end
   local.get $1

--- a/tests/compiler/empty-exportruntime.release.wat
+++ b/tests/compiler/empty-exportruntime.release.wat
@@ -646,11 +646,16 @@
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
+  local.get $2
   local.get $1
   i64.extend_i32_u
-  local.get $2
-  i64.gt_u
+  i64.lt_u
   if
+   i32.const 0
+   i32.const 1392
+   i32.const 386
+   i32.const 14
+   call $~lib/builtins/abort
    unreachable
   end
   local.get $1
@@ -673,7 +678,7 @@
    if
     i32.const 0
     i32.const 1392
-    i32.const 392
+    i32.const 393
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -700,7 +705,7 @@
    if
     i32.const 0
     i32.const 1392
-    i32.const 405
+    i32.const 406
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1063,7 +1068,7 @@
       if
        i32.const 0
        i32.const 1392
-       i32.const 555
+       i32.const 556
        i32.const 3
        call $~lib/builtins/abort
        unreachable
@@ -1298,7 +1303,7 @@
   if
    i32.const 1056
    i32.const 1392
-   i32.const 460
+   i32.const 461
    i32.const 29
    call $~lib/builtins/abort
    unreachable
@@ -1400,7 +1405,7 @@
    if
     i32.const 0
     i32.const 1392
-    i32.const 492
+    i32.const 493
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1415,7 +1420,7 @@
   if
    i32.const 0
    i32.const 1392
-   i32.const 494
+   i32.const 495
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/empty-exportruntime.release.wat
+++ b/tests/compiler/empty-exportruntime.release.wat
@@ -653,7 +653,7 @@
   if
    i32.const 0
    i32.const 1392
-   i32.const 382
+   i32.const 385
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -678,7 +678,7 @@
    if
     i32.const 0
     i32.const 1392
-    i32.const 389
+    i32.const 392
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -705,7 +705,7 @@
    if
     i32.const 0
     i32.const 1392
-    i32.const 402
+    i32.const 405
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1068,7 +1068,7 @@
       if
        i32.const 0
        i32.const 1392
-       i32.const 562
+       i32.const 555
        i32.const 3
        call $~lib/builtins/abort
        unreachable
@@ -1303,7 +1303,7 @@
   if
    i32.const 1056
    i32.const 1392
-   i32.const 461
+   i32.const 460
    i32.const 29
    call $~lib/builtins/abort
    unreachable
@@ -1405,7 +1405,7 @@
    if
     i32.const 0
     i32.const 1392
-    i32.const 499
+    i32.const 492
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1420,7 +1420,7 @@
   if
    i32.const 0
    i32.const 1392
-   i32.const 501
+   i32.const 494
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/empty-new.debug.wat
+++ b/tests/compiler/empty-new.debug.wat
@@ -1024,19 +1024,11 @@
   local.set $end
   i32.const 0
   drop
-  i32.const 1
-  drop
   local.get $start
   i64.extend_i32_u
   local.get $endU64
-  i64.le_u
-  i32.eqz
+  i64.gt_u
   if
-   i32.const 0
-   i32.const 368
-   i32.const 385
-   i32.const 14
-   call $~lib/builtins/abort
    unreachable
   end
   local.get $start

--- a/tests/compiler/empty-new.debug.wat
+++ b/tests/compiler/empty-new.debug.wat
@@ -1024,11 +1024,19 @@
   local.set $end
   i32.const 0
   drop
+  i32.const 1
+  drop
   local.get $start
   i64.extend_i32_u
   local.get $endU64
-  i64.gt_u
+  i64.le_u
+  i32.eqz
   if
+   i32.const 0
+   i32.const 368
+   i32.const 386
+   i32.const 14
+   call $~lib/builtins/abort
    unreachable
   end
   local.get $start
@@ -1072,7 +1080,7 @@
    if
     i32.const 0
     i32.const 368
-    i32.const 392
+    i32.const 393
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1104,7 +1112,7 @@
    if
     i32.const 0
     i32.const 368
-    i32.const 405
+    i32.const 406
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1346,7 +1354,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 555
+   i32.const 556
    i32.const 3
    call $~lib/builtins/abort
    unreachable
@@ -1675,7 +1683,7 @@
   if
    i32.const 32
    i32.const 368
-   i32.const 460
+   i32.const 461
    i32.const 29
    call $~lib/builtins/abort
    unreachable
@@ -2118,7 +2126,7 @@
    if
     i32.const 0
     i32.const 368
-    i32.const 492
+    i32.const 493
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -2138,7 +2146,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 494
+   i32.const 495
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/empty-new.debug.wat
+++ b/tests/compiler/empty-new.debug.wat
@@ -1022,6 +1022,8 @@
   local.get $endU64
   i32.wrap_i64
   local.set $end
+  i32.const 0
+  drop
   i32.const 1
   drop
   local.get $start
@@ -1032,7 +1034,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 382
+   i32.const 385
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1078,7 +1080,7 @@
    if
     i32.const 0
     i32.const 368
-    i32.const 389
+    i32.const 392
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1110,7 +1112,7 @@
    if
     i32.const 0
     i32.const 368
-    i32.const 402
+    i32.const 405
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1311,8 +1313,6 @@
   i32.const 1572
   i32.add
   local.set $memStart
-  i32.const 0
-  drop
   local.get $root
   local.get $memStart
   memory.size
@@ -1354,7 +1354,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 562
+   i32.const 555
    i32.const 3
    call $~lib/builtins/abort
    unreachable
@@ -1683,7 +1683,7 @@
   if
    i32.const 32
    i32.const 368
-   i32.const 461
+   i32.const 460
    i32.const 29
    call $~lib/builtins/abort
    unreachable
@@ -1917,8 +1917,6 @@
   (local $6 i32)
   (local $pagesWanted i32)
   (local $pagesAfter i32)
-  i32.const 0
-  drop
   local.get $size
   i32.const 256
   i32.ge_u
@@ -2128,7 +2126,7 @@
    if
     i32.const 0
     i32.const 368
-    i32.const 499
+    i32.const 492
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -2148,7 +2146,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 501
+   i32.const 494
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/empty-new.release.wat
+++ b/tests/compiler/empty-new.release.wat
@@ -624,11 +624,16 @@
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
+  local.get $2
   local.get $1
   i64.extend_i32_u
-  local.get $2
-  i64.gt_u
+  i64.lt_u
   if
+   i32.const 0
+   i32.const 1392
+   i32.const 386
+   i32.const 14
+   call $~lib/builtins/abort
    unreachable
   end
   local.get $1
@@ -651,7 +656,7 @@
    if
     i32.const 0
     i32.const 1392
-    i32.const 392
+    i32.const 393
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -678,7 +683,7 @@
    if
     i32.const 0
     i32.const 1392
-    i32.const 405
+    i32.const 406
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1041,7 +1046,7 @@
       if
        i32.const 0
        i32.const 1392
-       i32.const 555
+       i32.const 556
        i32.const 3
        call $~lib/builtins/abort
        unreachable
@@ -1239,7 +1244,7 @@
    if
     i32.const 0
     i32.const 1392
-    i32.const 492
+    i32.const 493
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1254,7 +1259,7 @@
   if
    i32.const 0
    i32.const 1392
-   i32.const 494
+   i32.const 495
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/empty-new.release.wat
+++ b/tests/compiler/empty-new.release.wat
@@ -631,7 +631,7 @@
   if
    i32.const 0
    i32.const 1392
-   i32.const 382
+   i32.const 385
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -656,7 +656,7 @@
    if
     i32.const 0
     i32.const 1392
-    i32.const 389
+    i32.const 392
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -683,7 +683,7 @@
    if
     i32.const 0
     i32.const 1392
-    i32.const 402
+    i32.const 405
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1046,7 +1046,7 @@
       if
        i32.const 0
        i32.const 1392
-       i32.const 562
+       i32.const 555
        i32.const 3
        call $~lib/builtins/abort
        unreachable
@@ -1244,7 +1244,7 @@
    if
     i32.const 0
     i32.const 1392
-    i32.const 499
+    i32.const 492
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1259,7 +1259,7 @@
   if
    i32.const 0
    i32.const 1392
-   i32.const 501
+   i32.const 494
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/empty-new.release.wat
+++ b/tests/compiler/empty-new.release.wat
@@ -624,16 +624,11 @@
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
-  local.get $2
   local.get $1
   i64.extend_i32_u
-  i64.lt_u
+  local.get $2
+  i64.gt_u
   if
-   i32.const 0
-   i32.const 1392
-   i32.const 385
-   i32.const 14
-   call $~lib/builtins/abort
    unreachable
   end
   local.get $1

--- a/tests/compiler/exportstar-rereexport.debug.wat
+++ b/tests/compiler/exportstar-rereexport.debug.wat
@@ -1062,6 +1062,8 @@
   local.get $endU64
   i32.wrap_i64
   local.set $end
+  i32.const 0
+  drop
   i32.const 1
   drop
   local.get $start
@@ -1072,7 +1074,7 @@
   if
    i32.const 0
    i32.const 416
-   i32.const 382
+   i32.const 385
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1118,7 +1120,7 @@
    if
     i32.const 0
     i32.const 416
-    i32.const 389
+    i32.const 392
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1150,7 +1152,7 @@
    if
     i32.const 0
     i32.const 416
-    i32.const 402
+    i32.const 405
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1351,8 +1353,6 @@
   i32.const 1572
   i32.add
   local.set $memStart
-  i32.const 0
-  drop
   local.get $root
   local.get $memStart
   memory.size
@@ -1394,7 +1394,7 @@
   if
    i32.const 0
    i32.const 416
-   i32.const 562
+   i32.const 555
    i32.const 3
    call $~lib/builtins/abort
    unreachable
@@ -1723,7 +1723,7 @@
   if
    i32.const 80
    i32.const 416
-   i32.const 461
+   i32.const 460
    i32.const 29
    call $~lib/builtins/abort
    unreachable
@@ -1957,8 +1957,6 @@
   (local $6 i32)
   (local $pagesWanted i32)
   (local $pagesAfter i32)
-  i32.const 0
-  drop
   local.get $size
   i32.const 256
   i32.ge_u
@@ -2168,7 +2166,7 @@
    if
     i32.const 0
     i32.const 416
-    i32.const 499
+    i32.const 492
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -2188,7 +2186,7 @@
   if
    i32.const 0
    i32.const 416
-   i32.const 501
+   i32.const 494
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/exportstar-rereexport.debug.wat
+++ b/tests/compiler/exportstar-rereexport.debug.wat
@@ -1064,19 +1064,11 @@
   local.set $end
   i32.const 0
   drop
-  i32.const 1
-  drop
   local.get $start
   i64.extend_i32_u
   local.get $endU64
-  i64.le_u
-  i32.eqz
+  i64.gt_u
   if
-   i32.const 0
-   i32.const 416
-   i32.const 385
-   i32.const 14
-   call $~lib/builtins/abort
    unreachable
   end
   local.get $start

--- a/tests/compiler/exportstar-rereexport.debug.wat
+++ b/tests/compiler/exportstar-rereexport.debug.wat
@@ -1064,11 +1064,19 @@
   local.set $end
   i32.const 0
   drop
+  i32.const 1
+  drop
   local.get $start
   i64.extend_i32_u
   local.get $endU64
-  i64.gt_u
+  i64.le_u
+  i32.eqz
   if
+   i32.const 0
+   i32.const 416
+   i32.const 386
+   i32.const 14
+   call $~lib/builtins/abort
    unreachable
   end
   local.get $start
@@ -1112,7 +1120,7 @@
    if
     i32.const 0
     i32.const 416
-    i32.const 392
+    i32.const 393
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1144,7 +1152,7 @@
    if
     i32.const 0
     i32.const 416
-    i32.const 405
+    i32.const 406
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1386,7 +1394,7 @@
   if
    i32.const 0
    i32.const 416
-   i32.const 555
+   i32.const 556
    i32.const 3
    call $~lib/builtins/abort
    unreachable
@@ -1715,7 +1723,7 @@
   if
    i32.const 80
    i32.const 416
-   i32.const 460
+   i32.const 461
    i32.const 29
    call $~lib/builtins/abort
    unreachable
@@ -2158,7 +2166,7 @@
    if
     i32.const 0
     i32.const 416
-    i32.const 492
+    i32.const 493
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -2178,7 +2186,7 @@
   if
    i32.const 0
    i32.const 416
-   i32.const 494
+   i32.const 495
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/exportstar-rereexport.release.wat
+++ b/tests/compiler/exportstar-rereexport.release.wat
@@ -658,11 +658,16 @@
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
+  local.get $2
   local.get $1
   i64.extend_i32_u
-  local.get $2
-  i64.gt_u
+  i64.lt_u
   if
+   i32.const 0
+   i32.const 1440
+   i32.const 386
+   i32.const 14
+   call $~lib/builtins/abort
    unreachable
   end
   local.get $1
@@ -685,7 +690,7 @@
    if
     i32.const 0
     i32.const 1440
-    i32.const 392
+    i32.const 393
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -712,7 +717,7 @@
    if
     i32.const 0
     i32.const 1440
-    i32.const 405
+    i32.const 406
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1075,7 +1080,7 @@
       if
        i32.const 0
        i32.const 1440
-       i32.const 555
+       i32.const 556
        i32.const 3
        call $~lib/builtins/abort
        unreachable
@@ -1273,7 +1278,7 @@
    if
     i32.const 0
     i32.const 1440
-    i32.const 492
+    i32.const 493
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1288,7 +1293,7 @@
   if
    i32.const 0
    i32.const 1440
-   i32.const 494
+   i32.const 495
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/exportstar-rereexport.release.wat
+++ b/tests/compiler/exportstar-rereexport.release.wat
@@ -665,7 +665,7 @@
   if
    i32.const 0
    i32.const 1440
-   i32.const 382
+   i32.const 385
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -690,7 +690,7 @@
    if
     i32.const 0
     i32.const 1440
-    i32.const 389
+    i32.const 392
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -717,7 +717,7 @@
    if
     i32.const 0
     i32.const 1440
-    i32.const 402
+    i32.const 405
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1080,7 +1080,7 @@
       if
        i32.const 0
        i32.const 1440
-       i32.const 562
+       i32.const 555
        i32.const 3
        call $~lib/builtins/abort
        unreachable
@@ -1278,7 +1278,7 @@
    if
     i32.const 0
     i32.const 1440
-    i32.const 499
+    i32.const 492
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1293,7 +1293,7 @@
   if
    i32.const 0
    i32.const 1440
-   i32.const 501
+   i32.const 494
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/exportstar-rereexport.release.wat
+++ b/tests/compiler/exportstar-rereexport.release.wat
@@ -658,16 +658,11 @@
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
-  local.get $2
   local.get $1
   i64.extend_i32_u
-  i64.lt_u
+  local.get $2
+  i64.gt_u
   if
-   i32.const 0
-   i32.const 1440
-   i32.const 385
-   i32.const 14
-   call $~lib/builtins/abort
    unreachable
   end
   local.get $1

--- a/tests/compiler/extends-baseaggregate.debug.wat
+++ b/tests/compiler/extends-baseaggregate.debug.wat
@@ -1032,6 +1032,8 @@
   local.get $endU64
   i32.wrap_i64
   local.set $end
+  i32.const 0
+  drop
   i32.const 1
   drop
   local.get $start
@@ -1042,7 +1044,7 @@
   if
    i32.const 0
    i32.const 528
-   i32.const 382
+   i32.const 385
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1088,7 +1090,7 @@
    if
     i32.const 0
     i32.const 528
-    i32.const 389
+    i32.const 392
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1120,7 +1122,7 @@
    if
     i32.const 0
     i32.const 528
-    i32.const 402
+    i32.const 405
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1321,8 +1323,6 @@
   i32.const 1572
   i32.add
   local.set $memStart
-  i32.const 0
-  drop
   local.get $root
   local.get $memStart
   memory.size
@@ -1364,7 +1364,7 @@
   if
    i32.const 0
    i32.const 528
-   i32.const 562
+   i32.const 555
    i32.const 3
    call $~lib/builtins/abort
    unreachable
@@ -1693,7 +1693,7 @@
   if
    i32.const 192
    i32.const 528
-   i32.const 461
+   i32.const 460
    i32.const 29
    call $~lib/builtins/abort
    unreachable
@@ -1927,8 +1927,6 @@
   (local $6 i32)
   (local $pagesWanted i32)
   (local $pagesAfter i32)
-  i32.const 0
-  drop
   local.get $size
   i32.const 256
   i32.ge_u
@@ -2138,7 +2136,7 @@
    if
     i32.const 0
     i32.const 528
-    i32.const 499
+    i32.const 492
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -2158,7 +2156,7 @@
   if
    i32.const 0
    i32.const 528
-   i32.const 501
+   i32.const 494
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/extends-baseaggregate.debug.wat
+++ b/tests/compiler/extends-baseaggregate.debug.wat
@@ -1034,11 +1034,19 @@
   local.set $end
   i32.const 0
   drop
+  i32.const 1
+  drop
   local.get $start
   i64.extend_i32_u
   local.get $endU64
-  i64.gt_u
+  i64.le_u
+  i32.eqz
   if
+   i32.const 0
+   i32.const 528
+   i32.const 386
+   i32.const 14
+   call $~lib/builtins/abort
    unreachable
   end
   local.get $start
@@ -1082,7 +1090,7 @@
    if
     i32.const 0
     i32.const 528
-    i32.const 392
+    i32.const 393
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1114,7 +1122,7 @@
    if
     i32.const 0
     i32.const 528
-    i32.const 405
+    i32.const 406
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1356,7 +1364,7 @@
   if
    i32.const 0
    i32.const 528
-   i32.const 555
+   i32.const 556
    i32.const 3
    call $~lib/builtins/abort
    unreachable
@@ -1685,7 +1693,7 @@
   if
    i32.const 192
    i32.const 528
-   i32.const 460
+   i32.const 461
    i32.const 29
    call $~lib/builtins/abort
    unreachable
@@ -2128,7 +2136,7 @@
    if
     i32.const 0
     i32.const 528
-    i32.const 492
+    i32.const 493
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -2148,7 +2156,7 @@
   if
    i32.const 0
    i32.const 528
-   i32.const 494
+   i32.const 495
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/extends-baseaggregate.debug.wat
+++ b/tests/compiler/extends-baseaggregate.debug.wat
@@ -1034,19 +1034,11 @@
   local.set $end
   i32.const 0
   drop
-  i32.const 1
-  drop
   local.get $start
   i64.extend_i32_u
   local.get $endU64
-  i64.le_u
-  i32.eqz
+  i64.gt_u
   if
-   i32.const 0
-   i32.const 528
-   i32.const 385
-   i32.const 14
-   call $~lib/builtins/abort
    unreachable
   end
   local.get $start

--- a/tests/compiler/extends-baseaggregate.release.wat
+++ b/tests/compiler/extends-baseaggregate.release.wat
@@ -656,7 +656,7 @@
   if
    i32.const 0
    i32.const 1552
-   i32.const 382
+   i32.const 385
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -681,7 +681,7 @@
    if
     i32.const 0
     i32.const 1552
-    i32.const 389
+    i32.const 392
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -708,7 +708,7 @@
    if
     i32.const 0
     i32.const 1552
-    i32.const 402
+    i32.const 405
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1071,7 +1071,7 @@
       if
        i32.const 0
        i32.const 1552
-       i32.const 562
+       i32.const 555
        i32.const 3
        call $~lib/builtins/abort
        unreachable
@@ -1306,7 +1306,7 @@
   if
    i32.const 1216
    i32.const 1552
-   i32.const 461
+   i32.const 460
    i32.const 29
    call $~lib/builtins/abort
    unreachable
@@ -1408,7 +1408,7 @@
    if
     i32.const 0
     i32.const 1552
-    i32.const 499
+    i32.const 492
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1423,7 +1423,7 @@
   if
    i32.const 0
    i32.const 1552
-   i32.const 501
+   i32.const 494
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/extends-baseaggregate.release.wat
+++ b/tests/compiler/extends-baseaggregate.release.wat
@@ -649,16 +649,11 @@
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
-  local.get $2
   local.get $1
   i64.extend_i32_u
-  i64.lt_u
+  local.get $2
+  i64.gt_u
   if
-   i32.const 0
-   i32.const 1552
-   i32.const 385
-   i32.const 14
-   call $~lib/builtins/abort
    unreachable
   end
   local.get $1

--- a/tests/compiler/extends-baseaggregate.release.wat
+++ b/tests/compiler/extends-baseaggregate.release.wat
@@ -649,11 +649,16 @@
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
+  local.get $2
   local.get $1
   i64.extend_i32_u
-  local.get $2
-  i64.gt_u
+  i64.lt_u
   if
+   i32.const 0
+   i32.const 1552
+   i32.const 386
+   i32.const 14
+   call $~lib/builtins/abort
    unreachable
   end
   local.get $1
@@ -676,7 +681,7 @@
    if
     i32.const 0
     i32.const 1552
-    i32.const 392
+    i32.const 393
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -703,7 +708,7 @@
    if
     i32.const 0
     i32.const 1552
-    i32.const 405
+    i32.const 406
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1066,7 +1071,7 @@
       if
        i32.const 0
        i32.const 1552
-       i32.const 555
+       i32.const 556
        i32.const 3
        call $~lib/builtins/abort
        unreachable
@@ -1301,7 +1306,7 @@
   if
    i32.const 1216
    i32.const 1552
-   i32.const 460
+   i32.const 461
    i32.const 29
    call $~lib/builtins/abort
    unreachable
@@ -1403,7 +1408,7 @@
    if
     i32.const 0
     i32.const 1552
-    i32.const 492
+    i32.const 493
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1418,7 +1423,7 @@
   if
    i32.const 0
    i32.const 1552
-   i32.const 494
+   i32.const 495
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/extends-recursive.debug.wat
+++ b/tests/compiler/extends-recursive.debug.wat
@@ -1024,19 +1024,11 @@
   local.set $end
   i32.const 0
   drop
-  i32.const 1
-  drop
   local.get $start
   i64.extend_i32_u
   local.get $endU64
-  i64.le_u
-  i32.eqz
+  i64.gt_u
   if
-   i32.const 0
-   i32.const 368
-   i32.const 385
-   i32.const 14
-   call $~lib/builtins/abort
    unreachable
   end
   local.get $start

--- a/tests/compiler/extends-recursive.debug.wat
+++ b/tests/compiler/extends-recursive.debug.wat
@@ -1024,11 +1024,19 @@
   local.set $end
   i32.const 0
   drop
+  i32.const 1
+  drop
   local.get $start
   i64.extend_i32_u
   local.get $endU64
-  i64.gt_u
+  i64.le_u
+  i32.eqz
   if
+   i32.const 0
+   i32.const 368
+   i32.const 386
+   i32.const 14
+   call $~lib/builtins/abort
    unreachable
   end
   local.get $start
@@ -1072,7 +1080,7 @@
    if
     i32.const 0
     i32.const 368
-    i32.const 392
+    i32.const 393
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1104,7 +1112,7 @@
    if
     i32.const 0
     i32.const 368
-    i32.const 405
+    i32.const 406
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1346,7 +1354,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 555
+   i32.const 556
    i32.const 3
    call $~lib/builtins/abort
    unreachable
@@ -1675,7 +1683,7 @@
   if
    i32.const 32
    i32.const 368
-   i32.const 460
+   i32.const 461
    i32.const 29
    call $~lib/builtins/abort
    unreachable
@@ -2118,7 +2126,7 @@
    if
     i32.const 0
     i32.const 368
-    i32.const 492
+    i32.const 493
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -2138,7 +2146,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 494
+   i32.const 495
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/extends-recursive.debug.wat
+++ b/tests/compiler/extends-recursive.debug.wat
@@ -1022,6 +1022,8 @@
   local.get $endU64
   i32.wrap_i64
   local.set $end
+  i32.const 0
+  drop
   i32.const 1
   drop
   local.get $start
@@ -1032,7 +1034,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 382
+   i32.const 385
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1078,7 +1080,7 @@
    if
     i32.const 0
     i32.const 368
-    i32.const 389
+    i32.const 392
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1110,7 +1112,7 @@
    if
     i32.const 0
     i32.const 368
-    i32.const 402
+    i32.const 405
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1311,8 +1313,6 @@
   i32.const 1572
   i32.add
   local.set $memStart
-  i32.const 0
-  drop
   local.get $root
   local.get $memStart
   memory.size
@@ -1354,7 +1354,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 562
+   i32.const 555
    i32.const 3
    call $~lib/builtins/abort
    unreachable
@@ -1683,7 +1683,7 @@
   if
    i32.const 32
    i32.const 368
-   i32.const 461
+   i32.const 460
    i32.const 29
    call $~lib/builtins/abort
    unreachable
@@ -1917,8 +1917,6 @@
   (local $6 i32)
   (local $pagesWanted i32)
   (local $pagesAfter i32)
-  i32.const 0
-  drop
   local.get $size
   i32.const 256
   i32.ge_u
@@ -2128,7 +2126,7 @@
    if
     i32.const 0
     i32.const 368
-    i32.const 499
+    i32.const 492
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -2148,7 +2146,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 501
+   i32.const 494
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/extends-recursive.release.wat
+++ b/tests/compiler/extends-recursive.release.wat
@@ -625,16 +625,11 @@
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
-  local.get $2
   local.get $1
   i64.extend_i32_u
-  i64.lt_u
+  local.get $2
+  i64.gt_u
   if
-   i32.const 0
-   i32.const 1392
-   i32.const 385
-   i32.const 14
-   call $~lib/builtins/abort
    unreachable
   end
   local.get $1

--- a/tests/compiler/extends-recursive.release.wat
+++ b/tests/compiler/extends-recursive.release.wat
@@ -625,11 +625,16 @@
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
+  local.get $2
   local.get $1
   i64.extend_i32_u
-  local.get $2
-  i64.gt_u
+  i64.lt_u
   if
+   i32.const 0
+   i32.const 1392
+   i32.const 386
+   i32.const 14
+   call $~lib/builtins/abort
    unreachable
   end
   local.get $1
@@ -652,7 +657,7 @@
    if
     i32.const 0
     i32.const 1392
-    i32.const 392
+    i32.const 393
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -679,7 +684,7 @@
    if
     i32.const 0
     i32.const 1392
-    i32.const 405
+    i32.const 406
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1042,7 +1047,7 @@
       if
        i32.const 0
        i32.const 1392
-       i32.const 555
+       i32.const 556
        i32.const 3
        call $~lib/builtins/abort
        unreachable
@@ -1277,7 +1282,7 @@
   if
    i32.const 1056
    i32.const 1392
-   i32.const 460
+   i32.const 461
    i32.const 29
    call $~lib/builtins/abort
    unreachable
@@ -1379,7 +1384,7 @@
    if
     i32.const 0
     i32.const 1392
-    i32.const 492
+    i32.const 493
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1394,7 +1399,7 @@
   if
    i32.const 0
    i32.const 1392
-   i32.const 494
+   i32.const 495
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/extends-recursive.release.wat
+++ b/tests/compiler/extends-recursive.release.wat
@@ -632,7 +632,7 @@
   if
    i32.const 0
    i32.const 1392
-   i32.const 382
+   i32.const 385
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -657,7 +657,7 @@
    if
     i32.const 0
     i32.const 1392
-    i32.const 389
+    i32.const 392
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -684,7 +684,7 @@
    if
     i32.const 0
     i32.const 1392
-    i32.const 402
+    i32.const 405
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1047,7 +1047,7 @@
       if
        i32.const 0
        i32.const 1392
-       i32.const 562
+       i32.const 555
        i32.const 3
        call $~lib/builtins/abort
        unreachable
@@ -1282,7 +1282,7 @@
   if
    i32.const 1056
    i32.const 1392
-   i32.const 461
+   i32.const 460
    i32.const 29
    call $~lib/builtins/abort
    unreachable
@@ -1384,7 +1384,7 @@
    if
     i32.const 0
     i32.const 1392
-    i32.const 499
+    i32.const 492
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1399,7 +1399,7 @@
   if
    i32.const 0
    i32.const 1392
-   i32.const 501
+   i32.const 494
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/field-initialization.debug.wat
+++ b/tests/compiler/field-initialization.debug.wat
@@ -1033,6 +1033,8 @@
   local.get $endU64
   i32.wrap_i64
   local.set $end
+  i32.const 0
+  drop
   i32.const 1
   drop
   local.get $start
@@ -1043,7 +1045,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 382
+   i32.const 385
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1089,7 +1091,7 @@
    if
     i32.const 0
     i32.const 368
-    i32.const 389
+    i32.const 392
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1121,7 +1123,7 @@
    if
     i32.const 0
     i32.const 368
-    i32.const 402
+    i32.const 405
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1322,8 +1324,6 @@
   i32.const 1572
   i32.add
   local.set $memStart
-  i32.const 0
-  drop
   local.get $root
   local.get $memStart
   memory.size
@@ -1365,7 +1365,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 562
+   i32.const 555
    i32.const 3
    call $~lib/builtins/abort
    unreachable
@@ -1694,7 +1694,7 @@
   if
    i32.const 32
    i32.const 368
-   i32.const 461
+   i32.const 460
    i32.const 29
    call $~lib/builtins/abort
    unreachable
@@ -1928,8 +1928,6 @@
   (local $6 i32)
   (local $pagesWanted i32)
   (local $pagesAfter i32)
-  i32.const 0
-  drop
   local.get $size
   i32.const 256
   i32.ge_u
@@ -2139,7 +2137,7 @@
    if
     i32.const 0
     i32.const 368
-    i32.const 499
+    i32.const 492
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -2159,7 +2157,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 501
+   i32.const 494
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/field-initialization.debug.wat
+++ b/tests/compiler/field-initialization.debug.wat
@@ -1035,11 +1035,19 @@
   local.set $end
   i32.const 0
   drop
+  i32.const 1
+  drop
   local.get $start
   i64.extend_i32_u
   local.get $endU64
-  i64.gt_u
+  i64.le_u
+  i32.eqz
   if
+   i32.const 0
+   i32.const 368
+   i32.const 386
+   i32.const 14
+   call $~lib/builtins/abort
    unreachable
   end
   local.get $start
@@ -1083,7 +1091,7 @@
    if
     i32.const 0
     i32.const 368
-    i32.const 392
+    i32.const 393
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1115,7 +1123,7 @@
    if
     i32.const 0
     i32.const 368
-    i32.const 405
+    i32.const 406
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1357,7 +1365,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 555
+   i32.const 556
    i32.const 3
    call $~lib/builtins/abort
    unreachable
@@ -1686,7 +1694,7 @@
   if
    i32.const 32
    i32.const 368
-   i32.const 460
+   i32.const 461
    i32.const 29
    call $~lib/builtins/abort
    unreachable
@@ -2129,7 +2137,7 @@
    if
     i32.const 0
     i32.const 368
-    i32.const 492
+    i32.const 493
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -2149,7 +2157,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 494
+   i32.const 495
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/field-initialization.debug.wat
+++ b/tests/compiler/field-initialization.debug.wat
@@ -1035,19 +1035,11 @@
   local.set $end
   i32.const 0
   drop
-  i32.const 1
-  drop
   local.get $start
   i64.extend_i32_u
   local.get $endU64
-  i64.le_u
-  i32.eqz
+  i64.gt_u
   if
-   i32.const 0
-   i32.const 368
-   i32.const 385
-   i32.const 14
-   call $~lib/builtins/abort
    unreachable
   end
   local.get $start

--- a/tests/compiler/field-initialization.release.wat
+++ b/tests/compiler/field-initialization.release.wat
@@ -649,16 +649,11 @@
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
-  local.get $2
   local.get $1
   i64.extend_i32_u
-  i64.lt_u
+  local.get $2
+  i64.gt_u
   if
-   i32.const 0
-   i32.const 1392
-   i32.const 385
-   i32.const 14
-   call $~lib/builtins/abort
    unreachable
   end
   local.get $1

--- a/tests/compiler/field-initialization.release.wat
+++ b/tests/compiler/field-initialization.release.wat
@@ -656,7 +656,7 @@
   if
    i32.const 0
    i32.const 1392
-   i32.const 382
+   i32.const 385
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -681,7 +681,7 @@
    if
     i32.const 0
     i32.const 1392
-    i32.const 389
+    i32.const 392
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -708,7 +708,7 @@
    if
     i32.const 0
     i32.const 1392
-    i32.const 402
+    i32.const 405
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1071,7 +1071,7 @@
       if
        i32.const 0
        i32.const 1392
-       i32.const 562
+       i32.const 555
        i32.const 3
        call $~lib/builtins/abort
        unreachable
@@ -1306,7 +1306,7 @@
   if
    i32.const 1056
    i32.const 1392
-   i32.const 461
+   i32.const 460
    i32.const 29
    call $~lib/builtins/abort
    unreachable
@@ -1408,7 +1408,7 @@
    if
     i32.const 0
     i32.const 1392
-    i32.const 499
+    i32.const 492
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1423,7 +1423,7 @@
   if
    i32.const 0
    i32.const 1392
-   i32.const 501
+   i32.const 494
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/field-initialization.release.wat
+++ b/tests/compiler/field-initialization.release.wat
@@ -649,11 +649,16 @@
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
+  local.get $2
   local.get $1
   i64.extend_i32_u
-  local.get $2
-  i64.gt_u
+  i64.lt_u
   if
+   i32.const 0
+   i32.const 1392
+   i32.const 386
+   i32.const 14
+   call $~lib/builtins/abort
    unreachable
   end
   local.get $1
@@ -676,7 +681,7 @@
    if
     i32.const 0
     i32.const 1392
-    i32.const 392
+    i32.const 393
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -703,7 +708,7 @@
    if
     i32.const 0
     i32.const 1392
-    i32.const 405
+    i32.const 406
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1066,7 +1071,7 @@
       if
        i32.const 0
        i32.const 1392
-       i32.const 555
+       i32.const 556
        i32.const 3
        call $~lib/builtins/abort
        unreachable
@@ -1301,7 +1306,7 @@
   if
    i32.const 1056
    i32.const 1392
-   i32.const 460
+   i32.const 461
    i32.const 29
    call $~lib/builtins/abort
    unreachable
@@ -1403,7 +1408,7 @@
    if
     i32.const 0
     i32.const 1392
-    i32.const 492
+    i32.const 493
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1418,7 +1423,7 @@
   if
    i32.const 0
    i32.const 1392
-   i32.const 494
+   i32.const 495
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/field.debug.wat
+++ b/tests/compiler/field.debug.wat
@@ -1027,19 +1027,11 @@
   local.set $end
   i32.const 0
   drop
-  i32.const 1
-  drop
   local.get $start
   i64.extend_i32_u
   local.get $endU64
-  i64.le_u
-  i32.eqz
+  i64.gt_u
   if
-   i32.const 0
-   i32.const 368
-   i32.const 385
-   i32.const 14
-   call $~lib/builtins/abort
    unreachable
   end
   local.get $start

--- a/tests/compiler/field.debug.wat
+++ b/tests/compiler/field.debug.wat
@@ -1027,11 +1027,19 @@
   local.set $end
   i32.const 0
   drop
+  i32.const 1
+  drop
   local.get $start
   i64.extend_i32_u
   local.get $endU64
-  i64.gt_u
+  i64.le_u
+  i32.eqz
   if
+   i32.const 0
+   i32.const 368
+   i32.const 386
+   i32.const 14
+   call $~lib/builtins/abort
    unreachable
   end
   local.get $start
@@ -1075,7 +1083,7 @@
    if
     i32.const 0
     i32.const 368
-    i32.const 392
+    i32.const 393
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1107,7 +1115,7 @@
    if
     i32.const 0
     i32.const 368
-    i32.const 405
+    i32.const 406
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1349,7 +1357,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 555
+   i32.const 556
    i32.const 3
    call $~lib/builtins/abort
    unreachable
@@ -1678,7 +1686,7 @@
   if
    i32.const 32
    i32.const 368
-   i32.const 460
+   i32.const 461
    i32.const 29
    call $~lib/builtins/abort
    unreachable
@@ -2121,7 +2129,7 @@
    if
     i32.const 0
     i32.const 368
-    i32.const 492
+    i32.const 493
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -2141,7 +2149,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 494
+   i32.const 495
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/field.debug.wat
+++ b/tests/compiler/field.debug.wat
@@ -1025,6 +1025,8 @@
   local.get $endU64
   i32.wrap_i64
   local.set $end
+  i32.const 0
+  drop
   i32.const 1
   drop
   local.get $start
@@ -1035,7 +1037,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 382
+   i32.const 385
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1081,7 +1083,7 @@
    if
     i32.const 0
     i32.const 368
-    i32.const 389
+    i32.const 392
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1113,7 +1115,7 @@
    if
     i32.const 0
     i32.const 368
-    i32.const 402
+    i32.const 405
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1314,8 +1316,6 @@
   i32.const 1572
   i32.add
   local.set $memStart
-  i32.const 0
-  drop
   local.get $root
   local.get $memStart
   memory.size
@@ -1357,7 +1357,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 562
+   i32.const 555
    i32.const 3
    call $~lib/builtins/abort
    unreachable
@@ -1686,7 +1686,7 @@
   if
    i32.const 32
    i32.const 368
-   i32.const 461
+   i32.const 460
    i32.const 29
    call $~lib/builtins/abort
    unreachable
@@ -1920,8 +1920,6 @@
   (local $6 i32)
   (local $pagesWanted i32)
   (local $pagesAfter i32)
-  i32.const 0
-  drop
   local.get $size
   i32.const 256
   i32.ge_u
@@ -2131,7 +2129,7 @@
    if
     i32.const 0
     i32.const 368
-    i32.const 499
+    i32.const 492
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -2151,7 +2149,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 501
+   i32.const 494
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/field.release.wat
+++ b/tests/compiler/field.release.wat
@@ -632,16 +632,11 @@
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
-  local.get $2
   local.get $1
   i64.extend_i32_u
-  i64.lt_u
+  local.get $2
+  i64.gt_u
   if
-   i32.const 0
-   i32.const 1392
-   i32.const 385
-   i32.const 14
-   call $~lib/builtins/abort
    unreachable
   end
   local.get $1

--- a/tests/compiler/field.release.wat
+++ b/tests/compiler/field.release.wat
@@ -639,7 +639,7 @@
   if
    i32.const 0
    i32.const 1392
-   i32.const 382
+   i32.const 385
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -664,7 +664,7 @@
    if
     i32.const 0
     i32.const 1392
-    i32.const 389
+    i32.const 392
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -691,7 +691,7 @@
    if
     i32.const 0
     i32.const 1392
-    i32.const 402
+    i32.const 405
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1054,7 +1054,7 @@
       if
        i32.const 0
        i32.const 1392
-       i32.const 562
+       i32.const 555
        i32.const 3
        call $~lib/builtins/abort
        unreachable
@@ -1289,7 +1289,7 @@
   if
    i32.const 1056
    i32.const 1392
-   i32.const 461
+   i32.const 460
    i32.const 29
    call $~lib/builtins/abort
    unreachable
@@ -1391,7 +1391,7 @@
    if
     i32.const 0
     i32.const 1392
-    i32.const 499
+    i32.const 492
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1406,7 +1406,7 @@
   if
    i32.const 0
    i32.const 1392
-   i32.const 501
+   i32.const 494
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/field.release.wat
+++ b/tests/compiler/field.release.wat
@@ -632,11 +632,16 @@
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
+  local.get $2
   local.get $1
   i64.extend_i32_u
-  local.get $2
-  i64.gt_u
+  i64.lt_u
   if
+   i32.const 0
+   i32.const 1392
+   i32.const 386
+   i32.const 14
+   call $~lib/builtins/abort
    unreachable
   end
   local.get $1
@@ -659,7 +664,7 @@
    if
     i32.const 0
     i32.const 1392
-    i32.const 392
+    i32.const 393
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -686,7 +691,7 @@
    if
     i32.const 0
     i32.const 1392
-    i32.const 405
+    i32.const 406
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1049,7 +1054,7 @@
       if
        i32.const 0
        i32.const 1392
-       i32.const 555
+       i32.const 556
        i32.const 3
        call $~lib/builtins/abort
        unreachable
@@ -1284,7 +1289,7 @@
   if
    i32.const 1056
    i32.const 1392
-   i32.const 460
+   i32.const 461
    i32.const 29
    call $~lib/builtins/abort
    unreachable
@@ -1386,7 +1391,7 @@
    if
     i32.const 0
     i32.const 1392
-    i32.const 492
+    i32.const 493
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1401,7 +1406,7 @@
   if
    i32.const 0
    i32.const 1392
-   i32.const 494
+   i32.const 495
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/for.debug.wat
+++ b/tests/compiler/for.debug.wat
@@ -1413,11 +1413,19 @@
   local.set $end
   i32.const 0
   drop
+  i32.const 1
+  drop
   local.get $start
   i64.extend_i32_u
   local.get $endU64
-  i64.gt_u
+  i64.le_u
+  i32.eqz
   if
+   i32.const 0
+   i32.const 400
+   i32.const 386
+   i32.const 14
+   call $~lib/builtins/abort
    unreachable
   end
   local.get $start
@@ -1461,7 +1469,7 @@
    if
     i32.const 0
     i32.const 400
-    i32.const 392
+    i32.const 393
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1493,7 +1501,7 @@
    if
     i32.const 0
     i32.const 400
-    i32.const 405
+    i32.const 406
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1735,7 +1743,7 @@
   if
    i32.const 0
    i32.const 400
-   i32.const 555
+   i32.const 556
    i32.const 3
    call $~lib/builtins/abort
    unreachable
@@ -2064,7 +2072,7 @@
   if
    i32.const 64
    i32.const 400
-   i32.const 460
+   i32.const 461
    i32.const 29
    call $~lib/builtins/abort
    unreachable
@@ -2507,7 +2515,7 @@
    if
     i32.const 0
     i32.const 400
-    i32.const 492
+    i32.const 493
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -2527,7 +2535,7 @@
   if
    i32.const 0
    i32.const 400
-   i32.const 494
+   i32.const 495
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/for.debug.wat
+++ b/tests/compiler/for.debug.wat
@@ -1411,6 +1411,8 @@
   local.get $endU64
   i32.wrap_i64
   local.set $end
+  i32.const 0
+  drop
   i32.const 1
   drop
   local.get $start
@@ -1421,7 +1423,7 @@
   if
    i32.const 0
    i32.const 400
-   i32.const 382
+   i32.const 385
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1467,7 +1469,7 @@
    if
     i32.const 0
     i32.const 400
-    i32.const 389
+    i32.const 392
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1499,7 +1501,7 @@
    if
     i32.const 0
     i32.const 400
-    i32.const 402
+    i32.const 405
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1700,8 +1702,6 @@
   i32.const 1572
   i32.add
   local.set $memStart
-  i32.const 0
-  drop
   local.get $root
   local.get $memStart
   memory.size
@@ -1743,7 +1743,7 @@
   if
    i32.const 0
    i32.const 400
-   i32.const 562
+   i32.const 555
    i32.const 3
    call $~lib/builtins/abort
    unreachable
@@ -2072,7 +2072,7 @@
   if
    i32.const 64
    i32.const 400
-   i32.const 461
+   i32.const 460
    i32.const 29
    call $~lib/builtins/abort
    unreachable
@@ -2306,8 +2306,6 @@
   (local $6 i32)
   (local $pagesWanted i32)
   (local $pagesAfter i32)
-  i32.const 0
-  drop
   local.get $size
   i32.const 256
   i32.ge_u
@@ -2517,7 +2515,7 @@
    if
     i32.const 0
     i32.const 400
-    i32.const 499
+    i32.const 492
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -2537,7 +2535,7 @@
   if
    i32.const 0
    i32.const 400
-   i32.const 501
+   i32.const 494
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/for.debug.wat
+++ b/tests/compiler/for.debug.wat
@@ -1413,19 +1413,11 @@
   local.set $end
   i32.const 0
   drop
-  i32.const 1
-  drop
   local.get $start
   i64.extend_i32_u
   local.get $endU64
-  i64.le_u
-  i32.eqz
+  i64.gt_u
   if
-   i32.const 0
-   i32.const 400
-   i32.const 385
-   i32.const 14
-   call $~lib/builtins/abort
    unreachable
   end
   local.get $start

--- a/tests/compiler/for.release.wat
+++ b/tests/compiler/for.release.wat
@@ -627,11 +627,16 @@
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
+  local.get $2
   local.get $1
   i64.extend_i32_u
-  local.get $2
-  i64.gt_u
+  i64.lt_u
   if
+   i32.const 0
+   i32.const 1424
+   i32.const 386
+   i32.const 14
+   call $~lib/builtins/abort
    unreachable
   end
   local.get $1
@@ -654,7 +659,7 @@
    if
     i32.const 0
     i32.const 1424
-    i32.const 392
+    i32.const 393
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -681,7 +686,7 @@
    if
     i32.const 0
     i32.const 1424
-    i32.const 405
+    i32.const 406
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1044,7 +1049,7 @@
       if
        i32.const 0
        i32.const 1424
-       i32.const 555
+       i32.const 556
        i32.const 3
        call $~lib/builtins/abort
        unreachable
@@ -1242,7 +1247,7 @@
    if
     i32.const 0
     i32.const 1424
-    i32.const 492
+    i32.const 493
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1257,7 +1262,7 @@
   if
    i32.const 0
    i32.const 1424
-   i32.const 494
+   i32.const 495
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/for.release.wat
+++ b/tests/compiler/for.release.wat
@@ -634,7 +634,7 @@
   if
    i32.const 0
    i32.const 1424
-   i32.const 382
+   i32.const 385
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -659,7 +659,7 @@
    if
     i32.const 0
     i32.const 1424
-    i32.const 389
+    i32.const 392
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -686,7 +686,7 @@
    if
     i32.const 0
     i32.const 1424
-    i32.const 402
+    i32.const 405
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1049,7 +1049,7 @@
       if
        i32.const 0
        i32.const 1424
-       i32.const 562
+       i32.const 555
        i32.const 3
        call $~lib/builtins/abort
        unreachable
@@ -1247,7 +1247,7 @@
    if
     i32.const 0
     i32.const 1424
-    i32.const 499
+    i32.const 492
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1262,7 +1262,7 @@
   if
    i32.const 0
    i32.const 1424
-   i32.const 501
+   i32.const 494
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/for.release.wat
+++ b/tests/compiler/for.release.wat
@@ -627,16 +627,11 @@
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
-  local.get $2
   local.get $1
   i64.extend_i32_u
-  i64.lt_u
+  local.get $2
+  i64.gt_u
   if
-   i32.const 0
-   i32.const 1424
-   i32.const 385
-   i32.const 14
-   call $~lib/builtins/abort
    unreachable
   end
   local.get $1

--- a/tests/compiler/function-call.debug.wat
+++ b/tests/compiler/function-call.debug.wat
@@ -1059,6 +1059,8 @@
   local.get $endU64
   i32.wrap_i64
   local.set $end
+  i32.const 0
+  drop
   i32.const 1
   drop
   local.get $start
@@ -1069,7 +1071,7 @@
   if
    i32.const 0
    i32.const 592
-   i32.const 382
+   i32.const 385
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1115,7 +1117,7 @@
    if
     i32.const 0
     i32.const 592
-    i32.const 389
+    i32.const 392
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1147,7 +1149,7 @@
    if
     i32.const 0
     i32.const 592
-    i32.const 402
+    i32.const 405
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1348,8 +1350,6 @@
   i32.const 1572
   i32.add
   local.set $memStart
-  i32.const 0
-  drop
   local.get $root
   local.get $memStart
   memory.size
@@ -1391,7 +1391,7 @@
   if
    i32.const 0
    i32.const 592
-   i32.const 562
+   i32.const 555
    i32.const 3
    call $~lib/builtins/abort
    unreachable
@@ -1720,7 +1720,7 @@
   if
    i32.const 256
    i32.const 592
-   i32.const 461
+   i32.const 460
    i32.const 29
    call $~lib/builtins/abort
    unreachable
@@ -1954,8 +1954,6 @@
   (local $6 i32)
   (local $pagesWanted i32)
   (local $pagesAfter i32)
-  i32.const 0
-  drop
   local.get $size
   i32.const 256
   i32.ge_u
@@ -2165,7 +2163,7 @@
    if
     i32.const 0
     i32.const 592
-    i32.const 499
+    i32.const 492
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -2185,7 +2183,7 @@
   if
    i32.const 0
    i32.const 592
-   i32.const 501
+   i32.const 494
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/function-call.debug.wat
+++ b/tests/compiler/function-call.debug.wat
@@ -1061,11 +1061,19 @@
   local.set $end
   i32.const 0
   drop
+  i32.const 1
+  drop
   local.get $start
   i64.extend_i32_u
   local.get $endU64
-  i64.gt_u
+  i64.le_u
+  i32.eqz
   if
+   i32.const 0
+   i32.const 592
+   i32.const 386
+   i32.const 14
+   call $~lib/builtins/abort
    unreachable
   end
   local.get $start
@@ -1109,7 +1117,7 @@
    if
     i32.const 0
     i32.const 592
-    i32.const 392
+    i32.const 393
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1141,7 +1149,7 @@
    if
     i32.const 0
     i32.const 592
-    i32.const 405
+    i32.const 406
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1383,7 +1391,7 @@
   if
    i32.const 0
    i32.const 592
-   i32.const 555
+   i32.const 556
    i32.const 3
    call $~lib/builtins/abort
    unreachable
@@ -1712,7 +1720,7 @@
   if
    i32.const 256
    i32.const 592
-   i32.const 460
+   i32.const 461
    i32.const 29
    call $~lib/builtins/abort
    unreachable
@@ -2155,7 +2163,7 @@
    if
     i32.const 0
     i32.const 592
-    i32.const 492
+    i32.const 493
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -2175,7 +2183,7 @@
   if
    i32.const 0
    i32.const 592
-   i32.const 494
+   i32.const 495
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/function-call.debug.wat
+++ b/tests/compiler/function-call.debug.wat
@@ -1061,19 +1061,11 @@
   local.set $end
   i32.const 0
   drop
-  i32.const 1
-  drop
   local.get $start
   i64.extend_i32_u
   local.get $endU64
-  i64.le_u
-  i32.eqz
+  i64.gt_u
   if
-   i32.const 0
-   i32.const 592
-   i32.const 385
-   i32.const 14
-   call $~lib/builtins/abort
    unreachable
   end
   local.get $start

--- a/tests/compiler/function-call.release.wat
+++ b/tests/compiler/function-call.release.wat
@@ -665,11 +665,16 @@
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
+  local.get $2
   local.get $1
   i64.extend_i32_u
-  local.get $2
-  i64.gt_u
+  i64.lt_u
   if
+   i32.const 0
+   i32.const 1616
+   i32.const 386
+   i32.const 14
+   call $~lib/builtins/abort
    unreachable
   end
   local.get $1
@@ -692,7 +697,7 @@
    if
     i32.const 0
     i32.const 1616
-    i32.const 392
+    i32.const 393
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -719,7 +724,7 @@
    if
     i32.const 0
     i32.const 1616
-    i32.const 405
+    i32.const 406
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1082,7 +1087,7 @@
       if
        i32.const 0
        i32.const 1616
-       i32.const 555
+       i32.const 556
        i32.const 3
        call $~lib/builtins/abort
        unreachable
@@ -1280,7 +1285,7 @@
    if
     i32.const 0
     i32.const 1616
-    i32.const 492
+    i32.const 493
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1295,7 +1300,7 @@
   if
    i32.const 0
    i32.const 1616
-   i32.const 494
+   i32.const 495
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/function-call.release.wat
+++ b/tests/compiler/function-call.release.wat
@@ -665,16 +665,11 @@
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
-  local.get $2
   local.get $1
   i64.extend_i32_u
-  i64.lt_u
+  local.get $2
+  i64.gt_u
   if
-   i32.const 0
-   i32.const 1616
-   i32.const 385
-   i32.const 14
-   call $~lib/builtins/abort
    unreachable
   end
   local.get $1

--- a/tests/compiler/function-call.release.wat
+++ b/tests/compiler/function-call.release.wat
@@ -672,7 +672,7 @@
   if
    i32.const 0
    i32.const 1616
-   i32.const 382
+   i32.const 385
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -697,7 +697,7 @@
    if
     i32.const 0
     i32.const 1616
-    i32.const 389
+    i32.const 392
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -724,7 +724,7 @@
    if
     i32.const 0
     i32.const 1616
-    i32.const 402
+    i32.const 405
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1087,7 +1087,7 @@
       if
        i32.const 0
        i32.const 1616
-       i32.const 562
+       i32.const 555
        i32.const 3
        call $~lib/builtins/abort
        unreachable
@@ -1285,7 +1285,7 @@
    if
     i32.const 0
     i32.const 1616
-    i32.const 499
+    i32.const 492
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1300,7 +1300,7 @@
   if
    i32.const 0
    i32.const 1616
-   i32.const 501
+   i32.const 494
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/function-expression.debug.wat
+++ b/tests/compiler/function-expression.debug.wat
@@ -1219,11 +1219,19 @@
   local.set $end
   i32.const 0
   drop
+  i32.const 1
+  drop
   local.get $start
   i64.extend_i32_u
   local.get $endU64
-  i64.gt_u
+  i64.le_u
+  i32.eqz
   if
+   i32.const 0
+   i32.const 912
+   i32.const 386
+   i32.const 14
+   call $~lib/builtins/abort
    unreachable
   end
   local.get $start
@@ -1267,7 +1275,7 @@
    if
     i32.const 0
     i32.const 912
-    i32.const 392
+    i32.const 393
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1299,7 +1307,7 @@
    if
     i32.const 0
     i32.const 912
-    i32.const 405
+    i32.const 406
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1541,7 +1549,7 @@
   if
    i32.const 0
    i32.const 912
-   i32.const 555
+   i32.const 556
    i32.const 3
    call $~lib/builtins/abort
    unreachable
@@ -1870,7 +1878,7 @@
   if
    i32.const 576
    i32.const 912
-   i32.const 460
+   i32.const 461
    i32.const 29
    call $~lib/builtins/abort
    unreachable
@@ -2313,7 +2321,7 @@
    if
     i32.const 0
     i32.const 912
-    i32.const 492
+    i32.const 493
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -2333,7 +2341,7 @@
   if
    i32.const 0
    i32.const 912
-   i32.const 494
+   i32.const 495
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/function-expression.debug.wat
+++ b/tests/compiler/function-expression.debug.wat
@@ -1217,6 +1217,8 @@
   local.get $endU64
   i32.wrap_i64
   local.set $end
+  i32.const 0
+  drop
   i32.const 1
   drop
   local.get $start
@@ -1227,7 +1229,7 @@
   if
    i32.const 0
    i32.const 912
-   i32.const 382
+   i32.const 385
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1273,7 +1275,7 @@
    if
     i32.const 0
     i32.const 912
-    i32.const 389
+    i32.const 392
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1305,7 +1307,7 @@
    if
     i32.const 0
     i32.const 912
-    i32.const 402
+    i32.const 405
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1506,8 +1508,6 @@
   i32.const 1572
   i32.add
   local.set $memStart
-  i32.const 0
-  drop
   local.get $root
   local.get $memStart
   memory.size
@@ -1549,7 +1549,7 @@
   if
    i32.const 0
    i32.const 912
-   i32.const 562
+   i32.const 555
    i32.const 3
    call $~lib/builtins/abort
    unreachable
@@ -1878,7 +1878,7 @@
   if
    i32.const 576
    i32.const 912
-   i32.const 461
+   i32.const 460
    i32.const 29
    call $~lib/builtins/abort
    unreachable
@@ -2112,8 +2112,6 @@
   (local $6 i32)
   (local $pagesWanted i32)
   (local $pagesAfter i32)
-  i32.const 0
-  drop
   local.get $size
   i32.const 256
   i32.ge_u
@@ -2323,7 +2321,7 @@
    if
     i32.const 0
     i32.const 912
-    i32.const 499
+    i32.const 492
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -2343,7 +2341,7 @@
   if
    i32.const 0
    i32.const 912
-   i32.const 501
+   i32.const 494
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/function-expression.debug.wat
+++ b/tests/compiler/function-expression.debug.wat
@@ -1219,19 +1219,11 @@
   local.set $end
   i32.const 0
   drop
-  i32.const 1
-  drop
   local.get $start
   i64.extend_i32_u
   local.get $endU64
-  i64.le_u
-  i32.eqz
+  i64.gt_u
   if
-   i32.const 0
-   i32.const 912
-   i32.const 385
-   i32.const 14
-   call $~lib/builtins/abort
    unreachable
   end
   local.get $start

--- a/tests/compiler/function-expression.release.wat
+++ b/tests/compiler/function-expression.release.wat
@@ -702,7 +702,7 @@
   if
    i32.const 0
    i32.const 1936
-   i32.const 382
+   i32.const 385
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -727,7 +727,7 @@
    if
     i32.const 0
     i32.const 1936
-    i32.const 389
+    i32.const 392
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -754,7 +754,7 @@
    if
     i32.const 0
     i32.const 1936
-    i32.const 402
+    i32.const 405
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1117,7 +1117,7 @@
       if
        i32.const 0
        i32.const 1936
-       i32.const 562
+       i32.const 555
        i32.const 3
        call $~lib/builtins/abort
        unreachable
@@ -1315,7 +1315,7 @@
    if
     i32.const 0
     i32.const 1936
-    i32.const 499
+    i32.const 492
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1330,7 +1330,7 @@
   if
    i32.const 0
    i32.const 1936
-   i32.const 501
+   i32.const 494
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/function-expression.release.wat
+++ b/tests/compiler/function-expression.release.wat
@@ -695,11 +695,16 @@
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
+  local.get $2
   local.get $1
   i64.extend_i32_u
-  local.get $2
-  i64.gt_u
+  i64.lt_u
   if
+   i32.const 0
+   i32.const 1936
+   i32.const 386
+   i32.const 14
+   call $~lib/builtins/abort
    unreachable
   end
   local.get $1
@@ -722,7 +727,7 @@
    if
     i32.const 0
     i32.const 1936
-    i32.const 392
+    i32.const 393
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -749,7 +754,7 @@
    if
     i32.const 0
     i32.const 1936
-    i32.const 405
+    i32.const 406
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1112,7 +1117,7 @@
       if
        i32.const 0
        i32.const 1936
-       i32.const 555
+       i32.const 556
        i32.const 3
        call $~lib/builtins/abort
        unreachable
@@ -1310,7 +1315,7 @@
    if
     i32.const 0
     i32.const 1936
-    i32.const 492
+    i32.const 493
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1325,7 +1330,7 @@
   if
    i32.const 0
    i32.const 1936
-   i32.const 494
+   i32.const 495
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/function-expression.release.wat
+++ b/tests/compiler/function-expression.release.wat
@@ -695,16 +695,11 @@
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
-  local.get $2
   local.get $1
   i64.extend_i32_u
-  i64.lt_u
+  local.get $2
+  i64.gt_u
   if
-   i32.const 0
-   i32.const 1936
-   i32.const 385
-   i32.const 14
-   call $~lib/builtins/abort
    unreachable
   end
   local.get $1

--- a/tests/compiler/getter-call.debug.wat
+++ b/tests/compiler/getter-call.debug.wat
@@ -1027,19 +1027,11 @@
   local.set $end
   i32.const 0
   drop
-  i32.const 1
-  drop
   local.get $start
   i64.extend_i32_u
   local.get $endU64
-  i64.le_u
-  i32.eqz
+  i64.gt_u
   if
-   i32.const 0
-   i32.const 368
-   i32.const 385
-   i32.const 14
-   call $~lib/builtins/abort
    unreachable
   end
   local.get $start

--- a/tests/compiler/getter-call.debug.wat
+++ b/tests/compiler/getter-call.debug.wat
@@ -1027,11 +1027,19 @@
   local.set $end
   i32.const 0
   drop
+  i32.const 1
+  drop
   local.get $start
   i64.extend_i32_u
   local.get $endU64
-  i64.gt_u
+  i64.le_u
+  i32.eqz
   if
+   i32.const 0
+   i32.const 368
+   i32.const 386
+   i32.const 14
+   call $~lib/builtins/abort
    unreachable
   end
   local.get $start
@@ -1075,7 +1083,7 @@
    if
     i32.const 0
     i32.const 368
-    i32.const 392
+    i32.const 393
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1107,7 +1115,7 @@
    if
     i32.const 0
     i32.const 368
-    i32.const 405
+    i32.const 406
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1349,7 +1357,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 555
+   i32.const 556
    i32.const 3
    call $~lib/builtins/abort
    unreachable
@@ -1678,7 +1686,7 @@
   if
    i32.const 32
    i32.const 368
-   i32.const 460
+   i32.const 461
    i32.const 29
    call $~lib/builtins/abort
    unreachable
@@ -2121,7 +2129,7 @@
    if
     i32.const 0
     i32.const 368
-    i32.const 492
+    i32.const 493
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -2141,7 +2149,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 494
+   i32.const 495
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/getter-call.debug.wat
+++ b/tests/compiler/getter-call.debug.wat
@@ -1025,6 +1025,8 @@
   local.get $endU64
   i32.wrap_i64
   local.set $end
+  i32.const 0
+  drop
   i32.const 1
   drop
   local.get $start
@@ -1035,7 +1037,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 382
+   i32.const 385
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1081,7 +1083,7 @@
    if
     i32.const 0
     i32.const 368
-    i32.const 389
+    i32.const 392
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1113,7 +1115,7 @@
    if
     i32.const 0
     i32.const 368
-    i32.const 402
+    i32.const 405
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1314,8 +1316,6 @@
   i32.const 1572
   i32.add
   local.set $memStart
-  i32.const 0
-  drop
   local.get $root
   local.get $memStart
   memory.size
@@ -1357,7 +1357,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 562
+   i32.const 555
    i32.const 3
    call $~lib/builtins/abort
    unreachable
@@ -1686,7 +1686,7 @@
   if
    i32.const 32
    i32.const 368
-   i32.const 461
+   i32.const 460
    i32.const 29
    call $~lib/builtins/abort
    unreachable
@@ -1920,8 +1920,6 @@
   (local $6 i32)
   (local $pagesWanted i32)
   (local $pagesAfter i32)
-  i32.const 0
-  drop
   local.get $size
   i32.const 256
   i32.ge_u
@@ -2131,7 +2129,7 @@
    if
     i32.const 0
     i32.const 368
-    i32.const 499
+    i32.const 492
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -2151,7 +2149,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 501
+   i32.const 494
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/getter-call.release.wat
+++ b/tests/compiler/getter-call.release.wat
@@ -630,11 +630,16 @@
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
+  local.get $2
   local.get $1
   i64.extend_i32_u
-  local.get $2
-  i64.gt_u
+  i64.lt_u
   if
+   i32.const 0
+   i32.const 1392
+   i32.const 386
+   i32.const 14
+   call $~lib/builtins/abort
    unreachable
   end
   local.get $1
@@ -657,7 +662,7 @@
    if
     i32.const 0
     i32.const 1392
-    i32.const 392
+    i32.const 393
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -684,7 +689,7 @@
    if
     i32.const 0
     i32.const 1392
-    i32.const 405
+    i32.const 406
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1047,7 +1052,7 @@
       if
        i32.const 0
        i32.const 1392
-       i32.const 555
+       i32.const 556
        i32.const 3
        call $~lib/builtins/abort
        unreachable
@@ -1245,7 +1250,7 @@
    if
     i32.const 0
     i32.const 1392
-    i32.const 492
+    i32.const 493
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1260,7 +1265,7 @@
   if
    i32.const 0
    i32.const 1392
-   i32.const 494
+   i32.const 495
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/getter-call.release.wat
+++ b/tests/compiler/getter-call.release.wat
@@ -630,16 +630,11 @@
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
-  local.get $2
   local.get $1
   i64.extend_i32_u
-  i64.lt_u
+  local.get $2
+  i64.gt_u
   if
-   i32.const 0
-   i32.const 1392
-   i32.const 385
-   i32.const 14
-   call $~lib/builtins/abort
    unreachable
   end
   local.get $1

--- a/tests/compiler/getter-call.release.wat
+++ b/tests/compiler/getter-call.release.wat
@@ -637,7 +637,7 @@
   if
    i32.const 0
    i32.const 1392
-   i32.const 382
+   i32.const 385
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -662,7 +662,7 @@
    if
     i32.const 0
     i32.const 1392
-    i32.const 389
+    i32.const 392
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -689,7 +689,7 @@
    if
     i32.const 0
     i32.const 1392
-    i32.const 402
+    i32.const 405
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1052,7 +1052,7 @@
       if
        i32.const 0
        i32.const 1392
-       i32.const 562
+       i32.const 555
        i32.const 3
        call $~lib/builtins/abort
        unreachable
@@ -1250,7 +1250,7 @@
    if
     i32.const 0
     i32.const 1392
-    i32.const 499
+    i32.const 492
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1265,7 +1265,7 @@
   if
    i32.const 0
    i32.const 1392
-   i32.const 501
+   i32.const 494
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/heap.debug.wat
+++ b/tests/compiler/heap.debug.wat
@@ -673,19 +673,11 @@
   local.set $end
   i32.const 0
   drop
-  i32.const 1
-  drop
   local.get $start
   i64.extend_i32_u
   local.get $endU64
-  i64.le_u
-  i32.eqz
+  i64.gt_u
   if
-   i32.const 0
-   i32.const 32
-   i32.const 385
-   i32.const 14
-   call $~lib/builtins/abort
    unreachable
   end
   local.get $start

--- a/tests/compiler/heap.debug.wat
+++ b/tests/compiler/heap.debug.wat
@@ -673,11 +673,19 @@
   local.set $end
   i32.const 0
   drop
+  i32.const 1
+  drop
   local.get $start
   i64.extend_i32_u
   local.get $endU64
-  i64.gt_u
+  i64.le_u
+  i32.eqz
   if
+   i32.const 0
+   i32.const 32
+   i32.const 386
+   i32.const 14
+   call $~lib/builtins/abort
    unreachable
   end
   local.get $start
@@ -721,7 +729,7 @@
    if
     i32.const 0
     i32.const 32
-    i32.const 392
+    i32.const 393
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -753,7 +761,7 @@
    if
     i32.const 0
     i32.const 32
-    i32.const 405
+    i32.const 406
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -993,7 +1001,7 @@
   if
    i32.const 96
    i32.const 32
-   i32.const 460
+   i32.const 461
    i32.const 29
    call $~lib/builtins/abort
    unreachable
@@ -1436,7 +1444,7 @@
    if
     i32.const 0
     i32.const 32
-    i32.const 492
+    i32.const 493
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1456,7 +1464,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 494
+   i32.const 495
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1521,7 +1529,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 555
+   i32.const 556
    i32.const 3
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/heap.debug.wat
+++ b/tests/compiler/heap.debug.wat
@@ -671,6 +671,8 @@
   local.get $endU64
   i32.wrap_i64
   local.set $end
+  i32.const 0
+  drop
   i32.const 1
   drop
   local.get $start
@@ -681,7 +683,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 382
+   i32.const 385
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -727,7 +729,7 @@
    if
     i32.const 0
     i32.const 32
-    i32.const 389
+    i32.const 392
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -759,7 +761,7 @@
    if
     i32.const 0
     i32.const 32
-    i32.const 402
+    i32.const 405
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -960,8 +962,6 @@
   i32.const 1572
   i32.add
   local.set $memStart
-  i32.const 0
-  drop
   local.get $root
   local.get $memStart
   memory.size
@@ -1001,7 +1001,7 @@
   if
    i32.const 96
    i32.const 32
-   i32.const 461
+   i32.const 460
    i32.const 29
    call $~lib/builtins/abort
    unreachable
@@ -1235,8 +1235,6 @@
   (local $6 i32)
   (local $pagesWanted i32)
   (local $pagesAfter i32)
-  i32.const 0
-  drop
   local.get $size
   i32.const 256
   i32.ge_u
@@ -1446,7 +1444,7 @@
    if
     i32.const 0
     i32.const 32
-    i32.const 499
+    i32.const 492
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1466,7 +1464,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 501
+   i32.const 494
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1531,7 +1529,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 562
+   i32.const 555
    i32.const 3
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/heap.release.wat
+++ b/tests/compiler/heap.release.wat
@@ -419,7 +419,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 382
+   i32.const 385
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -444,7 +444,7 @@
    if
     i32.const 0
     i32.const 1056
-    i32.const 389
+    i32.const 392
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -471,7 +471,7 @@
    if
     i32.const 0
     i32.const 1056
-    i32.const 402
+    i32.const 405
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -609,7 +609,7 @@
   if
    i32.const 1120
    i32.const 1056
-   i32.const 461
+   i32.const 460
    i32.const 29
    call $~lib/builtins/abort
    unreachable
@@ -917,7 +917,7 @@
    if
     i32.const 0
     i32.const 1056
-    i32.const 499
+    i32.const 492
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -932,7 +932,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 501
+   i32.const 494
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -969,7 +969,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 562
+   i32.const 555
    i32.const 3
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/heap.release.wat
+++ b/tests/compiler/heap.release.wat
@@ -412,11 +412,16 @@
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
+  local.get $2
   local.get $1
   i64.extend_i32_u
-  local.get $2
-  i64.gt_u
+  i64.lt_u
   if
+   i32.const 0
+   i32.const 1056
+   i32.const 386
+   i32.const 14
+   call $~lib/builtins/abort
    unreachable
   end
   local.get $1
@@ -439,7 +444,7 @@
    if
     i32.const 0
     i32.const 1056
-    i32.const 392
+    i32.const 393
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -466,7 +471,7 @@
    if
     i32.const 0
     i32.const 1056
-    i32.const 405
+    i32.const 406
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -604,7 +609,7 @@
   if
    i32.const 1120
    i32.const 1056
-   i32.const 460
+   i32.const 461
    i32.const 29
    call $~lib/builtins/abort
    unreachable
@@ -912,7 +917,7 @@
    if
     i32.const 0
     i32.const 1056
-    i32.const 492
+    i32.const 493
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -927,7 +932,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 494
+   i32.const 495
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -964,7 +969,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 555
+   i32.const 556
    i32.const 3
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/heap.release.wat
+++ b/tests/compiler/heap.release.wat
@@ -412,16 +412,11 @@
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
-  local.get $2
   local.get $1
   i64.extend_i32_u
-  i64.lt_u
+  local.get $2
+  i64.gt_u
   if
-   i32.const 0
-   i32.const 1056
-   i32.const 385
-   i32.const 14
-   call $~lib/builtins/abort
    unreachable
   end
   local.get $1

--- a/tests/compiler/infer-array.debug.wat
+++ b/tests/compiler/infer-array.debug.wat
@@ -1046,11 +1046,19 @@
   local.set $end
   i32.const 0
   drop
+  i32.const 1
+  drop
   local.get $start
   i64.extend_i32_u
   local.get $endU64
-  i64.gt_u
+  i64.le_u
+  i32.eqz
   if
+   i32.const 0
+   i32.const 400
+   i32.const 386
+   i32.const 14
+   call $~lib/builtins/abort
    unreachable
   end
   local.get $start
@@ -1094,7 +1102,7 @@
    if
     i32.const 0
     i32.const 400
-    i32.const 392
+    i32.const 393
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1126,7 +1134,7 @@
    if
     i32.const 0
     i32.const 400
-    i32.const 405
+    i32.const 406
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1368,7 +1376,7 @@
   if
    i32.const 0
    i32.const 400
-   i32.const 555
+   i32.const 556
    i32.const 3
    call $~lib/builtins/abort
    unreachable
@@ -1697,7 +1705,7 @@
   if
    i32.const 64
    i32.const 400
-   i32.const 460
+   i32.const 461
    i32.const 29
    call $~lib/builtins/abort
    unreachable
@@ -2140,7 +2148,7 @@
    if
     i32.const 0
     i32.const 400
-    i32.const 492
+    i32.const 493
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -2160,7 +2168,7 @@
   if
    i32.const 0
    i32.const 400
-   i32.const 494
+   i32.const 495
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/infer-array.debug.wat
+++ b/tests/compiler/infer-array.debug.wat
@@ -1046,19 +1046,11 @@
   local.set $end
   i32.const 0
   drop
-  i32.const 1
-  drop
   local.get $start
   i64.extend_i32_u
   local.get $endU64
-  i64.le_u
-  i32.eqz
+  i64.gt_u
   if
-   i32.const 0
-   i32.const 400
-   i32.const 385
-   i32.const 14
-   call $~lib/builtins/abort
    unreachable
   end
   local.get $start

--- a/tests/compiler/infer-array.debug.wat
+++ b/tests/compiler/infer-array.debug.wat
@@ -1044,6 +1044,8 @@
   local.get $endU64
   i32.wrap_i64
   local.set $end
+  i32.const 0
+  drop
   i32.const 1
   drop
   local.get $start
@@ -1054,7 +1056,7 @@
   if
    i32.const 0
    i32.const 400
-   i32.const 382
+   i32.const 385
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1100,7 +1102,7 @@
    if
     i32.const 0
     i32.const 400
-    i32.const 389
+    i32.const 392
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1132,7 +1134,7 @@
    if
     i32.const 0
     i32.const 400
-    i32.const 402
+    i32.const 405
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1333,8 +1335,6 @@
   i32.const 1572
   i32.add
   local.set $memStart
-  i32.const 0
-  drop
   local.get $root
   local.get $memStart
   memory.size
@@ -1376,7 +1376,7 @@
   if
    i32.const 0
    i32.const 400
-   i32.const 562
+   i32.const 555
    i32.const 3
    call $~lib/builtins/abort
    unreachable
@@ -1705,7 +1705,7 @@
   if
    i32.const 64
    i32.const 400
-   i32.const 461
+   i32.const 460
    i32.const 29
    call $~lib/builtins/abort
    unreachable
@@ -1939,8 +1939,6 @@
   (local $6 i32)
   (local $pagesWanted i32)
   (local $pagesAfter i32)
-  i32.const 0
-  drop
   local.get $size
   i32.const 256
   i32.ge_u
@@ -2150,7 +2148,7 @@
    if
     i32.const 0
     i32.const 400
-    i32.const 499
+    i32.const 492
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -2170,7 +2168,7 @@
   if
    i32.const 0
    i32.const 400
-   i32.const 501
+   i32.const 494
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/infer-array.release.wat
+++ b/tests/compiler/infer-array.release.wat
@@ -678,7 +678,7 @@
   if
    i32.const 0
    i32.const 1424
-   i32.const 382
+   i32.const 385
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -703,7 +703,7 @@
    if
     i32.const 0
     i32.const 1424
-    i32.const 389
+    i32.const 392
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -730,7 +730,7 @@
    if
     i32.const 0
     i32.const 1424
-    i32.const 402
+    i32.const 405
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1093,7 +1093,7 @@
       if
        i32.const 0
        i32.const 1424
-       i32.const 562
+       i32.const 555
        i32.const 3
        call $~lib/builtins/abort
        unreachable
@@ -1328,7 +1328,7 @@
   if
    i32.const 1088
    i32.const 1424
-   i32.const 461
+   i32.const 460
    i32.const 29
    call $~lib/builtins/abort
    unreachable
@@ -1430,7 +1430,7 @@
    if
     i32.const 0
     i32.const 1424
-    i32.const 499
+    i32.const 492
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1445,7 +1445,7 @@
   if
    i32.const 0
    i32.const 1424
-   i32.const 501
+   i32.const 494
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/infer-array.release.wat
+++ b/tests/compiler/infer-array.release.wat
@@ -671,16 +671,11 @@
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
-  local.get $2
   local.get $1
   i64.extend_i32_u
-  i64.lt_u
+  local.get $2
+  i64.gt_u
   if
-   i32.const 0
-   i32.const 1424
-   i32.const 385
-   i32.const 14
-   call $~lib/builtins/abort
    unreachable
   end
   local.get $1

--- a/tests/compiler/infer-array.release.wat
+++ b/tests/compiler/infer-array.release.wat
@@ -671,11 +671,16 @@
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
+  local.get $2
   local.get $1
   i64.extend_i32_u
-  local.get $2
-  i64.gt_u
+  i64.lt_u
   if
+   i32.const 0
+   i32.const 1424
+   i32.const 386
+   i32.const 14
+   call $~lib/builtins/abort
    unreachable
   end
   local.get $1
@@ -698,7 +703,7 @@
    if
     i32.const 0
     i32.const 1424
-    i32.const 392
+    i32.const 393
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -725,7 +730,7 @@
    if
     i32.const 0
     i32.const 1424
-    i32.const 405
+    i32.const 406
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1088,7 +1093,7 @@
       if
        i32.const 0
        i32.const 1424
-       i32.const 555
+       i32.const 556
        i32.const 3
        call $~lib/builtins/abort
        unreachable
@@ -1323,7 +1328,7 @@
   if
    i32.const 1088
    i32.const 1424
-   i32.const 460
+   i32.const 461
    i32.const 29
    call $~lib/builtins/abort
    unreachable
@@ -1425,7 +1430,7 @@
    if
     i32.const 0
     i32.const 1424
-    i32.const 492
+    i32.const 493
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1440,7 +1445,7 @@
   if
    i32.const 0
    i32.const 1424
-   i32.const 494
+   i32.const 495
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/infer-generic.debug.wat
+++ b/tests/compiler/infer-generic.debug.wat
@@ -1071,6 +1071,8 @@
   local.get $endU64
   i32.wrap_i64
   local.set $end
+  i32.const 0
+  drop
   i32.const 1
   drop
   local.get $start
@@ -1081,7 +1083,7 @@
   if
    i32.const 0
    i32.const 544
-   i32.const 382
+   i32.const 385
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1127,7 +1129,7 @@
    if
     i32.const 0
     i32.const 544
-    i32.const 389
+    i32.const 392
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1159,7 +1161,7 @@
    if
     i32.const 0
     i32.const 544
-    i32.const 402
+    i32.const 405
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1360,8 +1362,6 @@
   i32.const 1572
   i32.add
   local.set $memStart
-  i32.const 0
-  drop
   local.get $root
   local.get $memStart
   memory.size
@@ -1403,7 +1403,7 @@
   if
    i32.const 0
    i32.const 544
-   i32.const 562
+   i32.const 555
    i32.const 3
    call $~lib/builtins/abort
    unreachable
@@ -1732,7 +1732,7 @@
   if
    i32.const 208
    i32.const 544
-   i32.const 461
+   i32.const 460
    i32.const 29
    call $~lib/builtins/abort
    unreachable
@@ -1966,8 +1966,6 @@
   (local $6 i32)
   (local $pagesWanted i32)
   (local $pagesAfter i32)
-  i32.const 0
-  drop
   local.get $size
   i32.const 256
   i32.ge_u
@@ -2177,7 +2175,7 @@
    if
     i32.const 0
     i32.const 544
-    i32.const 499
+    i32.const 492
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -2197,7 +2195,7 @@
   if
    i32.const 0
    i32.const 544
-   i32.const 501
+   i32.const 494
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/infer-generic.debug.wat
+++ b/tests/compiler/infer-generic.debug.wat
@@ -1073,19 +1073,11 @@
   local.set $end
   i32.const 0
   drop
-  i32.const 1
-  drop
   local.get $start
   i64.extend_i32_u
   local.get $endU64
-  i64.le_u
-  i32.eqz
+  i64.gt_u
   if
-   i32.const 0
-   i32.const 544
-   i32.const 385
-   i32.const 14
-   call $~lib/builtins/abort
    unreachable
   end
   local.get $start

--- a/tests/compiler/infer-generic.debug.wat
+++ b/tests/compiler/infer-generic.debug.wat
@@ -1073,11 +1073,19 @@
   local.set $end
   i32.const 0
   drop
+  i32.const 1
+  drop
   local.get $start
   i64.extend_i32_u
   local.get $endU64
-  i64.gt_u
+  i64.le_u
+  i32.eqz
   if
+   i32.const 0
+   i32.const 544
+   i32.const 386
+   i32.const 14
+   call $~lib/builtins/abort
    unreachable
   end
   local.get $start
@@ -1121,7 +1129,7 @@
    if
     i32.const 0
     i32.const 544
-    i32.const 392
+    i32.const 393
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1153,7 +1161,7 @@
    if
     i32.const 0
     i32.const 544
-    i32.const 405
+    i32.const 406
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1395,7 +1403,7 @@
   if
    i32.const 0
    i32.const 544
-   i32.const 555
+   i32.const 556
    i32.const 3
    call $~lib/builtins/abort
    unreachable
@@ -1724,7 +1732,7 @@
   if
    i32.const 208
    i32.const 544
-   i32.const 460
+   i32.const 461
    i32.const 29
    call $~lib/builtins/abort
    unreachable
@@ -2167,7 +2175,7 @@
    if
     i32.const 0
     i32.const 544
-    i32.const 492
+    i32.const 493
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -2187,7 +2195,7 @@
   if
    i32.const 0
    i32.const 544
-   i32.const 494
+   i32.const 495
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/infer-generic.release.wat
+++ b/tests/compiler/infer-generic.release.wat
@@ -654,16 +654,11 @@
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
-  local.get $2
   local.get $1
   i64.extend_i32_u
-  i64.lt_u
+  local.get $2
+  i64.gt_u
   if
-   i32.const 0
-   i32.const 1568
-   i32.const 385
-   i32.const 14
-   call $~lib/builtins/abort
    unreachable
   end
   local.get $1

--- a/tests/compiler/infer-generic.release.wat
+++ b/tests/compiler/infer-generic.release.wat
@@ -654,11 +654,16 @@
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
+  local.get $2
   local.get $1
   i64.extend_i32_u
-  local.get $2
-  i64.gt_u
+  i64.lt_u
   if
+   i32.const 0
+   i32.const 1568
+   i32.const 386
+   i32.const 14
+   call $~lib/builtins/abort
    unreachable
   end
   local.get $1
@@ -681,7 +686,7 @@
    if
     i32.const 0
     i32.const 1568
-    i32.const 392
+    i32.const 393
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -708,7 +713,7 @@
    if
     i32.const 0
     i32.const 1568
-    i32.const 405
+    i32.const 406
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1071,7 +1076,7 @@
       if
        i32.const 0
        i32.const 1568
-       i32.const 555
+       i32.const 556
        i32.const 3
        call $~lib/builtins/abort
        unreachable
@@ -1306,7 +1311,7 @@
   if
    i32.const 1232
    i32.const 1568
-   i32.const 460
+   i32.const 461
    i32.const 29
    call $~lib/builtins/abort
    unreachable
@@ -1408,7 +1413,7 @@
    if
     i32.const 0
     i32.const 1568
-    i32.const 492
+    i32.const 493
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1423,7 +1428,7 @@
   if
    i32.const 0
    i32.const 1568
-   i32.const 494
+   i32.const 495
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/infer-generic.release.wat
+++ b/tests/compiler/infer-generic.release.wat
@@ -661,7 +661,7 @@
   if
    i32.const 0
    i32.const 1568
-   i32.const 382
+   i32.const 385
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -686,7 +686,7 @@
    if
     i32.const 0
     i32.const 1568
-    i32.const 389
+    i32.const 392
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -713,7 +713,7 @@
    if
     i32.const 0
     i32.const 1568
-    i32.const 402
+    i32.const 405
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1076,7 +1076,7 @@
       if
        i32.const 0
        i32.const 1568
-       i32.const 562
+       i32.const 555
        i32.const 3
        call $~lib/builtins/abort
        unreachable
@@ -1311,7 +1311,7 @@
   if
    i32.const 1232
    i32.const 1568
-   i32.const 461
+   i32.const 460
    i32.const 29
    call $~lib/builtins/abort
    unreachable
@@ -1413,7 +1413,7 @@
    if
     i32.const 0
     i32.const 1568
-    i32.const 499
+    i32.const 492
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1428,7 +1428,7 @@
   if
    i32.const 0
    i32.const 1568
-   i32.const 501
+   i32.const 494
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/inlining.debug.wat
+++ b/tests/compiler/inlining.debug.wat
@@ -1292,19 +1292,11 @@
   local.set $end
   i32.const 0
   drop
-  i32.const 1
-  drop
   local.get $start
   i64.extend_i32_u
   local.get $endU64
-  i64.le_u
-  i32.eqz
+  i64.gt_u
   if
-   i32.const 0
-   i32.const 448
-   i32.const 385
-   i32.const 14
-   call $~lib/builtins/abort
    unreachable
   end
   local.get $start

--- a/tests/compiler/inlining.debug.wat
+++ b/tests/compiler/inlining.debug.wat
@@ -1292,11 +1292,19 @@
   local.set $end
   i32.const 0
   drop
+  i32.const 1
+  drop
   local.get $start
   i64.extend_i32_u
   local.get $endU64
-  i64.gt_u
+  i64.le_u
+  i32.eqz
   if
+   i32.const 0
+   i32.const 448
+   i32.const 386
+   i32.const 14
+   call $~lib/builtins/abort
    unreachable
   end
   local.get $start
@@ -1340,7 +1348,7 @@
    if
     i32.const 0
     i32.const 448
-    i32.const 392
+    i32.const 393
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1372,7 +1380,7 @@
    if
     i32.const 0
     i32.const 448
-    i32.const 405
+    i32.const 406
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1614,7 +1622,7 @@
   if
    i32.const 0
    i32.const 448
-   i32.const 555
+   i32.const 556
    i32.const 3
    call $~lib/builtins/abort
    unreachable
@@ -1943,7 +1951,7 @@
   if
    i32.const 112
    i32.const 448
-   i32.const 460
+   i32.const 461
    i32.const 29
    call $~lib/builtins/abort
    unreachable
@@ -2386,7 +2394,7 @@
    if
     i32.const 0
     i32.const 448
-    i32.const 492
+    i32.const 493
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -2406,7 +2414,7 @@
   if
    i32.const 0
    i32.const 448
-   i32.const 494
+   i32.const 495
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/inlining.debug.wat
+++ b/tests/compiler/inlining.debug.wat
@@ -1290,6 +1290,8 @@
   local.get $endU64
   i32.wrap_i64
   local.set $end
+  i32.const 0
+  drop
   i32.const 1
   drop
   local.get $start
@@ -1300,7 +1302,7 @@
   if
    i32.const 0
    i32.const 448
-   i32.const 382
+   i32.const 385
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1346,7 +1348,7 @@
    if
     i32.const 0
     i32.const 448
-    i32.const 389
+    i32.const 392
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1378,7 +1380,7 @@
    if
     i32.const 0
     i32.const 448
-    i32.const 402
+    i32.const 405
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1579,8 +1581,6 @@
   i32.const 1572
   i32.add
   local.set $memStart
-  i32.const 0
-  drop
   local.get $root
   local.get $memStart
   memory.size
@@ -1622,7 +1622,7 @@
   if
    i32.const 0
    i32.const 448
-   i32.const 562
+   i32.const 555
    i32.const 3
    call $~lib/builtins/abort
    unreachable
@@ -1951,7 +1951,7 @@
   if
    i32.const 112
    i32.const 448
-   i32.const 461
+   i32.const 460
    i32.const 29
    call $~lib/builtins/abort
    unreachable
@@ -2185,8 +2185,6 @@
   (local $6 i32)
   (local $pagesWanted i32)
   (local $pagesAfter i32)
-  i32.const 0
-  drop
   local.get $size
   i32.const 256
   i32.ge_u
@@ -2396,7 +2394,7 @@
    if
     i32.const 0
     i32.const 448
-    i32.const 499
+    i32.const 492
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -2416,7 +2414,7 @@
   if
    i32.const 0
    i32.const 448
-   i32.const 501
+   i32.const 494
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/inlining.release.wat
+++ b/tests/compiler/inlining.release.wat
@@ -640,16 +640,11 @@
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
-  local.get $2
   local.get $1
   i64.extend_i32_u
-  i64.lt_u
+  local.get $2
+  i64.gt_u
   if
-   i32.const 0
-   i32.const 1472
-   i32.const 385
-   i32.const 14
-   call $~lib/builtins/abort
    unreachable
   end
   local.get $1

--- a/tests/compiler/inlining.release.wat
+++ b/tests/compiler/inlining.release.wat
@@ -647,7 +647,7 @@
   if
    i32.const 0
    i32.const 1472
-   i32.const 382
+   i32.const 385
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -672,7 +672,7 @@
    if
     i32.const 0
     i32.const 1472
-    i32.const 389
+    i32.const 392
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -699,7 +699,7 @@
    if
     i32.const 0
     i32.const 1472
-    i32.const 402
+    i32.const 405
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1062,7 +1062,7 @@
       if
        i32.const 0
        i32.const 1472
-       i32.const 562
+       i32.const 555
        i32.const 3
        call $~lib/builtins/abort
        unreachable
@@ -1297,7 +1297,7 @@
   if
    i32.const 1136
    i32.const 1472
-   i32.const 461
+   i32.const 460
    i32.const 29
    call $~lib/builtins/abort
    unreachable
@@ -1399,7 +1399,7 @@
    if
     i32.const 0
     i32.const 1472
-    i32.const 499
+    i32.const 492
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1414,7 +1414,7 @@
   if
    i32.const 0
    i32.const 1472
-   i32.const 501
+   i32.const 494
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/inlining.release.wat
+++ b/tests/compiler/inlining.release.wat
@@ -640,11 +640,16 @@
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
+  local.get $2
   local.get $1
   i64.extend_i32_u
-  local.get $2
-  i64.gt_u
+  i64.lt_u
   if
+   i32.const 0
+   i32.const 1472
+   i32.const 386
+   i32.const 14
+   call $~lib/builtins/abort
    unreachable
   end
   local.get $1
@@ -667,7 +672,7 @@
    if
     i32.const 0
     i32.const 1472
-    i32.const 392
+    i32.const 393
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -694,7 +699,7 @@
    if
     i32.const 0
     i32.const 1472
-    i32.const 405
+    i32.const 406
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1057,7 +1062,7 @@
       if
        i32.const 0
        i32.const 1472
-       i32.const 555
+       i32.const 556
        i32.const 3
        call $~lib/builtins/abort
        unreachable
@@ -1292,7 +1297,7 @@
   if
    i32.const 1136
    i32.const 1472
-   i32.const 460
+   i32.const 461
    i32.const 29
    call $~lib/builtins/abort
    unreachable
@@ -1394,7 +1399,7 @@
    if
     i32.const 0
     i32.const 1472
-    i32.const 492
+    i32.const 493
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1409,7 +1414,7 @@
   if
    i32.const 0
    i32.const 1472
-   i32.const 494
+   i32.const 495
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/instanceof.debug.wat
+++ b/tests/compiler/instanceof.debug.wat
@@ -1048,11 +1048,19 @@
   local.set $end
   i32.const 0
   drop
+  i32.const 1
+  drop
   local.get $start
   i64.extend_i32_u
   local.get $endU64
-  i64.gt_u
+  i64.le_u
+  i32.eqz
   if
+   i32.const 0
+   i32.const 368
+   i32.const 386
+   i32.const 14
+   call $~lib/builtins/abort
    unreachable
   end
   local.get $start
@@ -1096,7 +1104,7 @@
    if
     i32.const 0
     i32.const 368
-    i32.const 392
+    i32.const 393
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1128,7 +1136,7 @@
    if
     i32.const 0
     i32.const 368
-    i32.const 405
+    i32.const 406
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1370,7 +1378,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 555
+   i32.const 556
    i32.const 3
    call $~lib/builtins/abort
    unreachable
@@ -1699,7 +1707,7 @@
   if
    i32.const 32
    i32.const 368
-   i32.const 460
+   i32.const 461
    i32.const 29
    call $~lib/builtins/abort
    unreachable
@@ -2142,7 +2150,7 @@
    if
     i32.const 0
     i32.const 368
-    i32.const 492
+    i32.const 493
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -2162,7 +2170,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 494
+   i32.const 495
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/instanceof.debug.wat
+++ b/tests/compiler/instanceof.debug.wat
@@ -1046,6 +1046,8 @@
   local.get $endU64
   i32.wrap_i64
   local.set $end
+  i32.const 0
+  drop
   i32.const 1
   drop
   local.get $start
@@ -1056,7 +1058,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 382
+   i32.const 385
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1102,7 +1104,7 @@
    if
     i32.const 0
     i32.const 368
-    i32.const 389
+    i32.const 392
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1134,7 +1136,7 @@
    if
     i32.const 0
     i32.const 368
-    i32.const 402
+    i32.const 405
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1335,8 +1337,6 @@
   i32.const 1572
   i32.add
   local.set $memStart
-  i32.const 0
-  drop
   local.get $root
   local.get $memStart
   memory.size
@@ -1378,7 +1378,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 562
+   i32.const 555
    i32.const 3
    call $~lib/builtins/abort
    unreachable
@@ -1707,7 +1707,7 @@
   if
    i32.const 32
    i32.const 368
-   i32.const 461
+   i32.const 460
    i32.const 29
    call $~lib/builtins/abort
    unreachable
@@ -1941,8 +1941,6 @@
   (local $6 i32)
   (local $pagesWanted i32)
   (local $pagesAfter i32)
-  i32.const 0
-  drop
   local.get $size
   i32.const 256
   i32.ge_u
@@ -2152,7 +2150,7 @@
    if
     i32.const 0
     i32.const 368
-    i32.const 499
+    i32.const 492
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -2172,7 +2170,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 501
+   i32.const 494
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/instanceof.debug.wat
+++ b/tests/compiler/instanceof.debug.wat
@@ -1048,19 +1048,11 @@
   local.set $end
   i32.const 0
   drop
-  i32.const 1
-  drop
   local.get $start
   i64.extend_i32_u
   local.get $endU64
-  i64.le_u
-  i32.eqz
+  i64.gt_u
   if
-   i32.const 0
-   i32.const 368
-   i32.const 385
-   i32.const 14
-   call $~lib/builtins/abort
    unreachable
   end
   local.get $start

--- a/tests/compiler/instanceof.release.wat
+++ b/tests/compiler/instanceof.release.wat
@@ -732,16 +732,11 @@
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
-  local.get $2
   local.get $1
   i64.extend_i32_u
-  i64.lt_u
+  local.get $2
+  i64.gt_u
   if
-   i32.const 0
-   i32.const 1392
-   i32.const 385
-   i32.const 14
-   call $~lib/builtins/abort
    unreachable
   end
   local.get $1

--- a/tests/compiler/instanceof.release.wat
+++ b/tests/compiler/instanceof.release.wat
@@ -739,7 +739,7 @@
   if
    i32.const 0
    i32.const 1392
-   i32.const 382
+   i32.const 385
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -764,7 +764,7 @@
    if
     i32.const 0
     i32.const 1392
-    i32.const 389
+    i32.const 392
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -791,7 +791,7 @@
    if
     i32.const 0
     i32.const 1392
-    i32.const 402
+    i32.const 405
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1154,7 +1154,7 @@
       if
        i32.const 0
        i32.const 1392
-       i32.const 562
+       i32.const 555
        i32.const 3
        call $~lib/builtins/abort
        unreachable
@@ -1352,7 +1352,7 @@
    if
     i32.const 0
     i32.const 1392
-    i32.const 499
+    i32.const 492
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1367,7 +1367,7 @@
   if
    i32.const 0
    i32.const 1392
-   i32.const 501
+   i32.const 494
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/instanceof.release.wat
+++ b/tests/compiler/instanceof.release.wat
@@ -732,11 +732,16 @@
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
+  local.get $2
   local.get $1
   i64.extend_i32_u
-  local.get $2
-  i64.gt_u
+  i64.lt_u
   if
+   i32.const 0
+   i32.const 1392
+   i32.const 386
+   i32.const 14
+   call $~lib/builtins/abort
    unreachable
   end
   local.get $1
@@ -759,7 +764,7 @@
    if
     i32.const 0
     i32.const 1392
-    i32.const 392
+    i32.const 393
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -786,7 +791,7 @@
    if
     i32.const 0
     i32.const 1392
-    i32.const 405
+    i32.const 406
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1149,7 +1154,7 @@
       if
        i32.const 0
        i32.const 1392
-       i32.const 555
+       i32.const 556
        i32.const 3
        call $~lib/builtins/abort
        unreachable
@@ -1347,7 +1352,7 @@
    if
     i32.const 0
     i32.const 1392
-    i32.const 492
+    i32.const 493
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1362,7 +1367,7 @@
   if
    i32.const 0
    i32.const 1392
-   i32.const 494
+   i32.const 495
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/issues/1095.debug.wat
+++ b/tests/compiler/issues/1095.debug.wat
@@ -1027,19 +1027,11 @@
   local.set $end
   i32.const 0
   drop
-  i32.const 1
-  drop
   local.get $start
   i64.extend_i32_u
   local.get $endU64
-  i64.le_u
-  i32.eqz
+  i64.gt_u
   if
-   i32.const 0
-   i32.const 368
-   i32.const 385
-   i32.const 14
-   call $~lib/builtins/abort
    unreachable
   end
   local.get $start

--- a/tests/compiler/issues/1095.debug.wat
+++ b/tests/compiler/issues/1095.debug.wat
@@ -1027,11 +1027,19 @@
   local.set $end
   i32.const 0
   drop
+  i32.const 1
+  drop
   local.get $start
   i64.extend_i32_u
   local.get $endU64
-  i64.gt_u
+  i64.le_u
+  i32.eqz
   if
+   i32.const 0
+   i32.const 368
+   i32.const 386
+   i32.const 14
+   call $~lib/builtins/abort
    unreachable
   end
   local.get $start
@@ -1075,7 +1083,7 @@
    if
     i32.const 0
     i32.const 368
-    i32.const 392
+    i32.const 393
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1107,7 +1115,7 @@
    if
     i32.const 0
     i32.const 368
-    i32.const 405
+    i32.const 406
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1349,7 +1357,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 555
+   i32.const 556
    i32.const 3
    call $~lib/builtins/abort
    unreachable
@@ -1678,7 +1686,7 @@
   if
    i32.const 32
    i32.const 368
-   i32.const 460
+   i32.const 461
    i32.const 29
    call $~lib/builtins/abort
    unreachable
@@ -2121,7 +2129,7 @@
    if
     i32.const 0
     i32.const 368
-    i32.const 492
+    i32.const 493
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -2141,7 +2149,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 494
+   i32.const 495
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/issues/1095.debug.wat
+++ b/tests/compiler/issues/1095.debug.wat
@@ -1025,6 +1025,8 @@
   local.get $endU64
   i32.wrap_i64
   local.set $end
+  i32.const 0
+  drop
   i32.const 1
   drop
   local.get $start
@@ -1035,7 +1037,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 382
+   i32.const 385
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1081,7 +1083,7 @@
    if
     i32.const 0
     i32.const 368
-    i32.const 389
+    i32.const 392
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1113,7 +1115,7 @@
    if
     i32.const 0
     i32.const 368
-    i32.const 402
+    i32.const 405
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1314,8 +1316,6 @@
   i32.const 1572
   i32.add
   local.set $memStart
-  i32.const 0
-  drop
   local.get $root
   local.get $memStart
   memory.size
@@ -1357,7 +1357,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 562
+   i32.const 555
    i32.const 3
    call $~lib/builtins/abort
    unreachable
@@ -1686,7 +1686,7 @@
   if
    i32.const 32
    i32.const 368
-   i32.const 461
+   i32.const 460
    i32.const 29
    call $~lib/builtins/abort
    unreachable
@@ -1920,8 +1920,6 @@
   (local $6 i32)
   (local $pagesWanted i32)
   (local $pagesAfter i32)
-  i32.const 0
-  drop
   local.get $size
   i32.const 256
   i32.ge_u
@@ -2131,7 +2129,7 @@
    if
     i32.const 0
     i32.const 368
-    i32.const 499
+    i32.const 492
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -2151,7 +2149,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 501
+   i32.const 494
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/issues/1095.release.wat
+++ b/tests/compiler/issues/1095.release.wat
@@ -635,11 +635,16 @@
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
+  local.get $2
   local.get $1
   i64.extend_i32_u
-  local.get $2
-  i64.gt_u
+  i64.lt_u
   if
+   i32.const 0
+   i32.const 1392
+   i32.const 386
+   i32.const 14
+   call $~lib/builtins/abort
    unreachable
   end
   local.get $1
@@ -662,7 +667,7 @@
    if
     i32.const 0
     i32.const 1392
-    i32.const 392
+    i32.const 393
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -689,7 +694,7 @@
    if
     i32.const 0
     i32.const 1392
-    i32.const 405
+    i32.const 406
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1052,7 +1057,7 @@
       if
        i32.const 0
        i32.const 1392
-       i32.const 555
+       i32.const 556
        i32.const 3
        call $~lib/builtins/abort
        unreachable
@@ -1287,7 +1292,7 @@
   if
    i32.const 1056
    i32.const 1392
-   i32.const 460
+   i32.const 461
    i32.const 29
    call $~lib/builtins/abort
    unreachable
@@ -1389,7 +1394,7 @@
    if
     i32.const 0
     i32.const 1392
-    i32.const 492
+    i32.const 493
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1404,7 +1409,7 @@
   if
    i32.const 0
    i32.const 1392
-   i32.const 494
+   i32.const 495
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/issues/1095.release.wat
+++ b/tests/compiler/issues/1095.release.wat
@@ -635,16 +635,11 @@
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
-  local.get $2
   local.get $1
   i64.extend_i32_u
-  i64.lt_u
+  local.get $2
+  i64.gt_u
   if
-   i32.const 0
-   i32.const 1392
-   i32.const 385
-   i32.const 14
-   call $~lib/builtins/abort
    unreachable
   end
   local.get $1

--- a/tests/compiler/issues/1095.release.wat
+++ b/tests/compiler/issues/1095.release.wat
@@ -642,7 +642,7 @@
   if
    i32.const 0
    i32.const 1392
-   i32.const 382
+   i32.const 385
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -667,7 +667,7 @@
    if
     i32.const 0
     i32.const 1392
-    i32.const 389
+    i32.const 392
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -694,7 +694,7 @@
    if
     i32.const 0
     i32.const 1392
-    i32.const 402
+    i32.const 405
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1057,7 +1057,7 @@
       if
        i32.const 0
        i32.const 1392
-       i32.const 562
+       i32.const 555
        i32.const 3
        call $~lib/builtins/abort
        unreachable
@@ -1292,7 +1292,7 @@
   if
    i32.const 1056
    i32.const 1392
-   i32.const 461
+   i32.const 460
    i32.const 29
    call $~lib/builtins/abort
    unreachable
@@ -1394,7 +1394,7 @@
    if
     i32.const 0
     i32.const 1392
-    i32.const 499
+    i32.const 492
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1409,7 +1409,7 @@
   if
    i32.const 0
    i32.const 1392
-   i32.const 501
+   i32.const 494
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/issues/1225.debug.wat
+++ b/tests/compiler/issues/1225.debug.wat
@@ -1042,11 +1042,19 @@
   local.set $end
   i32.const 0
   drop
+  i32.const 1
+  drop
   local.get $start
   i64.extend_i32_u
   local.get $endU64
-  i64.gt_u
+  i64.le_u
+  i32.eqz
   if
+   i32.const 0
+   i32.const 368
+   i32.const 386
+   i32.const 14
+   call $~lib/builtins/abort
    unreachable
   end
   local.get $start
@@ -1090,7 +1098,7 @@
    if
     i32.const 0
     i32.const 368
-    i32.const 392
+    i32.const 393
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1122,7 +1130,7 @@
    if
     i32.const 0
     i32.const 368
-    i32.const 405
+    i32.const 406
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1364,7 +1372,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 555
+   i32.const 556
    i32.const 3
    call $~lib/builtins/abort
    unreachable
@@ -1693,7 +1701,7 @@
   if
    i32.const 32
    i32.const 368
-   i32.const 460
+   i32.const 461
    i32.const 29
    call $~lib/builtins/abort
    unreachable
@@ -2136,7 +2144,7 @@
    if
     i32.const 0
     i32.const 368
-    i32.const 492
+    i32.const 493
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -2156,7 +2164,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 494
+   i32.const 495
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/issues/1225.debug.wat
+++ b/tests/compiler/issues/1225.debug.wat
@@ -1042,19 +1042,11 @@
   local.set $end
   i32.const 0
   drop
-  i32.const 1
-  drop
   local.get $start
   i64.extend_i32_u
   local.get $endU64
-  i64.le_u
-  i32.eqz
+  i64.gt_u
   if
-   i32.const 0
-   i32.const 368
-   i32.const 385
-   i32.const 14
-   call $~lib/builtins/abort
    unreachable
   end
   local.get $start

--- a/tests/compiler/issues/1225.debug.wat
+++ b/tests/compiler/issues/1225.debug.wat
@@ -1040,6 +1040,8 @@
   local.get $endU64
   i32.wrap_i64
   local.set $end
+  i32.const 0
+  drop
   i32.const 1
   drop
   local.get $start
@@ -1050,7 +1052,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 382
+   i32.const 385
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1096,7 +1098,7 @@
    if
     i32.const 0
     i32.const 368
-    i32.const 389
+    i32.const 392
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1128,7 +1130,7 @@
    if
     i32.const 0
     i32.const 368
-    i32.const 402
+    i32.const 405
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1329,8 +1331,6 @@
   i32.const 1572
   i32.add
   local.set $memStart
-  i32.const 0
-  drop
   local.get $root
   local.get $memStart
   memory.size
@@ -1372,7 +1372,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 562
+   i32.const 555
    i32.const 3
    call $~lib/builtins/abort
    unreachable
@@ -1701,7 +1701,7 @@
   if
    i32.const 32
    i32.const 368
-   i32.const 461
+   i32.const 460
    i32.const 29
    call $~lib/builtins/abort
    unreachable
@@ -1935,8 +1935,6 @@
   (local $6 i32)
   (local $pagesWanted i32)
   (local $pagesAfter i32)
-  i32.const 0
-  drop
   local.get $size
   i32.const 256
   i32.ge_u
@@ -2146,7 +2144,7 @@
    if
     i32.const 0
     i32.const 368
-    i32.const 499
+    i32.const 492
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -2166,7 +2164,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 501
+   i32.const 494
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/issues/1225.release.wat
+++ b/tests/compiler/issues/1225.release.wat
@@ -636,16 +636,11 @@
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
-  local.get $2
   local.get $1
   i64.extend_i32_u
-  i64.lt_u
+  local.get $2
+  i64.gt_u
   if
-   i32.const 0
-   i32.const 1392
-   i32.const 385
-   i32.const 14
-   call $~lib/builtins/abort
    unreachable
   end
   local.get $1

--- a/tests/compiler/issues/1225.release.wat
+++ b/tests/compiler/issues/1225.release.wat
@@ -643,7 +643,7 @@
   if
    i32.const 0
    i32.const 1392
-   i32.const 382
+   i32.const 385
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -668,7 +668,7 @@
    if
     i32.const 0
     i32.const 1392
-    i32.const 389
+    i32.const 392
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -695,7 +695,7 @@
    if
     i32.const 0
     i32.const 1392
-    i32.const 402
+    i32.const 405
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1058,7 +1058,7 @@
       if
        i32.const 0
        i32.const 1392
-       i32.const 562
+       i32.const 555
        i32.const 3
        call $~lib/builtins/abort
        unreachable
@@ -1256,7 +1256,7 @@
    if
     i32.const 0
     i32.const 1392
-    i32.const 499
+    i32.const 492
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1271,7 +1271,7 @@
   if
    i32.const 0
    i32.const 1392
-   i32.const 501
+   i32.const 494
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/issues/1225.release.wat
+++ b/tests/compiler/issues/1225.release.wat
@@ -636,11 +636,16 @@
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
+  local.get $2
   local.get $1
   i64.extend_i32_u
-  local.get $2
-  i64.gt_u
+  i64.lt_u
   if
+   i32.const 0
+   i32.const 1392
+   i32.const 386
+   i32.const 14
+   call $~lib/builtins/abort
    unreachable
   end
   local.get $1
@@ -663,7 +668,7 @@
    if
     i32.const 0
     i32.const 1392
-    i32.const 392
+    i32.const 393
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -690,7 +695,7 @@
    if
     i32.const 0
     i32.const 1392
-    i32.const 405
+    i32.const 406
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1053,7 +1058,7 @@
       if
        i32.const 0
        i32.const 1392
-       i32.const 555
+       i32.const 556
        i32.const 3
        call $~lib/builtins/abort
        unreachable
@@ -1251,7 +1256,7 @@
    if
     i32.const 0
     i32.const 1392
-    i32.const 492
+    i32.const 493
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1266,7 +1271,7 @@
   if
    i32.const 0
    i32.const 1392
-   i32.const 494
+   i32.const 495
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/issues/1699.debug.wat
+++ b/tests/compiler/issues/1699.debug.wat
@@ -1029,19 +1029,11 @@
   local.set $end
   i32.const 0
   drop
-  i32.const 1
-  drop
   local.get $start
   i64.extend_i32_u
   local.get $endU64
-  i64.le_u
-  i32.eqz
+  i64.gt_u
   if
-   i32.const 0
-   i32.const 464
-   i32.const 385
-   i32.const 14
-   call $~lib/builtins/abort
    unreachable
   end
   local.get $start

--- a/tests/compiler/issues/1699.debug.wat
+++ b/tests/compiler/issues/1699.debug.wat
@@ -1027,6 +1027,8 @@
   local.get $endU64
   i32.wrap_i64
   local.set $end
+  i32.const 0
+  drop
   i32.const 1
   drop
   local.get $start
@@ -1037,7 +1039,7 @@
   if
    i32.const 0
    i32.const 464
-   i32.const 382
+   i32.const 385
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1083,7 +1085,7 @@
    if
     i32.const 0
     i32.const 464
-    i32.const 389
+    i32.const 392
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1115,7 +1117,7 @@
    if
     i32.const 0
     i32.const 464
-    i32.const 402
+    i32.const 405
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1316,8 +1318,6 @@
   i32.const 1572
   i32.add
   local.set $memStart
-  i32.const 0
-  drop
   local.get $root
   local.get $memStart
   memory.size
@@ -1359,7 +1359,7 @@
   if
    i32.const 0
    i32.const 464
-   i32.const 562
+   i32.const 555
    i32.const 3
    call $~lib/builtins/abort
    unreachable
@@ -1688,7 +1688,7 @@
   if
    i32.const 128
    i32.const 464
-   i32.const 461
+   i32.const 460
    i32.const 29
    call $~lib/builtins/abort
    unreachable
@@ -1922,8 +1922,6 @@
   (local $6 i32)
   (local $pagesWanted i32)
   (local $pagesAfter i32)
-  i32.const 0
-  drop
   local.get $size
   i32.const 256
   i32.ge_u
@@ -2133,7 +2131,7 @@
    if
     i32.const 0
     i32.const 464
-    i32.const 499
+    i32.const 492
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -2153,7 +2151,7 @@
   if
    i32.const 0
    i32.const 464
-   i32.const 501
+   i32.const 494
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/issues/1699.debug.wat
+++ b/tests/compiler/issues/1699.debug.wat
@@ -1029,11 +1029,19 @@
   local.set $end
   i32.const 0
   drop
+  i32.const 1
+  drop
   local.get $start
   i64.extend_i32_u
   local.get $endU64
-  i64.gt_u
+  i64.le_u
+  i32.eqz
   if
+   i32.const 0
+   i32.const 464
+   i32.const 386
+   i32.const 14
+   call $~lib/builtins/abort
    unreachable
   end
   local.get $start
@@ -1077,7 +1085,7 @@
    if
     i32.const 0
     i32.const 464
-    i32.const 392
+    i32.const 393
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1109,7 +1117,7 @@
    if
     i32.const 0
     i32.const 464
-    i32.const 405
+    i32.const 406
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1351,7 +1359,7 @@
   if
    i32.const 0
    i32.const 464
-   i32.const 555
+   i32.const 556
    i32.const 3
    call $~lib/builtins/abort
    unreachable
@@ -1680,7 +1688,7 @@
   if
    i32.const 128
    i32.const 464
-   i32.const 460
+   i32.const 461
    i32.const 29
    call $~lib/builtins/abort
    unreachable
@@ -2123,7 +2131,7 @@
    if
     i32.const 0
     i32.const 464
-    i32.const 492
+    i32.const 493
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -2143,7 +2151,7 @@
   if
    i32.const 0
    i32.const 464
-   i32.const 494
+   i32.const 495
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/issues/1699.release.wat
+++ b/tests/compiler/issues/1699.release.wat
@@ -649,7 +649,7 @@
   if
    i32.const 0
    i32.const 1488
-   i32.const 382
+   i32.const 385
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -674,7 +674,7 @@
    if
     i32.const 0
     i32.const 1488
-    i32.const 389
+    i32.const 392
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -701,7 +701,7 @@
    if
     i32.const 0
     i32.const 1488
-    i32.const 402
+    i32.const 405
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1064,7 +1064,7 @@
       if
        i32.const 0
        i32.const 1488
-       i32.const 562
+       i32.const 555
        i32.const 3
        call $~lib/builtins/abort
        unreachable
@@ -1299,7 +1299,7 @@
   if
    i32.const 1152
    i32.const 1488
-   i32.const 461
+   i32.const 460
    i32.const 29
    call $~lib/builtins/abort
    unreachable
@@ -1401,7 +1401,7 @@
    if
     i32.const 0
     i32.const 1488
-    i32.const 499
+    i32.const 492
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1416,7 +1416,7 @@
   if
    i32.const 0
    i32.const 1488
-   i32.const 501
+   i32.const 494
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/issues/1699.release.wat
+++ b/tests/compiler/issues/1699.release.wat
@@ -642,11 +642,16 @@
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
+  local.get $2
   local.get $1
   i64.extend_i32_u
-  local.get $2
-  i64.gt_u
+  i64.lt_u
   if
+   i32.const 0
+   i32.const 1488
+   i32.const 386
+   i32.const 14
+   call $~lib/builtins/abort
    unreachable
   end
   local.get $1
@@ -669,7 +674,7 @@
    if
     i32.const 0
     i32.const 1488
-    i32.const 392
+    i32.const 393
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -696,7 +701,7 @@
    if
     i32.const 0
     i32.const 1488
-    i32.const 405
+    i32.const 406
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1059,7 +1064,7 @@
       if
        i32.const 0
        i32.const 1488
-       i32.const 555
+       i32.const 556
        i32.const 3
        call $~lib/builtins/abort
        unreachable
@@ -1294,7 +1299,7 @@
   if
    i32.const 1152
    i32.const 1488
-   i32.const 460
+   i32.const 461
    i32.const 29
    call $~lib/builtins/abort
    unreachable
@@ -1396,7 +1401,7 @@
    if
     i32.const 0
     i32.const 1488
-    i32.const 492
+    i32.const 493
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1411,7 +1416,7 @@
   if
    i32.const 0
    i32.const 1488
-   i32.const 494
+   i32.const 495
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/issues/1699.release.wat
+++ b/tests/compiler/issues/1699.release.wat
@@ -642,16 +642,11 @@
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
-  local.get $2
   local.get $1
   i64.extend_i32_u
-  i64.lt_u
+  local.get $2
+  i64.gt_u
   if
-   i32.const 0
-   i32.const 1488
-   i32.const 385
-   i32.const 14
-   call $~lib/builtins/abort
    unreachable
   end
   local.get $1

--- a/tests/compiler/issues/2166.debug.wat
+++ b/tests/compiler/issues/2166.debug.wat
@@ -1031,11 +1031,19 @@
   local.set $end
   i32.const 0
   drop
+  i32.const 1
+  drop
   local.get $start
   i64.extend_i32_u
   local.get $endU64
-  i64.gt_u
+  i64.le_u
+  i32.eqz
   if
+   i32.const 0
+   i32.const 368
+   i32.const 386
+   i32.const 14
+   call $~lib/builtins/abort
    unreachable
   end
   local.get $start
@@ -1079,7 +1087,7 @@
    if
     i32.const 0
     i32.const 368
-    i32.const 392
+    i32.const 393
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1111,7 +1119,7 @@
    if
     i32.const 0
     i32.const 368
-    i32.const 405
+    i32.const 406
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1353,7 +1361,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 555
+   i32.const 556
    i32.const 3
    call $~lib/builtins/abort
    unreachable
@@ -1682,7 +1690,7 @@
   if
    i32.const 32
    i32.const 368
-   i32.const 460
+   i32.const 461
    i32.const 29
    call $~lib/builtins/abort
    unreachable
@@ -2125,7 +2133,7 @@
    if
     i32.const 0
     i32.const 368
-    i32.const 492
+    i32.const 493
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -2145,7 +2153,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 494
+   i32.const 495
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/issues/2166.debug.wat
+++ b/tests/compiler/issues/2166.debug.wat
@@ -1031,19 +1031,11 @@
   local.set $end
   i32.const 0
   drop
-  i32.const 1
-  drop
   local.get $start
   i64.extend_i32_u
   local.get $endU64
-  i64.le_u
-  i32.eqz
+  i64.gt_u
   if
-   i32.const 0
-   i32.const 368
-   i32.const 385
-   i32.const 14
-   call $~lib/builtins/abort
    unreachable
   end
   local.get $start

--- a/tests/compiler/issues/2166.debug.wat
+++ b/tests/compiler/issues/2166.debug.wat
@@ -1029,6 +1029,8 @@
   local.get $endU64
   i32.wrap_i64
   local.set $end
+  i32.const 0
+  drop
   i32.const 1
   drop
   local.get $start
@@ -1039,7 +1041,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 382
+   i32.const 385
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1085,7 +1087,7 @@
    if
     i32.const 0
     i32.const 368
-    i32.const 389
+    i32.const 392
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1117,7 +1119,7 @@
    if
     i32.const 0
     i32.const 368
-    i32.const 402
+    i32.const 405
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1318,8 +1320,6 @@
   i32.const 1572
   i32.add
   local.set $memStart
-  i32.const 0
-  drop
   local.get $root
   local.get $memStart
   memory.size
@@ -1361,7 +1361,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 562
+   i32.const 555
    i32.const 3
    call $~lib/builtins/abort
    unreachable
@@ -1690,7 +1690,7 @@
   if
    i32.const 32
    i32.const 368
-   i32.const 461
+   i32.const 460
    i32.const 29
    call $~lib/builtins/abort
    unreachable
@@ -1924,8 +1924,6 @@
   (local $6 i32)
   (local $pagesWanted i32)
   (local $pagesAfter i32)
-  i32.const 0
-  drop
   local.get $size
   i32.const 256
   i32.ge_u
@@ -2135,7 +2133,7 @@
    if
     i32.const 0
     i32.const 368
-    i32.const 499
+    i32.const 492
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -2155,7 +2153,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 501
+   i32.const 494
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/issues/2166.release.wat
+++ b/tests/compiler/issues/2166.release.wat
@@ -636,16 +636,11 @@
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
-  local.get $2
   local.get $1
   i64.extend_i32_u
-  i64.lt_u
+  local.get $2
+  i64.gt_u
   if
-   i32.const 0
-   i32.const 1392
-   i32.const 385
-   i32.const 14
-   call $~lib/builtins/abort
    unreachable
   end
   local.get $1

--- a/tests/compiler/issues/2166.release.wat
+++ b/tests/compiler/issues/2166.release.wat
@@ -643,7 +643,7 @@
   if
    i32.const 0
    i32.const 1392
-   i32.const 382
+   i32.const 385
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -668,7 +668,7 @@
    if
     i32.const 0
     i32.const 1392
-    i32.const 389
+    i32.const 392
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -695,7 +695,7 @@
    if
     i32.const 0
     i32.const 1392
-    i32.const 402
+    i32.const 405
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1058,7 +1058,7 @@
       if
        i32.const 0
        i32.const 1392
-       i32.const 562
+       i32.const 555
        i32.const 3
        call $~lib/builtins/abort
        unreachable
@@ -1256,7 +1256,7 @@
    if
     i32.const 0
     i32.const 1392
-    i32.const 499
+    i32.const 492
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1271,7 +1271,7 @@
   if
    i32.const 0
    i32.const 1392
-   i32.const 501
+   i32.const 494
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/issues/2166.release.wat
+++ b/tests/compiler/issues/2166.release.wat
@@ -636,11 +636,16 @@
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
+  local.get $2
   local.get $1
   i64.extend_i32_u
-  local.get $2
-  i64.gt_u
+  i64.lt_u
   if
+   i32.const 0
+   i32.const 1392
+   i32.const 386
+   i32.const 14
+   call $~lib/builtins/abort
    unreachable
   end
   local.get $1
@@ -663,7 +668,7 @@
    if
     i32.const 0
     i32.const 1392
-    i32.const 392
+    i32.const 393
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -690,7 +695,7 @@
    if
     i32.const 0
     i32.const 1392
-    i32.const 405
+    i32.const 406
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1053,7 +1058,7 @@
       if
        i32.const 0
        i32.const 1392
-       i32.const 555
+       i32.const 556
        i32.const 3
        call $~lib/builtins/abort
        unreachable
@@ -1251,7 +1256,7 @@
    if
     i32.const 0
     i32.const 1392
-    i32.const 492
+    i32.const 493
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1266,7 +1271,7 @@
   if
    i32.const 0
    i32.const 1392
-   i32.const 494
+   i32.const 495
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/issues/2322/index.debug.wat
+++ b/tests/compiler/issues/2322/index.debug.wat
@@ -1025,11 +1025,19 @@
   local.set $end
   i32.const 0
   drop
+  i32.const 1
+  drop
   local.get $start
   i64.extend_i32_u
   local.get $endU64
-  i64.gt_u
+  i64.le_u
+  i32.eqz
   if
+   i32.const 0
+   i32.const 368
+   i32.const 386
+   i32.const 14
+   call $~lib/builtins/abort
    unreachable
   end
   local.get $start
@@ -1073,7 +1081,7 @@
    if
     i32.const 0
     i32.const 368
-    i32.const 392
+    i32.const 393
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1105,7 +1113,7 @@
    if
     i32.const 0
     i32.const 368
-    i32.const 405
+    i32.const 406
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1347,7 +1355,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 555
+   i32.const 556
    i32.const 3
    call $~lib/builtins/abort
    unreachable
@@ -1676,7 +1684,7 @@
   if
    i32.const 32
    i32.const 368
-   i32.const 460
+   i32.const 461
    i32.const 29
    call $~lib/builtins/abort
    unreachable
@@ -2119,7 +2127,7 @@
    if
     i32.const 0
     i32.const 368
-    i32.const 492
+    i32.const 493
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -2139,7 +2147,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 494
+   i32.const 495
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/issues/2322/index.debug.wat
+++ b/tests/compiler/issues/2322/index.debug.wat
@@ -1023,6 +1023,8 @@
   local.get $endU64
   i32.wrap_i64
   local.set $end
+  i32.const 0
+  drop
   i32.const 1
   drop
   local.get $start
@@ -1033,7 +1035,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 382
+   i32.const 385
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1079,7 +1081,7 @@
    if
     i32.const 0
     i32.const 368
-    i32.const 389
+    i32.const 392
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1111,7 +1113,7 @@
    if
     i32.const 0
     i32.const 368
-    i32.const 402
+    i32.const 405
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1312,8 +1314,6 @@
   i32.const 1572
   i32.add
   local.set $memStart
-  i32.const 0
-  drop
   local.get $root
   local.get $memStart
   memory.size
@@ -1355,7 +1355,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 562
+   i32.const 555
    i32.const 3
    call $~lib/builtins/abort
    unreachable
@@ -1684,7 +1684,7 @@
   if
    i32.const 32
    i32.const 368
-   i32.const 461
+   i32.const 460
    i32.const 29
    call $~lib/builtins/abort
    unreachable
@@ -1918,8 +1918,6 @@
   (local $6 i32)
   (local $pagesWanted i32)
   (local $pagesAfter i32)
-  i32.const 0
-  drop
   local.get $size
   i32.const 256
   i32.ge_u
@@ -2129,7 +2127,7 @@
    if
     i32.const 0
     i32.const 368
-    i32.const 499
+    i32.const 492
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -2149,7 +2147,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 501
+   i32.const 494
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/issues/2322/index.debug.wat
+++ b/tests/compiler/issues/2322/index.debug.wat
@@ -1025,19 +1025,11 @@
   local.set $end
   i32.const 0
   drop
-  i32.const 1
-  drop
   local.get $start
   i64.extend_i32_u
   local.get $endU64
-  i64.le_u
-  i32.eqz
+  i64.gt_u
   if
-   i32.const 0
-   i32.const 368
-   i32.const 385
-   i32.const 14
-   call $~lib/builtins/abort
    unreachable
   end
   local.get $start

--- a/tests/compiler/issues/2322/index.release.wat
+++ b/tests/compiler/issues/2322/index.release.wat
@@ -626,16 +626,11 @@
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
-  local.get $2
   local.get $1
   i64.extend_i32_u
-  i64.lt_u
+  local.get $2
+  i64.gt_u
   if
-   i32.const 0
-   i32.const 1392
-   i32.const 385
-   i32.const 14
-   call $~lib/builtins/abort
    unreachable
   end
   local.get $1

--- a/tests/compiler/issues/2322/index.release.wat
+++ b/tests/compiler/issues/2322/index.release.wat
@@ -633,7 +633,7 @@
   if
    i32.const 0
    i32.const 1392
-   i32.const 382
+   i32.const 385
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -658,7 +658,7 @@
    if
     i32.const 0
     i32.const 1392
-    i32.const 389
+    i32.const 392
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -685,7 +685,7 @@
    if
     i32.const 0
     i32.const 1392
-    i32.const 402
+    i32.const 405
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1048,7 +1048,7 @@
       if
        i32.const 0
        i32.const 1392
-       i32.const 562
+       i32.const 555
        i32.const 3
        call $~lib/builtins/abort
        unreachable
@@ -1283,7 +1283,7 @@
   if
    i32.const 1056
    i32.const 1392
-   i32.const 461
+   i32.const 460
    i32.const 29
    call $~lib/builtins/abort
    unreachable
@@ -1385,7 +1385,7 @@
    if
     i32.const 0
     i32.const 1392
-    i32.const 499
+    i32.const 492
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1400,7 +1400,7 @@
   if
    i32.const 0
    i32.const 1392
-   i32.const 501
+   i32.const 494
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/issues/2322/index.release.wat
+++ b/tests/compiler/issues/2322/index.release.wat
@@ -626,11 +626,16 @@
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
+  local.get $2
   local.get $1
   i64.extend_i32_u
-  local.get $2
-  i64.gt_u
+  i64.lt_u
   if
+   i32.const 0
+   i32.const 1392
+   i32.const 386
+   i32.const 14
+   call $~lib/builtins/abort
    unreachable
   end
   local.get $1
@@ -653,7 +658,7 @@
    if
     i32.const 0
     i32.const 1392
-    i32.const 392
+    i32.const 393
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -680,7 +685,7 @@
    if
     i32.const 0
     i32.const 1392
-    i32.const 405
+    i32.const 406
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1043,7 +1048,7 @@
       if
        i32.const 0
        i32.const 1392
-       i32.const 555
+       i32.const 556
        i32.const 3
        call $~lib/builtins/abort
        unreachable
@@ -1278,7 +1283,7 @@
   if
    i32.const 1056
    i32.const 1392
-   i32.const 460
+   i32.const 461
    i32.const 29
    call $~lib/builtins/abort
    unreachable
@@ -1380,7 +1385,7 @@
    if
     i32.const 0
     i32.const 1392
-    i32.const 492
+    i32.const 493
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1395,7 +1400,7 @@
   if
    i32.const 0
    i32.const 1392
-   i32.const 494
+   i32.const 495
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/issues/2622.debug.wat
+++ b/tests/compiler/issues/2622.debug.wat
@@ -1028,11 +1028,19 @@
   local.set $end
   i32.const 0
   drop
+  i32.const 1
+  drop
   local.get $start
   i64.extend_i32_u
   local.get $endU64
-  i64.gt_u
+  i64.le_u
+  i32.eqz
   if
+   i32.const 0
+   i32.const 368
+   i32.const 386
+   i32.const 14
+   call $~lib/builtins/abort
    unreachable
   end
   local.get $start
@@ -1076,7 +1084,7 @@
    if
     i32.const 0
     i32.const 368
-    i32.const 392
+    i32.const 393
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1108,7 +1116,7 @@
    if
     i32.const 0
     i32.const 368
-    i32.const 405
+    i32.const 406
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1350,7 +1358,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 555
+   i32.const 556
    i32.const 3
    call $~lib/builtins/abort
    unreachable
@@ -1679,7 +1687,7 @@
   if
    i32.const 32
    i32.const 368
-   i32.const 460
+   i32.const 461
    i32.const 29
    call $~lib/builtins/abort
    unreachable
@@ -2122,7 +2130,7 @@
    if
     i32.const 0
     i32.const 368
-    i32.const 492
+    i32.const 493
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -2142,7 +2150,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 494
+   i32.const 495
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/issues/2622.debug.wat
+++ b/tests/compiler/issues/2622.debug.wat
@@ -1026,6 +1026,8 @@
   local.get $endU64
   i32.wrap_i64
   local.set $end
+  i32.const 0
+  drop
   i32.const 1
   drop
   local.get $start
@@ -1036,7 +1038,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 382
+   i32.const 385
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1082,7 +1084,7 @@
    if
     i32.const 0
     i32.const 368
-    i32.const 389
+    i32.const 392
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1114,7 +1116,7 @@
    if
     i32.const 0
     i32.const 368
-    i32.const 402
+    i32.const 405
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1315,8 +1317,6 @@
   i32.const 1572
   i32.add
   local.set $memStart
-  i32.const 0
-  drop
   local.get $root
   local.get $memStart
   memory.size
@@ -1358,7 +1358,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 562
+   i32.const 555
    i32.const 3
    call $~lib/builtins/abort
    unreachable
@@ -1687,7 +1687,7 @@
   if
    i32.const 32
    i32.const 368
-   i32.const 461
+   i32.const 460
    i32.const 29
    call $~lib/builtins/abort
    unreachable
@@ -1921,8 +1921,6 @@
   (local $6 i32)
   (local $pagesWanted i32)
   (local $pagesAfter i32)
-  i32.const 0
-  drop
   local.get $size
   i32.const 256
   i32.ge_u
@@ -2132,7 +2130,7 @@
    if
     i32.const 0
     i32.const 368
-    i32.const 499
+    i32.const 492
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -2152,7 +2150,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 501
+   i32.const 494
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/issues/2622.debug.wat
+++ b/tests/compiler/issues/2622.debug.wat
@@ -1028,19 +1028,11 @@
   local.set $end
   i32.const 0
   drop
-  i32.const 1
-  drop
   local.get $start
   i64.extend_i32_u
   local.get $endU64
-  i64.le_u
-  i32.eqz
+  i64.gt_u
   if
-   i32.const 0
-   i32.const 368
-   i32.const 385
-   i32.const 14
-   call $~lib/builtins/abort
    unreachable
   end
   local.get $start

--- a/tests/compiler/issues/2622.release.wat
+++ b/tests/compiler/issues/2622.release.wat
@@ -672,7 +672,7 @@
   if
    i32.const 0
    i32.const 1392
-   i32.const 382
+   i32.const 385
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -697,7 +697,7 @@
    if
     i32.const 0
     i32.const 1392
-    i32.const 389
+    i32.const 392
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -724,7 +724,7 @@
    if
     i32.const 0
     i32.const 1392
-    i32.const 402
+    i32.const 405
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1087,7 +1087,7 @@
       if
        i32.const 0
        i32.const 1392
-       i32.const 562
+       i32.const 555
        i32.const 3
        call $~lib/builtins/abort
        unreachable
@@ -1285,7 +1285,7 @@
    if
     i32.const 0
     i32.const 1392
-    i32.const 499
+    i32.const 492
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1300,7 +1300,7 @@
   if
    i32.const 0
    i32.const 1392
-   i32.const 501
+   i32.const 494
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/issues/2622.release.wat
+++ b/tests/compiler/issues/2622.release.wat
@@ -665,11 +665,16 @@
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
+  local.get $2
   local.get $1
   i64.extend_i32_u
-  local.get $2
-  i64.gt_u
+  i64.lt_u
   if
+   i32.const 0
+   i32.const 1392
+   i32.const 386
+   i32.const 14
+   call $~lib/builtins/abort
    unreachable
   end
   local.get $1
@@ -692,7 +697,7 @@
    if
     i32.const 0
     i32.const 1392
-    i32.const 392
+    i32.const 393
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -719,7 +724,7 @@
    if
     i32.const 0
     i32.const 1392
-    i32.const 405
+    i32.const 406
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1082,7 +1087,7 @@
       if
        i32.const 0
        i32.const 1392
-       i32.const 555
+       i32.const 556
        i32.const 3
        call $~lib/builtins/abort
        unreachable
@@ -1280,7 +1285,7 @@
    if
     i32.const 0
     i32.const 1392
-    i32.const 492
+    i32.const 493
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1295,7 +1300,7 @@
   if
    i32.const 0
    i32.const 1392
-   i32.const 494
+   i32.const 495
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/issues/2622.release.wat
+++ b/tests/compiler/issues/2622.release.wat
@@ -665,16 +665,11 @@
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
-  local.get $2
   local.get $1
   i64.extend_i32_u
-  i64.lt_u
+  local.get $2
+  i64.gt_u
   if
-   i32.const 0
-   i32.const 1392
-   i32.const 385
-   i32.const 14
-   call $~lib/builtins/abort
    unreachable
   end
   local.get $1

--- a/tests/compiler/logical.debug.wat
+++ b/tests/compiler/logical.debug.wat
@@ -1052,6 +1052,8 @@
   local.get $endU64
   i32.wrap_i64
   local.set $end
+  i32.const 0
+  drop
   i32.const 1
   drop
   local.get $start
@@ -1062,7 +1064,7 @@
   if
    i32.const 0
    i32.const 416
-   i32.const 382
+   i32.const 385
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1108,7 +1110,7 @@
    if
     i32.const 0
     i32.const 416
-    i32.const 389
+    i32.const 392
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1140,7 +1142,7 @@
    if
     i32.const 0
     i32.const 416
-    i32.const 402
+    i32.const 405
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1341,8 +1343,6 @@
   i32.const 1572
   i32.add
   local.set $memStart
-  i32.const 0
-  drop
   local.get $root
   local.get $memStart
   memory.size
@@ -1384,7 +1384,7 @@
   if
    i32.const 0
    i32.const 416
-   i32.const 562
+   i32.const 555
    i32.const 3
    call $~lib/builtins/abort
    unreachable
@@ -1713,7 +1713,7 @@
   if
    i32.const 80
    i32.const 416
-   i32.const 461
+   i32.const 460
    i32.const 29
    call $~lib/builtins/abort
    unreachable
@@ -1947,8 +1947,6 @@
   (local $6 i32)
   (local $pagesWanted i32)
   (local $pagesAfter i32)
-  i32.const 0
-  drop
   local.get $size
   i32.const 256
   i32.ge_u
@@ -2158,7 +2156,7 @@
    if
     i32.const 0
     i32.const 416
-    i32.const 499
+    i32.const 492
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -2178,7 +2176,7 @@
   if
    i32.const 0
    i32.const 416
-   i32.const 501
+   i32.const 494
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/logical.debug.wat
+++ b/tests/compiler/logical.debug.wat
@@ -1054,11 +1054,19 @@
   local.set $end
   i32.const 0
   drop
+  i32.const 1
+  drop
   local.get $start
   i64.extend_i32_u
   local.get $endU64
-  i64.gt_u
+  i64.le_u
+  i32.eqz
   if
+   i32.const 0
+   i32.const 416
+   i32.const 386
+   i32.const 14
+   call $~lib/builtins/abort
    unreachable
   end
   local.get $start
@@ -1102,7 +1110,7 @@
    if
     i32.const 0
     i32.const 416
-    i32.const 392
+    i32.const 393
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1134,7 +1142,7 @@
    if
     i32.const 0
     i32.const 416
-    i32.const 405
+    i32.const 406
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1376,7 +1384,7 @@
   if
    i32.const 0
    i32.const 416
-   i32.const 555
+   i32.const 556
    i32.const 3
    call $~lib/builtins/abort
    unreachable
@@ -1705,7 +1713,7 @@
   if
    i32.const 80
    i32.const 416
-   i32.const 460
+   i32.const 461
    i32.const 29
    call $~lib/builtins/abort
    unreachable
@@ -2148,7 +2156,7 @@
    if
     i32.const 0
     i32.const 416
-    i32.const 492
+    i32.const 493
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -2168,7 +2176,7 @@
   if
    i32.const 0
    i32.const 416
-   i32.const 494
+   i32.const 495
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/logical.debug.wat
+++ b/tests/compiler/logical.debug.wat
@@ -1054,19 +1054,11 @@
   local.set $end
   i32.const 0
   drop
-  i32.const 1
-  drop
   local.get $start
   i64.extend_i32_u
   local.get $endU64
-  i64.le_u
-  i32.eqz
+  i64.gt_u
   if
-   i32.const 0
-   i32.const 416
-   i32.const 385
-   i32.const 14
-   call $~lib/builtins/abort
    unreachable
   end
   local.get $start

--- a/tests/compiler/logical.release.wat
+++ b/tests/compiler/logical.release.wat
@@ -641,16 +641,11 @@
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
-  local.get $2
   local.get $1
   i64.extend_i32_u
-  i64.lt_u
+  local.get $2
+  i64.gt_u
   if
-   i32.const 0
-   i32.const 1440
-   i32.const 385
-   i32.const 14
-   call $~lib/builtins/abort
    unreachable
   end
   local.get $1

--- a/tests/compiler/logical.release.wat
+++ b/tests/compiler/logical.release.wat
@@ -648,7 +648,7 @@
   if
    i32.const 0
    i32.const 1440
-   i32.const 382
+   i32.const 385
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -673,7 +673,7 @@
    if
     i32.const 0
     i32.const 1440
-    i32.const 389
+    i32.const 392
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -700,7 +700,7 @@
    if
     i32.const 0
     i32.const 1440
-    i32.const 402
+    i32.const 405
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1063,7 +1063,7 @@
       if
        i32.const 0
        i32.const 1440
-       i32.const 562
+       i32.const 555
        i32.const 3
        call $~lib/builtins/abort
        unreachable
@@ -1261,7 +1261,7 @@
    if
     i32.const 0
     i32.const 1440
-    i32.const 499
+    i32.const 492
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1276,7 +1276,7 @@
   if
    i32.const 0
    i32.const 1440
-   i32.const 501
+   i32.const 494
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/logical.release.wat
+++ b/tests/compiler/logical.release.wat
@@ -641,11 +641,16 @@
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
+  local.get $2
   local.get $1
   i64.extend_i32_u
-  local.get $2
-  i64.gt_u
+  i64.lt_u
   if
+   i32.const 0
+   i32.const 1440
+   i32.const 386
+   i32.const 14
+   call $~lib/builtins/abort
    unreachable
   end
   local.get $1
@@ -668,7 +673,7 @@
    if
     i32.const 0
     i32.const 1440
-    i32.const 392
+    i32.const 393
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -695,7 +700,7 @@
    if
     i32.const 0
     i32.const 1440
-    i32.const 405
+    i32.const 406
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1058,7 +1063,7 @@
       if
        i32.const 0
        i32.const 1440
-       i32.const 555
+       i32.const 556
        i32.const 3
        call $~lib/builtins/abort
        unreachable
@@ -1256,7 +1261,7 @@
    if
     i32.const 0
     i32.const 1440
-    i32.const 492
+    i32.const 493
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1271,7 +1276,7 @@
   if
    i32.const 0
    i32.const 1440
-   i32.const 494
+   i32.const 495
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/managed-cast.debug.wat
+++ b/tests/compiler/managed-cast.debug.wat
@@ -1027,19 +1027,11 @@
   local.set $end
   i32.const 0
   drop
-  i32.const 1
-  drop
   local.get $start
   i64.extend_i32_u
   local.get $endU64
-  i64.le_u
-  i32.eqz
+  i64.gt_u
   if
-   i32.const 0
-   i32.const 368
-   i32.const 385
-   i32.const 14
-   call $~lib/builtins/abort
    unreachable
   end
   local.get $start

--- a/tests/compiler/managed-cast.debug.wat
+++ b/tests/compiler/managed-cast.debug.wat
@@ -1027,11 +1027,19 @@
   local.set $end
   i32.const 0
   drop
+  i32.const 1
+  drop
   local.get $start
   i64.extend_i32_u
   local.get $endU64
-  i64.gt_u
+  i64.le_u
+  i32.eqz
   if
+   i32.const 0
+   i32.const 368
+   i32.const 386
+   i32.const 14
+   call $~lib/builtins/abort
    unreachable
   end
   local.get $start
@@ -1075,7 +1083,7 @@
    if
     i32.const 0
     i32.const 368
-    i32.const 392
+    i32.const 393
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1107,7 +1115,7 @@
    if
     i32.const 0
     i32.const 368
-    i32.const 405
+    i32.const 406
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1349,7 +1357,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 555
+   i32.const 556
    i32.const 3
    call $~lib/builtins/abort
    unreachable
@@ -1678,7 +1686,7 @@
   if
    i32.const 32
    i32.const 368
-   i32.const 460
+   i32.const 461
    i32.const 29
    call $~lib/builtins/abort
    unreachable
@@ -2121,7 +2129,7 @@
    if
     i32.const 0
     i32.const 368
-    i32.const 492
+    i32.const 493
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -2141,7 +2149,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 494
+   i32.const 495
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/managed-cast.debug.wat
+++ b/tests/compiler/managed-cast.debug.wat
@@ -1025,6 +1025,8 @@
   local.get $endU64
   i32.wrap_i64
   local.set $end
+  i32.const 0
+  drop
   i32.const 1
   drop
   local.get $start
@@ -1035,7 +1037,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 382
+   i32.const 385
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1081,7 +1083,7 @@
    if
     i32.const 0
     i32.const 368
-    i32.const 389
+    i32.const 392
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1113,7 +1115,7 @@
    if
     i32.const 0
     i32.const 368
-    i32.const 402
+    i32.const 405
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1314,8 +1316,6 @@
   i32.const 1572
   i32.add
   local.set $memStart
-  i32.const 0
-  drop
   local.get $root
   local.get $memStart
   memory.size
@@ -1357,7 +1357,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 562
+   i32.const 555
    i32.const 3
    call $~lib/builtins/abort
    unreachable
@@ -1686,7 +1686,7 @@
   if
    i32.const 32
    i32.const 368
-   i32.const 461
+   i32.const 460
    i32.const 29
    call $~lib/builtins/abort
    unreachable
@@ -1920,8 +1920,6 @@
   (local $6 i32)
   (local $pagesWanted i32)
   (local $pagesAfter i32)
-  i32.const 0
-  drop
   local.get $size
   i32.const 256
   i32.ge_u
@@ -2131,7 +2129,7 @@
    if
     i32.const 0
     i32.const 368
-    i32.const 499
+    i32.const 492
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -2151,7 +2149,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 501
+   i32.const 494
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/managed-cast.release.wat
+++ b/tests/compiler/managed-cast.release.wat
@@ -631,16 +631,11 @@
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
-  local.get $2
   local.get $1
   i64.extend_i32_u
-  i64.lt_u
+  local.get $2
+  i64.gt_u
   if
-   i32.const 0
-   i32.const 1392
-   i32.const 385
-   i32.const 14
-   call $~lib/builtins/abort
    unreachable
   end
   local.get $1

--- a/tests/compiler/managed-cast.release.wat
+++ b/tests/compiler/managed-cast.release.wat
@@ -631,11 +631,16 @@
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
+  local.get $2
   local.get $1
   i64.extend_i32_u
-  local.get $2
-  i64.gt_u
+  i64.lt_u
   if
+   i32.const 0
+   i32.const 1392
+   i32.const 386
+   i32.const 14
+   call $~lib/builtins/abort
    unreachable
   end
   local.get $1
@@ -658,7 +663,7 @@
    if
     i32.const 0
     i32.const 1392
-    i32.const 392
+    i32.const 393
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -685,7 +690,7 @@
    if
     i32.const 0
     i32.const 1392
-    i32.const 405
+    i32.const 406
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1048,7 +1053,7 @@
       if
        i32.const 0
        i32.const 1392
-       i32.const 555
+       i32.const 556
        i32.const 3
        call $~lib/builtins/abort
        unreachable
@@ -1246,7 +1251,7 @@
    if
     i32.const 0
     i32.const 1392
-    i32.const 492
+    i32.const 493
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1261,7 +1266,7 @@
   if
    i32.const 0
    i32.const 1392
-   i32.const 494
+   i32.const 495
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/managed-cast.release.wat
+++ b/tests/compiler/managed-cast.release.wat
@@ -638,7 +638,7 @@
   if
    i32.const 0
    i32.const 1392
-   i32.const 382
+   i32.const 385
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -663,7 +663,7 @@
    if
     i32.const 0
     i32.const 1392
-    i32.const 389
+    i32.const 392
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -690,7 +690,7 @@
    if
     i32.const 0
     i32.const 1392
-    i32.const 402
+    i32.const 405
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1053,7 +1053,7 @@
       if
        i32.const 0
        i32.const 1392
-       i32.const 562
+       i32.const 555
        i32.const 3
        call $~lib/builtins/abort
        unreachable
@@ -1251,7 +1251,7 @@
    if
     i32.const 0
     i32.const 1392
-    i32.const 499
+    i32.const 492
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1266,7 +1266,7 @@
   if
    i32.const 0
    i32.const 1392
-   i32.const 501
+   i32.const 494
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/new.debug.wat
+++ b/tests/compiler/new.debug.wat
@@ -1030,11 +1030,19 @@
   local.set $end
   i32.const 0
   drop
+  i32.const 1
+  drop
   local.get $start
   i64.extend_i32_u
   local.get $endU64
-  i64.gt_u
+  i64.le_u
+  i32.eqz
   if
+   i32.const 0
+   i32.const 368
+   i32.const 386
+   i32.const 14
+   call $~lib/builtins/abort
    unreachable
   end
   local.get $start
@@ -1078,7 +1086,7 @@
    if
     i32.const 0
     i32.const 368
-    i32.const 392
+    i32.const 393
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1110,7 +1118,7 @@
    if
     i32.const 0
     i32.const 368
-    i32.const 405
+    i32.const 406
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1352,7 +1360,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 555
+   i32.const 556
    i32.const 3
    call $~lib/builtins/abort
    unreachable
@@ -1681,7 +1689,7 @@
   if
    i32.const 32
    i32.const 368
-   i32.const 460
+   i32.const 461
    i32.const 29
    call $~lib/builtins/abort
    unreachable
@@ -2124,7 +2132,7 @@
    if
     i32.const 0
     i32.const 368
-    i32.const 492
+    i32.const 493
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -2144,7 +2152,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 494
+   i32.const 495
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/new.debug.wat
+++ b/tests/compiler/new.debug.wat
@@ -1030,19 +1030,11 @@
   local.set $end
   i32.const 0
   drop
-  i32.const 1
-  drop
   local.get $start
   i64.extend_i32_u
   local.get $endU64
-  i64.le_u
-  i32.eqz
+  i64.gt_u
   if
-   i32.const 0
-   i32.const 368
-   i32.const 385
-   i32.const 14
-   call $~lib/builtins/abort
    unreachable
   end
   local.get $start

--- a/tests/compiler/new.debug.wat
+++ b/tests/compiler/new.debug.wat
@@ -1028,6 +1028,8 @@
   local.get $endU64
   i32.wrap_i64
   local.set $end
+  i32.const 0
+  drop
   i32.const 1
   drop
   local.get $start
@@ -1038,7 +1040,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 382
+   i32.const 385
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1084,7 +1086,7 @@
    if
     i32.const 0
     i32.const 368
-    i32.const 389
+    i32.const 392
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1116,7 +1118,7 @@
    if
     i32.const 0
     i32.const 368
-    i32.const 402
+    i32.const 405
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1317,8 +1319,6 @@
   i32.const 1572
   i32.add
   local.set $memStart
-  i32.const 0
-  drop
   local.get $root
   local.get $memStart
   memory.size
@@ -1360,7 +1360,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 562
+   i32.const 555
    i32.const 3
    call $~lib/builtins/abort
    unreachable
@@ -1689,7 +1689,7 @@
   if
    i32.const 32
    i32.const 368
-   i32.const 461
+   i32.const 460
    i32.const 29
    call $~lib/builtins/abort
    unreachable
@@ -1923,8 +1923,6 @@
   (local $6 i32)
   (local $pagesWanted i32)
   (local $pagesAfter i32)
-  i32.const 0
-  drop
   local.get $size
   i32.const 256
   i32.ge_u
@@ -2134,7 +2132,7 @@
    if
     i32.const 0
     i32.const 368
-    i32.const 499
+    i32.const 492
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -2154,7 +2152,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 501
+   i32.const 494
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/new.release.wat
+++ b/tests/compiler/new.release.wat
@@ -674,7 +674,7 @@
   if
    i32.const 0
    i32.const 1392
-   i32.const 382
+   i32.const 385
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -699,7 +699,7 @@
    if
     i32.const 0
     i32.const 1392
-    i32.const 389
+    i32.const 392
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -726,7 +726,7 @@
    if
     i32.const 0
     i32.const 1392
-    i32.const 402
+    i32.const 405
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1089,7 +1089,7 @@
       if
        i32.const 0
        i32.const 1392
-       i32.const 562
+       i32.const 555
        i32.const 3
        call $~lib/builtins/abort
        unreachable
@@ -1287,7 +1287,7 @@
    if
     i32.const 0
     i32.const 1392
-    i32.const 499
+    i32.const 492
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1302,7 +1302,7 @@
   if
    i32.const 0
    i32.const 1392
-   i32.const 501
+   i32.const 494
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/new.release.wat
+++ b/tests/compiler/new.release.wat
@@ -667,11 +667,16 @@
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
+  local.get $2
   local.get $1
   i64.extend_i32_u
-  local.get $2
-  i64.gt_u
+  i64.lt_u
   if
+   i32.const 0
+   i32.const 1392
+   i32.const 386
+   i32.const 14
+   call $~lib/builtins/abort
    unreachable
   end
   local.get $1
@@ -694,7 +699,7 @@
    if
     i32.const 0
     i32.const 1392
-    i32.const 392
+    i32.const 393
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -721,7 +726,7 @@
    if
     i32.const 0
     i32.const 1392
-    i32.const 405
+    i32.const 406
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1084,7 +1089,7 @@
       if
        i32.const 0
        i32.const 1392
-       i32.const 555
+       i32.const 556
        i32.const 3
        call $~lib/builtins/abort
        unreachable
@@ -1282,7 +1287,7 @@
    if
     i32.const 0
     i32.const 1392
-    i32.const 492
+    i32.const 493
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1297,7 +1302,7 @@
   if
    i32.const 0
    i32.const 1392
-   i32.const 494
+   i32.const 495
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/new.release.wat
+++ b/tests/compiler/new.release.wat
@@ -667,16 +667,11 @@
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
-  local.get $2
   local.get $1
   i64.extend_i32_u
-  i64.lt_u
+  local.get $2
+  i64.gt_u
   if
-   i32.const 0
-   i32.const 1392
-   i32.const 385
-   i32.const 14
-   call $~lib/builtins/abort
    unreachable
   end
   local.get $1

--- a/tests/compiler/object-literal.debug.wat
+++ b/tests/compiler/object-literal.debug.wat
@@ -1120,6 +1120,8 @@
   local.get $endU64
   i32.wrap_i64
   local.set $end
+  i32.const 0
+  drop
   i32.const 1
   drop
   local.get $start
@@ -1130,7 +1132,7 @@
   if
    i32.const 0
    i32.const 416
-   i32.const 382
+   i32.const 385
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1176,7 +1178,7 @@
    if
     i32.const 0
     i32.const 416
-    i32.const 389
+    i32.const 392
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1208,7 +1210,7 @@
    if
     i32.const 0
     i32.const 416
-    i32.const 402
+    i32.const 405
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1409,8 +1411,6 @@
   i32.const 1572
   i32.add
   local.set $memStart
-  i32.const 0
-  drop
   local.get $root
   local.get $memStart
   memory.size
@@ -1452,7 +1452,7 @@
   if
    i32.const 0
    i32.const 416
-   i32.const 562
+   i32.const 555
    i32.const 3
    call $~lib/builtins/abort
    unreachable
@@ -1781,7 +1781,7 @@
   if
    i32.const 288
    i32.const 416
-   i32.const 461
+   i32.const 460
    i32.const 29
    call $~lib/builtins/abort
    unreachable
@@ -2015,8 +2015,6 @@
   (local $6 i32)
   (local $pagesWanted i32)
   (local $pagesAfter i32)
-  i32.const 0
-  drop
   local.get $size
   i32.const 256
   i32.ge_u
@@ -2226,7 +2224,7 @@
    if
     i32.const 0
     i32.const 416
-    i32.const 499
+    i32.const 492
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -2246,7 +2244,7 @@
   if
    i32.const 0
    i32.const 416
-   i32.const 501
+   i32.const 494
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/object-literal.debug.wat
+++ b/tests/compiler/object-literal.debug.wat
@@ -1122,11 +1122,19 @@
   local.set $end
   i32.const 0
   drop
+  i32.const 1
+  drop
   local.get $start
   i64.extend_i32_u
   local.get $endU64
-  i64.gt_u
+  i64.le_u
+  i32.eqz
   if
+   i32.const 0
+   i32.const 416
+   i32.const 386
+   i32.const 14
+   call $~lib/builtins/abort
    unreachable
   end
   local.get $start
@@ -1170,7 +1178,7 @@
    if
     i32.const 0
     i32.const 416
-    i32.const 392
+    i32.const 393
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1202,7 +1210,7 @@
    if
     i32.const 0
     i32.const 416
-    i32.const 405
+    i32.const 406
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1444,7 +1452,7 @@
   if
    i32.const 0
    i32.const 416
-   i32.const 555
+   i32.const 556
    i32.const 3
    call $~lib/builtins/abort
    unreachable
@@ -1773,7 +1781,7 @@
   if
    i32.const 288
    i32.const 416
-   i32.const 460
+   i32.const 461
    i32.const 29
    call $~lib/builtins/abort
    unreachable
@@ -2216,7 +2224,7 @@
    if
     i32.const 0
     i32.const 416
-    i32.const 492
+    i32.const 493
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -2236,7 +2244,7 @@
   if
    i32.const 0
    i32.const 416
-   i32.const 494
+   i32.const 495
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/object-literal.debug.wat
+++ b/tests/compiler/object-literal.debug.wat
@@ -1122,19 +1122,11 @@
   local.set $end
   i32.const 0
   drop
-  i32.const 1
-  drop
   local.get $start
   i64.extend_i32_u
   local.get $endU64
-  i64.le_u
-  i32.eqz
+  i64.gt_u
   if
-   i32.const 0
-   i32.const 416
-   i32.const 385
-   i32.const 14
-   call $~lib/builtins/abort
    unreachable
   end
   local.get $start

--- a/tests/compiler/object-literal.release.wat
+++ b/tests/compiler/object-literal.release.wat
@@ -699,11 +699,16 @@
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
+  local.get $2
   local.get $1
   i64.extend_i32_u
-  local.get $2
-  i64.gt_u
+  i64.lt_u
   if
+   i32.const 0
+   i32.const 1440
+   i32.const 386
+   i32.const 14
+   call $~lib/builtins/abort
    unreachable
   end
   local.get $1
@@ -726,7 +731,7 @@
    if
     i32.const 0
     i32.const 1440
-    i32.const 392
+    i32.const 393
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -753,7 +758,7 @@
    if
     i32.const 0
     i32.const 1440
-    i32.const 405
+    i32.const 406
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -921,7 +926,7 @@
   if
    i32.const 0
    i32.const 1440
-   i32.const 555
+   i32.const 556
    i32.const 3
    call $~lib/builtins/abort
    unreachable
@@ -1290,7 +1295,7 @@
   if
    i32.const 1312
    i32.const 1440
-   i32.const 460
+   i32.const 461
    i32.const 29
    call $~lib/builtins/abort
    unreachable
@@ -1392,7 +1397,7 @@
    if
     i32.const 0
     i32.const 1440
-    i32.const 492
+    i32.const 493
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1407,7 +1412,7 @@
   if
    i32.const 0
    i32.const 1440
-   i32.const 494
+   i32.const 495
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/object-literal.release.wat
+++ b/tests/compiler/object-literal.release.wat
@@ -699,16 +699,11 @@
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
-  local.get $2
   local.get $1
   i64.extend_i32_u
-  i64.lt_u
+  local.get $2
+  i64.gt_u
   if
-   i32.const 0
-   i32.const 1440
-   i32.const 385
-   i32.const 14
-   call $~lib/builtins/abort
    unreachable
   end
   local.get $1

--- a/tests/compiler/object-literal.release.wat
+++ b/tests/compiler/object-literal.release.wat
@@ -706,7 +706,7 @@
   if
    i32.const 0
    i32.const 1440
-   i32.const 382
+   i32.const 385
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -731,7 +731,7 @@
    if
     i32.const 0
     i32.const 1440
-    i32.const 389
+    i32.const 392
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -758,7 +758,7 @@
    if
     i32.const 0
     i32.const 1440
-    i32.const 402
+    i32.const 405
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -926,7 +926,7 @@
   if
    i32.const 0
    i32.const 1440
-   i32.const 562
+   i32.const 555
    i32.const 3
    call $~lib/builtins/abort
    unreachable
@@ -1295,7 +1295,7 @@
   if
    i32.const 1312
    i32.const 1440
-   i32.const 461
+   i32.const 460
    i32.const 29
    call $~lib/builtins/abort
    unreachable
@@ -1397,7 +1397,7 @@
    if
     i32.const 0
     i32.const 1440
-    i32.const 499
+    i32.const 492
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1412,7 +1412,7 @@
   if
    i32.const 0
    i32.const 1440
-   i32.const 501
+   i32.const 494
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/optional-typeparameters.debug.wat
+++ b/tests/compiler/optional-typeparameters.debug.wat
@@ -1038,19 +1038,11 @@
   local.set $end
   i32.const 0
   drop
-  i32.const 1
-  drop
   local.get $start
   i64.extend_i32_u
   local.get $endU64
-  i64.le_u
-  i32.eqz
+  i64.gt_u
   if
-   i32.const 0
-   i32.const 368
-   i32.const 385
-   i32.const 14
-   call $~lib/builtins/abort
    unreachable
   end
   local.get $start

--- a/tests/compiler/optional-typeparameters.debug.wat
+++ b/tests/compiler/optional-typeparameters.debug.wat
@@ -1038,11 +1038,19 @@
   local.set $end
   i32.const 0
   drop
+  i32.const 1
+  drop
   local.get $start
   i64.extend_i32_u
   local.get $endU64
-  i64.gt_u
+  i64.le_u
+  i32.eqz
   if
+   i32.const 0
+   i32.const 368
+   i32.const 386
+   i32.const 14
+   call $~lib/builtins/abort
    unreachable
   end
   local.get $start
@@ -1086,7 +1094,7 @@
    if
     i32.const 0
     i32.const 368
-    i32.const 392
+    i32.const 393
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1118,7 +1126,7 @@
    if
     i32.const 0
     i32.const 368
-    i32.const 405
+    i32.const 406
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1360,7 +1368,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 555
+   i32.const 556
    i32.const 3
    call $~lib/builtins/abort
    unreachable
@@ -1689,7 +1697,7 @@
   if
    i32.const 32
    i32.const 368
-   i32.const 460
+   i32.const 461
    i32.const 29
    call $~lib/builtins/abort
    unreachable
@@ -2132,7 +2140,7 @@
    if
     i32.const 0
     i32.const 368
-    i32.const 492
+    i32.const 493
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -2152,7 +2160,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 494
+   i32.const 495
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/optional-typeparameters.debug.wat
+++ b/tests/compiler/optional-typeparameters.debug.wat
@@ -1036,6 +1036,8 @@
   local.get $endU64
   i32.wrap_i64
   local.set $end
+  i32.const 0
+  drop
   i32.const 1
   drop
   local.get $start
@@ -1046,7 +1048,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 382
+   i32.const 385
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1092,7 +1094,7 @@
    if
     i32.const 0
     i32.const 368
-    i32.const 389
+    i32.const 392
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1124,7 +1126,7 @@
    if
     i32.const 0
     i32.const 368
-    i32.const 402
+    i32.const 405
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1325,8 +1327,6 @@
   i32.const 1572
   i32.add
   local.set $memStart
-  i32.const 0
-  drop
   local.get $root
   local.get $memStart
   memory.size
@@ -1368,7 +1368,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 562
+   i32.const 555
    i32.const 3
    call $~lib/builtins/abort
    unreachable
@@ -1697,7 +1697,7 @@
   if
    i32.const 32
    i32.const 368
-   i32.const 461
+   i32.const 460
    i32.const 29
    call $~lib/builtins/abort
    unreachable
@@ -1931,8 +1931,6 @@
   (local $6 i32)
   (local $pagesWanted i32)
   (local $pagesAfter i32)
-  i32.const 0
-  drop
   local.get $size
   i32.const 256
   i32.ge_u
@@ -2142,7 +2140,7 @@
    if
     i32.const 0
     i32.const 368
-    i32.const 499
+    i32.const 492
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -2162,7 +2160,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 501
+   i32.const 494
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/optional-typeparameters.release.wat
+++ b/tests/compiler/optional-typeparameters.release.wat
@@ -653,11 +653,16 @@
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
+  local.get $2
   local.get $1
   i64.extend_i32_u
-  local.get $2
-  i64.gt_u
+  i64.lt_u
   if
+   i32.const 0
+   i32.const 1392
+   i32.const 386
+   i32.const 14
+   call $~lib/builtins/abort
    unreachable
   end
   local.get $1
@@ -680,7 +685,7 @@
    if
     i32.const 0
     i32.const 1392
-    i32.const 392
+    i32.const 393
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -707,7 +712,7 @@
    if
     i32.const 0
     i32.const 1392
-    i32.const 405
+    i32.const 406
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1070,7 +1075,7 @@
       if
        i32.const 0
        i32.const 1392
-       i32.const 555
+       i32.const 556
        i32.const 3
        call $~lib/builtins/abort
        unreachable
@@ -1268,7 +1273,7 @@
    if
     i32.const 0
     i32.const 1392
-    i32.const 492
+    i32.const 493
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1283,7 +1288,7 @@
   if
    i32.const 0
    i32.const 1392
-   i32.const 494
+   i32.const 495
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/optional-typeparameters.release.wat
+++ b/tests/compiler/optional-typeparameters.release.wat
@@ -660,7 +660,7 @@
   if
    i32.const 0
    i32.const 1392
-   i32.const 382
+   i32.const 385
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -685,7 +685,7 @@
    if
     i32.const 0
     i32.const 1392
-    i32.const 389
+    i32.const 392
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -712,7 +712,7 @@
    if
     i32.const 0
     i32.const 1392
-    i32.const 402
+    i32.const 405
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1075,7 +1075,7 @@
       if
        i32.const 0
        i32.const 1392
-       i32.const 562
+       i32.const 555
        i32.const 3
        call $~lib/builtins/abort
        unreachable
@@ -1273,7 +1273,7 @@
    if
     i32.const 0
     i32.const 1392
-    i32.const 499
+    i32.const 492
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1288,7 +1288,7 @@
   if
    i32.const 0
    i32.const 1392
-   i32.const 501
+   i32.const 494
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/optional-typeparameters.release.wat
+++ b/tests/compiler/optional-typeparameters.release.wat
@@ -653,16 +653,11 @@
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
-  local.get $2
   local.get $1
   i64.extend_i32_u
-  i64.lt_u
+  local.get $2
+  i64.gt_u
   if
-   i32.const 0
-   i32.const 1392
-   i32.const 385
-   i32.const 14
-   call $~lib/builtins/abort
    unreachable
   end
   local.get $1

--- a/tests/compiler/reexport.debug.wat
+++ b/tests/compiler/reexport.debug.wat
@@ -1071,19 +1071,11 @@
   local.set $end
   i32.const 0
   drop
-  i32.const 1
-  drop
   local.get $start
   i64.extend_i32_u
   local.get $endU64
-  i64.le_u
-  i32.eqz
+  i64.gt_u
   if
-   i32.const 0
-   i32.const 416
-   i32.const 385
-   i32.const 14
-   call $~lib/builtins/abort
    unreachable
   end
   local.get $start

--- a/tests/compiler/reexport.debug.wat
+++ b/tests/compiler/reexport.debug.wat
@@ -1071,11 +1071,19 @@
   local.set $end
   i32.const 0
   drop
+  i32.const 1
+  drop
   local.get $start
   i64.extend_i32_u
   local.get $endU64
-  i64.gt_u
+  i64.le_u
+  i32.eqz
   if
+   i32.const 0
+   i32.const 416
+   i32.const 386
+   i32.const 14
+   call $~lib/builtins/abort
    unreachable
   end
   local.get $start
@@ -1119,7 +1127,7 @@
    if
     i32.const 0
     i32.const 416
-    i32.const 392
+    i32.const 393
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1151,7 +1159,7 @@
    if
     i32.const 0
     i32.const 416
-    i32.const 405
+    i32.const 406
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1393,7 +1401,7 @@
   if
    i32.const 0
    i32.const 416
-   i32.const 555
+   i32.const 556
    i32.const 3
    call $~lib/builtins/abort
    unreachable
@@ -1722,7 +1730,7 @@
   if
    i32.const 80
    i32.const 416
-   i32.const 460
+   i32.const 461
    i32.const 29
    call $~lib/builtins/abort
    unreachable
@@ -2165,7 +2173,7 @@
    if
     i32.const 0
     i32.const 416
-    i32.const 492
+    i32.const 493
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -2185,7 +2193,7 @@
   if
    i32.const 0
    i32.const 416
-   i32.const 494
+   i32.const 495
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/reexport.debug.wat
+++ b/tests/compiler/reexport.debug.wat
@@ -1069,6 +1069,8 @@
   local.get $endU64
   i32.wrap_i64
   local.set $end
+  i32.const 0
+  drop
   i32.const 1
   drop
   local.get $start
@@ -1079,7 +1081,7 @@
   if
    i32.const 0
    i32.const 416
-   i32.const 382
+   i32.const 385
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1125,7 +1127,7 @@
    if
     i32.const 0
     i32.const 416
-    i32.const 389
+    i32.const 392
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1157,7 +1159,7 @@
    if
     i32.const 0
     i32.const 416
-    i32.const 402
+    i32.const 405
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1358,8 +1360,6 @@
   i32.const 1572
   i32.add
   local.set $memStart
-  i32.const 0
-  drop
   local.get $root
   local.get $memStart
   memory.size
@@ -1401,7 +1401,7 @@
   if
    i32.const 0
    i32.const 416
-   i32.const 562
+   i32.const 555
    i32.const 3
    call $~lib/builtins/abort
    unreachable
@@ -1730,7 +1730,7 @@
   if
    i32.const 80
    i32.const 416
-   i32.const 461
+   i32.const 460
    i32.const 29
    call $~lib/builtins/abort
    unreachable
@@ -1964,8 +1964,6 @@
   (local $6 i32)
   (local $pagesWanted i32)
   (local $pagesAfter i32)
-  i32.const 0
-  drop
   local.get $size
   i32.const 256
   i32.ge_u
@@ -2175,7 +2173,7 @@
    if
     i32.const 0
     i32.const 416
-    i32.const 499
+    i32.const 492
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -2195,7 +2193,7 @@
   if
    i32.const 0
    i32.const 416
-   i32.const 501
+   i32.const 494
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/reexport.release.wat
+++ b/tests/compiler/reexport.release.wat
@@ -660,16 +660,11 @@
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
-  local.get $2
   local.get $1
   i64.extend_i32_u
-  i64.lt_u
+  local.get $2
+  i64.gt_u
   if
-   i32.const 0
-   i32.const 1440
-   i32.const 385
-   i32.const 14
-   call $~lib/builtins/abort
    unreachable
   end
   local.get $1

--- a/tests/compiler/reexport.release.wat
+++ b/tests/compiler/reexport.release.wat
@@ -660,11 +660,16 @@
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
+  local.get $2
   local.get $1
   i64.extend_i32_u
-  local.get $2
-  i64.gt_u
+  i64.lt_u
   if
+   i32.const 0
+   i32.const 1440
+   i32.const 386
+   i32.const 14
+   call $~lib/builtins/abort
    unreachable
   end
   local.get $1
@@ -687,7 +692,7 @@
    if
     i32.const 0
     i32.const 1440
-    i32.const 392
+    i32.const 393
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -714,7 +719,7 @@
    if
     i32.const 0
     i32.const 1440
-    i32.const 405
+    i32.const 406
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1077,7 +1082,7 @@
       if
        i32.const 0
        i32.const 1440
-       i32.const 555
+       i32.const 556
        i32.const 3
        call $~lib/builtins/abort
        unreachable
@@ -1275,7 +1280,7 @@
    if
     i32.const 0
     i32.const 1440
-    i32.const 492
+    i32.const 493
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1290,7 +1295,7 @@
   if
    i32.const 0
    i32.const 1440
-   i32.const 494
+   i32.const 495
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/reexport.release.wat
+++ b/tests/compiler/reexport.release.wat
@@ -667,7 +667,7 @@
   if
    i32.const 0
    i32.const 1440
-   i32.const 382
+   i32.const 385
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -692,7 +692,7 @@
    if
     i32.const 0
     i32.const 1440
-    i32.const 389
+    i32.const 392
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -719,7 +719,7 @@
    if
     i32.const 0
     i32.const 1440
-    i32.const 402
+    i32.const 405
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1082,7 +1082,7 @@
       if
        i32.const 0
        i32.const 1440
-       i32.const 562
+       i32.const 555
        i32.const 3
        call $~lib/builtins/abort
        unreachable
@@ -1280,7 +1280,7 @@
    if
     i32.const 0
     i32.const 1440
-    i32.const 499
+    i32.const 492
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1295,7 +1295,7 @@
   if
    i32.const 0
    i32.const 1440
-   i32.const 501
+   i32.const 494
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/rereexport.debug.wat
+++ b/tests/compiler/rereexport.debug.wat
@@ -1062,6 +1062,8 @@
   local.get $endU64
   i32.wrap_i64
   local.set $end
+  i32.const 0
+  drop
   i32.const 1
   drop
   local.get $start
@@ -1072,7 +1074,7 @@
   if
    i32.const 0
    i32.const 416
-   i32.const 382
+   i32.const 385
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1118,7 +1120,7 @@
    if
     i32.const 0
     i32.const 416
-    i32.const 389
+    i32.const 392
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1150,7 +1152,7 @@
    if
     i32.const 0
     i32.const 416
-    i32.const 402
+    i32.const 405
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1351,8 +1353,6 @@
   i32.const 1572
   i32.add
   local.set $memStart
-  i32.const 0
-  drop
   local.get $root
   local.get $memStart
   memory.size
@@ -1394,7 +1394,7 @@
   if
    i32.const 0
    i32.const 416
-   i32.const 562
+   i32.const 555
    i32.const 3
    call $~lib/builtins/abort
    unreachable
@@ -1723,7 +1723,7 @@
   if
    i32.const 80
    i32.const 416
-   i32.const 461
+   i32.const 460
    i32.const 29
    call $~lib/builtins/abort
    unreachable
@@ -1957,8 +1957,6 @@
   (local $6 i32)
   (local $pagesWanted i32)
   (local $pagesAfter i32)
-  i32.const 0
-  drop
   local.get $size
   i32.const 256
   i32.ge_u
@@ -2168,7 +2166,7 @@
    if
     i32.const 0
     i32.const 416
-    i32.const 499
+    i32.const 492
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -2188,7 +2186,7 @@
   if
    i32.const 0
    i32.const 416
-   i32.const 501
+   i32.const 494
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/rereexport.debug.wat
+++ b/tests/compiler/rereexport.debug.wat
@@ -1064,19 +1064,11 @@
   local.set $end
   i32.const 0
   drop
-  i32.const 1
-  drop
   local.get $start
   i64.extend_i32_u
   local.get $endU64
-  i64.le_u
-  i32.eqz
+  i64.gt_u
   if
-   i32.const 0
-   i32.const 416
-   i32.const 385
-   i32.const 14
-   call $~lib/builtins/abort
    unreachable
   end
   local.get $start

--- a/tests/compiler/rereexport.debug.wat
+++ b/tests/compiler/rereexport.debug.wat
@@ -1064,11 +1064,19 @@
   local.set $end
   i32.const 0
   drop
+  i32.const 1
+  drop
   local.get $start
   i64.extend_i32_u
   local.get $endU64
-  i64.gt_u
+  i64.le_u
+  i32.eqz
   if
+   i32.const 0
+   i32.const 416
+   i32.const 386
+   i32.const 14
+   call $~lib/builtins/abort
    unreachable
   end
   local.get $start
@@ -1112,7 +1120,7 @@
    if
     i32.const 0
     i32.const 416
-    i32.const 392
+    i32.const 393
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1144,7 +1152,7 @@
    if
     i32.const 0
     i32.const 416
-    i32.const 405
+    i32.const 406
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1386,7 +1394,7 @@
   if
    i32.const 0
    i32.const 416
-   i32.const 555
+   i32.const 556
    i32.const 3
    call $~lib/builtins/abort
    unreachable
@@ -1715,7 +1723,7 @@
   if
    i32.const 80
    i32.const 416
-   i32.const 460
+   i32.const 461
    i32.const 29
    call $~lib/builtins/abort
    unreachable
@@ -2158,7 +2166,7 @@
    if
     i32.const 0
     i32.const 416
-    i32.const 492
+    i32.const 493
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -2178,7 +2186,7 @@
   if
    i32.const 0
    i32.const 416
-   i32.const 494
+   i32.const 495
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/rereexport.release.wat
+++ b/tests/compiler/rereexport.release.wat
@@ -658,11 +658,16 @@
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
+  local.get $2
   local.get $1
   i64.extend_i32_u
-  local.get $2
-  i64.gt_u
+  i64.lt_u
   if
+   i32.const 0
+   i32.const 1440
+   i32.const 386
+   i32.const 14
+   call $~lib/builtins/abort
    unreachable
   end
   local.get $1
@@ -685,7 +690,7 @@
    if
     i32.const 0
     i32.const 1440
-    i32.const 392
+    i32.const 393
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -712,7 +717,7 @@
    if
     i32.const 0
     i32.const 1440
-    i32.const 405
+    i32.const 406
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1075,7 +1080,7 @@
       if
        i32.const 0
        i32.const 1440
-       i32.const 555
+       i32.const 556
        i32.const 3
        call $~lib/builtins/abort
        unreachable
@@ -1273,7 +1278,7 @@
    if
     i32.const 0
     i32.const 1440
-    i32.const 492
+    i32.const 493
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1288,7 +1293,7 @@
   if
    i32.const 0
    i32.const 1440
-   i32.const 494
+   i32.const 495
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/rereexport.release.wat
+++ b/tests/compiler/rereexport.release.wat
@@ -665,7 +665,7 @@
   if
    i32.const 0
    i32.const 1440
-   i32.const 382
+   i32.const 385
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -690,7 +690,7 @@
    if
     i32.const 0
     i32.const 1440
-    i32.const 389
+    i32.const 392
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -717,7 +717,7 @@
    if
     i32.const 0
     i32.const 1440
-    i32.const 402
+    i32.const 405
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1080,7 +1080,7 @@
       if
        i32.const 0
        i32.const 1440
-       i32.const 562
+       i32.const 555
        i32.const 3
        call $~lib/builtins/abort
        unreachable
@@ -1278,7 +1278,7 @@
    if
     i32.const 0
     i32.const 1440
-    i32.const 499
+    i32.const 492
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1293,7 +1293,7 @@
   if
    i32.const 0
    i32.const 1440
-   i32.const 501
+   i32.const 494
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/rereexport.release.wat
+++ b/tests/compiler/rereexport.release.wat
@@ -658,16 +658,11 @@
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
-  local.get $2
   local.get $1
   i64.extend_i32_u
-  i64.lt_u
+  local.get $2
+  i64.gt_u
   if
-   i32.const 0
-   i32.const 1440
-   i32.const 385
-   i32.const 14
-   call $~lib/builtins/abort
    unreachable
   end
   local.get $1

--- a/tests/compiler/resolve-access.debug.wat
+++ b/tests/compiler/resolve-access.debug.wat
@@ -1046,11 +1046,19 @@
   local.set $end
   i32.const 0
   drop
+  i32.const 1
+  drop
   local.get $start
   i64.extend_i32_u
   local.get $endU64
-  i64.gt_u
+  i64.le_u
+  i32.eqz
   if
+   i32.const 0
+   i32.const 400
+   i32.const 386
+   i32.const 14
+   call $~lib/builtins/abort
    unreachable
   end
   local.get $start
@@ -1094,7 +1102,7 @@
    if
     i32.const 0
     i32.const 400
-    i32.const 392
+    i32.const 393
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1126,7 +1134,7 @@
    if
     i32.const 0
     i32.const 400
-    i32.const 405
+    i32.const 406
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1368,7 +1376,7 @@
   if
    i32.const 0
    i32.const 400
-   i32.const 555
+   i32.const 556
    i32.const 3
    call $~lib/builtins/abort
    unreachable
@@ -1697,7 +1705,7 @@
   if
    i32.const 64
    i32.const 400
-   i32.const 460
+   i32.const 461
    i32.const 29
    call $~lib/builtins/abort
    unreachable
@@ -2140,7 +2148,7 @@
    if
     i32.const 0
     i32.const 400
-    i32.const 492
+    i32.const 493
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -2160,7 +2168,7 @@
   if
    i32.const 0
    i32.const 400
-   i32.const 494
+   i32.const 495
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/resolve-access.debug.wat
+++ b/tests/compiler/resolve-access.debug.wat
@@ -1046,19 +1046,11 @@
   local.set $end
   i32.const 0
   drop
-  i32.const 1
-  drop
   local.get $start
   i64.extend_i32_u
   local.get $endU64
-  i64.le_u
-  i32.eqz
+  i64.gt_u
   if
-   i32.const 0
-   i32.const 400
-   i32.const 385
-   i32.const 14
-   call $~lib/builtins/abort
    unreachable
   end
   local.get $start

--- a/tests/compiler/resolve-access.debug.wat
+++ b/tests/compiler/resolve-access.debug.wat
@@ -1044,6 +1044,8 @@
   local.get $endU64
   i32.wrap_i64
   local.set $end
+  i32.const 0
+  drop
   i32.const 1
   drop
   local.get $start
@@ -1054,7 +1056,7 @@
   if
    i32.const 0
    i32.const 400
-   i32.const 382
+   i32.const 385
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1100,7 +1102,7 @@
    if
     i32.const 0
     i32.const 400
-    i32.const 389
+    i32.const 392
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1132,7 +1134,7 @@
    if
     i32.const 0
     i32.const 400
-    i32.const 402
+    i32.const 405
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1333,8 +1335,6 @@
   i32.const 1572
   i32.add
   local.set $memStart
-  i32.const 0
-  drop
   local.get $root
   local.get $memStart
   memory.size
@@ -1376,7 +1376,7 @@
   if
    i32.const 0
    i32.const 400
-   i32.const 562
+   i32.const 555
    i32.const 3
    call $~lib/builtins/abort
    unreachable
@@ -1705,7 +1705,7 @@
   if
    i32.const 64
    i32.const 400
-   i32.const 461
+   i32.const 460
    i32.const 29
    call $~lib/builtins/abort
    unreachable
@@ -1939,8 +1939,6 @@
   (local $6 i32)
   (local $pagesWanted i32)
   (local $pagesAfter i32)
-  i32.const 0
-  drop
   local.get $size
   i32.const 256
   i32.ge_u
@@ -2150,7 +2148,7 @@
    if
     i32.const 0
     i32.const 400
-    i32.const 499
+    i32.const 492
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -2170,7 +2168,7 @@
   if
    i32.const 0
    i32.const 400
-   i32.const 501
+   i32.const 494
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/resolve-access.release.wat
+++ b/tests/compiler/resolve-access.release.wat
@@ -653,11 +653,16 @@
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
+  local.get $2
   local.get $1
   i64.extend_i32_u
-  local.get $2
-  i64.gt_u
+  i64.lt_u
   if
+   i32.const 0
+   i32.const 1424
+   i32.const 386
+   i32.const 14
+   call $~lib/builtins/abort
    unreachable
   end
   local.get $1
@@ -680,7 +685,7 @@
    if
     i32.const 0
     i32.const 1424
-    i32.const 392
+    i32.const 393
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -707,7 +712,7 @@
    if
     i32.const 0
     i32.const 1424
-    i32.const 405
+    i32.const 406
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1070,7 +1075,7 @@
       if
        i32.const 0
        i32.const 1424
-       i32.const 555
+       i32.const 556
        i32.const 3
        call $~lib/builtins/abort
        unreachable
@@ -1305,7 +1310,7 @@
   if
    i32.const 1088
    i32.const 1424
-   i32.const 460
+   i32.const 461
    i32.const 29
    call $~lib/builtins/abort
    unreachable
@@ -1407,7 +1412,7 @@
    if
     i32.const 0
     i32.const 1424
-    i32.const 492
+    i32.const 493
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1422,7 +1427,7 @@
   if
    i32.const 0
    i32.const 1424
-   i32.const 494
+   i32.const 495
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/resolve-access.release.wat
+++ b/tests/compiler/resolve-access.release.wat
@@ -660,7 +660,7 @@
   if
    i32.const 0
    i32.const 1424
-   i32.const 382
+   i32.const 385
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -685,7 +685,7 @@
    if
     i32.const 0
     i32.const 1424
-    i32.const 389
+    i32.const 392
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -712,7 +712,7 @@
    if
     i32.const 0
     i32.const 1424
-    i32.const 402
+    i32.const 405
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1075,7 +1075,7 @@
       if
        i32.const 0
        i32.const 1424
-       i32.const 562
+       i32.const 555
        i32.const 3
        call $~lib/builtins/abort
        unreachable
@@ -1310,7 +1310,7 @@
   if
    i32.const 1088
    i32.const 1424
-   i32.const 461
+   i32.const 460
    i32.const 29
    call $~lib/builtins/abort
    unreachable
@@ -1412,7 +1412,7 @@
    if
     i32.const 0
     i32.const 1424
-    i32.const 499
+    i32.const 492
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1427,7 +1427,7 @@
   if
    i32.const 0
    i32.const 1424
-   i32.const 501
+   i32.const 494
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/resolve-access.release.wat
+++ b/tests/compiler/resolve-access.release.wat
@@ -653,16 +653,11 @@
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
-  local.get $2
   local.get $1
   i64.extend_i32_u
-  i64.lt_u
+  local.get $2
+  i64.gt_u
   if
-   i32.const 0
-   i32.const 1424
-   i32.const 385
-   i32.const 14
-   call $~lib/builtins/abort
    unreachable
   end
   local.get $1

--- a/tests/compiler/resolve-binary.debug.wat
+++ b/tests/compiler/resolve-binary.debug.wat
@@ -1266,11 +1266,19 @@
   local.set $end
   i32.const 0
   drop
+  i32.const 1
+  drop
   local.get $start
   i64.extend_i32_u
   local.get $endU64
-  i64.gt_u
+  i64.le_u
+  i32.eqz
   if
+   i32.const 0
+   i32.const 720
+   i32.const 386
+   i32.const 14
+   call $~lib/builtins/abort
    unreachable
   end
   local.get $start
@@ -1314,7 +1322,7 @@
    if
     i32.const 0
     i32.const 720
-    i32.const 392
+    i32.const 393
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1346,7 +1354,7 @@
    if
     i32.const 0
     i32.const 720
-    i32.const 405
+    i32.const 406
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1588,7 +1596,7 @@
   if
    i32.const 0
    i32.const 720
-   i32.const 555
+   i32.const 556
    i32.const 3
    call $~lib/builtins/abort
    unreachable
@@ -1917,7 +1925,7 @@
   if
    i32.const 384
    i32.const 720
-   i32.const 460
+   i32.const 461
    i32.const 29
    call $~lib/builtins/abort
    unreachable
@@ -2360,7 +2368,7 @@
    if
     i32.const 0
     i32.const 720
-    i32.const 492
+    i32.const 493
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -2380,7 +2388,7 @@
   if
    i32.const 0
    i32.const 720
-   i32.const 494
+   i32.const 495
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/resolve-binary.debug.wat
+++ b/tests/compiler/resolve-binary.debug.wat
@@ -1264,6 +1264,8 @@
   local.get $endU64
   i32.wrap_i64
   local.set $end
+  i32.const 0
+  drop
   i32.const 1
   drop
   local.get $start
@@ -1274,7 +1276,7 @@
   if
    i32.const 0
    i32.const 720
-   i32.const 382
+   i32.const 385
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1320,7 +1322,7 @@
    if
     i32.const 0
     i32.const 720
-    i32.const 389
+    i32.const 392
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1352,7 +1354,7 @@
    if
     i32.const 0
     i32.const 720
-    i32.const 402
+    i32.const 405
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1553,8 +1555,6 @@
   i32.const 1572
   i32.add
   local.set $memStart
-  i32.const 0
-  drop
   local.get $root
   local.get $memStart
   memory.size
@@ -1596,7 +1596,7 @@
   if
    i32.const 0
    i32.const 720
-   i32.const 562
+   i32.const 555
    i32.const 3
    call $~lib/builtins/abort
    unreachable
@@ -1925,7 +1925,7 @@
   if
    i32.const 384
    i32.const 720
-   i32.const 461
+   i32.const 460
    i32.const 29
    call $~lib/builtins/abort
    unreachable
@@ -2159,8 +2159,6 @@
   (local $6 i32)
   (local $pagesWanted i32)
   (local $pagesAfter i32)
-  i32.const 0
-  drop
   local.get $size
   i32.const 256
   i32.ge_u
@@ -2370,7 +2368,7 @@
    if
     i32.const 0
     i32.const 720
-    i32.const 499
+    i32.const 492
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -2390,7 +2388,7 @@
   if
    i32.const 0
    i32.const 720
-   i32.const 501
+   i32.const 494
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/resolve-binary.debug.wat
+++ b/tests/compiler/resolve-binary.debug.wat
@@ -1266,19 +1266,11 @@
   local.set $end
   i32.const 0
   drop
-  i32.const 1
-  drop
   local.get $start
   i64.extend_i32_u
   local.get $endU64
-  i64.le_u
-  i32.eqz
+  i64.gt_u
   if
-   i32.const 0
-   i32.const 720
-   i32.const 385
-   i32.const 14
-   call $~lib/builtins/abort
    unreachable
   end
   local.get $start

--- a/tests/compiler/resolve-binary.release.wat
+++ b/tests/compiler/resolve-binary.release.wat
@@ -858,16 +858,11 @@
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
-  local.get $2
   local.get $1
   i64.extend_i32_u
-  i64.lt_u
+  local.get $2
+  i64.gt_u
   if
-   i32.const 0
-   i32.const 1744
-   i32.const 385
-   i32.const 14
-   call $~lib/builtins/abort
    unreachable
   end
   local.get $1

--- a/tests/compiler/resolve-binary.release.wat
+++ b/tests/compiler/resolve-binary.release.wat
@@ -858,11 +858,16 @@
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
+  local.get $2
   local.get $1
   i64.extend_i32_u
-  local.get $2
-  i64.gt_u
+  i64.lt_u
   if
+   i32.const 0
+   i32.const 1744
+   i32.const 386
+   i32.const 14
+   call $~lib/builtins/abort
    unreachable
   end
   local.get $1
@@ -885,7 +890,7 @@
    if
     i32.const 0
     i32.const 1744
-    i32.const 392
+    i32.const 393
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -912,7 +917,7 @@
    if
     i32.const 0
     i32.const 1744
-    i32.const 405
+    i32.const 406
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1275,7 +1280,7 @@
       if
        i32.const 0
        i32.const 1744
-       i32.const 555
+       i32.const 556
        i32.const 3
        call $~lib/builtins/abort
        unreachable
@@ -1510,7 +1515,7 @@
   if
    i32.const 1408
    i32.const 1744
-   i32.const 460
+   i32.const 461
    i32.const 29
    call $~lib/builtins/abort
    unreachable
@@ -1612,7 +1617,7 @@
    if
     i32.const 0
     i32.const 1744
-    i32.const 492
+    i32.const 493
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1627,7 +1632,7 @@
   if
    i32.const 0
    i32.const 1744
-   i32.const 494
+   i32.const 495
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/resolve-binary.release.wat
+++ b/tests/compiler/resolve-binary.release.wat
@@ -865,7 +865,7 @@
   if
    i32.const 0
    i32.const 1744
-   i32.const 382
+   i32.const 385
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -890,7 +890,7 @@
    if
     i32.const 0
     i32.const 1744
-    i32.const 389
+    i32.const 392
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -917,7 +917,7 @@
    if
     i32.const 0
     i32.const 1744
-    i32.const 402
+    i32.const 405
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1280,7 +1280,7 @@
       if
        i32.const 0
        i32.const 1744
-       i32.const 562
+       i32.const 555
        i32.const 3
        call $~lib/builtins/abort
        unreachable
@@ -1515,7 +1515,7 @@
   if
    i32.const 1408
    i32.const 1744
-   i32.const 461
+   i32.const 460
    i32.const 29
    call $~lib/builtins/abort
    unreachable
@@ -1617,7 +1617,7 @@
    if
     i32.const 0
     i32.const 1744
-    i32.const 499
+    i32.const 492
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1632,7 +1632,7 @@
   if
    i32.const 0
    i32.const 1744
-   i32.const 501
+   i32.const 494
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/resolve-elementaccess.debug.wat
+++ b/tests/compiler/resolve-elementaccess.debug.wat
@@ -1069,19 +1069,11 @@
   local.set $end
   i32.const 0
   drop
-  i32.const 1
-  drop
   local.get $start
   i64.extend_i32_u
   local.get $endU64
-  i64.le_u
-  i32.eqz
+  i64.gt_u
   if
-   i32.const 0
-   i32.const 480
-   i32.const 385
-   i32.const 14
-   call $~lib/builtins/abort
    unreachable
   end
   local.get $start

--- a/tests/compiler/resolve-elementaccess.debug.wat
+++ b/tests/compiler/resolve-elementaccess.debug.wat
@@ -1069,11 +1069,19 @@
   local.set $end
   i32.const 0
   drop
+  i32.const 1
+  drop
   local.get $start
   i64.extend_i32_u
   local.get $endU64
-  i64.gt_u
+  i64.le_u
+  i32.eqz
   if
+   i32.const 0
+   i32.const 480
+   i32.const 386
+   i32.const 14
+   call $~lib/builtins/abort
    unreachable
   end
   local.get $start
@@ -1117,7 +1125,7 @@
    if
     i32.const 0
     i32.const 480
-    i32.const 392
+    i32.const 393
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1149,7 +1157,7 @@
    if
     i32.const 0
     i32.const 480
-    i32.const 405
+    i32.const 406
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1391,7 +1399,7 @@
   if
    i32.const 0
    i32.const 480
-   i32.const 555
+   i32.const 556
    i32.const 3
    call $~lib/builtins/abort
    unreachable
@@ -1720,7 +1728,7 @@
   if
    i32.const 144
    i32.const 480
-   i32.const 460
+   i32.const 461
    i32.const 29
    call $~lib/builtins/abort
    unreachable
@@ -2163,7 +2171,7 @@
    if
     i32.const 0
     i32.const 480
-    i32.const 492
+    i32.const 493
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -2183,7 +2191,7 @@
   if
    i32.const 0
    i32.const 480
-   i32.const 494
+   i32.const 495
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/resolve-elementaccess.debug.wat
+++ b/tests/compiler/resolve-elementaccess.debug.wat
@@ -1067,6 +1067,8 @@
   local.get $endU64
   i32.wrap_i64
   local.set $end
+  i32.const 0
+  drop
   i32.const 1
   drop
   local.get $start
@@ -1077,7 +1079,7 @@
   if
    i32.const 0
    i32.const 480
-   i32.const 382
+   i32.const 385
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1123,7 +1125,7 @@
    if
     i32.const 0
     i32.const 480
-    i32.const 389
+    i32.const 392
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1155,7 +1157,7 @@
    if
     i32.const 0
     i32.const 480
-    i32.const 402
+    i32.const 405
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1356,8 +1358,6 @@
   i32.const 1572
   i32.add
   local.set $memStart
-  i32.const 0
-  drop
   local.get $root
   local.get $memStart
   memory.size
@@ -1399,7 +1399,7 @@
   if
    i32.const 0
    i32.const 480
-   i32.const 562
+   i32.const 555
    i32.const 3
    call $~lib/builtins/abort
    unreachable
@@ -1728,7 +1728,7 @@
   if
    i32.const 144
    i32.const 480
-   i32.const 461
+   i32.const 460
    i32.const 29
    call $~lib/builtins/abort
    unreachable
@@ -1962,8 +1962,6 @@
   (local $6 i32)
   (local $pagesWanted i32)
   (local $pagesAfter i32)
-  i32.const 0
-  drop
   local.get $size
   i32.const 256
   i32.ge_u
@@ -2173,7 +2171,7 @@
    if
     i32.const 0
     i32.const 480
-    i32.const 499
+    i32.const 492
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -2193,7 +2191,7 @@
   if
    i32.const 0
    i32.const 480
-   i32.const 501
+   i32.const 494
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/resolve-elementaccess.release.wat
+++ b/tests/compiler/resolve-elementaccess.release.wat
@@ -712,7 +712,7 @@
   if
    i32.const 0
    i32.const 1504
-   i32.const 382
+   i32.const 385
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -737,7 +737,7 @@
    if
     i32.const 0
     i32.const 1504
-    i32.const 389
+    i32.const 392
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -764,7 +764,7 @@
    if
     i32.const 0
     i32.const 1504
-    i32.const 402
+    i32.const 405
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1127,7 +1127,7 @@
       if
        i32.const 0
        i32.const 1504
-       i32.const 562
+       i32.const 555
        i32.const 3
        call $~lib/builtins/abort
        unreachable
@@ -1362,7 +1362,7 @@
   if
    i32.const 1168
    i32.const 1504
-   i32.const 461
+   i32.const 460
    i32.const 29
    call $~lib/builtins/abort
    unreachable
@@ -1464,7 +1464,7 @@
    if
     i32.const 0
     i32.const 1504
-    i32.const 499
+    i32.const 492
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1479,7 +1479,7 @@
   if
    i32.const 0
    i32.const 1504
-   i32.const 501
+   i32.const 494
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/resolve-elementaccess.release.wat
+++ b/tests/compiler/resolve-elementaccess.release.wat
@@ -705,16 +705,11 @@
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
-  local.get $2
   local.get $1
   i64.extend_i32_u
-  i64.lt_u
+  local.get $2
+  i64.gt_u
   if
-   i32.const 0
-   i32.const 1504
-   i32.const 385
-   i32.const 14
-   call $~lib/builtins/abort
    unreachable
   end
   local.get $1

--- a/tests/compiler/resolve-elementaccess.release.wat
+++ b/tests/compiler/resolve-elementaccess.release.wat
@@ -705,11 +705,16 @@
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
+  local.get $2
   local.get $1
   i64.extend_i32_u
-  local.get $2
-  i64.gt_u
+  i64.lt_u
   if
+   i32.const 0
+   i32.const 1504
+   i32.const 386
+   i32.const 14
+   call $~lib/builtins/abort
    unreachable
   end
   local.get $1
@@ -732,7 +737,7 @@
    if
     i32.const 0
     i32.const 1504
-    i32.const 392
+    i32.const 393
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -759,7 +764,7 @@
    if
     i32.const 0
     i32.const 1504
-    i32.const 405
+    i32.const 406
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1122,7 +1127,7 @@
       if
        i32.const 0
        i32.const 1504
-       i32.const 555
+       i32.const 556
        i32.const 3
        call $~lib/builtins/abort
        unreachable
@@ -1357,7 +1362,7 @@
   if
    i32.const 1168
    i32.const 1504
-   i32.const 460
+   i32.const 461
    i32.const 29
    call $~lib/builtins/abort
    unreachable
@@ -1459,7 +1464,7 @@
    if
     i32.const 0
     i32.const 1504
-    i32.const 492
+    i32.const 493
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1474,7 +1479,7 @@
   if
    i32.const 0
    i32.const 1504
-   i32.const 494
+   i32.const 495
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/resolve-function-expression.debug.wat
+++ b/tests/compiler/resolve-function-expression.debug.wat
@@ -1110,6 +1110,8 @@
   local.get $endU64
   i32.wrap_i64
   local.set $end
+  i32.const 0
+  drop
   i32.const 1
   drop
   local.get $start
@@ -1120,7 +1122,7 @@
   if
    i32.const 0
    i32.const 768
-   i32.const 382
+   i32.const 385
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1166,7 +1168,7 @@
    if
     i32.const 0
     i32.const 768
-    i32.const 389
+    i32.const 392
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1198,7 +1200,7 @@
    if
     i32.const 0
     i32.const 768
-    i32.const 402
+    i32.const 405
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1399,8 +1401,6 @@
   i32.const 1572
   i32.add
   local.set $memStart
-  i32.const 0
-  drop
   local.get $root
   local.get $memStart
   memory.size
@@ -1442,7 +1442,7 @@
   if
    i32.const 0
    i32.const 768
-   i32.const 562
+   i32.const 555
    i32.const 3
    call $~lib/builtins/abort
    unreachable
@@ -1771,7 +1771,7 @@
   if
    i32.const 432
    i32.const 768
-   i32.const 461
+   i32.const 460
    i32.const 29
    call $~lib/builtins/abort
    unreachable
@@ -2005,8 +2005,6 @@
   (local $6 i32)
   (local $pagesWanted i32)
   (local $pagesAfter i32)
-  i32.const 0
-  drop
   local.get $size
   i32.const 256
   i32.ge_u
@@ -2216,7 +2214,7 @@
    if
     i32.const 0
     i32.const 768
-    i32.const 499
+    i32.const 492
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -2236,7 +2234,7 @@
   if
    i32.const 0
    i32.const 768
-   i32.const 501
+   i32.const 494
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/resolve-function-expression.debug.wat
+++ b/tests/compiler/resolve-function-expression.debug.wat
@@ -1112,19 +1112,11 @@
   local.set $end
   i32.const 0
   drop
-  i32.const 1
-  drop
   local.get $start
   i64.extend_i32_u
   local.get $endU64
-  i64.le_u
-  i32.eqz
+  i64.gt_u
   if
-   i32.const 0
-   i32.const 768
-   i32.const 385
-   i32.const 14
-   call $~lib/builtins/abort
    unreachable
   end
   local.get $start

--- a/tests/compiler/resolve-function-expression.debug.wat
+++ b/tests/compiler/resolve-function-expression.debug.wat
@@ -1112,11 +1112,19 @@
   local.set $end
   i32.const 0
   drop
+  i32.const 1
+  drop
   local.get $start
   i64.extend_i32_u
   local.get $endU64
-  i64.gt_u
+  i64.le_u
+  i32.eqz
   if
+   i32.const 0
+   i32.const 768
+   i32.const 386
+   i32.const 14
+   call $~lib/builtins/abort
    unreachable
   end
   local.get $start
@@ -1160,7 +1168,7 @@
    if
     i32.const 0
     i32.const 768
-    i32.const 392
+    i32.const 393
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1192,7 +1200,7 @@
    if
     i32.const 0
     i32.const 768
-    i32.const 405
+    i32.const 406
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1434,7 +1442,7 @@
   if
    i32.const 0
    i32.const 768
-   i32.const 555
+   i32.const 556
    i32.const 3
    call $~lib/builtins/abort
    unreachable
@@ -1763,7 +1771,7 @@
   if
    i32.const 432
    i32.const 768
-   i32.const 460
+   i32.const 461
    i32.const 29
    call $~lib/builtins/abort
    unreachable
@@ -2206,7 +2214,7 @@
    if
     i32.const 0
     i32.const 768
-    i32.const 492
+    i32.const 493
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -2226,7 +2234,7 @@
   if
    i32.const 0
    i32.const 768
-   i32.const 494
+   i32.const 495
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/resolve-function-expression.release.wat
+++ b/tests/compiler/resolve-function-expression.release.wat
@@ -675,7 +675,7 @@
   if
    i32.const 0
    i32.const 1792
-   i32.const 382
+   i32.const 385
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -700,7 +700,7 @@
    if
     i32.const 0
     i32.const 1792
-    i32.const 389
+    i32.const 392
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -727,7 +727,7 @@
    if
     i32.const 0
     i32.const 1792
-    i32.const 402
+    i32.const 405
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1090,7 +1090,7 @@
       if
        i32.const 0
        i32.const 1792
-       i32.const 562
+       i32.const 555
        i32.const 3
        call $~lib/builtins/abort
        unreachable
@@ -1423,7 +1423,7 @@
    if
     i32.const 1456
     i32.const 1792
-    i32.const 461
+    i32.const 460
     i32.const 29
     call $~lib/builtins/abort
     unreachable
@@ -1525,7 +1525,7 @@
     if
      i32.const 0
      i32.const 1792
-     i32.const 499
+     i32.const 492
      i32.const 16
      call $~lib/builtins/abort
      unreachable
@@ -1540,7 +1540,7 @@
    if
     i32.const 0
     i32.const 1792
-    i32.const 501
+    i32.const 494
     i32.const 14
     call $~lib/builtins/abort
     unreachable

--- a/tests/compiler/resolve-function-expression.release.wat
+++ b/tests/compiler/resolve-function-expression.release.wat
@@ -668,16 +668,11 @@
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
-  local.get $2
   local.get $1
   i64.extend_i32_u
-  i64.lt_u
+  local.get $2
+  i64.gt_u
   if
-   i32.const 0
-   i32.const 1792
-   i32.const 385
-   i32.const 14
-   call $~lib/builtins/abort
    unreachable
   end
   local.get $1

--- a/tests/compiler/resolve-function-expression.release.wat
+++ b/tests/compiler/resolve-function-expression.release.wat
@@ -668,11 +668,16 @@
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
+  local.get $2
   local.get $1
   i64.extend_i32_u
-  local.get $2
-  i64.gt_u
+  i64.lt_u
   if
+   i32.const 0
+   i32.const 1792
+   i32.const 386
+   i32.const 14
+   call $~lib/builtins/abort
    unreachable
   end
   local.get $1
@@ -695,7 +700,7 @@
    if
     i32.const 0
     i32.const 1792
-    i32.const 392
+    i32.const 393
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -722,7 +727,7 @@
    if
     i32.const 0
     i32.const 1792
-    i32.const 405
+    i32.const 406
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1085,7 +1090,7 @@
       if
        i32.const 0
        i32.const 1792
-       i32.const 555
+       i32.const 556
        i32.const 3
        call $~lib/builtins/abort
        unreachable
@@ -1418,7 +1423,7 @@
    if
     i32.const 1456
     i32.const 1792
-    i32.const 460
+    i32.const 461
     i32.const 29
     call $~lib/builtins/abort
     unreachable
@@ -1520,7 +1525,7 @@
     if
      i32.const 0
      i32.const 1792
-     i32.const 492
+     i32.const 493
      i32.const 16
      call $~lib/builtins/abort
      unreachable
@@ -1535,7 +1540,7 @@
    if
     i32.const 0
     i32.const 1792
-    i32.const 494
+    i32.const 495
     i32.const 14
     call $~lib/builtins/abort
     unreachable

--- a/tests/compiler/resolve-new.debug.wat
+++ b/tests/compiler/resolve-new.debug.wat
@@ -1025,11 +1025,19 @@
   local.set $end
   i32.const 0
   drop
+  i32.const 1
+  drop
   local.get $start
   i64.extend_i32_u
   local.get $endU64
-  i64.gt_u
+  i64.le_u
+  i32.eqz
   if
+   i32.const 0
+   i32.const 368
+   i32.const 386
+   i32.const 14
+   call $~lib/builtins/abort
    unreachable
   end
   local.get $start
@@ -1073,7 +1081,7 @@
    if
     i32.const 0
     i32.const 368
-    i32.const 392
+    i32.const 393
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1105,7 +1113,7 @@
    if
     i32.const 0
     i32.const 368
-    i32.const 405
+    i32.const 406
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1347,7 +1355,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 555
+   i32.const 556
    i32.const 3
    call $~lib/builtins/abort
    unreachable
@@ -1676,7 +1684,7 @@
   if
    i32.const 32
    i32.const 368
-   i32.const 460
+   i32.const 461
    i32.const 29
    call $~lib/builtins/abort
    unreachable
@@ -2119,7 +2127,7 @@
    if
     i32.const 0
     i32.const 368
-    i32.const 492
+    i32.const 493
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -2139,7 +2147,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 494
+   i32.const 495
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/resolve-new.debug.wat
+++ b/tests/compiler/resolve-new.debug.wat
@@ -1023,6 +1023,8 @@
   local.get $endU64
   i32.wrap_i64
   local.set $end
+  i32.const 0
+  drop
   i32.const 1
   drop
   local.get $start
@@ -1033,7 +1035,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 382
+   i32.const 385
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1079,7 +1081,7 @@
    if
     i32.const 0
     i32.const 368
-    i32.const 389
+    i32.const 392
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1111,7 +1113,7 @@
    if
     i32.const 0
     i32.const 368
-    i32.const 402
+    i32.const 405
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1312,8 +1314,6 @@
   i32.const 1572
   i32.add
   local.set $memStart
-  i32.const 0
-  drop
   local.get $root
   local.get $memStart
   memory.size
@@ -1355,7 +1355,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 562
+   i32.const 555
    i32.const 3
    call $~lib/builtins/abort
    unreachable
@@ -1684,7 +1684,7 @@
   if
    i32.const 32
    i32.const 368
-   i32.const 461
+   i32.const 460
    i32.const 29
    call $~lib/builtins/abort
    unreachable
@@ -1918,8 +1918,6 @@
   (local $6 i32)
   (local $pagesWanted i32)
   (local $pagesAfter i32)
-  i32.const 0
-  drop
   local.get $size
   i32.const 256
   i32.ge_u
@@ -2129,7 +2127,7 @@
    if
     i32.const 0
     i32.const 368
-    i32.const 499
+    i32.const 492
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -2149,7 +2147,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 501
+   i32.const 494
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/resolve-new.debug.wat
+++ b/tests/compiler/resolve-new.debug.wat
@@ -1025,19 +1025,11 @@
   local.set $end
   i32.const 0
   drop
-  i32.const 1
-  drop
   local.get $start
   i64.extend_i32_u
   local.get $endU64
-  i64.le_u
-  i32.eqz
+  i64.gt_u
   if
-   i32.const 0
-   i32.const 368
-   i32.const 385
-   i32.const 14
-   call $~lib/builtins/abort
    unreachable
   end
   local.get $start

--- a/tests/compiler/resolve-new.release.wat
+++ b/tests/compiler/resolve-new.release.wat
@@ -632,16 +632,11 @@
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
-  local.get $2
   local.get $1
   i64.extend_i32_u
-  i64.lt_u
+  local.get $2
+  i64.gt_u
   if
-   i32.const 0
-   i32.const 1392
-   i32.const 385
-   i32.const 14
-   call $~lib/builtins/abort
    unreachable
   end
   local.get $1

--- a/tests/compiler/resolve-new.release.wat
+++ b/tests/compiler/resolve-new.release.wat
@@ -639,7 +639,7 @@
   if
    i32.const 0
    i32.const 1392
-   i32.const 382
+   i32.const 385
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -664,7 +664,7 @@
    if
     i32.const 0
     i32.const 1392
-    i32.const 389
+    i32.const 392
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -691,7 +691,7 @@
    if
     i32.const 0
     i32.const 1392
-    i32.const 402
+    i32.const 405
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1054,7 +1054,7 @@
       if
        i32.const 0
        i32.const 1392
-       i32.const 562
+       i32.const 555
        i32.const 3
        call $~lib/builtins/abort
        unreachable
@@ -1252,7 +1252,7 @@
    if
     i32.const 0
     i32.const 1392
-    i32.const 499
+    i32.const 492
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1267,7 +1267,7 @@
   if
    i32.const 0
    i32.const 1392
-   i32.const 501
+   i32.const 494
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/resolve-new.release.wat
+++ b/tests/compiler/resolve-new.release.wat
@@ -632,11 +632,16 @@
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
+  local.get $2
   local.get $1
   i64.extend_i32_u
-  local.get $2
-  i64.gt_u
+  i64.lt_u
   if
+   i32.const 0
+   i32.const 1392
+   i32.const 386
+   i32.const 14
+   call $~lib/builtins/abort
    unreachable
   end
   local.get $1
@@ -659,7 +664,7 @@
    if
     i32.const 0
     i32.const 1392
-    i32.const 392
+    i32.const 393
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -686,7 +691,7 @@
    if
     i32.const 0
     i32.const 1392
-    i32.const 405
+    i32.const 406
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1049,7 +1054,7 @@
       if
        i32.const 0
        i32.const 1392
-       i32.const 555
+       i32.const 556
        i32.const 3
        call $~lib/builtins/abort
        unreachable
@@ -1247,7 +1252,7 @@
    if
     i32.const 0
     i32.const 1392
-    i32.const 492
+    i32.const 493
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1262,7 +1267,7 @@
   if
    i32.const 0
    i32.const 1392
-   i32.const 494
+   i32.const 495
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/resolve-propertyaccess.debug.wat
+++ b/tests/compiler/resolve-propertyaccess.debug.wat
@@ -1112,19 +1112,11 @@
   local.set $end
   i32.const 0
   drop
-  i32.const 1
-  drop
   local.get $start
   i64.extend_i32_u
   local.get $endU64
-  i64.le_u
-  i32.eqz
+  i64.gt_u
   if
-   i32.const 0
-   i32.const 592
-   i32.const 385
-   i32.const 14
-   call $~lib/builtins/abort
    unreachable
   end
   local.get $start

--- a/tests/compiler/resolve-propertyaccess.debug.wat
+++ b/tests/compiler/resolve-propertyaccess.debug.wat
@@ -1110,6 +1110,8 @@
   local.get $endU64
   i32.wrap_i64
   local.set $end
+  i32.const 0
+  drop
   i32.const 1
   drop
   local.get $start
@@ -1120,7 +1122,7 @@
   if
    i32.const 0
    i32.const 592
-   i32.const 382
+   i32.const 385
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1166,7 +1168,7 @@
    if
     i32.const 0
     i32.const 592
-    i32.const 389
+    i32.const 392
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1198,7 +1200,7 @@
    if
     i32.const 0
     i32.const 592
-    i32.const 402
+    i32.const 405
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1399,8 +1401,6 @@
   i32.const 1572
   i32.add
   local.set $memStart
-  i32.const 0
-  drop
   local.get $root
   local.get $memStart
   memory.size
@@ -1442,7 +1442,7 @@
   if
    i32.const 0
    i32.const 592
-   i32.const 562
+   i32.const 555
    i32.const 3
    call $~lib/builtins/abort
    unreachable
@@ -1771,7 +1771,7 @@
   if
    i32.const 256
    i32.const 592
-   i32.const 461
+   i32.const 460
    i32.const 29
    call $~lib/builtins/abort
    unreachable
@@ -2005,8 +2005,6 @@
   (local $6 i32)
   (local $pagesWanted i32)
   (local $pagesAfter i32)
-  i32.const 0
-  drop
   local.get $size
   i32.const 256
   i32.ge_u
@@ -2216,7 +2214,7 @@
    if
     i32.const 0
     i32.const 592
-    i32.const 499
+    i32.const 492
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -2236,7 +2234,7 @@
   if
    i32.const 0
    i32.const 592
-   i32.const 501
+   i32.const 494
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/resolve-propertyaccess.debug.wat
+++ b/tests/compiler/resolve-propertyaccess.debug.wat
@@ -1112,11 +1112,19 @@
   local.set $end
   i32.const 0
   drop
+  i32.const 1
+  drop
   local.get $start
   i64.extend_i32_u
   local.get $endU64
-  i64.gt_u
+  i64.le_u
+  i32.eqz
   if
+   i32.const 0
+   i32.const 592
+   i32.const 386
+   i32.const 14
+   call $~lib/builtins/abort
    unreachable
   end
   local.get $start
@@ -1160,7 +1168,7 @@
    if
     i32.const 0
     i32.const 592
-    i32.const 392
+    i32.const 393
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1192,7 +1200,7 @@
    if
     i32.const 0
     i32.const 592
-    i32.const 405
+    i32.const 406
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1434,7 +1442,7 @@
   if
    i32.const 0
    i32.const 592
-   i32.const 555
+   i32.const 556
    i32.const 3
    call $~lib/builtins/abort
    unreachable
@@ -1763,7 +1771,7 @@
   if
    i32.const 256
    i32.const 592
-   i32.const 460
+   i32.const 461
    i32.const 29
    call $~lib/builtins/abort
    unreachable
@@ -2206,7 +2214,7 @@
    if
     i32.const 0
     i32.const 592
-    i32.const 492
+    i32.const 493
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -2226,7 +2234,7 @@
   if
    i32.const 0
    i32.const 592
-   i32.const 494
+   i32.const 495
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/resolve-propertyaccess.release.wat
+++ b/tests/compiler/resolve-propertyaccess.release.wat
@@ -667,11 +667,16 @@
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
+  local.get $2
   local.get $1
   i64.extend_i32_u
-  local.get $2
-  i64.gt_u
+  i64.lt_u
   if
+   i32.const 0
+   i32.const 1616
+   i32.const 386
+   i32.const 14
+   call $~lib/builtins/abort
    unreachable
   end
   local.get $1
@@ -694,7 +699,7 @@
    if
     i32.const 0
     i32.const 1616
-    i32.const 392
+    i32.const 393
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -721,7 +726,7 @@
    if
     i32.const 0
     i32.const 1616
-    i32.const 405
+    i32.const 406
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1084,7 +1089,7 @@
       if
        i32.const 0
        i32.const 1616
-       i32.const 555
+       i32.const 556
        i32.const 3
        call $~lib/builtins/abort
        unreachable
@@ -1319,7 +1324,7 @@
   if
    i32.const 1280
    i32.const 1616
-   i32.const 460
+   i32.const 461
    i32.const 29
    call $~lib/builtins/abort
    unreachable
@@ -1421,7 +1426,7 @@
    if
     i32.const 0
     i32.const 1616
-    i32.const 492
+    i32.const 493
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1436,7 +1441,7 @@
   if
    i32.const 0
    i32.const 1616
-   i32.const 494
+   i32.const 495
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/resolve-propertyaccess.release.wat
+++ b/tests/compiler/resolve-propertyaccess.release.wat
@@ -674,7 +674,7 @@
   if
    i32.const 0
    i32.const 1616
-   i32.const 382
+   i32.const 385
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -699,7 +699,7 @@
    if
     i32.const 0
     i32.const 1616
-    i32.const 389
+    i32.const 392
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -726,7 +726,7 @@
    if
     i32.const 0
     i32.const 1616
-    i32.const 402
+    i32.const 405
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1089,7 +1089,7 @@
       if
        i32.const 0
        i32.const 1616
-       i32.const 562
+       i32.const 555
        i32.const 3
        call $~lib/builtins/abort
        unreachable
@@ -1324,7 +1324,7 @@
   if
    i32.const 1280
    i32.const 1616
-   i32.const 461
+   i32.const 460
    i32.const 29
    call $~lib/builtins/abort
    unreachable
@@ -1426,7 +1426,7 @@
    if
     i32.const 0
     i32.const 1616
-    i32.const 499
+    i32.const 492
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1441,7 +1441,7 @@
   if
    i32.const 0
    i32.const 1616
-   i32.const 501
+   i32.const 494
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/resolve-propertyaccess.release.wat
+++ b/tests/compiler/resolve-propertyaccess.release.wat
@@ -667,16 +667,11 @@
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
-  local.get $2
   local.get $1
   i64.extend_i32_u
-  i64.lt_u
+  local.get $2
+  i64.gt_u
   if
-   i32.const 0
-   i32.const 1616
-   i32.const 385
-   i32.const 14
-   call $~lib/builtins/abort
    unreachable
   end
   local.get $1

--- a/tests/compiler/resolve-ternary.debug.wat
+++ b/tests/compiler/resolve-ternary.debug.wat
@@ -1118,6 +1118,8 @@
   local.get $endU64
   i32.wrap_i64
   local.set $end
+  i32.const 0
+  drop
   i32.const 1
   drop
   local.get $start
@@ -1128,7 +1130,7 @@
   if
    i32.const 0
    i32.const 592
-   i32.const 382
+   i32.const 385
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1174,7 +1176,7 @@
    if
     i32.const 0
     i32.const 592
-    i32.const 389
+    i32.const 392
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1206,7 +1208,7 @@
    if
     i32.const 0
     i32.const 592
-    i32.const 402
+    i32.const 405
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1407,8 +1409,6 @@
   i32.const 1572
   i32.add
   local.set $memStart
-  i32.const 0
-  drop
   local.get $root
   local.get $memStart
   memory.size
@@ -1450,7 +1450,7 @@
   if
    i32.const 0
    i32.const 592
-   i32.const 562
+   i32.const 555
    i32.const 3
    call $~lib/builtins/abort
    unreachable
@@ -1779,7 +1779,7 @@
   if
    i32.const 256
    i32.const 592
-   i32.const 461
+   i32.const 460
    i32.const 29
    call $~lib/builtins/abort
    unreachable
@@ -2013,8 +2013,6 @@
   (local $6 i32)
   (local $pagesWanted i32)
   (local $pagesAfter i32)
-  i32.const 0
-  drop
   local.get $size
   i32.const 256
   i32.ge_u
@@ -2224,7 +2222,7 @@
    if
     i32.const 0
     i32.const 592
-    i32.const 499
+    i32.const 492
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -2244,7 +2242,7 @@
   if
    i32.const 0
    i32.const 592
-   i32.const 501
+   i32.const 494
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/resolve-ternary.debug.wat
+++ b/tests/compiler/resolve-ternary.debug.wat
@@ -1120,19 +1120,11 @@
   local.set $end
   i32.const 0
   drop
-  i32.const 1
-  drop
   local.get $start
   i64.extend_i32_u
   local.get $endU64
-  i64.le_u
-  i32.eqz
+  i64.gt_u
   if
-   i32.const 0
-   i32.const 592
-   i32.const 385
-   i32.const 14
-   call $~lib/builtins/abort
    unreachable
   end
   local.get $start

--- a/tests/compiler/resolve-ternary.debug.wat
+++ b/tests/compiler/resolve-ternary.debug.wat
@@ -1120,11 +1120,19 @@
   local.set $end
   i32.const 0
   drop
+  i32.const 1
+  drop
   local.get $start
   i64.extend_i32_u
   local.get $endU64
-  i64.gt_u
+  i64.le_u
+  i32.eqz
   if
+   i32.const 0
+   i32.const 592
+   i32.const 386
+   i32.const 14
+   call $~lib/builtins/abort
    unreachable
   end
   local.get $start
@@ -1168,7 +1176,7 @@
    if
     i32.const 0
     i32.const 592
-    i32.const 392
+    i32.const 393
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1200,7 +1208,7 @@
    if
     i32.const 0
     i32.const 592
-    i32.const 405
+    i32.const 406
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1442,7 +1450,7 @@
   if
    i32.const 0
    i32.const 592
-   i32.const 555
+   i32.const 556
    i32.const 3
    call $~lib/builtins/abort
    unreachable
@@ -1771,7 +1779,7 @@
   if
    i32.const 256
    i32.const 592
-   i32.const 460
+   i32.const 461
    i32.const 29
    call $~lib/builtins/abort
    unreachable
@@ -2214,7 +2222,7 @@
    if
     i32.const 0
     i32.const 592
-    i32.const 492
+    i32.const 493
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -2234,7 +2242,7 @@
   if
    i32.const 0
    i32.const 592
-   i32.const 494
+   i32.const 495
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/resolve-ternary.release.wat
+++ b/tests/compiler/resolve-ternary.release.wat
@@ -673,11 +673,16 @@
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
+  local.get $2
   local.get $1
   i64.extend_i32_u
-  local.get $2
-  i64.gt_u
+  i64.lt_u
   if
+   i32.const 0
+   i32.const 1616
+   i32.const 386
+   i32.const 14
+   call $~lib/builtins/abort
    unreachable
   end
   local.get $1
@@ -700,7 +705,7 @@
    if
     i32.const 0
     i32.const 1616
-    i32.const 392
+    i32.const 393
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -727,7 +732,7 @@
    if
     i32.const 0
     i32.const 1616
-    i32.const 405
+    i32.const 406
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1090,7 +1095,7 @@
       if
        i32.const 0
        i32.const 1616
-       i32.const 555
+       i32.const 556
        i32.const 3
        call $~lib/builtins/abort
        unreachable
@@ -1325,7 +1330,7 @@
   if
    i32.const 1280
    i32.const 1616
-   i32.const 460
+   i32.const 461
    i32.const 29
    call $~lib/builtins/abort
    unreachable
@@ -1427,7 +1432,7 @@
    if
     i32.const 0
     i32.const 1616
-    i32.const 492
+    i32.const 493
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1442,7 +1447,7 @@
   if
    i32.const 0
    i32.const 1616
-   i32.const 494
+   i32.const 495
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/resolve-ternary.release.wat
+++ b/tests/compiler/resolve-ternary.release.wat
@@ -680,7 +680,7 @@
   if
    i32.const 0
    i32.const 1616
-   i32.const 382
+   i32.const 385
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -705,7 +705,7 @@
    if
     i32.const 0
     i32.const 1616
-    i32.const 389
+    i32.const 392
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -732,7 +732,7 @@
    if
     i32.const 0
     i32.const 1616
-    i32.const 402
+    i32.const 405
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1095,7 +1095,7 @@
       if
        i32.const 0
        i32.const 1616
-       i32.const 562
+       i32.const 555
        i32.const 3
        call $~lib/builtins/abort
        unreachable
@@ -1330,7 +1330,7 @@
   if
    i32.const 1280
    i32.const 1616
-   i32.const 461
+   i32.const 460
    i32.const 29
    call $~lib/builtins/abort
    unreachable
@@ -1432,7 +1432,7 @@
    if
     i32.const 0
     i32.const 1616
-    i32.const 499
+    i32.const 492
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1447,7 +1447,7 @@
   if
    i32.const 0
    i32.const 1616
-   i32.const 501
+   i32.const 494
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/resolve-ternary.release.wat
+++ b/tests/compiler/resolve-ternary.release.wat
@@ -673,16 +673,11 @@
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
-  local.get $2
   local.get $1
   i64.extend_i32_u
-  i64.lt_u
+  local.get $2
+  i64.gt_u
   if
-   i32.const 0
-   i32.const 1616
-   i32.const 385
-   i32.const 14
-   call $~lib/builtins/abort
    unreachable
   end
   local.get $1

--- a/tests/compiler/resolve-unary.debug.wat
+++ b/tests/compiler/resolve-unary.debug.wat
@@ -1112,19 +1112,11 @@
   local.set $end
   i32.const 0
   drop
-  i32.const 1
-  drop
   local.get $start
   i64.extend_i32_u
   local.get $endU64
-  i64.le_u
-  i32.eqz
+  i64.gt_u
   if
-   i32.const 0
-   i32.const 592
-   i32.const 385
-   i32.const 14
-   call $~lib/builtins/abort
    unreachable
   end
   local.get $start

--- a/tests/compiler/resolve-unary.debug.wat
+++ b/tests/compiler/resolve-unary.debug.wat
@@ -1110,6 +1110,8 @@
   local.get $endU64
   i32.wrap_i64
   local.set $end
+  i32.const 0
+  drop
   i32.const 1
   drop
   local.get $start
@@ -1120,7 +1122,7 @@
   if
    i32.const 0
    i32.const 592
-   i32.const 382
+   i32.const 385
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1166,7 +1168,7 @@
    if
     i32.const 0
     i32.const 592
-    i32.const 389
+    i32.const 392
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1198,7 +1200,7 @@
    if
     i32.const 0
     i32.const 592
-    i32.const 402
+    i32.const 405
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1399,8 +1401,6 @@
   i32.const 1572
   i32.add
   local.set $memStart
-  i32.const 0
-  drop
   local.get $root
   local.get $memStart
   memory.size
@@ -1442,7 +1442,7 @@
   if
    i32.const 0
    i32.const 592
-   i32.const 562
+   i32.const 555
    i32.const 3
    call $~lib/builtins/abort
    unreachable
@@ -1771,7 +1771,7 @@
   if
    i32.const 256
    i32.const 592
-   i32.const 461
+   i32.const 460
    i32.const 29
    call $~lib/builtins/abort
    unreachable
@@ -2005,8 +2005,6 @@
   (local $6 i32)
   (local $pagesWanted i32)
   (local $pagesAfter i32)
-  i32.const 0
-  drop
   local.get $size
   i32.const 256
   i32.ge_u
@@ -2216,7 +2214,7 @@
    if
     i32.const 0
     i32.const 592
-    i32.const 499
+    i32.const 492
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -2236,7 +2234,7 @@
   if
    i32.const 0
    i32.const 592
-   i32.const 501
+   i32.const 494
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/resolve-unary.debug.wat
+++ b/tests/compiler/resolve-unary.debug.wat
@@ -1112,11 +1112,19 @@
   local.set $end
   i32.const 0
   drop
+  i32.const 1
+  drop
   local.get $start
   i64.extend_i32_u
   local.get $endU64
-  i64.gt_u
+  i64.le_u
+  i32.eqz
   if
+   i32.const 0
+   i32.const 592
+   i32.const 386
+   i32.const 14
+   call $~lib/builtins/abort
    unreachable
   end
   local.get $start
@@ -1160,7 +1168,7 @@
    if
     i32.const 0
     i32.const 592
-    i32.const 392
+    i32.const 393
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1192,7 +1200,7 @@
    if
     i32.const 0
     i32.const 592
-    i32.const 405
+    i32.const 406
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1434,7 +1442,7 @@
   if
    i32.const 0
    i32.const 592
-   i32.const 555
+   i32.const 556
    i32.const 3
    call $~lib/builtins/abort
    unreachable
@@ -1763,7 +1771,7 @@
   if
    i32.const 256
    i32.const 592
-   i32.const 460
+   i32.const 461
    i32.const 29
    call $~lib/builtins/abort
    unreachable
@@ -2206,7 +2214,7 @@
    if
     i32.const 0
     i32.const 592
-    i32.const 492
+    i32.const 493
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -2226,7 +2234,7 @@
   if
    i32.const 0
    i32.const 592
-   i32.const 494
+   i32.const 495
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/resolve-unary.release.wat
+++ b/tests/compiler/resolve-unary.release.wat
@@ -700,7 +700,7 @@
   if
    i32.const 0
    i32.const 1616
-   i32.const 382
+   i32.const 385
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -725,7 +725,7 @@
    if
     i32.const 0
     i32.const 1616
-    i32.const 389
+    i32.const 392
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -752,7 +752,7 @@
    if
     i32.const 0
     i32.const 1616
-    i32.const 402
+    i32.const 405
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1115,7 +1115,7 @@
       if
        i32.const 0
        i32.const 1616
-       i32.const 562
+       i32.const 555
        i32.const 3
        call $~lib/builtins/abort
        unreachable
@@ -1350,7 +1350,7 @@
   if
    i32.const 1280
    i32.const 1616
-   i32.const 461
+   i32.const 460
    i32.const 29
    call $~lib/builtins/abort
    unreachable
@@ -1452,7 +1452,7 @@
    if
     i32.const 0
     i32.const 1616
-    i32.const 499
+    i32.const 492
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1467,7 +1467,7 @@
   if
    i32.const 0
    i32.const 1616
-   i32.const 501
+   i32.const 494
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/resolve-unary.release.wat
+++ b/tests/compiler/resolve-unary.release.wat
@@ -693,11 +693,16 @@
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
+  local.get $2
   local.get $1
   i64.extend_i32_u
-  local.get $2
-  i64.gt_u
+  i64.lt_u
   if
+   i32.const 0
+   i32.const 1616
+   i32.const 386
+   i32.const 14
+   call $~lib/builtins/abort
    unreachable
   end
   local.get $1
@@ -720,7 +725,7 @@
    if
     i32.const 0
     i32.const 1616
-    i32.const 392
+    i32.const 393
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -747,7 +752,7 @@
    if
     i32.const 0
     i32.const 1616
-    i32.const 405
+    i32.const 406
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1110,7 +1115,7 @@
       if
        i32.const 0
        i32.const 1616
-       i32.const 555
+       i32.const 556
        i32.const 3
        call $~lib/builtins/abort
        unreachable
@@ -1345,7 +1350,7 @@
   if
    i32.const 1280
    i32.const 1616
-   i32.const 460
+   i32.const 461
    i32.const 29
    call $~lib/builtins/abort
    unreachable
@@ -1447,7 +1452,7 @@
    if
     i32.const 0
     i32.const 1616
-    i32.const 492
+    i32.const 493
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1462,7 +1467,7 @@
   if
    i32.const 0
    i32.const 1616
-   i32.const 494
+   i32.const 495
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/resolve-unary.release.wat
+++ b/tests/compiler/resolve-unary.release.wat
@@ -693,16 +693,11 @@
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
-  local.get $2
   local.get $1
   i64.extend_i32_u
-  i64.lt_u
+  local.get $2
+  i64.gt_u
   if
-   i32.const 0
-   i32.const 1616
-   i32.const 385
-   i32.const 14
-   call $~lib/builtins/abort
    unreachable
   end
   local.get $1

--- a/tests/compiler/return-unreachable.debug.wat
+++ b/tests/compiler/return-unreachable.debug.wat
@@ -1026,6 +1026,8 @@
   local.get $endU64
   i32.wrap_i64
   local.set $end
+  i32.const 0
+  drop
   i32.const 1
   drop
   local.get $start
@@ -1036,7 +1038,7 @@
   if
    i32.const 0
    i32.const 464
-   i32.const 382
+   i32.const 385
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1082,7 +1084,7 @@
    if
     i32.const 0
     i32.const 464
-    i32.const 389
+    i32.const 392
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1114,7 +1116,7 @@
    if
     i32.const 0
     i32.const 464
-    i32.const 402
+    i32.const 405
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1315,8 +1317,6 @@
   i32.const 1572
   i32.add
   local.set $memStart
-  i32.const 0
-  drop
   local.get $root
   local.get $memStart
   memory.size
@@ -1358,7 +1358,7 @@
   if
    i32.const 0
    i32.const 464
-   i32.const 562
+   i32.const 555
    i32.const 3
    call $~lib/builtins/abort
    unreachable
@@ -1687,7 +1687,7 @@
   if
    i32.const 128
    i32.const 464
-   i32.const 461
+   i32.const 460
    i32.const 29
    call $~lib/builtins/abort
    unreachable
@@ -1921,8 +1921,6 @@
   (local $6 i32)
   (local $pagesWanted i32)
   (local $pagesAfter i32)
-  i32.const 0
-  drop
   local.get $size
   i32.const 256
   i32.ge_u
@@ -2132,7 +2130,7 @@
    if
     i32.const 0
     i32.const 464
-    i32.const 499
+    i32.const 492
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -2152,7 +2150,7 @@
   if
    i32.const 0
    i32.const 464
-   i32.const 501
+   i32.const 494
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/return-unreachable.debug.wat
+++ b/tests/compiler/return-unreachable.debug.wat
@@ -1028,11 +1028,19 @@
   local.set $end
   i32.const 0
   drop
+  i32.const 1
+  drop
   local.get $start
   i64.extend_i32_u
   local.get $endU64
-  i64.gt_u
+  i64.le_u
+  i32.eqz
   if
+   i32.const 0
+   i32.const 464
+   i32.const 386
+   i32.const 14
+   call $~lib/builtins/abort
    unreachable
   end
   local.get $start
@@ -1076,7 +1084,7 @@
    if
     i32.const 0
     i32.const 464
-    i32.const 392
+    i32.const 393
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1108,7 +1116,7 @@
    if
     i32.const 0
     i32.const 464
-    i32.const 405
+    i32.const 406
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1350,7 +1358,7 @@
   if
    i32.const 0
    i32.const 464
-   i32.const 555
+   i32.const 556
    i32.const 3
    call $~lib/builtins/abort
    unreachable
@@ -1679,7 +1687,7 @@
   if
    i32.const 128
    i32.const 464
-   i32.const 460
+   i32.const 461
    i32.const 29
    call $~lib/builtins/abort
    unreachable
@@ -2122,7 +2130,7 @@
    if
     i32.const 0
     i32.const 464
-    i32.const 492
+    i32.const 493
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -2142,7 +2150,7 @@
   if
    i32.const 0
    i32.const 464
-   i32.const 494
+   i32.const 495
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/return-unreachable.debug.wat
+++ b/tests/compiler/return-unreachable.debug.wat
@@ -1028,19 +1028,11 @@
   local.set $end
   i32.const 0
   drop
-  i32.const 1
-  drop
   local.get $start
   i64.extend_i32_u
   local.get $endU64
-  i64.le_u
-  i32.eqz
+  i64.gt_u
   if
-   i32.const 0
-   i32.const 464
-   i32.const 385
-   i32.const 14
-   call $~lib/builtins/abort
    unreachable
   end
   local.get $start

--- a/tests/compiler/return-unreachable.release.wat
+++ b/tests/compiler/return-unreachable.release.wat
@@ -637,11 +637,16 @@
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
+  local.get $2
   local.get $1
   i64.extend_i32_u
-  local.get $2
-  i64.gt_u
+  i64.lt_u
   if
+   i32.const 0
+   i32.const 1488
+   i32.const 386
+   i32.const 14
+   call $~lib/builtins/abort
    unreachable
   end
   local.get $1
@@ -664,7 +669,7 @@
    if
     i32.const 0
     i32.const 1488
-    i32.const 392
+    i32.const 393
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -691,7 +696,7 @@
    if
     i32.const 0
     i32.const 1488
-    i32.const 405
+    i32.const 406
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1054,7 +1059,7 @@
       if
        i32.const 0
        i32.const 1488
-       i32.const 555
+       i32.const 556
        i32.const 3
        call $~lib/builtins/abort
        unreachable
@@ -1289,7 +1294,7 @@
   if
    i32.const 1152
    i32.const 1488
-   i32.const 460
+   i32.const 461
    i32.const 29
    call $~lib/builtins/abort
    unreachable
@@ -1391,7 +1396,7 @@
    if
     i32.const 0
     i32.const 1488
-    i32.const 492
+    i32.const 493
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1406,7 +1411,7 @@
   if
    i32.const 0
    i32.const 1488
-   i32.const 494
+   i32.const 495
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/return-unreachable.release.wat
+++ b/tests/compiler/return-unreachable.release.wat
@@ -644,7 +644,7 @@
   if
    i32.const 0
    i32.const 1488
-   i32.const 382
+   i32.const 385
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -669,7 +669,7 @@
    if
     i32.const 0
     i32.const 1488
-    i32.const 389
+    i32.const 392
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -696,7 +696,7 @@
    if
     i32.const 0
     i32.const 1488
-    i32.const 402
+    i32.const 405
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1059,7 +1059,7 @@
       if
        i32.const 0
        i32.const 1488
-       i32.const 562
+       i32.const 555
        i32.const 3
        call $~lib/builtins/abort
        unreachable
@@ -1294,7 +1294,7 @@
   if
    i32.const 1152
    i32.const 1488
-   i32.const 461
+   i32.const 460
    i32.const 29
    call $~lib/builtins/abort
    unreachable
@@ -1396,7 +1396,7 @@
    if
     i32.const 0
     i32.const 1488
-    i32.const 499
+    i32.const 492
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1411,7 +1411,7 @@
   if
    i32.const 0
    i32.const 1488
-   i32.const 501
+   i32.const 494
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/return-unreachable.release.wat
+++ b/tests/compiler/return-unreachable.release.wat
@@ -637,16 +637,11 @@
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
-  local.get $2
   local.get $1
   i64.extend_i32_u
-  i64.lt_u
+  local.get $2
+  i64.gt_u
   if
-   i32.const 0
-   i32.const 1488
-   i32.const 385
-   i32.const 14
-   call $~lib/builtins/abort
    unreachable
   end
   local.get $1

--- a/tests/compiler/rt/alloc-large-memory.debug.wat
+++ b/tests/compiler/rt/alloc-large-memory.debug.wat
@@ -668,6 +668,8 @@
   local.get $endU64
   i32.wrap_i64
   local.set $end
+  i32.const 0
+  drop
   i32.const 1
   drop
   local.get $start
@@ -678,7 +680,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 382
+   i32.const 385
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -724,7 +726,7 @@
    if
     i32.const 0
     i32.const 32
-    i32.const 389
+    i32.const 392
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -756,7 +758,7 @@
    if
     i32.const 0
     i32.const 32
-    i32.const 402
+    i32.const 405
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -957,8 +959,6 @@
   i32.const 1572
   i32.add
   local.set $memStart
-  i32.const 0
-  drop
   local.get $root
   local.get $memStart
   memory.size
@@ -998,7 +998,7 @@
   if
    i32.const 96
    i32.const 32
-   i32.const 461
+   i32.const 460
    i32.const 29
    call $~lib/builtins/abort
    unreachable
@@ -1232,8 +1232,6 @@
   (local $6 i32)
   (local $pagesWanted i32)
   (local $pagesAfter i32)
-  i32.const 0
-  drop
   local.get $size
   i32.const 256
   i32.ge_u
@@ -1443,7 +1441,7 @@
    if
     i32.const 0
     i32.const 32
-    i32.const 499
+    i32.const 492
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1463,7 +1461,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 501
+   i32.const 494
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/rt/alloc-large-memory.debug.wat
+++ b/tests/compiler/rt/alloc-large-memory.debug.wat
@@ -670,11 +670,19 @@
   local.set $end
   i32.const 0
   drop
+  i32.const 1
+  drop
   local.get $start
   i64.extend_i32_u
   local.get $endU64
-  i64.gt_u
+  i64.le_u
+  i32.eqz
   if
+   i32.const 0
+   i32.const 32
+   i32.const 386
+   i32.const 14
+   call $~lib/builtins/abort
    unreachable
   end
   local.get $start
@@ -718,7 +726,7 @@
    if
     i32.const 0
     i32.const 32
-    i32.const 392
+    i32.const 393
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -750,7 +758,7 @@
    if
     i32.const 0
     i32.const 32
-    i32.const 405
+    i32.const 406
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -990,7 +998,7 @@
   if
    i32.const 96
    i32.const 32
-   i32.const 460
+   i32.const 461
    i32.const 29
    call $~lib/builtins/abort
    unreachable
@@ -1433,7 +1441,7 @@
    if
     i32.const 0
     i32.const 32
-    i32.const 492
+    i32.const 493
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1453,7 +1461,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 494
+   i32.const 495
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/rt/alloc-large-memory.debug.wat
+++ b/tests/compiler/rt/alloc-large-memory.debug.wat
@@ -670,19 +670,11 @@
   local.set $end
   i32.const 0
   drop
-  i32.const 1
-  drop
   local.get $start
   i64.extend_i32_u
   local.get $endU64
-  i64.le_u
-  i32.eqz
+  i64.gt_u
   if
-   i32.const 0
-   i32.const 32
-   i32.const 385
-   i32.const 14
-   call $~lib/builtins/abort
    unreachable
   end
   local.get $start

--- a/tests/compiler/rt/alloc-large-memory.release.wat
+++ b/tests/compiler/rt/alloc-large-memory.release.wat
@@ -417,7 +417,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 382
+   i32.const 385
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -442,7 +442,7 @@
    if
     i32.const 0
     i32.const 1056
-    i32.const 389
+    i32.const 392
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -469,7 +469,7 @@
    if
     i32.const 0
     i32.const 1056
-    i32.const 402
+    i32.const 405
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -741,7 +741,7 @@
   if
    i32.const 1120
    i32.const 1056
-   i32.const 461
+   i32.const 460
    i32.const 29
    call $~lib/builtins/abort
    unreachable
@@ -843,7 +843,7 @@
    if
     i32.const 0
     i32.const 1056
-    i32.const 499
+    i32.const 492
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -858,7 +858,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 501
+   i32.const 494
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/rt/alloc-large-memory.release.wat
+++ b/tests/compiler/rt/alloc-large-memory.release.wat
@@ -410,11 +410,16 @@
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
+  local.get $2
   local.get $1
   i64.extend_i32_u
-  local.get $2
-  i64.gt_u
+  i64.lt_u
   if
+   i32.const 0
+   i32.const 1056
+   i32.const 386
+   i32.const 14
+   call $~lib/builtins/abort
    unreachable
   end
   local.get $1
@@ -437,7 +442,7 @@
    if
     i32.const 0
     i32.const 1056
-    i32.const 392
+    i32.const 393
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -464,7 +469,7 @@
    if
     i32.const 0
     i32.const 1056
-    i32.const 405
+    i32.const 406
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -736,7 +741,7 @@
   if
    i32.const 1120
    i32.const 1056
-   i32.const 460
+   i32.const 461
    i32.const 29
    call $~lib/builtins/abort
    unreachable
@@ -838,7 +843,7 @@
    if
     i32.const 0
     i32.const 1056
-    i32.const 492
+    i32.const 493
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -853,7 +858,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 494
+   i32.const 495
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/rt/alloc-large-memory.release.wat
+++ b/tests/compiler/rt/alloc-large-memory.release.wat
@@ -410,16 +410,11 @@
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
-  local.get $2
   local.get $1
   i64.extend_i32_u
-  i64.lt_u
+  local.get $2
+  i64.gt_u
   if
-   i32.const 0
-   i32.const 1056
-   i32.const 385
-   i32.const 14
-   call $~lib/builtins/abort
    unreachable
   end
   local.get $1

--- a/tests/compiler/rt/finalize.debug.wat
+++ b/tests/compiler/rt/finalize.debug.wat
@@ -1044,11 +1044,19 @@
   local.set $end
   i32.const 0
   drop
+  i32.const 1
+  drop
   local.get $start
   i64.extend_i32_u
   local.get $endU64
-  i64.gt_u
+  i64.le_u
+  i32.eqz
   if
+   i32.const 0
+   i32.const 416
+   i32.const 386
+   i32.const 14
+   call $~lib/builtins/abort
    unreachable
   end
   local.get $start
@@ -1092,7 +1100,7 @@
    if
     i32.const 0
     i32.const 416
-    i32.const 392
+    i32.const 393
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1124,7 +1132,7 @@
    if
     i32.const 0
     i32.const 416
-    i32.const 405
+    i32.const 406
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1366,7 +1374,7 @@
   if
    i32.const 0
    i32.const 416
-   i32.const 555
+   i32.const 556
    i32.const 3
    call $~lib/builtins/abort
    unreachable
@@ -1699,7 +1707,7 @@
   if
    i32.const 32
    i32.const 416
-   i32.const 460
+   i32.const 461
    i32.const 29
    call $~lib/builtins/abort
    unreachable
@@ -2142,7 +2150,7 @@
    if
     i32.const 0
     i32.const 416
-    i32.const 492
+    i32.const 493
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -2162,7 +2170,7 @@
   if
    i32.const 0
    i32.const 416
-   i32.const 494
+   i32.const 495
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/rt/finalize.debug.wat
+++ b/tests/compiler/rt/finalize.debug.wat
@@ -1042,6 +1042,8 @@
   local.get $endU64
   i32.wrap_i64
   local.set $end
+  i32.const 0
+  drop
   i32.const 1
   drop
   local.get $start
@@ -1052,7 +1054,7 @@
   if
    i32.const 0
    i32.const 416
-   i32.const 382
+   i32.const 385
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1098,7 +1100,7 @@
    if
     i32.const 0
     i32.const 416
-    i32.const 389
+    i32.const 392
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1130,7 +1132,7 @@
    if
     i32.const 0
     i32.const 416
-    i32.const 402
+    i32.const 405
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1331,8 +1333,6 @@
   i32.const 1572
   i32.add
   local.set $memStart
-  i32.const 0
-  drop
   local.get $root
   local.get $memStart
   memory.size
@@ -1374,7 +1374,7 @@
   if
    i32.const 0
    i32.const 416
-   i32.const 562
+   i32.const 555
    i32.const 3
    call $~lib/builtins/abort
    unreachable
@@ -1707,7 +1707,7 @@
   if
    i32.const 32
    i32.const 416
-   i32.const 461
+   i32.const 460
    i32.const 29
    call $~lib/builtins/abort
    unreachable
@@ -1941,8 +1941,6 @@
   (local $6 i32)
   (local $pagesWanted i32)
   (local $pagesAfter i32)
-  i32.const 0
-  drop
   local.get $size
   i32.const 256
   i32.ge_u
@@ -2152,7 +2150,7 @@
    if
     i32.const 0
     i32.const 416
-    i32.const 499
+    i32.const 492
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -2172,7 +2170,7 @@
   if
    i32.const 0
    i32.const 416
-   i32.const 501
+   i32.const 494
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/rt/finalize.debug.wat
+++ b/tests/compiler/rt/finalize.debug.wat
@@ -1044,19 +1044,11 @@
   local.set $end
   i32.const 0
   drop
-  i32.const 1
-  drop
   local.get $start
   i64.extend_i32_u
   local.get $endU64
-  i64.le_u
-  i32.eqz
+  i64.gt_u
   if
-   i32.const 0
-   i32.const 416
-   i32.const 385
-   i32.const 14
-   call $~lib/builtins/abort
    unreachable
   end
   local.get $start

--- a/tests/compiler/rt/finalize.release.wat
+++ b/tests/compiler/rt/finalize.release.wat
@@ -630,16 +630,11 @@
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
-  local.get $2
   local.get $1
   i64.extend_i32_u
-  i64.lt_u
+  local.get $2
+  i64.gt_u
   if
-   i32.const 0
-   i32.const 1440
-   i32.const 385
-   i32.const 14
-   call $~lib/builtins/abort
    unreachable
   end
   local.get $1

--- a/tests/compiler/rt/finalize.release.wat
+++ b/tests/compiler/rt/finalize.release.wat
@@ -630,11 +630,16 @@
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
+  local.get $2
   local.get $1
   i64.extend_i32_u
-  local.get $2
-  i64.gt_u
+  i64.lt_u
   if
+   i32.const 0
+   i32.const 1440
+   i32.const 386
+   i32.const 14
+   call $~lib/builtins/abort
    unreachable
   end
   local.get $1
@@ -657,7 +662,7 @@
    if
     i32.const 0
     i32.const 1440
-    i32.const 392
+    i32.const 393
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -684,7 +689,7 @@
    if
     i32.const 0
     i32.const 1440
-    i32.const 405
+    i32.const 406
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1062,7 +1067,7 @@
       if
        i32.const 0
        i32.const 1440
-       i32.const 555
+       i32.const 556
        i32.const 3
        call $~lib/builtins/abort
        unreachable
@@ -1260,7 +1265,7 @@
    if
     i32.const 0
     i32.const 1440
-    i32.const 492
+    i32.const 493
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1275,7 +1280,7 @@
   if
    i32.const 0
    i32.const 1440
-   i32.const 494
+   i32.const 495
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/rt/finalize.release.wat
+++ b/tests/compiler/rt/finalize.release.wat
@@ -637,7 +637,7 @@
   if
    i32.const 0
    i32.const 1440
-   i32.const 382
+   i32.const 385
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -662,7 +662,7 @@
    if
     i32.const 0
     i32.const 1440
-    i32.const 389
+    i32.const 392
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -689,7 +689,7 @@
    if
     i32.const 0
     i32.const 1440
-    i32.const 402
+    i32.const 405
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1067,7 +1067,7 @@
       if
        i32.const 0
        i32.const 1440
-       i32.const 562
+       i32.const 555
        i32.const 3
        call $~lib/builtins/abort
        unreachable
@@ -1265,7 +1265,7 @@
    if
     i32.const 0
     i32.const 1440
-    i32.const 499
+    i32.const 492
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1280,7 +1280,7 @@
   if
    i32.const 0
    i32.const 1440
-   i32.const 501
+   i32.const 494
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/rt/issue-2719.debug.wat
+++ b/tests/compiler/rt/issue-2719.debug.wat
@@ -1025,11 +1025,19 @@
   local.set $end
   i32.const 0
   drop
+  i32.const 1
+  drop
   local.get $start
   i64.extend_i32_u
   local.get $endU64
-  i64.gt_u
+  i64.le_u
+  i32.eqz
   if
+   i32.const 0
+   i32.const 368
+   i32.const 386
+   i32.const 14
+   call $~lib/builtins/abort
    unreachable
   end
   local.get $start
@@ -1073,7 +1081,7 @@
    if
     i32.const 0
     i32.const 368
-    i32.const 392
+    i32.const 393
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1105,7 +1113,7 @@
    if
     i32.const 0
     i32.const 368
-    i32.const 405
+    i32.const 406
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1347,7 +1355,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 555
+   i32.const 556
    i32.const 3
    call $~lib/builtins/abort
    unreachable
@@ -1676,7 +1684,7 @@
   if
    i32.const 32
    i32.const 368
-   i32.const 460
+   i32.const 461
    i32.const 29
    call $~lib/builtins/abort
    unreachable
@@ -2119,7 +2127,7 @@
    if
     i32.const 0
     i32.const 368
-    i32.const 492
+    i32.const 493
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -2139,7 +2147,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 494
+   i32.const 495
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/rt/issue-2719.debug.wat
+++ b/tests/compiler/rt/issue-2719.debug.wat
@@ -1023,6 +1023,8 @@
   local.get $endU64
   i32.wrap_i64
   local.set $end
+  i32.const 0
+  drop
   i32.const 1
   drop
   local.get $start
@@ -1033,7 +1035,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 382
+   i32.const 385
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1079,7 +1081,7 @@
    if
     i32.const 0
     i32.const 368
-    i32.const 389
+    i32.const 392
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1111,7 +1113,7 @@
    if
     i32.const 0
     i32.const 368
-    i32.const 402
+    i32.const 405
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1312,8 +1314,6 @@
   i32.const 1572
   i32.add
   local.set $memStart
-  i32.const 0
-  drop
   local.get $root
   local.get $memStart
   memory.size
@@ -1355,7 +1355,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 562
+   i32.const 555
    i32.const 3
    call $~lib/builtins/abort
    unreachable
@@ -1684,7 +1684,7 @@
   if
    i32.const 32
    i32.const 368
-   i32.const 461
+   i32.const 460
    i32.const 29
    call $~lib/builtins/abort
    unreachable
@@ -1918,8 +1918,6 @@
   (local $6 i32)
   (local $pagesWanted i32)
   (local $pagesAfter i32)
-  i32.const 0
-  drop
   local.get $size
   i32.const 256
   i32.ge_u
@@ -2129,7 +2127,7 @@
    if
     i32.const 0
     i32.const 368
-    i32.const 499
+    i32.const 492
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -2149,7 +2147,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 501
+   i32.const 494
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/rt/issue-2719.debug.wat
+++ b/tests/compiler/rt/issue-2719.debug.wat
@@ -1025,19 +1025,11 @@
   local.set $end
   i32.const 0
   drop
-  i32.const 1
-  drop
   local.get $start
   i64.extend_i32_u
   local.get $endU64
-  i64.le_u
-  i32.eqz
+  i64.gt_u
   if
-   i32.const 0
-   i32.const 368
-   i32.const 385
-   i32.const 14
-   call $~lib/builtins/abort
    unreachable
   end
   local.get $start

--- a/tests/compiler/rt/issue-2719.release.wat
+++ b/tests/compiler/rt/issue-2719.release.wat
@@ -627,11 +627,16 @@
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
+  local.get $2
   local.get $1
   i64.extend_i32_u
-  local.get $2
-  i64.gt_u
+  i64.lt_u
   if
+   i32.const 0
+   i32.const 1392
+   i32.const 386
+   i32.const 14
+   call $~lib/builtins/abort
    unreachable
   end
   local.get $1
@@ -654,7 +659,7 @@
    if
     i32.const 0
     i32.const 1392
-    i32.const 392
+    i32.const 393
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -681,7 +686,7 @@
    if
     i32.const 0
     i32.const 1392
-    i32.const 405
+    i32.const 406
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1044,7 +1049,7 @@
       if
        i32.const 0
        i32.const 1392
-       i32.const 555
+       i32.const 556
        i32.const 3
        call $~lib/builtins/abort
        unreachable
@@ -1279,7 +1284,7 @@
   if
    i32.const 1056
    i32.const 1392
-   i32.const 460
+   i32.const 461
    i32.const 29
    call $~lib/builtins/abort
    unreachable
@@ -1381,7 +1386,7 @@
    if
     i32.const 0
     i32.const 1392
-    i32.const 492
+    i32.const 493
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1396,7 +1401,7 @@
   if
    i32.const 0
    i32.const 1392
-   i32.const 494
+   i32.const 495
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/rt/issue-2719.release.wat
+++ b/tests/compiler/rt/issue-2719.release.wat
@@ -634,7 +634,7 @@
   if
    i32.const 0
    i32.const 1392
-   i32.const 382
+   i32.const 385
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -659,7 +659,7 @@
    if
     i32.const 0
     i32.const 1392
-    i32.const 389
+    i32.const 392
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -686,7 +686,7 @@
    if
     i32.const 0
     i32.const 1392
-    i32.const 402
+    i32.const 405
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1049,7 +1049,7 @@
       if
        i32.const 0
        i32.const 1392
-       i32.const 562
+       i32.const 555
        i32.const 3
        call $~lib/builtins/abort
        unreachable
@@ -1284,7 +1284,7 @@
   if
    i32.const 1056
    i32.const 1392
-   i32.const 461
+   i32.const 460
    i32.const 29
    call $~lib/builtins/abort
    unreachable
@@ -1386,7 +1386,7 @@
    if
     i32.const 0
     i32.const 1392
-    i32.const 499
+    i32.const 492
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1401,7 +1401,7 @@
   if
    i32.const 0
    i32.const 1392
-   i32.const 501
+   i32.const 494
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/rt/issue-2719.release.wat
+++ b/tests/compiler/rt/issue-2719.release.wat
@@ -627,16 +627,11 @@
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
-  local.get $2
   local.get $1
   i64.extend_i32_u
-  i64.lt_u
+  local.get $2
+  i64.gt_u
   if
-   i32.const 0
-   i32.const 1392
-   i32.const 385
-   i32.const 14
-   call $~lib/builtins/abort
    unreachable
   end
   local.get $1

--- a/tests/compiler/rt/runtime-incremental-export.debug.wat
+++ b/tests/compiler/rt/runtime-incremental-export.debug.wat
@@ -1031,11 +1031,19 @@
   local.set $end
   i32.const 0
   drop
+  i32.const 1
+  drop
   local.get $start
   i64.extend_i32_u
   local.get $endU64
-  i64.gt_u
+  i64.le_u
+  i32.eqz
   if
+   i32.const 0
+   i32.const 368
+   i32.const 386
+   i32.const 14
+   call $~lib/builtins/abort
    unreachable
   end
   local.get $start
@@ -1079,7 +1087,7 @@
    if
     i32.const 0
     i32.const 368
-    i32.const 392
+    i32.const 393
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1111,7 +1119,7 @@
    if
     i32.const 0
     i32.const 368
-    i32.const 405
+    i32.const 406
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1353,7 +1361,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 555
+   i32.const 556
    i32.const 3
    call $~lib/builtins/abort
    unreachable
@@ -1682,7 +1690,7 @@
   if
    i32.const 32
    i32.const 368
-   i32.const 460
+   i32.const 461
    i32.const 29
    call $~lib/builtins/abort
    unreachable
@@ -2125,7 +2133,7 @@
    if
     i32.const 0
     i32.const 368
-    i32.const 492
+    i32.const 493
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -2145,7 +2153,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 494
+   i32.const 495
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/rt/runtime-incremental-export.debug.wat
+++ b/tests/compiler/rt/runtime-incremental-export.debug.wat
@@ -1031,19 +1031,11 @@
   local.set $end
   i32.const 0
   drop
-  i32.const 1
-  drop
   local.get $start
   i64.extend_i32_u
   local.get $endU64
-  i64.le_u
-  i32.eqz
+  i64.gt_u
   if
-   i32.const 0
-   i32.const 368
-   i32.const 385
-   i32.const 14
-   call $~lib/builtins/abort
    unreachable
   end
   local.get $start

--- a/tests/compiler/rt/runtime-incremental-export.debug.wat
+++ b/tests/compiler/rt/runtime-incremental-export.debug.wat
@@ -1029,6 +1029,8 @@
   local.get $endU64
   i32.wrap_i64
   local.set $end
+  i32.const 0
+  drop
   i32.const 1
   drop
   local.get $start
@@ -1039,7 +1041,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 382
+   i32.const 385
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1085,7 +1087,7 @@
    if
     i32.const 0
     i32.const 368
-    i32.const 389
+    i32.const 392
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1117,7 +1119,7 @@
    if
     i32.const 0
     i32.const 368
-    i32.const 402
+    i32.const 405
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1318,8 +1320,6 @@
   i32.const 1572
   i32.add
   local.set $memStart
-  i32.const 0
-  drop
   local.get $root
   local.get $memStart
   memory.size
@@ -1361,7 +1361,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 562
+   i32.const 555
    i32.const 3
    call $~lib/builtins/abort
    unreachable
@@ -1690,7 +1690,7 @@
   if
    i32.const 32
    i32.const 368
-   i32.const 461
+   i32.const 460
    i32.const 29
    call $~lib/builtins/abort
    unreachable
@@ -1924,8 +1924,6 @@
   (local $6 i32)
   (local $pagesWanted i32)
   (local $pagesAfter i32)
-  i32.const 0
-  drop
   local.get $size
   i32.const 256
   i32.ge_u
@@ -2135,7 +2133,7 @@
    if
     i32.const 0
     i32.const 368
-    i32.const 499
+    i32.const 492
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -2155,7 +2153,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 501
+   i32.const 494
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/rt/runtime-incremental-export.release.wat
+++ b/tests/compiler/rt/runtime-incremental-export.release.wat
@@ -646,16 +646,11 @@
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
-  local.get $2
   local.get $1
   i64.extend_i32_u
-  i64.lt_u
+  local.get $2
+  i64.gt_u
   if
-   i32.const 0
-   i32.const 1392
-   i32.const 385
-   i32.const 14
-   call $~lib/builtins/abort
    unreachable
   end
   local.get $1

--- a/tests/compiler/rt/runtime-incremental-export.release.wat
+++ b/tests/compiler/rt/runtime-incremental-export.release.wat
@@ -646,11 +646,16 @@
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
+  local.get $2
   local.get $1
   i64.extend_i32_u
-  local.get $2
-  i64.gt_u
+  i64.lt_u
   if
+   i32.const 0
+   i32.const 1392
+   i32.const 386
+   i32.const 14
+   call $~lib/builtins/abort
    unreachable
   end
   local.get $1
@@ -673,7 +678,7 @@
    if
     i32.const 0
     i32.const 1392
-    i32.const 392
+    i32.const 393
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -700,7 +705,7 @@
    if
     i32.const 0
     i32.const 1392
-    i32.const 405
+    i32.const 406
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1063,7 +1068,7 @@
       if
        i32.const 0
        i32.const 1392
-       i32.const 555
+       i32.const 556
        i32.const 3
        call $~lib/builtins/abort
        unreachable
@@ -1298,7 +1303,7 @@
   if
    i32.const 1056
    i32.const 1392
-   i32.const 460
+   i32.const 461
    i32.const 29
    call $~lib/builtins/abort
    unreachable
@@ -1400,7 +1405,7 @@
    if
     i32.const 0
     i32.const 1392
-    i32.const 492
+    i32.const 493
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1415,7 +1420,7 @@
   if
    i32.const 0
    i32.const 1392
-   i32.const 494
+   i32.const 495
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/rt/runtime-incremental-export.release.wat
+++ b/tests/compiler/rt/runtime-incremental-export.release.wat
@@ -653,7 +653,7 @@
   if
    i32.const 0
    i32.const 1392
-   i32.const 382
+   i32.const 385
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -678,7 +678,7 @@
    if
     i32.const 0
     i32.const 1392
-    i32.const 389
+    i32.const 392
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -705,7 +705,7 @@
    if
     i32.const 0
     i32.const 1392
-    i32.const 402
+    i32.const 405
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1068,7 +1068,7 @@
       if
        i32.const 0
        i32.const 1392
-       i32.const 562
+       i32.const 555
        i32.const 3
        call $~lib/builtins/abort
        unreachable
@@ -1303,7 +1303,7 @@
   if
    i32.const 1056
    i32.const 1392
-   i32.const 461
+   i32.const 460
    i32.const 29
    call $~lib/builtins/abort
    unreachable
@@ -1405,7 +1405,7 @@
    if
     i32.const 0
     i32.const 1392
-    i32.const 499
+    i32.const 492
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1420,7 +1420,7 @@
   if
    i32.const 0
    i32.const 1392
-   i32.const 501
+   i32.const 494
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/rt/runtime-minimal-export.debug.wat
+++ b/tests/compiler/rt/runtime-minimal-export.debug.wat
@@ -687,11 +687,19 @@
   local.set $end
   i32.const 0
   drop
+  i32.const 1
+  drop
   local.get $start
   i64.extend_i32_u
   local.get $endU64
-  i64.gt_u
+  i64.le_u
+  i32.eqz
   if
+   i32.const 0
+   i32.const 160
+   i32.const 386
+   i32.const 14
+   call $~lib/builtins/abort
    unreachable
   end
   local.get $start
@@ -735,7 +743,7 @@
    if
     i32.const 0
     i32.const 160
-    i32.const 392
+    i32.const 393
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -767,7 +775,7 @@
    if
     i32.const 0
     i32.const 160
-    i32.const 405
+    i32.const 406
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1007,7 +1015,7 @@
   if
    i32.const 32
    i32.const 160
-   i32.const 460
+   i32.const 461
    i32.const 29
    call $~lib/builtins/abort
    unreachable
@@ -1450,7 +1458,7 @@
    if
     i32.const 0
     i32.const 160
-    i32.const 492
+    i32.const 493
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1470,7 +1478,7 @@
   if
    i32.const 0
    i32.const 160
-   i32.const 494
+   i32.const 495
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1781,7 +1789,7 @@
   if
    i32.const 0
    i32.const 160
-   i32.const 555
+   i32.const 556
    i32.const 3
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/rt/runtime-minimal-export.debug.wat
+++ b/tests/compiler/rt/runtime-minimal-export.debug.wat
@@ -685,6 +685,8 @@
   local.get $endU64
   i32.wrap_i64
   local.set $end
+  i32.const 0
+  drop
   i32.const 1
   drop
   local.get $start
@@ -695,7 +697,7 @@
   if
    i32.const 0
    i32.const 160
-   i32.const 382
+   i32.const 385
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -741,7 +743,7 @@
    if
     i32.const 0
     i32.const 160
-    i32.const 389
+    i32.const 392
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -773,7 +775,7 @@
    if
     i32.const 0
     i32.const 160
-    i32.const 402
+    i32.const 405
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -974,8 +976,6 @@
   i32.const 1572
   i32.add
   local.set $memStart
-  i32.const 0
-  drop
   local.get $root
   local.get $memStart
   memory.size
@@ -1015,7 +1015,7 @@
   if
    i32.const 32
    i32.const 160
-   i32.const 461
+   i32.const 460
    i32.const 29
    call $~lib/builtins/abort
    unreachable
@@ -1249,8 +1249,6 @@
   (local $6 i32)
   (local $pagesWanted i32)
   (local $pagesAfter i32)
-  i32.const 0
-  drop
   local.get $size
   i32.const 256
   i32.ge_u
@@ -1460,7 +1458,7 @@
    if
     i32.const 0
     i32.const 160
-    i32.const 499
+    i32.const 492
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1480,7 +1478,7 @@
   if
    i32.const 0
    i32.const 160
-   i32.const 501
+   i32.const 494
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1791,7 +1789,7 @@
   if
    i32.const 0
    i32.const 160
-   i32.const 562
+   i32.const 555
    i32.const 3
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/rt/runtime-minimal-export.debug.wat
+++ b/tests/compiler/rt/runtime-minimal-export.debug.wat
@@ -687,19 +687,11 @@
   local.set $end
   i32.const 0
   drop
-  i32.const 1
-  drop
   local.get $start
   i64.extend_i32_u
   local.get $endU64
-  i64.le_u
-  i32.eqz
+  i64.gt_u
   if
-   i32.const 0
-   i32.const 160
-   i32.const 385
-   i32.const 14
-   call $~lib/builtins/abort
    unreachable
   end
   local.get $start

--- a/tests/compiler/rt/runtime-minimal-export.release.wat
+++ b/tests/compiler/rt/runtime-minimal-export.release.wat
@@ -429,16 +429,11 @@
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
-  local.get $2
   local.get $1
   i64.extend_i32_u
-  i64.lt_u
+  local.get $2
+  i64.gt_u
   if
-   i32.const 0
-   i32.const 1184
-   i32.const 385
-   i32.const 14
-   call $~lib/builtins/abort
    unreachable
   end
   local.get $1

--- a/tests/compiler/rt/runtime-minimal-export.release.wat
+++ b/tests/compiler/rt/runtime-minimal-export.release.wat
@@ -436,7 +436,7 @@
   if
    i32.const 0
    i32.const 1184
-   i32.const 382
+   i32.const 385
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -461,7 +461,7 @@
    if
     i32.const 0
     i32.const 1184
-    i32.const 389
+    i32.const 392
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -488,7 +488,7 @@
    if
     i32.const 0
     i32.const 1184
-    i32.const 402
+    i32.const 405
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -780,7 +780,7 @@
   if
    i32.const 1056
    i32.const 1184
-   i32.const 461
+   i32.const 460
    i32.const 29
    call $~lib/builtins/abort
    unreachable
@@ -882,7 +882,7 @@
    if
     i32.const 0
     i32.const 1184
-    i32.const 499
+    i32.const 492
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -897,7 +897,7 @@
   if
    i32.const 0
    i32.const 1184
-   i32.const 501
+   i32.const 494
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1344,7 +1344,7 @@
       if
        i32.const 0
        i32.const 1184
-       i32.const 562
+       i32.const 555
        i32.const 3
        call $~lib/builtins/abort
        unreachable

--- a/tests/compiler/rt/runtime-minimal-export.release.wat
+++ b/tests/compiler/rt/runtime-minimal-export.release.wat
@@ -429,11 +429,16 @@
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
+  local.get $2
   local.get $1
   i64.extend_i32_u
-  local.get $2
-  i64.gt_u
+  i64.lt_u
   if
+   i32.const 0
+   i32.const 1184
+   i32.const 386
+   i32.const 14
+   call $~lib/builtins/abort
    unreachable
   end
   local.get $1
@@ -456,7 +461,7 @@
    if
     i32.const 0
     i32.const 1184
-    i32.const 392
+    i32.const 393
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -483,7 +488,7 @@
    if
     i32.const 0
     i32.const 1184
-    i32.const 405
+    i32.const 406
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -775,7 +780,7 @@
   if
    i32.const 1056
    i32.const 1184
-   i32.const 460
+   i32.const 461
    i32.const 29
    call $~lib/builtins/abort
    unreachable
@@ -877,7 +882,7 @@
    if
     i32.const 0
     i32.const 1184
-    i32.const 492
+    i32.const 493
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -892,7 +897,7 @@
   if
    i32.const 0
    i32.const 1184
-   i32.const 494
+   i32.const 495
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1339,7 +1344,7 @@
       if
        i32.const 0
        i32.const 1184
-       i32.const 555
+       i32.const 556
        i32.const 3
        call $~lib/builtins/abort
        unreachable

--- a/tests/compiler/simd.debug.wat
+++ b/tests/compiler/simd.debug.wat
@@ -1062,6 +1062,8 @@
   local.get $endU64
   i32.wrap_i64
   local.set $end
+  i32.const 0
+  drop
   i32.const 1
   drop
   local.get $start
@@ -1072,7 +1074,7 @@
   if
    i32.const 0
    i32.const 416
-   i32.const 382
+   i32.const 385
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1118,7 +1120,7 @@
    if
     i32.const 0
     i32.const 416
-    i32.const 389
+    i32.const 392
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1150,7 +1152,7 @@
    if
     i32.const 0
     i32.const 416
-    i32.const 402
+    i32.const 405
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1351,8 +1353,6 @@
   i32.const 1572
   i32.add
   local.set $memStart
-  i32.const 0
-  drop
   local.get $root
   local.get $memStart
   memory.size
@@ -1394,7 +1394,7 @@
   if
    i32.const 0
    i32.const 416
-   i32.const 562
+   i32.const 555
    i32.const 3
    call $~lib/builtins/abort
    unreachable
@@ -1723,7 +1723,7 @@
   if
    i32.const 80
    i32.const 416
-   i32.const 461
+   i32.const 460
    i32.const 29
    call $~lib/builtins/abort
    unreachable
@@ -1957,8 +1957,6 @@
   (local $6 i32)
   (local $pagesWanted i32)
   (local $pagesAfter i32)
-  i32.const 0
-  drop
   local.get $size
   i32.const 256
   i32.ge_u
@@ -2168,7 +2166,7 @@
    if
     i32.const 0
     i32.const 416
-    i32.const 499
+    i32.const 492
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -2188,7 +2186,7 @@
   if
    i32.const 0
    i32.const 416
-   i32.const 501
+   i32.const 494
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/simd.debug.wat
+++ b/tests/compiler/simd.debug.wat
@@ -1064,19 +1064,11 @@
   local.set $end
   i32.const 0
   drop
-  i32.const 1
-  drop
   local.get $start
   i64.extend_i32_u
   local.get $endU64
-  i64.le_u
-  i32.eqz
+  i64.gt_u
   if
-   i32.const 0
-   i32.const 416
-   i32.const 385
-   i32.const 14
-   call $~lib/builtins/abort
    unreachable
   end
   local.get $start

--- a/tests/compiler/simd.debug.wat
+++ b/tests/compiler/simd.debug.wat
@@ -1064,11 +1064,19 @@
   local.set $end
   i32.const 0
   drop
+  i32.const 1
+  drop
   local.get $start
   i64.extend_i32_u
   local.get $endU64
-  i64.gt_u
+  i64.le_u
+  i32.eqz
   if
+   i32.const 0
+   i32.const 416
+   i32.const 386
+   i32.const 14
+   call $~lib/builtins/abort
    unreachable
   end
   local.get $start
@@ -1112,7 +1120,7 @@
    if
     i32.const 0
     i32.const 416
-    i32.const 392
+    i32.const 393
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1144,7 +1152,7 @@
    if
     i32.const 0
     i32.const 416
-    i32.const 405
+    i32.const 406
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1386,7 +1394,7 @@
   if
    i32.const 0
    i32.const 416
-   i32.const 555
+   i32.const 556
    i32.const 3
    call $~lib/builtins/abort
    unreachable
@@ -1715,7 +1723,7 @@
   if
    i32.const 80
    i32.const 416
-   i32.const 460
+   i32.const 461
    i32.const 29
    call $~lib/builtins/abort
    unreachable
@@ -2158,7 +2166,7 @@
    if
     i32.const 0
     i32.const 416
-    i32.const 492
+    i32.const 493
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -2178,7 +2186,7 @@
   if
    i32.const 0
    i32.const 416
-   i32.const 494
+   i32.const 495
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/simd.release.wat
+++ b/tests/compiler/simd.release.wat
@@ -662,11 +662,16 @@
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
+  local.get $2
   local.get $1
   i64.extend_i32_u
-  local.get $2
-  i64.gt_u
+  i64.lt_u
   if
+   i32.const 0
+   i32.const 1440
+   i32.const 386
+   i32.const 14
+   call $~lib/builtins/abort
    unreachable
   end
   local.get $1
@@ -689,7 +694,7 @@
    if
     i32.const 0
     i32.const 1440
-    i32.const 392
+    i32.const 393
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -716,7 +721,7 @@
    if
     i32.const 0
     i32.const 1440
-    i32.const 405
+    i32.const 406
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -884,7 +889,7 @@
   if
    i32.const 0
    i32.const 1440
-   i32.const 555
+   i32.const 556
    i32.const 3
    call $~lib/builtins/abort
    unreachable
@@ -1253,7 +1258,7 @@
   if
    i32.const 1104
    i32.const 1440
-   i32.const 460
+   i32.const 461
    i32.const 29
    call $~lib/builtins/abort
    unreachable
@@ -1355,7 +1360,7 @@
    if
     i32.const 0
     i32.const 1440
-    i32.const 492
+    i32.const 493
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1370,7 +1375,7 @@
   if
    i32.const 0
    i32.const 1440
-   i32.const 494
+   i32.const 495
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/simd.release.wat
+++ b/tests/compiler/simd.release.wat
@@ -669,7 +669,7 @@
   if
    i32.const 0
    i32.const 1440
-   i32.const 382
+   i32.const 385
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -694,7 +694,7 @@
    if
     i32.const 0
     i32.const 1440
-    i32.const 389
+    i32.const 392
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -721,7 +721,7 @@
    if
     i32.const 0
     i32.const 1440
-    i32.const 402
+    i32.const 405
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -889,7 +889,7 @@
   if
    i32.const 0
    i32.const 1440
-   i32.const 562
+   i32.const 555
    i32.const 3
    call $~lib/builtins/abort
    unreachable
@@ -1258,7 +1258,7 @@
   if
    i32.const 1104
    i32.const 1440
-   i32.const 461
+   i32.const 460
    i32.const 29
    call $~lib/builtins/abort
    unreachable
@@ -1360,7 +1360,7 @@
    if
     i32.const 0
     i32.const 1440
-    i32.const 499
+    i32.const 492
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1375,7 +1375,7 @@
   if
    i32.const 0
    i32.const 1440
-   i32.const 501
+   i32.const 494
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/simd.release.wat
+++ b/tests/compiler/simd.release.wat
@@ -662,16 +662,11 @@
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
-  local.get $2
   local.get $1
   i64.extend_i32_u
-  i64.lt_u
+  local.get $2
+  i64.gt_u
   if
-   i32.const 0
-   i32.const 1440
-   i32.const 385
-   i32.const 14
-   call $~lib/builtins/abort
    unreachable
   end
   local.get $1

--- a/tests/compiler/std/array-literal.debug.wat
+++ b/tests/compiler/std/array-literal.debug.wat
@@ -1060,19 +1060,11 @@
   local.set $end
   i32.const 0
   drop
-  i32.const 1
-  drop
   local.get $start
   i64.extend_i32_u
   local.get $endU64
-  i64.le_u
-  i32.eqz
+  i64.gt_u
   if
-   i32.const 0
-   i32.const 720
-   i32.const 385
-   i32.const 14
-   call $~lib/builtins/abort
    unreachable
   end
   local.get $start

--- a/tests/compiler/std/array-literal.debug.wat
+++ b/tests/compiler/std/array-literal.debug.wat
@@ -1058,6 +1058,8 @@
   local.get $endU64
   i32.wrap_i64
   local.set $end
+  i32.const 0
+  drop
   i32.const 1
   drop
   local.get $start
@@ -1068,7 +1070,7 @@
   if
    i32.const 0
    i32.const 720
-   i32.const 382
+   i32.const 385
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1114,7 +1116,7 @@
    if
     i32.const 0
     i32.const 720
-    i32.const 389
+    i32.const 392
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1146,7 +1148,7 @@
    if
     i32.const 0
     i32.const 720
-    i32.const 402
+    i32.const 405
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1347,8 +1349,6 @@
   i32.const 1572
   i32.add
   local.set $memStart
-  i32.const 0
-  drop
   local.get $root
   local.get $memStart
   memory.size
@@ -1390,7 +1390,7 @@
   if
    i32.const 0
    i32.const 720
-   i32.const 562
+   i32.const 555
    i32.const 3
    call $~lib/builtins/abort
    unreachable
@@ -1719,7 +1719,7 @@
   if
    i32.const 448
    i32.const 720
-   i32.const 461
+   i32.const 460
    i32.const 29
    call $~lib/builtins/abort
    unreachable
@@ -1953,8 +1953,6 @@
   (local $6 i32)
   (local $pagesWanted i32)
   (local $pagesAfter i32)
-  i32.const 0
-  drop
   local.get $size
   i32.const 256
   i32.ge_u
@@ -2164,7 +2162,7 @@
    if
     i32.const 0
     i32.const 720
-    i32.const 499
+    i32.const 492
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -2184,7 +2182,7 @@
   if
    i32.const 0
    i32.const 720
-   i32.const 501
+   i32.const 494
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/std/array-literal.debug.wat
+++ b/tests/compiler/std/array-literal.debug.wat
@@ -1060,11 +1060,19 @@
   local.set $end
   i32.const 0
   drop
+  i32.const 1
+  drop
   local.get $start
   i64.extend_i32_u
   local.get $endU64
-  i64.gt_u
+  i64.le_u
+  i32.eqz
   if
+   i32.const 0
+   i32.const 720
+   i32.const 386
+   i32.const 14
+   call $~lib/builtins/abort
    unreachable
   end
   local.get $start
@@ -1108,7 +1116,7 @@
    if
     i32.const 0
     i32.const 720
-    i32.const 392
+    i32.const 393
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1140,7 +1148,7 @@
    if
     i32.const 0
     i32.const 720
-    i32.const 405
+    i32.const 406
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1382,7 +1390,7 @@
   if
    i32.const 0
    i32.const 720
-   i32.const 555
+   i32.const 556
    i32.const 3
    call $~lib/builtins/abort
    unreachable
@@ -1711,7 +1719,7 @@
   if
    i32.const 448
    i32.const 720
-   i32.const 460
+   i32.const 461
    i32.const 29
    call $~lib/builtins/abort
    unreachable
@@ -2154,7 +2162,7 @@
    if
     i32.const 0
     i32.const 720
-    i32.const 492
+    i32.const 493
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -2174,7 +2182,7 @@
   if
    i32.const 0
    i32.const 720
-   i32.const 494
+   i32.const 495
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/std/array-literal.release.wat
+++ b/tests/compiler/std/array-literal.release.wat
@@ -692,16 +692,11 @@
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
-  local.get $2
   local.get $1
   i64.extend_i32_u
-  i64.lt_u
+  local.get $2
+  i64.gt_u
   if
-   i32.const 0
-   i32.const 1744
-   i32.const 385
-   i32.const 14
-   call $~lib/builtins/abort
    unreachable
   end
   local.get $1

--- a/tests/compiler/std/array-literal.release.wat
+++ b/tests/compiler/std/array-literal.release.wat
@@ -699,7 +699,7 @@
   if
    i32.const 0
    i32.const 1744
-   i32.const 382
+   i32.const 385
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -724,7 +724,7 @@
    if
     i32.const 0
     i32.const 1744
-    i32.const 389
+    i32.const 392
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -751,7 +751,7 @@
    if
     i32.const 0
     i32.const 1744
-    i32.const 402
+    i32.const 405
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1114,7 +1114,7 @@
       if
        i32.const 0
        i32.const 1744
-       i32.const 562
+       i32.const 555
        i32.const 3
        call $~lib/builtins/abort
        unreachable
@@ -1349,7 +1349,7 @@
   if
    i32.const 1472
    i32.const 1744
-   i32.const 461
+   i32.const 460
    i32.const 29
    call $~lib/builtins/abort
    unreachable
@@ -1451,7 +1451,7 @@
    if
     i32.const 0
     i32.const 1744
-    i32.const 499
+    i32.const 492
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1466,7 +1466,7 @@
   if
    i32.const 0
    i32.const 1744
-   i32.const 501
+   i32.const 494
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/std/array-literal.release.wat
+++ b/tests/compiler/std/array-literal.release.wat
@@ -692,11 +692,16 @@
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
+  local.get $2
   local.get $1
   i64.extend_i32_u
-  local.get $2
-  i64.gt_u
+  i64.lt_u
   if
+   i32.const 0
+   i32.const 1744
+   i32.const 386
+   i32.const 14
+   call $~lib/builtins/abort
    unreachable
   end
   local.get $1
@@ -719,7 +724,7 @@
    if
     i32.const 0
     i32.const 1744
-    i32.const 392
+    i32.const 393
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -746,7 +751,7 @@
    if
     i32.const 0
     i32.const 1744
-    i32.const 405
+    i32.const 406
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1109,7 +1114,7 @@
       if
        i32.const 0
        i32.const 1744
-       i32.const 555
+       i32.const 556
        i32.const 3
        call $~lib/builtins/abort
        unreachable
@@ -1344,7 +1349,7 @@
   if
    i32.const 1472
    i32.const 1744
-   i32.const 460
+   i32.const 461
    i32.const 29
    call $~lib/builtins/abort
    unreachable
@@ -1446,7 +1451,7 @@
    if
     i32.const 0
     i32.const 1744
-    i32.const 492
+    i32.const 493
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1461,7 +1466,7 @@
   if
    i32.const 0
    i32.const 1744
-   i32.const 494
+   i32.const 495
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/std/array.debug.wat
+++ b/tests/compiler/std/array.debug.wat
@@ -1369,11 +1369,19 @@
   local.set $end
   i32.const 0
   drop
+  i32.const 1
+  drop
   local.get $start
   i64.extend_i32_u
   local.get $endU64
-  i64.gt_u
+  i64.le_u
+  i32.eqz
   if
+   i32.const 0
+   i32.const 464
+   i32.const 386
+   i32.const 14
+   call $~lib/builtins/abort
    unreachable
   end
   local.get $start
@@ -1417,7 +1425,7 @@
    if
     i32.const 0
     i32.const 464
-    i32.const 392
+    i32.const 393
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1449,7 +1457,7 @@
    if
     i32.const 0
     i32.const 464
-    i32.const 405
+    i32.const 406
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1691,7 +1699,7 @@
   if
    i32.const 0
    i32.const 464
-   i32.const 555
+   i32.const 556
    i32.const 3
    call $~lib/builtins/abort
    unreachable
@@ -2020,7 +2028,7 @@
   if
    i32.const 128
    i32.const 464
-   i32.const 460
+   i32.const 461
    i32.const 29
    call $~lib/builtins/abort
    unreachable
@@ -2463,7 +2471,7 @@
    if
     i32.const 0
     i32.const 464
-    i32.const 492
+    i32.const 493
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -2483,7 +2491,7 @@
   if
    i32.const 0
    i32.const 464
-   i32.const 494
+   i32.const 495
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/std/array.debug.wat
+++ b/tests/compiler/std/array.debug.wat
@@ -1367,6 +1367,8 @@
   local.get $endU64
   i32.wrap_i64
   local.set $end
+  i32.const 0
+  drop
   i32.const 1
   drop
   local.get $start
@@ -1377,7 +1379,7 @@
   if
    i32.const 0
    i32.const 464
-   i32.const 382
+   i32.const 385
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1423,7 +1425,7 @@
    if
     i32.const 0
     i32.const 464
-    i32.const 389
+    i32.const 392
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1455,7 +1457,7 @@
    if
     i32.const 0
     i32.const 464
-    i32.const 402
+    i32.const 405
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1656,8 +1658,6 @@
   i32.const 1572
   i32.add
   local.set $memStart
-  i32.const 0
-  drop
   local.get $root
   local.get $memStart
   memory.size
@@ -1699,7 +1699,7 @@
   if
    i32.const 0
    i32.const 464
-   i32.const 562
+   i32.const 555
    i32.const 3
    call $~lib/builtins/abort
    unreachable
@@ -2028,7 +2028,7 @@
   if
    i32.const 128
    i32.const 464
-   i32.const 461
+   i32.const 460
    i32.const 29
    call $~lib/builtins/abort
    unreachable
@@ -2262,8 +2262,6 @@
   (local $6 i32)
   (local $pagesWanted i32)
   (local $pagesAfter i32)
-  i32.const 0
-  drop
   local.get $size
   i32.const 256
   i32.ge_u
@@ -2473,7 +2471,7 @@
    if
     i32.const 0
     i32.const 464
-    i32.const 499
+    i32.const 492
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -2493,7 +2491,7 @@
   if
    i32.const 0
    i32.const 464
-   i32.const 501
+   i32.const 494
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/std/array.debug.wat
+++ b/tests/compiler/std/array.debug.wat
@@ -1369,19 +1369,11 @@
   local.set $end
   i32.const 0
   drop
-  i32.const 1
-  drop
   local.get $start
   i64.extend_i32_u
   local.get $endU64
-  i64.le_u
-  i32.eqz
+  i64.gt_u
   if
-   i32.const 0
-   i32.const 464
-   i32.const 385
-   i32.const 14
-   call $~lib/builtins/abort
    unreachable
   end
   local.get $start

--- a/tests/compiler/std/array.release.wat
+++ b/tests/compiler/std/array.release.wat
@@ -1294,7 +1294,7 @@
   if
    i32.const 0
    i32.const 1488
-   i32.const 382
+   i32.const 385
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1319,7 +1319,7 @@
    if
     i32.const 0
     i32.const 1488
-    i32.const 389
+    i32.const 392
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1346,7 +1346,7 @@
    if
     i32.const 0
     i32.const 1488
-    i32.const 402
+    i32.const 405
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1514,7 +1514,7 @@
   if
    i32.const 0
    i32.const 1488
-   i32.const 562
+   i32.const 555
    i32.const 3
    call $~lib/builtins/abort
    unreachable
@@ -1883,7 +1883,7 @@
   if
    i32.const 1152
    i32.const 1488
-   i32.const 461
+   i32.const 460
    i32.const 29
    call $~lib/builtins/abort
    unreachable
@@ -1985,7 +1985,7 @@
    if
     i32.const 0
     i32.const 1488
-    i32.const 499
+    i32.const 492
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -2000,7 +2000,7 @@
   if
    i32.const 0
    i32.const 1488
-   i32.const 501
+   i32.const 494
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/std/array.release.wat
+++ b/tests/compiler/std/array.release.wat
@@ -1287,11 +1287,16 @@
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
+  local.get $2
   local.get $1
   i64.extend_i32_u
-  local.get $2
-  i64.gt_u
+  i64.lt_u
   if
+   i32.const 0
+   i32.const 1488
+   i32.const 386
+   i32.const 14
+   call $~lib/builtins/abort
    unreachable
   end
   local.get $1
@@ -1314,7 +1319,7 @@
    if
     i32.const 0
     i32.const 1488
-    i32.const 392
+    i32.const 393
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1341,7 +1346,7 @@
    if
     i32.const 0
     i32.const 1488
-    i32.const 405
+    i32.const 406
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1509,7 +1514,7 @@
   if
    i32.const 0
    i32.const 1488
-   i32.const 555
+   i32.const 556
    i32.const 3
    call $~lib/builtins/abort
    unreachable
@@ -1878,7 +1883,7 @@
   if
    i32.const 1152
    i32.const 1488
-   i32.const 460
+   i32.const 461
    i32.const 29
    call $~lib/builtins/abort
    unreachable
@@ -1980,7 +1985,7 @@
    if
     i32.const 0
     i32.const 1488
-    i32.const 492
+    i32.const 493
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1995,7 +2000,7 @@
   if
    i32.const 0
    i32.const 1488
-   i32.const 494
+   i32.const 495
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/std/array.release.wat
+++ b/tests/compiler/std/array.release.wat
@@ -1287,16 +1287,11 @@
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
-  local.get $2
   local.get $1
   i64.extend_i32_u
-  i64.lt_u
+  local.get $2
+  i64.gt_u
   if
-   i32.const 0
-   i32.const 1488
-   i32.const 385
-   i32.const 14
-   call $~lib/builtins/abort
    unreachable
   end
   local.get $1

--- a/tests/compiler/std/arraybuffer.debug.wat
+++ b/tests/compiler/std/arraybuffer.debug.wat
@@ -1033,11 +1033,19 @@
   local.set $end
   i32.const 0
   drop
+  i32.const 1
+  drop
   local.get $start
   i64.extend_i32_u
   local.get $endU64
-  i64.gt_u
+  i64.le_u
+  i32.eqz
   if
+   i32.const 0
+   i32.const 480
+   i32.const 386
+   i32.const 14
+   call $~lib/builtins/abort
    unreachable
   end
   local.get $start
@@ -1081,7 +1089,7 @@
    if
     i32.const 0
     i32.const 480
-    i32.const 392
+    i32.const 393
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1113,7 +1121,7 @@
    if
     i32.const 0
     i32.const 480
-    i32.const 405
+    i32.const 406
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1355,7 +1363,7 @@
   if
    i32.const 0
    i32.const 480
-   i32.const 555
+   i32.const 556
    i32.const 3
    call $~lib/builtins/abort
    unreachable
@@ -1684,7 +1692,7 @@
   if
    i32.const 144
    i32.const 480
-   i32.const 460
+   i32.const 461
    i32.const 29
    call $~lib/builtins/abort
    unreachable
@@ -2127,7 +2135,7 @@
    if
     i32.const 0
     i32.const 480
-    i32.const 492
+    i32.const 493
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -2147,7 +2155,7 @@
   if
    i32.const 0
    i32.const 480
-   i32.const 494
+   i32.const 495
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/std/arraybuffer.debug.wat
+++ b/tests/compiler/std/arraybuffer.debug.wat
@@ -1031,6 +1031,8 @@
   local.get $endU64
   i32.wrap_i64
   local.set $end
+  i32.const 0
+  drop
   i32.const 1
   drop
   local.get $start
@@ -1041,7 +1043,7 @@
   if
    i32.const 0
    i32.const 480
-   i32.const 382
+   i32.const 385
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1087,7 +1089,7 @@
    if
     i32.const 0
     i32.const 480
-    i32.const 389
+    i32.const 392
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1119,7 +1121,7 @@
    if
     i32.const 0
     i32.const 480
-    i32.const 402
+    i32.const 405
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1320,8 +1322,6 @@
   i32.const 1572
   i32.add
   local.set $memStart
-  i32.const 0
-  drop
   local.get $root
   local.get $memStart
   memory.size
@@ -1363,7 +1363,7 @@
   if
    i32.const 0
    i32.const 480
-   i32.const 562
+   i32.const 555
    i32.const 3
    call $~lib/builtins/abort
    unreachable
@@ -1692,7 +1692,7 @@
   if
    i32.const 144
    i32.const 480
-   i32.const 461
+   i32.const 460
    i32.const 29
    call $~lib/builtins/abort
    unreachable
@@ -1926,8 +1926,6 @@
   (local $6 i32)
   (local $pagesWanted i32)
   (local $pagesAfter i32)
-  i32.const 0
-  drop
   local.get $size
   i32.const 256
   i32.ge_u
@@ -2137,7 +2135,7 @@
    if
     i32.const 0
     i32.const 480
-    i32.const 499
+    i32.const 492
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -2157,7 +2155,7 @@
   if
    i32.const 0
    i32.const 480
-   i32.const 501
+   i32.const 494
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/std/arraybuffer.debug.wat
+++ b/tests/compiler/std/arraybuffer.debug.wat
@@ -1033,19 +1033,11 @@
   local.set $end
   i32.const 0
   drop
-  i32.const 1
-  drop
   local.get $start
   i64.extend_i32_u
   local.get $endU64
-  i64.le_u
-  i32.eqz
+  i64.gt_u
   if
-   i32.const 0
-   i32.const 480
-   i32.const 385
-   i32.const 14
-   call $~lib/builtins/abort
    unreachable
   end
   local.get $start

--- a/tests/compiler/std/arraybuffer.release.wat
+++ b/tests/compiler/std/arraybuffer.release.wat
@@ -642,16 +642,11 @@
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
-  local.get $2
   local.get $1
   i64.extend_i32_u
-  i64.lt_u
+  local.get $2
+  i64.gt_u
   if
-   i32.const 0
-   i32.const 1504
-   i32.const 385
-   i32.const 14
-   call $~lib/builtins/abort
    unreachable
   end
   local.get $1

--- a/tests/compiler/std/arraybuffer.release.wat
+++ b/tests/compiler/std/arraybuffer.release.wat
@@ -649,7 +649,7 @@
   if
    i32.const 0
    i32.const 1504
-   i32.const 382
+   i32.const 385
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -674,7 +674,7 @@
    if
     i32.const 0
     i32.const 1504
-    i32.const 389
+    i32.const 392
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -701,7 +701,7 @@
    if
     i32.const 0
     i32.const 1504
-    i32.const 402
+    i32.const 405
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1064,7 +1064,7 @@
       if
        i32.const 0
        i32.const 1504
-       i32.const 562
+       i32.const 555
        i32.const 3
        call $~lib/builtins/abort
        unreachable
@@ -1299,7 +1299,7 @@
   if
    i32.const 1168
    i32.const 1504
-   i32.const 461
+   i32.const 460
    i32.const 29
    call $~lib/builtins/abort
    unreachable
@@ -1401,7 +1401,7 @@
    if
     i32.const 0
     i32.const 1504
-    i32.const 499
+    i32.const 492
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1416,7 +1416,7 @@
   if
    i32.const 0
    i32.const 1504
-   i32.const 501
+   i32.const 494
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/std/arraybuffer.release.wat
+++ b/tests/compiler/std/arraybuffer.release.wat
@@ -642,11 +642,16 @@
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
+  local.get $2
   local.get $1
   i64.extend_i32_u
-  local.get $2
-  i64.gt_u
+  i64.lt_u
   if
+   i32.const 0
+   i32.const 1504
+   i32.const 386
+   i32.const 14
+   call $~lib/builtins/abort
    unreachable
   end
   local.get $1
@@ -669,7 +674,7 @@
    if
     i32.const 0
     i32.const 1504
-    i32.const 392
+    i32.const 393
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -696,7 +701,7 @@
    if
     i32.const 0
     i32.const 1504
-    i32.const 405
+    i32.const 406
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1059,7 +1064,7 @@
       if
        i32.const 0
        i32.const 1504
-       i32.const 555
+       i32.const 556
        i32.const 3
        call $~lib/builtins/abort
        unreachable
@@ -1294,7 +1299,7 @@
   if
    i32.const 1168
    i32.const 1504
-   i32.const 460
+   i32.const 461
    i32.const 29
    call $~lib/builtins/abort
    unreachable
@@ -1396,7 +1401,7 @@
    if
     i32.const 0
     i32.const 1504
-    i32.const 492
+    i32.const 493
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1411,7 +1416,7 @@
   if
    i32.const 0
    i32.const 1504
-   i32.const 494
+   i32.const 495
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/std/dataview.debug.wat
+++ b/tests/compiler/std/dataview.debug.wat
@@ -1040,11 +1040,19 @@
   local.set $end
   i32.const 0
   drop
+  i32.const 1
+  drop
   local.get $start
   i64.extend_i32_u
   local.get $endU64
-  i64.gt_u
+  i64.le_u
+  i32.eqz
   if
+   i32.const 0
+   i32.const 480
+   i32.const 386
+   i32.const 14
+   call $~lib/builtins/abort
    unreachable
   end
   local.get $start
@@ -1088,7 +1096,7 @@
    if
     i32.const 0
     i32.const 480
-    i32.const 392
+    i32.const 393
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1120,7 +1128,7 @@
    if
     i32.const 0
     i32.const 480
-    i32.const 405
+    i32.const 406
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1362,7 +1370,7 @@
   if
    i32.const 0
    i32.const 480
-   i32.const 555
+   i32.const 556
    i32.const 3
    call $~lib/builtins/abort
    unreachable
@@ -1691,7 +1699,7 @@
   if
    i32.const 144
    i32.const 480
-   i32.const 460
+   i32.const 461
    i32.const 29
    call $~lib/builtins/abort
    unreachable
@@ -2134,7 +2142,7 @@
    if
     i32.const 0
     i32.const 480
-    i32.const 492
+    i32.const 493
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -2154,7 +2162,7 @@
   if
    i32.const 0
    i32.const 480
-   i32.const 494
+   i32.const 495
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/std/dataview.debug.wat
+++ b/tests/compiler/std/dataview.debug.wat
@@ -1040,19 +1040,11 @@
   local.set $end
   i32.const 0
   drop
-  i32.const 1
-  drop
   local.get $start
   i64.extend_i32_u
   local.get $endU64
-  i64.le_u
-  i32.eqz
+  i64.gt_u
   if
-   i32.const 0
-   i32.const 480
-   i32.const 385
-   i32.const 14
-   call $~lib/builtins/abort
    unreachable
   end
   local.get $start

--- a/tests/compiler/std/dataview.debug.wat
+++ b/tests/compiler/std/dataview.debug.wat
@@ -1038,6 +1038,8 @@
   local.get $endU64
   i32.wrap_i64
   local.set $end
+  i32.const 0
+  drop
   i32.const 1
   drop
   local.get $start
@@ -1048,7 +1050,7 @@
   if
    i32.const 0
    i32.const 480
-   i32.const 382
+   i32.const 385
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1094,7 +1096,7 @@
    if
     i32.const 0
     i32.const 480
-    i32.const 389
+    i32.const 392
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1126,7 +1128,7 @@
    if
     i32.const 0
     i32.const 480
-    i32.const 402
+    i32.const 405
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1327,8 +1329,6 @@
   i32.const 1572
   i32.add
   local.set $memStart
-  i32.const 0
-  drop
   local.get $root
   local.get $memStart
   memory.size
@@ -1370,7 +1370,7 @@
   if
    i32.const 0
    i32.const 480
-   i32.const 562
+   i32.const 555
    i32.const 3
    call $~lib/builtins/abort
    unreachable
@@ -1699,7 +1699,7 @@
   if
    i32.const 144
    i32.const 480
-   i32.const 461
+   i32.const 460
    i32.const 29
    call $~lib/builtins/abort
    unreachable
@@ -1933,8 +1933,6 @@
   (local $6 i32)
   (local $pagesWanted i32)
   (local $pagesAfter i32)
-  i32.const 0
-  drop
   local.get $size
   i32.const 256
   i32.ge_u
@@ -2144,7 +2142,7 @@
    if
     i32.const 0
     i32.const 480
-    i32.const 499
+    i32.const 492
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -2164,7 +2162,7 @@
   if
    i32.const 0
    i32.const 480
-   i32.const 501
+   i32.const 494
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/std/dataview.release.wat
+++ b/tests/compiler/std/dataview.release.wat
@@ -650,11 +650,16 @@
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
+  local.get $2
   local.get $1
   i64.extend_i32_u
-  local.get $2
-  i64.gt_u
+  i64.lt_u
   if
+   i32.const 0
+   i32.const 1504
+   i32.const 386
+   i32.const 14
+   call $~lib/builtins/abort
    unreachable
   end
   local.get $1
@@ -677,7 +682,7 @@
    if
     i32.const 0
     i32.const 1504
-    i32.const 392
+    i32.const 393
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -704,7 +709,7 @@
    if
     i32.const 0
     i32.const 1504
-    i32.const 405
+    i32.const 406
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1067,7 +1072,7 @@
       if
        i32.const 0
        i32.const 1504
-       i32.const 555
+       i32.const 556
        i32.const 3
        call $~lib/builtins/abort
        unreachable
@@ -1302,7 +1307,7 @@
   if
    i32.const 1168
    i32.const 1504
-   i32.const 460
+   i32.const 461
    i32.const 29
    call $~lib/builtins/abort
    unreachable
@@ -1404,7 +1409,7 @@
    if
     i32.const 0
     i32.const 1504
-    i32.const 492
+    i32.const 493
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1419,7 +1424,7 @@
   if
    i32.const 0
    i32.const 1504
-   i32.const 494
+   i32.const 495
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/std/dataview.release.wat
+++ b/tests/compiler/std/dataview.release.wat
@@ -650,16 +650,11 @@
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
-  local.get $2
   local.get $1
   i64.extend_i32_u
-  i64.lt_u
+  local.get $2
+  i64.gt_u
   if
-   i32.const 0
-   i32.const 1504
-   i32.const 385
-   i32.const 14
-   call $~lib/builtins/abort
    unreachable
   end
   local.get $1

--- a/tests/compiler/std/dataview.release.wat
+++ b/tests/compiler/std/dataview.release.wat
@@ -657,7 +657,7 @@
   if
    i32.const 0
    i32.const 1504
-   i32.const 382
+   i32.const 385
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -682,7 +682,7 @@
    if
     i32.const 0
     i32.const 1504
-    i32.const 389
+    i32.const 392
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -709,7 +709,7 @@
    if
     i32.const 0
     i32.const 1504
-    i32.const 402
+    i32.const 405
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1072,7 +1072,7 @@
       if
        i32.const 0
        i32.const 1504
-       i32.const 562
+       i32.const 555
        i32.const 3
        call $~lib/builtins/abort
        unreachable
@@ -1307,7 +1307,7 @@
   if
    i32.const 1168
    i32.const 1504
-   i32.const 461
+   i32.const 460
    i32.const 29
    call $~lib/builtins/abort
    unreachable
@@ -1409,7 +1409,7 @@
    if
     i32.const 0
     i32.const 1504
-    i32.const 499
+    i32.const 492
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1424,7 +1424,7 @@
   if
    i32.const 0
    i32.const 1504
-   i32.const 501
+   i32.const 494
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/std/date.debug.wat
+++ b/tests/compiler/std/date.debug.wat
@@ -1425,19 +1425,11 @@
   local.set $end
   i32.const 0
   drop
-  i32.const 1
-  drop
   local.get $start
   i64.extend_i32_u
   local.get $endU64
-  i64.le_u
-  i32.eqz
+  i64.gt_u
   if
-   i32.const 0
-   i32.const 512
-   i32.const 385
-   i32.const 14
-   call $~lib/builtins/abort
    unreachable
   end
   local.get $start

--- a/tests/compiler/std/date.debug.wat
+++ b/tests/compiler/std/date.debug.wat
@@ -1425,11 +1425,19 @@
   local.set $end
   i32.const 0
   drop
+  i32.const 1
+  drop
   local.get $start
   i64.extend_i32_u
   local.get $endU64
-  i64.gt_u
+  i64.le_u
+  i32.eqz
   if
+   i32.const 0
+   i32.const 512
+   i32.const 386
+   i32.const 14
+   call $~lib/builtins/abort
    unreachable
   end
   local.get $start
@@ -1473,7 +1481,7 @@
    if
     i32.const 0
     i32.const 512
-    i32.const 392
+    i32.const 393
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1505,7 +1513,7 @@
    if
     i32.const 0
     i32.const 512
-    i32.const 405
+    i32.const 406
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1747,7 +1755,7 @@
   if
    i32.const 0
    i32.const 512
-   i32.const 555
+   i32.const 556
    i32.const 3
    call $~lib/builtins/abort
    unreachable
@@ -2076,7 +2084,7 @@
   if
    i32.const 176
    i32.const 512
-   i32.const 460
+   i32.const 461
    i32.const 29
    call $~lib/builtins/abort
    unreachable
@@ -2519,7 +2527,7 @@
    if
     i32.const 0
     i32.const 512
-    i32.const 492
+    i32.const 493
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -2539,7 +2547,7 @@
   if
    i32.const 0
    i32.const 512
-   i32.const 494
+   i32.const 495
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/std/date.debug.wat
+++ b/tests/compiler/std/date.debug.wat
@@ -1423,6 +1423,8 @@
   local.get $endU64
   i32.wrap_i64
   local.set $end
+  i32.const 0
+  drop
   i32.const 1
   drop
   local.get $start
@@ -1433,7 +1435,7 @@
   if
    i32.const 0
    i32.const 512
-   i32.const 382
+   i32.const 385
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1479,7 +1481,7 @@
    if
     i32.const 0
     i32.const 512
-    i32.const 389
+    i32.const 392
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1511,7 +1513,7 @@
    if
     i32.const 0
     i32.const 512
-    i32.const 402
+    i32.const 405
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1712,8 +1714,6 @@
   i32.const 1572
   i32.add
   local.set $memStart
-  i32.const 0
-  drop
   local.get $root
   local.get $memStart
   memory.size
@@ -1755,7 +1755,7 @@
   if
    i32.const 0
    i32.const 512
-   i32.const 562
+   i32.const 555
    i32.const 3
    call $~lib/builtins/abort
    unreachable
@@ -2084,7 +2084,7 @@
   if
    i32.const 176
    i32.const 512
-   i32.const 461
+   i32.const 460
    i32.const 29
    call $~lib/builtins/abort
    unreachable
@@ -2318,8 +2318,6 @@
   (local $6 i32)
   (local $pagesWanted i32)
   (local $pagesAfter i32)
-  i32.const 0
-  drop
   local.get $size
   i32.const 256
   i32.ge_u
@@ -2529,7 +2527,7 @@
    if
     i32.const 0
     i32.const 512
-    i32.const 499
+    i32.const 492
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -2549,7 +2547,7 @@
   if
    i32.const 0
    i32.const 512
-   i32.const 501
+   i32.const 494
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/std/date.release.wat
+++ b/tests/compiler/std/date.release.wat
@@ -1033,11 +1033,16 @@
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
+  local.get $2
   local.get $1
   i64.extend_i32_u
-  local.get $2
-  i64.gt_u
+  i64.lt_u
   if
+   i32.const 0
+   i32.const 1536
+   i32.const 386
+   i32.const 14
+   call $~lib/builtins/abort
    unreachable
   end
   local.get $1
@@ -1060,7 +1065,7 @@
    if
     i32.const 0
     i32.const 1536
-    i32.const 392
+    i32.const 393
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1087,7 +1092,7 @@
    if
     i32.const 0
     i32.const 1536
-    i32.const 405
+    i32.const 406
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1450,7 +1455,7 @@
       if
        i32.const 0
        i32.const 1536
-       i32.const 555
+       i32.const 556
        i32.const 3
        call $~lib/builtins/abort
        unreachable
@@ -1685,7 +1690,7 @@
   if
    i32.const 1200
    i32.const 1536
-   i32.const 460
+   i32.const 461
    i32.const 29
    call $~lib/builtins/abort
    unreachable
@@ -1787,7 +1792,7 @@
    if
     i32.const 0
     i32.const 1536
-    i32.const 492
+    i32.const 493
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1802,7 +1807,7 @@
   if
    i32.const 0
    i32.const 1536
-   i32.const 494
+   i32.const 495
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/std/date.release.wat
+++ b/tests/compiler/std/date.release.wat
@@ -1033,16 +1033,11 @@
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
-  local.get $2
   local.get $1
   i64.extend_i32_u
-  i64.lt_u
+  local.get $2
+  i64.gt_u
   if
-   i32.const 0
-   i32.const 1536
-   i32.const 385
-   i32.const 14
-   call $~lib/builtins/abort
    unreachable
   end
   local.get $1

--- a/tests/compiler/std/date.release.wat
+++ b/tests/compiler/std/date.release.wat
@@ -1040,7 +1040,7 @@
   if
    i32.const 0
    i32.const 1536
-   i32.const 382
+   i32.const 385
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1065,7 +1065,7 @@
    if
     i32.const 0
     i32.const 1536
-    i32.const 389
+    i32.const 392
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1092,7 +1092,7 @@
    if
     i32.const 0
     i32.const 1536
-    i32.const 402
+    i32.const 405
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1455,7 +1455,7 @@
       if
        i32.const 0
        i32.const 1536
-       i32.const 562
+       i32.const 555
        i32.const 3
        call $~lib/builtins/abort
        unreachable
@@ -1690,7 +1690,7 @@
   if
    i32.const 1200
    i32.const 1536
-   i32.const 461
+   i32.const 460
    i32.const 29
    call $~lib/builtins/abort
    unreachable
@@ -1792,7 +1792,7 @@
    if
     i32.const 0
     i32.const 1536
-    i32.const 499
+    i32.const 492
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1807,7 +1807,7 @@
   if
    i32.const 0
    i32.const 1536
-   i32.const 501
+   i32.const 494
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/std/map.debug.wat
+++ b/tests/compiler/std/map.debug.wat
@@ -1056,19 +1056,11 @@
   local.set $end
   i32.const 0
   drop
-  i32.const 1
-  drop
   local.get $start
   i64.extend_i32_u
   local.get $endU64
-  i64.le_u
-  i32.eqz
+  i64.gt_u
   if
-   i32.const 0
-   i32.const 368
-   i32.const 385
-   i32.const 14
-   call $~lib/builtins/abort
    unreachable
   end
   local.get $start

--- a/tests/compiler/std/map.debug.wat
+++ b/tests/compiler/std/map.debug.wat
@@ -1054,6 +1054,8 @@
   local.get $endU64
   i32.wrap_i64
   local.set $end
+  i32.const 0
+  drop
   i32.const 1
   drop
   local.get $start
@@ -1064,7 +1066,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 382
+   i32.const 385
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1110,7 +1112,7 @@
    if
     i32.const 0
     i32.const 368
-    i32.const 389
+    i32.const 392
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1142,7 +1144,7 @@
    if
     i32.const 0
     i32.const 368
-    i32.const 402
+    i32.const 405
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1343,8 +1345,6 @@
   i32.const 1572
   i32.add
   local.set $memStart
-  i32.const 0
-  drop
   local.get $root
   local.get $memStart
   memory.size
@@ -1386,7 +1386,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 562
+   i32.const 555
    i32.const 3
    call $~lib/builtins/abort
    unreachable
@@ -1715,7 +1715,7 @@
   if
    i32.const 32
    i32.const 368
-   i32.const 461
+   i32.const 460
    i32.const 29
    call $~lib/builtins/abort
    unreachable
@@ -1949,8 +1949,6 @@
   (local $6 i32)
   (local $pagesWanted i32)
   (local $pagesAfter i32)
-  i32.const 0
-  drop
   local.get $size
   i32.const 256
   i32.ge_u
@@ -2160,7 +2158,7 @@
    if
     i32.const 0
     i32.const 368
-    i32.const 499
+    i32.const 492
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -2180,7 +2178,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 501
+   i32.const 494
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/std/map.debug.wat
+++ b/tests/compiler/std/map.debug.wat
@@ -1056,11 +1056,19 @@
   local.set $end
   i32.const 0
   drop
+  i32.const 1
+  drop
   local.get $start
   i64.extend_i32_u
   local.get $endU64
-  i64.gt_u
+  i64.le_u
+  i32.eqz
   if
+   i32.const 0
+   i32.const 368
+   i32.const 386
+   i32.const 14
+   call $~lib/builtins/abort
    unreachable
   end
   local.get $start
@@ -1104,7 +1112,7 @@
    if
     i32.const 0
     i32.const 368
-    i32.const 392
+    i32.const 393
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1136,7 +1144,7 @@
    if
     i32.const 0
     i32.const 368
-    i32.const 405
+    i32.const 406
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1378,7 +1386,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 555
+   i32.const 556
    i32.const 3
    call $~lib/builtins/abort
    unreachable
@@ -1707,7 +1715,7 @@
   if
    i32.const 32
    i32.const 368
-   i32.const 460
+   i32.const 461
    i32.const 29
    call $~lib/builtins/abort
    unreachable
@@ -2150,7 +2158,7 @@
    if
     i32.const 0
     i32.const 368
-    i32.const 492
+    i32.const 493
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -2170,7 +2178,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 494
+   i32.const 495
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/std/map.release.wat
+++ b/tests/compiler/std/map.release.wat
@@ -663,16 +663,11 @@
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
-  local.get $2
   local.get $1
   i64.extend_i32_u
-  i64.lt_u
+  local.get $2
+  i64.gt_u
   if
-   i32.const 0
-   i32.const 1392
-   i32.const 385
-   i32.const 14
-   call $~lib/builtins/abort
    unreachable
   end
   local.get $1

--- a/tests/compiler/std/map.release.wat
+++ b/tests/compiler/std/map.release.wat
@@ -670,7 +670,7 @@
   if
    i32.const 0
    i32.const 1392
-   i32.const 382
+   i32.const 385
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -695,7 +695,7 @@
    if
     i32.const 0
     i32.const 1392
-    i32.const 389
+    i32.const 392
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -722,7 +722,7 @@
    if
     i32.const 0
     i32.const 1392
-    i32.const 402
+    i32.const 405
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1085,7 +1085,7 @@
       if
        i32.const 0
        i32.const 1392
-       i32.const 562
+       i32.const 555
        i32.const 3
        call $~lib/builtins/abort
        unreachable
@@ -1320,7 +1320,7 @@
   if
    i32.const 1056
    i32.const 1392
-   i32.const 461
+   i32.const 460
    i32.const 29
    call $~lib/builtins/abort
    unreachable
@@ -1422,7 +1422,7 @@
    if
     i32.const 0
     i32.const 1392
-    i32.const 499
+    i32.const 492
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1437,7 +1437,7 @@
   if
    i32.const 0
    i32.const 1392
-   i32.const 501
+   i32.const 494
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/std/map.release.wat
+++ b/tests/compiler/std/map.release.wat
@@ -663,11 +663,16 @@
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
+  local.get $2
   local.get $1
   i64.extend_i32_u
-  local.get $2
-  i64.gt_u
+  i64.lt_u
   if
+   i32.const 0
+   i32.const 1392
+   i32.const 386
+   i32.const 14
+   call $~lib/builtins/abort
    unreachable
   end
   local.get $1
@@ -690,7 +695,7 @@
    if
     i32.const 0
     i32.const 1392
-    i32.const 392
+    i32.const 393
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -717,7 +722,7 @@
    if
     i32.const 0
     i32.const 1392
-    i32.const 405
+    i32.const 406
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1080,7 +1085,7 @@
       if
        i32.const 0
        i32.const 1392
-       i32.const 555
+       i32.const 556
        i32.const 3
        call $~lib/builtins/abort
        unreachable
@@ -1315,7 +1320,7 @@
   if
    i32.const 1056
    i32.const 1392
-   i32.const 460
+   i32.const 461
    i32.const 29
    call $~lib/builtins/abort
    unreachable
@@ -1417,7 +1422,7 @@
    if
     i32.const 0
     i32.const 1392
-    i32.const 492
+    i32.const 493
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1432,7 +1437,7 @@
   if
    i32.const 0
    i32.const 1392
-   i32.const 494
+   i32.const 495
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/std/math.release.wat
+++ b/tests/compiler/std/math.release.wat
@@ -49901,7 +49901,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const nan:0x8000000000000
+  f64.const -nan:0x8000000000000
   f64.const nan:0x8000000000000
   f64.const 0
   call $std/math/check<f64>
@@ -49945,7 +49945,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const nan:0x8000000000000
+  f64.const -nan:0x8000000000000
   f64.const nan:0x8000000000000
   f64.const 0
   call $std/math/check<f64>
@@ -49967,7 +49967,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const nan:0x8000000000000
+  f64.const -nan:0x8000000000000
   f64.const nan:0x8000000000000
   f64.const 0
   call $std/math/check<f64>
@@ -50033,7 +50033,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const nan:0x8000000000000
+  f64.const -nan:0x8000000000000
   f64.const nan:0x8000000000000
   f64.const 0
   call $std/math/check<f64>
@@ -50099,7 +50099,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const nan:0x8000000000000
+  f64.const -nan:0x8000000000000
   f64.const nan:0x8000000000000
   f64.const 0
   call $std/math/check<f64>
@@ -50165,7 +50165,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const nan:0x8000000000000
+  f64.const -nan:0x8000000000000
   f64.const nan:0x8000000000000
   f64.const 0
   call $std/math/check<f64>
@@ -50253,7 +50253,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const nan:0x8000000000000
+  f64.const -nan:0x8000000000000
   f64.const nan:0x8000000000000
   f64.const 0
   call $std/math/check<f64>
@@ -50363,7 +50363,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const nan:0x8000000000000
+  f64.const -nan:0x8000000000000
   f64.const nan:0x8000000000000
   f64.const 0
   call $std/math/check<f64>
@@ -50517,7 +50517,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const nan:0x8000000000000
+  f64.const -nan:0x8000000000000
   f64.const nan:0x8000000000000
   f64.const 0
   call $std/math/check<f64>
@@ -51749,7 +51749,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const nan:0x400000
+  f32.const -nan:0x400000
   f32.const nan:0x400000
   f32.const 0
   call $std/math/check<f32>
@@ -51775,7 +51775,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const nan:0x400000
+  f32.const -nan:0x400000
   f32.const nan:0x400000
   f32.const 0
   call $std/math/check<f32>
@@ -51788,7 +51788,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const nan:0x400000
+  f32.const -nan:0x400000
   f32.const nan:0x400000
   f32.const 0
   call $std/math/check<f32>
@@ -51827,7 +51827,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const nan:0x400000
+  f32.const -nan:0x400000
   f32.const nan:0x400000
   f32.const 0
   call $std/math/check<f32>
@@ -51866,7 +51866,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const nan:0x400000
+  f32.const -nan:0x400000
   f32.const nan:0x400000
   f32.const 0
   call $std/math/check<f32>
@@ -51905,7 +51905,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const nan:0x400000
+  f32.const -nan:0x400000
   f32.const nan:0x400000
   f32.const 0
   call $std/math/check<f32>
@@ -51957,7 +51957,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const nan:0x400000
+  f32.const -nan:0x400000
   f32.const nan:0x400000
   f32.const 0
   call $std/math/check<f32>
@@ -52022,7 +52022,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const nan:0x400000
+  f32.const -nan:0x400000
   f32.const nan:0x400000
   f32.const 0
   call $std/math/check<f32>
@@ -52048,7 +52048,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const nan:0x400000
+  f32.const -nan:0x400000
   f32.const nan:0x400000
   f32.const 0
   call $std/math/check<f32>

--- a/tests/compiler/std/math.release.wat
+++ b/tests/compiler/std/math.release.wat
@@ -49901,7 +49901,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -nan:0x8000000000000
+  f64.const nan:0x8000000000000
   f64.const nan:0x8000000000000
   f64.const 0
   call $std/math/check<f64>
@@ -49945,7 +49945,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -nan:0x8000000000000
+  f64.const nan:0x8000000000000
   f64.const nan:0x8000000000000
   f64.const 0
   call $std/math/check<f64>
@@ -49967,7 +49967,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -nan:0x8000000000000
+  f64.const nan:0x8000000000000
   f64.const nan:0x8000000000000
   f64.const 0
   call $std/math/check<f64>
@@ -50033,7 +50033,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -nan:0x8000000000000
+  f64.const nan:0x8000000000000
   f64.const nan:0x8000000000000
   f64.const 0
   call $std/math/check<f64>
@@ -50099,7 +50099,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -nan:0x8000000000000
+  f64.const nan:0x8000000000000
   f64.const nan:0x8000000000000
   f64.const 0
   call $std/math/check<f64>
@@ -50165,7 +50165,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -nan:0x8000000000000
+  f64.const nan:0x8000000000000
   f64.const nan:0x8000000000000
   f64.const 0
   call $std/math/check<f64>
@@ -50253,7 +50253,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -nan:0x8000000000000
+  f64.const nan:0x8000000000000
   f64.const nan:0x8000000000000
   f64.const 0
   call $std/math/check<f64>
@@ -50363,7 +50363,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -nan:0x8000000000000
+  f64.const nan:0x8000000000000
   f64.const nan:0x8000000000000
   f64.const 0
   call $std/math/check<f64>
@@ -50517,7 +50517,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -nan:0x8000000000000
+  f64.const nan:0x8000000000000
   f64.const nan:0x8000000000000
   f64.const 0
   call $std/math/check<f64>
@@ -51749,7 +51749,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -nan:0x400000
+  f32.const nan:0x400000
   f32.const nan:0x400000
   f32.const 0
   call $std/math/check<f32>
@@ -51775,7 +51775,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -nan:0x400000
+  f32.const nan:0x400000
   f32.const nan:0x400000
   f32.const 0
   call $std/math/check<f32>
@@ -51788,7 +51788,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -nan:0x400000
+  f32.const nan:0x400000
   f32.const nan:0x400000
   f32.const 0
   call $std/math/check<f32>
@@ -51827,7 +51827,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -nan:0x400000
+  f32.const nan:0x400000
   f32.const nan:0x400000
   f32.const 0
   call $std/math/check<f32>
@@ -51866,7 +51866,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -nan:0x400000
+  f32.const nan:0x400000
   f32.const nan:0x400000
   f32.const 0
   call $std/math/check<f32>
@@ -51905,7 +51905,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -nan:0x400000
+  f32.const nan:0x400000
   f32.const nan:0x400000
   f32.const 0
   call $std/math/check<f32>
@@ -51957,7 +51957,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -nan:0x400000
+  f32.const nan:0x400000
   f32.const nan:0x400000
   f32.const 0
   call $std/math/check<f32>
@@ -52022,7 +52022,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -nan:0x400000
+  f32.const nan:0x400000
   f32.const nan:0x400000
   f32.const 0
   call $std/math/check<f32>
@@ -52048,7 +52048,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -nan:0x400000
+  f32.const nan:0x400000
   f32.const nan:0x400000
   f32.const 0
   call $std/math/check<f32>

--- a/tests/compiler/std/new.debug.wat
+++ b/tests/compiler/std/new.debug.wat
@@ -1042,11 +1042,19 @@
   local.set $end
   i32.const 0
   drop
+  i32.const 1
+  drop
   local.get $start
   i64.extend_i32_u
   local.get $endU64
-  i64.gt_u
+  i64.le_u
+  i32.eqz
   if
+   i32.const 0
+   i32.const 368
+   i32.const 386
+   i32.const 14
+   call $~lib/builtins/abort
    unreachable
   end
   local.get $start
@@ -1090,7 +1098,7 @@
    if
     i32.const 0
     i32.const 368
-    i32.const 392
+    i32.const 393
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1122,7 +1130,7 @@
    if
     i32.const 0
     i32.const 368
-    i32.const 405
+    i32.const 406
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1364,7 +1372,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 555
+   i32.const 556
    i32.const 3
    call $~lib/builtins/abort
    unreachable
@@ -1693,7 +1701,7 @@
   if
    i32.const 32
    i32.const 368
-   i32.const 460
+   i32.const 461
    i32.const 29
    call $~lib/builtins/abort
    unreachable
@@ -2136,7 +2144,7 @@
    if
     i32.const 0
     i32.const 368
-    i32.const 492
+    i32.const 493
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -2156,7 +2164,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 494
+   i32.const 495
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/std/new.debug.wat
+++ b/tests/compiler/std/new.debug.wat
@@ -1042,19 +1042,11 @@
   local.set $end
   i32.const 0
   drop
-  i32.const 1
-  drop
   local.get $start
   i64.extend_i32_u
   local.get $endU64
-  i64.le_u
-  i32.eqz
+  i64.gt_u
   if
-   i32.const 0
-   i32.const 368
-   i32.const 385
-   i32.const 14
-   call $~lib/builtins/abort
    unreachable
   end
   local.get $start

--- a/tests/compiler/std/new.debug.wat
+++ b/tests/compiler/std/new.debug.wat
@@ -1040,6 +1040,8 @@
   local.get $endU64
   i32.wrap_i64
   local.set $end
+  i32.const 0
+  drop
   i32.const 1
   drop
   local.get $start
@@ -1050,7 +1052,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 382
+   i32.const 385
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1096,7 +1098,7 @@
    if
     i32.const 0
     i32.const 368
-    i32.const 389
+    i32.const 392
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1128,7 +1130,7 @@
    if
     i32.const 0
     i32.const 368
-    i32.const 402
+    i32.const 405
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1329,8 +1331,6 @@
   i32.const 1572
   i32.add
   local.set $memStart
-  i32.const 0
-  drop
   local.get $root
   local.get $memStart
   memory.size
@@ -1372,7 +1372,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 562
+   i32.const 555
    i32.const 3
    call $~lib/builtins/abort
    unreachable
@@ -1701,7 +1701,7 @@
   if
    i32.const 32
    i32.const 368
-   i32.const 461
+   i32.const 460
    i32.const 29
    call $~lib/builtins/abort
    unreachable
@@ -1935,8 +1935,6 @@
   (local $6 i32)
   (local $pagesWanted i32)
   (local $pagesAfter i32)
-  i32.const 0
-  drop
   local.get $size
   i32.const 256
   i32.ge_u
@@ -2146,7 +2144,7 @@
    if
     i32.const 0
     i32.const 368
-    i32.const 499
+    i32.const 492
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -2166,7 +2164,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 501
+   i32.const 494
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/std/new.release.wat
+++ b/tests/compiler/std/new.release.wat
@@ -632,16 +632,11 @@
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
-  local.get $2
   local.get $1
   i64.extend_i32_u
-  i64.lt_u
+  local.get $2
+  i64.gt_u
   if
-   i32.const 0
-   i32.const 1392
-   i32.const 385
-   i32.const 14
-   call $~lib/builtins/abort
    unreachable
   end
   local.get $1

--- a/tests/compiler/std/new.release.wat
+++ b/tests/compiler/std/new.release.wat
@@ -639,7 +639,7 @@
   if
    i32.const 0
    i32.const 1392
-   i32.const 382
+   i32.const 385
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -664,7 +664,7 @@
    if
     i32.const 0
     i32.const 1392
-    i32.const 389
+    i32.const 392
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -691,7 +691,7 @@
    if
     i32.const 0
     i32.const 1392
-    i32.const 402
+    i32.const 405
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1054,7 +1054,7 @@
       if
        i32.const 0
        i32.const 1392
-       i32.const 562
+       i32.const 555
        i32.const 3
        call $~lib/builtins/abort
        unreachable
@@ -1252,7 +1252,7 @@
    if
     i32.const 0
     i32.const 1392
-    i32.const 499
+    i32.const 492
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1267,7 +1267,7 @@
   if
    i32.const 0
    i32.const 1392
-   i32.const 501
+   i32.const 494
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/std/new.release.wat
+++ b/tests/compiler/std/new.release.wat
@@ -632,11 +632,16 @@
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
+  local.get $2
   local.get $1
   i64.extend_i32_u
-  local.get $2
-  i64.gt_u
+  i64.lt_u
   if
+   i32.const 0
+   i32.const 1392
+   i32.const 386
+   i32.const 14
+   call $~lib/builtins/abort
    unreachable
   end
   local.get $1
@@ -659,7 +664,7 @@
    if
     i32.const 0
     i32.const 1392
-    i32.const 392
+    i32.const 393
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -686,7 +691,7 @@
    if
     i32.const 0
     i32.const 1392
-    i32.const 405
+    i32.const 406
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1049,7 +1054,7 @@
       if
        i32.const 0
        i32.const 1392
-       i32.const 555
+       i32.const 556
        i32.const 3
        call $~lib/builtins/abort
        unreachable
@@ -1247,7 +1252,7 @@
    if
     i32.const 0
     i32.const 1392
-    i32.const 492
+    i32.const 493
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1262,7 +1267,7 @@
   if
    i32.const 0
    i32.const 1392
-   i32.const 494
+   i32.const 495
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/std/operator-overloading.debug.wat
+++ b/tests/compiler/std/operator-overloading.debug.wat
@@ -1098,19 +1098,11 @@
   local.set $end
   i32.const 0
   drop
-  i32.const 1
-  drop
   local.get $start
   i64.extend_i32_u
   local.get $endU64
-  i64.le_u
-  i32.eqz
+  i64.gt_u
   if
-   i32.const 0
-   i32.const 368
-   i32.const 385
-   i32.const 14
-   call $~lib/builtins/abort
    unreachable
   end
   local.get $start

--- a/tests/compiler/std/operator-overloading.debug.wat
+++ b/tests/compiler/std/operator-overloading.debug.wat
@@ -1098,11 +1098,19 @@
   local.set $end
   i32.const 0
   drop
+  i32.const 1
+  drop
   local.get $start
   i64.extend_i32_u
   local.get $endU64
-  i64.gt_u
+  i64.le_u
+  i32.eqz
   if
+   i32.const 0
+   i32.const 368
+   i32.const 386
+   i32.const 14
+   call $~lib/builtins/abort
    unreachable
   end
   local.get $start
@@ -1146,7 +1154,7 @@
    if
     i32.const 0
     i32.const 368
-    i32.const 392
+    i32.const 393
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1178,7 +1186,7 @@
    if
     i32.const 0
     i32.const 368
-    i32.const 405
+    i32.const 406
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1420,7 +1428,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 555
+   i32.const 556
    i32.const 3
    call $~lib/builtins/abort
    unreachable
@@ -1749,7 +1757,7 @@
   if
    i32.const 32
    i32.const 368
-   i32.const 460
+   i32.const 461
    i32.const 29
    call $~lib/builtins/abort
    unreachable
@@ -2192,7 +2200,7 @@
    if
     i32.const 0
     i32.const 368
-    i32.const 492
+    i32.const 493
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -2212,7 +2220,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 494
+   i32.const 495
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/std/operator-overloading.debug.wat
+++ b/tests/compiler/std/operator-overloading.debug.wat
@@ -1096,6 +1096,8 @@
   local.get $endU64
   i32.wrap_i64
   local.set $end
+  i32.const 0
+  drop
   i32.const 1
   drop
   local.get $start
@@ -1106,7 +1108,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 382
+   i32.const 385
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1152,7 +1154,7 @@
    if
     i32.const 0
     i32.const 368
-    i32.const 389
+    i32.const 392
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1184,7 +1186,7 @@
    if
     i32.const 0
     i32.const 368
-    i32.const 402
+    i32.const 405
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1385,8 +1387,6 @@
   i32.const 1572
   i32.add
   local.set $memStart
-  i32.const 0
-  drop
   local.get $root
   local.get $memStart
   memory.size
@@ -1428,7 +1428,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 562
+   i32.const 555
    i32.const 3
    call $~lib/builtins/abort
    unreachable
@@ -1757,7 +1757,7 @@
   if
    i32.const 32
    i32.const 368
-   i32.const 461
+   i32.const 460
    i32.const 29
    call $~lib/builtins/abort
    unreachable
@@ -1991,8 +1991,6 @@
   (local $6 i32)
   (local $pagesWanted i32)
   (local $pagesAfter i32)
-  i32.const 0
-  drop
   local.get $size
   i32.const 256
   i32.ge_u
@@ -2202,7 +2200,7 @@
    if
     i32.const 0
     i32.const 368
-    i32.const 499
+    i32.const 492
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -2222,7 +2220,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 501
+   i32.const 494
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/std/operator-overloading.release.wat
+++ b/tests/compiler/std/operator-overloading.release.wat
@@ -704,7 +704,7 @@
   if
    i32.const 0
    i32.const 1392
-   i32.const 382
+   i32.const 385
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -729,7 +729,7 @@
    if
     i32.const 0
     i32.const 1392
-    i32.const 389
+    i32.const 392
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -756,7 +756,7 @@
    if
     i32.const 0
     i32.const 1392
-    i32.const 402
+    i32.const 405
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1119,7 +1119,7 @@
       if
        i32.const 0
        i32.const 1392
-       i32.const 562
+       i32.const 555
        i32.const 3
        call $~lib/builtins/abort
        unreachable
@@ -1317,7 +1317,7 @@
    if
     i32.const 0
     i32.const 1392
-    i32.const 499
+    i32.const 492
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1332,7 +1332,7 @@
   if
    i32.const 0
    i32.const 1392
-   i32.const 501
+   i32.const 494
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/std/operator-overloading.release.wat
+++ b/tests/compiler/std/operator-overloading.release.wat
@@ -697,16 +697,11 @@
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
-  local.get $2
   local.get $1
   i64.extend_i32_u
-  i64.lt_u
+  local.get $2
+  i64.gt_u
   if
-   i32.const 0
-   i32.const 1392
-   i32.const 385
-   i32.const 14
-   call $~lib/builtins/abort
    unreachable
   end
   local.get $1

--- a/tests/compiler/std/operator-overloading.release.wat
+++ b/tests/compiler/std/operator-overloading.release.wat
@@ -697,11 +697,16 @@
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
+  local.get $2
   local.get $1
   i64.extend_i32_u
-  local.get $2
-  i64.gt_u
+  i64.lt_u
   if
+   i32.const 0
+   i32.const 1392
+   i32.const 386
+   i32.const 14
+   call $~lib/builtins/abort
    unreachable
   end
   local.get $1
@@ -724,7 +729,7 @@
    if
     i32.const 0
     i32.const 1392
-    i32.const 392
+    i32.const 393
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -751,7 +756,7 @@
    if
     i32.const 0
     i32.const 1392
-    i32.const 405
+    i32.const 406
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1114,7 +1119,7 @@
       if
        i32.const 0
        i32.const 1392
-       i32.const 555
+       i32.const 556
        i32.const 3
        call $~lib/builtins/abort
        unreachable
@@ -1312,7 +1317,7 @@
    if
     i32.const 0
     i32.const 1392
-    i32.const 492
+    i32.const 493
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1327,7 +1332,7 @@
   if
    i32.const 0
    i32.const 1392
-   i32.const 494
+   i32.const 495
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/std/set.debug.wat
+++ b/tests/compiler/std/set.debug.wat
@@ -1051,19 +1051,11 @@
   local.set $end
   i32.const 0
   drop
-  i32.const 1
-  drop
   local.get $start
   i64.extend_i32_u
   local.get $endU64
-  i64.le_u
-  i32.eqz
+  i64.gt_u
   if
-   i32.const 0
-   i32.const 368
-   i32.const 385
-   i32.const 14
-   call $~lib/builtins/abort
    unreachable
   end
   local.get $start

--- a/tests/compiler/std/set.debug.wat
+++ b/tests/compiler/std/set.debug.wat
@@ -1049,6 +1049,8 @@
   local.get $endU64
   i32.wrap_i64
   local.set $end
+  i32.const 0
+  drop
   i32.const 1
   drop
   local.get $start
@@ -1059,7 +1061,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 382
+   i32.const 385
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1105,7 +1107,7 @@
    if
     i32.const 0
     i32.const 368
-    i32.const 389
+    i32.const 392
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1137,7 +1139,7 @@
    if
     i32.const 0
     i32.const 368
-    i32.const 402
+    i32.const 405
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1338,8 +1340,6 @@
   i32.const 1572
   i32.add
   local.set $memStart
-  i32.const 0
-  drop
   local.get $root
   local.get $memStart
   memory.size
@@ -1381,7 +1381,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 562
+   i32.const 555
    i32.const 3
    call $~lib/builtins/abort
    unreachable
@@ -1710,7 +1710,7 @@
   if
    i32.const 32
    i32.const 368
-   i32.const 461
+   i32.const 460
    i32.const 29
    call $~lib/builtins/abort
    unreachable
@@ -1944,8 +1944,6 @@
   (local $6 i32)
   (local $pagesWanted i32)
   (local $pagesAfter i32)
-  i32.const 0
-  drop
   local.get $size
   i32.const 256
   i32.ge_u
@@ -2155,7 +2153,7 @@
    if
     i32.const 0
     i32.const 368
-    i32.const 499
+    i32.const 492
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -2175,7 +2173,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 501
+   i32.const 494
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/std/set.debug.wat
+++ b/tests/compiler/std/set.debug.wat
@@ -1051,11 +1051,19 @@
   local.set $end
   i32.const 0
   drop
+  i32.const 1
+  drop
   local.get $start
   i64.extend_i32_u
   local.get $endU64
-  i64.gt_u
+  i64.le_u
+  i32.eqz
   if
+   i32.const 0
+   i32.const 368
+   i32.const 386
+   i32.const 14
+   call $~lib/builtins/abort
    unreachable
   end
   local.get $start
@@ -1099,7 +1107,7 @@
    if
     i32.const 0
     i32.const 368
-    i32.const 392
+    i32.const 393
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1131,7 +1139,7 @@
    if
     i32.const 0
     i32.const 368
-    i32.const 405
+    i32.const 406
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1373,7 +1381,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 555
+   i32.const 556
    i32.const 3
    call $~lib/builtins/abort
    unreachable
@@ -1702,7 +1710,7 @@
   if
    i32.const 32
    i32.const 368
-   i32.const 460
+   i32.const 461
    i32.const 29
    call $~lib/builtins/abort
    unreachable
@@ -2145,7 +2153,7 @@
    if
     i32.const 0
     i32.const 368
-    i32.const 492
+    i32.const 493
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -2165,7 +2173,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 494
+   i32.const 495
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/std/set.release.wat
+++ b/tests/compiler/std/set.release.wat
@@ -654,16 +654,11 @@
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
-  local.get $2
   local.get $1
   i64.extend_i32_u
-  i64.lt_u
+  local.get $2
+  i64.gt_u
   if
-   i32.const 0
-   i32.const 1392
-   i32.const 385
-   i32.const 14
-   call $~lib/builtins/abort
    unreachable
   end
   local.get $1

--- a/tests/compiler/std/set.release.wat
+++ b/tests/compiler/std/set.release.wat
@@ -654,11 +654,16 @@
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
+  local.get $2
   local.get $1
   i64.extend_i32_u
-  local.get $2
-  i64.gt_u
+  i64.lt_u
   if
+   i32.const 0
+   i32.const 1392
+   i32.const 386
+   i32.const 14
+   call $~lib/builtins/abort
    unreachable
   end
   local.get $1
@@ -681,7 +686,7 @@
    if
     i32.const 0
     i32.const 1392
-    i32.const 392
+    i32.const 393
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -708,7 +713,7 @@
    if
     i32.const 0
     i32.const 1392
-    i32.const 405
+    i32.const 406
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1071,7 +1076,7 @@
       if
        i32.const 0
        i32.const 1392
-       i32.const 555
+       i32.const 556
        i32.const 3
        call $~lib/builtins/abort
        unreachable
@@ -1306,7 +1311,7 @@
   if
    i32.const 1056
    i32.const 1392
-   i32.const 460
+   i32.const 461
    i32.const 29
    call $~lib/builtins/abort
    unreachable
@@ -1408,7 +1413,7 @@
    if
     i32.const 0
     i32.const 1392
-    i32.const 492
+    i32.const 493
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1423,7 +1428,7 @@
   if
    i32.const 0
    i32.const 1392
-   i32.const 494
+   i32.const 495
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/std/set.release.wat
+++ b/tests/compiler/std/set.release.wat
@@ -661,7 +661,7 @@
   if
    i32.const 0
    i32.const 1392
-   i32.const 382
+   i32.const 385
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -686,7 +686,7 @@
    if
     i32.const 0
     i32.const 1392
-    i32.const 389
+    i32.const 392
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -713,7 +713,7 @@
    if
     i32.const 0
     i32.const 1392
-    i32.const 402
+    i32.const 405
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1076,7 +1076,7 @@
       if
        i32.const 0
        i32.const 1392
-       i32.const 562
+       i32.const 555
        i32.const 3
        call $~lib/builtins/abort
        unreachable
@@ -1311,7 +1311,7 @@
   if
    i32.const 1056
    i32.const 1392
-   i32.const 461
+   i32.const 460
    i32.const 29
    call $~lib/builtins/abort
    unreachable
@@ -1413,7 +1413,7 @@
    if
     i32.const 0
     i32.const 1392
-    i32.const 499
+    i32.const 492
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1428,7 +1428,7 @@
   if
    i32.const 0
    i32.const 1392
-   i32.const 501
+   i32.const 494
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/std/static-array.debug.wat
+++ b/tests/compiler/std/static-array.debug.wat
@@ -1065,6 +1065,8 @@
   local.get $endU64
   i32.wrap_i64
   local.set $end
+  i32.const 0
+  drop
   i32.const 1
   drop
   local.get $start
@@ -1075,7 +1077,7 @@
   if
    i32.const 0
    i32.const 880
-   i32.const 382
+   i32.const 385
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1121,7 +1123,7 @@
    if
     i32.const 0
     i32.const 880
-    i32.const 389
+    i32.const 392
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1153,7 +1155,7 @@
    if
     i32.const 0
     i32.const 880
-    i32.const 402
+    i32.const 405
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1354,8 +1356,6 @@
   i32.const 1572
   i32.add
   local.set $memStart
-  i32.const 0
-  drop
   local.get $root
   local.get $memStart
   memory.size
@@ -1397,7 +1397,7 @@
   if
    i32.const 0
    i32.const 880
-   i32.const 562
+   i32.const 555
    i32.const 3
    call $~lib/builtins/abort
    unreachable
@@ -1726,7 +1726,7 @@
   if
    i32.const 608
    i32.const 880
-   i32.const 461
+   i32.const 460
    i32.const 29
    call $~lib/builtins/abort
    unreachable
@@ -1960,8 +1960,6 @@
   (local $6 i32)
   (local $pagesWanted i32)
   (local $pagesAfter i32)
-  i32.const 0
-  drop
   local.get $size
   i32.const 256
   i32.ge_u
@@ -2171,7 +2169,7 @@
    if
     i32.const 0
     i32.const 880
-    i32.const 499
+    i32.const 492
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -2191,7 +2189,7 @@
   if
    i32.const 0
    i32.const 880
-   i32.const 501
+   i32.const 494
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/std/static-array.debug.wat
+++ b/tests/compiler/std/static-array.debug.wat
@@ -1067,11 +1067,19 @@
   local.set $end
   i32.const 0
   drop
+  i32.const 1
+  drop
   local.get $start
   i64.extend_i32_u
   local.get $endU64
-  i64.gt_u
+  i64.le_u
+  i32.eqz
   if
+   i32.const 0
+   i32.const 880
+   i32.const 386
+   i32.const 14
+   call $~lib/builtins/abort
    unreachable
   end
   local.get $start
@@ -1115,7 +1123,7 @@
    if
     i32.const 0
     i32.const 880
-    i32.const 392
+    i32.const 393
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1147,7 +1155,7 @@
    if
     i32.const 0
     i32.const 880
-    i32.const 405
+    i32.const 406
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1389,7 +1397,7 @@
   if
    i32.const 0
    i32.const 880
-   i32.const 555
+   i32.const 556
    i32.const 3
    call $~lib/builtins/abort
    unreachable
@@ -1718,7 +1726,7 @@
   if
    i32.const 608
    i32.const 880
-   i32.const 460
+   i32.const 461
    i32.const 29
    call $~lib/builtins/abort
    unreachable
@@ -2161,7 +2169,7 @@
    if
     i32.const 0
     i32.const 880
-    i32.const 492
+    i32.const 493
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -2181,7 +2189,7 @@
   if
    i32.const 0
    i32.const 880
-   i32.const 494
+   i32.const 495
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/std/static-array.debug.wat
+++ b/tests/compiler/std/static-array.debug.wat
@@ -1067,19 +1067,11 @@
   local.set $end
   i32.const 0
   drop
-  i32.const 1
-  drop
   local.get $start
   i64.extend_i32_u
   local.get $endU64
-  i64.le_u
-  i32.eqz
+  i64.gt_u
   if
-   i32.const 0
-   i32.const 880
-   i32.const 385
-   i32.const 14
-   call $~lib/builtins/abort
    unreachable
   end
   local.get $start

--- a/tests/compiler/std/static-array.release.wat
+++ b/tests/compiler/std/static-array.release.wat
@@ -673,7 +673,7 @@
   if
    i32.const 0
    i32.const 1904
-   i32.const 382
+   i32.const 385
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -698,7 +698,7 @@
    if
     i32.const 0
     i32.const 1904
-    i32.const 389
+    i32.const 392
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -725,7 +725,7 @@
    if
     i32.const 0
     i32.const 1904
-    i32.const 402
+    i32.const 405
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1088,7 +1088,7 @@
       if
        i32.const 0
        i32.const 1904
-       i32.const 562
+       i32.const 555
        i32.const 3
        call $~lib/builtins/abort
        unreachable
@@ -1556,7 +1556,7 @@
     if
      i32.const 1632
      i32.const 1904
-     i32.const 461
+     i32.const 460
      i32.const 29
      call $~lib/builtins/abort
      unreachable
@@ -1658,7 +1658,7 @@
      if
       i32.const 0
       i32.const 1904
-      i32.const 499
+      i32.const 492
       i32.const 16
       call $~lib/builtins/abort
       unreachable
@@ -1673,7 +1673,7 @@
     if
      i32.const 0
      i32.const 1904
-     i32.const 501
+     i32.const 494
      i32.const 14
      call $~lib/builtins/abort
      unreachable

--- a/tests/compiler/std/static-array.release.wat
+++ b/tests/compiler/std/static-array.release.wat
@@ -666,16 +666,11 @@
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
-  local.get $2
   local.get $1
   i64.extend_i32_u
-  i64.lt_u
+  local.get $2
+  i64.gt_u
   if
-   i32.const 0
-   i32.const 1904
-   i32.const 385
-   i32.const 14
-   call $~lib/builtins/abort
    unreachable
   end
   local.get $1

--- a/tests/compiler/std/static-array.release.wat
+++ b/tests/compiler/std/static-array.release.wat
@@ -666,11 +666,16 @@
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
+  local.get $2
   local.get $1
   i64.extend_i32_u
-  local.get $2
-  i64.gt_u
+  i64.lt_u
   if
+   i32.const 0
+   i32.const 1904
+   i32.const 386
+   i32.const 14
+   call $~lib/builtins/abort
    unreachable
   end
   local.get $1
@@ -693,7 +698,7 @@
    if
     i32.const 0
     i32.const 1904
-    i32.const 392
+    i32.const 393
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -720,7 +725,7 @@
    if
     i32.const 0
     i32.const 1904
-    i32.const 405
+    i32.const 406
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1083,7 +1088,7 @@
       if
        i32.const 0
        i32.const 1904
-       i32.const 555
+       i32.const 556
        i32.const 3
        call $~lib/builtins/abort
        unreachable
@@ -1551,7 +1556,7 @@
     if
      i32.const 1632
      i32.const 1904
-     i32.const 460
+     i32.const 461
      i32.const 29
      call $~lib/builtins/abort
      unreachable
@@ -1653,7 +1658,7 @@
      if
       i32.const 0
       i32.const 1904
-      i32.const 492
+      i32.const 493
       i32.const 16
       call $~lib/builtins/abort
       unreachable
@@ -1668,7 +1673,7 @@
     if
      i32.const 0
      i32.const 1904
-     i32.const 494
+     i32.const 495
      i32.const 14
      call $~lib/builtins/abort
      unreachable

--- a/tests/compiler/std/staticarray.debug.wat
+++ b/tests/compiler/std/staticarray.debug.wat
@@ -1131,6 +1131,8 @@
   local.get $endU64
   i32.wrap_i64
   local.set $end
+  i32.const 0
+  drop
   i32.const 1
   drop
   local.get $start
@@ -1141,7 +1143,7 @@
   if
    i32.const 0
    i32.const 592
-   i32.const 382
+   i32.const 385
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1187,7 +1189,7 @@
    if
     i32.const 0
     i32.const 592
-    i32.const 389
+    i32.const 392
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1219,7 +1221,7 @@
    if
     i32.const 0
     i32.const 592
-    i32.const 402
+    i32.const 405
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1420,8 +1422,6 @@
   i32.const 1572
   i32.add
   local.set $memStart
-  i32.const 0
-  drop
   local.get $root
   local.get $memStart
   memory.size
@@ -1463,7 +1463,7 @@
   if
    i32.const 0
    i32.const 592
-   i32.const 562
+   i32.const 555
    i32.const 3
    call $~lib/builtins/abort
    unreachable
@@ -1792,7 +1792,7 @@
   if
    i32.const 320
    i32.const 592
-   i32.const 461
+   i32.const 460
    i32.const 29
    call $~lib/builtins/abort
    unreachable
@@ -2026,8 +2026,6 @@
   (local $6 i32)
   (local $pagesWanted i32)
   (local $pagesAfter i32)
-  i32.const 0
-  drop
   local.get $size
   i32.const 256
   i32.ge_u
@@ -2237,7 +2235,7 @@
    if
     i32.const 0
     i32.const 592
-    i32.const 499
+    i32.const 492
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -2257,7 +2255,7 @@
   if
    i32.const 0
    i32.const 592
-   i32.const 501
+   i32.const 494
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/std/staticarray.debug.wat
+++ b/tests/compiler/std/staticarray.debug.wat
@@ -1133,11 +1133,19 @@
   local.set $end
   i32.const 0
   drop
+  i32.const 1
+  drop
   local.get $start
   i64.extend_i32_u
   local.get $endU64
-  i64.gt_u
+  i64.le_u
+  i32.eqz
   if
+   i32.const 0
+   i32.const 592
+   i32.const 386
+   i32.const 14
+   call $~lib/builtins/abort
    unreachable
   end
   local.get $start
@@ -1181,7 +1189,7 @@
    if
     i32.const 0
     i32.const 592
-    i32.const 392
+    i32.const 393
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1213,7 +1221,7 @@
    if
     i32.const 0
     i32.const 592
-    i32.const 405
+    i32.const 406
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1455,7 +1463,7 @@
   if
    i32.const 0
    i32.const 592
-   i32.const 555
+   i32.const 556
    i32.const 3
    call $~lib/builtins/abort
    unreachable
@@ -1784,7 +1792,7 @@
   if
    i32.const 320
    i32.const 592
-   i32.const 460
+   i32.const 461
    i32.const 29
    call $~lib/builtins/abort
    unreachable
@@ -2227,7 +2235,7 @@
    if
     i32.const 0
     i32.const 592
-    i32.const 492
+    i32.const 493
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -2247,7 +2255,7 @@
   if
    i32.const 0
    i32.const 592
-   i32.const 494
+   i32.const 495
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/std/staticarray.debug.wat
+++ b/tests/compiler/std/staticarray.debug.wat
@@ -1133,19 +1133,11 @@
   local.set $end
   i32.const 0
   drop
-  i32.const 1
-  drop
   local.get $start
   i64.extend_i32_u
   local.get $endU64
-  i64.le_u
-  i32.eqz
+  i64.gt_u
   if
-   i32.const 0
-   i32.const 592
-   i32.const 385
-   i32.const 14
-   call $~lib/builtins/abort
    unreachable
   end
   local.get $start

--- a/tests/compiler/std/staticarray.release.wat
+++ b/tests/compiler/std/staticarray.release.wat
@@ -796,7 +796,7 @@
   if
    i32.const 0
    i32.const 1616
-   i32.const 382
+   i32.const 385
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -821,7 +821,7 @@
    if
     i32.const 0
     i32.const 1616
-    i32.const 389
+    i32.const 392
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -848,7 +848,7 @@
    if
     i32.const 0
     i32.const 1616
-    i32.const 402
+    i32.const 405
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1016,7 +1016,7 @@
   if
    i32.const 0
    i32.const 1616
-   i32.const 562
+   i32.const 555
    i32.const 3
    call $~lib/builtins/abort
    unreachable
@@ -1385,7 +1385,7 @@
   if
    i32.const 1344
    i32.const 1616
-   i32.const 461
+   i32.const 460
    i32.const 29
    call $~lib/builtins/abort
    unreachable
@@ -1487,7 +1487,7 @@
    if
     i32.const 0
     i32.const 1616
-    i32.const 499
+    i32.const 492
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1502,7 +1502,7 @@
   if
    i32.const 0
    i32.const 1616
-   i32.const 501
+   i32.const 494
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/std/staticarray.release.wat
+++ b/tests/compiler/std/staticarray.release.wat
@@ -789,16 +789,11 @@
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
-  local.get $2
   local.get $1
   i64.extend_i32_u
-  i64.lt_u
+  local.get $2
+  i64.gt_u
   if
-   i32.const 0
-   i32.const 1616
-   i32.const 385
-   i32.const 14
-   call $~lib/builtins/abort
    unreachable
   end
   local.get $1

--- a/tests/compiler/std/staticarray.release.wat
+++ b/tests/compiler/std/staticarray.release.wat
@@ -789,11 +789,16 @@
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
+  local.get $2
   local.get $1
   i64.extend_i32_u
-  local.get $2
-  i64.gt_u
+  i64.lt_u
   if
+   i32.const 0
+   i32.const 1616
+   i32.const 386
+   i32.const 14
+   call $~lib/builtins/abort
    unreachable
   end
   local.get $1
@@ -816,7 +821,7 @@
    if
     i32.const 0
     i32.const 1616
-    i32.const 392
+    i32.const 393
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -843,7 +848,7 @@
    if
     i32.const 0
     i32.const 1616
-    i32.const 405
+    i32.const 406
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1011,7 +1016,7 @@
   if
    i32.const 0
    i32.const 1616
-   i32.const 555
+   i32.const 556
    i32.const 3
    call $~lib/builtins/abort
    unreachable
@@ -1380,7 +1385,7 @@
   if
    i32.const 1344
    i32.const 1616
-   i32.const 460
+   i32.const 461
    i32.const 29
    call $~lib/builtins/abort
    unreachable
@@ -1482,7 +1487,7 @@
    if
     i32.const 0
     i32.const 1616
-    i32.const 492
+    i32.const 493
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1497,7 +1502,7 @@
   if
    i32.const 0
    i32.const 1616
-   i32.const 494
+   i32.const 495
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/std/string-casemapping.debug.wat
+++ b/tests/compiler/std/string-casemapping.debug.wat
@@ -1217,6 +1217,8 @@
   local.get $endU64
   i32.wrap_i64
   local.set $end
+  i32.const 0
+  drop
   i32.const 1
   drop
   local.get $start
@@ -1227,7 +1229,7 @@
   if
    i32.const 0
    i32.const 400
-   i32.const 382
+   i32.const 385
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1273,7 +1275,7 @@
    if
     i32.const 0
     i32.const 400
-    i32.const 389
+    i32.const 392
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1305,7 +1307,7 @@
    if
     i32.const 0
     i32.const 400
-    i32.const 402
+    i32.const 405
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1506,8 +1508,6 @@
   i32.const 1572
   i32.add
   local.set $memStart
-  i32.const 0
-  drop
   local.get $root
   local.get $memStart
   memory.size
@@ -1549,7 +1549,7 @@
   if
    i32.const 0
    i32.const 400
-   i32.const 562
+   i32.const 555
    i32.const 3
    call $~lib/builtins/abort
    unreachable
@@ -1878,7 +1878,7 @@
   if
    i32.const 64
    i32.const 400
-   i32.const 461
+   i32.const 460
    i32.const 29
    call $~lib/builtins/abort
    unreachable
@@ -2112,8 +2112,6 @@
   (local $6 i32)
   (local $pagesWanted i32)
   (local $pagesAfter i32)
-  i32.const 0
-  drop
   local.get $size
   i32.const 256
   i32.ge_u
@@ -2323,7 +2321,7 @@
    if
     i32.const 0
     i32.const 400
-    i32.const 499
+    i32.const 492
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -2343,7 +2341,7 @@
   if
    i32.const 0
    i32.const 400
-   i32.const 501
+   i32.const 494
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/std/string-casemapping.debug.wat
+++ b/tests/compiler/std/string-casemapping.debug.wat
@@ -1219,11 +1219,19 @@
   local.set $end
   i32.const 0
   drop
+  i32.const 1
+  drop
   local.get $start
   i64.extend_i32_u
   local.get $endU64
-  i64.gt_u
+  i64.le_u
+  i32.eqz
   if
+   i32.const 0
+   i32.const 400
+   i32.const 386
+   i32.const 14
+   call $~lib/builtins/abort
    unreachable
   end
   local.get $start
@@ -1267,7 +1275,7 @@
    if
     i32.const 0
     i32.const 400
-    i32.const 392
+    i32.const 393
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1299,7 +1307,7 @@
    if
     i32.const 0
     i32.const 400
-    i32.const 405
+    i32.const 406
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1541,7 +1549,7 @@
   if
    i32.const 0
    i32.const 400
-   i32.const 555
+   i32.const 556
    i32.const 3
    call $~lib/builtins/abort
    unreachable
@@ -1870,7 +1878,7 @@
   if
    i32.const 64
    i32.const 400
-   i32.const 460
+   i32.const 461
    i32.const 29
    call $~lib/builtins/abort
    unreachable
@@ -2313,7 +2321,7 @@
    if
     i32.const 0
     i32.const 400
-    i32.const 492
+    i32.const 493
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -2333,7 +2341,7 @@
   if
    i32.const 0
    i32.const 400
-   i32.const 494
+   i32.const 495
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/std/string-casemapping.debug.wat
+++ b/tests/compiler/std/string-casemapping.debug.wat
@@ -1219,19 +1219,11 @@
   local.set $end
   i32.const 0
   drop
-  i32.const 1
-  drop
   local.get $start
   i64.extend_i32_u
   local.get $endU64
-  i64.le_u
-  i32.eqz
+  i64.gt_u
   if
-   i32.const 0
-   i32.const 400
-   i32.const 385
-   i32.const 14
-   call $~lib/builtins/abort
    unreachable
   end
   local.get $start

--- a/tests/compiler/std/string-casemapping.release.wat
+++ b/tests/compiler/std/string-casemapping.release.wat
@@ -1088,7 +1088,7 @@
   if
    i32.const 0
    i32.const 1424
-   i32.const 382
+   i32.const 385
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1113,7 +1113,7 @@
    if
     i32.const 0
     i32.const 1424
-    i32.const 389
+    i32.const 392
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1140,7 +1140,7 @@
    if
     i32.const 0
     i32.const 1424
-    i32.const 402
+    i32.const 405
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1503,7 +1503,7 @@
       if
        i32.const 0
        i32.const 1424
-       i32.const 562
+       i32.const 555
        i32.const 3
        call $~lib/builtins/abort
        unreachable
@@ -1738,7 +1738,7 @@
   if
    i32.const 1088
    i32.const 1424
-   i32.const 461
+   i32.const 460
    i32.const 29
    call $~lib/builtins/abort
    unreachable
@@ -1840,7 +1840,7 @@
    if
     i32.const 0
     i32.const 1424
-    i32.const 499
+    i32.const 492
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1855,7 +1855,7 @@
   if
    i32.const 0
    i32.const 1424
-   i32.const 501
+   i32.const 494
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/std/string-casemapping.release.wat
+++ b/tests/compiler/std/string-casemapping.release.wat
@@ -1081,11 +1081,16 @@
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
+  local.get $2
   local.get $1
   i64.extend_i32_u
-  local.get $2
-  i64.gt_u
+  i64.lt_u
   if
+   i32.const 0
+   i32.const 1424
+   i32.const 386
+   i32.const 14
+   call $~lib/builtins/abort
    unreachable
   end
   local.get $1
@@ -1108,7 +1113,7 @@
    if
     i32.const 0
     i32.const 1424
-    i32.const 392
+    i32.const 393
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1135,7 +1140,7 @@
    if
     i32.const 0
     i32.const 1424
-    i32.const 405
+    i32.const 406
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1498,7 +1503,7 @@
       if
        i32.const 0
        i32.const 1424
-       i32.const 555
+       i32.const 556
        i32.const 3
        call $~lib/builtins/abort
        unreachable
@@ -1733,7 +1738,7 @@
   if
    i32.const 1088
    i32.const 1424
-   i32.const 460
+   i32.const 461
    i32.const 29
    call $~lib/builtins/abort
    unreachable
@@ -1835,7 +1840,7 @@
    if
     i32.const 0
     i32.const 1424
-    i32.const 492
+    i32.const 493
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1850,7 +1855,7 @@
   if
    i32.const 0
    i32.const 1424
-   i32.const 494
+   i32.const 495
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/std/string-casemapping.release.wat
+++ b/tests/compiler/std/string-casemapping.release.wat
@@ -1081,16 +1081,11 @@
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
-  local.get $2
   local.get $1
   i64.extend_i32_u
-  i64.lt_u
+  local.get $2
+  i64.gt_u
   if
-   i32.const 0
-   i32.const 1424
-   i32.const 385
-   i32.const 14
-   call $~lib/builtins/abort
    unreachable
   end
   local.get $1

--- a/tests/compiler/std/string-encoding.debug.wat
+++ b/tests/compiler/std/string-encoding.debug.wat
@@ -1058,19 +1058,11 @@
   local.set $end
   i32.const 0
   drop
-  i32.const 1
-  drop
   local.get $start
   i64.extend_i32_u
   local.get $endU64
-  i64.le_u
-  i32.eqz
+  i64.gt_u
   if
-   i32.const 0
-   i32.const 464
-   i32.const 385
-   i32.const 14
-   call $~lib/builtins/abort
    unreachable
   end
   local.get $start

--- a/tests/compiler/std/string-encoding.debug.wat
+++ b/tests/compiler/std/string-encoding.debug.wat
@@ -1058,11 +1058,19 @@
   local.set $end
   i32.const 0
   drop
+  i32.const 1
+  drop
   local.get $start
   i64.extend_i32_u
   local.get $endU64
-  i64.gt_u
+  i64.le_u
+  i32.eqz
   if
+   i32.const 0
+   i32.const 464
+   i32.const 386
+   i32.const 14
+   call $~lib/builtins/abort
    unreachable
   end
   local.get $start
@@ -1106,7 +1114,7 @@
    if
     i32.const 0
     i32.const 464
-    i32.const 392
+    i32.const 393
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1138,7 +1146,7 @@
    if
     i32.const 0
     i32.const 464
-    i32.const 405
+    i32.const 406
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1380,7 +1388,7 @@
   if
    i32.const 0
    i32.const 464
-   i32.const 555
+   i32.const 556
    i32.const 3
    call $~lib/builtins/abort
    unreachable
@@ -1709,7 +1717,7 @@
   if
    i32.const 128
    i32.const 464
-   i32.const 460
+   i32.const 461
    i32.const 29
    call $~lib/builtins/abort
    unreachable
@@ -2152,7 +2160,7 @@
    if
     i32.const 0
     i32.const 464
-    i32.const 492
+    i32.const 493
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -2172,7 +2180,7 @@
   if
    i32.const 0
    i32.const 464
-   i32.const 494
+   i32.const 495
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/std/string-encoding.debug.wat
+++ b/tests/compiler/std/string-encoding.debug.wat
@@ -1056,6 +1056,8 @@
   local.get $endU64
   i32.wrap_i64
   local.set $end
+  i32.const 0
+  drop
   i32.const 1
   drop
   local.get $start
@@ -1066,7 +1068,7 @@
   if
    i32.const 0
    i32.const 464
-   i32.const 382
+   i32.const 385
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1112,7 +1114,7 @@
    if
     i32.const 0
     i32.const 464
-    i32.const 389
+    i32.const 392
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1144,7 +1146,7 @@
    if
     i32.const 0
     i32.const 464
-    i32.const 402
+    i32.const 405
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1345,8 +1347,6 @@
   i32.const 1572
   i32.add
   local.set $memStart
-  i32.const 0
-  drop
   local.get $root
   local.get $memStart
   memory.size
@@ -1388,7 +1388,7 @@
   if
    i32.const 0
    i32.const 464
-   i32.const 562
+   i32.const 555
    i32.const 3
    call $~lib/builtins/abort
    unreachable
@@ -1717,7 +1717,7 @@
   if
    i32.const 128
    i32.const 464
-   i32.const 461
+   i32.const 460
    i32.const 29
    call $~lib/builtins/abort
    unreachable
@@ -1951,8 +1951,6 @@
   (local $6 i32)
   (local $pagesWanted i32)
   (local $pagesAfter i32)
-  i32.const 0
-  drop
   local.get $size
   i32.const 256
   i32.ge_u
@@ -2162,7 +2160,7 @@
    if
     i32.const 0
     i32.const 464
-    i32.const 499
+    i32.const 492
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -2182,7 +2180,7 @@
   if
    i32.const 0
    i32.const 464
-   i32.const 501
+   i32.const 494
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/std/string-encoding.release.wat
+++ b/tests/compiler/std/string-encoding.release.wat
@@ -668,11 +668,16 @@
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
+  local.get $2
   local.get $1
   i64.extend_i32_u
-  local.get $2
-  i64.gt_u
+  i64.lt_u
   if
+   i32.const 0
+   i32.const 1488
+   i32.const 386
+   i32.const 14
+   call $~lib/builtins/abort
    unreachable
   end
   local.get $1
@@ -695,7 +700,7 @@
    if
     i32.const 0
     i32.const 1488
-    i32.const 392
+    i32.const 393
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -722,7 +727,7 @@
    if
     i32.const 0
     i32.const 1488
-    i32.const 405
+    i32.const 406
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1085,7 +1090,7 @@
       if
        i32.const 0
        i32.const 1488
-       i32.const 555
+       i32.const 556
        i32.const 3
        call $~lib/builtins/abort
        unreachable
@@ -1320,7 +1325,7 @@
   if
    i32.const 1152
    i32.const 1488
-   i32.const 460
+   i32.const 461
    i32.const 29
    call $~lib/builtins/abort
    unreachable
@@ -1422,7 +1427,7 @@
    if
     i32.const 0
     i32.const 1488
-    i32.const 492
+    i32.const 493
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1437,7 +1442,7 @@
   if
    i32.const 0
    i32.const 1488
-   i32.const 494
+   i32.const 495
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/std/string-encoding.release.wat
+++ b/tests/compiler/std/string-encoding.release.wat
@@ -668,16 +668,11 @@
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
-  local.get $2
   local.get $1
   i64.extend_i32_u
-  i64.lt_u
+  local.get $2
+  i64.gt_u
   if
-   i32.const 0
-   i32.const 1488
-   i32.const 385
-   i32.const 14
-   call $~lib/builtins/abort
    unreachable
   end
   local.get $1

--- a/tests/compiler/std/string-encoding.release.wat
+++ b/tests/compiler/std/string-encoding.release.wat
@@ -675,7 +675,7 @@
   if
    i32.const 0
    i32.const 1488
-   i32.const 382
+   i32.const 385
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -700,7 +700,7 @@
    if
     i32.const 0
     i32.const 1488
-    i32.const 389
+    i32.const 392
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -727,7 +727,7 @@
    if
     i32.const 0
     i32.const 1488
-    i32.const 402
+    i32.const 405
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1090,7 +1090,7 @@
       if
        i32.const 0
        i32.const 1488
-       i32.const 562
+       i32.const 555
        i32.const 3
        call $~lib/builtins/abort
        unreachable
@@ -1325,7 +1325,7 @@
   if
    i32.const 1152
    i32.const 1488
-   i32.const 461
+   i32.const 460
    i32.const 29
    call $~lib/builtins/abort
    unreachable
@@ -1427,7 +1427,7 @@
    if
     i32.const 0
     i32.const 1488
-    i32.const 499
+    i32.const 492
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1442,7 +1442,7 @@
   if
    i32.const 0
    i32.const 1488
-   i32.const 501
+   i32.const 494
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/std/string.debug.wat
+++ b/tests/compiler/std/string.debug.wat
@@ -1649,11 +1649,19 @@
   local.set $end
   i32.const 0
   drop
+  i32.const 1
+  drop
   local.get $start
   i64.extend_i32_u
   local.get $endU64
-  i64.gt_u
+  i64.le_u
+  i32.eqz
   if
+   i32.const 0
+   i32.const 624
+   i32.const 386
+   i32.const 14
+   call $~lib/builtins/abort
    unreachable
   end
   local.get $start
@@ -1697,7 +1705,7 @@
    if
     i32.const 0
     i32.const 624
-    i32.const 392
+    i32.const 393
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1729,7 +1737,7 @@
    if
     i32.const 0
     i32.const 624
-    i32.const 405
+    i32.const 406
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1971,7 +1979,7 @@
   if
    i32.const 0
    i32.const 624
-   i32.const 555
+   i32.const 556
    i32.const 3
    call $~lib/builtins/abort
    unreachable
@@ -2300,7 +2308,7 @@
   if
    i32.const 352
    i32.const 624
-   i32.const 460
+   i32.const 461
    i32.const 29
    call $~lib/builtins/abort
    unreachable
@@ -2743,7 +2751,7 @@
    if
     i32.const 0
     i32.const 624
-    i32.const 492
+    i32.const 493
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -2763,7 +2771,7 @@
   if
    i32.const 0
    i32.const 624
-   i32.const 494
+   i32.const 495
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/std/string.debug.wat
+++ b/tests/compiler/std/string.debug.wat
@@ -1647,6 +1647,8 @@
   local.get $endU64
   i32.wrap_i64
   local.set $end
+  i32.const 0
+  drop
   i32.const 1
   drop
   local.get $start
@@ -1657,7 +1659,7 @@
   if
    i32.const 0
    i32.const 624
-   i32.const 382
+   i32.const 385
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1703,7 +1705,7 @@
    if
     i32.const 0
     i32.const 624
-    i32.const 389
+    i32.const 392
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1735,7 +1737,7 @@
    if
     i32.const 0
     i32.const 624
-    i32.const 402
+    i32.const 405
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1936,8 +1938,6 @@
   i32.const 1572
   i32.add
   local.set $memStart
-  i32.const 0
-  drop
   local.get $root
   local.get $memStart
   memory.size
@@ -1979,7 +1979,7 @@
   if
    i32.const 0
    i32.const 624
-   i32.const 562
+   i32.const 555
    i32.const 3
    call $~lib/builtins/abort
    unreachable
@@ -2308,7 +2308,7 @@
   if
    i32.const 352
    i32.const 624
-   i32.const 461
+   i32.const 460
    i32.const 29
    call $~lib/builtins/abort
    unreachable
@@ -2542,8 +2542,6 @@
   (local $6 i32)
   (local $pagesWanted i32)
   (local $pagesAfter i32)
-  i32.const 0
-  drop
   local.get $size
   i32.const 256
   i32.ge_u
@@ -2753,7 +2751,7 @@
    if
     i32.const 0
     i32.const 624
-    i32.const 499
+    i32.const 492
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -2773,7 +2771,7 @@
   if
    i32.const 0
    i32.const 624
-   i32.const 501
+   i32.const 494
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/std/string.debug.wat
+++ b/tests/compiler/std/string.debug.wat
@@ -1649,19 +1649,11 @@
   local.set $end
   i32.const 0
   drop
-  i32.const 1
-  drop
   local.get $start
   i64.extend_i32_u
   local.get $endU64
-  i64.le_u
-  i32.eqz
+  i64.gt_u
   if
-   i32.const 0
-   i32.const 624
-   i32.const 385
-   i32.const 14
-   call $~lib/builtins/abort
    unreachable
   end
   local.get $start

--- a/tests/compiler/std/string.release.wat
+++ b/tests/compiler/std/string.release.wat
@@ -1668,11 +1668,16 @@
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
+  local.get $2
   local.get $1
   i64.extend_i32_u
-  local.get $2
-  i64.gt_u
+  i64.lt_u
   if
+   i32.const 0
+   i32.const 1648
+   i32.const 386
+   i32.const 14
+   call $~lib/builtins/abort
    unreachable
   end
   local.get $1
@@ -1695,7 +1700,7 @@
    if
     i32.const 0
     i32.const 1648
-    i32.const 392
+    i32.const 393
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1722,7 +1727,7 @@
    if
     i32.const 0
     i32.const 1648
-    i32.const 405
+    i32.const 406
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -2085,7 +2090,7 @@
       if
        i32.const 0
        i32.const 1648
-       i32.const 555
+       i32.const 556
        i32.const 3
        call $~lib/builtins/abort
        unreachable
@@ -2320,7 +2325,7 @@
   if
    i32.const 1376
    i32.const 1648
-   i32.const 460
+   i32.const 461
    i32.const 29
    call $~lib/builtins/abort
    unreachable
@@ -2422,7 +2427,7 @@
    if
     i32.const 0
     i32.const 1648
-    i32.const 492
+    i32.const 493
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -2437,7 +2442,7 @@
   if
    i32.const 0
    i32.const 1648
-   i32.const 494
+   i32.const 495
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/std/string.release.wat
+++ b/tests/compiler/std/string.release.wat
@@ -1668,16 +1668,11 @@
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
-  local.get $2
   local.get $1
   i64.extend_i32_u
-  i64.lt_u
+  local.get $2
+  i64.gt_u
   if
-   i32.const 0
-   i32.const 1648
-   i32.const 385
-   i32.const 14
-   call $~lib/builtins/abort
    unreachable
   end
   local.get $1

--- a/tests/compiler/std/string.release.wat
+++ b/tests/compiler/std/string.release.wat
@@ -1675,7 +1675,7 @@
   if
    i32.const 0
    i32.const 1648
-   i32.const 382
+   i32.const 385
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1700,7 +1700,7 @@
    if
     i32.const 0
     i32.const 1648
-    i32.const 389
+    i32.const 392
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1727,7 +1727,7 @@
    if
     i32.const 0
     i32.const 1648
-    i32.const 402
+    i32.const 405
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -2090,7 +2090,7 @@
       if
        i32.const 0
        i32.const 1648
-       i32.const 562
+       i32.const 555
        i32.const 3
        call $~lib/builtins/abort
        unreachable
@@ -2325,7 +2325,7 @@
   if
    i32.const 1376
    i32.const 1648
-   i32.const 461
+   i32.const 460
    i32.const 29
    call $~lib/builtins/abort
    unreachable
@@ -2427,7 +2427,7 @@
    if
     i32.const 0
     i32.const 1648
-    i32.const 499
+    i32.const 492
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -2442,7 +2442,7 @@
   if
    i32.const 0
    i32.const 1648
-   i32.const 501
+   i32.const 494
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/std/symbol.debug.wat
+++ b/tests/compiler/std/symbol.debug.wat
@@ -1087,11 +1087,19 @@
   local.set $end
   i32.const 0
   drop
+  i32.const 1
+  drop
   local.get $start
   i64.extend_i32_u
   local.get $endU64
-  i64.gt_u
+  i64.le_u
+  i32.eqz
   if
+   i32.const 0
+   i32.const 448
+   i32.const 386
+   i32.const 14
+   call $~lib/builtins/abort
    unreachable
   end
   local.get $start
@@ -1135,7 +1143,7 @@
    if
     i32.const 0
     i32.const 448
-    i32.const 392
+    i32.const 393
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1167,7 +1175,7 @@
    if
     i32.const 0
     i32.const 448
-    i32.const 405
+    i32.const 406
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1409,7 +1417,7 @@
   if
    i32.const 0
    i32.const 448
-   i32.const 555
+   i32.const 556
    i32.const 3
    call $~lib/builtins/abort
    unreachable
@@ -1738,7 +1746,7 @@
   if
    i32.const 112
    i32.const 448
-   i32.const 460
+   i32.const 461
    i32.const 29
    call $~lib/builtins/abort
    unreachable
@@ -2181,7 +2189,7 @@
    if
     i32.const 0
     i32.const 448
-    i32.const 492
+    i32.const 493
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -2201,7 +2209,7 @@
   if
    i32.const 0
    i32.const 448
-   i32.const 494
+   i32.const 495
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/std/symbol.debug.wat
+++ b/tests/compiler/std/symbol.debug.wat
@@ -1087,19 +1087,11 @@
   local.set $end
   i32.const 0
   drop
-  i32.const 1
-  drop
   local.get $start
   i64.extend_i32_u
   local.get $endU64
-  i64.le_u
-  i32.eqz
+  i64.gt_u
   if
-   i32.const 0
-   i32.const 448
-   i32.const 385
-   i32.const 14
-   call $~lib/builtins/abort
    unreachable
   end
   local.get $start

--- a/tests/compiler/std/symbol.debug.wat
+++ b/tests/compiler/std/symbol.debug.wat
@@ -1085,6 +1085,8 @@
   local.get $endU64
   i32.wrap_i64
   local.set $end
+  i32.const 0
+  drop
   i32.const 1
   drop
   local.get $start
@@ -1095,7 +1097,7 @@
   if
    i32.const 0
    i32.const 448
-   i32.const 382
+   i32.const 385
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1141,7 +1143,7 @@
    if
     i32.const 0
     i32.const 448
-    i32.const 389
+    i32.const 392
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1173,7 +1175,7 @@
    if
     i32.const 0
     i32.const 448
-    i32.const 402
+    i32.const 405
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1374,8 +1376,6 @@
   i32.const 1572
   i32.add
   local.set $memStart
-  i32.const 0
-  drop
   local.get $root
   local.get $memStart
   memory.size
@@ -1417,7 +1417,7 @@
   if
    i32.const 0
    i32.const 448
-   i32.const 562
+   i32.const 555
    i32.const 3
    call $~lib/builtins/abort
    unreachable
@@ -1746,7 +1746,7 @@
   if
    i32.const 112
    i32.const 448
-   i32.const 461
+   i32.const 460
    i32.const 29
    call $~lib/builtins/abort
    unreachable
@@ -1980,8 +1980,6 @@
   (local $6 i32)
   (local $pagesWanted i32)
   (local $pagesAfter i32)
-  i32.const 0
-  drop
   local.get $size
   i32.const 256
   i32.ge_u
@@ -2191,7 +2189,7 @@
    if
     i32.const 0
     i32.const 448
-    i32.const 499
+    i32.const 492
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -2211,7 +2209,7 @@
   if
    i32.const 0
    i32.const 448
-   i32.const 501
+   i32.const 494
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/std/symbol.release.wat
+++ b/tests/compiler/std/symbol.release.wat
@@ -735,16 +735,11 @@
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
-  local.get $2
   local.get $1
   i64.extend_i32_u
-  i64.lt_u
+  local.get $2
+  i64.gt_u
   if
-   i32.const 0
-   i32.const 1472
-   i32.const 385
-   i32.const 14
-   call $~lib/builtins/abort
    unreachable
   end
   local.get $1

--- a/tests/compiler/std/symbol.release.wat
+++ b/tests/compiler/std/symbol.release.wat
@@ -742,7 +742,7 @@
   if
    i32.const 0
    i32.const 1472
-   i32.const 382
+   i32.const 385
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -767,7 +767,7 @@
    if
     i32.const 0
     i32.const 1472
-    i32.const 389
+    i32.const 392
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -794,7 +794,7 @@
    if
     i32.const 0
     i32.const 1472
-    i32.const 402
+    i32.const 405
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1157,7 +1157,7 @@
       if
        i32.const 0
        i32.const 1472
-       i32.const 562
+       i32.const 555
        i32.const 3
        call $~lib/builtins/abort
        unreachable
@@ -1392,7 +1392,7 @@
   if
    i32.const 1136
    i32.const 1472
-   i32.const 461
+   i32.const 460
    i32.const 29
    call $~lib/builtins/abort
    unreachable
@@ -1494,7 +1494,7 @@
    if
     i32.const 0
     i32.const 1472
-    i32.const 499
+    i32.const 492
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1509,7 +1509,7 @@
   if
    i32.const 0
    i32.const 1472
-   i32.const 501
+   i32.const 494
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/std/symbol.release.wat
+++ b/tests/compiler/std/symbol.release.wat
@@ -735,11 +735,16 @@
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
+  local.get $2
   local.get $1
   i64.extend_i32_u
-  local.get $2
-  i64.gt_u
+  i64.lt_u
   if
+   i32.const 0
+   i32.const 1472
+   i32.const 386
+   i32.const 14
+   call $~lib/builtins/abort
    unreachable
   end
   local.get $1
@@ -762,7 +767,7 @@
    if
     i32.const 0
     i32.const 1472
-    i32.const 392
+    i32.const 393
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -789,7 +794,7 @@
    if
     i32.const 0
     i32.const 1472
-    i32.const 405
+    i32.const 406
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1152,7 +1157,7 @@
       if
        i32.const 0
        i32.const 1472
-       i32.const 555
+       i32.const 556
        i32.const 3
        call $~lib/builtins/abort
        unreachable
@@ -1387,7 +1392,7 @@
   if
    i32.const 1136
    i32.const 1472
-   i32.const 460
+   i32.const 461
    i32.const 29
    call $~lib/builtins/abort
    unreachable
@@ -1489,7 +1494,7 @@
    if
     i32.const 0
     i32.const 1472
-    i32.const 492
+    i32.const 493
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1504,7 +1509,7 @@
   if
    i32.const 0
    i32.const 1472
-   i32.const 494
+   i32.const 495
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/std/typedarray.debug.wat
+++ b/tests/compiler/std/typedarray.debug.wat
@@ -1395,6 +1395,8 @@
   local.get $endU64
   i32.wrap_i64
   local.set $end
+  i32.const 0
+  drop
   i32.const 1
   drop
   local.get $start
@@ -1405,7 +1407,7 @@
   if
    i32.const 0
    i32.const 480
-   i32.const 382
+   i32.const 385
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1451,7 +1453,7 @@
    if
     i32.const 0
     i32.const 480
-    i32.const 389
+    i32.const 392
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1483,7 +1485,7 @@
    if
     i32.const 0
     i32.const 480
-    i32.const 402
+    i32.const 405
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1684,8 +1686,6 @@
   i32.const 1572
   i32.add
   local.set $memStart
-  i32.const 0
-  drop
   local.get $root
   local.get $memStart
   memory.size
@@ -1727,7 +1727,7 @@
   if
    i32.const 0
    i32.const 480
-   i32.const 562
+   i32.const 555
    i32.const 3
    call $~lib/builtins/abort
    unreachable
@@ -2056,7 +2056,7 @@
   if
    i32.const 144
    i32.const 480
-   i32.const 461
+   i32.const 460
    i32.const 29
    call $~lib/builtins/abort
    unreachable
@@ -2290,8 +2290,6 @@
   (local $6 i32)
   (local $pagesWanted i32)
   (local $pagesAfter i32)
-  i32.const 0
-  drop
   local.get $size
   i32.const 256
   i32.ge_u
@@ -2501,7 +2499,7 @@
    if
     i32.const 0
     i32.const 480
-    i32.const 499
+    i32.const 492
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -2521,7 +2519,7 @@
   if
    i32.const 0
    i32.const 480
-   i32.const 501
+   i32.const 494
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/std/typedarray.debug.wat
+++ b/tests/compiler/std/typedarray.debug.wat
@@ -1397,11 +1397,19 @@
   local.set $end
   i32.const 0
   drop
+  i32.const 1
+  drop
   local.get $start
   i64.extend_i32_u
   local.get $endU64
-  i64.gt_u
+  i64.le_u
+  i32.eqz
   if
+   i32.const 0
+   i32.const 480
+   i32.const 386
+   i32.const 14
+   call $~lib/builtins/abort
    unreachable
   end
   local.get $start
@@ -1445,7 +1453,7 @@
    if
     i32.const 0
     i32.const 480
-    i32.const 392
+    i32.const 393
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1477,7 +1485,7 @@
    if
     i32.const 0
     i32.const 480
-    i32.const 405
+    i32.const 406
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1719,7 +1727,7 @@
   if
    i32.const 0
    i32.const 480
-   i32.const 555
+   i32.const 556
    i32.const 3
    call $~lib/builtins/abort
    unreachable
@@ -2048,7 +2056,7 @@
   if
    i32.const 144
    i32.const 480
-   i32.const 460
+   i32.const 461
    i32.const 29
    call $~lib/builtins/abort
    unreachable
@@ -2491,7 +2499,7 @@
    if
     i32.const 0
     i32.const 480
-    i32.const 492
+    i32.const 493
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -2511,7 +2519,7 @@
   if
    i32.const 0
    i32.const 480
-   i32.const 494
+   i32.const 495
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/std/typedarray.debug.wat
+++ b/tests/compiler/std/typedarray.debug.wat
@@ -1397,19 +1397,11 @@
   local.set $end
   i32.const 0
   drop
-  i32.const 1
-  drop
   local.get $start
   i64.extend_i32_u
   local.get $endU64
-  i64.le_u
-  i32.eqz
+  i64.gt_u
   if
-   i32.const 0
-   i32.const 480
-   i32.const 385
-   i32.const 14
-   call $~lib/builtins/abort
    unreachable
   end
   local.get $start

--- a/tests/compiler/std/typedarray.release.wat
+++ b/tests/compiler/std/typedarray.release.wat
@@ -1296,11 +1296,16 @@
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
+  local.get $2
   local.get $1
   i64.extend_i32_u
-  local.get $2
-  i64.gt_u
+  i64.lt_u
   if
+   i32.const 0
+   i32.const 1504
+   i32.const 386
+   i32.const 14
+   call $~lib/builtins/abort
    unreachable
   end
   local.get $1
@@ -1323,7 +1328,7 @@
    if
     i32.const 0
     i32.const 1504
-    i32.const 392
+    i32.const 393
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1350,7 +1355,7 @@
    if
     i32.const 0
     i32.const 1504
-    i32.const 405
+    i32.const 406
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1518,7 +1523,7 @@
   if
    i32.const 0
    i32.const 1504
-   i32.const 555
+   i32.const 556
    i32.const 3
    call $~lib/builtins/abort
    unreachable
@@ -1887,7 +1892,7 @@
   if
    i32.const 1168
    i32.const 1504
-   i32.const 460
+   i32.const 461
    i32.const 29
    call $~lib/builtins/abort
    unreachable
@@ -1989,7 +1994,7 @@
    if
     i32.const 0
     i32.const 1504
-    i32.const 492
+    i32.const 493
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -2004,7 +2009,7 @@
   if
    i32.const 0
    i32.const 1504
-   i32.const 494
+   i32.const 495
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/std/typedarray.release.wat
+++ b/tests/compiler/std/typedarray.release.wat
@@ -1303,7 +1303,7 @@
   if
    i32.const 0
    i32.const 1504
-   i32.const 382
+   i32.const 385
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1328,7 +1328,7 @@
    if
     i32.const 0
     i32.const 1504
-    i32.const 389
+    i32.const 392
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1355,7 +1355,7 @@
    if
     i32.const 0
     i32.const 1504
-    i32.const 402
+    i32.const 405
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1523,7 +1523,7 @@
   if
    i32.const 0
    i32.const 1504
-   i32.const 562
+   i32.const 555
    i32.const 3
    call $~lib/builtins/abort
    unreachable
@@ -1892,7 +1892,7 @@
   if
    i32.const 1168
    i32.const 1504
-   i32.const 461
+   i32.const 460
    i32.const 29
    call $~lib/builtins/abort
    unreachable
@@ -1994,7 +1994,7 @@
    if
     i32.const 0
     i32.const 1504
-    i32.const 499
+    i32.const 492
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -2009,7 +2009,7 @@
   if
    i32.const 0
    i32.const 1504
-   i32.const 501
+   i32.const 494
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/std/typedarray.release.wat
+++ b/tests/compiler/std/typedarray.release.wat
@@ -1296,16 +1296,11 @@
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
-  local.get $2
   local.get $1
   i64.extend_i32_u
-  i64.lt_u
+  local.get $2
+  i64.gt_u
   if
-   i32.const 0
-   i32.const 1504
-   i32.const 385
-   i32.const 14
-   call $~lib/builtins/abort
    unreachable
   end
   local.get $1

--- a/tests/compiler/std/uri.debug.wat
+++ b/tests/compiler/std/uri.debug.wat
@@ -1101,19 +1101,11 @@
   local.set $end
   i32.const 0
   drop
-  i32.const 1
-  drop
   local.get $start
   i64.extend_i32_u
   local.get $endU64
-  i64.le_u
-  i32.eqz
+  i64.gt_u
   if
-   i32.const 0
-   i32.const 496
-   i32.const 385
-   i32.const 14
-   call $~lib/builtins/abort
    unreachable
   end
   local.get $start

--- a/tests/compiler/std/uri.debug.wat
+++ b/tests/compiler/std/uri.debug.wat
@@ -1101,11 +1101,19 @@
   local.set $end
   i32.const 0
   drop
+  i32.const 1
+  drop
   local.get $start
   i64.extend_i32_u
   local.get $endU64
-  i64.gt_u
+  i64.le_u
+  i32.eqz
   if
+   i32.const 0
+   i32.const 496
+   i32.const 386
+   i32.const 14
+   call $~lib/builtins/abort
    unreachable
   end
   local.get $start
@@ -1149,7 +1157,7 @@
    if
     i32.const 0
     i32.const 496
-    i32.const 392
+    i32.const 393
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1181,7 +1189,7 @@
    if
     i32.const 0
     i32.const 496
-    i32.const 405
+    i32.const 406
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1423,7 +1431,7 @@
   if
    i32.const 0
    i32.const 496
-   i32.const 555
+   i32.const 556
    i32.const 3
    call $~lib/builtins/abort
    unreachable
@@ -1752,7 +1760,7 @@
   if
    i32.const 160
    i32.const 496
-   i32.const 460
+   i32.const 461
    i32.const 29
    call $~lib/builtins/abort
    unreachable
@@ -2195,7 +2203,7 @@
    if
     i32.const 0
     i32.const 496
-    i32.const 492
+    i32.const 493
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -2215,7 +2223,7 @@
   if
    i32.const 0
    i32.const 496
-   i32.const 494
+   i32.const 495
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/std/uri.debug.wat
+++ b/tests/compiler/std/uri.debug.wat
@@ -1099,6 +1099,8 @@
   local.get $endU64
   i32.wrap_i64
   local.set $end
+  i32.const 0
+  drop
   i32.const 1
   drop
   local.get $start
@@ -1109,7 +1111,7 @@
   if
    i32.const 0
    i32.const 496
-   i32.const 382
+   i32.const 385
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1155,7 +1157,7 @@
    if
     i32.const 0
     i32.const 496
-    i32.const 389
+    i32.const 392
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1187,7 +1189,7 @@
    if
     i32.const 0
     i32.const 496
-    i32.const 402
+    i32.const 405
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1388,8 +1390,6 @@
   i32.const 1572
   i32.add
   local.set $memStart
-  i32.const 0
-  drop
   local.get $root
   local.get $memStart
   memory.size
@@ -1431,7 +1431,7 @@
   if
    i32.const 0
    i32.const 496
-   i32.const 562
+   i32.const 555
    i32.const 3
    call $~lib/builtins/abort
    unreachable
@@ -1760,7 +1760,7 @@
   if
    i32.const 160
    i32.const 496
-   i32.const 461
+   i32.const 460
    i32.const 29
    call $~lib/builtins/abort
    unreachable
@@ -1994,8 +1994,6 @@
   (local $6 i32)
   (local $pagesWanted i32)
   (local $pagesAfter i32)
-  i32.const 0
-  drop
   local.get $size
   i32.const 256
   i32.ge_u
@@ -2205,7 +2203,7 @@
    if
     i32.const 0
     i32.const 496
-    i32.const 499
+    i32.const 492
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -2225,7 +2223,7 @@
   if
    i32.const 0
    i32.const 496
-   i32.const 501
+   i32.const 494
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/std/uri.release.wat
+++ b/tests/compiler/std/uri.release.wat
@@ -755,7 +755,7 @@
   if
    i32.const 0
    i32.const 1520
-   i32.const 382
+   i32.const 385
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -780,7 +780,7 @@
    if
     i32.const 0
     i32.const 1520
-    i32.const 389
+    i32.const 392
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -807,7 +807,7 @@
    if
     i32.const 0
     i32.const 1520
-    i32.const 402
+    i32.const 405
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1170,7 +1170,7 @@
       if
        i32.const 0
        i32.const 1520
-       i32.const 562
+       i32.const 555
        i32.const 3
        call $~lib/builtins/abort
        unreachable
@@ -1405,7 +1405,7 @@
   if
    i32.const 1184
    i32.const 1520
-   i32.const 461
+   i32.const 460
    i32.const 29
    call $~lib/builtins/abort
    unreachable
@@ -1507,7 +1507,7 @@
    if
     i32.const 0
     i32.const 1520
-    i32.const 499
+    i32.const 492
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1522,7 +1522,7 @@
   if
    i32.const 0
    i32.const 1520
-   i32.const 501
+   i32.const 494
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/std/uri.release.wat
+++ b/tests/compiler/std/uri.release.wat
@@ -748,16 +748,11 @@
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
-  local.get $2
   local.get $1
   i64.extend_i32_u
-  i64.lt_u
+  local.get $2
+  i64.gt_u
   if
-   i32.const 0
-   i32.const 1520
-   i32.const 385
-   i32.const 14
-   call $~lib/builtins/abort
    unreachable
   end
   local.get $1

--- a/tests/compiler/std/uri.release.wat
+++ b/tests/compiler/std/uri.release.wat
@@ -748,11 +748,16 @@
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
+  local.get $2
   local.get $1
   i64.extend_i32_u
-  local.get $2
-  i64.gt_u
+  i64.lt_u
   if
+   i32.const 0
+   i32.const 1520
+   i32.const 386
+   i32.const 14
+   call $~lib/builtins/abort
    unreachable
   end
   local.get $1
@@ -775,7 +780,7 @@
    if
     i32.const 0
     i32.const 1520
-    i32.const 392
+    i32.const 393
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -802,7 +807,7 @@
    if
     i32.const 0
     i32.const 1520
-    i32.const 405
+    i32.const 406
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1165,7 +1170,7 @@
       if
        i32.const 0
        i32.const 1520
-       i32.const 555
+       i32.const 556
        i32.const 3
        call $~lib/builtins/abort
        unreachable
@@ -1400,7 +1405,7 @@
   if
    i32.const 1184
    i32.const 1520
-   i32.const 460
+   i32.const 461
    i32.const 29
    call $~lib/builtins/abort
    unreachable
@@ -1502,7 +1507,7 @@
    if
     i32.const 0
     i32.const 1520
-    i32.const 492
+    i32.const 493
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1517,7 +1522,7 @@
   if
    i32.const 0
    i32.const 1520
-   i32.const 494
+   i32.const 495
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/super-inline.debug.wat
+++ b/tests/compiler/super-inline.debug.wat
@@ -1026,11 +1026,19 @@
   local.set $end
   i32.const 0
   drop
+  i32.const 1
+  drop
   local.get $start
   i64.extend_i32_u
   local.get $endU64
-  i64.gt_u
+  i64.le_u
+  i32.eqz
   if
+   i32.const 0
+   i32.const 368
+   i32.const 386
+   i32.const 14
+   call $~lib/builtins/abort
    unreachable
   end
   local.get $start
@@ -1074,7 +1082,7 @@
    if
     i32.const 0
     i32.const 368
-    i32.const 392
+    i32.const 393
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1106,7 +1114,7 @@
    if
     i32.const 0
     i32.const 368
-    i32.const 405
+    i32.const 406
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1348,7 +1356,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 555
+   i32.const 556
    i32.const 3
    call $~lib/builtins/abort
    unreachable
@@ -1677,7 +1685,7 @@
   if
    i32.const 32
    i32.const 368
-   i32.const 460
+   i32.const 461
    i32.const 29
    call $~lib/builtins/abort
    unreachable
@@ -2120,7 +2128,7 @@
    if
     i32.const 0
     i32.const 368
-    i32.const 492
+    i32.const 493
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -2140,7 +2148,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 494
+   i32.const 495
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/super-inline.debug.wat
+++ b/tests/compiler/super-inline.debug.wat
@@ -1026,19 +1026,11 @@
   local.set $end
   i32.const 0
   drop
-  i32.const 1
-  drop
   local.get $start
   i64.extend_i32_u
   local.get $endU64
-  i64.le_u
-  i32.eqz
+  i64.gt_u
   if
-   i32.const 0
-   i32.const 368
-   i32.const 385
-   i32.const 14
-   call $~lib/builtins/abort
    unreachable
   end
   local.get $start

--- a/tests/compiler/super-inline.debug.wat
+++ b/tests/compiler/super-inline.debug.wat
@@ -1024,6 +1024,8 @@
   local.get $endU64
   i32.wrap_i64
   local.set $end
+  i32.const 0
+  drop
   i32.const 1
   drop
   local.get $start
@@ -1034,7 +1036,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 382
+   i32.const 385
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1080,7 +1082,7 @@
    if
     i32.const 0
     i32.const 368
-    i32.const 389
+    i32.const 392
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1112,7 +1114,7 @@
    if
     i32.const 0
     i32.const 368
-    i32.const 402
+    i32.const 405
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1313,8 +1315,6 @@
   i32.const 1572
   i32.add
   local.set $memStart
-  i32.const 0
-  drop
   local.get $root
   local.get $memStart
   memory.size
@@ -1356,7 +1356,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 562
+   i32.const 555
    i32.const 3
    call $~lib/builtins/abort
    unreachable
@@ -1685,7 +1685,7 @@
   if
    i32.const 32
    i32.const 368
-   i32.const 461
+   i32.const 460
    i32.const 29
    call $~lib/builtins/abort
    unreachable
@@ -1919,8 +1919,6 @@
   (local $6 i32)
   (local $pagesWanted i32)
   (local $pagesAfter i32)
-  i32.const 0
-  drop
   local.get $size
   i32.const 256
   i32.ge_u
@@ -2130,7 +2128,7 @@
    if
     i32.const 0
     i32.const 368
-    i32.const 499
+    i32.const 492
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -2150,7 +2148,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 501
+   i32.const 494
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/super-inline.release.wat
+++ b/tests/compiler/super-inline.release.wat
@@ -639,11 +639,16 @@
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
+  local.get $2
   local.get $1
   i64.extend_i32_u
-  local.get $2
-  i64.gt_u
+  i64.lt_u
   if
+   i32.const 0
+   i32.const 1392
+   i32.const 386
+   i32.const 14
+   call $~lib/builtins/abort
    unreachable
   end
   local.get $1
@@ -666,7 +671,7 @@
    if
     i32.const 0
     i32.const 1392
-    i32.const 392
+    i32.const 393
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -693,7 +698,7 @@
    if
     i32.const 0
     i32.const 1392
-    i32.const 405
+    i32.const 406
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1056,7 +1061,7 @@
       if
        i32.const 0
        i32.const 1392
-       i32.const 555
+       i32.const 556
        i32.const 3
        call $~lib/builtins/abort
        unreachable
@@ -1254,7 +1259,7 @@
    if
     i32.const 0
     i32.const 1392
-    i32.const 492
+    i32.const 493
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1269,7 +1274,7 @@
   if
    i32.const 0
    i32.const 1392
-   i32.const 494
+   i32.const 495
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/super-inline.release.wat
+++ b/tests/compiler/super-inline.release.wat
@@ -646,7 +646,7 @@
   if
    i32.const 0
    i32.const 1392
-   i32.const 382
+   i32.const 385
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -671,7 +671,7 @@
    if
     i32.const 0
     i32.const 1392
-    i32.const 389
+    i32.const 392
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -698,7 +698,7 @@
    if
     i32.const 0
     i32.const 1392
-    i32.const 402
+    i32.const 405
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1061,7 +1061,7 @@
       if
        i32.const 0
        i32.const 1392
-       i32.const 562
+       i32.const 555
        i32.const 3
        call $~lib/builtins/abort
        unreachable
@@ -1259,7 +1259,7 @@
    if
     i32.const 0
     i32.const 1392
-    i32.const 499
+    i32.const 492
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1274,7 +1274,7 @@
   if
    i32.const 0
    i32.const 1392
-   i32.const 501
+   i32.const 494
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/super-inline.release.wat
+++ b/tests/compiler/super-inline.release.wat
@@ -639,16 +639,11 @@
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
-  local.get $2
   local.get $1
   i64.extend_i32_u
-  i64.lt_u
+  local.get $2
+  i64.gt_u
   if
-   i32.const 0
-   i32.const 1392
-   i32.const 385
-   i32.const 14
-   call $~lib/builtins/abort
    unreachable
   end
   local.get $1

--- a/tests/compiler/templateliteral.debug.wat
+++ b/tests/compiler/templateliteral.debug.wat
@@ -1207,19 +1207,11 @@
   local.set $end
   i32.const 0
   drop
-  i32.const 1
-  drop
   local.get $start
   i64.extend_i32_u
   local.get $endU64
-  i64.le_u
-  i32.eqz
+  i64.gt_u
   if
-   i32.const 0
-   i32.const 528
-   i32.const 385
-   i32.const 14
-   call $~lib/builtins/abort
    unreachable
   end
   local.get $start

--- a/tests/compiler/templateliteral.debug.wat
+++ b/tests/compiler/templateliteral.debug.wat
@@ -1207,11 +1207,19 @@
   local.set $end
   i32.const 0
   drop
+  i32.const 1
+  drop
   local.get $start
   i64.extend_i32_u
   local.get $endU64
-  i64.gt_u
+  i64.le_u
+  i32.eqz
   if
+   i32.const 0
+   i32.const 528
+   i32.const 386
+   i32.const 14
+   call $~lib/builtins/abort
    unreachable
   end
   local.get $start
@@ -1255,7 +1263,7 @@
    if
     i32.const 0
     i32.const 528
-    i32.const 392
+    i32.const 393
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1287,7 +1295,7 @@
    if
     i32.const 0
     i32.const 528
-    i32.const 405
+    i32.const 406
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1529,7 +1537,7 @@
   if
    i32.const 0
    i32.const 528
-   i32.const 555
+   i32.const 556
    i32.const 3
    call $~lib/builtins/abort
    unreachable
@@ -1858,7 +1866,7 @@
   if
    i32.const 192
    i32.const 528
-   i32.const 460
+   i32.const 461
    i32.const 29
    call $~lib/builtins/abort
    unreachable
@@ -2301,7 +2309,7 @@
    if
     i32.const 0
     i32.const 528
-    i32.const 492
+    i32.const 493
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -2321,7 +2329,7 @@
   if
    i32.const 0
    i32.const 528
-   i32.const 494
+   i32.const 495
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/templateliteral.debug.wat
+++ b/tests/compiler/templateliteral.debug.wat
@@ -1205,6 +1205,8 @@
   local.get $endU64
   i32.wrap_i64
   local.set $end
+  i32.const 0
+  drop
   i32.const 1
   drop
   local.get $start
@@ -1215,7 +1217,7 @@
   if
    i32.const 0
    i32.const 528
-   i32.const 382
+   i32.const 385
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1261,7 +1263,7 @@
    if
     i32.const 0
     i32.const 528
-    i32.const 389
+    i32.const 392
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1293,7 +1295,7 @@
    if
     i32.const 0
     i32.const 528
-    i32.const 402
+    i32.const 405
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1494,8 +1496,6 @@
   i32.const 1572
   i32.add
   local.set $memStart
-  i32.const 0
-  drop
   local.get $root
   local.get $memStart
   memory.size
@@ -1537,7 +1537,7 @@
   if
    i32.const 0
    i32.const 528
-   i32.const 562
+   i32.const 555
    i32.const 3
    call $~lib/builtins/abort
    unreachable
@@ -1866,7 +1866,7 @@
   if
    i32.const 192
    i32.const 528
-   i32.const 461
+   i32.const 460
    i32.const 29
    call $~lib/builtins/abort
    unreachable
@@ -2100,8 +2100,6 @@
   (local $6 i32)
   (local $pagesWanted i32)
   (local $pagesAfter i32)
-  i32.const 0
-  drop
   local.get $size
   i32.const 256
   i32.ge_u
@@ -2311,7 +2309,7 @@
    if
     i32.const 0
     i32.const 528
-    i32.const 499
+    i32.const 492
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -2331,7 +2329,7 @@
   if
    i32.const 0
    i32.const 528
-   i32.const 501
+   i32.const 494
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/templateliteral.release.wat
+++ b/tests/compiler/templateliteral.release.wat
@@ -732,16 +732,11 @@
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
-  local.get $2
   local.get $1
   i64.extend_i32_u
-  i64.lt_u
+  local.get $2
+  i64.gt_u
   if
-   i32.const 0
-   i32.const 1552
-   i32.const 385
-   i32.const 14
-   call $~lib/builtins/abort
    unreachable
   end
   local.get $1

--- a/tests/compiler/templateliteral.release.wat
+++ b/tests/compiler/templateliteral.release.wat
@@ -739,7 +739,7 @@
   if
    i32.const 0
    i32.const 1552
-   i32.const 382
+   i32.const 385
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -764,7 +764,7 @@
    if
     i32.const 0
     i32.const 1552
-    i32.const 389
+    i32.const 392
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -791,7 +791,7 @@
    if
     i32.const 0
     i32.const 1552
-    i32.const 402
+    i32.const 405
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1154,7 +1154,7 @@
       if
        i32.const 0
        i32.const 1552
-       i32.const 562
+       i32.const 555
        i32.const 3
        call $~lib/builtins/abort
        unreachable
@@ -1389,7 +1389,7 @@
   if
    i32.const 1216
    i32.const 1552
-   i32.const 461
+   i32.const 460
    i32.const 29
    call $~lib/builtins/abort
    unreachable
@@ -1491,7 +1491,7 @@
    if
     i32.const 0
     i32.const 1552
-    i32.const 499
+    i32.const 492
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1506,7 +1506,7 @@
   if
    i32.const 0
    i32.const 1552
-   i32.const 501
+   i32.const 494
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/templateliteral.release.wat
+++ b/tests/compiler/templateliteral.release.wat
@@ -732,11 +732,16 @@
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
+  local.get $2
   local.get $1
   i64.extend_i32_u
-  local.get $2
-  i64.gt_u
+  i64.lt_u
   if
+   i32.const 0
+   i32.const 1552
+   i32.const 386
+   i32.const 14
+   call $~lib/builtins/abort
    unreachable
   end
   local.get $1
@@ -759,7 +764,7 @@
    if
     i32.const 0
     i32.const 1552
-    i32.const 392
+    i32.const 393
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -786,7 +791,7 @@
    if
     i32.const 0
     i32.const 1552
-    i32.const 405
+    i32.const 406
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1149,7 +1154,7 @@
       if
        i32.const 0
        i32.const 1552
-       i32.const 555
+       i32.const 556
        i32.const 3
        call $~lib/builtins/abort
        unreachable
@@ -1384,7 +1389,7 @@
   if
    i32.const 1216
    i32.const 1552
-   i32.const 460
+   i32.const 461
    i32.const 29
    call $~lib/builtins/abort
    unreachable
@@ -1486,7 +1491,7 @@
    if
     i32.const 0
     i32.const 1552
-    i32.const 492
+    i32.const 493
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1501,7 +1506,7 @@
   if
    i32.const 0
    i32.const 1552
-   i32.const 494
+   i32.const 495
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/throw.debug.wat
+++ b/tests/compiler/throw.debug.wat
@@ -1136,6 +1136,8 @@
   local.get $endU64
   i32.wrap_i64
   local.set $end
+  i32.const 0
+  drop
   i32.const 1
   drop
   local.get $start
@@ -1146,7 +1148,7 @@
   if
    i32.const 0
    i32.const 608
-   i32.const 382
+   i32.const 385
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1192,7 +1194,7 @@
    if
     i32.const 0
     i32.const 608
-    i32.const 389
+    i32.const 392
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1224,7 +1226,7 @@
    if
     i32.const 0
     i32.const 608
-    i32.const 402
+    i32.const 405
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1425,8 +1427,6 @@
   i32.const 1572
   i32.add
   local.set $memStart
-  i32.const 0
-  drop
   local.get $root
   local.get $memStart
   memory.size
@@ -1468,7 +1468,7 @@
   if
    i32.const 0
    i32.const 608
-   i32.const 562
+   i32.const 555
    i32.const 3
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/throw.debug.wat
+++ b/tests/compiler/throw.debug.wat
@@ -1138,11 +1138,19 @@
   local.set $end
   i32.const 0
   drop
+  i32.const 1
+  drop
   local.get $start
   i64.extend_i32_u
   local.get $endU64
-  i64.gt_u
+  i64.le_u
+  i32.eqz
   if
+   i32.const 0
+   i32.const 608
+   i32.const 386
+   i32.const 14
+   call $~lib/builtins/abort
    unreachable
   end
   local.get $start
@@ -1186,7 +1194,7 @@
    if
     i32.const 0
     i32.const 608
-    i32.const 392
+    i32.const 393
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1218,7 +1226,7 @@
    if
     i32.const 0
     i32.const 608
-    i32.const 405
+    i32.const 406
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1460,7 +1468,7 @@
   if
    i32.const 0
    i32.const 608
-   i32.const 555
+   i32.const 556
    i32.const 3
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/throw.debug.wat
+++ b/tests/compiler/throw.debug.wat
@@ -1138,19 +1138,11 @@
   local.set $end
   i32.const 0
   drop
-  i32.const 1
-  drop
   local.get $start
   i64.extend_i32_u
   local.get $endU64
-  i64.le_u
-  i32.eqz
+  i64.gt_u
   if
-   i32.const 0
-   i32.const 608
-   i32.const 385
-   i32.const 14
-   call $~lib/builtins/abort
    unreachable
   end
   local.get $start

--- a/tests/compiler/throw.release.wat
+++ b/tests/compiler/throw.release.wat
@@ -916,6 +916,11 @@
        i64.const 36100
        i64.lt_u
        if
+        i32.const 0
+        i32.const 1632
+        i32.const 386
+        i32.const 14
+        call $~lib/builtins/abort
         unreachable
        end
        i32.const 36108
@@ -932,7 +937,7 @@
         if
          i32.const 0
          i32.const 1632
-         i32.const 392
+         i32.const 393
          i32.const 16
          call $~lib/builtins/abort
          unreachable
@@ -1020,7 +1025,7 @@
       if
        i32.const 0
        i32.const 1632
-       i32.const 555
+       i32.const 556
        i32.const 3
        call $~lib/builtins/abort
        unreachable

--- a/tests/compiler/throw.release.wat
+++ b/tests/compiler/throw.release.wat
@@ -916,11 +916,6 @@
        i64.const 36100
        i64.lt_u
        if
-        i32.const 0
-        i32.const 1632
-        i32.const 385
-        i32.const 14
-        call $~lib/builtins/abort
         unreachable
        end
        i32.const 36108

--- a/tests/compiler/throw.release.wat
+++ b/tests/compiler/throw.release.wat
@@ -918,7 +918,7 @@
        if
         i32.const 0
         i32.const 1632
-        i32.const 382
+        i32.const 385
         i32.const 14
         call $~lib/builtins/abort
         unreachable
@@ -937,7 +937,7 @@
         if
          i32.const 0
          i32.const 1632
-         i32.const 389
+         i32.const 392
          i32.const 16
          call $~lib/builtins/abort
          unreachable
@@ -1025,7 +1025,7 @@
       if
        i32.const 0
        i32.const 1632
-       i32.const 562
+       i32.const 555
        i32.const 3
        call $~lib/builtins/abort
        unreachable

--- a/tests/compiler/typeof.debug.wat
+++ b/tests/compiler/typeof.debug.wat
@@ -1162,6 +1162,8 @@
   local.get $endU64
   i32.wrap_i64
   local.set $end
+  i32.const 0
+  drop
   i32.const 1
   drop
   local.get $start
@@ -1172,7 +1174,7 @@
   if
    i32.const 0
    i32.const 672
-   i32.const 382
+   i32.const 385
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1218,7 +1220,7 @@
    if
     i32.const 0
     i32.const 672
-    i32.const 389
+    i32.const 392
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1250,7 +1252,7 @@
    if
     i32.const 0
     i32.const 672
-    i32.const 402
+    i32.const 405
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1451,8 +1453,6 @@
   i32.const 1572
   i32.add
   local.set $memStart
-  i32.const 0
-  drop
   local.get $root
   local.get $memStart
   memory.size
@@ -1494,7 +1494,7 @@
   if
    i32.const 0
    i32.const 672
-   i32.const 562
+   i32.const 555
    i32.const 3
    call $~lib/builtins/abort
    unreachable
@@ -1823,7 +1823,7 @@
   if
    i32.const 336
    i32.const 672
-   i32.const 461
+   i32.const 460
    i32.const 29
    call $~lib/builtins/abort
    unreachable
@@ -2057,8 +2057,6 @@
   (local $6 i32)
   (local $pagesWanted i32)
   (local $pagesAfter i32)
-  i32.const 0
-  drop
   local.get $size
   i32.const 256
   i32.ge_u
@@ -2268,7 +2266,7 @@
    if
     i32.const 0
     i32.const 672
-    i32.const 499
+    i32.const 492
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -2288,7 +2286,7 @@
   if
    i32.const 0
    i32.const 672
-   i32.const 501
+   i32.const 494
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/typeof.debug.wat
+++ b/tests/compiler/typeof.debug.wat
@@ -1164,19 +1164,11 @@
   local.set $end
   i32.const 0
   drop
-  i32.const 1
-  drop
   local.get $start
   i64.extend_i32_u
   local.get $endU64
-  i64.le_u
-  i32.eqz
+  i64.gt_u
   if
-   i32.const 0
-   i32.const 672
-   i32.const 385
-   i32.const 14
-   call $~lib/builtins/abort
    unreachable
   end
   local.get $start

--- a/tests/compiler/typeof.debug.wat
+++ b/tests/compiler/typeof.debug.wat
@@ -1164,11 +1164,19 @@
   local.set $end
   i32.const 0
   drop
+  i32.const 1
+  drop
   local.get $start
   i64.extend_i32_u
   local.get $endU64
-  i64.gt_u
+  i64.le_u
+  i32.eqz
   if
+   i32.const 0
+   i32.const 672
+   i32.const 386
+   i32.const 14
+   call $~lib/builtins/abort
    unreachable
   end
   local.get $start
@@ -1212,7 +1220,7 @@
    if
     i32.const 0
     i32.const 672
-    i32.const 392
+    i32.const 393
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1244,7 +1252,7 @@
    if
     i32.const 0
     i32.const 672
-    i32.const 405
+    i32.const 406
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1486,7 +1494,7 @@
   if
    i32.const 0
    i32.const 672
-   i32.const 555
+   i32.const 556
    i32.const 3
    call $~lib/builtins/abort
    unreachable
@@ -1815,7 +1823,7 @@
   if
    i32.const 336
    i32.const 672
-   i32.const 460
+   i32.const 461
    i32.const 29
    call $~lib/builtins/abort
    unreachable
@@ -2258,7 +2266,7 @@
    if
     i32.const 0
     i32.const 672
-    i32.const 492
+    i32.const 493
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -2278,7 +2286,7 @@
   if
    i32.const 0
    i32.const 672
-   i32.const 494
+   i32.const 495
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/typeof.release.wat
+++ b/tests/compiler/typeof.release.wat
@@ -655,16 +655,11 @@
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
-  local.get $2
   local.get $1
   i64.extend_i32_u
-  i64.lt_u
+  local.get $2
+  i64.gt_u
   if
-   i32.const 0
-   i32.const 1696
-   i32.const 385
-   i32.const 14
-   call $~lib/builtins/abort
    unreachable
   end
   local.get $1

--- a/tests/compiler/typeof.release.wat
+++ b/tests/compiler/typeof.release.wat
@@ -655,11 +655,16 @@
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
+  local.get $2
   local.get $1
   i64.extend_i32_u
-  local.get $2
-  i64.gt_u
+  i64.lt_u
   if
+   i32.const 0
+   i32.const 1696
+   i32.const 386
+   i32.const 14
+   call $~lib/builtins/abort
    unreachable
   end
   local.get $1
@@ -682,7 +687,7 @@
    if
     i32.const 0
     i32.const 1696
-    i32.const 392
+    i32.const 393
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -709,7 +714,7 @@
    if
     i32.const 0
     i32.const 1696
-    i32.const 405
+    i32.const 406
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1072,7 +1077,7 @@
       if
        i32.const 0
        i32.const 1696
-       i32.const 555
+       i32.const 556
        i32.const 3
        call $~lib/builtins/abort
        unreachable
@@ -1270,7 +1275,7 @@
    if
     i32.const 0
     i32.const 1696
-    i32.const 492
+    i32.const 493
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1285,7 +1290,7 @@
   if
    i32.const 0
    i32.const 1696
-   i32.const 494
+   i32.const 495
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/typeof.release.wat
+++ b/tests/compiler/typeof.release.wat
@@ -662,7 +662,7 @@
   if
    i32.const 0
    i32.const 1696
-   i32.const 382
+   i32.const 385
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -687,7 +687,7 @@
    if
     i32.const 0
     i32.const 1696
-    i32.const 389
+    i32.const 392
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -714,7 +714,7 @@
    if
     i32.const 0
     i32.const 1696
-    i32.const 402
+    i32.const 405
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1077,7 +1077,7 @@
       if
        i32.const 0
        i32.const 1696
-       i32.const 562
+       i32.const 555
        i32.const 3
        call $~lib/builtins/abort
        unreachable
@@ -1275,7 +1275,7 @@
    if
     i32.const 0
     i32.const 1696
-    i32.const 499
+    i32.const 492
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1290,7 +1290,7 @@
   if
    i32.const 0
    i32.const 1696
-   i32.const 501
+   i32.const 494
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/while.debug.wat
+++ b/tests/compiler/while.debug.wat
@@ -1445,6 +1445,8 @@
   local.get $endU64
   i32.wrap_i64
   local.set $end
+  i32.const 0
+  drop
   i32.const 1
   drop
   local.get $start
@@ -1455,7 +1457,7 @@
   if
    i32.const 0
    i32.const 416
-   i32.const 382
+   i32.const 385
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1501,7 +1503,7 @@
    if
     i32.const 0
     i32.const 416
-    i32.const 389
+    i32.const 392
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1533,7 +1535,7 @@
    if
     i32.const 0
     i32.const 416
-    i32.const 402
+    i32.const 405
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1734,8 +1736,6 @@
   i32.const 1572
   i32.add
   local.set $memStart
-  i32.const 0
-  drop
   local.get $root
   local.get $memStart
   memory.size
@@ -1777,7 +1777,7 @@
   if
    i32.const 0
    i32.const 416
-   i32.const 562
+   i32.const 555
    i32.const 3
    call $~lib/builtins/abort
    unreachable
@@ -2106,7 +2106,7 @@
   if
    i32.const 80
    i32.const 416
-   i32.const 461
+   i32.const 460
    i32.const 29
    call $~lib/builtins/abort
    unreachable
@@ -2340,8 +2340,6 @@
   (local $6 i32)
   (local $pagesWanted i32)
   (local $pagesAfter i32)
-  i32.const 0
-  drop
   local.get $size
   i32.const 256
   i32.ge_u
@@ -2551,7 +2549,7 @@
    if
     i32.const 0
     i32.const 416
-    i32.const 499
+    i32.const 492
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -2571,7 +2569,7 @@
   if
    i32.const 0
    i32.const 416
-   i32.const 501
+   i32.const 494
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/while.debug.wat
+++ b/tests/compiler/while.debug.wat
@@ -1447,11 +1447,19 @@
   local.set $end
   i32.const 0
   drop
+  i32.const 1
+  drop
   local.get $start
   i64.extend_i32_u
   local.get $endU64
-  i64.gt_u
+  i64.le_u
+  i32.eqz
   if
+   i32.const 0
+   i32.const 416
+   i32.const 386
+   i32.const 14
+   call $~lib/builtins/abort
    unreachable
   end
   local.get $start
@@ -1495,7 +1503,7 @@
    if
     i32.const 0
     i32.const 416
-    i32.const 392
+    i32.const 393
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1527,7 +1535,7 @@
    if
     i32.const 0
     i32.const 416
-    i32.const 405
+    i32.const 406
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1769,7 +1777,7 @@
   if
    i32.const 0
    i32.const 416
-   i32.const 555
+   i32.const 556
    i32.const 3
    call $~lib/builtins/abort
    unreachable
@@ -2098,7 +2106,7 @@
   if
    i32.const 80
    i32.const 416
-   i32.const 460
+   i32.const 461
    i32.const 29
    call $~lib/builtins/abort
    unreachable
@@ -2541,7 +2549,7 @@
    if
     i32.const 0
     i32.const 416
-    i32.const 492
+    i32.const 493
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -2561,7 +2569,7 @@
   if
    i32.const 0
    i32.const 416
-   i32.const 494
+   i32.const 495
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/while.debug.wat
+++ b/tests/compiler/while.debug.wat
@@ -1447,19 +1447,11 @@
   local.set $end
   i32.const 0
   drop
-  i32.const 1
-  drop
   local.get $start
   i64.extend_i32_u
   local.get $endU64
-  i64.le_u
-  i32.eqz
+  i64.gt_u
   if
-   i32.const 0
-   i32.const 416
-   i32.const 385
-   i32.const 14
-   call $~lib/builtins/abort
    unreachable
   end
   local.get $start

--- a/tests/compiler/while.release.wat
+++ b/tests/compiler/while.release.wat
@@ -634,7 +634,7 @@
   if
    i32.const 0
    i32.const 1440
-   i32.const 382
+   i32.const 385
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -659,7 +659,7 @@
    if
     i32.const 0
     i32.const 1440
-    i32.const 389
+    i32.const 392
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -686,7 +686,7 @@
    if
     i32.const 0
     i32.const 1440
-    i32.const 402
+    i32.const 405
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1049,7 +1049,7 @@
       if
        i32.const 0
        i32.const 1440
-       i32.const 562
+       i32.const 555
        i32.const 3
        call $~lib/builtins/abort
        unreachable
@@ -1247,7 +1247,7 @@
    if
     i32.const 0
     i32.const 1440
-    i32.const 499
+    i32.const 492
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1262,7 +1262,7 @@
   if
    i32.const 0
    i32.const 1440
-   i32.const 501
+   i32.const 494
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/while.release.wat
+++ b/tests/compiler/while.release.wat
@@ -627,16 +627,11 @@
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
-  local.get $2
   local.get $1
   i64.extend_i32_u
-  i64.lt_u
+  local.get $2
+  i64.gt_u
   if
-   i32.const 0
-   i32.const 1440
-   i32.const 385
-   i32.const 14
-   call $~lib/builtins/abort
    unreachable
   end
   local.get $1

--- a/tests/compiler/while.release.wat
+++ b/tests/compiler/while.release.wat
@@ -627,11 +627,16 @@
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
+  local.get $2
   local.get $1
   i64.extend_i32_u
-  local.get $2
-  i64.gt_u
+  i64.lt_u
   if
+   i32.const 0
+   i32.const 1440
+   i32.const 386
+   i32.const 14
+   call $~lib/builtins/abort
    unreachable
   end
   local.get $1
@@ -654,7 +659,7 @@
    if
     i32.const 0
     i32.const 1440
-    i32.const 392
+    i32.const 393
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -681,7 +686,7 @@
    if
     i32.const 0
     i32.const 1440
-    i32.const 405
+    i32.const 406
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1044,7 +1049,7 @@
       if
        i32.const 0
        i32.const 1440
-       i32.const 555
+       i32.const 556
        i32.const 3
        call $~lib/builtins/abort
        unreachable
@@ -1242,7 +1247,7 @@
    if
     i32.const 0
     i32.const 1440
-    i32.const 492
+    i32.const 493
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1257,7 +1262,7 @@
   if
    i32.const 0
    i32.const 1440
-   i32.const 494
+   i32.const 495
    i32.const 14
    call $~lib/builtins/abort
    unreachable


### PR DESCRIPTION
The original `lowMemoryLimit` only support memory less than 64kB (1 wasm page).
This PR wants to extend the function of `lowMemoryLimit` to support more than 64kB memory limitation.