### PR TITLE
fix: create 2 kinds of constructor for instantiation and instantiation of inherited types

### DIFF
--- a/src/common.ts
+++ b/src/common.ts
@@ -166,6 +166,7 @@ export namespace CommonNames {
   export const this_ = "this";
   export const super_ = "super";
   export const constructor = "constructor";
+  export const raw_constructor = "raw_constructor";
   // constants
   export const ASC_TARGET = "ASC_TARGET";
   export const ASC_RUNTIME = "ASC_RUNTIME";

--- a/src/program.ts
+++ b/src/program.ts
@@ -4367,6 +4367,8 @@ export class Class extends TypedElement {
   nextMemoryOffset: u32 = 0;
   /** Constructor instance. */
   constructorInstance: Function | null = null;
+  /** Constructor instance for inheritance. */
+  rawConstructorInstance: Function | null = null;
   /** Operator overloads. */
   operatorOverloads: Map<OperatorKind,Function> | null = null;
   /** Index signature, if present. */

--- a/tests/compiler/assignment-chain.debug.wat
+++ b/tests/compiler/assignment-chain.debug.wat
@@ -50,6 +50,9 @@
  (export "static_setter_assignment_chain" (func $assignment-chain/static_setter_assignment_chain))
  (export "memory" (memory $0))
  (start $~start)
+ (func $~lib/object/Object#raw_constructor (param $this i32) (result i32)
+  local.get $this
+ )
  (func $~lib/rt/itcms/Object#set:nextWithColor (param $this i32) (param $nextWithColor i32)
   local.get $this
   local.get $nextWithColor
@@ -2401,6 +2404,50 @@
    unreachable
   end
  )
+ (func $assignment-chain/A#raw_constructor (param $this i32) (result i32)
+  (local $1 i32)
+  global.get $~lib/memory/__stack_pointer
+  i32.const 8
+  i32.sub
+  global.set $~lib/memory/__stack_pointer
+  call $~stack_check
+  global.get $~lib/memory/__stack_pointer
+  i64.const 0
+  i64.store
+  global.get $~lib/memory/__stack_pointer
+  local.get $this
+  local.set $1
+  global.get $~lib/memory/__stack_pointer
+  local.get $1
+  i32.store
+  local.get $1
+  call $~lib/object/Object#raw_constructor
+  local.tee $this
+  i32.store offset=4
+  local.get $this
+  local.set $1
+  global.get $~lib/memory/__stack_pointer
+  local.get $1
+  i32.store
+  local.get $1
+  i64.const 0
+  call $assignment-chain/A#set:x
+  local.get $this
+  local.set $1
+  global.get $~lib/memory/__stack_pointer
+  local.get $1
+  i32.store
+  local.get $1
+  i64.const 0
+  call $assignment-chain/A#set:y
+  local.get $this
+  local.set $1
+  global.get $~lib/memory/__stack_pointer
+  i32.const 8
+  i32.add
+  global.set $~lib/memory/__stack_pointer
+  local.get $1
+ )
  (func $assignment-chain/A#constructor (param $this i32) (result i32)
   (local $1 i32)
   global.get $~lib/memory/__stack_pointer
@@ -2428,7 +2475,7 @@
   local.get $1
   i32.store offset=4
   local.get $1
-  call $~lib/object/Object#constructor
+  call $~lib/object/Object#raw_constructor
   local.tee $this
   i32.store
   local.get $this
@@ -2519,6 +2566,58 @@
   i32.add
   global.set $~lib/memory/__stack_pointer
  )
+ (func $assignment-chain/B#raw_constructor (param $this i32) (result i32)
+  (local $1 i32)
+  global.get $~lib/memory/__stack_pointer
+  i32.const 8
+  i32.sub
+  global.set $~lib/memory/__stack_pointer
+  call $~stack_check
+  global.get $~lib/memory/__stack_pointer
+  i64.const 0
+  i64.store
+  global.get $~lib/memory/__stack_pointer
+  local.get $this
+  local.set $1
+  global.get $~lib/memory/__stack_pointer
+  local.get $1
+  i32.store
+  local.get $1
+  call $~lib/object/Object#raw_constructor
+  local.tee $this
+  i32.store offset=4
+  local.get $this
+  local.set $1
+  global.get $~lib/memory/__stack_pointer
+  local.get $1
+  i32.store
+  local.get $1
+  i32.const 0
+  call $assignment-chain/B#set:_setter_cnt
+  local.get $this
+  local.set $1
+  global.get $~lib/memory/__stack_pointer
+  local.get $1
+  i32.store
+  local.get $1
+  i32.const 0
+  call $assignment-chain/B#set:_getter_cnt
+  local.get $this
+  local.set $1
+  global.get $~lib/memory/__stack_pointer
+  local.get $1
+  i32.store
+  local.get $1
+  f64.const 0
+  call $assignment-chain/B#set:_y
+  local.get $this
+  local.set $1
+  global.get $~lib/memory/__stack_pointer
+  i32.const 8
+  i32.add
+  global.set $~lib/memory/__stack_pointer
+  local.get $1
+ )
  (func $assignment-chain/B#constructor (param $this i32) (result i32)
   (local $1 i32)
   global.get $~lib/memory/__stack_pointer
@@ -2546,7 +2645,7 @@
   local.get $1
   i32.store offset=4
   local.get $1
-  call $~lib/object/Object#constructor
+  call $~lib/object/Object#raw_constructor
   local.tee $this
   i32.store
   local.get $this

--- a/tests/compiler/assignment-chain.release.wat
+++ b/tests/compiler/assignment-chain.release.wat
@@ -2,11 +2,10 @@
  (type $0 (func))
  (type $1 (func (param i32)))
  (type $2 (func (param i32 i32)))
- (type $3 (func (param i32 i32) (result i32)))
+ (type $3 (func (param i32) (result i32)))
  (type $4 (func (param i32 i32 i32 i32)))
  (type $5 (func (param i32 i32 i64)))
  (type $6 (func (result i32)))
- (type $7 (func (param i32) (result i32)))
  (import "env" "abort" (func $~lib/builtins/abort (param i32 i32 i32 i32)))
  (global $~lib/rt/itcms/total (mut i32) (i32.const 0))
  (global $~lib/rt/itcms/threshold (mut i32) (i32.const 0))
@@ -122,7 +121,7 @@
     local.get $0
     global.set $~lib/rt/itcms/iter
    end
-   block $__inlined_func$~lib/rt/itcms/Object#unlink$129
+   block $__inlined_func$~lib/rt/itcms/Object#unlink$130
     local.get $1
     i32.load offset=4
     i32.const -4
@@ -146,7 +145,7 @@
       call $~lib/builtins/abort
       unreachable
      end
-     br $__inlined_func$~lib/rt/itcms/Object#unlink$129
+     br $__inlined_func$~lib/rt/itcms/Object#unlink$130
     end
     local.get $1
     i32.load offset=8
@@ -1082,85 +1081,18 @@
   end
   i32.const 0
  )
- (func $~lib/rt/tlsf/searchBlock (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/rt/tlsf/searchBlock (param $0 i32) (result i32)
+  (local $1 i32)
   (local $2 i32)
-  local.get $1
-  i32.const 256
-  i32.lt_u
-  if
-   local.get $1
-   i32.const 4
-   i32.shr_u
-   local.set $1
-  else
-   local.get $1
-   i32.const 536870910
-   i32.lt_u
-   if
-    local.get $1
-    i32.const 1
-    i32.const 27
-    local.get $1
-    i32.clz
-    i32.sub
-    i32.shl
-    i32.add
-    i32.const 1
-    i32.sub
-    local.set $1
-   end
-   local.get $1
-   i32.const 31
-   local.get $1
-   i32.clz
-   i32.sub
-   local.tee $2
-   i32.const 4
-   i32.sub
-   i32.shr_u
-   i32.const 16
-   i32.xor
-   local.set $1
-   local.get $2
-   i32.const 7
-   i32.sub
-   local.set $2
-  end
-  local.get $1
-  i32.const 16
-  i32.lt_u
-  local.get $2
-  i32.const 23
-  i32.lt_u
-  i32.and
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1392
-   i32.const 334
-   i32.const 14
-   call $~lib/builtins/abort
-   unreachable
-  end
   local.get $0
-  local.get $2
-  i32.const 2
-  i32.shl
-  i32.add
   i32.load offset=4
-  i32.const -1
-  local.get $1
-  i32.shl
+  i32.const -4
   i32.and
   local.tee $1
   if (result i32)
    local.get $0
    local.get $1
    i32.ctz
-   local.get $2
-   i32.const 4
-   i32.shl
-   i32.add
    i32.const 2
    i32.shl
    i32.add
@@ -1168,23 +1100,19 @@
   else
    local.get $0
    i32.load
-   i32.const -1
-   local.get $2
-   i32.const 1
-   i32.add
-   i32.shl
+   i32.const -2
    i32.and
    local.tee $1
    if (result i32)
     local.get $0
     local.get $1
     i32.ctz
-    local.tee $1
+    local.tee $2
     i32.const 2
     i32.shl
     i32.add
     i32.load offset=4
-    local.tee $2
+    local.tee $1
     i32.eqz
     if
      i32.const 0
@@ -1195,9 +1123,9 @@
      unreachable
     end
     local.get $0
-    local.get $2
-    i32.ctz
     local.get $1
+    i32.ctz
+    local.get $2
     i32.const 4
     i32.shl
     i32.add
@@ -1210,35 +1138,23 @@
    end
   end
  )
- (func $~lib/rt/itcms/__new (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/rt/itcms/__new (param $0 i32) (result i32)
+  (local $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
-  (local $5 i32)
-  (local $6 i32)
-  local.get $0
-  i32.const 1073741804
-  i32.ge_u
-  if
-   i32.const 1056
-   i32.const 1120
-   i32.const 261
-   i32.const 31
-   call $~lib/builtins/abort
-   unreachable
-  end
   global.get $~lib/rt/itcms/total
   global.get $~lib/rt/itcms/threshold
   i32.ge_u
   if
    block $__inlined_func$~lib/rt/itcms/interrupt$69
     i32.const 2048
-    local.set $2
+    local.set $1
     loop $do-loop|0
-     local.get $2
+     local.get $1
      call $~lib/rt/itcms/step
      i32.sub
-     local.set $2
+     local.set $1
      global.get $~lib/rt/itcms/state
      i32.eqz
      if
@@ -1254,7 +1170,7 @@
       global.set $~lib/rt/itcms/threshold
       br $__inlined_func$~lib/rt/itcms/interrupt$69
      end
-     local.get $2
+     local.get $1
      i32.const 0
      i32.gt_s
      br_if $do-loop|0
@@ -1277,86 +1193,31 @@
    call $~lib/rt/tlsf/initialize
   end
   global.get $~lib/rt/tlsf/ROOT
-  local.set $4
-  local.get $0
-  i32.const 16
-  i32.add
   local.tee $2
-  i32.const 1073741820
-  i32.gt_u
-  if
-   i32.const 1056
-   i32.const 1392
-   i32.const 461
-   i32.const 29
-   call $~lib/builtins/abort
-   unreachable
-  end
-  local.get $4
-  local.get $2
-  i32.const 12
-  i32.le_u
-  if (result i32)
-   i32.const 12
-  else
-   local.get $2
-   i32.const 19
-   i32.add
-   i32.const -16
-   i32.and
-   i32.const 4
-   i32.sub
-  end
-  local.tee $5
   call $~lib/rt/tlsf/searchBlock
-  local.tee $2
+  local.tee $1
   i32.eqz
   if
    memory.size
-   local.tee $2
-   local.get $5
-   i32.const 256
-   i32.ge_u
-   if (result i32)
-    local.get $5
-    i32.const 536870910
-    i32.lt_u
-    if (result i32)
-     local.get $5
-     i32.const 1
-     i32.const 27
-     local.get $5
-     i32.clz
-     i32.sub
-     i32.shl
-     i32.add
-     i32.const 1
-     i32.sub
-    else
-     local.get $5
-    end
-   else
-    local.get $5
-   end
+   local.tee $1
    i32.const 4
-   local.get $4
-   i32.load offset=1568
    local.get $2
+   i32.load offset=1568
+   local.get $1
    i32.const 16
    i32.shl
    i32.const 4
    i32.sub
    i32.ne
    i32.shl
-   i32.add
-   i32.const 65535
+   i32.const 65579
    i32.add
    i32.const -65536
    i32.and
    i32.const 16
    i32.shr_u
    local.tee $3
-   local.get $2
+   local.get $1
    local.get $3
    i32.gt_s
    select
@@ -1372,8 +1233,8 @@
      unreachable
     end
    end
-   local.get $4
    local.get $2
+   local.get $1
    i32.const 16
    i32.shl
    memory.size
@@ -1381,10 +1242,9 @@
    i64.const 16
    i64.shl
    call $~lib/rt/tlsf/addMemory
-   local.get $4
-   local.get $5
+   local.get $2
    call $~lib/rt/tlsf/searchBlock
-   local.tee $2
+   local.tee $1
    i32.eqz
    if
     i32.const 0
@@ -1395,12 +1255,12 @@
     unreachable
    end
   end
-  local.get $5
-  local.get $2
+  local.get $1
   i32.load
   i32.const -4
   i32.and
-  i32.gt_u
+  i32.const 44
+  i32.lt_u
   if
    i32.const 0
    i32.const 1392
@@ -1409,108 +1269,92 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $4
   local.get $2
+  local.get $1
   call $~lib/rt/tlsf/removeBlock
-  local.get $2
+  local.get $1
   i32.load
-  local.set $6
-  local.get $5
-  i32.const 4
-  i32.add
-  i32.const 15
-  i32.and
-  if
-   i32.const 0
-   i32.const 1392
-   i32.const 361
-   i32.const 14
-   call $~lib/builtins/abort
-   unreachable
-  end
-  local.get $6
+  local.tee $3
   i32.const -4
   i32.and
-  local.get $5
+  i32.const 44
   i32.sub
-  local.tee $3
+  local.tee $4
   i32.const 16
   i32.ge_u
   if
-   local.get $2
-   local.get $5
-   local.get $6
+   local.get $1
+   local.get $3
    i32.const 2
    i32.and
+   i32.const 44
    i32.or
    i32.store
-   local.get $2
-   i32.const 4
+   local.get $1
+   i32.const 48
    i32.add
-   local.get $5
-   i32.add
-   local.tee $5
-   local.get $3
+   local.tee $3
+   local.get $4
    i32.const 4
    i32.sub
    i32.const 1
    i32.or
    i32.store
-   local.get $4
-   local.get $5
+   local.get $2
+   local.get $3
    call $~lib/rt/tlsf/insertBlock
   else
-   local.get $2
-   local.get $6
+   local.get $1
+   local.get $3
    i32.const -2
    i32.and
    i32.store
-   local.get $2
+   local.get $1
    i32.const 4
    i32.add
-   local.get $2
+   local.get $1
    i32.load
    i32.const -4
    i32.and
    i32.add
-   local.tee $3
-   local.get $3
+   local.tee $2
+   local.get $2
    i32.load
    i32.const -3
    i32.and
    i32.store
   end
-  local.get $2
   local.get $1
-  i32.store offset=12
-  local.get $2
   local.get $0
+  i32.store offset=12
+  local.get $1
+  i32.const 16
   i32.store offset=16
   global.get $~lib/rt/itcms/fromSpace
-  local.tee $1
+  local.tee $0
   i32.load offset=8
-  local.set $3
-  local.get $2
+  local.set $2
   local.get $1
+  local.get $0
   global.get $~lib/rt/itcms/white
   i32.or
   i32.store offset=4
+  local.get $1
   local.get $2
-  local.get $3
   i32.store offset=8
-  local.get $3
   local.get $2
-  local.get $3
+  local.get $1
+  local.get $2
   i32.load offset=4
   i32.const 3
   i32.and
   i32.or
   i32.store offset=4
+  local.get $0
   local.get $1
-  local.get $2
   i32.store offset=8
   global.get $~lib/rt/itcms/total
-  local.get $2
+  local.get $1
   i32.load
   i32.const -4
   i32.and
@@ -1518,14 +1362,16 @@
   i32.add
   i32.add
   global.set $~lib/rt/itcms/total
-  local.get $2
+  local.get $1
   i32.const 20
   i32.add
-  local.tee $1
-  i32.const 0
+  local.tee $0
+  i64.const 0
+  i64.store align=1
   local.get $0
-  memory.fill
-  local.get $1
+  i64.const 0
+  i64.store offset=8 align=1
+  local.get $0
  )
  (func $assignment-chain/static_setter_assignment_chain
   global.get $assignment-chain/C._setter_cnt
@@ -1647,47 +1493,44 @@
    i64.const 0
    i64.store
    global.get $~lib/memory/__stack_pointer
-   i32.const 16
    i32.const 4
    call $~lib/rt/itcms/__new
-   local.tee $1
+   local.tee $0
    i32.store
    global.get $~lib/memory/__stack_pointer
-   local.get $1
+   local.get $0
    i32.store offset=4
    global.get $~lib/memory/__stack_pointer
-   local.get $1
-   call $~lib/object/Object#constructor
-   local.tee $1
+   local.get $0
    i32.store
    global.get $~lib/memory/__stack_pointer
-   local.get $1
+   local.get $0
    i32.store offset=4
-   local.get $1
+   local.get $0
    i64.const 0
    i64.store
    global.get $~lib/memory/__stack_pointer
-   local.get $1
+   local.get $0
    i32.store offset=4
-   local.get $1
+   local.get $0
    i64.const 0
    i64.store offset=8
    global.get $~lib/memory/__stack_pointer
    i32.const 8
    i32.add
    global.set $~lib/memory/__stack_pointer
-   local.get $1
+   local.get $0
    i32.store
    global.get $~lib/memory/__stack_pointer
-   local.get $1
+   local.get $0
    i32.store offset=4
    global.get $~lib/memory/__stack_pointer
-   local.get $1
+   local.get $0
    i32.store offset=8
-   local.get $1
+   local.get $0
    i64.const 0
    i64.store offset=8
-   local.get $1
+   local.get $0
    i64.const 0
    i64.store
    global.get $~lib/memory/__stack_pointer
@@ -1776,57 +1619,54 @@
    i64.const 0
    i64.store
    global.get $~lib/memory/__stack_pointer
-   i32.const 16
    i32.const 5
    call $~lib/rt/itcms/__new
-   local.tee $1
+   local.tee $0
    i32.store
    global.get $~lib/memory/__stack_pointer
-   local.get $1
+   local.get $0
    i32.store offset=4
    global.get $~lib/memory/__stack_pointer
-   local.get $1
-   call $~lib/object/Object#constructor
-   local.tee $1
+   local.get $0
    i32.store
    global.get $~lib/memory/__stack_pointer
-   local.get $1
+   local.get $0
    i32.store offset=4
-   local.get $1
+   local.get $0
    i32.const 0
    i32.store
    global.get $~lib/memory/__stack_pointer
-   local.get $1
+   local.get $0
    i32.store offset=4
-   local.get $1
+   local.get $0
    i32.const 0
    i32.store offset=4
    global.get $~lib/memory/__stack_pointer
-   local.get $1
+   local.get $0
    i32.store offset=4
-   local.get $1
+   local.get $0
    f64.const 0
    f64.store offset=8
    global.get $~lib/memory/__stack_pointer
    i32.const 8
    i32.add
    global.set $~lib/memory/__stack_pointer
-   local.get $1
+   local.get $0
    i32.store
    global.get $~lib/memory/__stack_pointer
-   local.get $1
+   local.get $0
    i32.store offset=4
    global.get $~lib/memory/__stack_pointer
-   local.get $1
+   local.get $0
    i32.store offset=8
-   local.get $1
+   local.get $0
    call $assignment-chain/B#set:y
-   local.get $1
+   local.get $0
    call $assignment-chain/B#set:y
    global.get $~lib/memory/__stack_pointer
-   local.get $1
+   local.get $0
    i32.store offset=4
-   local.get $1
+   local.get $0
    i32.load
    i32.const 2
    i32.ne
@@ -1839,9 +1679,9 @@
     unreachable
    end
    global.get $~lib/memory/__stack_pointer
-   local.get $1
+   local.get $0
    i32.store offset=4
-   local.get $1
+   local.get $0
    i32.load offset=4
    if
     i32.const 0
@@ -1863,40 +1703,5 @@
   i32.const 1
   call $~lib/builtins/abort
   unreachable
- )
- (func $~lib/object/Object#constructor (param $0 i32) (result i32)
-  global.get $~lib/memory/__stack_pointer
-  i32.const 4
-  i32.sub
-  global.set $~lib/memory/__stack_pointer
-  global.get $~lib/memory/__stack_pointer
-  i32.const 1532
-  i32.lt_s
-  if
-   i32.const 34320
-   i32.const 34368
-   i32.const 1
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  global.get $~lib/memory/__stack_pointer
-  i32.const 0
-  i32.store
-  local.get $0
-  i32.eqz
-  if
-   global.get $~lib/memory/__stack_pointer
-   i32.const 0
-   i32.const 0
-   call $~lib/rt/itcms/__new
-   local.tee $0
-   i32.store
-  end
-  global.get $~lib/memory/__stack_pointer
-  i32.const 4
-  i32.add
-  global.set $~lib/memory/__stack_pointer
-  local.get $0
  )
 )

--- a/tests/compiler/bindings/esm.debug.wat
+++ b/tests/compiler/bindings/esm.debug.wat
@@ -1,6 +1,6 @@
 (module
- (type $0 (func (param i32 i32)))
- (type $1 (func (param i32) (result i32)))
+ (type $0 (func (param i32) (result i32)))
+ (type $1 (func (param i32 i32)))
  (type $2 (func (param i32 i32) (result i32)))
  (type $3 (func (param i32)))
  (type $4 (func))
@@ -2605,6 +2605,9 @@
   local.get $this
   i32.load offset=4
  )
+ (func $~lib/object/Object#raw_constructor (param $this i32) (result i32)
+  local.get $this
+ )
  (func $bindings/esm/PlainObject#set:a (param $this i32) (param $a i32)
   local.get $this
   local.get $a
@@ -5054,6 +5057,162 @@
   local.get $5
   return
  )
+ (func $bindings/esm/PlainObject#raw_constructor (param $this i32) (result i32)
+  (local $1 i32)
+  global.get $~lib/memory/__stack_pointer
+  i32.const 8
+  i32.sub
+  global.set $~lib/memory/__stack_pointer
+  call $~stack_check
+  global.get $~lib/memory/__stack_pointer
+  i64.const 0
+  i64.store
+  global.get $~lib/memory/__stack_pointer
+  local.get $this
+  local.set $1
+  global.get $~lib/memory/__stack_pointer
+  local.get $1
+  i32.store
+  local.get $1
+  call $~lib/object/Object#raw_constructor
+  local.tee $this
+  i32.store offset=4
+  local.get $this
+  local.set $1
+  global.get $~lib/memory/__stack_pointer
+  local.get $1
+  i32.store
+  local.get $1
+  i32.const 0
+  call $bindings/esm/PlainObject#set:a
+  local.get $this
+  local.set $1
+  global.get $~lib/memory/__stack_pointer
+  local.get $1
+  i32.store
+  local.get $1
+  i32.const 0
+  call $bindings/esm/PlainObject#set:b
+  local.get $this
+  local.set $1
+  global.get $~lib/memory/__stack_pointer
+  local.get $1
+  i32.store
+  local.get $1
+  i32.const 0
+  call $bindings/esm/PlainObject#set:c
+  local.get $this
+  local.set $1
+  global.get $~lib/memory/__stack_pointer
+  local.get $1
+  i32.store
+  local.get $1
+  i64.const 0
+  call $bindings/esm/PlainObject#set:d
+  local.get $this
+  local.set $1
+  global.get $~lib/memory/__stack_pointer
+  local.get $1
+  i32.store
+  local.get $1
+  i32.const 0
+  call $bindings/esm/PlainObject#set:e
+  local.get $this
+  local.set $1
+  global.get $~lib/memory/__stack_pointer
+  local.get $1
+  i32.store
+  local.get $1
+  i32.const 0
+  call $bindings/esm/PlainObject#set:f
+  local.get $this
+  local.set $1
+  global.get $~lib/memory/__stack_pointer
+  local.get $1
+  i32.store
+  local.get $1
+  i32.const 0
+  call $bindings/esm/PlainObject#set:g
+  local.get $this
+  local.set $1
+  global.get $~lib/memory/__stack_pointer
+  local.get $1
+  i32.store
+  local.get $1
+  i64.const 0
+  call $bindings/esm/PlainObject#set:h
+  local.get $this
+  local.set $1
+  global.get $~lib/memory/__stack_pointer
+  local.get $1
+  i32.store
+  local.get $1
+  i32.const 0
+  call $bindings/esm/PlainObject#set:i
+  local.get $this
+  local.set $1
+  global.get $~lib/memory/__stack_pointer
+  local.get $1
+  i32.store
+  local.get $1
+  i32.const 0
+  call $bindings/esm/PlainObject#set:j
+  local.get $this
+  local.set $1
+  global.get $~lib/memory/__stack_pointer
+  local.get $1
+  i32.store
+  local.get $1
+  i32.const 0
+  call $bindings/esm/PlainObject#set:k
+  local.get $this
+  local.set $1
+  global.get $~lib/memory/__stack_pointer
+  local.get $1
+  i32.store
+  local.get $1
+  f32.const 0
+  call $bindings/esm/PlainObject#set:l
+  local.get $this
+  local.set $1
+  global.get $~lib/memory/__stack_pointer
+  local.get $1
+  i32.store
+  local.get $1
+  f64.const 0
+  call $bindings/esm/PlainObject#set:m
+  local.get $this
+  local.set $1
+  global.get $~lib/memory/__stack_pointer
+  local.get $1
+  i32.store
+  local.get $1
+  i32.const 0
+  call $bindings/esm/PlainObject#set:n
+  local.get $this
+  local.set $1
+  global.get $~lib/memory/__stack_pointer
+  local.get $1
+  i32.store
+  local.get $1
+  i32.const 0
+  call $bindings/esm/PlainObject#set:o
+  local.get $this
+  local.set $1
+  global.get $~lib/memory/__stack_pointer
+  local.get $1
+  i32.store
+  local.get $1
+  i32.const 0
+  call $bindings/esm/PlainObject#set:p
+  local.get $this
+  local.set $1
+  global.get $~lib/memory/__stack_pointer
+  i32.const 8
+  i32.add
+  global.set $~lib/memory/__stack_pointer
+  local.get $1
+ )
  (func $bindings/esm/PlainObject#constructor (param $this i32) (result i32)
   (local $1 i32)
   global.get $~lib/memory/__stack_pointer
@@ -5081,7 +5240,7 @@
   local.get $1
   i32.store offset=4
   local.get $1
-  call $~lib/object/Object#constructor
+  call $~lib/object/Object#raw_constructor
   local.tee $this
   i32.store
   local.get $this

--- a/tests/compiler/bindings/esm.release.wat
+++ b/tests/compiler/bindings/esm.release.wat
@@ -2192,7 +2192,7 @@
    global.get $~lib/memory/__stack_pointer
    local.get $1
    i32.store
-   block $__inlined_func$~lib/string/String#concat$285
+   block $__inlined_func$~lib/string/String#concat$284
     local.get $1
     i32.const 20
     i32.sub
@@ -2211,7 +2211,7 @@
      global.set $~lib/memory/__stack_pointer
      i32.const 1760
      local.set $2
-     br $__inlined_func$~lib/string/String#concat$285
+     br $__inlined_func$~lib/string/String#concat$284
     end
     global.get $~lib/memory/__stack_pointer
     local.get $2
@@ -4206,174 +4206,142 @@
    i32.const 0
    i32.store offset=8
    global.get $~lib/memory/__stack_pointer
-   block $__inlined_func$bindings/esm/PlainObject#constructor$4 (result i32)
-    global.get $~lib/memory/__stack_pointer
-    i32.const 8
-    i32.sub
-    global.set $~lib/memory/__stack_pointer
-    block $folding-inner00
-     global.get $~lib/memory/__stack_pointer
-     i32.const 2276
-     i32.lt_s
-     br_if $folding-inner00
-     global.get $~lib/memory/__stack_pointer
-     i64.const 0
-     i64.store
-     global.get $~lib/memory/__stack_pointer
-     i32.const 68
-     i32.const 13
-     call $~lib/rt/itcms/__new
-     local.tee $2
-     i32.store
-     global.get $~lib/memory/__stack_pointer
-     global.get $~lib/memory/__stack_pointer
-     local.get $2
-     i32.store offset=4
-     global.get $~lib/memory/__stack_pointer
-     i32.const 4
-     i32.sub
-     global.set $~lib/memory/__stack_pointer
-     global.get $~lib/memory/__stack_pointer
-     i32.const 2276
-     i32.lt_s
-     br_if $folding-inner00
-     global.get $~lib/memory/__stack_pointer
-     i32.const 0
-     i32.store
-     local.get $2
-     i32.eqz
-     if
-      global.get $~lib/memory/__stack_pointer
-      i32.const 0
-      i32.const 0
-      call $~lib/rt/itcms/__new
-      local.tee $2
-      i32.store
-     end
-     global.get $~lib/memory/__stack_pointer
-     i32.const 4
-     i32.add
-     global.set $~lib/memory/__stack_pointer
-     local.get $2
-     i32.store
-     global.get $~lib/memory/__stack_pointer
-     local.get $2
-     i32.store offset=4
-     local.get $2
-     i32.const 0
-     i32.store8
-     global.get $~lib/memory/__stack_pointer
-     local.get $2
-     i32.store offset=4
-     local.get $2
-     i32.const 0
-     i32.store16 offset=2
-     global.get $~lib/memory/__stack_pointer
-     local.get $2
-     i32.store offset=4
-     local.get $2
-     i32.const 0
-     i32.store offset=4
-     global.get $~lib/memory/__stack_pointer
-     local.get $2
-     i32.store offset=4
-     local.get $2
-     i64.const 0
-     i64.store offset=8
-     global.get $~lib/memory/__stack_pointer
-     local.get $2
-     i32.store offset=4
-     local.get $2
-     i32.const 0
-     i32.store8 offset=16
-     global.get $~lib/memory/__stack_pointer
-     local.get $2
-     i32.store offset=4
-     local.get $2
-     i32.const 0
-     i32.store16 offset=18
-     global.get $~lib/memory/__stack_pointer
-     local.get $2
-     i32.store offset=4
-     local.get $2
-     i32.const 0
-     i32.store offset=20
-     global.get $~lib/memory/__stack_pointer
-     local.get $2
-     i32.store offset=4
-     local.get $2
-     i64.const 0
-     i64.store offset=24
-     global.get $~lib/memory/__stack_pointer
-     local.get $2
-     i32.store offset=4
-     local.get $2
-     i32.const 0
-     i32.store offset=32
-     global.get $~lib/memory/__stack_pointer
-     local.get $2
-     i32.store offset=4
-     local.get $2
-     i32.const 0
-     i32.store offset=36
-     global.get $~lib/memory/__stack_pointer
-     local.get $2
-     i32.store offset=4
-     local.get $2
-     i32.const 0
-     i32.store8 offset=40
-     global.get $~lib/memory/__stack_pointer
-     local.get $2
-     i32.store offset=4
-     local.get $2
-     f32.const 0
-     f32.store offset=44
-     global.get $~lib/memory/__stack_pointer
-     local.get $2
-     i32.store offset=4
-     local.get $2
-     f64.const 0
-     f64.store offset=48
-     global.get $~lib/memory/__stack_pointer
-     local.get $2
-     i32.store offset=4
-     local.get $2
-     i32.const 0
-     i32.store offset=56
-     local.get $2
-     i32.const 0
-     i32.const 0
-     call $~lib/rt/itcms/__link
-     global.get $~lib/memory/__stack_pointer
-     local.get $2
-     i32.store offset=4
-     local.get $2
-     i32.const 0
-     i32.store offset=60
-     local.get $2
-     i32.const 0
-     i32.const 0
-     call $~lib/rt/itcms/__link
-     global.get $~lib/memory/__stack_pointer
-     local.get $2
-     i32.store offset=4
-     local.get $2
-     i32.const 0
-     i32.store offset=64
-     local.get $2
-     i32.const 0
-     i32.const 0
-     call $~lib/rt/itcms/__link
-     global.get $~lib/memory/__stack_pointer
-     i32.const 8
-     i32.add
-     global.set $~lib/memory/__stack_pointer
-     local.get $2
-     br $__inlined_func$bindings/esm/PlainObject#constructor$4
-    end
-    br $folding-inner1
-   end
+   global.get $~lib/memory/__stack_pointer
+   i32.const 8
+   i32.sub
+   global.set $~lib/memory/__stack_pointer
+   global.get $~lib/memory/__stack_pointer
+   i32.const 2276
+   i32.lt_s
+   br_if $folding-inner1
+   global.get $~lib/memory/__stack_pointer
+   i64.const 0
+   i64.store
+   global.get $~lib/memory/__stack_pointer
+   i32.const 68
+   i32.const 13
+   call $~lib/rt/itcms/__new
    local.tee $2
+   i32.store
+   global.get $~lib/memory/__stack_pointer
+   local.get $2
+   i32.store offset=4
+   global.get $~lib/memory/__stack_pointer
+   local.get $2
+   i32.store
+   global.get $~lib/memory/__stack_pointer
+   local.get $2
+   i32.store offset=4
+   local.get $2
+   i32.const 0
+   i32.store8
+   global.get $~lib/memory/__stack_pointer
+   local.get $2
+   i32.store offset=4
+   local.get $2
+   i32.const 0
+   i32.store16 offset=2
+   global.get $~lib/memory/__stack_pointer
+   local.get $2
+   i32.store offset=4
+   local.get $2
+   i32.const 0
+   i32.store offset=4
+   global.get $~lib/memory/__stack_pointer
+   local.get $2
+   i32.store offset=4
+   local.get $2
+   i64.const 0
+   i64.store offset=8
+   global.get $~lib/memory/__stack_pointer
+   local.get $2
+   i32.store offset=4
+   local.get $2
+   i32.const 0
+   i32.store8 offset=16
+   global.get $~lib/memory/__stack_pointer
+   local.get $2
+   i32.store offset=4
+   local.get $2
+   i32.const 0
+   i32.store16 offset=18
+   global.get $~lib/memory/__stack_pointer
+   local.get $2
+   i32.store offset=4
+   local.get $2
+   i32.const 0
+   i32.store offset=20
+   global.get $~lib/memory/__stack_pointer
+   local.get $2
+   i32.store offset=4
+   local.get $2
+   i64.const 0
+   i64.store offset=24
+   global.get $~lib/memory/__stack_pointer
+   local.get $2
+   i32.store offset=4
+   local.get $2
+   i32.const 0
+   i32.store offset=32
+   global.get $~lib/memory/__stack_pointer
+   local.get $2
+   i32.store offset=4
+   local.get $2
+   i32.const 0
+   i32.store offset=36
+   global.get $~lib/memory/__stack_pointer
+   local.get $2
+   i32.store offset=4
+   local.get $2
+   i32.const 0
+   i32.store8 offset=40
+   global.get $~lib/memory/__stack_pointer
+   local.get $2
+   i32.store offset=4
+   local.get $2
+   f32.const 0
+   f32.store offset=44
+   global.get $~lib/memory/__stack_pointer
+   local.get $2
+   i32.store offset=4
+   local.get $2
+   f64.const 0
+   f64.store offset=48
+   global.get $~lib/memory/__stack_pointer
+   local.get $2
+   i32.store offset=4
+   local.get $2
+   i32.const 0
+   i32.store offset=56
+   local.get $2
+   i32.const 0
+   i32.const 0
+   call $~lib/rt/itcms/__link
+   global.get $~lib/memory/__stack_pointer
+   local.get $2
+   i32.store offset=4
+   local.get $2
+   i32.const 0
+   i32.store offset=60
+   local.get $2
+   i32.const 0
+   i32.const 0
+   call $~lib/rt/itcms/__link
+   global.get $~lib/memory/__stack_pointer
+   local.get $2
+   i32.store offset=4
+   local.get $2
+   i32.const 0
+   i32.store offset=64
+   local.get $2
+   i32.const 0
+   i32.const 0
+   call $~lib/rt/itcms/__link
+   global.get $~lib/memory/__stack_pointer
+   i32.const 8
+   i32.add
+   global.set $~lib/memory/__stack_pointer
+   local.get $2
    i32.store
    global.get $~lib/memory/__stack_pointer
    local.get $2

--- a/tests/compiler/bindings/raw.debug.wat
+++ b/tests/compiler/bindings/raw.debug.wat
@@ -1,6 +1,6 @@
 (module
- (type $0 (func (param i32 i32)))
- (type $1 (func (param i32) (result i32)))
+ (type $0 (func (param i32) (result i32)))
+ (type $1 (func (param i32 i32)))
  (type $2 (func (param i32 i32) (result i32)))
  (type $3 (func (param i32)))
  (type $4 (func))
@@ -2608,6 +2608,9 @@
   local.get $this
   i32.load offset=4
  )
+ (func $~lib/object/Object#raw_constructor (param $this i32) (result i32)
+  local.get $this
+ )
  (func $bindings/esm/PlainObject#set:a (param $this i32) (param $a i32)
   local.get $this
   local.get $a
@@ -5057,6 +5060,162 @@
   local.get $5
   return
  )
+ (func $bindings/esm/PlainObject#raw_constructor (param $this i32) (result i32)
+  (local $1 i32)
+  global.get $~lib/memory/__stack_pointer
+  i32.const 8
+  i32.sub
+  global.set $~lib/memory/__stack_pointer
+  call $~stack_check
+  global.get $~lib/memory/__stack_pointer
+  i64.const 0
+  i64.store
+  global.get $~lib/memory/__stack_pointer
+  local.get $this
+  local.set $1
+  global.get $~lib/memory/__stack_pointer
+  local.get $1
+  i32.store
+  local.get $1
+  call $~lib/object/Object#raw_constructor
+  local.tee $this
+  i32.store offset=4
+  local.get $this
+  local.set $1
+  global.get $~lib/memory/__stack_pointer
+  local.get $1
+  i32.store
+  local.get $1
+  i32.const 0
+  call $bindings/esm/PlainObject#set:a
+  local.get $this
+  local.set $1
+  global.get $~lib/memory/__stack_pointer
+  local.get $1
+  i32.store
+  local.get $1
+  i32.const 0
+  call $bindings/esm/PlainObject#set:b
+  local.get $this
+  local.set $1
+  global.get $~lib/memory/__stack_pointer
+  local.get $1
+  i32.store
+  local.get $1
+  i32.const 0
+  call $bindings/esm/PlainObject#set:c
+  local.get $this
+  local.set $1
+  global.get $~lib/memory/__stack_pointer
+  local.get $1
+  i32.store
+  local.get $1
+  i64.const 0
+  call $bindings/esm/PlainObject#set:d
+  local.get $this
+  local.set $1
+  global.get $~lib/memory/__stack_pointer
+  local.get $1
+  i32.store
+  local.get $1
+  i32.const 0
+  call $bindings/esm/PlainObject#set:e
+  local.get $this
+  local.set $1
+  global.get $~lib/memory/__stack_pointer
+  local.get $1
+  i32.store
+  local.get $1
+  i32.const 0
+  call $bindings/esm/PlainObject#set:f
+  local.get $this
+  local.set $1
+  global.get $~lib/memory/__stack_pointer
+  local.get $1
+  i32.store
+  local.get $1
+  i32.const 0
+  call $bindings/esm/PlainObject#set:g
+  local.get $this
+  local.set $1
+  global.get $~lib/memory/__stack_pointer
+  local.get $1
+  i32.store
+  local.get $1
+  i64.const 0
+  call $bindings/esm/PlainObject#set:h
+  local.get $this
+  local.set $1
+  global.get $~lib/memory/__stack_pointer
+  local.get $1
+  i32.store
+  local.get $1
+  i32.const 0
+  call $bindings/esm/PlainObject#set:i
+  local.get $this
+  local.set $1
+  global.get $~lib/memory/__stack_pointer
+  local.get $1
+  i32.store
+  local.get $1
+  i32.const 0
+  call $bindings/esm/PlainObject#set:j
+  local.get $this
+  local.set $1
+  global.get $~lib/memory/__stack_pointer
+  local.get $1
+  i32.store
+  local.get $1
+  i32.const 0
+  call $bindings/esm/PlainObject#set:k
+  local.get $this
+  local.set $1
+  global.get $~lib/memory/__stack_pointer
+  local.get $1
+  i32.store
+  local.get $1
+  f32.const 0
+  call $bindings/esm/PlainObject#set:l
+  local.get $this
+  local.set $1
+  global.get $~lib/memory/__stack_pointer
+  local.get $1
+  i32.store
+  local.get $1
+  f64.const 0
+  call $bindings/esm/PlainObject#set:m
+  local.get $this
+  local.set $1
+  global.get $~lib/memory/__stack_pointer
+  local.get $1
+  i32.store
+  local.get $1
+  i32.const 0
+  call $bindings/esm/PlainObject#set:n
+  local.get $this
+  local.set $1
+  global.get $~lib/memory/__stack_pointer
+  local.get $1
+  i32.store
+  local.get $1
+  i32.const 0
+  call $bindings/esm/PlainObject#set:o
+  local.get $this
+  local.set $1
+  global.get $~lib/memory/__stack_pointer
+  local.get $1
+  i32.store
+  local.get $1
+  i32.const 0
+  call $bindings/esm/PlainObject#set:p
+  local.get $this
+  local.set $1
+  global.get $~lib/memory/__stack_pointer
+  i32.const 8
+  i32.add
+  global.set $~lib/memory/__stack_pointer
+  local.get $1
+ )
  (func $bindings/esm/PlainObject#constructor (param $this i32) (result i32)
   (local $1 i32)
   global.get $~lib/memory/__stack_pointer
@@ -5084,7 +5243,7 @@
   local.get $1
   i32.store offset=4
   local.get $1
-  call $~lib/object/Object#constructor
+  call $~lib/object/Object#raw_constructor
   local.tee $this
   i32.store
   local.get $this

--- a/tests/compiler/bindings/raw.release.wat
+++ b/tests/compiler/bindings/raw.release.wat
@@ -2192,7 +2192,7 @@
    global.get $~lib/memory/__stack_pointer
    local.get $1
    i32.store
-   block $__inlined_func$~lib/string/String#concat$286
+   block $__inlined_func$~lib/string/String#concat$285
     local.get $1
     i32.const 20
     i32.sub
@@ -2211,7 +2211,7 @@
      global.set $~lib/memory/__stack_pointer
      i32.const 1760
      local.set $2
-     br $__inlined_func$~lib/string/String#concat$286
+     br $__inlined_func$~lib/string/String#concat$285
     end
     global.get $~lib/memory/__stack_pointer
     local.get $2
@@ -4206,174 +4206,142 @@
    i32.const 0
    i32.store offset=8
    global.get $~lib/memory/__stack_pointer
-   block $__inlined_func$bindings/esm/PlainObject#constructor$4 (result i32)
-    global.get $~lib/memory/__stack_pointer
-    i32.const 8
-    i32.sub
-    global.set $~lib/memory/__stack_pointer
-    block $folding-inner00
-     global.get $~lib/memory/__stack_pointer
-     i32.const 2276
-     i32.lt_s
-     br_if $folding-inner00
-     global.get $~lib/memory/__stack_pointer
-     i64.const 0
-     i64.store
-     global.get $~lib/memory/__stack_pointer
-     i32.const 68
-     i32.const 13
-     call $~lib/rt/itcms/__new
-     local.tee $2
-     i32.store
-     global.get $~lib/memory/__stack_pointer
-     global.get $~lib/memory/__stack_pointer
-     local.get $2
-     i32.store offset=4
-     global.get $~lib/memory/__stack_pointer
-     i32.const 4
-     i32.sub
-     global.set $~lib/memory/__stack_pointer
-     global.get $~lib/memory/__stack_pointer
-     i32.const 2276
-     i32.lt_s
-     br_if $folding-inner00
-     global.get $~lib/memory/__stack_pointer
-     i32.const 0
-     i32.store
-     local.get $2
-     i32.eqz
-     if
-      global.get $~lib/memory/__stack_pointer
-      i32.const 0
-      i32.const 0
-      call $~lib/rt/itcms/__new
-      local.tee $2
-      i32.store
-     end
-     global.get $~lib/memory/__stack_pointer
-     i32.const 4
-     i32.add
-     global.set $~lib/memory/__stack_pointer
-     local.get $2
-     i32.store
-     global.get $~lib/memory/__stack_pointer
-     local.get $2
-     i32.store offset=4
-     local.get $2
-     i32.const 0
-     i32.store8
-     global.get $~lib/memory/__stack_pointer
-     local.get $2
-     i32.store offset=4
-     local.get $2
-     i32.const 0
-     i32.store16 offset=2
-     global.get $~lib/memory/__stack_pointer
-     local.get $2
-     i32.store offset=4
-     local.get $2
-     i32.const 0
-     i32.store offset=4
-     global.get $~lib/memory/__stack_pointer
-     local.get $2
-     i32.store offset=4
-     local.get $2
-     i64.const 0
-     i64.store offset=8
-     global.get $~lib/memory/__stack_pointer
-     local.get $2
-     i32.store offset=4
-     local.get $2
-     i32.const 0
-     i32.store8 offset=16
-     global.get $~lib/memory/__stack_pointer
-     local.get $2
-     i32.store offset=4
-     local.get $2
-     i32.const 0
-     i32.store16 offset=18
-     global.get $~lib/memory/__stack_pointer
-     local.get $2
-     i32.store offset=4
-     local.get $2
-     i32.const 0
-     i32.store offset=20
-     global.get $~lib/memory/__stack_pointer
-     local.get $2
-     i32.store offset=4
-     local.get $2
-     i64.const 0
-     i64.store offset=24
-     global.get $~lib/memory/__stack_pointer
-     local.get $2
-     i32.store offset=4
-     local.get $2
-     i32.const 0
-     i32.store offset=32
-     global.get $~lib/memory/__stack_pointer
-     local.get $2
-     i32.store offset=4
-     local.get $2
-     i32.const 0
-     i32.store offset=36
-     global.get $~lib/memory/__stack_pointer
-     local.get $2
-     i32.store offset=4
-     local.get $2
-     i32.const 0
-     i32.store8 offset=40
-     global.get $~lib/memory/__stack_pointer
-     local.get $2
-     i32.store offset=4
-     local.get $2
-     f32.const 0
-     f32.store offset=44
-     global.get $~lib/memory/__stack_pointer
-     local.get $2
-     i32.store offset=4
-     local.get $2
-     f64.const 0
-     f64.store offset=48
-     global.get $~lib/memory/__stack_pointer
-     local.get $2
-     i32.store offset=4
-     local.get $2
-     i32.const 0
-     i32.store offset=56
-     local.get $2
-     i32.const 0
-     i32.const 0
-     call $~lib/rt/itcms/__link
-     global.get $~lib/memory/__stack_pointer
-     local.get $2
-     i32.store offset=4
-     local.get $2
-     i32.const 0
-     i32.store offset=60
-     local.get $2
-     i32.const 0
-     i32.const 0
-     call $~lib/rt/itcms/__link
-     global.get $~lib/memory/__stack_pointer
-     local.get $2
-     i32.store offset=4
-     local.get $2
-     i32.const 0
-     i32.store offset=64
-     local.get $2
-     i32.const 0
-     i32.const 0
-     call $~lib/rt/itcms/__link
-     global.get $~lib/memory/__stack_pointer
-     i32.const 8
-     i32.add
-     global.set $~lib/memory/__stack_pointer
-     local.get $2
-     br $__inlined_func$bindings/esm/PlainObject#constructor$4
-    end
-    br $folding-inner1
-   end
+   global.get $~lib/memory/__stack_pointer
+   i32.const 8
+   i32.sub
+   global.set $~lib/memory/__stack_pointer
+   global.get $~lib/memory/__stack_pointer
+   i32.const 2276
+   i32.lt_s
+   br_if $folding-inner1
+   global.get $~lib/memory/__stack_pointer
+   i64.const 0
+   i64.store
+   global.get $~lib/memory/__stack_pointer
+   i32.const 68
+   i32.const 13
+   call $~lib/rt/itcms/__new
    local.tee $2
+   i32.store
+   global.get $~lib/memory/__stack_pointer
+   local.get $2
+   i32.store offset=4
+   global.get $~lib/memory/__stack_pointer
+   local.get $2
+   i32.store
+   global.get $~lib/memory/__stack_pointer
+   local.get $2
+   i32.store offset=4
+   local.get $2
+   i32.const 0
+   i32.store8
+   global.get $~lib/memory/__stack_pointer
+   local.get $2
+   i32.store offset=4
+   local.get $2
+   i32.const 0
+   i32.store16 offset=2
+   global.get $~lib/memory/__stack_pointer
+   local.get $2
+   i32.store offset=4
+   local.get $2
+   i32.const 0
+   i32.store offset=4
+   global.get $~lib/memory/__stack_pointer
+   local.get $2
+   i32.store offset=4
+   local.get $2
+   i64.const 0
+   i64.store offset=8
+   global.get $~lib/memory/__stack_pointer
+   local.get $2
+   i32.store offset=4
+   local.get $2
+   i32.const 0
+   i32.store8 offset=16
+   global.get $~lib/memory/__stack_pointer
+   local.get $2
+   i32.store offset=4
+   local.get $2
+   i32.const 0
+   i32.store16 offset=18
+   global.get $~lib/memory/__stack_pointer
+   local.get $2
+   i32.store offset=4
+   local.get $2
+   i32.const 0
+   i32.store offset=20
+   global.get $~lib/memory/__stack_pointer
+   local.get $2
+   i32.store offset=4
+   local.get $2
+   i64.const 0
+   i64.store offset=24
+   global.get $~lib/memory/__stack_pointer
+   local.get $2
+   i32.store offset=4
+   local.get $2
+   i32.const 0
+   i32.store offset=32
+   global.get $~lib/memory/__stack_pointer
+   local.get $2
+   i32.store offset=4
+   local.get $2
+   i32.const 0
+   i32.store offset=36
+   global.get $~lib/memory/__stack_pointer
+   local.get $2
+   i32.store offset=4
+   local.get $2
+   i32.const 0
+   i32.store8 offset=40
+   global.get $~lib/memory/__stack_pointer
+   local.get $2
+   i32.store offset=4
+   local.get $2
+   f32.const 0
+   f32.store offset=44
+   global.get $~lib/memory/__stack_pointer
+   local.get $2
+   i32.store offset=4
+   local.get $2
+   f64.const 0
+   f64.store offset=48
+   global.get $~lib/memory/__stack_pointer
+   local.get $2
+   i32.store offset=4
+   local.get $2
+   i32.const 0
+   i32.store offset=56
+   local.get $2
+   i32.const 0
+   i32.const 0
+   call $~lib/rt/itcms/__link
+   global.get $~lib/memory/__stack_pointer
+   local.get $2
+   i32.store offset=4
+   local.get $2
+   i32.const 0
+   i32.store offset=60
+   local.get $2
+   i32.const 0
+   i32.const 0
+   call $~lib/rt/itcms/__link
+   global.get $~lib/memory/__stack_pointer
+   local.get $2
+   i32.store offset=4
+   local.get $2
+   i32.const 0
+   i32.store offset=64
+   local.get $2
+   i32.const 0
+   i32.const 0
+   call $~lib/rt/itcms/__link
+   global.get $~lib/memory/__stack_pointer
+   i32.const 8
+   i32.add
+   global.set $~lib/memory/__stack_pointer
+   local.get $2
    i32.store
    global.get $~lib/memory/__stack_pointer
    local.get $2

--- a/tests/compiler/call-inferred.debug.wat
+++ b/tests/compiler/call-inferred.debug.wat
@@ -2291,6 +2291,9 @@
   call $call-inferred/Foo<i32>#constructor
   return
  )
+ (func $~lib/object/Object#raw_constructor (param $this i32) (result i32)
+  local.get $this
+ )
  (func $call-inferred/Bar#doSomething<i32> (param $this i32) (param $a i32) (result i32)
   local.get $a
   return
@@ -2402,6 +2405,34 @@
   global.set $~lib/memory/__stack_pointer
   local.get $2
  )
+ (func $call-inferred/Bar#raw_constructor (param $this i32) (result i32)
+  (local $1 i32)
+  global.get $~lib/memory/__stack_pointer
+  i32.const 8
+  i32.sub
+  global.set $~lib/memory/__stack_pointer
+  call $~stack_check
+  global.get $~lib/memory/__stack_pointer
+  i64.const 0
+  i64.store
+  global.get $~lib/memory/__stack_pointer
+  local.get $this
+  local.set $1
+  global.get $~lib/memory/__stack_pointer
+  local.get $1
+  i32.store
+  local.get $1
+  call $~lib/object/Object#raw_constructor
+  local.tee $this
+  i32.store offset=4
+  local.get $this
+  local.set $1
+  global.get $~lib/memory/__stack_pointer
+  i32.const 8
+  i32.add
+  global.set $~lib/memory/__stack_pointer
+  local.get $1
+ )
  (func $call-inferred/Bar#constructor (param $this i32) (result i32)
   (local $1 i32)
   global.get $~lib/memory/__stack_pointer
@@ -2429,7 +2460,7 @@
   local.get $1
   i32.store offset=4
   local.get $1
-  call $~lib/object/Object#constructor
+  call $~lib/object/Object#raw_constructor
   local.tee $this
   i32.store
   local.get $this
@@ -2439,6 +2470,35 @@
   i32.add
   global.set $~lib/memory/__stack_pointer
   local.get $1
+ )
+ (func $call-inferred/Baz<i32>#raw_constructor (param $this i32) (param $value i32) (result i32)
+  (local $2 i32)
+  global.get $~lib/memory/__stack_pointer
+  i32.const 8
+  i32.sub
+  global.set $~lib/memory/__stack_pointer
+  call $~stack_check
+  global.get $~lib/memory/__stack_pointer
+  i64.const 0
+  i64.store
+  global.get $~lib/memory/__stack_pointer
+  local.get $this
+  local.set $2
+  global.get $~lib/memory/__stack_pointer
+  local.get $2
+  i32.store
+  local.get $2
+  local.get $value
+  call $call-inferred/Foo<i32>#constructor
+  local.tee $this
+  i32.store offset=4
+  local.get $this
+  local.set $2
+  global.get $~lib/memory/__stack_pointer
+  i32.const 8
+  i32.add
+  global.set $~lib/memory/__stack_pointer
+  local.get $2
  )
  (func $call-inferred/Baz<i32>#constructor (param $this i32) (param $value i32) (result i32)
   (local $2 i32)

--- a/tests/compiler/call-inferred.release.wat
+++ b/tests/compiler/call-inferred.release.wat
@@ -1559,7 +1559,6 @@
  )
  (func $~start
   (local $0 i32)
-  (local $1 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 4
   i32.sub
@@ -1658,34 +1657,9 @@
    local.tee $0
    i32.store
    global.get $~lib/memory/__stack_pointer
-   global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store offset=4
    global.get $~lib/memory/__stack_pointer
-   i32.const 4
-   i32.sub
-   global.set $~lib/memory/__stack_pointer
-   global.get $~lib/memory/__stack_pointer
-   i32.const 1536
-   i32.lt_s
-   br_if $folding-inner0
-   global.get $~lib/memory/__stack_pointer
-   i32.const 0
-   i32.store
-   local.get $0
-   i32.eqz
-   if
-    global.get $~lib/memory/__stack_pointer
-    i32.const 0
-    i32.const 0
-    call $~lib/rt/itcms/__new
-    local.tee $0
-    i32.store
-   end
-   global.get $~lib/memory/__stack_pointer
-   i32.const 4
-   i32.add
-   global.set $~lib/memory/__stack_pointer
    local.get $0
    i32.store
    global.get $~lib/memory/__stack_pointer

--- a/tests/compiler/call-super.debug.wat
+++ b/tests/compiler/call-super.debug.wat
@@ -2260,6 +2260,9 @@
   local.get $b
   i32.store offset=4
  )
+ (func $~lib/object/Object#raw_constructor (param $this i32) (result i32)
+  local.get $this
+ )
  (func $call-super/C#set:a (param $this i32) (param $a i32)
   local.get $this
   local.get $a
@@ -2641,6 +2644,42 @@
   i32.add
   global.set $~lib/memory/__stack_pointer
  )
+ (func $call-super/C#raw_constructor (param $this i32) (result i32)
+  (local $1 i32)
+  global.get $~lib/memory/__stack_pointer
+  i32.const 8
+  i32.sub
+  global.set $~lib/memory/__stack_pointer
+  call $~stack_check
+  global.get $~lib/memory/__stack_pointer
+  i64.const 0
+  i64.store
+  global.get $~lib/memory/__stack_pointer
+  local.get $this
+  local.set $1
+  global.get $~lib/memory/__stack_pointer
+  local.get $1
+  i32.store
+  local.get $1
+  call $~lib/object/Object#raw_constructor
+  local.tee $this
+  i32.store offset=4
+  local.get $this
+  local.set $1
+  global.get $~lib/memory/__stack_pointer
+  local.get $1
+  i32.store
+  local.get $1
+  i32.const 1
+  call $call-super/C#set:a
+  local.get $this
+  local.set $1
+  global.get $~lib/memory/__stack_pointer
+  i32.const 8
+  i32.add
+  global.set $~lib/memory/__stack_pointer
+  local.get $1
+ )
  (func $call-super/C#constructor (param $this i32) (result i32)
   (local $1 i32)
   global.get $~lib/memory/__stack_pointer
@@ -2668,7 +2707,7 @@
   local.get $1
   i32.store offset=4
   local.get $1
-  call $~lib/object/Object#constructor
+  call $~lib/object/Object#raw_constructor
   local.tee $this
   i32.store
   local.get $this
@@ -2880,6 +2919,42 @@
   global.set $~lib/memory/__stack_pointer
   local.get $1
  )
+ (func $call-super/F#raw_constructor (param $this i32) (result i32)
+  (local $1 i32)
+  global.get $~lib/memory/__stack_pointer
+  i32.const 8
+  i32.sub
+  global.set $~lib/memory/__stack_pointer
+  call $~stack_check
+  global.get $~lib/memory/__stack_pointer
+  i64.const 0
+  i64.store
+  global.get $~lib/memory/__stack_pointer
+  local.get $this
+  local.set $1
+  global.get $~lib/memory/__stack_pointer
+  local.get $1
+  i32.store
+  local.get $1
+  call $call-super/E#constructor
+  local.tee $this
+  i32.store offset=4
+  local.get $this
+  local.set $1
+  global.get $~lib/memory/__stack_pointer
+  local.get $1
+  i32.store
+  local.get $1
+  i32.const 2
+  call $call-super/F#set:b
+  local.get $this
+  local.set $1
+  global.get $~lib/memory/__stack_pointer
+  i32.const 8
+  i32.add
+  global.set $~lib/memory/__stack_pointer
+  local.get $1
+ )
  (func $call-super/F#constructor (param $this i32) (result i32)
   (local $1 i32)
   global.get $~lib/memory/__stack_pointer
@@ -2983,6 +3058,42 @@
   i32.add
   global.set $~lib/memory/__stack_pointer
  )
+ (func $call-super/G#raw_constructor (param $this i32) (result i32)
+  (local $1 i32)
+  global.get $~lib/memory/__stack_pointer
+  i32.const 8
+  i32.sub
+  global.set $~lib/memory/__stack_pointer
+  call $~stack_check
+  global.get $~lib/memory/__stack_pointer
+  i64.const 0
+  i64.store
+  global.get $~lib/memory/__stack_pointer
+  local.get $this
+  local.set $1
+  global.get $~lib/memory/__stack_pointer
+  local.get $1
+  i32.store
+  local.get $1
+  call $~lib/object/Object#raw_constructor
+  local.tee $this
+  i32.store offset=4
+  local.get $this
+  local.set $1
+  global.get $~lib/memory/__stack_pointer
+  local.get $1
+  i32.store
+  local.get $1
+  i32.const 1
+  call $call-super/G#set:a
+  local.get $this
+  local.set $1
+  global.get $~lib/memory/__stack_pointer
+  i32.const 8
+  i32.add
+  global.set $~lib/memory/__stack_pointer
+  local.get $1
+ )
  (func $call-super/G#constructor (param $this i32) (result i32)
   (local $1 i32)
   global.get $~lib/memory/__stack_pointer
@@ -3010,7 +3121,7 @@
   local.get $1
   i32.store offset=4
   local.get $1
-  call $~lib/object/Object#constructor
+  call $~lib/object/Object#raw_constructor
   local.tee $this
   i32.store
   local.get $this
@@ -3021,6 +3132,42 @@
   local.get $1
   i32.const 1
   call $call-super/G#set:a
+  local.get $this
+  local.set $1
+  global.get $~lib/memory/__stack_pointer
+  i32.const 8
+  i32.add
+  global.set $~lib/memory/__stack_pointer
+  local.get $1
+ )
+ (func $call-super/H#raw_constructor (param $this i32) (result i32)
+  (local $1 i32)
+  global.get $~lib/memory/__stack_pointer
+  i32.const 8
+  i32.sub
+  global.set $~lib/memory/__stack_pointer
+  call $~stack_check
+  global.get $~lib/memory/__stack_pointer
+  i64.const 0
+  i64.store
+  global.get $~lib/memory/__stack_pointer
+  local.get $this
+  local.set $1
+  global.get $~lib/memory/__stack_pointer
+  local.get $1
+  i32.store
+  local.get $1
+  call $call-super/G#raw_constructor
+  local.tee $this
+  i32.store offset=4
+  local.get $this
+  local.set $1
+  global.get $~lib/memory/__stack_pointer
+  local.get $1
+  i32.store
+  local.get $1
+  i32.const 2
+  call $call-super/H#set:b
   local.get $this
   local.set $1
   global.get $~lib/memory/__stack_pointer
@@ -3056,7 +3203,7 @@
   local.get $1
   i32.store offset=4
   local.get $1
-  call $call-super/G#constructor
+  call $call-super/G#raw_constructor
   local.tee $this
   i32.store
   local.get $this
@@ -3160,6 +3307,42 @@
   local.get $1
   i32.const 1
   call $call-super/I#set:a
+  local.get $this
+  local.set $1
+  global.get $~lib/memory/__stack_pointer
+  i32.const 8
+  i32.add
+  global.set $~lib/memory/__stack_pointer
+  local.get $1
+ )
+ (func $call-super/J#raw_constructor (param $this i32) (result i32)
+  (local $1 i32)
+  global.get $~lib/memory/__stack_pointer
+  i32.const 8
+  i32.sub
+  global.set $~lib/memory/__stack_pointer
+  call $~stack_check
+  global.get $~lib/memory/__stack_pointer
+  i64.const 0
+  i64.store
+  global.get $~lib/memory/__stack_pointer
+  local.get $this
+  local.set $1
+  global.get $~lib/memory/__stack_pointer
+  local.get $1
+  i32.store
+  local.get $1
+  call $call-super/I#constructor
+  local.tee $this
+  i32.store offset=4
+  local.get $this
+  local.set $1
+  global.get $~lib/memory/__stack_pointer
+  local.get $1
+  i32.store
+  local.get $1
+  i32.const 2
+  call $call-super/J#set:b
   local.get $this
   local.set $1
   global.get $~lib/memory/__stack_pointer

--- a/tests/compiler/call-super.release.wat
+++ b/tests/compiler/call-super.release.wat
@@ -6,7 +6,6 @@
  (type $4 (func (param i32 i32 i32 i32)))
  (type $5 (func (param i32 i32 i64)))
  (type $6 (func (result i32)))
- (type $7 (func (param i32) (result i32)))
  (import "env" "abort" (func $~lib/builtins/abort (param i32 i32 i32 i32)))
  (global $~lib/rt/itcms/total (mut i32) (i32.const 0))
  (global $~lib/rt/itcms/threshold (mut i32) (i32.const 0))
@@ -118,7 +117,7 @@
     local.get $0
     global.set $~lib/rt/itcms/iter
    end
-   block $__inlined_func$~lib/rt/itcms/Object#unlink$158
+   block $__inlined_func$~lib/rt/itcms/Object#unlink$159
     local.get $1
     i32.load offset=4
     i32.const -4
@@ -142,7 +141,7 @@
       call $~lib/builtins/abort
       unreachable
      end
-     br $__inlined_func$~lib/rt/itcms/Object#unlink$158
+     br $__inlined_func$~lib/rt/itcms/Object#unlink$159
     end
     local.get $1
     i32.load offset=8
@@ -1782,8 +1781,6 @@
    i32.store offset=4
    global.get $~lib/memory/__stack_pointer
    local.get $0
-   call $~lib/object/Object#constructor
-   local.tee $0
    i32.store
    global.get $~lib/memory/__stack_pointer
    local.get $0
@@ -2021,11 +2018,11 @@
    i32.const 8
    i32.const 10
    call $~lib/rt/itcms/__new
-   local.tee $0
+   local.tee $1
    i32.store
    global.get $~lib/memory/__stack_pointer
    global.get $~lib/memory/__stack_pointer
-   local.get $0
+   local.get $1
    i32.store offset=4
    global.get $~lib/memory/__stack_pointer
    i32.const 8
@@ -2038,52 +2035,40 @@
    global.get $~lib/memory/__stack_pointer
    i64.const 0
    i64.store
-   local.get $0
-   i32.eqz
-   if
-    global.get $~lib/memory/__stack_pointer
-    i32.const 4
-    i32.const 11
-    call $~lib/rt/itcms/__new
-    local.tee $0
-    i32.store
-   end
    global.get $~lib/memory/__stack_pointer
-   local.get $0
-   i32.store offset=4
-   global.get $~lib/memory/__stack_pointer
-   local.get $0
-   call $~lib/object/Object#constructor
-   local.tee $0
+   local.get $1
    i32.store
    global.get $~lib/memory/__stack_pointer
-   local.get $0
+   local.get $1
    i32.store offset=4
-   local.get $0
+   global.get $~lib/memory/__stack_pointer
+   local.get $1
+   i32.store
+   local.get $1
    i32.const 1
    i32.store
    global.get $~lib/memory/__stack_pointer
    i32.const 8
    i32.add
    global.set $~lib/memory/__stack_pointer
-   local.get $0
+   local.get $1
    i32.store
    global.get $~lib/memory/__stack_pointer
-   local.get $0
+   local.get $1
    i32.store offset=4
-   local.get $0
+   local.get $1
    i32.const 2
    i32.store offset=4
    global.get $~lib/memory/__stack_pointer
    i32.const 8
    i32.add
    global.set $~lib/memory/__stack_pointer
-   local.get $0
+   local.get $1
    i32.store
    global.get $~lib/memory/__stack_pointer
-   local.get $0
+   local.get $1
    i32.store offset=4
-   local.get $0
+   local.get $1
    i32.load
    i32.const 1
    i32.ne
@@ -2096,9 +2081,9 @@
     unreachable
    end
    global.get $~lib/memory/__stack_pointer
-   local.get $0
+   local.get $1
    i32.store offset=4
-   local.get $0
+   local.get $1
    i32.load offset=4
    i32.const 2
    i32.ne
@@ -2292,40 +2277,5 @@
  )
  (func $~start
   call $start:call-super
- )
- (func $~lib/object/Object#constructor (param $0 i32) (result i32)
-  global.get $~lib/memory/__stack_pointer
-  i32.const 4
-  i32.sub
-  global.set $~lib/memory/__stack_pointer
-  global.get $~lib/memory/__stack_pointer
-  i32.const 1548
-  i32.lt_s
-  if
-   i32.const 34336
-   i32.const 34384
-   i32.const 1
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  global.get $~lib/memory/__stack_pointer
-  i32.const 0
-  i32.store
-  local.get $0
-  i32.eqz
-  if
-   global.get $~lib/memory/__stack_pointer
-   i32.const 0
-   i32.const 0
-   call $~lib/rt/itcms/__new
-   local.tee $0
-   i32.store
-  end
-  global.get $~lib/memory/__stack_pointer
-  i32.const 4
-  i32.add
-  global.set $~lib/memory/__stack_pointer
-  local.get $0
  )
 )

--- a/tests/compiler/class-implements.debug.wat
+++ b/tests/compiler/class-implements.debug.wat
@@ -49,6 +49,9 @@
  (elem $0 (i32.const 1))
  (export "memory" (memory $0))
  (start $~start)
+ (func $~lib/object/Object#raw_constructor (param $this i32) (result i32)
+  local.get $this
+ )
  (func $~lib/rt/itcms/Object#set:nextWithColor (param $this i32) (param $nextWithColor i32)
   local.get $this
   local.get $nextWithColor
@@ -2795,6 +2798,34 @@
    unreachable
   end
  )
+ (func $class-implements/A#raw_constructor (param $this i32) (result i32)
+  (local $1 i32)
+  global.get $~lib/memory/__stack_pointer
+  i32.const 8
+  i32.sub
+  global.set $~lib/memory/__stack_pointer
+  call $~stack_check
+  global.get $~lib/memory/__stack_pointer
+  i64.const 0
+  i64.store
+  global.get $~lib/memory/__stack_pointer
+  local.get $this
+  local.set $1
+  global.get $~lib/memory/__stack_pointer
+  local.get $1
+  i32.store
+  local.get $1
+  call $~lib/object/Object#raw_constructor
+  local.tee $this
+  i32.store offset=4
+  local.get $this
+  local.set $1
+  global.get $~lib/memory/__stack_pointer
+  i32.const 8
+  i32.add
+  global.set $~lib/memory/__stack_pointer
+  local.get $1
+ )
  (func $class-implements/A#constructor (param $this i32) (result i32)
   (local $1 i32)
   global.get $~lib/memory/__stack_pointer
@@ -2822,9 +2853,37 @@
   local.get $1
   i32.store offset=4
   local.get $1
-  call $~lib/object/Object#constructor
+  call $~lib/object/Object#raw_constructor
   local.tee $this
   i32.store
+  local.get $this
+  local.set $1
+  global.get $~lib/memory/__stack_pointer
+  i32.const 8
+  i32.add
+  global.set $~lib/memory/__stack_pointer
+  local.get $1
+ )
+ (func $class-implements/B#raw_constructor (param $this i32) (result i32)
+  (local $1 i32)
+  global.get $~lib/memory/__stack_pointer
+  i32.const 8
+  i32.sub
+  global.set $~lib/memory/__stack_pointer
+  call $~stack_check
+  global.get $~lib/memory/__stack_pointer
+  i64.const 0
+  i64.store
+  global.get $~lib/memory/__stack_pointer
+  local.get $this
+  local.set $1
+  global.get $~lib/memory/__stack_pointer
+  local.get $1
+  i32.store
+  local.get $1
+  call $~lib/object/Object#raw_constructor
+  local.tee $this
+  i32.store offset=4
   local.get $this
   local.set $1
   global.get $~lib/memory/__stack_pointer
@@ -2860,9 +2919,37 @@
   local.get $1
   i32.store offset=4
   local.get $1
-  call $~lib/object/Object#constructor
+  call $~lib/object/Object#raw_constructor
   local.tee $this
   i32.store
+  local.get $this
+  local.set $1
+  global.get $~lib/memory/__stack_pointer
+  i32.const 8
+  i32.add
+  global.set $~lib/memory/__stack_pointer
+  local.get $1
+ )
+ (func $class-implements/C#raw_constructor (param $this i32) (result i32)
+  (local $1 i32)
+  global.get $~lib/memory/__stack_pointer
+  i32.const 8
+  i32.sub
+  global.set $~lib/memory/__stack_pointer
+  call $~stack_check
+  global.get $~lib/memory/__stack_pointer
+  i64.const 0
+  i64.store
+  global.get $~lib/memory/__stack_pointer
+  local.get $this
+  local.set $1
+  global.get $~lib/memory/__stack_pointer
+  local.get $1
+  i32.store
+  local.get $1
+  call $class-implements/B#raw_constructor
+  local.tee $this
+  i32.store offset=4
   local.get $this
   local.set $1
   global.get $~lib/memory/__stack_pointer
@@ -2898,9 +2985,37 @@
   local.get $1
   i32.store offset=4
   local.get $1
-  call $class-implements/B#constructor
+  call $class-implements/B#raw_constructor
   local.tee $this
   i32.store
+  local.get $this
+  local.set $1
+  global.get $~lib/memory/__stack_pointer
+  i32.const 8
+  i32.add
+  global.set $~lib/memory/__stack_pointer
+  local.get $1
+ )
+ (func $class-implements/D#raw_constructor (param $this i32) (result i32)
+  (local $1 i32)
+  global.get $~lib/memory/__stack_pointer
+  i32.const 8
+  i32.sub
+  global.set $~lib/memory/__stack_pointer
+  call $~stack_check
+  global.get $~lib/memory/__stack_pointer
+  i64.const 0
+  i64.store
+  global.get $~lib/memory/__stack_pointer
+  local.get $this
+  local.set $1
+  global.get $~lib/memory/__stack_pointer
+  local.get $1
+  i32.store
+  local.get $1
+  call $~lib/object/Object#raw_constructor
+  local.tee $this
+  i32.store offset=4
   local.get $this
   local.set $1
   global.get $~lib/memory/__stack_pointer
@@ -2936,9 +3051,37 @@
   local.get $1
   i32.store offset=4
   local.get $1
-  call $~lib/object/Object#constructor
+  call $~lib/object/Object#raw_constructor
   local.tee $this
   i32.store
+  local.get $this
+  local.set $1
+  global.get $~lib/memory/__stack_pointer
+  i32.const 8
+  i32.add
+  global.set $~lib/memory/__stack_pointer
+  local.get $1
+ )
+ (func $class-implements/E#raw_constructor (param $this i32) (result i32)
+  (local $1 i32)
+  global.get $~lib/memory/__stack_pointer
+  i32.const 8
+  i32.sub
+  global.set $~lib/memory/__stack_pointer
+  call $~stack_check
+  global.get $~lib/memory/__stack_pointer
+  i64.const 0
+  i64.store
+  global.get $~lib/memory/__stack_pointer
+  local.get $this
+  local.set $1
+  global.get $~lib/memory/__stack_pointer
+  local.get $1
+  i32.store
+  local.get $1
+  call $class-implements/D#raw_constructor
+  local.tee $this
+  i32.store offset=4
   local.get $this
   local.set $1
   global.get $~lib/memory/__stack_pointer
@@ -2974,9 +3117,37 @@
   local.get $1
   i32.store offset=4
   local.get $1
-  call $class-implements/D#constructor
+  call $class-implements/D#raw_constructor
   local.tee $this
   i32.store
+  local.get $this
+  local.set $1
+  global.get $~lib/memory/__stack_pointer
+  i32.const 8
+  i32.add
+  global.set $~lib/memory/__stack_pointer
+  local.get $1
+ )
+ (func $class-implements/F#raw_constructor (param $this i32) (result i32)
+  (local $1 i32)
+  global.get $~lib/memory/__stack_pointer
+  i32.const 8
+  i32.sub
+  global.set $~lib/memory/__stack_pointer
+  call $~stack_check
+  global.get $~lib/memory/__stack_pointer
+  i64.const 0
+  i64.store
+  global.get $~lib/memory/__stack_pointer
+  local.get $this
+  local.set $1
+  global.get $~lib/memory/__stack_pointer
+  local.get $1
+  i32.store
+  local.get $1
+  call $class-implements/D#raw_constructor
+  local.tee $this
+  i32.store offset=4
   local.get $this
   local.set $1
   global.get $~lib/memory/__stack_pointer
@@ -3012,9 +3183,37 @@
   local.get $1
   i32.store offset=4
   local.get $1
-  call $class-implements/D#constructor
+  call $class-implements/D#raw_constructor
   local.tee $this
   i32.store
+  local.get $this
+  local.set $1
+  global.get $~lib/memory/__stack_pointer
+  i32.const 8
+  i32.add
+  global.set $~lib/memory/__stack_pointer
+  local.get $1
+ )
+ (func $class-implements/G#raw_constructor (param $this i32) (result i32)
+  (local $1 i32)
+  global.get $~lib/memory/__stack_pointer
+  i32.const 8
+  i32.sub
+  global.set $~lib/memory/__stack_pointer
+  call $~stack_check
+  global.get $~lib/memory/__stack_pointer
+  i64.const 0
+  i64.store
+  global.get $~lib/memory/__stack_pointer
+  local.get $this
+  local.set $1
+  global.get $~lib/memory/__stack_pointer
+  local.get $1
+  i32.store
+  local.get $1
+  call $~lib/object/Object#raw_constructor
+  local.tee $this
+  i32.store offset=4
   local.get $this
   local.set $1
   global.get $~lib/memory/__stack_pointer
@@ -3050,9 +3249,45 @@
   local.get $1
   i32.store offset=4
   local.get $1
-  call $~lib/object/Object#constructor
+  call $~lib/object/Object#raw_constructor
   local.tee $this
   i32.store
+  local.get $this
+  local.set $1
+  global.get $~lib/memory/__stack_pointer
+  i32.const 8
+  i32.add
+  global.set $~lib/memory/__stack_pointer
+  local.get $1
+ )
+ (func $class-implements/A2#raw_constructor (param $this i32) (result i32)
+  (local $1 i32)
+  global.get $~lib/memory/__stack_pointer
+  i32.const 8
+  i32.sub
+  global.set $~lib/memory/__stack_pointer
+  call $~stack_check
+  global.get $~lib/memory/__stack_pointer
+  i64.const 0
+  i64.store
+  global.get $~lib/memory/__stack_pointer
+  local.get $this
+  local.set $1
+  global.get $~lib/memory/__stack_pointer
+  local.get $1
+  i32.store
+  local.get $1
+  call $~lib/object/Object#raw_constructor
+  local.tee $this
+  i32.store offset=4
+  local.get $this
+  local.set $1
+  global.get $~lib/memory/__stack_pointer
+  local.get $1
+  i32.store
+  local.get $1
+  i32.const 1
+  call $class-implements/A2#set:foo
   local.get $this
   local.set $1
   global.get $~lib/memory/__stack_pointer
@@ -3088,7 +3323,7 @@
   local.get $1
   i32.store offset=4
   local.get $1
-  call $~lib/object/Object#constructor
+  call $~lib/object/Object#raw_constructor
   local.tee $this
   i32.store
   local.get $this
@@ -3099,6 +3334,42 @@
   local.get $1
   i32.const 1
   call $class-implements/A2#set:foo
+  local.get $this
+  local.set $1
+  global.get $~lib/memory/__stack_pointer
+  i32.const 8
+  i32.add
+  global.set $~lib/memory/__stack_pointer
+  local.get $1
+ )
+ (func $class-implements/A3#raw_constructor (param $this i32) (result i32)
+  (local $1 i32)
+  global.get $~lib/memory/__stack_pointer
+  i32.const 8
+  i32.sub
+  global.set $~lib/memory/__stack_pointer
+  call $~stack_check
+  global.get $~lib/memory/__stack_pointer
+  i64.const 0
+  i64.store
+  global.get $~lib/memory/__stack_pointer
+  local.get $this
+  local.set $1
+  global.get $~lib/memory/__stack_pointer
+  local.get $1
+  i32.store
+  local.get $1
+  call $class-implements/A2#raw_constructor
+  local.tee $this
+  i32.store offset=4
+  local.get $this
+  local.set $1
+  global.get $~lib/memory/__stack_pointer
+  local.get $1
+  i32.store
+  local.get $1
+  i32.const 5
+  call $class-implements/A3#set:foo
   local.get $this
   local.set $1
   global.get $~lib/memory/__stack_pointer
@@ -3134,7 +3405,7 @@
   local.get $1
   i32.store offset=4
   local.get $1
-  call $class-implements/A2#constructor
+  call $class-implements/A2#raw_constructor
   local.tee $this
   i32.store
   local.get $this
@@ -3145,6 +3416,42 @@
   local.get $1
   i32.const 5
   call $class-implements/A3#set:foo
+  local.get $this
+  local.set $1
+  global.get $~lib/memory/__stack_pointer
+  i32.const 8
+  i32.add
+  global.set $~lib/memory/__stack_pointer
+  local.get $1
+ )
+ (func $class-implements/A4#raw_constructor (param $this i32) (result i32)
+  (local $1 i32)
+  global.get $~lib/memory/__stack_pointer
+  i32.const 8
+  i32.sub
+  global.set $~lib/memory/__stack_pointer
+  call $~stack_check
+  global.get $~lib/memory/__stack_pointer
+  i64.const 0
+  i64.store
+  global.get $~lib/memory/__stack_pointer
+  local.get $this
+  local.set $1
+  global.get $~lib/memory/__stack_pointer
+  local.get $1
+  i32.store
+  local.get $1
+  call $class-implements/A2#raw_constructor
+  local.tee $this
+  i32.store offset=4
+  local.get $this
+  local.set $1
+  global.get $~lib/memory/__stack_pointer
+  local.get $1
+  i32.store
+  local.get $1
+  i32.const 7
+  call $class-implements/A4#set:foo
   local.get $this
   local.set $1
   global.get $~lib/memory/__stack_pointer
@@ -3180,7 +3487,7 @@
   local.get $1
   i32.store offset=4
   local.get $1
-  call $class-implements/A2#constructor
+  call $class-implements/A2#raw_constructor
   local.tee $this
   i32.store
   local.get $this
@@ -3191,6 +3498,42 @@
   local.get $1
   i32.const 7
   call $class-implements/A4#set:foo
+  local.get $this
+  local.set $1
+  global.get $~lib/memory/__stack_pointer
+  i32.const 8
+  i32.add
+  global.set $~lib/memory/__stack_pointer
+  local.get $1
+ )
+ (func $class-implements/B2#raw_constructor (param $this i32) (result i32)
+  (local $1 i32)
+  global.get $~lib/memory/__stack_pointer
+  i32.const 8
+  i32.sub
+  global.set $~lib/memory/__stack_pointer
+  call $~stack_check
+  global.get $~lib/memory/__stack_pointer
+  i64.const 0
+  i64.store
+  global.get $~lib/memory/__stack_pointer
+  local.get $this
+  local.set $1
+  global.get $~lib/memory/__stack_pointer
+  local.get $1
+  i32.store
+  local.get $1
+  call $~lib/object/Object#raw_constructor
+  local.tee $this
+  i32.store offset=4
+  local.get $this
+  local.set $1
+  global.get $~lib/memory/__stack_pointer
+  local.get $1
+  i32.store
+  local.get $1
+  i32.const 3
+  call $class-implements/B2#set:_foo
   local.get $this
   local.set $1
   global.get $~lib/memory/__stack_pointer
@@ -3226,7 +3569,7 @@
   local.get $1
   i32.store offset=4
   local.get $1
-  call $~lib/object/Object#constructor
+  call $~lib/object/Object#raw_constructor
   local.tee $this
   i32.store
   local.get $this
@@ -3270,6 +3613,42 @@
   local.get $1
   return
  )
+ (func $class-implements/B3#raw_constructor (param $this i32) (result i32)
+  (local $1 i32)
+  global.get $~lib/memory/__stack_pointer
+  i32.const 8
+  i32.sub
+  global.set $~lib/memory/__stack_pointer
+  call $~stack_check
+  global.get $~lib/memory/__stack_pointer
+  i64.const 0
+  i64.store
+  global.get $~lib/memory/__stack_pointer
+  local.get $this
+  local.set $1
+  global.get $~lib/memory/__stack_pointer
+  local.get $1
+  i32.store
+  local.get $1
+  call $class-implements/B2#raw_constructor
+  local.tee $this
+  i32.store offset=4
+  local.get $this
+  local.set $1
+  global.get $~lib/memory/__stack_pointer
+  local.get $1
+  i32.store
+  local.get $1
+  i32.const 9
+  call $class-implements/B3#set:_foo2
+  local.get $this
+  local.set $1
+  global.get $~lib/memory/__stack_pointer
+  i32.const 8
+  i32.add
+  global.set $~lib/memory/__stack_pointer
+  local.get $1
+ )
  (func $class-implements/B3#constructor (param $this i32) (result i32)
   (local $1 i32)
   global.get $~lib/memory/__stack_pointer
@@ -3297,7 +3676,7 @@
   local.get $1
   i32.store offset=4
   local.get $1
-  call $class-implements/B2#constructor
+  call $class-implements/B2#raw_constructor
   local.tee $this
   i32.store
   local.get $this
@@ -3341,6 +3720,42 @@
   local.get $1
   return
  )
+ (func $class-implements/B4#raw_constructor (param $this i32) (result i32)
+  (local $1 i32)
+  global.get $~lib/memory/__stack_pointer
+  i32.const 8
+  i32.sub
+  global.set $~lib/memory/__stack_pointer
+  call $~stack_check
+  global.get $~lib/memory/__stack_pointer
+  i64.const 0
+  i64.store
+  global.get $~lib/memory/__stack_pointer
+  local.get $this
+  local.set $1
+  global.get $~lib/memory/__stack_pointer
+  local.get $1
+  i32.store
+  local.get $1
+  call $class-implements/B2#raw_constructor
+  local.tee $this
+  i32.store offset=4
+  local.get $this
+  local.set $1
+  global.get $~lib/memory/__stack_pointer
+  local.get $1
+  i32.store
+  local.get $1
+  i32.const 11
+  call $class-implements/B4#set:_foo2
+  local.get $this
+  local.set $1
+  global.get $~lib/memory/__stack_pointer
+  i32.const 8
+  i32.add
+  global.set $~lib/memory/__stack_pointer
+  local.get $1
+ )
  (func $class-implements/B4#constructor (param $this i32) (result i32)
   (local $1 i32)
   global.get $~lib/memory/__stack_pointer
@@ -3368,7 +3783,7 @@
   local.get $1
   i32.store offset=4
   local.get $1
-  call $class-implements/B2#constructor
+  call $class-implements/B2#raw_constructor
   local.tee $this
   i32.store
   local.get $this

--- a/tests/compiler/class-implements.release.wat
+++ b/tests/compiler/class-implements.release.wat
@@ -167,7 +167,7 @@
     local.get $0
     global.set $~lib/rt/itcms/iter
    end
-   block $__inlined_func$~lib/rt/itcms/Object#unlink$174
+   block $__inlined_func$~lib/rt/itcms/Object#unlink$188
     local.get $1
     i32.load offset=4
     i32.const -4
@@ -191,7 +191,7 @@
       call $~lib/builtins/abort
       unreachable
      end
-     br $__inlined_func$~lib/rt/itcms/Object#unlink$174
+     br $__inlined_func$~lib/rt/itcms/Object#unlink$188
     end
     local.get $1
     i32.load offset=8
@@ -1782,7 +1782,7 @@
  (func $~start
   call $start:class-implements
  )
- (func $class-implements/D#constructor (param $0 i32) (result i32)
+ (func $class-implements/A#raw_constructor (param $0 i32) (result i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 8
   i32.sub
@@ -1801,24 +1801,12 @@
   global.get $~lib/memory/__stack_pointer
   i64.const 0
   i64.store
+  global.get $~lib/memory/__stack_pointer
   local.get $0
-  i32.eqz
-  if
-   global.get $~lib/memory/__stack_pointer
-   i32.const 0
-   i32.const 8
-   call $~lib/rt/itcms/__new
-   local.tee $0
-   i32.store
-  end
+  i32.store
   global.get $~lib/memory/__stack_pointer
   local.get $0
   i32.store offset=4
-  global.get $~lib/memory/__stack_pointer
-  local.get $0
-  call $~lib/object/Object#constructor
-  local.tee $0
-  i32.store
   global.get $~lib/memory/__stack_pointer
   i32.const 8
   i32.add
@@ -1856,7 +1844,7 @@
   i32.store offset=4
   global.get $~lib/memory/__stack_pointer
   local.get $0
-  call $class-implements/D#constructor
+  call $class-implements/A#raw_constructor
   local.tee $0
   i32.store
   global.get $~lib/memory/__stack_pointer
@@ -1865,7 +1853,7 @@
   global.set $~lib/memory/__stack_pointer
   local.get $0
  )
- (func $class-implements/A2#constructor (param $0 i32) (result i32)
+ (func $class-implements/A2#raw_constructor (param $0 i32) (result i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 8
   i32.sub
@@ -1884,27 +1872,15 @@
   global.get $~lib/memory/__stack_pointer
   i64.const 0
   i64.store
-  local.get $0
-  i32.eqz
-  if
-   global.get $~lib/memory/__stack_pointer
-   i32.const 4
-   i32.const 14
-   call $~lib/rt/itcms/__new
-   local.tee $0
-   i32.store
-  end
   global.get $~lib/memory/__stack_pointer
   local.get $0
-  i32.store offset=4
-  global.get $~lib/memory/__stack_pointer
-  local.get $0
-  call $~lib/object/Object#constructor
-  local.tee $0
   i32.store
   global.get $~lib/memory/__stack_pointer
   local.get $0
   i32.store offset=4
+  global.get $~lib/memory/__stack_pointer
+  local.get $0
+  i32.store
   local.get $0
   i32.const 1
   i32.store
@@ -1914,7 +1890,7 @@
   global.set $~lib/memory/__stack_pointer
   local.get $0
  )
- (func $class-implements/B2#constructor (param $0 i32) (result i32)
+ (func $class-implements/B2#raw_constructor (param $0 i32) (result i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 8
   i32.sub
@@ -1933,27 +1909,15 @@
   global.get $~lib/memory/__stack_pointer
   i64.const 0
   i64.store
-  local.get $0
-  i32.eqz
-  if
-   global.get $~lib/memory/__stack_pointer
-   i32.const 4
-   i32.const 18
-   call $~lib/rt/itcms/__new
-   local.tee $0
-   i32.store
-  end
   global.get $~lib/memory/__stack_pointer
   local.get $0
-  i32.store offset=4
-  global.get $~lib/memory/__stack_pointer
-  local.get $0
-  call $~lib/object/Object#constructor
-  local.tee $0
   i32.store
   global.get $~lib/memory/__stack_pointer
   local.get $0
   i32.store offset=4
+  global.get $~lib/memory/__stack_pointer
+  local.get $0
+  i32.store
   local.get $0
   i32.const 3
   i32.store
@@ -2091,8 +2055,6 @@
    i32.store offset=4
    global.get $~lib/memory/__stack_pointer
    local.get $0
-   call $~lib/object/Object#constructor
-   local.tee $0
    i32.store
    global.get $~lib/memory/__stack_pointer
    i32.const 8
@@ -2121,9 +2083,22 @@
    local.tee $0
    i32.store
    global.get $~lib/memory/__stack_pointer
-   global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store offset=4
+   global.get $~lib/memory/__stack_pointer
+   local.get $0
+   call $class-implements/A#raw_constructor
+   local.tee $0
+   i32.store
+   global.get $~lib/memory/__stack_pointer
+   i32.const 8
+   i32.add
+   global.set $~lib/memory/__stack_pointer
+   local.get $0
+   global.set $class-implements/c
+   global.get $~lib/memory/__stack_pointer
+   global.get $class-implements/c
+   i32.store
    global.get $~lib/memory/__stack_pointer
    i32.const 8
    i32.sub
@@ -2135,43 +2110,25 @@
    global.get $~lib/memory/__stack_pointer
    i64.const 0
    i64.store
-   local.get $0
-   i32.eqz
-   if
-    global.get $~lib/memory/__stack_pointer
-    i32.const 0
-    i32.const 7
-    call $~lib/rt/itcms/__new
-    local.tee $0
-    i32.store
-   end
+   global.get $~lib/memory/__stack_pointer
+   i32.const 0
+   i32.const 8
+   call $~lib/rt/itcms/__new
+   local.tee $0
+   i32.store
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store offset=4
    global.get $~lib/memory/__stack_pointer
    local.get $0
-   call $~lib/object/Object#constructor
-   local.tee $0
    i32.store
    global.get $~lib/memory/__stack_pointer
    i32.const 8
    i32.add
    global.set $~lib/memory/__stack_pointer
    local.get $0
-   i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 8
-   i32.add
-   global.set $~lib/memory/__stack_pointer
-   local.get $0
-   global.set $class-implements/c
-   global.get $~lib/memory/__stack_pointer
-   global.get $class-implements/c
-   i32.store
-   i32.const 0
-   call $class-implements/D#constructor
    global.set $class-implements/d
-   block $__inlined_func$class-implements/D#foo@override$163 (result i32)
+   block $__inlined_func$class-implements/D#foo@override$175 (result i32)
     global.get $~lib/memory/__stack_pointer
     global.get $class-implements/d
     local.tee $0
@@ -2183,7 +2140,7 @@
     i32.load
     i32.const 11
     i32.eq
-    br_if $__inlined_func$class-implements/D#foo@override$163
+    br_if $__inlined_func$class-implements/D#foo@override$175
     drop
     i32.const 3
    end
@@ -2219,7 +2176,7 @@
    i32.store offset=4
    global.get $~lib/memory/__stack_pointer
    local.get $0
-   call $class-implements/D#constructor
+   call $class-implements/A#raw_constructor
    local.tee $0
    i32.store
    global.get $~lib/memory/__stack_pointer
@@ -2228,7 +2185,7 @@
    global.set $~lib/memory/__stack_pointer
    local.get $0
    global.set $class-implements/e
-   block $__inlined_func$class-implements/D#foo@override$165 (result i32)
+   block $__inlined_func$class-implements/D#foo@override$177 (result i32)
     global.get $~lib/memory/__stack_pointer
     global.get $class-implements/e
     local.tee $0
@@ -2240,7 +2197,7 @@
     i32.load
     i32.const 11
     i32.eq
-    br_if $__inlined_func$class-implements/D#foo@override$165
+    br_if $__inlined_func$class-implements/D#foo@override$177
     drop
     i32.const 3
    end
@@ -2261,7 +2218,7 @@
    i32.store
    call $class-implements/F#constructor
    global.set $class-implements/g
-   block $__inlined_func$class-implements/D#foo@override$166 (result i32)
+   block $__inlined_func$class-implements/D#foo@override$178 (result i32)
     global.get $~lib/memory/__stack_pointer
     global.get $class-implements/g
     local.tee $0
@@ -2273,7 +2230,7 @@
     i32.load
     i32.const 11
     i32.eq
-    br_if $__inlined_func$class-implements/D#foo@override$166
+    br_if $__inlined_func$class-implements/D#foo@override$178
     drop
     i32.const 3
    end
@@ -2293,7 +2250,7 @@
    global.get $class-implements/h
    local.tee $0
    i32.store
-   block $__inlined_func$class-implements/I#foo@override$167
+   block $__inlined_func$class-implements/I#foo@override$179
     block $default12
      block $case3
       block $case2
@@ -2309,19 +2266,19 @@
         end
         i32.const 4
         local.set $0
-        br $__inlined_func$class-implements/I#foo@override$167
+        br $__inlined_func$class-implements/I#foo@override$179
        end
        i32.const 1
        local.set $0
-       br $__inlined_func$class-implements/I#foo@override$167
+       br $__inlined_func$class-implements/I#foo@override$179
       end
       i32.const 2
       local.set $0
-      br $__inlined_func$class-implements/I#foo@override$167
+      br $__inlined_func$class-implements/I#foo@override$179
      end
      i32.const 3
      local.set $0
-     br $__inlined_func$class-implements/I#foo@override$167
+     br $__inlined_func$class-implements/I#foo@override$179
     end
     unreachable
    end
@@ -2358,8 +2315,6 @@
    i32.store offset=4
    global.get $~lib/memory/__stack_pointer
    local.get $0
-   call $~lib/object/Object#constructor
-   local.tee $0
    i32.store
    global.get $~lib/memory/__stack_pointer
    i32.const 8
@@ -2368,7 +2323,7 @@
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store
-   block $__inlined_func$class-implements/J#foo@override$169
+   block $__inlined_func$class-implements/J#foo@override$181
     block $default14
      block $case315
       block $case216
@@ -2386,15 +2341,15 @@
        end
        i32.const 4
        local.set $0
-       br $__inlined_func$class-implements/J#foo@override$169
+       br $__inlined_func$class-implements/J#foo@override$181
       end
       i32.const 3
       local.set $0
-      br $__inlined_func$class-implements/J#foo@override$169
+      br $__inlined_func$class-implements/J#foo@override$181
      end
      i32.const 1
      local.set $0
-     br $__inlined_func$class-implements/J#foo@override$169
+     br $__inlined_func$class-implements/J#foo@override$181
     end
     unreachable
    end
@@ -2410,14 +2365,45 @@
     unreachable
    end
    global.get $~lib/memory/__stack_pointer
-   i32.const 0
-   call $class-implements/A2#constructor
-   local.tee $0
+   global.get $~lib/memory/__stack_pointer
+   i32.const 8
+   i32.sub
+   global.set $~lib/memory/__stack_pointer
+   global.get $~lib/memory/__stack_pointer
+   i32.const 1592
+   i32.lt_s
+   br_if $folding-inner0
+   global.get $~lib/memory/__stack_pointer
+   i64.const 0
+   i64.store
+   global.get $~lib/memory/__stack_pointer
+   i32.const 4
+   i32.const 14
+   call $~lib/rt/itcms/__new
+   local.tee $1
+   i32.store
+   global.get $~lib/memory/__stack_pointer
+   local.get $1
    i32.store offset=4
    global.get $~lib/memory/__stack_pointer
-   local.get $0
+   local.get $1
    i32.store
-   local.get $0
+   global.get $~lib/memory/__stack_pointer
+   local.get $1
+   i32.store offset=4
+   local.get $1
+   i32.const 1
+   i32.store
+   global.get $~lib/memory/__stack_pointer
+   i32.const 8
+   i32.add
+   global.set $~lib/memory/__stack_pointer
+   local.get $1
+   i32.store offset=4
+   global.get $~lib/memory/__stack_pointer
+   local.get $1
+   i32.store
+   local.get $1
    i32.load
    i32.const 1
    i32.ne
@@ -2430,9 +2416,9 @@
     unreachable
    end
    global.get $~lib/memory/__stack_pointer
-   local.get $0
+   local.get $1
    i32.store
-   local.get $0
+   local.get $1
    call $class-implements/I2#get:foo@override
    i32.const 1
    i32.ne
@@ -2445,15 +2431,15 @@
     unreachable
    end
    global.get $~lib/memory/__stack_pointer
-   local.get $0
+   local.get $1
    i32.store
-   local.get $0
+   local.get $1
    i32.const 2
    call $class-implements/I2#set:foo@override
    global.get $~lib/memory/__stack_pointer
-   local.get $0
+   local.get $1
    i32.store
-   local.get $0
+   local.get $1
    i32.load
    i32.const 2
    i32.ne
@@ -2466,9 +2452,9 @@
     unreachable
    end
    global.get $~lib/memory/__stack_pointer
-   local.get $0
+   local.get $1
    i32.store
-   local.get $0
+   local.get $1
    call $class-implements/I2#get:foo@override
    i32.const 2
    i32.ne
@@ -2503,7 +2489,7 @@
    i32.store offset=4
    global.get $~lib/memory/__stack_pointer
    local.get $1
-   call $class-implements/A2#constructor
+   call $class-implements/A2#raw_constructor
    local.tee $1
    i32.store
    global.get $~lib/memory/__stack_pointer
@@ -2607,7 +2593,7 @@
    i32.store offset=4
    global.get $~lib/memory/__stack_pointer
    local.get $1
-   call $class-implements/A2#constructor
+   call $class-implements/A2#raw_constructor
    local.tee $1
    i32.store
    global.get $~lib/memory/__stack_pointer
@@ -2689,14 +2675,45 @@
     unreachable
    end
    global.get $~lib/memory/__stack_pointer
-   i32.const 0
-   call $class-implements/B2#constructor
-   local.tee $0
+   global.get $~lib/memory/__stack_pointer
+   i32.const 8
+   i32.sub
+   global.set $~lib/memory/__stack_pointer
+   global.get $~lib/memory/__stack_pointer
+   i32.const 1592
+   i32.lt_s
+   br_if $folding-inner0
+   global.get $~lib/memory/__stack_pointer
+   i64.const 0
+   i64.store
+   global.get $~lib/memory/__stack_pointer
+   i32.const 4
+   i32.const 18
+   call $~lib/rt/itcms/__new
+   local.tee $1
+   i32.store
+   global.get $~lib/memory/__stack_pointer
+   local.get $1
+   i32.store offset=4
+   global.get $~lib/memory/__stack_pointer
+   local.get $1
+   i32.store
+   global.get $~lib/memory/__stack_pointer
+   local.get $1
+   i32.store offset=4
+   local.get $1
+   i32.const 3
+   i32.store
+   global.get $~lib/memory/__stack_pointer
+   i32.const 8
+   i32.add
+   global.set $~lib/memory/__stack_pointer
+   local.get $1
    i32.store offset=16
    global.get $~lib/memory/__stack_pointer
-   local.get $0
+   local.get $1
    i32.store
-   local.get $0
+   local.get $1
    call $class-implements/B2#get:foo@override
    i32.const 3
    i32.ne
@@ -2709,9 +2726,9 @@
     unreachable
    end
    global.get $~lib/memory/__stack_pointer
-   local.get $0
+   local.get $1
    i32.store
-   local.get $0
+   local.get $1
    call $class-implements/I2#get:foo@override
    i32.const 3
    i32.ne
@@ -2724,15 +2741,15 @@
     unreachable
    end
    global.get $~lib/memory/__stack_pointer
-   local.get $0
+   local.get $1
    i32.store
-   local.get $0
+   local.get $1
    i32.const 4
    call $class-implements/I2#set:foo@override
    global.get $~lib/memory/__stack_pointer
-   local.get $0
+   local.get $1
    i32.store
-   local.get $0
+   local.get $1
    call $class-implements/B2#get:foo@override
    i32.const 4
    i32.ne
@@ -2745,9 +2762,9 @@
     unreachable
    end
    global.get $~lib/memory/__stack_pointer
-   local.get $0
+   local.get $1
    i32.store
-   local.get $0
+   local.get $1
    call $class-implements/I2#get:foo@override
    i32.const 4
    i32.ne
@@ -2782,7 +2799,7 @@
    i32.store offset=4
    global.get $~lib/memory/__stack_pointer
    local.get $1
-   call $class-implements/B2#constructor
+   call $class-implements/B2#raw_constructor
    local.tee $1
    i32.store
    global.get $~lib/memory/__stack_pointer
@@ -2886,7 +2903,7 @@
    i32.store offset=4
    global.get $~lib/memory/__stack_pointer
    local.get $1
-   call $class-implements/B2#constructor
+   call $class-implements/B2#raw_constructor
    local.tee $1
    i32.store
    global.get $~lib/memory/__stack_pointer
@@ -3009,40 +3026,5 @@
   i32.const 4
   i32.add
   global.set $~lib/memory/__stack_pointer
- )
- (func $~lib/object/Object#constructor (param $0 i32) (result i32)
-  global.get $~lib/memory/__stack_pointer
-  i32.const 4
-  i32.sub
-  global.set $~lib/memory/__stack_pointer
-  global.get $~lib/memory/__stack_pointer
-  i32.const 1592
-  i32.lt_s
-  if
-   i32.const 34384
-   i32.const 34432
-   i32.const 1
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  global.get $~lib/memory/__stack_pointer
-  i32.const 0
-  i32.store
-  local.get $0
-  i32.eqz
-  if
-   global.get $~lib/memory/__stack_pointer
-   i32.const 0
-   i32.const 0
-   call $~lib/rt/itcms/__new
-   local.tee $0
-   i32.store
-  end
-  global.get $~lib/memory/__stack_pointer
-  i32.const 4
-  i32.add
-  global.set $~lib/memory/__stack_pointer
-  local.get $0
  )
 )

--- a/tests/compiler/class-overloading-cast.debug.wat
+++ b/tests/compiler/class-overloading-cast.debug.wat
@@ -55,6 +55,9 @@
  (elem $0 (i32.const 1))
  (export "memory" (memory $0))
  (export "_start" (func $~start))
+ (func $~lib/object/Object#raw_constructor (param $this i32) (result i32)
+  local.get $this
+ )
  (func $~lib/rt/itcms/Object#set:nextWithColor (param $this i32) (param $nextWithColor i32)
   local.get $this
   local.get $nextWithColor
@@ -2595,6 +2598,34 @@
    unreachable
   end
  )
+ (func $class-overloading-cast/A<i32>#raw_constructor (param $this i32) (result i32)
+  (local $1 i32)
+  global.get $~lib/memory/__stack_pointer
+  i32.const 8
+  i32.sub
+  global.set $~lib/memory/__stack_pointer
+  call $~stack_check
+  global.get $~lib/memory/__stack_pointer
+  i64.const 0
+  i64.store
+  global.get $~lib/memory/__stack_pointer
+  local.get $this
+  local.set $1
+  global.get $~lib/memory/__stack_pointer
+  local.get $1
+  i32.store
+  local.get $1
+  call $~lib/object/Object#raw_constructor
+  local.tee $this
+  i32.store offset=4
+  local.get $this
+  local.set $1
+  global.get $~lib/memory/__stack_pointer
+  i32.const 8
+  i32.add
+  global.set $~lib/memory/__stack_pointer
+  local.get $1
+ )
  (func $class-overloading-cast/A<i32>#constructor (param $this i32) (result i32)
   (local $1 i32)
   global.get $~lib/memory/__stack_pointer
@@ -2622,9 +2653,37 @@
   local.get $1
   i32.store offset=4
   local.get $1
-  call $~lib/object/Object#constructor
+  call $~lib/object/Object#raw_constructor
   local.tee $this
   i32.store
+  local.get $this
+  local.set $1
+  global.get $~lib/memory/__stack_pointer
+  i32.const 8
+  i32.add
+  global.set $~lib/memory/__stack_pointer
+  local.get $1
+ )
+ (func $"class-overloading-cast/B<i32,f64>#raw_constructor" (param $this i32) (result i32)
+  (local $1 i32)
+  global.get $~lib/memory/__stack_pointer
+  i32.const 8
+  i32.sub
+  global.set $~lib/memory/__stack_pointer
+  call $~stack_check
+  global.get $~lib/memory/__stack_pointer
+  i64.const 0
+  i64.store
+  global.get $~lib/memory/__stack_pointer
+  local.get $this
+  local.set $1
+  global.get $~lib/memory/__stack_pointer
+  local.get $1
+  i32.store
+  local.get $1
+  call $class-overloading-cast/A<i32>#raw_constructor
+  local.tee $this
+  i32.store offset=4
   local.get $this
   local.set $1
   global.get $~lib/memory/__stack_pointer
@@ -2660,9 +2719,37 @@
   local.get $1
   i32.store offset=4
   local.get $1
-  call $class-overloading-cast/A<i32>#constructor
+  call $class-overloading-cast/A<i32>#raw_constructor
   local.tee $this
   i32.store
+  local.get $this
+  local.set $1
+  global.get $~lib/memory/__stack_pointer
+  i32.const 8
+  i32.add
+  global.set $~lib/memory/__stack_pointer
+  local.get $1
+ )
+ (func $"class-overloading-cast/B<i32,~lib/string/String>#raw_constructor" (param $this i32) (result i32)
+  (local $1 i32)
+  global.get $~lib/memory/__stack_pointer
+  i32.const 8
+  i32.sub
+  global.set $~lib/memory/__stack_pointer
+  call $~stack_check
+  global.get $~lib/memory/__stack_pointer
+  i64.const 0
+  i64.store
+  global.get $~lib/memory/__stack_pointer
+  local.get $this
+  local.set $1
+  global.get $~lib/memory/__stack_pointer
+  local.get $1
+  i32.store
+  local.get $1
+  call $class-overloading-cast/A<i32>#raw_constructor
+  local.tee $this
+  i32.store offset=4
   local.get $this
   local.set $1
   global.get $~lib/memory/__stack_pointer
@@ -2698,9 +2785,37 @@
   local.get $1
   i32.store offset=4
   local.get $1
-  call $class-overloading-cast/A<i32>#constructor
+  call $class-overloading-cast/A<i32>#raw_constructor
   local.tee $this
   i32.store
+  local.get $this
+  local.set $1
+  global.get $~lib/memory/__stack_pointer
+  i32.const 8
+  i32.add
+  global.set $~lib/memory/__stack_pointer
+  local.get $1
+ )
+ (func $class-overloading-cast/A<f64>#raw_constructor (param $this i32) (result i32)
+  (local $1 i32)
+  global.get $~lib/memory/__stack_pointer
+  i32.const 8
+  i32.sub
+  global.set $~lib/memory/__stack_pointer
+  call $~stack_check
+  global.get $~lib/memory/__stack_pointer
+  i64.const 0
+  i64.store
+  global.get $~lib/memory/__stack_pointer
+  local.get $this
+  local.set $1
+  global.get $~lib/memory/__stack_pointer
+  local.get $1
+  i32.store
+  local.get $1
+  call $~lib/object/Object#raw_constructor
+  local.tee $this
+  i32.store offset=4
   local.get $this
   local.set $1
   global.get $~lib/memory/__stack_pointer
@@ -2736,9 +2851,37 @@
   local.get $1
   i32.store offset=4
   local.get $1
-  call $~lib/object/Object#constructor
+  call $~lib/object/Object#raw_constructor
   local.tee $this
   i32.store
+  local.get $this
+  local.set $1
+  global.get $~lib/memory/__stack_pointer
+  i32.const 8
+  i32.add
+  global.set $~lib/memory/__stack_pointer
+  local.get $1
+ )
+ (func $"class-overloading-cast/B<f64,~lib/string/String>#raw_constructor" (param $this i32) (result i32)
+  (local $1 i32)
+  global.get $~lib/memory/__stack_pointer
+  i32.const 8
+  i32.sub
+  global.set $~lib/memory/__stack_pointer
+  call $~stack_check
+  global.get $~lib/memory/__stack_pointer
+  i64.const 0
+  i64.store
+  global.get $~lib/memory/__stack_pointer
+  local.get $this
+  local.set $1
+  global.get $~lib/memory/__stack_pointer
+  local.get $1
+  i32.store
+  local.get $1
+  call $class-overloading-cast/A<f64>#raw_constructor
+  local.tee $this
+  i32.store offset=4
   local.get $this
   local.set $1
   global.get $~lib/memory/__stack_pointer
@@ -2774,7 +2917,7 @@
   local.get $1
   i32.store offset=4
   local.get $1
-  call $class-overloading-cast/A<f64>#constructor
+  call $class-overloading-cast/A<f64>#raw_constructor
   local.tee $this
   i32.store
   local.get $this
@@ -2881,6 +3024,34 @@
   local.get $3
   return
  )
+ (func $class-overloading-cast/A<~lib/string/String>#raw_constructor (param $this i32) (result i32)
+  (local $1 i32)
+  global.get $~lib/memory/__stack_pointer
+  i32.const 8
+  i32.sub
+  global.set $~lib/memory/__stack_pointer
+  call $~stack_check
+  global.get $~lib/memory/__stack_pointer
+  i64.const 0
+  i64.store
+  global.get $~lib/memory/__stack_pointer
+  local.get $this
+  local.set $1
+  global.get $~lib/memory/__stack_pointer
+  local.get $1
+  i32.store
+  local.get $1
+  call $~lib/object/Object#raw_constructor
+  local.tee $this
+  i32.store offset=4
+  local.get $this
+  local.set $1
+  global.get $~lib/memory/__stack_pointer
+  i32.const 8
+  i32.add
+  global.set $~lib/memory/__stack_pointer
+  local.get $1
+ )
  (func $class-overloading-cast/A<~lib/string/String>#constructor (param $this i32) (result i32)
   (local $1 i32)
   global.get $~lib/memory/__stack_pointer
@@ -2908,9 +3079,37 @@
   local.get $1
   i32.store offset=4
   local.get $1
-  call $~lib/object/Object#constructor
+  call $~lib/object/Object#raw_constructor
   local.tee $this
   i32.store
+  local.get $this
+  local.set $1
+  global.get $~lib/memory/__stack_pointer
+  i32.const 8
+  i32.add
+  global.set $~lib/memory/__stack_pointer
+  local.get $1
+ )
+ (func $class-overloading-cast/C#raw_constructor (param $this i32) (result i32)
+  (local $1 i32)
+  global.get $~lib/memory/__stack_pointer
+  i32.const 8
+  i32.sub
+  global.set $~lib/memory/__stack_pointer
+  call $~stack_check
+  global.get $~lib/memory/__stack_pointer
+  i64.const 0
+  i64.store
+  global.get $~lib/memory/__stack_pointer
+  local.get $this
+  local.set $1
+  global.get $~lib/memory/__stack_pointer
+  local.get $1
+  i32.store
+  local.get $1
+  call $class-overloading-cast/A<~lib/string/String>#raw_constructor
+  local.tee $this
+  i32.store offset=4
   local.get $this
   local.set $1
   global.get $~lib/memory/__stack_pointer
@@ -2946,9 +3145,37 @@
   local.get $1
   i32.store offset=4
   local.get $1
-  call $class-overloading-cast/A<~lib/string/String>#constructor
+  call $class-overloading-cast/A<~lib/string/String>#raw_constructor
   local.tee $this
   i32.store
+  local.get $this
+  local.set $1
+  global.get $~lib/memory/__stack_pointer
+  i32.const 8
+  i32.add
+  global.set $~lib/memory/__stack_pointer
+  local.get $1
+ )
+ (func $class-overloading-cast/A<f32>#raw_constructor (param $this i32) (result i32)
+  (local $1 i32)
+  global.get $~lib/memory/__stack_pointer
+  i32.const 8
+  i32.sub
+  global.set $~lib/memory/__stack_pointer
+  call $~stack_check
+  global.get $~lib/memory/__stack_pointer
+  i64.const 0
+  i64.store
+  global.get $~lib/memory/__stack_pointer
+  local.get $this
+  local.set $1
+  global.get $~lib/memory/__stack_pointer
+  local.get $1
+  i32.store
+  local.get $1
+  call $~lib/object/Object#raw_constructor
+  local.tee $this
+  i32.store offset=4
   local.get $this
   local.set $1
   global.get $~lib/memory/__stack_pointer
@@ -2984,9 +3211,37 @@
   local.get $1
   i32.store offset=4
   local.get $1
-  call $~lib/object/Object#constructor
+  call $~lib/object/Object#raw_constructor
   local.tee $this
   i32.store
+  local.get $this
+  local.set $1
+  global.get $~lib/memory/__stack_pointer
+  i32.const 8
+  i32.add
+  global.set $~lib/memory/__stack_pointer
+  local.get $1
+ )
+ (func $"class-overloading-cast/B<f32,f64>#raw_constructor" (param $this i32) (result i32)
+  (local $1 i32)
+  global.get $~lib/memory/__stack_pointer
+  i32.const 8
+  i32.sub
+  global.set $~lib/memory/__stack_pointer
+  call $~stack_check
+  global.get $~lib/memory/__stack_pointer
+  i64.const 0
+  i64.store
+  global.get $~lib/memory/__stack_pointer
+  local.get $this
+  local.set $1
+  global.get $~lib/memory/__stack_pointer
+  local.get $1
+  i32.store
+  local.get $1
+  call $class-overloading-cast/A<f32>#raw_constructor
+  local.tee $this
+  i32.store offset=4
   local.get $this
   local.set $1
   global.get $~lib/memory/__stack_pointer
@@ -3022,9 +3277,37 @@
   local.get $1
   i32.store offset=4
   local.get $1
-  call $class-overloading-cast/A<f32>#constructor
+  call $class-overloading-cast/A<f32>#raw_constructor
   local.tee $this
   i32.store
+  local.get $this
+  local.set $1
+  global.get $~lib/memory/__stack_pointer
+  i32.const 8
+  i32.add
+  global.set $~lib/memory/__stack_pointer
+  local.get $1
+ )
+ (func $class-overloading-cast/D#raw_constructor (param $this i32) (result i32)
+  (local $1 i32)
+  global.get $~lib/memory/__stack_pointer
+  i32.const 8
+  i32.sub
+  global.set $~lib/memory/__stack_pointer
+  call $~stack_check
+  global.get $~lib/memory/__stack_pointer
+  i64.const 0
+  i64.store
+  global.get $~lib/memory/__stack_pointer
+  local.get $this
+  local.set $1
+  global.get $~lib/memory/__stack_pointer
+  local.get $1
+  i32.store
+  local.get $1
+  call $"class-overloading-cast/B<f32,f64>#raw_constructor"
+  local.tee $this
+  i32.store offset=4
   local.get $this
   local.set $1
   global.get $~lib/memory/__stack_pointer
@@ -3060,7 +3343,7 @@
   local.get $1
   i32.store offset=4
   local.get $1
-  call $"class-overloading-cast/B<f32,f64>#constructor"
+  call $"class-overloading-cast/B<f32,f64>#raw_constructor"
   local.tee $this
   i32.store
   local.get $this

--- a/tests/compiler/class-overloading-cast.release.wat
+++ b/tests/compiler/class-overloading-cast.release.wat
@@ -155,7 +155,7 @@
     local.get $0
     global.set $~lib/rt/itcms/iter
    end
-   block $__inlined_func$~lib/rt/itcms/Object#unlink$141
+   block $__inlined_func$~lib/rt/itcms/Object#unlink$137
     local.get $1
     i32.load offset=4
     i32.const -4
@@ -179,7 +179,7 @@
       call $~lib/builtins/abort
       unreachable
      end
-     br $__inlined_func$~lib/rt/itcms/Object#unlink$141
+     br $__inlined_func$~lib/rt/itcms/Object#unlink$137
     end
     local.get $1
     i32.load offset=8
@@ -1469,7 +1469,7 @@
   global.set $~started
   call $start:class-overloading-cast
  )
- (func $class-overloading-cast/A<i32>#constructor (param $0 i32) (result i32)
+ (func $class-overloading-cast/A<i32>#raw_constructor (param $0 i32) (result i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 8
   i32.sub
@@ -1488,23 +1488,12 @@
   global.get $~lib/memory/__stack_pointer
   i64.const 0
   i64.store
+  global.get $~lib/memory/__stack_pointer
   local.get $0
-  i32.eqz
-  if
-   global.get $~lib/memory/__stack_pointer
-   i32.const 5
-   call $~lib/rt/itcms/__new
-   local.tee $0
-   i32.store
-  end
+  i32.store
   global.get $~lib/memory/__stack_pointer
   local.get $0
   i32.store offset=4
-  global.get $~lib/memory/__stack_pointer
-  local.get $0
-  call $~lib/object/Object#constructor
-  local.tee $0
-  i32.store
   global.get $~lib/memory/__stack_pointer
   i32.const 8
   i32.add
@@ -1624,7 +1613,7 @@
      end
     end
    end
-   block $__inlined_func$~lib/util/string/compareImpl$87
+   block $__inlined_func$~lib/util/string/compareImpl$88
     loop $while-continue|1
      local.get $0
      local.tee $3
@@ -1644,7 +1633,7 @@
       local.get $4
       local.get $5
       i32.ne
-      br_if $__inlined_func$~lib/util/string/compareImpl$87
+      br_if $__inlined_func$~lib/util/string/compareImpl$88
       local.get $2
       i32.const 2
       i32.add
@@ -1676,7 +1665,6 @@
  (func $start:class-overloading-cast
   (local $0 i32)
   (local $1 i32)
-  (local $2 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 16
   i32.sub
@@ -1745,7 +1733,7 @@
    i32.store offset=4
    global.get $~lib/memory/__stack_pointer
    local.get $0
-   call $class-overloading-cast/A<i32>#constructor
+   call $class-overloading-cast/A<i32>#raw_constructor
    local.tee $0
    i32.store
    global.get $~lib/memory/__stack_pointer
@@ -1775,7 +1763,7 @@
    i32.store offset=4
    global.get $~lib/memory/__stack_pointer
    local.get $0
-   call $class-overloading-cast/A<i32>#constructor
+   call $class-overloading-cast/A<i32>#raw_constructor
    local.tee $0
    i32.store
    global.get $~lib/memory/__stack_pointer
@@ -1801,42 +1789,12 @@
    local.tee $0
    i32.store
    global.get $~lib/memory/__stack_pointer
-   global.get $~lib/memory/__stack_pointer
-   local.get $0
-   i32.store offset=4
-   global.get $~lib/memory/__stack_pointer
-   i32.const 8
-   i32.sub
-   global.set $~lib/memory/__stack_pointer
-   global.get $~lib/memory/__stack_pointer
-   i32.const 1708
-   i32.lt_s
-   br_if $folding-inner0
-   global.get $~lib/memory/__stack_pointer
-   i64.const 0
-   i64.store
-   local.get $0
-   i32.eqz
-   if
-    global.get $~lib/memory/__stack_pointer
-    i32.const 8
-    call $~lib/rt/itcms/__new
-    local.tee $0
-    i32.store
-   end
-   global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store offset=4
    global.get $~lib/memory/__stack_pointer
    local.get $0
-   call $~lib/object/Object#constructor
+   call $class-overloading-cast/A<i32>#raw_constructor
    local.tee $0
-   i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 8
-   i32.add
-   global.set $~lib/memory/__stack_pointer
-   local.get $0
    i32.store
    global.get $~lib/memory/__stack_pointer
    i32.const 8
@@ -1845,7 +1803,7 @@
    local.get $0
    global.set $class-overloading-cast/v3
    global.get $~lib/memory/__stack_pointer
-   block $__inlined_func$class-overloading-cast/A<i32>#foo@override$136 (result i32)
+   block $__inlined_func$class-overloading-cast/A<i32>#foo@override$132 (result i32)
     global.get $~lib/memory/__stack_pointer
     global.get $class-overloading-cast/v
     local.tee $0
@@ -1867,10 +1825,10 @@
        br $default
       end
       i32.const 1488
-      br $__inlined_func$class-overloading-cast/A<i32>#foo@override$136
+      br $__inlined_func$class-overloading-cast/A<i32>#foo@override$132
      end
      i32.const 1488
-     br $__inlined_func$class-overloading-cast/A<i32>#foo@override$136
+     br $__inlined_func$class-overloading-cast/A<i32>#foo@override$132
     end
     i32.const 1456
    end
@@ -1913,7 +1871,7 @@
     unreachable
    end
    global.get $~lib/memory/__stack_pointer
-   block $__inlined_func$class-overloading-cast/A<f64>#foo@override$137 (result i32)
+   block $__inlined_func$class-overloading-cast/A<f64>#foo@override$133 (result i32)
     global.get $~lib/memory/__stack_pointer
     global.get $class-overloading-cast/v3
     local.tee $0
@@ -1925,7 +1883,7 @@
     i32.load
     i32.const 7
     i32.eq
-    br_if $__inlined_func$class-overloading-cast/A<f64>#foo@override$137
+    br_if $__inlined_func$class-overloading-cast/A<f64>#foo@override$133
     drop
     i32.const 1456
    end
@@ -1963,42 +1921,12 @@
    local.tee $0
    i32.store
    global.get $~lib/memory/__stack_pointer
-   global.get $~lib/memory/__stack_pointer
-   local.get $0
-   i32.store offset=4
-   global.get $~lib/memory/__stack_pointer
-   i32.const 8
-   i32.sub
-   global.set $~lib/memory/__stack_pointer
-   global.get $~lib/memory/__stack_pointer
-   i32.const 1708
-   i32.lt_s
-   br_if $folding-inner0
-   global.get $~lib/memory/__stack_pointer
-   i64.const 0
-   i64.store
-   local.get $0
-   i32.eqz
-   if
-    global.get $~lib/memory/__stack_pointer
-    i32.const 10
-    call $~lib/rt/itcms/__new
-    local.tee $0
-    i32.store
-   end
-   global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store offset=4
    global.get $~lib/memory/__stack_pointer
    local.get $0
-   call $~lib/object/Object#constructor
+   call $class-overloading-cast/A<i32>#raw_constructor
    local.tee $0
-   i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 8
-   i32.add
-   global.set $~lib/memory/__stack_pointer
-   local.get $0
    i32.store
    global.get $~lib/memory/__stack_pointer
    i32.const 8
@@ -2080,11 +2008,11 @@
    global.get $~lib/memory/__stack_pointer
    i32.const 11
    call $~lib/rt/itcms/__new
-   local.tee $0
+   local.tee $1
    i32.store
    global.get $~lib/memory/__stack_pointer
    global.get $~lib/memory/__stack_pointer
-   local.get $0
+   local.get $1
    i32.store offset=4
    global.get $~lib/memory/__stack_pointer
    i32.const 8
@@ -2097,65 +2025,26 @@
    global.get $~lib/memory/__stack_pointer
    i64.const 0
    i64.store
-   local.get $0
-   i32.eqz
-   if
-    global.get $~lib/memory/__stack_pointer
-    i32.const 12
-    call $~lib/rt/itcms/__new
-    local.tee $0
-    i32.store
-   end
    global.get $~lib/memory/__stack_pointer
+   local.get $1
+   i32.store
    global.get $~lib/memory/__stack_pointer
-   local.get $0
+   local.get $1
+   call $class-overloading-cast/A<i32>#raw_constructor
+   local.tee $1
    i32.store offset=4
    global.get $~lib/memory/__stack_pointer
    i32.const 8
-   i32.sub
-   global.set $~lib/memory/__stack_pointer
-   global.get $~lib/memory/__stack_pointer
-   i32.const 1708
-   i32.lt_s
-   br_if $folding-inner0
-   global.get $~lib/memory/__stack_pointer
-   i64.const 0
-   i64.store
-   local.get $0
-   i32.eqz
-   if
-    global.get $~lib/memory/__stack_pointer
-    i32.const 13
-    call $~lib/rt/itcms/__new
-    local.tee $0
-    i32.store
-   end
-   global.get $~lib/memory/__stack_pointer
-   local.get $0
-   i32.store offset=4
-   global.get $~lib/memory/__stack_pointer
-   local.get $0
-   call $~lib/object/Object#constructor
-   local.tee $0
-   i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 8
    i32.add
    global.set $~lib/memory/__stack_pointer
-   local.get $0
-   i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 8
-   i32.add
-   global.set $~lib/memory/__stack_pointer
-   local.get $0
+   local.get $1
    i32.store
    global.get $~lib/memory/__stack_pointer
    i32.const 8
    i32.add
    global.set $~lib/memory/__stack_pointer
    global.get $~lib/memory/__stack_pointer
-   local.get $0
+   local.get $1
    i32.store offset=8
    global.get $~lib/memory/__stack_pointer
    i32.const 1632
@@ -2187,39 +2076,5 @@
   i32.const 1
   call $~lib/builtins/abort
   unreachable
- )
- (func $~lib/object/Object#constructor (param $0 i32) (result i32)
-  global.get $~lib/memory/__stack_pointer
-  i32.const 4
-  i32.sub
-  global.set $~lib/memory/__stack_pointer
-  global.get $~lib/memory/__stack_pointer
-  i32.const 1708
-  i32.lt_s
-  if
-   i32.const 34496
-   i32.const 34544
-   i32.const 1
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  global.get $~lib/memory/__stack_pointer
-  i32.const 0
-  i32.store
-  local.get $0
-  i32.eqz
-  if
-   global.get $~lib/memory/__stack_pointer
-   i32.const 0
-   call $~lib/rt/itcms/__new
-   local.tee $0
-   i32.store
-  end
-  global.get $~lib/memory/__stack_pointer
-  i32.const 4
-  i32.add
-  global.set $~lib/memory/__stack_pointer
-  local.get $0
  )
 )

--- a/tests/compiler/class-overloading.debug.wat
+++ b/tests/compiler/class-overloading.debug.wat
@@ -59,6 +59,9 @@
  (elem $0 (i32.const 1))
  (export "memory" (memory $0))
  (export "_start" (func $~start))
+ (func $~lib/object/Object#raw_constructor (param $this i32) (result i32)
+  local.get $this
+ )
  (func $~lib/rt/itcms/Object#set:nextWithColor (param $this i32) (param $nextWithColor i32)
   local.get $this
   local.get $nextWithColor
@@ -2905,6 +2908,34 @@
    unreachable
   end
  )
+ (func $class-overloading/A#raw_constructor (param $this i32) (result i32)
+  (local $1 i32)
+  global.get $~lib/memory/__stack_pointer
+  i32.const 8
+  i32.sub
+  global.set $~lib/memory/__stack_pointer
+  call $~stack_check
+  global.get $~lib/memory/__stack_pointer
+  i64.const 0
+  i64.store
+  global.get $~lib/memory/__stack_pointer
+  local.get $this
+  local.set $1
+  global.get $~lib/memory/__stack_pointer
+  local.get $1
+  i32.store
+  local.get $1
+  call $~lib/object/Object#raw_constructor
+  local.tee $this
+  i32.store offset=4
+  local.get $this
+  local.set $1
+  global.get $~lib/memory/__stack_pointer
+  i32.const 8
+  i32.add
+  global.set $~lib/memory/__stack_pointer
+  local.get $1
+ )
  (func $class-overloading/A#constructor (param $this i32) (result i32)
   (local $1 i32)
   global.get $~lib/memory/__stack_pointer
@@ -2932,9 +2963,37 @@
   local.get $1
   i32.store offset=4
   local.get $1
-  call $~lib/object/Object#constructor
+  call $~lib/object/Object#raw_constructor
   local.tee $this
   i32.store
+  local.get $this
+  local.set $1
+  global.get $~lib/memory/__stack_pointer
+  i32.const 8
+  i32.add
+  global.set $~lib/memory/__stack_pointer
+  local.get $1
+ )
+ (func $class-overloading/B#raw_constructor (param $this i32) (result i32)
+  (local $1 i32)
+  global.get $~lib/memory/__stack_pointer
+  i32.const 8
+  i32.sub
+  global.set $~lib/memory/__stack_pointer
+  call $~stack_check
+  global.get $~lib/memory/__stack_pointer
+  i64.const 0
+  i64.store
+  global.get $~lib/memory/__stack_pointer
+  local.get $this
+  local.set $1
+  global.get $~lib/memory/__stack_pointer
+  local.get $1
+  i32.store
+  local.get $1
+  call $class-overloading/A#raw_constructor
+  local.tee $this
+  i32.store offset=4
   local.get $this
   local.set $1
   global.get $~lib/memory/__stack_pointer
@@ -2970,7 +3029,7 @@
   local.get $1
   i32.store offset=4
   local.get $1
-  call $class-overloading/A#constructor
+  call $class-overloading/A#raw_constructor
   local.tee $this
   i32.store
   local.get $this
@@ -3077,6 +3136,34 @@
   local.get $3
   return
  )
+ (func $class-overloading/C#raw_constructor (param $this i32) (result i32)
+  (local $1 i32)
+  global.get $~lib/memory/__stack_pointer
+  i32.const 8
+  i32.sub
+  global.set $~lib/memory/__stack_pointer
+  call $~stack_check
+  global.get $~lib/memory/__stack_pointer
+  i64.const 0
+  i64.store
+  global.get $~lib/memory/__stack_pointer
+  local.get $this
+  local.set $1
+  global.get $~lib/memory/__stack_pointer
+  local.get $1
+  i32.store
+  local.get $1
+  call $class-overloading/B#raw_constructor
+  local.tee $this
+  i32.store offset=4
+  local.get $this
+  local.set $1
+  global.get $~lib/memory/__stack_pointer
+  i32.const 8
+  i32.add
+  global.set $~lib/memory/__stack_pointer
+  local.get $1
+ )
  (func $class-overloading/C#constructor (param $this i32) (result i32)
   (local $1 i32)
   global.get $~lib/memory/__stack_pointer
@@ -3104,7 +3191,7 @@
   local.get $1
   i32.store offset=4
   local.get $1
-  call $class-overloading/B#constructor
+  call $class-overloading/B#raw_constructor
   local.tee $this
   i32.store
   local.get $this
@@ -3162,6 +3249,34 @@
   i32.add
   global.set $~lib/memory/__stack_pointer
  )
+ (func $class-overloading/D#raw_constructor (param $this i32) (result i32)
+  (local $1 i32)
+  global.get $~lib/memory/__stack_pointer
+  i32.const 8
+  i32.sub
+  global.set $~lib/memory/__stack_pointer
+  call $~stack_check
+  global.get $~lib/memory/__stack_pointer
+  i64.const 0
+  i64.store
+  global.get $~lib/memory/__stack_pointer
+  local.get $this
+  local.set $1
+  global.get $~lib/memory/__stack_pointer
+  local.get $1
+  i32.store
+  local.get $1
+  call $class-overloading/B#raw_constructor
+  local.tee $this
+  i32.store offset=4
+  local.get $this
+  local.set $1
+  global.get $~lib/memory/__stack_pointer
+  i32.const 8
+  i32.add
+  global.set $~lib/memory/__stack_pointer
+  local.get $1
+ )
  (func $class-overloading/D#constructor (param $this i32) (result i32)
   (local $1 i32)
   global.get $~lib/memory/__stack_pointer
@@ -3189,9 +3304,37 @@
   local.get $1
   i32.store offset=4
   local.get $1
-  call $class-overloading/B#constructor
+  call $class-overloading/B#raw_constructor
   local.tee $this
   i32.store
+  local.get $this
+  local.set $1
+  global.get $~lib/memory/__stack_pointer
+  i32.const 8
+  i32.add
+  global.set $~lib/memory/__stack_pointer
+  local.get $1
+ )
+ (func $class-overloading/E#raw_constructor (param $this i32) (result i32)
+  (local $1 i32)
+  global.get $~lib/memory/__stack_pointer
+  i32.const 8
+  i32.sub
+  global.set $~lib/memory/__stack_pointer
+  call $~stack_check
+  global.get $~lib/memory/__stack_pointer
+  i64.const 0
+  i64.store
+  global.get $~lib/memory/__stack_pointer
+  local.get $this
+  local.set $1
+  global.get $~lib/memory/__stack_pointer
+  local.get $1
+  i32.store
+  local.get $1
+  call $class-overloading/D#raw_constructor
+  local.tee $this
+  i32.store offset=4
   local.get $this
   local.set $1
   global.get $~lib/memory/__stack_pointer
@@ -3227,9 +3370,37 @@
   local.get $1
   i32.store offset=4
   local.get $1
-  call $class-overloading/D#constructor
+  call $class-overloading/D#raw_constructor
   local.tee $this
   i32.store
+  local.get $this
+  local.set $1
+  global.get $~lib/memory/__stack_pointer
+  i32.const 8
+  i32.add
+  global.set $~lib/memory/__stack_pointer
+  local.get $1
+ )
+ (func $class-overloading/F#raw_constructor (param $this i32) (result i32)
+  (local $1 i32)
+  global.get $~lib/memory/__stack_pointer
+  i32.const 8
+  i32.sub
+  global.set $~lib/memory/__stack_pointer
+  call $~stack_check
+  global.get $~lib/memory/__stack_pointer
+  i64.const 0
+  i64.store
+  global.get $~lib/memory/__stack_pointer
+  local.get $this
+  local.set $1
+  global.get $~lib/memory/__stack_pointer
+  local.get $1
+  i32.store
+  local.get $1
+  call $class-overloading/E#raw_constructor
+  local.tee $this
+  i32.store offset=4
   local.get $this
   local.set $1
   global.get $~lib/memory/__stack_pointer
@@ -3265,9 +3436,37 @@
   local.get $1
   i32.store offset=4
   local.get $1
-  call $class-overloading/E#constructor
+  call $class-overloading/E#raw_constructor
   local.tee $this
   i32.store
+  local.get $this
+  local.set $1
+  global.get $~lib/memory/__stack_pointer
+  i32.const 8
+  i32.add
+  global.set $~lib/memory/__stack_pointer
+  local.get $1
+ )
+ (func $class-overloading/CA#raw_constructor (param $this i32) (result i32)
+  (local $1 i32)
+  global.get $~lib/memory/__stack_pointer
+  i32.const 8
+  i32.sub
+  global.set $~lib/memory/__stack_pointer
+  call $~stack_check
+  global.get $~lib/memory/__stack_pointer
+  i64.const 0
+  i64.store
+  global.get $~lib/memory/__stack_pointer
+  local.get $this
+  local.set $1
+  global.get $~lib/memory/__stack_pointer
+  local.get $1
+  i32.store
+  local.get $1
+  call $~lib/object/Object#raw_constructor
+  local.tee $this
+  i32.store offset=4
   local.get $this
   local.set $1
   global.get $~lib/memory/__stack_pointer
@@ -3303,9 +3502,37 @@
   local.get $1
   i32.store offset=4
   local.get $1
-  call $~lib/object/Object#constructor
+  call $~lib/object/Object#raw_constructor
   local.tee $this
   i32.store
+  local.get $this
+  local.set $1
+  global.get $~lib/memory/__stack_pointer
+  i32.const 8
+  i32.add
+  global.set $~lib/memory/__stack_pointer
+  local.get $1
+ )
+ (func $class-overloading/CC#raw_constructor (param $this i32) (result i32)
+  (local $1 i32)
+  global.get $~lib/memory/__stack_pointer
+  i32.const 8
+  i32.sub
+  global.set $~lib/memory/__stack_pointer
+  call $~stack_check
+  global.get $~lib/memory/__stack_pointer
+  i64.const 0
+  i64.store
+  global.get $~lib/memory/__stack_pointer
+  local.get $this
+  local.set $1
+  global.get $~lib/memory/__stack_pointer
+  local.get $1
+  i32.store
+  local.get $1
+  call $~lib/object/Object#raw_constructor
+  local.tee $this
+  i32.store offset=4
   local.get $this
   local.set $1
   global.get $~lib/memory/__stack_pointer
@@ -3341,9 +3568,37 @@
   local.get $1
   i32.store offset=4
   local.get $1
-  call $~lib/object/Object#constructor
+  call $~lib/object/Object#raw_constructor
   local.tee $this
   i32.store
+  local.get $this
+  local.set $1
+  global.get $~lib/memory/__stack_pointer
+  i32.const 8
+  i32.add
+  global.set $~lib/memory/__stack_pointer
+  local.get $1
+ )
+ (func $class-overloading/A2#raw_constructor (param $this i32) (result i32)
+  (local $1 i32)
+  global.get $~lib/memory/__stack_pointer
+  i32.const 8
+  i32.sub
+  global.set $~lib/memory/__stack_pointer
+  call $~stack_check
+  global.get $~lib/memory/__stack_pointer
+  i64.const 0
+  i64.store
+  global.get $~lib/memory/__stack_pointer
+  local.get $this
+  local.set $1
+  global.get $~lib/memory/__stack_pointer
+  local.get $1
+  i32.store
+  local.get $1
+  call $~lib/object/Object#raw_constructor
+  local.tee $this
+  i32.store offset=4
   local.get $this
   local.set $1
   global.get $~lib/memory/__stack_pointer
@@ -3379,9 +3634,37 @@
   local.get $1
   i32.store offset=4
   local.get $1
-  call $~lib/object/Object#constructor
+  call $~lib/object/Object#raw_constructor
   local.tee $this
   i32.store
+  local.get $this
+  local.set $1
+  global.get $~lib/memory/__stack_pointer
+  i32.const 8
+  i32.add
+  global.set $~lib/memory/__stack_pointer
+  local.get $1
+ )
+ (func $class-overloading/B2#raw_constructor (param $this i32) (result i32)
+  (local $1 i32)
+  global.get $~lib/memory/__stack_pointer
+  i32.const 8
+  i32.sub
+  global.set $~lib/memory/__stack_pointer
+  call $~stack_check
+  global.get $~lib/memory/__stack_pointer
+  i64.const 0
+  i64.store
+  global.get $~lib/memory/__stack_pointer
+  local.get $this
+  local.set $1
+  global.get $~lib/memory/__stack_pointer
+  local.get $1
+  i32.store
+  local.get $1
+  call $class-overloading/A2#raw_constructor
+  local.tee $this
+  i32.store offset=4
   local.get $this
   local.set $1
   global.get $~lib/memory/__stack_pointer
@@ -3417,7 +3700,7 @@
   local.get $1
   i32.store offset=4
   local.get $1
-  call $class-overloading/A2#constructor
+  call $class-overloading/A2#raw_constructor
   local.tee $this
   i32.store
   local.get $this
@@ -4196,6 +4479,34 @@
   i32.add
   global.set $~lib/memory/__stack_pointer
  )
+ (func $class-overloading/A1#raw_constructor (param $this i32) (result i32)
+  (local $1 i32)
+  global.get $~lib/memory/__stack_pointer
+  i32.const 8
+  i32.sub
+  global.set $~lib/memory/__stack_pointer
+  call $~stack_check
+  global.get $~lib/memory/__stack_pointer
+  i64.const 0
+  i64.store
+  global.get $~lib/memory/__stack_pointer
+  local.get $this
+  local.set $1
+  global.get $~lib/memory/__stack_pointer
+  local.get $1
+  i32.store
+  local.get $1
+  call $~lib/object/Object#raw_constructor
+  local.tee $this
+  i32.store offset=4
+  local.get $this
+  local.set $1
+  global.get $~lib/memory/__stack_pointer
+  i32.const 8
+  i32.add
+  global.set $~lib/memory/__stack_pointer
+  local.get $1
+ )
  (func $class-overloading/A1#constructor (param $this i32) (result i32)
   (local $1 i32)
   global.get $~lib/memory/__stack_pointer
@@ -4223,9 +4534,37 @@
   local.get $1
   i32.store offset=4
   local.get $1
-  call $~lib/object/Object#constructor
+  call $~lib/object/Object#raw_constructor
   local.tee $this
   i32.store
+  local.get $this
+  local.set $1
+  global.get $~lib/memory/__stack_pointer
+  i32.const 8
+  i32.add
+  global.set $~lib/memory/__stack_pointer
+  local.get $1
+ )
+ (func $class-overloading/B1#raw_constructor (param $this i32) (result i32)
+  (local $1 i32)
+  global.get $~lib/memory/__stack_pointer
+  i32.const 8
+  i32.sub
+  global.set $~lib/memory/__stack_pointer
+  call $~stack_check
+  global.get $~lib/memory/__stack_pointer
+  i64.const 0
+  i64.store
+  global.get $~lib/memory/__stack_pointer
+  local.get $this
+  local.set $1
+  global.get $~lib/memory/__stack_pointer
+  local.get $1
+  i32.store
+  local.get $1
+  call $class-overloading/A1#raw_constructor
+  local.tee $this
+  i32.store offset=4
   local.get $this
   local.set $1
   global.get $~lib/memory/__stack_pointer
@@ -4261,7 +4600,7 @@
   local.get $1
   i32.store offset=4
   local.get $1
-  call $class-overloading/A1#constructor
+  call $class-overloading/A1#raw_constructor
   local.tee $this
   i32.store
   local.get $this

--- a/tests/compiler/class-overloading.release.wat
+++ b/tests/compiler/class-overloading.release.wat
@@ -177,7 +177,7 @@
     local.get $0
     global.set $~lib/rt/itcms/iter
    end
-   block $__inlined_func$~lib/rt/itcms/Object#unlink$171
+   block $__inlined_func$~lib/rt/itcms/Object#unlink$176
     local.get $1
     i32.load offset=4
     i32.const -4
@@ -201,7 +201,7 @@
       call $~lib/builtins/abort
       unreachable
      end
-     br $__inlined_func$~lib/rt/itcms/Object#unlink$171
+     br $__inlined_func$~lib/rt/itcms/Object#unlink$176
     end
     local.get $1
     i32.load offset=8
@@ -1531,80 +1531,69 @@
   global.set $~started
   call $start:class-overloading
  )
- (func $class-overloading/B#constructor (param $0 i32) (result i32)
-  (local $1 i32)
+ (func $class-overloading/A#raw_constructor (param $0 i32) (result i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 8
   i32.sub
   global.set $~lib/memory/__stack_pointer
-  block $folding-inner0
-   global.get $~lib/memory/__stack_pointer
-   i32.const 1868
-   i32.lt_s
-   br_if $folding-inner0
-   global.get $~lib/memory/__stack_pointer
-   i64.const 0
-   i64.store
-   local.get $0
-   i32.eqz
-   if
-    global.get $~lib/memory/__stack_pointer
-    i32.const 5
-    call $~lib/rt/itcms/__new
-    local.tee $0
-    i32.store
-   end
-   global.get $~lib/memory/__stack_pointer
-   global.get $~lib/memory/__stack_pointer
-   local.get $0
-   i32.store offset=4
-   global.get $~lib/memory/__stack_pointer
-   i32.const 8
-   i32.sub
-   global.set $~lib/memory/__stack_pointer
-   global.get $~lib/memory/__stack_pointer
-   i32.const 1868
-   i32.lt_s
-   br_if $folding-inner0
-   global.get $~lib/memory/__stack_pointer
-   i64.const 0
-   i64.store
-   local.get $0
-   i32.eqz
-   if
-    global.get $~lib/memory/__stack_pointer
-    i32.const 4
-    call $~lib/rt/itcms/__new
-    local.tee $0
-    i32.store
-   end
-   global.get $~lib/memory/__stack_pointer
-   local.get $0
-   i32.store offset=4
-   global.get $~lib/memory/__stack_pointer
-   local.get $0
-   call $~lib/object/Object#constructor
-   local.tee $0
-   i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 8
-   i32.add
-   global.set $~lib/memory/__stack_pointer
-   local.get $0
-   i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 8
-   i32.add
-   global.set $~lib/memory/__stack_pointer
-   local.get $0
-   return
+  global.get $~lib/memory/__stack_pointer
+  i32.const 1868
+  i32.lt_s
+  if
+   i32.const 34656
+   i32.const 34704
+   i32.const 1
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
   end
-  i32.const 34656
-  i32.const 34704
-  i32.const 1
-  i32.const 1
-  call $~lib/builtins/abort
-  unreachable
+  global.get $~lib/memory/__stack_pointer
+  i64.const 0
+  i64.store
+  global.get $~lib/memory/__stack_pointer
+  local.get $0
+  i32.store
+  global.get $~lib/memory/__stack_pointer
+  local.get $0
+  i32.store offset=4
+  global.get $~lib/memory/__stack_pointer
+  i32.const 8
+  i32.add
+  global.set $~lib/memory/__stack_pointer
+  local.get $0
+ )
+ (func $class-overloading/B#raw_constructor (param $0 i32) (result i32)
+  global.get $~lib/memory/__stack_pointer
+  i32.const 8
+  i32.sub
+  global.set $~lib/memory/__stack_pointer
+  global.get $~lib/memory/__stack_pointer
+  i32.const 1868
+  i32.lt_s
+  if
+   i32.const 34656
+   i32.const 34704
+   i32.const 1
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  global.get $~lib/memory/__stack_pointer
+  i64.const 0
+  i64.store
+  global.get $~lib/memory/__stack_pointer
+  local.get $0
+  i32.store
+  global.get $~lib/memory/__stack_pointer
+  local.get $0
+  call $class-overloading/A#raw_constructor
+  local.tee $0
+  i32.store offset=4
+  global.get $~lib/memory/__stack_pointer
+  i32.const 8
+  i32.add
+  global.set $~lib/memory/__stack_pointer
+  local.get $0
  )
  (func $~lib/string/String.__eq (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
@@ -1719,7 +1708,7 @@
      end
     end
    end
-   block $__inlined_func$~lib/util/string/compareImpl$95
+   block $__inlined_func$~lib/util/string/compareImpl$97
     loop $while-continue|1
      local.get $0
      local.tee $3
@@ -1739,7 +1728,7 @@
       local.get $4
       local.get $5
       i32.ne
-      br_if $__inlined_func$~lib/util/string/compareImpl$95
+      br_if $__inlined_func$~lib/util/string/compareImpl$97
       local.get $2
       i32.const 2
       i32.add
@@ -1767,6 +1756,39 @@
   i32.add
   global.set $~lib/memory/__stack_pointer
   i32.const 0
+ )
+ (func $class-overloading/C#raw_constructor (param $0 i32) (result i32)
+  global.get $~lib/memory/__stack_pointer
+  i32.const 8
+  i32.sub
+  global.set $~lib/memory/__stack_pointer
+  global.get $~lib/memory/__stack_pointer
+  i32.const 1868
+  i32.lt_s
+  if
+   i32.const 34656
+   i32.const 34704
+   i32.const 1
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  global.get $~lib/memory/__stack_pointer
+  i64.const 0
+  i64.store
+  global.get $~lib/memory/__stack_pointer
+  local.get $0
+  i32.store
+  global.get $~lib/memory/__stack_pointer
+  local.get $0
+  call $class-overloading/B#raw_constructor
+  local.tee $0
+  i32.store offset=4
+  global.get $~lib/memory/__stack_pointer
+  i32.const 8
+  i32.add
+  global.set $~lib/memory/__stack_pointer
+  local.get $0
  )
  (func $class-overloading/C#a<i32> (param $0 i32)
   global.get $~lib/memory/__stack_pointer
@@ -1817,90 +1839,6 @@
   i32.add
   global.set $~lib/memory/__stack_pointer
  )
- (func $class-overloading/D#constructor (param $0 i32) (result i32)
-  global.get $~lib/memory/__stack_pointer
-  i32.const 8
-  i32.sub
-  global.set $~lib/memory/__stack_pointer
-  global.get $~lib/memory/__stack_pointer
-  i32.const 1868
-  i32.lt_s
-  if
-   i32.const 34656
-   i32.const 34704
-   i32.const 1
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  global.get $~lib/memory/__stack_pointer
-  i64.const 0
-  i64.store
-  local.get $0
-  i32.eqz
-  if
-   global.get $~lib/memory/__stack_pointer
-   i32.const 7
-   call $~lib/rt/itcms/__new
-   local.tee $0
-   i32.store
-  end
-  global.get $~lib/memory/__stack_pointer
-  local.get $0
-  i32.store offset=4
-  global.get $~lib/memory/__stack_pointer
-  local.get $0
-  call $class-overloading/B#constructor
-  local.tee $0
-  i32.store
-  global.get $~lib/memory/__stack_pointer
-  i32.const 8
-  i32.add
-  global.set $~lib/memory/__stack_pointer
-  local.get $0
- )
- (func $class-overloading/E#constructor (param $0 i32) (result i32)
-  global.get $~lib/memory/__stack_pointer
-  i32.const 8
-  i32.sub
-  global.set $~lib/memory/__stack_pointer
-  global.get $~lib/memory/__stack_pointer
-  i32.const 1868
-  i32.lt_s
-  if
-   i32.const 34656
-   i32.const 34704
-   i32.const 1
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  global.get $~lib/memory/__stack_pointer
-  i64.const 0
-  i64.store
-  local.get $0
-  i32.eqz
-  if
-   global.get $~lib/memory/__stack_pointer
-   i32.const 8
-   call $~lib/rt/itcms/__new
-   local.tee $0
-   i32.store
-  end
-  global.get $~lib/memory/__stack_pointer
-  local.get $0
-  i32.store offset=4
-  global.get $~lib/memory/__stack_pointer
-  local.get $0
-  call $class-overloading/D#constructor
-  local.tee $0
-  i32.store
-  global.get $~lib/memory/__stack_pointer
-  i32.const 8
-  i32.add
-  global.set $~lib/memory/__stack_pointer
-  local.get $0
- )
  (func $start:class-overloading
   (local $0 i32)
   (local $1 i32)
@@ -1908,11 +1846,11 @@
   i32.const 8
   i32.sub
   global.set $~lib/memory/__stack_pointer
-  block $folding-inner1
+  block $folding-inner0
    global.get $~lib/memory/__stack_pointer
    i32.const 1868
    i32.lt_s
-   br_if $folding-inner1
+   br_if $folding-inner0
    global.get $~lib/memory/__stack_pointer
    i64.const 0
    i64.store
@@ -1948,8 +1886,35 @@
    i32.store
    i32.const 1376
    global.set $~lib/rt/itcms/fromSpace
-   i32.const 0
-   call $class-overloading/B#constructor
+   global.get $~lib/memory/__stack_pointer
+   i32.const 8
+   i32.sub
+   global.set $~lib/memory/__stack_pointer
+   global.get $~lib/memory/__stack_pointer
+   i32.const 1868
+   i32.lt_s
+   br_if $folding-inner0
+   global.get $~lib/memory/__stack_pointer
+   i64.const 0
+   i64.store
+   global.get $~lib/memory/__stack_pointer
+   i32.const 5
+   call $~lib/rt/itcms/__new
+   local.tee $0
+   i32.store
+   global.get $~lib/memory/__stack_pointer
+   local.get $0
+   i32.store offset=4
+   global.get $~lib/memory/__stack_pointer
+   local.get $0
+   call $class-overloading/A#raw_constructor
+   local.tee $0
+   i32.store
+   global.get $~lib/memory/__stack_pointer
+   i32.const 8
+   i32.add
+   global.set $~lib/memory/__stack_pointer
+   local.get $0
    global.set $class-overloading/a
    global.get $~lib/memory/__stack_pointer
    global.get $class-overloading/a
@@ -1982,7 +1947,7 @@
    global.get $class-overloading/a
    local.tee $0
    i32.store
-   block $__inlined_func$class-overloading/A#b@override$153
+   block $__inlined_func$class-overloading/A#b@override$156
     block $default
      block $case2
       block $case1
@@ -1997,15 +1962,15 @@
        end
        i32.const 1520
        global.set $class-overloading/which
-       br $__inlined_func$class-overloading/A#b@override$153
+       br $__inlined_func$class-overloading/A#b@override$156
       end
       i32.const 1616
       global.set $class-overloading/which
-      br $__inlined_func$class-overloading/A#b@override$153
+      br $__inlined_func$class-overloading/A#b@override$156
      end
      i32.const 1648
      global.set $class-overloading/which
-     br $__inlined_func$class-overloading/A#b@override$153
+     br $__inlined_func$class-overloading/A#b@override$156
     end
     i32.const 1488
     global.set $class-overloading/which
@@ -2035,7 +2000,7 @@
    global.get $class-overloading/a
    local.tee $0
    i32.store
-   block $__inlined_func$class-overloading/A#get:c@override$154
+   block $__inlined_func$class-overloading/A#get:c@override$157
     block $default4
      block $case25
       block $case16
@@ -2050,15 +2015,15 @@
        end
        i32.const 1520
        global.set $class-overloading/which
-       br $__inlined_func$class-overloading/A#get:c@override$154
+       br $__inlined_func$class-overloading/A#get:c@override$157
       end
       i32.const 1616
       global.set $class-overloading/which
-      br $__inlined_func$class-overloading/A#get:c@override$154
+      br $__inlined_func$class-overloading/A#get:c@override$157
      end
      i32.const 1648
      global.set $class-overloading/which
-     br $__inlined_func$class-overloading/A#get:c@override$154
+     br $__inlined_func$class-overloading/A#get:c@override$157
     end
     i32.const 1488
     global.set $class-overloading/which
@@ -2088,7 +2053,7 @@
    global.get $class-overloading/a
    local.tee $0
    i32.store
-   block $__inlined_func$class-overloading/A#b@override$155
+   block $__inlined_func$class-overloading/A#b@override$158
     block $default8
      block $case29
       block $case110
@@ -2103,15 +2068,15 @@
        end
        i32.const 1520
        global.set $class-overloading/which
-       br $__inlined_func$class-overloading/A#b@override$155
+       br $__inlined_func$class-overloading/A#b@override$158
       end
       i32.const 1616
       global.set $class-overloading/which
-      br $__inlined_func$class-overloading/A#b@override$155
+      br $__inlined_func$class-overloading/A#b@override$158
      end
      i32.const 1648
      global.set $class-overloading/which
-     br $__inlined_func$class-overloading/A#b@override$155
+     br $__inlined_func$class-overloading/A#b@override$158
     end
     i32.const 1488
     global.set $class-overloading/which
@@ -2142,7 +2107,7 @@
    global.get $~lib/memory/__stack_pointer
    i32.const 1868
    i32.lt_s
-   br_if $folding-inner1
+   br_if $folding-inner0
    global.get $~lib/memory/__stack_pointer
    i64.const 0
    i64.store
@@ -2156,7 +2121,7 @@
    i32.store offset=4
    global.get $~lib/memory/__stack_pointer
    local.get $0
-   call $class-overloading/B#constructor
+   call $class-overloading/B#raw_constructor
    local.tee $0
    i32.store
    global.get $~lib/memory/__stack_pointer
@@ -2265,8 +2230,35 @@
     call $~lib/builtins/abort
     unreachable
    end
-   i32.const 0
-   call $class-overloading/D#constructor
+   global.get $~lib/memory/__stack_pointer
+   i32.const 8
+   i32.sub
+   global.set $~lib/memory/__stack_pointer
+   global.get $~lib/memory/__stack_pointer
+   i32.const 1868
+   i32.lt_s
+   br_if $folding-inner0
+   global.get $~lib/memory/__stack_pointer
+   i64.const 0
+   i64.store
+   global.get $~lib/memory/__stack_pointer
+   i32.const 7
+   call $~lib/rt/itcms/__new
+   local.tee $0
+   i32.store
+   global.get $~lib/memory/__stack_pointer
+   local.get $0
+   i32.store offset=4
+   global.get $~lib/memory/__stack_pointer
+   local.get $0
+   call $class-overloading/B#raw_constructor
+   local.tee $0
+   i32.store
+   global.get $~lib/memory/__stack_pointer
+   i32.const 8
+   i32.add
+   global.set $~lib/memory/__stack_pointer
+   local.get $0
    global.set $class-overloading/a
    i32.const 1056
    global.set $class-overloading/which
@@ -2301,7 +2293,7 @@
    global.get $class-overloading/a
    local.tee $0
    i32.store
-   block $__inlined_func$class-overloading/A#b@override$157
+   block $__inlined_func$class-overloading/A#b@override$161
     block $default16
      block $case217
       block $case118
@@ -2316,15 +2308,15 @@
        end
        i32.const 1520
        global.set $class-overloading/which
-       br $__inlined_func$class-overloading/A#b@override$157
+       br $__inlined_func$class-overloading/A#b@override$161
       end
       i32.const 1616
       global.set $class-overloading/which
-      br $__inlined_func$class-overloading/A#b@override$157
+      br $__inlined_func$class-overloading/A#b@override$161
      end
      i32.const 1648
      global.set $class-overloading/which
-     br $__inlined_func$class-overloading/A#b@override$157
+     br $__inlined_func$class-overloading/A#b@override$161
     end
     i32.const 1488
     global.set $class-overloading/which
@@ -2354,7 +2346,7 @@
    global.get $class-overloading/a
    local.tee $0
    i32.store
-   block $__inlined_func$class-overloading/A#get:c@override$158
+   block $__inlined_func$class-overloading/A#get:c@override$162
     block $default24
      block $case225
       block $case126
@@ -2369,15 +2361,15 @@
        end
        i32.const 1520
        global.set $class-overloading/which
-       br $__inlined_func$class-overloading/A#get:c@override$158
+       br $__inlined_func$class-overloading/A#get:c@override$162
       end
       i32.const 1616
       global.set $class-overloading/which
-      br $__inlined_func$class-overloading/A#get:c@override$158
+      br $__inlined_func$class-overloading/A#get:c@override$162
      end
      i32.const 1648
      global.set $class-overloading/which
-     br $__inlined_func$class-overloading/A#get:c@override$158
+     br $__inlined_func$class-overloading/A#get:c@override$162
     end
     i32.const 1488
     global.set $class-overloading/which
@@ -2405,7 +2397,7 @@
    global.get $class-overloading/a
    local.tee $0
    i32.store
-   block $__inlined_func$class-overloading/A#b@override$159
+   block $__inlined_func$class-overloading/A#b@override$163
     block $default32
      block $case233
       block $case134
@@ -2420,15 +2412,15 @@
        end
        i32.const 1520
        global.set $class-overloading/which
-       br $__inlined_func$class-overloading/A#b@override$159
+       br $__inlined_func$class-overloading/A#b@override$163
       end
       i32.const 1616
       global.set $class-overloading/which
-      br $__inlined_func$class-overloading/A#b@override$159
+      br $__inlined_func$class-overloading/A#b@override$163
      end
      i32.const 1648
      global.set $class-overloading/which
-     br $__inlined_func$class-overloading/A#b@override$159
+     br $__inlined_func$class-overloading/A#b@override$163
     end
     i32.const 1488
     global.set $class-overloading/which
@@ -2452,8 +2444,35 @@
     call $~lib/builtins/abort
     unreachable
    end
-   i32.const 0
-   call $class-overloading/E#constructor
+   global.get $~lib/memory/__stack_pointer
+   i32.const 8
+   i32.sub
+   global.set $~lib/memory/__stack_pointer
+   global.get $~lib/memory/__stack_pointer
+   i32.const 1868
+   i32.lt_s
+   br_if $folding-inner0
+   global.get $~lib/memory/__stack_pointer
+   i64.const 0
+   i64.store
+   global.get $~lib/memory/__stack_pointer
+   i32.const 8
+   call $~lib/rt/itcms/__new
+   local.tee $0
+   i32.store
+   global.get $~lib/memory/__stack_pointer
+   local.get $0
+   i32.store offset=4
+   global.get $~lib/memory/__stack_pointer
+   local.get $0
+   call $class-overloading/C#raw_constructor
+   local.tee $0
+   i32.store
+   global.get $~lib/memory/__stack_pointer
+   i32.const 8
+   i32.add
+   global.set $~lib/memory/__stack_pointer
+   local.get $0
    global.set $class-overloading/a
    i32.const 1056
    global.set $class-overloading/which
@@ -2488,7 +2507,7 @@
    global.get $class-overloading/a
    local.tee $0
    i32.store
-   block $__inlined_func$class-overloading/A#b@override$160
+   block $__inlined_func$class-overloading/A#b@override$165
     block $default40
      block $case241
       block $case142
@@ -2503,15 +2522,15 @@
        end
        i32.const 1520
        global.set $class-overloading/which
-       br $__inlined_func$class-overloading/A#b@override$160
+       br $__inlined_func$class-overloading/A#b@override$165
       end
       i32.const 1616
       global.set $class-overloading/which
-      br $__inlined_func$class-overloading/A#b@override$160
+      br $__inlined_func$class-overloading/A#b@override$165
      end
      i32.const 1648
      global.set $class-overloading/which
-     br $__inlined_func$class-overloading/A#b@override$160
+     br $__inlined_func$class-overloading/A#b@override$165
     end
     i32.const 1488
     global.set $class-overloading/which
@@ -2541,7 +2560,7 @@
    global.get $class-overloading/a
    local.tee $0
    i32.store
-   block $__inlined_func$class-overloading/A#get:c@override$161
+   block $__inlined_func$class-overloading/A#get:c@override$166
     block $default48
      block $case249
       block $case150
@@ -2556,15 +2575,15 @@
        end
        i32.const 1520
        global.set $class-overloading/which
-       br $__inlined_func$class-overloading/A#get:c@override$161
+       br $__inlined_func$class-overloading/A#get:c@override$166
       end
       i32.const 1616
       global.set $class-overloading/which
-      br $__inlined_func$class-overloading/A#get:c@override$161
+      br $__inlined_func$class-overloading/A#get:c@override$166
      end
      i32.const 1648
      global.set $class-overloading/which
-     br $__inlined_func$class-overloading/A#get:c@override$161
+     br $__inlined_func$class-overloading/A#get:c@override$166
     end
     i32.const 1488
     global.set $class-overloading/which
@@ -2592,7 +2611,7 @@
    global.get $class-overloading/a
    local.tee $0
    i32.store
-   block $__inlined_func$class-overloading/A#b@override$162
+   block $__inlined_func$class-overloading/A#b@override$167
     block $default56
      block $case257
       block $case158
@@ -2607,15 +2626,15 @@
        end
        i32.const 1520
        global.set $class-overloading/which
-       br $__inlined_func$class-overloading/A#b@override$162
+       br $__inlined_func$class-overloading/A#b@override$167
       end
       i32.const 1616
       global.set $class-overloading/which
-      br $__inlined_func$class-overloading/A#b@override$162
+      br $__inlined_func$class-overloading/A#b@override$167
      end
      i32.const 1648
      global.set $class-overloading/which
-     br $__inlined_func$class-overloading/A#b@override$162
+     br $__inlined_func$class-overloading/A#b@override$167
     end
     i32.const 1488
     global.set $class-overloading/which
@@ -2646,7 +2665,7 @@
    global.get $~lib/memory/__stack_pointer
    i32.const 1868
    i32.lt_s
-   br_if $folding-inner1
+   br_if $folding-inner0
    global.get $~lib/memory/__stack_pointer
    i64.const 0
    i64.store
@@ -2656,12 +2675,33 @@
    local.tee $0
    i32.store
    global.get $~lib/memory/__stack_pointer
+   global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store offset=4
    global.get $~lib/memory/__stack_pointer
+   i32.const 8
+   i32.sub
+   global.set $~lib/memory/__stack_pointer
+   global.get $~lib/memory/__stack_pointer
+   i32.const 1868
+   i32.lt_s
+   br_if $folding-inner0
+   global.get $~lib/memory/__stack_pointer
+   i64.const 0
+   i64.store
+   global.get $~lib/memory/__stack_pointer
    local.get $0
-   call $class-overloading/E#constructor
+   i32.store
+   global.get $~lib/memory/__stack_pointer
+   local.get $0
+   call $class-overloading/C#raw_constructor
    local.tee $0
+   i32.store offset=4
+   global.get $~lib/memory/__stack_pointer
+   i32.const 8
+   i32.add
+   global.set $~lib/memory/__stack_pointer
+   local.get $0
    i32.store
    global.get $~lib/memory/__stack_pointer
    i32.const 8
@@ -2702,7 +2742,7 @@
    global.get $class-overloading/a
    local.tee $0
    i32.store
-   block $__inlined_func$class-overloading/A#b@override$164
+   block $__inlined_func$class-overloading/A#b@override$168
     block $default64
      block $case265
       block $case166
@@ -2717,15 +2757,15 @@
        end
        i32.const 1520
        global.set $class-overloading/which
-       br $__inlined_func$class-overloading/A#b@override$164
+       br $__inlined_func$class-overloading/A#b@override$168
       end
       i32.const 1616
       global.set $class-overloading/which
-      br $__inlined_func$class-overloading/A#b@override$164
+      br $__inlined_func$class-overloading/A#b@override$168
      end
      i32.const 1648
      global.set $class-overloading/which
-     br $__inlined_func$class-overloading/A#b@override$164
+     br $__inlined_func$class-overloading/A#b@override$168
     end
     i32.const 1488
     global.set $class-overloading/which
@@ -2755,7 +2795,7 @@
    global.get $class-overloading/a
    local.tee $0
    i32.store
-   block $__inlined_func$class-overloading/A#get:c@override$165
+   block $__inlined_func$class-overloading/A#get:c@override$169
     block $default72
      block $case273
       block $case174
@@ -2770,15 +2810,15 @@
        end
        i32.const 1520
        global.set $class-overloading/which
-       br $__inlined_func$class-overloading/A#get:c@override$165
+       br $__inlined_func$class-overloading/A#get:c@override$169
       end
       i32.const 1616
       global.set $class-overloading/which
-      br $__inlined_func$class-overloading/A#get:c@override$165
+      br $__inlined_func$class-overloading/A#get:c@override$169
      end
      i32.const 1648
      global.set $class-overloading/which
-     br $__inlined_func$class-overloading/A#get:c@override$165
+     br $__inlined_func$class-overloading/A#get:c@override$169
     end
     i32.const 1488
     global.set $class-overloading/which
@@ -2808,7 +2848,7 @@
    global.get $class-overloading/a
    local.tee $0
    i32.store
-   block $__inlined_func$class-overloading/A#b@override$166
+   block $__inlined_func$class-overloading/A#b@override$170
     block $default80
      block $case281
       block $case182
@@ -2823,15 +2863,15 @@
        end
        i32.const 1520
        global.set $class-overloading/which
-       br $__inlined_func$class-overloading/A#b@override$166
+       br $__inlined_func$class-overloading/A#b@override$170
       end
       i32.const 1616
       global.set $class-overloading/which
-      br $__inlined_func$class-overloading/A#b@override$166
+      br $__inlined_func$class-overloading/A#b@override$170
      end
      i32.const 1648
      global.set $class-overloading/which
-     br $__inlined_func$class-overloading/A#b@override$166
+     br $__inlined_func$class-overloading/A#b@override$170
     end
     i32.const 1488
     global.set $class-overloading/which
@@ -2862,7 +2902,7 @@
    global.get $~lib/memory/__stack_pointer
    i32.const 1868
    i32.lt_s
-   br_if $folding-inner1
+   br_if $folding-inner0
    global.get $~lib/memory/__stack_pointer
    i64.const 0
    i64.store
@@ -2876,8 +2916,6 @@
    i32.store offset=4
    global.get $~lib/memory/__stack_pointer
    local.get $0
-   call $~lib/object/Object#constructor
-   local.tee $0
    i32.store
    global.get $~lib/memory/__stack_pointer
    i32.const 8
@@ -2891,7 +2929,7 @@
    global.get $class-overloading/ia
    local.tee $0
    i32.store
-   block $__inlined_func$class-overloading/IA#foo@override$168
+   block $__inlined_func$class-overloading/IA#foo@override$172
     block $default88
      block $case189
       local.get $0
@@ -2910,11 +2948,11 @@
       end
       i32.const 1680
       global.set $class-overloading/which
-      br $__inlined_func$class-overloading/IA#foo@override$168
+      br $__inlined_func$class-overloading/IA#foo@override$172
      end
      i32.const 1712
      global.set $class-overloading/which
-     br $__inlined_func$class-overloading/IA#foo@override$168
+     br $__inlined_func$class-overloading/IA#foo@override$172
     end
     unreachable
    end
@@ -2944,7 +2982,7 @@
    global.get $~lib/memory/__stack_pointer
    i32.const 1868
    i32.lt_s
-   br_if $folding-inner1
+   br_if $folding-inner0
    global.get $~lib/memory/__stack_pointer
    i64.const 0
    i64.store
@@ -2958,8 +2996,6 @@
    i32.store offset=4
    global.get $~lib/memory/__stack_pointer
    local.get $0
-   call $~lib/object/Object#constructor
-   local.tee $0
    i32.store
    global.get $~lib/memory/__stack_pointer
    i32.const 8
@@ -2973,7 +3009,7 @@
    global.get $class-overloading/ic
    local.tee $0
    i32.store
-   block $__inlined_func$class-overloading/IA#foo@override$170
+   block $__inlined_func$class-overloading/IA#foo@override$174
     block $default91
      block $case192
       local.get $0
@@ -2992,11 +3028,11 @@
       end
       i32.const 1680
       global.set $class-overloading/which
-      br $__inlined_func$class-overloading/IA#foo@override$170
+      br $__inlined_func$class-overloading/IA#foo@override$174
      end
      i32.const 1712
      global.set $class-overloading/which
-     br $__inlined_func$class-overloading/IA#foo@override$170
+     br $__inlined_func$class-overloading/IA#foo@override$174
     end
     unreachable
    end
@@ -3026,7 +3062,7 @@
    global.get $~lib/memory/__stack_pointer
    i32.const 1868
    i32.lt_s
-   br_if $folding-inner1
+   br_if $folding-inner0
    global.get $~lib/memory/__stack_pointer
    i64.const 0
    i64.store
@@ -3036,42 +3072,12 @@
    local.tee $0
    i32.store
    global.get $~lib/memory/__stack_pointer
-   global.get $~lib/memory/__stack_pointer
-   local.get $0
-   i32.store offset=4
-   global.get $~lib/memory/__stack_pointer
-   i32.const 8
-   i32.sub
-   global.set $~lib/memory/__stack_pointer
-   global.get $~lib/memory/__stack_pointer
-   i32.const 1868
-   i32.lt_s
-   br_if $folding-inner1
-   global.get $~lib/memory/__stack_pointer
-   i64.const 0
-   i64.store
-   local.get $0
-   i32.eqz
-   if
-    global.get $~lib/memory/__stack_pointer
-    i32.const 14
-    call $~lib/rt/itcms/__new
-    local.tee $0
-    i32.store
-   end
-   global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store offset=4
    global.get $~lib/memory/__stack_pointer
    local.get $0
-   call $~lib/object/Object#constructor
+   call $class-overloading/A#raw_constructor
    local.tee $0
-   i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 8
-   i32.add
-   global.set $~lib/memory/__stack_pointer
-   local.get $0
    i32.store
    global.get $~lib/memory/__stack_pointer
    i32.const 8
@@ -3083,7 +3089,7 @@
    global.get $class-overloading/b2
    local.tee $0
    i32.store
-   block $__inlined_func$class-overloading/A2#foo@override$1
+   block $__inlined_func$class-overloading/A2#foo@override$183
     local.get $0
     i32.const 8
     i32.sub
@@ -3098,7 +3104,7 @@
      global.get $~lib/memory/__stack_pointer
      i32.const 1868
      i32.lt_s
-     br_if $folding-inner1
+     br_if $folding-inner0
      global.get $~lib/memory/__stack_pointer
      i32.const 0
      i32.store
@@ -3109,7 +3115,7 @@
      global.get $~lib/memory/__stack_pointer
      i32.const 1868
      i32.lt_s
-     br_if $folding-inner1
+     br_if $folding-inner0
      global.get $~lib/memory/__stack_pointer
      i64.const 0
      i64.store
@@ -3119,42 +3125,12 @@
      local.tee $0
      i32.store
      global.get $~lib/memory/__stack_pointer
-     global.get $~lib/memory/__stack_pointer
-     local.get $0
-     i32.store offset=4
-     global.get $~lib/memory/__stack_pointer
-     i32.const 8
-     i32.sub
-     global.set $~lib/memory/__stack_pointer
-     global.get $~lib/memory/__stack_pointer
-     i32.const 1868
-     i32.lt_s
-     br_if $folding-inner1
-     global.get $~lib/memory/__stack_pointer
-     i64.const 0
-     i64.store
-     local.get $0
-     i32.eqz
-     if
-      global.get $~lib/memory/__stack_pointer
-      i32.const 17
-      call $~lib/rt/itcms/__new
-      local.tee $0
-      i32.store
-     end
-     global.get $~lib/memory/__stack_pointer
      local.get $0
      i32.store offset=4
      global.get $~lib/memory/__stack_pointer
      local.get $0
-     call $~lib/object/Object#constructor
+     call $class-overloading/A#raw_constructor
      local.tee $0
-     i32.store
-     global.get $~lib/memory/__stack_pointer
-     i32.const 8
-     i32.add
-     global.set $~lib/memory/__stack_pointer
-     local.get $0
      i32.store
      global.get $~lib/memory/__stack_pointer
      i32.const 8
@@ -3170,7 +3146,7 @@
      global.get $~lib/memory/__stack_pointer
      i32.const 1868
      i32.lt_s
-     br_if $folding-inner1
+     br_if $folding-inner0
      global.get $~lib/memory/__stack_pointer
      i32.const 0
      i32.store
@@ -3199,7 +3175,7 @@
      i32.const 4
      i32.add
      global.set $~lib/memory/__stack_pointer
-     br $__inlined_func$class-overloading/A2#foo@override$1
+     br $__inlined_func$class-overloading/A2#foo@override$183
     end
     i32.const 1744
     i32.const 1552
@@ -3220,39 +3196,5 @@
   i32.const 1
   call $~lib/builtins/abort
   unreachable
- )
- (func $~lib/object/Object#constructor (param $0 i32) (result i32)
-  global.get $~lib/memory/__stack_pointer
-  i32.const 4
-  i32.sub
-  global.set $~lib/memory/__stack_pointer
-  global.get $~lib/memory/__stack_pointer
-  i32.const 1868
-  i32.lt_s
-  if
-   i32.const 34656
-   i32.const 34704
-   i32.const 1
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  global.get $~lib/memory/__stack_pointer
-  i32.const 0
-  i32.store
-  local.get $0
-  i32.eqz
-  if
-   global.get $~lib/memory/__stack_pointer
-   i32.const 0
-   call $~lib/rt/itcms/__new
-   local.tee $0
-   i32.store
-  end
-  global.get $~lib/memory/__stack_pointer
-  i32.const 4
-  i32.add
-  global.set $~lib/memory/__stack_pointer
-  local.get $0
  )
 )

--- a/tests/compiler/class-override.debug.wat
+++ b/tests/compiler/class-override.debug.wat
@@ -44,6 +44,9 @@
  (export "fn" (func $class-override/fn))
  (export "memory" (memory $0))
  (start $~start)
+ (func $~lib/object/Object#raw_constructor (param $this i32) (result i32)
+  local.get $this
+ )
  (func $~lib/rt/itcms/Object#set:nextWithColor (param $this i32) (param $nextWithColor i32)
   local.get $this
   local.get $nextWithColor
@@ -2404,6 +2407,34 @@
    unreachable
   end
  )
+ (func $class-override/A#raw_constructor (param $this i32) (result i32)
+  (local $1 i32)
+  global.get $~lib/memory/__stack_pointer
+  i32.const 8
+  i32.sub
+  global.set $~lib/memory/__stack_pointer
+  call $~stack_check
+  global.get $~lib/memory/__stack_pointer
+  i64.const 0
+  i64.store
+  global.get $~lib/memory/__stack_pointer
+  local.get $this
+  local.set $1
+  global.get $~lib/memory/__stack_pointer
+  local.get $1
+  i32.store
+  local.get $1
+  call $~lib/object/Object#raw_constructor
+  local.tee $this
+  i32.store offset=4
+  local.get $this
+  local.set $1
+  global.get $~lib/memory/__stack_pointer
+  i32.const 8
+  i32.add
+  global.set $~lib/memory/__stack_pointer
+  local.get $1
+ )
  (func $class-override/A#constructor (param $this i32) (result i32)
   (local $1 i32)
   global.get $~lib/memory/__stack_pointer
@@ -2431,9 +2462,37 @@
   local.get $1
   i32.store offset=4
   local.get $1
-  call $~lib/object/Object#constructor
+  call $~lib/object/Object#raw_constructor
   local.tee $this
   i32.store
+  local.get $this
+  local.set $1
+  global.get $~lib/memory/__stack_pointer
+  i32.const 8
+  i32.add
+  global.set $~lib/memory/__stack_pointer
+  local.get $1
+ )
+ (func $class-override/B#raw_constructor (param $this i32) (result i32)
+  (local $1 i32)
+  global.get $~lib/memory/__stack_pointer
+  i32.const 8
+  i32.sub
+  global.set $~lib/memory/__stack_pointer
+  call $~stack_check
+  global.get $~lib/memory/__stack_pointer
+  i64.const 0
+  i64.store
+  global.get $~lib/memory/__stack_pointer
+  local.get $this
+  local.set $1
+  global.get $~lib/memory/__stack_pointer
+  local.get $1
+  i32.store
+  local.get $1
+  call $class-override/A#raw_constructor
+  local.tee $this
+  i32.store offset=4
   local.get $this
   local.set $1
   global.get $~lib/memory/__stack_pointer
@@ -2469,9 +2528,37 @@
   local.get $1
   i32.store offset=4
   local.get $1
-  call $class-override/A#constructor
+  call $class-override/A#raw_constructor
   local.tee $this
   i32.store
+  local.get $this
+  local.set $1
+  global.get $~lib/memory/__stack_pointer
+  i32.const 8
+  i32.add
+  global.set $~lib/memory/__stack_pointer
+  local.get $1
+ )
+ (func $class-override/C#raw_constructor (param $this i32) (result i32)
+  (local $1 i32)
+  global.get $~lib/memory/__stack_pointer
+  i32.const 8
+  i32.sub
+  global.set $~lib/memory/__stack_pointer
+  call $~stack_check
+  global.get $~lib/memory/__stack_pointer
+  i64.const 0
+  i64.store
+  global.get $~lib/memory/__stack_pointer
+  local.get $this
+  local.set $1
+  global.get $~lib/memory/__stack_pointer
+  local.get $1
+  i32.store
+  local.get $1
+  call $class-override/B#raw_constructor
+  local.tee $this
+  i32.store offset=4
   local.get $this
   local.set $1
   global.get $~lib/memory/__stack_pointer
@@ -2507,9 +2594,37 @@
   local.get $1
   i32.store offset=4
   local.get $1
-  call $class-override/B#constructor
+  call $class-override/B#raw_constructor
   local.tee $this
   i32.store
+  local.get $this
+  local.set $1
+  global.get $~lib/memory/__stack_pointer
+  i32.const 8
+  i32.add
+  global.set $~lib/memory/__stack_pointer
+  local.get $1
+ )
+ (func $class-override/D#raw_constructor (param $this i32) (result i32)
+  (local $1 i32)
+  global.get $~lib/memory/__stack_pointer
+  i32.const 8
+  i32.sub
+  global.set $~lib/memory/__stack_pointer
+  call $~stack_check
+  global.get $~lib/memory/__stack_pointer
+  i64.const 0
+  i64.store
+  global.get $~lib/memory/__stack_pointer
+  local.get $this
+  local.set $1
+  global.get $~lib/memory/__stack_pointer
+  local.get $1
+  i32.store
+  local.get $1
+  call $class-override/C#raw_constructor
+  local.tee $this
+  i32.store offset=4
   local.get $this
   local.set $1
   global.get $~lib/memory/__stack_pointer
@@ -2545,7 +2660,7 @@
   local.get $1
   i32.store offset=4
   local.get $1
-  call $class-override/C#constructor
+  call $class-override/C#raw_constructor
   local.tee $this
   i32.store
   local.get $this

--- a/tests/compiler/class-override.release.wat
+++ b/tests/compiler/class-override.release.wat
@@ -1,11 +1,11 @@
 (module
  (type $0 (func))
- (type $1 (func (param i32) (result i32)))
- (type $2 (func (param i32)))
- (type $3 (func (param i32 i32)))
- (type $4 (func (param i32 i32 i32 i32)))
- (type $5 (func (param i32 i32 i64)))
- (type $6 (func (result i32)))
+ (type $1 (func (param i32)))
+ (type $2 (func (param i32 i32)))
+ (type $3 (func (result i32)))
+ (type $4 (func (param i32) (result i32)))
+ (type $5 (func (param i32 i32 i32 i32)))
+ (type $6 (func (param i32 i32 i64)))
  (type $7 (func (param i32 i32) (result i32)))
  (import "env" "abort" (func $~lib/builtins/abort (param i32 i32 i32 i32)))
  (global $~lib/rt/itcms/total (mut i32) (i32.const 0))
@@ -1143,23 +1143,23 @@
    end
   end
  )
- (func $~lib/rt/itcms/__new (param $0 i32) (result i32)
+ (func $~lib/rt/itcms/__new (result i32)
+  (local $0 i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
-  (local $4 i32)
   global.get $~lib/rt/itcms/total
   global.get $~lib/rt/itcms/threshold
   i32.ge_u
   if
    block $__inlined_func$~lib/rt/itcms/interrupt$69
     i32.const 2048
-    local.set $1
+    local.set $0
     loop $do-loop|0
-     local.get $1
+     local.get $0
      call $~lib/rt/itcms/step
      i32.sub
-     local.set $1
+     local.set $0
      global.get $~lib/rt/itcms/state
      i32.eqz
      if
@@ -1175,7 +1175,7 @@
       global.set $~lib/rt/itcms/threshold
       br $__inlined_func$~lib/rt/itcms/interrupt$69
      end
-     local.get $1
+     local.get $0
      i32.const 0
      i32.gt_s
      br_if $do-loop|0
@@ -1198,17 +1198,17 @@
    call $~lib/rt/tlsf/initialize
   end
   global.get $~lib/rt/tlsf/ROOT
-  local.tee $2
-  call $~lib/rt/tlsf/searchBlock
   local.tee $1
+  call $~lib/rt/tlsf/searchBlock
+  local.tee $0
   i32.eqz
   if
    memory.size
-   local.tee $1
+   local.tee $0
    i32.const 4
-   local.get $2
-   i32.load offset=1568
    local.get $1
+   i32.load offset=1568
+   local.get $0
    i32.const 16
    i32.shl
    i32.const 4
@@ -1221,16 +1221,16 @@
    i32.and
    i32.const 16
    i32.shr_u
-   local.tee $3
-   local.get $1
-   local.get $3
+   local.tee $2
+   local.get $0
+   local.get $2
    i32.gt_s
    select
    memory.grow
    i32.const 0
    i32.lt_s
    if
-    local.get $3
+    local.get $2
     memory.grow
     i32.const 0
     i32.lt_s
@@ -1238,8 +1238,8 @@
      unreachable
     end
    end
-   local.get $2
    local.get $1
+   local.get $0
    i32.const 16
    i32.shl
    memory.size
@@ -1247,9 +1247,9 @@
    i64.const 16
    i64.shl
    call $~lib/rt/tlsf/addMemory
-   local.get $2
+   local.get $1
    call $~lib/rt/tlsf/searchBlock
-   local.tee $1
+   local.tee $0
    i32.eqz
    if
     i32.const 0
@@ -1260,7 +1260,7 @@
     unreachable
    end
   end
-  local.get $1
+  local.get $0
   i32.load
   i32.const -4
   i32.and
@@ -1274,92 +1274,92 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $2
   local.get $1
+  local.get $0
   call $~lib/rt/tlsf/removeBlock
-  local.get $1
+  local.get $0
   i32.load
-  local.tee $3
+  local.tee $2
   i32.const -4
   i32.and
   i32.const 28
   i32.sub
-  local.tee $4
+  local.tee $3
   i32.const 16
   i32.ge_u
   if
-   local.get $1
-   local.get $3
+   local.get $0
+   local.get $2
    i32.const 2
    i32.and
    i32.const 28
    i32.or
    i32.store
-   local.get $1
+   local.get $0
    i32.const 32
    i32.add
-   local.tee $3
-   local.get $4
+   local.tee $2
+   local.get $3
    i32.const 4
    i32.sub
    i32.const 1
    i32.or
    i32.store
+   local.get $1
    local.get $2
-   local.get $3
    call $~lib/rt/tlsf/insertBlock
   else
-   local.get $1
-   local.get $3
+   local.get $0
+   local.get $2
    i32.const -2
    i32.and
    i32.store
-   local.get $1
+   local.get $0
    i32.const 4
    i32.add
-   local.get $1
+   local.get $0
    i32.load
    i32.const -4
    i32.and
    i32.add
-   local.tee $2
-   local.get $2
+   local.tee $1
+   local.get $1
    i32.load
    i32.const -3
    i32.and
    i32.store
   end
-  local.get $1
   local.get $0
+  i32.const 5
   i32.store offset=12
-  local.get $1
+  local.get $0
   i32.const 0
   i32.store offset=16
   global.get $~lib/rt/itcms/fromSpace
-  local.tee $0
+  local.tee $1
   i32.load offset=8
   local.set $2
-  local.get $1
   local.get $0
+  local.get $1
   global.get $~lib/rt/itcms/white
   i32.or
   i32.store offset=4
-  local.get $1
+  local.get $0
   local.get $2
   i32.store offset=8
   local.get $2
-  local.get $1
+  local.get $0
   local.get $2
   i32.load offset=4
   i32.const 3
   i32.and
   i32.or
   i32.store offset=4
-  local.get $0
   local.get $1
+  local.get $0
   i32.store offset=8
   global.get $~lib/rt/itcms/total
-  local.get $1
+  local.get $0
   i32.load
   i32.const -4
   i32.and
@@ -1367,7 +1367,7 @@
   i32.add
   i32.add
   global.set $~lib/rt/itcms/total
-  local.get $1
+  local.get $0
   i32.const 20
   i32.add
   local.tee $0
@@ -1418,8 +1418,7 @@
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
-  (local $4 i32)
-  block $__inlined_func$start:class-override
+  block $__inlined_func$start:class-override$1
    memory.size
    i32.const 16
    i32.shl
@@ -1465,7 +1464,6 @@
     i64.const 0
     i64.store
     global.get $~lib/memory/__stack_pointer
-    i32.const 5
     call $~lib/rt/itcms/__new
     local.tee $0
     i32.store
@@ -1484,19 +1482,10 @@
     global.get $~lib/memory/__stack_pointer
     i64.const 0
     i64.store
-    local.get $0
-    i32.eqz
-    if
-     global.get $~lib/memory/__stack_pointer
-     i32.const 6
-     call $~lib/rt/itcms/__new
-     local.tee $0
-     i32.store
-    end
     global.get $~lib/memory/__stack_pointer
     global.get $~lib/memory/__stack_pointer
     local.get $0
-    i32.store offset=4
+    i32.store
     global.get $~lib/memory/__stack_pointer
     i32.const 8
     i32.sub
@@ -1508,19 +1497,10 @@
     global.get $~lib/memory/__stack_pointer
     i64.const 0
     i64.store
-    local.get $0
-    i32.eqz
-    if
-     global.get $~lib/memory/__stack_pointer
-     i32.const 7
-     call $~lib/rt/itcms/__new
-     local.tee $0
-     i32.store
-    end
     global.get $~lib/memory/__stack_pointer
     global.get $~lib/memory/__stack_pointer
     local.get $0
-    i32.store offset=4
+    i32.store
     global.get $~lib/memory/__stack_pointer
     i32.const 8
     i32.sub
@@ -1532,57 +1512,24 @@
     global.get $~lib/memory/__stack_pointer
     i64.const 0
     i64.store
-    local.get $0
-    i32.eqz
-    if
-     global.get $~lib/memory/__stack_pointer
-     i32.const 4
-     call $~lib/rt/itcms/__new
-     local.tee $0
-     i32.store
-    end
     global.get $~lib/memory/__stack_pointer
+    local.get $0
+    i32.store
     global.get $~lib/memory/__stack_pointer
     local.get $0
     i32.store offset=4
     global.get $~lib/memory/__stack_pointer
-    i32.const 4
-    i32.sub
-    global.set $~lib/memory/__stack_pointer
-    global.get $~lib/memory/__stack_pointer
-    i32.const 1540
-    i32.lt_s
-    br_if $folding-inner0
-    global.get $~lib/memory/__stack_pointer
-    i32.const 0
-    i32.store
-    local.get $0
-    i32.eqz
-    if
-     global.get $~lib/memory/__stack_pointer
-     i32.const 0
-     call $~lib/rt/itcms/__new
-     local.tee $0
-     i32.store
-    end
-    global.get $~lib/memory/__stack_pointer
-    i32.const 4
+    i32.const 8
     i32.add
     global.set $~lib/memory/__stack_pointer
     local.get $0
-    i32.store
+    i32.store offset=4
     global.get $~lib/memory/__stack_pointer
     i32.const 8
     i32.add
     global.set $~lib/memory/__stack_pointer
     local.get $0
-    i32.store
-    global.get $~lib/memory/__stack_pointer
-    i32.const 8
-    i32.add
-    global.set $~lib/memory/__stack_pointer
-    local.get $0
-    i32.store
+    i32.store offset=4
     global.get $~lib/memory/__stack_pointer
     i32.const 8
     i32.add
@@ -1607,7 +1554,7 @@
      call $~lib/builtins/abort
      unreachable
     end
-    br $__inlined_func$start:class-override
+    br $__inlined_func$start:class-override$1
    end
    i32.const 34336
    i32.const 34384

--- a/tests/compiler/class.debug.wat
+++ b/tests/compiler/class.debug.wat
@@ -1,6 +1,6 @@
 (module
- (type $0 (func (param i32 i32)))
- (type $1 (func (param i32) (result i32)))
+ (type $0 (func (param i32) (result i32)))
+ (type $1 (func (param i32 i32)))
  (type $2 (func (param i32)))
  (type $3 (func))
  (type $4 (func (param i32 i32) (result i32)))
@@ -126,6 +126,9 @@
   local.get $this
   local.get $three
   i32.store8 offset=6
+ )
+ (func $~lib/object/Object#raw_constructor (param $this i32) (result i32)
+  local.get $this
  )
  (func $~lib/rt/itcms/Object#set:nextWithColor (param $this i32) (param $nextWithColor i32)
   local.get $this
@@ -2793,6 +2796,52 @@
   global.set $~lib/memory/__stack_pointer
   local.get $6
  )
+ (func $class/GenericInitializer<i32>#raw_constructor (param $this i32) (result i32)
+  (local $1 i32)
+  global.get $~lib/memory/__stack_pointer
+  i32.const 12
+  i32.sub
+  global.set $~lib/memory/__stack_pointer
+  call $~stack_check
+  global.get $~lib/memory/__stack_pointer
+  i64.const 0
+  i64.store
+  global.get $~lib/memory/__stack_pointer
+  i32.const 0
+  i32.store offset=8
+  global.get $~lib/memory/__stack_pointer
+  local.get $this
+  local.set $1
+  global.get $~lib/memory/__stack_pointer
+  local.get $1
+  i32.store
+  local.get $1
+  call $~lib/object/Object#raw_constructor
+  local.tee $this
+  i32.store offset=4
+  local.get $this
+  local.set $1
+  global.get $~lib/memory/__stack_pointer
+  local.get $1
+  i32.store
+  local.get $1
+  i32.const 0
+  i32.const 0
+  call $~lib/array/Array<i32>#constructor
+  local.set $1
+  global.get $~lib/memory/__stack_pointer
+  local.get $1
+  i32.store offset=8
+  local.get $1
+  call $class/GenericInitializer<i32>#set:foo
+  local.get $this
+  local.set $1
+  global.get $~lib/memory/__stack_pointer
+  i32.const 12
+  i32.add
+  global.set $~lib/memory/__stack_pointer
+  local.get $1
+ )
  (func $class/GenericInitializer<i32>#constructor (param $this i32) (result i32)
   (local $1 i32)
   global.get $~lib/memory/__stack_pointer
@@ -2823,7 +2872,7 @@
   local.get $1
   i32.store offset=4
   local.get $1
-  call $~lib/object/Object#constructor
+  call $~lib/object/Object#raw_constructor
   local.tee $this
   i32.store
   local.get $this

--- a/tests/compiler/class.release.wat
+++ b/tests/compiler/class.release.wat
@@ -109,7 +109,7 @@
    local.get $1
    global.set $~lib/rt/itcms/iter
   end
-  block $__inlined_func$~lib/rt/itcms/Object#unlink$139
+  block $__inlined_func$~lib/rt/itcms/Object#unlink$138
    local.get $0
    i32.load offset=4
    i32.const -4
@@ -133,7 +133,7 @@
      call $~lib/builtins/abort
      unreachable
     end
-    br $__inlined_func$~lib/rt/itcms/Object#unlink$139
+    br $__inlined_func$~lib/rt/itcms/Object#unlink$138
    end
    local.get $0
    i32.load offset=8
@@ -1611,41 +1611,16 @@
    i32.const 4
    i32.const 5
    call $~lib/rt/itcms/__new
-   local.tee $0
+   local.tee $1
    i32.store
    global.get $~lib/memory/__stack_pointer
-   global.get $~lib/memory/__stack_pointer
-   local.get $0
+   local.get $1
    i32.store offset=4
    global.get $~lib/memory/__stack_pointer
-   i32.const 4
-   i32.sub
-   global.set $~lib/memory/__stack_pointer
-   global.get $~lib/memory/__stack_pointer
-   i32.const 1568
-   i32.lt_s
-   br_if $folding-inner0
-   global.get $~lib/memory/__stack_pointer
-   i32.const 0
-   i32.store
-   local.get $0
-   i32.eqz
-   if
-    global.get $~lib/memory/__stack_pointer
-    i32.const 0
-    i32.const 0
-    call $~lib/rt/itcms/__new
-    local.tee $0
-    i32.store
-   end
-   global.get $~lib/memory/__stack_pointer
-   i32.const 4
-   i32.add
-   global.set $~lib/memory/__stack_pointer
-   local.get $0
+   local.get $1
    i32.store
    global.get $~lib/memory/__stack_pointer
-   local.get $0
+   local.get $1
    i32.store offset=4
    global.get $~lib/memory/__stack_pointer
    i32.const 16
@@ -1665,63 +1640,63 @@
    i32.const 16
    i32.const 6
    call $~lib/rt/itcms/__new
-   local.tee $2
+   local.tee $0
    i32.store
    global.get $~lib/memory/__stack_pointer
-   local.get $2
+   local.get $0
    i32.store offset=4
-   local.get $2
+   local.get $0
    i32.const 0
    call $~lib/array/Array<i32>#set:buffer
    global.get $~lib/memory/__stack_pointer
-   local.get $2
+   local.get $0
    i32.store offset=4
-   local.get $2
+   local.get $0
    i32.const 0
    i32.store offset=4
    global.get $~lib/memory/__stack_pointer
-   local.get $2
+   local.get $0
    i32.store offset=4
-   local.get $2
+   local.get $0
    i32.const 0
    i32.store offset=8
    global.get $~lib/memory/__stack_pointer
-   local.get $2
+   local.get $0
    i32.store offset=4
-   local.get $2
+   local.get $0
    i32.const 0
    i32.store offset=12
    global.get $~lib/memory/__stack_pointer
    i32.const 32
    i32.const 1
    call $~lib/rt/itcms/__new
-   local.tee $1
+   local.tee $2
    i32.store offset=8
    global.get $~lib/memory/__stack_pointer
-   local.get $2
+   local.get $0
    i32.store offset=4
    global.get $~lib/memory/__stack_pointer
-   local.get $1
-   i32.store offset=12
    local.get $2
-   local.get $1
+   i32.store offset=12
+   local.get $0
+   local.get $2
    call $~lib/array/Array<i32>#set:buffer
    global.get $~lib/memory/__stack_pointer
-   local.get $2
+   local.get $0
    i32.store offset=4
+   local.get $0
    local.get $2
-   local.get $1
    i32.store offset=4
    global.get $~lib/memory/__stack_pointer
-   local.get $2
+   local.get $0
    i32.store offset=4
-   local.get $2
+   local.get $0
    i32.const 32
    i32.store offset=8
    global.get $~lib/memory/__stack_pointer
-   local.get $2
+   local.get $0
    i32.store offset=4
-   local.get $2
+   local.get $0
    i32.const 0
    i32.store offset=12
    global.get $~lib/memory/__stack_pointer
@@ -1729,10 +1704,10 @@
    i32.add
    global.set $~lib/memory/__stack_pointer
    global.get $~lib/memory/__stack_pointer
-   local.get $2
-   i32.store offset=8
    local.get $0
-   local.get $2
+   i32.store offset=8
+   local.get $1
+   local.get $0
    call $~lib/array/Array<i32>#set:buffer
    global.get $~lib/memory/__stack_pointer
    i32.const 12

--- a/tests/compiler/constructor.debug.wat
+++ b/tests/compiler/constructor.debug.wat
@@ -2270,6 +2270,9 @@
   local.get $a
   i32.store
  )
+ (func $~lib/object/Object#raw_constructor (param $this i32) (result i32)
+  local.get $this
+ )
  (func $constructor/JustFieldInit#set:a (param $this i32) (param $a i32)
   local.get $this
   local.get $a
@@ -2620,6 +2623,34 @@
   global.set $~lib/memory/__stack_pointer
   local.get $1
  )
+ (func $constructor/None#raw_constructor (param $this i32) (result i32)
+  (local $1 i32)
+  global.get $~lib/memory/__stack_pointer
+  i32.const 8
+  i32.sub
+  global.set $~lib/memory/__stack_pointer
+  call $~stack_check
+  global.get $~lib/memory/__stack_pointer
+  i64.const 0
+  i64.store
+  global.get $~lib/memory/__stack_pointer
+  local.get $this
+  local.set $1
+  global.get $~lib/memory/__stack_pointer
+  local.get $1
+  i32.store
+  local.get $1
+  call $~lib/object/Object#raw_constructor
+  local.tee $this
+  i32.store offset=4
+  local.get $this
+  local.set $1
+  global.get $~lib/memory/__stack_pointer
+  i32.const 8
+  i32.add
+  global.set $~lib/memory/__stack_pointer
+  local.get $1
+ )
  (func $constructor/None#constructor (param $this i32) (result i32)
   (local $1 i32)
   global.get $~lib/memory/__stack_pointer
@@ -2647,9 +2678,45 @@
   local.get $1
   i32.store offset=4
   local.get $1
-  call $~lib/object/Object#constructor
+  call $~lib/object/Object#raw_constructor
   local.tee $this
   i32.store
+  local.get $this
+  local.set $1
+  global.get $~lib/memory/__stack_pointer
+  i32.const 8
+  i32.add
+  global.set $~lib/memory/__stack_pointer
+  local.get $1
+ )
+ (func $constructor/JustFieldInit#raw_constructor (param $this i32) (result i32)
+  (local $1 i32)
+  global.get $~lib/memory/__stack_pointer
+  i32.const 8
+  i32.sub
+  global.set $~lib/memory/__stack_pointer
+  call $~stack_check
+  global.get $~lib/memory/__stack_pointer
+  i64.const 0
+  i64.store
+  global.get $~lib/memory/__stack_pointer
+  local.get $this
+  local.set $1
+  global.get $~lib/memory/__stack_pointer
+  local.get $1
+  i32.store
+  local.get $1
+  call $~lib/object/Object#raw_constructor
+  local.tee $this
+  i32.store offset=4
+  local.get $this
+  local.set $1
+  global.get $~lib/memory/__stack_pointer
+  local.get $1
+  i32.store
+  local.get $1
+  i32.const 1
+  call $constructor/JustFieldInit#set:a
   local.get $this
   local.set $1
   global.get $~lib/memory/__stack_pointer
@@ -2685,7 +2752,7 @@
   local.get $1
   i32.store offset=4
   local.get $1
-  call $~lib/object/Object#constructor
+  call $~lib/object/Object#raw_constructor
   local.tee $this
   i32.store
   local.get $this
@@ -2696,6 +2763,42 @@
   local.get $1
   i32.const 1
   call $constructor/JustFieldInit#set:a
+  local.get $this
+  local.set $1
+  global.get $~lib/memory/__stack_pointer
+  i32.const 8
+  i32.add
+  global.set $~lib/memory/__stack_pointer
+  local.get $1
+ )
+ (func $constructor/JustFieldNoInit#raw_constructor (param $this i32) (result i32)
+  (local $1 i32)
+  global.get $~lib/memory/__stack_pointer
+  i32.const 8
+  i32.sub
+  global.set $~lib/memory/__stack_pointer
+  call $~stack_check
+  global.get $~lib/memory/__stack_pointer
+  i64.const 0
+  i64.store
+  global.get $~lib/memory/__stack_pointer
+  local.get $this
+  local.set $1
+  global.get $~lib/memory/__stack_pointer
+  local.get $1
+  i32.store
+  local.get $1
+  call $~lib/object/Object#raw_constructor
+  local.tee $this
+  i32.store offset=4
+  local.get $this
+  local.set $1
+  global.get $~lib/memory/__stack_pointer
+  local.get $1
+  i32.store
+  local.get $1
+  i32.const 0
+  call $constructor/JustFieldNoInit#set:a
   local.get $this
   local.set $1
   global.get $~lib/memory/__stack_pointer
@@ -2731,7 +2834,7 @@
   local.get $1
   i32.store offset=4
   local.get $1
-  call $~lib/object/Object#constructor
+  call $~lib/object/Object#raw_constructor
   local.tee $this
   i32.store
   local.get $this
@@ -2746,6 +2849,59 @@
   local.set $1
   global.get $~lib/memory/__stack_pointer
   i32.const 8
+  i32.add
+  global.set $~lib/memory/__stack_pointer
+  local.get $1
+ )
+ (func $constructor/CtorFieldInitWithoutConstructor#raw_constructor (param $this i32) (result i32)
+  (local $1 i32)
+  global.get $~lib/memory/__stack_pointer
+  i32.const 12
+  i32.sub
+  global.set $~lib/memory/__stack_pointer
+  call $~stack_check
+  global.get $~lib/memory/__stack_pointer
+  i64.const 0
+  i64.store
+  global.get $~lib/memory/__stack_pointer
+  i32.const 0
+  i32.store offset=8
+  global.get $~lib/memory/__stack_pointer
+  local.get $this
+  local.set $1
+  global.get $~lib/memory/__stack_pointer
+  local.get $1
+  i32.store
+  local.get $1
+  call $~lib/object/Object#raw_constructor
+  local.tee $this
+  i32.store offset=4
+  local.get $this
+  local.set $1
+  global.get $~lib/memory/__stack_pointer
+  local.get $1
+  i32.store
+  local.get $1
+  i32.const 10
+  call $constructor/CtorFieldInitWithoutConstructor#set:a
+  local.get $this
+  local.set $1
+  global.get $~lib/memory/__stack_pointer
+  local.get $1
+  i32.store
+  local.get $1
+  local.get $this
+  local.set $1
+  global.get $~lib/memory/__stack_pointer
+  local.get $1
+  i32.store offset=8
+  local.get $1
+  call $constructor/CtorFieldInitWithoutConstructor#get:a
+  call $constructor/CtorFieldInitWithoutConstructor#set:b
+  local.get $this
+  local.set $1
+  global.get $~lib/memory/__stack_pointer
+  i32.const 12
   i32.add
   global.set $~lib/memory/__stack_pointer
   local.get $1
@@ -2780,7 +2936,7 @@
   local.get $1
   i32.store offset=4
   local.get $1
-  call $~lib/object/Object#constructor
+  call $~lib/object/Object#raw_constructor
   local.tee $this
   i32.store
   local.get $this

--- a/tests/compiler/constructor.release.wat
+++ b/tests/compiler/constructor.release.wat
@@ -6,7 +6,6 @@
  (type $4 (func (param i32 i32) (result i32)))
  (type $5 (func (param i32 i32 i32 i32)))
  (type $6 (func (param i32 i32 i64)))
- (type $7 (func (param i32) (result i32)))
  (import "env" "abort" (func $~lib/builtins/abort (param i32 i32 i32 i32)))
  (global $~lib/rt/itcms/total (mut i32) (i32.const 0))
  (global $~lib/rt/itcms/threshold (mut i32) (i32.const 0))
@@ -181,7 +180,7 @@
     local.get $0
     global.set $~lib/rt/itcms/iter
    end
-   block $__inlined_func$~lib/rt/itcms/Object#unlink$153
+   block $__inlined_func$~lib/rt/itcms/Object#unlink$156
     local.get $1
     i32.load offset=4
     i32.const -4
@@ -205,7 +204,7 @@
       call $~lib/builtins/abort
       unreachable
      end
-     br $__inlined_func$~lib/rt/itcms/Object#unlink$153
+     br $__inlined_func$~lib/rt/itcms/Object#unlink$156
     end
     local.get $1
     i32.load offset=8
@@ -1832,8 +1831,6 @@
    i32.store offset=4
    global.get $~lib/memory/__stack_pointer
    local.get $0
-   call $~lib/object/Object#constructor
-   local.tee $0
    i32.store
    global.get $~lib/memory/__stack_pointer
    i32.const 8
@@ -1863,8 +1860,6 @@
    i32.store offset=4
    global.get $~lib/memory/__stack_pointer
    local.get $0
-   call $~lib/object/Object#constructor
-   local.tee $0
    i32.store
    global.get $~lib/memory/__stack_pointer
    local.get $0
@@ -1900,8 +1895,6 @@
    i32.store offset=4
    global.get $~lib/memory/__stack_pointer
    local.get $0
-   call $~lib/object/Object#constructor
-   local.tee $0
    i32.store
    global.get $~lib/memory/__stack_pointer
    local.get $0
@@ -2188,8 +2181,6 @@
   i32.store offset=4
   global.get $~lib/memory/__stack_pointer
   local.get $0
-  call $~lib/object/Object#constructor
-  local.tee $0
   i32.store
   global.get $~lib/memory/__stack_pointer
   local.get $0
@@ -2209,41 +2200,6 @@
   i32.store offset=4
   global.get $~lib/memory/__stack_pointer
   i32.const 12
-  i32.add
-  global.set $~lib/memory/__stack_pointer
-  local.get $0
- )
- (func $~lib/object/Object#constructor (param $0 i32) (result i32)
-  global.get $~lib/memory/__stack_pointer
-  i32.const 4
-  i32.sub
-  global.set $~lib/memory/__stack_pointer
-  global.get $~lib/memory/__stack_pointer
-  i32.const 1556
-  i32.lt_s
-  if
-   i32.const 34352
-   i32.const 34400
-   i32.const 1
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  global.get $~lib/memory/__stack_pointer
-  i32.const 0
-  i32.store
-  local.get $0
-  i32.eqz
-  if
-   global.get $~lib/memory/__stack_pointer
-   i32.const 0
-   i32.const 0
-   call $~lib/rt/itcms/__new
-   local.tee $0
-   i32.store
-  end
-  global.get $~lib/memory/__stack_pointer
-  i32.const 4
   i32.add
   global.set $~lib/memory/__stack_pointer
   local.get $0

--- a/tests/compiler/do.debug.wat
+++ b/tests/compiler/do.debug.wat
@@ -449,6 +449,9 @@
   i32.const 1
   global.set $do/ran
  )
+ (func $~lib/object/Object#raw_constructor (param $this i32) (result i32)
+  local.get $this
+ )
  (func $~lib/rt/itcms/Object#set:nextWithColor (param $this i32) (param $nextWithColor i32)
   local.get $this
   local.get $nextWithColor
@@ -3073,6 +3076,34 @@
    unreachable
   end
  )
+ (func $do/Ref#raw_constructor (param $this i32) (result i32)
+  (local $1 i32)
+  global.get $~lib/memory/__stack_pointer
+  i32.const 8
+  i32.sub
+  global.set $~lib/memory/__stack_pointer
+  call $~stack_check
+  global.get $~lib/memory/__stack_pointer
+  i64.const 0
+  i64.store
+  global.get $~lib/memory/__stack_pointer
+  local.get $this
+  local.set $1
+  global.get $~lib/memory/__stack_pointer
+  local.get $1
+  i32.store
+  local.get $1
+  call $~lib/object/Object#raw_constructor
+  local.tee $this
+  i32.store offset=4
+  local.get $this
+  local.set $1
+  global.get $~lib/memory/__stack_pointer
+  i32.const 8
+  i32.add
+  global.set $~lib/memory/__stack_pointer
+  local.get $1
+ )
  (func $do/Ref#constructor (param $this i32) (result i32)
   (local $1 i32)
   global.get $~lib/memory/__stack_pointer
@@ -3100,7 +3131,7 @@
   local.get $1
   i32.store offset=4
   local.get $1
-  call $~lib/object/Object#constructor
+  call $~lib/object/Object#raw_constructor
   local.tee $this
   i32.store
   local.get $this

--- a/tests/compiler/do.release.wat
+++ b/tests/compiler/do.release.wat
@@ -1,11 +1,11 @@
 (module
  (type $0 (func))
- (type $1 (func (param i32)))
- (type $2 (func (param i32 i32)))
- (type $3 (func (result i32)))
- (type $4 (func (param i32) (result i32)))
- (type $5 (func (param i32 i32 i32 i32)))
- (type $6 (func (param i32 i32 i64)))
+ (type $1 (func (result i32)))
+ (type $2 (func (param i32)))
+ (type $3 (func (param i32 i32)))
+ (type $4 (func (param i32 i32 i32 i32)))
+ (type $5 (func (param i32 i32 i64)))
+ (type $6 (func (param i32) (result i32)))
  (import "env" "abort" (func $~lib/builtins/abort (param i32 i32 i32 i32)))
  (global $~lib/rt/itcms/total (mut i32) (i32.const 0))
  (global $~lib/rt/itcms/threshold (mut i32) (i32.const 0))
@@ -117,7 +117,7 @@
     local.get $0
     global.set $~lib/rt/itcms/iter
    end
-   block $__inlined_func$~lib/rt/itcms/Object#unlink$125
+   block $__inlined_func$~lib/rt/itcms/Object#unlink$124
     local.get $1
     i32.load offset=4
     i32.const -4
@@ -141,7 +141,7 @@
       call $~lib/builtins/abort
       unreachable
      end
-     br $__inlined_func$~lib/rt/itcms/Object#unlink$125
+     br $__inlined_func$~lib/rt/itcms/Object#unlink$124
     end
     local.get $1
     i32.load offset=8
@@ -1134,23 +1134,23 @@
    end
   end
  )
- (func $~lib/rt/itcms/__new (param $0 i32) (result i32)
+ (func $~lib/rt/itcms/__new (result i32)
+  (local $0 i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
-  (local $4 i32)
   global.get $~lib/rt/itcms/total
   global.get $~lib/rt/itcms/threshold
   i32.ge_u
   if
    block $__inlined_func$~lib/rt/itcms/interrupt$69
     i32.const 2048
-    local.set $1
+    local.set $0
     loop $do-loop|0
-     local.get $1
+     local.get $0
      call $~lib/rt/itcms/step
      i32.sub
-     local.set $1
+     local.set $0
      global.get $~lib/rt/itcms/state
      i32.eqz
      if
@@ -1166,7 +1166,7 @@
       global.set $~lib/rt/itcms/threshold
       br $__inlined_func$~lib/rt/itcms/interrupt$69
      end
-     local.get $1
+     local.get $0
      i32.const 0
      i32.gt_s
      br_if $do-loop|0
@@ -1189,17 +1189,17 @@
    call $~lib/rt/tlsf/initialize
   end
   global.get $~lib/rt/tlsf/ROOT
-  local.tee $2
-  call $~lib/rt/tlsf/searchBlock
   local.tee $1
+  call $~lib/rt/tlsf/searchBlock
+  local.tee $0
   i32.eqz
   if
    memory.size
-   local.tee $1
+   local.tee $0
    i32.const 4
-   local.get $2
-   i32.load offset=1568
    local.get $1
+   i32.load offset=1568
+   local.get $0
    i32.const 16
    i32.shl
    i32.const 4
@@ -1212,16 +1212,16 @@
    i32.and
    i32.const 16
    i32.shr_u
-   local.tee $3
-   local.get $1
-   local.get $3
+   local.tee $2
+   local.get $0
+   local.get $2
    i32.gt_s
    select
    memory.grow
    i32.const 0
    i32.lt_s
    if
-    local.get $3
+    local.get $2
     memory.grow
     i32.const 0
     i32.lt_s
@@ -1229,8 +1229,8 @@
      unreachable
     end
    end
-   local.get $2
    local.get $1
+   local.get $0
    i32.const 16
    i32.shl
    memory.size
@@ -1238,9 +1238,9 @@
    i64.const 16
    i64.shl
    call $~lib/rt/tlsf/addMemory
-   local.get $2
+   local.get $1
    call $~lib/rt/tlsf/searchBlock
-   local.tee $1
+   local.tee $0
    i32.eqz
    if
     i32.const 0
@@ -1251,7 +1251,7 @@
     unreachable
    end
   end
-  local.get $1
+  local.get $0
   i32.load
   i32.const -4
   i32.and
@@ -1265,92 +1265,92 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $2
   local.get $1
+  local.get $0
   call $~lib/rt/tlsf/removeBlock
-  local.get $1
+  local.get $0
   i32.load
-  local.tee $3
+  local.tee $2
   i32.const -4
   i32.and
   i32.const 28
   i32.sub
-  local.tee $4
+  local.tee $3
   i32.const 16
   i32.ge_u
   if
-   local.get $1
-   local.get $3
+   local.get $0
+   local.get $2
    i32.const 2
    i32.and
    i32.const 28
    i32.or
    i32.store
-   local.get $1
+   local.get $0
    i32.const 32
    i32.add
-   local.tee $3
-   local.get $4
+   local.tee $2
+   local.get $3
    i32.const 4
    i32.sub
    i32.const 1
    i32.or
    i32.store
+   local.get $1
    local.get $2
-   local.get $3
    call $~lib/rt/tlsf/insertBlock
   else
-   local.get $1
-   local.get $3
+   local.get $0
+   local.get $2
    i32.const -2
    i32.and
    i32.store
-   local.get $1
+   local.get $0
    i32.const 4
    i32.add
-   local.get $1
+   local.get $0
    i32.load
    i32.const -4
    i32.and
    i32.add
-   local.tee $2
-   local.get $2
+   local.tee $1
+   local.get $1
    i32.load
    i32.const -3
    i32.and
    i32.store
   end
-  local.get $1
   local.get $0
+  i32.const 4
   i32.store offset=12
-  local.get $1
+  local.get $0
   i32.const 0
   i32.store offset=16
   global.get $~lib/rt/itcms/fromSpace
-  local.tee $0
+  local.tee $1
   i32.load offset=8
   local.set $2
-  local.get $1
   local.get $0
+  local.get $1
   global.get $~lib/rt/itcms/white
   i32.or
   i32.store offset=4
-  local.get $1
+  local.get $0
   local.get $2
   i32.store offset=8
   local.get $2
-  local.get $1
+  local.get $0
   local.get $2
   i32.load offset=4
   i32.const 3
   i32.and
   i32.or
   i32.store offset=4
-  local.get $0
   local.get $1
+  local.get $0
   i32.store offset=8
   global.get $~lib/rt/itcms/total
-  local.get $1
+  local.get $0
   i32.load
   i32.const -4
   i32.and
@@ -1358,7 +1358,7 @@
   i32.add
   i32.add
   global.set $~lib/rt/itcms/total
-  local.get $1
+  local.get $0
   i32.const 20
   i32.add
   local.tee $0
@@ -1848,66 +1848,38 @@
  )
  (func $do/Ref#constructor (result i32)
   (local $0 i32)
-  (local $1 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 8
   i32.sub
   global.set $~lib/memory/__stack_pointer
-  block $folding-inner0
-   global.get $~lib/memory/__stack_pointer
-   i32.const 1496
-   i32.lt_s
-   br_if $folding-inner0
-   global.get $~lib/memory/__stack_pointer
-   i64.const 0
-   i64.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 4
-   call $~lib/rt/itcms/__new
-   local.tee $0
-   i32.store
-   global.get $~lib/memory/__stack_pointer
-   global.get $~lib/memory/__stack_pointer
-   local.get $0
-   i32.store offset=4
-   global.get $~lib/memory/__stack_pointer
-   i32.const 4
-   i32.sub
-   global.set $~lib/memory/__stack_pointer
-   global.get $~lib/memory/__stack_pointer
-   i32.const 1496
-   i32.lt_s
-   br_if $folding-inner0
-   global.get $~lib/memory/__stack_pointer
-   i32.const 0
-   i32.store
-   local.get $0
-   i32.eqz
-   if
-    global.get $~lib/memory/__stack_pointer
-    i32.const 0
-    call $~lib/rt/itcms/__new
-    local.tee $0
-    i32.store
-   end
-   global.get $~lib/memory/__stack_pointer
-   i32.const 4
-   i32.add
-   global.set $~lib/memory/__stack_pointer
-   local.get $0
-   i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 8
-   i32.add
-   global.set $~lib/memory/__stack_pointer
-   local.get $0
-   return
+  global.get $~lib/memory/__stack_pointer
+  i32.const 1496
+  i32.lt_s
+  if
+   i32.const 34288
+   i32.const 34336
+   i32.const 1
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
   end
-  i32.const 34288
-  i32.const 34336
-  i32.const 1
-  i32.const 1
-  call $~lib/builtins/abort
-  unreachable
+  global.get $~lib/memory/__stack_pointer
+  i64.const 0
+  i64.store
+  global.get $~lib/memory/__stack_pointer
+  call $~lib/rt/itcms/__new
+  local.tee $0
+  i32.store
+  global.get $~lib/memory/__stack_pointer
+  local.get $0
+  i32.store offset=4
+  global.get $~lib/memory/__stack_pointer
+  local.get $0
+  i32.store
+  global.get $~lib/memory/__stack_pointer
+  i32.const 8
+  i32.add
+  global.set $~lib/memory/__stack_pointer
+  local.get $0
  )
 )

--- a/tests/compiler/duplicate-fields.debug.wat
+++ b/tests/compiler/duplicate-fields.debug.wat
@@ -2357,6 +2357,9 @@
   local.get $this
   i32.load
  )
+ (func $~lib/object/Object#raw_constructor (param $this i32) (result i32)
+  local.get $this
+ )
  (func $duplicate-fields/A3#set:prot (param $this i32) (param $prot i32)
   local.get $this
   local.get $prot
@@ -2763,6 +2766,50 @@
   global.set $~lib/memory/__stack_pointer
   local.get $2
  )
+ (func $duplicate-fields/A3#raw_constructor (param $this i32) (result i32)
+  (local $1 i32)
+  global.get $~lib/memory/__stack_pointer
+  i32.const 8
+  i32.sub
+  global.set $~lib/memory/__stack_pointer
+  call $~stack_check
+  global.get $~lib/memory/__stack_pointer
+  i64.const 0
+  i64.store
+  global.get $~lib/memory/__stack_pointer
+  local.get $this
+  local.set $1
+  global.get $~lib/memory/__stack_pointer
+  local.get $1
+  i32.store
+  local.get $1
+  call $~lib/object/Object#raw_constructor
+  local.tee $this
+  i32.store offset=4
+  local.get $this
+  local.set $1
+  global.get $~lib/memory/__stack_pointer
+  local.get $1
+  i32.store
+  local.get $1
+  i32.const 0
+  call $duplicate-fields/A3#set:prot
+  local.get $this
+  local.set $1
+  global.get $~lib/memory/__stack_pointer
+  local.get $1
+  i32.store
+  local.get $1
+  i32.const 0
+  call $duplicate-fields/A3#set:pub
+  local.get $this
+  local.set $1
+  global.get $~lib/memory/__stack_pointer
+  i32.const 8
+  i32.add
+  global.set $~lib/memory/__stack_pointer
+  local.get $1
+ )
  (func $duplicate-fields/A3#constructor (param $this i32) (result i32)
   (local $1 i32)
   global.get $~lib/memory/__stack_pointer
@@ -2790,7 +2837,7 @@
   local.get $1
   i32.store offset=4
   local.get $1
-  call $~lib/object/Object#constructor
+  call $~lib/object/Object#raw_constructor
   local.tee $this
   i32.store
   local.get $this
@@ -2809,6 +2856,50 @@
   local.get $1
   i32.const 0
   call $duplicate-fields/A3#set:pub
+  local.get $this
+  local.set $1
+  global.get $~lib/memory/__stack_pointer
+  i32.const 8
+  i32.add
+  global.set $~lib/memory/__stack_pointer
+  local.get $1
+ )
+ (func $duplicate-fields/B3#raw_constructor (param $this i32) (result i32)
+  (local $1 i32)
+  global.get $~lib/memory/__stack_pointer
+  i32.const 8
+  i32.sub
+  global.set $~lib/memory/__stack_pointer
+  call $~stack_check
+  global.get $~lib/memory/__stack_pointer
+  i64.const 0
+  i64.store
+  global.get $~lib/memory/__stack_pointer
+  local.get $this
+  local.set $1
+  global.get $~lib/memory/__stack_pointer
+  local.get $1
+  i32.store
+  local.get $1
+  call $duplicate-fields/A3#raw_constructor
+  local.tee $this
+  i32.store offset=4
+  local.get $this
+  local.set $1
+  global.get $~lib/memory/__stack_pointer
+  local.get $1
+  i32.store
+  local.get $1
+  i32.const 0
+  call $duplicate-fields/B3#set:prot
+  local.get $this
+  local.set $1
+  global.get $~lib/memory/__stack_pointer
+  local.get $1
+  i32.store
+  local.get $1
+  i32.const 0
+  call $duplicate-fields/B3#set:pub
   local.get $this
   local.set $1
   global.get $~lib/memory/__stack_pointer
@@ -2844,7 +2935,7 @@
   local.get $1
   i32.store offset=4
   local.get $1
-  call $duplicate-fields/A3#constructor
+  call $duplicate-fields/A3#raw_constructor
   local.tee $this
   i32.store
   local.get $this

--- a/tests/compiler/duplicate-fields.release.wat
+++ b/tests/compiler/duplicate-fields.release.wat
@@ -116,7 +116,7 @@
    local.get $1
    global.set $~lib/rt/itcms/iter
   end
-  block $__inlined_func$~lib/rt/itcms/Object#unlink$139
+  block $__inlined_func$~lib/rt/itcms/Object#unlink$138
    local.get $0
    i32.load offset=4
    i32.const -4
@@ -140,7 +140,7 @@
      call $~lib/builtins/abort
      unreachable
     end
-    br $__inlined_func$~lib/rt/itcms/Object#unlink$139
+    br $__inlined_func$~lib/rt/itcms/Object#unlink$138
    end
    local.get $0
    i32.load offset=8
@@ -1797,18 +1797,18 @@
    i32.const 4
    i32.const 7
    call $~lib/rt/itcms/__new
-   local.tee $1
+   local.tee $2
    i32.store
    global.get $~lib/memory/__stack_pointer
-   local.get $1
+   local.get $2
    i32.store offset=4
-   local.get $1
+   local.get $2
    i32.const 0
    i32.store
    global.get $~lib/memory/__stack_pointer
-   local.get $1
+   local.get $2
    i32.store offset=4
-   local.get $1
+   local.get $2
    i32.const 1
    i32.store
    global.get $~lib/memory/__stack_pointer
@@ -1816,7 +1816,7 @@
    i32.add
    global.set $~lib/memory/__stack_pointer
    global.get $~lib/memory/__stack_pointer
-   local.get $1
+   local.get $2
    i32.store
    global.get $~lib/memory/__stack_pointer
    i32.const 12
@@ -1849,7 +1849,7 @@
    local.get $0
    i32.store offset=4
    global.get $~lib/memory/__stack_pointer
-   local.get $1
+   local.get $2
    i32.store offset=8
    global.get $~lib/memory/__stack_pointer
    i32.const 12
@@ -1885,10 +1885,10 @@
    local.get $0
    i32.store offset=4
    global.get $~lib/memory/__stack_pointer
-   local.get $1
+   local.get $2
    i32.store offset=8
    local.get $0
-   local.get $1
+   local.get $2
    call $duplicate-fields/A2#set:bar
    global.get $~lib/memory/__stack_pointer
    i32.const 12
@@ -1900,10 +1900,10 @@
    local.get $0
    i32.store offset=4
    global.get $~lib/memory/__stack_pointer
-   local.get $1
+   local.get $2
    i32.store offset=8
    local.get $0
-   local.get $1
+   local.get $2
    call $duplicate-fields/A2#set:bar
    global.get $~lib/memory/__stack_pointer
    i32.const 12
@@ -1964,56 +1964,21 @@
    global.get $~lib/memory/__stack_pointer
    i64.const 0
    i64.store
-   local.get $0
-   i32.eqz
-   if
-    global.get $~lib/memory/__stack_pointer
-    i32.const 8
-    i32.const 10
-    call $~lib/rt/itcms/__new
-    local.tee $0
-    i32.store
-   end
    global.get $~lib/memory/__stack_pointer
-   global.get $~lib/memory/__stack_pointer
-   local.get $0
-   i32.store offset=4
-   global.get $~lib/memory/__stack_pointer
-   i32.const 4
-   i32.sub
-   global.set $~lib/memory/__stack_pointer
-   global.get $~lib/memory/__stack_pointer
-   i32.const 1552
-   i32.lt_s
-   br_if $folding-inner0
-   global.get $~lib/memory/__stack_pointer
-   i32.const 0
-   i32.store
-   local.get $0
-   i32.eqz
-   if
-    global.get $~lib/memory/__stack_pointer
-    i32.const 0
-    i32.const 0
-    call $~lib/rt/itcms/__new
-    local.tee $0
-    i32.store
-   end
-   global.get $~lib/memory/__stack_pointer
-   i32.const 4
-   i32.add
-   global.set $~lib/memory/__stack_pointer
    local.get $0
    i32.store
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store offset=4
+   global.get $~lib/memory/__stack_pointer
+   local.get $0
+   i32.store
    local.get $0
    i32.const 0
    i32.store
    global.get $~lib/memory/__stack_pointer
    local.get $0
-   i32.store offset=4
+   i32.store
    local.get $0
    i32.const 0
    i32.store offset=4

--- a/tests/compiler/extends-baseaggregate.debug.wat
+++ b/tests/compiler/extends-baseaggregate.debug.wat
@@ -51,6 +51,9 @@
  (elem $0 (i32.const 1))
  (export "memory" (memory $0))
  (start $~start)
+ (func $~lib/object/Object#raw_constructor (param $this i32) (result i32)
+  local.get $this
+ )
  (func $~lib/rt/itcms/Object#set:nextWithColor (param $this i32) (param $nextWithColor i32)
   local.get $this
   local.get $nextWithColor
@@ -2591,6 +2594,58 @@
    unreachable
   end
  )
+ (func $extends-baseaggregate/A1#raw_constructor (param $this i32) (result i32)
+  (local $1 i32)
+  global.get $~lib/memory/__stack_pointer
+  i32.const 8
+  i32.sub
+  global.set $~lib/memory/__stack_pointer
+  call $~stack_check
+  global.get $~lib/memory/__stack_pointer
+  i64.const 0
+  i64.store
+  global.get $~lib/memory/__stack_pointer
+  local.get $this
+  local.set $1
+  global.get $~lib/memory/__stack_pointer
+  local.get $1
+  i32.store
+  local.get $1
+  call $~lib/object/Object#raw_constructor
+  local.tee $this
+  i32.store offset=4
+  local.get $this
+  local.set $1
+  global.get $~lib/memory/__stack_pointer
+  local.get $1
+  i32.store
+  local.get $1
+  f64.const 0
+  call $extends-baseaggregate/A1#set:padding0
+  local.get $this
+  local.set $1
+  global.get $~lib/memory/__stack_pointer
+  local.get $1
+  i32.store
+  local.get $1
+  f64.const 0
+  call $extends-baseaggregate/A1#set:padding1
+  local.get $this
+  local.set $1
+  global.get $~lib/memory/__stack_pointer
+  local.get $1
+  i32.store
+  local.get $1
+  i32.const 0
+  call $extends-baseaggregate/A1#set:c1
+  local.get $this
+  local.set $1
+  global.get $~lib/memory/__stack_pointer
+  i32.const 8
+  i32.add
+  global.set $~lib/memory/__stack_pointer
+  local.get $1
+ )
  (func $extends-baseaggregate/A1#constructor (param $this i32) (result i32)
   (local $1 i32)
   global.get $~lib/memory/__stack_pointer
@@ -2618,7 +2673,7 @@
   local.get $1
   i32.store offset=4
   local.get $1
-  call $~lib/object/Object#constructor
+  call $~lib/object/Object#raw_constructor
   local.tee $this
   i32.store
   local.get $this
@@ -2645,6 +2700,34 @@
   local.get $1
   i32.const 0
   call $extends-baseaggregate/A1#set:c1
+  local.get $this
+  local.set $1
+  global.get $~lib/memory/__stack_pointer
+  i32.const 8
+  i32.add
+  global.set $~lib/memory/__stack_pointer
+  local.get $1
+ )
+ (func $extends-baseaggregate/A2#raw_constructor (param $this i32) (result i32)
+  (local $1 i32)
+  global.get $~lib/memory/__stack_pointer
+  i32.const 8
+  i32.sub
+  global.set $~lib/memory/__stack_pointer
+  call $~stack_check
+  global.get $~lib/memory/__stack_pointer
+  i64.const 0
+  i64.store
+  global.get $~lib/memory/__stack_pointer
+  local.get $this
+  local.set $1
+  global.get $~lib/memory/__stack_pointer
+  local.get $1
+  i32.store
+  local.get $1
+  call $extends-baseaggregate/A1#raw_constructor
+  local.tee $this
+  i32.store offset=4
   local.get $this
   local.set $1
   global.get $~lib/memory/__stack_pointer
@@ -2680,7 +2763,7 @@
   local.get $1
   i32.store offset=4
   local.get $1
-  call $extends-baseaggregate/A1#constructor
+  call $extends-baseaggregate/A1#raw_constructor
   local.tee $this
   i32.store
   local.get $this

--- a/tests/compiler/extends-baseaggregate.release.wat
+++ b/tests/compiler/extends-baseaggregate.release.wat
@@ -120,7 +120,7 @@
    local.get $1
    global.set $~lib/rt/itcms/iter
   end
-  block $__inlined_func$~lib/rt/itcms/Object#unlink$142
+  block $__inlined_func$~lib/rt/itcms/Object#unlink$141
    local.get $0
    i32.load offset=4
    i32.const -4
@@ -144,7 +144,7 @@
      call $~lib/builtins/abort
      unreachable
     end
-    br $__inlined_func$~lib/rt/itcms/Object#unlink$142
+    br $__inlined_func$~lib/rt/itcms/Object#unlink$141
    end
    local.get $0
    i32.load offset=8
@@ -1804,62 +1804,27 @@
    global.get $~lib/memory/__stack_pointer
    i64.const 0
    i64.store
-   local.get $6
-   i32.eqz
-   if
-    global.get $~lib/memory/__stack_pointer
-    i32.const 20
-    i32.const 5
-    call $~lib/rt/itcms/__new
-    local.tee $6
-    i32.store
-   end
    global.get $~lib/memory/__stack_pointer
-   global.get $~lib/memory/__stack_pointer
-   local.get $6
-   i32.store offset=4
-   global.get $~lib/memory/__stack_pointer
-   i32.const 4
-   i32.sub
-   global.set $~lib/memory/__stack_pointer
-   global.get $~lib/memory/__stack_pointer
-   i32.const 1740
-   i32.lt_s
-   br_if $folding-inner1
-   global.get $~lib/memory/__stack_pointer
-   i32.const 0
-   i32.store
-   local.get $6
-   i32.eqz
-   if
-    global.get $~lib/memory/__stack_pointer
-    i32.const 0
-    i32.const 0
-    call $~lib/rt/itcms/__new
-    local.tee $6
-    i32.store
-   end
-   global.get $~lib/memory/__stack_pointer
-   i32.const 4
-   i32.add
-   global.set $~lib/memory/__stack_pointer
    local.get $6
    i32.store
    global.get $~lib/memory/__stack_pointer
    local.get $6
    i32.store offset=4
+   global.get $~lib/memory/__stack_pointer
+   local.get $6
+   i32.store
    local.get $6
    f64.const 0
    f64.store
    global.get $~lib/memory/__stack_pointer
    local.get $6
-   i32.store offset=4
+   i32.store
    local.get $6
    f64.const 0
    f64.store offset=8
    global.get $~lib/memory/__stack_pointer
    local.get $6
-   i32.store offset=4
+   i32.store
    local.get $6
    i32.const 0
    i32.store offset=16
@@ -1937,7 +1902,7 @@
     global.get $~lib/memory/__stack_pointer
     i32.const 1168
     i32.store
-    block $__inlined_func$~lib/rt/itcms/__renew$141
+    block $__inlined_func$~lib/rt/itcms/__renew$140
      i32.const 1073741820
      local.get $0
      i32.const 1
@@ -1980,7 +1945,7 @@
       i32.store offset=16
       local.get $0
       local.set $1
-      br $__inlined_func$~lib/rt/itcms/__renew$141
+      br $__inlined_func$~lib/rt/itcms/__renew$140
      end
      local.get $3
      local.get $2

--- a/tests/compiler/extends-recursive.debug.wat
+++ b/tests/compiler/extends-recursive.debug.wat
@@ -41,6 +41,9 @@
  (elem $0 (i32.const 1))
  (export "memory" (memory $0))
  (start $~start)
+ (func $~lib/object/Object#raw_constructor (param $this i32) (result i32)
+  local.get $this
+ )
  (func $~lib/rt/itcms/Object#set:nextWithColor (param $this i32) (param $nextWithColor i32)
   local.get $this
   local.get $nextWithColor
@@ -2429,6 +2432,42 @@
    unreachable
   end
  )
+ (func $extends-recursive/Parent#raw_constructor (param $this i32) (result i32)
+  (local $1 i32)
+  global.get $~lib/memory/__stack_pointer
+  i32.const 8
+  i32.sub
+  global.set $~lib/memory/__stack_pointer
+  call $~stack_check
+  global.get $~lib/memory/__stack_pointer
+  i64.const 0
+  i64.store
+  global.get $~lib/memory/__stack_pointer
+  local.get $this
+  local.set $1
+  global.get $~lib/memory/__stack_pointer
+  local.get $1
+  i32.store
+  local.get $1
+  call $~lib/object/Object#raw_constructor
+  local.tee $this
+  i32.store offset=4
+  local.get $this
+  local.set $1
+  global.get $~lib/memory/__stack_pointer
+  local.get $1
+  i32.store
+  local.get $1
+  i32.const 0
+  call $extends-recursive/Parent#set:child
+  local.get $this
+  local.set $1
+  global.get $~lib/memory/__stack_pointer
+  i32.const 8
+  i32.add
+  global.set $~lib/memory/__stack_pointer
+  local.get $1
+ )
  (func $extends-recursive/Parent#constructor (param $this i32) (result i32)
   (local $1 i32)
   global.get $~lib/memory/__stack_pointer
@@ -2456,7 +2495,7 @@
   local.get $1
   i32.store offset=4
   local.get $1
-  call $~lib/object/Object#constructor
+  call $~lib/object/Object#raw_constructor
   local.tee $this
   i32.store
   local.get $this
@@ -2467,6 +2506,34 @@
   local.get $1
   i32.const 0
   call $extends-recursive/Parent#set:child
+  local.get $this
+  local.set $1
+  global.get $~lib/memory/__stack_pointer
+  i32.const 8
+  i32.add
+  global.set $~lib/memory/__stack_pointer
+  local.get $1
+ )
+ (func $extends-recursive/Child#raw_constructor (param $this i32) (result i32)
+  (local $1 i32)
+  global.get $~lib/memory/__stack_pointer
+  i32.const 8
+  i32.sub
+  global.set $~lib/memory/__stack_pointer
+  call $~stack_check
+  global.get $~lib/memory/__stack_pointer
+  i64.const 0
+  i64.store
+  global.get $~lib/memory/__stack_pointer
+  local.get $this
+  local.set $1
+  global.get $~lib/memory/__stack_pointer
+  local.get $1
+  i32.store
+  local.get $1
+  call $extends-recursive/Parent#raw_constructor
+  local.tee $this
+  i32.store offset=4
   local.get $this
   local.set $1
   global.get $~lib/memory/__stack_pointer
@@ -2502,7 +2569,7 @@
   local.get $1
   i32.store offset=4
   local.get $1
-  call $extends-recursive/Parent#constructor
+  call $extends-recursive/Parent#raw_constructor
   local.tee $this
   i32.store
   local.get $this

--- a/tests/compiler/extends-recursive.release.wat
+++ b/tests/compiler/extends-recursive.release.wat
@@ -2,10 +2,10 @@
  (type $0 (func))
  (type $1 (func (param i32)))
  (type $2 (func (param i32 i32)))
- (type $3 (func (param i32 i32) (result i32)))
+ (type $3 (func (result i32)))
  (type $4 (func (param i32 i32 i32 i32)))
  (type $5 (func (param i32 i32 i64)))
- (type $6 (func (result i32)))
+ (type $6 (func (param i32) (result i32)))
  (import "env" "abort" (func $~lib/builtins/abort (param i32 i32 i32 i32)))
  (global $~lib/rt/itcms/total (mut i32) (i32.const 0))
  (global $~lib/rt/itcms/threshold (mut i32) (i32.const 0))
@@ -1075,85 +1075,18 @@
   end
   i32.const 0
  )
- (func $~lib/rt/tlsf/searchBlock (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/rt/tlsf/searchBlock (param $0 i32) (result i32)
+  (local $1 i32)
   (local $2 i32)
-  local.get $1
-  i32.const 256
-  i32.lt_u
-  if
-   local.get $1
-   i32.const 4
-   i32.shr_u
-   local.set $1
-  else
-   local.get $1
-   i32.const 536870910
-   i32.lt_u
-   if
-    local.get $1
-    i32.const 1
-    i32.const 27
-    local.get $1
-    i32.clz
-    i32.sub
-    i32.shl
-    i32.add
-    i32.const 1
-    i32.sub
-    local.set $1
-   end
-   local.get $1
-   i32.const 31
-   local.get $1
-   i32.clz
-   i32.sub
-   local.tee $2
-   i32.const 4
-   i32.sub
-   i32.shr_u
-   i32.const 16
-   i32.xor
-   local.set $1
-   local.get $2
-   i32.const 7
-   i32.sub
-   local.set $2
-  end
-  local.get $1
-  i32.const 16
-  i32.lt_u
-  local.get $2
-  i32.const 23
-  i32.lt_u
-  i32.and
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1392
-   i32.const 334
-   i32.const 14
-   call $~lib/builtins/abort
-   unreachable
-  end
   local.get $0
-  local.get $2
-  i32.const 2
-  i32.shl
-  i32.add
   i32.load offset=4
-  i32.const -1
-  local.get $1
-  i32.shl
+  i32.const -2
   i32.and
   local.tee $1
   if (result i32)
    local.get $0
    local.get $1
    i32.ctz
-   local.get $2
-   i32.const 4
-   i32.shl
-   i32.add
    i32.const 2
    i32.shl
    i32.add
@@ -1161,23 +1094,19 @@
   else
    local.get $0
    i32.load
-   i32.const -1
-   local.get $2
-   i32.const 1
-   i32.add
-   i32.shl
+   i32.const -2
    i32.and
    local.tee $1
    if (result i32)
     local.get $0
     local.get $1
     i32.ctz
-    local.tee $1
+    local.tee $2
     i32.const 2
     i32.shl
     i32.add
     i32.load offset=4
-    local.tee $2
+    local.tee $1
     i32.eqz
     if
      i32.const 0
@@ -1188,9 +1117,9 @@
      unreachable
     end
     local.get $0
-    local.get $2
-    i32.ctz
     local.get $1
+    i32.ctz
+    local.get $2
     i32.const 4
     i32.shl
     i32.add
@@ -1203,35 +1132,23 @@
    end
   end
  )
- (func $~lib/rt/itcms/__new (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/rt/itcms/__new (result i32)
+  (local $0 i32)
+  (local $1 i32)
   (local $2 i32)
   (local $3 i32)
-  (local $4 i32)
-  (local $5 i32)
-  (local $6 i32)
-  local.get $0
-  i32.const 1073741804
-  i32.ge_u
-  if
-   i32.const 1056
-   i32.const 1120
-   i32.const 261
-   i32.const 31
-   call $~lib/builtins/abort
-   unreachable
-  end
   global.get $~lib/rt/itcms/total
   global.get $~lib/rt/itcms/threshold
   i32.ge_u
   if
    block $__inlined_func$~lib/rt/itcms/interrupt$69
     i32.const 2048
-    local.set $2
+    local.set $0
     loop $do-loop|0
-     local.get $2
+     local.get $0
      call $~lib/rt/itcms/step
      i32.sub
-     local.set $2
+     local.set $0
      global.get $~lib/rt/itcms/state
      i32.eqz
      if
@@ -1247,7 +1164,7 @@
       global.set $~lib/rt/itcms/threshold
       br $__inlined_func$~lib/rt/itcms/interrupt$69
      end
-     local.get $2
+     local.get $0
      i32.const 0
      i32.gt_s
      br_if $do-loop|0
@@ -1270,94 +1187,39 @@
    call $~lib/rt/tlsf/initialize
   end
   global.get $~lib/rt/tlsf/ROOT
-  local.set $4
-  local.get $0
-  i32.const 16
-  i32.add
-  local.tee $2
-  i32.const 1073741820
-  i32.gt_u
-  if
-   i32.const 1056
-   i32.const 1392
-   i32.const 461
-   i32.const 29
-   call $~lib/builtins/abort
-   unreachable
-  end
-  local.get $4
-  local.get $2
-  i32.const 12
-  i32.le_u
-  if (result i32)
-   i32.const 12
-  else
-   local.get $2
-   i32.const 19
-   i32.add
-   i32.const -16
-   i32.and
-   i32.const 4
-   i32.sub
-  end
-  local.tee $5
+  local.tee $1
   call $~lib/rt/tlsf/searchBlock
-  local.tee $2
+  local.tee $0
   i32.eqz
   if
    memory.size
-   local.tee $2
-   local.get $5
-   i32.const 256
-   i32.ge_u
-   if (result i32)
-    local.get $5
-    i32.const 536870910
-    i32.lt_u
-    if (result i32)
-     local.get $5
-     i32.const 1
-     i32.const 27
-     local.get $5
-     i32.clz
-     i32.sub
-     i32.shl
-     i32.add
-     i32.const 1
-     i32.sub
-    else
-     local.get $5
-    end
-   else
-    local.get $5
-   end
+   local.tee $0
    i32.const 4
-   local.get $4
+   local.get $1
    i32.load offset=1568
-   local.get $2
+   local.get $0
    i32.const 16
    i32.shl
    i32.const 4
    i32.sub
    i32.ne
    i32.shl
-   i32.add
-   i32.const 65535
+   i32.const 65563
    i32.add
    i32.const -65536
    i32.and
    i32.const 16
    i32.shr_u
-   local.tee $3
+   local.tee $2
+   local.get $0
    local.get $2
-   local.get $3
    i32.gt_s
    select
    memory.grow
    i32.const 0
    i32.lt_s
    if
-    local.get $3
+    local.get $2
     memory.grow
     i32.const 0
     i32.lt_s
@@ -1365,8 +1227,8 @@
      unreachable
     end
    end
-   local.get $4
-   local.get $2
+   local.get $1
+   local.get $0
    i32.const 16
    i32.shl
    memory.size
@@ -1374,10 +1236,9 @@
    i64.const 16
    i64.shl
    call $~lib/rt/tlsf/addMemory
-   local.get $4
-   local.get $5
+   local.get $1
    call $~lib/rt/tlsf/searchBlock
-   local.tee $2
+   local.tee $0
    i32.eqz
    if
     i32.const 0
@@ -1388,12 +1249,12 @@
     unreachable
    end
   end
-  local.get $5
-  local.get $2
+  local.get $0
   i32.load
   i32.const -4
   i32.and
-  i32.gt_u
+  i32.const 28
+  i32.lt_u
   if
    i32.const 0
    i32.const 1392
@@ -1402,108 +1263,92 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $4
-  local.get $2
+  local.get $1
+  local.get $0
   call $~lib/rt/tlsf/removeBlock
-  local.get $2
+  local.get $0
   i32.load
-  local.set $6
-  local.get $5
-  i32.const 4
-  i32.add
-  i32.const 15
-  i32.and
-  if
-   i32.const 0
-   i32.const 1392
-   i32.const 361
-   i32.const 14
-   call $~lib/builtins/abort
-   unreachable
-  end
-  local.get $6
+  local.tee $2
   i32.const -4
   i32.and
-  local.get $5
+  i32.const 28
   i32.sub
   local.tee $3
   i32.const 16
   i32.ge_u
   if
+   local.get $0
    local.get $2
-   local.get $5
-   local.get $6
    i32.const 2
    i32.and
+   i32.const 28
    i32.or
    i32.store
-   local.get $2
-   i32.const 4
+   local.get $0
+   i32.const 32
    i32.add
-   local.get $5
-   i32.add
-   local.tee $5
+   local.tee $2
    local.get $3
    i32.const 4
    i32.sub
    i32.const 1
    i32.or
    i32.store
-   local.get $4
-   local.get $5
+   local.get $1
+   local.get $2
    call $~lib/rt/tlsf/insertBlock
   else
+   local.get $0
    local.get $2
-   local.get $6
    i32.const -2
    i32.and
    i32.store
-   local.get $2
+   local.get $0
    i32.const 4
    i32.add
-   local.get $2
+   local.get $0
    i32.load
    i32.const -4
    i32.and
    i32.add
-   local.tee $3
-   local.get $3
+   local.tee $1
+   local.get $1
    i32.load
    i32.const -3
    i32.and
    i32.store
   end
-  local.get $2
-  local.get $1
-  i32.store offset=12
-  local.get $2
   local.get $0
+  i32.const 4
+  i32.store offset=12
+  local.get $0
+  i32.const 4
   i32.store offset=16
   global.get $~lib/rt/itcms/fromSpace
   local.tee $1
   i32.load offset=8
-  local.set $3
-  local.get $2
+  local.set $2
+  local.get $0
   local.get $1
   global.get $~lib/rt/itcms/white
   i32.or
   i32.store offset=4
+  local.get $0
   local.get $2
-  local.get $3
   i32.store offset=8
-  local.get $3
   local.get $2
-  local.get $3
+  local.get $0
+  local.get $2
   i32.load offset=4
   i32.const 3
   i32.and
   i32.or
   i32.store offset=4
   local.get $1
-  local.get $2
+  local.get $0
   i32.store offset=8
   global.get $~lib/rt/itcms/total
-  local.get $2
+  local.get $0
   i32.load
   i32.const -4
   i32.and
@@ -1511,14 +1356,13 @@
   i32.add
   i32.add
   global.set $~lib/rt/itcms/total
-  local.get $2
+  local.get $0
   i32.const 20
   i32.add
-  local.tee $1
+  local.tee $0
   i32.const 0
+  i32.store align=1
   local.get $0
-  memory.fill
-  local.get $1
  )
  (func $~lib/rt/__visit_members (param $0 i32)
   block $folding-inner0
@@ -1547,8 +1391,7 @@
  (func $~start
   (local $0 i32)
   (local $1 i32)
-  (local $2 i32)
-  block $__inlined_func$start:extends-recursive$1
+  block $__inlined_func$start:extends-recursive$2
    memory.size
    i32.const 16
    i32.shl
@@ -1594,8 +1437,6 @@
     i64.const 0
     i64.store
     global.get $~lib/memory/__stack_pointer
-    i32.const 4
-    i32.const 4
     call $~lib/rt/itcms/__new
     local.tee $0
     i32.store
@@ -1614,50 +1455,15 @@
     global.get $~lib/memory/__stack_pointer
     i64.const 0
     i64.store
-    local.get $0
-    i32.eqz
-    if
-     global.get $~lib/memory/__stack_pointer
-     i32.const 4
-     i32.const 5
-     call $~lib/rt/itcms/__new
-     local.tee $0
-     i32.store
-    end
     global.get $~lib/memory/__stack_pointer
-    global.get $~lib/memory/__stack_pointer
-    local.get $0
-    i32.store offset=4
-    global.get $~lib/memory/__stack_pointer
-    i32.const 4
-    i32.sub
-    global.set $~lib/memory/__stack_pointer
-    global.get $~lib/memory/__stack_pointer
-    i32.const 1468
-    i32.lt_s
-    br_if $folding-inner0
-    global.get $~lib/memory/__stack_pointer
-    i32.const 0
-    i32.store
-    local.get $0
-    i32.eqz
-    if
-     global.get $~lib/memory/__stack_pointer
-     i32.const 0
-     i32.const 0
-     call $~lib/rt/itcms/__new
-     local.tee $0
-     i32.store
-    end
-    global.get $~lib/memory/__stack_pointer
-    i32.const 4
-    i32.add
-    global.set $~lib/memory/__stack_pointer
     local.get $0
     i32.store
     global.get $~lib/memory/__stack_pointer
     local.get $0
     i32.store offset=4
+    global.get $~lib/memory/__stack_pointer
+    local.get $0
+    i32.store
     local.get $0
     i32.const 0
     i32.store
@@ -1671,7 +1477,7 @@
     i32.const 8
     i32.add
     global.set $~lib/memory/__stack_pointer
-    br $__inlined_func$start:extends-recursive$1
+    br $__inlined_func$start:extends-recursive$2
    end
    i32.const 34256
    i32.const 34304

--- a/tests/compiler/field-initialization.debug.wat
+++ b/tests/compiler/field-initialization.debug.wat
@@ -52,6 +52,9 @@
  (elem $0 (i32.const 1))
  (export "memory" (memory $0))
  (start $~start)
+ (func $~lib/object/Object#raw_constructor (param $this i32) (result i32)
+  local.get $this
+ )
  (func $~lib/rt/itcms/Object#set:nextWithColor (param $this i32) (param $nextWithColor i32)
   local.get $this
   local.get $nextWithColor
@@ -3028,6 +3031,42 @@
    unreachable
   end
  )
+ (func $field-initialization/Value_Init#raw_constructor (param $this i32) (result i32)
+  (local $1 i32)
+  global.get $~lib/memory/__stack_pointer
+  i32.const 8
+  i32.sub
+  global.set $~lib/memory/__stack_pointer
+  call $~stack_check
+  global.get $~lib/memory/__stack_pointer
+  i64.const 0
+  i64.store
+  global.get $~lib/memory/__stack_pointer
+  local.get $this
+  local.set $1
+  global.get $~lib/memory/__stack_pointer
+  local.get $1
+  i32.store
+  local.get $1
+  call $~lib/object/Object#raw_constructor
+  local.tee $this
+  i32.store offset=4
+  local.get $this
+  local.set $1
+  global.get $~lib/memory/__stack_pointer
+  local.get $1
+  i32.store
+  local.get $1
+  i32.const 1
+  call $field-initialization/Value_Init#set:a
+  local.get $this
+  local.set $1
+  global.get $~lib/memory/__stack_pointer
+  i32.const 8
+  i32.add
+  global.set $~lib/memory/__stack_pointer
+  local.get $1
+ )
  (func $field-initialization/Value_Init#constructor (param $this i32) (result i32)
   (local $1 i32)
   global.get $~lib/memory/__stack_pointer
@@ -3055,7 +3094,7 @@
   local.get $1
   i32.store offset=4
   local.get $1
-  call $~lib/object/Object#constructor
+  call $~lib/object/Object#raw_constructor
   local.tee $this
   i32.store
   local.get $this
@@ -3066,6 +3105,42 @@
   local.get $1
   i32.const 1
   call $field-initialization/Value_Init#set:a
+  local.get $this
+  local.set $1
+  global.get $~lib/memory/__stack_pointer
+  i32.const 8
+  i32.add
+  global.set $~lib/memory/__stack_pointer
+  local.get $1
+ )
+ (func $field-initialization/Value#raw_constructor (param $this i32) (result i32)
+  (local $1 i32)
+  global.get $~lib/memory/__stack_pointer
+  i32.const 8
+  i32.sub
+  global.set $~lib/memory/__stack_pointer
+  call $~stack_check
+  global.get $~lib/memory/__stack_pointer
+  i64.const 0
+  i64.store
+  global.get $~lib/memory/__stack_pointer
+  local.get $this
+  local.set $1
+  global.get $~lib/memory/__stack_pointer
+  local.get $1
+  i32.store
+  local.get $1
+  call $~lib/object/Object#raw_constructor
+  local.tee $this
+  i32.store offset=4
+  local.get $this
+  local.set $1
+  global.get $~lib/memory/__stack_pointer
+  local.get $1
+  i32.store
+  local.get $1
+  i32.const 0
+  call $field-initialization/Value#set:a
   local.get $this
   local.set $1
   global.get $~lib/memory/__stack_pointer
@@ -3101,7 +3176,7 @@
   local.get $1
   i32.store offset=4
   local.get $1
-  call $~lib/object/Object#constructor
+  call $~lib/object/Object#raw_constructor
   local.tee $this
   i32.store
   local.get $this
@@ -3116,6 +3191,52 @@
   local.set $1
   global.get $~lib/memory/__stack_pointer
   i32.const 8
+  i32.add
+  global.set $~lib/memory/__stack_pointer
+  local.get $1
+ )
+ (func $field-initialization/Ref_Init#raw_constructor (param $this i32) (result i32)
+  (local $1 i32)
+  global.get $~lib/memory/__stack_pointer
+  i32.const 12
+  i32.sub
+  global.set $~lib/memory/__stack_pointer
+  call $~stack_check
+  global.get $~lib/memory/__stack_pointer
+  i64.const 0
+  i64.store
+  global.get $~lib/memory/__stack_pointer
+  i32.const 0
+  i32.store offset=8
+  global.get $~lib/memory/__stack_pointer
+  local.get $this
+  local.set $1
+  global.get $~lib/memory/__stack_pointer
+  local.get $1
+  i32.store
+  local.get $1
+  call $~lib/object/Object#raw_constructor
+  local.tee $this
+  i32.store offset=4
+  local.get $this
+  local.set $1
+  global.get $~lib/memory/__stack_pointer
+  local.get $1
+  i32.store
+  local.get $1
+  i32.const 0
+  i32.const 0
+  call $~lib/arraybuffer/ArrayBuffer#constructor
+  local.set $1
+  global.get $~lib/memory/__stack_pointer
+  local.get $1
+  i32.store offset=8
+  local.get $1
+  call $field-initialization/Ref_Init#set:a
+  local.get $this
+  local.set $1
+  global.get $~lib/memory/__stack_pointer
+  i32.const 12
   i32.add
   global.set $~lib/memory/__stack_pointer
   local.get $1
@@ -3150,7 +3271,7 @@
   local.get $1
   i32.store offset=4
   local.get $1
-  call $~lib/object/Object#constructor
+  call $~lib/object/Object#raw_constructor
   local.tee $this
   i32.store
   local.get $this
@@ -3168,6 +3289,52 @@
   i32.store offset=8
   local.get $1
   call $field-initialization/Ref_Init#set:a
+  local.get $this
+  local.set $1
+  global.get $~lib/memory/__stack_pointer
+  i32.const 12
+  i32.add
+  global.set $~lib/memory/__stack_pointer
+  local.get $1
+ )
+ (func $field-initialization/Nullable_Init#raw_constructor (param $this i32) (result i32)
+  (local $1 i32)
+  global.get $~lib/memory/__stack_pointer
+  i32.const 12
+  i32.sub
+  global.set $~lib/memory/__stack_pointer
+  call $~stack_check
+  global.get $~lib/memory/__stack_pointer
+  i64.const 0
+  i64.store
+  global.get $~lib/memory/__stack_pointer
+  i32.const 0
+  i32.store offset=8
+  global.get $~lib/memory/__stack_pointer
+  local.get $this
+  local.set $1
+  global.get $~lib/memory/__stack_pointer
+  local.get $1
+  i32.store
+  local.get $1
+  call $~lib/object/Object#raw_constructor
+  local.tee $this
+  i32.store offset=4
+  local.get $this
+  local.set $1
+  global.get $~lib/memory/__stack_pointer
+  local.get $1
+  i32.store
+  local.get $1
+  i32.const 0
+  i32.const 0
+  call $~lib/arraybuffer/ArrayBuffer#constructor
+  local.set $1
+  global.get $~lib/memory/__stack_pointer
+  local.get $1
+  i32.store offset=8
+  local.get $1
+  call $field-initialization/Nullable_Init#set:a
   local.get $this
   local.set $1
   global.get $~lib/memory/__stack_pointer
@@ -3206,7 +3373,7 @@
   local.get $1
   i32.store offset=4
   local.get $1
-  call $~lib/object/Object#constructor
+  call $~lib/object/Object#raw_constructor
   local.tee $this
   i32.store
   local.get $this
@@ -3228,6 +3395,42 @@
   local.set $1
   global.get $~lib/memory/__stack_pointer
   i32.const 12
+  i32.add
+  global.set $~lib/memory/__stack_pointer
+  local.get $1
+ )
+ (func $field-initialization/Nullable#raw_constructor (param $this i32) (result i32)
+  (local $1 i32)
+  global.get $~lib/memory/__stack_pointer
+  i32.const 8
+  i32.sub
+  global.set $~lib/memory/__stack_pointer
+  call $~stack_check
+  global.get $~lib/memory/__stack_pointer
+  i64.const 0
+  i64.store
+  global.get $~lib/memory/__stack_pointer
+  local.get $this
+  local.set $1
+  global.get $~lib/memory/__stack_pointer
+  local.get $1
+  i32.store
+  local.get $1
+  call $~lib/object/Object#raw_constructor
+  local.tee $this
+  i32.store offset=4
+  local.get $this
+  local.set $1
+  global.get $~lib/memory/__stack_pointer
+  local.get $1
+  i32.store
+  local.get $1
+  i32.const 0
+  call $field-initialization/Nullable#set:a
+  local.get $this
+  local.set $1
+  global.get $~lib/memory/__stack_pointer
+  i32.const 8
   i32.add
   global.set $~lib/memory/__stack_pointer
   local.get $1
@@ -3259,7 +3462,7 @@
   local.get $1
   i32.store offset=4
   local.get $1
-  call $~lib/object/Object#constructor
+  call $~lib/object/Object#raw_constructor
   local.tee $this
   i32.store
   local.get $this
@@ -3674,6 +3877,52 @@
   global.set $~lib/memory/__stack_pointer
   local.get $1
  )
+ (func $field-initialization/Inherit_Base#raw_constructor (param $this i32) (result i32)
+  (local $1 i32)
+  global.get $~lib/memory/__stack_pointer
+  i32.const 12
+  i32.sub
+  global.set $~lib/memory/__stack_pointer
+  call $~stack_check
+  global.get $~lib/memory/__stack_pointer
+  i64.const 0
+  i64.store
+  global.get $~lib/memory/__stack_pointer
+  i32.const 0
+  i32.store offset=8
+  global.get $~lib/memory/__stack_pointer
+  local.get $this
+  local.set $1
+  global.get $~lib/memory/__stack_pointer
+  local.get $1
+  i32.store
+  local.get $1
+  call $~lib/object/Object#raw_constructor
+  local.tee $this
+  i32.store offset=4
+  local.get $this
+  local.set $1
+  global.get $~lib/memory/__stack_pointer
+  local.get $1
+  i32.store
+  local.get $1
+  i32.const 0
+  i32.const 0
+  call $~lib/arraybuffer/ArrayBuffer#constructor
+  local.set $1
+  global.get $~lib/memory/__stack_pointer
+  local.get $1
+  i32.store offset=8
+  local.get $1
+  call $field-initialization/Inherit_Base#set:a
+  local.get $this
+  local.set $1
+  global.get $~lib/memory/__stack_pointer
+  i32.const 12
+  i32.add
+  global.set $~lib/memory/__stack_pointer
+  local.get $1
+ )
  (func $field-initialization/Inherit_Base#constructor (param $this i32) (result i32)
   (local $1 i32)
   global.get $~lib/memory/__stack_pointer
@@ -3704,7 +3953,7 @@
   local.get $1
   i32.store offset=4
   local.get $1
-  call $~lib/object/Object#constructor
+  call $~lib/object/Object#raw_constructor
   local.tee $this
   i32.store
   local.get $this
@@ -3726,6 +3975,34 @@
   local.set $1
   global.get $~lib/memory/__stack_pointer
   i32.const 12
+  i32.add
+  global.set $~lib/memory/__stack_pointer
+  local.get $1
+ )
+ (func $field-initialization/Inherit#raw_constructor (param $this i32) (result i32)
+  (local $1 i32)
+  global.get $~lib/memory/__stack_pointer
+  i32.const 8
+  i32.sub
+  global.set $~lib/memory/__stack_pointer
+  call $~stack_check
+  global.get $~lib/memory/__stack_pointer
+  i64.const 0
+  i64.store
+  global.get $~lib/memory/__stack_pointer
+  local.get $this
+  local.set $1
+  global.get $~lib/memory/__stack_pointer
+  local.get $1
+  i32.store
+  local.get $1
+  call $field-initialization/Inherit_Base#raw_constructor
+  local.tee $this
+  i32.store offset=4
+  local.get $this
+  local.set $1
+  global.get $~lib/memory/__stack_pointer
+  i32.const 8
   i32.add
   global.set $~lib/memory/__stack_pointer
   local.get $1
@@ -3757,9 +4034,37 @@
   local.get $1
   i32.store offset=4
   local.get $1
-  call $field-initialization/Inherit_Base#constructor
+  call $field-initialization/Inherit_Base#raw_constructor
   local.tee $this
   i32.store
+  local.get $this
+  local.set $1
+  global.get $~lib/memory/__stack_pointer
+  i32.const 8
+  i32.add
+  global.set $~lib/memory/__stack_pointer
+  local.get $1
+ )
+ (func $field-initialization/Inherit_Ctor#raw_constructor (param $this i32) (result i32)
+  (local $1 i32)
+  global.get $~lib/memory/__stack_pointer
+  i32.const 8
+  i32.sub
+  global.set $~lib/memory/__stack_pointer
+  call $~stack_check
+  global.get $~lib/memory/__stack_pointer
+  i64.const 0
+  i64.store
+  global.get $~lib/memory/__stack_pointer
+  local.get $this
+  local.set $1
+  global.get $~lib/memory/__stack_pointer
+  local.get $1
+  i32.store
+  local.get $1
+  call $field-initialization/Inherit_Base#raw_constructor
+  local.tee $this
+  i32.store offset=4
   local.get $this
   local.set $1
   global.get $~lib/memory/__stack_pointer
@@ -3795,9 +4100,53 @@
   local.get $1
   i32.store offset=4
   local.get $1
-  call $field-initialization/Inherit_Base#constructor
+  call $field-initialization/Inherit_Base#raw_constructor
   local.tee $this
   i32.store
+  local.get $this
+  local.set $1
+  global.get $~lib/memory/__stack_pointer
+  i32.const 8
+  i32.add
+  global.set $~lib/memory/__stack_pointer
+  local.get $1
+ )
+ (func $field-initialization/SomeObject#raw_constructor (param $this i32) (result i32)
+  (local $1 i32)
+  global.get $~lib/memory/__stack_pointer
+  i32.const 8
+  i32.sub
+  global.set $~lib/memory/__stack_pointer
+  call $~stack_check
+  global.get $~lib/memory/__stack_pointer
+  i64.const 0
+  i64.store
+  global.get $~lib/memory/__stack_pointer
+  local.get $this
+  local.set $1
+  global.get $~lib/memory/__stack_pointer
+  local.get $1
+  i32.store
+  local.get $1
+  call $~lib/object/Object#raw_constructor
+  local.tee $this
+  i32.store offset=4
+  local.get $this
+  local.set $1
+  global.get $~lib/memory/__stack_pointer
+  local.get $1
+  i32.store
+  local.get $1
+  i32.const 0
+  call $field-initialization/SomeObject#set:a
+  local.get $this
+  local.set $1
+  global.get $~lib/memory/__stack_pointer
+  local.get $1
+  i32.store
+  local.get $1
+  i32.const 0
+  call $field-initialization/SomeObject#set:b
   local.get $this
   local.set $1
   global.get $~lib/memory/__stack_pointer
@@ -3833,7 +4182,7 @@
   local.get $1
   i32.store offset=4
   local.get $1
-  call $~lib/object/Object#constructor
+  call $~lib/object/Object#raw_constructor
   local.tee $this
   i32.store
   local.get $this
@@ -3956,6 +4305,42 @@
   local.get $3
   return
  )
+ (func $field-initialization/SomeOtherObject#raw_constructor (param $this i32) (result i32)
+  (local $1 i32)
+  global.get $~lib/memory/__stack_pointer
+  i32.const 8
+  i32.sub
+  global.set $~lib/memory/__stack_pointer
+  call $~stack_check
+  global.get $~lib/memory/__stack_pointer
+  i64.const 0
+  i64.store
+  global.get $~lib/memory/__stack_pointer
+  local.get $this
+  local.set $1
+  global.get $~lib/memory/__stack_pointer
+  local.get $1
+  i32.store
+  local.get $1
+  call $field-initialization/SomeObject#raw_constructor
+  local.tee $this
+  i32.store offset=4
+  local.get $this
+  local.set $1
+  global.get $~lib/memory/__stack_pointer
+  local.get $1
+  i32.store
+  local.get $1
+  i32.const 0
+  call $field-initialization/SomeOtherObject#set:c
+  local.get $this
+  local.set $1
+  global.get $~lib/memory/__stack_pointer
+  i32.const 8
+  i32.add
+  global.set $~lib/memory/__stack_pointer
+  local.get $1
+ )
  (func $field-initialization/SomeOtherObject#constructor (param $this i32) (result i32)
   (local $1 i32)
   global.get $~lib/memory/__stack_pointer
@@ -3983,7 +4368,7 @@
   local.get $1
   i32.store offset=4
   local.get $1
-  call $field-initialization/SomeObject#constructor
+  call $field-initialization/SomeObject#raw_constructor
   local.tee $this
   i32.store
   local.get $this

--- a/tests/compiler/field-initialization.release.wat
+++ b/tests/compiler/field-initialization.release.wat
@@ -1,12 +1,12 @@
 (module
  (type $0 (func))
- (type $1 (func (param i32)))
- (type $2 (func (param i32 i32)))
- (type $3 (func (result i32)))
+ (type $1 (func (result i32)))
+ (type $2 (func (param i32)))
+ (type $3 (func (param i32 i32)))
  (type $4 (func (param i32 i32) (result i32)))
- (type $5 (func (param i32) (result i32)))
- (type $6 (func (param i32 i32 i32 i32)))
- (type $7 (func (param i32 i32 i64)))
+ (type $5 (func (param i32 i32 i32 i32)))
+ (type $6 (func (param i32 i32 i64)))
+ (type $7 (func (param i32) (result i32)))
  (import "env" "abort" (func $~lib/builtins/abort (param i32 i32 i32 i32)))
  (global $~lib/rt/itcms/total (mut i32) (i32.const 0))
  (global $~lib/rt/itcms/threshold (mut i32) (i32.const 0))
@@ -120,7 +120,7 @@
    local.get $1
    global.set $~lib/rt/itcms/iter
   end
-  block $__inlined_func$~lib/rt/itcms/Object#unlink$241
+  block $__inlined_func$~lib/rt/itcms/Object#unlink$252
    local.get $0
    i32.load offset=4
    i32.const -4
@@ -144,7 +144,7 @@
      call $~lib/builtins/abort
      unreachable
     end
-    br $__inlined_func$~lib/rt/itcms/Object#unlink$241
+    br $__inlined_func$~lib/rt/itcms/Object#unlink$252
    end
    local.get $0
    i32.load offset=8
@@ -1655,7 +1655,7 @@
  (func $~start
   call $start:field-initialization
  )
- (func $field-initialization/Inherit_Base#constructor (param $0 i32) (result i32)
+ (func $field-initialization/Ref_Init#raw_constructor (param $0 i32) (result i32)
   (local $1 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 12
@@ -1678,27 +1678,15 @@
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   i32.store offset=8
-  local.get $0
-  i32.eqz
-  if
-   global.get $~lib/memory/__stack_pointer
-   i32.const 4
-   i32.const 19
-   call $~lib/rt/itcms/__new
-   local.tee $0
-   i32.store
-  end
   global.get $~lib/memory/__stack_pointer
   local.get $0
-  i32.store offset=4
-  global.get $~lib/memory/__stack_pointer
-  local.get $0
-  call $~lib/object/Object#constructor
-  local.tee $0
   i32.store
   global.get $~lib/memory/__stack_pointer
   local.get $0
   i32.store offset=4
+  global.get $~lib/memory/__stack_pointer
+  local.get $0
+  i32.store
   call $~lib/arraybuffer/ArrayBuffer#constructor
   local.set $1
   global.get $~lib/memory/__stack_pointer
@@ -1716,7 +1704,8 @@
   global.set $~lib/memory/__stack_pointer
   local.get $0
  )
- (func $field-initialization/SomeObject#constructor (param $0 i32) (result i32)
+ (func $field-initialization/SomeObject#constructor (result i32)
+  (local $0 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 8
   i32.sub
@@ -1735,23 +1724,17 @@
   global.get $~lib/memory/__stack_pointer
   i64.const 0
   i64.store
-  local.get $0
-  i32.eqz
-  if
-   global.get $~lib/memory/__stack_pointer
-   i32.const 8
-   i32.const 21
-   call $~lib/rt/itcms/__new
-   local.tee $0
-   i32.store
-  end
+  global.get $~lib/memory/__stack_pointer
+  i32.const 8
+  i32.const 21
+  call $~lib/rt/itcms/__new
+  local.tee $0
+  i32.store
   global.get $~lib/memory/__stack_pointer
   local.get $0
   i32.store offset=4
   global.get $~lib/memory/__stack_pointer
   local.get $0
-  call $~lib/object/Object#constructor
-  local.tee $0
   i32.store
   global.get $~lib/memory/__stack_pointer
   local.get $0
@@ -1887,7 +1870,7 @@
      end
     end
    end
-   block $__inlined_func$~lib/util/string/compareImpl$118
+   block $__inlined_func$~lib/util/string/compareImpl$129
     loop $while-continue|1
      local.get $0
      local.tee $3
@@ -1907,7 +1890,7 @@
       local.get $4
       local.get $5
       i32.ne
-      br_if $__inlined_func$~lib/util/string/compareImpl$118
+      br_if $__inlined_func$~lib/util/string/compareImpl$129
       local.get $2
       i32.const 2
       i32.add
@@ -1938,52 +1921,89 @@
  )
  (func $field-initialization/SomeOtherObject#constructor (result i32)
   (local $0 i32)
+  (local $1 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 8
   i32.sub
   global.set $~lib/memory/__stack_pointer
-  global.get $~lib/memory/__stack_pointer
-  i32.const 1900
-  i32.lt_s
-  if
-   i32.const 34688
-   i32.const 34736
-   i32.const 1
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
+  block $folding-inner0
+   global.get $~lib/memory/__stack_pointer
+   i32.const 1900
+   i32.lt_s
+   br_if $folding-inner0
+   global.get $~lib/memory/__stack_pointer
+   i64.const 0
+   i64.store
+   global.get $~lib/memory/__stack_pointer
+   i32.const 12
+   i32.const 22
+   call $~lib/rt/itcms/__new
+   local.tee $0
+   i32.store
+   global.get $~lib/memory/__stack_pointer
+   global.get $~lib/memory/__stack_pointer
+   local.get $0
+   i32.store offset=4
+   global.get $~lib/memory/__stack_pointer
+   i32.const 8
+   i32.sub
+   global.set $~lib/memory/__stack_pointer
+   global.get $~lib/memory/__stack_pointer
+   i32.const 1900
+   i32.lt_s
+   br_if $folding-inner0
+   global.get $~lib/memory/__stack_pointer
+   i64.const 0
+   i64.store
+   global.get $~lib/memory/__stack_pointer
+   local.get $0
+   i32.store
+   global.get $~lib/memory/__stack_pointer
+   local.get $0
+   i32.store offset=4
+   global.get $~lib/memory/__stack_pointer
+   local.get $0
+   i32.store
+   local.get $0
+   i32.const 0
+   i32.store
+   global.get $~lib/memory/__stack_pointer
+   local.get $0
+   i32.store
+   local.get $0
+   i32.const 0
+   i32.store offset=4
+   local.get $0
+   i32.const 0
+   call $~lib/rt/itcms/__link
+   global.get $~lib/memory/__stack_pointer
+   i32.const 8
+   i32.add
+   global.set $~lib/memory/__stack_pointer
+   local.get $0
+   i32.store
+   global.get $~lib/memory/__stack_pointer
+   local.get $0
+   i32.store offset=4
+   local.get $0
+   i32.const 0
+   i32.store offset=8
+   local.get $0
+   i32.const 0
+   call $~lib/rt/itcms/__link
+   global.get $~lib/memory/__stack_pointer
+   i32.const 8
+   i32.add
+   global.set $~lib/memory/__stack_pointer
+   local.get $0
+   return
   end
-  global.get $~lib/memory/__stack_pointer
-  i64.const 0
-  i64.store
-  global.get $~lib/memory/__stack_pointer
-  i32.const 12
-  i32.const 22
-  call $~lib/rt/itcms/__new
-  local.tee $0
-  i32.store
-  global.get $~lib/memory/__stack_pointer
-  local.get $0
-  i32.store offset=4
-  global.get $~lib/memory/__stack_pointer
-  local.get $0
-  call $field-initialization/SomeObject#constructor
-  local.tee $0
-  i32.store
-  global.get $~lib/memory/__stack_pointer
-  local.get $0
-  i32.store offset=4
-  local.get $0
-  i32.const 0
-  i32.store offset=8
-  local.get $0
-  i32.const 0
-  call $~lib/rt/itcms/__link
-  global.get $~lib/memory/__stack_pointer
-  i32.const 8
-  i32.add
-  global.set $~lib/memory/__stack_pointer
-  local.get $0
+  i32.const 34688
+  i32.const 34736
+  i32.const 1
+  i32.const 1
+  call $~lib/builtins/abort
+  unreachable
  )
  (func $start:field-initialization
   (local $0 i32)
@@ -2057,8 +2077,6 @@
    i32.store offset=4
    global.get $~lib/memory/__stack_pointer
    local.get $1
-   call $~lib/object/Object#constructor
-   local.tee $1
    i32.store
    global.get $~lib/memory/__stack_pointer
    local.get $1
@@ -2110,8 +2128,6 @@
    i32.store offset=4
    global.get $~lib/memory/__stack_pointer
    local.get $1
-   call $~lib/object/Object#constructor
-   local.tee $1
    i32.store
    global.get $~lib/memory/__stack_pointer
    local.get $1
@@ -2164,8 +2180,6 @@
    i32.store offset=4
    global.get $~lib/memory/__stack_pointer
    local.get $1
-   call $~lib/object/Object#constructor
-   local.tee $1
    i32.store
    global.get $~lib/memory/__stack_pointer
    local.get $1
@@ -2227,8 +2241,6 @@
    i32.store offset=4
    global.get $~lib/memory/__stack_pointer
    local.get $1
-   call $~lib/object/Object#constructor
-   local.tee $1
    i32.store
    global.get $~lib/memory/__stack_pointer
    local.get $1
@@ -2287,8 +2299,6 @@
    i32.store offset=4
    global.get $~lib/memory/__stack_pointer
    local.get $1
-   call $~lib/object/Object#constructor
-   local.tee $1
    i32.store
    global.get $~lib/memory/__stack_pointer
    local.get $1
@@ -2825,7 +2835,7 @@
    i32.store offset=4
    global.get $~lib/memory/__stack_pointer
    local.get $1
-   call $field-initialization/Inherit_Base#constructor
+   call $field-initialization/Ref_Init#raw_constructor
    local.tee $1
    i32.store
    global.get $~lib/memory/__stack_pointer
@@ -2871,7 +2881,7 @@
    i32.store offset=4
    global.get $~lib/memory/__stack_pointer
    local.get $1
-   call $field-initialization/Inherit_Base#constructor
+   call $field-initialization/Ref_Init#raw_constructor
    local.tee $1
    i32.store
    global.get $~lib/memory/__stack_pointer
@@ -2896,7 +2906,6 @@
    end
    global.get $~lib/memory/__stack_pointer
    global.get $~lib/memory/__stack_pointer
-   i32.const 0
    call $field-initialization/SomeObject#constructor
    local.tee $1
    i32.store offset=72
@@ -2943,7 +2952,6 @@
    end
    global.get $~lib/memory/__stack_pointer
    global.get $~lib/memory/__stack_pointer
-   i32.const 0
    call $field-initialization/SomeObject#constructor
    local.tee $1
    i32.store offset=84
@@ -2995,7 +3003,6 @@
    end
    global.get $~lib/memory/__stack_pointer
    global.get $~lib/memory/__stack_pointer
-   i32.const 0
    call $field-initialization/SomeObject#constructor
    local.tee $1
    i32.store offset=92
@@ -3054,7 +3061,6 @@
    end
    global.get $~lib/memory/__stack_pointer
    global.get $~lib/memory/__stack_pointer
-   i32.const 0
    call $field-initialization/SomeObject#constructor
    local.tee $1
    i32.store offset=104
@@ -3454,41 +3460,6 @@
   i32.const 1
   call $~lib/builtins/abort
   unreachable
- )
- (func $~lib/object/Object#constructor (param $0 i32) (result i32)
-  global.get $~lib/memory/__stack_pointer
-  i32.const 4
-  i32.sub
-  global.set $~lib/memory/__stack_pointer
-  global.get $~lib/memory/__stack_pointer
-  i32.const 1900
-  i32.lt_s
-  if
-   i32.const 34688
-   i32.const 34736
-   i32.const 1
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  global.get $~lib/memory/__stack_pointer
-  i32.const 0
-  i32.store
-  local.get $0
-  i32.eqz
-  if
-   global.get $~lib/memory/__stack_pointer
-   i32.const 0
-   i32.const 0
-   call $~lib/rt/itcms/__new
-   local.tee $0
-   i32.store
-  end
-  global.get $~lib/memory/__stack_pointer
-  i32.const 4
-  i32.add
-  global.set $~lib/memory/__stack_pointer
-  local.get $0
  )
  (func $~lib/arraybuffer/ArrayBuffer#constructor (result i32)
   (local $0 i32)

--- a/tests/compiler/field.debug.wat
+++ b/tests/compiler/field.debug.wat
@@ -25,10 +25,10 @@
  (global $~lib/rt/itcms/fromSpace (mut i32) (i32.const 0))
  (global $~lib/rt/tlsf/ROOT (mut i32) (i32.const 0))
  (global $~lib/native/ASC_LOW_MEMORY_LIMIT i32 (i32.const 0))
- (global $~lib/rt/__rtti_base i32 (i32.const 448))
- (global $~lib/memory/__data_end i32 (i32.const 480))
- (global $~lib/memory/__stack_pointer (mut i32) (i32.const 33248))
- (global $~lib/memory/__heap_base i32 (i32.const 33248))
+ (global $~lib/rt/__rtti_base i32 (i32.const 480))
+ (global $~lib/memory/__data_end i32 (i32.const 512))
+ (global $~lib/memory/__stack_pointer (mut i32) (i32.const 33280))
+ (global $~lib/memory/__heap_base i32 (i32.const 33280))
  (memory $0 1)
  (data $0 (i32.const 12) "<\00\00\00\00\00\00\00\00\00\00\00\02\00\00\00(\00\00\00A\00l\00l\00o\00c\00a\00t\00i\00o\00n\00 \00t\00o\00o\00 \00l\00a\00r\00g\00e\00\00\00\00\00")
  (data $1 (i32.const 76) "<\00\00\00\00\00\00\00\00\00\00\00\02\00\00\00 \00\00\00~\00l\00i\00b\00/\00r\00t\00/\00i\00t\00c\00m\00s\00.\00t\00s\00\00\00\00\00\00\00\00\00\00\00\00\00")
@@ -39,11 +39,15 @@
  (data $6 (i32.const 320) "\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00")
  (data $7 (i32.const 348) "<\00\00\00\00\00\00\00\00\00\00\00\02\00\00\00\1e\00\00\00~\00l\00i\00b\00/\00r\00t\00/\00t\00l\00s\00f\00.\00t\00s\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00")
  (data $8 (i32.const 412) "\1c\00\00\00\00\00\00\00\00\00\00\00\01\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00")
- (data $9 (i32.const 448) "\07\00\00\00 \00\00\00 \00\00\00 \00\00\00\00\00\00\00\00\00\00\00\02A\00\00\02\t\00\00")
+ (data $9 (i32.const 444) "\1c\00\00\00\00\00\00\00\00\00\00\00\01\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00")
+ (data $10 (i32.const 480) "\07\00\00\00 \00\00\00 \00\00\00 \00\00\00\00\00\00\00\00\00\00\00\02A\00\00\02\t\00\00")
  (table $0 1 1 funcref)
  (elem $0 (i32.const 1))
  (export "memory" (memory $0))
  (start $~start)
+ (func $~lib/object/Object#raw_constructor (param $this i32) (result i32)
+  local.get $this
+ )
  (func $~lib/rt/itcms/Object#set:nextWithColor (param $this i32) (param $nextWithColor i32)
   local.get $this
   local.get $nextWithColor
@@ -2520,13 +2524,62 @@
   global.get $~lib/memory/__data_end
   i32.lt_s
   if
-   i32.const 33280
-   i32.const 33328
+   i32.const 33312
+   i32.const 33360
    i32.const 1
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
+ )
+ (func $field/NoStaticConflict#raw_constructor (param $this i32) (result i32)
+  (local $1 i32)
+  (local $2 i32)
+  global.get $~lib/memory/__stack_pointer
+  i32.const 12
+  i32.sub
+  global.set $~lib/memory/__stack_pointer
+  call $~stack_check
+  global.get $~lib/memory/__stack_pointer
+  i64.const 0
+  i64.store
+  global.get $~lib/memory/__stack_pointer
+  i32.const 0
+  i32.store offset=8
+  global.get $~lib/memory/__stack_pointer
+  local.get $this
+  local.set $2
+  global.get $~lib/memory/__stack_pointer
+  local.get $2
+  i32.store
+  local.get $2
+  call $~lib/object/Object#raw_constructor
+  local.tee $this
+  i32.store offset=4
+  local.get $this
+  local.set $2
+  global.get $~lib/memory/__stack_pointer
+  local.get $2
+  i32.store
+  local.get $2
+  i32.const 0
+  i32.const 2
+  i32.const 5
+  i32.const 432
+  call $~lib/rt/__newArray
+  local.set $2
+  global.get $~lib/memory/__stack_pointer
+  local.get $2
+  i32.store offset=8
+  local.get $2
+  call $field/NoStaticConflict#set:a
+  local.get $this
+  local.set $2
+  global.get $~lib/memory/__stack_pointer
+  i32.const 12
+  i32.add
+  global.set $~lib/memory/__stack_pointer
+  local.get $2
  )
  (func $field/NoStaticConflict#constructor (param $this i32) (result i32)
   (local $1 i32)
@@ -2559,7 +2612,7 @@
   local.get $2
   i32.store offset=4
   local.get $2
-  call $~lib/object/Object#constructor
+  call $~lib/object/Object#raw_constructor
   local.tee $this
   i32.store
   local.get $this
@@ -2571,7 +2624,7 @@
   i32.const 0
   i32.const 2
   i32.const 5
-  i32.const 432
+  i32.const 464
   call $~lib/rt/__newArray
   local.set $2
   global.get $~lib/memory/__stack_pointer

--- a/tests/compiler/field.release.wat
+++ b/tests/compiler/field.release.wat
@@ -17,7 +17,7 @@
  (global $~lib/rt/itcms/white (mut i32) (i32.const 0))
  (global $~lib/rt/itcms/fromSpace (mut i32) (i32.const 0))
  (global $~lib/rt/tlsf/ROOT (mut i32) (i32.const 0))
- (global $~lib/memory/__stack_pointer (mut i32) (i32.const 34272))
+ (global $~lib/memory/__stack_pointer (mut i32) (i32.const 34304))
  (memory $0 1)
  (data $0 (i32.const 1036) "<")
  (data $0.1 (i32.const 1048) "\02\00\00\00(\00\00\00A\00l\00l\00o\00c\00a\00t\00i\00o\00n\00 \00t\00o\00o\00 \00l\00a\00r\00g\00e")
@@ -31,8 +31,10 @@
  (data $7.1 (i32.const 1384) "\02\00\00\00\1e\00\00\00~\00l\00i\00b\00/\00r\00t\00/\00t\00l\00s\00f\00.\00t\00s")
  (data $8 (i32.const 1436) "\1c")
  (data $8.1 (i32.const 1448) "\01")
- (data $9 (i32.const 1472) "\07\00\00\00 \00\00\00 \00\00\00 ")
- (data $9.1 (i32.const 1496) "\02A\00\00\02\t")
+ (data $9 (i32.const 1468) "\1c")
+ (data $9.1 (i32.const 1480) "\01")
+ (data $10 (i32.const 1504) "\07\00\00\00 \00\00\00 \00\00\00 ")
+ (data $10.1 (i32.const 1528) "\02A\00\00\02\t")
  (export "memory" (memory $0))
  (start $~start)
  (func $~lib/rt/itcms/visitRoots
@@ -115,7 +117,7 @@
     i32.load offset=8
     i32.eqz
     local.get $0
-    i32.const 34272
+    i32.const 34304
     i32.lt_u
     i32.and
     i32.eqz
@@ -164,7 +166,7 @@
    i32.const 1
   else
    local.get $1
-   i32.const 1472
+   i32.const 1504
    i32.load
    i32.gt_u
    if
@@ -178,7 +180,7 @@
    local.get $1
    i32.const 2
    i32.shl
-   i32.const 1476
+   i32.const 1508
    i32.add
    i32.load
    i32.const 32
@@ -762,10 +764,10 @@
   if
    unreachable
   end
-  i32.const 34272
+  i32.const 34304
   i32.const 0
   i32.store
-  i32.const 35840
+  i32.const 35872
   i32.const 0
   i32.store
   loop $for-loop|0
@@ -776,7 +778,7 @@
     local.get $0
     i32.const 2
     i32.shl
-    i32.const 34272
+    i32.const 34304
     i32.add
     i32.const 0
     i32.store offset=4
@@ -794,7 +796,7 @@
       i32.add
       i32.const 2
       i32.shl
-      i32.const 34272
+      i32.const 34304
       i32.add
       i32.const 0
       i32.store offset=96
@@ -812,14 +814,14 @@
     br $for-loop|0
    end
   end
-  i32.const 34272
-  i32.const 35844
+  i32.const 34304
+  i32.const 35876
   memory.size
   i64.extend_i32_s
   i64.const 16
   i64.shl
   call $~lib/rt/tlsf/addMemory
-  i32.const 34272
+  i32.const 34304
   global.set $~lib/rt/tlsf/ROOT
  )
  (func $~lib/rt/itcms/step (result i32)
@@ -904,7 +906,7 @@
      local.set $0
      loop $while-continue|0
       local.get $0
-      i32.const 34272
+      i32.const 34304
       i32.lt_u
       if
        local.get $0
@@ -1000,7 +1002,7 @@
      unreachable
     end
     local.get $0
-    i32.const 34272
+    i32.const 34304
     i32.lt_u
     if
      local.get $0
@@ -1023,7 +1025,7 @@
      i32.const 4
      i32.add
      local.tee $0
-     i32.const 34272
+     i32.const 34304
      i32.ge_u
      if
       global.get $~lib/rt/tlsf/ROOT
@@ -1581,217 +1583,6 @@
    end
   end
  )
- (func $start:field
-  (local $0 i32)
-  (local $1 i32)
-  (local $2 i32)
-  (local $3 i32)
-  memory.size
-  i32.const 16
-  i32.shl
-  i32.const 34272
-  i32.sub
-  i32.const 1
-  i32.shr_u
-  global.set $~lib/rt/itcms/threshold
-  i32.const 1172
-  i32.const 1168
-  i32.store
-  i32.const 1176
-  i32.const 1168
-  i32.store
-  i32.const 1168
-  global.set $~lib/rt/itcms/pinSpace
-  i32.const 1204
-  i32.const 1200
-  i32.store
-  i32.const 1208
-  i32.const 1200
-  i32.store
-  i32.const 1200
-  global.set $~lib/rt/itcms/toSpace
-  i32.const 1348
-  i32.const 1344
-  i32.store
-  i32.const 1352
-  i32.const 1344
-  i32.store
-  i32.const 1344
-  global.set $~lib/rt/itcms/fromSpace
-  global.get $~lib/memory/__stack_pointer
-  i32.const 8
-  i32.sub
-  global.set $~lib/memory/__stack_pointer
-  block $folding-inner0
-   global.get $~lib/memory/__stack_pointer
-   i32.const 1504
-   i32.lt_s
-   br_if $folding-inner0
-   global.get $~lib/memory/__stack_pointer
-   i64.const 0
-   i64.store
-   global.get $~lib/memory/__stack_pointer
-   global.get $~lib/memory/__stack_pointer
-   i32.const 12
-   i32.sub
-   global.set $~lib/memory/__stack_pointer
-   global.get $~lib/memory/__stack_pointer
-   i32.const 1504
-   i32.lt_s
-   br_if $folding-inner0
-   global.get $~lib/memory/__stack_pointer
-   i64.const 0
-   i64.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 0
-   i32.store offset=8
-   global.get $~lib/memory/__stack_pointer
-   i32.const 4
-   i32.const 4
-   call $~lib/rt/itcms/__new
-   local.tee $0
-   i32.store
-   global.get $~lib/memory/__stack_pointer
-   global.get $~lib/memory/__stack_pointer
-   local.get $0
-   i32.store offset=4
-   global.get $~lib/memory/__stack_pointer
-   i32.const 4
-   i32.sub
-   global.set $~lib/memory/__stack_pointer
-   global.get $~lib/memory/__stack_pointer
-   i32.const 1504
-   i32.lt_s
-   br_if $folding-inner0
-   global.get $~lib/memory/__stack_pointer
-   i32.const 0
-   i32.store
-   local.get $0
-   i32.eqz
-   if
-    global.get $~lib/memory/__stack_pointer
-    i32.const 0
-    i32.const 0
-    call $~lib/rt/itcms/__new
-    local.tee $0
-    i32.store
-   end
-   global.get $~lib/memory/__stack_pointer
-   i32.const 4
-   i32.add
-   global.set $~lib/memory/__stack_pointer
-   local.get $0
-   i32.store
-   global.get $~lib/memory/__stack_pointer
-   local.get $0
-   i32.store offset=4
-   global.get $~lib/memory/__stack_pointer
-   i32.const 4
-   i32.sub
-   global.set $~lib/memory/__stack_pointer
-   global.get $~lib/memory/__stack_pointer
-   i32.const 1504
-   i32.lt_s
-   br_if $folding-inner0
-   global.get $~lib/memory/__stack_pointer
-   i32.const 0
-   i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 0
-   i32.const 1
-   call $~lib/rt/itcms/__new
-   local.tee $3
-   i32.const 1456
-   i32.const 0
-   memory.copy
-   local.get $3
-   i32.store
-   i32.const 16
-   i32.const 5
-   call $~lib/rt/itcms/__new
-   local.tee $2
-   local.get $3
-   i32.store
-   local.get $2
-   local.get $3
-   call $~lib/rt/itcms/__link
-   local.get $2
-   local.get $3
-   i32.store offset=4
-   local.get $2
-   i32.const 0
-   i32.store offset=8
-   local.get $2
-   i32.const 0
-   i32.store offset=12
-   global.get $~lib/memory/__stack_pointer
-   i32.const 4
-   i32.add
-   global.set $~lib/memory/__stack_pointer
-   global.get $~lib/memory/__stack_pointer
-   local.get $2
-   i32.store offset=8
-   local.get $0
-   local.get $2
-   i32.store
-   local.get $0
-   local.get $2
-   call $~lib/rt/itcms/__link
-   global.get $~lib/memory/__stack_pointer
-   i32.const 12
-   i32.add
-   global.set $~lib/memory/__stack_pointer
-   local.get $0
-   i32.store
-   global.get $~lib/memory/__stack_pointer
-   local.get $0
-   i32.store offset=4
-   global.get $~lib/memory/__stack_pointer
-   i32.const 8
-   i32.add
-   global.set $~lib/memory/__stack_pointer
-   global.get $~lib/rt/itcms/state
-   i32.const 0
-   i32.gt_s
-   if
-    loop $while-continue|0
-     global.get $~lib/rt/itcms/state
-     if
-      call $~lib/rt/itcms/step
-      drop
-      br $while-continue|0
-     end
-    end
-   end
-   call $~lib/rt/itcms/step
-   drop
-   loop $while-continue|1
-    global.get $~lib/rt/itcms/state
-    if
-     call $~lib/rt/itcms/step
-     drop
-     br $while-continue|1
-    end
-   end
-   global.get $~lib/rt/itcms/total
-   i64.extend_i32_u
-   i64.const 200
-   i64.mul
-   i64.const 100
-   i64.div_u
-   i32.wrap_i64
-   i32.const 1024
-   i32.add
-   global.set $~lib/rt/itcms/threshold
-   return
-  end
-  i32.const 34304
-  i32.const 34352
-  i32.const 1
-  i32.const 1
-  call $~lib/builtins/abort
-  unreachable
- )
  (func $~lib/rt/__visit_members (param $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -1833,7 +1624,7 @@
       i32.sub
       global.set $~lib/memory/__stack_pointer
       global.get $~lib/memory/__stack_pointer
-      i32.const 1504
+      i32.const 1536
       i32.lt_s
       br_if $folding-inner0
       global.get $~lib/memory/__stack_pointer
@@ -1881,7 +1672,7 @@
      i32.sub
      global.set $~lib/memory/__stack_pointer
      global.get $~lib/memory/__stack_pointer
-     i32.const 1504
+     i32.const 1536
      i32.lt_s
      br_if $folding-inner0
      global.get $~lib/memory/__stack_pointer
@@ -1891,8 +1682,8 @@
     end
     unreachable
    end
-   i32.const 34304
-   i32.const 34352
+   i32.const 34336
+   i32.const 34384
    i32.const 1
    i32.const 1
    call $~lib/builtins/abort
@@ -1910,6 +1701,191 @@
   global.set $~lib/memory/__stack_pointer
  )
  (func $~start
-  call $start:field
+  (local $0 i32)
+  (local $1 i32)
+  (local $2 i32)
+  (local $3 i32)
+  block $__inlined_func$start:field
+   memory.size
+   i32.const 16
+   i32.shl
+   i32.const 34304
+   i32.sub
+   i32.const 1
+   i32.shr_u
+   global.set $~lib/rt/itcms/threshold
+   i32.const 1172
+   i32.const 1168
+   i32.store
+   i32.const 1176
+   i32.const 1168
+   i32.store
+   i32.const 1168
+   global.set $~lib/rt/itcms/pinSpace
+   i32.const 1204
+   i32.const 1200
+   i32.store
+   i32.const 1208
+   i32.const 1200
+   i32.store
+   i32.const 1200
+   global.set $~lib/rt/itcms/toSpace
+   i32.const 1348
+   i32.const 1344
+   i32.store
+   i32.const 1352
+   i32.const 1344
+   i32.store
+   i32.const 1344
+   global.set $~lib/rt/itcms/fromSpace
+   global.get $~lib/memory/__stack_pointer
+   i32.const 8
+   i32.sub
+   global.set $~lib/memory/__stack_pointer
+   block $folding-inner0
+    global.get $~lib/memory/__stack_pointer
+    i32.const 1536
+    i32.lt_s
+    br_if $folding-inner0
+    global.get $~lib/memory/__stack_pointer
+    i64.const 0
+    i64.store
+    global.get $~lib/memory/__stack_pointer
+    global.get $~lib/memory/__stack_pointer
+    i32.const 12
+    i32.sub
+    global.set $~lib/memory/__stack_pointer
+    global.get $~lib/memory/__stack_pointer
+    i32.const 1536
+    i32.lt_s
+    br_if $folding-inner0
+    global.get $~lib/memory/__stack_pointer
+    i64.const 0
+    i64.store
+    global.get $~lib/memory/__stack_pointer
+    i32.const 0
+    i32.store offset=8
+    global.get $~lib/memory/__stack_pointer
+    i32.const 4
+    i32.const 4
+    call $~lib/rt/itcms/__new
+    local.tee $0
+    i32.store
+    global.get $~lib/memory/__stack_pointer
+    local.get $0
+    i32.store offset=4
+    global.get $~lib/memory/__stack_pointer
+    local.get $0
+    i32.store
+    global.get $~lib/memory/__stack_pointer
+    local.get $0
+    i32.store offset=4
+    global.get $~lib/memory/__stack_pointer
+    i32.const 4
+    i32.sub
+    global.set $~lib/memory/__stack_pointer
+    global.get $~lib/memory/__stack_pointer
+    i32.const 1536
+    i32.lt_s
+    br_if $folding-inner0
+    global.get $~lib/memory/__stack_pointer
+    i32.const 0
+    i32.store
+    global.get $~lib/memory/__stack_pointer
+    i32.const 0
+    i32.const 1
+    call $~lib/rt/itcms/__new
+    local.tee $1
+    i32.const 1488
+    i32.const 0
+    memory.copy
+    local.get $1
+    i32.store
+    i32.const 16
+    i32.const 5
+    call $~lib/rt/itcms/__new
+    local.tee $3
+    local.get $1
+    i32.store
+    local.get $3
+    local.get $1
+    call $~lib/rt/itcms/__link
+    local.get $3
+    local.get $1
+    i32.store offset=4
+    local.get $3
+    i32.const 0
+    i32.store offset=8
+    local.get $3
+    i32.const 0
+    i32.store offset=12
+    global.get $~lib/memory/__stack_pointer
+    i32.const 4
+    i32.add
+    global.set $~lib/memory/__stack_pointer
+    global.get $~lib/memory/__stack_pointer
+    local.get $3
+    i32.store offset=8
+    local.get $0
+    local.get $3
+    i32.store
+    local.get $0
+    local.get $3
+    call $~lib/rt/itcms/__link
+    global.get $~lib/memory/__stack_pointer
+    i32.const 12
+    i32.add
+    global.set $~lib/memory/__stack_pointer
+    local.get $0
+    i32.store
+    global.get $~lib/memory/__stack_pointer
+    local.get $0
+    i32.store offset=4
+    global.get $~lib/memory/__stack_pointer
+    i32.const 8
+    i32.add
+    global.set $~lib/memory/__stack_pointer
+    global.get $~lib/rt/itcms/state
+    i32.const 0
+    i32.gt_s
+    if
+     loop $while-continue|0
+      global.get $~lib/rt/itcms/state
+      if
+       call $~lib/rt/itcms/step
+       drop
+       br $while-continue|0
+      end
+     end
+    end
+    call $~lib/rt/itcms/step
+    drop
+    loop $while-continue|1
+     global.get $~lib/rt/itcms/state
+     if
+      call $~lib/rt/itcms/step
+      drop
+      br $while-continue|1
+     end
+    end
+    global.get $~lib/rt/itcms/total
+    i64.extend_i32_u
+    i64.const 200
+    i64.mul
+    i64.const 100
+    i64.div_u
+    i32.wrap_i64
+    i32.const 1024
+    i32.add
+    global.set $~lib/rt/itcms/threshold
+    br $__inlined_func$start:field
+   end
+   i32.const 34336
+   i32.const 34384
+   i32.const 1
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
  )
 )

--- a/tests/compiler/for.debug.wat
+++ b/tests/compiler/for.debug.wat
@@ -430,6 +430,9 @@
   i32.const 1
   global.set $for/ran
  )
+ (func $~lib/object/Object#raw_constructor (param $this i32) (result i32)
+  local.get $this
+ )
  (func $~lib/rt/itcms/Object#set:nextWithColor (param $this i32) (param $nextWithColor i32)
   local.get $this
   local.get $nextWithColor
@@ -3080,6 +3083,34 @@
    unreachable
   end
  )
+ (func $for/Ref#raw_constructor (param $this i32) (result i32)
+  (local $1 i32)
+  global.get $~lib/memory/__stack_pointer
+  i32.const 8
+  i32.sub
+  global.set $~lib/memory/__stack_pointer
+  call $~stack_check
+  global.get $~lib/memory/__stack_pointer
+  i64.const 0
+  i64.store
+  global.get $~lib/memory/__stack_pointer
+  local.get $this
+  local.set $1
+  global.get $~lib/memory/__stack_pointer
+  local.get $1
+  i32.store
+  local.get $1
+  call $~lib/object/Object#raw_constructor
+  local.tee $this
+  i32.store offset=4
+  local.get $this
+  local.set $1
+  global.get $~lib/memory/__stack_pointer
+  i32.const 8
+  i32.add
+  global.set $~lib/memory/__stack_pointer
+  local.get $1
+ )
  (func $for/Ref#constructor (param $this i32) (result i32)
   (local $1 i32)
   global.get $~lib/memory/__stack_pointer
@@ -3107,7 +3138,7 @@
   local.get $1
   i32.store offset=4
   local.get $1
-  call $~lib/object/Object#constructor
+  call $~lib/object/Object#raw_constructor
   local.tee $this
   i32.store
   local.get $this

--- a/tests/compiler/for.release.wat
+++ b/tests/compiler/for.release.wat
@@ -1,11 +1,11 @@
 (module
  (type $0 (func))
- (type $1 (func (param i32)))
- (type $2 (func (param i32 i32)))
- (type $3 (func (result i32)))
- (type $4 (func (param i32) (result i32)))
- (type $5 (func (param i32 i32 i32 i32)))
- (type $6 (func (param i32 i32 i64)))
+ (type $1 (func (result i32)))
+ (type $2 (func (param i32)))
+ (type $3 (func (param i32 i32)))
+ (type $4 (func (param i32 i32 i32 i32)))
+ (type $5 (func (param i32 i32 i64)))
+ (type $6 (func (param i32) (result i32)))
  (import "env" "abort" (func $~lib/builtins/abort (param i32 i32 i32 i32)))
  (global $~lib/rt/itcms/total (mut i32) (i32.const 0))
  (global $~lib/rt/itcms/threshold (mut i32) (i32.const 0))
@@ -117,7 +117,7 @@
     local.get $0
     global.set $~lib/rt/itcms/iter
    end
-   block $__inlined_func$~lib/rt/itcms/Object#unlink$128
+   block $__inlined_func$~lib/rt/itcms/Object#unlink$127
     local.get $1
     i32.load offset=4
     i32.const -4
@@ -141,7 +141,7 @@
       call $~lib/builtins/abort
       unreachable
      end
-     br $__inlined_func$~lib/rt/itcms/Object#unlink$128
+     br $__inlined_func$~lib/rt/itcms/Object#unlink$127
     end
     local.get $1
     i32.load offset=8
@@ -1134,23 +1134,23 @@
    end
   end
  )
- (func $~lib/rt/itcms/__new (param $0 i32) (result i32)
+ (func $~lib/rt/itcms/__new (result i32)
+  (local $0 i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
-  (local $4 i32)
   global.get $~lib/rt/itcms/total
   global.get $~lib/rt/itcms/threshold
   i32.ge_u
   if
    block $__inlined_func$~lib/rt/itcms/interrupt$69
     i32.const 2048
-    local.set $1
+    local.set $0
     loop $do-loop|0
-     local.get $1
+     local.get $0
      call $~lib/rt/itcms/step
      i32.sub
-     local.set $1
+     local.set $0
      global.get $~lib/rt/itcms/state
      i32.eqz
      if
@@ -1166,7 +1166,7 @@
       global.set $~lib/rt/itcms/threshold
       br $__inlined_func$~lib/rt/itcms/interrupt$69
      end
-     local.get $1
+     local.get $0
      i32.const 0
      i32.gt_s
      br_if $do-loop|0
@@ -1189,17 +1189,17 @@
    call $~lib/rt/tlsf/initialize
   end
   global.get $~lib/rt/tlsf/ROOT
-  local.tee $2
-  call $~lib/rt/tlsf/searchBlock
   local.tee $1
+  call $~lib/rt/tlsf/searchBlock
+  local.tee $0
   i32.eqz
   if
    memory.size
-   local.tee $1
+   local.tee $0
    i32.const 4
-   local.get $2
-   i32.load offset=1568
    local.get $1
+   i32.load offset=1568
+   local.get $0
    i32.const 16
    i32.shl
    i32.const 4
@@ -1212,16 +1212,16 @@
    i32.and
    i32.const 16
    i32.shr_u
-   local.tee $3
-   local.get $1
-   local.get $3
+   local.tee $2
+   local.get $0
+   local.get $2
    i32.gt_s
    select
    memory.grow
    i32.const 0
    i32.lt_s
    if
-    local.get $3
+    local.get $2
     memory.grow
     i32.const 0
     i32.lt_s
@@ -1229,8 +1229,8 @@
      unreachable
     end
    end
-   local.get $2
    local.get $1
+   local.get $0
    i32.const 16
    i32.shl
    memory.size
@@ -1238,9 +1238,9 @@
    i64.const 16
    i64.shl
    call $~lib/rt/tlsf/addMemory
-   local.get $2
+   local.get $1
    call $~lib/rt/tlsf/searchBlock
-   local.tee $1
+   local.tee $0
    i32.eqz
    if
     i32.const 0
@@ -1251,7 +1251,7 @@
     unreachable
    end
   end
-  local.get $1
+  local.get $0
   i32.load
   i32.const -4
   i32.and
@@ -1265,92 +1265,92 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $2
   local.get $1
+  local.get $0
   call $~lib/rt/tlsf/removeBlock
-  local.get $1
+  local.get $0
   i32.load
-  local.tee $3
+  local.tee $2
   i32.const -4
   i32.and
   i32.const 28
   i32.sub
-  local.tee $4
+  local.tee $3
   i32.const 16
   i32.ge_u
   if
-   local.get $1
-   local.get $3
+   local.get $0
+   local.get $2
    i32.const 2
    i32.and
    i32.const 28
    i32.or
    i32.store
-   local.get $1
+   local.get $0
    i32.const 32
    i32.add
-   local.tee $3
-   local.get $4
+   local.tee $2
+   local.get $3
    i32.const 4
    i32.sub
    i32.const 1
    i32.or
    i32.store
+   local.get $1
    local.get $2
-   local.get $3
    call $~lib/rt/tlsf/insertBlock
   else
-   local.get $1
-   local.get $3
+   local.get $0
+   local.get $2
    i32.const -2
    i32.and
    i32.store
-   local.get $1
+   local.get $0
    i32.const 4
    i32.add
-   local.get $1
+   local.get $0
    i32.load
    i32.const -4
    i32.and
    i32.add
-   local.tee $2
-   local.get $2
+   local.tee $1
+   local.get $1
    i32.load
    i32.const -3
    i32.and
    i32.store
   end
-  local.get $1
   local.get $0
+  i32.const 4
   i32.store offset=12
-  local.get $1
+  local.get $0
   i32.const 0
   i32.store offset=16
   global.get $~lib/rt/itcms/fromSpace
-  local.tee $0
+  local.tee $1
   i32.load offset=8
   local.set $2
-  local.get $1
   local.get $0
+  local.get $1
   global.get $~lib/rt/itcms/white
   i32.or
   i32.store offset=4
-  local.get $1
+  local.get $0
   local.get $2
   i32.store offset=8
   local.get $2
-  local.get $1
+  local.get $0
   local.get $2
   i32.load offset=4
   i32.const 3
   i32.and
   i32.or
   i32.store offset=4
-  local.get $0
   local.get $1
+  local.get $0
   i32.store offset=8
   global.get $~lib/rt/itcms/total
-  local.get $1
+  local.get $0
   i32.load
   i32.const -4
   i32.and
@@ -1358,7 +1358,7 @@
   i32.add
   i32.add
   global.set $~lib/rt/itcms/total
-  local.get $1
+  local.get $0
   i32.const 20
   i32.add
   local.tee $0
@@ -1844,66 +1844,38 @@
  )
  (func $for/Ref#constructor (result i32)
   (local $0 i32)
-  (local $1 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 8
   i32.sub
   global.set $~lib/memory/__stack_pointer
-  block $folding-inner0
-   global.get $~lib/memory/__stack_pointer
-   i32.const 1496
-   i32.lt_s
-   br_if $folding-inner0
-   global.get $~lib/memory/__stack_pointer
-   i64.const 0
-   i64.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 4
-   call $~lib/rt/itcms/__new
-   local.tee $0
-   i32.store
-   global.get $~lib/memory/__stack_pointer
-   global.get $~lib/memory/__stack_pointer
-   local.get $0
-   i32.store offset=4
-   global.get $~lib/memory/__stack_pointer
-   i32.const 4
-   i32.sub
-   global.set $~lib/memory/__stack_pointer
-   global.get $~lib/memory/__stack_pointer
-   i32.const 1496
-   i32.lt_s
-   br_if $folding-inner0
-   global.get $~lib/memory/__stack_pointer
-   i32.const 0
-   i32.store
-   local.get $0
-   i32.eqz
-   if
-    global.get $~lib/memory/__stack_pointer
-    i32.const 0
-    call $~lib/rt/itcms/__new
-    local.tee $0
-    i32.store
-   end
-   global.get $~lib/memory/__stack_pointer
-   i32.const 4
-   i32.add
-   global.set $~lib/memory/__stack_pointer
-   local.get $0
-   i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 8
-   i32.add
-   global.set $~lib/memory/__stack_pointer
-   local.get $0
-   return
+  global.get $~lib/memory/__stack_pointer
+  i32.const 1496
+  i32.lt_s
+  if
+   i32.const 34288
+   i32.const 34336
+   i32.const 1
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
   end
-  i32.const 34288
-  i32.const 34336
-  i32.const 1
-  i32.const 1
-  call $~lib/builtins/abort
-  unreachable
+  global.get $~lib/memory/__stack_pointer
+  i64.const 0
+  i64.store
+  global.get $~lib/memory/__stack_pointer
+  call $~lib/rt/itcms/__new
+  local.tee $0
+  i32.store
+  global.get $~lib/memory/__stack_pointer
+  local.get $0
+  i32.store offset=4
+  global.get $~lib/memory/__stack_pointer
+  local.get $0
+  i32.store
+  global.get $~lib/memory/__stack_pointer
+  i32.const 8
+  i32.add
+  global.set $~lib/memory/__stack_pointer
+  local.get $0
  )
 )

--- a/tests/compiler/function-call.debug.wat
+++ b/tests/compiler/function-call.debug.wat
@@ -78,6 +78,9 @@
   local.get $this
   return
  )
+ (func $~lib/object/Object#raw_constructor (param $this i32) (result i32)
+  local.get $this
+ )
  (func $~lib/rt/itcms/Object#set:nextWithColor (param $this i32) (param $nextWithColor i32)
   local.get $this
   local.get $nextWithColor
@@ -2452,6 +2455,34 @@
    unreachable
   end
  )
+ (func $function-call/Foo#raw_constructor (param $this i32) (result i32)
+  (local $1 i32)
+  global.get $~lib/memory/__stack_pointer
+  i32.const 8
+  i32.sub
+  global.set $~lib/memory/__stack_pointer
+  call $~stack_check
+  global.get $~lib/memory/__stack_pointer
+  i64.const 0
+  i64.store
+  global.get $~lib/memory/__stack_pointer
+  local.get $this
+  local.set $1
+  global.get $~lib/memory/__stack_pointer
+  local.get $1
+  i32.store
+  local.get $1
+  call $~lib/object/Object#raw_constructor
+  local.tee $this
+  i32.store offset=4
+  local.get $this
+  local.set $1
+  global.get $~lib/memory/__stack_pointer
+  i32.const 8
+  i32.add
+  global.set $~lib/memory/__stack_pointer
+  local.get $1
+ )
  (func $function-call/Foo#constructor (param $this i32) (result i32)
   (local $1 i32)
   global.get $~lib/memory/__stack_pointer
@@ -2479,7 +2510,7 @@
   local.get $1
   i32.store offset=4
   local.get $1
-  call $~lib/object/Object#constructor
+  call $~lib/object/Object#raw_constructor
   local.tee $this
   i32.store
   local.get $this

--- a/tests/compiler/function-call.release.wat
+++ b/tests/compiler/function-call.release.wat
@@ -4,10 +4,10 @@
  (type $2 (func (param i32)))
  (type $3 (func (param i32 i32) (result i32)))
  (type $4 (func (param i32 i32)))
- (type $5 (func (param i32 i32 i32) (result i32)))
- (type $6 (func (param i32 i32 i32 i32)))
- (type $7 (func (param i32 i32 i64)))
- (type $8 (func (result i32)))
+ (type $5 (func (result i32)))
+ (type $6 (func (param i32 i32 i32) (result i32)))
+ (type $7 (func (param i32 i32 i32 i32)))
+ (type $8 (func (param i32 i32 i64)))
  (import "env" "abort" (func $~lib/builtins/abort (param i32 i32 i32 i32)))
  (global $~lib/rt/itcms/total (mut i32) (i32.const 0))
  (global $~lib/rt/itcms/threshold (mut i32) (i32.const 0))
@@ -1172,23 +1172,23 @@
    end
   end
  )
- (func $~lib/rt/itcms/__new (param $0 i32) (result i32)
+ (func $~lib/rt/itcms/__new (result i32)
+  (local $0 i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
-  (local $4 i32)
   global.get $~lib/rt/itcms/total
   global.get $~lib/rt/itcms/threshold
   i32.ge_u
   if
    block $__inlined_func$~lib/rt/itcms/interrupt$69
     i32.const 2048
-    local.set $1
+    local.set $0
     loop $do-loop|0
-     local.get $1
+     local.get $0
      call $~lib/rt/itcms/step
      i32.sub
-     local.set $1
+     local.set $0
      global.get $~lib/rt/itcms/state
      i32.eqz
      if
@@ -1204,7 +1204,7 @@
       global.set $~lib/rt/itcms/threshold
       br $__inlined_func$~lib/rt/itcms/interrupt$69
      end
-     local.get $1
+     local.get $0
      i32.const 0
      i32.gt_s
      br_if $do-loop|0
@@ -1227,17 +1227,17 @@
    call $~lib/rt/tlsf/initialize
   end
   global.get $~lib/rt/tlsf/ROOT
-  local.tee $2
-  call $~lib/rt/tlsf/searchBlock
   local.tee $1
+  call $~lib/rt/tlsf/searchBlock
+  local.tee $0
   i32.eqz
   if
    memory.size
-   local.tee $1
+   local.tee $0
    i32.const 4
-   local.get $2
-   i32.load offset=1568
    local.get $1
+   i32.load offset=1568
+   local.get $0
    i32.const 16
    i32.shl
    i32.const 4
@@ -1250,16 +1250,16 @@
    i32.and
    i32.const 16
    i32.shr_u
-   local.tee $3
-   local.get $1
-   local.get $3
+   local.tee $2
+   local.get $0
+   local.get $2
    i32.gt_s
    select
    memory.grow
    i32.const 0
    i32.lt_s
    if
-    local.get $3
+    local.get $2
     memory.grow
     i32.const 0
     i32.lt_s
@@ -1267,8 +1267,8 @@
      unreachable
     end
    end
-   local.get $2
    local.get $1
+   local.get $0
    i32.const 16
    i32.shl
    memory.size
@@ -1276,9 +1276,9 @@
    i64.const 16
    i64.shl
    call $~lib/rt/tlsf/addMemory
-   local.get $2
+   local.get $1
    call $~lib/rt/tlsf/searchBlock
-   local.tee $1
+   local.tee $0
    i32.eqz
    if
     i32.const 0
@@ -1289,7 +1289,7 @@
     unreachable
    end
   end
-  local.get $1
+  local.get $0
   i32.load
   i32.const -4
   i32.and
@@ -1303,92 +1303,92 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $2
   local.get $1
+  local.get $0
   call $~lib/rt/tlsf/removeBlock
-  local.get $1
+  local.get $0
   i32.load
-  local.tee $3
+  local.tee $2
   i32.const -4
   i32.and
   i32.const 28
   i32.sub
-  local.tee $4
+  local.tee $3
   i32.const 16
   i32.ge_u
   if
-   local.get $1
-   local.get $3
+   local.get $0
+   local.get $2
    i32.const 2
    i32.and
    i32.const 28
    i32.or
    i32.store
-   local.get $1
+   local.get $0
    i32.const 32
    i32.add
-   local.tee $3
-   local.get $4
+   local.tee $2
+   local.get $3
    i32.const 4
    i32.sub
    i32.const 1
    i32.or
    i32.store
+   local.get $1
    local.get $2
-   local.get $3
    call $~lib/rt/tlsf/insertBlock
   else
-   local.get $1
-   local.get $3
+   local.get $0
+   local.get $2
    i32.const -2
    i32.and
    i32.store
-   local.get $1
+   local.get $0
    i32.const 4
    i32.add
-   local.get $1
+   local.get $0
    i32.load
    i32.const -4
    i32.and
    i32.add
-   local.tee $2
-   local.get $2
+   local.tee $1
+   local.get $1
    i32.load
    i32.const -3
    i32.and
    i32.store
   end
-  local.get $1
   local.get $0
+  i32.const 7
   i32.store offset=12
-  local.get $1
+  local.get $0
   i32.const 0
   i32.store offset=16
   global.get $~lib/rt/itcms/fromSpace
-  local.tee $0
+  local.tee $1
   i32.load offset=8
   local.set $2
-  local.get $1
   local.get $0
+  local.get $1
   global.get $~lib/rt/itcms/white
   i32.or
   i32.store offset=4
-  local.get $1
+  local.get $0
   local.get $2
   i32.store offset=8
   local.get $2
-  local.get $1
+  local.get $0
   local.get $2
   i32.load offset=4
   i32.const 3
   i32.and
   i32.or
   i32.store offset=4
-  local.get $0
   local.get $1
+  local.get $0
   i32.store offset=8
   global.get $~lib/rt/itcms/total
-  local.get $1
+  local.get $0
   i32.load
   i32.const -4
   i32.and
@@ -1396,7 +1396,7 @@
   i32.add
   i32.add
   global.set $~lib/rt/itcms/total
-  local.get $1
+  local.get $0
   i32.const 20
   i32.add
   local.tee $0
@@ -1470,7 +1470,6 @@
  )
  (func $~start
   (local $0 i32)
-  (local $1 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 4
   i32.sub
@@ -1568,38 +1567,13 @@
    i64.const 0
    i64.store
    global.get $~lib/memory/__stack_pointer
-   i32.const 7
    call $~lib/rt/itcms/__new
    local.tee $0
    i32.store
    global.get $~lib/memory/__stack_pointer
-   global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store offset=4
    global.get $~lib/memory/__stack_pointer
-   i32.const 4
-   i32.sub
-   global.set $~lib/memory/__stack_pointer
-   global.get $~lib/memory/__stack_pointer
-   i32.const 1804
-   i32.lt_s
-   br_if $folding-inner0
-   global.get $~lib/memory/__stack_pointer
-   i32.const 0
-   i32.store
-   local.get $0
-   i32.eqz
-   if
-    global.get $~lib/memory/__stack_pointer
-    i32.const 0
-    call $~lib/rt/itcms/__new
-    local.tee $0
-    i32.store
-   end
-   global.get $~lib/memory/__stack_pointer
-   i32.const 4
-   i32.add
-   global.set $~lib/memory/__stack_pointer
    local.get $0
    i32.store
    global.get $~lib/memory/__stack_pointer
@@ -1630,7 +1604,7 @@
    i32.const 2
    i32.const 1744
    i32.load
-   call_indirect (type $5)
+   call_indirect (type $6)
    i32.const 3
    i32.ne
    if

--- a/tests/compiler/getter-call.debug.wat
+++ b/tests/compiler/getter-call.debug.wat
@@ -44,6 +44,9 @@
  (export "test" (func $getter-call/test))
  (export "memory" (memory $0))
  (start $~start)
+ (func $~lib/object/Object#raw_constructor (param $this i32) (result i32)
+  local.get $this
+ )
  (func $~lib/rt/itcms/Object#set:nextWithColor (param $this i32) (param $nextWithColor i32)
   local.get $this
   local.get $nextWithColor
@@ -2350,6 +2353,34 @@
    unreachable
   end
  )
+ (func $getter-call/C#raw_constructor (param $this i32) (result i32)
+  (local $1 i32)
+  global.get $~lib/memory/__stack_pointer
+  i32.const 8
+  i32.sub
+  global.set $~lib/memory/__stack_pointer
+  call $~stack_check
+  global.get $~lib/memory/__stack_pointer
+  i64.const 0
+  i64.store
+  global.get $~lib/memory/__stack_pointer
+  local.get $this
+  local.set $1
+  global.get $~lib/memory/__stack_pointer
+  local.get $1
+  i32.store
+  local.get $1
+  call $~lib/object/Object#raw_constructor
+  local.tee $this
+  i32.store offset=4
+  local.get $this
+  local.set $1
+  global.get $~lib/memory/__stack_pointer
+  i32.const 8
+  i32.add
+  global.set $~lib/memory/__stack_pointer
+  local.get $1
+ )
  (func $getter-call/C#constructor (param $this i32) (result i32)
   (local $1 i32)
   global.get $~lib/memory/__stack_pointer
@@ -2377,7 +2408,7 @@
   local.get $1
   i32.store offset=4
   local.get $1
-  call $~lib/object/Object#constructor
+  call $~lib/object/Object#raw_constructor
   local.tee $this
   i32.store
   local.get $this

--- a/tests/compiler/getter-call.release.wat
+++ b/tests/compiler/getter-call.release.wat
@@ -3,9 +3,9 @@
  (type $1 (func))
  (type $2 (func (param i32)))
  (type $3 (func (param i32 i32)))
- (type $4 (func (param i32) (result i32)))
- (type $5 (func (param i32 i32 i32 i32)))
- (type $6 (func (param i32 i32 i64)))
+ (type $4 (func (param i32 i32 i32 i32)))
+ (type $5 (func (param i32 i32 i64)))
+ (type $6 (func (param i32) (result i32)))
  (import "env" "abort" (func $~lib/builtins/abort (param i32 i32 i32 i32)))
  (global $~lib/rt/itcms/total (mut i32) (i32.const 0))
  (global $~lib/rt/itcms/threshold (mut i32) (i32.const 0))
@@ -1137,23 +1137,23 @@
    end
   end
  )
- (func $~lib/rt/itcms/__new (param $0 i32) (result i32)
+ (func $~lib/rt/itcms/__new (result i32)
+  (local $0 i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
-  (local $4 i32)
   global.get $~lib/rt/itcms/total
   global.get $~lib/rt/itcms/threshold
   i32.ge_u
   if
    block $__inlined_func$~lib/rt/itcms/interrupt$69
     i32.const 2048
-    local.set $1
+    local.set $0
     loop $do-loop|0
-     local.get $1
+     local.get $0
      call $~lib/rt/itcms/step
      i32.sub
-     local.set $1
+     local.set $0
      global.get $~lib/rt/itcms/state
      i32.eqz
      if
@@ -1169,7 +1169,7 @@
       global.set $~lib/rt/itcms/threshold
       br $__inlined_func$~lib/rt/itcms/interrupt$69
      end
-     local.get $1
+     local.get $0
      i32.const 0
      i32.gt_s
      br_if $do-loop|0
@@ -1192,17 +1192,17 @@
    call $~lib/rt/tlsf/initialize
   end
   global.get $~lib/rt/tlsf/ROOT
-  local.tee $2
-  call $~lib/rt/tlsf/searchBlock
   local.tee $1
+  call $~lib/rt/tlsf/searchBlock
+  local.tee $0
   i32.eqz
   if
    memory.size
-   local.tee $1
+   local.tee $0
    i32.const 4
-   local.get $2
-   i32.load offset=1568
    local.get $1
+   i32.load offset=1568
+   local.get $0
    i32.const 16
    i32.shl
    i32.const 4
@@ -1215,16 +1215,16 @@
    i32.and
    i32.const 16
    i32.shr_u
-   local.tee $3
-   local.get $1
-   local.get $3
+   local.tee $2
+   local.get $0
+   local.get $2
    i32.gt_s
    select
    memory.grow
    i32.const 0
    i32.lt_s
    if
-    local.get $3
+    local.get $2
     memory.grow
     i32.const 0
     i32.lt_s
@@ -1232,8 +1232,8 @@
      unreachable
     end
    end
-   local.get $2
    local.get $1
+   local.get $0
    i32.const 16
    i32.shl
    memory.size
@@ -1241,9 +1241,9 @@
    i64.const 16
    i64.shl
    call $~lib/rt/tlsf/addMemory
-   local.get $2
+   local.get $1
    call $~lib/rt/tlsf/searchBlock
-   local.tee $1
+   local.tee $0
    i32.eqz
    if
     i32.const 0
@@ -1254,7 +1254,7 @@
     unreachable
    end
   end
-  local.get $1
+  local.get $0
   i32.load
   i32.const -4
   i32.and
@@ -1268,92 +1268,92 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $2
   local.get $1
+  local.get $0
   call $~lib/rt/tlsf/removeBlock
-  local.get $1
+  local.get $0
   i32.load
-  local.tee $3
+  local.tee $2
   i32.const -4
   i32.and
   i32.const 28
   i32.sub
-  local.tee $4
+  local.tee $3
   i32.const 16
   i32.ge_u
   if
-   local.get $1
-   local.get $3
+   local.get $0
+   local.get $2
    i32.const 2
    i32.and
    i32.const 28
    i32.or
    i32.store
-   local.get $1
+   local.get $0
    i32.const 32
    i32.add
-   local.tee $3
-   local.get $4
+   local.tee $2
+   local.get $3
    i32.const 4
    i32.sub
    i32.const 1
    i32.or
    i32.store
+   local.get $1
    local.get $2
-   local.get $3
    call $~lib/rt/tlsf/insertBlock
   else
-   local.get $1
-   local.get $3
+   local.get $0
+   local.get $2
    i32.const -2
    i32.and
    i32.store
-   local.get $1
+   local.get $0
    i32.const 4
    i32.add
-   local.get $1
+   local.get $0
    i32.load
    i32.const -4
    i32.and
    i32.add
-   local.tee $2
-   local.get $2
+   local.tee $1
+   local.get $1
    i32.load
    i32.const -3
    i32.and
    i32.store
   end
-  local.get $1
   local.get $0
+  i32.const 4
   i32.store offset=12
-  local.get $1
+  local.get $0
   i32.const 0
   i32.store offset=16
   global.get $~lib/rt/itcms/fromSpace
-  local.tee $0
+  local.tee $1
   i32.load offset=8
   local.set $2
-  local.get $1
   local.get $0
+  local.get $1
   global.get $~lib/rt/itcms/white
   i32.or
   i32.store offset=4
-  local.get $1
+  local.get $0
   local.get $2
   i32.store offset=8
   local.get $2
-  local.get $1
+  local.get $0
   local.get $2
   i32.load offset=4
   i32.const 3
   i32.and
   i32.or
   i32.store offset=4
-  local.get $0
   local.get $1
+  local.get $0
   i32.store offset=8
   global.get $~lib/rt/itcms/total
-  local.get $1
+  local.get $0
   i32.load
   i32.const -4
   i32.and
@@ -1361,7 +1361,7 @@
   i32.add
   i32.add
   global.set $~lib/rt/itcms/total
-  local.get $1
+  local.get $0
   i32.const 20
   i32.add
   local.tee $0
@@ -1469,7 +1469,6 @@
  (func $getter-call/test (result i32)
   (local $0 i32)
   (local $1 i32)
-  (local $2 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 8
   i32.sub
@@ -1495,38 +1494,13 @@
    i64.const 0
    i64.store
    global.get $~lib/memory/__stack_pointer
-   i32.const 4
    call $~lib/rt/itcms/__new
    local.tee $0
    i32.store
    global.get $~lib/memory/__stack_pointer
-   global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store offset=4
    global.get $~lib/memory/__stack_pointer
-   i32.const 4
-   i32.sub
-   global.set $~lib/memory/__stack_pointer
-   global.get $~lib/memory/__stack_pointer
-   i32.const 1500
-   i32.lt_s
-   br_if $folding-inner0
-   global.get $~lib/memory/__stack_pointer
-   i32.const 0
-   i32.store
-   local.get $0
-   i32.eqz
-   if
-    global.get $~lib/memory/__stack_pointer
-    i32.const 0
-    call $~lib/rt/itcms/__new
-    local.tee $0
-    i32.store
-   end
-   global.get $~lib/memory/__stack_pointer
-   i32.const 4
-   i32.add
-   global.set $~lib/memory/__stack_pointer
    local.get $0
    i32.store
    global.get $~lib/memory/__stack_pointer

--- a/tests/compiler/incremental-gc/call-indirect.debug.wat
+++ b/tests/compiler/incremental-gc/call-indirect.debug.wat
@@ -1646,6 +1646,9 @@
   i32.const 0
   drop
  )
+ (func $~lib/object/Object#raw_constructor (param $this i32) (result i32)
+  local.get $this
+ )
  (func $~lib/rt/itcms/interrupt
   (local $budget i32)
   i32.const 0
@@ -2426,6 +2429,42 @@
    unreachable
   end
  )
+ (func $incremental-gc/call-indirect/B#raw_constructor (param $this i32) (result i32)
+  (local $1 i32)
+  global.get $~lib/memory/__stack_pointer
+  i32.const 8
+  i32.sub
+  global.set $~lib/memory/__stack_pointer
+  call $~stack_check
+  global.get $~lib/memory/__stack_pointer
+  i64.const 0
+  i64.store
+  global.get $~lib/memory/__stack_pointer
+  local.get $this
+  local.set $1
+  global.get $~lib/memory/__stack_pointer
+  local.get $1
+  i32.store
+  local.get $1
+  call $~lib/object/Object#raw_constructor
+  local.tee $this
+  i32.store offset=4
+  local.get $this
+  local.set $1
+  global.get $~lib/memory/__stack_pointer
+  local.get $1
+  i32.store
+  local.get $1
+  i32.const 20
+  call $incremental-gc/call-indirect/B#set:v
+  local.get $this
+  local.set $1
+  global.get $~lib/memory/__stack_pointer
+  i32.const 8
+  i32.add
+  global.set $~lib/memory/__stack_pointer
+  local.get $1
+ )
  (func $incremental-gc/call-indirect/B#constructor (param $this i32) (result i32)
   (local $1 i32)
   global.get $~lib/memory/__stack_pointer
@@ -2453,7 +2492,7 @@
   local.get $1
   i32.store offset=4
   local.get $1
-  call $~lib/object/Object#constructor
+  call $~lib/object/Object#raw_constructor
   local.tee $this
   i32.store
   local.get $this
@@ -2504,6 +2543,42 @@
   local.get $2
   return
  )
+ (func $incremental-gc/call-indirect/A#raw_constructor (param $this i32) (result i32)
+  (local $1 i32)
+  global.get $~lib/memory/__stack_pointer
+  i32.const 8
+  i32.sub
+  global.set $~lib/memory/__stack_pointer
+  call $~stack_check
+  global.get $~lib/memory/__stack_pointer
+  i64.const 0
+  i64.store
+  global.get $~lib/memory/__stack_pointer
+  local.get $this
+  local.set $1
+  global.get $~lib/memory/__stack_pointer
+  local.get $1
+  i32.store
+  local.get $1
+  call $~lib/object/Object#raw_constructor
+  local.tee $this
+  i32.store offset=4
+  local.get $this
+  local.set $1
+  global.get $~lib/memory/__stack_pointer
+  local.get $1
+  i32.store
+  local.get $1
+  i32.const 10
+  call $incremental-gc/call-indirect/A#set:v
+  local.get $this
+  local.set $1
+  global.get $~lib/memory/__stack_pointer
+  i32.const 8
+  i32.add
+  global.set $~lib/memory/__stack_pointer
+  local.get $1
+ )
  (func $incremental-gc/call-indirect/A#constructor (param $this i32) (result i32)
   (local $1 i32)
   global.get $~lib/memory/__stack_pointer
@@ -2531,7 +2606,7 @@
   local.get $1
   i32.store offset=4
   local.get $1
-  call $~lib/object/Object#constructor
+  call $~lib/object/Object#raw_constructor
   local.tee $this
   i32.store
   local.get $this

--- a/tests/compiler/incremental-gc/call-indirect.release.wat
+++ b/tests/compiler/incremental-gc/call-indirect.release.wat
@@ -1,12 +1,11 @@
 (module
- (type $0 (func))
- (type $1 (func (param i32) (result i32)))
+ (type $0 (func (param i32) (result i32)))
+ (type $1 (func))
  (type $2 (func (param i32)))
  (type $3 (func (param i32 i32)))
  (type $4 (func (result i32)))
- (type $5 (func (param i32 i32) (result i32)))
- (type $6 (func (param i32 i32 i32 i32)))
- (type $7 (func (param i32 i32 i64)))
+ (type $5 (func (param i32 i32 i32 i32)))
+ (type $6 (func (param i32 i32 i64)))
  (import "env" "abort" (func $~lib/builtins/abort (param i32 i32 i32 i32)))
  (global $~lib/rt/itcms/state (mut i32) (i32.const 0))
  (global $~lib/rt/itcms/visitCount (mut i32) (i32.const 0))
@@ -123,7 +122,7 @@
     local.get $0
     global.set $~lib/rt/itcms/iter
    end
-   block $__inlined_func$~lib/rt/itcms/Object#unlink$123
+   block $__inlined_func$~lib/rt/itcms/Object#unlink$124
     local.get $1
     i32.load offset=4
     i32.const -4
@@ -147,7 +146,7 @@
       call $~lib/builtins/abort
       unreachable
      end
-     br $__inlined_func$~lib/rt/itcms/Object#unlink$123
+     br $__inlined_func$~lib/rt/itcms/Object#unlink$124
     end
     local.get $1
     i32.load offset=8
@@ -1083,85 +1082,18 @@
   end
   i32.const 0
  )
- (func $~lib/rt/tlsf/searchBlock (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/rt/tlsf/searchBlock (param $0 i32) (result i32)
+  (local $1 i32)
   (local $2 i32)
-  local.get $1
-  i32.const 256
-  i32.lt_u
-  if
-   local.get $1
-   i32.const 4
-   i32.shr_u
-   local.set $1
-  else
-   local.get $1
-   i32.const 536870910
-   i32.lt_u
-   if
-    local.get $1
-    i32.const 1
-    i32.const 27
-    local.get $1
-    i32.clz
-    i32.sub
-    i32.shl
-    i32.add
-    i32.const 1
-    i32.sub
-    local.set $1
-   end
-   local.get $1
-   i32.const 31
-   local.get $1
-   i32.clz
-   i32.sub
-   local.tee $2
-   i32.const 4
-   i32.sub
-   i32.shr_u
-   i32.const 16
-   i32.xor
-   local.set $1
-   local.get $2
-   i32.const 7
-   i32.sub
-   local.set $2
-  end
-  local.get $1
-  i32.const 16
-  i32.lt_u
-  local.get $2
-  i32.const 23
-  i32.lt_u
-  i32.and
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1312
-   i32.const 334
-   i32.const 14
-   call $~lib/builtins/abort
-   unreachable
-  end
   local.get $0
-  local.get $2
-  i32.const 2
-  i32.shl
-  i32.add
   i32.load offset=4
-  i32.const -1
-  local.get $1
-  i32.shl
+  i32.const -2
   i32.and
   local.tee $1
   if (result i32)
    local.get $0
    local.get $1
    i32.ctz
-   local.get $2
-   i32.const 4
-   i32.shl
-   i32.add
    i32.const 2
    i32.shl
    i32.add
@@ -1169,23 +1101,19 @@
   else
    local.get $0
    i32.load
-   i32.const -1
-   local.get $2
-   i32.const 1
-   i32.add
-   i32.shl
+   i32.const -2
    i32.and
    local.tee $1
    if (result i32)
     local.get $0
     local.get $1
     i32.ctz
-    local.tee $1
+    local.tee $2
     i32.const 2
     i32.shl
     i32.add
     i32.load offset=4
-    local.tee $2
+    local.tee $1
     i32.eqz
     if
      i32.const 0
@@ -1196,9 +1124,9 @@
      unreachable
     end
     local.get $0
-    local.get $2
-    i32.ctz
     local.get $1
+    i32.ctz
+    local.get $2
     i32.const 4
     i32.shl
     i32.add
@@ -1211,35 +1139,23 @@
    end
   end
  )
- (func $~lib/rt/itcms/__new (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/rt/itcms/__new (param $0 i32) (result i32)
+  (local $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
-  (local $5 i32)
-  (local $6 i32)
-  local.get $0
-  i32.const 1073741804
-  i32.ge_u
-  if
-   i32.const 1376
-   i32.const 1072
-   i32.const 261
-   i32.const 31
-   call $~lib/builtins/abort
-   unreachable
-  end
   global.get $~lib/rt/itcms/total
   global.get $~lib/rt/itcms/threshold
   i32.ge_u
   if
    block $__inlined_func$~lib/rt/itcms/interrupt$69
     i32.const 2048
-    local.set $2
+    local.set $1
     loop $do-loop|0
-     local.get $2
+     local.get $1
      call $~lib/rt/itcms/step
      i32.sub
-     local.set $2
+     local.set $1
      global.get $~lib/rt/itcms/state
      i32.eqz
      if
@@ -1255,7 +1171,7 @@
       global.set $~lib/rt/itcms/threshold
       br $__inlined_func$~lib/rt/itcms/interrupt$69
      end
-     local.get $2
+     local.get $1
      i32.const 0
      i32.gt_s
      br_if $do-loop|0
@@ -1278,86 +1194,31 @@
    call $~lib/rt/tlsf/initialize
   end
   global.get $~lib/rt/tlsf/ROOT
-  local.set $4
-  local.get $0
-  i32.const 16
-  i32.add
   local.tee $2
-  i32.const 1073741820
-  i32.gt_u
-  if
-   i32.const 1376
-   i32.const 1312
-   i32.const 461
-   i32.const 29
-   call $~lib/builtins/abort
-   unreachable
-  end
-  local.get $4
-  local.get $2
-  i32.const 12
-  i32.le_u
-  if (result i32)
-   i32.const 12
-  else
-   local.get $2
-   i32.const 19
-   i32.add
-   i32.const -16
-   i32.and
-   i32.const 4
-   i32.sub
-  end
-  local.tee $5
   call $~lib/rt/tlsf/searchBlock
-  local.tee $2
+  local.tee $1
   i32.eqz
   if
    memory.size
-   local.tee $2
-   local.get $5
-   i32.const 256
-   i32.ge_u
-   if (result i32)
-    local.get $5
-    i32.const 536870910
-    i32.lt_u
-    if (result i32)
-     local.get $5
-     i32.const 1
-     i32.const 27
-     local.get $5
-     i32.clz
-     i32.sub
-     i32.shl
-     i32.add
-     i32.const 1
-     i32.sub
-    else
-     local.get $5
-    end
-   else
-    local.get $5
-   end
+   local.tee $1
    i32.const 4
-   local.get $4
-   i32.load offset=1568
    local.get $2
+   i32.load offset=1568
+   local.get $1
    i32.const 16
    i32.shl
    i32.const 4
    i32.sub
    i32.ne
    i32.shl
-   i32.add
-   i32.const 65535
+   i32.const 65563
    i32.add
    i32.const -65536
    i32.and
    i32.const 16
    i32.shr_u
    local.tee $3
-   local.get $2
+   local.get $1
    local.get $3
    i32.gt_s
    select
@@ -1373,8 +1234,8 @@
      unreachable
     end
    end
-   local.get $4
    local.get $2
+   local.get $1
    i32.const 16
    i32.shl
    memory.size
@@ -1382,10 +1243,9 @@
    i64.const 16
    i64.shl
    call $~lib/rt/tlsf/addMemory
-   local.get $4
-   local.get $5
+   local.get $2
    call $~lib/rt/tlsf/searchBlock
-   local.tee $2
+   local.tee $1
    i32.eqz
    if
     i32.const 0
@@ -1396,12 +1256,12 @@
     unreachable
    end
   end
-  local.get $5
-  local.get $2
+  local.get $1
   i32.load
   i32.const -4
   i32.and
-  i32.gt_u
+  i32.const 28
+  i32.lt_u
   if
    i32.const 0
    i32.const 1312
@@ -1410,108 +1270,92 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $4
   local.get $2
+  local.get $1
   call $~lib/rt/tlsf/removeBlock
-  local.get $2
+  local.get $1
   i32.load
-  local.set $6
-  local.get $5
-  i32.const 4
-  i32.add
-  i32.const 15
-  i32.and
-  if
-   i32.const 0
-   i32.const 1312
-   i32.const 361
-   i32.const 14
-   call $~lib/builtins/abort
-   unreachable
-  end
-  local.get $6
+  local.tee $3
   i32.const -4
   i32.and
-  local.get $5
+  i32.const 28
   i32.sub
-  local.tee $3
+  local.tee $4
   i32.const 16
   i32.ge_u
   if
-   local.get $2
-   local.get $5
-   local.get $6
+   local.get $1
+   local.get $3
    i32.const 2
    i32.and
+   i32.const 28
    i32.or
    i32.store
-   local.get $2
-   i32.const 4
+   local.get $1
+   i32.const 32
    i32.add
-   local.get $5
-   i32.add
-   local.tee $5
-   local.get $3
+   local.tee $3
+   local.get $4
    i32.const 4
    i32.sub
    i32.const 1
    i32.or
    i32.store
-   local.get $4
-   local.get $5
+   local.get $2
+   local.get $3
    call $~lib/rt/tlsf/insertBlock
   else
-   local.get $2
-   local.get $6
+   local.get $1
+   local.get $3
    i32.const -2
    i32.and
    i32.store
-   local.get $2
+   local.get $1
    i32.const 4
    i32.add
-   local.get $2
+   local.get $1
    i32.load
    i32.const -4
    i32.and
    i32.add
-   local.tee $3
-   local.get $3
+   local.tee $2
+   local.get $2
    i32.load
    i32.const -3
    i32.and
    i32.store
   end
-  local.get $2
   local.get $1
-  i32.store offset=12
-  local.get $2
   local.get $0
+  i32.store offset=12
+  local.get $1
+  i32.const 4
   i32.store offset=16
   global.get $~lib/rt/itcms/fromSpace
-  local.tee $1
+  local.tee $0
   i32.load offset=8
-  local.set $3
-  local.get $2
+  local.set $2
   local.get $1
+  local.get $0
   global.get $~lib/rt/itcms/white
   i32.or
   i32.store offset=4
+  local.get $1
   local.get $2
-  local.get $3
   i32.store offset=8
-  local.get $3
   local.get $2
-  local.get $3
+  local.get $1
+  local.get $2
   i32.load offset=4
   i32.const 3
   i32.and
   i32.or
   i32.store offset=4
+  local.get $0
   local.get $1
-  local.get $2
   i32.store offset=8
   global.get $~lib/rt/itcms/total
-  local.get $2
+  local.get $1
   i32.load
   i32.const -4
   i32.and
@@ -1519,14 +1363,13 @@
   i32.add
   i32.add
   global.set $~lib/rt/itcms/total
-  local.get $2
+  local.get $1
   i32.const 20
   i32.add
-  local.tee $1
+  local.tee $0
   i32.const 0
+  i32.store align=1
   local.get $0
-  memory.fill
-  local.get $1
  )
  (func $~lib/rt/__visit_members (param $0 i32)
   block $invalid
@@ -1696,30 +1539,27 @@
    i64.const 0
    i64.store
    global.get $~lib/memory/__stack_pointer
-   i32.const 4
    i32.const 6
    call $~lib/rt/itcms/__new
-   local.tee $2
+   local.tee $1
    i32.store
    global.get $~lib/memory/__stack_pointer
-   local.get $2
+   local.get $1
    i32.store offset=4
    global.get $~lib/memory/__stack_pointer
-   local.get $2
-   call $~lib/object/Object#constructor
-   local.tee $2
+   local.get $1
    i32.store
    global.get $~lib/memory/__stack_pointer
-   local.get $2
+   local.get $1
    i32.store offset=4
-   local.get $2
+   local.get $1
    i32.const 20
    i32.store
    global.get $~lib/memory/__stack_pointer
    i32.const 8
    i32.add
    global.set $~lib/memory/__stack_pointer
-   local.get $2
+   local.get $1
    i32.store
    global.get $~lib/memory/__stack_pointer
    local.get $0
@@ -1766,7 +1606,6 @@
    i64.store
    global.get $~lib/memory/__stack_pointer
    i32.const 4
-   i32.const 4
    call $~lib/rt/itcms/__new
    local.tee $0
    i32.store
@@ -1775,8 +1614,6 @@
    i32.store offset=4
    global.get $~lib/memory/__stack_pointer
    local.get $0
-   call $~lib/object/Object#constructor
-   local.tee $0
    i32.store
    global.get $~lib/memory/__stack_pointer
    local.get $0
@@ -1797,7 +1634,7 @@
    local.get $0
    i32.const 1440
    i32.load
-   call_indirect (type $1)
+   call_indirect (type $0)
    global.get $~lib/memory/__stack_pointer
    i32.const 8
    i32.add
@@ -1810,40 +1647,5 @@
   i32.const 1
   call $~lib/builtins/abort
   unreachable
- )
- (func $~lib/object/Object#constructor (param $0 i32) (result i32)
-  global.get $~lib/memory/__stack_pointer
-  i32.const 4
-  i32.sub
-  global.set $~lib/memory/__stack_pointer
-  global.get $~lib/memory/__stack_pointer
-  i32.const 1584
-  i32.lt_s
-  if
-   i32.const 34384
-   i32.const 34432
-   i32.const 1
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  global.get $~lib/memory/__stack_pointer
-  i32.const 0
-  i32.store
-  local.get $0
-  i32.eqz
-  if
-   global.get $~lib/memory/__stack_pointer
-   i32.const 0
-   i32.const 0
-   call $~lib/rt/itcms/__new
-   local.tee $0
-   i32.store
-  end
-  global.get $~lib/memory/__stack_pointer
-  i32.const 4
-  i32.add
-  global.set $~lib/memory/__stack_pointer
-  local.get $0
  )
 )

--- a/tests/compiler/infer-array.debug.wat
+++ b/tests/compiler/infer-array.debug.wat
@@ -2379,6 +2379,9 @@
   local.get $this
   i32.load offset=4
  )
+ (func $~lib/object/Object#raw_constructor (param $this i32) (result i32)
+  local.get $this
+ )
  (func $~lib/array/Array<infer-array/Ref|null>#get:length_ (param $this i32) (result i32)
   local.get $this
   i32.load offset=12
@@ -2904,6 +2907,34 @@
   local.get $4
   return
  )
+ (func $infer-array/Ref#raw_constructor (param $this i32) (result i32)
+  (local $1 i32)
+  global.get $~lib/memory/__stack_pointer
+  i32.const 8
+  i32.sub
+  global.set $~lib/memory/__stack_pointer
+  call $~stack_check
+  global.get $~lib/memory/__stack_pointer
+  i64.const 0
+  i64.store
+  global.get $~lib/memory/__stack_pointer
+  local.get $this
+  local.set $1
+  global.get $~lib/memory/__stack_pointer
+  local.get $1
+  i32.store
+  local.get $1
+  call $~lib/object/Object#raw_constructor
+  local.tee $this
+  i32.store offset=4
+  local.get $this
+  local.set $1
+  global.get $~lib/memory/__stack_pointer
+  i32.const 8
+  i32.add
+  global.set $~lib/memory/__stack_pointer
+  local.get $1
+ )
  (func $infer-array/Ref#constructor (param $this i32) (result i32)
   (local $1 i32)
   global.get $~lib/memory/__stack_pointer
@@ -2931,7 +2962,7 @@
   local.get $1
   i32.store offset=4
   local.get $1
-  call $~lib/object/Object#constructor
+  call $~lib/object/Object#raw_constructor
   local.tee $this
   i32.store
   local.get $this

--- a/tests/compiler/infer-array.release.wat
+++ b/tests/compiler/infer-array.release.wat
@@ -142,7 +142,7 @@
    local.get $1
    global.set $~lib/rt/itcms/iter
   end
-  block $__inlined_func$~lib/rt/itcms/Object#unlink$154
+  block $__inlined_func$~lib/rt/itcms/Object#unlink$153
    local.get $0
    i32.load offset=4
    i32.const -4
@@ -166,7 +166,7 @@
      call $~lib/builtins/abort
      unreachable
     end
-    br $__inlined_func$~lib/rt/itcms/Object#unlink$154
+    br $__inlined_func$~lib/rt/itcms/Object#unlink$153
    end
    local.get $0
    i32.load offset=8
@@ -1941,69 +1941,41 @@
  )
  (func $infer-array/Ref#constructor (result i32)
   (local $0 i32)
-  (local $1 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 8
   i32.sub
   global.set $~lib/memory/__stack_pointer
-  block $folding-inner0
-   global.get $~lib/memory/__stack_pointer
-   i32.const 2216
-   i32.lt_s
-   br_if $folding-inner0
-   global.get $~lib/memory/__stack_pointer
-   i64.const 0
-   i64.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 0
-   i32.const 8
-   call $~lib/rt/itcms/__new
-   local.tee $0
-   i32.store
-   global.get $~lib/memory/__stack_pointer
-   global.get $~lib/memory/__stack_pointer
-   local.get $0
-   i32.store offset=4
-   global.get $~lib/memory/__stack_pointer
-   i32.const 4
-   i32.sub
-   global.set $~lib/memory/__stack_pointer
-   global.get $~lib/memory/__stack_pointer
-   i32.const 2216
-   i32.lt_s
-   br_if $folding-inner0
-   global.get $~lib/memory/__stack_pointer
-   i32.const 0
-   i32.store
-   local.get $0
-   i32.eqz
-   if
-    global.get $~lib/memory/__stack_pointer
-    i32.const 0
-    i32.const 0
-    call $~lib/rt/itcms/__new
-    local.tee $0
-    i32.store
-   end
-   global.get $~lib/memory/__stack_pointer
-   i32.const 4
-   i32.add
-   global.set $~lib/memory/__stack_pointer
-   local.get $0
-   i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 8
-   i32.add
-   global.set $~lib/memory/__stack_pointer
-   local.get $0
-   return
+  global.get $~lib/memory/__stack_pointer
+  i32.const 2216
+  i32.lt_s
+  if
+   i32.const 35008
+   i32.const 35056
+   i32.const 1
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
   end
-  i32.const 35008
-  i32.const 35056
-  i32.const 1
-  i32.const 1
-  call $~lib/builtins/abort
-  unreachable
+  global.get $~lib/memory/__stack_pointer
+  i64.const 0
+  i64.store
+  global.get $~lib/memory/__stack_pointer
+  i32.const 0
+  i32.const 8
+  call $~lib/rt/itcms/__new
+  local.tee $0
+  i32.store
+  global.get $~lib/memory/__stack_pointer
+  local.get $0
+  i32.store offset=4
+  global.get $~lib/memory/__stack_pointer
+  local.get $0
+  i32.store
+  global.get $~lib/memory/__stack_pointer
+  i32.const 8
+  i32.add
+  global.set $~lib/memory/__stack_pointer
+  local.get $0
  )
  (func $~lib/array/Array<infer-array/Ref|null>#__set (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
@@ -2083,7 +2055,7 @@
      global.get $~lib/memory/__stack_pointer
      local.get $0
      i32.store
-     block $__inlined_func$~lib/rt/itcms/__renew$149
+     block $__inlined_func$~lib/rt/itcms/__renew$148
       i32.const 1073741820
       local.get $4
       i32.const 1
@@ -2126,7 +2098,7 @@
        i32.store offset=16
        local.get $4
        local.set $3
-       br $__inlined_func$~lib/rt/itcms/__renew$149
+       br $__inlined_func$~lib/rt/itcms/__renew$148
       end
       local.get $5
       local.get $7

--- a/tests/compiler/infer-generic.debug.wat
+++ b/tests/compiler/infer-generic.debug.wat
@@ -90,6 +90,9 @@
   local.get $x
   i32.store
  )
+ (func $~lib/object/Object#raw_constructor (param $this i32) (result i32)
+  local.get $this
+ )
  (func $~lib/rt/itcms/Object#set:nextWithColor (param $this i32) (param $nextWithColor i32)
   local.get $this
   local.get $nextWithColor
@@ -2572,6 +2575,42 @@
   local.get $8
   return
  )
+ (func $infer-generic/Ref#raw_constructor (param $this i32) (result i32)
+  (local $1 i32)
+  global.get $~lib/memory/__stack_pointer
+  i32.const 8
+  i32.sub
+  global.set $~lib/memory/__stack_pointer
+  call $~stack_check
+  global.get $~lib/memory/__stack_pointer
+  i64.const 0
+  i64.store
+  global.get $~lib/memory/__stack_pointer
+  local.get $this
+  local.set $1
+  global.get $~lib/memory/__stack_pointer
+  local.get $1
+  i32.store
+  local.get $1
+  call $~lib/object/Object#raw_constructor
+  local.tee $this
+  i32.store offset=4
+  local.get $this
+  local.set $1
+  global.get $~lib/memory/__stack_pointer
+  local.get $1
+  i32.store
+  local.get $1
+  i32.const 0
+  call $infer-generic/Ref#set:x
+  local.get $this
+  local.set $1
+  global.get $~lib/memory/__stack_pointer
+  i32.const 8
+  i32.add
+  global.set $~lib/memory/__stack_pointer
+  local.get $1
+ )
  (func $infer-generic/Ref#constructor (param $this i32) (result i32)
   (local $1 i32)
   global.get $~lib/memory/__stack_pointer
@@ -2599,7 +2638,7 @@
   local.get $1
   i32.store offset=4
   local.get $1
-  call $~lib/object/Object#constructor
+  call $~lib/object/Object#raw_constructor
   local.tee $this
   i32.store
   local.get $this

--- a/tests/compiler/infer-generic.release.wat
+++ b/tests/compiler/infer-generic.release.wat
@@ -3,12 +3,11 @@
  (type $1 (func (param i32)))
  (type $2 (func (param i32 f32 i32 i32) (result i32)))
  (type $3 (func (param i32 i32)))
- (type $4 (func (param i32 i32) (result i32)))
- (type $5 (func (param i32 i32 i32 i32)))
- (type $6 (func (param i32 i32 i64)))
- (type $7 (func (result i32)))
+ (type $4 (func (result i32)))
+ (type $5 (func (param i32) (result i32)))
+ (type $6 (func (param i32 i32 i32 i32)))
+ (type $7 (func (param i32 i32 i64)))
  (type $8 (func (param f32) (result f32)))
- (type $9 (func (param i32) (result i32)))
  (import "env" "abort" (func $~lib/builtins/abort (param i32 i32 i32 i32)))
  (global $~lib/rt/itcms/total (mut i32) (i32.const 0))
  (global $~lib/rt/itcms/threshold (mut i32) (i32.const 0))
@@ -1104,85 +1103,18 @@
   end
   i32.const 0
  )
- (func $~lib/rt/tlsf/searchBlock (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/rt/tlsf/searchBlock (param $0 i32) (result i32)
+  (local $1 i32)
   (local $2 i32)
-  local.get $1
-  i32.const 256
-  i32.lt_u
-  if
-   local.get $1
-   i32.const 4
-   i32.shr_u
-   local.set $1
-  else
-   local.get $1
-   i32.const 536870910
-   i32.lt_u
-   if
-    local.get $1
-    i32.const 1
-    i32.const 27
-    local.get $1
-    i32.clz
-    i32.sub
-    i32.shl
-    i32.add
-    i32.const 1
-    i32.sub
-    local.set $1
-   end
-   local.get $1
-   i32.const 31
-   local.get $1
-   i32.clz
-   i32.sub
-   local.tee $2
-   i32.const 4
-   i32.sub
-   i32.shr_u
-   i32.const 16
-   i32.xor
-   local.set $1
-   local.get $2
-   i32.const 7
-   i32.sub
-   local.set $2
-  end
-  local.get $1
-  i32.const 16
-  i32.lt_u
-  local.get $2
-  i32.const 23
-  i32.lt_u
-  i32.and
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1568
-   i32.const 334
-   i32.const 14
-   call $~lib/builtins/abort
-   unreachable
-  end
   local.get $0
-  local.get $2
-  i32.const 2
-  i32.shl
-  i32.add
   i32.load offset=4
-  i32.const -1
-  local.get $1
-  i32.shl
+  i32.const -2
   i32.and
   local.tee $1
   if (result i32)
    local.get $0
    local.get $1
    i32.ctz
-   local.get $2
-   i32.const 4
-   i32.shl
-   i32.add
    i32.const 2
    i32.shl
    i32.add
@@ -1190,23 +1122,19 @@
   else
    local.get $0
    i32.load
-   i32.const -1
-   local.get $2
-   i32.const 1
-   i32.add
-   i32.shl
+   i32.const -2
    i32.and
    local.tee $1
    if (result i32)
     local.get $0
     local.get $1
     i32.ctz
-    local.tee $1
+    local.tee $2
     i32.const 2
     i32.shl
     i32.add
     i32.load offset=4
-    local.tee $2
+    local.tee $1
     i32.eqz
     if
      i32.const 0
@@ -1217,9 +1145,9 @@
      unreachable
     end
     local.get $0
-    local.get $2
-    i32.ctz
     local.get $1
+    i32.ctz
+    local.get $2
     i32.const 4
     i32.shl
     i32.add
@@ -1232,35 +1160,23 @@
    end
   end
  )
- (func $~lib/rt/itcms/__new (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/rt/itcms/__new (result i32)
+  (local $0 i32)
+  (local $1 i32)
   (local $2 i32)
   (local $3 i32)
-  (local $4 i32)
-  (local $5 i32)
-  (local $6 i32)
-  local.get $0
-  i32.const 1073741804
-  i32.ge_u
-  if
-   i32.const 1232
-   i32.const 1296
-   i32.const 261
-   i32.const 31
-   call $~lib/builtins/abort
-   unreachable
-  end
   global.get $~lib/rt/itcms/total
   global.get $~lib/rt/itcms/threshold
   i32.ge_u
   if
    block $__inlined_func$~lib/rt/itcms/interrupt$69
     i32.const 2048
-    local.set $2
+    local.set $0
     loop $do-loop|0
-     local.get $2
+     local.get $0
      call $~lib/rt/itcms/step
      i32.sub
-     local.set $2
+     local.set $0
      global.get $~lib/rt/itcms/state
      i32.eqz
      if
@@ -1276,7 +1192,7 @@
       global.set $~lib/rt/itcms/threshold
       br $__inlined_func$~lib/rt/itcms/interrupt$69
      end
-     local.get $2
+     local.get $0
      i32.const 0
      i32.gt_s
      br_if $do-loop|0
@@ -1299,94 +1215,39 @@
    call $~lib/rt/tlsf/initialize
   end
   global.get $~lib/rt/tlsf/ROOT
-  local.set $4
-  local.get $0
-  i32.const 16
-  i32.add
-  local.tee $2
-  i32.const 1073741820
-  i32.gt_u
-  if
-   i32.const 1232
-   i32.const 1568
-   i32.const 461
-   i32.const 29
-   call $~lib/builtins/abort
-   unreachable
-  end
-  local.get $4
-  local.get $2
-  i32.const 12
-  i32.le_u
-  if (result i32)
-   i32.const 12
-  else
-   local.get $2
-   i32.const 19
-   i32.add
-   i32.const -16
-   i32.and
-   i32.const 4
-   i32.sub
-  end
-  local.tee $5
+  local.tee $1
   call $~lib/rt/tlsf/searchBlock
-  local.tee $2
+  local.tee $0
   i32.eqz
   if
    memory.size
-   local.tee $2
-   local.get $5
-   i32.const 256
-   i32.ge_u
-   if (result i32)
-    local.get $5
-    i32.const 536870910
-    i32.lt_u
-    if (result i32)
-     local.get $5
-     i32.const 1
-     i32.const 27
-     local.get $5
-     i32.clz
-     i32.sub
-     i32.shl
-     i32.add
-     i32.const 1
-     i32.sub
-    else
-     local.get $5
-    end
-   else
-    local.get $5
-   end
+   local.tee $0
    i32.const 4
-   local.get $4
+   local.get $1
    i32.load offset=1568
-   local.get $2
+   local.get $0
    i32.const 16
    i32.shl
    i32.const 4
    i32.sub
    i32.ne
    i32.shl
-   i32.add
-   i32.const 65535
+   i32.const 65563
    i32.add
    i32.const -65536
    i32.and
    i32.const 16
    i32.shr_u
-   local.tee $3
+   local.tee $2
+   local.get $0
    local.get $2
-   local.get $3
    i32.gt_s
    select
    memory.grow
    i32.const 0
    i32.lt_s
    if
-    local.get $3
+    local.get $2
     memory.grow
     i32.const 0
     i32.lt_s
@@ -1394,8 +1255,8 @@
      unreachable
     end
    end
-   local.get $4
-   local.get $2
+   local.get $1
+   local.get $0
    i32.const 16
    i32.shl
    memory.size
@@ -1403,10 +1264,9 @@
    i64.const 16
    i64.shl
    call $~lib/rt/tlsf/addMemory
-   local.get $4
-   local.get $5
+   local.get $1
    call $~lib/rt/tlsf/searchBlock
-   local.tee $2
+   local.tee $0
    i32.eqz
    if
     i32.const 0
@@ -1417,12 +1277,12 @@
     unreachable
    end
   end
-  local.get $5
-  local.get $2
+  local.get $0
   i32.load
   i32.const -4
   i32.and
-  i32.gt_u
+  i32.const 28
+  i32.lt_u
   if
    i32.const 0
    i32.const 1568
@@ -1431,108 +1291,92 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $4
-  local.get $2
+  local.get $1
+  local.get $0
   call $~lib/rt/tlsf/removeBlock
-  local.get $2
+  local.get $0
   i32.load
-  local.set $6
-  local.get $5
-  i32.const 4
-  i32.add
-  i32.const 15
-  i32.and
-  if
-   i32.const 0
-   i32.const 1568
-   i32.const 361
-   i32.const 14
-   call $~lib/builtins/abort
-   unreachable
-  end
-  local.get $6
+  local.tee $2
   i32.const -4
   i32.and
-  local.get $5
+  i32.const 28
   i32.sub
   local.tee $3
   i32.const 16
   i32.ge_u
   if
+   local.get $0
    local.get $2
-   local.get $5
-   local.get $6
    i32.const 2
    i32.and
+   i32.const 28
    i32.or
    i32.store
-   local.get $2
-   i32.const 4
+   local.get $0
+   i32.const 32
    i32.add
-   local.get $5
-   i32.add
-   local.tee $5
+   local.tee $2
    local.get $3
    i32.const 4
    i32.sub
    i32.const 1
    i32.or
    i32.store
-   local.get $4
-   local.get $5
+   local.get $1
+   local.get $2
    call $~lib/rt/tlsf/insertBlock
   else
+   local.get $0
    local.get $2
-   local.get $6
    i32.const -2
    i32.and
    i32.store
-   local.get $2
+   local.get $0
    i32.const 4
    i32.add
-   local.get $2
+   local.get $0
    i32.load
    i32.const -4
    i32.and
    i32.add
-   local.tee $3
-   local.get $3
+   local.tee $1
+   local.get $1
    i32.load
    i32.const -3
    i32.and
    i32.store
   end
-  local.get $2
-  local.get $1
-  i32.store offset=12
-  local.get $2
   local.get $0
+  i32.const 6
+  i32.store offset=12
+  local.get $0
+  i32.const 4
   i32.store offset=16
   global.get $~lib/rt/itcms/fromSpace
   local.tee $1
   i32.load offset=8
-  local.set $3
-  local.get $2
+  local.set $2
+  local.get $0
   local.get $1
   global.get $~lib/rt/itcms/white
   i32.or
   i32.store offset=4
+  local.get $0
   local.get $2
-  local.get $3
   i32.store offset=8
-  local.get $3
   local.get $2
-  local.get $3
+  local.get $0
+  local.get $2
   i32.load offset=4
   i32.const 3
   i32.and
   i32.or
   i32.store offset=4
   local.get $1
-  local.get $2
+  local.get $0
   i32.store offset=8
   global.get $~lib/rt/itcms/total
-  local.get $2
+  local.get $0
   i32.load
   i32.const -4
   i32.and
@@ -1540,14 +1384,13 @@
   i32.add
   i32.add
   global.set $~lib/rt/itcms/total
-  local.get $2
+  local.get $0
   i32.const 20
   i32.add
-  local.tee $1
+  local.tee $0
   i32.const 0
+  i32.store align=1
   local.get $0
-  memory.fill
-  local.get $1
  )
  (func $infer-generic/test1 (param $0 f32) (result f32)
   local.get $0
@@ -1639,9 +1482,9 @@
  (func $~start
   (local $0 i32)
   (local $1 i32)
-  (local $2 f32)
+  (local $2 i32)
   (local $3 i32)
-  (local $4 i32)
+  (local $4 f32)
   global.get $~lib/memory/__stack_pointer
   i32.const 12
   i32.sub
@@ -1679,18 +1522,18 @@
    i32.store
    i32.const 1164
    i32.load
-   local.set $3
+   local.set $2
    loop $for-loop|0
     global.get $~lib/memory/__stack_pointer
     i32.const 1152
     i32.store
     local.get $1
-    local.get $3
+    local.get $2
     i32.const 1164
     i32.load
-    local.tee $4
+    local.tee $3
+    local.get $2
     local.get $3
-    local.get $4
     i32.lt_s
     select
     i32.lt_s
@@ -1705,12 +1548,12 @@
      i32.shl
      i32.add
      f32.load
-     local.set $2
+     local.set $4
      global.get $~lib/memory/__stack_pointer
      i32.const 1152
      i32.store
      local.get $0
-     local.get $2
+     local.get $4
      local.get $1
      i32.const 1152
      i32.const 1200
@@ -1773,62 +1616,35 @@
    i64.const 0
    i64.store
    global.get $~lib/memory/__stack_pointer
-   i32.const 4
-   i32.const 6
    call $~lib/rt/itcms/__new
-   local.tee $0
+   local.tee $1
    i32.store
    global.get $~lib/memory/__stack_pointer
-   global.get $~lib/memory/__stack_pointer
-   local.get $0
+   local.get $1
    i32.store offset=4
    global.get $~lib/memory/__stack_pointer
-   i32.const 4
-   i32.sub
-   global.set $~lib/memory/__stack_pointer
-   global.get $~lib/memory/__stack_pointer
-   i32.const 1660
-   i32.lt_s
-   br_if $folding-inner0
-   global.get $~lib/memory/__stack_pointer
-   i32.const 0
-   i32.store
-   local.get $0
-   i32.eqz
-   if
-    global.get $~lib/memory/__stack_pointer
-    i32.const 0
-    i32.const 0
-    call $~lib/rt/itcms/__new
-    local.tee $0
-    i32.store
-   end
-   global.get $~lib/memory/__stack_pointer
-   i32.const 4
-   i32.add
-   global.set $~lib/memory/__stack_pointer
-   local.get $0
+   local.get $1
    i32.store
    global.get $~lib/memory/__stack_pointer
-   local.get $0
+   local.get $1
    i32.store offset=4
-   local.get $0
+   local.get $1
    i32.const 0
    i32.store
    global.get $~lib/memory/__stack_pointer
    i32.const 8
    i32.add
    global.set $~lib/memory/__stack_pointer
-   local.get $0
+   local.get $1
    i32.store offset=8
    global.get $~lib/memory/__stack_pointer
-   local.get $0
+   local.get $1
    i32.store offset=4
-   local.get $0
+   local.get $1
    i32.const 2
    i32.store
    global.get $~lib/memory/__stack_pointer
-   local.get $0
+   local.get $1
    i32.store
    global.get $~lib/memory/__stack_pointer
    i32.const 12

--- a/tests/compiler/instanceof.debug.wat
+++ b/tests/compiler/instanceof.debug.wat
@@ -65,6 +65,9 @@
  (elem $0 (i32.const 1))
  (export "memory" (memory $0))
  (start $~start)
+ (func $~lib/object/Object#raw_constructor (param $this i32) (result i32)
+  local.get $this
+ )
  (func $~lib/rt/itcms/Object#set:nextWithColor (param $this i32) (param $nextWithColor i32)
   local.get $this
   local.get $nextWithColor
@@ -4698,6 +4701,34 @@
    unreachable
   end
  )
+ (func $instanceof/A#raw_constructor (param $this i32) (result i32)
+  (local $1 i32)
+  global.get $~lib/memory/__stack_pointer
+  i32.const 8
+  i32.sub
+  global.set $~lib/memory/__stack_pointer
+  call $~stack_check
+  global.get $~lib/memory/__stack_pointer
+  i64.const 0
+  i64.store
+  global.get $~lib/memory/__stack_pointer
+  local.get $this
+  local.set $1
+  global.get $~lib/memory/__stack_pointer
+  local.get $1
+  i32.store
+  local.get $1
+  call $~lib/object/Object#raw_constructor
+  local.tee $this
+  i32.store offset=4
+  local.get $this
+  local.set $1
+  global.get $~lib/memory/__stack_pointer
+  i32.const 8
+  i32.add
+  global.set $~lib/memory/__stack_pointer
+  local.get $1
+ )
  (func $instanceof/A#constructor (param $this i32) (result i32)
   (local $1 i32)
   global.get $~lib/memory/__stack_pointer
@@ -4725,9 +4756,37 @@
   local.get $1
   i32.store offset=4
   local.get $1
-  call $~lib/object/Object#constructor
+  call $~lib/object/Object#raw_constructor
   local.tee $this
   i32.store
+  local.get $this
+  local.set $1
+  global.get $~lib/memory/__stack_pointer
+  i32.const 8
+  i32.add
+  global.set $~lib/memory/__stack_pointer
+  local.get $1
+ )
+ (func $instanceof/B#raw_constructor (param $this i32) (result i32)
+  (local $1 i32)
+  global.get $~lib/memory/__stack_pointer
+  i32.const 8
+  i32.sub
+  global.set $~lib/memory/__stack_pointer
+  call $~stack_check
+  global.get $~lib/memory/__stack_pointer
+  i64.const 0
+  i64.store
+  global.get $~lib/memory/__stack_pointer
+  local.get $this
+  local.set $1
+  global.get $~lib/memory/__stack_pointer
+  local.get $1
+  i32.store
+  local.get $1
+  call $instanceof/A#raw_constructor
+  local.tee $this
+  i32.store offset=4
   local.get $this
   local.set $1
   global.get $~lib/memory/__stack_pointer
@@ -4763,9 +4822,37 @@
   local.get $1
   i32.store offset=4
   local.get $1
-  call $instanceof/A#constructor
+  call $instanceof/A#raw_constructor
   local.tee $this
   i32.store
+  local.get $this
+  local.set $1
+  global.get $~lib/memory/__stack_pointer
+  i32.const 8
+  i32.add
+  global.set $~lib/memory/__stack_pointer
+  local.get $1
+ )
+ (func $instanceof/C#raw_constructor (param $this i32) (result i32)
+  (local $1 i32)
+  global.get $~lib/memory/__stack_pointer
+  i32.const 8
+  i32.sub
+  global.set $~lib/memory/__stack_pointer
+  call $~stack_check
+  global.get $~lib/memory/__stack_pointer
+  i64.const 0
+  i64.store
+  global.get $~lib/memory/__stack_pointer
+  local.get $this
+  local.set $1
+  global.get $~lib/memory/__stack_pointer
+  local.get $1
+  i32.store
+  local.get $1
+  call $instanceof/A#raw_constructor
+  local.tee $this
+  i32.store offset=4
   local.get $this
   local.set $1
   global.get $~lib/memory/__stack_pointer
@@ -4801,9 +4888,37 @@
   local.get $1
   i32.store offset=4
   local.get $1
-  call $instanceof/A#constructor
+  call $instanceof/A#raw_constructor
   local.tee $this
   i32.store
+  local.get $this
+  local.set $1
+  global.get $~lib/memory/__stack_pointer
+  i32.const 8
+  i32.add
+  global.set $~lib/memory/__stack_pointer
+  local.get $1
+ )
+ (func $instanceof/Parent<i32>#raw_constructor (param $this i32) (result i32)
+  (local $1 i32)
+  global.get $~lib/memory/__stack_pointer
+  i32.const 8
+  i32.sub
+  global.set $~lib/memory/__stack_pointer
+  call $~stack_check
+  global.get $~lib/memory/__stack_pointer
+  i64.const 0
+  i64.store
+  global.get $~lib/memory/__stack_pointer
+  local.get $this
+  local.set $1
+  global.get $~lib/memory/__stack_pointer
+  local.get $1
+  i32.store
+  local.get $1
+  call $~lib/object/Object#raw_constructor
+  local.tee $this
+  i32.store offset=4
   local.get $this
   local.set $1
   global.get $~lib/memory/__stack_pointer
@@ -4839,9 +4954,37 @@
   local.get $1
   i32.store offset=4
   local.get $1
-  call $~lib/object/Object#constructor
+  call $~lib/object/Object#raw_constructor
   local.tee $this
   i32.store
+  local.get $this
+  local.set $1
+  global.get $~lib/memory/__stack_pointer
+  i32.const 8
+  i32.add
+  global.set $~lib/memory/__stack_pointer
+  local.get $1
+ )
+ (func $instanceof/Child<i32>#raw_constructor (param $this i32) (result i32)
+  (local $1 i32)
+  global.get $~lib/memory/__stack_pointer
+  i32.const 8
+  i32.sub
+  global.set $~lib/memory/__stack_pointer
+  call $~stack_check
+  global.get $~lib/memory/__stack_pointer
+  i64.const 0
+  i64.store
+  global.get $~lib/memory/__stack_pointer
+  local.get $this
+  local.set $1
+  global.get $~lib/memory/__stack_pointer
+  local.get $1
+  i32.store
+  local.get $1
+  call $instanceof/Parent<i32>#raw_constructor
+  local.tee $this
+  i32.store offset=4
   local.get $this
   local.set $1
   global.get $~lib/memory/__stack_pointer
@@ -4877,9 +5020,37 @@
   local.get $1
   i32.store offset=4
   local.get $1
-  call $instanceof/Parent<i32>#constructor
+  call $instanceof/Parent<i32>#raw_constructor
   local.tee $this
   i32.store
+  local.get $this
+  local.set $1
+  global.get $~lib/memory/__stack_pointer
+  i32.const 8
+  i32.add
+  global.set $~lib/memory/__stack_pointer
+  local.get $1
+ )
+ (func $instanceof/Parent<f32>#raw_constructor (param $this i32) (result i32)
+  (local $1 i32)
+  global.get $~lib/memory/__stack_pointer
+  i32.const 8
+  i32.sub
+  global.set $~lib/memory/__stack_pointer
+  call $~stack_check
+  global.get $~lib/memory/__stack_pointer
+  i64.const 0
+  i64.store
+  global.get $~lib/memory/__stack_pointer
+  local.get $this
+  local.set $1
+  global.get $~lib/memory/__stack_pointer
+  local.get $1
+  i32.store
+  local.get $1
+  call $~lib/object/Object#raw_constructor
+  local.tee $this
+  i32.store offset=4
   local.get $this
   local.set $1
   global.get $~lib/memory/__stack_pointer
@@ -4915,9 +5086,37 @@
   local.get $1
   i32.store offset=4
   local.get $1
-  call $~lib/object/Object#constructor
+  call $~lib/object/Object#raw_constructor
   local.tee $this
   i32.store
+  local.get $this
+  local.set $1
+  global.get $~lib/memory/__stack_pointer
+  i32.const 8
+  i32.add
+  global.set $~lib/memory/__stack_pointer
+  local.get $1
+ )
+ (func $instanceof/Child<f32>#raw_constructor (param $this i32) (result i32)
+  (local $1 i32)
+  global.get $~lib/memory/__stack_pointer
+  i32.const 8
+  i32.sub
+  global.set $~lib/memory/__stack_pointer
+  call $~stack_check
+  global.get $~lib/memory/__stack_pointer
+  i64.const 0
+  i64.store
+  global.get $~lib/memory/__stack_pointer
+  local.get $this
+  local.set $1
+  global.get $~lib/memory/__stack_pointer
+  local.get $1
+  i32.store
+  local.get $1
+  call $instanceof/Parent<f32>#raw_constructor
+  local.tee $this
+  i32.store offset=4
   local.get $this
   local.set $1
   global.get $~lib/memory/__stack_pointer
@@ -4953,9 +5152,37 @@
   local.get $1
   i32.store offset=4
   local.get $1
-  call $instanceof/Parent<f32>#constructor
+  call $instanceof/Parent<f32>#raw_constructor
   local.tee $this
   i32.store
+  local.get $this
+  local.set $1
+  global.get $~lib/memory/__stack_pointer
+  i32.const 8
+  i32.add
+  global.set $~lib/memory/__stack_pointer
+  local.get $1
+ )
+ (func $instanceof/Animal#raw_constructor (param $this i32) (result i32)
+  (local $1 i32)
+  global.get $~lib/memory/__stack_pointer
+  i32.const 8
+  i32.sub
+  global.set $~lib/memory/__stack_pointer
+  call $~stack_check
+  global.get $~lib/memory/__stack_pointer
+  i64.const 0
+  i64.store
+  global.get $~lib/memory/__stack_pointer
+  local.get $this
+  local.set $1
+  global.get $~lib/memory/__stack_pointer
+  local.get $1
+  i32.store
+  local.get $1
+  call $~lib/object/Object#raw_constructor
+  local.tee $this
+  i32.store offset=4
   local.get $this
   local.set $1
   global.get $~lib/memory/__stack_pointer
@@ -4991,9 +5218,37 @@
   local.get $1
   i32.store offset=4
   local.get $1
-  call $~lib/object/Object#constructor
+  call $~lib/object/Object#raw_constructor
   local.tee $this
   i32.store
+  local.get $this
+  local.set $1
+  global.get $~lib/memory/__stack_pointer
+  i32.const 8
+  i32.add
+  global.set $~lib/memory/__stack_pointer
+  local.get $1
+ )
+ (func $instanceof/Cat#raw_constructor (param $this i32) (result i32)
+  (local $1 i32)
+  global.get $~lib/memory/__stack_pointer
+  i32.const 8
+  i32.sub
+  global.set $~lib/memory/__stack_pointer
+  call $~stack_check
+  global.get $~lib/memory/__stack_pointer
+  i64.const 0
+  i64.store
+  global.get $~lib/memory/__stack_pointer
+  local.get $this
+  local.set $1
+  global.get $~lib/memory/__stack_pointer
+  local.get $1
+  i32.store
+  local.get $1
+  call $instanceof/Animal#raw_constructor
+  local.tee $this
+  i32.store offset=4
   local.get $this
   local.set $1
   global.get $~lib/memory/__stack_pointer
@@ -5029,9 +5284,37 @@
   local.get $1
   i32.store offset=4
   local.get $1
-  call $instanceof/Animal#constructor
+  call $instanceof/Animal#raw_constructor
   local.tee $this
   i32.store
+  local.get $this
+  local.set $1
+  global.get $~lib/memory/__stack_pointer
+  i32.const 8
+  i32.add
+  global.set $~lib/memory/__stack_pointer
+  local.get $1
+ )
+ (func $instanceof/BlackCat#raw_constructor (param $this i32) (result i32)
+  (local $1 i32)
+  global.get $~lib/memory/__stack_pointer
+  i32.const 8
+  i32.sub
+  global.set $~lib/memory/__stack_pointer
+  call $~stack_check
+  global.get $~lib/memory/__stack_pointer
+  i64.const 0
+  i64.store
+  global.get $~lib/memory/__stack_pointer
+  local.get $this
+  local.set $1
+  global.get $~lib/memory/__stack_pointer
+  local.get $1
+  i32.store
+  local.get $1
+  call $instanceof/Cat#raw_constructor
+  local.tee $this
+  i32.store offset=4
   local.get $this
   local.set $1
   global.get $~lib/memory/__stack_pointer
@@ -5067,9 +5350,37 @@
   local.get $1
   i32.store offset=4
   local.get $1
-  call $instanceof/Cat#constructor
+  call $instanceof/Cat#raw_constructor
   local.tee $this
   i32.store
+  local.get $this
+  local.set $1
+  global.get $~lib/memory/__stack_pointer
+  i32.const 8
+  i32.add
+  global.set $~lib/memory/__stack_pointer
+  local.get $1
+ )
+ (func $instanceof/W#raw_constructor (param $this i32) (result i32)
+  (local $1 i32)
+  global.get $~lib/memory/__stack_pointer
+  i32.const 8
+  i32.sub
+  global.set $~lib/memory/__stack_pointer
+  call $~stack_check
+  global.get $~lib/memory/__stack_pointer
+  i64.const 0
+  i64.store
+  global.get $~lib/memory/__stack_pointer
+  local.get $this
+  local.set $1
+  global.get $~lib/memory/__stack_pointer
+  local.get $1
+  i32.store
+  local.get $1
+  call $~lib/object/Object#raw_constructor
+  local.tee $this
+  i32.store offset=4
   local.get $this
   local.set $1
   global.get $~lib/memory/__stack_pointer
@@ -5105,9 +5416,37 @@
   local.get $1
   i32.store offset=4
   local.get $1
-  call $~lib/object/Object#constructor
+  call $~lib/object/Object#raw_constructor
   local.tee $this
   i32.store
+  local.get $this
+  local.set $1
+  global.get $~lib/memory/__stack_pointer
+  i32.const 8
+  i32.add
+  global.set $~lib/memory/__stack_pointer
+  local.get $1
+ )
+ (func $instanceof/X#raw_constructor (param $this i32) (result i32)
+  (local $1 i32)
+  global.get $~lib/memory/__stack_pointer
+  i32.const 8
+  i32.sub
+  global.set $~lib/memory/__stack_pointer
+  call $~stack_check
+  global.get $~lib/memory/__stack_pointer
+  i64.const 0
+  i64.store
+  global.get $~lib/memory/__stack_pointer
+  local.get $this
+  local.set $1
+  global.get $~lib/memory/__stack_pointer
+  local.get $1
+  i32.store
+  local.get $1
+  call $~lib/object/Object#raw_constructor
+  local.tee $this
+  i32.store offset=4
   local.get $this
   local.set $1
   global.get $~lib/memory/__stack_pointer
@@ -5143,9 +5482,37 @@
   local.get $1
   i32.store offset=4
   local.get $1
-  call $~lib/object/Object#constructor
+  call $~lib/object/Object#raw_constructor
   local.tee $this
   i32.store
+  local.get $this
+  local.set $1
+  global.get $~lib/memory/__stack_pointer
+  i32.const 8
+  i32.add
+  global.set $~lib/memory/__stack_pointer
+  local.get $1
+ )
+ (func $instanceof/Y#raw_constructor (param $this i32) (result i32)
+  (local $1 i32)
+  global.get $~lib/memory/__stack_pointer
+  i32.const 8
+  i32.sub
+  global.set $~lib/memory/__stack_pointer
+  call $~stack_check
+  global.get $~lib/memory/__stack_pointer
+  i64.const 0
+  i64.store
+  global.get $~lib/memory/__stack_pointer
+  local.get $this
+  local.set $1
+  global.get $~lib/memory/__stack_pointer
+  local.get $1
+  i32.store
+  local.get $1
+  call $instanceof/X#raw_constructor
+  local.tee $this
+  i32.store offset=4
   local.get $this
   local.set $1
   global.get $~lib/memory/__stack_pointer
@@ -5181,9 +5548,37 @@
   local.get $1
   i32.store offset=4
   local.get $1
-  call $instanceof/X#constructor
+  call $instanceof/X#raw_constructor
   local.tee $this
   i32.store
+  local.get $this
+  local.set $1
+  global.get $~lib/memory/__stack_pointer
+  i32.const 8
+  i32.add
+  global.set $~lib/memory/__stack_pointer
+  local.get $1
+ )
+ (func $instanceof/Z#raw_constructor (param $this i32) (result i32)
+  (local $1 i32)
+  global.get $~lib/memory/__stack_pointer
+  i32.const 8
+  i32.sub
+  global.set $~lib/memory/__stack_pointer
+  call $~stack_check
+  global.get $~lib/memory/__stack_pointer
+  i64.const 0
+  i64.store
+  global.get $~lib/memory/__stack_pointer
+  local.get $this
+  local.set $1
+  global.get $~lib/memory/__stack_pointer
+  local.get $1
+  i32.store
+  local.get $1
+  call $instanceof/Y#raw_constructor
+  local.tee $this
+  i32.store offset=4
   local.get $this
   local.set $1
   global.get $~lib/memory/__stack_pointer
@@ -5219,7 +5614,7 @@
   local.get $1
   i32.store offset=4
   local.get $1
-  call $instanceof/Y#constructor
+  call $instanceof/Y#raw_constructor
   local.tee $this
   i32.store
   local.get $this

--- a/tests/compiler/instanceof.release.wat
+++ b/tests/compiler/instanceof.release.wat
@@ -1,9 +1,9 @@
 (module
- (type $0 (func (param i32) (result i32)))
- (type $1 (func (param i32)))
- (type $2 (func))
- (type $3 (func (param i32 i32)))
- (type $4 (func (result i32)))
+ (type $0 (func (param i32)))
+ (type $1 (func))
+ (type $2 (func (result i32)))
+ (type $3 (func (param i32) (result i32)))
+ (type $4 (func (param i32 i32)))
  (type $5 (func (param i32 i32 i32 i32)))
  (type $6 (func (param i32 i32 i64)))
  (import "env" "abort" (func $~lib/builtins/abort (param i32 i32 i32 i32)))
@@ -222,7 +222,7 @@
     local.get $0
     global.set $~lib/rt/itcms/iter
    end
-   block $__inlined_func$~lib/rt/itcms/Object#unlink$241
+   block $__inlined_func$~lib/rt/itcms/Object#unlink$248
     local.get $1
     i32.load offset=4
     i32.const -4
@@ -246,7 +246,7 @@
       call $~lib/builtins/abort
       unreachable
      end
-     br $__inlined_func$~lib/rt/itcms/Object#unlink$241
+     br $__inlined_func$~lib/rt/itcms/Object#unlink$248
     end
     local.get $1
     i32.load offset=8
@@ -1829,7 +1829,7 @@
  (func $~start
   call $start:instanceof
  )
- (func $instanceof/A#constructor (param $0 i32) (result i32)
+ (func $instanceof/A#raw_constructor (param $0 i32) (result i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 8
   i32.sub
@@ -1848,22 +1848,81 @@
   global.get $~lib/memory/__stack_pointer
   i64.const 0
   i64.store
+  global.get $~lib/memory/__stack_pointer
   local.get $0
-  i32.eqz
+  i32.store
+  global.get $~lib/memory/__stack_pointer
+  local.get $0
+  i32.store offset=4
+  global.get $~lib/memory/__stack_pointer
+  i32.const 8
+  i32.add
+  global.set $~lib/memory/__stack_pointer
+  local.get $0
+ )
+ (func $instanceof/B#raw_constructor (param $0 i32) (result i32)
+  global.get $~lib/memory/__stack_pointer
+  i32.const 8
+  i32.sub
+  global.set $~lib/memory/__stack_pointer
+  global.get $~lib/memory/__stack_pointer
+  i32.const 1588
+  i32.lt_s
   if
-   global.get $~lib/memory/__stack_pointer
-   i32.const 4
-   call $~lib/rt/itcms/__new
-   local.tee $0
-   i32.store
+   i32.const 34384
+   i32.const 34432
+   i32.const 1
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
   end
+  global.get $~lib/memory/__stack_pointer
+  i64.const 0
+  i64.store
+  global.get $~lib/memory/__stack_pointer
+  local.get $0
+  i32.store
+  global.get $~lib/memory/__stack_pointer
+  local.get $0
+  call $instanceof/A#raw_constructor
+  local.tee $0
+  i32.store offset=4
+  global.get $~lib/memory/__stack_pointer
+  i32.const 8
+  i32.add
+  global.set $~lib/memory/__stack_pointer
+  local.get $0
+ )
+ (func $instanceof/Animal#constructor (result i32)
+  (local $0 i32)
+  global.get $~lib/memory/__stack_pointer
+  i32.const 8
+  i32.sub
+  global.set $~lib/memory/__stack_pointer
+  global.get $~lib/memory/__stack_pointer
+  i32.const 1588
+  i32.lt_s
+  if
+   i32.const 34384
+   i32.const 34432
+   i32.const 1
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  global.get $~lib/memory/__stack_pointer
+  i64.const 0
+  i64.store
+  global.get $~lib/memory/__stack_pointer
+  i32.const 12
+  call $~lib/rt/itcms/__new
+  local.tee $0
+  i32.store
   global.get $~lib/memory/__stack_pointer
   local.get $0
   i32.store offset=4
   global.get $~lib/memory/__stack_pointer
   local.get $0
-  call $~lib/object/Object#constructor
-  local.tee $0
   i32.store
   global.get $~lib/memory/__stack_pointer
   i32.const 8
@@ -1871,7 +1930,8 @@
   global.set $~lib/memory/__stack_pointer
   local.get $0
  )
- (func $instanceof/Animal#constructor (param $0 i32) (result i32)
+ (func $instanceof/Cat#constructor (result i32)
+  (local $0 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 8
   i32.sub
@@ -1890,63 +1950,17 @@
   global.get $~lib/memory/__stack_pointer
   i64.const 0
   i64.store
-  local.get $0
-  i32.eqz
-  if
-   global.get $~lib/memory/__stack_pointer
-   i32.const 12
-   call $~lib/rt/itcms/__new
-   local.tee $0
-   i32.store
-  end
   global.get $~lib/memory/__stack_pointer
-  local.get $0
-  i32.store offset=4
-  global.get $~lib/memory/__stack_pointer
-  local.get $0
-  call $~lib/object/Object#constructor
+  i32.const 13
+  call $~lib/rt/itcms/__new
   local.tee $0
   i32.store
   global.get $~lib/memory/__stack_pointer
-  i32.const 8
-  i32.add
-  global.set $~lib/memory/__stack_pointer
-  local.get $0
- )
- (func $instanceof/Cat#constructor (param $0 i32) (result i32)
-  global.get $~lib/memory/__stack_pointer
-  i32.const 8
-  i32.sub
-  global.set $~lib/memory/__stack_pointer
-  global.get $~lib/memory/__stack_pointer
-  i32.const 1588
-  i32.lt_s
-  if
-   i32.const 34384
-   i32.const 34432
-   i32.const 1
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  global.get $~lib/memory/__stack_pointer
-  i64.const 0
-  i64.store
-  local.get $0
-  i32.eqz
-  if
-   global.get $~lib/memory/__stack_pointer
-   i32.const 13
-   call $~lib/rt/itcms/__new
-   local.tee $0
-   i32.store
-  end
-  global.get $~lib/memory/__stack_pointer
   local.get $0
   i32.store offset=4
   global.get $~lib/memory/__stack_pointer
   local.get $0
-  call $instanceof/Animal#constructor
+  call $instanceof/A#raw_constructor
   local.tee $0
   i32.store
   global.get $~lib/memory/__stack_pointer
@@ -1985,91 +1999,7 @@
   i32.store offset=4
   global.get $~lib/memory/__stack_pointer
   local.get $0
-  call $instanceof/Cat#constructor
-  local.tee $0
-  i32.store
-  global.get $~lib/memory/__stack_pointer
-  i32.const 8
-  i32.add
-  global.set $~lib/memory/__stack_pointer
-  local.get $0
- )
- (func $instanceof/X#constructor (param $0 i32) (result i32)
-  global.get $~lib/memory/__stack_pointer
-  i32.const 8
-  i32.sub
-  global.set $~lib/memory/__stack_pointer
-  global.get $~lib/memory/__stack_pointer
-  i32.const 1588
-  i32.lt_s
-  if
-   i32.const 34384
-   i32.const 34432
-   i32.const 1
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  global.get $~lib/memory/__stack_pointer
-  i64.const 0
-  i64.store
-  local.get $0
-  i32.eqz
-  if
-   global.get $~lib/memory/__stack_pointer
-   i32.const 16
-   call $~lib/rt/itcms/__new
-   local.tee $0
-   i32.store
-  end
-  global.get $~lib/memory/__stack_pointer
-  local.get $0
-  i32.store offset=4
-  global.get $~lib/memory/__stack_pointer
-  local.get $0
-  call $~lib/object/Object#constructor
-  local.tee $0
-  i32.store
-  global.get $~lib/memory/__stack_pointer
-  i32.const 8
-  i32.add
-  global.set $~lib/memory/__stack_pointer
-  local.get $0
- )
- (func $instanceof/Y#constructor (param $0 i32) (result i32)
-  global.get $~lib/memory/__stack_pointer
-  i32.const 8
-  i32.sub
-  global.set $~lib/memory/__stack_pointer
-  global.get $~lib/memory/__stack_pointer
-  i32.const 1588
-  i32.lt_s
-  if
-   i32.const 34384
-   i32.const 34432
-   i32.const 1
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  global.get $~lib/memory/__stack_pointer
-  i64.const 0
-  i64.store
-  local.get $0
-  i32.eqz
-  if
-   global.get $~lib/memory/__stack_pointer
-   i32.const 19
-   call $~lib/rt/itcms/__new
-   local.tee $0
-   i32.store
-  end
-  global.get $~lib/memory/__stack_pointer
-  local.get $0
-  i32.store offset=4
-  global.get $~lib/memory/__stack_pointer
-  local.get $0
-  call $instanceof/X#constructor
+  call $instanceof/B#raw_constructor
   local.tee $0
   i32.store
   global.get $~lib/memory/__stack_pointer
@@ -2080,7 +2010,6 @@
  )
  (func $start:instanceof
   (local $0 i32)
-  (local $1 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 88
   i32.sub
@@ -2126,8 +2055,33 @@
    i32.store
    i32.const 1344
    global.set $~lib/rt/itcms/fromSpace
-   i32.const 0
-   call $instanceof/A#constructor
+   global.get $~lib/memory/__stack_pointer
+   i32.const 8
+   i32.sub
+   global.set $~lib/memory/__stack_pointer
+   global.get $~lib/memory/__stack_pointer
+   i32.const 1588
+   i32.lt_s
+   br_if $folding-inner0
+   global.get $~lib/memory/__stack_pointer
+   i64.const 0
+   i64.store
+   global.get $~lib/memory/__stack_pointer
+   i32.const 4
+   call $~lib/rt/itcms/__new
+   local.tee $0
+   i32.store
+   global.get $~lib/memory/__stack_pointer
+   local.get $0
+   i32.store offset=4
+   global.get $~lib/memory/__stack_pointer
+   local.get $0
+   i32.store
+   global.get $~lib/memory/__stack_pointer
+   i32.const 8
+   i32.add
+   global.set $~lib/memory/__stack_pointer
+   local.get $0
    global.set $instanceof/a
    global.get $~lib/memory/__stack_pointer
    i32.const 8
@@ -2150,7 +2104,7 @@
    i32.store offset=4
    global.get $~lib/memory/__stack_pointer
    local.get $0
-   call $instanceof/A#constructor
+   call $instanceof/A#raw_constructor
    local.tee $0
    i32.store
    global.get $~lib/memory/__stack_pointer
@@ -2180,7 +2134,7 @@
    i32.store offset=4
    global.get $~lib/memory/__stack_pointer
    local.get $0
-   call $instanceof/A#constructor
+   call $instanceof/A#raw_constructor
    local.tee $0
    i32.store
    global.get $~lib/memory/__stack_pointer
@@ -2276,42 +2230,12 @@
    local.tee $0
    i32.store
    global.get $~lib/memory/__stack_pointer
-   global.get $~lib/memory/__stack_pointer
-   local.get $0
-   i32.store offset=4
-   global.get $~lib/memory/__stack_pointer
-   i32.const 8
-   i32.sub
-   global.set $~lib/memory/__stack_pointer
-   global.get $~lib/memory/__stack_pointer
-   i32.const 1588
-   i32.lt_s
-   br_if $folding-inner0
-   global.get $~lib/memory/__stack_pointer
-   i64.const 0
-   i64.store
-   local.get $0
-   i32.eqz
-   if
-    global.get $~lib/memory/__stack_pointer
-    i32.const 8
-    call $~lib/rt/itcms/__new
-    local.tee $0
-    i32.store
-   end
-   global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store offset=4
    global.get $~lib/memory/__stack_pointer
    local.get $0
-   call $~lib/object/Object#constructor
+   call $instanceof/A#raw_constructor
    local.tee $0
-   i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 8
-   i32.add
-   global.set $~lib/memory/__stack_pointer
-   local.get $0
    i32.store
    global.get $~lib/memory/__stack_pointer
    i32.const 8
@@ -2336,42 +2260,12 @@
    local.tee $0
    i32.store
    global.get $~lib/memory/__stack_pointer
-   global.get $~lib/memory/__stack_pointer
-   local.get $0
-   i32.store offset=4
-   global.get $~lib/memory/__stack_pointer
-   i32.const 8
-   i32.sub
-   global.set $~lib/memory/__stack_pointer
-   global.get $~lib/memory/__stack_pointer
-   i32.const 1588
-   i32.lt_s
-   br_if $folding-inner0
-   global.get $~lib/memory/__stack_pointer
-   i64.const 0
-   i64.store
-   local.get $0
-   i32.eqz
-   if
-    global.get $~lib/memory/__stack_pointer
-    i32.const 10
-    call $~lib/rt/itcms/__new
-    local.tee $0
-    i32.store
-   end
-   global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store offset=4
    global.get $~lib/memory/__stack_pointer
    local.get $0
-   call $~lib/object/Object#constructor
+   call $instanceof/A#raw_constructor
    local.tee $0
-   i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 8
-   i32.add
-   global.set $~lib/memory/__stack_pointer
-   local.get $0
    i32.store
    global.get $~lib/memory/__stack_pointer
    i32.const 8
@@ -2409,7 +2303,7 @@
    i32.store offset=12
    local.get $0
    if (result i32)
-    block $__inlined_func$~anyinstanceof|instanceof/Child$110 (result i32)
+    block $__inlined_func$~anyinstanceof|instanceof/Child$115 (result i32)
      block $is_instance1
       local.get $0
       i32.const 8
@@ -2424,7 +2318,7 @@
       i32.eq
       br_if $is_instance1
       i32.const 0
-      br $__inlined_func$~anyinstanceof|instanceof/Child$110
+      br $__inlined_func$~anyinstanceof|instanceof/Child$115
      end
      i32.const 1
     end
@@ -2440,10 +2334,8 @@
     call $~lib/builtins/abort
     unreachable
    end
-   i32.const 0
    call $instanceof/Animal#constructor
    global.set $instanceof/animal
-   i32.const 0
    call $instanceof/Cat#constructor
    global.set $instanceof/cat
    call $instanceof/BlackCat#constructor
@@ -2454,7 +2346,7 @@
    i32.store offset=16
    local.get $0
    if (result i32)
-    block $__inlined_func$~instanceof|instanceof/Cat$111 (result i32)
+    block $__inlined_func$~instanceof|instanceof/Cat$116 (result i32)
      block $is_instance2
       local.get $0
       i32.const 8
@@ -2469,7 +2361,7 @@
       i32.eq
       br_if $is_instance2
       i32.const 0
-      br $__inlined_func$~instanceof|instanceof/Cat$111
+      br $__inlined_func$~instanceof|instanceof/Cat$116
      end
      i32.const 1
     end
@@ -2513,7 +2405,7 @@
    i32.store offset=24
    local.get $0
    if (result i32)
-    block $__inlined_func$~instanceof|instanceof/Cat$113 (result i32)
+    block $__inlined_func$~instanceof|instanceof/Cat$118 (result i32)
      block $is_instance4
       local.get $0
       i32.const 8
@@ -2528,7 +2420,7 @@
       i32.eq
       br_if $is_instance4
       i32.const 0
-      br $__inlined_func$~instanceof|instanceof/Cat$113
+      br $__inlined_func$~instanceof|instanceof/Cat$118
      end
      i32.const 1
     end
@@ -2573,7 +2465,7 @@
    i32.store offset=32
    local.get $0
    if (result i32)
-    block $__inlined_func$~instanceof|instanceof/Cat$115 (result i32)
+    block $__inlined_func$~instanceof|instanceof/Cat$120 (result i32)
      block $is_instance6
       local.get $0
       i32.const 8
@@ -2588,7 +2480,7 @@
       i32.eq
       br_if $is_instance6
       i32.const 0
-      br $__inlined_func$~instanceof|instanceof/Cat$115
+      br $__inlined_func$~instanceof|instanceof/Cat$120
      end
      i32.const 1
     end
@@ -2628,10 +2520,8 @@
     call $~lib/builtins/abort
     unreachable
    end
-   i32.const 0
    call $instanceof/Animal#constructor
    global.set $instanceof/nullableAnimal
-   i32.const 0
    call $instanceof/Cat#constructor
    global.set $instanceof/nullableCat
    call $instanceof/BlackCat#constructor
@@ -2652,7 +2542,7 @@
    i32.store offset=40
    local.get $0
    if (result i32)
-    block $__inlined_func$~instanceof|instanceof/Cat$117 (result i32)
+    block $__inlined_func$~instanceof|instanceof/Cat$122 (result i32)
      block $is_instance8
       local.get $0
       i32.const 8
@@ -2667,7 +2557,7 @@
       i32.eq
       br_if $is_instance8
       i32.const 0
-      br $__inlined_func$~instanceof|instanceof/Cat$117
+      br $__inlined_func$~instanceof|instanceof/Cat$122
      end
      i32.const 1
     end
@@ -2721,7 +2611,7 @@
    i32.store offset=48
    local.get $0
    if (result i32)
-    block $__inlined_func$~instanceof|instanceof/Cat$119 (result i32)
+    block $__inlined_func$~instanceof|instanceof/Cat$124 (result i32)
      block $is_instance10
       local.get $0
       i32.const 8
@@ -2736,7 +2626,7 @@
       i32.eq
       br_if $is_instance10
       i32.const 0
-      br $__inlined_func$~instanceof|instanceof/Cat$119
+      br $__inlined_func$~instanceof|instanceof/Cat$124
      end
      i32.const 1
     end
@@ -2791,7 +2681,7 @@
    i32.store offset=56
    local.get $0
    if (result i32)
-    block $__inlined_func$~instanceof|instanceof/Cat$121 (result i32)
+    block $__inlined_func$~instanceof|instanceof/Cat$126 (result i32)
      block $is_instance12
       local.get $0
       i32.const 8
@@ -2806,7 +2696,7 @@
       i32.eq
       br_if $is_instance12
       i32.const 0
-      br $__inlined_func$~instanceof|instanceof/Cat$121
+      br $__inlined_func$~instanceof|instanceof/Cat$126
      end
      i32.const 1
     end
@@ -2885,8 +2775,6 @@
    i32.store offset=4
    global.get $~lib/memory/__stack_pointer
    local.get $0
-   call $~lib/object/Object#constructor
-   local.tee $0
    i32.store
    global.get $~lib/memory/__stack_pointer
    i32.const 8
@@ -2894,11 +2782,63 @@
    global.set $~lib/memory/__stack_pointer
    local.get $0
    global.set $instanceof/w
-   i32.const 0
-   call $instanceof/X#constructor
+   global.get $~lib/memory/__stack_pointer
+   i32.const 8
+   i32.sub
+   global.set $~lib/memory/__stack_pointer
+   global.get $~lib/memory/__stack_pointer
+   i32.const 1588
+   i32.lt_s
+   br_if $folding-inner0
+   global.get $~lib/memory/__stack_pointer
+   i64.const 0
+   i64.store
+   global.get $~lib/memory/__stack_pointer
+   i32.const 16
+   call $~lib/rt/itcms/__new
+   local.tee $0
+   i32.store
+   global.get $~lib/memory/__stack_pointer
+   local.get $0
+   i32.store offset=4
+   global.get $~lib/memory/__stack_pointer
+   local.get $0
+   i32.store
+   global.get $~lib/memory/__stack_pointer
+   i32.const 8
+   i32.add
+   global.set $~lib/memory/__stack_pointer
+   local.get $0
    global.set $instanceof/x
-   i32.const 0
-   call $instanceof/Y#constructor
+   global.get $~lib/memory/__stack_pointer
+   i32.const 8
+   i32.sub
+   global.set $~lib/memory/__stack_pointer
+   global.get $~lib/memory/__stack_pointer
+   i32.const 1588
+   i32.lt_s
+   br_if $folding-inner0
+   global.get $~lib/memory/__stack_pointer
+   i64.const 0
+   i64.store
+   global.get $~lib/memory/__stack_pointer
+   i32.const 19
+   call $~lib/rt/itcms/__new
+   local.tee $0
+   i32.store
+   global.get $~lib/memory/__stack_pointer
+   local.get $0
+   i32.store offset=4
+   global.get $~lib/memory/__stack_pointer
+   local.get $0
+   call $instanceof/A#raw_constructor
+   local.tee $0
+   i32.store
+   global.get $~lib/memory/__stack_pointer
+   i32.const 8
+   i32.add
+   global.set $~lib/memory/__stack_pointer
+   local.get $0
    global.set $instanceof/y
    global.get $~lib/memory/__stack_pointer
    i32.const 8
@@ -2921,7 +2861,7 @@
    i32.store offset=4
    global.get $~lib/memory/__stack_pointer
    local.get $0
-   call $instanceof/Y#constructor
+   call $instanceof/B#raw_constructor
    local.tee $0
    i32.store
    global.get $~lib/memory/__stack_pointer
@@ -3557,39 +3497,5 @@
   i32.const 1
   call $~lib/builtins/abort
   unreachable
- )
- (func $~lib/object/Object#constructor (param $0 i32) (result i32)
-  global.get $~lib/memory/__stack_pointer
-  i32.const 4
-  i32.sub
-  global.set $~lib/memory/__stack_pointer
-  global.get $~lib/memory/__stack_pointer
-  i32.const 1588
-  i32.lt_s
-  if
-   i32.const 34384
-   i32.const 34432
-   i32.const 1
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  global.get $~lib/memory/__stack_pointer
-  i32.const 0
-  i32.store
-  local.get $0
-  i32.eqz
-  if
-   global.get $~lib/memory/__stack_pointer
-   i32.const 0
-   call $~lib/rt/itcms/__new
-   local.tee $0
-   i32.store
-  end
-  global.get $~lib/memory/__stack_pointer
-  i32.const 4
-  i32.add
-  global.set $~lib/memory/__stack_pointer
-  local.get $0
  )
 )

--- a/tests/compiler/issues/1095.debug.wat
+++ b/tests/compiler/issues/1095.debug.wat
@@ -44,6 +44,9 @@
  (elem $0 (i32.const 1))
  (export "memory" (memory $0))
  (start $~start)
+ (func $~lib/object/Object#raw_constructor (param $this i32) (result i32)
+  local.get $this
+ )
  (func $~lib/rt/itcms/Object#set:nextWithColor (param $this i32) (param $nextWithColor i32)
   local.get $this
   local.get $nextWithColor
@@ -2403,6 +2406,50 @@
    unreachable
   end
  )
+ (func $issues/1095/Foo#raw_constructor (param $this i32) (result i32)
+  (local $1 i32)
+  global.get $~lib/memory/__stack_pointer
+  i32.const 12
+  i32.sub
+  global.set $~lib/memory/__stack_pointer
+  call $~stack_check
+  global.get $~lib/memory/__stack_pointer
+  i64.const 0
+  i64.store
+  global.get $~lib/memory/__stack_pointer
+  i32.const 0
+  i32.store offset=8
+  global.get $~lib/memory/__stack_pointer
+  local.get $this
+  local.set $1
+  global.get $~lib/memory/__stack_pointer
+  local.get $1
+  i32.store
+  local.get $1
+  call $~lib/object/Object#raw_constructor
+  local.tee $this
+  i32.store offset=4
+  local.get $this
+  local.set $1
+  global.get $~lib/memory/__stack_pointer
+  local.get $1
+  i32.store
+  local.get $1
+  i32.const 432
+  local.set $1
+  global.get $~lib/memory/__stack_pointer
+  local.get $1
+  i32.store offset=8
+  local.get $1
+  call $issues/1095/Foo#set:bar
+  local.get $this
+  local.set $1
+  global.get $~lib/memory/__stack_pointer
+  i32.const 12
+  i32.add
+  global.set $~lib/memory/__stack_pointer
+  local.get $1
+ )
  (func $issues/1095/Foo#constructor (param $this i32) (result i32)
   (local $1 i32)
   global.get $~lib/memory/__stack_pointer
@@ -2433,7 +2480,7 @@
   local.get $1
   i32.store offset=4
   local.get $1
-  call $~lib/object/Object#constructor
+  call $~lib/object/Object#raw_constructor
   local.tee $this
   i32.store
   local.get $this

--- a/tests/compiler/issues/1095.release.wat
+++ b/tests/compiler/issues/1095.release.wat
@@ -2,10 +2,10 @@
  (type $0 (func))
  (type $1 (func (param i32)))
  (type $2 (func (param i32 i32)))
- (type $3 (func (param i32 i32) (result i32)))
+ (type $3 (func (result i32)))
  (type $4 (func (param i32 i32 i32 i32)))
  (type $5 (func (param i32 i32 i64)))
- (type $6 (func (result i32)))
+ (type $6 (func (param i32) (result i32)))
  (import "env" "abort" (func $~lib/builtins/abort (param i32 i32 i32 i32)))
  (global $~lib/rt/itcms/total (mut i32) (i32.const 0))
  (global $~lib/rt/itcms/threshold (mut i32) (i32.const 0))
@@ -1085,85 +1085,18 @@
   end
   i32.const 0
  )
- (func $~lib/rt/tlsf/searchBlock (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/rt/tlsf/searchBlock (param $0 i32) (result i32)
+  (local $1 i32)
   (local $2 i32)
-  local.get $1
-  i32.const 256
-  i32.lt_u
-  if
-   local.get $1
-   i32.const 4
-   i32.shr_u
-   local.set $1
-  else
-   local.get $1
-   i32.const 536870910
-   i32.lt_u
-   if
-    local.get $1
-    i32.const 1
-    i32.const 27
-    local.get $1
-    i32.clz
-    i32.sub
-    i32.shl
-    i32.add
-    i32.const 1
-    i32.sub
-    local.set $1
-   end
-   local.get $1
-   i32.const 31
-   local.get $1
-   i32.clz
-   i32.sub
-   local.tee $2
-   i32.const 4
-   i32.sub
-   i32.shr_u
-   i32.const 16
-   i32.xor
-   local.set $1
-   local.get $2
-   i32.const 7
-   i32.sub
-   local.set $2
-  end
-  local.get $1
-  i32.const 16
-  i32.lt_u
-  local.get $2
-  i32.const 23
-  i32.lt_u
-  i32.and
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1392
-   i32.const 334
-   i32.const 14
-   call $~lib/builtins/abort
-   unreachable
-  end
   local.get $0
-  local.get $2
-  i32.const 2
-  i32.shl
-  i32.add
   i32.load offset=4
-  i32.const -1
-  local.get $1
-  i32.shl
+  i32.const -2
   i32.and
   local.tee $1
   if (result i32)
    local.get $0
    local.get $1
    i32.ctz
-   local.get $2
-   i32.const 4
-   i32.shl
-   i32.add
    i32.const 2
    i32.shl
    i32.add
@@ -1171,23 +1104,19 @@
   else
    local.get $0
    i32.load
-   i32.const -1
-   local.get $2
-   i32.const 1
-   i32.add
-   i32.shl
+   i32.const -2
    i32.and
    local.tee $1
    if (result i32)
     local.get $0
     local.get $1
     i32.ctz
-    local.tee $1
+    local.tee $2
     i32.const 2
     i32.shl
     i32.add
     i32.load offset=4
-    local.tee $2
+    local.tee $1
     i32.eqz
     if
      i32.const 0
@@ -1198,9 +1127,9 @@
      unreachable
     end
     local.get $0
-    local.get $2
-    i32.ctz
     local.get $1
+    i32.ctz
+    local.get $2
     i32.const 4
     i32.shl
     i32.add
@@ -1213,35 +1142,23 @@
    end
   end
  )
- (func $~lib/rt/itcms/__new (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/rt/itcms/__new (result i32)
+  (local $0 i32)
+  (local $1 i32)
   (local $2 i32)
   (local $3 i32)
-  (local $4 i32)
-  (local $5 i32)
-  (local $6 i32)
-  local.get $0
-  i32.const 1073741804
-  i32.ge_u
-  if
-   i32.const 1056
-   i32.const 1120
-   i32.const 261
-   i32.const 31
-   call $~lib/builtins/abort
-   unreachable
-  end
   global.get $~lib/rt/itcms/total
   global.get $~lib/rt/itcms/threshold
   i32.ge_u
   if
    block $__inlined_func$~lib/rt/itcms/interrupt$69
     i32.const 2048
-    local.set $2
+    local.set $0
     loop $do-loop|0
-     local.get $2
+     local.get $0
      call $~lib/rt/itcms/step
      i32.sub
-     local.set $2
+     local.set $0
      global.get $~lib/rt/itcms/state
      i32.eqz
      if
@@ -1257,7 +1174,7 @@
       global.set $~lib/rt/itcms/threshold
       br $__inlined_func$~lib/rt/itcms/interrupt$69
      end
-     local.get $2
+     local.get $0
      i32.const 0
      i32.gt_s
      br_if $do-loop|0
@@ -1280,94 +1197,39 @@
    call $~lib/rt/tlsf/initialize
   end
   global.get $~lib/rt/tlsf/ROOT
-  local.set $4
-  local.get $0
-  i32.const 16
-  i32.add
-  local.tee $2
-  i32.const 1073741820
-  i32.gt_u
-  if
-   i32.const 1056
-   i32.const 1392
-   i32.const 461
-   i32.const 29
-   call $~lib/builtins/abort
-   unreachable
-  end
-  local.get $4
-  local.get $2
-  i32.const 12
-  i32.le_u
-  if (result i32)
-   i32.const 12
-  else
-   local.get $2
-   i32.const 19
-   i32.add
-   i32.const -16
-   i32.and
-   i32.const 4
-   i32.sub
-  end
-  local.tee $5
+  local.tee $1
   call $~lib/rt/tlsf/searchBlock
-  local.tee $2
+  local.tee $0
   i32.eqz
   if
    memory.size
-   local.tee $2
-   local.get $5
-   i32.const 256
-   i32.ge_u
-   if (result i32)
-    local.get $5
-    i32.const 536870910
-    i32.lt_u
-    if (result i32)
-     local.get $5
-     i32.const 1
-     i32.const 27
-     local.get $5
-     i32.clz
-     i32.sub
-     i32.shl
-     i32.add
-     i32.const 1
-     i32.sub
-    else
-     local.get $5
-    end
-   else
-    local.get $5
-   end
+   local.tee $0
    i32.const 4
-   local.get $4
+   local.get $1
    i32.load offset=1568
-   local.get $2
+   local.get $0
    i32.const 16
    i32.shl
    i32.const 4
    i32.sub
    i32.ne
    i32.shl
-   i32.add
-   i32.const 65535
+   i32.const 65563
    i32.add
    i32.const -65536
    i32.and
    i32.const 16
    i32.shr_u
-   local.tee $3
+   local.tee $2
+   local.get $0
    local.get $2
-   local.get $3
    i32.gt_s
    select
    memory.grow
    i32.const 0
    i32.lt_s
    if
-    local.get $3
+    local.get $2
     memory.grow
     i32.const 0
     i32.lt_s
@@ -1375,8 +1237,8 @@
      unreachable
     end
    end
-   local.get $4
-   local.get $2
+   local.get $1
+   local.get $0
    i32.const 16
    i32.shl
    memory.size
@@ -1384,10 +1246,9 @@
    i64.const 16
    i64.shl
    call $~lib/rt/tlsf/addMemory
-   local.get $4
-   local.get $5
+   local.get $1
    call $~lib/rt/tlsf/searchBlock
-   local.tee $2
+   local.tee $0
    i32.eqz
    if
     i32.const 0
@@ -1398,12 +1259,12 @@
     unreachable
    end
   end
-  local.get $5
-  local.get $2
+  local.get $0
   i32.load
   i32.const -4
   i32.and
-  i32.gt_u
+  i32.const 28
+  i32.lt_u
   if
    i32.const 0
    i32.const 1392
@@ -1412,108 +1273,92 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $4
-  local.get $2
+  local.get $1
+  local.get $0
   call $~lib/rt/tlsf/removeBlock
-  local.get $2
+  local.get $0
   i32.load
-  local.set $6
-  local.get $5
-  i32.const 4
-  i32.add
-  i32.const 15
-  i32.and
-  if
-   i32.const 0
-   i32.const 1392
-   i32.const 361
-   i32.const 14
-   call $~lib/builtins/abort
-   unreachable
-  end
-  local.get $6
+  local.tee $2
   i32.const -4
   i32.and
-  local.get $5
+  i32.const 28
   i32.sub
   local.tee $3
   i32.const 16
   i32.ge_u
   if
+   local.get $0
    local.get $2
-   local.get $5
-   local.get $6
    i32.const 2
    i32.and
+   i32.const 28
    i32.or
    i32.store
-   local.get $2
-   i32.const 4
+   local.get $0
+   i32.const 32
    i32.add
-   local.get $5
-   i32.add
-   local.tee $5
+   local.tee $2
    local.get $3
    i32.const 4
    i32.sub
    i32.const 1
    i32.or
    i32.store
-   local.get $4
-   local.get $5
+   local.get $1
+   local.get $2
    call $~lib/rt/tlsf/insertBlock
   else
+   local.get $0
    local.get $2
-   local.get $6
    i32.const -2
    i32.and
    i32.store
-   local.get $2
+   local.get $0
    i32.const 4
    i32.add
-   local.get $2
+   local.get $0
    i32.load
    i32.const -4
    i32.and
    i32.add
-   local.tee $3
-   local.get $3
+   local.tee $1
+   local.get $1
    i32.load
    i32.const -3
    i32.and
    i32.store
   end
-  local.get $2
-  local.get $1
-  i32.store offset=12
-  local.get $2
   local.get $0
+  i32.const 4
+  i32.store offset=12
+  local.get $0
+  i32.const 4
   i32.store offset=16
   global.get $~lib/rt/itcms/fromSpace
   local.tee $1
   i32.load offset=8
-  local.set $3
-  local.get $2
+  local.set $2
+  local.get $0
   local.get $1
   global.get $~lib/rt/itcms/white
   i32.or
   i32.store offset=4
+  local.get $0
   local.get $2
-  local.get $3
   i32.store offset=8
-  local.get $3
   local.get $2
-  local.get $3
+  local.get $0
+  local.get $2
   i32.load offset=4
   i32.const 3
   i32.and
   i32.or
   i32.store offset=4
   local.get $1
-  local.get $2
+  local.get $0
   i32.store offset=8
   global.get $~lib/rt/itcms/total
-  local.get $2
+  local.get $0
   i32.load
   i32.const -4
   i32.and
@@ -1521,14 +1366,13 @@
   i32.add
   i32.add
   global.set $~lib/rt/itcms/total
-  local.get $2
+  local.get $0
   i32.const 20
   i32.add
-  local.tee $1
+  local.tee $0
   i32.const 0
+  i32.store align=1
   local.get $0
-  memory.fill
-  local.get $1
  )
  (func $issues/1095/Foo#set:bar (param $0 i32) (param $1 i32)
   local.get $0
@@ -1678,40 +1522,13 @@
    i32.const 0
    i32.store offset=8
    global.get $~lib/memory/__stack_pointer
-   i32.const 4
-   i32.const 4
    call $~lib/rt/itcms/__new
    local.tee $0
    i32.store
    global.get $~lib/memory/__stack_pointer
-   global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store offset=4
    global.get $~lib/memory/__stack_pointer
-   i32.const 4
-   i32.sub
-   global.set $~lib/memory/__stack_pointer
-   global.get $~lib/memory/__stack_pointer
-   i32.const 1672
-   i32.lt_s
-   br_if $folding-inner0
-   global.get $~lib/memory/__stack_pointer
-   i32.const 0
-   i32.store
-   local.get $0
-   i32.eqz
-   if
-    global.get $~lib/memory/__stack_pointer
-    i32.const 0
-    i32.const 0
-    call $~lib/rt/itcms/__new
-    local.tee $0
-    i32.store
-   end
-   global.get $~lib/memory/__stack_pointer
-   i32.const 4
-   i32.add
-   global.set $~lib/memory/__stack_pointer
    local.get $0
    i32.store
    global.get $~lib/memory/__stack_pointer

--- a/tests/compiler/issues/1699.debug.wat
+++ b/tests/compiler/issues/1699.debug.wat
@@ -2338,6 +2338,9 @@
   local.get $length_
   i32.store offset=12
  )
+ (func $~lib/object/Object#raw_constructor (param $this i32) (result i32)
+  local.get $this
+ )
  (func $issues/1699/MultiAssignmentTest#set:test (param $this i32) (param $test i32)
   local.get $this
   local.get $test
@@ -2656,6 +2659,42 @@
   global.set $~lib/memory/__stack_pointer
   local.get $6
  )
+ (func $issues/1699/MultiAssignmentTest#raw_constructor (param $this i32) (result i32)
+  (local $1 i32)
+  global.get $~lib/memory/__stack_pointer
+  i32.const 8
+  i32.sub
+  global.set $~lib/memory/__stack_pointer
+  call $~stack_check
+  global.get $~lib/memory/__stack_pointer
+  i64.const 0
+  i64.store
+  global.get $~lib/memory/__stack_pointer
+  local.get $this
+  local.set $1
+  global.get $~lib/memory/__stack_pointer
+  local.get $1
+  i32.store
+  local.get $1
+  call $~lib/object/Object#raw_constructor
+  local.tee $this
+  i32.store offset=4
+  local.get $this
+  local.set $1
+  global.get $~lib/memory/__stack_pointer
+  local.get $1
+  i32.store
+  local.get $1
+  i32.const 2
+  call $issues/1699/MultiAssignmentTest#set:test
+  local.get $this
+  local.set $1
+  global.get $~lib/memory/__stack_pointer
+  i32.const 8
+  i32.add
+  global.set $~lib/memory/__stack_pointer
+  local.get $1
+ )
  (func $issues/1699/MultiAssignmentTest#constructor (param $this i32) (result i32)
   (local $1 i32)
   global.get $~lib/memory/__stack_pointer
@@ -2683,7 +2722,7 @@
   local.get $1
   i32.store offset=4
   local.get $1
-  call $~lib/object/Object#constructor
+  call $~lib/object/Object#raw_constructor
   local.tee $this
   i32.store
   local.get $this

--- a/tests/compiler/issues/1699.release.wat
+++ b/tests/compiler/issues/1699.release.wat
@@ -113,7 +113,7 @@
    local.get $1
    global.set $~lib/rt/itcms/iter
   end
-  block $__inlined_func$~lib/rt/itcms/Object#unlink$146
+  block $__inlined_func$~lib/rt/itcms/Object#unlink$145
    local.get $0
    i32.load offset=4
    i32.const -4
@@ -137,7 +137,7 @@
      call $~lib/builtins/abort
      unreachable
     end
-    br $__inlined_func$~lib/rt/itcms/Object#unlink$146
+    br $__inlined_func$~lib/rt/itcms/Object#unlink$145
    end
    local.get $0
    i32.load offset=8
@@ -1985,75 +1985,47 @@
  )
  (func $issues/1699/MultiAssignmentTest#constructor (result i32)
   (local $0 i32)
-  (local $1 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 8
   i32.sub
   global.set $~lib/memory/__stack_pointer
-  block $folding-inner0
-   global.get $~lib/memory/__stack_pointer
-   i32.const 1740
-   i32.lt_s
-   br_if $folding-inner0
-   global.get $~lib/memory/__stack_pointer
-   i64.const 0
-   i64.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 4
-   i32.const 4
-   call $~lib/rt/itcms/__new
-   local.tee $0
-   i32.store
-   global.get $~lib/memory/__stack_pointer
-   global.get $~lib/memory/__stack_pointer
-   local.get $0
-   i32.store offset=4
-   global.get $~lib/memory/__stack_pointer
-   i32.const 4
-   i32.sub
-   global.set $~lib/memory/__stack_pointer
-   global.get $~lib/memory/__stack_pointer
-   i32.const 1740
-   i32.lt_s
-   br_if $folding-inner0
-   global.get $~lib/memory/__stack_pointer
-   i32.const 0
-   i32.store
-   local.get $0
-   i32.eqz
-   if
-    global.get $~lib/memory/__stack_pointer
-    i32.const 0
-    i32.const 0
-    call $~lib/rt/itcms/__new
-    local.tee $0
-    i32.store
-   end
-   global.get $~lib/memory/__stack_pointer
-   i32.const 4
-   i32.add
-   global.set $~lib/memory/__stack_pointer
-   local.get $0
-   i32.store
-   global.get $~lib/memory/__stack_pointer
-   local.get $0
-   i32.store offset=4
-   local.get $0
-   i32.const 2
-   i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 8
-   i32.add
-   global.set $~lib/memory/__stack_pointer
-   local.get $0
-   return
+  global.get $~lib/memory/__stack_pointer
+  i32.const 1740
+  i32.lt_s
+  if
+   i32.const 34528
+   i32.const 34576
+   i32.const 1
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
   end
-  i32.const 34528
-  i32.const 34576
-  i32.const 1
-  i32.const 1
-  call $~lib/builtins/abort
-  unreachable
+  global.get $~lib/memory/__stack_pointer
+  i64.const 0
+  i64.store
+  global.get $~lib/memory/__stack_pointer
+  i32.const 4
+  i32.const 4
+  call $~lib/rt/itcms/__new
+  local.tee $0
+  i32.store
+  global.get $~lib/memory/__stack_pointer
+  local.get $0
+  i32.store offset=4
+  global.get $~lib/memory/__stack_pointer
+  local.get $0
+  i32.store
+  global.get $~lib/memory/__stack_pointer
+  local.get $0
+  i32.store offset=4
+  local.get $0
+  i32.const 2
+  i32.store
+  global.get $~lib/memory/__stack_pointer
+  i32.const 8
+  i32.add
+  global.set $~lib/memory/__stack_pointer
+  local.get $0
  )
  (func $~lib/array/Array<issues/1699/MultiAssignmentTest>#__set (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
@@ -2133,7 +2105,7 @@
      global.get $~lib/memory/__stack_pointer
      local.get $0
      i32.store
-     block $__inlined_func$~lib/rt/itcms/__renew$145
+     block $__inlined_func$~lib/rt/itcms/__renew$144
       i32.const 1073741820
       local.get $4
       i32.const 1
@@ -2176,7 +2148,7 @@
        i32.store offset=16
        local.get $4
        local.set $3
-       br $__inlined_func$~lib/rt/itcms/__renew$145
+       br $__inlined_func$~lib/rt/itcms/__renew$144
       end
       local.get $5
       local.get $7

--- a/tests/compiler/issues/2166.debug.wat
+++ b/tests/compiler/issues/2166.debug.wat
@@ -48,6 +48,9 @@
  (elem $0 (i32.const 1))
  (export "memory" (memory $0))
  (start $~start)
+ (func $~lib/object/Object#raw_constructor (param $this i32) (result i32)
+  local.get $this
+ )
  (func $~lib/rt/itcms/Object#set:nextWithColor (param $this i32) (param $nextWithColor i32)
   local.get $this
   local.get $nextWithColor
@@ -2433,6 +2436,34 @@
    unreachable
   end
  )
+ (func $issues/2166/Test2166Ref1<~lib/string/String>#raw_constructor (param $this i32) (result i32)
+  (local $1 i32)
+  global.get $~lib/memory/__stack_pointer
+  i32.const 8
+  i32.sub
+  global.set $~lib/memory/__stack_pointer
+  call $~stack_check
+  global.get $~lib/memory/__stack_pointer
+  i64.const 0
+  i64.store
+  global.get $~lib/memory/__stack_pointer
+  local.get $this
+  local.set $1
+  global.get $~lib/memory/__stack_pointer
+  local.get $1
+  i32.store
+  local.get $1
+  call $~lib/object/Object#raw_constructor
+  local.tee $this
+  i32.store offset=4
+  local.get $this
+  local.set $1
+  global.get $~lib/memory/__stack_pointer
+  i32.const 8
+  i32.add
+  global.set $~lib/memory/__stack_pointer
+  local.get $1
+ )
  (func $issues/2166/Test2166Ref1<~lib/string/String>#constructor (param $this i32) (result i32)
   (local $1 i32)
   global.get $~lib/memory/__stack_pointer
@@ -2460,7 +2491,7 @@
   local.get $1
   i32.store offset=4
   local.get $1
-  call $~lib/object/Object#constructor
+  call $~lib/object/Object#raw_constructor
   local.tee $this
   i32.store
   local.get $this

--- a/tests/compiler/issues/2166.release.wat
+++ b/tests/compiler/issues/2166.release.wat
@@ -126,7 +126,7 @@
     local.get $0
     global.set $~lib/rt/itcms/iter
    end
-   block $__inlined_func$~lib/rt/itcms/Object#unlink$123
+   block $__inlined_func$~lib/rt/itcms/Object#unlink$122
     local.get $1
     i32.load offset=4
     i32.const -4
@@ -150,7 +150,7 @@
       call $~lib/builtins/abort
       unreachable
      end
-     br $__inlined_func$~lib/rt/itcms/Object#unlink$123
+     br $__inlined_func$~lib/rt/itcms/Object#unlink$122
     end
     local.get $1
     i32.load offset=8
@@ -1410,7 +1410,6 @@
  (func $~start
   (local $0 i32)
   (local $1 i32)
-  (local $2 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 8
   i32.sub
@@ -1487,33 +1486,9 @@
    local.tee $0
    i32.store
    global.get $~lib/memory/__stack_pointer
-   global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store offset=4
    global.get $~lib/memory/__stack_pointer
-   i32.const 4
-   i32.sub
-   global.set $~lib/memory/__stack_pointer
-   global.get $~lib/memory/__stack_pointer
-   i32.const 1660
-   i32.lt_s
-   br_if $folding-inner0
-   global.get $~lib/memory/__stack_pointer
-   i32.const 0
-   i32.store
-   local.get $0
-   i32.eqz
-   if
-    global.get $~lib/memory/__stack_pointer
-    i32.const 0
-    call $~lib/rt/itcms/__new
-    local.tee $0
-    i32.store
-   end
-   global.get $~lib/memory/__stack_pointer
-   i32.const 4
-   i32.add
-   global.set $~lib/memory/__stack_pointer
    local.get $0
    i32.store
    global.get $~lib/memory/__stack_pointer

--- a/tests/compiler/issues/2322/index.debug.wat
+++ b/tests/compiler/issues/2322/index.debug.wat
@@ -42,6 +42,9 @@
  (export "test" (func $issues/2322/index/test))
  (export "memory" (memory $0))
  (start $~start)
+ (func $~lib/object/Object#raw_constructor (param $this i32) (result i32)
+  local.get $this
+ )
  (func $~lib/rt/itcms/Object#set:nextWithColor (param $this i32) (param $nextWithColor i32)
   local.get $this
   local.get $nextWithColor
@@ -2330,6 +2333,42 @@
    unreachable
   end
  )
+ (func $issues/2322/lib/Wrapper<i32>#raw_constructor (param $this i32) (result i32)
+  (local $1 i32)
+  global.get $~lib/memory/__stack_pointer
+  i32.const 8
+  i32.sub
+  global.set $~lib/memory/__stack_pointer
+  call $~stack_check
+  global.get $~lib/memory/__stack_pointer
+  i64.const 0
+  i64.store
+  global.get $~lib/memory/__stack_pointer
+  local.get $this
+  local.set $1
+  global.get $~lib/memory/__stack_pointer
+  local.get $1
+  i32.store
+  local.get $1
+  call $~lib/object/Object#raw_constructor
+  local.tee $this
+  i32.store offset=4
+  local.get $this
+  local.set $1
+  global.get $~lib/memory/__stack_pointer
+  local.get $1
+  i32.store
+  local.get $1
+  i32.const 0
+  call $issues/2322/lib/Wrapper<i32>#set:v
+  local.get $this
+  local.set $1
+  global.get $~lib/memory/__stack_pointer
+  i32.const 8
+  i32.add
+  global.set $~lib/memory/__stack_pointer
+  local.get $1
+ )
  (func $issues/2322/lib/Wrapper<i32>#constructor (param $this i32) (result i32)
   (local $1 i32)
   global.get $~lib/memory/__stack_pointer
@@ -2357,7 +2396,7 @@
   local.get $1
   i32.store offset=4
   local.get $1
-  call $~lib/object/Object#constructor
+  call $~lib/object/Object#raw_constructor
   local.tee $this
   i32.store
   local.get $this

--- a/tests/compiler/issues/2322/index.release.wat
+++ b/tests/compiler/issues/2322/index.release.wat
@@ -2,10 +2,10 @@
  (type $0 (func))
  (type $1 (func (param i32)))
  (type $2 (func (param i32 i32)))
- (type $3 (func (param i32 i32) (result i32)))
+ (type $3 (func (result i32)))
  (type $4 (func (param i32 i32 i32 i32)))
  (type $5 (func (param i32 i32 i64)))
- (type $6 (func (result i32)))
+ (type $6 (func (param i32) (result i32)))
  (import "env" "abort" (func $~lib/builtins/abort (param i32 i32 i32 i32)))
  (global $~lib/rt/itcms/total (mut i32) (i32.const 0))
  (global $~lib/rt/itcms/threshold (mut i32) (i32.const 0))
@@ -1076,85 +1076,18 @@
   end
   i32.const 0
  )
- (func $~lib/rt/tlsf/searchBlock (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/rt/tlsf/searchBlock (param $0 i32) (result i32)
+  (local $1 i32)
   (local $2 i32)
-  local.get $1
-  i32.const 256
-  i32.lt_u
-  if
-   local.get $1
-   i32.const 4
-   i32.shr_u
-   local.set $1
-  else
-   local.get $1
-   i32.const 536870910
-   i32.lt_u
-   if
-    local.get $1
-    i32.const 1
-    i32.const 27
-    local.get $1
-    i32.clz
-    i32.sub
-    i32.shl
-    i32.add
-    i32.const 1
-    i32.sub
-    local.set $1
-   end
-   local.get $1
-   i32.const 31
-   local.get $1
-   i32.clz
-   i32.sub
-   local.tee $2
-   i32.const 4
-   i32.sub
-   i32.shr_u
-   i32.const 16
-   i32.xor
-   local.set $1
-   local.get $2
-   i32.const 7
-   i32.sub
-   local.set $2
-  end
-  local.get $1
-  i32.const 16
-  i32.lt_u
-  local.get $2
-  i32.const 23
-  i32.lt_u
-  i32.and
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1392
-   i32.const 334
-   i32.const 14
-   call $~lib/builtins/abort
-   unreachable
-  end
   local.get $0
-  local.get $2
-  i32.const 2
-  i32.shl
-  i32.add
   i32.load offset=4
-  i32.const -1
-  local.get $1
-  i32.shl
+  i32.const -2
   i32.and
   local.tee $1
   if (result i32)
    local.get $0
    local.get $1
    i32.ctz
-   local.get $2
-   i32.const 4
-   i32.shl
-   i32.add
    i32.const 2
    i32.shl
    i32.add
@@ -1162,23 +1095,19 @@
   else
    local.get $0
    i32.load
-   i32.const -1
-   local.get $2
-   i32.const 1
-   i32.add
-   i32.shl
+   i32.const -2
    i32.and
    local.tee $1
    if (result i32)
     local.get $0
     local.get $1
     i32.ctz
-    local.tee $1
+    local.tee $2
     i32.const 2
     i32.shl
     i32.add
     i32.load offset=4
-    local.tee $2
+    local.tee $1
     i32.eqz
     if
      i32.const 0
@@ -1189,9 +1118,9 @@
      unreachable
     end
     local.get $0
-    local.get $2
-    i32.ctz
     local.get $1
+    i32.ctz
+    local.get $2
     i32.const 4
     i32.shl
     i32.add
@@ -1204,35 +1133,23 @@
    end
   end
  )
- (func $~lib/rt/itcms/__new (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/rt/itcms/__new (result i32)
+  (local $0 i32)
+  (local $1 i32)
   (local $2 i32)
   (local $3 i32)
-  (local $4 i32)
-  (local $5 i32)
-  (local $6 i32)
-  local.get $0
-  i32.const 1073741804
-  i32.ge_u
-  if
-   i32.const 1056
-   i32.const 1120
-   i32.const 261
-   i32.const 31
-   call $~lib/builtins/abort
-   unreachable
-  end
   global.get $~lib/rt/itcms/total
   global.get $~lib/rt/itcms/threshold
   i32.ge_u
   if
    block $__inlined_func$~lib/rt/itcms/interrupt$69
     i32.const 2048
-    local.set $2
+    local.set $0
     loop $do-loop|0
-     local.get $2
+     local.get $0
      call $~lib/rt/itcms/step
      i32.sub
-     local.set $2
+     local.set $0
      global.get $~lib/rt/itcms/state
      i32.eqz
      if
@@ -1248,7 +1165,7 @@
       global.set $~lib/rt/itcms/threshold
       br $__inlined_func$~lib/rt/itcms/interrupt$69
      end
-     local.get $2
+     local.get $0
      i32.const 0
      i32.gt_s
      br_if $do-loop|0
@@ -1271,94 +1188,39 @@
    call $~lib/rt/tlsf/initialize
   end
   global.get $~lib/rt/tlsf/ROOT
-  local.set $4
-  local.get $0
-  i32.const 16
-  i32.add
-  local.tee $2
-  i32.const 1073741820
-  i32.gt_u
-  if
-   i32.const 1056
-   i32.const 1392
-   i32.const 461
-   i32.const 29
-   call $~lib/builtins/abort
-   unreachable
-  end
-  local.get $4
-  local.get $2
-  i32.const 12
-  i32.le_u
-  if (result i32)
-   i32.const 12
-  else
-   local.get $2
-   i32.const 19
-   i32.add
-   i32.const -16
-   i32.and
-   i32.const 4
-   i32.sub
-  end
-  local.tee $5
+  local.tee $1
   call $~lib/rt/tlsf/searchBlock
-  local.tee $2
+  local.tee $0
   i32.eqz
   if
    memory.size
-   local.tee $2
-   local.get $5
-   i32.const 256
-   i32.ge_u
-   if (result i32)
-    local.get $5
-    i32.const 536870910
-    i32.lt_u
-    if (result i32)
-     local.get $5
-     i32.const 1
-     i32.const 27
-     local.get $5
-     i32.clz
-     i32.sub
-     i32.shl
-     i32.add
-     i32.const 1
-     i32.sub
-    else
-     local.get $5
-    end
-   else
-    local.get $5
-   end
+   local.tee $0
    i32.const 4
-   local.get $4
+   local.get $1
    i32.load offset=1568
-   local.get $2
+   local.get $0
    i32.const 16
    i32.shl
    i32.const 4
    i32.sub
    i32.ne
    i32.shl
-   i32.add
-   i32.const 65535
+   i32.const 65563
    i32.add
    i32.const -65536
    i32.and
    i32.const 16
    i32.shr_u
-   local.tee $3
+   local.tee $2
+   local.get $0
    local.get $2
-   local.get $3
    i32.gt_s
    select
    memory.grow
    i32.const 0
    i32.lt_s
    if
-    local.get $3
+    local.get $2
     memory.grow
     i32.const 0
     i32.lt_s
@@ -1366,8 +1228,8 @@
      unreachable
     end
    end
-   local.get $4
-   local.get $2
+   local.get $1
+   local.get $0
    i32.const 16
    i32.shl
    memory.size
@@ -1375,10 +1237,9 @@
    i64.const 16
    i64.shl
    call $~lib/rt/tlsf/addMemory
-   local.get $4
-   local.get $5
+   local.get $1
    call $~lib/rt/tlsf/searchBlock
-   local.tee $2
+   local.tee $0
    i32.eqz
    if
     i32.const 0
@@ -1389,12 +1250,12 @@
     unreachable
    end
   end
-  local.get $5
-  local.get $2
+  local.get $0
   i32.load
   i32.const -4
   i32.and
-  i32.gt_u
+  i32.const 28
+  i32.lt_u
   if
    i32.const 0
    i32.const 1392
@@ -1403,108 +1264,92 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $4
-  local.get $2
+  local.get $1
+  local.get $0
   call $~lib/rt/tlsf/removeBlock
-  local.get $2
+  local.get $0
   i32.load
-  local.set $6
-  local.get $5
-  i32.const 4
-  i32.add
-  i32.const 15
-  i32.and
-  if
-   i32.const 0
-   i32.const 1392
-   i32.const 361
-   i32.const 14
-   call $~lib/builtins/abort
-   unreachable
-  end
-  local.get $6
+  local.tee $2
   i32.const -4
   i32.and
-  local.get $5
+  i32.const 28
   i32.sub
   local.tee $3
   i32.const 16
   i32.ge_u
   if
+   local.get $0
    local.get $2
-   local.get $5
-   local.get $6
    i32.const 2
    i32.and
+   i32.const 28
    i32.or
    i32.store
-   local.get $2
-   i32.const 4
+   local.get $0
+   i32.const 32
    i32.add
-   local.get $5
-   i32.add
-   local.tee $5
+   local.tee $2
    local.get $3
    i32.const 4
    i32.sub
    i32.const 1
    i32.or
    i32.store
-   local.get $4
-   local.get $5
+   local.get $1
+   local.get $2
    call $~lib/rt/tlsf/insertBlock
   else
+   local.get $0
    local.get $2
-   local.get $6
    i32.const -2
    i32.and
    i32.store
-   local.get $2
+   local.get $0
    i32.const 4
    i32.add
-   local.get $2
+   local.get $0
    i32.load
    i32.const -4
    i32.and
    i32.add
-   local.tee $3
-   local.get $3
+   local.tee $1
+   local.get $1
    i32.load
    i32.const -3
    i32.and
    i32.store
   end
-  local.get $2
-  local.get $1
-  i32.store offset=12
-  local.get $2
   local.get $0
+  i32.const 4
+  i32.store offset=12
+  local.get $0
+  i32.const 4
   i32.store offset=16
   global.get $~lib/rt/itcms/fromSpace
   local.tee $1
   i32.load offset=8
-  local.set $3
-  local.get $2
+  local.set $2
+  local.get $0
   local.get $1
   global.get $~lib/rt/itcms/white
   i32.or
   i32.store offset=4
+  local.get $0
   local.get $2
-  local.get $3
   i32.store offset=8
-  local.get $3
   local.get $2
-  local.get $3
+  local.get $0
+  local.get $2
   i32.load offset=4
   i32.const 3
   i32.and
   i32.or
   i32.store offset=4
   local.get $1
-  local.get $2
+  local.get $0
   i32.store offset=8
   global.get $~lib/rt/itcms/total
-  local.get $2
+  local.get $0
   i32.load
   i32.const -4
   i32.and
@@ -1512,14 +1357,13 @@
   i32.add
   i32.add
   global.set $~lib/rt/itcms/total
-  local.get $2
+  local.get $0
   i32.const 20
   i32.add
-  local.tee $1
+  local.tee $0
   i32.const 0
+  i32.store align=1
   local.get $0
-  memory.fill
-  local.get $1
  )
  (func $~lib/rt/__visit_members (param $0 i32)
   block $invalid
@@ -1585,7 +1429,6 @@
  )
  (func $issues/2322/index/test
   (local $0 i32)
-  (local $1 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 4
   i32.sub
@@ -1610,40 +1453,13 @@
    i64.const 0
    i64.store
    global.get $~lib/memory/__stack_pointer
-   i32.const 4
-   i32.const 4
    call $~lib/rt/itcms/__new
    local.tee $0
    i32.store
    global.get $~lib/memory/__stack_pointer
-   global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store offset=4
    global.get $~lib/memory/__stack_pointer
-   i32.const 4
-   i32.sub
-   global.set $~lib/memory/__stack_pointer
-   global.get $~lib/memory/__stack_pointer
-   i32.const 1464
-   i32.lt_s
-   br_if $folding-inner0
-   global.get $~lib/memory/__stack_pointer
-   i32.const 0
-   i32.store
-   local.get $0
-   i32.eqz
-   if
-    global.get $~lib/memory/__stack_pointer
-    i32.const 0
-    i32.const 0
-    call $~lib/rt/itcms/__new
-    local.tee $0
-    i32.store
-   end
-   global.get $~lib/memory/__stack_pointer
-   i32.const 4
-   i32.add
-   global.set $~lib/memory/__stack_pointer
    local.get $0
    i32.store
    global.get $~lib/memory/__stack_pointer

--- a/tests/compiler/issues/2622.debug.wat
+++ b/tests/compiler/issues/2622.debug.wat
@@ -45,6 +45,9 @@
  (elem $0 (i32.const 1))
  (export "memory" (memory $0))
  (start $~start)
+ (func $~lib/object/Object#raw_constructor (param $this i32) (result i32)
+  local.get $this
+ )
  (func $~lib/rt/itcms/Object#set:nextWithColor (param $this i32) (param $nextWithColor i32)
   local.get $this
   local.get $nextWithColor
@@ -2387,6 +2390,34 @@
    unreachable
   end
  )
+ (func $issues/2622/_a/T1#raw_constructor (param $this i32) (result i32)
+  (local $1 i32)
+  global.get $~lib/memory/__stack_pointer
+  i32.const 8
+  i32.sub
+  global.set $~lib/memory/__stack_pointer
+  call $~stack_check
+  global.get $~lib/memory/__stack_pointer
+  i64.const 0
+  i64.store
+  global.get $~lib/memory/__stack_pointer
+  local.get $this
+  local.set $1
+  global.get $~lib/memory/__stack_pointer
+  local.get $1
+  i32.store
+  local.get $1
+  call $~lib/object/Object#raw_constructor
+  local.tee $this
+  i32.store offset=4
+  local.get $this
+  local.set $1
+  global.get $~lib/memory/__stack_pointer
+  i32.const 8
+  i32.add
+  global.set $~lib/memory/__stack_pointer
+  local.get $1
+ )
  (func $issues/2622/_a/T1#constructor (param $this i32) (result i32)
   (local $1 i32)
   global.get $~lib/memory/__stack_pointer
@@ -2414,9 +2445,37 @@
   local.get $1
   i32.store offset=4
   local.get $1
-  call $~lib/object/Object#constructor
+  call $~lib/object/Object#raw_constructor
   local.tee $this
   i32.store
+  local.get $this
+  local.set $1
+  global.get $~lib/memory/__stack_pointer
+  i32.const 8
+  i32.add
+  global.set $~lib/memory/__stack_pointer
+  local.get $1
+ )
+ (func $issues/2622/_b/T2#raw_constructor (param $this i32) (result i32)
+  (local $1 i32)
+  global.get $~lib/memory/__stack_pointer
+  i32.const 8
+  i32.sub
+  global.set $~lib/memory/__stack_pointer
+  call $~stack_check
+  global.get $~lib/memory/__stack_pointer
+  i64.const 0
+  i64.store
+  global.get $~lib/memory/__stack_pointer
+  local.get $this
+  local.set $1
+  global.get $~lib/memory/__stack_pointer
+  local.get $1
+  i32.store
+  local.get $1
+  call $~lib/object/Object#raw_constructor
+  local.tee $this
+  i32.store offset=4
   local.get $this
   local.set $1
   global.get $~lib/memory/__stack_pointer
@@ -2452,7 +2511,7 @@
   local.get $1
   i32.store offset=4
   local.get $1
-  call $~lib/object/Object#constructor
+  call $~lib/object/Object#raw_constructor
   local.tee $this
   i32.store
   local.get $this

--- a/tests/compiler/issues/2622.release.wat
+++ b/tests/compiler/issues/2622.release.wat
@@ -1,8 +1,8 @@
 (module
  (type $0 (func))
- (type $1 (func (param i32) (result i32)))
- (type $2 (func (param i32)))
- (type $3 (func (param i32 i32)))
+ (type $1 (func (param i32)))
+ (type $2 (func (param i32 i32)))
+ (type $3 (func (param i32) (result i32)))
  (type $4 (func (param i32 i32 i32 i32)))
  (type $5 (func (param i32 i32 i64)))
  (type $6 (func (result i32)))
@@ -155,7 +155,7 @@
     local.get $0
     global.set $~lib/rt/itcms/iter
    end
-   block $__inlined_func$~lib/rt/itcms/Object#unlink$111
+   block $__inlined_func$~lib/rt/itcms/Object#unlink$112
     local.get $1
     i32.load offset=4
     i32.const -4
@@ -179,7 +179,7 @@
       call $~lib/builtins/abort
       unreachable
      end
-     br $__inlined_func$~lib/rt/itcms/Object#unlink$111
+     br $__inlined_func$~lib/rt/itcms/Object#unlink$112
     end
     local.get $1
     i32.load offset=8
@@ -1493,8 +1493,6 @@
     i32.store offset=4
     global.get $~lib/memory/__stack_pointer
     local.get $0
-    call $~lib/object/Object#constructor
-    local.tee $0
     i32.store
     global.get $~lib/memory/__stack_pointer
     i32.const 8
@@ -1525,8 +1523,6 @@
     i32.store offset=4
     global.get $~lib/memory/__stack_pointer
     local.get $0
-    call $~lib/object/Object#constructor
-    local.tee $0
     i32.store
     global.get $~lib/memory/__stack_pointer
     i32.const 8
@@ -1545,39 +1541,5 @@
    call $~lib/builtins/abort
    unreachable
   end
- )
- (func $~lib/object/Object#constructor (param $0 i32) (result i32)
-  global.get $~lib/memory/__stack_pointer
-  i32.const 4
-  i32.sub
-  global.set $~lib/memory/__stack_pointer
-  global.get $~lib/memory/__stack_pointer
-  i32.const 1468
-  i32.lt_s
-  if
-   i32.const 34256
-   i32.const 34304
-   i32.const 1
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  global.get $~lib/memory/__stack_pointer
-  i32.const 0
-  i32.store
-  local.get $0
-  i32.eqz
-  if
-   global.get $~lib/memory/__stack_pointer
-   i32.const 0
-   call $~lib/rt/itcms/__new
-   local.tee $0
-   i32.store
-  end
-  global.get $~lib/memory/__stack_pointer
-  i32.const 4
-  i32.add
-  global.set $~lib/memory/__stack_pointer
-  local.get $0
  )
 )

--- a/tests/compiler/logical.debug.wat
+++ b/tests/compiler/logical.debug.wat
@@ -71,6 +71,9 @@
   end
   return
  )
+ (func $~lib/object/Object#raw_constructor (param $this i32) (result i32)
+  local.get $this
+ )
  (func $~lib/rt/itcms/Object#set:nextWithColor (param $this i32) (param $nextWithColor i32)
   local.get $this
   local.get $nextWithColor
@@ -2395,6 +2398,34 @@
    unreachable
   end
  )
+ (func $logical/Obj#raw_constructor (param $this i32) (result i32)
+  (local $1 i32)
+  global.get $~lib/memory/__stack_pointer
+  i32.const 8
+  i32.sub
+  global.set $~lib/memory/__stack_pointer
+  call $~stack_check
+  global.get $~lib/memory/__stack_pointer
+  i64.const 0
+  i64.store
+  global.get $~lib/memory/__stack_pointer
+  local.get $this
+  local.set $1
+  global.get $~lib/memory/__stack_pointer
+  local.get $1
+  i32.store
+  local.get $1
+  call $~lib/object/Object#raw_constructor
+  local.tee $this
+  i32.store offset=4
+  local.get $this
+  local.set $1
+  global.get $~lib/memory/__stack_pointer
+  i32.const 8
+  i32.add
+  global.set $~lib/memory/__stack_pointer
+  local.get $1
+ )
  (func $logical/Obj#constructor (param $this i32) (result i32)
   (local $1 i32)
   global.get $~lib/memory/__stack_pointer
@@ -2422,9 +2453,37 @@
   local.get $1
   i32.store offset=4
   local.get $1
-  call $~lib/object/Object#constructor
+  call $~lib/object/Object#raw_constructor
   local.tee $this
   i32.store
+  local.get $this
+  local.set $1
+  global.get $~lib/memory/__stack_pointer
+  i32.const 8
+  i32.add
+  global.set $~lib/memory/__stack_pointer
+  local.get $1
+ )
+ (func $logical/A#raw_constructor (param $this i32) (result i32)
+  (local $1 i32)
+  global.get $~lib/memory/__stack_pointer
+  i32.const 8
+  i32.sub
+  global.set $~lib/memory/__stack_pointer
+  call $~stack_check
+  global.get $~lib/memory/__stack_pointer
+  i64.const 0
+  i64.store
+  global.get $~lib/memory/__stack_pointer
+  local.get $this
+  local.set $1
+  global.get $~lib/memory/__stack_pointer
+  local.get $1
+  i32.store
+  local.get $1
+  call $~lib/object/Object#raw_constructor
+  local.tee $this
+  i32.store offset=4
   local.get $this
   local.set $1
   global.get $~lib/memory/__stack_pointer
@@ -2460,9 +2519,37 @@
   local.get $1
   i32.store offset=4
   local.get $1
-  call $~lib/object/Object#constructor
+  call $~lib/object/Object#raw_constructor
   local.tee $this
   i32.store
+  local.get $this
+  local.set $1
+  global.get $~lib/memory/__stack_pointer
+  i32.const 8
+  i32.add
+  global.set $~lib/memory/__stack_pointer
+  local.get $1
+ )
+ (func $logical/B#raw_constructor (param $this i32) (result i32)
+  (local $1 i32)
+  global.get $~lib/memory/__stack_pointer
+  i32.const 8
+  i32.sub
+  global.set $~lib/memory/__stack_pointer
+  call $~stack_check
+  global.get $~lib/memory/__stack_pointer
+  i64.const 0
+  i64.store
+  global.get $~lib/memory/__stack_pointer
+  local.get $this
+  local.set $1
+  global.get $~lib/memory/__stack_pointer
+  local.get $1
+  i32.store
+  local.get $1
+  call $logical/A#raw_constructor
+  local.tee $this
+  i32.store offset=4
   local.get $this
   local.set $1
   global.get $~lib/memory/__stack_pointer
@@ -2498,9 +2585,37 @@
   local.get $1
   i32.store offset=4
   local.get $1
-  call $logical/A#constructor
+  call $logical/A#raw_constructor
   local.tee $this
   i32.store
+  local.get $this
+  local.set $1
+  global.get $~lib/memory/__stack_pointer
+  i32.const 8
+  i32.add
+  global.set $~lib/memory/__stack_pointer
+  local.get $1
+ )
+ (func $logical/C#raw_constructor (param $this i32) (result i32)
+  (local $1 i32)
+  global.get $~lib/memory/__stack_pointer
+  i32.const 8
+  i32.sub
+  global.set $~lib/memory/__stack_pointer
+  call $~stack_check
+  global.get $~lib/memory/__stack_pointer
+  i64.const 0
+  i64.store
+  global.get $~lib/memory/__stack_pointer
+  local.get $this
+  local.set $1
+  global.get $~lib/memory/__stack_pointer
+  local.get $1
+  i32.store
+  local.get $1
+  call $logical/A#raw_constructor
+  local.tee $this
+  i32.store offset=4
   local.get $this
   local.set $1
   global.get $~lib/memory/__stack_pointer
@@ -2536,7 +2651,7 @@
   local.get $1
   i32.store offset=4
   local.get $1
-  call $logical/A#constructor
+  call $logical/A#raw_constructor
   local.tee $this
   i32.store
   local.get $this

--- a/tests/compiler/logical.release.wat
+++ b/tests/compiler/logical.release.wat
@@ -1,6 +1,6 @@
 (module
- (type $0 (func (param i32) (result i32)))
- (type $1 (func))
+ (type $0 (func))
+ (type $1 (func (param i32) (result i32)))
  (type $2 (func (param i32)))
  (type $3 (func (param i32 i32)))
  (type $4 (func (result i32)))
@@ -131,7 +131,7 @@
     local.get $0
     global.set $~lib/rt/itcms/iter
    end
-   block $__inlined_func$~lib/rt/itcms/Object#unlink$122
+   block $__inlined_func$~lib/rt/itcms/Object#unlink$123
     local.get $1
     i32.load offset=4
     i32.const -4
@@ -155,7 +155,7 @@
       call $~lib/builtins/abort
       unreachable
      end
-     br $__inlined_func$~lib/rt/itcms/Object#unlink$122
+     br $__inlined_func$~lib/rt/itcms/Object#unlink$123
     end
     local.get $1
     i32.load offset=8
@@ -1516,7 +1516,7 @@
     i32.store offset=4
     global.get $~lib/memory/__stack_pointer
     local.get $0
-    call $logical/A#constructor
+    call $logical/Obj#raw_constructor
     local.tee $0
     i32.store
     global.get $~lib/memory/__stack_pointer
@@ -1546,7 +1546,7 @@
     i32.store offset=4
     global.get $~lib/memory/__stack_pointer
     local.get $0
-    call $logical/A#constructor
+    call $logical/Obj#raw_constructor
     local.tee $0
     i32.store
     global.get $~lib/memory/__stack_pointer
@@ -1605,6 +1605,37 @@
    unreachable
   end
  )
+ (func $logical/Obj#raw_constructor (param $0 i32) (result i32)
+  global.get $~lib/memory/__stack_pointer
+  i32.const 8
+  i32.sub
+  global.set $~lib/memory/__stack_pointer
+  global.get $~lib/memory/__stack_pointer
+  i32.const 1524
+  i32.lt_s
+  if
+   i32.const 34320
+   i32.const 34368
+   i32.const 1
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  global.get $~lib/memory/__stack_pointer
+  i64.const 0
+  i64.store
+  global.get $~lib/memory/__stack_pointer
+  local.get $0
+  i32.store
+  global.get $~lib/memory/__stack_pointer
+  local.get $0
+  i32.store offset=4
+  global.get $~lib/memory/__stack_pointer
+  i32.const 8
+  i32.add
+  global.set $~lib/memory/__stack_pointer
+  local.get $0
+ )
  (func $logical/Obj#constructor (result i32)
   (local $0 i32)
   global.get $~lib/memory/__stack_pointer
@@ -1635,87 +1666,9 @@
   i32.store offset=4
   global.get $~lib/memory/__stack_pointer
   local.get $0
-  call $~lib/object/Object#constructor
-  local.tee $0
   i32.store
   global.get $~lib/memory/__stack_pointer
   i32.const 8
-  i32.add
-  global.set $~lib/memory/__stack_pointer
-  local.get $0
- )
- (func $logical/A#constructor (param $0 i32) (result i32)
-  global.get $~lib/memory/__stack_pointer
-  i32.const 8
-  i32.sub
-  global.set $~lib/memory/__stack_pointer
-  global.get $~lib/memory/__stack_pointer
-  i32.const 1524
-  i32.lt_s
-  if
-   i32.const 34320
-   i32.const 34368
-   i32.const 1
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  global.get $~lib/memory/__stack_pointer
-  i64.const 0
-  i64.store
-  local.get $0
-  i32.eqz
-  if
-   global.get $~lib/memory/__stack_pointer
-   i32.const 6
-   call $~lib/rt/itcms/__new
-   local.tee $0
-   i32.store
-  end
-  global.get $~lib/memory/__stack_pointer
-  local.get $0
-  i32.store offset=4
-  global.get $~lib/memory/__stack_pointer
-  local.get $0
-  call $~lib/object/Object#constructor
-  local.tee $0
-  i32.store
-  global.get $~lib/memory/__stack_pointer
-  i32.const 8
-  i32.add
-  global.set $~lib/memory/__stack_pointer
-  local.get $0
- )
- (func $~lib/object/Object#constructor (param $0 i32) (result i32)
-  global.get $~lib/memory/__stack_pointer
-  i32.const 4
-  i32.sub
-  global.set $~lib/memory/__stack_pointer
-  global.get $~lib/memory/__stack_pointer
-  i32.const 1524
-  i32.lt_s
-  if
-   i32.const 34320
-   i32.const 34368
-   i32.const 1
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  global.get $~lib/memory/__stack_pointer
-  i32.const 0
-  i32.store
-  local.get $0
-  i32.eqz
-  if
-   global.get $~lib/memory/__stack_pointer
-   i32.const 0
-   call $~lib/rt/itcms/__new
-   local.tee $0
-   i32.store
-  end
-  global.get $~lib/memory/__stack_pointer
-  i32.const 4
   i32.add
   global.set $~lib/memory/__stack_pointer
   local.get $0

--- a/tests/compiler/managed-cast.debug.wat
+++ b/tests/compiler/managed-cast.debug.wat
@@ -44,6 +44,9 @@
  (elem $0 (i32.const 1))
  (export "memory" (memory $0))
  (start $~start)
+ (func $~lib/object/Object#raw_constructor (param $this i32) (result i32)
+  local.get $this
+ )
  (func $~lib/rt/itcms/Object#set:nextWithColor (param $this i32) (param $nextWithColor i32)
   local.get $this
   local.get $nextWithColor
@@ -2379,6 +2382,34 @@
    unreachable
   end
  )
+ (func $managed-cast/Animal#raw_constructor (param $this i32) (result i32)
+  (local $1 i32)
+  global.get $~lib/memory/__stack_pointer
+  i32.const 8
+  i32.sub
+  global.set $~lib/memory/__stack_pointer
+  call $~stack_check
+  global.get $~lib/memory/__stack_pointer
+  i64.const 0
+  i64.store
+  global.get $~lib/memory/__stack_pointer
+  local.get $this
+  local.set $1
+  global.get $~lib/memory/__stack_pointer
+  local.get $1
+  i32.store
+  local.get $1
+  call $~lib/object/Object#raw_constructor
+  local.tee $this
+  i32.store offset=4
+  local.get $this
+  local.set $1
+  global.get $~lib/memory/__stack_pointer
+  i32.const 8
+  i32.add
+  global.set $~lib/memory/__stack_pointer
+  local.get $1
+ )
  (func $managed-cast/Animal#constructor (param $this i32) (result i32)
   (local $1 i32)
   global.get $~lib/memory/__stack_pointer
@@ -2406,9 +2437,37 @@
   local.get $1
   i32.store offset=4
   local.get $1
-  call $~lib/object/Object#constructor
+  call $~lib/object/Object#raw_constructor
   local.tee $this
   i32.store
+  local.get $this
+  local.set $1
+  global.get $~lib/memory/__stack_pointer
+  i32.const 8
+  i32.add
+  global.set $~lib/memory/__stack_pointer
+  local.get $1
+ )
+ (func $managed-cast/Cat#raw_constructor (param $this i32) (result i32)
+  (local $1 i32)
+  global.get $~lib/memory/__stack_pointer
+  i32.const 8
+  i32.sub
+  global.set $~lib/memory/__stack_pointer
+  call $~stack_check
+  global.get $~lib/memory/__stack_pointer
+  i64.const 0
+  i64.store
+  global.get $~lib/memory/__stack_pointer
+  local.get $this
+  local.set $1
+  global.get $~lib/memory/__stack_pointer
+  local.get $1
+  i32.store
+  local.get $1
+  call $managed-cast/Animal#raw_constructor
+  local.tee $this
+  i32.store offset=4
   local.get $this
   local.set $1
   global.get $~lib/memory/__stack_pointer
@@ -2444,7 +2503,7 @@
   local.get $1
   i32.store offset=4
   local.get $1
-  call $managed-cast/Animal#constructor
+  call $managed-cast/Animal#raw_constructor
   local.tee $this
   i32.store
   local.get $this

--- a/tests/compiler/managed-cast.release.wat
+++ b/tests/compiler/managed-cast.release.wat
@@ -1,11 +1,11 @@
 (module
  (type $0 (func))
  (type $1 (func (param i32)))
- (type $2 (func (param i32 i32)))
- (type $3 (func (result i32)))
- (type $4 (func (param i32) (result i32)))
- (type $5 (func (param i32 i32 i32 i32)))
- (type $6 (func (param i32 i32 i64)))
+ (type $2 (func (result i32)))
+ (type $3 (func (param i32 i32)))
+ (type $4 (func (param i32 i32 i32 i32)))
+ (type $5 (func (param i32 i32 i64)))
+ (type $6 (func (param i32) (result i32)))
  (import "env" "abort" (func $~lib/builtins/abort (param i32 i32 i32 i32)))
  (global $~lib/rt/itcms/total (mut i32) (i32.const 0))
  (global $~lib/rt/itcms/threshold (mut i32) (i32.const 0))
@@ -1138,23 +1138,23 @@
    end
   end
  )
- (func $~lib/rt/itcms/__new (param $0 i32) (result i32)
+ (func $~lib/rt/itcms/__new (result i32)
+  (local $0 i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
-  (local $4 i32)
   global.get $~lib/rt/itcms/total
   global.get $~lib/rt/itcms/threshold
   i32.ge_u
   if
    block $__inlined_func$~lib/rt/itcms/interrupt$69
     i32.const 2048
-    local.set $1
+    local.set $0
     loop $do-loop|0
-     local.get $1
+     local.get $0
      call $~lib/rt/itcms/step
      i32.sub
-     local.set $1
+     local.set $0
      global.get $~lib/rt/itcms/state
      i32.eqz
      if
@@ -1170,7 +1170,7 @@
       global.set $~lib/rt/itcms/threshold
       br $__inlined_func$~lib/rt/itcms/interrupt$69
      end
-     local.get $1
+     local.get $0
      i32.const 0
      i32.gt_s
      br_if $do-loop|0
@@ -1193,17 +1193,17 @@
    call $~lib/rt/tlsf/initialize
   end
   global.get $~lib/rt/tlsf/ROOT
-  local.tee $2
-  call $~lib/rt/tlsf/searchBlock
   local.tee $1
+  call $~lib/rt/tlsf/searchBlock
+  local.tee $0
   i32.eqz
   if
    memory.size
-   local.tee $1
+   local.tee $0
    i32.const 4
-   local.get $2
-   i32.load offset=1568
    local.get $1
+   i32.load offset=1568
+   local.get $0
    i32.const 16
    i32.shl
    i32.const 4
@@ -1216,16 +1216,16 @@
    i32.and
    i32.const 16
    i32.shr_u
-   local.tee $3
-   local.get $1
-   local.get $3
+   local.tee $2
+   local.get $0
+   local.get $2
    i32.gt_s
    select
    memory.grow
    i32.const 0
    i32.lt_s
    if
-    local.get $3
+    local.get $2
     memory.grow
     i32.const 0
     i32.lt_s
@@ -1233,8 +1233,8 @@
      unreachable
     end
    end
-   local.get $2
    local.get $1
+   local.get $0
    i32.const 16
    i32.shl
    memory.size
@@ -1242,9 +1242,9 @@
    i64.const 16
    i64.shl
    call $~lib/rt/tlsf/addMemory
-   local.get $2
+   local.get $1
    call $~lib/rt/tlsf/searchBlock
-   local.tee $1
+   local.tee $0
    i32.eqz
    if
     i32.const 0
@@ -1255,7 +1255,7 @@
     unreachable
    end
   end
-  local.get $1
+  local.get $0
   i32.load
   i32.const -4
   i32.and
@@ -1269,92 +1269,92 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $2
   local.get $1
+  local.get $0
   call $~lib/rt/tlsf/removeBlock
-  local.get $1
+  local.get $0
   i32.load
-  local.tee $3
+  local.tee $2
   i32.const -4
   i32.and
   i32.const 28
   i32.sub
-  local.tee $4
+  local.tee $3
   i32.const 16
   i32.ge_u
   if
-   local.get $1
-   local.get $3
+   local.get $0
+   local.get $2
    i32.const 2
    i32.and
    i32.const 28
    i32.or
    i32.store
-   local.get $1
+   local.get $0
    i32.const 32
    i32.add
-   local.tee $3
-   local.get $4
+   local.tee $2
+   local.get $3
    i32.const 4
    i32.sub
    i32.const 1
    i32.or
    i32.store
+   local.get $1
    local.get $2
-   local.get $3
    call $~lib/rt/tlsf/insertBlock
   else
-   local.get $1
-   local.get $3
+   local.get $0
+   local.get $2
    i32.const -2
    i32.and
    i32.store
-   local.get $1
+   local.get $0
    i32.const 4
    i32.add
-   local.get $1
+   local.get $0
    i32.load
    i32.const -4
    i32.and
    i32.add
-   local.tee $2
-   local.get $2
+   local.tee $1
+   local.get $1
    i32.load
    i32.const -3
    i32.and
    i32.store
   end
-  local.get $1
   local.get $0
+  i32.const 4
   i32.store offset=12
-  local.get $1
+  local.get $0
   i32.const 0
   i32.store offset=16
   global.get $~lib/rt/itcms/fromSpace
-  local.tee $0
+  local.tee $1
   i32.load offset=8
   local.set $2
-  local.get $1
   local.get $0
+  local.get $1
   global.get $~lib/rt/itcms/white
   i32.or
   i32.store offset=4
-  local.get $1
+  local.get $0
   local.get $2
   i32.store offset=8
   local.get $2
-  local.get $1
+  local.get $0
   local.get $2
   i32.load offset=4
   i32.const 3
   i32.and
   i32.or
   i32.store offset=4
-  local.get $0
   local.get $1
+  local.get $0
   i32.store offset=8
   global.get $~lib/rt/itcms/total
-  local.get $1
+  local.get $0
   i32.load
   i32.const -4
   i32.and
@@ -1362,7 +1362,7 @@
   i32.add
   i32.add
   global.set $~lib/rt/itcms/total
-  local.get $1
+  local.get $0
   i32.const 20
   i32.add
   local.tee $0
@@ -1794,7 +1794,6 @@
  (func $managed-cast/Cat#constructor (result i32)
   (local $0 i32)
   (local $1 i32)
-  (local $2 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 8
   i32.sub
@@ -1808,7 +1807,6 @@
    i64.const 0
    i64.store
    global.get $~lib/memory/__stack_pointer
-   i32.const 4
    call $~lib/rt/itcms/__new
    local.tee $0
    i32.store
@@ -1827,45 +1825,12 @@
    global.get $~lib/memory/__stack_pointer
    i64.const 0
    i64.store
-   local.get $0
-   i32.eqz
-   if
-    global.get $~lib/memory/__stack_pointer
-    i32.const 5
-    call $~lib/rt/itcms/__new
-    local.tee $0
-    i32.store
-   end
    global.get $~lib/memory/__stack_pointer
+   local.get $0
+   i32.store
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store offset=4
-   global.get $~lib/memory/__stack_pointer
-   i32.const 4
-   i32.sub
-   global.set $~lib/memory/__stack_pointer
-   global.get $~lib/memory/__stack_pointer
-   i32.const 1724
-   i32.lt_s
-   br_if $folding-inner0
-   global.get $~lib/memory/__stack_pointer
-   i32.const 0
-   i32.store
-   local.get $0
-   i32.eqz
-   if
-    global.get $~lib/memory/__stack_pointer
-    i32.const 0
-    call $~lib/rt/itcms/__new
-    local.tee $0
-    i32.store
-   end
-   global.get $~lib/memory/__stack_pointer
-   i32.const 4
-   i32.add
-   global.set $~lib/memory/__stack_pointer
-   local.get $0
-   i32.store
    global.get $~lib/memory/__stack_pointer
    i32.const 8
    i32.add

--- a/tests/compiler/new.debug.wat
+++ b/tests/compiler/new.debug.wat
@@ -47,6 +47,9 @@
  (elem $0 (i32.const 1))
  (export "memory" (memory $0))
  (start $~start)
+ (func $~lib/object/Object#raw_constructor (param $this i32) (result i32)
+  local.get $this
+ )
  (func $~lib/rt/itcms/Object#set:nextWithColor (param $this i32) (param $nextWithColor i32)
   local.get $this
   local.get $nextWithColor
@@ -2375,6 +2378,34 @@
    unreachable
   end
  )
+ (func $new/Ref#raw_constructor (param $this i32) (result i32)
+  (local $1 i32)
+  global.get $~lib/memory/__stack_pointer
+  i32.const 8
+  i32.sub
+  global.set $~lib/memory/__stack_pointer
+  call $~stack_check
+  global.get $~lib/memory/__stack_pointer
+  i64.const 0
+  i64.store
+  global.get $~lib/memory/__stack_pointer
+  local.get $this
+  local.set $1
+  global.get $~lib/memory/__stack_pointer
+  local.get $1
+  i32.store
+  local.get $1
+  call $~lib/object/Object#raw_constructor
+  local.tee $this
+  i32.store offset=4
+  local.get $this
+  local.set $1
+  global.get $~lib/memory/__stack_pointer
+  i32.const 8
+  i32.add
+  global.set $~lib/memory/__stack_pointer
+  local.get $1
+ )
  (func $new/Ref#constructor (param $this i32) (result i32)
   (local $1 i32)
   global.get $~lib/memory/__stack_pointer
@@ -2402,9 +2433,37 @@
   local.get $1
   i32.store offset=4
   local.get $1
-  call $~lib/object/Object#constructor
+  call $~lib/object/Object#raw_constructor
   local.tee $this
   i32.store
+  local.get $this
+  local.set $1
+  global.get $~lib/memory/__stack_pointer
+  i32.const 8
+  i32.add
+  global.set $~lib/memory/__stack_pointer
+  local.get $1
+ )
+ (func $new/Gen<i32>#raw_constructor (param $this i32) (result i32)
+  (local $1 i32)
+  global.get $~lib/memory/__stack_pointer
+  i32.const 8
+  i32.sub
+  global.set $~lib/memory/__stack_pointer
+  call $~stack_check
+  global.get $~lib/memory/__stack_pointer
+  i64.const 0
+  i64.store
+  global.get $~lib/memory/__stack_pointer
+  local.get $this
+  local.set $1
+  global.get $~lib/memory/__stack_pointer
+  local.get $1
+  i32.store
+  local.get $1
+  call $~lib/object/Object#raw_constructor
+  local.tee $this
+  i32.store offset=4
   local.get $this
   local.set $1
   global.get $~lib/memory/__stack_pointer
@@ -2440,9 +2499,37 @@
   local.get $1
   i32.store offset=4
   local.get $1
-  call $~lib/object/Object#constructor
+  call $~lib/object/Object#raw_constructor
   local.tee $this
   i32.store
+  local.get $this
+  local.set $1
+  global.get $~lib/memory/__stack_pointer
+  i32.const 8
+  i32.add
+  global.set $~lib/memory/__stack_pointer
+  local.get $1
+ )
+ (func $new/ns.Ref#raw_constructor (param $this i32) (result i32)
+  (local $1 i32)
+  global.get $~lib/memory/__stack_pointer
+  i32.const 8
+  i32.sub
+  global.set $~lib/memory/__stack_pointer
+  call $~stack_check
+  global.get $~lib/memory/__stack_pointer
+  i64.const 0
+  i64.store
+  global.get $~lib/memory/__stack_pointer
+  local.get $this
+  local.set $1
+  global.get $~lib/memory/__stack_pointer
+  local.get $1
+  i32.store
+  local.get $1
+  call $~lib/object/Object#raw_constructor
+  local.tee $this
+  i32.store offset=4
   local.get $this
   local.set $1
   global.get $~lib/memory/__stack_pointer
@@ -2478,9 +2565,37 @@
   local.get $1
   i32.store offset=4
   local.get $1
-  call $~lib/object/Object#constructor
+  call $~lib/object/Object#raw_constructor
   local.tee $this
   i32.store
+  local.get $this
+  local.set $1
+  global.get $~lib/memory/__stack_pointer
+  i32.const 8
+  i32.add
+  global.set $~lib/memory/__stack_pointer
+  local.get $1
+ )
+ (func $new/GenExt#raw_constructor (param $this i32) (result i32)
+  (local $1 i32)
+  global.get $~lib/memory/__stack_pointer
+  i32.const 8
+  i32.sub
+  global.set $~lib/memory/__stack_pointer
+  call $~stack_check
+  global.get $~lib/memory/__stack_pointer
+  i64.const 0
+  i64.store
+  global.get $~lib/memory/__stack_pointer
+  local.get $this
+  local.set $1
+  global.get $~lib/memory/__stack_pointer
+  local.get $1
+  i32.store
+  local.get $1
+  call $new/Gen<i32>#raw_constructor
+  local.tee $this
+  i32.store offset=4
   local.get $this
   local.set $1
   global.get $~lib/memory/__stack_pointer
@@ -2516,7 +2631,7 @@
   local.get $1
   i32.store offset=4
   local.get $1
-  call $new/Gen<i32>#constructor
+  call $new/Gen<i32>#raw_constructor
   local.tee $this
   i32.store
   local.get $this

--- a/tests/compiler/new.release.wat
+++ b/tests/compiler/new.release.wat
@@ -1,9 +1,9 @@
 (module
  (type $0 (func (result i32)))
- (type $1 (func (param i32) (result i32)))
- (type $2 (func))
- (type $3 (func (param i32)))
- (type $4 (func (param i32 i32)))
+ (type $1 (func))
+ (type $2 (func (param i32)))
+ (type $3 (func (param i32 i32)))
+ (type $4 (func (param i32) (result i32)))
  (type $5 (func (param i32 i32 i32 i32)))
  (type $6 (func (param i32 i32 i64)))
  (import "env" "abort" (func $~lib/builtins/abort (param i32 i32 i32 i32)))
@@ -157,7 +157,7 @@
     local.get $0
     global.set $~lib/rt/itcms/iter
    end
-   block $__inlined_func$~lib/rt/itcms/Object#unlink$116
+   block $__inlined_func$~lib/rt/itcms/Object#unlink$121
     local.get $1
     i32.load offset=4
     i32.const -4
@@ -181,7 +181,7 @@
       call $~lib/builtins/abort
       unreachable
      end
-     br $__inlined_func$~lib/rt/itcms/Object#unlink$116
+     br $__inlined_func$~lib/rt/itcms/Object#unlink$121
     end
     local.get $1
     i32.load offset=8
@@ -1507,13 +1507,10 @@
   i32.store
   local.get $0
   global.set $new/ref
-  i32.const 0
   call $new/Gen<i32>#constructor
   global.set $new/gen
-  i32.const 0
   call $new/Gen<i32>#constructor
   global.set $new/gen
-  i32.const 0
   call $new/Gen<i32>#constructor
   local.set $0
   global.get $~lib/memory/__stack_pointer
@@ -1573,8 +1570,6 @@
   i32.store offset=4
   global.get $~lib/memory/__stack_pointer
   local.get $0
-  call $~lib/object/Object#constructor
-  local.tee $0
   i32.store
   global.get $~lib/memory/__stack_pointer
   i32.const 8
@@ -1582,7 +1577,8 @@
   global.set $~lib/memory/__stack_pointer
   local.get $0
  )
- (func $new/Gen<i32>#constructor (param $0 i32) (result i32)
+ (func $new/Gen<i32>#constructor (result i32)
+  (local $0 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 8
   i32.sub
@@ -1601,22 +1597,16 @@
   global.get $~lib/memory/__stack_pointer
   i64.const 0
   i64.store
-  local.get $0
-  i32.eqz
-  if
-   global.get $~lib/memory/__stack_pointer
-   i32.const 5
-   call $~lib/rt/itcms/__new
-   local.tee $0
-   i32.store
-  end
+  global.get $~lib/memory/__stack_pointer
+  i32.const 5
+  call $~lib/rt/itcms/__new
+  local.tee $0
+  i32.store
   global.get $~lib/memory/__stack_pointer
   local.get $0
   i32.store offset=4
   global.get $~lib/memory/__stack_pointer
   local.get $0
-  call $~lib/object/Object#constructor
-  local.tee $0
   i32.store
   global.get $~lib/memory/__stack_pointer
   i32.const 8
@@ -1654,8 +1644,6 @@
   i32.store offset=4
   global.get $~lib/memory/__stack_pointer
   local.get $0
-  call $~lib/object/Object#constructor
-  local.tee $0
   i32.store
   global.get $~lib/memory/__stack_pointer
   i32.const 8
@@ -1665,75 +1653,63 @@
  )
  (func $new/GenExt#constructor (result i32)
   (local $0 i32)
+  (local $1 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 8
   i32.sub
   global.set $~lib/memory/__stack_pointer
-  global.get $~lib/memory/__stack_pointer
-  i32.const 1476
-  i32.lt_s
-  if
-   i32.const 34272
-   i32.const 34320
-   i32.const 1
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  global.get $~lib/memory/__stack_pointer
-  i64.const 0
-  i64.store
-  global.get $~lib/memory/__stack_pointer
-  i32.const 7
-  call $~lib/rt/itcms/__new
-  local.tee $0
-  i32.store
-  global.get $~lib/memory/__stack_pointer
-  local.get $0
-  i32.store offset=4
-  global.get $~lib/memory/__stack_pointer
-  local.get $0
-  call $new/Gen<i32>#constructor
-  local.tee $0
-  i32.store
-  global.get $~lib/memory/__stack_pointer
-  i32.const 8
-  i32.add
-  global.set $~lib/memory/__stack_pointer
-  local.get $0
- )
- (func $~lib/object/Object#constructor (param $0 i32) (result i32)
-  global.get $~lib/memory/__stack_pointer
-  i32.const 4
-  i32.sub
-  global.set $~lib/memory/__stack_pointer
-  global.get $~lib/memory/__stack_pointer
-  i32.const 1476
-  i32.lt_s
-  if
-   i32.const 34272
-   i32.const 34320
-   i32.const 1
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  global.get $~lib/memory/__stack_pointer
-  i32.const 0
-  i32.store
-  local.get $0
-  i32.eqz
-  if
+  block $folding-inner0
    global.get $~lib/memory/__stack_pointer
-   i32.const 0
+   i32.const 1476
+   i32.lt_s
+   br_if $folding-inner0
+   global.get $~lib/memory/__stack_pointer
+   i64.const 0
+   i64.store
+   global.get $~lib/memory/__stack_pointer
+   i32.const 7
    call $~lib/rt/itcms/__new
    local.tee $0
    i32.store
+   global.get $~lib/memory/__stack_pointer
+   global.get $~lib/memory/__stack_pointer
+   local.get $0
+   i32.store offset=4
+   global.get $~lib/memory/__stack_pointer
+   i32.const 8
+   i32.sub
+   global.set $~lib/memory/__stack_pointer
+   global.get $~lib/memory/__stack_pointer
+   i32.const 1476
+   i32.lt_s
+   br_if $folding-inner0
+   global.get $~lib/memory/__stack_pointer
+   i64.const 0
+   i64.store
+   global.get $~lib/memory/__stack_pointer
+   local.get $0
+   i32.store
+   global.get $~lib/memory/__stack_pointer
+   local.get $0
+   i32.store offset=4
+   global.get $~lib/memory/__stack_pointer
+   i32.const 8
+   i32.add
+   global.set $~lib/memory/__stack_pointer
+   local.get $0
+   i32.store
+   global.get $~lib/memory/__stack_pointer
+   i32.const 8
+   i32.add
+   global.set $~lib/memory/__stack_pointer
+   local.get $0
+   return
   end
-  global.get $~lib/memory/__stack_pointer
-  i32.const 4
-  i32.add
-  global.set $~lib/memory/__stack_pointer
-  local.get $0
+  i32.const 34272
+  i32.const 34320
+  i32.const 1
+  i32.const 1
+  call $~lib/builtins/abort
+  unreachable
  )
 )

--- a/tests/compiler/object-literal.debug.wat
+++ b/tests/compiler/object-literal.debug.wat
@@ -359,6 +359,9 @@
   i32.const 0
   call $~lib/rt/itcms/__link
  )
+ (func $~lib/object/Object#raw_constructor (param $this i32) (result i32)
+  local.get $this
+ )
  (func $~lib/rt/itcms/visitRoots (param $cookie i32)
   (local $pn i32)
   (local $iter i32)
@@ -2474,6 +2477,15 @@
   local.get $baz
   i32.store offset=4
  )
+ (func $object-literal/Unmanaged#raw_constructor (param $this i32) (result i32)
+  local.get $this
+  i32.const 0
+  call $object-literal/Unmanaged#set:bar
+  local.get $this
+  i32.const 0
+  call $object-literal/Unmanaged#set:baz
+  local.get $this
+ )
  (func $object-literal/Unmanaged#constructor (param $this i32) (result i32)
   local.get $this
   i32.eqz
@@ -2964,6 +2976,50 @@
    unreachable
   end
  )
+ (func $object-literal/Managed#raw_constructor (param $this i32) (result i32)
+  (local $1 i32)
+  global.get $~lib/memory/__stack_pointer
+  i32.const 8
+  i32.sub
+  global.set $~lib/memory/__stack_pointer
+  call $~stack_check
+  global.get $~lib/memory/__stack_pointer
+  i64.const 0
+  i64.store
+  global.get $~lib/memory/__stack_pointer
+  local.get $this
+  local.set $1
+  global.get $~lib/memory/__stack_pointer
+  local.get $1
+  i32.store
+  local.get $1
+  call $~lib/object/Object#raw_constructor
+  local.tee $this
+  i32.store offset=4
+  local.get $this
+  local.set $1
+  global.get $~lib/memory/__stack_pointer
+  local.get $1
+  i32.store
+  local.get $1
+  i32.const 0
+  call $object-literal/Managed#set:bar
+  local.get $this
+  local.set $1
+  global.get $~lib/memory/__stack_pointer
+  local.get $1
+  i32.store
+  local.get $1
+  i32.const 0
+  call $object-literal/Managed#set:baz
+  local.get $this
+  local.set $1
+  global.get $~lib/memory/__stack_pointer
+  i32.const 8
+  i32.add
+  global.set $~lib/memory/__stack_pointer
+  local.get $1
+ )
  (func $object-literal/Managed#constructor (param $this i32) (result i32)
   (local $1 i32)
   global.get $~lib/memory/__stack_pointer
@@ -2991,7 +3047,7 @@
   local.get $1
   i32.store offset=4
   local.get $1
-  call $~lib/object/Object#constructor
+  call $~lib/object/Object#raw_constructor
   local.tee $this
   i32.store
   local.get $this
@@ -3380,6 +3436,146 @@
   i32.add
   global.set $~lib/memory/__stack_pointer
  )
+ (func $object-literal/OmittedTypes#raw_constructor (param $this i32) (result i32)
+  (local $1 i32)
+  global.get $~lib/memory/__stack_pointer
+  i32.const 8
+  i32.sub
+  global.set $~lib/memory/__stack_pointer
+  call $~stack_check
+  global.get $~lib/memory/__stack_pointer
+  i64.const 0
+  i64.store
+  global.get $~lib/memory/__stack_pointer
+  local.get $this
+  local.set $1
+  global.get $~lib/memory/__stack_pointer
+  local.get $1
+  i32.store
+  local.get $1
+  call $~lib/object/Object#raw_constructor
+  local.tee $this
+  i32.store offset=4
+  local.get $this
+  local.set $1
+  global.get $~lib/memory/__stack_pointer
+  local.get $1
+  i32.store
+  local.get $1
+  i32.const 0
+  call $object-literal/OmittedTypes#set:int32
+  local.get $this
+  local.set $1
+  global.get $~lib/memory/__stack_pointer
+  local.get $1
+  i32.store
+  local.get $1
+  i32.const 0
+  call $object-literal/OmittedTypes#set:uint32
+  local.get $this
+  local.set $1
+  global.get $~lib/memory/__stack_pointer
+  local.get $1
+  i32.store
+  local.get $1
+  i64.const 0
+  call $object-literal/OmittedTypes#set:int64
+  local.get $this
+  local.set $1
+  global.get $~lib/memory/__stack_pointer
+  local.get $1
+  i32.store
+  local.get $1
+  i64.const 0
+  call $object-literal/OmittedTypes#set:uint64
+  local.get $this
+  local.set $1
+  global.get $~lib/memory/__stack_pointer
+  local.get $1
+  i32.store
+  local.get $1
+  f32.const 0
+  call $object-literal/OmittedTypes#set:float32
+  local.get $this
+  local.set $1
+  global.get $~lib/memory/__stack_pointer
+  local.get $1
+  i32.store
+  local.get $1
+  f64.const 0
+  call $object-literal/OmittedTypes#set:float64
+  local.get $this
+  local.set $1
+  global.get $~lib/memory/__stack_pointer
+  local.get $1
+  i32.store
+  local.get $1
+  i32.const 0
+  call $object-literal/OmittedTypes#set:int8
+  local.get $this
+  local.set $1
+  global.get $~lib/memory/__stack_pointer
+  local.get $1
+  i32.store
+  local.get $1
+  i32.const 0
+  call $object-literal/OmittedTypes#set:uint8
+  local.get $this
+  local.set $1
+  global.get $~lib/memory/__stack_pointer
+  local.get $1
+  i32.store
+  local.get $1
+  i32.const 0
+  call $object-literal/OmittedTypes#set:int16
+  local.get $this
+  local.set $1
+  global.get $~lib/memory/__stack_pointer
+  local.get $1
+  i32.store
+  local.get $1
+  i32.const 0
+  call $object-literal/OmittedTypes#set:uint16
+  local.get $this
+  local.set $1
+  global.get $~lib/memory/__stack_pointer
+  local.get $1
+  i32.store
+  local.get $1
+  i32.const 0
+  call $object-literal/OmittedTypes#set:intsize
+  local.get $this
+  local.set $1
+  global.get $~lib/memory/__stack_pointer
+  local.get $1
+  i32.store
+  local.get $1
+  i32.const 0
+  call $object-literal/OmittedTypes#set:uintsize
+  local.get $this
+  local.set $1
+  global.get $~lib/memory/__stack_pointer
+  local.get $1
+  i32.store
+  local.get $1
+  f64.const 0
+  call $object-literal/OmittedTypes#set:alias
+  local.get $this
+  local.set $1
+  global.get $~lib/memory/__stack_pointer
+  local.get $1
+  i32.store
+  local.get $1
+  i32.const 0
+  call $object-literal/OmittedTypes#set:isTrue
+  local.get $this
+  local.set $1
+  global.get $~lib/memory/__stack_pointer
+  i32.const 8
+  i32.add
+  global.set $~lib/memory/__stack_pointer
+  local.get $1
+ )
  (func $object-literal/OmittedTypes#constructor (param $this i32) (result i32)
   (local $1 i32)
   global.get $~lib/memory/__stack_pointer
@@ -3407,7 +3603,7 @@
   local.get $1
   i32.store offset=4
   local.get $1
-  call $~lib/object/Object#constructor
+  call $~lib/object/Object#raw_constructor
   local.tee $this
   i32.store
   local.get $this
@@ -3805,6 +4001,58 @@
   i32.add
   global.set $~lib/memory/__stack_pointer
  )
+ (func $object-literal/MixedOmitted#raw_constructor (param $this i32) (result i32)
+  (local $1 i32)
+  global.get $~lib/memory/__stack_pointer
+  i32.const 8
+  i32.sub
+  global.set $~lib/memory/__stack_pointer
+  call $~stack_check
+  global.get $~lib/memory/__stack_pointer
+  i64.const 0
+  i64.store
+  global.get $~lib/memory/__stack_pointer
+  local.get $this
+  local.set $1
+  global.get $~lib/memory/__stack_pointer
+  local.get $1
+  i32.store
+  local.get $1
+  call $~lib/object/Object#raw_constructor
+  local.tee $this
+  i32.store offset=4
+  local.get $this
+  local.set $1
+  global.get $~lib/memory/__stack_pointer
+  local.get $1
+  i32.store
+  local.get $1
+  i32.const 0
+  call $object-literal/MixedOmitted#set:simpleType
+  local.get $this
+  local.set $1
+  global.get $~lib/memory/__stack_pointer
+  local.get $1
+  i32.store
+  local.get $1
+  i32.const 0
+  call $object-literal/MixedOmitted#set:complexType
+  local.get $this
+  local.set $1
+  global.get $~lib/memory/__stack_pointer
+  local.get $1
+  i32.store
+  local.get $1
+  f64.const 0
+  call $object-literal/MixedOmitted#set:anotherSimpleType
+  local.get $this
+  local.set $1
+  global.get $~lib/memory/__stack_pointer
+  i32.const 8
+  i32.add
+  global.set $~lib/memory/__stack_pointer
+  local.get $1
+ )
  (func $object-literal/MixedOmitted#constructor (param $this i32) (result i32)
   (local $1 i32)
   global.get $~lib/memory/__stack_pointer
@@ -3832,7 +4080,7 @@
   local.get $1
   i32.store offset=4
   local.get $1
-  call $~lib/object/Object#constructor
+  call $~lib/object/Object#raw_constructor
   local.tee $this
   i32.store
   local.get $this
@@ -3949,6 +4197,127 @@
   i32.add
   global.set $~lib/memory/__stack_pointer
  )
+ (func $object-literal/OmittedFoo#raw_constructor (param $this i32) (result i32)
+  (local $1 i32)
+  global.get $~lib/memory/__stack_pointer
+  i32.const 12
+  i32.sub
+  global.set $~lib/memory/__stack_pointer
+  call $~stack_check
+  global.get $~lib/memory/__stack_pointer
+  i64.const 0
+  i64.store
+  global.get $~lib/memory/__stack_pointer
+  i32.const 0
+  i32.store offset=8
+  global.get $~lib/memory/__stack_pointer
+  local.get $this
+  local.set $1
+  global.get $~lib/memory/__stack_pointer
+  local.get $1
+  i32.store
+  local.get $1
+  call $~lib/object/Object#raw_constructor
+  local.tee $this
+  i32.store offset=4
+  local.get $this
+  local.set $1
+  global.get $~lib/memory/__stack_pointer
+  local.get $1
+  i32.store
+  local.get $1
+  i32.const 640
+  local.set $1
+  global.get $~lib/memory/__stack_pointer
+  local.get $1
+  i32.store offset=8
+  local.get $1
+  call $object-literal/OmittedFoo#set:bar
+  local.get $this
+  local.set $1
+  global.get $~lib/memory/__stack_pointer
+  local.get $1
+  i32.store
+  local.get $1
+  i32.const 672
+  local.set $1
+  global.get $~lib/memory/__stack_pointer
+  local.get $1
+  i32.store offset=8
+  local.get $1
+  call $object-literal/OmittedFoo#set:baz
+  local.get $this
+  local.set $1
+  global.get $~lib/memory/__stack_pointer
+  local.get $1
+  i32.store
+  local.get $1
+  i32.const 0
+  call $object-literal/OmittedFoo#set:quux
+  local.get $this
+  local.set $1
+  global.get $~lib/memory/__stack_pointer
+  local.get $1
+  i32.store
+  local.get $1
+  i32.const 0
+  call $object-literal/OmittedFoo#set:quuz
+  local.get $this
+  local.set $1
+  global.get $~lib/memory/__stack_pointer
+  local.get $1
+  i32.store
+  local.get $1
+  i32.const 0
+  call $object-literal/OmittedFoo#set:corge
+  local.get $this
+  local.set $1
+  global.get $~lib/memory/__stack_pointer
+  local.get $1
+  i32.store
+  local.get $1
+  i32.const 0
+  call $object-literal/OmittedFoo#set:grault
+  local.get $this
+  local.set $1
+  global.get $~lib/memory/__stack_pointer
+  local.get $1
+  i32.store
+  local.get $1
+  i32.const 0
+  call $object-literal/OmittedFoo#set:garply
+  local.get $this
+  local.set $1
+  global.get $~lib/memory/__stack_pointer
+  local.get $1
+  i32.store
+  local.get $1
+  i32.const 0
+  call $object-literal/OmittedFoo#set:waldo
+  local.get $this
+  local.set $1
+  global.get $~lib/memory/__stack_pointer
+  local.get $1
+  i32.store
+  local.get $1
+  i32.const 0
+  call $object-literal/OmittedFoo#set:fred
+  local.get $this
+  local.set $1
+  global.get $~lib/memory/__stack_pointer
+  local.get $1
+  i32.store
+  local.get $1
+  i32.const -1
+  call $object-literal/OmittedFoo#set:qux
+  local.get $this
+  local.set $1
+  global.get $~lib/memory/__stack_pointer
+  i32.const 12
+  i32.add
+  global.set $~lib/memory/__stack_pointer
+  local.get $1
+ )
  (func $object-literal/OmittedFoo#constructor (param $this i32) (result i32)
   (local $1 i32)
   global.get $~lib/memory/__stack_pointer
@@ -3979,7 +4348,7 @@
   local.get $1
   i32.store offset=4
   local.get $1
-  call $~lib/object/Object#constructor
+  call $~lib/object/Object#raw_constructor
   local.tee $this
   i32.store
   local.get $this

--- a/tests/compiler/object-literal.release.wat
+++ b/tests/compiler/object-literal.release.wat
@@ -6,7 +6,6 @@
  (type $4 (func (param i32 i32 i32 i32)))
  (type $5 (func (param i32 i32 i64)))
  (type $6 (func (result i32)))
- (type $7 (func (param i32) (result i32)))
  (import "env" "abort" (func $~lib/builtins/abort (param i32 i32 i32 i32)))
  (global $~lib/rt/itcms/white (mut i32) (i32.const 0))
  (global $~lib/rt/itcms/iter (mut i32) (i32.const 0))
@@ -71,7 +70,7 @@
    local.get $1
    global.set $~lib/rt/itcms/iter
   end
-  block $__inlined_func$~lib/rt/itcms/Object#unlink$205
+  block $__inlined_func$~lib/rt/itcms/Object#unlink$208
    local.get $0
    i32.load offset=4
    i32.const -4
@@ -95,7 +94,7 @@
      call $~lib/builtins/abort
      unreachable
     end
-    br $__inlined_func$~lib/rt/itcms/Object#unlink$205
+    br $__inlined_func$~lib/rt/itcms/Object#unlink$208
    end
    local.get $0
    i32.load offset=8
@@ -1786,7 +1785,7 @@
      end
     end
    end
-   block $__inlined_func$~lib/util/string/compareImpl$83
+   block $__inlined_func$~lib/util/string/compareImpl$84
     loop $while-continue|1
      local.get $0
      local.tee $3
@@ -1806,7 +1805,7 @@
       local.get $4
       local.get $5
       i32.ne
-      br_if $__inlined_func$~lib/util/string/compareImpl$83
+      br_if $__inlined_func$~lib/util/string/compareImpl$84
       local.get $2
       i32.const 2
       i32.add
@@ -2347,8 +2346,6 @@
    i32.store offset=4
    global.get $~lib/memory/__stack_pointer
    local.get $1
-   call $~lib/object/Object#constructor
-   local.tee $1
    i32.store
    global.get $~lib/memory/__stack_pointer
    local.get $1
@@ -2503,7 +2500,7 @@
    i32.const 1
    i32.shl
    local.set $3
-   block $__inlined_func$~lib/string/String#substring$210
+   block $__inlined_func$~lib/string/String#substring$213
     local.get $2
     i32.const 0
     local.get $2
@@ -2524,7 +2521,7 @@
      global.set $~lib/memory/__stack_pointer
      i32.const 1568
      local.set $0
-     br $__inlined_func$~lib/string/String#substring$210
+     br $__inlined_func$~lib/string/String#substring$213
     end
     local.get $3
     i32.eqz
@@ -2541,7 +2538,7 @@
      global.set $~lib/memory/__stack_pointer
      i32.const 1056
      local.set $0
-     br $__inlined_func$~lib/string/String#substring$210
+     br $__inlined_func$~lib/string/String#substring$213
     end
     global.get $~lib/memory/__stack_pointer
     local.get $2
@@ -2638,8 +2635,6 @@
    i32.store offset=4
    global.get $~lib/memory/__stack_pointer
    local.get $0
-   call $~lib/object/Object#constructor
-   local.tee $0
    i32.store
    global.get $~lib/memory/__stack_pointer
    local.get $0
@@ -2801,8 +2796,6 @@
    i32.store offset=4
    global.get $~lib/memory/__stack_pointer
    local.get $1
-   call $~lib/object/Object#constructor
-   local.tee $1
    i32.store
    global.get $~lib/memory/__stack_pointer
    local.get $1
@@ -2950,8 +2943,6 @@
    i32.store offset=4
    global.get $~lib/memory/__stack_pointer
    local.get $0
-   call $~lib/object/Object#constructor
-   local.tee $0
    i32.store
    global.get $~lib/memory/__stack_pointer
    local.get $0
@@ -3122,40 +3113,5 @@
   i32.const 1
   call $~lib/builtins/abort
   unreachable
- )
- (func $~lib/object/Object#constructor (param $0 i32) (result i32)
-  global.get $~lib/memory/__stack_pointer
-  i32.const 4
-  i32.sub
-  global.set $~lib/memory/__stack_pointer
-  global.get $~lib/memory/__stack_pointer
-  i32.const 1748
-  i32.lt_s
-  if
-   i32.const 34544
-   i32.const 34592
-   i32.const 1
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  global.get $~lib/memory/__stack_pointer
-  i32.const 0
-  i32.store
-  local.get $0
-  i32.eqz
-  if
-   global.get $~lib/memory/__stack_pointer
-   i32.const 0
-   i32.const 0
-   call $~lib/rt/itcms/__new
-   local.tee $0
-   i32.store
-  end
-  global.get $~lib/memory/__stack_pointer
-  i32.const 4
-  i32.add
-  global.set $~lib/memory/__stack_pointer
-  local.get $0
  )
 )

--- a/tests/compiler/operator-overload-non-ambiguity.debug.wat
+++ b/tests/compiler/operator-overload-non-ambiguity.debug.wat
@@ -42,6 +42,9 @@
  (elem $0 (i32.const 1))
  (export "memory" (memory $0))
  (start $~start)
+ (func $~lib/object/Object#raw_constructor (param $this i32) (result i32)
+  local.get $this
+ )
  (func $~lib/rt/itcms/Object#set:nextWithColor (param $this i32) (param $nextWithColor i32)
   local.get $this
   local.get $nextWithColor
@@ -2336,6 +2339,34 @@
    unreachable
   end
  )
+ (func $operator-overload-non-ambiguity/Base#raw_constructor (param $this i32) (result i32)
+  (local $1 i32)
+  global.get $~lib/memory/__stack_pointer
+  i32.const 8
+  i32.sub
+  global.set $~lib/memory/__stack_pointer
+  call $~stack_check
+  global.get $~lib/memory/__stack_pointer
+  i64.const 0
+  i64.store
+  global.get $~lib/memory/__stack_pointer
+  local.get $this
+  local.set $1
+  global.get $~lib/memory/__stack_pointer
+  local.get $1
+  i32.store
+  local.get $1
+  call $~lib/object/Object#raw_constructor
+  local.tee $this
+  i32.store offset=4
+  local.get $this
+  local.set $1
+  global.get $~lib/memory/__stack_pointer
+  i32.const 8
+  i32.add
+  global.set $~lib/memory/__stack_pointer
+  local.get $1
+ )
  (func $operator-overload-non-ambiguity/Base#constructor (param $this i32) (result i32)
   (local $1 i32)
   global.get $~lib/memory/__stack_pointer
@@ -2363,9 +2394,37 @@
   local.get $1
   i32.store offset=4
   local.get $1
-  call $~lib/object/Object#constructor
+  call $~lib/object/Object#raw_constructor
   local.tee $this
   i32.store
+  local.get $this
+  local.set $1
+  global.get $~lib/memory/__stack_pointer
+  i32.const 8
+  i32.add
+  global.set $~lib/memory/__stack_pointer
+  local.get $1
+ )
+ (func $operator-overload-non-ambiguity/P1#raw_constructor (param $this i32) (result i32)
+  (local $1 i32)
+  global.get $~lib/memory/__stack_pointer
+  i32.const 8
+  i32.sub
+  global.set $~lib/memory/__stack_pointer
+  call $~stack_check
+  global.get $~lib/memory/__stack_pointer
+  i64.const 0
+  i64.store
+  global.get $~lib/memory/__stack_pointer
+  local.get $this
+  local.set $1
+  global.get $~lib/memory/__stack_pointer
+  local.get $1
+  i32.store
+  local.get $1
+  call $operator-overload-non-ambiguity/Base#raw_constructor
+  local.tee $this
+  i32.store offset=4
   local.get $this
   local.set $1
   global.get $~lib/memory/__stack_pointer
@@ -2401,9 +2460,37 @@
   local.get $1
   i32.store offset=4
   local.get $1
-  call $operator-overload-non-ambiguity/Base#constructor
+  call $operator-overload-non-ambiguity/Base#raw_constructor
   local.tee $this
   i32.store
+  local.get $this
+  local.set $1
+  global.get $~lib/memory/__stack_pointer
+  i32.const 8
+  i32.add
+  global.set $~lib/memory/__stack_pointer
+  local.get $1
+ )
+ (func $operator-overload-non-ambiguity/P2#raw_constructor (param $this i32) (result i32)
+  (local $1 i32)
+  global.get $~lib/memory/__stack_pointer
+  i32.const 8
+  i32.sub
+  global.set $~lib/memory/__stack_pointer
+  call $~stack_check
+  global.get $~lib/memory/__stack_pointer
+  i64.const 0
+  i64.store
+  global.get $~lib/memory/__stack_pointer
+  local.get $this
+  local.set $1
+  global.get $~lib/memory/__stack_pointer
+  local.get $1
+  i32.store
+  local.get $1
+  call $operator-overload-non-ambiguity/Base#raw_constructor
+  local.tee $this
+  i32.store offset=4
   local.get $this
   local.set $1
   global.get $~lib/memory/__stack_pointer
@@ -2439,9 +2526,37 @@
   local.get $1
   i32.store offset=4
   local.get $1
-  call $operator-overload-non-ambiguity/Base#constructor
+  call $operator-overload-non-ambiguity/Base#raw_constructor
   local.tee $this
   i32.store
+  local.get $this
+  local.set $1
+  global.get $~lib/memory/__stack_pointer
+  i32.const 8
+  i32.add
+  global.set $~lib/memory/__stack_pointer
+  local.get $1
+ )
+ (func $operator-overload-non-ambiguity/T1#raw_constructor (param $this i32) (result i32)
+  (local $1 i32)
+  global.get $~lib/memory/__stack_pointer
+  i32.const 8
+  i32.sub
+  global.set $~lib/memory/__stack_pointer
+  call $~stack_check
+  global.get $~lib/memory/__stack_pointer
+  i64.const 0
+  i64.store
+  global.get $~lib/memory/__stack_pointer
+  local.get $this
+  local.set $1
+  global.get $~lib/memory/__stack_pointer
+  local.get $1
+  i32.store
+  local.get $1
+  call $~lib/object/Object#raw_constructor
+  local.tee $this
+  i32.store offset=4
   local.get $this
   local.set $1
   global.get $~lib/memory/__stack_pointer
@@ -2477,7 +2592,7 @@
   local.get $1
   i32.store offset=4
   local.get $1
-  call $~lib/object/Object#constructor
+  call $~lib/object/Object#raw_constructor
   local.tee $this
   i32.store
   local.get $this

--- a/tests/compiler/operator-overload-non-ambiguity.release.wat
+++ b/tests/compiler/operator-overload-non-ambiguity.release.wat
@@ -1,6 +1,6 @@
 (module
- (type $0 (func (param i32) (result i32)))
- (type $1 (func))
+ (type $0 (func))
+ (type $1 (func (param i32) (result i32)))
  (type $2 (func (param i32)))
  (type $3 (func (param i32 i32)))
  (type $4 (func (result i32)))
@@ -117,7 +117,7 @@
     local.get $0
     global.set $~lib/rt/itcms/iter
    end
-   block $__inlined_func$~lib/rt/itcms/Object#unlink$116
+   block $__inlined_func$~lib/rt/itcms/Object#unlink$117
     local.get $1
     i32.load offset=4
     i32.const -4
@@ -141,7 +141,7 @@
       call $~lib/builtins/abort
       unreachable
      end
-     br $__inlined_func$~lib/rt/itcms/Object#unlink$116
+     br $__inlined_func$~lib/rt/itcms/Object#unlink$117
     end
     local.get $1
     i32.load offset=8
@@ -1471,7 +1471,7 @@
    i32.store offset=4
    global.get $~lib/memory/__stack_pointer
    local.get $0
-   call $operator-overload-non-ambiguity/Base#constructor
+   call $operator-overload-non-ambiguity/Base#raw_constructor
    local.tee $0
    i32.store
    global.get $~lib/memory/__stack_pointer
@@ -1502,7 +1502,7 @@
    i32.store offset=4
    global.get $~lib/memory/__stack_pointer
    local.get $0
-   call $operator-overload-non-ambiguity/Base#constructor
+   call $operator-overload-non-ambiguity/Base#raw_constructor
    local.tee $0
    i32.store
    global.get $~lib/memory/__stack_pointer
@@ -1535,7 +1535,7 @@
   call $~lib/builtins/abort
   unreachable
  )
- (func $operator-overload-non-ambiguity/Base#constructor (param $0 i32) (result i32)
+ (func $operator-overload-non-ambiguity/Base#raw_constructor (param $0 i32) (result i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 8
   i32.sub
@@ -1554,23 +1554,12 @@
   global.get $~lib/memory/__stack_pointer
   i64.const 0
   i64.store
+  global.get $~lib/memory/__stack_pointer
   local.get $0
-  i32.eqz
-  if
-   global.get $~lib/memory/__stack_pointer
-   i32.const 5
-   call $~lib/rt/itcms/__new
-   local.tee $0
-   i32.store
-  end
+  i32.store
   global.get $~lib/memory/__stack_pointer
   local.get $0
   i32.store offset=4
-  global.get $~lib/memory/__stack_pointer
-  local.get $0
-  call $~lib/object/Object#constructor
-  local.tee $0
-  i32.store
   global.get $~lib/memory/__stack_pointer
   i32.const 8
   i32.add
@@ -1607,45 +1596,9 @@
   i32.store offset=4
   global.get $~lib/memory/__stack_pointer
   local.get $0
-  call $~lib/object/Object#constructor
-  local.tee $0
   i32.store
   global.get $~lib/memory/__stack_pointer
   i32.const 8
-  i32.add
-  global.set $~lib/memory/__stack_pointer
-  local.get $0
- )
- (func $~lib/object/Object#constructor (param $0 i32) (result i32)
-  global.get $~lib/memory/__stack_pointer
-  i32.const 4
-  i32.sub
-  global.set $~lib/memory/__stack_pointer
-  global.get $~lib/memory/__stack_pointer
-  i32.const 1572
-  i32.lt_s
-  if
-   i32.const 34368
-   i32.const 34416
-   i32.const 1
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  global.get $~lib/memory/__stack_pointer
-  i32.const 0
-  i32.store
-  local.get $0
-  i32.eqz
-  if
-   global.get $~lib/memory/__stack_pointer
-   i32.const 0
-   call $~lib/rt/itcms/__new
-   local.tee $0
-   i32.store
-  end
-  global.get $~lib/memory/__stack_pointer
-  i32.const 4
   i32.add
   global.set $~lib/memory/__stack_pointer
   local.get $0

--- a/tests/compiler/optional-typeparameters.debug.wat
+++ b/tests/compiler/optional-typeparameters.debug.wat
@@ -55,6 +55,9 @@
   local.get $a
   return
  )
+ (func $~lib/object/Object#raw_constructor (param $this i32) (result i32)
+  local.get $this
+ )
  (func $~lib/rt/itcms/Object#set:nextWithColor (param $this i32) (param $nextWithColor i32)
   local.get $this
   local.get $nextWithColor
@@ -2401,6 +2404,34 @@
    unreachable
   end
  )
+ (func $"optional-typeparameters/TestConcrete<i32,i32>#raw_constructor" (param $this i32) (result i32)
+  (local $1 i32)
+  global.get $~lib/memory/__stack_pointer
+  i32.const 8
+  i32.sub
+  global.set $~lib/memory/__stack_pointer
+  call $~stack_check
+  global.get $~lib/memory/__stack_pointer
+  i64.const 0
+  i64.store
+  global.get $~lib/memory/__stack_pointer
+  local.get $this
+  local.set $1
+  global.get $~lib/memory/__stack_pointer
+  local.get $1
+  i32.store
+  local.get $1
+  call $~lib/object/Object#raw_constructor
+  local.tee $this
+  i32.store offset=4
+  local.get $this
+  local.set $1
+  global.get $~lib/memory/__stack_pointer
+  i32.const 8
+  i32.add
+  global.set $~lib/memory/__stack_pointer
+  local.get $1
+ )
  (func $"optional-typeparameters/TestConcrete<i32,i32>#constructor" (param $this i32) (result i32)
   (local $1 i32)
   global.get $~lib/memory/__stack_pointer
@@ -2428,9 +2459,37 @@
   local.get $1
   i32.store offset=4
   local.get $1
-  call $~lib/object/Object#constructor
+  call $~lib/object/Object#raw_constructor
   local.tee $this
   i32.store
+  local.get $this
+  local.set $1
+  global.get $~lib/memory/__stack_pointer
+  i32.const 8
+  i32.add
+  global.set $~lib/memory/__stack_pointer
+  local.get $1
+ )
+ (func $"optional-typeparameters/TestDerived<f64,f64>#raw_constructor" (param $this i32) (result i32)
+  (local $1 i32)
+  global.get $~lib/memory/__stack_pointer
+  i32.const 8
+  i32.sub
+  global.set $~lib/memory/__stack_pointer
+  call $~stack_check
+  global.get $~lib/memory/__stack_pointer
+  i64.const 0
+  i64.store
+  global.get $~lib/memory/__stack_pointer
+  local.get $this
+  local.set $1
+  global.get $~lib/memory/__stack_pointer
+  local.get $1
+  i32.store
+  local.get $1
+  call $~lib/object/Object#raw_constructor
+  local.tee $this
+  i32.store offset=4
   local.get $this
   local.set $1
   global.get $~lib/memory/__stack_pointer
@@ -2466,9 +2525,37 @@
   local.get $1
   i32.store offset=4
   local.get $1
-  call $~lib/object/Object#constructor
+  call $~lib/object/Object#raw_constructor
   local.tee $this
   i32.store
+  local.get $this
+  local.set $1
+  global.get $~lib/memory/__stack_pointer
+  i32.const 8
+  i32.add
+  global.set $~lib/memory/__stack_pointer
+  local.get $1
+ )
+ (func $optional-typeparameters/TestMethodDerived<~lib/string/String>#raw_constructor (param $this i32) (result i32)
+  (local $1 i32)
+  global.get $~lib/memory/__stack_pointer
+  i32.const 8
+  i32.sub
+  global.set $~lib/memory/__stack_pointer
+  call $~stack_check
+  global.get $~lib/memory/__stack_pointer
+  i64.const 0
+  i64.store
+  global.get $~lib/memory/__stack_pointer
+  local.get $this
+  local.set $1
+  global.get $~lib/memory/__stack_pointer
+  local.get $1
+  i32.store
+  local.get $1
+  call $~lib/object/Object#raw_constructor
+  local.tee $this
+  i32.store offset=4
   local.get $this
   local.set $1
   global.get $~lib/memory/__stack_pointer
@@ -2504,9 +2591,37 @@
   local.get $1
   i32.store offset=4
   local.get $1
-  call $~lib/object/Object#constructor
+  call $~lib/object/Object#raw_constructor
   local.tee $this
   i32.store
+  local.get $this
+  local.set $1
+  global.get $~lib/memory/__stack_pointer
+  i32.const 8
+  i32.add
+  global.set $~lib/memory/__stack_pointer
+  local.get $1
+ )
+ (func $optional-typeparameters/TestMethodDerived2<f64>#raw_constructor (param $this i32) (result i32)
+  (local $1 i32)
+  global.get $~lib/memory/__stack_pointer
+  i32.const 8
+  i32.sub
+  global.set $~lib/memory/__stack_pointer
+  call $~stack_check
+  global.get $~lib/memory/__stack_pointer
+  i64.const 0
+  i64.store
+  global.get $~lib/memory/__stack_pointer
+  local.get $this
+  local.set $1
+  global.get $~lib/memory/__stack_pointer
+  local.get $1
+  i32.store
+  local.get $1
+  call $~lib/object/Object#raw_constructor
+  local.tee $this
+  i32.store offset=4
   local.get $this
   local.set $1
   global.get $~lib/memory/__stack_pointer
@@ -2542,7 +2657,7 @@
   local.get $1
   i32.store offset=4
   local.get $1
-  call $~lib/object/Object#constructor
+  call $~lib/object/Object#raw_constructor
   local.tee $this
   i32.store
   local.get $this

--- a/tests/compiler/optional-typeparameters.release.wat
+++ b/tests/compiler/optional-typeparameters.release.wat
@@ -1,8 +1,8 @@
 (module
  (type $0 (func))
- (type $1 (func (param i32) (result i32)))
- (type $2 (func (param i32)))
- (type $3 (func (param i32 i32)))
+ (type $1 (func (param i32)))
+ (type $2 (func (param i32 i32)))
+ (type $3 (func (param i32) (result i32)))
  (type $4 (func (param i32 i32 i32 i32)))
  (type $5 (func (param i32 i32 i64)))
  (type $6 (func (result i32)))
@@ -143,7 +143,7 @@
     local.get $0
     global.set $~lib/rt/itcms/iter
    end
-   block $__inlined_func$~lib/rt/itcms/Object#unlink$131
+   block $__inlined_func$~lib/rt/itcms/Object#unlink$134
     local.get $1
     i32.load offset=4
     i32.const -4
@@ -167,7 +167,7 @@
       call $~lib/builtins/abort
       unreachable
      end
-     br $__inlined_func$~lib/rt/itcms/Object#unlink$131
+     br $__inlined_func$~lib/rt/itcms/Object#unlink$134
     end
     local.get $1
     i32.load offset=8
@@ -1566,8 +1566,6 @@
    i32.store offset=4
    global.get $~lib/memory/__stack_pointer
    local.get $0
-   call $~lib/object/Object#constructor
-   local.tee $0
    i32.store
    global.get $~lib/memory/__stack_pointer
    i32.const 8
@@ -1599,8 +1597,6 @@
    i32.store offset=4
    global.get $~lib/memory/__stack_pointer
    local.get $0
-   call $~lib/object/Object#constructor
-   local.tee $0
    i32.store
    global.get $~lib/memory/__stack_pointer
    i32.const 8
@@ -1632,8 +1628,6 @@
    i32.store offset=4
    global.get $~lib/memory/__stack_pointer
    local.get $0
-   call $~lib/object/Object#constructor
-   local.tee $0
    i32.store
    global.get $~lib/memory/__stack_pointer
    i32.const 8
@@ -1665,8 +1659,6 @@
    i32.store offset=4
    global.get $~lib/memory/__stack_pointer
    local.get $0
-   call $~lib/object/Object#constructor
-   local.tee $0
    i32.store
    global.get $~lib/memory/__stack_pointer
    i32.const 8
@@ -1711,39 +1703,5 @@
   i32.const 1
   call $~lib/builtins/abort
   unreachable
- )
- (func $~lib/object/Object#constructor (param $0 i32) (result i32)
-  global.get $~lib/memory/__stack_pointer
-  i32.const 4
-  i32.sub
-  global.set $~lib/memory/__stack_pointer
-  global.get $~lib/memory/__stack_pointer
-  i32.const 1480
-  i32.lt_s
-  if
-   i32.const 34272
-   i32.const 34320
-   i32.const 1
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  global.get $~lib/memory/__stack_pointer
-  i32.const 0
-  i32.store
-  local.get $0
-  i32.eqz
-  if
-   global.get $~lib/memory/__stack_pointer
-   i32.const 0
-   call $~lib/rt/itcms/__new
-   local.tee $0
-   i32.store
-  end
-  global.get $~lib/memory/__stack_pointer
-  i32.const 4
-  i32.add
-  global.set $~lib/memory/__stack_pointer
-  local.get $0
  )
 )

--- a/tests/compiler/resolve-access.debug.wat
+++ b/tests/compiler/resolve-access.debug.wat
@@ -2950,6 +2950,9 @@
   call $~lib/util/number/utoa64
   return
  )
+ (func $~lib/object/Object#raw_constructor (param $this i32) (result i32)
+  local.get $this
+ )
  (func $resolve-access/Container#set:foo (param $this i32) (param $foo i64)
   local.get $this
   local.get $foo
@@ -3179,6 +3182,42 @@
   local.get $2
   return
  )
+ (func $resolve-access/Container#raw_constructor (param $this i32) (result i32)
+  (local $1 i32)
+  global.get $~lib/memory/__stack_pointer
+  i32.const 8
+  i32.sub
+  global.set $~lib/memory/__stack_pointer
+  call $~stack_check
+  global.get $~lib/memory/__stack_pointer
+  i64.const 0
+  i64.store
+  global.get $~lib/memory/__stack_pointer
+  local.get $this
+  local.set $1
+  global.get $~lib/memory/__stack_pointer
+  local.get $1
+  i32.store
+  local.get $1
+  call $~lib/object/Object#raw_constructor
+  local.tee $this
+  i32.store offset=4
+  local.get $this
+  local.set $1
+  global.get $~lib/memory/__stack_pointer
+  local.get $1
+  i32.store
+  local.get $1
+  i64.const 0
+  call $resolve-access/Container#set:foo
+  local.get $this
+  local.set $1
+  global.get $~lib/memory/__stack_pointer
+  i32.const 8
+  i32.add
+  global.set $~lib/memory/__stack_pointer
+  local.get $1
+ )
  (func $resolve-access/Container#constructor (param $this i32) (result i32)
   (local $1 i32)
   global.get $~lib/memory/__stack_pointer
@@ -3206,7 +3245,7 @@
   local.get $1
   i32.store offset=4
   local.get $1
-  call $~lib/object/Object#constructor
+  call $~lib/object/Object#raw_constructor
   local.tee $this
   i32.store
   local.get $this

--- a/tests/compiler/resolve-access.release.wat
+++ b/tests/compiler/resolve-access.release.wat
@@ -124,7 +124,7 @@
    local.get $1
    global.set $~lib/rt/itcms/iter
   end
-  block $__inlined_func$~lib/rt/itcms/Object#unlink$143
+  block $__inlined_func$~lib/rt/itcms/Object#unlink$142
    local.get $0
    i32.load offset=4
    i32.const -4
@@ -148,7 +148,7 @@
      call $~lib/builtins/abort
      unreachable
     end
-    br $__inlined_func$~lib/rt/itcms/Object#unlink$143
+    br $__inlined_func$~lib/rt/itcms/Object#unlink$142
    end
    local.get $0
    i32.load offset=8
@@ -2170,75 +2170,47 @@
  )
  (func $resolve-access/Container#constructor (result i32)
   (local $0 i32)
-  (local $1 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 8
   i32.sub
   global.set $~lib/memory/__stack_pointer
-  block $folding-inner0
-   global.get $~lib/memory/__stack_pointer
-   i32.const 3328
-   i32.lt_s
-   br_if $folding-inner0
-   global.get $~lib/memory/__stack_pointer
-   i64.const 0
-   i64.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 8
-   i32.const 6
-   call $~lib/rt/itcms/__new
-   local.tee $0
-   i32.store
-   global.get $~lib/memory/__stack_pointer
-   global.get $~lib/memory/__stack_pointer
-   local.get $0
-   i32.store offset=4
-   global.get $~lib/memory/__stack_pointer
-   i32.const 4
-   i32.sub
-   global.set $~lib/memory/__stack_pointer
-   global.get $~lib/memory/__stack_pointer
-   i32.const 3328
-   i32.lt_s
-   br_if $folding-inner0
-   global.get $~lib/memory/__stack_pointer
-   i32.const 0
-   i32.store
-   local.get $0
-   i32.eqz
-   if
-    global.get $~lib/memory/__stack_pointer
-    i32.const 0
-    i32.const 0
-    call $~lib/rt/itcms/__new
-    local.tee $0
-    i32.store
-   end
-   global.get $~lib/memory/__stack_pointer
-   i32.const 4
-   i32.add
-   global.set $~lib/memory/__stack_pointer
-   local.get $0
-   i32.store
-   global.get $~lib/memory/__stack_pointer
-   local.get $0
-   i32.store offset=4
-   local.get $0
-   i64.const 0
-   i64.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 8
-   i32.add
-   global.set $~lib/memory/__stack_pointer
-   local.get $0
-   return
+  global.get $~lib/memory/__stack_pointer
+  i32.const 3328
+  i32.lt_s
+  if
+   i32.const 36128
+   i32.const 36176
+   i32.const 1
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
   end
-  i32.const 36128
-  i32.const 36176
-  i32.const 1
-  i32.const 1
-  call $~lib/builtins/abort
-  unreachable
+  global.get $~lib/memory/__stack_pointer
+  i64.const 0
+  i64.store
+  global.get $~lib/memory/__stack_pointer
+  i32.const 8
+  i32.const 6
+  call $~lib/rt/itcms/__new
+  local.tee $0
+  i32.store
+  global.get $~lib/memory/__stack_pointer
+  local.get $0
+  i32.store offset=4
+  global.get $~lib/memory/__stack_pointer
+  local.get $0
+  i32.store
+  global.get $~lib/memory/__stack_pointer
+  local.get $0
+  i32.store offset=4
+  local.get $0
+  i64.const 0
+  i64.store
+  global.get $~lib/memory/__stack_pointer
+  i32.const 8
+  i32.add
+  global.set $~lib/memory/__stack_pointer
+  local.get $0
  )
  (func $resolve-access/fieldAccess (result i32)
   (local $0 i32)

--- a/tests/compiler/resolve-binary.debug.wat
+++ b/tests/compiler/resolve-binary.debug.wat
@@ -5481,6 +5481,9 @@
   local.get $out
   return
  )
+ (func $~lib/object/Object#raw_constructor (param $this i32) (result i32)
+  local.get $this
+ )
  (func $resolve-binary/Foo#lt (param $this i32) (param $other i32) (result i32)
   i32.const 9824
   return
@@ -5758,6 +5761,34 @@
   local.get $3
   return
  )
+ (func $resolve-binary/Foo#raw_constructor (param $this i32) (result i32)
+  (local $1 i32)
+  global.get $~lib/memory/__stack_pointer
+  i32.const 8
+  i32.sub
+  global.set $~lib/memory/__stack_pointer
+  call $~stack_check
+  global.get $~lib/memory/__stack_pointer
+  i64.const 0
+  i64.store
+  global.get $~lib/memory/__stack_pointer
+  local.get $this
+  local.set $1
+  global.get $~lib/memory/__stack_pointer
+  local.get $1
+  i32.store
+  local.get $1
+  call $~lib/object/Object#raw_constructor
+  local.tee $this
+  i32.store offset=4
+  local.get $this
+  local.set $1
+  global.get $~lib/memory/__stack_pointer
+  i32.const 8
+  i32.add
+  global.set $~lib/memory/__stack_pointer
+  local.get $1
+ )
  (func $resolve-binary/Foo#constructor (param $this i32) (result i32)
   (local $1 i32)
   global.get $~lib/memory/__stack_pointer
@@ -5785,9 +5816,37 @@
   local.get $1
   i32.store offset=4
   local.get $1
-  call $~lib/object/Object#constructor
+  call $~lib/object/Object#raw_constructor
   local.tee $this
   i32.store
+  local.get $this
+  local.set $1
+  global.get $~lib/memory/__stack_pointer
+  i32.const 8
+  i32.add
+  global.set $~lib/memory/__stack_pointer
+  local.get $1
+ )
+ (func $resolve-binary/Bar#raw_constructor (param $this i32) (result i32)
+  (local $1 i32)
+  global.get $~lib/memory/__stack_pointer
+  i32.const 8
+  i32.sub
+  global.set $~lib/memory/__stack_pointer
+  call $~stack_check
+  global.get $~lib/memory/__stack_pointer
+  i64.const 0
+  i64.store
+  global.get $~lib/memory/__stack_pointer
+  local.get $this
+  local.set $1
+  global.get $~lib/memory/__stack_pointer
+  local.get $1
+  i32.store
+  local.get $1
+  call $~lib/object/Object#raw_constructor
+  local.tee $this
+  i32.store offset=4
   local.get $this
   local.set $1
   global.get $~lib/memory/__stack_pointer
@@ -5823,9 +5882,37 @@
   local.get $1
   i32.store offset=4
   local.get $1
-  call $~lib/object/Object#constructor
+  call $~lib/object/Object#raw_constructor
   local.tee $this
   i32.store
+  local.get $this
+  local.set $1
+  global.get $~lib/memory/__stack_pointer
+  i32.const 8
+  i32.add
+  global.set $~lib/memory/__stack_pointer
+  local.get $1
+ )
+ (func $resolve-binary/Baz#raw_constructor (param $this i32) (result i32)
+  (local $1 i32)
+  global.get $~lib/memory/__stack_pointer
+  i32.const 8
+  i32.sub
+  global.set $~lib/memory/__stack_pointer
+  call $~stack_check
+  global.get $~lib/memory/__stack_pointer
+  i64.const 0
+  i64.store
+  global.get $~lib/memory/__stack_pointer
+  local.get $this
+  local.set $1
+  global.get $~lib/memory/__stack_pointer
+  local.get $1
+  i32.store
+  local.get $1
+  call $~lib/object/Object#raw_constructor
+  local.tee $this
+  i32.store offset=4
   local.get $this
   local.set $1
   global.get $~lib/memory/__stack_pointer
@@ -5861,7 +5948,7 @@
   local.get $1
   i32.store offset=4
   local.get $1
-  call $~lib/object/Object#constructor
+  call $~lib/object/Object#raw_constructor
   local.tee $this
   i32.store
   local.get $this

--- a/tests/compiler/resolve-binary.release.wat
+++ b/tests/compiler/resolve-binary.release.wat
@@ -4,10 +4,10 @@
  (type $2 (func (result i32)))
  (type $3 (func (param i32)))
  (type $4 (func (param i32 i32)))
- (type $5 (func (param i32) (result i32)))
- (type $6 (func (param i32 i32 i32 i32)))
- (type $7 (func (param i32 i32 i64)))
- (type $8 (func (param i32 i32 i32)))
+ (type $5 (func (param i32 i32 i32 i32)))
+ (type $6 (func (param i32 i32 i64)))
+ (type $7 (func (param i32 i32 i32)))
+ (type $8 (func (param i32) (result i32)))
  (type $9 (func (param i64 i64 i32 i64) (result i32)))
  (import "env" "abort" (func $~lib/builtins/abort (param i32 i32 i32 i32)))
  (global $resolve-binary/a (mut i32) (i32.const 0))
@@ -348,7 +348,7 @@
     local.get $0
     global.set $~lib/rt/itcms/iter
    end
-   block $__inlined_func$~lib/rt/itcms/Object#unlink$165
+   block $__inlined_func$~lib/rt/itcms/Object#unlink$167
     local.get $1
     i32.load offset=4
     i32.const -4
@@ -372,7 +372,7 @@
       call $~lib/builtins/abort
       unreachable
      end
-     br $__inlined_func$~lib/rt/itcms/Object#unlink$165
+     br $__inlined_func$~lib/rt/itcms/Object#unlink$167
     end
     local.get $1
     i32.load offset=8
@@ -3101,8 +3101,6 @@
   i32.store offset=4
   global.get $~lib/memory/__stack_pointer
   local.get $0
-  call $~lib/object/Object#constructor
-  local.tee $0
   i32.store
   global.get $~lib/memory/__stack_pointer
   i32.const 8
@@ -3981,8 +3979,6 @@
    i32.store offset=4
    global.get $~lib/memory/__stack_pointer
    local.get $0
-   call $~lib/object/Object#constructor
-   local.tee $0
    i32.store
    global.get $~lib/memory/__stack_pointer
    i32.const 8
@@ -4375,8 +4371,6 @@
    i32.store offset=4
    global.get $~lib/memory/__stack_pointer
    local.get $0
-   call $~lib/object/Object#constructor
-   local.tee $0
    i32.store
    global.get $~lib/memory/__stack_pointer
    i32.const 8
@@ -4432,40 +4426,5 @@
   i32.const 1
   call $~lib/builtins/abort
   unreachable
- )
- (func $~lib/object/Object#constructor (param $0 i32) (result i32)
-  global.get $~lib/memory/__stack_pointer
-  i32.const 4
-  i32.sub
-  global.set $~lib/memory/__stack_pointer
-  global.get $~lib/memory/__stack_pointer
-  i32.const 11248
-  i32.lt_s
-  if
-   i32.const 44048
-   i32.const 44096
-   i32.const 1
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  global.get $~lib/memory/__stack_pointer
-  i32.const 0
-  i32.store
-  local.get $0
-  i32.eqz
-  if
-   global.get $~lib/memory/__stack_pointer
-   i32.const 0
-   i32.const 0
-   call $~lib/rt/itcms/__new
-   local.tee $0
-   i32.store
-  end
-  global.get $~lib/memory/__stack_pointer
-  i32.const 4
-  i32.add
-  global.set $~lib/memory/__stack_pointer
-  local.get $0
  )
 )

--- a/tests/compiler/resolve-elementaccess.debug.wat
+++ b/tests/compiler/resolve-elementaccess.debug.wat
@@ -4793,6 +4793,35 @@
   global.set $~lib/memory/__stack_pointer
   local.get $2
  )
+ (func $resolve-elementaccess/Buffer#raw_constructor (param $this i32) (param $length i32) (result i32)
+  (local $2 i32)
+  global.get $~lib/memory/__stack_pointer
+  i32.const 8
+  i32.sub
+  global.set $~lib/memory/__stack_pointer
+  call $~stack_check
+  global.get $~lib/memory/__stack_pointer
+  i64.const 0
+  i64.store
+  global.get $~lib/memory/__stack_pointer
+  local.get $this
+  local.set $2
+  global.get $~lib/memory/__stack_pointer
+  local.get $2
+  i32.store
+  local.get $2
+  local.get $length
+  call $~lib/typedarray/Uint8Array#constructor
+  local.tee $this
+  i32.store offset=4
+  local.get $this
+  local.set $2
+  global.get $~lib/memory/__stack_pointer
+  i32.const 8
+  i32.add
+  global.set $~lib/memory/__stack_pointer
+  local.get $2
+ )
  (func $resolve-elementaccess/Buffer#constructor (param $this i32) (param $length i32) (result i32)
   (local $2 i32)
   global.get $~lib/memory/__stack_pointer

--- a/tests/compiler/resolve-new.debug.wat
+++ b/tests/compiler/resolve-new.debug.wat
@@ -42,6 +42,9 @@
  (elem $0 (i32.const 1))
  (export "memory" (memory $0))
  (start $~start)
+ (func $~lib/object/Object#raw_constructor (param $this i32) (result i32)
+  local.get $this
+ )
  (func $~lib/rt/itcms/Object#set:nextWithColor (param $this i32) (param $nextWithColor i32)
   local.get $this
   local.get $nextWithColor
@@ -2316,6 +2319,34 @@
    unreachable
   end
  )
+ (func $resolve-new/Foo#raw_constructor (param $this i32) (result i32)
+  (local $1 i32)
+  global.get $~lib/memory/__stack_pointer
+  i32.const 8
+  i32.sub
+  global.set $~lib/memory/__stack_pointer
+  call $~stack_check
+  global.get $~lib/memory/__stack_pointer
+  i64.const 0
+  i64.store
+  global.get $~lib/memory/__stack_pointer
+  local.get $this
+  local.set $1
+  global.get $~lib/memory/__stack_pointer
+  local.get $1
+  i32.store
+  local.get $1
+  call $~lib/object/Object#raw_constructor
+  local.tee $this
+  i32.store offset=4
+  local.get $this
+  local.set $1
+  global.get $~lib/memory/__stack_pointer
+  i32.const 8
+  i32.add
+  global.set $~lib/memory/__stack_pointer
+  local.get $1
+ )
  (func $resolve-new/Foo#constructor (param $this i32) (result i32)
   (local $1 i32)
   global.get $~lib/memory/__stack_pointer
@@ -2343,7 +2374,7 @@
   local.get $1
   i32.store offset=4
   local.get $1
-  call $~lib/object/Object#constructor
+  call $~lib/object/Object#raw_constructor
   local.tee $this
   i32.store
   local.get $this

--- a/tests/compiler/resolve-new.release.wat
+++ b/tests/compiler/resolve-new.release.wat
@@ -1,11 +1,11 @@
 (module
  (type $0 (func))
- (type $1 (func (param i32)))
- (type $2 (func (param i32 i32)))
- (type $3 (func (result i32)))
- (type $4 (func (param i32) (result i32)))
- (type $5 (func (param i32 i32 i32 i32)))
- (type $6 (func (param i32 i32 i64)))
+ (type $1 (func (result i32)))
+ (type $2 (func (param i32)))
+ (type $3 (func (param i32 i32)))
+ (type $4 (func (param i32 i32 i32 i32)))
+ (type $5 (func (param i32 i32 i64)))
+ (type $6 (func (param i32) (result i32)))
  (import "env" "abort" (func $~lib/builtins/abort (param i32 i32 i32 i32)))
  (global $~lib/rt/itcms/total (mut i32) (i32.const 0))
  (global $~lib/rt/itcms/threshold (mut i32) (i32.const 0))
@@ -122,7 +122,7 @@
     local.get $0
     global.set $~lib/rt/itcms/iter
    end
-   block $__inlined_func$~lib/rt/itcms/Object#unlink$112
+   block $__inlined_func$~lib/rt/itcms/Object#unlink$111
     local.get $1
     i32.load offset=4
     i32.const -4
@@ -146,7 +146,7 @@
       call $~lib/builtins/abort
       unreachable
      end
-     br $__inlined_func$~lib/rt/itcms/Object#unlink$112
+     br $__inlined_func$~lib/rt/itcms/Object#unlink$111
     end
     local.get $1
     i32.load offset=8
@@ -1139,23 +1139,23 @@
    end
   end
  )
- (func $~lib/rt/itcms/__new (param $0 i32) (result i32)
+ (func $~lib/rt/itcms/__new (result i32)
+  (local $0 i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
-  (local $4 i32)
   global.get $~lib/rt/itcms/total
   global.get $~lib/rt/itcms/threshold
   i32.ge_u
   if
    block $__inlined_func$~lib/rt/itcms/interrupt$69
     i32.const 2048
-    local.set $1
+    local.set $0
     loop $do-loop|0
-     local.get $1
+     local.get $0
      call $~lib/rt/itcms/step
      i32.sub
-     local.set $1
+     local.set $0
      global.get $~lib/rt/itcms/state
      i32.eqz
      if
@@ -1171,7 +1171,7 @@
       global.set $~lib/rt/itcms/threshold
       br $__inlined_func$~lib/rt/itcms/interrupt$69
      end
-     local.get $1
+     local.get $0
      i32.const 0
      i32.gt_s
      br_if $do-loop|0
@@ -1194,17 +1194,17 @@
    call $~lib/rt/tlsf/initialize
   end
   global.get $~lib/rt/tlsf/ROOT
-  local.tee $2
-  call $~lib/rt/tlsf/searchBlock
   local.tee $1
+  call $~lib/rt/tlsf/searchBlock
+  local.tee $0
   i32.eqz
   if
    memory.size
-   local.tee $1
+   local.tee $0
    i32.const 4
-   local.get $2
-   i32.load offset=1568
    local.get $1
+   i32.load offset=1568
+   local.get $0
    i32.const 16
    i32.shl
    i32.const 4
@@ -1217,16 +1217,16 @@
    i32.and
    i32.const 16
    i32.shr_u
-   local.tee $3
-   local.get $1
-   local.get $3
+   local.tee $2
+   local.get $0
+   local.get $2
    i32.gt_s
    select
    memory.grow
    i32.const 0
    i32.lt_s
    if
-    local.get $3
+    local.get $2
     memory.grow
     i32.const 0
     i32.lt_s
@@ -1234,8 +1234,8 @@
      unreachable
     end
    end
-   local.get $2
    local.get $1
+   local.get $0
    i32.const 16
    i32.shl
    memory.size
@@ -1243,9 +1243,9 @@
    i64.const 16
    i64.shl
    call $~lib/rt/tlsf/addMemory
-   local.get $2
+   local.get $1
    call $~lib/rt/tlsf/searchBlock
-   local.tee $1
+   local.tee $0
    i32.eqz
    if
     i32.const 0
@@ -1256,7 +1256,7 @@
     unreachable
    end
   end
-  local.get $1
+  local.get $0
   i32.load
   i32.const -4
   i32.and
@@ -1270,92 +1270,92 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $2
   local.get $1
+  local.get $0
   call $~lib/rt/tlsf/removeBlock
-  local.get $1
+  local.get $0
   i32.load
-  local.tee $3
+  local.tee $2
   i32.const -4
   i32.and
   i32.const 28
   i32.sub
-  local.tee $4
+  local.tee $3
   i32.const 16
   i32.ge_u
   if
-   local.get $1
-   local.get $3
+   local.get $0
+   local.get $2
    i32.const 2
    i32.and
    i32.const 28
    i32.or
    i32.store
-   local.get $1
+   local.get $0
    i32.const 32
    i32.add
-   local.tee $3
-   local.get $4
+   local.tee $2
+   local.get $3
    i32.const 4
    i32.sub
    i32.const 1
    i32.or
    i32.store
+   local.get $1
    local.get $2
-   local.get $3
    call $~lib/rt/tlsf/insertBlock
   else
-   local.get $1
-   local.get $3
+   local.get $0
+   local.get $2
    i32.const -2
    i32.and
    i32.store
-   local.get $1
+   local.get $0
    i32.const 4
    i32.add
-   local.get $1
+   local.get $0
    i32.load
    i32.const -4
    i32.and
    i32.add
-   local.tee $2
-   local.get $2
+   local.tee $1
+   local.get $1
    i32.load
    i32.const -3
    i32.and
    i32.store
   end
-  local.get $1
   local.get $0
+  i32.const 4
   i32.store offset=12
-  local.get $1
+  local.get $0
   i32.const 0
   i32.store offset=16
   global.get $~lib/rt/itcms/fromSpace
-  local.tee $0
+  local.tee $1
   i32.load offset=8
   local.set $2
-  local.get $1
   local.get $0
+  local.get $1
   global.get $~lib/rt/itcms/white
   i32.or
   i32.store offset=4
-  local.get $1
+  local.get $0
   local.get $2
   i32.store offset=8
   local.get $2
-  local.get $1
+  local.get $0
   local.get $2
   i32.load offset=4
   i32.const 3
   i32.and
   i32.or
   i32.store offset=4
-  local.get $0
   local.get $1
+  local.get $0
   i32.store offset=8
   global.get $~lib/rt/itcms/total
-  local.get $1
+  local.get $0
   i32.load
   i32.const -4
   i32.and
@@ -1363,7 +1363,7 @@
   i32.add
   i32.add
   global.set $~lib/rt/itcms/total
-  local.get $1
+  local.get $0
   i32.const 20
   i32.add
   local.tee $0
@@ -1466,66 +1466,38 @@
  )
  (func $resolve-new/Foo#constructor (result i32)
   (local $0 i32)
-  (local $1 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 8
   i32.sub
   global.set $~lib/memory/__stack_pointer
-  block $folding-inner0
-   global.get $~lib/memory/__stack_pointer
-   i32.const 1464
-   i32.lt_s
-   br_if $folding-inner0
-   global.get $~lib/memory/__stack_pointer
-   i64.const 0
-   i64.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 4
-   call $~lib/rt/itcms/__new
-   local.tee $0
-   i32.store
-   global.get $~lib/memory/__stack_pointer
-   global.get $~lib/memory/__stack_pointer
-   local.get $0
-   i32.store offset=4
-   global.get $~lib/memory/__stack_pointer
-   i32.const 4
-   i32.sub
-   global.set $~lib/memory/__stack_pointer
-   global.get $~lib/memory/__stack_pointer
-   i32.const 1464
-   i32.lt_s
-   br_if $folding-inner0
-   global.get $~lib/memory/__stack_pointer
-   i32.const 0
-   i32.store
-   local.get $0
-   i32.eqz
-   if
-    global.get $~lib/memory/__stack_pointer
-    i32.const 0
-    call $~lib/rt/itcms/__new
-    local.tee $0
-    i32.store
-   end
-   global.get $~lib/memory/__stack_pointer
-   i32.const 4
-   i32.add
-   global.set $~lib/memory/__stack_pointer
-   local.get $0
-   i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 8
-   i32.add
-   global.set $~lib/memory/__stack_pointer
-   local.get $0
-   return
+  global.get $~lib/memory/__stack_pointer
+  i32.const 1464
+  i32.lt_s
+  if
+   i32.const 34256
+   i32.const 34304
+   i32.const 1
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
   end
-  i32.const 34256
-  i32.const 34304
-  i32.const 1
-  i32.const 1
-  call $~lib/builtins/abort
-  unreachable
+  global.get $~lib/memory/__stack_pointer
+  i64.const 0
+  i64.store
+  global.get $~lib/memory/__stack_pointer
+  call $~lib/rt/itcms/__new
+  local.tee $0
+  i32.store
+  global.get $~lib/memory/__stack_pointer
+  local.get $0
+  i32.store offset=4
+  global.get $~lib/memory/__stack_pointer
+  local.get $0
+  i32.store
+  global.get $~lib/memory/__stack_pointer
+  i32.const 8
+  i32.add
+  global.set $~lib/memory/__stack_pointer
+  local.get $0
  )
 )

--- a/tests/compiler/resolve-propertyaccess.debug.wat
+++ b/tests/compiler/resolve-propertyaccess.debug.wat
@@ -2811,6 +2811,9 @@
   i32.const 7
   return
  )
+ (func $~lib/object/Object#raw_constructor (param $this i32) (result i32)
+  local.get $this
+ )
  (func $resolve-propertyaccess/Class#set:instanceField (param $this i32) (param $instanceField i32)
   local.get $this
   local.get $instanceField
@@ -2991,6 +2994,42 @@
   local.get $3
   return
  )
+ (func $resolve-propertyaccess/Class#raw_constructor (param $this i32) (result i32)
+  (local $1 i32)
+  global.get $~lib/memory/__stack_pointer
+  i32.const 8
+  i32.sub
+  global.set $~lib/memory/__stack_pointer
+  call $~stack_check
+  global.get $~lib/memory/__stack_pointer
+  i64.const 0
+  i64.store
+  global.get $~lib/memory/__stack_pointer
+  local.get $this
+  local.set $1
+  global.get $~lib/memory/__stack_pointer
+  local.get $1
+  i32.store
+  local.get $1
+  call $~lib/object/Object#raw_constructor
+  local.tee $this
+  i32.store offset=4
+  local.get $this
+  local.set $1
+  global.get $~lib/memory/__stack_pointer
+  local.get $1
+  i32.store
+  local.get $1
+  i32.const 6
+  call $resolve-propertyaccess/Class#set:instanceField
+  local.get $this
+  local.set $1
+  global.get $~lib/memory/__stack_pointer
+  i32.const 8
+  i32.add
+  global.set $~lib/memory/__stack_pointer
+  local.get $1
+ )
  (func $resolve-propertyaccess/Class#constructor (param $this i32) (result i32)
   (local $1 i32)
   global.get $~lib/memory/__stack_pointer
@@ -3018,7 +3057,7 @@
   local.get $1
   i32.store offset=4
   local.get $1
-  call $~lib/object/Object#constructor
+  call $~lib/object/Object#raw_constructor
   local.tee $this
   i32.store
   local.get $this

--- a/tests/compiler/resolve-propertyaccess.release.wat
+++ b/tests/compiler/resolve-propertyaccess.release.wat
@@ -1979,7 +1979,6 @@
  (func $start:resolve-propertyaccess
   (local $0 i32)
   (local $1 i32)
-  (local $2 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 16
   i32.sub
@@ -2256,34 +2255,9 @@
    local.tee $0
    i32.store
    global.get $~lib/memory/__stack_pointer
-   global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store offset=4
    global.get $~lib/memory/__stack_pointer
-   i32.const 4
-   i32.sub
-   global.set $~lib/memory/__stack_pointer
-   global.get $~lib/memory/__stack_pointer
-   i32.const 3704
-   i32.lt_s
-   br_if $folding-inner0
-   global.get $~lib/memory/__stack_pointer
-   i32.const 0
-   i32.store
-   local.get $0
-   i32.eqz
-   if
-    global.get $~lib/memory/__stack_pointer
-    i32.const 0
-    i32.const 0
-    call $~lib/rt/itcms/__new
-    local.tee $0
-    i32.store
-   end
-   global.get $~lib/memory/__stack_pointer
-   i32.const 4
-   i32.add
-   global.set $~lib/memory/__stack_pointer
    local.get $0
    i32.store
    global.get $~lib/memory/__stack_pointer

--- a/tests/compiler/resolve-unary.debug.wat
+++ b/tests/compiler/resolve-unary.debug.wat
@@ -2816,6 +2816,9 @@
   end
   return
  )
+ (func $~lib/object/Object#raw_constructor (param $this i32) (result i32)
+  local.get $this
+ )
  (func $resolve-unary/Foo#plus (param $this i32) (result i32)
   i32.const 2464
   return
@@ -3078,6 +3081,34 @@
   local.get $3
   return
  )
+ (func $resolve-unary/Foo#raw_constructor (param $this i32) (result i32)
+  (local $1 i32)
+  global.get $~lib/memory/__stack_pointer
+  i32.const 8
+  i32.sub
+  global.set $~lib/memory/__stack_pointer
+  call $~stack_check
+  global.get $~lib/memory/__stack_pointer
+  i64.const 0
+  i64.store
+  global.get $~lib/memory/__stack_pointer
+  local.get $this
+  local.set $1
+  global.get $~lib/memory/__stack_pointer
+  local.get $1
+  i32.store
+  local.get $1
+  call $~lib/object/Object#raw_constructor
+  local.tee $this
+  i32.store offset=4
+  local.get $this
+  local.set $1
+  global.get $~lib/memory/__stack_pointer
+  i32.const 8
+  i32.add
+  global.set $~lib/memory/__stack_pointer
+  local.get $1
+ )
  (func $resolve-unary/Foo#constructor (param $this i32) (result i32)
   (local $1 i32)
   global.get $~lib/memory/__stack_pointer
@@ -3105,9 +3136,37 @@
   local.get $1
   i32.store offset=4
   local.get $1
-  call $~lib/object/Object#constructor
+  call $~lib/object/Object#raw_constructor
   local.tee $this
   i32.store
+  local.get $this
+  local.set $1
+  global.get $~lib/memory/__stack_pointer
+  i32.const 8
+  i32.add
+  global.set $~lib/memory/__stack_pointer
+  local.get $1
+ )
+ (func $resolve-unary/Bar#raw_constructor (param $this i32) (result i32)
+  (local $1 i32)
+  global.get $~lib/memory/__stack_pointer
+  i32.const 8
+  i32.sub
+  global.set $~lib/memory/__stack_pointer
+  call $~stack_check
+  global.get $~lib/memory/__stack_pointer
+  i64.const 0
+  i64.store
+  global.get $~lib/memory/__stack_pointer
+  local.get $this
+  local.set $1
+  global.get $~lib/memory/__stack_pointer
+  local.get $1
+  i32.store
+  local.get $1
+  call $~lib/object/Object#raw_constructor
+  local.tee $this
+  i32.store offset=4
   local.get $this
   local.set $1
   global.get $~lib/memory/__stack_pointer
@@ -3143,7 +3202,7 @@
   local.get $1
   i32.store offset=4
   local.get $1
-  call $~lib/object/Object#constructor
+  call $~lib/object/Object#raw_constructor
   local.tee $this
   i32.store
   local.get $this

--- a/tests/compiler/resolve-unary.release.wat
+++ b/tests/compiler/resolve-unary.release.wat
@@ -3,10 +3,10 @@
  (type $1 (func (param i32 i32) (result i32)))
  (type $2 (func (param i32)))
  (type $3 (func (param i32 i32)))
- (type $4 (func (param i32) (result i32)))
- (type $5 (func (param i32 i32 i32 i32)))
- (type $6 (func (param i32 i32 i64)))
- (type $7 (func (result i32)))
+ (type $4 (func (param i32 i32 i32 i32)))
+ (type $5 (func (param i32 i32 i64)))
+ (type $6 (func (result i32)))
+ (type $7 (func (param i32) (result i32)))
  (import "env" "abort" (func $~lib/builtins/abort (param i32 i32 i32 i32)))
  (global $~lib/rt/itcms/total (mut i32) (i32.const 0))
  (global $~lib/rt/itcms/threshold (mut i32) (i32.const 0))
@@ -183,7 +183,7 @@
     local.get $0
     global.set $~lib/rt/itcms/iter
    end
-   block $__inlined_func$~lib/rt/itcms/Object#unlink$156
+   block $__inlined_func$~lib/rt/itcms/Object#unlink$157
     local.get $1
     i32.load offset=4
     i32.const -4
@@ -207,7 +207,7 @@
       call $~lib/builtins/abort
       unreachable
      end
-     br $__inlined_func$~lib/rt/itcms/Object#unlink$156
+     br $__inlined_func$~lib/rt/itcms/Object#unlink$157
     end
     local.get $1
     i32.load offset=8
@@ -2316,8 +2316,6 @@
    i32.store offset=4
    global.get $~lib/memory/__stack_pointer
    local.get $0
-   call $~lib/object/Object#constructor
-   local.tee $0
    i32.store
    global.get $~lib/memory/__stack_pointer
    i32.const 8
@@ -2531,8 +2529,6 @@
    i32.store offset=4
    global.get $~lib/memory/__stack_pointer
    local.get $0
-   call $~lib/object/Object#constructor
-   local.tee $0
    i32.store
    global.get $~lib/memory/__stack_pointer
    i32.const 8
@@ -2657,40 +2653,5 @@
   i32.const 1
   call $~lib/builtins/abort
   unreachable
- )
- (func $~lib/object/Object#constructor (param $0 i32) (result i32)
-  global.get $~lib/memory/__stack_pointer
-  i32.const 4
-  i32.sub
-  global.set $~lib/memory/__stack_pointer
-  global.get $~lib/memory/__stack_pointer
-  i32.const 3872
-  i32.lt_s
-  if
-   i32.const 36672
-   i32.const 36720
-   i32.const 1
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  global.get $~lib/memory/__stack_pointer
-  i32.const 0
-  i32.store
-  local.get $0
-  i32.eqz
-  if
-   global.get $~lib/memory/__stack_pointer
-   i32.const 0
-   i32.const 0
-   call $~lib/rt/itcms/__new
-   local.tee $0
-   i32.store
-  end
-  global.get $~lib/memory/__stack_pointer
-  i32.const 4
-  i32.add
-  global.set $~lib/memory/__stack_pointer
-  local.get $0
  )
 )

--- a/tests/compiler/rt/finalize.debug.wat
+++ b/tests/compiler/rt/finalize.debug.wat
@@ -45,6 +45,9 @@
  (elem $0 (i32.const 1))
  (export "memory" (memory $0))
  (export "_start" (func $~start))
+ (func $~lib/object/Object#raw_constructor (param $this i32) (result i32)
+  local.get $this
+ )
  (func $~lib/rt/itcms/Object#set:nextWithColor (param $this i32) (param $nextWithColor i32)
   local.get $this
   local.get $nextWithColor
@@ -2415,6 +2418,34 @@
    unreachable
   end
  )
+ (func $rt/finalize/Ref#raw_constructor (param $this i32) (result i32)
+  (local $1 i32)
+  global.get $~lib/memory/__stack_pointer
+  i32.const 8
+  i32.sub
+  global.set $~lib/memory/__stack_pointer
+  call $~stack_check
+  global.get $~lib/memory/__stack_pointer
+  i64.const 0
+  i64.store
+  global.get $~lib/memory/__stack_pointer
+  local.get $this
+  local.set $1
+  global.get $~lib/memory/__stack_pointer
+  local.get $1
+  i32.store
+  local.get $1
+  call $~lib/object/Object#raw_constructor
+  local.tee $this
+  i32.store offset=4
+  local.get $this
+  local.set $1
+  global.get $~lib/memory/__stack_pointer
+  i32.const 8
+  i32.add
+  global.set $~lib/memory/__stack_pointer
+  local.get $1
+ )
  (func $rt/finalize/Ref#constructor (param $this i32) (result i32)
   (local $1 i32)
   global.get $~lib/memory/__stack_pointer
@@ -2442,7 +2473,7 @@
   local.get $1
   i32.store offset=4
   local.get $1
-  call $~lib/object/Object#constructor
+  call $~lib/object/Object#raw_constructor
   local.tee $this
   i32.store
   local.get $this

--- a/tests/compiler/rt/finalize.release.wat
+++ b/tests/compiler/rt/finalize.release.wat
@@ -2,10 +2,10 @@
  (type $0 (func))
  (type $1 (func (param i32)))
  (type $2 (func (param i32 i32)))
- (type $3 (func (param i32) (result i32)))
+ (type $3 (func (result i32)))
  (type $4 (func (param i32 i32 i32 i32)))
  (type $5 (func (param i32 i32 i64)))
- (type $6 (func (result i32)))
+ (type $6 (func (param i32) (result i32)))
  (import "env" "abort" (func $~lib/builtins/abort (param i32 i32 i32 i32)))
  (global $rt/finalize/expect (mut i32) (i32.const 0))
  (global $rt/finalize/ran (mut i32) (i32.const 0))
@@ -120,7 +120,7 @@
     local.get $0
     global.set $~lib/rt/itcms/iter
    end
-   block $__inlined_func$~lib/rt/itcms/Object#unlink$112
+   block $__inlined_func$~lib/rt/itcms/Object#unlink$111
     local.get $1
     i32.load offset=4
     i32.const -4
@@ -144,7 +144,7 @@
       call $~lib/builtins/abort
       unreachable
      end
-     br $__inlined_func$~lib/rt/itcms/Object#unlink$112
+     br $__inlined_func$~lib/rt/itcms/Object#unlink$111
     end
     local.get $1
     i32.load offset=8
@@ -1152,23 +1152,23 @@
    end
   end
  )
- (func $~lib/rt/itcms/__new (param $0 i32) (result i32)
+ (func $~lib/rt/itcms/__new (result i32)
+  (local $0 i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
-  (local $4 i32)
   global.get $~lib/rt/itcms/total
   global.get $~lib/rt/itcms/threshold
   i32.ge_u
   if
    block $__inlined_func$~lib/rt/itcms/interrupt$70
     i32.const 2048
-    local.set $1
+    local.set $0
     loop $do-loop|0
-     local.get $1
+     local.get $0
      call $~lib/rt/itcms/step
      i32.sub
-     local.set $1
+     local.set $0
      global.get $~lib/rt/itcms/state
      i32.eqz
      if
@@ -1184,7 +1184,7 @@
       global.set $~lib/rt/itcms/threshold
       br $__inlined_func$~lib/rt/itcms/interrupt$70
      end
-     local.get $1
+     local.get $0
      i32.const 0
      i32.gt_s
      br_if $do-loop|0
@@ -1207,17 +1207,17 @@
    call $~lib/rt/tlsf/initialize
   end
   global.get $~lib/rt/tlsf/ROOT
-  local.tee $2
-  call $~lib/rt/tlsf/searchBlock
   local.tee $1
+  call $~lib/rt/tlsf/searchBlock
+  local.tee $0
   i32.eqz
   if
    memory.size
-   local.tee $1
+   local.tee $0
    i32.const 4
-   local.get $2
-   i32.load offset=1568
    local.get $1
+   i32.load offset=1568
+   local.get $0
    i32.const 16
    i32.shl
    i32.const 4
@@ -1230,16 +1230,16 @@
    i32.and
    i32.const 16
    i32.shr_u
-   local.tee $3
-   local.get $1
-   local.get $3
+   local.tee $2
+   local.get $0
+   local.get $2
    i32.gt_s
    select
    memory.grow
    i32.const 0
    i32.lt_s
    if
-    local.get $3
+    local.get $2
     memory.grow
     i32.const 0
     i32.lt_s
@@ -1247,8 +1247,8 @@
      unreachable
     end
    end
-   local.get $2
    local.get $1
+   local.get $0
    i32.const 16
    i32.shl
    memory.size
@@ -1256,9 +1256,9 @@
    i64.const 16
    i64.shl
    call $~lib/rt/tlsf/addMemory
-   local.get $2
+   local.get $1
    call $~lib/rt/tlsf/searchBlock
-   local.tee $1
+   local.tee $0
    i32.eqz
    if
     i32.const 0
@@ -1269,7 +1269,7 @@
     unreachable
    end
   end
-  local.get $1
+  local.get $0
   i32.load
   i32.const -4
   i32.and
@@ -1283,92 +1283,92 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $2
   local.get $1
+  local.get $0
   call $~lib/rt/tlsf/removeBlock
-  local.get $1
+  local.get $0
   i32.load
-  local.tee $3
+  local.tee $2
   i32.const -4
   i32.and
   i32.const 28
   i32.sub
-  local.tee $4
+  local.tee $3
   i32.const 16
   i32.ge_u
   if
-   local.get $1
-   local.get $3
+   local.get $0
+   local.get $2
    i32.const 2
    i32.and
    i32.const 28
    i32.or
    i32.store
-   local.get $1
+   local.get $0
    i32.const 32
    i32.add
-   local.tee $3
-   local.get $4
+   local.tee $2
+   local.get $3
    i32.const 4
    i32.sub
    i32.const 1
    i32.or
    i32.store
+   local.get $1
    local.get $2
-   local.get $3
    call $~lib/rt/tlsf/insertBlock
   else
-   local.get $1
-   local.get $3
+   local.get $0
+   local.get $2
    i32.const -2
    i32.and
    i32.store
-   local.get $1
+   local.get $0
    i32.const 4
    i32.add
-   local.get $1
+   local.get $0
    i32.load
    i32.const -4
    i32.and
    i32.add
-   local.tee $2
-   local.get $2
+   local.tee $1
+   local.get $1
    i32.load
    i32.const -3
    i32.and
    i32.store
   end
-  local.get $1
   local.get $0
+  i32.const 4
   i32.store offset=12
-  local.get $1
+  local.get $0
   i32.const 0
   i32.store offset=16
   global.get $~lib/rt/itcms/fromSpace
-  local.tee $0
+  local.tee $1
   i32.load offset=8
   local.set $2
-  local.get $1
   local.get $0
+  local.get $1
   global.get $~lib/rt/itcms/white
   i32.or
   i32.store offset=4
-  local.get $1
+  local.get $0
   local.get $2
   i32.store offset=8
   local.get $2
-  local.get $1
+  local.get $0
   local.get $2
   i32.load offset=4
   i32.const 3
   i32.and
   i32.or
   i32.store offset=4
-  local.get $0
   local.get $1
+  local.get $0
   i32.store offset=8
   global.get $~lib/rt/itcms/total
-  local.get $1
+  local.get $0
   i32.load
   i32.const -4
   i32.and
@@ -1376,7 +1376,7 @@
   i32.add
   i32.add
   global.set $~lib/rt/itcms/total
-  local.get $1
+  local.get $0
   i32.const 20
   i32.add
   local.tee $0
@@ -1415,7 +1415,6 @@
  )
  (func $~start
   (local $0 i32)
-  (local $1 i32)
   global.get $~started
   if
    return
@@ -1458,104 +1457,75 @@
   i32.const 8
   i32.sub
   global.set $~lib/memory/__stack_pointer
-  block $__inlined_func$start:rt/finalize$1
-   block $folding-inner0
-    global.get $~lib/memory/__stack_pointer
-    i32.const 1512
-    i32.lt_s
-    br_if $folding-inner0
-    global.get $~lib/memory/__stack_pointer
-    i64.const 0
-    i64.store
-    global.get $~lib/memory/__stack_pointer
-    i32.const 4
-    call $~lib/rt/itcms/__new
-    local.tee $0
-    i32.store
-    global.get $~lib/memory/__stack_pointer
-    global.get $~lib/memory/__stack_pointer
-    local.get $0
-    i32.store offset=4
-    global.get $~lib/memory/__stack_pointer
-    i32.const 4
-    i32.sub
-    global.set $~lib/memory/__stack_pointer
-    global.get $~lib/memory/__stack_pointer
-    i32.const 1512
-    i32.lt_s
-    br_if $folding-inner0
-    global.get $~lib/memory/__stack_pointer
-    i32.const 0
-    i32.store
-    local.get $0
-    i32.eqz
-    if
-     global.get $~lib/memory/__stack_pointer
-     i32.const 0
-     call $~lib/rt/itcms/__new
-     local.tee $0
-     i32.store
-    end
-    global.get $~lib/memory/__stack_pointer
-    i32.const 4
-    i32.add
-    global.set $~lib/memory/__stack_pointer
-    local.get $0
-    i32.store
-    global.get $~lib/memory/__stack_pointer
-    i32.const 8
-    i32.add
-    global.set $~lib/memory/__stack_pointer
-    local.get $0
-    global.set $rt/finalize/expect
-    global.get $~lib/rt/itcms/state
-    i32.const 0
-    i32.gt_s
-    if
-     loop $while-continue|0
-      global.get $~lib/rt/itcms/state
-      if
-       call $~lib/rt/itcms/step
-       drop
-       br $while-continue|0
-      end
-     end
-    end
-    call $~lib/rt/itcms/step
-    drop
-    loop $while-continue|1
-     global.get $~lib/rt/itcms/state
-     if
-      call $~lib/rt/itcms/step
-      drop
-      br $while-continue|1
-     end
-    end
-    global.get $~lib/rt/itcms/total
-    i64.extend_i32_u
-    i64.const 200
-    i64.mul
-    i64.const 100
-    i64.div_u
-    i32.wrap_i64
-    i32.const 1024
-    i32.add
-    global.set $~lib/rt/itcms/threshold
-    global.get $rt/finalize/ran
-    i32.eqz
-    if
-     i32.const 0
-     i32.const 1392
-     i32.const 13
-     i32.const 1
-     call $~lib/builtins/abort
-     unreachable
-    end
-    br $__inlined_func$start:rt/finalize$1
-   end
+  global.get $~lib/memory/__stack_pointer
+  i32.const 1512
+  i32.lt_s
+  if
    i32.const 34304
    i32.const 34352
    i32.const 1
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  global.get $~lib/memory/__stack_pointer
+  i64.const 0
+  i64.store
+  global.get $~lib/memory/__stack_pointer
+  call $~lib/rt/itcms/__new
+  local.tee $0
+  i32.store
+  global.get $~lib/memory/__stack_pointer
+  local.get $0
+  i32.store offset=4
+  global.get $~lib/memory/__stack_pointer
+  local.get $0
+  i32.store
+  global.get $~lib/memory/__stack_pointer
+  i32.const 8
+  i32.add
+  global.set $~lib/memory/__stack_pointer
+  local.get $0
+  global.set $rt/finalize/expect
+  global.get $~lib/rt/itcms/state
+  i32.const 0
+  i32.gt_s
+  if
+   loop $while-continue|0
+    global.get $~lib/rt/itcms/state
+    if
+     call $~lib/rt/itcms/step
+     drop
+     br $while-continue|0
+    end
+   end
+  end
+  call $~lib/rt/itcms/step
+  drop
+  loop $while-continue|1
+   global.get $~lib/rt/itcms/state
+   if
+    call $~lib/rt/itcms/step
+    drop
+    br $while-continue|1
+   end
+  end
+  global.get $~lib/rt/itcms/total
+  i64.extend_i32_u
+  i64.const 200
+  i64.mul
+  i64.const 100
+  i64.div_u
+  i32.wrap_i64
+  i32.const 1024
+  i32.add
+  global.set $~lib/rt/itcms/threshold
+  global.get $rt/finalize/ran
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1392
+   i32.const 13
    i32.const 1
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/rt/issue-2719.debug.wat
+++ b/tests/compiler/rt/issue-2719.debug.wat
@@ -42,6 +42,9 @@
  (elem $0 (i32.const 1))
  (export "memory" (memory $0))
  (start $~start)
+ (func $~lib/object/Object#raw_constructor (param $this i32) (result i32)
+  local.get $this
+ )
  (func $~lib/rt/itcms/Object#set:nextWithColor (param $this i32) (param $nextWithColor i32)
   local.get $this
   local.get $nextWithColor
@@ -2362,6 +2365,42 @@
    unreachable
   end
  )
+ (func $rt/issue-2719/issue2719_T#raw_constructor (param $this i32) (result i32)
+  (local $1 i32)
+  global.get $~lib/memory/__stack_pointer
+  i32.const 8
+  i32.sub
+  global.set $~lib/memory/__stack_pointer
+  call $~stack_check
+  global.get $~lib/memory/__stack_pointer
+  i64.const 0
+  i64.store
+  global.get $~lib/memory/__stack_pointer
+  local.get $this
+  local.set $1
+  global.get $~lib/memory/__stack_pointer
+  local.get $1
+  i32.store
+  local.get $1
+  call $~lib/object/Object#raw_constructor
+  local.tee $this
+  i32.store offset=4
+  local.get $this
+  local.set $1
+  global.get $~lib/memory/__stack_pointer
+  local.get $1
+  i32.store
+  local.get $1
+  i32.const 0
+  call $rt/issue-2719/issue2719_T#set:v
+  local.get $this
+  local.set $1
+  global.get $~lib/memory/__stack_pointer
+  i32.const 8
+  i32.add
+  global.set $~lib/memory/__stack_pointer
+  local.get $1
+ )
  (func $rt/issue-2719/issue2719_T#constructor (param $this i32) (result i32)
   (local $1 i32)
   global.get $~lib/memory/__stack_pointer
@@ -2389,7 +2428,7 @@
   local.get $1
   i32.store offset=4
   local.get $1
-  call $~lib/object/Object#constructor
+  call $~lib/object/Object#raw_constructor
   local.tee $this
   i32.store
   local.get $this

--- a/tests/compiler/rt/issue-2719.release.wat
+++ b/tests/compiler/rt/issue-2719.release.wat
@@ -1,11 +1,11 @@
 (module
  (type $0 (func))
- (type $1 (func (param i32)))
- (type $2 (func (param i32 i32)))
- (type $3 (func (result i32)))
- (type $4 (func (param i32 i32) (result i32)))
- (type $5 (func (param i32 i32 i32 i32)))
- (type $6 (func (param i32 i32 i64)))
+ (type $1 (func (result i32)))
+ (type $2 (func (param i32)))
+ (type $3 (func (param i32 i32)))
+ (type $4 (func (param i32 i32 i32 i32)))
+ (type $5 (func (param i32 i32 i64)))
+ (type $6 (func (param i32) (result i32)))
  (import "env" "abort" (func $~lib/builtins/abort (param i32 i32 i32 i32)))
  (global $~lib/rt/itcms/total (mut i32) (i32.const 0))
  (global $~lib/rt/itcms/threshold (mut i32) (i32.const 0))
@@ -117,7 +117,7 @@
     local.get $0
     global.set $~lib/rt/itcms/iter
    end
-   block $__inlined_func$~lib/rt/itcms/Object#unlink$119
+   block $__inlined_func$~lib/rt/itcms/Object#unlink$118
     local.get $1
     i32.load offset=4
     i32.const -4
@@ -141,7 +141,7 @@
       call $~lib/builtins/abort
       unreachable
      end
-     br $__inlined_func$~lib/rt/itcms/Object#unlink$119
+     br $__inlined_func$~lib/rt/itcms/Object#unlink$118
     end
     local.get $1
     i32.load offset=8
@@ -1077,85 +1077,18 @@
   end
   i32.const 0
  )
- (func $~lib/rt/tlsf/searchBlock (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/rt/tlsf/searchBlock (param $0 i32) (result i32)
+  (local $1 i32)
   (local $2 i32)
-  local.get $1
-  i32.const 256
-  i32.lt_u
-  if
-   local.get $1
-   i32.const 4
-   i32.shr_u
-   local.set $1
-  else
-   local.get $1
-   i32.const 536870910
-   i32.lt_u
-   if
-    local.get $1
-    i32.const 1
-    i32.const 27
-    local.get $1
-    i32.clz
-    i32.sub
-    i32.shl
-    i32.add
-    i32.const 1
-    i32.sub
-    local.set $1
-   end
-   local.get $1
-   i32.const 31
-   local.get $1
-   i32.clz
-   i32.sub
-   local.tee $2
-   i32.const 4
-   i32.sub
-   i32.shr_u
-   i32.const 16
-   i32.xor
-   local.set $1
-   local.get $2
-   i32.const 7
-   i32.sub
-   local.set $2
-  end
-  local.get $1
-  i32.const 16
-  i32.lt_u
-  local.get $2
-  i32.const 23
-  i32.lt_u
-  i32.and
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1392
-   i32.const 334
-   i32.const 14
-   call $~lib/builtins/abort
-   unreachable
-  end
   local.get $0
-  local.get $2
-  i32.const 2
-  i32.shl
-  i32.add
   i32.load offset=4
-  i32.const -1
-  local.get $1
-  i32.shl
+  i32.const -2
   i32.and
   local.tee $1
   if (result i32)
    local.get $0
    local.get $1
    i32.ctz
-   local.get $2
-   i32.const 4
-   i32.shl
-   i32.add
    i32.const 2
    i32.shl
    i32.add
@@ -1163,23 +1096,19 @@
   else
    local.get $0
    i32.load
-   i32.const -1
-   local.get $2
-   i32.const 1
-   i32.add
-   i32.shl
+   i32.const -2
    i32.and
    local.tee $1
    if (result i32)
     local.get $0
     local.get $1
     i32.ctz
-    local.tee $1
+    local.tee $2
     i32.const 2
     i32.shl
     i32.add
     i32.load offset=4
-    local.tee $2
+    local.tee $1
     i32.eqz
     if
      i32.const 0
@@ -1190,9 +1119,9 @@
      unreachable
     end
     local.get $0
-    local.get $2
-    i32.ctz
     local.get $1
+    i32.ctz
+    local.get $2
     i32.const 4
     i32.shl
     i32.add
@@ -1205,35 +1134,23 @@
    end
   end
  )
- (func $~lib/rt/itcms/__new (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/rt/itcms/__new (result i32)
+  (local $0 i32)
+  (local $1 i32)
   (local $2 i32)
   (local $3 i32)
-  (local $4 i32)
-  (local $5 i32)
-  (local $6 i32)
-  local.get $0
-  i32.const 1073741804
-  i32.ge_u
-  if
-   i32.const 1056
-   i32.const 1120
-   i32.const 261
-   i32.const 31
-   call $~lib/builtins/abort
-   unreachable
-  end
   global.get $~lib/rt/itcms/total
   global.get $~lib/rt/itcms/threshold
   i32.ge_u
   if
    block $__inlined_func$~lib/rt/itcms/interrupt$69
     i32.const 2048
-    local.set $2
+    local.set $0
     loop $do-loop|0
-     local.get $2
+     local.get $0
      call $~lib/rt/itcms/step
      i32.sub
-     local.set $2
+     local.set $0
      global.get $~lib/rt/itcms/state
      i32.eqz
      if
@@ -1249,7 +1166,7 @@
       global.set $~lib/rt/itcms/threshold
       br $__inlined_func$~lib/rt/itcms/interrupt$69
      end
-     local.get $2
+     local.get $0
      i32.const 0
      i32.gt_s
      br_if $do-loop|0
@@ -1272,94 +1189,39 @@
    call $~lib/rt/tlsf/initialize
   end
   global.get $~lib/rt/tlsf/ROOT
-  local.set $4
-  local.get $0
-  i32.const 16
-  i32.add
-  local.tee $2
-  i32.const 1073741820
-  i32.gt_u
-  if
-   i32.const 1056
-   i32.const 1392
-   i32.const 461
-   i32.const 29
-   call $~lib/builtins/abort
-   unreachable
-  end
-  local.get $4
-  local.get $2
-  i32.const 12
-  i32.le_u
-  if (result i32)
-   i32.const 12
-  else
-   local.get $2
-   i32.const 19
-   i32.add
-   i32.const -16
-   i32.and
-   i32.const 4
-   i32.sub
-  end
-  local.tee $5
+  local.tee $1
   call $~lib/rt/tlsf/searchBlock
-  local.tee $2
+  local.tee $0
   i32.eqz
   if
    memory.size
-   local.tee $2
-   local.get $5
-   i32.const 256
-   i32.ge_u
-   if (result i32)
-    local.get $5
-    i32.const 536870910
-    i32.lt_u
-    if (result i32)
-     local.get $5
-     i32.const 1
-     i32.const 27
-     local.get $5
-     i32.clz
-     i32.sub
-     i32.shl
-     i32.add
-     i32.const 1
-     i32.sub
-    else
-     local.get $5
-    end
-   else
-    local.get $5
-   end
+   local.tee $0
    i32.const 4
-   local.get $4
+   local.get $1
    i32.load offset=1568
-   local.get $2
+   local.get $0
    i32.const 16
    i32.shl
    i32.const 4
    i32.sub
    i32.ne
    i32.shl
-   i32.add
-   i32.const 65535
+   i32.const 65563
    i32.add
    i32.const -65536
    i32.and
    i32.const 16
    i32.shr_u
-   local.tee $3
+   local.tee $2
+   local.get $0
    local.get $2
-   local.get $3
    i32.gt_s
    select
    memory.grow
    i32.const 0
    i32.lt_s
    if
-    local.get $3
+    local.get $2
     memory.grow
     i32.const 0
     i32.lt_s
@@ -1367,8 +1229,8 @@
      unreachable
     end
    end
-   local.get $4
-   local.get $2
+   local.get $1
+   local.get $0
    i32.const 16
    i32.shl
    memory.size
@@ -1376,10 +1238,9 @@
    i64.const 16
    i64.shl
    call $~lib/rt/tlsf/addMemory
-   local.get $4
-   local.get $5
+   local.get $1
    call $~lib/rt/tlsf/searchBlock
-   local.tee $2
+   local.tee $0
    i32.eqz
    if
     i32.const 0
@@ -1390,12 +1251,12 @@
     unreachable
    end
   end
-  local.get $5
-  local.get $2
+  local.get $0
   i32.load
   i32.const -4
   i32.and
-  i32.gt_u
+  i32.const 28
+  i32.lt_u
   if
    i32.const 0
    i32.const 1392
@@ -1404,108 +1265,92 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $4
-  local.get $2
+  local.get $1
+  local.get $0
   call $~lib/rt/tlsf/removeBlock
-  local.get $2
+  local.get $0
   i32.load
-  local.set $6
-  local.get $5
-  i32.const 4
-  i32.add
-  i32.const 15
-  i32.and
-  if
-   i32.const 0
-   i32.const 1392
-   i32.const 361
-   i32.const 14
-   call $~lib/builtins/abort
-   unreachable
-  end
-  local.get $6
+  local.tee $2
   i32.const -4
   i32.and
-  local.get $5
+  i32.const 28
   i32.sub
   local.tee $3
   i32.const 16
   i32.ge_u
   if
+   local.get $0
    local.get $2
-   local.get $5
-   local.get $6
    i32.const 2
    i32.and
+   i32.const 28
    i32.or
    i32.store
-   local.get $2
-   i32.const 4
+   local.get $0
+   i32.const 32
    i32.add
-   local.get $5
-   i32.add
-   local.tee $5
+   local.tee $2
    local.get $3
    i32.const 4
    i32.sub
    i32.const 1
    i32.or
    i32.store
-   local.get $4
-   local.get $5
+   local.get $1
+   local.get $2
    call $~lib/rt/tlsf/insertBlock
   else
+   local.get $0
    local.get $2
-   local.get $6
    i32.const -2
    i32.and
    i32.store
-   local.get $2
+   local.get $0
    i32.const 4
    i32.add
-   local.get $2
+   local.get $0
    i32.load
    i32.const -4
    i32.and
    i32.add
-   local.tee $3
-   local.get $3
+   local.tee $1
+   local.get $1
    i32.load
    i32.const -3
    i32.and
    i32.store
   end
-  local.get $2
-  local.get $1
-  i32.store offset=12
-  local.get $2
   local.get $0
+  i32.const 4
+  i32.store offset=12
+  local.get $0
+  i32.const 4
   i32.store offset=16
   global.get $~lib/rt/itcms/fromSpace
   local.tee $1
   i32.load offset=8
-  local.set $3
-  local.get $2
+  local.set $2
+  local.get $0
   local.get $1
   global.get $~lib/rt/itcms/white
   i32.or
   i32.store offset=4
+  local.get $0
   local.get $2
-  local.get $3
   i32.store offset=8
-  local.get $3
   local.get $2
-  local.get $3
+  local.get $0
+  local.get $2
   i32.load offset=4
   i32.const 3
   i32.and
   i32.or
   i32.store offset=4
   local.get $1
-  local.get $2
+  local.get $0
   i32.store offset=8
   global.get $~lib/rt/itcms/total
-  local.get $2
+  local.get $0
   i32.load
   i32.const -4
   i32.and
@@ -1513,14 +1358,13 @@
   i32.add
   i32.add
   global.set $~lib/rt/itcms/total
-  local.get $2
+  local.get $0
   i32.const 20
   i32.add
-  local.tee $1
+  local.tee $0
   i32.const 0
+  i32.store align=1
   local.get $0
-  memory.fill
-  local.get $1
  )
  (func $~lib/rt/__visit_members (param $0 i32)
   block $invalid
@@ -1708,74 +1552,44 @@
  )
  (func $rt/issue-2719/issue2719_T#constructor (result i32)
   (local $0 i32)
-  (local $1 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 8
   i32.sub
   global.set $~lib/memory/__stack_pointer
-  block $folding-inner0
-   global.get $~lib/memory/__stack_pointer
-   i32.const 1528
-   i32.lt_s
-   br_if $folding-inner0
-   global.get $~lib/memory/__stack_pointer
-   i64.const 0
-   i64.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 4
-   i32.const 4
-   call $~lib/rt/itcms/__new
-   local.tee $0
-   i32.store
-   global.get $~lib/memory/__stack_pointer
-   global.get $~lib/memory/__stack_pointer
-   local.get $0
-   i32.store offset=4
-   global.get $~lib/memory/__stack_pointer
-   i32.const 4
-   i32.sub
-   global.set $~lib/memory/__stack_pointer
-   global.get $~lib/memory/__stack_pointer
-   i32.const 1528
-   i32.lt_s
-   br_if $folding-inner0
-   global.get $~lib/memory/__stack_pointer
-   i32.const 0
-   i32.store
-   local.get $0
-   i32.eqz
-   if
-    global.get $~lib/memory/__stack_pointer
-    i32.const 0
-    i32.const 0
-    call $~lib/rt/itcms/__new
-    local.tee $0
-    i32.store
-   end
-   global.get $~lib/memory/__stack_pointer
-   i32.const 4
-   i32.add
-   global.set $~lib/memory/__stack_pointer
-   local.get $0
-   i32.store
-   global.get $~lib/memory/__stack_pointer
-   local.get $0
-   i32.store offset=4
-   local.get $0
-   i32.const 0
-   i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 8
-   i32.add
-   global.set $~lib/memory/__stack_pointer
-   local.get $0
-   return
+  global.get $~lib/memory/__stack_pointer
+  i32.const 1528
+  i32.lt_s
+  if
+   i32.const 34320
+   i32.const 34368
+   i32.const 1
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
   end
-  i32.const 34320
-  i32.const 34368
-  i32.const 1
-  i32.const 1
-  call $~lib/builtins/abort
-  unreachable
+  global.get $~lib/memory/__stack_pointer
+  i64.const 0
+  i64.store
+  global.get $~lib/memory/__stack_pointer
+  call $~lib/rt/itcms/__new
+  local.tee $0
+  i32.store
+  global.get $~lib/memory/__stack_pointer
+  local.get $0
+  i32.store offset=4
+  global.get $~lib/memory/__stack_pointer
+  local.get $0
+  i32.store
+  global.get $~lib/memory/__stack_pointer
+  local.get $0
+  i32.store offset=4
+  local.get $0
+  i32.const 0
+  i32.store
+  global.get $~lib/memory/__stack_pointer
+  i32.const 8
+  i32.add
+  global.set $~lib/memory/__stack_pointer
+  local.get $0
  )
 )

--- a/tests/compiler/std/array-literal.debug.wat
+++ b/tests/compiler/std/array-literal.debug.wat
@@ -2429,6 +2429,9 @@
   local.get $length_
   i32.store offset=12
  )
+ (func $~lib/object/Object#raw_constructor (param $this i32) (result i32)
+  local.get $this
+ )
  (func $~lib/array/Array<std/array-literal/Ref>#get:length_ (param $this i32) (result i32)
   local.get $this
   i32.load offset=12
@@ -3106,6 +3109,34 @@
   i32.add
   global.set $~lib/memory/__stack_pointer
  )
+ (func $std/array-literal/Ref#raw_constructor (param $this i32) (result i32)
+  (local $1 i32)
+  global.get $~lib/memory/__stack_pointer
+  i32.const 8
+  i32.sub
+  global.set $~lib/memory/__stack_pointer
+  call $~stack_check
+  global.get $~lib/memory/__stack_pointer
+  i64.const 0
+  i64.store
+  global.get $~lib/memory/__stack_pointer
+  local.get $this
+  local.set $1
+  global.get $~lib/memory/__stack_pointer
+  local.get $1
+  i32.store
+  local.get $1
+  call $~lib/object/Object#raw_constructor
+  local.tee $this
+  i32.store offset=4
+  local.get $this
+  local.set $1
+  global.get $~lib/memory/__stack_pointer
+  i32.const 8
+  i32.add
+  global.set $~lib/memory/__stack_pointer
+  local.get $1
+ )
  (func $std/array-literal/Ref#constructor (param $this i32) (result i32)
   (local $1 i32)
   global.get $~lib/memory/__stack_pointer
@@ -3133,7 +3164,7 @@
   local.get $1
   i32.store offset=4
   local.get $1
-  call $~lib/object/Object#constructor
+  call $~lib/object/Object#raw_constructor
   local.tee $this
   i32.store
   local.get $this

--- a/tests/compiler/std/array-literal.release.wat
+++ b/tests/compiler/std/array-literal.release.wat
@@ -163,7 +163,7 @@
    local.get $1
    global.set $~lib/rt/itcms/iter
   end
-  block $__inlined_func$~lib/rt/itcms/Object#unlink$154
+  block $__inlined_func$~lib/rt/itcms/Object#unlink$153
    local.get $0
    i32.load offset=4
    i32.const -4
@@ -187,7 +187,7 @@
      call $~lib/builtins/abort
      unreachable
     end
-    br $__inlined_func$~lib/rt/itcms/Object#unlink$154
+    br $__inlined_func$~lib/rt/itcms/Object#unlink$153
    end
    local.get $0
    i32.load offset=8
@@ -2194,69 +2194,41 @@
  )
  (func $std/array-literal/Ref#constructor (result i32)
   (local $0 i32)
-  (local $1 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 8
   i32.sub
   global.set $~lib/memory/__stack_pointer
-  block $folding-inner0
-   global.get $~lib/memory/__stack_pointer
-   i32.const 1884
-   i32.lt_s
-   br_if $folding-inner0
-   global.get $~lib/memory/__stack_pointer
-   i64.const 0
-   i64.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 0
-   i32.const 6
-   call $~lib/rt/itcms/__new
-   local.tee $0
-   i32.store
-   global.get $~lib/memory/__stack_pointer
-   global.get $~lib/memory/__stack_pointer
-   local.get $0
-   i32.store offset=4
-   global.get $~lib/memory/__stack_pointer
-   i32.const 4
-   i32.sub
-   global.set $~lib/memory/__stack_pointer
-   global.get $~lib/memory/__stack_pointer
-   i32.const 1884
-   i32.lt_s
-   br_if $folding-inner0
-   global.get $~lib/memory/__stack_pointer
-   i32.const 0
-   i32.store
-   local.get $0
-   i32.eqz
-   if
-    global.get $~lib/memory/__stack_pointer
-    i32.const 0
-    i32.const 0
-    call $~lib/rt/itcms/__new
-    local.tee $0
-    i32.store
-   end
-   global.get $~lib/memory/__stack_pointer
-   i32.const 4
-   i32.add
-   global.set $~lib/memory/__stack_pointer
-   local.get $0
-   i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 8
-   i32.add
-   global.set $~lib/memory/__stack_pointer
-   local.get $0
-   return
+  global.get $~lib/memory/__stack_pointer
+  i32.const 1884
+  i32.lt_s
+  if
+   i32.const 34672
+   i32.const 34720
+   i32.const 1
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
   end
-  i32.const 34672
-  i32.const 34720
-  i32.const 1
-  i32.const 1
-  call $~lib/builtins/abort
-  unreachable
+  global.get $~lib/memory/__stack_pointer
+  i64.const 0
+  i64.store
+  global.get $~lib/memory/__stack_pointer
+  i32.const 0
+  i32.const 6
+  call $~lib/rt/itcms/__new
+  local.tee $0
+  i32.store
+  global.get $~lib/memory/__stack_pointer
+  local.get $0
+  i32.store offset=4
+  global.get $~lib/memory/__stack_pointer
+  local.get $0
+  i32.store
+  global.get $~lib/memory/__stack_pointer
+  i32.const 8
+  i32.add
+  global.set $~lib/memory/__stack_pointer
+  local.get $0
  )
  (func $~lib/array/Array<std/array-literal/Ref>#__set (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)

--- a/tests/compiler/std/array.debug.wat
+++ b/tests/compiler/std/array.debug.wat
@@ -4306,6 +4306,9 @@
   local.get $width
   i32.store offset=4
  )
+ (func $~lib/object/Object#raw_constructor (param $this i32) (result i32)
+  local.get $this
+ )
  (func $~lib/array/Array<std/array/Dim>#get:length_ (param $this i32) (result i32)
   local.get $this
   i32.load offset=12
@@ -16116,6 +16119,50 @@
   local.get $4
   return
  )
+ (func $std/array/Dim#raw_constructor (param $this i32) (result i32)
+  (local $1 i32)
+  global.get $~lib/memory/__stack_pointer
+  i32.const 8
+  i32.sub
+  global.set $~lib/memory/__stack_pointer
+  call $~stack_check
+  global.get $~lib/memory/__stack_pointer
+  i64.const 0
+  i64.store
+  global.get $~lib/memory/__stack_pointer
+  local.get $this
+  local.set $1
+  global.get $~lib/memory/__stack_pointer
+  local.get $1
+  i32.store
+  local.get $1
+  call $~lib/object/Object#raw_constructor
+  local.tee $this
+  i32.store offset=4
+  local.get $this
+  local.set $1
+  global.get $~lib/memory/__stack_pointer
+  local.get $1
+  i32.store
+  local.get $1
+  i32.const 0
+  call $std/array/Dim#set:height
+  local.get $this
+  local.set $1
+  global.get $~lib/memory/__stack_pointer
+  local.get $1
+  i32.store
+  local.get $1
+  i32.const 0
+  call $std/array/Dim#set:width
+  local.get $this
+  local.set $1
+  global.get $~lib/memory/__stack_pointer
+  i32.const 8
+  i32.add
+  global.set $~lib/memory/__stack_pointer
+  local.get $1
+ )
  (func $std/array/Dim#constructor (param $this i32) (result i32)
   (local $1 i32)
   global.get $~lib/memory/__stack_pointer
@@ -16143,7 +16190,7 @@
   local.get $1
   i32.store offset=4
   local.get $1
-  call $~lib/object/Object#constructor
+  call $~lib/object/Object#raw_constructor
   local.tee $this
   i32.store
   local.get $this

--- a/tests/compiler/std/array.release.wat
+++ b/tests/compiler/std/array.release.wat
@@ -758,7 +758,7 @@
    local.get $1
    global.set $~lib/rt/itcms/iter
   end
-  block $__inlined_func$~lib/rt/itcms/Object#unlink$731
+  block $__inlined_func$~lib/rt/itcms/Object#unlink$730
    local.get $0
    i32.load offset=4
    i32.const -4
@@ -782,7 +782,7 @@
      call $~lib/builtins/abort
      unreachable
     end
-    br $__inlined_func$~lib/rt/itcms/Object#unlink$731
+    br $__inlined_func$~lib/rt/itcms/Object#unlink$730
    end
    local.get $0
    i32.load offset=8
@@ -10981,81 +10981,53 @@
  )
  (func $std/array/Dim#constructor (result i32)
   (local $0 i32)
-  (local $1 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 8
   i32.sub
   global.set $~lib/memory/__stack_pointer
-  block $folding-inner0
-   global.get $~lib/memory/__stack_pointer
-   i32.const 16192
-   i32.lt_s
-   br_if $folding-inner0
-   global.get $~lib/memory/__stack_pointer
-   i64.const 0
-   i64.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 8
-   i32.const 22
-   call $~lib/rt/itcms/__new
-   local.tee $0
-   i32.store
-   global.get $~lib/memory/__stack_pointer
-   global.get $~lib/memory/__stack_pointer
-   local.get $0
-   i32.store offset=4
-   global.get $~lib/memory/__stack_pointer
-   i32.const 4
-   i32.sub
-   global.set $~lib/memory/__stack_pointer
-   global.get $~lib/memory/__stack_pointer
-   i32.const 16192
-   i32.lt_s
-   br_if $folding-inner0
-   global.get $~lib/memory/__stack_pointer
-   i32.const 0
-   i32.store
-   local.get $0
-   i32.eqz
-   if
-    global.get $~lib/memory/__stack_pointer
-    i32.const 0
-    i32.const 0
-    call $~lib/rt/itcms/__new
-    local.tee $0
-    i32.store
-   end
-   global.get $~lib/memory/__stack_pointer
-   i32.const 4
-   i32.add
-   global.set $~lib/memory/__stack_pointer
-   local.get $0
-   i32.store
-   global.get $~lib/memory/__stack_pointer
-   local.get $0
-   i32.store offset=4
-   local.get $0
-   i32.const 0
-   i32.store
-   global.get $~lib/memory/__stack_pointer
-   local.get $0
-   i32.store offset=4
-   local.get $0
-   i32.const 0
-   i32.store offset=4
-   global.get $~lib/memory/__stack_pointer
-   i32.const 8
-   i32.add
-   global.set $~lib/memory/__stack_pointer
-   local.get $0
-   return
+  global.get $~lib/memory/__stack_pointer
+  i32.const 16192
+  i32.lt_s
+  if
+   i32.const 48992
+   i32.const 49040
+   i32.const 1
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
   end
-  i32.const 48992
-  i32.const 49040
-  i32.const 1
-  i32.const 1
-  call $~lib/builtins/abort
-  unreachable
+  global.get $~lib/memory/__stack_pointer
+  i64.const 0
+  i64.store
+  global.get $~lib/memory/__stack_pointer
+  i32.const 8
+  i32.const 22
+  call $~lib/rt/itcms/__new
+  local.tee $0
+  i32.store
+  global.get $~lib/memory/__stack_pointer
+  local.get $0
+  i32.store offset=4
+  global.get $~lib/memory/__stack_pointer
+  local.get $0
+  i32.store
+  global.get $~lib/memory/__stack_pointer
+  local.get $0
+  i32.store offset=4
+  local.get $0
+  i32.const 0
+  i32.store
+  global.get $~lib/memory/__stack_pointer
+  local.get $0
+  i32.store offset=4
+  local.get $0
+  i32.const 0
+  i32.store offset=4
+  global.get $~lib/memory/__stack_pointer
+  i32.const 8
+  i32.add
+  global.set $~lib/memory/__stack_pointer
+  local.get $0
  )
  (func $~lib/util/sort/SORT<f32> (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
@@ -13086,7 +13058,7 @@
    global.get $~lib/memory/__stack_pointer
    i64.const 0
    i64.store offset=8
-   block $__inlined_func$std/array/isSorted<i32>$658 (result i32)
+   block $__inlined_func$std/array/isSorted<i32>$657 (result i32)
     global.get $~lib/memory/__stack_pointer
     local.get $0
     i32.store offset=8
@@ -13154,7 +13126,7 @@
        i32.add
        global.set $~lib/memory/__stack_pointer
        i32.const 0
-       br $__inlined_func$std/array/isSorted<i32>$658
+       br $__inlined_func$std/array/isSorted<i32>$657
       end
       local.get $0
       i32.const 1
@@ -14391,7 +14363,7 @@
    global.get $~lib/memory/__stack_pointer
    i64.const 0
    i64.store offset=8
-   block $__inlined_func$std/array/isSorted<~lib/array/Array<i32>>$660 (result i32)
+   block $__inlined_func$std/array/isSorted<~lib/array/Array<i32>>$659 (result i32)
     global.get $~lib/memory/__stack_pointer
     local.get $0
     i32.store offset=8
@@ -14474,7 +14446,7 @@
        i32.add
        global.set $~lib/memory/__stack_pointer
        i32.const 0
-       br $__inlined_func$std/array/isSorted<~lib/array/Array<i32>>$660
+       br $__inlined_func$std/array/isSorted<~lib/array/Array<i32>>$659
       end
       local.get $1
       i32.const 1
@@ -14901,7 +14873,7 @@
    global.get $~lib/memory/__stack_pointer
    local.get $1
    i32.store
-   block $__inlined_func$~lib/string/String#concat$736
+   block $__inlined_func$~lib/string/String#concat$735
     local.get $1
     i32.const 20
     i32.sub
@@ -14920,7 +14892,7 @@
      global.set $~lib/memory/__stack_pointer
      i32.const 11568
      local.set $0
-     br $__inlined_func$~lib/string/String#concat$736
+     br $__inlined_func$~lib/string/String#concat$735
     end
     global.get $~lib/memory/__stack_pointer
     local.get $0
@@ -15109,7 +15081,7 @@
    global.get $~lib/memory/__stack_pointer
    i64.const 0
    i64.store
-   block $__inlined_func$~lib/util/string/joinIntegerArray<i32>$738
+   block $__inlined_func$~lib/util/string/joinIntegerArray<i32>$737
     local.get $0
     i32.const 1
     i32.sub
@@ -15123,7 +15095,7 @@
      global.set $~lib/memory/__stack_pointer
      i32.const 11568
      local.set $0
-     br $__inlined_func$~lib/util/string/joinIntegerArray<i32>$738
+     br $__inlined_func$~lib/util/string/joinIntegerArray<i32>$737
     end
     local.get $7
     i32.eqz
@@ -15136,7 +15108,7 @@
      i32.const 8
      i32.add
      global.set $~lib/memory/__stack_pointer
-     br $__inlined_func$~lib/util/string/joinIntegerArray<i32>$738
+     br $__inlined_func$~lib/util/string/joinIntegerArray<i32>$737
     end
     global.get $~lib/memory/__stack_pointer
     local.get $1
@@ -15235,7 +15207,7 @@
      i32.const 8
      i32.add
      global.set $~lib/memory/__stack_pointer
-     br $__inlined_func$~lib/util/string/joinIntegerArray<i32>$738
+     br $__inlined_func$~lib/util/string/joinIntegerArray<i32>$737
     end
     global.get $~lib/memory/__stack_pointer
     i32.const 8
@@ -15301,7 +15273,7 @@
    global.get $~lib/memory/__stack_pointer
    i64.const 0
    i64.store
-   block $__inlined_func$~lib/util/string/joinIntegerArray<u32>$739
+   block $__inlined_func$~lib/util/string/joinIntegerArray<u32>$738
     local.get $0
     i32.const 1
     i32.sub
@@ -15315,7 +15287,7 @@
      global.set $~lib/memory/__stack_pointer
      i32.const 11568
      local.set $0
-     br $__inlined_func$~lib/util/string/joinIntegerArray<u32>$739
+     br $__inlined_func$~lib/util/string/joinIntegerArray<u32>$738
     end
     local.get $7
     i32.eqz
@@ -15328,7 +15300,7 @@
      i32.const 8
      i32.add
      global.set $~lib/memory/__stack_pointer
-     br $__inlined_func$~lib/util/string/joinIntegerArray<u32>$739
+     br $__inlined_func$~lib/util/string/joinIntegerArray<u32>$738
     end
     global.get $~lib/memory/__stack_pointer
     local.get $1
@@ -15427,7 +15399,7 @@
      i32.const 8
      i32.add
      global.set $~lib/memory/__stack_pointer
-     br $__inlined_func$~lib/util/string/joinIntegerArray<u32>$739
+     br $__inlined_func$~lib/util/string/joinIntegerArray<u32>$738
     end
     global.get $~lib/memory/__stack_pointer
     i32.const 8
@@ -16212,7 +16184,7 @@
    global.get $~lib/memory/__stack_pointer
    i64.const 0
    i64.store
-   block $__inlined_func$~lib/util/string/joinIntegerArray<i8>$740
+   block $__inlined_func$~lib/util/string/joinIntegerArray<i8>$739
     local.get $0
     i32.const 1
     i32.sub
@@ -16226,7 +16198,7 @@
      global.set $~lib/memory/__stack_pointer
      i32.const 11568
      local.set $0
-     br $__inlined_func$~lib/util/string/joinIntegerArray<i8>$740
+     br $__inlined_func$~lib/util/string/joinIntegerArray<i8>$739
     end
     local.get $6
     i32.eqz
@@ -16239,7 +16211,7 @@
      i32.const 8
      i32.add
      global.set $~lib/memory/__stack_pointer
-     br $__inlined_func$~lib/util/string/joinIntegerArray<i8>$740
+     br $__inlined_func$~lib/util/string/joinIntegerArray<i8>$739
     end
     global.get $~lib/memory/__stack_pointer
     i32.const 11856
@@ -16332,7 +16304,7 @@
      i32.const 8
      i32.add
      global.set $~lib/memory/__stack_pointer
-     br $__inlined_func$~lib/util/string/joinIntegerArray<i8>$740
+     br $__inlined_func$~lib/util/string/joinIntegerArray<i8>$739
     end
     global.get $~lib/memory/__stack_pointer
     i32.const 8
@@ -16419,7 +16391,7 @@
    global.get $~lib/memory/__stack_pointer
    i64.const 0
    i64.store
-   block $__inlined_func$~lib/util/string/joinIntegerArray<u16>$741
+   block $__inlined_func$~lib/util/string/joinIntegerArray<u16>$740
     local.get $0
     i32.const 1
     i32.sub
@@ -16433,7 +16405,7 @@
      global.set $~lib/memory/__stack_pointer
      i32.const 11568
      local.set $0
-     br $__inlined_func$~lib/util/string/joinIntegerArray<u16>$741
+     br $__inlined_func$~lib/util/string/joinIntegerArray<u16>$740
     end
     local.get $6
     i32.eqz
@@ -16446,7 +16418,7 @@
      i32.const 8
      i32.add
      global.set $~lib/memory/__stack_pointer
-     br $__inlined_func$~lib/util/string/joinIntegerArray<u16>$741
+     br $__inlined_func$~lib/util/string/joinIntegerArray<u16>$740
     end
     global.get $~lib/memory/__stack_pointer
     i32.const 11856
@@ -16543,7 +16515,7 @@
      i32.const 8
      i32.add
      global.set $~lib/memory/__stack_pointer
-     br $__inlined_func$~lib/util/string/joinIntegerArray<u16>$741
+     br $__inlined_func$~lib/util/string/joinIntegerArray<u16>$740
     end
     global.get $~lib/memory/__stack_pointer
     i32.const 8
@@ -16630,7 +16602,7 @@
    global.get $~lib/memory/__stack_pointer
    i64.const 0
    i64.store
-   block $__inlined_func$~lib/util/string/joinIntegerArray<i16>$742
+   block $__inlined_func$~lib/util/string/joinIntegerArray<i16>$741
     local.get $0
     i32.const 1
     i32.sub
@@ -16644,7 +16616,7 @@
      global.set $~lib/memory/__stack_pointer
      i32.const 11568
      local.set $0
-     br $__inlined_func$~lib/util/string/joinIntegerArray<i16>$742
+     br $__inlined_func$~lib/util/string/joinIntegerArray<i16>$741
     end
     local.get $6
     i32.eqz
@@ -16657,7 +16629,7 @@
      i32.const 8
      i32.add
      global.set $~lib/memory/__stack_pointer
-     br $__inlined_func$~lib/util/string/joinIntegerArray<i16>$742
+     br $__inlined_func$~lib/util/string/joinIntegerArray<i16>$741
     end
     global.get $~lib/memory/__stack_pointer
     i32.const 11856
@@ -16754,7 +16726,7 @@
      i32.const 8
      i32.add
      global.set $~lib/memory/__stack_pointer
-     br $__inlined_func$~lib/util/string/joinIntegerArray<i16>$742
+     br $__inlined_func$~lib/util/string/joinIntegerArray<i16>$741
     end
     global.get $~lib/memory/__stack_pointer
     i32.const 8
@@ -17185,7 +17157,7 @@
    global.get $~lib/memory/__stack_pointer
    i64.const 0
    i64.store
-   block $__inlined_func$~lib/util/string/joinIntegerArray<u8>$743
+   block $__inlined_func$~lib/util/string/joinIntegerArray<u8>$742
     local.get $0
     i32.const 1
     i32.sub
@@ -17199,7 +17171,7 @@
      global.set $~lib/memory/__stack_pointer
      i32.const 11568
      local.set $0
-     br $__inlined_func$~lib/util/string/joinIntegerArray<u8>$743
+     br $__inlined_func$~lib/util/string/joinIntegerArray<u8>$742
     end
     local.get $6
     i32.eqz
@@ -17212,7 +17184,7 @@
      i32.const 8
      i32.add
      global.set $~lib/memory/__stack_pointer
-     br $__inlined_func$~lib/util/string/joinIntegerArray<u8>$743
+     br $__inlined_func$~lib/util/string/joinIntegerArray<u8>$742
     end
     global.get $~lib/memory/__stack_pointer
     i32.const 11856
@@ -17305,7 +17277,7 @@
      i32.const 8
      i32.add
      global.set $~lib/memory/__stack_pointer
-     br $__inlined_func$~lib/util/string/joinIntegerArray<u8>$743
+     br $__inlined_func$~lib/util/string/joinIntegerArray<u8>$742
     end
     global.get $~lib/memory/__stack_pointer
     i32.const 8
@@ -21553,7 +21525,7 @@
    global.get $~lib/memory/__stack_pointer
    local.get $2
    i32.store
-   block $__inlined_func$~lib/array/Array<f32>#indexOf$714
+   block $__inlined_func$~lib/array/Array<f32>#indexOf$713
     local.get $2
     i32.load offset=12
     local.tee $4
@@ -21569,7 +21541,7 @@
      global.set $~lib/memory/__stack_pointer
      i32.const -1
      local.set $0
-     br $__inlined_func$~lib/array/Array<f32>#indexOf$714
+     br $__inlined_func$~lib/array/Array<f32>#indexOf$713
     end
     global.get $~lib/memory/__stack_pointer
     local.get $2
@@ -21595,7 +21567,7 @@
        i32.const 4
        i32.add
        global.set $~lib/memory/__stack_pointer
-       br $__inlined_func$~lib/array/Array<f32>#indexOf$714
+       br $__inlined_func$~lib/array/Array<f32>#indexOf$713
       end
       local.get $0
       i32.const 1
@@ -21647,7 +21619,7 @@
    global.get $~lib/memory/__stack_pointer
    local.get $2
    i32.store
-   block $__inlined_func$~lib/array/Array<f64>#indexOf$715
+   block $__inlined_func$~lib/array/Array<f64>#indexOf$714
     local.get $2
     i32.load offset=12
     local.tee $4
@@ -21663,7 +21635,7 @@
      global.set $~lib/memory/__stack_pointer
      i32.const -1
      local.set $0
-     br $__inlined_func$~lib/array/Array<f64>#indexOf$715
+     br $__inlined_func$~lib/array/Array<f64>#indexOf$714
     end
     global.get $~lib/memory/__stack_pointer
     local.get $2
@@ -21689,7 +21661,7 @@
        i32.const 4
        i32.add
        global.set $~lib/memory/__stack_pointer
-       br $__inlined_func$~lib/array/Array<f64>#indexOf$715
+       br $__inlined_func$~lib/array/Array<f64>#indexOf$714
       end
       local.get $0
       i32.const 1
@@ -22000,7 +21972,7 @@
     call $~lib/builtins/abort
     unreachable
    end
-   block $__inlined_func$~lib/array/Array<f32>#includes$716 (result i32)
+   block $__inlined_func$~lib/array/Array<f32>#includes$715 (result i32)
     i32.const 1
     i32.const 2
     i32.const 9
@@ -22040,7 +22012,7 @@
      i32.add
      global.set $~lib/memory/__stack_pointer
      i32.const 0
-     br $__inlined_func$~lib/array/Array<f32>#includes$716
+     br $__inlined_func$~lib/array/Array<f32>#includes$715
     end
     global.get $~lib/memory/__stack_pointer
     local.get $2
@@ -22068,7 +22040,7 @@
        i32.add
        global.set $~lib/memory/__stack_pointer
        i32.const 1
-       br $__inlined_func$~lib/array/Array<f32>#includes$716
+       br $__inlined_func$~lib/array/Array<f32>#includes$715
       end
       local.get $0
       i32.const 1
@@ -22092,7 +22064,7 @@
     call $~lib/builtins/abort
     unreachable
    end
-   block $__inlined_func$~lib/array/Array<f64>#includes$717 (result i32)
+   block $__inlined_func$~lib/array/Array<f64>#includes$716 (result i32)
     i32.const 1
     i32.const 3
     i32.const 12
@@ -22132,7 +22104,7 @@
      i32.add
      global.set $~lib/memory/__stack_pointer
      i32.const 0
-     br $__inlined_func$~lib/array/Array<f64>#includes$717
+     br $__inlined_func$~lib/array/Array<f64>#includes$716
     end
     global.get $~lib/memory/__stack_pointer
     local.get $2
@@ -22160,7 +22132,7 @@
        i32.add
        global.set $~lib/memory/__stack_pointer
        i32.const 1
-       br $__inlined_func$~lib/array/Array<f64>#includes$717
+       br $__inlined_func$~lib/array/Array<f64>#includes$716
       end
       local.get $0
       i32.const 1
@@ -27514,7 +27486,7 @@
    global.get $~lib/memory/__stack_pointer
    i64.const 0
    i64.store offset=8
-   block $__inlined_func$std/array/isSorted<~lib/string/String|null>$662 (result i32)
+   block $__inlined_func$std/array/isSorted<~lib/string/String|null>$661 (result i32)
     global.get $~lib/memory/__stack_pointer
     local.get $0
     i32.store offset=8
@@ -27595,7 +27567,7 @@
        i32.add
        global.set $~lib/memory/__stack_pointer
        i32.const 0
-       br $__inlined_func$std/array/isSorted<~lib/string/String|null>$662
+       br $__inlined_func$std/array/isSorted<~lib/string/String|null>$661
       end
       local.get $1
       i32.const 1
@@ -27627,7 +27599,7 @@
    i32.const 12
    i32.add
    global.set $~lib/memory/__stack_pointer
-   block $__inlined_func$std/array/isArraysEqual<~lib/string/String|null>$748 (result i32)
+   block $__inlined_func$std/array/isArraysEqual<~lib/string/String|null>$747 (result i32)
     global.get $~lib/memory/__stack_pointer
     local.get $0
     i32.store
@@ -27667,7 +27639,7 @@
      i32.add
      global.set $~lib/memory/__stack_pointer
      i32.const 0
-     br $__inlined_func$std/array/isArraysEqual<~lib/string/String|null>$748
+     br $__inlined_func$std/array/isArraysEqual<~lib/string/String|null>$747
     end
     local.get $0
     local.get $2
@@ -27678,7 +27650,7 @@
      i32.add
      global.set $~lib/memory/__stack_pointer
      i32.const 1
-     br $__inlined_func$std/array/isArraysEqual<~lib/string/String|null>$748
+     br $__inlined_func$std/array/isArraysEqual<~lib/string/String|null>$747
     end
     i32.const 0
     local.set $1
@@ -27738,7 +27710,7 @@
        i32.add
        global.set $~lib/memory/__stack_pointer
        i32.const 0
-       br $__inlined_func$std/array/isArraysEqual<~lib/string/String|null>$748
+       br $__inlined_func$std/array/isArraysEqual<~lib/string/String|null>$747
       end
       local.get $1
       i32.const 1
@@ -27942,7 +27914,7 @@
        global.get $~lib/memory/__stack_pointer
        i32.const 10032
        i32.store
-       block $__inlined_func$~lib/string/String#charAt$737
+       block $__inlined_func$~lib/string/String#charAt$736
         local.get $12
         i32.const 10028
         i32.load
@@ -27956,7 +27928,7 @@
          global.set $~lib/memory/__stack_pointer
          i32.const 11568
          local.set $2
-         br $__inlined_func$~lib/string/String#charAt$737
+         br $__inlined_func$~lib/string/String#charAt$736
         end
         global.get $~lib/memory/__stack_pointer
         i32.const 2

--- a/tests/compiler/std/object.debug.wat
+++ b/tests/compiler/std/object.debug.wat
@@ -454,6 +454,9 @@
   end
   local.get $this
  )
+ (func $~lib/object/Object#raw_constructor (param $this i32) (result i32)
+  local.get $this
+ )
  (func $~lib/object/Object#constructor (param $this i32) (result i32)
   local.get $this
   i32.eqz

--- a/tests/compiler/std/staticarray.debug.wat
+++ b/tests/compiler/std/staticarray.debug.wat
@@ -2374,6 +2374,9 @@
   call $~lib/rt/__newBuffer
   return
  )
+ (func $~lib/object/Object#raw_constructor (param $this i32) (result i32)
+  local.get $this
+ )
  (func $~lib/rt/itcms/__link (param $parentPtr i32) (param $childPtr i32) (param $expectMultiple i32)
   (local $child i32)
   (local $parent i32)
@@ -3935,6 +3938,34 @@
   i32.add
   global.set $~lib/memory/__stack_pointer
  )
+ (func $std/staticarray/Ref#raw_constructor (param $this i32) (result i32)
+  (local $1 i32)
+  global.get $~lib/memory/__stack_pointer
+  i32.const 8
+  i32.sub
+  global.set $~lib/memory/__stack_pointer
+  call $~stack_check
+  global.get $~lib/memory/__stack_pointer
+  i64.const 0
+  i64.store
+  global.get $~lib/memory/__stack_pointer
+  local.get $this
+  local.set $1
+  global.get $~lib/memory/__stack_pointer
+  local.get $1
+  i32.store
+  local.get $1
+  call $~lib/object/Object#raw_constructor
+  local.tee $this
+  i32.store offset=4
+  local.get $this
+  local.set $1
+  global.get $~lib/memory/__stack_pointer
+  i32.const 8
+  i32.add
+  global.set $~lib/memory/__stack_pointer
+  local.get $1
+ )
  (func $std/staticarray/Ref#constructor (param $this i32) (result i32)
   (local $1 i32)
   global.get $~lib/memory/__stack_pointer
@@ -3962,7 +3993,7 @@
   local.get $1
   i32.store offset=4
   local.get $1
-  call $~lib/object/Object#constructor
+  call $~lib/object/Object#raw_constructor
   local.tee $this
   i32.store
   local.get $this

--- a/tests/compiler/std/staticarray.release.wat
+++ b/tests/compiler/std/staticarray.release.wat
@@ -260,7 +260,7 @@
    local.get $1
    global.set $~lib/rt/itcms/iter
   end
-  block $__inlined_func$~lib/rt/itcms/Object#unlink$267
+  block $__inlined_func$~lib/rt/itcms/Object#unlink$266
    local.get $0
    i32.load offset=4
    i32.const -4
@@ -284,7 +284,7 @@
      call $~lib/builtins/abort
      unreachable
     end
-    br $__inlined_func$~lib/rt/itcms/Object#unlink$267
+    br $__inlined_func$~lib/rt/itcms/Object#unlink$266
    end
    local.get $0
    i32.load offset=8
@@ -2511,69 +2511,41 @@
  )
  (func $std/staticarray/Ref#constructor (result i32)
   (local $0 i32)
-  (local $1 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 8
   i32.sub
   global.set $~lib/memory/__stack_pointer
-  block $folding-inner0
-   global.get $~lib/memory/__stack_pointer
-   i32.const 3960
-   i32.lt_s
-   br_if $folding-inner0
-   global.get $~lib/memory/__stack_pointer
-   i64.const 0
-   i64.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 0
-   i32.const 5
-   call $~lib/rt/itcms/__new
-   local.tee $0
-   i32.store
-   global.get $~lib/memory/__stack_pointer
-   global.get $~lib/memory/__stack_pointer
-   local.get $0
-   i32.store offset=4
-   global.get $~lib/memory/__stack_pointer
-   i32.const 4
-   i32.sub
-   global.set $~lib/memory/__stack_pointer
-   global.get $~lib/memory/__stack_pointer
-   i32.const 3960
-   i32.lt_s
-   br_if $folding-inner0
-   global.get $~lib/memory/__stack_pointer
-   i32.const 0
-   i32.store
-   local.get $0
-   i32.eqz
-   if
-    global.get $~lib/memory/__stack_pointer
-    i32.const 0
-    i32.const 0
-    call $~lib/rt/itcms/__new
-    local.tee $0
-    i32.store
-   end
-   global.get $~lib/memory/__stack_pointer
-   i32.const 4
-   i32.add
-   global.set $~lib/memory/__stack_pointer
-   local.get $0
-   i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 8
-   i32.add
-   global.set $~lib/memory/__stack_pointer
-   local.get $0
-   return
+  global.get $~lib/memory/__stack_pointer
+  i32.const 3960
+  i32.lt_s
+  if
+   i32.const 36752
+   i32.const 36800
+   i32.const 1
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
   end
-  i32.const 36752
-  i32.const 36800
-  i32.const 1
-  i32.const 1
-  call $~lib/builtins/abort
-  unreachable
+  global.get $~lib/memory/__stack_pointer
+  i64.const 0
+  i64.store
+  global.get $~lib/memory/__stack_pointer
+  i32.const 0
+  i32.const 5
+  call $~lib/rt/itcms/__new
+  local.tee $0
+  i32.store
+  global.get $~lib/memory/__stack_pointer
+  local.get $0
+  i32.store offset=4
+  global.get $~lib/memory/__stack_pointer
+  local.get $0
+  i32.store
+  global.get $~lib/memory/__stack_pointer
+  i32.const 8
+  i32.add
+  global.set $~lib/memory/__stack_pointer
+  local.get $0
  )
  (func $~lib/array/Array<i32>#get:length (param $0 i32) (result i32)
   global.get $~lib/memory/__stack_pointer
@@ -3376,7 +3348,7 @@
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store
-   block $__inlined_func$~lib/staticarray/StaticArray<~lib/string/String>#indexOf$274
+   block $__inlined_func$~lib/staticarray/StaticArray<~lib/string/String>#indexOf$273
     local.get $0
     i32.const 20
     i32.sub
@@ -3396,7 +3368,7 @@
      global.set $~lib/memory/__stack_pointer
      i32.const -1
      local.set $2
-     br $__inlined_func$~lib/staticarray/StaticArray<~lib/string/String>#indexOf$274
+     br $__inlined_func$~lib/staticarray/StaticArray<~lib/string/String>#indexOf$273
     end
     local.get $2
     i32.const 0
@@ -3438,7 +3410,7 @@
        i32.const 8
        i32.add
        global.set $~lib/memory/__stack_pointer
-       br $__inlined_func$~lib/staticarray/StaticArray<~lib/string/String>#indexOf$274
+       br $__inlined_func$~lib/staticarray/StaticArray<~lib/string/String>#indexOf$273
       end
       local.get $2
       i32.const 1
@@ -4088,7 +4060,7 @@
        global.get $~lib/memory/__stack_pointer
        local.get $10
        i32.store
-       block $__inlined_func$~lib/rt/itcms/__renew$224
+       block $__inlined_func$~lib/rt/itcms/__renew$223
         i32.const 1073741820
         local.get $1
         i32.const 1
@@ -4131,7 +4103,7 @@
          i32.store offset=16
          local.get $1
          local.set $2
-         br $__inlined_func$~lib/rt/itcms/__renew$224
+         br $__inlined_func$~lib/rt/itcms/__renew$223
         end
         local.get $4
         local.get $3
@@ -6324,7 +6296,7 @@
     call $~lib/builtins/abort
     unreachable
    end
-   block $__inlined_func$~lib/staticarray/StaticArray<f64>#includes$276 (result i32)
+   block $__inlined_func$~lib/staticarray/StaticArray<f64>#includes$275 (result i32)
     i32.const 8
     i32.const 10
     call $~lib/rt/itcms/__new
@@ -6365,7 +6337,7 @@
      i32.add
      global.set $~lib/memory/__stack_pointer
      i32.const 0
-     br $__inlined_func$~lib/staticarray/StaticArray<f64>#includes$276
+     br $__inlined_func$~lib/staticarray/StaticArray<f64>#includes$275
     end
     loop $while-continue|0
      local.get $1
@@ -6387,7 +6359,7 @@
        i32.add
        global.set $~lib/memory/__stack_pointer
        i32.const 1
-       br $__inlined_func$~lib/staticarray/StaticArray<f64>#includes$276
+       br $__inlined_func$~lib/staticarray/StaticArray<f64>#includes$275
       end
       local.get $1
       i32.const 1
@@ -6411,7 +6383,7 @@
     call $~lib/builtins/abort
     unreachable
    end
-   block $__inlined_func$~lib/staticarray/StaticArray<f32>#includes$277 (result i32)
+   block $__inlined_func$~lib/staticarray/StaticArray<f32>#includes$276 (result i32)
     i32.const 4
     i32.const 11
     call $~lib/rt/itcms/__new
@@ -6452,7 +6424,7 @@
      i32.add
      global.set $~lib/memory/__stack_pointer
      i32.const 0
-     br $__inlined_func$~lib/staticarray/StaticArray<f32>#includes$277
+     br $__inlined_func$~lib/staticarray/StaticArray<f32>#includes$276
     end
     loop $while-continue|030
      local.get $1
@@ -6474,7 +6446,7 @@
        i32.add
        global.set $~lib/memory/__stack_pointer
        i32.const 1
-       br $__inlined_func$~lib/staticarray/StaticArray<f32>#includes$277
+       br $__inlined_func$~lib/staticarray/StaticArray<f32>#includes$276
       end
       local.get $1
       i32.const 1

--- a/tests/compiler/super-inline.debug.wat
+++ b/tests/compiler/super-inline.debug.wat
@@ -43,6 +43,9 @@
  (elem $0 (i32.const 1))
  (export "memory" (memory $0))
  (start $~start)
+ (func $~lib/object/Object#raw_constructor (param $this i32) (result i32)
+  local.get $this
+ )
  (func $~lib/rt/itcms/Object#set:nextWithColor (param $this i32) (param $nextWithColor i32)
   local.get $this
   local.get $nextWithColor
@@ -2351,6 +2354,34 @@
    unreachable
   end
  )
+ (func $super-inline/Foo#raw_constructor (param $this i32) (result i32)
+  (local $1 i32)
+  global.get $~lib/memory/__stack_pointer
+  i32.const 8
+  i32.sub
+  global.set $~lib/memory/__stack_pointer
+  call $~stack_check
+  global.get $~lib/memory/__stack_pointer
+  i64.const 0
+  i64.store
+  global.get $~lib/memory/__stack_pointer
+  local.get $this
+  local.set $1
+  global.get $~lib/memory/__stack_pointer
+  local.get $1
+  i32.store
+  local.get $1
+  call $~lib/object/Object#raw_constructor
+  local.tee $this
+  i32.store offset=4
+  local.get $this
+  local.set $1
+  global.get $~lib/memory/__stack_pointer
+  i32.const 8
+  i32.add
+  global.set $~lib/memory/__stack_pointer
+  local.get $1
+ )
  (func $super-inline/Foo#constructor (param $this i32) (result i32)
   (local $1 i32)
   global.get $~lib/memory/__stack_pointer
@@ -2378,9 +2409,37 @@
   local.get $1
   i32.store offset=4
   local.get $1
-  call $~lib/object/Object#constructor
+  call $~lib/object/Object#raw_constructor
   local.tee $this
   i32.store
+  local.get $this
+  local.set $1
+  global.get $~lib/memory/__stack_pointer
+  i32.const 8
+  i32.add
+  global.set $~lib/memory/__stack_pointer
+  local.get $1
+ )
+ (func $super-inline/Bar#raw_constructor (param $this i32) (result i32)
+  (local $1 i32)
+  global.get $~lib/memory/__stack_pointer
+  i32.const 8
+  i32.sub
+  global.set $~lib/memory/__stack_pointer
+  call $~stack_check
+  global.get $~lib/memory/__stack_pointer
+  i64.const 0
+  i64.store
+  global.get $~lib/memory/__stack_pointer
+  local.get $this
+  local.set $1
+  global.get $~lib/memory/__stack_pointer
+  local.get $1
+  i32.store
+  local.get $1
+  call $super-inline/Foo#raw_constructor
+  local.tee $this
+  i32.store offset=4
   local.get $this
   local.set $1
   global.get $~lib/memory/__stack_pointer
@@ -2416,7 +2475,7 @@
   local.get $1
   i32.store offset=4
   local.get $1
-  call $super-inline/Foo#constructor
+  call $super-inline/Foo#raw_constructor
   local.tee $this
   i32.store
   local.get $this

--- a/tests/compiler/super-inline.release.wat
+++ b/tests/compiler/super-inline.release.wat
@@ -1,8 +1,8 @@
 (module
  (type $0 (func))
  (type $1 (func (param i32)))
- (type $2 (func (param i32) (result i32)))
- (type $3 (func (param i32 i32)))
+ (type $2 (func (param i32 i32)))
+ (type $3 (func (param i32) (result i32)))
  (type $4 (func (param i32 i32 i32 i32)))
  (type $5 (func (param i32 i32 i64)))
  (type $6 (func (result i32)))
@@ -129,7 +129,7 @@
     local.get $0
     global.set $~lib/rt/itcms/iter
    end
-   block $__inlined_func$~lib/rt/itcms/Object#unlink$116
+   block $__inlined_func$~lib/rt/itcms/Object#unlink$118
     local.get $1
     i32.load offset=4
     i32.const -4
@@ -153,7 +153,7 @@
       call $~lib/builtins/abort
       unreachable
      end
-     br $__inlined_func$~lib/rt/itcms/Object#unlink$116
+     br $__inlined_func$~lib/rt/itcms/Object#unlink$118
     end
     local.get $1
     i32.load offset=8
@@ -1412,6 +1412,7 @@
  )
  (func $~start
   (local $0 i32)
+  (local $1 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 4
   i32.sub
@@ -1456,8 +1457,33 @@
    i32.store
    i32.const 1344
    global.set $~lib/rt/itcms/fromSpace
-   i32.const 0
-   call $super-inline/Foo#constructor
+   global.get $~lib/memory/__stack_pointer
+   i32.const 8
+   i32.sub
+   global.set $~lib/memory/__stack_pointer
+   global.get $~lib/memory/__stack_pointer
+   i32.const 1468
+   i32.lt_s
+   br_if $folding-inner0
+   global.get $~lib/memory/__stack_pointer
+   i64.const 0
+   i64.store
+   global.get $~lib/memory/__stack_pointer
+   i32.const 4
+   call $~lib/rt/itcms/__new
+   local.tee $0
+   i32.store
+   global.get $~lib/memory/__stack_pointer
+   local.get $0
+   i32.store offset=4
+   global.get $~lib/memory/__stack_pointer
+   local.get $0
+   i32.store
+   global.get $~lib/memory/__stack_pointer
+   i32.const 8
+   i32.add
+   global.set $~lib/memory/__stack_pointer
+   local.get $0
    global.set $super-inline/foo
    global.get $~lib/memory/__stack_pointer
    global.get $super-inline/foo
@@ -1490,12 +1516,31 @@
    local.tee $0
    i32.store
    global.get $~lib/memory/__stack_pointer
+   global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store offset=4
    global.get $~lib/memory/__stack_pointer
+   i32.const 8
+   i32.sub
+   global.set $~lib/memory/__stack_pointer
+   global.get $~lib/memory/__stack_pointer
+   i32.const 1468
+   i32.lt_s
+   br_if $folding-inner0
+   global.get $~lib/memory/__stack_pointer
+   i64.const 0
+   i64.store
+   global.get $~lib/memory/__stack_pointer
    local.get $0
-   call $super-inline/Foo#constructor
-   local.tee $0
+   i32.store
+   global.get $~lib/memory/__stack_pointer
+   local.get $0
+   i32.store offset=4
+   global.get $~lib/memory/__stack_pointer
+   i32.const 8
+   i32.add
+   global.set $~lib/memory/__stack_pointer
+   local.get $0
    i32.store
    global.get $~lib/memory/__stack_pointer
    i32.const 8
@@ -1513,73 +1558,6 @@
    i32.const 4
    i32.add
    global.set $~lib/memory/__stack_pointer
-   return
-  end
-  i32.const 34256
-  i32.const 34304
-  i32.const 1
-  i32.const 1
-  call $~lib/builtins/abort
-  unreachable
- )
- (func $super-inline/Foo#constructor (param $0 i32) (result i32)
-  (local $1 i32)
-  global.get $~lib/memory/__stack_pointer
-  i32.const 8
-  i32.sub
-  global.set $~lib/memory/__stack_pointer
-  block $folding-inner0
-   global.get $~lib/memory/__stack_pointer
-   i32.const 1468
-   i32.lt_s
-   br_if $folding-inner0
-   global.get $~lib/memory/__stack_pointer
-   i64.const 0
-   i64.store
-   local.get $0
-   i32.eqz
-   if
-    global.get $~lib/memory/__stack_pointer
-    i32.const 4
-    call $~lib/rt/itcms/__new
-    local.tee $0
-    i32.store
-   end
-   global.get $~lib/memory/__stack_pointer
-   global.get $~lib/memory/__stack_pointer
-   local.get $0
-   i32.store offset=4
-   global.get $~lib/memory/__stack_pointer
-   i32.const 4
-   i32.sub
-   global.set $~lib/memory/__stack_pointer
-   global.get $~lib/memory/__stack_pointer
-   i32.const 1468
-   i32.lt_s
-   br_if $folding-inner0
-   global.get $~lib/memory/__stack_pointer
-   i32.const 0
-   i32.store
-   local.get $0
-   i32.eqz
-   if
-    global.get $~lib/memory/__stack_pointer
-    i32.const 0
-    call $~lib/rt/itcms/__new
-    local.tee $0
-    i32.store
-   end
-   global.get $~lib/memory/__stack_pointer
-   i32.const 4
-   i32.add
-   global.set $~lib/memory/__stack_pointer
-   local.get $0
-   i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 8
-   i32.add
-   global.set $~lib/memory/__stack_pointer
-   local.get $0
    return
   end
   i32.const 34256

--- a/tests/compiler/typeof.debug.wat
+++ b/tests/compiler/typeof.debug.wat
@@ -181,6 +181,9 @@
  )
  (func $start:typeof~anonymous|0
  )
+ (func $~lib/object/Object#raw_constructor (param $this i32) (result i32)
+  local.get $this
+ )
  (func $~lib/rt/itcms/Object#set:nextWithColor (param $this i32) (param $nextWithColor i32)
   local.get $this
   local.get $nextWithColor
@@ -2580,6 +2583,34 @@
   local.get $3
   return
  )
+ (func $typeof/SomeClass#raw_constructor (param $this i32) (result i32)
+  (local $1 i32)
+  global.get $~lib/memory/__stack_pointer
+  i32.const 8
+  i32.sub
+  global.set $~lib/memory/__stack_pointer
+  call $~stack_check
+  global.get $~lib/memory/__stack_pointer
+  i64.const 0
+  i64.store
+  global.get $~lib/memory/__stack_pointer
+  local.get $this
+  local.set $1
+  global.get $~lib/memory/__stack_pointer
+  local.get $1
+  i32.store
+  local.get $1
+  call $~lib/object/Object#raw_constructor
+  local.tee $this
+  i32.store offset=4
+  local.get $this
+  local.set $1
+  global.get $~lib/memory/__stack_pointer
+  i32.const 8
+  i32.add
+  global.set $~lib/memory/__stack_pointer
+  local.get $1
+ )
  (func $typeof/SomeClass#constructor (param $this i32) (result i32)
   (local $1 i32)
   global.get $~lib/memory/__stack_pointer
@@ -2607,7 +2638,7 @@
   local.get $1
   i32.store offset=4
   local.get $1
-  call $~lib/object/Object#constructor
+  call $~lib/object/Object#raw_constructor
   local.tee $this
   i32.store
   local.get $this

--- a/tests/compiler/typeof.release.wat
+++ b/tests/compiler/typeof.release.wat
@@ -2,10 +2,10 @@
  (type $0 (func))
  (type $1 (func (param i32)))
  (type $2 (func (param i32 i32)))
- (type $3 (func (param i32) (result i32)))
+ (type $3 (func (result i32)))
  (type $4 (func (param i32 i32 i32 i32)))
  (type $5 (func (param i32 i32 i64)))
- (type $6 (func (result i32)))
+ (type $6 (func (param i32) (result i32)))
  (type $7 (func (param i32 i32) (result i32)))
  (import "env" "abort" (func $~lib/builtins/abort (param i32 i32 i32 i32)))
  (global $~lib/rt/itcms/total (mut i32) (i32.const 0))
@@ -1162,23 +1162,23 @@
    end
   end
  )
- (func $~lib/rt/itcms/__new (param $0 i32) (result i32)
+ (func $~lib/rt/itcms/__new (result i32)
+  (local $0 i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
-  (local $4 i32)
   global.get $~lib/rt/itcms/total
   global.get $~lib/rt/itcms/threshold
   i32.ge_u
   if
    block $__inlined_func$~lib/rt/itcms/interrupt$70
     i32.const 2048
-    local.set $1
+    local.set $0
     loop $do-loop|0
-     local.get $1
+     local.get $0
      call $~lib/rt/itcms/step
      i32.sub
-     local.set $1
+     local.set $0
      global.get $~lib/rt/itcms/state
      i32.eqz
      if
@@ -1194,7 +1194,7 @@
       global.set $~lib/rt/itcms/threshold
       br $__inlined_func$~lib/rt/itcms/interrupt$70
      end
-     local.get $1
+     local.get $0
      i32.const 0
      i32.gt_s
      br_if $do-loop|0
@@ -1217,17 +1217,17 @@
    call $~lib/rt/tlsf/initialize
   end
   global.get $~lib/rt/tlsf/ROOT
-  local.tee $2
-  call $~lib/rt/tlsf/searchBlock
   local.tee $1
+  call $~lib/rt/tlsf/searchBlock
+  local.tee $0
   i32.eqz
   if
    memory.size
-   local.tee $1
+   local.tee $0
    i32.const 4
-   local.get $2
-   i32.load offset=1568
    local.get $1
+   i32.load offset=1568
+   local.get $0
    i32.const 16
    i32.shl
    i32.const 4
@@ -1240,16 +1240,16 @@
    i32.and
    i32.const 16
    i32.shr_u
-   local.tee $3
-   local.get $1
-   local.get $3
+   local.tee $2
+   local.get $0
+   local.get $2
    i32.gt_s
    select
    memory.grow
    i32.const 0
    i32.lt_s
    if
-    local.get $3
+    local.get $2
     memory.grow
     i32.const 0
     i32.lt_s
@@ -1257,8 +1257,8 @@
      unreachable
     end
    end
-   local.get $2
    local.get $1
+   local.get $0
    i32.const 16
    i32.shl
    memory.size
@@ -1266,9 +1266,9 @@
    i64.const 16
    i64.shl
    call $~lib/rt/tlsf/addMemory
-   local.get $2
+   local.get $1
    call $~lib/rt/tlsf/searchBlock
-   local.tee $1
+   local.tee $0
    i32.eqz
    if
     i32.const 0
@@ -1279,7 +1279,7 @@
     unreachable
    end
   end
-  local.get $1
+  local.get $0
   i32.load
   i32.const -4
   i32.and
@@ -1293,92 +1293,92 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $2
   local.get $1
+  local.get $0
   call $~lib/rt/tlsf/removeBlock
-  local.get $1
+  local.get $0
   i32.load
-  local.tee $3
+  local.tee $2
   i32.const -4
   i32.and
   i32.const 28
   i32.sub
-  local.tee $4
+  local.tee $3
   i32.const 16
   i32.ge_u
   if
-   local.get $1
-   local.get $3
+   local.get $0
+   local.get $2
    i32.const 2
    i32.and
    i32.const 28
    i32.or
    i32.store
-   local.get $1
+   local.get $0
    i32.const 32
    i32.add
-   local.tee $3
-   local.get $4
+   local.tee $2
+   local.get $3
    i32.const 4
    i32.sub
    i32.const 1
    i32.or
    i32.store
+   local.get $1
    local.get $2
-   local.get $3
    call $~lib/rt/tlsf/insertBlock
   else
-   local.get $1
-   local.get $3
+   local.get $0
+   local.get $2
    i32.const -2
    i32.and
    i32.store
-   local.get $1
+   local.get $0
    i32.const 4
    i32.add
-   local.get $1
+   local.get $0
    i32.load
    i32.const -4
    i32.and
    i32.add
-   local.tee $2
-   local.get $2
+   local.tee $1
+   local.get $1
    i32.load
    i32.const -3
    i32.and
    i32.store
   end
-  local.get $1
   local.get $0
+  i32.const 5
   i32.store offset=12
-  local.get $1
+  local.get $0
   i32.const 0
   i32.store offset=16
   global.get $~lib/rt/itcms/fromSpace
-  local.tee $0
+  local.tee $1
   i32.load offset=8
   local.set $2
-  local.get $1
   local.get $0
+  local.get $1
   global.get $~lib/rt/itcms/white
   i32.or
   i32.store offset=4
-  local.get $1
+  local.get $0
   local.get $2
   i32.store offset=8
   local.get $2
-  local.get $1
+  local.get $0
   local.get $2
   i32.load offset=4
   i32.const 3
   i32.and
   i32.or
   i32.store offset=4
-  local.get $0
   local.get $1
+  local.get $0
   i32.store offset=8
   global.get $~lib/rt/itcms/total
-  local.get $1
+  local.get $0
   i32.load
   i32.const -4
   i32.and
@@ -1386,7 +1386,7 @@
   i32.add
   i32.add
   global.set $~lib/rt/itcms/total
-  local.get $1
+  local.get $0
   i32.const 20
   i32.add
   local.tee $0
@@ -1627,7 +1627,6 @@
  )
  (func $start:typeof
   (local $0 i32)
-  (local $1 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 8
   i32.sub
@@ -2026,38 +2025,13 @@
    i64.const 0
    i64.store
    global.get $~lib/memory/__stack_pointer
-   i32.const 5
    call $~lib/rt/itcms/__new
    local.tee $0
    i32.store
    global.get $~lib/memory/__stack_pointer
-   global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store offset=4
    global.get $~lib/memory/__stack_pointer
-   i32.const 4
-   i32.sub
-   global.set $~lib/memory/__stack_pointer
-   global.get $~lib/memory/__stack_pointer
-   i32.const 1820
-   i32.lt_s
-   br_if $folding-inner0
-   global.get $~lib/memory/__stack_pointer
-   i32.const 0
-   i32.store
-   local.get $0
-   i32.eqz
-   if
-    global.get $~lib/memory/__stack_pointer
-    i32.const 0
-    call $~lib/rt/itcms/__new
-    local.tee $0
-    i32.store
-   end
-   global.get $~lib/memory/__stack_pointer
-   i32.const 4
-   i32.add
-   global.set $~lib/memory/__stack_pointer
    local.get $0
    i32.store
    global.get $~lib/memory/__stack_pointer

--- a/tests/compiler/while.debug.wat
+++ b/tests/compiler/while.debug.wat
@@ -464,6 +464,9 @@
   i32.const 1
   global.set $while/ran
  )
+ (func $~lib/object/Object#raw_constructor (param $this i32) (result i32)
+  local.get $this
+ )
  (func $~lib/rt/itcms/Object#set:nextWithColor (param $this i32) (param $nextWithColor i32)
   local.get $this
   local.get $nextWithColor
@@ -3215,6 +3218,34 @@
    unreachable
   end
  )
+ (func $while/Ref#raw_constructor (param $this i32) (result i32)
+  (local $1 i32)
+  global.get $~lib/memory/__stack_pointer
+  i32.const 8
+  i32.sub
+  global.set $~lib/memory/__stack_pointer
+  call $~stack_check
+  global.get $~lib/memory/__stack_pointer
+  i64.const 0
+  i64.store
+  global.get $~lib/memory/__stack_pointer
+  local.get $this
+  local.set $1
+  global.get $~lib/memory/__stack_pointer
+  local.get $1
+  i32.store
+  local.get $1
+  call $~lib/object/Object#raw_constructor
+  local.tee $this
+  i32.store offset=4
+  local.get $this
+  local.set $1
+  global.get $~lib/memory/__stack_pointer
+  i32.const 8
+  i32.add
+  global.set $~lib/memory/__stack_pointer
+  local.get $1
+ )
  (func $while/Ref#constructor (param $this i32) (result i32)
   (local $1 i32)
   global.get $~lib/memory/__stack_pointer
@@ -3242,7 +3273,7 @@
   local.get $1
   i32.store offset=4
   local.get $1
-  call $~lib/object/Object#constructor
+  call $~lib/object/Object#raw_constructor
   local.tee $this
   i32.store
   local.get $this

--- a/tests/compiler/while.release.wat
+++ b/tests/compiler/while.release.wat
@@ -1,11 +1,11 @@
 (module
  (type $0 (func))
- (type $1 (func (param i32)))
- (type $2 (func (param i32 i32)))
- (type $3 (func (result i32)))
- (type $4 (func (param i32) (result i32)))
- (type $5 (func (param i32 i32 i32 i32)))
- (type $6 (func (param i32 i32 i64)))
+ (type $1 (func (result i32)))
+ (type $2 (func (param i32)))
+ (type $3 (func (param i32 i32)))
+ (type $4 (func (param i32 i32 i32 i32)))
+ (type $5 (func (param i32 i32 i64)))
+ (type $6 (func (param i32) (result i32)))
  (import "env" "abort" (func $~lib/builtins/abort (param i32 i32 i32 i32)))
  (global $~lib/rt/itcms/total (mut i32) (i32.const 0))
  (global $~lib/rt/itcms/threshold (mut i32) (i32.const 0))
@@ -117,7 +117,7 @@
     local.get $0
     global.set $~lib/rt/itcms/iter
    end
-   block $__inlined_func$~lib/rt/itcms/Object#unlink$128
+   block $__inlined_func$~lib/rt/itcms/Object#unlink$127
     local.get $1
     i32.load offset=4
     i32.const -4
@@ -141,7 +141,7 @@
       call $~lib/builtins/abort
       unreachable
      end
-     br $__inlined_func$~lib/rt/itcms/Object#unlink$128
+     br $__inlined_func$~lib/rt/itcms/Object#unlink$127
     end
     local.get $1
     i32.load offset=8
@@ -1134,23 +1134,23 @@
    end
   end
  )
- (func $~lib/rt/itcms/__new (param $0 i32) (result i32)
+ (func $~lib/rt/itcms/__new (result i32)
+  (local $0 i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
-  (local $4 i32)
   global.get $~lib/rt/itcms/total
   global.get $~lib/rt/itcms/threshold
   i32.ge_u
   if
    block $__inlined_func$~lib/rt/itcms/interrupt$69
     i32.const 2048
-    local.set $1
+    local.set $0
     loop $do-loop|0
-     local.get $1
+     local.get $0
      call $~lib/rt/itcms/step
      i32.sub
-     local.set $1
+     local.set $0
      global.get $~lib/rt/itcms/state
      i32.eqz
      if
@@ -1166,7 +1166,7 @@
       global.set $~lib/rt/itcms/threshold
       br $__inlined_func$~lib/rt/itcms/interrupt$69
      end
-     local.get $1
+     local.get $0
      i32.const 0
      i32.gt_s
      br_if $do-loop|0
@@ -1189,17 +1189,17 @@
    call $~lib/rt/tlsf/initialize
   end
   global.get $~lib/rt/tlsf/ROOT
-  local.tee $2
-  call $~lib/rt/tlsf/searchBlock
   local.tee $1
+  call $~lib/rt/tlsf/searchBlock
+  local.tee $0
   i32.eqz
   if
    memory.size
-   local.tee $1
+   local.tee $0
    i32.const 4
-   local.get $2
-   i32.load offset=1568
    local.get $1
+   i32.load offset=1568
+   local.get $0
    i32.const 16
    i32.shl
    i32.const 4
@@ -1212,16 +1212,16 @@
    i32.and
    i32.const 16
    i32.shr_u
-   local.tee $3
-   local.get $1
-   local.get $3
+   local.tee $2
+   local.get $0
+   local.get $2
    i32.gt_s
    select
    memory.grow
    i32.const 0
    i32.lt_s
    if
-    local.get $3
+    local.get $2
     memory.grow
     i32.const 0
     i32.lt_s
@@ -1229,8 +1229,8 @@
      unreachable
     end
    end
-   local.get $2
    local.get $1
+   local.get $0
    i32.const 16
    i32.shl
    memory.size
@@ -1238,9 +1238,9 @@
    i64.const 16
    i64.shl
    call $~lib/rt/tlsf/addMemory
-   local.get $2
+   local.get $1
    call $~lib/rt/tlsf/searchBlock
-   local.tee $1
+   local.tee $0
    i32.eqz
    if
     i32.const 0
@@ -1251,7 +1251,7 @@
     unreachable
    end
   end
-  local.get $1
+  local.get $0
   i32.load
   i32.const -4
   i32.and
@@ -1265,92 +1265,92 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $2
   local.get $1
+  local.get $0
   call $~lib/rt/tlsf/removeBlock
-  local.get $1
+  local.get $0
   i32.load
-  local.tee $3
+  local.tee $2
   i32.const -4
   i32.and
   i32.const 28
   i32.sub
-  local.tee $4
+  local.tee $3
   i32.const 16
   i32.ge_u
   if
-   local.get $1
-   local.get $3
+   local.get $0
+   local.get $2
    i32.const 2
    i32.and
    i32.const 28
    i32.or
    i32.store
-   local.get $1
+   local.get $0
    i32.const 32
    i32.add
-   local.tee $3
-   local.get $4
+   local.tee $2
+   local.get $3
    i32.const 4
    i32.sub
    i32.const 1
    i32.or
    i32.store
+   local.get $1
    local.get $2
-   local.get $3
    call $~lib/rt/tlsf/insertBlock
   else
-   local.get $1
-   local.get $3
+   local.get $0
+   local.get $2
    i32.const -2
    i32.and
    i32.store
-   local.get $1
+   local.get $0
    i32.const 4
    i32.add
-   local.get $1
+   local.get $0
    i32.load
    i32.const -4
    i32.and
    i32.add
-   local.tee $2
-   local.get $2
+   local.tee $1
+   local.get $1
    i32.load
    i32.const -3
    i32.and
    i32.store
   end
-  local.get $1
   local.get $0
+  i32.const 4
   i32.store offset=12
-  local.get $1
+  local.get $0
   i32.const 0
   i32.store offset=16
   global.get $~lib/rt/itcms/fromSpace
-  local.tee $0
+  local.tee $1
   i32.load offset=8
   local.set $2
-  local.get $1
   local.get $0
+  local.get $1
   global.get $~lib/rt/itcms/white
   i32.or
   i32.store offset=4
-  local.get $1
+  local.get $0
   local.get $2
   i32.store offset=8
   local.get $2
-  local.get $1
+  local.get $0
   local.get $2
   i32.load offset=4
   i32.const 3
   i32.and
   i32.or
   i32.store offset=4
-  local.get $0
   local.get $1
+  local.get $0
   i32.store offset=8
   global.get $~lib/rt/itcms/total
-  local.get $1
+  local.get $0
   i32.load
   i32.const -4
   i32.and
@@ -1358,7 +1358,7 @@
   i32.add
   i32.add
   global.set $~lib/rt/itcms/total
-  local.get $1
+  local.get $0
   i32.const 20
   i32.add
   local.tee $0
@@ -1914,66 +1914,38 @@
  )
  (func $while/Ref#constructor (result i32)
   (local $0 i32)
-  (local $1 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 8
   i32.sub
   global.set $~lib/memory/__stack_pointer
-  block $folding-inner0
-   global.get $~lib/memory/__stack_pointer
-   i32.const 1512
-   i32.lt_s
-   br_if $folding-inner0
-   global.get $~lib/memory/__stack_pointer
-   i64.const 0
-   i64.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 4
-   call $~lib/rt/itcms/__new
-   local.tee $0
-   i32.store
-   global.get $~lib/memory/__stack_pointer
-   global.get $~lib/memory/__stack_pointer
-   local.get $0
-   i32.store offset=4
-   global.get $~lib/memory/__stack_pointer
-   i32.const 4
-   i32.sub
-   global.set $~lib/memory/__stack_pointer
-   global.get $~lib/memory/__stack_pointer
-   i32.const 1512
-   i32.lt_s
-   br_if $folding-inner0
-   global.get $~lib/memory/__stack_pointer
-   i32.const 0
-   i32.store
-   local.get $0
-   i32.eqz
-   if
-    global.get $~lib/memory/__stack_pointer
-    i32.const 0
-    call $~lib/rt/itcms/__new
-    local.tee $0
-    i32.store
-   end
-   global.get $~lib/memory/__stack_pointer
-   i32.const 4
-   i32.add
-   global.set $~lib/memory/__stack_pointer
-   local.get $0
-   i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 8
-   i32.add
-   global.set $~lib/memory/__stack_pointer
-   local.get $0
-   return
+  global.get $~lib/memory/__stack_pointer
+  i32.const 1512
+  i32.lt_s
+  if
+   i32.const 34304
+   i32.const 34352
+   i32.const 1
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
   end
-  i32.const 34304
-  i32.const 34352
-  i32.const 1
-  i32.const 1
-  call $~lib/builtins/abort
-  unreachable
+  global.get $~lib/memory/__stack_pointer
+  i64.const 0
+  i64.store
+  global.get $~lib/memory/__stack_pointer
+  call $~lib/rt/itcms/__new
+  local.tee $0
+  i32.store
+  global.get $~lib/memory/__stack_pointer
+  local.get $0
+  i32.store offset=4
+  global.get $~lib/memory/__stack_pointer
+  local.get $0
+  i32.store
+  global.get $~lib/memory/__stack_pointer
+  i32.const 8
+  i32.add
+  global.set $~lib/memory/__stack_pointer
+  local.get $0
  )
 )


### PR DESCRIPTION
create 2 kinds constructor can help binaryen to optimize code better. since binaryen cannot optimize conditional allocation in base class. It will be obvious for `~lib/object/Object` because it is the base class for all kinds of class.