### PR TITLE
fix: remove unused tmp local in array literal generated code

### DIFF
--- a/src/compiler.ts
+++ b/src/compiler.ts
@@ -8193,7 +8193,6 @@ export class Compiler extends DiagnosticEmitter {
 
     // block those here so compiling expressions doesn't conflict
     let tempThis = flow.getTempLocal(this.options.usizeType);
-    let tempDataStart = flow.getTempLocal(arrayBufferInstance.type);
 
     // compile value expressions and find out whether all are constant
     let expressions = expression.elementExpressions;
@@ -8269,16 +8268,6 @@ export class Compiler extends DiagnosticEmitter {
     let dataStartProperty = (<PropertyPrototype>dataStartMember).instance;
     if (!dataStartProperty) return module.unreachable();
     assert(dataStartProperty.isField && dataStartProperty.memoryOffset >= 0);
-    stmts.push(
-      module.local_set(tempDataStart.index,
-        module.load(arrayType.byteSize, false,
-          module.local_get(tempThis.index, arrayTypeRef),
-          arrayTypeRef,
-          dataStartProperty.memoryOffset
-        ),
-        true // ArrayBuffer
-      )
-    );
     for (let i = 0; i < length; ++i) {
       // this[i] = value
       stmts.push(

--- a/tests/compiler/bindings/noExportRuntime.debug.wat
+++ b/tests/compiler/bindings/noExportRuntime.debug.wat
@@ -2361,8 +2361,6 @@
  (func $start:bindings/noExportRuntime
   (local $0 i32)
   (local $1 i32)
-  (local $2 i32)
-  (local $3 i32)
   memory.size
   i32.const 16
   i32.shl

--- a/tests/compiler/call-rest.debug.wat
+++ b/tests/compiler/call-rest.debug.wat
@@ -2741,7 +2741,6 @@
  (func $call-rest/fn@varargs (param $a i32) (param $b i32) (param $rest i32) (result i32)
   (local $3 i32)
   (local $4 i32)
-  (local $5 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 8
   i32.sub
@@ -2776,18 +2775,18 @@
   local.get $a
   local.get $b
   local.get $rest
-  local.set $5
+  local.set $4
   global.get $~lib/memory/__stack_pointer
-  local.get $5
+  local.get $4
   i32.store offset=4
-  local.get $5
+  local.get $4
   call $call-rest/fn
-  local.set $5
+  local.set $4
   global.get $~lib/memory/__stack_pointer
   i32.const 8
   i32.add
   global.set $~lib/memory/__stack_pointer
-  local.get $5
+  local.get $4
  )
  (func $~lib/array/ensureCapacity (param $array i32) (param $newSize i32) (param $alignLog2 i32) (param $canGrow i32)
   (local $oldCapacity i32)
@@ -3040,19 +3039,20 @@
  )
  (func $call-rest/Foo#constructor (param $this i32) (param $a i32) (param $b i32) (param $rest i32) (result i32)
   (local $4 i32)
-  (local $5 i32)
   (local $i i32)
   (local $k i32)
-  (local $8 i32)
+  (local $7 i32)
   global.get $~lib/memory/__stack_pointer
-  i32.const 20
+  i32.const 16
   i32.sub
   global.set $~lib/memory/__stack_pointer
   call $~stack_check
   global.get $~lib/memory/__stack_pointer
-  i32.const 0
-  i32.const 20
-  memory.fill
+  i64.const 0
+  i64.store
+  global.get $~lib/memory/__stack_pointer
+  i64.const 0
+  i64.store offset=8
   local.get $this
   i32.eqz
   if
@@ -3064,19 +3064,19 @@
    i32.store
   end
   local.get $this
-  local.set $8
+  local.set $7
   global.get $~lib/memory/__stack_pointer
-  local.get $8
+  local.get $7
   i32.store offset=4
-  local.get $8
+  local.get $7
   i32.const 0
   call $call-rest/Foo#set:values
   local.get $this
-  local.set $8
+  local.set $7
   global.get $~lib/memory/__stack_pointer
-  local.get $8
+  local.get $7
   i32.store offset=4
-  local.get $8
+  local.get $7
   global.get $~lib/memory/__stack_pointer
   i32.const 2
   i32.const 2
@@ -3085,11 +3085,6 @@
   call $~lib/rt/__newArray
   local.tee $4
   i32.store offset=12
-  global.get $~lib/memory/__stack_pointer
-  local.get $4
-  i32.load offset=4
-  local.tee $5
-  i32.store offset=16
   local.get $4
   i32.const 0
   local.get $a
@@ -3099,20 +3094,20 @@
   local.get $b
   call $~lib/array/Array<i32>#__set
   local.get $4
-  local.set $8
+  local.set $7
   global.get $~lib/memory/__stack_pointer
-  local.get $8
+  local.get $7
   i32.store offset=8
-  local.get $8
+  local.get $7
   call $call-rest/Foo#set:values
   i32.const 0
   local.set $i
   local.get $rest
-  local.set $8
+  local.set $7
   global.get $~lib/memory/__stack_pointer
-  local.get $8
+  local.get $7
   i32.store offset=4
-  local.get $8
+  local.get $7
   call $~lib/array/Array<i32>#get:length
   local.set $k
   loop $for-loop|0
@@ -3121,23 +3116,23 @@
    i32.lt_s
    if
     local.get $this
-    local.set $8
+    local.set $7
     global.get $~lib/memory/__stack_pointer
-    local.get $8
+    local.get $7
     i32.store offset=8
-    local.get $8
+    local.get $7
     call $call-rest/Foo#get:values
-    local.set $8
+    local.set $7
     global.get $~lib/memory/__stack_pointer
-    local.get $8
+    local.get $7
     i32.store offset=4
-    local.get $8
+    local.get $7
     local.get $rest
-    local.set $8
+    local.set $7
     global.get $~lib/memory/__stack_pointer
-    local.get $8
+    local.get $7
     i32.store offset=8
-    local.get $8
+    local.get $7
     local.get $i
     call $~lib/array/Array<i32>#__get
     call $~lib/array/Array<i32>#push
@@ -3150,17 +3145,16 @@
    end
   end
   local.get $this
-  local.set $8
+  local.set $7
   global.get $~lib/memory/__stack_pointer
-  i32.const 20
+  i32.const 16
   i32.add
   global.set $~lib/memory/__stack_pointer
-  local.get $8
+  local.get $7
  )
  (func $call-rest/Foo#constructor@varargs (param $this i32) (param $a i32) (param $b i32) (param $rest i32) (result i32)
   (local $4 i32)
   (local $5 i32)
-  (local $6 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 12
   i32.sub
@@ -3196,26 +3190,26 @@
    i32.store
   end
   local.get $this
-  local.set $6
+  local.set $5
   global.get $~lib/memory/__stack_pointer
-  local.get $6
+  local.get $5
   i32.store offset=4
-  local.get $6
+  local.get $5
   local.get $a
   local.get $b
   local.get $rest
-  local.set $6
+  local.set $5
   global.get $~lib/memory/__stack_pointer
-  local.get $6
+  local.get $5
   i32.store offset=8
-  local.get $6
+  local.get $5
   call $call-rest/Foo#constructor
-  local.set $6
+  local.set $5
   global.get $~lib/memory/__stack_pointer
   i32.const 12
   i32.add
   global.set $~lib/memory/__stack_pointer
-  local.get $6
+  local.get $5
  )
  (func $call-rest/Foo#sum (param $this i32) (result i32)
   (local $sum i32)
@@ -3314,7 +3308,6 @@
  (func $call-rest/count<i32>@varargs (param $args i32) (result i32)
   (local $1 i32)
   (local $2 i32)
-  (local $3 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 8
   i32.sub
@@ -3341,18 +3334,18 @@
    i32.store
   end
   local.get $args
-  local.set $3
+  local.set $2
   global.get $~lib/memory/__stack_pointer
-  local.get $3
+  local.get $2
   i32.store offset=4
-  local.get $3
+  local.get $2
   call $call-rest/count<i32>
-  local.set $3
+  local.set $2
   global.get $~lib/memory/__stack_pointer
   i32.const 8
   i32.add
   global.set $~lib/memory/__stack_pointer
-  local.get $3
+  local.get $2
  )
  (func $~lib/array/Array<~lib/string/String>#get:length (param $this i32) (result i32)
   (local $1 i32)
@@ -3415,15 +3408,6 @@
   (local $7 i32)
   (local $8 i32)
   (local $9 i32)
-  (local $10 i32)
-  (local $11 i32)
-  (local $12 i32)
-  (local $13 i32)
-  (local $14 i32)
-  (local $15 i32)
-  (local $16 i32)
-  (local $17 i32)
-  (local $18 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 8
   i32.sub
@@ -3490,11 +3474,11 @@
   i32.const 4
   i32.const 560
   call $~lib/rt/__newArray
-  local.set $18
+  local.set $9
   global.get $~lib/memory/__stack_pointer
-  local.get $18
+  local.get $9
   i32.store
-  local.get $18
+  local.get $9
   call $call-rest/fn
   i32.const 6
   i32.eq
@@ -3514,11 +3498,11 @@
   i32.const 4
   i32.const 592
   call $~lib/rt/__newArray
-  local.set $18
+  local.set $9
   global.get $~lib/memory/__stack_pointer
-  local.get $18
+  local.get $9
   i32.store
-  local.get $18
+  local.get $9
   call $call-rest/fn
   i32.const 15
   i32.eq
@@ -3576,11 +3560,11 @@
   i32.const 4
   i32.const 656
   call $~lib/rt/__newArray
-  local.set $18
+  local.set $9
   global.get $~lib/memory/__stack_pointer
-  local.get $18
+  local.get $9
   i32.store
-  local.get $18
+  local.get $9
   i32.const 3
   global.set $~argumentsLength
   global.get $call-rest/indirect
@@ -3604,11 +3588,11 @@
   i32.const 4
   i32.const 688
   call $~lib/rt/__newArray
-  local.set $18
+  local.set $9
   global.get $~lib/memory/__stack_pointer
-  local.get $18
+  local.get $9
   i32.store
-  local.get $18
+  local.get $9
   i32.const 3
   global.set $~argumentsLength
   global.get $call-rest/indirect
@@ -3632,11 +3616,11 @@
   global.set $~argumentsLength
   i32.const 0
   call $call-rest/Foo#constructor@varargs
-  local.set $18
+  local.set $9
   global.get $~lib/memory/__stack_pointer
-  local.get $18
+  local.get $9
   i32.store
-  local.get $18
+  local.get $9
   call $call-rest/Foo#sum
   i32.const 1
   i32.eq
@@ -3656,11 +3640,11 @@
   global.set $~argumentsLength
   i32.const 0
   call $call-rest/Foo#constructor@varargs
-  local.set $18
+  local.set $9
   global.get $~lib/memory/__stack_pointer
-  local.get $18
+  local.get $9
   i32.store
-  local.get $18
+  local.get $9
   call $call-rest/Foo#sum
   i32.const 3
   i32.eq
@@ -3681,17 +3665,17 @@
   i32.const 4
   i32.const 800
   call $~lib/rt/__newArray
-  local.set $18
+  local.set $9
   global.get $~lib/memory/__stack_pointer
-  local.get $18
+  local.get $9
   i32.store offset=4
-  local.get $18
+  local.get $9
   call $call-rest/Foo#constructor
-  local.set $18
+  local.set $9
   global.get $~lib/memory/__stack_pointer
-  local.get $18
+  local.get $9
   i32.store
-  local.get $18
+  local.get $9
   call $call-rest/Foo#sum
   i32.const 6
   i32.eq
@@ -3712,17 +3696,17 @@
   i32.const 4
   i32.const 832
   call $~lib/rt/__newArray
-  local.set $18
+  local.set $9
   global.get $~lib/memory/__stack_pointer
-  local.get $18
+  local.get $9
   i32.store offset=4
-  local.get $18
+  local.get $9
   call $call-rest/Foo#constructor
-  local.set $18
+  local.set $9
   global.get $~lib/memory/__stack_pointer
-  local.get $18
+  local.get $9
   i32.store
-  local.get $18
+  local.get $9
   call $call-rest/Foo#sum
   i32.const 15
   i32.eq
@@ -3755,11 +3739,11 @@
   i32.const 4
   i32.const 896
   call $~lib/rt/__newArray
-  local.set $18
+  local.set $9
   global.get $~lib/memory/__stack_pointer
-  local.get $18
+  local.get $9
   i32.store
-  local.get $18
+  local.get $9
   call $call-rest/count<i32>
   i32.const 1
   i32.eq
@@ -3777,11 +3761,11 @@
   i32.const 4
   i32.const 928
   call $~lib/rt/__newArray
-  local.set $18
+  local.set $9
   global.get $~lib/memory/__stack_pointer
-  local.get $18
+  local.get $9
   i32.store
-  local.get $18
+  local.get $9
   call $call-rest/count<i32>
   i32.const 3
   i32.eq
@@ -3799,11 +3783,11 @@
   i32.const 8
   i32.const 1056
   call $~lib/rt/__newArray
-  local.set $18
+  local.set $9
   global.get $~lib/memory/__stack_pointer
-  local.get $18
+  local.get $9
   i32.store
-  local.get $18
+  local.get $9
   call $call-rest/count<~lib/string/String>
   i32.const 3
   i32.eq

--- a/tests/compiler/call-rest.release.wat
+++ b/tests/compiler/call-rest.release.wat
@@ -2193,7 +2193,7 @@
   (local $6 i32)
   (local $7 i32)
   global.get $~lib/memory/__stack_pointer
-  i32.const 20
+  i32.const 16
   i32.sub
   global.set $~lib/memory/__stack_pointer
   block $folding-inner0
@@ -2202,9 +2202,11 @@
    i32.lt_s
    br_if $folding-inner0
    global.get $~lib/memory/__stack_pointer
-   i32.const 0
-   i32.const 20
-   memory.fill
+   i64.const 0
+   i64.store
+   global.get $~lib/memory/__stack_pointer
+   i64.const 0
+   i64.store offset=8
    global.get $~lib/memory/__stack_pointer
    i32.const 4
    i32.const 7
@@ -2230,10 +2232,6 @@
    call $~lib/rt/__newArray
    local.tee $3
    i32.store offset=12
-   global.get $~lib/memory/__stack_pointer
-   local.get $3
-   i32.load offset=4
-   i32.store offset=16
    local.get $3
    i32.const 0
    i32.const 1
@@ -2330,7 +2328,7 @@
     end
    end
    global.get $~lib/memory/__stack_pointer
-   i32.const 20
+   i32.const 16
    i32.add
    global.set $~lib/memory/__stack_pointer
    local.get $2

--- a/tests/compiler/exports-lazy.debug.wat
+++ b/tests/compiler/exports-lazy.debug.wat
@@ -18,7 +18,6 @@
  (start $~start)
  (func $start:exports-lazy
   (local $0 i32)
-  (local $1 i32)
   global.get $exports-lazy/lazyGlobalUsed
   drop
   call $exports-lazy/lazyFuncUsed

--- a/tests/compiler/extends-baseaggregate.debug.wat
+++ b/tests/compiler/extends-baseaggregate.debug.wat
@@ -2895,8 +2895,6 @@
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
-  (local $3 i32)
-  (local $4 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 8
   i32.sub
@@ -2923,18 +2921,18 @@
   call $~lib/rt/itcms/initLazy
   global.set $~lib/rt/itcms/fromSpace
   global.get $extends-baseaggregate/poolA
-  local.set $4
+  local.set $2
   global.get $~lib/memory/__stack_pointer
-  local.get $4
+  local.get $2
   i32.store
-  local.get $4
+  local.get $2
   i32.const 0
   call $extends-baseaggregate/A2#constructor
-  local.set $4
+  local.set $2
   global.get $~lib/memory/__stack_pointer
-  local.get $4
+  local.get $2
   i32.store offset=4
-  local.get $4
+  local.get $2
   call $~lib/array/Array<extends-baseaggregate/A2>#push
   drop
   global.get $~lib/memory/__stack_pointer

--- a/tests/compiler/field.debug.wat
+++ b/tests/compiler/field.debug.wat
@@ -2539,7 +2539,6 @@
  (func $field/NoStaticConflict#constructor (param $this i32) (result i32)
   (local $1 i32)
   (local $2 i32)
-  (local $3 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 12
   i32.sub
@@ -2563,38 +2562,38 @@
   end
   global.get $~lib/memory/__stack_pointer
   local.get $this
-  local.set $3
+  local.set $2
   global.get $~lib/memory/__stack_pointer
-  local.get $3
+  local.get $2
   i32.store offset=4
-  local.get $3
+  local.get $2
   call $~lib/object/Object#constructor
   local.tee $this
   i32.store
   local.get $this
-  local.set $3
+  local.set $2
   global.get $~lib/memory/__stack_pointer
-  local.get $3
+  local.get $2
   i32.store offset=4
-  local.get $3
+  local.get $2
   i32.const 0
   i32.const 2
   i32.const 5
   i32.const 432
   call $~lib/rt/__newArray
-  local.set $3
+  local.set $2
   global.get $~lib/memory/__stack_pointer
-  local.get $3
+  local.get $2
   i32.store offset=8
-  local.get $3
+  local.get $2
   call $field/NoStaticConflict#set:a
   local.get $this
-  local.set $3
+  local.set $2
   global.get $~lib/memory/__stack_pointer
   i32.const 12
   i32.add
   global.set $~lib/memory/__stack_pointer
-  local.get $3
+  local.get $2
  )
  (func $field/testNoStaticConflict
   (local $inst i32)

--- a/tests/compiler/infer-array.debug.wat
+++ b/tests/compiler/infer-array.debug.wat
@@ -3455,12 +3455,12 @@
   (local $7 i32)
   (local $8 i32)
   (local $9 i32)
-  (local $10 i32)
+  (local $10 f32)
   (local $11 i32)
   (local $12 i32)
   (local $13 i32)
   (local $14 i32)
-  (local $15 f32)
+  (local $15 i32)
   (local $16 i32)
   (local $17 i32)
   (local $18 i32)
@@ -3482,30 +3482,14 @@
   (local $34 i32)
   (local $35 i32)
   (local $36 i32)
-  (local $37 i32)
-  (local $38 i32)
-  (local $39 i32)
-  (local $40 i32)
-  (local $41 i32)
-  (local $42 i32)
-  (local $43 i32)
-  (local $44 i32)
-  (local $45 i32)
-  (local $46 i32)
-  (local $47 i32)
-  (local $48 i32)
-  (local $49 i32)
-  (local $50 i32)
-  (local $51 i32)
-  (local $52 i32)
   global.get $~lib/memory/__stack_pointer
-  i32.const 112
+  i32.const 96
   i32.sub
   global.set $~lib/memory/__stack_pointer
   call $~stack_check
   global.get $~lib/memory/__stack_pointer
   i32.const 0
-  i32.const 112
+  i32.const 96
   memory.fill
   memory.size
   i32.const 16
@@ -3530,14 +3514,14 @@
   i32.const 4
   i32.const 32
   call $~lib/rt/__newArray
-  local.tee $2
+  local.tee $1
   i32.store
-  local.get $2
-  local.set $52
+  local.get $1
+  local.set $36
   global.get $~lib/memory/__stack_pointer
-  local.get $52
+  local.get $36
   i32.store offset=4
-  local.get $52
+  local.get $36
   i32.const 0
   call $~lib/array/Array<i32>#__get
   drop
@@ -3551,12 +3535,12 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $2
-  local.set $52
+  local.get $1
+  local.set $36
   global.get $~lib/memory/__stack_pointer
-  local.get $52
+  local.get $36
   i32.store offset=4
-  local.get $52
+  local.get $36
   i32.const 0
   call $~lib/array/Array<i32>#__get
   drop
@@ -3576,14 +3560,14 @@
   i32.const 5
   i32.const 560
   call $~lib/rt/__newArray
-  local.tee $5
+  local.tee $3
   i32.store offset=8
-  local.get $5
-  local.set $52
+  local.get $3
+  local.set $36
   global.get $~lib/memory/__stack_pointer
-  local.get $52
+  local.get $36
   i32.store offset=4
-  local.get $52
+  local.get $36
   i32.const 0
   call $~lib/array/Array<f64>#__get
   drop
@@ -3603,14 +3587,14 @@
   i32.const 6
   i32.const 608
   call $~lib/rt/__newArray
-  local.tee $8
+  local.tee $5
   i32.store offset=12
-  local.get $8
-  local.set $52
+  local.get $5
+  local.set $36
   global.get $~lib/memory/__stack_pointer
-  local.get $52
+  local.get $36
   i32.store offset=4
-  local.get $52
+  local.get $36
   i32.const 0
   call $~lib/array/Array<u32>#__get
   drop
@@ -3624,12 +3608,12 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $8
-  local.set $52
+  local.get $5
+  local.set $36
   global.get $~lib/memory/__stack_pointer
-  local.get $52
+  local.get $36
   i32.store offset=4
-  local.get $52
+  local.get $36
   i32.const 0
   call $~lib/array/Array<u32>#__get
   drop
@@ -3644,12 +3628,12 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $8
-  local.set $52
+  local.get $5
+  local.set $36
   global.get $~lib/memory/__stack_pointer
-  local.get $52
+  local.get $36
   i32.store offset=4
-  local.get $52
+  local.get $36
   i32.const 1
   call $~lib/array/Array<u32>#__get
   i32.const -1
@@ -3669,14 +3653,14 @@
   i32.const 5
   i32.const 640
   call $~lib/rt/__newArray
-  local.tee $11
+  local.tee $7
   i32.store offset=16
-  local.get $11
-  local.set $52
+  local.get $7
+  local.set $36
   global.get $~lib/memory/__stack_pointer
-  local.get $52
+  local.get $36
   i32.store offset=4
-  local.get $52
+  local.get $36
   i32.const 0
   call $~lib/array/Array<f64>#__get
   drop
@@ -3696,14 +3680,14 @@
   i32.const 7
   i32.const 688
   call $~lib/rt/__newArray
-  local.tee $14
+  local.tee $9
   i32.store offset=20
-  local.get $14
-  local.set $52
+  local.get $9
+  local.set $36
   global.get $~lib/memory/__stack_pointer
-  local.get $52
+  local.get $36
   i32.store offset=4
-  local.get $52
+  local.get $36
   i32.const 0
   call $~lib/array/Array<f32>#__get
   drop
@@ -3717,24 +3701,24 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $14
-  local.set $52
+  local.get $9
+  local.set $36
   global.get $~lib/memory/__stack_pointer
-  local.get $52
+  local.get $36
   i32.store offset=4
-  local.get $52
+  local.get $36
   i32.const 1
   call $~lib/array/Array<f32>#__get
-  local.set $15
+  local.set $10
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   call $infer-array/Ref#constructor
-  local.tee $16
+  local.tee $11
   i32.store offset=24
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   call $infer-array/Ref#constructor
-  local.tee $17
+  local.tee $12
   i32.store offset=28
   global.get $~lib/memory/__stack_pointer
   global.get $~lib/memory/__stack_pointer
@@ -3743,30 +3727,25 @@
   i32.const 9
   i32.const 0
   call $~lib/rt/__newArray
-  local.tee $18
+  local.tee $13
   i32.store offset=32
-  global.get $~lib/memory/__stack_pointer
-  local.get $18
-  i32.load offset=4
-  local.tee $19
-  i32.store offset=36
-  local.get $18
+  local.get $13
   i32.const 0
-  local.get $16
+  local.get $11
   call $~lib/array/Array<infer-array/Ref|null>#__set
-  local.get $18
+  local.get $13
   i32.const 1
-  local.get $17
+  local.get $12
   call $~lib/array/Array<infer-array/Ref|null>#__set
-  local.get $18
-  local.tee $20
-  i32.store offset=40
-  local.get $20
-  local.set $52
+  local.get $13
+  local.tee $14
+  i32.store offset=36
+  local.get $14
+  local.set $36
   global.get $~lib/memory/__stack_pointer
-  local.get $52
+  local.get $36
   i32.store offset=4
-  local.get $52
+  local.get $36
   i32.const 0
   call $~lib/array/Array<infer-array/Ref|null>#__get
   drop
@@ -3783,13 +3762,13 @@
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   call $infer-array/Ref#constructor
-  local.tee $21
-  i32.store offset=44
+  local.tee $15
+  i32.store offset=40
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   call $infer-array/Ref#constructor
-  local.tee $22
-  i32.store offset=48
+  local.tee $16
+  i32.store offset=44
   global.get $~lib/memory/__stack_pointer
   global.get $~lib/memory/__stack_pointer
   i32.const 2
@@ -3797,30 +3776,25 @@
   i32.const 9
   i32.const 0
   call $~lib/rt/__newArray
-  local.tee $23
-  i32.store offset=52
-  global.get $~lib/memory/__stack_pointer
-  local.get $23
-  i32.load offset=4
-  local.tee $24
-  i32.store offset=56
-  local.get $23
+  local.tee $17
+  i32.store offset=48
+  local.get $17
   i32.const 0
-  local.get $21
+  local.get $15
   call $~lib/array/Array<infer-array/Ref|null>#__set
-  local.get $23
+  local.get $17
   i32.const 1
-  local.get $22
+  local.get $16
   call $~lib/array/Array<infer-array/Ref|null>#__set
-  local.get $23
-  local.tee $25
-  i32.store offset=60
-  local.get $25
-  local.set $52
+  local.get $17
+  local.tee $18
+  i32.store offset=52
+  local.get $18
+  local.set $36
   global.get $~lib/memory/__stack_pointer
-  local.get $52
+  local.get $36
   i32.store offset=4
-  local.get $52
+  local.get $36
   i32.const 1
   call $~lib/array/Array<infer-array/Ref|null>#__get
   drop
@@ -3837,8 +3811,8 @@
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   call $infer-array/Ref#constructor
-  local.tee $26
-  i32.store offset=64
+  local.tee $19
+  i32.store offset=56
   global.get $~lib/memory/__stack_pointer
   global.get $~lib/memory/__stack_pointer
   i32.const 2
@@ -3846,30 +3820,25 @@
   i32.const 9
   i32.const 0
   call $~lib/rt/__newArray
-  local.tee $27
-  i32.store offset=68
-  global.get $~lib/memory/__stack_pointer
-  local.get $27
-  i32.load offset=4
-  local.tee $28
-  i32.store offset=72
-  local.get $27
+  local.tee $20
+  i32.store offset=60
+  local.get $20
   i32.const 0
-  local.get $26
+  local.get $19
   call $~lib/array/Array<infer-array/Ref|null>#__set
-  local.get $27
+  local.get $20
   i32.const 1
   i32.const 0
   call $~lib/array/Array<infer-array/Ref|null>#__set
-  local.get $27
-  local.tee $29
-  i32.store offset=76
-  local.get $29
-  local.set $52
+  local.get $20
+  local.tee $21
+  i32.store offset=64
+  local.get $21
+  local.set $36
   global.get $~lib/memory/__stack_pointer
-  local.get $52
+  local.get $36
   i32.store offset=4
-  local.get $52
+  local.get $36
   i32.const 0
   call $~lib/array/Array<infer-array/Ref|null>#__get
   drop
@@ -3889,14 +3858,14 @@
   i32.const 10
   i32.const 800
   call $~lib/rt/__newArray
-  local.tee $32
-  i32.store offset=80
-  local.get $32
-  local.set $52
+  local.tee $23
+  i32.store offset=68
+  local.get $23
+  local.set $36
   global.get $~lib/memory/__stack_pointer
-  local.get $52
+  local.get $36
   i32.store offset=4
-  local.get $52
+  local.get $36
   i32.const 0
   call $~lib/array/Array<~lib/string/String|null>#__get
   drop
@@ -3916,14 +3885,14 @@
   i32.const 11
   i32.const 832
   call $~lib/rt/__newArray
-  local.tee $35
-  i32.store offset=84
-  local.get $35
-  local.set $52
+  local.tee $25
+  i32.store offset=72
+  local.get $25
+  local.set $36
   global.get $~lib/memory/__stack_pointer
-  local.get $52
+  local.get $36
   i32.store offset=4
-  local.get $52
+  local.get $36
   i32.const 0
   call $~lib/array/Array<usize>#__get
   drop
@@ -3937,12 +3906,12 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $35
-  local.set $52
+  local.get $25
+  local.set $36
   global.get $~lib/memory/__stack_pointer
-  local.get $52
+  local.get $36
   i32.store offset=4
-  local.get $52
+  local.get $36
   i32.const 0
   call $~lib/array/Array<usize>#__get
   drop
@@ -3963,14 +3932,14 @@
   i32.const 11
   i32.const 864
   call $~lib/rt/__newArray
-  local.tee $38
-  i32.store offset=88
-  local.get $38
-  local.set $52
+  local.tee $27
+  i32.store offset=76
+  local.get $27
+  local.set $36
   global.get $~lib/memory/__stack_pointer
-  local.get $52
+  local.get $36
   i32.store offset=4
-  local.get $52
+  local.get $36
   i32.const 0
   call $~lib/array/Array<usize>#__get
   drop
@@ -3984,12 +3953,12 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $38
-  local.set $52
+  local.get $27
+  local.set $36
   global.get $~lib/memory/__stack_pointer
-  local.get $52
+  local.get $36
   i32.store offset=4
-  local.get $52
+  local.get $36
   i32.const 0
   call $~lib/array/Array<usize>#__get
   drop
@@ -4010,14 +3979,14 @@
   i32.const 4
   i32.const 896
   call $~lib/rt/__newArray
-  local.tee $41
-  i32.store offset=92
-  local.get $41
-  local.set $52
+  local.tee $29
+  i32.store offset=80
+  local.get $29
+  local.set $36
   global.get $~lib/memory/__stack_pointer
-  local.get $52
+  local.get $36
   i32.store offset=4
-  local.get $52
+  local.get $36
   i32.const 0
   call $~lib/array/Array<i32>#__get
   drop
@@ -4031,12 +4000,12 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $41
-  local.set $52
+  local.get $29
+  local.set $36
   global.get $~lib/memory/__stack_pointer
-  local.get $52
+  local.get $36
   i32.store offset=4
-  local.get $52
+  local.get $36
   i32.const 0
   call $~lib/array/Array<i32>#__get
   drop
@@ -4057,14 +4026,14 @@
   i32.const 4
   i32.const 928
   call $~lib/rt/__newArray
-  local.tee $44
-  i32.store offset=96
-  local.get $44
-  local.set $52
+  local.tee $31
+  i32.store offset=84
+  local.get $31
+  local.set $36
   global.get $~lib/memory/__stack_pointer
-  local.get $52
+  local.get $36
   i32.store offset=4
-  local.get $52
+  local.get $36
   i32.const 0
   call $~lib/array/Array<i32>#__get
   drop
@@ -4078,12 +4047,12 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $44
-  local.set $52
+  local.get $31
+  local.set $36
   global.get $~lib/memory/__stack_pointer
-  local.get $52
+  local.get $36
   i32.store offset=4
-  local.get $52
+  local.get $36
   i32.const 0
   call $~lib/array/Array<i32>#__get
   drop
@@ -4105,14 +4074,9 @@
   i32.const 12
   i32.const 0
   call $~lib/rt/__newArray
-  local.tee $45
-  i32.store offset=100
-  global.get $~lib/memory/__stack_pointer
-  local.get $45
-  i32.load offset=4
-  local.tee $46
-  i32.store offset=104
-  local.get $45
+  local.tee $32
+  i32.store offset=88
+  local.get $32
   i32.const 0
   i32.const 1
   i32.const 2
@@ -4120,7 +4084,7 @@
   i32.const 960
   call $~lib/rt/__newArray
   call $~lib/array/Array<~lib/array/Array<i32>>#__set
-  local.get $45
+  local.get $32
   i32.const 1
   i32.const 1
   i32.const 2
@@ -4128,15 +4092,15 @@
   i32.const 992
   call $~lib/rt/__newArray
   call $~lib/array/Array<~lib/array/Array<i32>>#__set
-  local.get $45
-  local.tee $51
-  i32.store offset=108
-  local.get $51
-  local.set $52
+  local.get $32
+  local.tee $35
+  i32.store offset=92
+  local.get $35
+  local.set $36
   global.get $~lib/memory/__stack_pointer
-  local.get $52
+  local.get $36
   i32.store offset=4
-  local.get $52
+  local.get $36
   i32.const 0
   call $~lib/array/Array<~lib/array/Array<i32>>#__get
   drop
@@ -4154,7 +4118,7 @@
   i32.eqz
   drop
   global.get $~lib/memory/__stack_pointer
-  i32.const 112
+  i32.const 96
   i32.add
   global.set $~lib/memory/__stack_pointer
  )

--- a/tests/compiler/infer-array.release.wat
+++ b/tests/compiler/infer-array.release.wat
@@ -2269,7 +2269,7 @@
   (local $2 i32)
   (local $3 i32)
   global.get $~lib/memory/__stack_pointer
-  i32.const 112
+  i32.const 96
   i32.sub
   global.set $~lib/memory/__stack_pointer
   block $folding-inner0
@@ -2279,7 +2279,7 @@
    br_if $folding-inner0
    global.get $~lib/memory/__stack_pointer
    i32.const 0
-   i32.const 112
+   i32.const 96
    memory.fill
    memory.size
    i32.const 16
@@ -2433,10 +2433,6 @@
    call $~lib/rt/__newArray
    local.tee $3
    i32.store offset=32
-   global.get $~lib/memory/__stack_pointer
-   local.get $3
-   i32.load offset=4
-   i32.store offset=36
    local.get $3
    i32.const 0
    local.get $0
@@ -2447,7 +2443,7 @@
    call $~lib/array/Array<infer-array/Ref|null>#__set
    local.get $2
    local.get $3
-   i32.store offset=40
+   i32.store offset=36
    global.get $~lib/memory/__stack_pointer
    local.get $3
    i32.store offset=4
@@ -2457,11 +2453,11 @@
    global.get $~lib/memory/__stack_pointer
    call $infer-array/Ref#constructor
    local.tee $0
-   i32.store offset=44
+   i32.store offset=40
    global.get $~lib/memory/__stack_pointer
    call $infer-array/Ref#constructor
    local.tee $1
-   i32.store offset=48
+   i32.store offset=44
    global.get $~lib/memory/__stack_pointer
    local.set $2
    global.get $~lib/memory/__stack_pointer
@@ -2471,11 +2467,7 @@
    i32.const 0
    call $~lib/rt/__newArray
    local.tee $3
-   i32.store offset=52
-   global.get $~lib/memory/__stack_pointer
-   local.get $3
-   i32.load offset=4
-   i32.store offset=56
+   i32.store offset=48
    local.get $3
    i32.const 0
    local.get $0
@@ -2486,7 +2478,7 @@
    call $~lib/array/Array<infer-array/Ref|null>#__set
    local.get $2
    local.get $3
-   i32.store offset=60
+   i32.store offset=52
    global.get $~lib/memory/__stack_pointer
    local.get $3
    i32.store offset=4
@@ -2496,7 +2488,7 @@
    global.get $~lib/memory/__stack_pointer
    call $infer-array/Ref#constructor
    local.tee $0
-   i32.store offset=64
+   i32.store offset=56
    global.get $~lib/memory/__stack_pointer
    local.set $1
    global.get $~lib/memory/__stack_pointer
@@ -2506,11 +2498,7 @@
    i32.const 0
    call $~lib/rt/__newArray
    local.tee $2
-   i32.store offset=68
-   global.get $~lib/memory/__stack_pointer
-   local.get $2
-   i32.load offset=4
-   i32.store offset=72
+   i32.store offset=60
    local.get $2
    i32.const 0
    local.get $0
@@ -2521,7 +2509,7 @@
    call $~lib/array/Array<infer-array/Ref|null>#__set
    local.get $1
    local.get $2
-   i32.store offset=76
+   i32.store offset=64
    global.get $~lib/memory/__stack_pointer
    local.get $2
    i32.store offset=4
@@ -2535,7 +2523,7 @@
    i32.const 1824
    call $~lib/rt/__newArray
    local.tee $0
-   i32.store offset=80
+   i32.store offset=68
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store offset=4
@@ -2549,7 +2537,7 @@
    i32.const 1856
    call $~lib/rt/__newArray
    local.tee $0
-   i32.store offset=84
+   i32.store offset=72
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store offset=4
@@ -2571,7 +2559,7 @@
    i32.const 1888
    call $~lib/rt/__newArray
    local.tee $0
-   i32.store offset=88
+   i32.store offset=76
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store offset=4
@@ -2593,7 +2581,7 @@
    i32.const 1920
    call $~lib/rt/__newArray
    local.tee $0
-   i32.store offset=92
+   i32.store offset=80
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store offset=4
@@ -2611,7 +2599,7 @@
    i32.const 1952
    call $~lib/rt/__newArray
    local.tee $0
-   i32.store offset=96
+   i32.store offset=84
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store offset=4
@@ -2631,11 +2619,7 @@
    i32.const 0
    call $~lib/rt/__newArray
    local.tee $1
-   i32.store offset=100
-   global.get $~lib/memory/__stack_pointer
-   local.get $1
-   i32.load offset=4
-   i32.store offset=104
+   i32.store offset=88
    local.get $1
    i32.const 0
    i32.const 1
@@ -2654,7 +2638,7 @@
    call $~lib/array/Array<infer-array/Ref|null>#__set
    local.get $0
    local.get $1
-   i32.store offset=108
+   i32.store offset=92
    global.get $~lib/memory/__stack_pointer
    local.get $1
    i32.store offset=4
@@ -2707,7 +2691,7 @@
    i32.add
    global.set $~lib/memory/__stack_pointer
    global.get $~lib/memory/__stack_pointer
-   i32.const 112
+   i32.const 96
    i32.add
    global.set $~lib/memory/__stack_pointer
    return

--- a/tests/compiler/infer-generic.debug.wat
+++ b/tests/compiler/infer-generic.debug.wat
@@ -2626,7 +2626,6 @@
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
-  (local $3 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 12
   i32.sub
@@ -2651,17 +2650,17 @@
    unreachable
   end
   global.get $infer-generic/arr
-  local.set $3
+  local.set $2
   global.get $~lib/memory/__stack_pointer
-  local.get $3
+  local.get $2
   i32.store
-  local.get $3
+  local.get $2
   i32.const 176
-  local.set $3
+  local.set $2
   global.get $~lib/memory/__stack_pointer
-  local.get $3
+  local.get $2
   i32.store offset=4
-  local.get $3
+  local.get $2
   i32.const 0
   call $~lib/array/Array<f32>#reduce<bool>
   drop
@@ -2698,22 +2697,22 @@
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   call $infer-generic/Ref#constructor
-  local.tee $2
+  local.tee $1
   i32.store offset=8
-  local.get $2
-  local.set $3
+  local.get $1
+  local.set $2
   global.get $~lib/memory/__stack_pointer
-  local.get $3
+  local.get $2
   i32.store offset=4
-  local.get $3
+  local.get $2
   i32.const 2
   call $infer-generic/Ref#set:x
-  local.get $2
-  local.set $3
+  local.get $1
+  local.set $2
   global.get $~lib/memory/__stack_pointer
-  local.get $3
+  local.get $2
   i32.store
-  local.get $3
+  local.get $2
   call $infer-generic/inferDefault<infer-generic/Ref>
   drop
   i32.const 1

--- a/tests/compiler/issues/2707.debug.wat
+++ b/tests/compiler/issues/2707.debug.wat
@@ -2440,7 +2440,6 @@
  (func $start:issues/2707
   (local $0 i32)
   (local $1 i32)
-  (local $2 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 4
   i32.sub
@@ -2471,11 +2470,11 @@
   i32.const 4
   i32.const 64
   call $~lib/rt/__newArray
-  local.set $2
+  local.set $1
   global.get $~lib/memory/__stack_pointer
-  local.get $2
+  local.get $1
   i32.store
-  local.get $2
+  local.get $1
   i32.const 1
   global.set $~argumentsLength
   global.get $issues/2707/func

--- a/tests/compiler/issues/2873.debug.wat
+++ b/tests/compiler/issues/2873.debug.wat
@@ -4964,8 +4964,6 @@
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
-  (local $3 i32)
-  (local $4 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 16
   i32.sub
@@ -4997,17 +4995,17 @@
   f32.const 1.100000023841858
   i32.const 0
   call $~lib/number/F32#toString
-  local.set $4
+  local.set $2
   global.get $~lib/memory/__stack_pointer
-  local.get $4
+  local.get $2
   i32.store
-  local.get $4
+  local.get $2
   i32.const 1968
-  local.set $4
+  local.set $2
   global.get $~lib/memory/__stack_pointer
-  local.get $4
+  local.get $2
   i32.store offset=4
-  local.get $4
+  local.get $2
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -5021,17 +5019,17 @@
   f64.const 1.1
   i32.const 0
   call $~lib/number/F64#toString
-  local.set $4
+  local.set $2
   global.get $~lib/memory/__stack_pointer
-  local.get $4
+  local.get $2
   i32.store
-  local.get $4
+  local.get $2
   i32.const 1968
-  local.set $4
+  local.set $2
   global.get $~lib/memory/__stack_pointer
-  local.get $4
+  local.get $2
   i32.store offset=4
-  local.get $4
+  local.get $2
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -5043,29 +5041,29 @@
    unreachable
   end
   global.get $issues/2873/f32arr
-  local.set $4
+  local.set $2
   global.get $~lib/memory/__stack_pointer
-  local.get $4
+  local.get $2
   i32.store offset=8
-  local.get $4
+  local.get $2
   i32.const 2160
-  local.set $4
+  local.set $2
   global.get $~lib/memory/__stack_pointer
-  local.get $4
+  local.get $2
   i32.store offset=12
-  local.get $4
+  local.get $2
   call $~lib/array/Array<f32>#join
-  local.set $4
+  local.set $2
   global.get $~lib/memory/__stack_pointer
-  local.get $4
+  local.get $2
   i32.store
-  local.get $4
+  local.get $2
   i32.const 2192
-  local.set $4
+  local.set $2
   global.get $~lib/memory/__stack_pointer
-  local.get $4
+  local.get $2
   i32.store offset=4
-  local.get $4
+  local.get $2
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -5077,29 +5075,29 @@
    unreachable
   end
   global.get $issues/2873/f64arr
-  local.set $4
+  local.set $2
   global.get $~lib/memory/__stack_pointer
-  local.get $4
+  local.get $2
   i32.store offset=8
-  local.get $4
+  local.get $2
   i32.const 2160
-  local.set $4
+  local.set $2
   global.get $~lib/memory/__stack_pointer
-  local.get $4
+  local.get $2
   i32.store offset=12
-  local.get $4
+  local.get $2
   call $~lib/array/Array<f64>#join
-  local.set $4
+  local.set $2
   global.get $~lib/memory/__stack_pointer
-  local.get $4
+  local.get $2
   i32.store
-  local.get $4
+  local.get $2
   i32.const 2192
-  local.set $4
+  local.set $2
   global.get $~lib/memory/__stack_pointer
-  local.get $4
+  local.get $2
   i32.store offset=4
-  local.get $4
+  local.get $2
   call $~lib/string/String.__eq
   i32.eqz
   if

--- a/tests/compiler/resolve-access.debug.wat
+++ b/tests/compiler/resolve-access.debug.wat
@@ -3147,9 +3147,8 @@
  )
  (func $resolve-access/arrayAccess (result i32)
   (local $0 i32)
-  (local $1 i32)
   (local $arr i32)
-  (local $3 i32)
+  (local $2 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 8
   i32.sub
@@ -3167,21 +3166,21 @@
   local.tee $arr
   i32.store
   local.get $arr
-  local.set $3
+  local.set $2
   global.get $~lib/memory/__stack_pointer
-  local.get $3
+  local.get $2
   i32.store offset=4
-  local.get $3
+  local.get $2
   i32.const 0
   call $~lib/array/Array<u64>#__get
   i32.const 10
   call $~lib/number/U64#toString
-  local.set $3
+  local.set $2
   global.get $~lib/memory/__stack_pointer
   i32.const 8
   i32.add
   global.set $~lib/memory/__stack_pointer
-  local.get $3
+  local.get $2
   return
  )
  (func $resolve-access/Container#constructor (param $this i32) (result i32)

--- a/tests/compiler/simd.debug.wat
+++ b/tests/compiler/simd.debug.wat
@@ -6954,7 +6954,6 @@
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
-  (local $3 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 8
   i32.sub
@@ -6986,14 +6985,14 @@
   i32.const 4
   i32.const 32
   call $~lib/rt/__newArray
-  local.tee $2
+  local.tee $1
   i32.store
-  local.get $2
-  local.set $3
+  local.get $1
+  local.set $2
   global.get $~lib/memory/__stack_pointer
-  local.get $3
+  local.get $2
   i32.store offset=4
-  local.get $3
+  local.get $2
   i32.const 0
   call $~lib/array/Array<v128>#__get
   i32x4.extract_lane 0

--- a/tests/compiler/std/array-literal.debug.wat
+++ b/tests/compiler/std/array-literal.debug.wat
@@ -3354,29 +3354,21 @@
   (local $6 i32)
   (local $7 i32)
   (local $8 i32)
-  (local $9 i32)
-  (local $10 i32)
-  (local $11 i32)
-  (local $12 i32)
-  (local $13 i32)
-  (local $14 i32)
-  (local $15 i32)
-  (local $16 i32)
   global.get $~lib/memory/__stack_pointer
-  i32.const 44
+  i32.const 24
   i32.sub
   global.set $~lib/memory/__stack_pointer
   call $~stack_check
   global.get $~lib/memory/__stack_pointer
   i32.const 0
-  i32.const 44
+  i32.const 24
   memory.fill
   global.get $std/array-literal/staticArrayI8
-  local.set $16
+  local.set $8
   global.get $~lib/memory/__stack_pointer
-  local.get $16
+  local.get $8
   i32.store
-  local.get $16
+  local.get $8
   call $~lib/array/Array<i8>#get:length
   i32.const 3
   i32.eq
@@ -3390,11 +3382,11 @@
    unreachable
   end
   global.get $std/array-literal/staticArrayI8
-  local.set $16
+  local.set $8
   global.get $~lib/memory/__stack_pointer
-  local.get $16
+  local.get $8
   i32.store
-  local.get $16
+  local.get $8
   i32.const 0
   call $~lib/array/Array<i8>#__get
   i32.const 0
@@ -3409,11 +3401,11 @@
    unreachable
   end
   global.get $std/array-literal/staticArrayI8
-  local.set $16
+  local.set $8
   global.get $~lib/memory/__stack_pointer
-  local.get $16
+  local.get $8
   i32.store
-  local.get $16
+  local.get $8
   i32.const 1
   call $~lib/array/Array<i8>#__get
   i32.const 1
@@ -3428,11 +3420,11 @@
    unreachable
   end
   global.get $std/array-literal/staticArrayI8
-  local.set $16
+  local.set $8
   global.get $~lib/memory/__stack_pointer
-  local.get $16
+  local.get $8
   i32.store
-  local.get $16
+  local.get $8
   i32.const 2
   call $~lib/array/Array<i8>#__get
   i32.const 2
@@ -3447,11 +3439,11 @@
    unreachable
   end
   global.get $std/array-literal/staticArrayI32
-  local.set $16
+  local.set $8
   global.get $~lib/memory/__stack_pointer
-  local.get $16
+  local.get $8
   i32.store
-  local.get $16
+  local.get $8
   call $~lib/array/Array<i32>#get:length
   i32.const 3
   i32.eq
@@ -3465,11 +3457,11 @@
    unreachable
   end
   global.get $std/array-literal/staticArrayI32
-  local.set $16
+  local.set $8
   global.get $~lib/memory/__stack_pointer
-  local.get $16
+  local.get $8
   i32.store
-  local.get $16
+  local.get $8
   i32.const 0
   call $~lib/array/Array<i32>#__get
   i32.const 0
@@ -3484,11 +3476,11 @@
    unreachable
   end
   global.get $std/array-literal/staticArrayI32
-  local.set $16
+  local.set $8
   global.get $~lib/memory/__stack_pointer
-  local.get $16
+  local.get $8
   i32.store
-  local.get $16
+  local.get $8
   i32.const 1
   call $~lib/array/Array<i32>#__get
   i32.const 1
@@ -3503,11 +3495,11 @@
    unreachable
   end
   global.get $std/array-literal/staticArrayI32
-  local.set $16
+  local.set $8
   global.get $~lib/memory/__stack_pointer
-  local.get $16
+  local.get $8
   i32.store
-  local.get $16
+  local.get $8
   i32.const 2
   call $~lib/array/Array<i32>#__get
   i32.const 2
@@ -3522,11 +3514,11 @@
    unreachable
   end
   global.get $std/array-literal/emptyArrayI32
-  local.set $16
+  local.set $8
   global.get $~lib/memory/__stack_pointer
-  local.get $16
+  local.get $8
   i32.store
-  local.get $16
+  local.get $8
   call $~lib/array/Array<i32>#get:length
   i32.const 0
   i32.eq
@@ -3562,18 +3554,13 @@
   i32.const 4
   i32.const 0
   call $~lib/rt/__newArray
-  local.tee $6
+  local.tee $3
   i32.store offset=4
-  global.get $~lib/memory/__stack_pointer
-  local.get $6
-  i32.load offset=4
-  local.tee $7
-  i32.store offset=8
-  local.get $6
+  local.get $3
   i32.const 0
   global.get $std/array-literal/i
   call $~lib/array/Array<i8>#__set
-  local.get $6
+  local.get $3
   i32.const 1
   global.get $std/array-literal/i
   i32.const 1
@@ -3581,7 +3568,7 @@
   global.set $std/array-literal/i
   global.get $std/array-literal/i
   call $~lib/array/Array<i8>#__set
-  local.get $6
+  local.get $3
   i32.const 2
   global.get $std/array-literal/i
   i32.const 1
@@ -3589,14 +3576,14 @@
   global.set $std/array-literal/i
   global.get $std/array-literal/i
   call $~lib/array/Array<i8>#__set
-  local.get $6
+  local.get $3
   global.set $std/array-literal/dynamicArrayI8
   global.get $std/array-literal/dynamicArrayI8
-  local.set $16
+  local.set $8
   global.get $~lib/memory/__stack_pointer
-  local.get $16
+  local.get $8
   i32.store
-  local.get $16
+  local.get $8
   call $~lib/array/Array<i8>#get:length
   i32.const 3
   i32.eq
@@ -3610,11 +3597,11 @@
    unreachable
   end
   global.get $std/array-literal/dynamicArrayI8
-  local.set $16
+  local.set $8
   global.get $~lib/memory/__stack_pointer
-  local.get $16
+  local.get $8
   i32.store
-  local.get $16
+  local.get $8
   i32.const 0
   call $~lib/array/Array<i8>#__get
   i32.const 0
@@ -3629,11 +3616,11 @@
    unreachable
   end
   global.get $std/array-literal/dynamicArrayI8
-  local.set $16
+  local.set $8
   global.get $~lib/memory/__stack_pointer
-  local.get $16
+  local.get $8
   i32.store
-  local.get $16
+  local.get $8
   i32.const 1
   call $~lib/array/Array<i8>#__get
   i32.const 1
@@ -3648,11 +3635,11 @@
    unreachable
   end
   global.get $std/array-literal/dynamicArrayI8
-  local.set $16
+  local.set $8
   global.get $~lib/memory/__stack_pointer
-  local.get $16
+  local.get $8
   i32.store
-  local.get $16
+  local.get $8
   i32.const 2
   call $~lib/array/Array<i8>#__get
   i32.const 2
@@ -3674,18 +3661,13 @@
   i32.const 5
   i32.const 0
   call $~lib/rt/__newArray
-  local.tee $8
-  i32.store offset=12
-  global.get $~lib/memory/__stack_pointer
-  local.get $8
-  i32.load offset=4
-  local.tee $9
-  i32.store offset=16
-  local.get $8
+  local.tee $4
+  i32.store offset=8
+  local.get $4
   i32.const 0
   global.get $std/array-literal/i
   call $~lib/array/Array<i32>#__set
-  local.get $8
+  local.get $4
   i32.const 1
   global.get $std/array-literal/i
   i32.const 1
@@ -3693,7 +3675,7 @@
   global.set $std/array-literal/i
   global.get $std/array-literal/i
   call $~lib/array/Array<i32>#__set
-  local.get $8
+  local.get $4
   i32.const 2
   global.get $std/array-literal/i
   i32.const 1
@@ -3701,14 +3683,14 @@
   global.set $std/array-literal/i
   global.get $std/array-literal/i
   call $~lib/array/Array<i32>#__set
-  local.get $8
+  local.get $4
   global.set $std/array-literal/dynamicArrayI32
   global.get $std/array-literal/dynamicArrayI32
-  local.set $16
+  local.set $8
   global.get $~lib/memory/__stack_pointer
-  local.get $16
+  local.get $8
   i32.store
-  local.get $16
+  local.get $8
   call $~lib/array/Array<i32>#get:length
   i32.const 3
   i32.eq
@@ -3722,11 +3704,11 @@
    unreachable
   end
   global.get $std/array-literal/dynamicArrayI32
-  local.set $16
+  local.set $8
   global.get $~lib/memory/__stack_pointer
-  local.get $16
+  local.get $8
   i32.store
-  local.get $16
+  local.get $8
   i32.const 0
   call $~lib/array/Array<i32>#__get
   i32.const 0
@@ -3741,11 +3723,11 @@
    unreachable
   end
   global.get $std/array-literal/dynamicArrayI32
-  local.set $16
+  local.set $8
   global.get $~lib/memory/__stack_pointer
-  local.get $16
+  local.get $8
   i32.store
-  local.get $16
+  local.get $8
   i32.const 1
   call $~lib/array/Array<i32>#__get
   i32.const 1
@@ -3760,11 +3742,11 @@
    unreachable
   end
   global.get $std/array-literal/dynamicArrayI32
-  local.set $16
+  local.set $8
   global.get $~lib/memory/__stack_pointer
-  local.get $16
+  local.get $8
   i32.store
-  local.get $16
+  local.get $8
   i32.const 2
   call $~lib/array/Array<i32>#__get
   i32.const 2
@@ -3784,36 +3766,31 @@
   i32.const 7
   i32.const 0
   call $~lib/rt/__newArray
-  local.tee $10
-  i32.store offset=20
-  global.get $~lib/memory/__stack_pointer
-  local.get $10
-  i32.load offset=4
-  local.tee $11
-  i32.store offset=24
-  local.get $10
+  local.tee $5
+  i32.store offset=12
+  local.get $5
   i32.const 0
   i32.const 0
   call $std/array-literal/Ref#constructor
   call $~lib/array/Array<std/array-literal/Ref>#__set
-  local.get $10
+  local.get $5
   i32.const 1
   i32.const 0
   call $std/array-literal/Ref#constructor
   call $~lib/array/Array<std/array-literal/Ref>#__set
-  local.get $10
+  local.get $5
   i32.const 2
   i32.const 0
   call $std/array-literal/Ref#constructor
   call $~lib/array/Array<std/array-literal/Ref>#__set
-  local.get $10
+  local.get $5
   global.set $std/array-literal/dynamicArrayRef
   global.get $std/array-literal/dynamicArrayRef
-  local.set $16
+  local.set $8
   global.get $~lib/memory/__stack_pointer
-  local.get $16
+  local.get $8
   i32.store
-  local.get $16
+  local.get $8
   call $~lib/array/Array<std/array-literal/Ref>#get:length
   i32.const 3
   i32.eq
@@ -3832,36 +3809,31 @@
   i32.const 9
   i32.const 0
   call $~lib/rt/__newArray
-  local.tee $12
-  i32.store offset=28
-  global.get $~lib/memory/__stack_pointer
-  local.get $12
-  i32.load offset=4
-  local.tee $13
-  i32.store offset=32
-  local.get $12
+  local.tee $6
+  i32.store offset=16
+  local.get $6
   i32.const 0
   i32.const 0
   call $std/array-literal/RefWithCtor#constructor
   call $~lib/array/Array<std/array-literal/RefWithCtor>#__set
-  local.get $12
+  local.get $6
   i32.const 1
   i32.const 0
   call $std/array-literal/RefWithCtor#constructor
   call $~lib/array/Array<std/array-literal/RefWithCtor>#__set
-  local.get $12
+  local.get $6
   i32.const 2
   i32.const 0
   call $std/array-literal/RefWithCtor#constructor
   call $~lib/array/Array<std/array-literal/RefWithCtor>#__set
-  local.get $12
+  local.get $6
   global.set $std/array-literal/dynamicArrayRefWithCtor
   global.get $std/array-literal/dynamicArrayRefWithCtor
-  local.set $16
+  local.set $8
   global.get $~lib/memory/__stack_pointer
-  local.get $16
+  local.get $8
   i32.store
-  local.get $16
+  local.get $8
   call $~lib/array/Array<std/array-literal/RefWithCtor>#get:length
   i32.const 3
   i32.eq
@@ -3890,30 +3862,25 @@
   i32.const 7
   i32.const 0
   call $~lib/rt/__newArray
-  local.tee $14
-  i32.store offset=36
-  global.get $~lib/memory/__stack_pointer
-  local.get $14
-  i32.load offset=4
-  local.tee $15
-  i32.store offset=40
-  local.get $14
+  local.tee $7
+  i32.store offset=20
+  local.get $7
   i32.const 0
   i32.const 0
   call $std/array-literal/Ref#constructor
   call $~lib/array/Array<std/array-literal/Ref>#__set
-  local.get $14
-  local.set $16
+  local.get $7
+  local.set $8
   global.get $~lib/memory/__stack_pointer
-  local.get $16
+  local.get $8
   i32.store
-  local.get $16
+  local.get $8
   call $std/array-literal/doesntLeak
   global.get $~lib/memory/__heap_base
   global.set $~lib/memory/__stack_pointer
   call $~lib/rt/itcms/__collect
   global.get $~lib/memory/__stack_pointer
-  i32.const 44
+  i32.const 24
   i32.add
   global.set $~lib/memory/__stack_pointer
  )

--- a/tests/compiler/std/array-literal.release.wat
+++ b/tests/compiler/std/array-literal.release.wat
@@ -2348,7 +2348,7 @@
  (func $start:std/array-literal
   (local $0 i32)
   global.get $~lib/memory/__stack_pointer
-  i32.const 44
+  i32.const 24
   i32.sub
   global.set $~lib/memory/__stack_pointer
   global.get $~lib/memory/__stack_pointer
@@ -2364,7 +2364,7 @@
   end
   global.get $~lib/memory/__stack_pointer
   i32.const 0
-  i32.const 44
+  i32.const 24
   memory.fill
   global.get $~lib/memory/__stack_pointer
   i32.const 1088
@@ -2541,10 +2541,6 @@
   call $~lib/rt/__newArray
   local.tee $0
   i32.store offset=4
-  global.get $~lib/memory/__stack_pointer
-  local.get $0
-  i32.load offset=4
-  i32.store offset=8
   local.get $0
   i32.const 0
   global.get $std/array-literal/i
@@ -2640,11 +2636,7 @@
   i32.const 5
   call $~lib/rt/__newArray
   local.tee $0
-  i32.store offset=12
-  global.get $~lib/memory/__stack_pointer
-  local.get $0
-  i32.load offset=4
-  i32.store offset=16
+  i32.store offset=8
   local.get $0
   i32.const 0
   global.get $std/array-literal/i
@@ -2738,11 +2730,7 @@
   i32.const 7
   call $~lib/rt/__newArray
   local.tee $0
-  i32.store offset=20
-  global.get $~lib/memory/__stack_pointer
-  local.get $0
-  i32.load offset=4
-  i32.store offset=24
+  i32.store offset=12
   local.get $0
   i32.const 0
   call $std/array-literal/Ref#constructor
@@ -2779,11 +2767,7 @@
   i32.const 9
   call $~lib/rt/__newArray
   local.tee $0
-  i32.store offset=28
-  global.get $~lib/memory/__stack_pointer
-  local.get $0
-  i32.load offset=4
-  i32.store offset=32
+  i32.store offset=16
   local.get $0
   i32.const 0
   call $std/array-literal/RefWithCtor#constructor
@@ -2830,11 +2814,7 @@
   i32.const 7
   call $~lib/rt/__newArray
   local.tee $0
-  i32.store offset=36
-  global.get $~lib/memory/__stack_pointer
-  local.get $0
-  i32.load offset=4
-  i32.store offset=40
+  i32.store offset=20
   local.get $0
   i32.const 0
   call $std/array-literal/Ref#constructor
@@ -2878,7 +2858,7 @@
   i32.add
   global.set $~lib/rt/itcms/threshold
   global.get $~lib/memory/__stack_pointer
-  i32.const 44
+  i32.const 24
   i32.add
   global.set $~lib/memory/__stack_pointer
  )

--- a/tests/compiler/std/array.debug.wat
+++ b/tests/compiler/std/array.debug.wat
@@ -33926,196 +33926,14 @@
   (local $294 i32)
   (local $295 i32)
   (local $296 i32)
-  (local $297 i32)
-  (local $298 i32)
-  (local $299 i32)
-  (local $300 i32)
-  (local $301 i32)
-  (local $302 i32)
-  (local $303 i32)
-  (local $304 i32)
-  (local $305 i32)
-  (local $306 i32)
-  (local $307 i32)
-  (local $308 i32)
-  (local $309 i32)
-  (local $310 i32)
-  (local $311 i32)
-  (local $312 i32)
-  (local $313 i32)
-  (local $314 i32)
-  (local $315 i32)
-  (local $316 i32)
-  (local $317 i32)
-  (local $318 i32)
-  (local $319 i32)
-  (local $320 i32)
-  (local $321 i32)
-  (local $322 i32)
-  (local $323 i32)
-  (local $324 i32)
-  (local $325 i32)
-  (local $326 i32)
-  (local $327 i32)
-  (local $328 i32)
-  (local $329 i32)
-  (local $330 i32)
-  (local $331 i32)
-  (local $332 i32)
-  (local $333 i32)
-  (local $334 i32)
-  (local $335 i32)
-  (local $336 i32)
-  (local $337 i32)
-  (local $338 i32)
-  (local $339 i32)
-  (local $340 i32)
-  (local $341 i32)
-  (local $342 i32)
-  (local $343 i32)
-  (local $344 i32)
-  (local $345 i32)
-  (local $346 i32)
-  (local $347 i32)
-  (local $348 i32)
-  (local $349 i32)
-  (local $350 i32)
-  (local $351 i32)
-  (local $352 i32)
-  (local $353 i32)
-  (local $354 i32)
-  (local $355 i32)
-  (local $356 i32)
-  (local $357 i32)
-  (local $358 i32)
-  (local $359 i32)
-  (local $360 i32)
-  (local $361 i32)
-  (local $362 i32)
-  (local $363 i32)
-  (local $364 i32)
-  (local $365 i32)
-  (local $366 i32)
-  (local $367 i32)
-  (local $368 i32)
-  (local $369 i32)
-  (local $370 i32)
-  (local $371 i32)
-  (local $372 i32)
-  (local $373 i32)
-  (local $374 i32)
-  (local $375 i32)
-  (local $376 i32)
-  (local $377 i32)
-  (local $378 i32)
-  (local $379 i32)
-  (local $380 i32)
-  (local $381 i32)
-  (local $382 i32)
-  (local $383 i32)
-  (local $384 i32)
-  (local $385 i32)
-  (local $386 i32)
-  (local $387 i32)
-  (local $388 i32)
-  (local $389 i32)
-  (local $390 i32)
-  (local $391 i32)
-  (local $392 i32)
-  (local $393 i32)
-  (local $394 i32)
-  (local $395 i32)
-  (local $396 i32)
-  (local $397 i32)
-  (local $398 i32)
-  (local $399 i32)
-  (local $400 i32)
-  (local $401 i32)
-  (local $402 i32)
-  (local $403 i32)
-  (local $404 i32)
-  (local $405 i32)
-  (local $406 i32)
-  (local $407 i32)
-  (local $408 i32)
-  (local $409 i32)
-  (local $410 i32)
-  (local $411 i32)
-  (local $412 i32)
-  (local $413 i32)
-  (local $414 i32)
-  (local $415 i32)
-  (local $416 i32)
-  (local $417 i32)
-  (local $418 i32)
-  (local $419 i32)
-  (local $420 i32)
-  (local $421 i32)
-  (local $422 i32)
-  (local $423 i32)
-  (local $424 i32)
-  (local $425 i32)
-  (local $426 i32)
-  (local $427 i32)
-  (local $428 i32)
-  (local $429 i32)
-  (local $430 i32)
-  (local $431 i32)
-  (local $432 i32)
-  (local $433 i32)
-  (local $434 i32)
-  (local $435 i32)
-  (local $436 i32)
-  (local $437 i32)
-  (local $438 i32)
-  (local $439 i32)
-  (local $440 i32)
-  (local $441 i32)
-  (local $442 i32)
-  (local $443 i32)
-  (local $444 i32)
-  (local $445 i32)
-  (local $446 i32)
-  (local $447 i32)
-  (local $448 i32)
-  (local $449 i32)
-  (local $450 i32)
-  (local $451 i32)
-  (local $452 i32)
-  (local $453 i32)
-  (local $454 i32)
-  (local $455 i32)
-  (local $456 i32)
-  (local $457 i32)
-  (local $458 i32)
-  (local $459 i32)
-  (local $460 i32)
-  (local $461 i32)
-  (local $462 i32)
-  (local $463 i32)
-  (local $464 i32)
-  (local $465 i32)
-  (local $466 i32)
-  (local $467 i32)
-  (local $468 i32)
-  (local $469 i32)
-  (local $470 i32)
-  (local $471 i32)
-  (local $472 i32)
-  (local $473 i32)
-  (local $474 i32)
-  (local $475 i32)
-  (local $476 i32)
-  (local $477 i32)
-  (local $478 i32)
   global.get $~lib/memory/__stack_pointer
-  i32.const 508
+  i32.const 448
   i32.sub
   global.set $~lib/memory/__stack_pointer
   call $~stack_check
   global.get $~lib/memory/__stack_pointer
   i32.const 0
-  i32.const 508
+  i32.const 448
   memory.fill
   i32.const 0
   i32.const 0
@@ -34165,11 +33983,11 @@
   i32.const 0
   i32.const 0
   call $std/array/Ref#constructor
-  local.set $478
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store
-  local.get $478
+  local.get $296
   call $~lib/array/Array.isArray<std/array/Ref>
   i32.eqz
   i32.eqz
@@ -34184,11 +34002,11 @@
   i32.const 0
   i32.const 1
   call $~lib/typedarray/Uint8Array#constructor
-  local.set $478
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store
-  local.get $478
+  local.get $296
   call $~lib/array/Array.isArray<~lib/typedarray/Uint8Array>
   i32.eqz
   i32.eqz
@@ -34213,11 +34031,11 @@
    unreachable
   end
   i32.const 640
-  local.set $478
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store
-  local.get $478
+  local.get $296
   call $~lib/array/Array.isArray<~lib/string/String>
   i32.eqz
   i32.eqz
@@ -34230,11 +34048,11 @@
    unreachable
   end
   global.get $std/array/arr
-  local.set $478
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store
-  local.get $478
+  local.get $296
   call $~lib/array/Array.isArray<~lib/array/Array<i32>>
   i32.eqz
   if
@@ -34251,35 +34069,35 @@
   i32.const 7
   i32.const 672
   call $~lib/rt/__newArray
-  local.tee $2
+  local.tee $1
   i32.store offset=4
-  local.get $2
-  local.set $478
+  local.get $1
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store
-  local.get $478
+  local.get $296
   i32.const 1
   i32.const 1
   i32.const 3
   call $~lib/array/Array<u8>#fill
   drop
-  local.get $2
-  local.set $478
+  local.get $1
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store
-  local.get $478
+  local.get $296
   i32.const 5
   i32.const 0
   i32.const 7
   i32.const 704
   call $~lib/rt/__newArray
-  local.set $478
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store offset=8
-  local.get $478
+  local.get $296
   i32.const 0
   call $std/array/isArraysEqual<u8>
   i32.eqz
@@ -34291,12 +34109,12 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $2
-  local.set $478
+  local.get $1
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store
-  local.get $478
+  local.get $296
   i32.const 0
   i32.const 0
   i32.const 1
@@ -34304,22 +34122,22 @@
   i32.const 0
   call $~lib/array/Array<u8>#fill@varargs
   drop
-  local.get $2
-  local.set $478
+  local.get $1
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store
-  local.get $478
+  local.get $296
   i32.const 5
   i32.const 0
   i32.const 7
   i32.const 736
   call $~lib/rt/__newArray
-  local.set $478
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store offset=8
-  local.get $478
+  local.get $296
   i32.const 0
   call $std/array/isArraysEqual<u8>
   i32.eqz
@@ -34331,33 +34149,33 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $2
-  local.set $478
+  local.get $1
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store
-  local.get $478
+  local.get $296
   i32.const 1
   i32.const 0
   i32.const -3
   call $~lib/array/Array<u8>#fill
   drop
-  local.get $2
-  local.set $478
+  local.get $1
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store
-  local.get $478
+  local.get $296
   i32.const 5
   i32.const 0
   i32.const 7
   i32.const 768
   call $~lib/rt/__newArray
-  local.set $478
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store offset=8
-  local.get $478
+  local.get $296
   i32.const 0
   call $std/array/isArraysEqual<u8>
   i32.eqz
@@ -34369,12 +34187,12 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $2
-  local.set $478
+  local.get $1
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store
-  local.get $478
+  local.get $296
   i32.const 2
   i32.const -2
   i32.const 2
@@ -34382,22 +34200,22 @@
   i32.const 0
   call $~lib/array/Array<u8>#fill@varargs
   drop
-  local.get $2
-  local.set $478
+  local.get $1
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store
-  local.get $478
+  local.get $296
   i32.const 5
   i32.const 0
   i32.const 7
   i32.const 800
   call $~lib/rt/__newArray
-  local.set $478
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store offset=8
-  local.get $478
+  local.get $296
   i32.const 0
   call $std/array/isArraysEqual<u8>
   i32.eqz
@@ -34409,33 +34227,33 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $2
-  local.set $478
+  local.get $1
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store
-  local.get $478
+  local.get $296
   i32.const 0
   i32.const 1
   i32.const 0
   call $~lib/array/Array<u8>#fill
   drop
-  local.get $2
-  local.set $478
+  local.get $1
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store
-  local.get $478
+  local.get $296
   i32.const 5
   i32.const 0
   i32.const 7
   i32.const 832
   call $~lib/rt/__newArray
-  local.set $478
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store offset=8
-  local.get $478
+  local.get $296
   i32.const 0
   call $std/array/isArraysEqual<u8>
   i32.eqz
@@ -34447,12 +34265,12 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $2
-  local.set $478
+  local.get $1
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store
-  local.get $478
+  local.get $296
   i32.const -1
   i32.const 0
   i32.const 1
@@ -34460,22 +34278,22 @@
   i32.const 0
   call $~lib/array/Array<u8>#fill@varargs
   drop
-  local.get $2
-  local.set $478
+  local.get $1
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store
-  local.get $478
+  local.get $296
   i32.const 5
   i32.const 0
   i32.const 7
   i32.const 864
   call $~lib/rt/__newArray
-  local.set $478
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store offset=8
-  local.get $478
+  local.get $296
   i32.const 0
   call $std/array/isArraysEqual<u8>
   i32.eqz
@@ -34493,35 +34311,35 @@
   i32.const 8
   i32.const 896
   call $~lib/rt/__newArray
-  local.tee $17
+  local.tee $9
   i32.store offset=12
-  local.get $17
-  local.set $478
+  local.get $9
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store
-  local.get $478
+  local.get $296
   i32.const 1
   i32.const 1
   i32.const 3
   call $~lib/array/Array<u32>#fill
   drop
-  local.get $17
-  local.set $478
+  local.get $9
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store
-  local.get $478
+  local.get $296
   i32.const 5
   i32.const 2
   i32.const 8
   i32.const 944
   call $~lib/rt/__newArray
-  local.set $478
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store offset=8
-  local.get $478
+  local.get $296
   i32.const 0
   call $std/array/isArraysEqual<u32>
   i32.eqz
@@ -34533,12 +34351,12 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $17
-  local.set $478
+  local.get $9
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store
-  local.get $478
+  local.get $296
   i32.const 0
   i32.const 0
   i32.const 1
@@ -34546,22 +34364,22 @@
   i32.const 0
   call $~lib/array/Array<u32>#fill@varargs
   drop
-  local.get $17
-  local.set $478
+  local.get $9
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store
-  local.get $478
+  local.get $296
   i32.const 5
   i32.const 2
   i32.const 8
   i32.const 992
   call $~lib/rt/__newArray
-  local.set $478
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store offset=8
-  local.get $478
+  local.get $296
   i32.const 0
   call $std/array/isArraysEqual<u32>
   i32.eqz
@@ -34573,33 +34391,33 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $17
-  local.set $478
+  local.get $9
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store
-  local.get $478
+  local.get $296
   i32.const 1
   i32.const 0
   i32.const -3
   call $~lib/array/Array<u32>#fill
   drop
-  local.get $17
-  local.set $478
+  local.get $9
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store
-  local.get $478
+  local.get $296
   i32.const 5
   i32.const 2
   i32.const 8
   i32.const 1040
   call $~lib/rt/__newArray
-  local.set $478
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store offset=8
-  local.get $478
+  local.get $296
   i32.const 0
   call $std/array/isArraysEqual<u32>
   i32.eqz
@@ -34611,12 +34429,12 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $17
-  local.set $478
+  local.get $9
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store
-  local.get $478
+  local.get $296
   i32.const 2
   i32.const -2
   i32.const 2
@@ -34624,22 +34442,22 @@
   i32.const 0
   call $~lib/array/Array<u32>#fill@varargs
   drop
-  local.get $17
-  local.set $478
+  local.get $9
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store
-  local.get $478
+  local.get $296
   i32.const 5
   i32.const 2
   i32.const 8
   i32.const 1088
   call $~lib/rt/__newArray
-  local.set $478
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store offset=8
-  local.get $478
+  local.get $296
   i32.const 0
   call $std/array/isArraysEqual<u32>
   i32.eqz
@@ -34651,33 +34469,33 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $17
-  local.set $478
+  local.get $9
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store
-  local.get $478
+  local.get $296
   i32.const 0
   i32.const 1
   i32.const 0
   call $~lib/array/Array<u32>#fill
   drop
-  local.get $17
-  local.set $478
+  local.get $9
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store
-  local.get $478
+  local.get $296
   i32.const 5
   i32.const 2
   i32.const 8
   i32.const 1136
   call $~lib/rt/__newArray
-  local.set $478
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store offset=8
-  local.get $478
+  local.get $296
   i32.const 0
   call $std/array/isArraysEqual<u32>
   i32.eqz
@@ -34689,12 +34507,12 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $17
-  local.set $478
+  local.get $9
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store
-  local.get $478
+  local.get $296
   i32.const -1
   i32.const 0
   i32.const 1
@@ -34702,22 +34520,22 @@
   i32.const 0
   call $~lib/array/Array<u32>#fill@varargs
   drop
-  local.get $17
-  local.set $478
+  local.get $9
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store
-  local.get $478
+  local.get $296
   i32.const 5
   i32.const 2
   i32.const 8
   i32.const 1184
   call $~lib/rt/__newArray
-  local.set $478
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store offset=8
-  local.get $478
+  local.get $296
   i32.const 0
   call $std/array/isArraysEqual<u32>
   i32.eqz
@@ -34735,35 +34553,35 @@
   i32.const 9
   i32.const 1232
   call $~lib/rt/__newArray
-  local.tee $32
+  local.tee $17
   i32.store offset=16
-  local.get $32
-  local.set $478
+  local.get $17
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store
-  local.get $478
+  local.get $296
   f32.const 1
   i32.const 1
   i32.const 3
   call $~lib/array/Array<f32>#fill
   drop
-  local.get $32
-  local.set $478
+  local.get $17
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store
-  local.get $478
+  local.get $296
   i32.const 5
   i32.const 2
   i32.const 9
   i32.const 1280
   call $~lib/rt/__newArray
-  local.set $478
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store offset=8
-  local.get $478
+  local.get $296
   i32.const 0
   call $std/array/isArraysEqual<f32>
   i32.eqz
@@ -34775,12 +34593,12 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $32
-  local.set $478
+  local.get $17
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store
-  local.get $478
+  local.get $296
   f32.const 0
   i32.const 0
   i32.const 1
@@ -34788,22 +34606,22 @@
   i32.const 0
   call $~lib/array/Array<f32>#fill@varargs
   drop
-  local.get $32
-  local.set $478
+  local.get $17
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store
-  local.get $478
+  local.get $296
   i32.const 5
   i32.const 2
   i32.const 9
   i32.const 1328
   call $~lib/rt/__newArray
-  local.set $478
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store offset=8
-  local.get $478
+  local.get $296
   i32.const 0
   call $std/array/isArraysEqual<f32>
   i32.eqz
@@ -34815,33 +34633,33 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $32
-  local.set $478
+  local.get $17
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store
-  local.get $478
+  local.get $296
   f32.const 1
   i32.const 0
   i32.const -3
   call $~lib/array/Array<f32>#fill
   drop
-  local.get $32
-  local.set $478
+  local.get $17
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store
-  local.get $478
+  local.get $296
   i32.const 5
   i32.const 2
   i32.const 9
   i32.const 1376
   call $~lib/rt/__newArray
-  local.set $478
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store offset=8
-  local.get $478
+  local.get $296
   i32.const 0
   call $std/array/isArraysEqual<f32>
   i32.eqz
@@ -34853,12 +34671,12 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $32
-  local.set $478
+  local.get $17
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store
-  local.get $478
+  local.get $296
   f32.const 2
   i32.const -2
   i32.const 2
@@ -34866,22 +34684,22 @@
   i32.const 0
   call $~lib/array/Array<f32>#fill@varargs
   drop
-  local.get $32
-  local.set $478
+  local.get $17
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store
-  local.get $478
+  local.get $296
   i32.const 5
   i32.const 2
   i32.const 9
   i32.const 1424
   call $~lib/rt/__newArray
-  local.set $478
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store offset=8
-  local.get $478
+  local.get $296
   i32.const 0
   call $std/array/isArraysEqual<f32>
   i32.eqz
@@ -34893,33 +34711,33 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $32
-  local.set $478
+  local.get $17
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store
-  local.get $478
+  local.get $296
   f32.const 0
   i32.const 1
   i32.const 0
   call $~lib/array/Array<f32>#fill
   drop
-  local.get $32
-  local.set $478
+  local.get $17
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store
-  local.get $478
+  local.get $296
   i32.const 5
   i32.const 2
   i32.const 9
   i32.const 1472
   call $~lib/rt/__newArray
-  local.set $478
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store offset=8
-  local.get $478
+  local.get $296
   i32.const 0
   call $std/array/isArraysEqual<f32>
   i32.eqz
@@ -34931,12 +34749,12 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $32
-  local.set $478
+  local.get $17
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store
-  local.get $478
+  local.get $296
   f32.const -1
   i32.const 0
   i32.const 1
@@ -34944,22 +34762,22 @@
   i32.const 0
   call $~lib/array/Array<f32>#fill@varargs
   drop
-  local.get $32
-  local.set $478
+  local.get $17
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store
-  local.get $478
+  local.get $296
   i32.const 5
   i32.const 2
   i32.const 9
   i32.const 1520
   call $~lib/rt/__newArray
-  local.set $478
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store offset=8
-  local.get $478
+  local.get $296
   i32.const 0
   call $std/array/isArraysEqual<f32>
   i32.eqz
@@ -34971,12 +34789,12 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $32
-  local.set $478
+  local.get $17
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store
-  local.get $478
+  local.get $296
   f32.const -0
   i32.const 0
   i32.const 1
@@ -34984,22 +34802,22 @@
   i32.const 0
   call $~lib/array/Array<f32>#fill@varargs
   drop
-  local.get $32
-  local.set $478
+  local.get $17
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store
-  local.get $478
+  local.get $296
   i32.const 5
   i32.const 2
   i32.const 9
   i32.const 1568
   call $~lib/rt/__newArray
-  local.set $478
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store offset=8
-  local.get $478
+  local.get $296
   i32.const 0
   call $std/array/isArraysEqual<f32>
   i32.eqz
@@ -35012,11 +34830,11 @@
    unreachable
   end
   global.get $std/array/arr
-  local.set $478
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store
-  local.get $478
+  local.get $296
   call $~lib/array/Array<i32>#get:length
   i32.const 0
   i32.eq
@@ -35030,11 +34848,11 @@
    unreachable
   end
   global.get $std/array/arr
-  local.set $478
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store
-  local.get $478
+  local.get $296
   call $std/array/internalCapacity<i32>
   i32.const 8
   i32.eq
@@ -35048,20 +34866,20 @@
    unreachable
   end
   global.get $std/array/arr
-  local.set $478
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store
-  local.get $478
+  local.get $296
   i32.const 42
   call $~lib/array/Array<i32>#push
   drop
   global.get $std/array/arr
-  local.set $478
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store
-  local.get $478
+  local.get $296
   i32.const 0
   call $~lib/array/Array<i32>#__get
   i32.const 42
@@ -35076,11 +34894,11 @@
    unreachable
   end
   global.get $std/array/arr
-  local.set $478
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store
-  local.get $478
+  local.get $296
   call $~lib/array/Array<i32>#get:length
   i32.const 1
   i32.eq
@@ -35094,11 +34912,11 @@
    unreachable
   end
   global.get $std/array/arr
-  local.set $478
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store
-  local.get $478
+  local.get $296
   call $std/array/internalCapacity<i32>
   i32.const 8
   i32.eq
@@ -35112,14 +34930,14 @@
    unreachable
   end
   global.get $std/array/arr
-  local.set $478
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store
-  local.get $478
+  local.get $296
   call $~lib/array/Array<i32>#pop
-  local.set $47
-  local.get $47
+  local.set $25
+  local.get $25
   i32.const 42
   i32.eq
   i32.eqz
@@ -35132,11 +34950,11 @@
    unreachable
   end
   global.get $std/array/arr
-  local.set $478
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store
-  local.get $478
+  local.get $296
   call $~lib/array/Array<i32>#get:length
   i32.const 0
   i32.eq
@@ -35150,11 +34968,11 @@
    unreachable
   end
   global.get $std/array/arr
-  local.set $478
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store
-  local.get $478
+  local.get $296
   call $std/array/internalCapacity<i32>
   i32.const 8
   i32.eq
@@ -35168,20 +34986,20 @@
    unreachable
   end
   global.get $std/array/arr
-  local.set $478
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store
-  local.get $478
+  local.get $296
   i32.const 43
   call $~lib/array/Array<i32>#push
   drop
   global.get $std/array/arr
-  local.set $478
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store
-  local.get $478
+  local.get $296
   call $~lib/array/Array<i32>#get:length
   i32.const 1
   i32.eq
@@ -35195,11 +35013,11 @@
    unreachable
   end
   global.get $std/array/arr
-  local.set $478
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store
-  local.get $478
+  local.get $296
   call $std/array/internalCapacity<i32>
   i32.const 8
   i32.eq
@@ -35213,11 +35031,11 @@
    unreachable
   end
   global.get $std/array/arr
-  local.set $478
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store
-  local.get $478
+  local.get $296
   i32.const 0
   call $~lib/array/Array<i32>#__get
   i32.const 43
@@ -35232,20 +35050,20 @@
    unreachable
   end
   global.get $std/array/arr
-  local.set $478
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store
-  local.get $478
+  local.get $296
   i32.const 44
   call $~lib/array/Array<i32>#push
   drop
   global.get $std/array/arr
-  local.set $478
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store
-  local.get $478
+  local.get $296
   call $~lib/array/Array<i32>#get:length
   i32.const 2
   i32.eq
@@ -35259,11 +35077,11 @@
    unreachable
   end
   global.get $std/array/arr
-  local.set $478
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store
-  local.get $478
+  local.get $296
   call $std/array/internalCapacity<i32>
   i32.const 8
   i32.eq
@@ -35277,11 +35095,11 @@
    unreachable
   end
   global.get $std/array/arr
-  local.set $478
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store
-  local.get $478
+  local.get $296
   i32.const 0
   call $~lib/array/Array<i32>#__get
   i32.const 43
@@ -35296,11 +35114,11 @@
    unreachable
   end
   global.get $std/array/arr
-  local.set $478
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store
-  local.get $478
+  local.get $296
   i32.const 1
   call $~lib/array/Array<i32>#__get
   i32.const 44
@@ -35315,20 +35133,20 @@
    unreachable
   end
   global.get $std/array/arr
-  local.set $478
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store
-  local.get $478
+  local.get $296
   i32.const 45
   call $~lib/array/Array<i32>#push
   drop
   global.get $std/array/arr
-  local.set $478
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store
-  local.get $478
+  local.get $296
   call $~lib/array/Array<i32>#get:length
   i32.const 3
   i32.eq
@@ -35342,11 +35160,11 @@
    unreachable
   end
   global.get $std/array/arr
-  local.set $478
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store
-  local.get $478
+  local.get $296
   call $std/array/internalCapacity<i32>
   i32.const 8
   i32.eq
@@ -35360,11 +35178,11 @@
    unreachable
   end
   global.get $std/array/arr
-  local.set $478
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store
-  local.get $478
+  local.get $296
   i32.const 0
   call $~lib/array/Array<i32>#__get
   i32.const 43
@@ -35379,11 +35197,11 @@
    unreachable
   end
   global.get $std/array/arr
-  local.set $478
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store
-  local.get $478
+  local.get $296
   i32.const 1
   call $~lib/array/Array<i32>#__get
   i32.const 44
@@ -35398,11 +35216,11 @@
    unreachable
   end
   global.get $std/array/arr
-  local.set $478
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store
-  local.get $478
+  local.get $296
   i32.const 2
   call $~lib/array/Array<i32>#__get
   i32.const 45
@@ -35423,42 +35241,37 @@
   i32.const 10
   i32.const 0
   call $~lib/rt/__newArray
-  local.tee $48
+  local.tee $26
   i32.store offset=20
-  global.get $~lib/memory/__stack_pointer
-  local.get $48
-  i32.load offset=4
-  local.tee $49
-  i32.store offset=24
-  local.get $48
+  local.get $26
   i32.const 0
   i32.const 0
   i32.const 0
   call $std/array/Ref#constructor
   call $~lib/array/Array<std/array/Ref>#__set
-  local.get $48
+  local.get $26
   i32.const 1
   i32.const 0
   i32.const 0
   call $std/array/Ref#constructor
   call $~lib/array/Array<std/array/Ref>#__set
-  local.get $48
-  local.tee $50
-  i32.store offset=28
-  local.get $50
-  local.set $478
+  local.get $26
+  local.tee $27
+  i32.store offset=24
+  local.get $27
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store
-  local.get $478
+  local.get $296
   i32.const 0
   call $~lib/array/Array<std/array/Ref>#set:length
-  local.get $50
-  local.set $478
+  local.get $27
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store
-  local.get $478
+  local.get $296
   call $~lib/array/Array<std/array/Ref>#get:length
   i32.const 0
   i32.eq
@@ -35477,14 +35290,14 @@
   i32.const 4
   i32.const 1664
   call $~lib/rt/__newArray
-  local.tee $53
-  i32.store offset=32
-  local.get $53
-  local.set $478
+  local.tee $29
+  i32.store offset=28
+  local.get $29
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store
-  local.get $478
+  local.get $296
   i32.const 0
   call $~lib/array/Array<i32>#at
   i32.const 1
@@ -35498,12 +35311,12 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $53
-  local.set $478
+  local.get $29
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store
-  local.get $478
+  local.get $296
   i32.const 3
   call $~lib/array/Array<i32>#at
   i32.const 4
@@ -35517,12 +35330,12 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $53
-  local.set $478
+  local.get $29
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store
-  local.get $478
+  local.get $296
   i32.const -1
   call $~lib/array/Array<i32>#at
   i32.const 4
@@ -35536,12 +35349,12 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $53
-  local.set $478
+  local.get $29
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store
-  local.get $478
+  local.get $296
   i32.const -4
   call $~lib/array/Array<i32>#at
   i32.const 1
@@ -35559,30 +35372,30 @@
   i32.const 0
   i32.const 0
   call $~lib/array/Array<i32>#constructor
-  local.tee $54
-  i32.store offset=36
+  local.tee $30
+  i32.store offset=32
   global.get $~lib/memory/__stack_pointer
   global.get $std/array/arr
-  local.set $478
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store
-  local.get $478
-  local.get $54
-  local.set $478
+  local.get $296
+  local.get $30
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store offset=8
-  local.get $478
+  local.get $296
   call $~lib/array/Array<i32>#concat
-  local.tee $55
-  i32.store offset=40
+  local.tee $31
+  i32.store offset=36
   global.get $std/array/arr
-  local.set $478
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store
-  local.get $478
+  local.get $296
   call $std/array/internalCapacity<i32>
   i32.const 8
   i32.eq
@@ -35596,11 +35409,11 @@
    unreachable
   end
   global.get $std/array/arr
-  local.set $478
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store
-  local.get $478
+  local.get $296
   call $~lib/array/Array<i32>#get:length
   i32.const 3
   i32.eq
@@ -35613,12 +35426,12 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $55
-  local.set $478
+  local.get $31
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store
-  local.get $478
+  local.get $296
   call $~lib/array/Array<i32>#get:length
   i32.const 3
   i32.eq
@@ -35631,30 +35444,30 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $55
-  local.set $478
+  local.get $31
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store
-  local.get $478
+  local.get $296
   i32.const 0
   i32.const 2
   i32.const 4
   i32.const 1712
   call $~lib/rt/__newArray
-  local.set $478
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store offset=8
-  local.get $478
+  local.get $296
   call $~lib/array/Array<i32>#concat
   drop
   global.get $std/array/arr
-  local.set $478
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store
-  local.get $478
+  local.get $296
   call $std/array/internalCapacity<i32>
   i32.const 8
   i32.eq
@@ -35667,12 +35480,12 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $55
-  local.set $478
+  local.get $31
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store
-  local.get $478
+  local.get $296
   i32.const 0
   call $~lib/array/Array<i32>#__get
   i32.const 43
@@ -35686,12 +35499,12 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $55
-  local.set $478
+  local.get $31
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store
-  local.get $478
+  local.get $296
   i32.const 1
   call $~lib/array/Array<i32>#__get
   i32.const 44
@@ -35705,12 +35518,12 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $55
-  local.set $478
+  local.get $31
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store
-  local.get $478
+  local.get $296
   i32.const 2
   call $~lib/array/Array<i32>#__get
   i32.const 45
@@ -35724,46 +35537,46 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $54
-  local.set $478
+  local.get $30
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store
-  local.get $478
+  local.get $296
   i32.const 46
   call $~lib/array/Array<i32>#push
   drop
-  local.get $54
-  local.set $478
+  local.get $30
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store
-  local.get $478
+  local.get $296
   i32.const 47
   call $~lib/array/Array<i32>#push
   drop
   global.get $~lib/memory/__stack_pointer
   global.get $std/array/arr
-  local.set $478
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store
-  local.get $478
-  local.get $54
-  local.set $478
+  local.get $296
+  local.get $30
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store offset=8
-  local.get $478
+  local.get $296
   call $~lib/array/Array<i32>#concat
-  local.tee $55
-  i32.store offset=40
+  local.tee $31
+  i32.store offset=36
   global.get $std/array/arr
-  local.set $478
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store
-  local.get $478
+  local.get $296
   call $std/array/internalCapacity<i32>
   i32.const 8
   i32.eq
@@ -35776,12 +35589,12 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $54
-  local.set $478
+  local.get $30
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store
-  local.get $478
+  local.get $296
   call $~lib/array/Array<i32>#get:length
   i32.const 2
   i32.eq
@@ -35794,12 +35607,12 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $55
-  local.set $478
+  local.get $31
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store
-  local.get $478
+  local.get $296
   call $~lib/array/Array<i32>#get:length
   i32.const 5
   i32.eq
@@ -35812,12 +35625,12 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $55
-  local.set $478
+  local.get $31
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store
-  local.get $478
+  local.get $296
   i32.const 0
   call $~lib/array/Array<i32>#__get
   i32.const 43
@@ -35831,12 +35644,12 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $55
-  local.set $478
+  local.get $31
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store
-  local.get $478
+  local.get $296
   i32.const 1
   call $~lib/array/Array<i32>#__get
   i32.const 44
@@ -35850,12 +35663,12 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $55
-  local.set $478
+  local.get $31
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store
-  local.get $478
+  local.get $296
   i32.const 2
   call $~lib/array/Array<i32>#__get
   i32.const 45
@@ -35869,12 +35682,12 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $55
-  local.set $478
+  local.get $31
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store
-  local.get $478
+  local.get $296
   i32.const 3
   call $~lib/array/Array<i32>#__get
   i32.const 46
@@ -35888,12 +35701,12 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $55
-  local.set $478
+  local.get $31
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store
-  local.get $478
+  local.get $296
   i32.const 4
   call $~lib/array/Array<i32>#__get
   i32.const 47
@@ -35907,20 +35720,20 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $55
-  local.set $478
+  local.get $31
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store
-  local.get $478
+  local.get $296
   call $~lib/array/Array<i32>#pop
   drop
-  local.get $55
-  local.set $478
+  local.get $31
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store
-  local.get $478
+  local.get $296
   call $~lib/array/Array<i32>#get:length
   i32.const 4
   i32.eq
@@ -35939,14 +35752,14 @@
   i32.const 4
   i32.const 1744
   call $~lib/rt/__newArray
-  local.tee $60
-  i32.store offset=44
-  local.get $60
-  local.set $478
+  local.tee $34
+  i32.store offset=40
+  local.get $34
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store
-  local.get $478
+  local.get $296
   call $~lib/array/Array<i32>#get:length
   i32.const 0
   i32.eq
@@ -35960,27 +35773,27 @@
    unreachable
   end
   global.get $~lib/memory/__stack_pointer
-  local.get $60
-  local.set $478
+  local.get $34
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store
-  local.get $478
+  local.get $296
   global.get $std/array/arr
-  local.set $478
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store offset=8
-  local.get $478
+  local.get $296
   call $~lib/array/Array<i32>#concat
-  local.tee $55
-  i32.store offset=40
-  local.get $55
-  local.set $478
+  local.tee $31
+  i32.store offset=36
+  local.get $31
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store
-  local.get $478
+  local.get $296
   call $~lib/array/Array<i32>#get:length
   i32.const 3
   i32.eq
@@ -35993,12 +35806,12 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $60
-  local.set $478
+  local.get $34
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store
-  local.get $478
+  local.get $296
   call $~lib/array/Array<i32>#get:length
   i32.const 0
   i32.eq
@@ -36017,35 +35830,35 @@
   i32.const 4
   i32.const 1776
   call $~lib/rt/__newArray
-  local.tee $63
-  i32.store offset=48
-  local.get $63
-  local.set $478
+  local.tee $36
+  i32.store offset=44
+  local.get $36
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
-  i32.store offset=52
-  local.get $478
+  local.get $296
+  i32.store offset=48
+  local.get $296
   i32.const 0
   i32.const 3
   i32.const 2
   global.set $~argumentsLength
   i32.const 0
   call $~lib/array/Array<i32>#copyWithin@varargs
-  local.set $478
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store
-  local.get $478
+  local.get $296
   i32.const 5
   i32.const 2
   i32.const 4
   i32.const 1824
   call $~lib/rt/__newArray
-  local.set $478
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store offset=8
-  local.get $478
+  local.get $296
   i32.const 0
   call $std/array/isArraysEqual<i32>
   i32.eqz
@@ -36063,35 +35876,35 @@
   i32.const 4
   i32.const 1872
   call $~lib/rt/__newArray
-  local.tee $63
-  i32.store offset=48
-  local.get $63
-  local.set $478
+  local.tee $36
+  i32.store offset=44
+  local.get $36
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
-  i32.store offset=52
-  local.get $478
+  local.get $296
+  i32.store offset=48
+  local.get $296
   i32.const 1
   i32.const 3
   i32.const 2
   global.set $~argumentsLength
   i32.const 0
   call $~lib/array/Array<i32>#copyWithin@varargs
-  local.set $478
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store
-  local.get $478
+  local.get $296
   i32.const 5
   i32.const 2
   i32.const 4
   i32.const 1920
   call $~lib/rt/__newArray
-  local.set $478
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store offset=8
-  local.get $478
+  local.get $296
   i32.const 0
   call $std/array/isArraysEqual<i32>
   i32.eqz
@@ -36109,35 +35922,35 @@
   i32.const 4
   i32.const 1968
   call $~lib/rt/__newArray
-  local.tee $63
-  i32.store offset=48
-  local.get $63
-  local.set $478
+  local.tee $36
+  i32.store offset=44
+  local.get $36
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
-  i32.store offset=52
-  local.get $478
+  local.get $296
+  i32.store offset=48
+  local.get $296
   i32.const 1
   i32.const 2
   i32.const 2
   global.set $~argumentsLength
   i32.const 0
   call $~lib/array/Array<i32>#copyWithin@varargs
-  local.set $478
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store
-  local.get $478
+  local.get $296
   i32.const 5
   i32.const 2
   i32.const 4
   i32.const 2016
   call $~lib/rt/__newArray
-  local.set $478
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store offset=8
-  local.get $478
+  local.get $296
   i32.const 0
   call $std/array/isArraysEqual<i32>
   i32.eqz
@@ -36155,35 +35968,35 @@
   i32.const 4
   i32.const 2064
   call $~lib/rt/__newArray
-  local.tee $63
-  i32.store offset=48
-  local.get $63
-  local.set $478
+  local.tee $36
+  i32.store offset=44
+  local.get $36
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
-  i32.store offset=52
-  local.get $478
+  local.get $296
+  i32.store offset=48
+  local.get $296
   i32.const 2
   i32.const 2
   i32.const 2
   global.set $~argumentsLength
   i32.const 0
   call $~lib/array/Array<i32>#copyWithin@varargs
-  local.set $478
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store
-  local.get $478
+  local.get $296
   i32.const 5
   i32.const 2
   i32.const 4
   i32.const 2112
   call $~lib/rt/__newArray
-  local.set $478
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store offset=8
-  local.get $478
+  local.get $296
   i32.const 0
   call $std/array/isArraysEqual<i32>
   i32.eqz
@@ -36201,33 +36014,33 @@
   i32.const 4
   i32.const 2160
   call $~lib/rt/__newArray
-  local.tee $63
-  i32.store offset=48
-  local.get $63
-  local.set $478
+  local.tee $36
+  i32.store offset=44
+  local.get $36
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
-  i32.store offset=52
-  local.get $478
+  local.get $296
+  i32.store offset=48
+  local.get $296
   i32.const 0
   i32.const 3
   i32.const 4
   call $~lib/array/Array<i32>#copyWithin
-  local.set $478
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store
-  local.get $478
+  local.get $296
   i32.const 5
   i32.const 2
   i32.const 4
   i32.const 2208
   call $~lib/rt/__newArray
-  local.set $478
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store offset=8
-  local.get $478
+  local.get $296
   i32.const 0
   call $std/array/isArraysEqual<i32>
   i32.eqz
@@ -36245,33 +36058,33 @@
   i32.const 4
   i32.const 2256
   call $~lib/rt/__newArray
-  local.tee $63
-  i32.store offset=48
-  local.get $63
-  local.set $478
+  local.tee $36
+  i32.store offset=44
+  local.get $36
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
-  i32.store offset=52
-  local.get $478
+  local.get $296
+  i32.store offset=48
+  local.get $296
   i32.const 1
   i32.const 3
   i32.const 4
   call $~lib/array/Array<i32>#copyWithin
-  local.set $478
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store
-  local.get $478
+  local.get $296
   i32.const 5
   i32.const 2
   i32.const 4
   i32.const 2304
   call $~lib/rt/__newArray
-  local.set $478
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store offset=8
-  local.get $478
+  local.get $296
   i32.const 0
   call $std/array/isArraysEqual<i32>
   i32.eqz
@@ -36289,33 +36102,33 @@
   i32.const 4
   i32.const 2352
   call $~lib/rt/__newArray
-  local.tee $63
-  i32.store offset=48
-  local.get $63
-  local.set $478
+  local.tee $36
+  i32.store offset=44
+  local.get $36
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
-  i32.store offset=52
-  local.get $478
+  local.get $296
+  i32.store offset=48
+  local.get $296
   i32.const 1
   i32.const 2
   i32.const 4
   call $~lib/array/Array<i32>#copyWithin
-  local.set $478
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store
-  local.get $478
+  local.get $296
   i32.const 5
   i32.const 2
   i32.const 4
   i32.const 2400
   call $~lib/rt/__newArray
-  local.set $478
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store offset=8
-  local.get $478
+  local.get $296
   i32.const 0
   call $std/array/isArraysEqual<i32>
   i32.eqz
@@ -36333,35 +36146,35 @@
   i32.const 4
   i32.const 2448
   call $~lib/rt/__newArray
-  local.tee $63
-  i32.store offset=48
-  local.get $63
-  local.set $478
+  local.tee $36
+  i32.store offset=44
+  local.get $36
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
-  i32.store offset=52
-  local.get $478
+  local.get $296
+  i32.store offset=48
+  local.get $296
   i32.const 0
   i32.const -2
   i32.const 2
   global.set $~argumentsLength
   i32.const 0
   call $~lib/array/Array<i32>#copyWithin@varargs
-  local.set $478
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store
-  local.get $478
+  local.get $296
   i32.const 5
   i32.const 2
   i32.const 4
   i32.const 2496
   call $~lib/rt/__newArray
-  local.set $478
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store offset=8
-  local.get $478
+  local.get $296
   i32.const 0
   call $std/array/isArraysEqual<i32>
   i32.eqz
@@ -36379,33 +36192,33 @@
   i32.const 4
   i32.const 2544
   call $~lib/rt/__newArray
-  local.tee $63
-  i32.store offset=48
-  local.get $63
-  local.set $478
+  local.tee $36
+  i32.store offset=44
+  local.get $36
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
-  i32.store offset=52
-  local.get $478
+  local.get $296
+  i32.store offset=48
+  local.get $296
   i32.const 0
   i32.const -2
   i32.const -1
   call $~lib/array/Array<i32>#copyWithin
-  local.set $478
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store
-  local.get $478
+  local.get $296
   i32.const 5
   i32.const 2
   i32.const 4
   i32.const 2592
   call $~lib/rt/__newArray
-  local.set $478
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store offset=8
-  local.get $478
+  local.get $296
   i32.const 0
   call $std/array/isArraysEqual<i32>
   i32.eqz
@@ -36423,33 +36236,33 @@
   i32.const 4
   i32.const 2640
   call $~lib/rt/__newArray
-  local.tee $63
-  i32.store offset=48
-  local.get $63
-  local.set $478
+  local.tee $36
+  i32.store offset=44
+  local.get $36
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
-  i32.store offset=52
-  local.get $478
+  local.get $296
+  i32.store offset=48
+  local.get $296
   i32.const -4
   i32.const -3
   i32.const -2
   call $~lib/array/Array<i32>#copyWithin
-  local.set $478
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store
-  local.get $478
+  local.get $296
   i32.const 5
   i32.const 2
   i32.const 4
   i32.const 2688
   call $~lib/rt/__newArray
-  local.set $478
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store offset=8
-  local.get $478
+  local.get $296
   i32.const 0
   call $std/array/isArraysEqual<i32>
   i32.eqz
@@ -36467,33 +36280,33 @@
   i32.const 4
   i32.const 2736
   call $~lib/rt/__newArray
-  local.tee $63
-  i32.store offset=48
-  local.get $63
-  local.set $478
+  local.tee $36
+  i32.store offset=44
+  local.get $36
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
-  i32.store offset=52
-  local.get $478
+  local.get $296
+  i32.store offset=48
+  local.get $296
   i32.const -4
   i32.const -3
   i32.const -1
   call $~lib/array/Array<i32>#copyWithin
-  local.set $478
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store
-  local.get $478
+  local.get $296
   i32.const 5
   i32.const 2
   i32.const 4
   i32.const 2784
   call $~lib/rt/__newArray
-  local.set $478
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store offset=8
-  local.get $478
+  local.get $296
   i32.const 0
   call $std/array/isArraysEqual<i32>
   i32.eqz
@@ -36511,35 +36324,35 @@
   i32.const 4
   i32.const 2832
   call $~lib/rt/__newArray
-  local.tee $63
-  i32.store offset=48
-  local.get $63
-  local.set $478
+  local.tee $36
+  i32.store offset=44
+  local.get $36
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
-  i32.store offset=52
-  local.get $478
+  local.get $296
+  i32.store offset=48
+  local.get $296
   i32.const -4
   i32.const -3
   i32.const 2
   global.set $~argumentsLength
   i32.const 0
   call $~lib/array/Array<i32>#copyWithin@varargs
-  local.set $478
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store
-  local.get $478
+  local.get $296
   i32.const 5
   i32.const 2
   i32.const 4
   i32.const 2880
   call $~lib/rt/__newArray
-  local.set $478
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store offset=8
-  local.get $478
+  local.get $296
   i32.const 0
   call $std/array/isArraysEqual<i32>
   i32.eqz
@@ -36552,20 +36365,20 @@
    unreachable
   end
   global.get $std/array/arr
-  local.set $478
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store
-  local.get $478
+  local.get $296
   i32.const 42
   call $~lib/array/Array<i32>#unshift
   drop
   global.get $std/array/arr
-  local.set $478
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store
-  local.get $478
+  local.get $296
   call $~lib/array/Array<i32>#get:length
   i32.const 4
   i32.eq
@@ -36579,11 +36392,11 @@
    unreachable
   end
   global.get $std/array/arr
-  local.set $478
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store
-  local.get $478
+  local.get $296
   call $std/array/internalCapacity<i32>
   i32.const 8
   i32.eq
@@ -36597,11 +36410,11 @@
    unreachable
   end
   global.get $std/array/arr
-  local.set $478
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store
-  local.get $478
+  local.get $296
   i32.const 0
   call $~lib/array/Array<i32>#__get
   i32.const 42
@@ -36616,11 +36429,11 @@
    unreachable
   end
   global.get $std/array/arr
-  local.set $478
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store
-  local.get $478
+  local.get $296
   i32.const 1
   call $~lib/array/Array<i32>#__get
   i32.const 43
@@ -36635,11 +36448,11 @@
    unreachable
   end
   global.get $std/array/arr
-  local.set $478
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store
-  local.get $478
+  local.get $296
   i32.const 2
   call $~lib/array/Array<i32>#__get
   i32.const 44
@@ -36654,11 +36467,11 @@
    unreachable
   end
   global.get $std/array/arr
-  local.set $478
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store
-  local.get $478
+  local.get $296
   i32.const 3
   call $~lib/array/Array<i32>#__get
   i32.const 45
@@ -36673,20 +36486,20 @@
    unreachable
   end
   global.get $std/array/arr
-  local.set $478
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store
-  local.get $478
+  local.get $296
   i32.const 41
   call $~lib/array/Array<i32>#unshift
   drop
   global.get $std/array/arr
-  local.set $478
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store
-  local.get $478
+  local.get $296
   call $~lib/array/Array<i32>#get:length
   i32.const 5
   i32.eq
@@ -36700,11 +36513,11 @@
    unreachable
   end
   global.get $std/array/arr
-  local.set $478
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store
-  local.get $478
+  local.get $296
   call $std/array/internalCapacity<i32>
   i32.const 8
   i32.eq
@@ -36718,11 +36531,11 @@
    unreachable
   end
   global.get $std/array/arr
-  local.set $478
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store
-  local.get $478
+  local.get $296
   i32.const 0
   call $~lib/array/Array<i32>#__get
   i32.const 41
@@ -36737,11 +36550,11 @@
    unreachable
   end
   global.get $std/array/arr
-  local.set $478
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store
-  local.get $478
+  local.get $296
   i32.const 1
   call $~lib/array/Array<i32>#__get
   i32.const 42
@@ -36756,11 +36569,11 @@
    unreachable
   end
   global.get $std/array/arr
-  local.set $478
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store
-  local.get $478
+  local.get $296
   i32.const 2
   call $~lib/array/Array<i32>#__get
   i32.const 43
@@ -36775,11 +36588,11 @@
    unreachable
   end
   global.get $std/array/arr
-  local.set $478
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store
-  local.get $478
+  local.get $296
   i32.const 3
   call $~lib/array/Array<i32>#__get
   i32.const 44
@@ -36794,11 +36607,11 @@
    unreachable
   end
   global.get $std/array/arr
-  local.set $478
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store
-  local.get $478
+  local.get $296
   i32.const 4
   call $~lib/array/Array<i32>#__get
   i32.const 45
@@ -36813,11 +36626,11 @@
    unreachable
   end
   global.get $std/array/arr
-  local.set $478
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store
-  local.get $478
+  local.get $296
   call $~lib/array/Array<i32>#shift
   global.set $std/array/i
   global.get $std/array/i
@@ -36833,11 +36646,11 @@
    unreachable
   end
   global.get $std/array/arr
-  local.set $478
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store
-  local.get $478
+  local.get $296
   call $~lib/array/Array<i32>#get:length
   i32.const 4
   i32.eq
@@ -36851,11 +36664,11 @@
    unreachable
   end
   global.get $std/array/arr
-  local.set $478
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store
-  local.get $478
+  local.get $296
   call $std/array/internalCapacity<i32>
   i32.const 8
   i32.eq
@@ -36869,11 +36682,11 @@
    unreachable
   end
   global.get $std/array/arr
-  local.set $478
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store
-  local.get $478
+  local.get $296
   i32.const 0
   call $~lib/array/Array<i32>#__get
   i32.const 42
@@ -36888,11 +36701,11 @@
    unreachable
   end
   global.get $std/array/arr
-  local.set $478
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store
-  local.get $478
+  local.get $296
   i32.const 1
   call $~lib/array/Array<i32>#__get
   i32.const 43
@@ -36907,11 +36720,11 @@
    unreachable
   end
   global.get $std/array/arr
-  local.set $478
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store
-  local.get $478
+  local.get $296
   i32.const 2
   call $~lib/array/Array<i32>#__get
   i32.const 44
@@ -36926,11 +36739,11 @@
    unreachable
   end
   global.get $std/array/arr
-  local.set $478
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store
-  local.get $478
+  local.get $296
   i32.const 3
   call $~lib/array/Array<i32>#__get
   i32.const 45
@@ -36945,11 +36758,11 @@
    unreachable
   end
   global.get $std/array/arr
-  local.set $478
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store
-  local.get $478
+  local.get $296
   call $~lib/array/Array<i32>#pop
   global.set $std/array/i
   global.get $std/array/i
@@ -36965,11 +36778,11 @@
    unreachable
   end
   global.get $std/array/arr
-  local.set $478
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store
-  local.get $478
+  local.get $296
   call $~lib/array/Array<i32>#get:length
   i32.const 3
   i32.eq
@@ -36983,11 +36796,11 @@
    unreachable
   end
   global.get $std/array/arr
-  local.set $478
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store
-  local.get $478
+  local.get $296
   call $std/array/internalCapacity<i32>
   i32.const 8
   i32.eq
@@ -37001,11 +36814,11 @@
    unreachable
   end
   global.get $std/array/arr
-  local.set $478
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store
-  local.get $478
+  local.get $296
   i32.const 0
   call $~lib/array/Array<i32>#__get
   i32.const 42
@@ -37020,11 +36833,11 @@
    unreachable
   end
   global.get $std/array/arr
-  local.set $478
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store
-  local.get $478
+  local.get $296
   i32.const 1
   call $~lib/array/Array<i32>#__get
   i32.const 43
@@ -37039,11 +36852,11 @@
    unreachable
   end
   global.get $std/array/arr
-  local.set $478
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store
-  local.get $478
+  local.get $296
   i32.const 2
   call $~lib/array/Array<i32>#__get
   i32.const 44
@@ -37063,38 +36876,38 @@
   i32.const 4
   i32.const 2928
   call $~lib/rt/__newArray
-  local.tee $113
-  i32.store offset=56
+  local.tee $62
+  i32.store offset=52
   global.get $~lib/memory/__stack_pointer
-  local.get $113
-  local.set $478
+  local.get $62
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store
-  local.get $478
+  local.get $296
   i32.const 2
   i32.const 1
   global.set $~argumentsLength
   i32.const 0
   call $~lib/array/Array<i32>#slice@varargs
-  local.tee $110
-  i32.store offset=60
-  local.get $110
-  local.set $478
+  local.tee $60
+  i32.store offset=56
+  local.get $60
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store
-  local.get $478
+  local.get $296
   i32.const 3
   i32.const 2
   i32.const 4
   i32.const 2976
   call $~lib/rt/__newArray
-  local.set $478
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store offset=8
-  local.get $478
+  local.get $296
   i32.const 0
   call $std/array/isArraysEqual<i32>
   i32.eqz
@@ -37107,33 +36920,33 @@
    unreachable
   end
   global.get $~lib/memory/__stack_pointer
-  local.get $113
-  local.set $478
+  local.get $62
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store
-  local.get $478
+  local.get $296
   i32.const 2
   i32.const 4
   call $~lib/array/Array<i32>#slice
-  local.tee $110
-  i32.store offset=60
-  local.get $110
-  local.set $478
+  local.tee $60
+  i32.store offset=56
+  local.get $60
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store
-  local.get $478
+  local.get $296
   i32.const 2
   i32.const 2
   i32.const 4
   i32.const 3008
   call $~lib/rt/__newArray
-  local.set $478
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store offset=8
-  local.get $478
+  local.get $296
   i32.const 0
   call $std/array/isArraysEqual<i32>
   i32.eqz
@@ -37146,33 +36959,33 @@
    unreachable
   end
   global.get $~lib/memory/__stack_pointer
-  local.get $113
-  local.set $478
+  local.get $62
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store
-  local.get $478
+  local.get $296
   i32.const 1
   i32.const 5
   call $~lib/array/Array<i32>#slice
-  local.tee $110
-  i32.store offset=60
-  local.get $110
-  local.set $478
+  local.tee $60
+  i32.store offset=56
+  local.get $60
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store
-  local.get $478
+  local.get $296
   i32.const 4
   i32.const 2
   i32.const 4
   i32.const 3040
   call $~lib/rt/__newArray
-  local.set $478
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store offset=8
-  local.get $478
+  local.get $296
   i32.const 0
   call $std/array/isArraysEqual<i32>
   i32.eqz
@@ -37185,31 +36998,31 @@
    unreachable
   end
   global.get $~lib/memory/__stack_pointer
-  local.get $113
-  local.set $478
+  local.get $62
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store
-  local.get $478
+  local.get $296
   i32.const 0
   i32.const 0
   global.set $~argumentsLength
   i32.const 0
   call $~lib/array/Array<i32>#slice@varargs
-  local.tee $110
-  i32.store offset=60
-  local.get $110
-  local.set $478
+  local.tee $60
+  i32.store offset=56
+  local.get $60
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store
-  local.get $478
-  local.get $113
-  local.set $478
+  local.get $296
+  local.get $62
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store offset=8
-  local.get $478
+  local.get $296
   i32.const 0
   call $std/array/isArraysEqual<i32>
   i32.eqz
@@ -37222,35 +37035,35 @@
    unreachable
   end
   global.get $~lib/memory/__stack_pointer
-  local.get $113
-  local.set $478
+  local.get $62
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store
-  local.get $478
+  local.get $296
   i32.const -2
   i32.const 1
   global.set $~argumentsLength
   i32.const 0
   call $~lib/array/Array<i32>#slice@varargs
-  local.tee $110
-  i32.store offset=60
-  local.get $110
-  local.set $478
+  local.tee $60
+  i32.store offset=56
+  local.get $60
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store
-  local.get $478
+  local.get $296
   i32.const 2
   i32.const 2
   i32.const 4
   i32.const 3088
   call $~lib/rt/__newArray
-  local.set $478
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store offset=8
-  local.get $478
+  local.get $296
   i32.const 0
   call $std/array/isArraysEqual<i32>
   i32.eqz
@@ -37263,33 +37076,33 @@
    unreachable
   end
   global.get $~lib/memory/__stack_pointer
-  local.get $113
-  local.set $478
+  local.get $62
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store
-  local.get $478
+  local.get $296
   i32.const 2
   i32.const -1
   call $~lib/array/Array<i32>#slice
-  local.tee $110
-  i32.store offset=60
-  local.get $110
-  local.set $478
+  local.tee $60
+  i32.store offset=56
+  local.get $60
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store
-  local.get $478
+  local.get $296
   i32.const 2
   i32.const 2
   i32.const 4
   i32.const 3120
   call $~lib/rt/__newArray
-  local.set $478
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store offset=8
-  local.get $478
+  local.get $296
   i32.const 0
   call $std/array/isArraysEqual<i32>
   i32.eqz
@@ -37302,33 +37115,33 @@
    unreachable
   end
   global.get $~lib/memory/__stack_pointer
-  local.get $113
-  local.set $478
+  local.get $62
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store
-  local.get $478
+  local.get $296
   i32.const -3
   i32.const -1
   call $~lib/array/Array<i32>#slice
-  local.tee $110
-  i32.store offset=60
-  local.get $110
-  local.set $478
+  local.tee $60
+  i32.store offset=56
+  local.get $60
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store
-  local.get $478
+  local.get $296
   i32.const 2
   i32.const 2
   i32.const 4
   i32.const 3152
   call $~lib/rt/__newArray
-  local.set $478
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store offset=8
-  local.get $478
+  local.get $296
   i32.const 0
   call $std/array/isArraysEqual<i32>
   i32.eqz
@@ -37340,20 +37153,20 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $113
-  local.set $478
+  local.get $62
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store offset=8
-  local.get $478
+  local.get $296
   i32.const -1
   i32.const -3
   call $~lib/array/Array<i32>#slice
-  local.set $478
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store
-  local.get $478
+  local.get $296
   call $~lib/array/Array<i32>#get:length
   i32.const 0
   i32.eq
@@ -37366,22 +37179,22 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $113
-  local.set $478
+  local.get $62
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store offset=8
-  local.get $478
+  local.get $296
   i32.const 10
   i32.const 1
   global.set $~argumentsLength
   i32.const 0
   call $~lib/array/Array<i32>#slice@varargs
-  local.set $478
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store
-  local.get $478
+  local.get $296
   call $~lib/array/Array<i32>#get:length
   i32.const 0
   i32.eq
@@ -37395,19 +37208,19 @@
    unreachable
   end
   global.get $std/array/arr
-  local.set $478
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store
-  local.get $478
+  local.get $296
   call $~lib/array/Array<i32>#reverse
   drop
   global.get $std/array/arr
-  local.set $478
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store
-  local.get $478
+  local.get $296
   call $~lib/array/Array<i32>#get:length
   i32.const 3
   i32.eq
@@ -37421,11 +37234,11 @@
    unreachable
   end
   global.get $std/array/arr
-  local.set $478
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store
-  local.get $478
+  local.get $296
   call $std/array/internalCapacity<i32>
   i32.const 8
   i32.eq
@@ -37439,11 +37252,11 @@
    unreachable
   end
   global.get $std/array/arr
-  local.set $478
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store
-  local.get $478
+  local.get $296
   i32.const 0
   call $~lib/array/Array<i32>#__get
   i32.const 44
@@ -37458,11 +37271,11 @@
    unreachable
   end
   global.get $std/array/arr
-  local.set $478
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store
-  local.get $478
+  local.get $296
   i32.const 1
   call $~lib/array/Array<i32>#__get
   i32.const 43
@@ -37477,11 +37290,11 @@
    unreachable
   end
   global.get $std/array/arr
-  local.set $478
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store
-  local.get $478
+  local.get $296
   i32.const 2
   call $~lib/array/Array<i32>#__get
   i32.const 42
@@ -37496,20 +37309,20 @@
    unreachable
   end
   global.get $std/array/arr
-  local.set $478
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store
-  local.get $478
+  local.get $296
   i32.const 43
   call $~lib/array/Array<i32>#push
   drop
   global.get $std/array/arr
-  local.set $478
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store
-  local.get $478
+  local.get $296
   i32.const 44
   call $~lib/array/Array<i32>#push
   drop
@@ -37519,45 +37332,45 @@
   i32.const 7
   i32.const 3184
   call $~lib/rt/__newArray
-  local.set $478
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store
-  local.get $478
+  local.get $296
   call $~lib/array/Array<u8>#reverse
-  local.tee $128
-  i32.store offset=64
+  local.tee $70
+  i32.store offset=60
   i32.const 0
-  local.set $129
-  local.get $128
-  local.set $478
+  local.set $71
+  local.get $70
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store
-  local.get $478
+  local.get $296
   call $~lib/array/Array<u8>#get:length
-  local.set $130
+  local.set $72
   loop $for-loop|0
-   local.get $129
-   local.get $130
+   local.get $71
+   local.get $72
    i32.lt_s
    if
-    local.get $128
-    local.set $478
+    local.get $70
+    local.set $296
     global.get $~lib/memory/__stack_pointer
-    local.get $478
+    local.get $296
     i32.store
-    local.get $478
-    local.get $129
+    local.get $296
+    local.get $71
     call $~lib/array/Array<u8>#__get
-    local.get $128
-    local.set $478
+    local.get $70
+    local.set $296
     global.get $~lib/memory/__stack_pointer
-    local.get $478
+    local.get $296
     i32.store
-    local.get $478
+    local.get $296
     call $~lib/array/Array<u8>#get:length
-    local.get $129
+    local.get $71
     i32.sub
     i32.const 1
     i32.sub
@@ -37571,10 +37384,10 @@
      call $~lib/builtins/abort
      unreachable
     end
-    local.get $129
+    local.get $71
     i32.const 1
     i32.add
-    local.set $129
+    local.set $71
     br $for-loop|0
    end
   end
@@ -37584,45 +37397,45 @@
   i32.const 7
   i32.const 3216
   call $~lib/rt/__newArray
-  local.set $478
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store
-  local.get $478
+  local.get $296
   call $~lib/array/Array<u8>#reverse
-  local.tee $133
-  i32.store offset=68
+  local.tee $74
+  i32.store offset=64
   i32.const 0
-  local.set $134
-  local.get $133
-  local.set $478
+  local.set $75
+  local.get $74
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store
-  local.get $478
+  local.get $296
   call $~lib/array/Array<u8>#get:length
-  local.set $135
+  local.set $76
   loop $for-loop|1
-   local.get $134
-   local.get $135
+   local.get $75
+   local.get $76
    i32.lt_s
    if
-    local.get $133
-    local.set $478
+    local.get $74
+    local.set $296
     global.get $~lib/memory/__stack_pointer
-    local.get $478
+    local.get $296
     i32.store
-    local.get $478
-    local.get $134
+    local.get $296
+    local.get $75
     call $~lib/array/Array<u8>#__get
-    local.get $133
-    local.set $478
+    local.get $74
+    local.set $296
     global.get $~lib/memory/__stack_pointer
-    local.get $478
+    local.get $296
     i32.store
-    local.get $478
+    local.get $296
     call $~lib/array/Array<u8>#get:length
-    local.get $134
+    local.get $75
     i32.sub
     i32.const 1
     i32.sub
@@ -37636,10 +37449,10 @@
      call $~lib/builtins/abort
      unreachable
     end
-    local.get $134
+    local.get $75
     i32.const 1
     i32.add
-    local.set $134
+    local.set $75
     br $for-loop|1
    end
   end
@@ -37649,45 +37462,45 @@
   i32.const 7
   i32.const 3248
   call $~lib/rt/__newArray
-  local.set $478
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store
-  local.get $478
+  local.get $296
   call $~lib/array/Array<u8>#reverse
-  local.tee $138
-  i32.store offset=72
+  local.tee $78
+  i32.store offset=68
   i32.const 0
-  local.set $139
-  local.get $138
-  local.set $478
+  local.set $79
+  local.get $78
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store
-  local.get $478
+  local.get $296
   call $~lib/array/Array<u8>#get:length
-  local.set $140
+  local.set $80
   loop $for-loop|2
-   local.get $139
-   local.get $140
+   local.get $79
+   local.get $80
    i32.lt_s
    if
-    local.get $138
-    local.set $478
+    local.get $78
+    local.set $296
     global.get $~lib/memory/__stack_pointer
-    local.get $478
+    local.get $296
     i32.store
-    local.get $478
-    local.get $139
+    local.get $296
+    local.get $79
     call $~lib/array/Array<u8>#__get
-    local.get $138
-    local.set $478
+    local.get $78
+    local.set $296
     global.get $~lib/memory/__stack_pointer
-    local.get $478
+    local.get $296
     i32.store
-    local.get $478
+    local.get $296
     call $~lib/array/Array<u8>#get:length
-    local.get $139
+    local.get $79
     i32.sub
     i32.const 1
     i32.sub
@@ -37701,10 +37514,10 @@
      call $~lib/builtins/abort
      unreachable
     end
-    local.get $139
+    local.get $79
     i32.const 1
     i32.add
-    local.set $139
+    local.set $79
     br $for-loop|2
    end
   end
@@ -37714,45 +37527,45 @@
   i32.const 11
   i32.const 3296
   call $~lib/rt/__newArray
-  local.set $478
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store
-  local.get $478
+  local.get $296
   call $~lib/array/Array<u16>#reverse
-  local.tee $143
-  i32.store offset=76
+  local.tee $82
+  i32.store offset=72
   i32.const 0
-  local.set $144
-  local.get $143
-  local.set $478
+  local.set $83
+  local.get $82
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store
-  local.get $478
+  local.get $296
   call $~lib/array/Array<u16>#get:length
-  local.set $145
+  local.set $84
   loop $for-loop|3
-   local.get $144
-   local.get $145
+   local.get $83
+   local.get $84
    i32.lt_s
    if
-    local.get $143
-    local.set $478
+    local.get $82
+    local.set $296
     global.get $~lib/memory/__stack_pointer
-    local.get $478
+    local.get $296
     i32.store
-    local.get $478
-    local.get $144
+    local.get $296
+    local.get $83
     call $~lib/array/Array<u16>#__get
-    local.get $143
-    local.set $478
+    local.get $82
+    local.set $296
     global.get $~lib/memory/__stack_pointer
-    local.get $478
+    local.get $296
     i32.store
-    local.get $478
+    local.get $296
     call $~lib/array/Array<u16>#get:length
-    local.get $144
+    local.get $83
     i32.sub
     i32.const 1
     i32.sub
@@ -37766,10 +37579,10 @@
      call $~lib/builtins/abort
      unreachable
     end
-    local.get $144
+    local.get $83
     i32.const 1
     i32.add
-    local.set $144
+    local.set $83
     br $for-loop|3
    end
   end
@@ -37779,45 +37592,45 @@
   i32.const 11
   i32.const 3344
   call $~lib/rt/__newArray
-  local.set $478
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store
-  local.get $478
+  local.get $296
   call $~lib/array/Array<u16>#reverse
-  local.tee $148
-  i32.store offset=80
+  local.tee $86
+  i32.store offset=76
   i32.const 0
-  local.set $149
-  local.get $148
-  local.set $478
+  local.set $87
+  local.get $86
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store
-  local.get $478
+  local.get $296
   call $~lib/array/Array<u16>#get:length
-  local.set $150
+  local.set $88
   loop $for-loop|4
-   local.get $149
-   local.get $150
+   local.get $87
+   local.get $88
    i32.lt_s
    if
-    local.get $148
-    local.set $478
+    local.get $86
+    local.set $296
     global.get $~lib/memory/__stack_pointer
-    local.get $478
+    local.get $296
     i32.store
-    local.get $478
-    local.get $149
+    local.get $296
+    local.get $87
     call $~lib/array/Array<u16>#__get
-    local.get $148
-    local.set $478
+    local.get $86
+    local.set $296
     global.get $~lib/memory/__stack_pointer
-    local.get $478
+    local.get $296
     i32.store
-    local.get $478
+    local.get $296
     call $~lib/array/Array<u16>#get:length
-    local.get $149
+    local.get $87
     i32.sub
     i32.const 1
     i32.sub
@@ -37831,10 +37644,10 @@
      call $~lib/builtins/abort
      unreachable
     end
-    local.get $149
+    local.get $87
     i32.const 1
     i32.add
-    local.set $149
+    local.set $87
     br $for-loop|4
    end
   end
@@ -37844,45 +37657,45 @@
   i32.const 11
   i32.const 3392
   call $~lib/rt/__newArray
-  local.set $478
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store
-  local.get $478
+  local.get $296
   call $~lib/array/Array<u16>#reverse
-  local.tee $153
-  i32.store offset=84
+  local.tee $90
+  i32.store offset=80
   i32.const 0
-  local.set $154
-  local.get $153
-  local.set $478
+  local.set $91
+  local.get $90
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store
-  local.get $478
+  local.get $296
   call $~lib/array/Array<u16>#get:length
-  local.set $155
+  local.set $92
   loop $for-loop|5
-   local.get $154
-   local.get $155
+   local.get $91
+   local.get $92
    i32.lt_s
    if
-    local.get $153
-    local.set $478
+    local.get $90
+    local.set $296
     global.get $~lib/memory/__stack_pointer
-    local.get $478
+    local.get $296
     i32.store
-    local.get $478
-    local.get $154
+    local.get $296
+    local.get $91
     call $~lib/array/Array<u16>#__get
-    local.get $153
-    local.set $478
+    local.get $90
+    local.set $296
     global.get $~lib/memory/__stack_pointer
-    local.get $478
+    local.get $296
     i32.store
-    local.get $478
+    local.get $296
     call $~lib/array/Array<u16>#get:length
-    local.get $154
+    local.get $91
     i32.sub
     i32.const 1
     i32.sub
@@ -37896,19 +37709,19 @@
      call $~lib/builtins/abort
      unreachable
     end
-    local.get $154
+    local.get $91
     i32.const 1
     i32.add
-    local.set $154
+    local.set $91
     br $for-loop|5
    end
   end
   global.get $std/array/arr
-  local.set $478
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store
-  local.get $478
+  local.get $296
   i32.const 44
   i32.const 0
   call $~lib/array/Array<i32>#indexOf
@@ -37926,11 +37739,11 @@
    unreachable
   end
   global.get $std/array/arr
-  local.set $478
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store
-  local.get $478
+  local.get $296
   i32.const 42
   i32.const 0
   call $~lib/array/Array<i32>#indexOf
@@ -37948,11 +37761,11 @@
    unreachable
   end
   global.get $std/array/arr
-  local.set $478
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store
-  local.get $478
+  local.get $296
   i32.const 45
   i32.const 0
   call $~lib/array/Array<i32>#indexOf
@@ -37970,11 +37783,11 @@
    unreachable
   end
   global.get $std/array/arr
-  local.set $478
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store
-  local.get $478
+  local.get $296
   i32.const 43
   i32.const 100
   call $~lib/array/Array<i32>#indexOf
@@ -37992,11 +37805,11 @@
    unreachable
   end
   global.get $std/array/arr
-  local.set $478
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store
-  local.get $478
+  local.get $296
   i32.const 43
   i32.const -100
   call $~lib/array/Array<i32>#indexOf
@@ -38014,11 +37827,11 @@
    unreachable
   end
   global.get $std/array/arr
-  local.set $478
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store
-  local.get $478
+  local.get $296
   i32.const 43
   i32.const -2
   call $~lib/array/Array<i32>#indexOf
@@ -38036,11 +37849,11 @@
    unreachable
   end
   global.get $std/array/arr
-  local.set $478
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store
-  local.get $478
+  local.get $296
   i32.const 43
   i32.const -4
   call $~lib/array/Array<i32>#indexOf
@@ -38058,11 +37871,11 @@
    unreachable
   end
   global.get $std/array/arr
-  local.set $478
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store
-  local.get $478
+  local.get $296
   i32.const 43
   i32.const 0
   call $~lib/array/Array<i32>#indexOf
@@ -38080,11 +37893,11 @@
    unreachable
   end
   global.get $std/array/arr
-  local.set $478
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store
-  local.get $478
+  local.get $296
   i32.const 43
   i32.const 1
   call $~lib/array/Array<i32>#indexOf
@@ -38102,11 +37915,11 @@
    unreachable
   end
   global.get $std/array/arr
-  local.set $478
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store
-  local.get $478
+  local.get $296
   i32.const 43
   i32.const 2
   call $~lib/array/Array<i32>#indexOf
@@ -38128,11 +37941,11 @@
   i32.const 9
   i32.const 3440
   call $~lib/rt/__newArray
-  local.set $478
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store
-  local.get $478
+  local.get $296
   f32.const nan:0x400000
   i32.const 0
   call $~lib/array/Array<f32>#indexOf
@@ -38152,11 +37965,11 @@
   i32.const 12
   i32.const 3472
   call $~lib/rt/__newArray
-  local.set $478
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store
-  local.get $478
+  local.get $296
   f64.const nan:0x8000000000000
   i32.const 0
   call $~lib/array/Array<f64>#indexOf
@@ -38177,14 +37990,14 @@
   i32.const 4
   i32.const 3504
   call $~lib/rt/__newArray
-  local.tee $162
-  i32.store offset=88
-  local.get $162
-  local.set $478
+  local.tee $96
+  i32.store offset=84
+  local.get $96
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store
-  local.get $478
+  local.get $296
   i32.const 2
   i32.const 1
   global.set $~argumentsLength
@@ -38201,12 +38014,12 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $162
-  local.set $478
+  local.get $96
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store
-  local.get $478
+  local.get $296
   i32.const 7
   i32.const 1
   global.set $~argumentsLength
@@ -38223,12 +38036,12 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $162
-  local.set $478
+  local.get $96
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store
-  local.get $478
+  local.get $296
   i32.const 2
   i32.const 3
   call $~lib/array/Array<i32>#lastIndexOf
@@ -38243,12 +38056,12 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $162
-  local.set $478
+  local.get $96
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store
-  local.get $478
+  local.get $296
   i32.const 2
   i32.const 2
   call $~lib/array/Array<i32>#lastIndexOf
@@ -38263,12 +38076,12 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $162
-  local.set $478
+  local.get $96
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store
-  local.get $478
+  local.get $296
   i32.const 2
   i32.const -2
   call $~lib/array/Array<i32>#lastIndexOf
@@ -38283,12 +38096,12 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $162
-  local.set $478
+  local.get $96
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store
-  local.get $478
+  local.get $296
   i32.const 2
   i32.const -1
   call $~lib/array/Array<i32>#lastIndexOf
@@ -38304,16 +38117,16 @@
    unreachable
   end
   global.get $std/array/arr
-  local.set $478
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store
-  local.get $478
+  local.get $296
   i32.const 44
   i32.const 0
   call $~lib/array/Array<i32>#includes
-  local.set $163
-  local.get $163
+  local.set $97
+  local.get $97
   i32.const 1
   i32.eq
   i32.eqz
@@ -38326,16 +38139,16 @@
    unreachable
   end
   global.get $std/array/arr
-  local.set $478
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store
-  local.get $478
+  local.get $296
   i32.const 42
   i32.const 0
   call $~lib/array/Array<i32>#includes
-  local.set $163
-  local.get $163
+  local.set $97
+  local.get $97
   i32.const 1
   i32.eq
   i32.eqz
@@ -38348,16 +38161,16 @@
    unreachable
   end
   global.get $std/array/arr
-  local.set $478
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store
-  local.get $478
+  local.get $296
   i32.const 45
   i32.const 0
   call $~lib/array/Array<i32>#includes
-  local.set $163
-  local.get $163
+  local.set $97
+  local.get $97
   i32.const 0
   i32.eq
   i32.eqz
@@ -38370,16 +38183,16 @@
    unreachable
   end
   global.get $std/array/arr
-  local.set $478
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store
-  local.get $478
+  local.get $296
   i32.const 43
   i32.const 100
   call $~lib/array/Array<i32>#includes
-  local.set $163
-  local.get $163
+  local.set $97
+  local.get $97
   i32.const 0
   i32.eq
   i32.eqz
@@ -38392,16 +38205,16 @@
    unreachable
   end
   global.get $std/array/arr
-  local.set $478
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store
-  local.get $478
+  local.get $296
   i32.const 43
   i32.const -100
   call $~lib/array/Array<i32>#includes
-  local.set $163
-  local.get $163
+  local.set $97
+  local.get $97
   i32.const 1
   i32.eq
   i32.eqz
@@ -38414,16 +38227,16 @@
    unreachable
   end
   global.get $std/array/arr
-  local.set $478
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store
-  local.get $478
+  local.get $296
   i32.const 43
   i32.const -2
   call $~lib/array/Array<i32>#includes
-  local.set $163
-  local.get $163
+  local.set $97
+  local.get $97
   i32.const 1
   i32.eq
   i32.eqz
@@ -38436,16 +38249,16 @@
    unreachable
   end
   global.get $std/array/arr
-  local.set $478
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store
-  local.get $478
+  local.get $296
   i32.const 43
   i32.const -4
   call $~lib/array/Array<i32>#includes
-  local.set $163
-  local.get $163
+  local.set $97
+  local.get $97
   i32.const 1
   i32.eq
   i32.eqz
@@ -38458,16 +38271,16 @@
    unreachable
   end
   global.get $std/array/arr
-  local.set $478
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store
-  local.get $478
+  local.get $296
   i32.const 43
   i32.const 0
   call $~lib/array/Array<i32>#includes
-  local.set $163
-  local.get $163
+  local.set $97
+  local.get $97
   i32.const 1
   i32.eq
   i32.eqz
@@ -38480,16 +38293,16 @@
    unreachable
   end
   global.get $std/array/arr
-  local.set $478
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store
-  local.get $478
+  local.get $296
   i32.const 43
   i32.const 1
   call $~lib/array/Array<i32>#includes
-  local.set $163
-  local.get $163
+  local.set $97
+  local.get $97
   i32.const 1
   i32.eq
   i32.eqz
@@ -38502,16 +38315,16 @@
    unreachable
   end
   global.get $std/array/arr
-  local.set $478
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store
-  local.get $478
+  local.get $296
   i32.const 43
   i32.const 2
   call $~lib/array/Array<i32>#includes
-  local.set $163
-  local.get $163
+  local.set $97
+  local.get $97
   i32.const 1
   i32.eq
   i32.eqz
@@ -38528,11 +38341,11 @@
   i32.const 9
   i32.const 3552
   call $~lib/rt/__newArray
-  local.set $478
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store
-  local.get $478
+  local.get $296
   f32.const nan:0x400000
   i32.const 0
   call $~lib/array/Array<f32>#includes
@@ -38550,11 +38363,11 @@
   i32.const 12
   i32.const 3584
   call $~lib/rt/__newArray
-  local.set $478
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store
-  local.get $478
+  local.get $296
   f64.const nan:0x8000000000000
   i32.const 0
   call $~lib/array/Array<f64>#includes
@@ -38568,21 +38381,21 @@
    unreachable
   end
   global.get $std/array/arr
-  local.set $478
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store
-  local.get $478
+  local.get $296
   i32.const 1
   i32.const 1
   call $~lib/array/Array<i32>#splice
   drop
   global.get $std/array/arr
-  local.set $478
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store
-  local.get $478
+  local.get $296
   call $~lib/array/Array<i32>#get:length
   i32.const 4
   i32.eq
@@ -38596,11 +38409,11 @@
    unreachable
   end
   global.get $std/array/arr
-  local.set $478
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store
-  local.get $478
+  local.get $296
   call $std/array/internalCapacity<i32>
   i32.const 8
   i32.eq
@@ -38614,11 +38427,11 @@
    unreachable
   end
   global.get $std/array/arr
-  local.set $478
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store
-  local.get $478
+  local.get $296
   i32.const 0
   call $~lib/array/Array<i32>#__get
   i32.const 44
@@ -38633,11 +38446,11 @@
    unreachable
   end
   global.get $std/array/arr
-  local.set $478
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store
-  local.get $478
+  local.get $296
   i32.const 1
   call $~lib/array/Array<i32>#__get
   i32.const 42
@@ -38657,34 +38470,34 @@
   i32.const 4
   i32.const 3616
   call $~lib/rt/__newArray
-  local.tee $170
-  i32.store offset=92
-  local.get $170
-  local.set $478
+  local.tee $101
+  i32.store offset=88
+  local.get $101
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
-  i32.store offset=52
-  local.get $478
+  local.get $296
+  i32.store offset=48
+  local.get $296
   i32.const 0
   i32.const 1
   global.set $~argumentsLength
   i32.const 0
   call $~lib/array/Array<i32>#splice@varargs
-  local.set $478
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store
-  local.get $478
+  local.get $296
   i32.const 5
   i32.const 2
   i32.const 4
   i32.const 3664
   call $~lib/rt/__newArray
-  local.set $478
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store offset=8
-  local.get $478
+  local.get $296
   i32.const 0
   call $std/array/isArraysEqual<i32>
   i32.eqz
@@ -38696,22 +38509,22 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $170
-  local.set $478
+  local.get $101
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store
-  local.get $478
+  local.get $296
   i32.const 0
   i32.const 2
   i32.const 4
   i32.const 3712
   call $~lib/rt/__newArray
-  local.set $478
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store offset=8
-  local.get $478
+  local.get $296
   i32.const 0
   call $std/array/isArraysEqual<i32>
   i32.eqz
@@ -38729,32 +38542,32 @@
   i32.const 4
   i32.const 3744
   call $~lib/rt/__newArray
-  local.tee $170
-  i32.store offset=92
-  local.get $170
-  local.set $478
+  local.tee $101
+  i32.store offset=88
+  local.get $101
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
-  i32.store offset=52
-  local.get $478
+  local.get $296
+  i32.store offset=48
+  local.get $296
   i32.const 0
   i32.const 0
   call $~lib/array/Array<i32>#splice
-  local.set $478
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store
-  local.get $478
+  local.get $296
   i32.const 0
   i32.const 2
   i32.const 4
   i32.const 3792
   call $~lib/rt/__newArray
-  local.set $478
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store offset=8
-  local.get $478
+  local.get $296
   i32.const 0
   call $std/array/isArraysEqual<i32>
   i32.eqz
@@ -38766,22 +38579,22 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $170
-  local.set $478
+  local.get $101
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store
-  local.get $478
+  local.get $296
   i32.const 5
   i32.const 2
   i32.const 4
   i32.const 3824
   call $~lib/rt/__newArray
-  local.set $478
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store offset=8
-  local.get $478
+  local.get $296
   i32.const 0
   call $std/array/isArraysEqual<i32>
   i32.eqz
@@ -38799,34 +38612,34 @@
   i32.const 4
   i32.const 3872
   call $~lib/rt/__newArray
-  local.tee $170
-  i32.store offset=92
-  local.get $170
-  local.set $478
+  local.tee $101
+  i32.store offset=88
+  local.get $101
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
-  i32.store offset=52
-  local.get $478
+  local.get $296
+  i32.store offset=48
+  local.get $296
   i32.const 2
   i32.const 1
   global.set $~argumentsLength
   i32.const 0
   call $~lib/array/Array<i32>#splice@varargs
-  local.set $478
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store
-  local.get $478
+  local.get $296
   i32.const 3
   i32.const 2
   i32.const 4
   i32.const 3920
   call $~lib/rt/__newArray
-  local.set $478
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store offset=8
-  local.get $478
+  local.get $296
   i32.const 0
   call $std/array/isArraysEqual<i32>
   i32.eqz
@@ -38838,22 +38651,22 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $170
-  local.set $478
+  local.get $101
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store
-  local.get $478
+  local.get $296
   i32.const 2
   i32.const 2
   i32.const 4
   i32.const 3952
   call $~lib/rt/__newArray
-  local.set $478
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store offset=8
-  local.get $478
+  local.get $296
   i32.const 0
   call $std/array/isArraysEqual<i32>
   i32.eqz
@@ -38871,32 +38684,32 @@
   i32.const 4
   i32.const 3984
   call $~lib/rt/__newArray
-  local.tee $170
-  i32.store offset=92
-  local.get $170
-  local.set $478
+  local.tee $101
+  i32.store offset=88
+  local.get $101
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
-  i32.store offset=52
-  local.get $478
+  local.get $296
+  i32.store offset=48
+  local.get $296
   i32.const 2
   i32.const 2
   call $~lib/array/Array<i32>#splice
-  local.set $478
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store
-  local.get $478
+  local.get $296
   i32.const 2
   i32.const 2
   i32.const 4
   i32.const 4032
   call $~lib/rt/__newArray
-  local.set $478
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store offset=8
-  local.get $478
+  local.get $296
   i32.const 0
   call $std/array/isArraysEqual<i32>
   i32.eqz
@@ -38908,22 +38721,22 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $170
-  local.set $478
+  local.get $101
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store
-  local.get $478
+  local.get $296
   i32.const 3
   i32.const 2
   i32.const 4
   i32.const 4064
   call $~lib/rt/__newArray
-  local.set $478
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store offset=8
-  local.get $478
+  local.get $296
   i32.const 0
   call $std/array/isArraysEqual<i32>
   i32.eqz
@@ -38941,32 +38754,32 @@
   i32.const 4
   i32.const 4096
   call $~lib/rt/__newArray
-  local.tee $170
-  i32.store offset=92
-  local.get $170
-  local.set $478
+  local.tee $101
+  i32.store offset=88
+  local.get $101
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
-  i32.store offset=52
-  local.get $478
+  local.get $296
+  i32.store offset=48
+  local.get $296
   i32.const 0
   i32.const 1
   call $~lib/array/Array<i32>#splice
-  local.set $478
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store
-  local.get $478
+  local.get $296
   i32.const 1
   i32.const 2
   i32.const 4
   i32.const 4144
   call $~lib/rt/__newArray
-  local.set $478
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store offset=8
-  local.get $478
+  local.get $296
   i32.const 0
   call $std/array/isArraysEqual<i32>
   i32.eqz
@@ -38978,22 +38791,22 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $170
-  local.set $478
+  local.get $101
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store
-  local.get $478
+  local.get $296
   i32.const 4
   i32.const 2
   i32.const 4
   i32.const 4176
   call $~lib/rt/__newArray
-  local.set $478
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store offset=8
-  local.get $478
+  local.get $296
   i32.const 0
   call $std/array/isArraysEqual<i32>
   i32.eqz
@@ -39011,34 +38824,34 @@
   i32.const 4
   i32.const 4224
   call $~lib/rt/__newArray
-  local.tee $170
-  i32.store offset=92
-  local.get $170
-  local.set $478
+  local.tee $101
+  i32.store offset=88
+  local.get $101
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
-  i32.store offset=52
-  local.get $478
+  local.get $296
+  i32.store offset=48
+  local.get $296
   i32.const -1
   i32.const 1
   global.set $~argumentsLength
   i32.const 0
   call $~lib/array/Array<i32>#splice@varargs
-  local.set $478
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store
-  local.get $478
+  local.get $296
   i32.const 1
   i32.const 2
   i32.const 4
   i32.const 4272
   call $~lib/rt/__newArray
-  local.set $478
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store offset=8
-  local.get $478
+  local.get $296
   i32.const 0
   call $std/array/isArraysEqual<i32>
   i32.eqz
@@ -39050,22 +38863,22 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $170
-  local.set $478
+  local.get $101
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store
-  local.get $478
+  local.get $296
   i32.const 4
   i32.const 2
   i32.const 4
   i32.const 4304
   call $~lib/rt/__newArray
-  local.set $478
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store offset=8
-  local.get $478
+  local.get $296
   i32.const 0
   call $std/array/isArraysEqual<i32>
   i32.eqz
@@ -39083,34 +38896,34 @@
   i32.const 4
   i32.const 4352
   call $~lib/rt/__newArray
-  local.tee $170
-  i32.store offset=92
-  local.get $170
-  local.set $478
+  local.tee $101
+  i32.store offset=88
+  local.get $101
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
-  i32.store offset=52
-  local.get $478
+  local.get $296
+  i32.store offset=48
+  local.get $296
   i32.const -2
   i32.const 1
   global.set $~argumentsLength
   i32.const 0
   call $~lib/array/Array<i32>#splice@varargs
-  local.set $478
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store
-  local.get $478
+  local.get $296
   i32.const 2
   i32.const 2
   i32.const 4
   i32.const 4400
   call $~lib/rt/__newArray
-  local.set $478
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store offset=8
-  local.get $478
+  local.get $296
   i32.const 0
   call $std/array/isArraysEqual<i32>
   i32.eqz
@@ -39122,22 +38935,22 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $170
-  local.set $478
+  local.get $101
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store
-  local.get $478
+  local.get $296
   i32.const 3
   i32.const 2
   i32.const 4
   i32.const 4432
   call $~lib/rt/__newArray
-  local.set $478
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store offset=8
-  local.get $478
+  local.get $296
   i32.const 0
   call $std/array/isArraysEqual<i32>
   i32.eqz
@@ -39155,32 +38968,32 @@
   i32.const 4
   i32.const 4464
   call $~lib/rt/__newArray
-  local.tee $170
-  i32.store offset=92
-  local.get $170
-  local.set $478
+  local.tee $101
+  i32.store offset=88
+  local.get $101
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
-  i32.store offset=52
-  local.get $478
+  local.get $296
+  i32.store offset=48
+  local.get $296
   i32.const -2
   i32.const 1
   call $~lib/array/Array<i32>#splice
-  local.set $478
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store
-  local.get $478
+  local.get $296
   i32.const 1
   i32.const 2
   i32.const 4
   i32.const 4512
   call $~lib/rt/__newArray
-  local.set $478
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store offset=8
-  local.get $478
+  local.get $296
   i32.const 0
   call $std/array/isArraysEqual<i32>
   i32.eqz
@@ -39192,22 +39005,22 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $170
-  local.set $478
+  local.get $101
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store
-  local.get $478
+  local.get $296
   i32.const 4
   i32.const 2
   i32.const 4
   i32.const 4544
   call $~lib/rt/__newArray
-  local.set $478
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store offset=8
-  local.get $478
+  local.get $296
   i32.const 0
   call $std/array/isArraysEqual<i32>
   i32.eqz
@@ -39225,32 +39038,32 @@
   i32.const 4
   i32.const 4592
   call $~lib/rt/__newArray
-  local.tee $170
-  i32.store offset=92
-  local.get $170
-  local.set $478
+  local.tee $101
+  i32.store offset=88
+  local.get $101
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
-  i32.store offset=52
-  local.get $478
+  local.get $296
+  i32.store offset=48
+  local.get $296
   i32.const -7
   i32.const 1
   call $~lib/array/Array<i32>#splice
-  local.set $478
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store
-  local.get $478
+  local.get $296
   i32.const 1
   i32.const 2
   i32.const 4
   i32.const 4640
   call $~lib/rt/__newArray
-  local.set $478
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store offset=8
-  local.get $478
+  local.get $296
   i32.const 0
   call $std/array/isArraysEqual<i32>
   i32.eqz
@@ -39262,22 +39075,22 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $170
-  local.set $478
+  local.get $101
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store
-  local.get $478
+  local.get $296
   i32.const 4
   i32.const 2
   i32.const 4
   i32.const 4672
   call $~lib/rt/__newArray
-  local.set $478
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store offset=8
-  local.get $478
+  local.get $296
   i32.const 0
   call $std/array/isArraysEqual<i32>
   i32.eqz
@@ -39295,32 +39108,32 @@
   i32.const 4
   i32.const 4720
   call $~lib/rt/__newArray
-  local.tee $170
-  i32.store offset=92
-  local.get $170
-  local.set $478
+  local.tee $101
+  i32.store offset=88
+  local.get $101
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
-  i32.store offset=52
-  local.get $478
+  local.get $296
+  i32.store offset=48
+  local.get $296
   i32.const -2
   i32.const -1
   call $~lib/array/Array<i32>#splice
-  local.set $478
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store
-  local.get $478
+  local.get $296
   i32.const 0
   i32.const 2
   i32.const 4
   i32.const 4768
   call $~lib/rt/__newArray
-  local.set $478
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store offset=8
-  local.get $478
+  local.get $296
   i32.const 0
   call $std/array/isArraysEqual<i32>
   i32.eqz
@@ -39332,22 +39145,22 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $170
-  local.set $478
+  local.get $101
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store
-  local.get $478
+  local.get $296
   i32.const 5
   i32.const 2
   i32.const 4
   i32.const 4800
   call $~lib/rt/__newArray
-  local.set $478
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store offset=8
-  local.get $478
+  local.get $296
   i32.const 0
   call $std/array/isArraysEqual<i32>
   i32.eqz
@@ -39365,32 +39178,32 @@
   i32.const 4
   i32.const 4848
   call $~lib/rt/__newArray
-  local.tee $170
-  i32.store offset=92
-  local.get $170
-  local.set $478
+  local.tee $101
+  i32.store offset=88
+  local.get $101
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
-  i32.store offset=52
-  local.get $478
+  local.get $296
+  i32.store offset=48
+  local.get $296
   i32.const 1
   i32.const -2
   call $~lib/array/Array<i32>#splice
-  local.set $478
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store
-  local.get $478
+  local.get $296
   i32.const 0
   i32.const 2
   i32.const 4
   i32.const 4896
   call $~lib/rt/__newArray
-  local.set $478
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store offset=8
-  local.get $478
+  local.get $296
   i32.const 0
   call $std/array/isArraysEqual<i32>
   i32.eqz
@@ -39402,22 +39215,22 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $170
-  local.set $478
+  local.get $101
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store
-  local.get $478
+  local.get $296
   i32.const 5
   i32.const 2
   i32.const 4
   i32.const 4928
   call $~lib/rt/__newArray
-  local.set $478
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store offset=8
-  local.get $478
+  local.get $296
   i32.const 0
   call $std/array/isArraysEqual<i32>
   i32.eqz
@@ -39435,32 +39248,32 @@
   i32.const 4
   i32.const 4976
   call $~lib/rt/__newArray
-  local.tee $170
-  i32.store offset=92
-  local.get $170
-  local.set $478
+  local.tee $101
+  i32.store offset=88
+  local.get $101
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
-  i32.store offset=52
-  local.get $478
+  local.get $296
+  i32.store offset=48
+  local.get $296
   i32.const 4
   i32.const 0
   call $~lib/array/Array<i32>#splice
-  local.set $478
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store
-  local.get $478
+  local.get $296
   i32.const 0
   i32.const 2
   i32.const 4
   i32.const 5024
   call $~lib/rt/__newArray
-  local.set $478
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store offset=8
-  local.get $478
+  local.get $296
   i32.const 0
   call $std/array/isArraysEqual<i32>
   i32.eqz
@@ -39472,22 +39285,22 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $170
-  local.set $478
+  local.get $101
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store
-  local.get $478
+  local.get $296
   i32.const 5
   i32.const 2
   i32.const 4
   i32.const 5056
   call $~lib/rt/__newArray
-  local.set $478
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store offset=8
-  local.get $478
+  local.get $296
   i32.const 0
   call $std/array/isArraysEqual<i32>
   i32.eqz
@@ -39505,32 +39318,32 @@
   i32.const 4
   i32.const 5104
   call $~lib/rt/__newArray
-  local.tee $170
-  i32.store offset=92
-  local.get $170
-  local.set $478
+  local.tee $101
+  i32.store offset=88
+  local.get $101
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
-  i32.store offset=52
-  local.get $478
+  local.get $296
+  i32.store offset=48
+  local.get $296
   i32.const 7
   i32.const 0
   call $~lib/array/Array<i32>#splice
-  local.set $478
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store
-  local.get $478
+  local.get $296
   i32.const 0
   i32.const 2
   i32.const 4
   i32.const 5152
   call $~lib/rt/__newArray
-  local.set $478
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store offset=8
-  local.get $478
+  local.get $296
   i32.const 0
   call $std/array/isArraysEqual<i32>
   i32.eqz
@@ -39542,22 +39355,22 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $170
-  local.set $478
+  local.get $101
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store
-  local.get $478
+  local.get $296
   i32.const 5
   i32.const 2
   i32.const 4
   i32.const 5184
   call $~lib/rt/__newArray
-  local.set $478
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store offset=8
-  local.get $478
+  local.get $296
   i32.const 0
   call $std/array/isArraysEqual<i32>
   i32.eqz
@@ -39575,32 +39388,32 @@
   i32.const 4
   i32.const 5232
   call $~lib/rt/__newArray
-  local.tee $170
-  i32.store offset=92
-  local.get $170
-  local.set $478
+  local.tee $101
+  i32.store offset=88
+  local.get $101
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
-  i32.store offset=52
-  local.get $478
+  local.get $296
+  i32.store offset=48
+  local.get $296
   i32.const 7
   i32.const 5
   call $~lib/array/Array<i32>#splice
-  local.set $478
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store
-  local.get $478
+  local.get $296
   i32.const 0
   i32.const 2
   i32.const 4
   i32.const 5280
   call $~lib/rt/__newArray
-  local.set $478
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store offset=8
-  local.get $478
+  local.get $296
   i32.const 0
   call $std/array/isArraysEqual<i32>
   i32.eqz
@@ -39612,22 +39425,22 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $170
-  local.set $478
+  local.get $101
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store
-  local.get $478
+  local.get $296
   i32.const 5
   i32.const 2
   i32.const 4
   i32.const 5312
   call $~lib/rt/__newArray
-  local.set $478
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store offset=8
-  local.get $478
+  local.get $296
   i32.const 0
   call $std/array/isArraysEqual<i32>
   i32.eqz
@@ -39645,26 +39458,26 @@
   i32.const 10
   i32.const 5360
   call $~lib/rt/__newArray
-  local.tee $255
-  i32.store offset=96
+  local.tee $144
+  i32.store offset=92
   global.get $~lib/memory/__stack_pointer
-  local.get $255
-  local.set $478
+  local.get $144
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store
-  local.get $478
+  local.get $296
   i32.const 1
   i32.const 2
   call $~lib/array/Array<std/array/Ref>#splice
-  local.tee $256
-  i32.store offset=100
-  local.get $256
-  local.set $478
+  local.tee $145
+  i32.store offset=96
+  local.get $145
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store
-  local.get $478
+  local.get $296
   call $~lib/array/Array<std/array/Ref>#get:length
   i32.const 0
   i32.eq
@@ -39677,12 +39490,12 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $255
-  local.set $478
+  local.get $144
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store
-  local.get $478
+  local.get $296
   call $~lib/array/Array<std/array/Ref>#get:length
   i32.const 0
   i32.eq
@@ -39702,64 +39515,59 @@
   i32.const 10
   i32.const 0
   call $~lib/rt/__newArray
-  local.tee $257
-  i32.store offset=104
-  global.get $~lib/memory/__stack_pointer
-  local.get $257
-  i32.load offset=4
-  local.tee $258
-  i32.store offset=108
-  local.get $257
+  local.tee $146
+  i32.store offset=100
+  local.get $146
   i32.const 0
   i32.const 0
   i32.const 1
   call $std/array/Ref#constructor
   call $~lib/array/Array<std/array/Ref>#__set
-  local.get $257
+  local.get $146
   i32.const 1
   i32.const 0
   i32.const 2
   call $std/array/Ref#constructor
   call $~lib/array/Array<std/array/Ref>#__set
-  local.get $257
+  local.get $146
   i32.const 2
   i32.const 0
   i32.const 3
   call $std/array/Ref#constructor
   call $~lib/array/Array<std/array/Ref>#__set
-  local.get $257
+  local.get $146
   i32.const 3
   i32.const 0
   i32.const 4
   call $std/array/Ref#constructor
   call $~lib/array/Array<std/array/Ref>#__set
-  local.get $257
+  local.get $146
   i32.const 4
   i32.const 0
   i32.const 5
   call $std/array/Ref#constructor
   call $~lib/array/Array<std/array/Ref>#__set
-  local.get $257
-  local.tee $255
-  i32.store offset=96
+  local.get $146
+  local.tee $144
+  i32.store offset=92
   global.get $~lib/memory/__stack_pointer
-  local.get $255
-  local.set $478
+  local.get $144
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store
-  local.get $478
+  local.get $296
   i32.const 2
   i32.const 2
   call $~lib/array/Array<std/array/Ref>#splice
-  local.tee $256
-  i32.store offset=100
-  local.get $256
-  local.set $478
+  local.tee $145
+  i32.store offset=96
+  local.get $145
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store
-  local.get $478
+  local.get $296
   call $~lib/array/Array<std/array/Ref>#get:length
   i32.const 2
   i32.eq
@@ -39772,19 +39580,19 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $256
-  local.set $478
+  local.get $145
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store offset=8
-  local.get $478
+  local.get $296
   i32.const 0
   call $~lib/array/Array<std/array/Ref>#__get
-  local.set $478
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store
-  local.get $478
+  local.get $296
   call $std/array/Ref#get:v
   i32.const 3
   i32.eq
@@ -39797,19 +39605,19 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $256
-  local.set $478
+  local.get $145
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store offset=8
-  local.get $478
+  local.get $296
   i32.const 1
   call $~lib/array/Array<std/array/Ref>#__get
-  local.set $478
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store
-  local.get $478
+  local.get $296
   call $std/array/Ref#get:v
   i32.const 4
   i32.eq
@@ -39822,12 +39630,12 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $255
-  local.set $478
+  local.get $144
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store
-  local.get $478
+  local.get $296
   call $~lib/array/Array<std/array/Ref>#get:length
   i32.const 3
   i32.eq
@@ -39840,19 +39648,19 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $255
-  local.set $478
+  local.get $144
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store offset=8
-  local.get $478
+  local.get $296
   i32.const 0
   call $~lib/array/Array<std/array/Ref>#__get
-  local.set $478
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store
-  local.get $478
+  local.get $296
   call $std/array/Ref#get:v
   i32.const 1
   i32.eq
@@ -39865,19 +39673,19 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $255
-  local.set $478
+  local.get $144
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store offset=8
-  local.get $478
+  local.get $296
   i32.const 1
   call $~lib/array/Array<std/array/Ref>#__get
-  local.set $478
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store
-  local.get $478
+  local.get $296
   call $std/array/Ref#get:v
   i32.const 2
   i32.eq
@@ -39890,19 +39698,19 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $255
-  local.set $478
+  local.get $144
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store offset=8
-  local.get $478
+  local.get $296
   i32.const 2
   call $~lib/array/Array<std/array/Ref>#__get
-  local.set $478
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store
-  local.get $478
+  local.get $296
   call $std/array/Ref#get:v
   i32.const 5
   i32.eq
@@ -39922,50 +39730,45 @@
   i32.const 13
   i32.const 0
   call $~lib/rt/__newArray
-  local.tee $259
-  i32.store offset=112
-  global.get $~lib/memory/__stack_pointer
-  local.get $259
-  i32.load offset=4
-  local.tee $260
-  i32.store offset=116
-  local.get $259
+  local.tee $147
+  i32.store offset=104
+  local.get $147
   i32.const 0
   i32.const 0
   i32.const 1
   call $std/array/Ref#constructor
   call $~lib/array/Array<std/array/Ref|null>#__set
-  local.get $259
+  local.get $147
   i32.const 1
   i32.const 0
   call $~lib/array/Array<std/array/Ref|null>#__set
-  local.get $259
+  local.get $147
   i32.const 2
   i32.const 0
   i32.const 2
   call $std/array/Ref#constructor
   call $~lib/array/Array<std/array/Ref|null>#__set
-  local.get $259
-  local.tee $261
-  i32.store offset=120
+  local.get $147
+  local.tee $148
+  i32.store offset=108
   global.get $~lib/memory/__stack_pointer
-  local.get $261
-  local.set $478
+  local.get $148
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store
-  local.get $478
+  local.get $296
   i32.const 0
   i32.const 1
   call $~lib/array/Array<std/array/Ref|null>#splice
-  local.tee $262
-  i32.store offset=124
-  local.get $262
-  local.set $478
+  local.tee $149
+  i32.store offset=112
+  local.get $149
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store
-  local.get $478
+  local.get $296
   call $~lib/array/Array<std/array/Ref|null>#get:length
   i32.const 1
   i32.eq
@@ -39979,19 +39782,19 @@
    unreachable
   end
   global.get $~lib/memory/__stack_pointer
-  local.get $262
-  local.set $478
+  local.get $149
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store offset=8
-  local.get $478
+  local.get $296
   i32.const 0
   call $~lib/array/Array<std/array/Ref|null>#__get
-  local.tee $263
-  i32.store offset=128
-  local.get $263
+  local.tee $150
+  i32.store offset=116
+  local.get $150
   if (result i32)
-   local.get $263
+   local.get $150
   else
    i32.const 5520
    i32.const 528
@@ -40000,11 +39803,11 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.set $478
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store
-  local.get $478
+  local.get $296
   call $std/array/Ref#get:v
   i32.const 1
   i32.eq
@@ -40017,12 +39820,12 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $261
-  local.set $478
+  local.get $148
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store
-  local.get $478
+  local.get $296
   call $~lib/array/Array<std/array/Ref|null>#get:length
   i32.const 2
   i32.eq
@@ -40035,12 +39838,12 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $261
-  local.set $478
+  local.get $148
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store
-  local.get $478
+  local.get $296
   i32.const 0
   call $~lib/array/Array<std/array/Ref|null>#__get
   i32.const 0
@@ -40055,19 +39858,19 @@
    unreachable
   end
   global.get $~lib/memory/__stack_pointer
-  local.get $261
-  local.set $478
+  local.get $148
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store offset=8
-  local.get $478
+  local.get $296
   i32.const 1
   call $~lib/array/Array<std/array/Ref|null>#__get
-  local.tee $264
-  i32.store offset=132
-  local.get $264
+  local.tee $151
+  i32.store offset=120
+  local.get $151
   if (result i32)
-   local.get $264
+   local.get $151
   else
    i32.const 5520
    i32.const 528
@@ -40076,11 +39879,11 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.set $478
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store
-  local.get $478
+  local.get $296
   call $std/array/Ref#get:v
   i32.const 2
   i32.eq
@@ -40094,53 +39897,53 @@
    unreachable
   end
   global.get $std/array/arr
-  local.set $478
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store
-  local.get $478
+  local.get $296
   i32.const 0
   i32.const 0
   call $~lib/array/Array<i32>#__set
   global.get $std/array/arr
-  local.set $478
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store
-  local.get $478
+  local.get $296
   i32.const 1
   i32.const 1
   call $~lib/array/Array<i32>#__set
   global.get $std/array/arr
-  local.set $478
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store
-  local.get $478
+  local.get $296
   i32.const 2
   i32.const 2
   call $~lib/array/Array<i32>#__set
   global.get $std/array/arr
-  local.set $478
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store
-  local.get $478
+  local.get $296
   i32.const 3
   i32.const 3
   call $~lib/array/Array<i32>#__set
   global.get $std/array/arr
-  local.set $478
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store
-  local.get $478
+  local.get $296
   i32.const 5648
-  local.set $478
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store offset=8
-  local.get $478
+  local.get $296
   call $~lib/array/Array<i32>#findIndex
   global.set $std/array/i
   global.get $std/array/i
@@ -40156,17 +39959,17 @@
    unreachable
   end
   global.get $std/array/arr
-  local.set $478
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store
-  local.get $478
+  local.get $296
   i32.const 5680
-  local.set $478
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store offset=8
-  local.get $478
+  local.get $296
   call $~lib/array/Array<i32>#findIndex
   global.set $std/array/i
   global.get $std/array/i
@@ -40182,17 +39985,17 @@
    unreachable
   end
   global.get $std/array/arr
-  local.set $478
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store
-  local.get $478
+  local.get $296
   i32.const 5712
-  local.set $478
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store offset=8
-  local.get $478
+  local.get $296
   call $~lib/array/Array<i32>#findIndex
   global.set $std/array/i
   global.get $std/array/i
@@ -40208,17 +40011,17 @@
    unreachable
   end
   global.get $std/array/arr
-  local.set $478
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store
-  local.get $478
+  local.get $296
   i32.const 5744
-  local.set $478
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store offset=8
-  local.get $478
+  local.get $296
   call $~lib/array/Array<i32>#findIndex
   global.set $std/array/i
   global.get $std/array/i
@@ -40234,11 +40037,11 @@
    unreachable
   end
   global.get $std/array/arr
-  local.set $478
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store
-  local.get $478
+  local.get $296
   call $~lib/array/Array<i32>#get:length
   i32.const 8
   i32.eq
@@ -40252,17 +40055,17 @@
    unreachable
   end
   global.get $std/array/arr
-  local.set $478
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store
-  local.get $478
+  local.get $296
   i32.const 5776
-  local.set $478
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store offset=8
-  local.get $478
+  local.get $296
   call $~lib/array/Array<i32>#findIndex
   global.set $std/array/i
   global.get $std/array/i
@@ -40278,49 +40081,49 @@
    unreachable
   end
   global.get $std/array/arr
-  local.set $478
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store
-  local.get $478
+  local.get $296
   call $~lib/array/Array<i32>#pop
   drop
   global.get $std/array/arr
-  local.set $478
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store
-  local.get $478
+  local.get $296
   call $~lib/array/Array<i32>#pop
   drop
   global.get $std/array/arr
-  local.set $478
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store
-  local.get $478
+  local.get $296
   call $~lib/array/Array<i32>#pop
   drop
   global.get $std/array/arr
-  local.set $478
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store
-  local.get $478
+  local.get $296
   call $~lib/array/Array<i32>#pop
   drop
   global.get $std/array/arr
-  local.set $478
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store
-  local.get $478
+  local.get $296
   i32.const 5808
-  local.set $478
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store offset=8
-  local.get $478
+  local.get $296
   call $~lib/array/Array<i32>#findIndex
   global.set $std/array/i
   global.get $std/array/i
@@ -40336,11 +40139,11 @@
    unreachable
   end
   global.get $std/array/arr
-  local.set $478
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store
-  local.get $478
+  local.get $296
   call $~lib/array/Array<i32>#get:length
   i32.const 2
   i32.eq
@@ -40354,20 +40157,20 @@
    unreachable
   end
   global.get $std/array/arr
-  local.set $478
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store
-  local.get $478
+  local.get $296
   i32.const 2
   call $~lib/array/Array<i32>#push
   drop
   global.get $std/array/arr
-  local.set $478
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store
-  local.get $478
+  local.get $296
   i32.const 3
   call $~lib/array/Array<i32>#push
   drop
@@ -40377,20 +40180,20 @@
   i32.const 4
   i32.const 5840
   call $~lib/rt/__newArray
-  local.tee $267
-  i32.store offset=136
-  local.get $267
-  local.set $478
+  local.tee $153
+  i32.store offset=124
+  local.get $153
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store
-  local.get $478
+  local.get $296
   i32.const 5888
-  local.set $478
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store offset=8
-  local.get $478
+  local.get $296
   call $~lib/array/Array<i32>#findLastIndex
   global.set $std/array/i
   global.get $std/array/i
@@ -40405,18 +40208,18 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $267
-  local.set $478
+  local.get $153
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store
-  local.get $478
+  local.get $296
   i32.const 5920
-  local.set $478
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store offset=8
-  local.get $478
+  local.get $296
   call $~lib/array/Array<i32>#findLastIndex
   global.set $std/array/i
   global.get $std/array/i
@@ -40431,18 +40234,18 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $267
-  local.set $478
+  local.get $153
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store
-  local.get $478
+  local.get $296
   i32.const 5952
-  local.set $478
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store offset=8
-  local.get $478
+  local.get $296
   call $~lib/array/Array<i32>#findLastIndex
   global.set $std/array/i
   global.get $std/array/i
@@ -40457,18 +40260,18 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $267
-  local.set $478
+  local.get $153
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store
-  local.get $478
+  local.get $296
   i32.const 5984
-  local.set $478
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store offset=8
-  local.get $478
+  local.get $296
   call $~lib/array/Array<i32>#findLastIndex
   global.set $std/array/i
   global.get $std/array/i
@@ -40484,20 +40287,20 @@
    unreachable
   end
   global.get $std/array/arr
-  local.set $478
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store
-  local.get $478
+  local.get $296
   i32.const 6016
-  local.set $478
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store offset=8
-  local.get $478
+  local.get $296
   call $~lib/array/Array<i32>#every
-  local.set $268
-  local.get $268
+  local.set $154
+  local.get $154
   i32.const 1
   i32.eq
   i32.eqz
@@ -40510,20 +40313,20 @@
    unreachable
   end
   global.get $std/array/arr
-  local.set $478
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store
-  local.get $478
+  local.get $296
   i32.const 6048
-  local.set $478
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store offset=8
-  local.get $478
+  local.get $296
   call $~lib/array/Array<i32>#every
-  local.set $268
-  local.get $268
+  local.set $154
+  local.get $154
   i32.const 0
   i32.eq
   i32.eqz
@@ -40536,20 +40339,20 @@
    unreachable
   end
   global.get $std/array/arr
-  local.set $478
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store
-  local.get $478
+  local.get $296
   i32.const 6080
-  local.set $478
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store offset=8
-  local.get $478
+  local.get $296
   call $~lib/array/Array<i32>#every
-  local.set $268
-  local.get $268
+  local.set $154
+  local.get $154
   i32.const 1
   i32.eq
   i32.eqz
@@ -40562,11 +40365,11 @@
    unreachable
   end
   global.get $std/array/arr
-  local.set $478
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store
-  local.get $478
+  local.get $296
   call $~lib/array/Array<i32>#get:length
   i32.const 8
   i32.eq
@@ -40580,20 +40383,20 @@
    unreachable
   end
   global.get $std/array/arr
-  local.set $478
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store
-  local.get $478
+  local.get $296
   i32.const 6112
-  local.set $478
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store offset=8
-  local.get $478
+  local.get $296
   call $~lib/array/Array<i32>#every
-  local.set $268
-  local.get $268
+  local.set $154
+  local.get $154
   i32.const 0
   i32.eq
   i32.eqz
@@ -40606,52 +40409,52 @@
    unreachable
   end
   global.get $std/array/arr
-  local.set $478
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store
-  local.get $478
+  local.get $296
   call $~lib/array/Array<i32>#pop
   drop
   global.get $std/array/arr
-  local.set $478
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store
-  local.get $478
+  local.get $296
   call $~lib/array/Array<i32>#pop
   drop
   global.get $std/array/arr
-  local.set $478
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store
-  local.get $478
+  local.get $296
   call $~lib/array/Array<i32>#pop
   drop
   global.get $std/array/arr
-  local.set $478
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store
-  local.get $478
+  local.get $296
   call $~lib/array/Array<i32>#pop
   drop
   global.get $std/array/arr
-  local.set $478
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store
-  local.get $478
+  local.get $296
   i32.const 6144
-  local.set $478
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store offset=8
-  local.get $478
+  local.get $296
   call $~lib/array/Array<i32>#every
-  local.set $268
-  local.get $268
+  local.set $154
+  local.get $154
   i32.const 1
   i32.eq
   i32.eqz
@@ -40664,11 +40467,11 @@
    unreachable
   end
   global.get $std/array/arr
-  local.set $478
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store
-  local.get $478
+  local.get $296
   call $~lib/array/Array<i32>#get:length
   i32.const 2
   i32.eq
@@ -40682,38 +40485,38 @@
    unreachable
   end
   global.get $std/array/arr
-  local.set $478
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store
-  local.get $478
+  local.get $296
   i32.const 2
   call $~lib/array/Array<i32>#push
   drop
   global.get $std/array/arr
-  local.set $478
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store
-  local.get $478
+  local.get $296
   i32.const 3
   call $~lib/array/Array<i32>#push
   drop
   global.get $std/array/arr
-  local.set $478
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store
-  local.get $478
+  local.get $296
   i32.const 6176
-  local.set $478
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store offset=8
-  local.get $478
+  local.get $296
   call $~lib/array/Array<i32>#some
-  local.set $269
-  local.get $269
+  local.set $155
+  local.get $155
   i32.const 1
   i32.eq
   i32.eqz
@@ -40726,20 +40529,20 @@
    unreachable
   end
   global.get $std/array/arr
-  local.set $478
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store
-  local.get $478
+  local.get $296
   i32.const 6208
-  local.set $478
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store offset=8
-  local.get $478
+  local.get $296
   call $~lib/array/Array<i32>#some
-  local.set $269
-  local.get $269
+  local.set $155
+  local.get $155
   i32.const 0
   i32.eq
   i32.eqz
@@ -40752,20 +40555,20 @@
    unreachable
   end
   global.get $std/array/arr
-  local.set $478
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store
-  local.get $478
+  local.get $296
   i32.const 6240
-  local.set $478
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store offset=8
-  local.get $478
+  local.get $296
   call $~lib/array/Array<i32>#some
-  local.set $269
-  local.get $269
+  local.set $155
+  local.get $155
   i32.const 0
   i32.eq
   i32.eqz
@@ -40778,11 +40581,11 @@
    unreachable
   end
   global.get $std/array/arr
-  local.set $478
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store
-  local.get $478
+  local.get $296
   call $~lib/array/Array<i32>#get:length
   i32.const 8
   i32.eq
@@ -40796,20 +40599,20 @@
    unreachable
   end
   global.get $std/array/arr
-  local.set $478
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store
-  local.get $478
+  local.get $296
   i32.const 6272
-  local.set $478
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store offset=8
-  local.get $478
+  local.get $296
   call $~lib/array/Array<i32>#some
-  local.set $269
-  local.get $269
+  local.set $155
+  local.get $155
   i32.const 1
   i32.eq
   i32.eqz
@@ -40822,52 +40625,52 @@
    unreachable
   end
   global.get $std/array/arr
-  local.set $478
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store
-  local.get $478
+  local.get $296
   call $~lib/array/Array<i32>#pop
   drop
   global.get $std/array/arr
-  local.set $478
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store
-  local.get $478
+  local.get $296
   call $~lib/array/Array<i32>#pop
   drop
   global.get $std/array/arr
-  local.set $478
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store
-  local.get $478
+  local.get $296
   call $~lib/array/Array<i32>#pop
   drop
   global.get $std/array/arr
-  local.set $478
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store
-  local.get $478
+  local.get $296
   call $~lib/array/Array<i32>#pop
   drop
   global.get $std/array/arr
-  local.set $478
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store
-  local.get $478
+  local.get $296
   i32.const 6304
-  local.set $478
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store offset=8
-  local.get $478
+  local.get $296
   call $~lib/array/Array<i32>#some
-  local.set $269
-  local.get $269
+  local.set $155
+  local.get $155
   i32.const 0
   i32.eq
   i32.eqz
@@ -40880,11 +40683,11 @@
    unreachable
   end
   global.get $std/array/arr
-  local.set $478
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store
-  local.get $478
+  local.get $296
   call $~lib/array/Array<i32>#get:length
   i32.const 2
   i32.eq
@@ -40898,37 +40701,37 @@
    unreachable
   end
   global.get $std/array/arr
-  local.set $478
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store
-  local.get $478
+  local.get $296
   i32.const 2
   call $~lib/array/Array<i32>#push
   drop
   global.get $std/array/arr
-  local.set $478
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store
-  local.get $478
+  local.get $296
   i32.const 3
   call $~lib/array/Array<i32>#push
   drop
   i32.const 0
   global.set $std/array/i
   global.get $std/array/arr
-  local.set $478
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store
-  local.get $478
+  local.get $296
   i32.const 6336
-  local.set $478
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store offset=8
-  local.get $478
+  local.get $296
   call $~lib/array/Array<i32>#forEach
   global.get $std/array/i
   i32.const 6
@@ -40945,17 +40748,17 @@
   i32.const 0
   global.set $std/array/i
   global.get $std/array/arr
-  local.set $478
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store
-  local.get $478
+  local.get $296
   i32.const 6368
-  local.set $478
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store offset=8
-  local.get $478
+  local.get $296
   call $~lib/array/Array<i32>#forEach
   global.get $std/array/i
   i32.const 6
@@ -40970,11 +40773,11 @@
    unreachable
   end
   global.get $std/array/arr
-  local.set $478
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store
-  local.get $478
+  local.get $296
   call $~lib/array/Array<i32>#get:length
   i32.const 8
   i32.eq
@@ -40990,17 +40793,17 @@
   i32.const 0
   global.set $std/array/i
   global.get $std/array/arr
-  local.set $478
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store
-  local.get $478
+  local.get $296
   i32.const 6400
-  local.set $478
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store offset=8
-  local.get $478
+  local.get $296
   call $~lib/array/Array<i32>#forEach
   global.get $std/array/i
   i32.const 406
@@ -41015,51 +40818,51 @@
    unreachable
   end
   global.get $std/array/arr
-  local.set $478
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store
-  local.get $478
+  local.get $296
   call $~lib/array/Array<i32>#pop
   drop
   global.get $std/array/arr
-  local.set $478
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store
-  local.get $478
+  local.get $296
   call $~lib/array/Array<i32>#pop
   drop
   global.get $std/array/arr
-  local.set $478
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store
-  local.get $478
+  local.get $296
   call $~lib/array/Array<i32>#pop
   drop
   global.get $std/array/arr
-  local.set $478
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store
-  local.get $478
+  local.get $296
   call $~lib/array/Array<i32>#pop
   drop
   i32.const 0
   global.set $std/array/i
   global.get $std/array/arr
-  local.set $478
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store
-  local.get $478
+  local.get $296
   i32.const 6432
-  local.set $478
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store offset=8
-  local.get $478
+  local.get $296
   call $~lib/array/Array<i32>#forEach
   global.get $std/array/i
   i32.const 1
@@ -41074,11 +40877,11 @@
    unreachable
   end
   global.get $std/array/arr
-  local.set $478
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store
-  local.get $478
+  local.get $296
   call $~lib/array/Array<i32>#get:length
   i32.const 2
   i32.eq
@@ -41092,42 +40895,42 @@
    unreachable
   end
   global.get $std/array/arr
-  local.set $478
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store
-  local.get $478
+  local.get $296
   i32.const 2
   call $~lib/array/Array<i32>#push
   drop
   global.get $std/array/arr
-  local.set $478
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store
-  local.get $478
+  local.get $296
   i32.const 3
   call $~lib/array/Array<i32>#push
   drop
   global.get $std/array/arr
-  local.set $478
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store
-  local.get $478
+  local.get $296
   i32.const 6464
-  local.set $478
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store offset=8
-  local.get $478
+  local.get $296
   call $~lib/array/Array<i32>#forEach
   global.get $std/array/arr
-  local.set $478
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store
-  local.get $478
+  local.get $296
   call $~lib/array/Array<i32>#get:length
   i32.const 100
   i32.eq
@@ -41141,101 +40944,101 @@
    unreachable
   end
   i32.const 0
-  local.set $270
+  local.set $156
   loop $for-loop|6
-   local.get $270
+   local.get $156
    i32.const 100
    i32.lt_s
    if
     global.get $std/array/arr
-    local.set $478
+    local.set $296
     global.get $~lib/memory/__stack_pointer
-    local.get $478
+    local.get $296
     i32.store
-    local.get $478
+    local.get $296
     call $~lib/array/Array<i32>#pop
     drop
-    local.get $270
+    local.get $156
     i32.const 1
     i32.add
-    local.set $270
+    local.set $156
     br $for-loop|6
    end
   end
   global.get $std/array/arr
-  local.set $478
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store
-  local.get $478
+  local.get $296
   i32.const 0
   call $~lib/array/Array<i32>#push
   drop
   global.get $std/array/arr
-  local.set $478
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store
-  local.get $478
+  local.get $296
   i32.const 1
   call $~lib/array/Array<i32>#push
   drop
   global.get $std/array/arr
-  local.set $478
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store
-  local.get $478
+  local.get $296
   i32.const 2
   call $~lib/array/Array<i32>#push
   drop
   global.get $std/array/arr
-  local.set $478
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store
-  local.get $478
+  local.get $296
   i32.const 3
   call $~lib/array/Array<i32>#push
   drop
   global.get $~lib/memory/__stack_pointer
   global.get $std/array/arr
-  local.set $478
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store
-  local.get $478
+  local.get $296
   i32.const 8272
-  local.set $478
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store offset=8
-  local.get $478
+  local.get $296
   call $~lib/array/Array<i32>#map<~lib/string/String>
-  local.tee $271
-  i32.store offset=140
+  local.tee $157
+  i32.store offset=128
   global.get $~lib/memory/__stack_pointer
   global.get $std/array/arr
-  local.set $478
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store
-  local.get $478
+  local.get $296
   i32.const 8304
-  local.set $478
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store offset=8
-  local.get $478
+  local.get $296
   call $~lib/array/Array<i32>#map<f32>
-  local.tee $272
-  i32.store offset=144
-  local.get $272
-  local.set $478
+  local.tee $158
+  i32.store offset=132
+  local.get $158
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store
-  local.get $478
+  local.get $296
   call $~lib/array/Array<f32>#get:length
   i32.const 4
   i32.eq
@@ -41248,20 +41051,20 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $272
-  local.set $478
+  local.get $158
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store
-  local.get $478
+  local.get $296
   i32.const 0
   call $~lib/array/Array<f32>#__get
   global.get $std/array/arr
-  local.set $478
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store
-  local.get $478
+  local.get $296
   i32.const 0
   call $~lib/array/Array<i32>#__get
   f32.convert_i32_s
@@ -41278,17 +41081,17 @@
   i32.const 0
   global.set $std/array/i
   global.get $std/array/arr
-  local.set $478
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store
-  local.get $478
+  local.get $296
   i32.const 8336
-  local.set $478
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store offset=8
-  local.get $478
+  local.get $296
   call $~lib/array/Array<i32>#map<i32>
   drop
   global.get $std/array/i
@@ -41304,11 +41107,11 @@
    unreachable
   end
   global.get $std/array/arr
-  local.set $478
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store
-  local.get $478
+  local.get $296
   call $~lib/array/Array<i32>#get:length
   i32.const 8
   i32.eq
@@ -41324,17 +41127,17 @@
   i32.const 0
   global.set $std/array/i
   global.get $std/array/arr
-  local.set $478
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store
-  local.get $478
+  local.get $296
   i32.const 8368
-  local.set $478
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store offset=8
-  local.get $478
+  local.get $296
   call $~lib/array/Array<i32>#map<i32>
   drop
   global.get $std/array/i
@@ -41350,51 +41153,51 @@
    unreachable
   end
   global.get $std/array/arr
-  local.set $478
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store
-  local.get $478
+  local.get $296
   call $~lib/array/Array<i32>#pop
   drop
   global.get $std/array/arr
-  local.set $478
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store
-  local.get $478
+  local.get $296
   call $~lib/array/Array<i32>#pop
   drop
   global.get $std/array/arr
-  local.set $478
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store
-  local.get $478
+  local.get $296
   call $~lib/array/Array<i32>#pop
   drop
   global.get $std/array/arr
-  local.set $478
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store
-  local.get $478
+  local.get $296
   call $~lib/array/Array<i32>#pop
   drop
   i32.const 0
   global.set $std/array/i
   global.get $std/array/arr
-  local.set $478
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store
-  local.get $478
+  local.get $296
   i32.const 8400
-  local.set $478
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store offset=8
-  local.get $478
+  local.get $296
   call $~lib/array/Array<i32>#map<i32>
   drop
   global.get $std/array/i
@@ -41410,11 +41213,11 @@
    unreachable
   end
   global.get $std/array/arr
-  local.set $478
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store
-  local.get $478
+  local.get $296
   call $~lib/array/Array<i32>#get:length
   i32.const 2
   i32.eq
@@ -41428,45 +41231,45 @@
    unreachable
   end
   global.get $std/array/arr
-  local.set $478
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store
-  local.get $478
+  local.get $296
   i32.const 2
   call $~lib/array/Array<i32>#push
   drop
   global.get $std/array/arr
-  local.set $478
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store
-  local.get $478
+  local.get $296
   i32.const 3
   call $~lib/array/Array<i32>#push
   drop
   global.get $~lib/memory/__stack_pointer
   global.get $std/array/arr
-  local.set $478
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store
-  local.get $478
+  local.get $296
   i32.const 8432
-  local.set $478
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store offset=8
-  local.get $478
+  local.get $296
   call $~lib/array/Array<i32>#filter
-  local.tee $273
-  i32.store offset=148
-  local.get $273
-  local.set $478
+  local.tee $159
+  i32.store offset=136
+  local.get $159
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store
-  local.get $478
+  local.get $296
   call $~lib/array/Array<i32>#get:length
   i32.const 2
   i32.eq
@@ -41482,17 +41285,17 @@
   i32.const 0
   global.set $std/array/i
   global.get $std/array/arr
-  local.set $478
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store
-  local.get $478
+  local.get $296
   i32.const 8464
-  local.set $478
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store offset=8
-  local.get $478
+  local.get $296
   call $~lib/array/Array<i32>#filter
   drop
   global.get $std/array/i
@@ -41508,11 +41311,11 @@
    unreachable
   end
   global.get $std/array/arr
-  local.set $478
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store
-  local.get $478
+  local.get $296
   call $~lib/array/Array<i32>#get:length
   i32.const 8
   i32.eq
@@ -41528,17 +41331,17 @@
   i32.const 0
   global.set $std/array/i
   global.get $std/array/arr
-  local.set $478
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store
-  local.get $478
+  local.get $296
   i32.const 8496
-  local.set $478
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store offset=8
-  local.get $478
+  local.get $296
   call $~lib/array/Array<i32>#filter
   drop
   global.get $std/array/i
@@ -41554,51 +41357,51 @@
    unreachable
   end
   global.get $std/array/arr
-  local.set $478
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store
-  local.get $478
+  local.get $296
   call $~lib/array/Array<i32>#pop
   drop
   global.get $std/array/arr
-  local.set $478
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store
-  local.get $478
+  local.get $296
   call $~lib/array/Array<i32>#pop
   drop
   global.get $std/array/arr
-  local.set $478
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store
-  local.get $478
+  local.get $296
   call $~lib/array/Array<i32>#pop
   drop
   global.get $std/array/arr
-  local.set $478
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store
-  local.get $478
+  local.get $296
   call $~lib/array/Array<i32>#pop
   drop
   i32.const 0
   global.set $std/array/i
   global.get $std/array/arr
-  local.set $478
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store
-  local.get $478
+  local.get $296
   i32.const 8528
-  local.set $478
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store offset=8
-  local.get $478
+  local.get $296
   call $~lib/array/Array<i32>#filter
   drop
   global.get $std/array/i
@@ -41614,11 +41417,11 @@
    unreachable
   end
   global.get $std/array/arr
-  local.set $478
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store
-  local.get $478
+  local.get $296
   call $~lib/array/Array<i32>#get:length
   i32.const 2
   i32.eq
@@ -41632,35 +41435,35 @@
    unreachable
   end
   global.get $std/array/arr
-  local.set $478
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store
-  local.get $478
+  local.get $296
   i32.const 2
   call $~lib/array/Array<i32>#push
   drop
   global.get $std/array/arr
-  local.set $478
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store
-  local.get $478
+  local.get $296
   i32.const 3
   call $~lib/array/Array<i32>#push
   drop
   global.get $std/array/arr
-  local.set $478
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store
-  local.get $478
+  local.get $296
   i32.const 8560
-  local.set $478
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store offset=8
-  local.get $478
+  local.get $296
   i32.const 0
   call $~lib/array/Array<i32>#reduce<i32>
   global.set $std/array/i
@@ -41677,17 +41480,17 @@
    unreachable
   end
   global.get $std/array/arr
-  local.set $478
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store
-  local.get $478
+  local.get $296
   i32.const 8592
-  local.set $478
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store offset=8
-  local.get $478
+  local.get $296
   i32.const 4
   call $~lib/array/Array<i32>#reduce<i32>
   global.set $std/array/i
@@ -41704,21 +41507,21 @@
    unreachable
   end
   global.get $std/array/arr
-  local.set $478
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store
-  local.get $478
+  local.get $296
   i32.const 8624
-  local.set $478
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store offset=8
-  local.get $478
+  local.get $296
   i32.const 0
   call $~lib/array/Array<i32>#reduce<bool>
-  local.set $274
-  local.get $274
+  local.set $160
+  local.get $160
   i32.const 0
   i32.ne
   i32.const 1
@@ -41733,21 +41536,21 @@
    unreachable
   end
   global.get $std/array/arr
-  local.set $478
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store
-  local.get $478
+  local.get $296
   i32.const 8656
-  local.set $478
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store offset=8
-  local.get $478
+  local.get $296
   i32.const 0
   call $~lib/array/Array<i32>#reduce<bool>
-  local.set $274
-  local.get $274
+  local.set $160
+  local.get $160
   i32.const 0
   i32.ne
   i32.const 0
@@ -41762,17 +41565,17 @@
    unreachable
   end
   global.get $std/array/arr
-  local.set $478
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store
-  local.get $478
+  local.get $296
   i32.const 8688
-  local.set $478
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store offset=8
-  local.get $478
+  local.get $296
   i32.const 0
   call $~lib/array/Array<i32>#reduce<i32>
   global.set $std/array/i
@@ -41789,11 +41592,11 @@
    unreachable
   end
   global.get $std/array/arr
-  local.set $478
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store
-  local.get $478
+  local.get $296
   call $~lib/array/Array<i32>#get:length
   i32.const 8
   i32.eq
@@ -41807,17 +41610,17 @@
    unreachable
   end
   global.get $std/array/arr
-  local.set $478
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store
-  local.get $478
+  local.get $296
   i32.const 8720
-  local.set $478
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store offset=8
-  local.get $478
+  local.get $296
   i32.const 0
   call $~lib/array/Array<i32>#reduce<i32>
   global.set $std/array/i
@@ -41834,49 +41637,49 @@
    unreachable
   end
   global.get $std/array/arr
-  local.set $478
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store
-  local.get $478
+  local.get $296
   call $~lib/array/Array<i32>#pop
   drop
   global.get $std/array/arr
-  local.set $478
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store
-  local.get $478
+  local.get $296
   call $~lib/array/Array<i32>#pop
   drop
   global.get $std/array/arr
-  local.set $478
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store
-  local.get $478
+  local.get $296
   call $~lib/array/Array<i32>#pop
   drop
   global.get $std/array/arr
-  local.set $478
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store
-  local.get $478
+  local.get $296
   call $~lib/array/Array<i32>#pop
   drop
   global.get $std/array/arr
-  local.set $478
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store
-  local.get $478
+  local.get $296
   i32.const 8752
-  local.set $478
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store offset=8
-  local.get $478
+  local.get $296
   i32.const 0
   call $~lib/array/Array<i32>#reduce<i32>
   global.set $std/array/i
@@ -41893,11 +41696,11 @@
    unreachable
   end
   global.get $std/array/arr
-  local.set $478
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store
-  local.get $478
+  local.get $296
   call $~lib/array/Array<i32>#get:length
   i32.const 2
   i32.eq
@@ -41911,35 +41714,35 @@
    unreachable
   end
   global.get $std/array/arr
-  local.set $478
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store
-  local.get $478
+  local.get $296
   i32.const 2
   call $~lib/array/Array<i32>#push
   drop
   global.get $std/array/arr
-  local.set $478
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store
-  local.get $478
+  local.get $296
   i32.const 3
   call $~lib/array/Array<i32>#push
   drop
   global.get $std/array/arr
-  local.set $478
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store
-  local.get $478
+  local.get $296
   i32.const 8784
-  local.set $478
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store offset=8
-  local.get $478
+  local.get $296
   i32.const 0
   call $~lib/array/Array<i32>#reduceRight<i32>
   global.set $std/array/i
@@ -41956,17 +41759,17 @@
    unreachable
   end
   global.get $std/array/arr
-  local.set $478
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store
-  local.get $478
+  local.get $296
   i32.const 8816
-  local.set $478
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store offset=8
-  local.get $478
+  local.get $296
   i32.const 4
   call $~lib/array/Array<i32>#reduceRight<i32>
   global.set $std/array/i
@@ -41983,21 +41786,21 @@
    unreachable
   end
   global.get $std/array/arr
-  local.set $478
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store
-  local.get $478
+  local.get $296
   i32.const 8848
-  local.set $478
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store offset=8
-  local.get $478
+  local.get $296
   i32.const 0
   call $~lib/array/Array<i32>#reduceRight<bool>
-  local.set $275
-  local.get $275
+  local.set $161
+  local.get $161
   i32.const 0
   i32.ne
   i32.const 1
@@ -42012,21 +41815,21 @@
    unreachable
   end
   global.get $std/array/arr
-  local.set $478
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store
-  local.get $478
+  local.get $296
   i32.const 8880
-  local.set $478
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store offset=8
-  local.get $478
+  local.get $296
   i32.const 0
   call $~lib/array/Array<i32>#reduceRight<bool>
-  local.set $275
-  local.get $275
+  local.set $161
+  local.get $161
   i32.const 0
   i32.ne
   i32.const 0
@@ -42041,17 +41844,17 @@
    unreachable
   end
   global.get $std/array/arr
-  local.set $478
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store
-  local.get $478
+  local.get $296
   i32.const 8912
-  local.set $478
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store offset=8
-  local.get $478
+  local.get $296
   i32.const 0
   call $~lib/array/Array<i32>#reduceRight<i32>
   global.set $std/array/i
@@ -42068,11 +41871,11 @@
    unreachable
   end
   global.get $std/array/arr
-  local.set $478
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store
-  local.get $478
+  local.get $296
   call $~lib/array/Array<i32>#get:length
   i32.const 8
   i32.eq
@@ -42086,17 +41889,17 @@
    unreachable
   end
   global.get $std/array/arr
-  local.set $478
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store
-  local.get $478
+  local.get $296
   i32.const 8944
-  local.set $478
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store offset=8
-  local.get $478
+  local.get $296
   i32.const 0
   call $~lib/array/Array<i32>#reduceRight<i32>
   global.set $std/array/i
@@ -42113,49 +41916,49 @@
    unreachable
   end
   global.get $std/array/arr
-  local.set $478
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store
-  local.get $478
+  local.get $296
   call $~lib/array/Array<i32>#pop
   drop
   global.get $std/array/arr
-  local.set $478
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store
-  local.get $478
+  local.get $296
   call $~lib/array/Array<i32>#pop
   drop
   global.get $std/array/arr
-  local.set $478
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store
-  local.get $478
+  local.get $296
   call $~lib/array/Array<i32>#pop
   drop
   global.get $std/array/arr
-  local.set $478
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store
-  local.get $478
+  local.get $296
   call $~lib/array/Array<i32>#pop
   drop
   global.get $std/array/arr
-  local.set $478
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store
-  local.get $478
+  local.get $296
   i32.const 8976
-  local.set $478
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store offset=8
-  local.get $478
+  local.get $296
   i32.const 0
   call $~lib/array/Array<i32>#reduceRight<i32>
   global.set $std/array/i
@@ -42172,11 +41975,11 @@
    unreachable
   end
   global.get $std/array/arr
-  local.set $478
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store
-  local.get $478
+  local.get $296
   call $~lib/array/Array<i32>#get:length
   i32.const 0
   i32.eq
@@ -42190,38 +41993,38 @@
    unreachable
   end
   global.get $std/array/arr
-  local.set $478
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store
-  local.get $478
+  local.get $296
   i32.const 0
   call $~lib/array/Array<i32>#push
   drop
   global.get $std/array/arr
-  local.set $478
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store
-  local.get $478
+  local.get $296
   i32.const 1
   call $~lib/array/Array<i32>#push
   drop
   global.get $std/array/arr
-  local.set $478
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store
-  local.get $478
+  local.get $296
   i32.const 2
   call $~lib/array/Array<i32>#push
   drop
   global.get $std/array/arr
-  local.set $478
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store
-  local.get $478
+  local.get $296
   i32.const 3
   call $~lib/array/Array<i32>#push
   drop
@@ -42234,314 +42037,309 @@
   i32.const 23
   i32.const 0
   call $~lib/rt/__newArray
-  local.tee $276
-  i32.store offset=152
-  global.get $~lib/memory/__stack_pointer
-  local.get $276
-  i32.load offset=4
-  local.tee $277
-  i32.store offset=156
-  local.get $276
+  local.tee $162
+  i32.store offset=140
+  local.get $162
   i32.const 0
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   call $std/array/Dim#constructor
-  local.tee $278
-  i32.store offset=160
-  local.get $278
-  local.set $478
+  local.tee $163
+  i32.store offset=144
+  local.get $163
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store
-  local.get $478
+  local.get $296
   i32.const 100
   call $std/array/Dim#set:height
-  local.get $278
-  local.set $478
+  local.get $163
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store
-  local.get $478
+  local.get $296
   i32.const 80
   call $std/array/Dim#set:width
-  local.get $278
+  local.get $163
   call $~lib/array/Array<std/array/Dim>#__set
-  local.get $276
+  local.get $162
   i32.const 1
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   call $std/array/Dim#constructor
-  local.tee $279
-  i32.store offset=164
-  local.get $279
-  local.set $478
+  local.tee $164
+  i32.store offset=148
+  local.get $164
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store
-  local.get $478
+  local.get $296
   i32.const 90
   call $std/array/Dim#set:height
-  local.get $279
-  local.set $478
+  local.get $164
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store
-  local.get $478
+  local.get $296
   i32.const 90
   call $std/array/Dim#set:width
-  local.get $279
+  local.get $164
   call $~lib/array/Array<std/array/Dim>#__set
-  local.get $276
+  local.get $162
   i32.const 2
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   call $std/array/Dim#constructor
-  local.tee $280
-  i32.store offset=168
-  local.get $280
-  local.set $478
+  local.tee $165
+  i32.store offset=152
+  local.get $165
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store
-  local.get $478
+  local.get $296
   i32.const 70
   call $std/array/Dim#set:height
-  local.get $280
-  local.set $478
+  local.get $165
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store
-  local.get $478
+  local.get $296
   i32.const 95
   call $std/array/Dim#set:width
-  local.get $280
+  local.get $165
   call $~lib/array/Array<std/array/Dim>#__set
-  local.get $276
+  local.get $162
   i32.const 3
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   call $std/array/Dim#constructor
-  local.tee $281
-  i32.store offset=172
-  local.get $281
-  local.set $478
+  local.tee $166
+  i32.store offset=156
+  local.get $166
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store
-  local.get $478
+  local.get $296
   i32.const 100
   call $std/array/Dim#set:height
-  local.get $281
-  local.set $478
+  local.get $166
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store
-  local.get $478
+  local.get $296
   i32.const 100
   call $std/array/Dim#set:width
-  local.get $281
+  local.get $166
   call $~lib/array/Array<std/array/Dim>#__set
-  local.get $276
+  local.get $162
   i32.const 4
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   call $std/array/Dim#constructor
-  local.tee $282
-  i32.store offset=176
-  local.get $282
-  local.set $478
+  local.tee $167
+  i32.store offset=160
+  local.get $167
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store
-  local.get $478
+  local.get $296
   i32.const 80
   call $std/array/Dim#set:height
-  local.get $282
-  local.set $478
+  local.get $167
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store
-  local.get $478
+  local.get $296
   i32.const 110
   call $std/array/Dim#set:width
-  local.get $282
+  local.get $167
   call $~lib/array/Array<std/array/Dim>#__set
-  local.get $276
+  local.get $162
   i32.const 5
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   call $std/array/Dim#constructor
-  local.tee $283
-  i32.store offset=180
-  local.get $283
-  local.set $478
+  local.tee $168
+  i32.store offset=164
+  local.get $168
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store
-  local.get $478
+  local.get $296
   i32.const 110
   call $std/array/Dim#set:height
-  local.get $283
-  local.set $478
+  local.get $168
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store
-  local.get $478
+  local.get $296
   i32.const 115
   call $std/array/Dim#set:width
-  local.get $283
+  local.get $168
   call $~lib/array/Array<std/array/Dim>#__set
-  local.get $276
+  local.get $162
   i32.const 6
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   call $std/array/Dim#constructor
-  local.tee $284
-  i32.store offset=184
-  local.get $284
-  local.set $478
+  local.tee $169
+  i32.store offset=168
+  local.get $169
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store
-  local.get $478
+  local.get $296
   i32.const 100
   call $std/array/Dim#set:height
-  local.get $284
-  local.set $478
+  local.get $169
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store
-  local.get $478
+  local.get $296
   i32.const 120
   call $std/array/Dim#set:width
-  local.get $284
+  local.get $169
   call $~lib/array/Array<std/array/Dim>#__set
-  local.get $276
+  local.get $162
   i32.const 7
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   call $std/array/Dim#constructor
-  local.tee $285
-  i32.store offset=188
-  local.get $285
-  local.set $478
+  local.tee $170
+  i32.store offset=172
+  local.get $170
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store
-  local.get $478
+  local.get $296
   i32.const 70
   call $std/array/Dim#set:height
-  local.get $285
-  local.set $478
+  local.get $170
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store
-  local.get $478
+  local.get $296
   i32.const 125
   call $std/array/Dim#set:width
-  local.get $285
+  local.get $170
   call $~lib/array/Array<std/array/Dim>#__set
-  local.get $276
+  local.get $162
   i32.const 8
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   call $std/array/Dim#constructor
-  local.tee $286
-  i32.store offset=192
-  local.get $286
-  local.set $478
+  local.tee $171
+  i32.store offset=176
+  local.get $171
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store
-  local.get $478
+  local.get $296
   i32.const 70
   call $std/array/Dim#set:height
-  local.get $286
-  local.set $478
+  local.get $171
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store
-  local.get $478
+  local.get $296
   i32.const 130
   call $std/array/Dim#set:width
-  local.get $286
+  local.get $171
   call $~lib/array/Array<std/array/Dim>#__set
-  local.get $276
+  local.get $162
   i32.const 9
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   call $std/array/Dim#constructor
-  local.tee $287
-  i32.store offset=196
-  local.get $287
-  local.set $478
+  local.tee $172
+  i32.store offset=180
+  local.get $172
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store
-  local.get $478
+  local.get $296
   i32.const 100
   call $std/array/Dim#set:height
-  local.get $287
-  local.set $478
+  local.get $172
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store
-  local.get $478
+  local.get $296
   i32.const 135
   call $std/array/Dim#set:width
-  local.get $287
+  local.get $172
   call $~lib/array/Array<std/array/Dim>#__set
-  local.get $276
+  local.get $162
   i32.const 10
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   call $std/array/Dim#constructor
-  local.tee $288
-  i32.store offset=200
-  local.get $288
-  local.set $478
+  local.tee $173
+  i32.store offset=184
+  local.get $173
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store
-  local.get $478
+  local.get $296
   i32.const 75
   call $std/array/Dim#set:height
-  local.get $288
-  local.set $478
+  local.get $173
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store
-  local.get $478
+  local.get $296
   i32.const 140
   call $std/array/Dim#set:width
-  local.get $288
+  local.get $173
   call $~lib/array/Array<std/array/Dim>#__set
-  local.get $276
+  local.get $162
   i32.const 11
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   call $std/array/Dim#constructor
-  local.tee $289
-  i32.store offset=204
-  local.get $289
-  local.set $478
+  local.tee $174
+  i32.store offset=188
+  local.get $174
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store
-  local.get $478
+  local.get $296
   i32.const 70
   call $std/array/Dim#set:height
-  local.get $289
-  local.set $478
+  local.get $174
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store
-  local.get $478
+  local.get $296
   i32.const 140
   call $std/array/Dim#set:width
-  local.get $289
+  local.get $174
   call $~lib/array/Array<std/array/Dim>#__set
-  local.get $276
+  local.get $162
   global.set $std/array/inputStabArr
   global.get $~lib/memory/__stack_pointer
   i32.const 12
@@ -42549,314 +42347,309 @@
   i32.const 23
   i32.const 0
   call $~lib/rt/__newArray
-  local.tee $290
-  i32.store offset=208
-  global.get $~lib/memory/__stack_pointer
-  local.get $290
-  i32.load offset=4
-  local.tee $291
-  i32.store offset=212
-  local.get $290
+  local.tee $175
+  i32.store offset=192
+  local.get $175
   i32.const 0
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   call $std/array/Dim#constructor
-  local.tee $292
-  i32.store offset=216
-  local.get $292
-  local.set $478
+  local.tee $176
+  i32.store offset=196
+  local.get $176
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store
-  local.get $478
+  local.get $296
   i32.const 70
   call $std/array/Dim#set:height
-  local.get $292
-  local.set $478
+  local.get $176
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store
-  local.get $478
+  local.get $296
   i32.const 95
   call $std/array/Dim#set:width
-  local.get $292
+  local.get $176
   call $~lib/array/Array<std/array/Dim>#__set
-  local.get $290
+  local.get $175
   i32.const 1
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   call $std/array/Dim#constructor
-  local.tee $293
-  i32.store offset=220
-  local.get $293
-  local.set $478
+  local.tee $177
+  i32.store offset=200
+  local.get $177
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store
-  local.get $478
+  local.get $296
   i32.const 70
   call $std/array/Dim#set:height
-  local.get $293
-  local.set $478
+  local.get $177
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store
-  local.get $478
+  local.get $296
   i32.const 125
   call $std/array/Dim#set:width
-  local.get $293
+  local.get $177
   call $~lib/array/Array<std/array/Dim>#__set
-  local.get $290
+  local.get $175
   i32.const 2
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   call $std/array/Dim#constructor
-  local.tee $294
-  i32.store offset=224
-  local.get $294
-  local.set $478
+  local.tee $178
+  i32.store offset=204
+  local.get $178
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store
-  local.get $478
+  local.get $296
   i32.const 70
   call $std/array/Dim#set:height
-  local.get $294
-  local.set $478
+  local.get $178
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store
-  local.get $478
+  local.get $296
   i32.const 130
   call $std/array/Dim#set:width
-  local.get $294
+  local.get $178
   call $~lib/array/Array<std/array/Dim>#__set
-  local.get $290
+  local.get $175
   i32.const 3
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   call $std/array/Dim#constructor
-  local.tee $295
-  i32.store offset=228
-  local.get $295
-  local.set $478
+  local.tee $179
+  i32.store offset=208
+  local.get $179
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store
-  local.get $478
+  local.get $296
   i32.const 70
   call $std/array/Dim#set:height
-  local.get $295
-  local.set $478
+  local.get $179
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store
-  local.get $478
+  local.get $296
   i32.const 140
   call $std/array/Dim#set:width
-  local.get $295
+  local.get $179
   call $~lib/array/Array<std/array/Dim>#__set
-  local.get $290
+  local.get $175
   i32.const 4
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   call $std/array/Dim#constructor
-  local.tee $296
-  i32.store offset=232
-  local.get $296
-  local.set $478
+  local.tee $180
+  i32.store offset=212
+  local.get $180
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store
-  local.get $478
+  local.get $296
   i32.const 75
   call $std/array/Dim#set:height
-  local.get $296
-  local.set $478
+  local.get $180
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store
-  local.get $478
+  local.get $296
   i32.const 140
   call $std/array/Dim#set:width
-  local.get $296
+  local.get $180
   call $~lib/array/Array<std/array/Dim>#__set
-  local.get $290
+  local.get $175
   i32.const 5
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   call $std/array/Dim#constructor
-  local.tee $297
-  i32.store offset=236
-  local.get $297
-  local.set $478
+  local.tee $181
+  i32.store offset=216
+  local.get $181
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store
-  local.get $478
+  local.get $296
   i32.const 80
   call $std/array/Dim#set:height
-  local.get $297
-  local.set $478
+  local.get $181
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store
-  local.get $478
+  local.get $296
   i32.const 110
   call $std/array/Dim#set:width
-  local.get $297
+  local.get $181
   call $~lib/array/Array<std/array/Dim>#__set
-  local.get $290
+  local.get $175
   i32.const 6
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   call $std/array/Dim#constructor
-  local.tee $298
-  i32.store offset=240
-  local.get $298
-  local.set $478
+  local.tee $182
+  i32.store offset=220
+  local.get $182
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store
-  local.get $478
+  local.get $296
   i32.const 90
   call $std/array/Dim#set:height
-  local.get $298
-  local.set $478
+  local.get $182
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store
-  local.get $478
+  local.get $296
   i32.const 90
   call $std/array/Dim#set:width
-  local.get $298
+  local.get $182
   call $~lib/array/Array<std/array/Dim>#__set
-  local.get $290
+  local.get $175
   i32.const 7
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   call $std/array/Dim#constructor
-  local.tee $299
-  i32.store offset=244
-  local.get $299
-  local.set $478
+  local.tee $183
+  i32.store offset=224
+  local.get $183
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store
-  local.get $478
+  local.get $296
   i32.const 100
   call $std/array/Dim#set:height
-  local.get $299
-  local.set $478
+  local.get $183
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store
-  local.get $478
+  local.get $296
   i32.const 80
   call $std/array/Dim#set:width
-  local.get $299
+  local.get $183
   call $~lib/array/Array<std/array/Dim>#__set
-  local.get $290
+  local.get $175
   i32.const 8
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   call $std/array/Dim#constructor
-  local.tee $300
-  i32.store offset=248
-  local.get $300
-  local.set $478
+  local.tee $184
+  i32.store offset=228
+  local.get $184
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store
-  local.get $478
+  local.get $296
   i32.const 100
   call $std/array/Dim#set:height
-  local.get $300
-  local.set $478
+  local.get $184
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store
-  local.get $478
+  local.get $296
   i32.const 100
   call $std/array/Dim#set:width
-  local.get $300
+  local.get $184
   call $~lib/array/Array<std/array/Dim>#__set
-  local.get $290
+  local.get $175
   i32.const 9
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   call $std/array/Dim#constructor
-  local.tee $301
-  i32.store offset=252
-  local.get $301
-  local.set $478
+  local.tee $185
+  i32.store offset=232
+  local.get $185
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store
-  local.get $478
+  local.get $296
   i32.const 100
   call $std/array/Dim#set:height
-  local.get $301
-  local.set $478
+  local.get $185
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store
-  local.get $478
+  local.get $296
   i32.const 120
   call $std/array/Dim#set:width
-  local.get $301
+  local.get $185
   call $~lib/array/Array<std/array/Dim>#__set
-  local.get $290
+  local.get $175
   i32.const 10
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   call $std/array/Dim#constructor
-  local.tee $302
-  i32.store offset=256
-  local.get $302
-  local.set $478
+  local.tee $186
+  i32.store offset=236
+  local.get $186
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store
-  local.get $478
+  local.get $296
   i32.const 100
   call $std/array/Dim#set:height
-  local.get $302
-  local.set $478
+  local.get $186
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store
-  local.get $478
+  local.get $296
   i32.const 135
   call $std/array/Dim#set:width
-  local.get $302
+  local.get $186
   call $~lib/array/Array<std/array/Dim>#__set
-  local.get $290
+  local.get $175
   i32.const 11
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   call $std/array/Dim#constructor
-  local.tee $303
-  i32.store offset=260
-  local.get $303
-  local.set $478
+  local.tee $187
+  i32.store offset=240
+  local.get $187
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store
-  local.get $478
+  local.get $296
   i32.const 110
   call $std/array/Dim#set:height
-  local.get $303
-  local.set $478
+  local.get $187
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store
-  local.get $478
+  local.get $296
   i32.const 115
   call $std/array/Dim#set:width
-  local.get $303
+  local.get $187
   call $~lib/array/Array<std/array/Dim>#__set
-  local.get $290
+  local.get $175
   global.set $std/array/outputStabArr
   global.get $~lib/memory/__stack_pointer
   i32.const 3
@@ -42864,35 +42657,35 @@
   i32.const 9
   i32.const 9200
   call $~lib/rt/__newArray
-  local.tee $306
-  i32.store offset=264
-  local.get $306
-  local.set $478
+  local.tee $189
+  i32.store offset=244
+  local.get $189
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store
-  local.get $478
+  local.get $296
   i32.const 0
   global.set $~argumentsLength
   i32.const 0
   call $~lib/array/Array<f32>#sort@varargs
   drop
-  local.get $306
-  local.set $478
+  local.get $189
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store
-  local.get $478
+  local.get $296
   i32.const 3
   i32.const 2
   i32.const 9
   i32.const 9264
   call $~lib/rt/__newArray
-  local.set $478
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store offset=8
-  local.get $478
+  local.get $296
   i32.const 0
   call $std/array/isArraysEqual<f32>
   i32.eqz
@@ -42910,35 +42703,35 @@
   i32.const 9
   i32.const 9296
   call $~lib/rt/__newArray
-  local.tee $311
-  i32.store offset=268
-  local.get $311
-  local.set $478
+  local.tee $192
+  i32.store offset=248
+  local.get $192
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store
-  local.get $478
+  local.get $296
   i32.const 0
   global.set $~argumentsLength
   i32.const 0
   call $~lib/array/Array<f32>#sort@varargs
   drop
-  local.get $311
-  local.set $478
+  local.get $192
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store
-  local.get $478
+  local.get $296
   i32.const 8
   i32.const 2
   i32.const 9
   i32.const 9360
   call $~lib/rt/__newArray
-  local.set $478
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store offset=8
-  local.get $478
+  local.get $296
   i32.const 0
   call $std/array/isArraysEqual<f32>
   i32.eqz
@@ -42956,35 +42749,35 @@
   i32.const 12
   i32.const 9424
   call $~lib/rt/__newArray
-  local.tee $316
-  i32.store offset=272
-  local.get $316
-  local.set $478
+  local.tee $195
+  i32.store offset=252
+  local.get $195
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store
-  local.get $478
+  local.get $296
   i32.const 0
   global.set $~argumentsLength
   i32.const 0
   call $~lib/array/Array<f64>#sort@varargs
   drop
-  local.get $316
-  local.set $478
+  local.get $195
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store
-  local.get $478
+  local.get $296
   i32.const 8
   i32.const 3
   i32.const 12
   i32.const 9552
   call $~lib/rt/__newArray
-  local.set $478
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store offset=8
-  local.get $478
+  local.get $296
   i32.const 0
   call $std/array/isArraysEqual<f64>
   i32.eqz
@@ -43002,35 +42795,35 @@
   i32.const 4
   i32.const 9648
   call $~lib/rt/__newArray
-  local.tee $321
-  i32.store offset=276
-  local.get $321
-  local.set $478
+  local.tee $198
+  i32.store offset=256
+  local.get $198
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store
-  local.get $478
+  local.get $296
   i32.const 0
   global.set $~argumentsLength
   i32.const 0
   call $~lib/array/Array<i32>#sort@varargs
   drop
-  local.get $321
-  local.set $478
+  local.get $198
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store
-  local.get $478
+  local.get $296
   i32.const 5
   i32.const 2
   i32.const 4
   i32.const 9728
   call $~lib/rt/__newArray
-  local.set $478
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store offset=8
-  local.get $478
+  local.get $296
   i32.const 0
   call $std/array/isArraysEqual<i32>
   i32.eqz
@@ -43048,35 +42841,35 @@
   i32.const 8
   i32.const 9776
   call $~lib/rt/__newArray
-  local.tee $326
-  i32.store offset=280
-  local.get $326
-  local.set $478
+  local.tee $201
+  i32.store offset=260
+  local.get $201
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store
-  local.get $478
+  local.get $296
   i32.const 0
   global.set $~argumentsLength
   i32.const 0
   call $~lib/array/Array<u32>#sort@varargs
   drop
-  local.get $326
-  local.set $478
+  local.get $201
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store
-  local.get $478
+  local.get $296
   i32.const 5
   i32.const 2
   i32.const 8
   i32.const 9856
   call $~lib/rt/__newArray
-  local.set $478
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store offset=8
-  local.get $478
+  local.get $296
   i32.const 0
   call $std/array/isArraysEqual<u32>
   i32.eqz
@@ -43094,95 +42887,95 @@
   i32.const 4
   i32.const 9904
   call $~lib/rt/__newArray
-  local.tee $331
-  i32.store offset=284
+  local.tee $204
+  i32.store offset=264
   global.get $~lib/memory/__stack_pointer
   i32.const 1
   i32.const 2
   i32.const 4
   i32.const 9936
   call $~lib/rt/__newArray
-  local.tee $334
-  i32.store offset=288
+  local.tee $206
+  i32.store offset=268
   global.get $~lib/memory/__stack_pointer
   i32.const 2
   i32.const 2
   i32.const 4
   i32.const 9968
   call $~lib/rt/__newArray
-  local.tee $337
-  i32.store offset=292
+  local.tee $208
+  i32.store offset=272
   global.get $~lib/memory/__stack_pointer
   i32.const 4
   i32.const 2
   i32.const 4
   i32.const 10000
   call $~lib/rt/__newArray
-  local.tee $340
-  i32.store offset=296
+  local.tee $210
+  i32.store offset=276
   global.get $~lib/memory/__stack_pointer
   i32.const 4
   i32.const 2
   i32.const 4
   i32.const 10048
   call $~lib/rt/__newArray
-  local.tee $343
-  i32.store offset=300
+  local.tee $212
+  i32.store offset=280
   global.get $~lib/memory/__stack_pointer
   i32.const 64
   call $std/array/createReverseOrderedArray
-  local.tee $344
-  i32.store offset=304
+  local.tee $213
+  i32.store offset=284
   global.get $~lib/memory/__stack_pointer
   i32.const 128
   call $std/array/createReverseOrderedArray
-  local.tee $345
-  i32.store offset=308
+  local.tee $214
+  i32.store offset=288
   global.get $~lib/memory/__stack_pointer
   i32.const 1024
   call $std/array/createReverseOrderedArray
-  local.tee $346
-  i32.store offset=312
+  local.tee $215
+  i32.store offset=292
   global.get $~lib/memory/__stack_pointer
   i32.const 10000
   call $std/array/createReverseOrderedArray
-  local.tee $347
-  i32.store offset=316
+  local.tee $216
+  i32.store offset=296
   global.get $~lib/memory/__stack_pointer
   i32.const 512
   call $std/array/createRandomOrderedArray
-  local.tee $348
-  i32.store offset=320
-  local.get $331
-  local.set $478
+  local.tee $217
+  i32.store offset=300
+  local.get $204
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store
-  local.get $478
+  local.get $296
   call $std/array/assertSortedDefault<i32>
-  local.get $334
-  local.set $478
+  local.get $206
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store
-  local.get $478
+  local.get $296
   call $std/array/assertSortedDefault<i32>
-  local.get $334
-  local.set $478
+  local.get $206
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store
-  local.get $478
+  local.get $296
   i32.const 1
   i32.const 2
   i32.const 4
   i32.const 10128
   call $~lib/rt/__newArray
-  local.set $478
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store offset=8
-  local.get $478
+  local.get $296
   i32.const 0
   call $std/array/isArraysEqual<i32>
   i32.eqz
@@ -43194,29 +42987,29 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $337
-  local.set $478
+  local.get $208
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store
-  local.get $478
+  local.get $296
   call $std/array/assertSortedDefault<i32>
-  local.get $337
-  local.set $478
+  local.get $208
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store
-  local.get $478
+  local.get $296
   i32.const 2
   i32.const 2
   i32.const 4
   i32.const 10160
   call $~lib/rt/__newArray
-  local.set $478
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store offset=8
-  local.get $478
+  local.get $296
   i32.const 0
   call $std/array/isArraysEqual<i32>
   i32.eqz
@@ -43228,25 +43021,25 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $340
-  local.set $478
+  local.get $210
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store
-  local.get $478
+  local.get $296
   call $std/array/assertSortedDefault<i32>
-  local.get $340
-  local.set $478
+  local.get $210
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store
-  local.get $478
-  local.get $343
-  local.set $478
+  local.get $296
+  local.get $212
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store offset=8
-  local.get $478
+  local.get $296
   i32.const 0
   call $std/array/isArraysEqual<i32>
   i32.eqz
@@ -43258,25 +43051,25 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $344
-  local.set $478
+  local.get $213
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store
-  local.get $478
+  local.get $296
   call $std/array/assertSortedDefault<i32>
-  local.get $344
-  local.set $478
+  local.get $213
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store
-  local.get $478
-  local.get $343
-  local.set $478
+  local.get $296
+  local.get $212
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store offset=8
-  local.get $478
+  local.get $296
   i32.const 4
   call $std/array/isArraysEqual<i32>
   i32.eqz
@@ -43288,25 +43081,25 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $345
-  local.set $478
+  local.get $214
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store
-  local.get $478
+  local.get $296
   call $std/array/assertSortedDefault<i32>
-  local.get $345
-  local.set $478
+  local.get $214
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store
-  local.get $478
-  local.get $343
-  local.set $478
+  local.get $296
+  local.get $212
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store offset=8
-  local.get $478
+  local.get $296
   i32.const 4
   call $std/array/isArraysEqual<i32>
   i32.eqz
@@ -43318,25 +43111,25 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $346
-  local.set $478
+  local.get $215
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store
-  local.get $478
+  local.get $296
   call $std/array/assertSortedDefault<i32>
-  local.get $346
-  local.set $478
+  local.get $215
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store
-  local.get $478
-  local.get $343
-  local.set $478
+  local.get $296
+  local.get $212
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store offset=8
-  local.get $478
+  local.get $296
   i32.const 4
   call $std/array/isArraysEqual<i32>
   i32.eqz
@@ -43348,25 +43141,25 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $347
-  local.set $478
+  local.get $216
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store
-  local.get $478
+  local.get $296
   call $std/array/assertSortedDefault<i32>
-  local.get $347
-  local.set $478
+  local.get $216
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store
-  local.get $478
-  local.get $343
-  local.set $478
+  local.get $296
+  local.get $212
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store offset=8
-  local.get $478
+  local.get $296
   i32.const 4
   call $std/array/isArraysEqual<i32>
   i32.eqz
@@ -43378,111 +43171,111 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $348
-  local.set $478
+  local.get $217
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store
-  local.get $478
+  local.get $296
   call $std/array/assertSortedDefault<i32>
   call $std/array/assertStableSortedForComplexObjects
   global.get $~lib/memory/__stack_pointer
   i32.const 64
   call $std/array/createRandomOrderedArray
-  local.tee $353
-  i32.store offset=324
+  local.tee $220
+  i32.store offset=304
   global.get $~lib/memory/__stack_pointer
   i32.const 257
   call $std/array/createRandomOrderedArray
-  local.tee $354
-  i32.store offset=328
-  local.get $353
-  local.set $478
+  local.tee $221
+  i32.store offset=308
+  local.get $220
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store
-  local.get $478
+  local.get $296
   i32.const 10224
-  local.set $478
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store offset=8
-  local.get $478
+  local.get $296
   call $std/array/assertSorted<i32>
-  local.get $353
-  local.set $478
+  local.get $220
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store
-  local.get $478
+  local.get $296
   i32.const 10256
-  local.set $478
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store offset=8
-  local.get $478
+  local.get $296
   call $std/array/assertSorted<i32>
-  local.get $354
-  local.set $478
+  local.get $221
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store
-  local.get $478
+  local.get $296
   i32.const 10288
-  local.set $478
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store offset=8
-  local.get $478
+  local.get $296
   call $std/array/assertSorted<i32>
-  local.get $354
-  local.set $478
+  local.get $221
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store
-  local.get $478
+  local.get $296
   i32.const 10320
-  local.set $478
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store offset=8
-  local.get $478
+  local.get $296
   call $std/array/assertSorted<i32>
   global.get $~lib/memory/__stack_pointer
   i32.const 2
   call $std/array/createReverseOrderedNestedArray
-  local.tee $355
-  i32.store offset=332
-  local.get $355
-  local.set $478
+  local.tee $222
+  i32.store offset=312
+  local.get $222
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store
-  local.get $478
+  local.get $296
   i32.const 10352
-  local.set $478
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store offset=8
-  local.get $478
+  local.get $296
   call $std/array/assertSorted<~lib/array/Array<i32>>
   global.get $~lib/memory/__stack_pointer
   i32.const 512
   call $std/array/createReverseOrderedElementsArray
-  local.tee $356
-  i32.store offset=336
-  local.get $356
-  local.set $478
+  local.tee $223
+  i32.store offset=316
+  local.get $223
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store
-  local.get $478
+  local.get $296
   i32.const 10384
-  local.set $478
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store offset=8
-  local.get $478
+  local.get $296
   call $std/array/assertSorted<std/array/Proxy<i32>>
   global.get $~lib/memory/__stack_pointer
   i32.const 7
@@ -43490,38 +43283,38 @@
   i32.const 34
   i32.const 10576
   call $~lib/rt/__newArray
-  local.tee $359
-  i32.store offset=340
+  local.tee $225
+  i32.store offset=320
   global.get $~lib/memory/__stack_pointer
   i32.const 7
   i32.const 2
   i32.const 34
   i32.const 10624
   call $~lib/rt/__newArray
-  local.tee $362
-  i32.store offset=344
-  local.get $359
-  local.set $478
+  local.tee $227
+  i32.store offset=324
+  local.get $225
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store
-  local.get $478
+  local.get $296
   i32.const 1
   global.set $~argumentsLength
   i32.const 0
   call $std/array/assertSorted<~lib/string/String|null>@varargs
-  local.get $359
-  local.set $478
+  local.get $225
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store
-  local.get $478
-  local.get $362
-  local.set $478
+  local.get $296
+  local.get $227
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store offset=8
-  local.get $478
+  local.get $296
   i32.const 0
   call $std/array/isArraysEqual<~lib/string/String|null>
   i32.eqz
@@ -43536,14 +43329,14 @@
   global.get $~lib/memory/__stack_pointer
   i32.const 400
   call $std/array/createRandomStringArray
-  local.tee $363
-  i32.store offset=348
-  local.get $363
-  local.set $478
+  local.tee $228
+  i32.store offset=328
+  local.get $228
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store
-  local.get $478
+  local.get $296
   i32.const 1
   global.set $~argumentsLength
   i32.const 0
@@ -43553,29 +43346,29 @@
   i32.const 37
   i32.const 10736
   call $~lib/rt/__newArray
-  local.set $478
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
-  i32.store offset=52
-  local.get $478
+  local.get $296
+  i32.store offset=48
+  local.get $296
   i32.const 10832
-  local.set $478
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
-  i32.store offset=352
-  local.get $478
+  local.get $296
+  i32.store offset=332
+  local.get $296
   call $~lib/array/Array<bool>#join
-  local.set $478
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store
-  local.get $478
+  local.get $296
   i32.const 10864
-  local.set $478
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store offset=8
-  local.get $478
+  local.get $296
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -43591,29 +43384,29 @@
   i32.const 4
   i32.const 10912
   call $~lib/rt/__newArray
-  local.set $478
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
-  i32.store offset=52
-  local.get $478
+  local.get $296
+  i32.store offset=48
+  local.get $296
   i32.const 10544
-  local.set $478
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
-  i32.store offset=352
-  local.get $478
+  local.get $296
+  i32.store offset=332
+  local.get $296
   call $~lib/array/Array<i32>#join
-  local.set $478
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store
-  local.get $478
+  local.get $296
   i32.const 10944
-  local.set $478
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store offset=8
-  local.get $478
+  local.get $296
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -43629,29 +43422,29 @@
   i32.const 8
   i32.const 10976
   call $~lib/rt/__newArray
-  local.set $478
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
-  i32.store offset=52
-  local.get $478
+  local.get $296
+  i32.store offset=48
+  local.get $296
   i32.const 11008
-  local.set $478
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
-  i32.store offset=352
-  local.get $478
+  local.get $296
+  i32.store offset=332
+  local.get $296
   call $~lib/array/Array<u32>#join
-  local.set $478
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store
-  local.get $478
+  local.get $296
   i32.const 10944
-  local.set $478
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store offset=8
-  local.get $478
+  local.get $296
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -43667,29 +43460,29 @@
   i32.const 4
   i32.const 11040
   call $~lib/rt/__newArray
-  local.set $478
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
-  i32.store offset=52
-  local.get $478
+  local.get $296
+  i32.store offset=48
+  local.get $296
   i32.const 11072
-  local.set $478
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
-  i32.store offset=352
-  local.get $478
+  local.get $296
+  i32.store offset=332
+  local.get $296
   call $~lib/array/Array<i32>#join
-  local.set $478
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store
-  local.get $478
+  local.get $296
   i32.const 11104
-  local.set $478
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store offset=8
-  local.get $478
+  local.get $296
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -43705,29 +43498,29 @@
   i32.const 12
   i32.const 11184
   call $~lib/rt/__newArray
-  local.set $478
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
-  i32.store offset=52
-  local.get $478
+  local.get $296
+  i32.store offset=48
+  local.get $296
   i32.const 11264
-  local.set $478
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
-  i32.store offset=352
-  local.get $478
+  local.get $296
+  i32.store offset=332
+  local.get $296
   call $~lib/array/Array<f64>#join
-  local.set $478
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store
-  local.get $478
+  local.get $296
   i32.const 12432
-  local.set $478
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store offset=8
-  local.get $478
+  local.get $296
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -43743,29 +43536,29 @@
   i32.const 34
   i32.const 12576
   call $~lib/rt/__newArray
-  local.set $478
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
-  i32.store offset=52
-  local.get $478
+  local.get $296
+  i32.store offset=48
+  local.get $296
   i32.const 10544
-  local.set $478
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
-  i32.store offset=352
-  local.get $478
+  local.get $296
+  i32.store offset=332
+  local.get $296
   call $~lib/array/Array<~lib/string/String|null>#join
-  local.set $478
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store
-  local.get $478
+  local.get $296
   i32.const 12544
-  local.set $478
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store offset=8
-  local.get $478
+  local.get $296
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -43783,56 +43576,51 @@
   i32.const 13
   i32.const 0
   call $~lib/rt/__newArray
-  local.tee $376
-  i32.store offset=356
-  global.get $~lib/memory/__stack_pointer
-  local.get $376
-  i32.load offset=4
-  local.tee $377
-  i32.store offset=360
-  local.get $376
+  local.tee $235
+  i32.store offset=336
+  local.get $235
   i32.const 0
   i32.const 0
   i32.const 0
   call $std/array/Ref#constructor
   call $~lib/array/Array<std/array/Ref|null>#__set
-  local.get $376
+  local.get $235
   i32.const 1
   i32.const 0
   call $~lib/array/Array<std/array/Ref|null>#__set
-  local.get $376
+  local.get $235
   i32.const 2
   i32.const 0
   i32.const 0
   call $std/array/Ref#constructor
   call $~lib/array/Array<std/array/Ref|null>#__set
-  local.get $376
-  local.tee $378
-  i32.store offset=364
-  local.get $378
-  local.set $478
+  local.get $235
+  local.tee $236
+  i32.store offset=340
+  local.get $236
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
-  i32.store offset=52
-  local.get $478
+  local.get $296
+  i32.store offset=48
+  local.get $296
   i32.const 10832
-  local.set $478
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
-  i32.store offset=352
-  local.get $478
+  local.get $296
+  i32.store offset=332
+  local.get $296
   call $~lib/array/Array<std/array/Ref|null>#join
-  local.set $478
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store
-  local.get $478
+  local.get $296
   i32.const 12672
-  local.set $478
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store offset=8
-  local.get $478
+  local.get $296
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -43850,52 +43638,47 @@
   i32.const 10
   i32.const 0
   call $~lib/rt/__newArray
-  local.tee $379
-  i32.store offset=368
-  global.get $~lib/memory/__stack_pointer
-  local.get $379
-  i32.load offset=4
-  local.tee $380
-  i32.store offset=372
-  local.get $379
+  local.tee $237
+  i32.store offset=344
+  local.get $237
   i32.const 0
   i32.const 0
   i32.const 0
   call $std/array/Ref#constructor
   call $~lib/array/Array<std/array/Ref>#__set
-  local.get $379
+  local.get $237
   i32.const 1
   i32.const 0
   i32.const 0
   call $std/array/Ref#constructor
   call $~lib/array/Array<std/array/Ref>#__set
-  local.get $379
-  local.tee $381
-  i32.store offset=376
-  local.get $381
-  local.set $478
+  local.get $237
+  local.tee $238
+  i32.store offset=348
+  local.get $238
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
-  i32.store offset=52
-  local.get $478
+  local.get $296
+  i32.store offset=48
+  local.get $296
   i32.const 10832
-  local.set $478
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
-  i32.store offset=352
-  local.get $478
+  local.get $296
+  i32.store offset=332
+  local.get $296
   call $~lib/array/Array<std/array/Ref>#join
-  local.set $478
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store
-  local.get $478
+  local.get $296
   i32.const 12768
-  local.set $478
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store offset=8
-  local.get $478
+  local.get $296
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -43912,50 +43695,50 @@
   i32.const 4
   i32.const 12864
   call $~lib/rt/__newArray
-  local.tee $384
-  i32.store offset=380
+  local.tee $240
+  i32.store offset=352
   global.get $~lib/memory/__stack_pointer
   i32.const 1
   i32.const 2
   i32.const 4
   i32.const 12896
   call $~lib/rt/__newArray
-  local.tee $387
-  i32.store offset=384
+  local.tee $242
+  i32.store offset=356
   global.get $~lib/memory/__stack_pointer
   i32.const 2
   i32.const 2
   i32.const 4
   i32.const 12928
   call $~lib/rt/__newArray
-  local.tee $390
-  i32.store offset=388
+  local.tee $244
+  i32.store offset=360
   global.get $~lib/memory/__stack_pointer
   i32.const 4
   i32.const 2
   i32.const 4
   i32.const 12960
   call $~lib/rt/__newArray
-  local.tee $393
-  i32.store offset=392
-  local.get $384
-  local.set $478
+  local.tee $246
+  i32.store offset=364
+  local.get $240
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
-  i32.store offset=52
-  local.get $478
+  local.get $296
+  i32.store offset=48
+  local.get $296
   call $~lib/array/Array<i32>#toString
-  local.set $478
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store
-  local.get $478
+  local.get $296
   i32.const 10544
-  local.set $478
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store offset=8
-  local.get $478
+  local.get $296
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -43966,24 +43749,24 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $387
-  local.set $478
+  local.get $242
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
-  i32.store offset=52
-  local.get $478
+  local.get $296
+  i32.store offset=48
+  local.get $296
   call $~lib/array/Array<i32>#toString
-  local.set $478
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store
-  local.get $478
+  local.get $296
   i32.const 12544
-  local.set $478
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store offset=8
-  local.get $478
+  local.get $296
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -43994,24 +43777,24 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $390
-  local.set $478
+  local.get $244
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
-  i32.store offset=52
-  local.get $478
+  local.get $296
+  i32.store offset=48
+  local.get $296
   call $~lib/array/Array<i32>#toString
-  local.set $478
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store
-  local.get $478
+  local.get $296
   i32.const 13008
-  local.set $478
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store offset=8
-  local.get $478
+  local.get $296
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -44022,24 +43805,24 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $393
-  local.set $478
+  local.get $246
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
-  i32.store offset=52
-  local.get $478
+  local.get $296
+  i32.store offset=48
+  local.get $296
   call $~lib/array/Array<i32>#toString
-  local.set $478
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store
-  local.get $478
+  local.get $296
   i32.const 13040
-  local.set $478
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store offset=8
-  local.get $478
+  local.get $296
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -44055,23 +43838,23 @@
   i32.const 38
   i32.const 13088
   call $~lib/rt/__newArray
-  local.set $478
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
-  i32.store offset=52
-  local.get $478
+  local.get $296
+  i32.store offset=48
+  local.get $296
   call $~lib/array/Array<i8>#toString
-  local.set $478
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store
-  local.get $478
+  local.get $296
   i32.const 13120
-  local.set $478
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store offset=8
-  local.get $478
+  local.get $296
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -44087,23 +43870,23 @@
   i32.const 38
   i32.const 13152
   call $~lib/rt/__newArray
-  local.set $478
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
-  i32.store offset=52
-  local.get $478
+  local.get $296
+  i32.store offset=48
+  local.get $296
   call $~lib/array/Array<i8>#toString
-  local.set $478
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store
-  local.get $478
+  local.get $296
   i32.const 13184
-  local.set $478
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store offset=8
-  local.get $478
+  local.get $296
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -44119,23 +43902,23 @@
   i32.const 11
   i32.const 13232
   call $~lib/rt/__newArray
-  local.set $478
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
-  i32.store offset=52
-  local.get $478
+  local.get $296
+  i32.store offset=48
+  local.get $296
   call $~lib/array/Array<u16>#toString
-  local.set $478
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store
-  local.get $478
+  local.get $296
   i32.const 13264
-  local.set $478
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store offset=8
-  local.get $478
+  local.get $296
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -44151,23 +43934,23 @@
   i32.const 39
   i32.const 13312
   call $~lib/rt/__newArray
-  local.set $478
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
-  i32.store offset=52
-  local.get $478
+  local.get $296
+  i32.store offset=48
+  local.get $296
   call $~lib/array/Array<i16>#toString
-  local.set $478
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store
-  local.get $478
+  local.get $296
   i32.const 13344
-  local.set $478
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store offset=8
-  local.get $478
+  local.get $296
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -44183,23 +43966,23 @@
   i32.const 4
   i32.const 13392
   call $~lib/rt/__newArray
-  local.set $478
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
-  i32.store offset=52
-  local.get $478
+  local.get $296
+  i32.store offset=48
+  local.get $296
   call $~lib/array/Array<i32>#toString
-  local.set $478
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store
-  local.get $478
+  local.get $296
   i32.const 13424
-  local.set $478
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store offset=8
-  local.get $478
+  local.get $296
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -44215,23 +43998,23 @@
   i32.const 40
   i32.const 13488
   call $~lib/rt/__newArray
-  local.set $478
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
-  i32.store offset=52
-  local.get $478
+  local.get $296
+  i32.store offset=48
+  local.get $296
   call $~lib/array/Array<u64>#toString
-  local.set $478
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store
-  local.get $478
+  local.get $296
   i32.const 13536
-  local.set $478
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store offset=8
-  local.get $478
+  local.get $296
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -44247,23 +44030,23 @@
   i32.const 41
   i32.const 13616
   call $~lib/rt/__newArray
-  local.set $478
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
-  i32.store offset=52
-  local.get $478
+  local.get $296
+  i32.store offset=48
+  local.get $296
   call $~lib/array/Array<i64>#toString
-  local.set $478
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store
-  local.get $478
+  local.get $296
   i32.const 13680
-  local.set $478
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store offset=8
-  local.get $478
+  local.get $296
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -44280,26 +44063,26 @@
   i32.const 34
   i32.const 13840
   call $~lib/rt/__newArray
-  local.tee $410
-  i32.store offset=396
-  local.get $410
-  local.set $478
+  local.tee $255
+  i32.store offset=368
+  local.get $255
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
-  i32.store offset=52
-  local.get $478
+  local.get $296
+  i32.store offset=48
+  local.get $296
   call $~lib/array/Array<~lib/string/String|null>#toString
-  local.set $478
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store
-  local.get $478
+  local.get $296
   i32.const 13888
-  local.set $478
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store offset=8
-  local.get $478
+  local.get $296
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -44315,23 +44098,23 @@
   i32.const 34
   i32.const 14000
   call $~lib/rt/__newArray
-  local.set $478
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
-  i32.store offset=52
-  local.get $478
+  local.get $296
+  i32.store offset=48
+  local.get $296
   call $~lib/array/Array<~lib/string/String|null>#toString
-  local.set $478
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store
-  local.get $478
+  local.get $296
   i32.const 14048
-  local.set $478
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store offset=8
-  local.get $478
+  local.get $296
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -44349,14 +44132,9 @@
   i32.const 29
   i32.const 0
   call $~lib/rt/__newArray
-  local.tee $413
-  i32.store offset=400
-  global.get $~lib/memory/__stack_pointer
-  local.get $413
-  i32.load offset=4
-  local.tee $414
-  i32.store offset=404
-  local.get $413
+  local.tee $257
+  i32.store offset=372
+  local.get $257
   i32.const 0
   i32.const 2
   i32.const 2
@@ -44364,7 +44142,7 @@
   i32.const 14080
   call $~lib/rt/__newArray
   call $~lib/array/Array<~lib/array/Array<i32>>#__set
-  local.get $413
+  local.get $257
   i32.const 1
   i32.const 2
   i32.const 2
@@ -44372,27 +44150,27 @@
   i32.const 14112
   call $~lib/rt/__newArray
   call $~lib/array/Array<~lib/array/Array<i32>>#__set
-  local.get $413
-  local.tee $419
-  i32.store offset=408
-  local.get $419
-  local.set $478
+  local.get $257
+  local.tee $260
+  i32.store offset=376
+  local.get $260
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
-  i32.store offset=52
-  local.get $478
+  local.get $296
+  i32.store offset=48
+  local.get $296
   call $~lib/array/Array<~lib/array/Array<i32>>#toString
-  local.set $478
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store
-  local.get $478
+  local.get $296
   i32.const 14144
-  local.set $478
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store offset=8
-  local.get $478
+  local.get $296
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -44410,14 +44188,9 @@
   i32.const 42
   i32.const 0
   call $~lib/rt/__newArray
-  local.tee $420
-  i32.store offset=412
-  global.get $~lib/memory/__stack_pointer
-  local.get $420
-  i32.load offset=4
-  local.tee $421
-  i32.store offset=416
-  local.get $420
+  local.tee $261
+  i32.store offset=380
+  local.get $261
   i32.const 0
   i32.const 2
   i32.const 0
@@ -44425,7 +44198,7 @@
   i32.const 14192
   call $~lib/rt/__newArray
   call $~lib/array/Array<~lib/array/Array<u8>>#__set
-  local.get $420
+  local.get $261
   i32.const 1
   i32.const 2
   i32.const 0
@@ -44433,27 +44206,27 @@
   i32.const 14224
   call $~lib/rt/__newArray
   call $~lib/array/Array<~lib/array/Array<u8>>#__set
-  local.get $420
-  local.tee $426
-  i32.store offset=420
-  local.get $426
-  local.set $478
+  local.get $261
+  local.tee $264
+  i32.store offset=384
+  local.get $264
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
-  i32.store offset=52
-  local.get $478
+  local.get $296
+  i32.store offset=48
+  local.get $296
   call $~lib/array/Array<~lib/array/Array<u8>>#toString
-  local.set $478
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store
-  local.get $478
+  local.get $296
   i32.const 14144
-  local.set $478
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store offset=8
-  local.get $478
+  local.get $296
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -44471,14 +44244,9 @@
   i32.const 44
   i32.const 0
   call $~lib/rt/__newArray
-  local.tee $427
-  i32.store offset=424
-  global.get $~lib/memory/__stack_pointer
-  local.get $427
-  i32.load offset=4
-  local.tee $428
-  i32.store offset=428
-  local.get $427
+  local.tee $265
+  i32.store offset=388
+  local.get $265
   i32.const 0
   global.get $~lib/memory/__stack_pointer
   i32.const 1
@@ -44486,14 +44254,9 @@
   i32.const 43
   i32.const 0
   call $~lib/rt/__newArray
-  local.tee $429
-  i32.store offset=432
-  global.get $~lib/memory/__stack_pointer
-  local.get $429
-  i32.load offset=4
-  local.tee $430
-  i32.store offset=436
-  local.get $429
+  local.tee $266
+  i32.store offset=392
+  local.get $266
   i32.const 0
   i32.const 1
   i32.const 2
@@ -44501,29 +44264,29 @@
   i32.const 14256
   call $~lib/rt/__newArray
   call $~lib/array/Array<~lib/array/Array<u32>>#__set
-  local.get $429
+  local.get $266
   call $~lib/array/Array<~lib/array/Array<~lib/array/Array<u32>>>#__set
-  local.get $427
-  local.tee $433
-  i32.store offset=440
-  local.get $433
-  local.set $478
+  local.get $265
+  local.tee $268
+  i32.store offset=396
+  local.get $268
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
-  i32.store offset=52
-  local.get $478
+  local.get $296
+  i32.store offset=48
+  local.get $296
   call $~lib/array/Array<~lib/array/Array<~lib/array/Array<u32>>>#toString
-  local.set $478
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store
-  local.get $478
+  local.get $296
   i32.const 12544
-  local.set $478
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store offset=8
-  local.get $478
+  local.get $296
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -44541,14 +44304,9 @@
   i32.const 29
   i32.const 0
   call $~lib/rt/__newArray
-  local.tee $434
-  i32.store offset=444
-  global.get $~lib/memory/__stack_pointer
-  local.get $434
-  i32.load offset=4
-  local.tee $435
-  i32.store offset=448
-  local.get $434
+  local.tee $269
+  i32.store offset=400
+  local.get $269
   i32.const 0
   i32.const 1
   i32.const 2
@@ -44556,7 +44314,7 @@
   i32.const 14288
   call $~lib/rt/__newArray
   call $~lib/array/Array<~lib/array/Array<i32>>#__set
-  local.get $434
+  local.get $269
   i32.const 1
   i32.const 3
   i32.const 2
@@ -44564,7 +44322,7 @@
   i32.const 14320
   call $~lib/rt/__newArray
   call $~lib/array/Array<~lib/array/Array<i32>>#__set
-  local.get $434
+  local.get $269
   i32.const 2
   i32.const 3
   i32.const 2
@@ -44572,7 +44330,7 @@
   i32.const 14352
   call $~lib/rt/__newArray
   call $~lib/array/Array<~lib/array/Array<i32>>#__set
-  local.get $434
+  local.get $269
   i32.const 3
   i32.const 3
   i32.const 2
@@ -44580,25 +44338,25 @@
   i32.const 14384
   call $~lib/rt/__newArray
   call $~lib/array/Array<~lib/array/Array<i32>>#__set
-  local.get $434
-  local.tee $444
-  i32.store offset=452
+  local.get $269
+  local.tee $274
+  i32.store offset=404
   global.get $~lib/memory/__stack_pointer
-  local.get $444
-  local.set $478
+  local.get $274
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store
-  local.get $478
+  local.get $296
   call $~lib/array/Array<~lib/array/Array<i32>>#flat
-  local.tee $445
-  i32.store offset=456
-  local.get $445
-  local.set $478
+  local.tee $275
+  i32.store offset=408
+  local.get $275
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store
-  local.get $478
+  local.get $296
   call $~lib/array/Array<i32>#get:length
   i32.const 10
   i32.eq
@@ -44612,21 +44370,21 @@
    unreachable
   end
   i32.const 0
-  local.set $446
+  local.set $276
   loop $for-loop|7
-   local.get $446
+   local.get $276
    i32.const 10
    i32.lt_s
    if
-    local.get $445
-    local.set $478
+    local.get $275
+    local.set $296
     global.get $~lib/memory/__stack_pointer
-    local.get $478
+    local.get $296
     i32.store
-    local.get $478
-    local.get $446
+    local.get $296
+    local.get $276
     call $~lib/array/Array<i32>#__get
-    local.get $446
+    local.get $276
     i32.eq
     i32.eqz
     if
@@ -44637,10 +44395,10 @@
      call $~lib/builtins/abort
      unreachable
     end
-    local.get $446
+    local.get $276
     i32.const 1
     i32.add
-    local.set $446
+    local.set $276
     br $for-loop|7
    end
   end
@@ -44651,14 +44409,9 @@
   i32.const 45
   i32.const 0
   call $~lib/rt/__newArray
-  local.tee $447
-  i32.store offset=460
-  global.get $~lib/memory/__stack_pointer
-  local.get $447
-  i32.load offset=4
-  local.tee $448
-  i32.store offset=464
-  local.get $447
+  local.tee $277
+  i32.store offset=412
+  local.get $277
   i32.const 0
   i32.const 1
   i32.const 2
@@ -44666,7 +44419,7 @@
   i32.const 14448
   call $~lib/rt/__newArray
   call $~lib/array/Array<~lib/array/Array<~lib/string/String|null>>#__set
-  local.get $447
+  local.get $277
   i32.const 1
   i32.const 3
   i32.const 2
@@ -44674,7 +44427,7 @@
   i32.const 14544
   call $~lib/rt/__newArray
   call $~lib/array/Array<~lib/array/Array<~lib/string/String|null>>#__set
-  local.get $447
+  local.get $277
   i32.const 2
   i32.const 3
   i32.const 2
@@ -44682,7 +44435,7 @@
   i32.const 14672
   call $~lib/rt/__newArray
   call $~lib/array/Array<~lib/array/Array<~lib/string/String|null>>#__set
-  local.get $447
+  local.get $277
   i32.const 3
   i32.const 1
   i32.const 2
@@ -44690,33 +44443,33 @@
   i32.const 14736
   call $~lib/rt/__newArray
   call $~lib/array/Array<~lib/array/Array<~lib/string/String|null>>#__set
-  local.get $447
-  local.tee $457
-  i32.store offset=468
+  local.get $277
+  local.tee $282
+  i32.store offset=416
   global.get $~lib/memory/__stack_pointer
-  local.get $457
-  local.set $478
+  local.get $282
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store
-  local.get $478
+  local.get $296
   call $~lib/array/Array<~lib/array/Array<~lib/string/String|null>>#flat
-  local.tee $458
-  i32.store offset=472
+  local.tee $283
+  i32.store offset=420
   global.get $~lib/memory/__stack_pointer
   i32.const 8
   i32.const 2
   i32.const 34
   i32.const 14768
   call $~lib/rt/__newArray
-  local.tee $461
-  i32.store offset=476
-  local.get $458
-  local.set $478
+  local.tee $285
+  i32.store offset=424
+  local.get $283
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store
-  local.get $478
+  local.get $296
   call $~lib/array/Array<~lib/string/String|null>#get:length
   i32.const 8
   i32.eq
@@ -44730,44 +44483,44 @@
    unreachable
   end
   i32.const 0
-  local.set $462
+  local.set $286
   loop $for-loop|8
-   local.get $462
-   local.get $461
-   local.set $478
+   local.get $286
+   local.get $285
+   local.set $296
    global.get $~lib/memory/__stack_pointer
-   local.get $478
+   local.get $296
    i32.store
-   local.get $478
+   local.get $296
    call $~lib/array/Array<~lib/string/String|null>#get:length
    i32.lt_s
    if
-    local.get $458
-    local.set $478
+    local.get $283
+    local.set $296
     global.get $~lib/memory/__stack_pointer
-    local.get $478
-    i32.store offset=52
-    local.get $478
-    local.get $462
+    local.get $296
+    i32.store offset=48
+    local.get $296
+    local.get $286
     call $~lib/array/Array<~lib/string/String|null>#__get
-    local.set $478
+    local.set $296
     global.get $~lib/memory/__stack_pointer
-    local.get $478
+    local.get $296
     i32.store
-    local.get $478
-    local.get $461
-    local.set $478
+    local.get $296
+    local.get $285
+    local.set $296
     global.get $~lib/memory/__stack_pointer
-    local.get $478
-    i32.store offset=52
-    local.get $478
-    local.get $462
+    local.get $296
+    i32.store offset=48
+    local.get $296
+    local.get $286
     call $~lib/array/Array<~lib/string/String|null>#__get
-    local.set $478
+    local.set $296
     global.get $~lib/memory/__stack_pointer
-    local.get $478
+    local.get $296
     i32.store offset=8
-    local.get $478
+    local.get $296
     call $~lib/string/String.__eq
     i32.eqz
     if
@@ -44778,10 +44531,10 @@
      call $~lib/builtins/abort
      unreachable
     end
-    local.get $462
+    local.get $286
     i32.const 1
     i32.add
-    local.set $462
+    local.set $286
     br $for-loop|8
    end
   end
@@ -44792,14 +44545,9 @@
   i32.const 29
   i32.const 0
   call $~lib/rt/__newArray
-  local.tee $463
-  i32.store offset=480
-  global.get $~lib/memory/__stack_pointer
-  local.get $463
-  i32.load offset=4
-  local.tee $464
-  i32.store offset=484
-  local.get $463
+  local.tee $287
+  i32.store offset=428
+  local.get $287
   i32.const 0
   i32.const 0
   i32.const 2
@@ -44807,7 +44555,7 @@
   i32.const 14832
   call $~lib/rt/__newArray
   call $~lib/array/Array<~lib/array/Array<i32>>#__set
-  local.get $463
+  local.get $287
   i32.const 1
   i32.const 0
   i32.const 2
@@ -44815,21 +44563,21 @@
   i32.const 14864
   call $~lib/rt/__newArray
   call $~lib/array/Array<~lib/array/Array<i32>>#__set
-  local.get $463
-  local.tee $469
-  i32.store offset=488
-  local.get $469
-  local.set $478
+  local.get $287
+  local.tee $290
+  i32.store offset=432
+  local.get $290
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store offset=8
-  local.get $478
+  local.get $296
   call $~lib/array/Array<~lib/array/Array<i32>>#flat
-  local.set $478
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store
-  local.get $478
+  local.get $296
   call $~lib/array/Array<i32>#get:length
   i32.const 0
   i32.eq
@@ -44849,14 +44597,9 @@
   i32.const 29
   i32.const 0
   call $~lib/rt/__newArray
-  local.tee $470
-  i32.store offset=492
-  global.get $~lib/memory/__stack_pointer
-  local.get $470
-  i32.load offset=4
-  local.tee $471
-  i32.store offset=496
-  local.get $470
+  local.tee $291
+  i32.store offset=436
+  local.get $291
   i32.const 0
   i32.const 1
   i32.const 2
@@ -44864,7 +44607,7 @@
   i32.const 14896
   call $~lib/rt/__newArray
   call $~lib/array/Array<~lib/array/Array<i32>>#__set
-  local.get $470
+  local.get $291
   i32.const 1
   i32.const 1
   i32.const 2
@@ -44872,37 +44615,37 @@
   i32.const 14928
   call $~lib/rt/__newArray
   call $~lib/array/Array<~lib/array/Array<i32>>#__set
-  local.get $470
-  local.tee $476
-  i32.store offset=500
+  local.get $291
+  local.tee $294
+  i32.store offset=440
   global.get $~lib/memory/__stack_pointer
-  local.get $476
-  local.set $478
+  local.get $294
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store offset=8
-  local.get $478
+  local.get $296
   i32.const 14960
-  local.set $478
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
-  i32.store offset=52
-  local.get $478
+  local.get $296
+  i32.store offset=48
+  local.get $296
   call $~lib/array/Array<~lib/array/Array<i32>>#map<~lib/array/Array<i32>>
-  local.set $478
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store
-  local.get $478
+  local.get $296
   call $~lib/array/Array<~lib/array/Array<i32>>#flat
-  local.tee $477
-  i32.store offset=504
-  local.get $477
-  local.set $478
+  local.tee $295
+  i32.store offset=444
+  local.get $295
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store
-  local.get $478
+  local.get $296
   call $~lib/array/Array<i32>#get:length
   i32.const 4
   i32.eq
@@ -44915,12 +44658,12 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $477
-  local.set $478
+  local.get $295
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store
-  local.get $478
+  local.get $296
   i32.const 0
   call $~lib/array/Array<i32>#__get
   i32.const 1
@@ -44934,12 +44677,12 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $477
-  local.set $478
+  local.get $295
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store
-  local.get $478
+  local.get $296
   i32.const 1
   call $~lib/array/Array<i32>#__get
   i32.const 3
@@ -44953,12 +44696,12 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $477
-  local.set $478
+  local.get $295
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store
-  local.get $478
+  local.get $296
   i32.const 2
   call $~lib/array/Array<i32>#__get
   i32.const 2
@@ -44972,12 +44715,12 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $477
-  local.set $478
+  local.get $295
+  local.set $296
   global.get $~lib/memory/__stack_pointer
-  local.get $478
+  local.get $296
   i32.store
-  local.get $478
+  local.get $296
   i32.const 3
   call $~lib/array/Array<i32>#__get
   i32.const 3
@@ -45001,7 +44744,7 @@
   global.set $~lib/memory/__stack_pointer
   call $~lib/rt/itcms/__collect
   global.get $~lib/memory/__stack_pointer
-  i32.const 508
+  i32.const 448
   i32.add
   global.set $~lib/memory/__stack_pointer
  )

--- a/tests/compiler/std/array.release.wat
+++ b/tests/compiler/std/array.release.wat
@@ -17540,7 +17540,7 @@
   (local $12 i32)
   (local $13 i32)
   global.get $~lib/memory/__stack_pointer
-  i32.const 508
+  i32.const 448
   i32.sub
   global.set $~lib/memory/__stack_pointer
   block $folding-inner2
@@ -17550,7 +17550,7 @@
    br_if $folding-inner2
    global.get $~lib/memory/__stack_pointer
    i32.const 0
-   i32.const 508
+   i32.const 448
    memory.fill
    memory.size
    i32.const 16
@@ -18726,10 +18726,6 @@
    call $~lib/rt/__newArray
    local.tee $7
    i32.store offset=20
-   global.get $~lib/memory/__stack_pointer
-   local.get $7
-   i32.load offset=4
-   i32.store offset=24
    local.get $7
    i32.const 0
    i32.const 0
@@ -18742,7 +18738,7 @@
    call $~lib/array/Array<std/array/Ref>#__set
    local.get $1
    local.get $7
-   i32.store offset=28
+   i32.store offset=24
    global.get $~lib/memory/__stack_pointer
    local.get $7
    i32.store
@@ -18791,7 +18787,7 @@
    i32.const 2688
    call $~lib/rt/__newArray
    local.tee $1
-   i32.store offset=32
+   i32.store offset=28
    global.get $~lib/memory/__stack_pointer
    local.get $1
    i32.store
@@ -18860,7 +18856,7 @@
    i32.const 0
    call $~lib/array/Array<i32>#constructor
    local.tee $1
-   i32.store offset=36
+   i32.store offset=32
    global.get $~lib/memory/__stack_pointer
    global.get $std/array/arr
    local.tee $7
@@ -18873,7 +18869,7 @@
    local.get $1
    call $~lib/array/Array<i32>#concat
    local.tee $7
-   i32.store offset=40
+   i32.store offset=36
    global.get $~lib/memory/__stack_pointer
    global.get $std/array/arr
    local.tee $8
@@ -19025,7 +19021,7 @@
    local.get $1
    call $~lib/array/Array<i32>#concat
    local.tee $7
-   i32.store offset=40
+   i32.store offset=36
    global.get $~lib/memory/__stack_pointer
    global.get $std/array/arr
    local.tee $8
@@ -19180,7 +19176,7 @@
    i32.const 2768
    call $~lib/rt/__newArray
    local.tee $1
-   i32.store offset=44
+   i32.store offset=40
    global.get $~lib/memory/__stack_pointer
    local.get $1
    i32.store
@@ -19206,7 +19202,7 @@
    local.get $7
    call $~lib/array/Array<i32>#concat
    local.tee $7
-   i32.store offset=40
+   i32.store offset=36
    global.get $~lib/memory/__stack_pointer
    local.get $7
    i32.store
@@ -19242,10 +19238,10 @@
    i32.const 2800
    call $~lib/rt/__newArray
    local.tee $1
-   i32.store offset=48
+   i32.store offset=44
    global.get $~lib/memory/__stack_pointer
    local.get $1
-   i32.store offset=52
+   i32.store offset=48
    i32.const 2
    global.set $~argumentsLength
    local.get $1
@@ -19285,10 +19281,10 @@
    i32.const 2896
    call $~lib/rt/__newArray
    local.tee $1
-   i32.store offset=48
+   i32.store offset=44
    global.get $~lib/memory/__stack_pointer
    local.get $1
-   i32.store offset=52
+   i32.store offset=48
    i32.const 2
    global.set $~argumentsLength
    local.get $1
@@ -19328,10 +19324,10 @@
    i32.const 2992
    call $~lib/rt/__newArray
    local.tee $1
-   i32.store offset=48
+   i32.store offset=44
    global.get $~lib/memory/__stack_pointer
    local.get $1
-   i32.store offset=52
+   i32.store offset=48
    i32.const 2
    global.set $~argumentsLength
    local.get $1
@@ -19371,10 +19367,10 @@
    i32.const 3088
    call $~lib/rt/__newArray
    local.tee $1
-   i32.store offset=48
+   i32.store offset=44
    global.get $~lib/memory/__stack_pointer
    local.get $1
-   i32.store offset=52
+   i32.store offset=48
    i32.const 2
    global.set $~argumentsLength
    local.get $1
@@ -19414,10 +19410,10 @@
    i32.const 3184
    call $~lib/rt/__newArray
    local.tee $1
-   i32.store offset=48
+   i32.store offset=44
    global.get $~lib/memory/__stack_pointer
    local.get $1
-   i32.store offset=52
+   i32.store offset=48
    local.get $1
    i32.const 0
    i32.const 3
@@ -19456,10 +19452,10 @@
    i32.const 3280
    call $~lib/rt/__newArray
    local.tee $1
-   i32.store offset=48
+   i32.store offset=44
    global.get $~lib/memory/__stack_pointer
    local.get $1
-   i32.store offset=52
+   i32.store offset=48
    local.get $1
    i32.const 1
    i32.const 3
@@ -19498,10 +19494,10 @@
    i32.const 3376
    call $~lib/rt/__newArray
    local.tee $1
-   i32.store offset=48
+   i32.store offset=44
    global.get $~lib/memory/__stack_pointer
    local.get $1
-   i32.store offset=52
+   i32.store offset=48
    local.get $1
    i32.const 1
    i32.const 2
@@ -19540,10 +19536,10 @@
    i32.const 3472
    call $~lib/rt/__newArray
    local.tee $1
-   i32.store offset=48
+   i32.store offset=44
    global.get $~lib/memory/__stack_pointer
    local.get $1
-   i32.store offset=52
+   i32.store offset=48
    i32.const 2
    global.set $~argumentsLength
    local.get $1
@@ -19583,10 +19579,10 @@
    i32.const 3568
    call $~lib/rt/__newArray
    local.tee $1
-   i32.store offset=48
+   i32.store offset=44
    global.get $~lib/memory/__stack_pointer
    local.get $1
-   i32.store offset=52
+   i32.store offset=48
    local.get $1
    i32.const 0
    i32.const -2
@@ -19625,10 +19621,10 @@
    i32.const 3664
    call $~lib/rt/__newArray
    local.tee $1
-   i32.store offset=48
+   i32.store offset=44
    global.get $~lib/memory/__stack_pointer
    local.get $1
-   i32.store offset=52
+   i32.store offset=48
    local.get $1
    i32.const -4
    i32.const -3
@@ -19667,10 +19663,10 @@
    i32.const 3760
    call $~lib/rt/__newArray
    local.tee $1
-   i32.store offset=48
+   i32.store offset=44
    global.get $~lib/memory/__stack_pointer
    local.get $1
-   i32.store offset=52
+   i32.store offset=48
    local.get $1
    i32.const -4
    i32.const -3
@@ -19709,10 +19705,10 @@
    i32.const 3856
    call $~lib/rt/__newArray
    local.tee $1
-   i32.store offset=48
+   i32.store offset=44
    global.get $~lib/memory/__stack_pointer
    local.get $1
-   i32.store offset=52
+   i32.store offset=48
    i32.const 2
    global.set $~argumentsLength
    local.get $1
@@ -20263,7 +20259,7 @@
    i32.const 3952
    call $~lib/rt/__newArray
    local.tee $1
-   i32.store offset=56
+   i32.store offset=52
    global.get $~lib/memory/__stack_pointer
    local.get $1
    i32.store
@@ -20274,7 +20270,7 @@
    i32.const 2
    call $~lib/array/Array<i32>#slice@varargs
    local.tee $7
-   i32.store offset=60
+   i32.store offset=56
    global.get $~lib/memory/__stack_pointer
    local.get $7
    i32.store
@@ -20309,7 +20305,7 @@
    i32.const 4
    call $~lib/array/Array<i32>#slice
    local.tee $7
-   i32.store offset=60
+   i32.store offset=56
    global.get $~lib/memory/__stack_pointer
    local.get $7
    i32.store
@@ -20344,7 +20340,7 @@
    i32.const 5
    call $~lib/array/Array<i32>#slice
    local.tee $7
-   i32.store offset=60
+   i32.store offset=56
    global.get $~lib/memory/__stack_pointer
    local.get $7
    i32.store
@@ -20380,7 +20376,7 @@
    i32.const 0
    call $~lib/array/Array<i32>#slice@varargs
    local.tee $7
-   i32.store offset=60
+   i32.store offset=56
    global.get $~lib/memory/__stack_pointer
    local.get $7
    i32.store
@@ -20410,7 +20406,7 @@
    i32.const -2
    call $~lib/array/Array<i32>#slice@varargs
    local.tee $7
-   i32.store offset=60
+   i32.store offset=56
    global.get $~lib/memory/__stack_pointer
    local.get $7
    i32.store
@@ -20445,7 +20441,7 @@
    i32.const -1
    call $~lib/array/Array<i32>#slice
    local.tee $7
-   i32.store offset=60
+   i32.store offset=56
    global.get $~lib/memory/__stack_pointer
    local.get $7
    i32.store
@@ -20480,7 +20476,7 @@
    i32.const -1
    call $~lib/array/Array<i32>#slice
    local.tee $7
-   i32.store offset=60
+   i32.store offset=56
    global.get $~lib/memory/__stack_pointer
    local.get $7
    i32.store
@@ -20738,7 +20734,7 @@
    local.get $3
    call $~lib/array/Array<u8>#reverse
    local.tee $1
-   i32.store offset=64
+   i32.store offset=60
    global.get $~lib/memory/__stack_pointer
    local.get $1
    i32.store
@@ -20798,7 +20794,7 @@
    local.get $1
    call $~lib/array/Array<u8>#reverse
    local.tee $1
-   i32.store offset=68
+   i32.store offset=64
    i32.const 0
    local.set $0
    global.get $~lib/memory/__stack_pointer
@@ -20860,7 +20856,7 @@
    local.get $1
    call $~lib/array/Array<u8>#reverse
    local.tee $1
-   i32.store offset=72
+   i32.store offset=68
    i32.const 0
    local.set $0
    global.get $~lib/memory/__stack_pointer
@@ -20922,7 +20918,7 @@
    local.get $1
    call $~lib/array/Array<u16>#reverse
    local.tee $1
-   i32.store offset=76
+   i32.store offset=72
    i32.const 0
    local.set $0
    global.get $~lib/memory/__stack_pointer
@@ -20984,7 +20980,7 @@
    local.get $1
    call $~lib/array/Array<u16>#reverse
    local.tee $1
-   i32.store offset=80
+   i32.store offset=76
    i32.const 0
    local.set $0
    global.get $~lib/memory/__stack_pointer
@@ -21046,7 +21042,7 @@
    local.get $1
    call $~lib/array/Array<u16>#reverse
    local.tee $1
-   i32.store offset=84
+   i32.store offset=80
    i32.const 0
    local.set $0
    global.get $~lib/memory/__stack_pointer
@@ -21486,7 +21482,7 @@
    i32.const 4528
    call $~lib/rt/__newArray
    local.tee $0
-   i32.store offset=88
+   i32.store offset=84
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store
@@ -22029,10 +22025,10 @@
    i32.const 4640
    call $~lib/rt/__newArray
    local.tee $0
-   i32.store offset=92
+   i32.store offset=88
    global.get $~lib/memory/__stack_pointer
    local.get $0
-   i32.store offset=52
+   i32.store offset=48
    i32.const 1
    global.set $~argumentsLength
    local.get $0
@@ -22096,10 +22092,10 @@
    i32.const 4768
    call $~lib/rt/__newArray
    local.tee $0
-   i32.store offset=92
+   i32.store offset=88
    global.get $~lib/memory/__stack_pointer
    local.get $0
-   i32.store offset=52
+   i32.store offset=48
    local.get $0
    i32.const 0
    i32.const 0
@@ -22162,10 +22158,10 @@
    i32.const 4896
    call $~lib/rt/__newArray
    local.tee $0
-   i32.store offset=92
+   i32.store offset=88
    global.get $~lib/memory/__stack_pointer
    local.get $0
-   i32.store offset=52
+   i32.store offset=48
    i32.const 1
    global.set $~argumentsLength
    local.get $0
@@ -22229,10 +22225,10 @@
    i32.const 5008
    call $~lib/rt/__newArray
    local.tee $0
-   i32.store offset=92
+   i32.store offset=88
    global.get $~lib/memory/__stack_pointer
    local.get $0
-   i32.store offset=52
+   i32.store offset=48
    local.get $0
    i32.const 2
    i32.const 2
@@ -22295,10 +22291,10 @@
    i32.const 5120
    call $~lib/rt/__newArray
    local.tee $0
-   i32.store offset=92
+   i32.store offset=88
    global.get $~lib/memory/__stack_pointer
    local.get $0
-   i32.store offset=52
+   i32.store offset=48
    local.get $0
    i32.const 0
    i32.const 1
@@ -22361,10 +22357,10 @@
    i32.const 5248
    call $~lib/rt/__newArray
    local.tee $0
-   i32.store offset=92
+   i32.store offset=88
    global.get $~lib/memory/__stack_pointer
    local.get $0
-   i32.store offset=52
+   i32.store offset=48
    i32.const 1
    global.set $~argumentsLength
    local.get $0
@@ -22428,10 +22424,10 @@
    i32.const 5376
    call $~lib/rt/__newArray
    local.tee $0
-   i32.store offset=92
+   i32.store offset=88
    global.get $~lib/memory/__stack_pointer
    local.get $0
-   i32.store offset=52
+   i32.store offset=48
    i32.const 1
    global.set $~argumentsLength
    local.get $0
@@ -22495,10 +22491,10 @@
    i32.const 5488
    call $~lib/rt/__newArray
    local.tee $0
-   i32.store offset=92
+   i32.store offset=88
    global.get $~lib/memory/__stack_pointer
    local.get $0
-   i32.store offset=52
+   i32.store offset=48
    local.get $0
    i32.const -2
    i32.const 1
@@ -22561,10 +22557,10 @@
    i32.const 5616
    call $~lib/rt/__newArray
    local.tee $0
-   i32.store offset=92
+   i32.store offset=88
    global.get $~lib/memory/__stack_pointer
    local.get $0
-   i32.store offset=52
+   i32.store offset=48
    local.get $0
    i32.const -7
    i32.const 1
@@ -22627,10 +22623,10 @@
    i32.const 5744
    call $~lib/rt/__newArray
    local.tee $0
-   i32.store offset=92
+   i32.store offset=88
    global.get $~lib/memory/__stack_pointer
    local.get $0
-   i32.store offset=52
+   i32.store offset=48
    local.get $0
    i32.const -2
    i32.const -1
@@ -22693,10 +22689,10 @@
    i32.const 5872
    call $~lib/rt/__newArray
    local.tee $0
-   i32.store offset=92
+   i32.store offset=88
    global.get $~lib/memory/__stack_pointer
    local.get $0
-   i32.store offset=52
+   i32.store offset=48
    local.get $0
    i32.const 1
    i32.const -2
@@ -22759,10 +22755,10 @@
    i32.const 6000
    call $~lib/rt/__newArray
    local.tee $0
-   i32.store offset=92
+   i32.store offset=88
    global.get $~lib/memory/__stack_pointer
    local.get $0
-   i32.store offset=52
+   i32.store offset=48
    local.get $0
    i32.const 4
    i32.const 0
@@ -22825,10 +22821,10 @@
    i32.const 6128
    call $~lib/rt/__newArray
    local.tee $0
-   i32.store offset=92
+   i32.store offset=88
    global.get $~lib/memory/__stack_pointer
    local.get $0
-   i32.store offset=52
+   i32.store offset=48
    local.get $0
    i32.const 7
    i32.const 0
@@ -22891,10 +22887,10 @@
    i32.const 6256
    call $~lib/rt/__newArray
    local.tee $0
-   i32.store offset=92
+   i32.store offset=88
    global.get $~lib/memory/__stack_pointer
    local.get $0
-   i32.store offset=52
+   i32.store offset=48
    local.get $0
    i32.const 7
    i32.const 5
@@ -22957,7 +22953,7 @@
    i32.const 6384
    call $~lib/rt/__newArray
    local.tee $0
-   i32.store offset=96
+   i32.store offset=92
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store
@@ -22966,7 +22962,7 @@
    i32.const 1
    call $~lib/array/Array<std/array/Ref>#splice
    local.tee $1
-   i32.store offset=100
+   i32.store offset=96
    global.get $~lib/memory/__stack_pointer
    local.get $1
    i32.store
@@ -23002,11 +22998,7 @@
    i32.const 0
    call $~lib/rt/__newArray
    local.tee $1
-   i32.store offset=104
-   global.get $~lib/memory/__stack_pointer
-   local.get $1
-   i32.load offset=4
-   i32.store offset=108
+   i32.store offset=100
    local.get $1
    i32.const 0
    i32.const 1
@@ -23034,7 +23026,7 @@
    call $~lib/array/Array<std/array/Ref>#__set
    local.get $0
    local.get $1
-   i32.store offset=96
+   i32.store offset=92
    global.get $~lib/memory/__stack_pointer
    local.get $1
    i32.store
@@ -23043,7 +23035,7 @@
    i32.const 2
    call $~lib/array/Array<std/array/Ref>#splice
    local.tee $0
-   i32.store offset=100
+   i32.store offset=96
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store
@@ -23193,11 +23185,7 @@
    i32.const 0
    call $~lib/rt/__newArray
    local.tee $1
-   i32.store offset=112
-   global.get $~lib/memory/__stack_pointer
-   local.get $1
-   i32.load offset=4
-   i32.store offset=116
+   i32.store offset=104
    local.get $1
    i32.const 0
    i32.const 1
@@ -23214,7 +23202,7 @@
    call $~lib/array/Array<std/array/Ref>#__set
    local.get $0
    local.get $1
-   i32.store offset=120
+   i32.store offset=108
    global.get $~lib/memory/__stack_pointer
    local.set $0
    global.get $~lib/memory/__stack_pointer
@@ -23322,7 +23310,7 @@
    global.set $~lib/memory/__stack_pointer
    local.get $0
    local.get $9
-   i32.store offset=124
+   i32.store offset=112
    global.get $~lib/memory/__stack_pointer
    local.get $9
    i32.store
@@ -23346,7 +23334,7 @@
    i32.const 0
    call $~lib/array/Array<std/array/Ref|null>#__get
    local.tee $0
-   i32.store offset=128
+   i32.store offset=116
    local.get $0
    i32.eqz
    if
@@ -23409,7 +23397,7 @@
    i32.const 1
    call $~lib/array/Array<std/array/Ref|null>#__get
    local.tee $0
-   i32.store offset=132
+   i32.store offset=120
    local.get $0
    i32.eqz
    if
@@ -23678,7 +23666,7 @@
    i32.const 6864
    call $~lib/rt/__newArray
    local.tee $0
-   i32.store offset=136
+   i32.store offset=124
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store
@@ -24447,7 +24435,7 @@
    global.set $~lib/memory/__stack_pointer
    local.get $0
    local.get $8
-   i32.store offset=140
+   i32.store offset=128
    global.get $~lib/memory/__stack_pointer
    local.set $0
    global.get $~lib/memory/__stack_pointer
@@ -24547,7 +24535,7 @@
    global.set $~lib/memory/__stack_pointer
    local.get $0
    local.get $8
-   i32.store offset=144
+   i32.store offset=132
    global.get $~lib/memory/__stack_pointer
    local.get $8
    i32.store
@@ -24743,7 +24731,7 @@
    i32.const 9456
    call $~lib/array/Array<i32>#filter
    local.tee $0
-   i32.store offset=148
+   i32.store offset=136
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store
@@ -25432,15 +25420,11 @@
    i32.const 0
    call $~lib/rt/__newArray
    local.tee $0
-   i32.store offset=152
-   global.get $~lib/memory/__stack_pointer
-   local.get $0
-   i32.load offset=4
-   i32.store offset=156
+   i32.store offset=140
    global.get $~lib/memory/__stack_pointer
    call $std/array/Dim#constructor
    local.tee $1
-   i32.store offset=160
+   i32.store offset=144
    global.get $~lib/memory/__stack_pointer
    local.get $1
    i32.store
@@ -25460,7 +25444,7 @@
    global.get $~lib/memory/__stack_pointer
    call $std/array/Dim#constructor
    local.tee $1
-   i32.store offset=164
+   i32.store offset=148
    global.get $~lib/memory/__stack_pointer
    local.get $1
    i32.store
@@ -25480,7 +25464,7 @@
    global.get $~lib/memory/__stack_pointer
    call $std/array/Dim#constructor
    local.tee $1
-   i32.store offset=168
+   i32.store offset=152
    global.get $~lib/memory/__stack_pointer
    local.get $1
    i32.store
@@ -25500,7 +25484,7 @@
    global.get $~lib/memory/__stack_pointer
    call $std/array/Dim#constructor
    local.tee $1
-   i32.store offset=172
+   i32.store offset=156
    global.get $~lib/memory/__stack_pointer
    local.get $1
    i32.store
@@ -25520,7 +25504,7 @@
    global.get $~lib/memory/__stack_pointer
    call $std/array/Dim#constructor
    local.tee $1
-   i32.store offset=176
+   i32.store offset=160
    global.get $~lib/memory/__stack_pointer
    local.get $1
    i32.store
@@ -25540,7 +25524,7 @@
    global.get $~lib/memory/__stack_pointer
    call $std/array/Dim#constructor
    local.tee $1
-   i32.store offset=180
+   i32.store offset=164
    global.get $~lib/memory/__stack_pointer
    local.get $1
    i32.store
@@ -25560,7 +25544,7 @@
    global.get $~lib/memory/__stack_pointer
    call $std/array/Dim#constructor
    local.tee $1
-   i32.store offset=184
+   i32.store offset=168
    global.get $~lib/memory/__stack_pointer
    local.get $1
    i32.store
@@ -25580,7 +25564,7 @@
    global.get $~lib/memory/__stack_pointer
    call $std/array/Dim#constructor
    local.tee $1
-   i32.store offset=188
+   i32.store offset=172
    global.get $~lib/memory/__stack_pointer
    local.get $1
    i32.store
@@ -25600,7 +25584,7 @@
    global.get $~lib/memory/__stack_pointer
    call $std/array/Dim#constructor
    local.tee $1
-   i32.store offset=192
+   i32.store offset=176
    global.get $~lib/memory/__stack_pointer
    local.get $1
    i32.store
@@ -25620,7 +25604,7 @@
    global.get $~lib/memory/__stack_pointer
    call $std/array/Dim#constructor
    local.tee $1
-   i32.store offset=196
+   i32.store offset=180
    global.get $~lib/memory/__stack_pointer
    local.get $1
    i32.store
@@ -25640,7 +25624,7 @@
    global.get $~lib/memory/__stack_pointer
    call $std/array/Dim#constructor
    local.tee $1
-   i32.store offset=200
+   i32.store offset=184
    global.get $~lib/memory/__stack_pointer
    local.get $1
    i32.store
@@ -25660,7 +25644,7 @@
    global.get $~lib/memory/__stack_pointer
    call $std/array/Dim#constructor
    local.tee $1
-   i32.store offset=204
+   i32.store offset=188
    global.get $~lib/memory/__stack_pointer
    local.get $1
    i32.store
@@ -25686,15 +25670,11 @@
    i32.const 0
    call $~lib/rt/__newArray
    local.tee $0
-   i32.store offset=208
-   global.get $~lib/memory/__stack_pointer
-   local.get $0
-   i32.load offset=4
-   i32.store offset=212
+   i32.store offset=192
    global.get $~lib/memory/__stack_pointer
    call $std/array/Dim#constructor
    local.tee $1
-   i32.store offset=216
+   i32.store offset=196
    global.get $~lib/memory/__stack_pointer
    local.get $1
    i32.store
@@ -25714,7 +25694,7 @@
    global.get $~lib/memory/__stack_pointer
    call $std/array/Dim#constructor
    local.tee $1
-   i32.store offset=220
+   i32.store offset=200
    global.get $~lib/memory/__stack_pointer
    local.get $1
    i32.store
@@ -25734,7 +25714,7 @@
    global.get $~lib/memory/__stack_pointer
    call $std/array/Dim#constructor
    local.tee $1
-   i32.store offset=224
+   i32.store offset=204
    global.get $~lib/memory/__stack_pointer
    local.get $1
    i32.store
@@ -25754,7 +25734,7 @@
    global.get $~lib/memory/__stack_pointer
    call $std/array/Dim#constructor
    local.tee $1
-   i32.store offset=228
+   i32.store offset=208
    global.get $~lib/memory/__stack_pointer
    local.get $1
    i32.store
@@ -25774,7 +25754,7 @@
    global.get $~lib/memory/__stack_pointer
    call $std/array/Dim#constructor
    local.tee $1
-   i32.store offset=232
+   i32.store offset=212
    global.get $~lib/memory/__stack_pointer
    local.get $1
    i32.store
@@ -25794,7 +25774,7 @@
    global.get $~lib/memory/__stack_pointer
    call $std/array/Dim#constructor
    local.tee $1
-   i32.store offset=236
+   i32.store offset=216
    global.get $~lib/memory/__stack_pointer
    local.get $1
    i32.store
@@ -25814,7 +25794,7 @@
    global.get $~lib/memory/__stack_pointer
    call $std/array/Dim#constructor
    local.tee $1
-   i32.store offset=240
+   i32.store offset=220
    global.get $~lib/memory/__stack_pointer
    local.get $1
    i32.store
@@ -25834,7 +25814,7 @@
    global.get $~lib/memory/__stack_pointer
    call $std/array/Dim#constructor
    local.tee $1
-   i32.store offset=244
+   i32.store offset=224
    global.get $~lib/memory/__stack_pointer
    local.get $1
    i32.store
@@ -25854,7 +25834,7 @@
    global.get $~lib/memory/__stack_pointer
    call $std/array/Dim#constructor
    local.tee $1
-   i32.store offset=248
+   i32.store offset=228
    global.get $~lib/memory/__stack_pointer
    local.get $1
    i32.store
@@ -25874,7 +25854,7 @@
    global.get $~lib/memory/__stack_pointer
    call $std/array/Dim#constructor
    local.tee $1
-   i32.store offset=252
+   i32.store offset=232
    global.get $~lib/memory/__stack_pointer
    local.get $1
    i32.store
@@ -25894,7 +25874,7 @@
    global.get $~lib/memory/__stack_pointer
    call $std/array/Dim#constructor
    local.tee $1
-   i32.store offset=256
+   i32.store offset=236
    global.get $~lib/memory/__stack_pointer
    local.get $1
    i32.store
@@ -25914,7 +25894,7 @@
    global.get $~lib/memory/__stack_pointer
    call $std/array/Dim#constructor
    local.tee $1
-   i32.store offset=260
+   i32.store offset=240
    global.get $~lib/memory/__stack_pointer
    local.get $1
    i32.store
@@ -25940,7 +25920,7 @@
    i32.const 10224
    call $~lib/rt/__newArray
    local.tee $0
-   i32.store offset=264
+   i32.store offset=244
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store
@@ -25979,7 +25959,7 @@
    i32.const 10320
    call $~lib/rt/__newArray
    local.tee $0
-   i32.store offset=268
+   i32.store offset=248
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store
@@ -26018,7 +25998,7 @@
    i32.const 10448
    call $~lib/rt/__newArray
    local.tee $0
-   i32.store offset=272
+   i32.store offset=252
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store
@@ -26238,7 +26218,7 @@
    i32.const 10672
    call $~lib/rt/__newArray
    local.tee $0
-   i32.store offset=276
+   i32.store offset=256
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store
@@ -26307,7 +26287,7 @@
    i32.const 10800
    call $~lib/rt/__newArray
    local.tee $0
-   i32.store offset=280
+   i32.store offset=260
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store
@@ -26404,7 +26384,7 @@
    i32.const 10928
    call $~lib/rt/__newArray
    local.tee $3
-   i32.store offset=284
+   i32.store offset=264
    global.get $~lib/memory/__stack_pointer
    i32.const 1
    i32.const 2
@@ -26412,7 +26392,7 @@
    i32.const 10960
    call $~lib/rt/__newArray
    local.tee $7
-   i32.store offset=288
+   i32.store offset=268
    global.get $~lib/memory/__stack_pointer
    i32.const 2
    i32.const 2
@@ -26420,7 +26400,7 @@
    i32.const 10992
    call $~lib/rt/__newArray
    local.tee $8
-   i32.store offset=292
+   i32.store offset=272
    global.get $~lib/memory/__stack_pointer
    i32.const 4
    i32.const 2
@@ -26428,7 +26408,7 @@
    i32.const 11024
    call $~lib/rt/__newArray
    local.tee $9
-   i32.store offset=296
+   i32.store offset=276
    global.get $~lib/memory/__stack_pointer
    i32.const 4
    i32.const 2
@@ -26436,32 +26416,32 @@
    i32.const 11072
    call $~lib/rt/__newArray
    local.tee $10
-   i32.store offset=300
+   i32.store offset=280
    global.get $~lib/memory/__stack_pointer
    i32.const 64
    call $std/array/createReverseOrderedArray
    local.tee $11
-   i32.store offset=304
+   i32.store offset=284
    global.get $~lib/memory/__stack_pointer
    i32.const 128
    call $std/array/createReverseOrderedArray
    local.tee $12
-   i32.store offset=308
+   i32.store offset=288
    global.get $~lib/memory/__stack_pointer
    i32.const 1024
    call $std/array/createReverseOrderedArray
    local.tee $0
-   i32.store offset=312
+   i32.store offset=292
    global.get $~lib/memory/__stack_pointer
    i32.const 10000
    call $std/array/createReverseOrderedArray
    local.tee $1
-   i32.store offset=316
+   i32.store offset=296
    global.get $~lib/memory/__stack_pointer
    i32.const 512
    call $std/array/createRandomOrderedArray
    local.tee $13
-   i32.store offset=320
+   i32.store offset=300
    global.get $~lib/memory/__stack_pointer
    local.get $3
    i32.store
@@ -26888,12 +26868,12 @@
    i32.const 64
    call $std/array/createRandomOrderedArray
    local.tee $0
-   i32.store offset=324
+   i32.store offset=304
    global.get $~lib/memory/__stack_pointer
    i32.const 257
    call $std/array/createRandomOrderedArray
    local.tee $1
-   i32.store offset=328
+   i32.store offset=308
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store
@@ -27084,7 +27064,7 @@
    global.set $~lib/memory/__stack_pointer
    local.get $1
    local.get $2
-   i32.store offset=332
+   i32.store offset=312
    global.get $~lib/memory/__stack_pointer
    local.get $2
    i32.store
@@ -27263,7 +27243,7 @@
    global.set $~lib/memory/__stack_pointer
    local.get $0
    local.get $3
-   i32.store offset=336
+   i32.store offset=316
    global.get $~lib/memory/__stack_pointer
    local.get $3
    i32.store
@@ -27280,7 +27260,7 @@
    i32.const 11600
    call $~lib/rt/__newArray
    local.tee $0
-   i32.store offset=340
+   i32.store offset=320
    global.get $~lib/memory/__stack_pointer
    i32.const 7
    i32.const 2
@@ -27288,7 +27268,7 @@
    i32.const 11648
    call $~lib/rt/__newArray
    local.tee $1
-   i32.store offset=344
+   i32.store offset=324
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store
@@ -27842,7 +27822,7 @@
    global.set $~lib/memory/__stack_pointer
    local.get $7
    local.get $8
-   i32.store offset=348
+   i32.store offset=328
    global.get $~lib/memory/__stack_pointer
    local.get $8
    i32.store
@@ -27886,10 +27866,10 @@
    local.set $0
    global.get $~lib/memory/__stack_pointer
    local.get $0
-   i32.store offset=52
+   i32.store offset=48
    global.get $~lib/memory/__stack_pointer
    i32.const 11856
-   i32.store offset=352
+   i32.store offset=332
    global.get $~lib/memory/__stack_pointer
    i32.const 4
    i32.sub
@@ -28115,10 +28095,10 @@
    local.set $0
    global.get $~lib/memory/__stack_pointer
    local.get $0
-   i32.store offset=52
+   i32.store offset=48
    global.get $~lib/memory/__stack_pointer
    i32.const 11568
-   i32.store offset=352
+   i32.store offset=332
    local.get $0
    i32.const 11568
    call $~lib/array/Array<i32>#join
@@ -28149,10 +28129,10 @@
    local.set $0
    global.get $~lib/memory/__stack_pointer
    local.get $0
-   i32.store offset=52
+   i32.store offset=48
    global.get $~lib/memory/__stack_pointer
    i32.const 12032
-   i32.store offset=352
+   i32.store offset=332
    local.get $0
    i32.const 12032
    call $~lib/array/Array<u32>#join
@@ -28183,10 +28163,10 @@
    local.set $0
    global.get $~lib/memory/__stack_pointer
    local.get $0
-   i32.store offset=52
+   i32.store offset=48
    global.get $~lib/memory/__stack_pointer
    i32.const 12096
-   i32.store offset=352
+   i32.store offset=332
    local.get $0
    i32.const 12096
    call $~lib/array/Array<i32>#join
@@ -28217,10 +28197,10 @@
    local.set $0
    global.get $~lib/memory/__stack_pointer
    local.get $0
-   i32.store offset=52
+   i32.store offset=48
    global.get $~lib/memory/__stack_pointer
    i32.const 12288
-   i32.store offset=352
+   i32.store offset=332
    global.get $~lib/memory/__stack_pointer
    i32.const 4
    i32.sub
@@ -28281,10 +28261,10 @@
    local.set $0
    global.get $~lib/memory/__stack_pointer
    local.get $0
-   i32.store offset=52
+   i32.store offset=48
    global.get $~lib/memory/__stack_pointer
    i32.const 11568
-   i32.store offset=352
+   i32.store offset=332
    local.get $0
    i32.const 11568
    call $~lib/array/Array<~lib/string/String|null>#join
@@ -28316,11 +28296,7 @@
    i32.const 0
    call $~lib/rt/__newArray
    local.tee $1
-   i32.store offset=356
-   global.get $~lib/memory/__stack_pointer
-   local.get $1
-   i32.load offset=4
-   i32.store offset=360
+   i32.store offset=336
    local.get $1
    i32.const 0
    i32.const 0
@@ -28337,13 +28313,13 @@
    call $~lib/array/Array<std/array/Ref>#__set
    local.get $0
    local.get $1
-   i32.store offset=364
+   i32.store offset=340
    global.get $~lib/memory/__stack_pointer
    local.get $1
-   i32.store offset=52
+   i32.store offset=48
    global.get $~lib/memory/__stack_pointer
    i32.const 11856
-   i32.store offset=352
+   i32.store offset=332
    local.get $1
    call $~lib/array/Array<std/array/Ref|null>#join
    local.set $0
@@ -28374,11 +28350,7 @@
    i32.const 0
    call $~lib/rt/__newArray
    local.tee $1
-   i32.store offset=368
-   global.get $~lib/memory/__stack_pointer
-   local.get $1
-   i32.load offset=4
-   i32.store offset=372
+   i32.store offset=344
    local.get $1
    i32.const 0
    i32.const 0
@@ -28391,13 +28363,13 @@
    call $~lib/array/Array<std/array/Ref>#__set
    local.get $0
    local.get $1
-   i32.store offset=376
+   i32.store offset=348
    global.get $~lib/memory/__stack_pointer
    local.get $1
-   i32.store offset=52
+   i32.store offset=48
    global.get $~lib/memory/__stack_pointer
    i32.const 11856
-   i32.store offset=352
+   i32.store offset=332
    local.get $1
    call $~lib/array/Array<std/array/Ref|null>#join
    local.set $0
@@ -28426,7 +28398,7 @@
    i32.const 13888
    call $~lib/rt/__newArray
    local.tee $0
-   i32.store offset=380
+   i32.store offset=352
    global.get $~lib/memory/__stack_pointer
    i32.const 1
    i32.const 2
@@ -28434,7 +28406,7 @@
    i32.const 13920
    call $~lib/rt/__newArray
    local.tee $1
-   i32.store offset=384
+   i32.store offset=356
    global.get $~lib/memory/__stack_pointer
    i32.const 2
    i32.const 2
@@ -28442,7 +28414,7 @@
    i32.const 13952
    call $~lib/rt/__newArray
    local.tee $2
-   i32.store offset=388
+   i32.store offset=360
    global.get $~lib/memory/__stack_pointer
    i32.const 4
    i32.const 2
@@ -28450,10 +28422,10 @@
    i32.const 13984
    call $~lib/rt/__newArray
    local.tee $3
-   i32.store offset=392
+   i32.store offset=364
    global.get $~lib/memory/__stack_pointer
    local.get $0
-   i32.store offset=52
+   i32.store offset=48
    local.get $0
    call $~lib/array/Array<i32>#toString
    local.set $0
@@ -28477,7 +28449,7 @@
    end
    global.get $~lib/memory/__stack_pointer
    local.get $1
-   i32.store offset=52
+   i32.store offset=48
    local.get $1
    call $~lib/array/Array<i32>#toString
    local.set $0
@@ -28501,7 +28473,7 @@
    end
    global.get $~lib/memory/__stack_pointer
    local.get $2
-   i32.store offset=52
+   i32.store offset=48
    local.get $2
    call $~lib/array/Array<i32>#toString
    local.set $0
@@ -28525,7 +28497,7 @@
    end
    global.get $~lib/memory/__stack_pointer
    local.get $3
-   i32.store offset=52
+   i32.store offset=48
    local.get $3
    call $~lib/array/Array<i32>#toString
    local.set $0
@@ -28555,7 +28527,7 @@
    local.set $0
    global.get $~lib/memory/__stack_pointer
    local.get $0
-   i32.store offset=52
+   i32.store offset=48
    local.get $0
    call $~lib/array/Array<i8>#toString
    local.set $0
@@ -28585,7 +28557,7 @@
    local.set $0
    global.get $~lib/memory/__stack_pointer
    local.get $0
-   i32.store offset=52
+   i32.store offset=48
    local.get $0
    call $~lib/array/Array<i8>#toString
    local.set $0
@@ -28615,7 +28587,7 @@
    local.set $0
    global.get $~lib/memory/__stack_pointer
    local.get $0
-   i32.store offset=52
+   i32.store offset=48
    global.get $~lib/memory/__stack_pointer
    i32.const 8
    i32.sub
@@ -28840,7 +28812,7 @@
    local.set $0
    global.get $~lib/memory/__stack_pointer
    local.get $0
-   i32.store offset=52
+   i32.store offset=48
    global.get $~lib/memory/__stack_pointer
    i32.const 8
    i32.sub
@@ -29065,7 +29037,7 @@
    local.set $0
    global.get $~lib/memory/__stack_pointer
    local.get $0
-   i32.store offset=52
+   i32.store offset=48
    local.get $0
    call $~lib/array/Array<i32>#toString
    local.set $0
@@ -29095,7 +29067,7 @@
    local.set $0
    global.get $~lib/memory/__stack_pointer
    local.get $0
-   i32.store offset=52
+   i32.store offset=48
    global.get $~lib/memory/__stack_pointer
    i32.const 8
    i32.sub
@@ -29177,7 +29149,7 @@
    local.set $0
    global.get $~lib/memory/__stack_pointer
    local.get $0
-   i32.store offset=52
+   i32.store offset=48
    global.get $~lib/memory/__stack_pointer
    i32.const 8
    i32.sub
@@ -29584,10 +29556,10 @@
    i32.const 14864
    call $~lib/rt/__newArray
    local.tee $0
-   i32.store offset=396
+   i32.store offset=368
    global.get $~lib/memory/__stack_pointer
    local.get $0
-   i32.store offset=52
+   i32.store offset=48
    local.get $0
    call $~lib/array/Array<~lib/string/String|null>#toString
    local.set $0
@@ -29617,7 +29589,7 @@
    local.set $0
    global.get $~lib/memory/__stack_pointer
    local.get $0
-   i32.store offset=52
+   i32.store offset=48
    local.get $0
    call $~lib/array/Array<~lib/string/String|null>#toString
    local.set $0
@@ -29648,11 +29620,7 @@
    i32.const 0
    call $~lib/rt/__newArray
    local.tee $1
-   i32.store offset=400
-   global.get $~lib/memory/__stack_pointer
-   local.get $1
-   i32.load offset=4
-   i32.store offset=404
+   i32.store offset=372
    local.get $1
    i32.const 0
    i32.const 2
@@ -29671,10 +29639,10 @@
    call $~lib/array/Array<std/array/Ref>#__set
    local.get $0
    local.get $1
-   i32.store offset=408
+   i32.store offset=376
    global.get $~lib/memory/__stack_pointer
    local.get $1
-   i32.store offset=52
+   i32.store offset=48
    global.get $~lib/memory/__stack_pointer
    i32.const 8
    i32.sub
@@ -29917,11 +29885,7 @@
    i32.const 0
    call $~lib/rt/__newArray
    local.tee $1
-   i32.store offset=412
-   global.get $~lib/memory/__stack_pointer
-   local.get $1
-   i32.load offset=4
-   i32.store offset=416
+   i32.store offset=380
    local.get $1
    i32.const 0
    i32.const 2
@@ -29940,10 +29904,10 @@
    call $~lib/array/Array<std/array/Ref>#__set
    local.get $0
    local.get $1
-   i32.store offset=420
+   i32.store offset=384
    global.get $~lib/memory/__stack_pointer
    local.get $1
-   i32.store offset=52
+   i32.store offset=48
    global.get $~lib/memory/__stack_pointer
    i32.const 8
    i32.sub
@@ -30186,11 +30150,7 @@
    i32.const 0
    call $~lib/rt/__newArray
    local.tee $1
-   i32.store offset=424
-   global.get $~lib/memory/__stack_pointer
-   local.get $1
-   i32.load offset=4
-   i32.store offset=428
+   i32.store offset=388
    global.get $~lib/memory/__stack_pointer
    i32.const 1
    i32.const 2
@@ -30198,11 +30158,7 @@
    i32.const 0
    call $~lib/rt/__newArray
    local.tee $2
-   i32.store offset=432
-   global.get $~lib/memory/__stack_pointer
-   local.get $2
-   i32.load offset=4
-   i32.store offset=436
+   i32.store offset=392
    local.get $2
    i32.const 0
    i32.const 1
@@ -30217,10 +30173,10 @@
    call $~lib/array/Array<std/array/Ref>#__set
    local.get $0
    local.get $1
-   i32.store offset=440
+   i32.store offset=396
    global.get $~lib/memory/__stack_pointer
    local.get $1
-   i32.store offset=52
+   i32.store offset=48
    global.get $~lib/memory/__stack_pointer
    i32.const 8
    i32.sub
@@ -30463,11 +30419,7 @@
    i32.const 0
    call $~lib/rt/__newArray
    local.tee $1
-   i32.store offset=444
-   global.get $~lib/memory/__stack_pointer
-   local.get $1
-   i32.load offset=4
-   i32.store offset=448
+   i32.store offset=400
    local.get $1
    i32.const 0
    i32.const 1
@@ -30502,7 +30454,7 @@
    call $~lib/array/Array<std/array/Ref>#__set
    local.get $0
    local.get $1
-   i32.store offset=452
+   i32.store offset=404
    global.get $~lib/memory/__stack_pointer
    local.get $1
    i32.store
@@ -30510,7 +30462,7 @@
    local.get $1
    call $~lib/array/Array<~lib/array/Array<i32>>#flat
    local.tee $0
-   i32.store offset=456
+   i32.store offset=408
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store
@@ -30565,11 +30517,7 @@
    i32.const 0
    call $~lib/rt/__newArray
    local.tee $1
-   i32.store offset=460
-   global.get $~lib/memory/__stack_pointer
-   local.get $1
-   i32.load offset=4
-   i32.store offset=464
+   i32.store offset=412
    local.get $1
    i32.const 0
    i32.const 1
@@ -30604,7 +30552,7 @@
    call $~lib/array/Array<std/array/Ref>#__set
    local.get $0
    local.get $1
-   i32.store offset=468
+   i32.store offset=416
    global.get $~lib/memory/__stack_pointer
    local.set $7
    global.get $~lib/memory/__stack_pointer
@@ -30768,7 +30716,7 @@
    global.set $~lib/memory/__stack_pointer
    local.get $7
    local.get $11
-   i32.store offset=472
+   i32.store offset=420
    global.get $~lib/memory/__stack_pointer
    i32.const 8
    i32.const 2
@@ -30776,7 +30724,7 @@
    i32.const 15792
    call $~lib/rt/__newArray
    local.tee $0
-   i32.store offset=476
+   i32.store offset=424
    global.get $~lib/memory/__stack_pointer
    local.get $11
    i32.store
@@ -30805,7 +30753,7 @@
     if
      global.get $~lib/memory/__stack_pointer
      local.get $11
-     i32.store offset=52
+     i32.store offset=48
      local.get $11
      local.get $2
      call $~lib/array/Array<std/array/Ref|null>#__get
@@ -30815,7 +30763,7 @@
      i32.store
      global.get $~lib/memory/__stack_pointer
      local.get $0
-     i32.store offset=52
+     i32.store offset=48
      local.get $0
      local.get $2
      call $~lib/array/Array<std/array/Ref|null>#__get
@@ -30851,11 +30799,7 @@
    i32.const 0
    call $~lib/rt/__newArray
    local.tee $1
-   i32.store offset=480
-   global.get $~lib/memory/__stack_pointer
-   local.get $1
-   i32.load offset=4
-   i32.store offset=484
+   i32.store offset=428
    local.get $1
    i32.const 0
    i32.const 0
@@ -30874,7 +30818,7 @@
    call $~lib/array/Array<std/array/Ref>#__set
    local.get $0
    local.get $1
-   i32.store offset=488
+   i32.store offset=432
    global.get $~lib/memory/__stack_pointer
    local.get $1
    i32.store offset=8
@@ -30903,11 +30847,7 @@
    i32.const 0
    call $~lib/rt/__newArray
    local.tee $1
-   i32.store offset=492
-   global.get $~lib/memory/__stack_pointer
-   local.get $1
-   i32.load offset=4
-   i32.store offset=496
+   i32.store offset=436
    local.get $1
    i32.const 0
    i32.const 1
@@ -30926,7 +30866,7 @@
    call $~lib/array/Array<std/array/Ref>#__set
    local.get $0
    local.get $1
-   i32.store offset=500
+   i32.store offset=440
    global.get $~lib/memory/__stack_pointer
    local.set $0
    global.get $~lib/memory/__stack_pointer
@@ -30934,7 +30874,7 @@
    i32.store offset=8
    global.get $~lib/memory/__stack_pointer
    i32.const 15984
-   i32.store offset=52
+   i32.store offset=48
    global.get $~lib/memory/__stack_pointer
    i32.const 20
    i32.sub
@@ -31038,7 +30978,7 @@
    local.get $7
    call $~lib/array/Array<~lib/array/Array<i32>>#flat
    local.tee $0
-   i32.store offset=504
+   i32.store offset=444
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store
@@ -31160,7 +31100,7 @@
    i32.add
    global.set $~lib/rt/itcms/threshold
    global.get $~lib/memory/__stack_pointer
-   i32.const 508
+   i32.const 448
    i32.add
    global.set $~lib/memory/__stack_pointer
    return

--- a/tests/compiler/std/arraybuffer.debug.wat
+++ b/tests/compiler/std/arraybuffer.debug.wat
@@ -3372,7 +3372,6 @@
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
-  (local $5 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 24
   i32.sub
@@ -3406,11 +3405,11 @@
   local.tee $0
   i32.store
   local.get $0
-  local.set $5
+  local.set $4
   global.get $~lib/memory/__stack_pointer
-  local.get $5
+  local.get $4
   i32.store offset=4
-  local.get $5
+  local.get $4
   call $~lib/arraybuffer/ArrayBuffer#get:byteLength
   i32.const 8
   i32.eq
@@ -3425,22 +3424,22 @@
   end
   global.get $~lib/memory/__stack_pointer
   local.get $0
-  local.set $5
+  local.set $4
   global.get $~lib/memory/__stack_pointer
-  local.get $5
+  local.get $4
   i32.store offset=4
-  local.get $5
+  local.get $4
   i32.const 0
   i32.const 1073741820
   call $~lib/arraybuffer/ArrayBuffer#slice
   local.tee $1
   i32.store offset=8
   local.get $1
-  local.set $5
+  local.set $4
   global.get $~lib/memory/__stack_pointer
-  local.get $5
+  local.get $4
   i32.store offset=4
-  local.get $5
+  local.get $4
   call $~lib/arraybuffer/ArrayBuffer#get:byteLength
   i32.const 8
   i32.eq
@@ -3467,22 +3466,22 @@
   end
   global.get $~lib/memory/__stack_pointer
   local.get $0
-  local.set $5
+  local.set $4
   global.get $~lib/memory/__stack_pointer
-  local.get $5
+  local.get $4
   i32.store offset=4
-  local.get $5
+  local.get $4
   i32.const 1
   i32.const 1073741820
   call $~lib/arraybuffer/ArrayBuffer#slice
   local.tee $1
   i32.store offset=8
   local.get $1
-  local.set $5
+  local.set $4
   global.get $~lib/memory/__stack_pointer
-  local.get $5
+  local.get $4
   i32.store offset=4
-  local.get $5
+  local.get $4
   call $~lib/arraybuffer/ArrayBuffer#get:byteLength
   i32.const 7
   i32.eq
@@ -3497,22 +3496,22 @@
   end
   global.get $~lib/memory/__stack_pointer
   local.get $0
-  local.set $5
+  local.set $4
   global.get $~lib/memory/__stack_pointer
-  local.get $5
+  local.get $4
   i32.store offset=4
-  local.get $5
+  local.get $4
   i32.const -1
   i32.const 1073741820
   call $~lib/arraybuffer/ArrayBuffer#slice
   local.tee $1
   i32.store offset=8
   local.get $1
-  local.set $5
+  local.set $4
   global.get $~lib/memory/__stack_pointer
-  local.get $5
+  local.get $4
   i32.store offset=4
-  local.get $5
+  local.get $4
   call $~lib/arraybuffer/ArrayBuffer#get:byteLength
   i32.const 1
   i32.eq
@@ -3527,22 +3526,22 @@
   end
   global.get $~lib/memory/__stack_pointer
   local.get $0
-  local.set $5
+  local.set $4
   global.get $~lib/memory/__stack_pointer
-  local.get $5
+  local.get $4
   i32.store offset=4
-  local.get $5
+  local.get $4
   i32.const 1
   i32.const 3
   call $~lib/arraybuffer/ArrayBuffer#slice
   local.tee $1
   i32.store offset=8
   local.get $1
-  local.set $5
+  local.set $4
   global.get $~lib/memory/__stack_pointer
-  local.get $5
+  local.get $4
   i32.store offset=4
-  local.get $5
+  local.get $4
   call $~lib/arraybuffer/ArrayBuffer#get:byteLength
   i32.const 2
   i32.eq
@@ -3557,22 +3556,22 @@
   end
   global.get $~lib/memory/__stack_pointer
   local.get $0
-  local.set $5
+  local.set $4
   global.get $~lib/memory/__stack_pointer
-  local.get $5
+  local.get $4
   i32.store offset=4
-  local.get $5
+  local.get $4
   i32.const 1
   i32.const -1
   call $~lib/arraybuffer/ArrayBuffer#slice
   local.tee $1
   i32.store offset=8
   local.get $1
-  local.set $5
+  local.set $4
   global.get $~lib/memory/__stack_pointer
-  local.get $5
+  local.get $4
   i32.store offset=4
-  local.get $5
+  local.get $4
   call $~lib/arraybuffer/ArrayBuffer#get:byteLength
   i32.const 6
   i32.eq
@@ -3587,22 +3586,22 @@
   end
   global.get $~lib/memory/__stack_pointer
   local.get $0
-  local.set $5
+  local.set $4
   global.get $~lib/memory/__stack_pointer
-  local.get $5
+  local.get $4
   i32.store offset=4
-  local.get $5
+  local.get $4
   i32.const -3
   i32.const -1
   call $~lib/arraybuffer/ArrayBuffer#slice
   local.tee $1
   i32.store offset=8
   local.get $1
-  local.set $5
+  local.set $4
   global.get $~lib/memory/__stack_pointer
-  local.get $5
+  local.get $4
   i32.store offset=4
-  local.get $5
+  local.get $4
   call $~lib/arraybuffer/ArrayBuffer#get:byteLength
   i32.const 2
   i32.eq
@@ -3617,22 +3616,22 @@
   end
   global.get $~lib/memory/__stack_pointer
   local.get $0
-  local.set $5
+  local.set $4
   global.get $~lib/memory/__stack_pointer
-  local.get $5
+  local.get $4
   i32.store offset=4
-  local.get $5
+  local.get $4
   i32.const -4
   i32.const 42
   call $~lib/arraybuffer/ArrayBuffer#slice
   local.tee $1
   i32.store offset=8
   local.get $1
-  local.set $5
+  local.set $4
   global.get $~lib/memory/__stack_pointer
-  local.get $5
+  local.get $4
   i32.store offset=4
-  local.get $5
+  local.get $4
   call $~lib/arraybuffer/ArrayBuffer#get:byteLength
   i32.const 4
   i32.eq
@@ -3647,22 +3646,22 @@
   end
   global.get $~lib/memory/__stack_pointer
   local.get $0
-  local.set $5
+  local.set $4
   global.get $~lib/memory/__stack_pointer
-  local.get $5
+  local.get $4
   i32.store offset=4
-  local.get $5
+  local.get $4
   i32.const 42
   i32.const 1073741820
   call $~lib/arraybuffer/ArrayBuffer#slice
   local.tee $1
   i32.store offset=8
   local.get $1
-  local.set $5
+  local.set $4
   global.get $~lib/memory/__stack_pointer
-  local.get $5
+  local.get $4
   i32.store offset=4
-  local.get $5
+  local.get $4
   call $~lib/arraybuffer/ArrayBuffer#get:byteLength
   i32.const 0
   i32.eq
@@ -3770,11 +3769,11 @@
   i32.const 4
   i32.const 608
   call $~lib/rt/__newArray
-  local.set $5
+  local.set $4
   global.get $~lib/memory/__stack_pointer
-  local.get $5
+  local.get $4
   i32.store offset=4
-  local.get $5
+  local.get $4
   call $~lib/arraybuffer/ArrayBuffer.isView<~lib/array/Array<i32>>
   i32.eqz
   i32.eqz
@@ -3787,11 +3786,11 @@
    unreachable
   end
   local.get $2
-  local.set $5
+  local.set $4
   global.get $~lib/memory/__stack_pointer
-  local.get $5
+  local.get $4
   i32.store offset=4
-  local.get $5
+  local.get $4
   call $~lib/arraybuffer/ArrayBuffer.isView<~lib/typedarray/Uint8Array>
   i32.eqz
   if
@@ -3805,11 +3804,11 @@
   i32.const 0
   i32.const 1
   call $~lib/typedarray/Int32Array#constructor
-  local.set $5
+  local.set $4
   global.get $~lib/memory/__stack_pointer
-  local.get $5
+  local.get $4
   i32.store offset=4
-  local.get $5
+  local.get $4
   call $~lib/arraybuffer/ArrayBuffer.isView<~lib/typedarray/Int32Array>
   i32.eqz
   if
@@ -3822,27 +3821,27 @@
   end
   i32.const 0
   local.get $2
-  local.set $5
+  local.set $4
   global.get $~lib/memory/__stack_pointer
-  local.get $5
+  local.get $4
   i32.store offset=20
-  local.get $5
+  local.get $4
   call $~lib/arraybuffer/ArrayBufferView#get:buffer
-  local.set $5
+  local.set $4
   global.get $~lib/memory/__stack_pointer
-  local.get $5
+  local.get $4
   i32.store offset=16
-  local.get $5
+  local.get $4
   i32.const 0
   i32.const 1
   global.set $~argumentsLength
   i32.const 0
   call $~lib/dataview/DataView#constructor@varargs
-  local.set $5
+  local.set $4
   global.get $~lib/memory/__stack_pointer
-  local.get $5
+  local.get $4
   i32.store offset=4
-  local.get $5
+  local.get $4
   call $~lib/arraybuffer/ArrayBuffer.isView<~lib/dataview/DataView>
   i32.eqz
   if

--- a/tests/compiler/std/date.debug.wat
+++ b/tests/compiler/std/date.debug.wat
@@ -7189,33 +7189,32 @@
  )
  (func $~lib/string/String#split (param $this i32) (param $separator i32) (param $limit i32) (result i32)
   (local $3 i32)
-  (local $4 i32)
   (local $length i32)
   (local $sepLen i32)
+  (local $6 i32)
   (local $7 i32)
-  (local $8 i32)
   (local $result i32)
   (local $resultStart i32)
   (local $i i32)
   (local $charStr i32)
+  (local $result|12 i32)
   (local $result|13 i32)
-  (local $result|14 i32)
   (local $end i32)
   (local $start i32)
-  (local $i|17 i32)
+  (local $i|16 i32)
   (local $len i32)
   (local $out i32)
-  (local $len|20 i32)
-  (local $out|21 i32)
-  (local $22 i32)
+  (local $len|19 i32)
+  (local $out|20 i32)
+  (local $21 i32)
   global.get $~lib/memory/__stack_pointer
-  i32.const 40
+  i32.const 36
   i32.sub
   global.set $~lib/memory/__stack_pointer
   call $~stack_check
   global.get $~lib/memory/__stack_pointer
   i32.const 0
-  i32.const 40
+  i32.const 36
   memory.fill
   local.get $limit
   i32.eqz
@@ -7225,12 +7224,12 @@
    i32.const 6
    i32.const 0
    call $~lib/rt/__newArray
-   local.set $22
+   local.set $21
    global.get $~lib/memory/__stack_pointer
-   i32.const 40
+   i32.const 36
    i32.add
    global.set $~lib/memory/__stack_pointer
-   local.get $22
+   local.get $21
    return
   end
   local.get $separator
@@ -7245,38 +7244,33 @@
    call $~lib/rt/__newArray
    local.tee $3
    i32.store
-   global.get $~lib/memory/__stack_pointer
-   local.get $3
-   i32.load offset=4
-   local.tee $4
-   i32.store offset=4
    local.get $3
    i32.const 0
    local.get $this
    call $~lib/array/Array<~lib/string/String>#__set
    local.get $3
-   local.set $22
+   local.set $21
    global.get $~lib/memory/__stack_pointer
-   i32.const 40
+   i32.const 36
    i32.add
    global.set $~lib/memory/__stack_pointer
-   local.get $22
+   local.get $21
    return
   end
   local.get $this
-  local.set $22
+  local.set $21
   global.get $~lib/memory/__stack_pointer
-  local.get $22
-  i32.store offset=8
-  local.get $22
+  local.get $21
+  i32.store offset=4
+  local.get $21
   call $~lib/string/String#get:length
   local.set $length
   local.get $separator
-  local.set $22
+  local.set $21
   global.get $~lib/memory/__stack_pointer
-  local.get $22
-  i32.store offset=8
-  local.get $22
+  local.get $21
+  i32.store offset=4
+  local.get $21
   call $~lib/string/String#get:length
   local.set $sepLen
   local.get $limit
@@ -7297,20 +7291,20 @@
     i32.const 6
     i32.const 0
     call $~lib/rt/__newArray
-    local.set $22
+    local.set $21
     global.get $~lib/memory/__stack_pointer
-    i32.const 40
+    i32.const 36
     i32.add
     global.set $~lib/memory/__stack_pointer
-    local.get $22
+    local.get $21
     return
    end
    local.get $length
-   local.tee $7
+   local.tee $6
    local.get $limit
-   local.tee $8
+   local.tee $7
+   local.get $6
    local.get $7
-   local.get $8
    i32.lt_s
    select
    local.set $length
@@ -7321,13 +7315,13 @@
    i32.const 0
    call $~lib/rt/__newArray
    local.tee $result
-   i32.store offset=12
-   local.get $result
-   local.set $22
-   global.get $~lib/memory/__stack_pointer
-   local.get $22
    i32.store offset=8
-   local.get $22
+   local.get $result
+   local.set $21
+   global.get $~lib/memory/__stack_pointer
+   local.get $21
+   i32.store offset=4
+   local.get $21
    call $~lib/array/Array<~lib/string/String>#get:dataStart
    local.set $resultStart
    i32.const 0
@@ -7342,7 +7336,7 @@
      i32.const 2
      call $~lib/rt/itcms/__new
      local.tee $charStr
-     i32.store offset=16
+     i32.store offset=12
      local.get $charStr
      local.get $this
      local.get $i
@@ -7370,12 +7364,12 @@
     end
    end
    local.get $result
-   local.set $22
+   local.set $21
    global.get $~lib/memory/__stack_pointer
-   i32.const 40
+   i32.const 36
    i32.add
    global.set $~lib/memory/__stack_pointer
-   local.get $22
+   local.get $21
    return
   else
    local.get $length
@@ -7387,24 +7381,24 @@
     i32.const 6
     i32.const 0
     call $~lib/rt/__newArray
-    local.tee $result|13
-    i32.store offset=20
-    local.get $result|13
-    local.set $22
+    local.tee $result|12
+    i32.store offset=16
+    local.get $result|12
+    local.set $21
     global.get $~lib/memory/__stack_pointer
-    local.get $22
-    i32.store offset=8
-    local.get $22
+    local.get $21
+    i32.store offset=4
+    local.get $21
     call $~lib/array/Array<~lib/string/String>#get:dataStart
     i32.const 2432
     i32.store
-    local.get $result|13
-    local.set $22
+    local.get $result|12
+    local.set $21
     global.get $~lib/memory/__stack_pointer
-    i32.const 40
+    i32.const 36
     i32.add
     global.set $~lib/memory/__stack_pointer
-    local.get $22
+    local.get $21
     return
    end
   end
@@ -7414,27 +7408,27 @@
   i32.const 6
   i32.const 0
   call $~lib/rt/__newArray
-  local.tee $result|14
-  i32.store offset=24
+  local.tee $result|13
+  i32.store offset=20
   i32.const 0
   local.set $end
   i32.const 0
   local.set $start
   i32.const 0
-  local.set $i|17
+  local.set $i|16
   loop $while-continue|1
    local.get $this
-   local.set $22
+   local.set $21
    global.get $~lib/memory/__stack_pointer
-   local.get $22
-   i32.store offset=8
-   local.get $22
+   local.get $21
+   i32.store offset=4
+   local.get $21
    local.get $separator
-   local.set $22
+   local.set $21
    global.get $~lib/memory/__stack_pointer
-   local.get $22
-   i32.store offset=28
-   local.get $22
+   local.get $21
+   i32.store offset=24
+   local.get $21
    local.get $start
    call $~lib/string/String#indexOf
    local.tee $end
@@ -7456,7 +7450,7 @@
      i32.const 2
      call $~lib/rt/itcms/__new
      local.tee $out
-     i32.store offset=32
+     i32.store offset=28
      local.get $out
      local.get $this
      local.get $start
@@ -7467,50 +7461,50 @@
      i32.const 1
      i32.shl
      memory.copy
-     local.get $result|14
-     local.set $22
+     local.get $result|13
+     local.set $21
      global.get $~lib/memory/__stack_pointer
-     local.get $22
-     i32.store offset=8
-     local.get $22
+     local.get $21
+     i32.store offset=4
+     local.get $21
      local.get $out
-     local.set $22
+     local.set $21
      global.get $~lib/memory/__stack_pointer
-     local.get $22
-     i32.store offset=28
-     local.get $22
+     local.get $21
+     i32.store offset=24
+     local.get $21
      call $~lib/array/Array<~lib/string/String>#push
      drop
     else
-     local.get $result|14
-     local.set $22
+     local.get $result|13
+     local.set $21
      global.get $~lib/memory/__stack_pointer
-     local.get $22
-     i32.store offset=8
-     local.get $22
+     local.get $21
+     i32.store offset=4
+     local.get $21
      i32.const 2432
-     local.set $22
+     local.set $21
      global.get $~lib/memory/__stack_pointer
-     local.get $22
-     i32.store offset=28
-     local.get $22
+     local.get $21
+     i32.store offset=24
+     local.get $21
      call $~lib/array/Array<~lib/string/String>#push
      drop
     end
-    local.get $i|17
+    local.get $i|16
     i32.const 1
     i32.add
-    local.tee $i|17
+    local.tee $i|16
     local.get $limit
     i32.eq
     if
-     local.get $result|14
-     local.set $22
+     local.get $result|13
+     local.set $21
      global.get $~lib/memory/__stack_pointer
-     i32.const 40
+     i32.const 36
      i32.add
      global.set $~lib/memory/__stack_pointer
-     local.get $22
+     local.get $21
      return
     end
     local.get $end
@@ -7523,92 +7517,92 @@
   local.get $start
   i32.eqz
   if
-   local.get $result|14
-   local.set $22
+   local.get $result|13
+   local.set $21
    global.get $~lib/memory/__stack_pointer
-   local.get $22
-   i32.store offset=8
-   local.get $22
+   local.get $21
+   i32.store offset=4
+   local.get $21
    local.get $this
-   local.set $22
+   local.set $21
    global.get $~lib/memory/__stack_pointer
-   local.get $22
-   i32.store offset=28
-   local.get $22
+   local.get $21
+   i32.store offset=24
+   local.get $21
    call $~lib/array/Array<~lib/string/String>#push
    drop
-   local.get $result|14
-   local.set $22
+   local.get $result|13
+   local.set $21
    global.get $~lib/memory/__stack_pointer
-   i32.const 40
+   i32.const 36
    i32.add
    global.set $~lib/memory/__stack_pointer
-   local.get $22
+   local.get $21
    return
   end
   local.get $length
   local.get $start
   i32.sub
-  local.set $len|20
-  local.get $len|20
+  local.set $len|19
+  local.get $len|19
   i32.const 0
   i32.gt_s
   if
    global.get $~lib/memory/__stack_pointer
-   local.get $len|20
+   local.get $len|19
    i32.const 1
    i32.shl
    i32.const 2
    call $~lib/rt/itcms/__new
-   local.tee $out|21
-   i32.store offset=36
-   local.get $out|21
+   local.tee $out|20
+   i32.store offset=32
+   local.get $out|20
    local.get $this
    local.get $start
    i32.const 1
    i32.shl
    i32.add
-   local.get $len|20
+   local.get $len|19
    i32.const 1
    i32.shl
    memory.copy
-   local.get $result|14
-   local.set $22
+   local.get $result|13
+   local.set $21
    global.get $~lib/memory/__stack_pointer
-   local.get $22
-   i32.store offset=8
-   local.get $22
-   local.get $out|21
-   local.set $22
+   local.get $21
+   i32.store offset=4
+   local.get $21
+   local.get $out|20
+   local.set $21
    global.get $~lib/memory/__stack_pointer
-   local.get $22
-   i32.store offset=28
-   local.get $22
+   local.get $21
+   i32.store offset=24
+   local.get $21
    call $~lib/array/Array<~lib/string/String>#push
    drop
   else
-   local.get $result|14
-   local.set $22
+   local.get $result|13
+   local.set $21
    global.get $~lib/memory/__stack_pointer
-   local.get $22
-   i32.store offset=8
-   local.get $22
+   local.get $21
+   i32.store offset=4
+   local.get $21
    i32.const 2432
-   local.set $22
+   local.set $21
    global.get $~lib/memory/__stack_pointer
-   local.get $22
-   i32.store offset=28
-   local.get $22
+   local.get $21
+   i32.store offset=24
+   local.get $21
    call $~lib/array/Array<~lib/string/String>#push
    drop
   end
-  local.get $result|14
-  local.set $22
+  local.get $result|13
+  local.set $21
   global.get $~lib/memory/__stack_pointer
-  i32.const 40
+  i32.const 36
   i32.add
   global.set $~lib/memory/__stack_pointer
-  local.get $22
+  local.get $21
   return
  )
  (func $~lib/string/String#split@varargs (param $this i32) (param $separator i32) (param $limit i32) (result i32)

--- a/tests/compiler/std/date.release.wat
+++ b/tests/compiler/std/date.release.wat
@@ -5624,11 +5624,11 @@
   (local $9 i32)
   (local $10 i32)
   global.get $~lib/memory/__stack_pointer
-  i32.const 40
+  i32.const 36
   i32.sub
   global.set $~lib/memory/__stack_pointer
-  block $folding-inner3
-   block $folding-inner2
+  block $folding-inner4
+   block $folding-inner3
     block $folding-inner1
      block $folding-inner0
       global.get $~lib/memory/__stack_pointer
@@ -5637,7 +5637,7 @@
       br_if $folding-inner0
       global.get $~lib/memory/__stack_pointer
       i32.const 0
-      i32.const 40
+      i32.const 36
       memory.fill
       local.get $2
       i32.eqz
@@ -5650,10 +5650,6 @@
        call $~lib/rt/__newArray
        local.tee $2
        i32.store
-       global.get $~lib/memory/__stack_pointer
-       local.get $2
-       i32.load offset=4
-       i32.store offset=4
        global.get $~lib/memory/__stack_pointer
        i32.const 4
        i32.sub
@@ -5697,71 +5693,71 @@
        i32.const 4
        i32.add
        global.set $~lib/memory/__stack_pointer
-       br $folding-inner2
+       br $folding-inner4
       end
       global.get $~lib/memory/__stack_pointer
       local.get $0
-      i32.store offset=8
+      i32.store offset=4
       local.get $0
       i32.const 20
       i32.sub
       i32.load offset=16
       i32.const 1
       i32.shr_u
-      local.set $8
+      local.set $6
       global.get $~lib/memory/__stack_pointer
       local.get $1
-      i32.store offset=8
+      i32.store offset=4
       i32.const 2147483647
       local.get $2
       local.get $2
       i32.const 0
       i32.lt_s
       select
-      local.set $2
+      local.set $8
       local.get $1
       i32.const 20
       i32.sub
       i32.load offset=16
       i32.const 1
       i32.shr_u
-      local.tee $5
+      local.tee $4
       if
-       local.get $8
+       local.get $6
        i32.eqz
        if
         global.get $~lib/memory/__stack_pointer
         i32.const 1
         call $~lib/rt/__newArray
         local.tee $2
-        i32.store offset=20
+        i32.store offset=16
         global.get $~lib/memory/__stack_pointer
         local.get $2
-        i32.store offset=8
+        i32.store offset=4
         local.get $2
         i32.load offset=4
         i32.const 3456
         i32.store
-        br $folding-inner2
+        br $folding-inner4
        end
       else
-       local.get $8
+       local.get $6
        i32.eqz
        br_if $folding-inner1
        global.get $~lib/memory/__stack_pointer
+       local.get $6
        local.get $8
-       local.get $2
-       local.get $2
+       local.get $6
        local.get $8
-       i32.gt_s
+       i32.lt_s
        select
        local.tee $3
        call $~lib/rt/__newArray
        local.tee $2
-       i32.store offset=12
+       i32.store offset=8
        global.get $~lib/memory/__stack_pointer
        local.get $2
-       i32.store offset=8
+       i32.store offset=4
        local.get $2
        i32.load offset=4
        local.set $4
@@ -5777,7 +5773,7 @@
          i32.const 2
          call $~lib/rt/itcms/__new
          local.tee $5
-         i32.store offset=16
+         i32.store offset=12
          local.get $5
          local.get $0
          local.get $1
@@ -5804,29 +5800,29 @@
          br $for-loop|0
         end
        end
-       br $folding-inner2
+       br $folding-inner4
       end
       global.get $~lib/memory/__stack_pointer
       i32.const 0
       call $~lib/rt/__newArray
-      local.tee $9
-      i32.store offset=24
+      local.tee $2
+      i32.store offset=20
       loop $while-continue|1
        global.get $~lib/memory/__stack_pointer
        local.get $0
-       i32.store offset=8
+       i32.store offset=4
        global.get $~lib/memory/__stack_pointer
        local.get $1
-       i32.store offset=28
+       i32.store offset=24
        local.get $0
        local.get $1
        local.get $3
        call $~lib/string/String#indexOf
-       local.tee $6
+       local.tee $9
        i32.const -1
        i32.xor
        if
-        local.get $6
+        local.get $9
         local.get $3
         i32.sub
         local.tee $7
@@ -5837,48 +5833,48 @@
          local.get $7
          i32.const 1
          i32.shl
-         local.tee $7
+         local.tee $10
          i32.const 2
          call $~lib/rt/itcms/__new
-         local.tee $10
-         i32.store offset=32
-         local.get $10
+         local.tee $7
+         i32.store offset=28
+         local.get $7
          local.get $0
          local.get $3
          i32.const 1
          i32.shl
          i32.add
-         local.get $7
+         local.get $10
          memory.copy
          global.get $~lib/memory/__stack_pointer
-         local.get $9
-         i32.store offset=8
+         local.get $2
+         i32.store offset=4
          global.get $~lib/memory/__stack_pointer
-         local.get $10
-         i32.store offset=28
-         local.get $9
-         local.get $10
+         local.get $7
+         i32.store offset=24
+         local.get $2
+         local.get $7
          call $~lib/array/Array<~lib/string/String>#push
         else
          global.get $~lib/memory/__stack_pointer
-         local.get $9
-         i32.store offset=8
+         local.get $2
+         i32.store offset=4
          global.get $~lib/memory/__stack_pointer
          i32.const 3456
-         i32.store offset=28
-         local.get $9
+         i32.store offset=24
+         local.get $2
          i32.const 3456
          call $~lib/array/Array<~lib/string/String>#push
         end
-        local.get $4
+        local.get $5
         i32.const 1
         i32.add
-        local.tee $4
-        local.get $2
+        local.tee $5
+        local.get $8
         i32.eq
         br_if $folding-inner3
-        local.get $5
-        local.get $6
+        local.get $4
+        local.get $9
         i32.add
         local.set $3
         br $while-continue|1
@@ -5888,17 +5884,17 @@
       i32.eqz
       if
        global.get $~lib/memory/__stack_pointer
-       local.get $9
-       i32.store offset=8
+       local.get $2
+       i32.store offset=4
        global.get $~lib/memory/__stack_pointer
        local.get $0
-       i32.store offset=28
-       local.get $9
+       i32.store offset=24
+       local.get $2
        local.get $0
        call $~lib/array/Array<~lib/string/String>#push
        br $folding-inner3
       end
-      local.get $8
+      local.get $6
       local.get $3
       i32.sub
       local.tee $1
@@ -5912,9 +5908,9 @@
        local.tee $1
        i32.const 2
        call $~lib/rt/itcms/__new
-       local.tee $2
-       i32.store offset=36
-       local.get $2
+       local.tee $4
+       i32.store offset=32
+       local.get $4
        local.get $0
        local.get $3
        i32.const 1
@@ -5923,31 +5919,26 @@
        local.get $1
        memory.copy
        global.get $~lib/memory/__stack_pointer
-       local.get $9
-       i32.store offset=8
+       local.get $2
+       i32.store offset=4
        global.get $~lib/memory/__stack_pointer
+       local.get $4
+       i32.store offset=24
        local.get $2
-       i32.store offset=28
-       local.get $9
-       local.get $2
+       local.get $4
        call $~lib/array/Array<~lib/string/String>#push
       else
        global.get $~lib/memory/__stack_pointer
-       local.get $9
-       i32.store offset=8
+       local.get $2
+       i32.store offset=4
        global.get $~lib/memory/__stack_pointer
        i32.const 3456
-       i32.store offset=28
-       local.get $9
+       i32.store offset=24
+       local.get $2
        i32.const 3456
        call $~lib/array/Array<~lib/string/String>#push
       end
-      global.get $~lib/memory/__stack_pointer
-      i32.const 40
-      i32.add
-      global.set $~lib/memory/__stack_pointer
-      local.get $9
-      return
+      br $folding-inner4
      end
      i32.const 41264
      i32.const 41312
@@ -5959,19 +5950,20 @@
     i32.const 0
     call $~lib/rt/__newArray
     local.set $2
+    br $folding-inner4
    end
    global.get $~lib/memory/__stack_pointer
-   i32.const 40
+   i32.const 36
    i32.add
    global.set $~lib/memory/__stack_pointer
    local.get $2
    return
   end
   global.get $~lib/memory/__stack_pointer
-  i32.const 40
+  i32.const 36
   i32.add
   global.set $~lib/memory/__stack_pointer
-  local.get $9
+  local.get $2
  )
  (func $~lib/string/String#split@varargs (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)

--- a/tests/compiler/std/static-array.debug.wat
+++ b/tests/compiler/std/static-array.debug.wat
@@ -3322,10 +3322,6 @@
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
-  (local $5 i32)
-  (local $6 i32)
-  (local $7 i32)
-  (local $8 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 4
   i32.sub
@@ -3335,11 +3331,11 @@
   i32.const 0
   i32.store
   global.get $std/static-array/i
-  local.set $8
+  local.set $4
   global.get $~lib/memory/__stack_pointer
-  local.get $8
+  local.get $4
   i32.store
-  local.get $8
+  local.get $4
   call $~lib/array/Array<i32>#get:length
   i32.const 2
   i32.eq
@@ -3353,11 +3349,11 @@
    unreachable
   end
   global.get $std/static-array/i
-  local.set $8
+  local.set $4
   global.get $~lib/memory/__stack_pointer
-  local.get $8
+  local.get $4
   i32.store
-  local.get $8
+  local.get $4
   i32.const 0
   call $~lib/array/Array<i32>#__get
   i32.const 1
@@ -3372,11 +3368,11 @@
    unreachable
   end
   global.get $std/static-array/i
-  local.set $8
+  local.set $4
   global.get $~lib/memory/__stack_pointer
-  local.get $8
+  local.get $4
   i32.store
-  local.get $8
+  local.get $4
   i32.const 1
   call $~lib/array/Array<i32>#__get
   i32.const 2
@@ -3408,20 +3404,20 @@
   call $~lib/rt/itcms/initLazy
   global.set $~lib/rt/itcms/fromSpace
   global.get $std/static-array/i
-  local.set $8
+  local.set $4
   global.get $~lib/memory/__stack_pointer
-  local.get $8
+  local.get $4
   i32.store
-  local.get $8
+  local.get $4
   i32.const 0
   i32.const 2
   call $~lib/array/Array<i32>#__set
   global.get $std/static-array/i
-  local.set $8
+  local.set $4
   global.get $~lib/memory/__stack_pointer
-  local.get $8
+  local.get $4
   i32.store
-  local.get $8
+  local.get $4
   i32.const 0
   call $~lib/array/Array<i32>#__get
   i32.const 2
@@ -3436,11 +3432,11 @@
    unreachable
   end
   global.get $std/static-array/I
-  local.set $8
+  local.set $4
   global.get $~lib/memory/__stack_pointer
-  local.get $8
+  local.get $4
   i32.store
-  local.get $8
+  local.get $4
   call $~lib/array/Array<i64>#get:length
   i32.const 2
   i32.eq
@@ -3454,11 +3450,11 @@
    unreachable
   end
   global.get $std/static-array/I
-  local.set $8
+  local.set $4
   global.get $~lib/memory/__stack_pointer
-  local.get $8
+  local.get $4
   i32.store
-  local.get $8
+  local.get $4
   i32.const 0
   call $~lib/array/Array<i64>#__get
   i64.const 3
@@ -3473,11 +3469,11 @@
    unreachable
   end
   global.get $std/static-array/I
-  local.set $8
+  local.set $4
   global.get $~lib/memory/__stack_pointer
-  local.get $8
+  local.get $4
   i32.store
-  local.get $8
+  local.get $4
   i32.const 1
   call $~lib/array/Array<i64>#__get
   i64.const 4
@@ -3492,20 +3488,20 @@
    unreachable
   end
   global.get $std/static-array/I
-  local.set $8
+  local.set $4
   global.get $~lib/memory/__stack_pointer
-  local.get $8
+  local.get $4
   i32.store
-  local.get $8
+  local.get $4
   i32.const 0
   i64.const 4
   call $~lib/array/Array<i64>#__set
   global.get $std/static-array/I
-  local.set $8
+  local.set $4
   global.get $~lib/memory/__stack_pointer
-  local.get $8
+  local.get $4
   i32.store
-  local.get $8
+  local.get $4
   i32.const 0
   call $~lib/array/Array<i64>#__get
   i64.const 4
@@ -3520,11 +3516,11 @@
    unreachable
   end
   global.get $std/static-array/f
-  local.set $8
+  local.set $4
   global.get $~lib/memory/__stack_pointer
-  local.get $8
+  local.get $4
   i32.store
-  local.get $8
+  local.get $4
   call $~lib/array/Array<f32>#get:length
   i32.const 2
   i32.eq
@@ -3538,11 +3534,11 @@
    unreachable
   end
   global.get $std/static-array/f
-  local.set $8
+  local.set $4
   global.get $~lib/memory/__stack_pointer
-  local.get $8
+  local.get $4
   i32.store
-  local.get $8
+  local.get $4
   i32.const 0
   call $~lib/array/Array<f32>#__get
   f32.const 1.5
@@ -3557,11 +3553,11 @@
    unreachable
   end
   global.get $std/static-array/f
-  local.set $8
+  local.set $4
   global.get $~lib/memory/__stack_pointer
-  local.get $8
+  local.get $4
   i32.store
-  local.get $8
+  local.get $4
   i32.const 1
   call $~lib/array/Array<f32>#__get
   f32.const 2.5
@@ -3576,20 +3572,20 @@
    unreachable
   end
   global.get $std/static-array/f
-  local.set $8
+  local.set $4
   global.get $~lib/memory/__stack_pointer
-  local.get $8
+  local.get $4
   i32.store
-  local.get $8
+  local.get $4
   i32.const 0
   f32.const 2.5
   call $~lib/array/Array<f32>#__set
   global.get $std/static-array/f
-  local.set $8
+  local.set $4
   global.get $~lib/memory/__stack_pointer
-  local.get $8
+  local.get $4
   i32.store
-  local.get $8
+  local.get $4
   i32.const 0
   call $~lib/array/Array<f32>#__get
   f32.const 2.5
@@ -3604,11 +3600,11 @@
    unreachable
   end
   global.get $std/static-array/F
-  local.set $8
+  local.set $4
   global.get $~lib/memory/__stack_pointer
-  local.get $8
+  local.get $4
   i32.store
-  local.get $8
+  local.get $4
   call $~lib/array/Array<f64>#get:length
   i32.const 2
   i32.eq
@@ -3622,11 +3618,11 @@
    unreachable
   end
   global.get $std/static-array/F
-  local.set $8
+  local.set $4
   global.get $~lib/memory/__stack_pointer
-  local.get $8
+  local.get $4
   i32.store
-  local.get $8
+  local.get $4
   i32.const 0
   call $~lib/array/Array<f64>#__get
   f64.const 1.25
@@ -3641,11 +3637,11 @@
    unreachable
   end
   global.get $std/static-array/F
-  local.set $8
+  local.set $4
   global.get $~lib/memory/__stack_pointer
-  local.get $8
+  local.get $4
   i32.store
-  local.get $8
+  local.get $4
   i32.const 1
   call $~lib/array/Array<f64>#__get
   f64.const 2.25
@@ -3660,20 +3656,20 @@
    unreachable
   end
   global.get $std/static-array/F
-  local.set $8
+  local.set $4
   global.get $~lib/memory/__stack_pointer
-  local.get $8
+  local.get $4
   i32.store
-  local.get $8
+  local.get $4
   i32.const 0
   f64.const 2.25
   call $~lib/array/Array<f64>#__set
   global.get $std/static-array/F
-  local.set $8
+  local.set $4
   global.get $~lib/memory/__stack_pointer
-  local.get $8
+  local.get $4
   i32.store
-  local.get $8
+  local.get $4
   i32.const 0
   call $~lib/array/Array<f64>#__get
   f64.const 2.25

--- a/tests/compiler/std/staticarray.debug.wat
+++ b/tests/compiler/std/staticarray.debug.wat
@@ -7567,10 +7567,6 @@
   (local $50 i32)
   (local $51 i32)
   (local $52 i32)
-  (local $53 i32)
-  (local $54 i32)
-  (local $55 i32)
-  (local $56 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 108
   i32.sub
@@ -7581,11 +7577,11 @@
   i32.const 108
   memory.fill
   global.get $std/staticarray/arr1
-  local.set $56
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $56
+  local.get $52
   i32.store
-  local.get $56
+  local.get $52
   i32.const 1
   call $~lib/staticarray/StaticArray<i32>#__get
   i32.const 2
@@ -7600,11 +7596,11 @@
    unreachable
   end
   global.get $std/staticarray/arr1
-  local.set $56
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $56
+  local.get $52
   i32.store
-  local.get $56
+  local.get $52
   call $~lib/staticarray/StaticArray<i32>#get:length
   i32.const 3
   i32.eq
@@ -7618,20 +7614,20 @@
    unreachable
   end
   global.get $std/staticarray/arr1
-  local.set $56
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $56
+  local.get $52
   i32.store
-  local.get $56
+  local.get $52
   i32.const 1
   i32.const 4
   call $~lib/staticarray/StaticArray<i32>#__set
   global.get $std/staticarray/arr1
-  local.set $56
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $56
+  local.get $52
   i32.store
-  local.get $56
+  local.get $52
   i32.const 1
   call $~lib/staticarray/StaticArray<i32>#__get
   i32.const 4
@@ -7661,11 +7657,11 @@
    unreachable
   end
   global.get $std/staticarray/arr2
-  local.set $56
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $56
+  local.get $52
   i32.store
-  local.get $56
+  local.get $52
   i32.const 1
   call $~lib/staticarray/StaticArray<i32>#__get
   i32.const 2
@@ -7680,11 +7676,11 @@
    unreachable
   end
   global.get $std/staticarray/arr2
-  local.set $56
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $56
+  local.get $52
   i32.store
-  local.get $56
+  local.get $52
   call $~lib/staticarray/StaticArray<i32>#get:length
   i32.const 3
   i32.eq
@@ -7698,20 +7694,20 @@
    unreachable
   end
   global.get $std/staticarray/arr2
-  local.set $56
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $56
+  local.get $52
   i32.store
-  local.get $56
+  local.get $52
   i32.const 1
   i32.const 4
   call $~lib/staticarray/StaticArray<i32>#__set
   global.get $std/staticarray/arr2
-  local.set $56
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $56
+  local.get $52
   i32.store
-  local.get $56
+  local.get $52
   i32.const 1
   call $~lib/staticarray/StaticArray<i32>#__get
   i32.const 4
@@ -7745,11 +7741,11 @@
   call $std/staticarray/test
   global.set $std/staticarray/arr3
   global.get $std/staticarray/arr3
-  local.set $56
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $56
+  local.get $52
   i32.store
-  local.get $56
+  local.get $52
   i32.const 0
   call $~lib/staticarray/StaticArray<i32>#__get
   i32.const 5
@@ -7764,11 +7760,11 @@
    unreachable
   end
   global.get $std/staticarray/arr3
-  local.set $56
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $56
+  local.get $52
   i32.store
-  local.get $56
+  local.get $52
   i32.const 1
   call $~lib/staticarray/StaticArray<i32>#__get
   i32.const 6
@@ -7783,11 +7779,11 @@
    unreachable
   end
   global.get $std/staticarray/arr3
-  local.set $56
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $56
+  local.get $52
   i32.store
-  local.get $56
+  local.get $52
   i32.const 2
   call $~lib/staticarray/StaticArray<i32>#__get
   i32.const 7
@@ -7802,11 +7798,11 @@
    unreachable
   end
   global.get $std/staticarray/arr3
-  local.set $56
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $56
+  local.get $52
   i32.store
-  local.get $56
+  local.get $52
   call $~lib/staticarray/StaticArray<i32>#get:length
   i32.const 3
   i32.eq
@@ -7820,20 +7816,20 @@
    unreachable
   end
   global.get $std/staticarray/arr3
-  local.set $56
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $56
+  local.get $52
   i32.store
-  local.get $56
+  local.get $52
   i32.const 1
   i32.const 8
   call $~lib/staticarray/StaticArray<i32>#__set
   global.get $std/staticarray/arr3
-  local.set $56
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $56
+  local.get $52
   i32.store
-  local.get $56
+  local.get $52
   i32.const 1
   call $~lib/staticarray/StaticArray<i32>#__get
   i32.const 8
@@ -7850,11 +7846,11 @@
   call $std/staticarray/test
   global.set $std/staticarray/arr3
   global.get $std/staticarray/arr3
-  local.set $56
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $56
+  local.get $52
   i32.store
-  local.get $56
+  local.get $52
   i32.const 1
   call $~lib/staticarray/StaticArray<i32>#__get
   i32.const 6
@@ -7898,11 +7894,11 @@
   local.tee $3
   i32.store offset=8
   local.get $3
-  local.set $56
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $56
+  local.get $52
   i32.store
-  local.get $56
+  local.get $52
   call $~lib/staticarray/StaticArray<i32>#get:length
   i32.const 3
   i32.eq
@@ -7920,20 +7916,20 @@
   loop $for-loop|0
    local.get $4
    local.get $3
-   local.set $56
+   local.set $52
    global.get $~lib/memory/__stack_pointer
-   local.get $56
+   local.get $52
    i32.store
-   local.get $56
+   local.get $52
    call $~lib/staticarray/StaticArray<i32>#get:length
    i32.lt_s
    if
     local.get $3
-    local.set $56
+    local.set $52
     global.get $~lib/memory/__stack_pointer
-    local.get $56
+    local.get $52
     i32.store
-    local.get $56
+    local.get $52
     local.get $4
     call $~lib/staticarray/StaticArray<i32>#__get
     i32.const 0
@@ -7960,31 +7956,31 @@
   i32.const 7
   i32.const 704
   call $~lib/rt/__newArray
-  local.tee $7
+  local.tee $6
   i32.store offset=12
   global.get $~lib/memory/__stack_pointer
-  local.get $7
-  local.set $56
+  local.get $6
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $56
+  local.get $52
   i32.store
-  local.get $56
+  local.get $52
   call $~lib/staticarray/StaticArray.fromArray<i32>
-  local.tee $8
+  local.tee $7
   i32.store offset=16
-  local.get $8
-  local.set $56
-  global.get $~lib/memory/__stack_pointer
-  local.get $56
-  i32.store
-  local.get $56
-  call $~lib/staticarray/StaticArray<i32>#get:length
   local.get $7
-  local.set $56
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $56
+  local.get $52
   i32.store
-  local.get $56
+  local.get $52
+  call $~lib/staticarray/StaticArray<i32>#get:length
+  local.get $6
+  local.set $52
+  global.get $~lib/memory/__stack_pointer
+  local.get $52
+  i32.store
+  local.get $52
   call $~lib/array/Array<i32>#get:length
   i32.eq
   i32.eqz
@@ -7997,33 +7993,33 @@
    unreachable
   end
   i32.const 0
-  local.set $9
+  local.set $8
   loop $for-loop|1
-   local.get $9
-   local.get $7
-   local.set $56
+   local.get $8
+   local.get $6
+   local.set $52
    global.get $~lib/memory/__stack_pointer
-   local.get $56
+   local.get $52
    i32.store
-   local.get $56
+   local.get $52
    call $~lib/array/Array<i32>#get:length
    i32.lt_s
    if
-    local.get $8
-    local.set $56
-    global.get $~lib/memory/__stack_pointer
-    local.get $56
-    i32.store
-    local.get $56
-    local.get $9
-    call $~lib/staticarray/StaticArray<i32>#__get
     local.get $7
-    local.set $56
+    local.set $52
     global.get $~lib/memory/__stack_pointer
-    local.get $56
+    local.get $52
     i32.store
-    local.get $56
-    local.get $9
+    local.get $52
+    local.get $8
+    call $~lib/staticarray/StaticArray<i32>#__get
+    local.get $6
+    local.set $52
+    global.get $~lib/memory/__stack_pointer
+    local.get $52
+    i32.store
+    local.get $52
+    local.get $8
     call $~lib/array/Array<i32>#__get
     i32.eq
     i32.eqz
@@ -8035,10 +8031,10 @@
      call $~lib/builtins/abort
      unreachable
     end
-    local.get $9
+    local.get $8
     i32.const 1
     i32.add
-    local.set $9
+    local.set $8
     br $for-loop|1
    end
   end
@@ -8048,20 +8044,20 @@
   i32.const 7
   i32.const 800
   call $~lib/rt/__newArray
-  local.set $56
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $56
+  local.get $52
   i32.store
-  local.get $56
+  local.get $52
   call $~lib/staticarray/StaticArray.fromArray<i32>
-  local.tee $8
+  local.tee $7
   i32.store offset=16
-  local.get $8
-  local.set $56
+  local.get $7
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $56
+  local.get $52
   i32.store
-  local.get $56
+  local.get $52
   call $~lib/staticarray/StaticArray<i32>#get:length
   i32.const 0
   i32.eq
@@ -8079,33 +8075,33 @@
   i32.const 4
   i32.const 832
   call $~lib/rt/__newBuffer
-  local.tee $13
+  local.tee $11
   i32.store offset=20
   global.get $~lib/memory/__stack_pointer
-  local.get $13
-  local.set $56
+  local.get $11
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $56
+  local.get $52
   i32.store
-  local.get $56
+  local.get $52
   i32.const 4
   i32.const 4
   i32.const 864
   call $~lib/rt/__newBuffer
-  local.set $56
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $56
+  local.get $52
   i32.store offset=24
-  local.get $56
+  local.get $52
   call $~lib/staticarray/StaticArray<i32>#concat<~lib/staticarray/StaticArray<i32>>
-  local.tee $15
+  local.tee $13
   i32.store offset=28
-  local.get $15
-  local.set $56
+  local.get $13
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $56
+  local.get $52
   i32.store
-  local.get $56
+  local.get $52
   call $~lib/staticarray/StaticArray<i32>#get:length
   i32.const 3
   i32.eq
@@ -8119,37 +8115,37 @@
    unreachable
   end
   global.get $~lib/memory/__stack_pointer
-  local.get $13
-  local.set $56
+  local.get $11
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $56
+  local.get $52
   i32.store
-  local.get $56
+  local.get $52
   i32.const 0
   i32.const 4
   i32.const 896
   call $~lib/rt/__newBuffer
-  local.set $56
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $56
+  local.get $52
   i32.store offset=24
-  local.get $56
+  local.get $52
   call $~lib/staticarray/StaticArray<i32>#concat<~lib/staticarray/StaticArray<i32>>
-  local.tee $15
+  local.tee $13
   i32.store offset=28
-  local.get $15
-  local.set $56
-  global.get $~lib/memory/__stack_pointer
-  local.get $56
-  i32.store
-  local.get $56
-  call $~lib/staticarray/StaticArray<i32>#get:length
   local.get $13
-  local.set $56
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $56
+  local.get $52
   i32.store
-  local.get $56
+  local.get $52
+  call $~lib/staticarray/StaticArray<i32>#get:length
+  local.get $11
+  local.set $52
+  global.get $~lib/memory/__stack_pointer
+  local.get $52
+  i32.store
+  local.get $52
   call $~lib/staticarray/StaticArray<i32>#get:length
   i32.eq
   i32.eqz
@@ -8166,33 +8162,33 @@
   i32.const 8
   i32.const 992
   call $~lib/rt/__newBuffer
-  local.tee $18
+  local.tee $16
   i32.store offset=32
   global.get $~lib/memory/__stack_pointer
-  local.get $18
-  local.set $56
+  local.get $16
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $56
+  local.get $52
   i32.store
-  local.get $56
+  local.get $52
   i32.const 4
   i32.const 8
   i32.const 1056
   call $~lib/rt/__newBuffer
-  local.set $56
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $56
+  local.get $52
   i32.store offset=24
-  local.get $56
+  local.get $52
   call $~lib/staticarray/StaticArray<~lib/string/String>#concat<~lib/staticarray/StaticArray<~lib/string/String>>
-  local.tee $20
+  local.tee $18
   i32.store offset=36
-  local.get $20
-  local.set $56
+  local.get $18
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $56
+  local.get $52
   i32.store
-  local.get $56
+  local.get $52
   call $~lib/staticarray/StaticArray<~lib/string/String>#get:length
   i32.const 3
   i32.eq
@@ -8210,35 +8206,35 @@
   i32.const 8
   i32.const 1264
   call $~lib/rt/__newBuffer
-  local.tee $22
+  local.tee $20
   i32.store offset=40
   global.get $~lib/memory/__stack_pointer
-  local.get $22
-  local.set $56
+  local.get $20
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $56
+  local.get $52
   i32.store
-  local.get $56
+  local.get $52
   i32.const 0
   i32.const 0
   global.set $~argumentsLength
   i32.const 0
   call $~lib/staticarray/StaticArray<~lib/string/String>#slice<~lib/staticarray/StaticArray<~lib/string/String>>@varargs
-  local.tee $23
+  local.tee $21
   i32.store offset=44
-  local.get $23
-  local.set $56
+  local.get $21
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $56
+  local.get $52
   i32.store
-  local.get $56
+  local.get $52
   call $~lib/staticarray/StaticArray<~lib/string/String>#get:length
-  local.get $22
-  local.set $56
+  local.get $20
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $56
+  local.get $52
   i32.store
-  local.get $56
+  local.get $52
   call $~lib/staticarray/StaticArray<~lib/string/String>#get:length
   i32.eq
   i32.eqz
@@ -8251,44 +8247,44 @@
    unreachable
   end
   i32.const 0
-  local.set $24
+  local.set $22
   loop $for-loop|2
-   local.get $24
    local.get $22
-   local.set $56
+   local.get $20
+   local.set $52
    global.get $~lib/memory/__stack_pointer
-   local.get $56
+   local.get $52
    i32.store
-   local.get $56
+   local.get $52
    call $~lib/staticarray/StaticArray<~lib/string/String>#get:length
    i32.lt_s
    if
+    local.get $20
+    local.set $52
+    global.get $~lib/memory/__stack_pointer
+    local.get $52
+    i32.store offset=48
+    local.get $52
     local.get $22
-    local.set $56
-    global.get $~lib/memory/__stack_pointer
-    local.get $56
-    i32.store offset=48
-    local.get $56
-    local.get $24
     call $~lib/staticarray/StaticArray<~lib/string/String>#__get
-    local.set $56
+    local.set $52
     global.get $~lib/memory/__stack_pointer
-    local.get $56
+    local.get $52
     i32.store
-    local.get $56
-    local.get $23
-    local.set $56
+    local.get $52
+    local.get $21
+    local.set $52
     global.get $~lib/memory/__stack_pointer
-    local.get $56
+    local.get $52
     i32.store offset=48
-    local.get $56
-    local.get $24
+    local.get $52
+    local.get $22
     call $~lib/staticarray/StaticArray<~lib/string/String>#__get
-    local.set $56
+    local.set $52
     global.get $~lib/memory/__stack_pointer
-    local.get $56
+    local.get $52
     i32.store offset=24
-    local.get $56
+    local.get $52
     call $~lib/string/String.__eq
     i32.eqz
     if
@@ -8299,31 +8295,31 @@
      call $~lib/builtins/abort
      unreachable
     end
-    local.get $24
+    local.get $22
     i32.const 1
     i32.add
-    local.set $24
+    local.set $22
     br $for-loop|2
    end
   end
   global.get $~lib/memory/__stack_pointer
-  local.get $22
-  local.set $56
+  local.get $20
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $56
+  local.get $52
   i32.store
-  local.get $56
+  local.get $52
   i32.const 1
   i32.const 3
   call $~lib/staticarray/StaticArray<~lib/string/String>#slice<~lib/staticarray/StaticArray<~lib/string/String>>
-  local.tee $23
+  local.tee $21
   i32.store offset=44
-  local.get $23
-  local.set $56
+  local.get $21
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $56
+  local.get $52
   i32.store
-  local.get $56
+  local.get $52
   call $~lib/staticarray/StaticArray<~lib/string/String>#get:length
   i32.const 2
   i32.eq
@@ -8336,25 +8332,25 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $23
-  local.set $56
+  local.get $21
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $56
+  local.get $52
   i32.store offset=48
-  local.get $56
+  local.get $52
   i32.const 0
   call $~lib/staticarray/StaticArray<~lib/string/String>#__get
-  local.set $56
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $56
+  local.get $52
   i32.store
-  local.get $56
+  local.get $52
   i32.const 1120
-  local.set $56
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $56
+  local.get $52
   i32.store offset=24
-  local.get $56
+  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -8365,25 +8361,25 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $23
-  local.set $56
+  local.get $21
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $56
+  local.get $52
   i32.store offset=48
-  local.get $56
+  local.get $52
   i32.const 1
   call $~lib/staticarray/StaticArray<~lib/string/String>#__get
-  local.set $56
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $56
+  local.get $52
   i32.store
-  local.get $56
+  local.get $52
   i32.const 1152
-  local.set $56
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $56
+  local.get $52
   i32.store offset=24
-  local.get $56
+  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -8395,32 +8391,32 @@
    unreachable
   end
   global.get $~lib/memory/__stack_pointer
-  local.get $22
-  local.set $56
+  local.get $20
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $56
+  local.get $52
   i32.store
-  local.get $56
+  local.get $52
   i32.const 1
   i32.const 1
   global.set $~argumentsLength
   i32.const 0
   call $~lib/staticarray/StaticArray<~lib/string/String>#slice<~lib/staticarray/StaticArray<~lib/string/String>>@varargs
-  local.tee $23
+  local.tee $21
   i32.store offset=44
-  local.get $23
-  local.set $56
+  local.get $21
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $56
+  local.get $52
   i32.store
-  local.get $56
+  local.get $52
   call $~lib/staticarray/StaticArray<~lib/string/String>#get:length
-  local.get $22
-  local.set $56
+  local.get $20
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $56
+  local.get $52
   i32.store
-  local.get $56
+  local.get $52
   call $~lib/staticarray/StaticArray<~lib/string/String>#get:length
   i32.const 1
   i32.sub
@@ -8435,30 +8431,30 @@
    unreachable
   end
   global.get $~lib/memory/__stack_pointer
-  local.get $22
-  local.set $56
+  local.get $20
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $56
+  local.get $52
   i32.store
-  local.get $56
+  local.get $52
   i32.const 0
   i32.const 50
   call $~lib/staticarray/StaticArray<~lib/string/String>#slice<~lib/staticarray/StaticArray<~lib/string/String>>
-  local.tee $23
+  local.tee $21
   i32.store offset=44
-  local.get $23
-  local.set $56
+  local.get $21
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $56
+  local.get $52
   i32.store
-  local.get $56
+  local.get $52
   call $~lib/staticarray/StaticArray<~lib/string/String>#get:length
-  local.get $22
-  local.set $56
+  local.get $20
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $56
+  local.get $52
   i32.store
-  local.get $56
+  local.get $52
   call $~lib/staticarray/StaticArray<~lib/string/String>#get:length
   i32.eq
   i32.eqz
@@ -8471,25 +8467,25 @@
    unreachable
   end
   global.get $~lib/memory/__stack_pointer
-  local.get $22
-  local.set $56
+  local.get $20
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $56
+  local.get $52
   i32.store
-  local.get $56
+  local.get $52
   i32.const 100
   i32.const 1
   global.set $~argumentsLength
   i32.const 0
   call $~lib/staticarray/StaticArray<~lib/string/String>#slice<~lib/staticarray/StaticArray<~lib/string/String>>@varargs
-  local.tee $23
+  local.tee $21
   i32.store offset=44
-  local.get $23
-  local.set $56
+  local.get $21
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $56
+  local.get $52
   i32.store
-  local.get $56
+  local.get $52
   call $~lib/staticarray/StaticArray<~lib/string/String>#get:length
   i32.const 0
   i32.eq
@@ -8503,25 +8499,25 @@
    unreachable
   end
   global.get $~lib/memory/__stack_pointer
-  local.get $22
-  local.set $56
+  local.get $20
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $56
+  local.get $52
   i32.store
-  local.get $56
+  local.get $52
   i32.const -1
   i32.const 1
   global.set $~argumentsLength
   i32.const 0
   call $~lib/staticarray/StaticArray<~lib/string/String>#slice<~lib/staticarray/StaticArray<~lib/string/String>>@varargs
-  local.tee $23
+  local.tee $21
   i32.store offset=44
-  local.get $23
-  local.set $56
+  local.get $21
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $56
+  local.get $52
   i32.store
-  local.get $56
+  local.get $52
   call $~lib/staticarray/StaticArray<~lib/string/String>#get:length
   i32.const 1
   i32.eq
@@ -8534,25 +8530,25 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $23
-  local.set $56
+  local.get $21
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $56
+  local.get $52
   i32.store offset=48
-  local.get $56
+  local.get $52
   i32.const 0
   call $~lib/staticarray/StaticArray<~lib/string/String>#__get
-  local.set $56
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $56
+  local.get $52
   i32.store
-  local.get $56
+  local.get $52
   i32.const 1216
-  local.set $56
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $56
+  local.get $52
   i32.store offset=24
-  local.get $56
+  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -8564,23 +8560,23 @@
    unreachable
   end
   global.get $~lib/memory/__stack_pointer
-  local.get $22
-  local.set $56
+  local.get $20
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $56
+  local.get $52
   i32.store
-  local.get $56
+  local.get $52
   i32.const -2
   i32.const -2
   call $~lib/staticarray/StaticArray<~lib/string/String>#slice<~lib/staticarray/StaticArray<~lib/string/String>>
-  local.tee $23
+  local.tee $21
   i32.store offset=44
-  local.get $23
-  local.set $56
+  local.get $21
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $56
+  local.get $52
   i32.store
-  local.get $56
+  local.get $52
   call $~lib/staticarray/StaticArray<~lib/string/String>#get:length
   i32.const 0
   i32.eq
@@ -8594,23 +8590,23 @@
    unreachable
   end
   global.get $~lib/memory/__stack_pointer
-  local.get $22
-  local.set $56
+  local.get $20
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $56
+  local.get $52
   i32.store
-  local.get $56
+  local.get $52
   i32.const 2
   i32.const -2
   call $~lib/staticarray/StaticArray<~lib/string/String>#slice<~lib/staticarray/StaticArray<~lib/string/String>>
-  local.tee $23
+  local.tee $21
   i32.store offset=44
-  local.get $23
-  local.set $56
+  local.get $21
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $56
+  local.get $52
   i32.store
-  local.get $56
+  local.get $52
   call $~lib/staticarray/StaticArray<~lib/string/String>#get:length
   i32.const 1
   i32.eq
@@ -8623,25 +8619,25 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $23
-  local.set $56
+  local.get $21
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $56
+  local.get $52
   i32.store offset=48
-  local.get $56
+  local.get $52
   i32.const 0
   call $~lib/staticarray/StaticArray<~lib/string/String>#__get
-  local.set $56
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $56
+  local.get $52
   i32.store
-  local.get $56
+  local.get $52
   i32.const 1152
-  local.set $56
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $56
+  local.get $52
   i32.store offset=24
-  local.get $56
+  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -8657,41 +8653,41 @@
   i32.const 8
   i32.const 1440
   call $~lib/rt/__newBuffer
-  local.tee $26
+  local.tee $24
   i32.store offset=52
   global.get $~lib/memory/__stack_pointer
-  local.get $26
-  local.set $56
+  local.get $24
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $56
+  local.get $52
   i32.store
-  local.get $56
+  local.get $52
   i32.const 0
   i32.const 2
   i32.const 9
   i32.const 1488
   call $~lib/rt/__newArray
-  local.set $56
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $56
+  local.get $52
   i32.store offset=24
-  local.get $56
+  local.get $52
   call $~lib/staticarray/StaticArray<~lib/string/String>#concat<~lib/array/Array<~lib/string/String>>
-  local.tee $29
+  local.tee $26
   i32.store offset=56
-  local.get $29
-  local.set $56
-  global.get $~lib/memory/__stack_pointer
-  local.get $56
-  i32.store
-  local.get $56
-  call $~lib/array/Array<~lib/string/String>#get:length
   local.get $26
-  local.set $56
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $56
+  local.get $52
   i32.store
-  local.get $56
+  local.get $52
+  call $~lib/array/Array<~lib/string/String>#get:length
+  local.get $24
+  local.set $52
+  global.get $~lib/memory/__stack_pointer
+  local.get $52
+  i32.store
+  local.get $52
   call $~lib/staticarray/StaticArray<~lib/string/String>#get:length
   i32.eq
   i32.eqz
@@ -8706,38 +8702,38 @@
   i32.const 1
   drop
   global.get $~lib/memory/__stack_pointer
-  local.get $26
-  local.set $56
+  local.get $24
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $56
+  local.get $52
   i32.store
-  local.get $56
+  local.get $52
   i32.const 1
   i32.const 2
   i32.const 9
   i32.const 1552
   call $~lib/rt/__newArray
-  local.set $56
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $56
+  local.get $52
   i32.store offset=24
-  local.get $56
+  local.get $52
   call $~lib/staticarray/StaticArray<~lib/string/String>#concat<~lib/array/Array<~lib/string/String>>
-  local.tee $29
+  local.tee $26
   i32.store offset=56
-  local.get $29
-  local.set $56
-  global.get $~lib/memory/__stack_pointer
-  local.get $56
-  i32.store
-  local.get $56
-  call $~lib/array/Array<~lib/string/String>#get:length
   local.get $26
-  local.set $56
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $56
+  local.get $52
   i32.store
-  local.get $56
+  local.get $52
+  call $~lib/array/Array<~lib/string/String>#get:length
+  local.get $24
+  local.set $52
+  global.get $~lib/memory/__stack_pointer
+  local.get $52
+  i32.store
+  local.get $52
   call $~lib/staticarray/StaticArray<~lib/string/String>#get:length
   i32.const 1
   i32.add
@@ -8758,20 +8754,20 @@
   i32.const 8
   i32.const 1584
   call $~lib/rt/__newBuffer
-  local.tee $33
+  local.tee $29
   i32.store offset=60
-  local.get $33
-  local.set $56
+  local.get $29
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $56
+  local.get $52
   i32.store
-  local.get $56
+  local.get $52
   i32.const 1120
-  local.set $56
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $56
+  local.get $52
   i32.store offset=24
-  local.get $56
+  local.get $52
   i32.const 0
   call $~lib/staticarray/StaticArray<~lib/string/String>#includes
   i32.const 1
@@ -8785,18 +8781,18 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $33
-  local.set $56
+  local.get $29
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $56
+  local.get $52
   i32.store
-  local.get $56
+  local.get $52
   i32.const 1520
-  local.set $56
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $56
+  local.get $52
   i32.store offset=24
-  local.get $56
+  local.get $52
   i32.const 0
   call $~lib/staticarray/StaticArray<~lib/string/String>#includes
   i32.const 0
@@ -8810,18 +8806,18 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $33
-  local.set $56
+  local.get $29
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $56
+  local.get $52
   i32.store
-  local.get $56
+  local.get $52
   i32.const 1216
-  local.set $56
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $56
+  local.get $52
   i32.store offset=24
-  local.get $56
+  local.get $52
   i32.const 5
   call $~lib/staticarray/StaticArray<~lib/string/String>#includes
   i32.const 0
@@ -8835,18 +8831,18 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $33
-  local.set $56
+  local.get $29
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $56
+  local.get $52
   i32.store
-  local.get $56
+  local.get $52
   i32.const 1216
-  local.set $56
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $56
+  local.get $52
   i32.store offset=24
-  local.get $56
+  local.get $52
   i32.const -1
   call $~lib/staticarray/StaticArray<~lib/string/String>#includes
   i32.const 1
@@ -8864,11 +8860,11 @@
   i32.const 10
   i32.const 1632
   call $~lib/rt/__newBuffer
-  local.set $56
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $56
+  local.get $52
   i32.store
-  local.get $56
+  local.get $52
   f64.const nan:0x8000000000000
   i32.const 0
   call $~lib/staticarray/StaticArray<f64>#includes
@@ -8887,11 +8883,11 @@
   i32.const 11
   i32.const 1664
   call $~lib/rt/__newBuffer
-  local.set $56
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $56
+  local.get $52
   i32.store
-  local.get $56
+  local.get $52
   f32.const nan:0x400000
   i32.const 0
   call $~lib/staticarray/StaticArray<f32>#includes
@@ -8911,14 +8907,14 @@
   i32.const 4
   i32.const 1696
   call $~lib/rt/__newBuffer
-  local.tee $37
+  local.tee $33
   i32.store offset=64
-  local.get $37
-  local.set $56
+  local.get $33
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $56
+  local.get $52
   i32.store
-  local.get $56
+  local.get $52
   i32.const 2
   i32.const 0
   call $~lib/staticarray/StaticArray<i32>#indexOf
@@ -8933,12 +8929,12 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $37
-  local.set $56
+  local.get $33
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $56
+  local.get $52
   i32.store
-  local.get $56
+  local.get $52
   i32.const 7
   i32.const 0
   call $~lib/staticarray/StaticArray<i32>#indexOf
@@ -8953,12 +8949,12 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $37
-  local.set $56
+  local.get $33
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $56
+  local.get $52
   i32.store
-  local.get $56
+  local.get $52
   i32.const 9
   i32.const 2
   call $~lib/staticarray/StaticArray<i32>#indexOf
@@ -8973,12 +8969,12 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $37
-  local.set $56
+  local.get $33
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $56
+  local.get $52
   i32.store
-  local.get $56
+  local.get $52
   i32.const 2
   i32.const -1
   call $~lib/staticarray/StaticArray<i32>#indexOf
@@ -8993,12 +8989,12 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $37
-  local.set $56
+  local.get $33
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $56
+  local.get $52
   i32.store
-  local.get $56
+  local.get $52
   i32.const 2
   i32.const -3
   call $~lib/staticarray/StaticArray<i32>#indexOf
@@ -9018,14 +9014,14 @@
   i32.const 4
   i32.const 1728
   call $~lib/rt/__newBuffer
-  local.tee $39
+  local.tee $35
   i32.store offset=68
-  local.get $39
-  local.set $56
+  local.get $35
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $56
+  local.get $52
   i32.store
-  local.get $56
+  local.get $52
   i32.const 2
   i32.const 1
   global.set $~argumentsLength
@@ -9042,12 +9038,12 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $39
-  local.set $56
+  local.get $35
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $56
+  local.get $52
   i32.store
-  local.get $56
+  local.get $52
   i32.const 7
   i32.const 1
   global.set $~argumentsLength
@@ -9064,12 +9060,12 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $39
-  local.set $56
+  local.get $35
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $56
+  local.get $52
   i32.store
-  local.get $56
+  local.get $52
   i32.const 2
   i32.const 3
   call $~lib/staticarray/StaticArray<i32>#lastIndexOf
@@ -9084,12 +9080,12 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $39
-  local.set $56
+  local.get $35
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $56
+  local.get $52
   i32.store
-  local.get $56
+  local.get $52
   i32.const 2
   i32.const 2
   call $~lib/staticarray/StaticArray<i32>#lastIndexOf
@@ -9104,12 +9100,12 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $39
-  local.set $56
+  local.get $35
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $56
+  local.get $52
   i32.store
-  local.get $56
+  local.get $52
   i32.const 2
   i32.const -2
   call $~lib/staticarray/StaticArray<i32>#lastIndexOf
@@ -9124,12 +9120,12 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $39
-  local.set $56
+  local.get $35
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $56
+  local.get $52
   i32.store
-  local.get $56
+  local.get $52
   i32.const 2
   i32.const -1
   call $~lib/staticarray/StaticArray<i32>#lastIndexOf
@@ -9149,32 +9145,32 @@
   i32.const 8
   i32.const 1872
   call $~lib/rt/__newBuffer
-  local.tee $41
+  local.tee $37
   i32.store offset=72
-  local.get $41
-  local.set $56
+  local.get $37
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $56
+  local.get $52
   i32.store offset=48
-  local.get $56
+  local.get $52
   i32.const 1936
-  local.set $56
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $56
+  local.get $52
   i32.store offset=76
-  local.get $56
+  local.get $52
   call $~lib/staticarray/StaticArray<~lib/string/String>#join
-  local.set $56
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $56
+  local.get $52
   i32.store
-  local.get $56
+  local.get $52
   i32.const 1968
-  local.set $56
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $56
+  local.get $52
   i32.store offset=24
-  local.get $56
+  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -9185,30 +9181,30 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $41
-  local.set $56
+  local.get $37
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $56
+  local.get $52
   i32.store offset=48
-  local.get $56
+  local.get $52
   i32.const 1904
-  local.set $56
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $56
+  local.get $52
   i32.store offset=76
-  local.get $56
+  local.get $52
   call $~lib/staticarray/StaticArray<~lib/string/String>#join
-  local.set $56
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $56
+  local.get $52
   i32.store
-  local.get $56
+  local.get $52
   i32.const 2016
-  local.set $56
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $56
+  local.get $52
   i32.store offset=24
-  local.get $56
+  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -9219,30 +9215,30 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $41
-  local.set $56
+  local.get $37
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $56
+  local.get $52
   i32.store offset=48
-  local.get $56
+  local.get $52
   i32.const 2064
-  local.set $56
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $56
+  local.get $52
   i32.store offset=76
-  local.get $56
+  local.get $52
   call $~lib/staticarray/StaticArray<~lib/string/String>#join
-  local.set $56
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $56
+  local.get $52
   i32.store
-  local.get $56
+  local.get $52
   i32.const 2096
-  local.set $56
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $56
+  local.get $52
   i32.store offset=24
-  local.get $56
+  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -9253,30 +9249,30 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $41
-  local.set $56
+  local.get $37
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $56
+  local.get $52
   i32.store offset=48
-  local.get $56
+  local.get $52
   i32.const 2144
-  local.set $56
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $56
+  local.get $52
   i32.store offset=76
-  local.get $56
+  local.get $52
   call $~lib/staticarray/StaticArray<~lib/string/String>#join
-  local.set $56
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $56
+  local.get $52
   i32.store
-  local.get $56
+  local.get $52
   i32.const 2176
-  local.set $56
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $56
+  local.get $52
   i32.store offset=24
-  local.get $56
+  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -9287,36 +9283,36 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $41
-  local.set $56
+  local.get $37
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $56
+  local.get $52
   i32.store offset=48
-  local.get $56
+  local.get $52
   i32.const 1936
-  local.set $56
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $56
+  local.get $52
   i32.store offset=76
-  local.get $56
+  local.get $52
   call $~lib/staticarray/StaticArray<~lib/string/String>#join
-  local.set $56
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $56
+  local.get $52
   i32.store
-  local.get $56
-  local.get $41
-  local.set $56
+  local.get $52
+  local.get $37
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $56
+  local.get $52
   i32.store offset=48
-  local.get $56
+  local.get $52
   call $~lib/staticarray/StaticArray<~lib/string/String>#toString
-  local.set $56
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $56
+  local.get $52
   i32.store offset=24
-  local.get $56
+  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -9332,14 +9328,14 @@
   i32.const 4
   i32.const 2240
   call $~lib/rt/__newBuffer
-  local.tee $43
+  local.tee $39
   i32.store offset=80
-  local.get $43
-  local.set $56
+  local.get $39
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $56
+  local.get $52
   i32.store
-  local.get $56
+  local.get $52
   i32.const 1
   i32.const 1
   i32.const 2
@@ -9347,12 +9343,12 @@
   i32.const 0
   call $~lib/staticarray/StaticArray<i32>#fill@varargs
   drop
-  local.get $43
-  local.set $56
+  local.get $39
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $56
+  local.get $52
   i32.store
-  local.get $56
+  local.get $52
   i32.const 0
   call $~lib/staticarray/StaticArray<i32>#__get
   i32.const 0
@@ -9366,12 +9362,12 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $43
-  local.set $56
+  local.get $39
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $56
+  local.get $52
   i32.store
-  local.get $56
+  local.get $52
   i32.const 1
   call $~lib/staticarray/StaticArray<i32>#__get
   i32.const 1
@@ -9390,22 +9386,22 @@
   i32.const 4
   i32.const 2272
   call $~lib/rt/__newBuffer
-  local.tee $45
+  local.tee $41
   i32.store offset=84
-  local.get $45
-  local.set $56
+  local.get $41
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $56
+  local.get $52
   i32.store
-  local.get $56
+  local.get $52
   call $~lib/staticarray/StaticArray<i32>#reverse
   drop
-  local.get $45
-  local.set $56
+  local.get $41
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $56
+  local.get $52
   i32.store
-  local.get $56
+  local.get $52
   i32.const 0
   call $~lib/staticarray/StaticArray<i32>#__get
   i32.const 3
@@ -9419,12 +9415,12 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $45
-  local.set $56
+  local.get $41
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $56
+  local.get $52
   i32.store
-  local.get $56
+  local.get $52
   i32.const 1
   call $~lib/staticarray/StaticArray<i32>#__get
   i32.const 2
@@ -9438,12 +9434,12 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $45
-  local.set $56
+  local.get $41
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $56
+  local.get $52
   i32.store
-  local.get $56
+  local.get $52
   i32.const 2
   call $~lib/staticarray/StaticArray<i32>#__get
   i32.const 1
@@ -9462,14 +9458,14 @@
   i32.const 4
   i32.const 2304
   call $~lib/rt/__newBuffer
-  local.tee $47
+  local.tee $43
   i32.store offset=88
-  local.get $47
-  local.set $56
+  local.get $43
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $56
+  local.get $52
   i32.store
-  local.get $56
+  local.get $52
   i32.const 0
   i32.const 3
   i32.const 2
@@ -9477,12 +9473,12 @@
   i32.const 0
   call $~lib/staticarray/StaticArray<i32>#copyWithin@varargs
   drop
-  local.get $47
-  local.set $56
+  local.get $43
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $56
+  local.get $52
   i32.store
-  local.get $56
+  local.get $52
   i32.const 0
   call $~lib/staticarray/StaticArray<i32>#__get
   i32.const 4
@@ -9496,12 +9492,12 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $47
-  local.set $56
+  local.get $43
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $56
+  local.get $52
   i32.store
-  local.get $56
+  local.get $52
   i32.const 1
   call $~lib/staticarray/StaticArray<i32>#__get
   i32.const 5
@@ -9515,12 +9511,12 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $47
-  local.set $56
+  local.get $43
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $56
+  local.get $52
   i32.store
-  local.get $56
+  local.get $52
   i32.const 2
   call $~lib/staticarray/StaticArray<i32>#__get
   i32.const 3
@@ -9534,12 +9530,12 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $47
-  local.set $56
+  local.get $43
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $56
+  local.get $52
   i32.store
-  local.get $56
+  local.get $52
   i32.const 3
   call $~lib/staticarray/StaticArray<i32>#__get
   i32.const 4
@@ -9553,12 +9549,12 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $47
-  local.set $56
+  local.get $43
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $56
+  local.get $52
   i32.store
-  local.get $56
+  local.get $52
   i32.const 4
   call $~lib/staticarray/StaticArray<i32>#__get
   i32.const 5
@@ -9577,30 +9573,30 @@
   i32.const 4
   i32.const 2352
   call $~lib/rt/__newBuffer
-  local.tee $49
+  local.tee $45
   i32.store offset=92
   global.get $~lib/memory/__stack_pointer
-  local.get $49
-  local.set $56
+  local.get $45
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $56
+  local.get $52
   i32.store
-  local.get $56
+  local.get $52
   i32.const 2384
-  local.set $56
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $56
+  local.get $52
   i32.store offset=24
-  local.get $56
+  local.get $52
   call $~lib/staticarray/StaticArray<i32>#map<i32>
-  local.tee $50
+  local.tee $46
   i32.store offset=96
-  local.get $50
-  local.set $56
+  local.get $46
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $56
+  local.get $52
   i32.store
-  local.get $56
+  local.get $52
   i32.const 0
   call $~lib/array/Array<i32>#__get
   i32.const 2
@@ -9614,12 +9610,12 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $50
-  local.set $56
+  local.get $46
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $56
+  local.get $52
   i32.store
-  local.get $56
+  local.get $52
   i32.const 1
   call $~lib/array/Array<i32>#__get
   i32.const 3
@@ -9633,12 +9629,12 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $50
-  local.set $56
+  local.get $46
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $56
+  local.get $52
   i32.store
-  local.get $56
+  local.get $52
   i32.const 2
   call $~lib/array/Array<i32>#__get
   i32.const 4
@@ -9652,18 +9648,18 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $49
-  local.set $56
+  local.get $45
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $56
+  local.get $52
   i32.store
-  local.get $56
+  local.get $52
   i32.const 2416
-  local.set $56
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $56
+  local.get $52
   i32.store offset=24
-  local.get $56
+  local.get $52
   call $~lib/staticarray/StaticArray<i32>#forEach
   global.get $std/staticarray/maxVal
   i32.const 3
@@ -9678,27 +9674,27 @@
    unreachable
   end
   global.get $~lib/memory/__stack_pointer
-  local.get $49
-  local.set $56
+  local.get $45
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $56
+  local.get $52
   i32.store
-  local.get $56
+  local.get $52
   i32.const 2448
-  local.set $56
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $56
+  local.get $52
   i32.store offset=24
-  local.get $56
+  local.get $52
   call $~lib/staticarray/StaticArray<i32>#filter
-  local.tee $51
+  local.tee $47
   i32.store offset=100
-  local.get $51
-  local.set $56
+  local.get $47
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $56
+  local.get $52
   i32.store
-  local.get $56
+  local.get $52
   call $~lib/array/Array<i32>#get:length
   i32.const 2
   i32.eq
@@ -9711,12 +9707,12 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $51
-  local.set $56
+  local.get $47
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $56
+  local.get $52
   i32.store
-  local.get $56
+  local.get $52
   i32.const 0
   call $~lib/array/Array<i32>#__get
   i32.const 2
@@ -9730,12 +9726,12 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $51
-  local.set $56
+  local.get $47
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $56
+  local.get $52
   i32.store
-  local.get $56
+  local.get $52
   i32.const 1
   call $~lib/array/Array<i32>#__get
   i32.const 3
@@ -9749,22 +9745,22 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $49
-  local.set $56
+  local.get $45
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $56
+  local.get $52
   i32.store
-  local.get $56
+  local.get $52
   i32.const 2480
-  local.set $56
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $56
+  local.get $52
   i32.store offset=24
-  local.get $56
+  local.get $52
   i32.const 0
   call $~lib/staticarray/StaticArray<i32>#reduce<i32>
-  local.set $52
-  local.get $52
+  local.set $48
+  local.get $48
   i32.const 6
   i32.eq
   i32.eqz
@@ -9776,22 +9772,22 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $49
-  local.set $56
+  local.get $45
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $56
+  local.get $52
   i32.store
-  local.get $56
+  local.get $52
   i32.const 2512
-  local.set $56
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $56
+  local.get $52
   i32.store offset=24
-  local.get $56
+  local.get $52
   i32.const 0
   call $~lib/staticarray/StaticArray<i32>#reduceRight<i32>
-  local.set $53
-  local.get $53
+  local.set $49
+  local.get $49
   i32.const 6
   i32.eq
   i32.eqz
@@ -9803,18 +9799,18 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $49
-  local.set $56
+  local.get $45
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $56
+  local.get $52
   i32.store
-  local.get $56
+  local.get $52
   i32.const 2544
-  local.set $56
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $56
+  local.get $52
   i32.store offset=24
-  local.get $56
+  local.get $52
   call $~lib/staticarray/StaticArray<i32>#some
   i32.eqz
   if
@@ -9825,18 +9821,18 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $49
-  local.set $56
+  local.get $45
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $56
+  local.get $52
   i32.store
-  local.get $56
+  local.get $52
   i32.const 2576
-  local.set $56
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $56
+  local.get $52
   i32.store offset=24
-  local.get $56
+  local.get $52
   call $~lib/staticarray/StaticArray<i32>#some
   i32.eqz
   i32.eqz
@@ -9848,18 +9844,18 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $49
-  local.set $56
+  local.get $45
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $56
+  local.get $52
   i32.store
-  local.get $56
+  local.get $52
   i32.const 2608
-  local.set $56
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $56
+  local.get $52
   i32.store offset=24
-  local.get $56
+  local.get $52
   call $~lib/staticarray/StaticArray<i32>#every
   i32.eqz
   if
@@ -9870,18 +9866,18 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $49
-  local.set $56
+  local.get $45
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $56
+  local.get $52
   i32.store
-  local.get $56
+  local.get $52
   i32.const 2640
-  local.set $56
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $56
+  local.get $52
   i32.store offset=24
-  local.get $56
+  local.get $52
   call $~lib/staticarray/StaticArray<i32>#every
   i32.eqz
   i32.eqz
@@ -9893,18 +9889,18 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $49
-  local.set $56
+  local.get $45
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $56
+  local.get $52
   i32.store
-  local.get $56
+  local.get $52
   i32.const 2672
-  local.set $56
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $56
+  local.get $52
   i32.store offset=24
-  local.get $56
+  local.get $52
   call $~lib/staticarray/StaticArray<i32>#findIndex
   i32.const 1
   i32.eq
@@ -9917,18 +9913,18 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $49
-  local.set $56
+  local.get $45
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $56
+  local.get $52
   i32.store
-  local.get $56
+  local.get $52
   i32.const 2704
-  local.set $56
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $56
+  local.get $52
   i32.store offset=24
-  local.get $56
+  local.get $52
   call $~lib/staticarray/StaticArray<i32>#findIndex
   i32.const -1
   i32.eq
@@ -9941,18 +9937,18 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $49
-  local.set $56
+  local.get $45
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $56
+  local.get $52
   i32.store
-  local.get $56
+  local.get $52
   i32.const 2736
-  local.set $56
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $56
+  local.get $52
   i32.store offset=24
-  local.get $56
+  local.get $52
   call $~lib/staticarray/StaticArray<i32>#findLastIndex
   i32.const 1
   i32.eq
@@ -9965,18 +9961,18 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $49
-  local.set $56
+  local.get $45
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $56
+  local.get $52
   i32.store
-  local.get $56
+  local.get $52
   i32.const 2768
-  local.set $56
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $56
+  local.get $52
   i32.store offset=24
-  local.get $56
+  local.get $52
   call $~lib/staticarray/StaticArray<i32>#findLastIndex
   i32.const -1
   i32.eq
@@ -9994,25 +9990,25 @@
   i32.const 4
   i32.const 2800
   call $~lib/rt/__newBuffer
-  local.tee $55
+  local.tee $51
   i32.store offset=104
-  local.get $55
-  local.set $56
+  local.get $51
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $56
+  local.get $52
   i32.store
-  local.get $56
+  local.get $52
   i32.const 0
   global.set $~argumentsLength
   i32.const 0
   call $~lib/staticarray/StaticArray<i32>#sort@varargs
   drop
-  local.get $55
-  local.set $56
+  local.get $51
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $56
+  local.get $52
   i32.store
-  local.get $56
+  local.get $52
   i32.const 0
   call $~lib/staticarray/StaticArray<i32>#__get
   i32.const 0
@@ -10026,12 +10022,12 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $55
-  local.set $56
+  local.get $51
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $56
+  local.get $52
   i32.store
-  local.get $56
+  local.get $52
   i32.const 1
   call $~lib/staticarray/StaticArray<i32>#__get
   i32.const 1
@@ -10045,12 +10041,12 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $55
-  local.set $56
+  local.get $51
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $56
+  local.get $52
   i32.store
-  local.get $56
+  local.get $52
   i32.const 2
   call $~lib/staticarray/StaticArray<i32>#__get
   i32.const 2
@@ -10064,12 +10060,12 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $55
-  local.set $56
+  local.get $51
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $56
+  local.get $52
   i32.store
-  local.get $56
+  local.get $52
   i32.const 3
   call $~lib/staticarray/StaticArray<i32>#__get
   i32.const 3

--- a/tests/compiler/std/string.debug.wat
+++ b/tests/compiler/std/string.debug.wat
@@ -11586,33 +11586,32 @@
  )
  (func $~lib/string/String#split (param $this i32) (param $separator i32) (param $limit i32) (result i32)
   (local $3 i32)
-  (local $4 i32)
   (local $length i32)
   (local $sepLen i32)
+  (local $6 i32)
   (local $7 i32)
-  (local $8 i32)
   (local $result i32)
   (local $resultStart i32)
   (local $i i32)
   (local $charStr i32)
+  (local $result|12 i32)
   (local $result|13 i32)
-  (local $result|14 i32)
   (local $end i32)
   (local $start i32)
-  (local $i|17 i32)
+  (local $i|16 i32)
   (local $len i32)
   (local $out i32)
-  (local $len|20 i32)
-  (local $out|21 i32)
-  (local $22 i32)
+  (local $len|19 i32)
+  (local $out|20 i32)
+  (local $21 i32)
   global.get $~lib/memory/__stack_pointer
-  i32.const 40
+  i32.const 36
   i32.sub
   global.set $~lib/memory/__stack_pointer
   call $~stack_check
   global.get $~lib/memory/__stack_pointer
   i32.const 0
-  i32.const 40
+  i32.const 36
   memory.fill
   local.get $limit
   i32.eqz
@@ -11622,12 +11621,12 @@
    i32.const 5
    i32.const 0
    call $~lib/rt/__newArray
-   local.set $22
+   local.set $21
    global.get $~lib/memory/__stack_pointer
-   i32.const 40
+   i32.const 36
    i32.add
    global.set $~lib/memory/__stack_pointer
-   local.get $22
+   local.get $21
    return
   end
   local.get $separator
@@ -11642,38 +11641,33 @@
    call $~lib/rt/__newArray
    local.tee $3
    i32.store
-   global.get $~lib/memory/__stack_pointer
-   local.get $3
-   i32.load offset=4
-   local.tee $4
-   i32.store offset=4
    local.get $3
    i32.const 0
    local.get $this
    call $~lib/array/Array<~lib/string/String>#__set
    local.get $3
-   local.set $22
+   local.set $21
    global.get $~lib/memory/__stack_pointer
-   i32.const 40
+   i32.const 36
    i32.add
    global.set $~lib/memory/__stack_pointer
-   local.get $22
+   local.get $21
    return
   end
   local.get $this
-  local.set $22
+  local.set $21
   global.get $~lib/memory/__stack_pointer
-  local.get $22
-  i32.store offset=8
-  local.get $22
+  local.get $21
+  i32.store offset=4
+  local.get $21
   call $~lib/string/String#get:length
   local.set $length
   local.get $separator
-  local.set $22
+  local.set $21
   global.get $~lib/memory/__stack_pointer
-  local.get $22
-  i32.store offset=8
-  local.get $22
+  local.get $21
+  i32.store offset=4
+  local.get $21
   call $~lib/string/String#get:length
   local.set $sepLen
   local.get $limit
@@ -11694,20 +11688,20 @@
     i32.const 5
     i32.const 0
     call $~lib/rt/__newArray
-    local.set $22
+    local.set $21
     global.get $~lib/memory/__stack_pointer
-    i32.const 40
+    i32.const 36
     i32.add
     global.set $~lib/memory/__stack_pointer
-    local.get $22
+    local.get $21
     return
    end
    local.get $length
-   local.tee $7
+   local.tee $6
    local.get $limit
-   local.tee $8
+   local.tee $7
+   local.get $6
    local.get $7
-   local.get $8
    i32.lt_s
    select
    local.set $length
@@ -11718,13 +11712,13 @@
    i32.const 0
    call $~lib/rt/__newArray
    local.tee $result
-   i32.store offset=12
-   local.get $result
-   local.set $22
-   global.get $~lib/memory/__stack_pointer
-   local.get $22
    i32.store offset=8
-   local.get $22
+   local.get $result
+   local.set $21
+   global.get $~lib/memory/__stack_pointer
+   local.get $21
+   i32.store offset=4
+   local.get $21
    call $~lib/array/Array<~lib/string/String>#get:dataStart
    local.set $resultStart
    i32.const 0
@@ -11739,7 +11733,7 @@
      i32.const 2
      call $~lib/rt/itcms/__new
      local.tee $charStr
-     i32.store offset=16
+     i32.store offset=12
      local.get $charStr
      local.get $this
      local.get $i
@@ -11767,12 +11761,12 @@
     end
    end
    local.get $result
-   local.set $22
+   local.set $21
    global.get $~lib/memory/__stack_pointer
-   i32.const 40
+   i32.const 36
    i32.add
    global.set $~lib/memory/__stack_pointer
-   local.get $22
+   local.get $21
    return
   else
    local.get $length
@@ -11784,24 +11778,24 @@
     i32.const 5
     i32.const 0
     call $~lib/rt/__newArray
-    local.tee $result|13
-    i32.store offset=20
-    local.get $result|13
-    local.set $22
+    local.tee $result|12
+    i32.store offset=16
+    local.get $result|12
+    local.set $21
     global.get $~lib/memory/__stack_pointer
-    local.get $22
-    i32.store offset=8
-    local.get $22
+    local.get $21
+    i32.store offset=4
+    local.get $21
     call $~lib/array/Array<~lib/string/String>#get:dataStart
     i32.const 688
     i32.store
-    local.get $result|13
-    local.set $22
+    local.get $result|12
+    local.set $21
     global.get $~lib/memory/__stack_pointer
-    i32.const 40
+    i32.const 36
     i32.add
     global.set $~lib/memory/__stack_pointer
-    local.get $22
+    local.get $21
     return
    end
   end
@@ -11811,27 +11805,27 @@
   i32.const 5
   i32.const 0
   call $~lib/rt/__newArray
-  local.tee $result|14
-  i32.store offset=24
+  local.tee $result|13
+  i32.store offset=20
   i32.const 0
   local.set $end
   i32.const 0
   local.set $start
   i32.const 0
-  local.set $i|17
+  local.set $i|16
   loop $while-continue|1
    local.get $this
-   local.set $22
+   local.set $21
    global.get $~lib/memory/__stack_pointer
-   local.get $22
-   i32.store offset=8
-   local.get $22
+   local.get $21
+   i32.store offset=4
+   local.get $21
    local.get $separator
-   local.set $22
+   local.set $21
    global.get $~lib/memory/__stack_pointer
-   local.get $22
-   i32.store offset=28
-   local.get $22
+   local.get $21
+   i32.store offset=24
+   local.get $21
    local.get $start
    call $~lib/string/String#indexOf
    local.tee $end
@@ -11853,7 +11847,7 @@
      i32.const 2
      call $~lib/rt/itcms/__new
      local.tee $out
-     i32.store offset=32
+     i32.store offset=28
      local.get $out
      local.get $this
      local.get $start
@@ -11864,50 +11858,50 @@
      i32.const 1
      i32.shl
      memory.copy
-     local.get $result|14
-     local.set $22
+     local.get $result|13
+     local.set $21
      global.get $~lib/memory/__stack_pointer
-     local.get $22
-     i32.store offset=8
-     local.get $22
+     local.get $21
+     i32.store offset=4
+     local.get $21
      local.get $out
-     local.set $22
+     local.set $21
      global.get $~lib/memory/__stack_pointer
-     local.get $22
-     i32.store offset=28
-     local.get $22
+     local.get $21
+     i32.store offset=24
+     local.get $21
      call $~lib/array/Array<~lib/string/String>#push
      drop
     else
-     local.get $result|14
-     local.set $22
+     local.get $result|13
+     local.set $21
      global.get $~lib/memory/__stack_pointer
-     local.get $22
-     i32.store offset=8
-     local.get $22
+     local.get $21
+     i32.store offset=4
+     local.get $21
      i32.const 688
-     local.set $22
+     local.set $21
      global.get $~lib/memory/__stack_pointer
-     local.get $22
-     i32.store offset=28
-     local.get $22
+     local.get $21
+     i32.store offset=24
+     local.get $21
      call $~lib/array/Array<~lib/string/String>#push
      drop
     end
-    local.get $i|17
+    local.get $i|16
     i32.const 1
     i32.add
-    local.tee $i|17
+    local.tee $i|16
     local.get $limit
     i32.eq
     if
-     local.get $result|14
-     local.set $22
+     local.get $result|13
+     local.set $21
      global.get $~lib/memory/__stack_pointer
-     i32.const 40
+     i32.const 36
      i32.add
      global.set $~lib/memory/__stack_pointer
-     local.get $22
+     local.get $21
      return
     end
     local.get $end
@@ -11920,92 +11914,92 @@
   local.get $start
   i32.eqz
   if
-   local.get $result|14
-   local.set $22
+   local.get $result|13
+   local.set $21
    global.get $~lib/memory/__stack_pointer
-   local.get $22
-   i32.store offset=8
-   local.get $22
+   local.get $21
+   i32.store offset=4
+   local.get $21
    local.get $this
-   local.set $22
+   local.set $21
    global.get $~lib/memory/__stack_pointer
-   local.get $22
-   i32.store offset=28
-   local.get $22
+   local.get $21
+   i32.store offset=24
+   local.get $21
    call $~lib/array/Array<~lib/string/String>#push
    drop
-   local.get $result|14
-   local.set $22
+   local.get $result|13
+   local.set $21
    global.get $~lib/memory/__stack_pointer
-   i32.const 40
+   i32.const 36
    i32.add
    global.set $~lib/memory/__stack_pointer
-   local.get $22
+   local.get $21
    return
   end
   local.get $length
   local.get $start
   i32.sub
-  local.set $len|20
-  local.get $len|20
+  local.set $len|19
+  local.get $len|19
   i32.const 0
   i32.gt_s
   if
    global.get $~lib/memory/__stack_pointer
-   local.get $len|20
+   local.get $len|19
    i32.const 1
    i32.shl
    i32.const 2
    call $~lib/rt/itcms/__new
-   local.tee $out|21
-   i32.store offset=36
-   local.get $out|21
+   local.tee $out|20
+   i32.store offset=32
+   local.get $out|20
    local.get $this
    local.get $start
    i32.const 1
    i32.shl
    i32.add
-   local.get $len|20
+   local.get $len|19
    i32.const 1
    i32.shl
    memory.copy
-   local.get $result|14
-   local.set $22
+   local.get $result|13
+   local.set $21
    global.get $~lib/memory/__stack_pointer
-   local.get $22
-   i32.store offset=8
-   local.get $22
-   local.get $out|21
-   local.set $22
+   local.get $21
+   i32.store offset=4
+   local.get $21
+   local.get $out|20
+   local.set $21
    global.get $~lib/memory/__stack_pointer
-   local.get $22
-   i32.store offset=28
-   local.get $22
+   local.get $21
+   i32.store offset=24
+   local.get $21
    call $~lib/array/Array<~lib/string/String>#push
    drop
   else
-   local.get $result|14
-   local.set $22
+   local.get $result|13
+   local.set $21
    global.get $~lib/memory/__stack_pointer
-   local.get $22
-   i32.store offset=8
-   local.get $22
+   local.get $21
+   i32.store offset=4
+   local.get $21
    i32.const 688
-   local.set $22
+   local.set $21
    global.get $~lib/memory/__stack_pointer
-   local.get $22
-   i32.store offset=28
-   local.get $22
+   local.get $21
+   i32.store offset=24
+   local.get $21
    call $~lib/array/Array<~lib/string/String>#push
    drop
   end
-  local.get $result|14
-  local.set $22
+  local.get $result|13
+  local.set $21
   global.get $~lib/memory/__stack_pointer
-  i32.const 40
+  i32.const 36
   i32.add
   global.set $~lib/memory/__stack_pointer
-  local.get $22
+  local.get $21
   return
  )
  (func $~lib/string/String#split@varargs (param $this i32) (param $separator i32) (param $limit i32) (result i32)
@@ -12157,26 +12151,26 @@
   (local $7 i32)
   (local $8 i32)
   (local $9 i32)
-  (local $10 i32)
-  (local $11 i32)
-  (local $12 i32)
+  (local $10 f64)
+  (local $11 f64)
+  (local $12 f64)
   (local $13 f64)
   (local $14 f64)
   (local $15 f64)
   (local $16 f64)
-  (local $17 f64)
+  (local $17 f32)
   (local $18 f64)
-  (local $19 f64)
+  (local $19 i32)
   (local $20 f32)
-  (local $21 f64)
-  (local $22 i32)
-  (local $23 f32)
+  (local $21 i32)
+  (local $22 f64)
+  (local $23 i32)
   (local $24 i32)
-  (local $25 f64)
+  (local $25 i32)
   (local $26 i32)
-  (local $27 i32)
-  (local $28 i32)
-  (local $29 i32)
+  (local $27 f64)
+  (local $28 f64)
+  (local $29 f64)
   (local $30 f64)
   (local $31 f64)
   (local $32 f64)
@@ -12195,14 +12189,11 @@
   (local $45 f64)
   (local $46 f64)
   (local $47 f64)
-  (local $48 f64)
-  (local $49 f64)
-  (local $50 f64)
+  (local $48 i32)
+  (local $49 i32)
+  (local $50 i32)
   (local $51 i32)
   (local $52 i32)
-  (local $53 i32)
-  (local $54 i32)
-  (local $55 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 96
   i32.sub
@@ -12225,17 +12216,17 @@
    unreachable
   end
   i32.const 144
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   i32.const 144
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=4
-  local.get $55
+  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -12247,17 +12238,17 @@
    unreachable
   end
   i32.const 176
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   i32.const 176
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=4
-  local.get $55
+  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -12269,17 +12260,17 @@
    unreachable
   end
   i32.const 208
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   i32.const 208
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=4
-  local.get $55
+  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -12291,11 +12282,11 @@
    unreachable
   end
   global.get $std/string/str
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   call $~lib/string/String#get:length
   i32.const 16
   i32.eq
@@ -12309,11 +12300,11 @@
    unreachable
   end
   global.get $std/string/str
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   i32.const 0
   call $~lib/string/String#charCodeAt
   i32.const 104
@@ -12328,11 +12319,11 @@
    unreachable
   end
   global.get $std/string/str
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   i32.const 1
   call $~lib/string/String#codePointAt
   i32.const 105
@@ -12364,31 +12355,31 @@
   call $~lib/rt/itcms/initLazy
   global.set $~lib/rt/itcms/fromSpace
   global.get $std/string/str
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=8
-  local.get $55
+  local.get $52
   i32.const 15
   call $~lib/string/String#at
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   global.get $std/string/str
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=8
-  local.get $55
+  local.get $52
   i32.const 15
   call $~lib/string/String#charAt
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=4
-  local.get $55
+  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -12400,39 +12391,39 @@
    unreachable
   end
   global.get $std/string/str
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=8
-  local.get $55
+  local.get $52
   i32.const -1
   call $~lib/string/String#at
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   global.get $std/string/str
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=8
-  local.get $55
+  local.get $52
   global.get $std/string/str
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=12
-  local.get $55
+  local.get $52
   call $~lib/string/String#get:length
   i32.const 1
   i32.sub
   call $~lib/string/String#charAt
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=4
-  local.get $55
+  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -12444,32 +12435,32 @@
    unreachable
   end
   global.get $std/string/str
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=8
-  local.get $55
+  local.get $52
   i32.const 0
   global.get $std/string/str
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=12
-  local.get $55
+  local.get $52
   call $~lib/string/String#get:length
   i32.sub
   call $~lib/string/String#at
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   i32.const 720
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=4
-  local.get $55
+  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -12481,11 +12472,11 @@
    unreachable
   end
   i32.const 688
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   call $~lib/string/String.__not
   i32.eqz
   i32.const 0
@@ -12500,11 +12491,11 @@
    unreachable
   end
   i32.const 752
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   call $~lib/string/String.__not
   i32.eqz
   i32.const 1
@@ -12519,11 +12510,11 @@
    unreachable
   end
   i32.const 784
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   call $~lib/string/String.__not
   i32.eqz
   i32.const 1
@@ -12542,17 +12533,17 @@
   global.set $~argumentsLength
   i32.const 0
   call $~lib/string/String.fromCharCode@varargs
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   i32.const 752
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=4
-  local.get $55
+  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -12568,17 +12559,17 @@
   global.set $~argumentsLength
   i32.const 0
   call $~lib/string/String.fromCharCode@varargs
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   i32.const 816
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=4
-  local.get $55
+  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -12594,17 +12585,17 @@
   global.set $~argumentsLength
   i32.const 0
   call $~lib/string/String.fromCharCode@varargs
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   i32.const 848
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=4
-  local.get $55
+  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -12622,17 +12613,17 @@
   global.set $~argumentsLength
   i32.const 0
   call $~lib/string/String.fromCharCode@varargs
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   i32.const 848
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=4
-  local.get $55
+  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -12646,17 +12637,17 @@
   i32.const 55296
   i32.const 57088
   call $~lib/string/String.fromCharCode
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   i32.const 880
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=4
-  local.get $55
+  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -12672,23 +12663,23 @@
   i32.const 4
   i32.const 912
   call $~lib/rt/__newArray
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=8
-  local.get $55
+  local.get $52
   call $~lib/string/String.fromCharCodes
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   i32.const 944
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=4
-  local.get $55
+  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -12704,23 +12695,23 @@
   i32.const 4
   i32.const 976
   call $~lib/rt/__newArray
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=8
-  local.get $55
+  local.get $52
   call $~lib/string/String.fromCharCodes
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   i32.const 1008
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=4
-  local.get $55
+  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -12736,23 +12727,23 @@
   i32.const 4
   i32.const 1040
   call $~lib/rt/__newArray
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=8
-  local.get $55
+  local.get $52
   call $~lib/string/String.fromCharCodes
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   i32.const 1088
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=4
-  local.get $55
+  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -12765,17 +12756,17 @@
   end
   i32.const 0
   call $~lib/string/String.fromCodePoint
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   i32.const 752
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=4
-  local.get $55
+  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -12788,17 +12779,17 @@
   end
   i32.const 54
   call $~lib/string/String.fromCodePoint
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   i32.const 848
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=4
-  local.get $55
+  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -12811,17 +12802,17 @@
   end
   i32.const 119558
   call $~lib/string/String.fromCodePoint
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   i32.const 1120
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=4
-  local.get $55
+  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -12833,17 +12824,17 @@
    unreachable
   end
   global.get $std/string/str
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   i32.const 1152
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=4
-  local.get $55
+  local.get $52
   i32.const 0
   call $~lib/string/String#startsWith
   i32.eqz
@@ -12856,17 +12847,17 @@
    unreachable
   end
   global.get $std/string/str
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   i32.const 1184
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=4
-  local.get $55
+  local.get $52
   i32.const 1
   global.set $~argumentsLength
   i32.const 0
@@ -12881,17 +12872,17 @@
    unreachable
   end
   global.get $std/string/str
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   i32.const 1216
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=4
-  local.get $55
+  local.get $52
   i32.const 0
   call $~lib/string/String#includes
   i32.eqz
@@ -12904,30 +12895,30 @@
    unreachable
   end
   global.get $std/string/str
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=8
-  local.get $55
+  local.get $52
   i32.const 0
   i32.const 1248
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=12
-  local.get $55
+  local.get $52
   call $~lib/string/String#padStart
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   global.get $std/string/str
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=4
-  local.get $55
+  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -12939,30 +12930,30 @@
    unreachable
   end
   global.get $std/string/str
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=8
-  local.get $55
+  local.get $52
   i32.const 15
   i32.const 1248
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=12
-  local.get $55
+  local.get $52
   call $~lib/string/String#padStart
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   global.get $std/string/str
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=4
-  local.get $55
+  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -12974,30 +12965,30 @@
    unreachable
   end
   i32.const 688
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=8
-  local.get $55
+  local.get $52
   i32.const 3
   i32.const 1248
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=12
-  local.get $55
+  local.get $52
   call $~lib/string/String#padStart
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   i32.const 1280
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=4
-  local.get $55
+  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -13009,30 +13000,30 @@
    unreachable
   end
   i32.const 688
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=8
-  local.get $55
+  local.get $52
   i32.const 10
   i32.const 688
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=12
-  local.get $55
+  local.get $52
   call $~lib/string/String#padStart
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   i32.const 688
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=4
-  local.get $55
+  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -13044,30 +13035,30 @@
    unreachable
   end
   i32.const 784
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=8
-  local.get $55
+  local.get $52
   i32.const 100
   i32.const 688
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=12
-  local.get $55
+  local.get $52
   call $~lib/string/String#padStart
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   i32.const 784
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=4
-  local.get $55
+  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -13079,30 +13070,30 @@
    unreachable
   end
   i32.const 1312
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=8
-  local.get $55
+  local.get $52
   i32.const 5
   i32.const 1248
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=12
-  local.get $55
+  local.get $52
   call $~lib/string/String#padStart
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   i32.const 1344
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=4
-  local.get $55
+  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -13114,30 +13105,30 @@
    unreachable
   end
   i32.const 1312
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=8
-  local.get $55
+  local.get $52
   i32.const 6
   i32.const 1376
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=12
-  local.get $55
+  local.get $52
   call $~lib/string/String#padStart
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   i32.const 1408
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=4
-  local.get $55
+  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -13149,30 +13140,30 @@
    unreachable
   end
   i32.const 1312
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=8
-  local.get $55
+  local.get $52
   i32.const 8
   i32.const 1376
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=12
-  local.get $55
+  local.get $52
   call $~lib/string/String#padStart
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   i32.const 1440
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=4
-  local.get $55
+  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -13184,30 +13175,30 @@
    unreachable
   end
   global.get $std/string/str
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=8
-  local.get $55
+  local.get $52
   i32.const 0
   i32.const 1248
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=12
-  local.get $55
+  local.get $52
   call $~lib/string/String#padEnd
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   global.get $std/string/str
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=4
-  local.get $55
+  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -13219,30 +13210,30 @@
    unreachable
   end
   global.get $std/string/str
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=8
-  local.get $55
+  local.get $52
   i32.const 15
   i32.const 1248
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=12
-  local.get $55
+  local.get $52
   call $~lib/string/String#padEnd
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   global.get $std/string/str
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=4
-  local.get $55
+  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -13254,30 +13245,30 @@
    unreachable
   end
   i32.const 688
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=8
-  local.get $55
+  local.get $52
   i32.const 3
   i32.const 1248
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=12
-  local.get $55
+  local.get $52
   call $~lib/string/String#padEnd
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   i32.const 1280
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=4
-  local.get $55
+  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -13289,30 +13280,30 @@
    unreachable
   end
   i32.const 688
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=8
-  local.get $55
+  local.get $52
   i32.const 10
   i32.const 688
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=12
-  local.get $55
+  local.get $52
   call $~lib/string/String#padEnd
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   i32.const 688
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=4
-  local.get $55
+  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -13324,30 +13315,30 @@
    unreachable
   end
   i32.const 784
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=8
-  local.get $55
+  local.get $52
   i32.const 100
   i32.const 688
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=12
-  local.get $55
+  local.get $52
   call $~lib/string/String#padEnd
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   i32.const 784
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=4
-  local.get $55
+  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -13359,30 +13350,30 @@
    unreachable
   end
   i32.const 1312
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=8
-  local.get $55
+  local.get $52
   i32.const 5
   i32.const 1248
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=12
-  local.get $55
+  local.get $52
   call $~lib/string/String#padEnd
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   i32.const 1488
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=4
-  local.get $55
+  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -13394,30 +13385,30 @@
    unreachable
   end
   i32.const 1312
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=8
-  local.get $55
+  local.get $52
   i32.const 6
   i32.const 1312
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=12
-  local.get $55
+  local.get $52
   call $~lib/string/String#padEnd
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   i32.const 1520
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=4
-  local.get $55
+  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -13429,30 +13420,30 @@
    unreachable
   end
   i32.const 1312
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=8
-  local.get $55
+  local.get $52
   i32.const 8
   i32.const 1312
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=12
-  local.get $55
+  local.get $52
   call $~lib/string/String#padEnd
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   i32.const 1552
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=4
-  local.get $55
+  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -13464,17 +13455,17 @@
    unreachable
   end
   i32.const 688
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   i32.const 688
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=4
-  local.get $55
+  local.get $52
   i32.const 0
   call $~lib/string/String#indexOf
   i32.const 0
@@ -13489,17 +13480,17 @@
    unreachable
   end
   i32.const 688
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   i32.const 1152
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=4
-  local.get $55
+  local.get $52
   i32.const 0
   call $~lib/string/String#indexOf
   i32.const -1
@@ -13514,17 +13505,17 @@
    unreachable
   end
   i32.const 784
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   i32.const 784
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=4
-  local.get $55
+  local.get $52
   i32.const 0
   call $~lib/string/String#indexOf
   i32.const 0
@@ -13539,17 +13530,17 @@
    unreachable
   end
   global.get $std/string/str
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   global.get $std/string/str
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=4
-  local.get $55
+  local.get $52
   i32.const 0
   call $~lib/string/String#indexOf
   i32.const 0
@@ -13564,17 +13555,17 @@
    unreachable
   end
   global.get $std/string/str
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   i32.const 688
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=4
-  local.get $55
+  local.get $52
   i32.const 0
   call $~lib/string/String#indexOf
   i32.const 0
@@ -13589,17 +13580,17 @@
    unreachable
   end
   global.get $std/string/str
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   i32.const 1600
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=4
-  local.get $55
+  local.get $52
   i32.const 0
   call $~lib/string/String#indexOf
   i32.const 2
@@ -13614,17 +13605,17 @@
    unreachable
   end
   global.get $std/string/str
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   i32.const 1632
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=4
-  local.get $55
+  local.get $52
   i32.const 0
   call $~lib/string/String#indexOf
   i32.const -1
@@ -13639,17 +13630,17 @@
    unreachable
   end
   global.get $std/string/str
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   i32.const 1600
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=4
-  local.get $55
+  local.get $52
   i32.const 2
   call $~lib/string/String#indexOf
   i32.const 2
@@ -13664,17 +13655,17 @@
    unreachable
   end
   global.get $std/string/str
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   i32.const 1600
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=4
-  local.get $55
+  local.get $52
   i32.const 3
   call $~lib/string/String#indexOf
   i32.const -1
@@ -13689,17 +13680,17 @@
    unreachable
   end
   global.get $std/string/str
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   i32.const 1664
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=4
-  local.get $55
+  local.get $52
   i32.const -1
   call $~lib/string/String#indexOf
   i32.const 2
@@ -13714,17 +13705,17 @@
    unreachable
   end
   i32.const 688
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   i32.const 688
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=4
-  local.get $55
+  local.get $52
   i32.const 1
   global.set $~argumentsLength
   i32.const 0
@@ -13741,17 +13732,17 @@
    unreachable
   end
   i32.const 688
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   i32.const 1152
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=4
-  local.get $55
+  local.get $52
   i32.const 1
   global.set $~argumentsLength
   i32.const 0
@@ -13768,27 +13759,27 @@
    unreachable
   end
   global.get $std/string/str
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   i32.const 688
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=4
-  local.get $55
+  local.get $52
   i32.const 1
   global.set $~argumentsLength
   i32.const 0
   call $~lib/string/String#lastIndexOf@varargs
   global.get $std/string/str
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   call $~lib/string/String#get:length
   i32.eq
   i32.eqz
@@ -13801,17 +13792,17 @@
    unreachable
   end
   global.get $std/string/str
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   i32.const 1600
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=4
-  local.get $55
+  local.get $52
   i32.const 1
   global.set $~argumentsLength
   i32.const 0
@@ -13828,17 +13819,17 @@
    unreachable
   end
   global.get $std/string/str
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   i32.const 1632
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=4
-  local.get $55
+  local.get $52
   i32.const 1
   global.set $~argumentsLength
   i32.const 0
@@ -13855,17 +13846,17 @@
    unreachable
   end
   global.get $std/string/str
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   i32.const 1696
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=4
-  local.get $55
+  local.get $52
   i32.const 1
   global.set $~argumentsLength
   i32.const 0
@@ -13882,17 +13873,17 @@
    unreachable
   end
   global.get $std/string/str
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   i32.const 1600
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=4
-  local.get $55
+  local.get $52
   i32.const 2
   call $~lib/string/String#lastIndexOf
   i32.const 2
@@ -13907,17 +13898,17 @@
    unreachable
   end
   global.get $std/string/str
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   i32.const 1600
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=4
-  local.get $55
+  local.get $52
   i32.const 3
   call $~lib/string/String#lastIndexOf
   i32.const 2
@@ -13932,17 +13923,17 @@
    unreachable
   end
   global.get $std/string/str
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   i32.const 1664
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=4
-  local.get $55
+  local.get $52
   i32.const -1
   call $~lib/string/String#lastIndexOf
   i32.const -1
@@ -13957,17 +13948,17 @@
    unreachable
   end
   global.get $std/string/str
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   i32.const 1728
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=4
-  local.get $55
+  local.get $52
   i32.const 0
   call $~lib/string/String#lastIndexOf
   i32.const -1
@@ -13982,17 +13973,17 @@
    unreachable
   end
   global.get $std/string/str
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   i32.const 1152
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=4
-  local.get $55
+  local.get $52
   i32.const 0
   call $~lib/string/String#lastIndexOf
   i32.const 0
@@ -14007,17 +13998,17 @@
    unreachable
   end
   i32.const 688
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   i32.const 688
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=4
-  local.get $55
+  local.get $52
   call $~lib/string/String#localeCompare
   i32.const 0
   i32.eq
@@ -14031,17 +14022,17 @@
    unreachable
   end
   i32.const 784
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   i32.const 688
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=4
-  local.get $55
+  local.get $52
   call $~lib/string/String#localeCompare
   i32.const 1
   i32.eq
@@ -14055,17 +14046,17 @@
    unreachable
   end
   i32.const 688
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   i32.const 784
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=4
-  local.get $55
+  local.get $52
   call $~lib/string/String#localeCompare
   i32.const -1
   i32.eq
@@ -14079,17 +14070,17 @@
    unreachable
   end
   i32.const 1760
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   i32.const 1760
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=4
-  local.get $55
+  local.get $52
   call $~lib/string/String#localeCompare
   i32.const 0
   i32.eq
@@ -14103,17 +14094,17 @@
    unreachable
   end
   i32.const 1312
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   i32.const 1792
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=4
-  local.get $55
+  local.get $52
   call $~lib/string/String#localeCompare
   i32.const -1
   i32.eq
@@ -14127,17 +14118,17 @@
    unreachable
   end
   i32.const 1312
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   i32.const 1824
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=4
-  local.get $55
+  local.get $52
   call $~lib/string/String#localeCompare
   i32.const -1
   i32.eq
@@ -14151,17 +14142,17 @@
    unreachable
   end
   i32.const 1792
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   i32.const 1312
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=4
-  local.get $55
+  local.get $52
   call $~lib/string/String#localeCompare
   i32.const 1
   i32.eq
@@ -14175,17 +14166,17 @@
    unreachable
   end
   i32.const 1856
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   i32.const 1312
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=4
-  local.get $55
+  local.get $52
   call $~lib/string/String#localeCompare
   i32.const 1
   i32.eq
@@ -14199,17 +14190,17 @@
    unreachable
   end
   i32.const 1888
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   i32.const 1312
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=4
-  local.get $55
+  local.get $52
   call $~lib/string/String#localeCompare
   i32.const 1
   i32.eq
@@ -14223,17 +14214,17 @@
    unreachable
   end
   i32.const 1856
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   i32.const 1920
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=4
-  local.get $55
+  local.get $52
   call $~lib/string/String#localeCompare
   i32.const 1
   i32.eq
@@ -14247,17 +14238,17 @@
    unreachable
   end
   i32.const 1312
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   i32.const 1888
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=4
-  local.get $55
+  local.get $52
   call $~lib/string/String#localeCompare
   i32.const -1
   i32.eq
@@ -14271,17 +14262,17 @@
    unreachable
   end
   i32.const 1920
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   i32.const 1856
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=4
-  local.get $55
+  local.get $52
   call $~lib/string/String#localeCompare
   i32.const -1
   i32.eq
@@ -14295,17 +14286,17 @@
    unreachable
   end
   i32.const 688
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   i32.const 1280
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=4
-  local.get $55
+  local.get $52
   call $~lib/string/String#localeCompare
   i32.const -1
   i32.eq
@@ -14319,17 +14310,17 @@
    unreachable
   end
   i32.const 752
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   i32.const 688
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=4
-  local.get $55
+  local.get $52
   call $~lib/string/String#localeCompare
   i32.const 1
   i32.eq
@@ -14343,23 +14334,23 @@
    unreachable
   end
   i32.const 688
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=8
-  local.get $55
+  local.get $52
   call $~lib/string/String#trimStart
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   i32.const 688
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=4
-  local.get $55
+  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -14371,23 +14362,23 @@
    unreachable
   end
   i32.const 1952
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=8
-  local.get $55
+  local.get $52
   call $~lib/string/String#trimStart
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   i32.const 1952
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=4
-  local.get $55
+  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -14399,23 +14390,23 @@
    unreachable
   end
   i32.const 1984
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=8
-  local.get $55
+  local.get $52
   call $~lib/string/String#trimStart
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   i32.const 2032
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=4
-  local.get $55
+  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -14427,23 +14418,23 @@
    unreachable
   end
   i32.const 688
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=8
-  local.get $55
+  local.get $52
   call $~lib/string/String#trimEnd
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   i32.const 688
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=4
-  local.get $55
+  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -14455,23 +14446,23 @@
    unreachable
   end
   i32.const 1952
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=8
-  local.get $55
+  local.get $52
   call $~lib/string/String#trimEnd
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   i32.const 1952
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=4
-  local.get $55
+  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -14483,23 +14474,23 @@
    unreachable
   end
   i32.const 1984
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=8
-  local.get $55
+  local.get $52
   call $~lib/string/String#trimEnd
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   i32.const 2080
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=4
-  local.get $55
+  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -14511,23 +14502,23 @@
    unreachable
   end
   i32.const 688
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=8
-  local.get $55
+  local.get $52
   call $~lib/string/String#trim
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   i32.const 688
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=4
-  local.get $55
+  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -14539,23 +14530,23 @@
    unreachable
   end
   i32.const 1952
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=8
-  local.get $55
+  local.get $52
   call $~lib/string/String#trim
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   i32.const 1952
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=4
-  local.get $55
+  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -14567,23 +14558,23 @@
    unreachable
   end
   i32.const 1984
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=8
-  local.get $55
+  local.get $52
   call $~lib/string/String#trim
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   i32.const 1312
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=4
-  local.get $55
+  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -14597,14 +14588,14 @@
   block $~lib/builtins/bool.parse|inlined.0 (result i32)
    global.get $~lib/memory/__stack_pointer
    i32.const 2128
-   local.tee $6
+   local.tee $3
    i32.store offset=16
-   local.get $6
-   local.set $55
+   local.get $3
+   local.set $52
    global.get $~lib/memory/__stack_pointer
-   local.get $55
+   local.get $52
    i32.store
-   local.get $55
+   local.get $52
    call $~lib/util/string/strtob
    br $~lib/builtins/bool.parse|inlined.0
   end
@@ -14624,14 +14615,14 @@
   block $~lib/builtins/bool.parse|inlined.1 (result i32)
    global.get $~lib/memory/__stack_pointer
    i32.const 2176
-   local.tee $7
+   local.tee $4
    i32.store offset=20
-   local.get $7
-   local.set $55
+   local.get $4
+   local.set $52
    global.get $~lib/memory/__stack_pointer
-   local.get $55
+   local.get $52
    i32.store
-   local.get $55
+   local.get $52
    call $~lib/util/string/strtob
    br $~lib/builtins/bool.parse|inlined.1
   end
@@ -14651,14 +14642,14 @@
   block $~lib/builtins/bool.parse|inlined.2 (result i32)
    global.get $~lib/memory/__stack_pointer
    i32.const 2224
-   local.tee $8
+   local.tee $5
    i32.store offset=24
-   local.get $8
-   local.set $55
+   local.get $5
+   local.set $52
    global.get $~lib/memory/__stack_pointer
-   local.get $55
+   local.get $52
    i32.store
-   local.get $55
+   local.get $52
    call $~lib/util/string/strtob
    br $~lib/builtins/bool.parse|inlined.2
   end
@@ -14678,14 +14669,14 @@
   block $~lib/builtins/bool.parse|inlined.3 (result i32)
    global.get $~lib/memory/__stack_pointer
    i32.const 688
-   local.tee $9
+   local.tee $6
    i32.store offset=28
-   local.get $9
-   local.set $55
+   local.get $6
+   local.set $52
    global.get $~lib/memory/__stack_pointer
-   local.get $55
+   local.get $52
    i32.store
-   local.get $55
+   local.get $52
    call $~lib/util/string/strtob
    br $~lib/builtins/bool.parse|inlined.3
   end
@@ -14705,14 +14696,14 @@
   block $~lib/builtins/bool.parse|inlined.4 (result i32)
    global.get $~lib/memory/__stack_pointer
    i32.const 2272
-   local.tee $10
+   local.tee $7
    i32.store offset=32
-   local.get $10
-   local.set $55
+   local.get $7
+   local.set $52
    global.get $~lib/memory/__stack_pointer
-   local.get $55
+   local.get $52
    i32.store
-   local.get $55
+   local.get $52
    call $~lib/util/string/strtob
    br $~lib/builtins/bool.parse|inlined.4
   end
@@ -14732,14 +14723,14 @@
   block $~lib/builtins/bool.parse|inlined.5 (result i32)
    global.get $~lib/memory/__stack_pointer
    i32.const 2304
-   local.tee $11
+   local.tee $8
    i32.store offset=36
-   local.get $11
-   local.set $55
+   local.get $8
+   local.set $52
    global.get $~lib/memory/__stack_pointer
-   local.get $55
+   local.get $52
    i32.store
-   local.get $55
+   local.get $52
    call $~lib/util/string/strtob
    br $~lib/builtins/bool.parse|inlined.5
   end
@@ -14759,14 +14750,14 @@
   block $~lib/builtins/bool.parse|inlined.6 (result i32)
    global.get $~lib/memory/__stack_pointer
    i32.const 2336
-   local.tee $12
+   local.tee $9
    i32.store offset=40
-   local.get $12
-   local.set $55
+   local.get $9
+   local.set $52
    global.get $~lib/memory/__stack_pointer
-   local.get $55
+   local.get $52
    i32.store
-   local.get $55
+   local.get $52
    call $~lib/util/string/strtob
    br $~lib/builtins/bool.parse|inlined.6
   end
@@ -14784,11 +14775,11 @@
    unreachable
   end
   i32.const 2368
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   i32.const 0
   call $~lib/string/parseInt
   f64.const 0
@@ -14803,11 +14794,11 @@
    unreachable
   end
   i32.const 2400
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   i32.const 0
   call $~lib/string/parseInt
   f64.const 0
@@ -14822,11 +14813,11 @@
    unreachable
   end
   i32.const 2432
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   i32.const 0
   call $~lib/string/parseInt
   f64.const 1
@@ -14841,11 +14832,11 @@
    unreachable
   end
   i32.const 2464
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   i32.const 0
   call $~lib/string/parseInt
   f64.const 1
@@ -14860,11 +14851,11 @@
    unreachable
   end
   i32.const 2496
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   i32.const 0
   call $~lib/string/parseInt
   f64.const 5
@@ -14879,11 +14870,11 @@
    unreachable
   end
   i32.const 2528
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   i32.const 0
   call $~lib/string/parseInt
   f64.const 455
@@ -14898,11 +14889,11 @@
    unreachable
   end
   i32.const 2560
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   i32.const 0
   call $~lib/string/parseInt
   f64.const 3855
@@ -14917,11 +14908,11 @@
    unreachable
   end
   i32.const 2592
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   i32.const 0
   call $~lib/string/parseInt
   f64.const 3855
@@ -14936,11 +14927,11 @@
    unreachable
   end
   i32.const 2624
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   i32.const 0
   call $~lib/string/parseInt
   f64.const 11
@@ -14955,11 +14946,11 @@
    unreachable
   end
   i32.const 2656
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   i32.const 0
   call $~lib/string/parseInt
   f64.const 1
@@ -14974,11 +14965,11 @@
    unreachable
   end
   i32.const 2688
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   i32.const 0
   call $~lib/string/parseInt
   f64.const -123
@@ -14993,11 +14984,11 @@
    unreachable
   end
   i32.const 2720
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   i32.const 0
   call $~lib/string/parseInt
   f64.const 123
@@ -15012,11 +15003,11 @@
    unreachable
   end
   i32.const 2752
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   i32.const 0
   call $~lib/string/parseInt
   f64.const -12
@@ -15031,11 +15022,11 @@
    unreachable
   end
   i32.const 2368
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   i32.const 0
   call $~lib/string/parseInt
   f64.const 0
@@ -15050,11 +15041,11 @@
    unreachable
   end
   i32.const 2784
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   i32.const 0
   call $~lib/string/parseInt
   f64.const 0
@@ -15069,11 +15060,11 @@
    unreachable
   end
   i32.const 2816
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   i32.const 16
   call $~lib/string/parseInt
   f64.const 2833
@@ -15088,11 +15079,11 @@
    unreachable
   end
   i32.const 2848
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   i32.const 0
   call $~lib/string/parseInt
   f64.const 1
@@ -15107,11 +15098,11 @@
    unreachable
   end
   i32.const 2880
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   i32.const 0
   call $~lib/string/parseInt
   f64.const 1
@@ -15126,11 +15117,11 @@
    unreachable
   end
   i32.const 2912
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   i32.const 0
   call $~lib/string/parseInt
   f64.const 1
@@ -15146,15 +15137,15 @@
   end
   block $~lib/math/NativeMath.signbit|inlined.0 (result i32)
    i32.const 2944
-   local.set $55
+   local.set $52
    global.get $~lib/memory/__stack_pointer
-   local.get $55
+   local.get $52
    i32.store
-   local.get $55
+   local.get $52
    i32.const 0
    call $~lib/string/parseInt
-   local.set $13
-   local.get $13
+   local.set $10
+   local.get $10
    i64.reinterpret_f64
    i64.const 63
    i64.shr_u
@@ -15174,19 +15165,19 @@
    unreachable
   end
   i32.const 2976
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   i32.const 0
   call $~lib/string/parseInt
   i32.const 3024
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   i32.const 16
   call $~lib/string/parseInt
   f64.eq
@@ -15200,11 +15191,11 @@
    unreachable
   end
   i32.const 3056
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   i32.const 0
   call $~lib/string/parseInt
   f64.const 36893488147419103232
@@ -15219,11 +15210,11 @@
    unreachable
   end
   i32.const 3056
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   i32.const 13
   call $~lib/string/parseInt
   f64.const 5135857308667095285760
@@ -15238,11 +15229,11 @@
    unreachable
   end
   i32.const 3120
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   i32.const 10
   call $~lib/string/parseInt
   f64.const -1.e+24
@@ -15257,11 +15248,11 @@
    unreachable
   end
   i32.const 3200
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   i32.const 16
   call $~lib/string/parseInt
   f64.const 75557863725914323419136
@@ -15276,11 +15267,11 @@
    unreachable
   end
   i32.const 3264
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   i32.const 0
   call $~lib/string/parseInt
   f64.const 1
@@ -15295,11 +15286,11 @@
    unreachable
   end
   i32.const 3296
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   i32.const 0
   call $~lib/string/parseInt
   f64.const 2
@@ -15314,11 +15305,11 @@
    unreachable
   end
   i32.const 3344
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   i32.const 0
   call $~lib/string/parseInt
   f64.const 1
@@ -15333,11 +15324,11 @@
    unreachable
   end
   i32.const 3376
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   i32.const 0
   call $~lib/string/parseInt
   f64.const 2
@@ -15352,11 +15343,11 @@
    unreachable
   end
   i32.const 3424
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   i32.const 0
   call $~lib/string/parseInt
   f64.const 0
@@ -15371,11 +15362,11 @@
    unreachable
   end
   i32.const 3456
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   i32.const 0
   call $~lib/string/parseInt
   f64.const 1
@@ -15390,11 +15381,11 @@
    unreachable
   end
   i32.const 3488
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   i32.const 0
   call $~lib/string/parseInt
   f64.const 0
@@ -15409,15 +15400,15 @@
    unreachable
   end
   i32.const 688
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   i32.const 0
   call $~lib/string/parseInt
-  local.tee $14
-  local.get $14
+  local.tee $11
+  local.get $11
   f64.ne
   i32.eqz
   if
@@ -15429,15 +15420,15 @@
    unreachable
   end
   i32.const 3536
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   i32.const 0
   call $~lib/string/parseInt
-  local.tee $15
-  local.get $15
+  local.tee $12
+  local.get $12
   f64.ne
   i32.eqz
   if
@@ -15449,15 +15440,15 @@
    unreachable
   end
   i32.const 3568
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   i32.const 0
   call $~lib/string/parseInt
-  local.tee $16
-  local.get $16
+  local.tee $13
+  local.get $13
   f64.ne
   i32.eqz
   if
@@ -15469,15 +15460,15 @@
    unreachable
   end
   i32.const 1376
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   i32.const 37
   call $~lib/string/parseInt
-  local.tee $17
-  local.get $17
+  local.tee $14
+  local.get $14
   f64.ne
   i32.eqz
   if
@@ -15489,15 +15480,15 @@
    unreachable
   end
   i32.const 3600
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   i32.const 0
   call $~lib/string/parseInt
-  local.tee $18
-  local.get $18
+  local.tee $15
+  local.get $15
   f64.ne
   i32.eqz
   if
@@ -15509,15 +15500,15 @@
    unreachable
   end
   i32.const 3632
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   i32.const 0
   call $~lib/string/parseInt
-  local.tee $19
-  local.get $19
+  local.tee $16
+  local.get $16
   f64.ne
   i32.eqz
   if
@@ -15529,14 +15520,14 @@
    unreachable
   end
   i32.const 3632
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   call $~lib/number/F32.parseFloat
-  local.tee $20
-  local.get $20
+  local.tee $17
+  local.get $17
   f32.ne
   i32.eqz
   if
@@ -15548,14 +15539,14 @@
    unreachable
   end
   i32.const 3632
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   call $~lib/number/F64.parseFloat
-  local.tee $21
-  local.get $21
+  local.tee $18
+  local.get $18
   f64.ne
   i32.eqz
   if
@@ -15569,20 +15560,20 @@
   block $~lib/builtins/f32.parse|inlined.0 (result f32)
    global.get $~lib/memory/__stack_pointer
    i32.const 3632
-   local.tee $22
+   local.tee $19
    i32.store offset=44
-   local.get $22
-   local.set $55
+   local.get $19
+   local.set $52
    global.get $~lib/memory/__stack_pointer
-   local.get $55
+   local.get $52
    i32.store
-   local.get $55
+   local.get $52
    call $~lib/util/string/strtod
    f32.demote_f64
    br $~lib/builtins/f32.parse|inlined.0
   end
-  local.tee $23
-  local.get $23
+  local.tee $20
+  local.get $20
   f32.ne
   i32.eqz
   if
@@ -15596,19 +15587,19 @@
   block $~lib/builtins/f64.parse|inlined.0 (result f64)
    global.get $~lib/memory/__stack_pointer
    i32.const 3632
-   local.tee $24
+   local.tee $21
    i32.store offset=48
-   local.get $24
-   local.set $55
+   local.get $21
+   local.set $52
    global.get $~lib/memory/__stack_pointer
-   local.get $55
+   local.get $52
    i32.store
-   local.get $55
+   local.get $52
    call $~lib/util/string/strtod
    br $~lib/builtins/f64.parse|inlined.0
   end
-  local.tee $25
-  local.get $25
+  local.tee $22
+  local.get $22
   f64.ne
   i32.eqz
   if
@@ -15620,11 +15611,11 @@
    unreachable
   end
   i32.const 3856
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   i32.const 0
   call $~lib/number/I32.parseInt
   global.get $~lib/number/I32.MAX_VALUE
@@ -15641,17 +15632,17 @@
   block $~lib/builtins/i32.parse|inlined.0 (result i32)
    global.get $~lib/memory/__stack_pointer
    i32.const 3856
-   local.tee $26
+   local.tee $23
    i32.store offset=52
    i32.const 0
-   local.set $27
-   local.get $26
-   local.set $55
+   local.set $24
+   local.get $23
+   local.set $52
    global.get $~lib/memory/__stack_pointer
-   local.get $55
+   local.get $52
    i32.store
-   local.get $55
-   local.get $27
+   local.get $52
+   local.get $24
    call $~lib/util/string/strtol<i32>
    br $~lib/builtins/i32.parse|inlined.0
   end
@@ -15667,11 +15658,11 @@
    unreachable
   end
   i32.const 3904
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   i32.const 0
   call $~lib/number/I64.parseInt
   global.get $~lib/number/I64.MAX_VALUE
@@ -15688,17 +15679,17 @@
   block $~lib/builtins/i64.parse|inlined.0 (result i64)
    global.get $~lib/memory/__stack_pointer
    i32.const 3904
-   local.tee $28
+   local.tee $25
    i32.store offset=56
    i32.const 0
-   local.set $29
-   local.get $28
-   local.set $55
+   local.set $26
+   local.get $25
+   local.set $52
    global.get $~lib/memory/__stack_pointer
-   local.get $55
+   local.get $52
    i32.store
-   local.get $55
-   local.get $29
+   local.get $52
+   local.get $26
    call $~lib/util/string/strtol<i64>
    br $~lib/builtins/i64.parse|inlined.0
   end
@@ -15714,11 +15705,11 @@
    unreachable
   end
   i32.const 2368
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   call $~lib/string/parseFloat
   f64.const 0
   f64.eq
@@ -15732,11 +15723,11 @@
    unreachable
   end
   i32.const 2432
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   call $~lib/string/parseFloat
   f64.const 1
   f64.eq
@@ -15750,11 +15741,11 @@
    unreachable
   end
   i32.const 3968
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   call $~lib/string/parseFloat
   f64.const 1
   f64.eq
@@ -15768,11 +15759,11 @@
    unreachable
   end
   i32.const 4000
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   call $~lib/string/parseFloat
   f64.const 1
   f64.eq
@@ -15786,11 +15777,11 @@
    unreachable
   end
   i32.const 4032
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   call $~lib/string/parseFloat
   f64.const 1e-05
   f64.eq
@@ -15804,11 +15795,11 @@
    unreachable
   end
   i32.const 4064
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   call $~lib/string/parseFloat
   f64.const -1e-05
   f64.eq
@@ -15822,11 +15813,11 @@
    unreachable
   end
   i32.const 4096
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   call $~lib/string/parseFloat
   f64.const -3e-23
   f64.eq
@@ -15840,11 +15831,11 @@
    unreachable
   end
   i32.const 4144
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   call $~lib/string/parseFloat
   f64.const 3e21
   f64.eq
@@ -15858,11 +15849,11 @@
    unreachable
   end
   i32.const 4192
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   call $~lib/string/parseFloat
   f64.const 0.1
   f64.eq
@@ -15876,11 +15867,11 @@
    unreachable
   end
   i32.const 4224
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   call $~lib/string/parseFloat
   f64.const 0.1
   f64.eq
@@ -15894,11 +15885,11 @@
    unreachable
   end
   i32.const 4256
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   call $~lib/string/parseFloat
   f64.const 0.1
   f64.eq
@@ -15912,11 +15903,11 @@
    unreachable
   end
   i32.const 4288
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   call $~lib/string/parseFloat
   f64.const 0.25
   f64.eq
@@ -15930,11 +15921,11 @@
    unreachable
   end
   i32.const 4320
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   call $~lib/string/parseFloat
   f64.const 1e3
   f64.eq
@@ -15948,11 +15939,11 @@
    unreachable
   end
   i32.const 4352
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   call $~lib/string/parseFloat
   f64.const 1e-10
   f64.eq
@@ -15966,11 +15957,11 @@
    unreachable
   end
   i32.const 4400
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   call $~lib/string/parseFloat
   f64.const 1e-30
   f64.eq
@@ -15984,11 +15975,11 @@
    unreachable
   end
   i32.const 4448
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   call $~lib/string/parseFloat
   f64.const 1e-323
   f64.eq
@@ -16002,11 +15993,11 @@
    unreachable
   end
   i32.const 4496
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   call $~lib/string/parseFloat
   f64.const 0
   f64.eq
@@ -16020,11 +16011,11 @@
    unreachable
   end
   i32.const 4544
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   call $~lib/string/parseFloat
   f64.const 1.e+308
   f64.eq
@@ -16038,11 +16029,11 @@
    unreachable
   end
   i32.const 4576
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   call $~lib/string/parseFloat
   f64.const inf
   f64.eq
@@ -16056,14 +16047,14 @@
    unreachable
   end
   i32.const 688
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   call $~lib/string/parseFloat
-  local.tee $30
-  local.get $30
+  local.tee $27
+  local.get $27
   f64.ne
   i32.eqz
   if
@@ -16075,11 +16066,11 @@
    unreachable
   end
   i32.const 4608
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   call $~lib/string/parseFloat
   f64.const 0.1
   f64.eq
@@ -16093,11 +16084,11 @@
    unreachable
   end
   i32.const 4656
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   call $~lib/string/parseFloat
   f64.const 1e-10
   f64.eq
@@ -16111,11 +16102,11 @@
    unreachable
   end
   i32.const 4704
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   call $~lib/string/parseFloat
   f64.const 10
   f64.eq
@@ -16129,11 +16120,11 @@
    unreachable
   end
   i32.const 4752
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   call $~lib/string/parseFloat
   f64.const 1
   f64.eq
@@ -16147,11 +16138,11 @@
    unreachable
   end
   i32.const 4784
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   call $~lib/string/parseFloat
   f64.const 1
   f64.eq
@@ -16165,11 +16156,11 @@
    unreachable
   end
   i32.const 4816
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   call $~lib/string/parseFloat
   f64.const 10
   f64.eq
@@ -16183,11 +16174,11 @@
    unreachable
   end
   i32.const 4864
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   call $~lib/string/parseFloat
   f64.const 123456789
   f64.eq
@@ -16201,11 +16192,11 @@
    unreachable
   end
   i32.const 4912
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   call $~lib/string/parseFloat
   f64.const 1
   f64.eq
@@ -16219,11 +16210,11 @@
    unreachable
   end
   i32.const 4960
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   call $~lib/string/parseFloat
   f64.const 1e-60
   f64.eq
@@ -16237,11 +16228,11 @@
    unreachable
   end
   i32.const 4992
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   call $~lib/string/parseFloat
   f64.const 1.e+60
   f64.eq
@@ -16255,11 +16246,11 @@
    unreachable
   end
   i32.const 5024
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   call $~lib/string/parseFloat
   f64.const 123.4
   f64.eq
@@ -16273,11 +16264,11 @@
    unreachable
   end
   i32.const 5056
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   call $~lib/string/parseFloat
   f64.const 1
   f64.eq
@@ -16291,11 +16282,11 @@
    unreachable
   end
   i32.const 5088
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   call $~lib/string/parseFloat
   f64.const -1.1
   f64.eq
@@ -16309,11 +16300,11 @@
    unreachable
   end
   i32.const 5136
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   call $~lib/string/parseFloat
   f64.const 10
   f64.eq
@@ -16327,11 +16318,11 @@
    unreachable
   end
   i32.const 5184
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   call $~lib/string/parseFloat
   f64.const 10
   f64.eq
@@ -16345,11 +16336,11 @@
    unreachable
   end
   i32.const 5232
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   call $~lib/string/parseFloat
   f64.const 0.022
   f64.eq
@@ -16363,11 +16354,11 @@
    unreachable
   end
   i32.const 5280
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   call $~lib/string/parseFloat
   f64.const 11
   f64.eq
@@ -16381,11 +16372,11 @@
    unreachable
   end
   i32.const 2784
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   call $~lib/string/parseFloat
   f64.const 0
   f64.eq
@@ -16399,11 +16390,11 @@
    unreachable
   end
   i32.const 5312
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   call $~lib/string/parseFloat
   f64.const 0
   f64.eq
@@ -16417,11 +16408,11 @@
    unreachable
   end
   i32.const 5344
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   call $~lib/string/parseFloat
   f64.const 0
   f64.eq
@@ -16435,11 +16426,11 @@
    unreachable
   end
   i32.const 5376
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   call $~lib/string/parseFloat
   f64.const 1.1
   f64.eq
@@ -16453,11 +16444,11 @@
    unreachable
   end
   i32.const 5408
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   call $~lib/string/parseFloat
   f64.const -1.1
   f64.eq
@@ -16471,11 +16462,11 @@
    unreachable
   end
   i32.const 5440
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   call $~lib/string/parseFloat
   f64.const -1.1
   f64.eq
@@ -16489,11 +16480,11 @@
    unreachable
   end
   i32.const 5472
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   call $~lib/string/parseFloat
   f64.const -1.1
   f64.eq
@@ -16507,11 +16498,11 @@
    unreachable
   end
   i32.const 5504
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   call $~lib/string/parseFloat
   f64.const -1.1
   f64.eq
@@ -16525,11 +16516,11 @@
    unreachable
   end
   i32.const 5536
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   call $~lib/string/parseFloat
   f64.const 0
   f64.eq
@@ -16543,11 +16534,11 @@
    unreachable
   end
   i32.const 5568
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   call $~lib/string/parseFloat
   f64.const 0
   f64.eq
@@ -16561,11 +16552,11 @@
    unreachable
   end
   i32.const 5600
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   call $~lib/string/parseFloat
   f64.const 1
   f64.eq
@@ -16579,11 +16570,11 @@
    unreachable
   end
   i32.const 5632
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   call $~lib/string/parseFloat
   f64.const 0
   f64.eq
@@ -16597,11 +16588,11 @@
    unreachable
   end
   i32.const 5664
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   call $~lib/string/parseFloat
   f64.const 0
   f64.eq
@@ -16615,11 +16606,11 @@
    unreachable
   end
   i32.const 5696
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   call $~lib/string/parseFloat
   f64.const 10
   f64.eq
@@ -16633,11 +16624,11 @@
    unreachable
   end
   i32.const 5728
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   call $~lib/string/parseFloat
   f64.const 10
   f64.eq
@@ -16651,11 +16642,11 @@
    unreachable
   end
   i32.const 5776
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   call $~lib/string/parseFloat
   f64.const 0
   f64.eq
@@ -16669,11 +16660,11 @@
    unreachable
   end
   i32.const 5808
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   call $~lib/string/parseFloat
   f64.const 1
   f64.eq
@@ -16687,11 +16678,11 @@
    unreachable
   end
   i32.const 5840
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   call $~lib/string/parseFloat
   f64.const 0.1
   f64.eq
@@ -16705,11 +16696,11 @@
    unreachable
   end
   i32.const 5872
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   call $~lib/string/parseFloat
   f64.const 1
   f64.eq
@@ -16723,11 +16714,11 @@
    unreachable
   end
   i32.const 5904
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   call $~lib/string/parseFloat
   f64.const 10
   f64.eq
@@ -16741,11 +16732,11 @@
    unreachable
   end
   i32.const 5936
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   call $~lib/string/parseFloat
   f64.const 1
   f64.eq
@@ -16759,11 +16750,11 @@
    unreachable
   end
   i32.const 5968
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   call $~lib/string/parseFloat
   f64.const 0.1
   f64.eq
@@ -16777,11 +16768,11 @@
    unreachable
   end
   i32.const 6000
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   call $~lib/string/parseFloat
   f64.const 0.01
   f64.eq
@@ -16795,11 +16786,11 @@
    unreachable
   end
   i32.const 6048
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   call $~lib/string/parseFloat
   f64.const 0
   f64.eq
@@ -16813,11 +16804,11 @@
    unreachable
   end
   i32.const 6080
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   call $~lib/string/parseFloat
   f64.const 0
   f64.eq
@@ -16831,11 +16822,11 @@
    unreachable
   end
   i32.const 6112
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   call $~lib/string/parseFloat
   f64.const 0
   f64.eq
@@ -16849,11 +16840,11 @@
    unreachable
   end
   i32.const 6144
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   call $~lib/string/parseFloat
   f64.const 0.1
   f64.eq
@@ -16867,11 +16858,11 @@
    unreachable
   end
   i32.const 6176
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   call $~lib/string/parseFloat
   f64.const 0
   f64.eq
@@ -16885,11 +16876,11 @@
    unreachable
   end
   i32.const 6208
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   call $~lib/string/parseFloat
   f64.const 0
   f64.eq
@@ -16903,11 +16894,11 @@
    unreachable
   end
   i32.const 6240
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   call $~lib/string/parseFloat
   f64.const 1
   f64.eq
@@ -16921,11 +16912,11 @@
    unreachable
   end
   i32.const 6272
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   call $~lib/string/parseFloat
   f64.const 0.1
   f64.eq
@@ -16939,11 +16930,11 @@
    unreachable
   end
   i32.const 6304
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   call $~lib/string/parseFloat
   f64.const 0
   f64.eq
@@ -16957,11 +16948,11 @@
    unreachable
   end
   i32.const 6336
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   call $~lib/string/parseFloat
   f64.const 0
   call $~lib/object/Object.is<f64>
@@ -16977,11 +16968,11 @@
    unreachable
   end
   i32.const 6368
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   call $~lib/string/parseFloat
   f64.const -0
   call $~lib/object/Object.is<f64>
@@ -16997,11 +16988,11 @@
    unreachable
   end
   i32.const 6400
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   call $~lib/string/parseFloat
   f64.const 0
   call $~lib/object/Object.is<f64>
@@ -17017,11 +17008,11 @@
    unreachable
   end
   i32.const 2944
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   call $~lib/string/parseFloat
   f64.const -0
   call $~lib/object/Object.is<f64>
@@ -17037,11 +17028,11 @@
    unreachable
   end
   i32.const 6432
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   call $~lib/string/parseFloat
   f64.const -0
   call $~lib/object/Object.is<f64>
@@ -17057,14 +17048,14 @@
    unreachable
   end
   i32.const 3568
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   call $~lib/string/parseFloat
-  local.tee $31
-  local.get $31
+  local.tee $28
+  local.get $28
   f64.ne
   i32.eqz
   if
@@ -17076,14 +17067,14 @@
    unreachable
   end
   i32.const 3536
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   call $~lib/string/parseFloat
-  local.tee $32
-  local.get $32
+  local.tee $29
+  local.get $29
   f64.ne
   i32.eqz
   if
@@ -17095,14 +17086,14 @@
    unreachable
   end
   i32.const 6480
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   call $~lib/string/parseFloat
-  local.tee $33
-  local.get $33
+  local.tee $30
+  local.get $30
   f64.ne
   i32.eqz
   if
@@ -17114,14 +17105,14 @@
    unreachable
   end
   i32.const 6512
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   call $~lib/string/parseFloat
-  local.tee $34
-  local.get $34
+  local.tee $31
+  local.get $31
   f64.ne
   i32.eqz
   if
@@ -17133,14 +17124,14 @@
    unreachable
   end
   i32.const 6544
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   call $~lib/string/parseFloat
-  local.tee $35
-  local.get $35
+  local.tee $32
+  local.get $32
   f64.ne
   i32.eqz
   if
@@ -17152,14 +17143,14 @@
    unreachable
   end
   i32.const 6576
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   call $~lib/string/parseFloat
-  local.tee $36
-  local.get $36
+  local.tee $33
+  local.get $33
   f64.ne
   i32.eqz
   if
@@ -17171,14 +17162,14 @@
    unreachable
   end
   i32.const 6608
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   call $~lib/string/parseFloat
-  local.tee $37
-  local.get $37
+  local.tee $34
+  local.get $34
   f64.ne
   i32.eqz
   if
@@ -17190,14 +17181,14 @@
    unreachable
   end
   i32.const 6640
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   call $~lib/string/parseFloat
-  local.tee $38
-  local.get $38
+  local.tee $35
+  local.get $35
   f64.ne
   i32.eqz
   if
@@ -17209,14 +17200,14 @@
    unreachable
   end
   i32.const 6672
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   call $~lib/string/parseFloat
-  local.tee $39
-  local.get $39
+  local.tee $36
+  local.get $36
   f64.ne
   i32.eqz
   if
@@ -17228,14 +17219,14 @@
    unreachable
   end
   i32.const 6704
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   call $~lib/string/parseFloat
-  local.tee $40
-  local.get $40
+  local.tee $37
+  local.get $37
   f64.ne
   i32.eqz
   if
@@ -17247,14 +17238,14 @@
    unreachable
   end
   i32.const 6736
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   call $~lib/string/parseFloat
-  local.tee $41
-  local.get $41
+  local.tee $38
+  local.get $38
   f64.ne
   i32.eqz
   if
@@ -17266,14 +17257,14 @@
    unreachable
   end
   i32.const 6768
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   call $~lib/string/parseFloat
-  local.tee $42
-  local.get $42
+  local.tee $39
+  local.get $39
   f64.ne
   i32.eqz
   if
@@ -17285,14 +17276,14 @@
    unreachable
   end
   i32.const 6800
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   call $~lib/string/parseFloat
-  local.tee $43
-  local.get $43
+  local.tee $40
+  local.get $40
   f64.ne
   i32.eqz
   if
@@ -17304,14 +17295,14 @@
    unreachable
   end
   i32.const 6832
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   call $~lib/string/parseFloat
-  local.tee $44
-  local.get $44
+  local.tee $41
+  local.get $41
   f64.ne
   i32.eqz
   if
@@ -17323,14 +17314,14 @@
    unreachable
   end
   i32.const 6864
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   call $~lib/string/parseFloat
-  local.tee $45
-  local.get $45
+  local.tee $42
+  local.get $42
   f64.ne
   i32.eqz
   if
@@ -17342,14 +17333,14 @@
    unreachable
   end
   i32.const 2336
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   call $~lib/string/parseFloat
-  local.tee $46
-  local.get $46
+  local.tee $43
+  local.get $43
   f64.ne
   i32.eqz
   if
@@ -17361,11 +17352,11 @@
    unreachable
   end
   i32.const 6896
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   call $~lib/string/parseFloat
   f64.const 1e22
   f64.eq
@@ -17379,11 +17370,11 @@
    unreachable
   end
   i32.const 6928
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   call $~lib/string/parseFloat
   f64.const 1e-22
   f64.eq
@@ -17397,11 +17388,11 @@
    unreachable
   end
   i32.const 6960
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   call $~lib/string/parseFloat
   f64.const 1.e+23
   f64.eq
@@ -17415,11 +17406,11 @@
    unreachable
   end
   i32.const 6992
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   call $~lib/string/parseFloat
   f64.const 1e-23
   f64.eq
@@ -17433,11 +17424,11 @@
    unreachable
   end
   i32.const 7024
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   call $~lib/string/parseFloat
   f64.const 1.e+37
   f64.eq
@@ -17451,11 +17442,11 @@
    unreachable
   end
   i32.const 7056
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   call $~lib/string/parseFloat
   f64.const 1e-37
   f64.eq
@@ -17469,11 +17460,11 @@
    unreachable
   end
   i32.const 7088
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   call $~lib/string/parseFloat
   f64.const 1.e+38
   f64.eq
@@ -17487,11 +17478,11 @@
    unreachable
   end
   i32.const 7120
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   call $~lib/string/parseFloat
   f64.const 1e-38
   f64.eq
@@ -17505,11 +17496,11 @@
    unreachable
   end
   i32.const 7152
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   call $~lib/string/parseFloat
   global.get $~lib/builtins/f64.EPSILON
   f64.eq
@@ -17523,11 +17514,11 @@
    unreachable
   end
   i32.const 7216
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   call $~lib/string/parseFloat
   global.get $~lib/builtins/f64.MAX_VALUE
   f64.eq
@@ -17541,11 +17532,11 @@
    unreachable
   end
   i32.const 7296
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   call $~lib/string/parseFloat
   global.get $~lib/builtins/f64.MIN_VALUE
   f64.eq
@@ -17559,11 +17550,11 @@
    unreachable
   end
   i32.const 7328
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   call $~lib/string/parseFloat
   f64.const 1.e+308
   f64.eq
@@ -17577,11 +17568,11 @@
    unreachable
   end
   i32.const 7376
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   call $~lib/string/parseFloat
   f64.const 1
   f64.eq
@@ -17595,11 +17586,11 @@
    unreachable
   end
   i32.const 7520
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   call $~lib/string/parseFloat
   f64.const 0
   f64.eq
@@ -17613,11 +17604,11 @@
    unreachable
   end
   i32.const 7568
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   call $~lib/string/parseFloat
   f64.const inf
   f64.eq
@@ -17631,11 +17622,11 @@
    unreachable
   end
   i32.const 7616
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   call $~lib/string/parseFloat
   f64.const 0
   f64.eq
@@ -17649,11 +17640,11 @@
    unreachable
   end
   i32.const 7664
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   call $~lib/string/parseFloat
   f64.const inf
   f64.neg
@@ -17668,11 +17659,11 @@
    unreachable
   end
   i32.const 7712
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   call $~lib/string/parseFloat
   f64.const 0
   f64.eq
@@ -17686,11 +17677,11 @@
    unreachable
   end
   i32.const 7760
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   call $~lib/string/parseFloat
   f64.const inf
   f64.eq
@@ -17704,11 +17695,11 @@
    unreachable
   end
   i32.const 7808
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   call $~lib/string/parseFloat
   f64.const inf
   f64.eq
@@ -17722,11 +17713,11 @@
    unreachable
   end
   i32.const 7840
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   call $~lib/string/parseFloat
   f64.const inf
   f64.eq
@@ -17740,11 +17731,11 @@
    unreachable
   end
   i32.const 7888
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   call $~lib/string/parseFloat
   f64.const inf
   f64.eq
@@ -17758,11 +17749,11 @@
    unreachable
   end
   i32.const 7936
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   call $~lib/string/parseFloat
   f64.const inf
   f64.neg
@@ -17777,11 +17768,11 @@
    unreachable
   end
   i32.const 7984
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   call $~lib/string/parseFloat
   f64.const inf
   f64.eq
@@ -17795,11 +17786,11 @@
    unreachable
   end
   i32.const 8032
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   call $~lib/string/parseFloat
   f64.const inf
   f64.eq
@@ -17813,14 +17804,14 @@
    unreachable
   end
   i32.const 8080
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   call $~lib/string/parseFloat
-  local.tee $47
-  local.get $47
+  local.tee $44
+  local.get $44
   f64.ne
   i32.eqz
   if
@@ -17832,14 +17823,14 @@
    unreachable
   end
   i32.const 8112
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   call $~lib/string/parseFloat
-  local.tee $48
-  local.get $48
+  local.tee $45
+  local.get $45
   f64.ne
   i32.eqz
   if
@@ -17851,14 +17842,14 @@
    unreachable
   end
   i32.const 8160
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   call $~lib/string/parseFloat
-  local.tee $49
-  local.get $49
+  local.tee $46
+  local.get $46
   f64.ne
   i32.eqz
   if
@@ -17870,11 +17861,11 @@
    unreachable
   end
   i32.const 8208
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   call $~lib/string/parseFloat
   f64.const 0
   f64.eq
@@ -17888,11 +17879,11 @@
    unreachable
   end
   i32.const 8400
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   call $~lib/string/parseFloat
   global.get $std/string/Ox1p_1073
   f64.eq
@@ -17906,11 +17897,11 @@
    unreachable
   end
   i32.const 8592
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   call $~lib/string/parseFloat
   global.get $std/string/Ox1_0000000000001p_1022
   f64.eq
@@ -17924,59 +17915,59 @@
    unreachable
   end
   i32.const 8784
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=72
-  local.get $55
+  local.get $52
   i32.const 8944
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=76
-  local.get $55
+  local.get $52
   call $~lib/string/String.__concat
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=64
-  local.get $55
+  local.get $52
   i32.const 9104
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=68
-  local.get $55
+  local.get $52
   call $~lib/string/String.__concat
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=12
-  local.get $55
+  local.get $52
   i32.const 9264
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=60
-  local.get $55
+  local.get $52
   call $~lib/string/String.__concat
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=4
-  local.get $55
+  local.get $52
   i32.const 9424
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=8
-  local.get $55
+  local.get $52
   call $~lib/string/String.__concat
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   call $~lib/string/parseFloat
   global.get $~lib/builtins/f64.MAX_VALUE
   f64.eq
@@ -17990,11 +17981,11 @@
    unreachable
   end
   i32.const 9584
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   call $~lib/string/parseFloat
   f64.const 9.753531888799502e-104
   f64.eq
@@ -18008,11 +17999,11 @@
    unreachable
   end
   i32.const 9696
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   call $~lib/string/parseFloat
   f64.const 0.5961860348131807
   f64.eq
@@ -18026,11 +18017,11 @@
    unreachable
   end
   i32.const 9808
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   call $~lib/string/parseFloat
   f64.const 0.18150131692180388
   f64.eq
@@ -18044,11 +18035,11 @@
    unreachable
   end
   i32.const 9920
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   call $~lib/string/parseFloat
   f64.const 0.42070823575344535
   f64.eq
@@ -18062,11 +18053,11 @@
    unreachable
   end
   i32.const 10032
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   call $~lib/string/parseFloat
   f64.const 0.6654686306516261
   f64.eq
@@ -18080,11 +18071,11 @@
    unreachable
   end
   i32.const 10144
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   call $~lib/string/parseFloat
   f64.const 0.6101852922970868
   f64.eq
@@ -18098,11 +18089,11 @@
    unreachable
   end
   i32.const 10256
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   call $~lib/string/parseFloat
   f64.const 0.7696695208236968
   f64.eq
@@ -18116,11 +18107,11 @@
    unreachable
   end
   i32.const 10368
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   call $~lib/string/parseFloat
   f64.const 0.25050653222286823
   f64.eq
@@ -18134,11 +18125,11 @@
    unreachable
   end
   i32.const 10480
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   call $~lib/string/parseFloat
   f64.const 0.2740037230228005
   f64.eq
@@ -18152,11 +18143,11 @@
    unreachable
   end
   i32.const 10592
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   call $~lib/string/parseFloat
   f64.const 0.20723093500497428
   f64.eq
@@ -18170,11 +18161,11 @@
    unreachable
   end
   i32.const 10704
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   call $~lib/string/parseFloat
   f64.const 7.900280238081605
   f64.eq
@@ -18188,11 +18179,11 @@
    unreachable
   end
   i32.const 10816
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   call $~lib/string/parseFloat
   f64.const 98.22860653737297
   f64.eq
@@ -18206,11 +18197,11 @@
    unreachable
   end
   i32.const 10928
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   call $~lib/string/parseFloat
   f64.const 746.894972319037
   f64.eq
@@ -18224,11 +18215,11 @@
    unreachable
   end
   i32.const 11040
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   call $~lib/string/parseFloat
   f64.const 1630.2683202827284
   f64.eq
@@ -18242,11 +18233,11 @@
    unreachable
   end
   i32.const 11152
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   call $~lib/string/parseFloat
   f64.const 46371.68629719171
   f64.eq
@@ -18260,11 +18251,11 @@
    unreachable
   end
   i32.const 11264
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   call $~lib/string/parseFloat
   f64.const 653780.5944497711
   f64.eq
@@ -18278,11 +18269,11 @@
    unreachable
   end
   i32.const 11376
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   call $~lib/string/parseFloat
   f64.const 234632.43565024371
   f64.eq
@@ -18296,11 +18287,11 @@
    unreachable
   end
   i32.const 11488
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   call $~lib/string/parseFloat
   f64.const 97094817.16420048
   f64.eq
@@ -18314,11 +18305,11 @@
    unreachable
   end
   i32.const 11600
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   call $~lib/string/parseFloat
   f64.const 499690852.20518744
   f64.eq
@@ -18332,11 +18323,11 @@
    unreachable
   end
   i32.const 11712
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   call $~lib/string/parseFloat
   f64.const 7925201200557245595648
   f64.eq
@@ -18350,11 +18341,11 @@
    unreachable
   end
   i32.const 11824
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   call $~lib/string/parseFloat
   f64.const 6096564585983177528398588e5
   f64.eq
@@ -18368,11 +18359,11 @@
    unreachable
   end
   i32.const 11936
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   call $~lib/string/parseFloat
   f64.const 4800416117477028695992383e42
   f64.eq
@@ -18386,11 +18377,11 @@
    unreachable
   end
   i32.const 12048
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   call $~lib/string/parseFloat
   f64.const 8524829079817968137287277e80
   f64.eq
@@ -18404,11 +18395,11 @@
    unreachable
   end
   i32.const 12160
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   call $~lib/string/parseFloat
   f64.const 3271239291709782092398754e243
   f64.eq
@@ -18422,14 +18413,14 @@
    unreachable
   end
   i32.const 12272
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   call $~lib/string/parseFloat
-  local.tee $50
-  local.get $50
+  local.tee $47
+  local.get $47
   f64.ne
   i32.eqz
   if
@@ -18441,11 +18432,11 @@
    unreachable
   end
   i32.const 12304
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   call $~lib/string/parseFloat
   f64.const 0.1
   f64.eq
@@ -18460,32 +18451,32 @@
   end
   global.get $~lib/memory/__stack_pointer
   i32.const 784
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   i32.const 12336
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=4
-  local.get $55
+  local.get $52
   call $~lib/string/String.__concat
-  local.tee $51
+  local.tee $48
   i32.store offset=80
-  local.get $51
-  local.set $55
+  local.get $48
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   i32.const 12368
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=4
-  local.get $55
+  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -18496,18 +18487,18 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $51
-  local.set $55
+  local.get $48
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   i32.const 784
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=4
-  local.get $55
+  local.get $52
   call $~lib/string/String.__ne
   i32.eqz
   if
@@ -18519,17 +18510,17 @@
    unreachable
   end
   i32.const 688
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   i32.const 688
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=4
-  local.get $55
+  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -18541,11 +18532,11 @@
    unreachable
   end
   global.get $std/string/nullStr
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   i32.const 0
   call $~lib/string/String.__eq
   i32.eqz
@@ -18558,17 +18549,17 @@
    unreachable
   end
   i32.const 688
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   global.get $std/string/nullStr
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=4
-  local.get $55
+  local.get $52
   call $~lib/string/String.__ne
   i32.eqz
   if
@@ -18580,17 +18571,17 @@
    unreachable
   end
   global.get $std/string/nullStr
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   i32.const 688
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=4
-  local.get $55
+  local.get $52
   call $~lib/string/String.__ne
   i32.eqz
   if
@@ -18602,17 +18593,17 @@
    unreachable
   end
   i32.const 784
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   i32.const 12336
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=4
-  local.get $55
+  local.get $52
   call $~lib/string/String.__ne
   i32.eqz
   if
@@ -18624,17 +18615,17 @@
    unreachable
   end
   i32.const 784
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   i32.const 784
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=4
-  local.get $55
+  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -18646,17 +18637,17 @@
    unreachable
   end
   i32.const 12400
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   i32.const 12432
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=4
-  local.get $55
+  local.get $52
   call $~lib/string/String.__ne
   i32.eqz
   if
@@ -18668,17 +18659,17 @@
    unreachable
   end
   i32.const 12400
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   i32.const 12400
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=4
-  local.get $55
+  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -18690,17 +18681,17 @@
    unreachable
   end
   i32.const 12464
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   i32.const 12496
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=4
-  local.get $55
+  local.get $52
   call $~lib/string/String.__ne
   i32.eqz
   if
@@ -18712,17 +18703,17 @@
    unreachable
   end
   i32.const 12528
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   i32.const 12560
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=4
-  local.get $55
+  local.get $52
   call $~lib/string/String.__ne
   i32.eqz
   if
@@ -18734,17 +18725,17 @@
    unreachable
   end
   i32.const 12592
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   i32.const 12592
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=4
-  local.get $55
+  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -18756,17 +18747,17 @@
    unreachable
   end
   i32.const 12592
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   i32.const 12640
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=4
-  local.get $55
+  local.get $52
   call $~lib/string/String.__ne
   i32.eqz
   if
@@ -18778,17 +18769,17 @@
    unreachable
   end
   i32.const 12688
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   i32.const 12736
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=4
-  local.get $55
+  local.get $52
   call $~lib/string/String.__ne
   i32.eqz
   if
@@ -18800,17 +18791,17 @@
    unreachable
   end
   i32.const 12336
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   i32.const 784
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=4
-  local.get $55
+  local.get $52
   call $~lib/string/String.__gt
   i32.eqz
   if
@@ -18822,17 +18813,17 @@
    unreachable
   end
   i32.const 12784
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   i32.const 784
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=4
-  local.get $55
+  local.get $52
   call $~lib/string/String.__gt
   i32.eqz
   if
@@ -18844,17 +18835,17 @@
    unreachable
   end
   i32.const 12784
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   i32.const 12816
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=4
-  local.get $55
+  local.get $52
   call $~lib/string/String.__gte
   i32.eqz
   if
@@ -18866,17 +18857,17 @@
    unreachable
   end
   i32.const 12784
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   i32.const 12368
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=4
-  local.get $55
+  local.get $52
   call $~lib/string/String.__gt
   i32.eqz
   if
@@ -18888,17 +18879,17 @@
    unreachable
   end
   i32.const 12784
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   i32.const 12368
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=4
-  local.get $55
+  local.get $52
   call $~lib/string/String.__lt
   i32.eqz
   i32.eqz
@@ -18911,17 +18902,17 @@
    unreachable
   end
   i32.const 1312
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   i32.const 688
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=4
-  local.get $55
+  local.get $52
   call $~lib/string/String.__gt
   i32.eqz
   if
@@ -18933,17 +18924,17 @@
    unreachable
   end
   i32.const 688
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   i32.const 1312
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=4
-  local.get $55
+  local.get $52
   call $~lib/string/String.__lt
   i32.eqz
   if
@@ -18955,17 +18946,17 @@
    unreachable
   end
   i32.const 1312
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   i32.const 688
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=4
-  local.get $55
+  local.get $52
   call $~lib/string/String.__gte
   i32.eqz
   if
@@ -18977,17 +18968,17 @@
    unreachable
   end
   i32.const 688
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   i32.const 1312
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=4
-  local.get $55
+  local.get $52
   call $~lib/string/String.__lte
   i32.eqz
   if
@@ -18999,17 +18990,17 @@
    unreachable
   end
   i32.const 1312
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   i32.const 688
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=4
-  local.get $55
+  local.get $52
   call $~lib/string/String.__lt
   i32.eqz
   i32.eqz
@@ -19022,17 +19013,17 @@
    unreachable
   end
   i32.const 688
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   i32.const 1312
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=4
-  local.get $55
+  local.get $52
   call $~lib/string/String.__gt
   i32.eqz
   i32.eqz
@@ -19045,17 +19036,17 @@
    unreachable
   end
   i32.const 688
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   i32.const 688
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=4
-  local.get $55
+  local.get $52
   call $~lib/string/String.__lt
   i32.eqz
   i32.eqz
@@ -19068,17 +19059,17 @@
    unreachable
   end
   i32.const 688
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   i32.const 688
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=4
-  local.get $55
+  local.get $52
   call $~lib/string/String.__gt
   i32.eqz
   i32.eqz
@@ -19091,17 +19082,17 @@
    unreachable
   end
   i32.const 688
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   i32.const 688
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=4
-  local.get $55
+  local.get $52
   call $~lib/string/String.__gte
   i32.eqz
   if
@@ -19113,17 +19104,17 @@
    unreachable
   end
   i32.const 688
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   i32.const 688
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=4
-  local.get $55
+  local.get $52
   call $~lib/string/String.__lte
   i32.eqz
   if
@@ -19135,17 +19126,17 @@
    unreachable
   end
   i32.const 2432
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   i32.const 12848
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=4
-  local.get $55
+  local.get $52
   call $~lib/string/String.__lt
   i32.eqz
   if
@@ -19157,17 +19148,17 @@
    unreachable
   end
   i32.const 12848
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   i32.const 2432
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=4
-  local.get $55
+  local.get $52
   call $~lib/string/String.__gt
   i32.eqz
   if
@@ -19179,17 +19170,17 @@
    unreachable
   end
   i32.const 12880
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   i32.const 12848
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=4
-  local.get $55
+  local.get $52
   call $~lib/string/String.__lt
   i32.eqz
   i32.eqz
@@ -19202,17 +19193,17 @@
    unreachable
   end
   i32.const 12848
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   i32.const 12880
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=4
-  local.get $55
+  local.get $52
   call $~lib/string/String.__gt
   i32.eqz
   i32.eqz
@@ -19225,17 +19216,17 @@
    unreachable
   end
   i32.const 12880
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   i32.const 12848
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=4
-  local.get $55
+  local.get $52
   call $~lib/string/String.__gt
   i32.eqz
   if
@@ -19247,17 +19238,17 @@
    unreachable
   end
   i32.const 12848
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   i32.const 12880
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=4
-  local.get $55
+  local.get $52
   call $~lib/string/String.__lt
   i32.eqz
   if
@@ -19269,17 +19260,17 @@
    unreachable
   end
   i32.const 12880
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   i32.const 12880
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=4
-  local.get $55
+  local.get $52
   call $~lib/string/String.__lt
   i32.eqz
   i32.eqz
@@ -19292,17 +19283,17 @@
    unreachable
   end
   i32.const 12880
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   i32.const 12880
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=4
-  local.get $55
+  local.get $52
   call $~lib/string/String.__gt
   i32.eqz
   i32.eqz
@@ -19315,17 +19306,17 @@
    unreachable
   end
   i32.const 12880
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   i32.const 12880
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=4
-  local.get $55
+  local.get $52
   call $~lib/string/String.__lte
   i32.eqz
   if
@@ -19337,17 +19328,17 @@
    unreachable
   end
   i32.const 12880
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   i32.const 12880
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=4
-  local.get $55
+  local.get $52
   call $~lib/string/String.__gte
   i32.eqz
   if
@@ -19359,17 +19350,17 @@
    unreachable
   end
   i32.const 12848
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   i32.const 12912
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=4
-  local.get $55
+  local.get $52
   call $~lib/string/String.__gte
   i32.eqz
   i32.eqz
@@ -19382,17 +19373,17 @@
    unreachable
   end
   i32.const 12912
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   i32.const 12848
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=4
-  local.get $55
+  local.get $52
   call $~lib/string/String.__gte
   i32.eqz
   if
@@ -19404,17 +19395,17 @@
    unreachable
   end
   i32.const 12848
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   i32.const 12912
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=4
-  local.get $55
+  local.get $52
   call $~lib/string/String.__lte
   i32.eqz
   if
@@ -19426,17 +19417,17 @@
    unreachable
   end
   i32.const 2432
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   i32.const 2432
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=4
-  local.get $55
+  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -19448,17 +19439,17 @@
    unreachable
   end
   i32.const 12880
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   i32.const 12880
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=4
-  local.get $55
+  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -19470,17 +19461,17 @@
    unreachable
   end
   i32.const 1376
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   i32.const 1376
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=4
-  local.get $55
+  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -19492,17 +19483,17 @@
    unreachable
   end
   i32.const 1376
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   i32.const 12944
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=4
-  local.get $55
+  local.get $52
   call $~lib/string/String.__ne
   i32.eqz
   if
@@ -19514,17 +19505,17 @@
    unreachable
   end
   i32.const 12976
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   i32.const 12976
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=4
-  local.get $55
+  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -19536,17 +19527,17 @@
    unreachable
   end
   i32.const 13008
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   i32.const 12976
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=4
-  local.get $55
+  local.get $52
   call $~lib/string/String.__ne
   i32.eqz
   if
@@ -19560,38 +19551,38 @@
   global.get $~lib/memory/__stack_pointer
   i32.const 65377
   call $~lib/string/String.fromCodePoint
-  local.tee $52
+  local.tee $49
   i32.store offset=84
   global.get $~lib/memory/__stack_pointer
   i32.const 55296
   call $~lib/string/String.fromCodePoint
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   i32.const 56322
   call $~lib/string/String.fromCodePoint
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
-  i32.store offset=4
-  local.get $55
-  call $~lib/string/String.__concat
-  local.tee $53
-  i32.store offset=88
   local.get $52
-  local.set $55
-  global.get $~lib/memory/__stack_pointer
-  local.get $55
-  i32.store
-  local.get $55
-  local.get $53
-  local.set $55
-  global.get $~lib/memory/__stack_pointer
-  local.get $55
   i32.store offset=4
-  local.get $55
+  local.get $52
+  call $~lib/string/String.__concat
+  local.tee $50
+  i32.store offset=88
+  local.get $49
+  local.set $52
+  global.get $~lib/memory/__stack_pointer
+  local.get $52
+  i32.store
+  local.get $52
+  local.get $50
+  local.set $52
+  global.get $~lib/memory/__stack_pointer
+  local.get $52
+  i32.store offset=4
+  local.get $52
   call $~lib/string/String.__gt
   i32.eqz
   if
@@ -19603,11 +19594,11 @@
    unreachable
   end
   i32.const 1376
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   call $~lib/string/String#get:length
   i32.const 3
   i32.eq
@@ -19621,24 +19612,24 @@
    unreachable
   end
   i32.const 688
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=8
-  local.get $55
+  local.get $52
   i32.const 100
   call $~lib/string/String#repeat
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   i32.const 688
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=4
-  local.get $55
+  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -19650,24 +19641,24 @@
    unreachable
   end
   i32.const 784
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=8
-  local.get $55
+  local.get $52
   i32.const 0
   call $~lib/string/String#repeat
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   i32.const 688
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=4
-  local.get $55
+  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -19679,24 +19670,24 @@
    unreachable
   end
   i32.const 784
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=8
-  local.get $55
+  local.get $52
   i32.const 1
   call $~lib/string/String#repeat
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   i32.const 784
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=4
-  local.get $55
+  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -19708,24 +19699,24 @@
    unreachable
   end
   i32.const 784
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=8
-  local.get $55
+  local.get $52
   i32.const 2
   call $~lib/string/String#repeat
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   i32.const 12816
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=4
-  local.get $55
+  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -19737,24 +19728,24 @@
    unreachable
   end
   i32.const 784
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=8
-  local.get $55
+  local.get $52
   i32.const 3
   call $~lib/string/String#repeat
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   i32.const 13088
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=4
-  local.get $55
+  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -19766,24 +19757,24 @@
    unreachable
   end
   i32.const 12368
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=8
-  local.get $55
+  local.get $52
   i32.const 4
   call $~lib/string/String#repeat
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   i32.const 13120
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=4
-  local.get $55
+  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -19795,24 +19786,24 @@
    unreachable
   end
   i32.const 784
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=8
-  local.get $55
+  local.get $52
   i32.const 5
   call $~lib/string/String#repeat
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   i32.const 13168
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=4
-  local.get $55
+  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -19824,24 +19815,24 @@
    unreachable
   end
   i32.const 784
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=8
-  local.get $55
+  local.get $52
   i32.const 6
   call $~lib/string/String#repeat
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   i32.const 13200
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=4
-  local.get $55
+  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -19853,24 +19844,24 @@
    unreachable
   end
   i32.const 784
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=8
-  local.get $55
+  local.get $52
   i32.const 7
   call $~lib/string/String#repeat
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   i32.const 13232
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=4
-  local.get $55
+  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -19882,35 +19873,35 @@
    unreachable
   end
   i32.const 688
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=8
-  local.get $55
+  local.get $52
   i32.const 688
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=12
-  local.get $55
+  local.get $52
   i32.const 688
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=60
-  local.get $55
+  local.get $52
   call $~lib/string/String#replace
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   i32.const 688
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=4
-  local.get $55
+  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -19922,35 +19913,35 @@
    unreachable
   end
   i32.const 688
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=8
-  local.get $55
+  local.get $52
   i32.const 688
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=12
-  local.get $55
+  local.get $52
   i32.const 3568
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=60
-  local.get $55
+  local.get $52
   call $~lib/string/String#replace
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   i32.const 3568
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=4
-  local.get $55
+  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -19962,35 +19953,35 @@
    unreachable
   end
   i32.const 3568
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=8
-  local.get $55
+  local.get $52
   i32.const 3568
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=12
-  local.get $55
+  local.get $52
   i32.const 688
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=60
-  local.get $55
+  local.get $52
   call $~lib/string/String#replace
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   i32.const 688
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=4
-  local.get $55
+  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -20002,35 +19993,35 @@
    unreachable
   end
   i32.const 3568
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=8
-  local.get $55
+  local.get $52
   i32.const 688
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=12
-  local.get $55
+  local.get $52
   i32.const 688
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=60
-  local.get $55
+  local.get $52
   call $~lib/string/String#replace
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   i32.const 3568
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=4
-  local.get $55
+  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -20042,35 +20033,35 @@
    unreachable
   end
   i32.const 1312
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=8
-  local.get $55
+  local.get $52
   i32.const 3536
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=12
-  local.get $55
+  local.get $52
   i32.const 3568
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=60
-  local.get $55
+  local.get $52
   call $~lib/string/String#replace
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   i32.const 1312
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=4
-  local.get $55
+  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -20082,35 +20073,35 @@
    unreachable
   end
   i32.const 1312
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=8
-  local.get $55
+  local.get $52
   i32.const 1312
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=12
-  local.get $55
+  local.get $52
   i32.const 3568
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=60
-  local.get $55
+  local.get $52
   call $~lib/string/String#replace
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   i32.const 3568
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=4
-  local.get $55
+  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -20122,35 +20113,35 @@
    unreachable
   end
   i32.const 1312
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=8
-  local.get $55
+  local.get $52
   i32.const 1888
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=12
-  local.get $55
+  local.get $52
   i32.const 3568
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=60
-  local.get $55
+  local.get $52
   call $~lib/string/String#replace
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   i32.const 1312
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=4
-  local.get $55
+  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -20162,35 +20153,35 @@
    unreachable
   end
   i32.const 1312
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=8
-  local.get $55
+  local.get $52
   i32.const 12368
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=12
-  local.get $55
+  local.get $52
   i32.const 12368
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=60
-  local.get $55
+  local.get $52
   call $~lib/string/String#replace
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   i32.const 1312
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=4
-  local.get $55
+  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -20202,35 +20193,35 @@
    unreachable
   end
   i32.const 13280
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=8
-  local.get $55
+  local.get $52
   i32.const 3536
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=12
-  local.get $55
+  local.get $52
   i32.const 3568
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=60
-  local.get $55
+  local.get $52
   call $~lib/string/String#replace
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   i32.const 13312
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=4
-  local.get $55
+  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -20242,35 +20233,35 @@
    unreachable
   end
   i32.const 1312
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=8
-  local.get $55
+  local.get $52
   i32.const 688
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=12
-  local.get $55
+  local.get $52
   i32.const 3568
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=60
-  local.get $55
+  local.get $52
   call $~lib/string/String#replace
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   i32.const 13344
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=4
-  local.get $55
+  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -20282,35 +20273,35 @@
    unreachable
   end
   i32.const 13376
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=8
-  local.get $55
+  local.get $52
   i32.const 13408
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=12
-  local.get $55
+  local.get $52
   i32.const 3568
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=60
-  local.get $55
+  local.get $52
   call $~lib/string/String#replace
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   i32.const 13344
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=4
-  local.get $55
+  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -20322,35 +20313,35 @@
    unreachable
   end
   i32.const 1312
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=8
-  local.get $55
+  local.get $52
   i32.const 13440
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=12
-  local.get $55
+  local.get $52
   i32.const 13472
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=60
-  local.get $55
+  local.get $52
   call $~lib/string/String#replace
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   i32.const 13504
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=4
-  local.get $55
+  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -20362,35 +20353,35 @@
    unreachable
   end
   i32.const 1312
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=8
-  local.get $55
+  local.get $52
   i32.const 13440
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=12
-  local.get $55
+  local.get $52
   i32.const 688
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=60
-  local.get $55
+  local.get $52
   call $~lib/string/String#replace
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   i32.const 12368
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=4
-  local.get $55
+  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -20402,35 +20393,35 @@
    unreachable
   end
   i32.const 688
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=8
-  local.get $55
+  local.get $52
   i32.const 688
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=12
-  local.get $55
+  local.get $52
   i32.const 1312
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=60
-  local.get $55
+  local.get $52
   call $~lib/string/String#replaceAll
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   i32.const 1312
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=4
-  local.get $55
+  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -20442,35 +20433,35 @@
    unreachable
   end
   i32.const 1312
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=8
-  local.get $55
+  local.get $52
   i32.const 3536
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=12
-  local.get $55
+  local.get $52
   i32.const 3568
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=60
-  local.get $55
+  local.get $52
   call $~lib/string/String#replaceAll
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   i32.const 1312
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=4
-  local.get $55
+  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -20482,35 +20473,35 @@
    unreachable
   end
   i32.const 1520
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=8
-  local.get $55
+  local.get $52
   i32.const 1312
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=12
-  local.get $55
+  local.get $52
   i32.const 3568
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=60
-  local.get $55
+  local.get $52
   call $~lib/string/String#replaceAll
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   i32.const 13472
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=4
-  local.get $55
+  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -20522,35 +20513,35 @@
    unreachable
   end
   i32.const 13536
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=8
-  local.get $55
+  local.get $52
   i32.const 1312
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=12
-  local.get $55
+  local.get $52
   i32.const 3568
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=60
-  local.get $55
+  local.get $52
   call $~lib/string/String#replaceAll
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   i32.const 13584
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=4
-  local.get $55
+  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -20562,35 +20553,35 @@
    unreachable
   end
   i32.const 1520
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=8
-  local.get $55
+  local.get $52
   i32.const 12368
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=12
-  local.get $55
+  local.get $52
   i32.const 12368
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=60
-  local.get $55
+  local.get $52
   call $~lib/string/String#replaceAll
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   i32.const 1520
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=4
-  local.get $55
+  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -20602,35 +20593,35 @@
    unreachable
   end
   i32.const 13616
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=8
-  local.get $55
+  local.get $52
   i32.const 784
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=12
-  local.get $55
+  local.get $52
   i32.const 13584
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=60
-  local.get $55
+  local.get $52
   call $~lib/string/String#replaceAll
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   i32.const 13664
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=4
-  local.get $55
+  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -20642,35 +20633,35 @@
    unreachable
   end
   i32.const 1520
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=8
-  local.get $55
+  local.get $52
   i32.const 12368
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=12
-  local.get $55
+  local.get $52
   i32.const 13472
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=60
-  local.get $55
+  local.get $52
   call $~lib/string/String#replaceAll
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   i32.const 13712
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=4
-  local.get $55
+  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -20682,35 +20673,35 @@
    unreachable
   end
   i32.const 13744
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=8
-  local.get $55
+  local.get $52
   i32.const 13776
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=12
-  local.get $55
+  local.get $52
   i32.const 13472
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=60
-  local.get $55
+  local.get $52
   call $~lib/string/String#replaceAll
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   i32.const 13808
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=4
-  local.get $55
+  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -20722,35 +20713,35 @@
    unreachable
   end
   i32.const 1312
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=8
-  local.get $55
+  local.get $52
   i32.const 1888
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=12
-  local.get $55
+  local.get $52
   i32.const 3568
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=60
-  local.get $55
+  local.get $52
   call $~lib/string/String#replaceAll
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   i32.const 1312
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=4
-  local.get $55
+  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -20762,35 +20753,35 @@
    unreachable
   end
   i32.const 1888
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=8
-  local.get $55
+  local.get $52
   i32.const 13840
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=12
-  local.get $55
+  local.get $52
   i32.const 13472
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=60
-  local.get $55
+  local.get $52
   call $~lib/string/String#replaceAll
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   i32.const 1888
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=4
-  local.get $55
+  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -20802,35 +20793,35 @@
    unreachable
   end
   i32.const 1312
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=8
-  local.get $55
+  local.get $52
   i32.const 13872
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=12
-  local.get $55
+  local.get $52
   i32.const 3568
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=60
-  local.get $55
+  local.get $52
   call $~lib/string/String#replaceAll
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   i32.const 13904
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=4
-  local.get $55
+  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -20842,35 +20833,35 @@
    unreachable
   end
   i32.const 12368
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=8
-  local.get $55
+  local.get $52
   i32.const 12368
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=12
-  local.get $55
+  local.get $52
   i32.const 3568
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=60
-  local.get $55
+  local.get $52
   call $~lib/string/String#replaceAll
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   i32.const 3568
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=4
-  local.get $55
+  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -20882,35 +20873,35 @@
    unreachable
   end
   i32.const 13280
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=8
-  local.get $55
+  local.get $52
   i32.const 3536
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=12
-  local.get $55
+  local.get $52
   i32.const 3568
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=60
-  local.get $55
+  local.get $52
   call $~lib/string/String#replaceAll
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   i32.const 13936
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=4
-  local.get $55
+  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -20922,35 +20913,35 @@
    unreachable
   end
   i32.const 688
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=8
-  local.get $55
+  local.get $52
   i32.const 688
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=12
-  local.get $55
+  local.get $52
   i32.const 688
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=60
-  local.get $55
+  local.get $52
   call $~lib/string/String#replaceAll
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   i32.const 688
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=4
-  local.get $55
+  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -20962,35 +20953,35 @@
    unreachable
   end
   i32.const 688
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=8
-  local.get $55
+  local.get $52
   i32.const 688
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=12
-  local.get $55
+  local.get $52
   i32.const 3568
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=60
-  local.get $55
+  local.get $52
   call $~lib/string/String#replaceAll
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   i32.const 3568
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=4
-  local.get $55
+  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -21002,35 +20993,35 @@
    unreachable
   end
   i32.const 3568
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=8
-  local.get $55
+  local.get $52
   i32.const 3568
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=12
-  local.get $55
+  local.get $52
   i32.const 688
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=60
-  local.get $55
+  local.get $52
   call $~lib/string/String#replaceAll
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   i32.const 688
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=4
-  local.get $55
+  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -21042,35 +21033,35 @@
    unreachable
   end
   i32.const 3568
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=8
-  local.get $55
+  local.get $52
   i32.const 688
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=12
-  local.get $55
+  local.get $52
   i32.const 688
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=60
-  local.get $55
+  local.get $52
   call $~lib/string/String#replaceAll
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   i32.const 3568
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=4
-  local.get $55
+  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -21082,35 +21073,35 @@
    unreachable
   end
   i32.const 1312
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=8
-  local.get $55
+  local.get $52
   i32.const 1312
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=12
-  local.get $55
+  local.get $52
   i32.const 3536
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=60
-  local.get $55
+  local.get $52
   call $~lib/string/String#replaceAll
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   i32.const 3536
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=4
-  local.get $55
+  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -21122,35 +21113,35 @@
    unreachable
   end
   i32.const 1312
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=8
-  local.get $55
+  local.get $52
   i32.const 1792
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=12
-  local.get $55
+  local.get $52
   i32.const 3536
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=60
-  local.get $55
+  local.get $52
   call $~lib/string/String#replaceAll
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   i32.const 1312
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=4
-  local.get $55
+  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -21162,35 +21153,35 @@
    unreachable
   end
   i32.const 1312
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=8
-  local.get $55
+  local.get $52
   i32.const 688
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=12
-  local.get $55
+  local.get $52
   i32.const 3568
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=60
-  local.get $55
+  local.get $52
   call $~lib/string/String#replaceAll
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   i32.const 13968
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=4
-  local.get $55
+  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -21202,35 +21193,35 @@
    unreachable
   end
   i32.const 1312
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=8
-  local.get $55
+  local.get $52
   i32.const 688
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=12
-  local.get $55
+  local.get $52
   i32.const 688
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=60
-  local.get $55
+  local.get $52
   call $~lib/string/String#replaceAll
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   i32.const 1312
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=4
-  local.get $55
+  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -21242,35 +21233,35 @@
    unreachable
   end
   i32.const 14016
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=8
-  local.get $55
+  local.get $52
   i32.const 784
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=12
-  local.get $55
+  local.get $52
   i32.const 14048
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=60
-  local.get $55
+  local.get $52
   call $~lib/string/String#replaceAll
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   i32.const 14080
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=4
-  local.get $55
+  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -21282,35 +21273,35 @@
    unreachable
   end
   i32.const 12368
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=8
-  local.get $55
+  local.get $52
   i32.const 12368
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=12
-  local.get $55
+  local.get $52
   i32.const 14128
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=60
-  local.get $55
+  local.get $52
   call $~lib/string/String#replaceAll
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   i32.const 14128
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=4
-  local.get $55
+  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -21322,35 +21313,35 @@
    unreachable
   end
   i32.const 13088
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=8
-  local.get $55
+  local.get $52
   i32.const 784
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=12
-  local.get $55
+  local.get $52
   i32.const 14160
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=60
-  local.get $55
+  local.get $52
   call $~lib/string/String#replaceAll
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   i32.const 14192
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=4
-  local.get $55
+  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -21362,35 +21353,35 @@
    unreachable
   end
   i32.const 13088
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=8
-  local.get $55
+  local.get $52
   i32.const 12816
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=12
-  local.get $55
+  local.get $52
   i32.const 14048
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=60
-  local.get $55
+  local.get $52
   call $~lib/string/String#replaceAll
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   i32.const 14240
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=4
-  local.get $55
+  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -21404,27 +21395,27 @@
   i32.const 14272
   global.set $std/string/str
   global.get $std/string/str
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=8
-  local.get $55
+  local.get $52
   i32.const 0
   i32.const 1
   global.set $~argumentsLength
   i32.const 0
   call $~lib/string/String#slice@varargs
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   i32.const 14272
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=4
-  local.get $55
+  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -21436,27 +21427,27 @@
    unreachable
   end
   global.get $std/string/str
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=8
-  local.get $55
+  local.get $52
   i32.const -1
   i32.const 1
   global.set $~argumentsLength
   i32.const 0
   call $~lib/string/String#slice@varargs
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   i32.const 14320
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=4
-  local.get $55
+  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -21468,27 +21459,27 @@
    unreachable
   end
   global.get $std/string/str
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=8
-  local.get $55
+  local.get $52
   i32.const -5
   i32.const 1
   global.set $~argumentsLength
   i32.const 0
   call $~lib/string/String#slice@varargs
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   i32.const 14352
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=4
-  local.get $55
+  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -21500,25 +21491,25 @@
    unreachable
   end
   global.get $std/string/str
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=8
-  local.get $55
+  local.get $52
   i32.const 2
   i32.const 7
   call $~lib/string/String#slice
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   i32.const 14384
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=4
-  local.get $55
+  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -21530,25 +21521,25 @@
    unreachable
   end
   global.get $std/string/str
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=8
-  local.get $55
+  local.get $52
   i32.const -11
   i32.const -6
   call $~lib/string/String#slice
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   i32.const 14416
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=4
-  local.get $55
+  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -21560,25 +21551,25 @@
    unreachable
   end
   global.get $std/string/str
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=8
-  local.get $55
+  local.get $52
   i32.const 4
   i32.const 3
   call $~lib/string/String#slice
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   i32.const 688
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=4
-  local.get $55
+  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -21590,25 +21581,25 @@
    unreachable
   end
   global.get $std/string/str
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=8
-  local.get $55
+  local.get $52
   i32.const 0
   i32.const -1
   call $~lib/string/String#slice
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   i32.const 14448
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=4
-  local.get $55
+  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -21620,27 +21611,27 @@
    unreachable
   end
   global.get $std/string/str
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=8
-  local.get $55
+  local.get $52
   i32.const 0
   i32.const 1
   global.set $~argumentsLength
   i32.const 0
   call $~lib/string/String#substr@varargs
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   i32.const 14272
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=4
-  local.get $55
+  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -21652,27 +21643,27 @@
    unreachable
   end
   global.get $std/string/str
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=8
-  local.get $55
+  local.get $52
   i32.const -1
   i32.const 1
   global.set $~argumentsLength
   i32.const 0
   call $~lib/string/String#substr@varargs
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   i32.const 14320
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=4
-  local.get $55
+  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -21684,27 +21675,27 @@
    unreachable
   end
   global.get $std/string/str
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=8
-  local.get $55
+  local.get $52
   i32.const -5
   i32.const 1
   global.set $~argumentsLength
   i32.const 0
   call $~lib/string/String#substr@varargs
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   i32.const 14352
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=4
-  local.get $55
+  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -21716,25 +21707,25 @@
    unreachable
   end
   global.get $std/string/str
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=8
-  local.get $55
+  local.get $52
   i32.const 2
   i32.const 7
   call $~lib/string/String#substr
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   i32.const 14496
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=4
-  local.get $55
+  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -21746,25 +21737,25 @@
    unreachable
   end
   global.get $std/string/str
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=8
-  local.get $55
+  local.get $52
   i32.const -11
   i32.const -6
   call $~lib/string/String#substr
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   i32.const 688
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=4
-  local.get $55
+  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -21776,25 +21767,25 @@
    unreachable
   end
   global.get $std/string/str
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=8
-  local.get $55
+  local.get $52
   i32.const 4
   i32.const 3
   call $~lib/string/String#substr
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   i32.const 14544
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=4
-  local.get $55
+  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -21806,25 +21797,25 @@
    unreachable
   end
   global.get $std/string/str
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=8
-  local.get $55
+  local.get $52
   i32.const 0
   i32.const -1
   call $~lib/string/String#substr
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   i32.const 688
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=4
-  local.get $55
+  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -21836,25 +21827,25 @@
    unreachable
   end
   global.get $std/string/str
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=8
-  local.get $55
+  local.get $52
   i32.const 0
   i32.const 100
   call $~lib/string/String#substr
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   i32.const 14272
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=4
-  local.get $55
+  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -21866,25 +21857,25 @@
    unreachable
   end
   global.get $std/string/str
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=8
-  local.get $55
+  local.get $52
   i32.const 4
   i32.const 4
   call $~lib/string/String#substr
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   i32.const 14576
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=4
-  local.get $55
+  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -21896,25 +21887,25 @@
    unreachable
   end
   global.get $std/string/str
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=8
-  local.get $55
+  local.get $52
   i32.const 4
   i32.const -3
   call $~lib/string/String#substr
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   i32.const 688
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=4
-  local.get $55
+  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -21926,27 +21917,27 @@
    unreachable
   end
   global.get $std/string/str
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=8
-  local.get $55
+  local.get $52
   i32.const 0
   i32.const 1
   global.set $~argumentsLength
   i32.const 0
   call $~lib/string/String#substring@varargs
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   i32.const 14272
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=4
-  local.get $55
+  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -21958,27 +21949,27 @@
    unreachable
   end
   global.get $std/string/str
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=8
-  local.get $55
+  local.get $52
   i32.const -1
   i32.const 1
   global.set $~argumentsLength
   i32.const 0
   call $~lib/string/String#substring@varargs
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   i32.const 14272
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=4
-  local.get $55
+  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -21990,27 +21981,27 @@
    unreachable
   end
   global.get $std/string/str
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=8
-  local.get $55
+  local.get $52
   i32.const -5
   i32.const 1
   global.set $~argumentsLength
   i32.const 0
   call $~lib/string/String#substring@varargs
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   i32.const 14272
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=4
-  local.get $55
+  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -22022,25 +22013,25 @@
    unreachable
   end
   global.get $std/string/str
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=8
-  local.get $55
+  local.get $52
   i32.const 2
   i32.const 7
   call $~lib/string/String#substring
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   i32.const 14384
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=4
-  local.get $55
+  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -22052,25 +22043,25 @@
    unreachable
   end
   global.get $std/string/str
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=8
-  local.get $55
+  local.get $52
   i32.const -11
   i32.const -6
   call $~lib/string/String#substring
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   i32.const 688
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=4
-  local.get $55
+  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -22082,25 +22073,25 @@
    unreachable
   end
   global.get $std/string/str
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=8
-  local.get $55
+  local.get $52
   i32.const 4
   i32.const 3
   call $~lib/string/String#substring
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   i32.const 14608
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=4
-  local.get $55
+  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -22112,25 +22103,25 @@
    unreachable
   end
   global.get $std/string/str
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=8
-  local.get $55
+  local.get $52
   i32.const 0
   i32.const -1
   call $~lib/string/String#substring
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   i32.const 688
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=4
-  local.get $55
+  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -22142,25 +22133,25 @@
    unreachable
   end
   global.get $std/string/str
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=8
-  local.get $55
+  local.get $52
   i32.const 0
   i32.const 100
   call $~lib/string/String#substring
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   i32.const 14272
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=4
-  local.get $55
+  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -22172,25 +22163,25 @@
    unreachable
   end
   global.get $std/string/str
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=8
-  local.get $55
+  local.get $52
   i32.const 4
   i32.const 4
   call $~lib/string/String#substring
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   i32.const 688
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=4
-  local.get $55
+  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -22202,25 +22193,25 @@
    unreachable
   end
   global.get $std/string/str
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=8
-  local.get $55
+  local.get $52
   i32.const 4
   i32.const -3
   call $~lib/string/String#substring
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   i32.const 1888
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=4
-  local.get $55
+  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -22233,47 +22224,47 @@
   end
   global.get $~lib/memory/__stack_pointer
   i32.const 688
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   i32.const 0
   i32.const 0
   global.set $~argumentsLength
   i32.const 0
   call $~lib/string/String#split@varargs
-  local.tee $54
+  local.tee $51
   i32.store offset=92
-  local.get $54
-  local.set $55
+  local.get $51
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   call $~lib/array/Array<~lib/string/String>#get:length
   i32.const 1
   i32.eq
   if (result i32)
-   local.get $54
-   local.set $55
+   local.get $51
+   local.set $52
    global.get $~lib/memory/__stack_pointer
-   local.get $55
+   local.get $52
    i32.store offset=8
-   local.get $55
+   local.get $52
    i32.const 0
    call $~lib/array/Array<~lib/string/String>#__get
-   local.set $55
+   local.set $52
    global.get $~lib/memory/__stack_pointer
-   local.get $55
+   local.get $52
    i32.store
-   local.get $55
+   local.get $52
    i32.const 688
-   local.set $55
+   local.set $52
    global.get $~lib/memory/__stack_pointer
-   local.get $55
+   local.get $52
    i32.store offset=4
-   local.get $55
+   local.get $52
    call $~lib/string/String.__eq
   else
    i32.const 0
@@ -22289,29 +22280,29 @@
   end
   global.get $~lib/memory/__stack_pointer
   i32.const 688
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   i32.const 688
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=4
-  local.get $55
+  local.get $52
   i32.const 1
   global.set $~argumentsLength
   i32.const 0
   call $~lib/string/String#split@varargs
-  local.tee $54
+  local.tee $51
   i32.store offset=92
-  local.get $54
-  local.set $55
+  local.get $51
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   call $~lib/array/Array<~lib/string/String>#get:length
   i32.const 0
   i32.eq
@@ -22326,52 +22317,52 @@
   end
   global.get $~lib/memory/__stack_pointer
   i32.const 688
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   i32.const 1600
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=4
-  local.get $55
+  local.get $52
   i32.const 1
   global.set $~argumentsLength
   i32.const 0
   call $~lib/string/String#split@varargs
-  local.tee $54
+  local.tee $51
   i32.store offset=92
-  local.get $54
-  local.set $55
+  local.get $51
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   call $~lib/array/Array<~lib/string/String>#get:length
   i32.const 1
   i32.eq
   if (result i32)
-   local.get $54
-   local.set $55
+   local.get $51
+   local.set $52
    global.get $~lib/memory/__stack_pointer
-   local.get $55
+   local.get $52
    i32.store offset=8
-   local.get $55
+   local.get $52
    i32.const 0
    call $~lib/array/Array<~lib/string/String>#__get
-   local.set $55
+   local.set $52
    global.get $~lib/memory/__stack_pointer
-   local.get $55
+   local.get $52
    i32.store
-   local.get $55
+   local.get $52
    i32.const 688
-   local.set $55
+   local.set $52
    global.get $~lib/memory/__stack_pointer
-   local.get $55
+   local.get $52
    i32.store offset=4
-   local.get $55
+   local.get $52
    call $~lib/string/String.__eq
   else
    i32.const 0
@@ -22387,52 +22378,52 @@
   end
   global.get $~lib/memory/__stack_pointer
   i32.const 14816
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   i32.const 6608
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=4
-  local.get $55
+  local.get $52
   i32.const 1
   global.set $~argumentsLength
   i32.const 0
   call $~lib/string/String#split@varargs
-  local.tee $54
+  local.tee $51
   i32.store offset=92
-  local.get $54
-  local.set $55
+  local.get $51
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   call $~lib/array/Array<~lib/string/String>#get:length
   i32.const 1
   i32.eq
   if (result i32)
-   local.get $54
-   local.set $55
+   local.get $51
+   local.set $52
    global.get $~lib/memory/__stack_pointer
-   local.get $55
+   local.get $52
    i32.store offset=8
-   local.get $55
+   local.get $52
    i32.const 0
    call $~lib/array/Array<~lib/string/String>#__get
-   local.set $55
+   local.set $52
    global.get $~lib/memory/__stack_pointer
-   local.get $55
+   local.get $52
    i32.store
-   local.get $55
+   local.get $52
    i32.const 14816
-   local.set $55
+   local.set $52
    global.get $~lib/memory/__stack_pointer
-   local.get $55
+   local.get $52
    i32.store offset=4
-   local.get $55
+   local.get $52
    call $~lib/string/String.__eq
   else
    i32.const 0
@@ -22448,100 +22439,100 @@
   end
   global.get $~lib/memory/__stack_pointer
   i32.const 14816
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   i32.const 1600
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=4
-  local.get $55
+  local.get $52
   i32.const 1
   global.set $~argumentsLength
   i32.const 0
   call $~lib/string/String#split@varargs
-  local.tee $54
+  local.tee $51
   i32.store offset=92
-  local.get $54
-  local.set $55
+  local.get $51
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   call $~lib/array/Array<~lib/string/String>#get:length
   i32.const 3
   i32.eq
   if (result i32)
-   local.get $54
-   local.set $55
+   local.get $51
+   local.set $52
    global.get $~lib/memory/__stack_pointer
-   local.get $55
+   local.get $52
    i32.store offset=8
-   local.get $55
+   local.get $52
    i32.const 0
    call $~lib/array/Array<~lib/string/String>#__get
-   local.set $55
+   local.set $52
    global.get $~lib/memory/__stack_pointer
-   local.get $55
+   local.get $52
    i32.store
-   local.get $55
+   local.get $52
    i32.const 784
-   local.set $55
+   local.set $52
    global.get $~lib/memory/__stack_pointer
-   local.get $55
+   local.get $52
    i32.store offset=4
-   local.get $55
+   local.get $52
    call $~lib/string/String.__eq
   else
    i32.const 0
   end
   if (result i32)
-   local.get $54
-   local.set $55
+   local.get $51
+   local.set $52
    global.get $~lib/memory/__stack_pointer
-   local.get $55
+   local.get $52
    i32.store offset=8
-   local.get $55
+   local.get $52
    i32.const 1
    call $~lib/array/Array<~lib/string/String>#__get
-   local.set $55
+   local.set $52
    global.get $~lib/memory/__stack_pointer
-   local.get $55
+   local.get $52
    i32.store
-   local.get $55
+   local.get $52
    i32.const 12336
-   local.set $55
+   local.set $52
    global.get $~lib/memory/__stack_pointer
-   local.get $55
+   local.get $52
    i32.store offset=4
-   local.get $55
+   local.get $52
    call $~lib/string/String.__eq
   else
    i32.const 0
   end
   if (result i32)
-   local.get $54
-   local.set $55
+   local.get $51
+   local.set $52
    global.get $~lib/memory/__stack_pointer
-   local.get $55
+   local.get $52
    i32.store offset=8
-   local.get $55
+   local.get $52
    i32.const 2
    call $~lib/array/Array<~lib/string/String>#__get
-   local.set $55
+   local.set $52
    global.get $~lib/memory/__stack_pointer
-   local.get $55
+   local.get $52
    i32.store
-   local.get $55
+   local.get $52
    i32.const 13440
-   local.set $55
+   local.set $52
    global.get $~lib/memory/__stack_pointer
-   local.get $55
+   local.get $52
    i32.store offset=4
-   local.get $55
+   local.get $52
    call $~lib/string/String.__eq
   else
    i32.const 0
@@ -22557,100 +22548,100 @@
   end
   global.get $~lib/memory/__stack_pointer
   i32.const 14848
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   i32.const 14896
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=4
-  local.get $55
+  local.get $52
   i32.const 1
   global.set $~argumentsLength
   i32.const 0
   call $~lib/string/String#split@varargs
-  local.tee $54
+  local.tee $51
   i32.store offset=92
-  local.get $54
-  local.set $55
+  local.get $51
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   call $~lib/array/Array<~lib/string/String>#get:length
   i32.const 3
   i32.eq
   if (result i32)
-   local.get $54
-   local.set $55
+   local.get $51
+   local.set $52
    global.get $~lib/memory/__stack_pointer
-   local.get $55
+   local.get $52
    i32.store offset=8
-   local.get $55
+   local.get $52
    i32.const 0
    call $~lib/array/Array<~lib/string/String>#__get
-   local.set $55
+   local.set $52
    global.get $~lib/memory/__stack_pointer
-   local.get $55
+   local.get $52
    i32.store
-   local.get $55
+   local.get $52
    i32.const 784
-   local.set $55
+   local.set $52
    global.get $~lib/memory/__stack_pointer
-   local.get $55
+   local.get $52
    i32.store offset=4
-   local.get $55
+   local.get $52
    call $~lib/string/String.__eq
   else
    i32.const 0
   end
   if (result i32)
-   local.get $54
-   local.set $55
+   local.get $51
+   local.set $52
    global.get $~lib/memory/__stack_pointer
-   local.get $55
+   local.get $52
    i32.store offset=8
-   local.get $55
+   local.get $52
    i32.const 1
    call $~lib/array/Array<~lib/string/String>#__get
-   local.set $55
+   local.set $52
    global.get $~lib/memory/__stack_pointer
-   local.get $55
+   local.get $52
    i32.store
-   local.get $55
+   local.get $52
    i32.const 12336
-   local.set $55
+   local.set $52
    global.get $~lib/memory/__stack_pointer
-   local.get $55
+   local.get $52
    i32.store offset=4
-   local.get $55
+   local.get $52
    call $~lib/string/String.__eq
   else
    i32.const 0
   end
   if (result i32)
-   local.get $54
-   local.set $55
+   local.get $51
+   local.set $52
    global.get $~lib/memory/__stack_pointer
-   local.get $55
+   local.get $52
    i32.store offset=8
-   local.get $55
+   local.get $52
    i32.const 2
    call $~lib/array/Array<~lib/string/String>#__get
-   local.set $55
+   local.set $52
    global.get $~lib/memory/__stack_pointer
-   local.get $55
+   local.get $52
    i32.store
-   local.get $55
+   local.get $52
    i32.const 13440
-   local.set $55
+   local.set $52
    global.get $~lib/memory/__stack_pointer
-   local.get $55
+   local.get $52
    i32.store offset=4
-   local.get $55
+   local.get $52
    call $~lib/string/String.__eq
   else
    i32.const 0
@@ -22666,124 +22657,124 @@
   end
   global.get $~lib/memory/__stack_pointer
   i32.const 14928
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   i32.const 1600
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=4
-  local.get $55
+  local.get $52
   i32.const 1
   global.set $~argumentsLength
   i32.const 0
   call $~lib/string/String#split@varargs
-  local.tee $54
+  local.tee $51
   i32.store offset=92
-  local.get $54
-  local.set $55
+  local.get $51
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   call $~lib/array/Array<~lib/string/String>#get:length
   i32.const 4
   i32.eq
   if (result i32)
-   local.get $54
-   local.set $55
+   local.get $51
+   local.set $52
    global.get $~lib/memory/__stack_pointer
-   local.get $55
+   local.get $52
    i32.store offset=8
-   local.get $55
+   local.get $52
    i32.const 0
    call $~lib/array/Array<~lib/string/String>#__get
-   local.set $55
+   local.set $52
    global.get $~lib/memory/__stack_pointer
-   local.get $55
+   local.get $52
    i32.store
-   local.get $55
+   local.get $52
    i32.const 784
-   local.set $55
+   local.set $52
    global.get $~lib/memory/__stack_pointer
-   local.get $55
+   local.get $52
    i32.store offset=4
-   local.get $55
+   local.get $52
    call $~lib/string/String.__eq
   else
    i32.const 0
   end
   if (result i32)
-   local.get $54
-   local.set $55
+   local.get $51
+   local.set $52
    global.get $~lib/memory/__stack_pointer
-   local.get $55
+   local.get $52
    i32.store offset=8
-   local.get $55
+   local.get $52
    i32.const 1
    call $~lib/array/Array<~lib/string/String>#__get
-   local.set $55
+   local.set $52
    global.get $~lib/memory/__stack_pointer
-   local.get $55
+   local.get $52
    i32.store
-   local.get $55
+   local.get $52
    i32.const 12336
-   local.set $55
+   local.set $52
    global.get $~lib/memory/__stack_pointer
-   local.get $55
+   local.get $52
    i32.store offset=4
-   local.get $55
+   local.get $52
    call $~lib/string/String.__eq
   else
    i32.const 0
   end
   if (result i32)
-   local.get $54
-   local.set $55
+   local.get $51
+   local.set $52
    global.get $~lib/memory/__stack_pointer
-   local.get $55
+   local.get $52
    i32.store offset=8
-   local.get $55
+   local.get $52
    i32.const 2
    call $~lib/array/Array<~lib/string/String>#__get
-   local.set $55
+   local.set $52
    global.get $~lib/memory/__stack_pointer
-   local.get $55
+   local.get $52
    i32.store
-   local.get $55
+   local.get $52
    i32.const 688
-   local.set $55
+   local.set $52
    global.get $~lib/memory/__stack_pointer
-   local.get $55
+   local.get $52
    i32.store offset=4
-   local.get $55
+   local.get $52
    call $~lib/string/String.__eq
   else
    i32.const 0
   end
   if (result i32)
-   local.get $54
-   local.set $55
+   local.get $51
+   local.set $52
    global.get $~lib/memory/__stack_pointer
-   local.get $55
+   local.get $52
    i32.store offset=8
-   local.get $55
+   local.get $52
    i32.const 3
    call $~lib/array/Array<~lib/string/String>#__get
-   local.set $55
+   local.set $52
    global.get $~lib/memory/__stack_pointer
-   local.get $55
+   local.get $52
    i32.store
-   local.get $55
+   local.get $52
    i32.const 13440
-   local.set $55
+   local.set $52
    global.get $~lib/memory/__stack_pointer
-   local.get $55
+   local.get $52
    i32.store offset=4
-   local.get $55
+   local.get $52
    call $~lib/string/String.__eq
   else
    i32.const 0
@@ -22799,124 +22790,124 @@
   end
   global.get $~lib/memory/__stack_pointer
   i32.const 14960
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   i32.const 1600
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=4
-  local.get $55
+  local.get $52
   i32.const 1
   global.set $~argumentsLength
   i32.const 0
   call $~lib/string/String#split@varargs
-  local.tee $54
+  local.tee $51
   i32.store offset=92
-  local.get $54
-  local.set $55
+  local.get $51
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   call $~lib/array/Array<~lib/string/String>#get:length
   i32.const 4
   i32.eq
   if (result i32)
-   local.get $54
-   local.set $55
+   local.get $51
+   local.set $52
    global.get $~lib/memory/__stack_pointer
-   local.get $55
+   local.get $52
    i32.store offset=8
-   local.get $55
+   local.get $52
    i32.const 0
    call $~lib/array/Array<~lib/string/String>#__get
-   local.set $55
+   local.set $52
    global.get $~lib/memory/__stack_pointer
-   local.get $55
+   local.get $52
    i32.store
-   local.get $55
+   local.get $52
    i32.const 688
-   local.set $55
+   local.set $52
    global.get $~lib/memory/__stack_pointer
-   local.get $55
+   local.get $52
    i32.store offset=4
-   local.get $55
+   local.get $52
    call $~lib/string/String.__eq
   else
    i32.const 0
   end
   if (result i32)
-   local.get $54
-   local.set $55
+   local.get $51
+   local.set $52
    global.get $~lib/memory/__stack_pointer
-   local.get $55
+   local.get $52
    i32.store offset=8
-   local.get $55
+   local.get $52
    i32.const 1
    call $~lib/array/Array<~lib/string/String>#__get
-   local.set $55
+   local.set $52
    global.get $~lib/memory/__stack_pointer
-   local.get $55
+   local.get $52
    i32.store
-   local.get $55
+   local.get $52
    i32.const 784
-   local.set $55
+   local.set $52
    global.get $~lib/memory/__stack_pointer
-   local.get $55
+   local.get $52
    i32.store offset=4
-   local.get $55
+   local.get $52
    call $~lib/string/String.__eq
   else
    i32.const 0
   end
   if (result i32)
-   local.get $54
-   local.set $55
+   local.get $51
+   local.set $52
    global.get $~lib/memory/__stack_pointer
-   local.get $55
+   local.get $52
    i32.store offset=8
-   local.get $55
+   local.get $52
    i32.const 2
    call $~lib/array/Array<~lib/string/String>#__get
-   local.set $55
+   local.set $52
    global.get $~lib/memory/__stack_pointer
-   local.get $55
+   local.get $52
    i32.store
-   local.get $55
+   local.get $52
    i32.const 12336
-   local.set $55
+   local.set $52
    global.get $~lib/memory/__stack_pointer
-   local.get $55
+   local.get $52
    i32.store offset=4
-   local.get $55
+   local.get $52
    call $~lib/string/String.__eq
   else
    i32.const 0
   end
   if (result i32)
-   local.get $54
-   local.set $55
+   local.get $51
+   local.set $52
    global.get $~lib/memory/__stack_pointer
-   local.get $55
+   local.get $52
    i32.store offset=8
-   local.get $55
+   local.get $52
    i32.const 3
    call $~lib/array/Array<~lib/string/String>#__get
-   local.set $55
+   local.set $52
    global.get $~lib/memory/__stack_pointer
-   local.get $55
+   local.get $52
    i32.store
-   local.get $55
+   local.get $52
    i32.const 13440
-   local.set $55
+   local.set $52
    global.get $~lib/memory/__stack_pointer
-   local.get $55
+   local.get $52
    i32.store offset=4
-   local.get $55
+   local.get $52
    call $~lib/string/String.__eq
   else
    i32.const 0
@@ -22932,124 +22923,124 @@
   end
   global.get $~lib/memory/__stack_pointer
   i32.const 14992
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   i32.const 1600
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=4
-  local.get $55
+  local.get $52
   i32.const 1
   global.set $~argumentsLength
   i32.const 0
   call $~lib/string/String#split@varargs
-  local.tee $54
+  local.tee $51
   i32.store offset=92
-  local.get $54
-  local.set $55
+  local.get $51
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   call $~lib/array/Array<~lib/string/String>#get:length
   i32.const 4
   i32.eq
   if (result i32)
-   local.get $54
-   local.set $55
+   local.get $51
+   local.set $52
    global.get $~lib/memory/__stack_pointer
-   local.get $55
+   local.get $52
    i32.store offset=8
-   local.get $55
+   local.get $52
    i32.const 0
    call $~lib/array/Array<~lib/string/String>#__get
-   local.set $55
+   local.set $52
    global.get $~lib/memory/__stack_pointer
-   local.get $55
+   local.get $52
    i32.store
-   local.get $55
+   local.get $52
    i32.const 784
-   local.set $55
+   local.set $52
    global.get $~lib/memory/__stack_pointer
-   local.get $55
+   local.get $52
    i32.store offset=4
-   local.get $55
+   local.get $52
    call $~lib/string/String.__eq
   else
    i32.const 0
   end
   if (result i32)
-   local.get $54
-   local.set $55
+   local.get $51
+   local.set $52
    global.get $~lib/memory/__stack_pointer
-   local.get $55
+   local.get $52
    i32.store offset=8
-   local.get $55
+   local.get $52
    i32.const 1
    call $~lib/array/Array<~lib/string/String>#__get
-   local.set $55
+   local.set $52
    global.get $~lib/memory/__stack_pointer
-   local.get $55
+   local.get $52
    i32.store
-   local.get $55
+   local.get $52
    i32.const 12336
-   local.set $55
+   local.set $52
    global.get $~lib/memory/__stack_pointer
-   local.get $55
+   local.get $52
    i32.store offset=4
-   local.get $55
+   local.get $52
    call $~lib/string/String.__eq
   else
    i32.const 0
   end
   if (result i32)
-   local.get $54
-   local.set $55
+   local.get $51
+   local.set $52
    global.get $~lib/memory/__stack_pointer
-   local.get $55
+   local.get $52
    i32.store offset=8
-   local.get $55
+   local.get $52
    i32.const 2
    call $~lib/array/Array<~lib/string/String>#__get
-   local.set $55
+   local.set $52
    global.get $~lib/memory/__stack_pointer
-   local.get $55
+   local.get $52
    i32.store
-   local.get $55
+   local.get $52
    i32.const 13440
-   local.set $55
+   local.set $52
    global.get $~lib/memory/__stack_pointer
-   local.get $55
+   local.get $52
    i32.store offset=4
-   local.get $55
+   local.get $52
    call $~lib/string/String.__eq
   else
    i32.const 0
   end
   if (result i32)
-   local.get $54
-   local.set $55
+   local.get $51
+   local.set $52
    global.get $~lib/memory/__stack_pointer
-   local.get $55
+   local.get $52
    i32.store offset=8
-   local.get $55
+   local.get $52
    i32.const 3
    call $~lib/array/Array<~lib/string/String>#__get
-   local.set $55
+   local.set $52
    global.get $~lib/memory/__stack_pointer
-   local.get $55
+   local.get $52
    i32.store
-   local.get $55
+   local.get $52
    i32.const 688
-   local.set $55
+   local.set $52
    global.get $~lib/memory/__stack_pointer
-   local.get $55
+   local.get $52
    i32.store offset=4
-   local.get $55
+   local.get $52
    call $~lib/string/String.__eq
   else
    i32.const 0
@@ -23065,100 +23056,100 @@
   end
   global.get $~lib/memory/__stack_pointer
   i32.const 1312
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   i32.const 688
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=4
-  local.get $55
+  local.get $52
   i32.const 1
   global.set $~argumentsLength
   i32.const 0
   call $~lib/string/String#split@varargs
-  local.tee $54
+  local.tee $51
   i32.store offset=92
-  local.get $54
-  local.set $55
+  local.get $51
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   call $~lib/array/Array<~lib/string/String>#get:length
   i32.const 3
   i32.eq
   if (result i32)
-   local.get $54
-   local.set $55
+   local.get $51
+   local.set $52
    global.get $~lib/memory/__stack_pointer
-   local.get $55
+   local.get $52
    i32.store offset=8
-   local.get $55
+   local.get $52
    i32.const 0
    call $~lib/array/Array<~lib/string/String>#__get
-   local.set $55
+   local.set $52
    global.get $~lib/memory/__stack_pointer
-   local.get $55
+   local.get $52
    i32.store
-   local.get $55
+   local.get $52
    i32.const 784
-   local.set $55
+   local.set $52
    global.get $~lib/memory/__stack_pointer
-   local.get $55
+   local.get $52
    i32.store offset=4
-   local.get $55
+   local.get $52
    call $~lib/string/String.__eq
   else
    i32.const 0
   end
   if (result i32)
-   local.get $54
-   local.set $55
+   local.get $51
+   local.set $52
    global.get $~lib/memory/__stack_pointer
-   local.get $55
+   local.get $52
    i32.store offset=8
-   local.get $55
+   local.get $52
    i32.const 1
    call $~lib/array/Array<~lib/string/String>#__get
-   local.set $55
+   local.set $52
    global.get $~lib/memory/__stack_pointer
-   local.get $55
+   local.get $52
    i32.store
-   local.get $55
+   local.get $52
    i32.const 12336
-   local.set $55
+   local.set $52
    global.get $~lib/memory/__stack_pointer
-   local.get $55
+   local.get $52
    i32.store offset=4
-   local.get $55
+   local.get $52
    call $~lib/string/String.__eq
   else
    i32.const 0
   end
   if (result i32)
-   local.get $54
-   local.set $55
+   local.get $51
+   local.set $52
    global.get $~lib/memory/__stack_pointer
-   local.get $55
+   local.get $52
    i32.store offset=8
-   local.get $55
+   local.get $52
    i32.const 2
    call $~lib/array/Array<~lib/string/String>#__get
-   local.set $55
+   local.set $52
    global.get $~lib/memory/__stack_pointer
-   local.get $55
+   local.get $52
    i32.store
-   local.get $55
+   local.get $52
    i32.const 13440
-   local.set $55
+   local.set $52
    global.get $~lib/memory/__stack_pointer
-   local.get $55
+   local.get $52
    i32.store offset=4
-   local.get $55
+   local.get $52
    call $~lib/string/String.__eq
   else
    i32.const 0
@@ -23174,27 +23165,27 @@
   end
   global.get $~lib/memory/__stack_pointer
   i32.const 1312
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   i32.const 688
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=4
-  local.get $55
+  local.get $52
   i32.const 0
   call $~lib/string/String#split
-  local.tee $54
+  local.tee $51
   i32.store offset=92
-  local.get $54
-  local.set $55
+  local.get $51
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   call $~lib/array/Array<~lib/string/String>#get:length
   i32.const 0
   i32.eq
@@ -23209,50 +23200,50 @@
   end
   global.get $~lib/memory/__stack_pointer
   i32.const 1312
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   i32.const 688
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=4
-  local.get $55
+  local.get $52
   i32.const 1
   call $~lib/string/String#split
-  local.tee $54
+  local.tee $51
   i32.store offset=92
-  local.get $54
-  local.set $55
+  local.get $51
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   call $~lib/array/Array<~lib/string/String>#get:length
   i32.const 1
   i32.eq
   if (result i32)
-   local.get $54
-   local.set $55
+   local.get $51
+   local.set $52
    global.get $~lib/memory/__stack_pointer
-   local.get $55
+   local.get $52
    i32.store offset=8
-   local.get $55
+   local.get $52
    i32.const 0
    call $~lib/array/Array<~lib/string/String>#__get
-   local.set $55
+   local.set $52
    global.get $~lib/memory/__stack_pointer
-   local.get $55
+   local.get $52
    i32.store
-   local.get $55
+   local.get $52
    i32.const 784
-   local.set $55
+   local.set $52
    global.get $~lib/memory/__stack_pointer
-   local.get $55
+   local.get $52
    i32.store offset=4
-   local.get $55
+   local.get $52
    call $~lib/string/String.__eq
   else
    i32.const 0
@@ -23268,50 +23259,50 @@
   end
   global.get $~lib/memory/__stack_pointer
   i32.const 14816
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   i32.const 1600
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=4
-  local.get $55
+  local.get $52
   i32.const 1
   call $~lib/string/String#split
-  local.tee $54
+  local.tee $51
   i32.store offset=92
-  local.get $54
-  local.set $55
+  local.get $51
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   call $~lib/array/Array<~lib/string/String>#get:length
   i32.const 1
   i32.eq
   if (result i32)
-   local.get $54
-   local.set $55
+   local.get $51
+   local.set $52
    global.get $~lib/memory/__stack_pointer
-   local.get $55
+   local.get $52
    i32.store offset=8
-   local.get $55
+   local.get $52
    i32.const 0
    call $~lib/array/Array<~lib/string/String>#__get
-   local.set $55
+   local.set $52
    global.get $~lib/memory/__stack_pointer
-   local.get $55
+   local.get $52
    i32.store
-   local.get $55
+   local.get $52
    i32.const 784
-   local.set $55
+   local.set $52
    global.get $~lib/memory/__stack_pointer
-   local.get $55
+   local.get $52
    i32.store offset=4
-   local.get $55
+   local.get $52
    call $~lib/string/String.__eq
   else
    i32.const 0
@@ -23327,98 +23318,98 @@
   end
   global.get $~lib/memory/__stack_pointer
   i32.const 1312
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   i32.const 688
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=4
-  local.get $55
+  local.get $52
   i32.const 4
   call $~lib/string/String#split
-  local.tee $54
+  local.tee $51
   i32.store offset=92
-  local.get $54
-  local.set $55
+  local.get $51
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   call $~lib/array/Array<~lib/string/String>#get:length
   i32.const 3
   i32.eq
   if (result i32)
-   local.get $54
-   local.set $55
+   local.get $51
+   local.set $52
    global.get $~lib/memory/__stack_pointer
-   local.get $55
+   local.get $52
    i32.store offset=8
-   local.get $55
+   local.get $52
    i32.const 0
    call $~lib/array/Array<~lib/string/String>#__get
-   local.set $55
+   local.set $52
    global.get $~lib/memory/__stack_pointer
-   local.get $55
+   local.get $52
    i32.store
-   local.get $55
+   local.get $52
    i32.const 784
-   local.set $55
+   local.set $52
    global.get $~lib/memory/__stack_pointer
-   local.get $55
+   local.get $52
    i32.store offset=4
-   local.get $55
+   local.get $52
    call $~lib/string/String.__eq
   else
    i32.const 0
   end
   if (result i32)
-   local.get $54
-   local.set $55
+   local.get $51
+   local.set $52
    global.get $~lib/memory/__stack_pointer
-   local.get $55
+   local.get $52
    i32.store offset=8
-   local.get $55
+   local.get $52
    i32.const 1
    call $~lib/array/Array<~lib/string/String>#__get
-   local.set $55
+   local.set $52
    global.get $~lib/memory/__stack_pointer
-   local.get $55
+   local.get $52
    i32.store
-   local.get $55
+   local.get $52
    i32.const 12336
-   local.set $55
+   local.set $52
    global.get $~lib/memory/__stack_pointer
-   local.get $55
+   local.get $52
    i32.store offset=4
-   local.get $55
+   local.get $52
    call $~lib/string/String.__eq
   else
    i32.const 0
   end
   if (result i32)
-   local.get $54
-   local.set $55
+   local.get $51
+   local.set $52
    global.get $~lib/memory/__stack_pointer
-   local.get $55
+   local.get $52
    i32.store offset=8
-   local.get $55
+   local.get $52
    i32.const 2
    call $~lib/array/Array<~lib/string/String>#__get
-   local.set $55
+   local.set $52
    global.get $~lib/memory/__stack_pointer
-   local.get $55
+   local.get $52
    i32.store
-   local.get $55
+   local.get $52
    i32.const 13440
-   local.set $55
+   local.set $52
    global.get $~lib/memory/__stack_pointer
-   local.get $55
+   local.get $52
    i32.store offset=4
-   local.get $55
+   local.get $52
    call $~lib/string/String.__eq
   else
    i32.const 0
@@ -23434,98 +23425,98 @@
   end
   global.get $~lib/memory/__stack_pointer
   i32.const 1312
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   i32.const 688
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=4
-  local.get $55
+  local.get $52
   i32.const -1
   call $~lib/string/String#split
-  local.tee $54
+  local.tee $51
   i32.store offset=92
-  local.get $54
-  local.set $55
+  local.get $51
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   call $~lib/array/Array<~lib/string/String>#get:length
   i32.const 3
   i32.eq
   if (result i32)
-   local.get $54
-   local.set $55
+   local.get $51
+   local.set $52
    global.get $~lib/memory/__stack_pointer
-   local.get $55
+   local.get $52
    i32.store offset=8
-   local.get $55
+   local.get $52
    i32.const 0
    call $~lib/array/Array<~lib/string/String>#__get
-   local.set $55
+   local.set $52
    global.get $~lib/memory/__stack_pointer
-   local.get $55
+   local.get $52
    i32.store
-   local.get $55
+   local.get $52
    i32.const 784
-   local.set $55
+   local.set $52
    global.get $~lib/memory/__stack_pointer
-   local.get $55
+   local.get $52
    i32.store offset=4
-   local.get $55
+   local.get $52
    call $~lib/string/String.__eq
   else
    i32.const 0
   end
   if (result i32)
-   local.get $54
-   local.set $55
+   local.get $51
+   local.set $52
    global.get $~lib/memory/__stack_pointer
-   local.get $55
+   local.get $52
    i32.store offset=8
-   local.get $55
+   local.get $52
    i32.const 1
    call $~lib/array/Array<~lib/string/String>#__get
-   local.set $55
+   local.set $52
    global.get $~lib/memory/__stack_pointer
-   local.get $55
+   local.get $52
    i32.store
-   local.get $55
+   local.get $52
    i32.const 12336
-   local.set $55
+   local.set $52
    global.get $~lib/memory/__stack_pointer
-   local.get $55
+   local.get $52
    i32.store offset=4
-   local.get $55
+   local.get $52
    call $~lib/string/String.__eq
   else
    i32.const 0
   end
   if (result i32)
-   local.get $54
-   local.set $55
+   local.get $51
+   local.set $52
    global.get $~lib/memory/__stack_pointer
-   local.get $55
+   local.get $52
    i32.store offset=8
-   local.get $55
+   local.get $52
    i32.const 2
    call $~lib/array/Array<~lib/string/String>#__get
-   local.set $55
+   local.set $52
    global.get $~lib/memory/__stack_pointer
-   local.get $55
+   local.get $52
    i32.store
-   local.get $55
+   local.get $52
    i32.const 13440
-   local.set $55
+   local.set $52
    global.get $~lib/memory/__stack_pointer
-   local.get $55
+   local.get $52
    i32.store offset=4
-   local.get $55
+   local.get $52
    call $~lib/string/String.__eq
   else
    i32.const 0
@@ -23541,98 +23532,98 @@
   end
   global.get $~lib/memory/__stack_pointer
   i32.const 14816
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   i32.const 1600
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=4
-  local.get $55
+  local.get $52
   i32.const -1
   call $~lib/string/String#split
-  local.tee $54
+  local.tee $51
   i32.store offset=92
-  local.get $54
-  local.set $55
+  local.get $51
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   call $~lib/array/Array<~lib/string/String>#get:length
   i32.const 3
   i32.eq
   if (result i32)
-   local.get $54
-   local.set $55
+   local.get $51
+   local.set $52
    global.get $~lib/memory/__stack_pointer
-   local.get $55
+   local.get $52
    i32.store offset=8
-   local.get $55
+   local.get $52
    i32.const 0
    call $~lib/array/Array<~lib/string/String>#__get
-   local.set $55
+   local.set $52
    global.get $~lib/memory/__stack_pointer
-   local.get $55
+   local.get $52
    i32.store
-   local.get $55
+   local.get $52
    i32.const 784
-   local.set $55
+   local.set $52
    global.get $~lib/memory/__stack_pointer
-   local.get $55
+   local.get $52
    i32.store offset=4
-   local.get $55
+   local.get $52
    call $~lib/string/String.__eq
   else
    i32.const 0
   end
   if (result i32)
-   local.get $54
-   local.set $55
+   local.get $51
+   local.set $52
    global.get $~lib/memory/__stack_pointer
-   local.get $55
+   local.get $52
    i32.store offset=8
-   local.get $55
+   local.get $52
    i32.const 1
    call $~lib/array/Array<~lib/string/String>#__get
-   local.set $55
+   local.set $52
    global.get $~lib/memory/__stack_pointer
-   local.get $55
+   local.get $52
    i32.store
-   local.get $55
+   local.get $52
    i32.const 12336
-   local.set $55
+   local.set $52
    global.get $~lib/memory/__stack_pointer
-   local.get $55
+   local.get $52
    i32.store offset=4
-   local.get $55
+   local.get $52
    call $~lib/string/String.__eq
   else
    i32.const 0
   end
   if (result i32)
-   local.get $54
-   local.set $55
+   local.get $51
+   local.set $52
    global.get $~lib/memory/__stack_pointer
-   local.get $55
+   local.get $52
    i32.store offset=8
-   local.get $55
+   local.get $52
    i32.const 2
    call $~lib/array/Array<~lib/string/String>#__get
-   local.set $55
+   local.set $52
    global.get $~lib/memory/__stack_pointer
-   local.get $55
+   local.get $52
    i32.store
-   local.get $55
+   local.get $52
    i32.const 13440
-   local.set $55
+   local.set $52
    global.get $~lib/memory/__stack_pointer
-   local.get $55
+   local.get $52
    i32.store offset=4
-   local.get $55
+   local.get $52
    call $~lib/string/String.__eq
   else
    i32.const 0
@@ -23649,17 +23640,17 @@
   i32.const 0
   i32.const 10
   call $~lib/util/number/itoa32
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   i32.const 2368
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=4
-  local.get $55
+  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -23673,17 +23664,17 @@
   i32.const 1
   i32.const 10
   call $~lib/util/number/itoa32
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   i32.const 2432
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=4
-  local.get $55
+  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -23697,17 +23688,17 @@
   i32.const 8
   i32.const 10
   call $~lib/util/number/itoa32
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   i32.const 16768
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=4
-  local.get $55
+  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -23721,17 +23712,17 @@
   i32.const 12
   i32.const 10
   call $~lib/util/number/itoa32
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   i32.const 16800
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=4
-  local.get $55
+  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -23745,17 +23736,17 @@
   i32.const 123
   i32.const 10
   call $~lib/util/number/itoa32
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   i32.const 1376
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=4
-  local.get $55
+  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -23769,17 +23760,17 @@
   i32.const -1000
   i32.const 10
   call $~lib/util/number/itoa32
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   i32.const 16832
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=4
-  local.get $55
+  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -23793,17 +23784,17 @@
   i32.const 1234
   i32.const 10
   call $~lib/util/number/itoa32
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   i32.const 12976
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=4
-  local.get $55
+  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -23817,17 +23808,17 @@
   i32.const 12345
   i32.const 10
   call $~lib/util/number/itoa32
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   i32.const 16864
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=4
-  local.get $55
+  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -23841,17 +23832,17 @@
   i32.const 123456
   i32.const 10
   call $~lib/util/number/itoa32
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   i32.const 16896
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=4
-  local.get $55
+  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -23865,17 +23856,17 @@
   i32.const 1111111
   i32.const 10
   call $~lib/util/number/itoa32
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   i32.const 16928
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=4
-  local.get $55
+  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -23889,17 +23880,17 @@
   i32.const 1234567
   i32.const 10
   call $~lib/util/number/itoa32
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   i32.const 16976
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=4
-  local.get $55
+  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -23913,17 +23904,17 @@
   i32.const 12345678
   i32.const 10
   call $~lib/util/number/itoa32
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   i32.const 17024
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=4
-  local.get $55
+  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -23937,17 +23928,17 @@
   i32.const 123456789
   i32.const 10
   call $~lib/util/number/itoa32
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   i32.const 17072
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=4
-  local.get $55
+  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -23961,17 +23952,17 @@
   i32.const 2147483646
   i32.const 10
   call $~lib/util/number/itoa32
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   i32.const 17120
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=4
-  local.get $55
+  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -23985,17 +23976,17 @@
   i32.const 2147483647
   i32.const 10
   call $~lib/util/number/itoa32
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   i32.const 17168
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=4
-  local.get $55
+  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -24009,17 +24000,17 @@
   i32.const -2147483648
   i32.const 10
   call $~lib/util/number/itoa32
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   i32.const 17216
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=4
-  local.get $55
+  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -24033,17 +24024,17 @@
   i32.const -1
   i32.const 10
   call $~lib/util/number/itoa32
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   i32.const 17264
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=4
-  local.get $55
+  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -24057,17 +24048,17 @@
   global.get $~lib/builtins/i8.MIN_VALUE
   i32.const 10
   call $~lib/util/number/itoa32
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   i32.const 17296
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=4
-  local.get $55
+  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -24081,17 +24072,17 @@
   global.get $~lib/builtins/i16.MIN_VALUE
   i32.const 10
   call $~lib/util/number/itoa32
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   i32.const 17328
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=4
-  local.get $55
+  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -24105,17 +24096,17 @@
   global.get $~lib/builtins/i32.MIN_VALUE
   i32.const 10
   call $~lib/util/number/itoa32
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   i32.const 17216
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=4
-  local.get $55
+  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -24129,17 +24120,17 @@
   i32.const 0
   i32.const 10
   call $~lib/util/number/utoa32
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   i32.const 2368
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=4
-  local.get $55
+  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -24153,17 +24144,17 @@
   i32.const 1000
   i32.const 10
   call $~lib/util/number/utoa32
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   i32.const 17360
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=4
-  local.get $55
+  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -24177,17 +24168,17 @@
   i32.const 2147483647
   i32.const 10
   call $~lib/util/number/utoa32
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   i32.const 17168
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=4
-  local.get $55
+  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -24201,17 +24192,17 @@
   i32.const -2147483648
   i32.const 10
   call $~lib/util/number/utoa32
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   i32.const 17392
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=4
-  local.get $55
+  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -24225,17 +24216,17 @@
   global.get $~lib/builtins/u32.MAX_VALUE
   i32.const 10
   call $~lib/util/number/utoa32
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   i32.const 17440
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=4
-  local.get $55
+  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -24249,17 +24240,17 @@
   i32.const 0
   i32.const 16
   call $~lib/util/number/utoa32
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   i32.const 2368
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=4
-  local.get $55
+  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -24273,17 +24264,17 @@
   i32.const 1
   i32.const 16
   call $~lib/util/number/utoa32
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   i32.const 2432
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=4
-  local.get $55
+  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -24297,17 +24288,17 @@
   i32.const 8
   i32.const 16
   call $~lib/util/number/utoa32
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   i32.const 16768
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=4
-  local.get $55
+  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -24321,17 +24312,17 @@
   i32.const 12
   i32.const 16
   call $~lib/util/number/utoa32
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   i32.const 13440
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=4
-  local.get $55
+  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -24345,17 +24336,17 @@
   i32.const 123
   i32.const 16
   call $~lib/util/number/utoa32
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   i32.const 17488
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=4
-  local.get $55
+  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -24369,17 +24360,17 @@
   i32.const 1234
   i32.const 16
   call $~lib/util/number/utoa32
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   i32.const 17520
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=4
-  local.get $55
+  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -24393,17 +24384,17 @@
   i32.const 12345
   i32.const 16
   call $~lib/util/number/utoa32
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   i32.const 17552
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=4
-  local.get $55
+  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -24417,17 +24408,17 @@
   i32.const 123456
   i32.const 16
   call $~lib/util/number/utoa32
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   i32.const 17584
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=4
-  local.get $55
+  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -24441,17 +24432,17 @@
   i32.const 1111111
   i32.const 16
   call $~lib/util/number/utoa32
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   i32.const 17616
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=4
-  local.get $55
+  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -24465,17 +24456,17 @@
   i32.const 1234567
   i32.const 16
   call $~lib/util/number/utoa32
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   i32.const 17648
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=4
-  local.get $55
+  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -24489,17 +24480,17 @@
   i32.const 12345678
   i32.const 16
   call $~lib/util/number/utoa32
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   i32.const 17680
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=4
-  local.get $55
+  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -24513,17 +24504,17 @@
   i32.const 123456789
   i32.const 16
   call $~lib/util/number/utoa32
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   i32.const 17712
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=4
-  local.get $55
+  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -24537,17 +24528,17 @@
   i32.const 2147483646
   i32.const 16
   call $~lib/util/number/utoa32
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   i32.const 17760
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=4
-  local.get $55
+  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -24561,17 +24552,17 @@
   i32.const 2147483647
   i32.const 16
   call $~lib/util/number/utoa32
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   i32.const 17808
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=4
-  local.get $55
+  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -24585,17 +24576,17 @@
   i32.const -2147483648
   i32.const 16
   call $~lib/util/number/utoa32
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   i32.const 17856
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=4
-  local.get $55
+  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -24609,17 +24600,17 @@
   i32.const -1
   i32.const 16
   call $~lib/util/number/utoa32
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   i32.const 17904
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=4
-  local.get $55
+  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -24633,17 +24624,17 @@
   i32.const 0
   i32.const 16
   call $~lib/util/number/itoa32
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   i32.const 2368
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=4
-  local.get $55
+  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -24657,17 +24648,17 @@
   i32.const -4096
   i32.const 16
   call $~lib/util/number/itoa32
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   i32.const 16832
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=4
-  local.get $55
+  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -24681,17 +24672,17 @@
   i32.const 2147483647
   i32.const 16
   call $~lib/util/number/itoa32
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   i32.const 17808
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=4
-  local.get $55
+  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -24705,17 +24696,17 @@
   i32.const -2147483647
   i32.const 16
   call $~lib/util/number/itoa32
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   i32.const 17952
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=4
-  local.get $55
+  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -24729,17 +24720,17 @@
   i32.const -268435455
   i32.const 16
   call $~lib/util/number/itoa32
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   i32.const 18000
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=4
-  local.get $55
+  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -24753,17 +24744,17 @@
   i32.const -2147483648
   i32.const 16
   call $~lib/util/number/itoa32
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   i32.const 18048
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=4
-  local.get $55
+  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -24777,17 +24768,17 @@
   i32.const -2147483648
   i32.const 16
   call $~lib/util/number/itoa32
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   i32.const 18048
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=4
-  local.get $55
+  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -24801,17 +24792,17 @@
   i32.const 0
   i32.const 2
   call $~lib/util/number/utoa32
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   i32.const 2368
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=4
-  local.get $55
+  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -24825,17 +24816,17 @@
   i32.const 1
   i32.const 2
   call $~lib/util/number/utoa32
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   i32.const 2432
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=4
-  local.get $55
+  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -24849,17 +24840,17 @@
   i32.const 3
   i32.const 2
   call $~lib/util/number/utoa32
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   i32.const 12880
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=4
-  local.get $55
+  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -24873,17 +24864,17 @@
   i32.const 7
   i32.const 2
   call $~lib/util/number/utoa32
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   i32.const 18096
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=4
-  local.get $55
+  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -24897,17 +24888,17 @@
   i32.const 14
   i32.const 2
   call $~lib/util/number/utoa32
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   i32.const 18128
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=4
-  local.get $55
+  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -24921,17 +24912,17 @@
   i32.const 29
   i32.const 2
   call $~lib/util/number/utoa32
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   i32.const 18160
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=4
-  local.get $55
+  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -24945,17 +24936,17 @@
   i32.const 59
   i32.const 2
   call $~lib/util/number/utoa32
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   i32.const 18192
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=4
-  local.get $55
+  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -24969,17 +24960,17 @@
   i32.const 4095
   i32.const 2
   call $~lib/util/number/utoa32
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   i32.const 18224
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=4
-  local.get $55
+  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -24993,17 +24984,17 @@
   i32.const 33554431
   i32.const 2
   call $~lib/util/number/utoa32
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   i32.const 18272
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=4
-  local.get $55
+  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -25017,17 +25008,17 @@
   i32.const -12
   i32.const 2
   call $~lib/util/number/utoa32
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   i32.const 18352
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=4
-  local.get $55
+  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -25041,17 +25032,17 @@
   i32.const -4
   i32.const 2
   call $~lib/util/number/utoa32
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   i32.const 18448
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=4
-  local.get $55
+  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -25065,17 +25056,17 @@
   i32.const -2
   i32.const 2
   call $~lib/util/number/utoa32
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   i32.const 18544
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=4
-  local.get $55
+  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -25089,17 +25080,17 @@
   i32.const -1
   i32.const 2
   call $~lib/util/number/utoa32
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   i32.const 18640
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=4
-  local.get $55
+  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -25113,17 +25104,17 @@
   i32.const -2047
   i32.const 2
   call $~lib/util/number/itoa32
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   i32.const 18736
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=4
-  local.get $55
+  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -25137,17 +25128,17 @@
   i32.const -1
   i32.const 3
   call $~lib/util/number/utoa32
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   i32.const 18784
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=4
-  local.get $55
+  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -25161,17 +25152,17 @@
   i32.const -1
   i32.const 4
   call $~lib/util/number/utoa32
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   i32.const 18848
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=4
-  local.get $55
+  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -25185,17 +25176,17 @@
   i32.const -1
   i32.const 5
   call $~lib/util/number/utoa32
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   i32.const 18912
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=4
-  local.get $55
+  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -25209,17 +25200,17 @@
   i32.const -1
   i32.const 8
   call $~lib/util/number/utoa32
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   i32.const 18960
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=4
-  local.get $55
+  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -25233,17 +25224,17 @@
   i32.const -1
   i32.const 11
   call $~lib/util/number/utoa32
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   i32.const 19008
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=4
-  local.get $55
+  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -25257,17 +25248,17 @@
   i32.const -1
   i32.const 15
   call $~lib/util/number/utoa32
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   i32.const 19056
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=4
-  local.get $55
+  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -25281,17 +25272,17 @@
   i32.const -1
   i32.const 17
   call $~lib/util/number/utoa32
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   i32.const 19104
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=4
-  local.get $55
+  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -25305,17 +25296,17 @@
   i32.const -1
   i32.const 21
   call $~lib/util/number/utoa32
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   i32.const 19152
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=4
-  local.get $55
+  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -25329,17 +25320,17 @@
   i32.const -1
   i32.const 27
   call $~lib/util/number/utoa32
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   i32.const 19200
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=4
-  local.get $55
+  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -25353,17 +25344,17 @@
   i32.const -1
   i32.const 32
   call $~lib/util/number/utoa32
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   i32.const 19248
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=4
-  local.get $55
+  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -25377,17 +25368,17 @@
   i32.const -1
   i32.const 36
   call $~lib/util/number/utoa32
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   i32.const 19296
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=4
-  local.get $55
+  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -25401,17 +25392,17 @@
   i64.const 0
   i32.const 10
   call $~lib/util/number/utoa64
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   i32.const 2368
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=4
-  local.get $55
+  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -25425,17 +25416,17 @@
   i64.const 12
   i32.const 10
   call $~lib/util/number/utoa64
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   i32.const 16800
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=4
-  local.get $55
+  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -25449,17 +25440,17 @@
   i64.const 123
   i32.const 10
   call $~lib/util/number/utoa64
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   i32.const 1376
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=4
-  local.get $55
+  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -25473,17 +25464,17 @@
   i64.const 1234
   i32.const 10
   call $~lib/util/number/utoa64
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   i32.const 12976
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=4
-  local.get $55
+  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -25497,17 +25488,17 @@
   i64.const 12345
   i32.const 10
   call $~lib/util/number/utoa64
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   i32.const 16864
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=4
-  local.get $55
+  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -25521,17 +25512,17 @@
   i64.const 123456
   i32.const 10
   call $~lib/util/number/utoa64
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   i32.const 16896
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=4
-  local.get $55
+  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -25545,17 +25536,17 @@
   i64.const 1234567
   i32.const 10
   call $~lib/util/number/utoa64
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   i32.const 16976
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=4
-  local.get $55
+  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -25569,17 +25560,17 @@
   i64.const 99999999
   i32.const 10
   call $~lib/util/number/utoa64
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   i32.const 19344
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=4
-  local.get $55
+  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -25593,17 +25584,17 @@
   i64.const 100000000
   i32.const 10
   call $~lib/util/number/utoa64
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   i32.const 19392
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=4
-  local.get $55
+  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -25617,17 +25608,17 @@
   i64.const 4294967295
   i32.const 10
   call $~lib/util/number/utoa64
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   i32.const 17440
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=4
-  local.get $55
+  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -25641,17 +25632,17 @@
   i64.const 4294967297
   i32.const 10
   call $~lib/util/number/utoa64
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   i32.const 19440
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=4
-  local.get $55
+  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -25665,17 +25656,17 @@
   i64.const 68719476735
   i32.const 10
   call $~lib/util/number/utoa64
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   i32.const 19488
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=4
-  local.get $55
+  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -25689,17 +25680,17 @@
   i64.const 868719476735
   i32.const 10
   call $~lib/util/number/utoa64
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   i32.const 19536
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=4
-  local.get $55
+  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -25713,17 +25704,17 @@
   i64.const 8687194767350
   i32.const 10
   call $~lib/util/number/utoa64
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   i32.const 19584
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=4
-  local.get $55
+  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -25737,17 +25728,17 @@
   i64.const 86871947673501
   i32.const 10
   call $~lib/util/number/utoa64
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   i32.const 19632
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=4
-  local.get $55
+  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -25761,17 +25752,17 @@
   i64.const 999868719476735
   i32.const 10
   call $~lib/util/number/utoa64
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   i32.const 19680
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=4
-  local.get $55
+  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -25785,17 +25776,17 @@
   i64.const 9999868719476735
   i32.const 10
   call $~lib/util/number/utoa64
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   i32.const 19744
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=4
-  local.get $55
+  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -25809,17 +25800,17 @@
   i64.const 19999868719476735
   i32.const 10
   call $~lib/util/number/utoa64
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   i32.const 19808
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=4
-  local.get $55
+  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -25833,17 +25824,17 @@
   i64.const 129999868719476735
   i32.const 10
   call $~lib/util/number/utoa64
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   i32.const 19872
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=4
-  local.get $55
+  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -25857,17 +25848,17 @@
   i64.const 1239999868719476735
   i32.const 10
   call $~lib/util/number/utoa64
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   i32.const 19936
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=4
-  local.get $55
+  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -25881,17 +25872,17 @@
   global.get $~lib/builtins/u64.MAX_VALUE
   i32.const 10
   call $~lib/util/number/utoa64
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   i32.const 20000
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=4
-  local.get $55
+  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -25905,17 +25896,17 @@
   i64.const 0
   i32.const 10
   call $~lib/util/number/itoa64
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   i32.const 2368
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=4
-  local.get $55
+  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -25929,17 +25920,17 @@
   i64.const -1234
   i32.const 10
   call $~lib/util/number/itoa64
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   i32.const 20064
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=4
-  local.get $55
+  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -25953,17 +25944,17 @@
   i64.const 4294967295
   i32.const 10
   call $~lib/util/number/itoa64
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   i32.const 17440
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=4
-  local.get $55
+  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -25977,17 +25968,17 @@
   i64.const 4294967297
   i32.const 10
   call $~lib/util/number/itoa64
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   i32.const 19440
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=4
-  local.get $55
+  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -26001,17 +25992,17 @@
   i64.const -4294967295
   i32.const 10
   call $~lib/util/number/itoa64
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   i32.const 20096
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=4
-  local.get $55
+  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -26025,17 +26016,17 @@
   i64.const 68719476735
   i32.const 10
   call $~lib/util/number/itoa64
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   i32.const 19488
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=4
-  local.get $55
+  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -26049,17 +26040,17 @@
   i64.const -68719476735
   i32.const 10
   call $~lib/util/number/itoa64
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   i32.const 20144
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=4
-  local.get $55
+  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -26073,17 +26064,17 @@
   i64.const -868719476735
   i32.const 10
   call $~lib/util/number/itoa64
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   i32.const 20192
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=4
-  local.get $55
+  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -26097,17 +26088,17 @@
   i64.const -999868719476735
   i32.const 10
   call $~lib/util/number/itoa64
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   i32.const 20240
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=4
-  local.get $55
+  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -26121,17 +26112,17 @@
   i64.const -19999868719476735
   i32.const 10
   call $~lib/util/number/itoa64
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   i32.const 20304
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=4
-  local.get $55
+  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -26145,17 +26136,17 @@
   global.get $~lib/builtins/i64.MAX_VALUE
   i32.const 10
   call $~lib/util/number/itoa64
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   i32.const 20368
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=4
-  local.get $55
+  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -26169,17 +26160,17 @@
   global.get $~lib/builtins/i64.MIN_VALUE
   i32.const 10
   call $~lib/util/number/itoa64
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   i32.const 20432
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=4
-  local.get $55
+  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -26193,17 +26184,17 @@
   i64.const 0
   i32.const 16
   call $~lib/util/number/utoa64
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   i32.const 2368
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=4
-  local.get $55
+  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -26217,17 +26208,17 @@
   i64.const 1
   i32.const 16
   call $~lib/util/number/utoa64
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   i32.const 2432
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=4
-  local.get $55
+  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -26241,17 +26232,17 @@
   i64.const 12
   i32.const 16
   call $~lib/util/number/utoa64
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   i32.const 13440
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=4
-  local.get $55
+  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -26265,17 +26256,17 @@
   i64.const 1234
   i32.const 16
   call $~lib/util/number/utoa64
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   i32.const 17520
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=4
-  local.get $55
+  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -26289,17 +26280,17 @@
   i64.const 1111111
   i32.const 16
   call $~lib/util/number/utoa64
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   i32.const 17616
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=4
-  local.get $55
+  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -26313,17 +26304,17 @@
   i64.const 8589934591
   i32.const 16
   call $~lib/util/number/utoa64
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   i32.const 20496
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=4
-  local.get $55
+  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -26337,17 +26328,17 @@
   i64.const 5942249508321
   i32.const 16
   call $~lib/util/number/utoa64
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   i32.const 20544
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=4
-  local.get $55
+  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -26361,17 +26352,17 @@
   i64.const 76310993685985
   i32.const 16
   call $~lib/util/number/utoa64
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   i32.const 20592
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=4
-  local.get $55
+  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -26385,17 +26376,17 @@
   i64.const 920735923817967
   i32.const 16
   call $~lib/util/number/utoa64
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   i32.const 20640
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=4
-  local.get $55
+  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -26409,17 +26400,17 @@
   i64.const 9927935178558959
   i32.const 16
   call $~lib/util/number/utoa64
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   i32.const 20688
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=4
-  local.get $55
+  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -26433,17 +26424,17 @@
   i64.const 81985529216486895
   i32.const 16
   call $~lib/util/number/utoa64
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   i32.const 20736
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=4
-  local.get $55
+  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -26457,17 +26448,17 @@
   i64.const 1311768467463790320
   i32.const 16
   call $~lib/util/number/utoa64
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   i32.const 20800
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=4
-  local.get $55
+  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -26481,17 +26472,17 @@
   i64.const 9223372036854775807
   i32.const 16
   call $~lib/util/number/utoa64
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   i32.const 20864
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=4
-  local.get $55
+  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -26505,17 +26496,17 @@
   i64.const -1
   i32.const 16
   call $~lib/util/number/utoa64
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   i32.const 20928
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=4
-  local.get $55
+  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -26529,17 +26520,17 @@
   i64.const -9223372036854775807
   i32.const 16
   call $~lib/util/number/itoa64
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   i32.const 20992
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=4
-  local.get $55
+  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -26553,17 +26544,17 @@
   i64.const -9223372036854775808
   i32.const 16
   call $~lib/util/number/itoa64
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   i32.const 21056
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=4
-  local.get $55
+  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -26577,17 +26568,17 @@
   i64.const -9223372036854775808
   i32.const 16
   call $~lib/util/number/itoa64
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   i32.const 21056
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=4
-  local.get $55
+  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -26601,17 +26592,17 @@
   i64.const 0
   i32.const 2
   call $~lib/util/number/utoa64
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   i32.const 2368
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=4
-  local.get $55
+  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -26625,17 +26616,17 @@
   i64.const 1
   i32.const 2
   call $~lib/util/number/utoa64
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   i32.const 2432
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=4
-  local.get $55
+  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -26649,17 +26640,17 @@
   i64.const 7
   i32.const 2
   call $~lib/util/number/utoa64
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   i32.const 18096
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=4
-  local.get $55
+  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -26673,17 +26664,17 @@
   i64.const 14
   i32.const 2
   call $~lib/util/number/utoa64
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   i32.const 18128
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=4
-  local.get $55
+  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -26697,17 +26688,17 @@
   i64.const 59
   i32.const 2
   call $~lib/util/number/utoa64
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   i32.const 18192
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=4
-  local.get $55
+  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -26721,17 +26712,17 @@
   i64.const 4095
   i32.const 2
   call $~lib/util/number/utoa64
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   i32.const 18224
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=4
-  local.get $55
+  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -26745,17 +26736,17 @@
   i64.const 4294967295
   i32.const 2
   call $~lib/util/number/utoa64
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   i32.const 18640
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=4
-  local.get $55
+  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -26769,17 +26760,17 @@
   i64.const 562949953421311
   i32.const 2
   call $~lib/util/number/utoa64
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   i32.const 21120
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=4
-  local.get $55
+  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -26793,17 +26784,17 @@
   i64.const -1
   i32.const 2
   call $~lib/util/number/utoa64
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   i32.const 21248
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=4
-  local.get $55
+  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -26817,17 +26808,17 @@
   i64.const -8589934591
   i32.const 2
   call $~lib/util/number/itoa64
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   i32.const 21408
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=4
-  local.get $55
+  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -26841,17 +26832,17 @@
   i64.const -1
   i32.const 3
   call $~lib/util/number/utoa64
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   i32.const 21504
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=4
-  local.get $55
+  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -26865,17 +26856,17 @@
   i64.const -1
   i32.const 4
   call $~lib/util/number/utoa64
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   i32.const 21616
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=4
-  local.get $55
+  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -26889,17 +26880,17 @@
   i64.const -1
   i32.const 5
   call $~lib/util/number/utoa64
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   i32.const 21712
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=4
-  local.get $55
+  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -26913,17 +26904,17 @@
   i64.const -1
   i32.const 8
   call $~lib/util/number/utoa64
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   i32.const 21792
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=4
-  local.get $55
+  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -26937,17 +26928,17 @@
   i64.const -1
   i32.const 11
   call $~lib/util/number/utoa64
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   i32.const 21856
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=4
-  local.get $55
+  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -26961,17 +26952,17 @@
   i64.const -1
   i32.const 15
   call $~lib/util/number/utoa64
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   i32.const 21920
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=4
-  local.get $55
+  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -26985,17 +26976,17 @@
   i64.const -1
   i32.const 17
   call $~lib/util/number/utoa64
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   i32.const 21984
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=4
-  local.get $55
+  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -27009,17 +27000,17 @@
   i64.const -1
   i32.const 21
   call $~lib/util/number/utoa64
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   i32.const 22048
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=4
-  local.get $55
+  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -27033,17 +27024,17 @@
   i64.const -1
   i32.const 27
   call $~lib/util/number/utoa64
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   i32.const 22112
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=4
-  local.get $55
+  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -27057,17 +27048,17 @@
   i64.const -1
   i32.const 32
   call $~lib/util/number/utoa64
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   i32.const 22160
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=4
-  local.get $55
+  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -27081,17 +27072,17 @@
   i64.const -1
   i32.const 36
   call $~lib/util/number/utoa64
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   i32.const 22208
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=4
-  local.get $55
+  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -27104,17 +27095,17 @@
   end
   f64.const 0
   call $~lib/util/number/dtoa<f64>
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   i32.const 22256
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=4
-  local.get $55
+  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -27127,17 +27118,17 @@
   end
   f64.const -0
   call $~lib/util/number/dtoa<f64>
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   i32.const 22256
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=4
-  local.get $55
+  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -27150,17 +27141,17 @@
   end
   f64.const nan:0x8000000000000
   call $~lib/util/number/dtoa<f64>
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   i32.const 6672
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=4
-  local.get $55
+  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -27173,17 +27164,17 @@
   end
   f64.const inf
   call $~lib/util/number/dtoa<f64>
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   i32.const 22288
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=4
-  local.get $55
+  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -27197,17 +27188,17 @@
   f64.const inf
   f64.neg
   call $~lib/util/number/dtoa<f64>
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   i32.const 7936
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=4
-  local.get $55
+  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -27220,17 +27211,17 @@
   end
   global.get $~lib/builtins/f64.EPSILON
   call $~lib/util/number/dtoa<f64>
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   i32.const 7152
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=4
-  local.get $55
+  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -27244,17 +27235,17 @@
   global.get $~lib/builtins/f64.EPSILON
   f64.neg
   call $~lib/util/number/dtoa<f64>
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   i32.const 23312
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=4
-  local.get $55
+  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -27267,17 +27258,17 @@
   end
   global.get $~lib/builtins/f64.MAX_VALUE
   call $~lib/util/number/dtoa<f64>
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   i32.const 7216
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=4
-  local.get $55
+  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -27291,17 +27282,17 @@
   global.get $~lib/builtins/f64.MAX_VALUE
   f64.neg
   call $~lib/util/number/dtoa<f64>
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   i32.const 23376
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=4
-  local.get $55
+  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -27314,17 +27305,17 @@
   end
   global.get $~lib/builtins/f32.EPSILON
   call $~lib/util/number/dtoa<f32>
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   i32.const 23456
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=4
-  local.get $55
+  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -27338,17 +27329,17 @@
   global.get $~lib/builtins/f32.EPSILON
   f32.neg
   call $~lib/util/number/dtoa<f32>
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   i32.const 23504
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=4
-  local.get $55
+  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -27361,17 +27352,17 @@
   end
   global.get $~lib/builtins/f32.MAX_VALUE
   call $~lib/util/number/dtoa<f32>
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   i32.const 23552
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=4
-  local.get $55
+  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -27385,17 +27376,17 @@
   global.get $~lib/builtins/f32.MAX_VALUE
   f32.neg
   call $~lib/util/number/dtoa<f32>
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   i32.const 23600
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=4
-  local.get $55
+  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -27408,17 +27399,17 @@
   end
   f64.const 4185580496821356722454785e274
   call $~lib/util/number/dtoa<f64>
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   i32.const 23648
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=4
-  local.get $55
+  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -27431,17 +27422,17 @@
   end
   f64.const 2.2250738585072014e-308
   call $~lib/util/number/dtoa<f64>
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   i32.const 23712
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=4
-  local.get $55
+  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -27454,17 +27445,17 @@
   end
   f64.const 4.940656e-318
   call $~lib/util/number/dtoa<f64>
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   i32.const 23792
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=4
-  local.get $55
+  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -27477,17 +27468,17 @@
   end
   f64.const 9060801153433600
   call $~lib/util/number/dtoa<f64>
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   i32.const 23840
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=4
-  local.get $55
+  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -27500,17 +27491,17 @@
   end
   f64.const 4708356024711512064
   call $~lib/util/number/dtoa<f64>
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   i32.const 23904
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=4
-  local.get $55
+  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -27523,17 +27514,17 @@
   end
   f64.const 9409340012568248320
   call $~lib/util/number/dtoa<f64>
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   i32.const 23968
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=4
-  local.get $55
+  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -27546,17 +27537,17 @@
   end
   f64.const 5e-324
   call $~lib/util/number/dtoa<f64>
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   i32.const 7296
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=4
-  local.get $55
+  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -27569,17 +27560,17 @@
   end
   f64.const 1
   call $~lib/util/number/dtoa<f64>
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   i32.const 24032
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=4
-  local.get $55
+  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -27592,17 +27583,17 @@
   end
   f64.const 0.1
   call $~lib/util/number/dtoa<f64>
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   i32.const 4256
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=4
-  local.get $55
+  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -27615,17 +27606,17 @@
   end
   f64.const -1
   call $~lib/util/number/dtoa<f64>
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   i32.const 24064
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=4
-  local.get $55
+  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -27638,17 +27629,17 @@
   end
   f64.const -0.1
   call $~lib/util/number/dtoa<f64>
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   i32.const 24096
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=4
-  local.get $55
+  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -27661,17 +27652,17 @@
   end
   f64.const 1e6
   call $~lib/util/number/dtoa<f64>
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   i32.const 24128
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=4
-  local.get $55
+  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -27684,17 +27675,17 @@
   end
   f64.const 1e-06
   call $~lib/util/number/dtoa<f64>
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   i32.const 24176
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=4
-  local.get $55
+  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -27707,17 +27698,17 @@
   end
   f64.const -1e6
   call $~lib/util/number/dtoa<f64>
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   i32.const 24224
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=4
-  local.get $55
+  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -27730,17 +27721,17 @@
   end
   f64.const -1e-06
   call $~lib/util/number/dtoa<f64>
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   i32.const 24272
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=4
-  local.get $55
+  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -27753,17 +27744,17 @@
   end
   f64.const 1e7
   call $~lib/util/number/dtoa<f64>
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   i32.const 24320
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=4
-  local.get $55
+  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -27776,17 +27767,17 @@
   end
   f64.const 1e-07
   call $~lib/util/number/dtoa<f64>
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   i32.const 24368
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=4
-  local.get $55
+  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -27799,17 +27790,17 @@
   end
   f64.const 1.e+308
   call $~lib/util/number/dtoa<f64>
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   i32.const 4544
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=4
-  local.get $55
+  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -27822,17 +27813,17 @@
   end
   f64.const -1.e+308
   call $~lib/util/number/dtoa<f64>
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   i32.const 24400
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=4
-  local.get $55
+  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -27845,17 +27836,17 @@
   end
   f64.const inf
   call $~lib/util/number/dtoa<f64>
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   i32.const 22288
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=4
-  local.get $55
+  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -27868,17 +27859,17 @@
   end
   f64.const -inf
   call $~lib/util/number/dtoa<f64>
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   i32.const 7936
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=4
-  local.get $55
+  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -27891,17 +27882,17 @@
   end
   f64.const 1e-308
   call $~lib/util/number/dtoa<f64>
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   i32.const 24448
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=4
-  local.get $55
+  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -27914,17 +27905,17 @@
   end
   f64.const -1e-308
   call $~lib/util/number/dtoa<f64>
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   i32.const 24480
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=4
-  local.get $55
+  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -27937,17 +27928,17 @@
   end
   f64.const 1e-323
   call $~lib/util/number/dtoa<f64>
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   i32.const 24528
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=4
-  local.get $55
+  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -27960,17 +27951,17 @@
   end
   f64.const -1e-323
   call $~lib/util/number/dtoa<f64>
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   i32.const 24560
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=4
-  local.get $55
+  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -27983,17 +27974,17 @@
   end
   f64.const 0
   call $~lib/util/number/dtoa<f64>
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   i32.const 22256
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=4
-  local.get $55
+  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -28006,17 +27997,17 @@
   end
   i32.const -24
   call $~lib/util/number/dtoa<u32>
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   i32.const 24608
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=4
-  local.get $55
+  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -28029,17 +28020,17 @@
   end
   f64.const 1.2312145673456234e-08
   call $~lib/util/number/dtoa<f64>
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   i32.const 24656
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=4
-  local.get $55
+  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -28052,17 +28043,17 @@
   end
   f64.const 555555555.5555556
   call $~lib/util/number/dtoa<f64>
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   i32.const 24720
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=4
-  local.get $55
+  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -28075,17 +28066,17 @@
   end
   f64.const 0.9999999999999999
   call $~lib/util/number/dtoa<f64>
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   i32.const 24784
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=4
-  local.get $55
+  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -28098,17 +28089,17 @@
   end
   f64.const 1
   call $~lib/util/number/dtoa<f64>
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   i32.const 24032
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=4
-  local.get $55
+  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -28121,17 +28112,17 @@
   end
   f64.const 12.34
   call $~lib/util/number/dtoa<f64>
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   i32.const 24848
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=4
-  local.get $55
+  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -28146,17 +28137,17 @@
   f64.const 3
   f64.div
   call $~lib/util/number/dtoa<f64>
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   i32.const 24880
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=4
-  local.get $55
+  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -28169,17 +28160,17 @@
   end
   f64.const 1234e17
   call $~lib/util/number/dtoa<f64>
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   i32.const 24944
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=4
-  local.get $55
+  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -28192,17 +28183,17 @@
   end
   f64.const 1234e18
   call $~lib/util/number/dtoa<f64>
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   i32.const 25024
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=4
-  local.get $55
+  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -28215,17 +28206,17 @@
   end
   f64.const 2.71828
   call $~lib/util/number/dtoa<f64>
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   i32.const 25072
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=4
-  local.get $55
+  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -28238,17 +28229,17 @@
   end
   f64.const 0.0271828
   call $~lib/util/number/dtoa<f64>
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   i32.const 25120
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=4
-  local.get $55
+  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -28261,17 +28252,17 @@
   end
   f64.const 271.828
   call $~lib/util/number/dtoa<f64>
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   i32.const 25168
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=4
-  local.get $55
+  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -28284,17 +28275,17 @@
   end
   f64.const 1.1e+128
   call $~lib/util/number/dtoa<f64>
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   i32.const 25216
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=4
-  local.get $55
+  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -28307,17 +28298,17 @@
   end
   f64.const 1.1e-64
   call $~lib/util/number/dtoa<f64>
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   i32.const 25264
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=4
-  local.get $55
+  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -28330,17 +28321,17 @@
   end
   f64.const 0.000035689
   call $~lib/util/number/dtoa<f64>
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   i32.const 25312
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=4
-  local.get $55
+  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -28352,29 +28343,29 @@
    unreachable
   end
   i32.const 25360
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=8
-  local.get $55
+  local.get $52
   i32.const 25392
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=12
-  local.get $55
+  local.get $52
   call $~lib/string/String#concat
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   i32.const 25424
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=4
-  local.get $55
+  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -28386,29 +28377,29 @@
    unreachable
   end
   i32.const 688
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=8
-  local.get $55
+  local.get $52
   i32.const 25472
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=12
-  local.get $55
+  local.get $52
   call $~lib/string/String#concat
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   i32.const 25472
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=4
-  local.get $55
+  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -28420,29 +28411,29 @@
    unreachable
   end
   i32.const 25472
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=8
-  local.get $55
+  local.get $52
   i32.const 688
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=12
-  local.get $55
+  local.get $52
   call $~lib/string/String#concat
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   i32.const 25472
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=4
-  local.get $55
+  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -28454,29 +28445,29 @@
    unreachable
   end
   i32.const 688
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=8
-  local.get $55
+  local.get $52
   i32.const 688
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=12
-  local.get $55
+  local.get $52
   call $~lib/string/String#concat
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   i32.const 688
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=4
-  local.get $55
+  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -28488,17 +28479,17 @@
    unreachable
   end
   i32.const 25504
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   i32.const 25504
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=4
-  local.get $55
+  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -28510,17 +28501,17 @@
    unreachable
   end
   i32.const 25504
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   i32.const 25504
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=4
-  local.get $55
+  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -28532,17 +28523,17 @@
    unreachable
   end
   i32.const 25536
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   i32.const 25536
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=4
-  local.get $55
+  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -28554,17 +28545,17 @@
    unreachable
   end
   i32.const 25568
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store
-  local.get $55
+  local.get $52
   i32.const 25568
-  local.set $55
+  local.set $52
   global.get $~lib/memory/__stack_pointer
-  local.get $55
+  local.get $52
   i32.store offset=4
-  local.get $55
+  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if

--- a/tests/compiler/std/string.release.wat
+++ b/tests/compiler/std/string.release.wat
@@ -9711,11 +9711,11 @@
   (local $9 i32)
   (local $10 i32)
   global.get $~lib/memory/__stack_pointer
-  i32.const 40
+  i32.const 36
   i32.sub
   global.set $~lib/memory/__stack_pointer
-  block $folding-inner3
-   block $folding-inner2
+  block $folding-inner4
+   block $folding-inner3
     block $folding-inner1
      block $folding-inner0
       global.get $~lib/memory/__stack_pointer
@@ -9724,7 +9724,7 @@
       br_if $folding-inner0
       global.get $~lib/memory/__stack_pointer
       i32.const 0
-      i32.const 40
+      i32.const 36
       memory.fill
       local.get $2
       i32.eqz
@@ -9739,10 +9739,6 @@
        call $~lib/rt/__newArray
        local.tee $2
        i32.store
-       global.get $~lib/memory/__stack_pointer
-       local.get $2
-       i32.load offset=4
-       i32.store offset=4
        global.get $~lib/memory/__stack_pointer
        i32.const 4
        i32.sub
@@ -9786,37 +9782,37 @@
        i32.const 4
        i32.add
        global.set $~lib/memory/__stack_pointer
-       br $folding-inner2
+       br $folding-inner4
       end
       global.get $~lib/memory/__stack_pointer
       local.get $0
-      i32.store offset=8
+      i32.store offset=4
       local.get $0
       i32.const 20
       i32.sub
       i32.load offset=16
       i32.const 1
       i32.shr_u
-      local.set $8
+      local.set $6
       global.get $~lib/memory/__stack_pointer
       local.get $1
-      i32.store offset=8
+      i32.store offset=4
       i32.const 2147483647
       local.get $2
       local.get $2
       i32.const 0
       i32.lt_s
       select
-      local.set $2
+      local.set $8
       local.get $1
       i32.const 20
       i32.sub
       i32.load offset=16
       i32.const 1
       i32.shr_u
-      local.tee $5
+      local.tee $4
       if
-       local.get $8
+       local.get $6
        i32.eqz
        if
         global.get $~lib/memory/__stack_pointer
@@ -9825,36 +9821,36 @@
         i32.const 0
         call $~lib/rt/__newArray
         local.tee $2
-        i32.store offset=20
+        i32.store offset=16
         global.get $~lib/memory/__stack_pointer
         local.get $2
-        i32.store offset=8
+        i32.store offset=4
         local.get $2
         i32.load offset=4
         i32.const 1712
         i32.store
-        br $folding-inner2
+        br $folding-inner4
        end
       else
-       local.get $8
+       local.get $6
        i32.eqz
        br_if $folding-inner1
        global.get $~lib/memory/__stack_pointer
+       local.get $6
        local.get $8
-       local.get $2
-       local.get $2
+       local.get $6
        local.get $8
-       i32.gt_s
+       i32.lt_s
        select
        local.tee $3
        i32.const 5
        i32.const 0
        call $~lib/rt/__newArray
        local.tee $2
-       i32.store offset=12
+       i32.store offset=8
        global.get $~lib/memory/__stack_pointer
        local.get $2
-       i32.store offset=8
+       i32.store offset=4
        local.get $2
        i32.load offset=4
        local.set $4
@@ -9870,7 +9866,7 @@
          i32.const 2
          call $~lib/rt/itcms/__new
          local.tee $5
-         i32.store offset=16
+         i32.store offset=12
          local.get $5
          local.get $0
          local.get $1
@@ -9897,31 +9893,31 @@
          br $for-loop|0
         end
        end
-       br $folding-inner2
+       br $folding-inner4
       end
       global.get $~lib/memory/__stack_pointer
       i32.const 0
       i32.const 5
       i32.const 0
       call $~lib/rt/__newArray
-      local.tee $9
-      i32.store offset=24
+      local.tee $2
+      i32.store offset=20
       loop $while-continue|1
        global.get $~lib/memory/__stack_pointer
        local.get $0
-       i32.store offset=8
+       i32.store offset=4
        global.get $~lib/memory/__stack_pointer
        local.get $1
-       i32.store offset=28
+       i32.store offset=24
        local.get $0
        local.get $1
        local.get $3
        call $~lib/string/String#indexOf
-       local.tee $6
+       local.tee $9
        i32.const -1
        i32.xor
        if
-        local.get $6
+        local.get $9
         local.get $3
         i32.sub
         local.tee $7
@@ -9932,48 +9928,48 @@
          local.get $7
          i32.const 1
          i32.shl
-         local.tee $7
+         local.tee $10
          i32.const 2
          call $~lib/rt/itcms/__new
-         local.tee $10
-         i32.store offset=32
-         local.get $10
+         local.tee $7
+         i32.store offset=28
+         local.get $7
          local.get $0
          local.get $3
          i32.const 1
          i32.shl
          i32.add
-         local.get $7
+         local.get $10
          memory.copy
          global.get $~lib/memory/__stack_pointer
-         local.get $9
-         i32.store offset=8
+         local.get $2
+         i32.store offset=4
          global.get $~lib/memory/__stack_pointer
-         local.get $10
-         i32.store offset=28
-         local.get $9
-         local.get $10
+         local.get $7
+         i32.store offset=24
+         local.get $2
+         local.get $7
          call $~lib/array/Array<~lib/string/String>#push
         else
          global.get $~lib/memory/__stack_pointer
-         local.get $9
-         i32.store offset=8
+         local.get $2
+         i32.store offset=4
          global.get $~lib/memory/__stack_pointer
          i32.const 1712
-         i32.store offset=28
-         local.get $9
+         i32.store offset=24
+         local.get $2
          i32.const 1712
          call $~lib/array/Array<~lib/string/String>#push
         end
-        local.get $4
+        local.get $5
         i32.const 1
         i32.add
-        local.tee $4
-        local.get $2
+        local.tee $5
+        local.get $8
         i32.eq
         br_if $folding-inner3
-        local.get $5
-        local.get $6
+        local.get $4
+        local.get $9
         i32.add
         local.set $3
         br $while-continue|1
@@ -9983,17 +9979,17 @@
       i32.eqz
       if
        global.get $~lib/memory/__stack_pointer
-       local.get $9
-       i32.store offset=8
+       local.get $2
+       i32.store offset=4
        global.get $~lib/memory/__stack_pointer
        local.get $0
-       i32.store offset=28
-       local.get $9
+       i32.store offset=24
+       local.get $2
        local.get $0
        call $~lib/array/Array<~lib/string/String>#push
        br $folding-inner3
       end
-      local.get $8
+      local.get $6
       local.get $3
       i32.sub
       local.tee $1
@@ -10007,9 +10003,9 @@
        local.tee $1
        i32.const 2
        call $~lib/rt/itcms/__new
-       local.tee $2
-       i32.store offset=36
-       local.get $2
+       local.tee $4
+       i32.store offset=32
+       local.get $4
        local.get $0
        local.get $3
        i32.const 1
@@ -10018,31 +10014,26 @@
        local.get $1
        memory.copy
        global.get $~lib/memory/__stack_pointer
-       local.get $9
-       i32.store offset=8
+       local.get $2
+       i32.store offset=4
        global.get $~lib/memory/__stack_pointer
+       local.get $4
+       i32.store offset=24
        local.get $2
-       i32.store offset=28
-       local.get $9
-       local.get $2
+       local.get $4
        call $~lib/array/Array<~lib/string/String>#push
       else
        global.get $~lib/memory/__stack_pointer
-       local.get $9
-       i32.store offset=8
+       local.get $2
+       i32.store offset=4
        global.get $~lib/memory/__stack_pointer
        i32.const 1712
-       i32.store offset=28
-       local.get $9
+       i32.store offset=24
+       local.get $2
        i32.const 1712
        call $~lib/array/Array<~lib/string/String>#push
       end
-      global.get $~lib/memory/__stack_pointer
-      i32.const 40
-      i32.add
-      global.set $~lib/memory/__stack_pointer
-      local.get $9
-      return
+      br $folding-inner4
      end
      i32.const 59424
      i32.const 59472
@@ -10056,19 +10047,20 @@
     i32.const 0
     call $~lib/rt/__newArray
     local.set $2
+    br $folding-inner4
    end
    global.get $~lib/memory/__stack_pointer
-   i32.const 40
+   i32.const 36
    i32.add
    global.set $~lib/memory/__stack_pointer
    local.get $2
    return
   end
   global.get $~lib/memory/__stack_pointer
-  i32.const 40
+  i32.const 36
   i32.add
   global.set $~lib/memory/__stack_pointer
-  local.get $9
+  local.get $2
  )
  (func $~lib/string/String#split@varargs (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)

--- a/tests/compiler/std/typedarray.debug.wat
+++ b/tests/compiler/std/typedarray.debug.wat
@@ -66095,11 +66095,6 @@
   (local $7 i32)
   (local $8 i32)
   (local $9 i32)
-  (local $10 i32)
-  (local $11 i32)
-  (local $12 i32)
-  (local $13 i32)
-  (local $14 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 24
   i32.sub
@@ -66116,29 +66111,29 @@
   local.tee $setSource4
   i32.store
   local.get $setSource4
-  local.set $14
+  local.set $9
   global.get $~lib/memory/__stack_pointer
-  local.get $14
+  local.get $9
   i32.store offset=4
-  local.get $14
+  local.get $9
   i32.const 0
   i64.const 7
   call $~lib/typedarray/Int64Array#__set
   local.get $setSource4
-  local.set $14
+  local.set $9
   global.get $~lib/memory/__stack_pointer
-  local.get $14
+  local.get $9
   i32.store offset=4
-  local.get $14
+  local.get $9
   i32.const 1
   i64.const 8
   call $~lib/typedarray/Int64Array#__set
   local.get $setSource4
-  local.set $14
+  local.set $9
   global.get $~lib/memory/__stack_pointer
-  local.get $14
+  local.get $9
   i32.store offset=4
-  local.get $14
+  local.get $9
   i32.const 2
   i64.const 9
   call $~lib/typedarray/Int64Array#__set
@@ -66149,38 +66144,38 @@
   local.tee $setSource5
   i32.store offset=8
   local.get $setSource5
-  local.set $14
+  local.set $9
   global.get $~lib/memory/__stack_pointer
-  local.get $14
+  local.get $9
   i32.store offset=4
-  local.get $14
+  local.get $9
   i32.const 0
   i32.const 100
   call $~lib/typedarray/Uint8Array#__set
   local.get $setSource5
-  local.set $14
+  local.set $9
   global.get $~lib/memory/__stack_pointer
-  local.get $14
+  local.get $9
   i32.store offset=4
-  local.get $14
+  local.get $9
   i32.const 1
   i32.const 101
   call $~lib/typedarray/Uint8Array#__set
   local.get $setSource5
-  local.set $14
+  local.set $9
   global.get $~lib/memory/__stack_pointer
-  local.get $14
+  local.get $9
   i32.store offset=4
-  local.get $14
+  local.get $9
   i32.const 2
   i32.const 102
   call $~lib/typedarray/Uint8Array#__set
   local.get $setSource5
-  local.set $14
+  local.set $9
   global.get $~lib/memory/__stack_pointer
-  local.get $14
+  local.get $9
   i32.store offset=4
-  local.get $14
+  local.get $9
   i32.const 3
   i32.const 103
   call $~lib/typedarray/Uint8Array#__set
@@ -66191,29 +66186,29 @@
   local.tee $setSource6
   i32.store offset=12
   local.get $setSource6
-  local.set $14
+  local.set $9
   global.get $~lib/memory/__stack_pointer
-  local.get $14
+  local.get $9
   i32.store offset=4
-  local.get $14
+  local.get $9
   i32.const 0
   i32.const 1000
   call $~lib/typedarray/Int16Array#__set
   local.get $setSource6
-  local.set $14
+  local.set $9
   global.get $~lib/memory/__stack_pointer
-  local.get $14
+  local.get $9
   i32.store offset=4
-  local.get $14
+  local.get $9
   i32.const 1
   i32.const 1001
   call $~lib/typedarray/Int16Array#__set
   local.get $setSource6
-  local.set $14
+  local.set $9
   global.get $~lib/memory/__stack_pointer
-  local.get $14
+  local.get $9
   i32.store offset=4
-  local.get $14
+  local.get $9
   i32.const 2
   i32.const 1002
   call $~lib/typedarray/Int16Array#__set
@@ -66224,191 +66219,191 @@
   local.tee $a
   i32.store offset=16
   local.get $a
-  local.set $14
+  local.set $9
   global.get $~lib/memory/__stack_pointer
-  local.get $14
+  local.get $9
   i32.store offset=4
-  local.get $14
+  local.get $9
   global.get $std/typedarray/setSource1
-  local.set $14
+  local.set $9
   global.get $~lib/memory/__stack_pointer
-  local.get $14
+  local.get $9
   i32.store offset=20
-  local.get $14
+  local.get $9
   i32.const 0
   call $~lib/typedarray/Int8Array#set<~lib/array/Array<i32>>
   local.get $a
-  local.set $14
+  local.set $9
   global.get $~lib/memory/__stack_pointer
-  local.get $14
+  local.get $9
   i32.store offset=4
-  local.get $14
+  local.get $9
   i32.const 10
   i32.const 0
   i32.const 16
   i32.const 10288
   call $~lib/rt/__newArray
-  local.set $14
+  local.set $9
   global.get $~lib/memory/__stack_pointer
-  local.get $14
+  local.get $9
   i32.store offset=20
-  local.get $14
+  local.get $9
   call $std/typedarray/valuesEqual<~lib/typedarray/Int8Array>
   local.get $a
-  local.set $14
+  local.set $9
   global.get $~lib/memory/__stack_pointer
-  local.get $14
+  local.get $9
   i32.store offset=4
-  local.get $14
+  local.get $9
   global.get $std/typedarray/setSource2
-  local.set $14
+  local.set $9
   global.get $~lib/memory/__stack_pointer
-  local.get $14
+  local.get $9
   i32.store offset=20
-  local.get $14
+  local.get $9
   i32.const 3
   call $~lib/typedarray/Int8Array#set<~lib/array/Array<f32>>
   local.get $a
-  local.set $14
+  local.set $9
   global.get $~lib/memory/__stack_pointer
-  local.get $14
+  local.get $9
   i32.store offset=4
-  local.get $14
+  local.get $9
   i32.const 10
   i32.const 0
   i32.const 16
   i32.const 10368
   call $~lib/rt/__newArray
-  local.set $14
+  local.set $9
   global.get $~lib/memory/__stack_pointer
-  local.get $14
+  local.get $9
   i32.store offset=20
-  local.get $14
+  local.get $9
   call $std/typedarray/valuesEqual<~lib/typedarray/Int8Array>
   local.get $a
-  local.set $14
+  local.set $9
   global.get $~lib/memory/__stack_pointer
-  local.get $14
+  local.get $9
   i32.store offset=4
-  local.get $14
+  local.get $9
   local.get $setSource4
-  local.set $14
+  local.set $9
   global.get $~lib/memory/__stack_pointer
-  local.get $14
+  local.get $9
   i32.store offset=20
-  local.get $14
+  local.get $9
   i32.const 6
   call $~lib/typedarray/Int8Array#set<~lib/typedarray/Int64Array>
   local.get $a
-  local.set $14
+  local.set $9
   global.get $~lib/memory/__stack_pointer
-  local.get $14
+  local.get $9
   i32.store offset=4
-  local.get $14
+  local.get $9
   i32.const 10
   i32.const 0
   i32.const 16
   i32.const 10400
   call $~lib/rt/__newArray
-  local.set $14
+  local.set $9
   global.get $~lib/memory/__stack_pointer
-  local.get $14
+  local.get $9
   i32.store offset=20
-  local.get $14
+  local.get $9
   call $std/typedarray/valuesEqual<~lib/typedarray/Int8Array>
   i32.const 1
   drop
   local.get $a
-  local.set $14
+  local.set $9
   global.get $~lib/memory/__stack_pointer
-  local.get $14
+  local.get $9
   i32.store offset=4
-  local.get $14
+  local.get $9
   global.get $std/typedarray/setSource3
-  local.set $14
+  local.set $9
   global.get $~lib/memory/__stack_pointer
-  local.get $14
+  local.get $9
   i32.store offset=20
-  local.get $14
+  local.get $9
   i32.const 2
   call $~lib/typedarray/Int8Array#set<~lib/array/Array<f64>>
   local.get $a
-  local.set $14
+  local.set $9
   global.get $~lib/memory/__stack_pointer
-  local.get $14
+  local.get $9
   i32.store offset=4
-  local.get $14
+  local.get $9
   i32.const 10
   i32.const 0
   i32.const 16
   i32.const 10432
   call $~lib/rt/__newArray
-  local.set $14
+  local.set $9
   global.get $~lib/memory/__stack_pointer
-  local.get $14
+  local.get $9
   i32.store offset=20
-  local.get $14
+  local.get $9
   call $std/typedarray/valuesEqual<~lib/typedarray/Int8Array>
   local.get $a
-  local.set $14
+  local.set $9
   global.get $~lib/memory/__stack_pointer
-  local.get $14
+  local.get $9
   i32.store offset=4
-  local.get $14
+  local.get $9
   local.get $setSource5
-  local.set $14
+  local.set $9
   global.get $~lib/memory/__stack_pointer
-  local.get $14
+  local.get $9
   i32.store offset=20
-  local.get $14
+  local.get $9
   i32.const 0
   call $~lib/typedarray/Int8Array#set<~lib/typedarray/Uint8Array>
   local.get $a
-  local.set $14
+  local.set $9
   global.get $~lib/memory/__stack_pointer
-  local.get $14
+  local.get $9
   i32.store offset=4
-  local.get $14
+  local.get $9
   local.get $setSource6
-  local.set $14
+  local.set $9
   global.get $~lib/memory/__stack_pointer
-  local.get $14
+  local.get $9
   i32.store offset=20
-  local.get $14
+  local.get $9
   i32.const 4
   call $~lib/typedarray/Int8Array#set<~lib/typedarray/Int16Array>
   local.get $a
-  local.set $14
+  local.set $9
   global.get $~lib/memory/__stack_pointer
-  local.get $14
+  local.get $9
   i32.store offset=4
-  local.get $14
+  local.get $9
   global.get $std/typedarray/setSource7
-  local.set $14
+  local.set $9
   global.get $~lib/memory/__stack_pointer
-  local.get $14
+  local.get $9
   i32.store offset=20
-  local.get $14
+  local.get $9
   i32.const 7
   call $~lib/typedarray/Int8Array#set<~lib/array/Array<i8>>
   i32.const 0
   drop
   local.get $a
-  local.set $14
+  local.set $9
   global.get $~lib/memory/__stack_pointer
-  local.get $14
+  local.get $9
   i32.store offset=4
-  local.get $14
+  local.get $9
   i32.const 10
   i32.const 0
   i32.const 16
   i32.const 10464
   call $~lib/rt/__newArray
-  local.set $14
+  local.set $9
   global.get $~lib/memory/__stack_pointer
-  local.get $14
+  local.get $9
   i32.store offset=20
-  local.get $14
+  local.get $9
   call $std/typedarray/valuesEqual<~lib/typedarray/Int8Array>
   global.get $~lib/memory/__stack_pointer
   i32.const 24
@@ -67493,11 +67488,6 @@
   (local $7 i32)
   (local $8 i32)
   (local $9 i32)
-  (local $10 i32)
-  (local $11 i32)
-  (local $12 i32)
-  (local $13 i32)
-  (local $14 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 24
   i32.sub
@@ -67514,29 +67504,29 @@
   local.tee $setSource4
   i32.store
   local.get $setSource4
-  local.set $14
+  local.set $9
   global.get $~lib/memory/__stack_pointer
-  local.get $14
+  local.get $9
   i32.store offset=4
-  local.get $14
+  local.get $9
   i32.const 0
   i64.const 7
   call $~lib/typedarray/Int64Array#__set
   local.get $setSource4
-  local.set $14
+  local.set $9
   global.get $~lib/memory/__stack_pointer
-  local.get $14
+  local.get $9
   i32.store offset=4
-  local.get $14
+  local.get $9
   i32.const 1
   i64.const 8
   call $~lib/typedarray/Int64Array#__set
   local.get $setSource4
-  local.set $14
+  local.set $9
   global.get $~lib/memory/__stack_pointer
-  local.get $14
+  local.get $9
   i32.store offset=4
-  local.get $14
+  local.get $9
   i32.const 2
   i64.const 9
   call $~lib/typedarray/Int64Array#__set
@@ -67547,38 +67537,38 @@
   local.tee $setSource5
   i32.store offset=8
   local.get $setSource5
-  local.set $14
+  local.set $9
   global.get $~lib/memory/__stack_pointer
-  local.get $14
+  local.get $9
   i32.store offset=4
-  local.get $14
+  local.get $9
   i32.const 0
   i32.const 100
   call $~lib/typedarray/Uint8Array#__set
   local.get $setSource5
-  local.set $14
+  local.set $9
   global.get $~lib/memory/__stack_pointer
-  local.get $14
+  local.get $9
   i32.store offset=4
-  local.get $14
+  local.get $9
   i32.const 1
   i32.const 101
   call $~lib/typedarray/Uint8Array#__set
   local.get $setSource5
-  local.set $14
+  local.set $9
   global.get $~lib/memory/__stack_pointer
-  local.get $14
+  local.get $9
   i32.store offset=4
-  local.get $14
+  local.get $9
   i32.const 2
   i32.const 102
   call $~lib/typedarray/Uint8Array#__set
   local.get $setSource5
-  local.set $14
+  local.set $9
   global.get $~lib/memory/__stack_pointer
-  local.get $14
+  local.get $9
   i32.store offset=4
-  local.get $14
+  local.get $9
   i32.const 3
   i32.const 103
   call $~lib/typedarray/Uint8Array#__set
@@ -67589,29 +67579,29 @@
   local.tee $setSource6
   i32.store offset=12
   local.get $setSource6
-  local.set $14
+  local.set $9
   global.get $~lib/memory/__stack_pointer
-  local.get $14
+  local.get $9
   i32.store offset=4
-  local.get $14
+  local.get $9
   i32.const 0
   i32.const 1000
   call $~lib/typedarray/Int16Array#__set
   local.get $setSource6
-  local.set $14
+  local.set $9
   global.get $~lib/memory/__stack_pointer
-  local.get $14
+  local.get $9
   i32.store offset=4
-  local.get $14
+  local.get $9
   i32.const 1
   i32.const 1001
   call $~lib/typedarray/Int16Array#__set
   local.get $setSource6
-  local.set $14
+  local.set $9
   global.get $~lib/memory/__stack_pointer
-  local.get $14
+  local.get $9
   i32.store offset=4
-  local.get $14
+  local.get $9
   i32.const 2
   i32.const 1002
   call $~lib/typedarray/Int16Array#__set
@@ -67622,191 +67612,191 @@
   local.tee $a
   i32.store offset=16
   local.get $a
-  local.set $14
+  local.set $9
   global.get $~lib/memory/__stack_pointer
-  local.get $14
+  local.get $9
   i32.store offset=4
-  local.get $14
+  local.get $9
   global.get $std/typedarray/setSource1
-  local.set $14
+  local.set $9
   global.get $~lib/memory/__stack_pointer
-  local.get $14
+  local.get $9
   i32.store offset=20
-  local.get $14
+  local.get $9
   i32.const 0
   call $~lib/typedarray/Uint8Array#set<~lib/array/Array<i32>>
   local.get $a
-  local.set $14
+  local.set $9
   global.get $~lib/memory/__stack_pointer
-  local.get $14
+  local.get $9
   i32.store offset=4
-  local.get $14
+  local.get $9
   i32.const 10
   i32.const 0
   i32.const 64
   i32.const 10496
   call $~lib/rt/__newArray
-  local.set $14
+  local.set $9
   global.get $~lib/memory/__stack_pointer
-  local.get $14
+  local.get $9
   i32.store offset=20
-  local.get $14
+  local.get $9
   call $std/typedarray/valuesEqual<~lib/typedarray/Uint8Array>
   local.get $a
-  local.set $14
+  local.set $9
   global.get $~lib/memory/__stack_pointer
-  local.get $14
+  local.get $9
   i32.store offset=4
-  local.get $14
+  local.get $9
   global.get $std/typedarray/setSource2
-  local.set $14
+  local.set $9
   global.get $~lib/memory/__stack_pointer
-  local.get $14
+  local.get $9
   i32.store offset=20
-  local.get $14
+  local.get $9
   i32.const 3
   call $~lib/typedarray/Uint8Array#set<~lib/array/Array<f32>>
   local.get $a
-  local.set $14
+  local.set $9
   global.get $~lib/memory/__stack_pointer
-  local.get $14
+  local.get $9
   i32.store offset=4
-  local.get $14
+  local.get $9
   i32.const 10
   i32.const 0
   i32.const 64
   i32.const 10576
   call $~lib/rt/__newArray
-  local.set $14
+  local.set $9
   global.get $~lib/memory/__stack_pointer
-  local.get $14
+  local.get $9
   i32.store offset=20
-  local.get $14
+  local.get $9
   call $std/typedarray/valuesEqual<~lib/typedarray/Uint8Array>
   local.get $a
-  local.set $14
+  local.set $9
   global.get $~lib/memory/__stack_pointer
-  local.get $14
+  local.get $9
   i32.store offset=4
-  local.get $14
+  local.get $9
   local.get $setSource4
-  local.set $14
+  local.set $9
   global.get $~lib/memory/__stack_pointer
-  local.get $14
+  local.get $9
   i32.store offset=20
-  local.get $14
+  local.get $9
   i32.const 6
   call $~lib/typedarray/Uint8Array#set<~lib/typedarray/Int64Array>
   local.get $a
-  local.set $14
+  local.set $9
   global.get $~lib/memory/__stack_pointer
-  local.get $14
+  local.get $9
   i32.store offset=4
-  local.get $14
+  local.get $9
   i32.const 10
   i32.const 0
   i32.const 64
   i32.const 10608
   call $~lib/rt/__newArray
-  local.set $14
+  local.set $9
   global.get $~lib/memory/__stack_pointer
-  local.get $14
+  local.get $9
   i32.store offset=20
-  local.get $14
+  local.get $9
   call $std/typedarray/valuesEqual<~lib/typedarray/Uint8Array>
   i32.const 1
   drop
   local.get $a
-  local.set $14
+  local.set $9
   global.get $~lib/memory/__stack_pointer
-  local.get $14
+  local.get $9
   i32.store offset=4
-  local.get $14
+  local.get $9
   global.get $std/typedarray/setSource3
-  local.set $14
+  local.set $9
   global.get $~lib/memory/__stack_pointer
-  local.get $14
+  local.get $9
   i32.store offset=20
-  local.get $14
+  local.get $9
   i32.const 2
   call $~lib/typedarray/Uint8Array#set<~lib/array/Array<f64>>
   local.get $a
-  local.set $14
+  local.set $9
   global.get $~lib/memory/__stack_pointer
-  local.get $14
+  local.get $9
   i32.store offset=4
-  local.get $14
+  local.get $9
   i32.const 10
   i32.const 0
   i32.const 64
   i32.const 10640
   call $~lib/rt/__newArray
-  local.set $14
+  local.set $9
   global.get $~lib/memory/__stack_pointer
-  local.get $14
+  local.get $9
   i32.store offset=20
-  local.get $14
+  local.get $9
   call $std/typedarray/valuesEqual<~lib/typedarray/Uint8Array>
   local.get $a
-  local.set $14
+  local.set $9
   global.get $~lib/memory/__stack_pointer
-  local.get $14
+  local.get $9
   i32.store offset=4
-  local.get $14
+  local.get $9
   local.get $setSource5
-  local.set $14
+  local.set $9
   global.get $~lib/memory/__stack_pointer
-  local.get $14
+  local.get $9
   i32.store offset=20
-  local.get $14
+  local.get $9
   i32.const 0
   call $~lib/typedarray/Uint8Array#set<~lib/typedarray/Uint8Array>
   local.get $a
-  local.set $14
+  local.set $9
   global.get $~lib/memory/__stack_pointer
-  local.get $14
+  local.get $9
   i32.store offset=4
-  local.get $14
+  local.get $9
   local.get $setSource6
-  local.set $14
+  local.set $9
   global.get $~lib/memory/__stack_pointer
-  local.get $14
+  local.get $9
   i32.store offset=20
-  local.get $14
+  local.get $9
   i32.const 4
   call $~lib/typedarray/Uint8Array#set<~lib/typedarray/Int16Array>
   local.get $a
-  local.set $14
+  local.set $9
   global.get $~lib/memory/__stack_pointer
-  local.get $14
+  local.get $9
   i32.store offset=4
-  local.get $14
+  local.get $9
   global.get $std/typedarray/setSource7
-  local.set $14
+  local.set $9
   global.get $~lib/memory/__stack_pointer
-  local.get $14
+  local.get $9
   i32.store offset=20
-  local.get $14
+  local.get $9
   i32.const 7
   call $~lib/typedarray/Uint8Array#set<~lib/array/Array<i8>>
   i32.const 0
   drop
   local.get $a
-  local.set $14
+  local.set $9
   global.get $~lib/memory/__stack_pointer
-  local.get $14
+  local.get $9
   i32.store offset=4
-  local.get $14
+  local.get $9
   i32.const 10
   i32.const 0
   i32.const 64
   i32.const 10672
   call $~lib/rt/__newArray
-  local.set $14
+  local.set $9
   global.get $~lib/memory/__stack_pointer
-  local.get $14
+  local.get $9
   i32.store offset=20
-  local.get $14
+  local.get $9
   call $std/typedarray/valuesEqual<~lib/typedarray/Uint8Array>
   global.get $~lib/memory/__stack_pointer
   i32.const 24
@@ -68952,11 +68942,6 @@
   (local $7 i32)
   (local $8 i32)
   (local $9 i32)
-  (local $10 i32)
-  (local $11 i32)
-  (local $12 i32)
-  (local $13 i32)
-  (local $14 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 24
   i32.sub
@@ -68973,29 +68958,29 @@
   local.tee $setSource4
   i32.store
   local.get $setSource4
-  local.set $14
+  local.set $9
   global.get $~lib/memory/__stack_pointer
-  local.get $14
+  local.get $9
   i32.store offset=4
-  local.get $14
+  local.get $9
   i32.const 0
   i64.const 7
   call $~lib/typedarray/Int64Array#__set
   local.get $setSource4
-  local.set $14
+  local.set $9
   global.get $~lib/memory/__stack_pointer
-  local.get $14
+  local.get $9
   i32.store offset=4
-  local.get $14
+  local.get $9
   i32.const 1
   i64.const 8
   call $~lib/typedarray/Int64Array#__set
   local.get $setSource4
-  local.set $14
+  local.set $9
   global.get $~lib/memory/__stack_pointer
-  local.get $14
+  local.get $9
   i32.store offset=4
-  local.get $14
+  local.get $9
   i32.const 2
   i64.const 9
   call $~lib/typedarray/Int64Array#__set
@@ -69006,38 +68991,38 @@
   local.tee $setSource5
   i32.store offset=8
   local.get $setSource5
-  local.set $14
+  local.set $9
   global.get $~lib/memory/__stack_pointer
-  local.get $14
+  local.get $9
   i32.store offset=4
-  local.get $14
+  local.get $9
   i32.const 0
   i32.const 100
   call $~lib/typedarray/Uint8Array#__set
   local.get $setSource5
-  local.set $14
+  local.set $9
   global.get $~lib/memory/__stack_pointer
-  local.get $14
+  local.get $9
   i32.store offset=4
-  local.get $14
+  local.get $9
   i32.const 1
   i32.const 101
   call $~lib/typedarray/Uint8Array#__set
   local.get $setSource5
-  local.set $14
+  local.set $9
   global.get $~lib/memory/__stack_pointer
-  local.get $14
+  local.get $9
   i32.store offset=4
-  local.get $14
+  local.get $9
   i32.const 2
   i32.const 102
   call $~lib/typedarray/Uint8Array#__set
   local.get $setSource5
-  local.set $14
+  local.set $9
   global.get $~lib/memory/__stack_pointer
-  local.get $14
+  local.get $9
   i32.store offset=4
-  local.get $14
+  local.get $9
   i32.const 3
   i32.const 103
   call $~lib/typedarray/Uint8Array#__set
@@ -69048,29 +69033,29 @@
   local.tee $setSource6
   i32.store offset=12
   local.get $setSource6
-  local.set $14
+  local.set $9
   global.get $~lib/memory/__stack_pointer
-  local.get $14
+  local.get $9
   i32.store offset=4
-  local.get $14
+  local.get $9
   i32.const 0
   i32.const 1000
   call $~lib/typedarray/Int16Array#__set
   local.get $setSource6
-  local.set $14
+  local.set $9
   global.get $~lib/memory/__stack_pointer
-  local.get $14
+  local.get $9
   i32.store offset=4
-  local.get $14
+  local.get $9
   i32.const 1
   i32.const 1001
   call $~lib/typedarray/Int16Array#__set
   local.get $setSource6
-  local.set $14
+  local.set $9
   global.get $~lib/memory/__stack_pointer
-  local.get $14
+  local.get $9
   i32.store offset=4
-  local.get $14
+  local.get $9
   i32.const 2
   i32.const 1002
   call $~lib/typedarray/Int16Array#__set
@@ -69081,191 +69066,191 @@
   local.tee $a
   i32.store offset=16
   local.get $a
-  local.set $14
+  local.set $9
   global.get $~lib/memory/__stack_pointer
-  local.get $14
+  local.get $9
   i32.store offset=4
-  local.get $14
+  local.get $9
   global.get $std/typedarray/setSource1
-  local.set $14
+  local.set $9
   global.get $~lib/memory/__stack_pointer
-  local.get $14
+  local.get $9
   i32.store offset=20
-  local.get $14
+  local.get $9
   i32.const 0
   call $~lib/typedarray/Uint8ClampedArray#set<~lib/array/Array<i32>>
   local.get $a
-  local.set $14
+  local.set $9
   global.get $~lib/memory/__stack_pointer
-  local.get $14
+  local.get $9
   i32.store offset=4
-  local.get $14
+  local.get $9
   i32.const 10
   i32.const 0
   i32.const 64
   i32.const 10704
   call $~lib/rt/__newArray
-  local.set $14
+  local.set $9
   global.get $~lib/memory/__stack_pointer
-  local.get $14
+  local.get $9
   i32.store offset=20
-  local.get $14
+  local.get $9
   call $std/typedarray/valuesEqual<~lib/typedarray/Uint8ClampedArray>
   local.get $a
-  local.set $14
+  local.set $9
   global.get $~lib/memory/__stack_pointer
-  local.get $14
+  local.get $9
   i32.store offset=4
-  local.get $14
+  local.get $9
   global.get $std/typedarray/setSource2
-  local.set $14
+  local.set $9
   global.get $~lib/memory/__stack_pointer
-  local.get $14
+  local.get $9
   i32.store offset=20
-  local.get $14
+  local.get $9
   i32.const 3
   call $~lib/typedarray/Uint8ClampedArray#set<~lib/array/Array<f32>>
   local.get $a
-  local.set $14
+  local.set $9
   global.get $~lib/memory/__stack_pointer
-  local.get $14
+  local.get $9
   i32.store offset=4
-  local.get $14
+  local.get $9
   i32.const 10
   i32.const 0
   i32.const 64
   i32.const 10800
   call $~lib/rt/__newArray
-  local.set $14
+  local.set $9
   global.get $~lib/memory/__stack_pointer
-  local.get $14
+  local.get $9
   i32.store offset=20
-  local.get $14
+  local.get $9
   call $std/typedarray/valuesEqual<~lib/typedarray/Uint8ClampedArray>
   local.get $a
-  local.set $14
+  local.set $9
   global.get $~lib/memory/__stack_pointer
-  local.get $14
+  local.get $9
   i32.store offset=4
-  local.get $14
+  local.get $9
   local.get $setSource4
-  local.set $14
+  local.set $9
   global.get $~lib/memory/__stack_pointer
-  local.get $14
+  local.get $9
   i32.store offset=20
-  local.get $14
+  local.get $9
   i32.const 6
   call $~lib/typedarray/Uint8ClampedArray#set<~lib/typedarray/Int64Array>
   local.get $a
-  local.set $14
+  local.set $9
   global.get $~lib/memory/__stack_pointer
-  local.get $14
+  local.get $9
   i32.store offset=4
-  local.get $14
+  local.get $9
   i32.const 10
   i32.const 0
   i32.const 64
   i32.const 10832
   call $~lib/rt/__newArray
-  local.set $14
+  local.set $9
   global.get $~lib/memory/__stack_pointer
-  local.get $14
+  local.get $9
   i32.store offset=20
-  local.get $14
+  local.get $9
   call $std/typedarray/valuesEqual<~lib/typedarray/Uint8ClampedArray>
   i32.const 1
   drop
   local.get $a
-  local.set $14
+  local.set $9
   global.get $~lib/memory/__stack_pointer
-  local.get $14
+  local.get $9
   i32.store offset=4
-  local.get $14
+  local.get $9
   global.get $std/typedarray/setSource3
-  local.set $14
+  local.set $9
   global.get $~lib/memory/__stack_pointer
-  local.get $14
+  local.get $9
   i32.store offset=20
-  local.get $14
+  local.get $9
   i32.const 2
   call $~lib/typedarray/Uint8ClampedArray#set<~lib/array/Array<f64>>
   local.get $a
-  local.set $14
+  local.set $9
   global.get $~lib/memory/__stack_pointer
-  local.get $14
+  local.get $9
   i32.store offset=4
-  local.get $14
+  local.get $9
   i32.const 10
   i32.const 0
   i32.const 64
   i32.const 10864
   call $~lib/rt/__newArray
-  local.set $14
+  local.set $9
   global.get $~lib/memory/__stack_pointer
-  local.get $14
+  local.get $9
   i32.store offset=20
-  local.get $14
+  local.get $9
   call $std/typedarray/valuesEqual<~lib/typedarray/Uint8ClampedArray>
   local.get $a
-  local.set $14
+  local.set $9
   global.get $~lib/memory/__stack_pointer
-  local.get $14
+  local.get $9
   i32.store offset=4
-  local.get $14
+  local.get $9
   local.get $setSource5
-  local.set $14
+  local.set $9
   global.get $~lib/memory/__stack_pointer
-  local.get $14
+  local.get $9
   i32.store offset=20
-  local.get $14
+  local.get $9
   i32.const 0
   call $~lib/typedarray/Uint8ClampedArray#set<~lib/typedarray/Uint8Array>
   local.get $a
-  local.set $14
+  local.set $9
   global.get $~lib/memory/__stack_pointer
-  local.get $14
+  local.get $9
   i32.store offset=4
-  local.get $14
+  local.get $9
   local.get $setSource6
-  local.set $14
+  local.set $9
   global.get $~lib/memory/__stack_pointer
-  local.get $14
+  local.get $9
   i32.store offset=20
-  local.get $14
+  local.get $9
   i32.const 4
   call $~lib/typedarray/Uint8ClampedArray#set<~lib/typedarray/Int16Array>
   local.get $a
-  local.set $14
+  local.set $9
   global.get $~lib/memory/__stack_pointer
-  local.get $14
+  local.get $9
   i32.store offset=4
-  local.get $14
+  local.get $9
   global.get $std/typedarray/setSource7
-  local.set $14
+  local.set $9
   global.get $~lib/memory/__stack_pointer
-  local.get $14
+  local.get $9
   i32.store offset=20
-  local.get $14
+  local.get $9
   i32.const 7
   call $~lib/typedarray/Uint8ClampedArray#set<~lib/array/Array<i8>>
   i32.const 1
   drop
   local.get $a
-  local.set $14
+  local.set $9
   global.get $~lib/memory/__stack_pointer
-  local.get $14
+  local.get $9
   i32.store offset=4
-  local.get $14
+  local.get $9
   i32.const 10
   i32.const 0
   i32.const 64
   i32.const 10896
   call $~lib/rt/__newArray
-  local.set $14
+  local.set $9
   global.get $~lib/memory/__stack_pointer
-  local.get $14
+  local.get $9
   i32.store offset=20
-  local.get $14
+  local.get $9
   call $std/typedarray/valuesEqual<~lib/typedarray/Uint8ClampedArray>
   global.get $~lib/memory/__stack_pointer
   i32.const 24
@@ -70384,11 +70369,6 @@
   (local $7 i32)
   (local $8 i32)
   (local $9 i32)
-  (local $10 i32)
-  (local $11 i32)
-  (local $12 i32)
-  (local $13 i32)
-  (local $14 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 24
   i32.sub
@@ -70405,29 +70385,29 @@
   local.tee $setSource4
   i32.store
   local.get $setSource4
-  local.set $14
+  local.set $9
   global.get $~lib/memory/__stack_pointer
-  local.get $14
+  local.get $9
   i32.store offset=4
-  local.get $14
+  local.get $9
   i32.const 0
   i64.const 7
   call $~lib/typedarray/Int64Array#__set
   local.get $setSource4
-  local.set $14
+  local.set $9
   global.get $~lib/memory/__stack_pointer
-  local.get $14
+  local.get $9
   i32.store offset=4
-  local.get $14
+  local.get $9
   i32.const 1
   i64.const 8
   call $~lib/typedarray/Int64Array#__set
   local.get $setSource4
-  local.set $14
+  local.set $9
   global.get $~lib/memory/__stack_pointer
-  local.get $14
+  local.get $9
   i32.store offset=4
-  local.get $14
+  local.get $9
   i32.const 2
   i64.const 9
   call $~lib/typedarray/Int64Array#__set
@@ -70438,38 +70418,38 @@
   local.tee $setSource5
   i32.store offset=8
   local.get $setSource5
-  local.set $14
+  local.set $9
   global.get $~lib/memory/__stack_pointer
-  local.get $14
+  local.get $9
   i32.store offset=4
-  local.get $14
+  local.get $9
   i32.const 0
   i32.const 100
   call $~lib/typedarray/Uint8Array#__set
   local.get $setSource5
-  local.set $14
+  local.set $9
   global.get $~lib/memory/__stack_pointer
-  local.get $14
+  local.get $9
   i32.store offset=4
-  local.get $14
+  local.get $9
   i32.const 1
   i32.const 101
   call $~lib/typedarray/Uint8Array#__set
   local.get $setSource5
-  local.set $14
+  local.set $9
   global.get $~lib/memory/__stack_pointer
-  local.get $14
+  local.get $9
   i32.store offset=4
-  local.get $14
+  local.get $9
   i32.const 2
   i32.const 102
   call $~lib/typedarray/Uint8Array#__set
   local.get $setSource5
-  local.set $14
+  local.set $9
   global.get $~lib/memory/__stack_pointer
-  local.get $14
+  local.get $9
   i32.store offset=4
-  local.get $14
+  local.get $9
   i32.const 3
   i32.const 103
   call $~lib/typedarray/Uint8Array#__set
@@ -70480,29 +70460,29 @@
   local.tee $setSource6
   i32.store offset=12
   local.get $setSource6
-  local.set $14
+  local.set $9
   global.get $~lib/memory/__stack_pointer
-  local.get $14
+  local.get $9
   i32.store offset=4
-  local.get $14
+  local.get $9
   i32.const 0
   i32.const 1000
   call $~lib/typedarray/Int16Array#__set
   local.get $setSource6
-  local.set $14
+  local.set $9
   global.get $~lib/memory/__stack_pointer
-  local.get $14
+  local.get $9
   i32.store offset=4
-  local.get $14
+  local.get $9
   i32.const 1
   i32.const 1001
   call $~lib/typedarray/Int16Array#__set
   local.get $setSource6
-  local.set $14
+  local.set $9
   global.get $~lib/memory/__stack_pointer
-  local.get $14
+  local.get $9
   i32.store offset=4
-  local.get $14
+  local.get $9
   i32.const 2
   i32.const 1002
   call $~lib/typedarray/Int16Array#__set
@@ -70513,191 +70493,191 @@
   local.tee $a
   i32.store offset=16
   local.get $a
-  local.set $14
+  local.set $9
   global.get $~lib/memory/__stack_pointer
-  local.get $14
+  local.get $9
   i32.store offset=4
-  local.get $14
+  local.get $9
   global.get $std/typedarray/setSource1
-  local.set $14
+  local.set $9
   global.get $~lib/memory/__stack_pointer
-  local.get $14
+  local.get $9
   i32.store offset=20
-  local.get $14
+  local.get $9
   i32.const 0
   call $~lib/typedarray/Int16Array#set<~lib/array/Array<i32>>
   local.get $a
-  local.set $14
+  local.set $9
   global.get $~lib/memory/__stack_pointer
-  local.get $14
+  local.get $9
   i32.store offset=4
-  local.get $14
+  local.get $9
   i32.const 10
   i32.const 1
   i32.const 65
   i32.const 10928
   call $~lib/rt/__newArray
-  local.set $14
+  local.set $9
   global.get $~lib/memory/__stack_pointer
-  local.get $14
+  local.get $9
   i32.store offset=20
-  local.get $14
+  local.get $9
   call $std/typedarray/valuesEqual<~lib/typedarray/Int16Array>
   local.get $a
-  local.set $14
+  local.set $9
   global.get $~lib/memory/__stack_pointer
-  local.get $14
+  local.get $9
   i32.store offset=4
-  local.get $14
+  local.get $9
   global.get $std/typedarray/setSource2
-  local.set $14
+  local.set $9
   global.get $~lib/memory/__stack_pointer
-  local.get $14
+  local.get $9
   i32.store offset=20
-  local.get $14
+  local.get $9
   i32.const 3
   call $~lib/typedarray/Int16Array#set<~lib/array/Array<f32>>
   local.get $a
-  local.set $14
+  local.set $9
   global.get $~lib/memory/__stack_pointer
-  local.get $14
+  local.get $9
   i32.store offset=4
-  local.get $14
+  local.get $9
   i32.const 10
   i32.const 1
   i32.const 65
   i32.const 11024
   call $~lib/rt/__newArray
-  local.set $14
+  local.set $9
   global.get $~lib/memory/__stack_pointer
-  local.get $14
+  local.get $9
   i32.store offset=20
-  local.get $14
+  local.get $9
   call $std/typedarray/valuesEqual<~lib/typedarray/Int16Array>
   local.get $a
-  local.set $14
+  local.set $9
   global.get $~lib/memory/__stack_pointer
-  local.get $14
+  local.get $9
   i32.store offset=4
-  local.get $14
+  local.get $9
   local.get $setSource4
-  local.set $14
+  local.set $9
   global.get $~lib/memory/__stack_pointer
-  local.get $14
+  local.get $9
   i32.store offset=20
-  local.get $14
+  local.get $9
   i32.const 6
   call $~lib/typedarray/Int16Array#set<~lib/typedarray/Int64Array>
   local.get $a
-  local.set $14
+  local.set $9
   global.get $~lib/memory/__stack_pointer
-  local.get $14
+  local.get $9
   i32.store offset=4
-  local.get $14
+  local.get $9
   i32.const 10
   i32.const 1
   i32.const 65
   i32.const 11072
   call $~lib/rt/__newArray
-  local.set $14
+  local.set $9
   global.get $~lib/memory/__stack_pointer
-  local.get $14
+  local.get $9
   i32.store offset=20
-  local.get $14
+  local.get $9
   call $std/typedarray/valuesEqual<~lib/typedarray/Int16Array>
   i32.const 1
   drop
   local.get $a
-  local.set $14
+  local.set $9
   global.get $~lib/memory/__stack_pointer
-  local.get $14
+  local.get $9
   i32.store offset=4
-  local.get $14
+  local.get $9
   global.get $std/typedarray/setSource3
-  local.set $14
+  local.set $9
   global.get $~lib/memory/__stack_pointer
-  local.get $14
+  local.get $9
   i32.store offset=20
-  local.get $14
+  local.get $9
   i32.const 2
   call $~lib/typedarray/Int16Array#set<~lib/array/Array<f64>>
   local.get $a
-  local.set $14
+  local.set $9
   global.get $~lib/memory/__stack_pointer
-  local.get $14
+  local.get $9
   i32.store offset=4
-  local.get $14
+  local.get $9
   i32.const 10
   i32.const 1
   i32.const 65
   i32.const 11120
   call $~lib/rt/__newArray
-  local.set $14
+  local.set $9
   global.get $~lib/memory/__stack_pointer
-  local.get $14
+  local.get $9
   i32.store offset=20
-  local.get $14
+  local.get $9
   call $std/typedarray/valuesEqual<~lib/typedarray/Int16Array>
   local.get $a
-  local.set $14
+  local.set $9
   global.get $~lib/memory/__stack_pointer
-  local.get $14
+  local.get $9
   i32.store offset=4
-  local.get $14
+  local.get $9
   local.get $setSource5
-  local.set $14
+  local.set $9
   global.get $~lib/memory/__stack_pointer
-  local.get $14
+  local.get $9
   i32.store offset=20
-  local.get $14
+  local.get $9
   i32.const 0
   call $~lib/typedarray/Int16Array#set<~lib/typedarray/Uint8Array>
   local.get $a
-  local.set $14
+  local.set $9
   global.get $~lib/memory/__stack_pointer
-  local.get $14
+  local.get $9
   i32.store offset=4
-  local.get $14
+  local.get $9
   local.get $setSource6
-  local.set $14
+  local.set $9
   global.get $~lib/memory/__stack_pointer
-  local.get $14
+  local.get $9
   i32.store offset=20
-  local.get $14
+  local.get $9
   i32.const 4
   call $~lib/typedarray/Int16Array#set<~lib/typedarray/Int16Array>
   local.get $a
-  local.set $14
+  local.set $9
   global.get $~lib/memory/__stack_pointer
-  local.get $14
+  local.get $9
   i32.store offset=4
-  local.get $14
+  local.get $9
   global.get $std/typedarray/setSource7
-  local.set $14
+  local.set $9
   global.get $~lib/memory/__stack_pointer
-  local.get $14
+  local.get $9
   i32.store offset=20
-  local.get $14
+  local.get $9
   i32.const 7
   call $~lib/typedarray/Int16Array#set<~lib/array/Array<i8>>
   i32.const 0
   drop
   local.get $a
-  local.set $14
+  local.set $9
   global.get $~lib/memory/__stack_pointer
-  local.get $14
+  local.get $9
   i32.store offset=4
-  local.get $14
+  local.get $9
   i32.const 10
   i32.const 1
   i32.const 65
   i32.const 11168
   call $~lib/rt/__newArray
-  local.set $14
+  local.set $9
   global.get $~lib/memory/__stack_pointer
-  local.get $14
+  local.get $9
   i32.store offset=20
-  local.get $14
+  local.get $9
   call $std/typedarray/valuesEqual<~lib/typedarray/Int16Array>
   global.get $~lib/memory/__stack_pointer
   i32.const 24
@@ -71816,11 +71796,6 @@
   (local $7 i32)
   (local $8 i32)
   (local $9 i32)
-  (local $10 i32)
-  (local $11 i32)
-  (local $12 i32)
-  (local $13 i32)
-  (local $14 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 24
   i32.sub
@@ -71837,29 +71812,29 @@
   local.tee $setSource4
   i32.store
   local.get $setSource4
-  local.set $14
+  local.set $9
   global.get $~lib/memory/__stack_pointer
-  local.get $14
+  local.get $9
   i32.store offset=4
-  local.get $14
+  local.get $9
   i32.const 0
   i64.const 7
   call $~lib/typedarray/Int64Array#__set
   local.get $setSource4
-  local.set $14
+  local.set $9
   global.get $~lib/memory/__stack_pointer
-  local.get $14
+  local.get $9
   i32.store offset=4
-  local.get $14
+  local.get $9
   i32.const 1
   i64.const 8
   call $~lib/typedarray/Int64Array#__set
   local.get $setSource4
-  local.set $14
+  local.set $9
   global.get $~lib/memory/__stack_pointer
-  local.get $14
+  local.get $9
   i32.store offset=4
-  local.get $14
+  local.get $9
   i32.const 2
   i64.const 9
   call $~lib/typedarray/Int64Array#__set
@@ -71870,38 +71845,38 @@
   local.tee $setSource5
   i32.store offset=8
   local.get $setSource5
-  local.set $14
+  local.set $9
   global.get $~lib/memory/__stack_pointer
-  local.get $14
+  local.get $9
   i32.store offset=4
-  local.get $14
+  local.get $9
   i32.const 0
   i32.const 100
   call $~lib/typedarray/Uint8Array#__set
   local.get $setSource5
-  local.set $14
+  local.set $9
   global.get $~lib/memory/__stack_pointer
-  local.get $14
+  local.get $9
   i32.store offset=4
-  local.get $14
+  local.get $9
   i32.const 1
   i32.const 101
   call $~lib/typedarray/Uint8Array#__set
   local.get $setSource5
-  local.set $14
+  local.set $9
   global.get $~lib/memory/__stack_pointer
-  local.get $14
+  local.get $9
   i32.store offset=4
-  local.get $14
+  local.get $9
   i32.const 2
   i32.const 102
   call $~lib/typedarray/Uint8Array#__set
   local.get $setSource5
-  local.set $14
+  local.set $9
   global.get $~lib/memory/__stack_pointer
-  local.get $14
+  local.get $9
   i32.store offset=4
-  local.get $14
+  local.get $9
   i32.const 3
   i32.const 103
   call $~lib/typedarray/Uint8Array#__set
@@ -71912,29 +71887,29 @@
   local.tee $setSource6
   i32.store offset=12
   local.get $setSource6
-  local.set $14
+  local.set $9
   global.get $~lib/memory/__stack_pointer
-  local.get $14
+  local.get $9
   i32.store offset=4
-  local.get $14
+  local.get $9
   i32.const 0
   i32.const 1000
   call $~lib/typedarray/Int16Array#__set
   local.get $setSource6
-  local.set $14
+  local.set $9
   global.get $~lib/memory/__stack_pointer
-  local.get $14
+  local.get $9
   i32.store offset=4
-  local.get $14
+  local.get $9
   i32.const 1
   i32.const 1001
   call $~lib/typedarray/Int16Array#__set
   local.get $setSource6
-  local.set $14
+  local.set $9
   global.get $~lib/memory/__stack_pointer
-  local.get $14
+  local.get $9
   i32.store offset=4
-  local.get $14
+  local.get $9
   i32.const 2
   i32.const 1002
   call $~lib/typedarray/Int16Array#__set
@@ -71945,191 +71920,191 @@
   local.tee $a
   i32.store offset=16
   local.get $a
-  local.set $14
+  local.set $9
   global.get $~lib/memory/__stack_pointer
-  local.get $14
+  local.get $9
   i32.store offset=4
-  local.get $14
+  local.get $9
   global.get $std/typedarray/setSource1
-  local.set $14
+  local.set $9
   global.get $~lib/memory/__stack_pointer
-  local.get $14
+  local.get $9
   i32.store offset=20
-  local.get $14
+  local.get $9
   i32.const 0
   call $~lib/typedarray/Uint16Array#set<~lib/array/Array<i32>>
   local.get $a
-  local.set $14
+  local.set $9
   global.get $~lib/memory/__stack_pointer
-  local.get $14
+  local.get $9
   i32.store offset=4
-  local.get $14
+  local.get $9
   i32.const 10
   i32.const 1
   i32.const 66
   i32.const 11216
   call $~lib/rt/__newArray
-  local.set $14
+  local.set $9
   global.get $~lib/memory/__stack_pointer
-  local.get $14
+  local.get $9
   i32.store offset=20
-  local.get $14
+  local.get $9
   call $std/typedarray/valuesEqual<~lib/typedarray/Uint16Array>
   local.get $a
-  local.set $14
+  local.set $9
   global.get $~lib/memory/__stack_pointer
-  local.get $14
+  local.get $9
   i32.store offset=4
-  local.get $14
+  local.get $9
   global.get $std/typedarray/setSource2
-  local.set $14
+  local.set $9
   global.get $~lib/memory/__stack_pointer
-  local.get $14
+  local.get $9
   i32.store offset=20
-  local.get $14
+  local.get $9
   i32.const 3
   call $~lib/typedarray/Uint16Array#set<~lib/array/Array<f32>>
   local.get $a
-  local.set $14
+  local.set $9
   global.get $~lib/memory/__stack_pointer
-  local.get $14
+  local.get $9
   i32.store offset=4
-  local.get $14
+  local.get $9
   i32.const 10
   i32.const 1
   i32.const 66
   i32.const 11312
   call $~lib/rt/__newArray
-  local.set $14
+  local.set $9
   global.get $~lib/memory/__stack_pointer
-  local.get $14
+  local.get $9
   i32.store offset=20
-  local.get $14
+  local.get $9
   call $std/typedarray/valuesEqual<~lib/typedarray/Uint16Array>
   local.get $a
-  local.set $14
+  local.set $9
   global.get $~lib/memory/__stack_pointer
-  local.get $14
+  local.get $9
   i32.store offset=4
-  local.get $14
+  local.get $9
   local.get $setSource4
-  local.set $14
+  local.set $9
   global.get $~lib/memory/__stack_pointer
-  local.get $14
+  local.get $9
   i32.store offset=20
-  local.get $14
+  local.get $9
   i32.const 6
   call $~lib/typedarray/Uint16Array#set<~lib/typedarray/Int64Array>
   local.get $a
-  local.set $14
+  local.set $9
   global.get $~lib/memory/__stack_pointer
-  local.get $14
+  local.get $9
   i32.store offset=4
-  local.get $14
+  local.get $9
   i32.const 10
   i32.const 1
   i32.const 66
   i32.const 11360
   call $~lib/rt/__newArray
-  local.set $14
+  local.set $9
   global.get $~lib/memory/__stack_pointer
-  local.get $14
+  local.get $9
   i32.store offset=20
-  local.get $14
+  local.get $9
   call $std/typedarray/valuesEqual<~lib/typedarray/Uint16Array>
   i32.const 1
   drop
   local.get $a
-  local.set $14
+  local.set $9
   global.get $~lib/memory/__stack_pointer
-  local.get $14
+  local.get $9
   i32.store offset=4
-  local.get $14
+  local.get $9
   global.get $std/typedarray/setSource3
-  local.set $14
+  local.set $9
   global.get $~lib/memory/__stack_pointer
-  local.get $14
+  local.get $9
   i32.store offset=20
-  local.get $14
+  local.get $9
   i32.const 2
   call $~lib/typedarray/Uint16Array#set<~lib/array/Array<f64>>
   local.get $a
-  local.set $14
+  local.set $9
   global.get $~lib/memory/__stack_pointer
-  local.get $14
+  local.get $9
   i32.store offset=4
-  local.get $14
+  local.get $9
   i32.const 10
   i32.const 1
   i32.const 66
   i32.const 11408
   call $~lib/rt/__newArray
-  local.set $14
+  local.set $9
   global.get $~lib/memory/__stack_pointer
-  local.get $14
+  local.get $9
   i32.store offset=20
-  local.get $14
+  local.get $9
   call $std/typedarray/valuesEqual<~lib/typedarray/Uint16Array>
   local.get $a
-  local.set $14
+  local.set $9
   global.get $~lib/memory/__stack_pointer
-  local.get $14
+  local.get $9
   i32.store offset=4
-  local.get $14
+  local.get $9
   local.get $setSource5
-  local.set $14
+  local.set $9
   global.get $~lib/memory/__stack_pointer
-  local.get $14
+  local.get $9
   i32.store offset=20
-  local.get $14
+  local.get $9
   i32.const 0
   call $~lib/typedarray/Uint16Array#set<~lib/typedarray/Uint8Array>
   local.get $a
-  local.set $14
+  local.set $9
   global.get $~lib/memory/__stack_pointer
-  local.get $14
+  local.get $9
   i32.store offset=4
-  local.get $14
+  local.get $9
   local.get $setSource6
-  local.set $14
+  local.set $9
   global.get $~lib/memory/__stack_pointer
-  local.get $14
+  local.get $9
   i32.store offset=20
-  local.get $14
+  local.get $9
   i32.const 4
   call $~lib/typedarray/Uint16Array#set<~lib/typedarray/Int16Array>
   local.get $a
-  local.set $14
+  local.set $9
   global.get $~lib/memory/__stack_pointer
-  local.get $14
+  local.get $9
   i32.store offset=4
-  local.get $14
+  local.get $9
   global.get $std/typedarray/setSource7
-  local.set $14
+  local.set $9
   global.get $~lib/memory/__stack_pointer
-  local.get $14
+  local.get $9
   i32.store offset=20
-  local.get $14
+  local.get $9
   i32.const 7
   call $~lib/typedarray/Uint16Array#set<~lib/array/Array<i8>>
   i32.const 0
   drop
   local.get $a
-  local.set $14
+  local.set $9
   global.get $~lib/memory/__stack_pointer
-  local.get $14
+  local.get $9
   i32.store offset=4
-  local.get $14
+  local.get $9
   i32.const 10
   i32.const 1
   i32.const 66
   i32.const 11456
   call $~lib/rt/__newArray
-  local.set $14
+  local.set $9
   global.get $~lib/memory/__stack_pointer
-  local.get $14
+  local.get $9
   i32.store offset=20
-  local.get $14
+  local.get $9
   call $std/typedarray/valuesEqual<~lib/typedarray/Uint16Array>
   global.get $~lib/memory/__stack_pointer
   i32.const 24
@@ -73223,11 +73198,6 @@
   (local $7 i32)
   (local $8 i32)
   (local $9 i32)
-  (local $10 i32)
-  (local $11 i32)
-  (local $12 i32)
-  (local $13 i32)
-  (local $14 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 24
   i32.sub
@@ -73244,29 +73214,29 @@
   local.tee $setSource4
   i32.store
   local.get $setSource4
-  local.set $14
+  local.set $9
   global.get $~lib/memory/__stack_pointer
-  local.get $14
+  local.get $9
   i32.store offset=4
-  local.get $14
+  local.get $9
   i32.const 0
   i64.const 7
   call $~lib/typedarray/Int64Array#__set
   local.get $setSource4
-  local.set $14
+  local.set $9
   global.get $~lib/memory/__stack_pointer
-  local.get $14
+  local.get $9
   i32.store offset=4
-  local.get $14
+  local.get $9
   i32.const 1
   i64.const 8
   call $~lib/typedarray/Int64Array#__set
   local.get $setSource4
-  local.set $14
+  local.set $9
   global.get $~lib/memory/__stack_pointer
-  local.get $14
+  local.get $9
   i32.store offset=4
-  local.get $14
+  local.get $9
   i32.const 2
   i64.const 9
   call $~lib/typedarray/Int64Array#__set
@@ -73277,38 +73247,38 @@
   local.tee $setSource5
   i32.store offset=8
   local.get $setSource5
-  local.set $14
+  local.set $9
   global.get $~lib/memory/__stack_pointer
-  local.get $14
+  local.get $9
   i32.store offset=4
-  local.get $14
+  local.get $9
   i32.const 0
   i32.const 100
   call $~lib/typedarray/Uint8Array#__set
   local.get $setSource5
-  local.set $14
+  local.set $9
   global.get $~lib/memory/__stack_pointer
-  local.get $14
+  local.get $9
   i32.store offset=4
-  local.get $14
+  local.get $9
   i32.const 1
   i32.const 101
   call $~lib/typedarray/Uint8Array#__set
   local.get $setSource5
-  local.set $14
+  local.set $9
   global.get $~lib/memory/__stack_pointer
-  local.get $14
+  local.get $9
   i32.store offset=4
-  local.get $14
+  local.get $9
   i32.const 2
   i32.const 102
   call $~lib/typedarray/Uint8Array#__set
   local.get $setSource5
-  local.set $14
+  local.set $9
   global.get $~lib/memory/__stack_pointer
-  local.get $14
+  local.get $9
   i32.store offset=4
-  local.get $14
+  local.get $9
   i32.const 3
   i32.const 103
   call $~lib/typedarray/Uint8Array#__set
@@ -73319,29 +73289,29 @@
   local.tee $setSource6
   i32.store offset=12
   local.get $setSource6
-  local.set $14
+  local.set $9
   global.get $~lib/memory/__stack_pointer
-  local.get $14
+  local.get $9
   i32.store offset=4
-  local.get $14
+  local.get $9
   i32.const 0
   i32.const 1000
   call $~lib/typedarray/Int16Array#__set
   local.get $setSource6
-  local.set $14
+  local.set $9
   global.get $~lib/memory/__stack_pointer
-  local.get $14
+  local.get $9
   i32.store offset=4
-  local.get $14
+  local.get $9
   i32.const 1
   i32.const 1001
   call $~lib/typedarray/Int16Array#__set
   local.get $setSource6
-  local.set $14
+  local.set $9
   global.get $~lib/memory/__stack_pointer
-  local.get $14
+  local.get $9
   i32.store offset=4
-  local.get $14
+  local.get $9
   i32.const 2
   i32.const 1002
   call $~lib/typedarray/Int16Array#__set
@@ -73352,191 +73322,191 @@
   local.tee $a
   i32.store offset=16
   local.get $a
-  local.set $14
+  local.set $9
   global.get $~lib/memory/__stack_pointer
-  local.get $14
+  local.get $9
   i32.store offset=4
-  local.get $14
+  local.get $9
   global.get $std/typedarray/setSource1
-  local.set $14
+  local.set $9
   global.get $~lib/memory/__stack_pointer
-  local.get $14
+  local.get $9
   i32.store offset=20
-  local.get $14
+  local.get $9
   i32.const 0
   call $~lib/typedarray/Int32Array#set<~lib/array/Array<i32>>
   local.get $a
-  local.set $14
+  local.set $9
   global.get $~lib/memory/__stack_pointer
-  local.get $14
+  local.get $9
   i32.store offset=4
-  local.get $14
+  local.get $9
   i32.const 10
   i32.const 2
   i32.const 17
   i32.const 11504
   call $~lib/rt/__newArray
-  local.set $14
+  local.set $9
   global.get $~lib/memory/__stack_pointer
-  local.get $14
+  local.get $9
   i32.store offset=20
-  local.get $14
+  local.get $9
   call $std/typedarray/valuesEqual<~lib/typedarray/Int32Array>
   local.get $a
-  local.set $14
+  local.set $9
   global.get $~lib/memory/__stack_pointer
-  local.get $14
+  local.get $9
   i32.store offset=4
-  local.get $14
+  local.get $9
   global.get $std/typedarray/setSource2
-  local.set $14
+  local.set $9
   global.get $~lib/memory/__stack_pointer
-  local.get $14
+  local.get $9
   i32.store offset=20
-  local.get $14
+  local.get $9
   i32.const 3
   call $~lib/typedarray/Int32Array#set<~lib/array/Array<f32>>
   local.get $a
-  local.set $14
+  local.set $9
   global.get $~lib/memory/__stack_pointer
-  local.get $14
+  local.get $9
   i32.store offset=4
-  local.get $14
+  local.get $9
   i32.const 10
   i32.const 2
   i32.const 17
   i32.const 11616
   call $~lib/rt/__newArray
-  local.set $14
+  local.set $9
   global.get $~lib/memory/__stack_pointer
-  local.get $14
+  local.get $9
   i32.store offset=20
-  local.get $14
+  local.get $9
   call $std/typedarray/valuesEqual<~lib/typedarray/Int32Array>
   local.get $a
-  local.set $14
+  local.set $9
   global.get $~lib/memory/__stack_pointer
-  local.get $14
+  local.get $9
   i32.store offset=4
-  local.get $14
+  local.get $9
   local.get $setSource4
-  local.set $14
+  local.set $9
   global.get $~lib/memory/__stack_pointer
-  local.get $14
+  local.get $9
   i32.store offset=20
-  local.get $14
+  local.get $9
   i32.const 6
   call $~lib/typedarray/Int32Array#set<~lib/typedarray/Int64Array>
   local.get $a
-  local.set $14
+  local.set $9
   global.get $~lib/memory/__stack_pointer
-  local.get $14
+  local.get $9
   i32.store offset=4
-  local.get $14
+  local.get $9
   i32.const 10
   i32.const 2
   i32.const 17
   i32.const 11680
   call $~lib/rt/__newArray
-  local.set $14
+  local.set $9
   global.get $~lib/memory/__stack_pointer
-  local.get $14
+  local.get $9
   i32.store offset=20
-  local.get $14
+  local.get $9
   call $std/typedarray/valuesEqual<~lib/typedarray/Int32Array>
   i32.const 1
   drop
   local.get $a
-  local.set $14
+  local.set $9
   global.get $~lib/memory/__stack_pointer
-  local.get $14
+  local.get $9
   i32.store offset=4
-  local.get $14
+  local.get $9
   global.get $std/typedarray/setSource3
-  local.set $14
+  local.set $9
   global.get $~lib/memory/__stack_pointer
-  local.get $14
+  local.get $9
   i32.store offset=20
-  local.get $14
+  local.get $9
   i32.const 2
   call $~lib/typedarray/Int32Array#set<~lib/array/Array<f64>>
   local.get $a
-  local.set $14
+  local.set $9
   global.get $~lib/memory/__stack_pointer
-  local.get $14
+  local.get $9
   i32.store offset=4
-  local.get $14
+  local.get $9
   i32.const 10
   i32.const 2
   i32.const 17
   i32.const 11744
   call $~lib/rt/__newArray
-  local.set $14
+  local.set $9
   global.get $~lib/memory/__stack_pointer
-  local.get $14
+  local.get $9
   i32.store offset=20
-  local.get $14
+  local.get $9
   call $std/typedarray/valuesEqual<~lib/typedarray/Int32Array>
   local.get $a
-  local.set $14
+  local.set $9
   global.get $~lib/memory/__stack_pointer
-  local.get $14
+  local.get $9
   i32.store offset=4
-  local.get $14
+  local.get $9
   local.get $setSource5
-  local.set $14
+  local.set $9
   global.get $~lib/memory/__stack_pointer
-  local.get $14
+  local.get $9
   i32.store offset=20
-  local.get $14
+  local.get $9
   i32.const 0
   call $~lib/typedarray/Int32Array#set<~lib/typedarray/Uint8Array>
   local.get $a
-  local.set $14
+  local.set $9
   global.get $~lib/memory/__stack_pointer
-  local.get $14
+  local.get $9
   i32.store offset=4
-  local.get $14
+  local.get $9
   local.get $setSource6
-  local.set $14
+  local.set $9
   global.get $~lib/memory/__stack_pointer
-  local.get $14
+  local.get $9
   i32.store offset=20
-  local.get $14
+  local.get $9
   i32.const 4
   call $~lib/typedarray/Int32Array#set<~lib/typedarray/Int16Array>
   local.get $a
-  local.set $14
+  local.set $9
   global.get $~lib/memory/__stack_pointer
-  local.get $14
+  local.get $9
   i32.store offset=4
-  local.get $14
+  local.get $9
   global.get $std/typedarray/setSource7
-  local.set $14
+  local.set $9
   global.get $~lib/memory/__stack_pointer
-  local.get $14
+  local.get $9
   i32.store offset=20
-  local.get $14
+  local.get $9
   i32.const 7
   call $~lib/typedarray/Int32Array#set<~lib/array/Array<i8>>
   i32.const 0
   drop
   local.get $a
-  local.set $14
+  local.set $9
   global.get $~lib/memory/__stack_pointer
-  local.get $14
+  local.get $9
   i32.store offset=4
-  local.get $14
+  local.get $9
   i32.const 10
   i32.const 2
   i32.const 17
   i32.const 11808
   call $~lib/rt/__newArray
-  local.set $14
+  local.set $9
   global.get $~lib/memory/__stack_pointer
-  local.get $14
+  local.get $9
   i32.store offset=20
-  local.get $14
+  local.get $9
   call $std/typedarray/valuesEqual<~lib/typedarray/Int32Array>
   global.get $~lib/memory/__stack_pointer
   i32.const 24
@@ -74655,11 +74625,6 @@
   (local $7 i32)
   (local $8 i32)
   (local $9 i32)
-  (local $10 i32)
-  (local $11 i32)
-  (local $12 i32)
-  (local $13 i32)
-  (local $14 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 24
   i32.sub
@@ -74676,29 +74641,29 @@
   local.tee $setSource4
   i32.store
   local.get $setSource4
-  local.set $14
+  local.set $9
   global.get $~lib/memory/__stack_pointer
-  local.get $14
+  local.get $9
   i32.store offset=4
-  local.get $14
+  local.get $9
   i32.const 0
   i64.const 7
   call $~lib/typedarray/Int64Array#__set
   local.get $setSource4
-  local.set $14
+  local.set $9
   global.get $~lib/memory/__stack_pointer
-  local.get $14
+  local.get $9
   i32.store offset=4
-  local.get $14
+  local.get $9
   i32.const 1
   i64.const 8
   call $~lib/typedarray/Int64Array#__set
   local.get $setSource4
-  local.set $14
+  local.set $9
   global.get $~lib/memory/__stack_pointer
-  local.get $14
+  local.get $9
   i32.store offset=4
-  local.get $14
+  local.get $9
   i32.const 2
   i64.const 9
   call $~lib/typedarray/Int64Array#__set
@@ -74709,38 +74674,38 @@
   local.tee $setSource5
   i32.store offset=8
   local.get $setSource5
-  local.set $14
+  local.set $9
   global.get $~lib/memory/__stack_pointer
-  local.get $14
+  local.get $9
   i32.store offset=4
-  local.get $14
+  local.get $9
   i32.const 0
   i32.const 100
   call $~lib/typedarray/Uint8Array#__set
   local.get $setSource5
-  local.set $14
+  local.set $9
   global.get $~lib/memory/__stack_pointer
-  local.get $14
+  local.get $9
   i32.store offset=4
-  local.get $14
+  local.get $9
   i32.const 1
   i32.const 101
   call $~lib/typedarray/Uint8Array#__set
   local.get $setSource5
-  local.set $14
+  local.set $9
   global.get $~lib/memory/__stack_pointer
-  local.get $14
+  local.get $9
   i32.store offset=4
-  local.get $14
+  local.get $9
   i32.const 2
   i32.const 102
   call $~lib/typedarray/Uint8Array#__set
   local.get $setSource5
-  local.set $14
+  local.set $9
   global.get $~lib/memory/__stack_pointer
-  local.get $14
+  local.get $9
   i32.store offset=4
-  local.get $14
+  local.get $9
   i32.const 3
   i32.const 103
   call $~lib/typedarray/Uint8Array#__set
@@ -74751,29 +74716,29 @@
   local.tee $setSource6
   i32.store offset=12
   local.get $setSource6
-  local.set $14
+  local.set $9
   global.get $~lib/memory/__stack_pointer
-  local.get $14
+  local.get $9
   i32.store offset=4
-  local.get $14
+  local.get $9
   i32.const 0
   i32.const 1000
   call $~lib/typedarray/Int16Array#__set
   local.get $setSource6
-  local.set $14
+  local.set $9
   global.get $~lib/memory/__stack_pointer
-  local.get $14
+  local.get $9
   i32.store offset=4
-  local.get $14
+  local.get $9
   i32.const 1
   i32.const 1001
   call $~lib/typedarray/Int16Array#__set
   local.get $setSource6
-  local.set $14
+  local.set $9
   global.get $~lib/memory/__stack_pointer
-  local.get $14
+  local.get $9
   i32.store offset=4
-  local.get $14
+  local.get $9
   i32.const 2
   i32.const 1002
   call $~lib/typedarray/Int16Array#__set
@@ -74784,191 +74749,191 @@
   local.tee $a
   i32.store offset=16
   local.get $a
-  local.set $14
+  local.set $9
   global.get $~lib/memory/__stack_pointer
-  local.get $14
+  local.get $9
   i32.store offset=4
-  local.get $14
+  local.get $9
   global.get $std/typedarray/setSource1
-  local.set $14
+  local.set $9
   global.get $~lib/memory/__stack_pointer
-  local.get $14
+  local.get $9
   i32.store offset=20
-  local.get $14
+  local.get $9
   i32.const 0
   call $~lib/typedarray/Uint32Array#set<~lib/array/Array<i32>>
   local.get $a
-  local.set $14
+  local.set $9
   global.get $~lib/memory/__stack_pointer
-  local.get $14
+  local.get $9
   i32.store offset=4
-  local.get $14
+  local.get $9
   i32.const 10
   i32.const 2
   i32.const 67
   i32.const 11872
   call $~lib/rt/__newArray
-  local.set $14
+  local.set $9
   global.get $~lib/memory/__stack_pointer
-  local.get $14
+  local.get $9
   i32.store offset=20
-  local.get $14
+  local.get $9
   call $std/typedarray/valuesEqual<~lib/typedarray/Uint32Array>
   local.get $a
-  local.set $14
+  local.set $9
   global.get $~lib/memory/__stack_pointer
-  local.get $14
+  local.get $9
   i32.store offset=4
-  local.get $14
+  local.get $9
   global.get $std/typedarray/setSource2
-  local.set $14
+  local.set $9
   global.get $~lib/memory/__stack_pointer
-  local.get $14
+  local.get $9
   i32.store offset=20
-  local.get $14
+  local.get $9
   i32.const 3
   call $~lib/typedarray/Uint32Array#set<~lib/array/Array<f32>>
   local.get $a
-  local.set $14
+  local.set $9
   global.get $~lib/memory/__stack_pointer
-  local.get $14
+  local.get $9
   i32.store offset=4
-  local.get $14
+  local.get $9
   i32.const 10
   i32.const 2
   i32.const 67
   i32.const 11984
   call $~lib/rt/__newArray
-  local.set $14
+  local.set $9
   global.get $~lib/memory/__stack_pointer
-  local.get $14
+  local.get $9
   i32.store offset=20
-  local.get $14
+  local.get $9
   call $std/typedarray/valuesEqual<~lib/typedarray/Uint32Array>
   local.get $a
-  local.set $14
+  local.set $9
   global.get $~lib/memory/__stack_pointer
-  local.get $14
+  local.get $9
   i32.store offset=4
-  local.get $14
+  local.get $9
   local.get $setSource4
-  local.set $14
+  local.set $9
   global.get $~lib/memory/__stack_pointer
-  local.get $14
+  local.get $9
   i32.store offset=20
-  local.get $14
+  local.get $9
   i32.const 6
   call $~lib/typedarray/Uint32Array#set<~lib/typedarray/Int64Array>
   local.get $a
-  local.set $14
+  local.set $9
   global.get $~lib/memory/__stack_pointer
-  local.get $14
+  local.get $9
   i32.store offset=4
-  local.get $14
+  local.get $9
   i32.const 10
   i32.const 2
   i32.const 67
   i32.const 12048
   call $~lib/rt/__newArray
-  local.set $14
+  local.set $9
   global.get $~lib/memory/__stack_pointer
-  local.get $14
+  local.get $9
   i32.store offset=20
-  local.get $14
+  local.get $9
   call $std/typedarray/valuesEqual<~lib/typedarray/Uint32Array>
   i32.const 1
   drop
   local.get $a
-  local.set $14
+  local.set $9
   global.get $~lib/memory/__stack_pointer
-  local.get $14
+  local.get $9
   i32.store offset=4
-  local.get $14
+  local.get $9
   global.get $std/typedarray/setSource3
-  local.set $14
+  local.set $9
   global.get $~lib/memory/__stack_pointer
-  local.get $14
+  local.get $9
   i32.store offset=20
-  local.get $14
+  local.get $9
   i32.const 2
   call $~lib/typedarray/Uint32Array#set<~lib/array/Array<f64>>
   local.get $a
-  local.set $14
+  local.set $9
   global.get $~lib/memory/__stack_pointer
-  local.get $14
+  local.get $9
   i32.store offset=4
-  local.get $14
+  local.get $9
   i32.const 10
   i32.const 2
   i32.const 67
   i32.const 12112
   call $~lib/rt/__newArray
-  local.set $14
+  local.set $9
   global.get $~lib/memory/__stack_pointer
-  local.get $14
+  local.get $9
   i32.store offset=20
-  local.get $14
+  local.get $9
   call $std/typedarray/valuesEqual<~lib/typedarray/Uint32Array>
   local.get $a
-  local.set $14
+  local.set $9
   global.get $~lib/memory/__stack_pointer
-  local.get $14
+  local.get $9
   i32.store offset=4
-  local.get $14
+  local.get $9
   local.get $setSource5
-  local.set $14
+  local.set $9
   global.get $~lib/memory/__stack_pointer
-  local.get $14
+  local.get $9
   i32.store offset=20
-  local.get $14
+  local.get $9
   i32.const 0
   call $~lib/typedarray/Uint32Array#set<~lib/typedarray/Uint8Array>
   local.get $a
-  local.set $14
+  local.set $9
   global.get $~lib/memory/__stack_pointer
-  local.get $14
+  local.get $9
   i32.store offset=4
-  local.get $14
+  local.get $9
   local.get $setSource6
-  local.set $14
+  local.set $9
   global.get $~lib/memory/__stack_pointer
-  local.get $14
+  local.get $9
   i32.store offset=20
-  local.get $14
+  local.get $9
   i32.const 4
   call $~lib/typedarray/Uint32Array#set<~lib/typedarray/Int16Array>
   local.get $a
-  local.set $14
+  local.set $9
   global.get $~lib/memory/__stack_pointer
-  local.get $14
+  local.get $9
   i32.store offset=4
-  local.get $14
+  local.get $9
   global.get $std/typedarray/setSource7
-  local.set $14
+  local.set $9
   global.get $~lib/memory/__stack_pointer
-  local.get $14
+  local.get $9
   i32.store offset=20
-  local.get $14
+  local.get $9
   i32.const 7
   call $~lib/typedarray/Uint32Array#set<~lib/array/Array<i8>>
   i32.const 0
   drop
   local.get $a
-  local.set $14
+  local.set $9
   global.get $~lib/memory/__stack_pointer
-  local.get $14
+  local.get $9
   i32.store offset=4
-  local.get $14
+  local.get $9
   i32.const 10
   i32.const 2
   i32.const 67
   i32.const 12176
   call $~lib/rt/__newArray
-  local.set $14
+  local.set $9
   global.get $~lib/memory/__stack_pointer
-  local.get $14
+  local.get $9
   i32.store offset=20
-  local.get $14
+  local.get $9
   call $std/typedarray/valuesEqual<~lib/typedarray/Uint32Array>
   global.get $~lib/memory/__stack_pointer
   i32.const 24
@@ -76092,11 +76057,6 @@
   (local $7 i32)
   (local $8 i32)
   (local $9 i32)
-  (local $10 i32)
-  (local $11 i32)
-  (local $12 i32)
-  (local $13 i32)
-  (local $14 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 24
   i32.sub
@@ -76113,29 +76073,29 @@
   local.tee $setSource4
   i32.store
   local.get $setSource4
-  local.set $14
+  local.set $9
   global.get $~lib/memory/__stack_pointer
-  local.get $14
+  local.get $9
   i32.store offset=4
-  local.get $14
+  local.get $9
   i32.const 0
   i64.const 7
   call $~lib/typedarray/Int64Array#__set
   local.get $setSource4
-  local.set $14
+  local.set $9
   global.get $~lib/memory/__stack_pointer
-  local.get $14
+  local.get $9
   i32.store offset=4
-  local.get $14
+  local.get $9
   i32.const 1
   i64.const 8
   call $~lib/typedarray/Int64Array#__set
   local.get $setSource4
-  local.set $14
+  local.set $9
   global.get $~lib/memory/__stack_pointer
-  local.get $14
+  local.get $9
   i32.store offset=4
-  local.get $14
+  local.get $9
   i32.const 2
   i64.const 9
   call $~lib/typedarray/Int64Array#__set
@@ -76146,38 +76106,38 @@
   local.tee $setSource5
   i32.store offset=8
   local.get $setSource5
-  local.set $14
+  local.set $9
   global.get $~lib/memory/__stack_pointer
-  local.get $14
+  local.get $9
   i32.store offset=4
-  local.get $14
+  local.get $9
   i32.const 0
   i32.const 100
   call $~lib/typedarray/Uint8Array#__set
   local.get $setSource5
-  local.set $14
+  local.set $9
   global.get $~lib/memory/__stack_pointer
-  local.get $14
+  local.get $9
   i32.store offset=4
-  local.get $14
+  local.get $9
   i32.const 1
   i32.const 101
   call $~lib/typedarray/Uint8Array#__set
   local.get $setSource5
-  local.set $14
+  local.set $9
   global.get $~lib/memory/__stack_pointer
-  local.get $14
+  local.get $9
   i32.store offset=4
-  local.get $14
+  local.get $9
   i32.const 2
   i32.const 102
   call $~lib/typedarray/Uint8Array#__set
   local.get $setSource5
-  local.set $14
+  local.set $9
   global.get $~lib/memory/__stack_pointer
-  local.get $14
+  local.get $9
   i32.store offset=4
-  local.get $14
+  local.get $9
   i32.const 3
   i32.const 103
   call $~lib/typedarray/Uint8Array#__set
@@ -76188,29 +76148,29 @@
   local.tee $setSource6
   i32.store offset=12
   local.get $setSource6
-  local.set $14
+  local.set $9
   global.get $~lib/memory/__stack_pointer
-  local.get $14
+  local.get $9
   i32.store offset=4
-  local.get $14
+  local.get $9
   i32.const 0
   i32.const 1000
   call $~lib/typedarray/Int16Array#__set
   local.get $setSource6
-  local.set $14
+  local.set $9
   global.get $~lib/memory/__stack_pointer
-  local.get $14
+  local.get $9
   i32.store offset=4
-  local.get $14
+  local.get $9
   i32.const 1
   i32.const 1001
   call $~lib/typedarray/Int16Array#__set
   local.get $setSource6
-  local.set $14
+  local.set $9
   global.get $~lib/memory/__stack_pointer
-  local.get $14
+  local.get $9
   i32.store offset=4
-  local.get $14
+  local.get $9
   i32.const 2
   i32.const 1002
   call $~lib/typedarray/Int16Array#__set
@@ -76221,191 +76181,191 @@
   local.tee $a
   i32.store offset=16
   local.get $a
-  local.set $14
+  local.set $9
   global.get $~lib/memory/__stack_pointer
-  local.get $14
+  local.get $9
   i32.store offset=4
-  local.get $14
+  local.get $9
   global.get $std/typedarray/setSource1
-  local.set $14
+  local.set $9
   global.get $~lib/memory/__stack_pointer
-  local.get $14
+  local.get $9
   i32.store offset=20
-  local.get $14
+  local.get $9
   i32.const 0
   call $~lib/typedarray/Int64Array#set<~lib/array/Array<i32>>
   local.get $a
-  local.set $14
+  local.set $9
   global.get $~lib/memory/__stack_pointer
-  local.get $14
+  local.get $9
   i32.store offset=4
-  local.get $14
+  local.get $9
   i32.const 10
   i32.const 3
   i32.const 68
   i32.const 12240
   call $~lib/rt/__newArray
-  local.set $14
+  local.set $9
   global.get $~lib/memory/__stack_pointer
-  local.get $14
+  local.get $9
   i32.store offset=20
-  local.get $14
+  local.get $9
   call $std/typedarray/valuesEqual<~lib/typedarray/Int64Array>
   local.get $a
-  local.set $14
+  local.set $9
   global.get $~lib/memory/__stack_pointer
-  local.get $14
+  local.get $9
   i32.store offset=4
-  local.get $14
+  local.get $9
   global.get $std/typedarray/setSource2
-  local.set $14
+  local.set $9
   global.get $~lib/memory/__stack_pointer
-  local.get $14
+  local.get $9
   i32.store offset=20
-  local.get $14
+  local.get $9
   i32.const 3
   call $~lib/typedarray/Int64Array#set<~lib/array/Array<f32>>
   local.get $a
-  local.set $14
+  local.set $9
   global.get $~lib/memory/__stack_pointer
-  local.get $14
+  local.get $9
   i32.store offset=4
-  local.get $14
+  local.get $9
   i32.const 10
   i32.const 3
   i32.const 68
   i32.const 12400
   call $~lib/rt/__newArray
-  local.set $14
+  local.set $9
   global.get $~lib/memory/__stack_pointer
-  local.get $14
+  local.get $9
   i32.store offset=20
-  local.get $14
+  local.get $9
   call $std/typedarray/valuesEqual<~lib/typedarray/Int64Array>
   local.get $a
-  local.set $14
+  local.set $9
   global.get $~lib/memory/__stack_pointer
-  local.get $14
+  local.get $9
   i32.store offset=4
-  local.get $14
+  local.get $9
   local.get $setSource4
-  local.set $14
+  local.set $9
   global.get $~lib/memory/__stack_pointer
-  local.get $14
+  local.get $9
   i32.store offset=20
-  local.get $14
+  local.get $9
   i32.const 6
   call $~lib/typedarray/Int64Array#set<~lib/typedarray/Int64Array>
   local.get $a
-  local.set $14
+  local.set $9
   global.get $~lib/memory/__stack_pointer
-  local.get $14
+  local.get $9
   i32.store offset=4
-  local.get $14
+  local.get $9
   i32.const 10
   i32.const 3
   i32.const 68
   i32.const 12512
   call $~lib/rt/__newArray
-  local.set $14
+  local.set $9
   global.get $~lib/memory/__stack_pointer
-  local.get $14
+  local.get $9
   i32.store offset=20
-  local.get $14
+  local.get $9
   call $std/typedarray/valuesEqual<~lib/typedarray/Int64Array>
   i32.const 1
   drop
   local.get $a
-  local.set $14
+  local.set $9
   global.get $~lib/memory/__stack_pointer
-  local.get $14
+  local.get $9
   i32.store offset=4
-  local.get $14
+  local.get $9
   global.get $std/typedarray/setSource3
-  local.set $14
+  local.set $9
   global.get $~lib/memory/__stack_pointer
-  local.get $14
+  local.get $9
   i32.store offset=20
-  local.get $14
+  local.get $9
   i32.const 2
   call $~lib/typedarray/Int64Array#set<~lib/array/Array<f64>>
   local.get $a
-  local.set $14
+  local.set $9
   global.get $~lib/memory/__stack_pointer
-  local.get $14
+  local.get $9
   i32.store offset=4
-  local.get $14
+  local.get $9
   i32.const 10
   i32.const 3
   i32.const 68
   i32.const 12624
   call $~lib/rt/__newArray
-  local.set $14
+  local.set $9
   global.get $~lib/memory/__stack_pointer
-  local.get $14
+  local.get $9
   i32.store offset=20
-  local.get $14
+  local.get $9
   call $std/typedarray/valuesEqual<~lib/typedarray/Int64Array>
   local.get $a
-  local.set $14
+  local.set $9
   global.get $~lib/memory/__stack_pointer
-  local.get $14
+  local.get $9
   i32.store offset=4
-  local.get $14
+  local.get $9
   local.get $setSource5
-  local.set $14
+  local.set $9
   global.get $~lib/memory/__stack_pointer
-  local.get $14
+  local.get $9
   i32.store offset=20
-  local.get $14
+  local.get $9
   i32.const 0
   call $~lib/typedarray/Int64Array#set<~lib/typedarray/Uint8Array>
   local.get $a
-  local.set $14
+  local.set $9
   global.get $~lib/memory/__stack_pointer
-  local.get $14
+  local.get $9
   i32.store offset=4
-  local.get $14
+  local.get $9
   local.get $setSource6
-  local.set $14
+  local.set $9
   global.get $~lib/memory/__stack_pointer
-  local.get $14
+  local.get $9
   i32.store offset=20
-  local.get $14
+  local.get $9
   i32.const 4
   call $~lib/typedarray/Int64Array#set<~lib/typedarray/Int16Array>
   local.get $a
-  local.set $14
+  local.set $9
   global.get $~lib/memory/__stack_pointer
-  local.get $14
+  local.get $9
   i32.store offset=4
-  local.get $14
+  local.get $9
   global.get $std/typedarray/setSource7
-  local.set $14
+  local.set $9
   global.get $~lib/memory/__stack_pointer
-  local.get $14
+  local.get $9
   i32.store offset=20
-  local.get $14
+  local.get $9
   i32.const 7
   call $~lib/typedarray/Int64Array#set<~lib/array/Array<i8>>
   i32.const 0
   drop
   local.get $a
-  local.set $14
+  local.set $9
   global.get $~lib/memory/__stack_pointer
-  local.get $14
+  local.get $9
   i32.store offset=4
-  local.get $14
+  local.get $9
   i32.const 10
   i32.const 3
   i32.const 68
   i32.const 12736
   call $~lib/rt/__newArray
-  local.set $14
+  local.set $9
   global.get $~lib/memory/__stack_pointer
-  local.get $14
+  local.get $9
   i32.store offset=20
-  local.get $14
+  local.get $9
   call $std/typedarray/valuesEqual<~lib/typedarray/Int64Array>
   global.get $~lib/memory/__stack_pointer
   i32.const 24
@@ -77529,11 +77489,6 @@
   (local $7 i32)
   (local $8 i32)
   (local $9 i32)
-  (local $10 i32)
-  (local $11 i32)
-  (local $12 i32)
-  (local $13 i32)
-  (local $14 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 24
   i32.sub
@@ -77550,29 +77505,29 @@
   local.tee $setSource4
   i32.store
   local.get $setSource4
-  local.set $14
+  local.set $9
   global.get $~lib/memory/__stack_pointer
-  local.get $14
+  local.get $9
   i32.store offset=4
-  local.get $14
+  local.get $9
   i32.const 0
   i64.const 7
   call $~lib/typedarray/Int64Array#__set
   local.get $setSource4
-  local.set $14
+  local.set $9
   global.get $~lib/memory/__stack_pointer
-  local.get $14
+  local.get $9
   i32.store offset=4
-  local.get $14
+  local.get $9
   i32.const 1
   i64.const 8
   call $~lib/typedarray/Int64Array#__set
   local.get $setSource4
-  local.set $14
+  local.set $9
   global.get $~lib/memory/__stack_pointer
-  local.get $14
+  local.get $9
   i32.store offset=4
-  local.get $14
+  local.get $9
   i32.const 2
   i64.const 9
   call $~lib/typedarray/Int64Array#__set
@@ -77583,38 +77538,38 @@
   local.tee $setSource5
   i32.store offset=8
   local.get $setSource5
-  local.set $14
+  local.set $9
   global.get $~lib/memory/__stack_pointer
-  local.get $14
+  local.get $9
   i32.store offset=4
-  local.get $14
+  local.get $9
   i32.const 0
   i32.const 100
   call $~lib/typedarray/Uint8Array#__set
   local.get $setSource5
-  local.set $14
+  local.set $9
   global.get $~lib/memory/__stack_pointer
-  local.get $14
+  local.get $9
   i32.store offset=4
-  local.get $14
+  local.get $9
   i32.const 1
   i32.const 101
   call $~lib/typedarray/Uint8Array#__set
   local.get $setSource5
-  local.set $14
+  local.set $9
   global.get $~lib/memory/__stack_pointer
-  local.get $14
+  local.get $9
   i32.store offset=4
-  local.get $14
+  local.get $9
   i32.const 2
   i32.const 102
   call $~lib/typedarray/Uint8Array#__set
   local.get $setSource5
-  local.set $14
+  local.set $9
   global.get $~lib/memory/__stack_pointer
-  local.get $14
+  local.get $9
   i32.store offset=4
-  local.get $14
+  local.get $9
   i32.const 3
   i32.const 103
   call $~lib/typedarray/Uint8Array#__set
@@ -77625,29 +77580,29 @@
   local.tee $setSource6
   i32.store offset=12
   local.get $setSource6
-  local.set $14
+  local.set $9
   global.get $~lib/memory/__stack_pointer
-  local.get $14
+  local.get $9
   i32.store offset=4
-  local.get $14
+  local.get $9
   i32.const 0
   i32.const 1000
   call $~lib/typedarray/Int16Array#__set
   local.get $setSource6
-  local.set $14
+  local.set $9
   global.get $~lib/memory/__stack_pointer
-  local.get $14
+  local.get $9
   i32.store offset=4
-  local.get $14
+  local.get $9
   i32.const 1
   i32.const 1001
   call $~lib/typedarray/Int16Array#__set
   local.get $setSource6
-  local.set $14
+  local.set $9
   global.get $~lib/memory/__stack_pointer
-  local.get $14
+  local.get $9
   i32.store offset=4
-  local.get $14
+  local.get $9
   i32.const 2
   i32.const 1002
   call $~lib/typedarray/Int16Array#__set
@@ -77658,191 +77613,191 @@
   local.tee $a
   i32.store offset=16
   local.get $a
-  local.set $14
+  local.set $9
   global.get $~lib/memory/__stack_pointer
-  local.get $14
+  local.get $9
   i32.store offset=4
-  local.get $14
+  local.get $9
   global.get $std/typedarray/setSource1
-  local.set $14
+  local.set $9
   global.get $~lib/memory/__stack_pointer
-  local.get $14
+  local.get $9
   i32.store offset=20
-  local.get $14
+  local.get $9
   i32.const 0
   call $~lib/typedarray/Uint64Array#set<~lib/array/Array<i32>>
   local.get $a
-  local.set $14
+  local.set $9
   global.get $~lib/memory/__stack_pointer
-  local.get $14
+  local.get $9
   i32.store offset=4
-  local.get $14
+  local.get $9
   i32.const 10
   i32.const 3
   i32.const 69
   i32.const 12848
   call $~lib/rt/__newArray
-  local.set $14
+  local.set $9
   global.get $~lib/memory/__stack_pointer
-  local.get $14
+  local.get $9
   i32.store offset=20
-  local.get $14
+  local.get $9
   call $std/typedarray/valuesEqual<~lib/typedarray/Uint64Array>
   local.get $a
-  local.set $14
+  local.set $9
   global.get $~lib/memory/__stack_pointer
-  local.get $14
+  local.get $9
   i32.store offset=4
-  local.get $14
+  local.get $9
   global.get $std/typedarray/setSource2
-  local.set $14
+  local.set $9
   global.get $~lib/memory/__stack_pointer
-  local.get $14
+  local.get $9
   i32.store offset=20
-  local.get $14
+  local.get $9
   i32.const 3
   call $~lib/typedarray/Uint64Array#set<~lib/array/Array<f32>>
   local.get $a
-  local.set $14
+  local.set $9
   global.get $~lib/memory/__stack_pointer
-  local.get $14
+  local.get $9
   i32.store offset=4
-  local.get $14
+  local.get $9
   i32.const 10
   i32.const 3
   i32.const 69
   i32.const 13008
   call $~lib/rt/__newArray
-  local.set $14
+  local.set $9
   global.get $~lib/memory/__stack_pointer
-  local.get $14
+  local.get $9
   i32.store offset=20
-  local.get $14
+  local.get $9
   call $std/typedarray/valuesEqual<~lib/typedarray/Uint64Array>
   local.get $a
-  local.set $14
+  local.set $9
   global.get $~lib/memory/__stack_pointer
-  local.get $14
+  local.get $9
   i32.store offset=4
-  local.get $14
+  local.get $9
   local.get $setSource4
-  local.set $14
+  local.set $9
   global.get $~lib/memory/__stack_pointer
-  local.get $14
+  local.get $9
   i32.store offset=20
-  local.get $14
+  local.get $9
   i32.const 6
   call $~lib/typedarray/Uint64Array#set<~lib/typedarray/Int64Array>
   local.get $a
-  local.set $14
+  local.set $9
   global.get $~lib/memory/__stack_pointer
-  local.get $14
+  local.get $9
   i32.store offset=4
-  local.get $14
+  local.get $9
   i32.const 10
   i32.const 3
   i32.const 69
   i32.const 13120
   call $~lib/rt/__newArray
-  local.set $14
+  local.set $9
   global.get $~lib/memory/__stack_pointer
-  local.get $14
+  local.get $9
   i32.store offset=20
-  local.get $14
+  local.get $9
   call $std/typedarray/valuesEqual<~lib/typedarray/Uint64Array>
   i32.const 1
   drop
   local.get $a
-  local.set $14
+  local.set $9
   global.get $~lib/memory/__stack_pointer
-  local.get $14
+  local.get $9
   i32.store offset=4
-  local.get $14
+  local.get $9
   global.get $std/typedarray/setSource3
-  local.set $14
+  local.set $9
   global.get $~lib/memory/__stack_pointer
-  local.get $14
+  local.get $9
   i32.store offset=20
-  local.get $14
+  local.get $9
   i32.const 2
   call $~lib/typedarray/Uint64Array#set<~lib/array/Array<f64>>
   local.get $a
-  local.set $14
+  local.set $9
   global.get $~lib/memory/__stack_pointer
-  local.get $14
+  local.get $9
   i32.store offset=4
-  local.get $14
+  local.get $9
   i32.const 10
   i32.const 3
   i32.const 69
   i32.const 13232
   call $~lib/rt/__newArray
-  local.set $14
+  local.set $9
   global.get $~lib/memory/__stack_pointer
-  local.get $14
+  local.get $9
   i32.store offset=20
-  local.get $14
+  local.get $9
   call $std/typedarray/valuesEqual<~lib/typedarray/Uint64Array>
   local.get $a
-  local.set $14
+  local.set $9
   global.get $~lib/memory/__stack_pointer
-  local.get $14
+  local.get $9
   i32.store offset=4
-  local.get $14
+  local.get $9
   local.get $setSource5
-  local.set $14
+  local.set $9
   global.get $~lib/memory/__stack_pointer
-  local.get $14
+  local.get $9
   i32.store offset=20
-  local.get $14
+  local.get $9
   i32.const 0
   call $~lib/typedarray/Uint64Array#set<~lib/typedarray/Uint8Array>
   local.get $a
-  local.set $14
+  local.set $9
   global.get $~lib/memory/__stack_pointer
-  local.get $14
+  local.get $9
   i32.store offset=4
-  local.get $14
+  local.get $9
   local.get $setSource6
-  local.set $14
+  local.set $9
   global.get $~lib/memory/__stack_pointer
-  local.get $14
+  local.get $9
   i32.store offset=20
-  local.get $14
+  local.get $9
   i32.const 4
   call $~lib/typedarray/Uint64Array#set<~lib/typedarray/Int16Array>
   local.get $a
-  local.set $14
+  local.set $9
   global.get $~lib/memory/__stack_pointer
-  local.get $14
+  local.get $9
   i32.store offset=4
-  local.get $14
+  local.get $9
   global.get $std/typedarray/setSource7
-  local.set $14
+  local.set $9
   global.get $~lib/memory/__stack_pointer
-  local.get $14
+  local.get $9
   i32.store offset=20
-  local.get $14
+  local.get $9
   i32.const 7
   call $~lib/typedarray/Uint64Array#set<~lib/array/Array<i8>>
   i32.const 0
   drop
   local.get $a
-  local.set $14
+  local.set $9
   global.get $~lib/memory/__stack_pointer
-  local.get $14
+  local.get $9
   i32.store offset=4
-  local.get $14
+  local.get $9
   i32.const 10
   i32.const 3
   i32.const 69
   i32.const 13344
   call $~lib/rt/__newArray
-  local.set $14
+  local.set $9
   global.get $~lib/memory/__stack_pointer
-  local.get $14
+  local.get $9
   i32.store offset=20
-  local.get $14
+  local.get $9
   call $std/typedarray/valuesEqual<~lib/typedarray/Uint64Array>
   global.get $~lib/memory/__stack_pointer
   i32.const 24
@@ -78788,10 +78743,6 @@
   (local $6 i32)
   (local $7 i32)
   (local $8 i32)
-  (local $9 i32)
-  (local $10 i32)
-  (local $11 i32)
-  (local $12 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 24
   i32.sub
@@ -78808,29 +78759,29 @@
   local.tee $setSource4
   i32.store
   local.get $setSource4
-  local.set $12
+  local.set $8
   global.get $~lib/memory/__stack_pointer
-  local.get $12
+  local.get $8
   i32.store offset=4
-  local.get $12
+  local.get $8
   i32.const 0
   i64.const 7
   call $~lib/typedarray/Int64Array#__set
   local.get $setSource4
-  local.set $12
+  local.set $8
   global.get $~lib/memory/__stack_pointer
-  local.get $12
+  local.get $8
   i32.store offset=4
-  local.get $12
+  local.get $8
   i32.const 1
   i64.const 8
   call $~lib/typedarray/Int64Array#__set
   local.get $setSource4
-  local.set $12
+  local.set $8
   global.get $~lib/memory/__stack_pointer
-  local.get $12
+  local.get $8
   i32.store offset=4
-  local.get $12
+  local.get $8
   i32.const 2
   i64.const 9
   call $~lib/typedarray/Int64Array#__set
@@ -78841,38 +78792,38 @@
   local.tee $setSource5
   i32.store offset=8
   local.get $setSource5
-  local.set $12
+  local.set $8
   global.get $~lib/memory/__stack_pointer
-  local.get $12
+  local.get $8
   i32.store offset=4
-  local.get $12
+  local.get $8
   i32.const 0
   i32.const 100
   call $~lib/typedarray/Uint8Array#__set
   local.get $setSource5
-  local.set $12
+  local.set $8
   global.get $~lib/memory/__stack_pointer
-  local.get $12
+  local.get $8
   i32.store offset=4
-  local.get $12
+  local.get $8
   i32.const 1
   i32.const 101
   call $~lib/typedarray/Uint8Array#__set
   local.get $setSource5
-  local.set $12
+  local.set $8
   global.get $~lib/memory/__stack_pointer
-  local.get $12
+  local.get $8
   i32.store offset=4
-  local.get $12
+  local.get $8
   i32.const 2
   i32.const 102
   call $~lib/typedarray/Uint8Array#__set
   local.get $setSource5
-  local.set $12
+  local.set $8
   global.get $~lib/memory/__stack_pointer
-  local.get $12
+  local.get $8
   i32.store offset=4
-  local.get $12
+  local.get $8
   i32.const 3
   i32.const 103
   call $~lib/typedarray/Uint8Array#__set
@@ -78883,29 +78834,29 @@
   local.tee $setSource6
   i32.store offset=12
   local.get $setSource6
-  local.set $12
+  local.set $8
   global.get $~lib/memory/__stack_pointer
-  local.get $12
+  local.get $8
   i32.store offset=4
-  local.get $12
+  local.get $8
   i32.const 0
   i32.const 1000
   call $~lib/typedarray/Int16Array#__set
   local.get $setSource6
-  local.set $12
+  local.set $8
   global.get $~lib/memory/__stack_pointer
-  local.get $12
+  local.get $8
   i32.store offset=4
-  local.get $12
+  local.get $8
   i32.const 1
   i32.const 1001
   call $~lib/typedarray/Int16Array#__set
   local.get $setSource6
-  local.set $12
+  local.set $8
   global.get $~lib/memory/__stack_pointer
-  local.get $12
+  local.get $8
   i32.store offset=4
-  local.get $12
+  local.get $8
   i32.const 2
   i32.const 1002
   call $~lib/typedarray/Int16Array#__set
@@ -78916,160 +78867,160 @@
   local.tee $a
   i32.store offset=16
   local.get $a
-  local.set $12
+  local.set $8
   global.get $~lib/memory/__stack_pointer
-  local.get $12
+  local.get $8
   i32.store offset=4
-  local.get $12
+  local.get $8
   global.get $std/typedarray/setSource1
-  local.set $12
+  local.set $8
   global.get $~lib/memory/__stack_pointer
-  local.get $12
+  local.get $8
   i32.store offset=20
-  local.get $12
+  local.get $8
   i32.const 0
   call $~lib/typedarray/Float32Array#set<~lib/array/Array<i32>>
   local.get $a
-  local.set $12
+  local.set $8
   global.get $~lib/memory/__stack_pointer
-  local.get $12
+  local.get $8
   i32.store offset=4
-  local.get $12
+  local.get $8
   i32.const 10
   i32.const 2
   i32.const 62
   i32.const 13456
   call $~lib/rt/__newArray
-  local.set $12
+  local.set $8
   global.get $~lib/memory/__stack_pointer
-  local.get $12
+  local.get $8
   i32.store offset=20
-  local.get $12
+  local.get $8
   call $std/typedarray/valuesEqual<~lib/typedarray/Float32Array>
   local.get $a
-  local.set $12
+  local.set $8
   global.get $~lib/memory/__stack_pointer
-  local.get $12
+  local.get $8
   i32.store offset=4
-  local.get $12
+  local.get $8
   global.get $std/typedarray/setSource2
-  local.set $12
+  local.set $8
   global.get $~lib/memory/__stack_pointer
-  local.get $12
+  local.get $8
   i32.store offset=20
-  local.get $12
+  local.get $8
   i32.const 3
   call $~lib/typedarray/Float32Array#set<~lib/array/Array<f32>>
   local.get $a
-  local.set $12
+  local.set $8
   global.get $~lib/memory/__stack_pointer
-  local.get $12
+  local.get $8
   i32.store offset=4
-  local.get $12
+  local.get $8
   i32.const 10
   i32.const 2
   i32.const 62
   i32.const 13568
   call $~lib/rt/__newArray
-  local.set $12
+  local.set $8
   global.get $~lib/memory/__stack_pointer
-  local.get $12
+  local.get $8
   i32.store offset=20
-  local.get $12
+  local.get $8
   call $std/typedarray/valuesEqual<~lib/typedarray/Float32Array>
   local.get $a
-  local.set $12
+  local.set $8
   global.get $~lib/memory/__stack_pointer
-  local.get $12
+  local.get $8
   i32.store offset=4
-  local.get $12
+  local.get $8
   local.get $setSource4
-  local.set $12
+  local.set $8
   global.get $~lib/memory/__stack_pointer
-  local.get $12
+  local.get $8
   i32.store offset=20
-  local.get $12
+  local.get $8
   i32.const 6
   call $~lib/typedarray/Float32Array#set<~lib/typedarray/Int64Array>
   local.get $a
-  local.set $12
+  local.set $8
   global.get $~lib/memory/__stack_pointer
-  local.get $12
+  local.get $8
   i32.store offset=4
-  local.get $12
+  local.get $8
   i32.const 10
   i32.const 2
   i32.const 62
   i32.const 13632
   call $~lib/rt/__newArray
-  local.set $12
+  local.set $8
   global.get $~lib/memory/__stack_pointer
-  local.get $12
+  local.get $8
   i32.store offset=20
-  local.get $12
+  local.get $8
   call $std/typedarray/valuesEqual<~lib/typedarray/Float32Array>
   i32.const 0
   drop
   local.get $a
-  local.set $12
+  local.set $8
   global.get $~lib/memory/__stack_pointer
-  local.get $12
+  local.get $8
   i32.store offset=4
-  local.get $12
+  local.get $8
   local.get $setSource5
-  local.set $12
+  local.set $8
   global.get $~lib/memory/__stack_pointer
-  local.get $12
+  local.get $8
   i32.store offset=20
-  local.get $12
+  local.get $8
   i32.const 0
   call $~lib/typedarray/Float32Array#set<~lib/typedarray/Uint8Array>
   local.get $a
-  local.set $12
+  local.set $8
   global.get $~lib/memory/__stack_pointer
-  local.get $12
+  local.get $8
   i32.store offset=4
-  local.get $12
+  local.get $8
   local.get $setSource6
-  local.set $12
+  local.set $8
   global.get $~lib/memory/__stack_pointer
-  local.get $12
+  local.get $8
   i32.store offset=20
-  local.get $12
+  local.get $8
   i32.const 4
   call $~lib/typedarray/Float32Array#set<~lib/typedarray/Int16Array>
   local.get $a
-  local.set $12
+  local.set $8
   global.get $~lib/memory/__stack_pointer
-  local.get $12
+  local.get $8
   i32.store offset=4
-  local.get $12
+  local.get $8
   global.get $std/typedarray/setSource7
-  local.set $12
+  local.set $8
   global.get $~lib/memory/__stack_pointer
-  local.get $12
+  local.get $8
   i32.store offset=20
-  local.get $12
+  local.get $8
   i32.const 7
   call $~lib/typedarray/Float32Array#set<~lib/array/Array<i8>>
   i32.const 0
   drop
   local.get $a
-  local.set $12
+  local.set $8
   global.get $~lib/memory/__stack_pointer
-  local.get $12
+  local.get $8
   i32.store offset=4
-  local.get $12
+  local.get $8
   i32.const 10
   i32.const 2
   i32.const 62
   i32.const 13696
   call $~lib/rt/__newArray
-  local.set $12
+  local.set $8
   global.get $~lib/memory/__stack_pointer
-  local.get $12
+  local.get $8
   i32.store offset=20
-  local.get $12
+  local.get $8
   call $std/typedarray/valuesEqual<~lib/typedarray/Float32Array>
   global.get $~lib/memory/__stack_pointer
   i32.const 24
@@ -80047,10 +79998,6 @@
   (local $6 i32)
   (local $7 i32)
   (local $8 i32)
-  (local $9 i32)
-  (local $10 i32)
-  (local $11 i32)
-  (local $12 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 24
   i32.sub
@@ -80067,29 +80014,29 @@
   local.tee $setSource4
   i32.store
   local.get $setSource4
-  local.set $12
+  local.set $8
   global.get $~lib/memory/__stack_pointer
-  local.get $12
+  local.get $8
   i32.store offset=4
-  local.get $12
+  local.get $8
   i32.const 0
   i64.const 7
   call $~lib/typedarray/Int64Array#__set
   local.get $setSource4
-  local.set $12
+  local.set $8
   global.get $~lib/memory/__stack_pointer
-  local.get $12
+  local.get $8
   i32.store offset=4
-  local.get $12
+  local.get $8
   i32.const 1
   i64.const 8
   call $~lib/typedarray/Int64Array#__set
   local.get $setSource4
-  local.set $12
+  local.set $8
   global.get $~lib/memory/__stack_pointer
-  local.get $12
+  local.get $8
   i32.store offset=4
-  local.get $12
+  local.get $8
   i32.const 2
   i64.const 9
   call $~lib/typedarray/Int64Array#__set
@@ -80100,38 +80047,38 @@
   local.tee $setSource5
   i32.store offset=8
   local.get $setSource5
-  local.set $12
+  local.set $8
   global.get $~lib/memory/__stack_pointer
-  local.get $12
+  local.get $8
   i32.store offset=4
-  local.get $12
+  local.get $8
   i32.const 0
   i32.const 100
   call $~lib/typedarray/Uint8Array#__set
   local.get $setSource5
-  local.set $12
+  local.set $8
   global.get $~lib/memory/__stack_pointer
-  local.get $12
+  local.get $8
   i32.store offset=4
-  local.get $12
+  local.get $8
   i32.const 1
   i32.const 101
   call $~lib/typedarray/Uint8Array#__set
   local.get $setSource5
-  local.set $12
+  local.set $8
   global.get $~lib/memory/__stack_pointer
-  local.get $12
+  local.get $8
   i32.store offset=4
-  local.get $12
+  local.get $8
   i32.const 2
   i32.const 102
   call $~lib/typedarray/Uint8Array#__set
   local.get $setSource5
-  local.set $12
+  local.set $8
   global.get $~lib/memory/__stack_pointer
-  local.get $12
+  local.get $8
   i32.store offset=4
-  local.get $12
+  local.get $8
   i32.const 3
   i32.const 103
   call $~lib/typedarray/Uint8Array#__set
@@ -80142,29 +80089,29 @@
   local.tee $setSource6
   i32.store offset=12
   local.get $setSource6
-  local.set $12
+  local.set $8
   global.get $~lib/memory/__stack_pointer
-  local.get $12
+  local.get $8
   i32.store offset=4
-  local.get $12
+  local.get $8
   i32.const 0
   i32.const 1000
   call $~lib/typedarray/Int16Array#__set
   local.get $setSource6
-  local.set $12
+  local.set $8
   global.get $~lib/memory/__stack_pointer
-  local.get $12
+  local.get $8
   i32.store offset=4
-  local.get $12
+  local.get $8
   i32.const 1
   i32.const 1001
   call $~lib/typedarray/Int16Array#__set
   local.get $setSource6
-  local.set $12
+  local.set $8
   global.get $~lib/memory/__stack_pointer
-  local.get $12
+  local.get $8
   i32.store offset=4
-  local.get $12
+  local.get $8
   i32.const 2
   i32.const 1002
   call $~lib/typedarray/Int16Array#__set
@@ -80175,160 +80122,160 @@
   local.tee $a
   i32.store offset=16
   local.get $a
-  local.set $12
+  local.set $8
   global.get $~lib/memory/__stack_pointer
-  local.get $12
+  local.get $8
   i32.store offset=4
-  local.get $12
+  local.get $8
   global.get $std/typedarray/setSource1
-  local.set $12
+  local.set $8
   global.get $~lib/memory/__stack_pointer
-  local.get $12
+  local.get $8
   i32.store offset=20
-  local.get $12
+  local.get $8
   i32.const 0
   call $~lib/typedarray/Float64Array#set<~lib/array/Array<i32>>
   local.get $a
-  local.set $12
+  local.set $8
   global.get $~lib/memory/__stack_pointer
-  local.get $12
+  local.get $8
   i32.store offset=4
-  local.get $12
+  local.get $8
   i32.const 10
   i32.const 3
   i32.const 63
   i32.const 13760
   call $~lib/rt/__newArray
-  local.set $12
+  local.set $8
   global.get $~lib/memory/__stack_pointer
-  local.get $12
+  local.get $8
   i32.store offset=20
-  local.get $12
+  local.get $8
   call $std/typedarray/valuesEqual<~lib/typedarray/Float64Array>
   local.get $a
-  local.set $12
+  local.set $8
   global.get $~lib/memory/__stack_pointer
-  local.get $12
+  local.get $8
   i32.store offset=4
-  local.get $12
+  local.get $8
   global.get $std/typedarray/setSource2
-  local.set $12
+  local.set $8
   global.get $~lib/memory/__stack_pointer
-  local.get $12
+  local.get $8
   i32.store offset=20
-  local.get $12
+  local.get $8
   i32.const 3
   call $~lib/typedarray/Float64Array#set<~lib/array/Array<f32>>
   local.get $a
-  local.set $12
+  local.set $8
   global.get $~lib/memory/__stack_pointer
-  local.get $12
+  local.get $8
   i32.store offset=4
-  local.get $12
+  local.get $8
   i32.const 10
   i32.const 3
   i32.const 63
   i32.const 13920
   call $~lib/rt/__newArray
-  local.set $12
+  local.set $8
   global.get $~lib/memory/__stack_pointer
-  local.get $12
+  local.get $8
   i32.store offset=20
-  local.get $12
+  local.get $8
   call $std/typedarray/valuesEqual<~lib/typedarray/Float64Array>
   local.get $a
-  local.set $12
+  local.set $8
   global.get $~lib/memory/__stack_pointer
-  local.get $12
+  local.get $8
   i32.store offset=4
-  local.get $12
+  local.get $8
   local.get $setSource4
-  local.set $12
+  local.set $8
   global.get $~lib/memory/__stack_pointer
-  local.get $12
+  local.get $8
   i32.store offset=20
-  local.get $12
+  local.get $8
   i32.const 6
   call $~lib/typedarray/Float64Array#set<~lib/typedarray/Int64Array>
   local.get $a
-  local.set $12
+  local.set $8
   global.get $~lib/memory/__stack_pointer
-  local.get $12
+  local.get $8
   i32.store offset=4
-  local.get $12
+  local.get $8
   i32.const 10
   i32.const 3
   i32.const 63
   i32.const 14032
   call $~lib/rt/__newArray
-  local.set $12
+  local.set $8
   global.get $~lib/memory/__stack_pointer
-  local.get $12
+  local.get $8
   i32.store offset=20
-  local.get $12
+  local.get $8
   call $std/typedarray/valuesEqual<~lib/typedarray/Float64Array>
   i32.const 0
   drop
   local.get $a
-  local.set $12
+  local.set $8
   global.get $~lib/memory/__stack_pointer
-  local.get $12
+  local.get $8
   i32.store offset=4
-  local.get $12
+  local.get $8
   local.get $setSource5
-  local.set $12
+  local.set $8
   global.get $~lib/memory/__stack_pointer
-  local.get $12
+  local.get $8
   i32.store offset=20
-  local.get $12
+  local.get $8
   i32.const 0
   call $~lib/typedarray/Float64Array#set<~lib/typedarray/Uint8Array>
   local.get $a
-  local.set $12
+  local.set $8
   global.get $~lib/memory/__stack_pointer
-  local.get $12
+  local.get $8
   i32.store offset=4
-  local.get $12
+  local.get $8
   local.get $setSource6
-  local.set $12
+  local.set $8
   global.get $~lib/memory/__stack_pointer
-  local.get $12
+  local.get $8
   i32.store offset=20
-  local.get $12
+  local.get $8
   i32.const 4
   call $~lib/typedarray/Float64Array#set<~lib/typedarray/Int16Array>
   local.get $a
-  local.set $12
+  local.set $8
   global.get $~lib/memory/__stack_pointer
-  local.get $12
+  local.get $8
   i32.store offset=4
-  local.get $12
+  local.get $8
   global.get $std/typedarray/setSource7
-  local.set $12
+  local.set $8
   global.get $~lib/memory/__stack_pointer
-  local.get $12
+  local.get $8
   i32.store offset=20
-  local.get $12
+  local.get $8
   i32.const 7
   call $~lib/typedarray/Float64Array#set<~lib/array/Array<i8>>
   i32.const 0
   drop
   local.get $a
-  local.set $12
+  local.set $8
   global.get $~lib/memory/__stack_pointer
-  local.get $12
+  local.get $8
   i32.store offset=4
-  local.get $12
+  local.get $8
   i32.const 10
   i32.const 3
   i32.const 63
   i32.const 14144
   call $~lib/rt/__newArray
-  local.set $12
+  local.set $8
   global.get $~lib/memory/__stack_pointer
-  local.get $12
+  local.get $8
   i32.store offset=20
-  local.get $12
+  local.get $8
   call $std/typedarray/valuesEqual<~lib/typedarray/Float64Array>
   global.get $~lib/memory/__stack_pointer
   i32.const 24
@@ -88181,42 +88128,6 @@
   (local $62 i32)
   (local $63 i32)
   (local $64 i32)
-  (local $65 i32)
-  (local $66 i32)
-  (local $67 i32)
-  (local $68 i32)
-  (local $69 i32)
-  (local $70 i32)
-  (local $71 i32)
-  (local $72 i32)
-  (local $73 i32)
-  (local $74 i32)
-  (local $75 i32)
-  (local $76 i32)
-  (local $77 i32)
-  (local $78 i32)
-  (local $79 i32)
-  (local $80 i32)
-  (local $81 i32)
-  (local $82 i32)
-  (local $83 i32)
-  (local $84 i32)
-  (local $85 i32)
-  (local $86 i32)
-  (local $87 i32)
-  (local $88 i32)
-  (local $89 i32)
-  (local $90 i32)
-  (local $91 i32)
-  (local $92 i32)
-  (local $93 i32)
-  (local $94 i32)
-  (local $95 i32)
-  (local $96 i32)
-  (local $97 i32)
-  (local $98 i32)
-  (local $99 i32)
-  (local $100 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 124
   i32.sub
@@ -88298,38 +88209,38 @@
   local.tee $0
   i32.store
   local.get $0
-  local.set $100
+  local.set $64
   global.get $~lib/memory/__stack_pointer
-  local.get $100
+  local.get $64
   i32.store offset=4
-  local.get $100
+  local.get $64
   i32.const 0
   i32.const 1
   call $~lib/typedarray/Int32Array#__set
   local.get $0
-  local.set $100
+  local.set $64
   global.get $~lib/memory/__stack_pointer
-  local.get $100
+  local.get $64
   i32.store offset=4
-  local.get $100
+  local.get $64
   i32.const 1
   i32.const 2
   call $~lib/typedarray/Int32Array#__set
   local.get $0
-  local.set $100
+  local.set $64
   global.get $~lib/memory/__stack_pointer
-  local.get $100
+  local.get $64
   i32.store offset=4
-  local.get $100
+  local.get $64
   i32.const 2
   i32.const 3
   call $~lib/typedarray/Int32Array#__set
   local.get $0
-  local.set $100
+  local.set $64
   global.get $~lib/memory/__stack_pointer
-  local.get $100
+  local.get $64
   i32.store offset=4
-  local.get $100
+  local.get $64
   call $~lib/typedarray/Int32Array#get:length
   i32.const 3
   i32.eq
@@ -88343,11 +88254,11 @@
    unreachable
   end
   local.get $0
-  local.set $100
+  local.set $64
   global.get $~lib/memory/__stack_pointer
-  local.get $100
+  local.get $64
   i32.store offset=4
-  local.get $100
+  local.get $64
   call $~lib/arraybuffer/ArrayBufferView#get:byteOffset
   i32.const 0
   i32.eq
@@ -88361,11 +88272,11 @@
    unreachable
   end
   local.get $0
-  local.set $100
+  local.set $64
   global.get $~lib/memory/__stack_pointer
-  local.get $100
+  local.get $64
   i32.store offset=4
-  local.get $100
+  local.get $64
   call $~lib/arraybuffer/ArrayBufferView#get:byteLength
   i32.const 3
   i32.const 4
@@ -88381,11 +88292,11 @@
    unreachable
   end
   local.get $0
-  local.set $100
+  local.set $64
   global.get $~lib/memory/__stack_pointer
-  local.get $100
+  local.get $64
   i32.store offset=4
-  local.get $100
+  local.get $64
   i32.const 0
   call $~lib/typedarray/Int32Array#__get
   i32.const 1
@@ -88400,11 +88311,11 @@
    unreachable
   end
   local.get $0
-  local.set $100
+  local.set $64
   global.get $~lib/memory/__stack_pointer
-  local.get $100
+  local.get $64
   i32.store offset=4
-  local.get $100
+  local.get $64
   i32.const 1
   call $~lib/typedarray/Int32Array#__get
   i32.const 2
@@ -88419,11 +88330,11 @@
    unreachable
   end
   local.get $0
-  local.set $100
+  local.set $64
   global.get $~lib/memory/__stack_pointer
-  local.get $100
+  local.get $64
   i32.store offset=4
-  local.get $100
+  local.get $64
   i32.const 2
   call $~lib/typedarray/Int32Array#__get
   i32.const 3
@@ -88439,22 +88350,22 @@
   end
   global.get $~lib/memory/__stack_pointer
   local.get $0
-  local.set $100
+  local.set $64
   global.get $~lib/memory/__stack_pointer
-  local.get $100
+  local.get $64
   i32.store offset=4
-  local.get $100
+  local.get $64
   i32.const 1
   i32.const 2
   call $~lib/typedarray/Int32Array#subarray
   local.tee $0
   i32.store
   local.get $0
-  local.set $100
+  local.set $64
   global.get $~lib/memory/__stack_pointer
-  local.get $100
+  local.get $64
   i32.store offset=4
-  local.get $100
+  local.get $64
   call $~lib/typedarray/Int32Array#get:length
   i32.const 1
   i32.eq
@@ -88468,11 +88379,11 @@
    unreachable
   end
   local.get $0
-  local.set $100
+  local.set $64
   global.get $~lib/memory/__stack_pointer
-  local.get $100
+  local.get $64
   i32.store offset=4
-  local.get $100
+  local.get $64
   call $~lib/arraybuffer/ArrayBufferView#get:byteOffset
   i32.const 1
   i32.const 4
@@ -88488,11 +88399,11 @@
    unreachable
   end
   local.get $0
-  local.set $100
+  local.set $64
   global.get $~lib/memory/__stack_pointer
-  local.get $100
+  local.get $64
   i32.store offset=4
-  local.get $100
+  local.get $64
   call $~lib/arraybuffer/ArrayBufferView#get:byteLength
   i32.const 1
   i32.const 4
@@ -88508,11 +88419,11 @@
    unreachable
   end
   local.get $0
-  local.set $100
+  local.set $64
   global.get $~lib/memory/__stack_pointer
-  local.get $100
+  local.get $64
   i32.store offset=4
-  local.get $100
+  local.get $64
   i32.const 0
   call $~lib/typedarray/Int32Array#__get
   i32.const 2
@@ -88533,95 +88444,95 @@
   local.tee $1
   i32.store offset=8
   local.get $1
-  local.set $100
+  local.set $64
   global.get $~lib/memory/__stack_pointer
-  local.get $100
+  local.get $64
   i32.store offset=4
-  local.get $100
+  local.get $64
   i32.const 0
   f64.const 1
   call $~lib/typedarray/Float64Array#__set
   local.get $1
-  local.set $100
+  local.set $64
   global.get $~lib/memory/__stack_pointer
-  local.get $100
+  local.get $64
   i32.store offset=4
-  local.get $100
+  local.get $64
   i32.const 1
   f64.const 2
   call $~lib/typedarray/Float64Array#__set
   local.get $1
-  local.set $100
+  local.set $64
   global.get $~lib/memory/__stack_pointer
-  local.get $100
+  local.get $64
   i32.store offset=4
-  local.get $100
+  local.get $64
   i32.const 2
   f64.const 7
   call $~lib/typedarray/Float64Array#__set
   local.get $1
-  local.set $100
+  local.set $64
   global.get $~lib/memory/__stack_pointer
-  local.get $100
+  local.get $64
   i32.store offset=4
-  local.get $100
+  local.get $64
   i32.const 3
   f64.const 6
   call $~lib/typedarray/Float64Array#__set
   local.get $1
-  local.set $100
+  local.set $64
   global.get $~lib/memory/__stack_pointer
-  local.get $100
+  local.get $64
   i32.store offset=4
-  local.get $100
+  local.get $64
   i32.const 4
   f64.const 5
   call $~lib/typedarray/Float64Array#__set
   local.get $1
-  local.set $100
+  local.set $64
   global.get $~lib/memory/__stack_pointer
-  local.get $100
+  local.get $64
   i32.store offset=4
-  local.get $100
+  local.get $64
   i32.const 5
   f64.const 4
   call $~lib/typedarray/Float64Array#__set
   local.get $1
-  local.set $100
+  local.set $64
   global.get $~lib/memory/__stack_pointer
-  local.get $100
+  local.get $64
   i32.store offset=4
-  local.get $100
+  local.get $64
   i32.const 6
   f64.const 3
   call $~lib/typedarray/Float64Array#__set
   local.get $1
-  local.set $100
+  local.set $64
   global.get $~lib/memory/__stack_pointer
-  local.get $100
+  local.get $64
   i32.store offset=4
-  local.get $100
+  local.get $64
   i32.const 7
   f64.const 8
   call $~lib/typedarray/Float64Array#__set
   global.get $~lib/memory/__stack_pointer
   local.get $1
-  local.set $100
+  local.set $64
   global.get $~lib/memory/__stack_pointer
-  local.get $100
+  local.get $64
   i32.store offset=4
-  local.get $100
+  local.get $64
   i32.const 2
   i32.const 6
   call $~lib/typedarray/Float64Array#subarray
   local.tee $1
   i32.store offset=8
   local.get $1
-  local.set $100
+  local.set $64
   global.get $~lib/memory/__stack_pointer
-  local.get $100
+  local.get $64
   i32.store offset=4
-  local.get $100
+  local.get $64
   call $~lib/typedarray/Float64Array#get:length
   i32.const 4
   i32.eq
@@ -88635,11 +88546,11 @@
    unreachable
   end
   local.get $1
-  local.set $100
+  local.set $64
   global.get $~lib/memory/__stack_pointer
-  local.get $100
+  local.get $64
   i32.store offset=4
-  local.get $100
+  local.get $64
   call $~lib/arraybuffer/ArrayBufferView#get:byteOffset
   i32.const 2
   i32.const 8
@@ -88655,11 +88566,11 @@
    unreachable
   end
   local.get $1
-  local.set $100
+  local.set $64
   global.get $~lib/memory/__stack_pointer
-  local.get $100
+  local.get $64
   i32.store offset=4
-  local.get $100
+  local.get $64
   call $~lib/arraybuffer/ArrayBufferView#get:byteLength
   i32.const 4
   i32.const 8
@@ -88675,33 +88586,33 @@
    unreachable
   end
   local.get $1
-  local.set $100
+  local.set $64
   global.get $~lib/memory/__stack_pointer
-  local.get $100
+  local.get $64
   i32.store offset=4
-  local.get $100
+  local.get $64
   i32.const 0
   global.set $~argumentsLength
   i32.const 0
   call $~lib/typedarray/Float64Array#sort@varargs
   drop
   local.get $1
-  local.set $100
+  local.set $64
   global.get $~lib/memory/__stack_pointer
-  local.get $100
+  local.get $64
   i32.store offset=4
-  local.get $100
+  local.get $64
   i32.const 0
   call $~lib/typedarray/Float64Array#__get
   f64.const 4
   f64.eq
   if (result i32)
    local.get $1
-   local.set $100
+   local.set $64
    global.get $~lib/memory/__stack_pointer
-   local.get $100
+   local.get $64
    i32.store offset=4
-   local.get $100
+   local.get $64
    i32.const 1
    call $~lib/typedarray/Float64Array#__get
    f64.const 5
@@ -88711,11 +88622,11 @@
   end
   if (result i32)
    local.get $1
-   local.set $100
+   local.set $64
    global.get $~lib/memory/__stack_pointer
-   local.get $100
+   local.get $64
    i32.store offset=4
-   local.get $100
+   local.get $64
    i32.const 2
    call $~lib/typedarray/Float64Array#__get
    f64.const 6
@@ -88725,11 +88636,11 @@
   end
   if (result i32)
    local.get $1
-   local.set $100
+   local.set $64
    global.get $~lib/memory/__stack_pointer
-   local.get $100
+   local.get $64
    i32.store offset=4
-   local.get $100
+   local.get $64
    i32.const 3
    call $~lib/typedarray/Float64Array#__get
    f64.const 7
@@ -88753,38 +88664,38 @@
   local.tee $2
   i32.store offset=12
   local.get $2
-  local.set $100
+  local.set $64
   global.get $~lib/memory/__stack_pointer
-  local.get $100
+  local.get $64
   i32.store offset=4
-  local.get $100
+  local.get $64
   i32.const 0
   i32.const -32
   call $~lib/typedarray/Uint8ClampedArray#__set
   local.get $2
-  local.set $100
+  local.set $64
   global.get $~lib/memory/__stack_pointer
-  local.get $100
+  local.get $64
   i32.store offset=4
-  local.get $100
+  local.get $64
   i32.const 1
   i32.const 2
   call $~lib/typedarray/Uint8ClampedArray#__set
   local.get $2
-  local.set $100
+  local.set $64
   global.get $~lib/memory/__stack_pointer
-  local.get $100
+  local.get $64
   i32.store offset=4
-  local.get $100
+  local.get $64
   i32.const 2
   i32.const 256
   call $~lib/typedarray/Uint8ClampedArray#__set
   local.get $2
-  local.set $100
+  local.set $64
   global.get $~lib/memory/__stack_pointer
-  local.get $100
+  local.get $64
   i32.store offset=4
-  local.get $100
+  local.get $64
   i32.const 0
   call $~lib/typedarray/Uint8ClampedArray#__get
   i32.const 0
@@ -88799,11 +88710,11 @@
    unreachable
   end
   local.get $2
-  local.set $100
+  local.set $64
   global.get $~lib/memory/__stack_pointer
-  local.get $100
+  local.get $64
   i32.store offset=4
-  local.get $100
+  local.get $64
   i32.const 1
   call $~lib/typedarray/Uint8ClampedArray#__get
   i32.const 2
@@ -88818,11 +88729,11 @@
    unreachable
   end
   local.get $2
-  local.set $100
+  local.set $64
   global.get $~lib/memory/__stack_pointer
-  local.get $100
+  local.get $64
   i32.store offset=4
-  local.get $100
+  local.get $64
   i32.const 2
   call $~lib/typedarray/Uint8ClampedArray#__get
   i32.const 255
@@ -88843,77 +88754,77 @@
   local.tee $3
   i32.store offset=16
   local.get $3
-  local.set $100
+  local.set $64
   global.get $~lib/memory/__stack_pointer
-  local.get $100
+  local.get $64
   i32.store offset=4
-  local.get $100
+  local.get $64
   i32.const 0
   i32.const 1
   call $~lib/typedarray/Int8Array#__set
   local.get $3
-  local.set $100
+  local.set $64
   global.get $~lib/memory/__stack_pointer
-  local.get $100
+  local.get $64
   i32.store offset=4
-  local.get $100
+  local.get $64
   i32.const 1
   i32.const 2
   call $~lib/typedarray/Int8Array#__set
   local.get $3
-  local.set $100
+  local.set $64
   global.get $~lib/memory/__stack_pointer
-  local.get $100
+  local.get $64
   i32.store offset=4
-  local.get $100
+  local.get $64
   i32.const 2
   i32.const 3
   call $~lib/typedarray/Int8Array#__set
   local.get $3
-  local.set $100
+  local.set $64
   global.get $~lib/memory/__stack_pointer
-  local.get $100
+  local.get $64
   i32.store offset=4
-  local.get $100
+  local.get $64
   i32.const 3
   i32.const 4
   call $~lib/typedarray/Int8Array#__set
   local.get $3
-  local.set $100
+  local.set $64
   global.get $~lib/memory/__stack_pointer
-  local.get $100
+  local.get $64
   i32.store offset=4
-  local.get $100
+  local.get $64
   i32.const 4
   i32.const 5
   call $~lib/typedarray/Int8Array#__set
   local.get $3
-  local.set $100
+  local.set $64
   global.get $~lib/memory/__stack_pointer
-  local.get $100
+  local.get $64
   i32.store offset=4
-  local.get $100
+  local.get $64
   i32.const 1
   i32.const 1
   i32.const 3
   call $~lib/typedarray/Int8Array#fill
   drop
   local.get $3
-  local.set $100
+  local.set $64
   global.get $~lib/memory/__stack_pointer
-  local.get $100
+  local.get $64
   i32.store offset=4
-  local.get $100
+  local.get $64
   i32.const 5
   i32.const 0
   i32.const 16
   i32.const 704
   call $~lib/rt/__newArray
-  local.set $100
+  local.set $64
   global.get $~lib/memory/__stack_pointer
-  local.get $100
+  local.get $64
   i32.store offset=20
-  local.get $100
+  local.get $64
   call $std/typedarray/isInt8ArrayEqual
   i32.eqz
   if
@@ -88925,11 +88836,11 @@
    unreachable
   end
   local.get $3
-  local.set $100
+  local.set $64
   global.get $~lib/memory/__stack_pointer
-  local.get $100
+  local.get $64
   i32.store offset=4
-  local.get $100
+  local.get $64
   i32.const 0
   i32.const 0
   i32.const 1
@@ -88938,21 +88849,21 @@
   call $~lib/typedarray/Int8Array#fill@varargs
   drop
   local.get $3
-  local.set $100
+  local.set $64
   global.get $~lib/memory/__stack_pointer
-  local.get $100
+  local.get $64
   i32.store offset=4
-  local.get $100
+  local.get $64
   i32.const 5
   i32.const 0
   i32.const 16
   i32.const 784
   call $~lib/rt/__newArray
-  local.set $100
+  local.set $64
   global.get $~lib/memory/__stack_pointer
-  local.get $100
+  local.get $64
   i32.store offset=20
-  local.get $100
+  local.get $64
   call $std/typedarray/isInt8ArrayEqual
   i32.eqz
   if
@@ -88964,32 +88875,32 @@
    unreachable
   end
   local.get $3
-  local.set $100
+  local.set $64
   global.get $~lib/memory/__stack_pointer
-  local.get $100
+  local.get $64
   i32.store offset=4
-  local.get $100
+  local.get $64
   i32.const 1
   i32.const 0
   i32.const -3
   call $~lib/typedarray/Int8Array#fill
   drop
   local.get $3
-  local.set $100
+  local.set $64
   global.get $~lib/memory/__stack_pointer
-  local.get $100
+  local.get $64
   i32.store offset=4
-  local.get $100
+  local.get $64
   i32.const 5
   i32.const 0
   i32.const 16
   i32.const 816
   call $~lib/rt/__newArray
-  local.set $100
+  local.set $64
   global.get $~lib/memory/__stack_pointer
-  local.get $100
+  local.get $64
   i32.store offset=20
-  local.get $100
+  local.get $64
   call $std/typedarray/isInt8ArrayEqual
   i32.eqz
   if
@@ -89001,11 +88912,11 @@
    unreachable
   end
   local.get $3
-  local.set $100
+  local.set $64
   global.get $~lib/memory/__stack_pointer
-  local.get $100
+  local.get $64
   i32.store offset=4
-  local.get $100
+  local.get $64
   i32.const 2
   i32.const -2
   i32.const 2
@@ -89014,21 +88925,21 @@
   call $~lib/typedarray/Int8Array#fill@varargs
   drop
   local.get $3
-  local.set $100
+  local.set $64
   global.get $~lib/memory/__stack_pointer
-  local.get $100
+  local.get $64
   i32.store offset=4
-  local.get $100
+  local.get $64
   i32.const 5
   i32.const 0
   i32.const 16
   i32.const 848
   call $~lib/rt/__newArray
-  local.set $100
+  local.set $64
   global.get $~lib/memory/__stack_pointer
-  local.get $100
+  local.get $64
   i32.store offset=20
-  local.get $100
+  local.get $64
   call $std/typedarray/isInt8ArrayEqual
   i32.eqz
   if
@@ -89040,32 +88951,32 @@
    unreachable
   end
   local.get $3
-  local.set $100
+  local.set $64
   global.get $~lib/memory/__stack_pointer
-  local.get $100
+  local.get $64
   i32.store offset=4
-  local.get $100
+  local.get $64
   i32.const 0
   i32.const 1
   i32.const 0
   call $~lib/typedarray/Int8Array#fill
   drop
   local.get $3
-  local.set $100
+  local.set $64
   global.get $~lib/memory/__stack_pointer
-  local.get $100
+  local.get $64
   i32.store offset=4
-  local.get $100
+  local.get $64
   i32.const 5
   i32.const 0
   i32.const 16
   i32.const 880
   call $~lib/rt/__newArray
-  local.set $100
+  local.set $64
   global.get $~lib/memory/__stack_pointer
-  local.get $100
+  local.get $64
   i32.store offset=20
-  local.get $100
+  local.get $64
   call $std/typedarray/isInt8ArrayEqual
   i32.eqz
   if
@@ -89078,22 +88989,22 @@
   end
   global.get $~lib/memory/__stack_pointer
   local.get $3
-  local.set $100
+  local.set $64
   global.get $~lib/memory/__stack_pointer
-  local.get $100
+  local.get $64
   i32.store offset=4
-  local.get $100
+  local.get $64
   i32.const 1
   i32.const 4
   call $~lib/typedarray/Int8Array#subarray
-  local.tee $14
+  local.tee $9
   i32.store offset=24
-  local.get $14
-  local.set $100
+  local.get $9
+  local.set $64
   global.get $~lib/memory/__stack_pointer
-  local.get $100
+  local.get $64
   i32.store offset=4
-  local.get $100
+  local.get $64
   i32.const 0
   i32.const 0
   i32.const 1
@@ -89101,12 +89012,12 @@
   i32.const 0
   call $~lib/typedarray/Int8Array#fill@varargs
   drop
-  local.get $14
-  local.set $100
+  local.get $9
+  local.set $64
   global.get $~lib/memory/__stack_pointer
-  local.get $100
+  local.get $64
   i32.store offset=4
-  local.get $100
+  local.get $64
   call $~lib/typedarray/Int8Array#get:length
   i32.const 3
   i32.eq
@@ -89119,12 +89030,12 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $14
-  local.set $100
+  local.get $9
+  local.set $64
   global.get $~lib/memory/__stack_pointer
-  local.get $100
+  local.get $64
   i32.store offset=4
-  local.get $100
+  local.get $64
   call $~lib/arraybuffer/ArrayBufferView#get:byteOffset
   i32.const 1
   i32.eq
@@ -89137,12 +89048,12 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $14
-  local.set $100
+  local.get $9
+  local.set $64
   global.get $~lib/memory/__stack_pointer
-  local.get $100
+  local.get $64
   i32.store offset=4
-  local.get $100
+  local.get $64
   call $~lib/arraybuffer/ArrayBufferView#get:byteLength
   i32.const 3
   i32.eq
@@ -89155,22 +89066,22 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $14
-  local.set $100
+  local.get $9
+  local.set $64
   global.get $~lib/memory/__stack_pointer
-  local.get $100
+  local.get $64
   i32.store offset=4
-  local.get $100
+  local.get $64
   i32.const 3
   i32.const 0
   i32.const 16
   i32.const 912
   call $~lib/rt/__newArray
-  local.set $100
+  local.set $64
   global.get $~lib/memory/__stack_pointer
-  local.get $100
+  local.get $64
   i32.store offset=20
-  local.get $100
+  local.get $64
   call $std/typedarray/isInt8ArrayEqual
   i32.eqz
   if
@@ -89182,21 +89093,21 @@
    unreachable
   end
   local.get $3
-  local.set $100
+  local.set $64
   global.get $~lib/memory/__stack_pointer
-  local.get $100
+  local.get $64
   i32.store offset=4
-  local.get $100
+  local.get $64
   i32.const 5
   i32.const 0
   i32.const 16
   i32.const 944
   call $~lib/rt/__newArray
-  local.set $100
+  local.set $64
   global.get $~lib/memory/__stack_pointer
-  local.get $100
+  local.get $64
   i32.store offset=20
-  local.get $100
+  local.get $64
   call $std/typedarray/isInt8ArrayEqual
   i32.eqz
   if
@@ -89211,80 +89122,80 @@
   i32.const 0
   i32.const 5
   call $~lib/typedarray/Int32Array#constructor
-  local.tee $19
+  local.tee $12
   i32.store offset=28
-  local.get $19
-  local.set $100
+  local.get $12
+  local.set $64
   global.get $~lib/memory/__stack_pointer
-  local.get $100
+  local.get $64
   i32.store offset=4
-  local.get $100
+  local.get $64
   i32.const 0
   i32.const 1
   call $~lib/typedarray/Int32Array#__set
-  local.get $19
-  local.set $100
+  local.get $12
+  local.set $64
   global.get $~lib/memory/__stack_pointer
-  local.get $100
+  local.get $64
   i32.store offset=4
-  local.get $100
+  local.get $64
   i32.const 1
   i32.const 2
   call $~lib/typedarray/Int32Array#__set
-  local.get $19
-  local.set $100
+  local.get $12
+  local.set $64
   global.get $~lib/memory/__stack_pointer
-  local.get $100
+  local.get $64
   i32.store offset=4
-  local.get $100
+  local.get $64
   i32.const 2
   i32.const 3
   call $~lib/typedarray/Int32Array#__set
-  local.get $19
-  local.set $100
+  local.get $12
+  local.set $64
   global.get $~lib/memory/__stack_pointer
-  local.get $100
+  local.get $64
   i32.store offset=4
-  local.get $100
+  local.get $64
   i32.const 3
   i32.const 4
   call $~lib/typedarray/Int32Array#__set
-  local.get $19
-  local.set $100
+  local.get $12
+  local.set $64
   global.get $~lib/memory/__stack_pointer
-  local.get $100
+  local.get $64
   i32.store offset=4
-  local.get $100
+  local.get $64
   i32.const 4
   i32.const 5
   call $~lib/typedarray/Int32Array#__set
-  local.get $19
-  local.set $100
+  local.get $12
+  local.set $64
   global.get $~lib/memory/__stack_pointer
-  local.get $100
+  local.get $64
   i32.store offset=4
-  local.get $100
+  local.get $64
   i32.const 1
   i32.const 1
   i32.const 3
   call $~lib/typedarray/Int32Array#fill
   drop
-  local.get $19
-  local.set $100
+  local.get $12
+  local.set $64
   global.get $~lib/memory/__stack_pointer
-  local.get $100
+  local.get $64
   i32.store offset=4
-  local.get $100
+  local.get $64
   i32.const 5
   i32.const 2
   i32.const 17
   i32.const 976
   call $~lib/rt/__newArray
-  local.set $100
+  local.set $64
   global.get $~lib/memory/__stack_pointer
-  local.get $100
+  local.get $64
   i32.store offset=20
-  local.get $100
+  local.get $64
   call $std/typedarray/isInt32ArrayEqual
   i32.eqz
   if
@@ -89295,12 +89206,12 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $19
-  local.set $100
+  local.get $12
+  local.set $64
   global.get $~lib/memory/__stack_pointer
-  local.get $100
+  local.get $64
   i32.store offset=4
-  local.get $100
+  local.get $64
   i32.const 0
   i32.const 0
   i32.const 1
@@ -89308,22 +89219,22 @@
   i32.const 0
   call $~lib/typedarray/Int32Array#fill@varargs
   drop
-  local.get $19
-  local.set $100
+  local.get $12
+  local.set $64
   global.get $~lib/memory/__stack_pointer
-  local.get $100
+  local.get $64
   i32.store offset=4
-  local.get $100
+  local.get $64
   i32.const 5
   i32.const 2
   i32.const 17
   i32.const 1024
   call $~lib/rt/__newArray
-  local.set $100
+  local.set $64
   global.get $~lib/memory/__stack_pointer
-  local.get $100
+  local.get $64
   i32.store offset=20
-  local.get $100
+  local.get $64
   call $std/typedarray/isInt32ArrayEqual
   i32.eqz
   if
@@ -89334,33 +89245,33 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $19
-  local.set $100
+  local.get $12
+  local.set $64
   global.get $~lib/memory/__stack_pointer
-  local.get $100
+  local.get $64
   i32.store offset=4
-  local.get $100
+  local.get $64
   i32.const 1
   i32.const 0
   i32.const -3
   call $~lib/typedarray/Int32Array#fill
   drop
-  local.get $19
-  local.set $100
+  local.get $12
+  local.set $64
   global.get $~lib/memory/__stack_pointer
-  local.get $100
+  local.get $64
   i32.store offset=4
-  local.get $100
+  local.get $64
   i32.const 5
   i32.const 2
   i32.const 17
   i32.const 1072
   call $~lib/rt/__newArray
-  local.set $100
+  local.set $64
   global.get $~lib/memory/__stack_pointer
-  local.get $100
+  local.get $64
   i32.store offset=20
-  local.get $100
+  local.get $64
   call $std/typedarray/isInt32ArrayEqual
   i32.eqz
   if
@@ -89371,12 +89282,12 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $19
-  local.set $100
+  local.get $12
+  local.set $64
   global.get $~lib/memory/__stack_pointer
-  local.get $100
+  local.get $64
   i32.store offset=4
-  local.get $100
+  local.get $64
   i32.const 2
   i32.const -2
   i32.const 2
@@ -89384,22 +89295,22 @@
   i32.const 0
   call $~lib/typedarray/Int32Array#fill@varargs
   drop
-  local.get $19
-  local.set $100
+  local.get $12
+  local.set $64
   global.get $~lib/memory/__stack_pointer
-  local.get $100
+  local.get $64
   i32.store offset=4
-  local.get $100
+  local.get $64
   i32.const 5
   i32.const 2
   i32.const 17
   i32.const 1120
   call $~lib/rt/__newArray
-  local.set $100
+  local.set $64
   global.get $~lib/memory/__stack_pointer
-  local.get $100
+  local.get $64
   i32.store offset=20
-  local.get $100
+  local.get $64
   call $std/typedarray/isInt32ArrayEqual
   i32.eqz
   if
@@ -89410,33 +89321,33 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $19
-  local.set $100
+  local.get $12
+  local.set $64
   global.get $~lib/memory/__stack_pointer
-  local.get $100
+  local.get $64
   i32.store offset=4
-  local.get $100
+  local.get $64
   i32.const 0
   i32.const 1
   i32.const 0
   call $~lib/typedarray/Int32Array#fill
   drop
-  local.get $19
-  local.set $100
+  local.get $12
+  local.set $64
   global.get $~lib/memory/__stack_pointer
-  local.get $100
+  local.get $64
   i32.store offset=4
-  local.get $100
+  local.get $64
   i32.const 5
   i32.const 2
   i32.const 17
   i32.const 1168
   call $~lib/rt/__newArray
-  local.set $100
+  local.set $64
   global.get $~lib/memory/__stack_pointer
-  local.get $100
+  local.get $64
   i32.store offset=20
-  local.get $100
+  local.get $64
   call $std/typedarray/isInt32ArrayEqual
   i32.eqz
   if
@@ -89448,23 +89359,23 @@
    unreachable
   end
   global.get $~lib/memory/__stack_pointer
-  local.get $19
-  local.set $100
+  local.get $12
+  local.set $64
   global.get $~lib/memory/__stack_pointer
-  local.get $100
+  local.get $64
   i32.store offset=4
-  local.get $100
+  local.get $64
   i32.const 1
   i32.const 4
   call $~lib/typedarray/Int32Array#subarray
-  local.tee $30
+  local.tee $18
   i32.store offset=32
-  local.get $30
-  local.set $100
+  local.get $18
+  local.set $64
   global.get $~lib/memory/__stack_pointer
-  local.get $100
+  local.get $64
   i32.store offset=4
-  local.get $100
+  local.get $64
   i32.const 0
   i32.const 0
   i32.const 1
@@ -89472,12 +89383,12 @@
   i32.const 0
   call $~lib/typedarray/Int32Array#fill@varargs
   drop
-  local.get $30
-  local.set $100
+  local.get $18
+  local.set $64
   global.get $~lib/memory/__stack_pointer
-  local.get $100
+  local.get $64
   i32.store offset=4
-  local.get $100
+  local.get $64
   call $~lib/typedarray/Int32Array#get:length
   i32.const 3
   i32.eq
@@ -89490,12 +89401,12 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $30
-  local.set $100
+  local.get $18
+  local.set $64
   global.get $~lib/memory/__stack_pointer
-  local.get $100
+  local.get $64
   i32.store offset=4
-  local.get $100
+  local.get $64
   call $~lib/arraybuffer/ArrayBufferView#get:byteOffset
   i32.const 1
   i32.const 4
@@ -89510,12 +89421,12 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $30
-  local.set $100
+  local.get $18
+  local.set $64
   global.get $~lib/memory/__stack_pointer
-  local.get $100
+  local.get $64
   i32.store offset=4
-  local.get $100
+  local.get $64
   call $~lib/arraybuffer/ArrayBufferView#get:byteLength
   i32.const 3
   i32.const 4
@@ -89530,22 +89441,22 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $30
-  local.set $100
+  local.get $18
+  local.set $64
   global.get $~lib/memory/__stack_pointer
-  local.get $100
+  local.get $64
   i32.store offset=4
-  local.get $100
+  local.get $64
   i32.const 3
   i32.const 2
   i32.const 17
   i32.const 1216
   call $~lib/rt/__newArray
-  local.set $100
+  local.set $64
   global.get $~lib/memory/__stack_pointer
-  local.get $100
+  local.get $64
   i32.store offset=20
-  local.get $100
+  local.get $64
   call $std/typedarray/isInt32ArrayEqual
   i32.eqz
   if
@@ -89556,22 +89467,22 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $19
-  local.set $100
+  local.get $12
+  local.set $64
   global.get $~lib/memory/__stack_pointer
-  local.get $100
+  local.get $64
   i32.store offset=4
-  local.get $100
+  local.get $64
   i32.const 5
   i32.const 2
   i32.const 17
   i32.const 1248
   call $~lib/rt/__newArray
-  local.set $100
+  local.set $64
   global.get $~lib/memory/__stack_pointer
-  local.get $100
+  local.get $64
   i32.store offset=20
-  local.get $100
+  local.get $64
   call $std/typedarray/isInt32ArrayEqual
   i32.eqz
   if
@@ -89586,80 +89497,80 @@
   i32.const 0
   i32.const 6
   call $~lib/typedarray/Int8Array#constructor
-  local.tee $35
+  local.tee $21
   i32.store offset=36
-  local.get $35
-  local.set $100
+  local.get $21
+  local.set $64
   global.get $~lib/memory/__stack_pointer
-  local.get $100
+  local.get $64
   i32.store offset=4
-  local.get $100
+  local.get $64
   i32.const 0
   i32.const 1
   call $~lib/typedarray/Int8Array#__set
-  local.get $35
-  local.set $100
+  local.get $21
+  local.set $64
   global.get $~lib/memory/__stack_pointer
-  local.get $100
+  local.get $64
   i32.store offset=4
-  local.get $100
+  local.get $64
   i32.const 1
   i32.const 2
   call $~lib/typedarray/Int8Array#__set
-  local.get $35
-  local.set $100
+  local.get $21
+  local.set $64
   global.get $~lib/memory/__stack_pointer
-  local.get $100
+  local.get $64
   i32.store offset=4
-  local.get $100
+  local.get $64
   i32.const 2
   i32.const 3
   call $~lib/typedarray/Int8Array#__set
-  local.get $35
-  local.set $100
+  local.get $21
+  local.set $64
   global.get $~lib/memory/__stack_pointer
-  local.get $100
+  local.get $64
   i32.store offset=4
-  local.get $100
+  local.get $64
   i32.const 3
   i32.const 4
   call $~lib/typedarray/Int8Array#__set
-  local.get $35
-  local.set $100
+  local.get $21
+  local.set $64
   global.get $~lib/memory/__stack_pointer
-  local.get $100
+  local.get $64
   i32.store offset=4
-  local.get $100
+  local.get $64
   i32.const 4
   i32.const 5
   call $~lib/typedarray/Int8Array#__set
-  local.get $35
-  local.set $100
+  local.get $21
+  local.set $64
   global.get $~lib/memory/__stack_pointer
-  local.get $100
+  local.get $64
   i32.store offset=4
-  local.get $100
+  local.get $64
   i32.const 5
   i32.const 6
   call $~lib/typedarray/Int8Array#__set
   global.get $~lib/memory/__stack_pointer
-  local.get $35
-  local.set $100
+  local.get $21
+  local.set $64
   global.get $~lib/memory/__stack_pointer
-  local.get $100
+  local.get $64
   i32.store offset=4
-  local.get $100
+  local.get $64
   i32.const 1
   i32.const 6
   call $~lib/typedarray/Int8Array#subarray
-  local.tee $36
+  local.tee $22
   i32.store offset=40
-  local.get $36
-  local.set $100
+  local.get $22
+  local.set $64
   global.get $~lib/memory/__stack_pointer
-  local.get $100
+  local.get $64
   i32.store offset=4
-  local.get $100
+  local.get $64
   i32.const 0
   call $~lib/typedarray/Int8Array#__get
   i32.const 2
@@ -89673,12 +89584,12 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $36
-  local.set $100
+  local.get $22
+  local.set $64
   global.get $~lib/memory/__stack_pointer
-  local.get $100
+  local.get $64
   i32.store offset=4
-  local.get $100
+  local.get $64
   call $~lib/typedarray/Int8Array#get:length
   i32.const 5
   i32.eq
@@ -89691,12 +89602,12 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $36
-  local.set $100
+  local.get $22
+  local.set $64
   global.get $~lib/memory/__stack_pointer
-  local.get $100
+  local.get $64
   i32.store offset=4
-  local.get $100
+  local.get $64
   call $~lib/arraybuffer/ArrayBufferView#get:byteOffset
   i32.const 1
   i32.eq
@@ -89709,12 +89620,12 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $36
-  local.set $100
+  local.get $22
+  local.set $64
   global.get $~lib/memory/__stack_pointer
-  local.get $100
+  local.get $64
   i32.store offset=4
-  local.get $100
+  local.get $64
   call $~lib/arraybuffer/ArrayBufferView#get:byteLength
   i32.const 5
   i32.eq
@@ -89728,23 +89639,23 @@
    unreachable
   end
   global.get $~lib/memory/__stack_pointer
-  local.get $36
-  local.set $100
+  local.get $22
+  local.set $64
   global.get $~lib/memory/__stack_pointer
-  local.get $100
+  local.get $64
   i32.store offset=4
-  local.get $100
+  local.get $64
   i32.const 1
   i32.const 5
   call $~lib/typedarray/Int8Array#subarray
-  local.tee $37
+  local.tee $23
   i32.store offset=44
-  local.get $37
-  local.set $100
+  local.get $23
+  local.set $64
   global.get $~lib/memory/__stack_pointer
-  local.get $100
+  local.get $64
   i32.store offset=4
-  local.get $100
+  local.get $64
   i32.const 0
   call $~lib/typedarray/Int8Array#__get
   i32.const 3
@@ -89758,12 +89669,12 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $37
-  local.set $100
+  local.get $23
+  local.set $64
   global.get $~lib/memory/__stack_pointer
-  local.get $100
+  local.get $64
   i32.store offset=4
-  local.get $100
+  local.get $64
   call $~lib/typedarray/Int8Array#get:length
   i32.const 4
   i32.eq
@@ -89776,12 +89687,12 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $37
-  local.set $100
+  local.get $23
+  local.set $64
   global.get $~lib/memory/__stack_pointer
-  local.get $100
+  local.get $64
   i32.store offset=4
-  local.get $100
+  local.get $64
   call $~lib/arraybuffer/ArrayBufferView#get:byteOffset
   i32.const 2
   i32.eq
@@ -89794,12 +89705,12 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $37
-  local.set $100
+  local.get $23
+  local.set $64
   global.get $~lib/memory/__stack_pointer
-  local.get $100
+  local.get $64
   i32.store offset=4
-  local.get $100
+  local.get $64
   call $~lib/arraybuffer/ArrayBufferView#get:byteLength
   i32.const 4
   i32.eq
@@ -89813,23 +89724,23 @@
    unreachable
   end
   global.get $~lib/memory/__stack_pointer
-  local.get $37
-  local.set $100
+  local.get $23
+  local.set $64
   global.get $~lib/memory/__stack_pointer
-  local.get $100
+  local.get $64
   i32.store offset=4
-  local.get $100
+  local.get $64
   i32.const 1
   i32.const 4
   call $~lib/typedarray/Int8Array#subarray
-  local.tee $38
+  local.tee $24
   i32.store offset=48
-  local.get $38
-  local.set $100
+  local.get $24
+  local.set $64
   global.get $~lib/memory/__stack_pointer
-  local.get $100
+  local.get $64
   i32.store offset=4
-  local.get $100
+  local.get $64
   i32.const 0
   call $~lib/typedarray/Int8Array#__get
   i32.const 4
@@ -89843,12 +89754,12 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $38
-  local.set $100
+  local.get $24
+  local.set $64
   global.get $~lib/memory/__stack_pointer
-  local.get $100
+  local.get $64
   i32.store offset=4
-  local.get $100
+  local.get $64
   call $~lib/typedarray/Int8Array#get:length
   i32.const 3
   i32.eq
@@ -89861,12 +89772,12 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $38
-  local.set $100
+  local.get $24
+  local.set $64
   global.get $~lib/memory/__stack_pointer
-  local.get $100
+  local.get $64
   i32.store offset=4
-  local.get $100
+  local.get $64
   call $~lib/arraybuffer/ArrayBufferView#get:byteOffset
   i32.const 3
   i32.eq
@@ -89879,12 +89790,12 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $38
-  local.set $100
+  local.get $24
+  local.set $64
   global.get $~lib/memory/__stack_pointer
-  local.get $100
+  local.get $64
   i32.store offset=4
-  local.get $100
+  local.get $64
   call $~lib/arraybuffer/ArrayBufferView#get:byteLength
   i32.const 3
   i32.eq
@@ -89901,94 +89812,94 @@
   i32.const 0
   i32.const 5
   call $~lib/typedarray/Int32Array#constructor
-  local.tee $39
+  local.tee $25
   i32.store offset=52
-  local.get $39
-  local.set $100
+  local.get $25
+  local.set $64
   global.get $~lib/memory/__stack_pointer
-  local.get $100
+  local.get $64
   i32.store offset=4
-  local.get $100
+  local.get $64
   i32.const 0
   i32.const 1
   call $~lib/typedarray/Int32Array#__set
-  local.get $39
-  local.set $100
+  local.get $25
+  local.set $64
   global.get $~lib/memory/__stack_pointer
-  local.get $100
+  local.get $64
   i32.store offset=4
-  local.get $100
+  local.get $64
   i32.const 1
   i32.const 2
   call $~lib/typedarray/Int32Array#__set
-  local.get $39
-  local.set $100
+  local.get $25
+  local.set $64
   global.get $~lib/memory/__stack_pointer
-  local.get $100
+  local.get $64
   i32.store offset=4
-  local.get $100
+  local.get $64
   i32.const 2
   i32.const 3
   call $~lib/typedarray/Int32Array#__set
-  local.get $39
-  local.set $100
+  local.get $25
+  local.set $64
   global.get $~lib/memory/__stack_pointer
-  local.get $100
+  local.get $64
   i32.store offset=4
-  local.get $100
+  local.get $64
   i32.const 3
   i32.const 4
   call $~lib/typedarray/Int32Array#__set
-  local.get $39
-  local.set $100
+  local.get $25
+  local.set $64
   global.get $~lib/memory/__stack_pointer
-  local.get $100
+  local.get $64
   i32.store offset=4
-  local.get $100
+  local.get $64
   i32.const 4
   i32.const 5
   call $~lib/typedarray/Int32Array#__set
   global.get $~lib/memory/__stack_pointer
-  local.get $39
-  local.set $100
+  local.get $25
+  local.set $64
   global.get $~lib/memory/__stack_pointer
-  local.get $100
+  local.get $64
   i32.store offset=4
-  local.get $100
+  local.get $64
   i32.const 0
   i32.const 1
   global.set $~argumentsLength
   i32.const 0
   call $~lib/typedarray/Int32Array#slice@varargs
-  local.tee $40
+  local.tee $26
   i32.store offset=56
-  local.get $39
-  local.set $100
+  local.get $25
+  local.set $64
   global.get $~lib/memory/__stack_pointer
-  local.get $100
+  local.get $64
   i32.store offset=60
-  local.get $100
+  local.get $64
   i32.const 0
   i32.const 3
   i32.const 2
   global.set $~argumentsLength
   i32.const 0
   call $~lib/typedarray/Int32Array#copyWithin@varargs
-  local.set $100
+  local.set $64
   global.get $~lib/memory/__stack_pointer
-  local.get $100
+  local.get $64
   i32.store offset=4
-  local.get $100
+  local.get $64
   i32.const 5
   i32.const 2
   i32.const 17
   i32.const 1296
   call $~lib/rt/__newArray
-  local.set $100
+  local.set $64
   global.get $~lib/memory/__stack_pointer
-  local.get $100
+  local.get $64
   i32.store offset=20
-  local.get $100
+  local.get $64
   call $std/typedarray/isInt32ArrayEqual
   i32.eqz
   if
@@ -90000,46 +89911,46 @@
    unreachable
   end
   global.get $~lib/memory/__stack_pointer
-  local.get $40
-  local.set $100
+  local.get $26
+  local.set $64
   global.get $~lib/memory/__stack_pointer
-  local.get $100
+  local.get $64
   i32.store offset=4
-  local.get $100
+  local.get $64
   i32.const 0
   i32.const 1
   global.set $~argumentsLength
   i32.const 0
   call $~lib/typedarray/Int32Array#slice@varargs
-  local.tee $39
+  local.tee $25
   i32.store offset=52
-  local.get $39
-  local.set $100
+  local.get $25
+  local.set $64
   global.get $~lib/memory/__stack_pointer
-  local.get $100
+  local.get $64
   i32.store offset=60
-  local.get $100
+  local.get $64
   i32.const 1
   i32.const 3
   i32.const 2
   global.set $~argumentsLength
   i32.const 0
   call $~lib/typedarray/Int32Array#copyWithin@varargs
-  local.set $100
+  local.set $64
   global.get $~lib/memory/__stack_pointer
-  local.get $100
+  local.get $64
   i32.store offset=4
-  local.get $100
+  local.get $64
   i32.const 5
   i32.const 2
   i32.const 17
   i32.const 1344
   call $~lib/rt/__newArray
-  local.set $100
+  local.set $64
   global.get $~lib/memory/__stack_pointer
-  local.get $100
+  local.get $64
   i32.store offset=20
-  local.get $100
+  local.get $64
   call $std/typedarray/isInt32ArrayEqual
   i32.eqz
   if
@@ -90051,46 +89962,46 @@
    unreachable
   end
   global.get $~lib/memory/__stack_pointer
-  local.get $40
-  local.set $100
+  local.get $26
+  local.set $64
   global.get $~lib/memory/__stack_pointer
-  local.get $100
+  local.get $64
   i32.store offset=4
-  local.get $100
+  local.get $64
   i32.const 0
   i32.const 1
   global.set $~argumentsLength
   i32.const 0
   call $~lib/typedarray/Int32Array#slice@varargs
-  local.tee $39
+  local.tee $25
   i32.store offset=52
-  local.get $39
-  local.set $100
+  local.get $25
+  local.set $64
   global.get $~lib/memory/__stack_pointer
-  local.get $100
+  local.get $64
   i32.store offset=60
-  local.get $100
+  local.get $64
   i32.const 1
   i32.const 2
   i32.const 2
   global.set $~argumentsLength
   i32.const 0
   call $~lib/typedarray/Int32Array#copyWithin@varargs
-  local.set $100
+  local.set $64
   global.get $~lib/memory/__stack_pointer
-  local.get $100
+  local.get $64
   i32.store offset=4
-  local.get $100
+  local.get $64
   i32.const 5
   i32.const 2
   i32.const 17
   i32.const 1392
   call $~lib/rt/__newArray
-  local.set $100
+  local.set $64
   global.get $~lib/memory/__stack_pointer
-  local.get $100
+  local.get $64
   i32.store offset=20
-  local.get $100
+  local.get $64
   call $std/typedarray/isInt32ArrayEqual
   i32.eqz
   if
@@ -90102,46 +90013,46 @@
    unreachable
   end
   global.get $~lib/memory/__stack_pointer
-  local.get $40
-  local.set $100
+  local.get $26
+  local.set $64
   global.get $~lib/memory/__stack_pointer
-  local.get $100
+  local.get $64
   i32.store offset=4
-  local.get $100
+  local.get $64
   i32.const 0
   i32.const 1
   global.set $~argumentsLength
   i32.const 0
   call $~lib/typedarray/Int32Array#slice@varargs
-  local.tee $39
+  local.tee $25
   i32.store offset=52
-  local.get $39
-  local.set $100
+  local.get $25
+  local.set $64
   global.get $~lib/memory/__stack_pointer
-  local.get $100
+  local.get $64
   i32.store offset=60
-  local.get $100
+  local.get $64
   i32.const 2
   i32.const 2
   i32.const 2
   global.set $~argumentsLength
   i32.const 0
   call $~lib/typedarray/Int32Array#copyWithin@varargs
-  local.set $100
+  local.set $64
   global.get $~lib/memory/__stack_pointer
-  local.get $100
+  local.get $64
   i32.store offset=4
-  local.get $100
+  local.get $64
   i32.const 5
   i32.const 2
   i32.const 17
   i32.const 1440
   call $~lib/rt/__newArray
-  local.set $100
+  local.set $64
   global.get $~lib/memory/__stack_pointer
-  local.get $100
+  local.get $64
   i32.store offset=20
-  local.get $100
+  local.get $64
   call $std/typedarray/isInt32ArrayEqual
   i32.eqz
   if
@@ -90153,44 +90064,44 @@
    unreachable
   end
   global.get $~lib/memory/__stack_pointer
-  local.get $40
-  local.set $100
+  local.get $26
+  local.set $64
   global.get $~lib/memory/__stack_pointer
-  local.get $100
+  local.get $64
   i32.store offset=4
-  local.get $100
+  local.get $64
   i32.const 0
   i32.const 1
   global.set $~argumentsLength
   i32.const 0
   call $~lib/typedarray/Int32Array#slice@varargs
-  local.tee $39
+  local.tee $25
   i32.store offset=52
-  local.get $39
-  local.set $100
+  local.get $25
+  local.set $64
   global.get $~lib/memory/__stack_pointer
-  local.get $100
+  local.get $64
   i32.store offset=60
-  local.get $100
+  local.get $64
   i32.const 0
   i32.const 3
   i32.const 4
   call $~lib/typedarray/Int32Array#copyWithin
-  local.set $100
+  local.set $64
   global.get $~lib/memory/__stack_pointer
-  local.get $100
+  local.get $64
   i32.store offset=4
-  local.get $100
+  local.get $64
   i32.const 5
   i32.const 2
   i32.const 17
   i32.const 1488
   call $~lib/rt/__newArray
-  local.set $100
+  local.set $64
   global.get $~lib/memory/__stack_pointer
-  local.get $100
+  local.get $64
   i32.store offset=20
-  local.get $100
+  local.get $64
   call $std/typedarray/isInt32ArrayEqual
   i32.eqz
   if
@@ -90202,44 +90113,44 @@
    unreachable
   end
   global.get $~lib/memory/__stack_pointer
-  local.get $40
-  local.set $100
+  local.get $26
+  local.set $64
   global.get $~lib/memory/__stack_pointer
-  local.get $100
+  local.get $64
   i32.store offset=4
-  local.get $100
+  local.get $64
   i32.const 0
   i32.const 1
   global.set $~argumentsLength
   i32.const 0
   call $~lib/typedarray/Int32Array#slice@varargs
-  local.tee $39
+  local.tee $25
   i32.store offset=52
-  local.get $39
-  local.set $100
+  local.get $25
+  local.set $64
   global.get $~lib/memory/__stack_pointer
-  local.get $100
+  local.get $64
   i32.store offset=60
-  local.get $100
+  local.get $64
   i32.const 1
   i32.const 3
   i32.const 4
   call $~lib/typedarray/Int32Array#copyWithin
-  local.set $100
+  local.set $64
   global.get $~lib/memory/__stack_pointer
-  local.get $100
+  local.get $64
   i32.store offset=4
-  local.get $100
+  local.get $64
   i32.const 5
   i32.const 2
   i32.const 17
   i32.const 1536
   call $~lib/rt/__newArray
-  local.set $100
+  local.set $64
   global.get $~lib/memory/__stack_pointer
-  local.get $100
+  local.get $64
   i32.store offset=20
-  local.get $100
+  local.get $64
   call $std/typedarray/isInt32ArrayEqual
   i32.eqz
   if
@@ -90251,44 +90162,44 @@
    unreachable
   end
   global.get $~lib/memory/__stack_pointer
-  local.get $40
-  local.set $100
+  local.get $26
+  local.set $64
   global.get $~lib/memory/__stack_pointer
-  local.get $100
+  local.get $64
   i32.store offset=4
-  local.get $100
+  local.get $64
   i32.const 0
   i32.const 1
   global.set $~argumentsLength
   i32.const 0
   call $~lib/typedarray/Int32Array#slice@varargs
-  local.tee $39
+  local.tee $25
   i32.store offset=52
-  local.get $39
-  local.set $100
+  local.get $25
+  local.set $64
   global.get $~lib/memory/__stack_pointer
-  local.get $100
+  local.get $64
   i32.store offset=60
-  local.get $100
+  local.get $64
   i32.const 1
   i32.const 2
   i32.const 4
   call $~lib/typedarray/Int32Array#copyWithin
-  local.set $100
+  local.set $64
   global.get $~lib/memory/__stack_pointer
-  local.get $100
+  local.get $64
   i32.store offset=4
-  local.get $100
+  local.get $64
   i32.const 5
   i32.const 2
   i32.const 17
   i32.const 1584
   call $~lib/rt/__newArray
-  local.set $100
+  local.set $64
   global.get $~lib/memory/__stack_pointer
-  local.get $100
+  local.get $64
   i32.store offset=20
-  local.get $100
+  local.get $64
   call $std/typedarray/isInt32ArrayEqual
   i32.eqz
   if
@@ -90300,46 +90211,46 @@
    unreachable
   end
   global.get $~lib/memory/__stack_pointer
-  local.get $40
-  local.set $100
+  local.get $26
+  local.set $64
   global.get $~lib/memory/__stack_pointer
-  local.get $100
+  local.get $64
   i32.store offset=4
-  local.get $100
+  local.get $64
   i32.const 0
   i32.const 1
   global.set $~argumentsLength
   i32.const 0
   call $~lib/typedarray/Int32Array#slice@varargs
-  local.tee $39
+  local.tee $25
   i32.store offset=52
-  local.get $39
-  local.set $100
+  local.get $25
+  local.set $64
   global.get $~lib/memory/__stack_pointer
-  local.get $100
+  local.get $64
   i32.store offset=60
-  local.get $100
+  local.get $64
   i32.const 0
   i32.const -2
   i32.const 2
   global.set $~argumentsLength
   i32.const 0
   call $~lib/typedarray/Int32Array#copyWithin@varargs
-  local.set $100
+  local.set $64
   global.get $~lib/memory/__stack_pointer
-  local.get $100
+  local.get $64
   i32.store offset=4
-  local.get $100
+  local.get $64
   i32.const 5
   i32.const 2
   i32.const 17
   i32.const 1632
   call $~lib/rt/__newArray
-  local.set $100
+  local.set $64
   global.get $~lib/memory/__stack_pointer
-  local.get $100
+  local.get $64
   i32.store offset=20
-  local.get $100
+  local.get $64
   call $std/typedarray/isInt32ArrayEqual
   i32.eqz
   if
@@ -90351,44 +90262,44 @@
    unreachable
   end
   global.get $~lib/memory/__stack_pointer
-  local.get $40
-  local.set $100
+  local.get $26
+  local.set $64
   global.get $~lib/memory/__stack_pointer
-  local.get $100
+  local.get $64
   i32.store offset=4
-  local.get $100
+  local.get $64
   i32.const 0
   i32.const 1
   global.set $~argumentsLength
   i32.const 0
   call $~lib/typedarray/Int32Array#slice@varargs
-  local.tee $39
+  local.tee $25
   i32.store offset=52
-  local.get $39
-  local.set $100
+  local.get $25
+  local.set $64
   global.get $~lib/memory/__stack_pointer
-  local.get $100
+  local.get $64
   i32.store offset=60
-  local.get $100
+  local.get $64
   i32.const 0
   i32.const -2
   i32.const -1
   call $~lib/typedarray/Int32Array#copyWithin
-  local.set $100
+  local.set $64
   global.get $~lib/memory/__stack_pointer
-  local.get $100
+  local.get $64
   i32.store offset=4
-  local.get $100
+  local.get $64
   i32.const 5
   i32.const 2
   i32.const 17
   i32.const 1680
   call $~lib/rt/__newArray
-  local.set $100
+  local.set $64
   global.get $~lib/memory/__stack_pointer
-  local.get $100
+  local.get $64
   i32.store offset=20
-  local.get $100
+  local.get $64
   call $std/typedarray/isInt32ArrayEqual
   i32.eqz
   if
@@ -90400,44 +90311,44 @@
    unreachable
   end
   global.get $~lib/memory/__stack_pointer
-  local.get $40
-  local.set $100
+  local.get $26
+  local.set $64
   global.get $~lib/memory/__stack_pointer
-  local.get $100
+  local.get $64
   i32.store offset=4
-  local.get $100
+  local.get $64
   i32.const 0
   i32.const 1
   global.set $~argumentsLength
   i32.const 0
   call $~lib/typedarray/Int32Array#slice@varargs
-  local.tee $39
+  local.tee $25
   i32.store offset=52
-  local.get $39
-  local.set $100
+  local.get $25
+  local.set $64
   global.get $~lib/memory/__stack_pointer
-  local.get $100
+  local.get $64
   i32.store offset=60
-  local.get $100
+  local.get $64
   i32.const -4
   i32.const -3
   i32.const -2
   call $~lib/typedarray/Int32Array#copyWithin
-  local.set $100
+  local.set $64
   global.get $~lib/memory/__stack_pointer
-  local.get $100
+  local.get $64
   i32.store offset=4
-  local.get $100
+  local.get $64
   i32.const 5
   i32.const 2
   i32.const 17
   i32.const 1728
   call $~lib/rt/__newArray
-  local.set $100
+  local.set $64
   global.get $~lib/memory/__stack_pointer
-  local.get $100
+  local.get $64
   i32.store offset=20
-  local.get $100
+  local.get $64
   call $std/typedarray/isInt32ArrayEqual
   i32.eqz
   if
@@ -90449,44 +90360,44 @@
    unreachable
   end
   global.get $~lib/memory/__stack_pointer
-  local.get $40
-  local.set $100
+  local.get $26
+  local.set $64
   global.get $~lib/memory/__stack_pointer
-  local.get $100
+  local.get $64
   i32.store offset=4
-  local.get $100
+  local.get $64
   i32.const 0
   i32.const 1
   global.set $~argumentsLength
   i32.const 0
   call $~lib/typedarray/Int32Array#slice@varargs
-  local.tee $39
+  local.tee $25
   i32.store offset=52
-  local.get $39
-  local.set $100
+  local.get $25
+  local.set $64
   global.get $~lib/memory/__stack_pointer
-  local.get $100
+  local.get $64
   i32.store offset=60
-  local.get $100
+  local.get $64
   i32.const -4
   i32.const -3
   i32.const -1
   call $~lib/typedarray/Int32Array#copyWithin
-  local.set $100
+  local.set $64
   global.get $~lib/memory/__stack_pointer
-  local.get $100
+  local.get $64
   i32.store offset=4
-  local.get $100
+  local.get $64
   i32.const 5
   i32.const 2
   i32.const 17
   i32.const 1776
   call $~lib/rt/__newArray
-  local.set $100
+  local.set $64
   global.get $~lib/memory/__stack_pointer
-  local.get $100
+  local.get $64
   i32.store offset=20
-  local.get $100
+  local.get $64
   call $std/typedarray/isInt32ArrayEqual
   i32.eqz
   if
@@ -90498,46 +90409,46 @@
    unreachable
   end
   global.get $~lib/memory/__stack_pointer
-  local.get $40
-  local.set $100
+  local.get $26
+  local.set $64
   global.get $~lib/memory/__stack_pointer
-  local.get $100
+  local.get $64
   i32.store offset=4
-  local.get $100
+  local.get $64
   i32.const 0
   i32.const 1
   global.set $~argumentsLength
   i32.const 0
   call $~lib/typedarray/Int32Array#slice@varargs
-  local.tee $39
+  local.tee $25
   i32.store offset=52
-  local.get $39
-  local.set $100
+  local.get $25
+  local.set $64
   global.get $~lib/memory/__stack_pointer
-  local.get $100
+  local.get $64
   i32.store offset=60
-  local.get $100
+  local.get $64
   i32.const -4
   i32.const -3
   i32.const 2
   global.set $~argumentsLength
   i32.const 0
   call $~lib/typedarray/Int32Array#copyWithin@varargs
-  local.set $100
+  local.set $64
   global.get $~lib/memory/__stack_pointer
-  local.get $100
+  local.get $64
   i32.store offset=4
-  local.get $100
+  local.get $64
   i32.const 5
   i32.const 2
   i32.const 17
   i32.const 1824
   call $~lib/rt/__newArray
-  local.set $100
+  local.set $64
   global.get $~lib/memory/__stack_pointer
-  local.get $100
+  local.get $64
   i32.store offset=20
-  local.get $100
+  local.get $64
   call $std/typedarray/isInt32ArrayEqual
   i32.eqz
   if
@@ -90552,71 +90463,71 @@
   i32.const 0
   i32.const 5
   call $~lib/typedarray/Int32Array#constructor
-  local.tee $65
+  local.tee $39
   i32.store offset=64
-  local.get $65
-  local.set $100
+  local.get $39
+  local.set $64
   global.get $~lib/memory/__stack_pointer
-  local.get $100
+  local.get $64
   i32.store offset=4
-  local.get $100
+  local.get $64
   i32.const 0
   i32.const 1
   call $~lib/typedarray/Int32Array#__set
-  local.get $65
-  local.set $100
+  local.get $39
+  local.set $64
   global.get $~lib/memory/__stack_pointer
-  local.get $100
+  local.get $64
   i32.store offset=4
-  local.get $100
+  local.get $64
   i32.const 1
   i32.const 2
   call $~lib/typedarray/Int32Array#__set
-  local.get $65
-  local.set $100
+  local.get $39
+  local.set $64
   global.get $~lib/memory/__stack_pointer
-  local.get $100
+  local.get $64
   i32.store offset=4
-  local.get $100
+  local.get $64
   i32.const 2
   i32.const 3
   call $~lib/typedarray/Int32Array#__set
-  local.get $65
-  local.set $100
+  local.get $39
+  local.set $64
   global.get $~lib/memory/__stack_pointer
-  local.get $100
+  local.get $64
   i32.store offset=4
-  local.get $100
+  local.get $64
   i32.const 3
   i32.const 4
   call $~lib/typedarray/Int32Array#__set
-  local.get $65
-  local.set $100
+  local.get $39
+  local.set $64
   global.get $~lib/memory/__stack_pointer
-  local.get $100
+  local.get $64
   i32.store offset=4
-  local.get $100
+  local.get $64
   i32.const 4
   i32.const 5
   call $~lib/typedarray/Int32Array#__set
   global.get $~lib/memory/__stack_pointer
-  local.get $65
-  local.set $100
+  local.get $39
+  local.set $64
   global.get $~lib/memory/__stack_pointer
-  local.get $100
+  local.get $64
   i32.store offset=4
-  local.get $100
+  local.get $64
   i32.const 1
   i32.const 4
   call $~lib/typedarray/Int32Array#subarray
-  local.tee $66
+  local.tee $40
   i32.store offset=68
-  local.get $66
-  local.set $100
+  local.get $40
+  local.set $64
   global.get $~lib/memory/__stack_pointer
-  local.get $100
+  local.get $64
   i32.store offset=4
-  local.get $100
+  local.get $64
   call $~lib/typedarray/Int32Array#get:length
   i32.const 3
   i32.eq
@@ -90629,12 +90540,12 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $66
-  local.set $100
+  local.get $40
+  local.set $64
   global.get $~lib/memory/__stack_pointer
-  local.get $100
+  local.get $64
   i32.store offset=4
-  local.get $100
+  local.get $64
   call $~lib/arraybuffer/ArrayBufferView#get:byteOffset
   i32.const 4
   i32.eq
@@ -90647,12 +90558,12 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $66
-  local.set $100
+  local.get $40
+  local.set $64
   global.get $~lib/memory/__stack_pointer
-  local.get $100
+  local.get $64
   i32.store offset=4
-  local.get $100
+  local.get $64
   call $~lib/arraybuffer/ArrayBufferView#get:byteLength
   i32.const 12
   i32.eq
@@ -90666,23 +90577,23 @@
    unreachable
   end
   global.get $~lib/memory/__stack_pointer
-  local.get $65
-  local.set $100
+  local.get $39
+  local.set $64
   global.get $~lib/memory/__stack_pointer
-  local.get $100
+  local.get $64
   i32.store offset=4
-  local.get $100
+  local.get $64
   i32.const 1
   i32.const 3
   call $~lib/typedarray/Int32Array#slice
-  local.tee $67
+  local.tee $41
   i32.store offset=72
-  local.get $67
-  local.set $100
+  local.get $41
+  local.set $64
   global.get $~lib/memory/__stack_pointer
-  local.get $100
+  local.get $64
   i32.store offset=4
-  local.get $100
+  local.get $64
   i32.const 0
   call $~lib/typedarray/Int32Array#__get
   i32.const 2
@@ -90696,12 +90607,12 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $67
-  local.set $100
+  local.get $41
+  local.set $64
   global.get $~lib/memory/__stack_pointer
-  local.get $100
+  local.get $64
   i32.store offset=4
-  local.get $100
+  local.get $64
   i32.const 1
   call $~lib/typedarray/Int32Array#__get
   i32.const 3
@@ -90715,12 +90626,12 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $67
-  local.set $100
+  local.get $41
+  local.set $64
   global.get $~lib/memory/__stack_pointer
-  local.get $100
+  local.get $64
   i32.store offset=4
-  local.get $100
+  local.get $64
   call $~lib/typedarray/Int32Array#get:length
   i32.const 2
   i32.eq
@@ -90733,12 +90644,12 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $67
-  local.set $100
+  local.get $41
+  local.set $64
   global.get $~lib/memory/__stack_pointer
-  local.get $100
+  local.get $64
   i32.store offset=4
-  local.get $100
+  local.get $64
   call $~lib/arraybuffer/ArrayBufferView#get:byteOffset
   i32.const 0
   i32.eq
@@ -90751,12 +90662,12 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $67
-  local.set $100
+  local.get $41
+  local.set $64
   global.get $~lib/memory/__stack_pointer
-  local.get $100
+  local.get $64
   i32.store offset=4
-  local.get $100
+  local.get $64
   call $~lib/arraybuffer/ArrayBufferView#get:byteLength
   i32.const 8
   i32.eq
@@ -90770,23 +90681,23 @@
    unreachable
   end
   global.get $~lib/memory/__stack_pointer
-  local.get $66
-  local.set $100
+  local.get $40
+  local.set $64
   global.get $~lib/memory/__stack_pointer
-  local.get $100
+  local.get $64
   i32.store offset=4
-  local.get $100
+  local.get $64
   i32.const 1
   i32.const 2
   call $~lib/typedarray/Int32Array#slice
-  local.tee $68
+  local.tee $42
   i32.store offset=76
-  local.get $68
-  local.set $100
+  local.get $42
+  local.set $64
   global.get $~lib/memory/__stack_pointer
-  local.get $100
+  local.get $64
   i32.store offset=4
-  local.get $100
+  local.get $64
   i32.const 0
   call $~lib/typedarray/Int32Array#__get
   i32.const 3
@@ -90800,12 +90711,12 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $68
-  local.set $100
+  local.get $42
+  local.set $64
   global.get $~lib/memory/__stack_pointer
-  local.get $100
+  local.get $64
   i32.store offset=4
-  local.get $100
+  local.get $64
   call $~lib/typedarray/Int32Array#get:length
   i32.const 1
   i32.eq
@@ -90818,12 +90729,12 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $68
-  local.set $100
+  local.get $42
+  local.set $64
   global.get $~lib/memory/__stack_pointer
-  local.get $100
+  local.get $64
   i32.store offset=4
-  local.get $100
+  local.get $64
   call $~lib/arraybuffer/ArrayBufferView#get:byteOffset
   i32.const 0
   i32.eq
@@ -90836,12 +90747,12 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $68
-  local.set $100
+  local.get $42
+  local.set $64
   global.get $~lib/memory/__stack_pointer
-  local.get $100
+  local.get $64
   i32.store offset=4
-  local.get $100
+  local.get $64
   call $~lib/arraybuffer/ArrayBufferView#get:byteLength
   i32.const 4
   i32.eq
@@ -90855,21 +90766,21 @@
    unreachable
   end
   global.get $~lib/memory/__stack_pointer
-  local.get $65
-  local.set $100
+  local.get $39
+  local.set $64
   global.get $~lib/memory/__stack_pointer
-  local.get $100
+  local.get $64
   i32.store offset=4
-  local.get $100
+  local.get $64
   i32.const 0
   i32.const 0
   global.set $~argumentsLength
   i32.const 0
   call $~lib/typedarray/Int32Array#slice@varargs
-  local.tee $69
+  local.tee $43
   i32.store offset=80
-  local.get $69
-  local.get $65
+  local.get $43
+  local.get $39
   i32.ne
   i32.eqz
   if
@@ -90880,19 +90791,19 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $69
-  local.set $100
+  local.get $43
+  local.set $64
   global.get $~lib/memory/__stack_pointer
-  local.get $100
+  local.get $64
   i32.store offset=4
-  local.get $100
+  local.get $64
   call $~lib/typedarray/Int32Array#get:length
-  local.get $65
-  local.set $100
+  local.get $39
+  local.set $64
   global.get $~lib/memory/__stack_pointer
-  local.get $100
+  local.get $64
   i32.store offset=4
-  local.get $100
+  local.get $64
   call $~lib/typedarray/Int32Array#get:length
   i32.eq
   i32.eqz
@@ -90904,19 +90815,19 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $69
-  local.set $100
+  local.get $43
+  local.set $64
   global.get $~lib/memory/__stack_pointer
-  local.get $100
+  local.get $64
   i32.store offset=4
-  local.get $100
+  local.get $64
   call $~lib/arraybuffer/ArrayBufferView#get:byteOffset
-  local.get $65
-  local.set $100
+  local.get $39
+  local.set $64
   global.get $~lib/memory/__stack_pointer
-  local.get $100
+  local.get $64
   i32.store offset=4
-  local.get $100
+  local.get $64
   call $~lib/arraybuffer/ArrayBufferView#get:byteOffset
   i32.eq
   i32.eqz
@@ -90928,19 +90839,19 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $69
-  local.set $100
+  local.get $43
+  local.set $64
   global.get $~lib/memory/__stack_pointer
-  local.get $100
+  local.get $64
   i32.store offset=4
-  local.get $100
+  local.get $64
   call $~lib/arraybuffer/ArrayBufferView#get:byteLength
-  local.get $65
-  local.set $100
+  local.get $39
+  local.set $64
   global.get $~lib/memory/__stack_pointer
-  local.get $100
+  local.get $64
   i32.store offset=4
-  local.get $100
+  local.get $64
   call $~lib/arraybuffer/ArrayBufferView#get:byteLength
   i32.eq
   i32.eqz
@@ -91088,23 +90999,23 @@
   i32.const 0
   i32.const 1
   call $~lib/typedarray/Float64Array#constructor
-  local.tee $76
+  local.tee $47
   i32.store offset=84
-  local.get $76
-  local.set $100
+  local.get $47
+  local.set $64
   global.get $~lib/memory/__stack_pointer
-  local.get $100
+  local.get $64
   i32.store offset=4
-  local.get $100
+  local.get $64
   i32.const 0
   f64.const nan:0x8000000000000
   call $~lib/typedarray/Float64Array#__set
-  local.get $76
-  local.set $100
+  local.get $47
+  local.set $64
   global.get $~lib/memory/__stack_pointer
-  local.get $100
+  local.get $64
   i32.store offset=4
-  local.get $100
+  local.get $64
   f64.const nan:0x8000000000000
   i32.const 0
   call $~lib/typedarray/Float64Array#indexOf
@@ -91119,12 +91030,12 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $76
-  local.set $100
+  local.get $47
+  local.set $64
   global.get $~lib/memory/__stack_pointer
-  local.get $100
+  local.get $64
   i32.store offset=4
-  local.get $100
+  local.get $64
   f64.const nan:0x8000000000000
   i32.const 0
   call $~lib/typedarray/Float64Array#includes
@@ -91145,23 +91056,23 @@
   i32.const 0
   i32.const 1
   call $~lib/typedarray/Float32Array#constructor
-  local.tee $77
+  local.tee $48
   i32.store offset=88
-  local.get $77
-  local.set $100
+  local.get $48
+  local.set $64
   global.get $~lib/memory/__stack_pointer
-  local.get $100
+  local.get $64
   i32.store offset=4
-  local.get $100
+  local.get $64
   i32.const 0
   f32.const nan:0x400000
   call $~lib/typedarray/Float32Array#__set
-  local.get $77
-  local.set $100
+  local.get $48
+  local.set $64
   global.get $~lib/memory/__stack_pointer
-  local.get $100
+  local.get $64
   i32.store offset=4
-  local.get $100
+  local.get $64
   f32.const nan:0x400000
   i32.const 0
   call $~lib/typedarray/Float32Array#indexOf
@@ -91176,12 +91087,12 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $77
-  local.set $100
+  local.get $48
+  local.set $64
   global.get $~lib/memory/__stack_pointer
-  local.get $100
+  local.get $64
   i32.store offset=4
-  local.get $100
+  local.get $64
   f32.const nan:0x400000
   i32.const 0
   call $~lib/typedarray/Float32Array#includes
@@ -91213,28 +91124,28 @@
   i32.const 0
   i32.const 0
   call $~lib/arraybuffer/ArrayBuffer#constructor
-  local.tee $80
+  local.tee $50
   i32.store offset=92
   global.get $~lib/memory/__stack_pointer
-  local.get $80
-  local.set $100
+  local.get $50
+  local.set $64
   global.get $~lib/memory/__stack_pointer
-  local.get $100
+  local.get $64
   i32.store offset=4
-  local.get $100
+  local.get $64
   i32.const 0
   i32.const 2
   global.set $~argumentsLength
   i32.const 0
   call $~lib/typedarray/Uint8Array.wrap@varargs
-  local.tee $81
+  local.tee $51
   i32.store offset=96
-  local.get $81
-  local.set $100
+  local.get $51
+  local.set $64
   global.get $~lib/memory/__stack_pointer
-  local.get $100
+  local.get $64
   i32.store offset=4
-  local.get $100
+  local.get $64
   call $~lib/typedarray/Uint8Array#get:length
   i32.const 0
   i32.eq
@@ -91251,28 +91162,28 @@
   i32.const 0
   i32.const 2
   call $~lib/arraybuffer/ArrayBuffer#constructor
-  local.tee $80
+  local.tee $50
   i32.store offset=92
   global.get $~lib/memory/__stack_pointer
-  local.get $80
-  local.set $100
+  local.get $50
+  local.set $64
   global.get $~lib/memory/__stack_pointer
-  local.get $100
+  local.get $64
   i32.store offset=4
-  local.get $100
+  local.get $64
   i32.const 2
   i32.const 2
   global.set $~argumentsLength
   i32.const 0
   call $~lib/typedarray/Uint8Array.wrap@varargs
-  local.tee $81
+  local.tee $51
   i32.store offset=96
-  local.get $81
-  local.set $100
+  local.get $51
+  local.set $64
   global.get $~lib/memory/__stack_pointer
-  local.get $100
+  local.get $64
   i32.store offset=4
-  local.get $100
+  local.get $64
   call $~lib/typedarray/Uint8Array#get:length
   i32.const 0
   i32.eq
@@ -91311,38 +91222,38 @@
   i32.const 0
   i32.const 10
   call $~lib/typedarray/Uint8ClampedArray#constructor
-  local.tee $90
+  local.tee $56
   i32.store offset=100
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   i32.const 3
   call $~lib/typedarray/Float32Array#constructor
-  local.tee $91
+  local.tee $57
   i32.store offset=104
-  local.get $91
-  local.set $100
+  local.get $57
+  local.set $64
   global.get $~lib/memory/__stack_pointer
-  local.get $100
+  local.get $64
   i32.store offset=4
-  local.get $100
+  local.get $64
   i32.const 0
   f32.const 400
   call $~lib/typedarray/Float32Array#__set
-  local.get $91
-  local.set $100
+  local.get $57
+  local.set $64
   global.get $~lib/memory/__stack_pointer
-  local.get $100
+  local.get $64
   i32.store offset=4
-  local.get $100
+  local.get $64
   i32.const 1
   f32.const nan:0x400000
   call $~lib/typedarray/Float32Array#__set
-  local.get $91
-  local.set $100
+  local.get $57
+  local.set $64
   global.get $~lib/memory/__stack_pointer
-  local.get $100
+  local.get $64
   i32.store offset=4
-  local.get $100
+  local.get $64
   i32.const 2
   f32.const inf
   call $~lib/typedarray/Float32Array#__set
@@ -91350,41 +91261,41 @@
   i32.const 0
   i32.const 4
   call $~lib/typedarray/Int64Array#constructor
-  local.tee $92
+  local.tee $58
   i32.store offset=108
-  local.get $92
-  local.set $100
+  local.get $58
+  local.set $64
   global.get $~lib/memory/__stack_pointer
-  local.get $100
+  local.get $64
   i32.store offset=4
-  local.get $100
+  local.get $64
   i32.const 0
   i64.const -10
   call $~lib/typedarray/Int64Array#__set
-  local.get $92
-  local.set $100
+  local.get $58
+  local.set $64
   global.get $~lib/memory/__stack_pointer
-  local.get $100
+  local.get $64
   i32.store offset=4
-  local.get $100
+  local.get $64
   i32.const 1
   i64.const 100
   call $~lib/typedarray/Int64Array#__set
-  local.get $92
-  local.set $100
+  local.get $58
+  local.set $64
   global.get $~lib/memory/__stack_pointer
-  local.get $100
+  local.get $64
   i32.store offset=4
-  local.get $100
+  local.get $64
   i32.const 2
   i64.const 10
   call $~lib/typedarray/Int64Array#__set
-  local.get $92
-  local.set $100
+  local.get $58
+  local.set $64
   global.get $~lib/memory/__stack_pointer
-  local.get $100
+  local.get $64
   i32.store offset=4
-  local.get $100
+  local.get $64
   i32.const 3
   i64.const 300
   call $~lib/typedarray/Int64Array#__set
@@ -91392,124 +91303,124 @@
   i32.const 0
   i32.const 2
   call $~lib/typedarray/Int32Array#constructor
-  local.tee $93
+  local.tee $59
   i32.store offset=112
-  local.get $93
-  local.set $100
+  local.get $59
+  local.set $64
   global.get $~lib/memory/__stack_pointer
-  local.get $100
+  local.get $64
   i32.store offset=4
-  local.get $100
+  local.get $64
   i32.const 0
   i32.const 300
   call $~lib/typedarray/Int32Array#__set
-  local.get $93
-  local.set $100
+  local.get $59
+  local.set $64
   global.get $~lib/memory/__stack_pointer
-  local.get $100
+  local.get $64
   i32.store offset=4
-  local.get $100
+  local.get $64
   i32.const 1
   i32.const -1
   call $~lib/typedarray/Int32Array#__set
-  local.get $90
-  local.set $100
+  local.get $56
+  local.set $64
   global.get $~lib/memory/__stack_pointer
-  local.get $100
+  local.get $64
   i32.store offset=4
-  local.get $100
-  local.get $91
-  local.set $100
+  local.get $64
+  local.get $57
+  local.set $64
   global.get $~lib/memory/__stack_pointer
-  local.get $100
+  local.get $64
   i32.store offset=20
-  local.get $100
+  local.get $64
   i32.const 1
   call $~lib/typedarray/Uint8ClampedArray#set<~lib/typedarray/Float32Array>
-  local.get $90
-  local.set $100
+  local.get $56
+  local.set $64
   global.get $~lib/memory/__stack_pointer
-  local.get $100
+  local.get $64
   i32.store offset=4
-  local.get $100
-  local.get $92
-  local.set $100
+  local.get $64
+  local.get $58
+  local.set $64
   global.get $~lib/memory/__stack_pointer
-  local.get $100
+  local.get $64
   i32.store offset=20
-  local.get $100
+  local.get $64
   i32.const 4
   call $~lib/typedarray/Uint8ClampedArray#set<~lib/typedarray/Int64Array>
-  local.get $90
-  local.set $100
+  local.get $56
+  local.set $64
   global.get $~lib/memory/__stack_pointer
-  local.get $100
+  local.get $64
   i32.store offset=4
-  local.get $100
-  local.get $93
-  local.set $100
+  local.get $64
+  local.get $59
+  local.set $64
   global.get $~lib/memory/__stack_pointer
-  local.get $100
+  local.get $64
   i32.store offset=20
-  local.get $100
+  local.get $64
   i32.const 8
   call $~lib/typedarray/Uint8ClampedArray#set<~lib/typedarray/Int32Array>
-  local.get $90
-  local.set $100
+  local.get $56
+  local.set $64
   global.get $~lib/memory/__stack_pointer
-  local.get $100
+  local.get $64
   i32.store offset=4
-  local.get $100
+  local.get $64
   i32.const 10
   i32.const 0
   i32.const 64
   i32.const 14256
   call $~lib/rt/__newArray
-  local.set $100
+  local.set $64
   global.get $~lib/memory/__stack_pointer
-  local.get $100
+  local.get $64
   i32.store offset=20
-  local.get $100
+  local.get $64
   call $std/typedarray/valuesEqual<~lib/typedarray/Uint8ClampedArray>
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   i32.const 4
   call $~lib/typedarray/Uint32Array#constructor
-  local.tee $96
+  local.tee $61
   i32.store offset=116
-  local.get $96
-  local.set $100
+  local.get $61
+  local.set $64
   global.get $~lib/memory/__stack_pointer
-  local.get $100
+  local.get $64
   i32.store offset=4
-  local.get $100
+  local.get $64
   i32.const 0
   i32.const 1
   call $~lib/typedarray/Uint32Array#__set
-  local.get $96
-  local.set $100
+  local.get $61
+  local.set $64
   global.get $~lib/memory/__stack_pointer
-  local.get $100
+  local.get $64
   i32.store offset=4
-  local.get $100
+  local.get $64
   i32.const 1
   i32.const 300
   call $~lib/typedarray/Uint32Array#__set
-  local.get $96
-  local.set $100
+  local.get $61
+  local.set $64
   global.get $~lib/memory/__stack_pointer
-  local.get $100
+  local.get $64
   i32.store offset=4
-  local.get $100
+  local.get $64
   i32.const 2
   i32.const 100
   call $~lib/typedarray/Uint32Array#__set
-  local.get $96
-  local.set $100
+  local.get $61
+  local.set $64
   global.get $~lib/memory/__stack_pointer
-  local.get $100
+  local.get $64
   i32.store offset=4
-  local.get $100
+  local.get $64
   i32.const 3
   i32.const -1
   call $~lib/typedarray/Uint32Array#__set
@@ -91517,88 +91428,88 @@
   i32.const 0
   i32.const 4
   call $~lib/typedarray/Int16Array#constructor
-  local.tee $97
+  local.tee $62
   i32.store offset=120
-  local.get $97
-  local.set $100
+  local.get $62
+  local.set $64
   global.get $~lib/memory/__stack_pointer
-  local.get $100
+  local.get $64
   i32.store offset=4
-  local.get $100
+  local.get $64
   i32.const 0
   i32.const -10
   call $~lib/typedarray/Int16Array#__set
-  local.get $97
-  local.set $100
+  local.get $62
+  local.set $64
   global.get $~lib/memory/__stack_pointer
-  local.get $100
+  local.get $64
   i32.store offset=4
-  local.get $100
+  local.get $64
   i32.const 1
   i32.const 100
   call $~lib/typedarray/Int16Array#__set
-  local.get $97
-  local.set $100
+  local.get $62
+  local.set $64
   global.get $~lib/memory/__stack_pointer
-  local.get $100
+  local.get $64
   i32.store offset=4
-  local.get $100
+  local.get $64
   i32.const 2
   i32.const 10
   call $~lib/typedarray/Int16Array#__set
-  local.get $97
-  local.set $100
+  local.get $62
+  local.set $64
   global.get $~lib/memory/__stack_pointer
-  local.get $100
+  local.get $64
   i32.store offset=4
-  local.get $100
+  local.get $64
   i32.const 3
   i32.const 300
   call $~lib/typedarray/Int16Array#__set
-  local.get $90
-  local.set $100
+  local.get $56
+  local.set $64
   global.get $~lib/memory/__stack_pointer
-  local.get $100
+  local.get $64
   i32.store offset=4
-  local.get $100
-  local.get $96
-  local.set $100
+  local.get $64
+  local.get $61
+  local.set $64
   global.get $~lib/memory/__stack_pointer
-  local.get $100
+  local.get $64
   i32.store offset=20
-  local.get $100
+  local.get $64
   i32.const 0
   call $~lib/typedarray/Uint8ClampedArray#set<~lib/typedarray/Uint32Array>
-  local.get $90
-  local.set $100
+  local.get $56
+  local.set $64
   global.get $~lib/memory/__stack_pointer
-  local.get $100
+  local.get $64
   i32.store offset=4
-  local.get $100
-  local.get $97
-  local.set $100
+  local.get $64
+  local.get $62
+  local.set $64
   global.get $~lib/memory/__stack_pointer
-  local.get $100
+  local.get $64
   i32.store offset=20
-  local.get $100
+  local.get $64
   i32.const 5
   call $~lib/typedarray/Uint8ClampedArray#set<~lib/typedarray/Int16Array>
-  local.get $90
-  local.set $100
+  local.get $56
+  local.set $64
   global.get $~lib/memory/__stack_pointer
-  local.get $100
+  local.get $64
   i32.store offset=4
-  local.get $100
+  local.get $64
   i32.const 10
   i32.const 0
   i32.const 64
   i32.const 14288
   call $~lib/rt/__newArray
-  local.set $100
+  local.set $64
   global.get $~lib/memory/__stack_pointer
-  local.get $100
+  local.get $64
   i32.store offset=20
-  local.get $100
+  local.get $64
   call $std/typedarray/valuesEqual<~lib/typedarray/Uint8ClampedArray>
   call $"std/typedarray/testArraySort<~lib/typedarray/Int8Array,i8>"
   call $"std/typedarray/testArraySort<~lib/typedarray/Uint8Array,u8>"


### PR DESCRIPTION
`tempDataStart` is never used later.