### PR TITLE
fix: remove erroneous `declare` for `inline.always`

### DIFF
--- a/std/assembly/index.d.ts
+++ b/std/assembly/index.d.ts
@@ -2695,7 +2695,7 @@ declare function final(constructor: Constructor): void;
 declare function inline(...args: any[]): any;
 declare namespace inline {
   /** Explicitly requests inlined function calls on the provided expression wherever possible. */
-  declare function always<T>(value: T): T;
+  export function always<T>(value: T): T;
 }
 
 /** Annotates a method, function or constant global as unsafe. */


### PR DESCRIPTION
Changes proposed in this pull request:
⯈ Replace an erroneous `declare` with `export`

- [x] I've read the contributing guidelines
- [x] I've added my name and email to the NOTICE file
