### PR TITLE
fix: use Object.setPrototypeOf in JS bindings

### DIFF
--- a/tests/compiler/bindings/esm.debug.js
+++ b/tests/compiler/bindings/esm.debug.js
@@ -1,6 +1,6 @@
 async function instantiate(module, imports = {}) {
   const adaptedImports = {
-    env: Object.assign(Object.create(globalThis), imports.env || {}, {
+    env: Object.setPrototypeOf({
       trace(message, n, a0, a1, a2, a3, a4) {
         // ~lib/builtins/trace(~lib/string/String, i32?, f64?, f64?, f64?, f64?, f64?) => void
         message = __liftString(message >>> 0);
@@ -44,7 +44,7 @@ async function instantiate(module, imports = {}) {
           throw Error(`${message} in ${fileName}:${lineNumber}:${columnNumber}`);
         })();
       },
-    }),
+    }, Object.assign(Object.create(globalThis), imports.env || {})),
   };
   const { exports } = await WebAssembly.instantiate(module, adaptedImports);
   const memory = exports.memory || imports.env.memory;

--- a/tests/compiler/bindings/esm.release.js
+++ b/tests/compiler/bindings/esm.release.js
@@ -1,6 +1,6 @@
 async function instantiate(module, imports = {}) {
   const adaptedImports = {
-    env: Object.assign(Object.create(globalThis), imports.env || {}, {
+    env: Object.setPrototypeOf({
       trace(message, n, a0, a1, a2, a3, a4) {
         // ~lib/builtins/trace(~lib/string/String, i32?, f64?, f64?, f64?, f64?, f64?) => void
         message = __liftString(message >>> 0);
@@ -44,7 +44,7 @@ async function instantiate(module, imports = {}) {
           throw Error(`${message} in ${fileName}:${lineNumber}:${columnNumber}`);
         })();
       },
-    }),
+    }, Object.assign(Object.create(globalThis), imports.env || {})),
   };
   const { exports } = await WebAssembly.instantiate(module, adaptedImports);
   const memory = exports.memory || imports.env.memory;

--- a/tests/compiler/bindings/noExportRuntime.debug.js
+++ b/tests/compiler/bindings/noExportRuntime.debug.js
@@ -1,6 +1,6 @@
 async function instantiate(module, imports = {}) {
   const adaptedImports = {
-    env: Object.assign(Object.create(globalThis), imports.env || {}, {
+    env: Object.setPrototypeOf({
       abort(message, fileName, lineNumber, columnNumber) {
         // ~lib/builtins/abort(~lib/string/String | null?, ~lib/string/String | null?, u32?, u32?) => void
         message = __liftString(message >>> 0);
@@ -12,7 +12,7 @@ async function instantiate(module, imports = {}) {
           throw Error(`${message} in ${fileName}:${lineNumber}:${columnNumber}`);
         })();
       },
-    }),
+    }, Object.assign(Object.create(globalThis), imports.env || {})),
   };
   const { exports } = await WebAssembly.instantiate(module, adaptedImports);
   const memory = exports.memory || imports.env.memory;

--- a/tests/compiler/bindings/noExportRuntime.release.js
+++ b/tests/compiler/bindings/noExportRuntime.release.js
@@ -1,6 +1,6 @@
 async function instantiate(module, imports = {}) {
   const adaptedImports = {
-    env: Object.assign(Object.create(globalThis), imports.env || {}, {
+    env: Object.setPrototypeOf({
       abort(message, fileName, lineNumber, columnNumber) {
         // ~lib/builtins/abort(~lib/string/String | null?, ~lib/string/String | null?, u32?, u32?) => void
         message = __liftString(message >>> 0);
@@ -12,7 +12,7 @@ async function instantiate(module, imports = {}) {
           throw Error(`${message} in ${fileName}:${lineNumber}:${columnNumber}`);
         })();
       },
-    }),
+    }, Object.assign(Object.create(globalThis), imports.env || {})),
   };
   const { exports } = await WebAssembly.instantiate(module, adaptedImports);
   const memory = exports.memory || imports.env.memory;

--- a/tests/compiler/bindings/raw.debug.js
+++ b/tests/compiler/bindings/raw.debug.js
@@ -1,6 +1,6 @@
 export async function instantiate(module, imports = {}) {
   const adaptedImports = {
-    env: Object.assign(Object.create(globalThis), imports.env || {}, {
+    env: Object.setPrototypeOf({
       trace(message, n, a0, a1, a2, a3, a4) {
         // ~lib/builtins/trace(~lib/string/String, i32?, f64?, f64?, f64?, f64?, f64?) => void
         message = __liftString(message >>> 0);
@@ -44,7 +44,7 @@ export async function instantiate(module, imports = {}) {
           throw Error(`${message} in ${fileName}:${lineNumber}:${columnNumber}`);
         })();
       },
-    }),
+    }, Object.assign(Object.create(globalThis), imports.env || {})),
   };
   const { exports } = await WebAssembly.instantiate(module, adaptedImports);
   const memory = exports.memory || imports.env.memory;

--- a/tests/compiler/bindings/raw.release.js
+++ b/tests/compiler/bindings/raw.release.js
@@ -1,6 +1,6 @@
 export async function instantiate(module, imports = {}) {
   const adaptedImports = {
-    env: Object.assign(Object.create(globalThis), imports.env || {}, {
+    env: Object.setPrototypeOf({
       trace(message, n, a0, a1, a2, a3, a4) {
         // ~lib/builtins/trace(~lib/string/String, i32?, f64?, f64?, f64?, f64?, f64?) => void
         message = __liftString(message >>> 0);
@@ -44,7 +44,7 @@ export async function instantiate(module, imports = {}) {
           throw Error(`${message} in ${fileName}:${lineNumber}:${columnNumber}`);
         })();
       },
-    }),
+    }, Object.assign(Object.create(globalThis), imports.env || {})),
   };
   const { exports } = await WebAssembly.instantiate(module, adaptedImports);
   const memory = exports.memory || imports.env.memory;


### PR DESCRIPTION
<!--
 Thanks for submitting a pull request to AssemblyScript! Please take a moment to
 review the contributing guidelines linked below, and confirm with an [x] 🙂
-->
Fixes #2659.

Changes proposed in this pull request:
⯈ Use `Object.setPrototypeOf({ /* instrumented imports */ }, __moduleN)` instead of `Object.assign(Object.create(__moduleN), { /* instrumented imports */ })`

- [x] I've read the contributing guidelines
- [x] I've added my name and email to the NOTICE file
