### PR TITLE
Include runtime from current directory instead of lib

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -58,6 +58,7 @@ under the licensing terms detailed in LICENSE:
 * Xinquan Xu <xinquan0203@163.com>
 * Matt Johnson-Pint <mattjohnsonpint@gmail.com>
 * Fabián Heredia Montiel <fabianhjr@users.noreply.github.com>
+* Jonas Minnberg <sasq64@gmail.com>
 
 Portions of this software are derived from third-party works licensed under
 the following terms:

--- a/std/assembly/rt/index-incremental.ts
+++ b/std/assembly/rt/index-incremental.ts
@@ -1,2 +1,2 @@
-import "rt/tlsf";
-import "rt/itcms";
+import "./tlsf";
+import "./itcms";

--- a/std/assembly/rt/index-minimal.ts
+++ b/std/assembly/rt/index-minimal.ts
@@ -1,2 +1,2 @@
-import "rt/tlsf";
-import "rt/tcms";
+import "./tlsf";
+import "./tcms";

--- a/std/assembly/rt/index-stub.ts
+++ b/std/assembly/rt/index-stub.ts
@@ -1,1 +1,1 @@
-import "rt/stub";
+import "./stub";


### PR DESCRIPTION
<!--
 Thanks for submitting a pull request to AssemblyScript! Please take a moment to
 review the contributing guidelines linked below, and confirm with an [x] 🙂
-->

### Changes proposed in this pull request:

The runtime entry points (`index-*.ts`) all include their child modules from `lib` instead
the current directory.

This causes problems in particular when you try to base your custom runtime on the standard runtime, since it will ignore any code and just include from the standard library embedded in the compiler instead.


- [x] I've read the contributing guidelines
- [x] I've added my name and email to the NOTICE file
