### PR TITLE
chore: typescript: 4.7.4 → 5.5.4

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -57,6 +57,7 @@ under the licensing terms detailed in LICENSE:
 * Bach Le <bach@bullno1.com>
 * Xinquan Xu <xinquan0203@163.com>
 * Matt Johnson-Pint <mattjohnsonpint@gmail.com>
+* Fabián Heredia Montiel <fabianhjr@users.noreply.github.com>
 
 Portions of this software are derived from third-party works licensed under
 the following terms:

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,7 +24,7 @@
         "esbuild": "^0.19.4",
         "eslint": "^8.33.0",
         "glob": "^10.3.0",
-        "typescript": "~4.7.4"
+        "typescript": "^5.5.4"
       },
       "engines": {
         "node": ">=16",
@@ -2273,16 +2273,17 @@
       }
     },
     "node_modules/typescript": {
-      "version": "4.7.4",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.7.4.tgz",
-      "integrity": "sha512-C0WQT0gezHuw6AdY1M2jxUO83Rjf0HP7Sk1DtXj6j1EwkQNZrHAg2XPWlq62oqEhYvONq5pkC2Y9oPljWToLmQ==",
+      "version": "5.5.4",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.5.4.tgz",
+      "integrity": "sha512-Mtq29sKDAEYP7aljRgtPOpTvOfbwRWlS6dPRzwjdE+C0R4brX/GUyhHSecbHMFLNBLcJIPt9nl9yG5TZ1weH+Q==",
       "dev": true,
+      "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
       },
       "engines": {
-        "node": ">=4.2.0"
+        "node": ">=14.17"
       }
     },
     "node_modules/undici-types": {
@@ -3924,9 +3925,9 @@
       "dev": true
     },
     "typescript": {
-      "version": "4.7.4",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.7.4.tgz",
-      "integrity": "sha512-C0WQT0gezHuw6AdY1M2jxUO83Rjf0HP7Sk1DtXj6j1EwkQNZrHAg2XPWlq62oqEhYvONq5pkC2Y9oPljWToLmQ==",
+      "version": "5.5.4",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.5.4.tgz",
+      "integrity": "sha512-Mtq29sKDAEYP7aljRgtPOpTvOfbwRWlS6dPRzwjdE+C0R4brX/GUyhHSecbHMFLNBLcJIPt9nl9yG5TZ1weH+Q==",
       "dev": true
     },
     "undici-types": {

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "esbuild": "^0.19.4",
     "eslint": "^8.33.0",
     "glob": "^10.3.0",
-    "typescript": "~4.7.4"
+    "typescript": "^5.5.4"
   },
   "type": "module",
   "exports": {

--- a/src/builtins.ts
+++ b/src/builtins.ts
@@ -1623,6 +1623,7 @@ function builtin_max(ctx: BuiltinFunctionContext): ExpressionRef {
     } else {
       arg1 = compiler.compileExpression(operands[1], type, Constraints.ConvImplicit | Constraints.MustWrap);
     }
+    // @ts-expect-error
     let op: BinaryOp = -1;
     switch (type.kind) {
       case TypeKind.I8:
@@ -1691,6 +1692,7 @@ function builtin_min(ctx: BuiltinFunctionContext): ExpressionRef {
     } else {
       arg1 = compiler.compileExpression(operands[1], type, Constraints.ConvImplicit | Constraints.MustWrap);
     }
+    // @ts-expect-error
     let op: BinaryOp = -1;
     switch (type.kind) {
       case TypeKind.I8:

--- a/src/tokenizer.ts
+++ b/src/tokenizer.ts
@@ -463,9 +463,11 @@ export class Tokenizer extends DiagnosticEmitter {
   end: i32 = 0;
 
   pos: i32 = 0;
+  // @ts-expect-error
   token: Token = -1;
   tokenPos: i32 = 0;
 
+  // @ts-expect-error
   nextToken: Token = -1;
   nextTokenPos: i32 = 0;
   nextTokenOnNewLine: OnNewLine = OnNewLine.Unknown;
@@ -1055,6 +1057,7 @@ export class Tokenizer extends DiagnosticEmitter {
   }
 
   clearNextToken(): void {
+    // @ts-expect-error
     this.nextToken = -1;
     this.nextTokenPos = 0;
     this.nextTokenOnNewLine = OnNewLine.Unknown;

--- a/tests/compiler/std/string-encoding.ts
+++ b/tests/compiler/std/string-encoding.ts
@@ -118,7 +118,7 @@ testUTF8Decode();
 function testUTF8DecodeNullTerminated(): void {
   var buf = String.UTF8.encode(str, true);
   assert(String.UTF8.decode(buf, true) == str);
-  var str2 = "123\0456";
+  var str2 = "123\x00456";
   assert(String.UTF8.byteLength(str2, true) == 4);
   var buf2 = String.UTF8.encode(str2, true);
   assert(buf2.byteLength == 4);

--- a/tests/compiler/std/string.ts
+++ b/tests/compiler/std/string.ts
@@ -27,7 +27,7 @@ assert(String.fromCharCode(65600) == "@");
 assert(String.fromCharCode(54) == "6");
 assert(String.fromCharCode(0x10000 + 54) == "6");
 assert(String.fromCharCode(0xD800, 0xDF00) == "𐌀");
-assert(String.fromCharCodes([0, 54]) == "\06");
+assert(String.fromCharCodes([0, 54]) == "\x006");
 assert(String.fromCharCodes([65, 66, 67]) == "ABC");
 assert(String.fromCharCodes([0xD834, 0xDF06, 0x61, 0xD834, 0xDF07]) == "\uD834\uDF06a\uD834\uDF07");
 


### PR DESCRIPTION
Changes proposed in this pull request:
⯈ Upgrade TypeScript to 5.5.4 from 4.7.4

- [x] I've read the contributing guidelines
- [x] I've added my name and email to the NOTICE file

Notice: eslint emits a warning about the typescript version and checks pass however attempting to upgrade eslint seems to be more involved.