### PR TITLE
fix: make asinit exit if package.json has a "type" not equal to "module"

### DIFF
--- a/bin/asinit.js
+++ b/bin/asinit.js
@@ -115,11 +115,22 @@ const paths = [
   [gitignoreFile, "Git configuration that excludes compiled binaries from source control."],
   [asconfigFile, "Configuration file defining both a 'debug' and a 'release' target."],
   [packageFile, "Package info containing the necessary commands to compile to WebAssembly."],
-  [testsIndexFile, "Stater test to check that the module is functioning."],
+  [testsIndexFile, "Starter test to check that the module is functioning."],
   [indexHtmlFile, "Starter HTML file that loads the module in a browser."]
 ];
 
 const formatPath = filePath => "./" + path.relative(projectDir, filePath).replace(/\\/g, "/");
+
+if (fs.existsSync(packageFile)) {
+  const pkg = JSON.parse(fs.readFileSync(packageFile));
+  if ("type" in pkg && pkg["type"] !== "module") {
+    console.error(stdoutColors.red([
+      `Error: The "type" field in ${formatPath(packageFile)} is set to "${pkg["type"]}".`,
+      `       asinit requires the "type" field to be set to "module" (ES modules).`
+    ].join("\n")));
+    process.exit(1);
+  }
+}
 
 console.log([
   "Version: " + version,


### PR DESCRIPTION
Fixes AssemblyScript/website#237. When the "type" field isn't specified, or if package.json doesn't exist, it's already set to "module". This removes the remaining hole when "type" is set to, say, "commonjs", by refusing to continue.

- [x] I've read the contributing guidelines
- [x] I've added my name and email to the NOTICE file
