### PR TITLE
fix: std/portable included twice

### DIFF
--- a/std/portable/index.js
+++ b/std/portable/index.js
@@ -412,6 +412,4 @@ if (typeof globalScope.ASC_TARGET === "undefined") {
     if (n) message += Array.prototype.slice.call(arguments, 2, 2 + n);
     console.error("trace: " + message);
   };
-} else {
-  console.warn("compiler mismatch: std/portable included twice");
 }


### PR DESCRIPTION
Whenever importing from within a transform,
```js
import { Transform } from "assemblyscript/dist/transform.js";
import { Parser } from "assemblyscript/dist/assemblyscript.js";
```

I get the following warning:

`compiler mismatch: std/portable included twice`

The warning occurs with nearly every transform I have written and since it writes to `stderr` which is problematic.

Instead of warning the user when `std/portable` is imported twice, it seems more reasonable just to ignore it altogether. After all, its the compiler importing it twice, not the user.