### PR TITLE
fix: avoid to use visit wrapper for __visit_globals

### DIFF
--- a/src/builtins.ts
+++ b/src/builtins.ts
@@ -10674,11 +10674,12 @@ builtinFunctions.set(BuiltinNames.i32x4_relaxed_dot_i8x16_i7x16_add_s, builtin_i
 
 // === Internal helpers =======================================================================
 
+// When no visit is needed, null is returned, otherwise the name of the visit function is returned.
 function getVisitInstanceName(visitInstance: Function, classReference: Class): string | null {
   if (classReference.hasDecorator(DecoratorFlags.Final)) {
     if (classReference.visitRef != 0) {
       return classReference.visitorFunctionName;
-    } else  if (classReference.isPointerfree) {
+    } else if (classReference.isPointerfree) {
       return null; // no visitor for pointerfree classes
     }
   }

--- a/src/compiler.ts
+++ b/src/compiler.ts
@@ -647,6 +647,8 @@ export class Compiler extends DiagnosticEmitter {
     // finalize runtime features
     module.removeGlobal(BuiltinNames.rtti_base);
     if (this.runtimeFeatures & RuntimeFeatures.Rtti) compileRTTI(this);
+    // visit globals can rely on the result of visit members to visit globals of
+    // certain type directly thought the visit of the class.
     if (this.runtimeFeatures & RuntimeFeatures.visitMembers) compileVisitMembers(this);
     if (this.runtimeFeatures & RuntimeFeatures.visitGlobals) compileVisitGlobals(this);
 

--- a/src/compiler.ts
+++ b/src/compiler.ts
@@ -647,8 +647,8 @@ export class Compiler extends DiagnosticEmitter {
     // finalize runtime features
     module.removeGlobal(BuiltinNames.rtti_base);
     if (this.runtimeFeatures & RuntimeFeatures.Rtti) compileRTTI(this);
-    if (this.runtimeFeatures & RuntimeFeatures.visitGlobals) compileVisitGlobals(this);
     if (this.runtimeFeatures & RuntimeFeatures.visitMembers) compileVisitMembers(this);
+    if (this.runtimeFeatures & RuntimeFeatures.visitGlobals) compileVisitGlobals(this);
 
     let memoryOffset = i64_align(this.memoryOffset, options.usizeType.byteSize);
 

--- a/src/program.ts
+++ b/src/program.ts
@@ -4910,6 +4910,10 @@ export class Class extends TypedElement {
     }
     return false;
   }
+
+  get visitorFunctionName(): string {
+    return `${this.internalName}~visit`;
+  }
 }
 
 /** A yet unresolved interface. */

--- a/tests/compiler/assignment-chain.debug.wat
+++ b/tests/compiler/assignment-chain.debug.wat
@@ -2333,15 +2333,6 @@
   call $assignment-chain/setter_assignment_chain
   call $assignment-chain/static_setter_assignment_chain
  )
- (func $~lib/rt/__visit_globals (param $0 i32)
-  (local $1 i32)
-  i32.const 224
-  local.get $0
-  call $~lib/rt/itcms/__visit
-  i32.const 32
-  local.get $0
-  call $~lib/rt/itcms/__visit
- )
  (func $~lib/arraybuffer/ArrayBufferView~visit (param $0 i32) (param $1 i32)
   (local $2 i32)
   local.get $0
@@ -2384,6 +2375,9 @@
    return
   end
   unreachable
+ )
+ (func $~lib/rt/__visit_globals (param $0 i32)
+  (local $1 i32)
  )
  (func $~start
   call $start:assignment-chain

--- a/tests/compiler/assignment-chain.release.wat
+++ b/tests/compiler/assignment-chain.release.wat
@@ -42,10 +42,6 @@
  (func $~lib/rt/itcms/visitRoots
   (local $0 i32)
   (local $1 i32)
-  i32.const 1248
-  call $~lib/rt/itcms/__visit
-  i32.const 1056
-  call $~lib/rt/itcms/__visit
   global.get $~lib/rt/itcms/pinSpace
   local.tee $1
   i32.load offset=4

--- a/tests/compiler/bindings/esm.debug.wat
+++ b/tests/compiler/bindings/esm.debug.wat
@@ -2832,41 +2832,6 @@
   i32.const 0
   drop
  )
- (func $~lib/rt/__visit_globals (param $0 i32)
-  (local $1 i32)
-  global.get $bindings/esm/stringGlobal
-  local.tee $1
-  if
-   local.get $1
-   local.get $0
-   call $~lib/rt/itcms/__visit
-  end
-  global.get $bindings/esm/mutableStringGlobal
-  local.tee $1
-  if
-   local.get $1
-   local.get $0
-   call $~lib/rt/itcms/__visit
-  end
-  i32.const 528
-  local.get $0
-  call $~lib/rt/itcms/__visit
-  i32.const 224
-  local.get $0
-  call $~lib/rt/itcms/__visit
-  i32.const 944
-  local.get $0
-  call $~lib/rt/itcms/__visit
-  i32.const 336
-  local.get $0
-  call $~lib/rt/itcms/__visit
-  i32.const 1072
-  local.get $0
-  call $~lib/rt/itcms/__visit
-  i32.const 1136
-  local.get $0
-  call $~lib/rt/itcms/__visit
- )
  (func $~lib/arraybuffer/ArrayBufferView~visit (param $0 i32) (param $1 i32)
   (local $2 i32)
   local.get $0
@@ -3037,6 +3002,9 @@
    return
   end
   unreachable
+ )
+ (func $~lib/rt/__visit_globals (param $0 i32)
+  (local $1 i32)
  )
  (func $~setArgumentsLength (param $0 i32)
   local.get $0

--- a/tests/compiler/bindings/esm.release.wat
+++ b/tests/compiler/bindings/esm.release.wat
@@ -139,26 +139,6 @@
  (func $~lib/rt/itcms/visitRoots
   (local $0 i32)
   (local $1 i32)
-  i32.const 1056
-  call $~lib/rt/itcms/__visit
-  global.get $bindings/esm/mutableStringGlobal
-  local.tee $0
-  if
-   local.get $0
-   call $~lib/rt/itcms/__visit
-  end
-  i32.const 1552
-  call $~lib/rt/itcms/__visit
-  i32.const 1248
-  call $~lib/rt/itcms/__visit
-  i32.const 1968
-  call $~lib/rt/itcms/__visit
-  i32.const 1360
-  call $~lib/rt/itcms/__visit
-  i32.const 2096
-  call $~lib/rt/itcms/__visit
-  i32.const 2160
-  call $~lib/rt/itcms/__visit
   global.get $~lib/rt/itcms/pinSpace
   local.tee $1
   i32.load offset=4

--- a/tests/compiler/bindings/noExportRuntime.debug.wat
+++ b/tests/compiler/bindings/noExportRuntime.debug.wat
@@ -2415,53 +2415,6 @@
  )
  (func $bindings/noExportRuntime/takesFunction (param $fn i32)
  )
- (func $~lib/rt/__visit_globals (param $0 i32)
-  (local $1 i32)
-  global.get $bindings/noExportRuntime/isString
-  local.tee $1
-  if
-   local.get $1
-   local.get $0
-   call $~lib/rt/itcms/__visit
-  end
-  global.get $bindings/noExportRuntime/isBuffer
-  local.tee $1
-  if
-   local.get $1
-   local.get $0
-   call $~lib/rt/itcms/__visit
-  end
-  global.get $bindings/noExportRuntime/isTypedArray
-  local.tee $1
-  if
-   local.get $1
-   local.get $0
-   call $~lib/rt/itcms/__visit
-  end
-  global.get $bindings/noExportRuntime/isArrayOfBasic
-  local.tee $1
-  if
-   local.get $1
-   local.get $0
-   call $~lib/rt/itcms/__visit
-  end
-  global.get $bindings/noExportRuntime/isArrayOfArray
-  local.tee $1
-  if
-   local.get $1
-   local.get $0
-   call $~lib/rt/itcms/__visit
-  end
-  i32.const 368
-  local.get $0
-  call $~lib/rt/itcms/__visit
-  i32.const 64
-  local.get $0
-  call $~lib/rt/itcms/__visit
-  i32.const 176
-  local.get $0
-  call $~lib/rt/itcms/__visit
- )
  (func $~lib/arraybuffer/ArrayBufferView~visit (param $0 i32) (param $1 i32)
   (local $2 i32)
   local.get $0
@@ -2556,6 +2509,30 @@
    return
   end
   unreachable
+ )
+ (func $~lib/rt/__visit_globals (param $0 i32)
+  (local $1 i32)
+  global.get $bindings/noExportRuntime/isTypedArray
+  local.tee $1
+  if
+   local.get $1
+   local.get $0
+   call $~lib/rt/itcms/__visit
+  end
+  global.get $bindings/noExportRuntime/isArrayOfBasic
+  local.tee $1
+  if
+   local.get $1
+   local.get $0
+   call $~lib/rt/itcms/__visit
+  end
+  global.get $bindings/noExportRuntime/isArrayOfArray
+  local.tee $1
+  if
+   local.get $1
+   local.get $0
+   call $~lib/rt/itcms/__visit
+  end
  )
  (func $~start
   global.get $~started

--- a/tests/compiler/bindings/noExportRuntime.release.wat
+++ b/tests/compiler/bindings/noExportRuntime.release.wat
@@ -71,14 +71,6 @@
  (func $~lib/rt/itcms/visitRoots
   (local $0 i32)
   (local $1 i32)
-  i32.const 1056
-  call $~lib/rt/itcms/__visit
-  global.get $bindings/noExportRuntime/isBuffer
-  local.tee $0
-  if
-   local.get $0
-   call $~lib/rt/itcms/__visit
-  end
   global.get $bindings/noExportRuntime/isTypedArray
   local.tee $0
   if
@@ -88,12 +80,6 @@
   i32.const 1632
   call $~lib/rt/itcms/__visit
   i32.const 1712
-  call $~lib/rt/itcms/__visit
-  i32.const 1392
-  call $~lib/rt/itcms/__visit
-  i32.const 1088
-  call $~lib/rt/itcms/__visit
-  i32.const 1200
   call $~lib/rt/itcms/__visit
   global.get $~lib/rt/itcms/pinSpace
   local.tee $1

--- a/tests/compiler/bindings/raw.debug.wat
+++ b/tests/compiler/bindings/raw.debug.wat
@@ -2835,41 +2835,6 @@
   i32.const 0
   drop
  )
- (func $~lib/rt/__visit_globals (param $0 i32)
-  (local $1 i32)
-  i32.const 528
-  local.get $0
-  call $~lib/rt/itcms/__visit
-  i32.const 224
-  local.get $0
-  call $~lib/rt/itcms/__visit
-  i32.const 944
-  local.get $0
-  call $~lib/rt/itcms/__visit
-  i32.const 336
-  local.get $0
-  call $~lib/rt/itcms/__visit
-  i32.const 1072
-  local.get $0
-  call $~lib/rt/itcms/__visit
-  i32.const 1136
-  local.get $0
-  call $~lib/rt/itcms/__visit
-  global.get $bindings/esm/stringGlobal
-  local.tee $1
-  if
-   local.get $1
-   local.get $0
-   call $~lib/rt/itcms/__visit
-  end
-  global.get $bindings/esm/mutableStringGlobal
-  local.tee $1
-  if
-   local.get $1
-   local.get $0
-   call $~lib/rt/itcms/__visit
-  end
- )
  (func $~lib/arraybuffer/ArrayBufferView~visit (param $0 i32) (param $1 i32)
   (local $2 i32)
   local.get $0
@@ -3040,6 +3005,9 @@
    return
   end
   unreachable
+ )
+ (func $~lib/rt/__visit_globals (param $0 i32)
+  (local $1 i32)
  )
  (func $~setArgumentsLength (param $0 i32)
   local.get $0

--- a/tests/compiler/bindings/raw.release.wat
+++ b/tests/compiler/bindings/raw.release.wat
@@ -139,26 +139,6 @@
  (func $~lib/rt/itcms/visitRoots
   (local $0 i32)
   (local $1 i32)
-  i32.const 1552
-  call $~lib/rt/itcms/__visit
-  i32.const 1248
-  call $~lib/rt/itcms/__visit
-  i32.const 1968
-  call $~lib/rt/itcms/__visit
-  i32.const 1360
-  call $~lib/rt/itcms/__visit
-  i32.const 2096
-  call $~lib/rt/itcms/__visit
-  i32.const 2160
-  call $~lib/rt/itcms/__visit
-  i32.const 1056
-  call $~lib/rt/itcms/__visit
-  global.get $bindings/esm/mutableStringGlobal
-  local.tee $0
-  if
-   local.get $0
-   call $~lib/rt/itcms/__visit
-  end
   global.get $~lib/rt/itcms/pinSpace
   local.tee $1
   i32.load offset=4

--- a/tests/compiler/call-inferred.debug.wat
+++ b/tests/compiler/call-inferred.debug.wat
@@ -2295,15 +2295,6 @@
   local.get $a
   return
  )
- (func $~lib/rt/__visit_globals (param $0 i32)
-  (local $1 i32)
-  i32.const 288
-  local.get $0
-  call $~lib/rt/itcms/__visit
-  i32.const 96
-  local.get $0
-  call $~lib/rt/itcms/__visit
- )
  (func $~lib/arraybuffer/ArrayBufferView~visit (param $0 i32) (param $1 i32)
   (local $2 i32)
   local.get $0
@@ -2349,6 +2340,9 @@
    return
   end
   unreachable
+ )
+ (func $~lib/rt/__visit_globals (param $0 i32)
+  (local $1 i32)
  )
  (func $~start
   call $start:call-inferred

--- a/tests/compiler/call-inferred.release.wat
+++ b/tests/compiler/call-inferred.release.wat
@@ -38,10 +38,6 @@
  (func $~lib/rt/itcms/visitRoots
   (local $0 i32)
   (local $1 i32)
-  i32.const 1312
-  call $~lib/rt/itcms/__visit
-  i32.const 1120
-  call $~lib/rt/itcms/__visit
   global.get $~lib/rt/itcms/pinSpace
   local.tee $1
   i32.load offset=4

--- a/tests/compiler/call-rest.debug.wat
+++ b/tests/compiler/call-rest.debug.wat
@@ -2437,18 +2437,6 @@
   local.get $this
   i32.load offset=12
  )
- (func $~lib/rt/__visit_globals (param $0 i32)
-  (local $1 i32)
-  i32.const 32
-  local.get $0
-  call $~lib/rt/itcms/__visit
-  i32.const 720
-  local.get $0
-  call $~lib/rt/itcms/__visit
-  i32.const 176
-  local.get $0
-  call $~lib/rt/itcms/__visit
- )
  (func $~lib/arraybuffer/ArrayBufferView~visit (param $0 i32) (param $1 i32)
   (local $2 i32)
   local.get $0
@@ -2577,6 +2565,9 @@
    return
   end
   unreachable
+ )
+ (func $~lib/rt/__visit_globals (param $0 i32)
+  (local $1 i32)
  )
  (func $~start
   call $start:call-rest

--- a/tests/compiler/call-rest.release.wat
+++ b/tests/compiler/call-rest.release.wat
@@ -80,12 +80,6 @@
  (func $~lib/rt/itcms/visitRoots
   (local $0 i32)
   (local $1 i32)
-  i32.const 1056
-  call $~lib/rt/itcms/__visit
-  i32.const 1744
-  call $~lib/rt/itcms/__visit
-  i32.const 1200
-  call $~lib/rt/itcms/__visit
   global.get $~lib/rt/itcms/pinSpace
   local.tee $1
   i32.load offset=4

--- a/tests/compiler/call-super.debug.wat
+++ b/tests/compiler/call-super.debug.wat
@@ -2356,15 +2356,6 @@
   call $call-super/test4
   call $call-super/test5
  )
- (func $~lib/rt/__visit_globals (param $0 i32)
-  (local $1 i32)
-  i32.const 272
-  local.get $0
-  call $~lib/rt/itcms/__visit
-  i32.const 80
-  local.get $0
-  call $~lib/rt/itcms/__visit
- )
  (func $~lib/arraybuffer/ArrayBufferView~visit (param $0 i32) (param $1 i32)
   (local $2 i32)
   local.get $0
@@ -2431,6 +2422,9 @@
    return
   end
   unreachable
+ )
+ (func $~lib/rt/__visit_globals (param $0 i32)
+  (local $1 i32)
  )
  (func $~start
   call $start:call-super

--- a/tests/compiler/call-super.release.wat
+++ b/tests/compiler/call-super.release.wat
@@ -38,10 +38,6 @@
  (func $~lib/rt/itcms/visitRoots
   (local $0 i32)
   (local $1 i32)
-  i32.const 1296
-  call $~lib/rt/itcms/__visit
-  i32.const 1104
-  call $~lib/rt/itcms/__visit
   global.get $~lib/rt/itcms/pinSpace
   local.tee $1
   i32.load offset=4

--- a/tests/compiler/class-implements.debug.wat
+++ b/tests/compiler/class-implements.debug.wat
@@ -2633,64 +2633,6 @@
   local.get $0
   call $class-implements/B2#get:foo
  )
- (func $~lib/rt/__visit_globals (param $0 i32)
-  (local $1 i32)
-  global.get $class-implements/a
-  local.tee $1
-  if
-   local.get $1
-   local.get $0
-   call $~lib/rt/itcms/__visit
-  end
-  global.get $class-implements/c
-  local.tee $1
-  if
-   local.get $1
-   local.get $0
-   call $~lib/rt/itcms/__visit
-  end
-  global.get $class-implements/d
-  local.tee $1
-  if
-   local.get $1
-   local.get $0
-   call $~lib/rt/itcms/__visit
-  end
-  global.get $class-implements/e
-  local.tee $1
-  if
-   local.get $1
-   local.get $0
-   call $~lib/rt/itcms/__visit
-  end
-  global.get $class-implements/f
-  local.tee $1
-  if
-   local.get $1
-   local.get $0
-   call $~lib/rt/itcms/__visit
-  end
-  global.get $class-implements/g
-  local.tee $1
-  if
-   local.get $1
-   local.get $0
-   call $~lib/rt/itcms/__visit
-  end
-  global.get $class-implements/h
-  local.tee $1
-  if
-   local.get $1
-   local.get $0
-   call $~lib/rt/itcms/__visit
-  end
-  i32.const 224
-  local.get $0
-  call $~lib/rt/itcms/__visit
-  i32.const 32
-  local.get $0
-  call $~lib/rt/itcms/__visit
- )
  (func $~lib/arraybuffer/ArrayBufferView~visit (param $0 i32) (param $1 i32)
   (local $2 i32)
   local.get $0
@@ -2778,6 +2720,58 @@
    return
   end
   unreachable
+ )
+ (func $~lib/rt/__visit_globals (param $0 i32)
+  (local $1 i32)
+  global.get $class-implements/a
+  local.tee $1
+  if
+   local.get $1
+   local.get $0
+   call $~lib/rt/itcms/__visit
+  end
+  global.get $class-implements/c
+  local.tee $1
+  if
+   local.get $1
+   local.get $0
+   call $~lib/rt/itcms/__visit
+  end
+  global.get $class-implements/d
+  local.tee $1
+  if
+   local.get $1
+   local.get $0
+   call $~lib/rt/itcms/__visit
+  end
+  global.get $class-implements/e
+  local.tee $1
+  if
+   local.get $1
+   local.get $0
+   call $~lib/rt/itcms/__visit
+  end
+  global.get $class-implements/f
+  local.tee $1
+  if
+   local.get $1
+   local.get $0
+   call $~lib/rt/itcms/__visit
+  end
+  global.get $class-implements/g
+  local.tee $1
+  if
+   local.get $1
+   local.get $0
+   call $~lib/rt/itcms/__visit
+  end
+  global.get $class-implements/h
+  local.tee $1
+  if
+   local.get $1
+   local.get $0
+   call $~lib/rt/itcms/__visit
+  end
  )
  (func $~start
   call $start:class-implements

--- a/tests/compiler/class-implements.release.wat
+++ b/tests/compiler/class-implements.release.wat
@@ -87,10 +87,6 @@
    local.get $0
    call $~lib/rt/itcms/__visit
   end
-  i32.const 1248
-  call $~lib/rt/itcms/__visit
-  i32.const 1056
-  call $~lib/rt/itcms/__visit
   global.get $~lib/rt/itcms/pinSpace
   local.tee $1
   i32.load offset=4

--- a/tests/compiler/class-overloading-cast.debug.wat
+++ b/tests/compiler/class-overloading-cast.debug.wat
@@ -2469,43 +2469,6 @@
   local.get $1
   call $class-overloading-cast/A<~lib/string/String>#foo
  )
- (func $~lib/rt/__visit_globals (param $0 i32)
-  (local $1 i32)
-  global.get $class-overloading-cast/v
-  local.tee $1
-  if
-   local.get $1
-   local.get $0
-   call $~lib/rt/itcms/__visit
-  end
-  global.get $class-overloading-cast/v2
-  local.tee $1
-  if
-   local.get $1
-   local.get $0
-   call $~lib/rt/itcms/__visit
-  end
-  global.get $class-overloading-cast/v3
-  local.tee $1
-  if
-   local.get $1
-   local.get $0
-   call $~lib/rt/itcms/__visit
-  end
-  global.get $class-overloading-cast/c
-  local.tee $1
-  if
-   local.get $1
-   local.get $0
-   call $~lib/rt/itcms/__visit
-  end
-  i32.const 224
-  local.get $0
-  call $~lib/rt/itcms/__visit
-  i32.const 32
-  local.get $0
-  call $~lib/rt/itcms/__visit
- )
  (func $~lib/arraybuffer/ArrayBufferView~visit (param $0 i32) (param $1 i32)
   (local $2 i32)
   local.get $0
@@ -2572,6 +2535,37 @@
    return
   end
   unreachable
+ )
+ (func $~lib/rt/__visit_globals (param $0 i32)
+  (local $1 i32)
+  global.get $class-overloading-cast/v
+  local.tee $1
+  if
+   local.get $1
+   local.get $0
+   call $~lib/rt/itcms/__visit
+  end
+  global.get $class-overloading-cast/v2
+  local.tee $1
+  if
+   local.get $1
+   local.get $0
+   call $~lib/rt/itcms/__visit
+  end
+  global.get $class-overloading-cast/v3
+  local.tee $1
+  if
+   local.get $1
+   local.get $0
+   call $~lib/rt/itcms/__visit
+  end
+  global.get $class-overloading-cast/c
+  local.tee $1
+  if
+   local.get $1
+   local.get $0
+   call $~lib/rt/itcms/__visit
+  end
  )
  (func $~start
   global.get $~started

--- a/tests/compiler/class-overloading-cast.release.wat
+++ b/tests/compiler/class-overloading-cast.release.wat
@@ -75,10 +75,6 @@
    local.get $0
    call $~lib/rt/itcms/__visit
   end
-  i32.const 1248
-  call $~lib/rt/itcms/__visit
-  i32.const 1056
-  call $~lib/rt/itcms/__visit
   global.get $~lib/rt/itcms/pinSpace
   local.tee $1
   i32.load offset=4

--- a/tests/compiler/class-overloading.debug.wat
+++ b/tests/compiler/class-overloading.debug.wat
@@ -2753,57 +2753,6 @@
   local.get $0
   call $class-overloading/A1#baz
  )
- (func $~lib/rt/__visit_globals (param $0 i32)
-  (local $1 i32)
-  global.get $class-overloading/which
-  local.tee $1
-  if
-   local.get $1
-   local.get $0
-   call $~lib/rt/itcms/__visit
-  end
-  global.get $class-overloading/a
-  local.tee $1
-  if
-   local.get $1
-   local.get $0
-   call $~lib/rt/itcms/__visit
-  end
-  global.get $class-overloading/c
-  local.tee $1
-  if
-   local.get $1
-   local.get $0
-   call $~lib/rt/itcms/__visit
-  end
-  global.get $class-overloading/ia
-  local.tee $1
-  if
-   local.get $1
-   local.get $0
-   call $~lib/rt/itcms/__visit
-  end
-  global.get $class-overloading/ic
-  local.tee $1
-  if
-   local.get $1
-   local.get $0
-   call $~lib/rt/itcms/__visit
-  end
-  global.get $class-overloading/b2
-  local.tee $1
-  if
-   local.get $1
-   local.get $0
-   call $~lib/rt/itcms/__visit
-  end
-  i32.const 256
-  local.get $0
-  call $~lib/rt/itcms/__visit
-  i32.const 64
-  local.get $0
-  call $~lib/rt/itcms/__visit
- )
  (func $~lib/arraybuffer/ArrayBufferView~visit (param $0 i32) (param $1 i32)
   (local $2 i32)
   local.get $0
@@ -2882,6 +2831,44 @@
    return
   end
   unreachable
+ )
+ (func $~lib/rt/__visit_globals (param $0 i32)
+  (local $1 i32)
+  global.get $class-overloading/a
+  local.tee $1
+  if
+   local.get $1
+   local.get $0
+   call $~lib/rt/itcms/__visit
+  end
+  global.get $class-overloading/c
+  local.tee $1
+  if
+   local.get $1
+   local.get $0
+   call $~lib/rt/itcms/__visit
+  end
+  global.get $class-overloading/ia
+  local.tee $1
+  if
+   local.get $1
+   local.get $0
+   call $~lib/rt/itcms/__visit
+  end
+  global.get $class-overloading/ic
+  local.tee $1
+  if
+   local.get $1
+   local.get $0
+   call $~lib/rt/itcms/__visit
+  end
+  global.get $class-overloading/b2
+  local.tee $1
+  if
+   local.get $1
+   local.get $0
+   call $~lib/rt/itcms/__visit
+  end
  )
  (func $~start
   global.get $~started

--- a/tests/compiler/class-overloading.release.wat
+++ b/tests/compiler/class-overloading.release.wat
@@ -61,12 +61,6 @@
  (func $~lib/rt/itcms/visitRoots
   (local $0 i32)
   (local $1 i32)
-  global.get $class-overloading/which
-  local.tee $0
-  if
-   local.get $0
-   call $~lib/rt/itcms/__visit
-  end
   global.get $class-overloading/a
   local.tee $0
   if
@@ -97,10 +91,6 @@
    local.get $0
    call $~lib/rt/itcms/__visit
   end
-  i32.const 1280
-  call $~lib/rt/itcms/__visit
-  i32.const 1088
-  call $~lib/rt/itcms/__visit
   global.get $~lib/rt/itcms/pinSpace
   local.tee $1
   i32.load offset=4

--- a/tests/compiler/class-override.debug.wat
+++ b/tests/compiler/class-override.debug.wat
@@ -2323,22 +2323,6 @@
   local.get $1
   call $class-override/A#f
  )
- (func $~lib/rt/__visit_globals (param $0 i32)
-  (local $1 i32)
-  global.get $class-override/x
-  local.tee $1
-  if
-   local.get $1
-   local.get $0
-   call $~lib/rt/itcms/__visit
-  end
-  i32.const 224
-  local.get $0
-  call $~lib/rt/itcms/__visit
-  i32.const 32
-  local.get $0
-  call $~lib/rt/itcms/__visit
- )
  (func $~lib/arraybuffer/ArrayBufferView~visit (param $0 i32) (param $1 i32)
   (local $2 i32)
   local.get $0
@@ -2387,6 +2371,16 @@
    return
   end
   unreachable
+ )
+ (func $~lib/rt/__visit_globals (param $0 i32)
+  (local $1 i32)
+  global.get $class-override/x
+  local.tee $1
+  if
+   local.get $1
+   local.get $0
+   call $~lib/rt/itcms/__visit
+  end
  )
  (func $~start
   call $start:class-override

--- a/tests/compiler/class-override.release.wat
+++ b/tests/compiler/class-override.release.wat
@@ -46,10 +46,6 @@
    local.get $0
    call $~lib/rt/itcms/__visit
   end
-  i32.const 1248
-  call $~lib/rt/itcms/__visit
-  i32.const 1056
-  call $~lib/rt/itcms/__visit
   global.get $~lib/rt/itcms/pinSpace
   local.tee $1
   i32.load offset=4

--- a/tests/compiler/class.debug.wat
+++ b/tests/compiler/class.debug.wat
@@ -2433,18 +2433,6 @@
   call $class/GenericInitializer<i32>#constructor
   drop
  )
- (func $~lib/rt/__visit_globals (param $0 i32)
-  (local $1 i32)
-  i32.const 224
-  local.get $0
-  call $~lib/rt/itcms/__visit
-  i32.const 432
-  local.get $0
-  call $~lib/rt/itcms/__visit
-  i32.const 32
-  local.get $0
-  call $~lib/rt/itcms/__visit
- )
  (func $~lib/arraybuffer/ArrayBufferView~visit (param $0 i32) (param $1 i32)
   (local $2 i32)
   local.get $0
@@ -2518,6 +2506,9 @@
    return
   end
   unreachable
+ )
+ (func $~lib/rt/__visit_globals (param $0 i32)
+  (local $1 i32)
  )
  (func $~start
   call $start:class

--- a/tests/compiler/class.release.wat
+++ b/tests/compiler/class.release.wat
@@ -42,12 +42,6 @@
  (func $~lib/rt/itcms/visitRoots
   (local $0 i32)
   (local $1 i32)
-  i32.const 1248
-  call $~lib/rt/itcms/__visit
-  i32.const 1456
-  call $~lib/rt/itcms/__visit
-  i32.const 1056
-  call $~lib/rt/itcms/__visit
   global.get $~lib/rt/itcms/pinSpace
   local.tee $1
   i32.load offset=4

--- a/tests/compiler/constructor.debug.wat
+++ b/tests/compiler/constructor.debug.wat
@@ -2329,92 +2329,6 @@
   local.get $c
   i32.store
  )
- (func $~lib/rt/__visit_globals (param $0 i32)
-  (local $1 i32)
-  global.get $constructor/emptyCtor
-  local.tee $1
-  if
-   local.get $1
-   local.get $0
-   call $~lib/rt/itcms/__visit
-  end
-  global.get $constructor/emptyCtorWithFieldInit
-  local.tee $1
-  if
-   local.get $1
-   local.get $0
-   call $~lib/rt/itcms/__visit
-  end
-  global.get $constructor/emptyCtorWithFieldNoInit
-  local.tee $1
-  if
-   local.get $1
-   local.get $0
-   call $~lib/rt/itcms/__visit
-  end
-  global.get $constructor/emptyCtorWithFieldAccess
-  local.tee $1
-  if
-   local.get $1
-   local.get $0
-   call $~lib/rt/itcms/__visit
-  end
-  global.get $constructor/none
-  local.tee $1
-  if
-   local.get $1
-   local.get $0
-   call $~lib/rt/itcms/__visit
-  end
-  global.get $constructor/justFieldInit
-  local.tee $1
-  if
-   local.get $1
-   local.get $0
-   call $~lib/rt/itcms/__visit
-  end
-  global.get $constructor/justFieldNoInit
-  local.tee $1
-  if
-   local.get $1
-   local.get $0
-   call $~lib/rt/itcms/__visit
-  end
-  global.get $constructor/ctorReturns
-  local.tee $1
-  if
-   local.get $1
-   local.get $0
-   call $~lib/rt/itcms/__visit
-  end
-  global.get $constructor/ctorConditionallyReturns
-  local.tee $1
-  if
-   local.get $1
-   local.get $0
-   call $~lib/rt/itcms/__visit
-  end
-  global.get $constructor/ctorConditionallyReturnsThis
-  local.tee $1
-  if
-   local.get $1
-   local.get $0
-   call $~lib/rt/itcms/__visit
-  end
-  global.get $constructor/ctorFieldInitOrder
-  local.tee $1
-  if
-   local.get $1
-   local.get $0
-   call $~lib/rt/itcms/__visit
-  end
-  i32.const 224
-  local.get $0
-  call $~lib/rt/itcms/__visit
-  i32.const 32
-  local.get $0
-  call $~lib/rt/itcms/__visit
- )
  (func $~lib/arraybuffer/ArrayBufferView~visit (param $0 i32) (param $1 i32)
   (local $2 i32)
   local.get $0
@@ -2487,6 +2401,72 @@
    return
   end
   unreachable
+ )
+ (func $~lib/rt/__visit_globals (param $0 i32)
+  (local $1 i32)
+  global.get $constructor/emptyCtor
+  local.tee $1
+  if
+   local.get $1
+   local.get $0
+   call $~lib/rt/itcms/__visit
+  end
+  global.get $constructor/emptyCtorWithFieldInit
+  local.tee $1
+  if
+   local.get $1
+   local.get $0
+   call $~lib/rt/itcms/__visit
+  end
+  global.get $constructor/emptyCtorWithFieldNoInit
+  local.tee $1
+  if
+   local.get $1
+   local.get $0
+   call $~lib/rt/itcms/__visit
+  end
+  global.get $constructor/emptyCtorWithFieldAccess
+  local.tee $1
+  if
+   local.get $1
+   local.get $0
+   call $~lib/rt/itcms/__visit
+  end
+  global.get $constructor/none
+  local.tee $1
+  if
+   local.get $1
+   local.get $0
+   call $~lib/rt/itcms/__visit
+  end
+  global.get $constructor/justFieldInit
+  local.tee $1
+  if
+   local.get $1
+   local.get $0
+   call $~lib/rt/itcms/__visit
+  end
+  global.get $constructor/justFieldNoInit
+  local.tee $1
+  if
+   local.get $1
+   local.get $0
+   call $~lib/rt/itcms/__visit
+  end
+  global.get $constructor/ctorConditionallyReturnsThis
+  local.tee $1
+  if
+   local.get $1
+   local.get $0
+   call $~lib/rt/itcms/__visit
+  end
+  global.get $constructor/ctorFieldInitOrder
+  local.tee $1
+  if
+   local.get $1
+   local.get $0
+   call $~lib/rt/itcms/__visit
+  end
  )
  (func $~start
   call $start:constructor

--- a/tests/compiler/constructor.release.wat
+++ b/tests/compiler/constructor.release.wat
@@ -101,10 +101,6 @@
    local.get $0
    call $~lib/rt/itcms/__visit
   end
-  i32.const 1248
-  call $~lib/rt/itcms/__visit
-  i32.const 1056
-  call $~lib/rt/itcms/__visit
   global.get $~lib/rt/itcms/pinSpace
   local.tee $1
   i32.load offset=4

--- a/tests/compiler/do.debug.wat
+++ b/tests/compiler/do.debug.wat
@@ -3008,15 +3008,6 @@
   end
   call $~lib/rt/itcms/__collect
  )
- (func $~lib/rt/__visit_globals (param $0 i32)
-  (local $1 i32)
-  i32.const 256
-  local.get $0
-  call $~lib/rt/itcms/__visit
-  i32.const 64
-  local.get $0
-  call $~lib/rt/itcms/__visit
- )
  (func $~lib/arraybuffer/ArrayBufferView~visit (param $0 i32) (param $1 i32)
   (local $2 i32)
   local.get $0
@@ -3056,6 +3047,9 @@
    return
   end
   unreachable
+ )
+ (func $~lib/rt/__visit_globals (param $0 i32)
+  (local $1 i32)
  )
  (func $~start
   call $start:do

--- a/tests/compiler/do.release.wat
+++ b/tests/compiler/do.release.wat
@@ -37,10 +37,6 @@
  (func $~lib/rt/itcms/visitRoots
   (local $0 i32)
   (local $1 i32)
-  i32.const 1280
-  call $~lib/rt/itcms/__visit
-  i32.const 1088
-  call $~lib/rt/itcms/__visit
   global.get $~lib/rt/itcms/pinSpace
   local.tee $1
   i32.load offset=4

--- a/tests/compiler/duplicate-fields.debug.wat
+++ b/tests/compiler/duplicate-fields.debug.wat
@@ -2377,29 +2377,6 @@
   local.get $pub
   i32.store offset=4
  )
- (func $~lib/rt/__visit_globals (param $0 i32)
-  (local $1 i32)
-  global.get $duplicate-fields/foo
-  local.tee $1
-  if
-   local.get $1
-   local.get $0
-   call $~lib/rt/itcms/__visit
-  end
-  global.get $duplicate-fields/raz
-  local.tee $1
-  if
-   local.get $1
-   local.get $0
-   call $~lib/rt/itcms/__visit
-  end
-  i32.const 224
-  local.get $0
-  call $~lib/rt/itcms/__visit
-  i32.const 32
-  local.get $0
-  call $~lib/rt/itcms/__visit
- )
  (func $~lib/arraybuffer/ArrayBufferView~visit (param $0 i32) (param $1 i32)
   (local $2 i32)
   local.get $0
@@ -2483,6 +2460,23 @@
    return
   end
   unreachable
+ )
+ (func $~lib/rt/__visit_globals (param $0 i32)
+  (local $1 i32)
+  global.get $duplicate-fields/foo
+  local.tee $1
+  if
+   local.get $1
+   local.get $0
+   call $~lib/rt/itcms/__visit
+  end
+  global.get $duplicate-fields/raz
+  local.tee $1
+  if
+   local.get $1
+   local.get $0
+   call $~lib/rt/itcms/__visit
+  end
  )
  (func $~start
   call $start:duplicate-fields

--- a/tests/compiler/duplicate-fields.release.wat
+++ b/tests/compiler/duplicate-fields.release.wat
@@ -51,10 +51,6 @@
    local.get $0
    call $~lib/rt/itcms/__visit
   end
-  i32.const 1248
-  call $~lib/rt/itcms/__visit
-  i32.const 1056
-  call $~lib/rt/itcms/__visit
   global.get $~lib/rt/itcms/pinSpace
   local.tee $1
   i32.load offset=4

--- a/tests/compiler/empty-exportruntime.debug.wat
+++ b/tests/compiler/empty-exportruntime.debug.wat
@@ -2362,21 +2362,6 @@
   i32.const 0
   drop
  )
- (func $~lib/rt/__visit_globals (param $0 i32)
-  (local $1 i32)
-  i32.const 224
-  local.get $0
-  call $~lib/rt/itcms/__visit
-  i32.const 32
-  local.get $0
-  call $~lib/rt/itcms/__visit
-  i32.const 432
-  local.get $0
-  call $~lib/rt/itcms/__visit
-  i32.const 496
-  local.get $0
-  call $~lib/rt/itcms/__visit
- )
  (func $~lib/arraybuffer/ArrayBufferView~visit (param $0 i32) (param $1 i32)
   (local $2 i32)
   local.get $0
@@ -2413,6 +2398,9 @@
    return
   end
   unreachable
+ )
+ (func $~lib/rt/__visit_globals (param $0 i32)
+  (local $1 i32)
  )
  (func $~start
   memory.size

--- a/tests/compiler/empty-exportruntime.release.wat
+++ b/tests/compiler/empty-exportruntime.release.wat
@@ -45,14 +45,6 @@
  (func $~lib/rt/itcms/visitRoots
   (local $0 i32)
   (local $1 i32)
-  i32.const 1248
-  call $~lib/rt/itcms/__visit
-  i32.const 1056
-  call $~lib/rt/itcms/__visit
-  i32.const 1456
-  call $~lib/rt/itcms/__visit
-  i32.const 1520
-  call $~lib/rt/itcms/__visit
   global.get $~lib/rt/itcms/pinSpace
   local.tee $1
   i32.load offset=4

--- a/tests/compiler/empty-new.debug.wat
+++ b/tests/compiler/empty-new.debug.wat
@@ -2264,15 +2264,6 @@
   call $~lib/rt/itcms/__new
   drop
  )
- (func $~lib/rt/__visit_globals (param $0 i32)
-  (local $1 i32)
-  i32.const 224
-  local.get $0
-  call $~lib/rt/itcms/__visit
-  i32.const 32
-  local.get $0
-  call $~lib/rt/itcms/__visit
- )
  (func $~lib/arraybuffer/ArrayBufferView~visit (param $0 i32) (param $1 i32)
   (local $2 i32)
   local.get $0
@@ -2309,6 +2300,9 @@
    return
   end
   unreachable
+ )
+ (func $~lib/rt/__visit_globals (param $0 i32)
+  (local $1 i32)
  )
  (func $~start
   call $start:empty-new

--- a/tests/compiler/empty-new.release.wat
+++ b/tests/compiler/empty-new.release.wat
@@ -34,10 +34,6 @@
  (func $~lib/rt/itcms/visitRoots
   (local $0 i32)
   (local $1 i32)
-  i32.const 1248
-  call $~lib/rt/itcms/__visit
-  i32.const 1056
-  call $~lib/rt/itcms/__visit
   global.get $~lib/rt/itcms/pinSpace
   local.tee $1
   i32.load offset=4

--- a/tests/compiler/exportstar-rereexport.debug.wat
+++ b/tests/compiler/exportstar-rereexport.debug.wat
@@ -2290,36 +2290,6 @@
  )
  (func $export-default/theDefault
  )
- (func $~lib/rt/__visit_globals (param $0 i32)
-  (local $1 i32)
-  i32.const 272
-  local.get $0
-  call $~lib/rt/itcms/__visit
-  i32.const 80
-  local.get $0
-  call $~lib/rt/itcms/__visit
-  global.get $rereexport/car
-  local.tee $1
-  if
-   local.get $1
-   local.get $0
-   call $~lib/rt/itcms/__visit
-  end
-  global.get $rereexport/exportsNamespaceCar
-  local.tee $1
-  if
-   local.get $1
-   local.get $0
-   call $~lib/rt/itcms/__visit
-  end
-  global.get $reexport/car
-  local.tee $1
-  if
-   local.get $1
-   local.get $0
-   call $~lib/rt/itcms/__visit
-  end
- )
  (func $~lib/arraybuffer/ArrayBufferView~visit (param $0 i32) (param $1 i32)
   (local $2 i32)
   local.get $0
@@ -2359,6 +2329,30 @@
    return
   end
   unreachable
+ )
+ (func $~lib/rt/__visit_globals (param $0 i32)
+  (local $1 i32)
+  global.get $rereexport/car
+  local.tee $1
+  if
+   local.get $1
+   local.get $0
+   call $~lib/rt/itcms/__visit
+  end
+  global.get $rereexport/exportsNamespaceCar
+  local.tee $1
+  if
+   local.get $1
+   local.get $0
+   call $~lib/rt/itcms/__visit
+  end
+  global.get $reexport/car
+  local.tee $1
+  if
+   local.get $1
+   local.get $0
+   call $~lib/rt/itcms/__visit
+  end
  )
  (func $~start
   call $start:exportstar-rereexport

--- a/tests/compiler/exportstar-rereexport.release.wat
+++ b/tests/compiler/exportstar-rereexport.release.wat
@@ -50,10 +50,6 @@
  (func $~lib/rt/itcms/visitRoots
   (local $0 i32)
   (local $1 i32)
-  i32.const 1296
-  call $~lib/rt/itcms/__visit
-  i32.const 1104
-  call $~lib/rt/itcms/__visit
   global.get $rereexport/car
   local.tee $0
   if

--- a/tests/compiler/extends-baseaggregate.debug.wat
+++ b/tests/compiler/extends-baseaggregate.debug.wat
@@ -2409,32 +2409,6 @@
   local.get $length_
   i32.store offset=12
  )
- (func $~lib/rt/__visit_globals (param $0 i32)
-  (local $1 i32)
-  global.get $extends-baseaggregate/poolB
-  local.tee $1
-  if
-   local.get $1
-   local.get $0
-   call $~lib/rt/itcms/__visit
-  end
-  global.get $extends-baseaggregate/poolA
-  local.tee $1
-  if
-   local.get $1
-   local.get $0
-   call $~lib/rt/itcms/__visit
-  end
-  i32.const 384
-  local.get $0
-  call $~lib/rt/itcms/__visit
-  i32.const 592
-  local.get $0
-  call $~lib/rt/itcms/__visit
-  i32.const 192
-  local.get $0
-  call $~lib/rt/itcms/__visit
- )
  (func $~lib/arraybuffer/ArrayBufferView~visit (param $0 i32) (param $1 i32)
   (local $2 i32)
   local.get $0
@@ -2574,6 +2548,23 @@
    return
   end
   unreachable
+ )
+ (func $~lib/rt/__visit_globals (param $0 i32)
+  (local $1 i32)
+  global.get $extends-baseaggregate/poolB
+  local.tee $1
+  if
+   local.get $1
+   local.get $0
+   call $~lib/rt/itcms/__visit
+  end
+  global.get $extends-baseaggregate/poolA
+  local.tee $1
+  if
+   local.get $1
+   local.get $0
+   call $~lib/rt/itcms/__visit
+  end
  )
  (func $~start
   call $start:extends-baseaggregate

--- a/tests/compiler/extends-baseaggregate.release.wat
+++ b/tests/compiler/extends-baseaggregate.release.wat
@@ -53,12 +53,6 @@
   call $~lib/rt/itcms/__visit
   i32.const 1168
   call $~lib/rt/itcms/__visit
-  i32.const 1408
-  call $~lib/rt/itcms/__visit
-  i32.const 1616
-  call $~lib/rt/itcms/__visit
-  i32.const 1216
-  call $~lib/rt/itcms/__visit
   global.get $~lib/rt/itcms/pinSpace
   local.tee $1
   i32.load offset=4

--- a/tests/compiler/extends-recursive.debug.wat
+++ b/tests/compiler/extends-recursive.debug.wat
@@ -2340,15 +2340,6 @@
   call $extends-recursive/Child#constructor
   drop
  )
- (func $~lib/rt/__visit_globals (param $0 i32)
-  (local $1 i32)
-  i32.const 224
-  local.get $0
-  call $~lib/rt/itcms/__visit
-  i32.const 32
-  local.get $0
-  call $~lib/rt/itcms/__visit
- )
  (func $~lib/arraybuffer/ArrayBufferView~visit (param $0 i32) (param $1 i32)
   (local $2 i32)
   local.get $0
@@ -2412,6 +2403,9 @@
    return
   end
   unreachable
+ )
+ (func $~lib/rt/__visit_globals (param $0 i32)
+  (local $1 i32)
  )
  (func $~start
   call $start:extends-recursive

--- a/tests/compiler/extends-recursive.release.wat
+++ b/tests/compiler/extends-recursive.release.wat
@@ -35,10 +35,6 @@
  (func $~lib/rt/itcms/visitRoots
   (local $0 i32)
   (local $1 i32)
-  i32.const 1248
-  call $~lib/rt/itcms/__visit
-  i32.const 1056
-  call $~lib/rt/itcms/__visit
   global.get $~lib/rt/itcms/pinSpace
   local.tee $1
   i32.load offset=4

--- a/tests/compiler/field-initialization.debug.wat
+++ b/tests/compiler/field-initialization.debug.wat
@@ -2686,18 +2686,6 @@
   local.get $this
   i32.load
  )
- (func $~lib/rt/__visit_globals (param $0 i32)
-  (local $1 i32)
-  i32.const 224
-  local.get $0
-  call $~lib/rt/itcms/__visit
-  i32.const 512
-  local.get $0
-  call $~lib/rt/itcms/__visit
-  i32.const 32
-  local.get $0
-  call $~lib/rt/itcms/__visit
- )
  (func $~lib/arraybuffer/ArrayBufferView~visit (param $0 i32) (param $1 i32)
   (local $2 i32)
   local.get $0
@@ -3011,6 +2999,9 @@
    return
   end
   unreachable
+ )
+ (func $~lib/rt/__visit_globals (param $0 i32)
+  (local $1 i32)
  )
  (func $~start
   call $start:field-initialization

--- a/tests/compiler/field-initialization.release.wat
+++ b/tests/compiler/field-initialization.release.wat
@@ -53,12 +53,6 @@
  (func $~lib/rt/itcms/visitRoots
   (local $0 i32)
   (local $1 i32)
-  i32.const 1248
-  call $~lib/rt/itcms/__visit
-  i32.const 1536
-  call $~lib/rt/itcms/__visit
-  i32.const 1056
-  call $~lib/rt/itcms/__visit
   global.get $~lib/rt/itcms/pinSpace
   local.tee $1
   i32.load offset=4

--- a/tests/compiler/field.debug.wat
+++ b/tests/compiler/field.debug.wat
@@ -2406,15 +2406,6 @@
   call $field/testNoStaticConflict
   call $~lib/rt/itcms/__collect
  )
- (func $~lib/rt/__visit_globals (param $0 i32)
-  (local $1 i32)
-  i32.const 224
-  local.get $0
-  call $~lib/rt/itcms/__visit
-  i32.const 32
-  local.get $0
-  call $~lib/rt/itcms/__visit
- )
  (func $~lib/arraybuffer/ArrayBufferView~visit (param $0 i32) (param $1 i32)
   (local $2 i32)
   local.get $0
@@ -2511,6 +2502,9 @@
    return
   end
   unreachable
+ )
+ (func $~lib/rt/__visit_globals (param $0 i32)
+  (local $1 i32)
  )
  (func $~start
   call $start:field

--- a/tests/compiler/field.release.wat
+++ b/tests/compiler/field.release.wat
@@ -38,10 +38,6 @@
  (func $~lib/rt/itcms/visitRoots
   (local $0 i32)
   (local $1 i32)
-  i32.const 1248
-  call $~lib/rt/itcms/__visit
-  i32.const 1056
-  call $~lib/rt/itcms/__visit
   global.get $~lib/rt/itcms/pinSpace
   local.tee $1
   i32.load offset=4

--- a/tests/compiler/for.debug.wat
+++ b/tests/compiler/for.debug.wat
@@ -3015,15 +3015,6 @@
   end
   call $~lib/rt/itcms/__collect
  )
- (func $~lib/rt/__visit_globals (param $0 i32)
-  (local $1 i32)
-  i32.const 256
-  local.get $0
-  call $~lib/rt/itcms/__visit
-  i32.const 64
-  local.get $0
-  call $~lib/rt/itcms/__visit
- )
  (func $~lib/arraybuffer/ArrayBufferView~visit (param $0 i32) (param $1 i32)
   (local $2 i32)
   local.get $0
@@ -3063,6 +3054,9 @@
    return
   end
   unreachable
+ )
+ (func $~lib/rt/__visit_globals (param $0 i32)
+  (local $1 i32)
  )
  (func $~start
   call $start:for

--- a/tests/compiler/for.release.wat
+++ b/tests/compiler/for.release.wat
@@ -37,10 +37,6 @@
  (func $~lib/rt/itcms/visitRoots
   (local $0 i32)
   (local $1 i32)
-  i32.const 1280
-  call $~lib/rt/itcms/__visit
-  i32.const 1088
-  call $~lib/rt/itcms/__visit
   global.get $~lib/rt/itcms/pinSpace
   local.tee $1
   i32.load offset=4

--- a/tests/compiler/function-call.debug.wat
+++ b/tests/compiler/function-call.debug.wat
@@ -2290,22 +2290,6 @@
   i32.add
   return
  )
- (func $~lib/rt/__visit_globals (param $0 i32)
-  (local $1 i32)
-  global.get $function-call/foo
-  local.tee $1
-  if
-   local.get $1
-   local.get $0
-   call $~lib/rt/itcms/__visit
-  end
-  i32.const 448
-  local.get $0
-  call $~lib/rt/itcms/__visit
-  i32.const 256
-  local.get $0
-  call $~lib/rt/itcms/__visit
- )
  (func $~lib/arraybuffer/ArrayBufferView~visit (param $0 i32) (param $1 i32)
   (local $2 i32)
   local.get $0
@@ -2435,6 +2419,16 @@
    return
   end
   unreachable
+ )
+ (func $~lib/rt/__visit_globals (param $0 i32)
+  (local $1 i32)
+  global.get $function-call/foo
+  local.tee $1
+  if
+   local.get $1
+   local.get $0
+   call $~lib/rt/itcms/__visit
+  end
  )
  (func $~start
   call $start:function-call

--- a/tests/compiler/function-call.release.wat
+++ b/tests/compiler/function-call.release.wat
@@ -75,10 +75,6 @@
    local.get $0
    call $~lib/rt/itcms/__visit
   end
-  i32.const 1472
-  call $~lib/rt/itcms/__visit
-  i32.const 1280
-  call $~lib/rt/itcms/__visit
   global.get $~lib/rt/itcms/pinSpace
   local.tee $1
   i32.load offset=4

--- a/tests/compiler/function-expression.debug.wat
+++ b/tests/compiler/function-expression.debug.wat
@@ -2564,15 +2564,6 @@
   i32.add
   global.set $~lib/memory/__stack_pointer
  )
- (func $~lib/rt/__visit_globals (param $0 i32)
-  (local $1 i32)
-  i32.const 768
-  local.get $0
-  call $~lib/rt/itcms/__visit
-  i32.const 576
-  local.get $0
-  call $~lib/rt/itcms/__visit
- )
  (func $~lib/arraybuffer/ArrayBufferView~visit (param $0 i32) (param $1 i32)
   (local $2 i32)
   local.get $0
@@ -2715,6 +2706,9 @@
    return
   end
   unreachable
+ )
+ (func $~lib/rt/__visit_globals (param $0 i32)
+  (local $1 i32)
  )
  (func $~start
   call $start:function-expression

--- a/tests/compiler/function-expression.release.wat
+++ b/tests/compiler/function-expression.release.wat
@@ -101,10 +101,6 @@
  (func $~lib/rt/itcms/visitRoots
   (local $0 i32)
   (local $1 i32)
-  i32.const 1792
-  call $~lib/rt/itcms/__visit
-  i32.const 1600
-  call $~lib/rt/itcms/__visit
   global.get $~lib/rt/itcms/pinSpace
   local.tee $1
   i32.load offset=4

--- a/tests/compiler/getter-call.debug.wat
+++ b/tests/compiler/getter-call.debug.wat
@@ -2251,15 +2251,6 @@
   i32.const 432
   return
  )
- (func $~lib/rt/__visit_globals (param $0 i32)
-  (local $1 i32)
-  i32.const 224
-  local.get $0
-  call $~lib/rt/itcms/__visit
-  i32.const 32
-  local.get $0
-  call $~lib/rt/itcms/__visit
- )
  (func $~lib/arraybuffer/ArrayBufferView~visit (param $0 i32) (param $1 i32)
   (local $2 i32)
   local.get $0
@@ -2317,6 +2308,9 @@
    return
   end
   unreachable
+ )
+ (func $~lib/rt/__visit_globals (param $0 i32)
+  (local $1 i32)
  )
  (func $~start
   memory.size

--- a/tests/compiler/getter-call.release.wat
+++ b/tests/compiler/getter-call.release.wat
@@ -40,10 +40,6 @@
  (func $~lib/rt/itcms/visitRoots
   (local $0 i32)
   (local $1 i32)
-  i32.const 1248
-  call $~lib/rt/itcms/__visit
-  i32.const 1056
-  call $~lib/rt/itcms/__visit
   global.get $~lib/rt/itcms/pinSpace
   local.tee $1
   i32.load offset=4

--- a/tests/compiler/incremental-gc/call-indirect.debug.wat
+++ b/tests/compiler/incremental-gc/call-indirect.debug.wat
@@ -2340,15 +2340,6 @@
    unreachable
   end
  )
- (func $~lib/rt/__visit_globals (param $0 i32)
-  (local $1 i32)
-  i32.const 160
-  local.get $0
-  call $~lib/rt/itcms/__visit
-  i32.const 368
-  local.get $0
-  call $~lib/rt/itcms/__visit
- )
  (func $~lib/arraybuffer/ArrayBufferView~visit (param $0 i32) (param $1 i32)
   (local $2 i32)
   local.get $0
@@ -2409,6 +2400,9 @@
    return
   end
   unreachable
+ )
+ (func $~lib/rt/__visit_globals (param $0 i32)
+  (local $1 i32)
  )
  (func $~start
   call $start:incremental-gc/call-indirect

--- a/tests/compiler/incremental-gc/call-indirect.release.wat
+++ b/tests/compiler/incremental-gc/call-indirect.release.wat
@@ -43,10 +43,6 @@
  (func $~lib/rt/itcms/visitRoots
   (local $0 i32)
   (local $1 i32)
-  i32.const 1168
-  call $~lib/rt/itcms/__visit
-  i32.const 1376
-  call $~lib/rt/itcms/__visit
   global.get $~lib/rt/itcms/pinSpace
   local.tee $1
   i32.load offset=4

--- a/tests/compiler/infer-array.debug.wat
+++ b/tests/compiler/infer-array.debug.wat
@@ -2479,21 +2479,6 @@
   local.get $this
   i32.load offset=4
  )
- (func $~lib/rt/__visit_globals (param $0 i32)
-  (local $1 i32)
-  i32.const 256
-  local.get $0
-  call $~lib/rt/itcms/__visit
-  i32.const 720
-  local.get $0
-  call $~lib/rt/itcms/__visit
-  i32.const 1024
-  local.get $0
-  call $~lib/rt/itcms/__visit
-  i32.const 64
-  local.get $0
-  call $~lib/rt/itcms/__visit
- )
  (func $~lib/arraybuffer/ArrayBufferView~visit (param $0 i32) (param $1 i32)
   (local $2 i32)
   local.get $0
@@ -2677,6 +2662,9 @@
    return
   end
   unreachable
+ )
+ (func $~lib/rt/__visit_globals (param $0 i32)
+  (local $1 i32)
  )
  (func $~start
   call $start:infer-array

--- a/tests/compiler/infer-array.release.wat
+++ b/tests/compiler/infer-array.release.wat
@@ -73,14 +73,6 @@
  (func $~lib/rt/itcms/visitRoots
   (local $0 i32)
   (local $1 i32)
-  i32.const 1280
-  call $~lib/rt/itcms/__visit
-  i32.const 1744
-  call $~lib/rt/itcms/__visit
-  i32.const 2048
-  call $~lib/rt/itcms/__visit
-  i32.const 1088
-  call $~lib/rt/itcms/__visit
   global.get $~lib/rt/itcms/pinSpace
   local.tee $1
   i32.load offset=4

--- a/tests/compiler/infer-generic.debug.wat
+++ b/tests/compiler/infer-generic.debug.wat
@@ -2323,22 +2323,6 @@
   local.get $this
   i32.load
  )
- (func $~lib/rt/__visit_globals (param $0 i32)
-  (local $1 i32)
-  global.get $infer-generic/arr
-  local.tee $1
-  if
-   local.get $1
-   local.get $0
-   call $~lib/rt/itcms/__visit
-  end
-  i32.const 400
-  local.get $0
-  call $~lib/rt/itcms/__visit
-  i32.const 208
-  local.get $0
-  call $~lib/rt/itcms/__visit
- )
  (func $~lib/arraybuffer/ArrayBufferView~visit (param $0 i32) (param $1 i32)
   (local $2 i32)
   local.get $0
@@ -2468,6 +2452,16 @@
    return
   end
   unreachable
+ )
+ (func $~lib/rt/__visit_globals (param $0 i32)
+  (local $1 i32)
+  global.get $infer-generic/arr
+  local.tee $1
+  if
+   local.get $1
+   local.get $0
+   call $~lib/rt/itcms/__visit
+  end
  )
  (func $~start
   call $start:infer-generic

--- a/tests/compiler/infer-generic.release.wat
+++ b/tests/compiler/infer-generic.release.wat
@@ -64,10 +64,6 @@
   (local $1 i32)
   i32.const 1152
   call $~lib/rt/itcms/__visit
-  i32.const 1424
-  call $~lib/rt/itcms/__visit
-  i32.const 1232
-  call $~lib/rt/itcms/__visit
   global.get $~lib/rt/itcms/pinSpace
   local.tee $1
   i32.load offset=4

--- a/tests/compiler/inlining.debug.wat
+++ b/tests/compiler/inlining.debug.wat
@@ -2763,15 +2763,6 @@
   f64.div
   return
  )
- (func $~lib/rt/__visit_globals (param $0 i32)
-  (local $1 i32)
-  i32.const 304
-  local.get $0
-  call $~lib/rt/itcms/__visit
-  i32.const 112
-  local.get $0
-  call $~lib/rt/itcms/__visit
- )
  (func $~lib/arraybuffer/ArrayBufferView~visit (param $0 i32) (param $1 i32)
   (local $2 i32)
   local.get $0
@@ -2835,6 +2826,9 @@
    return
   end
   unreachable
+ )
+ (func $~lib/rt/__visit_globals (param $0 i32)
+  (local $1 i32)
  )
  (func $~start
   call $start:inlining

--- a/tests/compiler/inlining.release.wat
+++ b/tests/compiler/inlining.release.wat
@@ -54,10 +54,6 @@
  (func $~lib/rt/itcms/visitRoots
   (local $0 i32)
   (local $1 i32)
-  i32.const 1328
-  call $~lib/rt/itcms/__visit
-  i32.const 1136
-  call $~lib/rt/itcms/__visit
   global.get $~lib/rt/itcms/pinSpace
   local.tee $1
   i32.load offset=4

--- a/tests/compiler/instanceof.debug.wat
+++ b/tests/compiler/instanceof.debug.wat
@@ -4450,6 +4450,103 @@
   end
   i32.const 1
  )
+ (func $~lib/arraybuffer/ArrayBufferView~visit (param $0 i32) (param $1 i32)
+  (local $2 i32)
+  local.get $0
+  local.get $1
+  call $~lib/object/Object~visit
+  local.get $0
+  i32.load
+  local.get $1
+  call $~lib/rt/itcms/__visit
+ )
+ (func $~lib/object/Object~visit (param $0 i32) (param $1 i32)
+ )
+ (func $~lib/rt/__visit_members (param $0 i32) (param $1 i32)
+  block $invalid
+   block $instanceof/IE
+    block $instanceof/Z
+     block $instanceof/IC
+      block $instanceof/ID
+       block $instanceof/Y
+        block $instanceof/IA
+         block $instanceof/IB
+          block $instanceof/X
+           block $instanceof/W
+            block $instanceof/BlackCat
+             block $instanceof/Cat
+              block $instanceof/Animal
+               block $instanceof/SomethingElse<i32>
+                block $instanceof/Parent<f32>
+                 block $instanceof/Child<f32>
+                  block $instanceof/Parent<i32>
+                   block $instanceof/Child<i32>
+                    block $instanceof/C
+                     block $instanceof/B
+                      block $instanceof/A
+                       block $~lib/arraybuffer/ArrayBufferView
+                        block $~lib/string/String
+                         block $~lib/arraybuffer/ArrayBuffer
+                          block $~lib/object/Object
+                           local.get $0
+                           i32.const 8
+                           i32.sub
+                           i32.load
+                           br_table $~lib/object/Object $~lib/arraybuffer/ArrayBuffer $~lib/string/String $~lib/arraybuffer/ArrayBufferView $instanceof/A $instanceof/B $instanceof/C $instanceof/Child<i32> $instanceof/Parent<i32> $instanceof/Child<f32> $instanceof/Parent<f32> $instanceof/SomethingElse<i32> $instanceof/Animal $instanceof/Cat $instanceof/BlackCat $instanceof/W $instanceof/X $instanceof/IB $instanceof/IA $instanceof/Y $instanceof/ID $instanceof/IC $instanceof/Z $instanceof/IE $invalid
+                          end
+                          return
+                         end
+                         return
+                        end
+                        return
+                       end
+                       local.get $0
+                       local.get $1
+                       call $~lib/arraybuffer/ArrayBufferView~visit
+                       return
+                      end
+                      return
+                     end
+                     return
+                    end
+                    return
+                   end
+                   return
+                  end
+                  return
+                 end
+                 return
+                end
+                return
+               end
+               return
+              end
+              return
+             end
+             return
+            end
+            return
+           end
+           return
+          end
+          return
+         end
+         return
+        end
+        return
+       end
+       return
+      end
+      return
+     end
+     return
+    end
+    return
+   end
+   return
+  end
+  unreachable
+ )
  (func $~lib/rt/__visit_globals (param $0 i32)
   (local $1 i32)
   global.get $instanceof/a
@@ -4578,109 +4675,6 @@
    local.get $0
    call $~lib/rt/itcms/__visit
   end
-  i32.const 224
-  local.get $0
-  call $~lib/rt/itcms/__visit
-  i32.const 32
-  local.get $0
-  call $~lib/rt/itcms/__visit
- )
- (func $~lib/arraybuffer/ArrayBufferView~visit (param $0 i32) (param $1 i32)
-  (local $2 i32)
-  local.get $0
-  local.get $1
-  call $~lib/object/Object~visit
-  local.get $0
-  i32.load
-  local.get $1
-  call $~lib/rt/itcms/__visit
- )
- (func $~lib/object/Object~visit (param $0 i32) (param $1 i32)
- )
- (func $~lib/rt/__visit_members (param $0 i32) (param $1 i32)
-  block $invalid
-   block $instanceof/IE
-    block $instanceof/Z
-     block $instanceof/IC
-      block $instanceof/ID
-       block $instanceof/Y
-        block $instanceof/IA
-         block $instanceof/IB
-          block $instanceof/X
-           block $instanceof/W
-            block $instanceof/BlackCat
-             block $instanceof/Cat
-              block $instanceof/Animal
-               block $instanceof/SomethingElse<i32>
-                block $instanceof/Parent<f32>
-                 block $instanceof/Child<f32>
-                  block $instanceof/Parent<i32>
-                   block $instanceof/Child<i32>
-                    block $instanceof/C
-                     block $instanceof/B
-                      block $instanceof/A
-                       block $~lib/arraybuffer/ArrayBufferView
-                        block $~lib/string/String
-                         block $~lib/arraybuffer/ArrayBuffer
-                          block $~lib/object/Object
-                           local.get $0
-                           i32.const 8
-                           i32.sub
-                           i32.load
-                           br_table $~lib/object/Object $~lib/arraybuffer/ArrayBuffer $~lib/string/String $~lib/arraybuffer/ArrayBufferView $instanceof/A $instanceof/B $instanceof/C $instanceof/Child<i32> $instanceof/Parent<i32> $instanceof/Child<f32> $instanceof/Parent<f32> $instanceof/SomethingElse<i32> $instanceof/Animal $instanceof/Cat $instanceof/BlackCat $instanceof/W $instanceof/X $instanceof/IB $instanceof/IA $instanceof/Y $instanceof/ID $instanceof/IC $instanceof/Z $instanceof/IE $invalid
-                          end
-                          return
-                         end
-                         return
-                        end
-                        return
-                       end
-                       local.get $0
-                       local.get $1
-                       call $~lib/arraybuffer/ArrayBufferView~visit
-                       return
-                      end
-                      return
-                     end
-                     return
-                    end
-                    return
-                   end
-                   return
-                  end
-                  return
-                 end
-                 return
-                end
-                return
-               end
-               return
-              end
-              return
-             end
-             return
-            end
-            return
-           end
-           return
-          end
-          return
-         end
-         return
-        end
-        return
-       end
-       return
-      end
-      return
-     end
-     return
-    end
-    return
-   end
-   return
-  end
-  unreachable
  )
  (func $~start
   call $start:instanceof

--- a/tests/compiler/instanceof.release.wat
+++ b/tests/compiler/instanceof.release.wat
@@ -142,10 +142,6 @@
    local.get $0
    call $~lib/rt/itcms/__visit
   end
-  i32.const 1248
-  call $~lib/rt/itcms/__visit
-  i32.const 1056
-  call $~lib/rt/itcms/__visit
   global.get $~lib/rt/itcms/pinSpace
   local.tee $1
   i32.load offset=4

--- a/tests/compiler/issues/1095.debug.wat
+++ b/tests/compiler/issues/1095.debug.wat
@@ -2325,15 +2325,6 @@
   local.get $this
   i32.load
  )
- (func $~lib/rt/__visit_globals (param $0 i32)
-  (local $1 i32)
-  i32.const 224
-  local.get $0
-  call $~lib/rt/itcms/__visit
-  i32.const 32
-  local.get $0
-  call $~lib/rt/itcms/__visit
- )
  (func $~lib/arraybuffer/ArrayBufferView~visit (param $0 i32) (param $1 i32)
   (local $2 i32)
   local.get $0
@@ -2386,6 +2377,9 @@
    return
   end
   unreachable
+ )
+ (func $~lib/rt/__visit_globals (param $0 i32)
+  (local $1 i32)
  )
  (func $~start
   call $start:issues/1095

--- a/tests/compiler/issues/1095.release.wat
+++ b/tests/compiler/issues/1095.release.wat
@@ -41,10 +41,6 @@
  (func $~lib/rt/itcms/visitRoots
   (local $0 i32)
   (local $1 i32)
-  i32.const 1248
-  call $~lib/rt/itcms/__visit
-  i32.const 1056
-  call $~lib/rt/itcms/__visit
   global.get $~lib/rt/itcms/pinSpace
   local.tee $1
   i32.load offset=4

--- a/tests/compiler/issues/1225.debug.wat
+++ b/tests/compiler/issues/1225.debug.wat
@@ -2368,22 +2368,6 @@
   global.set $issues/1225/x
   call $~lib/rt/itcms/__collect
  )
- (func $~lib/rt/__visit_globals (param $0 i32)
-  (local $1 i32)
-  global.get $issues/1225/x
-  local.tee $1
-  if
-   local.get $1
-   local.get $0
-   call $~lib/rt/itcms/__visit
-  end
-  i32.const 224
-  local.get $0
-  call $~lib/rt/itcms/__visit
-  i32.const 32
-  local.get $0
-  call $~lib/rt/itcms/__visit
- )
  (func $~lib/arraybuffer/ArrayBufferView~visit (param $0 i32) (param $1 i32)
   (local $2 i32)
   local.get $0
@@ -2423,6 +2407,16 @@
    return
   end
   unreachable
+ )
+ (func $~lib/rt/__visit_globals (param $0 i32)
+  (local $1 i32)
+  global.get $issues/1225/x
+  local.tee $1
+  if
+   local.get $1
+   local.get $0
+   call $~lib/rt/itcms/__visit
+  end
  )
  (func $~start
   call $start:issues/1225

--- a/tests/compiler/issues/1225.release.wat
+++ b/tests/compiler/issues/1225.release.wat
@@ -46,10 +46,6 @@
    local.get $0
    call $~lib/rt/itcms/__visit
   end
-  i32.const 1248
-  call $~lib/rt/itcms/__visit
-  i32.const 1056
-  call $~lib/rt/itcms/__visit
   global.get $~lib/rt/itcms/pinSpace
   local.tee $1
   i32.load offset=4

--- a/tests/compiler/issues/1699.debug.wat
+++ b/tests/compiler/issues/1699.debug.wat
@@ -2429,21 +2429,6 @@
   global.set $~lib/rt/itcms/fromSpace
   call $issues/1699/test
  )
- (func $~lib/rt/__visit_globals (param $0 i32)
-  (local $1 i32)
-  i32.const 320
-  local.get $0
-  call $~lib/rt/itcms/__visit
-  i32.const 32
-  local.get $0
-  call $~lib/rt/itcms/__visit
-  i32.const 528
-  local.get $0
-  call $~lib/rt/itcms/__visit
-  i32.const 128
-  local.get $0
-  call $~lib/rt/itcms/__visit
- )
  (func $~lib/arraybuffer/ArrayBufferView~visit (param $0 i32) (param $1 i32)
   (local $2 i32)
   local.get $0
@@ -2501,6 +2486,9 @@
    return
   end
   unreachable
+ )
+ (func $~lib/rt/__visit_globals (param $0 i32)
+  (local $1 i32)
  )
  (func $~start
   call $start:issues/1699

--- a/tests/compiler/issues/1699.release.wat
+++ b/tests/compiler/issues/1699.release.wat
@@ -44,14 +44,6 @@
  (func $~lib/rt/itcms/visitRoots
   (local $0 i32)
   (local $1 i32)
-  i32.const 1344
-  call $~lib/rt/itcms/__visit
-  i32.const 1056
-  call $~lib/rt/itcms/__visit
-  i32.const 1552
-  call $~lib/rt/itcms/__visit
-  i32.const 1152
-  call $~lib/rt/itcms/__visit
   global.get $~lib/rt/itcms/pinSpace
   local.tee $1
   i32.load offset=4

--- a/tests/compiler/issues/2166.debug.wat
+++ b/tests/compiler/issues/2166.debug.wat
@@ -2365,15 +2365,6 @@
   i32.const 0
   return
  )
- (func $~lib/rt/__visit_globals (param $0 i32)
-  (local $1 i32)
-  i32.const 224
-  local.get $0
-  call $~lib/rt/itcms/__visit
-  i32.const 32
-  local.get $0
-  call $~lib/rt/itcms/__visit
- )
  (func $~lib/arraybuffer/ArrayBufferView~visit (param $0 i32) (param $1 i32)
   (local $2 i32)
   local.get $0
@@ -2416,6 +2407,9 @@
    return
   end
   unreachable
+ )
+ (func $~lib/rt/__visit_globals (param $0 i32)
+  (local $1 i32)
  )
  (func $~start
   call $start:issues/2166

--- a/tests/compiler/issues/2166.release.wat
+++ b/tests/compiler/issues/2166.release.wat
@@ -46,10 +46,6 @@
  (func $~lib/rt/itcms/visitRoots
   (local $0 i32)
   (local $1 i32)
-  i32.const 1248
-  call $~lib/rt/itcms/__visit
-  i32.const 1056
-  call $~lib/rt/itcms/__visit
   global.get $~lib/rt/itcms/pinSpace
   local.tee $1
   i32.load offset=4

--- a/tests/compiler/issues/2322/index.debug.wat
+++ b/tests/compiler/issues/2322/index.debug.wat
@@ -2249,15 +2249,6 @@
  )
  (func $issues/2322/lib/test<i32> (param $t i32)
  )
- (func $~lib/rt/__visit_globals (param $0 i32)
-  (local $1 i32)
-  i32.const 224
-  local.get $0
-  call $~lib/rt/itcms/__visit
-  i32.const 32
-  local.get $0
-  call $~lib/rt/itcms/__visit
- )
  (func $~lib/arraybuffer/ArrayBufferView~visit (param $0 i32) (param $1 i32)
   (local $2 i32)
   local.get $0
@@ -2297,6 +2288,9 @@
    return
   end
   unreachable
+ )
+ (func $~lib/rt/__visit_globals (param $0 i32)
+  (local $1 i32)
  )
  (func $~start
   memory.size

--- a/tests/compiler/issues/2322/index.release.wat
+++ b/tests/compiler/issues/2322/index.release.wat
@@ -36,10 +36,6 @@
  (func $~lib/rt/itcms/visitRoots
   (local $0 i32)
   (local $1 i32)
-  i32.const 1248
-  call $~lib/rt/itcms/__visit
-  i32.const 1056
-  call $~lib/rt/itcms/__visit
   global.get $~lib/rt/itcms/pinSpace
   local.tee $1
   i32.load offset=4

--- a/tests/compiler/issues/2622.debug.wat
+++ b/tests/compiler/issues/2622.debug.wat
@@ -2277,57 +2277,6 @@
   global.get $issues/2622/_b/t2
   global.set $issues/2622/b
  )
- (func $~lib/rt/__visit_globals (param $0 i32)
-  (local $1 i32)
-  global.get $issues/2622/a
-  local.tee $1
-  if
-   local.get $1
-   local.get $0
-   call $~lib/rt/itcms/__visit
-  end
-  global.get $issues/2622/b
-  local.tee $1
-  if
-   local.get $1
-   local.get $0
-   call $~lib/rt/itcms/__visit
-  end
-  i32.const 224
-  local.get $0
-  call $~lib/rt/itcms/__visit
-  i32.const 32
-  local.get $0
-  call $~lib/rt/itcms/__visit
-  global.get $issues/2622/_a/t1
-  local.tee $1
-  if
-   local.get $1
-   local.get $0
-   call $~lib/rt/itcms/__visit
-  end
-  global.get $issues/2622/_a/t1
-  local.tee $1
-  if
-   local.get $1
-   local.get $0
-   call $~lib/rt/itcms/__visit
-  end
-  global.get $issues/2622/_b/t2
-  local.tee $1
-  if
-   local.get $1
-   local.get $0
-   call $~lib/rt/itcms/__visit
-  end
-  global.get $issues/2622/_b/t2
-  local.tee $1
-  if
-   local.get $1
-   local.get $0
-   call $~lib/rt/itcms/__visit
-  end
- )
  (func $~lib/arraybuffer/ArrayBufferView~visit (param $0 i32) (param $1 i32)
   (local $2 i32)
   local.get $0
@@ -2370,6 +2319,51 @@
    return
   end
   unreachable
+ )
+ (func $~lib/rt/__visit_globals (param $0 i32)
+  (local $1 i32)
+  global.get $issues/2622/a
+  local.tee $1
+  if
+   local.get $1
+   local.get $0
+   call $~lib/rt/itcms/__visit
+  end
+  global.get $issues/2622/b
+  local.tee $1
+  if
+   local.get $1
+   local.get $0
+   call $~lib/rt/itcms/__visit
+  end
+  global.get $issues/2622/_a/t1
+  local.tee $1
+  if
+   local.get $1
+   local.get $0
+   call $~lib/rt/itcms/__visit
+  end
+  global.get $issues/2622/_a/t1
+  local.tee $1
+  if
+   local.get $1
+   local.get $0
+   call $~lib/rt/itcms/__visit
+  end
+  global.get $issues/2622/_b/t2
+  local.tee $1
+  if
+   local.get $1
+   local.get $0
+   call $~lib/rt/itcms/__visit
+  end
+  global.get $issues/2622/_b/t2
+  local.tee $1
+  if
+   local.get $1
+   local.get $0
+   call $~lib/rt/itcms/__visit
+  end
  )
  (func $~start
   call $start:issues/2622

--- a/tests/compiler/issues/2622.release.wat
+++ b/tests/compiler/issues/2622.release.wat
@@ -51,10 +51,6 @@
    local.get $0
    call $~lib/rt/itcms/__visit
   end
-  i32.const 1248
-  call $~lib/rt/itcms/__visit
-  i32.const 1056
-  call $~lib/rt/itcms/__visit
   global.get $issues/2622/_a/t1
   local.tee $0
   if

--- a/tests/compiler/issues/2707.debug.wat
+++ b/tests/compiler/issues/2707.debug.wat
@@ -2335,15 +2335,6 @@
    end
   end
  )
- (func $~lib/rt/__visit_globals (param $0 i32)
-  (local $1 i32)
-  i32.const 304
-  local.get $0
-  call $~lib/rt/itcms/__visit
-  i32.const 112
-  local.get $0
-  call $~lib/rt/itcms/__visit
- )
  (func $~lib/arraybuffer/ArrayBufferView~visit (param $0 i32) (param $1 i32)
   (local $2 i32)
   local.get $0
@@ -2416,6 +2407,9 @@
    return
   end
   unreachable
+ )
+ (func $~lib/rt/__visit_globals (param $0 i32)
+  (local $1 i32)
  )
  (func $~start
   call $start:issues/2707

--- a/tests/compiler/issues/2707.release.wat
+++ b/tests/compiler/issues/2707.release.wat
@@ -44,10 +44,6 @@
  (func $~lib/rt/itcms/visitRoots
   (local $0 i32)
   (local $1 i32)
-  i32.const 1328
-  call $~lib/rt/itcms/__visit
-  i32.const 1136
-  call $~lib/rt/itcms/__visit
   global.get $~lib/rt/itcms/pinSpace
   local.tee $1
   i32.load offset=4

--- a/tests/compiler/issues/2873.debug.wat
+++ b/tests/compiler/issues/2873.debug.wat
@@ -4159,29 +4159,6 @@
   end
   return
  )
- (func $~lib/rt/__visit_globals (param $0 i32)
-  (local $1 i32)
-  global.get $issues/2873/f32arr
-  local.tee $1
-  if
-   local.get $1
-   local.get $0
-   call $~lib/rt/itcms/__visit
-  end
-  global.get $issues/2873/f64arr
-  local.tee $1
-  if
-   local.get $1
-   local.get $0
-   call $~lib/rt/itcms/__visit
-  end
-  i32.const 1760
-  local.get $0
-  call $~lib/rt/itcms/__visit
-  i32.const 1568
-  local.get $0
-  call $~lib/rt/itcms/__visit
- )
  (func $~lib/arraybuffer/ArrayBufferView~visit (param $0 i32) (param $1 i32)
   (local $2 i32)
   local.get $0
@@ -4254,6 +4231,23 @@
    return
   end
   unreachable
+ )
+ (func $~lib/rt/__visit_globals (param $0 i32)
+  (local $1 i32)
+  global.get $issues/2873/f32arr
+  local.tee $1
+  if
+   local.get $1
+   local.get $0
+   call $~lib/rt/itcms/__visit
+  end
+  global.get $issues/2873/f64arr
+  local.tee $1
+  if
+   local.get $1
+   local.get $0
+   call $~lib/rt/itcms/__visit
+  end
  )
  (func $~start
   call $start:issues/2873

--- a/tests/compiler/issues/2873.release.wat
+++ b/tests/compiler/issues/2873.release.wat
@@ -1255,10 +1255,6 @@
   call $~lib/rt/itcms/__visit
   i32.const 3312
   call $~lib/rt/itcms/__visit
-  i32.const 2784
-  call $~lib/rt/itcms/__visit
-  i32.const 2592
-  call $~lib/rt/itcms/__visit
   global.get $~lib/rt/itcms/pinSpace
   local.tee $1
   i32.load offset=4

--- a/tests/compiler/logical.debug.wat
+++ b/tests/compiler/logical.debug.wat
@@ -2307,29 +2307,6 @@
   end
   return
  )
- (func $~lib/rt/__visit_globals (param $0 i32)
-  (local $1 i32)
-  global.get $logical/b
-  local.tee $1
-  if
-   local.get $1
-   local.get $0
-   call $~lib/rt/itcms/__visit
-  end
-  global.get $logical/c
-  local.tee $1
-  if
-   local.get $1
-   local.get $0
-   call $~lib/rt/itcms/__visit
-  end
-  i32.const 272
-  local.get $0
-  call $~lib/rt/itcms/__visit
-  i32.const 80
-  local.get $0
-  call $~lib/rt/itcms/__visit
- )
  (func $~lib/arraybuffer/ArrayBufferView~visit (param $0 i32) (param $1 i32)
   (local $2 i32)
   local.get $0
@@ -2378,6 +2355,23 @@
    return
   end
   unreachable
+ )
+ (func $~lib/rt/__visit_globals (param $0 i32)
+  (local $1 i32)
+  global.get $logical/b
+  local.tee $1
+  if
+   local.get $1
+   local.get $0
+   call $~lib/rt/itcms/__visit
+  end
+  global.get $logical/c
+  local.tee $1
+  if
+   local.get $1
+   local.get $0
+   call $~lib/rt/itcms/__visit
+  end
  )
  (func $~start
   call $start:logical

--- a/tests/compiler/logical.release.wat
+++ b/tests/compiler/logical.release.wat
@@ -51,10 +51,6 @@
    local.get $0
    call $~lib/rt/itcms/__visit
   end
-  i32.const 1296
-  call $~lib/rt/itcms/__visit
-  i32.const 1104
-  call $~lib/rt/itcms/__visit
   global.get $~lib/rt/itcms/pinSpace
   local.tee $1
   i32.load offset=4

--- a/tests/compiler/managed-cast.debug.wat
+++ b/tests/compiler/managed-cast.debug.wat
@@ -2311,15 +2311,6 @@
   end
   i32.const 1
  )
- (func $~lib/rt/__visit_globals (param $0 i32)
-  (local $1 i32)
-  i32.const 224
-  local.get $0
-  call $~lib/rt/itcms/__visit
-  i32.const 32
-  local.get $0
-  call $~lib/rt/itcms/__visit
- )
  (func $~lib/arraybuffer/ArrayBufferView~visit (param $0 i32) (param $1 i32)
   (local $2 i32)
   local.get $0
@@ -2362,6 +2353,9 @@
    return
   end
   unreachable
+ )
+ (func $~lib/rt/__visit_globals (param $0 i32)
+  (local $1 i32)
  )
  (func $~start
   call $start:managed-cast

--- a/tests/compiler/managed-cast.release.wat
+++ b/tests/compiler/managed-cast.release.wat
@@ -41,10 +41,6 @@
  (func $~lib/rt/itcms/visitRoots
   (local $0 i32)
   (local $1 i32)
-  i32.const 1248
-  call $~lib/rt/itcms/__visit
-  i32.const 1056
-  call $~lib/rt/itcms/__visit
   global.get $~lib/rt/itcms/pinSpace
   local.tee $1
   i32.load offset=4

--- a/tests/compiler/new.debug.wat
+++ b/tests/compiler/new.debug.wat
@@ -2259,57 +2259,6 @@
   local.get $this
   return
  )
- (func $~lib/rt/__visit_globals (param $0 i32)
-  (local $1 i32)
-  global.get $new/ref
-  local.tee $1
-  if
-   local.get $1
-   local.get $0
-   call $~lib/rt/itcms/__visit
-  end
-  global.get $new/gen
-  local.tee $1
-  if
-   local.get $1
-   local.get $0
-   call $~lib/rt/itcms/__visit
-  end
-  global.get $new/ref2
-  local.tee $1
-  if
-   local.get $1
-   local.get $0
-   call $~lib/rt/itcms/__visit
-  end
-  global.get $new/genext
-  local.tee $1
-  if
-   local.get $1
-   local.get $0
-   call $~lib/rt/itcms/__visit
-  end
-  global.get $new/genext2
-  local.tee $1
-  if
-   local.get $1
-   local.get $0
-   call $~lib/rt/itcms/__visit
-  end
-  global.get $new/genext3
-  local.tee $1
-  if
-   local.get $1
-   local.get $0
-   call $~lib/rt/itcms/__visit
-  end
-  i32.const 224
-  local.get $0
-  call $~lib/rt/itcms/__visit
-  i32.const 32
-  local.get $0
-  call $~lib/rt/itcms/__visit
- )
  (func $~lib/arraybuffer/ArrayBufferView~visit (param $0 i32) (param $1 i32)
   (local $2 i32)
   local.get $0
@@ -2358,6 +2307,51 @@
    return
   end
   unreachable
+ )
+ (func $~lib/rt/__visit_globals (param $0 i32)
+  (local $1 i32)
+  global.get $new/ref
+  local.tee $1
+  if
+   local.get $1
+   local.get $0
+   call $~lib/rt/itcms/__visit
+  end
+  global.get $new/gen
+  local.tee $1
+  if
+   local.get $1
+   local.get $0
+   call $~lib/rt/itcms/__visit
+  end
+  global.get $new/ref2
+  local.tee $1
+  if
+   local.get $1
+   local.get $0
+   call $~lib/rt/itcms/__visit
+  end
+  global.get $new/genext
+  local.tee $1
+  if
+   local.get $1
+   local.get $0
+   call $~lib/rt/itcms/__visit
+  end
+  global.get $new/genext2
+  local.tee $1
+  if
+   local.get $1
+   local.get $0
+   call $~lib/rt/itcms/__visit
+  end
+  global.get $new/genext3
+  local.tee $1
+  if
+   local.get $1
+   local.get $0
+   call $~lib/rt/itcms/__visit
+  end
  )
  (func $~start
   call $start:new

--- a/tests/compiler/new.release.wat
+++ b/tests/compiler/new.release.wat
@@ -77,10 +77,6 @@
    local.get $0
    call $~lib/rt/itcms/__visit
   end
-  i32.const 1248
-  call $~lib/rt/itcms/__visit
-  i32.const 1056
-  call $~lib/rt/itcms/__visit
   global.get $~lib/rt/itcms/pinSpace
   local.tee $1
   i32.load offset=4

--- a/tests/compiler/object-literal.debug.wat
+++ b/tests/compiler/object-literal.debug.wat
@@ -2823,15 +2823,6 @@
   i32.const 0
   drop
  )
- (func $~lib/rt/__visit_globals (param $0 i32)
-  (local $1 i32)
-  i32.const 176
-  local.get $0
-  call $~lib/rt/itcms/__visit
-  i32.const 288
-  local.get $0
-  call $~lib/rt/itcms/__visit
- )
  (func $~lib/arraybuffer/ArrayBufferView~visit (param $0 i32) (param $1 i32)
   (local $2 i32)
   local.get $0
@@ -2947,6 +2938,9 @@
    return
   end
   unreachable
+ )
+ (func $~lib/rt/__visit_globals (param $0 i32)
+  (local $1 i32)
  )
  (func $~start
   call $start:object-literal

--- a/tests/compiler/object-literal.release.wat
+++ b/tests/compiler/object-literal.release.wat
@@ -237,10 +237,6 @@
  (func $~lib/rt/itcms/visitRoots
   (local $0 i32)
   (local $1 i32)
-  i32.const 1200
-  call $~lib/rt/itcms/__visit
-  i32.const 1312
-  call $~lib/rt/itcms/__visit
   global.get $~lib/rt/itcms/pinSpace
   local.tee $1
   i32.load offset=4

--- a/tests/compiler/operator-overload-non-ambiguity.debug.wat
+++ b/tests/compiler/operator-overload-non-ambiguity.debug.wat
@@ -2262,15 +2262,6 @@
   i32.const 1
   return
  )
- (func $~lib/rt/__visit_globals (param $0 i32)
-  (local $1 i32)
-  i32.const 224
-  local.get $0
-  call $~lib/rt/itcms/__visit
-  i32.const 32
-  local.get $0
-  call $~lib/rt/itcms/__visit
- )
  (func $~lib/arraybuffer/ArrayBufferView~visit (param $0 i32) (param $1 i32)
   (local $2 i32)
   local.get $0
@@ -2319,6 +2310,9 @@
    return
   end
   unreachable
+ )
+ (func $~lib/rt/__visit_globals (param $0 i32)
+  (local $1 i32)
  )
  (func $~start
   call $start:operator-overload-non-ambiguity

--- a/tests/compiler/operator-overload-non-ambiguity.release.wat
+++ b/tests/compiler/operator-overload-non-ambiguity.release.wat
@@ -37,10 +37,6 @@
  (func $~lib/rt/itcms/visitRoots
   (local $0 i32)
   (local $1 i32)
-  i32.const 1248
-  call $~lib/rt/itcms/__visit
-  i32.const 1056
-  call $~lib/rt/itcms/__visit
   global.get $~lib/rt/itcms/pinSpace
   local.tee $1
   i32.load offset=4

--- a/tests/compiler/optional-typeparameters.debug.wat
+++ b/tests/compiler/optional-typeparameters.debug.wat
@@ -2273,43 +2273,6 @@
   i32.eq
   drop
  )
- (func $~lib/rt/__visit_globals (param $0 i32)
-  (local $1 i32)
-  global.get $optional-typeparameters/tConcrete
-  local.tee $1
-  if
-   local.get $1
-   local.get $0
-   call $~lib/rt/itcms/__visit
-  end
-  global.get $optional-typeparameters/tDerived
-  local.tee $1
-  if
-   local.get $1
-   local.get $0
-   call $~lib/rt/itcms/__visit
-  end
-  global.get $optional-typeparameters/tMethodDerived
-  local.tee $1
-  if
-   local.get $1
-   local.get $0
-   call $~lib/rt/itcms/__visit
-  end
-  global.get $optional-typeparameters/tMethodDerived2
-  local.tee $1
-  if
-   local.get $1
-   local.get $0
-   call $~lib/rt/itcms/__visit
-  end
-  i32.const 224
-  local.get $0
-  call $~lib/rt/itcms/__visit
-  i32.const 32
-  local.get $0
-  call $~lib/rt/itcms/__visit
- )
  (func $~lib/arraybuffer/ArrayBufferView~visit (param $0 i32) (param $1 i32)
   (local $2 i32)
   local.get $0
@@ -2384,6 +2347,37 @@
    return
   end
   unreachable
+ )
+ (func $~lib/rt/__visit_globals (param $0 i32)
+  (local $1 i32)
+  global.get $optional-typeparameters/tConcrete
+  local.tee $1
+  if
+   local.get $1
+   local.get $0
+   call $~lib/rt/itcms/__visit
+  end
+  global.get $optional-typeparameters/tDerived
+  local.tee $1
+  if
+   local.get $1
+   local.get $0
+   call $~lib/rt/itcms/__visit
+  end
+  global.get $optional-typeparameters/tMethodDerived
+  local.tee $1
+  if
+   local.get $1
+   local.get $0
+   call $~lib/rt/itcms/__visit
+  end
+  global.get $optional-typeparameters/tMethodDerived2
+  local.tee $1
+  if
+   local.get $1
+   local.get $0
+   call $~lib/rt/itcms/__visit
+  end
  )
  (func $~start
   call $start:optional-typeparameters

--- a/tests/compiler/optional-typeparameters.release.wat
+++ b/tests/compiler/optional-typeparameters.release.wat
@@ -63,10 +63,6 @@
    local.get $0
    call $~lib/rt/itcms/__visit
   end
-  i32.const 1248
-  call $~lib/rt/itcms/__visit
-  i32.const 1056
-  call $~lib/rt/itcms/__visit
   global.get $~lib/rt/itcms/pinSpace
   local.tee $1
   i32.load offset=4

--- a/tests/compiler/reexport.debug.wat
+++ b/tests/compiler/reexport.debug.wat
@@ -2300,22 +2300,6 @@
  )
  (func $export-default/theDefault
  )
- (func $~lib/rt/__visit_globals (param $0 i32)
-  (local $1 i32)
-  global.get $reexport/car
-  local.tee $1
-  if
-   local.get $1
-   local.get $0
-   call $~lib/rt/itcms/__visit
-  end
-  i32.const 272
-  local.get $0
-  call $~lib/rt/itcms/__visit
-  i32.const 80
-  local.get $0
-  call $~lib/rt/itcms/__visit
- )
  (func $~lib/arraybuffer/ArrayBufferView~visit (param $0 i32) (param $1 i32)
   (local $2 i32)
   local.get $0
@@ -2355,6 +2339,16 @@
    return
   end
   unreachable
+ )
+ (func $~lib/rt/__visit_globals (param $0 i32)
+  (local $1 i32)
+  global.get $reexport/car
+  local.tee $1
+  if
+   local.get $1
+   local.get $0
+   call $~lib/rt/itcms/__visit
+  end
  )
  (func $~start
   call $start:reexport

--- a/tests/compiler/reexport.release.wat
+++ b/tests/compiler/reexport.release.wat
@@ -70,10 +70,6 @@
    local.get $0
    call $~lib/rt/itcms/__visit
   end
-  i32.const 1296
-  call $~lib/rt/itcms/__visit
-  i32.const 1104
-  call $~lib/rt/itcms/__visit
   global.get $~lib/rt/itcms/pinSpace
   local.tee $1
   i32.load offset=4

--- a/tests/compiler/rereexport.debug.wat
+++ b/tests/compiler/rereexport.debug.wat
@@ -2287,36 +2287,6 @@
  )
  (func $export-default/theDefault
  )
- (func $~lib/rt/__visit_globals (param $0 i32)
-  (local $1 i32)
-  global.get $rereexport/car
-  local.tee $1
-  if
-   local.get $1
-   local.get $0
-   call $~lib/rt/itcms/__visit
-  end
-  global.get $rereexport/exportsNamespaceCar
-  local.tee $1
-  if
-   local.get $1
-   local.get $0
-   call $~lib/rt/itcms/__visit
-  end
-  i32.const 272
-  local.get $0
-  call $~lib/rt/itcms/__visit
-  i32.const 80
-  local.get $0
-  call $~lib/rt/itcms/__visit
-  global.get $reexport/car
-  local.tee $1
-  if
-   local.get $1
-   local.get $0
-   call $~lib/rt/itcms/__visit
-  end
- )
  (func $~lib/arraybuffer/ArrayBufferView~visit (param $0 i32) (param $1 i32)
   (local $2 i32)
   local.get $0
@@ -2356,6 +2326,30 @@
    return
   end
   unreachable
+ )
+ (func $~lib/rt/__visit_globals (param $0 i32)
+  (local $1 i32)
+  global.get $rereexport/car
+  local.tee $1
+  if
+   local.get $1
+   local.get $0
+   call $~lib/rt/itcms/__visit
+  end
+  global.get $rereexport/exportsNamespaceCar
+  local.tee $1
+  if
+   local.get $1
+   local.get $0
+   call $~lib/rt/itcms/__visit
+  end
+  global.get $reexport/car
+  local.tee $1
+  if
+   local.get $1
+   local.get $0
+   call $~lib/rt/itcms/__visit
+  end
  )
  (func $~start
   call $start:rereexport

--- a/tests/compiler/rereexport.release.wat
+++ b/tests/compiler/rereexport.release.wat
@@ -62,10 +62,6 @@
    local.get $0
    call $~lib/rt/itcms/__visit
   end
-  i32.const 1296
-  call $~lib/rt/itcms/__visit
-  i32.const 1104
-  call $~lib/rt/itcms/__visit
   global.get $reexport/car
   local.tee $0
   if

--- a/tests/compiler/resolve-access.debug.wat
+++ b/tests/compiler/resolve-access.debug.wat
@@ -2965,21 +2965,6 @@
   call $~lib/util/number/utoa32
   return
  )
- (func $~lib/rt/__visit_globals (param $0 i32)
-  (local $1 i32)
-  i32.const 256
-  local.get $0
-  call $~lib/rt/itcms/__visit
-  i32.const 64
-  local.get $0
-  call $~lib/rt/itcms/__visit
-  i32.const 1136
-  local.get $0
-  call $~lib/rt/itcms/__visit
-  i32.const 2192
-  local.get $0
-  call $~lib/rt/itcms/__visit
- )
  (func $~lib/arraybuffer/ArrayBufferView~visit (param $0 i32) (param $1 i32)
   (local $2 i32)
   local.get $0
@@ -3055,6 +3040,9 @@
    return
   end
   unreachable
+ )
+ (func $~lib/rt/__visit_globals (param $0 i32)
+  (local $1 i32)
  )
  (func $~start
   memory.size

--- a/tests/compiler/resolve-access.release.wat
+++ b/tests/compiler/resolve-access.release.wat
@@ -55,14 +55,6 @@
  (func $~lib/rt/itcms/visitRoots
   (local $0 i32)
   (local $1 i32)
-  i32.const 1280
-  call $~lib/rt/itcms/__visit
-  i32.const 1088
-  call $~lib/rt/itcms/__visit
-  i32.const 2160
-  call $~lib/rt/itcms/__visit
-  i32.const 3216
-  call $~lib/rt/itcms/__visit
   global.get $~lib/rt/itcms/pinSpace
   local.tee $1
   i32.load offset=4

--- a/tests/compiler/resolve-binary.debug.wat
+++ b/tests/compiler/resolve-binary.debug.wat
@@ -5557,49 +5557,6 @@
   local.get $left
   return
  )
- (func $~lib/rt/__visit_globals (param $0 i32)
-  (local $1 i32)
-  global.get $resolve-binary/foo
-  local.tee $1
-  if
-   local.get $1
-   local.get $0
-   call $~lib/rt/itcms/__visit
-  end
-  global.get $resolve-binary/bar
-  local.tee $1
-  if
-   local.get $1
-   local.get $0
-   call $~lib/rt/itcms/__visit
-  end
-  global.get $resolve-binary/bar2
-  local.tee $1
-  if
-   local.get $1
-   local.get $0
-   call $~lib/rt/itcms/__visit
-  end
-  global.get $resolve-binary/baz
-  local.tee $1
-  if
-   local.get $1
-   local.get $0
-   call $~lib/rt/itcms/__visit
-  end
-  i32.const 576
-  local.get $0
-  call $~lib/rt/itcms/__visit
-  i32.const 384
-  local.get $0
-  call $~lib/rt/itcms/__visit
-  i32.const 1184
-  local.get $0
-  call $~lib/rt/itcms/__visit
-  i32.const 2240
-  local.get $0
-  call $~lib/rt/itcms/__visit
- )
  (func $~lib/arraybuffer/ArrayBufferView~visit (param $0 i32) (param $1 i32)
   (local $2 i32)
   local.get $0
@@ -5645,6 +5602,37 @@
    return
   end
   unreachable
+ )
+ (func $~lib/rt/__visit_globals (param $0 i32)
+  (local $1 i32)
+  global.get $resolve-binary/foo
+  local.tee $1
+  if
+   local.get $1
+   local.get $0
+   call $~lib/rt/itcms/__visit
+  end
+  global.get $resolve-binary/bar
+  local.tee $1
+  if
+   local.get $1
+   local.get $0
+   call $~lib/rt/itcms/__visit
+  end
+  global.get $resolve-binary/bar2
+  local.tee $1
+  if
+   local.get $1
+   local.get $0
+   call $~lib/rt/itcms/__visit
+  end
+  global.get $resolve-binary/baz
+  local.tee $1
+  if
+   local.get $1
+   local.get $0
+   call $~lib/rt/itcms/__visit
+  end
  )
  (func $~start
   call $start:resolve-binary

--- a/tests/compiler/resolve-binary.release.wat
+++ b/tests/compiler/resolve-binary.release.wat
@@ -264,14 +264,6 @@
    local.get $0
    call $~lib/rt/itcms/__visit
   end
-  i32.const 1600
-  call $~lib/rt/itcms/__visit
-  i32.const 1408
-  call $~lib/rt/itcms/__visit
-  i32.const 2208
-  call $~lib/rt/itcms/__visit
-  i32.const 3264
-  call $~lib/rt/itcms/__visit
   global.get $~lib/rt/itcms/pinSpace
   local.tee $1
   i32.load offset=4

--- a/tests/compiler/resolve-elementaccess.debug.wat
+++ b/tests/compiler/resolve-elementaccess.debug.wat
@@ -4291,38 +4291,6 @@
   call $~lib/util/number/utoa32
   return
  )
- (func $~lib/rt/__visit_globals (param $0 i32)
-  (local $1 i32)
-  global.get $resolve-elementaccess/arr
-  local.tee $1
-  if
-   local.get $1
-   local.get $0
-   call $~lib/rt/itcms/__visit
-  end
-  global.get $resolve-elementaccess/buf
-  local.tee $1
-  if
-   local.get $1
-   local.get $0
-   call $~lib/rt/itcms/__visit
-  end
-  i32.const 336
-  local.get $0
-  call $~lib/rt/itcms/__visit
-  i32.const 32
-  local.get $0
-  call $~lib/rt/itcms/__visit
-  i32.const 144
-  local.get $0
-  call $~lib/rt/itcms/__visit
-  i32.const 2544
-  local.get $0
-  call $~lib/rt/itcms/__visit
-  i32.const 3600
-  local.get $0
-  call $~lib/rt/itcms/__visit
- )
  (func $~lib/arraybuffer/ArrayBufferView~visit (param $0 i32) (param $1 i32)
   (local $2 i32)
   local.get $0
@@ -4392,6 +4360,23 @@
    return
   end
   unreachable
+ )
+ (func $~lib/rt/__visit_globals (param $0 i32)
+  (local $1 i32)
+  global.get $resolve-elementaccess/arr
+  local.tee $1
+  if
+   local.get $1
+   local.get $0
+   call $~lib/rt/itcms/__visit
+  end
+  global.get $resolve-elementaccess/buf
+  local.tee $1
+  if
+   local.get $1
+   local.get $0
+   call $~lib/rt/itcms/__visit
+  end
  )
  (func $~start
   call $start:resolve-elementaccess

--- a/tests/compiler/resolve-elementaccess.release.wat
+++ b/tests/compiler/resolve-elementaccess.release.wat
@@ -105,16 +105,6 @@
    local.get $0
    call $~lib/rt/itcms/__visit
   end
-  i32.const 1360
-  call $~lib/rt/itcms/__visit
-  i32.const 1056
-  call $~lib/rt/itcms/__visit
-  i32.const 1168
-  call $~lib/rt/itcms/__visit
-  i32.const 3568
-  call $~lib/rt/itcms/__visit
-  i32.const 4624
-  call $~lib/rt/itcms/__visit
   global.get $~lib/rt/itcms/pinSpace
   local.tee $1
   i32.load offset=4

--- a/tests/compiler/resolve-function-expression.debug.wat
+++ b/tests/compiler/resolve-function-expression.debug.wat
@@ -2807,21 +2807,6 @@
   i32.const 0
   return
  )
- (func $~lib/rt/__visit_globals (param $0 i32)
-  (local $1 i32)
-  i32.const 624
-  local.get $0
-  call $~lib/rt/itcms/__visit
-  i32.const 432
-  local.get $0
-  call $~lib/rt/itcms/__visit
-  i32.const 1232
-  local.get $0
-  call $~lib/rt/itcms/__visit
-  i32.const 2288
-  local.get $0
-  call $~lib/rt/itcms/__visit
- )
  (func $~lib/arraybuffer/ArrayBufferView~visit (param $0 i32) (param $1 i32)
   (local $2 i32)
   local.get $0
@@ -2876,6 +2861,9 @@
    return
   end
   unreachable
+ )
+ (func $~lib/rt/__visit_globals (param $0 i32)
+  (local $1 i32)
  )
  (func $~start
   call $start:resolve-function-expression

--- a/tests/compiler/resolve-function-expression.release.wat
+++ b/tests/compiler/resolve-function-expression.release.wat
@@ -74,14 +74,6 @@
  (func $~lib/rt/itcms/visitRoots
   (local $0 i32)
   (local $1 i32)
-  i32.const 1648
-  call $~lib/rt/itcms/__visit
-  i32.const 1456
-  call $~lib/rt/itcms/__visit
-  i32.const 2256
-  call $~lib/rt/itcms/__visit
-  i32.const 3312
-  call $~lib/rt/itcms/__visit
   global.get $~lib/rt/itcms/pinSpace
   local.tee $1
   i32.load offset=4

--- a/tests/compiler/resolve-new.debug.wat
+++ b/tests/compiler/resolve-new.debug.wat
@@ -2244,22 +2244,6 @@
  )
  (func $resolve-new/Foo#bar (param $this i32)
  )
- (func $~lib/rt/__visit_globals (param $0 i32)
-  (local $1 i32)
-  global.get $resolve-new/foo
-  local.tee $1
-  if
-   local.get $1
-   local.get $0
-   call $~lib/rt/itcms/__visit
-  end
-  i32.const 224
-  local.get $0
-  call $~lib/rt/itcms/__visit
-  i32.const 32
-  local.get $0
-  call $~lib/rt/itcms/__visit
- )
  (func $~lib/arraybuffer/ArrayBufferView~visit (param $0 i32) (param $1 i32)
   (local $2 i32)
   local.get $0
@@ -2299,6 +2283,16 @@
    return
   end
   unreachable
+ )
+ (func $~lib/rt/__visit_globals (param $0 i32)
+  (local $1 i32)
+  global.get $resolve-new/foo
+  local.tee $1
+  if
+   local.get $1
+   local.get $0
+   call $~lib/rt/itcms/__visit
+  end
  )
  (func $~start
   call $start:resolve-new

--- a/tests/compiler/resolve-new.release.wat
+++ b/tests/compiler/resolve-new.release.wat
@@ -42,10 +42,6 @@
    local.get $0
    call $~lib/rt/itcms/__visit
   end
-  i32.const 1248
-  call $~lib/rt/itcms/__visit
-  i32.const 1056
-  call $~lib/rt/itcms/__visit
   global.get $~lib/rt/itcms/pinSpace
   local.tee $1
   i32.load offset=4

--- a/tests/compiler/resolve-propertyaccess.debug.wat
+++ b/tests/compiler/resolve-propertyaccess.debug.wat
@@ -2824,21 +2824,6 @@
   i32.const 8
   return
  )
- (func $~lib/rt/__visit_globals (param $0 i32)
-  (local $1 i32)
-  i32.const 448
-  local.get $0
-  call $~lib/rt/itcms/__visit
-  i32.const 256
-  local.get $0
-  call $~lib/rt/itcms/__visit
-  i32.const 1056
-  local.get $0
-  call $~lib/rt/itcms/__visit
-  i32.const 2112
-  local.get $0
-  call $~lib/rt/itcms/__visit
- )
  (func $~lib/arraybuffer/ArrayBufferView~visit (param $0 i32) (param $1 i32)
   (local $2 i32)
   local.get $0
@@ -2878,6 +2863,9 @@
    return
   end
   unreachable
+ )
+ (func $~lib/rt/__visit_globals (param $0 i32)
+  (local $1 i32)
  )
  (func $~start
   call $start:resolve-propertyaccess

--- a/tests/compiler/resolve-propertyaccess.release.wat
+++ b/tests/compiler/resolve-propertyaccess.release.wat
@@ -73,14 +73,6 @@
  (func $~lib/rt/itcms/visitRoots
   (local $0 i32)
   (local $1 i32)
-  i32.const 1472
-  call $~lib/rt/itcms/__visit
-  i32.const 1280
-  call $~lib/rt/itcms/__visit
-  i32.const 2080
-  call $~lib/rt/itcms/__visit
-  i32.const 3136
-  call $~lib/rt/itcms/__visit
   global.get $~lib/rt/itcms/pinSpace
   local.tee $1
   i32.load offset=4

--- a/tests/compiler/resolve-ternary.debug.wat
+++ b/tests/compiler/resolve-ternary.debug.wat
@@ -4212,21 +4212,6 @@
   i32.add
   return
  )
- (func $~lib/rt/__visit_globals (param $0 i32)
-  (local $1 i32)
-  i32.const 448
-  local.get $0
-  call $~lib/rt/itcms/__visit
-  i32.const 256
-  local.get $0
-  call $~lib/rt/itcms/__visit
-  i32.const 1056
-  local.get $0
-  call $~lib/rt/itcms/__visit
-  i32.const 2112
-  local.get $0
-  call $~lib/rt/itcms/__visit
- )
  (func $~lib/arraybuffer/ArrayBufferView~visit (param $0 i32) (param $1 i32)
   (local $2 i32)
   local.get $0
@@ -4281,6 +4266,9 @@
    return
   end
   unreachable
+ )
+ (func $~lib/rt/__visit_globals (param $0 i32)
+  (local $1 i32)
  )
  (func $~start
   call $start:resolve-ternary

--- a/tests/compiler/resolve-ternary.release.wat
+++ b/tests/compiler/resolve-ternary.release.wat
@@ -79,14 +79,6 @@
  (func $~lib/rt/itcms/visitRoots
   (local $0 i32)
   (local $1 i32)
-  i32.const 1472
-  call $~lib/rt/itcms/__visit
-  i32.const 1280
-  call $~lib/rt/itcms/__visit
-  i32.const 2080
-  call $~lib/rt/itcms/__visit
-  i32.const 3136
-  call $~lib/rt/itcms/__visit
   global.get $~lib/rt/itcms/pinSpace
   local.tee $1
   i32.load offset=4

--- a/tests/compiler/resolve-unary.debug.wat
+++ b/tests/compiler/resolve-unary.debug.wat
@@ -2876,35 +2876,6 @@
  )
  (func $resolve-unary/generic<~lib/string/String> (param $v i32)
  )
- (func $~lib/rt/__visit_globals (param $0 i32)
-  (local $1 i32)
-  global.get $resolve-unary/foo
-  local.tee $1
-  if
-   local.get $1
-   local.get $0
-   call $~lib/rt/itcms/__visit
-  end
-  global.get $resolve-unary/bar
-  local.tee $1
-  if
-   local.get $1
-   local.get $0
-   call $~lib/rt/itcms/__visit
-  end
-  i32.const 448
-  local.get $0
-  call $~lib/rt/itcms/__visit
-  i32.const 256
-  local.get $0
-  call $~lib/rt/itcms/__visit
-  i32.const 1056
-  local.get $0
-  call $~lib/rt/itcms/__visit
-  i32.const 2112
-  local.get $0
-  call $~lib/rt/itcms/__visit
- )
  (func $~lib/arraybuffer/ArrayBufferView~visit (param $0 i32) (param $1 i32)
   (local $2 i32)
   local.get $0
@@ -2965,6 +2936,23 @@
    return
   end
   unreachable
+ )
+ (func $~lib/rt/__visit_globals (param $0 i32)
+  (local $1 i32)
+  global.get $resolve-unary/foo
+  local.tee $1
+  if
+   local.get $1
+   local.get $0
+   call $~lib/rt/itcms/__visit
+  end
+  global.get $resolve-unary/bar
+  local.tee $1
+  if
+   local.get $1
+   local.get $0
+   call $~lib/rt/itcms/__visit
+  end
  )
  (func $~start
   call $start:resolve-unary

--- a/tests/compiler/resolve-unary.release.wat
+++ b/tests/compiler/resolve-unary.release.wat
@@ -99,14 +99,6 @@
    local.get $0
    call $~lib/rt/itcms/__visit
   end
-  i32.const 1472
-  call $~lib/rt/itcms/__visit
-  i32.const 1280
-  call $~lib/rt/itcms/__visit
-  i32.const 2080
-  call $~lib/rt/itcms/__visit
-  i32.const 3136
-  call $~lib/rt/itcms/__visit
   global.get $~lib/rt/itcms/pinSpace
   local.tee $1
   i32.load offset=4

--- a/tests/compiler/return-unreachable.debug.wat
+++ b/tests/compiler/return-unreachable.debug.wat
@@ -2355,18 +2355,6 @@
   i32.store
   unreachable
  )
- (func $~lib/rt/__visit_globals (param $0 i32)
-  (local $1 i32)
-  i32.const 320
-  local.get $0
-  call $~lib/rt/itcms/__visit
-  i32.const 32
-  local.get $0
-  call $~lib/rt/itcms/__visit
-  i32.const 128
-  local.get $0
-  call $~lib/rt/itcms/__visit
- )
  (func $~lib/arraybuffer/ArrayBufferView~visit (param $0 i32) (param $1 i32)
   (local $2 i32)
   local.get $0
@@ -2421,6 +2409,9 @@
    return
   end
   unreachable
+ )
+ (func $~lib/rt/__visit_globals (param $0 i32)
+  (local $1 i32)
  )
  (func $~start
   memory.size

--- a/tests/compiler/return-unreachable.release.wat
+++ b/tests/compiler/return-unreachable.release.wat
@@ -41,12 +41,6 @@
  (func $~lib/rt/itcms/visitRoots
   (local $0 i32)
   (local $1 i32)
-  i32.const 1344
-  call $~lib/rt/itcms/__visit
-  i32.const 1056
-  call $~lib/rt/itcms/__visit
-  i32.const 1152
-  call $~lib/rt/itcms/__visit
   global.get $~lib/rt/itcms/pinSpace
   local.tee $1
   i32.load offset=4

--- a/tests/compiler/rt/finalize.debug.wat
+++ b/tests/compiler/rt/finalize.debug.wat
@@ -2344,15 +2344,6 @@
    unreachable
   end
  )
- (func $~lib/rt/__visit_globals (param $0 i32)
-  (local $1 i32)
-  i32.const 224
-  local.get $0
-  call $~lib/rt/itcms/__visit
-  i32.const 32
-  local.get $0
-  call $~lib/rt/itcms/__visit
- )
  (func $~lib/arraybuffer/ArrayBufferView~visit (param $0 i32) (param $1 i32)
   (local $2 i32)
   local.get $0
@@ -2392,6 +2383,9 @@
    return
   end
   unreachable
+ )
+ (func $~lib/rt/__visit_globals (param $0 i32)
+  (local $1 i32)
  )
  (func $~start
   global.get $~started

--- a/tests/compiler/rt/finalize.release.wat
+++ b/tests/compiler/rt/finalize.release.wat
@@ -40,10 +40,6 @@
  (func $~lib/rt/itcms/visitRoots
   (local $0 i32)
   (local $1 i32)
-  i32.const 1248
-  call $~lib/rt/itcms/__visit
-  i32.const 1056
-  call $~lib/rt/itcms/__visit
   global.get $~lib/rt/itcms/pinSpace
   local.tee $1
   i32.load offset=4

--- a/tests/compiler/rt/issue-2719.debug.wat
+++ b/tests/compiler/rt/issue-2719.debug.wat
@@ -2297,15 +2297,6 @@
   local.get $this
   i32.load
  )
- (func $~lib/rt/__visit_globals (param $0 i32)
-  (local $1 i32)
-  i32.const 224
-  local.get $0
-  call $~lib/rt/itcms/__visit
-  i32.const 32
-  local.get $0
-  call $~lib/rt/itcms/__visit
- )
  (func $~lib/arraybuffer/ArrayBufferView~visit (param $0 i32) (param $1 i32)
   (local $2 i32)
   local.get $0
@@ -2345,6 +2336,9 @@
    return
   end
   unreachable
+ )
+ (func $~lib/rt/__visit_globals (param $0 i32)
+  (local $1 i32)
  )
  (func $~start
   call $start:rt/issue-2719

--- a/tests/compiler/rt/issue-2719.release.wat
+++ b/tests/compiler/rt/issue-2719.release.wat
@@ -37,10 +37,6 @@
  (func $~lib/rt/itcms/visitRoots
   (local $0 i32)
   (local $1 i32)
-  i32.const 1248
-  call $~lib/rt/itcms/__visit
-  i32.const 1056
-  call $~lib/rt/itcms/__visit
   global.get $~lib/rt/itcms/pinSpace
   local.tee $1
   i32.load offset=4

--- a/tests/compiler/rt/runtime-incremental-export.debug.wat
+++ b/tests/compiler/rt/runtime-incremental-export.debug.wat
@@ -2362,21 +2362,6 @@
   i32.const 0
   drop
  )
- (func $~lib/rt/__visit_globals (param $0 i32)
-  (local $1 i32)
-  i32.const 224
-  local.get $0
-  call $~lib/rt/itcms/__visit
-  i32.const 32
-  local.get $0
-  call $~lib/rt/itcms/__visit
-  i32.const 432
-  local.get $0
-  call $~lib/rt/itcms/__visit
-  i32.const 496
-  local.get $0
-  call $~lib/rt/itcms/__visit
- )
  (func $~lib/arraybuffer/ArrayBufferView~visit (param $0 i32) (param $1 i32)
   (local $2 i32)
   local.get $0
@@ -2413,6 +2398,9 @@
    return
   end
   unreachable
+ )
+ (func $~lib/rt/__visit_globals (param $0 i32)
+  (local $1 i32)
  )
  (func $~start
   memory.size

--- a/tests/compiler/rt/runtime-incremental-export.release.wat
+++ b/tests/compiler/rt/runtime-incremental-export.release.wat
@@ -45,14 +45,6 @@
  (func $~lib/rt/itcms/visitRoots
   (local $0 i32)
   (local $1 i32)
-  i32.const 1248
-  call $~lib/rt/itcms/__visit
-  i32.const 1056
-  call $~lib/rt/itcms/__visit
-  i32.const 1456
-  call $~lib/rt/itcms/__visit
-  i32.const 1520
-  call $~lib/rt/itcms/__visit
   global.get $~lib/rt/itcms/pinSpace
   local.tee $1
   i32.load offset=4

--- a/tests/compiler/rt/runtime-minimal-export.debug.wat
+++ b/tests/compiler/rt/runtime-minimal-export.debug.wat
@@ -2015,18 +2015,6 @@
    call $~lib/rt/tcms/Object#linkTo
   end
  )
- (func $~lib/rt/__visit_globals (param $0 i32)
-  (local $1 i32)
-  i32.const 32
-  local.get $0
-  call $~lib/rt/tcms/__visit
-  i32.const 256
-  local.get $0
-  call $~lib/rt/tcms/__visit
-  i32.const 352
-  local.get $0
-  call $~lib/rt/tcms/__visit
- )
  (func $~lib/arraybuffer/ArrayBufferView~visit (param $0 i32) (param $1 i32)
   (local $2 i32)
   local.get $0
@@ -2063,6 +2051,9 @@
    return
   end
   unreachable
+ )
+ (func $~lib/rt/__visit_globals (param $0 i32)
+  (local $1 i32)
  )
  (func $~start
   i32.const 208

--- a/tests/compiler/rt/runtime-minimal-export.release.wat
+++ b/tests/compiler/rt/runtime-minimal-export.release.wat
@@ -1,6 +1,6 @@
 (module
- (type $0 (func (param i32)))
- (type $1 (func))
+ (type $0 (func))
+ (type $1 (func (param i32)))
  (type $2 (func (param i32 i32)))
  (type $3 (func (param i32 i32) (result i32)))
  (type $4 (func (param i32 i32 i32 i32)))
@@ -1176,12 +1176,6 @@
   (local $4 i32)
   (local $5 i32)
   (local $6 i32)
-  i32.const 1056
-  call $~lib/rt/tcms/__visit
-  i32.const 1280
-  call $~lib/rt/tcms/__visit
-  i32.const 1376
-  call $~lib/rt/tcms/__visit
   global.get $~lib/rt/tcms/pinSpace
   local.tee $1
   i32.load offset=4
@@ -1374,53 +1368,9 @@
   local.get $3
   global.set $~lib/rt/tcms/white
  )
- (func $~lib/rt/tcms/__visit (param $0 i32)
+ (func $~lib/rt/__visit_members (param $0 i32)
   (local $1 i32)
   (local $2 i32)
-  local.get $0
-  i32.eqz
-  if
-   return
-  end
-  global.get $~lib/rt/tcms/white
-  local.get $0
-  i32.const 20
-  i32.sub
-  local.tee $1
-  i32.load offset=4
-  i32.const 3
-  i32.and
-  i32.eq
-  if
-   local.get $1
-   call $~lib/rt/tcms/Object#unlink
-   global.get $~lib/rt/tcms/toSpace
-   local.tee $0
-   i32.load offset=8
-   local.set $2
-   local.get $1
-   local.get $0
-   global.get $~lib/rt/tcms/white
-   i32.eqz
-   i32.or
-   i32.store offset=4
-   local.get $1
-   local.get $2
-   i32.store offset=8
-   local.get $2
-   local.get $1
-   local.get $2
-   i32.load offset=4
-   i32.const 3
-   i32.and
-   i32.or
-   i32.store offset=4
-   local.get $0
-   local.get $1
-   i32.store offset=8
-  end
- )
- (func $~lib/rt/__visit_members (param $0 i32)
   block $invalid
    block $~lib/arraybuffer/ArrayBufferView
     block $~lib/string/String
@@ -1440,7 +1390,46 @@
    end
    local.get $0
    i32.load
-   call $~lib/rt/tcms/__visit
+   local.tee $0
+   if
+    global.get $~lib/rt/tcms/white
+    local.get $0
+    i32.const 20
+    i32.sub
+    local.tee $1
+    i32.load offset=4
+    i32.const 3
+    i32.and
+    i32.eq
+    if
+     local.get $1
+     call $~lib/rt/tcms/Object#unlink
+     global.get $~lib/rt/tcms/toSpace
+     local.tee $0
+     i32.load offset=8
+     local.set $2
+     local.get $1
+     local.get $0
+     global.get $~lib/rt/tcms/white
+     i32.eqz
+     i32.or
+     i32.store offset=4
+     local.get $1
+     local.get $2
+     i32.store offset=8
+     local.get $2
+     local.get $1
+     local.get $2
+     i32.load offset=4
+     i32.const 3
+     i32.and
+     i32.or
+     i32.store offset=4
+     local.get $0
+     local.get $1
+     i32.store offset=8
+    end
+   end
    return
   end
   unreachable

--- a/tests/compiler/simd.debug.wat
+++ b/tests/compiler/simd.debug.wat
@@ -6795,15 +6795,6 @@
   f64x2.replace_lane 1
   return
  )
- (func $~lib/rt/__visit_globals (param $0 i32)
-  (local $1 i32)
-  i32.const 272
-  local.get $0
-  call $~lib/rt/itcms/__visit
-  i32.const 80
-  local.get $0
-  call $~lib/rt/itcms/__visit
- )
  (func $~lib/arraybuffer/ArrayBufferView~visit (param $0 i32) (param $1 i32)
   (local $2 i32)
   local.get $0
@@ -6876,6 +6867,9 @@
    return
   end
   unreachable
+ )
+ (func $~lib/rt/__visit_globals (param $0 i32)
+  (local $1 i32)
  )
  (func $~start
   call $start:simd

--- a/tests/compiler/simd.release.wat
+++ b/tests/compiler/simd.release.wat
@@ -68,10 +68,6 @@
  (func $~lib/rt/itcms/visitRoots
   (local $0 i32)
   (local $1 i32)
-  i32.const 1296
-  call $~lib/rt/itcms/__visit
-  i32.const 1104
-  call $~lib/rt/itcms/__visit
   global.get $~lib/rt/itcms/pinSpace
   local.tee $1
   i32.load offset=4

--- a/tests/compiler/std/array-literal.debug.wat
+++ b/tests/compiler/std/array-literal.debug.wat
@@ -2503,67 +2503,6 @@
   i32.const 0
   drop
  )
- (func $~lib/rt/__visit_globals (param $0 i32)
-  (local $1 i32)
-  global.get $std/array-literal/staticArrayI8
-  local.tee $1
-  if
-   local.get $1
-   local.get $0
-   call $~lib/rt/itcms/__visit
-  end
-  global.get $std/array-literal/staticArrayI32
-  local.tee $1
-  if
-   local.get $1
-   local.get $0
-   call $~lib/rt/itcms/__visit
-  end
-  global.get $std/array-literal/emptyArrayI32
-  local.tee $1
-  if
-   local.get $1
-   local.get $0
-   call $~lib/rt/itcms/__visit
-  end
-  global.get $std/array-literal/dynamicArrayI8
-  local.tee $1
-  if
-   local.get $1
-   local.get $0
-   call $~lib/rt/itcms/__visit
-  end
-  global.get $std/array-literal/dynamicArrayI32
-  local.tee $1
-  if
-   local.get $1
-   local.get $0
-   call $~lib/rt/itcms/__visit
-  end
-  global.get $std/array-literal/dynamicArrayRef
-  local.tee $1
-  if
-   local.get $1
-   local.get $0
-   call $~lib/rt/itcms/__visit
-  end
-  global.get $std/array-literal/dynamicArrayRefWithCtor
-  local.tee $1
-  if
-   local.get $1
-   local.get $0
-   call $~lib/rt/itcms/__visit
-  end
-  i32.const 176
-  local.get $0
-  call $~lib/rt/itcms/__visit
-  i32.const 784
-  local.get $0
-  call $~lib/rt/itcms/__visit
-  i32.const 448
-  local.get $0
-  call $~lib/rt/itcms/__visit
- )
  (func $~lib/arraybuffer/ArrayBufferView~visit (param $0 i32) (param $1 i32)
   (local $2 i32)
   local.get $0
@@ -2678,6 +2617,58 @@
    return
   end
   unreachable
+ )
+ (func $~lib/rt/__visit_globals (param $0 i32)
+  (local $1 i32)
+  global.get $std/array-literal/staticArrayI8
+  local.tee $1
+  if
+   local.get $1
+   local.get $0
+   call $~lib/rt/itcms/__visit
+  end
+  global.get $std/array-literal/staticArrayI32
+  local.tee $1
+  if
+   local.get $1
+   local.get $0
+   call $~lib/rt/itcms/__visit
+  end
+  global.get $std/array-literal/emptyArrayI32
+  local.tee $1
+  if
+   local.get $1
+   local.get $0
+   call $~lib/rt/itcms/__visit
+  end
+  global.get $std/array-literal/dynamicArrayI8
+  local.tee $1
+  if
+   local.get $1
+   local.get $0
+   call $~lib/rt/itcms/__visit
+  end
+  global.get $std/array-literal/dynamicArrayI32
+  local.tee $1
+  if
+   local.get $1
+   local.get $0
+   call $~lib/rt/itcms/__visit
+  end
+  global.get $std/array-literal/dynamicArrayRef
+  local.tee $1
+  if
+   local.get $1
+   local.get $0
+   call $~lib/rt/itcms/__visit
+  end
+  global.get $std/array-literal/dynamicArrayRefWithCtor
+  local.tee $1
+  if
+   local.get $1
+   local.get $0
+   call $~lib/rt/itcms/__visit
+  end
  )
  (func $~start
   call $start:std/array-literal

--- a/tests/compiler/std/array-literal.release.wat
+++ b/tests/compiler/std/array-literal.release.wat
@@ -96,12 +96,6 @@
    local.get $0
    call $~lib/rt/itcms/__visit
   end
-  i32.const 1200
-  call $~lib/rt/itcms/__visit
-  i32.const 1808
-  call $~lib/rt/itcms/__visit
-  i32.const 1472
-  call $~lib/rt/itcms/__visit
   global.get $~lib/rt/itcms/pinSpace
   local.tee $1
   i32.load offset=4

--- a/tests/compiler/std/array.debug.wat
+++ b/tests/compiler/std/array.debug.wat
@@ -9238,58 +9238,6 @@
   i32.const 0
   drop
  )
- (func $~lib/rt/__visit_globals (param $0 i32)
-  (local $1 i32)
-  global.get $std/array/arr
-  local.tee $1
-  if
-   local.get $1
-   local.get $0
-   call $~lib/rt/itcms/__visit
-  end
-  global.get $std/array/charset
-  local.tee $1
-  if
-   local.get $1
-   local.get $0
-   call $~lib/rt/itcms/__visit
-  end
-  global.get $std/array/inputStabArr
-  local.tee $1
-  if
-   local.get $1
-   local.get $0
-   call $~lib/rt/itcms/__visit
-  end
-  global.get $std/array/outputStabArr
-  local.tee $1
-  if
-   local.get $1
-   local.get $0
-   call $~lib/rt/itcms/__visit
-  end
-  i32.const 320
-  local.get $0
-  call $~lib/rt/itcms/__visit
-  i32.const 32
-  local.get $0
-  call $~lib/rt/itcms/__visit
-  i32.const 1616
-  local.get $0
-  call $~lib/rt/itcms/__visit
-  i32.const 5392
-  local.get $0
-  call $~lib/rt/itcms/__visit
-  i32.const 128
-  local.get $0
-  call $~lib/rt/itcms/__visit
-  i32.const 7120
-  local.get $0
-  call $~lib/rt/itcms/__visit
-  i32.const 8176
-  local.get $0
-  call $~lib/rt/itcms/__visit
- )
  (func $~lib/arraybuffer/ArrayBufferView~visit (param $0 i32) (param $1 i32)
   (local $2 i32)
   local.get $0
@@ -10044,6 +9992,30 @@
    return
   end
   unreachable
+ )
+ (func $~lib/rt/__visit_globals (param $0 i32)
+  (local $1 i32)
+  global.get $std/array/arr
+  local.tee $1
+  if
+   local.get $1
+   local.get $0
+   call $~lib/rt/itcms/__visit
+  end
+  global.get $std/array/inputStabArr
+  local.tee $1
+  if
+   local.get $1
+   local.get $0
+   call $~lib/rt/itcms/__visit
+  end
+  global.get $std/array/outputStabArr
+  local.tee $1
+  if
+   local.get $1
+   local.get $0
+   call $~lib/rt/itcms/__visit
+  end
  )
  (func $~start
   global.get $~started

--- a/tests/compiler/std/array.release.wat
+++ b/tests/compiler/std/array.release.wat
@@ -669,8 +669,6 @@
    local.get $0
    call $~lib/rt/itcms/__visit
   end
-  i32.const 10032
-  call $~lib/rt/itcms/__visit
   global.get $std/array/inputStabArr
   local.tee $0
   if
@@ -683,20 +681,6 @@
    local.get $0
    call $~lib/rt/itcms/__visit
   end
-  i32.const 1344
-  call $~lib/rt/itcms/__visit
-  i32.const 1056
-  call $~lib/rt/itcms/__visit
-  i32.const 2640
-  call $~lib/rt/itcms/__visit
-  i32.const 6416
-  call $~lib/rt/itcms/__visit
-  i32.const 1152
-  call $~lib/rt/itcms/__visit
-  i32.const 8144
-  call $~lib/rt/itcms/__visit
-  i32.const 9200
-  call $~lib/rt/itcms/__visit
   global.get $~lib/rt/itcms/pinSpace
   local.tee $1
   i32.load offset=4

--- a/tests/compiler/std/arraybuffer.debug.wat
+++ b/tests/compiler/std/arraybuffer.debug.wat
@@ -2667,18 +2667,6 @@
   i32.const 0
   drop
  )
- (func $~lib/rt/__visit_globals (param $0 i32)
-  (local $1 i32)
-  i32.const 336
-  local.get $0
-  call $~lib/rt/itcms/__visit
-  i32.const 32
-  local.get $0
-  call $~lib/rt/itcms/__visit
-  i32.const 144
-  local.get $0
-  call $~lib/rt/itcms/__visit
- )
  (func $~lib/arraybuffer/ArrayBufferView~visit (param $0 i32) (param $1 i32)
   (local $2 i32)
   local.get $0
@@ -2870,6 +2858,9 @@
    return
   end
   unreachable
+ )
+ (func $~lib/rt/__visit_globals (param $0 i32)
+  (local $1 i32)
  )
  (func $~start
   call $start:std/arraybuffer

--- a/tests/compiler/std/arraybuffer.release.wat
+++ b/tests/compiler/std/arraybuffer.release.wat
@@ -46,12 +46,6 @@
  (func $~lib/rt/itcms/visitRoots
   (local $0 i32)
   (local $1 i32)
-  i32.const 1360
-  call $~lib/rt/itcms/__visit
-  i32.const 1056
-  call $~lib/rt/itcms/__visit
-  i32.const 1168
-  call $~lib/rt/itcms/__visit
   global.get $~lib/rt/itcms/pinSpace
   local.tee $1
   i32.load offset=4

--- a/tests/compiler/std/dataview.debug.wat
+++ b/tests/compiler/std/dataview.debug.wat
@@ -2555,18 +2555,6 @@
   i32.const 0
   drop
  )
- (func $~lib/rt/__visit_globals (param $0 i32)
-  (local $1 i32)
-  i32.const 336
-  local.get $0
-  call $~lib/rt/itcms/__visit
-  i32.const 32
-  local.get $0
-  call $~lib/rt/itcms/__visit
-  i32.const 144
-  local.get $0
-  call $~lib/rt/itcms/__visit
- )
  (func $~lib/arraybuffer/ArrayBufferView~visit (param $0 i32) (param $1 i32)
   (local $2 i32)
   local.get $0
@@ -2630,6 +2618,9 @@
    return
   end
   unreachable
+ )
+ (func $~lib/rt/__visit_globals (param $0 i32)
+  (local $1 i32)
  )
  (func $~start
   call $start:std/dataview

--- a/tests/compiler/std/dataview.release.wat
+++ b/tests/compiler/std/dataview.release.wat
@@ -54,12 +54,6 @@
  (func $~lib/rt/itcms/visitRoots
   (local $0 i32)
   (local $1 i32)
-  i32.const 1360
-  call $~lib/rt/itcms/__visit
-  i32.const 1056
-  call $~lib/rt/itcms/__visit
-  i32.const 1168
-  call $~lib/rt/itcms/__visit
   global.get $~lib/rt/itcms/pinSpace
   local.tee $1
   i32.load offset=4

--- a/tests/compiler/std/date.debug.wat
+++ b/tests/compiler/std/date.debug.wat
@@ -3653,30 +3653,6 @@
   local.get $this
   i32.load offset=4
  )
- (func $~lib/rt/__visit_globals (param $0 i32)
-  (local $1 i32)
-  i32.const 368
-  local.get $0
-  call $~lib/rt/itcms/__visit
-  i32.const 5760
-  local.get $0
-  call $~lib/rt/itcms/__visit
-  i32.const 5808
-  local.get $0
-  call $~lib/rt/itcms/__visit
-  i32.const 176
-  local.get $0
-  call $~lib/rt/itcms/__visit
-  i32.const 32
-  local.get $0
-  call $~lib/rt/itcms/__visit
-  i32.const 1280
-  local.get $0
-  call $~lib/rt/itcms/__visit
-  i32.const 2336
-  local.get $0
-  call $~lib/rt/itcms/__visit
- )
  (func $~lib/arraybuffer/ArrayBufferView~visit (param $0 i32) (param $1 i32)
   (local $2 i32)
   local.get $0
@@ -3803,6 +3779,9 @@
    return
   end
   unreachable
+ )
+ (func $~lib/rt/__visit_globals (param $0 i32)
+  (local $1 i32)
  )
  (func $~start
   global.get $~started

--- a/tests/compiler/std/date.release.wat
+++ b/tests/compiler/std/date.release.wat
@@ -429,20 +429,6 @@
  (func $~lib/rt/itcms/visitRoots
   (local $0 i32)
   (local $1 i32)
-  i32.const 1392
-  call $~lib/rt/itcms/__visit
-  i32.const 6784
-  call $~lib/rt/itcms/__visit
-  i32.const 6832
-  call $~lib/rt/itcms/__visit
-  i32.const 1200
-  call $~lib/rt/itcms/__visit
-  i32.const 1056
-  call $~lib/rt/itcms/__visit
-  i32.const 2304
-  call $~lib/rt/itcms/__visit
-  i32.const 3360
-  call $~lib/rt/itcms/__visit
   global.get $~lib/rt/itcms/pinSpace
   local.tee $1
   i32.load offset=4

--- a/tests/compiler/std/map.debug.wat
+++ b/tests/compiler/std/map.debug.wat
@@ -5225,21 +5225,6 @@
   call $"std/map/testNumeric<f64,i32>"
   call $~lib/rt/itcms/__collect
  )
- (func $~lib/rt/__visit_globals (param $0 i32)
-  (local $1 i32)
-  i32.const 224
-  local.get $0
-  call $~lib/rt/itcms/__visit
-  i32.const 432
-  local.get $0
-  call $~lib/rt/itcms/__visit
-  i32.const 592
-  local.get $0
-  call $~lib/rt/itcms/__visit
-  i32.const 32
-  local.get $0
-  call $~lib/rt/itcms/__visit
- )
  (func $~lib/arraybuffer/ArrayBufferView~visit (param $0 i32) (param $1 i32)
   (local $2 i32)
   local.get $0
@@ -5722,6 +5707,9 @@
    return
   end
   unreachable
+ )
+ (func $~lib/rt/__visit_globals (param $0 i32)
+  (local $1 i32)
  )
  (func $~start
   call $start:std/map

--- a/tests/compiler/std/map.release.wat
+++ b/tests/compiler/std/map.release.wat
@@ -65,14 +65,6 @@
  (func $~lib/rt/itcms/visitRoots
   (local $0 i32)
   (local $1 i32)
-  i32.const 1248
-  call $~lib/rt/itcms/__visit
-  i32.const 1456
-  call $~lib/rt/itcms/__visit
-  i32.const 1616
-  call $~lib/rt/itcms/__visit
-  i32.const 1056
-  call $~lib/rt/itcms/__visit
   global.get $~lib/rt/itcms/pinSpace
   local.tee $1
   i32.load offset=4

--- a/tests/compiler/std/new.debug.wat
+++ b/tests/compiler/std/new.debug.wat
@@ -2282,22 +2282,6 @@
   call $std/new/AClass#constructor
   global.set $std/new/aClass
  )
- (func $~lib/rt/__visit_globals (param $0 i32)
-  (local $1 i32)
-  global.get $std/new/aClass
-  local.tee $1
-  if
-   local.get $1
-   local.get $0
-   call $~lib/rt/itcms/__visit
-  end
-  i32.const 224
-  local.get $0
-  call $~lib/rt/itcms/__visit
-  i32.const 32
-  local.get $0
-  call $~lib/rt/itcms/__visit
- )
  (func $~lib/arraybuffer/ArrayBufferView~visit (param $0 i32) (param $1 i32)
   (local $2 i32)
   local.get $0
@@ -2337,6 +2321,16 @@
    return
   end
   unreachable
+ )
+ (func $~lib/rt/__visit_globals (param $0 i32)
+  (local $1 i32)
+  global.get $std/new/aClass
+  local.tee $1
+  if
+   local.get $1
+   local.get $0
+   call $~lib/rt/itcms/__visit
+  end
  )
  (func $~start
   call $start:std/new

--- a/tests/compiler/std/new.release.wat
+++ b/tests/compiler/std/new.release.wat
@@ -42,10 +42,6 @@
    local.get $0
    call $~lib/rt/itcms/__visit
   end
-  i32.const 1248
-  call $~lib/rt/itcms/__visit
-  i32.const 1056
-  call $~lib/rt/itcms/__visit
   global.get $~lib/rt/itcms/pinSpace
   local.tee $1
   i32.load offset=4

--- a/tests/compiler/std/operator-overloading.debug.wat
+++ b/tests/compiler/std/operator-overloading.debug.wat
@@ -2722,6 +2722,55 @@
   local.get $this
   i32.load offset=4
  )
+ (func $~lib/arraybuffer/ArrayBufferView~visit (param $0 i32) (param $1 i32)
+  (local $2 i32)
+  local.get $0
+  local.get $1
+  call $~lib/object/Object~visit
+  local.get $0
+  i32.load
+  local.get $1
+  call $~lib/rt/itcms/__visit
+ )
+ (func $~lib/object/Object~visit (param $0 i32) (param $1 i32)
+ )
+ (func $~lib/rt/__visit_members (param $0 i32) (param $1 i32)
+  block $invalid
+   block $std/operator-overloading/TesterElementAccess
+    block $std/operator-overloading/TesterInlineInstance
+     block $std/operator-overloading/TesterInlineStatic
+      block $std/operator-overloading/Tester
+       block $~lib/arraybuffer/ArrayBufferView
+        block $~lib/string/String
+         block $~lib/arraybuffer/ArrayBuffer
+          block $~lib/object/Object
+           local.get $0
+           i32.const 8
+           i32.sub
+           i32.load
+           br_table $~lib/object/Object $~lib/arraybuffer/ArrayBuffer $~lib/string/String $~lib/arraybuffer/ArrayBufferView $std/operator-overloading/Tester $std/operator-overloading/TesterInlineStatic $std/operator-overloading/TesterInlineInstance $std/operator-overloading/TesterElementAccess $invalid
+          end
+          return
+         end
+         return
+        end
+        return
+       end
+       local.get $0
+       local.get $1
+       call $~lib/arraybuffer/ArrayBufferView~visit
+       return
+      end
+      return
+     end
+     return
+    end
+    return
+   end
+   return
+  end
+  unreachable
+ )
  (func $~lib/rt/__visit_globals (param $0 i32)
   (local $1 i32)
   global.get $std/operator-overloading/a1
@@ -3144,61 +3193,6 @@
    local.get $0
    call $~lib/rt/itcms/__visit
   end
-  i32.const 224
-  local.get $0
-  call $~lib/rt/itcms/__visit
-  i32.const 32
-  local.get $0
-  call $~lib/rt/itcms/__visit
- )
- (func $~lib/arraybuffer/ArrayBufferView~visit (param $0 i32) (param $1 i32)
-  (local $2 i32)
-  local.get $0
-  local.get $1
-  call $~lib/object/Object~visit
-  local.get $0
-  i32.load
-  local.get $1
-  call $~lib/rt/itcms/__visit
- )
- (func $~lib/object/Object~visit (param $0 i32) (param $1 i32)
- )
- (func $~lib/rt/__visit_members (param $0 i32) (param $1 i32)
-  block $invalid
-   block $std/operator-overloading/TesterElementAccess
-    block $std/operator-overloading/TesterInlineInstance
-     block $std/operator-overloading/TesterInlineStatic
-      block $std/operator-overloading/Tester
-       block $~lib/arraybuffer/ArrayBufferView
-        block $~lib/string/String
-         block $~lib/arraybuffer/ArrayBuffer
-          block $~lib/object/Object
-           local.get $0
-           i32.const 8
-           i32.sub
-           i32.load
-           br_table $~lib/object/Object $~lib/arraybuffer/ArrayBuffer $~lib/string/String $~lib/arraybuffer/ArrayBufferView $std/operator-overloading/Tester $std/operator-overloading/TesterInlineStatic $std/operator-overloading/TesterInlineInstance $std/operator-overloading/TesterElementAccess $invalid
-          end
-          return
-         end
-         return
-        end
-        return
-       end
-       local.get $0
-       local.get $1
-       call $~lib/arraybuffer/ArrayBufferView~visit
-       return
-      end
-      return
-     end
-     return
-    end
-    return
-   end
-   return
-  end
-  unreachable
  )
  (func $~start
   call $start:std/operator-overloading

--- a/tests/compiler/std/operator-overloading.release.wat
+++ b/tests/compiler/std/operator-overloading.release.wat
@@ -1621,6 +1621,43 @@
   end
   local.get $2
  )
+ (func $~lib/rt/__visit_members (param $0 i32)
+  block $invalid
+   block $std/operator-overloading/TesterElementAccess
+    block $std/operator-overloading/TesterInlineInstance
+     block $std/operator-overloading/TesterInlineStatic
+      block $std/operator-overloading/Tester
+       block $~lib/arraybuffer/ArrayBufferView
+        block $~lib/string/String
+         block $~lib/arraybuffer/ArrayBuffer
+          block $~lib/object/Object
+           local.get $0
+           i32.const 8
+           i32.sub
+           i32.load
+           br_table $~lib/object/Object $~lib/arraybuffer/ArrayBuffer $~lib/string/String $~lib/arraybuffer/ArrayBufferView $std/operator-overloading/Tester $std/operator-overloading/TesterInlineStatic $std/operator-overloading/TesterInlineInstance $std/operator-overloading/TesterElementAccess $invalid
+          end
+          return
+         end
+         return
+        end
+        return
+       end
+       local.get $0
+       i32.load
+       call $~lib/rt/itcms/__visit
+       return
+      end
+      return
+     end
+     return
+    end
+    return
+   end
+   return
+  end
+  unreachable
+ )
  (func $~lib/rt/__visit_globals
   (local $0 i32)
   global.get $std/operator-overloading/a1
@@ -1983,47 +2020,6 @@
    local.get $0
    call $~lib/rt/itcms/__visit
   end
-  i32.const 1248
-  call $~lib/rt/itcms/__visit
-  i32.const 1056
-  call $~lib/rt/itcms/__visit
- )
- (func $~lib/rt/__visit_members (param $0 i32)
-  block $invalid
-   block $std/operator-overloading/TesterElementAccess
-    block $std/operator-overloading/TesterInlineInstance
-     block $std/operator-overloading/TesterInlineStatic
-      block $std/operator-overloading/Tester
-       block $~lib/arraybuffer/ArrayBufferView
-        block $~lib/string/String
-         block $~lib/arraybuffer/ArrayBuffer
-          block $~lib/object/Object
-           local.get $0
-           i32.const 8
-           i32.sub
-           i32.load
-           br_table $~lib/object/Object $~lib/arraybuffer/ArrayBuffer $~lib/string/String $~lib/arraybuffer/ArrayBufferView $std/operator-overloading/Tester $std/operator-overloading/TesterInlineStatic $std/operator-overloading/TesterInlineInstance $std/operator-overloading/TesterElementAccess $invalid
-          end
-          return
-         end
-         return
-        end
-        return
-       end
-       local.get $0
-       i32.load
-       call $~lib/rt/itcms/__visit
-       return
-      end
-      return
-     end
-     return
-    end
-    return
-   end
-   return
-  end
-  unreachable
  )
  (func $~start
   call $start:std/operator-overloading

--- a/tests/compiler/std/set.debug.wat
+++ b/tests/compiler/std/set.debug.wat
@@ -4329,18 +4329,6 @@
   call $std/set/testNumeric<f64>
   call $~lib/rt/itcms/__collect
  )
- (func $~lib/rt/__visit_globals (param $0 i32)
-  (local $1 i32)
-  i32.const 224
-  local.get $0
-  call $~lib/rt/itcms/__visit
-  i32.const 432
-  local.get $0
-  call $~lib/rt/itcms/__visit
-  i32.const 32
-  local.get $0
-  call $~lib/rt/itcms/__visit
- )
  (func $~lib/arraybuffer/ArrayBufferView~visit (param $0 i32) (param $1 i32)
   (local $2 i32)
   local.get $0
@@ -4697,6 +4685,9 @@
    return
   end
   unreachable
+ )
+ (func $~lib/rt/__visit_globals (param $0 i32)
+  (local $1 i32)
  )
  (func $~start
   call $start:std/set

--- a/tests/compiler/std/set.release.wat
+++ b/tests/compiler/std/set.release.wat
@@ -58,12 +58,6 @@
  (func $~lib/rt/itcms/visitRoots
   (local $0 i32)
   (local $1 i32)
-  i32.const 1248
-  call $~lib/rt/itcms/__visit
-  i32.const 1456
-  call $~lib/rt/itcms/__visit
-  i32.const 1056
-  call $~lib/rt/itcms/__visit
   global.get $~lib/rt/itcms/pinSpace
   local.tee $1
   i32.load offset=4

--- a/tests/compiler/std/static-array.debug.wat
+++ b/tests/compiler/std/static-array.debug.wat
@@ -2441,46 +2441,6 @@
   local.get $length_
   i32.store offset=12
  )
- (func $~lib/rt/__visit_globals (param $0 i32)
-  (local $1 i32)
-  global.get $std/static-array/i
-  local.tee $1
-  if
-   local.get $1
-   local.get $0
-   call $~lib/rt/itcms/__visit
-  end
-  global.get $std/static-array/I
-  local.tee $1
-  if
-   local.get $1
-   local.get $0
-   call $~lib/rt/itcms/__visit
-  end
-  global.get $std/static-array/f
-  local.tee $1
-  if
-   local.get $1
-   local.get $0
-   call $~lib/rt/itcms/__visit
-  end
-  global.get $std/static-array/F
-  local.tee $1
-  if
-   local.get $1
-   local.get $0
-   call $~lib/rt/itcms/__visit
-  end
-  i32.const 448
-  local.get $0
-  call $~lib/rt/itcms/__visit
-  i32.const 560
-  local.get $0
-  call $~lib/rt/itcms/__visit
-  i32.const 608
-  local.get $0
-  call $~lib/rt/itcms/__visit
- )
  (func $~lib/arraybuffer/ArrayBufferView~visit (param $0 i32) (param $1 i32)
   (local $2 i32)
   local.get $0
@@ -2589,6 +2549,37 @@
    return
   end
   unreachable
+ )
+ (func $~lib/rt/__visit_globals (param $0 i32)
+  (local $1 i32)
+  global.get $std/static-array/i
+  local.tee $1
+  if
+   local.get $1
+   local.get $0
+   call $~lib/rt/itcms/__visit
+  end
+  global.get $std/static-array/I
+  local.tee $1
+  if
+   local.get $1
+   local.get $0
+   call $~lib/rt/itcms/__visit
+  end
+  global.get $std/static-array/f
+  local.tee $1
+  if
+   local.get $1
+   local.get $0
+   call $~lib/rt/itcms/__visit
+  end
+  global.get $std/static-array/F
+  local.tee $1
+  if
+   local.get $1
+   local.get $0
+   call $~lib/rt/itcms/__visit
+  end
  )
  (func $~start
   call $start:std/static-array

--- a/tests/compiler/std/static-array.release.wat
+++ b/tests/compiler/std/static-array.release.wat
@@ -70,12 +70,6 @@
   call $~lib/rt/itcms/__visit
   i32.const 1360
   call $~lib/rt/itcms/__visit
-  i32.const 1472
-  call $~lib/rt/itcms/__visit
-  i32.const 1584
-  call $~lib/rt/itcms/__visit
-  i32.const 1632
-  call $~lib/rt/itcms/__visit
   global.get $~lib/rt/itcms/pinSpace
   local.tee $1
   i32.load offset=4

--- a/tests/compiler/std/staticarray.debug.wat
+++ b/tests/compiler/std/staticarray.debug.wat
@@ -3512,49 +3512,6 @@
   i32.const 0
   drop
  )
- (func $~lib/rt/__visit_globals (param $0 i32)
-  (local $1 i32)
-  global.get $std/staticarray/arr1
-  local.tee $1
-  if
-   local.get $1
-   local.get $0
-   call $~lib/rt/itcms/__visit
-  end
-  global.get $std/staticarray/arr2
-  local.tee $1
-  if
-   local.get $1
-   local.get $0
-   call $~lib/rt/itcms/__visit
-  end
-  global.get $std/staticarray/arr3
-  local.tee $1
-  if
-   local.get $1
-   local.get $0
-   call $~lib/rt/itcms/__visit
-  end
-  global.get $std/staticarray/arr4
-  local.tee $1
-  if
-   local.get $1
-   local.get $0
-   call $~lib/rt/itcms/__visit
-  end
-  i32.const 64
-  local.get $0
-  call $~lib/rt/itcms/__visit
-  i32.const 656
-  local.get $0
-  call $~lib/rt/itcms/__visit
-  i32.const 1312
-  local.get $0
-  call $~lib/rt/itcms/__visit
-  i32.const 320
-  local.get $0
-  call $~lib/rt/itcms/__visit
- )
  (func $~lib/arraybuffer/ArrayBufferView~visit (param $0 i32) (param $1 i32)
   (local $2 i32)
   local.get $0
@@ -3831,6 +3788,16 @@
    return
   end
   unreachable
+ )
+ (func $~lib/rt/__visit_globals (param $0 i32)
+  (local $1 i32)
+  global.get $std/staticarray/arr4
+  local.tee $1
+  if
+   local.get $1
+   local.get $0
+   call $~lib/staticarray/StaticArray<std/staticarray/Ref>~visit
+  end
  )
  (func $~start
   call $start:std/staticarray

--- a/tests/compiler/std/staticarray.release.wat
+++ b/tests/compiler/std/staticarray.release.wat
@@ -175,30 +175,12 @@
  (func $~lib/rt/itcms/visitRoots
   (local $0 i32)
   (local $1 i32)
-  i32.const 1056
-  call $~lib/rt/itcms/__visit
-  i32.const 1280
-  call $~lib/rt/itcms/__visit
-  global.get $std/staticarray/arr3
-  local.tee $0
-  if
-   local.get $0
-   call $~lib/rt/itcms/__visit
-  end
   global.get $std/staticarray/arr4
   local.tee $0
   if
    local.get $0
-   call $~lib/rt/itcms/__visit
+   call $~lib/staticarray/StaticArray<std/staticarray/Ref>#__visit
   end
-  i32.const 1088
-  call $~lib/rt/itcms/__visit
-  i32.const 1680
-  call $~lib/rt/itcms/__visit
-  i32.const 2336
-  call $~lib/rt/itcms/__visit
-  i32.const 1344
-  call $~lib/rt/itcms/__visit
   global.get $~lib/rt/itcms/pinSpace
   local.tee $1
   i32.load offset=4
@@ -260,7 +242,7 @@
    local.get $1
    global.set $~lib/rt/itcms/iter
   end
-  block $__inlined_func$~lib/rt/itcms/Object#unlink$267
+  block $__inlined_func$~lib/rt/itcms/Object#unlink$269
    local.get $0
    i32.load offset=4
    i32.const -4
@@ -284,7 +266,7 @@
      call $~lib/builtins/abort
      unreachable
     end
-    br $__inlined_func$~lib/rt/itcms/Object#unlink$267
+    br $__inlined_func$~lib/rt/itcms/Object#unlink$269
    end
    local.get $0
    i32.load offset=8
@@ -2220,7 +2202,7 @@
   local.get $1
   i32.sub
  )
- (func $~lib/staticarray/StaticArray<std/staticarray/Ref>~visit (param $0 i32)
+ (func $~lib/staticarray/StaticArray<std/staticarray/Ref>#__visit (param $0 i32)
   (local $1 i32)
   (local $2 i32)
   local.get $0
@@ -2292,7 +2274,7 @@
             return
            end
            local.get $0
-           call $~lib/staticarray/StaticArray<std/staticarray/Ref>~visit
+           call $~lib/staticarray/StaticArray<std/staticarray/Ref>#__visit
            return
           end
           global.get $~lib/memory/__stack_pointer
@@ -2309,7 +2291,7 @@
           br $folding-inner1
          end
          local.get $0
-         call $~lib/staticarray/StaticArray<std/staticarray/Ref>~visit
+         call $~lib/staticarray/StaticArray<std/staticarray/Ref>#__visit
          return
         end
         global.get $~lib/memory/__stack_pointer
@@ -3376,7 +3358,7 @@
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store
-   block $__inlined_func$~lib/staticarray/StaticArray<~lib/string/String>#indexOf$274
+   block $__inlined_func$~lib/staticarray/StaticArray<~lib/string/String>#indexOf$276
     local.get $0
     i32.const 20
     i32.sub
@@ -3396,7 +3378,7 @@
      global.set $~lib/memory/__stack_pointer
      i32.const -1
      local.set $2
-     br $__inlined_func$~lib/staticarray/StaticArray<~lib/string/String>#indexOf$274
+     br $__inlined_func$~lib/staticarray/StaticArray<~lib/string/String>#indexOf$276
     end
     local.get $2
     i32.const 0
@@ -3438,7 +3420,7 @@
        i32.const 8
        i32.add
        global.set $~lib/memory/__stack_pointer
-       br $__inlined_func$~lib/staticarray/StaticArray<~lib/string/String>#indexOf$274
+       br $__inlined_func$~lib/staticarray/StaticArray<~lib/string/String>#indexOf$276
       end
       local.get $2
       i32.const 1
@@ -4088,7 +4070,7 @@
        global.get $~lib/memory/__stack_pointer
        local.get $10
        i32.store
-       block $__inlined_func$~lib/rt/itcms/__renew$224
+       block $__inlined_func$~lib/rt/itcms/__renew$226
         i32.const 1073741820
         local.get $1
         i32.const 1
@@ -4131,7 +4113,7 @@
          i32.store offset=16
          local.get $1
          local.set $2
-         br $__inlined_func$~lib/rt/itcms/__renew$224
+         br $__inlined_func$~lib/rt/itcms/__renew$226
         end
         local.get $4
         local.get $3
@@ -6324,7 +6306,7 @@
     call $~lib/builtins/abort
     unreachable
    end
-   block $__inlined_func$~lib/staticarray/StaticArray<f64>#includes$276 (result i32)
+   block $__inlined_func$~lib/staticarray/StaticArray<f64>#includes$278 (result i32)
     i32.const 8
     i32.const 10
     call $~lib/rt/itcms/__new
@@ -6365,7 +6347,7 @@
      i32.add
      global.set $~lib/memory/__stack_pointer
      i32.const 0
-     br $__inlined_func$~lib/staticarray/StaticArray<f64>#includes$276
+     br $__inlined_func$~lib/staticarray/StaticArray<f64>#includes$278
     end
     loop $while-continue|0
      local.get $1
@@ -6387,7 +6369,7 @@
        i32.add
        global.set $~lib/memory/__stack_pointer
        i32.const 1
-       br $__inlined_func$~lib/staticarray/StaticArray<f64>#includes$276
+       br $__inlined_func$~lib/staticarray/StaticArray<f64>#includes$278
       end
       local.get $1
       i32.const 1
@@ -6411,7 +6393,7 @@
     call $~lib/builtins/abort
     unreachable
    end
-   block $__inlined_func$~lib/staticarray/StaticArray<f32>#includes$277 (result i32)
+   block $__inlined_func$~lib/staticarray/StaticArray<f32>#includes$279 (result i32)
     i32.const 4
     i32.const 11
     call $~lib/rt/itcms/__new
@@ -6452,7 +6434,7 @@
      i32.add
      global.set $~lib/memory/__stack_pointer
      i32.const 0
-     br $__inlined_func$~lib/staticarray/StaticArray<f32>#includes$277
+     br $__inlined_func$~lib/staticarray/StaticArray<f32>#includes$279
     end
     loop $while-continue|030
      local.get $1
@@ -6474,7 +6456,7 @@
        i32.add
        global.set $~lib/memory/__stack_pointer
        i32.const 1
-       br $__inlined_func$~lib/staticarray/StaticArray<f32>#includes$277
+       br $__inlined_func$~lib/staticarray/StaticArray<f32>#includes$279
       end
       local.get $1
       i32.const 1

--- a/tests/compiler/std/string-casemapping.debug.wat
+++ b/tests/compiler/std/string-casemapping.debug.wat
@@ -3408,28 +3408,6 @@
   call $~lib/util/number/itoa64
   return
  )
- (func $~lib/rt/__visit_globals (param $0 i32)
-  (local $1 i32)
-  i32.const 256
-  local.get $0
-  call $~lib/rt/itcms/__visit
-  i32.const 64
-  local.get $0
-  call $~lib/rt/itcms/__visit
-  i32.const 18608
-  local.get $0
-  call $~lib/rt/itcms/__visit
-  i32.const 19664
-  local.get $0
-  call $~lib/rt/itcms/__visit
-  global.get $~lib/util/casemap/SPECIALS_UPPER
-  local.tee $1
-  if
-   local.get $1
-   local.get $0
-   call $~lib/rt/itcms/__visit
-  end
- )
  (func $~lib/arraybuffer/ArrayBufferView~visit (param $0 i32) (param $1 i32)
   (local $2 i32)
   local.get $0
@@ -3469,6 +3447,9 @@
    return
   end
   unreachable
+ )
+ (func $~lib/rt/__visit_globals (param $0 i32)
+  (local $1 i32)
  )
  (func $~start
   call $start:std/string-casemapping

--- a/tests/compiler/std/string-casemapping.release.wat
+++ b/tests/compiler/std/string-casemapping.release.wat
@@ -485,16 +485,6 @@
  (func $~lib/rt/itcms/visitRoots
   (local $0 i32)
   (local $1 i32)
-  i32.const 1280
-  call $~lib/rt/itcms/__visit
-  i32.const 1088
-  call $~lib/rt/itcms/__visit
-  i32.const 19632
-  call $~lib/rt/itcms/__visit
-  i32.const 20688
-  call $~lib/rt/itcms/__visit
-  i32.const 1488
-  call $~lib/rt/itcms/__visit
   global.get $~lib/rt/itcms/pinSpace
   local.tee $1
   i32.load offset=4

--- a/tests/compiler/std/string-encoding.debug.wat
+++ b/tests/compiler/std/string-encoding.debug.wat
@@ -2859,25 +2859,6 @@
   i32.const 0
   drop
  )
- (func $~lib/rt/__visit_globals (param $0 i32)
-  (local $1 i32)
-  global.get $std/string-encoding/str
-  local.tee $1
-  if
-   local.get $1
-   local.get $0
-   call $~lib/rt/itcms/__visit
-  end
-  i32.const 320
-  local.get $0
-  call $~lib/rt/itcms/__visit
-  i32.const 128
-  local.get $0
-  call $~lib/rt/itcms/__visit
-  i32.const 688
-  local.get $0
-  call $~lib/rt/itcms/__visit
- )
  (func $~lib/arraybuffer/ArrayBufferView~visit (param $0 i32) (param $1 i32)
   (local $2 i32)
   local.get $0
@@ -2914,6 +2895,9 @@
    return
   end
   unreachable
+ )
+ (func $~lib/rt/__visit_globals (param $0 i32)
+  (local $1 i32)
  )
  (func $~start
   call $start:std/string-encoding

--- a/tests/compiler/std/string-encoding.release.wat
+++ b/tests/compiler/std/string-encoding.release.wat
@@ -74,14 +74,6 @@
  (func $~lib/rt/itcms/visitRoots
   (local $0 i32)
   (local $1 i32)
-  i32.const 1056
-  call $~lib/rt/itcms/__visit
-  i32.const 1344
-  call $~lib/rt/itcms/__visit
-  i32.const 1152
-  call $~lib/rt/itcms/__visit
-  i32.const 1712
-  call $~lib/rt/itcms/__visit
   global.get $~lib/rt/itcms/pinSpace
   local.tee $1
   i32.load offset=4

--- a/tests/compiler/std/string.debug.wat
+++ b/tests/compiler/std/string.debug.wat
@@ -5512,41 +5512,6 @@
   global.get $std/string/str
   return
  )
- (func $~lib/rt/__visit_globals (param $0 i32)
-  (local $1 i32)
-  global.get $std/string/str
-  local.tee $1
-  if
-   local.get $1
-   local.get $0
-   call $~lib/rt/itcms/__visit
-  end
-  global.get $std/string/nullStr
-  local.tee $1
-  if
-   local.get $1
-   local.get $0
-   call $~lib/rt/itcms/__visit
-  end
-  i32.const 240
-  local.get $0
-  call $~lib/rt/itcms/__visit
-  i32.const 13040
-  local.get $0
-  call $~lib/rt/itcms/__visit
-  i32.const 14688
-  local.get $0
-  call $~lib/rt/itcms/__visit
-  i32.const 352
-  local.get $0
-  call $~lib/rt/itcms/__visit
-  i32.const 15616
-  local.get $0
-  call $~lib/rt/itcms/__visit
-  i32.const 16672
-  local.get $0
-  call $~lib/rt/itcms/__visit
- )
  (func $~lib/arraybuffer/ArrayBufferView~visit (param $0 i32) (param $1 i32)
   (local $2 i32)
   local.get $0
@@ -5619,6 +5584,9 @@
    return
   end
   unreachable
+ )
+ (func $~lib/rt/__visit_globals (param $0 i32)
+  (local $1 i32)
  )
  (func $~start
   call $start:std/string

--- a/tests/compiler/std/string.release.wat
+++ b/tests/compiler/std/string.release.wat
@@ -1070,24 +1070,6 @@
  (func $~lib/rt/itcms/visitRoots
   (local $0 i32)
   (local $1 i32)
-  global.get $std/string/str
-  local.tee $0
-  if
-   local.get $0
-   call $~lib/rt/itcms/__visit
-  end
-  i32.const 1264
-  call $~lib/rt/itcms/__visit
-  i32.const 14064
-  call $~lib/rt/itcms/__visit
-  i32.const 15712
-  call $~lib/rt/itcms/__visit
-  i32.const 1376
-  call $~lib/rt/itcms/__visit
-  i32.const 16640
-  call $~lib/rt/itcms/__visit
-  i32.const 17696
-  call $~lib/rt/itcms/__visit
   global.get $~lib/rt/itcms/pinSpace
   local.tee $1
   i32.load offset=4

--- a/tests/compiler/std/symbol.debug.wat
+++ b/tests/compiler/std/symbol.debug.wat
@@ -2735,63 +2735,6 @@
   local.get $taggedNext
   i32.store offset=8
  )
- (func $~lib/rt/__visit_globals (param $0 i32)
-  (local $1 i32)
-  global.get $~lib/symbol/stringToId
-  local.tee $1
-  if
-   local.get $1
-   local.get $0
-   call $~lib/rt/itcms/__visit
-  end
-  global.get $~lib/symbol/idToString
-  local.tee $1
-  if
-   local.get $1
-   local.get $0
-   call $~lib/rt/itcms/__visit
-  end
-  global.get $std/symbol/key1
-  local.tee $1
-  if
-   local.get $1
-   local.get $0
-   call $~lib/rt/itcms/__visit
-  end
-  global.get $std/symbol/key2
-  local.tee $1
-  if
-   local.get $1
-   local.get $0
-   call $~lib/rt/itcms/__visit
-  end
-  global.get $std/symbol/key3
-  local.tee $1
-  if
-   local.get $1
-   local.get $0
-   call $~lib/rt/itcms/__visit
-  end
-  global.get $std/symbol/key4
-  local.tee $1
-  if
-   local.get $1
-   local.get $0
-   call $~lib/rt/itcms/__visit
-  end
-  i32.const 304
-  local.get $0
-  call $~lib/rt/itcms/__visit
-  i32.const 512
-  local.get $0
-  call $~lib/rt/itcms/__visit
-  i32.const 624
-  local.get $0
-  call $~lib/rt/itcms/__visit
-  i32.const 112
-  local.get $0
-  call $~lib/rt/itcms/__visit
- )
  (func $~lib/arraybuffer/ArrayBufferView~visit (param $0 i32) (param $1 i32)
   (local $2 i32)
   local.get $0
@@ -2856,6 +2799,23 @@
    return
   end
   unreachable
+ )
+ (func $~lib/rt/__visit_globals (param $0 i32)
+  (local $1 i32)
+  global.get $~lib/symbol/stringToId
+  local.tee $1
+  if
+   local.get $1
+   local.get $0
+   call $~lib/rt/itcms/__visit
+  end
+  global.get $~lib/symbol/idToString
+  local.tee $1
+  if
+   local.get $1
+   local.get $0
+   call $~lib/rt/itcms/__visit
+  end
  )
  (func $~start
   global.get $~started

--- a/tests/compiler/std/symbol.release.wat
+++ b/tests/compiler/std/symbol.release.wat
@@ -113,38 +113,6 @@
    local.get $0
    call $~lib/rt/itcms/__visit
   end
-  global.get $std/symbol/key1
-  local.tee $0
-  if
-   local.get $0
-   call $~lib/rt/itcms/__visit
-  end
-  global.get $std/symbol/key2
-  local.tee $0
-  if
-   local.get $0
-   call $~lib/rt/itcms/__visit
-  end
-  global.get $std/symbol/key3
-  local.tee $0
-  if
-   local.get $0
-   call $~lib/rt/itcms/__visit
-  end
-  global.get $std/symbol/key4
-  local.tee $0
-  if
-   local.get $0
-   call $~lib/rt/itcms/__visit
-  end
-  i32.const 1328
-  call $~lib/rt/itcms/__visit
-  i32.const 1536
-  call $~lib/rt/itcms/__visit
-  i32.const 1648
-  call $~lib/rt/itcms/__visit
-  i32.const 1136
-  call $~lib/rt/itcms/__visit
   global.get $~lib/rt/itcms/pinSpace
   local.tee $1
   i32.load offset=4

--- a/tests/compiler/std/typedarray.debug.wat
+++ b/tests/compiler/std/typedarray.debug.wat
@@ -13081,80 +13081,6 @@
   i32.const 0
   drop
  )
- (func $~lib/rt/__visit_globals (param $0 i32)
-  (local $1 i32)
-  global.get $std/typedarray/forEachValues
-  local.tee $1
-  if
-   local.get $1
-   local.get $0
-   call $~lib/rt/itcms/__visit
-  end
-  global.get $std/typedarray/testArrayReverseValues
-  local.tee $1
-  if
-   local.get $1
-   local.get $0
-   call $~lib/rt/itcms/__visit
-  end
-  global.get $std/typedarray/testArrayIndexOfAndLastIndexOfValues
-  local.tee $1
-  if
-   local.get $1
-   local.get $0
-   call $~lib/rt/itcms/__visit
-  end
-  global.get $std/typedarray/testArrayWrapValues
-  local.tee $1
-  if
-   local.get $1
-   local.get $0
-   call $~lib/rt/itcms/__visit
-  end
-  global.get $std/typedarray/setSource1
-  local.tee $1
-  if
-   local.get $1
-   local.get $0
-   call $~lib/rt/itcms/__visit
-  end
-  global.get $std/typedarray/setSource2
-  local.tee $1
-  if
-   local.get $1
-   local.get $0
-   call $~lib/rt/itcms/__visit
-  end
-  global.get $std/typedarray/setSource3
-  local.tee $1
-  if
-   local.get $1
-   local.get $0
-   call $~lib/rt/itcms/__visit
-  end
-  global.get $std/typedarray/setSource7
-  local.tee $1
-  if
-   local.get $1
-   local.get $0
-   call $~lib/rt/itcms/__visit
-  end
-  i32.const 336
-  local.get $0
-  call $~lib/rt/itcms/__visit
-  i32.const 32
-  local.get $0
-  call $~lib/rt/itcms/__visit
-  i32.const 144
-  local.get $0
-  call $~lib/rt/itcms/__visit
-  i32.const 7408
-  local.get $0
-  call $~lib/rt/itcms/__visit
-  i32.const 8464
-  local.get $0
-  call $~lib/rt/itcms/__visit
- )
  (func $~lib/arraybuffer/ArrayBufferView~visit (param $0 i32) (param $1 i32)
   (local $2 i32)
   local.get $0
@@ -14464,6 +14390,65 @@
    return
   end
   unreachable
+ )
+ (func $~lib/rt/__visit_globals (param $0 i32)
+  (local $1 i32)
+  global.get $std/typedarray/forEachValues
+  local.tee $1
+  if
+   local.get $1
+   local.get $0
+   call $~lib/rt/itcms/__visit
+  end
+  global.get $std/typedarray/testArrayReverseValues
+  local.tee $1
+  if
+   local.get $1
+   local.get $0
+   call $~lib/rt/itcms/__visit
+  end
+  global.get $std/typedarray/testArrayIndexOfAndLastIndexOfValues
+  local.tee $1
+  if
+   local.get $1
+   local.get $0
+   call $~lib/rt/itcms/__visit
+  end
+  global.get $std/typedarray/testArrayWrapValues
+  local.tee $1
+  if
+   local.get $1
+   local.get $0
+   call $~lib/rt/itcms/__visit
+  end
+  global.get $std/typedarray/setSource1
+  local.tee $1
+  if
+   local.get $1
+   local.get $0
+   call $~lib/rt/itcms/__visit
+  end
+  global.get $std/typedarray/setSource2
+  local.tee $1
+  if
+   local.get $1
+   local.get $0
+   call $~lib/rt/itcms/__visit
+  end
+  global.get $std/typedarray/setSource3
+  local.tee $1
+  if
+   local.get $1
+   local.get $0
+   call $~lib/rt/itcms/__visit
+  end
+  global.get $std/typedarray/setSource7
+  local.tee $1
+  if
+   local.get $1
+   local.get $0
+   call $~lib/rt/itcms/__visit
+  end
  )
  (func $~start
   call $start:std/typedarray

--- a/tests/compiler/std/typedarray.release.wat
+++ b/tests/compiler/std/typedarray.release.wat
@@ -695,16 +695,6 @@
   call $~lib/rt/itcms/__visit
   i32.const 11264
   call $~lib/rt/itcms/__visit
-  i32.const 1360
-  call $~lib/rt/itcms/__visit
-  i32.const 1056
-  call $~lib/rt/itcms/__visit
-  i32.const 1168
-  call $~lib/rt/itcms/__visit
-  i32.const 8432
-  call $~lib/rt/itcms/__visit
-  i32.const 9488
-  call $~lib/rt/itcms/__visit
   global.get $~lib/rt/itcms/pinSpace
   local.tee $1
   i32.load offset=4

--- a/tests/compiler/std/uri.debug.wat
+++ b/tests/compiler/std/uri.debug.wat
@@ -3403,18 +3403,6 @@
   i32.const 0
   drop
  )
- (func $~lib/rt/__visit_globals (param $0 i32)
-  (local $1 i32)
-  i32.const 352
-  local.get $0
-  call $~lib/rt/itcms/__visit
-  i32.const 160
-  local.get $0
-  call $~lib/rt/itcms/__visit
-  i32.const 560
-  local.get $0
-  call $~lib/rt/itcms/__visit
- )
  (func $~lib/arraybuffer/ArrayBufferView~visit (param $0 i32) (param $1 i32)
   (local $2 i32)
   local.get $0
@@ -3451,6 +3439,9 @@
    return
   end
   unreachable
+ )
+ (func $~lib/rt/__visit_globals (param $0 i32)
+  (local $1 i32)
  )
  (func $~start
   call $start:std/uri

--- a/tests/compiler/std/uri.release.wat
+++ b/tests/compiler/std/uri.release.wat
@@ -156,12 +156,6 @@
  (func $~lib/rt/itcms/visitRoots
   (local $0 i32)
   (local $1 i32)
-  i32.const 1376
-  call $~lib/rt/itcms/__visit
-  i32.const 1184
-  call $~lib/rt/itcms/__visit
-  i32.const 1584
-  call $~lib/rt/itcms/__visit
   global.get $~lib/rt/itcms/pinSpace
   local.tee $1
   i32.load offset=4

--- a/tests/compiler/super-inline.debug.wat
+++ b/tests/compiler/super-inline.debug.wat
@@ -2269,29 +2269,6 @@
   local.get $0
   call $super-inline/Foo#a
  )
- (func $~lib/rt/__visit_globals (param $0 i32)
-  (local $1 i32)
-  global.get $super-inline/foo
-  local.tee $1
-  if
-   local.get $1
-   local.get $0
-   call $~lib/rt/itcms/__visit
-  end
-  global.get $super-inline/bar
-  local.tee $1
-  if
-   local.get $1
-   local.get $0
-   call $~lib/rt/itcms/__visit
-  end
-  i32.const 224
-  local.get $0
-  call $~lib/rt/itcms/__visit
-  i32.const 32
-  local.get $0
-  call $~lib/rt/itcms/__visit
- )
  (func $~lib/arraybuffer/ArrayBufferView~visit (param $0 i32) (param $1 i32)
   (local $2 i32)
   local.get $0
@@ -2334,6 +2311,23 @@
    return
   end
   unreachable
+ )
+ (func $~lib/rt/__visit_globals (param $0 i32)
+  (local $1 i32)
+  global.get $super-inline/foo
+  local.tee $1
+  if
+   local.get $1
+   local.get $0
+   call $~lib/rt/itcms/__visit
+  end
+  global.get $super-inline/bar
+  local.tee $1
+  if
+   local.get $1
+   local.get $0
+   call $~lib/rt/itcms/__visit
+  end
  )
  (func $~start
   call $start:super-inline

--- a/tests/compiler/super-inline.release.wat
+++ b/tests/compiler/super-inline.release.wat
@@ -49,10 +49,6 @@
    local.get $0
    call $~lib/rt/itcms/__visit
   end
-  i32.const 1248
-  call $~lib/rt/itcms/__visit
-  i32.const 1056
-  call $~lib/rt/itcms/__visit
   global.get $~lib/rt/itcms/pinSpace
   local.tee $1
   i32.load offset=4

--- a/tests/compiler/switch.debug.wat
+++ b/tests/compiler/switch.debug.wat
@@ -2803,29 +2803,6 @@
   local.get $value
   i32.store
  )
- (func $~lib/rt/__visit_globals (param $0 i32)
-  (local $1 i32)
-  global.get $switch/foo1
-  local.tee $1
-  if
-   local.get $1
-   local.get $0
-   call $~lib/rt/itcms/__visit
-  end
-  global.get $switch/foo2
-  local.tee $1
-  if
-   local.get $1
-   local.get $0
-   call $~lib/rt/itcms/__visit
-  end
-  i32.const 496
-  local.get $0
-  call $~lib/rt/itcms/__visit
-  i32.const 304
-  local.get $0
-  call $~lib/rt/itcms/__visit
- )
  (func $~lib/arraybuffer/ArrayBufferView~visit (param $0 i32) (param $1 i32)
   (local $2 i32)
   local.get $0
@@ -2868,6 +2845,23 @@
    return
   end
   unreachable
+ )
+ (func $~lib/rt/__visit_globals (param $0 i32)
+  (local $1 i32)
+  global.get $switch/foo1
+  local.tee $1
+  if
+   local.get $1
+   local.get $0
+   call $~lib/rt/itcms/__visit
+  end
+  global.get $switch/foo2
+  local.tee $1
+  if
+   local.get $1
+   local.get $0
+   call $~lib/rt/itcms/__visit
+  end
  )
  (func $~start
   call $start:switch

--- a/tests/compiler/switch.release.wat
+++ b/tests/compiler/switch.release.wat
@@ -80,10 +80,6 @@
    local.get $0
    call $~lib/rt/itcms/__visit
   end
-  i32.const 1520
-  call $~lib/rt/itcms/__visit
-  i32.const 1328
-  call $~lib/rt/itcms/__visit
   global.get $~lib/rt/itcms/pinSpace
   local.tee $1
   i32.load offset=4

--- a/tests/compiler/templateliteral.debug.wat
+++ b/tests/compiler/templateliteral.debug.wat
@@ -4373,21 +4373,6 @@
   call $templateliteral/test_null
   call $templateliteral/test_recursive
  )
- (func $~lib/rt/__visit_globals (param $0 i32)
-  (local $1 i32)
-  i32.const 384
-  local.get $0
-  call $~lib/rt/itcms/__visit
-  i32.const 192
-  local.get $0
-  call $~lib/rt/itcms/__visit
-  i32.const 1440
-  local.get $0
-  call $~lib/rt/itcms/__visit
-  i32.const 2496
-  local.get $0
-  call $~lib/rt/itcms/__visit
- )
  (func $~lib/arraybuffer/ArrayBufferView~visit (param $0 i32) (param $1 i32)
   (local $2 i32)
   local.get $0
@@ -4498,6 +4483,9 @@
    return
   end
   unreachable
+ )
+ (func $~lib/rt/__visit_globals (param $0 i32)
+  (local $1 i32)
  )
  (func $~start
   global.get $~started

--- a/tests/compiler/templateliteral.release.wat
+++ b/tests/compiler/templateliteral.release.wat
@@ -143,14 +143,6 @@
  (func $~lib/rt/itcms/visitRoots
   (local $0 i32)
   (local $1 i32)
-  i32.const 1408
-  call $~lib/rt/itcms/__visit
-  i32.const 1216
-  call $~lib/rt/itcms/__visit
-  i32.const 2464
-  call $~lib/rt/itcms/__visit
-  i32.const 3520
-  call $~lib/rt/itcms/__visit
   global.get $~lib/rt/itcms/pinSpace
   local.tee $1
   i32.load offset=4

--- a/tests/compiler/throw.debug.wat
+++ b/tests/compiler/throw.debug.wat
@@ -1802,12 +1802,6 @@
   call $~lib/builtins/abort
   unreachable
  )
- (func $~lib/rt/__visit_globals (param $0 i32)
-  (local $1 i32)
-  i32.const 464
-  local.get $0
-  call $~lib/rt/itcms/__visit
- )
  (func $~lib/arraybuffer/ArrayBufferView~visit (param $0 i32) (param $1 i32)
   (local $2 i32)
   local.get $0
@@ -1844,6 +1838,9 @@
    return
   end
   unreachable
+ )
+ (func $~lib/rt/__visit_globals (param $0 i32)
+  (local $1 i32)
  )
  (func $~start
   call $start:throw

--- a/tests/compiler/throw.release.wat
+++ b/tests/compiler/throw.release.wat
@@ -48,8 +48,6 @@
  (func $~lib/rt/itcms/visitRoots
   (local $0 i32)
   (local $1 i32)
-  i32.const 1488
-  call $~lib/rt/itcms/__visit
   global.get $~lib/rt/itcms/pinSpace
   local.tee $1
   i32.load offset=4

--- a/tests/compiler/typeof.debug.wat
+++ b/tests/compiler/typeof.debug.wat
@@ -2381,29 +2381,6 @@
   local.get $ptr
   return
  )
- (func $~lib/rt/__visit_globals (param $0 i32)
-  (local $1 i32)
-  global.get $typeof/s
-  local.tee $1
-  if
-   local.get $1
-   local.get $0
-   call $~lib/rt/itcms/__visit
-  end
-  global.get $typeof/c
-  local.tee $1
-  if
-   local.get $1
-   local.get $0
-   call $~lib/rt/itcms/__visit
-  end
-  i32.const 528
-  local.get $0
-  call $~lib/rt/itcms/__visit
-  i32.const 336
-  local.get $0
-  call $~lib/rt/itcms/__visit
- )
  (func $~lib/arraybuffer/ArrayBufferView~visit (param $0 i32) (param $1 i32)
   (local $2 i32)
   local.get $0
@@ -2461,6 +2438,16 @@
    return
   end
   unreachable
+ )
+ (func $~lib/rt/__visit_globals (param $0 i32)
+  (local $1 i32)
+  global.get $typeof/c
+  local.tee $1
+  if
+   local.get $1
+   local.get $0
+   call $~lib/rt/itcms/__visit
+  end
  )
  (func $~start
   global.get $~started

--- a/tests/compiler/typeof.release.wat
+++ b/tests/compiler/typeof.release.wat
@@ -57,18 +57,12 @@
  (func $~lib/rt/itcms/visitRoots
   (local $0 i32)
   (local $1 i32)
-  i32.const 1264
-  call $~lib/rt/itcms/__visit
   global.get $typeof/c
   local.tee $0
   if
    local.get $0
    call $~lib/rt/itcms/__visit
   end
-  i32.const 1552
-  call $~lib/rt/itcms/__visit
-  i32.const 1360
-  call $~lib/rt/itcms/__visit
   global.get $~lib/rt/itcms/pinSpace
   local.tee $1
   i32.load offset=4

--- a/tests/compiler/while.debug.wat
+++ b/tests/compiler/while.debug.wat
@@ -3150,15 +3150,6 @@
   end
   call $~lib/rt/itcms/__collect
  )
- (func $~lib/rt/__visit_globals (param $0 i32)
-  (local $1 i32)
-  i32.const 272
-  local.get $0
-  call $~lib/rt/itcms/__visit
-  i32.const 80
-  local.get $0
-  call $~lib/rt/itcms/__visit
- )
  (func $~lib/arraybuffer/ArrayBufferView~visit (param $0 i32) (param $1 i32)
   (local $2 i32)
   local.get $0
@@ -3198,6 +3189,9 @@
    return
   end
   unreachable
+ )
+ (func $~lib/rt/__visit_globals (param $0 i32)
+  (local $1 i32)
  )
  (func $~start
   call $start:while

--- a/tests/compiler/while.release.wat
+++ b/tests/compiler/while.release.wat
@@ -37,10 +37,6 @@
  (func $~lib/rt/itcms/visitRoots
   (local $0 i32)
   (local $1 i32)
-  i32.const 1296
-  call $~lib/rt/itcms/__visit
-  i32.const 1104
-  call $~lib/rt/itcms/__visit
   global.get $~lib/rt/itcms/pinSpace
   local.tee $1
   i32.load offset=4


### PR DESCRIPTION
If a class is annotated as final, it is impossible to have dynamic dispatch for __visit. So we can call the class's __visit function directly.
For pointee free object, we can even save the call
