### PR TITLE
chore: enhance comment for extract_lane functions to include "idx" argument needs to be compile time constant

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -59,6 +59,7 @@ under the licensing terms detailed in LICENSE:
 * Matt Johnson-Pint <mattjohnsonpint@gmail.com>
 * Fabián Heredia Montiel <fabianhjr@users.noreply.github.com>
 * Jonas Minnberg <sasq64@gmail.com>
+* Kam Chehresa <kaz.che@gmail.com>
 
 Portions of this software are derived from third-party works licensed under
 the following terms:

--- a/NOTICE
+++ b/NOTICE
@@ -1,90 +1,89 @@
 The following authors have all licensed their contributions to AssemblyScript
 under the licensing terms detailed in LICENSE:
 
-- Daniel Wirtz <dcode@dcode.io>
-- Max Graey <maxgraey@gmail.com>
-- Igor Sbitnev <PinkaminaDianePie@gmail.com>
-- Norton Wang <me@nortonwang.com>
-- Alan Pierce <alangpierce@gmail.com>
-- Palmer <pengliao@live.cn>
-- Linus Unnebäck <linus@folkdatorn.se>
-- Joshua Tenner <tenner.joshua@gmail.com>
-- Nidin Vinayakan <01@01alchemist.com>
-- Aaron Turner <aaron@aaronthedev.com>
-- Willem Wyndham <willem@cs.umd.edu>
-- Bowen Wang <bowen@nearprotocol.com>
-- Emil Laine <laine.emil@gmail.com>
-- Stephen Paul Weber <stephen.weber@shopify.com>
-- Jay Phelps <hello@jayphelps.com>
-- jhwgh1968 <jhwgh1968@protonmail.com>
-- Jeffrey Charles <jeffreycharles@gmail.com>
-- Vladimir Tikhonov <reg@tikhonov.by>
-- Duncan Uszkay <duncan.uszkay@shopify.com>
-- Surma <surma@surma.dev>
-- Julien Letellier <letellier.julien@gmail.com>
-- Guido Zuidhof <me@guido.io>
-- ncave <777696+ncave@users.noreply.github.com>
-- Andrew Davis <pulpdrew@gmail.com>
-- Maël Nison <nison.mael@gmail.com>
-- Valeria Viana Gusmao <valeria.viana.gusmao@gmail.com>
-- Gabor Greif <ggreif@gmail.com>
-- Martin Fredriksson <martin.fredriksson@vikinganalytics.se>
-- forcepusher <bionitsoup@gmail.com>
-- Piotr Oleś <piotrek.oles@gmail.com>
-- Saúl Cabrera <saulecabrera@gmail.com>
-- Chance Snow <git@chancesnow.me>
-- Peter Salomonsen <petersalomonsen@runbox.com>
-- ookangzheng <git-ed@runbox.no>
-- yjhmelody <yjh465402634@gmail.com>
-- bnbarak <bn.barak@gmail.com>
-- Colin Eberhardt <colin.eberhardt@gmail.com>
-- Ryan Pivovar <ryanpivovar@gmail.com>
-- Roman F. <70765447+romdotdog@users.noreply.github.com>
-- Joe Pea <trusktr@gmail.com>
-- Felipe Gasper <FGasper@users.noreply.github.com>
-- Congcong Cai <congcongcai0907@163.com>
-- mooooooi <emwings@outlook.com>
-- Yasushi Ando <andyjpn@gmail.com>
-- Syed Jafri <syed@metalpay.co>
-- Peter Hayman <peteyhayman@gmail.com>
-- ApsarasX <apsarax@outlook.com>
-- Adrien Zinger <zinger.ad@gmail.com>
-- Ruixiang Chen <xiang19890319@gmail.com>
-- Daniel Salvadori <danaugrs@gmail.com>
-- Jairus Tanaka <jairus.v.tanaka@outlook.com>
-- CountBleck <Mr.YouKnowWhoIAm@protonmail.com>
-- Abdul Rauf <abdulraufmujahid@gmail.com>
-- Bach Le <bach@bullno1.com>
-- Xinquan Xu <xinquan0203@163.com>
-- Matt Johnson-Pint <mattjohnsonpint@gmail.com>
-- Fabián Heredia Montiel <fabianhjr@users.noreply.github.com>
-- Jonas Minnberg <sasq64@gmail.com>
-- Kam Chehresa <kaz.che@gmail.com>
+* Daniel Wirtz <dcode@dcode.io>
+* Max Graey <maxgraey@gmail.com>
+* Igor Sbitnev <PinkaminaDianePie@gmail.com>
+* Norton Wang <me@nortonwang.com>
+* Alan Pierce <alangpierce@gmail.com>
+* Palmer <pengliao@live.cn>
+* Linus Unnebäck <linus@folkdatorn.se>
+* Joshua Tenner <tenner.joshua@gmail.com>
+* Nidin Vinayakan <01@01alchemist.com>
+* Aaron Turner <aaron@aaronthedev.com>
+* Willem Wyndham <willem@cs.umd.edu>
+* Bowen Wang <bowen@nearprotocol.com>
+* Emil Laine <laine.emil@gmail.com>
+* Stephen Paul Weber <stephen.weber@shopify.com>
+* Jay Phelps <hello@jayphelps.com>
+* jhwgh1968 <jhwgh1968@protonmail.com>
+* Jeffrey Charles <jeffreycharles@gmail.com>
+* Vladimir Tikhonov <reg@tikhonov.by>
+* Duncan Uszkay <duncan.uszkay@shopify.com>
+* Surma <surma@surma.dev>
+* Julien Letellier <letellier.julien@gmail.com>
+* Guido Zuidhof <me@guido.io>
+* ncave <777696+ncave@users.noreply.github.com>
+* Andrew Davis <pulpdrew@gmail.com>
+* Maël Nison <nison.mael@gmail.com>
+* Valeria Viana Gusmao <valeria.viana.gusmao@gmail.com>
+* Gabor Greif <ggreif@gmail.com>
+* Martin Fredriksson <martin.fredriksson@vikinganalytics.se>
+* forcepusher <bionitsoup@gmail.com>
+* Piotr Oleś <piotrek.oles@gmail.com>
+* Saúl Cabrera <saulecabrera@gmail.com>
+* Chance Snow <git@chancesnow.me>
+* Peter Salomonsen <petersalomonsen@runbox.com>
+* ookangzheng <git-ed@runbox.no>
+* yjhmelody <yjh465402634@gmail.com>
+* bnbarak <bn.barak@gmail.com>
+* Colin Eberhardt <colin.eberhardt@gmail.com>
+* Ryan Pivovar <ryanpivovar@gmail.com>
+* Roman F. <70765447+romdotdog@users.noreply.github.com>
+* Joe Pea <trusktr@gmail.com>
+* Felipe Gasper <FGasper@users.noreply.github.com>
+* Congcong Cai <congcongcai0907@163.com>
+* mooooooi <emwings@outlook.com>
+* Yasushi Ando <andyjpn@gmail.com>
+* Syed Jafri <syed@metalpay.co>
+* Peter Hayman <peteyhayman@gmail.com>
+* ApsarasX <apsarax@outlook.com>
+* Adrien Zinger <zinger.ad@gmail.com>
+* Ruixiang Chen <xiang19890319@gmail.com>
+* Daniel Salvadori <danaugrs@gmail.com>
+* Jairus Tanaka <jairus.v.tanaka@outlook.com>
+* CountBleck <Mr.YouKnowWhoIAm@protonmail.com>
+* Abdul Rauf <abdulraufmujahid@gmail.com>
+* Bach Le <bach@bullno1.com>
+* Xinquan Xu <xinquan0203@163.com>
+* Matt Johnson-Pint <mattjohnsonpint@gmail.com>
+* Fabián Heredia Montiel <fabianhjr@users.noreply.github.com>
+* Jonas Minnberg <sasq64@gmail.com>
 
 Portions of this software are derived from third-party works licensed under
 the following terms:
 
-- TypeScript: https://github.com/Microsoft/TypeScript
+* TypeScript: https://github.com/Microsoft/TypeScript
 
   Copyright (c) Microsoft Corporation
   Apache License, Version 2.0 (https://opensource.org/licenses/Apache-2.0)
 
-- Binaryen: https://github.com/WebAssembly/binaryen
+* Binaryen: https://github.com/WebAssembly/binaryen
 
   Copyright (c) WebAssembly Community Group participants
   Apache License, Version 2.0 (https://opensource.org/licenses/Apache-2.0)
 
-- musl libc: http://www.musl-libc.org
+* musl libc: http://www.musl-libc.org
 
   Copyright (c) Rich Felker, et al.
   The MIT License (https://opensource.org/licenses/MIT)
 
-- V8: https://developers.google.com/v8/
+* V8: https://developers.google.com/v8/
 
   Copyright (c) the V8 project authors
   The 3-Clause BSD License (https://opensource.org/licenses/BSD-3-Clause)
 
-- Arm Optimized Routines: https://github.com/ARM-software/optimized-routines
+* Arm Optimized Routines: https://github.com/ARM-software/optimized-routines
 
   Copyright (c) Arm Limited
   The MIT License (https://opensource.org/licenses/MIT)

--- a/NOTICE
+++ b/NOTICE
@@ -1,89 +1,90 @@
 The following authors have all licensed their contributions to AssemblyScript
 under the licensing terms detailed in LICENSE:
 
-* Daniel Wirtz <dcode@dcode.io>
-* Max Graey <maxgraey@gmail.com>
-* Igor Sbitnev <PinkaminaDianePie@gmail.com>
-* Norton Wang <me@nortonwang.com>
-* Alan Pierce <alangpierce@gmail.com>
-* Palmer <pengliao@live.cn>
-* Linus Unnebäck <linus@folkdatorn.se>
-* Joshua Tenner <tenner.joshua@gmail.com>
-* Nidin Vinayakan <01@01alchemist.com>
-* Aaron Turner <aaron@aaronthedev.com>
-* Willem Wyndham <willem@cs.umd.edu>
-* Bowen Wang <bowen@nearprotocol.com>
-* Emil Laine <laine.emil@gmail.com>
-* Stephen Paul Weber <stephen.weber@shopify.com>
-* Jay Phelps <hello@jayphelps.com>
-* jhwgh1968 <jhwgh1968@protonmail.com>
-* Jeffrey Charles <jeffreycharles@gmail.com>
-* Vladimir Tikhonov <reg@tikhonov.by>
-* Duncan Uszkay <duncan.uszkay@shopify.com>
-* Surma <surma@surma.dev>
-* Julien Letellier <letellier.julien@gmail.com>
-* Guido Zuidhof <me@guido.io>
-* ncave <777696+ncave@users.noreply.github.com>
-* Andrew Davis <pulpdrew@gmail.com>
-* Maël Nison <nison.mael@gmail.com>
-* Valeria Viana Gusmao <valeria.viana.gusmao@gmail.com>
-* Gabor Greif <ggreif@gmail.com>
-* Martin Fredriksson <martin.fredriksson@vikinganalytics.se>
-* forcepusher <bionitsoup@gmail.com>
-* Piotr Oleś <piotrek.oles@gmail.com>
-* Saúl Cabrera <saulecabrera@gmail.com>
-* Chance Snow <git@chancesnow.me>
-* Peter Salomonsen <petersalomonsen@runbox.com>
-* ookangzheng <git-ed@runbox.no>
-* yjhmelody <yjh465402634@gmail.com>
-* bnbarak <bn.barak@gmail.com>
-* Colin Eberhardt <colin.eberhardt@gmail.com>
-* Ryan Pivovar <ryanpivovar@gmail.com>
-* Roman F. <70765447+romdotdog@users.noreply.github.com>
-* Joe Pea <trusktr@gmail.com>
-* Felipe Gasper <FGasper@users.noreply.github.com>
-* Congcong Cai <congcongcai0907@163.com>
-* mooooooi <emwings@outlook.com>
-* Yasushi Ando <andyjpn@gmail.com>
-* Syed Jafri <syed@metalpay.co>
-* Peter Hayman <peteyhayman@gmail.com>
-* ApsarasX <apsarax@outlook.com>
-* Adrien Zinger <zinger.ad@gmail.com>
-* Ruixiang Chen <xiang19890319@gmail.com>
-* Daniel Salvadori <danaugrs@gmail.com>
-* Jairus Tanaka <jairus.v.tanaka@outlook.com>
-* CountBleck <Mr.YouKnowWhoIAm@protonmail.com>
-* Abdul Rauf <abdulraufmujahid@gmail.com>
-* Bach Le <bach@bullno1.com>
-* Xinquan Xu <xinquan0203@163.com>
-* Matt Johnson-Pint <mattjohnsonpint@gmail.com>
-* Fabián Heredia Montiel <fabianhjr@users.noreply.github.com>
-* Jonas Minnberg <sasq64@gmail.com>
+- Daniel Wirtz <dcode@dcode.io>
+- Max Graey <maxgraey@gmail.com>
+- Igor Sbitnev <PinkaminaDianePie@gmail.com>
+- Norton Wang <me@nortonwang.com>
+- Alan Pierce <alangpierce@gmail.com>
+- Palmer <pengliao@live.cn>
+- Linus Unnebäck <linus@folkdatorn.se>
+- Joshua Tenner <tenner.joshua@gmail.com>
+- Nidin Vinayakan <01@01alchemist.com>
+- Aaron Turner <aaron@aaronthedev.com>
+- Willem Wyndham <willem@cs.umd.edu>
+- Bowen Wang <bowen@nearprotocol.com>
+- Emil Laine <laine.emil@gmail.com>
+- Stephen Paul Weber <stephen.weber@shopify.com>
+- Jay Phelps <hello@jayphelps.com>
+- jhwgh1968 <jhwgh1968@protonmail.com>
+- Jeffrey Charles <jeffreycharles@gmail.com>
+- Vladimir Tikhonov <reg@tikhonov.by>
+- Duncan Uszkay <duncan.uszkay@shopify.com>
+- Surma <surma@surma.dev>
+- Julien Letellier <letellier.julien@gmail.com>
+- Guido Zuidhof <me@guido.io>
+- ncave <777696+ncave@users.noreply.github.com>
+- Andrew Davis <pulpdrew@gmail.com>
+- Maël Nison <nison.mael@gmail.com>
+- Valeria Viana Gusmao <valeria.viana.gusmao@gmail.com>
+- Gabor Greif <ggreif@gmail.com>
+- Martin Fredriksson <martin.fredriksson@vikinganalytics.se>
+- forcepusher <bionitsoup@gmail.com>
+- Piotr Oleś <piotrek.oles@gmail.com>
+- Saúl Cabrera <saulecabrera@gmail.com>
+- Chance Snow <git@chancesnow.me>
+- Peter Salomonsen <petersalomonsen@runbox.com>
+- ookangzheng <git-ed@runbox.no>
+- yjhmelody <yjh465402634@gmail.com>
+- bnbarak <bn.barak@gmail.com>
+- Colin Eberhardt <colin.eberhardt@gmail.com>
+- Ryan Pivovar <ryanpivovar@gmail.com>
+- Roman F. <70765447+romdotdog@users.noreply.github.com>
+- Joe Pea <trusktr@gmail.com>
+- Felipe Gasper <FGasper@users.noreply.github.com>
+- Congcong Cai <congcongcai0907@163.com>
+- mooooooi <emwings@outlook.com>
+- Yasushi Ando <andyjpn@gmail.com>
+- Syed Jafri <syed@metalpay.co>
+- Peter Hayman <peteyhayman@gmail.com>
+- ApsarasX <apsarax@outlook.com>
+- Adrien Zinger <zinger.ad@gmail.com>
+- Ruixiang Chen <xiang19890319@gmail.com>
+- Daniel Salvadori <danaugrs@gmail.com>
+- Jairus Tanaka <jairus.v.tanaka@outlook.com>
+- CountBleck <Mr.YouKnowWhoIAm@protonmail.com>
+- Abdul Rauf <abdulraufmujahid@gmail.com>
+- Bach Le <bach@bullno1.com>
+- Xinquan Xu <xinquan0203@163.com>
+- Matt Johnson-Pint <mattjohnsonpint@gmail.com>
+- Fabián Heredia Montiel <fabianhjr@users.noreply.github.com>
+- Jonas Minnberg <sasq64@gmail.com>
+- Kam Chehresa <kaz.che@gmail.com>
 
 Portions of this software are derived from third-party works licensed under
 the following terms:
 
-* TypeScript: https://github.com/Microsoft/TypeScript
+- TypeScript: https://github.com/Microsoft/TypeScript
 
   Copyright (c) Microsoft Corporation
   Apache License, Version 2.0 (https://opensource.org/licenses/Apache-2.0)
 
-* Binaryen: https://github.com/WebAssembly/binaryen
+- Binaryen: https://github.com/WebAssembly/binaryen
 
   Copyright (c) WebAssembly Community Group participants
   Apache License, Version 2.0 (https://opensource.org/licenses/Apache-2.0)
 
-* musl libc: http://www.musl-libc.org
+- musl libc: http://www.musl-libc.org
 
   Copyright (c) Rich Felker, et al.
   The MIT License (https://opensource.org/licenses/MIT)
 
-* V8: https://developers.google.com/v8/
+- V8: https://developers.google.com/v8/
 
   Copyright (c) the V8 project authors
   The 3-Clause BSD License (https://opensource.org/licenses/BSD-3-Clause)
 
-* Arm Optimized Routines: https://github.com/ARM-software/optimized-routines
+- Arm Optimized Routines: https://github.com/ARM-software/optimized-routines
 
   Copyright (c) Arm Limited
   The MIT License (https://opensource.org/licenses/MIT)

--- a/std/assembly/index.d.ts
+++ b/std/assembly/index.d.ts
@@ -791,7 +791,7 @@ declare function v128(a: i8, b: i8, c: i8, d: i8, e: i8, f: i8, g: i8, h: i8, i:
 declare namespace v128 {
   /** Creates a vector with identical lanes. */
   export function splat<T>(x: T): v128;
-  /** Extracts one lane as a scalar. idx argument needs to be compile time constant. */
+  /** Extracts one lane as a scalar. */
   export function extract_lane<T>(x: v128, idx: u8): T;
   /** Replaces one lane. */
   export function replace_lane<T>(x: v128, idx: u8, value: T): v128;
@@ -1051,9 +1051,9 @@ declare function i8x16(a: i8, b: i8, c: i8, d: i8, e: i8, f: i8, g: i8, h: i8, i
 declare namespace i8x16 {
   /** Creates a vector with sixteen identical 8-bit integer lanes. */
   export function splat(x: i8): v128;
-  /** Extracts one 8-bit integer lane as a signed scalar. idx argument needs to be compile time constant. */
+  /** Extracts one 8-bit integer lane as a signed scalar. */
   export function extract_lane_s(x: v128, idx: u8): i8;
-  /** Extracts one 8-bit integer lane as an unsigned scalar. idx argument needs to be compile time constant. */
+  /** Extracts one 8-bit integer lane as an unsigned scalar. */
   export function extract_lane_u(x: v128, idx: u8): u8;
   /** Replaces one 8-bit integer lane. */
   export function replace_lane(x: v128, idx: u8, value: i8): v128;
@@ -1146,9 +1146,9 @@ declare function i16x8(a: i16, b: i16, c: i16, d: i16, e: i16, f: i16, g: i16, h
 declare namespace i16x8 {
   /** Creates a vector with eight identical 16-bit integer lanes. */
   export function splat(x: i16): v128;
-  /** Extracts one 16-bit integer lane as a signed scalar. idx argument needs to be compile time constant. */
+  /** Extracts one 16-bit integer lane as a signed scalar. */
   export function extract_lane_s(x: v128, idx: u8): i16;
-  /** Extracts one 16-bit integer lane as an unsigned scalar. idx argument needs to be compile time constant. */
+  /** Extracts one 16-bit integer lane as an unsigned scalar. */
   export function extract_lane_u(x: v128, idx: u8): u16;
   /** Replaces one 16-bit integer lane. */
   export function replace_lane(x: v128, idx: u8, value: i16): v128;
@@ -1267,7 +1267,7 @@ declare function i32x4(a: i32, b: i32, c: i32, d: i32): v128;
 declare namespace i32x4 {
   /** Creates a vector with four identical 32-bit integer lanes. */
   export function splat(x: i32): v128;
-  /** Extracts one 32-bit integer lane as a scalar. idx argument needs to be compile time constant. */
+  /** Extracts one 32-bit integer lane as a scalar. */
   export function extract_lane(x: v128, idx: u8): i32;
   /** Replaces one 32-bit integer lane. */
   export function replace_lane(x: v128, idx: u8, value: i32): v128;
@@ -1416,7 +1416,7 @@ declare function i64x2(a: i64, b: i64): v128;
 declare namespace i64x2 {
   /** Creates a vector with two identical 64-bit integer lanes. */
   export function splat(x: i64): v128;
-  /** Extracts one 64-bit integer lane as a scalar. `idx` argument need to be compile time constant */
+  /** Extracts one 64-bit integer lane as a scalar. */
   export function extract_lane(x: v128, idx: u8): i64;
   /** Replaces one 64-bit integer lane. */
   export function replace_lane(x: v128, idx: u8, value: i64): v128;
@@ -1485,7 +1485,7 @@ declare function f32x4(a: f32, b: f32, c: f32, d: f32): v128;
 declare namespace f32x4 {
   /** Creates a vector with four identical 32-bit float lanes. */
   export function splat(x: f32): v128;
-  /** Extracts one 32-bit float lane as a scalar. idx argument needs to be compile time constant. */
+  /** Extracts one 32-bit float lane as a scalar. */
   export function extract_lane(x: v128, idx: u8): f32;
   /** Replaces one 32-bit float lane. */
   export function replace_lane(x: v128, idx: u8, value: f32): v128;
@@ -1575,7 +1575,7 @@ declare function f64x2(a: f64, b: f64): v128;
 declare namespace f64x2 {
   /** Creates a vector with two identical 64-bit float lanes. */
   export function splat(x: f64): v128;
-  /** Extracts one 64-bit float lane as a scalar. idx argument needs to be compile time constant. */
+  /** Extracts one 64-bit float lane as a scalar. */
   export function extract_lane(x: v128, idx: u8): f64;
   /** Replaces one 64-bit float lane. */
   export function replace_lane(x: v128, idx: u8, value: f64): v128;

--- a/std/assembly/index.d.ts
+++ b/std/assembly/index.d.ts
@@ -791,7 +791,7 @@ declare function v128(a: i8, b: i8, c: i8, d: i8, e: i8, f: i8, g: i8, h: i8, i:
 declare namespace v128 {
   /** Creates a vector with identical lanes. */
   export function splat<T>(x: T): v128;
-  /** Extracts one lane as a scalar. */
+  /** Extracts one lane as a scalar. idx argument needs to be compile time constant. */
   export function extract_lane<T>(x: v128, idx: u8): T;
   /** Replaces one lane. */
   export function replace_lane<T>(x: v128, idx: u8, value: T): v128;
@@ -1051,9 +1051,9 @@ declare function i8x16(a: i8, b: i8, c: i8, d: i8, e: i8, f: i8, g: i8, h: i8, i
 declare namespace i8x16 {
   /** Creates a vector with sixteen identical 8-bit integer lanes. */
   export function splat(x: i8): v128;
-  /** Extracts one 8-bit integer lane as a signed scalar. */
+  /** Extracts one 8-bit integer lane as a signed scalar. idx argument needs to be compile time constant. */
   export function extract_lane_s(x: v128, idx: u8): i8;
-  /** Extracts one 8-bit integer lane as an unsigned scalar. */
+  /** Extracts one 8-bit integer lane as an unsigned scalar. idx argument needs to be compile time constant. */
   export function extract_lane_u(x: v128, idx: u8): u8;
   /** Replaces one 8-bit integer lane. */
   export function replace_lane(x: v128, idx: u8, value: i8): v128;
@@ -1146,9 +1146,9 @@ declare function i16x8(a: i16, b: i16, c: i16, d: i16, e: i16, f: i16, g: i16, h
 declare namespace i16x8 {
   /** Creates a vector with eight identical 16-bit integer lanes. */
   export function splat(x: i16): v128;
-  /** Extracts one 16-bit integer lane as a signed scalar. */
+  /** Extracts one 16-bit integer lane as a signed scalar. idx argument needs to be compile time constant. */
   export function extract_lane_s(x: v128, idx: u8): i16;
-  /** Extracts one 16-bit integer lane as an unsigned scalar. */
+  /** Extracts one 16-bit integer lane as an unsigned scalar. idx argument needs to be compile time constant. */
   export function extract_lane_u(x: v128, idx: u8): u16;
   /** Replaces one 16-bit integer lane. */
   export function replace_lane(x: v128, idx: u8, value: i16): v128;
@@ -1267,7 +1267,7 @@ declare function i32x4(a: i32, b: i32, c: i32, d: i32): v128;
 declare namespace i32x4 {
   /** Creates a vector with four identical 32-bit integer lanes. */
   export function splat(x: i32): v128;
-  /** Extracts one 32-bit integer lane as a scalar. */
+  /** Extracts one 32-bit integer lane as a scalar. idx argument needs to be compile time constant. */
   export function extract_lane(x: v128, idx: u8): i32;
   /** Replaces one 32-bit integer lane. */
   export function replace_lane(x: v128, idx: u8, value: i32): v128;
@@ -1416,7 +1416,7 @@ declare function i64x2(a: i64, b: i64): v128;
 declare namespace i64x2 {
   /** Creates a vector with two identical 64-bit integer lanes. */
   export function splat(x: i64): v128;
-  /** Extracts one 64-bit integer lane as a scalar. */
+  /** Extracts one 64-bit integer lane as a scalar. `idx` argument need to be compile time constant */
   export function extract_lane(x: v128, idx: u8): i64;
   /** Replaces one 64-bit integer lane. */
   export function replace_lane(x: v128, idx: u8, value: i64): v128;
@@ -1485,7 +1485,7 @@ declare function f32x4(a: f32, b: f32, c: f32, d: f32): v128;
 declare namespace f32x4 {
   /** Creates a vector with four identical 32-bit float lanes. */
   export function splat(x: f32): v128;
-  /** Extracts one 32-bit float lane as a scalar. */
+  /** Extracts one 32-bit float lane as a scalar. idx argument needs to be compile time constant. */
   export function extract_lane(x: v128, idx: u8): f32;
   /** Replaces one 32-bit float lane. */
   export function replace_lane(x: v128, idx: u8, value: f32): v128;
@@ -1575,7 +1575,7 @@ declare function f64x2(a: f64, b: f64): v128;
 declare namespace f64x2 {
   /** Creates a vector with two identical 64-bit float lanes. */
   export function splat(x: f64): v128;
-  /** Extracts one 64-bit float lane as a scalar. */
+  /** Extracts one 64-bit float lane as a scalar. idx argument needs to be compile time constant. */
   export function extract_lane(x: v128, idx: u8): f64;
   /** Replaces one 64-bit float lane. */
   export function replace_lane(x: v128, idx: u8, value: f64): v128;

--- a/std/assembly/index.d.ts
+++ b/std/assembly/index.d.ts
@@ -793,7 +793,7 @@ declare namespace v128 {
   export function splat<T>(x: T): v128;
   /** Extracts one lane as a scalar. idx argument needs to be compile time constant. */
   export function extract_lane<T>(x: v128, idx: u8): T;
-  /** Replaces one lane. */
+  /** Replaces one lane. idx argument needs to be compile time constant.*/
   export function replace_lane<T>(x: v128, idx: u8, value: T): v128;
   /** Selects lanes from either vector according to the specified lane indexes. */
   export function shuffle<T>(a: v128, b: v128, ...lanes: u8[]): v128;
@@ -1055,7 +1055,7 @@ declare namespace i8x16 {
   export function extract_lane_s(x: v128, idx: u8): i8;
   /** Extracts one 8-bit integer lane as an unsigned scalar. idx argument needs to be compile time constant. */
   export function extract_lane_u(x: v128, idx: u8): u8;
-  /** Replaces one 8-bit integer lane. */
+  /** Replaces one 8-bit integer lane. idx argument needs to be compile time constant. */
   export function replace_lane(x: v128, idx: u8, value: i8): v128;
   /** Adds each 8-bit integer lane. */
   export function add(a: v128, b: v128): v128;
@@ -1150,7 +1150,7 @@ declare namespace i16x8 {
   export function extract_lane_s(x: v128, idx: u8): i16;
   /** Extracts one 16-bit integer lane as an unsigned scalar. idx argument needs to be compile time constant. */
   export function extract_lane_u(x: v128, idx: u8): u16;
-  /** Replaces one 16-bit integer lane. */
+  /** Replaces one 16-bit integer lane. idx argument needs to be compile time constant. */
   export function replace_lane(x: v128, idx: u8, value: i16): v128;
   /** Adds each 16-bit integer lane. */
   export function add(a: v128, b: v128): v128;
@@ -1269,7 +1269,7 @@ declare namespace i32x4 {
   export function splat(x: i32): v128;
   /** Extracts one 32-bit integer lane as a scalar. idx argument needs to be compile time constant. */
   export function extract_lane(x: v128, idx: u8): i32;
-  /** Replaces one 32-bit integer lane. */
+  /** Replaces one 32-bit integer lane. idx argument needs to be compile time constant. */
   export function replace_lane(x: v128, idx: u8, value: i32): v128;
   /** Adds each 32-bit integer lane. */
   export function add(a: v128, b: v128): v128;
@@ -1418,7 +1418,7 @@ declare namespace i64x2 {
   export function splat(x: i64): v128;
   /** Extracts one 64-bit integer lane as a scalar. `idx` argument need to be compile time constant */
   export function extract_lane(x: v128, idx: u8): i64;
-  /** Replaces one 64-bit integer lane. */
+  /** Replaces one 64-bit integer lane. idx argument needs to be compile time constant. */
   export function replace_lane(x: v128, idx: u8, value: i64): v128;
   /** Adds each 64-bit integer lane. */
   export function add(a: v128, b: v128): v128;
@@ -1487,7 +1487,7 @@ declare namespace f32x4 {
   export function splat(x: f32): v128;
   /** Extracts one 32-bit float lane as a scalar. idx argument needs to be compile time constant. */
   export function extract_lane(x: v128, idx: u8): f32;
-  /** Replaces one 32-bit float lane. */
+  /** Replaces one 32-bit float lane. idx argument needs to be compile time constant. */
   export function replace_lane(x: v128, idx: u8, value: f32): v128;
   /** Adds each 32-bit float lane. */
   export function add(a: v128, b: v128): v128;
@@ -1577,7 +1577,7 @@ declare namespace f64x2 {
   export function splat(x: f64): v128;
   /** Extracts one 64-bit float lane as a scalar. idx argument needs to be compile time constant. */
   export function extract_lane(x: v128, idx: u8): f64;
-  /** Replaces one 64-bit float lane. */
+  /** Replaces one 64-bit float lane. idx argument needs to be compile time constant. */
   export function replace_lane(x: v128, idx: u8, value: f64): v128;
   /** Adds each 64-bit float lane. */
   export function add(a: v128, b: v128): v128;


### PR DESCRIPTION

<!--
 Thanks for submitting a pull request to AssemblyScript! Please take a moment to
 review the contributing guidelines linked below, and confirm with an [x] 🙂
-->
Fixes #2877 

Changes proposed in this pull request:
⯈ Changes made in the TypeScript declaration file `std/assembly/index.d.ts`, where the v128.extract_lane functions are declared.
⯈ Comments now include: `idx argument needs to be compile time constant.` 
⯈

- [ x] I've read the contributing guidelines
- [ x] I've added my name and email to the NOTICE file
