### PR TITLE
chore: remove redundant word in comment

### DIFF
--- a/cli/index.js
+++ b/cli/index.js
@@ -598,7 +598,7 @@ export async function main(argv, options) {
     return { sourceText, sourcePath };
   }
 
-  // Gets all pending imported files from the the backlog
+  // Gets all pending imported files from the backlog
   function getBacklog(paths = []) {
     do {
       let internalPath = assemblyscript.nextFile(program);


### PR DESCRIPTION
<!--
 Thanks for submitting a pull request to AssemblyScript! Please take a moment to
 review the contributing guidelines linked below, and confirm with an [x] 🙂
-->

remove redundant word in comment

Changes proposed in this pull request:
⯈
⯈
⯈

- [ ] I've read the contributing guidelines
- [ ] I've added my name and email to the NOTICE file
