### PR TITLE
chore: remove last instance of setup-node-nvm

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -132,7 +132,7 @@ jobs:
     needs: check
     steps:
     - uses: actions/checkout@v3
-    - uses: dcodeIO/setup-node-nvm@master
+    - uses: actions/setup-node@v3
       with:
         node-version: current
     - name: Install dependencies


### PR DESCRIPTION
It looks like we missed this when removing every other instance of setup-node-nvm in #2779.

<!--
 Thanks for submitting a pull request to AssemblyScript! Please take a moment to
 review the contributing guidelines linked below, and confirm with an [x] 🙂
-->

- [x] I've read the contributing guidelines
- [x] I've added my name and email to the NOTICE file
