### PR TITLE
fix: avoid to visit nullptr in binaryen

### DIFF
--- a/src/compiler.ts
+++ b/src/compiler.ts
@@ -6764,7 +6764,7 @@ export class Compiler extends DiagnosticEmitter {
       if (thisType.isManaged) {
         let operand = operands[0];
         let precomp = module.runExpression(operand, ExpressionRunnerFlags.Default);
-        if (!isConstZero(precomp)) { // otherwise unnecessary
+        if (!precomp || !isConstZero(precomp)) { // otherwise unnecessary
           operands[operandIndex] = module.tostack(operand);
         }
       }
@@ -6778,7 +6778,7 @@ export class Compiler extends DiagnosticEmitter {
       if (paramType.isManaged) {
         let operand = operands[operandIndex];
         let precomp = module.runExpression(operand, ExpressionRunnerFlags.Default);
-        if (!isConstZero(precomp)) { // otherwise unnecessary
+        if (!precomp || !isConstZero(precomp)) { // otherwise unnecessary
           operands[operandIndex] = module.tostack(operand);
         }
       }

--- a/src/module.ts
+++ b/src/module.ts
@@ -3019,7 +3019,6 @@ export function isNullableType(type: TypeRef): bool {
 // expressions
 
 export function getExpressionId(expr: ExpressionRef): ExpressionId {
-  if (expr == 0) return ExpressionId.Invalid;
   return binaryen._BinaryenExpressionGetId(expr);
 }
 


### PR DESCRIPTION
Module.getExpressionId will be used for nullptr ExpressionRef. It works because deref nullptr in binaryen's wasm is valid.
check BinaryenExprRef non-null before.
