### PR TITLE
feat: cli: allow imports with explicit extension

### DIFF
--- a/cli/index.js
+++ b/cli/index.js
@@ -488,7 +488,9 @@ export async function main(argv, options) {
     if (libPath.includes("/")) return; // in sub-directory: imported on demand
     let begin = stats.begin();
     stats.parseCount++;
-    assemblyscript.parse(program, libraryFiles[libPath], libraryPrefix + libPath + extension, false);
+    const path = libraryPrefix + libPath;
+    const pathWithExtension = extension_re.test(path) ? path : path + extension;
+    assemblyscript.parse(program, libraryFiles[libPath], pathWithExtension, false);
     stats.parseTime += stats.end(begin);
   });
   let customLibDirs = [];


### PR DESCRIPTION
Changes proposed in this pull request:
⯈ Allow imports with explicit extension set

Eg, deno / bun allow and prefer something like

```
export { Parser0 } from "./parsers/Parser0.ts";
export { Parser } from "./parsers/Parser.ts";
export { ParserResult } from "./parsers/ParserResult.ts";
```

But AssemblyScript complains:

```
ERROR TS6054: File 'src/parsers/Parser0.ts.ts' not found.
   :
 1 │ export { Parser0 } from "./parsers/Parser0.ts";
   │                         ~~~~~~~~~~~~~~~~~~~~~~
   └─ in src/index.ts(1,25)

ERROR TS6054: File 'src/parsers/Parser.ts.ts' not found.
   :
 2 │ export { Parser } from "./parsers/Parser.ts";
   │                        ~~~~~~~~~~~~~~~~~~~~~
   └─ in src/index.ts(2,24)

ERROR TS6054: File 'src/parsers/ParserResult.ts.ts' not found.
   :
 3 │ export { ParserResult } from "./parsers/ParserResult.ts";
   │                              ~~~~~~~~~~~~~~~~~~~~~~~~~~~
   └─ in src/index.ts(3,30)
```


- [x] I've read the contributing guidelines
- [x] I've added my name and email to the NOTICE file
