### PR TITLE
chore: import node process to skip checking runtime

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -59,6 +59,7 @@ under the licensing terms detailed in LICENSE:
 * Matt Johnson-Pint <mattjohnsonpint@gmail.com>
 * Fabián Heredia Montiel <fabianhjr@users.noreply.github.com>
 * Jonas Minnberg <sasq64@gmail.com>
+* Omar Aziz <omaraziz.dev@gmail.com>
 
 Portions of this software are derived from third-party works licensed under
 the following terms:

--- a/bin/asc.js
+++ b/bin/asc.js
@@ -1,15 +1,11 @@
 #!/usr/bin/env node
+import process from "node:process";
 
 const [ nodePath, thisPath, ...args ] = process.argv;
 const nodeArgs = process.execArgv;
 
 const hasSourceMaps = nodeArgs.includes("--enable-source-maps");
 const posCustomArgs = args.indexOf("--");
-const isDeno = typeof Deno !== "undefined";
-
-if (isDeno) {
-  process.on = function() { /* suppress 'not implemented' message */ };
-}
 
 if ((!hasSourceMaps || ~posCustomArgs) && !isDeno) {
   if (!hasSourceMaps) {


### PR DESCRIPTION
<!--
 Thanks for submitting a pull request to AssemblyScript! Please take a moment to
 review the contributing guidelines linked below, and confirm with an [x] 🙂
-->
Fixes # .

Changes proposed in this pull request:

Deno now supports node process. It requires it to be imported from `node:process` then it should work the same way. This change means it's no longer necessary to check whether the runtime is Deno

- [x] I've read the contributing guidelines
- [x] I've added my name and email to the NOTICE file
