### PR TITLE
fix: remove non-zero check before __visit

### DIFF
--- a/src/builtins.ts
+++ b/src/builtins.ts
@@ -10808,7 +10808,7 @@ function ensureVisitMembersOf(compiler: Compiler, instance: Class): void {
         assert(fieldOffset >= 0);
         needsTempValue = true;
         body.push(
-          // __visit(load<uszie>($0), $1)
+          // __visit(load<usize>($this, fieldOffset), $cookie)
           module.call(visitInstance.internalName, [
             module.load(sizeTypeSize, false,
               module.local_get(0, sizeTypeRef),

--- a/src/builtins.ts
+++ b/src/builtins.ts
@@ -10808,20 +10808,14 @@ function ensureVisitMembersOf(compiler: Compiler, instance: Class): void {
         assert(fieldOffset >= 0);
         needsTempValue = true;
         body.push(
-          // if ($2 = value) __visit($2, $1)
-          module.if(
-            module.local_tee(2,
-              module.load(sizeTypeSize, false,
-                module.local_get(0, sizeTypeRef),
-                sizeTypeRef, fieldOffset
-              ),
-              false // internal
-            ),
-            module.call(visitInstance.internalName, [
-              module.local_get(2, sizeTypeRef), // value
-              module.local_get(1, TypeRef.I32)  // cookie
-            ], TypeRef.None)
-          )
+          // __visit(load<uszie>($0), $1)
+          module.call(visitInstance.internalName, [
+            module.load(sizeTypeSize, false,
+              module.local_get(0, sizeTypeRef),
+              sizeTypeRef, fieldOffset
+            ), // value
+            module.local_get(1, TypeRef.I32)  // cookie
+          ], TypeRef.None)
         );
       }
     }

--- a/tests/compiler/assignment-chain.debug.wat
+++ b/tests/compiler/assignment-chain.debug.wat
@@ -2349,12 +2349,8 @@
   call $~lib/object/Object~visit
   local.get $0
   i32.load
-  local.tee $2
-  if
-   local.get $2
-   local.get $1
-   call $~lib/rt/itcms/__visit
-  end
+  local.get $1
+  call $~lib/rt/itcms/__visit
  )
  (func $~lib/object/Object~visit (param $0 i32) (param $1 i32)
  )

--- a/tests/compiler/assignment-chain.release.wat
+++ b/tests/compiler/assignment-chain.release.wat
@@ -1570,11 +1570,7 @@
      end
      local.get $0
      i32.load
-     local.tee $0
-     if
-      local.get $0
-      call $~lib/rt/itcms/__visit
-     end
+     call $~lib/rt/itcms/__visit
      return
     end
     return

--- a/tests/compiler/bindings/esm.debug.wat
+++ b/tests/compiler/bindings/esm.debug.wat
@@ -2874,12 +2874,8 @@
   call $~lib/object/Object~visit
   local.get $0
   i32.load
-  local.tee $2
-  if
-   local.get $2
-   local.get $1
-   call $~lib/rt/itcms/__visit
-  end
+  local.get $1
+  call $~lib/rt/itcms/__visit
  )
  (func $~lib/object/Object~visit (param $0 i32) (param $1 i32)
  )
@@ -2941,28 +2937,16 @@
   call $~lib/object/Object~visit
   local.get $0
   i32.load offset=56
-  local.tee $2
-  if
-   local.get $2
-   local.get $1
-   call $~lib/rt/itcms/__visit
-  end
+  local.get $1
+  call $~lib/rt/itcms/__visit
   local.get $0
   i32.load offset=60
-  local.tee $2
-  if
-   local.get $2
-   local.get $1
-   call $~lib/rt/itcms/__visit
-  end
+  local.get $1
+  call $~lib/rt/itcms/__visit
   local.get $0
   i32.load offset=64
-  local.tee $2
-  if
-   local.get $2
-   local.get $1
-   call $~lib/rt/itcms/__visit
-  end
+  local.get $1
+  call $~lib/rt/itcms/__visit
  )
  (func $~lib/typedarray/Uint8Array~visit (param $0 i32) (param $1 i32)
   local.get $0

--- a/tests/compiler/bindings/esm.release.wat
+++ b/tests/compiler/bindings/esm.release.wat
@@ -2006,25 +2006,13 @@
        end
        local.get $0
        i32.load offset=56
-       local.tee $1
-       if
-        local.get $1
-        call $~lib/rt/itcms/__visit
-       end
+       call $~lib/rt/itcms/__visit
        local.get $0
        i32.load offset=60
-       local.tee $1
-       if
-        local.get $1
-        call $~lib/rt/itcms/__visit
-       end
+       call $~lib/rt/itcms/__visit
        local.get $0
        i32.load offset=64
-       local.tee $0
-       if
-        local.get $0
-        call $~lib/rt/itcms/__visit
-       end
+       call $~lib/rt/itcms/__visit
        return
       end
       return
@@ -2040,11 +2028,7 @@
    end
    local.get $0
    i32.load
-   local.tee $0
-   if
-    local.get $0
-    call $~lib/rt/itcms/__visit
-   end
+   call $~lib/rt/itcms/__visit
    return
   end
   global.get $~lib/memory/__stack_pointer
@@ -2208,7 +2192,7 @@
    global.get $~lib/memory/__stack_pointer
    local.get $1
    i32.store
-   block $__inlined_func$~lib/string/String#concat$280
+   block $__inlined_func$~lib/string/String#concat$285
     local.get $1
     i32.const 20
     i32.sub
@@ -2227,7 +2211,7 @@
      global.set $~lib/memory/__stack_pointer
      i32.const 1760
      local.set $2
-     br $__inlined_func$~lib/string/String#concat$280
+     br $__inlined_func$~lib/string/String#concat$285
     end
     global.get $~lib/memory/__stack_pointer
     local.get $2
@@ -2414,7 +2398,7 @@
    global.get $~lib/memory/__stack_pointer
    local.get $1
    i32.store
-   block $__inlined_func$~lib/typedarray/Uint64Array#constructor$1 (result i32)
+   block $__inlined_func$~lib/typedarray/Uint64Array#constructor (result i32)
     local.get $1
     call $~lib/typedarray/Float32Array#get:length
     local.get $5
@@ -2544,7 +2528,7 @@
      i32.add
      global.set $~lib/memory/__stack_pointer
      local.get $2
-     br $__inlined_func$~lib/typedarray/Uint64Array#constructor$1
+     br $__inlined_func$~lib/typedarray/Uint64Array#constructor
     end
     br $folding-inner1
    end
@@ -2941,7 +2925,7 @@
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store
-   block $__inlined_func$~lib/rt/itcms/__renew$265
+   block $__inlined_func$~lib/rt/itcms/__renew$270
     i32.const 1073741820
     local.get $2
     i32.const 1
@@ -2984,7 +2968,7 @@
      i32.store offset=16
      local.get $2
      local.set $1
-     br $__inlined_func$~lib/rt/itcms/__renew$265
+     br $__inlined_func$~lib/rt/itcms/__renew$270
     end
     local.get $3
     local.get $4
@@ -3493,7 +3477,7 @@
    global.get $~lib/memory/__stack_pointer
    local.get $1
    i32.store offset=4
-   block $__inlined_func$bindings/esm/staticarrayFunction$2 (result i32)
+   block $__inlined_func$bindings/esm/staticarrayFunction$1 (result i32)
     global.get $~lib/memory/__stack_pointer
     i32.const 12
     i32.sub
@@ -3649,7 +3633,7 @@
      i32.add
      global.set $~lib/memory/__stack_pointer
      local.get $4
-     br $__inlined_func$bindings/esm/staticarrayFunction$2
+     br $__inlined_func$bindings/esm/staticarrayFunction$1
     end
     br $folding-inner1
    end
@@ -4222,7 +4206,7 @@
    i32.const 0
    i32.store offset=8
    global.get $~lib/memory/__stack_pointer
-   block $__inlined_func$bindings/esm/PlainObject#constructor$5 (result i32)
+   block $__inlined_func$bindings/esm/PlainObject#constructor$4 (result i32)
     global.get $~lib/memory/__stack_pointer
     i32.const 8
     i32.sub
@@ -4385,7 +4369,7 @@
      i32.add
      global.set $~lib/memory/__stack_pointer
      local.get $2
-     br $__inlined_func$bindings/esm/PlainObject#constructor$5
+     br $__inlined_func$bindings/esm/PlainObject#constructor$4
     end
     br $folding-inner1
    end

--- a/tests/compiler/bindings/noExportRuntime.debug.wat
+++ b/tests/compiler/bindings/noExportRuntime.debug.wat
@@ -2469,12 +2469,8 @@
   call $~lib/object/Object~visit
   local.get $0
   i32.load
-  local.tee $2
-  if
-   local.get $2
-   local.get $1
-   call $~lib/rt/itcms/__visit
-  end
+  local.get $1
+  call $~lib/rt/itcms/__visit
  )
  (func $~lib/object/Object~visit (param $0 i32) (param $1 i32)
  )

--- a/tests/compiler/bindings/noExportRuntime.release.wat
+++ b/tests/compiler/bindings/noExportRuntime.release.wat
@@ -156,7 +156,7 @@
    local.get $1
    global.set $~lib/rt/itcms/iter
   end
-  block $__inlined_func$~lib/rt/itcms/Object#unlink$130
+  block $__inlined_func$~lib/rt/itcms/Object#unlink$132
    local.get $0
    i32.load offset=4
    i32.const -4
@@ -180,7 +180,7 @@
      call $~lib/builtins/abort
      unreachable
     end
-    br $__inlined_func$~lib/rt/itcms/Object#unlink$130
+    br $__inlined_func$~lib/rt/itcms/Object#unlink$132
    end
    local.get $0
    i32.load offset=8
@@ -1657,40 +1657,38 @@
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
-  block $folding-inner2
-   block $folding-inner1
-    block $folding-inner0
-     block $invalid
-      block $bindings/noExportRuntime/NonPlainObject
-       block $~lib/array/Array<~lib/array/Array<i32>>
-        block $~lib/array/Array<i32>
-         block $~lib/string/String
-          block $~lib/arraybuffer/ArrayBuffer
-           block $~lib/object/Object
-            local.get $0
-            i32.const 8
-            i32.sub
-            i32.load
-            br_table $~lib/object/Object $~lib/arraybuffer/ArrayBuffer $~lib/string/String $folding-inner2 $folding-inner2 $~lib/array/Array<i32> $~lib/array/Array<~lib/array/Array<i32>> $bindings/noExportRuntime/NonPlainObject $invalid
+  block $folding-inner1
+   block $folding-inner0
+    block $invalid
+     block $bindings/noExportRuntime/NonPlainObject
+      block $~lib/array/Array<~lib/array/Array<i32>>
+       block $~lib/array/Array<i32>
+        block $~lib/typedarray/Int32Array
+         block $~lib/arraybuffer/ArrayBufferView
+          block $~lib/string/String
+           block $~lib/arraybuffer/ArrayBuffer
+            block $~lib/object/Object
+             local.get $0
+             i32.const 8
+             i32.sub
+             i32.load
+             br_table $~lib/object/Object $~lib/arraybuffer/ArrayBuffer $~lib/string/String $~lib/arraybuffer/ArrayBufferView $~lib/typedarray/Int32Array $~lib/array/Array<i32> $~lib/array/Array<~lib/array/Array<i32>> $bindings/noExportRuntime/NonPlainObject $invalid
+            end
+            return
            end
            return
           end
           return
          end
+         local.get $0
+         i32.load
+         call $~lib/rt/itcms/__visit
          return
         end
-        global.get $~lib/memory/__stack_pointer
-        i32.const 4
-        i32.sub
-        global.set $~lib/memory/__stack_pointer
-        global.get $~lib/memory/__stack_pointer
-        i32.const 1780
-        i32.lt_s
-        br_if $folding-inner0
-        global.get $~lib/memory/__stack_pointer
-        i32.const 0
-        i32.store
-        br $folding-inner1
+        local.get $0
+        i32.load
+        call $~lib/rt/itcms/__visit
+        return
        end
        global.get $~lib/memory/__stack_pointer
        i32.const 4
@@ -1703,73 +1701,77 @@
        global.get $~lib/memory/__stack_pointer
        i32.const 0
        i32.store
-       global.get $~lib/memory/__stack_pointer
-       local.get $0
-       i32.store
-       local.get $0
-       i32.load offset=4
-       local.set $1
-       global.get $~lib/memory/__stack_pointer
-       local.get $0
-       i32.store
-       local.get $1
-       local.get $0
-       i32.load offset=12
-       i32.const 2
-       i32.shl
-       i32.add
-       local.set $2
-       loop $while-continue|0
-        local.get $1
-        local.get $2
-        i32.lt_u
-        if
-         local.get $1
-         i32.load
-         local.tee $3
-         if
-          local.get $3
-          call $~lib/rt/itcms/__visit
-         end
-         local.get $1
-         i32.const 4
-         i32.add
-         local.set $1
-         br $while-continue|0
-        end
-       end
        br $folding-inner1
       end
-      return
+      global.get $~lib/memory/__stack_pointer
+      i32.const 4
+      i32.sub
+      global.set $~lib/memory/__stack_pointer
+      global.get $~lib/memory/__stack_pointer
+      i32.const 1780
+      i32.lt_s
+      br_if $folding-inner0
+      global.get $~lib/memory/__stack_pointer
+      i32.const 0
+      i32.store
+      global.get $~lib/memory/__stack_pointer
+      local.get $0
+      i32.store
+      local.get $0
+      i32.load offset=4
+      local.set $1
+      global.get $~lib/memory/__stack_pointer
+      local.get $0
+      i32.store
+      local.get $1
+      local.get $0
+      i32.load offset=12
+      i32.const 2
+      i32.shl
+      i32.add
+      local.set $2
+      loop $while-continue|0
+       local.get $1
+       local.get $2
+       i32.lt_u
+       if
+        local.get $1
+        i32.load
+        local.tee $3
+        if
+         local.get $3
+         call $~lib/rt/itcms/__visit
+        end
+        local.get $1
+        i32.const 4
+        i32.add
+        local.set $1
+        br $while-continue|0
+       end
+      end
+      br $folding-inner1
      end
-     unreachable
+     return
     end
-    i32.const 34576
-    i32.const 34624
-    i32.const 1
-    i32.const 1
-    call $~lib/builtins/abort
     unreachable
    end
-   global.get $~lib/memory/__stack_pointer
-   local.get $0
-   i32.store
-   local.get $0
-   i32.load
-   call $~lib/rt/itcms/__visit
-   global.get $~lib/memory/__stack_pointer
-   i32.const 4
-   i32.add
-   global.set $~lib/memory/__stack_pointer
-   return
+   i32.const 34576
+   i32.const 34624
+   i32.const 1
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
   end
+  global.get $~lib/memory/__stack_pointer
+  local.get $0
+  i32.store
   local.get $0
   i32.load
-  local.tee $0
-  if
-   local.get $0
-   call $~lib/rt/itcms/__visit
-  end
+  call $~lib/rt/itcms/__visit
+  global.get $~lib/memory/__stack_pointer
+  i32.const 4
+  i32.add
+  global.set $~lib/memory/__stack_pointer
  )
  (func $~start
   (local $0 i32)
@@ -1817,7 +1819,7 @@
   i32.const 4
   i32.sub
   global.set $~lib/memory/__stack_pointer
-  block $__inlined_func$start:bindings/noExportRuntime$2
+  block $__inlined_func$start:bindings/noExportRuntime
    block $folding-inner0
     global.get $~lib/memory/__stack_pointer
     i32.const 1780
@@ -1940,7 +1942,7 @@
     global.set $~lib/memory/__stack_pointer
     local.get $0
     global.set $bindings/noExportRuntime/isTypedArray
-    br $__inlined_func$start:bindings/noExportRuntime$2
+    br $__inlined_func$start:bindings/noExportRuntime
    end
    i32.const 34576
    i32.const 34624

--- a/tests/compiler/bindings/raw.debug.wat
+++ b/tests/compiler/bindings/raw.debug.wat
@@ -2877,12 +2877,8 @@
   call $~lib/object/Object~visit
   local.get $0
   i32.load
-  local.tee $2
-  if
-   local.get $2
-   local.get $1
-   call $~lib/rt/itcms/__visit
-  end
+  local.get $1
+  call $~lib/rt/itcms/__visit
  )
  (func $~lib/object/Object~visit (param $0 i32) (param $1 i32)
  )
@@ -2944,28 +2940,16 @@
   call $~lib/object/Object~visit
   local.get $0
   i32.load offset=56
-  local.tee $2
-  if
-   local.get $2
-   local.get $1
-   call $~lib/rt/itcms/__visit
-  end
+  local.get $1
+  call $~lib/rt/itcms/__visit
   local.get $0
   i32.load offset=60
-  local.tee $2
-  if
-   local.get $2
-   local.get $1
-   call $~lib/rt/itcms/__visit
-  end
+  local.get $1
+  call $~lib/rt/itcms/__visit
   local.get $0
   i32.load offset=64
-  local.tee $2
-  if
-   local.get $2
-   local.get $1
-   call $~lib/rt/itcms/__visit
-  end
+  local.get $1
+  call $~lib/rt/itcms/__visit
  )
  (func $~lib/typedarray/Uint8Array~visit (param $0 i32) (param $1 i32)
   local.get $0

--- a/tests/compiler/bindings/raw.release.wat
+++ b/tests/compiler/bindings/raw.release.wat
@@ -2006,25 +2006,13 @@
        end
        local.get $0
        i32.load offset=56
-       local.tee $1
-       if
-        local.get $1
-        call $~lib/rt/itcms/__visit
-       end
+       call $~lib/rt/itcms/__visit
        local.get $0
        i32.load offset=60
-       local.tee $1
-       if
-        local.get $1
-        call $~lib/rt/itcms/__visit
-       end
+       call $~lib/rt/itcms/__visit
        local.get $0
        i32.load offset=64
-       local.tee $0
-       if
-        local.get $0
-        call $~lib/rt/itcms/__visit
-       end
+       call $~lib/rt/itcms/__visit
        return
       end
       return
@@ -2040,11 +2028,7 @@
    end
    local.get $0
    i32.load
-   local.tee $0
-   if
-    local.get $0
-    call $~lib/rt/itcms/__visit
-   end
+   call $~lib/rt/itcms/__visit
    return
   end
   global.get $~lib/memory/__stack_pointer
@@ -2208,7 +2192,7 @@
    global.get $~lib/memory/__stack_pointer
    local.get $1
    i32.store
-   block $__inlined_func$~lib/string/String#concat$281
+   block $__inlined_func$~lib/string/String#concat$286
     local.get $1
     i32.const 20
     i32.sub
@@ -2227,7 +2211,7 @@
      global.set $~lib/memory/__stack_pointer
      i32.const 1760
      local.set $2
-     br $__inlined_func$~lib/string/String#concat$281
+     br $__inlined_func$~lib/string/String#concat$286
     end
     global.get $~lib/memory/__stack_pointer
     local.get $2
@@ -2414,7 +2398,7 @@
    global.get $~lib/memory/__stack_pointer
    local.get $1
    i32.store
-   block $__inlined_func$~lib/typedarray/Uint64Array#constructor$1 (result i32)
+   block $__inlined_func$~lib/typedarray/Uint64Array#constructor (result i32)
     local.get $1
     call $~lib/typedarray/Float32Array#get:length
     local.get $5
@@ -2544,7 +2528,7 @@
      i32.add
      global.set $~lib/memory/__stack_pointer
      local.get $2
-     br $__inlined_func$~lib/typedarray/Uint64Array#constructor$1
+     br $__inlined_func$~lib/typedarray/Uint64Array#constructor
     end
     br $folding-inner1
    end
@@ -2941,7 +2925,7 @@
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store
-   block $__inlined_func$~lib/rt/itcms/__renew$265
+   block $__inlined_func$~lib/rt/itcms/__renew$270
     i32.const 1073741820
     local.get $2
     i32.const 1
@@ -2984,7 +2968,7 @@
      i32.store offset=16
      local.get $2
      local.set $1
-     br $__inlined_func$~lib/rt/itcms/__renew$265
+     br $__inlined_func$~lib/rt/itcms/__renew$270
     end
     local.get $3
     local.get $4
@@ -3493,7 +3477,7 @@
    global.get $~lib/memory/__stack_pointer
    local.get $1
    i32.store offset=4
-   block $__inlined_func$bindings/esm/staticarrayFunction$2 (result i32)
+   block $__inlined_func$bindings/esm/staticarrayFunction$1 (result i32)
     global.get $~lib/memory/__stack_pointer
     i32.const 12
     i32.sub
@@ -3649,7 +3633,7 @@
      i32.add
      global.set $~lib/memory/__stack_pointer
      local.get $4
-     br $__inlined_func$bindings/esm/staticarrayFunction$2
+     br $__inlined_func$bindings/esm/staticarrayFunction$1
     end
     br $folding-inner1
    end
@@ -4222,7 +4206,7 @@
    i32.const 0
    i32.store offset=8
    global.get $~lib/memory/__stack_pointer
-   block $__inlined_func$bindings/esm/PlainObject#constructor$5 (result i32)
+   block $__inlined_func$bindings/esm/PlainObject#constructor$4 (result i32)
     global.get $~lib/memory/__stack_pointer
     i32.const 8
     i32.sub
@@ -4385,7 +4369,7 @@
      i32.add
      global.set $~lib/memory/__stack_pointer
      local.get $2
-     br $__inlined_func$bindings/esm/PlainObject#constructor$5
+     br $__inlined_func$bindings/esm/PlainObject#constructor$4
     end
     br $folding-inner1
    end

--- a/tests/compiler/call-inferred.debug.wat
+++ b/tests/compiler/call-inferred.debug.wat
@@ -2311,12 +2311,8 @@
   call $~lib/object/Object~visit
   local.get $0
   i32.load
-  local.tee $2
-  if
-   local.get $2
-   local.get $1
-   call $~lib/rt/itcms/__visit
-  end
+  local.get $1
+  call $~lib/rt/itcms/__visit
  )
  (func $~lib/object/Object~visit (param $0 i32) (param $1 i32)
  )

--- a/tests/compiler/call-inferred.release.wat
+++ b/tests/compiler/call-inferred.release.wat
@@ -1546,11 +1546,7 @@
       end
       local.get $0
       i32.load
-      local.tee $0
-      if
-       local.get $0
-       call $~lib/rt/itcms/__visit
-      end
+      call $~lib/rt/itcms/__visit
       return
      end
      return

--- a/tests/compiler/call-rest.debug.wat
+++ b/tests/compiler/call-rest.debug.wat
@@ -2456,12 +2456,8 @@
   call $~lib/object/Object~visit
   local.get $0
   i32.load
-  local.tee $2
-  if
-   local.get $2
-   local.get $1
-   call $~lib/rt/itcms/__visit
-  end
+  local.get $1
+  call $~lib/rt/itcms/__visit
  )
  (func $~lib/object/Object~visit (param $0 i32) (param $1 i32)
  )
@@ -2508,12 +2504,8 @@
   call $~lib/object/Object~visit
   local.get $0
   i32.load
-  local.tee $2
-  if
-   local.get $2
-   local.get $1
-   call $~lib/rt/itcms/__visit
-  end
+  local.get $1
+  call $~lib/rt/itcms/__visit
  )
  (func $~lib/array/Array<~lib/string/String>#get:dataStart (param $this i32) (result i32)
   local.get $this

--- a/tests/compiler/call-rest.release.wat
+++ b/tests/compiler/call-rest.release.wat
@@ -147,7 +147,7 @@
    local.get $1
    global.set $~lib/rt/itcms/iter
   end
-  block $__inlined_func$~lib/rt/itcms/Object#unlink$158
+  block $__inlined_func$~lib/rt/itcms/Object#unlink$160
    local.get $0
    i32.load offset=4
    i32.const -4
@@ -171,7 +171,7 @@
      call $~lib/builtins/abort
      unreachable
     end
-    br $__inlined_func$~lib/rt/itcms/Object#unlink$158
+    br $__inlined_func$~lib/rt/itcms/Object#unlink$160
    end
    local.get $0
    i32.load offset=8
@@ -1659,26 +1659,32 @@
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
-  block $folding-inner1
-   block $folding-inner0
-    block $invalid
-     block $~lib/array/Array<~lib/string/String>
+  block $folding-inner0
+   block $invalid
+    block $~lib/array/Array<~lib/string/String>
+     block $call-rest/Foo
       block $~lib/function/Function<%28i32%2Ci32?%2C...~lib/array/Array<i32>%29=>i32>
        block $~lib/array/Array<usize>
         block $~lib/array/Array<i32>
-         block $~lib/string/String
-          block $~lib/arraybuffer/ArrayBuffer
-           block $~lib/object/Object
-            local.get $0
-            i32.const 8
-            i32.sub
-            i32.load
-            br_table $~lib/object/Object $~lib/arraybuffer/ArrayBuffer $~lib/string/String $folding-inner1 $~lib/array/Array<i32> $~lib/array/Array<usize> $~lib/function/Function<%28i32%2Ci32?%2C...~lib/array/Array<i32>%29=>i32> $folding-inner1 $~lib/array/Array<~lib/string/String> $invalid
+         block $~lib/arraybuffer/ArrayBufferView
+          block $~lib/string/String
+           block $~lib/arraybuffer/ArrayBuffer
+            block $~lib/object/Object
+             local.get $0
+             i32.const 8
+             i32.sub
+             i32.load
+             br_table $~lib/object/Object $~lib/arraybuffer/ArrayBuffer $~lib/string/String $~lib/arraybuffer/ArrayBufferView $~lib/array/Array<i32> $~lib/array/Array<usize> $~lib/function/Function<%28i32%2Ci32?%2C...~lib/array/Array<i32>%29=>i32> $call-rest/Foo $~lib/array/Array<~lib/string/String> $invalid
+            end
+            return
            end
            return
           end
           return
          end
+         local.get $0
+         i32.load
+         call $~lib/rt/itcms/__visit
          return
         end
         local.get $0
@@ -1712,80 +1718,77 @@
       global.set $~lib/memory/__stack_pointer
       return
      end
-     global.get $~lib/memory/__stack_pointer
-     i32.const 4
-     i32.sub
-     global.set $~lib/memory/__stack_pointer
-     global.get $~lib/memory/__stack_pointer
-     i32.const 2136
-     i32.lt_s
-     br_if $folding-inner0
-     global.get $~lib/memory/__stack_pointer
-     i32.const 0
-     i32.store
-     global.get $~lib/memory/__stack_pointer
-     local.get $0
-     i32.store
-     local.get $0
-     i32.load offset=4
-     local.set $1
-     global.get $~lib/memory/__stack_pointer
-     local.get $0
-     i32.store
-     local.get $1
-     local.get $0
-     i32.load offset=12
-     i32.const 2
-     i32.shl
-     i32.add
-     local.set $2
-     loop $while-continue|0
-      local.get $1
-      local.get $2
-      i32.lt_u
-      if
-       local.get $1
-       i32.load
-       local.tee $3
-       if
-        local.get $3
-        call $~lib/rt/itcms/__visit
-       end
-       local.get $1
-       i32.const 4
-       i32.add
-       local.set $1
-       br $while-continue|0
-      end
-     end
-     global.get $~lib/memory/__stack_pointer
-     local.get $0
-     i32.store
      local.get $0
      i32.load
      call $~lib/rt/itcms/__visit
-     global.get $~lib/memory/__stack_pointer
-     i32.const 4
-     i32.add
-     global.set $~lib/memory/__stack_pointer
      return
     end
-    unreachable
+    global.get $~lib/memory/__stack_pointer
+    i32.const 4
+    i32.sub
+    global.set $~lib/memory/__stack_pointer
+    global.get $~lib/memory/__stack_pointer
+    i32.const 2136
+    i32.lt_s
+    br_if $folding-inner0
+    global.get $~lib/memory/__stack_pointer
+    i32.const 0
+    i32.store
+    global.get $~lib/memory/__stack_pointer
+    local.get $0
+    i32.store
+    local.get $0
+    i32.load offset=4
+    local.set $1
+    global.get $~lib/memory/__stack_pointer
+    local.get $0
+    i32.store
+    local.get $1
+    local.get $0
+    i32.load offset=12
+    i32.const 2
+    i32.shl
+    i32.add
+    local.set $2
+    loop $while-continue|0
+     local.get $1
+     local.get $2
+     i32.lt_u
+     if
+      local.get $1
+      i32.load
+      local.tee $3
+      if
+       local.get $3
+       call $~lib/rt/itcms/__visit
+      end
+      local.get $1
+      i32.const 4
+      i32.add
+      local.set $1
+      br $while-continue|0
+     end
+    end
+    global.get $~lib/memory/__stack_pointer
+    local.get $0
+    i32.store
+    local.get $0
+    i32.load
+    call $~lib/rt/itcms/__visit
+    global.get $~lib/memory/__stack_pointer
+    i32.const 4
+    i32.add
+    global.set $~lib/memory/__stack_pointer
+    return
    end
-   i32.const 34928
-   i32.const 34976
-   i32.const 1
-   i32.const 1
-   call $~lib/builtins/abort
    unreachable
   end
-  local.get $0
-  i32.load
-  local.tee $0
-  if
-   local.get $0
-   call $~lib/rt/itcms/__visit
-  end
+  i32.const 34928
+  i32.const 34976
+  i32.const 1
+  i32.const 1
+  call $~lib/builtins/abort
+  unreachable
  )
  (func $~start
   call $start:call-rest
@@ -2025,7 +2028,7 @@
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store
-   block $__inlined_func$~lib/rt/itcms/__renew$152
+   block $__inlined_func$~lib/rt/itcms/__renew$154
     i32.const 1073741820
     local.get $2
     i32.const 1
@@ -2068,7 +2071,7 @@
      i32.store offset=16
      local.get $2
      local.set $1
-     br $__inlined_func$~lib/rt/itcms/__renew$152
+     br $__inlined_func$~lib/rt/itcms/__renew$154
     end
     local.get $3
     local.get $4

--- a/tests/compiler/call-super.debug.wat
+++ b/tests/compiler/call-super.debug.wat
@@ -2372,12 +2372,8 @@
   call $~lib/object/Object~visit
   local.get $0
   i32.load
-  local.tee $2
-  if
-   local.get $2
-   local.get $1
-   call $~lib/rt/itcms/__visit
-  end
+  local.get $1
+  call $~lib/rt/itcms/__visit
  )
  (func $~lib/object/Object~visit (param $0 i32) (param $1 i32)
  )

--- a/tests/compiler/call-super.release.wat
+++ b/tests/compiler/call-super.release.wat
@@ -2265,11 +2265,7 @@
              end
              local.get $0
              i32.load
-             local.tee $0
-             if
-              local.get $0
-              call $~lib/rt/itcms/__visit
-             end
+             call $~lib/rt/itcms/__visit
              return
             end
             return

--- a/tests/compiler/class-implements.debug.wat
+++ b/tests/compiler/class-implements.debug.wat
@@ -2698,12 +2698,8 @@
   call $~lib/object/Object~visit
   local.get $0
   i32.load
-  local.tee $2
-  if
-   local.get $2
-   local.get $1
-   call $~lib/rt/itcms/__visit
-  end
+  local.get $1
+  call $~lib/rt/itcms/__visit
  )
  (func $~lib/object/Object~visit (param $0 i32) (param $1 i32)
  )

--- a/tests/compiler/class-implements.release.wat
+++ b/tests/compiler/class-implements.release.wat
@@ -1740,11 +1740,7 @@
                     end
                     local.get $0
                     i32.load
-                    local.tee $0
-                    if
-                     local.get $0
-                     call $~lib/rt/itcms/__visit
-                    end
+                    call $~lib/rt/itcms/__visit
                     return
                    end
                    return

--- a/tests/compiler/class-overloading-cast.debug.wat
+++ b/tests/compiler/class-overloading-cast.debug.wat
@@ -2513,12 +2513,8 @@
   call $~lib/object/Object~visit
   local.get $0
   i32.load
-  local.tee $2
-  if
-   local.get $2
-   local.get $1
-   call $~lib/rt/itcms/__visit
-  end
+  local.get $1
+  call $~lib/rt/itcms/__visit
  )
  (func $~lib/object/Object~visit (param $0 i32) (param $1 i32)
  )

--- a/tests/compiler/class-overloading-cast.release.wat
+++ b/tests/compiler/class-overloading-cast.release.wat
@@ -1435,11 +1435,7 @@
              end
              local.get $0
              i32.load
-             local.tee $0
-             if
-              local.get $0
-              call $~lib/rt/itcms/__visit
-             end
+             call $~lib/rt/itcms/__visit
              return
             end
             return

--- a/tests/compiler/class-overloading.debug.wat
+++ b/tests/compiler/class-overloading.debug.wat
@@ -2811,12 +2811,8 @@
   call $~lib/object/Object~visit
   local.get $0
   i32.load
-  local.tee $2
-  if
-   local.get $2
-   local.get $1
-   call $~lib/rt/itcms/__visit
-  end
+  local.get $1
+  call $~lib/rt/itcms/__visit
  )
  (func $~lib/object/Object~visit (param $0 i32) (param $1 i32)
  )

--- a/tests/compiler/class-overloading.release.wat
+++ b/tests/compiler/class-overloading.release.wat
@@ -1489,11 +1489,7 @@
                  end
                  local.get $0
                  i32.load
-                 local.tee $0
-                 if
-                  local.get $0
-                  call $~lib/rt/itcms/__visit
-                 end
+                 call $~lib/rt/itcms/__visit
                  return
                 end
                 return

--- a/tests/compiler/class-override.debug.wat
+++ b/tests/compiler/class-override.debug.wat
@@ -2346,12 +2346,8 @@
   call $~lib/object/Object~visit
   local.get $0
   i32.load
-  local.tee $2
-  if
-   local.get $2
-   local.get $1
-   call $~lib/rt/itcms/__visit
-  end
+  local.get $1
+  call $~lib/rt/itcms/__visit
  )
  (func $~lib/object/Object~visit (param $0 i32) (param $1 i32)
  )

--- a/tests/compiler/class-override.release.wat
+++ b/tests/compiler/class-override.release.wat
@@ -1400,11 +1400,7 @@
        end
        local.get $0
        i32.load
-       local.tee $0
-       if
-        local.get $0
-        call $~lib/rt/itcms/__visit
-       end
+       call $~lib/rt/itcms/__visit
        return
       end
       return

--- a/tests/compiler/class.debug.wat
+++ b/tests/compiler/class.debug.wat
@@ -2452,12 +2452,8 @@
   call $~lib/object/Object~visit
   local.get $0
   i32.load
-  local.tee $2
-  if
-   local.get $2
-   local.get $1
-   call $~lib/rt/itcms/__visit
-  end
+  local.get $1
+  call $~lib/rt/itcms/__visit
  )
  (func $~lib/object/Object~visit (param $0 i32) (param $1 i32)
  )
@@ -2468,12 +2464,8 @@
   call $~lib/object/Object~visit
   local.get $0
   i32.load
-  local.tee $2
-  if
-   local.get $2
-   local.get $1
-   call $~lib/rt/itcms/__visit
-  end
+  local.get $1
+  call $~lib/rt/itcms/__visit
  )
  (func $~lib/array/Array<i32>#get:buffer (param $this i32) (result i32)
   local.get $this

--- a/tests/compiler/class.release.wat
+++ b/tests/compiler/class.release.wat
@@ -109,7 +109,7 @@
    local.get $1
    global.set $~lib/rt/itcms/iter
   end
-  block $__inlined_func$~lib/rt/itcms/Object#unlink$137
+  block $__inlined_func$~lib/rt/itcms/Object#unlink$139
    local.get $0
    i32.load offset=4
    i32.const -4
@@ -133,7 +133,7 @@
      call $~lib/builtins/abort
      unreachable
     end
-    br $__inlined_func$~lib/rt/itcms/Object#unlink$137
+    br $__inlined_func$~lib/rt/itcms/Object#unlink$139
    end
    local.get $0
    i32.load offset=8
@@ -1748,66 +1748,69 @@
   unreachable
  )
  (func $~lib/rt/__visit_members (param $0 i32)
-  block $folding-inner0
-   block $invalid
-    block $~lib/array/Array<i32>
+  block $invalid
+   block $~lib/array/Array<i32>
+    block $class/GenericInitializer<i32>
      block $class/Animal<f64>
-      block $~lib/string/String
-       block $~lib/arraybuffer/ArrayBuffer
-        block $~lib/object/Object
-         local.get $0
-         i32.const 8
-         i32.sub
-         i32.load
-         br_table $~lib/object/Object $~lib/arraybuffer/ArrayBuffer $~lib/string/String $folding-inner0 $class/Animal<f64> $folding-inner0 $~lib/array/Array<i32> $invalid
+      block $~lib/arraybuffer/ArrayBufferView
+       block $~lib/string/String
+        block $~lib/arraybuffer/ArrayBuffer
+         block $~lib/object/Object
+          local.get $0
+          i32.const 8
+          i32.sub
+          i32.load
+          br_table $~lib/object/Object $~lib/arraybuffer/ArrayBuffer $~lib/string/String $~lib/arraybuffer/ArrayBufferView $class/Animal<f64> $class/GenericInitializer<i32> $~lib/array/Array<i32> $invalid
+         end
+         return
         end
         return
        end
        return
       end
+      local.get $0
+      i32.load
+      call $~lib/rt/itcms/__visit
       return
      end
      return
     end
-    global.get $~lib/memory/__stack_pointer
-    i32.const 4
-    i32.sub
-    global.set $~lib/memory/__stack_pointer
-    global.get $~lib/memory/__stack_pointer
-    i32.const 1568
-    i32.lt_s
-    if
-     i32.const 34368
-     i32.const 34416
-     i32.const 1
-     i32.const 1
-     call $~lib/builtins/abort
-     unreachable
-    end
-    global.get $~lib/memory/__stack_pointer
-    i32.const 0
-    i32.store
-    global.get $~lib/memory/__stack_pointer
-    local.get $0
-    i32.store
     local.get $0
     i32.load
     call $~lib/rt/itcms/__visit
-    global.get $~lib/memory/__stack_pointer
-    i32.const 4
-    i32.add
-    global.set $~lib/memory/__stack_pointer
     return
    end
-   unreachable
-  end
-  local.get $0
-  i32.load
-  local.tee $0
-  if
+   global.get $~lib/memory/__stack_pointer
+   i32.const 4
+   i32.sub
+   global.set $~lib/memory/__stack_pointer
+   global.get $~lib/memory/__stack_pointer
+   i32.const 1568
+   i32.lt_s
+   if
+    i32.const 34368
+    i32.const 34416
+    i32.const 1
+    i32.const 1
+    call $~lib/builtins/abort
+    unreachable
+   end
+   global.get $~lib/memory/__stack_pointer
+   i32.const 0
+   i32.store
+   global.get $~lib/memory/__stack_pointer
    local.get $0
+   i32.store
+   local.get $0
+   i32.load
    call $~lib/rt/itcms/__visit
+   global.get $~lib/memory/__stack_pointer
+   i32.const 4
+   i32.add
+   global.set $~lib/memory/__stack_pointer
+   return
   end
+  unreachable
  )
  (func $~start
   memory.size

--- a/tests/compiler/constructor.debug.wat
+++ b/tests/compiler/constructor.debug.wat
@@ -2422,12 +2422,8 @@
   call $~lib/object/Object~visit
   local.get $0
   i32.load
-  local.tee $2
-  if
-   local.get $2
-   local.get $1
-   call $~lib/rt/itcms/__visit
-  end
+  local.get $1
+  call $~lib/rt/itcms/__visit
  )
  (func $~lib/object/Object~visit (param $0 i32) (param $1 i32)
  )

--- a/tests/compiler/constructor.release.wat
+++ b/tests/compiler/constructor.release.wat
@@ -1618,11 +1618,7 @@
                end
                local.get $0
                i32.load
-               local.tee $0
-               if
-                local.get $0
-                call $~lib/rt/itcms/__visit
-               end
+               call $~lib/rt/itcms/__visit
                return
               end
               return

--- a/tests/compiler/do.debug.wat
+++ b/tests/compiler/do.debug.wat
@@ -3024,12 +3024,8 @@
   call $~lib/object/Object~visit
   local.get $0
   i32.load
-  local.tee $2
-  if
-   local.get $2
-   local.get $1
-   call $~lib/rt/itcms/__visit
-  end
+  local.get $1
+  call $~lib/rt/itcms/__visit
  )
  (func $~lib/object/Object~visit (param $0 i32) (param $1 i32)
  )

--- a/tests/compiler/do.release.wat
+++ b/tests/compiler/do.release.wat
@@ -1836,11 +1836,7 @@
     end
     local.get $0
     i32.load
-    local.tee $0
-    if
-     local.get $0
-     call $~lib/rt/itcms/__visit
-    end
+    call $~lib/rt/itcms/__visit
     return
    end
    return

--- a/tests/compiler/duplicate-fields.debug.wat
+++ b/tests/compiler/duplicate-fields.debug.wat
@@ -2407,12 +2407,8 @@
   call $~lib/object/Object~visit
   local.get $0
   i32.load
-  local.tee $2
-  if
-   local.get $2
-   local.get $1
-   call $~lib/rt/itcms/__visit
-  end
+  local.get $1
+  call $~lib/rt/itcms/__visit
  )
  (func $~lib/object/Object~visit (param $0 i32) (param $1 i32)
  )
@@ -2423,12 +2419,8 @@
   call $~lib/object/Object~visit
   local.get $0
   i32.load
-  local.tee $2
-  if
-   local.get $2
-   local.get $1
-   call $~lib/rt/itcms/__visit
-  end
+  local.get $1
+  call $~lib/rt/itcms/__visit
  )
  (func $duplicate-fields/B2~visit (param $0 i32) (param $1 i32)
   (local $2 i32)
@@ -2437,12 +2429,8 @@
   call $duplicate-fields/A2~visit
   local.get $0
   i32.load
-  local.tee $2
-  if
-   local.get $2
-   local.get $1
-   call $~lib/rt/itcms/__visit
-  end
+  local.get $1
+  call $~lib/rt/itcms/__visit
  )
  (func $~lib/rt/__visit_members (param $0 i32) (param $1 i32)
   block $invalid

--- a/tests/compiler/duplicate-fields.release.wat
+++ b/tests/compiler/duplicate-fields.release.wat
@@ -116,7 +116,7 @@
    local.get $1
    global.set $~lib/rt/itcms/iter
   end
-  block $__inlined_func$~lib/rt/itcms/Object#unlink$136
+  block $__inlined_func$~lib/rt/itcms/Object#unlink$139
    local.get $0
    i32.load offset=4
    i32.const -4
@@ -140,7 +140,7 @@
      call $~lib/builtins/abort
      unreachable
     end
-    br $__inlined_func$~lib/rt/itcms/Object#unlink$136
+    br $__inlined_func$~lib/rt/itcms/Object#unlink$139
    end
    local.get $0
    i32.load offset=8
@@ -1596,7 +1596,6 @@
   end
  )
  (func $~lib/rt/__visit_members (param $0 i32)
-  (local $1 i32)
   block $folding-inner0
    block $invalid
     block $duplicate-fields/A3
@@ -1628,11 +1627,7 @@
       end
       local.get $0
       i32.load
-      local.tee $1
-      if
-       local.get $1
-       call $~lib/rt/itcms/__visit
-      end
+      call $~lib/rt/itcms/__visit
       br $folding-inner0
      end
      return
@@ -1643,11 +1638,7 @@
   end
   local.get $0
   i32.load
-  local.tee $0
-  if
-   local.get $0
-   call $~lib/rt/itcms/__visit
-  end
+  call $~lib/rt/itcms/__visit
  )
  (func $~start
   (local $0 i32)

--- a/tests/compiler/empty-exportruntime.debug.wat
+++ b/tests/compiler/empty-exportruntime.debug.wat
@@ -2384,12 +2384,8 @@
   call $~lib/object/Object~visit
   local.get $0
   i32.load
-  local.tee $2
-  if
-   local.get $2
-   local.get $1
-   call $~lib/rt/itcms/__visit
-  end
+  local.get $1
+  call $~lib/rt/itcms/__visit
  )
  (func $~lib/object/Object~visit (param $0 i32) (param $1 i32)
  )

--- a/tests/compiler/empty-exportruntime.release.wat
+++ b/tests/compiler/empty-exportruntime.release.wat
@@ -1706,11 +1706,7 @@
    end
    local.get $0
    i32.load
-   local.tee $0
-   if
-    local.get $0
-    call $~lib/rt/itcms/__visit
-   end
+   call $~lib/rt/itcms/__visit
    return
   end
   unreachable

--- a/tests/compiler/empty-new.debug.wat
+++ b/tests/compiler/empty-new.debug.wat
@@ -2280,12 +2280,8 @@
   call $~lib/object/Object~visit
   local.get $0
   i32.load
-  local.tee $2
-  if
-   local.get $2
-   local.get $1
-   call $~lib/rt/itcms/__visit
-  end
+  local.get $1
+  call $~lib/rt/itcms/__visit
  )
  (func $~lib/object/Object~visit (param $0 i32) (param $1 i32)
  )

--- a/tests/compiler/empty-new.release.wat
+++ b/tests/compiler/empty-new.release.wat
@@ -1382,11 +1382,7 @@
    end
    local.get $0
    i32.load
-   local.tee $0
-   if
-    local.get $0
-    call $~lib/rt/itcms/__visit
-   end
+   call $~lib/rt/itcms/__visit
    return
   end
   unreachable

--- a/tests/compiler/exportstar-rereexport.debug.wat
+++ b/tests/compiler/exportstar-rereexport.debug.wat
@@ -2327,12 +2327,8 @@
   call $~lib/object/Object~visit
   local.get $0
   i32.load
-  local.tee $2
-  if
-   local.get $2
-   local.get $1
-   call $~lib/rt/itcms/__visit
-  end
+  local.get $1
+  call $~lib/rt/itcms/__visit
  )
  (func $~lib/object/Object~visit (param $0 i32) (param $1 i32)
  )

--- a/tests/compiler/exportstar-rereexport.release.wat
+++ b/tests/compiler/exportstar-rereexport.release.wat
@@ -1420,11 +1420,7 @@
     end
     local.get $0
     i32.load
-    local.tee $0
-    if
-     local.get $0
-     call $~lib/rt/itcms/__visit
-    end
+    call $~lib/rt/itcms/__visit
     return
    end
    return

--- a/tests/compiler/extends-baseaggregate.debug.wat
+++ b/tests/compiler/extends-baseaggregate.debug.wat
@@ -2442,12 +2442,8 @@
   call $~lib/object/Object~visit
   local.get $0
   i32.load
-  local.tee $2
-  if
-   local.get $2
-   local.get $1
-   call $~lib/rt/itcms/__visit
-  end
+  local.get $1
+  call $~lib/rt/itcms/__visit
  )
  (func $~lib/object/Object~visit (param $0 i32) (param $1 i32)
  )
@@ -2458,12 +2454,8 @@
   call $~lib/object/Object~visit
   local.get $0
   i32.load
-  local.tee $2
-  if
-   local.get $2
-   local.get $1
-   call $~lib/rt/itcms/__visit
-  end
+  local.get $1
+  call $~lib/rt/itcms/__visit
  )
  (func $extends-baseaggregate/A1~visit (param $0 i32) (param $1 i32)
   (local $2 i32)
@@ -2472,12 +2464,8 @@
   call $~lib/object/Object~visit
   local.get $0
   i32.load offset=16
-  local.tee $2
-  if
-   local.get $2
-   local.get $1
-   call $~lib/rt/itcms/__visit
-  end
+  local.get $1
+  call $~lib/rt/itcms/__visit
  )
  (func $extends-baseaggregate/C1~visit (param $0 i32) (param $1 i32)
   (local $2 i32)
@@ -2486,12 +2474,8 @@
   call $~lib/object/Object~visit
   local.get $0
   i32.load
-  local.tee $2
-  if
-   local.get $2
-   local.get $1
-   call $~lib/rt/itcms/__visit
-  end
+  local.get $1
+  call $~lib/rt/itcms/__visit
  )
  (func $extends-baseaggregate/A2~visit (param $0 i32) (param $1 i32)
   local.get $0

--- a/tests/compiler/extends-baseaggregate.release.wat
+++ b/tests/compiler/extends-baseaggregate.release.wat
@@ -120,7 +120,7 @@
    local.get $1
    global.set $~lib/rt/itcms/iter
   end
-  block $__inlined_func$~lib/rt/itcms/Object#unlink$137
+  block $__inlined_func$~lib/rt/itcms/Object#unlink$142
    local.get $0
    i32.load offset=4
    i32.const -4
@@ -144,7 +144,7 @@
      call $~lib/builtins/abort
      unreachable
     end
-    br $__inlined_func$~lib/rt/itcms/Object#unlink$137
+    br $__inlined_func$~lib/rt/itcms/Object#unlink$142
    end
    local.get $0
    i32.load offset=8
@@ -1672,52 +1672,50 @@
   global.set $~lib/memory/__stack_pointer
  )
  (func $~lib/rt/__visit_members (param $0 i32)
-  block $folding-inner1
-   block $folding-inner0
-    block $invalid
-     block $~lib/array/Array<extends-baseaggregate/A2>
-      block $~lib/array/Array<extends-baseaggregate/B1>
-       block $~lib/string/String
-        block $~lib/arraybuffer/ArrayBuffer
-         block $~lib/object/Object
-          local.get $0
-          i32.const 8
-          i32.sub
-          i32.load
-          br_table $~lib/object/Object $~lib/arraybuffer/ArrayBuffer $~lib/string/String $folding-inner0 $folding-inner0 $folding-inner1 $folding-inner0 $folding-inner1 $~lib/array/Array<extends-baseaggregate/B1> $~lib/array/Array<extends-baseaggregate/A2> $invalid
+  block $folding-inner0
+   block $invalid
+    block $~lib/array/Array<extends-baseaggregate/A2>
+     block $~lib/array/Array<extends-baseaggregate/B1>
+      block $extends-baseaggregate/A2
+       block $extends-baseaggregate/A1
+        block $~lib/string/String
+         block $~lib/arraybuffer/ArrayBuffer
+          block $~lib/object/Object
+           local.get $0
+           i32.const 8
+           i32.sub
+           i32.load
+           br_table $~lib/object/Object $~lib/arraybuffer/ArrayBuffer $~lib/string/String $folding-inner0 $folding-inner0 $extends-baseaggregate/A1 $folding-inner0 $extends-baseaggregate/A2 $~lib/array/Array<extends-baseaggregate/B1> $~lib/array/Array<extends-baseaggregate/A2> $invalid
+          end
+          return
          end
          return
         end
         return
        end
+       local.get $0
+       i32.load offset=16
+       call $~lib/rt/itcms/__visit
        return
       end
       local.get $0
-      call $~lib/array/Array<extends-baseaggregate/B1>~visit
+      i32.load offset=16
+      call $~lib/rt/itcms/__visit
       return
      end
      local.get $0
      call $~lib/array/Array<extends-baseaggregate/B1>~visit
      return
     end
-    unreachable
-   end
-   local.get $0
-   i32.load
-   local.tee $0
-   if
     local.get $0
-    call $~lib/rt/itcms/__visit
+    call $~lib/array/Array<extends-baseaggregate/B1>~visit
+    return
    end
-   return
+   unreachable
   end
   local.get $0
-  i32.load offset=16
-  local.tee $0
-  if
-   local.get $0
-   call $~lib/rt/itcms/__visit
-  end
+  i32.load
+  call $~lib/rt/itcms/__visit
  )
  (func $~start
   (local $0 i32)
@@ -1939,7 +1937,7 @@
     global.get $~lib/memory/__stack_pointer
     i32.const 1168
     i32.store
-    block $__inlined_func$~lib/rt/itcms/__renew$136
+    block $__inlined_func$~lib/rt/itcms/__renew$141
      i32.const 1073741820
      local.get $0
      i32.const 1
@@ -1982,7 +1980,7 @@
       i32.store offset=16
       local.get $0
       local.set $1
-      br $__inlined_func$~lib/rt/itcms/__renew$136
+      br $__inlined_func$~lib/rt/itcms/__renew$141
      end
      local.get $3
      local.get $2

--- a/tests/compiler/extends-recursive.debug.wat
+++ b/tests/compiler/extends-recursive.debug.wat
@@ -2356,12 +2356,8 @@
   call $~lib/object/Object~visit
   local.get $0
   i32.load
-  local.tee $2
-  if
-   local.get $2
-   local.get $1
-   call $~lib/rt/itcms/__visit
-  end
+  local.get $1
+  call $~lib/rt/itcms/__visit
  )
  (func $~lib/object/Object~visit (param $0 i32) (param $1 i32)
  )
@@ -2377,12 +2373,8 @@
   call $~lib/object/Object~visit
   local.get $0
   i32.load
-  local.tee $2
-  if
-   local.get $2
-   local.get $1
-   call $~lib/rt/itcms/__visit
-  end
+  local.get $1
+  call $~lib/rt/itcms/__visit
  )
  (func $~lib/rt/__visit_members (param $0 i32) (param $1 i32)
   block $invalid

--- a/tests/compiler/extends-recursive.release.wat
+++ b/tests/compiler/extends-recursive.release.wat
@@ -115,7 +115,7 @@
     local.get $1
     global.set $~lib/rt/itcms/iter
    end
-   block $__inlined_func$~lib/rt/itcms/Object#unlink$113
+   block $__inlined_func$~lib/rt/itcms/Object#unlink$116
     local.get $0
     i32.load offset=4
     i32.const -4
@@ -139,7 +139,7 @@
       call $~lib/builtins/abort
       unreachable
      end
-     br $__inlined_func$~lib/rt/itcms/Object#unlink$113
+     br $__inlined_func$~lib/rt/itcms/Object#unlink$116
     end
     local.get $0
     i32.load offset=8
@@ -1542,17 +1542,13 @@
   end
   local.get $0
   i32.load
-  local.tee $0
-  if
-   local.get $0
-   call $~lib/rt/itcms/__visit
-  end
+  call $~lib/rt/itcms/__visit
  )
  (func $~start
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
-  block $__inlined_func$start:extends-recursive$4
+  block $__inlined_func$start:extends-recursive$1
    memory.size
    i32.const 16
    i32.shl
@@ -1675,7 +1671,7 @@
     i32.const 8
     i32.add
     global.set $~lib/memory/__stack_pointer
-    br $__inlined_func$start:extends-recursive$4
+    br $__inlined_func$start:extends-recursive$1
    end
    i32.const 34256
    i32.const 34304

--- a/tests/compiler/field-initialization.debug.wat
+++ b/tests/compiler/field-initialization.debug.wat
@@ -2705,12 +2705,8 @@
   call $~lib/object/Object~visit
   local.get $0
   i32.load
-  local.tee $2
-  if
-   local.get $2
-   local.get $1
-   call $~lib/rt/itcms/__visit
-  end
+  local.get $1
+  call $~lib/rt/itcms/__visit
  )
  (func $~lib/object/Object~visit (param $0 i32) (param $1 i32)
  )
@@ -2721,12 +2717,8 @@
   call $~lib/object/Object~visit
   local.get $0
   i32.load
-  local.tee $2
-  if
-   local.get $2
-   local.get $1
-   call $~lib/rt/itcms/__visit
-  end
+  local.get $1
+  call $~lib/rt/itcms/__visit
  )
  (func $field-initialization/Nullable_Init~visit (param $0 i32) (param $1 i32)
   (local $2 i32)
@@ -2735,12 +2727,8 @@
   call $~lib/object/Object~visit
   local.get $0
   i32.load
-  local.tee $2
-  if
-   local.get $2
-   local.get $1
-   call $~lib/rt/itcms/__visit
-  end
+  local.get $1
+  call $~lib/rt/itcms/__visit
  )
  (func $field-initialization/Nullable~visit (param $0 i32) (param $1 i32)
   (local $2 i32)
@@ -2749,12 +2737,8 @@
   call $~lib/object/Object~visit
   local.get $0
   i32.load
-  local.tee $2
-  if
-   local.get $2
-   local.get $1
-   call $~lib/rt/itcms/__visit
-  end
+  local.get $1
+  call $~lib/rt/itcms/__visit
  )
  (func $field-initialization/Ref_Init_Ctor~visit (param $0 i32) (param $1 i32)
   (local $2 i32)
@@ -2763,12 +2747,8 @@
   call $~lib/object/Object~visit
   local.get $0
   i32.load
-  local.tee $2
-  if
-   local.get $2
-   local.get $1
-   call $~lib/rt/itcms/__visit
-  end
+  local.get $1
+  call $~lib/rt/itcms/__visit
  )
  (func $field-initialization/Ref_Ctor_Init~visit (param $0 i32) (param $1 i32)
   (local $2 i32)
@@ -2777,12 +2757,8 @@
   call $~lib/object/Object~visit
   local.get $0
   i32.load
-  local.tee $2
-  if
-   local.get $2
-   local.get $1
-   call $~lib/rt/itcms/__visit
-  end
+  local.get $1
+  call $~lib/rt/itcms/__visit
  )
  (func $field-initialization/Ref_Ctor_Param~visit (param $0 i32) (param $1 i32)
   (local $2 i32)
@@ -2791,12 +2767,8 @@
   call $~lib/object/Object~visit
   local.get $0
   i32.load
-  local.tee $2
-  if
-   local.get $2
-   local.get $1
-   call $~lib/rt/itcms/__visit
-  end
+  local.get $1
+  call $~lib/rt/itcms/__visit
  )
  (func $field-initialization/Nullable_Ctor~visit (param $0 i32) (param $1 i32)
   (local $2 i32)
@@ -2805,12 +2777,8 @@
   call $~lib/object/Object~visit
   local.get $0
   i32.load
-  local.tee $2
-  if
-   local.get $2
-   local.get $1
-   call $~lib/rt/itcms/__visit
-  end
+  local.get $1
+  call $~lib/rt/itcms/__visit
  )
  (func $field-initialization/Nullable_Init_Ctor~visit (param $0 i32) (param $1 i32)
   (local $2 i32)
@@ -2819,12 +2787,8 @@
   call $~lib/object/Object~visit
   local.get $0
   i32.load
-  local.tee $2
-  if
-   local.get $2
-   local.get $1
-   call $~lib/rt/itcms/__visit
-  end
+  local.get $1
+  call $~lib/rt/itcms/__visit
  )
  (func $field-initialization/Nullable_Ctor_Init~visit (param $0 i32) (param $1 i32)
   (local $2 i32)
@@ -2833,12 +2797,8 @@
   call $~lib/object/Object~visit
   local.get $0
   i32.load
-  local.tee $2
-  if
-   local.get $2
-   local.get $1
-   call $~lib/rt/itcms/__visit
-  end
+  local.get $1
+  call $~lib/rt/itcms/__visit
  )
  (func $field-initialization/Inherit~visit (param $0 i32) (param $1 i32)
   local.get $0
@@ -2852,12 +2812,8 @@
   call $~lib/object/Object~visit
   local.get $0
   i32.load
-  local.tee $2
-  if
-   local.get $2
-   local.get $1
-   call $~lib/rt/itcms/__visit
-  end
+  local.get $1
+  call $~lib/rt/itcms/__visit
  )
  (func $field-initialization/Inherit_Ctor~visit (param $0 i32) (param $1 i32)
   local.get $0
@@ -2871,12 +2827,8 @@
   call $~lib/object/Object~visit
   local.get $0
   i32.load offset=4
-  local.tee $2
-  if
-   local.get $2
-   local.get $1
-   call $~lib/rt/itcms/__visit
-  end
+  local.get $1
+  call $~lib/rt/itcms/__visit
  )
  (func $field-initialization/SomeOtherObject~visit (param $0 i32) (param $1 i32)
   (local $2 i32)
@@ -2885,12 +2837,8 @@
   call $field-initialization/SomeObject~visit
   local.get $0
   i32.load offset=8
-  local.tee $2
-  if
-   local.get $2
-   local.get $1
-   call $~lib/rt/itcms/__visit
-  end
+  local.get $1
+  call $~lib/rt/itcms/__visit
  )
  (func $field-initialization/Flow_Balanced~visit (param $0 i32) (param $1 i32)
   (local $2 i32)
@@ -2899,12 +2847,8 @@
   call $~lib/object/Object~visit
   local.get $0
   i32.load
-  local.tee $2
-  if
-   local.get $2
-   local.get $1
-   call $~lib/rt/itcms/__visit
-  end
+  local.get $1
+  call $~lib/rt/itcms/__visit
  )
  (func $field-initialization/Ref_Init_InlineCtor~visit (param $0 i32) (param $1 i32)
   (local $2 i32)
@@ -2913,12 +2857,8 @@
   call $~lib/object/Object~visit
   local.get $0
   i32.load
-  local.tee $2
-  if
-   local.get $2
-   local.get $1
-   call $~lib/rt/itcms/__visit
-  end
+  local.get $1
+  call $~lib/rt/itcms/__visit
  )
  (func $field-initialization/Ref_InlineCtor_Init~visit (param $0 i32) (param $1 i32)
   (local $2 i32)
@@ -2927,12 +2867,8 @@
   call $~lib/object/Object~visit
   local.get $0
   i32.load
-  local.tee $2
-  if
-   local.get $2
-   local.get $1
-   call $~lib/rt/itcms/__visit
-  end
+  local.get $1
+  call $~lib/rt/itcms/__visit
  )
  (func $~lib/rt/__visit_members (param $0 i32) (param $1 i32)
   block $invalid

--- a/tests/compiler/field-initialization.release.wat
+++ b/tests/compiler/field-initialization.release.wat
@@ -120,7 +120,7 @@
    local.get $1
    global.set $~lib/rt/itcms/iter
   end
-  block $__inlined_func$~lib/rt/itcms/Object#unlink$223
+  block $__inlined_func$~lib/rt/itcms/Object#unlink$241
    local.get $0
    i32.load offset=4
    i32.const -4
@@ -144,7 +144,7 @@
      call $~lib/builtins/abort
      unreachable
     end
-    br $__inlined_func$~lib/rt/itcms/Object#unlink$223
+    br $__inlined_func$~lib/rt/itcms/Object#unlink$241
    end
    local.get $0
    i32.load offset=8
@@ -1599,27 +1599,23 @@
   end
  )
  (func $~lib/rt/__visit_members (param $0 i32)
-  (local $1 i32)
-  block $folding-inner1
-   block $folding-inner0
-    block $invalid
-     block $field-initialization/SomeOtherObject
-      block $field-initialization/SomeObject
-       block $field-initialization/Value_Ctor_Init
-        block $field-initialization/Value_Init_Ctor
-         block $field-initialization/Value_Ctor
-          block $field-initialization/Value
-           block $field-initialization/Value_Init
-            block $~lib/string/String
-             block $~lib/arraybuffer/ArrayBuffer
-              block $~lib/object/Object
-               local.get $0
-               i32.const 8
-               i32.sub
-               i32.load
-               br_table $~lib/object/Object $~lib/arraybuffer/ArrayBuffer $~lib/string/String $folding-inner0 $field-initialization/Value_Init $field-initialization/Value $folding-inner0 $folding-inner0 $folding-inner0 $field-initialization/Value_Ctor $field-initialization/Value_Init_Ctor $field-initialization/Value_Ctor_Init $folding-inner0 $folding-inner0 $folding-inner0 $folding-inner0 $folding-inner0 $folding-inner0 $folding-inner1 $folding-inner0 $folding-inner1 $field-initialization/SomeObject $field-initialization/SomeOtherObject $folding-inner0 $folding-inner0 $folding-inner0 $invalid
-              end
-              return
+  block $folding-inner0
+   block $invalid
+    block $field-initialization/SomeOtherObject
+     block $field-initialization/SomeObject
+      block $field-initialization/Value_Ctor_Init
+       block $field-initialization/Value_Init_Ctor
+        block $field-initialization/Value_Ctor
+         block $field-initialization/Value
+          block $field-initialization/Value_Init
+           block $~lib/string/String
+            block $~lib/arraybuffer/ArrayBuffer
+             block $~lib/object/Object
+              local.get $0
+              i32.const 8
+              i32.sub
+              i32.load
+              br_table $~lib/object/Object $~lib/arraybuffer/ArrayBuffer $~lib/string/String $folding-inner0 $field-initialization/Value_Init $field-initialization/Value $folding-inner0 $folding-inner0 $folding-inner0 $field-initialization/Value_Ctor $field-initialization/Value_Init_Ctor $field-initialization/Value_Ctor_Init $folding-inner0 $folding-inner0 $folding-inner0 $folding-inner0 $folding-inner0 $folding-inner0 $folding-inner0 $folding-inner0 $folding-inner0 $field-initialization/SomeObject $field-initialization/SomeOtherObject $folding-inner0 $folding-inner0 $folding-inner0 $invalid
              end
              return
             end
@@ -1635,49 +1631,26 @@
        end
        return
       end
-      local.get $0
-      i32.load offset=4
-      local.tee $0
-      if
-       local.get $0
-       call $~lib/rt/itcms/__visit
-      end
       return
      end
      local.get $0
      i32.load offset=4
-     local.tee $1
-     if
-      local.get $1
-      call $~lib/rt/itcms/__visit
-     end
-     local.get $0
-     i32.load offset=8
-     local.tee $0
-     if
-      local.get $0
-      call $~lib/rt/itcms/__visit
-     end
+     call $~lib/rt/itcms/__visit
      return
     end
-    unreachable
-   end
-   local.get $0
-   i32.load
-   local.tee $0
-   if
     local.get $0
+    i32.load offset=4
     call $~lib/rt/itcms/__visit
+    local.get $0
+    i32.load offset=8
+    call $~lib/rt/itcms/__visit
+    return
    end
-   return
+   unreachable
   end
   local.get $0
   i32.load
-  local.tee $0
-  if
-   local.get $0
-   call $~lib/rt/itcms/__visit
-  end
+  call $~lib/rt/itcms/__visit
  )
  (func $~start
   call $start:field-initialization

--- a/tests/compiler/field.debug.wat
+++ b/tests/compiler/field.debug.wat
@@ -2422,12 +2422,8 @@
   call $~lib/object/Object~visit
   local.get $0
   i32.load
-  local.tee $2
-  if
-   local.get $2
-   local.get $1
-   call $~lib/rt/itcms/__visit
-  end
+  local.get $1
+  call $~lib/rt/itcms/__visit
  )
  (func $~lib/object/Object~visit (param $0 i32) (param $1 i32)
  )
@@ -2438,12 +2434,8 @@
   call $~lib/object/Object~visit
   local.get $0
   i32.load
-  local.tee $2
-  if
-   local.get $2
-   local.get $1
-   call $~lib/rt/itcms/__visit
-  end
+  local.get $1
+  call $~lib/rt/itcms/__visit
  )
  (func $~lib/array/Array<~lib/string/String>#get:dataStart (param $this i32) (result i32)
   local.get $this

--- a/tests/compiler/field.release.wat
+++ b/tests/compiler/field.release.wat
@@ -103,7 +103,7 @@
    local.get $1
    global.set $~lib/rt/itcms/iter
   end
-  block $__inlined_func$~lib/rt/itcms/Object#unlink$125
+  block $__inlined_func$~lib/rt/itcms/Object#unlink$127
    local.get $0
    i32.load offset=4
    i32.const -4
@@ -127,7 +127,7 @@
      call $~lib/builtins/abort
      unreachable
     end
-    br $__inlined_func$~lib/rt/itcms/Object#unlink$125
+    br $__inlined_func$~lib/rt/itcms/Object#unlink$127
    end
    local.get $0
    i32.load offset=8
@@ -1796,74 +1796,37 @@
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
-  block $folding-inner2
-   block $folding-inner1
-    block $folding-inner0
-     block $invalid
-      block $~lib/array/Array<i32>
-       block $~lib/array/Array<~lib/string/String>
-        block $~lib/string/String
-         block $~lib/arraybuffer/ArrayBuffer
-          block $~lib/object/Object
-           local.get $0
-           i32.const 8
-           i32.sub
-           i32.load
-           br_table $~lib/object/Object $~lib/arraybuffer/ArrayBuffer $~lib/string/String $folding-inner2 $folding-inner2 $~lib/array/Array<~lib/string/String> $~lib/array/Array<i32> $invalid
+  block $folding-inner1
+   block $folding-inner0
+    block $invalid
+     block $~lib/array/Array<i32>
+      block $~lib/array/Array<~lib/string/String>
+       block $field/NoStaticConflict
+        block $~lib/arraybuffer/ArrayBufferView
+         block $~lib/string/String
+          block $~lib/arraybuffer/ArrayBuffer
+           block $~lib/object/Object
+            local.get $0
+            i32.const 8
+            i32.sub
+            i32.load
+            br_table $~lib/object/Object $~lib/arraybuffer/ArrayBuffer $~lib/string/String $~lib/arraybuffer/ArrayBufferView $field/NoStaticConflict $~lib/array/Array<~lib/string/String> $~lib/array/Array<i32> $invalid
+           end
+           return
           end
           return
          end
          return
         end
+        local.get $0
+        i32.load
+        call $~lib/rt/itcms/__visit
         return
        end
-       global.get $~lib/memory/__stack_pointer
-       i32.const 4
-       i32.sub
-       global.set $~lib/memory/__stack_pointer
-       global.get $~lib/memory/__stack_pointer
-       i32.const 1504
-       i32.lt_s
-       br_if $folding-inner0
-       global.get $~lib/memory/__stack_pointer
-       i32.const 0
-       i32.store
-       global.get $~lib/memory/__stack_pointer
        local.get $0
-       i32.store
-       local.get $0
-       i32.load offset=4
-       local.set $1
-       global.get $~lib/memory/__stack_pointer
-       local.get $0
-       i32.store
-       local.get $1
-       local.get $0
-       i32.load offset=12
-       i32.const 2
-       i32.shl
-       i32.add
-       local.set $2
-       loop $while-continue|0
-        local.get $1
-        local.get $2
-        i32.lt_u
-        if
-         local.get $1
-         i32.load
-         local.tee $3
-         if
-          local.get $3
-          call $~lib/rt/itcms/__visit
-         end
-         local.get $1
-         i32.const 4
-         i32.add
-         local.set $1
-         br $while-continue|0
-        end
-       end
-       br $folding-inner1
+       i32.load
+       call $~lib/rt/itcms/__visit
+       return
       end
       global.get $~lib/memory/__stack_pointer
       i32.const 4
@@ -1876,36 +1839,75 @@
       global.get $~lib/memory/__stack_pointer
       i32.const 0
       i32.store
+      global.get $~lib/memory/__stack_pointer
+      local.get $0
+      i32.store
+      local.get $0
+      i32.load offset=4
+      local.set $1
+      global.get $~lib/memory/__stack_pointer
+      local.get $0
+      i32.store
+      local.get $1
+      local.get $0
+      i32.load offset=12
+      i32.const 2
+      i32.shl
+      i32.add
+      local.set $2
+      loop $while-continue|0
+       local.get $1
+       local.get $2
+       i32.lt_u
+       if
+        local.get $1
+        i32.load
+        local.tee $3
+        if
+         local.get $3
+         call $~lib/rt/itcms/__visit
+        end
+        local.get $1
+        i32.const 4
+        i32.add
+        local.set $1
+        br $while-continue|0
+       end
+      end
       br $folding-inner1
      end
-     unreachable
+     global.get $~lib/memory/__stack_pointer
+     i32.const 4
+     i32.sub
+     global.set $~lib/memory/__stack_pointer
+     global.get $~lib/memory/__stack_pointer
+     i32.const 1504
+     i32.lt_s
+     br_if $folding-inner0
+     global.get $~lib/memory/__stack_pointer
+     i32.const 0
+     i32.store
+     br $folding-inner1
     end
-    i32.const 34304
-    i32.const 34352
-    i32.const 1
-    i32.const 1
-    call $~lib/builtins/abort
     unreachable
    end
-   global.get $~lib/memory/__stack_pointer
-   local.get $0
-   i32.store
-   local.get $0
-   i32.load
-   call $~lib/rt/itcms/__visit
-   global.get $~lib/memory/__stack_pointer
-   i32.const 4
-   i32.add
-   global.set $~lib/memory/__stack_pointer
-   return
+   i32.const 34304
+   i32.const 34352
+   i32.const 1
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
   end
+  global.get $~lib/memory/__stack_pointer
+  local.get $0
+  i32.store
   local.get $0
   i32.load
-  local.tee $0
-  if
-   local.get $0
-   call $~lib/rt/itcms/__visit
-  end
+  call $~lib/rt/itcms/__visit
+  global.get $~lib/memory/__stack_pointer
+  i32.const 4
+  i32.add
+  global.set $~lib/memory/__stack_pointer
  )
  (func $~start
   call $start:field

--- a/tests/compiler/for.debug.wat
+++ b/tests/compiler/for.debug.wat
@@ -3031,12 +3031,8 @@
   call $~lib/object/Object~visit
   local.get $0
   i32.load
-  local.tee $2
-  if
-   local.get $2
-   local.get $1
-   call $~lib/rt/itcms/__visit
-  end
+  local.get $1
+  call $~lib/rt/itcms/__visit
  )
  (func $~lib/object/Object~visit (param $0 i32) (param $1 i32)
  )

--- a/tests/compiler/for.release.wat
+++ b/tests/compiler/for.release.wat
@@ -1832,11 +1832,7 @@
     end
     local.get $0
     i32.load
-    local.tee $0
-    if
-     local.get $0
-     call $~lib/rt/itcms/__visit
-    end
+    call $~lib/rt/itcms/__visit
     return
    end
    return

--- a/tests/compiler/function-call.debug.wat
+++ b/tests/compiler/function-call.debug.wat
@@ -2313,12 +2313,8 @@
   call $~lib/object/Object~visit
   local.get $0
   i32.load
-  local.tee $2
-  if
-   local.get $2
-   local.get $1
-   call $~lib/rt/itcms/__visit
-  end
+  local.get $1
+  call $~lib/rt/itcms/__visit
  )
  (func $~lib/object/Object~visit (param $0 i32) (param $1 i32)
  )

--- a/tests/compiler/function-call.release.wat
+++ b/tests/compiler/function-call.release.wat
@@ -1432,11 +1432,7 @@
      end
      local.get $0
      i32.load
-     local.tee $0
-     if
-      local.get $0
-      call $~lib/rt/itcms/__visit
-     end
+     call $~lib/rt/itcms/__visit
      return
     end
     return

--- a/tests/compiler/function-expression.debug.wat
+++ b/tests/compiler/function-expression.debug.wat
@@ -2580,12 +2580,8 @@
   call $~lib/object/Object~visit
   local.get $0
   i32.load
-  local.tee $2
-  if
-   local.get $2
-   local.get $1
-   call $~lib/rt/itcms/__visit
-  end
+  local.get $1
+  call $~lib/rt/itcms/__visit
  )
  (func $~lib/object/Object~visit (param $0 i32) (param $1 i32)
  )
@@ -2656,12 +2652,8 @@
   call $~lib/object/Object~visit
   local.get $0
   i32.load
-  local.tee $2
-  if
-   local.get $2
-   local.get $1
-   call $~lib/rt/itcms/__visit
-  end
+  local.get $1
+  call $~lib/rt/itcms/__visit
  )
  (func $~lib/rt/__visit_members (param $0 i32) (param $1 i32)
   block $invalid

--- a/tests/compiler/function-expression.release.wat
+++ b/tests/compiler/function-expression.release.wat
@@ -166,7 +166,7 @@
    local.get $1
    global.set $~lib/rt/itcms/iter
   end
-  block $__inlined_func$~lib/rt/itcms/Object#unlink$131
+  block $__inlined_func$~lib/rt/itcms/Object#unlink$133
    local.get $0
    i32.load offset=4
    i32.const -4
@@ -190,7 +190,7 @@
      call $~lib/builtins/abort
      unreachable
     end
-    br $__inlined_func$~lib/rt/itcms/Object#unlink$131
+    br $__inlined_func$~lib/rt/itcms/Object#unlink$133
    end
    local.get $0
    i32.load offset=8
@@ -1462,63 +1462,65 @@
   global.set $~lib/memory/__stack_pointer
  )
  (func $~lib/rt/__visit_members (param $0 i32)
-  block $folding-inner1
-   block $folding-inner0
-    block $invalid
-     block $~lib/string/String
-      block $~lib/arraybuffer/ArrayBuffer
-       block $~lib/object/Object
-        local.get $0
-        i32.const 8
-        i32.sub
-        i32.load
-        br_table $~lib/object/Object $~lib/arraybuffer/ArrayBuffer $~lib/string/String $folding-inner1 $folding-inner0 $folding-inner0 $folding-inner0 $folding-inner0 $folding-inner0 $folding-inner1 $invalid
+  block $folding-inner0
+   block $invalid
+    block $function-expression/FieldClass
+     block $~lib/arraybuffer/ArrayBufferView
+      block $~lib/string/String
+       block $~lib/arraybuffer/ArrayBuffer
+        block $~lib/object/Object
+         local.get $0
+         i32.const 8
+         i32.sub
+         i32.load
+         br_table $~lib/object/Object $~lib/arraybuffer/ArrayBuffer $~lib/string/String $~lib/arraybuffer/ArrayBufferView $folding-inner0 $folding-inner0 $folding-inner0 $folding-inner0 $folding-inner0 $function-expression/FieldClass $invalid
+        end
+        return
        end
        return
       end
       return
      end
+     local.get $0
+     i32.load
+     call $~lib/rt/itcms/__visit
      return
     end
-    unreachable
+    local.get $0
+    i32.load
+    call $~lib/rt/itcms/__visit
+    return
    end
-   global.get $~lib/memory/__stack_pointer
-   i32.const 4
-   i32.sub
-   global.set $~lib/memory/__stack_pointer
-   global.get $~lib/memory/__stack_pointer
-   i32.const 2156
-   i32.lt_s
-   if
-    i32.const 34944
-    i32.const 34992
-    i32.const 1
-    i32.const 1
-    call $~lib/builtins/abort
-    unreachable
-   end
-   global.get $~lib/memory/__stack_pointer
-   i32.const 0
-   i32.store
-   global.get $~lib/memory/__stack_pointer
-   local.get $0
-   i32.store
-   local.get $0
-   i32.load offset=4
-   call $~lib/rt/itcms/__visit
-   global.get $~lib/memory/__stack_pointer
-   i32.const 4
-   i32.add
-   global.set $~lib/memory/__stack_pointer
-   return
+   unreachable
   end
-  local.get $0
-  i32.load
-  local.tee $0
+  global.get $~lib/memory/__stack_pointer
+  i32.const 4
+  i32.sub
+  global.set $~lib/memory/__stack_pointer
+  global.get $~lib/memory/__stack_pointer
+  i32.const 2156
+  i32.lt_s
   if
-   local.get $0
-   call $~lib/rt/itcms/__visit
+   i32.const 34944
+   i32.const 34992
+   i32.const 1
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
   end
+  global.get $~lib/memory/__stack_pointer
+  i32.const 0
+  i32.store
+  global.get $~lib/memory/__stack_pointer
+  local.get $0
+  i32.store
+  local.get $0
+  i32.load offset=4
+  call $~lib/rt/itcms/__visit
+  global.get $~lib/memory/__stack_pointer
+  i32.const 4
+  i32.add
+  global.set $~lib/memory/__stack_pointer
  )
  (func $~start
   call $start:function-expression

--- a/tests/compiler/getter-call.debug.wat
+++ b/tests/compiler/getter-call.debug.wat
@@ -2267,12 +2267,8 @@
   call $~lib/object/Object~visit
   local.get $0
   i32.load
-  local.tee $2
-  if
-   local.get $2
-   local.get $1
-   call $~lib/rt/itcms/__visit
-  end
+  local.get $1
+  call $~lib/rt/itcms/__visit
  )
  (func $~lib/object/Object~visit (param $0 i32) (param $1 i32)
  )

--- a/tests/compiler/getter-call.release.wat
+++ b/tests/compiler/getter-call.release.wat
@@ -1395,11 +1395,7 @@
      end
      local.get $0
      i32.load
-     local.tee $0
-     if
-      local.get $0
-      call $~lib/rt/itcms/__visit
-     end
+     call $~lib/rt/itcms/__visit
      return
     end
     return

--- a/tests/compiler/incremental-gc/call-indirect.debug.wat
+++ b/tests/compiler/incremental-gc/call-indirect.debug.wat
@@ -2356,12 +2356,8 @@
   call $~lib/object/Object~visit
   local.get $0
   i32.load
-  local.tee $2
-  if
-   local.get $2
-   local.get $1
-   call $~lib/rt/itcms/__visit
-  end
+  local.get $1
+  call $~lib/rt/itcms/__visit
  )
  (func $~lib/object/Object~visit (param $0 i32) (param $1 i32)
  )

--- a/tests/compiler/incremental-gc/call-indirect.release.wat
+++ b/tests/compiler/incremental-gc/call-indirect.release.wat
@@ -1551,11 +1551,7 @@
       end
       local.get $0
       i32.load
-      local.tee $0
-      if
-       local.get $0
-       call $~lib/rt/itcms/__visit
-      end
+      call $~lib/rt/itcms/__visit
       return
      end
      return

--- a/tests/compiler/infer-array.debug.wat
+++ b/tests/compiler/infer-array.debug.wat
@@ -2501,12 +2501,8 @@
   call $~lib/object/Object~visit
   local.get $0
   i32.load
-  local.tee $2
-  if
-   local.get $2
-   local.get $1
-   call $~lib/rt/itcms/__visit
-  end
+  local.get $1
+  call $~lib/rt/itcms/__visit
  )
  (func $~lib/object/Object~visit (param $0 i32) (param $1 i32)
  )

--- a/tests/compiler/infer-array.release.wat
+++ b/tests/compiler/infer-array.release.wat
@@ -1652,11 +1652,7 @@
        end
        local.get $0
        i32.load
-       local.tee $0
-       if
-        local.get $0
-        call $~lib/rt/itcms/__visit
-       end
+       call $~lib/rt/itcms/__visit
        return
       end
       return

--- a/tests/compiler/infer-generic.debug.wat
+++ b/tests/compiler/infer-generic.debug.wat
@@ -2346,12 +2346,8 @@
   call $~lib/object/Object~visit
   local.get $0
   i32.load
-  local.tee $2
-  if
-   local.get $2
-   local.get $1
-   call $~lib/rt/itcms/__visit
-  end
+  local.get $1
+  call $~lib/rt/itcms/__visit
  )
  (func $~lib/object/Object~visit (param $0 i32) (param $1 i32)
  )

--- a/tests/compiler/infer-generic.release.wat
+++ b/tests/compiler/infer-generic.release.wat
@@ -1576,11 +1576,7 @@
        end
        local.get $0
        i32.load
-       local.tee $0
-       if
-        local.get $0
-        call $~lib/rt/itcms/__visit
-       end
+       call $~lib/rt/itcms/__visit
        return
       end
       global.get $~lib/memory/__stack_pointer

--- a/tests/compiler/inlining.debug.wat
+++ b/tests/compiler/inlining.debug.wat
@@ -2779,12 +2779,8 @@
   call $~lib/object/Object~visit
   local.get $0
   i32.load
-  local.tee $2
-  if
-   local.get $2
-   local.get $1
-   call $~lib/rt/itcms/__visit
-  end
+  local.get $1
+  call $~lib/rt/itcms/__visit
  )
  (func $~lib/object/Object~visit (param $0 i32) (param $1 i32)
  )

--- a/tests/compiler/inlining.release.wat
+++ b/tests/compiler/inlining.release.wat
@@ -1930,11 +1930,7 @@
        end
        local.get $0
        i32.load
-       local.tee $0
-       if
-        local.get $0
-        call $~lib/rt/itcms/__visit
-       end
+       call $~lib/rt/itcms/__visit
        return
       end
       global.get $~lib/memory/__stack_pointer

--- a/tests/compiler/instanceof.debug.wat
+++ b/tests/compiler/instanceof.debug.wat
@@ -4592,12 +4592,8 @@
   call $~lib/object/Object~visit
   local.get $0
   i32.load
-  local.tee $2
-  if
-   local.get $2
-   local.get $1
-   call $~lib/rt/itcms/__visit
-  end
+  local.get $1
+  call $~lib/rt/itcms/__visit
  )
  (func $~lib/object/Object~visit (param $0 i32) (param $1 i32)
  )

--- a/tests/compiler/instanceof.release.wat
+++ b/tests/compiler/instanceof.release.wat
@@ -1781,11 +1781,7 @@
                        end
                        local.get $0
                        i32.load
-                       local.tee $0
-                       if
-                        local.get $0
-                        call $~lib/rt/itcms/__visit
-                       end
+                       call $~lib/rt/itcms/__visit
                        return
                       end
                       return

--- a/tests/compiler/issues/1095.debug.wat
+++ b/tests/compiler/issues/1095.debug.wat
@@ -2341,12 +2341,8 @@
   call $~lib/object/Object~visit
   local.get $0
   i32.load
-  local.tee $2
-  if
-   local.get $2
-   local.get $1
-   call $~lib/rt/itcms/__visit
-  end
+  local.get $1
+  call $~lib/rt/itcms/__visit
  )
  (func $~lib/object/Object~visit (param $0 i32) (param $1 i32)
  )
@@ -2357,12 +2353,8 @@
   call $~lib/object/Object~visit
   local.get $0
   i32.load
-  local.tee $2
-  if
-   local.get $2
-   local.get $1
-   call $~lib/rt/itcms/__visit
-  end
+  local.get $1
+  call $~lib/rt/itcms/__visit
  )
  (func $~lib/rt/__visit_members (param $0 i32) (param $1 i32)
   block $invalid

--- a/tests/compiler/issues/1095.release.wat
+++ b/tests/compiler/issues/1095.release.wat
@@ -106,7 +106,7 @@
    local.get $1
    global.set $~lib/rt/itcms/iter
   end
-  block $__inlined_func$~lib/rt/itcms/Object#unlink$115
+  block $__inlined_func$~lib/rt/itcms/Object#unlink$117
    local.get $0
    i32.load offset=4
    i32.const -4
@@ -130,7 +130,7 @@
      call $~lib/builtins/abort
      unreachable
     end
-    br $__inlined_func$~lib/rt/itcms/Object#unlink$115
+    br $__inlined_func$~lib/rt/itcms/Object#unlink$117
    end
    local.get $0
    i32.load offset=8
@@ -1586,32 +1586,35 @@
   end
  )
  (func $~lib/rt/__visit_members (param $0 i32)
-  block $folding-inner0
-   block $invalid
-    block $~lib/string/String
-     block $~lib/arraybuffer/ArrayBuffer
-      block $~lib/object/Object
-       local.get $0
-       i32.const 8
-       i32.sub
-       i32.load
-       br_table $~lib/object/Object $~lib/arraybuffer/ArrayBuffer $~lib/string/String $folding-inner0 $folding-inner0 $invalid
+  block $invalid
+   block $issues/1095/Foo
+    block $~lib/arraybuffer/ArrayBufferView
+     block $~lib/string/String
+      block $~lib/arraybuffer/ArrayBuffer
+       block $~lib/object/Object
+        local.get $0
+        i32.const 8
+        i32.sub
+        i32.load
+        br_table $~lib/object/Object $~lib/arraybuffer/ArrayBuffer $~lib/string/String $~lib/arraybuffer/ArrayBufferView $issues/1095/Foo $invalid
+       end
+       return
       end
       return
      end
      return
     end
+    local.get $0
+    i32.load
+    call $~lib/rt/itcms/__visit
     return
    end
-   unreachable
-  end
-  local.get $0
-  i32.load
-  local.tee $0
-  if
    local.get $0
+   i32.load
    call $~lib/rt/itcms/__visit
+   return
   end
+  unreachable
  )
  (func $~start
   (local $0 i32)

--- a/tests/compiler/issues/1225.debug.wat
+++ b/tests/compiler/issues/1225.debug.wat
@@ -2391,12 +2391,8 @@
   call $~lib/object/Object~visit
   local.get $0
   i32.load
-  local.tee $2
-  if
-   local.get $2
-   local.get $1
-   call $~lib/rt/itcms/__visit
-  end
+  local.get $1
+  call $~lib/rt/itcms/__visit
  )
  (func $~lib/object/Object~visit (param $0 i32) (param $1 i32)
  )

--- a/tests/compiler/issues/1225.release.wat
+++ b/tests/compiler/issues/1225.release.wat
@@ -1397,11 +1397,7 @@
     end
     local.get $0
     i32.load
-    local.tee $0
-    if
-     local.get $0
-     call $~lib/rt/itcms/__visit
-    end
+    call $~lib/rt/itcms/__visit
     return
    end
    return

--- a/tests/compiler/issues/1699.debug.wat
+++ b/tests/compiler/issues/1699.debug.wat
@@ -2451,12 +2451,8 @@
   call $~lib/object/Object~visit
   local.get $0
   i32.load
-  local.tee $2
-  if
-   local.get $2
-   local.get $1
-   call $~lib/rt/itcms/__visit
-  end
+  local.get $1
+  call $~lib/rt/itcms/__visit
  )
  (func $~lib/object/Object~visit (param $0 i32) (param $1 i32)
  )

--- a/tests/compiler/issues/1699.release.wat
+++ b/tests/compiler/issues/1699.release.wat
@@ -1908,11 +1908,7 @@
      end
      local.get $0
      i32.load
-     local.tee $0
-     if
-      local.get $0
-      call $~lib/rt/itcms/__visit
-     end
+     call $~lib/rt/itcms/__visit
      return
     end
     return

--- a/tests/compiler/issues/2166.debug.wat
+++ b/tests/compiler/issues/2166.debug.wat
@@ -2381,12 +2381,8 @@
   call $~lib/object/Object~visit
   local.get $0
   i32.load
-  local.tee $2
-  if
-   local.get $2
-   local.get $1
-   call $~lib/rt/itcms/__visit
-  end
+  local.get $1
+  call $~lib/rt/itcms/__visit
  )
  (func $~lib/object/Object~visit (param $0 i32) (param $1 i32)
  )

--- a/tests/compiler/issues/2166.release.wat
+++ b/tests/compiler/issues/2166.release.wat
@@ -1398,11 +1398,7 @@
      end
      local.get $0
      i32.load
-     local.tee $0
-     if
-      local.get $0
-      call $~lib/rt/itcms/__visit
-     end
+     call $~lib/rt/itcms/__visit
      return
     end
     return

--- a/tests/compiler/issues/2322/index.debug.wat
+++ b/tests/compiler/issues/2322/index.debug.wat
@@ -2265,12 +2265,8 @@
   call $~lib/object/Object~visit
   local.get $0
   i32.load
-  local.tee $2
-  if
-   local.get $2
-   local.get $1
-   call $~lib/rt/itcms/__visit
-  end
+  local.get $1
+  call $~lib/rt/itcms/__visit
  )
  (func $~lib/object/Object~visit (param $0 i32) (param $1 i32)
  )

--- a/tests/compiler/issues/2322/index.release.wat
+++ b/tests/compiler/issues/2322/index.release.wat
@@ -1542,11 +1542,7 @@
     end
     local.get $0
     i32.load
-    local.tee $0
-    if
-     local.get $0
-     call $~lib/rt/itcms/__visit
-    end
+    call $~lib/rt/itcms/__visit
     return
    end
    return

--- a/tests/compiler/issues/2622.debug.wat
+++ b/tests/compiler/issues/2622.debug.wat
@@ -2335,12 +2335,8 @@
   call $~lib/object/Object~visit
   local.get $0
   i32.load
-  local.tee $2
-  if
-   local.get $2
-   local.get $1
-   call $~lib/rt/itcms/__visit
-  end
+  local.get $1
+  call $~lib/rt/itcms/__visit
  )
  (func $~lib/object/Object~visit (param $0 i32) (param $1 i32)
  )

--- a/tests/compiler/issues/2622.release.wat
+++ b/tests/compiler/issues/2622.release.wat
@@ -1427,11 +1427,7 @@
      end
      local.get $0
      i32.load
-     local.tee $0
-     if
-      local.get $0
-      call $~lib/rt/itcms/__visit
-     end
+     call $~lib/rt/itcms/__visit
      return
     end
     return

--- a/tests/compiler/issues/2707.debug.wat
+++ b/tests/compiler/issues/2707.debug.wat
@@ -2351,12 +2351,8 @@
   call $~lib/object/Object~visit
   local.get $0
   i32.load
-  local.tee $2
-  if
-   local.get $2
-   local.get $1
-   call $~lib/rt/itcms/__visit
-  end
+  local.get $1
+  call $~lib/rt/itcms/__visit
  )
  (func $~lib/object/Object~visit (param $0 i32) (param $1 i32)
  )

--- a/tests/compiler/issues/2707.release.wat
+++ b/tests/compiler/issues/2707.release.wat
@@ -1403,11 +1403,7 @@
       end
       local.get $0
       i32.load
-      local.tee $0
-      if
-       local.get $0
-       call $~lib/rt/itcms/__visit
-      end
+      call $~lib/rt/itcms/__visit
       return
      end
      global.get $~lib/memory/__stack_pointer

--- a/tests/compiler/issues/2873.debug.wat
+++ b/tests/compiler/issues/2873.debug.wat
@@ -4189,12 +4189,8 @@
   call $~lib/object/Object~visit
   local.get $0
   i32.load
-  local.tee $2
-  if
-   local.get $2
-   local.get $1
-   call $~lib/rt/itcms/__visit
-  end
+  local.get $1
+  call $~lib/rt/itcms/__visit
  )
  (func $~lib/object/Object~visit (param $0 i32) (param $1 i32)
  )

--- a/tests/compiler/issues/2873.release.wat
+++ b/tests/compiler/issues/2873.release.wat
@@ -2941,11 +2941,7 @@
      end
      local.get $0
      i32.load
-     local.tee $0
-     if
-      local.get $0
-      call $~lib/rt/itcms/__visit
-     end
+     call $~lib/rt/itcms/__visit
      return
     end
     local.get $0

--- a/tests/compiler/logical.debug.wat
+++ b/tests/compiler/logical.debug.wat
@@ -2337,12 +2337,8 @@
   call $~lib/object/Object~visit
   local.get $0
   i32.load
-  local.tee $2
-  if
-   local.get $2
-   local.get $1
-   call $~lib/rt/itcms/__visit
-  end
+  local.get $1
+  call $~lib/rt/itcms/__visit
  )
  (func $~lib/object/Object~visit (param $0 i32) (param $1 i32)
  )

--- a/tests/compiler/logical.release.wat
+++ b/tests/compiler/logical.release.wat
@@ -1405,11 +1405,7 @@
        end
        local.get $0
        i32.load
-       local.tee $0
-       if
-        local.get $0
-        call $~lib/rt/itcms/__visit
-       end
+       call $~lib/rt/itcms/__visit
        return
       end
       return

--- a/tests/compiler/managed-cast.debug.wat
+++ b/tests/compiler/managed-cast.debug.wat
@@ -2327,12 +2327,8 @@
   call $~lib/object/Object~visit
   local.get $0
   i32.load
-  local.tee $2
-  if
-   local.get $2
-   local.get $1
-   call $~lib/rt/itcms/__visit
-  end
+  local.get $1
+  call $~lib/rt/itcms/__visit
  )
  (func $~lib/object/Object~visit (param $0 i32) (param $1 i32)
  )

--- a/tests/compiler/managed-cast.release.wat
+++ b/tests/compiler/managed-cast.release.wat
@@ -1393,11 +1393,7 @@
      end
      local.get $0
      i32.load
-     local.tee $0
-     if
-      local.get $0
-      call $~lib/rt/itcms/__visit
-     end
+     call $~lib/rt/itcms/__visit
      return
     end
     return

--- a/tests/compiler/new.debug.wat
+++ b/tests/compiler/new.debug.wat
@@ -2317,12 +2317,8 @@
   call $~lib/object/Object~visit
   local.get $0
   i32.load
-  local.tee $2
-  if
-   local.get $2
-   local.get $1
-   call $~lib/rt/itcms/__visit
-  end
+  local.get $1
+  call $~lib/rt/itcms/__visit
  )
  (func $~lib/object/Object~visit (param $0 i32) (param $1 i32)
  )

--- a/tests/compiler/new.release.wat
+++ b/tests/compiler/new.release.wat
@@ -1431,11 +1431,7 @@
        end
        local.get $0
        i32.load
-       local.tee $0
-       if
-        local.get $0
-        call $~lib/rt/itcms/__visit
-       end
+       call $~lib/rt/itcms/__visit
        return
       end
       return

--- a/tests/compiler/object-literal.debug.wat
+++ b/tests/compiler/object-literal.debug.wat
@@ -2839,12 +2839,8 @@
   call $~lib/object/Object~visit
   local.get $0
   i32.load
-  local.tee $2
-  if
-   local.get $2
-   local.get $1
-   call $~lib/rt/itcms/__visit
-  end
+  local.get $1
+  call $~lib/rt/itcms/__visit
  )
  (func $~lib/object/Object~visit (param $0 i32) (param $1 i32)
  )
@@ -2855,12 +2851,8 @@
   call $~lib/object/Object~visit
   local.get $0
   i32.load offset=4
-  local.tee $2
-  if
-   local.get $2
-   local.get $1
-   call $~lib/rt/itcms/__visit
-  end
+  local.get $1
+  call $~lib/rt/itcms/__visit
  )
  (func $object-literal/MixedOmitted~visit (param $0 i32) (param $1 i32)
   (local $2 i32)
@@ -2869,12 +2861,8 @@
   call $~lib/object/Object~visit
   local.get $0
   i32.load offset=4
-  local.tee $2
-  if
-   local.get $2
-   local.get $1
-   call $~lib/rt/itcms/__visit
-  end
+  local.get $1
+  call $~lib/rt/itcms/__visit
  )
  (func $object-literal/OmittedFoo~visit (param $0 i32) (param $1 i32)
   (local $2 i32)
@@ -2883,68 +2871,36 @@
   call $~lib/object/Object~visit
   local.get $0
   i32.load
-  local.tee $2
-  if
-   local.get $2
-   local.get $1
-   call $~lib/rt/itcms/__visit
-  end
+  local.get $1
+  call $~lib/rt/itcms/__visit
   local.get $0
   i32.load offset=4
-  local.tee $2
-  if
-   local.get $2
-   local.get $1
-   call $~lib/rt/itcms/__visit
-  end
+  local.get $1
+  call $~lib/rt/itcms/__visit
   local.get $0
   i32.load offset=8
-  local.tee $2
-  if
-   local.get $2
-   local.get $1
-   call $~lib/rt/itcms/__visit
-  end
+  local.get $1
+  call $~lib/rt/itcms/__visit
   local.get $0
   i32.load offset=12
-  local.tee $2
-  if
-   local.get $2
-   local.get $1
-   call $~lib/rt/itcms/__visit
-  end
+  local.get $1
+  call $~lib/rt/itcms/__visit
   local.get $0
   i32.load offset=16
-  local.tee $2
-  if
-   local.get $2
-   local.get $1
-   call $~lib/rt/itcms/__visit
-  end
+  local.get $1
+  call $~lib/rt/itcms/__visit
   local.get $0
   i32.load offset=20
-  local.tee $2
-  if
-   local.get $2
-   local.get $1
-   call $~lib/rt/itcms/__visit
-  end
+  local.get $1
+  call $~lib/rt/itcms/__visit
   local.get $0
   i32.load offset=24
-  local.tee $2
-  if
-   local.get $2
-   local.get $1
-   call $~lib/rt/itcms/__visit
-  end
+  local.get $1
+  call $~lib/rt/itcms/__visit
   local.get $0
   i32.load offset=28
-  local.tee $2
-  if
-   local.get $2
-   local.get $1
-   call $~lib/rt/itcms/__visit
-  end
+  local.get $1
+  call $~lib/rt/itcms/__visit
  )
  (func $~lib/rt/__visit_members (param $0 i32) (param $1 i32)
   block $invalid

--- a/tests/compiler/object-literal.release.wat
+++ b/tests/compiler/object-literal.release.wat
@@ -71,7 +71,7 @@
    local.get $1
    global.set $~lib/rt/itcms/iter
   end
-  block $__inlined_func$~lib/rt/itcms/Object#unlink$203
+  block $__inlined_func$~lib/rt/itcms/Object#unlink$205
    local.get $0
    i32.load offset=4
    i32.const -4
@@ -95,7 +95,7 @@
      call $~lib/builtins/abort
      unreachable
     end
-    br $__inlined_func$~lib/rt/itcms/Object#unlink$203
+    br $__inlined_func$~lib/rt/itcms/Object#unlink$205
    end
    local.get $0
    i32.load offset=8
@@ -1604,105 +1604,71 @@
   local.get $1
  )
  (func $~lib/rt/__visit_members (param $0 i32)
-  (local $1 i32)
-  block $folding-inner0
-   block $invalid
-    block $object-literal/OmittedFoo
+  block $invalid
+   block $object-literal/OmittedFoo
+    block $object-literal/MixedOmitted
      block $object-literal/OmittedTypes
-      block $~lib/arraybuffer/ArrayBufferView
-       block $~lib/string/String
-        block $~lib/arraybuffer/ArrayBuffer
-         block $~lib/object/Object
-          local.get $0
-          i32.const 8
-          i32.sub
-          i32.load
-          br_table $~lib/object/Object $~lib/arraybuffer/ArrayBuffer $~lib/string/String $~lib/arraybuffer/ArrayBufferView $folding-inner0 $object-literal/OmittedTypes $folding-inner0 $object-literal/OmittedFoo $invalid
+      block $object-literal/Managed
+       block $~lib/arraybuffer/ArrayBufferView
+        block $~lib/string/String
+         block $~lib/arraybuffer/ArrayBuffer
+          block $~lib/object/Object
+           local.get $0
+           i32.const 8
+           i32.sub
+           i32.load
+           br_table $~lib/object/Object $~lib/arraybuffer/ArrayBuffer $~lib/string/String $~lib/arraybuffer/ArrayBufferView $object-literal/Managed $object-literal/OmittedTypes $object-literal/MixedOmitted $object-literal/OmittedFoo $invalid
+          end
+          return
          end
          return
         end
         return
        end
+       local.get $0
+       i32.load
+       call $~lib/rt/itcms/__visit
        return
       end
       local.get $0
-      i32.load
-      local.tee $0
-      if
-       local.get $0
-       call $~lib/rt/itcms/__visit
-      end
+      i32.load offset=4
+      call $~lib/rt/itcms/__visit
       return
      end
      return
     end
     local.get $0
-    i32.load
-    local.tee $1
-    if
-     local.get $1
-     call $~lib/rt/itcms/__visit
-    end
-    local.get $0
     i32.load offset=4
-    local.tee $1
-    if
-     local.get $1
-     call $~lib/rt/itcms/__visit
-    end
-    local.get $0
-    i32.load offset=8
-    local.tee $1
-    if
-     local.get $1
-     call $~lib/rt/itcms/__visit
-    end
-    local.get $0
-    i32.load offset=12
-    local.tee $1
-    if
-     local.get $1
-     call $~lib/rt/itcms/__visit
-    end
-    local.get $0
-    i32.load offset=16
-    local.tee $1
-    if
-     local.get $1
-     call $~lib/rt/itcms/__visit
-    end
-    local.get $0
-    i32.load offset=20
-    local.tee $1
-    if
-     local.get $1
-     call $~lib/rt/itcms/__visit
-    end
-    local.get $0
-    i32.load offset=24
-    local.tee $1
-    if
-     local.get $1
-     call $~lib/rt/itcms/__visit
-    end
-    local.get $0
-    i32.load offset=28
-    local.tee $0
-    if
-     local.get $0
-     call $~lib/rt/itcms/__visit
-    end
+    call $~lib/rt/itcms/__visit
     return
    end
-   unreachable
-  end
-  local.get $0
-  i32.load offset=4
-  local.tee $0
-  if
    local.get $0
+   i32.load
    call $~lib/rt/itcms/__visit
+   local.get $0
+   i32.load offset=4
+   call $~lib/rt/itcms/__visit
+   local.get $0
+   i32.load offset=8
+   call $~lib/rt/itcms/__visit
+   local.get $0
+   i32.load offset=12
+   call $~lib/rt/itcms/__visit
+   local.get $0
+   i32.load offset=16
+   call $~lib/rt/itcms/__visit
+   local.get $0
+   i32.load offset=20
+   call $~lib/rt/itcms/__visit
+   local.get $0
+   i32.load offset=24
+   call $~lib/rt/itcms/__visit
+   local.get $0
+   i32.load offset=28
+   call $~lib/rt/itcms/__visit
+   return
   end
+  unreachable
  )
  (func $~start
   call $start:object-literal
@@ -2537,7 +2503,7 @@
    i32.const 1
    i32.shl
    local.set $3
-   block $__inlined_func$~lib/string/String#substring$208
+   block $__inlined_func$~lib/string/String#substring$210
     local.get $2
     i32.const 0
     local.get $2
@@ -2558,7 +2524,7 @@
      global.set $~lib/memory/__stack_pointer
      i32.const 1568
      local.set $0
-     br $__inlined_func$~lib/string/String#substring$208
+     br $__inlined_func$~lib/string/String#substring$210
     end
     local.get $3
     i32.eqz
@@ -2575,7 +2541,7 @@
      global.set $~lib/memory/__stack_pointer
      i32.const 1056
      local.set $0
-     br $__inlined_func$~lib/string/String#substring$208
+     br $__inlined_func$~lib/string/String#substring$210
     end
     global.get $~lib/memory/__stack_pointer
     local.get $2

--- a/tests/compiler/operator-overload-non-ambiguity.debug.wat
+++ b/tests/compiler/operator-overload-non-ambiguity.debug.wat
@@ -2278,12 +2278,8 @@
   call $~lib/object/Object~visit
   local.get $0
   i32.load
-  local.tee $2
-  if
-   local.get $2
-   local.get $1
-   call $~lib/rt/itcms/__visit
-  end
+  local.get $1
+  call $~lib/rt/itcms/__visit
  )
  (func $~lib/object/Object~visit (param $0 i32) (param $1 i32)
  )

--- a/tests/compiler/operator-overload-non-ambiguity.release.wat
+++ b/tests/compiler/operator-overload-non-ambiguity.release.wat
@@ -1391,11 +1391,7 @@
        end
        local.get $0
        i32.load
-       local.tee $0
-       if
-        local.get $0
-        call $~lib/rt/itcms/__visit
-       end
+       call $~lib/rt/itcms/__visit
        return
       end
       return

--- a/tests/compiler/optional-typeparameters.debug.wat
+++ b/tests/compiler/optional-typeparameters.debug.wat
@@ -2317,12 +2317,8 @@
   call $~lib/object/Object~visit
   local.get $0
   i32.load
-  local.tee $2
-  if
-   local.get $2
-   local.get $1
-   call $~lib/rt/itcms/__visit
-  end
+  local.get $1
+  call $~lib/rt/itcms/__visit
  )
  (func $~lib/object/Object~visit (param $0 i32) (param $1 i32)
  )

--- a/tests/compiler/optional-typeparameters.release.wat
+++ b/tests/compiler/optional-typeparameters.release.wat
@@ -1421,11 +1421,7 @@
         end
         local.get $0
         i32.load
-        local.tee $0
-        if
-         local.get $0
-         call $~lib/rt/itcms/__visit
-        end
+        call $~lib/rt/itcms/__visit
         return
        end
        return

--- a/tests/compiler/reexport.debug.wat
+++ b/tests/compiler/reexport.debug.wat
@@ -2323,12 +2323,8 @@
   call $~lib/object/Object~visit
   local.get $0
   i32.load
-  local.tee $2
-  if
-   local.get $2
-   local.get $1
-   call $~lib/rt/itcms/__visit
-  end
+  local.get $1
+  call $~lib/rt/itcms/__visit
  )
  (func $~lib/object/Object~visit (param $0 i32) (param $1 i32)
  )

--- a/tests/compiler/reexport.release.wat
+++ b/tests/compiler/reexport.release.wat
@@ -1427,11 +1427,7 @@
     end
     local.get $0
     i32.load
-    local.tee $0
-    if
-     local.get $0
-     call $~lib/rt/itcms/__visit
-    end
+    call $~lib/rt/itcms/__visit
     return
    end
    return

--- a/tests/compiler/rereexport.debug.wat
+++ b/tests/compiler/rereexport.debug.wat
@@ -2324,12 +2324,8 @@
   call $~lib/object/Object~visit
   local.get $0
   i32.load
-  local.tee $2
-  if
-   local.get $2
-   local.get $1
-   call $~lib/rt/itcms/__visit
-  end
+  local.get $1
+  call $~lib/rt/itcms/__visit
  )
  (func $~lib/object/Object~visit (param $0 i32) (param $1 i32)
  )

--- a/tests/compiler/rereexport.release.wat
+++ b/tests/compiler/rereexport.release.wat
@@ -1420,11 +1420,7 @@
     end
     local.get $0
     i32.load
-    local.tee $0
-    if
-     local.get $0
-     call $~lib/rt/itcms/__visit
-    end
+    call $~lib/rt/itcms/__visit
     return
    end
    return

--- a/tests/compiler/resolve-access.debug.wat
+++ b/tests/compiler/resolve-access.debug.wat
@@ -2987,12 +2987,8 @@
   call $~lib/object/Object~visit
   local.get $0
   i32.load
-  local.tee $2
-  if
-   local.get $2
-   local.get $1
-   call $~lib/rt/itcms/__visit
-  end
+  local.get $1
+  call $~lib/rt/itcms/__visit
  )
  (func $~lib/object/Object~visit (param $0 i32) (param $1 i32)
  )

--- a/tests/compiler/resolve-access.release.wat
+++ b/tests/compiler/resolve-access.release.wat
@@ -1955,11 +1955,7 @@
       end
       local.get $0
       i32.load
-      local.tee $0
-      if
-       local.get $0
-       call $~lib/rt/itcms/__visit
-      end
+      call $~lib/rt/itcms/__visit
       return
      end
      local.get $0

--- a/tests/compiler/resolve-binary.debug.wat
+++ b/tests/compiler/resolve-binary.debug.wat
@@ -5607,12 +5607,8 @@
   call $~lib/object/Object~visit
   local.get $0
   i32.load
-  local.tee $2
-  if
-   local.get $2
-   local.get $1
-   call $~lib/rt/itcms/__visit
-  end
+  local.get $1
+  call $~lib/rt/itcms/__visit
  )
  (func $~lib/object/Object~visit (param $0 i32) (param $1 i32)
  )

--- a/tests/compiler/resolve-binary.release.wat
+++ b/tests/compiler/resolve-binary.release.wat
@@ -2894,11 +2894,7 @@
       end
       local.get $0
       i32.load
-      local.tee $0
-      if
-       local.get $0
-       call $~lib/rt/itcms/__visit
-      end
+      call $~lib/rt/itcms/__visit
       return
      end
      return

--- a/tests/compiler/resolve-elementaccess.debug.wat
+++ b/tests/compiler/resolve-elementaccess.debug.wat
@@ -4330,12 +4330,8 @@
   call $~lib/object/Object~visit
   local.get $0
   i32.load
-  local.tee $2
-  if
-   local.get $2
-   local.get $1
-   call $~lib/rt/itcms/__visit
-  end
+  local.get $1
+  call $~lib/rt/itcms/__visit
  )
  (func $~lib/object/Object~visit (param $0 i32) (param $1 i32)
  )

--- a/tests/compiler/resolve-elementaccess.release.wat
+++ b/tests/compiler/resolve-elementaccess.release.wat
@@ -176,7 +176,7 @@
    local.get $1
    global.set $~lib/rt/itcms/iter
   end
-  block $__inlined_func$~lib/rt/itcms/Object#unlink$150
+  block $__inlined_func$~lib/rt/itcms/Object#unlink$153
    local.get $0
    i32.load offset=4
    i32.const -4
@@ -200,7 +200,7 @@
      call $~lib/builtins/abort
      unreachable
     end
-    br $__inlined_func$~lib/rt/itcms/Object#unlink$150
+    br $__inlined_func$~lib/rt/itcms/Object#unlink$153
    end
    local.get $0
    i32.load offset=8
@@ -2950,11 +2950,7 @@
   end
   local.get $0
   i32.load
-  local.tee $0
-  if
-   local.get $0
-   call $~lib/rt/itcms/__visit
-  end
+  call $~lib/rt/itcms/__visit
  )
  (func $~start
   call $start:resolve-elementaccess

--- a/tests/compiler/resolve-function-expression.debug.wat
+++ b/tests/compiler/resolve-function-expression.debug.wat
@@ -2829,12 +2829,8 @@
   call $~lib/object/Object~visit
   local.get $0
   i32.load
-  local.tee $2
-  if
-   local.get $2
-   local.get $1
-   call $~lib/rt/itcms/__visit
-  end
+  local.get $1
+  call $~lib/rt/itcms/__visit
  )
  (func $~lib/object/Object~visit (param $0 i32) (param $1 i32)
  )

--- a/tests/compiler/resolve-function-expression.release.wat
+++ b/tests/compiler/resolve-function-expression.release.wat
@@ -1799,11 +1799,7 @@
     end
     local.get $0
     i32.load
-    local.tee $0
-    if
-     local.get $0
-     call $~lib/rt/itcms/__visit
-    end
+    call $~lib/rt/itcms/__visit
     return
    end
    global.get $~lib/memory/__stack_pointer

--- a/tests/compiler/resolve-new.debug.wat
+++ b/tests/compiler/resolve-new.debug.wat
@@ -2267,12 +2267,8 @@
   call $~lib/object/Object~visit
   local.get $0
   i32.load
-  local.tee $2
-  if
-   local.get $2
-   local.get $1
-   call $~lib/rt/itcms/__visit
-  end
+  local.get $1
+  call $~lib/rt/itcms/__visit
  )
  (func $~lib/object/Object~visit (param $0 i32) (param $1 i32)
  )

--- a/tests/compiler/resolve-new.release.wat
+++ b/tests/compiler/resolve-new.release.wat
@@ -1393,11 +1393,7 @@
     end
     local.get $0
     i32.load
-    local.tee $0
-    if
-     local.get $0
-     call $~lib/rt/itcms/__visit
-    end
+    call $~lib/rt/itcms/__visit
     return
    end
    return

--- a/tests/compiler/resolve-propertyaccess.debug.wat
+++ b/tests/compiler/resolve-propertyaccess.debug.wat
@@ -2846,12 +2846,8 @@
   call $~lib/object/Object~visit
   local.get $0
   i32.load
-  local.tee $2
-  if
-   local.get $2
-   local.get $1
-   call $~lib/rt/itcms/__visit
-  end
+  local.get $1
+  call $~lib/rt/itcms/__visit
  )
  (func $~lib/object/Object~visit (param $0 i32) (param $1 i32)
  )

--- a/tests/compiler/resolve-propertyaccess.release.wat
+++ b/tests/compiler/resolve-propertyaccess.release.wat
@@ -1804,11 +1804,7 @@
     end
     local.get $0
     i32.load
-    local.tee $0
-    if
-     local.get $0
-     call $~lib/rt/itcms/__visit
-    end
+    call $~lib/rt/itcms/__visit
     return
    end
    return

--- a/tests/compiler/resolve-ternary.debug.wat
+++ b/tests/compiler/resolve-ternary.debug.wat
@@ -4234,12 +4234,8 @@
   call $~lib/object/Object~visit
   local.get $0
   i32.load
-  local.tee $2
-  if
-   local.get $2
-   local.get $1
-   call $~lib/rt/itcms/__visit
-  end
+  local.get $1
+  call $~lib/rt/itcms/__visit
  )
  (func $~lib/object/Object~visit (param $0 i32) (param $1 i32)
  )

--- a/tests/compiler/resolve-ternary.release.wat
+++ b/tests/compiler/resolve-ternary.release.wat
@@ -2448,11 +2448,7 @@
     end
     local.get $0
     i32.load
-    local.tee $0
-    if
-     local.get $0
-     call $~lib/rt/itcms/__visit
-    end
+    call $~lib/rt/itcms/__visit
     return
    end
    global.get $~lib/memory/__stack_pointer

--- a/tests/compiler/resolve-unary.debug.wat
+++ b/tests/compiler/resolve-unary.debug.wat
@@ -2912,12 +2912,8 @@
   call $~lib/object/Object~visit
   local.get $0
   i32.load
-  local.tee $2
-  if
-   local.get $2
-   local.get $1
-   call $~lib/rt/itcms/__visit
-  end
+  local.get $1
+  call $~lib/rt/itcms/__visit
  )
  (func $~lib/object/Object~visit (param $0 i32) (param $1 i32)
  )

--- a/tests/compiler/resolve-unary.release.wat
+++ b/tests/compiler/resolve-unary.release.wat
@@ -1832,11 +1832,7 @@
       end
       local.get $0
       i32.load
-      local.tee $0
-      if
-       local.get $0
-       call $~lib/rt/itcms/__visit
-      end
+      call $~lib/rt/itcms/__visit
       return
      end
      return

--- a/tests/compiler/return-unreachable.debug.wat
+++ b/tests/compiler/return-unreachable.debug.wat
@@ -2374,12 +2374,8 @@
   call $~lib/object/Object~visit
   local.get $0
   i32.load
-  local.tee $2
-  if
-   local.get $2
-   local.get $1
-   call $~lib/rt/itcms/__visit
-  end
+  local.get $1
+  call $~lib/rt/itcms/__visit
  )
  (func $~lib/object/Object~visit (param $0 i32) (param $1 i32)
  )

--- a/tests/compiler/return-unreachable.release.wat
+++ b/tests/compiler/return-unreachable.release.wat
@@ -1716,11 +1716,7 @@
     end
     local.get $0
     i32.load
-    local.tee $0
-    if
-     local.get $0
-     call $~lib/rt/itcms/__visit
-    end
+    call $~lib/rt/itcms/__visit
     return
    end
    global.get $~lib/memory/__stack_pointer

--- a/tests/compiler/rt/finalize.debug.wat
+++ b/tests/compiler/rt/finalize.debug.wat
@@ -2360,12 +2360,8 @@
   call $~lib/object/Object~visit
   local.get $0
   i32.load
-  local.tee $2
-  if
-   local.get $2
-   local.get $1
-   call $~lib/rt/itcms/__visit
-  end
+  local.get $1
+  call $~lib/rt/itcms/__visit
  )
  (func $~lib/object/Object~visit (param $0 i32) (param $1 i32)
  )

--- a/tests/compiler/rt/finalize.release.wat
+++ b/tests/compiler/rt/finalize.release.wat
@@ -1406,11 +1406,7 @@
     end
     local.get $0
     i32.load
-    local.tee $0
-    if
-     local.get $0
-     call $~lib/rt/itcms/__visit
-    end
+    call $~lib/rt/itcms/__visit
     return
    end
    return

--- a/tests/compiler/rt/issue-2719.debug.wat
+++ b/tests/compiler/rt/issue-2719.debug.wat
@@ -2313,12 +2313,8 @@
   call $~lib/object/Object~visit
   local.get $0
   i32.load
-  local.tee $2
-  if
-   local.get $2
-   local.get $1
-   call $~lib/rt/itcms/__visit
-  end
+  local.get $1
+  call $~lib/rt/itcms/__visit
  )
  (func $~lib/object/Object~visit (param $0 i32) (param $1 i32)
  )

--- a/tests/compiler/rt/issue-2719.release.wat
+++ b/tests/compiler/rt/issue-2719.release.wat
@@ -1543,11 +1543,7 @@
     end
     local.get $0
     i32.load
-    local.tee $0
-    if
-     local.get $0
-     call $~lib/rt/itcms/__visit
-    end
+    call $~lib/rt/itcms/__visit
     return
    end
    return

--- a/tests/compiler/rt/runtime-incremental-export.debug.wat
+++ b/tests/compiler/rt/runtime-incremental-export.debug.wat
@@ -2384,12 +2384,8 @@
   call $~lib/object/Object~visit
   local.get $0
   i32.load
-  local.tee $2
-  if
-   local.get $2
-   local.get $1
-   call $~lib/rt/itcms/__visit
-  end
+  local.get $1
+  call $~lib/rt/itcms/__visit
  )
  (func $~lib/object/Object~visit (param $0 i32) (param $1 i32)
  )

--- a/tests/compiler/rt/runtime-incremental-export.release.wat
+++ b/tests/compiler/rt/runtime-incremental-export.release.wat
@@ -1706,11 +1706,7 @@
    end
    local.get $0
    i32.load
-   local.tee $0
-   if
-    local.get $0
-    call $~lib/rt/itcms/__visit
-   end
+   call $~lib/rt/itcms/__visit
    return
   end
   unreachable

--- a/tests/compiler/rt/runtime-minimal-export.debug.wat
+++ b/tests/compiler/rt/runtime-minimal-export.debug.wat
@@ -2034,12 +2034,8 @@
   call $~lib/object/Object~visit
   local.get $0
   i32.load
-  local.tee $2
-  if
-   local.get $2
-   local.get $1
-   call $~lib/rt/tcms/__visit
-  end
+  local.get $1
+  call $~lib/rt/tcms/__visit
  )
  (func $~lib/object/Object~visit (param $0 i32) (param $1 i32)
  )

--- a/tests/compiler/rt/runtime-minimal-export.release.wat
+++ b/tests/compiler/rt/runtime-minimal-export.release.wat
@@ -1440,11 +1440,7 @@
    end
    local.get $0
    i32.load
-   local.tee $0
-   if
-    local.get $0
-    call $~lib/rt/tcms/__visit
-   end
+   call $~lib/rt/tcms/__visit
    return
   end
   unreachable

--- a/tests/compiler/simd.debug.wat
+++ b/tests/compiler/simd.debug.wat
@@ -6811,12 +6811,8 @@
   call $~lib/object/Object~visit
   local.get $0
   i32.load
-  local.tee $2
-  if
-   local.get $2
-   local.get $1
-   call $~lib/rt/itcms/__visit
-  end
+  local.get $1
+  call $~lib/rt/itcms/__visit
  )
  (func $~lib/object/Object~visit (param $0 i32) (param $1 i32)
  )

--- a/tests/compiler/simd.release.wat
+++ b/tests/compiler/simd.release.wat
@@ -2144,11 +2144,7 @@
      end
      local.get $0
      i32.load
-     local.tee $0
-     if
-      local.get $0
-      call $~lib/rt/itcms/__visit
-     end
+     call $~lib/rt/itcms/__visit
      return
     end
     local.get $0

--- a/tests/compiler/std/array-literal.debug.wat
+++ b/tests/compiler/std/array-literal.debug.wat
@@ -2571,12 +2571,8 @@
   call $~lib/object/Object~visit
   local.get $0
   i32.load
-  local.tee $2
-  if
-   local.get $2
-   local.get $1
-   call $~lib/rt/itcms/__visit
-  end
+  local.get $1
+  call $~lib/rt/itcms/__visit
  )
  (func $~lib/object/Object~visit (param $0 i32) (param $1 i32)
  )

--- a/tests/compiler/std/array-literal.release.wat
+++ b/tests/compiler/std/array-literal.release.wat
@@ -1770,11 +1770,7 @@
          end
          local.get $0
          i32.load
-         local.tee $0
-         if
-          local.get $0
-          call $~lib/rt/itcms/__visit
-         end
+         call $~lib/rt/itcms/__visit
          return
         end
         local.get $0

--- a/tests/compiler/std/array.debug.wat
+++ b/tests/compiler/std/array.debug.wat
@@ -9297,12 +9297,8 @@
   call $~lib/object/Object~visit
   local.get $0
   i32.load
-  local.tee $2
-  if
-   local.get $2
-   local.get $1
-   call $~lib/rt/itcms/__visit
-  end
+  local.get $1
+  call $~lib/rt/itcms/__visit
  )
  (func $~lib/object/Object~visit (param $0 i32) (param $1 i32)
  )

--- a/tests/compiler/std/array.release.wat
+++ b/tests/compiler/std/array.release.wat
@@ -758,7 +758,7 @@
    local.get $1
    global.set $~lib/rt/itcms/iter
   end
-  block $__inlined_func$~lib/rt/itcms/Object#unlink$729
+  block $__inlined_func$~lib/rt/itcms/Object#unlink$731
    local.get $0
    i32.load offset=4
    i32.const -4
@@ -782,7 +782,7 @@
      call $~lib/builtins/abort
      unreachable
     end
-    br $__inlined_func$~lib/rt/itcms/Object#unlink$729
+    br $__inlined_func$~lib/rt/itcms/Object#unlink$731
    end
    local.get $0
    i32.load offset=8
@@ -6237,51 +6237,49 @@
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
-  block $folding-inner5
-   block $folding-inner4
-    block $folding-inner3
-     block $folding-inner2
-      block $folding-inner1
-       block $folding-inner0
-        block $invalid
-         block $std/array/Proxy<i32>
-          block $std/array/Dim
+  block $folding-inner4
+   block $folding-inner3
+    block $folding-inner2
+     block $folding-inner1
+      block $folding-inner0
+       block $invalid
+        block $std/array/Proxy<i32>
+         block $std/array/Dim
+          block $~lib/typedarray/Uint8Array
            block $std/array/Ref
-            block $~lib/string/String
-             block $~lib/arraybuffer/ArrayBuffer
-              block $~lib/object/Object
-               local.get $0
-               i32.const 8
-               i32.sub
-               i32.load
-               br_table $~lib/object/Object $~lib/arraybuffer/ArrayBuffer $~lib/string/String $folding-inner4 $folding-inner0 $std/array/Ref $folding-inner4 $folding-inner0 $folding-inner0 $folding-inner0 $folding-inner1 $folding-inner0 $folding-inner0 $folding-inner1 $folding-inner2 $folding-inner2 $folding-inner1 $folding-inner2 $folding-inner2 $folding-inner2 $folding-inner2 $folding-inner2 $std/array/Dim $folding-inner1 $folding-inner2 $folding-inner2 $folding-inner2 $folding-inner2 $folding-inner2 $folding-inner1 $folding-inner2 $std/array/Proxy<i32> $folding-inner1 $folding-inner2 $folding-inner1 $folding-inner2 $folding-inner2 $folding-inner0 $folding-inner0 $folding-inner0 $folding-inner0 $folding-inner0 $folding-inner1 $folding-inner1 $folding-inner1 $folding-inner1 $folding-inner2 $invalid
+            block $~lib/arraybuffer/ArrayBufferView
+             block $~lib/string/String
+              block $~lib/arraybuffer/ArrayBuffer
+               block $~lib/object/Object
+                local.get $0
+                i32.const 8
+                i32.sub
+                i32.load
+                br_table $~lib/object/Object $~lib/arraybuffer/ArrayBuffer $~lib/string/String $~lib/arraybuffer/ArrayBufferView $folding-inner0 $std/array/Ref $~lib/typedarray/Uint8Array $folding-inner0 $folding-inner0 $folding-inner0 $folding-inner1 $folding-inner0 $folding-inner0 $folding-inner1 $folding-inner2 $folding-inner2 $folding-inner1 $folding-inner2 $folding-inner2 $folding-inner2 $folding-inner2 $folding-inner2 $std/array/Dim $folding-inner1 $folding-inner2 $folding-inner2 $folding-inner2 $folding-inner2 $folding-inner2 $folding-inner1 $folding-inner2 $std/array/Proxy<i32> $folding-inner1 $folding-inner2 $folding-inner1 $folding-inner2 $folding-inner2 $folding-inner0 $folding-inner0 $folding-inner0 $folding-inner0 $folding-inner0 $folding-inner1 $folding-inner1 $folding-inner1 $folding-inner1 $folding-inner2 $invalid
+               end
+               return
               end
               return
              end
              return
             end
+            local.get $0
+            i32.load
+            call $~lib/rt/itcms/__visit
             return
            end
            return
           end
+          local.get $0
+          i32.load
+          call $~lib/rt/itcms/__visit
           return
          end
          return
         end
-        unreachable
+        return
        end
-       global.get $~lib/memory/__stack_pointer
-       i32.const 4
-       i32.sub
-       global.set $~lib/memory/__stack_pointer
-       global.get $~lib/memory/__stack_pointer
-       i32.const 16192
-       i32.lt_s
-       br_if $folding-inner3
-       global.get $~lib/memory/__stack_pointer
-       i32.const 0
-       i32.store
-       br $folding-inner5
+       unreachable
       end
       global.get $~lib/memory/__stack_pointer
       i32.const 4
@@ -6294,42 +6292,7 @@
       global.get $~lib/memory/__stack_pointer
       i32.const 0
       i32.store
-      global.get $~lib/memory/__stack_pointer
-      local.get $0
-      i32.store
-      local.get $0
-      i32.load offset=4
-      local.set $1
-      global.get $~lib/memory/__stack_pointer
-      local.get $0
-      i32.store
-      local.get $1
-      local.get $0
-      i32.load offset=12
-      i32.const 2
-      i32.shl
-      i32.add
-      local.set $2
-      loop $while-continue|0
-       local.get $1
-       local.get $2
-       i32.lt_u
-       if
-        local.get $1
-        i32.load
-        local.tee $3
-        if
-         local.get $3
-         call $~lib/rt/itcms/__visit
-        end
-        local.get $1
-        i32.const 4
-        i32.add
-        local.set $1
-        br $while-continue|0
-       end
-      end
-      br $folding-inner5
+      br $folding-inner4
      end
      global.get $~lib/memory/__stack_pointer
      i32.const 4
@@ -6347,28 +6310,67 @@
      i32.store
      local.get $0
      i32.load offset=4
-     call $~lib/rt/itcms/__visit
+     local.set $1
      global.get $~lib/memory/__stack_pointer
-     i32.const 4
+     local.get $0
+     i32.store
+     local.get $1
+     local.get $0
+     i32.load offset=12
+     i32.const 2
+     i32.shl
      i32.add
-     global.set $~lib/memory/__stack_pointer
-     return
+     local.set $2
+     loop $while-continue|0
+      local.get $1
+      local.get $2
+      i32.lt_u
+      if
+       local.get $1
+       i32.load
+       local.tee $3
+       if
+        local.get $3
+        call $~lib/rt/itcms/__visit
+       end
+       local.get $1
+       i32.const 4
+       i32.add
+       local.set $1
+       br $while-continue|0
+      end
+     end
+     br $folding-inner4
     end
-    i32.const 48992
-    i32.const 49040
-    i32.const 1
-    i32.const 1
-    call $~lib/builtins/abort
-    unreachable
-   end
-   local.get $0
-   i32.load
-   local.tee $0
-   if
+    global.get $~lib/memory/__stack_pointer
+    i32.const 4
+    i32.sub
+    global.set $~lib/memory/__stack_pointer
+    global.get $~lib/memory/__stack_pointer
+    i32.const 16192
+    i32.lt_s
+    br_if $folding-inner3
+    global.get $~lib/memory/__stack_pointer
+    i32.const 0
+    i32.store
+    global.get $~lib/memory/__stack_pointer
     local.get $0
+    i32.store
+    local.get $0
+    i32.load offset=4
     call $~lib/rt/itcms/__visit
+    global.get $~lib/memory/__stack_pointer
+    i32.const 4
+    i32.add
+    global.set $~lib/memory/__stack_pointer
+    return
    end
-   return
+   i32.const 48992
+   i32.const 49040
+   i32.const 1
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
   end
   global.get $~lib/memory/__stack_pointer
   local.get $0
@@ -7591,7 +7593,7 @@
     select
     local.set $1
    end
-   block $__inlined_func$~lib/rt/itcms/__renew$651
+   block $__inlined_func$~lib/rt/itcms/__renew$653
     local.get $3
     i32.const 20
     i32.sub
@@ -7609,7 +7611,7 @@
      i32.store offset=16
      local.get $3
      local.set $2
-     br $__inlined_func$~lib/rt/itcms/__renew$651
+     br $__inlined_func$~lib/rt/itcms/__renew$653
     end
     local.get $1
     local.get $4
@@ -13084,7 +13086,7 @@
    global.get $~lib/memory/__stack_pointer
    i64.const 0
    i64.store offset=8
-   block $__inlined_func$std/array/isSorted<i32>$656 (result i32)
+   block $__inlined_func$std/array/isSorted<i32>$658 (result i32)
     global.get $~lib/memory/__stack_pointer
     local.get $0
     i32.store offset=8
@@ -13152,7 +13154,7 @@
        i32.add
        global.set $~lib/memory/__stack_pointer
        i32.const 0
-       br $__inlined_func$std/array/isSorted<i32>$656
+       br $__inlined_func$std/array/isSorted<i32>$658
       end
       local.get $0
       i32.const 1
@@ -14389,7 +14391,7 @@
    global.get $~lib/memory/__stack_pointer
    i64.const 0
    i64.store offset=8
-   block $__inlined_func$std/array/isSorted<~lib/array/Array<i32>>$658 (result i32)
+   block $__inlined_func$std/array/isSorted<~lib/array/Array<i32>>$660 (result i32)
     global.get $~lib/memory/__stack_pointer
     local.get $0
     i32.store offset=8
@@ -14472,7 +14474,7 @@
        i32.add
        global.set $~lib/memory/__stack_pointer
        i32.const 0
-       br $__inlined_func$std/array/isSorted<~lib/array/Array<i32>>$658
+       br $__inlined_func$std/array/isSorted<~lib/array/Array<i32>>$660
       end
       local.get $1
       i32.const 1
@@ -14899,7 +14901,7 @@
    global.get $~lib/memory/__stack_pointer
    local.get $1
    i32.store
-   block $__inlined_func$~lib/string/String#concat$734
+   block $__inlined_func$~lib/string/String#concat$736
     local.get $1
     i32.const 20
     i32.sub
@@ -14918,7 +14920,7 @@
      global.set $~lib/memory/__stack_pointer
      i32.const 11568
      local.set $0
-     br $__inlined_func$~lib/string/String#concat$734
+     br $__inlined_func$~lib/string/String#concat$736
     end
     global.get $~lib/memory/__stack_pointer
     local.get $0
@@ -15107,7 +15109,7 @@
    global.get $~lib/memory/__stack_pointer
    i64.const 0
    i64.store
-   block $__inlined_func$~lib/util/string/joinIntegerArray<i32>$736
+   block $__inlined_func$~lib/util/string/joinIntegerArray<i32>$738
     local.get $0
     i32.const 1
     i32.sub
@@ -15121,7 +15123,7 @@
      global.set $~lib/memory/__stack_pointer
      i32.const 11568
      local.set $0
-     br $__inlined_func$~lib/util/string/joinIntegerArray<i32>$736
+     br $__inlined_func$~lib/util/string/joinIntegerArray<i32>$738
     end
     local.get $7
     i32.eqz
@@ -15134,7 +15136,7 @@
      i32.const 8
      i32.add
      global.set $~lib/memory/__stack_pointer
-     br $__inlined_func$~lib/util/string/joinIntegerArray<i32>$736
+     br $__inlined_func$~lib/util/string/joinIntegerArray<i32>$738
     end
     global.get $~lib/memory/__stack_pointer
     local.get $1
@@ -15233,7 +15235,7 @@
      i32.const 8
      i32.add
      global.set $~lib/memory/__stack_pointer
-     br $__inlined_func$~lib/util/string/joinIntegerArray<i32>$736
+     br $__inlined_func$~lib/util/string/joinIntegerArray<i32>$738
     end
     global.get $~lib/memory/__stack_pointer
     i32.const 8
@@ -15299,7 +15301,7 @@
    global.get $~lib/memory/__stack_pointer
    i64.const 0
    i64.store
-   block $__inlined_func$~lib/util/string/joinIntegerArray<u32>$737
+   block $__inlined_func$~lib/util/string/joinIntegerArray<u32>$739
     local.get $0
     i32.const 1
     i32.sub
@@ -15313,7 +15315,7 @@
      global.set $~lib/memory/__stack_pointer
      i32.const 11568
      local.set $0
-     br $__inlined_func$~lib/util/string/joinIntegerArray<u32>$737
+     br $__inlined_func$~lib/util/string/joinIntegerArray<u32>$739
     end
     local.get $7
     i32.eqz
@@ -15326,7 +15328,7 @@
      i32.const 8
      i32.add
      global.set $~lib/memory/__stack_pointer
-     br $__inlined_func$~lib/util/string/joinIntegerArray<u32>$737
+     br $__inlined_func$~lib/util/string/joinIntegerArray<u32>$739
     end
     global.get $~lib/memory/__stack_pointer
     local.get $1
@@ -15425,7 +15427,7 @@
      i32.const 8
      i32.add
      global.set $~lib/memory/__stack_pointer
-     br $__inlined_func$~lib/util/string/joinIntegerArray<u32>$737
+     br $__inlined_func$~lib/util/string/joinIntegerArray<u32>$739
     end
     global.get $~lib/memory/__stack_pointer
     i32.const 8
@@ -15952,7 +15954,7 @@
    global.get $~lib/memory/__stack_pointer
    i32.const 11856
    i32.store
-   block $__inlined_func$~lib/util/string/joinReferenceArray<std/array/Ref|null>$6 (result i32)
+   block $__inlined_func$~lib/util/string/joinReferenceArray<std/array/Ref|null>$4 (result i32)
     global.get $~lib/memory/__stack_pointer
     i32.const 20
     i32.sub
@@ -15977,7 +15979,7 @@
      i32.add
      global.set $~lib/memory/__stack_pointer
      i32.const 11568
-     br $__inlined_func$~lib/util/string/joinReferenceArray<std/array/Ref|null>$6
+     br $__inlined_func$~lib/util/string/joinReferenceArray<std/array/Ref|null>$4
     end
     local.get $2
     i32.eqz
@@ -16000,7 +16002,7 @@
      i32.const 20
      i32.add
      global.set $~lib/memory/__stack_pointer
-     br $__inlined_func$~lib/util/string/joinReferenceArray<std/array/Ref|null>$6
+     br $__inlined_func$~lib/util/string/joinReferenceArray<std/array/Ref|null>$4
     end
     i32.const 11568
     local.set $0
@@ -16210,7 +16212,7 @@
    global.get $~lib/memory/__stack_pointer
    i64.const 0
    i64.store
-   block $__inlined_func$~lib/util/string/joinIntegerArray<i8>$738
+   block $__inlined_func$~lib/util/string/joinIntegerArray<i8>$740
     local.get $0
     i32.const 1
     i32.sub
@@ -16224,7 +16226,7 @@
      global.set $~lib/memory/__stack_pointer
      i32.const 11568
      local.set $0
-     br $__inlined_func$~lib/util/string/joinIntegerArray<i8>$738
+     br $__inlined_func$~lib/util/string/joinIntegerArray<i8>$740
     end
     local.get $6
     i32.eqz
@@ -16237,7 +16239,7 @@
      i32.const 8
      i32.add
      global.set $~lib/memory/__stack_pointer
-     br $__inlined_func$~lib/util/string/joinIntegerArray<i8>$738
+     br $__inlined_func$~lib/util/string/joinIntegerArray<i8>$740
     end
     global.get $~lib/memory/__stack_pointer
     i32.const 11856
@@ -16330,7 +16332,7 @@
      i32.const 8
      i32.add
      global.set $~lib/memory/__stack_pointer
-     br $__inlined_func$~lib/util/string/joinIntegerArray<i8>$738
+     br $__inlined_func$~lib/util/string/joinIntegerArray<i8>$740
     end
     global.get $~lib/memory/__stack_pointer
     i32.const 8
@@ -16417,7 +16419,7 @@
    global.get $~lib/memory/__stack_pointer
    i64.const 0
    i64.store
-   block $__inlined_func$~lib/util/string/joinIntegerArray<u16>$739
+   block $__inlined_func$~lib/util/string/joinIntegerArray<u16>$741
     local.get $0
     i32.const 1
     i32.sub
@@ -16431,7 +16433,7 @@
      global.set $~lib/memory/__stack_pointer
      i32.const 11568
      local.set $0
-     br $__inlined_func$~lib/util/string/joinIntegerArray<u16>$739
+     br $__inlined_func$~lib/util/string/joinIntegerArray<u16>$741
     end
     local.get $6
     i32.eqz
@@ -16444,7 +16446,7 @@
      i32.const 8
      i32.add
      global.set $~lib/memory/__stack_pointer
-     br $__inlined_func$~lib/util/string/joinIntegerArray<u16>$739
+     br $__inlined_func$~lib/util/string/joinIntegerArray<u16>$741
     end
     global.get $~lib/memory/__stack_pointer
     i32.const 11856
@@ -16541,7 +16543,7 @@
      i32.const 8
      i32.add
      global.set $~lib/memory/__stack_pointer
-     br $__inlined_func$~lib/util/string/joinIntegerArray<u16>$739
+     br $__inlined_func$~lib/util/string/joinIntegerArray<u16>$741
     end
     global.get $~lib/memory/__stack_pointer
     i32.const 8
@@ -16628,7 +16630,7 @@
    global.get $~lib/memory/__stack_pointer
    i64.const 0
    i64.store
-   block $__inlined_func$~lib/util/string/joinIntegerArray<i16>$740
+   block $__inlined_func$~lib/util/string/joinIntegerArray<i16>$742
     local.get $0
     i32.const 1
     i32.sub
@@ -16642,7 +16644,7 @@
      global.set $~lib/memory/__stack_pointer
      i32.const 11568
      local.set $0
-     br $__inlined_func$~lib/util/string/joinIntegerArray<i16>$740
+     br $__inlined_func$~lib/util/string/joinIntegerArray<i16>$742
     end
     local.get $6
     i32.eqz
@@ -16655,7 +16657,7 @@
      i32.const 8
      i32.add
      global.set $~lib/memory/__stack_pointer
-     br $__inlined_func$~lib/util/string/joinIntegerArray<i16>$740
+     br $__inlined_func$~lib/util/string/joinIntegerArray<i16>$742
     end
     global.get $~lib/memory/__stack_pointer
     i32.const 11856
@@ -16752,7 +16754,7 @@
      i32.const 8
      i32.add
      global.set $~lib/memory/__stack_pointer
-     br $__inlined_func$~lib/util/string/joinIntegerArray<i16>$740
+     br $__inlined_func$~lib/util/string/joinIntegerArray<i16>$742
     end
     global.get $~lib/memory/__stack_pointer
     i32.const 8
@@ -17183,7 +17185,7 @@
    global.get $~lib/memory/__stack_pointer
    i64.const 0
    i64.store
-   block $__inlined_func$~lib/util/string/joinIntegerArray<u8>$741
+   block $__inlined_func$~lib/util/string/joinIntegerArray<u8>$743
     local.get $0
     i32.const 1
     i32.sub
@@ -17197,7 +17199,7 @@
      global.set $~lib/memory/__stack_pointer
      i32.const 11568
      local.set $0
-     br $__inlined_func$~lib/util/string/joinIntegerArray<u8>$741
+     br $__inlined_func$~lib/util/string/joinIntegerArray<u8>$743
     end
     local.get $6
     i32.eqz
@@ -17210,7 +17212,7 @@
      i32.const 8
      i32.add
      global.set $~lib/memory/__stack_pointer
-     br $__inlined_func$~lib/util/string/joinIntegerArray<u8>$741
+     br $__inlined_func$~lib/util/string/joinIntegerArray<u8>$743
     end
     global.get $~lib/memory/__stack_pointer
     i32.const 11856
@@ -17303,7 +17305,7 @@
      i32.const 8
      i32.add
      global.set $~lib/memory/__stack_pointer
-     br $__inlined_func$~lib/util/string/joinIntegerArray<u8>$741
+     br $__inlined_func$~lib/util/string/joinIntegerArray<u8>$743
     end
     global.get $~lib/memory/__stack_pointer
     i32.const 8
@@ -17412,7 +17414,7 @@
    global.get $~lib/memory/__stack_pointer
    i32.const 11856
    i32.store
-   block $__inlined_func$~lib/util/string/joinReferenceArray<~lib/array/Array<u32>>$7 (result i32)
+   block $__inlined_func$~lib/util/string/joinReferenceArray<~lib/array/Array<u32>>$5 (result i32)
     global.get $~lib/memory/__stack_pointer
     i32.const 20
     i32.sub
@@ -17437,7 +17439,7 @@
      i32.add
      global.set $~lib/memory/__stack_pointer
      i32.const 11568
-     br $__inlined_func$~lib/util/string/joinReferenceArray<~lib/array/Array<u32>>$7
+     br $__inlined_func$~lib/util/string/joinReferenceArray<~lib/array/Array<u32>>$5
     end
     local.get $4
     i32.eqz
@@ -17461,7 +17463,7 @@
      i32.const 20
      i32.add
      global.set $~lib/memory/__stack_pointer
-     br $__inlined_func$~lib/util/string/joinReferenceArray<~lib/array/Array<u32>>$7
+     br $__inlined_func$~lib/util/string/joinReferenceArray<~lib/array/Array<u32>>$5
     end
     i32.const 11568
     local.set $0
@@ -21551,7 +21553,7 @@
    global.get $~lib/memory/__stack_pointer
    local.get $2
    i32.store
-   block $__inlined_func$~lib/array/Array<f32>#indexOf$712
+   block $__inlined_func$~lib/array/Array<f32>#indexOf$714
     local.get $2
     i32.load offset=12
     local.tee $4
@@ -21567,7 +21569,7 @@
      global.set $~lib/memory/__stack_pointer
      i32.const -1
      local.set $0
-     br $__inlined_func$~lib/array/Array<f32>#indexOf$712
+     br $__inlined_func$~lib/array/Array<f32>#indexOf$714
     end
     global.get $~lib/memory/__stack_pointer
     local.get $2
@@ -21593,7 +21595,7 @@
        i32.const 4
        i32.add
        global.set $~lib/memory/__stack_pointer
-       br $__inlined_func$~lib/array/Array<f32>#indexOf$712
+       br $__inlined_func$~lib/array/Array<f32>#indexOf$714
       end
       local.get $0
       i32.const 1
@@ -21645,7 +21647,7 @@
    global.get $~lib/memory/__stack_pointer
    local.get $2
    i32.store
-   block $__inlined_func$~lib/array/Array<f64>#indexOf$713
+   block $__inlined_func$~lib/array/Array<f64>#indexOf$715
     local.get $2
     i32.load offset=12
     local.tee $4
@@ -21661,7 +21663,7 @@
      global.set $~lib/memory/__stack_pointer
      i32.const -1
      local.set $0
-     br $__inlined_func$~lib/array/Array<f64>#indexOf$713
+     br $__inlined_func$~lib/array/Array<f64>#indexOf$715
     end
     global.get $~lib/memory/__stack_pointer
     local.get $2
@@ -21687,7 +21689,7 @@
        i32.const 4
        i32.add
        global.set $~lib/memory/__stack_pointer
-       br $__inlined_func$~lib/array/Array<f64>#indexOf$713
+       br $__inlined_func$~lib/array/Array<f64>#indexOf$715
       end
       local.get $0
       i32.const 1
@@ -21998,7 +22000,7 @@
     call $~lib/builtins/abort
     unreachable
    end
-   block $__inlined_func$~lib/array/Array<f32>#includes$714 (result i32)
+   block $__inlined_func$~lib/array/Array<f32>#includes$716 (result i32)
     i32.const 1
     i32.const 2
     i32.const 9
@@ -22038,7 +22040,7 @@
      i32.add
      global.set $~lib/memory/__stack_pointer
      i32.const 0
-     br $__inlined_func$~lib/array/Array<f32>#includes$714
+     br $__inlined_func$~lib/array/Array<f32>#includes$716
     end
     global.get $~lib/memory/__stack_pointer
     local.get $2
@@ -22066,7 +22068,7 @@
        i32.add
        global.set $~lib/memory/__stack_pointer
        i32.const 1
-       br $__inlined_func$~lib/array/Array<f32>#includes$714
+       br $__inlined_func$~lib/array/Array<f32>#includes$716
       end
       local.get $0
       i32.const 1
@@ -22090,7 +22092,7 @@
     call $~lib/builtins/abort
     unreachable
    end
-   block $__inlined_func$~lib/array/Array<f64>#includes$715 (result i32)
+   block $__inlined_func$~lib/array/Array<f64>#includes$717 (result i32)
     i32.const 1
     i32.const 3
     i32.const 12
@@ -22130,7 +22132,7 @@
      i32.add
      global.set $~lib/memory/__stack_pointer
      i32.const 0
-     br $__inlined_func$~lib/array/Array<f64>#includes$715
+     br $__inlined_func$~lib/array/Array<f64>#includes$717
     end
     global.get $~lib/memory/__stack_pointer
     local.get $2
@@ -22158,7 +22160,7 @@
        i32.add
        global.set $~lib/memory/__stack_pointer
        i32.const 1
-       br $__inlined_func$~lib/array/Array<f64>#includes$715
+       br $__inlined_func$~lib/array/Array<f64>#includes$717
       end
       local.get $0
       i32.const 1
@@ -26297,7 +26299,7 @@
    global.get $~lib/memory/__stack_pointer
    local.get $4
    i32.store offset=8
-   block $__inlined_func$std/array/isArraysEqual<f64>$9 (result i32)
+   block $__inlined_func$std/array/isArraysEqual<f64>$7 (result i32)
     i32.const 0
     local.set $0
     global.get $~lib/memory/__stack_pointer
@@ -26413,7 +26415,7 @@
      i32.add
      global.set $~lib/memory/__stack_pointer
      i32.const 0
-     br $__inlined_func$std/array/isArraysEqual<f64>$9
+     br $__inlined_func$std/array/isArraysEqual<f64>$7
     end
     global.get $~lib/memory/__stack_pointer
     i32.const 4
@@ -27512,7 +27514,7 @@
    global.get $~lib/memory/__stack_pointer
    i64.const 0
    i64.store offset=8
-   block $__inlined_func$std/array/isSorted<~lib/string/String|null>$660 (result i32)
+   block $__inlined_func$std/array/isSorted<~lib/string/String|null>$662 (result i32)
     global.get $~lib/memory/__stack_pointer
     local.get $0
     i32.store offset=8
@@ -27593,7 +27595,7 @@
        i32.add
        global.set $~lib/memory/__stack_pointer
        i32.const 0
-       br $__inlined_func$std/array/isSorted<~lib/string/String|null>$660
+       br $__inlined_func$std/array/isSorted<~lib/string/String|null>$662
       end
       local.get $1
       i32.const 1
@@ -27625,7 +27627,7 @@
    i32.const 12
    i32.add
    global.set $~lib/memory/__stack_pointer
-   block $__inlined_func$std/array/isArraysEqual<~lib/string/String|null>$746 (result i32)
+   block $__inlined_func$std/array/isArraysEqual<~lib/string/String|null>$748 (result i32)
     global.get $~lib/memory/__stack_pointer
     local.get $0
     i32.store
@@ -27665,7 +27667,7 @@
      i32.add
      global.set $~lib/memory/__stack_pointer
      i32.const 0
-     br $__inlined_func$std/array/isArraysEqual<~lib/string/String|null>$746
+     br $__inlined_func$std/array/isArraysEqual<~lib/string/String|null>$748
     end
     local.get $0
     local.get $2
@@ -27676,7 +27678,7 @@
      i32.add
      global.set $~lib/memory/__stack_pointer
      i32.const 1
-     br $__inlined_func$std/array/isArraysEqual<~lib/string/String|null>$746
+     br $__inlined_func$std/array/isArraysEqual<~lib/string/String|null>$748
     end
     i32.const 0
     local.set $1
@@ -27736,7 +27738,7 @@
        i32.add
        global.set $~lib/memory/__stack_pointer
        i32.const 0
-       br $__inlined_func$std/array/isArraysEqual<~lib/string/String|null>$746
+       br $__inlined_func$std/array/isArraysEqual<~lib/string/String|null>$748
       end
       local.get $1
       i32.const 1
@@ -27940,7 +27942,7 @@
        global.get $~lib/memory/__stack_pointer
        i32.const 10032
        i32.store
-       block $__inlined_func$~lib/string/String#charAt$735
+       block $__inlined_func$~lib/string/String#charAt$737
         local.get $12
         i32.const 10028
         i32.load
@@ -27954,7 +27956,7 @@
          global.set $~lib/memory/__stack_pointer
          i32.const 11568
          local.set $2
-         br $__inlined_func$~lib/string/String#charAt$735
+         br $__inlined_func$~lib/string/String#charAt$737
         end
         global.get $~lib/memory/__stack_pointer
         i32.const 2
@@ -28102,7 +28104,7 @@
    global.get $~lib/memory/__stack_pointer
    i64.const 0
    i64.store
-   block $__inlined_func$~lib/util/string/joinBooleanArray$14
+   block $__inlined_func$~lib/util/string/joinBooleanArray$12
     local.get $0
     i32.const 1
     i32.sub
@@ -28116,7 +28118,7 @@
      global.set $~lib/memory/__stack_pointer
      i32.const 11568
      local.set $2
-     br $__inlined_func$~lib/util/string/joinBooleanArray$14
+     br $__inlined_func$~lib/util/string/joinBooleanArray$12
     end
     block $folding-inner07
      local.get $0
@@ -28249,7 +28251,7 @@
      i32.const 8
      i32.add
      global.set $~lib/memory/__stack_pointer
-     br $__inlined_func$~lib/util/string/joinBooleanArray$14
+     br $__inlined_func$~lib/util/string/joinBooleanArray$12
     end
     global.get $~lib/memory/__stack_pointer
     i32.const 8
@@ -28995,7 +28997,7 @@
    global.get $~lib/memory/__stack_pointer
    i64.const 0
    i64.store
-   block $__inlined_func$~lib/util/string/joinIntegerArray<i64>$15
+   block $__inlined_func$~lib/util/string/joinIntegerArray<i64>$13
     local.get $2
     i32.const 1
     i32.sub
@@ -29009,7 +29011,7 @@
      global.set $~lib/memory/__stack_pointer
      i32.const 11568
      local.set $2
-     br $__inlined_func$~lib/util/string/joinIntegerArray<i64>$15
+     br $__inlined_func$~lib/util/string/joinIntegerArray<i64>$13
     end
     block $folding-inner09
      local.get $4
@@ -29301,7 +29303,7 @@
      i32.const 8
      i32.add
      global.set $~lib/memory/__stack_pointer
-     br $__inlined_func$~lib/util/string/joinIntegerArray<i64>$15
+     br $__inlined_func$~lib/util/string/joinIntegerArray<i64>$13
     end
     global.get $~lib/memory/__stack_pointer
     i32.const 8
@@ -29483,7 +29485,7 @@
    i32.const 0
    i32.const 20
    memory.fill
-   block $__inlined_func$~lib/util/string/joinReferenceArray<~lib/array/Array<i32>>$16
+   block $__inlined_func$~lib/util/string/joinReferenceArray<~lib/array/Array<i32>>$14
     local.get $1
     i32.const 1
     i32.sub
@@ -29497,7 +29499,7 @@
      global.set $~lib/memory/__stack_pointer
      i32.const 11568
      local.set $2
-     br $__inlined_func$~lib/util/string/joinReferenceArray<~lib/array/Array<i32>>$16
+     br $__inlined_func$~lib/util/string/joinReferenceArray<~lib/array/Array<i32>>$14
     end
     local.get $1
     i32.eqz
@@ -29522,7 +29524,7 @@
      i32.const 20
      i32.add
      global.set $~lib/memory/__stack_pointer
-     br $__inlined_func$~lib/util/string/joinReferenceArray<~lib/array/Array<i32>>$16
+     br $__inlined_func$~lib/util/string/joinReferenceArray<~lib/array/Array<i32>>$14
     end
     i32.const 11568
     local.set $2
@@ -29742,7 +29744,7 @@
    i32.const 0
    i32.const 20
    memory.fill
-   block $__inlined_func$~lib/util/string/joinReferenceArray<~lib/array/Array<u8>>$17
+   block $__inlined_func$~lib/util/string/joinReferenceArray<~lib/array/Array<u8>>$15
     local.get $1
     i32.const 1
     i32.sub
@@ -29756,7 +29758,7 @@
      global.set $~lib/memory/__stack_pointer
      i32.const 11568
      local.set $2
-     br $__inlined_func$~lib/util/string/joinReferenceArray<~lib/array/Array<u8>>$17
+     br $__inlined_func$~lib/util/string/joinReferenceArray<~lib/array/Array<u8>>$15
     end
     local.get $1
     i32.eqz
@@ -29781,7 +29783,7 @@
      i32.const 20
      i32.add
      global.set $~lib/memory/__stack_pointer
-     br $__inlined_func$~lib/util/string/joinReferenceArray<~lib/array/Array<u8>>$17
+     br $__inlined_func$~lib/util/string/joinReferenceArray<~lib/array/Array<u8>>$15
     end
     i32.const 11568
     local.set $2
@@ -30005,7 +30007,7 @@
    i32.const 0
    i32.const 20
    memory.fill
-   block $__inlined_func$~lib/util/string/joinReferenceArray<~lib/array/Array<~lib/array/Array<u32>>>$18
+   block $__inlined_func$~lib/util/string/joinReferenceArray<~lib/array/Array<~lib/array/Array<u32>>>$16
     local.get $1
     i32.const 1
     i32.sub
@@ -30019,7 +30021,7 @@
      global.set $~lib/memory/__stack_pointer
      i32.const 11568
      local.set $2
-     br $__inlined_func$~lib/util/string/joinReferenceArray<~lib/array/Array<~lib/array/Array<u32>>>$18
+     br $__inlined_func$~lib/util/string/joinReferenceArray<~lib/array/Array<~lib/array/Array<u32>>>$16
     end
     local.get $1
     i32.eqz
@@ -30044,7 +30046,7 @@
      i32.const 20
      i32.add
      global.set $~lib/memory/__stack_pointer
-     br $__inlined_func$~lib/util/string/joinReferenceArray<~lib/array/Array<~lib/array/Array<u32>>>$18
+     br $__inlined_func$~lib/util/string/joinReferenceArray<~lib/array/Array<~lib/array/Array<u32>>>$16
     end
     i32.const 11568
     local.set $2

--- a/tests/compiler/std/arraybuffer.debug.wat
+++ b/tests/compiler/std/arraybuffer.debug.wat
@@ -2686,12 +2686,8 @@
   call $~lib/object/Object~visit
   local.get $0
   i32.load
-  local.tee $2
-  if
-   local.get $2
-   local.get $1
-   call $~lib/rt/itcms/__visit
-  end
+  local.get $1
+  call $~lib/rt/itcms/__visit
  )
  (func $~lib/object/Object~visit (param $0 i32) (param $1 i32)
  )
@@ -2769,12 +2765,8 @@
   call $~lib/object/Object~visit
   local.get $0
   i32.load
-  local.tee $2
-  if
-   local.get $2
-   local.get $1
-   call $~lib/rt/itcms/__visit
-  end
+  local.get $1
+  call $~lib/rt/itcms/__visit
  )
  (func $~lib/rt/__visit_members (param $0 i32) (param $1 i32)
   block $invalid

--- a/tests/compiler/std/arraybuffer.release.wat
+++ b/tests/compiler/std/arraybuffer.release.wat
@@ -113,7 +113,7 @@
    local.get $1
    global.set $~lib/rt/itcms/iter
   end
-  block $__inlined_func$~lib/rt/itcms/Object#unlink$172
+  block $__inlined_func$~lib/rt/itcms/Object#unlink$185
    local.get $0
    i32.load offset=4
    i32.const -4
@@ -137,7 +137,7 @@
      call $~lib/builtins/abort
      unreachable
     end
-    br $__inlined_func$~lib/rt/itcms/Object#unlink$172
+    br $__inlined_func$~lib/rt/itcms/Object#unlink$185
    end
    local.get $0
    i32.load offset=8
@@ -1644,11 +1644,7 @@
   end
   local.get $0
   i32.load
-  local.tee $0
-  if
-   local.get $0
-   call $~lib/rt/itcms/__visit
-  end
+  call $~lib/rt/itcms/__visit
  )
  (func $~start
   call $start:std/arraybuffer
@@ -2303,7 +2299,7 @@
    i32.load
    local.tee $0
    i32.store offset=16
-   block $__inlined_func$~lib/dataview/DataView#constructor@varargs$1 (result i32)
+   block $__inlined_func$~lib/dataview/DataView#constructor@varargs (result i32)
     global.get $~lib/memory/__stack_pointer
     i32.const 8
     i32.sub
@@ -2425,7 +2421,7 @@
      i32.add
      global.set $~lib/memory/__stack_pointer
      local.get $2
-     br $__inlined_func$~lib/dataview/DataView#constructor@varargs$1
+     br $__inlined_func$~lib/dataview/DataView#constructor@varargs
     end
     br $folding-inner1
    end

--- a/tests/compiler/std/dataview.debug.wat
+++ b/tests/compiler/std/dataview.debug.wat
@@ -2574,12 +2574,8 @@
   call $~lib/object/Object~visit
   local.get $0
   i32.load
-  local.tee $2
-  if
-   local.get $2
-   local.get $1
-   call $~lib/rt/itcms/__visit
-  end
+  local.get $1
+  call $~lib/rt/itcms/__visit
  )
  (func $~lib/object/Object~visit (param $0 i32) (param $1 i32)
  )
@@ -2595,12 +2591,8 @@
   call $~lib/object/Object~visit
   local.get $0
   i32.load
-  local.tee $2
-  if
-   local.get $2
-   local.get $1
-   call $~lib/rt/itcms/__visit
-  end
+  local.get $1
+  call $~lib/rt/itcms/__visit
  )
  (func $~lib/rt/__visit_members (param $0 i32) (param $1 i32)
   block $invalid

--- a/tests/compiler/std/dataview.release.wat
+++ b/tests/compiler/std/dataview.release.wat
@@ -121,7 +121,7 @@
    local.get $1
    global.set $~lib/rt/itcms/iter
   end
-  block $__inlined_func$~lib/rt/itcms/Object#unlink$218
+  block $__inlined_func$~lib/rt/itcms/Object#unlink$221
    local.get $0
    i32.load offset=4
    i32.const -4
@@ -145,7 +145,7 @@
      call $~lib/builtins/abort
      unreachable
     end
-    br $__inlined_func$~lib/rt/itcms/Object#unlink$218
+    br $__inlined_func$~lib/rt/itcms/Object#unlink$221
    end
    local.get $0
    i32.load offset=8
@@ -1622,11 +1622,7 @@
   end
   local.get $0
   i32.load
-  local.tee $0
-  if
-   local.get $0
-   call $~lib/rt/itcms/__visit
-  end
+  call $~lib/rt/itcms/__visit
  )
  (func $~start
   call $start:std/dataview
@@ -3087,7 +3083,7 @@
    i32.const 1456
    global.set $~lib/rt/itcms/fromSpace
    global.get $~lib/memory/__stack_pointer
-   block $__inlined_func$~lib/typedarray/Uint8Array#constructor$3 (result i32)
+   block $__inlined_func$~lib/typedarray/Uint8Array#constructor (result i32)
     global.get $~lib/memory/__stack_pointer
     i32.const 8
     i32.sub
@@ -3190,7 +3186,7 @@
      i32.add
      global.set $~lib/memory/__stack_pointer
      local.get $0
-     br $__inlined_func$~lib/typedarray/Uint8Array#constructor$3
+     br $__inlined_func$~lib/typedarray/Uint8Array#constructor
     end
     br $folding-inner1
    end

--- a/tests/compiler/std/date.debug.wat
+++ b/tests/compiler/std/date.debug.wat
@@ -3684,12 +3684,8 @@
   call $~lib/object/Object~visit
   local.get $0
   i32.load
-  local.tee $2
-  if
-   local.get $2
-   local.get $1
-   call $~lib/rt/itcms/__visit
-  end
+  local.get $1
+  call $~lib/rt/itcms/__visit
  )
  (func $~lib/object/Object~visit (param $0 i32) (param $1 i32)
  )

--- a/tests/compiler/std/date.release.wat
+++ b/tests/compiler/std/date.release.wat
@@ -2393,11 +2393,7 @@
          end
          local.get $0
          i32.load
-         local.tee $0
-         if
-          local.get $0
-          call $~lib/rt/itcms/__visit
-         end
+         call $~lib/rt/itcms/__visit
          return
         end
         return

--- a/tests/compiler/std/map.debug.wat
+++ b/tests/compiler/std/map.debug.wat
@@ -5247,12 +5247,8 @@
   call $~lib/object/Object~visit
   local.get $0
   i32.load
-  local.tee $2
-  if
-   local.get $2
-   local.get $1
-   call $~lib/rt/itcms/__visit
-  end
+  local.get $1
+  call $~lib/rt/itcms/__visit
  )
  (func $~lib/object/Object~visit (param $0 i32) (param $1 i32)
  )

--- a/tests/compiler/std/map.release.wat
+++ b/tests/compiler/std/map.release.wat
@@ -1635,11 +1635,7 @@
       end
       local.get $0
       i32.load
-      local.tee $0
-      if
-       local.get $0
-       call $~lib/rt/itcms/__visit
-      end
+      call $~lib/rt/itcms/__visit
       return
      end
      unreachable

--- a/tests/compiler/std/new.debug.wat
+++ b/tests/compiler/std/new.debug.wat
@@ -2305,12 +2305,8 @@
   call $~lib/object/Object~visit
   local.get $0
   i32.load
-  local.tee $2
-  if
-   local.get $2
-   local.get $1
-   call $~lib/rt/itcms/__visit
-  end
+  local.get $1
+  call $~lib/rt/itcms/__visit
  )
  (func $~lib/object/Object~visit (param $0 i32) (param $1 i32)
  )

--- a/tests/compiler/std/new.release.wat
+++ b/tests/compiler/std/new.release.wat
@@ -1392,11 +1392,7 @@
     end
     local.get $0
     i32.load
-    local.tee $0
-    if
-     local.get $0
-     call $~lib/rt/itcms/__visit
-    end
+    call $~lib/rt/itcms/__visit
     return
    end
    return

--- a/tests/compiler/std/operator-overloading.debug.wat
+++ b/tests/compiler/std/operator-overloading.debug.wat
@@ -3158,12 +3158,8 @@
   call $~lib/object/Object~visit
   local.get $0
   i32.load
-  local.tee $2
-  if
-   local.get $2
-   local.get $1
-   call $~lib/rt/itcms/__visit
-  end
+  local.get $1
+  call $~lib/rt/itcms/__visit
  )
  (func $~lib/object/Object~visit (param $0 i32) (param $1 i32)
  )

--- a/tests/compiler/std/operator-overloading.release.wat
+++ b/tests/compiler/std/operator-overloading.release.wat
@@ -2012,11 +2012,7 @@
        end
        local.get $0
        i32.load
-       local.tee $0
-       if
-        local.get $0
-        call $~lib/rt/itcms/__visit
-       end
+       call $~lib/rt/itcms/__visit
        return
       end
       return

--- a/tests/compiler/std/set.debug.wat
+++ b/tests/compiler/std/set.debug.wat
@@ -4348,12 +4348,8 @@
   call $~lib/object/Object~visit
   local.get $0
   i32.load
-  local.tee $2
-  if
-   local.get $2
-   local.get $1
-   call $~lib/rt/itcms/__visit
-  end
+  local.get $1
+  call $~lib/rt/itcms/__visit
  )
  (func $~lib/object/Object~visit (param $0 i32) (param $1 i32)
  )

--- a/tests/compiler/std/set.release.wat
+++ b/tests/compiler/std/set.release.wat
@@ -1626,11 +1626,7 @@
       end
       local.get $0
       i32.load
-      local.tee $0
-      if
-       local.get $0
-       call $~lib/rt/itcms/__visit
-      end
+      call $~lib/rt/itcms/__visit
       return
      end
      unreachable

--- a/tests/compiler/std/static-array.debug.wat
+++ b/tests/compiler/std/static-array.debug.wat
@@ -2488,12 +2488,8 @@
   call $~lib/object/Object~visit
   local.get $0
   i32.load
-  local.tee $2
-  if
-   local.get $2
-   local.get $1
-   call $~lib/rt/itcms/__visit
-  end
+  local.get $1
+  call $~lib/rt/itcms/__visit
  )
  (func $~lib/object/Object~visit (param $0 i32) (param $1 i32)
  )

--- a/tests/compiler/std/static-array.release.wat
+++ b/tests/compiler/std/static-array.release.wat
@@ -1265,11 +1265,7 @@
     end
     local.get $0
     i32.load
-    local.tee $0
-    if
-     local.get $0
-     call $~lib/rt/itcms/__visit
-    end
+    call $~lib/rt/itcms/__visit
     return
    end
    unreachable

--- a/tests/compiler/std/staticarray.debug.wat
+++ b/tests/compiler/std/staticarray.debug.wat
@@ -3562,12 +3562,8 @@
   call $~lib/object/Object~visit
   local.get $0
   i32.load
-  local.tee $2
-  if
-   local.get $2
-   local.get $1
-   call $~lib/rt/itcms/__visit
-  end
+  local.get $1
+  call $~lib/rt/itcms/__visit
  )
  (func $~lib/object/Object~visit (param $0 i32) (param $1 i32)
  )

--- a/tests/compiler/std/staticarray.release.wat
+++ b/tests/compiler/std/staticarray.release.wat
@@ -2284,11 +2284,7 @@
               end
               local.get $0
               i32.load
-              local.tee $0
-              if
-               local.get $0
-               call $~lib/rt/itcms/__visit
-              end
+              call $~lib/rt/itcms/__visit
               return
              end
              return

--- a/tests/compiler/std/string-casemapping.debug.wat
+++ b/tests/compiler/std/string-casemapping.debug.wat
@@ -3437,12 +3437,8 @@
   call $~lib/object/Object~visit
   local.get $0
   i32.load
-  local.tee $2
-  if
-   local.get $2
-   local.get $1
-   call $~lib/rt/itcms/__visit
-  end
+  local.get $1
+  call $~lib/rt/itcms/__visit
  )
  (func $~lib/object/Object~visit (param $0 i32) (param $1 i32)
  )

--- a/tests/compiler/std/string-casemapping.release.wat
+++ b/tests/compiler/std/string-casemapping.release.wat
@@ -2288,11 +2288,7 @@
     end
     local.get $0
     i32.load
-    local.tee $0
-    if
-     local.get $0
-     call $~lib/rt/itcms/__visit
-    end
+    call $~lib/rt/itcms/__visit
     return
    end
    return

--- a/tests/compiler/std/string-encoding.debug.wat
+++ b/tests/compiler/std/string-encoding.debug.wat
@@ -2885,12 +2885,8 @@
   call $~lib/object/Object~visit
   local.get $0
   i32.load
-  local.tee $2
-  if
-   local.get $2
-   local.get $1
-   call $~lib/rt/itcms/__visit
-  end
+  local.get $1
+  call $~lib/rt/itcms/__visit
  )
  (func $~lib/object/Object~visit (param $0 i32) (param $1 i32)
  )

--- a/tests/compiler/std/string-encoding.release.wat
+++ b/tests/compiler/std/string-encoding.release.wat
@@ -1673,11 +1673,7 @@
    end
    local.get $0
    i32.load
-   local.tee $0
-   if
-    local.get $0
-    call $~lib/rt/itcms/__visit
-   end
+   call $~lib/rt/itcms/__visit
    return
   end
   unreachable

--- a/tests/compiler/std/string.debug.wat
+++ b/tests/compiler/std/string.debug.wat
@@ -5554,12 +5554,8 @@
   call $~lib/object/Object~visit
   local.get $0
   i32.load
-  local.tee $2
-  if
-   local.get $2
-   local.get $1
-   call $~lib/rt/itcms/__visit
-  end
+  local.get $1
+  call $~lib/rt/itcms/__visit
  )
  (func $~lib/object/Object~visit (param $0 i32) (param $1 i32)
  )

--- a/tests/compiler/std/string.release.wat
+++ b/tests/compiler/std/string.release.wat
@@ -4288,11 +4288,7 @@
        end
        local.get $0
        i32.load
-       local.tee $0
-       if
-        local.get $0
-        call $~lib/rt/itcms/__visit
-       end
+       call $~lib/rt/itcms/__visit
        return
       end
       global.get $~lib/memory/__stack_pointer

--- a/tests/compiler/std/symbol.debug.wat
+++ b/tests/compiler/std/symbol.debug.wat
@@ -2799,12 +2799,8 @@
   call $~lib/object/Object~visit
   local.get $0
   i32.load
-  local.tee $2
-  if
-   local.get $2
-   local.get $1
-   call $~lib/rt/itcms/__visit
-  end
+  local.get $1
+  call $~lib/rt/itcms/__visit
  )
  (func $~lib/object/Object~visit (param $0 i32) (param $1 i32)
  )

--- a/tests/compiler/std/symbol.release.wat
+++ b/tests/compiler/std/symbol.release.wat
@@ -1715,11 +1715,7 @@
        end
        local.get $0
        i32.load
-       local.tee $0
-       if
-        local.get $0
-        call $~lib/rt/itcms/__visit
-       end
+       call $~lib/rt/itcms/__visit
        return
       end
       global.get $~lib/memory/__stack_pointer

--- a/tests/compiler/std/typedarray.debug.wat
+++ b/tests/compiler/std/typedarray.debug.wat
@@ -13162,12 +13162,8 @@
   call $~lib/object/Object~visit
   local.get $0
   i32.load
-  local.tee $2
-  if
-   local.get $2
-   local.get $1
-   call $~lib/rt/itcms/__visit
-  end
+  local.get $1
+  call $~lib/rt/itcms/__visit
  )
  (func $~lib/object/Object~visit (param $0 i32) (param $1 i32)
  )

--- a/tests/compiler/std/typedarray.release.wat
+++ b/tests/compiler/std/typedarray.release.wat
@@ -766,7 +766,7 @@
    local.get $1
    global.set $~lib/rt/itcms/iter
   end
-  block $__inlined_func$~lib/rt/itcms/Object#unlink$1391
+  block $__inlined_func$~lib/rt/itcms/Object#unlink$1403
    local.get $0
    i32.load offset=4
    i32.const -4
@@ -790,7 +790,7 @@
      call $~lib/builtins/abort
      unreachable
     end
-    br $__inlined_func$~lib/rt/itcms/Object#unlink$1391
+    br $__inlined_func$~lib/rt/itcms/Object#unlink$1403
    end
    local.get $0
    i32.load offset=8
@@ -9400,11 +9400,7 @@
    end
    local.get $0
    i32.load
-   local.tee $0
-   if
-    local.get $0
-    call $~lib/rt/itcms/__visit
-   end
+   call $~lib/rt/itcms/__visit
    return
   end
   i32.const 49120
@@ -35310,7 +35306,7 @@
    global.get $~lib/memory/__stack_pointer
    i64.const 0
    i64.store
-   block $__inlined_func$~lib/util/string/joinIntegerArray<i8>$1396
+   block $__inlined_func$~lib/util/string/joinIntegerArray<i8>$1408
     local.get $0
     i32.const 1
     i32.sub
@@ -35324,7 +35320,7 @@
      global.set $~lib/memory/__stack_pointer
      i32.const 7776
      local.set $0
-     br $__inlined_func$~lib/util/string/joinIntegerArray<i8>$1396
+     br $__inlined_func$~lib/util/string/joinIntegerArray<i8>$1408
     end
     local.get $6
     i32.eqz
@@ -35337,7 +35333,7 @@
      i32.const 8
      i32.add
      global.set $~lib/memory/__stack_pointer
-     br $__inlined_func$~lib/util/string/joinIntegerArray<i8>$1396
+     br $__inlined_func$~lib/util/string/joinIntegerArray<i8>$1408
     end
     global.get $~lib/memory/__stack_pointer
     i32.const 9584
@@ -35430,7 +35426,7 @@
      i32.const 8
      i32.add
      global.set $~lib/memory/__stack_pointer
-     br $__inlined_func$~lib/util/string/joinIntegerArray<i8>$1396
+     br $__inlined_func$~lib/util/string/joinIntegerArray<i8>$1408
     end
     global.get $~lib/memory/__stack_pointer
     i32.const 8
@@ -35658,7 +35654,7 @@
    global.get $~lib/memory/__stack_pointer
    i64.const 0
    i64.store
-   block $__inlined_func$~lib/util/string/joinIntegerArray<u8>$1397
+   block $__inlined_func$~lib/util/string/joinIntegerArray<u8>$1409
     local.get $0
     i32.const 1
     i32.sub
@@ -35672,7 +35668,7 @@
      global.set $~lib/memory/__stack_pointer
      i32.const 7776
      local.set $0
-     br $__inlined_func$~lib/util/string/joinIntegerArray<u8>$1397
+     br $__inlined_func$~lib/util/string/joinIntegerArray<u8>$1409
     end
     local.get $6
     i32.eqz
@@ -35685,7 +35681,7 @@
      i32.const 8
      i32.add
      global.set $~lib/memory/__stack_pointer
-     br $__inlined_func$~lib/util/string/joinIntegerArray<u8>$1397
+     br $__inlined_func$~lib/util/string/joinIntegerArray<u8>$1409
     end
     global.get $~lib/memory/__stack_pointer
     i32.const 9584
@@ -35778,7 +35774,7 @@
      i32.const 8
      i32.add
      global.set $~lib/memory/__stack_pointer
-     br $__inlined_func$~lib/util/string/joinIntegerArray<u8>$1397
+     br $__inlined_func$~lib/util/string/joinIntegerArray<u8>$1409
     end
     global.get $~lib/memory/__stack_pointer
     i32.const 8
@@ -35876,7 +35872,7 @@
    global.get $~lib/memory/__stack_pointer
    i64.const 0
    i64.store
-   block $__inlined_func$~lib/util/string/joinIntegerArray<i16>$1398
+   block $__inlined_func$~lib/util/string/joinIntegerArray<i16>$1410
     local.get $0
     i32.const 1
     i32.sub
@@ -35890,7 +35886,7 @@
      global.set $~lib/memory/__stack_pointer
      i32.const 7776
      local.set $0
-     br $__inlined_func$~lib/util/string/joinIntegerArray<i16>$1398
+     br $__inlined_func$~lib/util/string/joinIntegerArray<i16>$1410
     end
     local.get $6
     i32.eqz
@@ -35903,7 +35899,7 @@
      i32.const 8
      i32.add
      global.set $~lib/memory/__stack_pointer
-     br $__inlined_func$~lib/util/string/joinIntegerArray<i16>$1398
+     br $__inlined_func$~lib/util/string/joinIntegerArray<i16>$1410
     end
     global.get $~lib/memory/__stack_pointer
     i32.const 9584
@@ -36000,7 +35996,7 @@
      i32.const 8
      i32.add
      global.set $~lib/memory/__stack_pointer
-     br $__inlined_func$~lib/util/string/joinIntegerArray<i16>$1398
+     br $__inlined_func$~lib/util/string/joinIntegerArray<i16>$1410
     end
     global.get $~lib/memory/__stack_pointer
     i32.const 8
@@ -36066,7 +36062,7 @@
    global.get $~lib/memory/__stack_pointer
    i64.const 0
    i64.store
-   block $__inlined_func$~lib/util/string/joinIntegerArray<u16>$1399
+   block $__inlined_func$~lib/util/string/joinIntegerArray<u16>$1411
     local.get $0
     i32.const 1
     i32.sub
@@ -36080,7 +36076,7 @@
      global.set $~lib/memory/__stack_pointer
      i32.const 7776
      local.set $0
-     br $__inlined_func$~lib/util/string/joinIntegerArray<u16>$1399
+     br $__inlined_func$~lib/util/string/joinIntegerArray<u16>$1411
     end
     local.get $6
     i32.eqz
@@ -36093,7 +36089,7 @@
      i32.const 8
      i32.add
      global.set $~lib/memory/__stack_pointer
-     br $__inlined_func$~lib/util/string/joinIntegerArray<u16>$1399
+     br $__inlined_func$~lib/util/string/joinIntegerArray<u16>$1411
     end
     global.get $~lib/memory/__stack_pointer
     i32.const 9584
@@ -36190,7 +36186,7 @@
      i32.const 8
      i32.add
      global.set $~lib/memory/__stack_pointer
-     br $__inlined_func$~lib/util/string/joinIntegerArray<u16>$1399
+     br $__inlined_func$~lib/util/string/joinIntegerArray<u16>$1411
     end
     global.get $~lib/memory/__stack_pointer
     i32.const 8
@@ -36256,7 +36252,7 @@
    global.get $~lib/memory/__stack_pointer
    i64.const 0
    i64.store
-   block $__inlined_func$~lib/util/string/joinIntegerArray<i32>$1400
+   block $__inlined_func$~lib/util/string/joinIntegerArray<i32>$1412
     local.get $0
     i32.const 1
     i32.sub
@@ -36270,7 +36266,7 @@
      global.set $~lib/memory/__stack_pointer
      i32.const 7776
      local.set $0
-     br $__inlined_func$~lib/util/string/joinIntegerArray<i32>$1400
+     br $__inlined_func$~lib/util/string/joinIntegerArray<i32>$1412
     end
     local.get $6
     i32.eqz
@@ -36283,7 +36279,7 @@
      i32.const 8
      i32.add
      global.set $~lib/memory/__stack_pointer
-     br $__inlined_func$~lib/util/string/joinIntegerArray<i32>$1400
+     br $__inlined_func$~lib/util/string/joinIntegerArray<i32>$1412
     end
     global.get $~lib/memory/__stack_pointer
     i32.const 9584
@@ -36380,7 +36376,7 @@
      i32.const 8
      i32.add
      global.set $~lib/memory/__stack_pointer
-     br $__inlined_func$~lib/util/string/joinIntegerArray<i32>$1400
+     br $__inlined_func$~lib/util/string/joinIntegerArray<i32>$1412
     end
     global.get $~lib/memory/__stack_pointer
     i32.const 8
@@ -36446,7 +36442,7 @@
    global.get $~lib/memory/__stack_pointer
    i64.const 0
    i64.store
-   block $__inlined_func$~lib/util/string/joinIntegerArray<u32>$1401
+   block $__inlined_func$~lib/util/string/joinIntegerArray<u32>$1413
     local.get $0
     i32.const 1
     i32.sub
@@ -36460,7 +36456,7 @@
      global.set $~lib/memory/__stack_pointer
      i32.const 7776
      local.set $0
-     br $__inlined_func$~lib/util/string/joinIntegerArray<u32>$1401
+     br $__inlined_func$~lib/util/string/joinIntegerArray<u32>$1413
     end
     local.get $6
     i32.eqz
@@ -36473,7 +36469,7 @@
      i32.const 8
      i32.add
      global.set $~lib/memory/__stack_pointer
-     br $__inlined_func$~lib/util/string/joinIntegerArray<u32>$1401
+     br $__inlined_func$~lib/util/string/joinIntegerArray<u32>$1413
     end
     global.get $~lib/memory/__stack_pointer
     i32.const 9584
@@ -36570,7 +36566,7 @@
      i32.const 8
      i32.add
      global.set $~lib/memory/__stack_pointer
-     br $__inlined_func$~lib/util/string/joinIntegerArray<u32>$1401
+     br $__inlined_func$~lib/util/string/joinIntegerArray<u32>$1413
     end
     global.get $~lib/memory/__stack_pointer
     i32.const 8
@@ -36637,7 +36633,7 @@
    global.get $~lib/memory/__stack_pointer
    i64.const 0
    i64.store
-   block $__inlined_func$~lib/util/string/joinIntegerArray<i64>$6
+   block $__inlined_func$~lib/util/string/joinIntegerArray<i64>$5
     local.get $0
     i32.const 1
     i32.sub
@@ -36651,7 +36647,7 @@
      global.set $~lib/memory/__stack_pointer
      i32.const 7776
      local.set $0
-     br $__inlined_func$~lib/util/string/joinIntegerArray<i64>$6
+     br $__inlined_func$~lib/util/string/joinIntegerArray<i64>$5
     end
     block $folding-inner0
      local.get $6
@@ -36943,7 +36939,7 @@
      i32.const 8
      i32.add
      global.set $~lib/memory/__stack_pointer
-     br $__inlined_func$~lib/util/string/joinIntegerArray<i64>$6
+     br $__inlined_func$~lib/util/string/joinIntegerArray<i64>$5
     end
     global.get $~lib/memory/__stack_pointer
     i32.const 8

--- a/tests/compiler/std/uri.debug.wat
+++ b/tests/compiler/std/uri.debug.wat
@@ -3422,12 +3422,8 @@
   call $~lib/object/Object~visit
   local.get $0
   i32.load
-  local.tee $2
-  if
-   local.get $2
-   local.get $1
-   call $~lib/rt/itcms/__visit
-  end
+  local.get $1
+  call $~lib/rt/itcms/__visit
  )
  (func $~lib/object/Object~visit (param $0 i32) (param $1 i32)
  )

--- a/tests/compiler/std/uri.release.wat
+++ b/tests/compiler/std/uri.release.wat
@@ -2629,11 +2629,7 @@
    end
    local.get $0
    i32.load
-   local.tee $0
-   if
-    local.get $0
-    call $~lib/rt/itcms/__visit
-   end
+   call $~lib/rt/itcms/__visit
    return
   end
   unreachable

--- a/tests/compiler/super-inline.debug.wat
+++ b/tests/compiler/super-inline.debug.wat
@@ -2299,12 +2299,8 @@
   call $~lib/object/Object~visit
   local.get $0
   i32.load
-  local.tee $2
-  if
-   local.get $2
-   local.get $1
-   call $~lib/rt/itcms/__visit
-  end
+  local.get $1
+  call $~lib/rt/itcms/__visit
  )
  (func $~lib/object/Object~visit (param $0 i32) (param $1 i32)
  )

--- a/tests/compiler/super-inline.release.wat
+++ b/tests/compiler/super-inline.release.wat
@@ -1401,11 +1401,7 @@
      end
      local.get $0
      i32.load
-     local.tee $0
-     if
-      local.get $0
-      call $~lib/rt/itcms/__visit
-     end
+     call $~lib/rt/itcms/__visit
      return
     end
     return

--- a/tests/compiler/switch.debug.wat
+++ b/tests/compiler/switch.debug.wat
@@ -2833,12 +2833,8 @@
   call $~lib/object/Object~visit
   local.get $0
   i32.load
-  local.tee $2
-  if
-   local.get $2
-   local.get $1
-   call $~lib/rt/itcms/__visit
-  end
+  local.get $1
+  call $~lib/rt/itcms/__visit
  )
  (func $~lib/object/Object~visit (param $0 i32) (param $1 i32)
  )

--- a/tests/compiler/switch.release.wat
+++ b/tests/compiler/switch.release.wat
@@ -1587,11 +1587,7 @@
      end
      local.get $0
      i32.load
-     local.tee $0
-     if
-      local.get $0
-      call $~lib/rt/itcms/__visit
-     end
+     call $~lib/rt/itcms/__visit
      return
     end
     return

--- a/tests/compiler/templateliteral.debug.wat
+++ b/tests/compiler/templateliteral.debug.wat
@@ -4395,12 +4395,8 @@
   call $~lib/object/Object~visit
   local.get $0
   i32.load
-  local.tee $2
-  if
-   local.get $2
-   local.get $1
-   call $~lib/rt/itcms/__visit
-  end
+  local.get $1
+  call $~lib/rt/itcms/__visit
  )
  (func $~lib/object/Object~visit (param $0 i32) (param $1 i32)
  )
@@ -4456,20 +4452,12 @@
   call $~lib/object/Object~visit
   local.get $0
   i32.load
-  local.tee $2
-  if
-   local.get $2
-   local.get $1
-   call $~lib/rt/itcms/__visit
-  end
+  local.get $1
+  call $~lib/rt/itcms/__visit
   local.get $0
   i32.load offset=4
-  local.tee $2
-  if
-   local.get $2
-   local.get $1
-   call $~lib/rt/itcms/__visit
-  end
+  local.get $1
+  call $~lib/rt/itcms/__visit
  )
  (func $~lib/rt/__visit_members (param $0 i32) (param $1 i32)
   block $invalid

--- a/tests/compiler/templateliteral.release.wat
+++ b/tests/compiler/templateliteral.release.wat
@@ -3807,11 +3807,7 @@
       end
       local.get $0
       i32.load
-      local.tee $0
-      if
-       local.get $0
-       call $~lib/rt/itcms/__visit
-      end
+      call $~lib/rt/itcms/__visit
       return
      end
      local.get $0
@@ -3846,18 +3842,10 @@
    end
    local.get $0
    i32.load
-   local.tee $1
-   if
-    local.get $1
-    call $~lib/rt/itcms/__visit
-   end
+   call $~lib/rt/itcms/__visit
    local.get $0
    i32.load offset=4
-   local.tee $0
-   if
-    local.get $0
-    call $~lib/rt/itcms/__visit
-   end
+   call $~lib/rt/itcms/__visit
    return
   end
   unreachable

--- a/tests/compiler/throw.debug.wat
+++ b/tests/compiler/throw.debug.wat
@@ -1815,12 +1815,8 @@
   call $~lib/object/Object~visit
   local.get $0
   i32.load
-  local.tee $2
-  if
-   local.get $2
-   local.get $1
-   call $~lib/rt/itcms/__visit
-  end
+  local.get $1
+  call $~lib/rt/itcms/__visit
  )
  (func $~lib/object/Object~visit (param $0 i32) (param $1 i32)
  )

--- a/tests/compiler/throw.release.wat
+++ b/tests/compiler/throw.release.wat
@@ -1098,11 +1098,7 @@
    end
    local.get $0
    i32.load
-   local.tee $0
-   if
-    local.get $0
-    call $~lib/rt/itcms/__visit
-   end
+   call $~lib/rt/itcms/__visit
    return
   end
   unreachable

--- a/tests/compiler/typeof.debug.wat
+++ b/tests/compiler/typeof.debug.wat
@@ -2411,12 +2411,8 @@
   call $~lib/object/Object~visit
   local.get $0
   i32.load
-  local.tee $2
-  if
-   local.get $2
-   local.get $1
-   call $~lib/rt/itcms/__visit
-  end
+  local.get $1
+  call $~lib/rt/itcms/__visit
  )
  (func $~lib/object/Object~visit (param $0 i32) (param $1 i32)
  )

--- a/tests/compiler/typeof.release.wat
+++ b/tests/compiler/typeof.release.wat
@@ -1417,11 +1417,7 @@
      end
      local.get $0
      i32.load
-     local.tee $0
-     if
-      local.get $0
-      call $~lib/rt/itcms/__visit
-     end
+     call $~lib/rt/itcms/__visit
      return
     end
     global.get $~lib/memory/__stack_pointer

--- a/tests/compiler/while.debug.wat
+++ b/tests/compiler/while.debug.wat
@@ -3166,12 +3166,8 @@
   call $~lib/object/Object~visit
   local.get $0
   i32.load
-  local.tee $2
-  if
-   local.get $2
-   local.get $1
-   call $~lib/rt/itcms/__visit
-  end
+  local.get $1
+  call $~lib/rt/itcms/__visit
  )
  (func $~lib/object/Object~visit (param $0 i32) (param $1 i32)
  )

--- a/tests/compiler/while.release.wat
+++ b/tests/compiler/while.release.wat
@@ -1902,11 +1902,7 @@
     end
     local.get $0
     i32.load
-    local.tee $0
-    if
-     local.get $0
-     call $~lib/rt/itcms/__visit
-    end
+    call $~lib/rt/itcms/__visit
     return
    end
    return


### PR DESCRIPTION
In the implementation of __visit, we will do non-zero check, so in visitMemberOf, we don't need to emit non-zero check.
Emit them both maybe have some performance benefit (I don't do bench for it), but at least for -Oz target, we should remove it.

```ts
export function __visit(ptr: usize, cookie: i32): void {
  if (!ptr) return;
...
```