### PR TITLE
breaking: bump supported Node.js version to v20+

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -13,7 +13,7 @@ jobs:
         uses: actions/github-script@v7
         with:
           script: |
-            const titlePrefixes = ["feat", "fix", "break", "chore"];
+            const titlePrefixes = ["feat", "fix", "breaking", "chore"];
             const title = context.payload.pull_request.title.toLowerCase();
             const titleHasValidPrefix = titlePrefixes.some((prefix) => title.startsWith(`${prefix}:`));
             if (!titleHasValidPrefix) { process.exit(-1); }

--- a/package-lock.json
+++ b/package-lock.json
@@ -28,7 +28,7 @@
         "typescript": "^5.7.3"
       },
       "engines": {
-        "node": ">=18",
+        "node": ">=20",
         "npm": ">=10"
       },
       "funding": {

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "url": "https://github.com/AssemblyScript/assemblyscript/issues"
   },
   "engines": {
-    "node": ">=18",
+    "node": ">=20",
     "npm": ">=10"
   },
   "engineStrict": true,


### PR DESCRIPTION
This is necessary for #2920 due to AssemblyScript/as-float#1. Also, Node v18 is end-of-life.
This PR should be merged along with #2920 so both are present in the same release window.

- [x] I've read the contributing guidelines
- [x] I've added my name and email to the NOTICE file
